### PR TITLE
[triton][beta] [AMD] Modulo scheduling Steps 4.7+4.8: warp-pipeline partition + s_setprio (#1960)

### DIFF
--- a/test/TritonGPU/amd/amd-modulo-warp-pipeline-partition.mlir
+++ b/test/TritonGPU/amd/amd-modulo-warp-pipeline-partition.mlir
@@ -1,0 +1,134 @@
+// RUN: TRITON_ENABLE_AMD_MODULO=1 triton-opt %s -split-input-file \
+// RUN:   -tritonamdgpu-dot-decompose-and-schedule 2>&1 | FileCheck %s
+//
+// Steps 4.7 + 4.8: AMD warp-pipeline cluster partitioning and s_setprio
+// derivation.
+
+// Test 1: Two pipelines (LDS + MFMA).
+// A minimal GEMM loop with LDS local_loads feeding a dot.
+//
+// CHECK: remark: amd-modulo: DDG {{[0-9]+}} nodes MFMA={{[0-9]+}} LDS={{[0-9]+}}
+// CHECK-SAME: clusters=
+// Step 4.7/4.8 annotate each op with its cluster ID and derived s_setprio: the
+// LDS local_loads and the MFMA dot land in different clusters.
+// CHECK:      ttg.local_load {{.*}}ttg.warp_pipeline_cluster = {{[0-9]+}}{{.*}}ttg.warp_pipeline_priority = {{[0-9]+}}
+// CHECK:      tt.dot {{.*}}ttg.warp_pipeline_cluster = {{[0-9]+}}{{.*}}ttg.warp_pipeline_priority = {{[0-9]+}}
+
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [2, 2], instrShape = [16, 16, 32], isTransposed = true}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @gemm_lds_mfma(
+      %a_mem: !ttg.memdesc<256x64xf16, #shared, #smem>,
+      %b_mem: !ttg.memdesc<64x256xf16, #shared, #smem>,
+      %c_init: tensor<256x256xf32, #mma>,
+      %lb: index, %ub: index, %step: index) -> tensor<256x256xf32, #mma> {
+    %res = scf.for %iv = %lb to %ub step %step iter_args(%acc = %c_init)
+        -> (tensor<256x256xf32, #mma>) {
+      %a = ttg.local_load %a_mem : !ttg.memdesc<256x64xf16, #shared, #smem>
+           -> tensor<256x64xf16, #dot0>
+      %b = ttg.local_load %b_mem : !ttg.memdesc<64x256xf16, #shared, #smem>
+           -> tensor<64x256xf16, #dot1>
+      %d = tt.dot %a, %b, %acc :
+          tensor<256x64xf16, #dot0> * tensor<64x256xf16, #dot1>
+          -> tensor<256x256xf32, #mma>
+      scf.yield %d : tensor<256x256xf32, #mma>
+    }
+    tt.return %res : tensor<256x256xf32, #mma>
+  }
+}
+
+// -----
+
+// Test 2: Three pipelines (GLOBAL + LDS + MFMA).
+// A GEMM loop with global loads, local stores/loads, and a dot.
+//
+// CHECK: remark: amd-modulo: DDG {{[0-9]+}} nodes{{.*}}GLOBAL={{[1-9]}}
+// CHECK-SAME: clusters=
+// GLOBAL/LDS ops and the MFMA dot are annotated with cluster + priority.
+// CHECK:      tt.load {{.*}}ttg.warp_pipeline_cluster = {{[0-9]+}}{{.*}}ttg.warp_pipeline_priority = {{[0-9]+}}
+// CHECK:      tt.dot {{.*}}ttg.warp_pipeline_cluster = {{[0-9]+}}{{.*}}ttg.warp_pipeline_priority = {{[0-9]+}}
+
+#mma2 = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [16, 16, 16], isTransposed = true}>
+#dot0_2 = #ttg.dot_op<{opIdx = 0, parent = #mma2, kWidth = 4}>
+#dot1_2 = #ttg.dot_op<{opIdx = 1, parent = #mma2, kWidth = 4}>
+#blocked_a = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked_b = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+#shared2 = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0]}>
+#shared2t = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [0, 1]}>
+#smem2 = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @gemm_global_lds_mfma(
+      %a_ptr: tensor<128x64x!tt.ptr<f16>, #blocked_a>,
+      %b_ptr: tensor<64x128x!tt.ptr<f16>, #blocked_b>,
+      %a_buf: !ttg.memdesc<128x64xf16, #shared2, #smem2, mutable>,
+      %b_buf: !ttg.memdesc<64x128xf16, #shared2t, #smem2, mutable>,
+      %c_init: tensor<128x128xf32, #mma2>,
+      %lb: index, %ub: index, %step: index) -> tensor<128x128xf32, #mma2> {
+    %res:3 = scf.for %iv = %lb to %ub step %step
+        iter_args(%acc = %c_init,
+                  %pa = %a_ptr, %pb = %b_ptr)
+        -> (tensor<128x128xf32, #mma2>,
+            tensor<128x64x!tt.ptr<f16>, #blocked_a>,
+            tensor<64x128x!tt.ptr<f16>, #blocked_b>) {
+      // GLOBAL: async loads from HBM
+      %a_data = tt.load %pa : tensor<128x64x!tt.ptr<f16>, #blocked_a>
+      %b_data = tt.load %pb : tensor<64x128x!tt.ptr<f16>, #blocked_b>
+      // LDS: store to shared, then load with dot_op layout
+      ttg.local_store %a_data, %a_buf : tensor<128x64xf16, #blocked_a>
+          -> !ttg.memdesc<128x64xf16, #shared2, #smem2, mutable>
+      ttg.local_store %b_data, %b_buf : tensor<64x128xf16, #blocked_b>
+          -> !ttg.memdesc<64x128xf16, #shared2t, #smem2, mutable>
+      %a = ttg.local_load %a_buf : !ttg.memdesc<128x64xf16, #shared2, #smem2, mutable>
+           -> tensor<128x64xf16, #dot0_2>
+      %b = ttg.local_load %b_buf : !ttg.memdesc<64x128xf16, #shared2t, #smem2, mutable>
+           -> tensor<64x128xf16, #dot1_2>
+      // MFMA: matrix multiply
+      %d = tt.dot %a, %b, %acc :
+          tensor<128x64xf16, #dot0_2> * tensor<64x128xf16, #dot1_2>
+          -> tensor<128x128xf32, #mma2>
+      scf.yield %d, %pa, %pb : tensor<128x128xf32, #mma2>,
+          tensor<128x64x!tt.ptr<f16>, #blocked_a>,
+          tensor<64x128x!tt.ptr<f16>, #blocked_b>
+    }
+    tt.return %res#0 : tensor<128x128xf32, #mma2>
+  }
+}
+
+// -----
+
+// Test 3: Single pipeline (MFMA only).
+// A loop with only a dot and loop-carried operands. Only one pipeline (MFMA)
+// is active, so warp-pipelining is not applicable.
+//
+// With a single active pipeline there is no warp-pipelining: the remark reports
+// clusters=1(no-warp-pipeline) and no cluster/priority attributes are emitted.
+// CHECK: remark: amd-modulo: DDG {{[0-9]+}} nodes MFMA=1 LDS=0 GLOBAL=0
+// CHECK-SAME: clusters=1(no-warp-pipeline)
+
+#mma3 = #ttg.amd_mfma<{version = 4, warpsPerCTA = [2, 2], instrShape = [16, 16, 32], isTransposed = true}>
+#dot0_3 = #ttg.dot_op<{opIdx = 0, parent = #mma3, kWidth = 8}>
+#dot1_3 = #ttg.dot_op<{opIdx = 1, parent = #mma3, kWidth = 8}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @mfma_only(
+      %a: tensor<256x64xf16, #dot0_3>,
+      %b: tensor<64x256xf16, #dot1_3>,
+      %c_init: tensor<256x256xf32, #mma3>,
+      %lb: index, %ub: index, %step: index) -> tensor<256x256xf32, #mma3> {
+    %res:3 = scf.for %iv = %lb to %ub step %step
+        iter_args(%acc = %c_init, %ai = %a, %bi = %b)
+        -> (tensor<256x256xf32, #mma3>,
+            tensor<256x64xf16, #dot0_3>,
+            tensor<64x256xf16, #dot1_3>) {
+      %d = tt.dot %ai, %bi, %acc :
+          tensor<256x64xf16, #dot0_3> * tensor<64x256xf16, #dot1_3>
+          -> tensor<256x256xf32, #mma3>
+      scf.yield %d, %ai, %bi : tensor<256x256xf32, #mma3>,
+          tensor<256x64xf16, #dot0_3>,
+          tensor<64x256xf16, #dot1_3>
+    }
+    tt.return %res#0 : tensor<256x256xf32, #mma3>
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -31,6 +31,7 @@ add_triton_library(TritonAMDGPUTransforms
   TritonAMDGPUIR
   TritonAMDGPUTransformsIncGen
   TritonGPUIR
+  TritonGPUModuloCore
   TritonAMDUtils
   TritonAMDAnalysis
 )

