### PR TITLE
[triton][beta] Build C dispatcher before it is read on the JITFunction.run path (#1973)

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -1012,6 +1012,13 @@ class JITFunction(JITCallable, KernelInterface[T]):
 
             if hasattr(kernel, "result"):
                 kernel = kernel.result()
+            # Ensure module/function handles and the C dispatcher are built before we
+            # read `_dispatcher` below. Without this, the plain run path reads
+            # `_dispatcher` before `_init_handles()` (called lazily inside kernel.run)
+            # has built it, so TRITON_USE_C_DISPATCHER never engages on this path.
+            # `_init_handles` is idempotent (early-returns once module is loaded).
+            if hasattr(kernel, "_init_handles"):
+                kernel._init_handles()
             # compile_iq free-win: if a tuned ACF candidate is pending, run the one-shot plain-vs-ACF
             # competition with the real args before launching, and keep the winner (no-op/near-zero
             # cost otherwise; suppressed while the autotuner is benchmarking). Read _disp afterward so


### PR DESCRIPTION
Summary:

TRITON_USE_C_DISPATCHER never engaged for kernels launched through the plain
`JITFunction.run` path (e.g. non-autotuned kernels invoked via
`kernel[grid](...)`, and any call that falls through to `run`). Every such
launch emitted:

  [Triton] TRITON_USE_C_DISPATCHER=1 but kernel '<k>' has no C dispatcher,
  falling back to Python launch

and silently used the slower Python launcher.

This is an ordering bug, not a dispatcher-build failure. The C dispatcher is
built inside `CompiledKernel._init_handles()` (via `_build_dispatcher()`).
`CompiledKernel.__getitem__` calls `_init_handles()` first and then reads
`self._dispatcher`, so it works. But `JITFunction.run` (runtime/jit.py) reads
`kernel._dispatcher` BEFORE `_init_handles()` has run — `_init_handles()` is
only triggered lazily later, inside `kernel.run()`. So `_dispatcher` is always
None at the point it is checked, the Python fallback is taken, and the
dispatcher that gets built afterwards is never used.

Fix: after resolving `kernel.result()` and before reading `_dispatcher`, call
`kernel._init_handles()` (idempotent — early-returns once the module is
loaded), mirroring `CompiledKernel.__getitem__`.

Reviewed By: htyu

Differential Revision: D111291373


