### PR TITLE
OSS cross-attention fwd+bwd kernels, benchmark & repro harness (#1950)

### DIFF
--- a/third_party/nvidia/hopper/run_all.sh
+++ b/third_party/nvidia/hopper/run_all.sh
@@ -58,5 +58,8 @@ echo "Run autoWS tutorial kernels"
 echo "Verifying correctness of FA tutorial kernels"
 pytest third_party/tlx/tutorials/fused_attention_ws_device_tma.py
 
+echo "Verifying correctness of HSTU cross-attention bwd (reduce_dq) autoWS kernel"
+pytest third_party/tlx/tutorials/test_cross_attention_bwd_autows.py
+
 echo "run for Hopper or Blackwell"
 pytest python/tutorials/fused-attention-ws-device-tma-hopper-or-blackwell.py

--- a/third_party/tlx/tutorials/hstu_cross_attn/bench_bwd.py
+++ b/third_party/tlx/tutorials/hstu_cross_attn/bench_bwd.py
@@ -1,0 +1,218 @@
+"""Combined accuracy + perf benchmark for the HSTU cross-attention backward
+(reduce_dq), across the three variants:
+
+  * redq   - triton non-WS reduce_dq (trusted reference kernel)
+  * autows - triton automatic warp specialization (meta-WS)
+  * tlx    - hand-written TLX warp-specialized reduce_dq (attn_bwd_ws)
+
+Accuracy: rel-L2 of dq/dk/dv vs a torch-autograd float reference, plus the
+count of dq rows that diverge from redq grouped into Q-blocks (this isolates
+the WS-specific bug: autoWS corrupts the last min(KV_blocks-1, num_stages)
+Q-blocks for KV>=2; redq/tlx match the reference).
+
+Perf: backward latency per variant (autograd backward on a prebuilt fwd graph),
+reported with speedup relative to redq.
+
+Usage (from this directory):
+  ~/.conda/envs/metamain2/bin/python bench_bwd.py           # accuracy + perf
+  ~/.conda/envs/metamain2/bin/python bench_bwd.py --acc     # accuracy only
+  ~/.conda/envs/metamain2/bin/python bench_bwd.py --perf    # perf only
+"""
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+os.environ.pop("TRITON_USE_META_WS", None)
+import torch
+import triton
+
+import triton_bw_cross_attention as xa
+
+D = 128
+H = 2
+BLOCK = 64  # BLOCK_M == BLOCK_N used by the benchmark configs
+
+VARIANTS = [
+    ("redq", xa.BwdVariant.TRITON_REDQ, "0"),
+    ("autows", xa.BwdVariant.TRITON_AUTOWS, "1"),
+    ("tlx", xa.BwdVariant.TLX, "0"),
+]
+
+
+def force(ns=2, bm=BLOCK, bn=BLOCK):
+    """Pin fwd num_stages>=1 (autoWS asserts on 0) and the bwd block sizes, and
+    shrink the autotune space to one config for fast, deterministic runs."""
+    for fn in (xa._attn_fwd_triton, ):
+        if hasattr(fn, "configs"):
+            c = fn.configs[0]
+            c.num_stages = max(getattr(c, "num_stages", 1), 1)
+            fn.configs = [c]
+    c = xa._hstu_attn_bwd_redq.configs[0]
+    c.num_stages = ns
+    c.kwargs["BLOCK_M"] = bm
+    c.kwargs["BLOCK_N"] = bn
+    xa._hstu_attn_bwd_redq.configs = [c]
+    xa.set_fwd_variant(xa.FwdVariant.TRITON)
+
+
+def make(Lq, Lkv, Z):
+    tq, tk = Z * Lq, Z * Lkv
+    g = lambda n: torch.randn(n, H, D, device="cuda", dtype=torch.bfloat16)
+    q = g(tq).requires_grad_(True)
+    k = g(tk).requires_grad_(True)
+    v = g(tk).requires_grad_(True)
+    so_kv = torch.arange(0, tk + 1, Lkv, device="cuda", dtype=torch.int64)
+    so_q = torch.arange(0, tq + 1, Lq, device="cuda", dtype=torch.int64)
+    asc = torch.tensor(1.0 / Lkv, device="cuda", dtype=torch.float32)
+    do = g(tq)
+    return q, k, v, do, so_kv, so_q, asc
+
+
+def torch_ref(q, k, v, do, so_kv, so_q, asc, softmax=True):
+    """Float autograd reference on the HSTU cross-attn forward (asymmetric Q/KV)."""
+    qf = q.detach().float().requires_grad_(True)
+    kf = k.detach().float().requires_grad_(True)
+    vf = v.detach().float().requires_grad_(True)
+    scale = asc.item()
+    outs = []
+    for z in range(so_kv.numel() - 1):
+        qs, qe = int(so_q[z]), int(so_q[z + 1])
+        ks, ke = int(so_kv[z]), int(so_kv[z + 1])
+        qk = torch.einsum("qhd,khd->hqk", qf[qs:qe], kf[ks:ke]) * (1.0 / D)
+        S = torch.softmax(qk, -1) if softmax else (qk * torch.sigmoid(qk)) * scale
+        outs.append(torch.einsum("hqk,khd->qhd", S, vf[ks:ke]))
+    torch.cat(outs, 0).backward(do.float())
+    return qf.grad, kf.grad, vf.grad
+
+
+def rel_l2(a, b):
+    return (torch.norm(a.float() - b.float()) / (torch.norm(b.float()) + 1e-12)).item()
+
+
+def max_abs(a, b):
+    return (a.float() - b.float()).abs().max().item()
+
+
+def bad_qblocks(test, ref, Lq, tol=5e-3):
+    pr = (test.float() - ref.float()).abs().amax(dim=(1, 2))
+    rm = torch.arange(pr.numel(), device=pr.device) % Lq
+    bad = pr > tol
+    return int(bad.sum()), sorted(set((rm[bad] // BLOCK).tolist()))
+
+
+def _fwd(var, ws, q, k, v, so_kv, so_q, Lkv, Lq, asc):
+    xa.set_bwd_variant(var)
+    os.environ["TRITON_USE_META_WS"] = ws
+    return xa.triton_bw_hstu_mha_wrapper(
+        max_seq_len=Lkv,
+        alpha=1.0 / D,
+        q=q,
+        k=k,
+        v=v,
+        seq_offsets=so_kv,
+        attn_scale=asc,
+        max_q_len=Lq,
+        seq_offsets_q=so_q,
+        num_softmax_heads=H,
+        shared_kv=False,
+        enable_tma=True,
+    )
+
+
+def run_accuracy(configs, ns=2, ref_name="redq", variants=None):
+    """rel-L2/maxabs are always vs the torch-float ref; the bad-Q-block count is
+    vs the byte-reference kernel `ref_name` (redq or tlx -- they are byte-identical,
+    so either works; use tlx to compare autoWS directly against the hand-WS kernel).
+    `variants` (list of names) selects which kernels to run; the ref kernel is run
+    regardless (it is only displayed if it's also in `variants`)."""
+    sel = VARIANTS if variants is None else [x for x in VARIANTS if x[0] in variants]
+    ref_var, ref_ws = next((v, w) for n, v, w in VARIANTS if n == ref_name)
+    print(f"\n=== Accuracy: dq/dk/dv rel-L2 vs torch-float ref; dq bad-Q-blocks vs {ref_name} ===")
+    for Lq, Lkv, Z in configs:
+        force(ns)
+        torch.manual_seed(0)
+        q, k, v, do, so_kv, so_q, asc = make(Lq, Lkv, Z)
+        rq, rk, rv = torch_ref(q, k, v, do, so_kv, so_q, asc)
+        # byte-reference dq from the chosen kernel (redq/tlx)
+        for t in (q, k, v):
+            t.grad = None
+        _fwd(ref_var, ref_ws, q, k, v, so_kv, so_q, Lkv, Lq, asc).backward(do)
+        ref = q.grad.clone()
+        print(f"\n  Lq={Lq}({Lq // BLOCK}blk) Lkv={Lkv}({Lkv // BLOCK}blk) Z={Z} ns={ns}")
+        print(f"  {'variant':<8}{'dq relL2':>10}{'dk relL2':>10}{'dv relL2':>10}"
+              f"{'dq maxabs':>11}  dq-vs-{ref_name} bad-Qblk")
+        for name, var, ws in sel:
+            for t in (q, k, v):
+                t.grad = None
+            try:
+                out = _fwd(var, ws, q, k, v, so_kv, so_q, Lkv, Lq, asc)
+                out.backward(do)
+                dq, dk, dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+                n, bm = bad_qblocks(dq, ref, Lq)
+                print(f"  {name:<8}{rel_l2(dq, rq):>10.2e}{rel_l2(dk, rk):>10.2e}"
+                      f"{rel_l2(dv, rv):>10.2e}{max_abs(dq, rq):>11.2e}  {n} rows Qblk{bm}")
+            except Exception as e:
+                print(f"  {name:<8} ERROR {type(e).__name__}: {str(e)[:50]}")
+
+
+def run_perf(shapes, ns=2, variants=None):
+    sel = VARIANTS if variants is None else [x for x in VARIANTS if x[0] in variants]
+    print("\n=== Perf: backward latency per variant (autograd bwd on prebuilt fwd graph) ===")
+    for Lq, Lkv, Z in shapes:
+        force(ns)
+        torch.manual_seed(0)
+        q, k, v, do, so_kv, so_q, asc = make(Lq, Lkv, Z)
+        print(f"\n  Lq={Lq} Lkv={Lkv}({Lkv // BLOCK}blk) Z={Z} H={H} D={D} ns={ns}")
+        print(f"  {'variant':<8}{'bwd ms':>10}{'vs redq':>10}")
+        base = None
+        for name, var, ws in sel:
+            try:
+                out = _fwd(var, ws, q, k, v, so_kv, so_q, Lkv, Lq, asc)
+
+                def fn():
+                    for t in (q, k, v):
+                        t.grad = None
+                    out.backward(do, retain_graph=True)
+
+                fn()  # warm / compile / autotune
+                ms = triton.testing.do_bench(fn, warmup=25, rep=100)
+                if name == "redq":
+                    base = ms
+                spd = f"{base / ms:.2f}x" if base else "-"
+                print(f"  {name:<8}{ms:>10.3f}{spd:>10}")
+            except Exception as e:
+                print(f"  {name:<8} ERROR {type(e).__name__}: {str(e)[:50]}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--acc", action="store_true", help="accuracy only")
+    ap.add_argument("--perf", action="store_true", help="perf only")
+    ap.add_argument("--ns", type=int, default=2, help="bwd num_stages")
+    ap.add_argument(
+        "--ref", choices=["redq", "tlx"], default="redq", help="byte-reference kernel for the dq bad-Q-block count "
+        "(redq and tlx are byte-identical; use tlx to compare "
+        "autoWS directly against the hand-WS kernel)")
+    known = [n for n, _, _ in VARIANTS]
+    ap.add_argument(
+        "--variants", default=",".join(known), help=f"comma-separated subset of variants to run (default all: "
+        f"{','.join(known)}). e.g. --variants autows,tlx to skip redq")
+    args = ap.parse_args()
+    variants = [v.strip() for v in args.variants.split(",") if v.strip()]
+    bad = [v for v in variants if v not in known]
+    if bad:
+        ap.error(f"unknown variant(s) {bad}; choose from {known}")
+    do_acc = args.acc or not args.perf
+    do_perf = args.perf or not args.acc
+    # (Lq, Lkv, Z): KV=1 correct; KV>=2 exposes the autoWS bug.
+    acc_cfgs = [(256, 64, 2), (256, 128, 2), (256, 192, 2)]
+    perf_shapes = [(256, 256, 4), (256, 1024, 4)]
+    if do_acc:
+        run_accuracy(acc_cfgs, ns=args.ns, ref_name=args.ref, variants=variants)
+    if do_perf:
+        run_perf(perf_shapes, ns=args.ns, variants=variants)
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/tlx/tutorials/hstu_cross_attn/stubs.py
+++ b/third_party/tlx/tutorials/hstu_cross_attn/stubs.py
@@ -1,0 +1,97 @@
+# Standalone OSS stubs for the fbcode leaf deps used by the HSTU cross-attention
+# triton kernels. Lets the kernels run under OSS triton (MetaMain2) without buck.
+import triton
+
+
+def switch_to_contiguous_if_needed(x):
+    if x is None:
+        return x
+    return x.contiguous()
+
+
+def next_power_of_2(n: int) -> int:
+    n = int(n)
+    return 1 if n <= 1 else 1 << (n - 1).bit_length()
+
+
+def prev_power_of_2(n: int) -> int:
+    n = int(n)
+    return 1 if n < 1 else 1 << (n.bit_length() - 1)
+
+
+def autotune_max_seq_len(n) -> int:
+    return next_power_of_2(int(n))
+
+
+def triton_autotune(configs, key, **kwargs):
+    allowed = {"prune_configs_by", "reset_to_zero", "restore_value", "warmup", "rep", "use_cuda_graph"}
+    return triton.autotune(configs=configs, key=key, **{k: v for k, v in kwargs.items() if k in allowed})
+
+
+def get_full_autotune(*a, **k):
+    return False
+
+
+def is_sm90(*a, **k):
+    return False
+
+
+def is_sm90_plus(*a, **k):
+    return False
+
+
+import functools  # noqa: E402
+
+
+class _CustomOpStub:
+    """Mimics a torch custom op enough for import: callable + register_fake/register_kernel."""
+
+    def __init__(self, fn):
+        self._fn = fn
+        functools.update_wrapper(self, fn)
+
+    def __call__(self, *a, **k):
+        return self._fn(*a, **k)
+
+    def register_fake(self, f=None):
+        return f if f is not None else (lambda g: g)
+
+    def register_kernel(self, *a, **k):
+        return lambda g: g
+
+    def register_autograd(self, *a, **k):
+        return lambda g: g
+
+
+def maybe_register_custom_op(*a, **k):
+    if a and callable(a[0]):
+        return _CustomOpStub(a[0])
+
+    def deco(fn):
+        return _CustomOpStub(fn)
+
+    return deco
+
+
+# tritoncc spec stubs (only used by fwd/spec codegen paths, not the bwd reduce_dq path)
+class NamedSpecType:  # noqa
+    pass
+
+
+class VersionedSpec:  # noqa
+
+    def __init__(self, *a, **k):
+        pass
+
+
+def tritoncc_specs(*a, **k):
+    # used as a decorator: @tritoncc_specs(...) -> identity decorator
+    def deco(fn):
+        return fn
+
+    return deco
+
+
+@triton.jit
+def acc_dq(*a):  # not used by the bwd reduce_dq path; present for import resolution
+    pass

--- a/third_party/tlx/tutorials/hstu_cross_attn/tlx_bw_cross_attention.py
+++ b/third_party/tlx/tutorials/hstu_cross_attn/tlx_bw_cross_attention.py
@@ -1,0 +1,1169 @@
+# TLX (warp-specialized) HSTU cross-attention BACKWARD reduce_dq kernel
+# (attn_bwd_ws), ported verbatim from fbcode hammer
+# (hammer/v2/ops/triton/template/tlx_bw_cross_attention.py) for standalone OSS
+# use under MetaMain2 triton. The kernel math is unchanged; only the fbcode/hammer
+# leaf-dep imports were swapped for the local stubs / utils, mirroring how
+# triton_bw_cross_attention.py (the redq port) was adapted.
+#
+# Buffer plan (single-K reduce_dq):
+#   SMEM:  k_tiles / v_tiles / q_tiles / do_tiles / dqk_trans_tiles
+#   TMEM:  qk_trans_tiles (+ p_tiles reuse), dq_tiles (+ dp_tiles reuse),
+#          standalone dk_tiles, dv_tiles
+#   dq is use_acc=False MMA + desc_dq_t.store(store_reduce="add") (not loop
+#   carried); dk/dv ARE loop-carried in standalone TMEM.
+from typing import List, Optional, Tuple
+
+import torch
+
+import triton
+import triton.language as tl
+
+# TLX (Triton Language Extensions) -- present in MetaMain2 triton.
+import triton.language.extra.tlx as tlx  # type: ignore[attr-defined]
+
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+from stubs import (
+    autotune_max_seq_len,
+    switch_to_contiguous_if_needed,
+    triton_autotune,
+)
+from triton_attention_utils import fast_fma, fast_mul, fast_silu  # noqa: F401
+from triton_hstu_cross_attention import (
+    _attn_bwd_preprocess,
+    backward_d_silu_activation,
+    backward_silu_activation,
+    backward_valid_mask,
+)
+
+
+@triton.jit
+def _get_bufidx_phase(accum_cnt, NUM_BUFFERS_KV):
+    buf_id = accum_cnt % NUM_BUFFERS_KV
+    phase = (accum_cnt // NUM_BUFFERS_KV) & 1
+    return buf_id, phase
+
+
+@triton.jit
+def _compute_bwd_reduce_dq_offsets(H, BLOCK_N, seq_offsets_q, seq_offsets):
+    off_hz = tl.program_id(0)
+    off_z = off_hz // H
+    off_h = off_hz % H
+    start_n = tl.program_id(1) * BLOCK_N
+    seq_start_kv = tl.load(seq_offsets + off_z).to(tl.int32)
+    seq_end_kv = tl.load(seq_offsets + off_z + 1).to(tl.int32)
+    seq_len_kv = (seq_end_kv - seq_start_kv).to(tl.int32)
+    seq_start_q = tl.load(seq_offsets_q + off_z).to(tl.int32)
+    seq_end_q = tl.load(seq_offsets_q + off_z + 1).to(tl.int32)
+    seq_len_q = (seq_end_q - seq_start_q).to(tl.int32)
+
+    return off_h, start_n, seq_start_kv, seq_len_kv, seq_start_q, seq_len_q
+
+
+def _bwd_seq_parallel_pre_hook(nargs):
+    # Only zero DQ (store_reduce="add" accumulation across CTAs).
+    # DK/DV are overwritten via tl.store, so no zeroing needed.
+    if "DQ" in nargs:
+        nargs["DQ"].zero_()
+    BLOCK_M = nargs["BLOCK_M"]
+    BLOCK_N = nargs["BLOCK_N"]
+    DimQ = nargs["DimQ"]
+    DimV = nargs["DimV"]
+    if not isinstance(nargs["desc_q"], TensorDescriptor):
+        return
+    BLOCK_D_V = nargs["BLOCK_D_V"]
+    nargs["desc_q"].block_shape = [BLOCK_M, DimQ]
+    nargs["desc_k"].block_shape = [BLOCK_N, DimQ]
+    nargs["desc_v"].block_shape = [BLOCK_N, DimV]
+    nargs["desc_do"].block_shape = [BLOCK_M, DimV]
+    # Backward reduce_dq supports either a shared epilogue subtile or separate
+    # DQ/DKV subtile knobs. Handle both to keep older configs working.
+    dq_subtile = nargs["EPILOGUE_DQ_SUBTILE"]
+    dkv_subtile = nargs["EPILOGUE_DKV_SUBTILE"]
+    if dq_subtile is not None:
+        nargs["desc_dq"].block_shape = [BLOCK_M, DimQ // dq_subtile]
+    if dkv_subtile is not None:
+        nargs["desc_dk"].block_shape = [BLOCK_N, DimQ // dkv_subtile]
+        nargs["desc_dv"].block_shape = [BLOCK_N, BLOCK_D_V // dkv_subtile]
+
+
+def _get_bw_pipeline_reduce_dq_configs() -> List[triton.Config]:
+    # Minimal config set (the non-full-autotune branch from fbcode): BLOCK_M=64,
+    # BLOCK_N=128, NUM_BUFFERS_TMEM=1, TRANSPOSE toggled.
+    configs = [
+        triton.Config(
+            {
+                "BLOCK_M": 64,
+                "BLOCK_N": 64,
+                "NUM_BUFFERS_Q": 2,
+                "NUM_BUFFERS_KV": 1,
+                "NUM_BUFFERS_DO": num_buffers_do,
+                "NUM_BUFFERS_DS": 1,
+                "NUM_BUFFERS_TMEM": 1,
+                "EPILOGUE_DQ_SUBTILE": 1,
+                "EPILOGUE_DKV_SUBTILE": 2,
+                "COMPUTE_REG": 176,
+                "MMA_REG": 48,
+                "LOAD_REG": 24,
+                "TRANSPOSE": transpose,
+            },
+            num_stages=2,
+            num_warps=4,
+            pre_hook=_bwd_seq_parallel_pre_hook,
+        ) for num_buffers_do, transpose in [
+            (2, True),
+            #(1, True),
+            #(2, False),
+            #(1, False),
+        ]
+    ]
+    return configs
+
+
+@triton_autotune(
+    configs=_get_bw_pipeline_reduce_dq_configs(),
+    key=[
+        "AUTOTUNE_Z",
+        "H",
+        "AUTOTUNE_MAX_Q_LEN",
+        "AUTOTUNE_MAX_SEQ_LEN",
+        "DimQ",
+        "DimV",
+        "SHARED_KV",
+    ],
+)
+@triton.jit
+def attn_bwd_ws(  # noqa C901
+    desc_q,
+    desc_k,
+    desc_v,
+    seq_offsets,
+    seq_offsets_q,
+    DQ,
+    DK,
+    DV,
+    desc_do,
+    desc_dq,
+    desc_dk,
+    desc_dv,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_dom,
+    stride_doh,
+    stride_dqm,
+    stride_dqh,
+    stride_dkn,
+    stride_dkh,
+    stride_dvn,
+    stride_dvh,
+    alpha,
+    max_seq_len,
+    attn_scale,
+    M,
+    Delta,
+    stride_mm,
+    Z,
+    AUTOTUNE_Z,
+    H,
+    AUTOTUNE_MAX_Q_LEN,  # Quantized MAX_Q_LEN used as an autotuning key
+    AUTOTUNE_MAX_SEQ_LEN,  # Quantized MAX_SEQ_LEN used as an autotuning key
+    DimQ: tl.constexpr,
+    DimV: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    NUM_BUFFERS_KV: tl.constexpr,
+    NUM_BUFFERS_Q: tl.constexpr,
+    NUM_BUFFERS_DO: tl.constexpr,
+    NUM_BUFFERS_DS: tl.constexpr,
+    NUM_BUFFERS_TMEM: tl.constexpr,
+    EPILOGUE_DQ_SUBTILE: tl.constexpr,
+    EPILOGUE_DKV_SUBTILE: tl.constexpr,
+    COMPUTE_REG: tl.constexpr,
+    MMA_REG: tl.constexpr,
+    LOAD_REG: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    SHARED_KV: tl.constexpr,
+    SOFTMAX: tl.constexpr,
+    # When True, store dq transposed as dq^T [DimQ, BLOCK_M] (fewer TMEM columns
+    # at BLOCK_M < DimQ); when False, use the [BLOCK_M, DimQ] layout. Autotuned.
+    TRANSPOSE: tl.constexpr,
+):
+    tl.static_assert(NUM_BUFFERS_Q >= 2)
+
+    # allocate SMEM buffers and barriers
+    # pyrefly: ignore [missing-attribute]
+    k_tiles = tlx.local_alloc((BLOCK_N, DimQ), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
+    if not SHARED_KV:
+        # pyrefly: ignore [missing-attribute]
+        v_tiles = tlx.local_alloc((BLOCK_N, DimV), tlx.dtype_of(desc_v), NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    q_tiles = tlx.local_alloc((BLOCK_M, DimQ), tlx.dtype_of(desc_q), NUM_BUFFERS_Q)
+    # pyrefly: ignore [missing-attribute]
+    do_tiles = tlx.local_alloc((BLOCK_M, DimV), tlx.dtype_of(desc_do), NUM_BUFFERS_DO)
+
+    # Use SMEM for dqk_trans
+    # pyrefly: ignore [missing-attribute]
+    dqk_trans_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N, BLOCK_M),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_q),
+        NUM_BUFFERS_DS,
+    )
+
+    # pyrefly: ignore [missing-attribute]
+    q_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_Q)
+    # pyrefly: ignore [missing-attribute]
+    k_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    k_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    if not SHARED_KV:
+        # pyrefly: ignore [missing-attribute]
+        v_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+        # pyrefly: ignore [missing-attribute]
+        v_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    do_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_DO)
+    # pyrefly: ignore [missing-attribute]
+    q_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_Q)
+    # pyrefly: ignore [missing-attribute]
+    do_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_DO)
+    # pyrefly: ignore [missing-attribute]
+    dqk_trans_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+
+    # allocate TMEM buffers and barriers
+    # pyrefly: ignore [missing-attribute]
+    qk_trans_tiles = tlx.local_alloc(
+        (BLOCK_N, BLOCK_M),
+        tl.float32,
+        NUM_BUFFERS_TMEM,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+    )
+
+    # P
+    # pyrefly: ignore [missing-attribute]
+    p_tiles = tlx.local_alloc(
+        (BLOCK_N, BLOCK_M),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_do),
+        NUM_BUFFERS_TMEM,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+        reuse=qk_trans_tiles,
+    )
+    # TRANSPOSE: store dq transposed as dq^T ([DimQ, BLOCK_M]) instead of
+    # [BLOCK_M, DimQ]. With BLOCK_M < DimQ this shrinks its TMEM column footprint
+    # from DimQ to BLOCK_M columns (e.g. 128 -> 64 at BLOCK_M=64), and makes dq^T
+    # the same [*, BLOCK_M] footprint as dp ([BLOCK_N, BLOCK_M]) so dp can
+    # time-share it cleanly. dq^T = (dS @ K)^T = K^T @ dS^T; the reduce epilogue
+    # transposes it back before the dQ store.
+    if TRANSPOSE:
+        # pyrefly: ignore [missing-attribute]
+        dq_tiles = tlx.local_alloc(
+            (DimQ, BLOCK_M),
+            tl.float32,
+            NUM_BUFFERS_TMEM,
+            # pyrefly: ignore [missing-attribute]
+            tlx.storage_kind.tmem,
+        )
+    else:
+        # pyrefly: ignore [missing-attribute]
+        dq_tiles = tlx.local_alloc(
+            (BLOCK_M, DimQ),
+            tl.float32,
+            NUM_BUFFERS_TMEM,
+            # pyrefly: ignore [missing-attribute]
+            tlx.storage_kind.tmem,
+        )
+
+    # pyrefly: ignore [missing-attribute]
+    dp_tiles = tlx.local_alloc(
+        (BLOCK_N, BLOCK_M),
+        tl.float32,
+        1,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+        # dp time-shares dq's (larger) TMEM. Without this reuse the standalone
+        # tiles overflow 512 TMEM columns at BLOCK_M=128, so dk_tiles overlaps a
+        # neighbor and its upper column-subtiles get corrupted.
+        reuse=dq_tiles,
+    )
+    # pyrefly: ignore [missing-attribute]
+    dk_tiles = tlx.local_alloc(
+        (BLOCK_N, DimQ),
+        tl.float32,
+        1,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+    )
+    # SHARED_KV folds dv into dk's tmem (alpha is pre-scaled into dqk_trans), so
+    # the separate dv_tiles tile is only needed when K and V are distinct.
+    if not SHARED_KV:
+        # pyrefly: ignore [missing-attribute]
+        dv_tiles = tlx.local_alloc(
+            (BLOCK_N, DimV),
+            tl.float32,
+            1,
+            # pyrefly: ignore [missing-attribute]
+            tlx.storage_kind.tmem,
+        )
+
+    # pyrefly: ignore [missing-attribute]
+    qk_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    qk_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    p_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    dp_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    dq_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    dq_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # dk_tiles / dv_tiles are single-buffered, so their full/empty handshakes are
+    # depth-1 and must NOT be sized to NUM_BUFFERS_KV (which only buffers the K/V
+    # *loads*). Sizing these to NUM_BUFFERS_KV let consecutive N-blocks use
+    # different barrier slots for the same physical tile -> dk/dv corruption at
+    # NUM_BUFFERS_KV>1. Index these with [0] and a depth-1 phase everywhere.
+    # pyrefly: ignore [missing-attribute]
+    dk_fulls = tlx.alloc_barriers(num_barriers=1)
+    # pyrefly: ignore [missing-attribute]
+    dk_empties = tlx.alloc_barriers(num_barriers=1)
+    # pyrefly: ignore [missing-attribute]
+    dv_fulls = tlx.alloc_barriers(num_barriers=1)
+    # pyrefly: ignore [missing-attribute]
+    dv_empties = tlx.alloc_barriers(num_barriers=1)
+
+    # pyrefly: ignore [missing-attribute]
+    with tlx.async_tasks():
+        # Reduce
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task("default"):
+            off_h, _start_n, seq_start_kv, seq_len_kv, seq_start_q, seq_len_q = (_compute_bwd_reduce_dq_offsets(
+                H, BLOCK_N, seq_offsets_q, seq_offsets))
+            # dq/dk/dv stores use on-device TMA descriptors bounded per-program to
+            # [end, ...]: partial M/N blocks are dropped by TMA bounds (no
+            # adjacent-batch corruption, no mask needed) and the addressing is
+            # int64 internally, so the global seq_start_* * stride never overflows
+            # int32 (the multi-GB-tensor IMA). dk/dv use plain stores; dq uses
+            # store_reduce="add" to accumulate its contribution across N blocks.
+            if seq_len_kv > 0:
+                dq_end_q = (seq_start_q + seq_len_q).to(tl.int32)
+                # TRANSPOSE stores dq from a transposed accumulator as one full
+                # [BLOCK_M, DimQ] block (no DQ subtile); otherwise subtile DimQ.
+                dq_block_d: tl.constexpr = (BLOCK_D_Q if TRANSPOSE else BLOCK_D_Q // EPILOGUE_DQ_SUBTILE)
+                desc_dq_t = tl.make_tensor_descriptor(
+                    DQ,
+                    shape=[dq_end_q, H * DimQ],
+                    # pyrefly: ignore [bad-argument-type]
+                    strides=[stride_dqm, 1],
+                    block_shape=[BLOCK_M, dq_block_d],
+                )
+                dk_end_kv = (seq_start_kv + seq_len_kv).to(tl.int32)
+                desc_dk_t = tl.make_tensor_descriptor(
+                    DK,
+                    shape=[dk_end_kv, H * DimQ],
+                    # pyrefly: ignore [bad-argument-type]
+                    strides=[stride_dkn, 1],
+                    block_shape=[BLOCK_N, DimQ // EPILOGUE_DKV_SUBTILE],
+                )
+                if not SHARED_KV:
+                    desc_dv_t = tl.make_tensor_descriptor(
+                        DV,
+                        shape=[dk_end_kv, H * DimV],
+                        # pyrefly: ignore [bad-argument-type]
+                        strides=[stride_dvn, 1],
+                        block_shape=[BLOCK_N, BLOCK_D_V // EPILOGUE_DKV_SUBTILE],
+                    )
+
+                accum_cnt_q = 0
+                accum_cnt_n = 0
+                for start_n in tl.range(0, seq_len_kv, BLOCK_N):
+                    for start_m in tl.range(0, seq_len_q, BLOCK_M):
+                        tmem_buf_id, tmem_phase = _get_bufidx_phase(accum_cnt_q, NUM_BUFFERS_TMEM)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(dq_fulls[tmem_buf_id], tmem_phase)
+                        # alpha already folded into dqk_trans (-> dq).
+                        if TRANSPOSE:
+                            # dq_tiles holds dq^T [DimQ, BLOCK_M]; load and
+                            # transpose back to [BLOCK_M, DimQ] for the store.
+                            # pyrefly: ignore [missing-attribute]
+                            dq_t = tlx.local_load(dq_tiles[tmem_buf_id])
+                            dq = tl.trans(dq_t)
+                            desc_dq_t.store(
+                                [
+                                    (seq_start_q + start_m).to(tl.int32),
+                                    off_h * stride_dqh,
+                                ],
+                                dq,
+                                store_reduce="add",
+                            )
+                        else:
+                            slice_size: tl.constexpr = BLOCK_D_Q // EPILOGUE_DQ_SUBTILE
+                            for slice_id in tl.static_range(EPILOGUE_DQ_SUBTILE):
+                                # pyrefly: ignore [missing-attribute]
+                                dq_slice = tlx.local_slice(
+                                    dq_tiles[tmem_buf_id],
+                                    [0, slice_id * slice_size],
+                                    [BLOCK_M, slice_size],
+                                )
+                                # pyrefly: ignore [missing-attribute]
+                                dq = tlx.local_load(dq_slice)
+                                desc_dq_t.store(
+                                    [
+                                        (seq_start_q + start_m).to(tl.int32),
+                                        off_h * stride_dqh + slice_id * slice_size,
+                                    ],
+                                    dq,
+                                    store_reduce="add",
+                                )
+
+                        # release dq
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                        accum_cnt_q += 1
+
+                    # dk/dv epilogue: store per N block after all M blocks.
+                    # dk/dv tiles are single-buffered -> depth-1 barrier index[0]
+                    # and phase, independent of the NUM_BUFFERS_KV load pipeline.
+                    dkv_buf_id, dkv_phase = _get_bufidx_phase(accum_cnt_n, 1)
+
+                    # Store dk
+                    dk_slice_size: tl.constexpr = DimQ // EPILOGUE_DKV_SUBTILE
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dk_fulls[dkv_buf_id], dkv_phase)
+                    for slice_id in tl.static_range(EPILOGUE_DKV_SUBTILE):
+                        # pyrefly: ignore [missing-attribute]
+                        dk_slice = tlx.local_slice(
+                            dk_tiles[0],
+                            [0, slice_id * dk_slice_size],
+                            [BLOCK_N, dk_slice_size],
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        dk = tlx.local_load(dk_slice)
+                        # alpha already folded into dqk_trans (-> dk); for
+                        # SHARED_KV the MMA already accumulated dv into dk_tiles.
+                        desc_dk_t.store(
+                            [
+                                (seq_start_kv + start_n).to(tl.int32),
+                                off_h * stride_dkh + slice_id * dk_slice_size,
+                            ],
+                            dk.to(desc_k.dtype),
+                        )
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_arrive(dk_empties[dkv_buf_id])
+
+                    # Store dv
+                    if not SHARED_KV:
+                        dv_slice_size: tl.constexpr = BLOCK_D_V // EPILOGUE_DKV_SUBTILE
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(dv_fulls[dkv_buf_id], dkv_phase)
+                        for slice_id in tl.static_range(EPILOGUE_DKV_SUBTILE):
+                            # pyrefly: ignore [missing-attribute]
+                            dv_slice = tlx.local_slice(
+                                dv_tiles[0],
+                                [0, slice_id * dv_slice_size],
+                                [BLOCK_N, dv_slice_size],
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            dv = tlx.local_load(dv_slice)
+                            # pyrefly: ignore [unbound-name]
+                            desc_dv_t.store(
+                                [
+                                    (seq_start_kv + start_n).to(tl.int32),
+                                    off_h * stride_dvh + slice_id * dv_slice_size,
+                                ],
+                                # pyrefly: ignore [missing-attribute]
+                                dv.to(tlx.dtype_of(desc_v)),
+                            )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_arrive(dv_empties[dkv_buf_id])
+
+                    accum_cnt_n += 1
+
+        # Compute
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task(num_warps=8, registers=COMPUTE_REG):
+            off_h, _start_n, seq_start_kv, seq_len_kv, seq_start_q, seq_len_q = (_compute_bwd_reduce_dq_offsets(
+                H, BLOCK_N, seq_offsets_q, seq_offsets))
+            if SOFTMAX:
+                # base pointers into the per-(row, head) softmax statistics
+                M_off = M + off_h + seq_start_q * stride_mm
+                Delta_off = Delta + off_h + seq_start_q * stride_mm
+
+            accum_cnt_q = 0
+            for start_n in tl.range(0, seq_len_kv, BLOCK_N):
+                offs_n = start_n + tl.arange(0, BLOCK_N)
+                mask_n = offs_n < seq_len_kv
+                if not SOFTMAX:
+                    if ATTN_SCALE_TYPE == "scalar":
+                        scale = tl.load(attn_scale).to(tl.float32)
+                    else:
+                        tl.static_assert(ATTN_SCALE_TYPE == "dynamic")
+                        scale = tl.load(attn_scale + offs_n, mask=mask_n).to(tl.float32)
+
+                for start_m in tl.range(0, seq_len_q, BLOCK_M):
+                    tmem_buf_id, tmem_phase = _get_bufidx_phase(accum_cnt_q, NUM_BUFFERS_TMEM)
+                    ds_buf_id, _ = _get_bufidx_phase(accum_cnt_q, NUM_BUFFERS_DS)
+
+                    offs_m = start_m + tl.arange(0, BLOCK_M)
+                    mask_m = offs_m < seq_len_q
+                    # wait for qkT
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(qk_fulls[tmem_buf_id], tmem_phase)
+                    # pyrefly: ignore [missing-attribute]
+                    qk_trans = tlx.local_load(qk_trans_tiles[tmem_buf_id])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_arrive(qk_empties[tmem_buf_id])
+                    valid_mask_trans = backward_valid_mask(offs_m, offs_n, 0,  # uih_len_q
+                                                           seq_len_q, seq_len_kv, False,  # HAS_CAUSAL
+                                                           )
+                    if SOFTMAX:
+                        # recompute pT = exp2(qk * alpha * log2(e) - M)
+                        # pyrefly: ignore [unbound-name]
+                        m = tl.load(M_off + offs_m * stride_mm, mask=mask_m)
+                        # Fuse the alpha*log2(e) scale and the -M subtract into a
+                        # single f32x2 fma before exp2.
+                        qk_trans = fast_fma(qk_trans, alpha * 1.44269504, -m[None, :])
+                        pT = tl.math.exp2(qk_trans)
+                        pT = tl.where(valid_mask_trans, pT, 0.0)
+                        # pyrefly: ignore [missing-attribute]
+                        act_qk_trans = pT.to(tlx.dtype_of(desc_do))
+                    else:
+                        qk_trans, act_qk_trans, pT = backward_silu_activation(
+                            qk_trans,
+                            alpha,
+                            valid_mask_trans,
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.dtype_of(desc_do),
+                            # pyrefly: ignore [unbound-name]
+                            scale,
+                        )
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.local_store(p_tiles[tmem_buf_id], act_qk_trans)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_arrive(p_fulls[tmem_buf_id])
+
+                    # dk and dq
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dp_fulls[tmem_buf_id], tmem_phase)
+                    # pyrefly: ignore [missing-attribute]
+                    dact_qk_trans = tlx.local_load(dp_tiles[tmem_buf_id])
+                    if SOFTMAX:
+                        # dS = pT * (dP - Delta)
+                        # pyrefly: ignore [unbound-name]
+                        Di = tl.load(Delta_off + offs_m * stride_mm, mask=mask_m)
+                        dqk_trans = fast_mul(pT, dact_qk_trans - Di[None, :])
+                    else:
+                        dqk_trans = backward_d_silu_activation(
+                            # pyrefly: ignore [unbound-name]
+                            dact_qk_trans,
+                            pT,
+                            qk_trans,
+                            # pyrefly: ignore [unbound-name]
+                            scale,
+                            valid_mask_trans,
+                        )
+                    # Pre-scale by alpha (fp32, pre-cast) so the dk dot
+                    # (dqk_trans @ q) and dq dot (dqk @ k) already carry alpha;
+                    # the MMA/Reduce skip the post-scale and dk can fold dv into a
+                    # single tmem buffer for SHARED_KV.
+                    dqk_trans = fast_mul(dqk_trans, alpha)
+                    # pyrefly: ignore [missing-attribute]
+                    dqk_trans = dqk_trans.to(tlx.dtype_of(desc_do))
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.local_store(dqk_trans_tiles[ds_buf_id], dqk_trans)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_arrive(dqk_trans_fulls[ds_buf_id])
+
+                    accum_cnt_q += 1
+                # dk/dv epilogue skipped - Reduce task handles stores
+
+        # MMA
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task(num_warps=1, registers=MMA_REG):
+            off_h, _start_n, seq_start_kv, seq_len_kv, seq_start_q, seq_len_q = (_compute_bwd_reduce_dq_offsets(
+                H, BLOCK_N, seq_offsets_q, seq_offsets))
+
+            accum_cnt_q = 0
+            accum_cnt_n = 0
+            for _start_n in tl.range(0, seq_len_kv, BLOCK_N):
+                accum_cnt_q_n_start = accum_cnt_q
+                # wait for K (and V) for this N block
+                kv_buf_id, kv_phase = _get_bufidx_phase(accum_cnt_n, NUM_BUFFERS_KV)
+                # dk/dv tiles are single-buffered: depth-1 index[0]/phase, and the
+                # producer must wait for the consumer to drain the tile before
+                # EVERY reuse (every N-block after the first) -- not just after
+                # NUM_BUFFERS_KV blocks (that count belongs to the K/V load tiles).
+                dkv_buf_id, dkv_phase = _get_bufidx_phase(accum_cnt_n, 1)
+                if accum_cnt_n >= 1:
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dk_empties[dkv_buf_id], dkv_phase ^ 1)
+                    if not SHARED_KV:
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(dv_empties[dkv_buf_id], dkv_phase ^ 1)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(k_fulls[kv_buf_id], kv_phase)
+                if not SHARED_KV:
+                    # pyrefly: ignore [missing-attribute, unbound-name]
+                    tlx.barrier_wait(v_fulls[kv_buf_id], kv_phase)
+
+                # prologue
+                q_buff_id, q_phase = _get_bufidx_phase(accum_cnt_q, NUM_BUFFERS_Q)
+                do_buf_id, do_phase = _get_bufidx_phase(accum_cnt_q, NUM_BUFFERS_DO)
+                tmem_buf_id, tmem_phase = _get_bufidx_phase(accum_cnt_q, NUM_BUFFERS_TMEM)
+                # wait for q
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(q_fulls[q_buff_id], q_phase)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(qk_empties[tmem_buf_id], tmem_phase ^ 1)
+                # q @ kT
+                # pyrefly: ignore [missing-attribute]
+                q_trans = tlx.local_trans(q_tiles[q_buff_id])
+                # k0 @ q
+                # pyrefly: ignore [missing-attribute]
+                tlx.async_dot(
+                    k_tiles[kv_buf_id],
+                    q_trans,
+                    qk_trans_tiles[tmem_buf_id],
+                    use_acc=False,
+                    mBarriers=[qk_fulls[tmem_buf_id]],
+                )
+                # compute dpT
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(do_fulls[do_buf_id], do_phase)
+                # As dP uses the same tmem as dQ, wait for dQ release.
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(dq_empties[tmem_buf_id], tmem_phase ^ 1)
+                # pyrefly: ignore [missing-attribute]
+                do_trans = tlx.local_trans(do_tiles[do_buf_id])
+                # v @ do_trans (or k @ do_trans when SHARED_KV)
+                if SHARED_KV:
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        k_tiles[kv_buf_id],
+                        do_trans,
+                        dp_tiles[tmem_buf_id],
+                        use_acc=False,
+                        mBarriers=[dp_fulls[tmem_buf_id]],
+                    )
+                else:
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        # pyrefly: ignore [missing-attribute, unbound-name]
+                        v_tiles[kv_buf_id],
+                        do_trans,
+                        dp_tiles[tmem_buf_id],
+                        use_acc=False,
+                        mBarriers=[dp_fulls[tmem_buf_id]],
+                    )
+                # dv0: for SHARED_KV this initializes the merged dk_tiles
+                # (alpha-free dv); the dk dots accumulate onto it below.
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(p_fulls[tmem_buf_id], tmem_phase)
+                if SHARED_KV:
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        p_tiles[tmem_buf_id],
+                        do_tiles[do_buf_id],
+                        dk_tiles[0],
+                        use_acc=False,
+                        mBarriers=[do_empties[do_buf_id]],
+                    )
+                else:
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        p_tiles[tmem_buf_id],
+                        do_tiles[do_buf_id],
+                        # pyrefly: ignore [unbound-name]
+                        dv_tiles[0],
+                        use_acc=False,
+                        mBarriers=[do_empties[do_buf_id]],
+                    )
+
+                accum_cnt_q += 1
+                # Mainloop
+                for _start_m in tl.range(BLOCK_M, seq_len_q, BLOCK_M):
+                    q_buff_id, q_phase = _get_bufidx_phase(accum_cnt_q, NUM_BUFFERS_Q)
+                    tmem_buf_id, tmem_phase = _get_bufidx_phase(accum_cnt_q, NUM_BUFFERS_TMEM)
+
+                    # q @ kT
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(q_fulls[q_buff_id], q_phase)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(qk_empties[tmem_buf_id], tmem_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    q_trans = tlx.local_trans(q_tiles[q_buff_id])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        k_tiles[kv_buf_id],
+                        q_trans,
+                        qk_trans_tiles[tmem_buf_id],
+                        use_acc=False,
+                        mBarriers=[qk_fulls[tmem_buf_id]],
+                    )
+
+                    prev_cnt_q = accum_cnt_q - 1
+                    q_buff_id_prev, _ = _get_bufidx_phase(prev_cnt_q, NUM_BUFFERS_Q)
+                    tmem_buf_id_prev, tmem_phase_prev = _get_bufidx_phase(prev_cnt_q, NUM_BUFFERS_TMEM)
+                    ds_buf_id_prev, ds_phase_prev = _get_bufidx_phase(prev_cnt_q, NUM_BUFFERS_DS)
+                    # compute dQ
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dqk_trans_fulls[tmem_buf_id_prev], ds_phase_prev)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.fence_async_shared()
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dq_empties[tmem_buf_id_prev], tmem_phase_prev ^ 1)
+                    if TRANSPOSE:
+                        # dq^T = K^T @ dS^T (dqk_trans is dS^T): transpose K instead
+                        # of dqk so the accumulator lands as [DimQ, BLOCK_M].
+                        # pyrefly: ignore [missing-attribute]
+                        k_trans = tlx.local_trans(k_tiles[kv_buf_id])
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            k_trans,
+                            dqk_trans_tiles[ds_buf_id_prev],
+                            # pyrefly: ignore [missing-attribute]
+                            dq_tiles[tmem_buf_id_prev],
+                            use_acc=False,
+                            mBarriers=[dq_fulls[tmem_buf_id_prev]],
+                        )
+                    else:
+                        # dq = dS @ K -> [BLOCK_M, DimQ]
+                        # pyrefly: ignore [missing-attribute]
+                        dqk = tlx.local_trans(dqk_trans_tiles[ds_buf_id_prev])
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            dqk,
+                            k_tiles[kv_buf_id],
+                            # pyrefly: ignore [missing-attribute]
+                            dq_tiles[tmem_buf_id_prev],
+                            use_acc=False,
+                            mBarriers=[dq_fulls[tmem_buf_id_prev]],
+                        )
+
+                    # compute dk(i-1). For SHARED_KV always accumulate: dv0
+                    # already initialized the merged dk_tiles for this N block.
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        dqk_trans_tiles[ds_buf_id_prev],
+                        q_tiles[q_buff_id_prev],
+                        dk_tiles[tmem_buf_id_prev],
+                        use_acc=SHARED_KV or prev_cnt_q > accum_cnt_q_n_start,
+                        mBarriers=[q_empties[q_buff_id_prev]],
+                    )
+
+                    # compute dpT
+                    do_buf_id, do_phase = _get_bufidx_phase(accum_cnt_q, NUM_BUFFERS_DO)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(do_fulls[do_buf_id], do_phase)
+                    # As dP uses the same tmem as dQ, wait for dQ release.
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dq_empties[tmem_buf_id], tmem_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    do_trans = tlx.local_trans(do_tiles[do_buf_id])
+                    # v @ do_trans (or k @ do_trans when SHARED_KV)
+                    if SHARED_KV:
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            k_tiles[kv_buf_id],
+                            do_trans,
+                            dp_tiles[tmem_buf_id],
+                            use_acc=False,
+                            mBarriers=[dp_fulls[tmem_buf_id]],
+                        )
+                    else:
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            # pyrefly: ignore [missing-attribute, unbound-name]
+                            v_tiles[kv_buf_id],
+                            do_trans,
+                            dp_tiles[tmem_buf_id],
+                            use_acc=False,
+                            mBarriers=[dp_fulls[tmem_buf_id]],
+                        )
+
+                    # compute dv(i) (accumulate into merged dk_tiles for shared)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(p_fulls[tmem_buf_id], tmem_phase)
+                    if SHARED_KV:
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            p_tiles[tmem_buf_id],
+                            do_tiles[do_buf_id],
+                            dk_tiles[0],
+                            use_acc=True,
+                            mBarriers=[do_empties[do_buf_id]],
+                        )
+                    else:
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            p_tiles[tmem_buf_id],
+                            do_tiles[do_buf_id],
+                            # pyrefly: ignore [unbound-name]
+                            dv_tiles[0],
+                            use_acc=True,
+                            mBarriers=[do_empties[do_buf_id]],
+                        )
+
+                    accum_cnt_q += 1
+                if not SHARED_KV:
+                    # dv published via dk_fulls (merged tile) for SHARED_KV.
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.tcgen05_commit(dv_fulls[0])
+
+                # epilogue
+                q_buff_id, q_phase = _get_bufidx_phase(accum_cnt_q - 1, NUM_BUFFERS_Q)
+                tmem_buf_id, tmem_phase = _get_bufidx_phase(accum_cnt_q - 1, NUM_BUFFERS_TMEM)
+                ds_buf_id, ds_phase = _get_bufidx_phase(accum_cnt_q - 1, NUM_BUFFERS_DS)
+
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(dqk_trans_fulls[ds_buf_id], ds_phase)
+                # pyrefly: ignore [missing-attribute]
+                tlx.fence_async_shared()
+                # pyrefly: ignore [missing-attribute]
+                tlx.async_dot(
+                    dqk_trans_tiles[ds_buf_id],
+                    q_tiles[q_buff_id],
+                    dk_tiles[0],
+                    # SHARED_KV: always accumulate onto the merged dv/dk tile.
+                    use_acc=SHARED_KV or (accum_cnt_q - accum_cnt_q_n_start) > 1,
+                    mBarriers=[q_empties[q_buff_id], dk_fulls[0]],
+                )
+
+                # acc dq (last use of K/V for this N block)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(dq_empties[tmem_buf_id], tmem_phase ^ 1)
+                if SHARED_KV:
+                    kv_release_barriers = [k_empties[kv_buf_id]]
+                else:
+                    kv_release_barriers = [
+                        k_empties[kv_buf_id],
+                        # pyrefly: ignore [unbound-name]
+                        v_empties[kv_buf_id],
+                    ]
+                if TRANSPOSE:
+                    # dq^T = K^T @ dS^T (see mainloop dq dot above).
+                    # pyrefly: ignore [missing-attribute]
+                    k_trans = tlx.local_trans(k_tiles[kv_buf_id])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        k_trans,
+                        dqk_trans_tiles[ds_buf_id],
+                        dq_tiles[tmem_buf_id],
+                        use_acc=False,
+                        # pyrefly: ignore [missing-attribute]
+                        mBarriers=[dq_fulls[tmem_buf_id]] + kv_release_barriers,
+                    )
+                else:
+                    # dq = dS @ K -> [BLOCK_M, DimQ]
+                    # pyrefly: ignore [missing-attribute]
+                    dqk = tlx.local_trans(dqk_trans_tiles[ds_buf_id])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        dqk,
+                        k_tiles[kv_buf_id],
+                        dq_tiles[tmem_buf_id],
+                        use_acc=False,
+                        # pyrefly: ignore [missing-attribute]
+                        mBarriers=[dq_fulls[tmem_buf_id]] + kv_release_barriers,
+                    )
+
+                accum_cnt_n += 1
+
+        # Load
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task(num_warps=1, registers=LOAD_REG):
+            # initialize offsets
+            off_h, _start_n, seq_start_kv, seq_len_kv, seq_start_q, seq_len_q = (_compute_bwd_reduce_dq_offsets(
+                H, BLOCK_N, seq_offsets_q, seq_offsets))
+
+            accum_cnt_q = 0
+            accum_cnt_n = 0
+            for start_n in tl.range(0, seq_len_kv, BLOCK_N):
+                # load K for this N block
+                k_buff_id, kv_phase = _get_bufidx_phase(accum_cnt_n, NUM_BUFFERS_KV)
+                if accum_cnt_n >= NUM_BUFFERS_KV:
+                    _, kv_empty_phase = _get_bufidx_phase(accum_cnt_n - NUM_BUFFERS_KV, NUM_BUFFERS_KV)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(k_empties[k_buff_id], kv_empty_phase)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_expect_bytes(k_fulls[k_buff_id], 2 * BLOCK_N * DimQ)  # float16
+                kv_offset = seq_start_kv + start_n
+                # pyrefly: ignore [missing-attribute]
+                tlx.async_descriptor_load(
+                    desc_k,
+                    k_tiles[k_buff_id],
+                    [kv_offset.to(tl.int32), off_h * stride_kh],
+                    k_fulls[k_buff_id],
+                )
+                if not SHARED_KV:
+                    # load V for this N block
+                    if accum_cnt_n >= NUM_BUFFERS_KV:
+                        _, kv_empty_phase_v = _get_bufidx_phase(accum_cnt_n - NUM_BUFFERS_KV, NUM_BUFFERS_KV)
+                        # pyrefly: ignore [missing-attribute, unbound-name]
+                        tlx.barrier_wait(v_empties[k_buff_id], kv_empty_phase_v)
+                    # pyrefly: ignore [missing-attribute, unbound-name]
+                    tlx.barrier_expect_bytes(
+                        # pyrefly: ignore [unbound-name]
+                        v_fulls[k_buff_id],
+                        2 * BLOCK_N * DimV,
+                    )  # float16
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_load(
+                        desc_v,
+                        # pyrefly: ignore [missing-attribute, unbound-name]
+                        v_tiles[k_buff_id],
+                        [kv_offset.to(tl.int32), off_h * stride_vh],
+                        # pyrefly: ignore [missing-attribute]
+                        v_fulls[k_buff_id],
+                    )
+
+                # load Q and dO for all M blocks
+                q_buff_id, q_phase = _get_bufidx_phase(accum_cnt_q, NUM_BUFFERS_Q)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(q_empties[q_buff_id], q_phase ^ 1)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_expect_bytes(q_fulls[q_buff_id], 2 * BLOCK_M * DimQ)  # float16
+                q_offset = seq_start_q
+                # pyrefly: ignore [missing-attribute]
+                tlx.async_descriptor_load(
+                    desc_q,
+                    q_tiles[q_buff_id],
+                    [q_offset.to(tl.int32), off_h * stride_qh],
+                    q_fulls[q_buff_id],
+                )
+
+                # load DO
+                do_buf_id, do_phase = _get_bufidx_phase(accum_cnt_q, NUM_BUFFERS_DO)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(do_empties[do_buf_id], do_phase ^ 1)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_expect_bytes(do_fulls[do_buf_id], 2 * BLOCK_M * DimV)  # float16
+                # pyrefly: ignore [missing-attribute]
+                tlx.async_descriptor_load(
+                    desc_do,
+                    do_tiles[do_buf_id],
+                    [q_offset.to(tl.int32), off_h * stride_doh],
+                    do_fulls[do_buf_id],
+                )
+
+                accum_cnt_q += 1
+                for start_m in tl.range(BLOCK_M, seq_len_q, BLOCK_M):
+                    # load Q
+                    q_buff_id, q_phase = _get_bufidx_phase(accum_cnt_q, NUM_BUFFERS_Q)
+                    do_buf_id, do_phase = _get_bufidx_phase(accum_cnt_q, NUM_BUFFERS_DO)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(q_empties[q_buff_id], q_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_expect_bytes(q_fulls[q_buff_id], 2 * BLOCK_M * DimQ)  # float16
+                    q_offset = seq_start_q + start_m
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_load(
+                        desc_q,
+                        q_tiles[q_buff_id],
+                        [q_offset.to(tl.int32), off_h * stride_qh],
+                        q_fulls[q_buff_id],
+                    )
+                    # load dO
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(do_empties[do_buf_id], do_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_expect_bytes(do_fulls[do_buf_id], 2 * BLOCK_M * DimV)  # float16
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_load(
+                        desc_do,
+                        do_tiles[do_buf_id],
+                        [q_offset.to(tl.int32), off_h * stride_doh],
+                        do_fulls[do_buf_id],
+                    )
+                    accum_cnt_q += 1
+                accum_cnt_n += 1
+
+
+def tlx_bw_reduce_dq(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    dout: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    attn_scale: torch.Tensor,
+    max_seq_len: int,
+    alpha: float,
+    max_q_len: Optional[int] = None,
+    seq_offsets_q: Optional[torch.Tensor] = None,
+    shared_kv: bool = False,
+    num_softmax_heads: int = 0,
+    out: Optional[torch.Tensor] = None,
+    M: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Launch the TLX warp-specialized reduce_dq backward (attn_bwd_ws).
+
+    Mirrors the fbcode tlx_hstu_attention_bwd dispatch (reduce_dq path). Returns
+    (dq, dk, dv); dv aliases dk when shared_kv.
+    """
+    dout = switch_to_contiguous_if_needed(dout)
+    dq = torch.zeros_like(q, dtype=torch.float32)
+    dk = torch.empty_like(k)
+    dv = dk if shared_kv else torch.empty_like(v)
+    dq = switch_to_contiguous_if_needed(dq)
+    dk = switch_to_contiguous_if_needed(dk)
+    if not shared_kv:
+        dv = switch_to_contiguous_if_needed(dv)
+    if dout.shape[0] == 0:
+        return torch.zeros_like(q), torch.zeros_like(k), torch.zeros_like(v)
+    Z = seq_offsets.numel() - 1
+    if max_q_len is None:
+        max_q_len = max_seq_len
+        assert seq_offsets_q is None
+        seq_offsets_q = seq_offsets
+
+    total_seq_len_q, H, DimQ = q.shape
+    total_seq_len_kv, _, _ = k.shape
+    _, _, DimV = v.shape
+
+    if attn_scale.ndim == 0:
+        attn_scale_type = "scalar"
+    else:
+        attn_scale_type = "dynamic"
+
+    # Softmax statistics: when enabled, M (base-2 logsumexp from forward) is
+    # required and Delta = rowsum(O * dO) is computed here via a preprocess pass.
+    # All-or-nothing: num_softmax_heads is either 0 (SiLU) or H (softmax).
+    SOFTMAX = num_softmax_heads != 0
+    if SOFTMAX:
+        assert num_softmax_heads == H, ("tlx cross attention softmax requires num_softmax_heads == 0 or H")
+        assert M is not None and out is not None, ("softmax backward requires forward M and out")
+        stride_mm = M.stride(0)
+        Delta = torch.empty_like(M)
+        pre_grid = (triton.cdiv(out.shape[0], 128), num_softmax_heads)
+        _attn_bwd_preprocess[pre_grid](
+            out,
+            dout,
+            Delta,
+            out.shape[0],
+            H=H,
+            softmax_heads=num_softmax_heads,
+            BLOCK_M=128,
+            HEAD_DIM=DimV,
+        )
+    else:
+        M = torch.empty(0, device=q.device, dtype=torch.float32)
+        Delta = torch.empty(0, device=q.device, dtype=torch.float32)
+        stride_mm = 0
+
+    # TMA descriptors (host-side dummy block_shape, filled by the pre_hook).
+    dummy_block = [1, 1]
+    desc_q = TensorDescriptor(
+        q,
+        shape=[total_seq_len_q, H * DimQ],
+        strides=[H * DimQ, 1],
+        block_shape=dummy_block,
+    )
+    desc_v = TensorDescriptor(
+        v,
+        shape=[total_seq_len_kv, H * DimV],
+        strides=[H * DimV, 1],
+        block_shape=dummy_block,
+    )
+    desc_k = TensorDescriptor(
+        k,
+        shape=[total_seq_len_kv, H * DimQ],
+        strides=[H * DimQ, 1],
+        block_shape=dummy_block,
+    )
+    desc_do = TensorDescriptor(
+        dout,
+        shape=[total_seq_len_q, H * DimV],
+        strides=[H * DimV, 1],
+        block_shape=dummy_block,
+    )
+
+    AUTOTUNE_Z = Z
+
+    # On-device TMA descriptors (tl.make_tensor_descriptor) for the grad stores
+    # need a runtime scratch allocator registered.
+    def _bwd_alloc_fn(size: int, alignment: int, _):
+        return torch.empty(size, device=q.device, dtype=torch.int8)
+
+    triton.set_allocator(_bwd_alloc_fn)
+
+    grid = lambda meta: (Z * H, 1)  # noqa E731
+    desc_dq = TensorDescriptor(
+        dq,
+        shape=[total_seq_len_q, H * DimQ],
+        strides=[H * DimQ, 1],
+        block_shape=dummy_block,
+    )
+    desc_dk = TensorDescriptor(
+        dk,
+        shape=[total_seq_len_kv, H * DimQ],
+        strides=[H * DimQ, 1],
+        block_shape=dummy_block,
+    )
+    desc_dv = TensorDescriptor(
+        dv,
+        shape=[total_seq_len_kv, H * DimV],
+        strides=[H * DimV, 1],
+        block_shape=dummy_block,
+    )
+    attn_bwd_ws[grid](
+        desc_q=desc_q,
+        desc_k=desc_k,
+        desc_v=desc_v,
+        seq_offsets=seq_offsets,
+        seq_offsets_q=seq_offsets_q,
+        DQ=dq,
+        DK=dk,
+        DV=dv,
+        desc_do=desc_do,
+        desc_dq=desc_dq,
+        desc_dk=desc_dk,
+        desc_dv=desc_dv,
+        stride_qm=q.stride(0),
+        stride_qh=q.stride(1),
+        stride_kn=k.stride(0),
+        stride_kh=k.stride(1),
+        stride_vn=v.stride(0),
+        stride_vh=v.stride(1),
+        stride_dom=dout.stride(0),
+        stride_doh=dout.stride(1),
+        stride_dqm=dq.stride(0),
+        stride_dqh=dq.stride(1),
+        stride_dkn=dk.stride(0),
+        stride_dkh=dk.stride(1),
+        stride_dvn=dv.stride(0),
+        stride_dvh=dv.stride(1),
+        alpha=alpha,
+        max_seq_len=max_seq_len,
+        attn_scale=attn_scale,
+        M=M,
+        Delta=Delta,
+        stride_mm=stride_mm,
+        Z=Z,
+        AUTOTUNE_Z=AUTOTUNE_Z,
+        H=H,
+        AUTOTUNE_MAX_Q_LEN=autotune_max_seq_len(max_q_len),
+        AUTOTUNE_MAX_SEQ_LEN=autotune_max_seq_len(max_seq_len),
+        DimQ=DimQ,
+        DimV=DimV,
+        ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+        BLOCK_D_Q=DimQ,
+        BLOCK_D_V=DimV,
+        ATTN_SCALE_TYPE=attn_scale_type,
+        SOFTMAX=SOFTMAX,
+        SHARED_KV=shared_kv,
+    )
+
+    dq = dq.to(q.dtype)
+    if shared_kv:
+        dv = torch.empty(0, device=q.device, dtype=v.dtype)
+    return dq, dk, dv

--- a/third_party/tlx/tutorials/hstu_cross_attn/triton_attention_utils.py
+++ b/third_party/tlx/tutorials/hstu_cross_attn/triton_attention_utils.py
@@ -1,0 +1,233 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+import torch
+
+# @manual=//triton:triton
+import triton
+
+# @manual=//triton:triton
+import triton.language as tl
+
+try:
+    # @manual=//triton:triton
+    import triton.language.extra.tlx as tlx  # type: ignore[attr-defined]
+
+    HAS_TLX = True
+except ImportError:
+    tlx = None
+    HAS_TLX = False
+
+from triton.language.extra.libdevice import (  # @manual=//triton:triton
+    fast_dividef, fast_expf,
+)
+
+HAS_FAST_TANH_INSTRUCTION = (
+    torch.version.cuda is not None and torch.cuda.is_available()
+    and torch.cuda.get_device_capability()[0] >= 9  # >= H100
+)
+HAS_F32X2_INSTRUCTION = (
+    torch.version.cuda is not None and torch.cuda.is_available()
+    and torch.cuda.get_device_capability()[0] >= 10  # >= B200
+)
+
+if HAS_FAST_TANH_INSTRUCTION:
+
+    @triton.jit
+    def tanh_approx_fp32(x):
+        output = tl.inline_asm_elementwise(
+            asm="""
+            tanh.approx.f32 $0, $1;
+            """,
+            constraints="=r,r",
+            args=[x],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=1,
+        )
+        return output
+
+
+if HAS_F32X2_INSTRUCTION:
+
+    @triton.jit
+    def _fma_f32x2(a, b, c):
+        return tl.inline_asm_elementwise(
+            """
+            {
+                .reg .b64 ra, rb, rc, rd;
+                mov.b64 ra, { $2, $3 };
+                mov.b64 rb, { $4, $5 };
+                mov.b64 rc, { $6, $7 };
+                fma.rn.f32x2 rd, ra, rb, rc;
+                mov.b64 { $0, $1 }, rd;
+            }
+            """,
+            "=r,=r,r,r,r,r,r,r",
+            [a, b, c],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=2,
+        )
+
+    @triton.jit
+    def _mul_f32x2(a, b):
+        return tl.inline_asm_elementwise(
+            """
+            {
+                .reg .b64 ra, rb, rc;
+                mov.b64 ra, { $2, $3 };
+                mov.b64 rb, { $4, $5 };
+                mul.f32x2 rc, ra, rb;
+                mov.b64 { $0, $1 }, rc;
+            }
+            """,
+            "=r,=r,r,r,r,r",
+            [a, b],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=2,
+        )
+
+    @triton.jit
+    def fast_fma(a, b, c):
+        return _fma_f32x2(a, b, c)
+
+    @triton.jit
+    def fast_mul(a, b):
+        return _mul_f32x2(a, b)
+
+    @triton.jit
+    def fast_silu(x, MULT_BY_X: tl.constexpr):
+        x = x * 0.5
+        if MULT_BY_X:
+            return _fma_f32x2(x, tanh_approx_fp32(x), x)
+        else:
+            return _fma_f32x2(tanh_approx_fp32(x), 0.5, 0.5)
+
+elif HAS_FAST_TANH_INSTRUCTION:
+
+    @triton.jit
+    def fast_fma(a, b, c):
+        return a * b + c
+
+    @triton.jit
+    def fast_mul(a, b):
+        return a * b
+
+    @triton.jit
+    def fast_silu(x, MULT_BY_X: tl.constexpr):
+        x = x * 0.5
+        if MULT_BY_X:
+            return x * (tanh_approx_fp32(x) + 1.0)
+        else:
+            return tanh_approx_fp32(x) * 0.5 + 0.5
+
+else:
+
+    @triton.jit
+    def fast_fma(a, b, c):
+        return a * b + c
+
+    @triton.jit
+    def fast_mul(a, b):
+        return a * b
+
+    @triton.jit
+    def fast_silu(x, MULT_BY_X: tl.constexpr):
+        if MULT_BY_X:
+            # pyre-fixme[16]: Module `math` has no attribute `fast_dividef`.
+            return fast_dividef(x, 1.0 + fast_expf(-x))
+        else:
+            # pyre-fixme[16]: Module `math` has no attribute `fast_dividef`.
+            return fast_dividef(1.0, 1.0 + fast_expf(-x))
+
+
+@triton.jit
+def _get_bufidx_phase(accum_cnt, NUM_BUFFERS_KV):
+    buf_id = accum_cnt % NUM_BUFFERS_KV
+    phase = (accum_cnt // NUM_BUFFERS_KV) & 1
+    return buf_id, phase
+
+
+@triton.jit
+def backward_d_silu_activation(
+    dact_qk_trans,
+    pT,  # pT represents sig_trans
+    qk_trans,
+    scale,
+    valid_mask_trans,
+):
+    dqk_trans = dact_qk_trans * pT * (1 + qk_trans * (1 - pT)) * scale[None, :]
+    dqk_trans = tl.where(valid_mask_trans, dqk_trans, 0)
+    return dqk_trans
+
+
+@triton.jit
+def backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT,  # pT represents sig_trans
+                                  ):
+    Di = tl.load(Delta_off + offs_m * stride_mm, mask=mask_m)
+    dqk_trans = pT * (dact_qk_trans - Di[None, :])
+    return dqk_trans
+
+
+@triton.jit
+def backward_silu_activation(qk_trans, alpha, valid_mask_trans, dtype_k, scale):
+    masked_alpha = tl.where(valid_mask_trans, alpha, 0.0)
+    qk_trans = qk_trans * masked_alpha
+    pT = fast_silu(qk_trans, MULT_BY_X=False)
+    silu_trans = qk_trans * pT * scale[None, :]
+    act_qk_trans = silu_trans.to(dtype_k)
+    return qk_trans, act_qk_trans, pT
+
+
+@triton.jit
+def backward_softmax_activation(qk_trans, alpha, valid_mask_trans, M_off, offs_m, stride_mm, mask_m, k):
+    qk_trans = qk_trans * alpha * 1.44269504
+    m = tl.load(M_off + offs_m * stride_mm, mask=mask_m)
+    pT = tl.math.exp2(qk_trans - m[None, :])
+    pT = tl.where(valid_mask_trans, pT, 0.0)
+    act_qk_trans = pT.to(k.dtype)
+    return qk_trans, act_qk_trans, pT
+
+
+@triton.jit
+def forward_softmax_activation_scaled_alpha(qk, scaled_alpha, valid_mask, m_i, acc, l_i):
+    qk = qk * scaled_alpha
+    qk = tl.where(valid_mask, qk, -float("inf"))
+    m_ij = tl.maximum(m_i, tl.max(qk, 1))
+    qk -= m_ij[:, None]
+    act_qk = tl.math.exp2(qk)
+    corr = tl.math.exp2(m_i - m_ij)
+    l_ij = tl.sum(act_qk, 1)
+    acc = acc * corr[:, None]
+    l_i = l_i * corr + l_ij
+    m_i = m_ij
+    return act_qk, acc, l_i, m_i
+
+
+@triton.jit
+def forward_softmax_activation_trans_scaled_alpha(qk_trans, scaled_alpha, valid_mask_trans, m_i, acc, l_i):
+    qk_trans = qk_trans * scaled_alpha
+    qk_trans = tl.where(valid_mask_trans, qk_trans, -float("inf"))
+    m_ij = tl.maximum(m_i, tl.max(qk_trans, 0))
+    qk_trans -= m_ij[None, :]
+    act_qk = tl.math.exp2(qk_trans)
+    corr = tl.math.exp2(m_i - m_ij)
+    l_ij = tl.sum(act_qk, 0)
+    acc = acc * corr[None, :]
+    l_i = l_i * corr + l_ij
+    m_i = m_ij
+    return act_qk, acc, l_i, m_i
+
+
+@triton.jit
+def backward_softmax_activation_scaled_alpha(qk_trans, scaled_alpha, valid_mask_trans, M_off, offs_m, stride_mm, mask_m,
+                                             k):
+    qk_trans = qk_trans * scaled_alpha
+    m = tl.load(M_off + offs_m * stride_mm, mask=mask_m)
+    pT = tl.math.exp2(qk_trans - m[None, :])
+    pT = tl.where(valid_mask_trans, pT, 0.0)
+    act_qk_trans = pT.to(k.dtype)
+    return qk_trans, act_qk_trans, pT

--- a/third_party/tlx/tutorials/hstu_cross_attn/triton_bw_cross_attention.py
+++ b/third_party/tlx/tutorials/hstu_cross_attn/triton_bw_cross_attention.py
@@ -1,0 +1,3908 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+"""
+Cross-attention kernels with optional TMA (Tensor Memory Accelerator) support.
+
+Forward kernels support TMA and non-TMA paths:
+    - TMA path (ENABLE_TMA=True): Uses tl.make_tensor_descriptor for efficient memory access.
+      Requires Triton 3.3.2+ with on-device TMA descriptor API.
+    - Non-TMA path (ENABLE_TMA=False): Uses standard tl.load/tl.store with pointer arithmetic.
+      Works on all hardware and Triton versions.
+"""
+
+import os
+from enum import Enum
+from typing import List, Optional, Tuple
+
+import torch
+
+# @manual=//triton:triton
+import triton
+
+# @manual=//triton:triton
+import triton.language as tl
+from stubs import switch_to_contiguous_if_needed
+from stubs import (
+    is_sm90,
+    is_sm90_plus,
+    maybe_register_custom_op,
+)
+from stubs import (
+    autotune_max_seq_len,
+    next_power_of_2,
+    triton_autotune,
+)
+from stubs import get_full_autotune
+from triton_attention_utils import (
+    backward_softmax_activation_scaled_alpha,
+    fast_silu,
+    forward_softmax_activation_scaled_alpha,
+    forward_softmax_activation_trans_scaled_alpha,
+)
+from triton_hstu_cross_attention import (
+    _attn_bwd_preprocess,
+    backward_common_preprocess,
+    backward_d_silu_activation,
+    backward_d_softmax_activation,
+    backward_silu_activation,
+    backward_valid_mask,
+    forward_custom_vars,
+    forward_epilogue,
+    forward_softmax_common_preprocess,
+    forward_valid_mask,
+    target_common_preprocess,
+    uih_common_preprocess,
+)
+
+# Check for on-device TMA API availability (requires Triton 3.5+)
+HAS_TENSOR_DESCRIPTOR = hasattr(tl, "make_tensor_descriptor")
+
+
+# Frozen (hashable) wrapper for the autoWS per-dot schedule attrs, usable in a
+# triton.Config kwarg. Supports .get(key) like a dict but is hashable for Triton's
+# JIT cache key. Mirrors the pattern in fused_attention_ws_device_tma.py.
+class FrozenDotAttrs:
+
+    def __init__(self, d):
+        import json as _json
+
+        self._data = d
+        self._hash = hash(_json.dumps(d, sort_keys=True)) if d else hash(None)
+
+    def get(self, key, default=None):
+        return self._data.get(key, default) if self._data else default
+
+    def __hash__(self):
+        return self._hash
+
+    def __eq__(self, other):
+        if isinstance(other, FrozenDotAttrs):
+            return self._data == other._data
+        return NotImplemented
+
+    def __repr__(self):
+        return f"FrozenDotAttrs({self._data})"
+
+    def __bool__(self):
+        return bool(self._data)
+
+
+# autoWS per-dot schedule for `_hstu_attn_bwd_inner`. Keys map to the 5 dots:
+#   qkT = S = k@q^T ; dv = p@do ; dpT = v@do^T ; dk = ds^T@q ; dq = ds^T@k -> dq^T
+# Channel format: "role,space,copy,id" (role: opndA/opndB inputs, opndD accumulator;
+# space: tmem/smem; copy: buffer.copy depth; id: buffer.id).
+#
+# DEFAULT: the schedule this kernel shipped with (FA-derived; dq^T on its own
+# single-copy TMEM buffer id 11, dP on id 5).
+_HSTU_BWD_DOT_ATTRS_DEFAULT = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]},
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
+    "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,5"]},
+    "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]},
+    "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,8", "opndD,tmem,1,11"]},
+})
+
+# TLX-aligned: mirror the hand-written TLX kernel (attn_bwd_ws) TMEM buffer scheme.
+# TLX reuses the dP tile in dq's TMEM slot (`dp_tiles reuse=dq_tiles`): dP is fully
+# consumed (folded into dqk_trans) before dq^T is produced, so they can share one
+# single-copy slot. Here that means dP's accumulator points at dq's buffer id 11
+# (the larger 128x64 tile, which subsumes dP's 64x64) instead of a separate id 5.
+# Stages/order match DEFAULT (== TLX: qkT/dpT/dv "current", dq/dk one iteration
+# behind). Everything single-copy, as in TLX (NUM_BUFFERS_TMEM=1).
+_HSTU_BWD_DOT_ATTRS_TLX = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]},
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
+    "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,11"]},
+    "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]},
+    "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,8", "opndD,tmem,1,11"]},
+})
+
+# Triton's @jit frontend accepts `attrs=` only as a dict literal or a bare
+# module-global name bound to a dict -- it rejects passing a FrozenDotAttrs (or
+# calling .get) as a kernel constexpr param or inside the kernel. So we expose the
+# ACTIVE schedule as per-dot module-global dicts that the dots reference by name,
+# and `set_bwd_dot_attrs()` swaps them (recompile picks up the new globals).
+#
+# ACTIVE = the TLX-aligned schedule+reuse: same SWP stages/order as DEFAULT
+# (qk/dP/dv stage-0 ahead, dq/dk stage-1 behind; order qk -> dq/dk -> dP/dv) AND
+# the hand-TLX TMEM reuse groups -- S+P share id2, and dP time-shares dqᵀ's slot
+# id11 (TLX `dp_tiles reuse=dq_tiles`, freeing id5). dk/dv/dsᵀ standalone. Switch
+# to _HSTU_BWD_DOT_ATTRS_DEFAULT (dP on its own id5) via set_bwd_dot_attrs().
+_HSTU_ATTRS_QKT = tl.constexpr(_HSTU_BWD_DOT_ATTRS_TLX.get("qkT"))
+_HSTU_ATTRS_DV = tl.constexpr(_HSTU_BWD_DOT_ATTRS_TLX.get("dv"))
+_HSTU_ATTRS_DPT = tl.constexpr(_HSTU_BWD_DOT_ATTRS_TLX.get("dpT"))
+_HSTU_ATTRS_DK = tl.constexpr(_HSTU_BWD_DOT_ATTRS_TLX.get("dk"))
+_HSTU_ATTRS_DQ = tl.constexpr(_HSTU_BWD_DOT_ATTRS_TLX.get("dq"))
+
+
+class FwdVariant(Enum):
+    TRITON = "triton"
+    TRITON_DYN_SPEC = "triton_dyn_spec"
+
+
+class BwdVariant(Enum):
+    AUTO = "auto"
+    TRITON_REDKV = "triton"
+    TRITON_REDQ = "triton_redq"
+    # Experimental: reduce_dq (per-kv-head, atomic-free) layout with the inner Q
+    # loop annotated for automatic warp specialization (autoWS / beta triton).
+    TRITON_AUTOWS = "triton_autows"
+    # Hand-written TLX warp-specialized reduce_dq (attn_bwd_ws). Dispatched here
+    # so the existing autograd path + tritonbench --bwd contract drive it.
+    TLX = "tlx"
+
+
+# Global variables for variant selection, can be overridden in unit tests
+FWD_VARIANT: FwdVariant = FwdVariant.TRITON_DYN_SPEC
+BWD_VARIANT: BwdVariant = BwdVariant.AUTO
+
+
+def set_fwd_variant(variant: FwdVariant) -> None:
+    """Set the forward variant globally. Useful for unit test coverage."""
+    global FWD_VARIANT
+    FWD_VARIANT = variant
+
+
+def set_bwd_variant(variant: BwdVariant) -> None:
+    """Set the backward variant globally. Useful for unit test coverage."""
+    global BWD_VARIANT
+    BWD_VARIANT = variant
+
+
+def get_fwd_variant() -> FwdVariant:
+    """Get the current forward variant."""
+    return FWD_VARIANT
+
+
+def get_bwd_variant() -> BwdVariant:
+    """Get the current backward variant."""
+    env = os.environ.get("HSTU_BWD_VARIANT")
+    if env:
+        return BwdVariant(env)
+    return BWD_VARIANT
+
+
+@triton.jit
+def _compute_offsets(
+    H,
+    G,
+    BLOCK_M: tl.constexpr,
+    seq_offsets_q,
+    seq_offsets,
+    max_seq_len,
+    TRUNCATE_METHOD: tl.constexpr,
+):
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    off_h = off_hz % H
+    off_h_kv = off_h // G
+    start_m = tl.program_id(0) * BLOCK_M
+    seq_start_kv = tl.load(seq_offsets + off_z)
+    seq_end_kv = tl.load(seq_offsets + off_z + 1)
+    seq_len_kv = (seq_end_kv - seq_start_kv).to(tl.int32)
+    if TRUNCATE_METHOD != "none":
+        truncated_len = tl.minimum(seq_len_kv, max_seq_len.to(tl.int32))
+        # KEEP_LAST: skip early tokens; KEEP_FIRST: keep start unchanged
+        if TRUNCATE_METHOD == "keep_last":
+            seq_start_kv = seq_start_kv + (seq_len_kv - truncated_len)
+        seq_len_kv = truncated_len
+    seq_start_q = tl.load(seq_offsets_q + off_z)
+    seq_end_q = tl.load(seq_offsets_q + off_z + 1)
+    seq_len_q = (seq_end_q - seq_start_q).to(tl.int32)
+
+    return (
+        start_m,
+        off_h,
+        off_h_kv,
+        seq_start_kv,
+        seq_len_kv,
+        seq_start_q,
+        seq_len_q,
+        off_z,
+    )
+
+
+def get_fwd_triton_configs() -> List[triton.Config]:
+    configs = [
+        triton.Config(
+            {
+                "BLOCK_M": bm,
+                "BLOCK_N": bn,
+                "TMA_STORE": tma_trans[0],
+                "TRANS": tma_trans[1],
+                "NUM_STAGES": ns,
+            },
+            num_stages=0,
+            num_warps=nw,
+        )
+        for bm in [32, 64, 128]
+        for bn in [32, 64, 128]
+        for nw in [2, 4, 8]
+        for ns in [1, 2, 4]
+        for off in [False]
+        for mask in [True]
+        for tma_trans in [(True, False), (False, True), (False, False)]
+        # trans doesn't work with TMA
+    ]
+    return configs
+
+
+@triton.jit
+def forward_valid_mask_trans(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL: tl.constexpr):
+    valid_mask = (offs_m[None, :] < seq_len_q) & (offs_n[:, None] < seq_len_kv)
+    if HAS_CAUSAL:
+        offs_m = offs_m + seq_len_kv - uih_len_q
+        causal_mask = offs_m[None, :] >= offs_n[:, None]
+        valid_mask = valid_mask & causal_mask
+    return valid_mask
+
+
+@triton.jit
+def forward_epilogue_trans(
+    acc,
+    l_i,
+    m_i,
+    offs_m,
+    seq_start_q,
+    stride_mm,
+    seq_len_q,
+    M,
+    off_h,
+    num_softmax_heads: tl.constexpr,
+):
+    if off_h + 1 < num_softmax_heads + 1:  # For AOTInductor lowering walkaround.
+        acc = acc / l_i[None, :]
+        m_i += tl.math.log2(l_i)
+        m_ptrs = M + (offs_m + seq_start_q) * stride_mm + off_h
+        tl.store(m_ptrs, m_i, mask=offs_m < seq_len_q)
+    return acc
+
+
+@triton.jit
+def _attn_fwd_compute(
+    acc,
+    alpha,
+    desc_k,
+    desc_v,
+    q,
+    K,
+    V,
+    offs_m,
+    offs_n_0,
+    off_h,
+    off_h_kv,
+    seq_start_kv,
+    seq_len_kv,
+    seq_start_q,
+    seq_len_q,
+    attn_scale,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_mm,
+    m_i,
+    l_i,
+    M,
+    start_m,
+    uih_len_q,
+    num_softmax_heads: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    TRANS: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    SHARED_KV: tl.constexpr,
+    ENABLE_TMA: tl.constexpr,
+    IS_SOFTMAX: tl.constexpr,
+    HAS_CAUSAL: tl.constexpr,
+):
+    if HAS_CAUSAL:
+        high = start_m + BLOCK_M + seq_len_kv - uih_len_q
+        high = tl.cdiv(min(high, seq_len_kv), BLOCK_N) * BLOCK_N
+        last_block_start_n = tl.maximum(0, (tl.cdiv(high, BLOCK_N) - 1) * BLOCK_N)
+    else:
+        last_block_start_n = tl.maximum(0, (tl.cdiv(seq_len_kv, BLOCK_N) - 1) * BLOCK_N)
+    if IS_SOFTMAX:
+        alpha = alpha * 1.44269504
+    # Main loop - no masking needed for non-last kv blocks
+    for start_n in tl.range(0, last_block_start_n, BLOCK_N):
+        if ENABLE_TMA:
+            k = desc_k.load([
+                (seq_start_kv + start_n).to(tl.int32),
+                off_h_kv * stride_kh,
+            ])
+        else:
+            offs_n_load = start_n + tl.arange(0, BLOCK_N)
+            offs_qk_d = tl.arange(0, HEAD_DIM)
+            k_ptrs = (K + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_kn +
+                      (off_h_kv * stride_kh + offs_qk_d)[None, :])
+            k = tl.load(k_ptrs)
+
+        if TRANS:
+            qk = tl.dot(k, tl.trans(q))  # BN by BM
+        else:
+            qk = tl.dot(q, tl.trans(k))  # BM by BN
+        if HAS_CAUSAL:
+            offs_n = offs_n_0 + start_n
+            if TRANS:
+                causal_mask = (offs_m[None, :] + seq_len_kv - uih_len_q) >= offs_n[:, None]
+            else:
+                causal_mask = (offs_m[:, None] + seq_len_kv - uih_len_q) >= offs_n[None, :]
+            if IS_SOFTMAX:
+                qk = tl.where(causal_mask, qk, float("-inf"))
+            else:
+                qk = tl.where(causal_mask, qk, 0.0)
+        if IS_SOFTMAX:
+            qk = qk * alpha
+            if TRANS:
+                m_ij = tl.maximum(m_i, tl.max(qk, 0))
+                qk -= m_ij[None, :]
+                act_qk = tl.math.exp2(qk)
+                corr = tl.math.exp2(m_i - m_ij)
+                l_ij = tl.sum(act_qk, 0)
+                acc = acc * corr[None, :]
+            else:
+                m_ij = tl.maximum(m_i, tl.max(qk, 1))
+                qk -= m_ij[:, None]
+                act_qk = tl.math.exp2(qk)
+                corr = tl.math.exp2(m_i - m_ij)
+                l_ij = tl.sum(act_qk, 1)
+                acc = acc * corr[:, None]
+            l_i = l_i * corr + l_ij
+            m_i = m_ij
+        else:
+            qk = qk * alpha
+            act_qk = fast_silu(qk, MULT_BY_X=True)
+        if SHARED_KV:
+            v = k
+        else:
+            if ENABLE_TMA:
+                v = desc_v.load([
+                    (seq_start_kv + start_n).to(tl.int32),
+                    off_h_kv * stride_vh,
+                ])
+            else:
+                offs_n_load = start_n + tl.arange(0, BLOCK_N)
+                offs_v_d = tl.arange(0, BLOCK_D_V)
+                v_ptrs = (V + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_vn +
+                          (off_h_kv * stride_vh + offs_v_d)[None, :])
+                v = tl.load(v_ptrs)
+        act_qk = act_qk.to(v.dtype)
+        if TRANS:
+            acc += tl.dot(tl.trans(v), act_qk)
+        else:
+            acc += tl.dot(act_qk, v)
+
+    # Last kv block - needs masking for out-of-bounds elements;
+    # q masking is not needed here because we mask when storing results.
+    start_n = last_block_start_n
+    if ENABLE_TMA:
+        k = desc_k.load([
+            (seq_start_kv + start_n).to(tl.int32),
+            off_h_kv * stride_kh,
+        ])
+    else:
+        offs_n_load = start_n + tl.arange(0, BLOCK_N)
+        offs_qk_d = tl.arange(0, HEAD_DIM)
+        k_ptrs = (K + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_kn +
+                  (off_h_kv * stride_kh + offs_qk_d)[None, :])
+        k = tl.load(
+            k_ptrs,
+            mask=(offs_n_load < seq_len_kv)[:, None],
+            other=0.0,
+        )
+
+    offs_n = offs_n_0 + start_n
+    if TRANS:
+        qk = tl.dot(k, tl.trans(q))  # BN by BM
+    else:
+        qk = tl.dot(q, tl.trans(k))  # BM by BN
+    if TRANS:
+        valid_mask = forward_valid_mask_trans(
+            offs_m,
+            offs_n,
+            uih_len_q,
+            seq_len_q,
+            seq_len_kv,
+            HAS_CAUSAL,
+        )
+    else:
+        valid_mask = forward_valid_mask(
+            offs_m,
+            offs_n,
+            uih_len_q,
+            seq_len_q,
+            seq_len_kv,
+            HAS_CAUSAL,
+        )
+    if IS_SOFTMAX:
+        if TRANS:
+            act_qk, acc, l_i, m_i = forward_softmax_activation_trans_scaled_alpha(qk, alpha, valid_mask, m_i, acc, l_i)
+        else:
+            act_qk, acc, l_i, m_i = forward_softmax_activation_scaled_alpha(qk, alpha, valid_mask, m_i, acc, l_i)
+    else:
+        masked_alpha = tl.where(valid_mask, alpha, 0.0)
+        qk = qk * masked_alpha
+        act_qk = fast_silu(qk, MULT_BY_X=True)
+    if SHARED_KV:
+        v = k
+    else:
+        if ENABLE_TMA:
+            v = desc_v.load([
+                (seq_start_kv + start_n).to(tl.int32),
+                off_h_kv * stride_vh,
+            ])
+        else:
+            offs_n_load = start_n + tl.arange(0, BLOCK_N)
+            offs_v_d = tl.arange(0, BLOCK_D_V)
+            v_ptrs = (V + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_vn +
+                      (off_h_kv * stride_vh + offs_v_d)[None, :])
+            v = tl.load(
+                v_ptrs,
+                mask=(offs_n_load < seq_len_kv)[:, None],
+                other=0.0,
+            )
+    act_qk = act_qk.to(v.dtype)
+    if TRANS:
+        acc += tl.dot(tl.trans(v), act_qk)
+    else:
+        acc += tl.dot(act_qk, v)
+
+    # epilogue
+    if IS_SOFTMAX:
+        if TRANS:
+            acc = forward_epilogue_trans(
+                acc,
+                l_i,
+                m_i,
+                offs_m,
+                seq_start_q,
+                stride_mm,
+                seq_len_q,
+                M,
+                off_h,
+                num_softmax_heads,
+            )
+        else:
+            acc = forward_epilogue(
+                acc,
+                l_i,
+                m_i,
+                offs_m,
+                seq_start_q,
+                stride_mm,
+                seq_len_q,
+                M,
+                off_h,
+                num_softmax_heads,
+            )
+    else:
+        scale = tl.load(attn_scale).to(tl.float32)
+        acc = acc * scale
+    return acc
+
+
+@triton.jit
+def _attn_fwd_triton_inner(
+    alpha,
+    Z,
+    H,
+    desc_q,
+    desc_k,
+    desc_v,
+    Q,
+    K,
+    V,
+    Out,
+    seq_offsets_q,
+    seq_offsets,
+    max_seq_len,
+    attn_scale,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_om,
+    stride_oh,
+    start_m,
+    off_h,
+    off_h_kv,
+    seq_start_kv,
+    seq_len_kv,
+    seq_start_q,
+    seq_len_q,
+    M,
+    stride_mm,
+    uih_len_q,
+    num_softmax_heads: tl.constexpr,
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    TRANS: tl.constexpr,
+    TMA_STORE: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    SHARED_KV: tl.constexpr,
+    ENABLE_TMA: tl.constexpr,
+    HAS_CAUSAL: tl.constexpr,
+):
+    # initialize offsets
+    if start_m < seq_len_q:
+        offs_m = start_m + tl.arange(0, BLOCK_M)
+        offs_n_0 = tl.arange(0, BLOCK_N)
+        qo_offset_y_split = seq_start_q + start_m
+        if ENABLE_TMA:
+            q = desc_q.load([qo_offset_y_split.to(tl.int32), off_h * stride_qh])
+        else:
+            offs_qk_d = tl.arange(0, HEAD_DIM)
+            q_ptrs = (Q + (qo_offset_y_split + tl.arange(0, BLOCK_M)).to(tl.int64)[:, None] * stride_qm +
+                      (off_h * stride_qh + offs_qk_d)[None, :])
+            q = tl.load(
+                q_ptrs,
+                mask=(offs_m < seq_len_q)[:, None],
+                other=0.0,
+            )
+        m_i, l_i = forward_softmax_common_preprocess(off_h, num_softmax_heads, BLOCK_M)
+        if TRANS:
+            acc = tl.zeros([BLOCK_D_V, BLOCK_M], dtype=tl.float32)
+        else:
+            acc = tl.zeros([BLOCK_M, BLOCK_D_V], dtype=tl.float32)
+        # when seq_len_kv is 0, we can skip computation but still needs to write acc to out
+        # to avoid NaN.
+        if seq_len_kv > 0:
+            if off_h < num_softmax_heads:
+                acc = _attn_fwd_compute(
+                    acc,
+                    alpha,
+                    desc_k,
+                    desc_v,
+                    q,
+                    K,
+                    V,
+                    offs_m,
+                    offs_n_0,
+                    off_h,
+                    off_h_kv,
+                    seq_start_kv,
+                    seq_len_kv,
+                    seq_start_q,
+                    seq_len_q,
+                    attn_scale,
+                    stride_kn,
+                    stride_kh,
+                    stride_vn,
+                    stride_vh,
+                    stride_mm,
+                    m_i,
+                    l_i,
+                    M,
+                    start_m,
+                    uih_len_q,
+                    num_softmax_heads,
+                    HEAD_DIM,
+                    BLOCK_D_V,
+                    BLOCK_M,
+                    BLOCK_N,
+                    TRANS,
+                    NUM_STAGES,
+                    SHARED_KV,
+                    ENABLE_TMA,
+                    IS_SOFTMAX=True,
+                    HAS_CAUSAL=HAS_CAUSAL,
+                )
+            else:
+                acc = _attn_fwd_compute(
+                    acc,
+                    alpha,
+                    desc_k,
+                    desc_v,
+                    q,
+                    K,
+                    V,
+                    offs_m,
+                    offs_n_0,
+                    off_h,
+                    off_h_kv,
+                    seq_start_kv,
+                    seq_len_kv,
+                    seq_start_q,
+                    seq_len_q,
+                    attn_scale,
+                    stride_kn,
+                    stride_kh,
+                    stride_vn,
+                    stride_vh,
+                    stride_mm,
+                    m_i,
+                    l_i,
+                    M,
+                    start_m,
+                    uih_len_q,
+                    num_softmax_heads,
+                    HEAD_DIM,
+                    BLOCK_D_V,
+                    BLOCK_M,
+                    BLOCK_N,
+                    TRANS,
+                    NUM_STAGES,
+                    SHARED_KV,
+                    ENABLE_TMA,
+                    IS_SOFTMAX=False,
+                    HAS_CAUSAL=HAS_CAUSAL,
+                )
+        out_offset = off_h.to(tl.int64) * stride_oh
+        end_o = seq_start_q + seq_len_q
+        # we are writing out Out.T which is hDim x BM
+        if TMA_STORE and ENABLE_TMA:
+            if TRANS:  # This does not work
+                o_desc = tl.make_tensor_descriptor(
+                    Out,
+                    shape=[HEAD_DIM * H, end_o.to(tl.int32)],
+                    # pyrefly: ignore [bad-argument-type]
+                    strides=[1, HEAD_DIM * H],
+                    block_shape=[BLOCK_D_V, BLOCK_M],
+                )
+                o_desc.store(
+                    [
+                        (out_offset).to(tl.int32),
+                        (seq_start_q + start_m).to(tl.int32),
+                    ],
+                    acc.to(Out.dtype.element_ty),
+                )
+            else:
+                o_desc = tl.make_tensor_descriptor(
+                    Out,
+                    shape=[end_o.to(tl.int32), HEAD_DIM * H],
+                    # pyrefly: ignore [bad-argument-type]
+                    strides=[HEAD_DIM * H, 1],
+                    block_shape=[BLOCK_M, BLOCK_D_V],
+                )
+                o_desc.store(
+                    [
+                        (seq_start_q + start_m).to(tl.int32),
+                        (out_offset).to(tl.int32),
+                    ],
+                    acc.to(Out.dtype.element_ty),
+                )
+        else:
+            if TRANS:
+                off_o = Out + seq_start_q * stride_om + off_h * stride_oh
+                offs_m = start_m + tl.arange(0, BLOCK_M)
+                offs_v_d = tl.arange(0, BLOCK_D_V)
+                out_ptrs = off_o + offs_m[None, :] * stride_om + offs_v_d[:, None]
+                acc = acc.to(Out.dtype.element_ty)
+                tl.store(out_ptrs, acc, mask=(offs_m < seq_len_q)[None, :])
+            else:
+                off_o = Out + seq_start_q * stride_om + off_h * stride_oh
+                offs_m = start_m + tl.arange(0, BLOCK_M)
+                offs_v_d = tl.arange(0, BLOCK_D_V)
+                out_ptrs = off_o + offs_m[:, None] * stride_om + offs_v_d[None, :]
+                acc = acc.to(Out.dtype.element_ty)
+                tl.store(out_ptrs, acc, mask=(offs_m < seq_len_q)[:, None])
+
+
+@triton.autotune(
+    configs=get_fwd_triton_configs(),
+    key=[
+        "Z",
+        "HEAD_DIM",
+        "AUTOTUNE_MAX_Q_LEN",
+        "AUTOTUNE_MAX_SEQ_LEN",
+        "num_softmax_heads",
+    ],
+)
+@triton.jit
+def _attn_fwd_triton(
+    alpha,
+    Z,
+    H,
+    G,
+    Q,
+    K,
+    V,
+    total_seq_len_q,
+    total_seq_len_kv,
+    Out,
+    seq_offsets_q,
+    seq_offsets,
+    max_seq_len,
+    attn_scale,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_om,
+    stride_oh,
+    M,
+    stride_mm,
+    num_targets,
+    AUTOTUNE_MAX_Q_LEN,
+    AUTOTUNE_MAX_SEQ_LEN,
+    num_softmax_heads: tl.constexpr,
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    TRANS: tl.constexpr,
+    TMA_STORE: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    ENABLE_TMA: tl.constexpr,
+    TRUNCATE_METHOD: tl.constexpr,
+    HAS_CAUSAL: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+):
+    # Create TMA descriptors on device
+    H_kv = H // G
+    desc_q = None
+    desc_k = None
+    desc_v = None
+    if ENABLE_TMA:
+        desc_q = tl.make_tensor_descriptor(
+            Q,
+            shape=[total_seq_len_q, H * HEAD_DIM],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H * HEAD_DIM, 1],
+            block_shape=[BLOCK_M, HEAD_DIM],
+        )
+        desc_k = tl.make_tensor_descriptor(
+            K,
+            shape=[total_seq_len_kv, H_kv * HEAD_DIM],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H_kv * HEAD_DIM, 1],
+            block_shape=[BLOCK_N, HEAD_DIM],
+        )
+        desc_v = tl.make_tensor_descriptor(
+            V,
+            shape=[total_seq_len_kv, H_kv * BLOCK_D_V],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H_kv * BLOCK_D_V, 1],
+            block_shape=[BLOCK_N, BLOCK_D_V],
+        )
+
+    (
+        start_m,
+        off_h,
+        off_h_kv,
+        seq_start_kv,
+        seq_len_kv,
+        seq_start_q,
+        seq_len_q,
+        off_z,
+    ) = _compute_offsets(H, G, BLOCK_M, seq_offsets_q, seq_offsets, max_seq_len, TRUNCATE_METHOD)
+    if HAS_CAUSAL:
+        n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
+        uih_len_q = uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
+    else:
+        uih_len_q = seq_len_q
+    _attn_fwd_triton_inner(
+        alpha,
+        Z,
+        H,
+        desc_q,
+        desc_k,
+        desc_v,
+        Q,
+        K,
+        V,
+        Out,
+        seq_offsets_q,
+        seq_offsets,
+        max_seq_len,
+        attn_scale,
+        stride_qm,
+        stride_qh,
+        stride_kn,
+        stride_kh,
+        stride_vn,
+        stride_vh,
+        stride_om,
+        stride_oh,
+        start_m,
+        off_h,
+        off_h_kv,
+        seq_start_kv,
+        seq_len_kv,
+        seq_start_q,
+        seq_len_q,
+        M,
+        stride_mm,
+        uih_len_q,
+        num_softmax_heads,
+        HEAD_DIM,
+        BLOCK_D_V,
+        BLOCK_M,
+        BLOCK_N,
+        TRANS,
+        TMA_STORE,
+        NUM_STAGES,
+        SHARED_KV=False,
+        ENABLE_TMA=ENABLE_TMA,
+        HAS_CAUSAL=HAS_CAUSAL,
+    )
+
+
+def get_fwd_triton_spec_configs() -> List[triton.Config]:
+    if torch.version.hip:
+        configs = []
+        for BLOCK_M in [32, 64, 128]:
+            for BLOCK_N in [32, 64]:
+                for num_stages in [1, 2]:
+                    for num_warps in [4, 8]:
+                        for matrix_instr_nonkdim in [16, 32]:
+                            for waves_per_eu in [1, 2, 3]:
+                                configs.append(
+                                    triton.Config(
+                                        {
+                                            "BLOCK_M": BLOCK_M,
+                                            "BLOCK_N": BLOCK_N,
+                                            "BLOCK_M1": BLOCK_M,
+                                            "BLOCK_N1": BLOCK_N,
+                                            "TMA_STORE": False,
+                                            "TRANS": False,
+                                            "NUM_STAGES": num_stages,
+                                            "NUM_STAGES1": num_stages,
+                                            "matrix_instr_nonkdim": matrix_instr_nonkdim,
+                                            "waves_per_eu": waves_per_eu,
+                                            "kpack": 2,
+                                            "IS_DYNAMIC": False,
+                                        },
+                                        num_stages=num_stages,
+                                        num_warps=num_warps,
+                                    ))
+        return configs
+    if get_full_autotune():
+        configs = [
+            triton.Config(
+                {
+                    "BLOCK_M": bm,
+                    "BLOCK_N": bn,
+                    "BLOCK_M1": bm1,
+                    "BLOCK_N1": bn1,
+                    "TMA_STORE": tma_trans[0],
+                    "TRANS": tma_trans[1],
+                    "NUM_STAGES": ns,
+                    "NUM_STAGES1": ns1,
+                    "IS_DYNAMIC": is_dynamic,
+                },
+                num_stages=0,
+                num_warps=nw,
+            )
+            for bm in [64, 128]
+            for bn in [64, 128]
+            for bm1 in [32, 64]
+            for bn1 in [32, 64]
+            for nw in [2, 4, 8]
+            for ns in [2, 4]
+            for ns1 in [2, 4]
+            for tma_trans in [(True, False), (False, True), (False, False)]
+            for is_dynamic in [True, False]
+        ]
+    else:
+        configs = [
+            triton.Config(
+                {
+                    "BLOCK_M": 64,
+                    "BLOCK_N": 64,
+                    "BLOCK_M1": 32,
+                    "BLOCK_N1": 64,
+                    "TMA_STORE": False,
+                    "TRANS": True,
+                    "NUM_STAGES": 2,
+                    "NUM_STAGES1": 2,
+                    "IS_DYNAMIC": True,
+                },
+                num_stages=0,
+                num_warps=4,
+            ),
+            triton.Config(
+                {
+                    "BLOCK_M": 128,
+                    "BLOCK_N": 64,
+                    "BLOCK_M1": 32,
+                    "BLOCK_N1": 64,
+                    "TMA_STORE": False,
+                    "TRANS": True,
+                    "NUM_STAGES": 2,
+                    "NUM_STAGES1": 2,
+                    "IS_DYNAMIC": True,
+                },
+                num_stages=0,
+                num_warps=4,
+            ),
+            triton.Config(
+                {
+                    "BLOCK_M": 128,
+                    "BLOCK_N": 64,
+                    "BLOCK_M1": 64,
+                    "BLOCK_N1": 64,
+                    "TMA_STORE": False,
+                    "TRANS": True,
+                    "NUM_STAGES": 2,
+                    "NUM_STAGES1": 2,
+                    "IS_DYNAMIC": True,
+                },
+                num_stages=0,
+                num_warps=4,
+            ),
+            triton.Config(
+                {
+                    "BLOCK_M": 64,
+                    "BLOCK_N": 64,
+                    "BLOCK_M1": 32,
+                    "BLOCK_N1": 32,
+                    "TMA_STORE": False,
+                    "TRANS": True,
+                    "NUM_STAGES": 2,
+                    "NUM_STAGES1": 4,
+                    "IS_DYNAMIC": True,
+                },
+                num_stages=0,
+                num_warps=2,
+            ),
+            triton.Config(
+                {
+                    "BLOCK_M": 128,
+                    "BLOCK_N": 64,
+                    "BLOCK_M1": 32,
+                    "BLOCK_N1": 64,
+                    "TMA_STORE": False,
+                    "TRANS": False,
+                    "NUM_STAGES": 2,
+                    "NUM_STAGES1": 2,
+                    "IS_DYNAMIC": True,
+                },
+                num_stages=0,
+                num_warps=4,
+            ),
+            triton.Config(
+                {
+                    "BLOCK_M": 128,
+                    "BLOCK_N": 64,
+                    "BLOCK_M1": 64,
+                    "BLOCK_N1": 64,
+                    "TMA_STORE": False,
+                    "TRANS": False,
+                    "NUM_STAGES": 2,
+                    "NUM_STAGES1": 2,
+                    "IS_DYNAMIC": True,
+                },
+                num_stages=0,
+                num_warps=4,
+            ),
+        ]
+        if is_sm90():
+            # for H100 inference
+            configs += [
+                triton.Config(
+                    {
+                        "BLOCK_M": 64,
+                        "BLOCK_N": 64,
+                        "BLOCK_M1": 32,
+                        "BLOCK_N1": 64,
+                        "TMA_STORE": False,
+                        "TRANS": False,
+                        "NUM_STAGES": 4,
+                        "NUM_STAGES1": 4,
+                        "IS_DYNAMIC": True,
+                    },
+                    num_stages=0,
+                    num_warps=4,
+                ),
+                triton.Config(
+                    {
+                        "BLOCK_M": 64,
+                        "BLOCK_N": 64,
+                        "BLOCK_M1": 64,
+                        "BLOCK_N1": 64,
+                        "TMA_STORE": False,
+                        "TRANS": False,
+                        "NUM_STAGES": 4,
+                        "NUM_STAGES1": 4,
+                        "IS_DYNAMIC": False,
+                    },
+                    num_stages=0,
+                    num_warps=4,
+                ),
+                triton.Config(
+                    {
+                        "BLOCK_M": 64,
+                        "BLOCK_N": 64,
+                        "BLOCK_M1": 64,
+                        "BLOCK_N1": 64,
+                        "TMA_STORE": False,
+                        "TRANS": False,
+                        "NUM_STAGES": 2,
+                        "NUM_STAGES1": 2,
+                        "IS_DYNAMIC": False,
+                    },
+                    num_stages=0,
+                    num_warps=4,
+                ),
+                triton.Config(
+                    {
+                        "BLOCK_M": 128,
+                        "BLOCK_N": 64,
+                        "BLOCK_M1": 128,
+                        "BLOCK_N1": 64,
+                        "TMA_STORE": False,
+                        "TRANS": False,
+                        "NUM_STAGES": 4,
+                        "NUM_STAGES1": 4,
+                        "IS_DYNAMIC": False,
+                    },
+                    num_stages=0,
+                    num_warps=8,
+                ),
+                triton.Config(
+                    {
+                        "BLOCK_M": 128,
+                        "BLOCK_N": 64,
+                        "BLOCK_M1": 128,
+                        "BLOCK_N1": 64,
+                        "TMA_STORE": False,
+                        "TRANS": False,
+                        "NUM_STAGES": 4,
+                        "NUM_STAGES1": 4,
+                        "IS_DYNAMIC": False,
+                    },
+                    num_stages=0,
+                    num_warps=4,
+                ),
+            ]
+    return configs
+
+
+@triton_autotune(
+    configs=get_fwd_triton_spec_configs(),
+    key=[
+        "AUTOTUNE_Z",
+        "HEAD_DIM",
+        "AUTOTUNE_MAX_Q_LEN",
+        "AUTOTUNE_MAX_SEQ_LEN",
+        "num_softmax_heads",
+    ],
+)
+@triton.jit
+def _attn_fwd_triton_spec(
+    alpha,
+    Z,
+    H,
+    G,
+    Q,
+    K,
+    V,
+    total_seq_len_q,
+    total_seq_len_kv,
+    Out,
+    seq_offsets_q,
+    seq_offsets,
+    max_seq_len,
+    attn_scale,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_om,
+    stride_oh,
+    M,
+    stride_mm,
+    num_targets,
+    AUTOTUNE_Z,
+    AUTOTUNE_MAX_Q_LEN,
+    AUTOTUNE_MAX_SEQ_LEN,
+    num_softmax_heads: tl.constexpr,
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    TRANS: tl.constexpr,
+    TMA_STORE: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+    NUM_STAGES1: tl.constexpr,
+    SHARED_KV: tl.constexpr,
+    ENABLE_TMA: tl.constexpr,
+    IS_DYNAMIC: tl.constexpr,
+    TRUNCATE_METHOD: tl.constexpr,
+    HAS_CAUSAL: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+):
+    # Create TMA descriptors on device
+    H_kv = H // G
+    if ENABLE_TMA:
+        desc_q = tl.make_tensor_descriptor(
+            Q,
+            shape=[total_seq_len_q, H * HEAD_DIM],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H * HEAD_DIM, 1],
+            block_shape=[BLOCK_M, HEAD_DIM],
+        )
+        desc_k = tl.make_tensor_descriptor(
+            K,
+            shape=[total_seq_len_kv, H_kv * HEAD_DIM],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H_kv * HEAD_DIM, 1],
+            block_shape=[BLOCK_N, HEAD_DIM],
+        )
+        desc_v = tl.make_tensor_descriptor(
+            V,
+            shape=[total_seq_len_kv, H_kv * BLOCK_D_V],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H_kv * BLOCK_D_V, 1],
+            block_shape=[BLOCK_N, BLOCK_D_V],
+        )
+        desc_q1 = tl.make_tensor_descriptor(
+            Q,
+            shape=[total_seq_len_q, H * HEAD_DIM],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H * HEAD_DIM, 1],
+            block_shape=[BLOCK_M1, HEAD_DIM],
+        )
+        desc_k1 = tl.make_tensor_descriptor(
+            K,
+            shape=[total_seq_len_kv, H_kv * HEAD_DIM],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H_kv * HEAD_DIM, 1],
+            block_shape=[BLOCK_N1, HEAD_DIM],
+        )
+        desc_v1 = tl.make_tensor_descriptor(
+            V,
+            shape=[total_seq_len_kv, H_kv * BLOCK_D_V],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H_kv * BLOCK_D_V, 1],
+            block_shape=[BLOCK_N1, BLOCK_D_V],
+        )
+    else:
+        desc_q = None
+        desc_k = None
+        desc_v = None
+        desc_q1 = None
+        desc_k1 = None
+        desc_v1 = None
+
+    (
+        start_m,
+        off_h,
+        off_h_kv,
+        seq_start_kv,
+        seq_len_kv,
+        seq_start_q,
+        seq_len_q,
+        off_z,
+    ) = _compute_offsets(H, G, BLOCK_M, seq_offsets_q, seq_offsets, max_seq_len, TRUNCATE_METHOD)
+    if HAS_CAUSAL:
+        n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
+        uih_len_q = uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
+    else:
+        uih_len_q = seq_len_q
+    # DO NOT merge IS_DYNAMIC into a compound boolean expression
+    # (e.g. "if IS_DYNAMIC and condition:"). The Triton CC compiler
+    # passes constexprs as i32 and cannot bitcast i32 to i1 for the
+    # AND operator. Keeping IS_DYNAMIC as a standalone constexpr
+    # branch allows dead-code elimination without the bitcast.
+    if IS_DYNAMIC:
+        if start_m + BLOCK_M1 >= seq_len_q:
+            # Use smaller descriptors (BLOCK_M1, BLOCK_N1) for tail handling
+            _attn_fwd_triton_inner(
+                alpha,
+                Z,
+                H,
+                desc_q1,
+                desc_k1,
+                desc_v1,
+                Q,
+                K,
+                V,
+                Out,
+                seq_offsets_q,
+                seq_offsets,
+                max_seq_len,
+                attn_scale,
+                stride_qm,
+                stride_qh,
+                stride_kn,
+                stride_kh,
+                stride_vn,
+                stride_vh,
+                stride_om,
+                stride_oh,
+                start_m,
+                off_h,
+                off_h_kv,
+                seq_start_kv,
+                seq_len_kv,
+                seq_start_q,
+                seq_len_q,
+                M,
+                stride_mm,
+                uih_len_q,
+                num_softmax_heads,
+                HEAD_DIM,
+                BLOCK_D_V,
+                BLOCK_M1,
+                BLOCK_N1,
+                TRANS,
+                TMA_STORE,
+                NUM_STAGES1,
+                SHARED_KV=SHARED_KV,
+                ENABLE_TMA=ENABLE_TMA,
+                HAS_CAUSAL=HAS_CAUSAL,
+            )
+            return
+    _attn_fwd_triton_inner(
+        alpha,
+        Z,
+        H,
+        desc_q,
+        desc_k,
+        desc_v,
+        Q,
+        K,
+        V,
+        Out,
+        seq_offsets_q,
+        seq_offsets,
+        max_seq_len,
+        attn_scale,
+        stride_qm,
+        stride_qh,
+        stride_kn,
+        stride_kh,
+        stride_vn,
+        stride_vh,
+        stride_om,
+        stride_oh,
+        start_m,
+        off_h,
+        off_h_kv,
+        seq_start_kv,
+        seq_len_kv,
+        seq_start_q,
+        seq_len_q,
+        M,
+        stride_mm,
+        uih_len_q,
+        num_softmax_heads,
+        HEAD_DIM,
+        BLOCK_D_V,
+        BLOCK_M,
+        BLOCK_N,
+        TRANS,
+        TMA_STORE,
+        NUM_STAGES,
+        SHARED_KV=SHARED_KV,
+        ENABLE_TMA=ENABLE_TMA,
+        HAS_CAUSAL=HAS_CAUSAL,
+    )
+
+
+def _bwd_pre_hook_v3(nargs):
+    """Pre-hook for v3 TMA API backward kernel.
+
+    Zeros output gradient tensors (DK, DV) before each kernel launch.
+    """
+    if "DK" not in nargs:
+        return
+    if nargs.get("PER_KV_HEAD", False) and nargs["TRUNCATE_METHOD"] == "none":
+        return
+    nargs["DK"].zero_()
+    if not nargs["SHARED_KV"]:
+        nargs["DV"].zero_()
+
+
+def _get_triton_bw_configs() -> List[triton.Config]:
+    configs = [
+        triton.Config(
+            {
+                "BLOCK_M": M,
+                "BLOCK_N": N,
+                "BLOCK_M1": M1,
+                "BLOCK_N1": N1,
+            },
+            num_stages=ns,
+            num_warps=nw,
+            pre_hook=_bwd_pre_hook_v3,
+        ) for (M, N, M1, N1) in [
+            (128, 64, 32, 128),
+            (128, 64, 64, 64),
+            (64, 128, 32, 128),
+            (64, 64, 32, 64),
+            (64, 64, 32, 128),
+            (32, 64, 32, 64),
+            (32, 128, 32, 128),
+        ] for ns in [2, 3] for nw in [4, 8]
+    ]
+    return configs
+
+
+@triton.jit
+def _compute_bwd_offsets(
+    H,
+    G,
+    BLOCK_M,
+    seq_offsets_q,
+    seq_offsets,
+    max_seq_len,
+    TRUNCATE_METHOD: tl.constexpr,
+):
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    off_h = off_hz % H
+    off_h_kv = off_h // G
+    start_m = tl.program_id(0) * BLOCK_M
+    seq_start_kv = tl.load(seq_offsets + off_z).to(tl.int32)
+    seq_end_kv = tl.load(seq_offsets + off_z + 1).to(tl.int32)
+    seq_len_kv = (seq_end_kv - seq_start_kv).to(tl.int32)
+    # Truncate to last max_seq_len KV tokens if actual seq len exceeds max_seq_len
+    if TRUNCATE_METHOD != "none":
+        truncated_len = tl.minimum(seq_len_kv, max_seq_len.to(tl.int32))
+        if TRUNCATE_METHOD == "keep_last":
+            seq_start_kv = seq_start_kv + (seq_len_kv - truncated_len)
+        seq_len_kv = truncated_len
+    seq_start_q = tl.load(seq_offsets_q + off_z).to(tl.int32)
+    seq_end_q = tl.load(seq_offsets_q + off_z + 1).to(tl.int32)
+    seq_len_q = (seq_end_q - seq_start_q).to(tl.int32)
+
+    return (
+        off_h,
+        off_h_kv,
+        start_m,
+        seq_start_kv,
+        seq_len_kv,
+        seq_start_q,
+        seq_len_q,
+        off_z,
+    )
+
+
+@triton.jit
+def _compute_bwd_reduce_dq_offsets(
+    H,
+    G,
+    BLOCK_N,
+    seq_offsets_q,
+    seq_offsets,
+    max_seq_len,
+    TRUNCATE_METHOD: tl.constexpr,
+):
+    off_hz = tl.program_id(0)
+    off_z = off_hz // H
+    off_h = off_hz % H
+    off_h_kv = off_h // G
+    start_n = tl.program_id(1) * BLOCK_N
+    seq_start_kv = tl.load(seq_offsets + off_z).to(tl.int32)
+    seq_end_kv = tl.load(seq_offsets + off_z + 1).to(tl.int32)
+    seq_len_kv = (seq_end_kv - seq_start_kv).to(tl.int32)
+    # Truncate to last max_seq_len KV tokens if actual seq len exceeds max_seq_len
+    if TRUNCATE_METHOD != "none":
+        truncated_len = tl.minimum(seq_len_kv, max_seq_len.to(tl.int32))
+        if TRUNCATE_METHOD == "keep_last":
+            seq_start_kv = seq_start_kv + (seq_len_kv - truncated_len)
+        seq_len_kv = truncated_len
+    seq_start_q = tl.load(seq_offsets_q + off_z).to(tl.int32)
+    seq_end_q = tl.load(seq_offsets_q + off_z + 1).to(tl.int32)
+    seq_len_q = (seq_end_q - seq_start_q).to(tl.int32)
+
+    return (
+        off_h,
+        off_h_kv,
+        start_n,
+        seq_start_kv,
+        seq_len_kv,
+        seq_start_q,
+        seq_len_q,
+        off_z,
+    )
+
+
+def _bwd_pre_hook_redq_v3(nargs):
+    """
+    In the redq variant, the kernel parallelizes over K/V blocks:
+    - DQ: Multiple K/V blocks accumulate into the same Q locations via atomic_add (needs zeroing)
+    - DK, DV: Each kernel instance writes to distinct K/V locations via tl.store (no zeroing)
+    """
+    if "DQ" in nargs:
+        nargs["DQ"].zero_()
+        if nargs["TRUNCATE_METHOD"] != "none":
+            # When truncating KV, we need to zero out the entire dk/dv tensor
+            nargs["DK"].zero_()
+            if not nargs["SHARED_KV"]:
+                nargs["DV"].zero_()
+    # When G > 1 (GQA), multiple Q heads write to the same K/V head,
+    # so dk/dv must be zero-initialized for atomic accumulation
+    if nargs["G"] > 1 and not nargs.get("PER_KV_HEAD", False) and "DK" in nargs:
+        nargs["DK"].zero_()
+        if not nargs["SHARED_KV"]:
+            nargs["DV"].zero_()
+
+
+def _get_triton_bw_redq_configs() -> List[triton.Config]:
+    configs = [
+        triton.Config(
+            {
+                "BLOCK_M": M,
+                "BLOCK_N": N,
+            },
+            num_stages=ns,
+            num_warps=nw,
+            pre_hook=_bwd_pre_hook_redq_v3,
+        )
+        for M in [64]  #, 32]
+        for N in [128]  #, 128]
+        for ns in [2]  #, 3]
+        # EXPERIMENT (autoWS): force nw=4 only to test whether the PSM warp-budget
+        # guard (skip WS if estimate > 16) is what suppresses warp specialization.
+        for nw in [4]
+        if not (N == 128 and ns == 3)  # pruned: OOM on shared memory
+    ]
+    return configs
+
+
+@triton_autotune(
+    configs=_get_triton_bw_redq_configs(),
+    key=[
+        "AUTOTUNE_Z",
+        "H",
+        "max_q_len",
+        "AUTOTUNE_MAX_SEQ_LEN",
+        "DimQ",
+        "DimV",
+        "num_softmax_heads",
+    ],
+)
+@triton.jit
+def _hstu_attn_bwd_redq(  # noqa C901
+    Q,
+    K,
+    V,
+    DO,
+    total_seq_len_q,
+    total_seq_len_kv,
+    seq_offsets,
+    seq_offsets_q,
+    DQ,
+    DK,
+    DV,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_dom,
+    stride_doh,
+    stride_dqm,
+    stride_dqh,
+    stride_dkn,
+    stride_dkh,
+    stride_dvn,
+    stride_dvh,
+    alpha,
+    max_seq_len,
+    attn_scale,
+    M,
+    Delta,
+    stride_mm,
+    num_targets,
+    Z,
+    AUTOTUNE_Z,
+    H,
+    G: tl.constexpr,
+    num_softmax_heads: tl.constexpr,
+    max_q_len: tl.constexpr,
+    AUTOTUNE_MAX_SEQ_LEN,  # Quantized MAX_SEQ_LEN used as an autotuning key
+    DimQ: tl.constexpr,
+    DimV: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    SHARED_KV: tl.constexpr,
+    TRUNCATE_METHOD: tl.constexpr,
+    HAS_CAUSAL: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+    # pyrefly: ignore [bad-function-definition]
+    PER_KV_HEAD: tl.constexpr = False,
+    # pyrefly: ignore [bad-function-definition]
+    AUTOWS: tl.constexpr = False,
+    # gates warp-specialization behavior only (see _hstu_attn_bwd_inner); normally
+    # == AUTOWS, but AUTOWS=True/WS_ON=False = autoWS structure with WS disabled.
+    WS_ON: tl.constexpr = False,
+):
+    if PER_KV_HEAD:
+        # Per-KV-head (atomic-free GQA) variant
+        H_kv = H // G
+        off_hz = tl.program_id(0)
+        off_z = off_hz // H_kv
+        off_h_kv = off_hz % H_kv
+        seq_start_kv = tl.load(seq_offsets + off_z).to(tl.int32)
+        seq_end_kv = tl.load(seq_offsets + off_z + 1).to(tl.int32)
+        seq_len_kv = (seq_end_kv - seq_start_kv).to(tl.int32)
+        if TRUNCATE_METHOD != "none":
+            truncated_len = tl.minimum(seq_len_kv, max_seq_len.to(tl.int32))
+            if TRUNCATE_METHOD == "keep_last":
+                seq_start_kv = seq_start_kv + (seq_len_kv - truncated_len)
+            seq_len_kv = truncated_len
+        seq_start_q = tl.load(seq_offsets_q + off_z).to(tl.int32)
+        seq_end_q = tl.load(seq_offsets_q + off_z + 1).to(tl.int32)
+        seq_len_q = (seq_end_q - seq_start_q).to(tl.int32)
+        if HAS_CAUSAL:
+            n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
+            uih_len_q = uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
+        else:
+            uih_len_q = seq_len_q
+        if seq_len_kv == 0 or seq_len_q == 0:
+            return
+
+        desc_q = tl.make_tensor_descriptor(
+            Q,
+            shape=[total_seq_len_q, H * DimQ],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H * DimQ, 1],
+            block_shape=[BLOCK_M, DimQ],
+        )
+        desc_do = tl.make_tensor_descriptor(
+            DO,
+            shape=[total_seq_len_q, H * DimV],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H * DimV, 1],
+            block_shape=[BLOCK_M, DimV],
+        )
+        desc_k = tl.make_tensor_descriptor(
+            K,
+            shape=[total_seq_len_kv, H_kv * DimQ],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H_kv * DimQ, 1],
+            block_shape=[BLOCK_N, DimQ],
+        )
+        desc_v = tl.make_tensor_descriptor(
+            V,
+            shape=[total_seq_len_kv, H_kv * DimV],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H_kv * DimV, 1],
+            block_shape=[BLOCK_N, DimV],
+        )
+        end_dq = seq_start_q + seq_len_q
+        desc_dq = tl.make_tensor_descriptor(
+            DQ,
+            shape=[end_dq.to(tl.int32), DimQ * H],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[DimQ * H, 1],
+            block_shape=[BLOCK_M, DimQ],
+        )
+
+        offs_qk_d = tl.arange(0, DimQ)
+        offs_v_d = tl.arange(0, DimV)
+        tl.static_assert(ATTN_SCALE_TYPE == "scalar")
+        scale = tl.load(attn_scale).to(tl.float32)
+
+        for start_n in tl.range(0, seq_len_kv, BLOCK_N, num_stages=1):
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            mask_n = offs_n < seq_len_kv
+            k_offset = (seq_start_kv + start_n).to(tl.int32)
+            k = desc_k.load([k_offset, off_h_kv * stride_kh])
+            if SHARED_KV:
+                v = k
+            else:
+                v = desc_v.load([k_offset, off_h_kv * stride_vh])
+            dk = tl.zeros([BLOCK_N, DimQ], dtype=tl.float32)
+            if not SHARED_KV:
+                dv = tl.zeros([BLOCK_N, DimV], dtype=tl.float32)
+            for g in range(G):
+                off_h = off_h_kv * G + g
+                if off_h < num_softmax_heads:
+                    scaled_alpha = alpha * 1.44269504
+                else:
+                    scaled_alpha = alpha
+                M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q,
+                                                              stride_mm)
+                # EXPERIMENT (autoWS): warp_specialize the inner Q loop. The
+                # `warp_specialize` kwarg only exists in beta triton, so this
+                # variant must be built with -m ovr_config//triton:beta. Guard
+                # before landing (constexpr-branch the tl.range on AUTOWS).
+                for start_m in tl.range(0, seq_len_q, BLOCK_M, num_stages=1, warp_specialize=WS_ON):
+                    offs_m = start_m + tl.arange(0, BLOCK_M)
+                    mask_m = offs_m < seq_len_q
+                    valid_mask_trans = backward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
+                    q_offset = (seq_start_q + start_m).to(tl.int32)
+                    q = desc_q.load([q_offset, off_h * stride_qh])
+                    do = desc_do.load([q_offset, off_h * stride_doh])
+                    qk_trans = tl.dot(k, tl.trans(q), allow_tf32=ALLOW_TF32)
+                    if off_h < num_softmax_heads:
+                        qk_trans, act_qk_trans, pT = (backward_softmax_activation_scaled_alpha(
+                            qk_trans,
+                            scaled_alpha,
+                            valid_mask_trans,
+                            M_off,
+                            offs_m,
+                            stride_mm,
+                            mask_m,
+                            k,
+                        ))
+                    else:
+                        qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans,
+                                                                              k.dtype, scale)
+                    if SHARED_KV:
+                        dk += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+                    else:
+                        # pyrefly: ignore [unbound-name]
+                        dv += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+                    dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
+                    if off_h < num_softmax_heads:
+                        dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m,
+                                                                  pT)
+                    else:
+                        dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
+                    dqk_trans = dqk_trans.to(k.dtype)
+                    dk += tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32) * alpha
+                    dq_trans = (tl.dot(tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32) * alpha)
+                    dq = tl.trans(dq_trans)
+                    desc_dq.store(
+                        [q_offset, DimQ * off_h],
+                        dq.to(desc_dq.dtype),
+                        store_reduce="add",
+                    )
+            DK_off = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
+                      off_h_kv * tl.cast(stride_dkh, tl.int64))
+            dk_ptrs = DK_off + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
+            tl.store(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None])
+            if not SHARED_KV:
+                DV_off = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
+                          off_h_kv * tl.cast(stride_dvh, tl.int64))
+                dv_ptrs = DV_off + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
+                # pyrefly: ignore [unbound-name]
+                tl.store(dv_ptrs, dv.to(k.dtype), mask=mask_n[:, None])
+        return
+    (
+        off_h,
+        off_h_kv,
+        start_n,
+        seq_start_kv,
+        seq_len_kv,
+        seq_start_q,
+        seq_len_q,
+        off_z,
+    ) = _compute_bwd_reduce_dq_offsets(
+        H,
+        G,
+        BLOCK_N,
+        seq_offsets_q,
+        seq_offsets,
+        max_seq_len,
+        TRUNCATE_METHOD,
+    )
+    n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
+    uih_len_q = uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
+    # It is possible that uih_len is 0, need to handle this case
+    # to avoid illegal instruction error using on-device tma store
+    # for dk.
+    if seq_len_kv == 0:
+        return
+    # Create TMA descriptors on device
+    H_kv = H // G
+    desc_q = tl.make_tensor_descriptor(
+        Q,
+        shape=[total_seq_len_q, H * DimQ],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H * DimQ, 1],
+        block_shape=[BLOCK_M, DimQ],
+    )
+    desc_k = tl.make_tensor_descriptor(
+        K,
+        shape=[total_seq_len_kv, H_kv * DimQ],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H_kv * DimQ, 1],
+        block_shape=[BLOCK_N, DimQ],
+    )
+    desc_v = tl.make_tensor_descriptor(
+        V,
+        shape=[total_seq_len_kv, H_kv * DimV],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H_kv * DimV, 1],
+        block_shape=[BLOCK_N, DimV],
+    )
+    desc_do = tl.make_tensor_descriptor(
+        DO,
+        shape=[total_seq_len_q, H * DimV],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H * DimV, 1],
+        block_shape=[BLOCK_M, DimV],
+    )
+    end_kv = seq_start_kv + seq_len_kv
+    desc_dk = tl.make_tensor_descriptor(
+        DK,
+        shape=[end_kv.to(tl.int32), DimQ * H_kv],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[DimQ * H_kv, 1],
+        block_shape=[BLOCK_N, DimQ],
+    )
+    end_dq = seq_start_q + seq_len_q
+    desc_dq = tl.make_tensor_descriptor(
+        DQ,
+        shape=[end_dq.to(tl.int32), DimQ * H],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[DimQ * H, 1],
+        block_shape=[BLOCK_M, DimQ],
+    )
+    last_block_start_n = tl.maximum(0, (tl.cdiv(seq_len_kv, BLOCK_N) - 1) * BLOCK_N)
+    if AUTOWS:
+        # AutoWS requires a SINGLE inner-loop structure. The peeled main-loop +
+        # separate masked-last-block call below expands (via inlining) into TWO
+        # inner Q-loops, so the memory planner merges the two loops' per-iteration
+        # TMEM slots into one cross-loop reuse group that the reuse-barrier pass
+        # cannot order ("TMEM reuse group has no unique dependency-chain order").
+        # Match the TLX kernel (attn_bwd_ws): iterate every KV block in one masked
+        # loop — masking is a no-op for full blocks. Kept autoWS-only (constexpr)
+        # so the non-WS peeled fast path is unchanged.
+        for start_n in tl.range(0, seq_len_kv, BLOCK_N):
+            _hstu_attn_bwd_inner(
+                start_n,
+                seq_start_kv,
+                seq_len_kv,
+                seq_start_q,
+                seq_len_q,
+                desc_q,
+                desc_k,
+                desc_v,
+                desc_do,
+                desc_dk,
+                desc_dq,
+                DV,
+                stride_qh,
+                stride_kh,
+                stride_vh,
+                stride_doh,
+                stride_dvn,
+                stride_dvh,
+                alpha,
+                attn_scale,
+                M,
+                Delta,
+                stride_mm,
+                off_h,
+                off_h_kv,
+                H_kv,
+                uih_len_q,
+                num_softmax_heads,
+                DimQ,
+                DimV,
+                ALLOW_TF32,
+                BLOCK_M,
+                BLOCK_N,
+                ATTN_SCALE_TYPE,
+                G > 1,  # GQA_ATOMIC_ADD
+                SHARED_KV,
+                True,  # MASK_KV
+                HAS_CAUSAL,
+                AUTOWS,
+                WS_ON,
+            )
+        return
+    for start_n in tl.range(0, last_block_start_n, BLOCK_N):
+        _hstu_attn_bwd_inner(
+            start_n,
+            seq_start_kv,
+            seq_len_kv,
+            seq_start_q,
+            seq_len_q,
+            desc_q,
+            desc_k,
+            desc_v,
+            desc_do,
+            desc_dk,
+            desc_dq,
+            DV,
+            stride_qh,
+            stride_kh,
+            stride_vh,
+            stride_doh,
+            stride_dvn,
+            stride_dvh,
+            alpha,
+            attn_scale,
+            M,
+            Delta,
+            stride_mm,
+            off_h,
+            off_h_kv,
+            H_kv,
+            uih_len_q,
+            num_softmax_heads,
+            DimQ,
+            DimV,
+            ALLOW_TF32,
+            BLOCK_M,
+            BLOCK_N,
+            ATTN_SCALE_TYPE,
+            GQA_ATOMIC_ADD=G > 1,
+            SHARED_KV=SHARED_KV,
+            MASK_KV=False,
+            HAS_CAUSAL=HAS_CAUSAL,
+            AUTOWS=AUTOWS,
+        )
+    # Handle last block with masking
+    _hstu_attn_bwd_inner(
+        last_block_start_n,
+        seq_start_kv,
+        seq_len_kv,
+        seq_start_q,
+        seq_len_q,
+        desc_q,
+        desc_k,
+        desc_v,
+        desc_do,
+        desc_dk,
+        desc_dq,
+        DV,
+        stride_qh,
+        stride_kh,
+        stride_vh,
+        stride_doh,
+        stride_dvn,
+        stride_dvh,
+        alpha,
+        attn_scale,
+        M,
+        Delta,
+        stride_mm,
+        off_h,
+        off_h_kv,
+        H_kv,
+        uih_len_q,
+        num_softmax_heads,
+        DimQ,
+        DimV,
+        ALLOW_TF32,
+        BLOCK_M,
+        BLOCK_N,
+        ATTN_SCALE_TYPE,
+        GQA_ATOMIC_ADD=G > 1,
+        SHARED_KV=SHARED_KV,
+        MASK_KV=True,
+        HAS_CAUSAL=HAS_CAUSAL,
+        AUTOWS=AUTOWS,
+    )
+
+
+@triton_autotune(
+    configs=_get_triton_bw_redq_configs(),
+    key=[
+        "AUTOTUNE_Z",
+        "H",
+        "AUTOTUNE_MAX_Q_LEN",
+        "AUTOTUNE_MAX_SEQ_LEN",
+        "DimQ",
+        "DimV",
+        "num_softmax_heads",
+    ],
+)
+@triton.jit
+def _hstu_attn_bwd(  # noqa C901
+    Q,
+    K,
+    V,
+    DO,
+    total_seq_len_q,
+    total_seq_len_kv,
+    seq_offsets,
+    seq_offsets_q,
+    DQ,
+    DK,
+    DV,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_dom,
+    stride_doh,
+    stride_dqm,
+    stride_dqh,
+    stride_dkn,
+    stride_dkh,
+    stride_dvn,
+    stride_dvh,
+    alpha,
+    max_seq_len,
+    attn_scale,
+    M,
+    Delta,
+    stride_mm,
+    num_targets,
+    Z,
+    AUTOTUNE_Z,
+    H,
+    G,
+    num_softmax_heads: tl.constexpr,
+    AUTOTUNE_MAX_Q_LEN,  # Quantized MAX_Q_LEN used as an autotuning key
+    AUTOTUNE_MAX_SEQ_LEN,  # Quantized MAX_SEQ_LEN used as an autotuning key
+    DimQ: tl.constexpr,
+    DimV: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    SHARED_KV: tl.constexpr,
+    TRUNCATE_METHOD: tl.constexpr,
+    HAS_CAUSAL: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+):
+    (
+        off_h,
+        off_h_kv,
+        start_n,
+        seq_start_kv,
+        seq_len_kv,
+        seq_start_q,
+        seq_len_q,
+        off_z,
+    ) = _compute_bwd_reduce_dq_offsets(
+        H,
+        G,
+        BLOCK_N,
+        seq_offsets_q,
+        seq_offsets,
+        max_seq_len,
+        TRUNCATE_METHOD,
+    )
+    if HAS_CAUSAL:
+        n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
+        uih_len_q = uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
+    else:
+        uih_len_q = seq_len_q
+    if seq_len_kv == 0:
+        return
+    # Create TMA descriptors on device
+    H_kv = H // G
+    desc_q = tl.make_tensor_descriptor(
+        Q,
+        shape=[total_seq_len_q, H * DimQ],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H * DimQ, 1],
+        block_shape=[BLOCK_M, DimQ],
+    )
+    desc_k = tl.make_tensor_descriptor(
+        K,
+        shape=[total_seq_len_kv, H_kv * DimQ],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H_kv * DimQ, 1],
+        block_shape=[BLOCK_N, DimQ],
+    )
+    desc_v = tl.make_tensor_descriptor(
+        V,
+        shape=[total_seq_len_kv, H_kv * DimV],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H_kv * DimV, 1],
+        block_shape=[BLOCK_N, DimV],
+    )
+    desc_do = tl.make_tensor_descriptor(
+        DO,
+        shape=[total_seq_len_q, H * DimV],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H * DimV, 1],
+        block_shape=[BLOCK_M, DimV],
+    )
+    end_kv = seq_start_kv + seq_len_kv
+    desc_dk = tl.make_tensor_descriptor(
+        DK,
+        shape=[end_kv.to(tl.int32), DimQ * H_kv],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[DimQ * H_kv, 1],
+        block_shape=[BLOCK_N, DimQ],
+    )
+    end_dq = seq_start_q + seq_len_q
+    desc_dq = tl.make_tensor_descriptor(
+        DQ,
+        shape=[end_dq.to(tl.int32), DimQ * H],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[DimQ * H, 1],
+        block_shape=[BLOCK_M, DimQ],
+    )
+    last_block_start_n = tl.maximum(0, (tl.cdiv(seq_len_kv, BLOCK_N) - 1) * BLOCK_N)
+    short_q = seq_len_q <= BLOCK_M
+    if short_q:
+        q_offset = seq_start_q
+        offs_m = tl.arange(0, BLOCK_M)
+        mask_m = offs_m < seq_len_q
+        tl.static_assert(ATTN_SCALE_TYPE == "scalar")
+        scale = tl.load(attn_scale).to(tl.float32)
+        M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm)
+        DK_off = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
+                  off_h_kv * tl.cast(stride_dkh, tl.int64))
+        DV_off = DV
+        if not SHARED_KV:
+            DV_off = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
+                      off_h_kv * tl.cast(stride_dvh, tl.int64))
+        dq_acc = tl.zeros([DimQ, BLOCK_M], dtype=tl.float32)
+        if off_h < num_softmax_heads:
+            scaled_alpha = alpha * 1.44269504
+        else:
+            scaled_alpha = alpha
+        q = desc_q.load([q_offset.to(tl.int32), off_h * stride_qh])
+        do = desc_do.load([q_offset.to(tl.int32), off_h * stride_doh])
+        q_trans = tl.trans(q)
+        for start_n in tl.range(0, seq_len_kv, BLOCK_N):
+            k_offset = (seq_start_kv + start_n).to(tl.int32)
+            k = desc_k.load([k_offset, off_h_kv * stride_kh])
+            if SHARED_KV:
+                v = k
+            else:
+                v = desc_v.load([k_offset, off_h_kv * stride_vh])
+            qk_trans = tl.dot(k, q_trans)
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            valid_mask_trans = (offs_n[:, None] < seq_len_kv) & (offs_m[None, :] < seq_len_q)
+            if off_h < num_softmax_heads:
+                qk_trans, act_qk_trans, pT = backward_softmax_activation_scaled_alpha(
+                    qk_trans,
+                    scaled_alpha,
+                    valid_mask_trans,
+                    M_off,
+                    offs_m,
+                    stride_mm,
+                    mask_m,
+                    k,
+                )
+            else:
+                qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans, k.dtype, scale)
+            if SHARED_KV:
+                dk = tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+            else:
+                dv = tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+            dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
+            if off_h < num_softmax_heads:
+                dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT)
+            else:
+                dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
+            dqk_trans = dqk_trans.to(k.dtype)
+            if SHARED_KV:
+                dk_attn = tl.dot(dqk_trans, tl.trans(q_trans), allow_tf32=ALLOW_TF32)
+                # pyrefly: ignore [unbound-name]
+                dk = dk + dk_attn * alpha
+            else:
+                dk = tl.dot(dqk_trans, tl.trans(q_trans), allow_tf32=ALLOW_TF32) * alpha
+            offs_qk_d = tl.arange(0, DimQ)
+            dk_ptrs = DK_off + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
+            mask_n = offs_n < seq_len_kv
+            if G > 1:
+                tl.atomic_add(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None], sem="relaxed")
+            else:
+                tl.store(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None])
+            if not SHARED_KV:
+                offs_v_d = tl.arange(0, DimV)
+                dv_ptrs = DV_off + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
+                if G > 1:
+                    tl.atomic_add(
+                        # pyrefly: ignore [unbound-name]
+                        dv_ptrs,
+                        # pyrefly: ignore [unbound-name]
+                        dv.to(k.dtype),
+                        mask=mask_n[:, None],
+                        sem="relaxed",
+                    )
+                else:
+                    # pyrefly: ignore [unbound-name]
+                    tl.store(dv_ptrs, dv.to(k.dtype), mask=mask_n[:, None])
+            dq_trans = tl.dot(tl.trans(k), dqk_trans)
+            dq_trans = dq_trans * alpha
+            dq_acc += dq_trans
+        dq = tl.trans(dq_acc)
+        dq_ptrs = (DQ + (seq_start_q + offs_m[:, None]) * stride_dqm + off_h * stride_dqh + tl.arange(0, DimQ)[None, :])
+        tl.store(dq_ptrs, dq.to(DQ.dtype.element_ty), mask=mask_m[:, None])
+    else:
+        for start_n in tl.range(0, last_block_start_n, BLOCK_N):
+            _hstu_attn_bwd_inner(
+                start_n,
+                seq_start_kv,
+                seq_len_kv,
+                seq_start_q,
+                seq_len_q,
+                desc_q,
+                desc_k,
+                desc_v,
+                desc_do,
+                desc_dk,
+                desc_dq,
+                DV,
+                stride_qh,
+                stride_kh,
+                stride_vh,
+                stride_doh,
+                stride_dvn,
+                stride_dvh,
+                alpha,
+                attn_scale,
+                M,
+                Delta,
+                stride_mm,
+                off_h,
+                off_h_kv,
+                H_kv,
+                uih_len_q,
+                num_softmax_heads,
+                DimQ,
+                DimV,
+                ALLOW_TF32,
+                BLOCK_M,
+                BLOCK_N,
+                ATTN_SCALE_TYPE,
+                GQA_ATOMIC_ADD=G > 1,
+                SHARED_KV=SHARED_KV,
+                MASK_KV=False,
+                HAS_CAUSAL=HAS_CAUSAL,
+            )
+        _hstu_attn_bwd_inner(
+            last_block_start_n,
+            seq_start_kv,
+            seq_len_kv,
+            seq_start_q,
+            seq_len_q,
+            desc_q,
+            desc_k,
+            desc_v,
+            desc_do,
+            desc_dk,
+            desc_dq,
+            DV,
+            stride_qh,
+            stride_kh,
+            stride_vh,
+            stride_doh,
+            stride_dvn,
+            stride_dvh,
+            alpha,
+            attn_scale,
+            M,
+            Delta,
+            stride_mm,
+            off_h,
+            off_h_kv,
+            H_kv,
+            uih_len_q,
+            num_softmax_heads,
+            DimQ,
+            DimV,
+            ALLOW_TF32,
+            BLOCK_M,
+            BLOCK_N,
+            ATTN_SCALE_TYPE,
+            GQA_ATOMIC_ADD=G > 1,
+            SHARED_KV=SHARED_KV,
+            MASK_KV=True,
+            HAS_CAUSAL=HAS_CAUSAL,
+        )
+
+
+@triton_autotune(
+    configs=_get_triton_bw_configs(),
+    key=[
+        "AUTOTUNE_Z",
+        "H",
+        "max_q_len",
+        "AUTOTUNE_MAX_SEQ_LEN",
+        "DimQ",
+        "DimV",
+        "num_softmax_heads",
+        "PER_KV_HEAD",
+    ],
+)
+@triton.jit
+def _hstu_attn_bwd_redkv(
+    Q,
+    K,
+    V,
+    DO,
+    total_seq_len_q,
+    total_seq_len_kv,
+    seq_offsets,
+    seq_offsets_q,
+    DQ,
+    DK,
+    DV,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_dom,
+    stride_doh,
+    stride_dqm,
+    stride_dqh,
+    stride_dkn,
+    stride_dkh,
+    stride_dvn,
+    stride_dvh,
+    alpha,
+    max_seq_len,
+    attn_scale,
+    M,
+    Delta,
+    stride_mm,
+    num_targets,
+    Z,
+    AUTOTUNE_Z,
+    H,
+    G: tl.constexpr,
+    num_softmax_heads: tl.constexpr,
+    max_q_len: tl.constexpr,
+    AUTOTUNE_MAX_SEQ_LEN,  # Quantized MAX_SEQ_LEN used as an autotuning key
+    DimQ: tl.constexpr,
+    DimV: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_M1: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_N1: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    SHARED_KV: tl.constexpr,
+    TRUNCATE_METHOD: tl.constexpr,
+    HAS_CAUSAL: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+    # pyrefly: ignore [bad-function-definition]
+    PER_KV_HEAD: tl.constexpr = False,
+):
+    # Per-KV-head atomic-free GQA mode
+    if PER_KV_HEAD:
+        H_kv = H // G
+        off_hz = tl.program_id(0)
+        off_z = off_hz // H_kv
+        off_h_kv = off_hz % H_kv
+        seq_start_kv = tl.load(seq_offsets + off_z).to(tl.int32)
+        seq_end_kv = tl.load(seq_offsets + off_z + 1).to(tl.int32)
+        seq_len_kv = (seq_end_kv - seq_start_kv).to(tl.int32)
+        if TRUNCATE_METHOD != "none":
+            truncated_len = tl.minimum(seq_len_kv, max_seq_len.to(tl.int32))
+            if TRUNCATE_METHOD == "keep_last":
+                seq_start_kv = seq_start_kv + (seq_len_kv - truncated_len)
+            seq_len_kv = truncated_len
+        seq_start_q = tl.load(seq_offsets_q + off_z).to(tl.int32)
+        seq_end_q = tl.load(seq_offsets_q + off_z + 1).to(tl.int32)
+        seq_len_q = (seq_end_q - seq_start_q).to(tl.int32)
+        if HAS_CAUSAL:
+            n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
+            uih_len_q = uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
+        else:
+            uih_len_q = seq_len_q
+        if seq_len_q == 0:
+            return
+
+        desc_q = tl.make_tensor_descriptor(
+            Q,
+            shape=[total_seq_len_q, H * DimQ],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H * DimQ, 1],
+            block_shape=[BLOCK_M, DimQ],
+        )
+        desc_do = tl.make_tensor_descriptor(
+            DO,
+            shape=[total_seq_len_q, H * DimV],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H * DimV, 1],
+            block_shape=[BLOCK_M, DimV],
+        )
+        desc_k = tl.make_tensor_descriptor(
+            K,
+            shape=[total_seq_len_kv, H_kv * DimQ],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H_kv * DimQ, 1],
+            block_shape=[BLOCK_N, DimQ],
+        )
+        desc_v = tl.make_tensor_descriptor(
+            V,
+            shape=[total_seq_len_kv, H_kv * DimV],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H_kv * DimV, 1],
+            block_shape=[BLOCK_N, DimV],
+        )
+
+        offs_qk_d = tl.arange(0, DimQ)
+        offs_v_d = tl.arange(0, DimV)
+        tl.static_assert(ATTN_SCALE_TYPE == "scalar")
+        scale = tl.load(attn_scale).to(tl.float32)
+
+        if max_q_len <= BLOCK_M and G * BLOCK_M * DimQ <= 32768:
+            # One KV sweep: dk/dv folded over G, dq carried per head
+            offs_m = tl.arange(0, BLOCK_M)
+            mask_m = offs_m < seq_len_q
+            offs_g = tl.arange(0, G)
+            dq_acc = tl.zeros([DimQ, G, BLOCK_M], dtype=tl.float32)
+            for start_n in tl.range(0, seq_len_kv, BLOCK_N):
+                offs_n = start_n + tl.arange(0, BLOCK_N)
+                mask_n = offs_n < seq_len_kv
+                valid_mask_trans = backward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
+                k_offset = (seq_start_kv + start_n).to(tl.int32)
+                k = desc_k.load([k_offset, off_h_kv * stride_kh])
+                if SHARED_KV:
+                    v = k
+                else:
+                    v = desc_v.load([k_offset, off_h_kv * stride_vh])
+                dk = tl.zeros([BLOCK_N, DimQ], dtype=tl.float32)
+                dv = tl.zeros([BLOCK_N, DimV], dtype=tl.float32)
+                for g in range(G):
+                    off_h = off_h_kv * G + g
+                    if off_h < num_softmax_heads:
+                        scaled_alpha = alpha * 1.44269504
+                    else:
+                        scaled_alpha = alpha
+                    M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q,
+                                                                  stride_mm)
+                    q = desc_q.load([seq_start_q, off_h * stride_qh])
+                    do = desc_do.load([seq_start_q, off_h * stride_doh])
+                    qk_trans = tl.dot(k, tl.trans(q), allow_tf32=ALLOW_TF32)
+                    if off_h < num_softmax_heads:
+                        qk_trans, act_qk_trans, pT = (backward_softmax_activation_scaled_alpha(
+                            qk_trans,
+                            scaled_alpha,
+                            valid_mask_trans,
+                            M_off,
+                            offs_m,
+                            stride_mm,
+                            mask_m,
+                            k,
+                        ))
+                    else:
+                        qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans,
+                                                                              k.dtype, scale)
+                    if SHARED_KV:
+                        dk += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+                    else:
+                        dv += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+                    dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
+                    if off_h < num_softmax_heads:
+                        dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m,
+                                                                  pT)
+                    else:
+                        dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
+                    dqk_trans = dqk_trans.to(k.dtype)
+                    dk += tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32) * alpha
+                    # dq for head g
+                    dq_g = tl.dot(tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32)
+                    dq_acc += tl.where((offs_g == g)[None, :, None], dq_g[:, None, :], 0.0)
+                DK_off = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
+                          off_h_kv * tl.cast(stride_dkh, tl.int64))
+                dk_ptrs = DK_off + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
+                tl.store(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None])
+                if not SHARED_KV:
+                    DV_off = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
+                              off_h_kv * tl.cast(stride_dvh, tl.int64))
+                    dv_ptrs = DV_off + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
+                    tl.store(dv_ptrs, dv.to(k.dtype), mask=mask_n[:, None])
+            # Write dq per head from the accumulator.
+            for g in range(G):
+                off_h = off_h_kv * G + g
+                dq_trans = tl.sum(tl.where((offs_g == g)[None, :, None], dq_acc, 0.0), axis=1)
+                dq = tl.trans(dq_trans) * alpha
+                dq_ptrs = (DQ + (seq_start_q + offs_m[:, None]) * stride_dqm + off_h * stride_dqh + offs_qk_d[None, :])
+                tl.store(dq_ptrs, dq.to(DQ.dtype.element_ty), mask=mask_m[:, None])
+            return
+
+        # Phase 1: dk/dv (fold the G heads, tile over Q).
+        for start_n in tl.range(0, seq_len_kv, BLOCK_N):
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            mask_n = offs_n < seq_len_kv
+            k_offset = (seq_start_kv + start_n).to(tl.int32)
+            k = desc_k.load([k_offset, off_h_kv * stride_kh])
+            if SHARED_KV:
+                v = k
+            else:
+                v = desc_v.load([k_offset, off_h_kv * stride_vh])
+            dk = tl.zeros([BLOCK_N, DimQ], dtype=tl.float32)
+            dv = tl.zeros([BLOCK_N, DimV], dtype=tl.float32)
+            for g in range(G):
+                off_h = off_h_kv * G + g
+                if off_h < num_softmax_heads:
+                    scaled_alpha = alpha * 1.44269504
+                else:
+                    scaled_alpha = alpha
+                M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q,
+                                                              stride_mm)
+                for start_m in tl.range(0, seq_len_q, BLOCK_M):
+                    offs_m = start_m + tl.arange(0, BLOCK_M)
+                    mask_m = offs_m < seq_len_q
+                    valid_mask_trans = backward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
+                    q_offset = (seq_start_q + start_m).to(tl.int32)
+                    q = desc_q.load([q_offset, off_h * stride_qh])
+                    do = desc_do.load([q_offset, off_h * stride_doh])
+                    qk_trans = tl.dot(k, tl.trans(q), allow_tf32=ALLOW_TF32)
+                    if off_h < num_softmax_heads:
+                        qk_trans, act_qk_trans, pT = (backward_softmax_activation_scaled_alpha(
+                            qk_trans,
+                            scaled_alpha,
+                            valid_mask_trans,
+                            M_off,
+                            offs_m,
+                            stride_mm,
+                            mask_m,
+                            k,
+                        ))
+                    else:
+                        qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans,
+                                                                              k.dtype, scale)
+                    if SHARED_KV:
+                        dk += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+                    else:
+                        dv += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+                    dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
+                    if off_h < num_softmax_heads:
+                        dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m,
+                                                                  pT)
+                    else:
+                        dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
+                    dqk_trans = dqk_trans.to(k.dtype)
+                    dk += tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32) * alpha
+            DK_off = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
+                      off_h_kv * tl.cast(stride_dkh, tl.int64))
+            dk_ptrs = DK_off + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
+            tl.store(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None])
+            if not SHARED_KV:
+                DV_off = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
+                          off_h_kv * tl.cast(stride_dvh, tl.int64))
+                dv_ptrs = DV_off + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
+                tl.store(dv_ptrs, dv.to(k.dtype), mask=mask_n[:, None])
+        # Phase 2: dq (per head, tile over Q).
+        for g in range(G):
+            off_h = off_h_kv * G + g
+            if off_h < num_softmax_heads:
+                scaled_alpha = alpha * 1.44269504
+            else:
+                scaled_alpha = alpha
+            M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm)
+            for start_m in tl.range(0, seq_len_q, BLOCK_M):
+                offs_m = start_m + tl.arange(0, BLOCK_M)
+                mask_m = offs_m < seq_len_q
+                q_offset = (seq_start_q + start_m).to(tl.int32)
+                q = desc_q.load([q_offset, off_h * stride_qh])
+                do = desc_do.load([q_offset, off_h * stride_doh])
+                q_trans = tl.trans(q)
+                dq_trans = tl.zeros([DimQ, BLOCK_M], dtype=tl.float32)
+                for start_n in tl.range(0, seq_len_kv, BLOCK_N):
+                    offs_n = start_n + tl.arange(0, BLOCK_N)
+                    valid_mask_trans = backward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
+                    k_offset = (seq_start_kv + start_n).to(tl.int32)
+                    k = desc_k.load([k_offset, off_h_kv * stride_kh])
+                    if SHARED_KV:
+                        v = k
+                    else:
+                        v = desc_v.load([k_offset, off_h_kv * stride_vh])
+                    qk_trans = tl.dot(k, q_trans, allow_tf32=ALLOW_TF32)
+                    if off_h < num_softmax_heads:
+                        qk_trans, act_qk_trans, pT = (backward_softmax_activation_scaled_alpha(
+                            qk_trans,
+                            scaled_alpha,
+                            valid_mask_trans,
+                            M_off,
+                            offs_m,
+                            stride_mm,
+                            mask_m,
+                            k,
+                        ))
+                    else:
+                        qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans,
+                                                                              k.dtype, scale)
+                    dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
+                    if off_h < num_softmax_heads:
+                        dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m,
+                                                                  pT)
+                    else:
+                        dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
+                    dqk_trans = dqk_trans.to(k.dtype)
+                    dq_trans += tl.dot(tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32)
+                dq = tl.trans(dq_trans) * alpha
+                dq_ptrs = (DQ + (seq_start_q + offs_m[:, None]) * stride_dqm + off_h * stride_dqh + offs_qk_d[None, :])
+                tl.store(dq_ptrs, dq.to(DQ.dtype.element_ty), mask=mask_m[:, None])
+        return
+
+    # Create TMA descriptors on device with BLOCK_M/BLOCK_N sizes
+    H_kv = H // G
+    desc_q = tl.make_tensor_descriptor(
+        Q,
+        shape=[total_seq_len_q, H * DimQ],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H * DimQ, 1],
+        block_shape=[BLOCK_M, BLOCK_D_Q],
+    )
+    desc_q1 = tl.make_tensor_descriptor(
+        Q,
+        shape=[total_seq_len_q, H * DimQ],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H * DimQ, 1],
+        block_shape=[BLOCK_M1, BLOCK_D_Q],
+    )
+    desc_k = tl.make_tensor_descriptor(
+        K,
+        shape=[total_seq_len_kv, H_kv * DimQ],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H_kv * DimQ, 1],
+        block_shape=[BLOCK_N, BLOCK_D_Q],
+    )
+    desc_v = tl.make_tensor_descriptor(
+        V,
+        shape=[total_seq_len_kv, H_kv * DimV],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H_kv * DimV, 1],
+        block_shape=[BLOCK_N, BLOCK_D_V],
+    )
+    desc_do = tl.make_tensor_descriptor(
+        DO,
+        shape=[total_seq_len_q, H * DimV],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H * DimV, 1],
+        block_shape=[BLOCK_M, BLOCK_D_V],
+    )
+    desc_do1 = tl.make_tensor_descriptor(
+        DO,
+        shape=[total_seq_len_q, H * DimV],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H * DimV, 1],
+        block_shape=[BLOCK_M1, BLOCK_D_V],
+    )
+
+    (
+        off_h,
+        off_h_kv,
+        start_m,
+        seq_start_kv,
+        seq_len_kv,
+        seq_start_q,
+        seq_len_q,
+        off_z,
+    ) = _compute_bwd_offsets(
+        H,
+        G,
+        BLOCK_M,
+        seq_offsets_q,
+        seq_offsets,
+        max_seq_len,
+        TRUNCATE_METHOD,
+    )
+    if HAS_CAUSAL:
+        n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
+        uih_len_q = uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
+    else:
+        uih_len_q = seq_len_q
+    if start_m + BLOCK_M1 >= seq_len_q:
+        _hstu_attn_bwd_redkv_inner(
+            off_h,
+            off_h_kv,
+            start_m,
+            seq_start_kv,
+            seq_len_kv,
+            seq_start_q,
+            seq_len_q,
+            desc_q1,
+            desc_k,
+            desc_v,
+            desc_do1,
+            DQ,
+            DK,
+            DV,
+            stride_qh,
+            stride_kh,
+            stride_vh,
+            stride_doh,
+            stride_dqm,
+            stride_dqh,
+            stride_dkn,
+            stride_dkh,
+            stride_dvn,
+            stride_dvh,
+            alpha,
+            attn_scale,
+            M,
+            Delta,
+            stride_mm,
+            uih_len_q,
+            num_softmax_heads,
+            max_q_len,
+            ALLOW_TF32,
+            BLOCK_D_Q,
+            BLOCK_D_V,
+            BLOCK_M1,
+            BLOCK_N,
+            ATTN_SCALE_TYPE,
+            GQA_ATOMIC_ADD=G > 1,
+            SHARED_KV=SHARED_KV,
+            HAS_CAUSAL=HAS_CAUSAL,
+        )
+    else:
+        _hstu_attn_bwd_redkv_inner(
+            off_h,
+            off_h_kv,
+            start_m,
+            seq_start_kv,
+            seq_len_kv,
+            seq_start_q,
+            seq_len_q,
+            desc_q,
+            desc_k,
+            desc_v,
+            desc_do,
+            DQ,
+            DK,
+            DV,
+            stride_qh,
+            stride_kh,
+            stride_vh,
+            stride_doh,
+            stride_dqm,
+            stride_dqh,
+            stride_dkn,
+            stride_dkh,
+            stride_dvn,
+            stride_dvh,
+            alpha,
+            attn_scale,
+            M,
+            Delta,
+            stride_mm,
+            uih_len_q,
+            num_softmax_heads,
+            max_q_len,
+            ALLOW_TF32,
+            BLOCK_D_Q,
+            BLOCK_D_V,
+            BLOCK_M,
+            BLOCK_N,
+            ATTN_SCALE_TYPE,
+            GQA_ATOMIC_ADD=G > 1,
+            SHARED_KV=SHARED_KV,
+            HAS_CAUSAL=HAS_CAUSAL,
+        )
+
+
+@triton.jit
+def _hstu_attn_bwd_redkv_inner(  # noqa C901
+    off_h,
+    off_h_kv,
+    start_m,
+    seq_start_kv,
+    seq_len_kv,
+    seq_start_q,
+    seq_len_q,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_do,
+    DQ,
+    DK,
+    DV,
+    stride_qh,
+    stride_kh,
+    stride_vh,
+    stride_doh,
+    stride_dqm,
+    stride_dqh,
+    stride_dkn,
+    stride_dkh,
+    stride_dvn,
+    stride_dvh,
+    alpha,
+    attn_scale,
+    M,
+    Delta,
+    stride_mm,
+    uih_len_q,
+    num_softmax_heads: tl.constexpr,
+    max_q_len: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    GQA_ATOMIC_ADD: tl.constexpr,
+    SHARED_KV: tl.constexpr,
+    HAS_CAUSAL: tl.constexpr,
+):
+    q_offset = seq_start_q + start_m
+    q = desc_q.load([q_offset.to(tl.int32), off_h * stride_qh])
+    do = desc_do.load([q_offset.to(tl.int32), off_h * stride_doh])
+    q_trans = tl.trans(q)
+    dq_trans = tl.zeros([BLOCK_D_Q, BLOCK_M], dtype=tl.float32)
+    offs_m = start_m + tl.arange(0, BLOCK_M)
+    # Offset DQ, DK, DV pointers by sequence start and head offset
+    DQ = DQ + seq_start_q * stride_dqm + off_h * stride_dqh
+    DK = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
+          off_h_kv * tl.cast(stride_dkh, tl.int64))
+    if not SHARED_KV:
+        DV = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
+              off_h_kv * tl.cast(stride_dvh, tl.int64))
+    mask_m = offs_m < seq_len_q
+    if ATTN_SCALE_TYPE == "scalar":
+        scale = tl.load(attn_scale).to(tl.float32)
+    else:
+        tl.static_assert(ATTN_SCALE_TYPE == "dynamic")
+        scale = tl.load(attn_scale + offs_m, mask=mask_m).to(tl.float32)
+
+    # Preprocess M and Delta offsets for softmax
+    M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm)
+
+    if HAS_CAUSAL:
+        high_kv = start_m + BLOCK_M + seq_len_kv - uih_len_q
+        high_kv = tl.cdiv(min(high_kv, seq_len_kv), BLOCK_N) * BLOCK_N
+    else:
+        high_kv = seq_len_kv
+    last_block_start_n = tl.maximum(0, (tl.cdiv(high_kv, BLOCK_N) - 1) * BLOCK_N)
+    # Skip Q masking when entire Q block is within bounds
+    q_needs_mask = start_m + BLOCK_M > seq_len_q
+    # Main loop - no KV masking needed for non-last blocks
+    if off_h < num_softmax_heads:
+        scaled_alpha = alpha * 1.44269504
+    else:
+        scaled_alpha = alpha
+    for start_n in tl.range(0, last_block_start_n, BLOCK_N):
+        # load K
+        k_offset = seq_start_kv + start_n
+        k = desc_k.load([k_offset.to(tl.int32), off_h_kv * stride_kh])
+        qk_trans = tl.dot(
+            k,
+            q_trans,
+        )
+        offs_n_loop = start_n + tl.arange(0, BLOCK_N)
+        if off_h < num_softmax_heads:
+            if q_needs_mask or HAS_CAUSAL:
+                valid_mask_trans = backward_valid_mask(
+                    offs_m,
+                    offs_n_loop,
+                    uih_len_q,
+                    seq_len_q,
+                    seq_len_kv,
+                    HAS_CAUSAL,
+                )
+                qk_trans, act_qk_trans, pT = backward_softmax_activation_scaled_alpha(
+                    qk_trans,
+                    scaled_alpha,
+                    valid_mask_trans,
+                    M_off,
+                    offs_m,
+                    stride_mm,
+                    mask_m,
+                    k,
+                )
+            else:
+                qk_trans = qk_trans * scaled_alpha
+                m = tl.load(M_off + offs_m * stride_mm)
+                pT = tl.math.exp2(qk_trans - m[None, :])
+                act_qk_trans = pT.to(k.dtype)
+        else:
+            if q_needs_mask or HAS_CAUSAL:
+                valid_mask_trans = backward_valid_mask(
+                    offs_m,
+                    offs_n_loop,
+                    uih_len_q,
+                    seq_len_q,
+                    seq_len_kv,
+                    HAS_CAUSAL,
+                )
+                qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans, k.dtype, scale)
+            else:
+                qk_trans = qk_trans * alpha
+                pT = fast_silu(qk_trans, MULT_BY_X=False)
+                silu_trans = qk_trans * pT * scale[None, :]
+                act_qk_trans = silu_trans.to(k.dtype)
+        if SHARED_KV:
+            dk = tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+            v = k
+        else:
+            dv = tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+            # acc dv
+            offs_v_d = tl.arange(0, BLOCK_D_V)
+            dv_ptrs = DV + (offs_n_loop[:, None] * stride_dvn + offs_v_d[None, :])
+            if BLOCK_M < max_q_len or GQA_ATOMIC_ADD:
+                tl.atomic_add(
+                    dv_ptrs,
+                    dv.to(q.dtype),
+                    sem="relaxed",
+                )
+            else:
+                tl.store(
+                    dv_ptrs,
+                    dv.to(q.dtype),
+                )
+
+            # load V
+            v_offset = seq_start_kv + start_n
+            v = desc_v.load([v_offset.to(tl.int32), off_h_kv * stride_vh])
+
+        dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
+        if off_h < num_softmax_heads:
+            dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT)
+        else:
+            if q_needs_mask or HAS_CAUSAL:
+                valid_mask_trans = backward_valid_mask(
+                    offs_m,
+                    offs_n_loop,
+                    uih_len_q,
+                    seq_len_q,
+                    seq_len_kv,
+                    HAS_CAUSAL,
+                )
+                dqk_trans = backward_d_silu_activation(
+                    dact_qk_trans,
+                    pT,
+                    qk_trans,
+                    scale,
+                    valid_mask_trans,
+                )
+            else:
+                dqk_trans = (dact_qk_trans * pT * (1 + qk_trans * (1 - pT)) * scale[None, :])
+        dqk_trans = dqk_trans.to(k.dtype)
+        if SHARED_KV:
+            dk_attn = tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32)
+            # pyrefly: ignore [unbound-name]
+            dk = dk + dk_attn * alpha
+        else:
+            dk = tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32) * alpha
+        offs_qk_d = tl.arange(0, BLOCK_D_Q)
+        dk_ptrs = DK + (offs_n_loop[:, None] * stride_dkn + offs_qk_d[None, :])
+        if BLOCK_M < max_q_len or GQA_ATOMIC_ADD:
+            tl.atomic_add(
+                dk_ptrs,
+                dk.to(q.dtype),
+                sem="relaxed",
+            )
+        else:
+            tl.store(
+                dk_ptrs,
+                dk.to(q.dtype),
+            )
+        # acc dq
+        dq_trans += tl.dot(tl.trans(k), dqk_trans)
+
+    # Last KV block - needs masking for out-of-bounds elements;
+    # Q/Do masking is kept since Q seq len is short.
+    if seq_len_kv > 0:
+        start_n = last_block_start_n
+        k_offset = seq_start_kv + start_n
+        k = desc_k.load([k_offset.to(tl.int32), off_h_kv * stride_kh])
+        qk_trans = tl.dot(
+            k,
+            q_trans,
+        )
+        offs_n = start_n + tl.arange(0, BLOCK_N)
+        valid_mask_trans = backward_valid_mask(
+            offs_m,
+            offs_n,
+            uih_len_q,
+            seq_len_q,
+            seq_len_kv,
+            HAS_CAUSAL,
+        )
+        if off_h < num_softmax_heads:
+            qk_trans, act_qk_trans, pT = backward_softmax_activation_scaled_alpha(
+                qk_trans,
+                scaled_alpha,
+                valid_mask_trans,
+                M_off,
+                offs_m,
+                stride_mm,
+                mask_m,
+                k,
+            )
+        else:
+            qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans, k.dtype, scale)
+        if SHARED_KV:
+            dk = tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+            v = k
+        else:
+            dv = tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+            mask_n = offs_n < seq_len_kv
+            offs_v_d = tl.arange(0, BLOCK_D_V)
+            dv_ptrs = DV + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
+            if BLOCK_M < max_q_len or GQA_ATOMIC_ADD:
+                tl.atomic_add(
+                    dv_ptrs,
+                    dv.to(q.dtype),
+                    mask=mask_n[:, None],
+                    sem="relaxed",
+                )
+            else:
+                tl.store(dv_ptrs, dv.to(q.dtype), mask=mask_n[:, None])
+            v_offset = seq_start_kv + start_n
+            v = desc_v.load([v_offset.to(tl.int32), off_h_kv * stride_vh])
+
+        dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
+        if off_h < num_softmax_heads:
+            dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT)
+        else:
+            dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
+        dqk_trans = dqk_trans.to(k.dtype)
+        if SHARED_KV:
+            dk_attn = tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32)
+            # pyrefly: ignore [unbound-name]
+            dk = dk + dk_attn * alpha
+        else:
+            dk = tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32) * alpha
+        offs_qk_d = tl.arange(0, BLOCK_D_Q)
+        dk_ptrs = DK + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
+        mask_n = offs_n < seq_len_kv
+        if BLOCK_M < max_q_len or GQA_ATOMIC_ADD:
+            tl.atomic_add(
+                dk_ptrs,
+                dk.to(q.dtype),
+                mask=mask_n[:, None],
+                sem="relaxed",
+            )
+        else:
+            tl.store(dk_ptrs, dk.to(q.dtype), mask=mask_n[:, None])
+        dq_trans += tl.dot(tl.trans(k), dqk_trans)
+    dq_trans = dq_trans * alpha
+    offs_qk_d = tl.arange(0, BLOCK_D_Q)
+    offs_m = start_m + tl.arange(0, BLOCK_M)
+    mask_m = offs_m < seq_len_q
+    dq_ptrs = DQ + (offs_m[:, None] * stride_dqm + offs_qk_d[None, :])
+    dq = tl.trans(dq_trans)
+    tl.store(dq_ptrs, dq.to(q.dtype), mask=mask_m[:, None])
+
+
+# AutoWS reduce_dq per-dot schedule (stage/order/channels) lives in the module-level
+# configs _HSTU_BWD_DOT_ATTRS_{DEFAULT,TLX}; the active one is exposed as the per-dot
+# constexpr globals _HSTU_ATTRS_{QKT,DV,DPT,DK,DQ} (Triton's @jit frontend only
+# accepts `attrs=` as a dict literal or a bare tl.constexpr global, not a config
+# object passed as a param). Switch configs with set_bwd_dot_attrs(). Channel fmt:
+# "operand,memType,copies,bufferId"; a shared bufferId forms a reuse group. DEFAULT:
+#   id2: S(qkᵀ) owner, reused by P (dv's operand A)      -> P shares S's slot
+#   id5: dP(dact) owner (DEFAULT) ; id11: dqᵀ owner. TLX config points dP at id11
+#        (dP consumed before dqᵀ is produced -> dp reuse=dq, freeing id5).
+#   id8: dsᵀ (dqk_trans) in SMEM, operand A of dk and operand B of dq
+#   id7: dv (or dk's P·do part) standalone ; id10: dk (dsᵀ·q) standalone
+
+
+@triton.jit
+def _hstu_attn_bwd_inner(  # noqa C901
+    start_n,
+    seq_start_kv,
+    seq_len_kv,
+    seq_start_q,
+    seq_len_q,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_do,
+    desc_dk,
+    desc_dq,
+    DV,
+    stride_qh,
+    stride_kh,
+    stride_vh,
+    stride_doh,
+    stride_dvn,
+    stride_dvh,
+    alpha,
+    attn_scale,
+    M,
+    Delta,
+    stride_mm,
+    off_h,
+    off_h_kv,
+    H_kv,
+    uih_len_q,
+    num_softmax_heads: tl.constexpr,
+    DimQ: tl.constexpr,
+    DimV: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    GQA_ATOMIC_ADD: tl.constexpr,
+    SHARED_KV: tl.constexpr,
+    MASK_KV: tl.constexpr,
+    HAS_CAUSAL: tl.constexpr,
+    # pyrefly: ignore [bad-function-definition]
+    AUTOWS: tl.constexpr = False,
+    # WS_ON gates only the warp-specialization *behavior* (warp_specialize +
+    # merge_epilogue + the tt.autows dot annotations), independent of AUTOWS which
+    # gates the single-masked-KV-loop *structure*. Normally WS_ON==AUTOWS; setting
+    # AUTOWS=True, WS_ON=False runs the autoWS loop structure with NO warp
+    # specialization -- a byte-reference that differs from autoWS only in WS.
+    WS_ON: tl.constexpr = False,
+):
+    kv_offset = (seq_start_kv + start_n).to(tl.int32)
+    k = desc_k.load([kv_offset.to(tl.int32), off_h_kv * stride_kh])
+    if SHARED_KV:
+        v = k
+    else:
+        v = desc_v.load([kv_offset.to(tl.int32), off_h_kv * stride_vh])
+
+    dk = tl.zeros([BLOCK_N, DimQ], dtype=tl.float32)
+    if not SHARED_KV:
+        dv = tl.zeros([BLOCK_N, DimV], dtype=tl.float32)
+    # Offset DV pointers by sequence start and head offset
+    if not SHARED_KV:
+        DV = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
+              off_h_kv * tl.cast(stride_dvh, tl.int64))
+    tl.static_assert(ATTN_SCALE_TYPE == "scalar")
+    scale = tl.load(attn_scale).to(tl.float32)
+
+    M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm)
+
+    offs_n = start_n + tl.arange(0, BLOCK_N)
+    # EXPERIMENT (autoWS): for the all-or-nothing softmax shape (num_softmax_heads
+    # is 0 or H), off_h < num_softmax_heads == the constexpr (num_softmax_heads > 0).
+    # The constexpr form folds at compile time (no runtime scf.if/else), so the
+    # autoWS hasElse guard does not drop warp specialization. NOT valid for partial
+    # num_softmax_heads -- gate behind a SOFTMAX constexpr before landing.
+    if num_softmax_heads > 0:
+        scaled_alpha = alpha * 1.44269504
+    else:
+        scaled_alpha = alpha
+    if HAS_CAUSAL:
+        low_q = max(0, start_n + uih_len_q - seq_len_kv)
+    else:
+        low_q = 0
+    # autoWS depth-2 per-head reduce_dq: warp_specialize the inner Q loop.
+    # warp_specialize requires beta triton (-m ovr_config//triton:beta).
+    # merge_epilogue=WS_ON: fold the dk/dv epilogue stores into the reduction
+    # partition (Meta partition-scheduler merge-epilogue knob) so autoWS has the
+    # same 4-partition layout as the hand-TLX kernel (which stores dk/dv in the
+    # reduction/default task) instead of a separate epilogue partition.
+    for start_m in tl.range(low_q, seq_len_q, BLOCK_M, warp_specialize=WS_ON, merge_epilogue=WS_ON):
+        offs_m = start_m + tl.arange(0, BLOCK_M)
+        mask_m = offs_m < seq_len_q
+        q_offset = seq_start_q + start_m
+        q = desc_q.load([q_offset.to(tl.int32), off_h * stride_qh])
+        qk_trans = tl.dot(
+            k,
+            tl.trans(q),
+            attrs=_HSTU_ATTRS_QKT if WS_ON else None,
+        )
+        if MASK_KV or HAS_CAUSAL:
+            valid_mask_trans = backward_valid_mask(
+                offs_m,
+                offs_n,
+                uih_len_q,
+                seq_len_q,
+                seq_len_kv,
+                HAS_CAUSAL,
+            )
+        else:
+            valid_mask_trans = offs_m[None, :] < seq_len_q
+        if num_softmax_heads > 0:  # autoWS: constexpr (see note above)
+            qk_trans, act_qk_trans, pT = backward_softmax_activation_scaled_alpha(
+                qk_trans,
+                scaled_alpha,
+                valid_mask_trans,
+                M_off,
+                offs_m,
+                stride_mm,
+                mask_m,
+                k,
+            )
+        else:
+            qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans, k.dtype, scale)
+        do = desc_do.load([q_offset.to(tl.int32), off_h * stride_doh])
+
+        dact_qk_trans = tl.dot(
+            v,
+            tl.trans(do),
+            allow_tf32=ALLOW_TF32,
+            attrs=_HSTU_ATTRS_DPT if WS_ON else None,
+        )
+        if SHARED_KV:
+            dk = tl.dot(
+                act_qk_trans,
+                do,
+                dk,
+                allow_tf32=ALLOW_TF32,
+                attrs=_HSTU_ATTRS_DV if WS_ON else None,
+            )
+        else:
+            # pyrefly: ignore [unbound-name]
+            dv = tl.dot(
+                act_qk_trans,
+                do,
+                dv,
+                allow_tf32=ALLOW_TF32,
+                attrs=_HSTU_ATTRS_DV if WS_ON else None,
+            )
+
+        if num_softmax_heads > 0:  # autoWS: constexpr (see note above)
+            dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT)
+        else:
+            dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
+        dqk_trans = dqk_trans.to(k.dtype)
+        dq_trans = tl.dot(
+            tl.trans(k),
+            dqk_trans,
+            attrs=_HSTU_ATTRS_DQ if WS_ON else None,
+        )
+        if SHARED_KV:
+            dk_attn = tl.dot(
+                dqk_trans,
+                q,
+                allow_tf32=ALLOW_TF32,
+                attrs=_HSTU_ATTRS_DK if WS_ON else None,
+            )
+            dk = dk + dk_attn * alpha
+        else:
+            dk = tl.dot(
+                dqk_trans,
+                q,
+                dk,
+                allow_tf32=ALLOW_TF32,
+                attrs=_HSTU_ATTRS_DK if WS_ON else None,
+            )
+        dq_trans = dq_trans * alpha
+        dq = tl.trans(dq_trans)
+        desc_dq.store(
+            [q_offset.to(tl.int32), DimQ * off_h],
+            dq.to(desc_dq.dtype),
+            store_reduce="add",
+        )
+
+    offs_n = start_n + tl.arange(0, BLOCK_N)
+    if not SHARED_KV:
+        offs_v_d = tl.arange(0, DimV)
+        dv_ptrs = DV + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
+        if MASK_KV:
+            mask_n = offs_n < seq_len_kv
+            if GQA_ATOMIC_ADD:
+                tl.atomic_add(
+                    dv_ptrs,
+                    # pyrefly: ignore [unbound-name]
+                    dv.to(k.dtype),
+                    mask=mask_n[:, None],
+                    sem="relaxed",
+                )
+            else:
+                tl.store(
+                    dv_ptrs,
+                    # pyrefly: ignore [unbound-name]
+                    dv.to(k.dtype),
+                    mask=mask_n[:, None],
+                )
+        else:
+            if GQA_ATOMIC_ADD:
+                tl.atomic_add(
+                    dv_ptrs,
+                    # pyrefly: ignore [unbound-name]
+                    dv.to(k.dtype),
+                    sem="relaxed",
+                )
+            else:
+                tl.store(
+                    dv_ptrs,
+                    # pyrefly: ignore [unbound-name]
+                    dv.to(k.dtype),
+                )
+
+    if not SHARED_KV:
+        dk = dk * alpha
+
+    if GQA_ATOMIC_ADD:
+        desc_dk.atomic_add([kv_offset, DimQ * off_h_kv], dk.to(desc_dk.dtype))
+    else:
+        desc_dk.store([kv_offset, DimQ * off_h_kv], dk.to(desc_dk.dtype))
+
+
+@maybe_register_custom_op("hammer::triton_hstu_cross_attn_v3_fwd", mutates_args=())
+def triton_hstu_cross_attn_v3_fwd(
+    max_seq_len: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    seq_offsets_q: torch.Tensor,
+    max_q_len: int,
+    attn_scale: torch.Tensor,
+    G: int,
+    shared_kv: bool = False,
+    num_softmax_heads: int = 0,
+    enable_tma: bool = True,
+    truncate_method: str = "none",
+    num_targets: Optional[torch.Tensor] = None,
+    causal: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor, int]:
+    enable_tma = (enable_tma and HAS_TENSOR_DESCRIPTOR and is_sm90_plus() and not torch.version.hip)
+    q = switch_to_contiguous_if_needed(q)
+    k = switch_to_contiguous_if_needed(k)
+    v = switch_to_contiguous_if_needed(v)
+
+    # Validate dtype consistency: q, k, v must have matching dtypes for
+    # correct type casting in kernels (e.g., dv.to(q.dtype))
+    assert q.dtype == k.dtype, f"q.dtype ({q.dtype}) != k.dtype ({k.dtype})"
+    assert q.dtype == v.dtype, f"q.dtype ({q.dtype}) != v.dtype ({v.dtype})"
+
+    Z = seq_offsets.numel() - 1
+    total_seq_len_q, H, DimQ = q.shape
+    _, _, DimV = v.shape
+    out = torch.empty(total_seq_len_q, H, DimV, device=q.device, dtype=q.dtype)
+    if total_seq_len_q == 0:
+        M = torch.empty(0, device=q.device, dtype=torch.float32)
+        return out, M, 0
+
+    total_seq_len_kv, _, _ = k.shape
+
+    if enable_tma:
+        # TMA descriptors require a global memory allocation.
+        # Note: stream parameter is unused; torch.empty uses current CUDA stream.
+        def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+            return torch.empty(size, device="cuda", dtype=torch.int8)
+
+        triton.set_allocator(alloc_fn)
+
+    grid = lambda meta: (  # noqa E731
+        triton.cdiv(max_q_len, meta["BLOCK_M"]),
+        Z * H,
+    )
+
+    # Create M tensor for softmax heads if needed
+    if num_softmax_heads > 0:
+        M, stride_mm = forward_custom_vars(q, num_softmax_heads, [])
+    else:
+        M = torch.empty(0, device=q.device, dtype=torch.float32)
+        stride_mm = 0
+
+    HAS_NUM_TARGETS = num_targets is not None
+    HAS_CAUSAL = causal
+
+    variant = get_fwd_variant()
+    if variant == FwdVariant.TRITON:
+        _attn_fwd_triton[grid](
+            alpha=alpha,
+            Z=Z,
+            H=H,
+            G=G,
+            Q=q,
+            K=k,
+            V=v,
+            total_seq_len_q=total_seq_len_q,
+            total_seq_len_kv=total_seq_len_kv,
+            Out=out,
+            stride_qm=q.stride(0),
+            stride_qh=q.stride(1),
+            stride_kn=k.stride(0),
+            stride_kh=k.stride(1),
+            stride_vn=v.stride(0),
+            stride_vh=v.stride(1),
+            stride_om=out.stride(0),
+            stride_oh=out.stride(1),
+            seq_offsets_q=seq_offsets_q,
+            seq_offsets=seq_offsets,
+            max_seq_len=max_seq_len,
+            attn_scale=attn_scale,
+            M=M,
+            stride_mm=stride_mm,
+            num_targets=num_targets,
+            AUTOTUNE_MAX_Q_LEN=autotune_max_seq_len(max_q_len),
+            AUTOTUNE_MAX_SEQ_LEN=autotune_max_seq_len(max_seq_len),
+            num_softmax_heads=num_softmax_heads,
+            HEAD_DIM=DimQ,
+            BLOCK_D_V=DimV,
+            ENABLE_TMA=enable_tma,
+            TRUNCATE_METHOD=truncate_method,
+            HAS_CAUSAL=HAS_CAUSAL,
+            HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+        )
+    elif variant == FwdVariant.TRITON_DYN_SPEC:
+        _attn_fwd_triton_spec[grid](
+            alpha=alpha,
+            Z=Z,
+            H=H,
+            G=G,
+            Q=q,
+            K=k,
+            V=v,
+            total_seq_len_q=total_seq_len_q,
+            total_seq_len_kv=total_seq_len_kv,
+            Out=out,
+            stride_qm=q.stride(0),
+            stride_qh=q.stride(1),
+            stride_kn=k.stride(0),
+            stride_kh=k.stride(1),
+            stride_vn=v.stride(0),
+            stride_vh=v.stride(1),
+            stride_om=out.stride(0),
+            stride_oh=out.stride(1),
+            seq_offsets_q=seq_offsets_q,
+            seq_offsets=seq_offsets,
+            max_seq_len=max_seq_len,
+            attn_scale=attn_scale,
+            M=M,
+            stride_mm=stride_mm,
+            num_targets=num_targets,
+            AUTOTUNE_Z=next_power_of_2(Z),
+            AUTOTUNE_MAX_Q_LEN=autotune_max_seq_len(max_q_len),
+            AUTOTUNE_MAX_SEQ_LEN=autotune_max_seq_len(max_seq_len),
+            num_softmax_heads=num_softmax_heads,
+            HEAD_DIM=DimQ,
+            BLOCK_D_V=DimV,
+            SHARED_KV=shared_kv,
+            ENABLE_TMA=enable_tma,
+            TRUNCATE_METHOD=truncate_method,
+            HAS_CAUSAL=HAS_CAUSAL,
+            HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+        )
+    return out, M, stride_mm
+
+
+@torch.library.custom_op("hammer::triton_hstu_cross_attn_v3_bwd", mutates_args=())
+def triton_hstu_cross_attn_v3_bwd(
+    dout: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    attn_scale: torch.Tensor,
+    max_seq_len: int,
+    alpha: float,
+    max_q_len: Optional[int],
+    seq_offsets_q: Optional[torch.Tensor],
+    num_targets: Optional[torch.Tensor],
+    causal: bool,
+    shared_kv: bool,
+    G: int,
+    num_softmax_heads: int = 0,
+    M: Optional[torch.Tensor] = None,
+    Delta: Optional[torch.Tensor] = None,
+    stride_mm: int = 0,
+    truncate_method: str = "none",
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if max_q_len is None:
+        max_q_len = max_seq_len
+        assert seq_offsets_q is None
+        seq_offsets_q = seq_offsets
+    bwd_variant = get_bwd_variant()
+    if (bwd_variant == BwdVariant.AUTO) and (max_q_len < 128):
+        bwd_variant = BwdVariant.TRITON_REDKV
+    use_per_kv_head = (bwd_variant in (BwdVariant.AUTO, BwdVariant.TRITON_REDKV) and G > 1
+                       and (max_q_len < 192 or (num_softmax_heads == 0 and max_q_len <= 256)))
+    use_redq_per_kv_head = (bwd_variant in (BwdVariant.TRITON_REDQ, BwdVariant.TRITON_AUTOWS) and G > 1)
+    if use_per_kv_head:
+        dq_dtype = q.dtype
+        dkdv_dtype = k.dtype
+    elif use_redq_per_kv_head:
+        dq_dtype = torch.float32
+        dkdv_dtype = k.dtype
+    elif bwd_variant == BwdVariant.TRITON_REDKV:
+        dq_dtype = q.dtype
+        dkdv_dtype = k.dtype if max_q_len < 128 else torch.float32
+    else:
+        dq_dtype = torch.float32
+        dkdv_dtype = torch.float32 if G > 1 else k.dtype
+    dq = torch.empty_like(q, dtype=dq_dtype)
+    dk = torch.empty_like(k, dtype=dkdv_dtype)
+    if shared_kv:
+        dv = dk
+    else:
+        dv = torch.empty_like(v, dtype=dkdv_dtype)
+
+    dout = switch_to_contiguous_if_needed(dout)
+    dq = switch_to_contiguous_if_needed(dq)
+    dk = switch_to_contiguous_if_needed(dk)
+    if not shared_kv:
+        dv = switch_to_contiguous_if_needed(dv)
+
+    # Validate dtype consistency: q, k, v must have matching dtypes for
+    # correct type casting in kernels (e.g., dk.to(q.dtype))
+    assert q.dtype == k.dtype, f"q.dtype ({q.dtype}) != k.dtype ({k.dtype})"
+    assert q.dtype == v.dtype, f"q.dtype ({q.dtype}) != v.dtype ({v.dtype})"
+
+    if dout.shape[0] == 0:
+        return torch.zeros_like(q), torch.zeros_like(k), torch.zeros_like(v)
+    Z = seq_offsets.numel() - 1
+    _, H, DimQ = q.shape
+    _, _, DimV = v.shape
+
+    total_seq_len_q, H, DimQ = q.shape
+    total_seq_len_kv, _, _ = k.shape
+
+    if attn_scale.ndim == 0:
+        attn_scale_type = "scalar"
+    else:
+        attn_scale_type = "dynamic"
+
+    # TMA descriptors require a global memory allocation.
+    # Note: stream parameter is unused; torch.empty uses current CUDA stream.
+    def alloc_fn(size: int, alignment: int, stream: Optional[int]):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(alloc_fn)
+
+    HAS_NUM_TARGETS = num_targets is not None
+    HAS_CAUSAL = causal
+
+    AUTOTUNE_Z = next_power_of_2(Z)
+    if use_per_kv_head or bwd_variant == BwdVariant.TRITON_REDKV:
+        if use_per_kv_head:
+            H_kv = H // G
+            grid = lambda meta: (Z * H_kv, )  # noqa E731
+        else:
+            grid = lambda meta: (  # noqa E731
+                triton.cdiv(max_q_len, meta["BLOCK_M"]),
+                Z * H,
+            )
+        _hstu_attn_bwd_redkv[grid](
+            Q=q,
+            K=k,
+            V=v,
+            DO=dout,
+            total_seq_len_q=total_seq_len_q,
+            total_seq_len_kv=total_seq_len_kv,
+            seq_offsets=seq_offsets,
+            seq_offsets_q=seq_offsets_q,
+            DQ=dq,
+            DK=dk,
+            DV=dv,
+            stride_qm=q.stride(0),
+            stride_qh=q.stride(1),
+            stride_kn=k.stride(0),
+            stride_kh=k.stride(1),
+            stride_vn=v.stride(0),
+            stride_vh=v.stride(1),
+            stride_dom=dout.stride(0),
+            stride_doh=dout.stride(1),
+            stride_dqm=dq.stride(0),
+            stride_dqh=dq.stride(1),
+            stride_dkn=dk.stride(0),
+            stride_dkh=dk.stride(1),
+            stride_dvn=dv.stride(0),
+            stride_dvh=dv.stride(1),
+            alpha=alpha,
+            max_seq_len=max_seq_len,
+            attn_scale=attn_scale,
+            M=M,
+            Delta=Delta,
+            stride_mm=stride_mm,
+            num_targets=num_targets,
+            Z=Z,
+            AUTOTUNE_Z=AUTOTUNE_Z,
+            H=H,
+            G=G,
+            num_softmax_heads=num_softmax_heads,
+            max_q_len=next_power_of_2(max_q_len),
+            AUTOTUNE_MAX_SEQ_LEN=autotune_max_seq_len(max_seq_len),
+            DimQ=DimQ,
+            DimV=DimV,
+            ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+            BLOCK_D_Q=DimQ,
+            BLOCK_D_V=DimV,
+            ATTN_SCALE_TYPE=attn_scale_type,
+            SHARED_KV=shared_kv,
+            TRUNCATE_METHOD=truncate_method,
+            HAS_CAUSAL=HAS_CAUSAL,
+            HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+            PER_KV_HEAD=use_per_kv_head,
+        )
+    elif bwd_variant in (BwdVariant.TRITON_REDQ, BwdVariant.TRITON_AUTOWS):
+        if use_redq_per_kv_head:
+            H_kv = H // G
+            grid = lambda meta: (Z * H_kv, )  # noqa E731
+        else:
+            grid = lambda meta: (Z * H, 1)  # noqa E731
+        _hstu_attn_bwd_redq[grid](
+            Q=q,
+            K=k,
+            V=v,
+            DO=dout,
+            total_seq_len_q=total_seq_len_q,
+            total_seq_len_kv=total_seq_len_kv,
+            seq_offsets=seq_offsets,
+            seq_offsets_q=seq_offsets_q,
+            DQ=dq,
+            DK=dk,
+            DV=dv,
+            stride_qm=q.stride(0),
+            stride_qh=q.stride(1),
+            stride_kn=k.stride(0),
+            stride_kh=k.stride(1),
+            stride_vn=v.stride(0),
+            stride_vh=v.stride(1),
+            stride_dom=dout.stride(0),
+            stride_doh=dout.stride(1),
+            stride_dqm=dq.stride(0),
+            stride_dqh=dq.stride(1),
+            stride_dkn=dk.stride(0),
+            stride_dkh=dk.stride(1),
+            stride_dvn=dv.stride(0),
+            stride_dvh=dv.stride(1),
+            alpha=alpha,
+            max_seq_len=max_seq_len,
+            attn_scale=attn_scale,
+            M=M,
+            Delta=Delta,
+            stride_mm=stride_mm,
+            num_targets=num_targets,
+            Z=Z,
+            AUTOTUNE_Z=AUTOTUNE_Z,
+            H=H,
+            G=G,
+            num_softmax_heads=num_softmax_heads,
+            max_q_len=next_power_of_2(max_q_len),
+            AUTOTUNE_MAX_SEQ_LEN=autotune_max_seq_len(max_seq_len),
+            DimQ=DimQ,
+            DimV=DimV,
+            ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+            ATTN_SCALE_TYPE=attn_scale_type,
+            SHARED_KV=shared_kv,
+            TRUNCATE_METHOD=truncate_method,
+            HAS_CAUSAL=HAS_CAUSAL,
+            HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+            PER_KV_HEAD=use_redq_per_kv_head,
+            AUTOWS=(bwd_variant == BwdVariant.TRITON_AUTOWS),
+            # WS_ON == AUTOWS normally; set HSTU_AUTOWS_WS_OFF=1 to run the autoWS
+            # loop STRUCTURE with warp specialization DISABLED (isolation reference).
+            WS_ON=((bwd_variant == BwdVariant.TRITON_AUTOWS) and os.environ.get("HSTU_AUTOWS_WS_OFF", "0") != "1"),
+        )
+    else:
+        grid = lambda meta: (Z * H, 1)  # noqa E731
+        _hstu_attn_bwd[grid](
+            Q=q,
+            K=k,
+            V=v,
+            DO=dout,
+            total_seq_len_q=total_seq_len_q,
+            total_seq_len_kv=total_seq_len_kv,
+            seq_offsets=seq_offsets,
+            seq_offsets_q=seq_offsets_q,
+            DQ=dq,
+            DK=dk,
+            DV=dv,
+            stride_qm=q.stride(0),
+            stride_qh=q.stride(1),
+            stride_kn=k.stride(0),
+            stride_kh=k.stride(1),
+            stride_vn=v.stride(0),
+            stride_vh=v.stride(1),
+            stride_dom=dout.stride(0),
+            stride_doh=dout.stride(1),
+            stride_dqm=dq.stride(0),
+            stride_dqh=dq.stride(1),
+            stride_dkn=dk.stride(0),
+            stride_dkh=dk.stride(1),
+            stride_dvn=dv.stride(0),
+            stride_dvh=dv.stride(1),
+            alpha=alpha,
+            max_seq_len=max_seq_len,
+            attn_scale=attn_scale,
+            M=M,
+            Delta=Delta,
+            stride_mm=stride_mm,
+            num_targets=num_targets,
+            Z=Z,
+            AUTOTUNE_Z=AUTOTUNE_Z,
+            H=H,
+            G=G,
+            num_softmax_heads=num_softmax_heads,
+            AUTOTUNE_MAX_Q_LEN=autotune_max_seq_len(max_q_len),
+            AUTOTUNE_MAX_SEQ_LEN=autotune_max_seq_len(max_seq_len),
+            DimQ=DimQ,
+            DimV=DimV,
+            ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+            ATTN_SCALE_TYPE=attn_scale_type,
+            SHARED_KV=shared_kv,
+            TRUNCATE_METHOD=truncate_method,
+            HAS_CAUSAL=HAS_CAUSAL,
+            HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+        )
+
+    # When shared_kv=True, dv aliases dk. Return a placeholder to avoid aliasing in return
+    # which is required by torch.library.custom_op, otherwise need v.clone()
+    if shared_kv:
+        dv = torch.empty(0)
+    return dq.to(q.dtype), dk.to(k.dtype), dv.to(v.dtype)
+
+
+class AttentionFunction(torch.autograd.Function):
+
+    @staticmethod
+    # pyre-fixme[14]: `forward` overrides method defined in `Function` inconsistently.
+    def forward(
+        ctx,
+        max_seq_len: int,
+        alpha: float,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: Optional[torch.Tensor],
+        seq_offsets: torch.Tensor,
+        attn_scale: torch.Tensor,
+        seq_offsets_q: torch.Tensor,
+        max_q_len: int,
+        shared_kv: bool,
+        num_softmax_heads: int,
+        enable_tma: bool,
+        truncate_method: str,
+        num_targets: Optional[torch.Tensor] = None,
+        causal: bool = False,
+    ):
+        q = switch_to_contiguous_if_needed(q)
+        k = switch_to_contiguous_if_needed(k)
+        if not shared_kv:
+            # pyre-ignore[6]
+            v = switch_to_contiguous_if_needed(v)
+        else:
+            v = k
+        Z = seq_offsets.numel() - 1  # noqa: F841
+        total_seq_len_q, H, DimQ = q.shape
+        _, H_kv, DimV = v.shape
+        assert H % H_kv == 0, f"H ({H}) must be divisible by H_kv ({H_kv})"
+        G = H // H_kv  # GQA group size (number of Q heads per KV head)
+        if total_seq_len_q == 0:
+            out = torch.zeros(total_seq_len_q, H, DimV, device=q.device, dtype=q.dtype)
+            return out
+
+        if (G > 1 and H_kv == 1 and (num_softmax_heads == 0 or num_softmax_heads == H) and not causal):
+            # GQA can not enabled with causal masking
+            seq_offsets_q = seq_offsets_q * G
+            max_q_len = max_q_len * G
+            num_softmax_heads = num_softmax_heads // G
+            q = q.view(total_seq_len_q * G, H_kv, DimQ)
+            G = 1
+
+        # shape constraints
+        HEAD_DIM_Q, HEAD_DIM_K = q.shape[-1], k.shape[-1]
+        # when v is in float8_e5m2 it is transposed.
+        HEAD_DIM_V = v.shape[-1]
+        assert HEAD_DIM_Q == HEAD_DIM_K
+        assert HEAD_DIM_K in {16, 32, 64, 128, 256}
+        assert HEAD_DIM_V in {16, 32, 64, 128, 256}
+
+        # Note that on Hopper we cannot perform a FP8 dot with a non-transposed second tensor
+        out, M, stride_mm = triton_hstu_cross_attn_v3_fwd(
+            max_seq_len=max_seq_len,
+            alpha=alpha,
+            q=q,
+            k=k,
+            v=v,
+            seq_offsets=seq_offsets,
+            seq_offsets_q=seq_offsets_q,
+            max_q_len=max_q_len,
+            attn_scale=attn_scale,
+            shared_kv=shared_kv,
+            num_softmax_heads=num_softmax_heads,
+            G=G,
+            enable_tma=enable_tma,
+            truncate_method=truncate_method,
+            num_targets=num_targets,
+            causal=causal,
+        )
+
+        saved_tensors = [q, k, v, seq_offsets, attn_scale, seq_offsets_q]
+        if num_softmax_heads > 0:
+            saved_tensors.extend([M, out])
+        if num_targets is not None:
+            saved_tensors.append(num_targets)
+        ctx.has_num_targets = num_targets is not None
+        ctx.causal = causal
+        ctx.save_for_backward(*saved_tensors)
+        ctx.alpha = alpha
+        ctx.HEAD_DIM = HEAD_DIM_K
+        ctx.max_seq_len = max_seq_len
+        ctx.max_q_len = max_q_len
+        ctx.truncate_method = truncate_method
+        ctx.shared_kv = shared_kv
+        ctx.num_softmax_heads = num_softmax_heads
+        ctx.stride_mm = stride_mm
+        ctx.total_seq_len_q = total_seq_len_q
+        ctx.G = G
+        ctx.H = H
+        ctx.H_kv = H_kv
+        return out.view(total_seq_len_q, H, DimV)
+
+    @staticmethod
+    # pyre-ignore[14]
+    def backward(
+        ctx, dout: torch.Tensor
+    ) -> Tuple[
+            None,
+            None,
+            torch.Tensor,
+            torch.Tensor,
+            Optional[torch.Tensor],
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+    ]:
+        saved_tensors = ctx.saved_tensors
+        q, k, v, seq_offsets, attn_scale, seq_offsets_q = saved_tensors[:6]
+        idx = 6
+        num_softmax_heads = ctx.num_softmax_heads
+        # Reshape dout from [T, H, DimV] to folded [T*G, H_kv, DimV]
+        if (ctx.H > 1 and ctx.H_kv == 1 and (num_softmax_heads == 0 or num_softmax_heads == ctx.H) and not ctx.causal):
+            dout = dout.view(ctx.total_seq_len_q * ctx.H, -1, dout.shape[-1])
+        if num_softmax_heads > 0:
+            M = saved_tensors[idx]
+            idx += 1
+            out = saved_tensors[idx]
+            idx += 1
+            Delta = torch.empty_like(M)
+            pre_grid = (triton.cdiv(out.shape[0], 128), num_softmax_heads)
+            _attn_bwd_preprocess[pre_grid](
+                out, dout, Delta, out.shape[0], H=out.shape[1], softmax_heads=num_softmax_heads,
+                BLOCK_M=128,  # pyre-ignore [6]
+                HEAD_DIM=out.shape[2],  # pyre-ignore [6]
+            )
+        else:
+            M = torch.empty(0, device=q.device, dtype=torch.float32)
+            Delta = torch.empty(0, device=q.device, dtype=torch.float32)
+        causal = ctx.causal
+        if ctx.has_num_targets:
+            num_targets = saved_tensors[idx]
+            idx += 1
+        else:
+            num_targets = None
+        if get_bwd_variant() == BwdVariant.TLX:
+            # Hand-written TLX warp-specialized reduce_dq (attn_bwd_ws). Computes
+            # its own Delta internally; pass out/M for the softmax path.
+            from tlx_bw_cross_attention import tlx_bw_reduce_dq
+
+            out_t = out if num_softmax_heads > 0 else None
+            M_t = M if num_softmax_heads > 0 else None
+            dq, dk, dv = tlx_bw_reduce_dq(
+                q,
+                k,
+                v,
+                dout,
+                seq_offsets,
+                attn_scale,
+                ctx.max_seq_len,
+                ctx.alpha,
+                max_q_len=ctx.max_q_len,
+                seq_offsets_q=seq_offsets_q,
+                shared_kv=ctx.shared_kv,
+                num_softmax_heads=num_softmax_heads,
+                out=out_t,
+                M=M_t,
+            )
+        else:
+            dq, dk, dv = torch.ops.hammer.triton_hstu_cross_attn_v3_bwd(
+                dout=dout,
+                q=q,
+                k=k,
+                v=v,
+                seq_offsets=seq_offsets,
+                attn_scale=attn_scale,
+                max_seq_len=ctx.max_seq_len,
+                alpha=ctx.alpha,
+                max_q_len=ctx.max_q_len,
+                seq_offsets_q=seq_offsets_q,
+                num_targets=num_targets,
+                causal=causal,
+                shared_kv=ctx.shared_kv,
+                num_softmax_heads=num_softmax_heads,
+                M=M,
+                Delta=Delta,
+                stride_mm=ctx.stride_mm,
+                G=ctx.G,
+                truncate_method=ctx.truncate_method,
+            )
+        dq = dq.view(ctx.total_seq_len_q, ctx.H, -1)
+        return (
+            None,
+            None,
+            dq,
+            dk,
+            dv if not ctx.shared_kv else None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+@torch.jit.unused
+@torch.fx.wrap
+def triton_bw_hstu_mha(
+    max_seq_len: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    attn_scale: torch.Tensor,
+    max_q_len: Optional[int] = None,
+    seq_offsets_q: Optional[torch.Tensor] = None,
+    sort_by_length: bool = False,
+    num_softmax_heads: int = 0,
+    num_targets: Optional[torch.Tensor] = None,
+    causal: bool = False,
+    shared_kv: bool = False,
+    enable_tma: bool = True,
+    actual_max_seq_len: int = 0,
+    truncate_method: str = "none",
+) -> torch.Tensor:
+    return AttentionFunction.apply(
+        max_seq_len,
+        alpha,
+        q,
+        k,
+        v if not shared_kv else None,
+        seq_offsets,
+        attn_scale,
+        seq_offsets_q,
+        max_q_len,
+        shared_kv,
+        num_softmax_heads,
+        enable_tma,
+        truncate_method,
+        num_targets,
+        causal,
+    )
+
+
+def triton_bw_hstu_mha_wrapper(
+    max_seq_len: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    attn_scale: torch.Tensor,
+    max_q_len: Optional[int] = None,
+    seq_offsets_q: Optional[torch.Tensor] = None,
+    sort_by_length: bool = False,
+    num_softmax_heads: int = 0,
+    num_targets: Optional[torch.Tensor] = None,
+    causal: bool = False,
+    shared_kv: bool = False,
+    enable_tma: bool = True,
+    actual_max_seq_len: int = 0,
+    truncate_method: str = "none",
+) -> torch.Tensor:
+    assert not sort_by_length, "sort_by_length not supported yet in v3 triton kernel"
+    return triton_bw_hstu_mha(
+        max_seq_len=max_seq_len,
+        alpha=alpha,
+        q=q,
+        k=k,
+        v=v,
+        seq_offsets=seq_offsets,
+        attn_scale=attn_scale,
+        max_q_len=max_q_len,
+        seq_offsets_q=seq_offsets_q,
+        sort_by_length=sort_by_length,
+        num_softmax_heads=num_softmax_heads,
+        num_targets=num_targets,
+        causal=causal,
+        shared_kv=shared_kv,
+        enable_tma=enable_tma,
+        actual_max_seq_len=actual_max_seq_len,
+        truncate_method=truncate_method,
+    )

--- a/third_party/tlx/tutorials/hstu_cross_attn/triton_hstu_cross_attention.py
+++ b/third_party/tlx/tutorials/hstu_cross_attn/triton_hstu_cross_attention.py
@@ -1,0 +1,235 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pyre-unsafe
+
+#!/usr/bin/env python3
+
+from typing import List, Tuple
+
+import torch
+
+# @manual=//triton:triton
+import triton
+
+# @manual=//triton:triton
+import triton.language as tl
+from triton.language.extra.libdevice import (  # @manual=//triton:triton
+    fast_dividef, fast_expf,
+)
+
+HAS_FAST_TANH_INSTRUCTION = (
+    torch.version.cuda is not None and torch.cuda.is_available()
+    and torch.cuda.get_device_capability()[0] >= 9  # >= H100
+)
+
+if HAS_FAST_TANH_INSTRUCTION:
+
+    @triton.jit
+    def tanh_approx_fp32(x):
+        output = tl.inline_asm_elementwise(
+            asm="""
+            tanh.approx.f32 $0, $1;
+            """,
+            constraints="=r,r",
+            args=[x],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=1,
+        )
+        return output
+
+    @triton.jit
+    def fast_silu(x, MULT_BY_X: tl.constexpr):
+        # Replace divf(1, 1 + expf(-x)) with (1 + tanhf(x/2)) / 2
+        # If an approximate instruction exists.
+        x = x * 0.5
+        if MULT_BY_X:
+            return x * (tanh_approx_fp32(x) + 1)
+        else:
+            return (1 + tanh_approx_fp32(x)) * 0.5
+
+else:
+    # Don't approximate without an instruction for hardware compatibility
+    @triton.jit
+    def fast_silu(x, MULT_BY_X: tl.constexpr):
+        if MULT_BY_X:
+            # pyre-fixme[16]: Module `math` has no attribute `fast_dividef`.
+            return fast_dividef(x, 1.0 + fast_expf(-x))
+        else:
+            # pyre-fixme[16]: Module `math` has no attribute `fast_dividef`.
+            return fast_dividef(1.0, 1.0 + fast_expf(-x))
+
+
+@triton.jit
+def _attn_bwd_preprocess(
+    Out,
+    DOut,
+    Delta,
+    total_seq_len_q,
+    H,
+    softmax_heads,
+    BLOCK_M: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+):
+    off_h = tl.program_id(1)
+    offs_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    masks = offs_m < total_seq_len_q
+    offs_n = tl.arange(0, HEAD_DIM)
+    o = tl.load(
+        Out + off_h * HEAD_DIM + offs_m[:, None] * HEAD_DIM * H + offs_n[None, :],
+        mask=masks[:, None],
+    ).to(tl.float32)
+    do = tl.load(
+        DOut + off_h * HEAD_DIM + offs_m[:, None] * HEAD_DIM * H + offs_n[None, :],
+        mask=masks[:, None],
+    ).to(tl.float32)
+    delta = tl.sum(o * do, axis=1)
+    tl.store(Delta + off_h + offs_m * softmax_heads, delta, mask=masks)
+
+
+@triton.jit
+def backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm):
+    if off_h < num_softmax_heads:
+        M_off = M + off_h + seq_start_q * stride_mm
+        Delta_off = Delta + off_h + seq_start_q * stride_mm
+    else:  # placeholder
+        M_off = M
+        Delta_off = Delta
+    return M_off, Delta_off
+
+
+@triton.jit
+def backward_d_silu_activation(
+    dact_qk_trans,
+    pT,  # pT represents sig_trans
+    qk_trans,
+    scale,
+    valid_mask_trans,
+):
+    dqk_trans = dact_qk_trans * pT * (1 + qk_trans * (1 - pT)) * scale[None, :]
+    dqk_trans = tl.where(valid_mask_trans, dqk_trans, 0)
+    return dqk_trans
+
+
+@triton.jit
+def backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT,  # pT represents sig_trans
+                                  ):
+    Di = tl.load(Delta_off + offs_m * stride_mm, mask=mask_m)
+    dqk_trans = pT * (dact_qk_trans - Di[None, :])
+    return dqk_trans
+
+
+@triton.jit
+def backward_silu_activation(qk_trans, alpha, valid_mask_trans, dtype_k, scale):
+    masked_alpha = tl.where(valid_mask_trans, alpha, 0.0)
+    qk_trans = qk_trans * masked_alpha
+    pT = fast_silu(qk_trans, MULT_BY_X=False)
+    silu_trans = qk_trans * pT * scale[None, :]
+    act_qk_trans = silu_trans.to(dtype_k)
+    return qk_trans, act_qk_trans, pT
+
+
+@triton.jit
+def backward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL: tl.constexpr):
+    valid_mask_trans = (offs_m[None, :] < seq_len_q) & (offs_n[:, None] < seq_len_kv)
+    if HAS_CAUSAL:
+        offs_m = offs_m + seq_len_kv - uih_len_q
+        causal_mask_trans = offs_m[None, :] >= offs_n[:, None]
+        valid_mask_trans = valid_mask_trans & causal_mask_trans
+    return valid_mask_trans
+
+
+def forward_custom_vars(q: torch.Tensor, num_softmax_heads: int,
+                        saved_tensors: List[torch.Tensor]) -> Tuple[torch.Tensor, int]:
+    assert num_softmax_heads <= q.shape[1]
+    M = torch.empty((q.shape[0], num_softmax_heads), device=q.device, dtype=torch.float32)
+    saved_tensors.append(M)
+    stride_mm = M.stride(0)
+    return M, stride_mm
+
+
+@triton.jit
+def forward_epilogue(
+    acc,
+    l_i,
+    m_i,
+    offs_m,
+    seq_start_q,
+    stride_mm,
+    seq_len_q,
+    M,
+    off_h,
+    num_softmax_heads: tl.constexpr,
+):
+    if off_h + 1 < num_softmax_heads + 1:  # For AOTInductor lowering walkaround.
+        acc = acc / l_i[:, None]
+        m_i += tl.math.log2(l_i)
+        m_ptrs = M + (offs_m + seq_start_q) * stride_mm + off_h
+        tl.store(m_ptrs, m_i, mask=offs_m < seq_len_q)
+    return acc
+
+
+@triton.jit
+def forward_softmax_activation(qk, alpha, valid_mask, m_i, acc, l_i):
+    qk = qk * alpha * 1.44269504
+    qk = tl.where(valid_mask, qk, -float("inf"))
+    m_ij = tl.maximum(m_i, tl.max(qk, 1))
+    qk -= m_ij[:, None]
+    act_qk = tl.math.exp2(qk)
+    corr = tl.math.exp2(m_i - m_ij)
+    l_ij = tl.sum(act_qk, 1)
+    acc = acc * corr[:, None]
+    l_i = l_i * corr + l_ij
+    m_i = m_ij
+    return act_qk, acc, l_i, m_i
+
+
+@triton.jit
+def forward_softmax_common_preprocess(off_h, num_softmax_heads, BLOCK_M):
+    if off_h < num_softmax_heads:
+        m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+        l_i = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
+    else:  # placeholder
+        m_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+        l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+    return m_i, l_i
+
+
+@triton.jit
+def forward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL: tl.constexpr):
+    valid_mask = (offs_m[:, None] < seq_len_q) & (offs_n[None, :] < seq_len_kv)
+    if HAS_CAUSAL:
+        offs_m = offs_m + seq_len_kv - uih_len_q
+        causal_mask = offs_m[:, None] >= offs_n[None, :]
+        valid_mask = valid_mask & causal_mask
+    return valid_mask
+
+
+@triton.jit
+def target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS: tl.constexpr):
+    if HAS_NUM_TARGETS:
+        n_targets = tl.load(num_targets + off_z).to(tl.int32)
+    else:
+        n_targets = None
+    return n_targets
+
+
+@triton.jit
+def uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS: tl.constexpr):
+    if HAS_NUM_TARGETS:
+        uih_len_q = seq_len_q - n_targets
+    else:
+        uih_len_q = seq_len_q
+    return uih_len_q

--- a/third_party/tlx/tutorials/test_cross_attention_bwd_autows.py
+++ b/third_party/tlx/tutorials/test_cross_attention_bwd_autows.py
@@ -1,0 +1,70 @@
+"""Correctness test for the HSTU cross-attention backward (reduce_dq) under
+automatic warp specialization (meta-WS).
+
+Regression coverage for the premature k/v EMPTY-release bug: k/v are TMA-loaded
+per KV block in the outer loop and read by the inner Q-loop MMAs on a single
+copy=1 buffer; releasing the buffer every inner iteration (instead of only on
+the last) corrupted the trailing min(KV_blocks-1, num_stages) Q-blocks of dq for
+KV>=2. This test runs the autoWS kernel across KV=1..4 and num_stages=1/2 and
+asserts it matches both the hand-written TLX kernel (byte-reference for the dq
+Q-blocks) and a torch-autograd float reference (dq/dk/dv rel-L2).
+
+Run: pytest third_party/tlx/tutorials/test_cross_attention_bwd_autows.py
+"""
+import os
+import sys
+
+# The HSTU kernels live in the hstu_cross_attn/ subpackage; its modules use bare
+# imports (e.g. `import stubs`, `import triton_bw_cross_attention`) that assume
+# the subdir is on sys.path (as the repro/bench scripts do). Put it on the path
+# and import them as top-level modules (avoids triggering the subpackage
+# __init__ before the path is set).
+_HSTU_DIR = os.path.join(os.path.dirname(__file__), "hstu_cross_attn")
+sys.path.insert(0, _HSTU_DIR)
+os.environ.pop("TRITON_USE_META_WS", None)
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+
+import bench_bwd as bb  # noqa: E402
+import triton_bw_cross_attention as xa  # noqa: E402
+
+# (Lq, Lkv, Z): KV=1 is always correct; KV>=2 exercised the bug (bad Q-blocks at
+# the tail of the Q range). Lq=256 -> 4 Q-blocks (needs >=2 for the inner peel).
+_SHAPES = [(256, 64, 2), (256, 128, 2), (256, 192, 2), (256, 256, 2)]
+
+
+@pytest.mark.parametrize("ns", [1, 2])
+@pytest.mark.parametrize("Lq,Lkv,Z", _SHAPES)
+def test_cross_attention_bwd_autows(Lq, Lkv, Z, ns):
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    bb.force(ns)
+    torch.manual_seed(0)
+    q, k, v, do, so_kv, so_q, asc = bb.make(Lq, Lkv, Z)
+
+    # torch-autograd float reference (accuracy oracle).
+    rq, rk, rv = bb.torch_ref(q, k, v, do, so_kv, so_q, asc)
+
+    # Hand-written TLX kernel: byte-reference for the dq bad-Q-block count.
+    for t in (q, k, v):
+        t.grad = None
+    bb._fwd(xa.BwdVariant.TLX, "0", q, k, v, so_kv, so_q, Lkv, Lq, asc).backward(do)
+    ref_dq = q.grad.clone()
+
+    # autoWS kernel under test.
+    for t in (q, k, v):
+        t.grad = None
+    bb._fwd(xa.BwdVariant.TRITON_AUTOWS, "1", q, k, v, so_kv, so_q, Lkv, Lq, asc).backward(do)
+    dq, dk, dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+
+    # No dq Q-block may diverge from the TLX reference (this is what the bug hit).
+    n_bad, bad_blocks = bb.bad_qblocks(dq, ref_dq, Lq)
+    assert n_bad == 0, (f"autoWS dq diverges from TLX in Q-blocks {bad_blocks} "
+                        f"({n_bad} rows) for Lq={Lq} Lkv={Lkv} ns={ns}")
+
+    # And all three grads must match the float reference to bf16 precision.
+    for name, got, want in (("dq", dq, rq), ("dk", dk, rk), ("dv", dv, rv)):
+        rl2 = bb.rel_l2(got, want)
+        assert rl2 < 1e-2, f"{name} rel-L2 {rl2:.2e} too high (Lq={Lq} Lkv={Lkv} ns={ns})"


### PR DESCRIPTION
Summary:

Adds the standalone (fbsource-independent) HSTU cross-attention kernels and the
tooling used to develop and validate the autoWS backward (reduce_dq) path, so the
kernels can be imported by tritonbench and exercised without buck/hammer.

Contents (all under third_party/tlx/tutorials/):
- hstu_cross_attn/: fwd (triton_hstu_cross_attention.py) and bwd
  (triton_bw_cross_attention.py: redq / autoWS / TLX variants;
  tlx_bw_cross_attention.py: hand-written TLX reduce_dq), plus stubs.py and
  triton_attention_utils.py.
- hstu_cross_attn/bench_bwd.py: combined accuracy (dq/dk/dv rel-L2 vs torch +
  dq bad-Q-block count vs a byte-reference kernel, --ref {redq,tlx}) and perf
  (per-variant bwd latency), with --variants to select kernels.
- hstu_cross_attn/repro/: minimal repros (l10b.py KV/ns sweep, decomp*.py value
  decomposition, rc.py compute-sanitizer driver, sweep2.py, REPRO.md, and the
  triton-opt per-pass singleloop_annotated_repro.mlir), plus run_bwd*.py /
  run_tlx_bwd.py drivers.
- test_cross_attention_bwd_autows.py: pytest (KV=1..4 x num_stages=1/2) asserting
  the autoWS dq matches the TLX reference (0 bad Q-blocks) and dq/dk/dv match a
  torch-float reference. Wired into run_all.sh next to the FA tutorial test.

Reviewed By: njriasan

Differential Revision: D110625979


