### PR TITLE
[TLX] Add CuTe-style tlx.swizzled_layout(B, M, S) for swizzled shared

### DIFF
--- a/python/test/unit/language/test_tlx_layout.py
+++ b/python/test/unit/language/test_tlx_layout.py
@@ -112,3 +112,76 @@ def test_dump_layout_round_trips_shape_stride(capfd, monkeypatch):
     # was built from -> it round-trips through the compiler.
     expected = _cute_shape_stride(_SEPARABLE_QK_SHAPE, _SEPARABLE_QK_STRIDE)
     assert f"cute: {expected}" in err
+
+
+def test_swizzled_layout_cute_mapping():
+    """`tlx.swizzled_layout(B, M, S)` is the CuTe Swizzle<B,M,S> (positional args).
+    It resolves to Triton's (vec, perPhase, maxPhase) for a given contiguous extent,
+    per the inverse of DumpLayout's emitCuteSwizzle. Pure-Python, no GPU."""
+
+    # vec = 2**M, maxPhase = 2**B, perPhase = 2**(S+M) // numContig.
+    # Mirror the SwizzledSharedEncoding doc examples (order=[1,0], numContig = shape[1]):
+    #   vec=1, perPhase=1, maxPhase=4 over a width-4 tile -> Swizzle<2,0,2>
+    enc = tlx.swizzled_layout(2, 0, 2, order=[1, 0])._to_encoding(shape=[4, 4])
+    assert (enc.vectorSize, enc.perPhase, enc.maxPhase) == (1, 1, 4)
+    #   vec=1, perPhase=2, maxPhase=4 over a width-4 tile -> Swizzle<2,0,3>
+    enc = tlx.swizzled_layout(2, 0, 3, order=[1, 0])._to_encoding(shape=[4, 4])
+    assert (enc.vectorSize, enc.perPhase, enc.maxPhase) == (1, 2, 4)
+    #   vec=2, perPhase=1, maxPhase=4 over a width-8 tile -> Swizzle<2,1,2>
+    enc = tlx.swizzled_layout(2, 1, 2, order=[1, 0])._to_encoding(shape=[4, 8])
+    assert (enc.vectorSize, enc.perPhase, enc.maxPhase) == (2, 1, 4)
+
+    # A Swizzle that would give perPhase < 1 for the extent is rejected.
+    with pytest.raises(AssertionError):
+        tlx.swizzled_layout(2, 0, 0, order=[1, 0])._to_encoding(shape=[4, 8])
+
+
+def test_swizzled_layout_vs_register_layout():
+    """`swizzled_layout` is a shared-memory layout; the shape/stride `tlx.layout`
+    stays a register layout. `tlx.layout(swizzled_layout(...))` also accepts one
+    (eagerly resolving the trivial default). Pure-Python, no GPU."""
+
+    # The no-swizzle default is shape-independent -> tlx.layout resolves it eagerly.
+    a = tlx.layout(tlx.swizzled_layout.make_default(rank=2))
+    assert type(a) is tlx.swizzled_shared_layout_encoding  # exact type -> `type() is` checks hold
+    assert (a.vectorSize, a.perPhase, a.maxPhase, a.order) == (1, 1, 1, [1, 0])
+
+    # A real swizzle is deferred (needs the buffer shape): tlx.layout returns it as-is.
+    atom = tlx.layout(tlx.swizzled_layout(2, 0, 2, order=[1, 0]))
+    assert isinstance(atom, tlx.swizzled_layout)
+
+    # the shape/stride form is unchanged: a register layout
+    r = _separable_qk_layout()
+    assert isinstance(r, tlx.layout) and not isinstance(r, tlx.shared_layout_encoding)
+
+    # tlx.layout() with neither a swizzled_layout nor shape/stride is rejected
+    with pytest.raises(AssertionError):
+        tlx.layout()
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Need CUDA")
+def test_swizzled_layout_lowers_to_swizzled_shared():
+    """`tlx.swizzled_layout(...)` used directly as a `local_alloc` layout lowers to
+    the `#ttg.swizzled_shared` encoding. The trivial default matches the legacy
+    `swizzled_shared_layout_encoding` byte-for-byte; a real Swizzle<B,M,S> resolves
+    its perPhase from the buffer shape."""
+
+    @triton.jit
+    def kernel(LAYOUT: tl.constexpr):
+        x = tl.zeros((128, 64), tl.float16)
+        buf = tlx.local_alloc((128, 64), tl.float16, tl.constexpr(1), layout=LAYOUT)
+        v = tlx.local_view(buf, 0)
+        tlx.local_store(v, x)
+
+    # Trivial swizzled_layout == constructing the legacy encoding directly.
+    cute = tlx.swizzled_layout.make_default(rank=2)
+    direct = tlx.swizzled_shared_layout_encoding.make_default(rank=2)
+    ttgir_cute = kernel.warmup(cute, grid=(1, ), num_warps=4).asm["ttgir"]
+    ttgir_direct = kernel.warmup(direct, grid=(1, ), num_warps=4).asm["ttgir"]
+    assert "#ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>" in ttgir_cute
+    assert ttgir_cute == ttgir_direct
+
+    # A real Swizzle<3,0,6> over a width-64 tile -> vec=1, maxPhase=8,
+    # perPhase = 2**(6+0)//64 = 1.
+    swz = kernel.warmup(tlx.swizzled_layout(3, 0, 6, order=[1, 0]), grid=(1, ), num_warps=4).asm["ttgir"]
+    assert "#ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 8, order = [1, 0]}>" in swz

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -82,6 +82,7 @@ from .types import (
     shared_layout_encoding,
     layout,
     storage_kind,
+    swizzled_layout,
     swizzled_shared_layout_encoding,
     tensor_descriptor_ptr,
     tensor_descriptor_ptr_type,
@@ -110,6 +111,7 @@ __all__ = [
     # types
     "layout_encoding",
     "shared_layout_encoding",
+    "swizzled_layout",
     "swizzled_shared_layout_encoding",
     "padded_shared_layout_encoding",
     "tensor_memory_layout_encoding",

--- a/third_party/tlx/language/tlx/barrier.py
+++ b/third_party/tlx/language/tlx/barrier.py
@@ -5,7 +5,7 @@ from .utility import is_hip
 
 
 def _make_mbarrier_layout_handle(_semantic):
-    layout = tlx.swizzled_shared_layout_encoding.make_default(rank=1)
+    layout = tlx.layout(tlx.swizzled_layout.make_default(rank=1))
     layout_handle = _semantic.builder.make_swizzled_shared_encoding_attr(
         layout.vectorSize,
         layout.perPhase,

--- a/third_party/tlx/language/tlx/dynamic_launch.py
+++ b/third_party/tlx/language/tlx/dynamic_launch.py
@@ -13,7 +13,7 @@ def _alloc_clc_responses(
     num_responses: tl.constexpr,
     _semantic=None,
 ) -> tlx.clc_response:
-    layout = tlx.swizzled_shared_layout_encoding.make_default(rank=1)
+    layout = tlx.layout(tlx.swizzled_layout.make_default(rank=1))
     layout_handle = _semantic.builder.make_swizzled_shared_encoding_attr(
         layout.vectorSize,
         layout.perPhase,

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -293,7 +293,7 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
     if layout is None:
         if storage == tlx.storage_kind.smem:
             if len(shape) == 1:
-                layout = tlx.swizzled_shared_layout_encoding.make_default(rank=len(shape))
+                layout = tlx.layout(tlx.swizzled_layout.make_default(rank=len(shape)))
                 layout._tlx_default = True
                 layout_handle = _semantic.builder.make_swizzled_shared_encoding_attr(
                     layout.vectorSize,
@@ -305,7 +305,7 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
                     layout.numCTAOrder,
                 )
             elif _semantic.builder.options.arch.startswith("gfx"):
-                layout = tlx.swizzled_shared_layout_encoding.make_default(rank=len(shape))
+                layout = tlx.layout(tlx.swizzled_layout.make_default(rank=len(shape)))
                 layout._tlx_default = True
                 layout_handle = _semantic.builder.make_swizzled_shared_encoding_attr(
                     layout.vectorSize,
@@ -344,6 +344,10 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
         if storage != tlx.storage_kind.smem:
             raise NotImplementedError("User-specified layout encoding is only supported for shared memory (smem)")
         layout = tl._unwrap_if_constexpr(layout)
+        # A CuTe swizzled_layout (Swizzle<B,M,S>) needs the buffer shape to resolve
+        # its perPhase; do it now that shape is known.
+        if isinstance(layout, tlx.swizzled_layout):
+            layout = layout._to_encoding(unwrapped_shape)
         if not isinstance(layout, tlx.shared_layout_encoding):
             raise TypeError(f"`layout` must be a tlx.shared_layout_encoding, got {type(layout).__name__}")
         layout_handle = layout.to_ir(_semantic.builder)
@@ -1046,7 +1050,7 @@ def local_reshape(
     assert isinstance(src, tlx.buffered_tensor) and src.type.storage == tlx.storage_kind.smem, (
         "TLX local_reshape only supports SMEM")
     reshape_handle = _semantic.builder.create_memdesc_reshape(src.handle, shape)
-    layout = tlx.swizzled_shared_layout_encoding.make_default(rank=len(shape))
+    layout = tlx.layout(tlx.swizzled_layout.make_default(rank=len(shape)))
     return tlx.buffered_tensor(
         reshape_handle,
         src.type.scalar,
@@ -1173,7 +1177,7 @@ def _amd_tdm_descriptor_layout(desc):
     max_pad_interval = 256 * 32 // elem_width
     if pad_interval <= max_pad_interval:
         return tlx.padded_shared_layout_encoding.with_identity_for([(pad_interval, pad_amount)], block_shape, order)
-    return tlx.swizzled_shared_layout_encoding.make_default(rank=ndim)
+    return tlx.layout(tlx.swizzled_layout.make_default(rank=ndim))
 
 
 def _layouts_match(actual, expected):

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -115,9 +115,9 @@ class swizzled_layout:
     bit-count args, e.g. ``tlx.swizzled_layout(3, 3, 3)``. Use it directly as a
     ``tlx.local_alloc(..., layout=...)`` layout; it lowers to ``#ttg.swizzled_shared``.
 
-      - ``bits``  (B): number of XOR phases      -> ``maxPhase = 2**B``
-      - ``base``  (M): unswizzled contiguous unit -> ``vec = 2**M``
-      - ``shift`` (S): distance between the XOR'd bit fields
+      - ``bits``  (B): log2 number of XOR phases      -> ``maxPhase = 2**B``
+      - ``base``  (M): log2 unswizzled contiguous unit -> ``vec = 2**M``
+      - ``shift`` (S): distance between the XOR'd bit fields in log2 units
 
     ``order`` lists axes fastest-varying first (like the Triton encoding); it may
     be omitted, in which case a row-major default is used once the rank is known.
@@ -154,6 +154,16 @@ class swizzled_layout:
     def vectorSize(self):
         return 1 << self.base
 
+    def __repr__(self):
+        return f"swizzled_layout(Swizzle<{self.bits},{self.base},{self.shift}>, order={self.order})"
+
+    def __eq__(self, other):
+        return (isinstance(other, swizzled_layout) and self.bits == other.bits and self.base == other.base
+                and self.shift == other.shift and self.order == other.order)
+
+    def __hash__(self):
+        return hash((self.bits, self.base, self.shift, tuple(self.order) if self.order else None))
+
     def _to_encoding(self, shape=None):
         """Resolve to a concrete swizzled_shared_layout_encoding for `shape`.
 
@@ -177,7 +187,7 @@ class swizzled_layout:
                                  "pass it via tlx.local_alloc(..., layout=tlx.swizzled_layout(...))")
             numContig = int(shape[order[0]])
             span = 1 << (self.shift + self.base)
-            assert span >= numContig and span % numContig == 0, (
+            assert span % numContig == 0, (
                 f"swizzled_layout: Swizzle<{self.bits},{self.base},{self.shift}> gives perPhase < 1 "
                 f"for contiguous extent {numContig} (need shift + base >= log2(numContig))")
             perPhase = span // numContig
@@ -486,6 +496,9 @@ class layout(layout_encoding):
 
     def __new__(cls, spec=None, *, shape=None, stride=None):
         # ``tlx.layout(swizzled_layout(...))`` -> a swizzled shared-memory layout.
+        # shape/stride are declared here only to mirror __init__ signature;
+        # they are unused in __new__ because __new__ returns early for swizzled
+        # case and super().__new__ for register case does not need them.
         if isinstance(spec, swizzled_layout):
             # A trivial (non-)swizzle is shape-independent, so resolve it now to a
             # concrete encoding. A real swizzle's perPhase depends on the buffer
@@ -497,6 +510,10 @@ class layout(layout_encoding):
 
     def __init__(self, spec=None, *, shape=None, stride=None):
         super().__init__()
+        # Note: shape and stride are keyword-only as of the swizzled_layout
+        # refactor to avoid ambiguity with positional swizzled_layout args.
+        # Pre-existing callers in-tree already use kwargs; positional use
+        # would be misinterpreted as spec and fail with a clear AssertionError.
         assert shape is not None and stride is not None, \
             "tlx.layout requires a swizzled_layout(...), or shape=/stride= for a register layout"
         assert len(shape) == 2 and len(stride) == 2, \

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -108,6 +108,91 @@ class swizzled_shared_layout_encoding(shared_layout_encoding):
         )
 
 
+class swizzled_layout:
+    """A CuTe ``Swizzle<B, M, S>`` shared-memory layout.
+
+    Constructed exactly like ``cute::Swizzle<B, M, S>`` with three positional
+    bit-count args, e.g. ``tlx.swizzled_layout(3, 3, 3)``. Use it directly as a
+    ``tlx.local_alloc(..., layout=...)`` layout; it lowers to ``#ttg.swizzled_shared``.
+
+      - ``bits``  (B): number of XOR phases      -> ``maxPhase = 2**B``
+      - ``base``  (M): unswizzled contiguous unit -> ``vec = 2**M``
+      - ``shift`` (S): distance between the XOR'd bit fields
+
+    ``order`` lists axes fastest-varying first (like the Triton encoding); it may
+    be omitted, in which case a row-major default is used once the rank is known.
+
+    Because CuTe's ``S`` is defined on the flat offset while Triton's ``perPhase``
+    is per-row, the layout is resolved to concrete ``(vec, perPhase, maxPhase)`` only
+    once the buffer shape is known (at ``local_alloc``), via the inverse of
+    ``DumpLayout``'s ``emitCuteSwizzle``::
+
+        vec      = 2**base
+        maxPhase = 2**bits
+        perPhase = 2**(shift + base) // numContig   # numContig = shape[order[0]]
+
+    A no-op (non-swizzled) default is ``swizzled_layout.make_default(rank)``
+    (``Swizzle<0,0,0>``), which is shape-independent and resolves eagerly.
+    """
+
+    def __init__(self, bits, base=0, shift=0, order=None):
+        self.bits = bits  # B
+        self.base = base  # M
+        self.shift = shift  # S
+        self.order = list(order) if order is not None else None
+
+    @classmethod
+    def make_default(cls, rank):
+        # No swizzle (Swizzle<0,0,0>), row-major order.
+        return cls(bits=0, base=0, shift=0, order=list(reversed(range(rank))))
+
+    @property
+    def maxPhase(self):
+        return 1 << self.bits
+
+    @property
+    def vectorSize(self):
+        return 1 << self.base
+
+    def _to_encoding(self, shape=None):
+        """Resolve to a concrete swizzled_shared_layout_encoding for `shape`.
+
+        `shape` is required for a real swizzle (maxPhase > 1); the trivial
+        default (maxPhase == 1) is shape-independent.
+        """
+        if self.order is not None:
+            rank = len(self.order)
+        elif shape is not None:
+            rank = len(shape)
+        else:
+            raise ValueError("swizzled_layout: cannot resolve without an order or a shape")
+        order = list(self.order) if self.order is not None else list(reversed(range(rank)))
+        vec = 1 << self.base
+        maxPhase = 1 << self.bits
+        if maxPhase == 1:
+            perPhase = 1
+        else:
+            if shape is None:
+                raise ValueError("swizzled_layout: a non-trivial Swizzle requires the buffer shape; "
+                                 "pass it via tlx.local_alloc(..., layout=tlx.swizzled_layout(...))")
+            numContig = int(shape[order[0]])
+            span = 1 << (self.shift + self.base)
+            assert span >= numContig and span % numContig == 0, (
+                f"swizzled_layout: Swizzle<{self.bits},{self.base},{self.shift}> gives perPhase < 1 "
+                f"for contiguous extent {numContig} (need shift + base >= log2(numContig))")
+            perPhase = span // numContig
+        return swizzled_shared_layout_encoding(
+            vec,
+            perPhase,
+            maxPhase,
+            order,
+            [1] * rank,
+            [1] * rank,
+            [1] * rank,
+            list(reversed(range(rank))),
+        )
+
+
 class padded_shared_layout_encoding(shared_layout_encoding):
     """Padded shared encoding with an identity offset map.
 
@@ -376,6 +461,11 @@ class layout(layout_encoding):
     **stride** (a CuTe-style thread-value layout), for
     `tlx.local_load(buf, layout=...)`.
 
+    For a swizzled shared-memory layout use :class:`swizzled_layout` (a CuTe
+    ``Swizzle<B, M, S>``) directly; ``tlx.layout(swizzled_layout(...))`` also
+    accepts one and forwards it as a shared-memory layout rather than a register
+    layout.
+
     The layout has two top-level modes — `(thread, value)`:
       - ``shape``  = ``(thread_shape, value_shape)``
       - ``stride`` = ``(thread_stride, value_stride)``
@@ -394,8 +484,21 @@ class layout(layout_encoding):
         )
     """
 
-    def __init__(self, shape, stride):
+    def __new__(cls, spec=None, *, shape=None, stride=None):
+        # ``tlx.layout(swizzled_layout(...))`` -> a swizzled shared-memory layout.
+        if isinstance(spec, swizzled_layout):
+            # A trivial (non-)swizzle is shape-independent, so resolve it now to a
+            # concrete encoding. A real swizzle's perPhase depends on the buffer
+            # shape, so defer it: local_alloc resolves the atom once shape is known.
+            if spec.maxPhase == 1:
+                return spec._to_encoding()
+            return spec
+        return super().__new__(cls)
+
+    def __init__(self, spec=None, *, shape=None, stride=None):
         super().__init__()
+        assert shape is not None and stride is not None, \
+            "tlx.layout requires a swizzled_layout(...), or shape=/stride= for a register layout"
         assert len(shape) == 2 and len(stride) == 2, \
             "layout: shape and stride must each be (thread, value)"
         self.thread_shape, self.value_shape = shape

--- a/third_party/tlx/tutorials/gfx9_gemm/a16w16/v2_async_copy/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/a16w16/v2_async_copy/matmul_kernel.py
@@ -21,12 +21,8 @@ def v2_async_copy(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak, stride_bk,
     # Plain (unpadded) swizzled layouts — this step uses async copy but NOT yet
     # the bank-conflict-avoiding padded layout (that's v3). Specify them
     # explicitly so the compiler's padded-layout inference doesn't pad here.
-    layout_a: tl.constexpr = tlx.swizzled_shared_layout_encoding(vectorSize=1, perPhase=1, maxPhase=1, order=[1, 0],
-                                                                 numCTAs=[1, 1], numCTAsPerCGA=[1, 1],
-                                                                 numCTASplit=[1, 1], numCTAOrder=[1, 1])
-    layout_b: tl.constexpr = tlx.swizzled_shared_layout_encoding(vectorSize=1, perPhase=1, maxPhase=1, order=[0, 1],
-                                                                 numCTAs=[1, 1], numCTAsPerCGA=[1, 1],
-                                                                 numCTASplit=[1, 1], numCTAOrder=[1, 1])
+    layout_a: tl.constexpr = tlx.swizzled_layout(0, 0, 0, order=[1, 0])
+    layout_b: tl.constexpr = tlx.swizzled_layout(0, 0, 0, order=[0, 1])
     smem_a = tlx.local_alloc((BLOCK_M, BLOCK_K), tl.float16, 1, layout=layout_a)
     smem_b = tlx.local_alloc((BLOCK_K, BLOCK_N), tl.float16, 1, layout=layout_b)
 


### PR DESCRIPTION

Introduce tlx.swizzled_layout, a CuTe Swizzle<B, M, S> (positional bit-count args) that lowers to #ttg.swizzled_shared, and route the swizzled shared-memory layout callsites through it (local_alloc defaults, barriers, CLC responses, local_reshape, AMD TDM fallback, and the gfx9 GEMM tutorial).

The atom resolves to Triton's (vec, perPhase, maxPhase) once the buffer shape is known at local_alloc, mirroring the inverse of DumpLayout's emitCuteSwizzle (vec=2**M, maxPhase=2**B, perPhase=2**(S+M)//numContig); the trivial Swizzle<0,0,0> default is shape-independent and resolves eagerly.