### PR TITLE
Add auto-bisection + external-dep triage to nightly issue-filing

### DIFF
--- a/.github/scripts/bisect_failure.sh
+++ b/.github/scripts/bisect_failure.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# One `git bisect run` step for a nightly regression: build Triton at the
+# currently-checked-out commit and run the failing test's repro command.
+#
+# Exit-code contract expected by `git bisect run`:
+#   0   -> commit is GOOD (repro passed)
+#   1   -> commit is BAD  (repro failed)
+#   125 -> SKIP this commit (could not build it; do not blame it)
+#
+# Required env:
+#   BISECT_REPRO   the reproduce command to run (e.g. "python -m pytest a/b.py::t -v")
+# Optional env:
+#   BISECT_MODE    "gpu" (default) builds via the tritonbench install helper;
+#                  "lit" builds triton-opt via cmake/ninja for LIT repros.
+#   SETUP_SCRIPT   conda/env activation script for GPU runners
+#                  (default: /workspace/setup_instance.sh)
+set -uo pipefail
+
+MODE="${BISECT_MODE:-gpu}"
+REPRO="${BISECT_REPRO:?BISECT_REPRO (repro command) is required}"
+SETUP_SCRIPT="${SETUP_SCRIPT:-/workspace/setup_instance.sh}"
+
+echo "::group::bisect step $(git rev-parse --short HEAD) — build (mode=$MODE)"
+# Each bisect checkout can move submodule pointers; resync before building.
+git submodule update --init --recursive || true
+
+build_ok=0
+if [[ "$MODE" == "lit" ]]; then
+  # Assumes an llvm-install/ tree is already present on the runner (as in
+  # compiler.yml). Rebuilds only the LIT tooling target.
+  python3 -m pip install -q cmake ninja lit || true
+  LLVM="${GITHUB_WORKSPACE:-$PWD}/llvm-install"
+  if cmake -G Ninja -B build \
+        -DTRITON_CACHE_PATH="$HOME/.triton" \
+        -DLLVM_INCLUDE_DIRS="$LLVM/include" \
+        -DLLVM_LIBRARY_DIR="$LLVM/lib" \
+        -DLLVM_SYSPATH="$LLVM" \
+        -DTRITON_CODEGEN_BACKENDS="nvidia;amd" \
+        -DTRITON_BUILD_UT=OFF \
+        -DLLVM_EXTERNAL_LIT="$(which lit)" . \
+     && ninja -C build check-triton-lit-tests-build 2>/dev/null; then
+    build_ok=1
+  fi
+else
+  # GPU path: mirror the nightly "Compile Triton" step.
+  # shellcheck disable=SC1090
+  { . "$SETUP_SCRIPT" \
+      && . /workspace/tritonbench/.ci/triton/triton_install_utils.sh \
+      && install_triton "$PWD"; } && build_ok=1
+fi
+echo "::endgroup::"
+
+if [[ "$build_ok" -ne 1 ]]; then
+  echo "build failed at $(git rev-parse --short HEAD) -> SKIP (125)"
+  exit 125
+fi
+
+echo "::group::bisect step $(git rev-parse --short HEAD) — repro"
+if [[ "$MODE" == "gpu" ]]; then
+  # shellcheck disable=SC1090
+  . "$SETUP_SCRIPT" || true
+fi
+set -x
+eval "$REPRO"
+rc=$?
+set +x
+echo "::endgroup::"
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "repro passed -> GOOD (0)"
+  exit 0
+fi
+echo "repro failed (rc=$rc) -> BAD (1)"
+exit 1

--- a/.github/scripts/classify_failure.py
+++ b/.github/scripts/classify_failure.py
@@ -22,14 +22,11 @@ import re
 # Patterns run case-insensitively against the failure summary (first error line).
 _SIGNATURES = [
     # --- GPU / driver / runner-hardware infra ---
-    ("gpu-infra", "GPU busy or unavailable (runner infra)",
-     r"all CUDA-capable devices are busy or unavailable"),
+    ("gpu-infra", "GPU busy or unavailable (runner infra)", r"all CUDA-capable devices are busy or unavailable"),
     ("gpu-infra", "No CUDA-capable device on the runner (runner infra)",
      r"no CUDA-capable device (is|are) detected|No CUDA GPUs are available"),
-    ("gpu-infra", "CUDA driver too old for the toolkit (runner infra)",
-     r"CUDA driver version is insufficient"),
-    ("gpu-infra", "GPU/HIP device error (runner infra)",
-     r"HIP error: (invalid device|no ROCm-capable device)"),
+    ("gpu-infra", "CUDA driver too old for the toolkit (runner infra)", r"CUDA driver version is insufficient"),
+    ("gpu-infra", "GPU/HIP device error (runner infra)", r"HIP error: (invalid device|no ROCm-capable device)"),
     ("gpu-infra", "NVML/driver-library mismatch (runner infra)",
      r"Failed to initialize NVML|Driver/library version mismatch"),
 
@@ -53,8 +50,7 @@ _SIGNATURES = [
      r"RPC failed; curl|early EOF"),
 
     # --- runner disk / OS ---
-    ("runner", "Runner out of disk space (runner infra)",
-     r"No space left on device"),
+    ("runner", "Runner out of disk space (runner infra)", r"No space left on device"),
     ("runner", "Runner out of host memory / OOM-killed (runner infra)",
      r"Cannot allocate memory|Out of memory: Killed process|oom-kill"),
 ]

