### PR TITLE
[triton][beta] [CI] Align llvm-build.yml with upstream #10358 (fix AlmaLinux numpy + clang 21.1.8 ICE)

### DIFF
--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -30,10 +30,10 @@ jobs:
       matrix:
         config:
         - {runner: 'Ubuntu 22.04', runs_on: 'ubuntu-22.04', target-os: 'ubuntu', arch: 'x64'}
-        - {runner: 'Ubuntu 22.04 ARM64', runs_on: 'ubuntu-22.04', target-os: 'ubuntu', arch: 'arm64'}
+        - {runner: 'Ubuntu 22.04 ARM64', runs_on: 'ubuntu-22.04-arm', target-os: 'ubuntu', arch: 'arm64'}
         - {runner: 'AlmaLinux 8', runs_on: 'ubuntu-22.04', target-os: 'almalinux', arch: 'x64', container: 'almalinux:8.10-20250411'}
         - {runner: 'AlmaLinux 8 ARM64', runs_on: 'ubuntu-22.04-arm', target-os: 'almalinux', arch: 'arm64', container: 'almalinux:8.10-20250411'}
-        - {runner: 'MacOS X64', runs_on: 'macos-15', target-os: 'macos', arch: 'x64'}
+        - {runner: 'MacOS X64', runs_on: 'macos-15-intel', target-os: 'macos', arch: 'x64'}
         - {runner: 'MacOS ARM64', runs_on: 'macos-15', target-os: 'macos', arch: 'arm64'}
         - {runner: 'Windows Latest', runs_on: 'windows-latest', target-os: 'windows', arch: 'x64'}
 
@@ -44,27 +44,29 @@ jobs:
       with:
         path: llvm-build
 
-    - name: Fetch LLVM Info
+    - name: Install System Prerequisites (AlmaLinux)
+      if: matrix.config.target-os == 'almalinux'
+      run: |
+        rpm --import https://packages.microsoft.com/keys/microsoft.asc
+        dnf install --assumeyes https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
+        dnf install --assumeyes azure-cli llvm-toolset-20.1.8 python38-pip python38-devel git jq tar gzip
+        alternatives --set python3 /usr/bin/python3.8
+        echo "extra_cmake_flags=-DCMAKE_ASM_COMPILER=clang -DCMAKE_CXX_FLAGS=-Wno-everything -DPython3_EXECUTABLE=/usr/bin/python3.8 -DPython_EXECUTABLE=/usr/bin/python3.8" >> "$GITHUB_ENV"
+
+    - name: Fetch LLVM Build Metadata
       shell: bash
       run: |
-        LLVM_INFO="llvm-build/cmake/llvm-info.json"
-
-        # Parse cmake/llvm-info.json with sed so this step needs no jq/python
-        # (it runs before "Set up Python"); mirrors scripts/build-llvm-project.sh.
-        LLVM_COMMIT_HASH="$(sed -n 's/.*"llvm_hash"[[:space:]]*:[[:space:]]*"\([0-9a-f]*\)".*/\1/p' "${LLVM_INFO}")"
+        LLVM_COMMIT_HASH="$(jq -r '.llvm_hash' llvm-build/cmake/llvm-info.json)"
         echo "Found LLVM commit hash: ${LLVM_COMMIT_HASH}"
         echo "llvm_commit_hash=${LLVM_COMMIT_HASH}" >> ${GITHUB_ENV}
+
+        LLVM_BUILD_NUMBER="$(jq -r '.build_number' llvm-build/cmake/llvm-info.json)"
+        echo "Found LLVM build number: ${LLVM_BUILD_NUMBER}"
 
         SHORT_LLVM_COMMIT_HASH="${LLVM_COMMIT_HASH:0:8}"
         echo "Short LLVM commit hash: ${SHORT_LLVM_COMMIT_HASH}"
         echo "short_llvm_commit_hash=${SHORT_LLVM_COMMIT_HASH}" >> ${GITHUB_ENV}
 
