### PR TITLE
[TritonGPU] NPOT SMEM/MMA allocation, swizzling, and conversion foundation (#1900)

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -7,6 +7,7 @@
 
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/Support/MathExtras.h"
 #include <algorithm>
 #include <numeric>
 
@@ -51,6 +52,45 @@ unsigned
 getNumElementsPerThread(Operation *op, SmallVector<unsigned> order,
                         triton::ModuleAxisInfoAnalysis &axisInfoAnalysis,
                         ArrayRef<int64_t> shape, unsigned maxVecBits = 128);
+
+inline bool hasNpotShape(RankedTensorType ty) {
+  return llvm::any_of(ty.getShape(), [](int64_t d) {
+    return d > 0 && !llvm::isPowerOf2_64(d);
+  });
+}
+
+// Whether this encoding supports modular LinearLayouts.
+inline bool npotSafeForLinearLayout(Attribute encoding) {
+  if (!encoding) {
+    return false;
+  }
+  if (isa<triton::gpu::BlockedEncodingAttr, triton::gpu::LinearEncodingAttr>(
+          encoding)) {
+    return true;
+  }
+  if (auto mma = dyn_cast<triton::gpu::NvidiaMmaEncodingAttr>(encoding)) {
+    return mma.getVersionMajor() >= 2;
+  }
+  if (auto dotOp = dyn_cast<triton::gpu::DotOperandEncodingAttr>(encoding)) {
+    return npotSafeForLinearLayout(dotOp.getParent());
+  }
+  if (auto slice = dyn_cast<triton::gpu::SliceEncodingAttr>(encoding)) {
+    return npotSafeForLinearLayout(slice.getParent());
+  }
+  if (isa<triton::gpu::SharedEncodingTrait>(encoding)) {
+    return true;
+  }
+  return false;
+}
+
+// Whether both layouts support modular conversion.
+inline bool npotCvtSafe(RankedTensorType srcTy, RankedTensorType dstTy) {
+  if (!hasNpotShape(srcTy) && !hasNpotShape(dstTy)) {
+    return true;
+  }
+  return npotSafeForLinearLayout(srcTy.getEncoding()) &&
+         npotSafeForLinearLayout(dstTy.getEncoding());
+}
 
 // Returns whether the op is a "view op", i.e. doesn't move any data
 bool isView(Operation *op);

--- a/include/triton/Tools/GenericSwizzling.h
+++ b/include/triton/Tools/GenericSwizzling.h
@@ -20,6 +20,7 @@ namespace mlir::triton::gpu {
 // ldmatrix.v4 / stmatrix.v4
 // ldmatrix.trans.v4 / stmatrix.trans.v4
 struct LocalMemOpTile {
+  // Input-lane basis indices; output projection preserves their positions.
   // If laneContig.size() < log2(128/bitwidth), we assume that
   // the first log2(128/bitwidth) - laneContig.size() bases are registers
   llvm::SmallVector<int32_t> laneContig;

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -57,7 +57,10 @@ unsigned getNumScratchElemsSwizzledCvt(const LinearLayout &srcLayout,
   // We remove the number of elements that are duplicated in the cta layout
   auto nBlocks = product(triton::gpu::getCTASplitNum(
       gpu::LinearEncodingAttr::get(ctx, srcLayout)));
-  return smem.getTotalOutDimSize() / (reps * nBlocks);
+  // Modular layouts size the padded input cover; pow2 keeps output sizing.
+  auto elems =
+      smem.isModular() ? smem.getTotalInDimSize() : smem.getTotalOutDimSize();
+  return elems / (reps * nBlocks);
 }
 
 unsigned getNumScratchElemsSwizzledCvt(RankedTensorType srcTy,

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -13,6 +13,7 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/Sys/GetEnv.h"
@@ -928,6 +929,33 @@ unsigned getNumScratchElements(ArrayRef<unsigned> shape) {
   return product<unsigned>(shape);
 }
 
+// NPOT K must align to the 32-byte MMA K granule.
+static bool isNpotMmaKAligned(int64_t k, Type elementType) {
+  if (llvm::isPowerOf2_64(k))
+    return true;
+  int64_t bitwidth = elementType.getIntOrFloatBitWidth();
+  return (k * bitwidth) % 256 == 0;
+}
+
+static bool isMmaOutputShapeSupported(ArrayRef<int64_t> shape, int version) {
+  assert(shape.size() >= 2 && "MMA output must have M and N dimensions");
+  int64_t m = shape[shape.size() - 2];
+  int64_t n = shape[shape.size() - 1];
+
+  if (version == 2) {
+    return llvm::none_of(shape, [](int64_t dim) {
+      return dim > 0 && !llvm::isPowerOf2_64(dim);
+    });
+  }
+  if (version == 3) {
+    int64_t mAlignment = llvm::isPowerOf2_64(m) ? 64 : 16;
+    return m % mAlignment == 0 && n % 8 == 0;
+  }
+  assert(version == 5 && "unexpected MMA version with output constraints");
+  bool mOk = llvm::isPowerOf2_64(m) ? m % 64 == 0 : m <= 128 && m % 16 == 0;
+  return mOk && llvm::isPowerOf2_64(n) && n % 8 == 0;
+}
+
 bool supportMMA(triton::DotOp op, int version) {
   // Refer to mma section for the data type supported by Volta and Hopper
   // Tensor Core in
@@ -944,7 +972,6 @@ bool supportMMA(triton::DotOp op, int version) {
     int k = typeA.getShape().back();
     auto retType = op.getType();
     auto retShapePerCTA = getShapePerCTA(retType);
-    auto rank = retShapePerCTA.size();
     int numWarps = lookupNumWarps(op);
     // Allow int8 * int8 -> int32 for MMAv5, reject other integer combinations
     if (aElemTy.isInteger() || bElemTy.isInteger() ||
@@ -962,8 +989,7 @@ bool supportMMA(triton::DotOp op, int version) {
     // If k size is smaller than the native mma size, we cannot use MMA.
     if (k < 256 / aElemTy.getIntOrFloatBitWidth())
       return false;
-    if (!(retShapePerCTA[rank - 2] % 64 == 0 &&
-          retShapePerCTA[rank - 1] % 8 == 0))
+    if (!isMmaOutputShapeSupported(retShapePerCTA, version))
       return false;
     if (aElemTy.isF64() || bElemTy.isF64() ||
         retType.getElementType().isF64()) {
@@ -981,14 +1007,16 @@ bool supportMMA(triton::DotOp op, int version) {
     // If k size is smaller than the native mma size, we cannot use MMA.
     if (k < 256 / aElemTy.getIntOrFloatBitWidth())
       return false;
+    if (!isNpotMmaKAligned(k, aElemTy))
+      return false;
     auto retShapePerCTA = getShapePerCTA(retType);
     auto rank = retShapePerCTA.size();
     int numWarps = lookupNumWarps(op);
     // TODO(Keren): for now, fallback to MMAv2 if handling batch matmul.
     if (rank == 3)
       return false;
-    if (!(numWarps % 4 == 0 && retShapePerCTA[rank - 2] % 64 == 0 &&
-          retShapePerCTA[rank - 1] % 8 == 0 &&
+    if (!(numWarps % 4 == 0 &&
+          isMmaOutputShapeSupported(retShapePerCTA, version) &&
           (llvm::isa<Float8E5M2Type, Float8E4M3FNType>(aElemTy) ||
            aElemTy.isInteger(8) || aElemTy.isF16() || aElemTy.isBF16() ||
            aElemTy.isF32()))) {
@@ -1000,6 +1028,12 @@ bool supportMMA(triton::DotOp op, int version) {
         cast<RankedTensorType>(op.getType()).getElementType().isF32()) {
       return false;
     }
+  }
+  if (version == 2) {
+    int64_t k = op.getA().getType().getShape().back();
+    if (!isNpotMmaKAligned(k, aElemTy) ||
+        !isMmaOutputShapeSupported(getShapePerCTA(op.getType()), version))
+      return false;
   }
   if (aElemTy.isF32() && bElemTy.isF32()) {
     assert(op.getInputPrecision() == InputPrecision::TF32);
@@ -1060,7 +1094,27 @@ LinearLayout minimalCvtLayout(Type srcTy_, Type dstTy_) {
   return comp;
 }
 
+static bool npotMmaConversion(RankedTensorType srcTy, RankedTensorType dstTy) {
+  if (!hasNpotShape(srcTy) && !hasNpotShape(dstTy)) {
+    return false;
+  }
+  auto hasMmaFamily = [](Attribute enc) {
+    if (isa<triton::gpu::NvidiaMmaEncodingAttr>(enc)) {
+      return true;
+    }
+    if (auto dot = dyn_cast<triton::gpu::DotOperandEncodingAttr>(enc)) {
+      return isa<triton::gpu::NvidiaMmaEncodingAttr>(dot.getParent());
+    }
+    return false;
+  };
+  return hasMmaFamily(srcTy.getEncoding()) || hasMmaFamily(dstTy.getEncoding());
+}
+
 bool cvtReordersRegisters(RankedTensorType srcTy, RankedTensorType dstTy) {
+  // Modular MMA conversions can alias bases; use shared memory.
+  if (npotMmaConversion(srcTy, dstTy)) {
+    return false;
+  }
   auto layout = minimalCvtLayout(srcTy, dstTy);
   MLIRContext *ctx = srcTy.getContext();
   auto kRegister = StringAttr::get(ctx, "register");
@@ -1069,6 +1123,10 @@ bool cvtReordersRegisters(RankedTensorType srcTy, RankedTensorType dstTy) {
 }
 
 bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
+  // Warp decomposition assumes pow2 GF(2) layouts.
+  if (hasNpotShape(srcTy) || hasNpotShape(dstTy)) {
+    return false;
+  }
   auto layout = minimalCvtLayout(srcTy, dstTy);
   MLIRContext *ctx = srcTy.getContext();
   auto kRegister = StringAttr::get(ctx, "register");
@@ -1082,6 +1140,14 @@ bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
 }
 
 bool cvtNeedsSharedMemory(RankedTensorType srcTy, RankedTensorType dstTy) {
+  // Keep modular-unsafe encodings out of layout algebra.
+  if (hasNpotShape(srcTy) || hasNpotShape(dstTy)) {
+    bool srcSafe = npotSafeForLinearLayout(srcTy.getEncoding());
+    bool dstSafe = npotSafeForLinearLayout(dstTy.getEncoding());
+    if (!srcSafe || !dstSafe) {
+      return true;
+    }
+  }
   return !cvtReordersRegisters(srcTy, dstTy) &&
          !cvtNeedsWarpShuffle(srcTy, dstTy);
 }

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -131,6 +131,108 @@ struct ConvertLayoutOpConversion
     return success();
   }
 
+  SmallVector<Value> transferWithinBlockModular(
+      Location loc, ConversionPatternRewriter &rewriter,
+      const LinearLayout &srcLayout, const LinearLayout &dstLayout,
+      ArrayRef<Value> inVals, Type llvmElemTy, Value smemBase) const {
+    auto *ctx = rewriter.getContext();
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto kReg = str_attr("register");
+    auto kLane = str_attr("lane");
+    auto kWarp = str_attr("warp");
+
+    auto hasSupportedInputs = [&](const LinearLayout &layout) {
+      return llvm::all_of(layout.getInDimNames(), [&](StringAttr dim) {
+        return dim == kReg || dim == kLane || dim == kWarp;
+      });
+    };
+    // The caller removes block before entering this helper.
+    assert(hasSupportedInputs(srcLayout) && hasSupportedInputs(dstLayout) &&
+           "modular shared transfer expects register/lane/warp inputs");
+    assert(srcLayout.isSurjective() && dstLayout.isSurjective() &&
+           "modular shared transfer requires complete logical covers");
+    assert(to_vector(srcLayout.getOutDimNames()) ==
+               to_vector(dstLayout.getOutDimNames()) &&
+           "source and destination must cover the same logical dimensions");
+    for (auto dim : srcLayout.getOutDimNames())
+      assert(srcLayout.getOutDimSize(dim) == dstLayout.getOutDimSize(dim) &&
+             "source and destination logical dimensions must have equal size");
+
+    auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+    auto elemPtrTy = ptr_ty(ctx, targetInfo.getSharedAddressSpace());
+    smemBase = b.bitcast(smemBase, elemPtrTy);
+
+    auto getIndices = [&](const LinearLayout &layout, int32_t reg) {
+      SmallVector<std::pair<StringAttr, Value>> indices;
+      for (auto dim : layout.getInDimNames()) {
+        if (dim == kReg)
+          indices.push_back({dim, b.i32_val(reg)});
+        else if (dim == kLane)
+          indices.push_back({dim, laneId});
+        else if (dim == kWarp)
+          indices.push_back({dim, warpId});
+        else
+          llvm_unreachable("unsupported modular conversion input dimension");
+      }
+      return indices;
+    };
+
+    auto getOffset = [&](const LinearLayout &layout,
+                         ArrayRef<std::pair<StringAttr, Value>> indices) {
+      auto logical = applyLinearLayout(loc, rewriter, layout, indices);
+      SmallVector<Value> coords;
+      SmallVector<unsigned> shape;
+      for (auto &[dim, value] : logical) {
+        coords.push_back(value);
+        shape.push_back(layout.getOutDimSize(dim));
+      }
+      return LLVM::linearize(rewriter, loc, coords, shape);
+    };
+
+    // Select one pre-modulo representative per logical coordinate.
+    auto isCanonical = [&](const LinearLayout &layout,
+                           ArrayRef<std::pair<StringAttr, Value>> indices) {
+      Value canonical = b.true_val();
+      for (auto dim : layout.getOutDimNames()) {
+        if (!layout.isOutDimModular(dim))
+          continue;
+        Value raw = b.i32_val(0);
+        for (auto [inDim, index] : indices) {
+          for (int32_t bit = 0; bit < layout.getInDimSizeLog2(inDim); ++bit) {
+            int32_t basis = layout.getBasis(inDim, bit, dim);
+            if (basis == 0)
+              continue;
+            Value set =
+                b.icmp_ne(b.and_(index, b.i32_val(1u << bit)), b.i32_val(0));
+            raw = b.add(raw, b.select(set, b.i32_val(basis), b.i32_val(0)));
+          }
+        }
+        canonical = b.and_(
+            canonical, b.icmp_ult(raw, b.i32_val(layout.getOutDimSize(dim))));
+      }
+      return canonical;
+    };
+
+    for (auto [reg, value] : llvm::enumerate(inVals)) {
+      auto indices = getIndices(srcLayout, reg);
+      Value offset = getOffset(srcLayout, indices);
+      Value canonical = isCanonical(srcLayout, indices);
+      Value ptr = b.gep(elemPtrTy, llvmElemTy, smemBase, offset);
+      targetInfo.storeShared(rewriter, loc, ptr, value, canonical);
+    }
+    targetInfo.barrier(loc, rewriter, triton::gpu::AddrSpace::Local);
+
+    // Every destination offset has a canonical source store.
+    SmallVector<Value> outVals;
+    outVals.reserve(dstLayout.getInDimSize(kReg));
+    for (int32_t reg = 0; reg < dstLayout.getInDimSize(kReg); ++reg) {
+      Value offset = getOffset(dstLayout, getIndices(dstLayout, reg));
+      Value ptr = b.gep(elemPtrTy, llvmElemTy, smemBase, offset);
+      outVals.push_back(b.load(llvmElemTy, ptr));
+    }
+    return outVals;
+  }
+
   SmallVector<Value> transferWithinBlockSwizzlingImpl(
       Location loc, ConversionPatternRewriter &rewriter,
       const LinearLayout &srcLayout, const LinearLayout &dstLayout,
@@ -189,6 +291,10 @@ struct ConvertLayoutOpConversion
 
     // At this point we have a type that's at least 8-bit
     // and we don't have broadcasting in the registers
+    if (srcLayout.isModular() || dstLayout.isModular())
+      return transferWithinBlockModular(loc, rewriter, srcLayout, dstLayout,
+                                        inVals, llvmElemTy, smemBase);
+
     auto bitwidth = llvmElemTy.getIntOrFloatBitWidth();
     int numBanks = targetInfo.getSharedMemoryBanks();
     int32_t vecBitwidth =

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -14,6 +14,22 @@ using namespace mlir;
 using namespace mlir::triton;
 using namespace mlir::triton::gpu;
 
+static std::pair<LinearLayout, LinearLayout>
+getPhysicalLayouts(LinearLayout regLayout, MemDescType memDescTy) {
+  auto sharedLayout = toLinearLayout(memDescTy);
+  if (!regLayout.isModular())
+    return {std::move(regLayout), std::move(sharedLayout)};
+
+  auto allocShape = getAllocationShapePerCTA(memDescTy);
+  sharedLayout = toLinearLayout(allocShape, memDescTy.getEncoding());
+  SmallVector<std::pair<StringAttr, int32_t>> paddedOutDims;
+  for (auto dim : regLayout.getOutDimNames())
+    paddedOutDims.push_back({dim, sharedLayout.getOutDimSize(dim)});
+  regLayout = LinearLayout(regLayout.getBases(), paddedOutDims,
+                           /*requireSurjective=*/false);
+  return {std::move(regLayout), std::move(sharedLayout)};
+}
+
 // Helper for LocalGather/ScatterOpConversion.
 // For gather: storeVals is empty, returns loaded values.
 // For scatter: storeVals contains values to store, returns empty.
@@ -64,7 +80,9 @@ LogicalResult lowerLocalStore(Location loc, MLIRContext *ctx, Value regVal,
   if (isPaddedEncoding(memDescTy.getEncoding())) {
     cvt = regLayout.invertAndCompose(paddedLinearLayout(memDescTy));
   } else {
-    auto sharedLayout = toLinearLayout(memDescTy);
+    auto [physicalRegLayout, sharedLayout] =
+        getPhysicalLayouts(regLayout, memDescTy);
+    regLayout = std::move(physicalRegLayout);
     cvt = regLayout.invertAndCompose(sharedLayout);
   }
   auto kBlock = str_attr("block");
@@ -210,7 +228,9 @@ public:
     if (isPaddedEncoding(memDescTy.getEncoding())) {
       cvt = regLayout.invertAndCompose(paddedLinearLayout(memDescTy));
     } else {
-      auto sharedLayout = toLinearLayout(memDescTy);
+      auto [physicalRegLayout, sharedLayout] =
+          getPhysicalLayouts(regLayout, memDescTy);
+      regLayout = std::move(physicalRegLayout);
       cvt = regLayout.invertAndCompose(sharedLayout);
     }
     auto kBlock = str_attr("block");

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -426,10 +426,18 @@ SmallVector<int64_t> getShapePerCTA(Attribute layout, ArrayRef<int64_t> shape) {
 SmallVector<int64_t> getAllocationShapePerCTA(Attribute layout,
                                               ArrayRef<int64_t> shapeLogical) {
   SmallVector<int64_t> shape(shapeLogical);
-  if (auto sharedMMALayout = dyn_cast<NVMMASharedEncodingAttr>(layout)) {
-    if (sharedMMALayout.getFp4Padded()) {
+  auto sharedMMALayout = dyn_cast<NVMMASharedEncodingAttr>(layout);
+  if (sharedMMALayout || isa<SwizzledSharedEncodingAttr>(layout)) {
+    if (sharedMMALayout && sharedMMALayout.getFp4Padded()) {
       auto packedAxis = getOrder(sharedMMALayout, shapeLogical)[0];
       shape[packedAxis] *= 2;
+    }
+    // Pad only the trailing dimensions covered by the swizzle.
+    unsigned tileRank = getCGALayout(layout).getRank();
+    size_t firstTileDim = shape.size() > tileRank ? shape.size() - tileRank : 0;
+    for (size_t i = firstTileDim; i < shape.size(); ++i) {
+      if (!llvm::isPowerOf2_64(shape[i]))
+        shape[i] = llvm::NextPowerOf2(shape[i]);
     }
   }
   return getShapePerCTA(layout, shape);
@@ -3930,7 +3938,7 @@ std::string mlir::triton::gpu::getDistributedLayoutStr(LinearLayout &ll,
   StringAttr kWarp = StringAttr::get(ctx, "warp");
   StringAttr kBlock = StringAttr::get(ctx, "block");
 
-  int64_t tensorSize = ll.getTotalOutDimSize();
+  int64_t tensorSize = ll.getTotalOutDimSizeProduct();
   std::vector<std::string> elementMapping(tensorSize);
   std::vector<std::string> threadMapping;
   auto shape = convertType<int64_t>(llvm::to_vector(ll.getOutDimSizes()));

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1052,8 +1052,8 @@ LinearLayout SliceEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   }
   bases[S("register")] = newRegBases;
 
-  return LinearLayout(std::move(bases),
-                      llvm::to_vector(sliceLL.getOutDimNames()));
+  return LinearLayout(std::move(bases), sliceLL.getOutDims(),
+                      /*requireSurjective=*/true);
 }
 
 LinearLayout tensorMemoryToLinearLayout(ArrayRef<int64_t> shape,

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -58,11 +58,30 @@ public:
     auto newLl =
         transposeLinearLayout(oldCGALayout.getLinearLayout(), trans.getOrder());
     auto newCGALayout = CGAEncodingAttr::get(ctx, std::move(newLl));
-    auto newInnerCvtEnc =
-        SwizzledSharedEncodingAttr::get(ctx, cvtEncoding, srcTy.getShape(),
-                                        /*order=*/getOrderForMemory(srcTy),
-                                        newCGALayout, srcTy.getElementType(),
-                                        /*needTrans=*/true);
+    Attribute newInnerCvtEnc;
+    bool isNpot = hasNpotShape(srcTy);
+    if (isNpot && !npotSafeForLinearLayout(cvtEncoding.getParent())) {
+      return failure();
+    }
+    // Modular SM90+ layouts require NVMMAShared.
+    ModuleOp mod;
+    if (isNpot) {
+      mod = cvtOp->getParentOfType<ModuleOp>();
+      assert(mod && "convert op must be nested in a ModuleOp");
+    }
+    // NPOT FP4 is intentionally unsupported here.
+    if (isNpot && srcTy.getElementType().getIntOrFloatBitWidth() < 8) {
+      return failure();
+    }
+    if (isNpot && getNVIDIAComputeCapability(mod) >= 90) {
+      newInnerCvtEnc = NVMMASharedEncodingAttr::get(
+          ctx, srcTy.getShape(), getOrderForMemory(srcTy), newCGALayout,
+          srcTy.getElementType(), /*fp4Padded=*/false);
+    } else {
+      newInnerCvtEnc = SwizzledSharedEncodingAttr::get(
+          ctx, cvtEncoding, srcTy.getShape(), getOrderForMemory(srcTy),
+          newCGALayout, srcTy.getElementType(), /*needTrans=*/true);
+    }
     if (newInnerCvtEnc == cvtEncoding)
       return failure();
     rewriter.setInsertionPoint(trans);

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -523,6 +523,9 @@ static unsigned estimateConvertScratchCost(Value value, Attribute encoding) {
     if (encTrait && srcTy.getRank() != encTrait.getRank())
       continue;
     auto dstTy = srcTy.cloneWithEncoding(encoding);
+    // Skip encodings without modular layout support.
+    if (!npotCvtSafe(srcTy, dstTy))
+      continue;
     if (cvtNeedsSharedMemory(srcTy, dstTy)) {
       unsigned elems = getNumScratchElemsSwizzledCvt(srcTy, dstTy);
       cost += elems * getElementBitWidth(srcTy) / 8;
@@ -2022,6 +2025,9 @@ public:
       funcOp->walk([&](ConvertLayoutOp cvt) {
         auto srcTy = cvt.getSrc().getType();
         auto dstTy = cvt.getType();
+        // Skip encodings without modular layout support.
+        if (!npotCvtSafe(srcTy, dstTy))
+          return;
         if (!cvtNeedsSharedMemory(srcTy, dstTy))
           return;
         unsigned scratchBytes = getNumScratchElemsSwizzledCvt(srcTy, dstTy) *

--- a/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
@@ -277,6 +277,13 @@ computeTMemLdStEncodingInfo(RankedTensorType regTy, MemDescType memTy,
                             std::function<InFlightDiagnostic()> emitError) {
   auto memLayout = toLinearLayout(memTy);
   auto regLayout = toLinearLayout(regTy);
+  if (regLayout.isModular()) {
+    SmallVector<std::pair<StringAttr, int32_t>> paddedOutDims;
+    for (auto dim : regLayout.getOutDimNames())
+      paddedOutDims.push_back({dim, memLayout.getOutDimSize(dim)});
+    regLayout = LinearLayout(regLayout.getBases(), paddedOutDims,
+                             /*requireSurjective=*/false);
+  }
   auto *ctx = regTy.getContext();
   auto S = [ctx](StringRef str) { return StringAttr::get(ctx, str); };
   auto kBlock = S("block");

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -257,7 +257,7 @@ std::pair<int, int> bankConflicts(ArrayRef<int32_t> tileSrc,
   auto segment = StringAttr::get(ctx, "segment");
   auto segmentBases = flatten(smemFlat, segment);
 
-  int32_t rank = smem.getTotalOutDimSizeLog2();
+  int32_t rank = smem.getTotalOutDimSizeBits();
   // compute conflicts
   int write = 1 << intersectionBasis(segmentBases, tileSrc, rank).size();
   int read = 1 << intersectionBasis(segmentBases, tileDst, rank).size();
@@ -357,7 +357,7 @@ std::optional<SmallVector<int32_t>> optimalSwizzlingTile(
   auto *ctx = a.getInDimNames().begin()->getContext();
   auto kReg = StringAttr::get(ctx, "register");
   auto kLane = StringAttr::get(ctx, "lane");
-  auto dim = a.getTotalOutDimSizeLog2();
+  auto dim = a.getTotalOutDimSizeBits();
   // map from b to a
   LinearLayout cvt = b.invertAndCompose(a);
 
@@ -431,7 +431,7 @@ LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
   assert(src.getNumOutDims() == 1 && dst.getNumOutDims() == 1 &&
          "src and dst must have a single output dimension");
 
-  const int32_t dim = src.getTotalOutDimSizeLog2();
+  const int32_t dim = src.getTotalOutDimSizeBits();
   auto *ctx = src.getInDimNames().begin()->getContext();
   auto kReg = StringAttr::get(ctx, "register");
 
@@ -496,6 +496,52 @@ LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
   return basis1D.reshapeOuts(outDims);
 }
 
+// Swizzle pow2 dimensions and map NPOT dimensions to segment.
+static LinearLayout
+optimalSwizzlingLdStMixed(const LinearLayout &src, const LinearLayout &dst,
+                          int32_t bitwidth, int32_t numBanks,
+                          LocalMemOpTile srcTile, LocalMemOpTile dstTile) {
+  auto *ctx = src.getInDimNames().begin()->getContext();
+  auto S = [ctx](StringRef str) { return StringAttr::get(ctx, str); };
+  auto kSeg = S("segment");
+
+  SmallVector<StringAttr> pow2Dims, npotDims;
+  for (auto outDim : src.getOutDimNames()) {
+    if (src.isOutDimModular(outDim))
+      npotDims.push_back(outDim);
+    else
+      pow2Dims.push_back(outDim);
+  }
+
+  // NPOT inputs are pow2-padded; outputs remain modular.
+  LinearLayout npotPart = LinearLayout::empty();
+  for (auto npotDim : npotDims) {
+    int32_t N = src.getOutDimSize(npotDim);
+    npotPart *= LinearLayout::modularIdentity1D(N, kSeg, npotDim);
+  }
+
+  if (pow2Dims.empty()) {
+    auto kVec = S("vector"), kBank = S("bank"), kReps = S("reps");
+    auto segBases = npotPart.getBases().lookup(kSeg);
+    return LinearLayout(
+        {{kVec, {}}, {kBank, {}}, {kSeg, segBases}, {kReps, {}}},
+        npotPart.getOutDims(), /*requireSurjective=*/true);
+  }
+
+  auto inDims = llvm::to_vector(src.getInDimNames());
+  auto srcPow2 = src.sublayout(inDims, pow2Dims);
+  auto dstPow2 = dst.sublayout(inDims, pow2Dims);
+  srcPow2 = actionRemoveBroadcastedRegs(srcPow2).apply(srcPow2);
+  dstPow2 = actionRemoveBroadcastedRegs(dstPow2).apply(dstPow2);
+
+  auto smemPow2 = optimalSwizzlingLdSt(srcPow2, dstPow2, bitwidth, numBanks,
+                                       srcTile, dstTile);
+
+  // NPOT segment bases are disjoint from pow2 vector/bank bases. Output
+  // projection preserves the lane-basis indices used by srcTile/dstTile.
+  return smemPow2 * npotPart;
+}
+
 std::pair<SmallVector<int32_t>, std::optional<bool>>
 getVecBasisLdSt(const LinearLayout &srcFlat, const LinearLayout &dstFlat,
                 int32_t bitwidth) {
@@ -506,7 +552,7 @@ getVecBasisLdSt(const LinearLayout &srcFlat, const LinearLayout &dstFlat,
   auto regDst = flatten(dstFlat, kReg);
   auto blockSrc = srcFlat.getBases().contains(kBlock) ? flatten(srcFlat, kBlock)
                                                       : SmallVector<int32_t>{};
-  auto dim = srcFlat.getTotalOutDimSizeLog2();
+  auto dim = srcFlat.getTotalOutDimSizeBits();
   SmallVector<int32_t> vbasis = intersectionBasis(regSrc, regDst, dim);
   // Restrict the vectorisation to the maximum we can use
   auto maxVecBases = llvm::Log2_32(128 / bitwidth);
@@ -600,6 +646,10 @@ LinearLayout optimalSwizzlingLdSt(const LinearLayout &src,
                                   const LinearLayout &dst, int32_t bitwidth,
                                   int32_t numBanks, LocalMemOpTile srcTile,
                                   LocalMemOpTile dstTile) {
+  if (src.isModular())
+    return optimalSwizzlingLdStMixed(src, dst, bitwidth, numBanks, srcTile,
+                                     dstTile);
+
   auto *ctx = src.getInDimNames().begin()->getContext();
   auto kReg = StringAttr::get(ctx, "register");
   auto kLane = StringAttr::get(ctx, "lane");

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -253,7 +253,7 @@ std::optional<ColumnAction> regPermForDivide(const LinearLayout &A,
   llvm::DenseMap<StringAttr, unsigned> log2QuotSize;
   for (StringAttr out : A.getOutDimNames()) {
     log2QuotSize[out] =
-        A.getOutDimSizeLog2(out) - BBroadcast.getOutDimSizeLog2(out);
+        A.getOutDimSizeBits(out) - BBroadcast.getOutDimSizeBits(out);
     if (log2QuotSize[out] < 0)
       return std::nullopt;
   }
@@ -520,7 +520,7 @@ std::optional<LinearLayout> getReps(const LinearLayout &cvt,
   // Precompute tile out-dim bit-widths.
   llvm::SmallDenseMap<StringAttr, int> outBLog2;
   for (StringAttr od : cvt.getOutDimNames())
-    outBLog2[od] = tile.hasOutDim(od) ? tile.getOutDimSizeLog2(od) : 0;
+    outBLog2[od] = tile.hasOutDim(od) ? tile.getOutDimSizeBits(od) : 0;
 
   // Build a per-out-dimension mask by OR-ing all tile bases that touch it.
   llvm::SmallDenseMap<StringAttr, int32_t> tileMaskPerOutDim;

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -528,6 +528,22 @@ bool LinearLayout::isModularSurjective() const {
       continue; // Check next dimension
     }
 
+    // Pow2 output dimensions retain XOR semantics.
+    if (llvm::isPowerOf2_32(size)) {
+      std::vector<bool> reachable(size, false);
+      reachable[0] = true;
+      for (int32_t basis : allBases) {
+        auto next = reachable;
+        for (int32_t value = 0; value < size; ++value)
+          if (reachable[value])
+            next[value ^ basis] = true;
+        reachable.swap(next);
+      }
+      if (llvm::count(reachable, true) != size)
+        return false;
+      continue;
+    }
+
     // Use CRT factorization: check surjectivity per prime power factor.
     // For N = 2^k * p1^e1 * ... * pm^em, we check each factor separately.
     // Each factor uses DP reachability, so the total cost is

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
@@ -7,6 +7,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/GenericSwizzling.h"
 #include "triton/Tools/LayoutUtils.h"
@@ -59,7 +60,7 @@ static unsigned getNumScratchElemsSwizzledCvt(RankedTensorType srcTy,
   auto [smem, _] = triton::gpu::optimalSwizzling(srcLayout, dstLayout, srcTiles,
                                                  dstTiles, bitwidth);
   auto reps = smem.getInDimSize(StringAttr::get(ctx, "reps"));
-  return smem.getTotalOutDimSize() / reps;
+  return smem.getTotalOutDimSizeProduct() / reps;
 }
 
 std::function<unsigned(Operation *)>
@@ -68,6 +69,15 @@ getNvidiaAllocationAnalysisScratchSizeFn(TargetInfoBase &targetInfo) {
     if (auto cvtOp = dyn_cast<triton::gpu::ConvertLayoutOp>(op)) {
       auto srcTy = cvtOp.getSrc().getType();
       auto dstTy = cvtOp.getType();
+      if (hasNpotShape(srcTy) || hasNpotShape(dstTy)) {
+        // Use modular physical-cover sizing.
+        if (!cvtNeedsSharedMemory(srcTy, dstTy)) {
+          return 0;
+        }
+        auto elems = mlir::triton::getNumScratchElemsSwizzledCvt(srcTy, dstTy);
+        // Modular sub-byte values occupy one byte in shared memory.
+        return elems * std::max<unsigned>(getBitwidth(srcTy), 8) / 8;
+      }
       if (!cvtNeedsSharedMemory(srcTy, dstTy))
         return 0;
       // In cuda we always swizzle

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -37,6 +37,10 @@ struct ConvertLayoutOpSwizzlingConversion
     auto srcTy = op.getSrc().getType();
     auto dstTy = op.getType();
 
+    // Modular layouts use the generic conversion path.
+    if (hasNpotShape(srcTy) || hasNpotShape(dstTy))
+      return failure();
+
     LinearLayout conversion = minimalCvtLayout(srcTy, dstTy);
     LinearLayout srcLayout = toLinearLayout(srcTy);
     LinearLayout dstLayout = toLinearLayout(dstTy);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -69,7 +69,12 @@ public:
     // we would need to handle the getReps part more carefuly
     // This way we could support more subviews that we don't
     // We can implement this generalisation in the future if needed
-    auto llInv = toLinearLayout(memTy).pseudoinvert();
+    auto memLayout = toLinearLayout(memTy);
+    if (memLayout.isModular()) {
+      auto allocShape = gpu::getAllocationShapePerCTA(memTy);
+      memLayout = gpu::toLinearLayout(allocShape, memTy.getEncoding());
+    }
+    auto llInv = memLayout.pseudoinvert();
     auto bitwidth = memTy.getElementType().getIntOrFloatBitWidth();
     if (isFp4) {
       // hacky but well

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1192,6 +1192,15 @@ struct AsyncCopyGlobalToLocalOpConversion
     auto smemObj =
         getSharedMemoryObjectFromStruct(loc, llDst, resElemTy, rewriter);
     auto smemLayout = ttg::toLinearLayout(dstTy);
+    if (srcLayout.isModular()) {
+      auto allocShape = ttg::getAllocationShapePerCTA(dstTy);
+      smemLayout = ttg::toLinearLayout(allocShape, dstTy.getEncoding());
+      SmallVector<std::pair<StringAttr, int32_t>> paddedOutDims;
+      for (auto dim : srcLayout.getOutDimNames())
+        paddedOutDims.push_back({dim, smemLayout.getOutDimSize(dim)});
+      srcLayout = LinearLayout(srcLayout.getBases(), paddedOutDims,
+                               /*requireSurjective=*/false);
+    }
     auto cvt = srcLayout.invertAndCompose(smemLayout);
     if (!cvt.isTrivialOver({str_attr("block")})) {
       return emitError(loc,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/MemoryOpToLLVM.cpp
@@ -162,8 +162,18 @@ LogicalResult lowerLdStMatrix(
   if (isa<PaddedSharedEncodingAttr>(memDescType.getEncoding())) {
     return failure();
   }
+  auto activeRegLayout = regLayout;
   auto memLayout = toLinearLayout(memDescType);
-  auto cvt = regLayout.invertAndCompose(memLayout);
+  if (activeRegLayout.isModular()) {
+    auto allocShape = getAllocationShapePerCTA(memDescType);
+    memLayout = toLinearLayout(allocShape, memDescType.getEncoding());
+    SmallVector<std::pair<StringAttr, int32_t>> paddedOutDims;
+    for (auto dim : activeRegLayout.getOutDimNames())
+      paddedOutDims.push_back({dim, memLayout.getOutDimSize(dim)});
+    activeRegLayout = LinearLayout(activeRegLayout.getBases(), paddedOutDims,
+                                   /*requireSurjective=*/false);
+  }
+  auto cvt = activeRegLayout.invertAndCompose(memLayout);
   auto kBlock = StringAttr::get(loc.getContext(), "block");
   auto maybeSublayout = cvt.quotient({kBlock});
   if (!maybeSublayout) {

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -2793,6 +2793,19 @@ TEST_F(LinearLayoutConversionsTest, SliceOfBlocked) {
                          {S("dim0")}));
 }
 
+TEST_F(LinearLayoutConversionsTest, SliceOfBlockedPreservesNpotSize) {
+  auto parent = blocked({1, 4}, {4, 8}, {4, 1}, {1, 1}, {1, 1}, {1, 0}, {1, 0});
+  auto layout = toLinearLayout({48}, slice(parent, 0));
+
+  EXPECT_EQ(layout,
+            LinearLayout({{S("register"), {{1}, {2}, {32}}},
+                          {S("lane"), {{4}, {8}, {16}, {0}, {0}}},
+                          {S("warp"), {{0}, {0}}},
+                          {S("block"), {}}},
+                         {{S("dim0"), 48}}, /*requireSurjective=*/true));
+  EXPECT_TRUE(layout.isModular());
+}
+
 TEST_F(LinearLayoutConversionsTest, SliceWithShape1) {
   auto parent = blocked({1, 4}, {8, 4}, {2, 2}, {1, 1}, {1, 1}, {0, 1}, {1, 0});
   EXPECT_EQ(toLinearLayout({1}, slice(parent, 0)),

--- a/unittest/Dialect/TritonGPU/SwizzleTest.cpp
+++ b/unittest/Dialect/TritonGPU/SwizzleTest.cpp
@@ -426,6 +426,55 @@ TEST_F(SwizzleTest, Test64x128F16BlockedLinear32Bank) {
   EXPECT_EQ(w, 0);
 }
 
+TEST_F(SwizzleTest, MixedLayoutPreservesPow2TileSwizzle) {
+  auto kReg = S("register");
+  auto kLane = S("lane");
+  auto kWarp = S("warp");
+  auto kBlock = S("block");
+  auto dim0 = S("dim0");
+  auto dim1 = S("dim1");
+  LinearLayout src(
+      {{kReg, {{0, 1}, {0, 2}, {0, 4}, {16, 0}, {32, 0}}},
+       {kLane, {{0, 8}, {0, 16}, {0, 32}, {0, 64}, {1, 0}, {2, 0}}},
+       {kWarp, {{4, 0}, {8, 0}}},
+       {kBlock, {}}},
+      {{dim0, 64}, {dim1, 96}}, /*requireSurjective=*/true);
+  LinearLayout dst(
+      {{kReg, {{0, 1}, {0, 2}, {0, 8}, {0, 16}, {0, 32}, {0, 64}, {32, 0}}},
+       {kLane, {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {16, 0}, {0, 4}}},
+       {kWarp, {{0, 0}, {0, 0}}},
+       {kBlock, {}}},
+      {{dim0, 64}, {dim1, 96}}, /*requireSurjective=*/true);
+
+  constexpr int32_t numBanks = 32;
+  LocalMemOpTile srcTile;
+  LocalMemOpTile dstTile{{}, {0, 1, 4}};
+  auto mixed = optimalSwizzlingLdSt(src, dst, /*bitwidth=*/16, numBanks,
+                                    srcTile, dstTile);
+
+  auto inDims = llvm::to_vector(src.getInDimNames());
+  auto srcPow2 = src.sublayout(inDims, {dim0});
+  auto dstPow2 = dst.sublayout(inDims, {dim0});
+  srcPow2 = actionRemoveBroadcastedRegs(srcPow2).apply(srcPow2);
+  dstPow2 = actionRemoveBroadcastedRegs(dstPow2).apply(dstPow2);
+  auto pow2 = optimalSwizzlingLdSt(srcPow2, dstPow2, /*bitwidth=*/16, numBanks,
+                                   srcTile, dstTile);
+
+  for (auto inDim : {S("vector"), S("bank")}) {
+    EXPECT_EQ(mixed.getInDimSize(inDim), pow2.getInDimSize(inDim));
+    for (int bit = 0; bit < pow2.getInDimSizeLog2(inDim); ++bit) {
+      EXPECT_EQ(mixed.getBasis(inDim, bit, dim0),
+                pow2.getBasis(inDim, bit, dim0));
+      EXPECT_EQ(mixed.getBasis(inDim, bit, dim1), 0);
+    }
+  }
+
+  auto kSegment = S("segment");
+  int pow2SegmentBits = pow2.getInDimSizeLog2(kSegment);
+  for (int bit = pow2SegmentBits; bit < mixed.getInDimSizeLog2(kSegment); ++bit)
+    EXPECT_EQ(mixed.getBasis(kSegment, bit, dim0), 0);
+}
+
 TEST_F(SwizzleTest, Test64x128F16BlockedMfma64Bank) {
   LinearLayout src(
       {{S("register"), {{0, 1}, {0, 2}, {0, 4}, {16, 0}, {32, 0}}},

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -1484,6 +1484,15 @@ TEST_F(LinearLayoutTest, SurjectivityTruncationRegression) {
 // Verifies that per-layout isModular is correct for mixed shapes.
 //===----------------------------------------------------------------------===//
 
+TEST_F(LinearLayoutTest, MixedShapeSurjectivityUsesPerDimAlgebra) {
+  LinearLayout layout({{S("in"), {{1, 0}, {3, 0}, {0, 1}, {0, 2}, {0, 4}}}},
+                      {{S("pow2"), 4}, {S("npot"), 6}},
+                      /*requireSurjective=*/false);
+
+  EXPECT_TRUE(layout.isModular());
+  EXPECT_TRUE(layout.isModularSurjective());
+}
+
 TEST_F(LinearLayoutTest, MixedShape_OperatorStar_SharedDim) {
   // When inner and outer share an output dim, sizes multiply (not shift).
   // inner: 4 -> dim0=4; outer: 6 -> dim0=6. Product should be 24, not 64.


### PR DESCRIPTION
Summary:

Foundation for NPOT (non-power-of-2) SMEM allocation, swizzling, and MMA conversion, including the Blackwell validation fixes. Pow2 and flag-OFF lowering remain byte-identical; the NPOT paths activate only for modular layouts.

Blackwell validation showed that forwarding numBanks and the full LocalMemOpTile descriptors into the pow2 sub-swizzle is correct: those descriptors encode instruction lane selection, not tensor rank, and the projected sublayout retains the lane basis positions. The failures were instead caused by modular coordinates being treated as padded XOR coordinates, pseudoinversion selecting aliased representatives, slice conversion losing explicit NPOT output sizes, and logical layouts being composed against physically padded SMEM/TMEM allocations.

The fix keeps NPOT dimensions as independent modular identities, uses a canonical row-major shared transfer for modular convert_layout, preserves explicit NPOT slice sizes, fixes mixed-layout surjectivity algebra, and lifts modular register layouts to physical allocation shapes at local/cp.async/MMA/TMEM boundaries. MMAv5 admits validated NPOT-M shapes while NPOT-N remains on the correct FMA fallback. Modular scratch sizing measures the physical input cover while pow2 layouts retain the existing output-domain accounting.

F2 now rebases directly onto master after the verifier foundation landed; reduction is not a code dependency. To reduce conflicts with upstream merges and backports, NPOT MMA output/alignment policy lives in named helpers and the modular shared transfer is isolated behind one dispatch in the existing swizzle path. The transfer makes its no-block, equal-domain, and surjective-cover contracts explicit. NPOT sub-byte scratch allocation now matches the lowering's i8 promotion, and the NPOT-only compute-capability lookup is actually lazy.

All new behavior is modular/NPOT-gated. Pow2 layouts, including MMA descriptor construction, retain the existing paths unchanged.

Reviewed By: njriasan, stashuk-olek

Differential Revision: D110214712