--- a/.github/scripts/classify_failure.py
+++ b/.github/scripts/classify_failure.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Classify a nightly failure summary as an external-dependency error or not.
+
+Nightly issue-filing runs auto-bisection to blame the PR that introduced a
+regression. That only makes sense when the failure is caused by a code change in
+*this* repo. Failures caused by the environment -- a busy/unhealthy GPU, a driver
+mismatch, a broken LLVM/toolchain download, a network/proxy hiccup, a full disk --
+are NOT anyone's PR, so we skip bisection and annotate the issue instead.
+
+The classifier is intentionally conservative: it only flags a failure as external
+when a known infra signature matches, and it explicitly does NOT flag
+compiler/runtime resource errors (e.g. ``OutOfResources: shared memory``) or
+assertion failures, which are real regressions that bisection should chase.
+
+Public API:
+    classify(summary) -> (is_external: bool, reason: str)
+"""
+
+import re
+
+# Ordered (category, human-reason, compiled-pattern) signatures. First match wins.
+# Patterns run case-insensitively against the failure summary (first error line).
+_SIGNATURES = [
+    # --- GPU / driver / runner-hardware infra ---
+    ("gpu-infra", "GPU busy or unavailable (runner infra)",
+     r"all CUDA-capable devices are busy or unavailable"),
+    ("gpu-infra", "No CUDA-capable device on the runner (runner infra)",
+     r"no CUDA-capable device (is|are) detected|No CUDA GPUs are available"),
+    ("gpu-infra", "CUDA driver too old for the toolkit (runner infra)",
+     r"CUDA driver version is insufficient"),
+    ("gpu-infra", "GPU/HIP device error (runner infra)",
+     r"HIP error: (invalid device|no ROCm-capable device)"),
+    ("gpu-infra", "NVML/driver-library mismatch (runner infra)",
+     r"Failed to initialize NVML|Driver/library version mismatch"),
+
+    # --- toolchain / dependency build & download ---
+    ("toolchain", "LLVM build/download failed (external toolchain)",
+     r"llvm.*(download|build) failed|Failed to download LLVM|could not.*llvm-install"),
+    ("toolchain", "ptxas/toolchain binary error (external toolchain)",
+     r"ptxas.*(not found|command not found|No such file)"),
+
+    # --- package / network / proxy ---
+    ("network", "Proxy authentication/blocked (network infra)",
+     r"407 Proxy Authentication Required|\b403 Forbidden\b.*proxy|fwdproxy"),
+    ("network", "DNS/connection failure fetching a dependency (network infra)",
+     r"Could not resolve host|Temporary failure in name resolution|"
+     r"Connection timed out|Failed to establish a new connection"),
+    ("network", "pip/uv/conda could not install a dependency (network infra)",
+     r"(pip|uv|conda).*(Could not find a version|No matching distribution|"
+     r"ResolutionImpossible|HTTPError|Read timed out)"),
+    ("network", "git clone/fetch of a dependency failed (network infra)",
+     r"fatal: unable to access|fatal: could not read from remote|"
+     r"RPC failed; curl|early EOF"),
+
+    # --- runner disk / OS ---
+    ("runner", "Runner out of disk space (runner infra)",
+     r"No space left on device"),
+    ("runner", "Runner out of host memory / OOM-killed (runner infra)",
+     r"Cannot allocate memory|Out of memory: Killed process|oom-kill"),
+]
+
+_COMPILED = [(cat, reason, re.compile(pat, re.IGNORECASE)) for cat, reason, pat in _SIGNATURES]
+
+# Signatures that look infra-ish but are REAL regressions bisection must chase.
+# If any of these match, we never classify as external, even if a broad infra
+# pattern above would otherwise fire.
+_NOT_EXTERNAL = re.compile(
+    r"OutOfResources|shared memory|Required:\s*\d+|"
+    r"AssertionError|assert_close|Tensor-likes are not close|"
+    r"failed to legalize|\berror: |LLVM ERROR",
+    re.IGNORECASE,
+)
+
+
+def classify(summary):
+    """Return (is_external, reason) for a failure summary line.
+
+    A non-external failure returns (False, "").
+    """
+    text = (summary or "").strip()
+    if not text:
+        return False, ""
+    if _NOT_EXTERNAL.search(text):
+        # A concrete correctness/compiler error dominates: chase it, don't excuse it.
+        return False, ""
+    for _cat, reason, pat in _COMPILED:
+        if pat.search(text):
+            return True, reason
+    return False, ""
+
+
+if __name__ == "__main__":
+    import sys
+    is_ext, why = classify(" ".join(sys.argv[1:]))
+    print(f"external={is_ext} reason={why}")

--- a/.github/scripts/compute_suspects.py
+++ b/.github/scripts/compute_suspects.py
@@ -41,8 +41,7 @@ def parse_commits(log_output):
         if not line.strip():
             continue
         sha, _, subject = line.partition("\t")
-        commits.append({"sha": sha.strip(), "subject": subject.strip(),
-                        "pr": extract_pr(subject)})
+        commits.append({"sha": sha.strip(), "subject": subject.strip(), "pr": extract_pr(subject)})
     return commits
 
 
@@ -120,8 +119,8 @@ def render_markdown(ranked, good_sha, bad_sha, test_dir, limit=10):
         return ("_No merged PRs found in range "
                 f"`{good_sha[:9]}..{bad_sha[:9]}` — suspect list unavailable._")
     lines = [
-        f"**Suspected PRs** (range `{good_sha[:9]}..{bad_sha[:9]}`"
-        + (f", ranked by overlap with `{test_dir}`" if test_dir else ", newest first") + "):",
+        f"**Suspected PRs** (range `{good_sha[:9]}..{bad_sha[:9]}`" +
+        (f", ranked by overlap with `{test_dir}`" if test_dir else ", newest first") + "):",
         "",
         "| Rank | PR | Overlap | Title |",
         "| --- | --- | --- | --- |",

--- a/.github/scripts/compute_suspects.py
+++ b/.github/scripts/compute_suspects.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Compute a ranked list of suspect PRs for a nightly regression.
+
+Given the last-known-green nightly SHA and the failing SHA, this walks the commit
+range ``good..bad``, extracts the squash-merge PR number from each commit subject
+(``... (#1234)``), and ranks the PRs by how much their changed files overlap the
+failing test's subsystem. The result is a Markdown block injected into the
+auto-filed nightly issue as a cheap, immediate blame hint (the async git-bisect
+job later confirms the single culprit).
+
+The git-touching parts are isolated in thin wrappers so the ranking logic is unit
+testable without a repo. ``main`` shells out to ``git``; the pure helpers accept
+already-collected data.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+# Squash-merge subjects end with the PR number, e.g. "Fix foo (#1972)".
+_PR_RE = re.compile(r"\(#(\d+)\)\s*$")
+
+
+def extract_pr(subject):
+    """Return the trailing PR number in a commit subject, or None."""
+    m = _PR_RE.search(subject or "")
+    return int(m.group(1)) if m else None
+
+
+def parse_commits(log_output):
+    """Parse ``git log --format=%H%x09%s`` output into ordered commit dicts.
+
+    Output order is preserved (newest first, as git emits it). Each dict has
+    ``sha``, ``subject`` and ``pr`` (int or None).
+    """
+    commits = []
+    for line in (log_output or "").splitlines():
+        line = line.rstrip("\n")
+        if not line.strip():
+            continue
+        sha, _, subject = line.partition("\t")
+        commits.append({"sha": sha.strip(), "subject": subject.strip(),
+                        "pr": extract_pr(subject)})
+    return commits
+
+
+def test_subsystem_dir(normalized_failure_id):
+    """Best-effort source directory for a failing test identity, or None.
+
+    - pytest path id ``a/b/test_x.py::test_y``       -> ``a/b``
+    - pytest dotted classname ``a.b.test_x::test_y`` -> ``a/b``  (JUnit classname form)
+    - LIT id ``TRITON :: Conversion/foo.mlir``       -> ``test/Conversion``
+    - job-level bucket (no path)                     -> None
+    """
+    nid = (normalized_failure_id or "").strip()
+    if not nid or "::" not in nid:
+        return None
+    left, right = (s.strip() for s in nid.split("::", 1))
+    # LIT: "TRITON :: <relpath-under-test/>"
+    if left == "TRITON" or right.endswith((".mlir", ".ll", ".td")):
+        rel_dir = os.path.dirname(right)
+        return ("test/" + rel_dir).rstrip("/") if rel_dir else "test"
+    # pytest, path form: "a/b/test_x.py"
+    if left.endswith(".py"):
+        return os.path.dirname(left) or None
+    # pytest, dotted classname form: "a.b.test_x" -> "a/b/test_x.py" -> "a/b"
+    if "." in left:
+        return os.path.dirname(left.replace(".", "/") + ".py") or None
+    return None
+
+
+def _overlap(path, test_dir):
+    """Shared leading-directory-component count between a file and the test dir."""
+    if not test_dir:
+        return 0
+    a = os.path.dirname(path).split("/")
+    b = test_dir.split("/")
+    n = 0
+    for x, y in zip(a, b):
+        if x != y or x == "":
+            break
+        n += 1
+    return n
+
+
+def rank_prs(commits, files_by_sha, test_dir):
+    """Rank unique PRs by max file-path overlap with the failing test's dir.
+
+    Ties (and the no-test-dir case) keep git order (most recent first). Returns a
+    list of dicts: ``pr``, ``subject``, ``score``, ``top_path``.
+    """
+    best = {}
+    order = []
+    for c in commits:
+        pr = c["pr"]
+        if pr is None:
+            continue
+        files = files_by_sha.get(c["sha"], [])
+        score, top = 0, ""
+        for f in files:
+            o = _overlap(f, test_dir)
+            if o > score:
+                score, top = o, f
+        if pr not in best:
+            best[pr] = {"pr": pr, "subject": c["subject"], "score": score, "top_path": top}
+            order.append(pr)
+        elif score > best[pr]["score"]:
+            best[pr].update(score=score, top_path=top)
+    ranked = [best[pr] for pr in order]
+    # Stable sort by score desc; equal scores retain git (recency) order.
+    ranked.sort(key=lambda d: d["score"], reverse=True)
+    return ranked
+
+
+def render_markdown(ranked, good_sha, bad_sha, test_dir, limit=10):
+    """Render the ranked suspect list as a Markdown table."""
+    if not ranked:
+        return ("_No merged PRs found in range "
+                f"`{good_sha[:9]}..{bad_sha[:9]}` — suspect list unavailable._")
+    lines = [
+        f"**Suspected PRs** (range `{good_sha[:9]}..{bad_sha[:9]}`"
+        + (f", ranked by overlap with `{test_dir}`" if test_dir else ", newest first") + "):",
+        "",
+        "| Rank | PR | Overlap | Title |",
+        "| --- | --- | --- | --- |",
+    ]
+    for i, d in enumerate(ranked[:limit], 1):
+        overlap = f"`{d['top_path']}`" if d["score"] > 0 else "—"
+        subject = d["subject"].replace("|", "\\|")
+        lines.append(f"| {i} | #{d['pr']} | {overlap} | {subject} |")
+    if len(ranked) > limit:
+        lines.append("")
+        lines.append(f"_…and {len(ranked) - limit} more PR(s) in range._")
+    return "\n".join(lines)
+
+
+# --- git wrappers (not unit-tested; exercised in CI) ---
+def _git(args):
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=False).stdout
+
+
+def collect_range(good_sha, bad_sha):
+    commits = parse_commits(_git(["log", "--format=%H%x09%s", f"{good_sha}..{bad_sha}"]))
+    files_by_sha = {}
+    for c in commits:
+        out = _git(["show", "--no-notes", "--pretty=format:", "--name-only", c["sha"]])
+        files_by_sha[c["sha"]] = [ln.strip() for ln in out.splitlines() if ln.strip()]
+    return commits, files_by_sha
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--good-sha", required=True)
+    ap.add_argument("--bad-sha", required=True)
+    ap.add_argument("--normalized-id", default="")
+    ap.add_argument("--limit", type=int, default=10)
+    args = ap.parse_args()
+
+    if not args.good_sha:
+        print("_No prior green nightly found — suspect list unavailable._")
+        return 0
+    commits, files_by_sha = collect_range(args.good_sha, args.bad_sha)
+    test_dir = test_subsystem_dir(args.normalized_id)
+    ranked = rank_prs(commits, files_by_sha, test_dir)
+    print(render_markdown(ranked, args.good_sha, args.bad_sha, test_dir, args.limit))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/parse_junit_failures.py
+++ b/.github/scripts/parse_junit_failures.py
@@ -25,6 +25,8 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 
+from classify_failure import classify
+
 # Matches a single trailing bracketed parametrization suffix: test_x[a-b] -> test_x
 PARAM_SUFFIX = re.compile(r"\[.*\]$")
 
@@ -100,6 +102,7 @@ def build_items(failures, workflow, job):
     items = []
     for norm in order:
         info = grouped[norm]
+        is_external, reason = classify(info["summary"])
         items.append({
             "normalized_failure_id": norm,
             "raw_failure_ids": "\n".join(info["raw"]),
@@ -109,6 +112,9 @@ def build_items(failures, workflow, job):
             "repro": pytest_repro(norm),
             # Real per-test signal: safe for reconcile to close on recovery.
             "fallback": False,
+            # External-dep failures skip bisection and are annotated instead.
+            "external_dep": is_external,
+            "external_dep_reason": reason,
         })
     return items
 
@@ -117,15 +123,19 @@ def build_missing_junit_item(missing_paths, workflow, job):
     """Build a stable job-level item for pytest failures without JUnit XML."""
     norm = "pytest-junit-missing"
     missing = "\n".join(missing_paths)
+    summary = f"Pytest failed before producing JUnit XML: {', '.join(missing_paths)}"
+    is_external, reason = classify(summary)
     return {
         "normalized_failure_id": norm,
         "raw_failure_ids": missing,
         "issue_title": f"[nightly] {workflow} / {job} / {norm}",
         "job_name": job,
-        "summary": f"Pytest failed before producing JUnit XML: {', '.join(missing_paths)}",
+        "summary": summary,
         "repro": "",
         # Job-level fallback: no per-test signal -> reconcile must not close.
         "fallback": True,
+        "external_dep": is_external,
+        "external_dep_reason": reason,
     }
 
 
@@ -140,6 +150,9 @@ def build_bucket_item(bucket, workflow, job):
         "repro": "",
         # Job-level fallback: no per-test signal -> reconcile must not close.
         "fallback": True,
+        # No parseable summary to classify; treat as a code failure (not external).
+        "external_dep": False,
+        "external_dep_reason": "",
     }
 
 

--- a/.github/scripts/parse_lit_failures.py
+++ b/.github/scripts/parse_lit_failures.py
@@ -20,6 +20,8 @@ import json
 import os
 import re
 
+from classify_failure import classify
+
 # e.g. "FAIL: TRITON :: Conversion/foo.mlir (12 of 345)"
 LIT_LINE = re.compile(r"^(?:FAIL|UNRESOLVED|TIMEOUT|XPASS):\s+(.*?)\s*(?:\(\d+ of \d+\))?\s*$")
 
@@ -57,16 +59,21 @@ def lit_repro(ident, fallback):
 def build_items(ids, workflow, job, fallback):
     items = []
     for ident in ids:
+        summary = f"LIT test failed: {ident}"
+        is_external, reason = classify(summary)
         items.append({
             "normalized_failure_id": ident,
             "raw_failure_ids": ident,
             "issue_title": f"[nightly] {workflow} / {job} / {ident}",
             "job_name": job,
-            "summary": f"LIT test failed: {ident}",
+            "summary": summary,
             "repro": lit_repro(ident, fallback),
             # fallback=True means the bucket identity (no per-test signal), so
             # reconcile must not close per-test issues from this run.
             "fallback": fallback,
+            # External-dep failures skip bisection and are annotated instead.
+            "external_dep": is_external,
+            "external_dep_reason": reason,
         })
     return items
 

--- a/.github/scripts/test_classify_failure.py
+++ b/.github/scripts/test_classify_failure.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Unit tests for classify_failure.classify (stdlib-only; run with pytest)."""
 
 import classify_failure as cf

