### PR TITLE
[TLX FA BWD] Packed dQ accumulator with postprocess kernel (#1920)

### DIFF
--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -945,6 +945,28 @@ def _attn_bwd_preprocess(O, DO,  #
 
 
 @triton.jit
+def _attn_bwd_dq_postprocess(DQ_ACCUM, DQ_OUT,  #
+                             N_CTX,  #
+                             BLK: tl.constexpr, HALF_HD: tl.constexpr,  #
+                             BLOCK_M: tl.constexpr, HEAD_DIM: tl.constexpr,  #
+                             ):
+    off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    off_hz = tl.program_id(1)
+    off_h = tl.arange(0, HEAD_DIM)
+    q = off_m[:, None]
+    h = off_h[None, :]
+    tile_base = (q // BLK) * BLK
+    local = q % BLK
+    half = h // HALF_HD
+    col = h % HALF_HD
+    packed_row = 2 * tile_base + local + BLK * half
+    src = DQ_ACCUM + off_hz * N_CTX * HEAD_DIM + packed_row * HALF_HD + col
+    val = tl.load(src)
+    dst = DQ_OUT + off_hz * N_CTX * HEAD_DIM + q * HEAD_DIM + h
+    tl.store(dst, val.to(DQ_OUT.dtype.element_ty))
+
+
+@triton.jit
 def bwd_calculate_offsets(
     tile_idx,
     n_tile_num,
@@ -968,11 +990,17 @@ def bwd_calculate_offsets(
     return off_chz, batch, head, start_m, start_n, num_steps
 
 
+_bwd_selected_meta = {}
+
+
 def _bwd_host_descriptor_pre_hook_tlx(nargs):
     BLOCK_M1 = nargs["BLOCK_M1"]
     BLOCK_N1 = nargs["BLOCK_N1"]
     HEAD_DIM = nargs["HEAD_DIM"]
     NUM_CTAS = nargs.get("NUM_CTAS", 1)
+
+    _bwd_selected_meta["BLOCK_M1"] = BLOCK_M1
+    _bwd_selected_meta["NUM_CTAS"] = NUM_CTAS
 
     # Reset dq accumulator to zeros before each autotuner warmup run.
     # dq uses TMA reduce-add, so stale values accumulate across runs.
@@ -983,8 +1011,13 @@ def _bwd_host_descriptor_pre_hook_tlx(nargs):
     nargs["desc_do"].block_shape = [1, 1, BLOCK_M1, HEAD_DIM // NUM_CTAS]
     nargs["desc_v"].block_shape = [1, 1, BLOCK_N1, HEAD_DIM]
     nargs["desc_k"].block_shape = [1, 1, BLOCK_N1, HEAD_DIM]
-    EPILOGUE_SUBTILE = nargs.get("EPILOGUE_SUBTILE", 4)
-    nargs["desc_dq"].block_shape = [1, 1, BLOCK_M1 // NUM_CTAS, HEAD_DIM // EPILOGUE_SUBTILE]
+    if NUM_CTAS > 1:
+        EPILOGUE_SUBTILE = nargs["EPILOGUE_SUBTILE"]
+        DQ_SLICE_N = HEAD_DIM // EPILOGUE_SUBTILE
+        nargs["desc_dq"].block_shape = [1, 1, BLOCK_M1, DQ_SLICE_N]
+    else:
+        DQ_REDUCE_NCOL = nargs["DQ_REDUCE_NCOL"]
+        nargs["desc_dq"].block_shape = [1, 1, BLOCK_M1, DQ_REDUCE_NCOL]
     DKV_STORE_NCOL = nargs["DKV_STORE_NCOL"]
     nargs["desc_dv"].block_shape = [1, 1, BLOCK_N1, DKV_STORE_NCOL]
     nargs["desc_dk"].block_shape = [1, 1, BLOCK_N1, DKV_STORE_NCOL]
@@ -1019,7 +1052,7 @@ configs_bwd_1cta = [
         num_warps=8,
         num_stages=1,
         pre_hook=_bwd_host_descriptor_pre_hook_tlx,
-    ) for bm1 in [64, 128] for uwb in [False, True]
+    ) for bm1 in [64] for uwb in [False, True]
 ]
 
 configs_bwd_2cta = [
@@ -2231,7 +2264,7 @@ def _attn_bwd_ws(
     DQ_STORE_M: tl.constexpr = BLOCK_M1 // NUM_CTAS
     DQ_SLICE_N: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
     if USE_2CTA:
-        dq_store_buf = tlx.local_alloc((DQ_STORE_M, DQ_SLICE_N), tlx.dtype_of(desc_dq), 2)
+        dq_store_buf = tlx.local_alloc((BLOCK_M1, DQ_SLICE_N), tlx.dtype_of(desc_dq), 2)
     else:
         DQ_REDUCE_ITERS: tl.constexpr = HEAD_DIM // DQ_REDUCE_NCOL
         dq_store_buf = tlx.local_alloc((BLOCK_M1, DQ_REDUCE_NCOL), tlx.dtype_of(desc_dq), DQ_REDUCE_STAGES)
@@ -2316,6 +2349,13 @@ def _attn_bwd_ws(
             DQ_BUF_IDX: tl.constexpr = 0
             dq_tiles = tlx.local_alloc(
                 (BLOCK_M1 // NUM_CTAS, HEAD_DIM),
+                tl.float32,
+                NUM_BUFFERS_TMEM,
+                tlx.storage_kind.tmem,
+                reuse=qk_p_storage_alias,
+            )
+            dq_phys = tlx.local_alloc(
+                (BLOCK_M1, HEAD_DIM // NUM_CTAS),
                 tl.float32,
                 NUM_BUFFERS_TMEM,
                 tlx.storage_kind.tmem,
@@ -2573,13 +2613,16 @@ def _attn_bwd_ws(
                 tlx.barrier_wait(dq_fulls[tmem_buf_id], tmem_phase)
                 if USE_2CTA:
                     dq_m_offset = cluster_cta_rank * DQ_STORE_M
-                    dq_full = tlx.local_load(dq_tiles[tmem_buf_id + DQ_BUF_IDX])
-                    # Release TMEM early: dQ is in registers, so the MMA
-                    # can reuse the TMEM slot for QK/dQ while we store.
-                    tlx.barrier_arrive(dq_empties[tmem_buf_id], 1, remote_cta_rank=0)
+                    packed_row_base = 2 * (curr_m + dq_m_offset)
+                    DQ_PACK_ITERS: tl.constexpr = (HEAD_DIM // NUM_CTAS) // DQ_SLICE_N
+                    dq_full = tlx.local_load(dq_phys[tmem_buf_id + DQ_BUF_IDX])
+                    if USE_WARP_BARRIER:
+                        tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                    else:
+                        tlx.barrier_arrive(dq_empties[tmem_buf_id], 1, remote_cta_rank=0)
                     dq_full = dq_full * LN2
-                    dq_slices = _split_n_2D(dq_full, EPILOGUE_SUBTILE)
-                    for slice_id in tl.static_range(EPILOGUE_SUBTILE):
+                    dq_slices = _split_n_2D(dq_full, DQ_PACK_ITERS)
+                    for slice_id in tl.static_range(DQ_PACK_ITERS):
                         dq_smem = dq_store_buf[slice_id % 2]
                         tlx.async_descriptor_store_wait(1)
                         tlx.local_store(dq_smem, dq_slices[slice_id].to(tlx.dtype_of(desc_dq)))
@@ -2589,12 +2632,14 @@ def _attn_bwd_ws(
                             [
                                 batch,
                                 head,
-                                curr_m + dq_m_offset,
+                                packed_row_base,
                                 slice_id * DQ_SLICE_N,
                             ],
                             store_reduce="add",
                         )
                 else:
+                    HALF_HD: tl.constexpr = HEAD_DIM // 2
+                    SLICES_PER_HALF: tl.constexpr = HALF_HD // DQ_REDUCE_NCOL
                     for slice_id in tl.static_range(DQ_REDUCE_ITERS):
                         dq_smem_idx = slice_id % DQ_REDUCE_STAGES
                         dq_slice = tlx.local_slice(
@@ -2609,14 +2654,16 @@ def _attn_bwd_ws(
                             dq_store_buf[dq_smem_idx],
                             dq.to(tlx.dtype_of(desc_dq)),
                         )
+                        packed_half = slice_id // SLICES_PER_HALF
+                        packed_col = (slice_id % SLICES_PER_HALF) * DQ_REDUCE_NCOL
                         tlx.async_descriptor_store(
                             desc_dq,
                             dq_store_buf[dq_smem_idx],
                             [
                                 batch,
                                 head,
-                                curr_m,
-                                slice_id * DQ_REDUCE_NCOL,
+                                2 * curr_m + BLOCK_M1 * packed_half,
+                                packed_col,
                             ],
                             store_reduce="add",
                         )
@@ -2863,6 +2910,11 @@ def _attn_bwd_ws(
                     tlx.fence("async_shared")
                     tlx.barrier_arrive(ds_fulls[ds_buf_id_relay], 1, remote_cta_rank=0)
 
+        # TODO: empty task to absorb warps — needs num_warps bump in configs
+        # EMPTY_WARPS: tl.constexpr = 1 if USE_2CTA else 2
+        # with tlx.async_task(num_warps=EMPTY_WARPS, registers=24):
+        #     pass
+
 
 class _attention(torch.autograd.Function):
 
@@ -2942,10 +2994,12 @@ class _attention(torch.autograd.Function):
         q, k, v, o, M = ctx.saved_tensors
         assert q.is_contiguous() and k.is_contiguous() and v.is_contiguous()
         assert o.is_contiguous() and do.is_contiguous()
-        dq = torch.zeros(q.shape, device=q.device, dtype=torch.float32)
+        dq = torch.empty(q.shape, device=q.device, dtype=torch.float32)
         dk = torch.empty_like(k)
         dv = torch.empty_like(v)
         BATCH, N_HEAD, N_CTX = q.shape[:3]
+        _HALF_HD = ctx.HEAD_DIM // 2
+        dq_accum = torch.zeros([BATCH, N_HEAD, N_CTX, ctx.HEAD_DIM], device=q.device, dtype=torch.float32)
         PRE_BLOCK = 128
         BLK_SLICE_FACTOR = 2
         RCP_LN2 = 1.4426950408889634  # = 1.0 / ln(2)
@@ -2989,10 +3043,12 @@ class _attention(torch.autograd.Function):
             strides=desc_strides,
             block_shape=dummy_block,
         )
+        packed_shape = [BATCH, N_HEAD, 2 * N_CTX, _HALF_HD]
+        packed_strides = [N_HEAD * N_CTX * HEAD_DIM, N_CTX * HEAD_DIM, _HALF_HD, 1]
         desc_dq = TensorDescriptor(
-            dq,
-            shape=desc_shape,
-            strides=desc_strides,
+            dq_accum,
+            shape=packed_shape,
+            strides=packed_strides,
             block_shape=dummy_block,
         )
         desc_dk = TensorDescriptor(
@@ -3048,6 +3104,15 @@ class _attention(torch.autograd.Function):
             BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
             HEAD_DIM=ctx.HEAD_DIM,  #
             STAGE=stage,  #
+        )
+
+        _blk = _bwd_selected_meta["BLOCK_M1"] // _bwd_selected_meta["NUM_CTAS"]
+        post_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
+        _attn_bwd_dq_postprocess[post_grid](
+            dq_accum, dq,  #
+            N_CTX,  #
+            BLK=_blk, HALF_HD=_HALF_HD,  #
+            BLOCK_M=PRE_BLOCK, HEAD_DIM=ctx.HEAD_DIM,  #
         )
 
         return dq, dk, dv, None, None

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -19,11 +19,13 @@ from triton.language.extra.tlx.tutorials.blackwell_gemm_2cta import (
 from triton.language.extra.tlx.tutorials.blackwell_fa_ws_pipelined_persistent import (
     attention as _blackwell_fa_ws_pipelined_persistent,
     _attn_bwd_preprocess as _blackwell_fa_bwd_preprocess,
+    _attn_bwd_dq_postprocess as _blackwell_fa_bwd_dq_postprocess,
     _attn_bwd_ws as _blackwell_fa_bwd_ws,
     _attn_fwd_ws as _blackwell_fa_fwd_ws,
     _host_descriptor_pre_hook as _blackwell_fa_fwd_pre_hook,
     configs_bwd_1cta as _configs_bwd_1cta,
     configs_bwd_2cta as _configs_bwd_2cta,
+    _bwd_selected_meta,
 )
 from triton.language.extra.tlx.tutorials.blackwell_fa_clc import (
     attention as _blackwell_fa_clc, )
@@ -592,9 +594,12 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(causal, RESCALE_OPT, USE_WHERE
         _blackwell_fa_bwd_preprocess[pre_grid](o, do, delta, N_CTX, BLOCK_M=PRE_BLOCK, HEAD_DIM=HEAD_DIM)
 
         # Backward: main kernel
-        dq = torch.zeros(q.shape, device=q.device, dtype=torch.float32)
+        dq = torch.empty(q.shape, device=q.device, dtype=torch.float32)
         dk = torch.empty_like(k)
         dv = torch.empty_like(v)
+
+        _HALF_HD = HEAD_DIM // 2
+        dq_accum = torch.zeros([Z, H, N_CTX, HEAD_DIM], device=q.device, dtype=torch.float32)
 
         dummy_block_4d = [1, 1, 1, 1]
         desc_shape = [Z, H, N_CTX, HEAD_DIM]
@@ -603,7 +608,9 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(causal, RESCALE_OPT, USE_WHERE
         desc_bv = TensorDescriptor(v, shape=desc_shape, strides=desc_strides, block_shape=dummy_block_4d)
         desc_bq = TensorDescriptor(q, shape=desc_shape, strides=desc_strides, block_shape=dummy_block_4d)
         desc_do = TensorDescriptor(do, shape=desc_shape, strides=desc_strides, block_shape=dummy_block_4d)
-        desc_dq = TensorDescriptor(dq, shape=desc_shape, strides=desc_strides, block_shape=dummy_block_4d)
+        _dq_desc_shape = [Z, H, 2 * N_CTX, _HALF_HD]
+        _dq_desc_strides = [H * N_CTX * HEAD_DIM, N_CTX * HEAD_DIM, _HALF_HD, 1]
+        desc_dq = TensorDescriptor(dq_accum, shape=_dq_desc_shape, strides=_dq_desc_strides, block_shape=dummy_block_4d)
         desc_dk = TensorDescriptor(dk, shape=desc_shape, strides=desc_strides, block_shape=dummy_block_4d)
         desc_dv = TensorDescriptor(dv, shape=desc_shape, strides=desc_strides, block_shape=dummy_block_4d)
         desc_m = TensorDescriptor(M, shape=[Z * H * N_CTX], strides=[1], block_shape=[1])
@@ -648,6 +655,14 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(causal, RESCALE_OPT, USE_WHERE
             BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,
             HEAD_DIM=HEAD_DIM,
             STAGE=stage,
+        )
+
+        _blk = _bwd_selected_meta["BLOCK_M1"] // _bwd_selected_meta["NUM_CTAS"]
+        post_grid = (N_CTX // PRE_BLOCK, Z * H)
+        _blackwell_fa_bwd_dq_postprocess[post_grid](
+            dq_accum, dq, N_CTX,
+            BLK=_blk, HALF_HD=HEAD_DIM // 2,
+            BLOCK_M=PRE_BLOCK, HEAD_DIM=HEAD_DIM,
         )
 
         torch.testing.assert_close(dv, ref_dv, atol=1e-2, rtol=0)


### PR DESCRIPTION
Summary:

Replace `_split_n_2D` (STS+LDSM transpose) in the dQ reduction epilogue with a packed physical TMEM read + packed FP32 accumulator + lightweight postprocess kernel, for both 1-CTA and 2-CTA backward configs.

For 2-CTA, `dq_phys` reads the physical TMEM layout directly (128 x HEAD_DIM/2), avoiding the register-hungry transpose. The dQ reduction uses a single bulk `local_load` of the full `dq_phys` buffer to registers, immediately releases TMEM via `barrier_arrive`, then splits in registers with `_split_n_2D` for staged SMEM→TMA stores. This matches FA4's approach (`Ld32x32bOp` bulk copy + immediate `consumer_release`).

For 1-CTA, the logical TMEM data is written to packed coordinates (2*curr_m + BLOCK_M1*half), similarly skipping the transpose. A separate `_attn_bwd_dq_postprocess` kernel unpacks the packed FP32 accumulator back to the natural [M, HEAD_DIM] layout.

Performance (TFLOPS, bf16, B=4, H=48, D=128, non-causal):

Before (slice-by-slice TMEM load):
  SeqLen   cuDNN   TLX     FA4
  1024     596     513     620
  2048     711     667     770
  4096     774     765     874
  8192     815     832     936
  16384    843     869     978
  avg      748     729     835

After (bulk TMEM load + `_split_n_2D`):
  SeqLen   cuDNN   TLX     FA4
  1024     599     502     620
  2048     711     678     775
  4096     774     793     875
  8192     814     878     935
  16384    840     921     979
  avg      748     754     837

TLX average improved from 729 to 754 TFLOPS (+3.4%). At longer sequences the gains are larger: S=8192 832→878 (+5.5%), S=16384 869→921 (+6.0%). Short sequences (S=1024) regress slightly due to the postprocess kernel overhead amortizing less. The gap to FA4 narrowed from 12.7% to 9.9%.

NCU comparison (B=4, H=48, S=8192, D=128, 2-CTA):
- Old TLX (packed, slice-by-slice): 25.79ms, TC 56.5%, L1TEX stall 9.0 cycles
- New TLX (packed, bulk load): 19.94ms, TC 75.0%, L1TEX stall 5.0 cycles
- FA4: 18.62ms, TC 78.8%, L1TEX stall 4.8 cycles

Remaining gap vs FA4 is primarily register spill (TLX 7.09 MB vs FA4 221 KB), a Triton compiler limitation.

Also fixes the `desc_dq` block_shape in the pre_hook to use `DQ_SLICE_N` for 2-CTA instead of `DQ_REDUCE_NCOL`. Authored with Claude.

Reviewed By: pchen7e2

Differential Revision: D109966704


