### PR TITLE
[Triton][auto-TMA][5/N] device-descriptor mode + FA-enabling analysis (#1991)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -339,6 +339,12 @@ def TritonNvidiaGPUPromoteLoadToTMAPass : Pass<"triton-nvidia-promote-load-to-tm
     "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
     "mlir::arith::ArithDialect"
   ];
+
+  let options = [
+    Option<"deviceMode", "device-mode", "bool", /*default=*/"false",
+           "Emit device-side tt.make_tensor_descriptor + descriptor_load/store "
+           "instead of host-side TMA recipes.">
+  ];
 }
 
 #endif

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLoadToTMA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLoadToTMA.cpp
@@ -117,6 +117,11 @@ struct DecomposedLoad {
   Value basePtr;
   int basePtrArgIndex;
   SmallVector<DimInfo> dims;
+  // Uniform (per-program) scalar offset terms with no arange/expand_dims, e.g.
+  // `off_z * stride_z` in a batched/FA kernel. These shift the whole tile, so
+  // for a device descriptor they fold into the descriptor base pointer
+  // (make_tensor_descriptor(addptr(base, Σ scalarBaseOffsets), ...)).
+  SmallVector<Value> scalarBaseOffsets;
   bool valid;
 };
 
@@ -395,6 +400,14 @@ static DecomposedLoad decomposePointer(Value ptr) {
   Value base = matchSplat(cur);
   if (!base)
     return result;
+  // Peel scalar per-program addptr(s) folded into the base pointer before the
+  // tile splat, e.g. `addptr(Qptr, off_z*stride_z)`. Collect their offsets as
+  // per-program base shifts (folded into the descriptor base) and continue to
+  // the underlying kernel-arg pointer.
+  while (auto ap = base.getDefiningOp<tt::AddPtrOp>()) {
+    result.scalarBaseOffsets.push_back(ap.getOffset());
+    base = ap.getPtr();
+  }
   result.basePtr = base;
   result.basePtrArgIndex = getFuncArgIndex(base);
   if (result.basePtrArgIndex < 0)
@@ -450,6 +463,16 @@ static DecomposedLoad decomposePointer(Value ptr) {
     Value inner = term;
     if (auto broadcastOp = inner.getDefiningOp<tt::BroadcastOp>())
       inner = broadcastOp.getSrc();
+    // Uniform scalar offset (splat of a scalar, no arange/expand_dims): this is
+    // a per-program base shift (e.g. `off_z * stride_z` in a batched/FA
+    // kernel). Fold it into the descriptor base later instead of a per-dim
+    // index.
+    if (Value s = matchSplat(inner)) {
+      if (s.getType().isIntOrIndex()) {
+        result.scalarBaseOffsets.push_back(s);
+        continue;
+      }
+    }
     // The canonical Triton idiom `offs[:, None] * stride` lowers to
     // muli(expand_dims(offs), splat(stride)) -- the multiply is applied AFTER
     // expand_dims, and no canonicalization hoists it through expand_dims. Peel
@@ -751,6 +774,68 @@ static int findShapeArgForDim(tt::FuncOp func, Value ownMask,
   return found;
 }
 
+// Device mode hoists the make_tensor_descriptor above the load/store's
+// enclosing scf.for so the lowered tensormap_create can be predicated. Any
+// per-program scalar base offset folded into the descriptor base
+// (scalarBaseOffsets) is an operand of that hoisted op, so it must be defined
+// ABOVE the loop or the hoist would violate SSA dominance. Return false if any
+// offset is defined inside the enclosing loop (then the caller skips
+// promotion). No enclosing loop -> nothing to hoist past -> hoistable.
+static bool scalarBaseOffsetsHoistable(Operation *op,
+                                       const DecomposedLoad &decomp) {
+  if (decomp.scalarBaseOffsets.empty())
+    return true;
+  auto forOp = op->getParentOfType<scf::ForOp>();
+  if (!forOp)
+    return true;
+  Region &loopRegion = forOp.getRegion();
+  for (Value off : decomp.scalarBaseOffsets)
+    if (loopRegion.isAncestor(off.getParentRegion()))
+      return false;
+  return true;
+}
+
+// Whether `mask` carries an upper-bound comparison that is NOT attributable to
+// any *tiled* dim (a dim with a tile offset). Such an "unattributed" bound may
+// constrain an untiled/whole dim, whose true global extent could then exceed
+// blockSize -- in which case the -2 constant-extent sentinel would encode too
+// small an extent. Used to gate the whole-dim sentinel to genuinely unmasked
+// dims. Conservative: an unrecognized comparison counts as unattributed, so the
+// guard only ever declines to fabricate an extent (never emits a wrong one).
+static bool maskHasUnattributedBound(Value mask, const DecomposedLoad &decomp) {
+  if (!mask)
+    return false;
+  SmallVector<Value> cmpTerms;
+  std::function<void(Value)> collectCmps = [&](Value v) {
+    if (auto andOp = v.getDefiningOp<arith::AndIOp>()) {
+      collectCmps(andOp.getLhs());
+      collectCmps(andOp.getRhs());
+    } else {
+      cmpTerms.push_back(v);
+    }
+  };
+  collectCmps(mask);
+  for (Value cmpVal : cmpTerms) {
+    Value c = cmpVal;
+    if (auto bcast = c.getDefiningOp<tt::BroadcastOp>())
+      c = bcast.getSrc();
+    auto cmpOp = c.getDefiningOp<arith::CmpIOp>();
+    if (!cmpOp)
+      continue; // not a comparison we treat as a bound
+    bool attributed = false;
+    for (const DimInfo &dim : decomp.dims) {
+      int argIdx = -1;
+      if (dim.offset && cmpBoundsDim(cmpOp, dim, argIdx)) {
+        attributed = true;
+        break;
+      }
+    }
+    if (!attributed)
+      return true;
+  }
+  return false;
+}
+
 // Structural equality of scalar index expressions. The promote pass runs before
 // CSE, so the tile offset used in a pointer (`muli(ki, BLOCK)`) and the same
 // quantity recomputed in a mask bound (`K - muli(ki, BLOCK)`) are equal in
@@ -959,12 +1044,16 @@ struct Promotion {
   // Logical-tile -> descriptor-memory dim order (the single contiguous dim is
   // moved last). Identity when the contiguous dim is already innermost.
   SmallVector<int> perm;
+  // True when this load requires a device-built descriptor (in-kernel
+  // tt.make_tensor_descriptor) rather than the host recipe path.
+  bool useDeviceMode = false;
 };
 
 struct StorePromotion {
   tt::StoreOp storeOp;
   DecomposedLoad decomp;
   SmallVector<int> shapeArgIndices;
+  bool useDeviceMode = false;
 };
 
 class TritonNvidiaGPUPromoteLoadToTMAPass
@@ -1003,11 +1092,30 @@ public:
       return signalPassFailure();
     }
 
+    // Device-descriptor mode: build tt.make_tensor_descriptor in-kernel instead
+    // of a host recipe (handles per-program base + constant/whole-dim extents).
+    // Controlled by the `device-mode` pass option
+    // (knobs.nvidia.auto_tma_device); TRITON_AUTO_TMA_DEVICE stays as an env
+    // fallback for ad-hoc runs.
+    const char *devEnv = std::getenv("TRITON_AUTO_TMA_DEVICE");
+    bool useDevice = deviceMode || (devEnv && std::string(devEnv) == "1");
+
     // Phase 1: collect eligible loads.
-    SmallVector<Promotion> promotions;
+    SmallVector<Promotion, 0> promotions;
     kernelFunc.walk([&](tt::LoadOp loadOp) {
       DecomposedLoad decomp = decomposePointer(loadOp.getPtr());
       if (!decomp.valid || !isTMAEligible(loadOp, decomp))
+        return;
+      // Per-load host-vs-device decision: start with the global override, then
+      // auto-escalate to device mode for loads that host recipe can't handle.
+      bool needsDevice = useDevice;
+      // scalarBaseOffsets (per-program base shifts like off_z*stride_z) require
+      // device mode — the host recipe can only record base_ptr_arg_index.
+      if (!decomp.scalarBaseOffsets.empty())
+        needsDevice = true;
+      // Device mode hoists the descriptor above enclosing loops; skip if a
+      // scalar base offset is loop-defined (SSA dominance).
+      if (needsDevice && !scalarBaseOffsetsHoistable(loadOp, decomp))
         return;
       int rank = decomp.dims.size();
       SmallVector<int> shapeArgs(rank, -1);
@@ -1023,11 +1131,24 @@ public:
           s = findShapeArgFromTileBound(kernelFunc, dim);
         if (s < 0 && dim.loopAdvanced)
           s = findShapeArgForLoopDim(kernelFunc, dim);
+        // A dim loaded WHOLE (no tile offset -> not tiled, e.g. the FA head dim
+        // `offs_d = arange(0, HEAD_DIM)`) has global extent == blockSize, a
+        // compile-time constant. Use the -2 sentinel so Phase 2 emits an
+        // arith.constant extent. Host recipe can't encode a constant extent, so
+        // this auto-escalates to device mode. Require the dim be genuinely
+        // unmasked (no mask bound unattributable to a tiled dim): a
+        // partially-masked untiled dim could have a true extent > blockSize, so
+        // fabricating blockSize would under-size the descriptor.
+        if (s < 0 && !dim.offset &&
+            !maskHasUnattributedBound(loadOp.getMask(), decomp)) {
+          s = -2;
+          needsDevice = true;
+        }
         shapeArgs[d] = s;
       }
       bool ok = true;
       for (int d = 0; d < rank; d++)
-        if (shapeArgs[d] < 0)
+        if (shapeArgs[d] == -1) // -2 = constant extent (device mode), allowed
           ok = false;
       if (!ok)
         return;
@@ -1053,6 +1174,7 @@ public:
       p.loadOp = loadOp;
       p.decomp = decomp;
       p.shapeArgIndices = shapeArgs;
+      p.useDeviceMode = needsDevice;
       // Descriptor memory order: keep dims in order but move the single
       // contiguous dim last (TMA descriptor innermost must be contiguous).
       int contigDim = -1;
@@ -1071,11 +1193,17 @@ public:
     // already innermost (the standard row-major C[M,N] output); a transposed
     // store would need the value transposed before descriptor_store -- skipped
     // for now.
-    SmallVector<StorePromotion> storePromotions;
+    SmallVector<StorePromotion, 0> storePromotions;
     if (kernelIsWarpSpecialized(kernelFunc)) {
       kernelFunc.walk([&](tt::StoreOp storeOp) {
         DecomposedLoad decomp = decomposePointer(storeOp.getPtr());
         if (!decomp.valid || !isTMAEligibleStore(storeOp, decomp))
+          return;
+        // Per-store host-vs-device decision (same logic as loads).
+        bool needsDevice = useDevice;
+        if (!decomp.scalarBaseOffsets.empty())
+          needsDevice = true;
+        if (needsDevice && !scalarBaseOffsetsHoistable(storeOp, decomp))
           return;
         int rank = decomp.dims.size();
         // contiguous dim must already be innermost (identity perm).
@@ -1105,11 +1233,16 @@ public:
             s = findShapeArgForDim(kernelFunc, storeOp.getMask(), dim);
           if (s < 0)
             s = findShapeArgFromTileBound(kernelFunc, dim);
+          if (s < 0 && !dim.offset &&
+              !maskHasUnattributedBound(storeOp.getMask(), decomp)) {
+            s = -2;
+            needsDevice = true;
+          }
           shapeArgs[d] = s;
         }
         bool ok = true;
         for (int d = 0; d < rank; d++)
-          if (shapeArgs[d] < 0)
+          if (shapeArgs[d] == -1) // -2 = constant extent (device mode)
             ok = false;
         if (!ok)
           return;
@@ -1134,6 +1267,7 @@ public:
         p.storeOp = storeOp;
         p.decomp = decomp;
         p.shapeArgIndices = shapeArgs;
+        p.useDeviceMode = needsDevice;
         storePromotions.push_back(std::move(p));
       });
     }
@@ -1153,6 +1287,87 @@ public:
     OpBuilder builder(mod.getContext());
     MLIRContext *ctx = mod.getContext();
     Builder b(ctx);
+
+    // Shared builder for the device (in-kernel) TMA descriptor, used by both
+    // the load and store rewrites in device mode. Emits make_tensor_descriptor
+    // in the given dim order (`perm`; identity for stores), hoisted via LICM
+    // to the outermost scf.for where all descriptor operands are still
+    // loop-invariant, so the lowered tensormap_create is rebuilt only when its
+    // inputs actually change. Base ptr, shape, and stride args are kernel
+    // function arguments (always invariant); only scalarBaseOffsets can be
+    // loop-defined and thus limit the hoist distance. Phase 1
+    // (scalarBaseOffsetsHoistable) has already ensured at least one level of
+    // hoist is legal when an enclosing loop exists.
+    auto buildDeviceDescriptor =
+        [&](Operation *anchorOp, const DecomposedLoad &decomp,
+            ArrayRef<int> shapeArgIndices, ArrayRef<int> perm, Location loc,
+            Value &deviceZeroIdxOut) -> Value {
+      OpBuilder::InsertionGuard guard(builder);
+      // LICM: walk up nested scf::ForOps while all scalar base offsets are
+      // defined outside the loop (base ptr and shape/stride args are kernel
+      // function arguments, so they are invariant w.r.t. every loop).
+      Operation *hoistPt = anchorOp;
+      for (auto forOp = anchorOp->getParentOfType<scf::ForOp>(); forOp;
+           forOp = forOp->getParentOfType<scf::ForOp>()) {
+        Region &loopBody = forOp.getRegion();
+        bool allInvariant = true;
+        for (Value off : decomp.scalarBaseOffsets) {
+          if (loopBody.isAncestor(off.getParentRegion())) {
+            allInvariant = false;
+            break;
+          }
+        }
+        if (!allInvariant)
+          break;
+        hoistPt = forOp;
+      }
+      builder.setInsertionPoint(hoistPt);
+      Type i32 = builder.getI32Type();
+      deviceZeroIdxOut =
+          arith::ConstantOp::create(builder, loc, builder.getI32IntegerAttr(0));
+      SmallVector<Value> descShape, descStrides;
+      SmallVector<int32_t> descBlock;
+      for (int i = 0; i < (int)perm.size(); i++) {
+        int d = perm[i];
+        // Shape extent: kernel arg, or a compile-time constant (blockSize) for
+        // a whole-dim (untiled) dim recovered as the -2 sentinel.
+        Value shapeArg;
+        if (shapeArgIndices[d] == -2) {
+          shapeArg = arith::ConstantOp::create(
+              builder, loc,
+              builder.getI32IntegerAttr((int)decomp.dims[d].blockSize));
+        } else {
+          shapeArg = kernelFunc.getArgument(shapeArgIndices[d]);
+          if (shapeArg.getType().isInteger(64))
+            shapeArg = arith::TruncIOp::create(builder, loc, i32, shapeArg);
+        }
+        descShape.push_back(shapeArg);
+        // Contiguous dim (strideArgIdx < 0) has unit stride;
+        // make_tensor_descriptor needs an i64 stride operand per dim.
+        int strideIdx = decomp.dims[d].strideArgIdx;
+        Value strideV;
+        if (strideIdx < 0) {
+          strideV = arith::ConstantOp::create(builder, loc,
+                                              builder.getI64IntegerAttr(1));
+        } else {
+          strideV = kernelFunc.getArgument(strideIdx);
+          if (strideV.getType().isInteger(32))
+            strideV = arith::ExtSIOp::create(builder, loc, builder.getI64Type(),
+                                             strideV);
+        }
+        descStrides.push_back(strideV);
+        descBlock.push_back((int32_t)decomp.dims[d].blockSize);
+      }
+      // Fold uniform per-program scalar offsets (off_z*stride_z, ...) into the
+      // descriptor base -> a per-program (e.g. per-(batch,head)) view.
+      Value descBase = decomp.basePtr;
+      for (Value off : decomp.scalarBaseOffsets)
+        descBase = tt::AddPtrOp::create(builder, loc, descBase.getType(),
+                                        descBase, off);
+      return tt::MakeTensorDescOp::create(
+          builder, loc, descBase, descShape, descStrides, descBlock,
+          /*isSignedInteger=*/false, tt::PaddingOption::PAD_ZERO);
+    };
     auto i32Attr = [&](int v) { return b.getI32IntegerAttr(v); };
     SmallVector<Attribute> recipeAttrs;
 
@@ -1190,23 +1405,36 @@ public:
           isIdentity ? resultTy.getEncoding() : Attribute();
       auto descTileTy = RankedTensorType::get(permShape, elemTy, descEncoding);
 
-      // Synthesized host-side descriptor; its block type is the memory-order
-      // tile.
-      auto descTy = tt::TensorDescType::get(descTileTy.getShape(),
-                                            descTileTy.getElementType(),
-                                            descTileTy.getEncoding());
-      unsigned descArgIdx = kernelFunc.getNumArguments();
-      auto argAttrs =
-          b.getDictionaryAttr({b.getNamedAttr("tt.auto_tma", b.getUnitAttr())});
-      LogicalResult inserted =
-          kernelFunc.insertArgument(descArgIdx, descTy, argAttrs, loc);
-      assert(succeeded(inserted) &&
-             "failed to insert TMA descriptor kernel argument");
-      (void)inserted;
-      Value descArg = kernelFunc.getArgument(descArgIdx);
-
       builder.setInsertionPoint(loadOp);
       Type i32 = builder.getI32Type();
+
+      // The descriptor fed to descriptor_load: device-built (deviceMode) or a
+      // host-built descriptor passed as a synthesized kernel arg (recipe path).
+      Value descVal;
+      unsigned descArgIdx = 0;
+      // Loop-invariant zero index for whole-dim (untiled) dims, created OUTSIDE
+      // any loop so it needs no ttg.partition attr under warp specialization.
+      Value deviceZeroIdx;
+      if (promo.useDeviceMode) {
+        descVal =
+            buildDeviceDescriptor(loadOp, promo.decomp, promo.shapeArgIndices,
+                                  promo.perm, loc, deviceZeroIdx);
+      } else {
+        // Synthesized host-side descriptor; block type is the memory-order
+        // tile.
+        auto descTy = tt::TensorDescType::get(descTileTy.getShape(),
+                                              descTileTy.getElementType(),
+                                              descTileTy.getEncoding());
+        descArgIdx = kernelFunc.getNumArguments();
+        auto argAttrs = b.getDictionaryAttr(
+            {b.getNamedAttr("tt.auto_tma", b.getUnitAttr())});
+        LogicalResult inserted =
+            kernelFunc.insertArgument(descArgIdx, descTy, argAttrs, loc);
+        assert(succeeded(inserted) &&
+               "failed to insert TMA descriptor kernel argument");
+        (void)inserted;
+        descVal = kernelFunc.getArgument(descArgIdx);
+      }
       Type i64 = builder.getI64Type();
       // Convert an integer/index value to a target integer width,
       // sign-extending or truncating as needed. descriptor_load indices must be
@@ -1244,17 +1472,19 @@ public:
           Value prod = arith::MulIOp::create(builder, loc, iv, step);
           indices.push_back(arith::TruncIOp::create(builder, loc, i32, prod));
         } else if (!dim.offset) {
-          // Bare make_range with no tile offset (e.g. `arange % M` or a
-          // select-clamp, which peel to a bare range): the tile starts at 0.
-          indices.push_back(arith::ConstantOp::create(
-              builder, loc, builder.getI32IntegerAttr(0)));
+          // Whole-dim (untiled, e.g. FA HEAD_DIM): index is 0. Use the hoisted
+          // zero (deviceMode) so it isn't a constant inside the WS loop.
+          indices.push_back(
+              deviceZeroIdx ? deviceZeroIdx
+                            : arith::ConstantOp::create(
+                                  builder, loc, builder.getI32IntegerAttr(0)));
         } else {
           indices.push_back(toI32(dim.offset));
         }
       }
 
       auto newLoad = tt::DescriptorLoadOp::create(
-          builder, loc, descTileTy, descArg, indices, tt::CacheModifier::NONE,
+          builder, loc, descTileTy, descVal, indices, tt::CacheModifier::NONE,
           tt::EvictionPolicy::NORMAL);
 
       Value loaded = newLoad.getResult();
