### PR TITLE
[Triton][auto-TMA][6/N] plain-tl.load Flash Attention (device auto-TMA) + target (#2005)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -339,6 +339,12 @@ def TritonNvidiaGPUPromoteLoadToTMAPass : Pass<"triton-nvidia-promote-load-to-tm
     "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
     "mlir::arith::ArithDialect"
   ];
+
+  let options = [
+    Option<"deviceMode", "device-mode", "bool", /*default=*/"false",
+           "Emit device-side tt.make_tensor_descriptor + descriptor_load/store "
+           "instead of host-side TMA recipes.">
+  ];
 }
 
 #endif

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLoadToTMA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLoadToTMA.cpp
@@ -117,6 +117,11 @@ struct DecomposedLoad {
   Value basePtr;
   int basePtrArgIndex;
   SmallVector<DimInfo> dims;
+  // Uniform (per-program) scalar offset terms with no arange/expand_dims, e.g.
+  // `off_z * stride_z` in a batched/FA kernel. These shift the whole tile, so
+  // for a device descriptor they fold into the descriptor base pointer
+  // (make_tensor_descriptor(addptr(base, Σ scalarBaseOffsets), ...)).
+  SmallVector<Value> scalarBaseOffsets;
   bool valid;
 };
 
@@ -395,6 +400,14 @@ static DecomposedLoad decomposePointer(Value ptr) {
   Value base = matchSplat(cur);
   if (!base)
     return result;
+  // Peel scalar per-program addptr(s) folded into the base pointer before the
+  // tile splat, e.g. `addptr(Qptr, off_z*stride_z)`. Collect their offsets as
+  // per-program base shifts (folded into the descriptor base) and continue to
+  // the underlying kernel-arg pointer.
+  while (auto ap = base.getDefiningOp<tt::AddPtrOp>()) {
+    result.scalarBaseOffsets.push_back(ap.getOffset());
+    base = ap.getPtr();
+  }
   result.basePtr = base;
   result.basePtrArgIndex = getFuncArgIndex(base);
   if (result.basePtrArgIndex < 0)
@@ -450,6 +463,16 @@ static DecomposedLoad decomposePointer(Value ptr) {
     Value inner = term;
     if (auto broadcastOp = inner.getDefiningOp<tt::BroadcastOp>())
       inner = broadcastOp.getSrc();
+    // Uniform scalar offset (splat of a scalar, no arange/expand_dims): this is
+    // a per-program base shift (e.g. `off_z * stride_z` in a batched/FA
+    // kernel). Fold it into the descriptor base later instead of a per-dim
+    // index.
+    if (Value s = matchSplat(inner)) {
+      if (s.getType().isIntOrIndex()) {
+        result.scalarBaseOffsets.push_back(s);
+        continue;
+      }
+    }
     // The canonical Triton idiom `offs[:, None] * stride` lowers to
     // muli(expand_dims(offs), splat(stride)) -- the multiply is applied AFTER
     // expand_dims, and no canonicalization hoists it through expand_dims. Peel
@@ -751,6 +774,68 @@ static int findShapeArgForDim(tt::FuncOp func, Value ownMask,
   return found;
 }
 
+// Device mode hoists the make_tensor_descriptor above the load/store's
+// enclosing scf.for so the lowered tensormap_create can be predicated. Any
+// per-program scalar base offset folded into the descriptor base
+// (scalarBaseOffsets) is an operand of that hoisted op, so it must be defined
+// ABOVE the loop or the hoist would violate SSA dominance. Return false if any
+// offset is defined inside the enclosing loop (then the caller skips
+// promotion). No enclosing loop -> nothing to hoist past -> hoistable.
+static bool scalarBaseOffsetsHoistable(Operation *op,
+                                       const DecomposedLoad &decomp) {
+  if (decomp.scalarBaseOffsets.empty())
+    return true;
+  auto forOp = op->getParentOfType<scf::ForOp>();
+  if (!forOp)
+    return true;
+  Region &loopRegion = forOp.getRegion();
+  for (Value off : decomp.scalarBaseOffsets)
+    if (loopRegion.isAncestor(off.getParentRegion()))
+      return false;
+  return true;
+}
+
+// Whether `mask` carries an upper-bound comparison that is NOT attributable to
+// any *tiled* dim (a dim with a tile offset). Such an "unattributed" bound may
+// constrain an untiled/whole dim, whose true global extent could then exceed
+// blockSize -- in which case the -2 constant-extent sentinel would encode too
+// small an extent. Used to gate the whole-dim sentinel to genuinely unmasked
+// dims. Conservative: an unrecognized comparison counts as unattributed, so the
+// guard only ever declines to fabricate an extent (never emits a wrong one).
+static bool maskHasUnattributedBound(Value mask, const DecomposedLoad &decomp) {
+  if (!mask)
+    return false;
+  SmallVector<Value> cmpTerms;
+  std::function<void(Value)> collectCmps = [&](Value v) {
+    if (auto andOp = v.getDefiningOp<arith::AndIOp>()) {
+      collectCmps(andOp.getLhs());
+      collectCmps(andOp.getRhs());
+    } else {
+      cmpTerms.push_back(v);
+    }
+  };
+  collectCmps(mask);
+  for (Value cmpVal : cmpTerms) {
+    Value c = cmpVal;
+    if (auto bcast = c.getDefiningOp<tt::BroadcastOp>())
+      c = bcast.getSrc();
+    auto cmpOp = c.getDefiningOp<arith::CmpIOp>();
+    if (!cmpOp)
+      continue; // not a comparison we treat as a bound
+    bool attributed = false;
+    for (const DimInfo &dim : decomp.dims) {
+      int argIdx = -1;
+      if (dim.offset && cmpBoundsDim(cmpOp, dim, argIdx)) {
+        attributed = true;
+        break;
+      }
+    }
+    if (!attributed)
+      return true;
+  }
+  return false;
+}
+
 // Structural equality of scalar index expressions. The promote pass runs before
 // CSE, so the tile offset used in a pointer (`muli(ki, BLOCK)`) and the same
 // quantity recomputed in a mask bound (`K - muli(ki, BLOCK)`) are equal in
@@ -959,12 +1044,16 @@ struct Promotion {
   // Logical-tile -> descriptor-memory dim order (the single contiguous dim is
   // moved last). Identity when the contiguous dim is already innermost.
   SmallVector<int> perm;
+  // True when this load requires a device-built descriptor (in-kernel
+  // tt.make_tensor_descriptor) rather than the host recipe path.
+  bool useDeviceMode = false;
 };
 
 struct StorePromotion {
   tt::StoreOp storeOp;
   DecomposedLoad decomp;
   SmallVector<int> shapeArgIndices;
+  bool useDeviceMode = false;
 };
 
 class TritonNvidiaGPUPromoteLoadToTMAPass
@@ -1003,11 +1092,30 @@ public:
       return signalPassFailure();
     }
 
+    // Device-descriptor mode: build tt.make_tensor_descriptor in-kernel instead
+    // of a host recipe (handles per-program base + constant/whole-dim extents).
+    // Controlled by the `device-mode` pass option
+    // (knobs.nvidia.auto_tma_device); TRITON_AUTO_TMA_DEVICE stays as an env
+    // fallback for ad-hoc runs.
+    const char *devEnv = std::getenv("TRITON_AUTO_TMA_DEVICE");
+    bool useDevice = deviceMode || (devEnv && std::string(devEnv) == "1");
+
     // Phase 1: collect eligible loads.
-    SmallVector<Promotion> promotions;
+    SmallVector<Promotion, 0> promotions;
     kernelFunc.walk([&](tt::LoadOp loadOp) {
       DecomposedLoad decomp = decomposePointer(loadOp.getPtr());
       if (!decomp.valid || !isTMAEligible(loadOp, decomp))
+        return;
+      // Per-load host-vs-device decision: start with the global override, then
+      // auto-escalate to device mode for loads that host recipe can't handle.
+      bool needsDevice = useDevice;
+      // scalarBaseOffsets (per-program base shifts like off_z*stride_z) require
+      // device mode — the host recipe can only record base_ptr_arg_index.
+      if (!decomp.scalarBaseOffsets.empty())
+        needsDevice = true;
+      // Device mode hoists the descriptor above enclosing loops; skip if a
+      // scalar base offset is loop-defined (SSA dominance).
+      if (needsDevice && !scalarBaseOffsetsHoistable(loadOp, decomp))
         return;
       int rank = decomp.dims.size();
       SmallVector<int> shapeArgs(rank, -1);
@@ -1023,11 +1131,24 @@ public:
           s = findShapeArgFromTileBound(kernelFunc, dim);
         if (s < 0 && dim.loopAdvanced)
           s = findShapeArgForLoopDim(kernelFunc, dim);
+        // A dim loaded WHOLE (no tile offset -> not tiled, e.g. the FA head dim
+        // `offs_d = arange(0, HEAD_DIM)`) has global extent == blockSize, a
+        // compile-time constant. Use the -2 sentinel so Phase 2 emits an
+        // arith.constant extent. Host recipe can't encode a constant extent, so
+        // this auto-escalates to device mode. Require the dim be genuinely
+        // unmasked (no mask bound unattributable to a tiled dim): a
+        // partially-masked untiled dim could have a true extent > blockSize, so
+        // fabricating blockSize would under-size the descriptor.
+        if (s < 0 && !dim.offset &&
+            !maskHasUnattributedBound(loadOp.getMask(), decomp)) {
+          s = -2;
+          needsDevice = true;
+        }
         shapeArgs[d] = s;
       }
       bool ok = true;
       for (int d = 0; d < rank; d++)
-        if (shapeArgs[d] < 0)
+        if (shapeArgs[d] == -1) // -2 = constant extent (device mode), allowed
           ok = false;
       if (!ok)
         return;
@@ -1053,6 +1174,7 @@ public:
       p.loadOp = loadOp;
       p.decomp = decomp;
       p.shapeArgIndices = shapeArgs;
+      p.useDeviceMode = needsDevice;
       // Descriptor memory order: keep dims in order but move the single
       // contiguous dim last (TMA descriptor innermost must be contiguous).
       int contigDim = -1;
@@ -1071,11 +1193,17 @@ public:
     // already innermost (the standard row-major C[M,N] output); a transposed
     // store would need the value transposed before descriptor_store -- skipped
     // for now.
-    SmallVector<StorePromotion> storePromotions;
+    SmallVector<StorePromotion, 0> storePromotions;
     if (kernelIsWarpSpecialized(kernelFunc)) {
       kernelFunc.walk([&](tt::StoreOp storeOp) {
         DecomposedLoad decomp = decomposePointer(storeOp.getPtr());
         if (!decomp.valid || !isTMAEligibleStore(storeOp, decomp))
+          return;
+        // Per-store host-vs-device decision (same logic as loads).
+        bool needsDevice = useDevice;
+        if (!decomp.scalarBaseOffsets.empty())
+          needsDevice = true;
+        if (needsDevice && !scalarBaseOffsetsHoistable(storeOp, decomp))
           return;
         int rank = decomp.dims.size();
         // contiguous dim must already be innermost (identity perm).
@@ -1105,11 +1233,16 @@ public:
             s = findShapeArgForDim(kernelFunc, storeOp.getMask(), dim);
           if (s < 0)
             s = findShapeArgFromTileBound(kernelFunc, dim);
+          if (s < 0 && !dim.offset &&
+              !maskHasUnattributedBound(storeOp.getMask(), decomp)) {
+            s = -2;
+            needsDevice = true;
+          }
           shapeArgs[d] = s;
         }
         bool ok = true;
         for (int d = 0; d < rank; d++)
-          if (shapeArgs[d] < 0)
+          if (shapeArgs[d] == -1) // -2 = constant extent (device mode)
             ok = false;
         if (!ok)
           return;
@@ -1134,6 +1267,7 @@ public:
         p.storeOp = storeOp;
         p.decomp = decomp;
         p.shapeArgIndices = shapeArgs;
+        p.useDeviceMode = needsDevice;
         storePromotions.push_back(std::move(p));
       });
     }
@@ -1153,6 +1287,87 @@ public:
     OpBuilder builder(mod.getContext());
     MLIRContext *ctx = mod.getContext();
     Builder b(ctx);
+
+    // Shared builder for the device (in-kernel) TMA descriptor, used by both
+    // the load and store rewrites in device mode. Emits make_tensor_descriptor
+    // in the given dim order (`perm`; identity for stores), hoisted via LICM
+    // to the outermost scf.for where all descriptor operands are still
+    // loop-invariant, so the lowered tensormap_create is rebuilt only when its
+    // inputs actually change. Base ptr, shape, and stride args are kernel
+    // function arguments (always invariant); only scalarBaseOffsets can be
+    // loop-defined and thus limit the hoist distance. Phase 1
+    // (scalarBaseOffsetsHoistable) has already ensured at least one level of
+    // hoist is legal when an enclosing loop exists.
+    auto buildDeviceDescriptor =
+        [&](Operation *anchorOp, const DecomposedLoad &decomp,
+            ArrayRef<int> shapeArgIndices, ArrayRef<int> perm, Location loc,
+            Value &deviceZeroIdxOut) -> Value {
+      OpBuilder::InsertionGuard guard(builder);
+      // LICM: walk up nested scf::ForOps while all scalar base offsets are
+      // defined outside the loop (base ptr and shape/stride args are kernel
+      // function arguments, so they are invariant w.r.t. every loop).
+      Operation *hoistPt = anchorOp;
+      for (auto forOp = anchorOp->getParentOfType<scf::ForOp>(); forOp;
+           forOp = forOp->getParentOfType<scf::ForOp>()) {
+        Region &loopBody = forOp.getRegion();
+        bool allInvariant = true;
+        for (Value off : decomp.scalarBaseOffsets) {
+          if (loopBody.isAncestor(off.getParentRegion())) {
+            allInvariant = false;
+            break;
+          }
+        }
+        if (!allInvariant)
+          break;
+        hoistPt = forOp;
+      }
+      builder.setInsertionPoint(hoistPt);
+      Type i32 = builder.getI32Type();
+      deviceZeroIdxOut =
+          arith::ConstantOp::create(builder, loc, builder.getI32IntegerAttr(0));
+      SmallVector<Value> descShape, descStrides;
+      SmallVector<int32_t> descBlock;
+      for (int i = 0; i < (int)perm.size(); i++) {
+        int d = perm[i];
+        // Shape extent: kernel arg, or a compile-time constant (blockSize) for
+        // a whole-dim (untiled) dim recovered as the -2 sentinel.
+        Value shapeArg;
+        if (shapeArgIndices[d] == -2) {
+          shapeArg = arith::ConstantOp::create(
+              builder, loc,
+              builder.getI32IntegerAttr((int)decomp.dims[d].blockSize));
+        } else {
+          shapeArg = kernelFunc.getArgument(shapeArgIndices[d]);
+          if (shapeArg.getType().isInteger(64))
+            shapeArg = arith::TruncIOp::create(builder, loc, i32, shapeArg);
+        }
+        descShape.push_back(shapeArg);
+        // Contiguous dim (strideArgIdx < 0) has unit stride;
+        // make_tensor_descriptor needs an i64 stride operand per dim.
+        int strideIdx = decomp.dims[d].strideArgIdx;
+        Value strideV;
+        if (strideIdx < 0) {
+          strideV = arith::ConstantOp::create(builder, loc,
+                                              builder.getI64IntegerAttr(1));
+        } else {
+          strideV = kernelFunc.getArgument(strideIdx);
+          if (strideV.getType().isInteger(32))
+            strideV = arith::ExtSIOp::create(builder, loc, builder.getI64Type(),
+                                             strideV);
+        }
+        descStrides.push_back(strideV);
+        descBlock.push_back((int32_t)decomp.dims[d].blockSize);
+      }
+      // Fold uniform per-program scalar offsets (off_z*stride_z, ...) into the
+      // descriptor base -> a per-program (e.g. per-(batch,head)) view.
+      Value descBase = decomp.basePtr;
+      for (Value off : decomp.scalarBaseOffsets)
+        descBase = tt::AddPtrOp::create(builder, loc, descBase.getType(),
+                                        descBase, off);
+      return tt::MakeTensorDescOp::create(
+          builder, loc, descBase, descShape, descStrides, descBlock,
+          /*isSignedInteger=*/false, tt::PaddingOption::PAD_ZERO);
+    };
     auto i32Attr = [&](int v) { return b.getI32IntegerAttr(v); };
     SmallVector<Attribute> recipeAttrs;
 
@@ -1190,23 +1405,36 @@ public:
           isIdentity ? resultTy.getEncoding() : Attribute();
       auto descTileTy = RankedTensorType::get(permShape, elemTy, descEncoding);
 
-      // Synthesized host-side descriptor; its block type is the memory-order
-      // tile.
-      auto descTy = tt::TensorDescType::get(descTileTy.getShape(),
-                                            descTileTy.getElementType(),
-                                            descTileTy.getEncoding());
-      unsigned descArgIdx = kernelFunc.getNumArguments();
-      auto argAttrs =
-          b.getDictionaryAttr({b.getNamedAttr("tt.auto_tma", b.getUnitAttr())});
-      LogicalResult inserted =
-          kernelFunc.insertArgument(descArgIdx, descTy, argAttrs, loc);
-      assert(succeeded(inserted) &&
-             "failed to insert TMA descriptor kernel argument");
-      (void)inserted;
-      Value descArg = kernelFunc.getArgument(descArgIdx);
-
       builder.setInsertionPoint(loadOp);
       Type i32 = builder.getI32Type();
+
+      // The descriptor fed to descriptor_load: device-built (deviceMode) or a
+      // host-built descriptor passed as a synthesized kernel arg (recipe path).
+      Value descVal;
+      unsigned descArgIdx = 0;
+      // Loop-invariant zero index for whole-dim (untiled) dims, created OUTSIDE
+      // any loop so it needs no ttg.partition attr under warp specialization.
+      Value deviceZeroIdx;
+      if (promo.useDeviceMode) {
+        descVal =
+            buildDeviceDescriptor(loadOp, promo.decomp, promo.shapeArgIndices,
+                                  promo.perm, loc, deviceZeroIdx);
+      } else {
+        // Synthesized host-side descriptor; block type is the memory-order
+        // tile.
+        auto descTy = tt::TensorDescType::get(descTileTy.getShape(),
+                                              descTileTy.getElementType(),
+                                              descTileTy.getEncoding());
+        descArgIdx = kernelFunc.getNumArguments();
+        auto argAttrs = b.getDictionaryAttr(
+            {b.getNamedAttr("tt.auto_tma", b.getUnitAttr())});
+        LogicalResult inserted =
+            kernelFunc.insertArgument(descArgIdx, descTy, argAttrs, loc);
+        assert(succeeded(inserted) &&
+               "failed to insert TMA descriptor kernel argument");
+        (void)inserted;
+        descVal = kernelFunc.getArgument(descArgIdx);
+      }
       Type i64 = builder.getI64Type();
       // Convert an integer/index value to a target integer width,
       // sign-extending or truncating as needed. descriptor_load indices must be
@@ -1244,17 +1472,19 @@ public:
           Value prod = arith::MulIOp::create(builder, loc, iv, step);
           indices.push_back(arith::TruncIOp::create(builder, loc, i32, prod));
         } else if (!dim.offset) {
-          // Bare make_range with no tile offset (e.g. `arange % M` or a
-          // select-clamp, which peel to a bare range): the tile starts at 0.
-          indices.push_back(arith::ConstantOp::create(
-              builder, loc, builder.getI32IntegerAttr(0)));
+          // Whole-dim (untiled, e.g. FA HEAD_DIM): index is 0. Use the hoisted
+          // zero (deviceMode) so it isn't a constant inside the WS loop.
+          indices.push_back(
+              deviceZeroIdx ? deviceZeroIdx
+                            : arith::ConstantOp::create(
+                                  builder, loc, builder.getI32IntegerAttr(0)));
         } else {
           indices.push_back(toI32(dim.offset));
         }
       }
 
       auto newLoad = tt::DescriptorLoadOp::create(
-          builder, loc, descTileTy, descArg, indices, tt::CacheModifier::NONE,
+          builder, loc, descTileTy, descVal, indices, tt::CacheModifier::NONE,
           tt::EvictionPolicy::NORMAL);
 
       Value loaded = newLoad.getResult();
