### PR TITLE
 [TritonNvidiaGPU] Fix 2-CTA TMEM verify crash (#1905)

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -432,12 +432,17 @@ LogicalResult TensorMemoryEncodingAttr::verify(
     return emitError() << "CGALayout must have rank 2";
   }
   if (twoCTAs) {
+    // twoCTAs does not imply a sharded accumulator: num_ctas>1 shards it across
+    // the cluster (block axis = [1,0]), while ctas_per_cga with num_ctas==1
+    // keeps it single-CTA (empty block axis). Only check the shard direction
+    // when a shard exists -- never getBasis() an empty axis.
     auto kBlock = StringAttr::get(cgaLayout.getContext(), "block");
     auto cgaLL = cgaLayout.getLinearLayout();
-    if (cgaLL.getBasis(kBlock, 0) != ArrayRef{1, 0}) {
+    if (cgaLL.hasInDim(kBlock) && cgaLL.getInDimSizeLog2(kBlock) >= 1 &&
+        cgaLL.getBasis(kBlock, 0) != ArrayRef{1, 0}) {
       return emitError()
-             << "twoCTAs layout requires the first CGALayout block basis to "
-                "be [1, 0]";
+             << "twoCTAs layout with a CTA shard requires the first CGALayout "
+                "block basis to be [1, 0]";
     }
   }
   if (blockM != 64 && blockM != 128) {

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -818,6 +818,29 @@ module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32,
 
 // -----
 
+// twoCTAs via ctas_per_cga (num_ctas=1) with BLOCK_M>=128: the 2-CTA MMA is
+// created with a single-CTA accumulator (twoCTAs=true, empty block axis). Meta
+// warp-specialized path -- regression guard for the getBasis crash in
+// TensorMemoryEncodingAttr::verify.
+// CHECK: #[[$TMEM:.+]] = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, twoCTAs = true>
+#blocked_2cta = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: two_ctas_ctas_per_cga
+  tt.func public @two_ctas_ctas_per_cga(
+    %a: tensor<128x64xf16, #blocked_2cta>,
+    %b: tensor<64x128xf16, #blocked_2cta>,
+    %c: tensor<128x128xf32, #blocked_2cta>) -> tensor<128x128xf32, #blocked_2cta> {
+    %ad = ttg.convert_layout %a : tensor<128x64xf16, #blocked_2cta> -> tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked_2cta}>>
+    %bd = ttg.convert_layout %b : tensor<64x128xf16, #blocked_2cta> -> tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked_2cta}>>
+    // CHECK: ttng.tmem_alloc {{.*}}#[[$TMEM]]
+    // CHECK: ttng.tc_gen5_mma {{.*}} {two_ctas}
+    %d = tt.dot %ad, %bd, %c {two_ctas} : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #blocked_2cta}>> * tensor<64x128xf16, #ttg.dot_op<{opIdx = 1, parent = #blocked_2cta}>> -> tensor<128x128xf32, #blocked_2cta>
+    tt.return %d : tensor<128x128xf32, #blocked_2cta>
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>


### PR DESCRIPTION
Summary:
## Issue
`TensorMemoryEncodingAttr::verify` (introduced by the [https://github.com/facebookexperimental/triton/issues/1840 cherry-pick](https://github.com/facebookexperimental/triton/commit/69868ac932b28f94cd6703e704c39b2e6e30689e) of upstream PR #9557) requires a twoCTAs accumulator to carry a sharded `CGALayout`, i.e. the "block" axis first basis must be [1, 0]. That assumes upstream's num_ctas>1 representation, where a 2-CTA MMA always shards the accumulator across the cluster.

Meta's warp-specialized 2-CTA path does not use that representation. It sets `ctas_per_cga=(2,1,1)`, which pins `num_ctas=1`, so tensors are not sharded or accessed through remote CTA. So in our path, `verify` called `getBasis` on the empty "block" axis and hit an out-of-range assert `Assertion static_cast<size_t>(pos) < it->second.size() failed`. This crashed every tl.dot(two_ctas=True) + ctas_per_cga kernel, including the tritonbench scaled_mm kernel, pytests third_party/tlx/tutorials/blackwell-triton-addmm-2cta_test.py and python/test/unit/language/test_dot_2cta.py.

## Fix
The fix only enforces the block-basis check when a shard actually exists, and never calls `getBasis` on an empty axis. This restores the behavior in which `twoCTAs` is independent of the tensor shard, while still preserve the upstream intention of rejecting a genuinely mis-sharded num_ctas>1 layout. 

Also added a LIT regression test covers the previously-untested success path (cluster=2, num_ctas=1, BLOCK_M>=128); the existing two_ctas tests only covered the two fallback paths.


Test Plan:
1. lit test: test/TritonGPU/accelerate-matmul.mlir 

2. Previously-crashing tests now pass:
```  
pytest python/test/unit/language/test_dot_2cta.py -q                     # 1 passed
pytest third_party/tlx/tutorials/blackwell-triton-addmm-2cta_test.py -q -k "not perf"   # 13 passed
```
3. scaled_mm kernel compiles and runs:
```
  TRITON_USE_META_WS=1 python run.py --op fp8_gemm --scaling-pair TensorWise,TensorWise \
    --m 4096 --n 4096 --k 4096 --only triton_autows_fp8_gemm --metrics tflops
```

Reviewed By: manman-ren

Differential Revision: D110537437

Pulled By: Sibylau


