### PR TITLE
[AutoWS][HSTU] Coalesce chained MMAv5 accumulators in OptimizeAccumulatorInit

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
@@ -209,6 +209,118 @@ findZeroInitOp(Value accUse, scf::ForOp forOp, bool &loopArgIsZero) {
   return std::nullopt;
 }
 
+// Coalesce two chained accumulating MMAv5 ops that target one logical
+// accumulator into a single in-place accumulation. The pattern matches the
+// SECOND accumulator's TMEM tile (`t2`), whose init value is (through
+// single-use, layout-preserving ops) the TMEM read-out of the FIRST MMA's tile
+// (`t1`). It repoints the second MMA (and its read-out) at `t1` and deletes the
+// intermediate tile + read-out, so both MMAs accumulate into one TMEM tile.
+//
+// This is the shape produced when a kernel chains two accumulating dots into
+// the same value, e.g. `dk = tl.dot(a0, b0, dk); dk = tl.dot(a1, b1, dk)`:
+// AccelerateMatmul lowers each dot into its own `tmem_alloc + mma + tmem_load`,
+// threading the accumulator through registers. Left alone, HoistTMEMAlloc turns
+// that register hand-off into a TMEM<->TMEM load/store bridge across two
+// persistent tiles, which later blocks TMEM slot reuse (the WSCodePartition
+// reuse-order check aborts on the two co-live tiles sharing one buffer.id).
+class ChainAccumulatorInPlace
+    : public OpRewritePattern<triton::nvidia_gpu::TMEMAllocOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(triton::nvidia_gpu::TMEMAllocOp t2,
+                                PatternRewriter &rewriter) const override {
+    Value init2 = t2.getSrc();
+    if (!init2)
+      return failure();
+
+    // t2's memdesc is used by exactly one accumulator-writing MMAv5 (mma2) and
+    // at most one tmem_load (load2).
+    triton::nvidia_gpu::MMAv5OpInterface mma2 = nullptr;
+    triton::nvidia_gpu::TMEMLoadOp load2 = nullptr;
+    for (Operation *u : t2.getResult().getUsers()) {
+      if (auto m = dyn_cast<triton::nvidia_gpu::MMAv5OpInterface>(u)) {
+        if (mma2)
+          return failure();
+        mma2 = m;
+      } else if (auto l = dyn_cast<triton::nvidia_gpu::TMEMLoadOp>(u)) {
+        if (load2)
+          return failure();
+        load2 = l;
+      } else {
+        return failure();
+      }
+    }
+    if (!mma2 || mma2.getAccumulator() != t2.getResult() ||
+        mma2->getParentRegion() != t2->getParentRegion())
+      return failure();
+    // mma2 must accumulate onto its (chained) init with a constant-true flag;
+    // fusing a use_acc=false MMA would drop the first MMA's contribution.
+    auto useAcc2 = getBoolFromConstant(mma2.useAccumulator());
+    if (!useAcc2 || *useAcc2 == false)
+      return failure();
+
+    // Walk init2 back through single-use, data-preserving ops to a tmem_load.
+    SmallVector<Operation *> chain;
+    Value v = init2;
+    while (Operation *d = v.getDefiningOp()) {
+      if (isa<triton::nvidia_gpu::TMEMLoadOp>(d))
+        break;
+      if (!v.hasOneUse() || !isa<ConvertLayoutOp, ReshapeOp, TransOp,
+                                 BroadcastOp, ExpandDimsOp, SplitOp>(d))
+        return failure();
+      chain.push_back(d);
+      v = d->getOperand(0);
+    }
+    auto load1 = v.getDefiningOp<triton::nvidia_gpu::TMEMLoadOp>();
+    // load1's read-out must feed only this chain, and be a plain
+    // (non-reduction) load whose tensor result is what we traced.
+    if (!load1 || !v.hasOneUse() || load1.getRed() || load1.getResult() != v)
+      return failure();
+
+    // load1 reads t1 (the first MMA's tile), written by mma1 before mma2 in the
+    // same region; t1 and t2 must be the same TMEM tile type.
+    Value t1 = load1.getSrc();
+    Value dep = load1.getDep();
+    if (!dep)
+      return failure();
+    auto mma1 = dep.getDefiningOp<triton::nvidia_gpu::MMAv5OpInterface>();
+    if (!mma1 || mma1.getAccumulator() != t1 ||
+        mma1->getParentRegion() != mma2->getParentRegion() ||
+        !mma1->isBeforeInBlock(mma2))
+      return failure();
+    if (t1.getType() != t2.getResult().getType())
+      return failure();
+    // t1's only accesses may be mma1 (write) and load1 (read); an intervening
+    // access would make accumulating mma2 in place after mma1 unsafe.
+    for (Operation *u : t1.getUsers())
+      if (u != mma1.getOperation() && u != load1.getOperation())
+        return failure();
+
+    // Rewrite: mma2 accumulates into t1 in place (reading mma1's result via
+    // mma1's completion token); load2 reads t1.
+    Value mma1Token = mma1.getToken();
+    rewriter.modifyOpInPlace(mma2, [&]() {
+      mma2.setAccumulator(t1);
+      mma2.getAccDepMutable().assign(mma1Token);
+    });
+    if (load2)
+      rewriter.modifyOpInPlace(load2,
+                               [&]() { load2.getSrcMutable().assign(t1); });
+    // Any consumer of load1's read token is re-anchored on mma1's write token.
+    if (Value readTok = load1.getToken())
+      rewriter.replaceAllUsesWith(readTok, mma1Token);
+
+    // The intermediate tile, the layout-preserving chain, and the read-out are
+    // now dead; erase from the t2 end back to load1 so uses drop first.
+    rewriter.eraseOp(t2);
+    for (Operation *op : chain)
+      rewriter.eraseOp(op);
+    rewriter.eraseOp(load1);
+    return success();
+  }
+};
+
 } // namespace
 
 class OptimizeAccumulatorInitPass
@@ -338,7 +450,8 @@ public:
 
     // Cleanup unused init values in tmem allocs
     mlir::RewritePatternSet patterns(m.getContext());
-    patterns.add<TMEMAllocWithUnusedInit>(m.getContext());
+    patterns.add<TMEMAllocWithUnusedInit, ChainAccumulatorInPlace>(
+        m.getContext());
     if (applyPatternsGreedily(m, std::move(patterns)).failed())
       signalPassFailure();
   }