@@ -1269,6 +1499,10 @@ public:
 
       loadOp.getResult().replaceAllUsesWith(loaded);
       loadOp.erase();
+
+      // Device descriptors need no launcher recipe.
+      if (promo.useDeviceMode)
+        continue;
 
       // Record the recipe: how the launcher builds this CUtensorMap from the
       // existing scalar kernel args (base ptr / shape / stride) at launch time.
@@ -1309,20 +1543,33 @@ public:
       Type elemTy = valTy.getElementType();
       Location loc = storeOp.getLoc();
 
-      auto descTy = tt::TensorDescType::get(
-          valTy.getShape(), valTy.getElementType(), valTy.getEncoding());
-      unsigned descArgIdx = kernelFunc.getNumArguments();
-      auto argAttrs =
-          b.getDictionaryAttr({b.getNamedAttr("tt.auto_tma", b.getUnitAttr())});
-      LogicalResult inserted =
-          kernelFunc.insertArgument(descArgIdx, descTy, argAttrs, loc);
-      assert(succeeded(inserted) &&
-             "failed to insert TMA descriptor kernel argument");
-      (void)inserted;
-      Value descArg = kernelFunc.getArgument(descArgIdx);
-
       builder.setInsertionPoint(storeOp);
       Type i32 = builder.getI32Type();
+
+      // Descriptor for the store: device-built (deviceMode) or host recipe arg.
+      Value descVal;
+      unsigned descArgIdx = 0;
+      Value deviceZeroIdx;
+      if (promo.useDeviceMode) {
+        SmallVector<int> identity;
+        for (int d = 0; d < rank; d++)
+          identity.push_back(d);
+        descVal =
+            buildDeviceDescriptor(storeOp, promo.decomp, promo.shapeArgIndices,
+                                  identity, loc, deviceZeroIdx);
+      } else {
+        auto descTy = tt::TensorDescType::get(
+            valTy.getShape(), valTy.getElementType(), valTy.getEncoding());
+        descArgIdx = kernelFunc.getNumArguments();
+        auto argAttrs = b.getDictionaryAttr(
+            {b.getNamedAttr("tt.auto_tma", b.getUnitAttr())});
+        LogicalResult inserted =
+            kernelFunc.insertArgument(descArgIdx, descTy, argAttrs, loc);
+        assert(succeeded(inserted) &&
+               "failed to insert TMA descriptor kernel argument");
+        (void)inserted;
+        descVal = kernelFunc.getArgument(descArgIdx);
+      }
       // Same width handling as the load path's toIntWidth: descriptor_store
       // indices must be i32, but a tile offset may be index / i16 / i64 / etc.
       // depending on how the kernel computed it. Sign-extend or truncate as
@@ -1342,21 +1589,22 @@ public:
       };
       SmallVector<Value> indices;
       for (int d = 0; d < rank; d++) {
-        const DimInfo &dim = promo.decomp.dims[d];
-        if (!dim.offset) {
-          // Bare make_range with no tile offset (e.g. `arange % M` or a
-          // select-clamp that peels to a bare range): the tile starts at 0.
-          // Phase 1b can accept such a dim via shapeArgIdx alone, so mirror the
-          // load path (Phase 2) here instead of calling toI32 on a null offset.
-          indices.push_back(arith::ConstantOp::create(
-              builder, loc, builder.getI32IntegerAttr(0)));
-        } else {
-          indices.push_back(toI32(dim.offset));
-        }
+        Value off = promo.decomp.dims[d].offset;
+        if (!off)
+          indices.push_back(
+              deviceZeroIdx ? deviceZeroIdx
+                            : arith::ConstantOp::create(
+                                  builder, loc, builder.getI32IntegerAttr(0)));
+        else
+          indices.push_back(toI32(off));
       }
 
-      tt::DescriptorStoreOp::create(builder, loc, descArg, value, indices);
+      tt::DescriptorStoreOp::create(builder, loc, descVal, value, indices);
       storeOp.erase();
+
+      // Device stores need no launcher recipe.
+      if (promo.useDeviceMode)
+        continue;
 
       SmallVector<Attribute> shapeIdx, strideIdx, blk;
       for (int d = 0; d < rank; d++) {

--- a/python/test/unit/language/test_autows_auto_tma.py
+++ b/python/test/unit/language/test_autows_auto_tma.py
@@ -35,6 +35,7 @@ import triton
 import triton.language as tl
 from triton._internal_testing import is_cuda
 from triton.testing import do_bench
+import os
 
 
 def _is_sm90plus() -> bool:
@@ -125,6 +126,99 @@ def test_auto_tma_gemm_nows():
     assert "tt.descriptor_load" in kernel.asm["ttir"], "expected auto-TMA promotion"
     ref = (A.to(torch.float32) @ B.T.to(torch.float32)).to(dtype)
     torch.testing.assert_close(ref, C, atol=0.05, rtol=0.05)
+
+
+@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA promotion requires sm_90+")
+def test_auto_tma_gemm_nows_device(monkeypatch):
+    """Phase A: addptr loads promoted to a DEVICE-built tt.make_tensor_descriptor
+    (TRITON_AUTO_TMA_DEVICE=1), not the host-recipe path. Verifies the pass
+    synthesizes make_tensor_descriptor from the plain pointer + mask analysis.
+    Uses a dedicated kernel so the JIT cache does not collide with the host-mode
+    _gemm_nows test (the auto-TMA-device env is not part of the cache key)."""
+
+    @triton.jit
+    def _gemm_dev(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_bn, stride_cm, BLOCK_M: tl.constexpr,
+                  BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for ki in range(tl.cdiv(K, BLOCK_K)):
+            offs_k = ki * BLOCK_K + tl.arange(0, BLOCK_K)
+            a = tl.load(a_ptr + offs_m[:, None] * stride_am + offs_k[None, :],
+                        mask=(offs_m[:, None] < M) & (offs_k[None, :] < K), other=0.0)
+            b = tl.load(b_ptr + offs_n[:, None] * stride_bn + offs_k[None, :],
+                        mask=(offs_n[:, None] < N) & (offs_k[None, :] < K), other=0.0)
+            acc = tl.dot(a, b.T, acc)
+        tl.store(c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :], acc.to(tl.float16),
+                 mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
+
+    monkeypatch.setenv("TRITON_AUTO_TMA", "1")
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    M, N, K = 256, 256, 256
+    BLOCK_M, BLOCK_N, BLOCK_K = 64, 64, 32
+    dtype = torch.float16
+    torch.manual_seed(0)
+    A = torch.randn((M, K), dtype=dtype, device="cuda")
+    B = torch.randn((N, K), dtype=dtype, device="cuda")
+    C = torch.empty((M, N), dtype=dtype, device="cuda")
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    kernel = _gemm_dev[grid](A, B, C, M, N, K, A.stride(0), B.stride(0), C.stride(0), BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N,
+                             BLOCK_K=BLOCK_K)
+
+    ttir = kernel.asm["ttir"]
+    assert "tt.make_tensor_descriptor" in ttir, \
+        "device mode should synthesize an in-kernel make_tensor_descriptor"
+    assert "tt.descriptor_load" in ttir, "expected descriptor_load"
+    ref = (A.to(torch.float32) @ B.T.to(torch.float32)).to(dtype)
+    torch.testing.assert_close(ref, C, atol=0.05, rtol=0.05)
+
+
+@triton.jit
+def _batched_scale(x_ptr, out_ptr, B, M, N, stride_b, stride_m, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+    pid_b = tl.program_id(0)
+    pid_m = tl.program_id(1)
+    pid_n = tl.program_id(2)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    # Per-program base shift folded into the (scalar) base pointer.
+    xb = x_ptr + pid_b * stride_b
+    ob = out_ptr + pid_b * stride_b
+    x = tl.load(xb + offs_m[:, None] * stride_m + offs_n[None, :], mask=mask, other=0.0)
+    tl.store(ob + offs_m[:, None] * stride_m + offs_n[None, :], x * 2.0, mask=mask)
+
+
+@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA promotion requires sm_90+")
+def test_auto_tma_batched_device(monkeypatch):
+    """per-program base (pid_b*stride_b) must fold into the DEVICE descriptor base
+    (make_tensor_descriptor(addptr(x, off), ...)), giving a per-batch view."""
+    monkeypatch.setenv("TRITON_AUTO_TMA", "1")
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    B, M, N = 4, 128, 128
+    BLOCK_M, BLOCK_N = 64, 64
+    dtype = torch.float16
+    torch.manual_seed(0)
+    x = torch.randn((B, M, N), dtype=dtype, device="cuda")
+    out = torch.empty((B, M, N), dtype=dtype, device="cuda")
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    grid = (B, triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    kernel = _batched_scale[grid](x, out, B, M, N, x.stride(0), x.stride(1), BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N)
+
+    ttir = kernel.asm["ttir"]
+    assert "tt.make_tensor_descriptor" in ttir, \
+        "per-program base should still produce a device descriptor"
+    torch.testing.assert_close(out, x * 2.0)
 
 
 # ---------------------------------------------------------------------------
@@ -543,3 +637,234 @@ def test_scale_auto_tma_autotuner_picks_faster(M, N):
         assert pick == faster, (
             f"autotuner picked auto_tma={int(pick)} but independent timing says faster="
             f"{'on' if faster else 'off'} (off={off_ms:.5f} on={on_ms:.5f} ms, {rel * 100:.1f}% apart)")
+
+
+# ---------------------------------------------------------------------------
+# 5. Plain-pointer Flash Attention forward (no WS): Q/K/V/O plain tl.load/store
+#    auto-TMA promoted to DEVICE descriptors. Exercises per-program base (off_hz),
+#    the whole-dim (HEAD_DIM, unmasked) constant-extent path, and a loop-carried
+#    K/V load. Numerics vs torch SDPA.
+# ---------------------------------------------------------------------------
+@triton.jit
+def _plain_fa_fwd(Q, K, V, O, sm_scale, N_CTX, stride_h, stride_m, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+                  HEAD_DIM: tl.constexpr):
+    pid_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, HEAD_DIM)
+    # per-program base for this (batch, head)
+    q_base = Q + off_hz * stride_h
+    k_base = K + off_hz * stride_h
+    v_base = V + off_hz * stride_h
+    o_base = O + off_hz * stride_h
+    q = tl.load(q_base + offs_m[:, None] * stride_m + offs_d[None, :], mask=offs_m[:, None] < N_CTX, other=0.0)
+    m_i = tl.full([BLOCK_M], -float("inf"), tl.float32)
+    l_i = tl.zeros([BLOCK_M], tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], tl.float32)
+    qk_scale = sm_scale * 1.44269504  # log2(e)
+    for start_n in range(0, N_CTX, BLOCK_N):
+        offs_n = start_n + tl.arange(0, BLOCK_N)
+        k = tl.load(k_base + offs_n[:, None] * stride_m + offs_d[None, :], mask=offs_n[:, None] < N_CTX,
+                    other=0.0)  # [BLOCK_N, HEAD_DIM]
+        v = tl.load(v_base + offs_n[:, None] * stride_m + offs_d[None, :], mask=offs_n[:, None] < N_CTX,
+                    other=0.0)  # [BLOCK_N, HEAD_DIM]
+        qk = tl.dot(q, k.T) * qk_scale  # [BLOCK_M, BLOCK_N]
+        qk = tl.where(offs_n[None, :] < N_CTX, qk, -float("inf"))
+        m_ij = tl.maximum(m_i, tl.max(qk, 1))
+        p = tl.math.exp2(qk - m_ij[:, None])
+        alpha = tl.math.exp2(m_i - m_ij)
+        l_i = l_i * alpha + tl.sum(p, 1)
+        acc = acc * alpha[:, None] + tl.dot(p.to(tl.float16), v)
+        m_i = m_ij
+    acc = acc / l_i[:, None]
+    tl.store(o_base + offs_m[:, None] * stride_m + offs_d[None, :], acc.to(tl.float16), mask=offs_m[:, None] < N_CTX)
+
+
+@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA promotion requires sm_90+")
+def test_plain_fa_fwd_device(monkeypatch):
+    """A plain-pointer FA fwd (no descriptors, no warp_specialize): the Q/K/V
+    loads are auto-TMA promoted to DEVICE make_tensor_descriptor + descriptor_load
+    (per-program base folded into the descriptor base; unmasked HEAD_DIM extent as
+    a constant), numerics match torch SDPA."""
+    monkeypatch.setenv("TRITON_AUTO_TMA", "1")
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    Z, H, N_CTX, HEAD_DIM = 1, 2, 256, 64
+    BLOCK_M, BLOCK_N = 64, 64
+    dtype = torch.float16
+    sm_scale = 0.5
+    torch.manual_seed(0)
+    q = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    k = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    v = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    o = torch.empty_like(q)
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    stride_h = q.stride(1)  # one (batch,head) block = N_CTX*HEAD_DIM
+    stride_m = q.stride(2)  # seq stride = HEAD_DIM
+    grid = (triton.cdiv(N_CTX, BLOCK_M), Z * H)
+    kernel = _plain_fa_fwd[grid](q, k, v, o, sm_scale, N_CTX, stride_h, stride_m, BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N,
+                                 HEAD_DIM=HEAD_DIM)
+
+    ttir = kernel.asm["ttir"]
+    assert "tt.make_tensor_descriptor" in ttir, \
+        "plain-pointer FA Q/K/V loads should promote to device descriptors"
+    assert "tt.descriptor_load" in ttir, "expected descriptor_load"
+
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, scale=sm_scale, is_causal=False)
+    torch.testing.assert_close(o, ref, atol=1e-2, rtol=0)
+
+
+# ---------------------------------------------------------------------------
+# 4. Plain-pointer Flash Attention forward WITH warp_specialize: the plain loads
+#    are auto-TMA promoted (device descriptors) AND the loop is warp-specialized.
+#    auto-TMA is the WS enabler (descriptor_load is the partition scheduler seed).
+# ---------------------------------------------------------------------------
+@triton.jit
+def _plain_fa_fwd_ws(Q, K, V, O, sm_scale, N_CTX, stride_h, stride_m, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+                     HEAD_DIM: tl.constexpr):
+    pid_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, HEAD_DIM)
+    q_base = Q + off_hz * stride_h
+    k_base = K + off_hz * stride_h
+    v_base = V + off_hz * stride_h
+    o_base = O + off_hz * stride_h
+    q = tl.load(q_base + offs_m[:, None] * stride_m + offs_d[None, :], mask=offs_m[:, None] < N_CTX, other=0.0)
+    m_i = tl.full([BLOCK_M], -float("inf"), tl.float32)
+    l_i = tl.zeros([BLOCK_M], tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], tl.float32)
+    qk_scale = sm_scale * 1.44269504
+    for start_n in tl.range(0, N_CTX, BLOCK_N, warp_specialize=True, merge_epilogue=True, separate_epilogue_store=True,
+                            data_partition_factor=2):
+        offs_n = start_n + tl.arange(0, BLOCK_N)
+        k = tl.load(k_base + offs_n[:, None] * stride_m + offs_d[None, :], mask=offs_n[:, None] < N_CTX, other=0.0)
+        v = tl.load(v_base + offs_n[:, None] * stride_m + offs_d[None, :], mask=offs_n[:, None] < N_CTX, other=0.0)
+        # Mirror 06-fused-attention.py _attn_fwd_inner (non-causal STAGE), but with
+        # plain tl.load (auto-TMA promotes) instead of desc_k/desc_v.load.
+        qk = tl.dot(q, k.T)
+        m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+        qk = qk * qk_scale - m_ij[:, None]
+        p = tl.math.exp2(qk)
+        alpha = tl.math.exp2(m_i - m_ij)
+        l_ij = tl.sum(p, 1)
+        acc = acc * alpha[:, None]
+        acc = tl.dot(p.to(tl.float16), v, acc)
+        l_i = l_i * alpha + l_ij
+        m_i = m_ij
+    acc = acc / l_i[:, None]
+    tl.store(o_base + offs_m[:, None] * stride_m + offs_d[None, :], acc.to(tl.float16), mask=offs_m[:, None] < N_CTX)
+
+
+@pytest.mark.skipif(not _is_sm90plus(), reason="WS + auto-TMA requires sm_90+")
+def test_plain_fa_fwd_ws_device(monkeypatch):
+    """plain-pointer FA + warp_specialize: loads auto-TMA'd to device descriptors,
+    loop warp-specialized, numerics vs torch SDPA."""
+    monkeypatch.setenv("TRITON_AUTO_TMA", "1")
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    Z, H, N_CTX, HEAD_DIM = 1, 2, 256, 64
+    BLOCK_M, BLOCK_N = 128, 64  # dp=2 -> 64 rows per partition
+    dtype = torch.float16
+    sm_scale = 0.5
+    torch.manual_seed(0)
+    q = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    k = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    v = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    o = torch.empty_like(q)
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    grid = (triton.cdiv(N_CTX, BLOCK_M), Z * H)
+    with triton.knobs.nvidia.scope():
+        # Meta WS + meta partition scheduler (as the hand-written FA WS kernel
+        # uses); the default upstream add_warp_specialize does not partition the
+        # FA softmax compute.
+        triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.use_meta_partition = True
+        triton.knobs.nvidia.disable_wsbarrier_reorder = True
+        kernel = _plain_fa_fwd_ws[grid](q, k, v, o, sm_scale, N_CTX, q.stride(1), q.stride(2), BLOCK_M=BLOCK_M,
+                                        BLOCK_N=BLOCK_N, HEAD_DIM=HEAD_DIM, num_warps=4, num_stages=2, maxRegAutoWS=192)
+
+    ttgir = kernel.asm["ttgir"]
+    assert "tt.descriptor_load" in kernel.asm["ttir"], "expected auto-TMA promotion"
+    assert "ttg.warp_specialize" in ttgir, "expected warp specialization"
+    assert "ttng.async_tma_copy_global_to_local" in ttgir, "expected async TMA copy"
+
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, scale=sm_scale, is_causal=False)
+    torch.testing.assert_close(o, ref, atol=1e-2, rtol=0)
+
+
+def _run_plain_fa_ws(q, k, v, o, sm_scale, N_CTX, BLOCK_M, BLOCK_N, HEAD_DIM):
+    """Launch _plain_fa_fwd_ws under the meta-WS scheduler (as the hand-written
+    FA WS kernel does). Requires TRITON_AUTO_TMA[_DEVICE]=1 set by the caller."""
+    Z, H = q.shape[0], q.shape[1]
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    grid = (triton.cdiv(N_CTX, BLOCK_M), Z * H)
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.use_meta_partition = True
+        triton.knobs.nvidia.disable_wsbarrier_reorder = True
+        return _plain_fa_fwd_ws[grid](q, k, v, o, sm_scale, N_CTX, q.stride(1), q.stride(2), BLOCK_M=BLOCK_M,
+                                      BLOCK_N=BLOCK_N, HEAD_DIM=HEAD_DIM, num_warps=4, num_stages=2, maxRegAutoWS=192)
+
+
+@pytest.mark.skipif(not _is_sm90plus(), reason="WS + auto-TMA requires sm_90+")
+@pytest.mark.parametrize("N_CTX", [512, 1024, 2048])
+@pytest.mark.parametrize("HEAD_DIM", [64, 128])
+def test_plain_fa_fwd_ws_shapes(monkeypatch, N_CTX, HEAD_DIM):
+    """plain-pointer FA + WS + auto-TMA correctness across larger shapes."""
+    monkeypatch.setenv("TRITON_AUTO_TMA", "1")
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    Z, H = 2, 4
+    BLOCK_M, BLOCK_N = 128, 64
+    dtype = torch.float16
+    sm_scale = 1.0 / (HEAD_DIM**0.5)
+    torch.manual_seed(0)
+    q = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    k = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    v = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    o = torch.empty_like(q)
+    _run_plain_fa_ws(q, k, v, o, sm_scale, N_CTX, BLOCK_M, BLOCK_N, HEAD_DIM)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, scale=sm_scale, is_causal=False)
+    torch.testing.assert_close(o, ref, atol=1e-2, rtol=0)
+
+
+@pytest.mark.skipif(
+    os.environ.get("TRITON_RUN_PERF", "0") != "1",
+    reason="perf benchmark (large FA via do_bench); set TRITON_RUN_PERF=1 to run",
+)
+@pytest.mark.skipif(not _is_sm90plus(), reason="WS + auto-TMA requires sm_90+")
+def test_perf_plain_fa_fwd_ws(monkeypatch):
+    """Perf of the plain-pointer FA + WS + auto-TMA at a representative shape,
+    with accuracy vs torch SDPA. Prints TFLOP/s (pin a free GPU)."""
+    monkeypatch.setenv("TRITON_AUTO_TMA", "1")
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    Z, H, N_CTX, HEAD_DIM = 4, 32, 4096, 128
+    BLOCK_M, BLOCK_N = 128, 64
+    dtype = torch.float16
+    sm_scale = 1.0 / (HEAD_DIM**0.5)
+    torch.manual_seed(0)
+    q = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    k = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    v = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device="cuda")
+    o = torch.empty_like(q)
+    _run_plain_fa_ws(q, k, v, o, sm_scale, N_CTX, BLOCK_M, BLOCK_N, HEAD_DIM)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, scale=sm_scale, is_causal=False)
+    torch.testing.assert_close(o, ref, atol=1e-2, rtol=0)
+    fn = lambda: _run_plain_fa_ws(q, k, v, o, sm_scale, N_CTX, BLOCK_M, BLOCK_N, HEAD_DIM)
+    ms = triton.testing.do_bench(fn)
+    flops = 2 * 2.0 * Z * H * N_CTX * N_CTX * HEAD_DIM  # QK^T + PV, non-causal
+    tflops = flops * 1e-12 / (ms * 1e-3)
+    at = os.environ.get("TRITON_AUTO_TMA", "0")
+    print(f"\n[plain-fa-ws] auto_tma={at} fwd "
+          f"({Z}x{H}x{N_CTX}x{HEAD_DIM}): {ms:.4f} ms  {tflops:.1f} TFLOP/s  "
+          f"accuracy(vs torch SDPA)=PASS\n")

