### PR TITLE
[torchTLX] AMD FlexAttention Templates (gfx950/MI350) (#2003)

### DIFF
--- a/python/test/unit/language/test_torchtlx_fusions.py
+++ b/python/test/unit/language/test_torchtlx_fusions.py
@@ -65,6 +65,28 @@ def is_gfx950():
         return False
 
 
+def supports_template_epilogue_fusion():
+    """True if the active torch exposes the template epilogue-fusion codegen API.
+
+    Older torch wheels (e.g. the current ROCm nightly) lack it, and additionally
+    decompose ``addmm`` -> ``mm`` + epilogue when a pointwise consumer follows, so
+    the TLX addmm warp-pipe template is never a candidate. Epilogue-fusion tests
+    gate on this so they run on a matching torch and skip cleanly otherwise.
+
+    Probe torch directly (``codegen_template_body`` is the method the fork's
+    fusion path wraps) rather than importing the fork registry: importing the
+    registry this early — at collection time, before torch first imports it during
+    compile — perturbs TLX JIT resolution on some torch versions and breaks
+    unrelated template compiles.
+    """
+    try:
+        from torch._inductor.select_algorithm import TritonTemplateKernel
+
+        return hasattr(TritonTemplateKernel, "codegen_template_body")
+    except Exception:
+        return False
+
+
 torch.set_float32_matmul_precision("high")
 
 # Shapes for fusion testing - representative shapes from gemm_rule categories
@@ -283,6 +305,10 @@ class TestTorchTLXEpilogueFusion(TestCase):
         "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
     )
     @unittest.skipIf(not has_tlx(), "TLX not available")
+    @unittest.skipIf(
+        not supports_template_epilogue_fusion(),
+        "torch lacks the template epilogue-fusion codegen API (old ROCm nightly)",
+    )
     @parametrize("dtype", (torch.float16, torch.bfloat16))
     def test_tlx_addmm_relu_epilogue_is_fused(
         self,

--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -35,6 +35,20 @@ def is_gfx950() -> bool:
         return False
 
 
+def flex_choices_hook_available() -> bool:
+    """True if torch exposes the flex-attention choices hook the template needs.
+
+    Absent on the current ROCm nightly, so the flex-attention Inductor tests skip
+    there (the template can only be exercised end-to-end on a newer torch).
+    """
+    try:
+        from torch._inductor.choices import InductorChoices
+
+        return hasattr(InductorChoices, "append_flex_attention_choices")
+    except Exception:
+        return False
+
+
 torch.set_float32_matmul_precision("high")
 
 # Shapes for template testing - representative shapes from gemm_rule categories
@@ -682,6 +696,127 @@ HEURISTIC_CODEGEN_CASES = [
         True,
     ),
 ]