--- a/test/TritonGPU/accumulator-init-chain-fuse.mlir
+++ b/test/TritonGPU/accumulator-init-chain-fuse.mlir
@@ -1,0 +1,55 @@
+// RUN: triton-opt %s -tritongpu-optimize-accumulator-init | FileCheck %s
+
+// Two chained accumulating MMAv5 dots into one logical accumulator (the HSTU
+// reduce_dq "compute fold" shape: dk = dot(a0,b0,dk); dk = dot(a1,b1,dk)).
+// AccelerateMatmul lowers each dot into its own tmem_alloc + tc_gen5_mma +
+// tmem_load, threading the accumulator through registers, so dot2's TMEM tile is
+// initialized from dot1's TMEM read-out. ChainAccumulatorInPlace must coalesce
+// them into a single in-place accumulation on ONE TMEM tile (no intermediate
+// tile / read-out bridge), matching the TLX single-dk_tiles shape. Left alone,
+// the two tiles become a TMEM<->TMEM load/store bridge that blocks TMEM slot
+// reuse downstream (the WSCodePartition reuse-order check aborts).
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// CHECK-LABEL: @chain_accumulator_in_place
+// One accumulator tile; both MMAs accumulate into it; the second reads the
+// first's completion token in place; a single read-out; no bridge tile/load.
+// CHECK:       scf.for
+// CHECK:         %[[ACC:.*]], %[[TK0:.*]] = ttng.tmem_alloc %arg
+// CHECK:         %[[TK1:.*]] = ttng.tc_gen5_mma {{.*}} %[[ACC]][%[[TK0]]]
+// CHECK-NOT:     ttng.tmem_alloc
+// CHECK-NOT:     ttng.tmem_load
+// CHECK:         %[[TK2:.*]] = ttng.tc_gen5_mma {{.*}} %[[ACC]][%[[TK1]]], %true
+// CHECK:         ttng.tmem_load %[[ACC]][%[[TK2]]]
+tt.func public @chain_accumulator_in_place(
+    %a0: !ttg.memdesc<128x64xf16, #shared, #smem>,
+    %b0: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+    %a1: !ttg.memdesc<128x64xf16, #shared, #smem>,
+    %b1: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+    %n: i32) {
+  %true = arith.constant true
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+  %r = scf.for %i = %c0 to %n step %c1 iter_args(%acc = %cst) -> (tensor<128x128xf32, #blocked>) : i32 {
+    // dot1 tile
+    %t1, %tok1 = ttng.tmem_alloc %acc : (tensor<128x128xf32, #blocked>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %m1 = ttng.tc_gen5_mma %a0, %b0, %t1[%tok1], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %v1, %ld1 = ttng.tmem_load %t1[%m1] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    // dot2 tile, initialized from dot1's read-out
+    %t2, %tok2 = ttng.tmem_alloc %v1 : (tensor<128x128xf32, #blocked>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %m2 = ttng.tc_gen5_mma %a1, %b1, %t2[%tok2], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %v2, %ld2 = ttng.tmem_load %t2[%m2] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    scf.yield %v2 : tensor<128x128xf32, #blocked>
+  }
+  tt.return
+}
+
+}

--- a/third_party/tlx/tutorials/hstu_cross_attn/bench_bwd.py
+++ b/third_party/tlx/tutorials/hstu_cross_attn/bench_bwd.py
@@ -41,9 +41,12 @@ VARIANTS = [
     ("autows", xa.BwdVariant.TRITON_AUTOWS, "1"),
     ("tlx", xa.BwdVariant.TLX, "0"),
     ("tlx_2kv", xa.BwdVariant.TLX_2KV, "0"),
+    # Manual 2-KV data-partition + compute-fold + shared-KV. WS dispatch ("1");
+    # under TRITON_USE_LIST_SCHEDULE=1 its inner loop's schedule is autotuned.
+    ("autows_2kv", xa.BwdVariant.TRITON_AUTOWS_2KV, "1"),
 ]
 # Variants that require shared-KV (V aliases K); only run under --shared-kv.
-SHARED_KV_ONLY = {"tlx_2kv"}
+SHARED_KV_ONLY = {"tlx_2kv", "autows_2kv"}
 
 
 def force(ns=2, bm=BLOCK, bn=BLOCK):
@@ -61,6 +64,22 @@ def force(ns=2, bm=BLOCK, bn=BLOCK):
     c.kwargs["BLOCK_M"] = bm
     c.kwargs["BLOCK_N"] = bn
     xa._hstu_attn_bwd_redq.configs = [c]
+    if hasattr(xa, "_hstu_attn_bwd_redq_2kv"):
+        # Pin block sizes / stages but KEEP the per-INNER_PICK variants so the
+        # autotuner still sweeps the inner-loop list schedule (one config per
+        # distinct INNER_PICK). With list scheduling off there is only
+        # INNER_PICK=0, so this collapses to a single config as before.
+        kept, seen = [], set()
+        for c2 in xa._hstu_attn_bwd_redq_2kv.configs:
+            c2.num_stages = ns
+            c2.kwargs["BLOCK_M"] = bm
+            c2.kwargs["BLOCK_N"] = bn
+            pk = c2.kwargs.get("INNER_PICK", 0)
+            if pk in seen:
+                continue
+            seen.add(pk)
+            kept.append(c2)
+        xa._hstu_attn_bwd_redq_2kv.configs = kept
     xa.set_fwd_variant(xa.FwdVariant.TRITON)
 
 

--- a/third_party/tlx/tutorials/hstu_cross_attn/triton_bw_cross_attention.py
+++ b/third_party/tlx/tutorials/hstu_cross_attn/triton_bw_cross_attention.py
@@ -1,6 +1,7 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 # pyre-unsafe
+
 """
 Cross-attention kernels with optional TMA (Tensor Memory Accelerator) support.
 
@@ -63,7 +64,6 @@ HAS_TENSOR_DESCRIPTOR = hasattr(tl, "make_tensor_descriptor")
 # triton.Config kwarg. Supports .get(key) like a dict but is hashable for Triton's
 # JIT cache key. Mirrors the pattern in fused_attention_ws_device_tma.py.
 class FrozenDotAttrs:
-
     def __init__(self, d):
         import json as _json
 
@@ -95,13 +95,16 @@ class FrozenDotAttrs:
 #
 # DEFAULT: the schedule this kernel shipped with (FA-derived; dq^T on its own
 # single-copy TMEM buffer id 11, dP on id 5).
-_HSTU_BWD_DOT_ATTRS_DEFAULT = FrozenDotAttrs({
-    "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]},
-    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
-    "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,5"]},
-    "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]},
-    "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,8", "opndD,tmem,1,11"]},
-})
+_HSTU_BWD_DOT_ATTRS_DEFAULT = FrozenDotAttrs(
+    {
+        "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]},
+        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
+        "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,5"]},
+        "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]},
+        "dk_shared": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,7"]},
+        "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,8", "opndD,tmem,1,11"]},
+    }
+)
 
 # TLX-aligned: mirror the hand-written TLX kernel (attn_bwd_ws) TMEM buffer scheme.
 # TLX reuses the dP tile in dq's TMEM slot (`dp_tiles reuse=dq_tiles`): dP is fully
@@ -110,13 +113,36 @@ _HSTU_BWD_DOT_ATTRS_DEFAULT = FrozenDotAttrs({
 # (the larger 128x64 tile, which subsumes dP's 64x64) instead of a separate id 5.
 # Stages/order match DEFAULT (== TLX: qkT/dpT/dv "current", dq/dk one iteration
 # behind). Everything single-copy, as in TLX (NUM_BUFFERS_TMEM=1).
-_HSTU_BWD_DOT_ATTRS_TLX = FrozenDotAttrs({
-    "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]},
-    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
-    "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,11"]},
-    "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]},
-    "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,8", "opndD,tmem,1,11"]},
-})
+_HSTU_BWD_DOT_ATTRS_TLX = FrozenDotAttrs(
+    {
+        "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]},
+        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
+        "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,11"]},
+        "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]},
+        "dk_shared": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,7"]},
+        "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,8", "opndD,tmem,1,11"]},
+    }
+)
+
+# for SHARED_KV + DP and _HSTU_COMPUTE_FOLD
+# --> we can do dk += dot(...) dk += dot(...)
+# --> we use "dk_shared" instead of "dk"
+# Block b0 schedule. dq (opndD id 11) is a SINGLE accumulator SHARED with block
+# b1: both blocks MMA-accumulate dq^T into the same TMEM tile (dq is a reduction
+# over KV blocks -- like the hand-written attn_bwd_ws_2kv), then ONE store. So
+# dpT must NOT time-share id 11 with dq (as the single-KV _TLX schedule does); it
+# gets its own tile (id 5). Everything else (qkT/S+P id 2, dv/dk id 7) is b0's.
+_HSTU_BWD_DOT_ATTRS_2KV = FrozenDotAttrs(
+    {
+        "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]},
+        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
+        "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,5"]},
+        "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]},
+        "dk_shared": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,7"]},
+        "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,8", "opndD,tmem,1,11"]},
+    }
+)
+
 
 # Triton's @jit frontend accepts `attrs=` only as a dict literal or a bare
 # module-global name bound to a dict -- it rejects passing a FrozenDotAttrs (or
@@ -133,7 +159,71 @@ _HSTU_ATTRS_QKT = tl.constexpr(_HSTU_BWD_DOT_ATTRS_TLX.get("qkT"))
 _HSTU_ATTRS_DV = tl.constexpr(_HSTU_BWD_DOT_ATTRS_TLX.get("dv"))
 _HSTU_ATTRS_DPT = tl.constexpr(_HSTU_BWD_DOT_ATTRS_TLX.get("dpT"))
 _HSTU_ATTRS_DK = tl.constexpr(_HSTU_BWD_DOT_ATTRS_TLX.get("dk"))
+_HSTU_ATTRS_DK_SHARED = tl.constexpr(_HSTU_BWD_DOT_ATTRS_TLX.get("dk_shared"))
 _HSTU_ATTRS_DQ = tl.constexpr(_HSTU_BWD_DOT_ATTRS_TLX.get("dq"))
+
+# Per-dot 2KV variants, selected in-kernel on the SHARED_KV + compute-fold path
+# (SHARED_KV and _HSTU_COMPUTE_FOLD). The 2KV schedule is fixed to the TLX
+# 2-KV-block layout and is NOT swapped by set_bwd_dot_attrs(); the active globals
+# above still drive the non-fold paths.
+_HSTU_ATTRS_QKT_2KV = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV.get("qkT"))
+_HSTU_ATTRS_DV_2KV = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV.get("dv"))
+_HSTU_ATTRS_DPT_2KV = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV.get("dpT"))
+_HSTU_ATTRS_DK_2KV = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV.get("dk"))
+_HSTU_ATTRS_DK_SHARED_2KV = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV.get("dk_shared"))
+_HSTU_ATTRS_DQ_2KV = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV.get("dq"))
+
+# MANUAL 2-KV DP (milestone 2): with warp specialization ON, the two KV blocks'
+# per-block MMAs run concurrently and their operand/accumulator tiles are
+# simultaneously live, so block b1 uses DISJOINT buffer.ids from b0 (which keeps
+# _2KV above) for qkT/S+P (2->12), dv/dk (7->17), and the smem operands (8->9).
+# This is the hand-written equivalent of the per-half id-remap the compiler DP
+# pass is supposed to synthesize.
+#
+# TWO exceptions are INTENTIONALLY shared across the halves:
+#   * dq's accumulator (opndD id 11): dq is a reduction over both KV blocks,
+#     accumulated into one TMEM tile and stored once.
+#   * dpT (dP) accumulator (opndD id 5, NOT 15): dp0/dp1 REUSE one TMEM tile
+#     (b1's dpT points at b0's id 5), mirroring TLX (`dp_tiles` depth-1 recycled
+#     across n0->n1). This trades the b0<->b1 overlap on the dpT->dqk step for
+#     64 TMEM columns, which is what lets BLOCK_N=128 fit the 512-col budget
+#     (576 -> 512). The planner packs dp1 at colOffset 0 in dp0's tile and
+#     inserts the reuse WAR barrier that serializes dp0-consume -> dp1-write.
+#     (qk stays split/depth-2 for overlap, as in TLX.)
+_HSTU_BWD_DOT_ATTRS_2KV_B1 = FrozenDotAttrs(
+    {
+        "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,12"]},
+        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,12", "opndD,tmem,1,17"]},
+        # dpT opndD id 5 is SHARED with b0 (dp0/dp1 reuse one TMEM tile, TLX-style)
+        # so BLOCK_N=128 fits TMEM; see the module comment above.
+        "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,5"]},
+        "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,9", "opndD,tmem,1,20"]},
+        "dk_shared": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,9", "opndD,tmem,1,17"]},
+        # dq opndD id 11 is SHARED with b0 (single dq accumulator over both KV
+        # blocks); only its input operand (opndB smem) is b1's own (id 9).
+        "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,9", "opndD,tmem,1,11"]},
+    }
+)
+_HSTU_ATTRS_QKT_2KV_B1 = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV_B1.get("qkT"))
+_HSTU_ATTRS_DV_2KV_B1 = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV_B1.get("dv"))
+_HSTU_ATTRS_DPT_2KV_B1 = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV_B1.get("dpT"))
+_HSTU_ATTRS_DK_2KV_B1 = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV_B1.get("dk"))
+_HSTU_ATTRS_DK_SHARED_2KV_B1 = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV_B1.get("dk_shared"))
+_HSTU_ATTRS_DQ_2KV_B1 = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV_B1.get("dq"))
+
+# "compute fold": fold dk_attn (dqk @ q) into the dv/dk accumulator (TLX 2kv
+# parity) instead of a separate dk_attn tile + register add. Kept behind a
+# constexpr gate (env HSTU_COMPUTE_FOLD=1) while the partition scheduler
+# interaction (spurious correction partition) is under investigation.
+_HSTU_COMPUTE_FOLD = tl.constexpr(os.environ.get("HSTU_COMPUTE_FOLD", "0") == "1")
+
+# When modulo top-K schedule exploration is enabled (TRITON_MODULO_TOPK>1), do
+# NOT emit the user tt.autows annotations on the MMAs: they pin the schedule and
+# make the modulo pass skip the loop (hasExistingAnnotation), turning the picked
+# variant into a no-op. Dropping them lets the modulo scheduler own the schedule.
+_HSTU_MODULO_TOPK = tl.constexpr(
+    int(os.environ.get("TRITON_MODULO_TOPK", "1")) > 1
+)
 
 
 def set_bwd_dot_attrs(cfg: "FrozenDotAttrs") -> None:
@@ -142,12 +232,15 @@ def set_bwd_dot_attrs(cfg: "FrozenDotAttrs") -> None:
     Pass _HSTU_BWD_DOT_ATTRS_DEFAULT or _HSTU_BWD_DOT_ATTRS_TLX. Call before the
     kernel compiles (use TRITON_ALWAYS_COMPILE=1 to force a recompile).
     """
-    global _HSTU_ATTRS_QKT, _HSTU_ATTRS_DV, _HSTU_ATTRS_DPT, _HSTU_ATTRS_DK, _HSTU_ATTRS_DQ
+    global _HSTU_ATTRS_QKT, _HSTU_ATTRS_DV, _HSTU_ATTRS_DPT, _HSTU_ATTRS_DK, _HSTU_ATTRS_DK_SHARED, _HSTU_ATTRS_DQ
     _HSTU_ATTRS_QKT = tl.constexpr(cfg.get("qkT"))
     _HSTU_ATTRS_DV = tl.constexpr(cfg.get("dv"))
     _HSTU_ATTRS_DPT = tl.constexpr(cfg.get("dpT"))
     _HSTU_ATTRS_DK = tl.constexpr(cfg.get("dk"))
+    _HSTU_ATTRS_DK_SHARED = tl.constexpr(cfg.get("dk_shared"))
     _HSTU_ATTRS_DQ = tl.constexpr(cfg.get("dq"))
+
+
 
 
 class FwdVariant(Enum):
@@ -168,6 +261,11 @@ class BwdVariant(Enum):
     # TLX 2-KV-block data-partitioned reduce_dq (attn_bwd_ws_2kv): two independent
     # MMA groups per program. Shared-KV only (V aliases K).
     TLX_2KV = "tlx_2kv"
+    # MANUAL 2-KV-block data-partitioned reduce_dq written explicitly in Triton
+    # (_hstu_attn_bwd_redq_2kv): processes two KV blocks per step to get 2-way
+    # parallelism WITHOUT triggering the compiler's automatic DP pass. Shared-KV +
+    # compute-fold only. Milestone 1: WS off.
+    TRITON_AUTOWS_2KV = "triton_autows_2kv"
 
 
 # Global variables for variant selection, can be overridden in unit tests
@@ -240,6 +338,8 @@ def _compute_offsets(
     )
 
 
+
+
 def get_fwd_triton_configs() -> List[triton.Config]:
     configs = [
         triton.Config(
@@ -266,7 +366,9 @@ def get_fwd_triton_configs() -> List[triton.Config]:
 
 
 @triton.jit
-def forward_valid_mask_trans(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL: tl.constexpr):
+def forward_valid_mask_trans(
+    offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL: tl.constexpr
+):
     valid_mask = (offs_m[None, :] < seq_len_q) & (offs_n[:, None] < seq_len_kv)
     if HAS_CAUSAL:
         offs_m = offs_m + seq_len_kv - uih_len_q
@@ -347,15 +449,20 @@ def _attn_fwd_compute(
     # Main loop - no masking needed for non-last kv blocks
     for start_n in tl.range(0, last_block_start_n, BLOCK_N):
         if ENABLE_TMA:
-            k = desc_k.load([
-                (seq_start_kv + start_n).to(tl.int32),
-                off_h_kv * stride_kh,
-            ])
+            k = desc_k.load(
+                [
+                    (seq_start_kv + start_n).to(tl.int32),
+                    off_h_kv * stride_kh,
+                ]
+            )
         else:
             offs_n_load = start_n + tl.arange(0, BLOCK_N)
             offs_qk_d = tl.arange(0, HEAD_DIM)
-            k_ptrs = (K + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_kn +
-                      (off_h_kv * stride_kh + offs_qk_d)[None, :])
+            k_ptrs = (
+                K
+                + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_kn
+                + (off_h_kv * stride_kh + offs_qk_d)[None, :]
+            )
             k = tl.load(k_ptrs)
 
         if TRANS:
@@ -365,9 +472,13 @@ def _attn_fwd_compute(
         if HAS_CAUSAL:
             offs_n = offs_n_0 + start_n
             if TRANS:
-                causal_mask = (offs_m[None, :] + seq_len_kv - uih_len_q) >= offs_n[:, None]
+                causal_mask = (offs_m[None, :] + seq_len_kv - uih_len_q) >= offs_n[
+                    :, None
+                ]
             else:
-                causal_mask = (offs_m[:, None] + seq_len_kv - uih_len_q) >= offs_n[None, :]
+                causal_mask = (offs_m[:, None] + seq_len_kv - uih_len_q) >= offs_n[
+                    None, :
+                ]
             if IS_SOFTMAX:
                 qk = tl.where(causal_mask, qk, float("-inf"))
             else:
@@ -397,15 +508,20 @@ def _attn_fwd_compute(
             v = k
         else:
             if ENABLE_TMA:
-                v = desc_v.load([
-                    (seq_start_kv + start_n).to(tl.int32),
-                    off_h_kv * stride_vh,
-                ])
+                v = desc_v.load(
+                    [
+                        (seq_start_kv + start_n).to(tl.int32),
+                        off_h_kv * stride_vh,
+                    ]
+                )
             else:
                 offs_n_load = start_n + tl.arange(0, BLOCK_N)
                 offs_v_d = tl.arange(0, BLOCK_D_V)
-                v_ptrs = (V + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_vn +
-                          (off_h_kv * stride_vh + offs_v_d)[None, :])
+                v_ptrs = (
+                    V
+                    + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_vn
+                    + (off_h_kv * stride_vh + offs_v_d)[None, :]
+                )
                 v = tl.load(v_ptrs)
         act_qk = act_qk.to(v.dtype)
         if TRANS:
@@ -417,15 +533,20 @@ def _attn_fwd_compute(
     # q masking is not needed here because we mask when storing results.
     start_n = last_block_start_n
     if ENABLE_TMA:
-        k = desc_k.load([
-            (seq_start_kv + start_n).to(tl.int32),
-            off_h_kv * stride_kh,
-        ])
+        k = desc_k.load(
+            [
+                (seq_start_kv + start_n).to(tl.int32),
+                off_h_kv * stride_kh,
+            ]
+        )
     else:
         offs_n_load = start_n + tl.arange(0, BLOCK_N)
         offs_qk_d = tl.arange(0, HEAD_DIM)
-        k_ptrs = (K + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_kn +
-                  (off_h_kv * stride_kh + offs_qk_d)[None, :])
+        k_ptrs = (
+            K
+            + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_kn
+            + (off_h_kv * stride_kh + offs_qk_d)[None, :]
+        )
         k = tl.load(
             k_ptrs,
             mask=(offs_n_load < seq_len_kv)[:, None],
@@ -457,9 +578,13 @@ def _attn_fwd_compute(
         )
     if IS_SOFTMAX:
         if TRANS:
-            act_qk, acc, l_i, m_i = forward_softmax_activation_trans_scaled_alpha(qk, alpha, valid_mask, m_i, acc, l_i)
+            act_qk, acc, l_i, m_i = forward_softmax_activation_trans_scaled_alpha(
+                qk, alpha, valid_mask, m_i, acc, l_i
+            )
         else:
-            act_qk, acc, l_i, m_i = forward_softmax_activation_scaled_alpha(qk, alpha, valid_mask, m_i, acc, l_i)
+            act_qk, acc, l_i, m_i = forward_softmax_activation_scaled_alpha(
+                qk, alpha, valid_mask, m_i, acc, l_i
+            )
     else:
         masked_alpha = tl.where(valid_mask, alpha, 0.0)
         qk = qk * masked_alpha
@@ -468,15 +593,20 @@ def _attn_fwd_compute(
         v = k
     else:
         if ENABLE_TMA:
-            v = desc_v.load([
-                (seq_start_kv + start_n).to(tl.int32),
-                off_h_kv * stride_vh,
-            ])
+            v = desc_v.load(
+                [
+                    (seq_start_kv + start_n).to(tl.int32),
+                    off_h_kv * stride_vh,
+                ]
+            )
         else:
             offs_n_load = start_n + tl.arange(0, BLOCK_N)
             offs_v_d = tl.arange(0, BLOCK_D_V)
-            v_ptrs = (V + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_vn +
-                      (off_h_kv * stride_vh + offs_v_d)[None, :])
+            v_ptrs = (
+                V
+                + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_vn
+                + (off_h_kv * stride_vh + offs_v_d)[None, :]
+            )
             v = tl.load(
                 v_ptrs,
                 mask=(offs_n_load < seq_len_kv)[:, None],
@@ -577,8 +707,12 @@ def _attn_fwd_triton_inner(
             q = desc_q.load([qo_offset_y_split.to(tl.int32), off_h * stride_qh])
         else:
             offs_qk_d = tl.arange(0, HEAD_DIM)
-            q_ptrs = (Q + (qo_offset_y_split + tl.arange(0, BLOCK_M)).to(tl.int64)[:, None] * stride_qm +
-                      (off_h * stride_qh + offs_qk_d)[None, :])
+            q_ptrs = (
+                Q
+                + (qo_offset_y_split + tl.arange(0, BLOCK_M)).to(tl.int64)[:, None]
+                * stride_qm
+                + (off_h * stride_qh + offs_qk_d)[None, :]
+            )
             q = tl.load(
                 q_ptrs,
                 mask=(offs_m < seq_len_q)[:, None],
@@ -812,7 +946,9 @@ def _attn_fwd_triton(
         seq_start_q,
         seq_len_q,
         off_z,
-    ) = _compute_offsets(H, G, BLOCK_M, seq_offsets_q, seq_offsets, max_seq_len, TRUNCATE_METHOD)
+    ) = _compute_offsets(
+        H, G, BLOCK_M, seq_offsets_q, seq_offsets, max_seq_len, TRUNCATE_METHOD
+    )
     if HAS_CAUSAL:
         n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
         uih_len_q = uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
@@ -865,6 +1001,8 @@ def _attn_fwd_triton(
     )
 
 
+
+
 def get_fwd_triton_spec_configs() -> List[triton.Config]:
     if torch.version.hip:
         configs = []
@@ -892,7 +1030,8 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                                         },
                                         num_stages=num_stages,
                                         num_warps=num_warps,
-                                    ))
+                                    )
+                                )
         return configs
     if get_full_autotune():
         configs = [
@@ -1216,7 +1355,9 @@ def _attn_fwd_triton_spec(
         seq_start_q,
         seq_len_q,
         off_z,
-    ) = _compute_offsets(H, G, BLOCK_M, seq_offsets_q, seq_offsets, max_seq_len, TRUNCATE_METHOD)
+    ) = _compute_offsets(
+        H, G, BLOCK_M, seq_offsets_q, seq_offsets, max_seq_len, TRUNCATE_METHOD
+    )
     if HAS_CAUSAL:
         n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
         uih_len_q = uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
@@ -1349,7 +1490,8 @@ def _get_triton_bw_configs() -> List[triton.Config]:
             num_stages=ns,
             num_warps=nw,
             pre_hook=_bwd_pre_hook_v3,
-        ) for (M, N, M1, N1) in [
+        )
+        for (M, N, M1, N1) in [
             (128, 64, 32, 128),
             (128, 64, 64, 64),
             (64, 128, 32, 128),
@@ -1357,7 +1499,9 @@ def _get_triton_bw_configs() -> List[triton.Config]:
             (64, 64, 32, 128),
             (32, 64, 32, 64),
             (32, 128, 32, 128),
-        ] for ns in [2, 3] for nw in [4, 8]
+        ]
+        for ns in [2, 3]
+        for nw in [4, 8]
     ]
     return configs
 
@@ -1474,9 +1618,9 @@ def _get_triton_bw_redq_configs() -> List[triton.Config]:
             num_warps=nw,
             pre_hook=_bwd_pre_hook_redq_v3,
         )
-        for M in [64]  #, 32]
-        for N in [128]  #, 128]
-        for ns in [2]  #, 3]
+        for M in [64]#, 32]
+        for N in [128]#, 128]
+        for ns in [2]#, 3]
         # EXPERIMENT (autoWS): force nw=4 only to test whether the PSM warp-budget
         # guard (skip WS if estimate > 16) is what suppresses warp specialization.
         for nw in [4]
@@ -1641,34 +1785,42 @@ def _hstu_attn_bwd_redq(  # noqa C901
                     scaled_alpha = alpha * 1.44269504
                 else:
                     scaled_alpha = alpha
-                M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q,
-                                                              stride_mm)
+                M_off, Delta_off = backward_common_preprocess(
+                    M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
+                )
                 # EXPERIMENT (autoWS): warp_specialize the inner Q loop. The
                 # `warp_specialize` kwarg only exists in beta triton, so this
                 # variant must be built with -m ovr_config//triton:beta. Guard
                 # before landing (constexpr-branch the tl.range on AUTOWS).
-                for start_m in tl.range(0, seq_len_q, BLOCK_M, num_stages=1, warp_specialize=WS_ON):
+                for start_m in tl.range(
+                    0, seq_len_q, BLOCK_M, num_stages=1, warp_specialize=WS_ON
+                ):
                     offs_m = start_m + tl.arange(0, BLOCK_M)
                     mask_m = offs_m < seq_len_q
-                    valid_mask_trans = backward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
+                    valid_mask_trans = backward_valid_mask(
+                        offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL
+                    )
                     q_offset = (seq_start_q + start_m).to(tl.int32)
                     q = desc_q.load([q_offset, off_h * stride_qh])
                     do = desc_do.load([q_offset, off_h * stride_doh])
                     qk_trans = tl.dot(k, tl.trans(q), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        qk_trans, act_qk_trans, pT = (backward_softmax_activation_scaled_alpha(
-                            qk_trans,
-                            scaled_alpha,
-                            valid_mask_trans,
-                            M_off,
-                            offs_m,
-                            stride_mm,
-                            mask_m,
-                            k,
-                        ))
+                        qk_trans, act_qk_trans, pT = (
+                            backward_softmax_activation_scaled_alpha(
+                                qk_trans,
+                                scaled_alpha,
+                                valid_mask_trans,
+                                M_off,
+                                offs_m,
+                                stride_mm,
+                                mask_m,
+                                k,
+                            )
+                        )
                     else:
-                        qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans,
-                                                                              k.dtype, scale)
+                        qk_trans, act_qk_trans, pT = backward_silu_activation(
+                            qk_trans, alpha, valid_mask_trans, k.dtype, scale
+                        )
                     if SHARED_KV:
                         dk += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
                     else:
@@ -1676,26 +1828,37 @@ def _hstu_attn_bwd_redq(  # noqa C901
                         dv += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
                     dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m,
-                                                                  pT)
+                        dqk_trans = backward_d_softmax_activation(
+                            dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
+                        )
                     else:
-                        dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
+                        dqk_trans = backward_d_silu_activation(
+                            dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
+                        )
                     dqk_trans = dqk_trans.to(k.dtype)
                     dk += tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32) * alpha
-                    dq_trans = (tl.dot(tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32) * alpha)
+                    dq_trans = (
+                        tl.dot(tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32) * alpha
+                    )
                     dq = tl.trans(dq_trans)
                     desc_dq.store(
                         [q_offset, DimQ * off_h],
                         dq.to(desc_dq.dtype),
                         store_reduce="add",
                     )
-            DK_off = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
-                      off_h_kv * tl.cast(stride_dkh, tl.int64))
+            DK_off = (
+                DK
+                + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64)
+                + off_h_kv * tl.cast(stride_dkh, tl.int64)
+            )
             dk_ptrs = DK_off + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
             tl.store(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None])
             if not SHARED_KV:
-                DV_off = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
-                          off_h_kv * tl.cast(stride_dvh, tl.int64))
+                DV_off = (
+                    DV
+                    + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64)
+                    + off_h_kv * tl.cast(stride_dvh, tl.int64)
+                )
                 dv_ptrs = DV_off + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
                 # pyrefly: ignore [unbound-name]
                 tl.store(dv_ptrs, dv.to(k.dtype), mask=mask_n[:, None])
@@ -1781,7 +1944,19 @@ def _hstu_attn_bwd_redq(  # noqa C901
         # Match the TLX kernel (attn_bwd_ws): iterate every KV block in one masked
         # loop — masking is a no-op for full blocks. Kept autoWS-only (constexpr)
         # so the non-WS peeled fast path is unchanged.
-        for start_n in tl.range(0, seq_len_kv, BLOCK_N):
+        for start_n in tl.range(
+            0,
+            seq_len_kv,
+            BLOCK_N,
+            warp_specialize=WS_ON,
+            merge_epilogue_to_computation=WS_ON,
+            # With the compute fold, the dk accumulator's cross-iteration
+            # tmem_load is categorized as a correction op; merge it into the
+            # computation partition instead of spawning a separate correction
+            # partition (which would exceed the 16-warp budget).
+            merge_correction=WS_ON,
+            data_partition_factor=(2 if BLOCK_N >= 256 else 1),
+        ):
             _hstu_attn_bwd_inner(
                 start_n,
                 seq_start_kv,
@@ -1909,6 +2084,257 @@ def _hstu_attn_bwd_redq(  # noqa C901
         HAS_CAUSAL=HAS_CAUSAL,
         AUTOWS=AUTOWS,
     )
+
+
+def _get_triton_bw_redq_2kv_configs() -> List[triton.Config]:
+    # The manual 2-KV-block loop supplies the 2-way parallelism, so BLOCK_N stays
+    # well below the compiler-DP trigger (BLOCK_N >= 256) and the pass never runs.
+    #
+    # List-schedule autotuning: when TRITON_USE_LIST_SCHEDULE=1, sweep the inner
+    # (start_m) loop's schedule rank INNER_PICK over 0..K-1 (K from
+    # HSTU_INNER_SCHED_K, default 4). Each INNER_PICK is a distinct tl.constexpr
+    # -> a distinct compile key, so the autotuner compiles+times each inner
+    # schedule and caches the winner. Deliberately NOT keyed on
+    # TRITON_LIST_SCHEDULE_TOPK: that env is the pass's *global* generation count
+    # and would also make the OUTER loop generate variants. We leave it unset so
+    # the outer loop keeps a single schedule (only the inner, which carries the
+    # per-loop pick attr, is generated ranked). With list scheduling off,
+    # INNER_PICK stays [0] (no extra configs; the attr is ignored downstream).
+    if os.environ.get("TRITON_USE_LIST_SCHEDULE"):
+        inner_k = int(os.environ.get("HSTU_INNER_SCHED_K", "4"))
+        inner_picks = list(range(max(1, inner_k)))
+    else:
+        inner_picks = [0]
+    configs = [
+        triton.Config(
+            {
+                "BLOCK_M": M,
+                "BLOCK_N": N,
+                "INNER_PICK": pick,
+            },
+            num_stages=ns,
+            num_warps=nw,
+            pre_hook=_bwd_pre_hook_redq_v3,
+        )
+        # BLOCK_M=64, BLOCK_N=64. The compute fold MMA-accumulates BOTH KV blocks'
+        # dk in TMEM (each [BLOCK_N, DimQ]); at BLOCK_N=64 the two dk tiles stack
+        # in TMEM's two 64-row groups at the SAME columns (128 cols for both, not
+        # 256), which -- with dq as a single shared accumulator -- keeps the peak
+        # at ~480 < 512 cols and lets BLOCK_M reach 64. BLOCK_N=128 would need 256
+        # dk cols and overflows at BLOCK_M=64 (608 > 512).
+        for M in [64]
+        for N in [64]
+        for ns in [1]
+        for nw in [4]
+        for pick in inner_picks
+    ]
+    return configs
+
+
+@triton_autotune(
+    configs=_get_triton_bw_redq_2kv_configs(),
+    key=[
+        "AUTOTUNE_Z",
+        "H",
+        "max_q_len",
+        "AUTOTUNE_MAX_SEQ_LEN",
+        "DimQ",
+        "DimV",
+        "num_softmax_heads",
+    ],
+)
+@triton.jit
+def _hstu_attn_bwd_redq_2kv(  # noqa C901
+    Q,
+    K,
+    V,
+    DO,
+    total_seq_len_q,
+    total_seq_len_kv,
+    seq_offsets,
+    seq_offsets_q,
+    DQ,
+    DK,
+    DV,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_dom,
+    stride_doh,
+    stride_dqm,
+    stride_dqh,
+    stride_dkn,
+    stride_dkh,
+    stride_dvn,
+    stride_dvh,
+    alpha,
+    max_seq_len,
+    attn_scale,
+    M,
+    Delta,
+    stride_mm,
+    num_targets,
+    Z,
+    AUTOTUNE_Z,
+    H,
+    G: tl.constexpr,
+    num_softmax_heads: tl.constexpr,
+    max_q_len: tl.constexpr,
+    AUTOTUNE_MAX_SEQ_LEN,  # Quantized MAX_SEQ_LEN used as an autotuning key
+    DimQ: tl.constexpr,
+    DimV: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    SHARED_KV: tl.constexpr,
+    TRUNCATE_METHOD: tl.constexpr,
+    HAS_CAUSAL: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+    # pyrefly: ignore [bad-function-definition]
+    PER_KV_HEAD: tl.constexpr = False,
+    # pyrefly: ignore [bad-function-definition]
+    AUTOWS: tl.constexpr = False,
+    WS_ON: tl.constexpr = False,
+    # Inner (start_m) loop list-schedule rank; swept by autotune under
+    # TRITON_USE_LIST_SCHEDULE=1. See _get_triton_bw_redq_2kv_configs.
+    # pyrefly: ignore [bad-function-definition]
+    INNER_PICK: tl.constexpr = 0,
+):
+    """MANUAL 2-KV-block data-partition fork of `_hstu_attn_bwd_redq`.
+
+    Steps the KV loop by 2*BLOCK_N and dispatches `_hstu_attn_bwd_inner_2kv`
+    (two KV blocks per call), rounding the block count up so an odd leftover
+    block is handled by the same 2-KV inner with its second block fully masked
+    (no separate single-KV tail, whose buffer.ids would clash under WS).
+    SHARED_KV + compute-fold only.
+    """
+    tl.static_assert(SHARED_KV, "_hstu_attn_bwd_redq_2kv is SHARED_KV only")
+    tl.static_assert(not PER_KV_HEAD, "_hstu_attn_bwd_redq_2kv requires G == 1")
+    (
+        off_h,
+        off_h_kv,
+        start_n,
+        seq_start_kv,
+        seq_len_kv,
+        seq_start_q,
+        seq_len_q,
+        off_z,
+    ) = _compute_bwd_reduce_dq_offsets(
+        H,
+        G,
+        BLOCK_N,
+        seq_offsets_q,
+        seq_offsets,
+        max_seq_len,
+        TRUNCATE_METHOD,
+    )
+    n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
+    uih_len_q = uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
+    if seq_len_kv == 0:
+        return
+    H_kv = H // G
+    desc_q = tl.make_tensor_descriptor(
+        Q,
+        shape=[total_seq_len_q, H * DimQ],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H * DimQ, 1],
+        block_shape=[BLOCK_M, DimQ],
+    )
+    desc_k = tl.make_tensor_descriptor(
+        K,
+        shape=[total_seq_len_kv, H_kv * DimQ],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H_kv * DimQ, 1],
+        block_shape=[BLOCK_N, DimQ],
+    )
+    desc_v = tl.make_tensor_descriptor(
+        V,
+        shape=[total_seq_len_kv, H_kv * DimV],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H_kv * DimV, 1],
+        block_shape=[BLOCK_N, DimV],
+    )
+    desc_do = tl.make_tensor_descriptor(
+        DO,
+        shape=[total_seq_len_q, H * DimV],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[H * DimV, 1],
+        block_shape=[BLOCK_M, DimV],
+    )
+    end_kv = seq_start_kv + seq_len_kv
+    desc_dk = tl.make_tensor_descriptor(
+        DK,
+        shape=[end_kv.to(tl.int32), DimQ * H_kv],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[DimQ * H_kv, 1],
+        block_shape=[BLOCK_N, DimQ],
+    )
+    end_dq = seq_start_q + seq_len_q
+    desc_dq = tl.make_tensor_descriptor(
+        DQ,
+        shape=[end_dq.to(tl.int32), DimQ * H],
+        # pyrefly: ignore [bad-argument-type]
+        strides=[DimQ * H, 1],
+        block_shape=[BLOCK_M, DimQ],
+    )
+
+    # Pair up BLOCK_N KV blocks: process two blocks per _hstu_attn_bwd_inner_2kv
+    # call, rounding the block count UP so an odd leftover block is handled by
+    # the SAME 2-KV inner with its second block (b1) fully masked -- b1's dq
+    # contribution is zero and its dk1 store lands past end_kv (dropped by the
+    # desc_dk TMA bounds). This avoids a separate single-KV tail inner, whose
+    # distinct TLX buffer.ids collide with the 2-KV ids and crash the WS pass.
+    n_blocks = tl.cdiv(seq_len_kv, BLOCK_N)
+    n_pairs = tl.cdiv(n_blocks, 2)
+    pair_end_n = n_pairs * 2 * BLOCK_N
+    for start_n in tl.range(0, pair_end_n, 2 * BLOCK_N):
+        _hstu_attn_bwd_inner_2kv(
+            start_n,
+            seq_start_kv,
+            seq_len_kv,
+            seq_start_q,
+            seq_len_q,
+            desc_q,
+            desc_k,
+            desc_v,
+            desc_do,
+            desc_dk,
+            desc_dq,
+            DV,
+            stride_qh,
+            stride_kh,
+            stride_vh,
+            stride_doh,
+            stride_dvn,
+            stride_dvh,
+            alpha,
+            attn_scale,
+            M,
+            Delta,
+            stride_mm,
+            off_h,
+            off_h_kv,
+            H_kv,
+            uih_len_q,
+            num_softmax_heads,
+            DimQ,
+            DimV,
+            ALLOW_TF32,
+            BLOCK_M,
+            BLOCK_N,
+            ATTN_SCALE_TYPE,
+            G > 1,  # GQA_ATOMIC_ADD
+            SHARED_KV,
+            True,  # MASK_KV
+            HAS_CAUSAL,
+            AUTOWS,
+            WS_ON,
+            INNER_PICK,
+        )
 
 
 @triton_autotune(
@@ -2054,13 +2480,21 @@ def _hstu_attn_bwd(  # noqa C901
         mask_m = offs_m < seq_len_q
         tl.static_assert(ATTN_SCALE_TYPE == "scalar")
         scale = tl.load(attn_scale).to(tl.float32)
-        M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm)
-        DK_off = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
-                  off_h_kv * tl.cast(stride_dkh, tl.int64))
+        M_off, Delta_off = backward_common_preprocess(
+            M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
+        )
+        DK_off = (
+            DK
+            + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64)
+            + off_h_kv * tl.cast(stride_dkh, tl.int64)
+        )
         DV_off = DV
         if not SHARED_KV:
-            DV_off = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
-                      off_h_kv * tl.cast(stride_dvh, tl.int64))
+            DV_off = (
+                DV
+                + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64)
+                + off_h_kv * tl.cast(stride_dvh, tl.int64)
+            )
         dq_acc = tl.zeros([DimQ, BLOCK_M], dtype=tl.float32)
         if off_h < num_softmax_heads:
             scaled_alpha = alpha * 1.44269504
@@ -2078,7 +2512,9 @@ def _hstu_attn_bwd(  # noqa C901
                 v = desc_v.load([k_offset, off_h_kv * stride_vh])
             qk_trans = tl.dot(k, q_trans)
             offs_n = start_n + tl.arange(0, BLOCK_N)
-            valid_mask_trans = (offs_n[:, None] < seq_len_kv) & (offs_m[None, :] < seq_len_q)
+            valid_mask_trans = (offs_n[:, None] < seq_len_kv) & (
+                offs_m[None, :] < seq_len_q
+            )
             if off_h < num_softmax_heads:
                 qk_trans, act_qk_trans, pT = backward_softmax_activation_scaled_alpha(
                     qk_trans,
@@ -2091,16 +2527,22 @@ def _hstu_attn_bwd(  # noqa C901
                     k,
                 )
             else:
-                qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans, k.dtype, scale)
+                qk_trans, act_qk_trans, pT = backward_silu_activation(
+                    qk_trans, alpha, valid_mask_trans, k.dtype, scale
+                )
             if SHARED_KV:
                 dk = tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
             else:
                 dv = tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
             dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
             if off_h < num_softmax_heads:
-                dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT)
+                dqk_trans = backward_d_softmax_activation(
+                    dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
+                )
             else:
-                dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
+                dqk_trans = backward_d_silu_activation(
+                    dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
+                )
             dqk_trans = dqk_trans.to(k.dtype)
             if SHARED_KV:
                 dk_attn = tl.dot(dqk_trans, tl.trans(q_trans), allow_tf32=ALLOW_TF32)
@@ -2112,7 +2554,9 @@ def _hstu_attn_bwd(  # noqa C901
             dk_ptrs = DK_off + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
             mask_n = offs_n < seq_len_kv
             if G > 1:
-                tl.atomic_add(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None], sem="relaxed")
+                tl.atomic_add(
+                    dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None], sem="relaxed"
+                )
             else:
                 tl.store(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None])
             if not SHARED_KV:
@@ -2134,7 +2578,12 @@ def _hstu_attn_bwd(  # noqa C901
             dq_trans = dq_trans * alpha
             dq_acc += dq_trans
         dq = tl.trans(dq_acc)
-        dq_ptrs = (DQ + (seq_start_q + offs_m[:, None]) * stride_dqm + off_h * stride_dqh + tl.arange(0, DimQ)[None, :])
+        dq_ptrs = (
+            DQ
+            + (seq_start_q + offs_m[:, None]) * stride_dqm
+            + off_h * stride_dqh
+            + tl.arange(0, DimQ)[None, :]
+        )
         tl.store(dq_ptrs, dq.to(DQ.dtype.element_ty), mask=mask_m[:, None])
     else:
         for start_n in tl.range(0, last_block_start_n, BLOCK_N):
@@ -2359,7 +2808,9 @@ def _hstu_attn_bwd_redkv(
             for start_n in tl.range(0, seq_len_kv, BLOCK_N):
                 offs_n = start_n + tl.arange(0, BLOCK_N)
                 mask_n = offs_n < seq_len_kv
-                valid_mask_trans = backward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
+                valid_mask_trans = backward_valid_mask(
+                    offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL
+                )
                 k_offset = (seq_start_kv + start_n).to(tl.int32)
                 k = desc_k.load([k_offset, off_h_kv * stride_kh])
                 if SHARED_KV:
@@ -2374,55 +2825,80 @@ def _hstu_attn_bwd_redkv(
                         scaled_alpha = alpha * 1.44269504
                     else:
                         scaled_alpha = alpha
-                    M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q,
-                                                                  stride_mm)
+                    M_off, Delta_off = backward_common_preprocess(
+                        M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
+                    )
                     q = desc_q.load([seq_start_q, off_h * stride_qh])
                     do = desc_do.load([seq_start_q, off_h * stride_doh])
                     qk_trans = tl.dot(k, tl.trans(q), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        qk_trans, act_qk_trans, pT = (backward_softmax_activation_scaled_alpha(
-                            qk_trans,
-                            scaled_alpha,
-                            valid_mask_trans,
-                            M_off,
-                            offs_m,
-                            stride_mm,
-                            mask_m,
-                            k,
-                        ))
+                        qk_trans, act_qk_trans, pT = (
+                            backward_softmax_activation_scaled_alpha(
+                                qk_trans,
+                                scaled_alpha,
+                                valid_mask_trans,
+                                M_off,
+                                offs_m,
+                                stride_mm,
+                                mask_m,
+                                k,
+                            )
+                        )
                     else:
-                        qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans,
-                                                                              k.dtype, scale)
+                        qk_trans, act_qk_trans, pT = backward_silu_activation(
+                            qk_trans, alpha, valid_mask_trans, k.dtype, scale
+                        )
                     if SHARED_KV:
                         dk += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
                     else:
                         dv += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
                     dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m,
-                                                                  pT)
+                        dqk_trans = backward_d_softmax_activation(
+                            dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
+                        )
                     else:
-                        dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
+                        dqk_trans = backward_d_silu_activation(
+                            dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
+                        )
                     dqk_trans = dqk_trans.to(k.dtype)
                     dk += tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32) * alpha
                     # dq for head g
                     dq_g = tl.dot(tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32)
-                    dq_acc += tl.where((offs_g == g)[None, :, None], dq_g[:, None, :], 0.0)
-                DK_off = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
-                          off_h_kv * tl.cast(stride_dkh, tl.int64))
+                    dq_acc += tl.where(
+                        (offs_g == g)[None, :, None], dq_g[:, None, :], 0.0
+                    )
+                DK_off = (
+                    DK
+                    + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64)
+                    + off_h_kv * tl.cast(stride_dkh, tl.int64)
+                )
                 dk_ptrs = DK_off + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
                 tl.store(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None])
                 if not SHARED_KV:
-                    DV_off = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
-                              off_h_kv * tl.cast(stride_dvh, tl.int64))
-                    dv_ptrs = DV_off + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
+                    DV_off = (
+                        DV
+                        + tl.cast(seq_start_kv, tl.int64)
+                        * tl.cast(stride_dvn, tl.int64)
+                        + off_h_kv * tl.cast(stride_dvh, tl.int64)
+                    )
+                    dv_ptrs = DV_off + (
+                        offs_n[:, None] * stride_dvn + offs_v_d[None, :]
+                    )
                     tl.store(dv_ptrs, dv.to(k.dtype), mask=mask_n[:, None])
             # Write dq per head from the accumulator.
             for g in range(G):
                 off_h = off_h_kv * G + g
-                dq_trans = tl.sum(tl.where((offs_g == g)[None, :, None], dq_acc, 0.0), axis=1)
+                dq_trans = tl.sum(
+                    tl.where((offs_g == g)[None, :, None], dq_acc, 0.0), axis=1
+                )
                 dq = tl.trans(dq_trans) * alpha
-                dq_ptrs = (DQ + (seq_start_q + offs_m[:, None]) * stride_dqm + off_h * stride_dqh + offs_qk_d[None, :])
+                dq_ptrs = (
+                    DQ
+                    + (seq_start_q + offs_m[:, None]) * stride_dqm
+                    + off_h * stride_dqh
+                    + offs_qk_d[None, :]
+                )
                 tl.store(dq_ptrs, dq.to(DQ.dtype.element_ty), mask=mask_m[:, None])
             return
 
@@ -2444,49 +2920,64 @@ def _hstu_attn_bwd_redkv(
                     scaled_alpha = alpha * 1.44269504
                 else:
                     scaled_alpha = alpha
-                M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q,
-                                                              stride_mm)
+                M_off, Delta_off = backward_common_preprocess(
+                    M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
+                )
                 for start_m in tl.range(0, seq_len_q, BLOCK_M):
                     offs_m = start_m + tl.arange(0, BLOCK_M)
                     mask_m = offs_m < seq_len_q
-                    valid_mask_trans = backward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
+                    valid_mask_trans = backward_valid_mask(
+                        offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL
+                    )
                     q_offset = (seq_start_q + start_m).to(tl.int32)
                     q = desc_q.load([q_offset, off_h * stride_qh])
                     do = desc_do.load([q_offset, off_h * stride_doh])
                     qk_trans = tl.dot(k, tl.trans(q), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        qk_trans, act_qk_trans, pT = (backward_softmax_activation_scaled_alpha(
-                            qk_trans,
-                            scaled_alpha,
-                            valid_mask_trans,
-                            M_off,
-                            offs_m,
-                            stride_mm,
-                            mask_m,
-                            k,
-                        ))
+                        qk_trans, act_qk_trans, pT = (
+                            backward_softmax_activation_scaled_alpha(
+                                qk_trans,
+                                scaled_alpha,
+                                valid_mask_trans,
+                                M_off,
+                                offs_m,
+                                stride_mm,
+                                mask_m,
+                                k,
+                            )
+                        )
                     else:
-                        qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans,
-                                                                              k.dtype, scale)
+                        qk_trans, act_qk_trans, pT = backward_silu_activation(
+                            qk_trans, alpha, valid_mask_trans, k.dtype, scale
+                        )
                     if SHARED_KV:
                         dk += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
                     else:
                         dv += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
                     dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m,
-                                                                  pT)
+                        dqk_trans = backward_d_softmax_activation(
+                            dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
+                        )
                     else:
-                        dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
+                        dqk_trans = backward_d_silu_activation(
+                            dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
+                        )
                     dqk_trans = dqk_trans.to(k.dtype)
                     dk += tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32) * alpha
-            DK_off = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
-                      off_h_kv * tl.cast(stride_dkh, tl.int64))
+            DK_off = (
+                DK
+                + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64)
+                + off_h_kv * tl.cast(stride_dkh, tl.int64)
+            )
             dk_ptrs = DK_off + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
             tl.store(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None])
             if not SHARED_KV:
-                DV_off = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
-                          off_h_kv * tl.cast(stride_dvh, tl.int64))
+                DV_off = (
+                    DV
+                    + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64)
+                    + off_h_kv * tl.cast(stride_dvh, tl.int64)
+                )
                 dv_ptrs = DV_off + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
                 tl.store(dv_ptrs, dv.to(k.dtype), mask=mask_n[:, None])
         # Phase 2: dq (per head, tile over Q).
@@ -2496,7 +2987,9 @@ def _hstu_attn_bwd_redkv(
                 scaled_alpha = alpha * 1.44269504
             else:
                 scaled_alpha = alpha
-            M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm)
+            M_off, Delta_off = backward_common_preprocess(
+                M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
+            )
             for start_m in tl.range(0, seq_len_q, BLOCK_M):
                 offs_m = start_m + tl.arange(0, BLOCK_M)
                 mask_m = offs_m < seq_len_q