--- a/python/test/unit/runtime/test_promote_load_to_tma.py
+++ b/python/test/unit/runtime/test_promote_load_to_tma.py
@@ -407,3 +407,23 @@ def test_auto_tma_metaws_store_over_256():
         "meta-WS BLOCK_N=512 load must be auto-TMA promoted (clamped box + multi-copy)")
     assert "tt.descriptor_store" in k.asm["ttir"], (
         "meta-WS BLOCK_N=512 store must be auto-TMA store-promoted (clamped box + multi-copy)")
+
+
+@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
+def test_auto_tma_device_block_over_256(monkeypatch):
+    # DEVICE-descriptor mode (TRITON_AUTO_TMA_DEVICE=1, added in this diff): the load
+    # is promoted to an in-kernel tt.make_tensor_descriptor. Contiguous BLOCK_N=512 >
+    # 256. Unlike the host recipe, the device path clamps the box via getTMABlockShape
+    # at descriptor-build time (TMAUtilities::createTMADesc) and the device lowering
+    # multi-copies to fill the tile, so box>256 promotes and computes correctly. Non-WS,
+    # so it does not touch the AutoWS partition bug that blocks the host store path.
+    monkeypatch.setenv("TRITON_AUTO_TMA_DEVICE", "1")
+    M, N = 128, 512
+    BLOCK_M, BLOCK_N = 64, 512  # contiguous 512 > 256 -> device box clamp + multi-copy
+    x = torch.randn((M, N), device="cuda", dtype=torch.float16)
+    out = torch.empty((M, N), device="cuda", dtype=torch.float16)
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    k = _scale_2d_kernel[grid](x, out, M, N, x.stride(0), BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N)
+    torch.testing.assert_close(out, x * 2.0, atol=1e-2, rtol=1e-2)
+    assert "tt.make_tensor_descriptor" in k.asm["ttir"], "expected a device descriptor"
+    assert "tt.descriptor_load" in k.asm["ttir"], ("device-descriptor BLOCK_N=512 load must be auto-TMA promoted")

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -580,6 +580,8 @@ class nvidia_knobs(base_knobs):
     use_autotune_c_cache: env_bool = env_bool("TRITON_AUTOTUNE_USE_C_CACHE", True)
     # Default ON; opt out with TRITON_ENABLE_C_CACHE=0.
     enable_c_cache: env_bool = env_bool("TRITON_ENABLE_C_CACHE", True)
+    auto_tma_device: env_bool = env_bool("TRITON_AUTO_TMA_DEVICE")
+    use_autotune_c_cache: env_bool = env_bool("TRITON_AUTOTUNE_USE_C_CACHE")
     generate_subtiled_region: env_bool = env_bool("TRITON_GENERATE_SUBTILED_REGION")
     # When True, run the triton-nvidia-interleave-tmem pass on Blackwell.
     # Default ON; set TRITON_ENABLE_INTERLEAVE_TMEM=0 to opt out for A/B

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -206,6 +206,9 @@ class CUDAOptions:
     # Per-config auto-TMA toggle (autotunable). Falls back to the global
     # TRITON_AUTO_TMA knob when left at the default in make_ttir.
     auto_tma: bool = False
+    # Emit device-side descriptors (make_tensor_descriptor + descriptor_load/store)
+    # instead of host TMA recipes. Falls back to knobs.nvidia.auto_tma_device.
+    auto_tma_device: bool = False
 
     def __post_init__(self):
         default_libdir = Path(__file__).parent / "lib"
@@ -743,14 +746,15 @@ class CUDABackend(BaseBackend):
         # so the backing TMEM allocation is materialized with the resolved
         # 2-CTA (TwoCTA_RHS) storage format. See make_ttgir.
 
-        if capability // 10 < 9:
-            passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
         # Auto-TMA: rewrite eligible masked block loads into descriptor_load so
         # the standard sm_90+ TMA lowering turns them into real TMA copies. The
-        # per-config option (autotunable) takes precedence; otherwise fall back
-        # to the global TRITON_AUTO_TMA knob.
+        # per-config option (autotunable) takes precedence; otherwise the global
+        # TRITON_AUTO_TMA knob. (Block pointers are already tensor descriptors in
+        # this dialect, so there is no separate rewrite_tensor_pointer pass.)
         if (opt.auto_tma or knobs.nvidia.auto_tma) and capability // 10 >= 9:
-            nvidia.passes.ttnvgpuir.add_promote_load_to_tma(pm)
+            nvidia.passes.ttnvgpuir.add_promote_load_to_tma(pm, opt.auto_tma_device or knobs.nvidia.auto_tma_device)
+        if capability // 10 < 9:
+            passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_combine(pm)
         passes.ttir.add_reorder_broadcast(pm)

--- a/third_party/nvidia/hopper/run_all.sh
+++ b/third_party/nvidia/hopper/run_all.sh
@@ -69,3 +69,7 @@ pytest third_party/tlx/tutorials/test_self_attention_bwd.py
 
 echo "run for Hopper or Blackwell"
 pytest python/tutorials/fused-attention-ws-device-tma-hopper-or-blackwell.py
+
+echo "Verifying correctness of auto-TMA FA tutorial kernels"
+pytest third_party/tlx/tutorials/fused_attention_ws_auto_tma.py
+pytest third_party/tlx/tutorials/fused_attention_ws_auto_tma_dp.py

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -157,6 +157,13 @@ createTritonGPUProxyFenceInsertionWrapper(int32_t capability) {
   return ttng::createTritonGPUProxyFenceInsertion(options);
 }
 
+static std::unique_ptr<mlir::Pass>
+createPromoteLoadToTMAWrapper(bool deviceMode) {
+  ttng::TritonNvidiaGPUPromoteLoadToTMAPassOptions options;
+  options.deviceMode = deviceMode;
+  return ttng::createTritonNvidiaGPUPromoteLoadToTMAPass(options);
+}
+
 void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_plan_cta", ttng::createTritonNvidiaGPUPlanCTAPass);
   ADD_PASS_WRAPPER_1("add_fence_insertion",
@@ -169,8 +176,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      ttng::createTritonNvidiaGPUTMemBarrierInsertionPass);
   ADD_PASS_WRAPPER_0("add_tma_lowering",
                      ttng::createTritonNvidiaGPUTMALoweringPass);
