### PR TITLE
[torchTLX] move codebase to triton-beta / fbtriton (#1926)

### DIFF
--- a/third_party/tlx/language/tlx/inductor/README
+++ b/third_party/tlx/language/tlx/inductor/README
@@ -1,0 +1,7 @@
+### Q1 FY26 Plan
+
+In Q1’26, we plan to gate most future iterations within the `fb/` folder until they are production-ready. This includes:
+
+- modifying **TLX template files**
+- modifying **TLX heuristic configurations**
+- tuning **TLX template options**

--- a/third_party/tlx/language/tlx/inductor/__init__.py
+++ b/third_party/tlx/language/tlx/inductor/__init__.py
@@ -1,0 +1,6 @@
+# TorchTLX inductor integration.
+#
+# These modules import torch._inductor internals and are loaded lazily by
+# PyTorch (via torch/_inductor/template_heuristics/tlx.py) -- never by triton
+# itself. Do not import this subpackage from the tlx __init__ chain, or a
+# triton-only consumer would pull in torch.

--- a/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
@@ -1,0 +1,126 @@
+{{def_kernel("A", "B")}}
+    # TLX warp-pipelined addmm for AMD (MI350X / gfx950), COL-MAJOR B (stride_bk == 1).
+    # A:[M,K] row-major, B:[K,N] col-major (the nn.Linear weight-transpose layout).
+    # B is loaded as (BLOCK_N, BLOCK_K) tiles (K contiguous -> coalesced async_load) and
+    # transposed via tlx.local_trans for the MFMA. Bias is applied by store_output via the
+    # epilogue_fn / prefix_args supplied by the heuristic (not referenced here). num_stages=1.
+    #
+    # NOTE: tlx.async_load lowers to a 32-bit block pointer (flat-offset pattern, like the AMD
+    # warp-pipeline tutorials). It cannot represent 64-bit offsets, and a pre-advanced base pointer
+    # is miscompiled, so this template is restricted (by the heuristic) to shapes Inductor indexes
+    # with int32 (M*K and N*K statically < 2**31, i.e. static/bounded shapes).
+    M = {{size("A", 0)}}
+    N = {{size("B", 1)}}
+    K = {{size("A", 1)}}
+    if M * N == 0:
+        # early exit due to zero-size input(s)
+        return
+    stride_am = {{stride("A", 0)}}
+    stride_ak = {{stride("A", 1)}}
+    stride_bk = {{stride("B", 0)}}
+    stride_bn = {{stride("B", 1)}}
+    tl.assume(stride_am > 0)
+    tl.assume(stride_ak > 0)
+    tl.assume(stride_bk > 0)
+    tl.assume(stride_bn > 0)
+
+    # re-order program ID for better L2 performance
+    pid = tl.program_id(0).to(INDEX_DTYPE)
+    grid_m = (M + BLOCK_M - 1) // BLOCK_M
+    grid_n = (N + BLOCK_N - 1) // BLOCK_N
+
+    # L2 chiplet swizzle: group adjacent PIDs onto the same XCD in chunks so tiles that
+    # share operands hit warm L2. NUM_XCDS is injected by the heuristic (8 for gfx942/gfx950,
+    # else 1, which makes this an identity). Mirrors the standalone amd_addmm_mul.py
+    # chiplet_transform_chunked (XCD_CHUNK=4). PIDs in the trailing remainder (grid not a
+    # multiple of NUM_XCDS*XCD_CHUNK) pass through unchanged.
+    # Line-by-line walkthrough + chiplet diagrams: P2410594601.
+    XCD_CHUNK: tl.constexpr = 4
+    grid_mn = grid_m * grid_n
+    # aligned = largest whole number of NUM_XCDS*XCD_CHUNK "super-chunks"; only these are remapped.
+    aligned = (grid_mn // (NUM_XCDS * XCD_CHUNK)) * (NUM_XCDS * XCD_CHUNK)
+    if pid < aligned:
+        xcd = pid % NUM_XCDS            # the XCD the HW already placed this block on (fixed)
+        local_pid = pid // NUM_XCDS     # which round this block is within that XCD
+        # new logical tile = super-chunk base + this XCD's XCD_CHUNK-wide slot + position in slot,
+        # so consecutive tiles land as contiguous chunks on one XCD (a bijection; math unchanged).
+        pid = (local_pid // XCD_CHUNK) * (NUM_XCDS * XCD_CHUNK) + xcd * XCD_CHUNK + (local_pid % XCD_CHUNK)
+
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // (group_size)
+    tl.assume(pid_m >= 0)
+    tl.assume(pid_n >= 0)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)) % M
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N).to(INDEX_DTYPE)) % N
+    offs_k = tl.arange(0, BLOCK_K).to(INDEX_DTYPE)
+
+    a_base = offs_m[:, None] * stride_am
+    b_base = offs_n[:, None] * stride_bn          # B as (BLOCK_N, BLOCK_K): n is the row of the [N,K] view
+
+    K_ITERS = tl.cdiv(K, BLOCK_K)
+
+    smemA = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(A), NUM_BUFFERS)
+    smemB = tlx.local_alloc((BLOCK_N, BLOCK_K), tlx.dtype_of(B), NUM_BUFFERS)   # holds Bᵀ tile
+
+    # prologue: prefetch the first NUM_BUFFERS K-tiles (heuristic guarantees K_ITERS > NUM_BUFFERS)
+    for i in tl.range(0, NUM_BUFFERS, loop_unroll_factor=NUM_BUFFERS):
+        k_start = i * BLOCK_K
+        a_offs = a_base + (k_start + offs_k[None, :]) * stride_ak
+        b_offs = b_base + (k_start + offs_k[None, :]) * stride_bk
+        # int32 cast is lossless: the heuristic only emits this template when offsets fit int32.
+        tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, i), mask=offs_k[None, :] < K - k_start)
+        tlx.async_load_commit_group([tok_a])
+        tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, i), mask=offs_k[None, :] < K - k_start)
+        tlx.async_load_commit_group([tok_b])
+
+    tlx.async_load_wait_group((NUM_BUFFERS - 1) * 2)
+    a_tile = tlx.local_load(tlx.local_view(smemA, 0))
+    b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, 0)))
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+
+    for tile_id in tl.range(0, K_ITERS - NUM_BUFFERS):
+        # buffer indices MUST be int32: local_view feeds them to the block-ptr index check, which
+        # rejects int64. tile_id is int64 when K (-> K_ITERS) is symbolic (dynamic shapes).
+        prefetch_buf = (tile_id % NUM_BUFFERS).to(tl.int32)
+        next_buf = ((tile_id + 1) % NUM_BUFFERS).to(tl.int32)
+        k_prefetch = (tile_id + NUM_BUFFERS) * BLOCK_K
+
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+
+        tlx.async_load_wait_group(2)
+
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_offs = a_base + (k_prefetch + offs_k[None, :]) * stride_ak
+            b_offs = b_base + (k_prefetch + offs_k[None, :]) * stride_bk
+            tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, prefetch_buf),
+                                   mask=offs_k[None, :] < K - k_prefetch)
+            tlx.async_load_commit_group([tok_a])
+            tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, prefetch_buf),
+                                   mask=offs_k[None, :] < K - k_prefetch)
+            tlx.async_load_commit_group([tok_b])
+            a_tile = tlx.local_load(tlx.local_view(smemA, next_buf))
+            b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, next_buf)))
+
+    acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+    tlx.async_load_wait_group(0)
+    for i in tl.range(0, NUM_BUFFERS - 1, loop_unroll_factor=NUM_BUFFERS - 1):
+        buf = ((K_ITERS - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS).to(tl.int32)   # int32 buffer index
+        a_tile = tlx.local_load(tlx.local_view(smemA, buf))
+        b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, buf)))
+        acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+
+    # rematerialize rm and rn to save registers
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N).to(INDEX_DTYPE)
+    idx_m = rm[:, None]
+    idx_n = rn[None, :]
+    mask = (idx_m < M) & (idx_n < N)
+
+    # inductor generates a suffix (bias add via epilogue_fn + prefix_args, cast, store)
+    {{store_output(("idx_m", "idx_n"), "acc", "mask", val_shape=("BLOCK_M", "BLOCK_N"))}}