@@ -2507,7 +3000,9 @@ def _hstu_attn_bwd_redkv(
                 dq_trans = tl.zeros([DimQ, BLOCK_M], dtype=tl.float32)
                 for start_n in tl.range(0, seq_len_kv, BLOCK_N):
                     offs_n = start_n + tl.arange(0, BLOCK_N)
-                    valid_mask_trans = backward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
+                    valid_mask_trans = backward_valid_mask(
+                        offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL
+                    )
                     k_offset = (seq_start_kv + start_n).to(tl.int32)
                     k = desc_k.load([k_offset, off_h_kv * stride_kh])
                     if SHARED_KV:
@@ -2516,29 +3011,40 @@ def _hstu_attn_bwd_redkv(
                         v = desc_v.load([k_offset, off_h_kv * stride_vh])
                     qk_trans = tl.dot(k, q_trans, allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        qk_trans, act_qk_trans, pT = (backward_softmax_activation_scaled_alpha(
-                            qk_trans,
-                            scaled_alpha,
-                            valid_mask_trans,
-                            M_off,
-                            offs_m,
-                            stride_mm,
-                            mask_m,
-                            k,
-                        ))
+                        qk_trans, act_qk_trans, pT = (
+                            backward_softmax_activation_scaled_alpha(
+                                qk_trans,
+                                scaled_alpha,
+                                valid_mask_trans,
+                                M_off,
+                                offs_m,
+                                stride_mm,
+                                mask_m,
+                                k,
+                            )
+                        )
                     else:
-                        qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans,
-                                                                              k.dtype, scale)
+                        qk_trans, act_qk_trans, pT = backward_silu_activation(
+                            qk_trans, alpha, valid_mask_trans, k.dtype, scale
+                        )
                     dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m,
-                                                                  pT)
+                        dqk_trans = backward_d_softmax_activation(
+                            dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
+                        )
                     else:
-                        dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
+                        dqk_trans = backward_d_silu_activation(
+                            dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
+                        )
                     dqk_trans = dqk_trans.to(k.dtype)
                     dq_trans += tl.dot(tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32)
                 dq = tl.trans(dq_trans) * alpha
-                dq_ptrs = (DQ + (seq_start_q + offs_m[:, None]) * stride_dqm + off_h * stride_dqh + offs_qk_d[None, :])
+                dq_ptrs = (
+                    DQ
+                    + (seq_start_q + offs_m[:, None]) * stride_dqm
+                    + off_h * stride_dqh
+                    + offs_qk_d[None, :]
+                )
                 tl.store(dq_ptrs, dq.to(DQ.dtype.element_ty), mask=mask_m[:, None])
         return
 
@@ -2752,11 +3258,17 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
     offs_m = start_m + tl.arange(0, BLOCK_M)
     # Offset DQ, DK, DV pointers by sequence start and head offset
     DQ = DQ + seq_start_q * stride_dqm + off_h * stride_dqh
-    DK = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
-          off_h_kv * tl.cast(stride_dkh, tl.int64))
+    DK = (
+        DK
+        + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64)
+        + off_h_kv * tl.cast(stride_dkh, tl.int64)
+    )
     if not SHARED_KV:
-        DV = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
-              off_h_kv * tl.cast(stride_dvh, tl.int64))
+        DV = (
+            DV
+            + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64)
+            + off_h_kv * tl.cast(stride_dvh, tl.int64)
+        )
     mask_m = offs_m < seq_len_q
     if ATTN_SCALE_TYPE == "scalar":
         scale = tl.load(attn_scale).to(tl.float32)
@@ -2765,7 +3277,9 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
         scale = tl.load(attn_scale + offs_m, mask=mask_m).to(tl.float32)
 
     # Preprocess M and Delta offsets for softmax
-    M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm)
+    M_off, Delta_off = backward_common_preprocess(
+        M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
+    )
 
     if HAS_CAUSAL:
         high_kv = start_m + BLOCK_M + seq_len_kv - uih_len_q
@@ -2824,7 +3338,9 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
                     seq_len_kv,
                     HAS_CAUSAL,
                 )
-                qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans, k.dtype, scale)
+                qk_trans, act_qk_trans, pT = backward_silu_activation(
+                    qk_trans, alpha, valid_mask_trans, k.dtype, scale
+                )
             else:
                 qk_trans = qk_trans * alpha
                 pT = fast_silu(qk_trans, MULT_BY_X=False)
@@ -2856,7 +3372,9 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
 
         dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
         if off_h < num_softmax_heads:
-            dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT)
+            dqk_trans = backward_d_softmax_activation(
+                dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
+            )
         else:
             if q_needs_mask or HAS_CAUSAL:
                 valid_mask_trans = backward_valid_mask(
@@ -2875,7 +3393,9 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
                     valid_mask_trans,
                 )
             else:
-                dqk_trans = (dact_qk_trans * pT * (1 + qk_trans * (1 - pT)) * scale[None, :])
+                dqk_trans = (
+                    dact_qk_trans * pT * (1 + qk_trans * (1 - pT)) * scale[None, :]
+                )
         dqk_trans = dqk_trans.to(k.dtype)
         if SHARED_KV:
             dk_attn = tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32)
@@ -2930,7 +3450,9 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
                 k,
             )
         else:
-            qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans, k.dtype, scale)
+            qk_trans, act_qk_trans, pT = backward_silu_activation(
+                qk_trans, alpha, valid_mask_trans, k.dtype, scale
+            )
         if SHARED_KV:
             dk = tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
             v = k
@@ -2953,9 +3475,13 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
 
         dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
         if off_h < num_softmax_heads:
-            dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT)
+            dqk_trans = backward_d_softmax_activation(
+                dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
+            )
         else:
-            dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
+            dqk_trans = backward_d_silu_activation(
+                dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
+            )
         dqk_trans = dqk_trans.to(k.dtype)
         if SHARED_KV:
             dk_attn = tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32)
@@ -3059,12 +3585,17 @@ def _hstu_attn_bwd_inner(  # noqa C901
         dv = tl.zeros([BLOCK_N, DimV], dtype=tl.float32)
     # Offset DV pointers by sequence start and head offset
     if not SHARED_KV:
-        DV = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
-              off_h_kv * tl.cast(stride_dvh, tl.int64))
+        DV = (
+            DV
+            + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64)
+            + off_h_kv * tl.cast(stride_dvh, tl.int64)
+        )
     tl.static_assert(ATTN_SCALE_TYPE == "scalar")
     scale = tl.load(attn_scale).to(tl.float32)
 
-    M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm)
+    M_off, Delta_off = backward_common_preprocess(
+        M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
+    )
 
     offs_n = start_n + tl.arange(0, BLOCK_N)
     # EXPERIMENT (autoWS): for the all-or-nothing softmax shape (num_softmax_heads