@@ -1269,6 +1499,10 @@ public:
 
       loadOp.getResult().replaceAllUsesWith(loaded);
       loadOp.erase();
+
+      // Device descriptors need no launcher recipe.
+      if (promo.useDeviceMode)
+        continue;
 
       // Record the recipe: how the launcher builds this CUtensorMap from the
       // existing scalar kernel args (base ptr / shape / stride) at launch time.
@@ -1309,20 +1543,33 @@ public:
       Type elemTy = valTy.getElementType();
       Location loc = storeOp.getLoc();
 
-      auto descTy = tt::TensorDescType::get(
-          valTy.getShape(), valTy.getElementType(), valTy.getEncoding());
-      unsigned descArgIdx = kernelFunc.getNumArguments();
-      auto argAttrs =
-          b.getDictionaryAttr({b.getNamedAttr("tt.auto_tma", b.getUnitAttr())});
-      LogicalResult inserted =
-          kernelFunc.insertArgument(descArgIdx, descTy, argAttrs, loc);
-      assert(succeeded(inserted) &&
-             "failed to insert TMA descriptor kernel argument");
-      (void)inserted;
-      Value descArg = kernelFunc.getArgument(descArgIdx);
-
       builder.setInsertionPoint(storeOp);
       Type i32 = builder.getI32Type();
