### PR TITLE
[T278829272][Claude Code] Gate TLX flex_attention choices on tlx_mode

### DIFF
--- a/third_party/tlx/language/tlx/inductor/choices.py
+++ b/third_party/tlx/language/tlx/inductor/choices.py
@@ -151,6 +151,18 @@ class TLXInductorChoices(InductorChoices):
         sparse_q_block_size: int,
         sparse_kv_block_size: int,
     ) -> list[Any]:
+        if config.triton.tlx_mode == "default":
+            return super().append_flex_attention_choices(
+                choices,
+                configs,
+                input_nodes,
+                subgraphs,
+                layout,
+                kernel_options,
+                sparse_q_block_size,
+                sparse_kv_block_size,
+            )
+
         from .flex_attention_templates import (
             append_tlx_flex_attention_choice,
         )


### PR DESCRIPTION
Summary:
15 `caffe2/test/inductor:flex_attention` tests broke on Hopper/Blackwell CI, root-caused to a missing gate against tlx-mode in flex_attention code.

`TLXInductorChoices.append_flex_attention_choices` was the only method on the class that did not gate on `config.triton.tlx_mode`. Its docstring contract states "All methods check `config.triton.tlx_mode` at runtime and fall through to `super()` when mode is default", but this method unconditionally ran `from .flex_attention_templates import append_tlx_flex_attention_choice`, whose module-level `TritonTemplate` build broke the standard (non-TLX) flex_attention lowering path with an `InductorError`.

Fix adds the same `tlx_mode == "default"` guard used by `get_template_configs`, delegating to `super()` (a no-op returning `choices`) in default mode. This is the 2-line gate proposed in the task root-cause analysis.

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=761b0d3f-9d05-4c07-9b45-ef9a68038bdf)

Differential Revision: D111065524


