### PR TITLE
sched2tlx: mark schedule_graph.json/ddg.json dumps as @generated (#1942)

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -4552,6 +4552,7 @@ void writeScheduleGraphDoc(llvm::raw_ostream &os, ModuleOp moduleOp,
   JsonDumpContext dc = buildJsonDumpContext(kernelFn, scheduledLoops);
 
   os << "{\n";
+  os << "  \"@generated\": \"by triton — do not edit by hand.\",\n";
   os << "  \"schema_version\": \"0.1\",\n";
   // Autotuning variant id == predicted-performance rank (0 = cost-model best,
   // emitted first). Absent for legacy single-graph dumps.
@@ -4737,6 +4738,7 @@ void dumpDDGAsJSON(ModuleOp moduleOp, StringRef path,
   }
 
   os << "{\n";
+  os << "  \"@generated\": \"by triton — do not edit by hand.\",\n";
   os << "  \"schema_version\": \"ddg-0.1\",\n";
 
   // config — global knobs that shape how the solver turns this DDG into a


### PR DESCRIPTION
Summary:

The `sched2tlx` tool lowers the `schedule_graph.json` / `ddg.json` dumped by the modulo scheduling pass into `generated.py`, which already carries an `generated` header. The JSON dumps themselves were not marked, so Phabricator did not collapse them and `arc f` did not skip them. This stamps an `generated` key at the top of both dumps directly in the C++ dumpers (`writeScheduleGraphDoc` and `dumpDDGAsJSON` in `ModuloSchedulePass.cpp`), so every future dump is self-marked at the source. JSON has no comment syntax, so the marker is a top-level string key; it is inert downstream because the Python loader (`load_graph`) reads only known keys via `.get()` and nothing parses `ddg.json` from Python.

The checked-in example snapshots under `sched2tlx/examples/` are regenerated from the rebuilt compiler for case1/3/5/6/7. The large per-op churn is expected and non-semantic: op ids are opaque MLIR-pointer-derived keys, and cross-references stay internally consistent. `case2_persistent_gemm` is intentionally left untouched (its committed snapshot is stale vs its own `pre_modulo.ttgir`, which now declares 256 tiles against the committed 128 — regenerating would desync it from its `generated.py` until re-emitted and re-validated on GPU); `case4_FA_bwd` has no dumps yet.

This diff was authored with Claude Code.

Reviewed By: wlei-llvm

Differential Revision: D110833541