+
+      // Descriptor for the store: device-built (deviceMode) or host recipe arg.
+      Value descVal;
+      unsigned descArgIdx = 0;
+      Value deviceZeroIdx;
+      if (promo.useDeviceMode) {
+        SmallVector<int> identity;
+        for (int d = 0; d < rank; d++)
+          identity.push_back(d);
+        descVal =
+            buildDeviceDescriptor(storeOp, promo.decomp, promo.shapeArgIndices,
+                                  identity, loc, deviceZeroIdx);
+      } else {
+        auto descTy = tt::TensorDescType::get(
+            valTy.getShape(), valTy.getElementType(), valTy.getEncoding());
+        descArgIdx = kernelFunc.getNumArguments();
+        auto argAttrs = b.getDictionaryAttr(
+            {b.getNamedAttr("tt.auto_tma", b.getUnitAttr())});
+        LogicalResult inserted =
+            kernelFunc.insertArgument(descArgIdx, descTy, argAttrs, loc);
+        assert(succeeded(inserted) &&
+               "failed to insert TMA descriptor kernel argument");
+        (void)inserted;
+        descVal = kernelFunc.getArgument(descArgIdx);
+      }
       // Same width handling as the load path's toIntWidth: descriptor_store
       // indices must be i32, but a tile offset may be index / i16 / i64 / etc.
       // depending on how the kernel computed it. Sign-extend or truncate as
