### PR TITLE
[CI] Checkout linked TritonBench PR when meta-triton PR references it

### DIFF
--- a/.ci/tritonbench/checkout.sh
+++ b/.ci/tritonbench/checkout.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Optionally check out a TritonBench PR referenced from a meta-triton PR body.
+#
+# Usage:
+#   checkout.sh <pr-body-file> [--ref-only]
+#
+# The PR body is scanned for a line of the form:
+#   X-link: https://github.com/meta-pytorch/tritonbench/pull/<PR-NUMBER>
+#
+# When such a link is found:
+#   * The corresponding PR number and git ref are written to GITHUB_OUTPUT
+#     (pr_number / ref) so an actions/checkout step can consume `ref`.
+#   * Unless --ref-only is given, TritonBench is cloned into the `tritonbench/`
+#     subdirectory at that PR and TRITONBENCH_ROOT is exported via GITHUB_ENV
+#     for subsequent steps.
+#
+# When no link is found the script is a no-op (exit 0), leaving callers to fall
+# back to their default TRITONBENCH_ROOT.
+set -euo pipefail
+
+PR_BODY_FILE="${1:-}"
+REF_ONLY=0
+if [ "${2:-}" = "--ref-only" ]; then
+  REF_ONLY=1
+fi
+
+if [ -z "${PR_BODY_FILE}" ] || [ ! -f "${PR_BODY_FILE}" ]; then
+  echo "Usage: $0 <pr-body-file> [--ref-only]" >&2
+  exit 1
+fi
+
+# Match: X-link: https://github.com/meta-pytorch/tritonbench/pull/<PR-NUMBER>
+PR_NUMBER=$(grep -Eo \
+  'X-link:[[:space:]]*https://github\.com/meta-pytorch/tritonbench/pull/[0-9]+' \
+  "${PR_BODY_FILE}" | grep -Eo '[0-9]+$' | head -n 1 || true)
+
+if [ -z "${PR_NUMBER}" ]; then
+  echo "No TritonBench X-link found in PR body; keeping default TRITONBENCH_ROOT."
+  exit 0
+fi
+
+TRITONBENCH_REF="refs/pull/${PR_NUMBER}/head"
+echo "Found TritonBench PR #${PR_NUMBER} (ref: ${TRITONBENCH_REF})."
+
+# Expose the PR number and ref for actions/checkout-based consumers.
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "pr_number=${PR_NUMBER}"
+    echo "ref=${TRITONBENCH_REF}"
+  } >> "${GITHUB_OUTPUT}"
+fi
+
+if [ "${REF_ONLY}" -eq 1 ]; then
+  exit 0
+fi
+
+TRITONBENCH_DIR="${GITHUB_WORKSPACE:-$(pwd)}/tritonbench"
+echo "Cloning TritonBench PR #${PR_NUMBER} into ${TRITONBENCH_DIR}"
+rm -rf "${TRITONBENCH_DIR}"
+git clone https://github.com/meta-pytorch/tritonbench.git "${TRITONBENCH_DIR}"
+git -C "${TRITONBENCH_DIR}" fetch origin "${TRITONBENCH_REF}:pr-${PR_NUMBER}"
+git -C "${TRITONBENCH_DIR}" checkout "pr-${PR_NUMBER}"
+git -C "${TRITONBENCH_DIR}" submodule update --init --recursive
+
+# Export for subsequent workflow steps.
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "TRITONBENCH_ROOT=${TRITONBENCH_DIR}" >> "${GITHUB_ENV}"
+fi
+echo "TRITONBENCH_ROOT set to ${TRITONBENCH_DIR}"

--- a/.github/workflows/b200.yml
+++ b/.github/workflows/b200.yml
@@ -49,13 +49,23 @@ jobs:
               export TRITONBENCH_TRITON_INSTALL_DIR="${TRITONBENCH_INSTALL_DIR}"
           fi
           EOF
+      - name: Checkout TritonBench (Optional)
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          PR_BODY_FILE="$(mktemp)"
+          printf '%s' "${PR_BODY}" > "${PR_BODY_FILE}"
+          bash ./.ci/tritonbench/checkout.sh "${PR_BODY_FILE}"
       - name: Run TritonBench tests on B200 GPU
         id: tritonbench
         env:
           TRITONBENCH_TEST_SKIP_FILE: ${{ github.workspace }}/.ci/tritonbench/fbtriton_skip_tests.yaml
-          TRITONBENCH_ROOT: /workspace/tritonbench
         run: |
           . "${SETUP_SCRIPT}"
+          # Use the TritonBench checked out for a linked PR if present, else the
+          # pre-provisioned copy on the runner.
+          export TRITONBENCH_ROOT="${TRITONBENCH_ROOT:-/workspace/tritonbench}"
           bash ./.ci/tritonbench/test-gpu.sh
       - name: Collect nightly failure (TritonBench)
         id: collect

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -49,13 +49,23 @@ jobs:
               export TRITONBENCH_TRITON_INSTALL_DIR="${TRITONBENCH_INSTALL_DIR}"
           fi
           EOF
+      - name: Checkout TritonBench (Optional)
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          PR_BODY_FILE="$(mktemp)"
+          printf '%s' "${PR_BODY}" > "${PR_BODY_FILE}"
+          bash ./.ci/tritonbench/checkout.sh "${PR_BODY_FILE}"
       - name: Run TritonBench tests on H100 GPU
         id: tritonbench
         env:
           TRITONBENCH_TEST_SKIP_FILE: ${{ github.workspace }}/.ci/tritonbench/fbtriton_skip_tests.yaml
-          TRITONBENCH_ROOT: /workspace/tritonbench
         run: |
           . "${SETUP_SCRIPT}"
+          # Use the TritonBench checked out for a linked PR if present, else the
+          # pre-provisioned copy on the runner.
+          export TRITONBENCH_ROOT="${TRITONBENCH_ROOT:-/workspace/tritonbench}"
           bash ./.ci/tritonbench/test-gpu.sh
       - name: Collect nightly failure (TritonBench)
         id: collect

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -30,11 +30,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Checkout TritonBench (Optional)
+        id: tritonbench_pr
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          PR_BODY_FILE="$(mktemp)"
+          printf '%s' "${PR_BODY}" > "${PR_BODY_FILE}"
+          bash ./.ci/tritonbench/checkout.sh "${PR_BODY_FILE}" --ref-only
       - name: Checkout Tritonbench
         uses: actions/checkout@v3
         with:
           repository: meta-pytorch/tritonbench
           path: tritonbench
+          ref: ${{ steps.tritonbench_pr.outputs.ref }}
           submodules: recursive
       - name: Setup Tritonbench environment
         working-directory: tritonbench


### PR DESCRIPTION
Add .ci/tritonbench/checkout.sh, which scans a PR body for an "X-link: https://github.com/meta-pytorch/tritonbench/pull/<N>" reference and, when found, checks out that TritonBench PR and points TRITONBENCH_ROOT at it.

Review order: start with checkout.sh (the shared parsing/checkout logic), then the h100/b200 workflows (which run the script to clone into tritonbench/ and set TRITONBENCH_ROOT via GITHUB_ENV, falling back to /workspace/tritonbench), then mi350 (which runs the script in --ref-only mode to drive the ref of its existing actions/checkout step). All new checkout behavior is gated to pull_request events.

Authored with Claude.