--- a/.github/scripts/test_classify_failure.py
+++ b/.github/scripts/test_classify_failure.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Unit tests for classify_failure.classify (stdlib-only; run with pytest)."""
+
+import classify_failure as cf
+
+
+def test_gpu_busy_is_external():
+    ext, reason = cf.classify("RuntimeError: all CUDA-capable devices are busy or unavailable")
+    assert ext is True
+    assert "GPU" in reason
+
+
+def test_no_cuda_device_is_external():
+    ext, _ = cf.classify("No CUDA GPUs are available")
+    assert ext is True
+
+
+def test_driver_mismatch_is_external():
+    ext, _ = cf.classify("CUDA driver version is insufficient for CUDA runtime version")
+    assert ext is True
+
+
+def test_network_proxy_is_external():
+    ext, reason = cf.classify("Received HTTP code 407 Proxy Authentication Required from proxy")
+    assert ext is True
+    assert "roxy" in reason
+
+
+def test_llvm_download_is_external():
+    ext, _ = cf.classify("Failed to download LLVM tarball from blob storage")
+    assert ext is True
+
+
+def test_disk_full_is_external():
+    ext, _ = cf.classify("OSError: [Errno 28] No space left on device")
+    assert ext is True
+
+
+def test_out_of_resources_is_not_external():
+    # Compiler resource regression -> must be chased by bisection, not excused.
+    ext, reason = cf.classify("OutOfResources: shared memory, Required: 232712, Hardware limit: 232448")
+    assert ext is False
+    assert reason == ""
+
+
+def test_assertion_is_not_external():
+    ext, _ = cf.classify("AssertionError: Tensor-likes are not close! max abs diff 3.4")
+    assert ext is False
+
+
+def test_not_external_wins_over_infra_lookalike():
+    # Even if an infra-ish word appears, a concrete correctness error dominates.
+    ext, _ = cf.classify("AssertionError: out of memory expectation mismatch in test")
+    assert ext is False
+
+
+def test_empty_summary():
+    assert cf.classify("") == (False, "")
+    assert cf.classify(None) == (False, "")
+
+
+def test_generic_test_failure_is_not_external():
+    ext, _ = cf.classify("ValueError: shapes do not match")
+    assert ext is False

--- a/.github/scripts/test_compute_suspects.py
+++ b/.github/scripts/test_compute_suspects.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Unit tests for compute_suspects pure helpers (stdlib-only; run with pytest)."""
 
 import compute_suspects as cs