@@ -1342,21 +1589,22 @@ public:
       };
       SmallVector<Value> indices;
       for (int d = 0; d < rank; d++) {
-        const DimInfo &dim = promo.decomp.dims[d];
-        if (!dim.offset) {
-          // Bare make_range with no tile offset (e.g. `arange % M` or a
-          // select-clamp that peels to a bare range): the tile starts at 0.
-          // Phase 1b can accept such a dim via shapeArgIdx alone, so mirror the
-          // load path (Phase 2) here instead of calling toI32 on a null offset.
-          indices.push_back(arith::ConstantOp::create(
-              builder, loc, builder.getI32IntegerAttr(0)));
-        } else {
-          indices.push_back(toI32(dim.offset));
-        }
+        Value off = promo.decomp.dims[d].offset;
+        if (!off)
+          indices.push_back(
+              deviceZeroIdx ? deviceZeroIdx
+                            : arith::ConstantOp::create(
+                                  builder, loc, builder.getI32IntegerAttr(0)));
+        else
+          indices.push_back(toI32(off));
       }
 
-      tt::DescriptorStoreOp::create(builder, loc, descArg, value, indices);
+      tt::DescriptorStoreOp::create(builder, loc, descVal, value, indices);
       storeOp.erase();
+
+      // Device stores need no launcher recipe.
+      if (promo.useDeviceMode)
+        continue;
 
       SmallVector<Attribute> shapeIdx, strideIdx, blk;
       for (int d = 0; d < rank; d++) {

--- a/python/test/unit/language/test_autows_auto_tma.py
+++ b/python/test/unit/language/test_autows_auto_tma.py
@@ -35,6 +35,7 @@ import triton
 import triton.language as tl
 from triton._internal_testing import is_cuda
 from triton.testing import do_bench
+import os
 
 
 def _is_sm90plus() -> bool:
@@ -125,6 +126,99 @@ def test_auto_tma_gemm_nows():
     assert "tt.descriptor_load" in kernel.asm["ttir"], "expected auto-TMA promotion"
     ref = (A.to(torch.float32) @ B.T.to(torch.float32)).to(dtype)
     torch.testing.assert_close(ref, C, atol=0.05, rtol=0.05)
+
+
+@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA promotion requires sm_90+")
+def test_auto_tma_gemm_nows_device(monkeypatch):
+    """Phase A: addptr loads promoted to a DEVICE-built tt.make_tensor_descriptor
+    (TRITON_AUTO_TMA_DEVICE=1), not the host-recipe path. Verifies the pass
+    synthesizes make_tensor_descriptor from the plain pointer + mask analysis.
+    Uses a dedicated kernel so the JIT cache does not collide with the host-mode
+    _gemm_nows test (the auto-TMA-device env is not part of the cache key)."""
+
+    @triton.jit
+    def _gemm_dev(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_bn, stride_cm, BLOCK_M: tl.constexpr,
+                  BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for ki in range(tl.cdiv(K, BLOCK_K)):
+            offs_k = ki * BLOCK_K + tl.arange(0, BLOCK_K)
+            a = tl.load(a_ptr + offs_m[:, None] * stride_am + offs_k[None, :],
+                        mask=(offs_m[:, None] < M) & (offs_k[None, :] < K), other=0.0)
+            b = tl.load(b_ptr + offs_n[:, None] * stride_bn + offs_k[None, :],
+                        mask=(offs_n[:, None] < N) & (offs_k[None, :] < K), other=0.0)
+            acc = tl.dot(a, b.T, acc)
+        tl.store(c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :], acc.to(tl.float16),
+                 mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
+
+    monkeypatch.setenv("TRITON_AUTO_TMA", "1")
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    M, N, K = 256, 256, 256
+    BLOCK_M, BLOCK_N, BLOCK_K = 64, 64, 32
+    dtype = torch.float16
+    torch.manual_seed(0)
+    A = torch.randn((M, K), dtype=dtype, device="cuda")
+    B = torch.randn((N, K), dtype=dtype, device="cuda")
+    C = torch.empty((M, N), dtype=dtype, device="cuda")
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    kernel = _gemm_dev[grid](A, B, C, M, N, K, A.stride(0), B.stride(0), C.stride(0), BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N,
+                             BLOCK_K=BLOCK_K)
+
+    ttir = kernel.asm["ttir"]
+    assert "tt.make_tensor_descriptor" in ttir, \
+        "device mode should synthesize an in-kernel make_tensor_descriptor"
+    assert "tt.descriptor_load" in ttir, "expected descriptor_load"
+    ref = (A.to(torch.float32) @ B.T.to(torch.float32)).to(dtype)
+    torch.testing.assert_close(ref, C, atol=0.05, rtol=0.05)
+
+
+@triton.jit
+def _batched_scale(x_ptr, out_ptr, B, M, N, stride_b, stride_m, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+    pid_b = tl.program_id(0)
+    pid_m = tl.program_id(1)
+    pid_n = tl.program_id(2)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    # Per-program base shift folded into the (scalar) base pointer.
+    xb = x_ptr + pid_b * stride_b
+    ob = out_ptr + pid_b * stride_b
+    x = tl.load(xb + offs_m[:, None] * stride_m + offs_n[None, :], mask=mask, other=0.0)
+    tl.store(ob + offs_m[:, None] * stride_m + offs_n[None, :], x * 2.0, mask=mask)
+
+
+@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA promotion requires sm_90+")
+def test_auto_tma_batched_device(monkeypatch):
+    """per-program base (pid_b*stride_b) must fold into the DEVICE descriptor base
+    (make_tensor_descriptor(addptr(x, off), ...)), giving a per-batch view."""
+    monkeypatch.setenv("TRITON_AUTO_TMA", "1")
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    B, M, N = 4, 128, 128
+    BLOCK_M, BLOCK_N = 64, 64
+    dtype = torch.float16
+    torch.manual_seed(0)
+    x = torch.randn((B, M, N), dtype=dtype, device="cuda")
+    out = torch.empty((B, M, N), dtype=dtype, device="cuda")
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    grid = (B, triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    kernel = _batched_scale[grid](x, out, B, M, N, x.stride(0), x.stride(1), BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N)
+
+    ttir = kernel.asm["ttir"]
+    assert "tt.make_tensor_descriptor" in ttir, \
+        "per-program base should still produce a device descriptor"
+    torch.testing.assert_close(out, x * 2.0)
 
 
 # ---------------------------------------------------------------------------
@@ -543,3 +637,234 @@ def test_scale_auto_tma_autotuner_picks_faster(M, N):
         assert pick == faster, (
             f"autotuner picked auto_tma={int(pick)} but independent timing says faster="
             f"{'on' if faster else 'off'} (off={off_ms:.5f} on={on_ms:.5f} ms, {rel * 100:.1f}% apart)")
+
+
+# ---------------------------------------------------------------------------
+# 5. Plain-pointer Flash Attention forward (no WS): Q/K/V/O plain tl.load/store
+#    auto-TMA promoted to DEVICE descriptors. Exercises per-program base (off_hz),
+#    the whole-dim (HEAD_DIM, unmasked) constant-extent path, and a loop-carried
+#    K/V load. Numerics vs torch SDPA.
+# ---------------------------------------------------------------------------
+@triton.jit
+def _plain_fa_fwd(Q, K, V, O, sm_scale, N_CTX, stride_h, stride_m, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+                  HEAD_DIM: tl.constexpr):
+    pid_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, HEAD_DIM)
+    # per-program base for this (batch, head)
+    q_base = Q + off_hz * stride_h
+    k_base = K + off_hz * stride_h
+    v_base = V + off_hz * stride_h
+    o_base = O + off_hz * stride_h
+    q = tl.load(q_base + offs_m[:, None] * stride_m + offs_d[None, :], mask=offs_m[:, None] < N_CTX, other=0.0)
+    m_i = tl.full([BLOCK_M], -float("inf"), tl.float32)
+    l_i = tl.zeros([BLOCK_M], tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], tl.float32)
+    qk_scale = sm_scale * 1.44269504  # log2(e)
+    for start_n in range(0, N_CTX, BLOCK_N):
+        offs_n = start_n + tl.arange(0, BLOCK_N)
+        k = tl.load(k_base + offs_n[:, None] * stride_m + offs_d[None, :], mask=offs_n[:, None] < N_CTX,
+                    other=0.0)  # [BLOCK_N, HEAD_DIM]
+        v = tl.load(v_base + offs_n[:, None] * stride_m + offs_d[None, :], mask=offs_n[:, None] < N_CTX,
+                    other=0.0)  # [BLOCK_N, HEAD_DIM]
+        qk = tl.dot(q, k.T) * qk_scale  # [BLOCK_M, BLOCK_N]
+        qk = tl.where(offs_n[None, :] < N_CTX, qk, -float("inf"))
+        m_ij = tl.maximum(m_i, tl.max(qk, 1))
+        p = tl.math.exp2(qk - m_ij[:, None])
+        alpha = tl.math.exp2(m_i - m_ij)
+        l_i = l_i * alpha + tl.sum(p, 1)
+        acc = acc * alpha[:, None] + tl.dot(p.to(tl.float16), v)
+        m_i = m_ij
+    acc = acc / l_i[:, None]
+    tl.store(o_base + offs_m[:, None] * stride_m + offs_d[None, :], acc.to(tl.float16), mask=offs_m[:, None] < N_CTX)
+
+
+@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA promotion requires sm_90+")
+def test_plain_fa_fwd_device(monkeypatch):
+    """A plain-pointer FA fwd (no descriptors, no warp_specialize): the Q/K/V
+    loads are auto-TMA promoted to DEVICE make_tensor_descriptor + descriptor_load
+    (per-program base folded into the descriptor base; unmasked HEAD_DIM extent as
+    a constant), numerics match torch SDPA."""
+    monkeypatch.setenv("TRITON_AUTO_TMA", "1")
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    Z, H, N_CTX, HEAD_DIM = 1, 2, 256, 64
+    BLOCK_M, BLOCK_N = 64, 64
+    dtype = torch.float16
+    sm_scale = 0.5
+    torch.manual_seed(0)
+    q = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    k = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    v = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    o = torch.empty_like(q)
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    stride_h = q.stride(1)  # one (batch,head) block = N_CTX*HEAD_DIM
+    stride_m = q.stride(2)  # seq stride = HEAD_DIM
+    grid = (triton.cdiv(N_CTX, BLOCK_M), Z * H)
+    kernel = _plain_fa_fwd[grid](q, k, v, o, sm_scale, N_CTX, stride_h, stride_m, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N,
+                                 HEAD_DIM=HEAD_DIM)
+
+    ttir = kernel.asm["ttir"]
+    assert "tt.make_tensor_descriptor" in ttir, \
+        "plain-pointer FA Q/K/V loads should promote to device descriptors"
+    assert "tt.descriptor_load" in ttir, "expected descriptor_load"
+
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, scale=sm_scale, is_causal=False)
+    torch.testing.assert_close(o, ref, atol=1e-2, rtol=0)
+
+
+# ---------------------------------------------------------------------------
+# 4. Plain-pointer Flash Attention forward WITH warp_specialize: the plain loads
+#    are auto-TMA promoted (device descriptors) AND the loop is warp-specialized.
+#    auto-TMA is the WS enabler (descriptor_load is the partition scheduler seed).
+# ---------------------------------------------------------------------------
+@triton.jit
+def _plain_fa_fwd_ws(Q, K, V, O, sm_scale, N_CTX, stride_h, stride_m, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+                     HEAD_DIM: tl.constexpr):
+    pid_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, HEAD_DIM)
+    q_base = Q + off_hz * stride_h
+    k_base = K + off_hz * stride_h
+    v_base = V + off_hz * stride_h
+    o_base = O + off_hz * stride_h
+    q = tl.load(q_base + offs_m[:, None] * stride_m + offs_d[None, :], mask=offs_m[:, None] < N_CTX, other=0.0)
+    m_i = tl.full([BLOCK_M], -float("inf"), tl.float32)
+    l_i = tl.zeros([BLOCK_M], tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], tl.float32)
+    qk_scale = sm_scale * 1.44269504
+    for start_n in tl.range(0, N_CTX, BLOCK_N, warp_specialize=True, merge_epilogue=True, separate_epilogue_store=True,
+                            data_partition_factor=2):
+        offs_n = start_n + tl.arange(0, BLOCK_N)
+        k = tl.load(k_base + offs_n[:, None] * stride_m + offs_d[None, :], mask=offs_n[:, None] < N_CTX, other=0.0)
+        v = tl.load(v_base + offs_n[:, None] * stride_m + offs_d[None, :], mask=offs_n[:, None] < N_CTX, other=0.0)
+        # Mirror 06-fused-attention.py _attn_fwd_inner (non-causal STAGE), but with
+        # plain tl.load (auto-TMA promotes) instead of desc_k/desc_v.load.
+        qk = tl.dot(q, k.T)
+        m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+        qk = qk * qk_scale - m_ij[:, None]
+        p = tl.math.exp2(qk)
+        alpha = tl.math.exp2(m_i - m_ij)
+        l_ij = tl.sum(p, 1)
+        acc = acc * alpha[:, None]
+        acc = tl.dot(p.to(tl.float16), v, acc)
+        l_i = l_i * alpha + l_ij
+        m_i = m_ij
+    acc = acc / l_i[:, None]
+    tl.store(o_base + offs_m[:, None] * stride_m + offs_d[None, :], acc.to(tl.float16), mask=offs_m[:, None] < N_CTX)
+
+
+@pytest.mark.skipif(not _is_sm90plus(), reason="WS + auto-TMA requires sm_90+")
+def test_plain_fa_fwd_ws_device(monkeypatch):
+    """plain-pointer FA + warp_specialize: loads auto-TMA'd to device descriptors,
+    loop warp-specialized, numerics vs torch SDPA."""
+    monkeypatch.setenv("TRITON_AUTO_TMA", "1")
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    Z, H, N_CTX, HEAD_DIM = 1, 2, 256, 64
+    BLOCK_M, BLOCK_N = 128, 64  # dp=2 -> 64 rows per partition
+    dtype = torch.float16
+    sm_scale = 0.5
+    torch.manual_seed(0)
+    q = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    k = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    v = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    o = torch.empty_like(q)
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    grid = (triton.cdiv(N_CTX, BLOCK_M), Z * H)
+    with triton.knobs.nvidia.scope():
+        # Meta WS + meta partition scheduler (as the hand-written FA WS kernel
+        # uses); the default upstream add_warp_specialize does not partition the
+        # FA softmax compute.
+        triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.use_meta_partition = True
+        triton.knobs.nvidia.disable_wsbarrier_reorder = True
+        kernel = _plain_fa_fwd_ws[grid](q, k, v, o, sm_scale, N_CTX, q.stride(1), q.stride(2), BLOCK_M=BLOCK_M,
+                                        BLOCK_N=BLOCK_N, HEAD_DIM=HEAD_DIM, num_warps=4, num_stages=2, maxRegAutoWS=192)
+
+    ttgir = kernel.asm["ttgir"]
+    assert "tt.descriptor_load" in kernel.asm["ttir"], "expected auto-TMA promotion"
+    assert "ttg.warp_specialize" in ttgir, "expected warp specialization"
+    assert "ttng.async_tma_copy_global_to_local" in ttgir, "expected async TMA copy"
+
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, scale=sm_scale, is_causal=False)
+    torch.testing.assert_close(o, ref, atol=1e-2, rtol=0)
+
+
+def _run_plain_fa_ws(q, k, v, o, sm_scale, N_CTX, BLOCK_M, BLOCK_N, HEAD_DIM):
+    """Launch _plain_fa_fwd_ws under the meta-WS scheduler (as the hand-written
+    FA WS kernel does). Requires TRITON_AUTO_TMA[_DEVICE]=1 set by the caller."""
+    Z, H = q.shape[0], q.shape[1]
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    grid = (triton.cdiv(N_CTX, BLOCK_M), Z * H)
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.use_meta_partition = True
+        triton.knobs.nvidia.disable_wsbarrier_reorder = True
+        return _plain_fa_fwd_ws[grid](q, k, v, o, sm_scale, N_CTX, q.stride(1), q.stride(2), BLOCK_M=BLOCK_M,
+                                      BLOCK_N=BLOCK_N, HEAD_DIM=HEAD_DIM, num_warps=4, num_stages=2, maxRegAutoWS=192)
+
+
+@pytest.mark.skipif(not _is_sm90plus(), reason="WS + auto-TMA requires sm_90+")
+@pytest.mark.parametrize("N_CTX", [512, 1024, 2048])
+@pytest.mark.parametrize("HEAD_DIM", [64, 128])
+def test_plain_fa_fwd_ws_shapes(monkeypatch, N_CTX, HEAD_DIM):
+    """plain-pointer FA + WS + auto-TMA correctness across larger shapes."""
+    monkeypatch.setenv("TRITON_AUTO_TMA", "1")
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    Z, H = 2, 4
+    BLOCK_M, BLOCK_N = 128, 64
+    dtype = torch.float16
+    sm_scale = 1.0 / (HEAD_DIM**0.5)
+    torch.manual_seed(0)
+    q = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    k = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    v = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    o = torch.empty_like(q)
+    _run_plain_fa_ws(q, k, v, o, sm_scale, N_CTX, BLOCK_M, BLOCK_N, HEAD_DIM)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, scale=sm_scale, is_causal=False)
+    torch.testing.assert_close(o, ref, atol=1e-2, rtol=0)
+
+
+@pytest.mark.skipif(
+    os.environ.get("TRITON_RUN_PERF", "0") != "1",
+    reason="perf benchmark (large FA via do_bench); set TRITON_RUN_PERF=1 to run",
+)
+@pytest.mark.skipif(not _is_sm90plus(), reason="WS + auto-TMA requires sm_90+")
+def test_perf_plain_fa_fwd_ws(monkeypatch):
+    """Perf of the plain-pointer FA + WS + auto-TMA at a representative shape,
+    with accuracy vs torch SDPA. Prints TFLOP/s (pin a free GPU)."""
+    monkeypatch.setenv("TRITON_AUTO_TMA", "1")
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    Z, H, N_CTX, HEAD_DIM = 4, 32, 4096, 128
+    BLOCK_M, BLOCK_N = 128, 64
+    dtype = torch.float16
+    sm_scale = 1.0 / (HEAD_DIM**0.5)
+    torch.manual_seed(0)
+    q = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    k = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    v = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    o = torch.empty_like(q)
+    _run_plain_fa_ws(q, k, v, o, sm_scale, N_CTX, BLOCK_M, BLOCK_N, HEAD_DIM)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, scale=sm_scale, is_causal=False)
+    torch.testing.assert_close(o, ref, atol=1e-2, rtol=0)
+    fn = lambda: _run_plain_fa_ws(q, k, v, o, sm_scale, N_CTX, BLOCK_M, BLOCK_N, HEAD_DIM)
+    ms = triton.testing.do_bench(fn)
+    flops = 2 * 2.0 * Z * H * N_CTX * N_CTX * HEAD_DIM  # QK^T + PV, non-causal
+    tflops = flops * 1e-12 / (ms * 1e-3)
+    at = os.environ.get("TRITON_AUTO_TMA", "0")
+    print(f"\n[plain-fa-ws] auto_tma={at} fwd "
+          f"({Z}x{H}x{N_CTX}x{HEAD_DIM}): {ms:.4f} ms  {tflops:.1f} TFLOP/s  "
+          f"accuracy(vs torch SDPA)=PASS\n")

