### PR TITLE
[ci] add b200 runner

### DIFF
--- a/.github/workflows/b200.yml
+++ b/.github/workflows/b200.yml
@@ -1,0 +1,209 @@
+name: Meta Triton B200 Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # Every 6 hours at :30 past (00:30, 06:30, 12:30, 18:30 UTC).
+    - cron: '30 */6 * * *'
+
+jobs:
+  b200-meta-triton-test:
+    if: github.repository_owner == 'facebookexperimental'
+    runs-on: nvidia-dgx-b200
+    env:
+      CONDA_ENV: meta-triton
+      SETUP_SCRIPT: /workspace/setup_instance.sh
+    timeout-minutes: 240
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      failures: ${{ steps.collect.outputs.failures }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Tune Nvidia GPU
+        run: |
+          sudo nvidia-smi -pm 1
+          sudo ldconfig
+          nvidia-smi
+      - name: Compile Triton
+        run: |
+          . "${SETUP_SCRIPT}"
+          . /workspace/tritonbench/.ci/triton/triton_install_utils.sh
+          install_triton $PWD
+          set -x
+          TRITONBENCH_TRITON_COMMIT_HASH=$(git rev-parse --verify HEAD)
+          TRITONBENCH_TRITON_REPO=$(git config --get remote.origin.url | sed -E 's|.*github.com[:/](.+)\.git|\1|')
+          TRITONBENCH_TRITON_COMMIT=${GITHUB_REF_NAME}
+          TRITONBENCH_INSTALL_DIR=${PWD}
+          # If the current conda env matches the env we just created
+          # then export all Triton related envs to shell env
+          cat <<EOF >> "${SETUP_SCRIPT}"
+          if [ \${CONDA_ENV} == "${CONDA_ENV}" ] ; then
+              export TRITONBENCH_TRITON_COMMIT_HASH="${TRITONBENCH_TRITON_COMMIT_HASH}"
+              export TRITONBENCH_TRITON_REPO="${TRITONBENCH_TRITON_REPO}"
+              export TRITONBENCH_TRITON_COMMIT="${TRITONBENCH_TRITON_COMMIT}"
+              export TRITONBENCH_TRITON_INSTALL_DIR="${TRITONBENCH_INSTALL_DIR}"
+          fi
+          EOF
+      - name: Run TritonBench tests on B200 GPU
+        id: tritonbench
+        env:
+          TRITONBENCH_TEST_SKIP_FILE: ${{ github.workspace }}/.ci/tritonbench/fbtriton_skip_tests.yaml
+          TRITONBENCH_ROOT: /workspace/tritonbench
+        run: |
+          . "${SETUP_SCRIPT}"
+          bash ./.ci/tritonbench/test-gpu.sh
+      - name: Collect nightly failure (TritonBench)
+        id: collect
+        if: always() && github.event_name == 'schedule' && failure()
+        run: |
+          # TritonBench output is not a stable per-test format, so fall back to a
+          # stable logical bucket identity for this job.
+          BUCKET="b200-tritonbench"
+          TITLE="[nightly] ${GITHUB_WORKFLOW} / b200-meta-triton-test / ${BUCKET}"
+          FAILURES='[{"normalized_failure_id":"'"${BUCKET}"'","raw_failure_ids":"","issue_title":"'"${TITLE}"'","job_name":"b200-meta-triton-test","summary":"TritonBench tests failed on B200 (see run log).","repro":""}]'
+          echo "failures=${FAILURES}" >> "$GITHUB_OUTPUT"
+
+  b200-tlx-test:
+    if: github.repository_owner == 'facebookexperimental'
+    runs-on: nvidia-dgx-b200
+    env:
+      CONDA_ENV: meta-triton
+      SETUP_SCRIPT: /workspace/setup_instance.sh
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      failures: ${{ steps.parse.outputs.failures }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Tune Nvidia GPU
+        run: |
+          sudo nvidia-smi -pm 1
+          sudo ldconfig
+          nvidia-smi
+      - name: Compile Triton
+        run: |
+          . "${SETUP_SCRIPT}"
+          . /workspace/tritonbench/.ci/triton/triton_install_utils.sh
+          install_triton $PWD
+          uv pip install pytest
+      - name: Install torchao from source
+        run: |
+          . "${SETUP_SCRIPT}"
+          uv pip install --no-build-isolation --no-deps "git+https://github.com/pytorch/ao.git"
+          python -c 'from torchao.prototype.mx_formats.mx_tensor import MXTensor, ScaleCalculationMode'
+      - name: Run TLX unit tests
+        id: run_unit_tests
+        timeout-minutes: 5
+        run: |
+          . "${SETUP_SCRIPT}"
+          python -m pytest python/test/unit/language/test_tlx_*.py -v --junitxml=/tmp/tlx-unit.xml
+      - name: Run TLX tutorial correctness tests
+        id: run_correctness_tests
+        timeout-minutes: 5
+        run: |
+          . "${SETUP_SCRIPT}"
+          python -m pytest third_party/tlx/tutorials/testing/test_correctness.py -v --junitxml=/tmp/tlx-correctness.xml
+      - name: Collect nightly failures (TLX)
+        id: parse
+        if: always() && github.event_name == 'schedule'
+        run: |
+          . "${SETUP_SCRIPT}"
+          FAILED_FLAG=""
+          if [[ "${{ steps.run_unit_tests.outcome }}" != "success" || "${{ steps.run_correctness_tests.outcome }}" != "success" ]]; then
+            FAILED_FLAG="--failed --bucket b200-tlx-job-failed"
+          fi
+          python3 .github/scripts/parse_junit_failures.py \
+            --junit /tmp/tlx-unit.xml /tmp/tlx-correctness.xml \
+            --workflow "${GITHUB_WORKFLOW}" \
+            --job "b200-tlx-test" \
+            ${FAILED_FLAG}
+
+  # ----- Nightly issue filing (schedule only) -----
+  report-b200-tritonbench:
+    needs: b200-meta-triton-test
+    if: always() && github.event_name == 'schedule' && needs.b200-meta-triton-test.outputs.failures != '' && needs.b200-meta-triton-test.outputs.failures != '[]'
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      fail-fast: false
+      matrix:
+        item: ${{ fromJSON(needs.b200-meta-triton-test.outputs.failures) }}
+    uses: ./.github/workflows/report-nightly-failure.yml
+    with:
+      issue_title: ${{ matrix.item.issue_title }}
+      normalized_failure_id: ${{ matrix.item.normalized_failure_id }}
+      raw_failure_ids: ${{ matrix.item.raw_failure_ids }}
+      workflow_name: ${{ github.workflow }}
+      job_name: ${{ matrix.item.job_name }}
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      ref: ${{ github.ref }}
+      sha: ${{ github.sha }}
+      event_name: ${{ github.event_name }}
+      run_attempt: ${{ github.run_attempt }}
+      summary: ${{ matrix.item.summary }}
+      repro: ${{ matrix.item.repro }}
+
+  report-b200-tlx:
+    needs: b200-tlx-test
+    if: always() && github.event_name == 'schedule' && needs.b200-tlx-test.outputs.failures != '' && needs.b200-tlx-test.outputs.failures != '[]'
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      fail-fast: false
+      matrix:
+        item: ${{ fromJSON(needs.b200-tlx-test.outputs.failures) }}
+    uses: ./.github/workflows/report-nightly-failure.yml
+    with:
+      issue_title: ${{ matrix.item.issue_title }}
+      normalized_failure_id: ${{ matrix.item.normalized_failure_id }}
+      raw_failure_ids: ${{ matrix.item.raw_failure_ids }}
+      workflow_name: ${{ github.workflow }}
+      job_name: ${{ matrix.item.job_name }}
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      ref: ${{ github.ref }}
+      sha: ${{ github.sha }}
+      event_name: ${{ github.event_name }}
+      run_attempt: ${{ github.run_attempt }}
+      summary: ${{ matrix.item.summary }}
+      repro: ${{ matrix.item.repro }}
+
+  # ----- Nightly issue reconciliation: close recovered issues (schedule only) -----
+  reconcile-b200-tritonbench:
+    needs: b200-meta-triton-test
+    if: always() && github.event_name == 'schedule' && (needs.b200-meta-triton-test.result == 'success' || needs.b200-meta-triton-test.result == 'failure')
+    permissions:
+      contents: read
+      issues: write
+    uses: ./.github/workflows/reconcile-nightly-issues.yml
+    with:
+      workflow_name: ${{ github.workflow }}
+      job_name: b200-meta-triton-test
+      failures: ${{ needs.b200-meta-triton-test.outputs.failures }}
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  reconcile-b200-tlx:
+    needs: b200-tlx-test
+    if: always() && github.event_name == 'schedule' && (needs.b200-tlx-test.result == 'success' || needs.b200-tlx-test.result == 'failure')
+    permissions:
+      contents: read
+      issues: write
+    uses: ./.github/workflows/reconcile-nightly-issues.yml
+    with:
+      workflow_name: ${{ github.workflow }}
+      job_name: b200-tlx-test
+      failures: ${{ needs.b200-tlx-test.outputs.failures }}
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true

--- a/infra/b200-values.yaml
+++ b/infra/b200-values.yaml
@@ -1,0 +1,252 @@
+## githubConfigUrl is the GitHub url for where you want to configure runners
+## ex: https://github.com/myorg/myrepo or https://github.com/myorg
+githubConfigUrl: "https://github.com/facebookexperimental"
+runnerGroup: "tritonbench-runners"
+
+## githubConfigSecret is the k8s secrets to use when auth with GitHub API.
+## You can choose to use GitHub App or a PAT token
+## githubConfigSecret:
+  ### GitHub Apps Configuration
+  ## NOTE: IDs MUST be strings, use quotes
+  #github_app_id: ""
+  #github_app_installation_id: ""
+  #github_app_private_key: |
+
+  ### GitHub PAT Configuration
+  ### github_token: ""
+## If you have a pre-define Kubernetes secret in the same namespace the gha-runner-scale-set is going to deploy,
+## you can also reference it via `githubConfigSecret: pre-defined-secret`.
+## You need to make sure your predefined secret has all the required secret data set properly.
+##   For a pre-defined secret using GitHub PAT, the secret needs to be created like this:
+##   > kubectl create secret generic pre-defined-secret --namespace=my_namespace --from-literal=github_token='ghp_your_pat'
+##   For a pre-defined secret using GitHub App, the secret needs to be created like this:
+##   > kubectl create secret generic pre-defined-secret --namespace=my_namespace --from-literal=github_app_id=123456 --from-literal=github_app_installation_id=654321 --from-literal=github_app_private_key='-----BEGIN CERTIFICATE-----*******'
+githubConfigSecret: arc-secret
+
+## proxy can be used to define proxy settings that will be used by the
+## controller, the listener and the runner of this scale set.
+#
+# proxy:
+#   http:
+#     url: http://proxy.com:1234
+#     credentialSecretRef: proxy-auth # a secret with `username` and `password` keys
+#   https:
+#     url: http://proxy.com:1234
+#     credentialSecretRef: proxy-auth # a secret with `username` and `password` keys
+#   noProxy:
+#     - example.com
+#     - example.org
+
+## maxRunners is the max number of runners the autoscaling runner set will scale up to.
+maxRunners: 8
+
+## minRunners is the min number of idle runners. The target number of runners created will be
+## calculated as a sum of minRunners and the number of jobs assigned to the scale set.
+minRunners: 1
+
+# runnerGroup: "default"
+
+## name of the runner scale set to create.  Defaults to the helm release name
+# runnerScaleSetName: ""
+
+## A self-signed CA certificate for communication with the GitHub server can be
+## provided using a config map key selector. If `runnerMountPath` is set, for
+## each runner pod ARC will:
+## - create a `github-server-tls-cert` volume containing the certificate
+##   specified in `certificateFrom`
+## - mount that volume on path `runnerMountPath`/{certificate name}
+## - set NODE_EXTRA_CA_CERTS environment variable to that same path
+## - set RUNNER_UPDATE_CA_CERTS environment variable to "1" (as of version
+##   2.303.0 this will instruct the runner to reload certificates on the host)
+##
+## If any of the above had already been set by the user in the runner pod
+## template, ARC will observe those and not overwrite them.
+## Example configuration:
+#
+# githubServerTLS:
+#   certificateFrom:
+#     configMapKeyRef:
+#       name: config-map-name
+#       key: ca.crt
+#   runnerMountPath: /usr/local/share/ca-certificates/
+
+## Container mode is an object that provides out-of-box configuration
+## for dind and kubernetes mode. Template will be modified as documented under the
+## template object.
+##
+## If any customization is required for dind or kubernetes mode, containerMode should remain
+## empty, and configuration should be applied to the template.
+# containerMode:
+#   type: "dind"  ## type can be set to dind or kubernetes
+#   ## the following is required when containerMode.type=kubernetes
+#   kubernetesModeWorkVolumeClaim:
+#     accessModes: ["ReadWriteOnce"]
+#     # For local testing, use https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/quickstart.md to provide dynamic provision volume with storageClassName: openebs-hostpath
+#     storageClassName: "dynamic-blob-storage"
+#     resources:
+#       requests:
+#         storage: 1Gi
+#   kubernetesModeServiceAccount:
+#     annotations:
+
+## template is the PodSpec for each listener Pod
+## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+# listenerTemplate:
+#   spec:
+#     containers:
+#     # Use this section to append additional configuration to the listener container.
+#     # If you change the name of the container, the configuration will not be applied to the listener,
+#     # and it will be treated as a side-car container.
+#     - name: listener
+#       securityContext:
+#         runAsUser: 1000
+#     # Use this section to add the configuration of a side-car container.
+#     # Comment it out or remove it if you don't need it.
+#     # Spec for this container will be applied as is without any modifications.
+#     - name: side-car
+#       image: example-sidecar
+
+## template is the PodSpec for each runner Pod
+## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+template:
+  ## template.spec will be modified if you change the container mode
+  ## with containerMode.type=dind, we will populate the template.spec with following pod spec
+  ## template:
+  # spec:
+  #   initContainers:
+  #   - name: init-dind-externals
+  #     image: ghcr.io/actions/actions-runner:latest
+  #     command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
+  #     volumeMounts:
+  #       - name: dind-externals
+  #         mountPath: /home/runner/tmpDir
+  #   containers:
+  #   - name: runner
+  #     image: ghcr.io/actions/actions-runner:latest
+  #     command: ["/home/runner/run.sh"]
+  #     env:
+  #       - name: DOCKER_HOST
+  #         value: unix:///run/docker/docker.sock
+  #     volumeMounts:
+  #       - name: work
+  #         mountPath: /home/runner/_work
+  #       - name: dind-sock
+  #         mountPath: /run/docker
+  #         readOnly: true
+  #   - name: dind
+  #     image: teracy/ubuntu:20.04-dind-latest
+  #     command: ["sh", "-c", "cp -r /usr/bin/nvidia/* /usr/bin && cp -r /usr/lib/x86_64-linux-gnu/nvidia/* /usr/lib/x86_64-linux-gnu && dockerd --host=unix:///run/docker/docker.sock --group=$(DOCKER_GROUP_GID)"]
+  #     env:
+  #       - name: DOCKER_GROUP_GID
+  #         value: "123"
+  #     securityContext:
+  #       privileged: true
+  #     volumeMounts:
+  #       - name: work
+  #         mountPath: /home/runner/_work
+  #       - name: dind-sock
+  #         mountPath: /run/docker
+  #       - name: dind-externals
+  #         mountPath: /home/runner/externals
+  #       - name: nvidia-lib
+  #         mountPath: /usr/lib/x86_64-linux-gnu/nvidia
+  #       - name: nvidia-bin
+  #         mountPath: /usr/bin/nvidia
+  #       - name: nvidia-card
+  #         mountPath: /dev/nvidia0
+  #       - name: nvidia-uvm
+  #         mountPath: /dev/nvidia-uvm
+  #       - name: nvidia-ctl
+  #         mountPath: /dev/nvidiactl
+  #       - name: dshm
+  #         mountPath: /dev/shm
+  #   volumes:
+  #   - name: work
+  #     emptyDir: {}
+  #   - name: dind-sock
+  #     emptyDir: {}
+  #   - name: dind-externals
+  #     emptyDir: {}
+  #   - name: nvidia-lib
+  #     hostPath:
+  #       path: /opt/nvidia/lib64
+  #       type: Directory
+  #   - name: nvidia-bin
+  #     hostPath:
+  #       path: /opt/nvidia/bin
+  #       type: Directory
+  #   - name: nvidia-card
+  #     hostPath:
+  #       path: /dev/nvidia0
+  #       type: CharDevice
+  #   - name: nvidia-uvm
+  #     hostPath:
+  #       path: /dev/nvidia-uvm
+  #       type: CharDevice
+  #   - name: nvidia-ctl
+  #     hostPath:
+  #       path: /dev/nvidiactl
+  #       type: CharDevice
+  #   - name: dshm
+  #     emptyDir:
+  #       medium: Memory
+  ######################################################################################################
+  ## with containerMode.type=kubernetes, we will populate the template.spec with following pod spec
+  ## template:
+  ##   spec:
+  ##     containers:
+  ##     - name: runner
+  ##       image: ghcr.io/actions/actions-runner:latest
+  ##       command: ["/home/runner/run.sh"]
+  ##       env:
+  ##         - name: ACTIONS_RUNNER_CONTAINER_HOOKS
+  ##           value: /home/runner/k8s/index.js
+  ##         - name: ACTIONS_RUNNER_POD_NAME
+  ##           valueFrom:
+  ##             fieldRef:
+  ##               fieldPath: metadata.name
+  ##         - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+  ##           value: "true"
+  ##       volumeMounts:
+  ##         - name: work
+  ##           mountPath: /home/runner/_work
+  ##     volumes:
+  ##       - name: work
+  ##         ephemeral:
+  ##           volumeClaimTemplate:
+  ##             spec:
+  ##               accessModes: [ "ReadWriteOnce" ]
+  ##               storageClassName: "local-path"
+  ##               resources:
+  ##                 requests:
+  ##                   storage: 1Gi
+  spec:
+    #    runtimeClassName: nvidia
+    containers:
+    - name: runner
+      # image: ghcr.io/actions/actions-runner:latest
+      image: ghcr.io/meta-pytorch/tritonbench:latest
+      command: ["sh", "-c", "bash /home/runner/run.sh"]
+      securityContext:
+        privileged: false
+        capabilities:
+          add:
+            # Required for debugging
+            - SYS_PTRACE
+            # Required for frequency/power setup
+            - SYS_ADMIN
+      resources:
+        requests:
+          nvidia.com/gpu: 1 # requesting 1 GPU
+        limits:
+          nvidia.com/gpu: 1 # limiting 1 GPU
+## Optional controller service account that needs to have required Role and RoleBinding
+## to operate this gha-runner-scale-set installation.
+## The helm chart will try to find the controller deployment and its service account at installation time.
+## In case the helm chart can't find the right service account, you can explicitly pass in the following value
+## to help it finish RoleBinding with the right service account.
+## Note: if your controller is installed to only watch a single namespace, you have to pass these values explicitly.
+# controllerServiceAccount:
+#   namespace: arc-system
+#   name: test-arc-gha-runner-scale-set-controller
+


### PR DESCRIPTION
Now that NVIDIA B200 runner is online, we can setup the B200 runner workflows for OSS.

<img width="1576" height="503" alt="image" src="https://github.com/user-attachments/assets/1dd6e842-c689-4350-b58d-1aa0b72bf2db" />

Notes on setting up K8s host:

1. Use nvidia-runtime-docker for resource isolation
2. Use nvidia-device-plugin daemonset to interact with k3s
3. b200-value.yaml must set `privileged: false`, otherwise, each pod will still see 8 GPUs.