### PR TITLE
[Triton][auto-TMA][3/N] host-recipe STORE promotion (#1978)

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLoadToTMA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLoadToTMA.cpp
@@ -677,6 +677,44 @@ static bool cmpBoundsDim(arith::CmpIOp cmpOp, const DimInfo &dim, int &argIdx) {
   return true;
 }
 
+// A store mask may be reduced to the descriptor's globalDim bounds ONLY if it
+// is exactly a rectangular per-dim boundary AND_d(offs_d < E_d). Any extra
+// predicate (causal / data-dependent) would make the promoted TMA store write
+// the whole in-bounds box, clobbering elements the original masked off -- a
+// miscompile (unlike loads, where an extra in-bounds read is harmless). Return
+// false if any AND-term of the mask is not a recognized per-dim boundary of
+// some decomp dim.
+static bool storeMaskIsRectangular(Value mask, const DecomposedLoad &decomp) {
+  if (!mask)
+    return true; // no mask -> nothing masked off beyond globalDim
+  SmallVector<Value> terms;
+  std::function<void(Value)> collect = [&](Value v) {
+    if (auto andOp = v.getDefiningOp<arith::AndIOp>()) {
+      collect(andOp.getLhs());
+      collect(andOp.getRhs());
+    } else {
+      terms.push_back(v);
+    }
+  };
+  collect(mask);
+  for (Value t : terms) {
+    Value c = t;
+    if (auto bcast = c.getDefiningOp<tt::BroadcastOp>())
+      c = bcast.getSrc();
+    auto cmpOp = c.getDefiningOp<arith::CmpIOp>();
+    int argIdx = -1;
+    bool matched = false;
+    for (const DimInfo &dim : decomp.dims)
+      if (cmpBoundsDim(cmpOp, dim, argIdx)) {
+        matched = true;
+        break;
+      }
+    if (!matched)
+      return false;
+  }
+  return true;
+}
+
 static int findShapeArgForDim(tt::FuncOp func, Value ownMask,
                               const DimInfo &dim) {
   if (!dim.offset)
@@ -878,6 +916,47 @@ static bool dimStrideIs16BAligned(tt::FuncOp func, const DimInfo &dim,
   return argIs16BAligned(func, dim.strideArgIdx, elemBytes);
 }
 
+// TMA-eligibility for a store's value tensor — mirrors isTMAEligible minus the
+// load-only `other`/OOB-fill check (TMA store bounds via the descriptor's
+// globalDim, so a masked store maps to a bounded TMA copy).
+static bool isTMAEligibleStore(tt::StoreOp storeOp,
+                               const DecomposedLoad &decomp) {
+  auto valTy = dyn_cast<RankedTensorType>(storeOp.getValue().getType());
+  if (!valTy)
+    return false;
+  // Shared eligibility core (dtype, rank, single contiguous dim, inner box a
+  // 16B multiple, every box dim <= 256). The store drops only the load's OOB
+  // `other`-fill check; the caller additionally requires the store mask to be a
+  // pure rectangular boundary (storeMaskIsRectangular) before reducing it to
+  // the descriptor's globalDim bounds, and verifies base-ptr / stride 16B
+  // alignment.
+  return isTMAEligibleCommon(valTy.getElementType(), decomp);
+}
+
+// Store promotion is WS-gated: the TMA store stages the value reg->smem then
+// bulk-copies smem->global, which only pays off when overlapped with compute in
+// a separate epilogue partition under warp specialization (standalone it just
+// adds a round-trip).
+//
+// IR shape assumed: at the point this pass runs (TTIR, before WS lowering) a
+// warp-specialized loop is an `scf.for` carrying the `tt.warp_specialize` unit
+// attribute, set by `tl.range(warp_specialize=True)`. This is deliberately a
+// narrow structural check -- if a future pipeline represents WS differently (a
+// different op, or the attr on a non-ForOp construct) this returns false and
+// store promotion is simply skipped (a missed optimization, never a
+// miscompile). Broaden the walk here if/when such a representation is added.
+static bool kernelIsWarpSpecialized(tt::FuncOp func) {
+  bool ws = false;
+  func.walk([&](scf::ForOp forOp) {
+    if (forOp->hasAttr("tt.warp_specialize")) {
+      ws = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return ws;
+}
+
 struct Promotion {
   tt::LoadOp loadOp;
   DecomposedLoad decomp;
@@ -885,6 +964,12 @@ struct Promotion {
   // Logical-tile -> descriptor-memory dim order (the single contiguous dim is
   // moved last). Identity when the contiguous dim is already innermost.
   SmallVector<int> perm;
+};
+
+struct StorePromotion {
+  tt::StoreOp storeOp;
+  DecomposedLoad decomp;
+  SmallVector<int> shapeArgIndices;
 };
 
 class TritonNvidiaGPUPromoteLoadToTMAPass
@@ -986,7 +1071,79 @@ public:
       promotions.push_back(std::move(p));
     });
 
-    if (promotions.empty())
+    // Phase 1b: collect eligible stores, WS-gated (TMA store only pays off
+    // under warp specialization). Only promote stores whose contiguous dim is
+    // already innermost (the standard row-major C[M,N] output); a transposed
+    // store would need the value transposed before descriptor_store -- skipped
+    // for now.
+    SmallVector<StorePromotion> storePromotions;
+    if (kernelIsWarpSpecialized(kernelFunc)) {
+      kernelFunc.walk([&](tt::StoreOp storeOp) {
+        DecomposedLoad decomp = decomposePointer(storeOp.getPtr());
+        if (!decomp.valid || !isTMAEligibleStore(storeOp, decomp))
+          return;
+        int rank = decomp.dims.size();
+        // contiguous dim must already be innermost (identity perm).
+        if (decomp.dims[rank - 1].strideArgIdx >= 0)
+          return;
+        // Reject any loop-advanced (pointer-increment) dim. Phase 2b builds the
+        // store index directly from dim.offset and -- unlike the load rewrite
+        // -- does NOT reconstruct loopIV * perIterElems, so a loop-advanced dim
+        // would emit a wrong per-iteration index. This is also why the Phase 1b
+        // extent search below omits the findShapeArgForLoopDim fallback that
+        // Phase 1 uses: a loop-advanced dim never survives to need it. In
+        // practice the output store is the row-major C tile, not a
+        // pointer-increment operand, so this excludes nothing real.
+        bool loopAdvanced = false;
+        for (int d = 0; d < rank; d++)
+          if (decomp.dims[d].loopAdvanced)
+            loopAdvanced = true;
+        if (loopAdvanced)
+          return;
+        // static_cast<unsigned>: dodge GCC 13 -Wstringop-overflow false
+        // positive.
+        SmallVector<int> shapeArgs(static_cast<unsigned>(rank), -1);
+        for (int d = 0; d < rank; d++) {
+          const DimInfo &dim = decomp.dims[d];
+          int s = dim.shapeArgIdx;
+          if (s < 0)
+            s = findShapeArgForDim(kernelFunc, storeOp.getMask(), dim);
+          if (s < 0)
+            s = findShapeArgFromTileBound(kernelFunc, dim);
+          shapeArgs[d] = s;
+        }
+        bool ok = true;
+        for (int d = 0; d < rank; d++)
+          if (shapeArgs[d] < 0)
+            ok = false;
+        if (!ok)
+          return;
+        int elemBytes = cast<RankedTensorType>(storeOp.getValue().getType())
+                            .getElementType()
+                            .getIntOrFloatBitWidth() /
+                        8;
+        for (int d = 0; d < rank; d++)
+          if (!dimStrideIs16BAligned(kernelFunc, decomp.dims[d], elemBytes))
+            return;
+        // TMA requires a 16B-aligned global base address (mirrors the load path
+        // and the outer-stride check above).
+        if (!argIs16BAligned(kernelFunc, decomp.basePtrArgIndex, elemBytes))
+          return;
+        // Only a provably rectangular store mask (AND_d(offs_d < E_d)) may be
+        // reduced to the descriptor's globalDim bounds. An extra predicate
+        // would make the TMA store write elements the original masked off ->
+        // clobber.
+        if (!storeMaskIsRectangular(storeOp.getMask(), decomp))
+          return;
+        StorePromotion p;
+        p.storeOp = storeOp;
+        p.decomp = decomp;
+        p.shapeArgIndices = shapeArgs;
+        storePromotions.push_back(std::move(p));
+      });
+    }
+
+    if (promotions.empty() && storePromotions.empty())
       return;
 
     // Phase 2: rewrite each eligible load into a HOST-side TMA descriptor
@@ -1123,6 +1280,88 @@ public:
       SmallVector<Attribute> shapeIdx, strideIdx, blk;
       for (int i = 0; i < rank; i++) {
         int d = promo.perm[i];
+        shapeIdx.push_back(i32Attr(promo.shapeArgIndices[d]));
+        strideIdx.push_back(i32Attr(promo.decomp.dims[d].strideArgIdx));
+        blk.push_back(i32Attr((int)promo.decomp.dims[d].blockSize));
+      }
+      int tmaDtype = getTMADataType(elemTy).value();
+      int elemBytes = elemTy.getIntOrFloatBitWidth() / 8;
+      SmallVector<NamedAttribute> fields = {
+          b.getNamedAttr("desc_arg_index", i32Attr((int)descArgIdx)),
+          b.getNamedAttr("base_ptr_arg_index",
+                         i32Attr(promo.decomp.basePtrArgIndex)),
+          b.getNamedAttr("shape_arg_indices", b.getArrayAttr(shapeIdx)),
+          b.getNamedAttr("stride_arg_indices", b.getArrayAttr(strideIdx)),
+          b.getNamedAttr("block_shape", b.getArrayAttr(blk)),
+          b.getNamedAttr("elem_type", i32Attr(tmaDtype)),
+          b.getNamedAttr("elem_size", i32Attr(elemBytes)),
+          b.getNamedAttr("fp4_padded", i32Attr(0)),
+          b.getNamedAttr("fill_mode", i32Attr(0)),
+      };
+      recipeAttrs.push_back(b.getDictionaryAttr(fields));
+    }
+    // Phase 2b: rewrite eligible stores into descriptor_store against a
+    // synthesized host-side descriptor (symmetric to loads; the
+    // descriptor_store TTGIR lowering creates the reg->smem staging +
+    // async_tma_copy_local_to_global).
+    for (auto &promo : storePromotions) {
+      tt::StoreOp storeOp = promo.storeOp;
+      int rank = promo.decomp.dims.size();
+      Value value = storeOp.getValue();
+      auto valTy = cast<RankedTensorType>(value.getType());
+      Type elemTy = valTy.getElementType();
+      Location loc = storeOp.getLoc();
+
+      auto descTy = tt::TensorDescType::get(ctx, valTy);
+      unsigned descArgIdx = kernelFunc.getNumArguments();
+      auto argAttrs =
+          b.getDictionaryAttr({b.getNamedAttr("tt.auto_tma", b.getUnitAttr())});
+      LogicalResult inserted =
+          kernelFunc.insertArgument(descArgIdx, descTy, argAttrs, loc);
+      assert(succeeded(inserted) &&
+             "failed to insert TMA descriptor kernel argument");
+      (void)inserted;
+      Value descArg = kernelFunc.getArgument(descArgIdx);
+
+      builder.setInsertionPoint(storeOp);
+      Type i32 = builder.getI32Type();
+      // Same width handling as the load path's toIntWidth: descriptor_store
+      // indices must be i32, but a tile offset may be index / i16 / i64 / etc.
+      // depending on how the kernel computed it. Sign-extend or truncate as
+      // needed; unexpected non-integer types fall through to the op verifier.
+      auto toI32 = [&](Value v) -> Value {
+        Type ty = v.getType();
+        if (ty == i32)
+          return v;
+        if (ty.isIndex())
+          return arith::IndexCastOp::create(builder, loc, i32, v);
+        if (auto it = dyn_cast<IntegerType>(ty)) {
+          if (it.getWidth() > 32)
+            return arith::TruncIOp::create(builder, loc, i32, v);
+          return arith::ExtSIOp::create(builder, loc, i32, v);
+        }
+        return v;
+      };
+      SmallVector<Value> indices;
+      for (int d = 0; d < rank; d++) {
+        const DimInfo &dim = promo.decomp.dims[d];
+        if (!dim.offset) {
+          // Bare make_range with no tile offset (e.g. `arange % M` or a
+          // select-clamp that peels to a bare range): the tile starts at 0.
+          // Phase 1b can accept such a dim via shapeArgIdx alone, so mirror the
+          // load path (Phase 2) here instead of calling toI32 on a null offset.
+          indices.push_back(arith::ConstantOp::create(
+              builder, loc, builder.getI32IntegerAttr(0)));
+        } else {
+          indices.push_back(toI32(dim.offset));
+        }
+      }
+
+      tt::DescriptorStoreOp::create(builder, loc, descArg, value, indices);
+      storeOp.erase();
+
+      SmallVector<Attribute> shapeIdx, strideIdx, blk;
+      for (int d = 0; d < rank; d++) {
         shapeIdx.push_back(i32Attr(promo.shapeArgIndices[d]));
         strideIdx.push_back(i32Attr(promo.decomp.dims[d].strideArgIdx));
         blk.push_back(i32Attr((int)promo.decomp.dims[d].blockSize));

--- a/python/test/unit/runtime/test_promote_load_to_tma.py
+++ b/python/test/unit/runtime/test_promote_load_to_tma.py
@@ -224,3 +224,95 @@ def test_auto_tma_mixed_promoted_and_oversize_load():
     assert k.asm["ttir"].count("tt.descriptor_load") == 1, (
         "exactly the BLOCK_A=256 load must be auto-TMA promoted; the BLOCK_B=512 "
         "load exceeds the box cap and must stay an ordinary load")
+
+
+# Store promotion is WS-gated (see PromoteLoadToTMA.cpp): a tl.range with
+# warp_specialize=True carries the tt.warp_specialize attr, which is what
+# isTMAEligibleStore keys off. This kernel makes the store's contiguous box dim
+# (BLOCK_N) the thing under test.
+@triton.jit
+def _ws_scale_store(x_ptr, o_ptr, M, N, stride_m, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, NUM_SMS: tl.constexpr):
+    start_pid = tl.program_id(0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    num_tiles = num_pid_m * num_pid_n
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, warp_specialize=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+        x = tl.load(x_ptr + offs_m[:, None] * stride_m + offs_n[None, :], mask=mask, other=0.0)
+        tl.store(o_ptr + offs_m[:, None] * stride_m + offs_n[None, :], x * 2.0, mask=mask)
+
+
+@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
+def test_auto_tma_store_block_over_256_not_promoted():
+    # Symmetric to the load check, for the STORE path. cuTensorMapEncodeTiled
+    # caps every box dim at 256, and the host store recipe builds the CUtensorMap
+    # with box_dim == block_shape (launch.h does not clamp/decompose). So a store
+    # whose contiguous box dim (BLOCK_N) is > 256 must NOT be promoted to a
+    # descriptor_store -- otherwise it would fail encode at launch. Unlike a
+    # dp-halved outer dim, BLOCK_N is not halved by data partitioning, so 512
+    # would survive to the descriptor. It must stay an ordinary store and still
+    # compute the right result.
+    M, N = 128, 512
+    BLOCK_M, BLOCK_N = 64, 512  # 512 > 256 element box cap, on the store's contiguous dim
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    x = torch.randn((M, N), device="cuda", dtype=torch.float16)
+    o = torch.empty((M, N), device="cuda", dtype=torch.float16)
+    grid = (min(NUM_SMS, triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)), )
+    k = _ws_scale_store[grid](x, o, M, N, x.stride(0), BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, NUM_SMS=NUM_SMS, num_warps=4)
+    torch.testing.assert_close(o, x * 2.0, atol=1e-2, rtol=1e-2)
+    assert "tt.descriptor_store" not in k.asm["ttir"], (
+        "BLOCK_N>256 exceeds the TMA box limit and must not be auto-TMA store-promoted")
+
+
+# A store whose mask carries an extra (non-rectangular) predicate on top of the
+# per-dim boundary. Store promotion may only reduce a mask to the descriptor's
+# globalDim bounds when the mask is exactly AND_d(offs_d < E_d); an extra term
+# would make the TMA store write elements the original masked off.
+@triton.jit
+def _ws_extra_pred_store(x_ptr, o_ptr, M, N, stride_m, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+                         NUM_SMS: tl.constexpr):
+    start_pid = tl.program_id(0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    num_tiles = num_pid_m * num_pid_n
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, warp_specialize=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        rect = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+        # other=1.0 (non-zero) keeps this load ineligible for auto-TMA, so the
+        # kernel has no promoted TMA load -- isolates the store path and avoids an
+        # unrelated WS partition-scheduler issue with a TMA load in a trivial
+        # elementwise WS loop. rect is fully in-bounds here, so the fill is unused.
+        x = tl.load(x_ptr + offs_m[:, None] * stride_m + offs_n[None, :], mask=rect, other=1.0)
+        # extra predicate beyond the rectangular boundary: skip column 0.
+        mask = rect & (offs_n[None, :] > 0)
+        tl.store(o_ptr + offs_m[:, None] * stride_m + offs_n[None, :], x * 2.0, mask=mask)
+
+
+@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
+def test_auto_tma_store_nonrectangular_mask_not_promoted():
+    # A store whose mask is not a pure rectangular boundary (here: an extra
+    # skip-column-0 predicate) must NOT be promoted to a descriptor_store: the TMA
+    # store bounds only via globalDim, so it would write the whole in-bounds box
+    # and clobber the elements the extra predicate masked off (a miscompile). It
+    # must stay an ordinary masked store and leave the masked-off elements
+    # untouched.
+    M, N = 128, 128
+    BLOCK_M, BLOCK_N = 64, 128  # <=256 so the box guard is not what rejects it; single n-tile
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    x = torch.randn((M, N), device="cuda", dtype=torch.float16)
+    o = torch.zeros((M, N), device="cuda", dtype=torch.float16)
+    grid = (min(NUM_SMS, triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)), )
+    k = _ws_extra_pred_store[grid](x, o, M, N, x.stride(0), BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, NUM_SMS=NUM_SMS,
+                                   num_warps=4)
+    assert "tt.descriptor_store" not in k.asm["ttir"], (
+        "a non-rectangular store mask must not be auto-TMA store-promoted")
+    cols = torch.arange(N, device="cuda")[None, :]
+    ref = torch.where(cols > 0, x * 2.0, torch.zeros_like(x))
+    torch.testing.assert_close(o, ref, atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
Summary:

## Background

2/6 taught `PromoteLoadToTMA` to promote eligible `tl.load` into a host-recipe
`tt.descriptor_load`. TMA can also accelerate the *output*: a `tl.store` of a
block tile can become a `tt.descriptor_store` (lowered to
`async_tma_copy_local_to_global`). This diff adds that, symmetric to the load path.

## Why store promotion is warp-specialization-gated

A TMA store first stages the value registers -> shared memory, then bulk-copies
shared -> global. That round-trip only pays off when it is overlapped with compute
in a **separate epilogue partition under warp specialization** (WS). Standalone it
just adds latency. So store promotion only fires when the kernel is
warp-specialized (`kernelIsWarpSpecialized`: a `tt.warp_specialize` loop attr is
present).
## What this diff does

Adds to `PromoteLoadToTMA.cpp`:

- `isTMAEligibleStore` — like the load eligibility check minus the OOB-fill test
  (a masked store maps to a bounded TMA copy via the descriptor's global dims).
  It also applies the same `blockDimsWithinTMABox` <=256 box guard as the load
  path (see below).
- **Phase 1b** (collect): WS-gated; only stores whose contiguous dim is already
  innermost (row-major `C[M,N]`; a transposed store would need the value
  transposed first — skipped).
- **Phase 2b** (rewrite): `tt.store` -> `tt.descriptor_store` against a synthesized
  host-side descriptor + a recipe (same recipe machinery as loads, 1/n).

## Box-size legality (addresses review on 2/N)

`cuTensorMapEncodeTiled` caps every box (block) dim at [1, 256] elements, and the
host recipe path builds the `CUtensorMap` with `box_dim == block_shape` (launch.h
does NOT clamp / multi-copy-decompose the box, unlike the device
`AsyncTMACopyGlobalToLocal` lowering). 2/N added `blockDimsWithinTMABox` to the
load eligibility check; this diff mirrors it in `isTMAEligibleStore` so an oversize
store tile (e.g. `BLOCK_N=512`, which data partitioning does NOT halve on the N
dim) stays an ordinary store instead of being promoted into a descriptor that
would fail encode at launch. Both directions are conservative (checked pre-WS on
the un-halved tile) — correct, occasionally leaving a would-be-encodable tile
unaccelerated.

## Path

```
tl.store(ptr+offs, val, mask)   [only if kernel is warp-specialized]
  --> tt.descriptor_store %synthesized_desc[tileOffset], val
  --> ttg.auto_tma_recipes += {...}   (launcher builds the CUtensorMap, 1/n)
```

## Before / after

- **Before**: the output `tl.store` lowers to plain global stores.
- **After**: under WS, the output store becomes a real `async_tma_copy_local_to_global`
  that the epilogue partition overlaps with the next tile's compute.

## Note on verification

The host-store *promotion* path is WS-gated, so its positive (numerics) test lives
in 4/6 (the GEMM+WS+dp C-output store promotes). The box-legality guard added here
has a negative test in this diff (`test_auto_tma_store_block_over_256_not_promoted`:
a WS `BLOCK_N=512` store stays a plain store and still computes correctly).

Reviewed By: htyu

Differential Revision: D110948919


