### PR TITLE
[triton] Avoid recursion in deep BinOp codegen

### DIFF
--- a/python/test/unit/language/test_codegen_binop.py
+++ b/python/test/unit/language/test_codegen_binop.py
@@ -1,0 +1,18 @@
+import triton
+import triton.language as tl
+from triton._filecheck import run_parser
+
+
+@triton.jit
+def _deep_binop_template():
+    x = tl.arange(0, 1)
+    y = x  # REPLACE_WITH_DEEP_BINOP
+    tl.static_assert(y.shape[0] == 1)
+
+
+def test_deeply_nested_binop_does_not_recurse():
+    expr = "x" + " + x" * 1500
+    kernel = triton.JITFunction(_deep_binop_template.fn)
+    kernel._unsafe_update_src(kernel.src.replace("y = x  # REPLACE_WITH_DEEP_BINOP", f"y = {expr}"))
+
+    run_parser(kernel)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -866,15 +866,23 @@ class CodeGenerator(ast.NodeVisitor):
         return self.call_Function(node, fn, [rhs], {})
 
     def visit_BinOp(self, node):
-        lhs = self.visit(node.left)
-        rhs = self.visit(node.right)
-        method_name = self._method_name_for_bin_op.get(type(node.op))
+        op_type = type(node.op)
+        chain = []
+        current = node
+        while isinstance(current, ast.BinOp) and type(current.op) is op_type:
+            chain.append((current, current.right))
+            current = current.left
+        method_name = self._method_name_for_bin_op.get(op_type)
         if method_name is None:
             raise self._unsupported(
                 node,
                 "AST binary operator '{}' is not (currently) implemented.".format(node.op.__name__),
             )
-        return self._apply_binary_method(node, method_name, lhs, rhs)
+        result = self.visit(current)
+        for binop_node, right_node in reversed(chain):
+            rhs = self.visit(right_node)
+            result = self._apply_binary_method(binop_node, method_name, result, rhs)
+        return result
 
     _method_name_for_bin_op: Dict[Type[ast.operator], str] = {
         ast.Add: "__add__",


### PR DESCRIPTION
# Summary
Triton's CodeGenerator.visit_BinOp recursed via self.visit(node.left) for each level of a left-recursive BinOp chain. Python parses a + b + c + ... + z as a left-leaning tree of N nested BinOp nodes, so an expression with 468 terms (as generated by Inductor for torch.cat of many dynamic-shape tensors) exceeds Python's recursion limit.

The fix flattens left-recursive chains of the same operator iteratively: it walks down the left spine collecting each (BinOp node, right operand) pair, then folds left-to-right in a loop. It is semantics-preserving -- it reproduces the recursive version's operand visit order and its per-level _apply_binary_method(node, ...) calls (beta threads the originating node into call_Function), just with O(1) Python stack depth instead of O(N).

# Test
- buck2 test @fbcode//mode/opt fbsource//third-party/triton/beta/triton:py_unit_language_tests -- --regex '.*test_deeply_nested_binop_does_not_recurse.*' --print-passing-details --no-record-results