### PR TITLE
[triton][modulo] Epilogue subtiling: emit subtile chain + fix subsliced epilogue

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
@@ -151,6 +151,15 @@ struct ScheduleNode {
   unsigned partitionDim{0}; // 0 = M, 1 = N
   unsigned mSize{0};        // per-partition size along partitionDim
 
+  // Pass A.7 epilogue subtiling: when subtileCount > 1, this node is part of the
+  // epilogue chain (tmem_load -> ... -> descriptor_store) that the sched2tlx
+  // emitter unrolls into `subtileCount` sub-stores along N, each of width
+  // `nSize`. Default (subtileCount == 1) = not subtiled.
+  int subtileCount{1};
+  int subtileIndex{-1};
+  int nOffset{0};
+  int nSize{0};
+
   bool isSuperNode() const { return childPipelineId != UINT_MAX; }
   bool hasBuffer() const {
     return producesBuffer != UINT_MAX || !consumesBuffers.empty();

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -982,8 +982,58 @@ static bool bufferReachesPartMMA(const ttg::ScheduleLoop &loop,
   return false;
 }
 
+// Pass A.7: mark the epilogue value-chain (tmem_load -> ... -> descriptor_store)
+// with the subtile factor S and per-sub-tile N width, so the sched2tlx emitter
+// unrolls S sub-stores along N (overlapping TMA store i with compute of i+1).
+// Opt-in: getEpilogueSubtileForOp only returns S>1 when
+// TRITON_MODULO_EPILOGUE_SUBTILE is set, so this is a no-op by default.
+static void markEpilogueSubtileChain(ttg::ScheduleLoop &loop) {
+  llvm::DenseMap<Operation *, unsigned> opToNode;
+  for (unsigned i = 0; i < loop.nodes.size(); ++i)
+    if (loop.nodes[i].op)
+      opToNode[loop.nodes[i].op] = i;
+
+  for (auto &store : loop.nodes) {
+    if (!store.op || !isa<tt::DescriptorStoreOp>(store.op))
+      continue;
+    int S = getEpilogueSubtileForOp(store.op);
+    if (S <= 1)
+      continue;
+    auto storeOp = cast<tt::DescriptorStoreOp>(store.op);
+    auto srcTy = dyn_cast<RankedTensorType>(storeOp.getSrc().getType());
+    if (!srcTy || srcTy.getRank() < 2)
+      continue;
+    int nSize = static_cast<int>(srcTy.getShape()[1]) / S;
+
+    auto mark = [&](Operation *op) {
+      auto it = opToNode.find(op);
+      if (it == opToNode.end())
+        return;
+      loop.nodes[it->second].subtileCount = S;
+      loop.nodes[it->second].nSize = nSize;
+    };
+    mark(store.op);
+    // Walk the stored-VALUE chain (not the descriptor / index operands) back to
+    // the accumulator tmem_load, marking each epilogue node. Stop at tmem_load:
+    // its operands come from the K-loop, not the epilogue chain.
+    llvm::SmallVector<Value, 4> work{storeOp.getSrc()};
+    llvm::DenseSet<Operation *> seen;
+    while (!work.empty()) {
+      Operation *def = work.pop_back_val().getDefiningOp();
+      if (!def || !seen.insert(def).second || !opToNode.count(def))
+        continue;
+      mark(def);
+      if (def->getName().getStringRef() == "ttng.tmem_load")
+        continue;
+      for (Value operand : def->getOperands())
+        work.push_back(operand);
+    }
+  }
+}
+
 static void allocateBuffersForLoop(ttg::ScheduleLoop &loop,
                                    const DataPartitionPlan &plan) {
+  markEpilogueSubtileChain(loop);
   llvm::SmallVector<unsigned, 4> dataBufferIds;
   // Pass A.5: when this loop carries a partitioned MMA bundle, the DP-inflated
   // II collapses operand SMEM rings to depth 1 (computeBufferCount =
@@ -4366,12 +4416,16 @@ void jsonDumpScheduleLoop(llvm::raw_ostream &os, const ttg::ScheduleLoop &sl,
     if (n.isSuperNode())
       os << ", \"child_pipeline_id\": " << n.childPipelineId
          << ", \"prologue_latency\": " << n.prologueLatency;
-    // Pass A.5 data-partition fields on the (single) MMA bundle node. A.7
-    // subtile fields remain a separate follow-up.
+    // Pass A.5 data-partition fields on the (single) MMA bundle node.
     if (n.partitionCount > 1)
       os << ", \"partition_count\": " << n.partitionCount
          << ", \"partition_dim\": " << n.partitionDim
          << ", \"m_size\": " << n.mSize;
+    // Pass A.7 subtile fields (subtile_count == 1 => not subtiled). The
+    // sched2tlx emitter reads subtile_count + n_size to unroll the epilogue.
+    os << ", \"subtile_count\": " << n.subtileCount
+       << ", \"subtile_index\": " << n.subtileIndex
+       << ", \"n_offset\": " << n.nOffset << ", \"n_size\": " << n.nSize;
     os << "}" << (i + 1 == sl.nodes.size() ? "" : ",") << "\n";
   }
   os << "        ],\n";

--- a/third_party/tlx/tools/sched2tlx/sched2tlx/emitter.py
+++ b/third_party/tlx/tools/sched2tlx/sched2tlx/emitter.py
@@ -227,6 +227,12 @@ class RenderCtx:
     # Used when an emitter resolves a buffer via alloc_op_var instead of
     # (loop_id, buf_id).
     partition_alloc_names: dict[str, list[str]] = field(default_factory=dict)
+    # Pass A.7: op ids of kernel-internal `tt.make_tensor_descriptor`s that feed
+    # a subtiled epilogue store → the sub-tile N width. A subtiled store writes
+    # an N-slice of width sub_size, so the descriptor block N must match (the TMA
+    # copy asserts descriptor-block == source shape). Populated once in emit();
+    # consumed by `_render_make_tensor_descriptor` to override block N.
+    subtiled_desc_ops: dict[str, int] = field(default_factory=dict)
     # Monotonic, globally-unique counter for auto-named variables. Every
     # auto-named op draws a fresh index via `fresh_idx()`, so names minted in
     # different scopes (preamble, each per-WG outer-loop body, epilogue,
@@ -455,6 +461,11 @@ def _render_make_tensor_descriptor(op: Op, rctx: RenderCtx) -> str:
     if block_info is None:
         return f"tl.make_tensor_descriptor({ptr}, [{', '.join(shape)}], [{', '.join(strides)}], [...])"
     block_dims, _ = block_info
+    # Pass A.7: if this descriptor feeds a subtiled store, its block N must match
+    # the sub-tile width (the store writes an N-slice of that width).
+    sub_n = rctx.subtiled_desc_ops.get(op.op_id)
+    if sub_n is not None and len(block_dims) >= 2:
+        block_dims = list(block_dims[:-1]) + [sub_n]
     block_str = ", ".join(str(d) for d in block_dims)
     return (
         f"tl.make_tensor_descriptor({ptr}, [{', '.join(shape)}], "
@@ -4209,10 +4220,36 @@ def _emit_outer_epilogue_subtiled(
     # `wait(0)` is emitted by the caller AFTER the persistent loop ends.
     # Pattern matches blackwell_gemm_ws tutorial.
     BUF_RING = 2  # matches buf.count set in extractBufferShape / _emit_buffers
+    # Outer-loop TMA loads feeding the epilogue (case5/case7 bias) are full
+    # 128xBN register tensors; each sub-tile's acc is subsliced to 128xsub_size,
+    # so those operands must be reloaded sliced along N to match. Collect their
+    # op ids + staging bufname + row count once. Their pre-chain full local_load
+    # is left dead (DCE'd); the sliced reloads read the same still-valid SMEM
+    # (same default WG, sequential before the next tile's refill).
+    _bias_reload = []  # (op_id, bufname, rows)
+    _var_to_opid = {v: k for k, v in rctx.op_var.items()}
+    for _b in rctx.outer_load_bindings.values():
+        _opid = _var_to_opid.get(_b["var_name"])
+        if _opid is None:
+            continue
+        _op = g.ops.get(_opid)
+        _rows = 128
+        if _op is not None and _op.result_types:
+            _sh = _parse_tensor_shape(_op.result_types[0])
+            if _sh and _sh[0]:
+                _rows = _sh[0][0]
+        _bias_reload.append((_opid, _b["bufname"], _rows))
     for sub_n in range(S):
         n_off = sub_n * sub_size
         smem_slot = sub_n % BUF_RING
         is_last_sub = sub_n == S - 1
+        for _bi, (_opid, _bufname, _rows) in enumerate(_bias_reload):
+            _bvar = f"biassub_{sub_n}_{_bi}"
+            lines += (
+                f"{_bvar} = tlx.local_load(tlx.local_slice({_bufname}[0], "
+                f"[0, {n_off}], [{_rows}, {sub_size}]))"
+            )
+            rctx.op_var[_opid] = _bvar
         for n in chain_nodes:
             op = g.ops.get(n.op_ref) if n.op_ref else None
             if op is None or op.kind in _SKIP_FUNCTION_SCOPE:
@@ -4708,6 +4745,20 @@ def emit(graph: ScheduleGraph) -> str:
         op.kind in ("ttng.tc_gen5_mma", "ttng.tc_gen5_mma_scaled")
         for op in graph.ops.values()
     )
+
+    # Pass A.7: map kernel-internal make_tensor_descriptor ops feeding a subtiled
+    # store to the sub-tile N width, so their block N is emitted to match. Must
+    # run before the preamble (where descriptors are rendered).
+    for _loop in graph.loops:
+        for _node in _loop.schedule.nodes:
+            if _node.subtile_count <= 1 or _node.op_kind != "tt.descriptor_store":
+                continue
+            _store = graph.ops.get(_node.op_ref) if _node.op_ref else None
+            if _store is None or not _store.operands:
+                continue
+            _dref = _store.operands[0]
+            if isinstance(_dref, OpRef):
+                rctx.subtiled_desc_ops[_dref.op_id] = _node.n_size
 
     lines.indent = 1
     if outer_loop is None:


### PR DESCRIPTION
Summary:
This wires up Pass A.7 epilogue subtiling end-to-end for persistent GEMM kernels whose epilogue is `tmem_load -> (optional bias add) -> truncf -> descriptor_store`. `markEpilogueSubtileChain` in `ModuloSchedulePass.cpp` walks the store chain and tags its nodes with `subtile_count`/`n_size`, which are dumped into `schedule_graph.json`; `ModuloScheduleGraph.h` gains the matching `ScheduleNode` fields. The sched2tlx emitter then unrolls the epilogue into `S` N-slices, subslicing the accumulator, any bias operand, and the store descriptor block so each sub-tile is self-consistent.

Two emitter correctness fixes were needed for biased and kernel-internal-descriptor epilogues: any outer-loop TMA operand feeding the epilogue (e.g. the addmm bias) is now reloaded sliced along N to match the subsliced accumulator, and a kernel-internal `tt.make_tensor_descriptor` feeding a subtiled store now emits its block N as the sub-tile width so the TMA copy's descriptor block matches the source shape.

The feature stays opt-in behind the existing `TRITON_MODULO_EPILOGUE_SUBTILE` env var (unset by default, so generated output is byte-identical to master). It helps epilogue-bound persistent GEMMs whose epilogue carries real register pressure (an `acc + bias` add) and is neutral-to-slightly-negative otherwise, so it is meant to be enabled selectively.

Authored with Claude Code.

Differential Revision: D110817383


