### PR TITLE
 [AutoWS] [CLC] Add support for CLC APIs in Triton (#1881)

### DIFF
--- a/docs/design/triton-clc-tile-scheduler.md
+++ b/docs/design/triton-clc-tile-scheduler.md
@@ -1,0 +1,379 @@
+# Triton CLC Tile Scheduler
+
+Triton Cluster Launch Control (CLC) tile scheduler.
+
+Status: **frontend + Stages 1/2/4 lowering landed (single-CTA, non-WS); Stage 3
+(AutoWS) is future work.**
+
+## Motivation
+
+Cluster Launch Control (CLC) is a Blackwell (SM100+) hardware feature for
+dynamic persistent kernels. The grid is launched with one cluster per tile
+(over-subscribed relative to the SM count). A CTA that finishes early issues
+`clusterlaunchcontrol.try_cancel`, which atomically cancels a *pending*
+(not-yet-launched) cluster and hands the caller that cluster's program id — i.e.
+it steals the pending tile's work. This load-balances better than a static
+persistent schedule (the SM that finishes early does more tiles), and it
+absorbs over-provisioned / "jagged" tiles that a non-persistent kernel would
+otherwise launch and early-`return` on.
+
+Today CLC is only reachable via low-level ops (Gluon `clc.try_cancel` /
+`load_result`, or the TLX `clc_producer` / `clc_consumer` split), which force the
+kernel author to hand-manage a response buffer, an mbarrier, and a phase. This
+design adds a **core Triton (`tl.`) scheduler** that hides all of that.
+
+## Goals / principles
+
+- **Barrier-free pre-warp-specialization IR.** The high-level op references no
+  mbarrier, no response buffer, and no phase. All of that is materialized by a
+  later compiler lowering pass. This keeps the IR clean for the passes that run
+  before warp specialization (WS).
+- **No op is partition-aware.** The scheduler composes only single-program ops.
+  Splitting work across producer/consumer warp groups is AutoWS's job, not the
+  scheduler's.
+- **Runs without WS.** The scheduler is usable in a plain persistent kernel
+  (`warp_specialize=False`); WS is an orthogonal, later concern.
+- **Minimal, opaque API.** The kernel author never sees a buffer, barrier,
+  phase, or the `try_cancel`/`wait` split.
+- **Single CTA only (for now).** Multi-cluster / multi-CTA is not yet supported;
+  the materialization pass rejects `num-ctas > 1`. Multi-CTA is future work.
+
+## API
+
+```python
+sched = tl.clc_tile_scheduler()      # initialize
+while sched.is_valid():              # more work to steal?
+    pid = sched.tile_id[0]           # current tile coord x; [1]/[2] for y/z
+    ... compute for this tile ...
+    sched = sched.advance()          # fetch the next tile
+```
+
+- `tl.clc_tile_scheduler()` — construct the scheduler, seeded with this CTA's
+  own statically-launched tile.
+- `sched.is_valid() -> bool` — is the current tile real work? (Loop condition.)
+  True for the seed tile; after `advance`, reflects whether a cluster was
+  successfully cancelled.
+- `sched.tile_id[dim] -> i32` — the current tile's program-id coordinate along
+  `dim` (0=x, 1=y, 2=z).
+- `sched.advance() -> ClcTileScheduler` — fetch the next tile and return the
+  updated scheduler.
+
+There is intentionally **no `try_cancel` in the API.** Fetching the next tile
+*is* `advance`; the async issue/wait split (issue early, wait late, to overlap
+the CLC latency with compute) is a compiler optimization done during lowering,
+not something the user expresses. Problem-level "invalid/jagged tile" handling is
+just ordinary user control flow (a bounds `if` around the compute) — it is not a
+scheduler concept.
+
+## Frontend representation
+
+The scheduler is an opaque aggregate carrying the **decoded** current tile:
+
+```
+ClcTileScheduler { _valid: i1, _x: i32, _y: i32, _z: i32 }
+```
+
+- The constructor seeds it with `is_valid = true` and `_x/_y/_z = program_id(0/1/2)`.
+  The first tile needs no CLC op — it is just this CTA's static launch id.
+- `is_valid()` returns `_valid`; `tile_id` returns the `(x, y, z)` tuple.
+- `advance()` emits one op, `ttng.clc_advance`, which returns the decoded next
+  tile `{isValid, x, y, z}`.
+
+The persistent `scf.while` therefore carries four plain values `(i1, i32, i32,
+i32)` — no memory descriptors.
+
+### The op
+
+```
+def TTNG_CLCAdvanceOp : TTNG_Op<"clc_advance", []> {
+  let results = (outs I1:$isValid, I32:$x, I32:$y, I32:$z);
+}
+```
+
+Effectful (it claims a pending cluster) so it is neither DCE'd nor hoisted out of
+the loop; one per persistent-loop iteration. It references no mbarrier or buffer.
+
+### Initial TTIR
+
+```mlir
+%v0 = arith.constant true
+%x0 = tt.get_program_id x
+%y0 = tt.get_program_id y
+%z0 = tt.get_program_id z
+scf.while (%v=%v0, %x=%x0, %y=%y0, %z=%z0) : (i1,i32,i32,i32) -> (i1,i32,i32,i32) {
+  scf.condition(%v) %v, %x, %y, %z
+} do {
+^bb0(%v: i1, %x: i32, %y: i32, %z: i32):
+  ... compute using %x (guarded by problem bounds) ...
+  %v1, %x1, %y1, %z1 = ttng.clc_advance : i1, i32, i32, i32
+  scf.yield %v1, %x1, %y1, %z1
+}
+```
+
+No `init_barrier` / `wait_barrier` / `barrier_expect` / `clc_try_cancel` /
+`clc_load_result` — those belong to the lowering.
+
+## Lowering
+
+`clc_advance` is remapped to **two ops linked by a token**, and only later
+materialized into mbarriers by a **dedicated TTGIR pass that runs before AutoWS**.
+Crucially, mbarriers are not introduced by the split — the token stands in for the
+async dependency until materialization.
+
+### Token form (reuses `!ttg.async_token`)
+
+Two ops model the intermediate form; together they are exactly `clc_advance`
+(the split is result-preserving — we remap one op to two):
+
+- `ttng.clc_try_cancel_async : !ttg.async_token` — issue the async CLC request.
+  Returns **only a token**, nothing else. Effectful (claims a pending cluster).
+- `ttng.clc_read(!ttg.async_token) -> (i1 isValid, i32 x, i32 y, i32 z)` — await
+  the token and return the decoded tile. Same results as `clc_advance` (it must
+  return `is_valid` too).
+
+The token is `!ttg.async_token`, the same completion-handle type used by
+`cp.async` / TMA / `tcgen05` — so the existing async-dependency machinery applies.
+
+### Stage 1 — split (minimal, trivially correct)
+
+For each `%v,%x,%y,%z = ttng.clc_advance`, emit the issue immediately followed by
+the read, linked by a token — no code motion yet:
+```mlir
+%tok = ttng.clc_try_cancel_async : !ttg.async_token
+%v,%x,%y,%z = ttng.clc_read %tok : i1, i32, i32, i32
+```
+This is a pure structural remap (`clc_advance` ≡ `clc_read(clc_try_cancel_async())`);
+placing them adjacent is always correct. Overlap is introduced by the next pass.
+
+### Stage 2 — `clc_try_cancel_async` hoisting / unification (dedicated TTGIR pass, before AutoWS)
+
+Promotes each `clc_try_cancel_async` to the **earliest safe program point that
+dominates its `clc_read`** consumer(s). The goal is to maximize the distance
+between the async issue and the decode so the CLC round-trip is hidden behind
+compute — i.e. `clc_read`'s (eventual) wait rarely stalls.
+
+- **Same block (common case):** move the issue above the tile's compute (e.g. to
+  the top of the persistent loop body).
+- **Across basic blocks:** the issue can be hoisted out of conditional regions.
+  E.g. if `advance` appears in *both* arms of an `if/else` (a masked path),
+  **unify** the two issues into a single `clc_try_cancel_async` at the common
+  dominator (before the branch); each arm's `clc_read` consumes the shared token.
+  This both starts the request earlier and removes the redundant issue.
+
+**Correctness invariant — issue/read count parity.** Every dynamic path must
+execute exactly one `clc_try_cancel_async` per `clc_read`: an issue claims one
+pending cluster and a read consumes one response. The pass must never introduce
+an issue on a path that has no read (over-claim → lost/duplicated tiles, wrong
+termination) nor drop an issue on a path that reads. Hoisting past a branch is
+therefore legal only when *every* path from the hoisted location issues-and-reads
+exactly once (e.g. both `if/else` arms advance); otherwise the issue stays inside
+its conditional region. The token SSA edge makes this dominance-based code motion;
+the effect (claims a cluster) is what bounds it.
+
+Within a persistent loop, hoisting to the loop-body top gives one-iteration
+overlap; hoisting *across* iterations (loop rotation / run-ahead) is the depth>1
+prefetch case (token becomes loop-carried; needs drain-on-exit) — future.
+
+IR after Stage 2 (hoisted issue; still **no** mbarrier / buffer / phase — the
+token form flows unchanged into AutoWS):
+```mlir
+scf.while (%v=%v0,%x=%x0,%y=%y0,%z=%z0) : (i1,i32,i32,i32) -> (i1,i32,i32,i32) {
+  scf.condition(%v) %v, %x, %y, %z
+} do {
+^bb0(%v: i1, %x: i32, %y: i32, %z: i32):
+  %tok = ttng.clc_try_cancel_async : !ttg.async_token        // hoisted issue
+  ... compute using %x (guarded by problem bounds) ...
+  %v1,%x1,%y1,%z1 = ttng.clc_read %tok : i1, i32, i32, i32   // decode / await
+  scf.yield %v1, %x1, %y1, %z1
+}
+```
+
+### Stage 3 — AutoWS handling (fused into `WSAtomicBroadcast`)
+
+The token form flows **into** AutoWS unchanged. The CLC fetch is the same shape
+as the atomic tile-counter that `WSAtomicBroadcast` already handles — a run-once
+"claim the next tile" whose loop-carried result feeds *every* partition — so the
+handling is **fused into that pass** (see
+`third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSAtomicBroadcast.cpp`
+and `docs/.../CrossPartitionAtomicSupport.md`). Without this, each partition would
+run its own `clc_try_cancel_async`, cancel a different pending cluster, and
+diverge → deadlock.
+
+Primary scheme:
+
+1. **Recognize** the CLC fetch (`clc_try_cancel_async` + `clc_read`) as a
+   run-once loop-carried tile producer, alongside `atomic_rmw`.
+2. **Map all CLC ops to a single partition — the producer.** Both the issue and
+   the `clc_read` (decode) live only in the producer partition; no other partition
+   runs any CLC op. (The token stays intra-producer, so its completion is a local
+   wait, materialized in Stage 4.)
+3. **Broadcast `clc_read`'s 4-tuple `(is_valid, x, y, z)` through SMEM** to all
+   partitions, reusing the atomic-broadcast data path: the producer
+   `splat`→`local_store`s each scalar into a small SMEM slot; every partition
+   `local_load`→`unsplat`s it; the `scf.while` loop-carried tile is rewired to the
+   broadcast values. The `local_store`→`local_load` edges become the usual
+   `doCodePartitionPost` SMEM channels. `is_valid` is part of the broadcast tuple
+   (it drives every partition's loop).
+4. **Reject/bail** exactly like atomic broadcast's case-3: if the fetch's results
+   are not cleanly loop-carried-to-all, fall back to `removeWarpSpecializeAttr`
+   (unspecialized but compilable — never a crash).
+
+#### Followup optimizations (to explore, not in the first cut)
+
+- **Broadcast the response and decode per partition.** Instead of broadcasting the
+  decoded 4-tuple, broadcast the raw CLC response (or keep the token) and let each
+  partition run its own `clc_read`/decode. Only `clc_try_cancel_async` must remain
+  single (one claim) and delayed (overlap); the decode is pure and replicable.
+  This shrinks/changes the broadcast payload and composes with per-partition
+  dead-coordinate dropping (each partition decodes only the coords it uses). To be
+  explored as a channel optimization.
+- **Dedicated tile-computation partition/buffer.** Put the generic "tile
+  computation" (the `program_id` → tile-coordinate / offset math, e.g. the grouped
+  swizzle in `_compute_pid`) in its own partition with its own channel/buffer,
+  rather than replicating it in every partition. More flexible partitioning.
+
+Both are followup optimizations to the channel/broadcast design; the first cut
+uses the simple "producer decodes, broadcast the 4-tuple" scheme above.
+
+### Stage 4 — materialize token → mbarrier (after AutoWS)
+
+Runs *after* AutoWS, so it operates on the token pair as it now sits in the
+producer partition (Stage 3 put all CLC ops there). It converts the async token
+into the real barrier ops. This is a **separate barrier from the broadcast**:
+Stage 3 / AutoWS already created the SMEM channels (with their own full/empty
+mbarriers) that distribute the decoded 4-tuple to the other partitions; Stage 4
+only handles the CLC-response completion barrier local to the producer.
+
+Materialization (producer partition, depth-1):
+
+1. Allocate the response buffer (`memdesc<2xi64>`) and one **completion mbarrier**
+   at function scope; init / inval.
+2. `clc_try_cancel_async` → `ttng.clc_try_cancel(resp, bar)` + `barrier_expect(bar, 16)`.
+3. `clc_read %tok` → `wait_barrier(bar, phase)` + `ttng.clc_load_result(resp)` +
+   `ttng.clc_is_canceled` (→ `isValid`) + `ttng.clc_get_program_id` (→ x/y/z).
+
+#### Phase handling (one-sided channel)
+
+The CLC response is written by hardware (`try_cancel`) and read by `clc_read` —
+there is only the **"full" (data-ready) side** of a channel; there is no "empty"
+(buffer-free) side, because the single response buffer is reused each iteration
+and reuse is naturally program-ordered (the next iteration's issue at the loop-body
+top follows this iteration's read at the bottom, in the same partition). So a
+single completion mbarrier suffices, and only its phase must be tracked.
+
+**Require the phase to be a loop-carried variable, toggled before each advance.**
+Materialization adds an `i32`/`i1` phase iter_arg to the persistent `scf.while`,
+initialized to 0; `clc_read` waits with the carried phase, and the phase is XOR'd
+with 1 in the loop yield (once per iteration). This is:
+
+- **the same shape the software pipeliner already uses for TMA / async waits** —
+  `Pipeliner/LowerLoops.cpp` carries `phase` as an iter_arg and toggles it with
+  `arith.xori` at the yield (`phase = forOp.getRegionIterArg(...)`;
+  `newPhase = xori(phase, 1)`); and
+- **the one-sided (`numBuffers = 1`) case of the WS channel logic** — the channel
+  path computes `phase = (accumCnt / numBuffers) & 1` from a loop-carried
+  `accumCnt` in `CodePartitionUtility.cpp::getBufferIdxAndPhase`, which for a
+  single buffer reduces to `accumCnt & 1`, i.e. a per-iteration toggle.
+
+**TMA lowering reference (`lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp`).**
+The software pipeliner lowers `tt.descriptor_load` into exactly this shape; reuse it:
+
+- **Barrier ring:** `triton::createBarrierAlloc(loop, numBuffers)` (allocates +
+  inits `numBuffers` mbarriers); slot via
+  `triton::createSingleBufferView(builder, alloc, idx)`.
+- **Issue:** `ttng.BarrierExpectOp(bar, sizeInBytes, pred)` +
+  `ttng.AsyncTMACopyGlobalToLocalOp(...)` (`createTMABarrierAndWait` ~L380-403,
+  `createTMAAsyncLoad` ~L240-252). CLC substitutes `clc_try_cancel(resp, bar)`.
+- **Wait:** `ttng.WaitBarrierOp(barView, phase)` (~L402). CLC follows it with
+  `clc_load_result` + `clc_is_canceled` / `clc_get_program_id`.
+- **Phase + indices as loop-carried iter_args** (~L535-588): `insert/extract`
+  init `-1`, `phase` init `0`, added via `addIterArgsToLoop`; advanced per
+  iteration with `createIncrementModulo(idx, numBuffers, …)` and
+  `phase = select(cndExt, xori(phase, 1), phase)`; yield patched (~L612-618).
+
+For CLC depth-1 (`numBuffers = 1`) the ring wraps every iteration, so `cndExt` is
+always true and the phase reduces to a plain per-iteration `xori(phase, 1)` — the
+"loop-carried, toggled-before-each-advance" phase, and no separate insert/extract
+index is needed. Two differences to handle: CLC's loop is an `scf.while`
+(persistent), not `scf.for`, so the phase iter-arg follows the while before/after
+regions (cf. `getAccumCount`'s scf.while handling in `CodePartitionUtility.cpp`)
+rather than the scf.for-shaped `addIterArgsToLoop`; and the "copy" is
+`clc_try_cancel` (+ decode on read) instead of `async_tma_copy` (+ local_load).
+
+Depth > 1 (future) generalizes this to a buffer ring: the carried counter becomes
+`accumCnt`, `bufferIdx = accumCnt % depth`, `phase = (accumCnt / depth) & 1` (the
+full channel form), and the destructive claim then also needs drain-on-exit.
+
+### Pipeline
+
+```
+frontend ttng.clc_advance                          (TTIR)
+   -> [Stage 1: split]         clc_try_cancel_async (token) + clc_read  (adjacent)
+   -> [Stage 2: hoist/unify]   clc_try_cancel_async promoted to earliest safe point
+   -> [Stage 3: AutoWS]        producer runs fetch + broadcast decoded 4-tuple  (fused into WSAtomicBroadcast)
+   -> [Stage 4: materialize]   token -> buffer + completion mbarrier + loop-carried phase (after AutoWS)
+```
+
+Prefetch depth (`TRITON_WS_TILE_PREFETCH_DEPTH`) is a materialization-stage
+concern: depth 1 is single-stage; depth > 1 (multi-stage run-ahead) additionally
+requires drain-on-exit because the CLC claim is destructive.
+
+## Design decisions & rationale
+
+- **`advance`-only (no user `try_cancel`).** The optimal issue point for the
+  async request is invariant — the top of the loop body — so a user-placed
+  `try_cancel` could only reproduce what the compiler already picks, while adding
+  a footgun (the issue must fire exactly once per iteration and pair with exactly
+  one wait). Collapsing to one op makes mis-pairing unrepresentable. If manual
+  placement is ever needed, `try_cancel` can be re-added as an optional override
+  — a strict superset, no rework.
+- **Return the decoded tile (`isValid`, x, y, z), not an opaque i128.** This
+  removes the opaque result type, the separate `is_canceled` / `get_program_id`
+  decode ops, and the `tile_id` proxy from the frontend; the scheduler carries
+  plain `tl` values and `is_valid` / `tile_id` are trivial reads. Tradeoff: all
+  three coordinates are produced/carried, so dropping unused dims moves from
+  "free" (never emitted) to a lowering/canonicalization step. The coordinates are
+  cheap `i32`s and the pass eliminates the dead ones, so this is a good trade for
+  a much simpler frontend.
+- **Seed is `program_id`, not an op.** The first tile of every persistent CTA is
+  its static launch id; only *subsequent* tiles come from CLC. Expressing the
+  seed with `program_id` + `true` needs no new op and keeps the loop body
+  uniform.
+- **Phase and the issue/wait overlap are inferred in the pass.** Since the pass
+  already analyzes the persistent loop, it owns phase parity and the request
+  pull-up; the frontend carries no counter.
+- **Token-based split before mbarriers, reusing `!ttg.async_token`.** Splitting
+  `clc_advance` into `clc_try_cancel_async` (→ token) + `clc_read` (token →
+  decoded tile) expresses the request/acquire structure and enables the overlap
+  hoist *without* introducing mbarriers, using the same async-token dependency
+  model as `cp.async` / TMA. mbarriers are materialized only in a later pass
+  (after AutoWS), keeping the two concerns — async structure vs. barrier
+  realization — cleanly separated and independently testable.
+
+## Status & testing
+
+- **Implemented (this branch):** the `tl.clc_tile_scheduler` frontend and
+  `ttng.clc_advance` op; the token ops `ttng.clc_try_cancel_async` /
+  `ttng.clc_read`; and Stages 1 (`triton-nvidia-gpu-clc-split`), 2
+  (`triton-nvidia-gpu-clc-hoist`) and 4 (`triton-nvidia-gpu-clc-materialize`) as
+  TTGIR passes (`lib/Dialect/TritonNvidiaGPU/Transforms/CLCLowering.cpp`), wired
+  into the NVIDIA Blackwell `make_ttgir` pipeline — split + hoist before warp
+  specialization, materialize after.
+- **Restriction:** single CTA only — `clc-materialize` errors on `num-ctas > 1`.
+- **Not in this branch:** Stage 3 (AutoWS handling / `WSAtomicBroadcast` fusion).
+  Today the kernel runs with `warp_specialize=False`; Stage 2's hoist is
+  same-block only (cross-block unification is a follow-up).
+- **Tests:** `python/test/unit/language/test_triton_clc.py` — frontend IR-shape
+  checks (no GPU) plus Blackwell execution tests (scheduler claims each tile
+  exactly once; CLC GEMM correctness) and a materialized-TTGIR check.
+
+## Future work (next branch)
+
+- **Stage 3:** AutoWS handling fused into `WSAtomicBroadcast` — the producer runs
+  the fetch and the decoded 4-tuple is broadcast through SMEM; materialization
+  then runs after AutoWS for WS kernels.
+- Multi-cluster / multi-CTA support (lift the single-CTA restriction).
+- Multi-stage prefetch (`depth > 1`) with drain-on-exit (loop-carried token).
+- Cross-basic-block hoist / unification in Stage 2.
+- Channel optimizations: broadcast-and-decode-per-partition; a dedicated
+  tile-computation partition/buffer.

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -241,6 +241,82 @@ def TTNG_CLCGetProgramIdOp : TTNG_Op<"clc_get_program_id", [Pure]> {
 }
 
 //
+// High-level CLC scheduler op (barrier-free; lowered later)
+//
+// `clc_advance` expresses a dynamic-persistent CLC fetch WITHOUT any mbarrier /
+// response buffer / phase, so pre-warp-specialization IR stays clean. It returns
+// the decoded next tile directly: an `is_valid` predicate plus the (x, y, z)
+// program-id coordinates. The initial tile needs no op -- it is just this CTA's
+// `program_id` with is_valid = true. A later lowering pass materializes the
+// response buffer + mbarrier, expands `clc_advance` into the low-level
+// `clc_try_cancel` + `barrier_expect` (issue) and `wait_barrier` +
+// `clc_load_result` + `clc_is_canceled` / `clc_get_program_id` (consume + decode),
+// pulls the issue up to overlap the CLC latency with compute, infers the phase,
+// and drops any unused coordinate (dead loop-carried value elimination).
+
+def TTNG_CLCAdvanceOp : TTNG_Op<"clc_advance", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "High-level CLC advance: fetch the next tile (decoded)";
+
+  let description = [{
+    Fetches the next work tile via Cluster Launch Control and returns it decoded:
+    `isValid` (a tile was successfully claimed) and its (`x`, `y`, `z`)
+    program-id coordinates.
+
+    References no mbarrier or buffer -- a later lowering pass materializes them,
+    splits the fetch into an (overlap-hoisted) async issue and a wait+load+decode,
+    infers the phase, and drops unused coordinates. One per persistent-loop
+    iteration.
+  }];
+
+  let results = (outs I1:$isValid, I32:$x, I32:$y, I32:$z);
+
+  let assemblyFormat = [{ attr-dict `:` type($isValid) `,` type($x) `,` type($y) `,` type($z) }];
+}
+
+//
+// Token form of the CLC fetch (produced by the Stage-1 split of clc_advance)
+//
+// `clc_advance` is remapped to `clc_try_cancel_async` (async issue -> token) +
+// `clc_read` (await the token -> decoded tile). The token is `!ttg.async.token`,
+// reusing the same async-dependency model as cp.async / TMA, so the issue can be
+// hoisted for overlap without introducing any mbarrier. A later pass materializes
+// the token into the low-level barrier form.
+
+def TTNG_CLCTryCancelAsyncOp : TTNG_Op<"clc_try_cancel_async", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let summary = "Issue an async CLC request; returns a token (issue half)";
+
+  let description = [{
+    Issues an asynchronous Cluster Launch Control request to fetch the next work
+    tile (cancelling a pending cluster). Returns only an async token; the paired
+    `clc_read` awaits it and returns the decoded tile. References no mbarrier or
+    buffer. Effectful (claims a pending cluster) so it is neither DCE'd nor
+    hoisted out of the persistent loop.
+  }];
+
+  let results = (outs TTG_AsyncToken:$token);
+
+  let assemblyFormat = [{ attr-dict `:` type($token) }];
+}
+
+def TTNG_CLCReadOp : TTNG_Op<"clc_read", [MemoryEffects<[MemRead<GlobalMemory>]>]> {
+  let summary = "Await a CLC token and return the decoded tile (read half)";
+
+  let description = [{
+    Consumer half of the async CLC fetch started by `clc_try_cancel_async`: awaits
+    the token and returns the decoded tile -- `isValid` plus the (`x`, `y`, `z`)
+    program-id coordinates. References no mbarrier or buffer.
+  }];
+
+  let arguments = (ins TTG_AsyncToken:$token);
+
+  let results = (outs I1:$isValid, I32:$x, I32:$y, I32:$z);
+
+  let assemblyFormat = [{
+    $token attr-dict `:` type($token) `->` type($isValid) `,` type($x) `,` type($y) `,` type($z)
+  }];
+}
+
+//
 // WarpGroupDot Op
 //
 def TTNG_WarpGroupDotOp : TTNG_Op<"warp_group_dot", [

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -240,4 +240,54 @@ def TritonNvidiaGPUCheckMatmulTwoCTAPass : Pass<"triton-nvidia-check-matmul-two-
   }];
 }
 