-  ADD_PASS_WRAPPER_0("add_promote_load_to_tma",
-                     ttng::createTritonNvidiaGPUPromoteLoadToTMAPass);
+  ADD_PASS_WRAPPER_1("add_promote_load_to_tma", createPromoteLoadToTMAWrapper,
+                     bool);
   ADD_PASS_WRAPPER_0("add_tma_store_buffer_reuse",
                      ttng::createTritonNvidiaGPUTMAStoreBufferReusePass);
   ADD_PASS_WRAPPER_0("add_promote_lhs_to_tmem",

--- a/third_party/tlx/tutorials/fused_attention_ws_auto_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_auto_tma.py
@@ -1,0 +1,1841 @@
+import copy
+import json
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton.language.extra.cuda.inline_ptx_lib import _mul_f32x2, _fma_f32x2, _reduce_fadd2
+from triton.language.extra.subtile_ops import _split_n_2D
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+
+def is_hip():
+    return triton.runtime.driver.active.get_current_target().backend == "hip"
+
+
+def is_cuda():
+    target = triton.runtime.driver.active.get_current_target()
+    return getattr(target, "is_cuda_backend", lambda: target.backend == "cuda")()
+
+
+def supports_host_descriptor():
+    return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
+
+
+def is_blackwell():
+    return is_cuda() and torch.cuda.get_device_capability()[0] == 10
+
+
+def is_hopper():
+    return is_cuda() and torch.cuda.get_device_capability()[0] == 9
+
+
+@triton.jit
+def _mask_scalar(qk, col_limit_right, s, i):
+    col_lim_right_s = col_limit_right - s
+    col_lim_right_cur = max(col_lim_right_s, 0)
+    mask = -1 << col_lim_right_cur
+    mask_i_bit = (mask & (1 << i)) == 0
+    return tl.where(mask_i_bit, qk, -float("inf"))
+
+
+@triton.jit
+def _apply_causal_mask(qk, col_limit_right, BLOCK_N: tl.constexpr):
+    # Apply causal mask via a bitmask calculated for each block of 16 elements.
+    # This allows the efficient R2P (register to predicate) instruction to be used at the SASS level.
+    # Credit to Tri Dao,
+    # https://github.com/Dao-AILab/flash-attention/commit/bac1001e4f6caa09d70537495d6746a685a2fa78
+    #
+    # NOTE: We use map_elementwise here in order to generate an interleaved sequence of instructions
+    # that processes one element of qk at a time. This improves ptxas's resulting SASS.
+    offs_n = tl.arange(0, BLOCK_N)[None, :]
+    s = offs_n & ~0xF
+    i = offs_n & 0xF
+    return tl.map_elementwise(_mask_scalar, qk, col_limit_right, s, i)
+
+
+@triton.jit
+def _attn_fwd_subtile(
+    q,
+    k,
+    offs_m,
+    start_n,
+    start_m,
+    BLOCK_N,
+    BLOCK_M,
+    offs_n,
+    qk_scale,
+    l_i0,
+    l_i1,  # used when FADD2_REDUCE is true
+    m_i,
+    acc,
+    v,
+    dtype: tl.constexpr,
+    STAGE: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+):
+    qk = tl.dot(q, k)
+
+    if STAGE == 3 and start_n >= start_m * BLOCK_M:
+        col_limit_right = (offs_m - start_n + 1)[:, None]
+        qk = _apply_causal_mask(qk, col_limit_right, BLOCK_N)
+
+    m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+
+    if VECT_MUL == 2 or VECT_MUL == 3:
+        qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
+    else:
+        qk = qk * qk_scale - m_ij[:, None]
+
+    p = tl.math.exp2(qk)
+    # -- compute correction factor
+    alpha = tl.math.exp2(m_i - m_ij)
+    if not FADD2_REDUCE:
+        l_ij = tl.sum(p, 1)
+
+    # -- update output accumulator --
+    BM: tl.constexpr = acc.shape[0]
+    BN: tl.constexpr = acc.shape[1]
+
+    if SUBTILING:
+        acc0, acc1 = acc.reshape([BM, 2, BN // 2]).permute(0, 2, 1).split()
+        if VECT_MUL == 1 or VECT_MUL == 3:
+            acc0 = _mul_f32x2(acc0, alpha[:, None])
+            acc1 = _mul_f32x2(acc1, alpha[:, None])
+        else:
+            acc0 = acc0 * alpha[:, None]
+            acc1 = acc1 * alpha[:, None]
+        acc = tl.join(acc0, acc1).permute(0, 2, 1).reshape([BM, BN])
+    else:
+        acc = acc * alpha[:, None]
+
+    PM: tl.constexpr = p.shape[0]
+    PN: tl.constexpr = p.shape[1]
+    if FADD2_REDUCE:
+        p0, p1 = p.reshape([PM, 2, PN // 2]).permute(0, 2, 1).split()
+        l_ij0, l_ij1 = tl.reduce((p0, p1), axis=1, combine_fn=_reduce_fadd2)
+        l_i0 = l_i0 * alpha + l_ij0
+        l_i1 = l_i1 * alpha + l_ij1
+
+    # prepare p and v for the dot
+    p = p.to(dtype)
+    # note that this non transposed v for FP8 is only supported on Blackwell
+    acc = tl.dot(p, v, acc)
+    # update m_i and l_i
+    # place this at the end of the loop to reduce register pressure
+    if not FADD2_REDUCE:
+        l_i0 = l_i0 * alpha + l_ij
+    m_i = m_ij
+
+    return l_i0, l_i1, m_i, acc
+
+
+@triton.jit
+def _attn_fwd_inner_oss_dp(
+    acc0,
+    l_i0,
+    l_i0_1,
+    m_i0,
+    q0,
+    K,
+    V,  #
+    y_dim,
+    stride_m,
+    offset_y,
+    dtype: tl.constexpr,
+    start_m,
+    qk_scale,  #
+    BLOCK_M: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_N: tl.constexpr,  #
+    STAGE: tl.constexpr,
+    offs_m0: tl.constexpr,
+    offs_n: tl.constexpr,  #
+    N_CTX: tl.constexpr,
+    warp_specialize: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+    DP_FACTOR: tl.constexpr,
+):
+    # range of values handled by this stage
+    if STAGE == 1:  # causal = False
+        lo, hi = 0, N_CTX
+    else:  # causal = True
+        lo, hi = 0, (start_m + 1) * BLOCK_M
+    offsetkv_y = offset_y + lo
+
+    # loop over k, v and update accumulator
+    for start_n in tl.range(
+            lo,
+            hi,
+            BLOCK_N,
+            warp_specialize=warp_specialize,
+            merge_epilogue=True,
+            separate_epilogue_store=True,
+            # disallow_acc_multi_buffer=True,
+            data_partition_factor=DP_FACTOR,
+    ):
+        start_n = tl.multiple_of(start_n, BLOCK_N)
+
+        # auto-TMA: plain masked loads (mask recovers the global row extent y_dim;
+        # the contiguous HEAD_DIM dim has no mask -> whole-dim constant extent).
+        offs_kv = offsetkv_y + tl.arange(0, BLOCK_N)
+        offs_d = tl.arange(0, HEAD_DIM)[None, :]
+        kv_mask = offs_kv[:, None] < y_dim
+        k = tl.load(K + offs_kv[:, None] * stride_m + offs_d, mask=kv_mask, other=0.0).T
+        v = tl.load(V + offs_kv[:, None] * stride_m + offs_d, mask=kv_mask, other=0.0)
+
+        l_i0, l_i0_1, m_i0, acc0 = _attn_fwd_subtile(
+            q0,
+            k,
+            offs_m0,
+            start_n,
+            start_m,
+            BLOCK_N,
+            BLOCK_M,
+            offs_n,
+            qk_scale,
+            l_i0,
+            l_i0_1,
+            m_i0,
+            acc0,
+            v,
+            dtype,
+            STAGE,
+            SUBTILING,
+            VECT_MUL,
+            FADD2_REDUCE,
+        )
+
+        offsetkv_y += BLOCK_N
+
+    return acc0, l_i0, l_i0_1, m_i0
+
+
+def _host_descriptor_pre_hook(nargs):
+    BLOCK_M = nargs["BLOCK_M"]
+    BLOCK_N = nargs["BLOCK_N"]
+    HEAD_DIM = nargs["HEAD_DIM"]
+    # auto-TMA path passes raw tensors (Q/K/V/O) instead of host descriptors, so
+    # there is nothing to pre-shape here.
+    if "desc_q" not in nargs or not isinstance(nargs["desc_q"], TensorDescriptor):
+        return
+    nargs["desc_q"].block_shape = [BLOCK_M, HEAD_DIM]  # due to data partitioning
+    if nargs["FP8_OUTPUT"]:
+        nargs["desc_v"].block_shape = [HEAD_DIM, BLOCK_N]
+    else:
+        nargs["desc_v"].block_shape = [BLOCK_N, HEAD_DIM]
+    nargs["desc_k"].block_shape = [BLOCK_N, HEAD_DIM]
+    nargs["desc_o"].block_shape = [BLOCK_M, HEAD_DIM]
+
+
+if is_hip():
+    NUM_STAGES_OPTIONS = [1]
+elif supports_host_descriptor():
+    NUM_STAGES_OPTIONS = [3]
+else:
+    NUM_STAGES_OPTIONS = [3]
+
+configs = [
+    triton.Config(
+        {
+            "BLOCK_M": BM,
+            "BLOCK_N": BN,
+            "DP_FACTOR": 2,
+        },
+        num_stages=s,
+        num_warps=w,
+        pre_hook=_host_descriptor_pre_hook,
+    ) for BM in [256] for BN in [128] for s in NUM_STAGES_OPTIONS for w in [4]
+]
+
+
+def keep(conf):
+    BLOCK_M = conf.kwargs["BLOCK_M"]
+    BLOCK_N = conf.kwargs["BLOCK_N"]
+    return not (is_cuda() and torch.cuda.get_device_capability()[0] == 9 and BLOCK_M * BLOCK_N < 128 * 128
+                and conf.num_warps == 8)
+
+
+def prune_invalid_configs(configs, named_args, **kwargs):
+    N_CTX = kwargs["N_CTX"]
+
+    # Filter out configs where BLOCK_M > N_CTX
+    return [conf for conf in configs if conf.kwargs.get("BLOCK_M", 0) <= N_CTX]
+
+
+@triton.jit
+def _maybe_make_tensor_desc(desc_or_ptr, shape, strides, block_shape):
+    if isinstance(desc_or_ptr, tl.tensor_descriptor):
+        return desc_or_ptr
+    else:
+        return tl.make_tensor_descriptor(desc_or_ptr, shape, strides, block_shape)
+
+
+@triton.jit
+def _attn_fwd_tma_dp(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    Q,
+    K,
+    V,
+    O,
+    y_dim,
+    stride_m,
+    pid,
+    off_hz,
+    N_CTX: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    STAGE: tl.constexpr,  #
+    warp_specialize: tl.constexpr,  #
+    dtype: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+    DP_FACTOR: tl.constexpr,
+):
+    start_m = pid  # tl.program_id(0)
+    # off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    off_h = off_hz % H
+
+    offset_y = off_z * (N_CTX * H) + off_h * N_CTX
+    qo_offset_y = offset_y + start_m * BLOCK_M
+    # initialize offsets
+    offs_m0 = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+
+    m_i0 = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i0_0 = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
+    acc0 = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+
+    qk_scale = sm_scale
+    qk_scale *= 1.44269504  # 1/log(2)
+
+    offs_q = qo_offset_y + tl.arange(0, BLOCK_M)
+    offs_dq = tl.arange(0, HEAD_DIM)[None, :]
+    q_mask = offs_q[:, None] < y_dim
+    q0 = tl.load(Q + offs_q[:, None] * stride_m + offs_dq, mask=q_mask, other=0.0)
+
+    if FADD2_REDUCE:
+        l_i0_1 = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
+    else:
+        l_i0_1 = 0
+
+    acc0, l_i0_0, l_i0_1, m_i0 = _attn_fwd_inner_oss_dp(
+        acc0,
+        l_i0_0,
+        l_i0_1,
+        m_i0,
+        q0,
+        K,
+        V,
+        y_dim,
+        stride_m,
+        offset_y,
+        dtype,
+        start_m,
+        qk_scale,
+        BLOCK_M,
+        HEAD_DIM,
+        BLOCK_N,
+        STAGE,
+        offs_m0,
+        offs_n,
+        N_CTX,
+        warp_specialize,
+        SUBTILING,
+        VECT_MUL,
+        FADD2_REDUCE,
+        DP_FACTOR,
+    )
+
+    if FADD2_REDUCE:
+        l_i0 = l_i0_0 + l_i0_1
+    else:
+        l_i0 = l_i0_0
+
+    m_i0 += tl.math.log2(l_i0)
+    acc0 = acc0 / l_i0[:, None]
+    m_ptrs0 = M + off_hz * N_CTX + offs_m0
+    tl.store(m_ptrs0, m_i0)
+    tl.store(O + offs_q[:, None] * stride_m + offs_dq, acc0.to(dtype), mask=q_mask)
+
+
+@triton.autotune(
+    configs=list(filter(keep, configs)),
+    key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT", "warp_specialize"],
+    prune_configs_by={"early_config_prune": prune_invalid_configs},
+)
+@triton.jit
+def _attn_fwd(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    Q,
+    K,
+    V,
+    O,
+    y_dim,
+    stride_m,
+    N_CTX: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    STAGE: tl.constexpr,  #
+    warp_specialize: tl.constexpr,  #
+    dtype: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+    DP_FACTOR: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    off_hz = tl.program_id(1)
+
+    _attn_fwd_tma_dp(
+        sm_scale,
+        M,
+        Z,
+        H,
+        Q,
+        K,
+        V,
+        O,
+        y_dim,
+        stride_m,
+        pid,
+        off_hz,
+        N_CTX,
+        HEAD_DIM,
+        BLOCK_M,
+        BLOCK_N,
+        FP8_OUTPUT,
+        STAGE,
+        warp_specialize,
+        dtype,
+        SUBTILING,
+        VECT_MUL,
+        FADD2_REDUCE,
+        DP_FACTOR,
+    )
+
+
+@triton.autotune(
+    configs=list(filter(keep, configs)),
+    key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT", "warp_specialize"],
+    prune_configs_by={"early_config_prune": prune_invalid_configs},
+)
+@triton.jit
+def _attn_fwd_persist(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    Q,
+    K,
+    V,
+    O,
+    y_dim,
+    stride_m,
+    N_CTX: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    STAGE: tl.constexpr,  #
+    warp_specialize: tl.constexpr,  #
+    OUTER_LOOP: tl.constexpr,
+    dtype: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+    DP_FACTOR: tl.constexpr,
+):
+    n_tile_num = tl.cdiv(N_CTX, BLOCK_M)
+    prog_id = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    total_tiles = n_tile_num * Z * H
+
+    tiles_per_sm = total_tiles // num_progs
+    if prog_id < total_tiles % num_progs:
+        tiles_per_sm += 1
+
+    tile_idx = prog_id
+
+    # inner loop warpspec vs. outer loop warpspec
+    for _ in tl.range(
+            0,
+            tiles_per_sm,
+            warp_specialize=warp_specialize and OUTER_LOOP,
+            merge_epilogue=True,
+            separate_epilogue_store=True,
+            data_partition_factor=DP_FACTOR,
+    ):
+        pid = tile_idx % n_tile_num
+        off_hz = tile_idx // n_tile_num
+        _attn_fwd_tma_dp(
+            sm_scale,
+            M,
+            Z,
+            H,
+            Q,
+            K,
+            V,
+            O,
+            y_dim,
+            stride_m,
+            pid,
+            off_hz,
+            N_CTX,
+            HEAD_DIM,
+            BLOCK_M,
+            BLOCK_N,
+            FP8_OUTPUT,
+            STAGE,
+            warp_specialize and not OUTER_LOOP,
+            dtype,
+            SUBTILING,
+            VECT_MUL,
+            FADD2_REDUCE,
+            DP_FACTOR,
+        )
+        tile_idx += num_progs
+
+
+def torch_dtype_to_triton(dtype):
+    if dtype == torch.float8_e5m2:
+        return tl.float8e5
+    return getattr(tl, str(dtype).split(".")[1])
+
+
+@triton.jit
+def _attn_bwd_preprocess(O, DO,  #
+                         Delta,  #
+                         Z, H, N_CTX,  #
+                         BLOCK_M: tl.constexpr, HEAD_DIM: tl.constexpr,  #
+                         ):
+    off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    off_hz = tl.program_id(1)
+    off_n = tl.arange(0, HEAD_DIM)
+    # load
+    o = tl.load(O + off_hz * HEAD_DIM * N_CTX + off_m[:, None] * HEAD_DIM + off_n[None, :])
+    do = tl.load(DO + off_hz * HEAD_DIM * N_CTX + off_m[:, None] * HEAD_DIM + off_n[None, :]).to(tl.float32)
+    delta = tl.sum(o * do, axis=1)
+    # write-back
+    tl.store(Delta + off_hz * N_CTX + off_m, delta)
+
+
+# Frozen (hashable) wrapper for dot attrs configuration, usable in triton.Config.
+# Supports .get(key) like a dict but is hashable for Triton's JIT cache key.
+class FrozenDotAttrs:
+
+    def __init__(self, d):
+        self._data = d
+        self._hash = hash(json.dumps(d, sort_keys=True)) if d else hash(None)
+
+    def get(self, key, default=None):
+        return self._data.get(key, default) if self._data else default
+
+    def __hash__(self):
+        return self._hash
+
+    def __eq__(self, other):
+        if isinstance(other, FrozenDotAttrs):
+            return self._data == other._data
+        return NotImplemented
+
+    def __repr__(self):
+        return f"FrozenDotAttrs({self._data})"
+
+    def __bool__(self):
+        return bool(self._data)
+
+
+# Default dot attrs configuration for the BWD kernel.
+# Each key corresponds to a dot operation in _attn_bwd_dkdv_inner.
+# Set to None to disable attrs for a given dot (heuristic allocation).
+# Format: {"stage": str, "order": str, "channels": [str, ...]}
+_DEFAULT_BWD_DOT_ATTRS = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},
+    "dpT": {"stage": "0", "order": "2", "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"]},
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
+    "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,5"]},
+    "dk": {"stage": "1", "order": "1", "channels": ["opndD,tmem,1,10"]},
+})
+
+# For BM of 128: dpT share with dq, qk share with ppT, dsT share with dpT.
+_BWD_DOT_ATTRS_TMEM = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},
+    "dpT": {"stage": "0", "order": "2", "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"]},
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
+    "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,5"]},
+    "dk": {"stage": "1", "order": "1", "channels": ["opndA,tmem,1,5", "opndD,tmem,1,10"]},
+})
+
+_BWD_DOT_ATTRS_BM64_TMEM = FrozenDotAttrs({
+    # qkT inputs: k, q; dpT inputs: v, do; dv inputs: ppT, do; dq inputs: dsT, k; dk inputs: dsT, q
+    # no need to reuse between dq and dpT
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},  # k, q
+    "dpT": {
+        "stage": "0",
+        "order": "2",
+        "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"],
+    },  # v, do
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},  # ppT
+    "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,11"]},  # dsT
+    "dk": {"stage": "1", "order": "1", "channels": ["opndA,tmem,1,5", "opndD,tmem,1,10"]},  # dsT in tmem
+})
+
+_BWD_DOT_ATTRS_BM64 = FrozenDotAttrs({
+    # qkT inputs: k, q; dpT inputs: v, do; dv inputs: ppT, do; dq inputs: dsT, k; dk inputs: dsT, q
+    # no need to reuse between dq and dpT
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},  # k, q
+    "dpT": {
+        "stage": "0",
+        "order": "2",
+        "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"],
+    },  # v, do
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},  # ppT
+    "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,11"]},  # dsT
+    "dk": {"stage": "1", "order": "1", "channels": ["opndD,tmem,1,10"]},
+})
+
+_BWD_DOT_ATTRS_SCHED = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0"},
+    "dpT": {"stage": "0", "order": "2"},
+    "dv": {"stage": "0", "order": "2"},
+    "dq": {"stage": "1", "order": "1"},
+    "dk": {"stage": "1", "order": "1"},
+})
+
+
+@triton.jit
+def _attn_bwd_dkdv_inner(
+    dk,
+    dv,
+    desc_q,
+    k,
+    v,
+    desc_do,
+    desc_dq,
+    desc_m,
+    desc_delta,
+    off_bh,
+    off_chz,
+    curr_m,
+    step_m,
+    start_n,
+    offs_n,
+    BLOCK_M1: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    MASK: tl.constexpr,
+    dtype: tl.constexpr,
+    DQ_SUBTILE: tl.constexpr,
+    LN2: tl.constexpr,
+    RESCHED: tl.constexpr,
+    BWD_DOT_ATTRS: tl.constexpr = None,
+):
+    q = desc_q.load([(off_bh + curr_m).to(tl.int32), 0])
+    qT = tl.trans(q)
+    offs_m_start = off_chz + curr_m
+    m = desc_m.load([offs_m_start.to(tl.int32)])
+    if RESCHED:
+        qkT = tl.dot(k, qT, attrs=BWD_DOT_ATTRS.get("qkT"))
+    else:
+        qkT = tl.dot(k, qT)
+    pT = tl.math.exp2(qkT - m[None, :])
+    if MASK:
+        offs_m = curr_m + tl.arange(0, BLOCK_M1)
+        mask = offs_m[None, :] >= offs_n[:, None]
+        pT = tl.where(mask, pT, 0.0)
+    do = desc_do.load([(off_bh + curr_m).to(tl.int32), 0])
+    ppT = pT
+    ppT = ppT.to(dtype)
+    if RESCHED:
+        dpT = tl.dot(v, tl.trans(do), attrs=BWD_DOT_ATTRS.get("dpT")).to(tl.float32)
+        Di = desc_delta.load([offs_m_start.to(tl.int32)])
+        dv += tl.dot(ppT, do, attrs=BWD_DOT_ATTRS.get("dv"))
+    else:
+        dv += tl.dot(ppT, do)
+        Di = desc_delta.load([offs_m_start.to(tl.int32)])
+        dpT = tl.dot(v, tl.trans(do)).to(tl.float32)
+    dsT = pT * (dpT - Di[None, :])
+    dsT = dsT.to(dtype)
+    if RESCHED:
+        # dk reads dsT from the reused TMEM buffer-5; dq writes the same buffer.
+        # dk must read before dq overwrites (cf. TLX
+        # blackwell_fa_ws_pipelined_persistent: "dk must read dsT_tmem BEFORE
+        # dq writes ... same TMEM slot"). Emit dk first.
+        dk += tl.dot(dsT, tl.trans(qT), attrs=BWD_DOT_ATTRS.get("dk"))
+        dq = tl.dot(tl.trans(dsT), k, attrs=BWD_DOT_ATTRS.get("dq"))
+    else:
+        dk += tl.dot(dsT, tl.trans(qT))
+        dq = tl.dot(tl.trans(dsT), k)
+    dqs = _split_n_2D(dq, DQ_SUBTILE)
+    slice_size: tl.constexpr = HEAD_DIM // DQ_SUBTILE
+    for slice_id in tl.static_range(0, DQ_SUBTILE):
+        dqN = dqs[slice_id] * LN2
+        desc_dq.atomic_add([(off_bh + curr_m).to(tl.int32), slice_id * slice_size], dqN)
+    curr_m += step_m
+    return dk, dv, curr_m
+
+
+@triton.jit
+def _attn_bwd_dkdv(
+    dk,
+    dv,  #
+    desc_q,
+    k,
+    v,
+    sm_scale,  #
+    desc_do,  #
+    desc_dq,
+    desc_m,
+    desc_delta,  #
+    # shared by Q/K/V/DO.
+    stride_tok,
+    stride_d,  #
+    off_bh,
+    off_chz,
+    H,
+    N_CTX,
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,  #
+    # Filled in by the wrapper.
+    start_n,
+    start_m,
+    num_steps,  #
+    MASK: tl.constexpr,
+    dtype: tl.constexpr,
+    warp_specialize: tl.constexpr,  #
+    EPILOGUE_SUBTILE: tl.constexpr,
+    DQ_SUBTILE: tl.constexpr,
+    BWD_DOT_ATTRS: tl.constexpr = None,
+    SMEM_BUDGET: tl.constexpr = 200000,
+):
+    offs_n = start_n + tl.arange(0, BLOCK_N1)
+
+    LN2: tl.constexpr = 0.6931471824645996  # = ln(2)
+
+    # BLOCK_N1 must be a multiple of BLOCK_M1, otherwise the code wouldn't work.
+    tl.static_assert(BLOCK_N1 % BLOCK_M1 == 0)
+    curr_m = start_m
+    step_m = BLOCK_M1
+    if warp_specialize:
+        for blk_idx in tl.range(
+                0,
+                num_steps,
+                warp_specialize=True,
+                merge_epilogue_to_computation=True,
+                tmem_alloc_algo=2,
+                smem_alloc_algo=1,
+                smem_budget=SMEM_BUDGET,
+        ):
+            dk, dv, curr_m = _attn_bwd_dkdv_inner(
+                dk,
+                dv,
+                desc_q,
+                k,
+                v,
+                desc_do,
+                desc_dq,
+                desc_m,
+                desc_delta,
+                off_bh,
+                off_chz,
+                curr_m,
+                step_m,
+                start_n,
+                offs_n,
+                BLOCK_M1,
+                HEAD_DIM,
+                MASK,
+                dtype,
+                DQ_SUBTILE,
+                LN2,
+                True,
+                BWD_DOT_ATTRS,
+            )
+    else:
+        for blk_idx in tl.range(0, num_steps):
+            dk, dv, curr_m = _attn_bwd_dkdv_inner(
+                dk,
+                dv,
+                desc_q,
+                k,
+                v,
+                desc_do,
+                desc_dq,
+                desc_m,
+                desc_delta,
+                off_bh,
+                off_chz,
+                curr_m,
+                step_m,
+                start_n,
+                offs_n,
+                BLOCK_M1,
+                HEAD_DIM,
+                MASK,
+                dtype,
+                DQ_SUBTILE,
+                LN2,
+                True,
+                BWD_DOT_ATTRS,
+            )
+
+    return dk, dv
+
+
+def _bwd_host_descriptor_pre_hook(nargs):
+    BLOCK_M1 = nargs["BLOCK_M1"]
+    BLOCK_N1 = nargs["BLOCK_N1"]
+    HEAD_DIM = nargs["HEAD_DIM"]
+    EPILOGUE_SUBTILE = nargs["EPILOGUE_SUBTILE"]
+    # DQ_SUBTILE controls dq atomic_add staging only; defaults to
+    # EPILOGUE_SUBTILE so existing configs continue to behave the same.
+    DQ_SUBTILE = nargs.get("DQ_SUBTILE", EPILOGUE_SUBTILE)
+    if not isinstance(nargs["desc_q"], TensorDescriptor):
+        return
+
+    # Reset dq accumulator to zeros before each autotuner warmup run.
+    # Without this, dq accumulates across autotuner benchmark runs when
+    # multiple configs are present (e.g., USE_WARP_BARRIER in [False, True]).
+    nargs["desc_dq"].base.zero_()
+
+    nargs["desc_q"].block_shape = [BLOCK_M1, HEAD_DIM]
+    nargs["desc_do"].block_shape = [BLOCK_M1, HEAD_DIM]
+    nargs["desc_dq"].block_shape = [BLOCK_M1, HEAD_DIM // DQ_SUBTILE]
+    nargs["desc_v"].block_shape = [BLOCK_N1, HEAD_DIM]
+    nargs["desc_k"].block_shape = [BLOCK_N1, HEAD_DIM]
+    nargs["desc_dv"].block_shape = [BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE]
+    nargs["desc_dk"].block_shape = [BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE]
+    nargs["desc_m"].block_shape = [BLOCK_M1]
+    nargs["desc_delta"].block_shape = [BLOCK_M1]
+
+
+configs_bwd = [
+    triton.Config(
+        {
+            "BLOCK_M1": 128,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 4,
+            "DQ_SUBTILE": 4,
+            "BWD_DOT_ATTRS": FrozenDotAttrs(None),
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    )
+]
+
+configs_bwd_subtile_opt = [
+    triton.Config(
+        {
+            "BLOCK_M1": 64,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 4,
+            "DQ_SUBTILE": 4,
+            "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_BM64_TMEM,
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+]
+
+configs_bwd_persist = [
+    triton.Config(
+        {
+            "BLOCK_M1": 128,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 4,
+            "DQ_SUBTILE": 4,
+            "BWD_DOT_ATTRS": _DEFAULT_BWD_DOT_ATTRS,
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+    triton.Config(
+        {
+            "BLOCK_M1": 128, "BLOCK_N1": 128, "BLOCK_M2": 128, "BLOCK_N2": 128, "EPILOGUE_SUBTILE": 4, "DQ_SUBTILE": 4, "BWD_DOT_ATTRS":
+            _BWD_DOT_ATTRS_SCHED,  # use memory planner heuristics
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+    triton.Config( # test dk/dv staging buffer reuse
+        {
+            "BLOCK_M1": 128,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 2,
+            "DQ_SUBTILE": 4,
+            # The 3-group TMEM reuse benefits from extra SMEM headroom so Phase 4
+            # can pipeline (double-buffer) its staging; the other configs keep the
+            # default 200000 (a larger budget double-buffers their early-TMA store
+            # staging, which the store lowering mishandles -> wrong dv/dk/dq).
+            "SMEM_BUDGET": 220000,
+            "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_TMEM,
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+    triton.Config(
+        {
+            "BLOCK_M1": 64,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 2,
+            "DQ_SUBTILE": 4,
+            "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_BM64_TMEM,
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+    triton.Config(
+        {
+            "BLOCK_M1": 64,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 2,
+            "DQ_SUBTILE": 4,
+            "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_BM64,
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+]
+
+
+@triton.jit
+def _attn_bwd_core(
+    desc_q,
+    desc_k,
+    desc_v,
+    sm_scale,  #
+    desc_do,  #
+    desc_dq,
+    desc_dk,
+    desc_dv,  #
+    desc_m,
+    desc_delta,  #
+    stride_tok,
+    stride_d,  #
+    stride_z,
+    stride_h,  #
+    pid,
+    bhid,
+    BATCH: tl.constexpr,
+    H: tl.constexpr,
+    N_CTX: tl.constexpr,  #
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,
+    dtype: tl.constexpr,
+    warp_specialize: tl.constexpr,  #
+    EPILOGUE_SUBTILE: tl.constexpr,
+    DQ_SUBTILE: tl.constexpr,
+    BWD_DOT_ATTRS: tl.constexpr = None,
+    SMEM_BUDGET: tl.constexpr = 200000,
+):
+    off_chz = (bhid * N_CTX).to(tl.int64)
+    off_bh = ((stride_h * (bhid % H) + stride_z * (bhid // H)).to(tl.int64)) // stride_tok
+
+    dv = tl.zeros([BLOCK_N1, HEAD_DIM], dtype=tl.float32)
+    dk = tl.zeros([BLOCK_N1, HEAD_DIM], dtype=tl.float32)
+
+    start_n = pid * BLOCK_N1
+    start_m = 0
+
+    k = desc_k.load([(off_bh + start_n).to(tl.int32), 0])
+    v = desc_v.load([(off_bh + start_n).to(tl.int32), 0])
+    num_steps = (N_CTX - start_m) // BLOCK_M1
+    dk, dv = _attn_bwd_dkdv(  #
+        dk,
+        dv,  #
+        desc_q,
+        k,
+        v,
+        sm_scale,  #
+        desc_do,  #
+        desc_dq,
+        desc_m,
+        desc_delta,  #
+        stride_tok,
+        stride_d,  #
+        off_bh,
+        off_chz,
+        H,
+        N_CTX,  #
+        BLOCK_M1,
+        BLOCK_N1,
+        HEAD_DIM,  #
+        start_n,
+        start_m,
+        num_steps,  #
+        MASK=False,  #
+        dtype=dtype,
+        warp_specialize=warp_specialize,
+        EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
+        DQ_SUBTILE=DQ_SUBTILE,
+        BWD_DOT_ATTRS=BWD_DOT_ATTRS,
+        SMEM_BUDGET=SMEM_BUDGET,
+    )
+
+    dvs = _split_n_2D(dv, EPILOGUE_SUBTILE)
+    slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
+    for slice_id in tl.static_range(0, EPILOGUE_SUBTILE):
+        dvN = dvs[slice_id]
+        desc_dv.store(
+            [(off_bh + start_n).to(tl.int32), slice_id * slice_size],
+            dvN.to(dtype),
+        )
+
+    dks = _split_n_2D(dk, EPILOGUE_SUBTILE)
+    for slice_id in tl.static_range(0, EPILOGUE_SUBTILE):
+        dkN = dks[slice_id] * sm_scale
+        desc_dk.store(
+            [(off_bh + start_n).to(tl.int32), slice_id * slice_size],
+            dkN.to(dtype),
+        )
+
+
+@triton.autotune(configs=configs_bwd, key=["N_CTX", "HEAD_DIM"])
+@triton.jit
+def _attn_bwd(
+    desc_q,
+    desc_k,
+    desc_v,
+    sm_scale,  #
+    desc_do,  #
+    desc_dq,
+    desc_dk,
+    desc_dv,  #
+    desc_m,
+    desc_delta,
+    # shared by Q/K/V/DO.
+    stride_z,
+    stride_h,
+    stride_tok,
+    stride_d,  #
+    BATCH,
+    H,
+    N_CTX,  #
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    BLOCK_M2: tl.constexpr,  #
+    BLOCK_N2: tl.constexpr,  #
+    BLK_SLICE_FACTOR: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,
+    dtype: tl.constexpr,
+    warp_specialize: tl.constexpr,  #
+    EPILOGUE_SUBTILE: tl.constexpr,
+    DQ_SUBTILE: tl.constexpr,
+    BWD_DOT_ATTRS: tl.constexpr = None,
+    SMEM_BUDGET: tl.constexpr = 200000,
+):
+    bhid = tl.program_id(2)
+    pid = tl.program_id(0)
+
+    _attn_bwd_core(
+        desc_q,
+        desc_k,
+        desc_v,
+        sm_scale,
+        desc_do,
+        desc_dq,
+        desc_dk,
+        desc_dv,
+        desc_m,
+        desc_delta,
+        stride_tok,
+        stride_d,
+        stride_z,
+        stride_h,
+        pid,
+        bhid,
+        BATCH,
+        H,
+        N_CTX,
+        BLOCK_M1,
+        BLOCK_N1,
+        HEAD_DIM,
+        dtype,
+        warp_specialize,
+        EPILOGUE_SUBTILE,
+        DQ_SUBTILE,
+        BWD_DOT_ATTRS,
+        SMEM_BUDGET,
+    )
+
+
+@triton.autotune(configs=configs_bwd_persist, key=["N_CTX", "HEAD_DIM"])
+@triton.jit
+def _attn_bwd_persist(
+    desc_q,
+    desc_k,
+    desc_v,
+    sm_scale,  #
+    desc_do,  #
+    desc_dq,
+    desc_dk,
+    desc_dv,  #
+    desc_m,
+    desc_delta,
+    # shared by Q/K/V/DO.
+    stride_z,
+    stride_h,
+    stride_tok,
+    stride_d,  #
+    BATCH,
+    H,
+    N_CTX,  #
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    BLOCK_M2: tl.constexpr,  #
+    BLOCK_N2: tl.constexpr,  #
+    BLK_SLICE_FACTOR: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,
+    dtype: tl.constexpr,
+    warp_specialize: tl.constexpr,  #
+    EPILOGUE_SUBTILE: tl.constexpr,
+    DQ_SUBTILE: tl.constexpr,
+    BWD_DOT_ATTRS: tl.constexpr = None,
+    SMEM_BUDGET: tl.constexpr = 200000,
+):
+    n_tile_num = tl.cdiv(N_CTX, BLOCK_N1)
+    prog_id = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    total_tiles = n_tile_num * BATCH * H
+
+    tiles_per_sm = total_tiles // num_progs
+    if prog_id < total_tiles % num_progs:
+        tiles_per_sm += 1
+
+    tile_idx = prog_id
+
+    y_dim = BATCH * H * N_CTX
+    desc_q = _maybe_make_tensor_desc(
+        desc_q,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_M1, HEAD_DIM],
+    )
+    desc_do = _maybe_make_tensor_desc(
+        desc_do,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_M1, HEAD_DIM],
+    )
+    desc_dq = _maybe_make_tensor_desc(
+        desc_dq,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_M1, HEAD_DIM // DQ_SUBTILE],
+    )
+    desc_v = _maybe_make_tensor_desc(
+        desc_v,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_N1, HEAD_DIM],
+    )
+    desc_k = _maybe_make_tensor_desc(
+        desc_k,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_N1, HEAD_DIM],
+    )
+    desc_dv = _maybe_make_tensor_desc(
+        desc_dv,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE],
+    )
+    desc_dk = _maybe_make_tensor_desc(
+        desc_dk,
+        shape=[y_dim, HEAD_DIM],
+        strides=[HEAD_DIM, 1],
+        block_shape=[BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE],
+    )
+    desc_m = _maybe_make_tensor_desc(
+        desc_m,
+        shape=[y_dim],
+        strides=[1],
+        block_shape=[BLOCK_M1],
+    )
+    desc_delta = _maybe_make_tensor_desc(
+        desc_delta,
+        shape=[y_dim],
+        strides=[1],
+        block_shape=[BLOCK_M1],
+    )
+
+    for _ in tl.range(
+            0,
+            tiles_per_sm,
+            warp_specialize=True,
+            merge_epilogue_to_computation=True,
+            tmem_alloc_algo=2,
+            smem_alloc_algo=1,
+            smem_budget=SMEM_BUDGET,
+    ):
+        pid = tile_idx % n_tile_num
+        bhid = tile_idx // n_tile_num
+        _attn_bwd_core(
+            desc_q,
+            desc_k,
+            desc_v,
+            sm_scale,
+            desc_do,
+            desc_dq,
+            desc_dk,
+            desc_dv,
+            desc_m,
+            desc_delta,
+            stride_tok,
+            stride_d,
+            stride_z,
+            stride_h,
+            pid,
+            bhid,
+            BATCH,
+            H,
+            N_CTX,
+            BLOCK_M1,
+            BLOCK_N1,
+            HEAD_DIM,
+            dtype,
+            False,
+            EPILOGUE_SUBTILE,
+            DQ_SUBTILE,
+            BWD_DOT_ATTRS,
+            SMEM_BUDGET,
+        )
+        tile_idx += num_progs
+
+
+class _attention_opt(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, q, k, v, causal, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE):
+        # shape constraints
+        HEAD_DIM_Q, HEAD_DIM_K = q.shape[-1], k.shape[-1]
+        # when v is in float8_e5m2 it is transposed.
+        HEAD_DIM_V = v.shape[-1]
+        assert HEAD_DIM_Q == HEAD_DIM_K and HEAD_DIM_K == HEAD_DIM_V
+        assert HEAD_DIM_K in {16, 32, 64, 128, 256}
+        o = torch.empty_like(q)
+        stage = 3 if causal else 1
+        extra_kern_args = {}
+
+        M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        warp_specialize = True
+        desc_q = q
+        desc_v = v
+        desc_k = k
+        desc_o = o
+        y_dim = q.shape[0] * q.shape[1] * q.shape[2]
+        stride_m = q.stride(2)  # row stride (= HEAD_DIM) as a runtime arg for auto-TMA
+
+        def alloc_fn(size: int, align: int, _):
+            return torch.empty(size, dtype=torch.int8, device="cuda")
+
+        triton.set_allocator(alloc_fn)
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+        def grid(META):
+            return (
+                triton.cdiv(q.shape[2], META["BLOCK_M"]),
+                q.shape[0] * q.shape[1],
+                1,
+            )
+
+        def grid_persist(META):
+            return (
+                min(
+                    NUM_SMS,
+                    triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1],
+                ),
+                1,
+                1,
+            )
+
+        ctx.grid = grid
+        persistent = baseVariant == "persistent" or baseVariant == "ws_persistent"
+        if is_blackwell() and warp_specialize:
+            extra_kern_args["maxnreg"] = 128
+        with triton.knobs.nvidia.scope():
+            triton.knobs.nvidia.use_meta_ws = True
+            triton.knobs.nvidia.use_meta_partition = True
+            triton.knobs.nvidia.disable_wsbarrier_reorder = True
+            triton.knobs.nvidia.auto_tma = True
+            triton.knobs.nvidia.auto_tma_device = True
+            if persistent:
+                _attn_fwd_persist[grid_persist](
+                    sm_scale,
+                    M,  #
+                    q.shape[0],
+                    q.shape[1],  #
+                    desc_q,
+                    desc_k,
+                    desc_v,
+                    desc_o,
+                    y_dim,
+                    stride_m,  #
+                    N_CTX=q.shape[2],  #
+                    HEAD_DIM=HEAD_DIM_K,  #
+                    FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
+                    STAGE=stage,  #
+                    warp_specialize=warp_specialize,
+                    OUTER_LOOP=True,
+                    dtype=torch_dtype_to_triton(q.dtype),
+                    SUBTILING=SUBTILING,
+                    VECT_MUL=VECT_MUL,
+                    FADD2_REDUCE=FADD2_REDUCE,
+                    **extra_kern_args,
+                )
+            else:
+                _attn_fwd[grid](
+                    sm_scale,
+                    M,  #
+                    q.shape[0],
+                    q.shape[1],  #
+                    desc_q,
+                    desc_k,
+                    desc_v,
+                    desc_o,
+                    y_dim,
+                    stride_m,  #
+                    N_CTX=q.shape[2],  #
+                    HEAD_DIM=HEAD_DIM_K,  #
+                    FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
+                    STAGE=stage,  #
+                    warp_specialize=warp_specialize,
+                    dtype=torch_dtype_to_triton(q.dtype),
+                    SUBTILING=SUBTILING,
+                    VECT_MUL=VECT_MUL,
+                    FADD2_REDUCE=FADD2_REDUCE,
+                    **extra_kern_args,
+                )
+
+        ctx.save_for_backward(q, k, v, o, M)
+
+        ctx.sm_scale = sm_scale
+        ctx.HEAD_DIM = HEAD_DIM_K
+        ctx.causal = causal
+        ctx.persistent = persistent
+        return o
+
+    @staticmethod
+    def backward(ctx, do):
+        q, k, v, o, M = ctx.saved_tensors
+        assert do.is_contiguous()
+        assert q.stride() == k.stride() == v.stride() == o.stride() == do.stride()
+        dq = torch.zeros(q.shape, device=q.device, dtype=torch.float32)
+        dk = torch.empty_like(k)
+        dv = torch.empty_like(v)
+        BATCH, N_HEAD, N_CTX = q.shape[:3]
+        PRE_BLOCK = 128
+        BLK_SLICE_FACTOR = 2
+        RCP_LN2 = 1.4426950408889634  # = 1.0 / ln(2)
+        arg_k = k
+        arg_k = arg_k * (ctx.sm_scale * RCP_LN2)
+        assert N_CTX % PRE_BLOCK == 0
+        pre_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
+        delta = torch.empty_like(M)
+        _attn_bwd_preprocess[pre_grid](
+            o, do,  #
+            delta,  #
+            BATCH, N_HEAD, N_CTX,  #
+            BLOCK_M=PRE_BLOCK, HEAD_DIM=ctx.HEAD_DIM,  #
+        )
+        warp_specialize = True
+
+        dummy_block = [1, 1]
+        HEAD_DIM = ctx.HEAD_DIM
+
+        def alloc_fn(size: int, align: int, _):
+            return torch.empty(size, dtype=torch.int8, device="cuda")
+
+        triton.set_allocator(alloc_fn)
+
+        # NOTE: the persistent backward (_attn_bwd_persist) is functional for
+        # the tested configs (bwd_config_idx 0-4). bwd_config_idx 2
+        # (_BWD_DOT_ATTRS_TMEM, the 3-group dpT/dq/dsT TMEM reuse) relies on the
+        # early-TMA store staging (always on since #1709) and the cross-tile
+        # staging-reuse WAR barrier (WSCodePartition.cpp Step 7.5) — without it
+        # the dv/dk TMA-staging buffers (aliasing the v/do operand SMEM) race
+        # the next tile's operand load. See test_bwd_tmem_dsT_reuse_3group and
+        # test_bwd_tmem_dsT_reuse_3group_persistent.
+        desc_k = TensorDescriptor(
+            arg_k,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+        desc_v = TensorDescriptor(
+            v,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+        desc_q = TensorDescriptor(
+            q,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+        desc_do = TensorDescriptor(
+            do,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+        desc_dq = TensorDescriptor(
+            dq,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+        desc_dk = TensorDescriptor(
+            dk,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+        desc_dv = TensorDescriptor(
+            dv,
+            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
+            strides=[HEAD_DIM, 1],
+            block_shape=dummy_block,
+        )
+        dummy_block_1d = [1]
+        desc_m = TensorDescriptor(
+            M,
+            shape=[BATCH * N_HEAD * N_CTX],
+            strides=[1],
+            block_shape=dummy_block_1d,
+        )
+        desc_delta = TensorDescriptor(
+            delta,
+            shape=[BATCH * N_HEAD * N_CTX],
+            strides=[1],
+            block_shape=dummy_block_1d,
+        )
+
+        def grid(meta):
+            return (
+                triton.cdiv(N_CTX, meta["BLOCK_N1"]),  # tiles along N (K/V)
+                1,  # (or cdiv over M if you need)
+                BATCH * N_HEAD,
+            )  # batch*heads
+
+        if ctx.persistent:
+            NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+            def grid_persist_bwd(meta):
+                return (
+                    min(
+                        NUM_SMS,
+                        triton.cdiv(N_CTX, meta["BLOCK_N1"]) * BATCH * N_HEAD,
+                    ),
+                    1,
+                    1,
+                )
+
+        with triton.knobs.nvidia.scope():
+            triton.knobs.nvidia.use_meta_ws = True
+            triton.knobs.nvidia.use_meta_partition = True
+            triton.knobs.nvidia.disable_wsbarrier_reorder = True
+            if ctx.persistent:
+                _attn_bwd_persist[grid_persist_bwd](
+                    desc_q,
+                    desc_k,
+                    desc_v,
+                    ctx.sm_scale,
+                    desc_do,
+                    desc_dq,
+                    desc_dk,
+                    desc_dv,  #
+                    desc_m,
+                    desc_delta,  #
+                    q.stride(0),
+                    q.stride(1),
+                    q.stride(2),
+                    q.stride(3),  #
+                    BATCH,
+                    N_HEAD,
+                    N_CTX,  #
+                    BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
+                    HEAD_DIM=ctx.HEAD_DIM,  #
+                    dtype=torch_dtype_to_triton(q.dtype),
+                    warp_specialize=warp_specialize,
+                    maxRegAutoWS=192,
+                )
+            else:
+                _attn_bwd[grid](
+                    desc_q,
+                    desc_k,
+                    desc_v,
+                    ctx.sm_scale,
+                    desc_do,
+                    desc_dq,
+                    desc_dk,
+                    desc_dv,  #
+                    desc_m,
+                    desc_delta,  #
+                    q.stride(0),
+                    q.stride(1),
+                    q.stride(2),
+                    q.stride(3),  #
+                    BATCH,
+                    N_HEAD,
+                    N_CTX,  #
+                    BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
+                    HEAD_DIM=ctx.HEAD_DIM,  #
+                    dtype=torch_dtype_to_triton(q.dtype),
+                    warp_specialize=warp_specialize,
+                    maxRegAutoWS=192,
+                )
+
+        return dq, dk, dv, None, None, None, None, None, None, None
+
+
+attention = _attention_opt.apply
+
+
+@pytest.mark.skipif(
+    not is_blackwell(),
+    reason="Requires Blackwell GPU",
+)
+@pytest.mark.parametrize("Z", [8])
+@pytest.mark.parametrize("H", [16])
+@pytest.mark.parametrize("N_CTX", [1024])  # , 2048])
+@pytest.mark.parametrize("HEAD_DIM", [64, 128])
+@pytest.mark.parametrize("causal", [False])
+@pytest.mark.parametrize("mode", ["fwd", "bwd"])
+@pytest.mark.parametrize("baseVariant", ["ws_persistent", "ws"])
+@pytest.mark.parametrize("provider", ["triton-fp16"])
+@pytest.mark.parametrize("SUBTILING", [False, True])
+@pytest.mark.parametrize("VECT_MUL", [0])  # , 1, 2, 3])
+@pytest.mark.parametrize("FADD2_REDUCE", [False])
+@pytest.mark.parametrize("bwd_config_idx", range(len(configs_bwd_persist)))
+def test_op(
+    Z,
+    H,
+    N_CTX,
+    HEAD_DIM,
+    causal,
+    mode,
+    baseVariant,
+    provider,
+    SUBTILING,
+    VECT_MUL,
+    FADD2_REDUCE,
+    bwd_config_idx,
+    dtype=torch.float16,
+    smem_budget=None,
+):
+    # For fwd mode, only run once (bwd_config_idx=0) to avoid redundant tests
+    if mode == "fwd" and bwd_config_idx > 0:
+        pytest.skip("bwd_config_idx only applies to bwd mode")
+    if mode == "bwd" and "fp8" in provider:
+        pytest.skip("Backward pass with FP8 is not supported.")
+    if mode == "bwd" and HEAD_DIM == 64 and bwd_config_idx == 1:
+        pytest.skip("bwd_config_idx of 1 does not work with hDim 64")
+    # SUBTILING / VECT_MUL / FADD2_REDUCE only affect the forward kernels; the
+    # backward kernels ignore them. Running bwd across both SUBTILING values
+    # would re-run identical backward tests, so keep a single representative.
+    if mode == "bwd" and SUBTILING:
+        pytest.skip("SUBTILING is forward-only; redundant for bwd")
+    # bwd_config_idx 2 is the _BWD_DOT_ATTRS_TMEM 3-group TMEM-reuse config
+    # (BLOCK_M1=128, EPILOGUE_SUBTILE=2). The reuse packs dpT/dq/dsT into one
+    # TMEM allocation, which only fits via the early-TMA store staging (now
+    # always on; #1709 removed the early_tma_store_lowering knob). It runs on
+    # both the non-persistent (ws) and persistent (ws_persistent) backends
+    # (dedicated coverage: test_bwd_tmem_dsT_reuse_3group / _persistent).
+    if mode == "bwd":
+        chosen_cfg = configs_bwd_persist[bwd_config_idx]
+        # Optional per-test SMEM budget override (e.g. force depth-2 early-TMA
+        # store staging for the T277224987 regression). Copy so we never mutate
+        # the shared global config.
+        if smem_budget is not None:
+            chosen_cfg = copy.copy(chosen_cfg)
+            chosen_cfg.kwargs = dict(chosen_cfg.kwargs)
+            chosen_cfg.kwargs["SMEM_BUDGET"] = smem_budget
+        if baseVariant == "ws_persistent":
+            _attn_bwd_persist.configs = [chosen_cfg]
+            _attn_bwd_persist.cache = {}
+        elif baseVariant == "ws":
+            _attn_bwd.configs = [chosen_cfg]
+            _attn_bwd.cache = {}
+    torch.manual_seed(20)
+    q = torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_()
+    k = torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_()
+    v = torch.empty((Z, H, N_CTX, HEAD_DIM), dtype=dtype, device=DEVICE).normal_(mean=0.0, std=0.5).requires_grad_()
+    sm_scale = 0.5
+    # reference implementation
+    ref_dtype = dtype
+    if mode == "fwd" and "fp8" in provider:
+        ref_dtype = torch.float32
+    q = q.to(ref_dtype)
+    k = k.to(ref_dtype)
+    v = v.to(ref_dtype)
+    M = torch.tril(torch.ones((N_CTX, N_CTX), device=DEVICE))
+    p = torch.matmul(q, k.transpose(2, 3)) * sm_scale
+    if causal:
+        p[:, :, M == 0] = float("-inf")
+    p = torch.softmax(p.float(), dim=-1)
+    p = p.to(ref_dtype)
+    # p = torch.exp(p)
+    ref_out = torch.matmul(p, v).half()
+    if mode == "bwd":
+        dout = torch.randn_like(q)
+        ref_out.backward(dout)
+        ref_dv, v.grad = v.grad.clone(), None
+        ref_dk, k.grad = k.grad.clone(), None
+        ref_dq, q.grad = q.grad.clone(), None
+    # triton implementation
+    if mode == "fwd" and "fp8" in provider:
+        q = q.to(torch.float8_e5m2)
+        k = k.to(torch.float8_e5m2)
+        v = v.permute(0, 1, 3, 2).contiguous()
+        v = v.permute(0, 1, 3, 2)
+        v = v.to(torch.float8_e5m2)
+    tri_out = attention(q, k, v, causal, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE).half()
+    if mode == "fwd":
+        atol = 3 if "fp8" in provider else 1e-2
+        torch.testing.assert_close(tri_out, ref_out, atol=atol, rtol=0)
+        return
+    tri_out.backward(dout)
+    tri_dv, v.grad = v.grad.clone(), None
+    tri_dk, k.grad = k.grad.clone(), None
+    tri_dq, q.grad = q.grad.clone(), None
+    # compare
+    torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=0)
+    rtol = 0.0
+    # Relative tolerance workaround for known hardware limitation of CDNA2 GPU.
+    # For details see https://pytorch.org/docs/stable/notes/numerical_accuracy.html#reduced-precision-fp16-and-bf16-gemms-and-convolutions-on-amd-instinct-mi200-devices
+    if torch.version.hip is not None and triton.runtime.driver.active.get_current_target().arch == "gfx90a":
+        rtol = 1e-2
+    torch.testing.assert_close(tri_dv, ref_dv, atol=1e-2, rtol=rtol)
+    torch.testing.assert_close(tri_dk, ref_dk, atol=1e-2, rtol=rtol)
+    torch.testing.assert_close(tri_dq, ref_dq, atol=1e-2, rtol=rtol)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
+def test_bwd_tmem_dsT_reuse_3group():
+    # Regression for the 3-group TMEM-reuse accuracy bug.
+    #
+    # configs_bwd_persist[2] == _BWD_DOT_ATTRS_TMEM routes dsT through a TMEM
+    # buffer shared by {dpT, dq, dsT} (buffer.id=5) so dk reads dsT from TMEM
+    # instead of SMEM. The kernel computes dq and dk both from dsT and they
+    # alias the same TMEM slot: dk MUST read dsT before dq overwrites the slot
+    # (cf. TLX blackwell_fa_ws_pipelined_persistent: "dk must read dsT_tmem
+    # BEFORE dq writes ... same TMEM slot"). Before the fix the kernel emitted
+    # dq before dk, so dq clobbered dsT and the backward produced NaN. This test
+    # fails (NaN in dv/dk/dq) without the dk-before-dq ordering and passes with
+    # it.
+    #
+    # Runs on the non-persistent ("ws") backward.
+    test_op(
+        Z=8,
+        H=16,
+        N_CTX=1024,
+        HEAD_DIM=128,
+        causal=False,
+        mode="bwd",
+        baseVariant="ws",
+        provider="triton-fp16",
+        SUBTILING=False,  # forward-only knob; inert for the bwd kernel
+        VECT_MUL=0,
+        FADD2_REDUCE=False,
+        bwd_config_idx=2,
+    )
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
+def test_bwd_tmem_dsT_reuse_3group_persistent():
+    # Regression for the PERSISTENT 3-group TMEM-reuse SMEM race.
+    #
+    # Same config as test_bwd_tmem_dsT_reuse_3group but on the persistent
+    # backward (_attn_bwd_persist). The dv/dk TMA-staging buffers alias the v/do
+    # operand SMEM (allocation.reuseTarget); across the persistent outer tile
+    # loop the next tile's operand load raced the previous tile's staging TMA
+    # store (Step-7.5 cross-tile WAR barrier in WSCodePartition.cpp). Before the
+    # fix this produced non-deterministic wrong gradients (max-abs error ~3-4);
+    # with the dedicated cross-tile reuse token it is correct and deterministic.
+    test_op(
+        Z=8,
+        H=16,
+        N_CTX=1024,
+        HEAD_DIM=128,
+        causal=False,
+        mode="bwd",
+        baseVariant="ws_persistent",
+        provider="triton-fp16",
+        SUBTILING=False,
+        VECT_MUL=0,
+        FADD2_REDUCE=False,
+        bwd_config_idx=2,
+    )
+
+
+# T277224987: idx0 (EPILOGUE_SUBTILE=4) is shipped at SMEM_BUDGET=200000, which
+# keeps the early-TMA dk/dv/dq store-staging single-buffered. These regressions
+# force SMEM_BUDGET=220000 so Phase 4 double-buffers that staging (buffer.copy=2)
+# — the exact config that used to (1) corrupt dv/dk/dq (staging slot staggered by
+# the outer accumCnt instead of the subtile index) and then (2) OOR (Phase 3.6
+# marking an unrealizable swizzle-mismatched staging->operand reuse, undercounting
+# SMEM). The shipped configs pin 200000 so the autotuned matrix never exercises
+# this; these tests guard the underlying compiler fix directly.
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
+def test_bwd_early_tma_staging_depth2():
+    # Non-persistent ("ws"): correctness + fits SMEM at the depth-2 budget.
+    test_op(
+        Z=8,
+        H=16,
+        N_CTX=1024,
+        HEAD_DIM=128,
+        causal=False,
+        mode="bwd",
+        baseVariant="ws",
+        provider="triton-fp16",
+        SUBTILING=False,
+        VECT_MUL=0,
+        FADD2_REDUCE=False,
+        bwd_config_idx=0,
+        smem_budget=220000,
+    )
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
+def test_bwd_early_tma_staging_depth2_persistent():
+    # Persistent ("ws_persistent") variant of the T277224987 regression.
+    test_op(
+        Z=8,
+        H=16,
+        N_CTX=1024,
+        HEAD_DIM=128,
+        causal=False,
+        mode="bwd",
+        baseVariant="ws_persistent",
+        provider="triton-fp16",
+        SUBTILING=False,
+        VECT_MUL=0,
+        FADD2_REDUCE=False,
+        bwd_config_idx=0,
+        smem_budget=220000,
+    )
+
+
+try:
+    from flash_attn.flash_attn_interface import flash_attn_qkvpacked_func as flash_attn_func
+
+    HAS_FLASH = True
+except BaseException:
+    HAS_FLASH = False
+
+TORCH_HAS_FP8 = False
+BATCH, N_HEADS = 4, 48
+# vary seq length for fixed head and batch=4
+configs = []
+for HEAD_DIM in [128]:  # 64, 128]:
+    for baseVariant in ["ws_persistent"]:
+        for mode in ["bwd"]:
+            configs.append(
+                triton.testing.Benchmark(
+                    x_names=["N_CTX"],
+                    x_vals=[2**i for i in range(12, 13)],  # 0, 15)],
+                    line_arg="provider",
+                    line_vals=["triton-fp16"] + (["flash"] if HAS_FLASH else []),
+                    line_names=["Triton [FP16]"] + (["Flash-2"] if HAS_FLASH else []),
+                    styles=[("red", "-"), ("blue", "-"), ("green", "-")],
+                    ylabel="TFLOPS",
+                    plot_name=f"fused-attention-{baseVariant}-{mode}-batch{BATCH}-head{N_HEADS}-d{HEAD_DIM}",
+                    args={
+                        "H": N_HEADS,
+                        "BATCH": BATCH,
+                        "HEAD_DIM": HEAD_DIM,
+                        "mode": mode,
+                        "baseVariant": baseVariant,
+                    },
+                ))
+
+
+@triton.testing.perf_report(configs)
+def bench_flash_attention(BATCH, H, N_CTX, HEAD_DIM, mode, baseVariant, provider, device=DEVICE):
+    assert mode in ["fwd", "bwd"]
+    dtype = torch.float16
+    if "triton" in provider:
+        q = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        k = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        v = torch.randn((BATCH, H, N_CTX, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        if mode == "fwd" and "fp8" in provider:
+            q = q.to(torch.float8_e5m2)
+            k = k.to(torch.float8_e5m2)
+            v = v.permute(0, 1, 3, 2).contiguous()
+            v = v.permute(0, 1, 3, 2)
+            v = v.to(torch.float8_e5m2)
+        sm_scale = 1.3
+        SUBTILING = True
+        VECT_MUL = 1
+        FADD2_REDUCE = False
+        fn = lambda: attention(q, k, v, False, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE)
+        if mode == "bwd":
+            o = fn()
+            do = torch.randn_like(o)
+            fn = lambda: o.backward(do, retain_graph=True)
+        ms = triton.testing.do_bench(fn)
+
+    if provider == "flash":
+        qkv = torch.randn((BATCH, N_CTX, 3, H, HEAD_DIM), dtype=dtype, device=device, requires_grad=True)
+        fn = lambda: flash_attn_func(qkv)
+        if mode == "bwd":
+            o = fn()
+            do = torch.randn_like(o)
+            fn = lambda: o.backward(do, retain_graph=True)
+        ms = triton.testing.do_bench(fn)
+    flops_per_matmul = 2.0 * BATCH * H * N_CTX * N_CTX * HEAD_DIM
+    total_flops = 2 * flops_per_matmul
+    if mode == "bwd":
+        total_flops *= 2.5  # 2.0(bwd) + 0.5(recompute)
+    return total_flops * 1e-12 / (ms * 1e-3)
+
+
+if __name__ == "__main__":
+    if is_blackwell():
+        print("Running benchmarks...")
+        bench_flash_attention.run(print_data=True)
+    else:
+        print("Skipping benchmarks, no Blackwell GPU found.")

--- a/third_party/tlx/tutorials/fused_attention_ws_auto_tma_dp.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_auto_tma_dp.py
@@ -1,0 +1,1026 @@
+"""
+Fused Attention with Explicit Data Partitioning
+================================================
+
+This is a Triton implementation of the Flash Attention v2 algorithm with
+explicit (manual) data partitioning. The BLOCK_M dimension is split into two
+halves, each processed with its own q/acc pair while sharing K/V loads.
+
+Credits:
+- OpenAI kernel team
+- Tri Dao (https://tridao.me/publications/flash2/flash2.pdf)
+
+Extra Credits:
+- Original flash attention paper (https://arxiv.org/abs/2205.14135)
+- Rabe and Staats (https://arxiv.org/pdf/2112.05682v2.pdf)
+
+"""
+
+import os
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+FORCE_ON_DEVICE = os.getenv("FORCE_ON_DEVICE") == "1"
+WITH_MAXNREG = os.getenv("WITH_MAXNREG")
+
+
+def is_tile_enabled():
+    return os.getenv("ENABLE_TILE", "0") == "1"
+
+
+def is_hip():
+    return triton.runtime.driver.active.get_current_target().backend == "hip"
+
+
+def is_cuda():
+    target = triton.runtime.driver.active.get_current_target()
+    return getattr(target, "is_cuda_backend", lambda: target.backend == "cuda")()
+
+
+def supports_host_descriptor():
+    return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
+
+
+def is_blackwell():
+    return is_cuda() and torch.cuda.get_device_capability()[0] == 10
+
+
+def is_hopper():
+    return is_cuda() and torch.cuda.get_device_capability()[0] == 9
+
+
+def _supports_reg_auto_ws():
+    """Check if the current Triton version supports minRegAutoWS/maxRegAutoWS"""
+    try:
+        triton.Config({}, minRegAutoWS=24, maxRegAutoWS=152)
+        return True
+    except (TypeError, AttributeError):
+        return False
+
+
+HAS_REG_AUTO_WS = _supports_reg_auto_ws()
+
+
+def _supports_pingpong_auto_ws():
+    """Check if the current Triton version supports pingpongAutoWS"""
+    try:
+        triton.Config({}, pingpongAutoWS=True)
+        return True
+    except (TypeError, AttributeError):
+        return False
+
+
+HAS_PINGPONG_AUTO_WS = _supports_pingpong_auto_ws()
+
+
+@triton.jit
+def _mask_scalar(qk, col_limit_right, s, i):
+    col_lim_right_s = col_limit_right - s
+    col_lim_right_cur = max(col_lim_right_s, 0)
+    mask = -1 << col_lim_right_cur
+    mask_i_bit = (mask & (1 << i)) == 0
+    return tl.where(mask_i_bit, qk, -float("inf"))
+
+
+@triton.jit
+def _apply_causal_mask(qk, col_limit_right, BLOCK_N: tl.constexpr):
+    # Apply causal mask via a bitmask calculated for each block of 16 elements.
+    # This allows the efficient R2P (register to predicate) instruction to be used at the SASS level.
+    # Credit to Tri Dao,
+    # https://github.com/Dao-AILab/flash-attention/commit/bac1001e4f6caa09d70537495d6746a685a2fa78
+    #
+    # NOTE: We use map_elementwise here in order to generate an interleaved sequence of instructions
+    # that processes one element of qk at a time. This improves ptxas's resulting SASS.
+    offs_n = tl.arange(0, BLOCK_N)[None, :]
+    s = offs_n & ~0xF
+    i = offs_n & 0xF
+    return tl.map_elementwise(_mask_scalar, qk, col_limit_right, s, i)
+
+
+@triton.jit
+def _attn_fwd_subtile(
+    q,
+    k,
+    offs_m,
+    start_n,
+    start_m,
+    BLOCK_N,
+    BLOCK_M,
+    offs_n,
+    qk_scale,
+    l_i0,
+    l_i1,  # used when FADD2_REDUCE is true
+    m_i,
+    acc,
+    v,
+    dtype: tl.constexpr,
+    STAGE: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    SUBTILING_P: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+):
+    qk = tl.dot(q, k)
+    if STAGE == 3 and start_n >= start_m * BLOCK_M:
+        col_limit_right = (offs_m - start_n + 1)[:, None]
+        qk = _apply_causal_mask(qk, col_limit_right, BLOCK_N)
+
+    m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+    if VECT_MUL & 2:
+        qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
+    else:
+        qk = qk * qk_scale - m_ij[:, None]
+
+    PM: tl.constexpr = qk.shape[0]
+    PN: tl.constexpr = qk.shape[1]
+
+    if SUBTILING_P:
+        qk0, qk1 = qk.reshape([PM, 2, PN // 2]).permute(0, 2, 1).split()
+
+        p0 = tl.math.exp2(qk0)
+        p0_bf16 = p0.to(dtype)
+        p1 = tl.math.exp2(qk1)
+        p1_bf16 = p1.to(dtype)
+
+        p = tl.join(p0, p1).permute(0, 2, 1).reshape([PM, PN])
+    else:
+        p = tl.math.exp2(qk)
+
+    # -- compute correction factor
+    alpha = tl.math.exp2(m_i - m_ij)
+    if not FADD2_REDUCE:
+        l_ij = tl.sum(p, 1)
+
+    # -- update output accumulator --
+    BM: tl.constexpr = acc.shape[0]
+    BN: tl.constexpr = acc.shape[1]
+
+    if SUBTILING:
+        acc0, acc1 = acc.reshape([BM, 2, BN // 2]).permute(0, 2, 1).split()
+        if VECT_MUL & 1:
+            acc0 = _mul_f32x2(acc0, alpha[:, None])
+            acc1 = _mul_f32x2(acc1, alpha[:, None])
+        else:
+            acc0 = acc0 * alpha[:, None]
+            acc1 = acc1 * alpha[:, None]
+        acc = tl.join(acc0, acc1).permute(0, 2, 1).reshape([BM, BN])
+    else:
+        acc = acc * alpha[:, None]
+
+    # update m_i and l_i
+    # place this at the end of the loop to reduce register pressure
+    if FADD2_REDUCE:
+        p0, p1 = p.reshape([PM, 2, PN // 2]).permute(0, 2, 1).split()
+        l_ij0, l_ij1 = tl.reduce((p0, p1), axis=1, combine_fn=_reduce_fadd2)
+        l_i0 = l_i0 * alpha + l_ij0
+        l_i1 = l_i1 * alpha + l_ij1
+
+    # We can potentially move these to be before updating l_ij, so the dot
+    # is not blocked.
+    # prepare p and v for the dot
+    if not SUBTILING_P:
+        p_bf16 = p.to(dtype)
+    else:
+        p_bf16 = tl.join(p0_bf16, p1_bf16).permute(0, 2, 1).reshape([PM, PN])
+    # note that this non-transposed v for FP8 is only supported on Blackwell
+    acc = tl.dot(p_bf16, v, acc)
+    if not FADD2_REDUCE:
+        l_i0 = l_i0 * alpha + l_ij
+    m_i = m_ij
+
+    return l_i0, l_i1, m_i, acc
+
+
+@triton.jit
+def _attn_fwd_inner_oss_dp(
+    acc0,
+    acc1,
+    l_i0,
+    l_i0_1,
+    l_i1,
+    l_i1_1,
+    m_i0,
+    m_i1,
+    q0,
+    q1,  #
+    K,
+    V,  #
+    y_dim,
+    stride_m,
+    offset_y,
+    dtype: tl.constexpr,
+    start_m,
+    qk_scale,  #
+    BLOCK_M: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_N: tl.constexpr,  #
+    STAGE: tl.constexpr,
+    offs_m0: tl.constexpr,
+    offs_m1: tl.constexpr,  #
+    offs_n: tl.constexpr,  #
+    N_CTX: tl.constexpr,
+    warp_specialize: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    SUBTILING_P: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+):
+    # range of values handled by this stage
+    if STAGE == 1:
+        lo, hi = 0, N_CTX
+    else:
+        lo, hi = 0, (start_m + 1) * BLOCK_M
+
+    offsetkv_y = offset_y + lo
+
+    # loop over k, v and update accumulator
+    for start_n in tl.range(
+            lo,
+            hi,
+            BLOCK_N,
+            warp_specialize=warp_specialize,
+            merge_epilogue=True,
+            separate_epilogue_store=True,
+            disallow_acc_multi_buffer=True,
+    ):
+        start_n = tl.multiple_of(start_n, BLOCK_N)
+
+        offs_kv = offsetkv_y + tl.arange(0, BLOCK_N)
+        offs_dkv = tl.arange(0, HEAD_DIM)[None, :]
+        kv_mask = offs_kv[:, None] < y_dim
+        k = tl.load(K + offs_kv[:, None] * stride_m + offs_dkv, mask=kv_mask, other=0.0).T
+        v = tl.load(V + offs_kv[:, None] * stride_m + offs_dkv, mask=kv_mask, other=0.0)
+
+        l_i0, l_i0_1, m_i0, acc0 = _attn_fwd_subtile(
+            q0,
+            k,
+            offs_m0,
+            start_n,
+            start_m,
+            BLOCK_N,
+            BLOCK_M,
+            offs_n,
+            qk_scale,
+            l_i0,
+            l_i0_1,
+            m_i0,
+            acc0,
+            v,
+            dtype,
+            STAGE,
+            SUBTILING,
+            SUBTILING_P,
+            VECT_MUL,
+            FADD2_REDUCE,
+        )
+        l_i1, l_i1_1, m_i1, acc1 = _attn_fwd_subtile(
+            q1,
+            k,
+            offs_m1,
+            start_n,
+            start_m,
+            BLOCK_N,
+            BLOCK_M,
+            offs_n,
+            qk_scale,
+            l_i1,
+            l_i1_1,
+            m_i1,
+            acc1,
+            v,
+            dtype,
+            STAGE,
+            SUBTILING,
+            SUBTILING_P,
+            VECT_MUL,
+            FADD2_REDUCE,
+        )
+
+        offsetkv_y += BLOCK_N
+
+    return acc0, acc1, l_i0, l_i0_1, l_i1, l_i1_1, m_i0, m_i1
+
+
+def _host_descriptor_pre_hook(nargs):
+    BLOCK_M = nargs["BLOCK_M"]
+    BLOCK_N = nargs["BLOCK_N"]
+    HEAD_DIM = nargs["HEAD_DIM"]
+    # auto-TMA path passes raw tensors (Q/K/V/O), no host descriptor to pre-shape.
+    if "desc_q" not in nargs or not isinstance(nargs["desc_q"], TensorDescriptor):
+        return
+    nargs["desc_q"].block_shape = [BLOCK_M // 2, HEAD_DIM]  # due to data partitioning
+    if nargs["FP8_OUTPUT"]:
+        nargs["desc_v"].block_shape = [HEAD_DIM, BLOCK_N]
+    else:
+        nargs["desc_v"].block_shape = [BLOCK_N, HEAD_DIM]
+    nargs["desc_k"].block_shape = [BLOCK_N, HEAD_DIM]
+    nargs["desc_o"].block_shape = [BLOCK_M // 2, HEAD_DIM]
+
+
+if is_hip():
+    NUM_STAGES_OPTIONS = [1]
+elif supports_host_descriptor():
+    NUM_STAGES_OPTIONS = [3]
+else:
+    NUM_STAGES_OPTIONS = [3]
+
+if is_tile_enabled():
+
+    def make_tile_config(BM, BN, occ, subtile, subtile_p, vectmul, add2reduce):
+        config_kwargs = {
+            "BLOCK_M": BM,
+            "BLOCK_N": BN,
+            "occupancy": occ,
+            "SUBTILING": subtile,
+            "SUBTILING_P": subtile_p,
+            "VECT_MUL": vectmul,
+            "FADD2_REDUCE": add2reduce,
+        }
+        extra_kwargs = {"pre_hook": _host_descriptor_pre_hook}
+        return triton.Config(config_kwargs, **extra_kwargs)
+
+    configs = [
+        make_tile_config(BM, BN, occ, subtile, subtile_p, vectmul, add2reduce)
+        for BM in [256]
+        for BN in [64, 128]
+        for occ in [1, 2]
+        for subtile in [True]
+        for subtile_p in [False]
+        for vectmul in [0]
+        for add2reduce in [False]
+    ]
+else:
+
+    def make_standard_config(
+        BM,
+        BN,
+        s,
+        w,
+        subtile,
+        subtile_p,
+        vectmul,
+        add2reduce,
+        group_size_n,
+        maxreg,
+        pingpong,
+    ):
+        config_kwargs = {
+            "BLOCK_M": BM,
+            "BLOCK_N": BN,
+            "SUBTILING": subtile,
+            "SUBTILING_P": subtile_p,
+            "VECT_MUL": vectmul,
+            "FADD2_REDUCE": add2reduce,
+            "GROUP_SIZE_N": group_size_n,
+        }
+        extra_kwargs = {
+            "num_stages": s,
+            "num_warps": w,
+            "pre_hook": _host_descriptor_pre_hook,
+        }
+
+        if HAS_REG_AUTO_WS:
+            extra_kwargs["minRegAutoWS"] = 24
+            extra_kwargs["maxRegAutoWS"] = maxreg
+
+        if HAS_PINGPONG_AUTO_WS:
+            extra_kwargs["pingpongAutoWS"] = pingpong
+
+        return triton.Config(config_kwargs, **extra_kwargs)
+
+    configs = [
+        make_standard_config(
+            BM,
+            BN,
+            s,
+            w,
+            subtile,
+            subtile_p,
+            vectmul,
+            add2reduce,
+            group_size_n,
+            maxreg,
+            pingpong,
+        )
+        for BM in [256]
+        for BN in [64, 128]
+        for s in NUM_STAGES_OPTIONS
+        for w in [4]
+        for subtile in [True, False]
+        for subtile_p in [True, False]
+        for vectmul in [1]
+        for add2reduce in [False]
+        for group_size_n in [1]
+        for maxreg in [152, 192]
+        for pingpong in [True, False]
+    ]
+
+
+def keep(conf):
+    BLOCK_M = conf.kwargs["BLOCK_M"]
+    BLOCK_N = conf.kwargs["BLOCK_N"]
+    return not (is_cuda() and torch.cuda.get_device_capability()[0] == 9 and BLOCK_M * BLOCK_N < 128 * 128
+                and conf.num_warps == 8)
+
+
+def prune_invalid_configs(configs, named_args, **kwargs):
+    N_CTX = kwargs["N_CTX"]
+
+    # Filter out configs where BLOCK_M > N_CTX
+    return [conf for conf in configs if conf.kwargs.get("BLOCK_M", 0) <= N_CTX]
+
+
+def prune_persistent_configs(configs, named_args, **kwargs):
+    N_CTX = kwargs["N_CTX"]
+    # Filter out configs based on desired BLOCK_N
+    TARGET_BLOCK_N = 64 if N_CTX == 128 else 128
+    return [conf for conf in configs if conf.kwargs.get("BLOCK_N", 0) == TARGET_BLOCK_N]
+
+
+@triton.jit
+def _maybe_make_tensor_desc(desc_or_ptr, shape, strides, block_shape):
+    if isinstance(desc_or_ptr, tl.tensor_descriptor):
+        return desc_or_ptr
+    else:
+        return tl.make_tensor_descriptor(desc_or_ptr, shape, strides, block_shape)
+
+
+@triton.jit
+def _mul_f32x2(a, b):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 ra, rb, rc;
+            mov.b64 ra, { $2, $3 };
+            mov.b64 rb, { $4, $5 };
+            mul.f32x2 rc, ra, rb;
+            mov.b64 { $0, $1 }, rc;
+        }
+        """,
+        "=r,=r,r,r,r,r",
+        [a, b],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=2,
+    )
+
+
+@triton.jit
+def _fma_f32x2(a, b, c):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 ra, rb, rc, rd;
+            mov.b64 ra, { $2, $3 };
+            mov.b64 rb, { $4, $5 };
+            mov.b64 rc, { $6, $7 };
+            fma.rn.f32x2 rd, ra, rb, rc;
+            mov.b64 { $0, $1 }, rd;
+        }
+        """,
+        "=r,=r,r,r,r,r,r,r",
+        [a, b, c],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=2,
+    )
+
+
+@triton.jit
+def _reduce_fadd2(p0a, p1a, p0b, p1b):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 rc, ra, rb;
+            mov.b64 ra, { $2, $4 };
+            mov.b64 rb, { $3, $5 };
+            add.f32x2 rc, ra, rb;
+            mov.b64 { $0, $1 }, rc;
+        }
+        """,
+        "=r,=r,r,r,r,r",
+        [p0a, p0b, p1a, p1b],
+        dtype=[tl.float32, tl.float32],
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _attn_fwd_tma_dp(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    Q,
+    K,
+    V,
+    O,
+    y_dim,
+    stride_m,
+    pid,
+    off_hz,
+    N_CTX: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    STAGE: tl.constexpr,  #
+    warp_specialize: tl.constexpr,  #
+    dtype: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    SUBTILING_P: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+):
+    # tl.static_assert(BLOCK_N <= HEAD_DIM)
+    start_m = pid  # tl.program_id(0)
+    # off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    off_h = off_hz % H
+
+    offset_y = off_z * (N_CTX * H) + off_h * N_CTX
+    qo_offset_y = offset_y + start_m * BLOCK_M
+    # initialize offsets
+    offs_m0 = start_m * BLOCK_M + tl.arange(0, BLOCK_M // 2)
+    offs_m1 = start_m * BLOCK_M + tl.arange(BLOCK_M // 2, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+
+    m_i0 = tl.zeros([BLOCK_M // 2], dtype=tl.float32) - float("inf")
+    l_i0_0 = tl.zeros([BLOCK_M // 2], dtype=tl.float32) + 1.0
+    acc0 = tl.zeros([BLOCK_M // 2, HEAD_DIM], dtype=tl.float32)
+
+    m_i1 = tl.zeros([BLOCK_M // 2], dtype=tl.float32) - float("inf")
+    l_i1_0 = tl.zeros([BLOCK_M // 2], dtype=tl.float32) + 1.0
+    acc1 = tl.zeros([BLOCK_M // 2, HEAD_DIM], dtype=tl.float32)
+
+    qk_scale = sm_scale
+    qk_scale *= 1.44269504  # 1/log(2)
+
+    offs_q0 = qo_offset_y + tl.arange(0, BLOCK_M // 2)
+    offs_q1 = qo_offset_y + BLOCK_M // 2 + tl.arange(0, BLOCK_M // 2)
+    offs_dq = tl.arange(0, HEAD_DIM)[None, :]
+    q0 = tl.load(Q + offs_q0[:, None] * stride_m + offs_dq, mask=offs_q0[:, None] < y_dim, other=0.0)
+    q1 = tl.load(Q + offs_q1[:, None] * stride_m + offs_dq, mask=offs_q1[:, None] < y_dim, other=0.0)
+
+    if FADD2_REDUCE:
+        l_i0_1 = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
+        l_i1_1 = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
+    else:
+        l_i0_1 = 0
+        l_i1_1 = 0
+
+    # Merged causal: single loop covering below-diagonal and on-diagonal
+    acc0, acc1, l_i0_0, l_i0_1, l_i1_0, l_i1_1, m_i0, m_i1 = _attn_fwd_inner_oss_dp(
+        acc0,
+        acc1,
+        l_i0_0,
+        l_i0_1,
+        l_i1_0,
+        l_i1_1,
+        m_i0,
+        m_i1,
+        q0,
+        q1,  #
+        K,
+        V,  #
+        y_dim,
+        stride_m,  #
+        offset_y,
+        dtype,
+        start_m,
+        qk_scale,  #
+        BLOCK_M,
+        HEAD_DIM,
+        BLOCK_N,  #
+        STAGE,
+        offs_m0,
+        offs_m1,
+        offs_n,
+        N_CTX,  #
+        warp_specialize,
+        SUBTILING,
+        SUBTILING_P,
+        VECT_MUL,
+        FADD2_REDUCE,
+    )
+
+    if FADD2_REDUCE:
+        l_i0 = l_i0_0 + l_i0_1
+        l_i1 = l_i1_0 + l_i1_1
+    else:
+        l_i0 = l_i0_0
+        l_i1 = l_i1_0
+
+    m_i0 += tl.math.log2(l_i0)
+    acc0 = acc0 / l_i0[:, None]
+    m_ptrs0 = M + off_hz * N_CTX + offs_m0
+    tl.store(m_ptrs0, m_i0)
+    tl.store(O + offs_q0[:, None] * stride_m + offs_dq, acc0.to(dtype), mask=offs_q0[:, None] < y_dim)
+
+    m_i1 += tl.math.log2(l_i1)
+    acc1 = acc1 / l_i1[:, None]
+    m_ptrs1 = M + off_hz * N_CTX + offs_m1
+    tl.store(m_ptrs1, m_i1)
+    tl.store(O + offs_q1[:, None] * stride_m + offs_dq, acc1.to(dtype), mask=offs_q1[:, None] < y_dim)
+
+
+@triton.autotune(
+    configs=list(filter(keep, configs)),
+    key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT", "warp_specialize"],
+    prune_configs_by={"early_config_prune": prune_invalid_configs},
+)
+@triton.jit
+def _attn_fwd(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    Q,
+    K,
+    V,
+    O,
+    y_dim,
+    stride_m,
+    N_CTX: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    STAGE: tl.constexpr,  #
+    warp_specialize: tl.constexpr,  #
+    dtype: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    SUBTILING_P: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    _attn_fwd_tma_dp(
+        sm_scale,
+        M,
+        Z,
+        H,
+        Q,
+        K,
+        V,
+        O,
+        y_dim,
+        stride_m,
+        pid,
+        off_hz,
+        N_CTX,
+        HEAD_DIM,
+        BLOCK_M,
+        BLOCK_N,
+        FP8_OUTPUT,
+        STAGE,
+        warp_specialize,
+        dtype,
+        SUBTILING,
+        SUBTILING_P,
+        VECT_MUL,
+        FADD2_REDUCE,
+    )
+
+
+@triton.autotune(
+    configs=list(filter(keep, configs)),
+    key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT", "warp_specialize"],
+    prune_configs_by={"early_config_prune": prune_persistent_configs},
+)
+@triton.jit
+def _attn_fwd_persist(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    Q,
+    K,
+    V,
+    O,
+    y_dim,
+    stride_m,
+    N_CTX: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    FP8_OUTPUT: tl.constexpr,  #
+    STAGE: tl.constexpr,  #
+    warp_specialize: tl.constexpr,  #
+    OUTER_LOOP: tl.constexpr,
+    dtype: tl.constexpr,
+    SUBTILING: tl.constexpr,
+    SUBTILING_P: tl.constexpr,
+    VECT_MUL: tl.constexpr,
+    FADD2_REDUCE: tl.constexpr,
+    GROUP_SIZE_N: tl.constexpr,
+):
+    prog_id = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    num_pid_m = tl.cdiv(N_CTX, BLOCK_M)
+    num_pid_n = Z * H
+    num_pid_in_group = num_pid_m * GROUP_SIZE_N
+    total_tiles = num_pid_m * Z * H
+
+    tiles_per_sm = total_tiles // num_progs
+    if prog_id < total_tiles % num_progs:
+        tiles_per_sm += 1
+
+    tile_idx = prog_id
+
+    # inner loop warpspec vs. outer loop warpspec
+    for _ in tl.range(
+            0,
+            tiles_per_sm,
+            warp_specialize=warp_specialize and OUTER_LOOP,
+            merge_epilogue=True,
+            separate_epilogue_store=True,
+    ):
+        group_id = tile_idx // num_pid_in_group
+        first_pid_n = group_id * GROUP_SIZE_N
+        group_size_n = min(num_pid_n - first_pid_n, GROUP_SIZE_N)
+        off_hz = first_pid_n + (tile_idx % group_size_n)
+        pid = (tile_idx % num_pid_in_group) // group_size_n
+
+        _attn_fwd_tma_dp(
+            sm_scale,
+            M,
+            Z,
+            H,
+            Q,
+            K,
+            V,
+            O,
+            y_dim,
+            stride_m,
+            pid,
+            off_hz,
+            N_CTX,
+            HEAD_DIM,
+            BLOCK_M,
+            BLOCK_N,
+            FP8_OUTPUT,
+            STAGE,
+            warp_specialize and not OUTER_LOOP,
+            dtype,
+            SUBTILING,
+            SUBTILING_P,
+            VECT_MUL,
+            FADD2_REDUCE,
+        )
+        tile_idx += num_progs
+
+
+def torch_dtype_to_triton(dtype):
+    if dtype == torch.float8_e5m2:
+        return tl.float8e5
+    return getattr(tl, str(dtype).split(".")[1])
+
+
+class _attention_opt(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, q, k, v, causal, sm_scale, baseVariant):
+        # shape constraints
+        HEAD_DIM_Q, HEAD_DIM_K = q.shape[-1], k.shape[-1]
+        # when v is in float8_e5m2 it is transposed.
+        HEAD_DIM_V = v.shape[-1]
+        assert HEAD_DIM_Q == HEAD_DIM_K and HEAD_DIM_K == HEAD_DIM_V
+        assert HEAD_DIM_K in {16, 32, 64, 128, 256}
+        o = torch.empty_like(q)
+        stage = 3 if causal else 1
+        extra_kern_args = {}
+
+        M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+        warp_specialize = baseVariant == "ws" or baseVariant == "ws_persistent"
+        # auto-TMA: pass raw tensors; the pass builds device descriptors.
+        desc_q = q
+        desc_v = v
+        desc_k = k
+        desc_o = o
+        y_dim = q.shape[0] * q.shape[1] * q.shape[2]
+        stride_m = q.stride(2)
+
+        def alloc_fn(size: int, align: int, _):
+            return torch.empty(size, dtype=torch.int8, device="cuda")
+
+        triton.set_allocator(alloc_fn)
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+        def grid(META):
+            return (
+                triton.cdiv(q.shape[2], META["BLOCK_M"]),
+                q.shape[0] * q.shape[1],
+                1,
+            )
+
+        def grid_persist(META):
+            return (
+                min(
+                    NUM_SMS,
+                    triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1],
+                ),
+                1,
+                1,
+            )
+
+        ctx.grid = grid
+        persistent = baseVariant == "persistent" or baseVariant == "ws_persistent"
+        if WITH_MAXNREG and is_blackwell() and warp_specialize:
+            if HEAD_DIM_K == 128 and (q.dtype == torch.float16 or q.dtype == torch.bfloat16):
+                extra_kern_args["maxnreg"] = 128
+            else:
+                extra_kern_args["maxnreg"] = 80
+        with triton.knobs.nvidia.scope():
+            triton.knobs.nvidia.use_meta_ws = True
+            triton.knobs.nvidia.auto_tma = True
+            triton.knobs.nvidia.auto_tma_device = True
+
+            if persistent:
+                _attn_fwd_persist[grid_persist](
+                    sm_scale,
+                    M,  #
+                    q.shape[0],
+                    q.shape[1],  #
+                    desc_q,
+                    desc_k,
+                    desc_v,
+                    desc_o,
+                    y_dim,
+                    stride_m,  #
+                    N_CTX=q.shape[2],  #
+                    HEAD_DIM=HEAD_DIM_K,  #
+                    FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
+                    STAGE=stage,  #
+                    warp_specialize=warp_specialize,
+                    OUTER_LOOP=True,
+                    dtype=torch_dtype_to_triton(q.dtype),
+                    **extra_kern_args,
+                )
+            else:
+                _attn_fwd[grid](
+                    sm_scale,
+                    M,  #
+                    q.shape[0],
+                    q.shape[1],  #
+                    desc_q,
+                    desc_k,
+                    desc_v,
+                    desc_o,
+                    y_dim,
+                    stride_m,  #
+                    N_CTX=q.shape[2],  #
+                    HEAD_DIM=HEAD_DIM_K,  #
+                    FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
+                    STAGE=stage,  #
+                    warp_specialize=warp_specialize,
+                    dtype=torch_dtype_to_triton(q.dtype),
+                    **extra_kern_args,
+                )
+
+        ctx.save_for_backward(q, k, v, o, M)
+
+        ctx.sm_scale = sm_scale
+        ctx.HEAD_DIM = HEAD_DIM_K
+        ctx.causal = causal
+        return o
+
+
+def attention(q, k, v, causal, sm_scale, baseVariant="ws_persistent", config=None):
+    if config is None:
+        return _attention_opt.apply(q, k, v, causal, sm_scale, baseVariant)
+
+    # Non-autotuned path with explicit config
+    HEAD_DIM_K = q.shape[-1]
+    stage = 3 if causal else 1
+    o = torch.empty_like(q)
+    M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+    y_dim = q.shape[0] * q.shape[1] * q.shape[2]
+
+    # auto-TMA: raw tensors; device descriptors built by the pass.
+    desc_q, desc_k, desc_v, desc_o = q, k, v, o
+    stride_m = q.stride(2)
+
+    def alloc_fn(size: int, align: int, _):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+
+    persistent = baseVariant == "persistent" or baseVariant == "ws_persistent"
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.auto_tma = True
+        triton.knobs.nvidia.auto_tma_device = True
+
+        if persistent:
+            grid = (
+                min(
+                    NUM_SMS,
+                    triton.cdiv(q.shape[2], config["BLOCK_M"]) * q.shape[0] * q.shape[1],
+                ),
+                1,
+                1,
+            )
+            _attn_fwd_persist.fn[grid](
+                sm_scale,
+                M,
+                q.shape[0],
+                q.shape[1],
+                desc_q,
+                desc_k,
+                desc_v,
+                desc_o,
+                y_dim,
+                stride_m,
+                N_CTX=q.shape[2],
+                HEAD_DIM=HEAD_DIM_K,
+                FP8_OUTPUT=q.dtype == torch.float8_e5m2,
+                STAGE=stage,
+                warp_specialize=True,
+                OUTER_LOOP=True,
+                dtype=torch_dtype_to_triton(q.dtype),
+                num_stages=config.pop("num_stages", 3),
+                num_warps=config.pop("num_warps", 4),
+                **config,
+            )
+        else:
+            grid = (
+                triton.cdiv(q.shape[2], config["BLOCK_M"]),
+                q.shape[0] * q.shape[1],
+                1,
+            )
+            _attn_fwd.fn[grid](
+                sm_scale,
+                M,
+                q.shape[0],
+                q.shape[1],
+                desc_q,
+                desc_k,
+                desc_v,
+                desc_o,
+                y_dim,
+                stride_m,
+                N_CTX=q.shape[2],
+                HEAD_DIM=HEAD_DIM_K,
+                FP8_OUTPUT=q.dtype == torch.float8_e5m2,
+                STAGE=stage,
+                warp_specialize=True,
+                dtype=torch_dtype_to_triton(q.dtype),
+                num_stages=config.pop("num_stages", 3),
+                num_warps=config.pop("num_warps", 4),
+                **config,
+            )
+    return o
+
+
+def _bw_only():
+    import torch as _t
+    return _t.cuda.is_available() and _t.cuda.get_device_capability()[0] >= 9
+
+
+@pytest.mark.parametrize("baseVariant",
+                         ["ws"])  # ws_persistent: pre-existing GROUP_SIZE_N issue in this untested tutorial
+@pytest.mark.parametrize("HEAD_DIM", [64, 128])
+def test_op(HEAD_DIM, baseVariant):
+    if not _bw_only():
+        pytest.skip("sm90+ only")
+    Z, H, N_CTX = 2, 8, 1024
+    sm_scale = 0.5
+    torch.manual_seed(0)
+    q = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=torch.float16, device="cuda")
+    k = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=torch.float16, device="cuda")
+    v = torch.randn((Z, H, N_CTX, HEAD_DIM), dtype=torch.float16, device="cuda")
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, scale=sm_scale, is_causal=False)
+    cfg = {
+        "BLOCK_M": 256, "BLOCK_N": 128, "SUBTILING": True, "SUBTILING_P": False, "VECT_MUL": 0, "FADD2_REDUCE": False,
+        "num_stages": 2, "num_warps": 4
+    }
+    tri = attention(q, k, v, False, sm_scale, baseVariant, config=dict(cfg)).half()
+    torch.testing.assert_close(tri, ref, atol=1e-2, rtol=0)
+
+
+def test_bench():
+    if not _bw_only():
+        pytest.skip("sm90+ only")
+    Z, H, N, D = 4, 32, 4096, 128
+    q = torch.randn((Z, H, N, D), dtype=torch.float16, device="cuda")
+    k = torch.randn((Z, H, N, D), dtype=torch.float16, device="cuda")
+    v = torch.randn((Z, H, N, D), dtype=torch.float16, device="cuda")
+    flops = 4.0 * Z * H * N * N * D
+    cfg = {
+        "BLOCK_M": 256, "BLOCK_N": 128, "SUBTILING": True, "SUBTILING_P": False, "VECT_MUL": 0, "FADD2_REDUCE": False,
+        "num_stages": 2, "num_warps": 4
+    }
+    ms_a = triton.testing.do_bench(lambda: attention(q, k, v, False, 0.5, "ws", config=dict(cfg)))
+    print(f"\n[auto-tma-dp  ws] {ms_a:.4f} ms  {flops * 1e-12 / (ms_a * 1e-3):.1f} TFLOP/s\n")


### PR DESCRIPTION
Summary:

Applies the device auto-TMA mode (D110948916, 5/6) to a real, fully-tuned Flash
Attention forward, plus a B200 test target.

What changes:
- `hg cp` of the hand-written
  `third_party/tlx/tutorials/fused_attention_ws_device_tma.py` to
  `fused_attention_ws_auto_tma.py`. The copy is kept as the baseline; only the
  FORWARD is modified.
- The forward drops the explicit `tt.make_tensor_descriptor` +
  `desc.load`/`desc.store` and uses plain `tl.load`/`tl.store`: the raw Q/K/V/O
  pointers are passed directly with the full-tensor extent (`y_dim = Z*H*N_CTX`)
  and row stride threaded down, so PromoteLoadToTMA can recover each tile shape
  and promote the loads.
- The forward turns on device auto-TMA via `knobs.nvidia.auto_tma_device` inside
  its meta-WS scope.
- All tuning is preserved: SUBTILING / VECT_MUL / FADD2_REDUCE / autotune / dp=2 /
  meta warp-specialization.
- Adds B200 test target `py_auto_tma_fa_blackwell_test`, mirroring the existing
  `py_autows_fa_compiler_dp_blackwell_test`.

Result (B200, Z=4 H=32 N_CTX=4096 HEAD_DIM=128, fp16):
- Numerics match torch SDPA.
- Shared memory byte-for-byte identical to the hand-written baseline
  (ttg.shared = 231720, identical allocation offsets).
- Perf at parity: ws ~831 (hand) vs ~856 (auto); ws_persistent ~812 vs ~843.

Differential Revision: D110948914
