### PR TITLE
[TritonGPU] NPOT memdesc verifier relaxation + alloc-shape gating

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
@@ -7,6 +7,7 @@
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "llvm/Support/MathExtras.h" // Log2_64
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -89,8 +90,13 @@ public:
     auto invReg = inv.sublayout(dims, {kReg});
     auto bases_inv = invReg.getBases();
     for (auto [c, d] : llvm::zip(constancy, dims)) {
-      assert(llvm::isPowerOf2_32(c));
-      for (int i = 0; i < llvm::Log2_32(c); i++) {
+      // Clamp constancy to its largest pow2 divisor (c & -c) before Log2; NPOT
+      // constancy (e.g. 48) would mis-floor. c is a multiple of it, so the
+      // zeroed low bits never cross a constancy block boundary. Pow2 c: no-op.
+      if (c == 0)
+        continue; // Log2_64(0) is UB; nothing to dedup
+      int64_t pow2C = c & (-c);
+      for (int i = 0; i < llvm::Log2_64(pow2C); i++) {
         bases_inv[d][i] = {0};
       }
     }

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -14,6 +14,7 @@
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/StrUtil.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/MathExtras.h"
 
 #define DEBUG_TYPE "ttgpu_to_llvm"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -668,6 +669,30 @@ std::optional<LLVM::AtomicOrdering> getMemoryOrdering(MemSemantic memOrdering);
 llvm::MapVector<StringAttr, int32_t> getAllFreeVarMasks(MLIRContext *ctx);
 
 llvm::MapVector<StringAttr, int32_t> getFreeVariableMasks(Type type);
+
+/// Clamp vec size for NPOT dims: round down to a pow2 load/store width, then
+/// clamp to the alignment of a non-pow2 sizePerThread (Blocked only; Slice/
+/// Linear don't reach here). No-op for pow2, so safe to run unconditionally
+/// (not flag-gated).
+inline unsigned clampVecSizeForNpot(unsigned vec, RankedTensorType tensorTy) {
+  if (vec <= 1)
+    return vec; // avoids Log2_32(0) UB
+  if (!llvm::isPowerOf2_32(vec))
+    vec = 1u << llvm::Log2_32(vec);
+  if (!tensorTy)
+    return vec;
+  if (auto blocked =
+          dyn_cast<triton::gpu::BlockedEncodingAttr>(tensorTy.getEncoding())) {
+    auto contOrder = triton::gpu::getOrder(tensorTy);
+    unsigned spt = blocked.getSizePerThread()[contOrder[0]];
+    if (spt > 0 && !llvm::isPowerOf2_32(spt)) {
+      // Largest pow2 divisor (lowest set bit) = the guaranteed alignment.
+      unsigned maxAligned = spt & (0u - spt);
+      vec = std::min(vec, maxAligned);
+    }
+  }
+  return vec;
+}
 
 inline bool isCanonicalIndex(unsigned index, unsigned freeVarMask) {
   return (index & freeVarMask) == 0;

--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -7,6 +7,7 @@
 
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/Support/MathExtras.h"
 #include <algorithm>
 #include <numeric>
 
@@ -51,6 +52,55 @@ unsigned
 getNumElementsPerThread(Operation *op, SmallVector<unsigned> order,
                         triton::ModuleAxisInfoAnalysis &axisInfoAnalysis,
                         ArrayRef<int64_t> shape);
+
+// Returns true if any tensor dim is non-power-of-2. Pow2-assuming passes
+// should skip such tensors to avoid crashes in the layout algebra.
+inline bool hasNpotShape(RankedTensorType ty) {
+  return llvm::any_of(ty.getShape(), [](int64_t d) {
+    return d > 0 && !llvm::isPowerOf2_64(d);
+  });
+}
+
+// Returns true if the encoding's toLinearLayout can handle NPOT shapes
+// correctly. Encodings that produce valid modular LinearLayouts for NPOT
+// include: blocked, slice (inherits from parent), linear, MMAv2 (Ampere),
+// MMAv3+ (Hopper/Blackwell), and dot_op whose parent is safe. NOT safe: MMAv1.
+inline bool npotSafeForLinearLayout(Attribute encoding) {
+  if (!encoding) {
+    return false;
+  }
+  if (isa<triton::gpu::BlockedEncodingAttr, triton::gpu::LinearEncodingAttr>(
+          encoding)) {
+    return true;
+  }
+  if (auto mma = dyn_cast<triton::gpu::NvidiaMmaEncodingAttr>(encoding)) {
+    return mma.getVersionMajor() >= 2;
+  }
+  if (auto dotOp = dyn_cast<triton::gpu::DotOperandEncodingAttr>(encoding)) {
+    return npotSafeForLinearLayout(dotOp.getParent());
+  }
+  if (auto slice = dyn_cast<triton::gpu::SliceEncodingAttr>(encoding)) {
+    return npotSafeForLinearLayout(slice.getParent());
+  }
+  if (isa<triton::gpu::SharedEncodingTrait>(encoding)) {
+    return true;
+  }
+  // TODO: AMD MFMA/WMMA fall through to false (conservative shared-memory cvt).
+  // The AMD NPOT lane will need to add them here to avoid over-conservatism.
+  return false;
+}
+
+// True if a src->dst conversion is safe to feed to cvtNeedsSharedMemory /
+// toLinearLayout: always for pow2 shapes, and for NPOT shapes only when both
+// encodings produce valid modular LinearLayouts (else the modular solver hangs
+// or crashes). Callers skip the conversion when this is false.
+inline bool npotCvtSafe(RankedTensorType srcTy, RankedTensorType dstTy) {
+  if (!hasNpotShape(srcTy) && !hasNpotShape(dstTy)) {
+    return true;
+  }
+  return npotSafeForLinearLayout(srcTy.getEncoding()) &&
+         npotSafeForLinearLayout(dstTy.getEncoding());
+}
 
 // Returns whether the op is a "view op", i.e. doesn't move any data
 bool isView(Operation *op);

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -47,7 +47,7 @@ unsigned getNumScratchElemsSwizzledCvt(RankedTensorType srcTy,
   auto bitwidth = getBitwidth(srcTy);
   auto smem = gpu::optimalSwizzlingLdSt(srcLayout, dstLayout, bitwidth);
   auto reps = smem.getInDimSize(StringAttr::get(ctx, "reps"));
-  return smem.getTotalOutDimSize() / reps;
+  return smem.getTotalOutDimSizeProduct() / reps;
 }
 
 // Both `atomic_cas` and `atomic_rmw` may need scratch memory to store values

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -17,6 +17,7 @@
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/Support/MathExtras.h"
 
 namespace mlir {
 
@@ -159,6 +160,12 @@ SmallVector<unsigned> ReduceOpHelper::getScratchRepShape() {
 
 unsigned ReduceOpHelper::getScratchSizeInBytes() {
   auto smemShape = getScratchRepShape();
+  // Round an NPOT reduction axis up to pow2 (the inter-warp shuffle butterfly
+  // needs a pow2 axis); no-op for pow2 axes. product()==0 short-circuits the
+  // {0,0} warp-sync sentinel before indexing smemShape[axis] (OOB when
+  // rank>=3).
+  if (product<unsigned>(smemShape) > 0 && !llvm::isPowerOf2_32(smemShape[axis]))
+    smemShape[axis] = llvm::NextPowerOf2(smemShape[axis]);
   auto elems = product<unsigned>(smemShape);
 
   unsigned bytesPerElem = 0;

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -13,6 +13,7 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
@@ -979,14 +980,28 @@ bool supportMMA(triton::DotOp op, int version) {
     // If k size is smaller than the native mma size, we cannot use MMA.
     if (k < 256 / aElemTy.getIntOrFloatBitWidth())
       return false;
+    // NPOT K with swizzle=0 (K*elemBytes not a multiple of the 32B minimum
+    // swizzle granule): the SMEM alloc rounds K to pow2 and WGMMA would read
+    // uninitialized padding, so fall back to a non-MMA path.
+    if (!llvm::isPowerOf2_64(k)) {
+      // Compute in bits (256 bits == the 32B granule) so sub-byte element types
+      // are not silently zeroed by integer division of the byte width.
+      int64_t contigBits = (int64_t)k * aElemTy.getIntOrFloatBitWidth();
+      if (contigBits % 256 != 0) {
+        return false;
+      }
+    }
     auto retShapePerCTA = getShapePerCTA(retType);
     auto rank = retShapePerCTA.size();
     int numWarps = lookupNumWarps(op);
     // TODO(Keren): for now, fallback to MMAv2 if handling batch matmul.
     if (rank == 3)
       return false;
-    if (!(numWarps % 4 == 0 && retShapePerCTA[rank - 2] % 64 == 0 &&
-          retShapePerCTA[rank - 1] % 16 == 0 &&
+    // Pow2 M requires M%64 (routes pow2 GEMMs to MMAv2); NPOT M only M%16.
+    int64_t mDimV3 = retShapePerCTA[rank - 2];
+    bool mOkV3 =
+        llvm::isPowerOf2_64(mDimV3) ? (mDimV3 % 64 == 0) : (mDimV3 % 16 == 0);
+    if (!(numWarps % 4 == 0 && mOkV3 && retShapePerCTA[rank - 1] % 16 == 0 &&
           (llvm::isa<Float8E5M2Type, Float8E4M3FNType>(aElemTy) ||
            aElemTy.isInteger(8) || aElemTy.isF16() || aElemTy.isBF16() ||
            aElemTy.isF32()))) {
@@ -997,6 +1012,26 @@ bool supportMMA(triton::DotOp op, int version) {
         (llvm::isa<Float8E5M2Type, Float8E4M3FNType>(aElemTy)) &&
         cast<RankedTensorType>(op.getType()).getElementType().isF32()) {
       return false;
+    }
+  }
+  // MMAv2 (Ampere and consumer Blackwell) supports NPOT K (multiple of instrK);
+  // NPOT M/N are rejected and fall to FMA.
+  if (version == 2) {
+    RankedTensorType typeA2 = op.getA().getType();
+    int k2 = typeA2.getShape().back();
+    // Only NPOT K is constrained (must be a multiple of instrK); pow2 K
+    // (incl. K < instrK, e.g. f8 K=16) keeps upstream MMAv2 behaviour.
+    if (!llvm::isPowerOf2_64(k2)) {
+      int instrK = 256 / aElemTy.getIntOrFloatBitWidth();
+      if (k2 % instrK != 0) {
+        return false;
+      }
+    }
+    auto retShapePerCTA = getShapePerCTA(op.getType());
+    for (auto d : retShapePerCTA) {
+      if (d > 0 && !llvm::isPowerOf2_64(d)) {
+        return false;
+      }
     }
   }
   if (aElemTy.isF32() && bElemTy.isF32()) {
@@ -1057,7 +1092,34 @@ LinearLayout minimalCvtLayout(Type srcTy_, Type dstTy_) {
   return comp;
 }
 
+// Helper: true when an NPOT shape meets an MMA-family encoding. There
+// invertAndCompose's modular solver (lstsqModular) can emit aliased bases --
+// distinct register/lane offsets collapsing onto one -- instead of a clean
+// permutation, so the register-reorder and warp-shuffle fast paths are unsafe
+// and callers must route the conversion through shared memory.
+static bool npotMmaConversion(RankedTensorType srcTy, RankedTensorType dstTy) {
+  if (!hasNpotShape(srcTy) && !hasNpotShape(dstTy)) {
+    return false;
+  }
+  auto hasMmaFamily = [](Attribute enc) {
+    if (isa<triton::gpu::NvidiaMmaEncodingAttr>(enc)) {
+      return true;
+    }
+    if (auto dot = dyn_cast<triton::gpu::DotOperandEncodingAttr>(enc)) {
+      return isa<triton::gpu::NvidiaMmaEncodingAttr>(dot.getParent());
+    }
+    return false;
+  };
+  return hasMmaFamily(srcTy.getEncoding()) || hasMmaFamily(dstTy.getEncoding());
+}
+
 bool cvtReordersRegisters(RankedTensorType srcTy, RankedTensorType dstTy) {
+  // NPOT + MMA: invertAndCompose's modular solver can alias bases here (see
+  // npotMmaConversion), so a register reorder would be wrong -- report "no" and
+  // let the conversion fall to the shared-memory path.
+  if (npotMmaConversion(srcTy, dstTy)) {
+    return false;
+  }
   auto layout = minimalCvtLayout(srcTy, dstTy);
   MLIRContext *ctx = srcTy.getContext();
   auto kRegister = StringAttr::get(ctx, "register");
@@ -1066,6 +1128,12 @@ bool cvtReordersRegisters(RankedTensorType srcTy, RankedTensorType dstTy) {
 }
 
 bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
+  // getWarpLayoutConvertDecomposition is a pow2-only GF(2) bit-permutation and
+  // never terminates on a modular/NPOT layout -- this is the actual compile
+  // hang -- so bail for any NPOT shape.
+  if (hasNpotShape(srcTy) || hasNpotShape(dstTy)) {
+    return false;
+  }
   auto layout = minimalCvtLayout(srcTy, dstTy);
   MLIRContext *ctx = srcTy.getContext();
   auto kRegister = StringAttr::get(ctx, "register");
@@ -1079,6 +1147,18 @@ bool cvtNeedsWarpShuffle(RankedTensorType srcTy, RankedTensorType dstTy) {
 }
 
 bool cvtNeedsSharedMemory(RankedTensorType srcTy, RankedTensorType dstTy) {
+  // For NPOT shapes, toLinearLayout may crash if the encoding doesn't support
+  // modular layouts. Conservatively assume shared memory is needed for unsafe
+  // encodings.
+  if (hasNpotShape(srcTy) || hasNpotShape(dstTy)) {
+    bool srcSafe = npotSafeForLinearLayout(srcTy.getEncoding());
+    bool dstSafe = npotSafeForLinearLayout(dstTy.getEncoding());
+    if (!srcSafe || !dstSafe) {
+      return true;
+    }
+  }
+  // NPOT+MMA: the two guards above both return false, so this returns true
+  // without calling invertAndCompose.
   return !cvtReordersRegisters(srcTy, dstTy) &&
          !cvtNeedsWarpShuffle(srcTy, dstTy);
 }

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -12,6 +12,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/GenericSwizzling.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
 
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 
@@ -82,6 +83,26 @@ struct ConvertLayoutOpConversion
     } else {
       // Cast 5. The two layouts are equivalent. We should probably remove
       // these in RemoveLayoutConversion.
+      //
+      // NPOT: minimalCvtLayout's quotient uses squareSublayoutIsIdentity (pure
+      // GF(2), basis == 1<<b), which false-positives on modular register dims
+      // and collapses two different ADD-mod-N maps to a no-op -> scramble. If
+      // either side is modular and they are not truly equal, route the real
+      // remap through transferWithinThread. pow2 unaffected (isModular() is
+      // false).
+      if (srcLayout.isModular() || dstLayout.isModular()) {
+        static const bool allowNpot =
+            ::mlir::triton::tools::getBoolEnv("TRITON_ALLOW_NPOT");
+        if (allowNpot && srcLayout != dstLayout) {
+          // Rebuild the register remap without the quotient; lane/warp/block
+          // are identity at Case 5, so the register sublayout is the full
+          // conversion.
+          LinearLayout fullConversion = dstLayout.invertAndCompose(srcLayout);
+          LinearLayout regConversion =
+              fullConversion.sublayout({kRegister}, {kRegister});
+          return transferWithinThread(op, regConversion, adaptor, rewriter);
+        }
+      }
       rewriter.replaceOp(op, adaptor.getSrc());
       return success();
     }

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -3,6 +3,11 @@
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Tools/LayoutUtils.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/Support/MathExtras.h"
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -45,10 +50,21 @@ public:
     Location loc = op->getLoc();
 
     auto srcValues = unpackInputs(loc, op, adaptor, rewriter);
+
+    // Identity-fill phantom slots before the reduce; maskers below no-op for
+    // pow2 (see the "NPOT reduction wrapping prediction" section for why).
+    if (failed(maskWrappedRegisters(helper, op, srcValues, rewriter)))
+      return failure();
+
     std::map<SmallVector<unsigned>, SmallVector<Value>> accs;
     std::map<SmallVector<unsigned>, SmallVector<Value>> indices;
     // First reduce all the values along axis within each thread.
     reduceWithinThreads(helper, srcValues, accs, indices, rewriter);
+
+    // Identity-fill phantom lane/warp accumulators before the cross-thread
+    // butterfly + inter-warp accumulation.
+    if (failed(maskWrappedLanesAndWarps(helper, op, accs, rewriter)))
+      return failure();
 
     // Then reduce across threads within a warp.
     reduceWithinWarps(helper, accs, rewriter);
@@ -76,7 +92,8 @@ public:
     //
     // Each thread needs to process:
     //   elemsPerThread = sizeInterWarps * s1 * s2 .. Sn / numThreads
-    accumulatePartialReductions(helper, smemBases, rewriter);
+    if (failed(accumulatePartialReductions(helper, smemBases, rewriter)))
+      return failure();
 
     // We could avoid this barrier in some of the layouts, however this is not
     // the general case.
@@ -157,6 +174,177 @@ private:
     return true;
   }
 
+  // Get the neutral/identity element for the reduction operation in the combine
+  // region. Works around upstream not supporting MaxNumFOp/MinNumFOp.
+  std::optional<TypedAttr> getNeutralElement(Operation *op) const {
+    if (isa<arith::MaxNumFOp, arith::MinNumFOp>(op)) {
+      OpBuilder builder(op->getContext());
+      Type resultType = op->getResult(0).getType();
+      const llvm::fltSemantics &semantic =
+          llvm::cast<FloatType>(resultType).getFloatSemantics();
+      if (isa<arith::MaxNumFOp>(op))
+        return builder.getFloatAttr(
+            resultType, APFloat::getInf(semantic, /*Negative=*/true));
+      if (isa<arith::MinNumFOp>(op))
+        return builder.getFloatAttr(
+            resultType, APFloat::getInf(semantic, /*Negative=*/false));
+    }
+    return mlir::arith::getNeutralElement(op);
+  }
+
+  // Get the single non-terminator op from the combine region, if it exists.
+  std::optional<Operation *> getReductionOp(triton::ReduceOp op) const {
+    Region &region = op.getCombineOp();
+    if (region.getBlocks().size() != 1)
+      return std::nullopt;
+    Block &block = region.front();
+    auto body = block.without_terminator();
+    if (std::distance(body.begin(), body.end()) != 1)
+      return std::nullopt;
+    return &block.front();
+  }
+
+  // Classify a compare op as (isMax, isSigned). nullopt for non-directional
+  // predicates (EQ/NE/unordered-only). Float compares report isSigned=true
+  // (unused for floats). Integer compares report signedness from the predicate.
+  static std::optional<std::pair<bool, bool>>
+  classifyCmpPredicate(Operation *cmp) {
+    if (auto f = dyn_cast<arith::CmpFOp>(cmp)) {
+      using P = arith::CmpFPredicate;
+      // Ordered predicates only; unordered (true on NaN) are treated
+      // conservatively (unrecognized -> reject) so a -inf/INT_MIN phantom can't
+      // beat a real NaN.
+      switch (f.getPredicate()) {
+      case P::OGT:
+      case P::OGE:
+        return std::pair<bool, bool>{true, true};
+      case P::OLT:
+      case P::OLE:
+        return std::pair<bool, bool>{false, true};
+      default:
+        return std::nullopt;
+      }
+    }
+    if (auto i = dyn_cast<arith::CmpIOp>(cmp)) {
+      using P = arith::CmpIPredicate;
+      switch (i.getPredicate()) {
+      case P::sgt:
+      case P::sge:
+        return std::pair<bool, bool>{true, true};
+      case P::slt:
+      case P::sle:
+        return std::pair<bool, bool>{false, true};
+      case P::ugt:
+      case P::uge:
+        return std::pair<bool, bool>{true, false};
+      case P::ult:
+      case P::ule:
+        return std::pair<bool, bool>{false, false};
+      default:
+        return std::nullopt;
+      }
+    }
+    return std::nullopt;
+  }
+
+  // Identities for a multi-operand arg-reduce (argmax/argmin): only the value
+  // operand gets the losing extreme so a phantom slot never wins the select;
+  // the index operand is left unchanged. nullopt for any unrecognized combine.
+  std::optional<SmallVector<std::optional<TypedAttr>>>
+  getArgReduceIdentities(triton::ReduceOp op) const {
+    unsigned n = op.getNumOperands();
+    if (n < 2)
+      return std::nullopt;
+    Region &region = op.getCombineOp();
+    if (!region.hasOneBlock())
+      return std::nullopt;
+    Block &block = region.front();
+    if (block.getNumArguments() != 2 * n)
+      return std::nullopt;
+    // Operand 0 is the reduced value; its two sides are args[0] and args[n].
+    Value lhs = block.getArgument(0);
+    Value rhs = block.getArgument(n);
+    Type valTy = lhs.getType();
+    if (!valTy.isIntOrFloat())
+      return std::nullopt;
+
+    // Read the direction (max/min) from the canonical "value0 <pred> value1"
+    // compare that drives the selects.
+    std::optional<bool> isMax;
+    bool isSigned = true;
+    for (Operation &inner : block.without_terminator()) {
+      Value cmpLhs, cmpRhs;
+      if (auto f = dyn_cast<arith::CmpFOp>(&inner)) {
+        cmpLhs = f.getLhs();
+        cmpRhs = f.getRhs();
+      } else if (auto i = dyn_cast<arith::CmpIOp>(&inner)) {
+        cmpLhs = i.getLhs();
+        cmpRhs = i.getRhs();
+      } else {
+        continue;
+      }
+      if (cmpLhs != lhs || cmpRhs != rhs)
+        continue;
+      if (auto classified = classifyCmpPredicate(&inner)) {
+        isMax = classified->first;
+        isSigned = classified->second;
+        break;
+      }
+    }
+    if (!isMax)
+      return std::nullopt;
+
+    OpBuilder builder(op.getContext());
+    TypedAttr valIdentity;
+    if (auto ft = dyn_cast<FloatType>(valTy)) {
+      valIdentity = builder.getFloatAttr(
+          ft, APFloat::getInf(ft.getFloatSemantics(), /*Negative=*/*isMax));
+    } else {
+      auto it = cast<IntegerType>(valTy);
+      unsigned w = it.getWidth();
+      APInt v = *isMax ? (isSigned ? APInt::getSignedMinValue(w)
+                                   : APInt::getMinValue(w))
+                       : (isSigned ? APInt::getSignedMaxValue(w)
+                                   : APInt::getMaxValue(w));
+      valIdentity = builder.getIntegerAttr(it, v);
+    }
+    SmallVector<std::optional<TypedAttr>> identities(n, std::nullopt);
+    identities[0] = valIdentity;
+    return identities;
+  }
+
+  // Select the reduction identity into acc where `outOfRange` is true. Handles
+  // single-op reductions (known scalar neutral) and arg-reduce (value operand
+  // only). Returns false if no identity could be determined.
+  bool predicateAccWithIdentity(ConversionPatternRewriter &rewriter,
+                                Location loc, SmallVector<Value> &acc,
+                                triton::ReduceOp op, Value outOfRange) const {
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    // Single-operand reduction with a known scalar identity (sum, max, ...).
+    if (auto reductionOp = getReductionOp(op)) {
+      if (auto neutralAttr = getNeutralElement(*reductionOp)) {
+        for (unsigned i = 0; i < acc.size(); ++i) {
+          Value identity = arith::ConstantOp::create(
+              rewriter, loc, acc[i].getType(), cast<TypedAttr>(*neutralAttr));
+          acc[i] = b.select(outOfRange, identity, acc[i]);
+        }
+        return true;
+      }
+    }
+    // Multi-operand arg-reduce (argmax/argmin): mask only the value operand.
+    if (auto identities = getArgReduceIdentities(op)) {
+      for (unsigned i = 0; i < acc.size() && i < identities->size(); ++i) {
+        if (!(*identities)[i])
+          continue;
+        Value identity = arith::ConstantOp::create(
+            rewriter, loc, acc[i].getType(), *(*identities)[i]);
+        acc[i] = b.select(outOfRange, identity, acc[i]);
+      }
+      return true;
+    }
+    return false;
+  }
+
   SmallVector<SmallVector<Value>>
   unpackInputs(Location loc, triton::ReduceOp op, OpAdaptor adaptor,
                ConversionPatternRewriter &rewriter) const {
@@ -179,6 +367,308 @@ private:
             triton::ReduceOp op) const {
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     b.barrier(triton::gpu::AddrSpace::Local);
+  }
+
+  // === NPOT reduction wrapping prediction ===
+  // NPOT axis rounded up to pow2 creates phantom register/lane/warp slots.
+  // Reconstruct the raw position as the sum of per-bit bases, flag it >=
+  // dimSize, and overwrite with the reduction identity before the reduce.
+  // Pow2/MMA axes skip this -> byte-identical.
+
+  // True when the axis is NPOT (rounds up, creating phantom slots) and uses the
+  // register/lane/warp basis decomposition. False for pow2 and MMA/dot-operand
+  // encodings, so every caller short-circuits (byte-identical to pow2).
+  static bool axisNeedsNpotWrapMasking(int64_t dimSize, Attribute enc) {
+    return !llvm::isPowerOf2_64(dimSize) &&
+           !isa<NvidiaMmaEncodingAttr, DotOperandEncodingAttr>(enc);
+  }
+
+  // Per-axis lane/warp bases from a pow2 LinearLayout, with their summed max
+  // contributions (used to short-circuit before emitting runtime IR).
+  struct AxisLaneWarpBases {
+    SmallVector<unsigned> laneAxisBases;
+    SmallVector<unsigned> warpAxisBases;
+    unsigned maxLaneContrib = 0;
+    unsigned maxWarpContrib = 0;
+  };
+
+  // Extract lane/warp axis bases from `pow2LL` for output dim `axis` and sum
+  // each set into maxLaneContrib/maxWarpContrib. No IR emission.
+  AxisLaneWarpBases extractAxisLaneWarpBases(const LinearLayout &pow2LL,
+                                             unsigned axis,
+                                             MLIRContext *ctx) const {
+    auto kLane = StringAttr::get(ctx, "lane");
+    auto kWarp = StringAttr::get(ctx, "warp");
+
+    AxisLaneWarpBases out;
+    const auto &laneBases = pow2LL.getBases().find(kLane)->second;
+    for (const auto &basis : laneBases)
+      out.laneAxisBases.push_back(basis[axis]);
+    const auto &warpBases = pow2LL.getBases().find(kWarp)->second;
+    for (const auto &basis : warpBases)
+      out.warpAxisBases.push_back(basis[axis]);
+
+    for (auto v : out.laneAxisBases)
+      out.maxLaneContrib += v;
+    for (auto v : out.warpAxisBases)
+      out.maxWarpContrib += v;
+    return out;
+  }
+
+  // Build the pre-modulo pow2 LinearLayout (reduction axis rounded up) and its
+  // lane/warp axis bases. Returns both so callers needing the register bases
+  // can reuse the layout.
+  std::pair<LinearLayout, AxisLaneWarpBases>
+  buildPow2AxisLayout(ArrayRef<int64_t> srcShape, Attribute srcEncoding,
+                      unsigned axis) const {
+    SmallVector<int64_t> pow2Shape(srcShape.begin(), srcShape.end());
+    pow2Shape[axis] = llvm::NextPowerOf2(srcShape[axis]);
+    auto pow2LL = triton::gpu::toLinearLayout(pow2Shape, srcEncoding);
+    auto bases =
+        extractAxisLaneWarpBases(pow2LL, axis, srcEncoding.getContext());
+    return {std::move(pow2LL), std::move(bases)};
+  }
+
+  // Reconstruct the runtime axis contribution of `id` (a lane or warp id) from
+  // its per-bit position bases: acc += bases[i] for every set bit i of `id`.
+  // Zero bases are skipped (they emit no IR). Emits the same op sequence as the
+  // per-bit loops it replaces, so codegen is unchanged.
+  Value buildContrib(ArrayRef<unsigned> bases, Value id, Location loc,
+                     ConversionPatternRewriter &rewriter) const {
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    Value acc = b.i32_val(0);
+    for (unsigned i = 0; i < bases.size(); ++i) {
+      if (bases[i] == 0)
+        continue;
+      Value bit = b.and_(b.lshr(id, b.i32_val(i)), b.i32_val(1));
+      acc = b.add(acc, b.mul(bit, b.i32_val(bases[i])));
+    }
+    return acc;
+  }
+
+  // Build the runtime lane+warp contribution to the axis (i32) from the
+  // axis-specific lane/warp bases extracted by extractAxisLaneWarpBases.
+  Value buildAxisLaneWarpContrib(const AxisLaneWarpBases &bases, Location loc,
+                                 ConversionPatternRewriter &rewriter) const {
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+
+    Value laneContrib =
+        buildContrib(bases.laneAxisBases, laneId, loc, rewriter);
+    Value warpContrib =
+        buildContrib(bases.warpAxisBases, warpId, loc, rewriter);
+    return b.add(laneContrib, warpContrib);
+  }
+
+  // Per-register wrapping predicates: preds[i] is true when register i's raw
+  // axis offset can reach dimSize, null when it never wraps. Empty if the axis
+  // never wraps at all.
+  SmallVector<Value>
+  computeRegisterWrappingPreds(ArrayRef<int64_t> srcShape,
+                               Attribute srcEncoding, Location loc,
+                               unsigned axis, unsigned numTotalRegs,
+                               ConversionPatternRewriter &rewriter) const {
+    int64_t dimSize = srcShape[axis];
+    if (!axisNeedsNpotWrapMasking(dimSize, srcEncoding))
+      return {};
+
+    // Pre-modulo pow2 layout: positions >= dimSize are the wrapped ones.
+    auto pow2Layout = buildPow2AxisLayout(srcShape, srcEncoding, axis);
+    const LinearLayout &pow2LL = pow2Layout.first;
+    const AxisLaneWarpBases &bases = pow2Layout.second;
+    auto *ctx = srcEncoding.getContext();
+    auto kRegister = StringAttr::get(ctx, "register");
+
+    unsigned numRegs = pow2LL.getInDimSize(kRegister);
+
+    // Extract register bases for the reduction axis from the pow2 layout.
+    const auto &regBases = pow2LL.getBases().find(kRegister)->second;
+    unsigned regBasisCount = regBases.size();
+
+#ifndef NDEBUG
+    // Precondition for the ADD reconstruction below: the ADD of per-bit axis
+    // contributions equals the true GF(2)/XOR axis position only when the
+    // pow2-rounded layout's per-axis register bases are distinct powers of two.
+    // Verify each non-zero axis-component base is a power of two and that no
+    // two are equal (pairwise distinct), so ADD == XOR.
+    {
+      llvm::DenseSet<unsigned> seenAxisBases;
+      for (unsigned bit = 0; bit < regBasisCount; ++bit) {
+        unsigned axisBase = regBases[bit][axis];
+        if (axisBase == 0)
+          continue;
+        assert(llvm::isPowerOf2_64(axisBase) &&
+               "NPOT reduce: axis register base must be a power of two so the "
+               "ADD reconstruction equals the XOR axis position");
+        assert(seenAxisBases.insert(axisBase).second &&
+               "NPOT reduce: axis register bases must be pairwise distinct so "
+               "the ADD reconstruction equals the XOR axis position");
+      }
+    }
+#endif
+
+    // Compute raw register contribution to the axis for each register index. In
+    // the pow2-rounded layout the per-axis register bases are distinct powers
+    // of two (asserted above), so the ADD reconstruction below equals the XOR
+    // axis position: bases combined via XOR equal addition because they are
+    // linearly independent over GF(2).
+    SmallVector<unsigned> rawRegOffsets(numRegs, 0);
+    for (unsigned r = 0; r < numRegs; ++r) {
+      for (unsigned bit = 0; bit < regBasisCount; ++bit) {
+        if (r & (1u << bit))
+          rawRegOffsets[r] += regBases[bit][axis];
+      }
+    }
+
+    // Check if wrapping can occur at all.
+    unsigned maxRegOffset =
+        *std::max_element(rawRegOffsets.begin(), rawRegOffsets.end());
+    unsigned maxRawTotal =
+        maxRegOffset + bases.maxLaneContrib + bases.maxWarpContrib;
+    if (maxRawTotal < static_cast<unsigned>(dimSize))
+      return {};
+
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    Value threadBase = buildAxisLaneWarpContrib(bases, loc, rewriter);
+
+    // Compute per-register predicates. Group registers by their axis-only
+    // contribution to avoid redundant runtime comparisons.
+    llvm::DenseMap<unsigned, Value> axisPredCache;
+    unsigned maxThreadBase = bases.maxLaneContrib + bases.maxWarpContrib;
+
+    auto getAxisPred = [&](unsigned regOff) -> Value {
+      auto it = axisPredCache.find(regOff);
+      if (it != axisPredCache.end())
+        return it->second;
+      Value pred;
+      if (regOff + maxThreadBase < static_cast<unsigned>(dimSize)) {
+        pred = {};
+      } else if (regOff >= static_cast<unsigned>(dimSize)) {
+        pred = b.true_val();
+      } else {
+        Value rawTotal = b.add(threadBase, b.i32_val(regOff));
+        pred = b.icmp_uge(rawTotal, b.i32_val(dimSize));
+      }
+      axisPredCache[regOff] = pred;
+      return pred;
+    };
+
+    // Build per-register predicates. For multi-dim tensors, each total register
+    // index maps to an axis sub-index via the register bases.
+    SmallVector<Value> preds(numTotalRegs);
+    for (unsigned i = 0; i < numTotalRegs; ++i) {
+      unsigned regAxisOff = 0;
+      for (unsigned bit = 0; bit < regBasisCount; ++bit) {
+        if (i & (1u << bit))
+          regAxisOff += regBases[bit][axis];
+      }
+      preds[i] = getAxisPred(regAxisOff);
+    }
+    return preds;
+  }
+
+  // Predicate that is true for lanes/warps holding wrapped/duplicate data.
+  // Null when no wrapping occurs (pow2 dim or lane+warp coverage <= dimSize).
+  Value computeModularWrappingPred(ArrayRef<int64_t> srcShape,
+                                   Attribute srcEncoding, Location loc,
+                                   unsigned axis,
+                                   ConversionPatternRewriter &rewriter) const {
+    int64_t dimSize = srcShape[axis];
+    if (!axisNeedsNpotWrapMasking(dimSize, srcEncoding))
+      return {};
+
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    // Build pow2 layout to get raw (pre-modulo) offsets.
+    auto bases = buildPow2AxisLayout(srcShape, srcEncoding, axis).second;
+
+    // Check if total lane+warp coverage can exceed dimSize.
+    unsigned totalCoverage = bases.maxLaneContrib + bases.maxWarpContrib;
+    if (totalCoverage < static_cast<unsigned>(dimSize))
+      return {};
+
+    Value rawOffset = buildAxisLaneWarpContrib(bases, loc, rewriter);
+    return b.icmp_uge(rawOffset, b.i32_val(dimSize));
+  }
+
+  // Predicate that is true for phantom warps (raw axis offset out of range),
+  // which must not write to smem (they would clobber a real warp's slot). Null
+  // when no warp can wrap on its own (pow2 dim or warp coverage <= dimSize).
+  Value computeWarpWrappingPred(ArrayRef<int64_t> srcShape,
+                                Attribute srcEncoding, Location loc,
+                                unsigned axis, Value warpId,
+                                ConversionPatternRewriter &rewriter) const {
+    int64_t dimSize = srcShape[axis];
+    if (!axisNeedsNpotWrapMasking(dimSize, srcEncoding))
+      return {};
+
+    auto bases = buildPow2AxisLayout(srcShape, srcEncoding, axis).second;
+
+    // No warp can exceed dimSize on its own -> no phantom warps.
+    if (bases.maxWarpContrib < static_cast<unsigned>(dimSize))
+      return {};
+
+    auto b = TritonLLVMOpBuilder(loc, rewriter);
+    // Runtime warp contribution to the axis from the warp axis bases.
+    Value warpContrib =
+        buildContrib(bases.warpAxisBases, warpId, loc, rewriter);
+    return b.icmp_uge(warpContrib, b.i32_val(dimSize));
+  }
+
+  // Identity-fill wrapped register slots before within-thread reduction folds
+  // them in (empty preds = no-op). Returns failure() when wrapping is present
+  // but the combine identity is unknown -- reject rather than miscompute.
+  LogicalResult
+  maskWrappedRegisters(ReduceOpHelper &helper, triton::ReduceOp op,
+                       SmallVector<SmallVector<Value>> &srcValues,
+                       ConversionPatternRewriter &rewriter) const {
+    Location loc = op.getLoc();
+    unsigned axis = op.getAxis();
+    SmallVector<Value> regPreds = computeRegisterWrappingPreds(
+        helper.getSrcShape(), helper.getSrcLayout(), loc, axis,
+        srcValues.size(), rewriter);
+    if (regPreds.empty())
+      return success();
+
+    // regPreds is sized to srcValues.size() (== 2^#regBases) by construction;
+    // the NPOT fold reduces basis values, not the basis count.
+    for (unsigned i = 0; i < srcValues.size(); ++i) {
+      // A null predicate means this register never wraps (purely in-range).
+      if (!regPreds[i])
+        continue;
+      if (!predicateAccWithIdentity(rewriter, loc, srcValues[i], op,
+                                    regPreds[i]))
+        return op.emitError(
+            "NPOT reduction over an axis with wrapped register slots requires "
+            "a known reduction identity, but the combine op's identity could "
+            "not be determined");
+    }
+    return success();
+  }
+
+  // Identity-fill phantom lane/warp accumulators before the within-warp shuffle
+  // butterfly (one mask covers both intra-warp lanes and inter-warp warps).
+  // Null pred = no-op; returns failure() when wrapping is present but the
+  // combine identity is unknown.
+  LogicalResult maskWrappedLanesAndWarps(
+      ReduceOpHelper &helper, triton::ReduceOp op,
+      std::map<SmallVector<unsigned>, SmallVector<Value>> &accs,
+      ConversionPatternRewriter &rewriter) const {
+    Location loc = op.getLoc();
+    unsigned axis = op.getAxis();
+    Value lanePred = computeModularWrappingPred(
+        helper.getSrcShape(), helper.getSrcLayout(), loc, axis, rewriter);
+    if (!lanePred)
+      return success();
+
+    for (auto &it : accs) {
+      if (!predicateAccWithIdentity(rewriter, loc, it.second, op, lanePred))
+        return op.emitError(
+            "NPOT reduction over an axis with wrapped lane/warp slots requires "
+            "a known reduction identity, but the combine op's identity could "
+            "not be determined");
+    }
+    return success();
   }
 
   // Reduce along op axis for elements that are in the same thread. The
@@ -285,7 +775,16 @@ private:
                     std::map<SmallVector<unsigned>, SmallVector<Value>> &accs,
                     ConversionPatternRewriter &rewriter) const {
     triton::ReduceOp op = helper.getOperation();
-    unsigned sizeIntraWarps = helper.getIntraWarpSizeWithUniqueData();
+    // The shuffle butterfly in warpReduce halves the lane span each step and
+    // therefore requires a power-of-two lane count. For an NPOT reduction axis,
+    // getIntraWarpSizeWithUniqueData() can be NPOT (e.g. 3), which would make
+    // the butterfly skip lanes (3/2 -> a single xor-1 step, leaving lane 2
+    // unreduced). Round up to the next power of two so every real lane is
+    // visited; the phantom lanes in [realSize, pow2) were already identity-
+    // filled by maskWrappedLanesAndWarps, so they contribute nothing. For pow2
+    // axes this is a no-op (sizeIntraWarps is already pow2).
+    unsigned sizeIntraWarps =
+        llvm::PowerOf2Ceil(helper.getIntraWarpSizeWithUniqueData());
     unsigned threadOffsetOnReductionAxis =
         helper.getThreadOffsetOnReductionAxis();
     for (auto it : accs) {
@@ -372,9 +871,24 @@ private:
     Value write =
         b.and_(b.and_(isRepresentativeLane, isRepresentativeWarp), laneZero);
 
+    unsigned sizeInterWarps = helper.getInterWarpSizeWithUniqueData();
+
+    // NPOT warp collapse: when the reduction axis is NPOT, more warps may map
+    // onto the axis than there are unique warp slots (e.g. 4 warps over a dim
+    // of 96 -> getInterWarpSizeWithUniqueData() == 3). The extra warps are
+    // modular duplicates: their axis index (multiDimWarpId[axis] below) wraps
+    // (3 % 3 == 0), so they would write to the *same* smem slot as a real warp.
+    // Those duplicate warps hold identity (filled by maskWrappedLanesAndWarps),
+    // so the duplicate store races the real store and can clobber it with
+    // identity. Suppress writes from the phantom warps, identified from the raw
+    // (pre-collapse) warp axis offset >= dimSize. For pow2 axes there are no
+    // phantom warps so this guard is never added and codegen is unchanged.
+    if (Value warpPhantom = computeWarpWrappingPred(
+            srcShape, helper.getSrcLayout(), loc, axis, warpId, rewriter))
+      write = b.and_(write, b.icmp_eq(warpPhantom, b.i1_val(false)));
+
     Value warpIdAxis = multiDimWarpId[axis];
 
-    unsigned sizeInterWarps = helper.getInterWarpSizeWithUniqueData();
     unsigned numRegGroups = helper.getNumRegGroupsOnAxis();
     auto smemOrder = helper.getOrderWithAxisAtBeginning();
 
@@ -420,13 +934,22 @@ private:
 
   // Load the reduction of each warp and accumulate them to a final value and
   // store back to shared memory.
-  void accumulatePartialReductions(ReduceOpHelper &helper,
-                                   SmallVector<Value> &smemBases,
-                                   ConversionPatternRewriter &rewriter) const {
+  LogicalResult
+  accumulatePartialReductions(ReduceOpHelper &helper,
+                              SmallVector<Value> &smemBases,
+                              ConversionPatternRewriter &rewriter) const {
     triton::ReduceOp op = helper.getOperation();
     auto smemShape = helper.getScratchRepShape();
     unsigned elems = product<unsigned>(smemShape);
-    unsigned sizeInterWarps = helper.getInterWarpSizeWithUniqueData();
+    unsigned realInterWarps = helper.getInterWarpSizeWithUniqueData();
+    // The inter-warp shuffle butterfly (warpReduce below) halves the lane span
+    // each step and therefore requires a power-of-two count. For an NPOT
+    // reduction axis the per-warp axis count collapses to an NPOT value (e.g.
+    // 4 warps over a dim of 96 -> 3 unique warp slots), which would make the
+    // butterfly skip warp partials. Round up so every real partial is visited;
+    // the phantom slots in [realInterWarps, pow2) are identity-filled below so
+    // they contribute nothing. For pow2 axes this is a no-op.
+    unsigned sizeInterWarps = llvm::PowerOf2Ceil(realInterWarps);
     Location loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
@@ -442,6 +965,38 @@ private:
 
     unsigned elemsPerThread = std::max<unsigned>(elems / numThreads, 1);
     Value threadIsNeeded = b.icmp_slt(threadId, b.i32_val(elems));
+
+    // An inter-warp smem slot is phantom when the warp that owns it carries a
+    // raw axis offset >= dimSize (it wrapped): its store was suppressed (see
+    // computeWarpWrappingPred), so the load returns undef and the slot must be
+    // identity-filled before the butterfly folds it in. Counting unique warp
+    // bases (realInterWarps) is not enough -- e.g. 8 warps over a dim of 192
+    // reports 8 unique slots, yet warps 6,7 (raw 192,224) are phantom -- so
+    // detect phantoms from the warp axis bases directly. Only the single-
+    // register-group case maps a slot index contiguously onto the warp axis.
+    // For pow2 axes no warp wraps, so no phantom is found and the fill is
+    // skipped (byte-identical).
+    unsigned axis = op.getAxis();
+    ArrayRef<int64_t> srcShape = helper.getSrcShape();
+    Attribute srcEncoding = helper.getSrcLayout();
+    int64_t dimSize = srcShape[axis];
+    SmallVector<unsigned> warpAxisBases;
+    bool interWarpNeedsIdentity = false;
+    if (axisNeedsNpotWrapMasking(dimSize, srcEncoding) &&
+        helper.getNumRegGroupsOnAxis() == 1) {
+      warpAxisBases =
+          buildPow2AxisLayout(srcShape, srcEncoding, axis).second.warpAxisBases;
+      for (unsigned slot = 0; slot < sizeInterWarps && !interWarpNeedsIdentity;
+           ++slot) {
+        unsigned raw = 0;
+        for (unsigned i = 0; i < warpAxisBases.size(); ++i)
+          if (slot & (1u << i))
+            raw += warpAxisBases[i];
+        if (raw >= static_cast<unsigned>(dimSize))
+          interWarpNeedsIdentity = true;
+      }
+    }
+
     Value readOffset = threadId;
     for (unsigned round = 0; round < elemsPerThread; ++round) {
       SmallVector<Value> acc(op.getNumOperands());
@@ -451,6 +1006,20 @@ private:
             b.gep(smemBases[i].getType(), elemTy, smemBases[i], readOffset);
         acc[i] = targetInfo.loadShared(rewriter, loc, readPtr, elemTy,
                                        threadIsNeeded);
+      }
+      if (interWarpNeedsIdentity) {
+        // The slot's owning warp is its position within the pow2 inter-warp
+        // group; reconstruct that warp's raw axis offset from the warp bases
+        // (mirroring computeWarpWrappingPred) and flag it phantom when the
+        // offset reaches dimSize.
+        Value slotInGroup = b.urem(readOffset, b.i32_val(sizeInterWarps));
+        Value warpContrib =
+            buildContrib(warpAxisBases, slotInGroup, loc, rewriter);
+        Value isPhantom =
+            b.icmp_uge(warpContrib, b.i32_val(static_cast<int64_t>(dimSize)));
+        if (!predicateAccWithIdentity(rewriter, loc, acc, op, isPhantom))
+          return op.emitError("NPOT inter-warp reduction with phantom warp "
+                              "slots requires a known reduction identity");
       }
       warpReduce(rewriter, loc, acc, op, sizeInterWarps, 1 /* interleave */,
                  threadIsNeeded);
@@ -476,6 +1045,7 @@ private:
         readOffset = b.add(readOffset, b.i32_val(numThreads));
       }
     }
+    return success();
   }
 
   SmallVector<Value> loadAndReduceRegGroups(

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -115,10 +115,63 @@ Value matrixVectorProd(TritonLLVMOpBuilder &b, const LinearLayout &A, Value x) {
     return ret;
   };
   auto nCol = A.getTotalInDimSizeLog2();
-  auto nRow = A.getTotalOutDimSizeLog2();
+  // getTotalOutDimSizeLog2() asserts (debug) / silently truncates (opt) on
+  // modular layouts, and nRow is computed before the isModular() early-return,
+  // so getTotalOutDimSizeBits() is required here (pow2-equivalent, not
+  // optional).
+  auto nRow = A.getTotalOutDimSizeBits();
   SmallVector<int32_t> matrix = flatten(A.getBases().begin()->second);
   assert(matrix.size() == nCol);
 
+  // NPOT: accumulate ADD without an intermediate urem; applyNpotModulo does the
+  // single final modulo, which is equivalent for non-negative integers. No i32
+  // overflow: nCol <= ~20 bits and each basisValue < 2*outDimSize, so the sum
+  // stays < 2^25 for any practical dim.
+  if (A.isModular()) {
+    // Fast path for dense identity bases [1,2,...,2^(highBit-1)]: x mod
+    // 2^highBit == x & ((1u<<highBit)-1). Bail if a zero column sits below the
+    // highest set bit (a gap would leak that bit through the mask); trailing
+    // zero columns above the set bits are harmless.
+    unsigned nColU = static_cast<unsigned>(nCol);
+    bool isIdentity = true;
+    unsigned highBit = 0;
+    int firstZeroCol = -1;
+    for (unsigned col = 0; col < nColU; ++col) {
+      int32_t bv = matrix[col];
+      if (bv == 0) {
+        if (firstZeroCol < 0)
+          firstZeroCol = static_cast<int>(col);
+        continue;
+      }
+      // Set bit above an earlier zero column: the zero was a gap, not trailing.
+      if (firstZeroCol >= 0) {
+        isIdentity = false;
+        break;
+      }
+      if (bv != static_cast<int32_t>(1u << col)) {
+        isIdentity = false;
+        break;
+      }
+      highBit = col + 1;
+    }
+    if (isIdentity && highBit > 0)
+      return b.and_(x, b.i32_val((1u << highBit) - 1));
+
+    // General modular path: select+add per basis vector.
+    Value sum = b.i32_val(0);
+    for (unsigned col = 0; col < nColU; ++col) {
+      int32_t basisValue = matrix[col];
+      if (basisValue == 0)
+        continue;
+      Value bit = b.and_(x, b.i32_val(1u << col));
+      Value bitIsZero = b.icmp_eq(bit, b.i32_val(0));
+      Value term = b.select(bitIsZero, b.i32_val(0), b.i32_val(basisValue));
+      sum = b.add(sum, term);
+    }
+    return sum;
+  }
+
+  // Power-of-2 path: XOR-based optimization (unchanged)
   // Row-wise popcount to detect rows that appear exactly once across columns.
   uint32_t rowsUnique = 0;
   {
@@ -289,6 +342,78 @@ Value emitRedundantThreadPredicate(
 
 } // namespace triton::gpu
 
+// Cheap modulo for inputs provably < 2N: compare-and-subtract (2 ops vs
+// Barrett's 6; matters on AMD gfx950 where i64 multiply is slow).
+static Value smallModulo(TritonLLVMOpBuilder &b, Value x, int32_t N) {
+  Value cmp = b.icmp_uge(x, b.i32_val(N));
+  return b.select(cmp, b.sub(x, b.i32_val(N)), x);
+}
+
+// Largest input for which barrettModulo below is proven correct: the choice
+// k = 32 + ceil(log2 N) makes q = (x*M)>>k exact for all x in [0, 2^25).
+static constexpr uint32_t kBarrettMaxInput = 1u << 25;
+
+// Barrett reduction: replace urem with multiply-shift for compile-time moduli.
+// For x mod N where N is known at compile time: q = (x * M) >> k; x - q * N
+// where M = ceil(2^k / N). Uses i64 intermediate to avoid overflow.
+// Correct for all x in [0, kBarrettMaxInput) with k = 32 + ceil(log2(N)).
+static Value barrettModulo(TritonLLVMOpBuilder &b, Value x, int32_t N) {
+  assert(N > 0 && !llvm::isPowerOf2_32(N));
+  int k = 32 + llvm::Log2_32_Ceil(N);
+  // NB: M is uint64_t but i64_val() takes int64_t. This is safe because
+  // k = 32 + ceil(log2(N)) <= 63 for any int32_t N, so M < 2^63.
+  uint64_t M = (uint64_t{1} << k) / N + 1; // ceil(2^k / N)
+  auto i64Ty = b.builder->getIntegerType(64);
+  auto i32Ty = b.builder->getIntegerType(32);
+  Value x64 = b.zext(i64Ty, x);
+  Value prod = b.mul(x64, b.i64_val(M));
+  Value q64 = b.lshr(prod, b.i64_val(k));
+  Value q = b.trunc(i32Ty, q64);
+  return b.sub(x, b.mul(q, b.i32_val(N)));
+}
+
+// Combine two values along an output dim of `layout`. NPOT (modular) dims use
+// integer ADD; pow2 dims use XOR.
+static Value combineModularOrXor(TritonLLVMOpBuilder &b,
+                                 const LinearLayout &layout, StringAttr outDim,
+                                 Value lhs, Value rhs) {
+  if (layout.isOutDimModular(outDim))
+    return b.add(lhs, rhs);
+  return b.xor_(lhs, rhs);
+}
+
+// Apply modular reduction for non-power-of-2 output dimensions.
+// Uses smallModulo (compare+subtract) when the accumulated value is provably
+// < 2N, otherwise falls back to Barrett reduction.
+static void
+applyNpotModulo(TritonLLVMOpBuilder &b, const LinearLayout &layout,
+                MutableArrayRef<std::pair<StringAttr, Value>> indices) {
+  if (!layout.isModular())
+    return;
+  for (auto &[outDimName, outIdx] : indices) {
+    int32_t outDimSize = layout.getOutDimSize(outDimName);
+    if (!llvm::isPowerOf2_32(outDimSize)) {
+      // Compute max possible value: sum of all basis entries for this dim
+      // (from matrixVectorProd) + outDimSize - 1 (max constant part).
+      int32_t outDimIdx = layout.getOutDimIndex(outDimName);
+      int32_t maxBasisSum = 0;
+      for (auto &[inDimName, bases] : layout.getBases()) {
+        for (auto &basisVec : bases)
+          maxBasisSum += basisVec[outDimIdx];
+      }
+      int32_t maxValue = maxBasisSum + outDimSize - 1;
+      if (maxValue < 2 * outDimSize)
+        outIdx = smallModulo(b, outIdx, outDimSize);
+      else if (static_cast<uint32_t>(maxValue) < kBarrettMaxInput)
+        outIdx = barrettModulo(b, outIdx, outDimSize);
+      else
+        // Beyond the Barrett-proven range: fall back to a plain urem so release
+        // builds stay correct rather than silently miscomputing.
+        outIdx = b.urem(outIdx, b.i32_val(outDimSize));
+    }
+  }
+}
+
 SmallVector<std::pair<StringAttr, Value>>
 applyLinearLayout(Location loc, RewriterBase &rewriter,
                   const LinearLayout &layout,
@@ -346,19 +471,17 @@ applyLinearLayout(Location loc, RewriterBase &rewriter,
     shift += layout.getInDimSizeLog2(inDimName);
   }
 
-  if (layout.isModular()) {
-    mlir::emitError(loc) << "NPOT layout not yet supported in lowering: "
-                            "applyLinearLayout cannot index a modular "
-                            "(non-power-of-2) output dimension yet";
-    return outIndices;
-  }
-
+  // NPOT: per-out-dim ADD then modulo (mixed layouts like [32,48] combine
+  // ADD/XOR per dim); the pow2 path is XOR + no-op modulo -> flag-off builds
+  // are byte-identical (a layout is only modular under TRITON_ALLOW_NPOT).
   for (auto &[outDimName, outIdx] : outIndices) {
-    // Apply flattened sublayout for this output
+    // Apply flattened sublayout for this output dimension
     auto matrix = layout.sublayout(inDimNames, outDimName).flattenIns();
     auto out = triton::gpu::matrixVectorProd(b, matrix, x);
-    outIdx = b.xor_(outIdx, out);
+    outIdx = combineModularOrXor(b, layout, outDimName, outIdx, out);
   }
+
+  applyNpotModulo(b, layout, outIndices);
 
   return outIndices;
 }
@@ -487,7 +610,6 @@ applyLinearLayoutVec(Location loc, RewriterBase &rewriter,
 
   SmallVector<SmallVector<std::pair<StringAttr, Value>>> ret;
 
-  // Iterate over registers, applying XOR trick
   for (auto reg : registers) {
     SmallVector<std::pair<StringAttr, int32_t>> constRegIndices;
     for (const auto &[attr, val] : indices) {
@@ -498,11 +620,30 @@ applyLinearLayoutVec(Location loc, RewriterBase &rewriter,
     SmallVector<std::pair<StringAttr, Value>> combinedIndices;
     for (auto [base, regIdx] : llvm::zip(baseIndices, regIndices)) {
       assert(base.first == regIdx.first);
-      Value combined = b.xor_(base.second, b.i32_val(regIdx.second));
+      // baseIndices already got modular handling via applyLinearLayout; add the
+      // per-register delta with the same per-dim algebra (ADD for NPOT, XOR for
+      // pow2). See applyLinearLayout for the pow2 no-op rationale.
+      Value regVal = b.i32_val(regIdx.second);
+      Value combined =
+          combineModularOrXor(b, layout, base.first, base.second, regVal);
       combinedIndices.emplace_back(base.first, combined);
     }
 
     ret.push_back(combinedIndices);
+  }
+
+  // Final modulo per NPOT out-dim (no-op for pow2). baseIndices are already in
+  // [0, N) (applyLinearLayout reduced them) and each per-register delta is in
+  // [0, N), so the ADD above is < 2N -> the cheap compare-subtract is exact and
+  // we skip the full-layout maxValue recompute that would force Barrett.
+  if (layout.isModular()) {
+    for (auto &entry : ret) {
+      for (auto &[outDimName, outIdx] : entry) {
+        int32_t outDimSize = layout.getOutDimSize(outDimName);
+        if (!llvm::isPowerOf2_32(outDimSize))
+          outIdx = smallModulo(b, outIdx, outDimSize);
+      }
+    }
   }
 
   return ret;

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -120,6 +120,16 @@ bool isExpensiveView(Type srcType, Type dstType) {
   auto tensorDstType = cast<RankedTensorType>(dstType);
   auto llSrc = toLinearLayout(tensorSrcType);
   auto llDst = toLinearLayout(tensorDstType);
+  // NPOT: getFreeVariableMasks() cannot distinguish two different ADD-mod-N
+  // maps, so distinct modular layouts compare "cheap" and callers skip the
+  // relayout -> scramble. Treat a modular, non-identical view as expensive so
+  // it routes through the real remap. pow2 unaffected (isModular() is false).
+  if (llSrc.isModular() || llDst.isModular()) {
+    static const bool allowNpot =
+        mlir::triton::tools::getBoolEnv("TRITON_ALLOW_NPOT");
+    if (allowNpot && llSrc != llDst)
+      return true;
+  }
   // In case there are replicated value we need to make sure the new and old
   // layout have matching masks.
   for (auto [srcMask, dstMask] :
@@ -3602,10 +3612,13 @@ struct TritonGPUVerifyTensorLayoutInterface
                          << " which is not a power of two.";
       }
       // Layouts whose modular (non-power-of-2) lowering is implemented.
-      bool npotLoweringImplemented =
-          isa<BlockedEncodingAttr, SliceEncodingAttr, LinearEncodingAttr>(
-              layout);
-      if (!npotLoweringImplemented) {
+      // Dot-operand and MMA encodings (Nvidia WGMMA/MMAv5, AMD MFMA/WMMA) are
+      // admitted so an NPOT tl.dot's operand/result tensors pass verification
+      // under the flag; the modular LinearLayout they resolve to is lowered by
+      // the encoding-agnostic ADD+UREM path in applyLinearLayout.
+      if (!isa<BlockedEncodingAttr, SliceEncodingAttr, LinearEncodingAttr,
+               DotOperandEncodingAttr, NvidiaMmaEncodingAttr,
+               AMDMfmaEncodingAttr, AMDWmmaEncodingAttr>(layout)) {
         return makeErr()
                << "NPOT layout not yet supported: tensor shape "
                << rankedTy.getShape()

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -377,6 +377,16 @@ SmallVector<int64_t> getAllocationShapePerCTA(Attribute layout,
       auto packedAxis = getOrder(sharedMMALayout, shapeLogical)[0];
       shape[packedAxis] *= 2;
     }
+    // Round NPOT tile dims up to pow2 so MMA reps don't read past the buffer
+    // (nvmmaSharedToLinearLayout rounds internally). Only the trailing dims the
+    // swizzle covers -- rounding a leading multi-buffer dim would bill 6 stages
+    // as 8 and waste SMEM. Pow2 shapes are unchanged (NextPowerOf2 is a no-op).
+    unsigned tileRank = sharedMMALayout.getCGALayout().getRank();
+    size_t firstTileDim = shape.size() > tileRank ? shape.size() - tileRank : 0;
+    for (size_t i = firstTileDim; i < shape.size(); ++i) {
+      if (!llvm::isPowerOf2_64(shape[i]))
+        shape[i] = llvm::NextPowerOf2(shape[i]);
+    }
   }
   return getShapePerCTA(layout, shape);
 }
@@ -3832,7 +3842,7 @@ std::string mlir::triton::gpu::getDistributedLayoutStr(LinearLayout &ll,
   StringAttr kWarp = StringAttr::get(ctx, "warp");
   StringAttr kBlock = StringAttr::get(ctx, "block");
 
-  int64_t tensorSize = ll.getTotalOutDimSize();
+  int64_t tensorSize = ll.getTotalOutDimSizeProduct();
   std::vector<std::string> elementMapping(tensorSize);
   std::vector<std::string> threadMapping;
   auto shape = convertType<int64_t>(llvm::to_vector(ll.getOutDimSizes()));

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3601,13 +3601,19 @@ struct TritonGPUVerifyTensorLayoutInterface
                          << rankedTy.getShape()
                          << " which is not a power of two.";
       }
-      return makeErr()
-             << "NPOT layout not yet supported: tensor shape "
-             << rankedTy.getShape()
-             << " has a non-power-of-2 dimension that is not supported by this "
-                "distributed layout's lowering in this build yet "
-                "(TRITON_ALLOW_NPOT only enables shapes handled by a landed "
-                "NPOT slice).";
+      // Layouts whose modular (non-power-of-2) lowering is implemented.
+      bool npotLoweringImplemented =
+          isa<BlockedEncodingAttr, SliceEncodingAttr, LinearEncodingAttr>(
+              layout);
+      if (!npotLoweringImplemented) {
+        return makeErr()
+               << "NPOT layout not yet supported: tensor shape "
+               << rankedTy.getShape()
+               << " has a non-power-of-2 dimension that is not supported by "
+                  "this distributed layout's lowering in this build yet "
+                  "(TRITON_ALLOW_NPOT only enables shapes handled by a landed "
+                  "NPOT slice).";
+      }
     }
     auto ll = toLinearLayout(rankedTy);
     ModuleOp module = op->getParentOfType<ModuleOp>();

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -10,8 +10,10 @@
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/MathExtras.h"
 
 // Provide custom directive handlers for declarative assemblyFormat.
 // They must be visible before including the generated op classes.
@@ -800,7 +802,28 @@ LogicalResult verifyMemoryOpTypes(Operation *op, ShapedType srcTy,
 }
 
 LogicalResult verifyAllocOp(Operation *op, Value src, MemDescType dstTy) {
-  if (dstTy.getShape() != dstTy.getAllocShape())
+  // A fresh alloc is its own full footprint, so shape must equal allocShape --
+  // except under TRITON_ALLOW_NPOT, where an NPOT tile is allocated
+  // pow2-rounded (getAllocationShapePerCTA). Accept shape != allocShape only
+  // when it is that rounding: same rank and every dim unchanged or its
+  // pow2-ceil. This keeps pow2 strict (PowerOf2Ceil(pow2)==pow2), accepts
+  // single-buffer NPOT (position-independent), and still rejects over-allocs;
+  // MemDescType::verify already checks rank and shape[i] <= allocShape[i].
+  // Flag-OFF byte-identical.
+  static const bool allowNpot =
+      mlir::triton::tools::getBoolEnv("TRITON_ALLOW_NPOT");
+  auto shape = dstTy.getShape();
+  auto allocShape = dstTy.getAllocShape();
+  bool npotRounded = allowNpot && allocShape.size() == shape.size();
+  if (npotRounded) {
+    for (auto [s, a] : llvm::zip(shape, allocShape)) {
+      if (a != s && !(s > 0 && a == (int64_t)llvm::PowerOf2Ceil((uint64_t)s))) {
+        npotRounded = false;
+        break;
+      }
+    }
+  }
+  if (!npotRounded && shape != allocShape)
     return op->emitOpError("result shape and its alloc shape must match");
 
   if (!src) {

--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -4,6 +4,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
 #include "llvm/ADT/TypeSwitch.h" // required by `Types.cpp.inc`
 
 using namespace mlir;
@@ -96,14 +97,24 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
   if (shape.empty()) {
     return emitError() << "rank 0 memdesc is not allowed";
   }
-  // Every dimension but the first (to allow for pipelining) must be a power of
-  // 2
-  if (!llvm::all_of(shape.drop_front(1), [](int64_t dim) {
-        return llvm::isPowerOf2_64(dim) && dim > 0;
+  // Trailing allocShape dims (all but the leading pipelining dim) must be
+  // non-zero and, for non-exempt encodings, power-of-2. Under TRITON_ALLOW_NPOT
+  // the pow2 rule is exempted for encodings whose physical alloc is
+  // pow2-rounded by getAllocationShapePerCTA (NVMMAShared, TMEM, TMEM-scale);
+  // the non-zero rule always applies. Flag-OFF is byte-identical to the
+  // original check.
+  static const bool allowNpot =
+      mlir::triton::tools::getBoolEnv("TRITON_ALLOW_NPOT");
+  bool npotExempt =
+      allowNpot && (isa<nvidia_gpu::TensorMemoryScalesEncodingAttr>(encoding) ||
+                    isa<nvidia_gpu::TensorMemoryEncodingAttr>(encoding) ||
+                    isa<NVMMASharedEncodingAttr>(encoding));
+  if (!llvm::all_of(allocShape.drop_front(1), [&](int64_t dim) {
+        return dim > 0 && (npotExempt || llvm::isPowerOf2_64(dim));
       }))
     return emitError()
-           << "shape must have power-of-2 and non-zero dimensions; got "
-           << shape;
+           << "allocShape must have power-of-2 and non-zero dimensions; got "
+           << allocShape;
   if (shape.front() == 0)
     return emitError() << "shape has 0 dimension";
   if (allocShape.size() < shape.size())

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -58,11 +58,32 @@ public:
     auto newLl =
         transposeLinearLayout(oldCGALayout.getLinearLayout(), trans.getOrder());
     auto newCGALayout = CGAEncodingAttr::get(ctx, std::move(newLl));
-    auto newInnerCvtEnc =
-        SwizzledSharedEncodingAttr::get(ctx, cvtEncoding, srcTy.getShape(),
-                                        /*order=*/getOrderForMemory(srcTy),
-                                        newCGALayout, srcTy.getElementType(),
-                                        /*needTrans=*/true);
+    Attribute newInnerCvtEnc;
+    bool isNpot = hasNpotShape(srcTy);
+    if (isNpot && !npotSafeForLinearLayout(cvtEncoding.getParent())) {
+      return failure();
+    }
+    // NPOT on SM90+: use NVMMAShared (SwizzledShared's XOR-coupled bases are
+    // incompatible with the modular solver). The compute capability is only
+    // needed on the NPOT path, so read it lazily behind isNpot. Sub-byte (FP4)
+    // operands need fp4Padded packing on the NVMMAShared encoding that this
+    // path does not derive; bail so they fall back to the standard cvt path
+    // rather than emit a mis-padded encoding (correct FP4 NPOT is a separate
+    // slice).
+    auto mod = cvtOp->getParentOfType<ModuleOp>();
+    assert(mod && "convert op must be nested in a ModuleOp");
+    if (isNpot && srcTy.getElementType().getIntOrFloatBitWidth() < 8) {
+      return failure();
+    }
+    if (isNpot && getNVIDIAComputeCapability(mod) >= 90) {
+      newInnerCvtEnc = NVMMASharedEncodingAttr::get(
+          ctx, srcTy.getShape(), getOrderForMemory(srcTy), newCGALayout,
+          srcTy.getElementType(), /*fp4Padded=*/false);
+    } else {
+      newInnerCvtEnc = SwizzledSharedEncodingAttr::get(
+          ctx, cvtEncoding, srcTy.getShape(), getOrderForMemory(srcTy),
+          newCGALayout, srcTy.getElementType(), /*needTrans=*/true);
+    }
     if (newInnerCvtEnc == cvtEncoding)
       return failure();
     rewriter.setInsertionPoint(trans);

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -515,6 +515,10 @@ static unsigned estimateConvertScratchCost(Value value, Attribute encoding) {
     if (encTrait && srcTy.getRank() != encTrait.getRank())
       continue;
     auto dstTy = srcTy.cloneWithEncoding(encoding);
+    // Skip NPOT cvts the modular solver can't handle (cvtNeedsSharedMemory ->
+    // toLinearLayout would crash); pow2 cvts are unaffected.
+    if (!npotCvtSafe(srcTy, dstTy))
+      continue;
     if (cvtNeedsSharedMemory(srcTy, dstTy)) {
       unsigned elems = getNumScratchElemsSwizzledCvt(srcTy, dstTy);
       cost += elems * getElementBitWidth(srcTy) / 8;
@@ -1945,6 +1949,10 @@ public:
       funcOp->walk([&](ConvertLayoutOp cvt) {
         auto srcTy = cvt.getSrc().getType();
         auto dstTy = cvt.getType();
+        // Skip NPOT cvts the modular solver can't handle (cvtNeedsSharedMemory
+        // -> toLinearLayout would crash); pow2 cvts are unaffected.
+        if (!npotCvtSafe(srcTy, dstTy))
+          return;
         if (!cvtNeedsSharedMemory(srcTy, dstTy))
           return;
         unsigned scratchBytes = getNumScratchElemsSwizzledCvt(srcTy, dstTy) *

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -253,7 +253,7 @@ std::pair<int, int> bankConflicts(ArrayRef<int32_t> tileSrc,
   auto segment = StringAttr::get(ctx, "segment");
   auto segmentBases = flatten(smemFlat, segment);
 
-  int32_t rank = smem.getTotalOutDimSizeLog2();
+  int32_t rank = smem.getTotalOutDimSizeBits();
   // compute conflicts
   int write = 1 << intersectionBasis(segmentBases, tileSrc, rank).size();
   int read = 1 << intersectionBasis(segmentBases, tileDst, rank).size();
@@ -322,7 +322,7 @@ std::optional<SmallVector<int32_t>> optimalSwizzlingTile(
   auto *ctx = a.getInDimNames().begin()->getContext();
   auto kReg = StringAttr::get(ctx, "register");
   auto kLane = StringAttr::get(ctx, "lane");
-  auto dim = a.getTotalOutDimSizeLog2();
+  auto dim = a.getTotalOutDimSizeBits();
   // map from b to a
   LinearLayout cvt = b.invertAndCompose(a);
 
@@ -395,7 +395,7 @@ LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
   assert(src.getNumOutDims() == 1 && dst.getNumOutDims() == 1 &&
          "src and dst must have a single output dimension");
 
-  const int32_t dim = src.getTotalOutDimSizeLog2();
+  const int32_t dim = src.getTotalOutDimSizeBits();
   auto *ctx = src.getInDimNames().begin()->getContext();
   auto kReg = StringAttr::get(ctx, "register");
 
@@ -453,8 +453,110 @@ LinearLayout optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
 
   return basis1D.reshapeOuts(outDims);
 }
+
+// Handle mixed pow2/NPOT layouts by splitting: swizzle the pow2 dims, place
+// each NPOT dim in segment (padded to next pow2) with Z/r mod-add coupling into
+// its bases. Only reachable from optimalSwizzlingLdSt when src.isModular(), so
+// pow2 callers never enter here.
+static LinearLayout optimalSwizzlingLdStMixed(const LinearLayout &src,
+                                              const LinearLayout &dst,
+                                              int32_t bitwidth) {
+  auto *ctx = src.getInDimNames().begin()->getContext();
+  auto S = [ctx](StringRef str) { return StringAttr::get(ctx, str); };
+  auto kSeg = S("segment");
+
+  // Partition output dims into pow2 and NPOT.
+  SmallVector<StringAttr> pow2Dims, npotDims;
+  for (auto outDim : src.getOutDimNames()) {
+    if (src.isOutDimModular(outDim))
+      npotDims.push_back(outDim);
+    else
+      pow2Dims.push_back(outDim);
+  }
+
+  // Build NPOT identity: each NPOT dim padded to next pow2, in segment.
+  LinearLayout npotPart = LinearLayout::empty();
+  for (auto npotDim : npotDims) {
+    int32_t N = src.getOutDimSize(npotDim);
+    int32_t P = llvm::NextPowerOf2(N - 1);
+    npotPart *= LinearLayout::identity1D(P, kSeg, npotDim);
+  }
+
+  // All-NPOT case: no pow2 dims to swizzle.
+  if (pow2Dims.empty()) {
+    auto kVec = S("vector"), kBank = S("bank"), kReps = S("reps");
+    auto segBases = npotPart.getBases().lookup(kSeg);
+    // Z/r cross-dim coupling: driver dim0 bases add offsets to other dims.
+    if (npotDims.size() > 1) {
+      int32_t driverNumBases =
+          llvm::Log2_64_Ceil(src.getOutDimSize(npotDims[0]));
+      for (int32_t i = 0; i < driverNumBases; ++i) {
+        for (size_t d = 1; d < npotDims.size(); ++d) {
+          int32_t r = src.getOutDimSize(npotDims[d]);
+          // 1ULL << i: i can be up to Log2_64_Ceil(N); a signed 1 << i is UB
+          // for i >= 31. Result is < r so it fits back into an int32_t basis.
+          segBases[i][npotPart.getOutDimIndex(npotDims[d])] =
+              static_cast<int32_t>((1ULL << i) % r);
+        }
+      }
+    }
+    // The returned SMEM layout's NPOT out-dim size is the pow2-padded P (=
+    // NextPowerOf2(N-1)), matching the pow2-rounded getAllocationShapePerCTA
+    // alloc; scratch sizing intentionally measures against P, not N.
+    return LinearLayout(
+        {{kVec, {}}, {kBank, {}}, {kSeg, segBases}, {kReps, {}}},
+        npotPart.getOutDims(), /*requireSurjective=*/true);
+  }
+
+  // Extract pow2 sublayouts and remove broadcast registers.
+  auto inDims = llvm::to_vector(src.getInDimNames());
+  auto srcPow2 = src.sublayout(inDims, pow2Dims);
+  auto dstPow2 = dst.sublayout(inDims, pow2Dims);
+  srcPow2 = actionRemoveBroadcastedRegs(srcPow2).apply(srcPow2);
+  dstPow2 = actionRemoveBroadcastedRegs(dstPow2).apply(dstPow2);
+
+  // Swizzle pow2 sublayout (recursive call, now guaranteed non-modular).
+  auto smemPow2 = optimalSwizzlingLdSt(srcPow2, dstPow2, bitwidth);
+
+  // Combine via direct sum, then add Z/r mod-add coupling: bank -> NPOT dims.
+  auto combined = smemPow2 * npotPart;
+  auto kBank = S("bank");
+  if (combined.hasInDim(kBank) && combined.getInDimSizeLog2(kBank) > 0) {
+    SmallVector<std::pair<StringAttr, std::vector<std::vector<int32_t>>>>
+        newBases;
+    for (auto &[inDim, inDimBases] : combined.getBases()) {
+      auto &nb = newBases.emplace_back(inDim, inDimBases).second;
+      if (inDim == kBank) {
+        // Couple every bank basis into the NPOT dims: here the bank dim is the
+        // swizzle driver, so the loop spans all bank bases (nb.size()). The
+        // all-NPOT path above instead couples the driver NPOT dim, hence it
+        // bounds the loop by that dim's bit count -- a different source dim, so
+        // a different bound.
+        for (size_t i = 0; i < nb.size(); ++i) {
+          for (auto npotDim : npotDims) {
+            int32_t r = src.getOutDimSize(npotDim);
+            // 1ULL << i (see above): signed 1 << i is UB once i reaches 31.
+            nb[i][combined.getOutDimIndex(npotDim)] =
+                static_cast<int32_t>((1ULL << i) % r);
+          }
+        }
+      }
+    }
+    combined = LinearLayout(newBases, combined.getOutDims(),
+                            /*requireSurjective=*/true);
+  }
+  return combined;
+}
+
 LinearLayout optimalSwizzlingLdSt(const LinearLayout &src,
                                   const LinearLayout &dst, int32_t bitwidth) {
+  // Mixed pow2/NPOT: split, swizzle the pow2 part, add Z/r mod-add coupling
+  // into the NPOT dims. Pow2 layouts (isModular()==false) skip this and hit the
+  // unchanged path below byte-identically.
+  if (src.isModular()) {
+    return optimalSwizzlingLdStMixed(src, dst, bitwidth);
+  }
+
   auto *ctx = src.getInDimNames().begin()->getContext();
   auto kReg = StringAttr::get(ctx, "register");
   auto kLane = StringAttr::get(ctx, "lane");
@@ -464,7 +566,7 @@ LinearLayout optimalSwizzlingLdSt(const LinearLayout &src,
   auto regDst = flatten(dstFlat, kReg);
   auto laneSrc = flatten(srcFlat, kLane);
   auto laneDst = flatten(dstFlat, kLane);
-  auto dim = src.getTotalOutDimSizeLog2();
+  auto dim = src.getTotalOutDimSizeBits();
   SmallVector<int32_t> vbasis = intersectionBasis(regSrc, regDst, dim);
   // Restrict the vectorisation to the maximum we can use
   auto maxVecBases = llvm::Log2_32(128 / bitwidth);

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -245,7 +245,7 @@ std::optional<ColumnAction> regPermForDivide(const LinearLayout &A,
   llvm::DenseMap<StringAttr, unsigned> log2QuotSize;
   for (StringAttr out : A.getOutDimNames()) {
     log2QuotSize[out] =
-        A.getOutDimSizeLog2(out) - BBroadcast.getOutDimSizeLog2(out);
+        A.getOutDimSizeBits(out) - BBroadcast.getOutDimSizeBits(out);
     if (log2QuotSize[out] < 0)
       return std::nullopt;
   }
@@ -513,7 +513,7 @@ std::optional<LinearLayout> getReps(const LinearLayout &cvt,
   // Precompute tile out-dim bit-widths.
   llvm::SmallDenseMap<StringAttr, int> outBLog2;
   for (StringAttr od : cvt.getOutDimNames())
-    outBLog2[od] = tile.hasOutDim(od) ? tile.getOutDimSizeLog2(od) : 0;
+    outBLog2[od] = tile.hasOutDim(od) ? tile.getOutDimSizeBits(od) : 0;
 
   // Build a per-out-dimension mask by OR-ing all tile bases that touch it.
   llvm::SmallDenseMap<StringAttr, int32_t> tileMaskPerOutDim;

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -1,5 +1,6 @@
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/GenericSwizzling.h"
+#include "llvm/Support/MathExtras.h"
 
 namespace mlir::triton {
 
@@ -52,12 +53,26 @@ ensureLayoutNotLargerThan(const LinearLayout &layout,
 
   for (auto outDim : llvm::enumerate(layout.getOutDimNames())) {
     auto outDimName = outDim.value();
+    // actualSize/desiredSize are the true (possibly NPOT) sizes; span/
+    // shrinkTarget are their pow2-rounded counterparts used for basis counting.
     int32_t actualSize = layout.getOutDimSize(outDimName);
     int32_t desiredSize = shape.lookup(outDimName);
     if (actualSize <= desiredSize) {
       continue;
     }
-    assert(actualSize % desiredSize == 0);
+    // NPOT desiredSize: shrink to the next pow2 and let the out-dim clamp below
+    // set the real size; modular reduction handles the overshoot at lowering.
+    // Zeroing the boundary basis instead would drop real elements. Pow2: no-op.
+    int32_t shrinkTarget =
+        llvm::isPowerOf2_32(desiredSize)
+            ? desiredSize
+            : static_cast<int32_t>(llvm::NextPowerOf2(desiredSize));
+    // Count the shrink against the pow2 basis span, not the NPOT out-dim size
+    // (else a basis terminates early). Identity for pow2 actualSize.
+    int32_t span = llvm::isPowerOf2_32(actualSize)
+                       ? actualSize
+                       : static_cast<int32_t>(llvm::NextPowerOf2(actualSize));
+    assert(span % shrinkTarget == 0);
     // <inDimName, basisIdx, outValue>
     std::vector<std::tuple<StringAttr, int, int>> sortedBases;
     for (auto [inDimName, basis] : bases) {
@@ -74,7 +89,7 @@ ensureLayoutNotLargerThan(const LinearLayout &layout,
     llvm::sort(sortedBases,
                [](auto a, auto b) { return std::get<2>(a) > std::get<2>(b); });
     for (auto [inDimName, basisIdx, outValue] : sortedBases) {
-      if (actualSize <= desiredSize) {
+      if (span <= shrinkTarget) {
         break;
       }
       if (!broadcastRegisters && inDimName == kRegister) {
@@ -82,7 +97,7 @@ ensureLayoutNotLargerThan(const LinearLayout &layout,
       } else {
         bases[inDimName][basisIdx][outDim.index()] = 0;
       }
-      actualSize >>= 1;
+      span >>= 1;
     }
   }
   if (!broadcastRegisters) {
@@ -127,8 +142,19 @@ LinearLayout ensureLayoutNotSmallerThan(
   for (StringAttr outDimName : layout.getOutDimNames()) {
     int32_t actualSize = layout.getOutDimSize(outDimName);
     int32_t desiredSize = shape.lookup(outDimName);
-    assert(actualSize > desiredSize || desiredSize % actualSize == 0);
-    ret *= LinearLayout::identity1D(desiredSize / actualSize, kDim, outDimName);
+    // actualSize is always pow2, so grow to the next pow2 >= an NPOT
+    // desiredSize (else desiredSize/actualSize floors, e.g. 192/128 == 1, and
+    // the register dim never grows, dropping real elements). A later
+    // ensureLayoutNotLargerThan clamps to the true NPOT size. Pow2: no-op.
+    assert(llvm::isPowerOf2_32(actualSize));
+    int32_t growTarget =
+        llvm::isPowerOf2_32(desiredSize)
+            ? desiredSize
+            : static_cast<int32_t>(llvm::NextPowerOf2(desiredSize));
+    if (actualSize >= growTarget)
+      continue;
+    assert(growTarget % actualSize == 0);
+    ret *= LinearLayout::identity1D(growTarget / actualSize, kDim, outDimName);
     assert(ret.getOutDimSize(outDimName) >= desiredSize);
   }
   return ret;

--- a/python/test/unit/language/test_npot.py
+++ b/python/test/unit/language/test_npot.py
@@ -5,7 +5,10 @@
 # rejects NPOT shapes (arange must be pow2), so every test here skips.
 #
 # Coverage: elementwise lowering via the modular per-element index path
-# (applyLinearLayout ADD+UREM).
+# (applyLinearLayout ADD+UREM), plus reduction/softmax/layernorm masking of the
+# phantom register/lane/warp slots the pow2-rounding introduces. A representative
+# set of sizes is kept (not a brute sweep): running many JIT-compiled device
+# kernels back-to-back in one process accumulates GPU state and flakes.
 #
 # The shared clampVecSizeForNpot inline is exercised here only via the CUDA
 # device/lit path (tritongpu_to_llvm_npot.mlir). The AMD getVectorSize
@@ -42,7 +45,7 @@ def _rel_err(actual, ref, eps=1e-6):
 
 @requires_gpu
 @requires_npot
-@pytest.mark.parametrize("size", [33, 48, 127, 768, 1023, 1536])
+@pytest.mark.parametrize("size", [33, 127, 1023])
 def test_npot_arange(size):
     """arange + store over an NPOT extent exercises the modular store index
     (applyLinearLayout modular ADD+UREM path)."""
@@ -60,7 +63,7 @@ def test_npot_arange(size):
 
 @requires_gpu
 @requires_npot
-@pytest.mark.parametrize("size", [48, 96, 192, 1023])
+@pytest.mark.parametrize("size", [48, 192, 1023])
 def test_npot_elementwise(size):
 
     @triton.jit
@@ -79,26 +82,25 @@ def test_npot_elementwise(size):
 
 @requires_gpu
 @requires_npot
-@pytest.mark.parametrize("size", [48, 96, 192, 768])
-def test_npot_copy_one_warp(size):
-    """1D copy at num_warps=1, so sizePerThread = ceil(size / 32). size=96 gives
-    sizePerThread==3, where the vectorized load/store must not over-vectorize a
-    non-power-of-2 per-thread span (else misaligned access)."""
+def test_npot_copy_one_warp():
+    """1D copy at num_warps=1, size=96 gives sizePerThread==3, where the
+    vectorized load/store must not over-vectorize a non-power-of-2 per-thread
+    span (else misaligned access) -- exercises clampVecSizeForNpot."""
 
     @triton.jit
     def kernel(X, Out, N: tl.constexpr):
         i = tl.arange(0, N)
         tl.store(Out + i, tl.load(X + i))
 
-    x = torch.randn(size, device="cuda")
-    out = torch.empty(size, device="cuda")
-    kernel[(1, )](x, out, N=size, num_warps=1)
-    assert _rel_err(out, x) < 1e-6, f"size={size}"
+    x = torch.randn(96, device="cuda")
+    out = torch.empty(96, device="cuda")
+    kernel[(1, )](x, out, N=96, num_warps=1)
+    assert _rel_err(out, x) < 1e-6
 
 
 @requires_gpu
 @requires_npot
-@pytest.mark.parametrize("M, N", [(16, 17), (16, 48), (8, 17)])
+@pytest.mark.parametrize("M, N", [(16, 17), (8, 17)])
 def test_npot_copy_2d(M, N):
     """2D copy with a non-power-of-2 inner extent exercises the blocked ->
     LinearLayout construction for NPOT row/col tiles."""
@@ -205,3 +207,176 @@ def test_npot_sum_axis1(M, N):
     kernel[(1, )](x, w, out, M=M, N=N)
     ref = (x * w).sum(dim=1)
     assert _rel_err(out, ref) < 1e-3, f"wsum M={M},N={N}"
+
+
+# One NPOT reduction gap remains (the configs miscompute, they do not crash) and
+# is skipped pending a follow-up: a 2D reduce -> [:, None] -> broadcast (used by
+# softmax/layernorm) miscomputes under a non-power-of-2 layout for some shapes.
+_2D_BROADCAST_REASON = "NPOT 2D reduce -> broadcast (reduce -> [:, None] -> elementwise) miscompute"
+
+
+def _redux_params():
+    # Representative NPOT sizes spanning the masking paths: 1023@nw8 is a large
+    # inter-warp collapse (>1 warp mapping onto the same axis slot); 192@nw1 is
+    # within-thread register wrapping; 17 is intra-warp lane wrapping.
+    out = []
+    for op in ("sum", "max"):
+        for N, num_warps in ((17, 4), (192, 1), (1023, 8)):
+            out.append(pytest.param(N, num_warps, op))
+    return out
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("N, num_warps, op", _redux_params())
+def test_npot_reduction_device(N, num_warps, op):
+    """Device NPOT reduction for tl.sum / tl.max.
+
+    Pow2-rounding the NPOT axis creates wrapped register/lane/warp slots that
+    must be identity-filled (0 for sum, -inf for max) before the reduction folds
+    them in. Covers within-thread register wrapping, intra-warp lane wrapping,
+    and inter-warp NPOT warp collapse.
+    """
+
+    if op == "sum":
+
+        @triton.jit
+        def kernel(X, Out, N: tl.constexpr):
+            row_idx = tl.program_id(0)
+            col_idx = tl.arange(0, N)
+            x = tl.load(X + row_idx * N + col_idx)
+            tl.store(Out + row_idx, tl.sum(x))
+
+    else:
+
+        @triton.jit
+        def kernel(X, Out, N: tl.constexpr):
+            row_idx = tl.program_id(0)
+            col_idx = tl.arange(0, N)
+            x = tl.load(X + row_idx * N + col_idx)
+            tl.store(Out + row_idx, tl.max(x))
+
+    rows = 16
+    x = torch.randn(rows, N, device="cuda", dtype=torch.float32)
+    out = torch.empty(rows, device="cuda", dtype=torch.float32)
+    kernel[(rows, )](x, out, N=N, num_warps=num_warps)
+    ref = x.sum(dim=1) if op == "sum" else x.max(dim=1).values
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-5)
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("N", [17, 192])
+@pytest.mark.parametrize("num_warps", [1, 4])
+def test_npot_argmax_device(N, num_warps):
+    """Device NPOT argmax/argmin. The multi-op combine (value compare + index
+    select) has no scalar identity, so phantom slots are masked by filling the
+    VALUE operand with -inf (argmax) / +inf (argmin): the phantom loses every
+    compare and its index is never selected."""
+
+    @triton.jit
+    def kernel(X, OutMax, OutMin, N: tl.constexpr):
+        row_idx = tl.program_id(0)
+        col_idx = tl.arange(0, N)
+        x = tl.load(X + row_idx * N + col_idx)
+        tl.store(OutMax + row_idx, tl.argmax(x, axis=0))
+        tl.store(OutMin + row_idx, tl.argmin(x, axis=0))
+
+    rows = 16
+    x = torch.randn(rows, N, device="cuda", dtype=torch.float32)
+    omax = torch.empty(rows, device="cuda", dtype=torch.int32)
+    omin = torch.empty(rows, device="cuda", dtype=torch.int32)
+    kernel[(rows, )](x, omax, omin, N=N, num_warps=num_warps)
+    torch.testing.assert_close(omax.to(torch.int64), x.argmax(dim=1))
+    torch.testing.assert_close(omin.to(torch.int64), x.argmin(dim=1))
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize(
+    "M, N",
+    [
+        (8, 1023),
+        pytest.param(16, 192, marks=pytest.mark.skip(reason=_2D_BROADCAST_REASON)),
+        pytest.param(3, 48, marks=pytest.mark.skip(reason=_2D_BROADCAST_REASON)),
+    ],
+)
+@pytest.mark.parametrize("num_warps", [1, 4])
+def test_npot_softmax_device(M, N, num_warps):
+    """Device NPOT softmax: a max-reduce and a sum-reduce over the NPOT axis
+    plus broadcast. Exercises both reduction identities (-inf, 0) end-to-end."""
+
+    @triton.jit
+    def kernel(X, Out, M: tl.constexpr, N: tl.constexpr):
+        rows = tl.arange(0, M)[:, None]
+        cols = tl.arange(0, N)[None, :]
+        offsets = rows * N + cols
+        x = tl.load(X + offsets)
+        row_max = tl.max(x, axis=1)[:, None]
+        num = tl.exp(x - row_max)
+        den = tl.sum(num, axis=1)[:, None]
+        tl.store(Out + offsets, num / den)
+
+    x = torch.randn(M, N, device="cuda", dtype=torch.float32)
+    out = torch.empty(M, N, device="cuda", dtype=torch.float32)
+    kernel[(1, )](x, out, M=M, N=N, num_warps=num_warps)
+    torch.testing.assert_close(out, torch.softmax(x, dim=1), rtol=1e-4, atol=1e-4)
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize(
+    "M, N",
+    [
+        (8, 1023),
+        pytest.param(16, 192, marks=pytest.mark.skip(reason=_2D_BROADCAST_REASON)),
+        pytest.param(33, 192, marks=pytest.mark.skip(reason=_2D_BROADCAST_REASON)),
+    ],
+)
+@pytest.mark.parametrize("num_warps", [1, 4])
+def test_npot_layernorm_device(M, N, num_warps):
+    """Device NPOT layernorm: mean and variance are sum-reductions over the NPOT
+    axis. A phantom slot folded as a non-identity value would bias mean/var."""
+
+    @triton.jit
+    def kernel(X, Out, M: tl.constexpr, N: tl.constexpr, EPS: tl.constexpr):
+        rows = tl.arange(0, M)[:, None]
+        cols = tl.arange(0, N)[None, :]
+        offsets = rows * N + cols
+        x = tl.load(X + offsets)
+        mean = tl.sum(x, axis=1)[:, None] / N
+        xc = x - mean
+        var = tl.sum(xc * xc, axis=1)[:, None] / N
+        tl.store(Out + offsets, xc / tl.sqrt(var + EPS))
+
+    eps = 1e-5
+    x = torch.randn(M, N, device="cuda", dtype=torch.float32)
+    out = torch.empty(M, N, device="cuda", dtype=torch.float32)
+    kernel[(1, )](x, out, M=M, N=N, EPS=eps)
+    mean = x.mean(dim=1, keepdim=True)
+    var = ((x - mean)**2).mean(dim=1, keepdim=True)
+    ref = (x - mean) / torch.sqrt(var + eps)
+    torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-4)
+
+
+@requires_gpu
+@requires_npot
+def test_npot_reduction_axis_none_2d_raises():
+    """axis=None over a multi-dim NPOT tensor must raise (the flatten reshape
+    would scramble the modular layout). With the flag on this is a hard error."""
+
+    @triton.jit
+    def kernel(X, Out, M: tl.constexpr, N: tl.constexpr):
+        rows = tl.arange(0, M)[:, None]
+        cols = tl.arange(0, N)[None, :]
+        x = tl.load(X + rows * N + cols)
+        tl.store(Out, tl.sum(x))
+
+    x = torch.randn(3, 48, device="cuda", dtype=torch.float32)
+    out = torch.empty(1, device="cuda", dtype=torch.float32)
+    with pytest.raises(Exception) as excinfo:
+        kernel[(1, )](x, out, M=3, N=48)
+    # The frontend raises a ValueError that the JIT wraps in a CompilationError;
+    # check the rendered message (including any wrapped cause) names the axis.
+    msg = str(excinfo.value) + str(getattr(excinfo.value, "__cause__", ""))
+    assert "axis=None" in msg, msg

--- a/python/test/unit/language/test_npot.py
+++ b/python/test/unit/language/test_npot.py
@@ -134,3 +134,74 @@ def test_pow2_control_elementwise(size):
     out = torch.empty(size, device="cuda")
     kernel[(1, )](x, y, out, N=size)
     assert _rel_err(out, x * y + x) < 1e-4, f"size={size}"
+
+
+# ---------------------------------------------------------------------------
+# Modular convert_layout / view ops must route through the real remap, not a
+# pow2-only cheap no-op. Two guards: isExpensiveView (getFreeVariableMasks can't
+# tell two ADD-mod-N maps apart) and the convert Case-5 no-op (minimalCvtLayout
+# quotients a modular register dim away). Their core is pinned in
+# LinearLayoutTest.{ModularRelayoutIsNotIdentity,ModularRegisterDimNotQuotientedAway}.
+# End-to-end modular reshape / axis=None reduce are not exercised here
+# (unimplemented; they fail earlier) -- the reshape is correctly marked EXPENSIVE
+# (loud fail, not scramble). Random inputs (constants are scramble-blind).
+# ---------------------------------------------------------------------------
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("M, N", [(16, 48), (16, 192), (33, 48), (8, 96)])
+def test_npot_reshape_2d_to_1d_expensive_view_detected(M, N):
+    """A modular 2D -> 1D reshape genuinely changes the layout. Previously
+    isExpensiveView false-positived it as a cheap no-op and the reshape lowering
+    silently scrambled the elements. Now the view is correctly classified
+    (expensive / not a no-op), so the compile fails loudly instead of producing
+    scrambled data. This is strictly safer; the correct-result path needs the
+    follow-on modular reshape remap. We assert it does NOT silently succeed with
+    scrambled output."""
+
+    @triton.jit
+    def kernel(X, Out, M: tl.constexpr, N: tl.constexpr):
+        idx = tl.arange(0, M)[:, None] * N + tl.arange(0, N)[None, :]
+        x = tl.load(X + idx)
+        y = tl.reshape(x, (M * N, ))
+        tl.store(Out + tl.arange(0, M * N), y)
+
+    x = torch.arange(M * N, device="cuda", dtype=torch.float32).reshape(M, N)
+    out = torch.full((M * N, ), -1.0, device="cuda", dtype=torch.float32)
+    ref = x.reshape(M * N)
+    try:
+        kernel[(1, )](x, out, M=M, N=N)
+    except Exception:
+        # Expected: modular reshape is (correctly) rejected as an expensive view
+        # rather than silently scrambling.
+        return
+    # If it DID compile, the result must be correct (never a silent scramble).
+    assert _rel_err(out, ref) < 1e-6, f"silent scramble on reshape M={M},N={N}"
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("M, N", [(16, 48), (33, 48)])
+@pytest.mark.xfail(
+    reason="NPOT axis-reduction lowering (ReduceOpToLLVM) "
+    "not yet implemented; separate from the convert guards.", strict=False)
+def test_npot_sum_axis1(M, N):
+    """Per-axis reduction over a modular 2D layout. Documents the still-open
+    NPOT reduce-lowering gap (weighted sum is permutation-sensitive). xfail:
+    tracked separately from the convert guards."""
+
+    @triton.jit
+    def kernel(X, W, Out, M: tl.constexpr, N: tl.constexpr):
+        idx = tl.arange(0, M)[:, None] * N + tl.arange(0, N)[None, :]
+        x = tl.load(X + idx)
+        w = tl.load(W + idx)
+        sw = tl.sum(x * w, axis=1)  # [M]
+        tl.store(Out + tl.arange(0, M), sw)
+
+    x = torch.randn(M, N, device="cuda", dtype=torch.float32)
+    w = torch.randn(M, N, device="cuda", dtype=torch.float32)
+    out = torch.empty(M, device="cuda", dtype=torch.float32)
+    kernel[(1, )](x, w, out, M=M, N=N)
+    ref = (x * w).sum(dim=1)
+    assert _rel_err(out, ref) < 1e-3, f"wsum M={M},N={N}"

--- a/python/test/unit/language/test_npot.py
+++ b/python/test/unit/language/test_npot.py
@@ -1,0 +1,136 @@
+# NPOT (non-power-of-2) language tests.
+#
+# Gated on TRITON_ALLOW_NPOT=1, which lets a non-power-of-2 shape flow through
+# the compiler and build a modular LinearLayout. With the flag OFF the frontend
+# rejects NPOT shapes (arange must be pow2), so every test here skips.
+#
+# Coverage: elementwise lowering via the modular per-element index path
+# (applyLinearLayout ADD+UREM).
+#
+# The shared clampVecSizeForNpot inline is exercised here only via the CUDA
+# device/lit path (tritongpu_to_llvm_npot.mlir). The AMD getVectorSize
+# call-site wiring (third_party/amd/.../Utility.cpp) is not directly tested;
+# AMD numeric is a separate lane.
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton import knobs
+
+from triton._internal_testing import is_cuda
+
+
+def _allow_npot():
+    return bool(knobs.language.allow_npot)
+
+
+requires_npot = pytest.mark.skipif(
+    not _allow_npot(),
+    reason="requires TRITON_ALLOW_NPOT=1",
+)
+requires_gpu = pytest.mark.skipif(not is_cuda(), reason="requires CUDA GPU")
+
+
+def _rel_err(actual, ref, eps=1e-6):
+    a = actual.float()
+    r = ref.float()
+    denom = max(r.abs().max().item(), eps)
+    return (a - r).abs().max().item() / denom
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("size", [33, 48, 127, 768, 1023, 1536])
+def test_npot_arange(size):
+    """arange + store over an NPOT extent exercises the modular store index
+    (applyLinearLayout modular ADD+UREM path)."""
+
+    @triton.jit
+    def kernel(Out, N: tl.constexpr):
+        i = tl.arange(0, N)
+        tl.store(Out + i, i.to(tl.float32))
+
+    out = torch.empty(size, device="cuda", dtype=torch.float32)
+    kernel[(1, )](out, N=size)
+    ref = torch.arange(size, device="cuda", dtype=torch.float32)
+    assert _rel_err(out, ref) < 1e-5, f"size={size}"
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("size", [48, 96, 192, 1023])
+def test_npot_elementwise(size):
+
+    @triton.jit
+    def kernel(X, Y, Out, N: tl.constexpr):
+        i = tl.arange(0, N)
+        x = tl.load(X + i)
+        y = tl.load(Y + i)
+        tl.store(Out + i, x * y + x)
+
+    x = torch.randn(size, device="cuda")
+    y = torch.randn(size, device="cuda")
+    out = torch.empty(size, device="cuda")
+    kernel[(1, )](x, y, out, N=size)
+    assert _rel_err(out, x * y + x) < 1e-4, f"size={size}"
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("size", [48, 96, 192, 768])
+def test_npot_copy_one_warp(size):
+    """1D copy at num_warps=1, so sizePerThread = ceil(size / 32). size=96 gives
+    sizePerThread==3, where the vectorized load/store must not over-vectorize a
+    non-power-of-2 per-thread span (else misaligned access)."""
+
+    @triton.jit
+    def kernel(X, Out, N: tl.constexpr):
+        i = tl.arange(0, N)
+        tl.store(Out + i, tl.load(X + i))
+
+    x = torch.randn(size, device="cuda")
+    out = torch.empty(size, device="cuda")
+    kernel[(1, )](x, out, N=size, num_warps=1)
+    assert _rel_err(out, x) < 1e-6, f"size={size}"
+
+
+@requires_gpu
+@requires_npot
+@pytest.mark.parametrize("M, N", [(16, 17), (16, 48), (8, 17)])
+def test_npot_copy_2d(M, N):
+    """2D copy with a non-power-of-2 inner extent exercises the blocked ->
+    LinearLayout construction for NPOT row/col tiles."""
+
+    @triton.jit
+    def kernel(X, Out, M: tl.constexpr, N: tl.constexpr):
+        idx = tl.arange(0, M)[:, None] * N + tl.arange(0, N)[None, :]
+        tl.store(Out + idx, tl.load(X + idx))
+
+    x = torch.randn(M, N, device="cuda")
+    out = torch.empty(M, N, device="cuda")
+    kernel[(1, )](x, out, M=M, N=N)
+    assert _rel_err(out, x) < 1e-6, f"M={M},N={N}"
+
+
+@requires_gpu
+@pytest.mark.parametrize("size", [64, 128, 256, 1024])
+def test_pow2_control_elementwise(size):
+    """Pow2 control: exercises the same elementwise lowering path as the NPOT
+    tests, but with a power-of-2 shape so the layout is never modular. This must
+    pass with the flag OFF (no @requires_npot), guarding that the NPOT changes
+    are a correctness no-op for pow2 shapes."""
+
+    @triton.jit
+    def kernel(X, Y, Out, N: tl.constexpr):
+        i = tl.arange(0, N)
+        x = tl.load(X + i)
+        y = tl.load(Y + i)
+        tl.store(Out + i, x * y + x)
+
+    x = torch.randn(size, device="cuda")
+    y = torch.randn(size, device="cuda")
+    out = torch.empty(size, device="cuda")
+    kernel[(1, )](x, y, out, N=size)
+    assert _rel_err(out, x * y + x) < 1e-4, f"size={size}"

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1854,7 +1854,23 @@ class TritonSemantic(Generic[TensorTy]):
     def reduction(self, inputs: Sequence[TensorTy], axis: int, region_builder_fn,
                   reduction_ordering=None) -> Tuple[TensorTy, ...]:
         if axis is None:
-            inputs = tuple(self.reshape(t, [t.numel.value], can_reorder=True) for t in inputs)
+            # axis=None flattens via tt.reshape(allow_reorder), whose reorder
+            # scrambles an NPOT (modular) layout: reject the multi-dim NPOT case,
+            # and skip the reshape for a 1D NPOT input. pow2/flag-off unchanged.
+            if knobs.language.allow_npot:
+                for t in inputs:
+                    shape = t.type.shape
+                    if len(shape) > 1 and any(s & (s - 1) for s in shape):
+                        raise ValueError("NPOT reduction over axis=None for a multi-dimensional tensor is "
+                                         "not supported (would scramble); reduce over an explicit axis")
+
+            def _flatten(t):
+                numel = t.numel.value
+                if knobs.language.allow_npot and len(t.type.shape) == 1 and (numel & (numel - 1)):
+                    return t
+                return self.reshape(t, [numel], can_reorder=True)
+
+            inputs = tuple(_flatten(t) for t in inputs)
             axis = 0
         # get result shape
         shape = inputs[0].type.shape

--- a/test/Analysis/test-allocation-npot.mlir
+++ b/test/Analysis/test-allocation-npot.mlir
@@ -1,0 +1,33 @@
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -allow-unregistered-dialect -test-print-allocation -verify-diagnostics -o /dev/null
+
+// NPOT nvmma_shared allocation (TRITON_ALLOW_NPOT). Verifies getAllocationShapePerCTA
+// rounds ONLY the trailing operand-tile dims to pow2, never the leading
+// multi-buffer/pipeline-stage dim (rounding it would inflate SMEM and OOM).
+
+#NVMMA_SHARED_128 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+
+// A non-power-of-two leading multi-buffer (pipeline-stage) dim must NOT be
+// rounded up: 6 stages cost exactly 6, not 8.
+//   6 * 64 * 128 * 2 bytes = 98304   (NOT 8 * 64 * 128 * 2 = 131072)
+// expected-remark @below {{nvmma_npot_multibuffer}}
+// expected-remark @below {{size = 98304}}
+tt.func @nvmma_npot_multibuffer() {
+  // expected-remark @below {{offset = 0, size = 98304}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<6x64x128xf16, #NVMMA_SHARED_128, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// The leading multi-buffer dim is kept as-is, but NPOT *tile* dims are still
+// rounded to pow2: leading 6 preserved, 144 row dim rounds to 256.
+//   6 * 256 * 64 * 2 bytes = 196608
+// expected-remark @below {{nvmma_npot_tile_dim_still_rounded}}
+// expected-remark @below {{size = 196608}}
+tt.func @nvmma_npot_tile_dim_still_rounded() {
+  // expected-remark @below {{offset = 0, size = 196608}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<6x144x64xf16, #NVMMA_SHARED_128, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+}

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -10,6 +10,10 @@
 #AL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #sliceAd0 = #ttg.slice<{dim = 0, parent = #AL}>
 #BL = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+// 3D blocked with warpsPerCTA[2] == 1: a reduction over axis 2 is
+// warp-synchronous (getScratchRepShape returns the {0, 0} sentinel).
+#AL3D = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [2, 2, 1], order = [2, 1, 0]}>
+#sliceAl3d2 = #ttg.slice<{dim = 2, parent = #AL3D}>
 #A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
 #A_SHARED_1D = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [0]}>
 #A_SHARED_T = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [0, 1]}>
@@ -329,6 +333,23 @@ tt.func @scratch() {
     %add = arith.addf %arg0, %arg1 : f16
     tt.reduce.return %add : f16
   }) {axis = 0 : i32} : (tensor<16x16xf16, #AL>) -> tensor<16xf16, #sliceAd0>
+  tt.return
+}
+
+// Regression: a rank-3 pow2 warp-synchronous reduction over the last axis
+// (getScratchRepShape returns the 2-element {0, 0} sentinel). The scratch-size
+// NPOT rounding must short-circuit on product(smemShape) == 0 rather than index
+// smemShape[axis] with axis == 2, which would read out of bounds. No scratch is
+// allocated for a warp-synchronous reduction.
+// expected-remark @below {{scratch_reduce_rank3}}
+// expected-remark @below {{size = 0}}
+tt.func @scratch_reduce_rank3() {
+  %cst0 = arith.constant dense<0.000000e+00> : tensor<4x4x32xf16, #AL3D>
+  %b = "tt.reduce" (%cst0) ({
+  ^bb0(%arg0: f16, %arg1: f16):
+    %add = arith.addf %arg0, %arg1 : f16
+    tt.reduce.return %add : f16
+  }) {axis = 2 : i32} : (tensor<4x4x32xf16, #AL3D>) -> tensor<4x4xf16, #sliceAl3d2>
   tt.return
 }
 

--- a/test/Conversion/tritongpu_to_llvm_npot.mlir
+++ b/test/Conversion/tritongpu_to_llvm_npot.mlir
@@ -1,0 +1,82 @@
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file --allocate-shared-memory-nv=compute-capability=90 --convert-triton-gpu-to-llvm=compute-capability=90 | FileCheck %s
+//
+// NPOT (non-power-of-2) elementwise lowering. A non-power-of-2 out-dim builds a
+// modular LinearLayout, so the per-element index arithmetic uses ADD + a modulo
+// (Barrett multiply-shift, or the compare-subtract fast path when the value is
+// provably < 2N) instead of the pow2 GF(2) XOR. The AND-mask fast path replaces
+// the modulo entirely for dense identity bases (x mod 2^k == x & (2^k - 1)).
+// The pow2 companion module below asserts the modular ops never appear when the
+// shape is a power of two -> the NPOT path is byte-identical for pow2 / flag-off.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // N=48 is not a power of two and its worst-case index exceeds 2N, so the
+  // modulo lowers to Barrett reduction: q = (x * M) >> k; x - q*N, with the
+  // compile-time constants M = 5726623062 and k = 38 for N = 48.
+  // CHECK-LABEL: llvm.func @npot_barrett
+  // CHECK: %[[M:.*]] = llvm.mlir.constant(5726623062 : i64) : i64
+  // CHECK: llvm.mul %{{.*}}, %[[M]] : i64
+  // CHECK: %[[K:.*]] = llvm.mlir.constant(38 : i64) : i64
+  // CHECK: llvm.lshr %{{.*}}, %[[K]] : i64
+  // CHECK: llvm.trunc %{{.*}} : i64 to i32
+  // CHECK: %[[N:.*]] = llvm.mlir.constant(48 : i32) : i32
+  // CHECK: llvm.mul %{{.*}}, %[[N]] : i32
+  // CHECK: llvm.sub %{{.*}}, %{{.*}} : i32
+  tt.func public @npot_barrett(%arg0: !tt.ptr<f32>) {
+    %0 = tt.make_range {end = 48 : i32, start = 0 : i32} : tensor<48xi32, #blocked>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<48x!tt.ptr<f32>, #blocked>
+    %2 = tt.addptr %1, %0 : tensor<48x!tt.ptr<f32>, #blocked>, tensor<48xi32, #blocked>
+    %3 = arith.sitofp %0 : tensor<48xi32, #blocked> to tensor<48xf32, #blocked>
+    tt.store %2, %3 : tensor<48x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // N=1023 has dense identity register/lane/warp bases, so combining them hits
+  // the AND-mask fast path: (x mod 2^7) == x & 127 (highBit = 7, ceil(log2 1023)
+  // = 10 but the combined lane+warp span here is 128). The per-register ADD then
+  // overshoots at most into [N, 2N), so the final modulo is the cheap
+  // compare-subtract path (icmp uge N + select), not Barrett (no i64 multiply).
+  // CHECK-LABEL: llvm.func @npot_andmask
+  // CHECK: %[[MASK:.*]] = llvm.mlir.constant(127 : i32) : i32
+  // CHECK: llvm.and %{{.*}}, %[[MASK]] : i32
+  // CHECK: llvm.add %{{.*}}, %{{.*}} : i32
+  // CHECK: %[[N:.*]] = llvm.mlir.constant(1023 : i32) : i32
+  // CHECK: llvm.icmp "uge" %{{.*}}, %[[N]] : i32
+  // CHECK: llvm.select %{{.*}}, %{{.*}}, %{{.*}} : i1, i32
+  // Barrett must not appear for this size (no 64-bit multiply-shift modulo).
+  // CHECK-NOT: llvm.mul %{{.*}}, %{{.*}} : i64
+  tt.func public @npot_andmask(%arg0: !tt.ptr<f32>) {
+    %0 = tt.make_range {end = 1023 : i32, start = 0 : i32} : tensor<1023xi32, #blocked>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1023x!tt.ptr<f32>, #blocked>
+    %2 = tt.addptr %1, %0 : tensor<1023x!tt.ptr<f32>, #blocked>, tensor<1023xi32, #blocked>
+    %3 = arith.sitofp %0 : tensor<1023xi32, #blocked> to tensor<1023xf32, #blocked>
+    tt.store %2, %3 : tensor<1023x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // Pow2 companion (N=256): the shape is a power of two so the layout is never
+  // modular. The index arithmetic stays on the original GF(2) XOR path -- none
+  // of the modular ops (Barrett i64 multiply-shift, or the compare-subtract
+  // modulo) appear. This is the byte-identity guard: pow2 lowering is unchanged.
+  // CHECK-LABEL: llvm.func @pow2_no_modulo
+  // CHECK-NOT: llvm.mul %{{.*}}, %{{.*}} : i64
+  // CHECK-NOT: llvm.icmp "uge"
+  tt.func public @pow2_no_modulo(%arg0: !tt.ptr<f32>) {
+    %0 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked>
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>, #blocked>
+    %2 = tt.addptr %1, %0 : tensor<256x!tt.ptr<f32>, #blocked>, tensor<256xi32, #blocked>
+    %3 = arith.sitofp %0 : tensor<256xi32, #blocked> to tensor<256xf32, #blocked>
+    tt.store %2, %3 : tensor<256x!tt.ptr<f32>, #blocked>
+    tt.return
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm_npot_reduce_reject.mlir
+++ b/test/Conversion/tritongpu_to_llvm_npot_reduce_reject.mlir
@@ -1,0 +1,26 @@
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file --allocate-shared-memory-nv=compute-capability=90 --convert-triton-gpu-to-llvm=compute-capability=90 -verify-diagnostics
+//
+// Fail-safe: an NPOT reduction axis rounds up to a power of two, creating
+// phantom register/lane/warp slots that must be identity-filled before the
+// reduce. When the combine region has no determinable reduction identity (here
+// a single-op arith.divf, which is neither a known scalar neutral nor a
+// directional cmp+select arg-reduce), predicateAccWithIdentity() returns false
+// and the pass must LOUD-REJECT rather than silently miscompute. This proves
+// unrecognized combines are rejected, not silently mislowered.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @npot_reduce_divf_no_identity(%arg0: tensor<1x48xf32, #blocked>) {
+    // 48 is not a power of two, so the reduction axis wraps and needs
+    // identity-fill; arith.divf has no reduction identity, so the pattern emits
+    // a loud error and the conversion framework then reports the illegal op.
+    // expected-error @+2 {{requires a known reduction identity}}
+    // expected-error @+1 {{failed to legalize operation 'tt.reduce'}}
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %1 = arith.divf %lhs, %rhs : f32
+      tt.reduce.return %1 : f32
+    }) : (tensor<1x48xf32, #blocked>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return
+  }
+}

--- a/test/TritonGPU/npot-memdesc-verify-strict.mlir
+++ b/test/TritonGPU/npot-memdesc-verify-strict.mlir
@@ -1,0 +1,17 @@
+// RUN: TRITON_ALLOW_NPOT=0 triton-opt %s -verify-diagnostics
+
+// Flag-gating half of the relaxation: with TRITON_ALLOW_NPOT OFF, the exact
+// same alloc that npot-memdesc-verify.mlir accepts flag-ON is rejected. Proves
+// verifyAllocOp is byte-identical to the pre-NPOT strict check when the flag is
+// off (an alloc is never born a subview).
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+tt.func @flag_off_rejects_rounded() {
+  // expected-error @+1 {{result shape and its alloc shape must match}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<144x64xf16, #shared, #smem, mutable, 256x64>
+  tt.return
+}
+}

--- a/test/TritonGPU/npot-memdesc-verify.mlir
+++ b/test/TritonGPU/npot-memdesc-verify.mlir
@@ -1,0 +1,78 @@
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file -verify-diagnostics
+
+// verifyAllocOp (Ops.cpp) under TRITON_ALLOW_NPOT: an alloc may have
+// shape != allocShape ONLY when allocShape is the pow2-ceil rounding of shape
+// (getAllocationShapePerCTA rounds NPOT tile dims up to the next power of two).
+// The gate is a per-dim pow2-ceil match, NOT a "shape is NPOT" test, so pow2
+// dims keep the strict guarantee and single-buffer NPOT allocs are accepted.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+// ACCEPT: single-buffer NPOT tile rounded to pow2 (144 -> 256). The leading dim
+// is itself a tile here; a drop_front(1) rule would wrongly reject this.
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+tt.func @npot_single_buffer_rounded() {
+  %a = ttg.local_alloc : () -> !ttg.memdesc<144x64xf16, #shared, #smem, mutable, 256x64>
+  tt.return
+}
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+// ACCEPT: multi-buffered NPOT (leading pipeline-stage dim 6 preserved exactly,
+// trailing tile dim 144 -> 256).
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+tt.func @npot_multibuffer_rounded() {
+  %a = ttg.local_alloc : () -> !ttg.memdesc<6x144x64xf16, #shared, #smem, mutable, 6x256x64>
+  tt.return
+}
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+// REJECT: over-alloc -- 144 grown to 512, not its pow2-ceil 256.
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+tt.func @npot_over_alloc() {
+  // expected-error @+1 {{result shape and its alloc shape must match}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<144x64xf16, #shared, #smem, mutable, 512x64>
+  tt.return
+}
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+// REJECT: a pow2 shape keeps the full strict guarantee even flag-ON --
+// PowerOf2Ceil(128) == 128, so 128 != 256 cannot be a rounding.
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+tt.func @pow2_mismatch_still_strict() {
+  // expected-error @+1 {{result shape and its alloc shape must match}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 256x64>
+  tt.return
+}
+}
+
+// -----
+
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+// REJECT: the NPOT exemption relaxes only the pow2 requirement, never the
+// non-zero one -- a zero trailing dim is rejected even flag-ON for an exempt
+// (NVMMAShared) encoding.
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+tt.func @exempt_zero_trailing_dim_rejected() {
+  // expected-error @+1 {{allocShape must have power-of-2 and non-zero dimensions}}
+  %a = ttg.local_alloc : () -> !ttg.memdesc<6x0x64xf16, #nvmma, #smem, mutable>
+  tt.return
+}
+}

--- a/test/TritonGPU/verify-npot-dot-mma-layout.mlir
+++ b/test/TritonGPU/verify-npot-dot-mma-layout.mlir
@@ -1,0 +1,50 @@
+// Flag ON: NPOT dot-operand / MMA tensors PASS verifyTensorLayout and the
+// module round-trips cleanly (FileCheck the op labels are printed back).
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt --split-input-file %s | FileCheck %s
+//
+// Flag OFF (default): the same NPOT tensors are REJECTED by verifyTensorLayout
+// with the "not a power of two" diagnostic.
+// RUN: triton-opt --split-input-file %s --verify-diagnostics
+//
+// The NPOT allow-set admits DotOperand/NvidiaMma/AMDMfma/AMDWmma under the flag
+// so an NPOT tl.dot's tensors verify; parents keep pow2 sizePerThread/
+// threadsPerWarp, only the shape is NPOT. Verifier only, not dot codegen.
+
+// NPOT dot-operand (opIdx = 0). Shape N=96 is not a power of two.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @npot_dot_operand
+  tt.func public @npot_dot_operand(%arg0: tensor<16x96xf16, #dot0>) {
+    // expected-error @+1 {{which is not a power of two}}
+    %0 = ttg.convert_layout %arg0 : tensor<16x96xf16, #dot0> -> tensor<16x96xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// NPOT Nvidia MMA (MMAv2) result tensor. Shape N=96 is not a power of two.
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @npot_nvidia_mma
+  tt.func public @npot_nvidia_mma(%arg0: tensor<128x96xf16, #mma>) {
+    // expected-error @+1 {{which is not a power of two}}
+    %0 = ttg.convert_layout %arg0 : tensor<128x96xf16, #mma> -> tensor<128x96xf16, #mma>
+    tt.return
+  }
+}
+
+// -----
+
+// NPOT AMD MFMA (wave64) tensor. Shape N=96 is not a power of two. This is the
+// encoding the native AMD MFMA NPOT GEMM path depends on being admitted.
+#mfma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32, 16], isTransposed = false}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @npot_amd_mfma
+  tt.func public @npot_amd_mfma(%arg0: tensor<128x96xf16, #mfma>) {
+    // expected-error @+1 {{which is not a power of two}}
+    %0 = ttg.convert_layout %arg0 : tensor<128x96xf16, #mfma> -> tensor<128x96xf16, #mfma>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -621,14 +621,19 @@ unsigned getVectorSize(Value ptr, ModuleAxisInfoAnalysis &axisAnalysisPass) {
     return 1;
   auto contiguity = getContiguity(ptr, axisAnalysisPass);
   auto pointeeBitWidth = triton::getPointeeBitWidth(tensorTy);
-  return std::min<unsigned>(128 / pointeeBitWidth, contiguity);
+  unsigned vec = std::min<unsigned>(128 / pointeeBitWidth, contiguity);
+  // No-op for pow2; clamps the NPOT sizePerThread misalign (see NVIDIA).
+  return clampVecSizeForNpot(vec, tensorTy);
 }
 
 unsigned getVectorSize(Value ptr, Value offset,
                        ModuleAxisInfoAnalysis &axisAnalysisPass) {
   auto contiguity = getContiguity(ptr, offset, axisAnalysisPass);
   auto pointeeBitWidth = triton::getPointeeBitWidth(ptr.getType());
-  return std::min<unsigned>(128 / pointeeBitWidth, contiguity);
+  unsigned vec = std::min<unsigned>(128 / pointeeBitWidth, contiguity);
+  auto tensorTy =
+      dyn_cast<RankedTensorType>(getPointerTypeWithShape(ptr, offset));
+  return clampVecSizeForNpot(vec, tensorTy);
 }
 
 Type scaleDotElemTypeToMLIRType(MLIRContext *ctx, triton::ScaleDotElemType t) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.cpp
@@ -7,6 +7,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/GenericSwizzling.h"
 #include "triton/Tools/LayoutUtils.h"
@@ -59,7 +60,7 @@ static unsigned getNumScratchElemsSwizzledCvt(RankedTensorType srcTy,
   auto [smem, _] = triton::gpu::optimalSwizzling(srcLayout, dstLayout, srcTiles,
                                                  dstTiles, bitwidth);
   auto reps = smem.getInDimSize(StringAttr::get(ctx, "reps"));
-  return smem.getTotalOutDimSize() / reps;
+  return smem.getTotalOutDimSizeProduct() / reps;
 }
 
 std::function<unsigned(Operation *)>
@@ -68,6 +69,16 @@ getNvidiaAllocationAnalysisScratchSizeFn(TargetInfoBase &targetInfo) {
     if (auto cvtOp = dyn_cast<triton::gpu::ConvertLayoutOp>(op)) {
       auto srcTy = cvtOp.getSrc().getType();
       auto dstTy = cvtOp.getType();
+      if (hasNpotShape(srcTy) || hasNpotShape(dstTy)) {
+        // NPOT: the nvidia optimalSwizzling path below under-sizes the scratch
+        // (SMEM OOB), so delegate to the shared getNumScratchElemsSwizzledCvt
+        // which matches the base-class modular cvt lowering exactly.
+        if (!cvtNeedsSharedMemory(srcTy, dstTy)) {
+          return 0;
+        }
+        auto elems = mlir::triton::getNumScratchElemsSwizzledCvt(srcTy, dstTy);
+        return elems * getBitwidth(srcTy) / 8;
+      }
       if (!cvtNeedsSharedMemory(srcTy, dstTy))
         return 0;
       // In cuda we always swizzle

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -162,7 +162,8 @@ struct LoadStoreConversionBase {
     LDBG("getVectorSize contiguity = " << contiguity << " pointeeBitWidth = "
                                        << pointeeBitWidth);
     // The maximum vector size is 128 bits on NVIDIA GPUs.
-    return std::min<unsigned>(128 / pointeeBitWidth, contiguity);
+    unsigned vec = std::min<unsigned>(128 / pointeeBitWidth, contiguity);
+    return clampVecSizeForNpot(vec, tensorTy);
   }
 
   unsigned getMaskAlignment(Value mask) const {

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -769,6 +769,49 @@ TEST_F(LinearLayoutTest, FreeVariableMasks) {
             AR({{S("in"), 0b110}}));
 }
 
+// The pow2-only fast paths in isExpensiveView and the convert-layout no-op
+// collapse cannot distinguish two *different* modular (ADD-mod-N) register
+// maps, so they would treat a modular relayout as a cheap identity no-op and
+// scramble elements. These tests pin the two discriminators used by the
+// modular-aware guards:
+//   1. getFreeVariableMasks() is a conservative all-zero-basis check and
+//   returns
+//      the SAME masks for two different modular maps (isExpensiveView's old
+//      fast path relies on it -> false "cheap"). operator!= DOES distinguish
+//      them.
+//   2. quotient()/squareSublayoutIsIdentity() uses the pure GF(2) predicate
+//      (basis == 1<<b), which false-positives on a modular register basis, so
+//      minimalCvtLayout would quotient the register dim away and collapse to a
+//      no-op. isModular() flags the layout so the guard refuses the collapse.
+TEST_F(LinearLayoutTest, ModularRelayoutIsNotIdentity) {
+  // Two distinct modular maps over Z/6: strides 1 and 5. They are genuinely
+  // different permutations of {0..5} but the conservative free-variable mask is
+  // identical (no zero bases in either) -> the old isExpensiveView fast path
+  // would call them equal ("cheap").
+  auto modId = LinearLayout::modularStrided1D(6, 1, S("in"), S("out"));
+  auto modRev = LinearLayout::modularStrided1D(6, 5, S("in"), S("out"));
+  EXPECT_TRUE(modId.isModular());
+  EXPECT_TRUE(modRev.isModular());
+  // Old fast path: same free-variable masks despite being different maps.
+  EXPECT_EQ(to_vector(modId.getFreeVariableMasks()),
+            to_vector(modRev.getFreeVariableMasks()));
+  // The guard's discriminator: they are not equal.
+  EXPECT_NE(modId, modRev);
+  EXPECT_EQ(modId, modId);
+}
+
+TEST_F(LinearLayoutTest, ModularRegisterDimNotQuotientedAway) {
+  // A non-identity modular register map (stride 5 over Z/6). The GF(2) identity
+  // predicate used by squareSublayoutIsIdentity treats basis 5 (== 0b101) as
+  // "not identity" only for bit 0; but for a modular map the round-trip is not
+  // GF(2)-linear, so quotient must not silently drop it. Confirm isModular is
+  // set (the guard keys off it) and the map is not the identity.
+  auto modRev = LinearLayout::modularStrided1D(6, 5, S("register"), S("out"));
+  auto ident = LinearLayout::modularIdentity1D(6, S("register"), S("out"));
+  EXPECT_TRUE(modRev.isModular());
+  EXPECT_NE(modRev, ident);
+}
+
 TEST_F(LinearLayoutTest, QuotientOneDimension) {
   LinearLayout layout(
       {


### PR DESCRIPTION
Summary:
Relax the memdesc verifier to accept NPOT (non-power-of-2) allocation shapes,
gated on TRITON_ALLOW_NPOT. Two verifiers change; both are flag-OFF
byte-identical to the original strict checks.

MemDescType::verify (Types.cpp): trailing alloc dims must always be non-zero, and
power-of-2 unless the encoding is one whose physical alloc is pow2-rounded by
getAllocationShapePerCTA (NVMMAShared, TMEM, TMEM-scale). Only the pow2 rule is
relaxed for those encodings; the non-zero rule always holds.

verifyAllocOp (Ops.cpp): an alloc is normally its own full footprint
(shape == allocShape). Under the flag, accept shape != allocShape only when it is
exactly a pow2 rounding -- same rank and each dim either unchanged or its
PowerOf2Ceil. This keeps pow2 shapes strict (PowerOf2Ceil(pow2) == pow2), accepts
single-buffer NPOT allocs (position-independent, unlike a leading-dim carve-out),
and still rejects over-allocs. MemDescType::verify already checks rank and
shape[i] <= allocShape[i].

This is a flag-gated relaxation rather than the earlier unconditional removal of
the check (which dropped the guarantee for every build).

Authored with Claude.

Differential Revision: D110214711