--- a/python/test/unit/runtime/test_promote_load_to_tma.py
+++ b/python/test/unit/runtime/test_promote_load_to_tma.py
@@ -407,3 +407,23 @@ def test_auto_tma_metaws_store_over_256():
         "meta-WS BLOCK_N=512 load must be auto-TMA promoted (clamped box + multi-copy)")
     assert "tt.descriptor_store" in k.asm["ttir"], (
         "meta-WS BLOCK_N=512 store must be auto-TMA store-promoted (clamped box + multi-copy)")
+
+
+@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
+def test_auto_tma_device_block_over_256(monkeypatch):
+    # DEVICE-descriptor mode (TRITON_AUTO_TMA_DEVICE=1, added in this diff): the load
+    # is promoted to an in-kernel tt.make_tensor_descriptor. Contiguous BLOCK_N=512 >
+    # 256. Unlike the host recipe, the device path clamps the box via getTMABlockShape
+    # at descriptor-build time (TMAUtilities::createTMADesc) and the device lowering
+    # multi-copies to fill the tile, so box>256 promotes and computes correctly. Non-WS,
+    # so it does not touch the AutoWS partition bug that blocks the host store path.
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    M, N = 128, 512
+    BLOCK_M, BLOCK_N = 64, 512  # contiguous 512 > 256 -> device box clamp + multi-copy
+    x = torch.randn((M, N), device="cuda", dtype=torch.float16)
+    out = torch.empty((M, N), device="cuda", dtype=torch.float16)
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    k = _scale_2d_kernel[grid](x, out, M, N, x.stride(0), BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N)
+    torch.testing.assert_close(out, x * 2.0, atol=1e-2, rtol=1e-2)
+    assert "tt.make_tensor_descriptor" in k.asm["ttir"], "expected a device descriptor"
+    assert "tt.descriptor_load" in k.asm["ttir"], ("device-descriptor BLOCK_N=512 load must be auto-TMA promoted")

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -580,6 +580,8 @@ class nvidia_knobs(base_knobs):
     use_autotune_c_cache: env_bool = env_bool("TRITON_AUTOTUNE_USE_C_CACHE", True)
     # Default ON; opt out with TRITON_ENABLE_C_CACHE=0.
     enable_c_cache: env_bool = env_bool("TRITON_ENABLE_C_CACHE", True)
