### PR TITLE
[Triton][auto-TMA][2/N] PromoteLoadToTMA pass -- host-recipe LOAD promotion (#1977)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -290,4 +290,23 @@ def TritonNvidiaGPUCLCMaterializePass : Pass<"triton-nvidia-gpu-clc-materialize"
   ];
 }
 
+def TritonNvidiaGPUPromoteLoadToTMAPass : Pass<"triton-nvidia-promote-load-to-tma", "mlir::ModuleOp"> {
+  let summary = "Auto-promote eligible tt.load to a real TMA descriptor_load";
+
+  let description = [{
+    Analyze pointer-arithmetic patterns in tt.load operations. When a masked,
+    block-structured load is TMA-eligible (contiguous innermost dimension, rank
+    1-5, supported element type, >= 16 byte inner dim, zero OOB fill), rewrite it
+    into the explicit-TMA form -- tt.make_tensor_descriptor + tt.descriptor_load
+    -- so the standard nvidia TMA lowering turns it into an asynchronous TMA copy
+    on sm_90+. Non-eligible loads are left unchanged.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::TritonDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+    "mlir::arith::ArithDialect"
+  ];
+}
+
 #endif

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   OptimizeTMemLayouts.cpp
   PlanCTA.cpp
   PromoteLHSToTMem.cpp
+  PromoteLoadToTMA.cpp
   PruneUnusedBarriers.cpp
   ProxyFenceInsertion.cpp
   RemoveTMEMTokens.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLoadToTMA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLoadToTMA.cpp
@@ -1,0 +1,1151 @@
+// PromoteLoadToTMA.cpp — Auto-promote eligible tt.load to a real TMA load.
+//
+// Detects masked, block-structured global loads --
+//   tl.load(base + affine_block_offsets, mask = offs < shape)
+// -- and rewrites them, at TTIR time, into the explicit-TMA representation the
+// existing pipeline already lowers on Hopper (sm_90+):
+//   %d = tt.make_tensor_descriptor(base, shape, strides) : !tt.tensordesc<...>
+//   %v = tt.descriptor_load %d[tile_offsets] : ... -> tensor<BLOCK x dtype>
+//
+// The downstream nvidia pass `triton-nvidia-tma-lowering` turns descriptor_load
+// into AsyncTMACopyGlobalToLocal (cp.async.bulk.tensor) and
+// get_tensordesc_metadata records the host CUtensorMap params. Enabled
+// per-kernel by the autotunable `auto_tma` compile option (a
+// `triton.Config(..., auto_tma=True)` field) or, as a global default, the
+// `TRITON_AUTO_TMA` env knob
+// -- see make_ttir: `opt.auto_tma or knobs.nvidia.auto_tma`. Only invoked for
+// sm_90+; non-eligible loads are left untouched.
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <cstdlib>
+#include <functional>
+#include <string>
+
+namespace tt = mlir::triton;
+
+namespace mlir::triton::nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUPROMOTELOADTOTMAPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+// CU_TENSOR_MAP_DATA_TYPE values (device-side; remapped to host in the
+// launcher).
+enum TMADataType {
+  TMA_UINT8 = 0,
+  TMA_UINT16 = 1,
+  TMA_UINT32 = 2,
+  TMA_UINT64 = 3,
+  TMA_INT32 = 4,
+  TMA_INT64 = 5,
+  TMA_FLOAT16 = 6,
+  TMA_FLOAT32 = 7,
+  TMA_FLOAT64 = 8,
+  TMA_BFLOAT16 = 9,
+  TMA_FLOAT8_E4M3 = 13,
+  TMA_FLOAT8_E5M2 = 14,
+};
+
+static std::optional<int> getTMADataType(Type elemTy) {
+  if (auto intTy = dyn_cast<IntegerType>(elemTy)) {
+    switch (intTy.getWidth()) {
+    case 8:
+      return TMA_UINT8;
+    case 16:
+      return TMA_UINT16;
+    case 32:
+      return TMA_INT32;
+    case 64:
+      return TMA_INT64;
+    default:
+      return std::nullopt;
+    }
+  }
+  if (auto floatTy = dyn_cast<FloatType>(elemTy)) {
+    if (floatTy.isF16())
+      return TMA_FLOAT16;
+    if (floatTy.isBF16())
+      return TMA_BFLOAT16;
+    if (floatTy.isF32())
+      return TMA_FLOAT32;
+    if (floatTy.isF64())
+      return TMA_FLOAT64;
+    if (llvm::isa<Float8E4M3FNType, Float8E4M3FNUZType>(floatTy))
+      return TMA_FLOAT8_E4M3;
+    if (llvm::isa<Float8E5M2Type, Float8E5M2FNUZType>(floatTy))
+      return TMA_FLOAT8_E5M2;
+    return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+// Per-dimension decomposition of a load's pointer expression.
+struct DimInfo {
+  int64_t blockSize;
+  Value stride;     // outer-dim stride value (null if contiguous/innermost)
+  Value offset;     // tile start offset value (program_id * BLOCK, in elements)
+  int strideArgIdx; // func arg index for stride (-1 if contiguous)
+  int shapeArgIdx = -1; // func arg index for global extent, recovered from a
+                        // `offs % M` modulus (-1 if not modulo-bounded)
+  // Loop-advanced dim (pointer-increment K loop): the tile offset is not a
+  // fixed affine value but `loopIV * perIterElems`, reconstructed at rewrite
+  // time.
+  bool loopAdvanced = false;
+  Value loopIV;             // scf.for induction variable
+  int64_t perIterElems = 0; // per-iteration advance along this (contiguous) dim
+};
+
+struct DecomposedLoad {
+  Value basePtr;
+  int basePtrArgIndex;
+  SmallVector<DimInfo> dims;
+  bool valid;
+};
+
+static int getFuncArgIndex(Value v) {
+  if (auto blockArg = dyn_cast<BlockArgument>(v)) {
+    if (isa<tt::FuncOp>(blockArg.getOwner()->getParentOp()))
+      return blockArg.getArgNumber();
+  }
+  return -1;
+}
+
+static Value matchSplat(Value v) {
+  if (auto splatOp = v.getDefiningOp<tt::SplatOp>())
+    return splatOp.getSrc();
+  return {};
+}
+
+static bool matchMakeRange(Value v, int64_t &size) {
+  if (auto rangeOp = v.getDefiningOp<tt::MakeRangeOp>()) {
+    if (rangeOp.getStart() == 0) {
+      size = rangeOp.getEnd();
+      return true;
+    }
+  }
+  return false;
+}
+
+// True if v is a constant all-zeros value: tt.splat of a zero scalar, a dense
+// splat zero (int or float) constant, or a scalar zero constant. Used for the
+// select-clamp false value (below) and mirrors the OOB `other`-fill check in
+// isTMAEligible -- both must be zero for the TMA zero-fill equivalence to hold.
+static bool isConstantZero(Value v) {
+  if (!v)
+    return false;
+  if (Value s = matchSplat(v))
+    return matchPattern(s, m_Zero()) || matchPattern(s, m_AnyZeroFloat());
+  if (auto c = v.getDefiningOp<arith::ConstantOp>()) {
+    if (auto d = dyn_cast<DenseIntElementsAttr>(c.getValue()))
+      return d.isSplat() && d.getSplatValue<APInt>().isZero();
+    if (auto d = dyn_cast<DenseFPElementsAttr>(c.getValue()))
+      return d.isSplat() && d.getSplatValue<APFloat>().isZero();
+    if (auto ia = dyn_cast<IntegerAttr>(c.getValue()))
+      return ia.getValue().isZero();
+  }
+  return false;
+}
+
+// True if v is a bare tile-index expression -- make_range(0,B), or
+// make_range + splat(tile_off) -- with NO stride multiply. The RemSI/Select
+// OOB-idiom peels below record the modulus/clamp bound as this dim's global
+// extent, which is a valid element-count extent only when the modulus/clamp
+// wraps the RAW index. If it instead wraps a strided expression (e.g.
+// (idx*stride) % M), the recorded arg is not an element extent and the
+// descriptor's global_dim would be wrong -- so only peel a raw index.
+static bool isRawIndexOffset(Value v) {
+  int64_t b;
+  if (matchMakeRange(v, b))
+    return true;
+  if (auto addOp = v.getDefiningOp<arith::AddIOp>()) {
+    Value l = addOp.getLhs(), r = addOp.getRhs();
+    for (int s = 0; s < 2; s++) {
+      if (matchMakeRange(l, b) && matchSplat(r))
+        return true;
+      std::swap(l, r);
+    }
+  }
+  return false;
+}
+
+// Match (make_range(0,BLOCK) + splat(tile_off)) * splat(stride), or the
+// contiguous form make_range(0,BLOCK) + splat(tile_off).
+static bool match1DOffset(Value offsetVal, DimInfo &info) {
+  // Peel the no-mask OOB idiom `offs = (pid*BLOCK + arange) % M`: the modulus
+  // is this dim's global extent. Record the modulus kernel arg as the shape
+  // source and decompose the inner affine offset. (Upstream Triton matmuls wrap
+  // operand offsets with `% M` / `% N` instead of masking M / N.) Promoting
+  // such a load to TMA is correct: the descriptor uses global_dim = M with zero
+  // OOB fill, and the kernel's epilogue store mask already discards the tail.
+  if (auto remOp = offsetVal.getDefiningOp<arith::RemSIOp>()) {
+    if (Value modSplat = matchSplat(remOp.getRhs())) {
+      int modArg = getFuncArgIndex(modSplat);
+      // Only peel when the modulus wraps the RAW index (not a
+      // strided/byte-scaled expression); otherwise the modulus arg is not this
+      // dim's element extent.
+      if (modArg >= 0 && isRawIndexOffset(remOp.getLhs())) {
+        info.shapeArgIdx = modArg;
+        offsetVal = remOp.getLhs();
+      }
+    }
+  }
+  // Peel the other no-mask OOB idiom `offs = select(offs < M, offs, 0)`
+  // (operand rows past M are clamped to 0). The select predicate's bound M is
+  // this dim's global extent; decompose the true value (the clean affine
+  // offset). Same correctness argument as the remsi case: TMA zero-fills OOB
+  // and the epilogue store mask discards the tail.
+  if (auto selOp = offsetVal.getDefiningOp<arith::SelectOp>()) {
+    if (auto cmpOp = selOp.getCondition().getDefiningOp<arith::CmpIOp>()) {
+      if (cmpOp.getPredicate() == arith::CmpIPredicate::slt &&
+          selOp.getTrueValue() == cmpOp.getLhs()) {
+        if (Value modSplat = matchSplat(cmpOp.getRhs())) {
+          int modArg = getFuncArgIndex(modSplat);
+          // Only a clamp to ZERO matches TMA's OOB zero-fill; a clamp to a
+          // non-zero index would make the promoted load read different data
+          // (zero) than the original (that index) for out-of-bounds rows.
+          if (modArg >= 0 && isConstantZero(selOp.getFalseValue()) &&
+              isRawIndexOffset(selOp.getTrueValue())) {
+            info.shapeArgIdx = modArg;
+            offsetVal = selOp.getTrueValue();
+          }
+        }
+      }
+    }
+  }
+  if (auto mulOp = offsetVal.getDefiningOp<arith::MulIOp>()) {
+    Value lhs = mulOp.getLhs();
+    Value rhs = mulOp.getRhs();
+    for (int swap = 0; swap < 2; swap++) {
+      auto addOp = lhs.getDefiningOp<arith::AddIOp>();
+      Value strideSplat = matchSplat(rhs);
+      if (addOp && strideSplat) {
+        Value addLhs = addOp.getLhs();
+        Value addRhs = addOp.getRhs();
+        for (int swap2 = 0; swap2 < 2; swap2++) {
+          int64_t blockSize;
+          Value tileOff = matchSplat(addRhs);
+          if (matchMakeRange(addLhs, blockSize) && tileOff) {
+            info.blockSize = blockSize;
+            info.stride = strideSplat;
+            info.offset = tileOff;
+            info.strideArgIdx = getFuncArgIndex(strideSplat);
+            return true;
+          }
+          std::swap(addLhs, addRhs);
+        }
+      }
+      std::swap(lhs, rhs);
+    }
+  }
+  if (auto addOp = offsetVal.getDefiningOp<arith::AddIOp>()) {
+    Value addLhs = addOp.getLhs();
+    Value addRhs = addOp.getRhs();
+    for (int swap = 0; swap < 2; swap++) {
+      int64_t blockSize;
+      Value tileOff = matchSplat(addRhs);
+      if (matchMakeRange(addLhs, blockSize) && tileOff) {
+        info.blockSize = blockSize;
+        info.stride = {};
+        info.offset = tileOff;
+        info.strideArgIdx = -1;
+        return true;
+      }
+      std::swap(addLhs, addRhs);
+    }
+  }
+  // Bare make_range(0, BLOCK): a contiguous dim with no per-use tile offset.
+  // Used by pointer-increment loops (`a_ptrs += BLOCK*stride`) where the tile
+  // offset is carried in the advanced pointer, not recomputed. offset is left
+  // null (== 0 at iteration 0); the loop-advance reconstruction fills the real
+  // per-iteration offset (loopIV * perIterElems) at rewrite time.
+  int64_t bsz;
+  if (matchMakeRange(offsetVal, bsz)) {
+    info.blockSize = bsz;
+    info.stride = {};
+    info.offset = {};
+    info.strideArgIdx = -1;
+    return true;
+  }
+  return false;
+}
+
+// Match a uniform integer constant tensor (tt.splat of an int constant, or a
+// dense splat constant) — used for the per-iteration pointer increment.
+static bool matchUniformIntConst(Value v, int64_t &out) {
+  if (Value s = matchSplat(v)) {
+    if (auto c = s.getDefiningOp<arith::ConstantOp>())
+      if (auto ia = dyn_cast<IntegerAttr>(c.getValue())) {
+        out = ia.getInt();
+        return true;
+      }
+    return false;
+  }
+  if (auto c = v.getDefiningOp<arith::ConstantOp>())
+    if (auto d = dyn_cast<DenseIntElementsAttr>(c.getValue()))
+      if (d.isSplat()) {
+        out = d.getSplatValue<APInt>().getSExtValue();
+        return true;
+      }
+  return false;
+}
+
+struct LoopPtrInfo {
+  bool isLoop = false;
+  // Set when `ptr` IS an scf.for iter-arg pointer but its per-iteration advance
+  // was NOT the recognized addptr(ptr, splat(C)). decomposePointer bails in
+  // that case rather than decompose against the loop's INIT pointer (which
+  // would fix the tile offset at iteration 0 -> wrong per-iteration index).
+  bool unrecognized = false;
+  Value iv;
+  int64_t stepElems = 0;
+};
+
+// If `ptr` is an scf.for iter-arg pointer advanced each iteration by a uniform
+// constant (`yield addptr(ptr, splat(C))`) — the classic pointer-increment K
+// loop `a_ptrs += BLOCK_K*stride` — populate `info` (loop IV + per-iter element
+// step) and return the loop's INIT pointer (the pointer at iteration 0) to be
+// decomposed. Otherwise return `ptr` unchanged.
+static Value resolveLoopCarriedPtr(Value ptr, LoopPtrInfo &info) {
+  auto ba = dyn_cast<BlockArgument>(ptr);
+  if (!ba)
+    return ptr;
+  auto forOp = dyn_cast<scf::ForOp>(ba.getOwner()->getParentOp());
+  if (!forOp)
+    return ptr;
+  unsigned argNo = ba.getArgNumber();
+  if (argNo < 1) // 0 == induction variable
+    return ptr;
+  unsigned iterIdx = argNo - 1;
+  auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+  Value yielded = yieldOp.getOperand(iterIdx);
+  auto adv = yielded.getDefiningOp<tt::AddPtrOp>();
+  if (!adv || adv.getPtr() != ptr) {
+    info.unrecognized = true; // loop-carried ptr, but advance not recognized
+    return ptr;
+  }
+  int64_t stepC;
+  if (!matchUniformIntConst(adv.getOffset(), stepC)) {
+    info.unrecognized = true;
+    return ptr;
+  }
+  info.isLoop = true;
+  info.iv = forOp.getInductionVar();
+  info.stepElems = stepC;
+  return forOp.getInitArgs()[iterIdx];
+}
+
+static DecomposedLoad decomposePointer(Value ptr) {
+  DecomposedLoad result;
+  result.valid = false;
+  auto ptrTy = dyn_cast<RankedTensorType>(ptr.getType());
+  if (!ptrTy)
+    return result;
+  int rank = ptrTy.getRank();
+  if (rank < 1 || rank > 5)
+    return result;
+
+  // Pointer-increment loops: if the load reads a loop-carried pointer advanced
+  // by a uniform constant each iteration, decompose the loop's INIT pointer and
+  // remember the loop IV + step to reconstruct the per-iteration tile offset.
+  LoopPtrInfo loop;
+  ptr = resolveLoopCarriedPtr(ptr, loop);
+  // Loop-carried pointer with an unrecognized per-iteration advance: bail
+  // rather than silently decompose against the INIT pointer (iteration-0 tile
+  // offset).
+  if (loop.unrecognized)
+    return result;
+
+  // Walk the (possibly multi-level) addptr/broadcast chain back to the base
+  // pointer, collecting the offset operand at each level. Triton lowers
+  // `base + d0_off + d1_off + ...` with mismatched per-dim broadcast shapes as
+  // a CHAIN of addptr (with intervening broadcasts) rather than one summed
+  // offset (e.g. addptr(broadcast(addptr(splat(base), m_off)), k_off)), so peel
+  // each level instead of expecting a single addptr(splat(base), sum).
+  SmallVector<Value> offsetVals;
+  Value cur = ptr;
+  for (int guard = 0; guard < 16; guard++) {
+    if (auto bcast = cur.getDefiningOp<tt::BroadcastOp>()) {
+      cur = bcast.getSrc();
+      continue;
+    }
+    auto addPtrOp = cur.getDefiningOp<tt::AddPtrOp>();
+    if (!addPtrOp)
+      break;
+    offsetVals.push_back(addPtrOp.getOffset());
+    cur = addPtrOp.getPtr();
+  }
+  Value base = matchSplat(cur);
+  if (!base)
+    return result;
+  result.basePtr = base;
+  result.basePtrArgIndex = getFuncArgIndex(base);
+  if (result.basePtrArgIndex < 0)
+    return result;
+
+  // Flatten any summed (addi) offsets across all chain levels into terms.
+  SmallVector<Value> terms;
+  std::function<void(Value)> collectTerms = [&](Value v) {
+    if (auto addOp = v.getDefiningOp<arith::AddIOp>()) {
+      collectTerms(addOp.getLhs());
+      collectTerms(addOp.getRhs());
+    } else {
+      terms.push_back(v);
+    }
+  };
+  for (Value ov : offsetVals)
+    collectTerms(ov);
+
+  if (rank == 1) {
+    // Single-dim: match the whole per-level offset (make_range + splat), not
+    // the addi-split pieces — match1DOffset expects the full 1d offset
+    // expression. A rank-1 tile has exactly one affine offset level; if the
+    // addptr chain contributed more than one level we can't be sure
+    // match1DOffset captured them all (unlike the multi-dim branch below, which
+    // flattens across levels), so bail rather than emit a partial tile offset.
+    if (offsetVals.size() != 1)
+      return result;
+    Value inner = offsetVals[0];
+    if (auto b = inner.getDefiningOp<tt::BroadcastOp>())
+      inner = b.getSrc();
+    DimInfo dim;
+    if (match1DOffset(inner, dim)) {
+      if (loop.isLoop && dim.strideArgIdx < 0) {
+        // A pointer-increment loop's contiguous dim advances by
+        // loopIV * perIterElems; the rewrite reconstructs the index from that
+        // alone (init offset assumed 0, as in the canonical K-loop). If
+        // match1DOffset also found a static tile offset we'd drop it, so bail.
+        if (dim.offset)
+          return result;
+        dim.loopAdvanced = true;
+        dim.loopIV = loop.iv;
+        dim.perIterElems = loop.stepElems;
+      }
+      result.dims.push_back(dim);
+      result.valid = true;
+    }
+    return result;
+  }
+
+  result.dims.resize(rank);
+  SmallVector<bool> dimMatched(rank, false);
+  for (Value term : terms) {
+    Value inner = term;
+    if (auto broadcastOp = inner.getDefiningOp<tt::BroadcastOp>())
+      inner = broadcastOp.getSrc();
+    // The canonical Triton idiom `offs[:, None] * stride` lowers to
+    // muli(expand_dims(offs), splat(stride)) -- the multiply is applied AFTER
+    // expand_dims, and no canonicalization hoists it through expand_dims. Peel
+    // that form here and carry the stride into the DimInfo so multi-dim strided
+    // loads (e.g. GEMM operands) decompose, not just the contiguous form.
+    Value postExpandStride;
+    if (auto mulOp = inner.getDefiningOp<arith::MulIOp>()) {
+      Value lhs = mulOp.getLhs();
+      Value rhs = mulOp.getRhs();
+      for (int swap = 0; swap < 2; swap++) {
+        if (lhs.getDefiningOp<tt::ExpandDimsOp>()) {
+          if (Value strideSplat = matchSplat(rhs)) {
+            inner = lhs;
+            postExpandStride = strideSplat;
+            break;
+          }
+        }
+        std::swap(lhs, rhs);
+      }
+    }
+    // NOTE: this peels a SINGLE expand_dims level, so it reliably handles rank
+    // 1-2 tiles. A rank>=3 tile built with multiple expand_dims leaves src1d as
+    // another ExpandDimsOp, match1DOffset fails, the dim stays unmatched, and
+    // decomposePointer returns invalid (safe: load stays plain, never a wrong
+    // descriptor). Broaden to a multi-level peel + targetDim mapping if rank>=3
+    // auto-TMA is needed.
+    if (auto expandOp = inner.getDefiningOp<tt::ExpandDimsOp>()) {
+      int axis = expandOp.getAxis();
+      Value src1d = expandOp.getSrc();
+      int targetDim;
+      if (rank == 2)
+        targetDim = 1 - axis;
+      else
+        targetDim = (axis == 0) ? rank - 1 : axis - 1;
+      if (targetDim >= 0 && targetDim < rank && !dimMatched[targetDim]) {
+        DimInfo dim;
+        if (match1DOffset(src1d, dim)) {
+          // Stride applied post-expand (offs[:,None]*stride): the inner 1d is
+          // the contiguous form, so overlay the peeled stride.
+          if (postExpandStride && dim.strideArgIdx < 0 && !dim.stride) {
+            dim.stride = postExpandStride;
+            dim.strideArgIdx = getFuncArgIndex(postExpandStride);
+          }
+          result.dims[targetDim] = dim;
+          dimMatched[targetDim] = true;
+        }
+      }
+    }
+  }
+  for (int d = 0; d < rank; d++)
+    if (!dimMatched[d])
+      return result;
+  // Pointer-increment loop: the contiguous dim is the one advanced each
+  // iteration; its per-iteration tile offset is loopIV * stepElems. The rewrite
+  // reconstructs the index from loopIV * perIterElems alone (init offset
+  // assumed 0, as in the canonical K-loop). If that dim also carries a static
+  // tile offset, promoting would silently drop it, so bail (leave valid =
+  // false).
+  if (loop.isLoop)
+    for (int d = 0; d < rank; d++)
+      if (result.dims[d].strideArgIdx < 0) {
+        if (result.dims[d].offset)
+          return result;
+        result.dims[d].loopAdvanced = true;
+        result.dims[d].loopIV = loop.iv;
+        result.dims[d].perIterElems = loop.stepElems;
+      }
+  result.valid = true;
+  return result;
+}
+
+// cuTensorMapEncodeTiled requires every box (block) dim to be in [1, 256]
+// elements. The HOST recipe path builds the CUtensorMap with box_dim ==
+// block_shape, and launch.h does NOT clamp or multi-copy-decompose the box
+// (unlike the device AsyncTMACopyGlobalToLocal lowering), so an oversize tile
+// would fail encode at launch.
+//
+// NOTE (conservative): this runs pre-warp-specialization, so ``blockSize`` is
+// the pre-WS tile. WS / 2-CTA / dp only ever SHRINK the tile, so blockSize <=
+// 256 here guarantees the final descriptor box is <= 256 (safe). The converse
+// is imprecise -- a pre-WS tile > 256 that WS later halves to <= 256 would
+// actually be encodable -- but we can't see the final box at this point and the
+// host path can't decompose, so we reject it (the load stays a plain load:
+// correct, just not TMA-accelerated). Supporting oversize tiles on the host
+// path needs box decomposition in launch.h; see
+// PromoteLoadToTMA_box_decompose_design.md.
+static bool blockDimsWithinTMABox(const DecomposedLoad &decomp) {
+  for (const DimInfo &dim : decomp.dims)
+    if (dim.blockSize < 1 || dim.blockSize > 256)
+      return false;
+  return true;
+}
+
+// Shared TMA-eligibility core for a load/store tile (element type + decomposed
+// pointer): TMA-encodable dtype, rank 1-5, every strided dim's stride is a
+// kernel arg, exactly one contiguous dim, the contiguous (inner) box is a
+// positive multiple of 16 bytes, and every box dim <= 256
+// (cuTensorMapEncodeTiled). Load-/store-specific checks live in the callers.
+static bool isTMAEligibleCommon(Type elemTy, const DecomposedLoad &decomp) {
+  if (!getTMADataType(elemTy))
+    return false;
+  int rank = decomp.dims.size();
+  if (rank < 1 || rank > 5)
+    return false;
+  // A strided dim whose stride scalar is not a direct kernel argument (a
+  // computed value or a loop-carried IV) has stride != null but strideArgIdx <
+  // 0. The host recipe can only encode a stride via a kernel-arg index, and
+  // several places use strideArgIdx < 0 as the "contiguous dim" predicate, so
+  // reject.
+  for (const DimInfo &dim : decomp.dims)
+    if (dim.stride && dim.strideArgIdx < 0)
+      return false;
+  // Exactly one dim must be contiguous (stride == 1) -> TMA descriptor
+  // innermost.
+  int nContig = 0, contigDim = -1;
+  for (int d = 0; d < rank; d++)
+    if (decomp.dims[d].strideArgIdx < 0) {
+      nContig++;
+      contigDim = d;
+    }
+  if (nContig != 1)
+    return false;
+  // The contiguous (inner) box must be a positive multiple of 16 bytes: TMA
+  // requires the inner-dimension byte size to be 16B-aligned.
+  int elemBytes = elemTy.getIntOrFloatBitWidth() / 8;
+  int64_t innerBytes = (int64_t)decomp.dims[contigDim].blockSize * elemBytes;
+  if (innerBytes < 16 || innerBytes % 16 != 0)
+    return false;
+  // Every box dim must be <= 256 elements (cuTensorMapEncodeTiled).
+  if (!blockDimsWithinTMABox(decomp))
+    return false;
+  return true;
+}
+
+static bool isTMAEligible(tt::LoadOp loadOp, const DecomposedLoad &decomp) {
+  auto resultTy = dyn_cast<RankedTensorType>(loadOp.getResult().getType());
+  if (!resultTy)
+    return false;
+  if (!isTMAEligibleCommon(resultTy.getElementType(), decomp))
+    return false;
+  if (loadOp.getIsVolatile())
+    return false;
+  // 'other' (OOB fill) must be zero if present (TMA zero-fills).
+  if (Value other = loadOp.getOther()) {
+    bool isZero = false;
+    if (auto splatOp = other.getDefiningOp<tt::SplatOp>()) {
+      Value scalar = splatOp.getSrc();
+      if (matchPattern(scalar, m_AnyZeroFloat()) ||
+          matchPattern(scalar, m_Zero()))
+        isZero = true;
+    } else if (auto cstOp = other.getDefiningOp<arith::ConstantOp>()) {
+      // A tensor `other=0` often lowers to a dense splat constant rather than
+      // tt.splat(0) (e.g. multi-dim masked loads).
+      if (auto dense = dyn_cast<DenseFPElementsAttr>(cstOp.getValue())) {
+        if (dense.isSplat() && dense.getSplatValue<APFloat>().isZero())
+          isZero = true;
+      } else if (auto dense =
+                     dyn_cast<DenseIntElementsAttr>(cstOp.getValue())) {
+        if (dense.isSplat() && dense.getSplatValue<APInt>().isZero())
+          isZero = true;
+      }
+    }
+    if (!isZero)
+      return false;
+  }
+  return true;
+}
+
+// Recursively check if root's defining-op chain transitively uses target.
+// Memoized with a visited set: the SSA use-def graph is a DAG with heavy
+// reconvergence (shared tile offsets), so without memoization a wide address
+// expression could be re-walked exponentially. Visiting each node once bounds
+// this to O(nodes).
+static bool usesValueImpl(Value root, Value target,
+                          llvm::SmallPtrSetImpl<Value> &visited, int depth) {
+  if (depth > 12 || !root)
+    return false;
+  if (root == target)
+    return true;
+  if (!visited.insert(root).second)
+    return false; // already explored this node
+  auto *defOp = root.getDefiningOp();
+  if (!defOp)
+    return false;
+  for (Value operand : defOp->getOperands())
+    if (usesValueImpl(operand, target, visited, depth + 1))
+      return true;
+  return false;
+}
+static bool usesValue(Value root, Value target, int depth = 0) {
+  llvm::SmallPtrSet<Value, 32> visited;
+  return usesValueImpl(root, target, visited, depth);
+}
+
+// Find the func arg providing the global shape for a specific dimension.
+// The mask is typically `and(offs_d0 < splat(M), offs_d1 < splat(N))`.
+// We match each slt comparison's LHS back to the dim's tile_offset to
+// associate the right bound with the right dimension.
+// Find the kernel arg that supplies the global extent of `dim` -- the value the
+// host CUtensorMap needs for global_dim[d]. We look for a comparison
+// `offs_dim < splat(arg)` whose lhs is derived from this dim's tile offset
+// (dim.offset, the pid*BLOCK tile start). A matching cmp's rhs splat arg is the
+// global extent.
+//
+// We search the WHOLE kernel, not just this load's own mask: a typical GEMM
+// masks only the K dim on its operand loads (M / N are assumed divisible, so
+// the load itself carries no M / N bound), but the epilogue store DOES bound
+// them (`offs_cm < M`, `offs_cn < N`). Because the tile start (pid*BLOCK) is
+// one CSE'd SSA value shared by the operand-load offset and the store mask,
+// usesValue ties such a store cmp to exactly this dim. If no comparison in the
+// kernel bounds the dim, return -1 and the load is left unpromoted (we never
+// fabricate an extent -- a wrong global_dim would mis-bound the TMA copy).
+static bool cmpBoundsDim(arith::CmpIOp cmpOp, const DimInfo &dim, int &argIdx) {
+  if (!cmpOp || cmpOp.getPredicate() != arith::CmpIPredicate::slt)
+    return false;
+  if (!dim.offset || !usesValue(cmpOp.getLhs(), dim.offset))
+    return false;
+  Value bound = matchSplat(cmpOp.getRhs());
+  if (!bound)
+    return false;
+  int idx = getFuncArgIndex(bound);
+  if (idx < 0)
+    return false;
+  argIdx = idx;
+  return true;
+}
+
+static int findShapeArgForDim(tt::FuncOp func, Value ownMask,
+                              const DimInfo &dim) {
+  if (!dim.offset)
+    return -1;
+  // 1) Prefer the op's own mask (most specific bound for the dim).
+  if (Value mask = ownMask) {
+    SmallVector<Value> cmpTerms;
+    std::function<void(Value)> collectCmps = [&](Value v) {
+      if (auto andOp = v.getDefiningOp<arith::AndIOp>()) {
+        collectCmps(andOp.getLhs());
+        collectCmps(andOp.getRhs());
+      } else {
+        cmpTerms.push_back(v);
+      }
+    };
+    collectCmps(mask);
+    for (Value cmpVal : cmpTerms) {
+      // 2D/ND masks broadcast each per-dim comparison (offs[:,None] < M) up to
+      // the load shape, so peel the broadcast to reach the cmpi.
+      Value c = cmpVal;
+      if (auto bcast = c.getDefiningOp<tt::BroadcastOp>())
+        c = bcast.getSrc();
+      int argIdx = -1;
+      if (cmpBoundsDim(c.getDefiningOp<arith::CmpIOp>(), dim, argIdx))
+        return argIdx;
+    }
+  }
+  // 2) Fall back to any slt comparison in the kernel that bounds this dim
+  //    (e.g. the epilogue store's mask supplies M / N for K-only-masked loads).
+  int found = -1;
+  func.walk([&](arith::CmpIOp cmpOp) {
+    int argIdx = -1;
+    if (cmpBoundsDim(cmpOp, dim, argIdx)) {
+      found = argIdx;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return found;
+}
+
+// Structural equality of scalar index expressions. The promote pass runs before
+// CSE, so the tile offset used in a pointer (`muli(ki, BLOCK)`) and the same
+// quantity recomputed in a mask bound (`K - muli(ki, BLOCK)`) are equal in
+// value but distinct SSA. Compare by structure: same SSA leaf, equal constants,
+// or matching add/mul (commutative) / sub (ordered) trees.
+static bool sameScalarExpr(Value a, Value b, int depth = 0) {
+  if (a == b)
+    return true;
+  // Depth cap keeps the commutative add/mul 4-way branching bounded
+  // (tile-offset exprs are shallow, e.g. K - ki*BLOCK_K); a miss only costs a
+  // promotion.
+  if (depth > 6 || !a || !b)
+    return false;
+  Operation *oa = a.getDefiningOp();
+  Operation *ob = b.getDefiningOp();
+  if (!oa || !ob || oa->getName() != ob->getName())
+    return false;
+  if (auto ca = dyn_cast<arith::ConstantOp>(oa)) {
+    auto cb = cast<arith::ConstantOp>(ob);
+    return ca.getValue() == cb.getValue();
+  }
+  if (isa<arith::MulIOp, arith::AddIOp>(oa)) {
+    Value a0 = oa->getOperand(0), a1 = oa->getOperand(1);
+    Value b0 = ob->getOperand(0), b1 = ob->getOperand(1);
+    return (sameScalarExpr(a0, b0, depth + 1) &&
+            sameScalarExpr(a1, b1, depth + 1)) ||
+           (sameScalarExpr(a0, b1, depth + 1) &&
+            sameScalarExpr(a1, b0, depth + 1));
+  }
+  if (isa<arith::SubIOp>(oa))
+    return sameScalarExpr(oa->getOperand(0), ob->getOperand(0), depth + 1) &&
+           sameScalarExpr(oa->getOperand(1), ob->getOperand(1), depth + 1);
+  return false;
+}
+
+// Recover a dim's global extent from a per-tile "remaining" bound of the form
+//   localArange < E - tileOffset        (e.g. the reduction mask `arange < K -
+//   ki*BLOCK_K`)
+// Tiled loops mask the reduction dim against how much is LEFT in the current
+// tile, so the bound is `subi(E, tileOffset)` rather than the direct extent E.
+// We tie it to this dim by requiring the subtrahend to be exactly dim.offset
+// (the tile start) and the lhs to be this dim's local make_range(0, blockSize).
+// The minuend E is then the global-extent kernel arg.
+static int findShapeArgFromTileBound(tt::FuncOp func, const DimInfo &dim) {
+  if (!dim.offset)
+    return -1;
+  int found = -1;
+  func.walk([&](arith::CmpIOp cmpOp) {
+    if (found >= 0)
+      return WalkResult::interrupt();
+    if (cmpOp.getPredicate() != arith::CmpIPredicate::slt)
+      return WalkResult::advance();
+    // lhs: this dim's local range, peeled of expand_dims / broadcast.
+    Value lhs = cmpOp.getLhs();
+    if (auto b = lhs.getDefiningOp<tt::BroadcastOp>())
+      lhs = b.getSrc();
+    if (auto e = lhs.getDefiningOp<tt::ExpandDimsOp>())
+      lhs = e.getSrc();
+    int64_t bs = 0;
+    if (!matchMakeRange(lhs, bs) || bs != dim.blockSize)
+      return WalkResult::advance();
+    // rhs: splat(subi(E, tileOffset)) with tileOffset structurally ==
+    // dim.offset.
+    Value rhs = matchSplat(cmpOp.getRhs());
+    if (!rhs)
+      return WalkResult::advance();
+    auto subOp = rhs.getDefiningOp<arith::SubIOp>();
+    if (!subOp || !sameScalarExpr(subOp.getRhs(), dim.offset))
+      return WalkResult::advance();
+    int argIdx = getFuncArgIndex(subOp.getLhs());
+    if (argIdx < 0)
+      return WalkResult::advance();
+    found = argIdx;
+    return WalkResult::interrupt();
+  });
+  return found;
+}
+
+static bool matchScalarIntConst(Value v, int64_t &out) {
+  if (auto c = v.getDefiningOp<arith::ConstantOp>())
+    if (auto ia = dyn_cast<IntegerAttr>(c.getValue())) {
+      out = ia.getInt();
+      return true;
+    }
+  return false;
+}
+
+// Extent recovery for a loop-advanced (pointer-increment) dim. Its per-tile
+// reduction bound is `localArange < E - (loopIV * perIterElems)`; match
+// subi(E, muli(loopIV, perIterElems)) and return the extent arg E. The loop IV
+// is matched by SSA identity (it is the actual induction var); the per-iter
+// step by constant value.
+static int findShapeArgForLoopDim(tt::FuncOp func, const DimInfo &dim) {
+  if (!dim.loopAdvanced || !dim.loopIV)
+    return -1;
+  int found = -1;
+  func.walk([&](arith::CmpIOp cmpOp) {
+    if (found >= 0)
+      return WalkResult::interrupt();
+    if (cmpOp.getPredicate() != arith::CmpIPredicate::slt)
+      return WalkResult::advance();
+    // lhs: this dim's local range, peeled of expand_dims / broadcast. Required
+    // (mirrors findShapeArgFromTileBound) so an unrelated slt whose RHS happens
+    // to match subi(E, loopIV*step) can't select the wrong extent arg.
+    Value lhs = cmpOp.getLhs();
+    if (auto b = lhs.getDefiningOp<tt::BroadcastOp>())
+      lhs = b.getSrc();
+    if (auto e = lhs.getDefiningOp<tt::ExpandDimsOp>())
+      lhs = e.getSrc();
+    int64_t bs = 0;
+    if (!matchMakeRange(lhs, bs) || bs != dim.blockSize)
+      return WalkResult::advance();
+    Value rhs = matchSplat(cmpOp.getRhs());
+    if (!rhs)
+      return WalkResult::advance();
+    auto subOp = rhs.getDefiningOp<arith::SubIOp>();
+    if (!subOp)
+      return WalkResult::advance();
+    auto mul = subOp.getRhs().getDefiningOp<arith::MulIOp>();
+    if (!mul)
+      return WalkResult::advance();
+    auto isPerIter = [&](Value iv, Value c) {
+      int64_t cv;
+      return iv == dim.loopIV && matchScalarIntConst(c, cv) &&
+             cv == dim.perIterElems;
+    };
+    if (!isPerIter(mul.getLhs(), mul.getRhs()) &&
+        !isPerIter(mul.getRhs(), mul.getLhs()))
+      return WalkResult::advance();
+    int argIdx = getFuncArgIndex(subOp.getLhs());
+    if (argIdx < 0)
+      return WalkResult::advance();
+    found = argIdx;
+    return WalkResult::interrupt();
+  });
+  return found;
+}
+
+// A kernel arg is provably 16B-aligned if its ``tt.divisibility`` (in elements,
+// from specialization) times the element size is a multiple of 16. Absent attr
+// => alignment unknown => treated as not aligned (caller rejects).
+static bool argIs16BAligned(tt::FuncOp func, int argIdx, int elemBytes) {
+  auto attr = func.getArgAttrOfType<IntegerAttr>(argIdx, "tt.divisibility");
+  if (!attr)
+    return false;
+  return (attr.getInt() * (int64_t)elemBytes) % 16 == 0;
+}
+
+// TMA requires the global (outer) strides to be 16-byte aligned. A strided
+// dim's stride comes from a kernel arg whose element-divisibility is known from
+// specialization (tt.divisibility); the byte stride is divisible by
+// divisibility * elem_size. Contiguous innermost dims (strideArgIdx < 0) carry
+// no outer stride and are always fine.
+static bool dimStrideIs16BAligned(tt::FuncOp func, const DimInfo &dim,
+                                  int elemBytes) {
+  if (dim.strideArgIdx < 0)
+    return true;
+  return argIs16BAligned(func, dim.strideArgIdx, elemBytes);
+}
+
+struct Promotion {
+  tt::LoadOp loadOp;
+  DecomposedLoad decomp;
+  SmallVector<int> shapeArgIndices;
+  // Logical-tile -> descriptor-memory dim order (the single contiguous dim is
+  // moved last). Identity when the contiguous dim is already innermost.
+  SmallVector<int> perm;
+};
+
+class TritonNvidiaGPUPromoteLoadToTMAPass
+    : public impl::TritonNvidiaGPUPromoteLoadToTMAPassBase<
+          TritonNvidiaGPUPromoteLoadToTMAPass> {
+public:
+  using impl::TritonNvidiaGPUPromoteLoadToTMAPassBase<
+      TritonNvidiaGPUPromoteLoadToTMAPass>::
+      TritonNvidiaGPUPromoteLoadToTMAPassBase;
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    tt::FuncOp kernelFunc;
+    int numKernels = 0;
+    mod.walk([&](tt::FuncOp func) {
+      if (tt::isKernel(func)) {
+        ++numKernels;
+        if (!kernelFunc)
+          kernelFunc = func;
+      }
+      return WalkResult::skip();
+    });
+    if (!kernelFunc)
+      return;
+    // Recipes are recorded as a single module-wide ``ttg.auto_tma_recipes``
+    // attribute whose ``desc_arg_index`` / ``*_arg_indices`` are relative to
+    // one kernel's argument list, so this pass assumes exactly one kernel per
+    // module (the invariant for the Triton JIT compile pipeline). Fail loudly
+    // on a future multi-kernel module -- via a diagnostic that survives release
+    // (NDEBUG) builds, unlike assert -- instead of silently promoting only the
+    // first kernel and dropping the rest.
+    if (numKernels != 1) {
+      mod.emitError("PromoteLoadToTMA: expected exactly one kernel per module, "
+                    "got ")
+          << numKernels;
+      return signalPassFailure();
+    }
+
+    // Phase 1: collect eligible loads.
+    SmallVector<Promotion> promotions;
+    kernelFunc.walk([&](tt::LoadOp loadOp) {
+      DecomposedLoad decomp = decomposePointer(loadOp.getPtr());
+      if (!decomp.valid || !isTMAEligible(loadOp, decomp))
+        return;
+      int rank = decomp.dims.size();
+      SmallVector<int> shapeArgs(rank, -1);
+      for (int d = 0; d < rank; d++) {
+        const DimInfo &dim = decomp.dims[d];
+        // Extent sources, in priority order: (1) a modulus/select clamp on the
+        // offset (dim.shapeArgIdx), (2) a direct bound `offs < E` anywhere in
+        // the kernel, (3) a per-tile remaining bound `arange < E - tileOffset`.
+        int s = dim.shapeArgIdx;
+        if (s < 0)
+          s = findShapeArgForDim(kernelFunc, loadOp.getMask(), dim);
+        if (s < 0)
+          s = findShapeArgFromTileBound(kernelFunc, dim);
+        if (s < 0 && dim.loopAdvanced)
+          s = findShapeArgForLoopDim(kernelFunc, dim);
+        shapeArgs[d] = s;
+      }
+      bool ok = true;
+      for (int d = 0; d < rank; d++)
+        if (shapeArgs[d] < 0)
+          ok = false;
+      if (!ok)
+        return;
+      // TMA needs 16B-aligned outer strides; skip loads whose strides aren't
+      // provably aligned (e.g. a runtime stride with no divisibility
+      // guarantee).
+      int elemBytes = cast<RankedTensorType>(loadOp.getResult().getType())
+                          .getElementType()
+                          .getIntOrFloatBitWidth() /
+                      8;
+      for (int d = 0; d < rank; d++)
+        if (!dimStrideIs16BAligned(kernelFunc, decomp.dims[d], elemBytes))
+          return;
+      // TMA also requires the CUtensorMap global base address to be
+      // 16B-aligned. The base pointer's byte alignment is divisibility *
+      // elemBytes; reject if not provably 16B (mirrors the outer-stride check).
+      // Absent attr => unknown
+      // => reject, so a base marked divisible-by-1 (e.g. a sliced/offset
+      // tensor) isn't promoted into an illegal descriptor.
+      if (!argIs16BAligned(kernelFunc, decomp.basePtrArgIndex, elemBytes))
+        return;
+      Promotion p;
+      p.loadOp = loadOp;
+      p.decomp = decomp;
+      p.shapeArgIndices = shapeArgs;
+      // Descriptor memory order: keep dims in order but move the single
+      // contiguous dim last (TMA descriptor innermost must be contiguous).
+      int contigDim = -1;
+      for (int d = 0; d < rank; d++)
+        if (decomp.dims[d].strideArgIdx < 0)
+          contigDim = d;
+      for (int d = 0; d < rank; d++)
+        if (d != contigDim)
+          p.perm.push_back(d);
+      p.perm.push_back(contigDim);
+      promotions.push_back(std::move(p));
+    });
+
+    if (promotions.empty())
+      return;
+
+    // Phase 2: rewrite each eligible load into a HOST-side TMA descriptor
+    // passed as a compiler-synthesized kernel argument + descriptor_load, and
+    // record a recipe so the launcher builds the CUtensorMap on the host (no
+    // device global scratch). This routes auto-TMA through the shared launch.h
+    // recipe core.
+    //
+    // The synthesized descriptor arg is tagged `tt.auto_tma` so the metadata
+    // layer (get_tensordesc_metadata) skips it (it has no user-provided Python
+    // arg); get_auto_tma_recipes() surfaces it to the launcher instead.
+    OpBuilder builder(mod.getContext());
+    MLIRContext *ctx = mod.getContext();
+    Builder b(ctx);
+    auto i32Attr = [&](int v) { return b.getI32IntegerAttr(v); };
+    SmallVector<Attribute> recipeAttrs;
+
+    for (auto &promo : promotions) {
+      tt::LoadOp loadOp = promo.loadOp;
+      int rank = promo.decomp.dims.size();
+      auto resultTy = cast<RankedTensorType>(loadOp.getResult().getType());
+      Type elemTy = resultTy.getElementType();
+      Location loc = loadOp.getLoc();
+
+      // Build the descriptor in memory order (the single contiguous dim moved
+      // last, per promo.perm). For an operand whose contiguous dim is already
+      // innermost (e.g. A in C=A@B), perm is identity and this is the tile as
+      // loaded. For a transposed operand (e.g. B[K,N]: K contiguous but N is
+      // the tile innermost), the descriptor is built over the contiguous layout
+      // and the loaded tile is transposed back -- mirroring explicit-TMA
+      // `d.load().T`.
+      bool isIdentity = true;
+      for (int i = 0; i < rank; i++)
+        if (promo.perm[i] != i)
+          isIdentity = false;
+
+      SmallVector<int64_t> permShape;
+      for (int i = 0; i < rank; i++)
+        permShape.push_back(resultTy.getShape()[promo.perm[i]]);
+      // For the identity layout (contiguous dim already innermost) the load
+      // result's encoding maps 1:1 onto the descriptor tile. For a permuted
+      // (transposed-operand) layout the dims are reordered, so reusing the
+      // load-result encoding -- whose per-dim order / sizePerThread follow the
+      // LOGICAL shape -- would describe the permuted shape with the wrong dim
+      // order. Leave the descriptor block encoding unset in that case and let
+      // the downstream descriptor-encoding pass assign one matching the
+      // memory-order tile.
+      Attribute descEncoding =
+          isIdentity ? resultTy.getEncoding() : Attribute();
+      auto descTileTy = RankedTensorType::get(permShape, elemTy, descEncoding);
+
+      // Synthesized host-side descriptor; its block type is the memory-order
+      // tile.
+      auto descTy = tt::TensorDescType::get(ctx, descTileTy);
+      unsigned descArgIdx = kernelFunc.getNumArguments();
+      auto argAttrs =
+          b.getDictionaryAttr({b.getNamedAttr("tt.auto_tma", b.getUnitAttr())});
+      LogicalResult inserted =
+          kernelFunc.insertArgument(descArgIdx, descTy, argAttrs, loc);
+      assert(succeeded(inserted) &&
+             "failed to insert TMA descriptor kernel argument");
+      (void)inserted;
+      Value descArg = kernelFunc.getArgument(descArgIdx);
+
+      builder.setInsertionPoint(loadOp);
+      Type i32 = builder.getI32Type();
+      Type i64 = builder.getI64Type();
+      // Convert an integer/index value to a target integer width,
+      // sign-extending or truncating as needed. descriptor_load indices must be
+      // i32, but an offset may be i16 / i32 / i64 / index depending on how the
+      // kernel computed it. Unexpected non-integer types are left unchanged and
+      // get rejected by the op verifier rather than silently mis-typed.
+      auto toIntWidth = [&](Value v, Type target) -> Value {
+        Type ty = v.getType();
+        if (ty == target)
+          return v;
+        if (ty.isIndex())
+          return arith::IndexCastOp::create(builder, loc, target, v);
+        auto srcInt = dyn_cast<IntegerType>(ty);
+        auto dstInt = dyn_cast<IntegerType>(target);
+        if (srcInt && dstInt) {
+          if (srcInt.getWidth() > dstInt.getWidth())
+            return arith::TruncIOp::create(builder, loc, target, v);
+          return arith::ExtSIOp::create(builder, loc, target, v);
+        }
+        return v;
+      };
+      auto toI32 = [&](Value v) { return toIntWidth(v, i32); };
+
+      SmallVector<Value> indices;
+      for (int i = 0; i < rank; i++) {
+        const DimInfo &dim = promo.decomp.dims[promo.perm[i]];
+        if (dim.loopAdvanced) {
+          // Reconstruct the per-iteration tile offset: loopIV * perIterElems.
+          // Compute in i64 (perIterElems is i64, and loopIV * step can exceed
+          // i32 for large trip counts / strides), narrowing to i32 only at the
+          // descriptor_load index boundary.
+          Value iv = toIntWidth(dim.loopIV, i64);
+          Value step = arith::ConstantOp::create(
+              builder, loc, builder.getI64IntegerAttr(dim.perIterElems));
+          Value prod = arith::MulIOp::create(builder, loc, iv, step);
+          indices.push_back(arith::TruncIOp::create(builder, loc, i32, prod));
+        } else if (!dim.offset) {
+          // Bare make_range with no tile offset (e.g. `arange % M` or a
+          // select-clamp, which peel to a bare range): the tile starts at 0.
+          indices.push_back(arith::ConstantOp::create(
+              builder, loc, builder.getI32IntegerAttr(0)));
+        } else {
+          indices.push_back(toI32(dim.offset));
+        }
+      }
+
+      auto newLoad = tt::DescriptorLoadOp::create(
+          builder, loc, descTileTy, descArg, indices, tt::CacheModifier::NONE,
+          tt::EvictionPolicy::NORMAL);
+
+      Value loaded = newLoad.getResult();
+      if (!isIdentity) {
+        // Transpose the memory-order tile back to the kernel's logical tile.
+        // order[i] = position of logical dim i within the memory-order tile.
+        SmallVector<int32_t> order(rank);
+        for (int i = 0; i < rank; i++)
+          order[promo.perm[i]] = i;
+        loaded = tt::TransOp::create(builder, loc, loaded, order);
+      }
+
+      loadOp.getResult().replaceAllUsesWith(loaded);
+      loadOp.erase();
+
+      // Record the recipe: how the launcher builds this CUtensorMap from the
+      // existing scalar kernel args (base ptr / shape / stride) at launch time.
+      // Emit per-dim fields in descriptor memory order (promo.perm) so they
+      // match the descriptor arg's block type (contiguous dim last).
+      SmallVector<Attribute> shapeIdx, strideIdx, blk;
+      for (int i = 0; i < rank; i++) {
+        int d = promo.perm[i];
+        shapeIdx.push_back(i32Attr(promo.shapeArgIndices[d]));
+        strideIdx.push_back(i32Attr(promo.decomp.dims[d].strideArgIdx));
+        blk.push_back(i32Attr((int)promo.decomp.dims[d].blockSize));
+      }
+      int tmaDtype = getTMADataType(elemTy).value();
+      int elemBytes = elemTy.getIntOrFloatBitWidth() / 8;
+      SmallVector<NamedAttribute> fields = {
+          b.getNamedAttr("desc_arg_index", i32Attr((int)descArgIdx)),
+          b.getNamedAttr("base_ptr_arg_index",
+                         i32Attr(promo.decomp.basePtrArgIndex)),
+          b.getNamedAttr("shape_arg_indices", b.getArrayAttr(shapeIdx)),
+          b.getNamedAttr("stride_arg_indices", b.getArrayAttr(strideIdx)),
+          b.getNamedAttr("block_shape", b.getArrayAttr(blk)),
+          b.getNamedAttr("elem_type", i32Attr(tmaDtype)),
+          b.getNamedAttr("elem_size", i32Attr(elemBytes)),
+          b.getNamedAttr("fp4_padded", i32Attr(0)),
+          b.getNamedAttr("fill_mode", i32Attr(0)),
+      };
+      recipeAttrs.push_back(b.getDictionaryAttr(fields));
+    }
+    mod->setAttr("ttg.auto_tma_recipes", b.getArrayAttr(recipeAttrs));
+  }
+};
+
+} // namespace
+} // namespace mlir::triton::nvidia_gpu

--- a/python/test/unit/language/test_autows_auto_tma.py
+++ b/python/test/unit/language/test_autows_auto_tma.py
@@ -1,0 +1,111 @@
+"""auto-TMA promotion of multi-dim strided loads (non-WS).
+
+1. ``test_auto_tma_2d_strided_numerics``: a 2D strided masked block load
+   `x[:, :]` (row-major, contiguous innermost) is promoted by PromoteLoadToTMA
+   to a host-side TMA descriptor and runs correctly on GPU. Exercises the
+   decomposePointer extensions (addptr chain walk, stride-after-expand_dims,
+   dense-zero OOB fill, broadcast-wrapped mask cmp).
+2. ``test_auto_tma_gemm_nows``: auto-TMA on both DOT operands of a GEMM, without
+   warp specialization -- isolates the dot-operand promotion path (NVMMAShared
+   swizzle read from the final descriptor encoding).
+
+Requires sm_90+ (auto-TMA gating). Validated on Hopper (sm_90) and Blackwell
+(sm_100).
+"""
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton._internal_testing import is_cuda
+
+
+def _is_sm90plus() -> bool:
+    if not is_cuda():
+        return False
+    major, _ = torch.cuda.get_device_capability()
+    return major >= 9  # Hopper (sm_90) and Blackwell (sm_100)
+
+
+# ---------------------------------------------------------------------------
+# 2D strided promotion + numerics
+# ---------------------------------------------------------------------------
+@triton.jit
+def _scale_2d_strided(x_ptr, out_ptr, M, N, stride_xm, stride_om, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    # Row-major x: innermost (offs_n) is contiguous -> auto-TMA eligible.
+    x = tl.load(x_ptr + offs_m[:, None] * stride_xm + offs_n[None, :], mask=mask, other=0.0)
+    tl.store(out_ptr + offs_m[:, None] * stride_om + offs_n[None, :], x * 2.0, mask=mask)
+
+
+@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA promotion requires sm_90+")
+def test_auto_tma_2d_strided_numerics():
+    M, N = 512, 384
+    BLOCK_M, BLOCK_N = 64, 64
+    dtype = torch.float16
+    torch.manual_seed(0)
+    x = torch.randn((M, N), dtype=dtype, device="cuda")
+    out = torch.empty((M, N), dtype=dtype, device="cuda")
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.auto_tma = True
+        kernel = _scale_2d_strided[grid](x, out, M, N, x.stride(0), out.stride(0), BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N)
+
+    assert "tt.descriptor_load" in kernel.asm["ttir"], \
+        "expected the 2D strided masked load to be auto-TMA promoted"
+    torch.testing.assert_close(out, x * 2.0)
+
+
+@triton.jit
+def _gemm_nows(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_bn, stride_cm, BLOCK_M: tl.constexpr,
+               BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for ki in range(tl.cdiv(K, BLOCK_K)):
+        offs_k = ki * BLOCK_K + tl.arange(0, BLOCK_K)
+        a = tl.load(a_ptr + offs_m[:, None] * stride_am + offs_k[None, :],
+                    mask=(offs_m[:, None] < M) & (offs_k[None, :] < K), other=0.0)
+        b = tl.load(b_ptr + offs_n[:, None] * stride_bn + offs_k[None, :],
+                    mask=(offs_n[:, None] < N) & (offs_k[None, :] < K), other=0.0)
+        acc = tl.dot(a, b.T, acc)
+    tl.store(c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :], acc.to(tl.float16),
+             mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
+
+
+@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA promotion requires sm_90+")
+def test_auto_tma_gemm_nows():
+    """Isolates the auto-TMA DOT-operand path WITHOUT warp specialization."""
+    M, N, K = 256, 256, 256
+    BLOCK_M, BLOCK_N, BLOCK_K = 64, 64, 32
+    dtype = torch.float16
+    torch.manual_seed(0)
+    A = torch.randn((M, K), dtype=dtype, device="cuda")
+    B = torch.randn((N, K), dtype=dtype, device="cuda")
+    C = torch.empty((M, N), dtype=dtype, device="cuda")
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.auto_tma = True
+        kernel = _gemm_nows[grid](A, B, C, M, N, K, A.stride(0), B.stride(0), C.stride(0), BLOCK_M=BLOCK_M,
+                                  BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K)
+
+    assert "tt.descriptor_load" in kernel.asm["ttir"], "expected auto-TMA promotion"
+    ref = (A.to(torch.float32) @ B.T.to(torch.float32)).to(dtype)
+    torch.testing.assert_close(ref, C, atol=0.05, rtol=0.05)

--- a/python/test/unit/runtime/test_promote_load_to_tma.py
+++ b/python/test/unit/runtime/test_promote_load_to_tma.py
@@ -1,0 +1,226 @@
+"""End-to-end tests for auto-TMA promotion (TRITON_AUTO_TMA=1).
+
+The PromoteLoadToTMA pass rewrites eligible masked block loads into
+tt.descriptor_load, which the sm_90+ pipeline lowers to real TMA copies. These
+tests verify the rewrite produces correct results on Hopper+ (H100/H200).
+"""
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton._internal_testing import is_cuda
+
+
+def _has_hopper():
+    return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
+
+
+@pytest.fixture(autouse=True)
+def _auto_tma_env():
+    # TMA descriptors are built into global scratch, which needs an allocator.
+    if is_cuda():
+        triton.set_allocator(lambda size, alignment, stream: torch.empty(size, dtype=torch.int8, device="cuda"))
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.auto_tma = True
+        yield
+
+
+@triton.jit
+def _add_kernel(x_ptr, y_ptr, out_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(x_ptr + offs, mask=mask)
+    y = tl.load(y_ptr + offs, mask=mask)
+    tl.store(out_ptr + offs, x + y, mask=mask)
+
+
+@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
+def test_auto_tma_vector_add():
+    N = 8192
+    x = torch.randn(N, device="cuda", dtype=torch.float16)
+    y = torch.randn(N, device="cuda", dtype=torch.float16)
+    out = torch.empty(N, device="cuda", dtype=torch.float16)
+    grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]), )
+    _add_kernel[grid](x, y, out, N, BLOCK=256)
+    torch.testing.assert_close(out, x + y, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
+def test_auto_tma_vector_add_non_multiple():
+    # N not a multiple of BLOCK exercises the masked / OOB-zero-fill tail.
+    N = 8000
+    x = torch.randn(N, device="cuda", dtype=torch.float16)
+    y = torch.randn(N, device="cuda", dtype=torch.float16)
+    out = torch.empty(N, device="cuda", dtype=torch.float16)
+    grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]), )
+    _add_kernel[grid](x, y, out, N, BLOCK=256)
+    torch.testing.assert_close(out, x + y, atol=1e-2, rtol=1e-2)
+
+
+@triton.jit
+def _scale_2d_kernel(x_ptr, out_ptr, M, N, stride_m, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    ptrs = x_ptr + offs_m[:, None] * stride_m + offs_n[None, :]
+    x = tl.load(ptrs, mask=mask, other=0.0)
+    tl.store(out_ptr + offs_m[:, None] * stride_m + offs_n[None, :], x * 2.0, mask=mask)
+
+
+@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
+def test_auto_tma_2d_scale():
+    M, N = 200, 300  # non-multiples of BLOCK to exercise the mask
+    BLOCK_M, BLOCK_N = 64, 64
+    x = torch.randn((M, N), device="cuda", dtype=torch.float16)
+    out = torch.empty((M, N), device="cuda", dtype=torch.float16)
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    _scale_2d_kernel[grid](x, out, M, N, x.stride(0), BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N)
+    torch.testing.assert_close(out, x * 2.0, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
+def test_auto_tma_no_allocator_needed():
+    # Host-built TMA (launch.h recipe core) must NOT require a runtime allocator:
+    # the CUtensorMap is built on the host, not in device global scratch. With
+    # the null allocator active, a device-built descriptor would raise "Kernel
+    # requires a runtime memory allocation"; the host-built recipe path runs
+    # cleanly. This is the decisive proof that auto-TMA no longer depends on a
+    # global-scratch allocator.
+    from triton.runtime._allocation import NullAllocator
+
+    triton.set_allocator(NullAllocator())
+    N = 8192
+    x = torch.randn(N, device="cuda", dtype=torch.float16)
+    y = torch.randn(N, device="cuda", dtype=torch.float16)
+    out = torch.empty(N, device="cuda", dtype=torch.float16)
+    grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]), )
+    _add_kernel[grid](x, y, out, N, BLOCK=256)
+    torch.testing.assert_close(out, x + y, atol=1e-2, rtol=1e-2)
+
+
+@triton.jit
+def _knob_add_kernel(x_ptr, y_ptr, out_ptr, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(x_ptr + offs, mask=mask)
+    y = tl.load(y_ptr + offs, mask=mask)
+    tl.store(out_ptr + offs, x + y, mask=mask)
+
+
+@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
+def test_auto_tma_per_call_option():
+    # With the global TRITON_AUTO_TMA knob OFF, the per-call `auto_tma` compile
+    # option must independently control promotion: auto_tma=True promotes the
+    # load to a descriptor_load (host-built TMA, no allocator), auto_tma=False
+    # leaves it an ordinary load.
+    triton.knobs.nvidia.auto_tma = False  # override the autouse fixture's scope
+    from triton.runtime._allocation import NullAllocator
+
+    triton.set_allocator(NullAllocator())
+    N, BLOCK = 8192, 256
+    x = torch.randn(N, device="cuda", dtype=torch.float16)
+    y = torch.randn(N, device="cuda", dtype=torch.float16)
+    grid = (triton.cdiv(N, BLOCK), )
+
+    out_on = torch.empty(N, device="cuda", dtype=torch.float16)
+    k_on = _knob_add_kernel[grid](x, y, out_on, N, BLOCK=BLOCK, auto_tma=True)
+    torch.testing.assert_close(out_on, x + y, atol=1e-2, rtol=1e-2)
+    assert "tt.descriptor_load" in k_on.asm["ttir"], "auto_tma=True should promote to TMA"
+
+    out_off = torch.empty(N, device="cuda", dtype=torch.float16)
+    k_off = _knob_add_kernel[grid](x, y, out_off, N, BLOCK=BLOCK, auto_tma=False)
+    torch.testing.assert_close(out_off, x + y, atol=1e-2, rtol=1e-2)
+    assert "tt.descriptor_load" not in k_off.asm["ttir"], "auto_tma=False should stay a plain load"
+
+
+@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
+def test_auto_tma_autotune_config():
+    # auto_tma is an autotunable per-Config option (like num_warps): the
+    # autotuner compiles both the non-TMA and TMA variants and picks one; both
+    # must be correct. Global knob OFF so only the Config drives promotion.
+    triton.knobs.nvidia.auto_tma = False  # override the autouse fixture's scope
+    from triton.runtime._allocation import NullAllocator
+
+    triton.set_allocator(NullAllocator())
+
+    @triton.autotune(
+        configs=[
+            triton.Config({"BLOCK": 256}, num_warps=4, auto_tma=False),
+            triton.Config({"BLOCK": 256}, num_warps=4, auto_tma=True),
+        ],
+        key=["N"],
+    )
+    @triton.jit
+    def _autotuned_add(x_ptr, y_ptr, out_ptr, N, BLOCK: tl.constexpr):
+        offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+        mask = offs < N
+        x = tl.load(x_ptr + offs, mask=mask)
+        y = tl.load(y_ptr + offs, mask=mask)
+        tl.store(out_ptr + offs, x + y, mask=mask)
+
+    N = 8192
+    x = torch.randn(N, device="cuda", dtype=torch.float16)
+    y = torch.randn(N, device="cuda", dtype=torch.float16)
+    out = torch.empty(N, device="cuda", dtype=torch.float16)
+    grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]), )
+    _autotuned_add[grid](x, y, out, N)
+    torch.testing.assert_close(out, x + y, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
+def test_auto_tma_block_over_256_not_promoted():
+    # cuTensorMapEncodeTiled caps every box (block) dim at 256 elements, and the
+    # host recipe path builds the CUtensorMap with box_dim == block_shape (no
+    # clamp / decompose in launch.h). So a BLOCK > 256 load must NOT be auto-TMA
+    # promoted -- it would fail encode at launch. It stays an ordinary load and
+    # still computes the right result.
+    N, BLOCK = 8192, 512  # 512 > 256 element box cap
+    x = torch.randn(N, device="cuda", dtype=torch.float16)
+    y = torch.randn(N, device="cuda", dtype=torch.float16)
+    out = torch.empty(N, device="cuda", dtype=torch.float16)
+    grid = (triton.cdiv(N, BLOCK), )
+    k = _add_kernel[grid](x, y, out, N, BLOCK=BLOCK)
+    torch.testing.assert_close(out, x + y, atol=1e-2, rtol=1e-2)
+    assert "tt.descriptor_load" not in k.asm["ttir"], (
+        "BLOCK>256 exceeds the TMA box limit and must not be auto-TMA promoted")
+
+
+@triton.jit
+def _mixed_block_kernel(a_ptr, b_ptr, oa_ptr, ob_ptr, Na, Nb, BLOCK_A: tl.constexpr, BLOCK_B: tl.constexpr):
+    pid = tl.program_id(0)
+    offs_a = pid * BLOCK_A + tl.arange(0, BLOCK_A)
+    mask_a = offs_a < Na
+    a = tl.load(a_ptr + offs_a, mask=mask_a)
+    tl.store(oa_ptr + offs_a, a + 1.0, mask=mask_a)
+    offs_b = pid * BLOCK_B + tl.arange(0, BLOCK_B)
+    mask_b = offs_b < Nb
+    b = tl.load(b_ptr + offs_b, mask=mask_b)
+    tl.store(ob_ptr + offs_b, b + 2.0, mask=mask_b)
+
+
+@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
+def test_auto_tma_mixed_promoted_and_oversize_load():
+    # A single kernel with one TMA-eligible load (BLOCK_A=256, promoted to
+    # tt.descriptor_load) and one oversize load (BLOCK_B=512 > the 256 element box
+    # cap, left as an ordinary load). Promotion is per-load, so the eligible load
+    # must promote while the oversize one stays behind. The host then encodes only
+    # the legal 256-box descriptor, so the launch must not fail (an unclamped 512
+    # box would make cuTensorMapEncodeTiled reject the whole launch). Verifies
+    # exactly one descriptor_load in the IR and correct results for both loads.
+    BLOCK_A, BLOCK_B = 256, 512  # 256 <= box cap (promoted); 512 > cap (not promoted)
+    ntiles = 8
+    Na, Nb = ntiles * BLOCK_A, ntiles * BLOCK_B
+    a = torch.randn(Na, device="cuda", dtype=torch.float16)
+    b = torch.randn(Nb, device="cuda", dtype=torch.float16)
+    oa = torch.empty(Na, device="cuda", dtype=torch.float16)
+    ob = torch.empty(Nb, device="cuda", dtype=torch.float16)
+    k = _mixed_block_kernel[(ntiles, )](a, b, oa, ob, Na, Nb, BLOCK_A=BLOCK_A, BLOCK_B=BLOCK_B)
+    torch.testing.assert_close(oa, a + 1.0, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(ob, b + 2.0, atol=1e-2, rtol=1e-2)
+    assert k.asm["ttir"].count("tt.descriptor_load") == 1, (
+        "exactly the BLOCK_A=256 load must be auto-TMA promoted; the BLOCK_B=512 "
+        "load exceeds the box cap and must stay an ordinary load")

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -741,6 +741,12 @@ class CUDABackend(BaseBackend):
 
         if capability // 10 < 9:
             passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
+        # Auto-TMA: rewrite eligible masked block loads into descriptor_load so
+        # the standard sm_90+ TMA lowering turns them into real TMA copies. The
+        # per-config option (autotunable) takes precedence; otherwise fall back
+        # to the global TRITON_AUTO_TMA knob.
+        if (opt.auto_tma or knobs.nvidia.auto_tma) and capability // 10 >= 9:
+            nvidia.passes.ttnvgpuir.add_promote_load_to_tma(pm)
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_combine(pm)
         passes.ttir.add_reorder_broadcast(pm)

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -474,7 +474,7 @@ class CudaLauncher(object):
         # Compiler-synthesized auto-TMA descriptors (PromoteLoadToTMA): the
         # launcher builds each CUtensorMap host-side from existing scalar args
         # via the launch.h recipe core and injects it (no device global scratch).
-        self.auto_tma_recipes = schema.get("auto_tma_recipes", []) or []
+        self.auto_tma_recipes = getattr(metadata, "auto_tma_recipes", []) or []
         self.global_scratch_size = metadata.global_scratch_size
         self.global_scratch_align = metadata.global_scratch_align
         self.profile_scratch_size = metadata.profile_scratch_size

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -165,6 +165,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      createTritonGPUProxyFenceInsertionWrapper, int32_t);
   ADD_PASS_WRAPPER_0("add_tma_lowering",
                      ttng::createTritonNvidiaGPUTMALoweringPass);
+  ADD_PASS_WRAPPER_0("add_promote_load_to_tma",
+                     ttng::createTritonNvidiaGPUPromoteLoadToTMAPass);
   ADD_PASS_WRAPPER_0("add_tma_store_buffer_reuse",
                      ttng::createTritonNvidiaGPUTMAStoreBufferReusePass);
   ADD_PASS_WRAPPER_0("add_promote_lhs_to_tmem",


### PR DESCRIPTION
Summary:

## Background

TMA (see 1/n) needs a `CUtensorMap` describing each promoted tile: global extent
per dim, byte strides, tile/box shape, a single contiguous (stride==1) dim, and a
per-launch tile offset. To promote an ordinary `tl.load(ptr + offs, mask=...)`
into a TMA copy, the compiler must *recover* those quantities from the load's
pointer arithmetic — which real kernels do not spell out directly.

1/6 added the launcher that consumes recipes. This diff (2/n) adds the *producer*:
the `PromoteLoadToTMA` TTIR pass that recognizes eligible loads, recovers their
geometry, rewrites them to `tt.descriptor_load`, and records the recipe.

**LOAD only.** Store promotion is 3/n; device descriptors are 5/n.

## What this diff does

Adds the `PromoteLoadToTMA` pass (`TRITON_AUTO_TMA=1`, sm_90+), invoked in
`make_ttir` (early, on clean pre-warp-specialization IR so the pointer/mask affine
structure is intact). Three layers:

1. **Pointer decomposition** (`decomposePointer`): normalize the load pointer to
   `base + Σ_d idx_d * stride_d`; per dim recover `{blockSize, stride, tileOffset}`,
   walking `addptr / broadcast / expand_dims / muli / addi` and peeling boundary
   clamps (`% E`, `select(idx<E, idx, 0)`).
2. **Symbolic extent inference**: for each dim recover the global extent from the
   load's own mask (`offs < E`), a whole-function mask search, a per-tile bound
   (`localArange < E - tileOffset`, i.e. GEMM's remaining-K mask), or a loop trip
   count. Returns the kernel arg index that holds the extent.
3. **Eligibility + transpose** (`isTMAEligible`): exactly one contiguous dim,
   TMA-supported dtype, inner box >= 16 bytes, zero OOB fill, outer strides
   provably 16B-aligned (`tt.divisibility`). If the contiguous dim is not the
   tile's innermost (transposed operand), build the descriptor over the contiguous
   axis + emit `tt.trans`.

Then it rewrites each eligible load to `tt.descriptor_load` against a
compiler-synthesized host-side `!tt.tensordesc` argument (tagged `tt.auto_tma`)
and records a recipe in the `ttg.auto_tma_recipes` module attribute for the
launcher (1/n).

## Path

```
make_ttir: tl.load(ptr+offs, mask)
  --> decomposePointer + extent inference + eligibility
  --> tt.descriptor_load %synthesized_desc[tileOffset]
  --> ttg.auto_tma_recipes += {base/shape/stride arg indices, block_shape, dtype}
(then 1/6's launcher builds the CUtensorMap at launch)
```

## Before / after

- **Before**: `tl.load` on sm_90+ lowers to `cp.async` (per-thread staged copy).
- **After**: eligible `tl.load` becomes a real hardware `async_tma_copy`.
  Standalone (non-warp-specialized) this is roughly perf-neutral; the win comes
  once it overlaps with compute under warp specialization (4/6).

## Files

`PromoteLoadToTMA.cpp` (+ design.md), `Passes.td` (register pass), `CMakeLists.txt`
+ `BUCK` (build the .cpp), `triton_nvidia.cc` (Python binding), `nvidia/backend/
compiler.py` (invoke the pass in `make_ttir`), tests.

Reviewed By: htyu

Differential Revision: D110948917