+
+
+@instantiate_parametrized_tests
+class TestFlexAttention(TestCase):
+    """AMD (gfx950/MI350) FlexAttention Inductor template.
+
+    Exercises torch.compile(flex_attention) under tlx_mode and asserts the
+    tlx_amd_flex_attention template is selected and numerically correct across
+    score_mod / mask_mod / logsumexp. Gated on the torch flex-choices hook, which
+    the current ROCm nightly lacks, so these skip there and are validated on a
+    newer torch (e.g. fbsource).
+    """
+
+    def _qkv(self, B, H, N, D, dtype):
+        torch.manual_seed(0)
+        return [torch.randn(B, H, N, D, device=GPU_TYPE, dtype=dtype) for _ in range(3)]
+
+    def _run(self, fn, q, k, v):
+        with config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+        }):
+            out, code = run_and_get_code(torch.compile(fn), q, k, v)
+        return out, "\n".join(code)
+
+    @unittest.skipIf(not is_gfx950(), "Need AMD MI350X (gfx950)")
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @unittest.skipIf(
+        not flex_choices_hook_available(),
+        "torch lacks append_flex_attention_choices (old ROCm nightly)",
+    )
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    def test_flex_none(self, dtype):
+        from torch.nn.attention.flex_attention import flex_attention
+
+        B, H, N, D = 1, 2, 256, 64
+        sm = 1.0 / (D**0.5)
+        q, k, v = self._qkv(B, H, N, D, dtype)
+        out, code = self._run(lambda q, k, v: flex_attention(q, k, v, scale=sm), q, k, v)
+        ref = flex_attention(q, k, v, scale=sm)
+        torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+        self.assertIn("tlx_amd_flex_attention", code)
+
+    @unittest.skipIf(not is_gfx950(), "Need AMD MI350X (gfx950)")
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @unittest.skipIf(
+        not flex_choices_hook_available(),
+        "torch lacks append_flex_attention_choices (old ROCm nightly)",
+    )
+    def test_flex_causal(self):
+        from torch.nn.attention.flex_attention import (
+            create_block_mask,
+            flex_attention,
+        )
+
+        B, H, N, D = 1, 2, 256, 64
+        sm = 1.0 / (D**0.5)
+        q, k, v = self._qkv(B, H, N, D, torch.float16)
+        bm = create_block_mask(lambda b, h, m, n: m >= n, B, H, N, N, device=GPU_TYPE)
+        out, code = self._run(lambda q, k, v: flex_attention(q, k, v, block_mask=bm, scale=sm), q, k, v)
+        ref = flex_attention(q, k, v, block_mask=bm, scale=sm)
+        torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+        self.assertIn("tlx_amd_flex_attention", code)
+
+    @unittest.skipIf(not is_gfx950(), "Need AMD MI350X (gfx950)")
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @unittest.skipIf(
+        not flex_choices_hook_available(),
+        "torch lacks append_flex_attention_choices (old ROCm nightly)",
+    )
+    def test_flex_score_mod(self):
+        from torch.nn.attention.flex_attention import flex_attention
+
+        B, H, N, D = 1, 2, 256, 64
+        sm = 1.0 / (D**0.5)
+        slope = 0.1
+        q, k, v = self._qkv(B, H, N, D, torch.float16)
+        score_mod = lambda s, b, h, m, n: s - slope * (m - n)  # noqa: E731
+        out, code = self._run(
+            lambda q, k, v: flex_attention(q, k, v, score_mod=score_mod, scale=sm),
+            q,
+            k,
+            v,
+        )
+        ref = flex_attention(q, k, v, score_mod=score_mod, scale=sm)
+        torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+        self.assertIn("tlx_amd_flex_attention", code)
+
+    @unittest.skipIf(not is_gfx950(), "Need AMD MI350X (gfx950)")
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @unittest.skipIf(
+        not flex_choices_hook_available(),
+        "torch lacks append_flex_attention_choices (old ROCm nightly)",
+    )
+    def test_flex_logsumexp(self):
+        from torch.nn.attention.flex_attention import (
+            create_block_mask,
+            flex_attention,
+        )
+
+        B, H, N, D = 1, 2, 256, 64
+        sm = 1.0 / (D**0.5)
+        q, k, v = self._qkv(B, H, N, D, torch.float16)
+        bm = create_block_mask(lambda b, h, m, n: m >= n, B, H, N, N, device=GPU_TYPE)
+        with config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+        }):
+            (out, lse), code = run_and_get_code(
+                torch.compile(lambda q, k, v: flex_attention(q, k, v, block_mask=bm, scale=sm, return_lse=True)),
+                q,
+                k,
+                v,
+            )
+        ref_o, ref_lse = flex_attention(q, k, v, block_mask=bm, scale=sm, return_lse=True)
+        torch.testing.assert_close(out, ref_o, atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(lse, ref_lse, atol=3e-2, rtol=3e-2)
+        self.assertIn("tlx_amd_flex_attention", "\n".join(code))
+
 
 if __name__ == "__main__":
     run_tests()

--- a/scripts/run_torchtlx_tests.sh
+++ b/scripts/run_torchtlx_tests.sh
@@ -1,55 +1,47 @@
 #!/usr/bin/env bash
-# One-shot runner for the torchTLX Inductor unit tests (templates + fusions).
+# Runner for the torchTLX Inductor unit tests (templates + fusions, incl. the AMD
+# FlexAttention tests).
 #
-# From a fresh terminal on an fbtriton dev box this will, idempotently:
-#   1. create an isolated venv (.venv) if missing,
-#   2. install a nightly PyTorch (torchTLX tracks nightly, not stable),
-#   3. build the fbtriton fork Triton (with the TLX dialect) into that venv,
-#   4. apply a small stopgap so torch carries the torchTLX PyTorch-side pieces
-#      (tlx_mode knob + fork-loading template_heuristics/tlx.py) until they land
-#      in OSS PyTorch,
-#   5. run the two test files with the env fixes they need.
-# Re-running when everything is already set up just runs the tests.
+# By default it just RUNS the tests against the existing venv (fast). Pass --build
+# to bootstrap first: create the venv, install a PRE (nightly) PyTorch — torchTLX
+# tracks nightly, not stable — build the fbtriton fork Triton, and apply the torch
+# shim. Any other args (and explicit test paths) are forwarded to pytest.
 #
 # Usage:
-#   scripts/run_torchtlx_tests.sh                 # bootstrap (if needed) + run both files
-#   scripts/run_torchtlx_tests.sh -k matmul_ws    # forward extra args to pytest
-#   TORCHTLX_SKIP_SETUP=1 scripts/run_torchtlx_tests.sh   # just run, assume ready env
+#   scripts/run_torchtlx_tests.sh                  # run tests (env already set up)
+#   scripts/run_torchtlx_tests.sh --build          # bootstrap (pre torch + build) then run
+#   scripts/run_torchtlx_tests.sh -k flex          # forward args to pytest
+#   scripts/run_torchtlx_tests.sh --build -k flex  # combine
 #
 # Env knobs:
-#   TORCHTLX_VENV=<dir>     venv location (default: <repo>/.venv)
-#   TORCH_INDEX_URL=<url>   torch nightly index (default cu128; use a rocm index on AMD)
-#   TORCHTLX_STDCXX_DIR=<d> dir with a modern libstdc++.so.6 (auto-detected if unset)
-#   PIP_EXTRA_INDEX_URL=<url>  extra index for torch's deps (helps on networks that
-#                              block pypi.nvidia.com)
-#   Offline/constrained builds may also export LLVM_SYSPATH / TRITON_OFFLINE_BUILD /
-#   JSON_SYSPATH; they are inherited by the build step.
+#   TORCHTLX_VENV=<dir>       venv location (default <repo>/.venv)
+#   TORCH_INDEX_URL=<url>     torch nightly index (auto: cu128 on NV, rocm on AMD)
+#   TORCHTLX_ROCM_LINE=<x.y>  rocm nightly line on AMD (default 7.0)
+#   TORCHTLX_STDCXX_DIR=<d>   dir with a modern libstdc++.so.6 (auto-detected)
+#   PIP_EXTRA_INDEX_URL / LLVM_SYSPATH / TRITON_OFFLINE_BUILD / JSON_SYSPATH / CC /
+#   CXX are inherited by the --build step (needed for offline / AMD fork builds).
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 REPO="$PWD"
 VENV="${TORCHTLX_VENV:-$REPO/.venv}"
 PY="$VENV/bin/python"
-TORCH_INDEX_URL="${TORCH_INDEX_URL:-https://download.pytorch.org/whl/nightly/cu128}"
 TESTS=(
   python/test/unit/language/test_torchtlx_templates.py
   python/test/unit/language/test_torchtlx_fusions.py
 )
-
 log() { echo "[run_torchtlx_tests] $*"; }
 
-# --- pip/venv backend (prefer uv; fall back to python -m venv + pip) ----------
-if command -v uv >/dev/null 2>&1; then
-  mkvenv() { uv venv "$VENV"; }
-  PIP()    { uv pip install --python "$PY" "$@"; }
-  PIPUN()  { uv pip uninstall --python "$PY" "$@" 2>/dev/null || true; }
-else
-  mkvenv() { "$(command -v python3)" -m venv "$VENV"; }
-  PIP()    { "$PY" -m pip install "$@"; }
-  PIPUN()  { "$PY" -m pip uninstall -y "$@" 2>/dev/null || true; }
-fi
+# --- args: extract --build, forward the rest to pytest ------------------------
+BUILD=0
+PYTEST_ARGS=()
+for a in "$@"; do
+  if [ "$a" = "--build" ]; then BUILD=1; else PYTEST_ARGS+=("$a"); fi
+done
 
-# --- locate a modern libstdc++ (the prebuilt LLVM needs GLIBCXX_3.4.30) -------
+# --- runtime library path (import torch + the fork .so need these) ------------
+# .venv/lib carries the libzstd.so.1 symlink torch needs; a modern libstdc++
+# (GLIBCXX_3.4.30) is needed where the prebuilt LLVM was linked against it.
 detect_stdcxx_dir() {
   if [ -n "${TORCHTLX_STDCXX_DIR:-}" ]; then echo "$TORCHTLX_STDCXX_DIR"; return; fi
   local base_home cand
@@ -62,53 +54,75 @@ detect_stdcxx_dir() {
   done
   echo ""
 }
+[ -d "$VENV/lib" ] && export LD_LIBRARY_PATH="$VENV/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+STDCXX="$(detect_stdcxx_dir)"
+[ -n "$STDCXX" ] && export LD_LIBRARY_PATH="$STDCXX${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-if [ "${TORCHTLX_SKIP_SETUP:-0}" != "1" ]; then
-  # 1) venv --------------------------------------------------------------------
-  if [ ! -x "$PY" ]; then log "creating venv at $VENV"; mkvenv; fi
-  STDCXX="$(detect_stdcxx_dir)"
+if [ "$BUILD" = 1 ]; then
+  # pip/venv backend (prefer uv; fall back to python -m venv + pip)
+  if command -v uv >/dev/null 2>&1; then
+    PIP()   { uv pip install --python "$PY" "$@"; }
+    PIPUN() { uv pip uninstall --python "$PY" "$@" 2>/dev/null || true; }
+    [ -x "$PY" ] || { log "creating venv at $VENV"; uv venv "$VENV"; }
+  else
+    PIP()   { "$PY" -m pip install "$@"; }
+    PIPUN() { "$PY" -m pip uninstall -y "$@" 2>/dev/null || true; }
+    [ -x "$PY" ] || { log "creating venv at $VENV"; "$(command -v python3)" -m venv "$VENV"; }
+  fi
+  [ -d "$VENV/lib" ] && export LD_LIBRARY_PATH="$VENV/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+  # torch nightly index: cu128 on NV; on AMD the rocm<line> nightly (its wheel
+  # bundles the ROCm runtime so it runs on gfx950 regardless of system ROCm).
+  default_index() {
+    if command -v nvidia-smi >/dev/null 2>&1; then
+      echo "https://download.pytorch.org/whl/nightly/cu128"
+    elif command -v rocminfo >/dev/null 2>&1 || ls -d /opt/rocm* >/dev/null 2>&1; then
+      echo "https://download.pytorch.org/whl/nightly/rocm${TORCHTLX_ROCM_LINE:-7.0}"
+    else
+      echo "https://download.pytorch.org/whl/nightly/cu128"
+    fi
+  }
+  TORCH_INDEX_URL="${TORCH_INDEX_URL:-$(default_index)}"
+
+  # libstdc++ for the fork link step
   if [ -n "$STDCXX" ]; then
     log "using libstdc++ from $STDCXX"
-    export LD_LIBRARY_PATH="$STDCXX${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
     export LIBRARY_PATH="$STDCXX${LIBRARY_PATH:+:$LIBRARY_PATH}"
     export LDFLAGS="-L$STDCXX -Wl,-rpath,$STDCXX ${LDFLAGS:-}"
   else
     log "WARNING: no libstdc++ with GLIBCXX_3.4.30 found; the Triton link step may fail."
-    log "         set TORCHTLX_STDCXX_DIR to a dir containing a newer libstdc++.so.6"
   fi
 
-  # 2) nightly torch -----------------------------------------------------------
-  if ! LD_LIBRARY_PATH="${STDCXX:-}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" "$PY" -c "import torch" 2>/dev/null; then
-    log "installing nightly torch from $TORCH_INDEX_URL"
-    PIP --pre --upgrade torch --index-url "$TORCH_INDEX_URL" \
+  # PRE (nightly) torch — torchTLX tracks nightly (never stable): the TLX Inductor
+  # templates plug into recent Inductor APIs that stable releases lag.
+  if ! "$PY" -c "import torch" 2>/dev/null; then
+    log "installing nightly (pre) torch from $TORCH_INDEX_URL"
+    PIP --pre torch --index-url "$TORCH_INDEX_URL" \
       ${PIP_EXTRA_INDEX_URL:+--extra-index-url "$PIP_EXTRA_INDEX_URL"}
-    # drop the pytorch-triton torch pulls so it can't shadow the fork build
-    PIPUN pytorch-triton triton
+    PIPUN pytorch-triton triton pytorch-triton-rocm  # don't let a wheel triton shadow the fork
   fi
 
-  # 3) build the fork Triton ---------------------------------------------------
-  if ! LD_LIBRARY_PATH="${STDCXX:-}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" "$PY" -c "import triton, triton.language.extra.tlx" 2>/dev/null; then
+  # build the fork Triton (with the TLX dialect) into the venv
+  if ! "$PY" -c "import triton, triton.language.extra.tlx" 2>/dev/null; then
     log "installing build + test requirements"
     PIP -r python/requirements.txt -r python/test-requirements.txt
     log "building the fbtriton fork Triton (this can take a few minutes)"
     PIP -e . --no-build-isolation
   fi
 
-  # 4) torch stopgap (tlx_mode knob + fork-loading tlx.py) ---------------------
+  # torch shim: tlx_mode knob + fork-loading template_heuristics/tlx.py
   "$PY" scripts/_torchtlx_torch_shim.py
-else
-  STDCXX="$(detect_stdcxx_dir)"
-  [ -n "$STDCXX" ] && export LD_LIBRARY_PATH="$STDCXX${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 fi
 
 # --- sanity + run -------------------------------------------------------------
 "$PY" -c "import triton; print('[run_torchtlx_tests] triton ->', triton.__file__)"
 
-# TORCHINDUCTOR_COMPILE_THREADS=1: the autotune subprocess workers otherwise
-# crash with '0 active drivers' (no GPU backend in the worker).
+# COMPILE_THREADS=1: autotune subprocess workers otherwise crash with
+# '0 active drivers' (no GPU backend in the worker).
 export TORCHINDUCTOR_COMPILE_THREADS=1
 
 # Explicit test paths passed by the caller override the defaults.
+set -- "${PYTEST_ARGS[@]+"${PYTEST_ARGS[@]}"}"
 have_path=0
 for a in "$@"; do case "$a" in -*) ;; *) [ -e "$a" ] && have_path=1;; esac; done
 if [ "$have_path" -eq 0 ]; then set -- "${TESTS[@]}" "$@"; fi