@@ -3086,7 +3617,9 @@ def _hstu_attn_bwd_inner(  # noqa C901
     # partition (Meta partition-scheduler merge-epilogue knob) so autoWS has the
     # same 4-partition layout as the hand-TLX kernel (which stores dk/dv in the
     # reduction/default task) instead of a separate epilogue partition.
-    for start_m in tl.range(low_q, seq_len_q, BLOCK_M, warp_specialize=WS_ON, merge_epilogue=WS_ON):
+    for start_m in tl.range(
+        low_q, seq_len_q, BLOCK_M, warp_specialize=WS_ON, merge_epilogue=WS_ON
+    ):
         offs_m = start_m + tl.arange(0, BLOCK_M)
         mask_m = offs_m < seq_len_q
         q_offset = seq_start_q + start_m
@@ -3094,7 +3627,8 @@ def _hstu_attn_bwd_inner(  # noqa C901
         qk_trans = tl.dot(
             k,
             tl.trans(q),
-            attrs=_HSTU_ATTRS_QKT if WS_ON else None,
+            attrs=(_HSTU_ATTRS_QKT_2KV if (SHARED_KV and _HSTU_COMPUTE_FOLD)
+                   else _HSTU_ATTRS_QKT) if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
         if MASK_KV or HAS_CAUSAL:
             valid_mask_trans = backward_valid_mask(
@@ -3119,60 +3653,68 @@ def _hstu_attn_bwd_inner(  # noqa C901
                 k,
             )
         else:
-            qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans, k.dtype, scale)
+            qk_trans, act_qk_trans, pT = backward_silu_activation(
+                qk_trans, alpha, valid_mask_trans, k.dtype, scale
+            )
         do = desc_do.load([q_offset.to(tl.int32), off_h * stride_doh])
 
         dact_qk_trans = tl.dot(
-            v,
-            tl.trans(do),
-            allow_tf32=ALLOW_TF32,
-            attrs=_HSTU_ATTRS_DPT if WS_ON else None,
+            v, tl.trans(do), allow_tf32=ALLOW_TF32,
+            attrs=(_HSTU_ATTRS_DPT_2KV if (SHARED_KV and _HSTU_COMPUTE_FOLD)
+                   else _HSTU_ATTRS_DPT) if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
         if SHARED_KV:
             dk = tl.dot(
-                act_qk_trans,
-                do,
-                dk,
-                allow_tf32=ALLOW_TF32,
-                attrs=_HSTU_ATTRS_DV if WS_ON else None,
+                act_qk_trans, do, dk, allow_tf32=ALLOW_TF32,
+                attrs=(_HSTU_ATTRS_DV_2KV if _HSTU_COMPUTE_FOLD
+                       else _HSTU_ATTRS_DV) if (WS_ON and not _HSTU_MODULO_TOPK) else None,
             )
         else:
             # pyrefly: ignore [unbound-name]
             dv = tl.dot(
-                act_qk_trans,
-                do,
-                dv,
-                allow_tf32=ALLOW_TF32,
-                attrs=_HSTU_ATTRS_DV if WS_ON else None,
+                act_qk_trans, do, dv, allow_tf32=ALLOW_TF32,
+                attrs=_HSTU_ATTRS_DV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
             )
 
         if num_softmax_heads > 0:  # autoWS: constexpr (see note above)
-            dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT)
-        else:
-            dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
-        dqk_trans = dqk_trans.to(k.dtype)
-        dq_trans = tl.dot(
-            tl.trans(k),
-            dqk_trans,
-            attrs=_HSTU_ATTRS_DQ if WS_ON else None,
-        )
-        if SHARED_KV:
-            dk_attn = tl.dot(
-                dqk_trans,
-                q,
-                allow_tf32=ALLOW_TF32,
-                attrs=_HSTU_ATTRS_DK if WS_ON else None,
+            dqk_trans = backward_d_softmax_activation(
+                dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
             )
-            dk = dk + dk_attn * alpha
         else:
+            dqk_trans = backward_d_silu_activation(
+                dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
+            )
+        if SHARED_KV and _HSTU_COMPUTE_FOLD:
+            # Fold dk_attn into dk: pre-scale alpha into dqk_trans (fp32) so both
+            # the dq and dk_attn dots carry alpha, then accumulate dk_attn
+            # directly into the dv/dk accumulator (dk_shared -> buffer id 7).
+            dqk_trans = (dqk_trans * alpha).to(k.dtype)
+            dq_trans = tl.dot(
+                tl.trans(k), dqk_trans,
+                attrs=_HSTU_ATTRS_DQ_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+            )
             dk = tl.dot(
-                dqk_trans,
-                q,
-                dk,
-                allow_tf32=ALLOW_TF32,
-                attrs=_HSTU_ATTRS_DK if WS_ON else None,
+                dqk_trans, q, dk, allow_tf32=ALLOW_TF32,
+                attrs=_HSTU_ATTRS_DK_SHARED_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
             )
-        dq_trans = dq_trans * alpha
+        else:
+            dqk_trans = dqk_trans.to(k.dtype)
+            dq_trans = tl.dot(
+                tl.trans(k), dqk_trans,
+                attrs=_HSTU_ATTRS_DQ if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+            )
+            if SHARED_KV:
+                dk_attn = tl.dot(
+                    dqk_trans, q, allow_tf32=ALLOW_TF32,
+                    attrs=_HSTU_ATTRS_DK if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+                )
+                dk = dk + dk_attn * alpha
+            else:
+                dk = tl.dot(
+                    dqk_trans, q, dk, allow_tf32=ALLOW_TF32,
+                    attrs=_HSTU_ATTRS_DK if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+                )
+            dq_trans = dq_trans * alpha
         dq = tl.trans(dq_trans)
         desc_dq.store(
             [q_offset.to(tl.int32), DimQ * off_h],
@@ -3225,6 +3767,255 @@ def _hstu_attn_bwd_inner(  # noqa C901
         desc_dk.store([kv_offset, DimQ * off_h_kv], dk.to(desc_dk.dtype))
 
 
+@triton.jit
+def _hstu_attn_bwd_inner_2kv(  # noqa C901
+    start_n,
+    seq_start_kv,
+    seq_len_kv,
+    seq_start_q,
+    seq_len_q,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_do,
+    desc_dk,
+    desc_dq,
+    DV,
+    stride_qh,
+    stride_kh,
+    stride_vh,
+    stride_doh,
+    stride_dvn,
+    stride_dvh,
+    alpha,
+    attn_scale,
+    M,
+    Delta,
+    stride_mm,
+    off_h,
+    off_h_kv,
+    H_kv,
+    uih_len_q,
+    num_softmax_heads: tl.constexpr,
+    DimQ: tl.constexpr,
+    DimV: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    GQA_ATOMIC_ADD: tl.constexpr,
+    SHARED_KV: tl.constexpr,
+    MASK_KV: tl.constexpr,
+    HAS_CAUSAL: tl.constexpr,
+    # pyrefly: ignore [bad-function-definition]
+    AUTOWS: tl.constexpr = False,
+    WS_ON: tl.constexpr = False,
+    # Rank of the list-schedule variant to apply to the inner (start_m) loop.
+    # Swept by @triton.autotune when TRITON_USE_LIST_SCHEDULE=1; ignored
+    # otherwise. Only the inner loop is autotuned (outer keeps one schedule).
+    # pyrefly: ignore [bad-function-definition]
+    INNER_PICK: tl.constexpr = 0,
+):
+    """MANUAL 2-KV-block fork of `_hstu_attn_bwd_inner`.
+
+    Processes TWO KV blocks per call -- block b0 at `start_n` and block b1 at
+    `start_n + BLOCK_N` -- so a single program does the 2-way KV parallelism the
+    compiler DP pass would otherwise synthesize, but written out explicitly in
+    Triton so that pass never runs. SHARED_KV + compute-fold ONLY.
+    """
+    tl.static_assert(SHARED_KV, "_hstu_attn_bwd_inner_2kv is SHARED_KV only")
+    tl.static_assert(ATTN_SCALE_TYPE == "scalar")
+
+    kv_offset0 = (seq_start_kv + start_n).to(tl.int32)
+    kv_offset1 = (seq_start_kv + start_n + BLOCK_N).to(tl.int32)
+    k0 = desc_k.load([kv_offset0, off_h_kv * stride_kh])
+    k1 = desc_k.load([kv_offset1, off_h_kv * stride_kh])
+    # shared-KV: v aliases k.
+    v0 = k0
+    v1 = k1
+
+    dk0 = tl.zeros([BLOCK_N, DimQ], dtype=tl.float32)
+    dk1 = tl.zeros([BLOCK_N, DimQ], dtype=tl.float32)
+
+    scale = tl.load(attn_scale).to(tl.float32)
+
+    M_off, Delta_off = backward_common_preprocess(
+        M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
+    )
+
+    offs_n0 = start_n + tl.arange(0, BLOCK_N)
+    offs_n1 = start_n + BLOCK_N + tl.arange(0, BLOCK_N)
+    if num_softmax_heads > 0:
+        scaled_alpha = alpha * 1.44269504
+    else:
+        scaled_alpha = alpha
+    if HAS_CAUSAL:
+        low_q = max(0, start_n + uih_len_q - seq_len_kv)
+    else:
+        low_q = 0
+
+    # warp_specialize is OFF for the 2-KV inner loop. WS produces an incorrect
+    # dq here (rel-L2 ~89): the two-block shared dq accumulator is written in the
+    # gemm partition but loaded/stored (store_reduce="add") in the reduction
+    # partition, and that cross-partition gemm->reduction handoff over-counts dq.
+    # This is independent of MMA placement (all dq dots already co-locate in the
+    # gemm partition) -- see T279388065. Until that handoff is fixed, run the
+    # 2-KV inner loop unspecialized (correct via the non-WS fallback).
+    #
+    # NOTE: previously WS was effectively suppressed here by the warp budget
+    # (18/16); the accumulator-chain dpFactor collapse now fits the budget
+    # (14/16), so WS would fire and expose the dq bug -- hence the explicit OFF.
+    #
+    # merge_epilogue is also OFF (unlike the single-KV inner): folding the dq
+    # epilogue store into the computation partition duplicates/misplaces the
+    # store for the shared dq accumulator, over-counting dq.
+    #
+    # num_stages=1: software pipelining the two-block loop (num_stages>=2) trips
+    # the pipeliner ("local_alloc can't predicate") on the doubled operand
+    # allocs, so the loop pipeline depth is pinned to 1 regardless of num_stages.
+    for start_m in tl.range(
+        low_q, seq_len_q, BLOCK_M, num_stages=1,
+        warp_specialize=WS_ON, merge_epilogue=False,
+    ):
+        offs_m = start_m + tl.arange(0, BLOCK_M)
+        mask_m = offs_m < seq_len_q
+        q_offset = seq_start_q + start_m
+        # q/do are loaded ONCE and shared by both KV blocks.
+        q = desc_q.load([q_offset.to(tl.int32), off_h * stride_qh])
+        do = desc_do.load([q_offset.to(tl.int32), off_h * stride_doh])
+
+        # ---- KV block b0 (SHARED_KV + compute fold) ----
+        qk_trans0 = tl.dot(
+            k0, tl.trans(q),
+            attrs=_HSTU_ATTRS_QKT_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+        )
+
+        ######### computation/activation for P0
+        if MASK_KV or HAS_CAUSAL:
+            valid_mask_trans0 = backward_valid_mask(
+                offs_m, offs_n0, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL
+            )
+        else:
+            valid_mask_trans0 = offs_m[None, :] < seq_len_q
+        if num_softmax_heads > 0:
+            qk_trans0, act_qk_trans0, pT0 = (
+                backward_softmax_activation_scaled_alpha(
+                    qk_trans0, scaled_alpha, valid_mask_trans0, M_off, offs_m,
+                    stride_mm, mask_m, k0,
+                )
+            )
+        else:
+            qk_trans0, act_qk_trans0, pT0 = backward_silu_activation(
+                qk_trans0, alpha, valid_mask_trans0, k0.dtype, scale
+            )
+        dact_qk_trans0 = tl.dot(
+            v0, tl.trans(do), allow_tf32=ALLOW_TF32,
+            attrs=_HSTU_ATTRS_DPT_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+        )
+        if num_softmax_heads > 0:
+            dqk_trans0 = backward_d_softmax_activation(
+                dact_qk_trans0, Delta_off, offs_m, stride_mm, mask_m, pT0
+            )
+        else:
+            dqk_trans0 = backward_d_silu_activation(
+                dact_qk_trans0, pT0, qk_trans0, scale, valid_mask_trans0
+            )
+        ######### computation/activation for P1
+        # ---- KV block b1 (SHARED_KV + compute fold) ----
+        # WS on: b1 uses DISJOINT buffer.ids (_B1) so its concurrently-live
+        # tiles never alias b0's (which stays on _2KV).
+        qk_trans1 = tl.dot(
+            k1, tl.trans(q),
+            attrs=_HSTU_ATTRS_QKT_2KV_B1 if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+        )
+        if MASK_KV or HAS_CAUSAL:
+            valid_mask_trans1 = backward_valid_mask(
+                offs_m, offs_n1, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL
+            )
+        else:
+            valid_mask_trans1 = offs_m[None, :] < seq_len_q
+        # calculate pT
+        if num_softmax_heads > 0:
+            qk_trans1, act_qk_trans1, pT1 = (
+                backward_softmax_activation_scaled_alpha(
+                    qk_trans1, scaled_alpha, valid_mask_trans1, M_off, offs_m,
+                    stride_mm, mask_m, k1,
+                )
+            )
+        else:
+            qk_trans1, act_qk_trans1, pT1 = backward_silu_activation(
+                qk_trans1, alpha, valid_mask_trans1, k1.dtype, scale
+            )
+        dact_qk_trans1 = tl.dot(
+            v1, tl.trans(do), allow_tf32=ALLOW_TF32,
+            attrs=_HSTU_ATTRS_DPT_2KV_B1 if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+        )
+        # calculate dqk_trans
+        if num_softmax_heads > 0:
+            dqk_trans1 = backward_d_softmax_activation(
+                dact_qk_trans1, Delta_off, offs_m, stride_mm, mask_m, pT1
+            )
+        else:
+            dqk_trans1 = backward_d_silu_activation(
+                dact_qk_trans1, pT1, qk_trans1, scale, valid_mask_trans1
+            )
+
+        # compute fold: pre-scale alpha into dqk so both dq and dk_attn carry it.
+        dqk_trans0 = (dqk_trans0 * alpha).to(k0.dtype)
+        # dq is a SINGLE accumulator over both KV blocks: b0 fresh-writes it, b1
+        # accumulates into the same TMEM tile (opndD id 11) below. This avoids a
+        # cross-partition register sum (dq0 and dq1 land in different warp
+        # partitions under WS) and a two-store race, and needs one TMEM tile.
+        dq_trans = tl.dot(
+            tl.trans(k0), dqk_trans0,
+            attrs=_HSTU_ATTRS_DQ_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+        )
+        # dv fold: accumulate dv into the shared dk accumulator.
+        dk0 = tl.dot(
+            act_qk_trans0, do, dk0, allow_tf32=ALLOW_TF32,
+            attrs=_HSTU_ATTRS_DV_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+        )
+        dk0 = tl.dot(
+            dqk_trans0, q, dk0, allow_tf32=ALLOW_TF32,
+            attrs=_HSTU_ATTRS_DK_SHARED_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+        )
+
+        # ---- KV block b1 (SHARED_KV + compute fold) ----
+        # WS on: b1 uses DISJOINT buffer.ids (_B1) so its concurrently-live
+        # tiles never alias b0's (which stays on _2KV).
+        dqk_trans1 = (dqk_trans1 * alpha).to(k1.dtype)
+        # Accumulate b1's dq into the SAME dq_trans TMEM tile (opndD id 11 via
+        # _B1), reducing both KV blocks' contributions in TMEM.
+        dq_trans = tl.dot(
+            tl.trans(k1), dqk_trans1, dq_trans,
+            attrs=_HSTU_ATTRS_DQ_2KV_B1 if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+        )
+        dk1 = tl.dot(
+            act_qk_trans1, do, dk1, allow_tf32=ALLOW_TF32,
+            attrs=_HSTU_ATTRS_DV_2KV_B1 if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+        )
+        dk1 = tl.dot(
+            dqk_trans1, q, dk1, allow_tf32=ALLOW_TF32,
+            attrs=_HSTU_ATTRS_DK_SHARED_2KV_B1 if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+        )
+
+        # ONE store per Q: dq_trans already holds b0+b1.
+        dq = tl.trans(dq_trans)
+        desc_dq.store(
+            [q_offset.to(tl.int32), DimQ * off_h],
+            dq.to(desc_dq.dtype),
+            store_reduce="add",
+        )
+
+    # No dv store (shared-KV: dv folded into dk). alpha already folded into dk.
+    if GQA_ATOMIC_ADD:
+        desc_dk.atomic_add([kv_offset0, DimQ * off_h_kv], dk0.to(desc_dk.dtype))
+        desc_dk.atomic_add([kv_offset1, DimQ * off_h_kv], dk1.to(desc_dk.dtype))
+    else:
+        desc_dk.store([kv_offset0, DimQ * off_h_kv], dk0.to(desc_dk.dtype))
+        desc_dk.store([kv_offset1, DimQ * off_h_kv], dk1.to(desc_dk.dtype))
+
+
 @maybe_register_custom_op("hammer::triton_hstu_cross_attn_v3_fwd", mutates_args=())
 def triton_hstu_cross_attn_v3_fwd(
     max_seq_len: int,
@@ -3244,7 +4035,12 @@ def triton_hstu_cross_attn_v3_fwd(
     num_targets: Optional[torch.Tensor] = None,
     causal: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, int]:
-    enable_tma = (enable_tma and HAS_TENSOR_DESCRIPTOR and is_sm90_plus() and not torch.version.hip)
+    enable_tma = (
+        enable_tma
+        and HAS_TENSOR_DESCRIPTOR
+        and is_sm90_plus()
+        and not torch.version.hip
+    )
     q = switch_to_contiguous_if_needed(q)
     k = switch_to_contiguous_if_needed(k)
     v = switch_to_contiguous_if_needed(v)
@@ -3396,9 +4192,14 @@ def triton_hstu_cross_attn_v3_bwd(
     bwd_variant = get_bwd_variant()
     if (bwd_variant == BwdVariant.AUTO) and (max_q_len < 128):
         bwd_variant = BwdVariant.TRITON_REDKV
-    use_per_kv_head = (bwd_variant in (BwdVariant.AUTO, BwdVariant.TRITON_REDKV) and G > 1
-                       and (max_q_len < 192 or (num_softmax_heads == 0 and max_q_len <= 256)))
-    use_redq_per_kv_head = (bwd_variant in (BwdVariant.TRITON_REDQ, BwdVariant.TRITON_AUTOWS) and G > 1)
+    use_per_kv_head = (
+        bwd_variant in (BwdVariant.AUTO, BwdVariant.TRITON_REDKV)
+        and G > 1
+        and (max_q_len < 192 or (num_softmax_heads == 0 and max_q_len <= 256))
+    )
+    use_redq_per_kv_head = (
+        bwd_variant in (BwdVariant.TRITON_REDQ, BwdVariant.TRITON_AUTOWS) and G > 1
+    )
     if use_per_kv_head:
         dq_dtype = q.dtype
         dkdv_dtype = k.dtype
@@ -3457,7 +4258,7 @@ def triton_hstu_cross_attn_v3_bwd(
     if use_per_kv_head or bwd_variant == BwdVariant.TRITON_REDKV:
         if use_per_kv_head:
             H_kv = H // G
-            grid = lambda meta: (Z * H_kv, )  # noqa E731
+            grid = lambda meta: (Z * H_kv,)  # noqa E731
         else:
             grid = lambda meta: (  # noqa E731
                 triton.cdiv(max_q_len, meta["BLOCK_M"]),
@@ -3518,7 +4319,7 @@ def triton_hstu_cross_attn_v3_bwd(
     elif bwd_variant in (BwdVariant.TRITON_REDQ, BwdVariant.TRITON_AUTOWS):
         if use_redq_per_kv_head:
             H_kv = H // G
-            grid = lambda meta: (Z * H_kv, )  # noqa E731
+            grid = lambda meta: (Z * H_kv,)  # noqa E731
         else:
             grid = lambda meta: (Z * H, 1)  # noqa E731
         _hstu_attn_bwd_redq[grid](
@@ -3573,7 +4374,71 @@ def triton_hstu_cross_attn_v3_bwd(
             AUTOWS=(bwd_variant == BwdVariant.TRITON_AUTOWS),
             # WS_ON == AUTOWS normally; set HSTU_AUTOWS_WS_OFF=1 to run the autoWS
             # loop STRUCTURE with warp specialization DISABLED (isolation reference).
-            WS_ON=((bwd_variant == BwdVariant.TRITON_AUTOWS) and os.environ.get("HSTU_AUTOWS_WS_OFF", "0") != "1"),
+            WS_ON=(
+                (bwd_variant == BwdVariant.TRITON_AUTOWS)
+                and os.environ.get("HSTU_AUTOWS_WS_OFF", "0") != "1"
+            ),
+        )
+    elif bwd_variant == BwdVariant.TRITON_AUTOWS_2KV:
+        # MANUAL 2-KV-block data-partition variant. Shared-KV only; G == 1
+        # (self-attn) so no per-kv-head atomic path is needed.
+        assert shared_kv, "BwdVariant.TRITON_AUTOWS_2KV requires shared_kv"
+        assert G == 1, "BwdVariant.TRITON_AUTOWS_2KV requires G == 1"
+        grid = lambda meta: (Z * H, 1)  # noqa E731
+        _hstu_attn_bwd_redq_2kv[grid](
+            Q=q,
+            K=k,
+            V=v,
+            DO=dout,
+            total_seq_len_q=total_seq_len_q,
+            total_seq_len_kv=total_seq_len_kv,
+            seq_offsets=seq_offsets,
+            seq_offsets_q=seq_offsets_q,
+            DQ=dq,
+            DK=dk,
+            DV=dv,
+            stride_qm=q.stride(0),
+            stride_qh=q.stride(1),
+            stride_kn=k.stride(0),
+            stride_kh=k.stride(1),
+            stride_vn=v.stride(0),
+            stride_vh=v.stride(1),
+            stride_dom=dout.stride(0),
+            stride_doh=dout.stride(1),
+            stride_dqm=dq.stride(0),
+            stride_dqh=dq.stride(1),
+            stride_dkn=dk.stride(0),
+            stride_dkh=dk.stride(1),
+            stride_dvn=dv.stride(0),
+            stride_dvh=dv.stride(1),
+            alpha=alpha,
+            max_seq_len=max_seq_len,
+            attn_scale=attn_scale,
+            M=M,
+            Delta=Delta,
+            stride_mm=stride_mm,
+            num_targets=num_targets,
+            Z=Z,
+            AUTOTUNE_Z=AUTOTUNE_Z,
+            H=H,
+            G=G,
+            num_softmax_heads=num_softmax_heads,
+            max_q_len=next_power_of_2(max_q_len),
+            AUTOTUNE_MAX_SEQ_LEN=autotune_max_seq_len(max_seq_len),
+            DimQ=DimQ,
+            DimV=DimV,
+            ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+            ATTN_SCALE_TYPE=attn_scale_type,
+            SHARED_KV=shared_kv,
+            TRUNCATE_METHOD=truncate_method,
+            HAS_CAUSAL=HAS_CAUSAL,
+            HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+            PER_KV_HEAD=False,
+            # AUTOWS=False keeps the compiler DP pass from ever running; the
+            # manual 2-KV loop + disjoint b0/b1 buffer.ids do the partitioning.
+            AUTOWS=False,
+            # Milestone 2: warp specialization ON.
+            WS_ON=True,
         )
     else:
         grid = lambda meta: (Z * H, 1)  # noqa E731
@@ -3635,7 +4500,6 @@ def triton_hstu_cross_attn_v3_bwd(
 
 
 class AttentionFunction(torch.autograd.Function):
-
     @staticmethod
     # pyre-fixme[14]: `forward` overrides method defined in `Function` inconsistently.
     def forward(
@@ -3663,7 +4527,7 @@ class AttentionFunction(torch.autograd.Function):
             v = switch_to_contiguous_if_needed(v)
         else:
             v = k
-        Z = seq_offsets.numel() - 1  # noqa: F841
+        Z = seq_offsets.numel() - 1
         total_seq_len_q, H, DimQ = q.shape
         _, H_kv, DimV = v.shape
         assert H % H_kv == 0, f"H ({H}) must be divisible by H_kv ({H_kv})"
@@ -3672,7 +4536,12 @@ class AttentionFunction(torch.autograd.Function):
             out = torch.zeros(total_seq_len_q, H, DimV, device=q.device, dtype=q.dtype)
             return out
 
-        if (G > 1 and H_kv == 1 and (num_softmax_heads == 0 or num_softmax_heads == H) and not causal):
+        if (
+            G > 1
+            and H_kv == 1
+            and (num_softmax_heads == 0 or num_softmax_heads == H)
+            and not causal
+        ):
             # GQA can not enabled with causal masking
             seq_offsets_q = seq_offsets_q * G
             max_q_len = max_q_len * G
@@ -3735,28 +4604,33 @@ class AttentionFunction(torch.autograd.Function):
     def backward(
         ctx, dout: torch.Tensor
     ) -> Tuple[
-            None,
-            None,
-            torch.Tensor,
-            torch.Tensor,
-            Optional[torch.Tensor],
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
+        None,
+        None,
+        torch.Tensor,
+        torch.Tensor,
+        Optional[torch.Tensor],
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
     ]:
         saved_tensors = ctx.saved_tensors
         q, k, v, seq_offsets, attn_scale, seq_offsets_q = saved_tensors[:6]
         idx = 6
         num_softmax_heads = ctx.num_softmax_heads
         # Reshape dout from [T, H, DimV] to folded [T*G, H_kv, DimV]
-        if (ctx.H > 1 and ctx.H_kv == 1 and (num_softmax_heads == 0 or num_softmax_heads == ctx.H) and not ctx.causal):
+        if (
+            ctx.H > 1
+            and ctx.H_kv == 1
+            and (num_softmax_heads == 0 or num_softmax_heads == ctx.H)
+            and not ctx.causal
+        ):
             dout = dout.view(ctx.total_seq_len_q * ctx.H, -1, dout.shape[-1])
         if num_softmax_heads > 0:
             M = saved_tensors[idx]
@@ -3766,7 +4640,12 @@ class AttentionFunction(torch.autograd.Function):
             Delta = torch.empty_like(M)
             pre_grid = (triton.cdiv(out.shape[0], 128), num_softmax_heads)
             _attn_bwd_preprocess[pre_grid](
-                out, dout, Delta, out.shape[0], H=out.shape[1], softmax_heads=num_softmax_heads,
+                out,
+                dout,
+                Delta,
+                out.shape[0],
+                H=out.shape[1],
+                softmax_heads=num_softmax_heads,
                 BLOCK_M=128,  # pyre-ignore [6]
                 HEAD_DIM=out.shape[2],  # pyre-ignore [6]
             )
@@ -3787,7 +4666,9 @@ class AttentionFunction(torch.autograd.Function):
             from tlx_bw_cross_attention import tlx_bw_reduce_dq
 
             use_2kv = get_bwd_variant() == BwdVariant.TLX_2KV
-            assert not use_2kv or ctx.shared_kv, ("BwdVariant.TLX_2KV (attn_bwd_ws_2kv) requires shared_kv")
+            assert not use_2kv or ctx.shared_kv, (
+                "BwdVariant.TLX_2KV (attn_bwd_ws_2kv) requires shared_kv"
+            )
             out_t = out if num_softmax_heads > 0 else None
             M_t = M if num_softmax_heads > 0 else None
             dq, dk, dv = tlx_bw_reduce_dq(
@@ -3928,3 +4809,7 @@ def triton_bw_hstu_mha_wrapper(
         actual_max_seq_len=actual_max_seq_len,
         truncate_method=truncate_method,
     )
+
+
+
+


### PR DESCRIPTION
Summary:
When a kernel chains two accumulating dots into one value (e.g. the HSTU
reduce_dq compute fold: dk = dot(a0, b0, dk); dk = dot(a1, b1, dk)),
AccelerateMatmul lowers each dot into its own tmem_alloc / tc_gen5_mma /
tmem_load and threads the accumulator through registers, so the second dot's
TMEM tile is initialized from the first dot's TMEM read-out. HoistTMEMAlloc then
turns that register hand-off into a TMEM<->TMEM load/store bridge across two
persistent tiles, and the two co-live tiles end up sharing one buffer.id -- an
unorderable TMEM reuse group that makes WSCodePartition abort.

Add a ChainAccumulatorInPlace rewrite that recognizes this shape and points the
second MMA (and its read-out) at the first MMA's tile, accumulating in place with
use_acc=true, then deletes the intermediate tile and read-out. This matches the
TLX single-tile accumulation shape and removes the reuse-group blocker
end-to-end. The rewrite is tightly gated (single-use, layout-preserving init
chain; identical tile type; no intervening access to the first tile; constant
use_acc on the second MMA), so it is a no-op for unrelated kernels.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D110910650