-        LLVM_BUILD_NUMBER="$(sed -n 's/.*"build_number"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' "${LLVM_INFO}")"
-        echo "LLVM build number: ${LLVM_BUILD_NUMBER}"
-        echo "llvm_build_number=${LLVM_BUILD_NUMBER}" >> ${GITHUB_ENV}
-
-        # Artifact name must match what setup.py downloads:
-        # llvm-{short_hash}-{os}-{arch}-{build_number} (get_llvm_package_info, setup.py:241).
         INSTALL_DIR="llvm-${SHORT_LLVM_COMMIT_HASH}-${{ matrix.config.target-os }}-${{ matrix.config.arch }}-${LLVM_BUILD_NUMBER}"
         echo "LLVM installation directory name: ${INSTALL_DIR}"
         echo "llvm_install_dir=${INSTALL_DIR}" >> ${GITHUB_ENV}
@@ -88,15 +90,6 @@ jobs:
       with:
         arch: amd64
 
-    - name: Install System Prerequisites (AlmaLinux)
-      if: matrix.config.target-os == 'almalinux'
-      run: |
-        rpm --import https://packages.microsoft.com/keys/microsoft.asc
-        dnf install --assumeyes https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
-        dnf install --assumeyes azure-cli llvm-toolset python38-pip python38-devel git tar gzip
-        alternatives --set python3 /usr/bin/python3.8
-        echo "extra_cmake_flags=-DCMAKE_ASM_COMPILER=clang -DCMAKE_CXX_FLAGS=-Wno-everything -DPython3_EXECUTABLE=/usr/bin/python3.8 -DPython_EXECUTABLE=/usr/bin/python3.8" >> "$GITHUB_ENV"
-
     - name: Install Prerequisites
       shell: bash
       run: |
@@ -112,7 +105,7 @@ jobs:
         restore-keys: ${{ matrix.config.target-os }}-${{ matrix.config.arch }}-
 
     - name: Free disk space on Ubuntu
-      if: matrix.config.target-os == 'ubuntu'
+      if: matrix.config.arch == 'x64' && matrix.config.target-os == 'ubuntu'
       run: |
         df -h
         echo "Removing large packages"
@@ -122,11 +115,9 @@ jobs:
         sudo apt-get clean
         df -h
 
-    - name: Configure, Build, Test, and Install LLVM (Linux and macOS x64)
-      if: (matrix.config.arch == 'x64' && (matrix.config.target-os == 'ubuntu' || matrix.config.target-os == 'macos')) || matrix.config.target-os == 'almalinux'
+    - name: Configure, Build, Test, and Install LLVM (Ubuntu, CentOS, and macOS)
+      if: matrix.config.target-os == 'ubuntu' || matrix.config.target-os == 'almalinux' || matrix.config.target-os == 'macos'
       run: >
-        python3 -m pip install -r llvm-project/mlir/python/requirements.txt
-
         cmake -GNinja -Bllvm-project/build
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
@@ -151,8 +142,6 @@ jobs:
     - name: Configure, Build, Test, and Install LLVM (Windows)
       if: matrix.config.arch == 'x64' && (matrix.config.target-os == 'windows')
       run: >
-        python3 -m pip install -r llvm-project/mlir/python/requirements.txt
-
         cmake -GNinja -Bllvm-project/build
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
@@ -173,102 +162,12 @@ jobs:
         tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
 
 
