### PR TITLE
 [BE] [AutoWS] Refactor WarpSpecialization intra-pass declarations to a header (#1940)

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -5,6 +5,7 @@
 #include "mlir/Transforms/Passes.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
 #include "nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h"
+#include "nvidia/hopper/lib/Transforms/WarpSpecialization/WarpSpecializationPipeline.h"
 #include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Partition.h"
@@ -40,28 +41,6 @@ static LogicalResult cleanupWarpSpecializedLoops(Operation *op) {
   return applyPatternsGreedily(op, std::move(patterns));
 }
 
-int doTaskIdPropagate(triton::FuncOp &funcOp);
-// Cross-partition run-once atomic support. Returns failure() when an atomic
-// forces a graceful warp-specialization reject (kernel already de-specialized).
-LogicalResult doDynamicTileBroadcast(triton::FuncOp funcOp,
-                                     int tilePrefetchDepth);
-LogicalResult doMemoryPlanner(triton::FuncOp &funcOp, unsigned numBuffers,
-                              StringRef readDecisionFile = "",
-                              StringRef writeDecisionFile = "",
-                              int smemAllocAlgo = 1, unsigned smemBudget = 0,
-                              bool smemCircularReuse = false);
-void doBufferAllocation(triton::FuncOp &funcOp);
-void doHoistLoopInvariantTMEMStore(triton::FuncOp &funcOp);
-void removeRedundantTmemZeroStores(triton::FuncOp &funcOp);
-void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers);
-void doTokenLowering(triton::FuncOp &funcOp, unsigned numConsumerGroups);
-void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
-                    int capability, int defaultNumStages);
-void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups,
-                    int capability);
-void doTMAStoreWaitReorder(triton::FuncOp &funcOp);
-void doAnnotateTMAStoreWaits(triton::FuncOp &funcOp);
-void doValidateTMAStoreAnnotations(triton::FuncOp &funcOp);
 void doLowerSubtiledRegionsWithNVWSOps(triton::FuncOp &funcOp) {
   namespace ttng = triton::nvidia_gpu;
   namespace nvws = triton::nvws;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PingPong.cpp
@@ -24,6 +24,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Utility.h"
+#include "WarpSpecializationPipeline.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/IR/Location.h"
 #include "mlir/Pass/Pass.h"

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSAtomicBroadcast.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSAtomicBroadcast.cpp
@@ -32,6 +32,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CodePartitionUtility.h"
+#include "WarpSpecializationPipeline.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinAttributes.h"

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -1,6 +1,7 @@
 #include "CodePartitionUtility.h"
 #include "TMEMUtils.h"
 #include "WSBarrierAnalysis.h"
+#include "WarpSpecializationPipeline.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSHoistTMEMStore.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSHoistTMEMStore.cpp
@@ -1,3 +1,4 @@
+#include "WarpSpecializationPipeline.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
@@ -1,4 +1,5 @@
 #include "CodePartitionUtility.h"
+#include "WarpSpecializationPipeline.h"
 #include "mlir/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -1,4 +1,5 @@
 #include "CodePartitionUtility.h"
+#include "WarpSpecializationPipeline.h"
 #include "mlir/Analysis/Liveness.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Pass/Pass.h"
@@ -4050,11 +4051,12 @@ LogicalResult readDecisionsFromFile(SmallVector<Channel *> &channels,
   return success();
 }
 
+// Default arguments are declared in WarpSpecializationPipeline.h (the single
+// declaration site); they must not be repeated on the definition.
 LogicalResult doMemoryPlanner(triton::FuncOp &funcOp, unsigned numBuffers,
-                              StringRef readDecisionFile = "",
-                              StringRef writeDecisionFile = "",
-                              int smemAllocAlgo = 1, unsigned smemBudget = 0,
-                              bool smemCircularReuse = false) {
+                              StringRef readDecisionFile,
+                              StringRef writeDecisionFile, int smemAllocAlgo,
+                              unsigned smemBudget, bool smemCircularReuse) {
 
   // Step 1: collect all communications between producers and consumers.
   SmallVector<std::unique_ptr<Channel>> channelsOrigin;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -1,4 +1,5 @@
 #include "CodePartitionUtility.h"
+#include "WarpSpecializationPipeline.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskIdPropagate.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskIdPropagate.cpp
@@ -1,6 +1,7 @@
 #include "CodePartitionUtility.h"
 #include "TaskIdPropagation.h"
 #include "Utility.h"
+#include "WarpSpecializationPipeline.h"
 #include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
 #include "mlir/Analysis/DataFlowFramework.h"

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WarpSpecializationPipeline.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WarpSpecializationPipeline.h
@@ -1,0 +1,59 @@
+#ifndef NV_DIALECT_HOPPER_TRANSFORMS_WARPSPECIALIZATIONPIPELINE_H_
+#define NV_DIALECT_HOPPER_TRANSFORMS_WARPSPECIALIZATIONPIPELINE_H_
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/LogicalResult.h"
+
+// Declarations for the internal sub-steps of the `nvgpu-warp-specialization`
+// pipeline (orchestrated by WarpSpecialization.cpp). Each step is defined in
+// its own .cpp under this directory. Declaring them here — and including this
+// header from both the orchestrator and every definition site — gives the
+// pipeline API a single, compiler-checked source of truth instead of the
+// ad-hoc forward declarations that were previously duplicated across
+// translation units. Because each definition now includes this header, a
+// declaration that disagrees with its definition (e.g. on return type) is a
+// compile error rather than a silently mismatched forward declaration.
+//
+// NOTE: this header intentionally does NOT change any signature — it only
+// centralizes the existing declarations. Signature normalization (uniform
+// return type / by-value FuncOp) is tracked separately (WS-03).
+
+namespace mlir {
+
+// Assigns/normalizes async_task_id across the function. Returns -1 on failure.
+int doTaskIdPropagate(triton::FuncOp &funcOp);
+
+// Cross-partition run-once atomic support. Returns failure() when an atomic
+// forces a graceful warp-specialization reject (kernel already de-specialized).
+LogicalResult doDynamicTileBroadcast(triton::FuncOp funcOp,
+                                     int tilePrefetchDepth);
+
+// Plans SMEM/TMEM allocation (multi-buffering, liveness). The decision-file and
+// algorithm knobs are exercised only by the -nvgpu-test-ws-memory-planner test
+// pass; the production pipeline uses the defaults declared here. Defaults live
+// on this declaration only (not on the definition) so there is one source.
+LogicalResult doMemoryPlanner(triton::FuncOp &funcOp, unsigned numBuffers,
+                              StringRef readDecisionFile = "",
+                              StringRef writeDecisionFile = "",
+                              int smemAllocAlgo = 1, unsigned smemBudget = 0,
+                              bool smemCircularReuse = false);
+
+void doBufferAllocation(triton::FuncOp &funcOp);
+void doHoistLoopInvariantTMEMStore(triton::FuncOp &funcOp);
+void removeRedundantTmemZeroStores(triton::FuncOp &funcOp);
+void doCodePartitionPost(triton::FuncOp &funcOp, unsigned numBuffers);
+void doTokenLowering(triton::FuncOp &funcOp, unsigned numConsumerGroups);
+void doPingPongPrep(triton::FuncOp &funcOp, unsigned numWarpGroups,
+                    int capability, int defaultNumStages);
+void doPingPongSync(triton::FuncOp &funcOp, unsigned numWarpGroups,
+                    int capability);
+void doAnnotateTMAStoreWaits(triton::FuncOp &funcOp);
+void doValidateTMAStoreAnnotations(triton::FuncOp &funcOp);
+// Best-effort reordering of annotated TMA store waits; never fails (see the
+// definition in WSTMAStoreLowering.cpp).
+void doTMAStoreWaitReorder(triton::FuncOp &funcOp);
+
+} // namespace mlir
+
+#endif // NV_DIALECT_HOPPER_TRANSFORMS_WARPSPECIALIZATIONPIPELINE_H_


### PR DESCRIPTION
Summary:
Moves the function declarations to a header to attempt and establish a clear contract that should be obeyed. Presumably if we need to support semaphore + channels for some time we will need to expose some intermediate components.


Reviewed By: manman-ren

Differential Revision: D110937614

Pulled By: njriasan


