### PR TITLE
[torchTLX] Rename TLX enablement knob value `default` -> `None` (#1967)

### DIFF
--- a/third_party/tlx/language/tlx/inductor/README
+++ b/third_party/tlx/language/tlx/inductor/README
@@ -1,7 +1,0 @@
-### Q1 FY26 Plan
-
-In Q1’26, we plan to gate most future iterations within the `fb/` folder until they are production-ready. This includes:
-
-- modifying **TLX template files**
-- modifying **TLX heuristic configurations**
-- tuning **TLX template options**

--- a/third_party/tlx/language/tlx/inductor/README.md
+++ b/third_party/tlx/language/tlx/inductor/README.md
@@ -77,8 +77,10 @@ Second, it scales better than manual agentic kernel authoring. There is growing 
 
 ## Knob
 
-`TORCHINDUCTOR_TLX_MODE`
-- default - TLX not considered (standard inductor behavior)
+`TORCHINDUCTOR_TLX_MODE` (unset by default)
+- unset / any other value - TLX not considered (standard inductor behavior; the config value is `None`)
 - allow - TLX added to candidates, competes via autotuning
 - force - TLX templates enabled + forced epilogue fusion
+
+Only `allow` and `force` engage TLX; every other value (including an unset env var or a legacy `default`) maps to `None`, leaving TLX off. TLX is additionally a no-op unless the active Triton is the fbtriton fork.
 

--- a/third_party/tlx/language/tlx/inductor/choices.py
+++ b/third_party/tlx/language/tlx/inductor/choices.py
@@ -4,7 +4,7 @@ template selection, filtering, and layout logic.
 
 Activated via config.inductor_choices_class set in template_heuristics/tlx.py.
 All methods check config.triton.tlx_mode at runtime and fall through to
-super() when mode is "default".
+super() when TLX is disabled (mode is None).
 """
 
 from __future__ import annotations
@@ -34,7 +34,7 @@ class TLXInductorChoices(InductorChoices):
     InductorChoices subclass that handles TLX template injection,
     filtering, and layout fixing.
 
-    In "default" mode: delegates entirely to the parent class.
+    When disabled (mode is None): delegates entirely to the parent class.
     In "allow" mode: TLX templates compete with other backends via autotuning.
     In "force" mode: only TLX templates are used.
     """
@@ -95,7 +95,7 @@ class TLXInductorChoices(InductorChoices):
         kwarg_overrides: dict[str, dict[str, Any]] | None = None,
     ) -> list[ChoiceCaller]:
         tlx_mode = config.triton.tlx_mode
-        if tlx_mode == "default" or op_name in self._UNSUPPORTED_OPS:
+        if tlx_mode is None or op_name in self._UNSUPPORTED_OPS:
             return super().get_template_configs(
                 kernel_inputs, templates, op_name, kwarg_overrides
             )

--- a/third_party/tlx/language/tlx/inductor/flex_attention_templates.py
+++ b/third_party/tlx/language/tlx/inductor/flex_attention_templates.py
@@ -28,7 +28,7 @@ def append_tlx_flex_attention_choice(
     """Add Blackwell TLX flex-attention template choices to ``choices``.
 
     Gated by ``config.triton.tlx_mode``:
-      - "default": no-op.
+      - None (disabled): no-op.
       - "allow":   add TLX candidates alongside the standard template.
       - "force":   drop the standard choices and use only TLX.
 
@@ -42,7 +42,7 @@ def append_tlx_flex_attention_choice(
     """
     from torch._inductor import config
 
-    if config.triton.tlx_mode == "default":
+    if config.triton.tlx_mode is None:
         return
 
     if config.triton.tlx_mode == "force":


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/189340


A nomenclature fix to provide an unambiguous None state to turn off completely.

Authored with Claude Code.

Reviewed By: htyu

Differential Revision: D111169890


