### PR TITLE
[TLX] blackwell_gemm_ws: async tcgen05_commit epilogue signal to close the inter-tile MMA bubble (#2008)

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -923,14 +923,17 @@ def _process_tile_mma_inner(
 
         smem_accum_cnt += 1
 
-    # Wait for last MMA to complete and signal epilogue for all subtiles
-    last_buf, last_phase = get_bufidx_phase(smem_accum_cnt - 1, NUM_SMEM_BUFFERS)
+    # Signal the epilogue when the MMAs complete via an async tcgen05 commit,
+    # instead of blocking on the last MMA's A_smem_empty and then arriving on
+    # tmem_full. The commit makes tmem_full track completion of the prior
+    # tcgen05 MMAs asynchronously, so the MMA warpgroup can return and start
+    # the next tile's MMAs while this tile's final MMAs still drain -- closing
+    # the per-tile pipeline bubble between consecutive K-loops. In 2-CTA mode
+    # the commit multicasts the mbarrier signal to both CTAs' tmem_full (one
+    # arrive each), matching the previous local + remote_cta_rank arrives.
     for group_id in tl.static_range(NUM_MMA_GROUPS):
-        a_buf = group_id * NUM_SMEM_BUFFERS + last_buf
-        tlx.barrier_wait(A_smem_empty_bars[a_buf], last_phase)
         acc_buf = group_id * NUM_TMEM_BUFFERS + cur_tmem_buf
-        # Done filling this buffer, signal epilogue consumer
-        tlx.barrier_arrive(tmem_full_bars[acc_buf], 1)
+        tlx.tcgen05_commit(tmem_full_bars[acc_buf], two_ctas=NUM_CTAS == 2)
 
     return smem_accum_cnt
 
@@ -1174,13 +1177,12 @@ def matmul_kernel_tma_ws_blackwell(
     A_smem_full_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS * NUM_MMA_GROUPS, arrive_count=1)
     A_smem_empty_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS * NUM_MMA_GROUPS, arrive_count=1)
     B_smem_full_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS, arrive_count=1)
+    tmem_full_bars = tlx.alloc_barriers(num_barriers=NUM_TMEM_BUFFERS * NUM_MMA_GROUPS, arrive_count=1)
     # NUM_TMEM_BUFFERS (overlaps MMA and epilogue)
     if USE_WARP_BARRIER:
-        tmem_full_bars = tlx.alloc_warp_barrier(num_barriers=NUM_TMEM_BUFFERS * NUM_MMA_GROUPS, num_warps=1)
         tmem_empty_bars = tlx.alloc_warp_barrier(num_barriers=NUM_TMEM_BUFFERS * NUM_MMA_GROUPS, num_warps=4,
                                                  num_arrivals=EPILOGUE_SUBTILE)
     else:
-        tmem_full_bars = tlx.alloc_barriers(num_barriers=NUM_TMEM_BUFFERS * NUM_MMA_GROUPS, arrive_count=1)
         tmem_empty_bars = tlx.alloc_barriers(num_barriers=NUM_TMEM_BUFFERS * NUM_MMA_GROUPS,
                                              arrive_count=EPILOGUE_SUBTILE)
 


### PR DESCRIPTION
Summary:

At each tile's K-loop tail the MMA warpgroup blocked on `barrier_wait(A_smem_empty[last])` (waiting for the final MMA to drain) before arriving on `tmem_full` to release the epilogue. That drain sits BETWEEN consecutive tiles' K-loops: the tcgen05 pipeline emptied at every tile boundary and only refilled once the next tile's peeled first MMA issued — even though the next tile writes a different (rotated) TMEM accumulator and does not depend on the previous tile completing.

Replace the blocking wait + manual `barrier_arrive(tmem_full)` (local + `remote_cta_rank`) with a single `tlx.tcgen05_commit(tmem_full_bars[acc_buf], two_ctas=NUM_CTAS==2)`. The commit makes `tmem_full` track completion of the prior tcgen05 MMAs asynchronously, so the MMA warpgroup returns and starts the next tile's MMAs while this tile's final MMAs still drain. In 2-CTA mode it lowers to `tcgen05.commit...multicast::cluster`, broadcasting the arrive to both CTAs' `tmem_full` (one arrive each) — equivalent to the previous local + remote arrives.

This requires `tmem_full_bars` to be a real SMEM mbarrier: the commit signals it via a hardware `mbarrier.arrive`, which does not land on a warp barrier. So under `USE_WARP_BARRIER` allocate `tmem_full_bars` with `alloc_barriers` (not `alloc_warp_barrier`); `tmem_empty_bars` stays a warp barrier (pure software arrive/wait). The warp-barrier form deadlocks because the async commit's arrive never reaches it.

ncu findings (clean, denoise.sh + ncu_rep, GPU idle, M/N/K=1024/12800/1152, vs aten/nvjet 51.84us):
- Duration 55.81 -> 54.56us (~2.2%)
- Warp cycles per issued instruction 26.79 -> 24.53; long-scoreboard (MMA-data wait) stall 13.97 -> 11.88 cyc/inst -- the MMA starts the next tile sooner, so it waits less. Compute(SM) throughput 56.6% -> 57.9% (aten 62.7%).
- Root-cause context: the kernel is TMEM-pipe / latency bound, not tensor-core-math bound (TMEM pipe is the highest-utilized ~56-58%; tensor-core HMMA subpipe only ~15% active). The top stall PC is the epilogue waiting on `tmem_full` for the MMA; the remaining ~5.2% is still MMA tcgen05 / 2-CTA per-K cadence bound.

Before:
 {F1992318648} 

After:
 {F1992318642} 

The bubble between two K-loop runs are gone.

Reviewed By: shunting314

Differential Revision: D111816095


