### PR TITLE
[TritonGPU] NPOT layout support: verifier dot/MMA allow-set + modular convert/view remap

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -12,6 +12,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/GenericSwizzling.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "triton/Tools/Sys/GetEnv.h"
 
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 
@@ -82,6 +83,26 @@ struct ConvertLayoutOpConversion
     } else {
       // Cast 5. The two layouts are equivalent. We should probably remove
       // these in RemoveLayoutConversion.
+      //
+      // NPOT: minimalCvtLayout's quotient uses squareSublayoutIsIdentity (pure
+      // GF(2), basis == 1<<b), which false-positives on modular register dims
+      // and collapses two different ADD-mod-N maps to a no-op -> scramble. If
+      // either side is modular and they are not truly equal, route the real
+      // remap through transferWithinThread. pow2 unaffected (isModular() is
+      // false).
+      if (srcLayout.isModular() || dstLayout.isModular()) {
+        static const bool allowNpot =
+            ::mlir::triton::tools::getBoolEnv("TRITON_ALLOW_NPOT");
+        if (allowNpot && srcLayout != dstLayout) {
+          // Rebuild the register remap without the quotient; lane/warp/block
+          // are identity at Case 5, so the register sublayout is the full
+          // conversion.
+          LinearLayout fullConversion = dstLayout.invertAndCompose(srcLayout);
+          LinearLayout regConversion =
+              fullConversion.sublayout({kRegister}, {kRegister});
+          return transferWithinThread(op, regConversion, adaptor, rewriter);
+        }
+      }
       rewriter.replaceOp(op, adaptor.getSrc());
       return success();
     }

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -157,6 +157,22 @@ bool isExpensiveView(ArrayRef<int64_t> srcShape, Attribute srcEncoding,
                      ArrayRef<int64_t> dstShape, Attribute dstEncoding) {
   auto llSrc = toLinearLayout(srcShape, srcEncoding);
   auto llDst = toLinearLayout(dstShape, dstEncoding);
+  // NPOT: getFreeVariableMasks() cannot distinguish two different ADD-mod-N
+  // maps, so distinct modular layouts compare "cheap" and callers skip the
+  // relayout -> scramble. A shape-changing modular view can never be proven a
+  // true no-op (the `llSrc != llDst` LinearLayout compare has holes for
+  // modular maps: some genuine reshapes still compare equal/"cheap" and fall
+  // through to a silent no-op repack in ViewOpToLLVM). Conservatively treat any
+  // modular view whose src and dst shapes differ as expensive so it is
+  // loud-rejected / routed through the real remap rather than silently
+  // scrambled. Same-shape modular views (identity) stay cheap. pow2 unaffected
+  // (isModular() is false).
+  if (llSrc.isModular() || llDst.isModular()) {
+    static const bool allowNpot =
+        mlir::triton::tools::getBoolEnv("TRITON_ALLOW_NPOT");
+    if (allowNpot && srcShape != dstShape)
+      return true;
+  }
   // In case there are replicated value we need to make sure the new and old
   // layout have matching masks.
   for (auto [srcMask, dstMask] :
@@ -3403,7 +3419,17 @@ struct TritonGPUInferLayoutInterface
     auto result =
         inferReshapeOpLegacyEncoding(srcShape, srcEnc, dstShape, dstEnc);
     if (succeeded(result)) {
-      return result;
+      // A modular (NPOT) reshape can get a legacy default->default encoding
+      // that looks like a cheap register no-op but is NOT order-preserving
+      // (getFreeVariableMasks cannot tell two ADD-mod-N maps apart). Lowering
+      // that as a no-op repack (ReshapeOpConversion) silently scrambles data in
+      // opt builds (the assert(!isExpensiveView) there is compiled out). If the
+      // inferred view is expensive, fall through to the LinearLayout-based
+      // inference (real remap / loud-fail) instead of returning the scrambling
+      // no-op. pow2 is unaffected: isExpensiveView's modular branch never
+      // fires, so pow2 default->default stays cheap -> byte-identical.
+      if (!isExpensiveView(srcShape, srcEnc, dstShape, dstEnc))
+        return result;
     }
     if (!isa<DistributedEncodingTrait>(srcEnc)) {
       return emitOptionalError(loc,
@@ -3684,10 +3710,13 @@ struct TritonGPUVerifyTensorLayoutInterface
                          << " which is not a power of two.";
       }
       // Layouts whose modular (non-power-of-2) lowering is implemented.
-      bool npotLoweringImplemented =
-          isa<BlockedEncodingAttr, SliceEncodingAttr, LinearEncodingAttr>(
-              layout);
-      if (!npotLoweringImplemented) {
+      // Dot-operand and MMA encodings (Nvidia WGMMA/MMAv5, AMD MFMA/WMMA) are
+      // admitted so an NPOT tl.dot's operand/result tensors pass verification
+      // under the flag; the modular LinearLayout they resolve to is lowered by
+      // the encoding-agnostic ADD+UREM path in applyLinearLayout.
+      if (!isa<BlockedEncodingAttr, SliceEncodingAttr, LinearEncodingAttr,
+               DotOperandEncodingAttr, NvidiaMmaEncodingAttr,
+               AMDMfmaEncodingAttr, AMDWmmaEncodingAttr>(layout)) {
         return makeErr()
                << "NPOT layout not yet supported: tensor shape "
                << rankedTy.getShape()

--- a/python/test/unit/language/test_npot.py
+++ b/python/test/unit/language/test_npot.py
@@ -134,3 +134,74 @@ def test_pow2_control_elementwise(size):
     out = torch.empty(size, device="cuda")
     kernel[(1, )](x, y, out, N=size)
     assert _rel_err(out, x * y + x) < 1e-4, f"size={size}"
+
+
+# ---------------------------------------------------------------------------
+# Modular convert_layout / view ops must route through the real remap, not a
+# pow2-only cheap no-op. Two guards: isExpensiveView (getFreeVariableMasks can't
+# tell two ADD-mod-N maps apart) and the convert Case-5 no-op (minimalCvtLayout
+# quotients a modular register dim away). Their core is pinned in
+# LinearLayoutTest.{ModularRelayoutIsNotIdentity,ModularRegisterDimNotQuotientedAway}.
+# End-to-end modular reshape / axis=None reduce are not exercised here
+# (unimplemented; they fail earlier) -- the reshape is correctly marked EXPENSIVE
+# (loud fail, not scramble). Random inputs (constants are scramble-blind).
+# ---------------------------------------------------------------------------
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("M, N", [(16, 48), (16, 192), (33, 48), (8, 96)])
+def test_npot_reshape_2d_to_1d_expensive_view_detected(M, N):
+    """A modular 2D -> 1D reshape genuinely changes the layout. Previously
+    isExpensiveView false-positived it as a cheap no-op and the reshape lowering
+    silently scrambled the elements. Now the view is correctly classified
+    (expensive / not a no-op), so the compile fails loudly instead of producing
+    scrambled data. This is strictly safer; the correct-result path needs the
+    follow-on modular reshape remap. We assert it does NOT silently succeed with
+    scrambled output."""
+
+    @triton.jit
+    def kernel(X, Out, M: tl.constexpr, N: tl.constexpr):
+        idx = tl.arange(0, M)[:, None] * N + tl.arange(0, N)[None, :]
+        x = tl.load(X + idx)
+        y = tl.reshape(x, (M * N, ))
+        tl.store(Out + tl.arange(0, M * N), y)
+
+    x = torch.arange(M * N, device="cuda", dtype=torch.float32).reshape(M, N)
+    out = torch.full((M * N, ), -1.0, device="cuda", dtype=torch.float32)
+    ref = x.reshape(M * N)
+    try:
+        kernel[(1, )](x, out, M=M, N=N)
+    except Exception:
+        # Expected: modular reshape is (correctly) rejected as an expensive view
+        # rather than silently scrambling.
+        return
+    # If it DID compile, the result must be correct (never a silent scramble).
+    assert _rel_err(out, ref) < 1e-6, f"silent scramble on reshape M={M},N={N}"
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("M, N", [(16, 48), (33, 48)])
+@pytest.mark.xfail(
+    reason="NPOT axis-reduction lowering (ReduceOpToLLVM) "
+    "not yet implemented; separate from the convert guards.", strict=False)
+def test_npot_sum_axis1(M, N):
+    """Per-axis reduction over a modular 2D layout. Documents the still-open
+    NPOT reduce-lowering gap (weighted sum is permutation-sensitive). xfail:
+    tracked separately from the convert guards."""
+
+    @triton.jit
+    def kernel(X, W, Out, M: tl.constexpr, N: tl.constexpr):
+        idx = tl.arange(0, M)[:, None] * N + tl.arange(0, N)[None, :]
+        x = tl.load(X + idx)
+        w = tl.load(W + idx)
+        sw = tl.sum(x * w, axis=1)  # [M]
+        tl.store(Out + tl.arange(0, M), sw)
+
+    x = torch.randn(M, N, device="cuda", dtype=torch.float32)
+    w = torch.randn(M, N, device="cuda", dtype=torch.float32)
+    out = torch.empty(M, device="cuda", dtype=torch.float32)
+    kernel[(1, )](x, w, out, M=M, N=N)
+    ref = (x * w).sum(dim=1)
+    assert _rel_err(out, ref) < 1e-3, f"wsum M={M},N={N}"

--- a/test/TritonGPU/verify-npot-dot-mma-layout.mlir
+++ b/test/TritonGPU/verify-npot-dot-mma-layout.mlir
@@ -1,0 +1,50 @@
+// Flag ON: NPOT dot-operand / MMA tensors PASS verifyTensorLayout and the
+// module round-trips cleanly (FileCheck the op labels are printed back).
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt --split-input-file %s | FileCheck %s
+//
+// Flag OFF (default): the same NPOT tensors are REJECTED by verifyTensorLayout
+// with the "not a power of two" diagnostic.
+// RUN: triton-opt --split-input-file %s --verify-diagnostics
+//
+// The NPOT allow-set admits DotOperand/NvidiaMma/AMDMfma/AMDWmma under the flag
+// so an NPOT tl.dot's tensors verify; parents keep pow2 sizePerThread/
+// threadsPerWarp, only the shape is NPOT. Verifier only, not dot codegen.
+
+// NPOT dot-operand (opIdx = 0). Shape N=96 is not a power of two.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @npot_dot_operand
+  tt.func public @npot_dot_operand(%arg0: tensor<16x96xf16, #dot0>) {
+    // expected-error @+1 {{which is not a power of two}}
+    %0 = ttg.convert_layout %arg0 : tensor<16x96xf16, #dot0> -> tensor<16x96xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// NPOT Nvidia MMA (MMAv2) result tensor. Shape N=96 is not a power of two.
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @npot_nvidia_mma
+  tt.func public @npot_nvidia_mma(%arg0: tensor<128x96xf16, #mma>) {
+    // expected-error @+1 {{which is not a power of two}}
+    %0 = ttg.convert_layout %arg0 : tensor<128x96xf16, #mma> -> tensor<128x96xf16, #mma>
+    tt.return
+  }
+}
+
+// -----
+
+// NPOT AMD MFMA (wave64) tensor. Shape N=96 is not a power of two. This is the
+// encoding the native AMD MFMA NPOT GEMM path depends on being admitted.
+#mfma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32, 16], isTransposed = false}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @npot_amd_mfma
+  tt.func public @npot_amd_mfma(%arg0: tensor<128x96xf16, #mfma>) {
+    // expected-error @+1 {{which is not a power of two}}
+    %0 = ttg.convert_layout %arg0 : tensor<128x96xf16, #mfma> -> tensor<128x96xf16, #mfma>
+    tt.return
+  }
+}

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -769,6 +769,49 @@ TEST_F(LinearLayoutTest, FreeVariableMasks) {
             AR({{S("in"), 0b110}}));
 }
 
+// The pow2-only fast paths in isExpensiveView and the convert-layout no-op
+// collapse cannot distinguish two *different* modular (ADD-mod-N) register
+// maps, so they would treat a modular relayout as a cheap identity no-op and
+// scramble elements. These tests pin the two discriminators used by the
+// modular-aware guards:
+//   1. getFreeVariableMasks() is a conservative all-zero-basis check and
+//   returns
+//      the SAME masks for two different modular maps (isExpensiveView's old
+//      fast path relies on it -> false "cheap"). operator!= DOES distinguish
+//      them.
+//   2. quotient()/squareSublayoutIsIdentity() uses the pure GF(2) predicate
+//      (basis == 1<<b), which false-positives on a modular register basis, so
+//      minimalCvtLayout would quotient the register dim away and collapse to a
+//      no-op. isModular() flags the layout so the guard refuses the collapse.
+TEST_F(LinearLayoutTest, ModularRelayoutIsNotIdentity) {
+  // Two distinct modular maps over Z/6: strides 1 and 5. They are genuinely
+  // different permutations of {0..5} but the conservative free-variable mask is
+  // identical (no zero bases in either) -> the old isExpensiveView fast path
+  // would call them equal ("cheap").
+  auto modId = LinearLayout::modularStrided1D(6, 1, S("in"), S("out"));
+  auto modRev = LinearLayout::modularStrided1D(6, 5, S("in"), S("out"));
+  EXPECT_TRUE(modId.isModular());
+  EXPECT_TRUE(modRev.isModular());
+  // Old fast path: same free-variable masks despite being different maps.
+  EXPECT_EQ(to_vector(modId.getFreeVariableMasks()),
+            to_vector(modRev.getFreeVariableMasks()));
+  // The guard's discriminator: they are not equal.
+  EXPECT_NE(modId, modRev);
+  EXPECT_EQ(modId, modId);
+}
+
+TEST_F(LinearLayoutTest, ModularRegisterDimNotQuotientedAway) {
+  // A non-identity modular register map (stride 5 over Z/6). The GF(2) identity
+  // predicate used by squareSublayoutIsIdentity treats basis 5 (== 0b101) as
+  // "not identity" only for bit 0; but for a modular map the round-trip is not
+  // GF(2)-linear, so quotient must not silently drop it. Confirm isModular is
+  // set (the guard keys off it) and the map is not the identity.
+  auto modRev = LinearLayout::modularStrided1D(6, 5, S("register"), S("out"));
+  auto ident = LinearLayout::modularIdentity1D(6, S("register"), S("out"));
+  EXPECT_TRUE(modRev.isModular());
+  EXPECT_NE(modRev, ident);
+}
+
 TEST_F(LinearLayoutTest, QuotientOneDimension) {
   LinearLayout layout(
       {


### PR DESCRIPTION
Summary:
verifyTensorLayout admits NPOT dot-operand and MMA operand/result layouts
(DotOperand, NvidiaMma, AMDMfma, AMDWmma) under TRITON_ALLOW_NPOT, so an NPOT
tl.dot passes tensor-layout verification. isExpensiveView and the
convert_layout Case-5 no-op are routed through the real remap instead of the
pow2-only cheap-identity fast paths, which cannot tell two distinct modular
(ADD-mod-N) maps apart and would silently scramble elements. All new branches
are flag-gated and pow2 byte-identical (isModular() is always false for pow2).

Rollback: gated behind TRITON_ALLOW_NPOT (env, default OFF) and env-gated tests;
unset the flag or revert the diff to disable. pow2 paths are byte-identical (flag
OFF), so rollback is low-risk.

Reviewed By: stashuk-olek

Differential Revision: D110382281


