### PR TITLE
 [AutoWS] Optimize out single iteration while loops (#1886)

### DIFF
--- a/include/triton/Dialect/Triton/Transforms/Passes.td
+++ b/include/triton/Dialect/Triton/Transforms/Passes.td
@@ -56,6 +56,37 @@ def TritonLoopUnroll : Pass</*cli-arg*/"triton-loop-unroll", /*Op*/"mlir::Module
   let dependentDialects = ["mlir::triton::TritonDialect"];
 }
 
+def TritonSimplifySingleTripWhile : Pass</*cli-arg*/"triton-simplify-single-trip-while", /*Op*/"mlir::ModuleOp"> {
+  let summary = "Replace a provably single-iteration scf.while with its body";
+  let description = [{
+    This pass detects an `scf.while` loop that provably executes its body exactly
+    once and replaces the loop with the straight-line (inlined) body, eliminating
+    the loop overhead and its loop-carried state.
+
+    The current detection targets the "constant-flip" pattern produced by the
+    non-persistent unified tile scheduler: the loop condition is a loop-carried
+    `i1` value that is a constant `true` on entry (the while init) and a constant
+    `false` after the body (the after-region yield). Concretely, the pass fires
+    only when:
+      - the before-region is side-effect-free, and
+      - the `scf.condition` value is directly a before-block argument whose
+        `scf.while` init folds to a constant `true` while the corresponding
+        after-region yield operand folds to a constant `false`.
+
+    The rewrite evaluates the (pure) before-region for the forwarded args, inlines
+    the body once, and (only if the loop has results) evaluates the before-region
+    again on the yielded values to produce them. Broader conditions (computed
+    condition expressions) are not handled and could be added later via constant
+    folding of the condition.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::TritonDialect",
+    "mlir::arith::ArithDialect",
+    "mlir::scf::SCFDialect"
+  ];
+}
+
 def TritonLoopInvariantCodeMotion : Pass</*cli-arg*/"triton-licm", /*Op*/"mlir::ModuleOp"> {
   let summary = "MLIR's LICM plus hoist load ops out of loops with masks.";
   let description = [{

--- a/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_triton_library(TritonTransforms
   LoopUnroll.cpp
   ReorderBroadcast.cpp
   RewriteTensorDescriptorToPointer.cpp
+  SimplifySingleTripWhile.cpp
   ArithTypeConversion.cpp
   FunctionTypeConversion.cpp
 

--- a/lib/Dialect/Triton/Transforms/SimplifySingleTripWhile.cpp
+++ b/lib/Dialect/Triton/Transforms/SimplifySingleTripWhile.cpp
@@ -1,0 +1,144 @@
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/Transforms/Passes.h"
+#include "llvm/Support/Debug.h"
+
+namespace mlir::triton {
+
+#define GEN_PASS_DEF_TRITONSIMPLIFYSINGLETRIPWHILE
+#include "triton/Dialect/Triton/Transforms/Passes.h.inc"
+
+#define DEBUG_TYPE "triton-simplify-single-trip-while"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace {
+
+// Returns true if `v` is a constant `i1` equal to `expected`. Note: a 1-bit
+// APInt of value 1 sign-extends to -1, so compare the boolean value rather than
+// getConstantIntValue()'s sign-extended integer.
+static bool isConstantBool(Value v, bool expected) {
+  APInt val;
+  if (matchPattern(v, m_ConstantInt(&val)) && val.getBitWidth() == 1)
+    return val.getBoolValue() == expected;
+  return false;
+}
+
+// A single-trip `scf.while` matches the "constant-flip" pattern when:
+//  - the before-region has no side effects (it is evaluated by the rewrite but
+//    its ops are otherwise dropped), and
+//  - the `scf.condition` value is directly a before-block argument at index
+//  `c`,
+//    whose while init folds to constant `true` (so the loop is entered), while
+//    the after-region yield operand at index `c` folds to constant `false` (so
+//    the loop is not re-entered).
+// The condition need not be a pass-through of all args -- canonicalization
+// drops unused loop-carried values, so the real IR often forwards no args / has
+// no results.
+static bool isSingleTripConstantFlip(scf::WhileOp whileOp) {
+  Block &before = whileOp.getBefore().front();
+  auto condOp = cast<scf::ConditionOp>(before.getTerminator());
+
+  // The before-region is evaluated (cloned) but never kept, so it must be free
+  // of side effects.
+  for (Operation &op : before.without_terminator())
+    if (!isMemoryEffectFree(&op))
+      return false;
+
+  // The condition value must be directly a before-block argument.
+  auto condArg = dyn_cast<BlockArgument>(condOp.getCondition());
+  if (!condArg || condArg.getOwner() != &before)
+    return false;
+  unsigned c = condArg.getArgNumber();
+
+  // init[c] == true (enter once) and yield[c] == false (do not re-enter). The
+  // yield forwards the next loop-carried values, indexed like the before args.
+  // Well-formed IR keeps these arities in sync, but bounds-check `c` so
+  // malformed/partially-formed IR makes us decline rather than crash.
+  auto yieldOp = cast<scf::YieldOp>(whileOp.getAfter().front().getTerminator());
+  if (c >= whileOp.getInits().size() || c >= yieldOp.getResults().size())
+    return false;
+  return isConstantBool(whileOp.getInits()[c], /*expected=*/true) &&
+         isConstantBool(yieldOp.getResults()[c], /*expected=*/false);
+}
+
+// Clone the (pure) before-region ops under `argMap` (before-arg -> concrete
+// value) and return the resulting `scf.condition` forwarded args.
+static SmallVector<Value> evalBeforeForwardedArgs(OpBuilder &builder,
+                                                  scf::WhileOp whileOp,
+                                                  IRMapping argMap) {
+  Block &before = whileOp.getBefore().front();
+  for (Operation &op : before.without_terminator())
+    builder.clone(op, argMap);
+  auto condOp = cast<scf::ConditionOp>(before.getTerminator());
+  SmallVector<Value> fwd;
+  for (Value a : condOp.getArgs())
+    fwd.push_back(argMap.lookupOrDefault(a));
+  return fwd;
+}
+
+// Inline the after-region body once and replace the loop with its results.
+static void rewriteSingleTripWhile(scf::WhileOp whileOp) {
+  OpBuilder builder(whileOp);
+  Block &before = whileOp.getBefore().front();
+  Block &after = whileOp.getAfter().front();
+  auto yieldOp = cast<scf::YieldOp>(after.getTerminator());
+
+  // First before-region evaluation, with the loop inits substituted for the
+  // before-block args. Its forwarded args are what feed the after-block on the
+  // single entry.
+  IRMapping initMap;
+  for (auto [arg, init] : llvm::zip(before.getArguments(), whileOp.getInits()))
+    initMap.map(arg, init);
+  SmallVector<Value> forwarded =
+      evalBeforeForwardedArgs(builder, whileOp, initMap);
+
+  // Inline the after-region body once.
+  IRMapping bodyMap;
+  for (auto [arg, v] : llvm::zip(after.getArguments(), forwarded))
+    bodyMap.map(arg, v);
+  for (Operation &op : after.without_terminator())
+    builder.clone(op, bodyMap);
+
+  // The while results are the forwarded args of the *second* before-region
+  // evaluation, run on the loop-carried values yielded by the body (whose
+  // condition folds to false, so the loop exits after one iteration). Skip this
+  // when the loop has no results (the common canonicalized case).
+  SmallVector<Value> results;
+  if (whileOp.getNumResults() > 0) {
+    IRMapping nextMap;
+    for (auto [arg, y] : llvm::zip(before.getArguments(), yieldOp.getResults()))
+      nextMap.map(arg, bodyMap.lookupOrDefault(y));
+    results = evalBeforeForwardedArgs(builder, whileOp, nextMap);
+  }
+
+  whileOp.replaceAllUsesWith(results);
+  whileOp.erase();
+}
+
+} // namespace
+
+class SimplifySingleTripWhilePass
+    : public impl::TritonSimplifySingleTripWhileBase<
+          SimplifySingleTripWhilePass> {
+public:
+  void runOnOperation() override {
+    SmallVector<scf::WhileOp> loops;
+    getOperation()->walk([&](scf::WhileOp whileOp) {
+      if (isSingleTripConstantFlip(whileOp))
+        loops.push_back(whileOp);
+    });
+
+    for (scf::WhileOp whileOp : loops) {
+      LDBG("Simplifying single-trip while: " << whileOp);
+      rewriteSingleTripWhile(whileOp);
+    }
+  }
+};
+
+} // namespace mlir::triton

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -46,6 +46,8 @@ void init_triton_passes_ttir(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_rewrite_tensor_descriptor_to_pointer",
                      createTritonRewriteTensorDescriptorToPointer);
   ADD_PASS_WRAPPER_0("add_loop_unroll", createTritonLoopUnroll);
+  ADD_PASS_WRAPPER_0("add_simplify_single_trip_while",
+                     createTritonSimplifySingleTripWhile);
   ADD_PASS_WRAPPER_0("add_triton_licm", createTritonLoopInvariantCodeMotion);
   ADD_PASS_WRAPPER_0("add_loop_aware_cse", createTritonLoopAwareCSE);
   ADD_PASS_OPTION_WRAPPER_4("add_convert_to_ttgpuir",

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -1144,7 +1144,13 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(EPI
         )
 
         ttgir = kernel.asm["ttgir"]
-        assert "scf.while" in ttgir, "Expected persistent outer loop to lower to scf.while"
+        if SCHEDULE is tl.NonPersistentScheduler:
+            # The non-persistent schedule's outer loop provably runs exactly once
+            # (`_valid` flips True->False), so triton-simplify-single-trip-while
+            # optimizes the `scf.while` away at the TTIR stage.
+            assert "scf.while" not in ttgir, "Expected single-trip outer while to be optimized away"
+        else:
+            assert "scf.while" in ttgir, "Expected persistent outer loop to lower to scf.while"
         assert "ttg.warp_specialize" in ttgir, "Expected warp specialization in IR"
         assert "ttng.tc_gen5_mma" in ttgir or "ttng.warp_group_dot" in ttgir, "Expected an MMA instruction"
         assert "ttng.async_tma_copy_global_to_local" in ttgir, "Expected TMA copy"

--- a/test/Triton/simplify-single-trip-while.mlir
+++ b/test/Triton/simplify-single-trip-while.mlir
@@ -1,0 +1,102 @@
+// RUN: triton-opt --split-input-file %s -triton-simplify-single-trip-while | FileCheck %s
+
+// The "constant-flip" pattern: the loop-carried condition is a constant `true`
+// on entry and a constant `false` after the body, and scf.condition forwards all
+// before-block args unchanged. The loop provably runs once and is inlined.
+// CHECK-LABEL: @single_trip
+// CHECK-NOT: scf.while
+// CHECK: arith.addi
+// CHECK: tt.return
+tt.func @single_trip(%arg0: i32) -> i32 {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c1 = arith.constant 1 : i32
+  %r:2 = scf.while (%valid = %true, %acc = %arg0) : (i1, i32) -> (i1, i32) {
+    scf.condition(%valid) %valid, %acc : i1, i32
+  } do {
+  ^bb0(%v: i1, %a: i32):
+    %n = arith.addi %a, %c1 : i32
+    scf.yield %false, %n : i1, i32
+  }
+  tt.return %r#1 : i32
+}
+
+// -----
+
+// The canonicalized shape (as produced for the non-persistent tile scheduler):
+// unused loop-carried values are dropped, so the loop forwards no args and has no
+// results -- just the `i1` flag flipping true -> false. The body runs once.
+// CHECK-LABEL: @single_trip_no_results
+// CHECK-NOT: scf.while
+// CHECK: tt.store
+tt.func @single_trip_no_results(%arg0: !tt.ptr<i32>) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c1 = arith.constant 1 : i32
+  scf.while (%valid = %true) : (i1) -> () {
+    scf.condition(%valid)
+  } do {
+    tt.store %arg0, %c1 : !tt.ptr<i32>
+    scf.yield %false : i1
+  }
+  tt.return
+}
+
+// -----
+
+// Negative: the init condition is not a constant `true` (it is a runtime arg),
+// so the loop may run zero times and must be preserved.
+// CHECK-LABEL: @nonconstant_init
+// CHECK: scf.while
+tt.func @nonconstant_init(%arg0: i32, %valid0: i1) -> i32 {
+  %false = arith.constant false
+  %c1 = arith.constant 1 : i32
+  %r:2 = scf.while (%valid = %valid0, %acc = %arg0) : (i1, i32) -> (i1, i32) {
+    scf.condition(%valid) %valid, %acc : i1, i32
+  } do {
+  ^bb0(%v: i1, %a: i32):
+    %n = arith.addi %a, %c1 : i32
+    scf.yield %false, %n : i1, i32
+  }
+  tt.return %r#1 : i32
+}
+
+// -----
+
+// Negative: the after-region yields `true` for the condition, so the loop can
+// iterate more than once and must be preserved.
+// CHECK-LABEL: @yield_true
+// CHECK: scf.while
+tt.func @yield_true(%arg0: i32) -> i32 {
+  %true = arith.constant true
+  %c1 = arith.constant 1 : i32
+  %r:2 = scf.while (%valid = %true, %acc = %arg0) : (i1, i32) -> (i1, i32) {
+    scf.condition(%valid) %valid, %acc : i1, i32
+  } do {
+  ^bb0(%v: i1, %a: i32):
+    %n = arith.addi %a, %c1 : i32
+    scf.yield %true, %n : i1, i32
+  }
+  tt.return %r#1 : i32
+}
+
+// -----
+
+// Negative: the condition value is a computed op, not a direct before-block
+// argument, so the (deliberately narrow) matcher does not fire.
+// CHECK-LABEL: @computed_condition
+// CHECK: scf.while
+tt.func @computed_condition(%arg0: i32) -> i32 {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c1 = arith.constant 1 : i32
+  %r:2 = scf.while (%valid = %true, %acc = %arg0) : (i1, i32) -> (i1, i32) {
+    %c = arith.andi %valid, %valid : i1
+    scf.condition(%c) %valid, %acc : i1, i32
+  } do {
+  ^bb0(%v: i1, %a: i32):
+    %n = arith.addi %a, %c1 : i32
+    scf.yield %false, %n : i1, i32
+  }
+  tt.return %r#1 : i32
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -251,6 +251,7 @@ class HIPBackend(BaseBackend):
         if not amd.supports_tdm(options.arch):
             passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
         passes.common.add_canonicalizer(pm)
+        passes.ttir.add_simplify_single_trip_while(pm)
         passes.ttir.add_combine(pm)
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -748,6 +748,7 @@ class CUDABackend(BaseBackend):
         if (opt.auto_tma or knobs.nvidia.auto_tma) and capability // 10 >= 9:
             nvidia.passes.ttnvgpuir.add_promote_load_to_tma(pm)
         passes.common.add_canonicalizer(pm)
+        passes.ttir.add_simplify_single_trip_while(pm)
         passes.ttir.add_combine(pm)
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)


### PR DESCRIPTION
Summary:
Adds support for optimizing out a while loop that will only have a single iteration. This allows a kernel structure that is constructed as a standard persistent kernel to be transformed to the optimal structure.


Reviewed By: manman-ren

Differential Revision: D111960378

Pulled By: njriasan


