### PR TITLE
[AutoWS][FA] Fix non-deterministic SIGSEGV in insertAsyncComm channel-loop detection (#1895)

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -3137,8 +3137,14 @@ void insertAsyncComm(
       for (auto *ch : orderedChannels) {
         if (ch == chF)
           continue;
-        if (withSameTask(ch->getDstOp(), chF->getSrcOp()) &&
-            ch->getAllocOp() == chF->getAllocOp() &&
+        // Compare the cached allocOp pointers first: getSrcOp()/getDstOp() on a
+        // TMEMPost channel walk the allocOp's use-list (findTmemStartEnd), so
+        // calling them on a channel whose alloc was already erased dereferences
+        // freed memory (non-deterministic SIGSEGV). A stale channel's allocOp
+        // pointer never equals the live chF's, so this cheap pointer check
+        // short-circuits before any op is dereferenced.
+        if (ch->getAllocOp() == chF->getAllocOp() &&
+            withSameTask(ch->getDstOp(), chF->getSrcOp()) &&
             ch->getSrcOp() == chF->getDstOp() &&
             chF->getSrcOp()->getBlock() == ch->getSrcOp()->getBlock() &&
             chF->getSrcOp()->getBlock() == ch->getDstOp()->getBlock()) {
@@ -3162,8 +3168,11 @@ void insertAsyncComm(
       for (auto *ch : orderedChannels) {
         if (ch == chB)
           continue;
-        if (withSameTask(ch->getSrcOp(), chB->getDstOp()) &&
-            ch->getAllocOp() == chB->getAllocOp() &&
+        // See isForwardOfChannelLoop: compare cached allocOp pointers before
+        // getSrcOp()/getDstOp() so a stale channel (alloc already erased) is
+        // filtered out before findTmemStartEnd dereferences freed memory.
+        if (ch->getAllocOp() == chB->getAllocOp() &&
+            withSameTask(ch->getSrcOp(), chB->getDstOp()) &&
             ch->getDstOp() == chB->getSrcOp() &&
             chB->getSrcOp()->getBlock() == ch->getSrcOp()->getBlock() &&
             chB->getSrcOp()->getBlock() == ch->getDstOp()->getBlock()) {


### PR DESCRIPTION
Summary:

isForwardOfChannelLoop / isBackwardOfChannelLoop iterate all orderedChannels and
evaluate withSameTask(ch->getSrcOp()/getDstOp(), ...) before the cheap pointer
check ch->getAllocOp() == chX->getAllocOp(). For a TMEMPost operand-D channel,
getSrcOp()/getDstOp() call findTmemStartEnd, which walks
ch->allocOp->getResult(0).getUsers(). When that channel's TMEMAllocOp was already
erased by the reuse-group buffer collapse earlier in doCodePartitionPost, allocOp
dangles: the use-list walk reads freed memory, returns a garbage Operation*, and
getAsyncTaskIds dereferences it -> SIGSEGV. The crash is caught by MLIR's
CrashRecoveryContext and surfaces only as the generic "Failures have been
detected" pipeline error; whether the freed slot faults depends on heap/ASLR
state, making it a per-compile flaky failure that never reproduced from the
captured reproducer. Latent since d250c37258; triggered now that the reuse-group
collapse fires for the forward-persistent FA (sm100) operand-D path.

Reorder the && so the safe cached-pointer comparison short-circuits first: a
stale channel's allocOp never equals the live masterChannel's, so
getSrcOp()/getDstOp() only run once the alloc is known to match and be live.

Authored with Claude (Claude Code).

Reviewed By: njriasan

Differential Revision: D110479297