--- a/third_party/tlx/language/tlx/inductor/blackwell_gemm_ws.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/blackwell_gemm_ws.py.jinja
@@ -1,0 +1,615 @@
+{{def_kernel("A", "B")}}
+    M = {{size("A", 0)}}
+    N = {{size("B", 1)}}
+    K = {{size("A", 1)}}
+
+    stride_am = {{stride("A", 0)}}
+    stride_ak = {{stride("A", 1)}}
+    stride_bk = {{stride("B", 0)}}
+    stride_bn = {{stride("B", 1)}}
+
+    dsize: tl.constexpr = 2
+
+    desc_a = tl.make_tensor_descriptor(
+        A,
+        shape=[M, K],
+        strides=[stride_am, 1],
+        block_shape=[BLOCK_M_SPLIT, BLOCK_K],
+    )
+
+    desc_b = tl.make_tensor_descriptor(
+        B,
+        shape=[K, N],
+        strides=[stride_bk, 1],
+        block_shape=[BLOCK_K, BLOCK_N // NUM_CTAS],
+    )
+
+    buffers_A = tlx.local_alloc(
+        (BLOCK_M_SPLIT, BLOCK_K),
+        A.dtype.element_ty,
+        NUM_SMEM_BUFFERS * NUM_MMA_GROUPS,
+    )
+    buffers_B = tlx.local_alloc((BLOCK_K, BLOCK_N // NUM_CTAS), A.dtype.element_ty, NUM_SMEM_BUFFERS)
+    tmem_buffers = tlx.local_alloc(
+        (BLOCK_M_SPLIT, BLOCK_N),
+        tl.float32,
+        NUM_TMEM_BUFFERS * NUM_MMA_GROUPS,
+        tlx.storage_kind.tmem,
+    )
+{% if SPLIT_K > 1 %}
+    NUM_EPILOGUE_SMEM_BUFFERS: tl.constexpr = NUM_MMA_GROUPS if NUM_MMA_GROUPS > 2 else 2
+    ws_smem_buffers = tlx.local_alloc(
+        (BLOCK_M_SPLIT, slice_size),
+        tl.float32,
+        NUM_EPILOGUE_SMEM_BUFFERS,
+    )
+{% elif TMA_EPILOGUE_STORE %}
+    NUM_EPILOGUE_SMEM_BUFFERS: tl.constexpr = NUM_MMA_GROUPS if NUM_MMA_GROUPS > 2 else 2
+    c_smem_buffers = tlx.local_alloc(
+        (BLOCK_M_SPLIT, slice_size),
+        {{output_ptr()}}.dtype.element_ty,
+        NUM_EPILOGUE_SMEM_BUFFERS,
+    )
+    stride_cm = {{stride(None, 0)}}
+    desc_c = tl.make_tensor_descriptor(
+        {{output_ptr()}}, shape=[M, N], strides=[stride_cm, 1],
+        block_shape=[BLOCK_M_SPLIT, slice_size])
+{% endif %}
+
+    if NUM_CTAS == 2:
+        cluster_cta_rank = tlx.cluster_cta_rank()
+        pred_cta0 = cluster_cta_rank == 0
+        cta_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS * NUM_MMA_GROUPS, arrive_count=2)
+    else:
+        cluster_cta_rank = 0
+        pred_cta0 = False
+        cta_bars = None
+
+    A_smem_full_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS * NUM_MMA_GROUPS, arrive_count=1)
+    A_smem_empty_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS * NUM_MMA_GROUPS, arrive_count=1)
+    B_smem_full_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS, arrive_count=1)
+    tmem_full_bars = tlx.alloc_barriers(num_barriers=NUM_TMEM_BUFFERS * NUM_MMA_GROUPS, arrive_count=1)
+    tmem_empty_bars = tlx.alloc_barriers(num_barriers=NUM_TMEM_BUFFERS * NUM_MMA_GROUPS, arrive_count=EPILOGUE_SUBTILE)
+
+    with tlx.async_tasks():
+        with tlx.async_task("default"):  # epilogue consumer
+            (
+                start_pid,
+                num_pid_m,
+                num_pid_n,
+                num_pid_in_group,
+                num_mn_tiles,
+                num_tiles,
+                k_tiles_total,
+            ) = _compute_grid_info(
+                M,
+                N,
+                K,
+                BLOCK_M,
+                BLOCK_N,
+                BLOCK_K,
+                GROUP_SIZE_M,
+                SPLIT_K,
+                NUM_CTAS,
+            )
+
+            tmem_accum_cnt = 0
+            tile_id = start_pid
+
+            while tile_id < num_tiles:
+{% if SPLIT_K > 1 %}
+                split_id = tile_id // num_mn_tiles
+                k_tiles_per_split = tl.cdiv(k_tiles_total, SPLIT_K)
+                k_tile_start = split_id * k_tiles_per_split
+                k_tile_end = min(k_tile_start + k_tiles_per_split, k_tiles_total)
+                if k_tile_end > k_tile_start:
+                    cur_tmem_buf, tmem_read_phase = _get_bufidx_phase(tmem_accum_cnt, NUM_TMEM_BUFFERS)
+                    mn_tile_id = tile_id % num_mn_tiles
+                    pid_m, pid_n = _compute_pid(mn_tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
+                    offs_bn = pid_n * BLOCK_N
+
+                    # Per-partition descriptor with shape=[M, N] so TMA clips
+                    # at partition boundaries when M is not a multiple of BLOCK_M.
+                    desc_ws = tl.make_tensor_descriptor(
+                        split_k_ws + split_id * M * N,
+                        shape=[M, N], strides=[N, 1],
+                        block_shape=[BLOCK_M_SPLIT, slice_size])
+
+{% if INTERLEAVE_EPILOGUE %}
+                    # Interleaved split-K: alternate group 0/1 stores to hide TMEM read latency.
+                    buf_idx_0 = 0 * NUM_TMEM_BUFFERS + cur_tmem_buf
+                    buf_idx_1 = 1 * NUM_TMEM_BUFFERS + cur_tmem_buf
+                    acc_tmem_0 = tmem_buffers[buf_idx_0]
+                    acc_tmem_1 = tmem_buffers[buf_idx_1]
+                    offs_am_0 = pid_m * BLOCK_M + 0 * BLOCK_M_SPLIT
+                    offs_am_1 = pid_m * BLOCK_M + 1 * BLOCK_M_SPLIT
+
+                    # Group 0 slice 0
+                    tlx.barrier_wait(tmem_full_bars[buf_idx_0], tmem_read_phase)
+                    acc_sub = tlx.local_slice(acc_tmem_0, [0, 0], [BLOCK_M_SPLIT, slice_size])
+                    result = tlx.local_load(acc_sub)
+                    tlx.barrier_arrive(tmem_empty_bars[buf_idx_0], 1)
+                    offs_cn = offs_bn
+                    ws_smem = ws_smem_buffers[0]
+                    tlx.async_descriptor_store_wait(1)
+                    tlx.local_store(ws_smem, result)
+                    tlx.fence_async_shared()
+                    tlx.async_descriptor_store(desc_ws, ws_smem, [offs_am_0, offs_cn], eviction_policy="evict_first")
+
+                    # Group 1 slice 0
+                    tlx.barrier_wait(tmem_full_bars[buf_idx_1], tmem_read_phase)
+                    acc_sub = tlx.local_slice(acc_tmem_1, [0, 0], [BLOCK_M_SPLIT, slice_size])
+                    result = tlx.local_load(acc_sub)
+                    tlx.barrier_arrive(tmem_empty_bars[buf_idx_1], 1)
+                    offs_cn = offs_bn
+                    ws_smem = ws_smem_buffers[1]
+                    tlx.async_descriptor_store_wait(1)
+                    tlx.local_store(ws_smem, result)
+                    tlx.fence_async_shared()
+                    tlx.async_descriptor_store(desc_ws, ws_smem, [offs_am_1, offs_cn], eviction_policy="evict_first")
+
+                    # Remaining slices: alternate group 0 / group 1
+                    for slice_id in tl.static_range(1, EPILOGUE_SUBTILE):
+                        # Group 0
+                        acc_sub = tlx.local_slice(acc_tmem_0, [0, slice_id * slice_size], [BLOCK_M_SPLIT, slice_size])
+                        result = tlx.local_load(acc_sub)
+                        tlx.barrier_arrive(tmem_empty_bars[buf_idx_0], 1)
+                        offs_cn = offs_bn + slice_id * slice_size
+                        ws_smem = ws_smem_buffers[0]
+                        tlx.async_descriptor_store_wait(1)
+                        tlx.local_store(ws_smem, result)
+                        tlx.fence_async_shared()
+                        tlx.async_descriptor_store(desc_ws, ws_smem, [offs_am_0, offs_cn], eviction_policy="evict_first")
+
+                        # Group 1
+                        acc_sub = tlx.local_slice(acc_tmem_1, [0, slice_id * slice_size], [BLOCK_M_SPLIT, slice_size])
+                        result = tlx.local_load(acc_sub)
+                        tlx.barrier_arrive(tmem_empty_bars[buf_idx_1], 1)
+                        offs_cn = offs_bn + slice_id * slice_size
+                        ws_smem = ws_smem_buffers[1]
+                        tlx.async_descriptor_store_wait(1)
+                        tlx.local_store(ws_smem, result)
+                        tlx.fence_async_shared()
+                        tlx.async_descriptor_store(desc_ws, ws_smem, [offs_am_1, offs_cn], eviction_policy="evict_first")
+
+                    tlx.async_descriptor_store_wait(0)
+                    tmem_accum_cnt += 1
+{% else %}
+                    # Non-interleaved split-K: sequential group loop.
+                    for group_id in tl.static_range(NUM_MMA_GROUPS):
+                        buf_idx = group_id * NUM_TMEM_BUFFERS + cur_tmem_buf
+                        tlx.barrier_wait(tmem_full_bars[buf_idx], tmem_read_phase)
+                        acc_tmem = tmem_buffers[buf_idx]
+                        offs_am = pid_m * BLOCK_M + group_id * BLOCK_M_SPLIT
+
+                        for slice_id in tl.static_range(EPILOGUE_SUBTILE):
+                            acc_tmem_subslice = tlx.local_slice(
+                                acc_tmem,
+                                [0, slice_id * slice_size],
+                                [BLOCK_M_SPLIT, slice_size],
+                            )
+                            result = tlx.local_load(acc_tmem_subslice)
+                            tlx.barrier_arrive(tmem_empty_bars[buf_idx], 1)
+                            offs_cn = offs_bn + slice_id * slice_size
+                            ws_smem = ws_smem_buffers[(group_id * EPILOGUE_SUBTILE + slice_id) % NUM_EPILOGUE_SMEM_BUFFERS]
+                            tlx.async_descriptor_store_wait(1)
+                            tlx.local_store(ws_smem, result)
+                            tlx.fence_async_shared()
+                            tlx.async_descriptor_store(desc_ws, ws_smem, [offs_am, offs_cn], eviction_policy="evict_first")
+                    tlx.async_descriptor_store_wait(0)
+                    tmem_accum_cnt += 1
+{% endif %}
+{% else %}
+                cur_tmem_buf, tmem_read_phase = _get_bufidx_phase(tmem_accum_cnt, NUM_TMEM_BUFFERS)
+                mn_tile_id = tile_id % num_mn_tiles
+                pid_m, pid_n = _compute_pid(mn_tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
+                offs_bn = pid_n * BLOCK_N
+
+{% if INTERLEAVE_EPILOGUE and TMA_EPILOGUE_STORE %}
+                # Interleaved TMA stores across two MMA groups to hide TMEM read latency.
+                # Pattern: wait g0 -> store g0s0 -> wait g1 -> store g1s0, then alternate for remaining slices.
+                buf_idx_0 = 0 * NUM_TMEM_BUFFERS + cur_tmem_buf
+                buf_idx_1 = 1 * NUM_TMEM_BUFFERS + cur_tmem_buf
+                acc_tmem_0 = tmem_buffers[buf_idx_0]
+                acc_tmem_1 = tmem_buffers[buf_idx_1]
+                offs_am_0 = pid_m * BLOCK_M + 0 * BLOCK_M_SPLIT
+                offs_am_1 = pid_m * BLOCK_M + 1 * BLOCK_M_SPLIT
+
+                # Group 0 slice 0
+                tlx.barrier_wait(tmem_full_bars[buf_idx_0], tmem_read_phase)
+                acc_sub = tlx.local_slice(acc_tmem_0, [0, 0], [BLOCK_M_SPLIT, slice_size])
+                result = tlx.local_load(acc_sub)
+                tlx.barrier_arrive(tmem_empty_bars[buf_idx_0], 1)
+                offs_cn = offs_bn
+                {{compute_epilogue(("offs_am_0", "offs_cn"), "result", result_name="fused_c", indent_width=16, val_shape=("BLOCK_M_SPLIT", "slice_size"))}}
+                c_smem = c_smem_buffers[0]
+                tlx.async_descriptor_store_wait(1)
+                tlx.local_store(c_smem, fused_c.to(A.dtype.element_ty))
+                tlx.fence_async_shared()
+                tlx.async_descriptor_store(desc_c, c_smem, [offs_am_0, offs_cn], eviction_policy="evict_first")
+
+                # Group 1 slice 0
+                tlx.barrier_wait(tmem_full_bars[buf_idx_1], tmem_read_phase)
+                acc_sub = tlx.local_slice(acc_tmem_1, [0, 0], [BLOCK_M_SPLIT, slice_size])
+                result = tlx.local_load(acc_sub)
+                tlx.barrier_arrive(tmem_empty_bars[buf_idx_1], 1)
+                offs_cn = offs_bn
+                {{compute_epilogue(("offs_am_1", "offs_cn"), "result", result_name="fused_c", indent_width=16, val_shape=("BLOCK_M_SPLIT", "slice_size"))}}
+                c_smem = c_smem_buffers[1]
+                tlx.async_descriptor_store_wait(1)
+                tlx.local_store(c_smem, fused_c.to(A.dtype.element_ty))
+                tlx.fence_async_shared()
+                tlx.async_descriptor_store(desc_c, c_smem, [offs_am_1, offs_cn], eviction_policy="evict_first")
+
+                # Remaining slices: alternate group 0 / group 1
+                for slice_id in tl.static_range(1, EPILOGUE_SUBTILE):
+                    # Group 0
+                    acc_sub = tlx.local_slice(acc_tmem_0, [0, slice_id * slice_size], [BLOCK_M_SPLIT, slice_size])
+                    result = tlx.local_load(acc_sub)
+                    tlx.barrier_arrive(tmem_empty_bars[buf_idx_0], 1)
+                    offs_cn = offs_bn + slice_id * slice_size
+                    {{compute_epilogue(("offs_am_0", "offs_cn"), "result", result_name="fused_c", indent_width=20, val_shape=("BLOCK_M_SPLIT", "slice_size"))}}
+                    c_smem = c_smem_buffers[0]
+                    tlx.async_descriptor_store_wait(1)
+                    tlx.local_store(c_smem, fused_c.to(A.dtype.element_ty))
+                    tlx.fence_async_shared()
+                    tlx.async_descriptor_store(desc_c, c_smem, [offs_am_0, offs_cn], eviction_policy="evict_first")
+
+                    # Group 1
+                    acc_sub = tlx.local_slice(acc_tmem_1, [0, slice_id * slice_size], [BLOCK_M_SPLIT, slice_size])
+                    result = tlx.local_load(acc_sub)
+                    tlx.barrier_arrive(tmem_empty_bars[buf_idx_1], 1)
+                    offs_cn = offs_bn + slice_id * slice_size
+                    {{compute_epilogue(("offs_am_1", "offs_cn"), "result", result_name="fused_c", indent_width=20, val_shape=("BLOCK_M_SPLIT", "slice_size"))}}
+                    c_smem = c_smem_buffers[1]
+                    tlx.async_descriptor_store_wait(1)
+                    tlx.local_store(c_smem, fused_c.to(A.dtype.element_ty))
+                    tlx.fence_async_shared()
+                    tlx.async_descriptor_store(desc_c, c_smem, [offs_am_1, offs_cn], eviction_policy="evict_first")
+{% else %}
+                for group_id in tl.static_range(NUM_MMA_GROUPS):
+                    buf_idx = group_id * NUM_TMEM_BUFFERS + cur_tmem_buf
+                    tlx.barrier_wait(tmem_full_bars[buf_idx], tmem_read_phase)
+                    acc_tmem = tmem_buffers[buf_idx]
+                    offs_am = pid_m * BLOCK_M + group_id * BLOCK_M_SPLIT
+
+                    for slice_id in tl.static_range(EPILOGUE_SUBTILE):
+                        acc_tmem_subslice = tlx.local_slice(
+                            acc_tmem,
+                            [0, slice_id * slice_size],
+                            [BLOCK_M_SPLIT, slice_size],
+                        )
+                        result = tlx.local_load(acc_tmem_subslice)
+                        tlx.barrier_arrive(tmem_empty_bars[buf_idx], 1)
+                        offs_cn = offs_bn + slice_id * slice_size
+{% if TMA_EPILOGUE_STORE %}
+                        {{compute_epilogue(("offs_am", "offs_cn"), "result", result_name="fused_c", indent_width=24, val_shape=("BLOCK_M_SPLIT", "slice_size"))}}
+                        c_smem = c_smem_buffers[(group_id * EPILOGUE_SUBTILE + slice_id) % NUM_EPILOGUE_SMEM_BUFFERS]
+                        tlx.async_descriptor_store_wait(1)
+                        tlx.local_store(c_smem, fused_c.to(A.dtype.element_ty))
+                        tlx.fence_async_shared()
+                        tlx.async_descriptor_store(desc_c, c_smem, [offs_am, offs_cn], eviction_policy="evict_first")
+{% else %}
+                        {{store_output(("offs_am", "offs_cn"), "result", indent_width=24, val_shape=("BLOCK_M_SPLIT", "slice_size"), block_indexing=True)}}
+{% endif %}
+{% endif %}
+
+{% if TMA_EPILOGUE_STORE %}
+                tlx.async_descriptor_store_wait(0)
+{% endif %}
+                tmem_accum_cnt += 1
+{% endif %}
+                tile_id += NUM_SMS
+
+        with tlx.async_task(num_warps=1, num_regs=24):  # MMA consumer
+            (
+                start_pid,
+                num_pid_m,
+                num_pid_n,
+                num_pid_in_group,
+                num_mn_tiles,
+                num_tiles,
+                k_tiles_total,
+            ) = _compute_grid_info(
+                M,
+                N,
+                K,
+                BLOCK_M,
+                BLOCK_N,
+                BLOCK_K,
+                GROUP_SIZE_M,
+                SPLIT_K,
+                NUM_CTAS,
+            )
+
+            tmem_accum_cnt = 0
+            smem_accum_cnt = 0
+            tile_id = start_pid
+
+            while tile_id < num_tiles:
+                split_id = tile_id // num_mn_tiles
+                k_tiles_per_split = tl.cdiv(k_tiles_total, SPLIT_K)
+                k_tile_start = split_id * k_tiles_per_split
+                k_tile_end = min(k_tile_start + k_tiles_per_split, k_tiles_total)
+                local_k_tiles = k_tile_end - k_tile_start
+{% if SPLIT_K > 1 %}
+                if k_tile_end > k_tile_start:
+                    cur_tmem_buf, tmem_write_phase = _get_bufidx_phase(tmem_accum_cnt, NUM_TMEM_BUFFERS)
+
+                    buf, phase = _get_bufidx_phase(smem_accum_cnt, NUM_SMEM_BUFFERS)
+                    tlx.barrier_wait(B_smem_full_bars[buf], phase)
+
+                    for group_id in tl.static_range(NUM_MMA_GROUPS):
+                        a_buf = group_id * NUM_SMEM_BUFFERS + buf
+                        acc_buf = group_id * NUM_TMEM_BUFFERS + cur_tmem_buf
+
+                        tlx.barrier_wait(A_smem_full_bars[a_buf], phase)
+
+                        cur_barrier_idx = group_id * NUM_TMEM_BUFFERS + cur_tmem_buf
+                        tlx.barrier_wait(tmem_empty_bars[cur_barrier_idx], tmem_write_phase ^ 1)
+
+                        if NUM_CTAS == 2:
+                            tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
+                            tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
+
+                        tlx.async_dot(
+                            buffers_A[a_buf],
+                            buffers_B[buf],
+                            tmem_buffers[acc_buf],
+                            use_acc=False,
+                            mBarriers=[A_smem_empty_bars[a_buf]],
+                            two_ctas=NUM_CTAS == 2,
+                            out_dtype=tl.float32,
+                        )
+
+                    smem_accum_cnt += 1
+
+                    for _ in range(1, local_k_tiles):
+                        buf, phase = _get_bufidx_phase(smem_accum_cnt, NUM_SMEM_BUFFERS)
+                        tlx.barrier_wait(B_smem_full_bars[buf], phase)
+
+                        for group_id in tl.static_range(NUM_MMA_GROUPS):
+                            a_buf = group_id * NUM_SMEM_BUFFERS + buf
+                            acc_buf = group_id * NUM_TMEM_BUFFERS + cur_tmem_buf
+
+                            tlx.barrier_wait(A_smem_full_bars[a_buf], phase)
+
+                            if NUM_CTAS == 2:
+                                tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
+                                tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
+
+                            tlx.async_dot(
+                                buffers_A[a_buf],
+                                buffers_B[buf],
+                                tmem_buffers[acc_buf],
+                                use_acc=True,
+                                mBarriers=[A_smem_empty_bars[a_buf]],
+                                two_ctas=NUM_CTAS == 2,
+                                out_dtype=tl.float32,
+                            )
+
+                        smem_accum_cnt += 1
+
+                    last_buf, last_phase = _get_bufidx_phase(smem_accum_cnt - 1, NUM_SMEM_BUFFERS)
+                    for group_id in tl.static_range(NUM_MMA_GROUPS):
+                        a_buf = group_id * NUM_SMEM_BUFFERS + last_buf
+                        tlx.barrier_wait(A_smem_empty_bars[a_buf], last_phase)
+                        acc_buf = group_id * NUM_TMEM_BUFFERS + cur_tmem_buf
+                        tlx.barrier_arrive(tmem_full_bars[acc_buf], 1)
+
+                    tmem_accum_cnt += 1
+{% else %}
+                cur_tmem_buf, tmem_write_phase = _get_bufidx_phase(tmem_accum_cnt, NUM_TMEM_BUFFERS)
+
+                buf, phase = _get_bufidx_phase(smem_accum_cnt, NUM_SMEM_BUFFERS)
+                tlx.barrier_wait(B_smem_full_bars[buf], phase)
+
+                for group_id in tl.static_range(NUM_MMA_GROUPS):
+                    a_buf = group_id * NUM_SMEM_BUFFERS + buf
+                    acc_buf = group_id * NUM_TMEM_BUFFERS + cur_tmem_buf
+
+                    tlx.barrier_wait(A_smem_full_bars[a_buf], phase)
+
+                    cur_barrier_idx = group_id * NUM_TMEM_BUFFERS + cur_tmem_buf
+                    tlx.barrier_wait(tmem_empty_bars[cur_barrier_idx], tmem_write_phase ^ 1)
+
+                    if NUM_CTAS == 2:
+                        tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
+                        tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
+
+                    tlx.async_dot(
+                        buffers_A[a_buf],
+                        buffers_B[buf],
+                        tmem_buffers[acc_buf],
+                        use_acc=False,
+                        mBarriers=[A_smem_empty_bars[a_buf]],
+                        two_ctas=NUM_CTAS == 2,
+                        out_dtype=tl.float32,
+                    )
+
+                smem_accum_cnt += 1
+
+                for _ in range(1, local_k_tiles):
+                    buf, phase = _get_bufidx_phase(smem_accum_cnt, NUM_SMEM_BUFFERS)
+                    tlx.barrier_wait(B_smem_full_bars[buf], phase)
+
+                    for group_id in tl.static_range(NUM_MMA_GROUPS):
+                        a_buf = group_id * NUM_SMEM_BUFFERS + buf
+                        acc_buf = group_id * NUM_TMEM_BUFFERS + cur_tmem_buf
+
+                        tlx.barrier_wait(A_smem_full_bars[a_buf], phase)
+
+                        if NUM_CTAS == 2:
+                            tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
+                            tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
+
+                        tlx.async_dot(
+                            buffers_A[a_buf],
+                            buffers_B[buf],
+                            tmem_buffers[acc_buf],
+                            use_acc=True,
+                            mBarriers=[A_smem_empty_bars[a_buf]],
+                            two_ctas=NUM_CTAS == 2,
+                            out_dtype=tl.float32,
+                        )
+
+                    smem_accum_cnt += 1
+
+                last_buf, last_phase = _get_bufidx_phase(smem_accum_cnt - 1, NUM_SMEM_BUFFERS)
+                for group_id in tl.static_range(NUM_MMA_GROUPS):
+                    a_buf = group_id * NUM_SMEM_BUFFERS + last_buf
+                    tlx.barrier_wait(A_smem_empty_bars[a_buf], last_phase)
+                    acc_buf = group_id * NUM_TMEM_BUFFERS + cur_tmem_buf
+                    tlx.barrier_arrive(tmem_full_bars[acc_buf], 1)
+
+                tmem_accum_cnt += 1
+{% endif %}
+                tile_id += NUM_SMS
+
+        with tlx.async_task(num_warps=1, num_regs=24):  # producer, TMA load
+            (
+                start_pid,
+                num_pid_m,
+                num_pid_n,
+                num_pid_in_group,
+                num_mn_tiles,
+                num_tiles,
+                k_tiles_total,
+            ) = _compute_grid_info(
+                M,
+                N,
+                K,
+                BLOCK_M,
+                BLOCK_N,
+                BLOCK_K,
+                GROUP_SIZE_M,
+                SPLIT_K,
+                NUM_CTAS,
+            )
+
+            smem_accum_cnt = 0
+            tile_id = start_pid
+
+            expected_bytes: tl.constexpr = dsize * BLOCK_N * BLOCK_K // NUM_CTAS
+
+            while tile_id < num_tiles:
+                split_id = tile_id // num_mn_tiles
+                k_tiles_per_split = tl.cdiv(k_tiles_total, SPLIT_K)
+                k_tile_start = split_id * k_tiles_per_split
+                k_tile_end = min(k_tile_start + k_tiles_per_split, k_tiles_total)
+                local_k_tiles = k_tile_end - k_tile_start
+{% if SPLIT_K > 1 %}
+                if k_tile_end > k_tile_start:
+                    mn_tile_id = tile_id % num_mn_tiles
+                    pid_m, pid_n = _compute_pid(mn_tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
+                    offs_bn = pid_n * BLOCK_N + cluster_cta_rank * (BLOCK_N // NUM_CTAS)
+
+                    for k_idx in range(0, local_k_tiles):
+                        k = k_tile_start + k_idx
+                        buf, phase = _get_bufidx_phase(smem_accum_cnt, NUM_SMEM_BUFFERS)
+                        offs_k = k * BLOCK_K
+
+                        a_buf = buf
+                        tlx.barrier_wait(A_smem_empty_bars[a_buf], phase ^ 1)
+                        offs_am = pid_m * BLOCK_M
+                        tlx.barrier_expect_bytes(A_smem_full_bars[a_buf], dsize * BLOCK_M_SPLIT * BLOCK_K)
+                        tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_am, offs_k], A_smem_full_bars[a_buf],
+                                                  eviction_policy="evict_last")
+
+                        last_a_buf = (NUM_MMA_GROUPS - 1) * NUM_SMEM_BUFFERS + buf
+                        tlx.barrier_wait(A_smem_empty_bars[last_a_buf], phase ^ 1)
+                        tlx.barrier_expect_bytes(B_smem_full_bars[buf], expected_bytes)
+                        tlx.async_descriptor_load(desc_b, buffers_B[buf], [offs_k, offs_bn], B_smem_full_bars[buf],
+                                                  eviction_policy="evict_last")
+
+                        for group_id in tl.static_range(1, NUM_MMA_GROUPS):
+                            a_buf = group_id * NUM_SMEM_BUFFERS + buf
+
+                            tlx.barrier_wait(A_smem_empty_bars[a_buf], phase ^ 1)
+
+                            offs_am2 = offs_am + group_id * BLOCK_M_SPLIT
+
+                            tlx.barrier_expect_bytes(A_smem_full_bars[a_buf], dsize * BLOCK_M_SPLIT * BLOCK_K)
+                            tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_am2, offs_k], A_smem_full_bars[a_buf],
+                                                      eviction_policy="evict_last")
+
+                        smem_accum_cnt += 1
+{% else %}
+                mn_tile_id = tile_id % num_mn_tiles
+                pid_m, pid_n = _compute_pid(mn_tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
+                offs_bn = pid_n * BLOCK_N + cluster_cta_rank * (BLOCK_N // NUM_CTAS)
+
+                for k_idx in range(0, local_k_tiles):
+                    k = k_tile_start + k_idx
+                    buf, phase = _get_bufidx_phase(smem_accum_cnt, NUM_SMEM_BUFFERS)
+                    offs_k = k * BLOCK_K
+
+                    a_buf = buf
+                    tlx.barrier_wait(A_smem_empty_bars[a_buf], phase ^ 1)
+                    offs_am = pid_m * BLOCK_M
+                    tlx.barrier_expect_bytes(A_smem_full_bars[a_buf], dsize * BLOCK_M_SPLIT * BLOCK_K)
+                    tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_am, offs_k], A_smem_full_bars[a_buf],
+                                              eviction_policy="evict_last")
+
+                    last_a_buf = (NUM_MMA_GROUPS - 1) * NUM_SMEM_BUFFERS + buf
+                    tlx.barrier_wait(A_smem_empty_bars[last_a_buf], phase ^ 1)
+                    tlx.barrier_expect_bytes(B_smem_full_bars[buf], expected_bytes)
+                    tlx.async_descriptor_load(desc_b, buffers_B[buf], [offs_k, offs_bn], B_smem_full_bars[buf],
+                                              eviction_policy="evict_last")
+
+                    for group_id in tl.static_range(1, NUM_MMA_GROUPS):
+                        a_buf = group_id * NUM_SMEM_BUFFERS + buf
+
+                        tlx.barrier_wait(A_smem_empty_bars[a_buf], phase ^ 1)
+
+                        offs_am2 = offs_am + group_id * BLOCK_M_SPLIT
+
+                        tlx.barrier_expect_bytes(A_smem_full_bars[a_buf], dsize * BLOCK_M_SPLIT * BLOCK_K)
+                        tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_am2, offs_k], A_smem_full_bars[a_buf],
+                                                  eviction_policy="evict_last")
+
+                    smem_accum_cnt += 1
+{% endif %}
+
+                tile_id += NUM_SMS
+
+
+@triton.jit
+def _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M):
+    group_id = tile_id // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (tile_id % group_size_m)
+    pid_n = (tile_id % num_pid_in_group) // group_size_m
+    return pid_m, pid_n
+
+
+@triton.jit
+def _get_bufidx_phase(accum_cnt, NUM_BUFFERS_KV):
+    bufIdx = accum_cnt % NUM_BUFFERS_KV
+    phase = (accum_cnt // NUM_BUFFERS_KV) & 1
+    return bufIdx, phase
+
+
+@triton.jit
+def _compute_grid_info(
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    BLOCK_SIZE_K,
+    GROUP_SIZE_M,
+    SPLIT_K,
+    NUM_CTAS: tl.constexpr,
+):
+    """Compute common grid information used across async tasks."""
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M).to(tl.int32)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N).to(tl.int32)
+    num_pid_m = (num_pid_m + NUM_CTAS - 1) // NUM_CTAS * NUM_CTAS
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    num_mn_tiles = num_pid_m * num_pid_n
+    num_tiles = num_mn_tiles * SPLIT_K
+    k_tiles_total = tl.cdiv(K, BLOCK_SIZE_K).to(tl.int32)
+    return start_pid, num_pid_m, num_pid_n, num_pid_in_group, num_mn_tiles, num_tiles, k_tiles_total

