### PR TITLE
[TLX] Lower storage-alias after layout propagation for 2-CTA TMEM

### DIFF
--- a/python/test/unit/language/test_tlx_storage_alias.py
+++ b/python/test/unit/language/test_tlx_storage_alias.py
@@ -1,8 +1,12 @@
+import subprocess
+import sys
+import textwrap
+
 import pytest
 import torch
 import triton
 import triton.language as tl
-from triton._internal_testing import is_hopper_or_newer, is_hip
+from triton._internal_testing import is_blackwell, is_hopper_or_newer, is_hip
 import triton.language.extra.tlx as tlx
 
 
@@ -795,3 +799,154 @@ class TestSetBufferOverlap:
         # We can't predict exact values due to bit reinterpretation, but they should be non-zero
         assert out[:BLOCK_SIZE, :].abs().sum() > 0, "b_f16[0] should have non-zero data from a_f32[0]"
         assert out[BLOCK_SIZE:, :].abs().sum() > 0, "b_f16[1] should have non-zero data from a_f32[1]"
+
+
+@pytest.mark.skipif(is_hip(), reason="Not supported on AMD")
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (2-CTA MMA)")
+class TestStorageAlias2CTA:
+    """Tests for storage_alias_spec with 2-CTA (TwoCTA_RHS) TMEM tiles.
+
+    A 64-row accumulator under a collaborative ``two_ctas=True`` MMA uses the
+    ``TwoCTA_RHS`` layout (blockM=64): M=64 stays full in both CTAs and the split
+    is along N, so its real per-CTA footprint is 128x64. Storage-alias lowering
+    runs after layout propagation, so it knows this footprint and can place such
+    a tile at a non-zero TMEM column offset within a shared region.
+    """
+
+    @pytest.mark.parametrize("use_alias", [False, True])
+    def test_gemm_64x128_2cta(self, use_alias):
+        """64x128 2-CTA GEMM: the accumulator is the full (BLOCK_M, BLOCK_N) tile
+        (blockM=64 -> TwoCTA_RHS); the B operand is sliced along N per CTA. Run
+        with both a plain TMEM accumulator and a storage_alias_spec accumulator
+        (the latter checks the lowering produces a valid 2-CTA TMEM encoding)."""
+
+        @triton.jit
+        def gemm_2cta(a_ptr, stride_am, stride_ak, b_ptr, stride_bk, stride_bn, c_ptr, stride_cm, stride_cn,
+                      BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, OUT_DTYPE: tl.constexpr,
+                      M: tl.constexpr, N: tl.constexpr, K: tl.constexpr, USE_ALIAS: tl.constexpr):
+            pid_m = tl.program_id(axis=0)
+            pid_n = tl.program_id(axis=1)
+            cluster_cta_rank = tlx.cluster_cta_rank()
+            pred_leader_cta = cluster_cta_rank % 2 == 0
+
+            offs_am = pid_m * BLOCK_M
+            offs_bn = pid_n * BLOCK_N + (cluster_cta_rank % 2) * (BLOCK_N // 2)  # 2-CTA: B split along N
+            offs_cm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+            offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+            desc_a = tl.make_tensor_descriptor(a_ptr, shape=[M, K], strides=[stride_am, stride_ak],
+                                               block_shape=[BLOCK_M, BLOCK_K])
+            desc_b = tl.make_tensor_descriptor(b_ptr, shape=[K, N], strides=[stride_bk, stride_bn],
+                                               block_shape=[BLOCK_K, BLOCK_N // 2])
+
+            buf_alloc_a = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(a_ptr), tl.constexpr(1))
+            buf_alloc_b = tlx.local_alloc((BLOCK_K, BLOCK_N // 2), tlx.dtype_of(b_ptr), tl.constexpr(1))
+            a_smem = tlx.local_view(buf_alloc_a, 0)
+            b_smem = tlx.local_view(buf_alloc_b, 0)
+
+            bars = tlx.alloc_barriers(tl.constexpr(3))
+            bar_a = tlx.local_view(bars, 0)
+            bar_b = tlx.local_view(bars, 1)
+            bar_cta = tlx.alloc_barriers(1, arrive_count=2)
+            bar_leader_cta = tlx.local_view(bar_cta, 0)
+
+            # 64-row accumulator: full (BLOCK_M, BLOCK_N), blockM=64 -> TwoCTA_RHS.
+            if USE_ALIAS:
+                spec = tlx.storage_alias_spec(storage=tlx.storage_kind.tmem)
+                buffers = tlx.local_alloc((BLOCK_M, BLOCK_N), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem,
+                                          reuse=spec)
+            else:
+                buffers = tlx.local_alloc((BLOCK_M, BLOCK_N), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
+            acc_tmem = tlx.local_view(buffers, 0)
+            tlx.local_store(acc_tmem, tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32))
+            dot_bars = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+
+            phase = 0
+            for k in range(0, tl.cdiv(K, BLOCK_K)):
+                offs_k = k * BLOCK_K
+                tlx.barrier_expect_bytes(bar_a, BLOCK_M * BLOCK_K * 2)
+                tlx.barrier_expect_bytes(bar_b, BLOCK_K * (BLOCK_N // 2) * 2)
+                tlx.async_descriptor_load(desc_a, a_smem, [offs_am, offs_k], bar_a)
+                tlx.async_descriptor_load(desc_b, b_smem, [offs_k, offs_bn], bar_b)
+                tlx.barrier_wait(bar_a, phase)
+                tlx.barrier_wait(bar_b, phase)
+                # CTA0 waits for CTA1's data before issuing the collaborative MMA.
+                tlx.barrier_arrive(bar_leader_cta, 1, remote_cta_rank=cluster_cta_rank & ~1)
+                tlx.barrier_wait(bar_leader_cta, phase=k % 2, pred=pred_leader_cta)
+                tlx.async_dot(a_smem, b_smem, acc_tmem, use_acc=True, mBarriers=[dot_bars[0]], two_ctas=True,
+                              out_dtype=OUT_DTYPE)
+                tlx.barrier_wait(dot_bars[0], phase)
+                phase = phase ^ 1
+
+            result = tlx.local_load(acc_tmem)
+            c = result.to(tlx.dtype_of(c_ptr))
+            c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+            tl.store(c_ptrs, c)
+
+        def alloc_fn(size, align, stream):
+            return torch.empty(size, dtype=torch.int8, device="cuda")
+
+        torch.manual_seed(0)
+        triton.set_allocator(alloc_fn)
+        BLOCK_M, BLOCK_N, BLOCK_K = 64, 128, 128
+        # ctas_per_cga=(4,2,1): grid_x must be a multiple of 4, grid_y a multiple of 2.
+        M, N, K = BLOCK_M * 4, BLOCK_N * 2, 256
+        a = torch.randn((M, K), device="cuda", dtype=torch.float16)
+        b = torch.randn((K, N), device="cuda", dtype=torch.float16)
+        c = torch.empty((M, N), device="cuda", dtype=torch.float16)
+
+        gemm_2cta[(M // BLOCK_M, N // BLOCK_N)](
+            a, a.stride(0), a.stride(1), b, b.stride(0), b.stride(1), c, c.stride(0), c.stride(1),  #
+            BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K, OUT_DTYPE=tl.float32,  #
+            M=M, N=N, K=K, USE_ALIAS=use_alias, num_stages=1, ctas_per_cga=(4, 2, 1))
+        torch.cuda.synchronize()
+
+        ref = (a.float() @ b.float()).to(torch.float16)
+        torch.testing.assert_close(c, ref, rtol=1e-2, atol=5e-2)
+
+    def test_fa_bwd_64x128_2cta(self):
+        """FA backward 2-CTA: dQ is a 64x128 TwoCTA_RHS storage-alias tile placed
+        at a non-zero TMEM column offset via set_buffer_overlap. This only works
+        when storage-alias lowering runs after layout propagation (so it knows
+        dQ's real 128x64 footprint). Run the compile+launch in a subprocess so a
+        compile-time abort() surfaces as a clean failure instead of crashing
+        pytest."""
+        driver = textwrap.dedent(r"""
+            import torch
+            import triton.language.extra.tlx.tutorials.blackwell_fa_ws_pipelined_persistent as fa
+
+            # Force the backward autotuner to only the 2-CTA config (BLOCK_M1=128).
+            # Its dq tile is (BLOCK_M1//NUM_CTAS, HEAD_DIM) = (64,128): a blockM=64
+            # TwoCTA_RHS storage-alias tile placed at a non-zero column offset via
+            # set_buffer_overlap -- the "64x128 2-CTA" storage-alias case.
+            fa._attn_bwd_ws.configs = [fa.configs_bwd_2cta[0]]
+
+            torch.manual_seed(0)
+            BATCH, N_HEAD, N_CTX, HEAD_DIM = 1, 1, 512, 128
+            q = torch.randn((BATCH, N_HEAD, N_CTX, HEAD_DIM), device="cuda",
+                            dtype=torch.float16, requires_grad=True)
+            k = torch.randn_like(q, requires_grad=True)
+            v = torch.randn_like(q, requires_grad=True)
+            sm_scale = 1.0 / (HEAD_DIM ** 0.5)
+
+            out = fa.attention(q, k, v, sm_scale, False)
+            do = torch.randn_like(out)
+            out.backward(do)
+            tdq, tdk, tdv = q.grad.float(), k.grad.float(), v.grad.float()
+
+            # fp32 reference
+            qf = q.detach().float().requires_grad_()
+            kf = k.detach().float().requires_grad_()
+            vf = v.detach().float().requires_grad_()
+            p = torch.softmax((qf @ kf.transpose(-2, -1)) * sm_scale, dim=-1)
+            (p @ vf).backward(do.float())
+
+            for name, a, b in [("dq", tdq, qf.grad), ("dk", tdk, kf.grad), ("dv", tdv, vf.grad)]:
+                err = (a - b).abs().max().item()
+                assert err < 5e-2, f"{name} max_abs_err={err}"
+            print("OK")
+        """)
+        proc = subprocess.run([sys.executable, "-c", driver], capture_output=True, text=True, timeout=600)
+        assert proc.returncode == 0 and "OK" in proc.stdout, (
+            f"FA backward 64x128 2-CTA failed (rc={proc.returncode})\n"
+            f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}")

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -621,9 +621,9 @@ class CUDABackend(BaseBackend):
             list(opt.cluster_dims),
         )
         passes.common.add_inliner(pm)
-        # Handle storage lowering. In the future this may need
-        # dummy layouts
-        tlx.tlx_passes.add_tlx_storage_alias_lowering(pm)
+        # Storage alias lowering moved to make_ttgir (after layout propagation)
+        # so the backing TMEM allocation is materialized with the resolved
+        # 2-CTA (TwoCTA_RHS) storage format. See make_ttgir.
 
         if capability // 10 < 9:
             passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
@@ -686,6 +686,9 @@ class CUDABackend(BaseBackend):
         # optimize TTGIR
         passes.ttgpuir.add_coalesce(pm)
         tlx.tlx_passes.add_tlx_propagate_layout(pm)
+        # Storage alias lowering runs after layout propagation so the backing
+        # TMEM allocation is materialized with the resolved 2-CTA storage format.
+        tlx.tlx_passes.add_tlx_storage_alias_lowering(pm)
         # Only determine reg layouts after TMEM layout is finalized
         tlx.tlx_passes.add_tlx_resolve_placeholder_layouts(pm)
         tlx.tlx_passes.add_tlx_rewrite_local_alias(pm)

--- a/third_party/tlx/dialect/include/IR/TLXOps.td
+++ b/third_party/tlx/dialect/include/IR/TLXOps.td
@@ -23,7 +23,13 @@ class TLX_Op<string mnemonic, list<Trait> traits = []> :
 // Storage Alias Spec Operation
 //===----------------------------------------------------------------------===//
 
-def TLX_StorageAliasSpecOp : TLX_Op<"storage_alias_spec", [Pure]> {
+// NOTE: intentionally NOT Pure. Each storage_alias_spec is a distinct logical
+// buffer group. Two specs with identical attributes (e.g. both
+// storage_alias_spec<tmem>) must NOT be merged by CSE -- doing so collapses
+// separate reuse groups into one, tripping the "duplicate set_buffer_overlap"
+// check and corrupting size/offset computation. This matters once storage-alias
+// lowering runs after CSE (i.e. after layout propagation).
+def TLX_StorageAliasSpecOp : TLX_Op<"storage_alias_spec", []> {
   let summary = "Define a storage alias specification";
 
   let description = [{
@@ -69,8 +75,14 @@ def TLX_StorageAliasSpecOp : TLX_Op<"storage_alias_spec", [Pure]> {
 // Storage Alias Local Alloc Operation
 //===----------------------------------------------------------------------===//
 
+// NOTE: intentionally NOT Pure. Each storage_alias_local_alloc is a distinct
+// logical allocation. If marked Pure, CSE merges identically-shaped allocs
+// (e.g. FA's alpha/l/m tmem tiles), collapsing them to one SSA value and
+// making a `distinct` reuse_group contain duplicate leaves. Declaring an
+// allocation memory effect keeps each op distinct (not CSE-able) while still
+// allowing dead-alloc elimination.
 def TLX_StorageAliasLocalAllocOp : TLX_Op<"storage_alias_local_alloc",
-                                          [Pure]> {
+                                          [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "Allocate local memory referencing a storage alias specification";
 
   let description = [{

--- a/third_party/tlx/dialect/lib/IR/Ops.cpp
+++ b/third_party/tlx/dialect/lib/IR/Ops.cpp
@@ -65,6 +65,24 @@ LogicalResult StorageAliasSpecOp::verify() {
 
 //-- StorageAliasLocalAllocOp --
 
+// Each storage_alias_local_alloc is a distinct logical allocation. Emit an
+// unconditional Allocate effect so CSE never merges two identically-shaped
+// allocs (which would collapse `distinct` reuse_group leaves).
+void StorageAliasLocalAllocOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  OpResult alloc = getOperation()->getOpResult(0);
+  auto memDescTy =
+      cast<::mlir::triton::gpu::MemDescType>(getResult().getType());
+  if (isa<::mlir::triton::nvidia_gpu::TensorMemorySpaceAttr>(
+          memDescTy.getMemorySpace()))
+    effects.emplace_back(MemoryEffects::Allocate::get(), alloc,
+                         ::mlir::triton::nvidia_gpu::TensorMemory::get());
+  else
+    effects.emplace_back(MemoryEffects::Allocate::get(), alloc,
+                         ::mlir::triton::gpu::SharedMemory::get());
+}
+
 LogicalResult StorageAliasLocalAllocOp::verify() {
   // Verify that the storage alias and result have compatible storage kinds
   auto storageAliasType =

--- a/third_party/tlx/dialect/lib/Transforms/StorageAliasSizeDefinition.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/StorageAliasSizeDefinition.cpp
@@ -145,22 +145,27 @@ LogicalResult computeOrValidateStorageAliasSizes(ModuleOp m) {
           blockN = (blockN + scaleFactor - 1) / scaleFactor;
         }
 
-        // 2-CTA (TwoCTA_RHS/LHS) tiles are split along N across the CTA pair,
-        // so each CTA's real footprint is transposed: 2*blockM rows x blockN/2
-        // cols. This is only known after layout propagation resolves the
-        // ctaMode; account for it here so the backing size is consistent with
-        // getTmemAllocSizes (used by the offset/index math). Otherwise a
-        // (64,128) twocta_rhs view is over-counted as 128 cols and dQ cannot be
-        // placed at a non-zero column offset.
+        // 2-CTA (blockM=64) tiles occupy a per-CTA footprint whose rows double
+        // across the CTA pair. Columns behave differently by ctaMode, and this
+        // must match getTmemAllocSizes / tensorMemoryToLinearLayout (used by
+        // the offset/index math), else neighboring alias buffers overlap:
+        //   - TwoCTA_RHS (the MMA accumulator, split along N): cols halve,
+        //     rows double -> 2*blockM x blockN/2. Otherwise a (64,128) view is
+        //     over-counted as 128 cols and dQ cannot sit at a non-zero offset.
+        //   - TwoCTA_LHS (an A/LHS operand): N is NOT split; the second
+        //     row-half is a broadcast, so cols stay blockN and only rows
+        //     double.
+        // The ctaMode is only known after layout propagation.
         if (auto tmemEnc =
                 dyn_cast<mlir::triton::nvidia_gpu::TensorMemoryEncodingAttr>(
                     memDescType.getEncoding())) {
           auto ctaMode = tmemEnc.getCtaMode();
           if (ctaMode ==
-                  mlir::triton::nvidia_gpu::TensorMemoryCTAMode::TwoCTA_RHS ||
-              ctaMode ==
-                  mlir::triton::nvidia_gpu::TensorMemoryCTAMode::TwoCTA_LHS) {
+              mlir::triton::nvidia_gpu::TensorMemoryCTAMode::TwoCTA_RHS) {
             blockN /= 2;
+            blockM *= 2;
+          } else if (ctaMode == mlir::triton::nvidia_gpu::TensorMemoryCTAMode::
+                                    TwoCTA_LHS) {
             blockM *= 2;
           }
         }

--- a/third_party/tlx/dialect/lib/Transforms/StorageAliasSizeDefinition.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/StorageAliasSizeDefinition.cpp
@@ -145,6 +145,26 @@ LogicalResult computeOrValidateStorageAliasSizes(ModuleOp m) {
           blockN = (blockN + scaleFactor - 1) / scaleFactor;
         }
 
+        // 2-CTA (TwoCTA_RHS/LHS) tiles are split along N across the CTA pair,
+        // so each CTA's real footprint is transposed: 2*blockM rows x blockN/2
+        // cols. This is only known after layout propagation resolves the
+        // ctaMode; account for it here so the backing size is consistent with
+        // getTmemAllocSizes (used by the offset/index math). Otherwise a
+        // (64,128) twocta_rhs view is over-counted as 128 cols and dQ cannot be
+        // placed at a non-zero column offset.
+        if (auto tmemEnc =
+                dyn_cast<mlir::triton::nvidia_gpu::TensorMemoryEncodingAttr>(
+                    memDescType.getEncoding())) {
+          auto ctaMode = tmemEnc.getCtaMode();
+          if (ctaMode ==
+                  mlir::triton::nvidia_gpu::TensorMemoryCTAMode::TwoCTA_RHS ||
+              ctaMode ==
+                  mlir::triton::nvidia_gpu::TensorMemoryCTAMode::TwoCTA_LHS) {
+            blockN /= 2;
+            blockM *= 2;
+          }
+        }
+
         LDBG("  TMEM allocation: ");
         for (size_t i = 0; i < shape.size(); ++i) {
           LDBG(shape[i] << (i < shape.size() - 1 ? "x" : ""));

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -2285,11 +2285,8 @@ def _attn_bwd_ws(
     qk_p_storage_alias = tlx.storage_alias_spec(storage=tlx.storage_kind.tmem)
     qk_tiles = tlx.local_alloc((BLOCK_N1, BLOCK_M1), tl.float32, NUM_BUFFERS_TMEM, tlx.storage_kind.tmem,
                                reuse=qk_p_storage_alias)
-    # In 2-CTA mode, P is offset to column 64 (after dQ's 64 cols at column 0).
-    # P's per-buffer stride is 64 i32 cols (128x128 f16), so num=2 + index 1
-    # naturally places P at column 64. In 1-CTA mode, P stays at column 0.
-    P_NUM_BUFFERS: tl.constexpr = 2 if USE_2CTA and not REUSE_DP_FOR_DQ else NUM_BUFFERS_TMEM
-    P_BUF_IDX: tl.constexpr = 1 if USE_2CTA and not REUSE_DP_FOR_DQ else 0
+    P_NUM_BUFFERS: tl.constexpr = NUM_BUFFERS_TMEM
+    P_BUF_IDX: tl.constexpr = 0
     p_tiles = tlx.local_alloc(
         (BLOCK_N1, BLOCK_M1),
         tlx.dtype_of(desc_do),
@@ -2341,11 +2338,11 @@ def _attn_bwd_ws(
             ))
     else:
         if USE_2CTA:
-            # 2-CTA: dQ at column 0, P offset to column 64.
-            # dQ (64x128 f32 twocta_rhs) = 64 i32 cols at columns 0-63.
-            # P (128x128 f16) = 64 i32 cols at columns 64-127.
-            # P uses num=2 with index 1 to get the offset; P's per-buffer
-            # stride is naturally 64 from getTmemAllocSizes(128x128 f16).
+            # 2-CTA: place P and dQ explicitly via set_buffer_overlap.
+            # SWAP: P at column 0, dQ at column 64 (was the reverse). dQ's real
+            # TwoCTA_RHS footprint is 128x64 (64 i32 cols); storage-alias
+            # lowering runs after layout propagation, so it knows this and can
+            # place dQ at a non-zero column offset.
             DQ_BUF_IDX: tl.constexpr = 0
             dq_tiles = tlx.local_alloc(
                 (BLOCK_M1 // NUM_CTAS, HEAD_DIM),
@@ -2361,6 +2358,23 @@ def _attn_bwd_ws(
                 tlx.storage_kind.tmem,
                 reuse=qk_p_storage_alias,
             )
+            # qk shares the whole region; within it, P and dQ occupy distinct
+            # 64-col halves (P first -> col 0, dQ next -> col 64). dq_tiles and
+            # dq_phys are two views of the same dQ storage (shared subgroup).
+            qk_p_storage_alias.set_buffer_overlap(
+                tlx.reuse_group(
+                    qk_tiles,
+                    tlx.reuse_group(
+                        p_tiles,
+                        tlx.reuse_group(
+                            dq_tiles,
+                            dq_phys,
+                            group_type=tlx.reuse_group_type.shared,
+                        ),
+                        group_type=tlx.reuse_group_type.distinct,
+                    ),
+                    group_type=tlx.reuse_group_type.shared,
+                ))
         else:
             # 1-CTA with bm1=64: separate dQ TMEM
             DQ_BUF_IDX: tl.constexpr = 0


### PR DESCRIPTION
Move TLXStorageAliasLowering from make_ttir to make_ttgir (after tlx-propagate-layout) so the backing TMEM allocation is sized and placed using the resolved 2-CTA (TwoCTA_RHS) storage format. This lets a 64x128 TwoCTA_RHS tile (whose real per-CTA footprint is 128x64 = 64 i32 cols) be placed at a non-zero column offset within a shared storage-alias region, instead of being pinned to column 0.