+    auto_tma_device: env_bool = env_bool("TRITON_AUTO_TMA_DEVICE")
+    use_autotune_c_cache: env_bool = env_bool("TRITON_AUTOTUNE_USE_C_CACHE")
     generate_subtiled_region: env_bool = env_bool("TRITON_GENERATE_SUBTILED_REGION")
     # When True, run the triton-nvidia-interleave-tmem pass on Blackwell.
     # Default ON; set TRITON_ENABLE_INTERLEAVE_TMEM=0 to opt out for A/B

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -206,6 +206,9 @@ class CUDAOptions:
     # Per-config auto-TMA toggle (autotunable). Falls back to the global
     # TRITON_AUTO_TMA knob when left at the default in make_ttir.
     auto_tma: bool = False
+    # Emit device-side descriptors (make_tensor_descriptor + descriptor_load/store)
+    # instead of host TMA recipes. Falls back to knobs.nvidia.auto_tma_device.
+    auto_tma_device: bool = False
 
     def __post_init__(self):
         default_libdir = Path(__file__).parent / "lib"
@@ -743,14 +746,15 @@ class CUDABackend(BaseBackend):
         # so the backing TMEM allocation is materialized with the resolved
         # 2-CTA (TwoCTA_RHS) storage format. See make_ttgir.
 