--- a/third_party/tlx/language/tlx/inductor/choices.py
+++ b/third_party/tlx/language/tlx/inductor/choices.py
@@ -1,0 +1,207 @@
+"""
+TLXInductorChoices: InductorChoices subclass that consolidates all TLX
+template selection, filtering, and layout logic.
+
+Activated via config.inductor_choices_class set in template_heuristics/tlx.py.
+All methods check config.triton.tlx_mode at runtime and fall through to
+super() when mode is "default".
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, TYPE_CHECKING
+
+from torch._inductor import config
+from torch._inductor.choices import InductorChoices
+from torch._inductor.select_algorithm import ExternKernelChoice
+
+from . import tlx_config
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from torch._inductor.codegen.common import KernelTemplate
+    from torch._inductor.ir import ChoiceCaller
+    from torch._inductor.kernel_inputs import KernelInputs
+    from torch._inductor.kernel_template_choice import KernelTemplateChoice
+
+log = logging.getLogger(__name__)
+
+
+class TLXInductorChoices(InductorChoices):
+    """
+    InductorChoices subclass that handles TLX template injection,
+    filtering, and layout fixing.
+
+    In "default" mode: delegates entirely to the parent class.
+    In "allow" mode: TLX templates compete with other backends via autotuning.
+    In "force" mode: only TLX templates are used.
+    """
+
+    def uuid(self) -> str:
+        return "TLXInductorChoices"
+
+    def _finalize_template_configs(
+        self,
+        template_choices: dict[str, Generator[KernelTemplateChoice, None, None]],
+        kernel_inputs: KernelInputs,
+        templates: list[KernelTemplate | ExternKernelChoice],
+        op_name: str,
+        kwarg_overrides: dict[str, dict[str, Any]] | None = None,
+    ) -> list[KernelTemplateChoice]:
+        if config.triton.tlx_mode == "force":
+            # In force mode, keep only TLX templates
+            return [
+                c for uid, gen in template_choices.items() if "tlx_" in uid for c in gen
+            ]
+
+        return super()._finalize_template_configs(
+            template_choices, kernel_inputs, templates, op_name, kwarg_overrides
+        )
+
+    def customize_fused_kernel_name(self, fused_name: str, src_code: str) -> str:
+        from .fusion import maybe_add_tlx_prefix
+
+        return maybe_add_tlx_prefix(fused_name, src_code)
+
+    def override_best_choice(
+        self,
+        best_choice: ChoiceCaller,
+        timings: dict[ChoiceCaller, float],
+    ) -> ChoiceCaller:
+        return maybe_override_best_choice(best_choice, timings)
+
+    def _need_to_fix_layout(
+        self,
+        adjusted_choices: list[KernelTemplateChoice],
+        op_name: str,
+    ) -> bool:
+        if config.triton.tlx_mode == "force":
+            return True
+        return super()._need_to_fix_layout(adjusted_choices, op_name)
+
+    # Ops that use prefix_args (bias passed separately from mat1/mat2).
+    # The blackwell WS template only supports plain mm (2 named kernel args: A, B),
+    # so skip TLX injection for these ops. addmm IS supported: the AMD warp-pipe
+    # template handles the bias epilogue (prefix_args=1), injected via append_tlx.
+    _UNSUPPORTED_OPS = frozenset({"baddbmm"})
+
+    def get_template_configs(
+        self,
+        kernel_inputs: KernelInputs,
+        templates: list[KernelTemplate | ExternKernelChoice],
+        op_name: str,
+        kwarg_overrides: dict[str, dict[str, Any]] | None = None,
+    ) -> list[ChoiceCaller]:
+        tlx_mode = config.triton.tlx_mode
+        if tlx_mode == "default" or op_name in self._UNSUPPORTED_OPS:
+            return super().get_template_configs(
+                kernel_inputs, templates, op_name, kwarg_overrides
+            )
+
+        from .mm_templates import append_tlx
+
+        templates = list(templates)
+        kwarg_overrides = kwarg_overrides or {}
+        append_tlx(templates, op_name)
+
+        input_tensors = kernel_inputs.nodes()
+        if len(input_tensors) < 2:
+            raise ValueError(f"Need at least 2 input tensors, got {len(input_tensors)}")
+
+        template_choices = {
+            t.uid: self.get_ktc(
+                kernel_inputs, t, op_name, kwarg_overrides.get(t.uid, {})
+            )
+            for t in templates
+        }
+
+        # Second pass: Adjust the template choices
+        adjusted_choices = self._finalize_template_configs(
+            template_choices,
+            kernel_inputs,
+            templates,
+            op_name,
+            kwarg_overrides,
+        )
+
+        # Fix layouts: force mode fixes all, allow mode fixes non-extern only
+        fix_all = self._need_to_fix_layout(adjusted_choices, op_name)
+        if fix_all or tlx_mode == "allow":
+            fixed_layout = kernel_inputs.output_layout(flexible=False)
+            for ktc in adjusted_choices:
+                needs_fix = fix_all or not isinstance(ktc.template, ExternKernelChoice)
+                if needs_fix:
+                    ktc.layout = fixed_layout
+                    if hasattr(ktc, "_choice"):
+                        del ktc._choice
+
+        # Third pass: Convert to ChoiceCaller objects
+        return [ktc.choice for ktc in adjusted_choices if ktc.choice is not None]
+
+    def append_flex_attention_choices(
+        self,
+        choices: list[Any],
+        configs: list[Any],
+        input_nodes: list[Any],
+        subgraphs: list[Any],
+        layout: Any,
+        kernel_options: dict[str, Any],
+        sparse_q_block_size: int,
+        sparse_kv_block_size: int,
+    ) -> list[Any]:
+        from .flex_attention_templates import (
+            append_tlx_flex_attention_choice,
+        )
+
+        append_tlx_flex_attention_choice(
+            choices,
+            configs,
+            input_nodes,
+            subgraphs,
+            layout,
+            kernel_options,
+            sparse_q_block_size,
+            sparse_kv_block_size,
+        )
+        return choices
+
+
+def maybe_override_best_choice(
+    best_choice: ChoiceCaller,
+    timings: dict[ChoiceCaller, float],
+) -> ChoiceCaller:
+    """
+    In TLX "allow" mode, prefer extern kernels (cublas) unless a TLX template
+    beats them by a meaningful margin. Short autotuning benchmarks are noisy
+    and TLX can narrowly "win" but run slower in steady-state.
+
+    Returns the (possibly overridden) best choice.
+    """
+    from .fusion import _is_tlx_choice
+
+    if config.triton.tlx_mode != "allow" or not _is_tlx_choice(best_choice):
+        return best_choice
+
+    from torch._inductor.select_algorithm import ExternKernelCaller
+
+    extern_choices = [c for c in timings if isinstance(c, ExternKernelCaller)]
+    if not extern_choices:
+        return best_choice
+
+    tlx_threshold = tlx_config.allow_min_speedup
+
+    best_extern_time = min(timings[c] for c in extern_choices)
+    best_time = timings[best_choice]
+    speedup = best_extern_time / best_time if best_time > 0 else 0
+    if speedup < tlx_threshold:
+        log.debug(
+            "TLX choice %s speedup %.2fx < threshold %.2fx over extern, using extern",
+            best_choice.name,
+            speedup,
+            tlx_threshold,
+        )
+        return min(extern_choices, key=lambda c: timings[c])
+
+    return best_choice

--- a/third_party/tlx/language/tlx/inductor/codegen.py
+++ b/third_party/tlx/language/tlx/inductor/codegen.py
@@ -1,0 +1,83 @@
+"""
+TLX-specific codegen for async TMA descriptor store pipeline.
+
+This implements the Blackwell async TMA store pattern that stages values
+through SMEM before issuing an async descriptor store. It references
+TLX-specific APIs (tlx.local_store, tlx.async_descriptor_store, etc.) and
+SMEM buffers (c_smem_buffers).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from torch._inductor.codegen.common import DeferredLine
+from torch._inductor.codegen.triton import triton_store_type
+from torch._inductor.virtualized import V
+
+if TYPE_CHECKING:
+    from torch._inductor.codegen.triton import TritonKernel
+
+
+def _prepare_store_value(
+    kernel: TritonKernel, name: str, indexing: object, value: str
+) -> str:
+    """Prepare value for async TMA store (broadcast, reshape, cast)."""
+    value = f"tl.broadcast_to({value}, {indexing.final_shape})"  # type: ignore[attr-defined]
+
+    for idx, (dim, broadcast_dim) in enumerate(
+        zip(indexing.final_shape, indexing.broadcast_shape)  # type: ignore[attr-defined]
+    ):
+        if V.graph.sizevars.statically_known_equals(dim, broadcast_dim):
+            indexing.broadcasting_dims[idx] = False  # type: ignore[attr-defined]
+
+    value = indexing.codegen_broadcast_and_reshape(  # type: ignore[attr-defined]
+        value,
+        indexing.final_shape,  # type: ignore[attr-defined]
+        indexing.block_shape,  # type: ignore[attr-defined]
+        allow_implicit=False,
+        for_store=True,
+    )
+
+    value = f"{value}.to({triton_store_type(V.graph.get_dtype(name))})"
+    return value
+
+
+def codegen_async_tma_store(
+    self: TritonKernel, name: str, indexing: object, block_descriptor: str, value: str
+) -> None:
+    """Generate TLX async TMA descriptor store pipeline.
+
+    Stages the value through SMEM before issuing an async TMA store,
+    matching the standalone TLX kernel's store pattern for Blackwell.
+    Requires c_smem_buffers and NUM_EPILOGUE_SMEM_BUFFERS to be defined
+    in the template.
+
+    The SMEM buffer index can be controlled by setting
+    async_tma_store_buf_idx on the kernel to a Triton runtime expression
+    string (e.g. "group_id * EPILOGUE_SUBTILE + slice_id"). If not set,
+    falls back to a compile-time counter.
+    """
+    value = _prepare_store_value(self, name, indexing, value)
+
+    buf_idx_expr = getattr(self, "async_tma_store_buf_idx", None)
+    if buf_idx_expr is None:
+        counter = getattr(self, "_async_tma_store_counter", 0)
+        self._async_tma_store_counter = counter + 1  # type: ignore[attr-defined]
+        buf_idx_expr = str(counter)
+
+    offsets_str = self.index_to_str(indexing.offsets)  # type: ignore[attr-defined]
+
+    lines = [
+        f"c_smem = c_smem_buffers[({buf_idx_expr}) % NUM_EPILOGUE_SMEM_BUFFERS]",
+        "tlx.async_descriptor_store_wait(1)",
+        f"tlx.local_store(c_smem, {value})",
+        "tlx.fence_async_shared()",
+        f'tlx.async_descriptor_store({block_descriptor}, c_smem, {offsets_str}, eviction_policy="evict_first")',
+    ]
+    self._handle_pdl_before_access(self.stores, name, consider_reads=True)
+    for line in lines:
+        self.stores.writeline(DeferredLine(name, line))
+
+    if not self.inside_reduction:
+        self.outside_loop_vars.add(value)

--- a/third_party/tlx/language/tlx/inductor/flex_attention_templates.py
+++ b/third_party/tlx/language/tlx/inductor/flex_attention_templates.py
@@ -1,0 +1,96 @@
+import torch
+from torch._inductor.kernel.flex.common import load_flex_template
+from torch._inductor.kernel.flex.flex_attention import flex_attention_grid
+from torch._inductor.select_algorithm import TritonTemplate
+
+from .mm_templates import load_tlx_template
+
+
+tlx_flex_attention_template = TritonTemplate(
+    name="tlx_blackwell_flex_attention_ws",
+    grid=flex_attention_grid,
+    source=load_tlx_template("tlx_flex_attention")
+    + load_flex_template("utilities"),
+    always_freeze_layout=True,
+)
+
+
+def append_tlx_flex_attention_choice(
+    choices,
+    configs,
+    input_nodes,
+    subgraphs,
+    layout,
+    original_kernel_options,
+    sparse_q_block_size,
+    sparse_kv_block_size,
+):
+    """Add Blackwell TLX flex-attention template choices to ``choices``.
+
+    Gated by ``config.triton.tlx_mode``:
+      - "default": no-op.
+      - "allow":   add TLX candidates alongside the standard template.
+      - "force":   drop the standard choices and use only TLX.
+
+    Two warp-specialization shapes are offered as autotuning candidates: a
+    2-MMA-group variant (one per base config) and a single 1-MMA-group variant
+    (fewer barriers, 8 warps).
+
+    ``input_nodes`` is the standard flex-attention forward input list:
+    (query, key, value, logsumexp, max_scores, kv_num_blocks, kv_indices,
+    full_kv_num_blocks, full_kv_indices).
+    """
+    from torch._inductor import config
+
+    if config.triton.tlx_mode == "default":
+        return
+
+    if config.triton.tlx_mode == "force":
+        choices.clear()
+
+    query, logsumexp, max_scores = input_nodes[0], input_nodes[3], input_nodes[4]
+    mutated_inputs = [logsumexp, max_scores]
+    num_sms = torch.cuda.get_device_properties(0).multi_processor_count
+
+    def tlx_options():
+        opts = original_kernel_options.copy()
+        for k in list(opts.keys()):
+            if k.startswith("fwd_"):
+                opts[k[4:]] = opts.pop(k)
+            elif k.startswith("bwd_"):
+                opts.pop(k)
+        opts["USE_TMA"] = True
+        opts["NUM_SMS"] = num_sms
+        opts.setdefault("SPARSE_Q_BLOCK_SIZE", sparse_q_block_size)
+        opts.setdefault("SPARSE_KV_BLOCK_SIZE", sparse_kv_block_size)
+        return opts
+
+    def append(opts):
+        tlx_flex_attention_template.maybe_append_choice(
+            choices=choices,
+            input_nodes=input_nodes,
+            layout=layout,
+            subgraphs=subgraphs,
+            mutated_inputs=mutated_inputs,
+            call_sizes=query.get_size(),
+            **opts,
+        )
+
+    # 4-task warp specialization, 2 MMA groups: one candidate per base config.
+    for conf in configs:
+        opts = tlx_options()
+        opts["num_warps"] = conf.num_warps
+        opts["num_stages"] = conf.num_stages
+        opts["BLOCK_M"] = conf.block_m
+        opts["BLOCK_N"] = conf.block_n
+        append(opts)
+
+    # 4-task warp specialization, 1 MMA group (fewer barriers): 8 warps.
+    last_conf = configs[-1]
+    opts = tlx_options()
+    opts["num_warps"] = 8
+    opts["num_stages"] = 1
+    opts["NUM_MMA_GROUPS"] = 1
+    opts["BLOCK_M"] = last_conf.block_m
+    opts["BLOCK_N"] = last_conf.block_n
+    append(opts)

--- a/third_party/tlx/language/tlx/inductor/fusion.py
+++ b/third_party/tlx/language/tlx/inductor/fusion.py
@@ -1,0 +1,140 @@
+"""
+TLX Template Fusion Support
+
+This module provides functions to control epilogue fusion behavior for TLX templates
+during prototyping.
+
+Usage:
+    Set environment variable TORCHINDUCTOR_TLX_MODE=force to force
+    TLX templates to fuse with epilogues regardless of benchmark results.
+"""
+
+import logging
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torch._inductor import ir
+    from torch._inductor.scheduler import BaseSchedulerNode
+
+
+fusion_log = logging.getLogger(__name__)
+
+
+def _is_force_fusion_enabled() -> bool:
+    """Check if force fusion is enabled via tlx_mode config."""
+    from torch._inductor import config
+
+    return config.triton.tlx_mode == "force"
+
+
+def _is_tlx_choice(choice: Any) -> bool:
+    """Check if a choice is a TLX template by name pattern."""
+    if hasattr(choice, "name") and isinstance(choice.name, str):
+        return "tlx_" in choice.name
+    return False
+
+
+def _has_split_k(multi_node: "ir.MultiTemplateBuffer") -> bool:
+    """Check if any TLX choice in the node uses SPLIT_K > 1.
+
+    Since TritonTemplateCaller doesn't expose template kwargs directly,
+    we check via the description string which includes SPLIT_K info,
+    or infer from the heuristic config for the node's shape.
+    """
+    if not any(_is_tlx_choice(c) for c in multi_node.choices):
+        return False
+    try:
+        from torch._inductor.utils import get_num_sms
+
+        from . import tlx_config
+        from .registry import get_heuristic_config
+
+        layout = multi_node.get_layout()
+        sizes = [int(s) for s in layout.size]
+        if len(sizes) == 2:
+            m, n = sizes
+            # Infer K from input shapes
+            inputs = multi_node.inputs
+            if inputs and hasattr(inputs[0], "get_size"):
+                k = int(inputs[0].get_size()[-1])
+                if tlx_config.use_heuristic_config:
+                    cfg = get_heuristic_config(m, n, k, get_num_sms())
+                    if cfg and cfg.get("SPLIT_K", 1) > 1:
+                        return True
+    except Exception:
+        pass
+    return False
+
+
+def should_force_fusion(multi_node: "ir.MultiTemplateBuffer") -> bool:
+    """
+    Check if fusion should be forced for a MultiTemplateBuffer.
+
+    Returns True if TORCHINDUCTOR_TLX_MODE=force and the node
+    contains TLX templates.  Never force fusion when SPLIT_K > 1
+    because epilogue ops cannot be applied to partial results.
+    """
+    if not _is_force_fusion_enabled():
+        return False
+    if _has_split_k(multi_node):
+        return False
+    return any(_is_tlx_choice(c) for c in multi_node.choices)
+
+
+def should_force_fusion_for_node(node: "BaseSchedulerNode") -> bool:
+    """
+    Check if fusion should be forced for a scheduler node.
+
+    Returns True if TORCHINDUCTOR_TLX_MODE=force and the node
+    is a TLX template (or any Triton template when we can't determine).
+    """
+    from torch._inductor import ir
+
+    if not _is_force_fusion_enabled():
+        return False
+    if not node.is_template():
+        return False
+    template_node = node.get_template_node()
+    if template_node is None:
+        return False
+    if isinstance(template_node, ir.MultiTemplateBuffer):
+        if _has_split_k(template_node):
+            return False
+        return any(_is_tlx_choice(c) for c in template_node.choices)
+    return False
+
+
+def log_fusion_forced(
+    ms_fused: float,
+    ms1: float,
+    ms2: float,
+    path: str = "",
+) -> None:
+    """Log when fusion is forced despite benchmark results."""
+    ms_sum = ms1 + ms2
+    if ms_fused >= ms_sum:
+        fusion_log.info(
+            "TLX fusion forced%s despite slowdown: ms_fused=%.6f >= ms1+ms2=%.6f (%.2fx slower)",
+            f" ({path})" if path else "",
+            ms_fused,
+            ms_sum,
+            ms_fused / ms_sum,
+        )
+    else:
+        fusion_log.info(
+            "TLX fusion forced%s (also faster): ms_fused=%.6f < ms1+ms2=%.6f (%.2fx speedup)",
+            f" ({path})" if path else "",
+            ms_fused,
+            ms_sum,
+            ms_sum / ms_fused,
+        )
+
+
+def maybe_add_tlx_prefix(fused_name: str, src_code: str) -> str:
+    """
+    If the rendered kernel source uses TLX APIs, insert 'tlx' into
+    the fused kernel name (e.g. 'fused_mm' -> 'fused_tlx_mm').
+    """
+    if "tlx." in src_code:
+        return fused_name.replace("fused_", "fused_tlx_", 1)
+    return fused_name

--- a/third_party/tlx/language/tlx/inductor/mm_templates.py
+++ b/third_party/tlx/language/tlx/inductor/mm_templates.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+from torch._inductor.kernel.mm_common import mm_grid
+from torch._inductor.select_algorithm import SymbolicGridFn, TritonTemplate
+from torch._inductor.utils import load_template
+
+# TLX kernel .jinja templates ship alongside this module (packaged as buck
+# resources of the triton beta python library), so load them from here rather
+# than from the OSS inductor template dir.
+_TLX_TEMPLATE_DIR = Path(__file__).parent
+
+
+def load_tlx_template(name: str) -> str:
+    return load_template(name, template_dir=_TLX_TEMPLATE_DIR)
+
+
+@SymbolicGridFn
+def _persistent_mm_grid_split_k(*args, cdiv, min):
+    """Grid for persistent TLX GEMM kernels with split-K support.
+
+    Accepts variable positional args to handle both MM (M, N, meta)
+    and BMM (B, M, N, meta) call signatures.
+    """
+    meta = args[-1]
+    M = args[-3]
+    N = args[-2]
+    num_mn_tiles = cdiv(M, meta["BLOCK_M"]) * cdiv(N, meta["BLOCK_N"])
+    split_k = meta.get("SPLIT_K", 1)
+    return (min(meta["NUM_SMS"], num_mn_tiles * split_k), 1, 1)
+
+
+blackwell_gemm_ws_template = TritonTemplate(
+    name="tlx_blackwell_gemm_ws",
+    grid=_persistent_mm_grid_split_k,
+    source=load_tlx_template("blackwell_gemm_ws"),
+)
+
+# TLX warp-pipelined addmm template (AMD / MI350X gfx950), col-major B only.
+# Hand-pipelined (num_stages=1): async_load prefetch into multi-buffered LDS +
+# tlx.warp_pipeline_stage("mfma"/"mem"). Wins on latency-bound thin-N fp16 addmm.
+# The col-major-B requirement is enforced by the heuristic's adjust_kernel_inputs
+# (see registry.py); selection/gating is via TORCHINDUCTOR_TLX_MODE (tlx_config).
+amd_addmm_warppipe_template = TritonTemplate(
+    name="tlx_amd_addmm_warppipe",
+    grid=mm_grid,
+    source=load_tlx_template("amd_addmm_warppipe"),
+)
+
+
+def append_tlx(templates, op_name="mm"):
+    # Import registry to trigger heuristic registration via decorators
+    from . import registry  # noqa: F401
+
+    if op_name == "addmm":
+        # The warp-pipe addmm competes as an ADDITIONAL candidate alongside the stock
+        # mm_template + vendor (aten). tuned_addmm issues several get_template_configs
+        # calls (aten, subgraph, unified); inject only into the call that already carries
+        # mm_template (the unified one) so the warp-pipe is added exactly once.
+        from torch._inductor.kernel.mm import mm_template
+
+        uids = {getattr(t, "uid", None) for t in templates}
+        if mm_template.uid in uids and amd_addmm_warppipe_template.uid not in uids:
+            templates.append(amd_addmm_warppipe_template)
+    else:
+        templates.append(blackwell_gemm_ws_template)
+    return templates

