### PR TITLE
[triton][beta] [Cherry-pick][RESOLVED] 'Clean up dead operations immediately after backward remat (#9511)'

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -128,16 +128,33 @@ public:
     return rematMapping.lookup({value, encoding});
   }
 
-  void cleanup();
   bool backwardRematerialization();
-  void backwardRematerialization(ConvertLayoutOp convertOp);
+
+  /// Rematerialize the backward slice leading up to \p convertOp to produce the
+  /// result layout directly if it is possible and profitable to do so.
+  /// \return true if \p convertOp was eliminated, false otherwise.
+  bool backwardRematerialization(ConvertLayoutOp convertOp);
+
   // TODO: Merge the three hoistConvert*(); functions as they are duplicate code
   void hoistConvertDotOperand();
-  void hoistConvertDotOperand(ConvertLayoutOp convertOp);
   void hoistConvertOnTopOfExtOrBroadcast();
-  void hoistConvertOnTopOfExtOrBroadcast(ConvertLayoutOp convertOp);
   void hoistConvertIntoConditionals();
-  void hoistConvertIntoConditionals(ConvertLayoutOp convertOp);
+
+  /// Attempt to hoist \p convertOp above operations that make the tensor larger
+  /// and costlier to convert (e.g. ExtFOp and BroadcastOp). If this is
+  /// possible, rematerialize the slice between the convert and that operation
+  /// and hoist the convert above it.
+  /// \return true if \p convertOp was hoisted, false otherwise.
+  bool hoistConvertOnTopOfExtOrBroadcast(ConvertLayoutOp convertOp);
+
+  /// Attempt to hoist \p convertOp into conditionals so the conversion is only
+  /// conditionally executed. If this is possible, rematerialize the slice
+  /// between the convert and the conditional and move the convert inside.
+  /// \return true if \p convertOp was hoisted, false otherwise.
+  bool hoistConvertIntoConditionals(ConvertLayoutOp convertOp);
+
+  bool hoistConvertDotOperand(ConvertLayoutOp convertOp);
+
   void rewriteSlice(
       SetVector<Value> &slice, DenseMap<Value, Attribute> &layout,
       const DenseMap<std::pair<Value, Attribute>, Value> &existingRemats,
@@ -172,8 +189,6 @@ private:
   DenseMap<Value, Attribute> mappedValues;
   // map of the values remat based on encoding.
   DenseMap<std::pair<Value, Attribute>, Value> rematMapping;
-  // DenseMap<std::pair<Operation*, Attribute>, Operation*>
-  SetVector<Operation *> opToDelete;
   FuncOp funcOp;
   // Meta extension: when > 0, the remove-layout pass is operating under a SMEM
   // budget and convert-elimination hoists bypass the upstream perf cost gate.
@@ -187,12 +202,6 @@ void LayoutRematerialization::addRematValue(Value old, Attribute encoding,
   LDBG("addRematValue " << old << " encoding " << encoding << " " << newV);
   rematMapping[{old, encoding}] = newV;
   mappedValues[old] = encoding;
-}
-
-// Remove unneeded values now that we are done with the rematMapping.
-void LayoutRematerialization::cleanup() {
-  for (Operation *op : llvm::reverse(opToDelete))
-    op->erase();
 }
 
 // Facebook begin
@@ -1071,15 +1080,15 @@ void LayoutRematerialization::rewriteSlice(
   }
   // Check mapping and see if there are existing convertOps on the old Argument
   convertOp.replaceAllUsesWith(mapping.lookup(convertOp.getSrc()));
-  opToDelete.insert(convertOp);
 
   updateRematMapping(replacements);
   for (auto &kv : replacements) {
     builder.replaceAllUsesWith(std::get<0>(kv), std::get<1>(kv));
   }
 
+  convertOp->erase();
   for (Operation *op : deadOps)
-    opToDelete.insert(op);
+    op->erase();
 }
 
 void LayoutRematerialization::rewriteSlice(
@@ -1164,8 +1173,7 @@ bool LayoutRematerialization::backwardRematerialization() {
   funcOp.walk(
       [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
   for (ConvertLayoutOp convertOp : convertOps) {
-    backwardRematerialization(convertOp);
-    if (!opToDelete.contains(convertOp)) {
+    if (!backwardRematerialization(convertOp)) {
       // If the conversion didn't get removed, consider it for reuse in future
       // backward slices.
       addRematValue(convertOp.getSrc(), convertOp.getType().getEncoding(),
@@ -1183,8 +1191,7 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast() {
   funcOp.walk(
       [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
   for (ConvertLayoutOp convertOp : convertOps) {
-    hoistConvertOnTopOfExtOrBroadcast(convertOp);
-    if (!opToDelete.contains(convertOp)) {
+    if (!hoistConvertOnTopOfExtOrBroadcast(convertOp)) {
       // If the conversion didn't get removed, consider it for reuse in future
       // backward slices.
       addRematValue(convertOp.getSrc(), convertOp.getType().getEncoding(),
@@ -1199,8 +1206,7 @@ void LayoutRematerialization::hoistConvertIntoConditionals() {
   funcOp.walk(
       [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
   for (ConvertLayoutOp convertOp : convertOps) {
-    hoistConvertIntoConditionals(convertOp);
-    if (!opToDelete.contains(convertOp)) {
+    if (!hoistConvertIntoConditionals(convertOp)) {
       // If the conversion didn't get removed, consider it for reuse in future
       // backward slices.
       addRematValue(convertOp.getSrc(), convertOp.getType().getEncoding(),
@@ -1355,14 +1361,14 @@ bool isRematBeneficial(ConvertLayoutOp convertOp, const SetVector<Value> &slice,
   return convertLayoutCost >= rematerialisationCost;
 }
 
-void LayoutRematerialization::backwardRematerialization(
+bool LayoutRematerialization::backwardRematerialization(
     ConvertLayoutOp convertOp) {
   RankedTensorType targetType = convertOp.getType();
   if (isa<DotOperandEncodingAttr>(targetType.getEncoding())) {
     // DotOperand is hoisted by hoistDotOperand for pipelining purposes.
     if (auto parentForOp = convertOp->getParentOfType<scf::ForOp>()) {
       if (getNumStagesOrDefault(parentForOp, 3) > 1) {
-        return;
+        return false;
       }
     }
   }
@@ -1375,9 +1381,9 @@ void LayoutRematerialization::backwardRematerialization(
   if (newV && domInfo.properlyDominates(newV, convertOp)) {
     // Replace it with the remat'ed value.
     convertOp.replaceAllUsesWith(newV);
-    opToDelete.insert(convertOp);
+    convertOp->erase();
     LDBG("found remat'ed value" << newV);
-    return;
+    return true;
   }
 
   // 1. Take a backward slice of all the tensor dependencies that can be
@@ -1390,13 +1396,13 @@ void LayoutRematerialization::backwardRematerialization(
       existingRemats);
   if (result.failed()) {
     LDBG("  getRematerializableSlice failed");
-    return;
+    return false;
   }
 
   // 2. Determine whether rematerialisation is beneficial.
   if (!isRematBeneficial(convertOp, slice, /*newCvtCost=*/0)) {
     LDBG("  skipped rematerialization due to higher cost");
-    return;
+    return false;
   }
 
   LLVM_DEBUG({
@@ -1407,6 +1413,7 @@ void LayoutRematerialization::backwardRematerialization(
 
   // 3. Rewrite the slice.
   rewriteSlice(slice, layout, existingRemats, convertOp);
+  return true;
 }
 
 void LayoutRematerialization::hoistConvertDotOperand() {
@@ -1415,8 +1422,7 @@ void LayoutRematerialization::hoistConvertDotOperand() {
   funcOp.walk(
       [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
   for (ConvertLayoutOp convertOp : convertOps) {
-    hoistConvertDotOperand(convertOp);
-    if (!opToDelete.contains(convertOp)) {
+    if (!hoistConvertDotOperand(convertOp)) {
       // If the conversion didn't get removed, consider it for reuse in future
       // backward slices.
       addRematValue(convertOp.getSrc(), convertOp.getType().getEncoding(),
@@ -1425,7 +1431,7 @@ void LayoutRematerialization::hoistConvertDotOperand() {
   }
 }
 
-void LayoutRematerialization::hoistConvertDotOperand(
+bool LayoutRematerialization::hoistConvertDotOperand(
     ConvertLayoutOp convertOp) {
   auto targetType = convertOp.getType();
   // The pass is targeted to MMA dot operands
@@ -1462,7 +1468,7 @@ void LayoutRematerialization::hoistConvertDotOperand(
   // We move convert #dot_operand next to their loads. This is done
   // so that it's then easy to pipeline these loads
   if (!canBePipelined(convertOp))
-    return;
+    return false;
 
   // We hoist over any operation that can be done without data movement between
   // threads We do views and elementwise pure ops for now
@@ -1484,7 +1490,7 @@ void LayoutRematerialization::hoistConvertDotOperand(
       convertOp.getSrcMutable(), targetType.getEncoding(), slice, layout,
       existingRemats, stop);
   if (result.failed())
-    return;
+    return false;
 
   IRMapping mapping;
   OpBuilder builder(convertOp.getContext());
@@ -1493,7 +1499,7 @@ void LayoutRematerialization::hoistConvertDotOperand(
     if (!v.getDefiningOp()) {
       LLVM_DEBUG(
           { DBGS() << "  Block arguments not supported. Got " << v << "\n"; });
-      return;
+      return false;
     }
 
     // We expect the leaves of the slice to be Load, DescriptorLoad or
@@ -1508,7 +1514,7 @@ void LayoutRematerialization::hoistConvertDotOperand(
           DBGS() << "  Leaves must be Load, DescriptorLoad or Constant. Got "
                  << v << "\n";
         });
-        return;
+        return false;
       }
     }
     Operation *loadOp = v.getDefiningOp();
@@ -1523,7 +1529,7 @@ void LayoutRematerialization::hoistConvertDotOperand(
   }
 
   if (innerSlice.empty()) {
-    return;
+    return false;
   }
 
   LLVM_DEBUG({
@@ -1533,16 +1539,17 @@ void LayoutRematerialization::hoistConvertDotOperand(
   });
 
   rewriteSlice(innerSlice, layout, existingRemats, convertOp, mapping);
+  return true;
 }
 
 // For convert left we try to hoist them above type extension to reduce the cost
 // of the convert.
-void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
+bool LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
     ConvertLayoutOp convertOp) {
   // DotOperand is hoisted by hoistDotOperand
   RankedTensorType targetType = convertOp.getType();
   if (isa<DotOperandEncodingAttr>(targetType.getEncoding()))
-    return;
+    return false;
 
   auto isExtOrBroadcastOp = [](Operation *op) {
     if (isa<arith::ExtSIOp, arith::ExtUIOp, arith::ExtFOp, BroadcastOp,
@@ -1564,7 +1571,7 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
       convertOp.getSrcMutable(), targetType.getEncoding(), slice, layout,
       existingRemats, isExtOrBroadcastOp);
   if (result.failed())
-    return;
+    return false;
 
   Operation *extOrBroadcastOp = nullptr;
   unsigned sliceSize = slice.size();
@@ -1576,7 +1583,7 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
 
     Attribute srcEncoding = inferSrcEncoding(op, layout[v]);
     if (!srcEncoding)
-      return;
+      return false;
 
     // If we can rematerialize the rest of the ext slice we can ignore this ext
     // as it won't need a convert.
@@ -1587,23 +1594,23 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
     // Only apply it if there is a single ext op otherwise we would have to
     // duplicate the convert.
     if (extOrBroadcastOp != nullptr)
-      return;
+      return false;
     extOrBroadcastOp = op;
   }
 
   if (extOrBroadcastOp == nullptr)
-    return;
+    return false;
   Attribute dstEncoding = layout[extOrBroadcastOp->getResult(0)];
   Attribute srcEncoding = inferSrcEncoding(extOrBroadcastOp, dstEncoding);
   if (!srcEncoding)
-    return;
+    return false;
   // Under a SMEM budget (a Meta extension) eliminating convert-layout scratch
   // takes priority over the upstream perf-cost heuristic (#9194), so force the
   // hoist. Without a budget, keep the upstream cost gate.
   if (smemBudget == 0) {
     int64_t newCvtCost = getConvertCost(extOrBroadcastOp->getOperand(0));
     if (!isRematBeneficial(convertOp, slice, newCvtCost))
-      return;
+      return false;
   }
   // Move the convert before the ext op and rewrite the slice.
   OpBuilder builder(extOrBroadcastOp);
@@ -1624,9 +1631,10 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
   slice.remove(extOrBroadcastOp->getResult(0));
   // 3. Rewrite the slice.
   rewriteSlice(slice, layout, existingRemats, convertOp, mapping);
+  return true;
 }
 
-void LayoutRematerialization::hoistConvertIntoConditionals(
+bool LayoutRematerialization::hoistConvertIntoConditionals(
     ConvertLayoutOp convertOp) {
   // Take the backward slice of tensor dependencies rooted at the conversion,
   // stopping at conditionals. This subslice is used to initialize the analysis.
@@ -1637,7 +1645,7 @@ void LayoutRematerialization::hoistConvertIntoConditionals(
   if (failed(getRematerializableSlice(convertOp.getSrcMutable(),
                                       convertOp.getType().getEncoding(), slice,
                                       layout, existingRemats, isIfOp)))
-    return;
+    return false;
 
   // These are the conditional edges above which conversions should be hoisted.
   // The value represents the `scf.if` op result and the operand represents the
@@ -1716,7 +1724,7 @@ void LayoutRematerialization::hoistConvertIntoConditionals(
 
   // Exit early if there is nothing to do.
   if (hoistAbove.empty())
-    return;
+    return false;
 
   // Rematerialize failed hoists right before the condtional, and hoist those
   // that succeeded into the branch and then rewrite the slice.
@@ -1739,6 +1747,7 @@ void LayoutRematerialization::hoistConvertIntoConditionals(
     hoistRemat(b, edge->get(), layout.at(result));
   }
   rewriteSlice(slice, layout, existingRemats, convertOp, mapping);
+  return true;
 }
 
 bool backwardRematerialization(ModuleOp module) {
@@ -1746,7 +1755,6 @@ bool backwardRematerialization(ModuleOp module) {
   module.walk([&](FuncOp funcOp) {
     LayoutRematerialization layoutRemat(funcOp);
     changed |= layoutRemat.backwardRematerialization();
-    layoutRemat.cleanup();
   });
   return changed;
 }
@@ -1756,15 +1764,12 @@ void hoistConvert(ModuleOp module, unsigned smemBudget = 0) {
   module.walk([smemBudget](FuncOp funcOp) {
     LayoutRematerialization layoutRemat(funcOp, smemBudget);
     layoutRemat.hoistConvertOnTopOfExtOrBroadcast();
-    layoutRemat.cleanup();
 
     layoutRemat = LayoutRematerialization(funcOp);
     layoutRemat.hoistConvertIntoConditionals();
-    layoutRemat.cleanup();
 
     layoutRemat = LayoutRematerialization(funcOp);
     layoutRemat.hoistConvertDotOperand();
-    layoutRemat.cleanup();
   });
 }
 


### PR DESCRIPTION
Summary:
This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/9511

Upstream commit message:
```
> Clean up dead operations immediately after backward remat (#9511)

> We currently keep around ops that have become dead during
> rematerialization in `opToDelete` until after all converts have been
> visited. However, this does not seem to be necessary, since these
> operations no longer have users, and any entries for them in
> `mappedValues` and `rematMapping` should get cleaned up by the calls to
> `updateRematMapping`.

> Apart from being simpler, cleaning them up early also makes it safer to
> manipulate the IR, since the dead ops are often ill-formed (e.g. `ForOp`
> without a region).
```

Conflict Resolution:
#9511 deletes the deferred-deletion machinery (`opToDelete` + `cleanup()`) and erases dead ops immediately, switching the per-convert workers from `void` to `bool`. That collided with beta fork features absent from the upstream base. Four conflicts in `RemoveLayoutConversions.cpp`, all resolved to adopt #9511's refactor while preserving beta behavior:

- `cleanup()` / `opToDelete`: deleted (took upstream). No beta caller remained once the backward-remat and hoist paths stopped deferring deletion.
- `backwardRematerialization(ConvertLayoutOp)`: kept beta's conditional DotOperand guard (skip backward remat for a DotOperand convert only when it sits inside a multi-stage `scf.for`, so pipelining via `hoistConvertDotOperand` is preserved) instead of upstream's unconditional skip; applied #9511's `void`->`bool` + immediate `erase()`.
- `hoistConvertOnTopOfExtOrBroadcast(ConvertLayoutOp)`: kept beta's `smemBudget`-gated cost bypass (budget-aware convert elimination forces the hoist past the upstream #9194 cost heuristic); applied the `void`->`bool` change, returning `false` from the budget-gated path.
- `hoistConvert(ModuleOp, smemBudget)`: kept beta's `smemBudget` threading; dropped the now-dead `cleanup()` calls.

Verified: no conflict markers, no residual `opToDelete`/`cleanup()` references, and `fbsource//third-party/triton/beta/triton:TritonGPUTransforms` builds clean.

This PR was authored with Claude.

***Do not remove the following line from this commit***
Reactor Backport Revision: df14b75338e6f9b697856bbb2fb72e2a5095a27c
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 9511 -v beta --no-submit --skip-lint
```

Reviewed By: dshi7

Differential Revision: D110259246