-        if capability // 10 < 9:
-            passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
         # Auto-TMA: rewrite eligible masked block loads into descriptor_load so
         # the standard sm_90+ TMA lowering turns them into real TMA copies. The
-        # per-config option (autotunable) takes precedence; otherwise fall back
-        # to the global TRITON_AUTO_TMA knob.
+        # per-config option (autotunable) takes precedence; otherwise the global
+        # TRITON_AUTO_TMA knob. (Block pointers are already tensor descriptors in
+        # this dialect, so there is no separate rewrite_tensor_pointer pass.)
         if (opt.auto_tma or knobs.nvidia.auto_tma) and capability // 10 >= 9:
-            nvidia.passes.ttnvgpuir.add_promote_load_to_tma(pm)
+            nvidia.passes.ttnvgpuir.add_promote_load_to_tma(pm, opt.auto_tma_device or knobs.nvidia.auto_tma_device)
+        if capability // 10 < 9:
+            passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_combine(pm)
         passes.ttir.add_reorder_broadcast(pm)

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -157,6 +157,13 @@ createTritonGPUProxyFenceInsertionWrapper(int32_t capability) {
   return ttng::createTritonGPUProxyFenceInsertion(options);
 }
 
+static std::unique_ptr<mlir::Pass>
+createPromoteLoadToTMAWrapper(bool deviceMode) {
+  ttng::TritonNvidiaGPUPromoteLoadToTMAPassOptions options;
+  options.deviceMode = deviceMode;
+  return ttng::createTritonNvidiaGPUPromoteLoadToTMAPass(options);
+}
+
 void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_plan_cta", ttng::createTritonNvidiaGPUPlanCTAPass);
   ADD_PASS_WRAPPER_1("add_fence_insertion",
@@ -169,8 +176,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      ttng::createTritonNvidiaGPUTMemBarrierInsertionPass);
   ADD_PASS_WRAPPER_0("add_tma_lowering",
                      ttng::createTritonNvidiaGPUTMALoweringPass);