--- a/third_party/amd/lib/TritonAMDGPUTransforms/DotDecomposeAndSchedule.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/DotDecomposeAndSchedule.cpp
@@ -65,6 +65,7 @@
 // relocated to a neutral path.
 #include "mlir/IR/IRMapping.h"
 #include "third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDLatencyModel.h"
+#include "third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDWarpPipelinePartition.h"
 #include "third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h"
 #include "third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
@@ -972,6 +973,39 @@ static void runAMDModuloScaffold(ModuleOp module) {
       node.op->setAttr("ttg.modulo_order", b.getI32IntegerAttr(it->second));
     }
     os << " II=" << sched.II << " maxStage=" << sched.getMaxStage();
+
+    // E1.5: Step 4.7 + 4.8 — warp-pipeline cluster partitioning and s_setprio
+    // derivation. Runs the latency-aware partition, then derives priorities
+    // from MRT occupancy/slack. Annotates each op with its cluster ID and
+    // s_setprio.
+    auto partition = triton::gpu::partitionForAMDWarpPipeline(ddg, sched);
+    if (partition.isWarpPipelineCandidate()) {
+      triton::gpu::assignAMDWarpPipelinePriorities(partition, ddg, sched);
+      for (const auto &c : partition.clusters) {
+        for (unsigned idx : c.nodeIndices) {
+          const auto &node = ddg.getNode(idx);
+          node.op->setAttr("ttg.warp_pipeline_cluster",
+                           b.getI32IntegerAttr(c.clusterId));
+          node.op->setAttr("ttg.warp_pipeline_priority",
+                           b.getI32IntegerAttr(c.sSetprio));
+        }
+      }
+      os << " clusters=" << partition.clusters.size()
+         << " pingpong_offset=" << partition.pingpongOffset;
+      for (const auto &c : partition.clusters) {
+        os << " c" << c.clusterId << "={";
+        bool first = true;
+        for (triton::gpu::HWPipeline p : c.pipelines) {
+          if (!first)
+            os << ",";
+          os << triton::gpu::getPipelineName(p);
+          first = false;
+        }
+        os << " prio=" << c.sSetprio << "}";
+      }
+    } else {
+      os << " clusters=1(no-warp-pipeline)";
+    }
 
     // E3: emit a serialized triton::CoarseSchedule so the EXISTING AMD pipeline
     // expander (tritonamdgpu-pipeline) does multi-buffering + loop expansion —

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@
 add_triton_library(TritonGPUModuloCore
   ModuloScheduling/LatencyModel.cpp
   ModuloScheduling/AMDLatencyModel.cpp
+  ModuloScheduling/AMDWarpPipelinePartition.cpp
   ModuloScheduling/DataDependenceGraph.cpp
   ModuloScheduling/ModuloReservationTable.cpp
   ModuloScheduling/SwingScheduler.cpp

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDWarpPipelinePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDWarpPipelinePartition.cpp
@@ -1,0 +1,569 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// AMD Warp-Pipeline Partition — Steps 4.7 + 4.8 from the AMD Global
+// Instruction Scheduling design doc.
+//
+// See AMDWarpPipelinePartition.h for the public API.
+
+#include "AMDWarpPipelinePartition.h"
+
+#include "llvm/Support/Debug.h"
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <tuple>
+
+#define DEBUG_TYPE "amd-warp-pipeline-partition"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir::triton::gpu {
+
+namespace {
+
+// AMD barrier overhead costs (cycles).
+constexpr int kVmcntOverhead = 10;
+constexpr int kSbarrierOverhead = 40;
+
+// Step 4.8c tuning constants.
+constexpr double kLambdaWeight = 1.5;
+constexpr double kAsyncLoadPressure = 0.5;
+
+// The AMD pipelines relevant for clustering.
+constexpr HWPipeline kAMDPipelines[] = {HWPipeline::MFMA, HWPipeline::LDS,
+                                        HWPipeline::GLOBAL, HWPipeline::VALU};
+
+// ============================================================================
+// Step 4.7 helpers
+// ============================================================================
+
+using PipelinePairKey = std::pair<HWPipeline, HWPipeline>;
+
+static int barrierCostForEdge(const DDGEdge &edge,
+                              const DataDependenceGraph &ddg) {
+  const DDGNode &src = ddg.getNode(edge.srcIdx);
+  const DDGNode &dst = ddg.getNode(edge.dstIdx);
+  bool srcIsLDS = src.pipeline == HWPipeline::LDS;
+  bool dstIsLDS = dst.pipeline == HWPipeline::LDS;
+  if (srcIsLDS != dstIsLDS)
+    return kSbarrierOverhead;
+  return kVmcntOverhead;
+}
+
+static llvm::DenseMap<PipelinePairKey, double>
+computeSeparationCost(const DataDependenceGraph &ddg,
+                      const ModuloScheduleResult &schedule) {
+  llvm::DenseMap<PipelinePairKey, double> coupling;
+  int II = schedule.II;
+
+  for (const auto &edge : ddg.getEdges()) {
+    const DDGNode &src = ddg.getNode(edge.srcIdx);
+    const DDGNode &dst = ddg.getNode(edge.dstIdx);
+
+    if (src.pipeline == dst.pipeline)
+      continue;
+    if (src.pipeline == HWPipeline::NONE || dst.pipeline == HWPipeline::NONE)
+      continue;
+
+    auto srcIt = schedule.nodeToCycle.find(edge.srcIdx);
+    auto dstIt = schedule.nodeToCycle.find(edge.dstIdx);
+    if (srcIt == schedule.nodeToCycle.end() ||
+        dstIt == schedule.nodeToCycle.end())
+      continue;
+
+    // Fold the loop-carried distance into the gap so a distance>=1 edge
+    // reflects its true cross-iteration separation rather than collapsing to a
+    // spurious
+    // <=0 gap (which would clamp to 1 and over-weight the coupling).
+    int cycleGap =
+        dstIt->second - srcIt->second + static_cast<int>(edge.distance) * II;
+    if (cycleGap <= 0)
+      cycleGap = 1;
+
+    int cost = barrierCostForEdge(edge, ddg);
+    coupling[{src.pipeline, dst.pipeline}] +=
+        static_cast<double>(cost) / cycleGap;
+  }
+
+  return coupling;
+}
+
+static llvm::SmallVector<unsigned>
+topologicalSort(llvm::ArrayRef<unsigned> nodeIndices,
+                const DataDependenceGraph &ddg) {
+  llvm::DenseSet<unsigned> inSet;
+  for (unsigned idx : nodeIndices)
+    inSet.insert(idx);
+
+  llvm::DenseMap<unsigned, int> inDegree;
+  for (unsigned idx : nodeIndices) {
+    int deg = 0;
+    for (const auto *edge : ddg.getInEdges(idx)) {
+      if (edge->distance == 0 && inSet.count(edge->srcIdx))
+        ++deg;
+    }
+    inDegree[idx] = deg;
+  }
+
+  llvm::SmallVector<unsigned> queue;
+  for (unsigned idx : nodeIndices) {
+    if (inDegree[idx] == 0)
+      queue.push_back(idx);
+  }
+
+  llvm::SmallVector<unsigned> sorted;
+  sorted.reserve(nodeIndices.size());
+  while (!queue.empty()) {
+    unsigned cur = queue.pop_back_val();
+    sorted.push_back(cur);
+    for (const auto *edge : ddg.getOutEdges(cur)) {
+      if (edge->distance > 0 || !inSet.count(edge->dstIdx))
+        continue;
+      if (--inDegree[edge->dstIdx] == 0)
+        queue.push_back(edge->dstIdx);
+    }
+  }
+
+  if (sorted.size() < nodeIndices.size()) {
+    // A distance-0 subgraph should be acyclic; a leftover means DDG
+    // construction introduced an intra-iteration cycle. Log it (downstream
+    // makespan/ criticality will under-approximate deps for these nodes) and
+    // append the unordered remainder so callers still see every node.
+    LDBG("topologicalSort: distance-0 cycle detected, "
+         << (nodeIndices.size() - sorted.size()) << " node(s) left unordered");
+    llvm::DenseSet<unsigned> visited(sorted.begin(), sorted.end());
+    for (unsigned idx : nodeIndices) {
+      if (!visited.count(idx))
+        sorted.push_back(idx);
+    }
+  }
+
+  return sorted;
+}
+
+static int computeMultiPipelineMakespan(llvm::ArrayRef<unsigned> nodeIndices,
+                                        const DataDependenceGraph &ddg) {
+  auto sorted = topologicalSort(nodeIndices, ddg);
+
+  llvm::DenseSet<unsigned> inSet;
+  for (unsigned idx : nodeIndices)
+    inSet.insert(idx);
+
+  llvm::DenseMap<HWPipeline, int> pipeAvail;
+  llvm::DenseMap<unsigned, int> opStart;
+
+  for (unsigned idx : sorted) {
+    const DDGNode &node = ddg.getNode(idx);
+
+    int dataReady = 0;
+    for (const auto *edge : ddg.getInEdges(idx)) {
+      if (edge->distance > 0)
+        continue;
+      if (!inSet.count(edge->srcIdx))
+        continue;
+      auto it = opStart.find(edge->srcIdx);
+      if (it != opStart.end()) {
+        const DDGNode &pred = ddg.getNode(edge->srcIdx);
+        dataReady = std::max(dataReady, it->second + pred.latency);
+      }
+    }
+
+    int pipeReady = pipeAvail.lookup(node.pipeline);
+    int start = std::max(dataReady, pipeReady);
+    opStart[idx] = start;
+    pipeAvail[node.pipeline] = start + pipelineOccupancy(node);
+  }
+
+  int makespan = 0;
+  for (unsigned idx : nodeIndices) {
+    const DDGNode &node = ddg.getNode(idx);
+    auto it = opStart.find(idx);
+    if (it != opStart.end())
+      makespan = std::max(makespan, it->second + pipelineOccupancy(node));
+  }
+  return makespan;
+}
+
+static double
+mergeSavings(const AMDClusterInfo &c1, const AMDClusterInfo &c2,
+             const llvm::DenseMap<PipelinePairKey, double> &coupling) {
+  double savings = 0;
+  for (HWPipeline p1 : c1.pipelines) {
+    for (HWPipeline p2 : c2.pipelines) {
+      auto it1 = coupling.find({p1, p2});
+      if (it1 != coupling.end())
+        savings += it1->second;
+      auto it2 = coupling.find({p2, p1});
+      if (it2 != coupling.end())
+        savings += it2->second;
+    }
+  }
+  return savings;
+}
+
+// ============================================================================
+// Step 4.8 helpers
+// ============================================================================
+
+/// Look up per-cluster per-pipeline occupancy from the cluster's utilization
+/// map. Returns 0 if the pipeline isn't present.
+static double getClusterOcc(const AMDClusterInfo &c, HWPipeline pipe) {
+  auto it = c.utilization.find(pipe);
+  return (it != c.utilization.end()) ? it->second : 0.0;
+}
+
+/// Find cluster by ID in the result vector.
+static const AMDClusterInfo *
+findCluster(const llvm::SmallVector<AMDClusterInfo, 4> &clusters, int id) {
+  for (const auto &c : clusters) {
+    if (c.clusterId == id)
+      return &c;
+  }
+  return nullptr;
+}
+
+/// Step 4.8a: Compute per-op ASAP/ALAP slack and criticality.
+static llvm::DenseMap<unsigned, double>
+computeCriticality(const DataDependenceGraph &ddg,
+                   const ModuloScheduleResult &schedule) {
+  int II = schedule.II;
+
+  llvm::SmallVector<unsigned> allIndices;
+  for (unsigned i = 0; i < ddg.getNumNodes(); ++i)
+    allIndices.push_back(i);
+  auto sorted = topologicalSort(allIndices, ddg);
+
+  // ASAP.
+  llvm::DenseMap<unsigned, int> asap;
+  for (unsigned idx : sorted) {
+    int earliest = 0;
+    for (const auto *edge : ddg.getInEdges(idx)) {
+      auto predIt = asap.find(edge->srcIdx);
+      if (predIt == asap.end())
+        continue;
+      int predReady = predIt->second + edge->latency -
+                      static_cast<int>(edge->distance) * II;
+      earliest = std::max(earliest, predReady);
+    }
+    asap[idx] = earliest;
+  }
+
+  // ALAP.
+  int maxAsap = 0;
+  for (auto &[idx, val] : asap)
+    maxAsap = std::max(maxAsap, val);
+
+  llvm::DenseMap<unsigned, int> alap;
+  for (auto it = sorted.rbegin(), end = sorted.rend(); it != end; ++it) {
+    unsigned idx = *it;
+    int latest = maxAsap;
+    for (const auto *edge : ddg.getOutEdges(idx)) {
+      auto succIt = alap.find(edge->dstIdx);
+      if (succIt == alap.end())
+        continue;
+      int succStart = succIt->second - edge->latency +
+                      static_cast<int>(edge->distance) * II;
+      latest = std::min(latest, succStart);
+    }
+    alap[idx] = latest;
+  }
+
+  // Criticality.
+  int maxSlack = 0;
+  for (unsigned i = 0; i < ddg.getNumNodes(); ++i)
+    maxSlack = std::max(maxSlack, alap.lookup(i) - asap.lookup(i));
+
+  constexpr double eps = 1e-6;
+  llvm::DenseMap<unsigned, double> crit;
+  for (unsigned i = 0; i < ddg.getNumNodes(); ++i) {
+    int slack = alap.lookup(i) - asap.lookup(i);
+    crit[i] = 1.0 - static_cast<double>(slack) / (maxSlack + eps);
+  }
+  return crit;
+}
+
+static int
+computePingpongOffset(const llvm::SmallVector<AMDClusterInfo, 4> &clusters) {
+  int N = clusters.size();
+  if (N <= 1)
+    return 0;
+
+  int bestDelta = 1;
+  double bestContention = std::numeric_limits<double>::max();
+
+  for (int delta = 1; delta < N; ++delta) {
+    double contention = 0;
+    for (const auto &c : clusters) {
+      int oppositeId = (c.clusterId + delta) % N;
+      const auto *opp = findCluster(clusters, oppositeId);
+      if (!opp)
+        continue;
+      for (HWPipeline pipe : kAMDPipelines) {
+        double coOcc = getClusterOcc(c, pipe) + getClusterOcc(*opp, pipe);
+        if (coOcc > 1.0)
+          contention += coOcc - 1.0;
+      }
+    }
+    LDBG("Delta=" << delta << " contention=" << contention);
+    if (contention < bestContention) {
+      bestContention = contention;
+      bestDelta = delta;
+    }
+  }
+
+  LDBG("Best ping-pong offset: " << bestDelta);
+  return bestDelta;
+}
+
+static llvm::SmallDenseSet<HWPipeline, 4>
+findContendedPipelines(const llvm::SmallVector<AMDClusterInfo, 4> &clusters,
+                       int delta) {
+  int N = clusters.size();
+  llvm::SmallDenseSet<HWPipeline, 4> contended;
+
+  for (const auto &c : clusters) {
+    int oppositeId = (c.clusterId + delta) % N;
+    const auto *opp = findCluster(clusters, oppositeId);
+    if (!opp)
+      continue;
+    for (HWPipeline pipe : kAMDPipelines) {
+      if (getClusterOcc(c, pipe) > 0 && getClusterOcc(*opp, pipe) > 0)
+        contended.insert(pipe);
+    }
+  }
+
+  LLVM_DEBUG({
+    DBGS() << "Contended pipelines:";
+    for (HWPipeline p : contended)
+      llvm::dbgs() << " " << getPipelineName(p);
+    llvm::dbgs() << "\n";
+  });
+
+  return contended;
+}
+
+} // namespace
+
+// ============================================================================
+// Step 4.7: partitionForAMDWarpPipeline
+// ============================================================================
+
+AMDWarpPipelineResult
+partitionForAMDWarpPipeline(const DataDependenceGraph &ddg,
+                            const ModuloScheduleResult &schedule) {
+  int II = schedule.II;
+  if (II <= 0) {
+    LDBG("II <= 0, returning single cluster");
+    AMDWarpPipelineResult result;
+    AMDClusterInfo single;
+    single.clusterId = 0;
+    for (const auto &node : ddg.getNodes())
+      if (node.pipeline != HWPipeline::NONE)
+        single.nodeIndices.push_back(node.idx);
+    result.clusters.push_back(std::move(single));
+    return result;
+  }
+
+  // Per-pipeline utilization.
+  llvm::DenseMap<HWPipeline, double> pipeUtil;
+  for (HWPipeline pipe : kAMDPipelines) {
+    int busy = 0;
+    for (const auto &node : ddg.getNodes())
+      if (node.pipeline == pipe)
+        busy += pipelineOccupancy(node);
+    pipeUtil[pipe] = static_cast<double>(busy) / II;
+  }
+
+  // Initialize: one cluster per active pipeline.
+  llvm::SmallVector<AMDClusterInfo, 4> clusters;
+  for (HWPipeline pipe : kAMDPipelines) {
+    AMDClusterInfo c;
+    bool hasOps = false;
+    for (const auto &node : ddg.getNodes()) {
+      if (node.pipeline == pipe) {
+        c.nodeIndices.push_back(node.idx);
+        hasOps = true;
+      }
+    }
+    if (!hasOps)
+      continue;
+    c.clusterId = clusters.size();
+    c.pipelines.insert(pipe);
+    c.utilization[pipe] = pipeUtil[pipe];
+    clusters.push_back(std::move(c));
+  }
+
+  LDBG("Initial clusters: " << clusters.size());
+
+  if (clusters.size() <= 1) {
+    AMDWarpPipelineResult result;
+    if (!clusters.empty())
+      result.clusters.push_back(std::move(clusters[0]));
+    return result;
+  }
+
+  auto coupling = computeSeparationCost(ddg, schedule);
+
+  LLVM_DEBUG({
+    for (auto &[key, cost] : coupling)
+      DBGS() << "coupling(" << getPipelineName(key.first) << ", "
+             << getPipelineName(key.second) << ") = " << cost << "\n";
+  });
+
+  // Greedy agglomerative merging.
+  bool merged = true;
+  while (merged && clusters.size() > 1) {
+    merged = false;
+    int bestI = -1, bestJ = -1;
+    double bestSavings = 0;
+
+    for (int i = 0, e = clusters.size(); i < e; ++i) {
+      for (int j = i + 1; j < e; ++j) {
+        double savings = mergeSavings(clusters[i], clusters[j], coupling);
+        if (savings <= bestSavings)
+          continue;
+
+        // Fast reject: any single pipeline oversubscribed?
+        bool feasible = true;
+        llvm::SmallDenseMap<HWPipeline, double, 4> mergedUtil;
+        for (auto &[pipe, u] : clusters[i].utilization)
+          mergedUtil[pipe] += u;
+        for (auto &[pipe, u] : clusters[j].utilization)
+          mergedUtil[pipe] += u;
+        for (auto &[pipe, u] : mergedUtil) {
+          if (u > 1.0) {
+            feasible = false;
+            break;
+          }
+        }
+        if (!feasible)
+          continue;
+
+        // Precise check: multi-pipeline makespan.
+        llvm::SmallVector<unsigned> mergedOps;
+        mergedOps.append(clusters[i].nodeIndices.begin(),
+                         clusters[i].nodeIndices.end());
+        mergedOps.append(clusters[j].nodeIndices.begin(),
+                         clusters[j].nodeIndices.end());
+        int makespan = computeMultiPipelineMakespan(mergedOps, ddg);
+        if (makespan > II)
+          continue;
+
+        bestI = i;
+        bestJ = j;
+        bestSavings = savings;
+      }
+    }
+
+    if (bestI < 0)
+      break;
+
+    LDBG("Merging clusters " << bestI << " and " << bestJ
+                             << " (savings=" << bestSavings << ")");
+
+    clusters[bestI].nodeIndices.append(clusters[bestJ].nodeIndices.begin(),
+                                       clusters[bestJ].nodeIndices.end());
+    for (HWPipeline p : clusters[bestJ].pipelines)
+      clusters[bestI].pipelines.insert(p);
+    for (auto &[pipe, u] : clusters[bestJ].utilization)
+      clusters[bestI].utilization[pipe] += u;
+    clusters.erase(clusters.begin() + bestJ);
+    merged = true;
+  }
+
+  // Sort by earliest scheduled cycle, then assign sequential IDs. Ties break on
+  // the cluster's smallest node index (unique per cluster) so the final IDs —
+  // which feed ping-pong offset, priority, and the emitted op attributes — are
+  // deterministic across builds even when two clusters share an earliest cycle.
+  auto clusterSortKey =
+      [&](const AMDClusterInfo &c) -> std::pair<int, unsigned> {
+    int earliest = std::numeric_limits<int>::max();
+    unsigned minIdx = std::numeric_limits<unsigned>::max();
+    for (unsigned idx : c.nodeIndices) {
+      auto it = schedule.nodeToCycle.find(idx);
+      if (it != schedule.nodeToCycle.end())
+        earliest = std::min(earliest, it->second);
+      minIdx = std::min(minIdx, idx);
+    }
+    return {earliest, minIdx};
+  };
+  llvm::sort(clusters, [&](const AMDClusterInfo &a, const AMDClusterInfo &b) {
+    return clusterSortKey(a) < clusterSortKey(b);
+  });
+  for (int i = 0, e = clusters.size(); i < e; ++i)
+    clusters[i].clusterId = i;
+
+  LDBG("Final clusters: " << clusters.size());
+
+  AMDWarpPipelineResult result;
+  result.clusters = std::move(clusters);
+  return result;
+}
+
+// ============================================================================
+// Step 4.8: assignAMDWarpPipelinePriorities
+// ============================================================================
+
+void assignAMDWarpPipelinePriorities(AMDWarpPipelineResult &result,
+                                     const DataDependenceGraph &ddg,
+                                     const ModuloScheduleResult &schedule) {
+  if (result.clusters.size() < 2)
+    return;
+
+  // 4.8a: per-op criticality from ASAP/ALAP slack.
+  auto crit = computeCriticality(ddg, schedule);
+
+  // 4.8b: ping-pong offset minimizing pipeline contention.
+  int delta = computePingpongOffset(result.clusters);
+  result.pingpongOffset = delta;
+
+  auto contended = findContendedPipelines(result.clusters, delta);
+
+  // 4.8c: pscore(c) = U(c) - lambda * M(c).
+  llvm::SmallVector<std::pair<int, double>> clusterScores;
+
+  for (const auto &c : result.clusters) {
+    double M = 0;
+    for (HWPipeline pipe : contended)
+      M += getClusterOcc(c, pipe);
+
+    double U = 0;
+    for (unsigned idx : c.nodeIndices) {
+      const DDGNode &node = ddg.getNode(idx);
+      double nodeCrit = crit.lookup(idx);
+      if (node.pipeline == HWPipeline::GLOBAL)
+        nodeCrit += kAsyncLoadPressure;
+      U = std::max(U, nodeCrit);
+    }
+
+    double pscore = U - kLambdaWeight * M;
+    clusterScores.push_back({c.clusterId, pscore});
+
+    LDBG("Cluster " << c.clusterId << ": M=" << M << " U=" << U
+                    << " pscore=" << pscore);
+  }
+
+  // Sort by pscore; break ties on clusterId so equal-scored clusters get a
+  // stable s_setprio ranking across builds (llvm::sort is not stable).
+  llvm::sort(clusterScores, [](const auto &a, const auto &b) {
+    return std::tie(a.second, a.first) < std::tie(b.second, b.first);
+  });
+
+  int numLevels = std::min(static_cast<int>(clusterScores.size()), 4);
+  int numClusters = clusterScores.size();
+
+  for (int rank = 0; rank < numClusters; ++rank) {
+    int clusterId = clusterScores[rank].first;
+    int prio =
+        (numClusters > 1) ? (rank * (numLevels - 1)) / (numClusters - 1) : 0;
+    for (auto &c : result.clusters) {
+      if (c.clusterId == clusterId) {
+        c.sSetprio = prio;
+        LDBG("Cluster " << clusterId << " -> s_setprio=" << prio);
+        break;
+      }
+    }
+  }
+}
+
+} // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDWarpPipelinePartition.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDWarpPipelinePartition.h
@@ -1,0 +1,65 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// AMD Warp-Pipeline Partition (Steps 4.7 + 4.8)
+//
+// Step 4.7: Latency-aware multi-pipeline cluster partitioning for AMD
+//           warp-pipelining. Starts with one cluster per active pipeline,
+//           then greedily merges tightly-coupled pairs.
+//
+// Step 4.8: Derive s_setprio priorities from the modulo reservation table
+//           (MRT occupancy, monopolization, urgency).
+//
+// The output is a set of clusters, each becoming a warp_pipeline_stage
+// region. Both warp groups run ALL clusters, phase-offset by one stage
+// (the symmetric ping-pong model).
+
+#ifndef TRITON_GPU_MODULO_SCHEDULING_AMD_WARP_PIPELINE_PARTITION_H
+#define TRITON_GPU_MODULO_SCHEDULING_AMD_WARP_PIPELINE_PARTITION_H
+
+#include "DataDependenceGraph.h"
+#include "ModuloReservationTable.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::triton::gpu {
+
+/// A cluster of ops that will become a warp_pipeline_stage region.
+struct AMDClusterInfo {
+  int clusterId{0};
+  llvm::SmallVector<unsigned, 16> nodeIndices;
+  llvm::SmallDenseSet<HWPipeline, 4> pipelines;
+  llvm::SmallDenseMap<HWPipeline, double, 4> utilization;
+  int sSetprio{0};
+};
+
+/// Result of the warp-pipeline partition (Steps 4.7 + 4.8).
+struct AMDWarpPipelineResult {
+  llvm::SmallVector<AMDClusterInfo, 4> clusters;
+  int pingpongOffset{1};
+
+  bool isWarpPipelineCandidate() const { return clusters.size() >= 2; }
+};
+
+/// Step 4.7: Partition DDG nodes into clusters for AMD warp-pipelining.
+///
+/// Uses separation cost (barrier overhead / cycle gap) and multi-pipeline
+/// makespan validation to decide which pipelines merge. Produces >= 2
+/// clusters for warp-pipelining to be profitable; returns a single-cluster
+/// result if merging collapses everything (caller should skip warp-pipeline).
+AMDWarpPipelineResult
+partitionForAMDWarpPipeline(const DataDependenceGraph &ddg,
+                            const ModuloScheduleResult &schedule);
+
+/// Step 4.8: Derive s_setprio priorities from MRT occupancy and slack.
+///
+/// Populates sSetprio on each cluster in `result` and sets pingpongOffset.
+/// Only fires on warp-pipelined loops (>= 2 clusters).
+void assignAMDWarpPipelinePriorities(AMDWarpPipelineResult &result,
+                                     const DataDependenceGraph &ddg,
+                                     const ModuloScheduleResult &schedule);
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_GPU_MODULO_SCHEDULING_AMD_WARP_PIPELINE_PARTITION_H


### PR DESCRIPTION
Summary:

Step 4.7 partitions modulo-scheduled ops into clusters for warp-pipelining using separation cost (vmcnt/s_barrier overhead on cross-cluster edges) and multi-pipeline makespan validation via greedy agglomerative merge.

Step 4.8 derives `s_setprio` priorities from MRT occupancy, monopolization M(c), and urgency U(c), computing pscore = U - λ·M. Ops are annotated with `ttg.warp_pipeline_cluster` and `ttg.warp_pipeline_priority` attributes.

Design doc: D95269626, `docs/design/amd_global_instruction_scheduling.md`

Authored with Claude.

Reviewed By: manman-ren

Differential Revision: D109634504


