### PR TITLE
[TritonGPU] NPOT elementwise lowering via modular LinearLayout (#1892)

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
@@ -7,6 +7,7 @@
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "llvm/Support/MathExtras.h" // Log2_64
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -89,8 +90,13 @@ public:
     auto invReg = inv.sublayout(dims, {kReg});
     auto bases_inv = invReg.getBases();
     for (auto [c, d] : llvm::zip(constancy, dims)) {
-      assert(llvm::isPowerOf2_32(c));
-      for (int i = 0; i < llvm::Log2_32(c); i++) {
+      // Clamp constancy to its largest pow2 divisor (c & -c) before Log2; NPOT
+      // constancy (e.g. 48) would mis-floor. c is a multiple of it, so the
+      // zeroed low bits never cross a constancy block boundary. Pow2 c: no-op.
+      if (c == 0)
+        continue; // Log2_64(0) is UB; nothing to dedup
+      int64_t pow2C = c & (-c);
+      for (int i = 0; i < llvm::Log2_64(pow2C); i++) {
         bases_inv[d][i] = {0};
       }
     }

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -14,6 +14,7 @@
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/StrUtil.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/MathExtras.h"
 
 #define DEBUG_TYPE "ttgpu_to_llvm"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -668,6 +669,30 @@ std::optional<LLVM::AtomicOrdering> getMemoryOrdering(MemSemantic memOrdering);
 llvm::MapVector<StringAttr, int32_t> getAllFreeVarMasks(MLIRContext *ctx);
 
 llvm::MapVector<StringAttr, int32_t> getFreeVariableMasks(Type type);
+
+/// Clamp vec size for NPOT dims: round down to a pow2 load/store width, then
+/// clamp to the alignment of a non-pow2 sizePerThread (Blocked only; Slice/
+/// Linear don't reach here). No-op for pow2, so safe to run unconditionally
+/// (not flag-gated).
+inline unsigned clampVecSizeForNpot(unsigned vec, RankedTensorType tensorTy) {
+  if (vec <= 1)
+    return vec; // avoids Log2_32(0) UB
+  if (!llvm::isPowerOf2_32(vec))
+    vec = 1u << llvm::Log2_32(vec);
+  if (!tensorTy)
+    return vec;
+  if (auto blocked =
+          dyn_cast<triton::gpu::BlockedEncodingAttr>(tensorTy.getEncoding())) {
+    auto contOrder = triton::gpu::getOrder(tensorTy);
+    unsigned spt = blocked.getSizePerThread()[contOrder[0]];
+    if (spt > 0 && !llvm::isPowerOf2_32(spt)) {
+      // Largest pow2 divisor (lowest set bit) = the guaranteed alignment.
+      unsigned maxAligned = spt & (0u - spt);
+      vec = std::min(vec, maxAligned);
+    }
+  }
+  return vec;
+}
 
 inline bool isCanonicalIndex(unsigned index, unsigned freeVarMask) {
   return (index & freeVarMask) == 0;

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -115,10 +115,59 @@ Value matrixVectorProd(TritonLLVMOpBuilder &b, const LinearLayout &A, Value x) {
     return ret;
   };
   auto nCol = A.getTotalInDimSizeLog2();
-  auto nRow = A.getTotalOutDimSizeLog2();
   SmallVector<int32_t> matrix = flatten(A.getBases().begin()->second);
   assert(matrix.size() == nCol);
 
+  // NPOT: accumulate ADD without an intermediate urem; applyNpotModulo does the
+  // single final modulo, which is equivalent for non-negative integers. No i32
+  // overflow: nCol <= ~20 bits and each basisValue < 2*outDimSize, so the sum
+  // stays < 2^25 for any practical dim.
+  if (A.isModular()) {
+    // Fast path for dense identity bases [1,2,...,2^(highBit-1)]: x mod
+    // 2^highBit == x & ((1u<<highBit)-1). Bail if a zero column sits below the
+    // highest set bit (a gap would leak that bit through the mask); trailing
+    // zero columns above the set bits are harmless.
+    unsigned nColU = static_cast<unsigned>(nCol);
+    bool isIdentity = true;
+    unsigned highBit = 0;
+    int firstZeroCol = -1;
+    for (unsigned col = 0; col < nColU; ++col) {
+      int32_t bv = matrix[col];
+      if (bv == 0) {
+        if (firstZeroCol < 0)
+          firstZeroCol = static_cast<int>(col);
+        continue;
+      }
+      // Set bit above an earlier zero column: the zero was a gap, not trailing.
+      if (firstZeroCol >= 0) {
+        isIdentity = false;
+        break;
+      }
+      if (bv != static_cast<int32_t>(1u << col)) {
+        isIdentity = false;
+        break;
+      }
+      highBit = col + 1;
+    }
+    if (isIdentity && highBit > 0)
+      return b.and_(x, b.i32_val((1u << highBit) - 1));
+
+    // General modular path: select+add per basis vector.
+    Value sum = b.i32_val(0);
+    for (unsigned col = 0; col < nColU; ++col) {
+      int32_t basisValue = matrix[col];
+      if (basisValue == 0)
+        continue;
+      Value bit = b.and_(x, b.i32_val(1u << col));
+      Value bitIsZero = b.icmp_eq(bit, b.i32_val(0));
+      Value term = b.select(bitIsZero, b.i32_val(0), b.i32_val(basisValue));
+      sum = b.add(sum, term);
+    }
+    return sum;
+  }
+
+  // Power-of-2 path: XOR-based optimization (unchanged)
+  auto nRow = A.getTotalOutDimSizeLog2();
   // Row-wise popcount to detect rows that appear exactly once across columns.
   uint32_t rowsUnique = 0;
   {
@@ -289,6 +338,78 @@ Value emitRedundantThreadPredicate(
 
 } // namespace triton::gpu
 
+// Cheap modulo for inputs provably < 2N: compare-and-subtract (2 ops vs
+// Barrett's 6; matters on AMD gfx950 where i64 multiply is slow).
+static Value smallModulo(TritonLLVMOpBuilder &b, Value x, int32_t N) {
+  Value cmp = b.icmp_uge(x, b.i32_val(N));
+  return b.select(cmp, b.sub(x, b.i32_val(N)), x);
+}
+
+// Largest input for which barrettModulo below is proven correct: the choice
+// k = 32 + ceil(log2 N) makes q = (x*M)>>k exact for all x in [0, 2^25).
+static constexpr uint32_t kBarrettMaxInput = 1u << 25;
+
+// Barrett reduction: replace urem with multiply-shift for compile-time moduli.
+// For x mod N where N is known at compile time: q = (x * M) >> k; x - q * N
+// where M = ceil(2^k / N). Uses i64 intermediate to avoid overflow.
+// Correct for all x in [0, kBarrettMaxInput) with k = 32 + ceil(log2(N)).
+static Value barrettModulo(TritonLLVMOpBuilder &b, Value x, int32_t N) {
+  assert(N > 0 && !llvm::isPowerOf2_32(N));
+  int k = 32 + llvm::Log2_32_Ceil(N);
+  // NB: M is uint64_t but i64_val() takes int64_t. This is safe because
+  // k = 32 + ceil(log2(N)) <= 63 for any int32_t N, so M < 2^63.
+  uint64_t M = (uint64_t{1} << k) / N + 1; // ceil(2^k / N)
+  auto i64Ty = b.builder->getIntegerType(64);
+  auto i32Ty = b.builder->getIntegerType(32);
+  Value x64 = b.zext(i64Ty, x);
+  Value prod = b.mul(x64, b.i64_val(M));
+  Value q64 = b.lshr(prod, b.i64_val(k));
+  Value q = b.trunc(i32Ty, q64);
+  return b.sub(x, b.mul(q, b.i32_val(N)));
+}
+
+// Combine two values along an output dim of `layout`. NPOT (modular) dims use
+// integer ADD; pow2 dims use XOR.
+static Value combineModularOrXor(TritonLLVMOpBuilder &b,
+                                 const LinearLayout &layout, StringAttr outDim,
+                                 Value lhs, Value rhs) {
+  if (layout.isOutDimModular(outDim))
+    return b.add(lhs, rhs);
+  return b.xor_(lhs, rhs);
+}
+
+// Apply modular reduction for non-power-of-2 output dimensions.
+// Uses smallModulo (compare+subtract) when the accumulated value is provably
+// < 2N, otherwise falls back to Barrett reduction.
+static void
+applyNpotModulo(TritonLLVMOpBuilder &b, const LinearLayout &layout,
+                MutableArrayRef<std::pair<StringAttr, Value>> indices) {
+  if (!layout.isModular())
+    return;
+  for (auto &[outDimName, outIdx] : indices) {
+    int32_t outDimSize = layout.getOutDimSize(outDimName);
+    if (!llvm::isPowerOf2_32(outDimSize)) {
+      // Compute max possible value: sum of all basis entries for this dim
+      // (from matrixVectorProd) + outDimSize - 1 (max constant part).
+      int32_t outDimIdx = layout.getOutDimIndex(outDimName);
+      int32_t maxBasisSum = 0;
+      for (auto &[inDimName, bases] : layout.getBases()) {
+        for (auto &basisVec : bases)
+          maxBasisSum += basisVec[outDimIdx];
+      }
+      int32_t maxValue = maxBasisSum + outDimSize - 1;
+      if (maxValue < 2 * outDimSize)
+        outIdx = smallModulo(b, outIdx, outDimSize);
+      else if (static_cast<uint32_t>(maxValue) < kBarrettMaxInput)
+        outIdx = barrettModulo(b, outIdx, outDimSize);
+      else
+        // Beyond the Barrett-proven range: fall back to a plain urem so release
+        // builds stay correct rather than silently miscomputing.
+        outIdx = b.urem(outIdx, b.i32_val(outDimSize));
+    }
+  }
+}
+
 SmallVector<std::pair<StringAttr, Value>>
 applyLinearLayout(Location loc, RewriterBase &rewriter,
                   const LinearLayout &layout,
@@ -346,19 +467,17 @@ applyLinearLayout(Location loc, RewriterBase &rewriter,
     shift += layout.getInDimSizeLog2(inDimName);
   }
 
-  if (layout.isModular()) {
-    mlir::emitError(loc) << "NPOT layout not yet supported in lowering: "
-                            "applyLinearLayout cannot index a modular "
-                            "(non-power-of-2) output dimension yet";
-    return outIndices;
-  }
-
+  // NPOT: per-out-dim ADD then modulo (mixed layouts like [32,48] combine
+  // ADD/XOR per dim); the pow2 path is XOR + no-op modulo -> flag-off builds
+  // are byte-identical (a layout is only modular under TRITON_ALLOW_NPOT).
   for (auto &[outDimName, outIdx] : outIndices) {
-    // Apply flattened sublayout for this output
+    // Apply flattened sublayout for this output dimension
     auto matrix = layout.sublayout(inDimNames, outDimName).flattenIns();
     auto out = triton::gpu::matrixVectorProd(b, matrix, x);
-    outIdx = b.xor_(outIdx, out);
+    outIdx = combineModularOrXor(b, layout, outDimName, outIdx, out);
   }
+
+  applyNpotModulo(b, layout, outIndices);
 
   return outIndices;
 }
@@ -487,7 +606,6 @@ applyLinearLayoutVec(Location loc, RewriterBase &rewriter,
 
   SmallVector<SmallVector<std::pair<StringAttr, Value>>> ret;
 
-  // Iterate over registers, applying XOR trick
   for (auto reg : registers) {
     SmallVector<std::pair<StringAttr, int32_t>> constRegIndices;
     for (const auto &[attr, val] : indices) {
@@ -498,11 +616,30 @@ applyLinearLayoutVec(Location loc, RewriterBase &rewriter,
     SmallVector<std::pair<StringAttr, Value>> combinedIndices;
     for (auto [base, regIdx] : llvm::zip(baseIndices, regIndices)) {
       assert(base.first == regIdx.first);
-      Value combined = b.xor_(base.second, b.i32_val(regIdx.second));
+      // baseIndices already got modular handling via applyLinearLayout; add the
+      // per-register delta with the same per-dim algebra (ADD for NPOT, XOR for
+      // pow2). See applyLinearLayout for the pow2 no-op rationale.
+      Value regVal = b.i32_val(regIdx.second);
+      Value combined =
+          combineModularOrXor(b, layout, base.first, base.second, regVal);
       combinedIndices.emplace_back(base.first, combined);
     }
 
     ret.push_back(combinedIndices);
+  }
+
+  // Final modulo per NPOT out-dim (no-op for pow2). baseIndices are already in
+  // [0, N) (applyLinearLayout reduced them) and each per-register delta is in
+  // [0, N), so the ADD above is < 2N -> the cheap compare-subtract is exact and
+  // we skip the full-layout maxValue recompute that would force Barrett.
+  if (layout.isModular()) {
+    for (auto &entry : ret) {
+      for (auto &[outDimName, outIdx] : entry) {
+        int32_t outDimSize = layout.getOutDimSize(outDimName);
+        if (!llvm::isPowerOf2_32(outDimSize))
+          outIdx = smallModulo(b, outIdx, outDimSize);
+      }
+    }
   }
 
   return ret;

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3632,13 +3632,19 @@ struct TritonGPUVerifyTensorLayoutInterface
                          << rankedTy.getShape()
                          << " which is not a power of two.";
       }
-      return makeErr()
-             << "NPOT layout not yet supported: tensor shape "
-             << rankedTy.getShape()
-             << " has a non-power-of-2 dimension that is not supported by this "
-                "distributed layout's lowering in this build yet "
-                "(TRITON_ALLOW_NPOT only enables shapes handled by a landed "
-                "NPOT slice).";
+      // Layouts whose modular (non-power-of-2) lowering is implemented.
+      bool npotLoweringImplemented =
+          isa<BlockedEncodingAttr, SliceEncodingAttr, LinearEncodingAttr>(
+              layout);
+      if (!npotLoweringImplemented) {
+        return makeErr()
+               << "NPOT layout not yet supported: tensor shape "
+               << rankedTy.getShape()
+               << " has a non-power-of-2 dimension that is not supported by "
+                  "this distributed layout's lowering in this build yet "
+                  "(TRITON_ALLOW_NPOT only enables shapes handled by a landed "
+                  "NPOT slice).";
+      }
     }
     auto ll = toLinearLayout(rankedTy);
     ModuleOp module = op->getParentOfType<ModuleOp>();

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -1,5 +1,6 @@
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/GenericSwizzling.h"
+#include "llvm/Support/MathExtras.h"
 
 namespace mlir::triton {
 
@@ -52,12 +53,26 @@ ensureLayoutNotLargerThan(const LinearLayout &layout,
 
   for (auto outDim : llvm::enumerate(layout.getOutDimNames())) {
     auto outDimName = outDim.value();
+    // actualSize/desiredSize are the true (possibly NPOT) sizes; span/
+    // shrinkTarget are their pow2-rounded counterparts used for basis counting.
     int32_t actualSize = layout.getOutDimSize(outDimName);
     int32_t desiredSize = shape.lookup(outDimName);
     if (actualSize <= desiredSize) {
       continue;
     }
-    assert(actualSize % desiredSize == 0);
+    // NPOT desiredSize: shrink to the next pow2 and let the out-dim clamp below
+    // set the real size; modular reduction handles the overshoot at lowering.
+    // Zeroing the boundary basis instead would drop real elements. Pow2: no-op.
+    int32_t shrinkTarget =
+        llvm::isPowerOf2_32(desiredSize)
+            ? desiredSize
+            : static_cast<int32_t>(llvm::NextPowerOf2(desiredSize));
+    // Count the shrink against the pow2 basis span, not the NPOT out-dim size
+    // (else a basis terminates early). Identity for pow2 actualSize.
+    int32_t span = llvm::isPowerOf2_32(actualSize)
+                       ? actualSize
+                       : static_cast<int32_t>(llvm::NextPowerOf2(actualSize));
+    assert(span % shrinkTarget == 0);
     // <inDimName, basisIdx, outValue>
     std::vector<std::tuple<StringAttr, int, int>> sortedBases;
     for (auto [inDimName, basis] : bases) {
@@ -74,7 +89,7 @@ ensureLayoutNotLargerThan(const LinearLayout &layout,
     llvm::sort(sortedBases,
                [](auto a, auto b) { return std::get<2>(a) > std::get<2>(b); });
     for (auto [inDimName, basisIdx, outValue] : sortedBases) {
-      if (actualSize <= desiredSize) {
+      if (span <= shrinkTarget) {
         break;
       }
       if (!broadcastRegisters && inDimName == kRegister) {
@@ -82,7 +97,7 @@ ensureLayoutNotLargerThan(const LinearLayout &layout,
       } else {
         bases[inDimName][basisIdx][outDim.index()] = 0;
       }
-      actualSize >>= 1;
+      span >>= 1;
     }
   }
   if (!broadcastRegisters) {
@@ -127,8 +142,19 @@ LinearLayout ensureLayoutNotSmallerThan(
   for (StringAttr outDimName : layout.getOutDimNames()) {
     int32_t actualSize = layout.getOutDimSize(outDimName);
     int32_t desiredSize = shape.lookup(outDimName);
-    assert(actualSize > desiredSize || desiredSize % actualSize == 0);
-    ret *= LinearLayout::identity1D(desiredSize / actualSize, kDim, outDimName);
+    // actualSize is always pow2, so grow to the next pow2 >= an NPOT
+    // desiredSize (else desiredSize/actualSize floors, e.g. 192/128 == 1, and
+    // the register dim never grows, dropping real elements). A later
+    // ensureLayoutNotLargerThan clamps to the true NPOT size. Pow2: no-op.
+    assert(llvm::isPowerOf2_32(actualSize));
+    int32_t growTarget =
+        llvm::isPowerOf2_32(desiredSize)
+            ? desiredSize
+            : static_cast<int32_t>(llvm::NextPowerOf2(desiredSize));
+    if (actualSize >= growTarget)
+      continue;
+    assert(growTarget % actualSize == 0);
+    ret *= LinearLayout::identity1D(growTarget / actualSize, kDim, outDimName);
     assert(ret.getOutDimSize(outDimName) >= desiredSize);
   }
   return ret;

--- a/python/test/unit/language/test_npot.py
+++ b/python/test/unit/language/test_npot.py
@@ -1,0 +1,136 @@
+# NPOT (non-power-of-2) language tests.
+#
+# Gated on TRITON_ALLOW_NPOT=1, which lets a non-power-of-2 shape flow through
+# the compiler and build a modular LinearLayout. With the flag OFF the frontend
+# rejects NPOT shapes (arange must be pow2), so every test here skips.
+#
+# Coverage: elementwise lowering via the modular per-element index path
+# (applyLinearLayout ADD+UREM).
+#
+# The shared clampVecSizeForNpot inline is exercised here only via the CUDA
+# device/lit path (tritongpu_to_llvm_npot.mlir). The AMD getVectorSize
+# call-site wiring (third_party/amd/.../Utility.cpp) is not directly tested;
+# AMD numeric is a separate lane.
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton import knobs
+
+from triton._internal_testing import is_cuda
+
+
+def _allow_npot():
+    return bool(knobs.language.allow_npot)
+
+
+requires_npot = pytest.mark.skipif(
+    not _allow_npot(),
+    reason="requires TRITON_ALLOW_NPOT=1",
+)
+requires_gpu = pytest.mark.skipif(not is_cuda(), reason="requires CUDA GPU")
+
+
+def _rel_err(actual, ref, eps=1e-6):
+    a = actual.float()
+    r = ref.float()
+    denom = max(r.abs().max().item(), eps)
+    return (a - r).abs().max().item() / denom
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("size", [33, 48, 127, 768, 1023, 1536])
+def test_npot_arange(size):
+    """arange + store over an NPOT extent exercises the modular store index
+    (applyLinearLayout modular ADD+UREM path)."""
+
+    @triton.jit
+    def kernel(Out, N: tl.constexpr):
+        i = tl.arange(0, N)
+        tl.store(Out + i, i.to(tl.float32))
+
+    out = torch.empty(size, device="cuda", dtype=torch.float32)
+    kernel[(1, )](out, N=size)
+    ref = torch.arange(size, device="cuda", dtype=torch.float32)
+    assert _rel_err(out, ref) < 1e-5, f"size={size}"
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("size", [48, 96, 192, 1023])
+def test_npot_elementwise(size):
+
+    @triton.jit
+    def kernel(X, Y, Out, N: tl.constexpr):
+        i = tl.arange(0, N)
+        x = tl.load(X + i)
+        y = tl.load(Y + i)
+        tl.store(Out + i, x * y + x)
+
+    x = torch.randn(size, device="cuda")
+    y = torch.randn(size, device="cuda")
+    out = torch.empty(size, device="cuda")
+    kernel[(1, )](x, y, out, N=size)
+    assert _rel_err(out, x * y + x) < 1e-4, f"size={size}"
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("size", [48, 96, 192, 768])
+def test_npot_copy_one_warp(size):
+    """1D copy at num_warps=1, so sizePerThread = ceil(size / 32). size=96 gives
+    sizePerThread==3, where the vectorized load/store must not over-vectorize a
+    non-power-of-2 per-thread span (else misaligned access)."""
+
+    @triton.jit
+    def kernel(X, Out, N: tl.constexpr):
+        i = tl.arange(0, N)
+        tl.store(Out + i, tl.load(X + i))
+
+    x = torch.randn(size, device="cuda")
+    out = torch.empty(size, device="cuda")
+    kernel[(1, )](x, out, N=size, num_warps=1)
+    assert _rel_err(out, x) < 1e-6, f"size={size}"
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("M, N", [(16, 17), (16, 48), (8, 17)])
+def test_npot_copy_2d(M, N):
+    """2D copy with a non-power-of-2 inner extent exercises the blocked ->
+    LinearLayout construction for NPOT row/col tiles."""
+
+    @triton.jit
+    def kernel(X, Out, M: tl.constexpr, N: tl.constexpr):
+        idx = tl.arange(0, M)[:, None] * N + tl.arange(0, N)[None, :]
+        tl.store(Out + idx, tl.load(X + idx))
+
+    x = torch.randn(M, N, device="cuda")
+    out = torch.empty(M, N, device="cuda")
+    kernel[(1, )](x, out, M=M, N=N)
+    assert _rel_err(out, x) < 1e-6, f"M={M},N={N}"
+
+
+@requires_gpu
+@pytest.mark.parametrize("size", [64, 128, 256, 1024])
+def test_pow2_control_elementwise(size):
+    """Pow2 control: exercises the same elementwise lowering path as the NPOT
+    tests, but with a power-of-2 shape so the layout is never modular. This must
+    pass with the flag OFF (no @requires_npot), guarding that the NPOT changes
+    are a correctness no-op for pow2 shapes."""
+
+    @triton.jit
+    def kernel(X, Y, Out, N: tl.constexpr):
+        i = tl.arange(0, N)
+        x = tl.load(X + i)
+        y = tl.load(Y + i)
+        tl.store(Out + i, x * y + x)
+
+    x = torch.randn(size, device="cuda")
+    y = torch.randn(size, device="cuda")
+    out = torch.empty(size, device="cuda")
+    kernel[(1, )](x, y, out, N=size)
+    assert _rel_err(out, x * y + x) < 1e-4, f"size={size}"

--- a/test/Conversion/tritongpu_to_llvm_npot.mlir
+++ b/test/Conversion/tritongpu_to_llvm_npot.mlir
@@ -1,0 +1,82 @@
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file --allocate-shared-memory-nv=compute-capability=90 --convert-triton-gpu-to-llvm=compute-capability=90 | FileCheck %s
+//
+// NPOT (non-power-of-2) elementwise lowering. A non-power-of-2 out-dim builds a
+// modular LinearLayout, so the per-element index arithmetic uses ADD + a modulo
+// (Barrett multiply-shift, or the compare-subtract fast path when the value is
+// provably < 2N) instead of the pow2 GF(2) XOR. The AND-mask fast path replaces
+// the modulo entirely for dense identity bases (x mod 2^k == x & (2^k - 1)).
+// The pow2 companion module below asserts the modular ops never appear when the
+// shape is a power of two -> the NPOT path is byte-identical for pow2 / flag-off.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // N=48 is not a power of two and its worst-case index exceeds 2N, so the
+  // modulo lowers to Barrett reduction: q = (x * M) >> k; x - q*N, with the
+  // compile-time constants M = 5726623062 and k = 38 for N = 48.
+  // CHECK-LABEL: llvm.func @npot_barrett
+  // CHECK: %[[M:.*]] = llvm.mlir.constant(5726623062 : i64) : i64
+  // CHECK: llvm.mul %{{.*}}, %[[M]] : i64
+  // CHECK: %[[K:.*]] = llvm.mlir.constant(38 : i64) : i64
+  // CHECK: llvm.lshr %{{.*}}, %[[K]] : i64
+  // CHECK: llvm.trunc %{{.*}} : i64 to i32
+  // CHECK: %[[N:.*]] = llvm.mlir.constant(48 : i32) : i32
+  // CHECK: llvm.mul %{{.*}}, %[[N]] : i32
+  // CHECK: llvm.sub %{{.*}}, %{{.*}} : i32
+  tt.func public @npot_barrett(%arg0: !tt.ptr<f32>) {
+    %0 = tt.make_range {end = 48 : i32, start = 0 : i32} : tensor<48xi32, #blocked>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<48x!tt.ptr<f32>, #blocked>
+    %2 = tt.addptr %1, %0 : tensor<48x!tt.ptr<f32>, #blocked>, tensor<48xi32, #blocked>
+    %3 = arith.sitofp %0 : tensor<48xi32, #blocked> to tensor<48xf32, #blocked>
+    tt.store %2, %3 : tensor<48x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // N=1023 has dense identity register/lane/warp bases, so combining them hits
+  // the AND-mask fast path: (x mod 2^7) == x & 127 (highBit = 7, ceil(log2 1023)
+  // = 10 but the combined lane+warp span here is 128). The per-register ADD then
+  // overshoots at most into [N, 2N), so the final modulo is the cheap
+  // compare-subtract path (icmp uge N + select), not Barrett (no i64 multiply).
+  // CHECK-LABEL: llvm.func @npot_andmask
+  // CHECK: %[[MASK:.*]] = llvm.mlir.constant(127 : i32) : i32
+  // CHECK: llvm.and %{{.*}}, %[[MASK]] : i32
+  // CHECK: llvm.add %{{.*}}, %{{.*}} : i32
+  // CHECK: %[[N:.*]] = llvm.mlir.constant(1023 : i32) : i32
+  // CHECK: llvm.icmp "uge" %{{.*}}, %[[N]] : i32
+  // CHECK: llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
+  // Barrett must not appear for this size (no 64-bit multiply-shift modulo).
+  // CHECK-NOT: llvm.mul %{{.*}}, %{{.*}} : i64
+  tt.func public @npot_andmask(%arg0: !tt.ptr<f32>) {
+    %0 = tt.make_range {end = 1023 : i32, start = 0 : i32} : tensor<1023xi32, #blocked>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1023x!tt.ptr<f32>, #blocked>
+    %2 = tt.addptr %1, %0 : tensor<1023x!tt.ptr<f32>, #blocked>, tensor<1023xi32, #blocked>
+    %3 = arith.sitofp %0 : tensor<1023xi32, #blocked> to tensor<1023xf32, #blocked>
+    tt.store %2, %3 : tensor<1023x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // Pow2 companion (N=256): the shape is a power of two so the layout is never
+  // modular. The index arithmetic stays on the original GF(2) XOR path -- none
+  // of the modular ops (Barrett i64 multiply-shift, or the compare-subtract
+  // modulo) appear. This is the byte-identity guard: pow2 lowering is unchanged.
+  // CHECK-LABEL: llvm.func @pow2_no_modulo
+  // CHECK-NOT: llvm.mul %{{.*}}, %{{.*}} : i64
+  // CHECK-NOT: llvm.icmp "uge"
+  tt.func public @pow2_no_modulo(%arg0: !tt.ptr<f32>) {
+    %0 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>, #blocked>
+    %2 = tt.addptr %1, %0 : tensor<256x!tt.ptr<f32>, #blocked>, tensor<256xi32, #blocked>
+    %3 = arith.sitofp %0 : tensor<256xi32, #blocked> to tensor<256xf32, #blocked>
+    tt.store %2, %3 : tensor<256x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -627,14 +627,19 @@ unsigned getVectorSize(Value ptr, ModuleAxisInfoAnalysis &axisAnalysisPass) {
     return 1;
   auto contiguity = getContiguity(ptr, axisAnalysisPass);
   auto pointeeBitWidth = triton::getPointeeBitWidth(tensorTy);
-  return std::min<unsigned>(128 / pointeeBitWidth, contiguity);
+  unsigned vec = std::min<unsigned>(128 / pointeeBitWidth, contiguity);
+  // No-op for pow2; clamps the NPOT sizePerThread misalign (see NVIDIA).
+  return clampVecSizeForNpot(vec, tensorTy);
 }
 
 unsigned getVectorSize(Value ptr, Value offset,
                        ModuleAxisInfoAnalysis &axisAnalysisPass) {
   auto contiguity = getContiguity(ptr, offset, axisAnalysisPass);
   auto pointeeBitWidth = triton::getPointeeBitWidth(ptr.getType());
-  return std::min<unsigned>(128 / pointeeBitWidth, contiguity);
+  unsigned vec = std::min<unsigned>(128 / pointeeBitWidth, contiguity);
+  auto tensorTy =
+      dyn_cast<RankedTensorType>(getPointerTypeWithShape(ptr, offset));
+  return clampVecSizeForNpot(vec, tensorTy);
 }
 
 Type scaleDotElemTypeToMLIRType(MLIRContext *ctx, triton::ScaleDotElemType t) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -162,7 +162,8 @@ struct LoadStoreConversionBase {
     LDBG("getVectorSize contiguity = " << contiguity << " pointeeBitWidth = "
                                        << pointeeBitWidth);
     // The maximum vector size is 128 bits on NVIDIA GPUs.
-    return std::min<unsigned>(128 / pointeeBitWidth, contiguity);
+    unsigned vec = std::min<unsigned>(128 / pointeeBitWidth, contiguity);
+    return clampVecSizeForNpot(vec, tensorTy);
   }
 
   unsigned getMaskAlignment(Value mask) const {


### PR DESCRIPTION
Summary:

Implement NPOT (non-power-of-2) elementwise + arange/store indexing by routing
the modular LinearLayout through the real per-element lowering, lifting the F1
sentinel reject for the distributed (Blocked/Slice/Linear) encodings that the
generic per-element path produces. MMA/dot-operand encodings still hit F1's
explicit reject (handled by the tensor-core slices).

Flag-gated via TRITON_ALLOW_NPOT: a modular layout can only be constructed
under the flag, and every new branch is isModular()/isOutDimModular()-guarded,
so flag-OFF and all pow2 layouts produce byte-identical lowering
(all_cpp_tests 260/0, OFF-vs-ON pow2 TTGIR diff = 0).

Authored with Claude.

Review order:
1. lib/Tools/LayoutUtils.cpp - NPOT-aware ensureLayoutNotSmallerThan/
   NotLargerThan: round the span to NextPowerOf2 for an NPOT desiredSize and
   clamp the out-dim to the real size, so the modular distributed layout
   actually covers every element instead of broadcasting (silently dropping)
   the tail. pow2 path unchanged.
2. lib/Conversion/TritonGPUToLLVM/Utility.cpp - matrixVectorProd modular
   ADD-accumulate branch + smallModulo/barrettModulo/combineModularOrXor/
   applyNpotModulo helpers; wire ADD+UREM into applyLinearLayout(Vec).
3. lib/Dialect/TritonGPU/IR/Dialect.cpp - relax the F1 tensor-layout verifier
   for Blocked/Slice/Linear encodings.
4. include/.../Utility.h (clampVecSizeForNpot) +
   include/.../ElementwiseOpToLLVMBase.h (NPOT constancy clamp).

Rollback: gated behind TRITON_ALLOW_NPOT (env, default OFF) and env-gated tests;
unset the flag or revert the diff to disable. pow2 paths are byte-identical (flag
OFF), so rollback is low-risk.

Reviewed By: dshi7, stashuk-olek

Differential Revision: D110072971