--- a/.github/scripts/test_compute_suspects.py
+++ b/.github/scripts/test_compute_suspects.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Unit tests for compute_suspects pure helpers (stdlib-only; run with pytest)."""
+
+import compute_suspects as cs
+
+
+def test_extract_pr():
+    assert cs.extract_pr("Fix 2-CTA TMEM verify crash (#1905)") == 1905
+    assert cs.extract_pr("Add CLC GEMM support (#1882) ") == 1882
+    assert cs.extract_pr("no pr number here") is None
+    assert cs.extract_pr("mentions (#123) mid-line but ends elsewhere") is None
+
+
+def test_parse_commits_preserves_order_and_pr():
+    log = "aaa\tFirst (#10)\nbbb\tSecond change (#11)\nccc\tNo pr\n"
+    commits = cs.parse_commits(log)
+    assert [c["sha"] for c in commits] == ["aaa", "bbb", "ccc"]
+    assert [c["pr"] for c in commits] == [10, 11, None]
+
+
+def test_test_subsystem_dir_pytest():
+    nid = "third_party/tlx/tutorials/testing/test_correctness.py::test_blackwell_fa_ws"
+    assert cs.test_subsystem_dir(nid) == "third_party/tlx/tutorials/testing"
+
+
+def test_test_subsystem_dir_pytest_dotted_classname():
+    # JUnit stores the classname dotted (pytest default), not as a path.
+    nid = "third_party.tlx.tutorials.testing.test_correctness::test_blackwell_fa_ws"
+    assert cs.test_subsystem_dir(nid) == "third_party/tlx/tutorials/testing"
+
+
+def test_test_subsystem_dir_lit():
+    assert cs.test_subsystem_dir("TRITON :: Conversion/foo.mlir") == "test/Conversion"
+
+
+def test_test_subsystem_dir_bucket_is_none():
+    assert cs.test_subsystem_dir("b200-tritonbench") is None
+    assert cs.test_subsystem_dir("") is None
+
+
+def test_rank_prs_orders_by_overlap():
+    commits = [
+        {"sha": "a", "subject": "unrelated (#1)", "pr": 1},
+        {"sha": "b", "subject": "touches the test dir (#2)", "pr": 2},
+        {"sha": "c", "subject": "no pr", "pr": None},
+    ]
+    files_by_sha = {
+        "a": ["docs/readme.md"],
+        "b": ["third_party/tlx/tutorials/testing/test_correctness.py"],
+        "c": ["whatever.py"],
+    }
+    test_dir = "third_party/tlx/tutorials/testing"
+    ranked = cs.rank_prs(commits, files_by_sha, test_dir)
+    assert ranked[0]["pr"] == 2
+    assert ranked[0]["score"] > ranked[1]["score"]
+    assert {r["pr"] for r in ranked} == {1, 2}  # PR-less commit dropped
+
+
+def test_rank_prs_dedupes_pr_keeping_best_score():
+    commits = [
+        {"sha": "a", "subject": "part 1 (#5)", "pr": 5},
+        {"sha": "b", "subject": "part 2 (#5)", "pr": 5},
+    ]
+    files_by_sha = {"a": ["x/y.py"], "b": ["lib/Dialect/TritonGPU/foo.cpp"]}
+    ranked = cs.rank_prs(commits, files_by_sha, "lib/Dialect/TritonGPU")
+    assert len(ranked) == 1
+    assert ranked[0]["pr"] == 5
+    assert ranked[0]["score"] == 3  # from commit b: lib/Dialect/TritonGPU (3 components)
+
+
+def test_rank_prs_no_test_dir_keeps_recency_order():
+    commits = [
+        {"sha": "a", "subject": "newest (#9)", "pr": 9},
+        {"sha": "b", "subject": "older (#8)", "pr": 8},
+    ]
+    ranked = cs.rank_prs(commits, {"a": ["f.py"], "b": ["g.py"]}, None)
+    assert [r["pr"] for r in ranked] == [9, 8]
+
+
+def test_render_markdown_empty():
+    md = cs.render_markdown([], "goodsha123", "badsha456", None)
+    assert "suspect list unavailable" in md
+
+
+def test_render_markdown_table():
+    ranked = [{"pr": 2, "subject": "touches dir", "score": 3, "top_path": "a/b/c.py"}]
+    md = cs.render_markdown(ranked, "goodsha123", "badsha456", "a/b")
+    assert "#2" in md
+    assert "`a/b/c.py`" in md
+    assert "| Rank | PR | Overlap | Title |" in md

--- a/.github/workflows/b200.yml
+++ b/.github/workflows/b200.yml
@@ -65,7 +65,7 @@ jobs:
           # stable logical bucket identity for this job.
           BUCKET="b200-tritonbench"
           TITLE="[nightly] ${GITHUB_WORKFLOW} / b200-meta-triton-test / ${BUCKET}"
-          FAILURES='[{"normalized_failure_id":"'"${BUCKET}"'","raw_failure_ids":"","issue_title":"'"${TITLE}"'","job_name":"b200-meta-triton-test","summary":"TritonBench tests failed on B200 (see run log).","repro":""}]'
+          FAILURES='[{"normalized_failure_id":"'"${BUCKET}"'","raw_failure_ids":"","issue_title":"'"${TITLE}"'","job_name":"b200-meta-triton-test","summary":"TritonBench tests failed on B200 (see run log).","repro":"","external_dep":false,"external_dep_reason":""}]'
           echo "failures=${FAILURES}" >> "$GITHUB_OUTPUT"
 
   b200-tlx-test:
@@ -184,6 +184,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -202,6 +203,9 @@ jobs:
       run_attempt: ${{ github.run_attempt }}
       summary: ${{ matrix.item.summary }}
       repro: ${{ matrix.item.repro }}
+      external_dep: ${{ matrix.item.external_dep }}
+      external_dep_reason: ${{ matrix.item.external_dep_reason }}
+      platform: b200
 
   report-b200-tlx:
     needs: b200-tlx-test
@@ -209,6 +213,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -227,6 +232,9 @@ jobs:
       run_attempt: ${{ github.run_attempt }}
       summary: ${{ matrix.item.summary }}
       repro: ${{ matrix.item.repro }}
+      external_dep: ${{ matrix.item.external_dep }}
+      external_dep_reason: ${{ matrix.item.external_dep_reason }}
+      platform: b200
 
   report-b200-gluon:
     needs: b200-gluon-test
@@ -234,6 +242,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -252,6 +261,9 @@ jobs:
       run_attempt: ${{ github.run_attempt }}
       summary: ${{ matrix.item.summary }}
       repro: ${{ matrix.item.repro }}
+      external_dep: ${{ matrix.item.external_dep }}
+      external_dep_reason: ${{ matrix.item.external_dep_reason }}
+      platform: b200
 
   # ----- Nightly issue reconciliation: close recovered issues (schedule only) -----
   reconcile-b200-tritonbench:

--- a/.github/workflows/bisect-nightly-failure.yml
+++ b/.github/workflows/bisect-nightly-failure.yml
@@ -1,0 +1,222 @@
+name: Bisect Nightly Failure
+
+# Async companion to report-nightly-failure.yml. When a nightly failure issue is
+# labeled `needs-bisect`, this git-bisects the last-green..failing commit range on
+# the matching GPU runner (building + running the failing test's repro at each
+# step), then edits the issue with the confirmed blame commit/PR and @-mentions
+# the PR author. Kept out of the nightly workflow so nightly stays fast; the heavy
+# per-commit rebuild runs here on its own schedule.
+#
+# Metadata (good_sha, bad_sha, platform, repro) is read from the issue body's
+# `<!-- bisect-meta ... -->` block that the reporter embeds.
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Nightly failure issue number to bisect.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  prepare:
+    # Only react to our trigger label (or a manual dispatch).
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'needs-bisect'
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.meta.outputs.ok }}
+      runner: ${{ steps.meta.outputs.runner }}
+      mode: ${{ steps.meta.outputs.mode }}
+      good_sha: ${{ steps.meta.outputs.good_sha }}
+      bad_sha: ${{ steps.meta.outputs.bad_sha }}
+      repro: ${{ steps.meta.outputs.repro }}
+      issue_number: ${{ steps.meta.outputs.issue_number }}
+    steps:
+      - name: Parse bisect metadata from issue
+        id: meta
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const num = context.eventName === "workflow_dispatch"
+              ? Number(${{ toJSON(github.event.inputs.issue_number) }})
+              : context.payload.issue.number;
+            let body = context.payload.issue && context.payload.issue.body;
+            if (!body) {
+              const it = await github.rest.issues.get({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: num });
+              body = it.data.body || "";
+            }
+            const m = body.match(/<!--\s*bisect-meta([\s\S]*?)-->/);
+            const kv = {};
+            if (m) {
+              for (const line of m[1].split("\n")) {
+                const i = line.indexOf("=");
+                if (i > 0) kv[line.slice(0, i).trim()] = line.slice(i + 1).trim();
+              }
+            }
+            // Map platform -> runner label + build mode. GPU platforms only:
+            // compiler LIT bisection (per-commit LLVM+triton rebuild) is not wired.
+            const RUNNERS = {
+              b200:  { runner: "nvidia-dgx-b200",        mode: "gpu" },
+              h100:  { runner: "linux-gcp-h100",         mode: "gpu" },
+              mi350: { runner: "linux-fb-triton-mi350-1", mode: "gpu" },
+            };
+            const r = RUNNERS[kv.platform || ""];
+            const ok = !!(r && kv.good_sha && kv.bad_sha && kv.repro);
+            if (!ok) {
+              core.warning(`Cannot bisect issue #${num}: platform=${kv.platform} `
+                + `good=${kv.good_sha} bad=${kv.bad_sha} repro=${!!kv.repro}`);
+            }
+            core.setOutput("ok", String(ok));
+            core.setOutput("runner", r ? r.runner : "ubuntu-latest");
+            core.setOutput("mode", r ? r.mode : "gpu");
+            core.setOutput("good_sha", kv.good_sha || "");
+            core.setOutput("bad_sha", kv.bad_sha || "");
+            core.setOutput("repro", kv.repro || "");
+            core.setOutput("issue_number", String(num));
+
+  bisect:
+    needs: prepare
+    if: needs.prepare.outputs.ok == 'true'
+    runs-on: ${{ needs.prepare.outputs.runner }}
+    timeout-minutes: 600
+    permissions:
+      contents: read
+    outputs:
+      first_bad_sha: ${{ steps.run.outputs.first_bad_sha }}
+      subject: ${{ steps.run.outputs.subject }}
+    steps:
+      - name: Checkout (full history + submodules)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Run git bisect
+        id: run
+        env:
+          GOOD_SHA: ${{ needs.prepare.outputs.good_sha }}
+          BAD_SHA: ${{ needs.prepare.outputs.bad_sha }}
+          BISECT_REPRO: ${{ needs.prepare.outputs.repro }}
+          BISECT_MODE: ${{ needs.prepare.outputs.mode }}
+        run: |
+          set -x
+          git bisect start "$BAD_SHA" "$GOOD_SHA" --
+          set +e
+          git bisect run bash .github/scripts/bisect_failure.sh | tee /tmp/bisect.out
+          set -e
+          # Only trust a conclusive result: git prints "<sha> is the first bad commit".
+          FIRST_BAD="$(grep -oE '[0-9a-f]{40} is the first bad commit' /tmp/bisect.out | head -1 | cut -d' ' -f1)"
+          git bisect reset || true
+          if [ -z "$FIRST_BAD" ]; then
+            echo "Bisection inconclusive (no first-bad commit)."
+            exit 0
+          fi
+          SUBJECT="$(git show -s --format=%s "$FIRST_BAD")"
+          echo "first_bad_sha=${FIRST_BAD}" >> "$GITHUB_OUTPUT"
+          {
+            echo "subject<<__SUBJ_EOF__"
+            echo "$SUBJECT"
+            echo "__SUBJ_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+  blame:
+    needs: [prepare, bisect]
+    if: always() && needs.prepare.outputs.ok == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Record blame on the issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = Number(${{ toJSON(needs.prepare.outputs.issue_number) }});
+            const firstBad = ${{ toJSON(needs.bisect.outputs.first_bad_sha) }} || "";
+            const subject = ${{ toJSON(needs.bisect.outputs.subject) }} || "";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const owner = context.repo.owner, repo = context.repo.repo;
+
+            const BLAME_START = "<!-- BLAME:START -->";
+            const BLAME_END = "<!-- BLAME:END -->";
+
+            // Resolve blame PR + author (if a first-bad commit was found).
+            let prNum = null, author = null;
+            const m = subject.match(/\(#(\d+)\)\s*$/);
+            if (firstBad && m) {
+              prNum = Number(m[1]);
+              try {
+                const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNum });
+                author = pr.data.user && pr.data.user.login;
+              } catch (e) { core.warning(`Could not fetch PR #${prNum}: ${e}`); }
+            }
+
+            // Build the confirmed/inconclusive blame section.
+            let blame;
+            if (firstBad && prNum) {
+              blame = [
+                BLAME_START,
+                "### 🔎 Blame analysis",
+                `**Blame commit:** \`${firstBad}\` → **#${prNum}** — ${subject.replace(/\|/g, "\\|")}`,
+                "",
+                `Confirmed by \`git bisect\` ([bisect run](${runUrl})).`,
+                BLAME_END,
+              ].join("\n");
+            } else if (firstBad) {
+              blame = [
+                BLAME_START,
+                "### 🔎 Blame analysis",
+                `**Blame commit:** \`${firstBad}\` (no PR number in subject — could not resolve a PR).`,
+                `Found by \`git bisect\` ([bisect run](${runUrl})).`,
+                BLAME_END,
+              ].join("\n");
+            } else {
+              blame = [
+                BLAME_START,
+                "### 🔎 Blame analysis",
+                `**Bisection inconclusive** ([bisect run](${runUrl})) — the failure did not reproduce `,
+                "deterministically across the range, or every candidate commit failed to build. "
+                  + "The suspect list above still applies.",
+                BLAME_END,
+              ].join("\n");
+            }
+
+            // Splice the new blame section into the issue body between markers.
+            const it = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+            let body = it.data.body || "";
+            const s = body.indexOf(BLAME_START), e = body.indexOf(BLAME_END);
+            if (s >= 0 && e > s) {
+              body = body.slice(0, s) + blame + body.slice(e + BLAME_END.length);
+            } else {
+              body = blame + "\n\n" + body;
+            }
+            await github.rest.issues.update({ owner, repo, issue_number: issueNumber, body });
+
+            // Swap the trigger label so we don't re-bisect on the next update.
+            try { await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNumber, name: "needs-bisect" }); } catch (e) {}
+            await github.rest.issues.addLabels({ owner, repo, issue_number: issueNumber,
+              labels: [firstBad && prNum ? "bisected" : "bisect-inconclusive"] });
+
+            // Notify (and assign) the PR author on a confirmed blame.
+            if (firstBad && prNum && author) {
+              const repro = (body.match(/### Reproduce\n```\n([\s\S]*?)\n```/) || [])[1] || "";
+              const lines = [
+                "🔎 **Blame identified by auto-bisection**",
+                "",
+                `@${author} — this nightly failure bisected to your PR **#${prNum}** `
+                  + `(commit \`${firstBad}\`, _${subject.replace(/\|/g, "\\|")}_).`,
+                "",
+                `Confirmed by \`git bisect\` ([bisect run](${runUrl})). Please take a look.`,
+              ];
+              if (repro) lines.push("", "Reproduce:", "```", repro, "```");
+              await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body: lines.join("\n") });
+              try {
+                await github.rest.issues.addAssignees({ owner, repo, issue_number: issueNumber, assignees: [author] });
+              } catch (e) { core.warning(`Could not assign @${author}: ${e}`); }
+            }

--- a/.github/workflows/compiler.yml
+++ b/.github/workflows/compiler.yml
@@ -105,6 +105,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -123,6 +124,11 @@ jobs:
       run_attempt: ${{ github.run_attempt }}
       summary: ${{ matrix.item.summary }}
       repro: ${{ matrix.item.repro }}
+      external_dep: ${{ matrix.item.external_dep }}
+      external_dep_reason: ${{ matrix.item.external_dep_reason }}
+      # platform intentionally empty: compiler LIT gets the suspect list + external-dep
+      # annotation, but not per-commit deep bisection (LLVM+Triton rebuild is too heavy).
+      platform: ''
 
   # ----- Nightly issue reconciliation: close recovered issues (schedule only) -----
   reconcile-compiler-lit:

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -65,7 +65,7 @@ jobs:
           # stable logical bucket identity for this job.
           BUCKET="h100-tritonbench"
           TITLE="[nightly] ${GITHUB_WORKFLOW} / h100-meta-triton-test / ${BUCKET}"
-          FAILURES='[{"normalized_failure_id":"'"${BUCKET}"'","raw_failure_ids":"","issue_title":"'"${TITLE}"'","job_name":"h100-meta-triton-test","summary":"TritonBench tests failed on H100 (see run log).","repro":""}]'
+          FAILURES='[{"normalized_failure_id":"'"${BUCKET}"'","raw_failure_ids":"","issue_title":"'"${TITLE}"'","job_name":"h100-meta-triton-test","summary":"TritonBench tests failed on H100 (see run log).","repro":"","external_dep":false,"external_dep_reason":""}]'
           echo "failures=${FAILURES}" >> "$GITHUB_OUTPUT"
 
   h100-tlx-test:
@@ -133,6 +133,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -151,6 +152,9 @@ jobs:
       run_attempt: ${{ github.run_attempt }}
       summary: ${{ matrix.item.summary }}
       repro: ${{ matrix.item.repro }}
+      external_dep: ${{ matrix.item.external_dep }}
+      external_dep_reason: ${{ matrix.item.external_dep_reason }}
+      platform: h100
 
   report-h100-tlx:
     needs: h100-tlx-test
@@ -158,6 +162,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -176,6 +181,9 @@ jobs:
       run_attempt: ${{ github.run_attempt }}
       summary: ${{ matrix.item.summary }}
       repro: ${{ matrix.item.repro }}
+      external_dep: ${{ matrix.item.external_dep }}
+      external_dep_reason: ${{ matrix.item.external_dep_reason }}
+      platform: h100
 
   # ----- Nightly issue reconciliation: close recovered issues (schedule only) -----
   reconcile-h100-tritonbench:

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -57,7 +57,7 @@ jobs:
           # stable logical bucket identity for this job.
           BUCKET="amd-tritonbench"
           TITLE="[nightly] ${GITHUB_WORKFLOW} / mi350-meta-triton-test / ${BUCKET}"
-          FAILURES='[{"normalized_failure_id":"'"${BUCKET}"'","raw_failure_ids":"","issue_title":"'"${TITLE}"'","job_name":"mi350-meta-triton-test","summary":"TritonBench tests failed on MI350 (see run log).","repro":""}]'
+          FAILURES='[{"normalized_failure_id":"'"${BUCKET}"'","raw_failure_ids":"","issue_title":"'"${TITLE}"'","job_name":"mi350-meta-triton-test","summary":"TritonBench tests failed on MI350 (see run log).","repro":"","external_dep":false,"external_dep_reason":""}]'
           echo "failures=${FAILURES}" >> "$GITHUB_OUTPUT"
 
   mi350-tlx-test:
@@ -187,6 +187,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -205,6 +206,9 @@ jobs:
       run_attempt: ${{ github.run_attempt }}
       summary: ${{ matrix.item.summary }}
       repro: ${{ matrix.item.repro }}
+      external_dep: ${{ matrix.item.external_dep }}
+      external_dep_reason: ${{ matrix.item.external_dep_reason }}
+      platform: mi350
 
   report-mi350-tlx:
     needs: mi350-tlx-test
@@ -212,6 +216,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -230,6 +235,9 @@ jobs:
       run_attempt: ${{ github.run_attempt }}
       summary: ${{ matrix.item.summary }}
       repro: ${{ matrix.item.repro }}
+      external_dep: ${{ matrix.item.external_dep }}
+      external_dep_reason: ${{ matrix.item.external_dep_reason }}
+      platform: mi350
 
   report-mi350-gluon:
     needs: mi350-gluon-test
@@ -237,6 +245,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -255,6 +264,9 @@ jobs:
       run_attempt: ${{ github.run_attempt }}
       summary: ${{ matrix.item.summary }}
       repro: ${{ matrix.item.repro }}
+      external_dep: ${{ matrix.item.external_dep }}
+      external_dep_reason: ${{ matrix.item.external_dep_reason }}
+      platform: mi350
 
   # ----- Nightly issue reconciliation: close recovered issues (schedule only) -----
   reconcile-mi350-tritonbench:

--- a/.github/workflows/report-nightly-failure.yml
+++ b/.github/workflows/report-nightly-failure.yml
@@ -4,6 +4,19 @@ name: Report Nightly Failure
 # CI failure identity. Callers invoke it once per normalized failing test
 # identity (typically via a matrix), so each distinct failure gets its own
 # idempotent issue keyed on the issue title + labels.
+#
+# Beyond filing the issue, it adds a "blame" section:
+#   * external-dependency failures (busy GPU, driver/toolchain, network, disk)
+#     are annotated as such and skip bisection entirely;
+#   * real regressions get an immediate ranked suspect-PR list (commits merged
+#     since the last green nightly, ranked by file-path overlap) and are labeled
+#     `needs-bisect`, which triggers bisect-nightly-failure.yml to confirm the
+#     single blame PR asynchronously and @-mention its author.
+#
+# The issue body is split by an HTML `<!-- STATUS -->` marker: the blame section
+# above it is written once (and later edited by the bisect job); the status table
+# below it is refreshed on every nightly update, so a completed bisect result is
+# never clobbered.
 
 on:
   workflow_call:
@@ -59,10 +72,26 @@ on:
         required: false
         type: string
         default: ""
+      external_dep:
+        description: "'true' if the parser classified this as an external-dependency error."
+        required: false
+        type: string
+        default: "false"
+      external_dep_reason:
+        description: Human-readable reason for the external-dependency classification.
+        required: false
+        type: string
+        default: ""
+      platform:
+        description: Platform key for the deep-bisect runner (b200|h100|mi350|compiler). Empty disables bisection.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
   issues: write
+  actions: read
 
 jobs:
   file-issue:
@@ -70,7 +99,53 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: read
     steps:
+      - name: Checkout (full history for suspect range)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find last green nightly SHA
+        id: green
+        if: inputs.external_dep != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // The current run's workflow id, then its most recent successful
+            // scheduled run on main that started before it = last green nightly.
+            const run = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner, repo: context.repo.repo, run_id: context.runId,
+            });
+            const current = new Date(run.data.created_at);
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner, repo: context.repo.repo,
+              workflow_id: run.data.workflow_id,
+              branch: "main", event: "schedule", status: "success", per_page: 30,
+            });
+            let good = "";
+            for (const r of runs.data.workflow_runs) {   // newest-first
+              if (new Date(r.created_at) < current) { good = r.head_sha; break; }
+            }
+            core.info(`last green nightly SHA: ${good || "(none found)"}`);
+            core.setOutput("good_sha", good);
+
+      - name: Compute suspect PRs
+        id: suspects
+        if: inputs.external_dep != 'true' && steps.green.outputs.good_sha != ''
+        env:
+          GOOD_SHA: ${{ steps.green.outputs.good_sha }}
+          BAD_SHA: ${{ inputs.sha }}
+          NID: ${{ inputs.normalized_failure_id }}
+        run: |
+          {
+            echo "md<<__SUSPECTS_EOF__"
+            python3 .github/scripts/compute_suspects.py \
+              --good-sha "$GOOD_SHA" --bad-sha "$BAD_SHA" --normalized-id "$NID" \
+              || echo "_suspect computation failed; see run log._"
+            echo "__SUSPECTS_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create or update nightly failure issue
         uses: actions/github-script@v7
         with:
@@ -88,8 +163,60 @@ jobs:
             const runAttempt = ${{ toJSON(inputs.run_attempt) }};
             const summary = ${{ toJSON(inputs.summary) }};
             const repro = ${{ toJSON(inputs.repro) }};
+            const externalDep = ${{ toJSON(inputs.external_dep) }} === "true";
+            const externalReason = ${{ toJSON(inputs.external_dep_reason) }};
+            const platform = ${{ toJSON(inputs.platform) }};
+            const goodSha = ${{ toJSON(steps.green.outputs.good_sha) }} || "";
+            const suspectsMd = ${{ toJSON(steps.suspects.outputs.md) }} || "";
 
-            // Normalize raw IDs into a readable list (accepts newline or JSON).
+            const STATUS = "<!-- STATUS -->";
+            const BLAME_START = "<!-- BLAME:START -->";
+            const BLAME_END = "<!-- BLAME:END -->";
+
+            // Deep bisection only makes sense with a runnable repro + known platform.
+            const wantBisect = !externalDep && !!repro && !!platform;
+
+            // --- Blame section (written once; later edited by the bisect job) ---
+            let blame;
+            if (externalDep) {
+              blame = [
+                BLAME_START,
+                "### ⚠️ Likely external dependency error — bisection skipped",
+                "**Reason:** `" + (externalReason || "external dependency") + "`",
+                "",
+                "This failure matched an external-dependency signature (busy/unhealthy GPU, "
+                  + "driver/toolchain, network/proxy, or disk), so it is probably **not** caused "
+                  + "by a code change in this repo. No blame PR was computed. If it recurs across "
+                  + "runs, check runner health.",
+                BLAME_END,
+              ].join("\n");
+            } else {
+              const statusLine = wantBisect
+                ? "**Status:** deep bisection queued… the confirmed blame PR (and its author) "
+                  + "will be edited in here when the bisect job finishes."
+                : "**Status:** no runnable repro for this identity — suspect list only, no deep bisect.";
+              blame = [
+                BLAME_START,
+                "### 🔎 Blame analysis",
+                statusLine,
+                "",
+                suspectsMd || "_No suspect PRs computed (no prior green nightly found)._",
+                BLAME_END,
+              ].join("\n");
+            }
+
+            // --- Machine-readable metadata for the async bisect job ---
+            const meta = [
+              "<!-- bisect-meta",
+              "good_sha=" + goodSha,
+              "bad_sha=" + sha,
+              "platform=" + platform,
+              "normalized_id=" + normalizedId,
+              "repro=" + repro,
+              "-->",
+            ].join("\n");
+
+            // --- Status table (refreshed on every update) ---
             let rawList = [];
             if (rawIds && rawIds.trim()) {
               const trimmed = rawIds.trim();
@@ -99,13 +226,9 @@ jobs:
                 rawList = trimmed.split("\n").map(s => s.trim()).filter(Boolean);
               }
             }
-            const rawBlock = rawList.length
-              ? "```\n" + rawList.join("\n") + "\n```"
-              : "_none reported_";
-
-            const body = [
-              "> Auto-filed by nightly CI. Do not edit the title — it is the dedup key.",
-              "",
+            const rawBlock = rawList.length ? "```\n" + rawList.join("\n") + "\n```" : "_none reported_";
+            const status = [
+              STATUS,
               "| Field | Value |",
               "| --- | --- |",
               "| Workflow | `" + workflowName + "` |",
@@ -113,6 +236,7 @@ jobs:
               "| Normalized failing identity | `" + normalizedId + "` |",
               "| Ref | `" + ref + "` |",
               "| SHA | `" + sha + "` |",
+              "| Last green nightly | " + (goodSha ? "`" + goodSha + "`" : "_unknown_") + " |",
               "| Event | `" + eventName + "` |",
               "| Run attempt | `" + runAttempt + "` |",
               "| Run | " + runUrl + " |",
@@ -127,12 +251,14 @@ jobs:
               "_Last updated: " + new Date().toISOString() + "_",
             ].join("\n");
 
+            const header = "> Auto-filed by nightly CI. Do not edit the title — it is the dedup key.\n";
+            const fullBody = [header, blame, "", meta, "", status].join("\n");
+
             // Find an existing OPEN issue with the exact same title + labels.
             const escapedTitle = title.replace(/"/g, '\\"');
             const q = [
               `repo:${context.repo.owner}/${context.repo.repo}`,
-              "is:issue",
-              "is:open",
+              "is:issue", "is:open",
               ...labels.map(l => `label:"${l}"`),
               `in:title "${escapedTitle}"`,
             ].join(" ");
@@ -140,20 +266,29 @@ jobs:
             const existing = search.data.items.find(i => i.title === title && !i.pull_request);
 
             if (existing) {
+              // Preserve the blame section + metadata (possibly edited by the bisect
+              // job); only refresh the status table below the STATUS marker.
+              const old = existing.body || "";
+              const idx = old.indexOf(STATUS);
+              const body = idx >= 0 ? old.slice(0, idx) + status : fullBody;
               await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: existing.number,
-                body,
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: existing.number, body,
               });
               core.info(`Updated existing issue #${existing.number}: ${title}`);
             } else {
               const created = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body,
-                labels,
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body: fullBody, labels,
               });
               core.info(`Created issue #${created.data.number}: ${title}`);
+              // Add the bisect trigger label separately so the `issues.labeled`
+              // event reliably fires for bisect-nightly-failure.yml.
+              if (wantBisect) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: created.data.number, labels: ["needs-bisect"],
+                });
+                core.info(`Labeled #${created.data.number} needs-bisect`);
+              }
             }


### PR DESCRIPTION
  Nightly failure issues now point at who broke it, or flag that it wasn't a code change.

  - Suspect PRs: ranked list of commits since the last green nightly.
  - Auto-bisect: async git-bisect on the GPU runner confirms the single blame PR.
  - Author ping: @-mentions + assigns the PR author on a confirmed blame.
  - External-dep triage: flags GPU/driver/network/disk errors and skips bisection.
  - Non-clobbering: blame section written once; status table refreshes each nightly.
  - All four workflows: deep bisect on GPU platforms; compiler gets suspects only.

Authored with Claude Code.