+def TritonNvidiaGPUCLCSplitPass : Pass<"triton-nvidia-gpu-clc-split", "mlir::ModuleOp"> {
+  let summary = "Split ttng.clc_advance into the token form (clc_try_cancel_async + clc_read)";
+
+  let description = [{
+    Stage 1 of the CLC tile-scheduler lowering. Rewrites each `ttng.clc_advance`
+    into `ttng.clc_try_cancel_async` (async issue -> !ttg.async.token) followed by
+    `ttng.clc_read` (await the token -> decoded tile). No mbarrier/buffer is
+    introduced; the token models the async dependency.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+  ];
+}
+
+def TritonNvidiaGPUCLCHoistPass : Pass<"triton-nvidia-gpu-clc-hoist", "mlir::ModuleOp"> {
+  let summary = "Hoist ttng.clc_try_cancel_async to overlap CLC latency with compute";
+
+  let description = [{
+    Stage 2 of the CLC tile-scheduler lowering. Promotes each
+    `ttng.clc_try_cancel_async` to the top of its block so the CLC round-trip
+    overlaps the tile's compute before the paired `ttng.clc_read`.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+  ];
+}
+
+def TritonNvidiaGPUCLCMaterializePass : Pass<"triton-nvidia-gpu-clc-materialize", "mlir::ModuleOp"> {
+  let summary = "Materialize the CLC token form into mbarrier ops (single-CTA only)";
+
+  let description = [{
+    Stage 4 of the CLC tile-scheduler lowering. Materializes each
+    `clc_try_cancel_async` / `clc_read` pair into a response buffer + completion
+    mbarrier: the issue becomes `barrier_expect` + `clc_try_cancel`, the read
+    becomes `wait_barrier` + `clc_load_result` + `clc_is_canceled` /
+    `clc_get_program_id`, with a loop-carried, per-iteration-toggled phase.
+    Supports a single CTA only; multi-cluster / multi-CTA is rejected.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+    "mlir::arith::ArithDialect",
+    "mlir::scf::SCFDialect"
+  ];
+}
+
 #endif

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CLCLowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CLCLowering.cpp
@@ -1,0 +1,213 @@
+// CLC (Cluster Launch Control) tile-scheduler lowering.
+//
+// Implements Stages 1, 2 and 4 of the design in
+// docs/design/triton-clc-tile-scheduler.md:
+//
+//   Stage 1 (clc-split):        ttng.clc_advance -> ttng.clc_try_cancel_async
+//                               (-> !ttg.async.token) + ttng.clc_read
+//   Stage 2 (clc-hoist):        promote ttng.clc_try_cancel_async to the top of
+//                               its block so the CLC latency overlaps compute
+//   Stage 4 (clc-materialize):  token form -> response buffer + completion
+//                               mbarrier + low-level try_cancel/expect (issue)
+//                               and wait/load/decode (read), with a
+//                               loop-carried, per-iteration-toggled phase.
+//
+// Stage 3 (AutoWS handling) is intentionally NOT here; it lands in a follow-up
+// branch and slots between Stage 2 and Stage 4. Single-CTA only for now
+// (multi-cluster / multi-CTA is rejected in clc-materialize).
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUCLCSPLITPASS
+#define GEN_PASS_DEF_TRITONNVIDIAGPUCLCHOISTPASS
+#define GEN_PASS_DEF_TRITONNVIDIAGPUCLCMATERIALIZEPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+namespace ttg = triton::gpu;
+
+namespace {
+
+// A CLC response is 16 bytes; the low-level ops require a rank-1 memdesc of
+// exactly 2 x i64 (see verifyCLCResultMemdesc).
+constexpr int kClcResponseBytes = 16;
+
+Value createClcResponseAlloc(OpBuilder &b, Location loc) {
+  MLIRContext *ctx = b.getContext();
+  auto cga = ttg::CGAEncodingAttr::get1CTALayout(ctx, /*rank=*/1);
+  SmallVector<unsigned> order{0};
+  Attribute enc = ttg::SwizzledSharedEncodingAttr::get(
+      ctx, /*vec=*/1, /*perPhase=*/1, /*maxPhase=*/1, order, cga);
+  auto memSpace = ttg::SharedMemorySpaceAttr::get(ctx);
+  auto ty = ttg::MemDescType::get({2}, b.getI64Type(), enc, memSpace,
+                                  /*mutableMemory=*/true);
+  return ttg::LocalAllocOp::create(b, loc, ty);
+}
+
+//===--------------------------------------------------------------------===//
+// Stage 1 - split clc_advance into the token form.
+//===--------------------------------------------------------------------===//
+struct CLCSplitPass
+    : public impl::TritonNvidiaGPUCLCSplitPassBase<CLCSplitPass> {
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+    auto tokTy = ttg::AsyncTokenType::get(ctx);
+    SmallVector<Type> readTys{
+        IntegerType::get(ctx, 1), IntegerType::get(ctx, 32),
+        IntegerType::get(ctx, 32), IntegerType::get(ctx, 32)};
+    getOperation().walk([&](CLCAdvanceOp adv) {
+      OpBuilder b(adv);
+      auto issue = CLCTryCancelAsyncOp::create(b, adv.getLoc(), tokTy);
+      auto read = CLCReadOp::create(b, adv.getLoc(), readTys,
+                                    ValueRange{issue.getToken()});
+      adv->replaceAllUsesWith(read->getResults());
+      adv->erase();
+    });
+  }
+};
+
+//===--------------------------------------------------------------------===//
+// Stage 2 - hoist clc_try_cancel_async to overlap the CLC latency.
+//
+// clc_try_cancel_async has no operands, so within its block it can move to the
+// front freely; that places the issue above the tile's compute (loop-body top)
+// so the request resolves while the tile is computed. The move is restricted to
+// the persistent-loop body (the scf.while after-region), the only block whose
+// front is a safe issue point -- an arbitrary block's front may hold required
+// setup. TODO: cross-basic-block hoisting / unification (e.g. clc_advance in
+// both arms of an if/else) is a follow-up; see the design doc.
+//===--------------------------------------------------------------------===//
+struct CLCHoistPass
+    : public impl::TritonNvidiaGPUCLCHoistPassBase<CLCHoistPass> {
+  void runOnOperation() override {
+    getOperation().walk([&](CLCTryCancelAsyncOp issue) {
+      Block *blk = issue->getBlock();
+      auto whileOp = dyn_cast<scf::WhileOp>(blk->getParentOp());
+      if (!whileOp || blk != &whileOp.getAfter().front())
+        return;
+      if (&blk->front() != issue.getOperation())
+        issue->moveBefore(&blk->front());
+    });
+  }
+};
+
+//===--------------------------------------------------------------------===//
+// Stage 4 - materialize the token form into mbarrier ops (single-CTA).
+//===--------------------------------------------------------------------===//
+struct CLCMaterializePass
+    : public impl::TritonNvidiaGPUCLCMaterializePassBase<CLCMaterializePass> {
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+
+    // Single-CTA only for now: reject multi-cluster / multi-CTA.
+    if (ttg::TritonGPUDialect::getNumCTAs(mod) != 1) {
+      bool hasCLC = false;
+      mod.walk([&](Operation *op) {
+        if (isa<CLCTryCancelAsyncOp, CLCReadOp, CLCAdvanceOp>(op))
+          hasCLC = true;
+      });
+      if (hasCLC) {
+        mod.emitError("CLC tile scheduler currently supports a single CTA only "
+                      "(num-ctas == 1); multi-cluster / multi-CTA is not yet "
+                      "implemented");
+        return signalPassFailure();
+      }
+      return;
+    }
+
+    SmallVector<CLCReadOp> reads;
+    mod.walk([&](CLCReadOp read) { reads.push_back(read); });
+    for (CLCReadOp read : reads)
+      if (failed(materialize(read)))
+        return signalPassFailure();
+  }
+
+  LogicalResult materialize(CLCReadOp read) {
+    auto issue = read.getToken().getDefiningOp<CLCTryCancelAsyncOp>();
+    if (!issue)
+      return read.emitError("clc_read token is not from clc_try_cancel_async");
+
+    auto whileOp = read->getParentOfType<scf::WhileOp>();
+    if (!whileOp || issue->getParentOfType<scf::WhileOp>() != whileOp)
+      return read.emitError("CLC fetch must live in a single persistent "
+                            "scf.while (Stage 3 / cross-region CLC not yet "
+                            "supported in this branch)");
+
+    Location loc = read.getLoc();
+    OpBuilder b(whileOp);
+    Type i32 = b.getI32Type();
+
+    // Loop-carried phase, initialized to 0.
+    Value zero =
+        arith::ConstantIntOp::create(b, loc, /*value=*/0, /*width=*/32);
+    scf::WhileOp newLoop =
+        replaceWhileOpWithNewSignature(b, whileOp, {zero}, {i32});
+    whileOp->erase();
+
+    // Response buffer + completion mbarrier, allocated before the loop. The
+    // barrier ops take a single-buffer view of the (1-deep) barrier allocation.
+    b.setInsertionPoint(newLoop);
+    Value resp = createClcResponseAlloc(b, loc);
+    Value barAlloc = createBarrierAlloc(newLoop, /*numBarriers=*/1);
+    Value bar = createSingleBufferView(b, barAlloc, 0);
+
+    // Forward the phase from the before-region into the after-region and read
+    // it back as the wait phase.
+    Value phaseBefore = newLoop.getBeforeArguments().back();
+    Value phaseAfter = newLoop.getAfterArguments().back();
+    auto condOp =
+        cast<scf::ConditionOp>(newLoop.getBefore().front().getTerminator());
+    condOp.getArgsMutable().append(phaseBefore);
+
+    // Materialize the issue: barrier_expect + clc_try_cancel.
+    {
+      OpBuilder ib(issue);
+      Value pred = arith::ConstantIntOp::create(ib, issue.getLoc(), /*value=*/1,
+                                                /*width=*/1);
+      BarrierExpectOp::create(ib, issue.getLoc(), bar, kClcResponseBytes, pred);
+      CLCTryCancelOp::create(ib, issue.getLoc(), resp, bar,
+                             /*multicast=*/false);
+    }
+
+    // Materialize the read: wait_barrier + clc_load_result + decode.
+    {
+      OpBuilder rb(read);
+      WaitBarrierOp::create(rb, loc, bar, phaseAfter);
+      Value clcResult = CLCLoadResultOp::create(rb, loc, resp);
+      Value isValid = CLCIsCanceledOp::create(rb, loc, clcResult);
+      Value x = CLCGetProgramIdOp::create(rb, loc, clcResult, 0);
+      Value y = CLCGetProgramIdOp::create(rb, loc, clcResult, 1);
+      Value z = CLCGetProgramIdOp::create(rb, loc, clcResult, 2);
+      read->replaceAllUsesWith(ValueRange{isValid, x, y, z});
+    }
+    read->erase();
+    issue->erase();
+
+    // Toggle the phase once per iteration in the loop yield.
+    auto yieldOp =
+        cast<scf::YieldOp>(newLoop.getAfter().front().getTerminator());
+    OpBuilder yb(yieldOp);
+    Value one = arith::ConstantIntOp::create(yb, yieldOp.getLoc(), /*value=*/1,
+                                             /*width=*/32);
+    Value toggled =
+        arith::XOrIOp::create(yb, yieldOp.getLoc(), phaseAfter, one);
+    yieldOp.getResultsMutable().append(toggled);
+
+    return success();
+  }
+};
+
+} // namespace
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_triton_library(TritonNvidiaGPUTransforms
   CheckMatmulTwoCTAs.cpp
+  CLCLowering.cpp
   ConSanNVIDIA.cpp
   FenceInsertion.cpp
   GenerateSubtiledRegion.cpp

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1777,6 +1777,17 @@ void init_triton_ir(py::module &&m) {
                throw pybind11::index_error("program_id must be in [0,3]");
              return self.create<GetNumProgramsOp>(axis);
            })
+      // CLC (Cluster Launch Control) scheduler - SM100+ (Blackwell).
+      // `clc_advance` is the single high-level, barrier-free op: it returns the
+      // decoded next tile {isValid, x, y, z}. The initial tile needs no op
+      // (just program_id + true). A later lowering pass materializes the
+      // response buffer + mbarrier, splits the fetch into an (overlap-hoisted)
+      // issue + wait + decode, and infers the phase.
+      .def("create_clc_advance",
+           [](TritonOpBuilder &self) -> std::vector<Value> {
+             auto op = self.create<ttng::CLCAdvanceOp>();
+             return {op.getIsValid(), op.getX(), op.getY(), op.getZ()};
+           })
       .def("create_dot",
            [](TritonOpBuilder &self, mlir::Value &a, mlir::Value &b,
               mlir::Value &c, InputPrecision inputPrecision,

--- a/python/test/unit/language/test_triton_clc.py
+++ b/python/test/unit/language/test_triton_clc.py
@@ -1,0 +1,179 @@
+"""Tests for the core Triton CLC (Cluster Launch Control) tile scheduler.
+
+CLC is a Blackwell (SM100+) feature. The scheduler (`tl.clc_tile_scheduler`)
+emits a single high-level, barrier-free op (`ttng.clc_advance`) into the initial
+TTIR; the TTGIR pipeline then lowers it in stages: split into the async-token
+form (`clc_try_cancel_async` + `clc_read`), hoist the issue for overlap, and
+materialize the token into the completion mbarrier (single-CTA only).
+
+Two kinds of tests:
+- IR-shape tests on the initial TTIR (target-independent, no GPU).
+- Execution + materialized-TTGIR tests (require a Blackwell GPU).
+
+See docs/design/triton-clc-tile-scheduler.md.
+"""
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton.backends.compiler import GPUTarget
+from triton.compiler.compiler import ASTSource, make_backend
+from triton._C.libtriton import ir
+
+
+def is_blackwell():
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
+
+
+requires_blackwell = pytest.mark.skipif(not is_blackwell(), reason="CLC requires Blackwell (SM100+)")
+
+
+def initial_ttir(fn, signature, constexprs=None):
+    """Return the initial TTIR (frontend output, before any lowering pass)."""
+    target = GPUTarget("cuda", 100, 32)  # sm100 (Blackwell); frontend is target-independent
+    backend = make_backend(target)
+    src = ASTSource(fn, signature, constexprs)
+    options = backend.parse_options({})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    codegen_fns = backend.get_codegen_implementation(options)
+    module_map = backend.get_module_map()
+    return str(src.make_ir(target, options, codegen_fns, module_map, context))
+
+
+# Barrier / low-level CLC ops that must NOT appear in the initial (pre-lowering)
+# TTIR -- they are introduced by the TTGIR lowering passes.
+_LOWERING_ONLY_OPS = [
+    "ttng.init_barrier",
+    "ttng.wait_barrier",
+    "ttng.barrier_expect",
+    "ttng.clc_try_cancel",
+    "ttng.clc_load_result",
+    "ttng.clc_is_canceled",
+    "ttng.clc_get_program_id",
+    "ttng.clc_try_cancel_async",
+    "ttng.clc_read",
+]
+
+
+# ---------------------------------------------------------------------------
+# Kernels
+# ---------------------------------------------------------------------------
+@triton.jit
+def _clc_count_kernel(counts_ptr, num_tiles):
+    sched = tl.clc_tile_scheduler()
+    while sched.is_valid():
+        tid = sched.tile_id[0]
+        tl.atomic_add(counts_ptr + tid, 1, mask=tid < num_tiles)
+        sched = sched.advance()
+
+
+@triton.jit
+def _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_M: tl.constexpr):
+    group_id = tile_id // num_pid_in_group
+    first_pid_m = group_id * GROUP_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_M)
+    pid_m = first_pid_m + (tile_id % group_size_m)
+    pid_n = (tile_id % num_pid_in_group) // group_size_m
+    return pid_m, pid_n
+
+
+@triton.jit
+def _clc_matmul_kernel(a_ptr, b_ptr, c_ptr, M, N, K,  #
+                       stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,  #
+                       BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,  #
+                       GROUP_M: tl.constexpr):
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    num_pid_in_group = GROUP_M * num_pid_n
+
+    sched = tl.clc_tile_scheduler()
+    while sched.is_valid():
+        pid_m, pid_n = _compute_pid(sched.tile_id[0], num_pid_in_group, num_pid_m, GROUP_M)
+        offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)) % M
+        offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)) % N
+        offs_k = tl.arange(0, BLOCK_K)
+        a_ptrs = a_ptr + (offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak)
+        b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn)
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for k in range(0, tl.cdiv(K, BLOCK_K)):
+            a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_K, other=0.0)
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_K, other=0.0)
+            acc += tl.dot(a, b)
+            a_ptrs += BLOCK_K * stride_ak
+            b_ptrs += BLOCK_K * stride_bk
+        c = acc.to(c_ptr.dtype.element_ty)
+        offs_cm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+        tl.store(c_ptrs, c, mask=(offs_cm[:, None] < M) & (offs_cn[None, :] < N))
+        sched = sched.advance()
+
+
+# ---------------------------------------------------------------------------
+# Frontend IR-shape tests (no GPU required)
+# ---------------------------------------------------------------------------
+def test_clc_scheduler_emits_advance_and_seed():
+    ttir = initial_ttir(_clc_count_kernel, {"counts_ptr": "*i32", "num_tiles": "i32"})
+    assert "ttng.clc_advance" in ttir, "expected the high-level fetch op in the initial TTIR"
+    assert "tt.get_program_id" in ttir, "the initial tile should be seeded from program_id"
+    assert "scf.while" in ttir, "expected the scheduler to form an scf.while persistent loop"
+
+
+def test_clc_scheduler_carries_decoded_tile():
+    ttir = initial_ttir(_clc_count_kernel, {"counts_ptr": "*i32", "num_tiles": "i32"})
+    assert "(i1, i32, i32, i32) -> (i1, i32, i32, i32)" in ttir, \
+        "the scheduler loop must carry the decoded tile (is_valid, x, y, z)"
+
+
+def test_clc_initial_ttir_has_no_lowering_ops():
+    ttir = initial_ttir(_clc_count_kernel, {"counts_ptr": "*i32", "num_tiles": "i32"})
+    for op in _LOWERING_ONLY_OPS:
+        assert op not in ttir, f"{op} must not appear in the high-level (pre-lowering) TTIR"
+
+
+# ---------------------------------------------------------------------------
+# Execution tests (require a Blackwell GPU)
+# ---------------------------------------------------------------------------
+@requires_blackwell
+@pytest.mark.parametrize("num_tiles", [1, 7, 133, 1000])
+def test_clc_scheduler_visits_each_tile_once(num_tiles):
+    # Every tile in the grid must be claimed exactly once across all CTAs.
+    counts = torch.zeros(num_tiles, device="cuda", dtype=torch.int32)
+    _clc_count_kernel[(num_tiles, )](counts, num_tiles)
+    counts = counts.cpu()
+    assert counts.min().item() == 1, "some tile was never claimed"
+    assert counts.max().item() == 1, "some tile was claimed more than once"
+
+
+@requires_blackwell
+@pytest.mark.parametrize("M, N, K", [(256, 256, 128), (512, 512, 256), (1000, 1000, 500)])
+def test_clc_gemm(M, N, K):
+    torch.manual_seed(0)
+    a = torch.randn((M, K), device="cuda", dtype=torch.float16)
+    b = torch.randn((K, N), device="cuda", dtype=torch.float16)
+    c = torch.empty((M, N), device="cuda", dtype=torch.float16)
+
+    BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M = 64, 64, 32, 8
+    num_tiles = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
+    _clc_matmul_kernel[(num_tiles, )](
+        a, b, c, M, N, K,  #
+        a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0), c.stride(1),  #
+        BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M)
+
+    torch.testing.assert_close(c, torch.matmul(a, b), atol=1e-1, rtol=1e-2)
+
+
+@requires_blackwell
+def test_clc_materialized_ttgir():
+    # After the TTGIR lowering passes the high-level ops are gone and replaced by
+    # the low-level try_cancel / barrier form.
+    counts = torch.zeros(8, device="cuda", dtype=torch.int32)
+    kernel = _clc_count_kernel[(8, )](counts, 8)
+    ttgir = kernel.asm["ttgir"]
+    for op in ("ttng.clc_advance", "ttng.clc_try_cancel_async", "ttng.clc_read"):
+        assert op not in ttgir, f"{op} should be lowered away by the TTGIR passes"
+    for op in ("ttng.clc_try_cancel", "ttng.clc_load_result", "ttng.barrier_expect", "ttng.wait_barrier"):
+        assert op in ttgir, f"expected {op} in the materialized TTGIR"