-  ADD_PASS_WRAPPER_0("add_promote_load_to_tma",
-                     ttng::createTritonNvidiaGPUPromoteLoadToTMAPass);
+  ADD_PASS_WRAPPER_1("add_promote_load_to_tma", createPromoteLoadToTMAWrapper,
+                     bool);
   ADD_PASS_WRAPPER_0("add_tma_store_buffer_reuse",
                      ttng::createTritonNvidiaGPUTMAStoreBufferReusePass);
   ADD_PASS_WRAPPER_0("add_promote_lhs_to_tmem",


### PR DESCRIPTION
Summary:

## Background

Auto-TMA so far (1/n-4/n) uses the **host-recipe** mode: the CPU launcher builds
the `CUtensorMap` from a recipe and passes it in. That is enough for GEMM. A real,
fully-tuned, warp-specialized **Flash Attention (FA)** needs more, and its
hand-written form already builds descriptors **on the device** (`tl.make_tensor_
descriptor` + `desc.load`). To reach parity, auto-TMA needs a **device-descriptor**
mode plus a few FA-specific analysis abilities.

## What "device descriptor" means (vs host recipe)

- **host recipe** (1/6): `CUtensorMap` built on the CPU before launch, injected as
  a hidden arg; the launcher is involved.
- **device descriptor** (this diff): the kernel emits `tt.make_tensor_descriptor`
  in-kernel (lowered to an on-device `tensormap_create`) + `descriptor_load/store`
  — identical to what a hand-written `desc.load` FA produces. No launcher, no
  recipe, no `CUtensorMap` on the host.

## What this diff adds

A second output mode in `PromoteLoadToTMA.cpp`, selected by a new knob:

- **the knob**: `knobs.nvidia.auto_tma_device` (env fallback
  `TRITON_AUTO_TMA_DEVICE`) -> `Passes.td` `device-mode` pass option ->
  `triton_nvidia.cc` bool binding -> `compiler.py`
  `add_promote_load_to_tma(pm, opt.auto_tma_device or knobs.nvidia.auto_tma_device)`
  -> the pass reads `useDevice`.
- **device descriptors**: emit `tt.make_tensor_descriptor` +
  `tt.descriptor_load`/`descriptor_store` in-kernel instead of a host recipe.

Plus the four analysis abilities a warp-specialized FA needs:

1. **per-program base folding** (`scalarBaseOffsets`): fold a uniform per-program
   scalar offset (e.g. the (batch,head) slice) into the descriptor's base pointer.
Details*:
A batched "scale each batch" kernel shifts the whole tile to "its" batch via a
scalar term that belongs to no dimension:

```
pid_b = tl.program_id(0)
xb = x_ptr + pid_b * stride_b                 # whole-tile shift, NO arange
x  = tl.load(xb + offs_m[:, None] * stride_m + offs_n[None, :], mask=...)
```

`decomposePointer` normalizes the pointer to `base + Σ idx_d * stride_d`:
`offs_m*stride_m` is dim 0's index, `offs_n` is dim 1 (contiguous), but
`pid_b*stride_b` is a uniform splat with no arange/expand_dims — it is not any
dimension's index. If it is dropped, the descriptor base stays `x_ptr` and every
program reads batch 0 (wrong). Fix: peel such terms into `scalarBaseOffsets` and
fold them into the descriptor base:

```
desc = make_tensor_descriptor(base   = addptr(x_ptr, pid_b*stride_b),
                              shape  = [M, N], strides = [stride_m, 1],
                              block  = [BLOCK_M, BLOCK_N])
x = descriptor_load(desc, [offs_m_tile, offs_n_tile])
```

"select the batch" moves from a pointer index to the descriptor's base. FA is
identical, with `off_hz*stride_h` selecting the (batch,head) slice. (The host
recipe can only record "arg #k is the base"; it cannot express a runtime base
shift, so host mode skips these loads instead of silently reading batch 0.)

2. **whole-dimension constant extent** (`-2` sentinel): a dim loaded in full with
   no mask (e.g. FA's HEAD_DIM) takes its extent from the compile-time tile size
   instead of failing eligibility.

FA's head dim is loaded whole and is unmasked:

```
offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)   # tiled seq dim
offs_d = tl.arange(0, HEAD_DIM)                     # whole head dim, NO tile
q = tl.load(q_base + offs_m[:, None]*stride_m + offs_d[None, :],
            mask = offs_m[:, None] < N_CTX)         # mask bounds offs_m ONLY
```

The descriptor needs a global extent per dim, recovered from the mask (`offs < E`):
- dim 0 (`offs_m`): `mask offs_m < N_CTX` -> extent = `N_CTX` (a kernel arg). OK.
- dim 1 (`offs_d`): no `pid*BLOCK` offset AND no mask term -> every extent lookup
  returns -1, so the load would be rejected.

But `offs_d = arange(0, HEAD_DIM)` loads the dim in full, so its global extent IS
the compile-time `blockSize` (= HEAD_DIM). The `-2` sentinel records "use the
constant blockSize"; Phase 2 emits an `arith.constant` extent and a zero index for
that dim:

```
desc = make_tensor_descriptor(base   = q_base(+off_hz),
                              shape  = [N_CTX, HEAD_DIM],   # dim1 = const extent
                              strides= [stride_m, 1], block = [BLOCK_M, HEAD_DIM])
q = descriptor_load(desc, [offs_m_tile, 0])               # whole-dim index = 0
```

The sentinel only fires when the dim is genuinely unmasked — guarded so a
partially-masked untiled dim (`arange(0,B) < E` with a real extent E > B, whose
bound analysis failed) is NOT under-sized; such a load is left unpromoted rather
than encoded with a too-small extent. The host recipe cannot encode a constant
extent, so this path is device-only.


3. **device store promotion**: the `descriptor_store` device branch (the WS
   epilogue consumer).
4. **descriptor hoisting**: build the (loop-invariant) descriptor once before the
   pipelined/WS loop. If built inside, the on-device `tensormap_create` lands in
   the `warp_specialize` partition region (IsolatedFromAbove) and its
   `GlobalScratchAllocOp` never gets a scratch offset (LLVM-lowering assert); it
   would also rebuild every persistent tile (~13% slower).

## Worked examples: the two FA-enabling analyses

Recall the invariant: a TMA descriptor (`CUtensorMap`) needs a base pointer, a
(global extent, stride) per dim, and a tile/box shape. Auto-TMA must recover all
of that from the plain `tl.load(ptr + <arith>, mask=...)`. Abilities (1) and (2)
handle the two cases where the naive recovery cannot.

## Before / after

```
host recipe (4/6):  CPU builds CUtensorMap from recipe --> hidden arg     [GEMM]
device mode (this): kernel builds it in-kernel (tensormap_create)          [FA]
                    == byte-for-byte identical to hand-written desc.load
```

## Path (device mode)

```
tl.load(Q + off_hz*stride + offs*stride_m + offs_d, mask=offs<y_dim)
  --(useDevice)--> hoist %d = tt.make_tensor_descriptor(base(+scalar offsets),
                                shape(-2 -> const HEAD_DIM), strides)
              --> tt.descriptor_load %d[tileOffset]  (whole dim index = 0)
  (no recipe, no launcher; lowered to on-device tensormap_create + async_tma_copy)
```

## Files

`knobs.py`, `Passes.td`, `triton_nvidia.cc`, `nvidia/backend/compiler.py`,
`PromoteLoadToTMA.cpp` (device branches + the 4 abilities),
`test_autows_auto_tma.py` (device unit tests). Application to a real FA kernel is
6/6.

Differential Revision: D110948916