--- a/third_party/tlx/language/tlx/inductor/flex_attention_templates.py
+++ b/third_party/tlx/language/tlx/inductor/flex_attention_templates.py
@@ -6,13 +6,37 @@ from torch._inductor.select_algorithm import TritonTemplate
 from .mm_templates import load_tlx_template
 
 
-tlx_flex_attention_template = TritonTemplate(
-    name="tlx_blackwell_flex_attention_ws",
-    grid=flex_attention_grid,
-    source=load_tlx_template("tlx_flex_attention")
-    + load_flex_template("utilities"),
-    always_freeze_layout=True,
+def _make_flex_template(name, source):
+    # always_freeze_layout is a newer-torch TritonTemplate kwarg; drop it on
+    # torch versions that don't accept it so the module still imports.
+    try:
+        return TritonTemplate(name=name, grid=flex_attention_grid, source=source,
+                              always_freeze_layout=True)
+    except TypeError:
+        return TritonTemplate(name=name, grid=flex_attention_grid, source=source)
+
+
+tlx_flex_attention_template = _make_flex_template(
+    "tlx_blackwell_flex_attention_ws",
+    load_tlx_template("tlx_flex_attention") + load_flex_template("utilities"),
 )
+
+# AMD CDNA4 (gfx950/MI350) flex-attention: single-task MFMA + LDS async_load body
+# (no warp specialization / TMEM / TMA). Shares the flex scaffolding + utilities.
+tlx_amd_flex_attention_template = _make_flex_template(
+    "tlx_amd_flex_attention",
+    load_tlx_template("tlx_amd_flex_attention") + load_flex_template("utilities"),
+)
+
+
+def _is_amd_gfx950() -> bool:
+    """True on AMD MI350X (gfx950), where the AMD flex template applies."""
+    if torch.version.hip is None:
+        return False
+    try:
+        return "gfx95" in torch.cuda.get_device_properties(0).gcnArchName
+    except Exception:
+        return False
 
 
 def append_tlx_flex_attention_choice(
@@ -51,6 +75,15 @@ def append_tlx_flex_attention_choice(
     query, logsumexp, max_scores = input_nodes[0], input_nodes[3], input_nodes[4]
     mutated_inputs = [logsumexp, max_scores]
     num_sms = torch.cuda.get_device_properties(0).multi_processor_count
+
+    # ---- AMD (gfx950/MI350): single-task MFMA/LDS template ----
+    if _is_amd_gfx950():
+        _append_amd_flex_choices(
+            choices, configs, input_nodes, subgraphs, layout,
+            original_kernel_options, sparse_q_block_size, sparse_kv_block_size,
+            query, mutated_inputs,
+        )
+        return
 
     def tlx_options():
         opts = original_kernel_options.copy()
@@ -94,3 +127,52 @@ def append_tlx_flex_attention_choice(
     opts["BLOCK_M"] = last_conf.block_m
     opts["BLOCK_N"] = last_conf.block_n
     append(opts)
+
+
+def _append_amd_flex_choices(
+    choices,
+    configs,
+    input_nodes,
+    subgraphs,
+    layout,
+    original_kernel_options,
+    sparse_q_block_size,
+    sparse_kv_block_size,
+    query,
+    mutated_inputs,
+):
+    """Append AMD (gfx950) flex-attention candidates: single-task MFMA/LDS body.
+
+    Unlike the Blackwell path this uses no warp specialization / TMEM / TMA, so
+    USE_TMA / NUM_MMA_GROUPS are not set. num_warps follows the MFMA tile
+    (BLOCK_M / mfma_m rows per wave), capped at 8.
+    """
+    def amd_options():
+        opts = original_kernel_options.copy()
+        for k in list(opts.keys()):
+            if k.startswith("fwd_"):
+                opts[k[4:]] = opts.pop(k)
+            elif k.startswith("bwd_"):
+                opts.pop(k)
+        opts["USE_TMA"] = False
+        opts.setdefault("SPARSE_Q_BLOCK_SIZE", sparse_q_block_size)
+        opts.setdefault("SPARSE_KV_BLOCK_SIZE", sparse_kv_block_size)
+        return opts
+
+    mfma_m = 32
+    for conf in configs:
+        opts = amd_options()
+        opts["BLOCK_M"] = conf.block_m
+        opts["BLOCK_N"] = conf.block_n
+        opts["num_warps"] = min(8, max(1, conf.block_m // mfma_m))
+        # TLX is hand-pipelined; disable Triton software pipelining.
+        opts["num_stages"] = 1
+        tlx_amd_flex_attention_template.maybe_append_choice(
+            choices=choices,
+            input_nodes=input_nodes,
+            layout=layout,
+            subgraphs=subgraphs,
+            mutated_inputs=mutated_inputs,
+            call_sizes=query.get_size(),
+            **opts,
+        )

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -11,12 +11,43 @@ from torch._inductor.template_heuristics.registry import register_template_heuri
 from torch._inductor.template_heuristics.triton import (
     CUDAConfigHeuristic,
     GemmConfig,
-    IS_ROCM,
     ROCmMMTemplateConfigHeuristic,
     TMATemplateConfigMixin,
 )
 from torch._inductor.template_heuristics.triton_addmm import AddMMConfigMixin
-from torch._inductor.utils import get_default_kpack, get_num_sms
+from torch._inductor.utils import get_num_sms
+
+# IS_ROCM was dropped from torch._inductor.template_heuristics.triton on newer
+# nightlies (the module now branches on ``torch.version.hip`` inline). Derive it
+# locally so the fork loads across torch versions; matches torch's own definition
+# (CUDA vs ROCm keyed on torch.version.hip).
+IS_ROCM = torch.version.hip is not None
+
+try:
+    from torch._inductor.utils import get_default_kpack
+except ImportError:
+    # get_default_kpack is absent from some torch nightlies (notably ROCm
+    # wheels). Mirror torch's own definition so the fork loads across versions:
+    # 0 on CUDA; on AMD, kpack keyed on arch/block_k.
+    def get_default_kpack(block_k: int = 16) -> int:
+        if not torch.version.hip:
+            return 0
+        try:
+            arch = torch.cuda.get_device_properties(0).gcnArchName
+        except Exception:
+            arch = ""
+        if "gfx942" in arch and block_k <= 16:
+            return 1
+        return 2
+
+
+def _sizevar_hint(sizevars, expr, fallback):
+    # ``optimization_hint`` is the newer name; older torch (e.g. the current ROCm
+    # wheel) exposes ``size_hint`` with the same fallback semantics (example-input
+    # hint, ``fallback`` when unbacked/symbolic). Use whichever exists.
+    fn = getattr(sizevars, "optimization_hint", None) or sizevars.size_hint
+    return fn(expr, fallback=fallback)
+
 
 from . import tlx_config
 from .mm_templates import amd_addmm_warppipe_template, blackwell_gemm_ws_template
@@ -1168,8 +1199,8 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
         # under AOTI dynamic shapes.
         int32_max = 2**31 - 1
         if not (
-            sizevars.optimization_hint(m * k, fallback=int32_max) < int32_max
-            and sizevars.optimization_hint(n * k, fallback=int32_max) < int32_max
+            _sizevar_hint(sizevars, m * k, int32_max) < int32_max
+            and _sizevar_hint(sizevars, n * k, int32_max) < int32_max
         ):
             return
         num_xcds = _amd_num_xcds()
@@ -1667,7 +1698,15 @@ TritonTemplateKernel.compute_epilogue = _tlx_compute_epilogue  # type: ignore[me
 
 # -- codegen_template_body: wrap to set _final_output_name and handle
 #    COMPUTE_EPILOGUE subgraphs --
-_orig_codegen_template_body = TritonTemplateKernel.codegen_template_body
+# The epilogue-fusion codegen API below (codegen_template_body,
+# _emit_post_kernel_code, _compute_fusion_metadata, get_unfused_epilogues) only
+# exists on newer torch. On older wheels (e.g. the current ROCm nightly) these
+# base methods are absent; grab them defensively so the module still imports and
+# the core template path keeps working — the wrappers are only installed when the
+# base method exists.
+_orig_codegen_template_body = getattr(
+    TritonTemplateKernel, "codegen_template_body", None
+)
 
 
 def _tlx_codegen_template_body(  # type: ignore[no-untyped-def]
@@ -1732,7 +1771,8 @@ def _tlx_codegen_template_body(  # type: ignore[no-untyped-def]
     )
 
 
-TritonTemplateKernel.codegen_template_body = _tlx_codegen_template_body  # type: ignore[method-assign]
+if _orig_codegen_template_body is not None:
+    TritonTemplateKernel.codegen_template_body = _tlx_codegen_template_body  # type: ignore[method-assign]
 
 # -- render: add compute_epilogue and output_ptr to template env --
 _orig_render = TritonTemplateKernel.render
@@ -1749,7 +1789,9 @@ def _tlx_render(self, template, kwargs, record_input_dependent_tracked_event=Fal
 TritonTemplateKernel.render = _tlx_render  # type: ignore[method-assign]
 
 # -- _emit_post_kernel_code: emit split-K reduction kernel after main GEMM --
-_orig_emit_post_kernel = TritonTemplateKernel._emit_post_kernel_code
+_orig_emit_post_kernel = getattr(
+    TritonTemplateKernel, "_emit_post_kernel_code", None
+)
 
 
 def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-untyped-def]
@@ -1781,7 +1823,8 @@ def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-u
     _orig_emit_post_kernel(self, wrapper, kernel_name)
 
 
-TritonTemplateKernel._emit_post_kernel_code = _tlx_emit_post_kernel_code  # type: ignore[method-assign]
+if _orig_emit_post_kernel is not None:
+    TritonTemplateKernel._emit_post_kernel_code = _tlx_emit_post_kernel_code  # type: ignore[method-assign]
 
 
 # -- _compute_fusion_metadata: disable epilogue fusion for SPLIT_K > 1 ------
@@ -1790,7 +1833,9 @@ TritonTemplateKernel._emit_post_kernel_code = _tlx_emit_post_kernel_code  # type
 # so scheduler-level epilogue fusion can't work — the fused ops would be
 # silently dropped.  Instead, mark all epilogue nodes as "unfused" so the
 # scheduler codegen's them as separate kernels after reduce_k.
-_orig_compute_fusion_metadata = TritonTemplateKernel._compute_fusion_metadata
+_orig_compute_fusion_metadata = getattr(
+    TritonTemplateKernel, "_compute_fusion_metadata", None
+)
 
 
 def _tlx_compute_fusion_metadata(  # type: ignore[no-untyped-def]
@@ -1804,7 +1849,7 @@ def _tlx_compute_fusion_metadata(  # type: ignore[no-untyped-def]
         self._unfused_epilogues = list(epilogue_nodes)
         self._prologue_sources = {}
         self._scheduling_ref = scheduling
-    else:
+    elif _orig_compute_fusion_metadata is not None:
         _orig_compute_fusion_metadata(
             self,
             scheduling,
@@ -1814,10 +1859,13 @@ def _tlx_compute_fusion_metadata(  # type: ignore[no-untyped-def]
         )
 
 
-TritonTemplateKernel._compute_fusion_metadata = _tlx_compute_fusion_metadata  # type: ignore[method-assign]
+if _orig_compute_fusion_metadata is not None:
+    TritonTemplateKernel._compute_fusion_metadata = _tlx_compute_fusion_metadata  # type: ignore[method-assign]
 
 # -- get_unfused_epilogues: return split-K unfused epilogues -----------------
-_orig_get_unfused_epilogues = TritonTemplateKernel.get_unfused_epilogues
+_orig_get_unfused_epilogues = getattr(
+    TritonTemplateKernel, "get_unfused_epilogues", None
+)
 
 
 def _tlx_get_unfused_epilogues(self):  # type: ignore[no-untyped-def]
@@ -1827,7 +1875,8 @@ def _tlx_get_unfused_epilogues(self):  # type: ignore[no-untyped-def]
     return _orig_get_unfused_epilogues(self)
 
 
-TritonTemplateKernel.get_unfused_epilogues = _tlx_get_unfused_epilogues  # type: ignore[method-assign]
+if _orig_get_unfused_epilogues is not None:
+    TritonTemplateKernel.get_unfused_epilogues = _tlx_get_unfused_epilogues  # type: ignore[method-assign]
 
 # -- call_kernel: codegen unfused epilogues after split-K reduce_k -----------
 _orig_call_kernel = TritonTemplateKernel.call_kernel

--- a/third_party/tlx/language/tlx/inductor/tlx_amd_flex_attention.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/tlx_amd_flex_attention.py.jinja
@@ -1,0 +1,258 @@
+{{def_kernel("Q", "K", "V", "LSE", "MAX", "KV_NUM_BLKS", "KV_IDX", "FULL_KV_NUM_BLKS", "FULL_KV_IDX")}}
+    # tlx_amd_flex_attention: TLX AMD (CDNA4 / gfx950) FlexAttention forward kernel.
+    #
+    # Single-task (no warp specialization: MI350 has no WS) online-softmax FA with
+    # the FlexAttention scaffolding shared with the Blackwell template — block-sparse
+    # KV iteration, score_mod/mask_mod via modification() macros, logsumexp/max.
+    # AMD compute engine:
+    #   * K/V staged to LDS via tlx.async_load (K and V committed in ONE group),
+    #   * Q@K^T through tlx.local_trans + MFMA tl.dot,
+    #   * P@V through MFMA tl.dot, accumulated in registers.
+    # No TMEM / TMA / tcgen05 (Blackwell-only).
+
+    tl.static_assert(SPARSE_Q_BLOCK_SIZE >= BLOCK_M and SPARSE_Q_BLOCK_SIZE % BLOCK_M == 0)
+    tl.static_assert(SPARSE_KV_BLOCK_SIZE >= BLOCK_N and SPARSE_KV_BLOCK_SIZE % BLOCK_N == 0)
+
+    stride_qz, stride_qh, stride_qm, stride_qk = {{stride("Q")}}
+    stride_kz, stride_kh, stride_kn, stride_kk = {{stride("K")}}
+    stride_vz, stride_vh, stride_vn, stride_vk = {{stride("V")}}
+
+    ZQ = {{size("Q", 0)}}
+    HQ = {{size("Q", 1)}}
+    Q_LEN = {{size("Q", 2)}}
+    ZKV = {{size("K", 0)}}
+    KV_LEN = {{size("K", 2)}}
+
+    MATMUL_PRECISION = Q.dtype.element_ty
+
+    q_start = tl.program_id(0).to(INDEX_DTYPE)
+    off_zq = tl.program_id(1).to(INDEX_DTYPE)
+    off_hq = tl.program_id(2).to(INDEX_DTYPE)
+
+    off_zkv = off_zq % ZKV
+    off_hkv = off_hq // GQA_SHARED_HEADS
+    off_g = off_hq % GQA_SHARED_HEADS
+
+    q_offset = off_zq * stride_qz + off_hq * stride_qh
+    k_offset = off_zkv * stride_kz + off_hkv * stride_kh
+    v_offset = off_zkv * stride_vz + off_hkv * stride_vh
+
+    Q = Q + q_offset
+    K = K + k_offset
+    V = V + v_offset
+
+    # Sparse block setup (identical to the Blackwell template)
+    SPARSE_Z = {{size("KV_NUM_BLKS", 0)}}
+    SPARSE_HQ = {{size("KV_NUM_BLKS", 1)}}
+    sparse_idx_z = off_zq % SPARSE_Z
+    sparse_idx_hq = off_hq % SPARSE_HQ
+    SPARSE_Q_MULTIPLE: tl.constexpr = (SPARSE_Q_BLOCK_SIZE // BLOCK_M)
+    SPARSE_KV_MULTIPLE: tl.constexpr = (SPARSE_KV_BLOCK_SIZE // BLOCK_N)
+    stride_kv_num_blks_h = {{stride("KV_NUM_BLKS", 1)}}
+    stride_kv_idx_h = {{stride("KV_IDX", 1)}}
+    stride_kv_idx_m = {{stride("KV_IDX", 2)}}
+    sparse_hz_offset = sparse_idx_z * SPARSE_HQ + sparse_idx_hq
+    sparse_kv_num_blks_offset = sparse_hz_offset * stride_kv_num_blks_h + q_start // SPARSE_Q_MULTIPLE
+    sparse_kv_idx_offset = sparse_hz_offset * stride_kv_idx_h + (q_start // SPARSE_Q_MULTIPLE) * stride_kv_idx_m  # noqa: B950
+
+    # ===================== CONSTANTS =====================
+    NUM_KV_BUFFERS: tl.constexpr = 2
+    RCP_LN2: tl.constexpr = 1.44269504  # log2(e): change of base for exp2 softmax
+
+    offs_m = q_start * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, QK_HEAD_DIM_ROUNDED)
+    offs_vd = tl.arange(0, V_HEAD_DIM_ROUNDED)
+
+    # ---- Load Q tile into registers ----
+    q = tl.load(
+        Q + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk,
+        mask=(offs_m[:, None] < Q_LEN) & (offs_d[None, :] < QK_HEAD_DIM),
+        other=0.0,
+    )
+
+    # ---- LDS staging buffers for K / V ----
+    k_tiles = tlx.local_alloc((BLOCK_N, QK_HEAD_DIM_ROUNDED), MATMUL_PRECISION, NUM_KV_BUFFERS)
+    v_tiles = tlx.local_alloc((BLOCK_N, V_HEAD_DIM_ROUNDED), MATMUL_PRECISION, NUM_KV_BUFFERS)
+
+    # ---- Softmax accumulators (registers) ----
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
+    acc = tl.zeros([BLOCK_M, V_HEAD_DIM_ROUNDED], dtype=tl.float32)
+
+    qk_scale = SM_SCALE
+
+    # ===================== NORMAL BLOCKS (score_mod AND mask_mod) =====================
+    kv_indices = KV_IDX + sparse_kv_idx_offset
+    kv_start = tl.load(kv_indices) * SPARSE_KV_BLOCK_SIZE
+    kv_num_blocks = tl.load(KV_NUM_BLKS + sparse_kv_num_blks_offset)
+    block_n_end = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+
+    offs_n = kv_start + tl.arange(0, BLOCK_N)
+    buf = 0
+    for _sn in range(0, block_n_end):
+        # Stage K/V for this block into LDS. Commit K and V in ONE group: separate
+        # groups + wait_group(0) mis-syncs the LDS reads on gfx950 (garbage/NaN).
+        k_ptrs = K + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kk
+        v_ptrs = V + offs_n[:, None] * stride_vn + offs_vd[None, :] * stride_vk
+        if IS_DIVISIBLE:
+            tok_k = tlx.async_load(k_ptrs, tlx.local_view(k_tiles, buf))
+            tok_v = tlx.async_load(v_ptrs, tlx.local_view(v_tiles, buf))
+        else:
+            tok_k = tlx.async_load(k_ptrs, tlx.local_view(k_tiles, buf),
+                                   mask=offs_n[:, None] < KV_LEN)
+            tok_v = tlx.async_load(v_ptrs, tlx.local_view(v_tiles, buf),
+                                   mask=offs_n[:, None] < KV_LEN)
+        tlx.async_load_commit_group([tok_k, tok_v])
+        wait = tlx.async_load_wait_group(0)
+
+        kt = tlx.local_load(tlx.local_trans(tlx.local_view(k_tiles, buf)), token=wait, relaxed=True)
+        qk = tl.dot(q, kt)
+
+        qk = qk * qk_scale
+        m = get_bounded_indices(offs_m[:, None], Q_LEN if not IS_DIVISIBLE else None)
+        n = get_bounded_indices(offs_n[None, :], KV_LEN if not IS_DIVISIBLE else None)
+
+        {{ modification(
+            subgraph_number=0,
+            output_name="post_mod_scores",
+            score="qk",
+            b="off_zq",
+            h="off_hq",
+            m="m",
+            n="n",
+            out="qk"
+        ) | indent_except_first(2) }}
+
+        if not IS_DIVISIBLE:
+            post_mod_scores = tl.where(offs_n[None, :] < KV_LEN, post_mod_scores, float("-inf"))
+
+        {{ modification(
+            subgraph_number=1,
+            output_name="mask_mod_output",
+            score="qk",
+            b="off_zq",
+            h="off_hq",
+            m="m",
+            n="n",
+        ) | indent_except_first(2) }}
+
+        if not IS_DIVISIBLE:
+            mask_mod_output = tl.where(offs_n[None, :] < KV_LEN, mask_mod_output, False)
+        post_mod_scores = tl.where(mask_mod_output, post_mod_scores, float("-inf"))
+        post_mod_scores = post_mod_scores * RCP_LN2
+
+        # Online softmax update
+        m_ij = tl.maximum(m_i, tl.max(post_mod_scores, 1))
+        if not ROWS_GUARANTEED_SAFE:
+            m_ij_masked = tl.where(m_ij == float("-inf"), 0, m_ij)
+        else:
+            m_ij_masked = m_ij
+        alpha = tl.math.exp2(m_i - m_ij_masked)
+        p = tl.math.exp2(post_mod_scores - m_ij_masked[:, None])
+        l_i = l_i * alpha + tl.sum(p, 1)
+        acc = acc * alpha[:, None]
+
+        v = tlx.local_load(tlx.local_view(v_tiles, buf), token=wait, relaxed=True)
+        acc = tl.dot(p.to(MATMUL_PRECISION), v, acc)
+        m_i = m_ij
+
+        offset = get_offset_for_next_block(
+            _sn, kv_indices, kv_num_blocks,
+            SPARSE_KV_BLOCK_SIZE, SPARSE_KV_MULTIPLE, BLOCK_N, BLOCKS_ARE_CONTIGUOUS
+        )
+        offs_n = offs_n + offset
+        buf = (buf + 1) % NUM_KV_BUFFERS
+
+    # ===================== FULL BLOCKS (score_mod ONLY, skip mask_mod) =====================
+    if HAS_FULL_BLOCKS:
+        fkv_indices = FULL_KV_IDX + sparse_kv_idx_offset
+        fkv_start = tl.load(fkv_indices) * SPARSE_KV_BLOCK_SIZE
+        fkv_num_blocks = tl.load(FULL_KV_NUM_BLKS + sparse_kv_num_blks_offset)
+        fblock_n_end = tl.minimum(fkv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+        offs_n = fkv_start + tl.arange(0, BLOCK_N)
+
+        for _sn in range(0, fblock_n_end):
+            k_ptrs = K + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kk
+            v_ptrs = V + offs_n[:, None] * stride_vn + offs_vd[None, :] * stride_vk
+            if IS_DIVISIBLE:
+                tok_k = tlx.async_load(k_ptrs, tlx.local_view(k_tiles, buf))
+                tok_v = tlx.async_load(v_ptrs, tlx.local_view(v_tiles, buf))
+            else:
+                tok_k = tlx.async_load(k_ptrs, tlx.local_view(k_tiles, buf),
+                                       mask=offs_n[:, None] < KV_LEN)
+                tok_v = tlx.async_load(v_ptrs, tlx.local_view(v_tiles, buf),
+                                       mask=offs_n[:, None] < KV_LEN)
+            tlx.async_load_commit_group([tok_k, tok_v])
+            wait = tlx.async_load_wait_group(0)
+
+            kt = tlx.local_load(tlx.local_trans(tlx.local_view(k_tiles, buf)), token=wait, relaxed=True)
+            qk = tl.dot(q, kt)
+
+            qk = qk * qk_scale
+            m = get_bounded_indices(offs_m[:, None], Q_LEN if not IS_DIVISIBLE else None)
+            n = get_bounded_indices(offs_n[None, :], KV_LEN if not IS_DIVISIBLE else None)
+
+            {{ modification(
+                subgraph_number=0,
+                output_name="post_mod_scores",
+                score="qk",
+                b="off_zq",
+                h="off_hq",
+                m="m",
+                n="n",
+                out="qk"
+            ) | indent_except_first(3) }}
+
+            if not IS_DIVISIBLE:
+                post_mod_scores = tl.where(offs_n[None, :] < KV_LEN, post_mod_scores, float("-inf"))
+
+            post_mod_scores = post_mod_scores * RCP_LN2
+
+            m_ij = tl.maximum(m_i, tl.max(post_mod_scores, 1))
+            if not ROWS_GUARANTEED_SAFE:
+                m_ij_masked = tl.where(m_ij == float("-inf"), 0, m_ij)
+            else:
+                m_ij_masked = m_ij
+            alpha = tl.math.exp2(m_i - m_ij_masked)
+            p = tl.math.exp2(post_mod_scores - m_ij_masked[:, None])
+            l_i = l_i * alpha + tl.sum(p, 1)
+            acc = acc * alpha[:, None]
+
+            v = tlx.local_load(tlx.local_view(v_tiles, buf), token=wait, relaxed=True)
+            acc = tl.dot(p.to(MATMUL_PRECISION), v, acc)
+            m_i = m_ij
+
+            offset = get_offset_for_next_block(
+                _sn, fkv_indices, fkv_num_blocks,
+                SPARSE_KV_BLOCK_SIZE, SPARSE_KV_MULTIPLE, BLOCK_N, BLOCKS_ARE_CONTIGUOUS
+            )
+            offs_n = offs_n + offset
+            buf = (buf + 1) % NUM_KV_BUFFERS
+
+    # ===================== EPILOGUE: normalize + store =====================
+    l_safe = tl.where(l_i == 0.0, 1.0, l_i)
+    acc = acc / l_safe[:, None]
+
+    idx_zq = off_zq
+    idx_hq = off_hq
+    idx_m = offs_m[:, None].to(INDEX_DTYPE)
+    idx_d = offs_vd[None, :].to(INDEX_DTYPE)
+    mask = (idx_m < Q_LEN) & (idx_d < V_HEAD_DIM)
+    {{store_output(("idx_zq", "idx_hq", "idx_m", "idx_d"), "acc", "mask", val_shape=("BLOCK_M", "V_HEAD_DIM_ROUNDED"))}}
+
+    if OUTPUT_LOGSUMEXP:
+        off_hz = off_zq * HQ + off_hq
+        l_ptrs = LSE + off_hz * Q_LEN + offs_m
+        lse = tl.where(m_i == float("-inf"), float("-inf"), m_i + tl.math.log2(l_safe))
+        if IS_DIVISIBLE:
+            tl.store(l_ptrs, lse)
+        else:
+            tl.store(l_ptrs, lse, mask=offs_m < Q_LEN)
+
+    if OUTPUT_MAX:
+        off_hz = off_zq * HQ + off_hq
+        max_ptrs = MAX + off_hz * Q_LEN + offs_m
+        if IS_DIVISIBLE:
+            tl.store(max_ptrs, m_i)
+        else:
+            tl.store(max_ptrs, m_i, mask=offs_m < Q_LEN)


### PR DESCRIPTION
Summary:
- Add AMD FlexAttn Inductor Template (derived from `third_party/tlx/tutorials/amd_fa_cluster.py`)
- Add unit tests
- Streamline test script (following https://github.com/facebookexperimental/triton/issues/1968)

Here's a public doc about [TorchTLX code structure](https://docs.google.com/document/d/1j60dtD8Xj3pHkxmz1fWnDzDRJb6hrkIQafhvbQ5GbUM/edit?tab=t.0)


Test Plan:
`TORCHTLX_SKIP_SETUP=1 ./scripts/run_torchtlx_tests.sh python/test/unit/language/test_torchtlx_templates.py`

NOTE: atm new unit tests are currently skipped in this env even if installed with a pre torch version. After importing this PR to internal code base, I confirm the AMD Flex Attention unit tests all passed there.

Differential Revision: D111817271

Pulled By: dshi7