--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -5,6 +5,7 @@ from . import math
 from . import extra
 # Import TLX features (async_task, async_tasks) for backward compatibility
 from .extra.tlx import async_task, async_tasks
+from .clc import clc_tile_scheduler, ClcTileScheduler
 from .standard import (
     argmax,
     argmin,
@@ -170,6 +171,8 @@ __all__ = [
     "async_task",
     "async_tasks",
     "assume",
+    "clc_tile_scheduler",
+    "ClcTileScheduler",
     "atomic_add",
     "atomic_and",
     "atomic_cas",

--- a/python/triton/language/clc.py
+++ b/python/triton/language/clc.py
@@ -1,0 +1,68 @@
+"""Cluster Launch Control (CLC) tile scheduler for core Triton.
+
+CLC is a Blackwell (SM100+) hardware feature for dynamic persistent kernels: a
+block that finishes early cancels a pending (not-yet-launched) cluster and takes
+over its tile. This module exposes a minimal, opaque scheduler:
+
+    sched = tl.clc_tile_scheduler()      # initialize
+    while sched.is_valid():              # more work to steal?
+        pid = sched.tile_id[0]           # current tile coord (x); [1]/[2] for y/z
+        ... compute ...
+        sched = sched.advance()          # fetch the next tile
+
+The scheduler carries the *decoded* tile: an ``is_valid`` predicate and the
+(x, y, z) program-id coordinates. The initial tile is simply this CTA's
+``program_id`` (with ``is_valid = True``); every later tile comes from a single
+high-level ``ttng.clc_advance`` op. The response buffer, mbarrier, phase, and the
+issue/wait overlap are ALL handled by a later compiler lowering pass -- the kernel
+author writes none of that plumbing. The API is standalone (it does not require
+warp specialization).
+"""
+import triton.language.core as tl
+from triton.language.core import builtin
+
+__all__ = ["clc_tile_scheduler", "ClcTileScheduler"]
+
+
+@tl._aggregate
+class ClcTileScheduler:
+    # Decoded current tile: validity + (x, y, z) program-id coordinates.
+    _valid: tl.tensor
+    _x: tl.tensor
+    _y: tl.tensor
+    _z: tl.tensor
+
+    @builtin
+    def is_valid(self, _semantic=None):
+        """Whether the current tile holds real work. Use as the ``while`` condition."""
+        return self._valid
+
+    @builtin
+    def advance(self, _semantic=None):
+        """Fetch the next tile and return the updated scheduler."""
+        is_valid, x, y, z = _semantic.builder.create_clc_advance()
+        return ClcTileScheduler(tl.tensor(is_valid, tl.int1), tl.tensor(x, tl.int32), tl.tensor(y, tl.int32),
+                                tl.tensor(z, tl.int32))
+
+
+# `@_aggregate` only transfers methods (not properties) onto the value class, so
+# attach the `tile_id` accessor property here. Returns a 3-tuple; index it as
+# `tile_id[0|1|2]`.
+ClcTileScheduler.tile_id = property(lambda self: tl.tuple([self._x, self._y, self._z]))
+
+
+@builtin
+def clc_tile_scheduler(_semantic=None):
+    """Create a CLC tile scheduler for a dynamic persistent kernel (Blackwell).
+
+    Seeds the scheduler with this CTA's own statically-launched tile
+    (``program_id`` with ``is_valid = True``); subsequent tiles are fetched via
+    CLC work-stealing in ``advance``.
+    """
+    b = _semantic.builder
+    return ClcTileScheduler(
+        tl.tensor(b.get_int1(True), tl.int1),
+        tl.tensor(b.create_get_program_id(0), tl.int32),
+        tl.tensor(b.create_get_program_id(1), tl.int32),
+        tl.tensor(b.create_get_program_id(2), tl.int32),
+    )

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -746,6 +746,12 @@ class CUDABackend(BaseBackend):
             passes.ttgpuir.add_optimize_accumulator_init(pm)
             passes.ttgpuir.add_hoist_tmem_alloc(pm, False)
             nvidia.passes.ttnvgpuir.add_promote_lhs_to_tmem(pm)
+            # CLC tile scheduler (Stages 1 & 2): split ttng.clc_advance into the
+            # async-token form and hoist the issue for compute/CLC overlap. This
+            # runs before warp specialization; the token is materialized into the
+            # completion mbarrier after WS (add_clc_materialize below).
+            nvidia.passes.ttnvgpuir.add_clc_split(pm)
+            nvidia.passes.ttnvgpuir.add_clc_hoist(pm)
             if knobs.nvidia.use_llm_schedule:
                 nvidia.passes.hopper.add_llm_schedule(pm)
             elif knobs.nvidia.use_modulo_schedule is not None:
@@ -790,6 +796,10 @@ class CUDABackend(BaseBackend):
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
             # hoist again and allow hoisting out of if statements
             passes.ttgpuir.add_hoist_tmem_alloc(pm, True)
+            # CLC tile scheduler (Stage 4): materialize the async-token form into
+            # the response buffer + completion mbarrier (single-CTA only). Runs
+            # after warp specialization.
+            nvidia.passes.ttnvgpuir.add_clc_materialize(pm)
             nvidia.passes.ttnvgpuir.add_remove_tmem_tokens(pm)
             # 2-CTA: Insert cross-CTA sync AFTER all WS passes.
             # Only for Meta WS path — non-WS 2-CTA sync is handled by

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -189,6 +189,10 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      ttng::createTritonNvidiaGPUInterleaveTMemPass);
   ADD_PASS_WRAPPER_0("add_prune_unused_barriers",
                      ttng::createTritonNvidiaGPUPruneUnusedBarriersPass);
+  ADD_PASS_WRAPPER_0("add_clc_split", ttng::createTritonNvidiaGPUCLCSplitPass);
+  ADD_PASS_WRAPPER_0("add_clc_hoist", ttng::createTritonNvidiaGPUCLCHoistPass);
+  ADD_PASS_WRAPPER_0("add_clc_materialize",
+                     ttng::createTritonNvidiaGPUCLCMaterializePass);
   ttng::registerConSanNVIDIAHooks();
 }
 


### PR DESCRIPTION
Summary:
Adds support for CLC APIs in Triton. This does not include AutoWS support which will in the next PR. The basic idea is similar to Gluon we will depend on passing a schedule object to avoid extra APIs. This realistically only produces 1 new frontend op: CLC_Advance.

From there the compiler will transform these into async APIs that can eventually work with warp spec (and eventually map down to the raw TLX/Gluon APIs). Importantly: We introducing intermediate ops so that we can have "tokens" to give us flexibility for future optimizations. Two optimizations we consider are:

1. The need to pull the try_cancel earlier in the loop to avoid waiting on hardware. This depends on other barriers not being in the code and so must run before AutoWS.
2. Optimization on other code regions in AutoWS. This requires CLC to not introduce additional barriers before AutoWS.

The full design is included in this PR. As a recap this is the rough implementation plan:

1. Support static persistent GEMM with a while loop
2. Support dynamic persistent GEMM with a while loop
3. Support CLC APIs for Triton (here)
4. Support CLC GEMM with a while loop
5. Attention support (probably several PRs).


Differential Revision: D110904014

Pulled By: njriasan


