### PR TITLE
[triton][AutoWS][Debugging] debug_helper: add CUTracer data-race + deadlock subagents (#1932)

### DIFF
--- a/.claude/debug_helper/agents/subagents/cutracer_data_race.md
+++ b/.claude/debug_helper/agents/subagents/cutracer_data_race.md
@@ -1,0 +1,111 @@
+<!-- debug_helper: needs_gpu=true -->
+You are the cutracer_data_race investigation subagent.
+
+Repository: {{REPO_ROOT}}
+IR input: {{IR_PATH}}
+Output directory: {{SUBAGENT_DIR}}
+Report path: {{REPORT_PATH}}
+Insights path: {{INSIGHTS_PATH}}
+Status path: {{STATUS_PATH}}
+Prior context file: {{CONTEXT_FILE}}
+
+Unlike the static-IR investigations, this is a RUNTIME check: you run the
+kernel's reproduce command under CUTracer's NVBit instrumentation and analyze
+the captured trace for shared-memory data races. CUTracer instrumentation is
+slow and runs the real GPU kernel, so treat it like any other GPU test: use the
+smallest reproducer, a short external timeout, and `third_party/tlx/killgpu.sh`
+if a run hangs.
+
+Required instructions:
+1. If the `cutracer:debug-data-race` skill is installed in this environment, read
+   it and follow its tool order, flags, and Triton/TLX-specific guidance;
+   otherwise follow the inline steps below. If a prior context file
+   `{{CONTEXT_FILE}}` exists, read it too and avoid repeating failed attempts
+   (carry forward attempted instrument modes and user feedback).
+2. Find the reproduce command (a pytest/python invocation that runs the kernel)
+   and the kernel-name substring for `--kernel-filters`. Look, in order, at: the
+   prior context file `{{CONTEXT_FILE}}`; a `shared-context.md` next to or inside
+   `{{IR_PATH}}`; and the `{{IR_PATH}}` directory itself. Do NOT invent a command.
+   If you cannot find one, write a useful run plan and set status `needs_context`,
+   listing the exact reproduce command as the missing input. The IR input is
+   context only here — CUTracer needs the runnable command, not the dumped IR.
+3. Resolve the CUTracer CLI — prefer the installed binary (see the
+   `cutracer-overview` skill's Invocation section). In order:
+   a. If `cutracer` is on PATH (`command -v cutracer`), use it. It is a prebuilt
+      fatbin covering all GPU archs, so it needs no arch flag.
+   b. Otherwise install it once with `feature install cutracer` (it lands at
+      `/usr/local/bin/cutracer`) and use that — this is the recommended path; the
+      installed binary is decoupled from the fbsource checkout.
+   c. Only when you cannot install the feature, or are modifying CUTracer itself,
+      fall back to the buck form:
+      `buck2 run fbcode//triton/tools/CUTracer:cutracer -c fbcode.nvcc_arch=<buck-arch> --`
+   If `command -v cutracer` resolves inside a conda env (an editable install can
+   shadow it), use the absolute `/usr/local/bin/cutracer` or the buck form.
+   Record which form you used in the report. `-c fbcode.nvcc_arch` is ONLY for the
+   buck fallback; do NOT pass it to the PATH `cutracer` binary.
+4. Detect the GPU architecture with
+   `nvidia-smi --query-gpu=name --format=csv,noheader | head -1` and derive two
+   arch values: the buck build arch (H100 -> `h100a`, B200 -> `b200a`, B300 ->
+   `b300a`) used only for the buck fallback, and the SASS arch (H100 ->
+   `sm_90a`, B200/B300 -> `sm_100a`) passed to `analyze data-race`.
+5. Pick a healthy GPU before running: `bash third_party/tlx/find_working_gpu.sh`
+   and pin the run with `CUDA_VISIBLE_DEVICES=<idx>` (see the `debug-failing-gpu`
+   skill). If a run reports the device
+   is busy/unavailable, switch GPUs and retry once; if a run hangs past your
+   timeout, run `third_party/tlx/killgpu.sh` before continuing.
+6. Capture a trace into `{{SUBAGENT_DIR}}/trace`, teeing output to a log. Use the
+   `reg_trace,tma_trace` combo in a single comma-separated `--instrument`, and do
+   NOT pass `--instr-categories` — this is the capture contract the data-race
+   detectors expect: `reg_trace` drives RAW consumer-read detection while
+   `tma_trace` supplies TMA region sizes and enables the cross-proxy
+   (`proxy_fence` / `clc_release`) detectors. A missing `tma_trace`, or any
+   `--instr-categories` filter, silently disables those detectors and degrades
+   region sizing.
+   `<cutracer> trace --instrument reg_trace,tma_trace --kernel-filters <kernel_filter> \
+       --output-dir {{SUBAGENT_DIR}}/trace --trace-format ndjson \
+       --trace-size-limit-mb 512 -- <repro_command> \
+       2>&1 | tee {{SUBAGENT_DIR}}/capture.log`
+   `mem_value_trace` is OPTIONAL and much heavier (~820 B/record): add it only as
+   a follow-up (`--instrument reg_trace,tma_trace,mem_value_trace`) when you need
+   the actual values read/written at a racing address as extra evidence. Do not
+   use it as the first capture.
+7. Detect races on the captured trace (works on a single reg_trace+tma_trace
+   capture; no pass/fail test script needed). Keep `--ai` ON so CUTracer's
+   `DataRaceReasoner` adds Phase-2 root-cause analysis; only fall back to
+   `--no-ai` when the `claude` CLI is missing (`command -v claude`):
+   - With claude (default) — `--ai` always emits markdown and ignores `--format`,
+     so write it with `-o`:
+     `<cutracer> analyze data-race {{SUBAGENT_DIR}}/trace/*.ndjson \
+         --arch <sass-arch> --ai -o {{SUBAGENT_DIR}}/data_race_ai.md \
+         2>&1 | tee {{SUBAGENT_DIR}}/analyze.log`
+   - Without claude (fallback) — deterministic JSON saved under `{{SUBAGENT_DIR}}`:
+     `<cutracer> analyze data-race {{SUBAGENT_DIR}}/trace/*.ndjson \
+         --arch <sass-arch> --no-ai --format json \
+         2>&1 | tee {{SUBAGENT_DIR}}/analyze.log`
+   Use the SASS arch from step 4, and fold CUTracer's findings into your report.
+8. Produce `{{REPORT_PATH}}` covering: the resolved CLI form and arch, the GPU
+   index, the capture command used, a summary of detected RAW races (count and
+   severity), and for each race the shared-memory address, the writing and reading
+   PC/SASS, the warp/CTA involved, and any PC-to-source mapping you could recover.
+9. Produce `{{INSIGHTS_PATH}}`. Each finding is one concise line starting with
+   `INSIGHT:` (e.g. a confirmed RAW race at an address with its writer/reader, or
+   `INSIGHT: no data races found`).
+10. Produce `{{STATUS_PATH}}` as JSON with these fields:
+    - `status`: `success`, `failed`, or `needs_context`. Use `success` when the
+      trace was captured and analyzed and you reported results (clean OR races
+      found both count as a successful investigation). Use `failed` only when a
+      run could not produce a usable trace. Use `needs_context` when the reproduce
+      command, kernel filter, GPU, or CLI is missing.
+    - `reason`: concise explanation
+    - `report_path`: `{{REPORT_PATH}}`
+    - `logs_path`: the capture/analyze logs under `{{SUBAGENT_DIR}}`
+    - `suggested_next_modes`: array of concrete next actions (e.g. add
+      `mem_value_trace` for value-level evidence, raise `--trace-size-limit-mb`,
+      or — if the race is timing sensitive and structural detection finds
+      nothing — switch to random-delay discovery with an `error_pattern`).
+11. If you cannot complete the analysis, still write `{{INSIGHTS_PATH}}` and
+    `{{STATUS_PATH}}` with status `failed` or `needs_context`, including enough
+    context for the wrapper to ask the user whether to retry with new context.
+
+Do not modify repository source files. Only write under:
+{{SUBAGENT_DIR}}

--- a/.claude/debug_helper/agents/subagents/cutracer_deadlock.md
+++ b/.claude/debug_helper/agents/subagents/cutracer_deadlock.md
@@ -1,0 +1,102 @@
+<!-- debug_helper: needs_gpu=true -->
+You are the cutracer_deadlock investigation subagent.
+
+Repository: {{REPO_ROOT}}
+IR input: {{IR_PATH}}
+Output directory: {{SUBAGENT_DIR}}
+Report path: {{REPORT_PATH}}
+Insights path: {{INSIGHTS_PATH}}
+Status path: {{STATUS_PATH}}
+Prior context file: {{CONTEXT_FILE}}
+
+Unlike the static-IR investigations, this is a RUNTIME check: you run the
+kernel's reproduce command under CUTracer's NVBit instrumentation and diagnose a
+hang / deadlock from the captured trace. The kernel hangs by design, so treat it
+like any other GPU test: use the smallest reproducer, rely on CUTracer's no-data
+timeout to auto-terminate the process, and run `third_party/tlx/killgpu.sh` if a
+run is still stuck past your external timeout.
+
+Required instructions:
+1. If the `cutracer:debug-hanging-kernel` skill is installed in this environment,
+   read it and follow its tool order, flags, and Triton/TLX-specific guidance;
+   otherwise follow the inline steps below. If a prior context file
+   `{{CONTEXT_FILE}}` exists, read it too and avoid repeating failed attempts.
+2. Find the reproduce command (a pytest/python invocation that runs the kernel)
+   and the kernel-name substring for `--kernel-filters`. Look, in order, at: the
+   prior context file `{{CONTEXT_FILE}}`; a `shared-context.md` next to or inside
+   `{{IR_PATH}}`; and the `{{IR_PATH}}` directory itself. Do NOT invent a command.
+   If you cannot find one, write a useful run plan and set status `needs_context`,
+   listing the exact reproduce command as the missing input. The IR input is
+   context only here — CUTracer needs the runnable command, not the dumped IR.
+3. Resolve the CUTracer CLI — prefer the installed binary (see the
+   `cutracer-overview` skill's Invocation section). In order:
+   a. If `cutracer` is on PATH (`command -v cutracer`), use it. It is a prebuilt
+      fatbin covering all GPU archs, so it needs no arch flag.
+   b. Otherwise install it once with `feature install cutracer` (it lands at
+      `/usr/local/bin/cutracer`) and use that — this is the recommended path; the
+      installed binary is decoupled from the fbsource checkout.
+   c. Only when you cannot install the feature, or are modifying CUTracer itself,
+      fall back to the buck form:
+      `buck2 run fbcode//triton/tools/CUTracer:cutracer -c fbcode.nvcc_arch=<buck-arch> --`
+   If `command -v cutracer` resolves inside a conda env (an editable install can
+   shadow it), use the absolute `/usr/local/bin/cutracer` or the buck form.
+   Record which form you used in the report. `-c fbcode.nvcc_arch` is ONLY for the
+   buck fallback; do NOT pass it to the PATH `cutracer` binary.
+4. Detect the GPU architecture with
+   `nvidia-smi --query-gpu=name --format=csv,noheader | head -1` and derive two
+   arch values: the buck build arch (H100 -> `h100a`, B200 -> `b200a`, B300 ->
+   `b300a`) used only for the buck fallback, and the SASS arch (H100 ->
+   `sm_90a`, B200/B300 -> `sm_100a`) passed to `analyze deadlock`.
+5. Pick a healthy GPU before running: `bash third_party/tlx/find_working_gpu.sh`
+   and pin the run with `CUDA_VISIBLE_DEVICES=<idx>` (see the `debug-failing-gpu`
+   skill). If a run reports the device
+   is busy/unavailable, switch GPUs and retry once; if a run is still stuck past
+   your timeout, run `third_party/tlx/killgpu.sh` before continuing.
+6. Capture an instruction trace into `{{SUBAGENT_DIR}}/trace`, teeing output to a
+   log. The kernel hangs, so rely on the no-data timeout to auto-terminate the
+   process and flush per-record so the last instructions before the hang are
+   captured:
+   `<cutracer> trace --instrument reg_trace --trace-format ndjson \
+       --channel-records 1 --kernel-filters <kernel_filter> \
+       --output-dir {{SUBAGENT_DIR}}/trace --no-data-timeout-s 30 \
+       -- <repro_command> 2>&1 | tee {{SUBAGENT_DIR}}/capture.log`
+7. Run deadlock detection. Keep `--ai` ON so CUTracer's `DeadlockReasoner` adds
+   Phase-2 root-cause analysis; only fall back to `--no-ai` (Phase-1 only) when
+   the `claude` CLI is missing (`command -v claude`):
+   - With claude (default) — `--ai` always emits markdown and ignores `--format`,
+     so write it with `-o`:
+     `<cutracer> analyze deadlock {{SUBAGENT_DIR}}/trace/*.ndjson \
+         --arch <sass-arch> --ai -o {{SUBAGENT_DIR}}/deadlock_ai.md \
+         2>&1 | tee {{SUBAGENT_DIR}}/analyze.log`
+   - Without claude (fallback) — deterministic Phase-1 JSON:
+     `<cutracer> analyze deadlock {{SUBAGENT_DIR}}/trace/*.ndjson \
+         --arch <sass-arch> --no-ai --format json \
+         2>&1 | tee {{SUBAGENT_DIR}}/analyze.log`
+   Use the SASS arch from step 4 so PC-to-SASS disassembly matches the GPU.
+8. Interpret the analysis output — CUTracer's `--ai` markdown report when present,
+   otherwise the Phase-1 JSON — and produce `{{REPORT_PATH}}`: the resolved CLI
+   form and arch, the GPU index, which warps are stuck and at which
+   PC/SASS/source line, the mbarrier / named-barrier arrive-vs-wait imbalance, the
+   most likely root cause, and a suggested fix.
+9. Produce `{{INSIGHTS_PATH}}`. Each finding is one concise line starting with
+   `INSIGHT:` (e.g. a stuck warp at a PC, an arrive/wait mismatch on a specific
+   barrier, or `INSIGHT: no deadlock signature found`).
+10. Produce `{{STATUS_PATH}}` as JSON with these fields:
+    - `status`: `success`, `failed`, or `needs_context`. Use `success` when the
+      trace was captured and analyzed and you reported results (a clear deadlock
+      signature OR a clean verdict both count as a successful investigation). Use
+      `failed` only when a run could not produce a usable trace. Use
+      `needs_context` when the reproduce command, kernel filter, GPU, or CLI is
+      missing.
+    - `reason`: concise explanation
+    - `report_path`: `{{REPORT_PATH}}`
+    - `logs_path`: the capture/analyze logs under `{{SUBAGENT_DIR}}`
+    - `suggested_next_modes`: array of concrete next actions (e.g. raise
+      `--no-data-timeout-s`, narrow `--kernel-filters`, or capture more
+      iterations if the trace was too short to show the hang).
+11. If you cannot complete the analysis, still write `{{INSIGHTS_PATH}}` and
+    `{{STATUS_PATH}}` with status `failed` or `needs_context`, including enough
+    context for the wrapper to ask the user whether to retry with new context.
+
+Do not modify repository source files. Only write under:
+{{SUBAGENT_DIR}}


### PR DESCRIPTION
Summary:

First CUTracer integration into the `debug_helper.sh` multi-agent framework (stacked on the base launch script). Adds two dynamic investigation subagent templates; the harness auto-discovers them via `--list-investigations`, so no `debug_helper.sh` change is required.

Static investigations (e.g. `barrier_visualization`) read an IR dump. CUTracer is dynamic — it runs the kernel under NVBit instrumentation — so it needs a reproduction command, not an IR file. These subagents read the reproduce command from the context file the wrapper passes (its `shared-context.md`: goal / IR path / reproduce command) or a `shared-context.md` beside the `<ir-path>`; the `<ir-path>` slot itself still carries the IR dump as context. No harness interface change is needed.

New subagents:
- `cutracer_data_race`: captures a `reg_trace,tma_trace` trace — the contract the data-race detectors expect (`reg_trace` drives RAW consumer-read detection, `tma_trace` supplies region sizes and the cross-proxy `proxy_fence`/`clc_release` detectors); `mem_value_trace` is an optional heavier follow-up for value-level evidence. Then runs `analyze data-race` (structural detection on a single trace, no pass/fail script needed).
- `cutracer_deadlock`: captures a hanging-kernel `reg_trace` (per-record flush + no-data timeout) and runs `analyze deadlock`.

Both `analyze` steps keep `--ai` on so CUTracer's specialized `DataRaceReasoner`/`DeadlockReasoner` runs its Phase-2 root-cause analysis (markdown report via `-o`), falling back to `--no-ai --format json` only when the `claude` CLI is unavailable.

CLI resolution follows the current `cutracer-overview` skill: prefer a `cutracer` binary on PATH, install it with `feature install cutracer` when missing (the recommended path — a prebuilt, arch-agnostic fatbin decoupled from the checkout), and fall back to `buck2 run fbcode//triton/tools/CUTracer:cutracer -c fbcode.nvcc_arch=<h100a|b200a|b300a>` only when modifying CUTracer or the feature can't be installed. Each subagent carries a `needs_gpu=true` metadata comment that the GPU-aware scheduler (follow-up diff) consumes.

Authored with Claude Code.

Differential Revision: D109064843
