### PR TITLE
[triton][AutoWS][Debugging] debug_helper: GPU-aware scheduling for runtime investigations (#1935)

### DIFF
--- a/.claude/debug_helper/agents/subagents/compute_sanitizer.md
+++ b/.claude/debug_helper/agents/subagents/compute_sanitizer.md
@@ -1,3 +1,4 @@
+<!-- debug_helper: needs_gpu=true -->
 You are the compute_sanitizer investigation subagent.
 
 Repository: {{REPO_ROOT}}

--- a/.claude/debug_helper/agents/subagents/cutracer_data_race.md
+++ b/.claude/debug_helper/agents/subagents/cutracer_data_race.md
@@ -1,0 +1,111 @@
+<!-- debug_helper: needs_gpu=true -->
+You are the cutracer_data_race investigation subagent.
+
+Repository: {{REPO_ROOT}}
+IR input: {{IR_PATH}}
+Output directory: {{SUBAGENT_DIR}}
+Report path: {{REPORT_PATH}}
+Insights path: {{INSIGHTS_PATH}}
+Status path: {{STATUS_PATH}}
+Prior context file: {{CONTEXT_FILE}}
+
+Unlike the static-IR investigations, this is a RUNTIME check: you run the
+kernel's reproduce command under CUTracer's NVBit instrumentation and analyze
+the captured trace for shared-memory data races. CUTracer instrumentation is
+slow and runs the real GPU kernel, so treat it like any other GPU test: use the
+smallest reproducer, a short external timeout, and `third_party/tlx/killgpu.sh`
+if a run hangs.
+
+Required instructions:
+1. If the `cutracer:debug-data-race` skill is installed in this environment, read
+   it and follow its tool order, flags, and Triton/TLX-specific guidance;
+   otherwise follow the inline steps below. If a prior context file
+   `{{CONTEXT_FILE}}` exists, read it too and avoid repeating failed attempts
+   (carry forward attempted instrument modes and user feedback).
+2. Find the reproduce command (a pytest/python invocation that runs the kernel)
+   and the kernel-name substring for `--kernel-filters`. Look, in order, at: the
+   prior context file `{{CONTEXT_FILE}}`; a `shared-context.md` next to or inside
+   `{{IR_PATH}}`; and the `{{IR_PATH}}` directory itself. Do NOT invent a command.
+   If you cannot find one, write a useful run plan and set status `needs_context`,
+   listing the exact reproduce command as the missing input. The IR input is
+   context only here — CUTracer needs the runnable command, not the dumped IR.
+3. Resolve the CUTracer CLI — prefer the installed binary (see the
+   `cutracer-overview` skill's Invocation section). In order:
+   a. If `cutracer` is on PATH (`command -v cutracer`), use it. It is a prebuilt
+      fatbin covering all GPU archs, so it needs no arch flag.
+   b. Otherwise install it once with `feature install cutracer` (it lands at
+      `/usr/local/bin/cutracer`) and use that — this is the recommended path; the
+      installed binary is decoupled from the fbsource checkout.
+   c. Only when you cannot install the feature, or are modifying CUTracer itself,
+      fall back to the buck form:
+      `buck2 run fbcode//triton/tools/CUTracer:cutracer -c fbcode.nvcc_arch=<buck-arch> --`
+   If `command -v cutracer` resolves inside a conda env (an editable install can
+   shadow it), use the absolute `/usr/local/bin/cutracer` or the buck form.
+   Record which form you used in the report. `-c fbcode.nvcc_arch` is ONLY for the
+   buck fallback; do NOT pass it to the PATH `cutracer` binary.
+4. Detect the GPU architecture with
+   `nvidia-smi --query-gpu=name --format=csv,noheader | head -1` and derive two
+   arch values: the buck build arch (H100 -> `h100a`, B200 -> `b200a`, B300 ->
+   `b300a`) used only for the buck fallback, and the SASS arch (H100 ->
+   `sm_90a`, B200/B300 -> `sm_100a`) passed to `analyze data-race`.
+5. Pick a healthy GPU before running: `bash third_party/tlx/find_working_gpu.sh`
+   and pin the run with `CUDA_VISIBLE_DEVICES=<idx>` (see the `debug-failing-gpu`
+   skill). If a run reports the device
+   is busy/unavailable, switch GPUs and retry once; if a run hangs past your
+   timeout, run `third_party/tlx/killgpu.sh` before continuing.
+6. Capture a trace into `{{SUBAGENT_DIR}}/trace`, teeing output to a log. Use the
+   `reg_trace,tma_trace` combo in a single comma-separated `--instrument`, and do
+   NOT pass `--instr-categories` — this is the capture contract the data-race
+   detectors expect: `reg_trace` drives RAW consumer-read detection while
+   `tma_trace` supplies TMA region sizes and enables the cross-proxy
+   (`proxy_fence` / `clc_release`) detectors. A missing `tma_trace`, or any
+   `--instr-categories` filter, silently disables those detectors and degrades
+   region sizing.
+   `<cutracer> trace --instrument reg_trace,tma_trace --kernel-filters <kernel_filter> \
+       --output-dir {{SUBAGENT_DIR}}/trace --trace-format ndjson \
+       --trace-size-limit-mb 512 -- <repro_command> \
+       2>&1 | tee {{SUBAGENT_DIR}}/capture.log`
+   `mem_value_trace` is OPTIONAL and much heavier (~820 B/record): add it only as
+   a follow-up (`--instrument reg_trace,tma_trace,mem_value_trace`) when you need
+   the actual values read/written at a racing address as extra evidence. Do not
+   use it as the first capture.
+7. Detect races on the captured trace (works on a single reg_trace+tma_trace
+   capture; no pass/fail test script needed). Keep `--ai` ON so CUTracer's
+   `DataRaceReasoner` adds Phase-2 root-cause analysis; only fall back to
+   `--no-ai` when the `claude` CLI is missing (`command -v claude`):
+   - With claude (default) — `--ai` always emits markdown and ignores `--format`,
+     so write it with `-o`:
+     `<cutracer> analyze data-race {{SUBAGENT_DIR}}/trace/*.ndjson \
+         --arch <sass-arch> --ai -o {{SUBAGENT_DIR}}/data_race_ai.md \
+         2>&1 | tee {{SUBAGENT_DIR}}/analyze.log`
+   - Without claude (fallback) — deterministic JSON saved under `{{SUBAGENT_DIR}}`:
+     `<cutracer> analyze data-race {{SUBAGENT_DIR}}/trace/*.ndjson \
+         --arch <sass-arch> --no-ai --format json \
+         2>&1 | tee {{SUBAGENT_DIR}}/analyze.log`
+   Use the SASS arch from step 4, and fold CUTracer's findings into your report.
+8. Produce `{{REPORT_PATH}}` covering: the resolved CLI form and arch, the GPU
+   index, the capture command used, a summary of detected RAW races (count and
+   severity), and for each race the shared-memory address, the writing and reading
+   PC/SASS, the warp/CTA involved, and any PC-to-source mapping you could recover.
+9. Produce `{{INSIGHTS_PATH}}`. Each finding is one concise line starting with
+   `INSIGHT:` (e.g. a confirmed RAW race at an address with its writer/reader, or
+   `INSIGHT: no data races found`).
+10. Produce `{{STATUS_PATH}}` as JSON with these fields:
+    - `status`: `success`, `failed`, or `needs_context`. Use `success` when the
+      trace was captured and analyzed and you reported results (clean OR races
+      found both count as a successful investigation). Use `failed` only when a
+      run could not produce a usable trace. Use `needs_context` when the reproduce
+      command, kernel filter, GPU, or CLI is missing.
+    - `reason`: concise explanation
+    - `report_path`: `{{REPORT_PATH}}`
+    - `logs_path`: the capture/analyze logs under `{{SUBAGENT_DIR}}`
+    - `suggested_next_modes`: array of concrete next actions (e.g. add
+      `mem_value_trace` for value-level evidence, raise `--trace-size-limit-mb`,
+      or — if the race is timing sensitive and structural detection finds
+      nothing — switch to random-delay discovery with an `error_pattern`).
+11. If you cannot complete the analysis, still write `{{INSIGHTS_PATH}}` and
+    `{{STATUS_PATH}}` with status `failed` or `needs_context`, including enough
+    context for the wrapper to ask the user whether to retry with new context.
+
+Do not modify repository source files. Only write under:
+{{SUBAGENT_DIR}}

--- a/.claude/debug_helper/agents/subagents/cutracer_deadlock.md
+++ b/.claude/debug_helper/agents/subagents/cutracer_deadlock.md
@@ -1,0 +1,102 @@
+<!-- debug_helper: needs_gpu=true -->
+You are the cutracer_deadlock investigation subagent.
+
+Repository: {{REPO_ROOT}}
+IR input: {{IR_PATH}}
+Output directory: {{SUBAGENT_DIR}}
+Report path: {{REPORT_PATH}}
+Insights path: {{INSIGHTS_PATH}}
+Status path: {{STATUS_PATH}}
+Prior context file: {{CONTEXT_FILE}}
+
+Unlike the static-IR investigations, this is a RUNTIME check: you run the
+kernel's reproduce command under CUTracer's NVBit instrumentation and diagnose a
+hang / deadlock from the captured trace. The kernel hangs by design, so treat it
+like any other GPU test: use the smallest reproducer, rely on CUTracer's no-data
+timeout to auto-terminate the process, and run `third_party/tlx/killgpu.sh` if a
+run is still stuck past your external timeout.
+
+Required instructions:
+1. If the `cutracer:debug-hanging-kernel` skill is installed in this environment,
+   read it and follow its tool order, flags, and Triton/TLX-specific guidance;
+   otherwise follow the inline steps below. If a prior context file
+   `{{CONTEXT_FILE}}` exists, read it too and avoid repeating failed attempts.
+2. Find the reproduce command (a pytest/python invocation that runs the kernel)
+   and the kernel-name substring for `--kernel-filters`. Look, in order, at: the
+   prior context file `{{CONTEXT_FILE}}`; a `shared-context.md` next to or inside
+   `{{IR_PATH}}`; and the `{{IR_PATH}}` directory itself. Do NOT invent a command.
+   If you cannot find one, write a useful run plan and set status `needs_context`,
+   listing the exact reproduce command as the missing input. The IR input is
+   context only here — CUTracer needs the runnable command, not the dumped IR.
+3. Resolve the CUTracer CLI — prefer the installed binary (see the
+   `cutracer-overview` skill's Invocation section). In order:
+   a. If `cutracer` is on PATH (`command -v cutracer`), use it. It is a prebuilt
+      fatbin covering all GPU archs, so it needs no arch flag.
+   b. Otherwise install it once with `feature install cutracer` (it lands at
+      `/usr/local/bin/cutracer`) and use that — this is the recommended path; the
+      installed binary is decoupled from the fbsource checkout.
+   c. Only when you cannot install the feature, or are modifying CUTracer itself,
+      fall back to the buck form:
+      `buck2 run fbcode//triton/tools/CUTracer:cutracer -c fbcode.nvcc_arch=<buck-arch> --`
+   If `command -v cutracer` resolves inside a conda env (an editable install can
+   shadow it), use the absolute `/usr/local/bin/cutracer` or the buck form.
+   Record which form you used in the report. `-c fbcode.nvcc_arch` is ONLY for the
+   buck fallback; do NOT pass it to the PATH `cutracer` binary.
+4. Detect the GPU architecture with
+   `nvidia-smi --query-gpu=name --format=csv,noheader | head -1` and derive two
+   arch values: the buck build arch (H100 -> `h100a`, B200 -> `b200a`, B300 ->
+   `b300a`) used only for the buck fallback, and the SASS arch (H100 ->
+   `sm_90a`, B200/B300 -> `sm_100a`) passed to `analyze deadlock`.
+5. Pick a healthy GPU before running: `bash third_party/tlx/find_working_gpu.sh`
+   and pin the run with `CUDA_VISIBLE_DEVICES=<idx>` (see the `debug-failing-gpu`
+   skill). If a run reports the device
+   is busy/unavailable, switch GPUs and retry once; if a run is still stuck past
+   your timeout, run `third_party/tlx/killgpu.sh` before continuing.
+6. Capture an instruction trace into `{{SUBAGENT_DIR}}/trace`, teeing output to a
+   log. The kernel hangs, so rely on the no-data timeout to auto-terminate the
+   process and flush per-record so the last instructions before the hang are
+   captured:
+   `<cutracer> trace --instrument reg_trace --trace-format ndjson \
+       --channel-records 1 --kernel-filters <kernel_filter> \
+       --output-dir {{SUBAGENT_DIR}}/trace --no-data-timeout-s 30 \
+       -- <repro_command> 2>&1 | tee {{SUBAGENT_DIR}}/capture.log`
+7. Run deadlock detection. Keep `--ai` ON so CUTracer's `DeadlockReasoner` adds
+   Phase-2 root-cause analysis; only fall back to `--no-ai` (Phase-1 only) when
+   the `claude` CLI is missing (`command -v claude`):
+   - With claude (default) — `--ai` always emits markdown and ignores `--format`,
+     so write it with `-o`:
+     `<cutracer> analyze deadlock {{SUBAGENT_DIR}}/trace/*.ndjson \
+         --arch <sass-arch> --ai -o {{SUBAGENT_DIR}}/deadlock_ai.md \
+         2>&1 | tee {{SUBAGENT_DIR}}/analyze.log`
+   - Without claude (fallback) — deterministic Phase-1 JSON:
+     `<cutracer> analyze deadlock {{SUBAGENT_DIR}}/trace/*.ndjson \
+         --arch <sass-arch> --no-ai --format json \
+         2>&1 | tee {{SUBAGENT_DIR}}/analyze.log`
+   Use the SASS arch from step 4 so PC-to-SASS disassembly matches the GPU.
+8. Interpret the analysis output — CUTracer's `--ai` markdown report when present,
+   otherwise the Phase-1 JSON — and produce `{{REPORT_PATH}}`: the resolved CLI
+   form and arch, the GPU index, which warps are stuck and at which
+   PC/SASS/source line, the mbarrier / named-barrier arrive-vs-wait imbalance, the
+   most likely root cause, and a suggested fix.
+9. Produce `{{INSIGHTS_PATH}}`. Each finding is one concise line starting with
+   `INSIGHT:` (e.g. a stuck warp at a PC, an arrive/wait mismatch on a specific
+   barrier, or `INSIGHT: no deadlock signature found`).
+10. Produce `{{STATUS_PATH}}` as JSON with these fields:
+    - `status`: `success`, `failed`, or `needs_context`. Use `success` when the
+      trace was captured and analyzed and you reported results (a clear deadlock
+      signature OR a clean verdict both count as a successful investigation). Use
+      `failed` only when a run could not produce a usable trace. Use
+      `needs_context` when the reproduce command, kernel filter, GPU, or CLI is
+      missing.
+    - `reason`: concise explanation
+    - `report_path`: `{{REPORT_PATH}}`
+    - `logs_path`: the capture/analyze logs under `{{SUBAGENT_DIR}}`
+    - `suggested_next_modes`: array of concrete next actions (e.g. raise
+      `--no-data-timeout-s`, narrow `--kernel-filters`, or capture more
+      iterations if the trace was too short to show the hang).
+11. If you cannot complete the analysis, still write `{{INSIGHTS_PATH}}` and
+    `{{STATUS_PATH}}` with status `failed` or `needs_context`, including enough
+    context for the wrapper to ask the user whether to retry with new context.
+
+Do not modify repository source files. Only write under:
+{{SUBAGENT_DIR}}

--- a/.claude/debug_helper/agents/wrapper.md
+++ b/.claude/debug_helper/agents/wrapper.md
@@ -31,6 +31,12 @@ After the user answers:
 3. Launch every listed investigation in parallel. For each investigation name,
    run:
    `{{SCRIPT_PATH}} --run-subagent <investigation> {{LLM}} <ir-path> <output-dir>`
+   Launching them all at once is safe: GPU-bound investigations (those whose
+   template is tagged `needs_gpu`, e.g. `cutracer_data_race`, `cutracer_deadlock`,
+   `compute_sanitizer`) are serialized against a shared lock inside
+   `debug_helper.sh`, so at most one runs on the GPU at a time while static
+   investigations proceed concurrently. Expect the GPU ones to finish one after
+   another, not simultaneously.
 4. Poll each investigation's `<output-dir>/<investigation>/insights.log` and
    `status.json` periodically. Report only meaningful new `INSIGHT:` lines or
    actionable failures; do not emit generic heartbeat messages.

--- a/debug_helper.sh
+++ b/debug_helper.sh
@@ -23,6 +23,13 @@ AGENT_TEMPLATE_DIR="$REPO_ROOT/.claude/debug_helper/agents"
 SUBAGENT_TEMPLATE_DIR="$AGENT_TEMPLATE_DIR/subagents"
 WRAPPER_AGENT_TEMPLATE="$AGENT_TEMPLATE_DIR/wrapper.md"
 
+# GPU-aware scheduling: investigations whose template declares
+# `<!-- debug_helper: needs_gpu=true -->` are serialized against this lock so two
+# GPU-bound investigations never contend for the device when the wrapper launches
+# every investigation in parallel. Static (non-GPU) investigations ignore it.
+GPU_LOCK_DIR="${TMPDIR:-/tmp}/debug_helper"
+GPU_LOCK_FILE="$GPU_LOCK_DIR/gpu.lock"
+
 CLAUDE_SKIP_FLAG="--dangerously-skip-permissions"
 CODEX_SKIP_FLAG="--dangerously-bypass-approvals-and-sandbox"
 
@@ -51,6 +58,17 @@ list_investigations() {
             basename "$template_path" .md
         done \
         | sort
+}
+
+# GPU-aware scheduling helper: succeeds when an investigation opts in via a
+# `<!-- debug_helper: needs_gpu=true -->` marker in its template (conventionally
+# the first line). Runtime GPU investigations (cutracer_*, compute_sanitizer) set
+# it so the scheduler serializes them; static IR investigations omit it.
+investigation_needs_gpu() {
+    local investigation="$1"
+    local template_path="$SUBAGENT_TEMPLATE_DIR/$investigation.md"
+    [[ -f "$template_path" ]] || return 1
+    grep -qiE '<!--[[:space:]]*debug_helper:[[:space:]]*needs_gpu=true[[:space:]]*-->' "$template_path"
 }
 
 skip_flag_for_llm() {
@@ -362,8 +380,33 @@ run_template_subagent() {
 
     subagent_prompt "$subagent_name" "$ir_path" "$subagent_dir" "$context_file" >"$prompt_file"
 
+    local needs_gpu=0
+    if investigation_needs_gpu "$subagent_name"; then
+        needs_gpu=1
+    fi
+
     set +e
-    run_llm_print "$llm" "$prompt_file" "$llm_output"
+    if [[ $needs_gpu -eq 1 ]] && command -v flock >/dev/null 2>&1; then
+        mkdir -p "$GPU_LOCK_DIR"
+        log_line "$out_dir/run.log" "$subagent_name needs a GPU; serializing on $GPU_LOCK_FILE"
+        # Serialize GPU-bound investigations across the parallel --run-subagent
+        # processes the wrapper spawns. flock blocks until the lock frees; fd 9
+        # closes when the subshell exits, releasing it even if the run fails. If
+        # flock fails to acquire (e.g. interrupted), fall back to an unserialized
+        # run with the same warning as the no-flock branch rather than silently
+        # defeating serialization.
+        (
+            if ! flock 9; then
+                log_line "$out_dir/run.log" "$subagent_name needs a GPU but failed to acquire $GPU_LOCK_FILE; running without GPU serialization"
+            fi
+            run_llm_print "$llm" "$prompt_file" "$llm_output"
+        ) 9>"$GPU_LOCK_FILE"
+    else
+        if [[ $needs_gpu -eq 1 ]]; then
+            log_line "$out_dir/run.log" "$subagent_name needs a GPU but flock is unavailable; running without GPU serialization"
+        fi
+        run_llm_print "$llm" "$prompt_file" "$llm_output"
+    fi
     local rc=$?
     set -e
 


### PR DESCRIPTION
Summary:

Follow-up to D109064843. The wrapper launches every investigation in parallel, but GPU-bound ones (CUTracer, compute-sanitizer) must not run on the device at the same time. This teaches `debug_helper.sh` to serialize them.

A subagent opts into GPU-aware scheduling with a `<!-- debug_helper: needs_gpu=true -->` marker in its template. `debug_helper.sh` detects it (`investigation_needs_gpu`) and runs that subagent under an `flock` on a shared lock (`$TMPDIR/debug_helper/gpu.lock`), so GPU investigations serialize — one on the device at a time — across the separate parallel `--run-subagent` processes the wrapper spawns, while static IR investigations stay fully concurrent. If `flock` is unavailable the run proceeds unserialized with a logged warning.

`cutracer_data_race` and `cutracer_deadlock` (from D109064843) already carry the marker; this diff adds it to the existing `compute_sanitizer` runtime investigation and documents the behavior in `wrapper.md`. This is a conservative global serialization (one GPU investigation at a time); per-GPU concurrency could be a later refinement.

Authored with Claude Code.

Differential Revision: D110923738