-    - name: Configure, Build, and Install LLVM (ubuntu arm64)
-      if: matrix.config.arch == 'arm64' && matrix.config.target-os == 'ubuntu'
-      run: |
-        python3 -m pip install -r llvm-project/mlir/python/requirements.txt
-        mkdir arm-sysroot
-        mkdir -p llvm-project/host-tools
-        cd llvm-project/host-tools
-        cmake -GNinja ../llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="mlir;llvm;clang;lld"
-        ninja mlir-tblgen
-        ninja llvm-tblgen
-        ninja clang-tblgen
-        cd ../..
-        mv ./llvm-project/host-tools/bin ./host-tools
-        HOST_TOOLS="$(pwd)/host-tools"
-        rm -rf llvm-project/host-tools
-        sudo apt-get update
-        sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf qemu-user-static gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-        cp -r /usr/aarch64-linux-gnu/lib ./arm-sysroot
-        cp -r /usr/aarch64-linux-gnu/include ./arm-sysroot
-        LINKER=$(pwd)/arm-sysroot/lib/ld-linux-aarch64.so.1
-        wget http://ftp.de.debian.org/debian/pool/main/g/gcc-defaults/gcc-aarch64-linux-gnu_14.2.0-1_amd64.deb
-        dpkg-deb -x gcc-aarch64-linux-gnu_14.2.0-1_amd64.deb ./arm-sysroot
-        export LD_LIBRARY_PATH=$(pwd)/arm-sysroot/lib:$LD_LIBRARY_PATH
-        sudo ln -s $LINKER /lib/ld-linux-aarch64.so.1
-        SYSROOT="$(pwd)/arm-sysroot"
-        echo $SYSROOT
-        echo $LINKER
-        cmake -GNinja -Bllvm-project/build \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DLLVM_ENABLE_PROJECTS="mlir;llvm;lld;clang" \
-        -DLLVM_BUILD_UTILS=ON \
-        -DLLVM_TABLEGEN=$HOST_TOOLS/llvm-tblgen \
-        -DMLIR_TABLEGEN=$HOST_TOOLS/mlir-tblgen \
-        -DCLANG_TABLEGEN=$HOST_TOOLS/clang-tblgen \
-        -DLLVM_ENABLE_ASSERTIONS=ON \
-        -DCMAKE_LINKER=$LINKER \
-        -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
-        -DLLVM_ENABLE_ZSTD=OFF \
-        -DLLVM_ABI_BREAKING_CHECKS=FORCE_OFF \
-        -DLLVM_INSTALL_UTILS=ON \
-        -DCMAKE_INSTALL_PREFIX="${{ env.llvm_install_dir }}" \
-        -DLLVM_TARGETS_TO_BUILD="AArch64;NVPTX;AMDGPU" \
-        -DCMAKE_CROSSCOMPILING=True \
-        -DLLVM_TARGET_ARCH=AArch64 \
-        -DLLVM_DEFAULT_TARGET_TRIPLE=aarch64-linux-gnu \
-        -DLLVM_USE_HOST_TOOLS=OFF \
-        -DCMAKE_C_COMPILER="/usr/bin/aarch64-linux-gnu-gcc" \
-        -DCMAKE_CXX_COMPILER="/usr/bin/aarch64-linux-gnu-g++" \
-        -DCMAKE_ASM_COMPILER="/usr/bin/aarch64-linux-gnu-as" \
-        -DCMAKE_AR="/usr/bin/aarch64-linux-gnu-ar" \
-        -DCMAKE_NM="/usr/bin/aarch64-linux-gnu-nm" \
-        -DCMAKE_OBJCOPY="/usr/bin/aarch64-linux-gnu-objcopy" \
-        -DCMAKE_OBJDUMP="/usr/bin/aarch64-linux-gnu-objdump" \
-        -DCMAKE_RANLIB="/usr/bin/aarch64-linux-gnu-ranlib" \
-        -DCMAKE_STRIP="/usr/bin/aarch64-linux-gnu-strip" \
-        -DCMAKE_SYSROOT=$SYSROOT \
-        -DLLVM_INCLUDE_TESTS=OFF \
-        -DMLIR_INCLUDE_TESTS=OFF \
-        llvm-project/llvm
-        ninja -C llvm-project/build install
-        tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
-
-    - name: Configure, Build, and Install LLVM (macOS arm64)
-      if: matrix.config.arch == 'arm64' && matrix.config.target-os == 'macos'
-      run: >
-        python3 -m pip install -r llvm-project/mlir/python/requirements.txt
-
-        cmake -GNinja -Bllvm-project/build
-        -DCMAKE_BUILD_TYPE=Release
-        -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
-        -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-        -DCMAKE_INSTALL_PREFIX="${{ env.llvm_install_dir }}"
-        -DCMAKE_LINKER=lld
-        -DCMAKE_OSX_ARCHITECTURES=arm64
-        -DLLVM_BUILD_UTILS=ON
-        -DLLVM_BUILD_TOOLS=ON
-        -DLLVM_ENABLE_ASSERTIONS=ON
-        -DMLIR_ENABLE_BINDINGS_PYTHON=OFF
-        -DLLVM_ENABLE_PROJECTS="mlir;llvm;lld;clang"
-        -DLLVM_ENABLE_ZSTD=OFF
-        -DLLVM_INSTALL_UTILS=ON
-        -DLLVM_TARGETS_TO_BUILD="AArch64;NVPTX;AMDGPU"
-        -DLLVM_USE_HOST_TOOLS=ON
-        -DLLVM_ABI_BREAKING_CHECKS=FORCE_OFF
-        llvm-project/llvm
-
-        ninja -C llvm-project/build install
-
-        tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
-
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v7
       with:
         name: llvm-${{ matrix.config.target-os }}-${{ matrix.config.arch }}
         path: |