--- a/third_party/tlx/language/tlx/inductor/reduce_k.py
+++ b/third_party/tlx/language/tlx/inductor/reduce_k.py
@@ -1,0 +1,83 @@
+"""
+Split-K reduction kernel for TLX Blackwell GEMM templates.
+
+When SPLIT_K > 1, the main GEMM kernel writes fp32 partial results to a
+workspace of shape (SPLIT_K * M, N).  This module provides:
+  - _reduce_k_kernel:  Triton JIT kernel that sums the partials and writes
+                        the final output in the target dtype.
+  - emit_reduce_k_call: helper that emits wrapper code to launch the
+                        reduction kernel after the main GEMM.
+
+Ported from upstream:
+  third-party/triton/beta/triton/third_party/tlx/tutorials/blackwell_gemm_ws.py
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import triton
+import triton.language as tl
+
+if TYPE_CHECKING:
+    from torch._inductor.codegen.wrapper import WrapperCodeGen
+
+
+@triton.jit
+def _reduce_k_kernel(
+    workspace_ptr,
+    c_ptr,
+    M,
+    N,
+    SPLIT_K: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    OUTPUT_DTYPE: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    base_offs = offs_m[:, None] * N + offs_n[None, :]
+
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for s in range(SPLIT_K):
+        ws_offs = base_offs + s * M * N
+        partial = tl.load(workspace_ptr + ws_offs, mask=mask, other=0.0)
+        acc += partial.to(tl.float32)
+
+    tl.store(c_ptr + base_offs, acc.to(OUTPUT_DTYPE), mask=mask)
+
+
+def emit_reduce_k_call(
+    wrapper: "WrapperCodeGen",
+    ws_name: str,
+    output_name: str,
+    M_expr: str,
+    N_expr: str,
+    split_k: int,
+    output_triton_dtype: str,
+) -> None:
+    """Emit wrapper code to launch the split-K reduction kernel.
+
+    Args:
+        wrapper: The WrapperCodeGen instance to write lines to.
+        ws_name: Variable name of the fp32 workspace buffer in wrapper code.
+        output_name: Variable name of the output buffer in wrapper code.
+        M_expr: Expression string for the M dimension.
+        N_expr: Expression string for the N dimension.
+        split_k: The SPLIT_K value (compile-time constant).
+        output_triton_dtype: Triton dtype string for the output (e.g. "tl.float16").
+    """
+    wrapper.writeline(
+        "from triton.language.extra.tlx.inductor.reduce_k import _reduce_k_kernel"
+    )
+    wrapper.writeline("import triton")
+    wrapper.writeline("import triton.language as tl")
+    wrapper.writeline(
+        f"_reduce_k_kernel[(triton.cdiv({M_expr}, 32), triton.cdiv({N_expr}, 32))]"
+        f"({ws_name}, {output_name}, {M_expr}, {N_expr},"
+        f" SPLIT_K={split_k}, BLOCK_SIZE_M=32, BLOCK_SIZE_N=32,"
+        f" OUTPUT_DTYPE={output_triton_dtype})"
+    )

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1,0 +1,1846 @@
+import dataclasses
+import logging
+from typing import Any, Generator
+
+log = logging.getLogger(__name__)
+
+import torch
+from torch._inductor import config
+from torch._inductor.kernel_inputs import KernelInputs, MMKernelInputs
+from torch._inductor.template_heuristics.registry import register_template_heuristic
+from torch._inductor.template_heuristics.triton import (
+    CUDAConfigHeuristic,
+    GemmConfig,
+    IS_ROCM,
+    ROCmMMTemplateConfigHeuristic,
+    TMATemplateConfigMixin,
+)
+from torch._inductor.template_heuristics.triton_addmm import AddMMConfigMixin
+from torch._inductor.utils import get_default_kpack, get_num_sms
+
+from . import tlx_config
+from .mm_templates import amd_addmm_warppipe_template, blackwell_gemm_ws_template
+
+
+@dataclasses.dataclass
+class TlxGemmConfig(GemmConfig):
+    """
+    Gemm configuration for TLX templates with TLX-specific parameters.
+    """
+
+    group_size_m: int = dataclasses.field(kw_only=True, default=8)
+    smem_num: int = dataclasses.field(kw_only=True, default=3)
+    tmem_num: int = dataclasses.field(kw_only=True, default=2)
+    epilogue_subtile: int = dataclasses.field(kw_only=True, default=1)
+    num_mma_groups: int = dataclasses.field(kw_only=True, default=1)
+    num_ctas: int = dataclasses.field(kw_only=True, default=1)
+    split_k: int = dataclasses.field(kw_only=True, default=1)
+    interleave_epilogue: int = dataclasses.field(kw_only=True, default=0)
+
+
+# ---------------------------------------------------------------------
+# Heuristic config selection (matches tlx_matmul_ws behavior)
+# Implemented directly in Python to avoid dependency on YAML rule engine files
+# ---------------------------------------------------------------------
+
+import math as _math
+
+
+def _amd_num_xcds() -> int:
+    """Number of XCDs (chiplets) on the current ROCm GPU, for the L2 chiplet swizzle.
+
+    gfx942 (MI300X) and gfx950 (MI350X) have 8. Returns 1 -- which makes the swizzle a
+    no-op (identity) -- for non-HIP or arches with no known XCD count, since the template
+    is registered for all ROCm, not just the 8-XCD parts.
+    """
+    if not torch.version.hip:
+        return 1
+    arch = torch.cuda.get_device_properties(0).gcnArchName
+    if "gfx942" in arch or "gfx950" in arch:
+        return 8
+    return 1
+
+
+def _select_group_size_m(M: int, N: int, block_m: int) -> int:
+    """
+    Select GROUP_SIZE_M based on the golden rule for tile scheduling.
+
+    GROUP_SIZE_M controls how tiles are traversed:
+    - GROUP_SIZE_M = 1: Column-major (sweep M first), reuses B tiles
+    - GROUP_SIZE_M = large: Row-major (sweep N first), reuses A tiles
+
+    Golden rule:
+    - When M >> N: Use small GROUP_SIZE_M to reuse B (smaller dimension)
+    - When N >> M: Use large GROUP_SIZE_M to reuse A (smaller dimension)
+    - When M ~ N: Use moderate GROUP_SIZE_M for L2 locality
+    """
+    num_m_tiles = (M + block_m - 1) // block_m
+    ratio = M / max(N, 1)
+
+    if ratio > 10:
+        # M >> N: sweep M, reuse B
+        return 1
+    elif ratio < 0.1:
+        # N >> M: sweep N, reuse A
+        return min(64, num_m_tiles)
+    else:
+        # Balanced: moderate group size for L2 locality
+        return min(8, num_m_tiles)
+
+
+def _is_config_valid(
+    config: dict[str, Any], tma_epilogue_store: bool = False, smem_margin: int = 0
+) -> bool:
+    """Check if a config is valid based on hardware constraints."""
+    # Upstream uses 232*1024 as a loose estimate, but the actual Blackwell
+    # hardware limit is 232448 bytes.  We use the real limit because
+    # epilogue fusion can add SMEM beyond what the formula captures.
+    MAX_SHARED_MEMORY = 232448  # B200 SMEM per SM (actual hardware limit)
+    MAX_TMEM_COLUMNS = 512  # TMEM columns per SM (Blackwell hardware limit)
+
+    block_m = config["BLOCK_SIZE_M"]
+    block_n = config["BLOCK_SIZE_N"]
+    block_k = config["BLOCK_SIZE_K"]
+    num_ctas = config["NUM_CTAS"]
+    num_smem_buffers = config["NUM_SMEM_BUFFERS"]
+    num_tmem_buffers = config["NUM_TMEM_BUFFERS"]
+    num_mma_groups = config["NUM_MMA_GROUPS"]
+    epilogue_subtile = config["EPILOGUE_SUBTILE"]
+
+    # Check MMA groups constraint
+    if block_m // num_mma_groups > 128:
+        return False
+
+    # Pair-CTA MMA requires M=128 per MMA group
+    if num_ctas == 2 and block_m // num_mma_groups < 128:
+        return False
+
+    # Check epilogue subtile
+    if block_n % epilogue_subtile != 0:
+        return False
+
+    # Shared memory estimation — matches upstream estimate_smem exactly.
+    # Split-K fp32 workspace overhead is torchTLX-specific: upstream uses output
+    # dtype (bf16) for the workspace, but torchTLX uses fp32 for accuracy.
+    smem_a = block_m * block_k * 2 * num_smem_buffers
+    smem_b_size = block_n // num_ctas
+    smem_b = block_k * smem_b_size * 2 * num_smem_buffers
+    if tma_epilogue_store:
+        smem_epilog = block_m * (block_n // epilogue_subtile) * 2
+    else:
+        smem_epilog = 0
+    smem_barriers = num_smem_buffers * num_mma_groups * 8
+    if num_ctas == 2:
+        smem_barriers += num_smem_buffers * num_mma_groups * 8
+    total_smem = smem_a + smem_b + smem_epilog + smem_barriers
+
+    split_k = config.get("SPLIT_K", 1)
+    if split_k > 1:
+        # torchTLX stores fp32 partials to workspace (upstream uses bf16).
+        # Account for the fp32 ws_smem_buffers allocated in the template.
+        block_m_split = block_m // num_mma_groups
+        slice_size = block_n // epilogue_subtile
+        num_epilogue_smem_buffers = max(num_mma_groups, 2)
+        smem_ws = block_m_split * slice_size * 4 * num_epilogue_smem_buffers
+        total_smem += smem_ws
+
+    if total_smem + smem_margin > MAX_SHARED_MEMORY:
+        return False
+
+    # TMEM estimation (columns, not bytes)
+    total_tmem_columns = block_n * num_tmem_buffers * num_mma_groups
+    if total_tmem_columns > MAX_TMEM_COLUMNS:
+        return False
+
+    return True
+
+
+def _fix_config_if_needed(
+    config: dict[str, Any], tma_epilogue_store: bool = False
+) -> dict[str, Any] | None:
+    """
+    Fix config to stay within shared memory limits.
+    Returns None if config cannot be fixed.
+    """
+    if _is_config_valid(config, tma_epilogue_store=tma_epilogue_store):
+        return config
+    # Config overflows SMEM (e.g., split-K fp32 workspace overhead).
+    # Return None so get_heuristic_config falls through to the candidate
+    # scorer, and ultimately to the autotuning pool if no scorer config fits.
+    return None
+
+
+def _select_split_k(K: int, block_k: int) -> int:
+    """Select split-K factor for undersaturated shapes.
+
+    Tries split factors in order [4, 2, 8]; picks the first where each split
+    has at least 4 K-tiles.  Returns 1 if no split factor is suitable.
+    """
+    k_tiles = _math.ceil(K / block_k)
+    for sk in [4, 2, 8]:
+        k_tiles_per_split = _math.ceil(k_tiles / sk)
+        if k_tiles_per_split * (sk - 1) >= k_tiles:
+            continue  # last split would be empty
+        if k_tiles // sk >= 4:
+            return sk
+    return 1
+
+
+def get_heuristic_config(
+    M: int,
+    N: int,
+    K: int,
+    num_sms: int = 148,
+    tma_epilogue_store: bool = False,
+) -> dict[str, Any] | None:
+    """
+    Select optimal GEMM config based on problem shape characteristics.
+
+    This implements heuristic rules for TLX Blackwell GEMM kernel configuration.
+    Rules are evaluated in order (first match wins).
+
+    Heuristic Rules Index:
+    ----------------------
+    Rule 0: Fallback (Candidate Scoring)
+        - Condition: No single-config rule matches, or block size validation fails
+        - Config: Selected via _candidate_scorer_evaluate()
+        - Use case: Edge cases and shapes not covered by explicit rules
+
+    Rule 1a: Tall-M, alt-tiling, moderate M (torchTLX extension)
+        - Condition: is_tall_m AND gpu_saturated AND use_alt_tiling AND m_tiles <= num_sms//2
+        - Config: (128, 256, 64), 1-CTA, 3 SMEM buffers
+        - Use case: Shapes where BN=256 wastes tiles (N<=256, N unaligned, low tile count)
+
+    Rule 1b: Tall-M Low-AI (or alt-tiling fallback)
+        - Condition: is_tall_m AND gpu_saturated AND (AI <= 1.5 OR use_alt_tiling)
+        - Config: (256, 128, 128), 2-CTA, 2 SMEM buffers, INTERLEAVE=1
+        - Use case: Memory-bound tall-M shapes
+
+    Rule 3: Tall-M High-AI, K > N*2
+        - Condition: is_tall_m AND gpu_saturated AND AI > 1.5 AND K > N*2
+        - Config: (256, 256, 128), 2-CTA, 2 SMEM buffers, EPILOGUE_SUBTILE=4
+        - Use case: Compute-bound tall-M with large K relative to N
+
+    Rule 4: Tall-M High-AI, K <= N*2
+        - Condition: is_tall_m AND gpu_saturated AND AI > 1.5 AND K <= N*2
+        - Config: (256, 256, 64), 2-CTA, 4 SMEM buffers, EPILOGUE_SUBTILE=4, INTERLEAVE=1
+        - Use case: Compute-bound tall-M with K similar to or smaller than N
+
+    Rule 5: Undersaturated Large-Output
+        - Condition: undersaturated AND MN >= 1M
+        - Config: (256, 128, 64), 4 SMEM buffers, EPILOGUE_SUBTILE=8
+        - Use case: Large output matrices that don't saturate GPU
+
+    Rule 6: Undersaturated Small-Output
+        - Condition: undersaturated AND MN < 1M
+        - Config: (128, 64, 128), 4 SMEM buffers
+        - Use case: Small output matrices that don't saturate GPU
+
+    Rule 7: GPU-Saturated General (Wide-N)
+        - Condition: gpu_saturated AND NOT is_tall_m
+        - Config: (256, 256, 64), 1-CTA, 3 SMEM buffers, EPILOGUE_SUBTILE=4, INTERLEAVE=1
+        - Use case: GPU-saturated shapes with balanced or wide-N dimensions
+
+    Args:
+        M, N, K: GEMM dimensions (A is MxK, B is KxN, C is MxN)
+        num_sms: Number of SMs on the GPU (default 148 for B200)
+
+    Returns:
+        dict: Configuration parameters for the TLX GEMM kernel,
+        or None if no valid config can be determined.
+    """
+    # --- Compute derived features ---
+    mn_ratio = M / max(N, 1)
+    is_tall_m = mn_ratio > 4
+    is_tall_n = mn_ratio < 0.25
+
+    # Reference block sizes for tile counting
+    ref_bm = 256 if is_tall_m else (128 if is_tall_n else 256)
+    ref_bn = 128 if is_tall_m else (256 if is_tall_n else 256)
+
+    num_mn_tiles = _math.ceil(M / ref_bm) * _math.ceil(N / ref_bn)
+    gpu_saturated = num_mn_tiles >= num_sms
+    undersaturated = num_mn_tiles < num_sms
+    mn_product = M * N
+    is_large_output = mn_product >= 1000000
+
+    config = None
+
+    # --- Rule matching (first match wins) ---
+
+    # Characteristic 1: Tall-M saturated shapes
+    if is_tall_m and gpu_saturated:
+        arithmetic_intensity = K / max(min(M, N), 1)
+
+        # Check if the default high-AI path (Rule 3: BM=256 BN=256) would
+        # be suboptimal.  Three triggers:
+        #   1. N <= 256: BN=256 >= N, config would be rejected downstream
+        #   2. Few total tiles at BN=256: poor wave efficiency
+        #   3. N < 1024 and N not aligned to 256: significant tile waste
+        use_alt_tiling = False
+        if arithmetic_intensity > 1.5:
+            tiles_bn256 = _math.ceil(M / 256) * _math.ceil(N / 256)
+            if N <= 256:
+                use_alt_tiling = True
+            elif tiles_bn256 < 4 * num_sms:
+                use_alt_tiling = True
+            elif N < 1024 and N % 256 != 0:
+                use_alt_tiling = True
+
+        # Rule 1a/1b: Tall-M Low-AI, or high-AI with suboptimal BN=256
+        if arithmetic_intensity <= 1.5 or use_alt_tiling:
+            m_tiles_256 = _math.ceil(M / 256)
+            # Rule 1a: Moderate-M — use BM=128 1-CTA to avoid 2-CTA
+            # coordination overhead and improve tile granularity.
+            if use_alt_tiling and m_tiles_256 <= num_sms // 2:
+                config = {
+                    "BLOCK_SIZE_M": 128,
+                    "BLOCK_SIZE_N": 256,
+                    "BLOCK_SIZE_K": 64,
+                    "NUM_SMEM_BUFFERS": 3,
+                    "NUM_TMEM_BUFFERS": 2,
+                    "NUM_MMA_GROUPS": 1,
+                    "EPILOGUE_SUBTILE": 2,
+                    "NUM_CTAS": 1,
+                    "SPLIT_K": 1,
+                    "INTERLEAVE_EPILOGUE": 0,
+                }
+            # Rule 1b: Large-M — BM=256 2-CTA streams A efficiently.
+            else:
+                config = {
+                    "BLOCK_SIZE_M": 256,
+                    "BLOCK_SIZE_N": 128,
+                    "BLOCK_SIZE_K": 128,
+                    "NUM_SMEM_BUFFERS": 2,
+                    "NUM_TMEM_BUFFERS": 2,
+                    "NUM_MMA_GROUPS": 2,
+                    "EPILOGUE_SUBTILE": 1,
+                    "NUM_CTAS": 2,
+                    "SPLIT_K": 1,
+                    "INTERLEAVE_EPILOGUE": 1,
+                }
+        # Rule 3: Tall-M High-AI, K > N*2 — large BLOCK_K for fewer K-iterations
+        elif K > N * 2:
+            config = {
+                "BLOCK_SIZE_M": 256,
+                "BLOCK_SIZE_N": 256,
+                "BLOCK_SIZE_K": 128,
+                "NUM_SMEM_BUFFERS": 2,
+                "NUM_TMEM_BUFFERS": 1,
+                "NUM_MMA_GROUPS": 2,
+                "EPILOGUE_SUBTILE": 4,
+                "NUM_CTAS": 2,
+                "SPLIT_K": 1,
+                "INTERLEAVE_EPILOGUE": 0,
+            }
+        # Rule 4: Tall-M High-AI, K <= N*2 — more SMEM buffers, interleaved epilogue
+        else:
+            config = {
+                "BLOCK_SIZE_M": 256,
+                "BLOCK_SIZE_N": 256,
+                "BLOCK_SIZE_K": 64,
+                "NUM_SMEM_BUFFERS": 4,
+                "NUM_TMEM_BUFFERS": 1,
+                "NUM_MMA_GROUPS": 2,
+                "EPILOGUE_SUBTILE": 4,
+                "NUM_CTAS": 2,
+                "SPLIT_K": 1,
+                "INTERLEAVE_EPILOGUE": 1,
+            }
+
+    # Characteristic 2: Undersaturated shapes — use split-K to improve parallelism.
+    # The template writes fp32 partials to a workspace; a separate reduction
+    # kernel sums the partials after the main GEMM.
+    #
+    # Note: upstream only returns Rule 5/6 when split_k > 1 and falls through
+    # to the candidate scorer otherwise.  torchTLX intentionally returns the
+    # config even with split_k=1 to provide a deterministic tile size for
+    # undersaturated shapes (the candidate scorer may pick a suboptimal config
+    # for these shapes since its wave-efficiency scoring doesn't account for
+    # the tile shape preferences encoded in Rules 5/6).
+    elif undersaturated and is_large_output:
+        block_k = 64
+        split_k = _select_split_k(K, block_k)
+        # Rule 5: Undersaturated Large-Output
+        config = {
+            "BLOCK_SIZE_M": 256,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": block_k,
+            "NUM_SMEM_BUFFERS": 4,
+            "NUM_TMEM_BUFFERS": 2,
+            "NUM_MMA_GROUPS": 2,
+            "EPILOGUE_SUBTILE": 8,
+            "NUM_CTAS": 1,
+            "SPLIT_K": split_k,
+            "INTERLEAVE_EPILOGUE": 1,
+        }
+    elif undersaturated and not is_large_output:
+        block_k = 128
+        split_k = _select_split_k(K, block_k)
+        # Rule 6: Undersaturated Small-Output
+        config = {
+            "BLOCK_SIZE_M": 128,
+            "BLOCK_SIZE_N": 64,
+            "BLOCK_SIZE_K": block_k,
+            "NUM_SMEM_BUFFERS": 4,
+            "NUM_TMEM_BUFFERS": 3,
+            "NUM_MMA_GROUPS": 2,
+            "EPILOGUE_SUBTILE": 1,
+            "NUM_CTAS": 1,
+            "SPLIT_K": split_k,
+            "INTERLEAVE_EPILOGUE": 1,
+        }
+
+    # Rule 7: GPU-Saturated General (Wide-N)
+    elif gpu_saturated:
+        config = {
+            "BLOCK_SIZE_M": 256,
+            "BLOCK_SIZE_N": 256,
+            "BLOCK_SIZE_K": 64,
+            "NUM_SMEM_BUFFERS": 3,
+            "NUM_TMEM_BUFFERS": 1,
+            "NUM_MMA_GROUPS": 2,
+            "EPILOGUE_SUBTILE": 4,
+            "NUM_CTAS": 1,
+            "SPLIT_K": 1,
+            "INTERLEAVE_EPILOGUE": 1,
+        }
+
+    # Rule 0: Fallback (Candidate Scoring)
+    if config is None:
+        config = _candidate_scorer_evaluate(M, N, K, num_sms)
+
+    if config is None:
+        return None
+
+    # Validate block sizes don't exceed problem dimensions
+    block_n = config["BLOCK_SIZE_N"]
+    block_k = config["BLOCK_SIZE_K"]
+
+    if block_n >= N or block_k >= K:
+        config = _candidate_scorer_evaluate(M, N, K, num_sms)
+        if config is None:
+            return None
+        if config["BLOCK_SIZE_N"] >= N or config["BLOCK_SIZE_K"] >= K:
+            return None
+
+    # Validate and fix config if needed
+    config = _fix_config_if_needed(config, tma_epilogue_store=tma_epilogue_store)
+    if config is None:
+        config = _candidate_scorer_evaluate(M, N, K, num_sms)
+        if config is not None:
+            config = _fix_config_if_needed(
+                config, tma_epilogue_store=tma_epilogue_store
+            )
+        if config is None:
+            return None
+
+    # Post-process: add GROUP_SIZE_M and ctas_per_cga
+    block_m = config["BLOCK_SIZE_M"]
+    num_ctas = config["NUM_CTAS"]
+    config["GROUP_SIZE_M"] = _select_group_size_m(M, N, block_m)
+    # GROUP_SIZE_M must be a multiple of NUM_CTAS so that consecutive
+    # tile_ids (paired CTAs in a cluster) map to the same pid_n.
+    if num_ctas > 1:
+        gsm = config["GROUP_SIZE_M"]
+        config["GROUP_SIZE_M"] = ((gsm + num_ctas - 1) // num_ctas) * num_ctas
+    config["ctas_per_cga"] = (num_ctas, 1, 1) if num_ctas > 1 else None
+
+    return config
+
+
+# --- Candidate scoring (fallback when rules don't match) ---
+
+_CANDIDATES = [
+    {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "NUM_CTAS": 2,
+        "NUM_SMEM_BUFFERS": 2,
+        "NUM_TMEM_BUFFERS": 2,
+        "NUM_MMA_GROUPS": 2,
+        "EPILOGUE_SUBTILE": 1,
+    },
+    {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "NUM_CTAS": 1,
+        "NUM_SMEM_BUFFERS": 3,
+        "NUM_TMEM_BUFFERS": 1,
+        "NUM_MMA_GROUPS": 2,
+        "EPILOGUE_SUBTILE": 4,
+    },
+    {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "NUM_CTAS": 1,
+        "NUM_SMEM_BUFFERS": 4,
+        "NUM_TMEM_BUFFERS": 3,
+        "NUM_MMA_GROUPS": 2,
+        "EPILOGUE_SUBTILE": 1,
+    },
+    {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "NUM_CTAS": 2,
+        "NUM_SMEM_BUFFERS": 5,
+        "NUM_TMEM_BUFFERS": 2,
+        "NUM_MMA_GROUPS": 2,
+        "EPILOGUE_SUBTILE": 4,
+    },
+    {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "NUM_CTAS": 2,
+        "NUM_SMEM_BUFFERS": 4,
+        "NUM_TMEM_BUFFERS": 2,
+        "NUM_MMA_GROUPS": 1,
+        "EPILOGUE_SUBTILE": 2,
+    },
+    {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "NUM_CTAS": 2,
+        "NUM_SMEM_BUFFERS": 5,
+        "NUM_TMEM_BUFFERS": 2,
+        "NUM_MMA_GROUPS": 2,
+        "EPILOGUE_SUBTILE": 4,
+    },
+    {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "NUM_CTAS": 2,
+        "NUM_SMEM_BUFFERS": 5,
+        "NUM_TMEM_BUFFERS": 2,
+        "NUM_MMA_GROUPS": 2,
+        "EPILOGUE_SUBTILE": 1,
+    },
+    {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "NUM_CTAS": 1,
+        "NUM_SMEM_BUFFERS": 5,
+        "NUM_TMEM_BUFFERS": 2,
+        "NUM_MMA_GROUPS": 2,
+        "EPILOGUE_SUBTILE": 8,
+    },
+    {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "NUM_CTAS": 1,
+        "NUM_SMEM_BUFFERS": 3,
+        "NUM_TMEM_BUFFERS": 2,
+        "NUM_MMA_GROUPS": 1,
+        "EPILOGUE_SUBTILE": 2,
+    },
+    {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "NUM_CTAS": 1,
+        "NUM_SMEM_BUFFERS": 4,
+        "NUM_TMEM_BUFFERS": 2,
+        "NUM_MMA_GROUPS": 1,
+        "EPILOGUE_SUBTILE": 2,
+    },
+    {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "NUM_CTAS": 1,
+        "NUM_SMEM_BUFFERS": 3,
+        "NUM_TMEM_BUFFERS": 1,
+        "NUM_MMA_GROUPS": 2,
+        "EPILOGUE_SUBTILE": 2,
+    },
+    {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "NUM_CTAS": 1,
+        "NUM_SMEM_BUFFERS": 5,
+        "NUM_TMEM_BUFFERS": 2,
+        "NUM_MMA_GROUPS": 1,
+        "EPILOGUE_SUBTILE": 1,
+    },
+    {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "NUM_CTAS": 1,
+        "NUM_SMEM_BUFFERS": 5,
+        "NUM_TMEM_BUFFERS": 2,
+        "NUM_MMA_GROUPS": 1,
+        "EPILOGUE_SUBTILE": 1,
+    },
+    {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "NUM_CTAS": 1,
+        "NUM_SMEM_BUFFERS": 6,
+        "NUM_TMEM_BUFFERS": 2,
+        "NUM_MMA_GROUPS": 1,
+        "EPILOGUE_SUBTILE": 1,
+    },
+]
+
+
+def _candidate_scorer_evaluate(
+    M: int, N: int, K: int, num_sms: int
+) -> dict[str, Any] | None:
+    """Score candidates by wave efficiency and return best."""
+    MAX_SMEM = 232448  # B200 SMEM per SM (actual hardware limit)
+    MAX_TMEM = 256 * 1024
+
+    best_config = None
+    best_score = float("inf")
+    best_waves = float("inf")
+
+    for cfg in _CANDIDATES:
+        bm = cfg["BLOCK_SIZE_M"]
+        bn = cfg["BLOCK_SIZE_N"]
+        bk = cfg["BLOCK_SIZE_K"]
+        num_ctas = cfg["NUM_CTAS"]
+        num_smem_buffers = cfg["NUM_SMEM_BUFFERS"]
+        num_tmem_buffers = cfg["NUM_TMEM_BUFFERS"]
+        num_mma_groups = cfg["NUM_MMA_GROUPS"]
+        epilogue_subtile = cfg["EPILOGUE_SUBTILE"]
+
+        # Constraint checks
+        smem_a = bm * bk * 2 * num_smem_buffers
+        smem_b = bk * (bn // num_ctas) * 2 * num_smem_buffers
+        smem_epilog = bm * (bn // epilogue_subtile) * 2
+        smem_barriers = (
+            num_smem_buffers * num_mma_groups * 8 * (2 if num_ctas == 2 else 1)
+        )
+        total_smem = smem_a + smem_b + smem_epilog + smem_barriers
+        if total_smem > MAX_SMEM:
+            continue
+
+        total_tmem = bm * bn * 4 * num_tmem_buffers
+        if total_tmem > MAX_TMEM:
+            continue
+
+        if bm // num_mma_groups > 128:
+            continue
+
+        # Block sizes must be strictly less than problem dimensions for correctness
+        if bn >= N or bk >= K:
+            continue
+
+        if bm > M * 2:
+            continue
+
+        # Wave efficiency scoring
+        ctas_m = (M + bm - 1) // bm
+        ctas_n = (N + bn - 1) // bn
+        ctas_m = ((ctas_m + num_ctas - 1) // num_ctas) * num_ctas
+        total_ctas = ctas_m * ctas_n
+
+        if total_ctas == 0:
+            continue
+
+        waves = (total_ctas + num_sms - 1) // num_sms
+        fractional_waves = total_ctas / num_sms
+        score = waves - fractional_waves
+
+        # Consider split-K for undersaturated shapes
+        split_k = 1
+        num_tiles_m = _math.ceil(M / bm)
+        num_tiles_n = _math.ceil(N / bn)
+        num_mn_tiles = num_tiles_m * num_tiles_n
+
+        if num_mn_tiles < num_sms:
+            k_tiles = _math.ceil(K / bk)
+            for sk in [8, 4, 2]:
+                k_tiles_per_split = _math.ceil(k_tiles / sk)
+                if k_tiles_per_split * (sk - 1) >= k_tiles:
+                    continue  # last split would be empty
+                if k_tiles >= sk and k_tiles // sk >= 4:
+                    sk_ctas_m = ((num_tiles_m + num_ctas - 1) // num_ctas) * num_ctas
+                    sk_total_ctas = sk_ctas_m * num_tiles_n * sk
+                    sk_waves = (sk_total_ctas + num_sms - 1) // num_sms
+                    sk_frac = sk_total_ctas / num_sms
+                    sk_score = sk_waves - sk_frac
+                    if sk_score < score or (
+                        sk_score == score and sk_total_ctas > total_ctas
+                    ):
+                        score, total_ctas, waves, split_k = (
+                            sk_score,
+                            sk_total_ctas,
+                            sk_waves,
+                            sk,
+                        )
+                    break
+
+        # Selection
+        score_slack = 0.1
+        if (
+            score < best_score - score_slack
+            or (score < best_score + score_slack and waves < best_waves)
+            or (
+                score < best_score + score_slack
+                and waves == best_waves
+                and num_ctas > 1
+            )
+        ):
+            best_score = score
+            best_waves = waves
+            best_config = dict(cfg)
+            best_config["SPLIT_K"] = split_k
+            best_config["INTERLEAVE_EPILOGUE"] = 0
+
+    return best_config
+
+
+class TLXMatmulWSConfigMixin(TMATemplateConfigMixin):
+    """Mixin for TLX Matmul WS template with TLX-specific parameters and config validation."""
+
+    # Blackwell B200A resource limits
+    MAX_SHARED_MEMORY = 232448  # B200 SMEM per SM (actual hardware limit)
+    MAX_TMEM_COLUMNS = 512  # TMEM columns per SM (Blackwell hardware limit)
+    MBARRIER_SIZE = 8  # bytes
+
+    @staticmethod
+    def _is_valid_config(
+        block_m: int,
+        block_n: int,
+        block_k: int,
+        num_smem_buffers: int,
+        num_tmem_buffers: int,
+        num_mma_groups: int,
+        num_ctas: int,
+        epilogue_subtile: int,
+    ) -> bool:
+        """
+        Check if config is valid based on hardware constraints.
+        Based on preprocess_configs from tritonbench/operators/gemm/tlx_matmul.py
+
+        Returns:
+            True if config is valid, False if should be pruned.
+        """
+        # Rule 1: Filter out invalid config that causes wrong hardware MMA
+        if block_m // num_mma_groups > 128:
+            return False
+
+        # Rule 1b: Pair-CTA MMA requires M=128 per MMA group
+        if num_ctas == 2 and block_m // num_mma_groups < 128:
+            return False
+
+        # Rule 2: EPILOGUE_SUBTILE must evenly divide BLOCK_N
+        if block_n % epilogue_subtile != 0:
+            return False
+
+        # Rule 3: Estimate Shared Memory Usage
+        # buffers_A: BLOCK_M x BLOCK_K x float16 x NUM_SMEM_BUFFERS
+        smem_a = block_m * block_k * 2 * num_smem_buffers
+        # buffers_B: BLOCK_K x BLOCK_N x float16 x NUM_SMEM_BUFFERS
+        # In NUM_CTAS=2 mode, each CTA only loads half of B
+        smem_b_size = block_n // num_ctas
+        smem_b = block_k * smem_b_size * 2 * num_smem_buffers
+        # Epilogue staging buffer
+        smem_epilog = block_m * (block_n // epilogue_subtile) * 2
+
+        smem_barriers = (
+            num_smem_buffers * num_mma_groups * TLXMatmulWSConfigMixin.MBARRIER_SIZE
+        )
+        if num_ctas == 2:
+            smem_barriers += (
+                num_smem_buffers * num_mma_groups * TLXMatmulWSConfigMixin.MBARRIER_SIZE
+            )
+
+        total_smem = smem_a + smem_b + smem_epilog + smem_barriers
+        if total_smem > TLXMatmulWSConfigMixin.MAX_SHARED_MEMORY:
+            return False
+
+        # Rule 4: Estimate Tensor Memory (TMEM) Usage
+        total_tmem_columns = block_n * num_tmem_buffers * num_mma_groups
+        if total_tmem_columns > TLXMatmulWSConfigMixin.MAX_TMEM_COLUMNS:
+            return False
+
+        return True
+
+    # Safety margin (bytes) added to the static SMEM estimate to account for
+    # epilogue fusion overhead (alignment padding, extra barriers, etc.) that
+    # can push the actual kernel SMEM past the hardware limit at launch time.
+    _SMEM_SAFETY_MARGIN = 8192
+
+    @classmethod
+    def _is_valid_config_with_margin(
+        cls,
+        block_m: int,
+        block_n: int,
+        block_k: int,
+        num_smem_buffers: int,
+        num_tmem_buffers: int,
+        num_mma_groups: int,
+        num_ctas: int,
+        epilogue_subtile: int,
+    ) -> bool:
+        """Like _is_valid_config but with a safety margin on SMEM."""
+        smem_a = block_m * block_k * 2 * num_smem_buffers
+        smem_b_size = block_n // num_ctas
+        smem_b = block_k * smem_b_size * 2 * num_smem_buffers
+        smem_epilog = block_m * (block_n // epilogue_subtile) * 2
+
+        smem_barriers = num_smem_buffers * num_mma_groups * cls.MBARRIER_SIZE
+        if num_ctas == 2:
+            smem_barriers += num_smem_buffers * num_mma_groups * cls.MBARRIER_SIZE
+
+        total_smem = smem_a + smem_b + smem_epilog + smem_barriers
+        return total_smem + cls._SMEM_SAFETY_MARGIN <= cls.MAX_SHARED_MEMORY
+
+    def adjust_kernel_inputs(
+        self,
+        kernel_inputs: KernelInputs,
+        op_name: str,
+    ) -> KernelInputs:
+        """
+        Adjust kernel inputs for TLX template.
+
+        TLX Blackwell GEMM template requires both A and B to be row-major
+        (stride[-1] == 1). If either is column-major, make it contiguous to
+        convert to row-major layout.
+
+        Note: Unlike triton_blackwell_ws_persistent_device_tma_mm.py.jinja which uses
+        A_ROW_MAJOR/B_ROW_MAJOR flags to handle column-major inputs via transposed TMA
+        descriptor + .T after load, the TLX template cannot easily support this approach
+        because:
+        1. tlx.async_dot operates directly on SMEM buffers with fixed shapes
+        2. Loading column-major data with transposed descriptor yields transposed layout
+           in SMEM
+        3. There's no simple transpose before async_dot (unlike tl.dot which accepts .T)
+
+        Making A/B contiguous here matches the standalone TLX kernel behavior
+        (a.contiguous(), b.contiguous() in tritonbench wrapper) and ensures correct
+        results with minimal template changes.
+        """
+        from torch._inductor.ir import ExternKernel
+
+        assert isinstance(kernel_inputs, MMKernelInputs), "Expect MMKernelInputs"
+
+        strides = kernel_inputs.strides_hinted()
+        nodes = list(kernel_inputs.nodes())
+        mat1_idx = kernel_inputs._mat1_idx
+        mat2_idx = kernel_inputs._mat2_idx
+        changed = False
+
+        # Check A's layout from strides
+        # Column-major A has stride pattern [1, M] where inner dim stride is not 1
+        a_strides = strides[mat1_idx]
+        is_a_col_major = a_strides[-2] == 1 and a_strides[-1] != 1
+        if is_a_col_major:
+            mat_a_contiguous = ExternKernel.require_contiguous(nodes[mat1_idx])
+            nodes[mat1_idx] = mat_a_contiguous
+            changed = True
+
+        # Check B's layout from strides
+        # Column-major B has stride pattern [1, N] where first stride is 1
+        b_strides = strides[mat2_idx]
+        is_b_col_major = b_strides[-2] == 1 and b_strides[-1] != 1
+        if is_b_col_major:
+            mat_b_contiguous = ExternKernel.require_contiguous(nodes[mat2_idx])
+            nodes[mat2_idx] = mat_b_contiguous
+            changed = True
+
+        if changed:
+            return MMKernelInputs(
+                nodes,
+                kernel_inputs.output_layout(),
+                mat1_idx=mat1_idx,
+                mat2_idx=mat2_idx,
+            )
+
+        return kernel_inputs
+
+    def _get_template_configs_impl(
+        self,
+        kernel_inputs: KernelInputs,
+        op_name: str,
+    ) -> Generator[dict[str, Any], None, None]:
+        """
+        Generate TLX template configs with TLX-specific parameters,
+        adjusting NUM_CTAS based on problem size.
+
+        Behavior by mode:
+        - "force": yields a single heuristic config (if available), no autotuning
+        - "allow": yields heuristic config + additional autotuning configs from
+          self.mm_configs, so TLX competes via autotuning with cublas/triton
+        """
+        import math
+
+        # Get M, N, K from kernel inputs for compatibility check
+        assert isinstance(kernel_inputs, MMKernelInputs), "Expect MMKernelInputs"
+        m, n, k = kernel_inputs.mnk_hinted()
+        num_sms = get_num_sms()
+        is_allow_mode = config.triton.tlx_mode == "allow"
+
+        # Try heuristic config selection first (matches tlx_matmul_ws behavior).
+        # Always validate without TMA epilogue store, matching upstream TLX.
+        # TMA store adds SMEM overhead that would reject SMEM-tight heuristic
+        # configs (e.g. 256x256x64 3-buffer); _yield_tma_variants filters
+        # TMA=1 variants that don't fit in SMEM.
+        heuristic_config = (
+            get_heuristic_config(m, n, k, num_sms, tma_epilogue_store=False)
+            if tlx_config.use_heuristic_config
+            else None
+        )
+        if heuristic_config is not None:
+            # Convert config keys to template kwargs
+            template_kwargs: dict[str, Any] = {
+                "BLOCK_M": heuristic_config["BLOCK_SIZE_M"],
+                "BLOCK_N": heuristic_config["BLOCK_SIZE_N"],
+                "BLOCK_K": heuristic_config["BLOCK_SIZE_K"],
+                "GROUP_SIZE_M": heuristic_config["GROUP_SIZE_M"],
+                "NUM_SMEM_BUFFERS": heuristic_config["NUM_SMEM_BUFFERS"],
+                "NUM_TMEM_BUFFERS": heuristic_config["NUM_TMEM_BUFFERS"],
+                "NUM_MMA_GROUPS": heuristic_config["NUM_MMA_GROUPS"],
+                "EPILOGUE_SUBTILE": heuristic_config["EPILOGUE_SUBTILE"],
+                "BLOCK_M_SPLIT": heuristic_config["BLOCK_SIZE_M"]
+                // heuristic_config["NUM_MMA_GROUPS"],
+                "slice_size": heuristic_config["BLOCK_SIZE_N"]
+                // heuristic_config["EPILOGUE_SUBTILE"],
+                "NUM_CTAS": heuristic_config["NUM_CTAS"],
+                "SPLIT_K": heuristic_config.get("SPLIT_K", 1),
+                "INTERLEAVE_EPILOGUE": heuristic_config.get("INTERLEAVE_EPILOGUE", 0),
+                "num_stages": 1,
+                "num_warps": 4,
+                "NUM_SMS": num_sms,
+            }
+
+            # Check NUM_CTAS=2 compatibility
+            BLOCK_M = template_kwargs["BLOCK_M"]
+            BLOCK_N = template_kwargs["BLOCK_N"]
+            NUM_CTAS = template_kwargs["NUM_CTAS"]
+
+            if NUM_CTAS == 2:
+                num_tiles_m = math.ceil(m / BLOCK_M)
+                num_tiles_n = math.ceil(n / BLOCK_N)
+                ctas_compatible = (
+                    num_tiles_m % 2 == 0 and (num_tiles_m * num_tiles_n) % 2 == 0
+                )
+                if not ctas_compatible:
+                    template_kwargs["NUM_CTAS"] = 1
+                    NUM_CTAS = 1
+
+            # In allow mode, validate SMEM with margin before yielding heuristic
+            # config — autotuning configs provide fallback if this is skipped.
+            # In force mode, always yield since it's the only config.
+            BLOCK_K = template_kwargs["BLOCK_K"]
+            skip_heuristic = is_allow_mode and not self._is_valid_config_with_margin(
+                BLOCK_M,
+                BLOCK_N,
+                BLOCK_K,
+                heuristic_config["NUM_SMEM_BUFFERS"],
+                heuristic_config["NUM_TMEM_BUFFERS"],
+                heuristic_config["NUM_MMA_GROUPS"],
+                NUM_CTAS,
+                heuristic_config["EPILOGUE_SUBTILE"],
+            )
+            heuristic_yielded = False
+            if skip_heuristic:
+                log.debug(
+                    "Heuristic config (%d,%d,%d) exceeds SMEM with margin, skipping",
+                    BLOCK_M,
+                    BLOCK_N,
+                    BLOCK_K,
+                )
+            else:
+                # Add ctas_per_cga for NUM_CTAS=2 mode
+                if NUM_CTAS == 2:
+                    template_kwargs["ctas_per_cga"] = (2, 1, 1)
+
+                SPLIT_K = template_kwargs.get("SPLIT_K", 1)
+                if SPLIT_K > 1:
+                    # Split-K writes fp32 partials to workspace via its own TMA path;
+                    # TMA_EPILOGUE_STORE controls the non-split-K output store path.
+                    template_kwargs["TMA_EPILOGUE_STORE"] = 0
+                    yield template_kwargs
+                    heuristic_yielded = True
+                else:
+                    for tma_kwargs in self._yield_tma_variants(template_kwargs):
+                        yield tma_kwargs
+                        heuristic_yielded = True
+
+            # In force mode, return after yielding the heuristic config.
+            # Fall through to autotuning if heuristic was skipped (e.g.
+            # config exceeds SMEM with TMA epilogue buffers).
+            if not is_allow_mode and heuristic_yielded:
+                return
+
+        # Yield autotuning configs from self.mm_configs via the base class pipeline
+        for template_kwargs in super()._get_template_configs_impl(
+            kernel_inputs,
+            op_name,
+        ):
+            # Add TLX-specific defaults, allowing override from config
+            template_kwargs = {
+                **template_kwargs,
+                "GROUP_SIZE_M": template_kwargs.get("GROUP_SIZE_M", 8),
+                "NUM_SMEM_BUFFERS": template_kwargs.get("NUM_SMEM_BUFFERS", 3),
+                "NUM_TMEM_BUFFERS": template_kwargs.get("NUM_TMEM_BUFFERS", 2),
+                "EPILOGUE_SUBTILE": template_kwargs.get("EPILOGUE_SUBTILE", 1),
+                "NUM_MMA_GROUPS": template_kwargs.get("NUM_MMA_GROUPS", 1),
+                "NUM_CTAS": template_kwargs.get("NUM_CTAS", 1),
+                "SPLIT_K": template_kwargs.get("SPLIT_K", 1),
+                "INTERLEAVE_EPILOGUE": template_kwargs.get("INTERLEAVE_EPILOGUE", 0),
+            }
+            template_kwargs["BLOCK_M_SPLIT"] = (
+                template_kwargs["BLOCK_M"] // template_kwargs["NUM_MMA_GROUPS"]
+            )
+            template_kwargs["slice_size"] = (
+                template_kwargs["BLOCK_N"] // template_kwargs["EPILOGUE_SUBTILE"]
+            )
+
+            BLOCK_M = template_kwargs["BLOCK_M"]
+            BLOCK_N = template_kwargs["BLOCK_N"]
+            BLOCK_K = template_kwargs["BLOCK_K"]
+            NUM_CTAS = template_kwargs["NUM_CTAS"]
+
+            # Skip configs where block sizes >= problem dimensions (causes accuracy issues)
+            if BLOCK_N >= n or BLOCK_K >= k:
+                continue
+
+            # Interleaved epilogue hardcodes two MMA groups (buf_idx_0/1).
+            if (
+                template_kwargs["INTERLEAVE_EPILOGUE"]
+                and template_kwargs["NUM_MMA_GROUPS"] != 2
+            ):
+                continue
+
+            # 2-CTA cluster configs cause illegal memory access during
+            # autotuning for tall-M shapes.  The heuristic path selects
+            # 2-CTA with shape guards; the autotuning pool uses 1-CTA.
+            if NUM_CTAS == 2:
+                template_kwargs = {**template_kwargs, "NUM_CTAS": 1}
+                NUM_CTAS = 1
+
+            # Re-validate SMEM with actual NUM_CTAS (may have changed above).
+            # Use a safety margin to account for epilogue fusion overhead that
+            # the static estimate doesn't capture (alignment, extra barriers).
+            NUM_SMEM_BUFFERS = template_kwargs["NUM_SMEM_BUFFERS"]
+            NUM_TMEM_BUFFERS = template_kwargs["NUM_TMEM_BUFFERS"]
+            NUM_MMA_GROUPS = template_kwargs["NUM_MMA_GROUPS"]
+            EPILOGUE_SUBTILE = template_kwargs["EPILOGUE_SUBTILE"]
+            if not self._is_valid_config_with_margin(
+                BLOCK_M,
+                BLOCK_N,
+                BLOCK_K,
+                NUM_SMEM_BUFFERS,
+                NUM_TMEM_BUFFERS,
+                NUM_MMA_GROUPS,
+                NUM_CTAS,
+                EPILOGUE_SUBTILE,
+            ):
+                continue
+
+            # Add ctas_per_cga for NUM_CTAS=2 mode
+            if NUM_CTAS == 2:
+                template_kwargs = {
+                    **template_kwargs,
+                    "ctas_per_cga": (2, 1, 1),
+                }
+
+            # Yield TMA epilogue store variant(s)
+            yield from self._yield_tma_variants(template_kwargs)
+
+    @staticmethod
+    def _yield_tma_variants(
+        template_kwargs: dict[str, Any],
+    ) -> Generator[dict[str, Any], None, None]:
+        """Yield TMA_EPILOGUE_STORE=1 (preferred) or TMA=0 fallback.
+
+        Upstream TLX always uses TMA descriptor stores for the epilogue.
+        tl.store is incompatible with NUM_CTAS=2 (MultiCTAReduction pass
+        can't distribute direct stores across CTAs), so 2-CTA configs
+        must use TMA and are skipped if they don't fit in SMEM.
+
+        For 1-CTA configs, fall back to TMA=0 (tl.store) when TMA=1
+        exceeds SMEM — this can happen when epilogue fusion adds SMEM
+        for fused tensors (e.g. bias) beyond what the base estimate covers."""
+        config_dict = {
+            "BLOCK_SIZE_M": template_kwargs["BLOCK_M"],
+            "BLOCK_SIZE_N": template_kwargs["BLOCK_N"],
+            "BLOCK_SIZE_K": template_kwargs["BLOCK_K"],
+            "NUM_SMEM_BUFFERS": template_kwargs["NUM_SMEM_BUFFERS"],
+            "NUM_TMEM_BUFFERS": template_kwargs["NUM_TMEM_BUFFERS"],
+            "NUM_MMA_GROUPS": template_kwargs["NUM_MMA_GROUPS"],
+            "EPILOGUE_SUBTILE": template_kwargs["EPILOGUE_SUBTILE"],
+            "NUM_CTAS": template_kwargs["NUM_CTAS"],
+            "SPLIT_K": template_kwargs.get("SPLIT_K", 1),
+        }
+        num_ctas = template_kwargs.get("NUM_CTAS", 1)
+        if num_ctas == 1:
+            # For 1-CTA, use a margin to account for epilogue fusion SMEM
+            # (e.g. bias buffer ~4-5KB) that the base formula doesn't capture.
+            # Without this, TMA=1 compiles OK during benchmarking (no fusion)
+            # but can fail after fusion adds SMEM in the final codegen.
+            _TMA_SMEM_MARGIN = 8192
+            if _is_config_valid(
+                config_dict, tma_epilogue_store=True, smem_margin=_TMA_SMEM_MARGIN
+            ):
+                yield {**template_kwargs, "TMA_EPILOGUE_STORE": 1}
+            else:
+                yield {**template_kwargs, "TMA_EPILOGUE_STORE": 0}
+        else:
+            # 2-CTA requires TMA (tl.store incompatible with MultiCTAReduction)
+            if _is_config_valid(config_dict, tma_epilogue_store=True):
+                yield {**template_kwargs, "TMA_EPILOGUE_STORE": 1}
+
+
+@register_template_heuristic(
+    amd_addmm_warppipe_template.uid, "cuda", register=IS_ROCM, op_name="addmm"
+)
+class ROCmAddMMWarpPipeTemplateConfigHeuristic(
+    AddMMConfigMixin, ROCmMMTemplateConfigHeuristic
+):
+    """TLX warp-pipelined addmm heuristic for ROCm (col-major B, MI350X/gfx950).
+
+    Hand-pipelined (num_stages=1): async-prefetches NUM_BUFFERS K-tiles into multi-buffered
+    LDS and overlaps the loads with the MFMA via tlx.warp_pipeline_stage. Configs are the
+    standalone MI350X winners. Correctness requires K_ITERS > NUM_BUFFERS, so a config is
+    emitted only when cdiv(K, BLOCK_K) > NUM_BUFFERS is statically known (also declines
+    dynamic/unknown K). The kernel needs col-major B; adjust_kernel_inputs enforces it
+    (the col-major prep that used to live in OSS tuned_addmm).
+    """
+
+    # (BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M, num_warps, NUM_BUFFERS)
+    WARPPIPE_CONFIGS = [
+        (64, 64, 128, 8, 8, 3),
+        (64, 64, 64, 8, 8, 3),
+        (128, 128, 64, 8, 8, 2),
+        (64, 128, 64, 8, 8, 2),
+    ]
+
+    def adjust_kernel_inputs(
+        self, kernel_inputs: KernelInputs, op_name: str
+    ) -> KernelInputs:
+        # The warp-pipe kernel async-loads B as (BLOCK_N, BLOCK_K) with K contiguous, so it
+        # requires col-major B (stride_bk == 1). REQUIRE it here (free for an nn.Linear weight)
+        # rather than gate on the current -- possibly unfrozen -- stride; this replaces the
+        # require_stride_order that used to live in OSS tuned_addmm.
+        from torch._inductor.ir import ExternKernel
+
+        kernel_inputs = super().adjust_kernel_inputs(kernel_inputs, op_name)
+        if not isinstance(kernel_inputs, MMKernelInputs):
+            return kernel_inputs
+        nodes = list(kernel_inputs.nodes())
+        mat2_idx = kernel_inputs._mat2_idx
+        nodes[mat2_idx] = ExternKernel.require_stride_order(nodes[mat2_idx], [0, 1])
+        return MMKernelInputs(
+            nodes,
+            scalars=kernel_inputs._scalars,
+            out_dtype=kernel_inputs.out_dtype(),
+            mat1_idx=kernel_inputs._mat1_idx,
+            mat2_idx=mat2_idx,
+        )
+
+    def _get_template_configs_impl(self, kernel_inputs, op_name):
+        import sympy
+        from torch._inductor.virtualized import V
+
+        if not isinstance(kernel_inputs, MMKernelInputs):
+            raise AssertionError(f"{self.__class__.__name__} requires MMKernelInputs")
+        # The warp-pipe win is on fp16/bf16 latency-bound addmm; skip other dtypes. dtype()
+        # defaults to input 0 = the bias for addmm, so check mat1 (the matrix operand) instead
+        # so an fp32 bias doesn't wrongly decline a bf16/fp16 addmm.
+        if kernel_inputs.dtype(kernel_inputs._mat1_idx) not in (
+            torch.float16,
+            torch.bfloat16,
+        ):
+            return
+        m, n, k = kernel_inputs.mnk_symbolic()
+        out_dtype = kernel_inputs.out_dtype()
+        sizevars = V.graph.sizevars
+        # async_load lowers to a 32-bit block pointer, so this template is only valid when M*K
+        # and N*K fit int32. Use optimization_hint (not statically_known) so dynamic/symbolic M
+        # is allowed via the example-input hint -- the int32 buffer-index cast keeps it correct
+        # under AOTI dynamic shapes.
+        int32_max = 2**31 - 1
+        if not (
+            sizevars.optimization_hint(m * k, fallback=int32_max) < int32_max
+            and sizevars.optimization_hint(n * k, fallback=int32_max) < int32_max
+        ):
+            return
+        num_xcds = _amd_num_xcds()
+        for (
+            block_m,
+            block_n,
+            block_k,
+            group_m,
+            num_warps,
+            num_buffers,
+        ) in self.WARPPIPE_CONFIGS:
+            # MFMA requires block_m/block_n be multiples of matrix_instr_nonkdim (16).
+            if block_m % 16 != 0 or block_n % 16 != 0:
+                continue
+            # warp-pipeline correctness guard: K_ITERS > NUM_BUFFERS.
+            if not sizevars.statically_known_true(sympy.Gt(k, num_buffers * block_k)):
+                continue
+            triton_config = self.triton_config(
+                1,  # num_stages=1: TLX is hand-pipelined; auto software-pipelining must be off
+                num_warps,
+                BLOCK_M=block_m,
+                BLOCK_N=block_n,
+                BLOCK_K=block_k,
+                GROUP_M=group_m,
+                NUM_BUFFERS=num_buffers,
+                NUM_XCDS=num_xcds,
+                matrix_instr_nonkdim=16,
+                waves_per_eu=0,
+                kpack=get_default_kpack(block_k),
+            )
+            yield self._convert_config_to_template_kwargs(
+                triton_config, m, n, k, out_dtype
+            )
+
+
+@register_template_heuristic(
+    blackwell_gemm_ws_template.uid,
+    "cuda",
+    register=torch.version.hip is None,
+)
+class TemplateGemmWSConfigHeuristic(TLXMatmulWSConfigMixin, CUDAConfigHeuristic):
+    """
+    Blackwell TLX Warp-Specialized GEMM template from tritonbench.
+
+    Uses MMA groups and persistent kernel for optimized performance on Blackwell GPUs.
+    """
+
+    def should_run(self, inputs: KernelInputs) -> bool:
+        """
+        Override to allow TLX templates to run without max_autotune when tlx_mode is set.
+        """
+        if config.triton.tlx_mode in ("allow", "force"):
+            return True
+        return super().should_run(inputs)
+
+    def _get_extra_config_key_and_kwargs(
+        self, conf: GemmConfig
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        return get_tlx_config_key_and_kwargs(conf)
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Autotuning configs for "allow" mode: these compete alongside the heuristic
+        # config against cublas/triton. Selected via benchmarking on representative
+        # workloads — only configs that beat cublas for at least one shape are included.
+        # Tuple format: (BM, BN, BK, smem_num, tmem_num, num_mma_groups, epilogue_subtile, num_ctas)
+        # Upstream TLX candidate table — used as the autotuning pool.
+        # Format: (BM, BN, BK, smem_num, tmem_num, mma_groups, subtile, num_ctas)
+        _AUTOTUNE_CONFIGS = [
+            (256, 128, 128, 2, 2, 2, 1, 2),
+            (256, 256, 64, 3, 1, 2, 4, 1),
+            (128, 64, 128, 4, 3, 2, 1, 1),
+            (256, 128, 64, 5, 2, 2, 4, 2),
+            (128, 256, 64, 4, 2, 1, 2, 2),
+            (256, 64, 128, 5, 2, 2, 4, 2),
+            (128, 64, 128, 5, 2, 2, 1, 2),
+            (256, 64, 128, 5, 2, 2, 8, 1),
+            (128, 256, 64, 3, 2, 1, 2, 1),
+            (128, 128, 64, 4, 2, 1, 2, 1),
+            (256, 128, 64, 3, 1, 2, 2, 1),
+            (128, 64, 64, 5, 2, 1, 1, 1),
+            (64, 128, 64, 5, 2, 1, 1, 1),
+            (64, 64, 64, 6, 2, 1, 1, 1),
+        ]
+        self.mm_configs = [
+            TlxGemmConfig(
+                BM,
+                BN,
+                BK,
+                1,  # num_stages
+                4,  # num_warps
+                group_size_m=8,
+                smem_num=s,
+                tmem_num=t,
+                num_mma_groups=m,
+                epilogue_subtile=subtile,
+                num_ctas=num_ctas,
+                split_k=1,
+            )
+            for BM, BN, BK, s, t, m, subtile, num_ctas in _AUTOTUNE_CONFIGS
+            # Prune invalid configs based on hardware constraints
+            if TLXMatmulWSConfigMixin._is_valid_config(
+                block_m=BM,
+                block_n=BN,
+                block_k=BK,
+                num_smem_buffers=s,
+                num_tmem_buffers=t,
+                num_mma_groups=m,
+                num_ctas=num_ctas,
+                epilogue_subtile=subtile,
+            )
+        ]
+
+
+# export tuple of CUDA options in TLX
+tlx_only_cuda_options = ["ctas_per_cga"]
+
+
+def get_tlx_config_key_and_kwargs(
+    conf: GemmConfig,
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """
+    Extract TLX-specific key fields and kwargs from a TlxGemmConfig.
+
+    Returns:
+        A tuple of (key_fields, kwargs) where:
+        - key_fields: tuple of TLX-specific fields to add to deduplication key
+        - kwargs: dict of TLX-specific kwargs to add to TritonConfig
+
+    If the config is not a TlxGemmConfig, returns empty tuple and empty dict.
+    """
+    if not isinstance(conf, TlxGemmConfig):
+        return (), {}
+
+    key_fields = (
+        conf.group_size_m,
+        conf.smem_num,
+        conf.tmem_num,
+        conf.epilogue_subtile,
+        conf.num_mma_groups,
+        conf.num_ctas,
+        conf.split_k,
+        conf.interleave_epilogue,
+    )
+    kwargs = {
+        "GROUP_SIZE_M": conf.group_size_m,
+        "NUM_SMEM_BUFFERS": conf.smem_num,
+        "NUM_TMEM_BUFFERS": conf.tmem_num,
+        "EPILOGUE_SUBTILE": conf.epilogue_subtile,
+        "NUM_MMA_GROUPS": conf.num_mma_groups,
+        "NUM_CTAS": conf.num_ctas,
+        "SPLIT_K": conf.split_k,
+        "INTERLEAVE_EPILOGUE": conf.interleave_epilogue,
+    }
+    return key_fields, kwargs
+
+
+# Use a factory to defer the import of TLXInductorChoices, avoiding
+# circular import: template_heuristics/__init__ -> tlx -> choices ->
+# InductorChoices -> template_heuristics/__init__
+def _tlx_choices_factory():
+    from .choices import TLXInductorChoices
+
+    return TLXInductorChoices()
+
+
+config.inductor_choices_class = _tlx_choices_factory
+
+# ---------------------------------------------------------------------------
+# Override TritonTemplateKernel to support async TMA store (TLX-specific).
+#
+# async_tma_store is not exposed in OSS.  The TMA_EPILOGUE_STORE template
+# kwarg (set by _get_template_configs_impl above) flows through the meta
+# dict.  The overrides below extract it in __init__, set the store mode in
+# store_output, and dispatch to the TLX codegen in store.
+# ---------------------------------------------------------------------------
+from torch._inductor.codegen.triton import (
+    BlockPtrOptions,
+    DeferredLine,
+    TensorDescriptorOptions,
+)
+from .codegen import codegen_async_tma_store
+from torch._inductor.select_algorithm import TritonTemplate, TritonTemplateKernel
+from torch._inductor.virtualized import V
+
+# -- generate: inject split-K workspace_arg via the standard mechanism ------
+# The workspace_arg must flow through generate() so the autotuning benchmark
+# allocates the workspace tensor.  Creating it in __init__ is too late —
+# generate() has already captured workspace_arg=None for the benchmark request.
+_orig_tt_generate = TritonTemplate.generate
+
+
+def _tlx_tt_generate(self, input_nodes, layout, *args, **kwargs):  # type: ignore[no-untyped-def]
+    split_k = int(kwargs.get("SPLIT_K", 1))
+    if split_k > 1:
+        from torch._inductor.codegen.common import WorkspaceArg, WorkspaceZeroMode
+
+        # SPLIT_K > 1 forces TMA_EPILOGUE_STORE=0, so the TMA descriptor
+        # workspace (ws_ptr) from TMAWorkspaceMixin is unused.  Replace it
+        # with the split-K fp32 partial-results workspace.
+        kwargs["workspace_arg"] = WorkspaceArg(
+            count=split_k * layout.size[0] * layout.size[1],
+            zero_mode=WorkspaceZeroMode.ZERO_ON_CALL,
+            device=layout.device,
+            outer_name=WorkspaceArg.unique_name("split_k_ws_"),
+            inner_name="split_k_ws",
+            dtype=torch.float32,
+        )
+    return _orig_tt_generate(self, input_nodes, layout, *args, **kwargs)
+
+
+TritonTemplate.generate = _tlx_tt_generate  # type: ignore[method-assign]
+
+# -- __init__: extract TMA_EPILOGUE_STORE from meta, set tma_store=True -----
+_orig_ttk_init = TritonTemplateKernel.__init__
+
+
+def _tlx_ttk_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+    meta = kwargs.get("meta", {})
+    async_tma_store = bool(meta.get("TMA_EPILOGUE_STORE", 0))
+    split_k = int(meta.get("SPLIT_K", 1))
+    if async_tma_store:
+        kwargs["tma_store"] = True
+
+    _orig_ttk_init(self, *args, **kwargs)
+    self.async_tma_store = async_tma_store
+    self._tlx_split_k = split_k
+
+
+TritonTemplateKernel.__init__ = _tlx_ttk_init  # type: ignore[method-assign]
+
+# -- store_output: accept async_tma_store_buf_idx, set mode="async_tma" -----
+_orig_store_output = TritonTemplateKernel.store_output
+
+
+def _tlx_store_output(  # type: ignore[no-untyped-def]
+    self, *args, async_tma_store_buf_idx=None, **kwargs
+):
+    if getattr(self, "async_tma_store", False):
+        if async_tma_store_buf_idx is not None:
+            V.kernel.async_tma_store_buf_idx = async_tma_store_buf_idx
+        # Signal the store override to use async TMA mode instead of
+        # the regular TMA mode that OSS store_output will select.
+        self._tlx_async_tma_store_active = True
+    try:
+        return _orig_store_output(self, *args, **kwargs)
+    finally:
+        self._tlx_async_tma_store_active = False
+
+
+# Jinja template_env uses fn.__name__ to build the dict key — preserve it.
+_tlx_store_output.__name__ = "store_output"
+TritonTemplateKernel.store_output = _tlx_store_output  # type: ignore[method-assign]
+
+# -- store: intercept TMA mode when async TMA is active --------------------
+_orig_tk_store = TritonTemplateKernel.store
+
+
+def _tlx_store(self, name, index, value, mode=None):  # type: ignore[no-untyped-def]
+    if mode == "tma" and getattr(self, "_tlx_async_tma_store_active", False):
+        # Redirect from regular TMA store to async TMA store.
+        var = self.args.output(name)
+        original_index = index
+        dtype = V.graph.get_dtype(name)
+
+        tma_compatibility_checker = self.tma_compatibility_checker_cls(
+            self,
+            dtype,
+            for_store=True,
+            force=True,
+        )
+        indexing = self.indexing(
+            index,
+            dense_indexing=True,
+            block_ptr=False,
+            tma_compatibility_checker=tma_compatibility_checker,
+        )
+
+        if hasattr(indexing, "index") and self._has_stride1_on_rdim(indexing.index):
+            self.stores_with_contiguous_rdim.append(name)
+
+        is_inplace = name in self.args.inplace_buffers
+        is_broadcasted = self.is_broadcasted(original_index)
+        if is_inplace and is_broadcasted:
+            self.stores.writeline(DeferredLine(name, "tl.debug_barrier()"))
+
+        if not isinstance(indexing, (BlockPtrOptions, TensorDescriptorOptions)):
+            # Output indexing isn't TMA-compatible — fall back to regular store.
+            return _orig_tk_store(self, name, index, value, mode=mode)
+        block_descriptor, _other = self.codegen_block_ptr(name, var, indexing)
+        codegen_async_tma_store(self, name, indexing, block_descriptor, value)
+        return
+    return _orig_tk_store(self, name, index, value, mode=mode)
+
+
+TritonTemplateKernel.store = _tlx_store  # type: ignore[method-assign]
+
+# ---------------------------------------------------------------------------
+# compute_epilogue: run fused epilogue ops without emitting a store.
+#
+# When TMA_EPILOGUE_STORE is active, the template needs to:
+#   1. Run the fused epilogue (relu, bias add, etc.) to get the final value
+#   2. Manually TMA-store that value via tlx.async_descriptor_store
+#
+# The standard store_output can't do this because V.ops.store targets the
+# template's intermediate buffer (which is removed when fused), while the
+# epilogue nodes emit tl.store to the final buffer — bypassing TMA entirely.
+#
+# compute_epilogue solves this by:
+#   - Using the same index setup as store_output (tma_store=True path)
+#   - Running epilogue node codegen but redirecting stores to variable
+#     assignment ({result_name} = {value}) instead of tl.store
+#   - Returning the hook placeholder so the template can emit TMA store code
+#
+# output_ptr: resolves the correct output buffer for TMA descriptor creation.
+# When epilogue fusion is active, the TMA descriptor must point to the FINAL
+# output buffer (e.g., relu output), not the template's intermediate output
+# (e.g., raw mm result).
+# ---------------------------------------------------------------------------
+
+import itertools
+
+from torch.utils._ordered_set import OrderedSet
+
+
+def _tlx_output_ptr(self):  # type: ignore[no-untyped-def]
+    """Get the output pointer for TMA descriptor creation.
+
+    When epilogue fusion is active, returns the final output buffer pointer
+    (set by codegen_template_body via _final_output_name) so TMA descriptors
+    write directly to the fused output.
+    """
+    name = getattr(self, "_final_output_name", self.output_node.get_name())
+    return self.args.output(name)
+
+
+_tlx_output_ptr.__name__ = "output_ptr"
+TritonTemplateKernel.output_ptr = _tlx_output_ptr  # type: ignore[method-assign]
+
+
+def _tlx_get_compute_epilogue_subgraph_name(self, i):  # type: ignore[no-untyped-def]
+    return f"<COMPUTE_EPILOGUE_{i}>"
+
+
+TritonTemplateKernel._get_compute_epilogue_subgraph_name = (  # type: ignore[method-assign]
+    _tlx_get_compute_epilogue_subgraph_name
+)
+
+
+def _tlx_get_compute_epilogue_count(self):  # type: ignore[no-untyped-def]
+    total = next(self._compute_epilogue_ctr)
+    self._compute_epilogue_ctr = itertools.count(start=total - 1, step=1)
+    return total
+
+
+TritonTemplateKernel._tlx_get_compute_epilogue_count = (  # type: ignore[method-assign]
+    _tlx_get_compute_epilogue_count
+)
+
+# Patch __init__ to add compute_epilogue counter
+_orig_ttk_init_for_ctr = TritonTemplateKernel.__init__
+
+
+def _tlx_ttk_init_with_ctr(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+    _orig_ttk_init_for_ctr(self, *args, **kwargs)
+    self._compute_epilogue_ctr = itertools.count()
+
+
+TritonTemplateKernel.__init__ = _tlx_ttk_init_with_ctr  # type: ignore[method-assign]
+
+
+def _tlx_compute_epilogue(  # type: ignore[no-untyped-def]
+    self,
+    indices,
+    val,
+    result_name="fused_result",
+    indent_width=4,
+    val_shape=None,
+):
+    """Apply epilogue fusion ops and assign result to result_name, without emitting a store.
+
+    Used by templates that handle the store themselves (e.g., TMA async store).
+    Same index setup as store_output with block_indexing=True, tma_store=True.
+    """
+    import sympy
+    from torch._inductor.codegen.common import OpOverrides
+    from torch._inductor.utils import sympy_dot, triton_type_to_torch
+
+    subgraph_name = self._get_compute_epilogue_subgraph_name(
+        next(self._compute_epilogue_ctr)
+    )
+    with self.create_subgraph_body(subgraph_name, clear_cse=True):
+        assert isinstance(indices, (list, tuple))
+        assert isinstance(val, str)
+        assert val_shape and len(val_shape) == 2, (
+            "compute_epilogue requires a 2D val_shape"
+        )
+        assert self.template_mask is None
+
+        indices = list(map(OpOverrides.paren, indices))
+        index_symbols = [sympy.Symbol(x, integer=True) for x in indices]
+        lengths = [V.graph.sizevars.simplify(s) for s in self.output_node.get_size()]
+        assert len(indices) == len(lengths)
+
+        output_layout = self.output_node.get_layout()
+        self.template_out = val
+
+        # Use the tma_store index setup path (same as store_output with
+        # block_indexing=True and self.tma_store=True).
+        intermediate_lines: list[str] = []
+        epilogue_index_symbols: list[sympy.Symbol] = []
+        val_shape_copy = list(val_shape)
+        for i, range_tree in enumerate(self.range_trees[:-1]):
+            name = range_tree.name
+            symbol = range_tree.symbol()
+            epilogue_index_symbols.append(symbol)
+            lookup_output = range_tree.lookup(sympy.S.One, lengths[i])
+            old_name = lookup_output.symbol()
+            lookup_output.set_name(name)
+            range_tree.var_list[range_tree.var_list.index(old_name)] = symbol
+            range_val = range_tree.var_ranges[old_name]
+            del range_tree.var_ranges[old_name]
+            range_tree.var_ranges[symbol] = range_val
+            intermediate_lines.extend(
+                self._generate_index_from_tma_index(
+                    name,
+                    "xoffset" if name == "xindex" else "yoffset",
+                    index_symbols[i],
+                    val_shape[i],
+                    i,
+                    len(val_shape),
+                    block_name=range_tree.symt.name,
+                )
+            )
+            intermediate_lines.append(
+                self._generated_mask_for_tma(
+                    name,
+                    self.size(None, i),
+                    "xmask" if name == "xindex" else "ymask",
+                )
+            )
+            val_shape_copy[i] = range_tree.symt.name
+        val_shape = tuple(val_shape_copy)
+
+        index_symbols = epilogue_index_symbols
+        contiguous_index = sympy_dot(output_layout.stride, index_symbols)
+
+        for line in intermediate_lines:
+            self.body.writeline(line)
+
+        self.template_out_shape = val_shape
+        acc_dtype = (
+            triton_type_to_torch(self.meta["ACC_TYPE"])
+            if "ACC_TYPE" in self.meta
+            else torch.float32
+        )
+        epilogue_args = [V.kernel.cse.namedvar(val, dtype=acc_dtype, shape=val_shape)]
+        for input_node in itertools.chain(
+            self.input_nodes[: self.prefix_args],
+            self.input_nodes[len(self.input_nodes) - self.suffix_args :],
+        ):
+            input_node.freeze_layout()
+            epilogue_arg = V.kernel.cse.generate(
+                self.compute,
+                input_node.make_loader()(index_symbols),
+                dtype=acc_dtype,
+                shape=input_node.get_size(),
+            )
+            epilogue_args.append(epilogue_arg)
+            self.frozen_layouts_cnt += 1
+
+        # Instead of V.ops.store, we store to the template output's CSE cache
+        # (for store-to-load forwarding) and emit a variable assignment for
+        # the final result.  Epilogue nodes codegen'd later into this subgraph
+        # will pick up the accumulator from store_cache and apply their ops.
+        # Their stores are redirected to assignments by _TLXComputeOnlyHandler.
+        fused = self.epilogue_fn(*epilogue_args)
+        V.kernel.cse.store_cache[self.output_node.get_name()] = fused
+        self.body.writeline(f"{result_name} = {fused}")
+
+        # Mark that the template output buffer was "stored" for CSE purposes
+        self.store_buffer_names.add(self.output_node.get_name())
+
+        # Save result_name so epilogue node stores can be redirected
+        self._tlx_compute_epilogue_result_name = result_name
+        self.codegen_body()
+
+    return self._register_hook(
+        subgraph_name, self._make_codegen_hook(subgraph_name, indent_width)
+    )
+
+
+_tlx_compute_epilogue.__name__ = "compute_epilogue"
+TritonTemplateKernel.compute_epilogue = _tlx_compute_epilogue  # type: ignore[method-assign]
+
+# -- codegen_template_body: wrap to set _final_output_name and handle
+#    COMPUTE_EPILOGUE subgraphs --
+_orig_codegen_template_body = TritonTemplateKernel.codegen_template_body
+
+
+def _tlx_codegen_template_body(  # type: ignore[no-untyped-def]
+    self,
+    scheduling,
+    template_node,
+    epilogue_nodes,
+    prologue_nodes,
+    buf_name_to_prologue_group,
+    prologue_preserves_zero_mask_fn,
+    render,
+):
+    # Set _final_output_name so output_ptr() resolves to the fused output.
+    if epilogue_nodes:
+        last_names = epilogue_nodes[-1].get_buffer_names()
+        if len(last_names) == 1:
+            self._final_output_name = next(iter(last_names))
+
+    # Wrap the original render to also handle COMPUTE_EPILOGUE subgraphs.
+    orig_render = render
+
+    def _render_with_compute_epilogue():
+        result = orig_render()
+
+        # After render, codegen epilogue nodes into COMPUTE_EPILOGUE subgraphs,
+        # redirecting their stores to variable assignments.
+        num_ce = self._tlx_get_compute_epilogue_count()
+        for i in range(num_ce):
+            subgraph_name = self._get_compute_epilogue_subgraph_name(i)
+            result_name = getattr(
+                self, "_tlx_compute_epilogue_result_name", "fused_result"
+            )
+            with self.set_subgraph_body(subgraph_name):
+                # Redirect epilogue stores to variable assignments
+                orig_store = self.store
+
+                def _redirect_store(name, index, value, mode=None):  # type: ignore[no-untyped-def]
+                    self.store_buffer_names.add(name)
+                    self.cse.store_cache[name] = value
+                    if name not in V.graph.removed_buffers:
+                        self.compute.writeline(f"{result_name} = {value}")
+
+                self.store = _redirect_store  # type: ignore[method-assign]
+                try:
+                    for node in epilogue_nodes:
+                        node.codegen(self.split_and_set_ranges(node.get_ranges()))
+                finally:
+                    self.store = orig_store  # type: ignore[method-assign]
+                self.cse.invalidate(OrderedSet())
+
+        return result
+
+    return _orig_codegen_template_body(
+        self,
+        scheduling,
+        template_node,
+        epilogue_nodes,
+        prologue_nodes,
+        buf_name_to_prologue_group,
+        prologue_preserves_zero_mask_fn,
+        _render_with_compute_epilogue,
+    )
+
+
+TritonTemplateKernel.codegen_template_body = _tlx_codegen_template_body  # type: ignore[method-assign]
+
+# -- render: add compute_epilogue and output_ptr to template env --
+_orig_render = TritonTemplateKernel.render
+
+
+def _tlx_render(self, template, kwargs, record_input_dependent_tracked_event=False):  # type: ignore[no-untyped-def]
+    # Register compute_epilogue and output_ptr as extra template env functions
+    # so they're available in the jinja template.
+    if getattr(self, "async_tma_store", False):
+        self._register_extra_template_env_fns(self.compute_epilogue, self.output_ptr)
+    return _orig_render(self, template, kwargs, record_input_dependent_tracked_event)
+
+
+TritonTemplateKernel.render = _tlx_render  # type: ignore[method-assign]
+
+# -- _emit_post_kernel_code: emit split-K reduction kernel after main GEMM --
+_orig_emit_post_kernel = TritonTemplateKernel._emit_post_kernel_code
+
+
+def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-untyped-def]
+    split_k = getattr(self, "_tlx_split_k", 1)
+    if split_k > 1 and self.workspace_arg is not None:
+        from torch._inductor.codegen.triton import triton_type
+        from .reduce_k import emit_reduce_k_call
+
+        # Determine output buffer name and dtype
+        out_name = self.output_node.get_name()
+        out_dtype = self.output_node.get_layout().dtype
+        output_triton_dtype = triton_type(out_dtype)
+
+        # M and N from call_sizes
+        from torch._inductor.codegen.wrapper import pexpr
+
+        M_expr = pexpr(self.call_sizes[0])
+        N_expr = pexpr(self.call_sizes[1])
+
+        emit_reduce_k_call(
+            wrapper,
+            ws_name=self.workspace_arg.outer_name,
+            output_name=out_name,
+            M_expr=M_expr,
+            N_expr=N_expr,
+            split_k=split_k,
+            output_triton_dtype=output_triton_dtype,
+        )
+    _orig_emit_post_kernel(self, wrapper, kernel_name)
+
+
+TritonTemplateKernel._emit_post_kernel_code = _tlx_emit_post_kernel_code  # type: ignore[method-assign]
+
+
+# -- _compute_fusion_metadata: disable epilogue fusion for SPLIT_K > 1 ------
+#
+# Split-K bypasses store_output (writes partials to workspace via tl.store),
+# so scheduler-level epilogue fusion can't work — the fused ops would be
+# silently dropped.  Instead, mark all epilogue nodes as "unfused" so the
+# scheduler codegen's them as separate kernels after reduce_k.
+_orig_compute_fusion_metadata = TritonTemplateKernel._compute_fusion_metadata
+
+
+def _tlx_compute_fusion_metadata(  # type: ignore[no-untyped-def]
+    self, scheduling, epilogue_nodes, prologue_nodes, buf_name_to_prologue_group
+):
+    split_k = getattr(self, "_tlx_split_k", 1)
+    if split_k > 1 and epilogue_nodes:
+        from collections import defaultdict
+
+        self._epilogue_nodes_by_subgraph = defaultdict(list)
+        self._unfused_epilogues = list(epilogue_nodes)
+        self._prologue_sources = {}
+        self._scheduling_ref = scheduling
+    else:
+        _orig_compute_fusion_metadata(
+            self,
+            scheduling,
+            epilogue_nodes,
+            prologue_nodes,
+            buf_name_to_prologue_group,
+        )
+
+
+TritonTemplateKernel._compute_fusion_metadata = _tlx_compute_fusion_metadata  # type: ignore[method-assign]
+
+# -- get_unfused_epilogues: return split-K unfused epilogues -----------------
+_orig_get_unfused_epilogues = TritonTemplateKernel.get_unfused_epilogues
+
+
+def _tlx_get_unfused_epilogues(self):  # type: ignore[no-untyped-def]
+    unfused = getattr(self, "_unfused_epilogues", None)
+    if unfused:
+        return unfused
+    return _orig_get_unfused_epilogues(self)
+
+
+TritonTemplateKernel.get_unfused_epilogues = _tlx_get_unfused_epilogues  # type: ignore[method-assign]
+
+# -- call_kernel: codegen unfused epilogues after split-K reduce_k -----------
+_orig_call_kernel = TritonTemplateKernel.call_kernel
+
+
+def _tlx_call_kernel(self, name, node=None, deallocate_ws=True):  # type: ignore[no-untyped-def]
+    _orig_call_kernel(self, name, node=node, deallocate_ws=deallocate_ws)
+    # Codegen unfused epilogues after reduce_k (emitted in _emit_post_kernel_code)
+    unfused = getattr(self, "_unfused_epilogues", [])
+    scheduling = getattr(self, "_scheduling_ref", None)
+    if unfused and scheduling is not None:
+        for epi_node in unfused:
+            scheduling.codegen_node(epi_node)
+
+
+TritonTemplateKernel.call_kernel = _tlx_call_kernel  # type: ignore[method-assign]

--- a/third_party/tlx/language/tlx/inductor/tlx_config.py
+++ b/third_party/tlx/language/tlx/inductor/tlx_config.py
@@ -1,0 +1,54 @@
+"""TLX configuration sub-knobs.
+
+The primary enable/mode knob (``tlx_mode`` / ``TORCHINDUCTOR_TLX_MODE``) is an
+OSS-visible Inductor config option (``torch._inductor.config.triton.tlx_mode``).
+The knobs below stay here in the FB Triton fork alongside the TLX templates.
+"""
+
+import os
+from contextlib import contextmanager
+from typing import Generator
+
+
+# Use shape-based heuristic rules to pick a single GEMM config.
+# When False, falls back to iterating base configs from mm_configs.
+use_heuristic_config: bool = (
+    os.environ.get("TORCHINDUCTOR_TLX_USE_HEURISTIC_CONFIG", "1") == "1"
+)
+
+# Use TMA (asynchronous descriptor) stores for the GEMM epilogue.
+# Matches upstream TLX behavior; the tl.store path is incompatible with
+# NUM_CTAS=2 (MultiCTAReduction pass can't distribute direct stores across CTAs).
+tma_epilogue_store: bool = (
+    os.environ.get("TORCHINDUCTOR_TLX_TMA_EPILOGUE_STORE", "1") == "1"
+)
+
+# When True, yield both TMA_EPILOGUE_STORE=0 and TMA_EPILOGUE_STORE=1 variants
+# so autotuning can pick the faster path. When False, always prefer TMA=1 if it
+# fits in SMEM and fall back to TMA=0 otherwise (single variant, no autotuning).
+autotune_tma_epilogue_store: bool = (
+    os.environ.get("TORCHINDUCTOR_TLX_AUTOTUNE_TMA_EPILOGUE_STORE", "0") == "1"
+)
+
+# In "allow" mode, minimum speedup TLX must achieve over the best extern
+# kernel (cublas) to be selected. Below this threshold, the extern kernel wins.
+allow_min_speedup: float = float(
+    os.environ.get("TORCHINDUCTOR_TLX_ALLOW_MIN_SPEEDUP", "1.0")
+)
+
+
+@contextmanager
+def patch(**kwargs: object) -> Generator[None, None, None]:
+    """Context manager to temporarily override TLX config values."""
+    import sys
+
+    _self = sys.modules[__name__]
+
+    saved = {k: getattr(_self, k) for k in kwargs}
+    try:
+        for k, v in kwargs.items():
+            setattr(_self, k, v)
+        yield
+    finally:
+        for k, v in saved.items():
+            setattr(_self, k, v)

--- a/third_party/tlx/language/tlx/inductor/tlx_flex_attention.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/tlx_flex_attention.py.jinja
@@ -1,0 +1,487 @@
+{{def_kernel("Q", "K", "V", "LSE", "MAX", "KV_NUM_BLKS", "KV_IDX", "FULL_KV_NUM_BLKS", "FULL_KV_IDX")}}
+    # TLX 4-Task Warp-Specialized Flex Attention Forward Kernel (Blackwell)
+    #
+    # Architecture (modeled after _attn_fwd_ws from tlx_attention_ws_pipelined.py):
+    #   Task 1 "default" : Correction (alpha scaling) + Epilogue (normalize, store)
+    #   Task 2 (replicated): Softmax + score_mod/mask_mod via modification() macros
+    #   Task 3            : MMA via tlx.async_dot (Q@K^T, P@V)
+    #   Task 4            : TMA Load (Q, K, V)
+    #
+    # Memory hierarchy:
+    #   SMEM: Q tiles (split), K tiles, V tiles (double buffered)
+    #   TMEM: QK scores, P values, accumulator, alpha/l/m corrections
+
+    tl.static_assert(SPARSE_Q_BLOCK_SIZE >= BLOCK_M and SPARSE_Q_BLOCK_SIZE % BLOCK_M == 0)
+    tl.static_assert(SPARSE_KV_BLOCK_SIZE >= BLOCK_N and SPARSE_KV_BLOCK_SIZE % BLOCK_N == 0)
+
+    stride_qz, stride_qh, stride_qm, stride_qk = {{stride("Q")}}
+    stride_kz, stride_kh, stride_kn, stride_kk = {{stride("K")}}
+    stride_vz, stride_vh, stride_vn, stride_vk = {{stride("V")}}
+
+    ZQ = {{size("Q", 0)}}
+    HQ = {{size("Q", 1)}}
+    Q_LEN = {{size("Q", 2)}}
+    ZKV = {{size("K", 0)}}
+    KV_LEN = {{size("K", 2)}}
+
+    MATMUL_PRECISION = Q.dtype.element_ty
+
+    q_start = tl.program_id(0).to(INDEX_DTYPE)
+    off_zq = tl.program_id(1).to(INDEX_DTYPE)
+    off_hq = tl.program_id(2).to(INDEX_DTYPE)
+
+    off_zkv = off_zq % ZKV
+    off_hkv = off_hq // GQA_SHARED_HEADS
+    off_g = off_hq % GQA_SHARED_HEADS
+
+    q_offset = off_zq * stride_qz + off_hq * stride_qh
+    k_offset = off_zkv * stride_kz + off_hkv * stride_kh
+    v_offset = off_zkv * stride_vz + off_hkv * stride_vh
+
+    Q = Q + q_offset
+    K = K + k_offset
+    V = V + v_offset
+
+    # TMA descriptors
+    desc_q = tl.make_tensor_descriptor(
+        base=Q, shape=[Q_LEN, QK_HEAD_DIM], strides=[stride_qm, 1],
+        block_shape=[BLOCK_M // 2, QK_HEAD_DIM_ROUNDED],
+    )
+    desc_k = tl.make_tensor_descriptor(
+        base=K, shape=[KV_LEN, QK_HEAD_DIM], strides=[stride_kn, 1],
+        block_shape=[BLOCK_N, QK_HEAD_DIM_ROUNDED],
+    )
+    desc_v = tl.make_tensor_descriptor(
+        base=V, shape=[KV_LEN, V_HEAD_DIM], strides=[stride_vn, 1],
+        block_shape=[BLOCK_N, V_HEAD_DIM_ROUNDED],
+    )
+
+    # Sparse block setup
+    SPARSE_Z = {{size("KV_NUM_BLKS", 0)}}
+    SPARSE_HQ = {{size("KV_NUM_BLKS", 1)}}
+    sparse_idx_z = off_zq % SPARSE_Z
+    sparse_idx_hq = off_hq % SPARSE_HQ
+    SPARSE_Q_MULTIPLE: tl.constexpr = (SPARSE_Q_BLOCK_SIZE // BLOCK_M)
+    SPARSE_KV_MULTIPLE: tl.constexpr = (SPARSE_KV_BLOCK_SIZE // BLOCK_N)
+    stride_kv_num_blks_h = {{stride("KV_NUM_BLKS", 1)}}
+    stride_kv_idx_h = {{stride("KV_IDX", 1)}}
+    stride_kv_idx_m = {{stride("KV_IDX", 2)}}
+    sparse_hz_offset = sparse_idx_z * SPARSE_HQ + sparse_idx_hq
+    sparse_kv_num_blks_offset = sparse_hz_offset * stride_kv_num_blks_h + q_start // SPARSE_Q_MULTIPLE
+    sparse_kv_idx_offset = sparse_hz_offset * stride_kv_idx_h + (q_start // SPARSE_Q_MULTIPLE) * stride_kv_idx_m  # noqa: B950
+
+    # ===================== CONSTANTS =====================
+    NUM_MMA_GROUPS: tl.constexpr = 2
+    BLOCK_M_SPLIT: tl.constexpr = BLOCK_M // NUM_MMA_GROUPS
+    NUM_KV_BUFFERS: tl.constexpr = 2
+    NUM_QK_BUFFERS: tl.constexpr = 1
+    dtype_bytes: tl.constexpr = 2  # bf16/fp16
+
+    # ===================== SMEM ALLOCATIONS =====================
+    q_tiles = tlx.local_alloc((BLOCK_M_SPLIT, QK_HEAD_DIM_ROUNDED), MATMUL_PRECISION, NUM_MMA_GROUPS)
+    k_tiles = tlx.local_alloc((BLOCK_N, QK_HEAD_DIM_ROUNDED), MATMUL_PRECISION, NUM_KV_BUFFERS)
+    v_tiles = tlx.local_alloc((BLOCK_N, V_HEAD_DIM_ROUNDED), MATMUL_PRECISION, NUM_KV_BUFFERS)
+
+    # ===================== TMEM ALLOCATIONS =====================
+    qk_tmem = tlx.local_alloc((BLOCK_M_SPLIT, BLOCK_N), tl.float32, NUM_MMA_GROUPS * NUM_QK_BUFFERS, tlx.storage_kind.tmem)
+    p_tmem = tlx.local_alloc((BLOCK_M_SPLIT, BLOCK_N), MATMUL_PRECISION, NUM_MMA_GROUPS * NUM_QK_BUFFERS, tlx.storage_kind.tmem)
+    acc_tmem = tlx.local_alloc((BLOCK_M_SPLIT, V_HEAD_DIM_ROUNDED), tl.float32, NUM_MMA_GROUPS * NUM_QK_BUFFERS, tlx.storage_kind.tmem)
+
+    # alpha/l/m use SMEM (not TMEM) to avoid TMEM minimum-size alignment issues
+    alpha_smem = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, NUM_MMA_GROUPS)
+    l_smem = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, NUM_MMA_GROUPS)
+    m_smem = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, NUM_MMA_GROUPS)
+
+    # ===================== BARRIERS =====================
+    q_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+    k_fulls = tlx.alloc_barriers(num_barriers=NUM_KV_BUFFERS)
+    k_empties = tlx.alloc_barriers(num_barriers=NUM_KV_BUFFERS)
+    v_fulls = tlx.alloc_barriers(num_barriers=NUM_KV_BUFFERS)
+    v_empties = tlx.alloc_barriers(num_barriers=NUM_KV_BUFFERS)
+    qk_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_QK_BUFFERS)
+    p_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_QK_BUFFERS)
+    acc_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_QK_BUFFERS)
+    acc_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_QK_BUFFERS)
+    alpha_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+    alpha_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+    l_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+
+    with tlx.async_tasks():
+
+        # ================================================================
+        # TASK 1: CORRECTION + EPILOGUE  (default, gets remaining warps)
+        # ================================================================
+        with tlx.async_task("default"):
+            kv_indices_c = KV_IDX + sparse_kv_idx_offset
+            kv_num_blocks_c = tl.load(KV_NUM_BLKS + sparse_kv_num_blks_offset)
+            block_n_end_c = tl.minimum(kv_num_blocks_c * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+
+            total_blocks = block_n_end_c
+            if HAS_FULL_BLOCKS:
+                fkv_num_blocks_c = tl.load(FULL_KV_NUM_BLKS + sparse_kv_num_blks_offset)
+                total_blocks = total_blocks + tl.minimum(fkv_num_blocks_c * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+
+            accum_cnt_c = 0
+            for _block in range(0, total_blocks):
+                for cid in tl.static_range(NUM_MMA_GROUPS):
+                    # Wait for alpha from softmax
+                    tlx.barrier_wait(alpha_fulls[cid], (accum_cnt_c // 1) & 1)
+                    alpha_val = tlx.local_load(alpha_smem[cid])
+                    tlx.barrier_arrive(alpha_empties[cid])
+
+                    # Scale accumulator by alpha correction
+                    acc_val = tlx.local_load(acc_tmem[cid])
+                    acc_val = acc_val * alpha_val
+                    tlx.local_store(acc_tmem[cid], acc_val)
+                    tlx.barrier_arrive(acc_fulls[cid])
+
+                accum_cnt_c += 1
+
+            # ---- Epilogue: normalize and store output ----
+            for cid in tl.static_range(NUM_MMA_GROUPS):
+                tlx.barrier_wait(l_fulls[cid], 0)
+                l_val = tlx.local_load(l_smem[cid])
+                m_val = tlx.local_load(m_smem[cid])
+
+                tlx.barrier_wait(acc_empties[cid], 0)
+                acc_val = tlx.local_load(acc_tmem[cid])
+                acc_val = acc_val / l_val
+                lse_val = tl.reshape(m_val, [BLOCK_M_SPLIT]) + tl.math.log2(tl.reshape(l_val, [BLOCK_M_SPLIT]))
+
+                offs_m_cid = q_start * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+                idx_zq = tl.program_id(1).to(INDEX_DTYPE)
+                idx_hq = tl.program_id(2).to(INDEX_DTYPE)
+                idx_m = offs_m_cid[:, None].to(INDEX_DTYPE)
+                idx_d = tl.arange(0, V_HEAD_DIM_ROUNDED)[None, :].to(INDEX_DTYPE)
+                mask = (idx_m < Q_LEN) & (idx_d < V_HEAD_DIM)
+                {{store_output(("idx_zq", "idx_hq", "idx_m", "idx_d"), "acc_val", "mask", indent_width=16, val_shape=("BLOCK_M_SPLIT", "V_HEAD_DIM_ROUNDED"))}}
+
+                if OUTPUT_LOGSUMEXP:
+                    off_hz = off_zq * HQ + off_hq
+                    l_ptrs = LSE + off_hz * Q_LEN + offs_m_cid
+                    if IS_DIVISIBLE:
+                        tl.store(l_ptrs, lse_val)
+                    else:
+                        tl.store(l_ptrs, lse_val, mask=offs_m_cid < Q_LEN)
+
+                if OUTPUT_MAX:
+                    off_hz = off_zq * HQ + off_hq
+                    max_ptrs = MAX + off_hz * Q_LEN + offs_m_cid
+                    m_scalar = tl.reshape(m_val, [BLOCK_M_SPLIT])
+                    if IS_DIVISIBLE:
+                        tl.store(max_ptrs, m_scalar)
+                    else:
+                        tl.store(max_ptrs, m_scalar, mask=offs_m_cid < Q_LEN)
+
+        # ================================================================
+        # TASK 2: SOFTMAX + MODIFICATIONS  (replicated x NUM_MMA_GROUPS)
+        # ================================================================
+        with tlx.async_task(num_warps=4, registers=152, replicate=NUM_MMA_GROUPS):
+            cid = tlx.async_task_replica_id()
+            offs_m = q_start * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+            m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
+            l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) + 1.0
+            qk_scale = SM_SCALE  # natural scale; RCP_LN2 applied after score_mod/mask_mod
+            RCP_LN2 = 1.44269504  # log2(e): change of base for the exp2 softmax
+
+            # Sparse indices
+            kv_indices_s = KV_IDX + sparse_kv_idx_offset
+            kv_start_s = tl.load(kv_indices_s) * SPARSE_KV_BLOCK_SIZE
+            kv_num_blocks_s = tl.load(KV_NUM_BLKS + sparse_kv_num_blks_offset)
+            block_n_end_s = tl.minimum(kv_num_blocks_s * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+
+            offs_n = kv_start_s + tl.arange(0, BLOCK_N)
+            kv_offset_s = 0
+            accum_cnt_s = 0
+
+            # ---- Normal blocks (apply score_mod AND mask_mod) ----
+            for _sn in range(0, block_n_end_s):
+                tlx.barrier_wait(qk_fulls[cid], accum_cnt_s & 1)
+                qk = tlx.local_load(qk_tmem[cid])
+
+                # Scale and apply score_mod
+                qk = qk * qk_scale
+                m = get_bounded_indices(offs_m[:, None], Q_LEN if not IS_DIVISIBLE else None)
+                n = get_bounded_indices(offs_n[None, :], KV_LEN if not IS_DIVISIBLE else None)
+
+                {{ modification(
+                    subgraph_number=0,
+                    output_name="post_mod_scores",
+                    score="qk",
+                    b="off_zq",
+                    h="off_hq",
+                    m="m",
+                    n="n",
+                    out="qk"
+                ) | indent_except_first(4) }}
+
+                if not IS_DIVISIBLE:
+                    post_mod_scores = tl.where(offs_n[None, :] < KV_LEN, post_mod_scores, float("-inf"))
+
+                # Apply mask_mod (non-full blocks)
+                {{ modification(
+                    subgraph_number=1,
+                    output_name="mask_mod_output",
+                    score="qk",
+                    b="off_zq",
+                    h="off_hq",
+                    m="m",
+                    n="n",
+                ) | indent_except_first(4) }}
+
+                if not IS_DIVISIBLE:
+                    mask_mod_output = tl.where(offs_n[None, :] < KV_LEN, mask_mod_output, False)
+                post_mod_scores = tl.where(mask_mod_output, post_mod_scores, float("-inf"))
+                # Change of base now that score_mod + mask_mod are applied.
+                post_mod_scores = post_mod_scores * RCP_LN2
+
+                # Online softmax
+                m_ij = tl.maximum(m_i, tl.max(post_mod_scores, 1))
+                if not ROWS_GUARANTEED_SAFE:
+                    m_ij_masked = tl.where(m_ij == float("-inf"), 0, m_ij)
+                else:
+                    m_ij_masked = m_ij
+                alpha = tl.math.exp2(m_i - m_ij_masked)
+                p = tl.math.exp2(post_mod_scores - m_ij_masked[:, None])
+                l_i = l_i * alpha + tl.sum(p, 1)
+                m_i = m_ij
+
+                # Store alpha to TMEM for correction task
+                tlx.barrier_wait(alpha_empties[cid], accum_cnt_s & 1 ^ 1)
+                tlx.local_store(alpha_smem[cid], alpha[:, None])
+                tlx.barrier_arrive(alpha_fulls[cid])
+
+                # Store P to TMEM for MMA task (P@V)
+                p = p.to(MATMUL_PRECISION)
+                tlx.local_store(p_tmem[cid], p)
+                tlx.barrier_arrive(p_fulls[cid])
+
+                offset = get_offset_for_next_block(
+                    _sn, kv_indices_s, kv_num_blocks_s,
+                    SPARSE_KV_BLOCK_SIZE, SPARSE_KV_MULTIPLE, BLOCK_N, BLOCKS_ARE_CONTIGUOUS
+                )
+                offs_n = offs_n + offset
+                kv_offset_s += offset
+                accum_cnt_s += 1
+
+            # ---- Full blocks (apply score_mod ONLY, skip mask_mod) ----
+            if HAS_FULL_BLOCKS:
+                fkv_indices_s = FULL_KV_IDX + sparse_kv_idx_offset
+                fkv_start_s = tl.load(fkv_indices_s) * SPARSE_KV_BLOCK_SIZE
+                fkv_num_blocks_s = tl.load(FULL_KV_NUM_BLKS + sparse_kv_num_blks_offset)
+                fblock_n_end_s = tl.minimum(fkv_num_blocks_s * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+                offs_n = fkv_start_s + tl.arange(0, BLOCK_N)
+                kv_offset_s = 0
+
+                for _sn in range(0, fblock_n_end_s):
+                    tlx.barrier_wait(qk_fulls[cid], accum_cnt_s & 1)
+                    qk = tlx.local_load(qk_tmem[cid])
+
+                    qk = qk * qk_scale
+                    m = get_bounded_indices(offs_m[:, None], Q_LEN if not IS_DIVISIBLE else None)
+                    n = get_bounded_indices(offs_n[None, :], KV_LEN if not IS_DIVISIBLE else None)
+
+                    {{ modification(
+                        subgraph_number=0,
+                        output_name="post_mod_scores",
+                        score="qk",
+                        b="off_zq",
+                        h="off_hq",
+                        m="m",
+                        n="n",
+                        out="qk"
+                    ) | indent_except_first(5) }}
+
+                    if not IS_DIVISIBLE:
+                        post_mod_scores = tl.where(offs_n[None, :] < KV_LEN, post_mod_scores, float("-inf"))
+
+                    # Change of base now that score_mod is applied.
+                    post_mod_scores = post_mod_scores * RCP_LN2
+
+                    m_ij = tl.maximum(m_i, tl.max(post_mod_scores, 1))
+                    if not ROWS_GUARANTEED_SAFE:
+                        m_ij_masked = tl.where(m_ij == float("-inf"), 0, m_ij)
+                    else:
+                        m_ij_masked = m_ij
+                    alpha = tl.math.exp2(m_i - m_ij_masked)
+                    p = tl.math.exp2(post_mod_scores - m_ij_masked[:, None])
+                    l_i = l_i * alpha + tl.sum(p, 1)
+                    m_i = m_ij
+
+                    tlx.barrier_wait(alpha_empties[cid], accum_cnt_s & 1 ^ 1)
+                    tlx.local_store(alpha_smem[cid], alpha[:, None])
+                    tlx.barrier_arrive(alpha_fulls[cid])
+
+                    p = p.to(MATMUL_PRECISION)
+                    tlx.local_store(p_tmem[cid], p)
+                    tlx.barrier_arrive(p_fulls[cid])
+
+                    offset = get_offset_for_next_block(
+                        _sn, fkv_indices_s, fkv_num_blocks_s,
+                        SPARSE_KV_BLOCK_SIZE, SPARSE_KV_MULTIPLE, BLOCK_N, BLOCKS_ARE_CONTIGUOUS
+                    )
+                    offs_n = offs_n + offset
+                    kv_offset_s += offset
+                    accum_cnt_s += 1
+
+            # Store final l_i, m_i for epilogue
+            tlx.local_store(l_smem[cid], l_i[:, None])
+            tlx.local_store(m_smem[cid], m_i[:, None])
+            tlx.barrier_arrive(l_fulls[cid])
+
+        # ================================================================
+        # TASK 3: MMA  (1 warp, async_dot for Q@K^T and P@V)
+        #
+        # Interleaved pattern (matches _attn_fwd_ws reference):
+        #   Peeled iter 0:  Q[0]@K[0] → Q[1]@K[0] → P[0]@V[0]
+        #   Loop iter i:    Q[0]@K[i] → P[1]@V[i-1] → Q[1]@K[i] → P[0]@V[i]
+        #   Cleanup:        P[1]@V[last]
+        #
+        # This overlaps P[1]@V with Q@K, hiding softmax latency.
+        # ================================================================
+        with tlx.async_task(num_warps=1, registers=24):
+            kv_indices_m = KV_IDX + sparse_kv_idx_offset
+            kv_num_blocks_m = tl.load(KV_NUM_BLKS + sparse_kv_num_blks_offset)
+            block_n_end_m = tl.minimum(kv_num_blocks_m * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+
+            total_blocks_m = block_n_end_m
+            if HAS_FULL_BLOCKS:
+                fkv_num_blocks_m = tl.load(FULL_KV_NUM_BLKS + sparse_kv_num_blks_offset)
+                total_blocks_m = total_blocks_m + tl.minimum(fkv_num_blocks_m * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+
+            # Wait for Q to be loaded (ONCE, before the loop)
+            tlx.barrier_wait(q_fulls[0], 0)
+            tlx.barrier_wait(q_fulls[1], 0)
+
+            # ---- Peeled first iteration (block 0) ----
+            accum_cnt_m = 0
+            k_buf = 0
+            v_buf = 0
+
+            # Q[0]@K[0] → QK[0]
+            tlx.barrier_wait(k_fulls[0], 0)
+            k_t = tlx.local_trans(k_tiles[0])
+            tlx.async_dot(q_tiles[0], k_t, qk_tmem[0], use_acc=False, mBarriers=[qk_fulls[0]])
+            # Q[1]@K[0] → QK[1], release K[0]
+            tlx.async_dot(q_tiles[1], k_t, qk_tmem[1], use_acc=False, mBarriers=[qk_fulls[1], k_empties[0]])
+
+            # P[0]@V[0] → acc[0] (first write, use_acc=False)
+            tlx.barrier_wait(v_fulls[0], 0)
+            tlx.barrier_wait(p_fulls[0], 0)
+            tlx.barrier_wait(acc_fulls[0], 0)
+            tlx.async_dot(p_tmem[0], v_tiles[0], acc_tmem[0], use_acc=False, force_async=True)
+
+            acc1_init = False
+
+            # ---- Interleaved loop (blocks 1..N-1) ----
+            for _block in range(1, total_blocks_m):
+                v_buf_prev = accum_cnt_m % NUM_KV_BUFFERS
+                qk_phase_prev = accum_cnt_m & 1
+
+                accum_cnt_m = accum_cnt_m + 1
+                k_buf = accum_cnt_m % NUM_KV_BUFFERS
+                v_buf = accum_cnt_m % NUM_KV_BUFFERS
+                k_phase = (accum_cnt_m // NUM_KV_BUFFERS) & 1
+                qk_phase = accum_cnt_m & 1
+
+                # Q[0]@K[i] → QK[0]
+                tlx.barrier_wait(k_fulls[k_buf], k_phase)
+                k_t = tlx.local_trans(k_tiles[k_buf])
+                tlx.async_dot(q_tiles[0], k_t, qk_tmem[0], use_acc=False, mBarriers=[qk_fulls[0]])
+
+                # P[1]@V[i-1] → acc[1] (INTERLEAVED from previous iteration!)
+                tlx.barrier_wait(p_fulls[1], qk_phase_prev)
+                tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
+                tlx.async_dot(p_tmem[1], v_tiles[v_buf_prev], acc_tmem[1],
+                              use_acc=acc1_init, mBarriers=[v_empties[v_buf_prev]])
+                acc1_init = True
+
+                # Q[1]@K[i] → QK[1], release K[i]
+                tlx.async_dot(q_tiles[1], k_t, qk_tmem[1], use_acc=False,
+                              mBarriers=[qk_fulls[1], k_empties[k_buf]])
+
+                # P[0]@V[i] → acc[0] (accumulate)
+                v_phase = (accum_cnt_m // NUM_KV_BUFFERS) & 1
+                tlx.barrier_wait(v_fulls[v_buf], v_phase)
+                tlx.barrier_wait(p_fulls[0], qk_phase)
+                tlx.barrier_wait(acc_fulls[0], qk_phase)
+                tlx.async_dot(p_tmem[0], v_tiles[v_buf], acc_tmem[0],
+                              use_acc=True, force_async=True)
+
+            # ---- Cleanup: final P[1]@V[last] ----
+            qk_phase = accum_cnt_m & 1
+            tlx.tcgen05_commit(acc_empties[0])
+
+            tlx.barrier_wait(p_fulls[1], qk_phase)
+            tlx.barrier_wait(acc_fulls[1], qk_phase)
+            tlx.async_dot(p_tmem[1], v_tiles[v_buf], acc_tmem[1],
+                          use_acc=acc1_init,
+                          mBarriers=[acc_empties[1], v_empties[v_buf]])
+
+        # ================================================================
+        # TASK 4: LOAD  (1 warp, TMA loads for Q, K, V)
+        # ================================================================
+        with tlx.async_task(num_warps=1, registers=24):
+            # Load Q[0] and Q[1] via TMA (once)
+            q_base = (q_start * BLOCK_M).to(tl.int32)
+            tlx.barrier_expect_bytes(q_fulls[0], dtype_bytes * BLOCK_M_SPLIT * QK_HEAD_DIM_ROUNDED)
+            tlx.async_descriptor_load(desc_q, q_tiles[0], [q_base, 0], q_fulls[0])
+            tlx.barrier_expect_bytes(q_fulls[1], dtype_bytes * BLOCK_M_SPLIT * QK_HEAD_DIM_ROUNDED)
+            tlx.async_descriptor_load(desc_q, q_tiles[1], [q_base + BLOCK_M_SPLIT, 0], q_fulls[1])
+
+            # Sparse indices for load
+            kv_indices_ld = KV_IDX + sparse_kv_idx_offset
+            kv_start_ld = tl.load(kv_indices_ld) * SPARSE_KV_BLOCK_SIZE
+            kv_num_blocks_ld = tl.load(KV_NUM_BLKS + sparse_kv_num_blks_offset)
+            block_n_end_ld = tl.minimum(kv_num_blocks_ld * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+
+            # Load K/V for normal blocks
+            kv_offset_ld = 0
+            accum_cnt_ld = 0
+            for _sn in range(0, block_n_end_ld):
+                buf = accum_cnt_ld % NUM_KV_BUFFERS
+                kv_base = kv_start_ld + kv_offset_ld
+
+                # Load K
+                tlx.barrier_wait(k_empties[buf], (accum_cnt_ld // NUM_KV_BUFFERS) & 1 ^ 1)
+                tlx.barrier_expect_bytes(k_fulls[buf], dtype_bytes * BLOCK_N * QK_HEAD_DIM_ROUNDED)
+                tlx.async_descriptor_load(desc_k, k_tiles[buf], [kv_base, 0], k_fulls[buf])
+
+                # Load V
+                tlx.barrier_wait(v_empties[buf], (accum_cnt_ld // NUM_KV_BUFFERS) & 1 ^ 1)
+                tlx.barrier_expect_bytes(v_fulls[buf], dtype_bytes * BLOCK_N * V_HEAD_DIM_ROUNDED)
+                tlx.async_descriptor_load(desc_v, v_tiles[buf], [kv_base, 0], v_fulls[buf])
+
+                offset = get_offset_for_next_block(
+                    _sn, kv_indices_ld, kv_num_blocks_ld,
+                    SPARSE_KV_BLOCK_SIZE, SPARSE_KV_MULTIPLE, BLOCK_N, BLOCKS_ARE_CONTIGUOUS
+                )
+                kv_offset_ld += offset
+                accum_cnt_ld += 1
+
+            # Load K/V for full blocks
+            if HAS_FULL_BLOCKS:
+                fkv_indices_ld = FULL_KV_IDX + sparse_kv_idx_offset
+                fkv_start_ld = tl.load(fkv_indices_ld) * SPARSE_KV_BLOCK_SIZE
+                fkv_num_blocks_ld = tl.load(FULL_KV_NUM_BLKS + sparse_kv_num_blks_offset)
+                fblock_n_end_ld = tl.minimum(fkv_num_blocks_ld * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+
+                kv_offset_ld = 0
+                for _sn in range(0, fblock_n_end_ld):
+                    buf = accum_cnt_ld % NUM_KV_BUFFERS
+                    kv_base = fkv_start_ld + kv_offset_ld
+
+                    tlx.barrier_wait(k_empties[buf], (accum_cnt_ld // NUM_KV_BUFFERS) & 1 ^ 1)
+                    tlx.barrier_expect_bytes(k_fulls[buf], dtype_bytes * BLOCK_N * QK_HEAD_DIM_ROUNDED)
+                    tlx.async_descriptor_load(desc_k, k_tiles[buf], [kv_base, 0], k_fulls[buf])
+
+                    tlx.barrier_wait(v_empties[buf], (accum_cnt_ld // NUM_KV_BUFFERS) & 1 ^ 1)
+                    tlx.barrier_expect_bytes(v_fulls[buf], dtype_bytes * BLOCK_N * V_HEAD_DIM_ROUNDED)
+                    tlx.async_descriptor_load(desc_v, v_tiles[buf], [kv_base, 0], v_fulls[buf])
+
+                    offset = get_offset_for_next_block(
+                        _sn, fkv_indices_ld, fkv_num_blocks_ld,
+                        SPARSE_KV_BLOCK_SIZE, SPARSE_KV_MULTIPLE, BLOCK_N, BLOCKS_ARE_CONTIGUOUS
+                    )
+                    kv_offset_ld += offset
+                    accum_cnt_ld += 1

--- a/third_party/tlx/language/tlx/inductor/tlx_only_cuda_options_flow.md
+++ b/third_party/tlx/language/tlx/inductor/tlx_only_cuda_options_flow.md
@@ -1,0 +1,68 @@
+# tlx_only_cuda_options Flow in Inductor TLX Templates
+
+This document shows how `tlx_only_cuda_options` (e.g., `ctas_per_cga`) flows from the TLX template heuristic configuration to the Triton kernel decorator.
+
+---
+
+## Complete Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Registry as tlx/inductor/registry.py
+    participant Utils as utils.py
+    participant Choices as choices.py
+    participant KTC as KernelTemplateChoice
+    participant Template as TritonTemplate
+    participant Caller as TritonTemplateCaller
+    participant Kernel as TritonTemplateKernel
+    participant Heuristics as triton_heuristics.py
+    participant Triton as Triton Compiler
+
+    Registry->>Registry: Define tlx_only_cuda_options = ["ctas_per_cga"]
+    Registry->>Registry: TLX2CTAConfigMixin.get_extra_kwargs() returns {ctas_per_cga: (2,1,1)}
+
+    Note over Choices: Template selection begins
+    Choices->>Utils: tlx_only_cuda_options()
+    Utils->>Registry: Import tlx_only_cuda_options
+    Registry-->>Utils: ["ctas_per_cga"]
+    Utils-->>Choices: ["ctas_per_cga"]
+
+    Choices->>Registry: heuristic.get_extra_kwargs()
+    Registry-->>Choices: {ctas_per_cga: (2,1,1)}
+
+    Choices->>KTC: make_ktc_generator(extra_kwargs)
+    KTC->>Template: choice_or_none(**extra_kwargs)
+    Template->>Caller: TritonTemplateCaller(kwargs with ctas_per_cga)
+
+    Note over Kernel: Code generation begins
+    Caller->>Kernel: TritonTemplateKernel(meta=kwargs)
+    Kernel->>Kernel: self.meta = meta
+
+    Kernel->>Utils: tlx_only_cuda_options()
+    Utils-->>Kernel: ["ctas_per_cga"]
+    Kernel->>Kernel: for k in tlx_only_cuda_options(): add to template_args
+
+    Kernel->>Heuristics: @triton_heuristics.template(ctas_per_cga=(2,1,1))
+    Heuristics->>Heuristics: triton.Config(ctas_per_cga=(2,1,1))
+    Heuristics->>Heuristics: _create_compile_meta() extracts ctas_per_cga
+    Heuristics->>Heuristics: _create_compile_options() sets cluster_dims
+    Heuristics->>Triton: Compile with cluster_dims=(2,1,1)
+    Triton->>Triton: CTA Cluster launch on Blackwell GPU
+```
+
+---
+
+## Adding a New tlx_only_cuda_option
+
+To add a new FB-only option (e.g., `my_new_option`):
+
+1. **Add to registry.py**:
+   ```python
+   tlx_only_cuda_options = ["ctas_per_cga", "my_new_option"]
+   ```
+
+2. **Return from get_extra_kwargs()**:
+   ```python
+   def get_extra_kwargs(self, kernel_inputs, op_name):
+       return {"ctas_per_cga": (2, 1, 1), "my_new_option": value}
+   ```


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/189094


TorchTLX lives in an `fb/` folder of Inductor with minimal hooks visible to OSS. Now that OSS fbtriton is available and more non-Triton DSLs are adopted as an Inductor backend DSL, this diff open-sources torchTLX.

To minimize disruption to OSS PyTorch, future iterations of torchTLX will happen in OSS fbtriton.

Reviewed By: htyu

Differential Revision: D110802590