-          ${{ github.workspace }}/${{ env.llvm_install_dir }}.tar.gz
+          ${{ github.workspace }}/llvm-*-${{ matrix.config.target-os }}-${{ matrix.config.arch }}-*.tar.gz
 
     - name: Azure login
       if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'llvm-head' }}
@@ -282,7 +181,9 @@ jobs:
       if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'llvm-head' }}
       shell: bash -el {0}
       run: |
-        az storage blob upload --account-name oaitriton --auth-mode login --container-name public --file "${{ env.llvm_install_dir }}.tar.gz" --name "llvm-builds/${{ env.llvm_install_dir }}.tar.gz" --overwrite
+        sha256sum "${{ env.llvm_install_dir }}.tar.gz"
+
+        az storage blob upload --account-name oaitriton --auth-mode login --container-name public --file "${{ env.llvm_install_dir }}.tar.gz" --name "llvm-builds/${{ env.llvm_install_dir }}.tar.gz"
 
         URL=$(az storage blob url --account-name oaitriton --auth-mode login --container-name public --name "llvm-builds/${{ env.llvm_install_dir }}.tar.gz")
         echo "Blob URL: ${URL}"


### PR DESCRIPTION
Summary:
Adopts upstream triton-lang/triton PR #10358 `.github/workflows/llvm-build.yml` for the beta fork, replacing the divergent beta version. This fixes two AlmaLinux `LLVM Build` failures the beta version caused:

1. `No matching distribution found for numpy<=2.1.2,>=2.1.0`: the beta version ran `python3 -m pip install -r llvm-project/mlir/python/requirements.txt`, which after the `62b7cf9` LLVM bump pins `numpy>=2.1.0` (needs Python >= 3.10) and cannot install on AlmaLinux Python 3.8. Every step builds with `-DMLIR_ENABLE_BINDINGS_PYTHON=OFF`, so that requirements file is never needed; #10358 has no such step.

2. `clang frontend command failed with exit code 133` (ICE) on AlmaLinux 8 ARM64 compiling MLIR `BuiltinDialectBytecode.cpp`: the beta version installed unversioned `llvm-toolset`, which now resolves to clang 21.1.8 and crashes on aarch64. #10358 pins `llvm-toolset-20.1.8` -- the same stable clang upstream used to produce the `almalinux-arm64` sha256 already in `cmake/llvm-info.json`.

The adoption also fixes two latent matrix bugs (`Ubuntu 22.04 ARM64` ran on an x64 runner via a hand-rolled cross-compile step, now native `ubuntu-22.04-arm`; `MacOS X64` ran on `macos-15`, now `macos-15-intel`), collapses the separate arm64/macOS-arm64 build steps into the unified native build, and switches LLVM-metadata parsing from sed to jq (installed on AlmaLinux; pre-installed on GitHub-hosted runners). The Azure upload stays gated to `github.repository == 'triton-lang/triton'`, so the fork still skips it.

Authored with Claude.

Differential Revision: D111103780


