### PR TITLE
[AutoWS][PSM] Group accumulator-chained MMAs into one data partition (#2019)

### DIFF
--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-shared-accumulator-dp.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-shared-accumulator-dp.mlir
@@ -1,0 +1,238 @@
+// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta | FileCheck %s
+
+// Test for the accumulator-chain data-partition grouping.
+//
+// This HSTU cross-attention backward reduce_dq kernel processes two KV blocks
+// per program. Both blocks' dq dots accumulate into ONE shared tensor-memory
+// tile (the dq accumulator, encoding #tmem1): b0 fresh-writes it, b1 adds into
+// it (use_acc). Data-partition detection used to treat the two blocks as
+// independent groups (dpFactor=2) purely from their disjoint compute slices,
+// and split their compute into two computation partitions -- inflating the
+// partition count and warp budget (18/16, over budget) even though the two
+// streams converge on a single serialized reduction and gain no real
+// parallelism.
+//
+// The accumulator-chain grouping unions MMAs that write the same accumulator
+// buffer, so the two streams are recognized as one data-partition group
+// (dpFactor collapses to 1). The compute merges into a single computation
+// partition, the budget fits (14/16), and every MMA -- including both dq dots
+// -- shares the gemm partition. (This is a partition-count/budget lever; it is
+// NOT a correctness fix for the separate gemm->reduction dq store-reduce
+// handoff bug tracked in T279388065.)
+
+// CHECK-LABEL: @_hstu_attn_bwd_redq_2kv
+// Both dq MMAs (accumulator memdesc #tmem1) share the same partition:
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[DQP:[0-9]+]]>{{.*}}memdesc<128x64xf32, #tmem1
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[DQP]]>{{.*}}memdesc<128x64xf32, #tmem1
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 32]], warp = [[16, 0], [32, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 64]], warp = [[16, 0], [32, 0]], block = []}>
+#linear3 = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 64, colStride = 1>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+#tmem2 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @_hstu_attn_bwd_redq_2kv(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: !tt.ptr<i64> {tt.divisibility = 16 : i32}, %arg7: !tt.ptr<i64> {tt.divisibility = 16 : i32}, %arg8: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg9: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg10: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}, %arg14: i32 {tt.divisibility = 16 : i32}, %arg15: i32 {tt.divisibility = 16 : i32}, %arg16: i32 {tt.divisibility = 16 : i32}, %arg17: i32 {tt.divisibility = 16 : i32}, %arg18: i32 {tt.divisibility = 16 : i32}, %arg19: i32 {tt.divisibility = 16 : i32}, %arg20: i32 {tt.divisibility = 16 : i32}, %arg21: i32 {tt.divisibility = 16 : i32}, %arg22: i32 {tt.divisibility = 16 : i32}, %arg23: i32 {tt.divisibility = 16 : i32}, %arg24: i32 {tt.divisibility = 16 : i32}, %arg25: f32, %arg26: i32 {tt.divisibility = 16 : i32}, %arg27: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg28: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg29: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg30: i32, %arg31: i32, %arg32: i32, %arg33: i32, %arg34: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant false
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #linear>
+    %true = arith.constant true
+    %c1_i32 = arith.constant 1 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c63_i32 = arith.constant 63 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %cst_0 = arith.constant 1.44269502 : f32
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #linear1>
+    %cst_2 = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #linear2>
+    %0 = tt.get_program_id x : i32
+    %1 = arith.divsi %0, %arg33 : i32
+    %2 = arith.remsi %0, %arg33 : i32
+    %3 = tt.addptr %arg6, %1 : !tt.ptr<i64>, i32
+    %4 = tt.load %3 : !tt.ptr<i64>
+    %5 = arith.trunci %4 : i64 to i32
+    %6 = tt.addptr %3, %c1_i32 : !tt.ptr<i64>, i32
+    %7 = tt.load %6 : !tt.ptr<i64>
+    %8 = arith.trunci %7 : i64 to i32
+    %9 = arith.subi %8, %5 : i32
+    %10 = tt.addptr %arg7, %1 : !tt.ptr<i64>, i32
+    %11 = tt.load %10 : !tt.ptr<i64>
+    %12 = arith.trunci %11 : i64 to i32
+    %13 = tt.addptr %10, %c1_i32 : !tt.ptr<i64>, i32
+    %14 = tt.load %13 : !tt.ptr<i64>
+    %15 = arith.trunci %14 : i64 to i32
+    %16 = arith.subi %15, %12 : i32
+    %17 = arith.cmpi eq, %9, %c0_i32 : i32
+    cf.cond_br %17, ^bb1, ^bb2
+  ^bb1:  // pred: ^bb0
+    tt.return
+  ^bb2:  // pred: ^bb0
+    %18 = arith.muli %arg33, %c128_i32 : i32
+    %19 = arith.extsi %18 : i32 to i64
+    %20 = tt.make_tensor_descriptor %arg0, [%arg4, %18], [%19, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<64x128xbf16, #shared>>
+    %21 = tt.make_tensor_descriptor %arg1, [%arg5, %18], [%19, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<64x128xbf16, #shared>>
+    %22 = tt.make_tensor_descriptor %arg3, [%arg4, %18], [%19, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<64x128xbf16, #shared>>
+    %23 = tt.make_tensor_descriptor %arg9, [%8, %18], [%19, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<tensor<64x128xbf16, #shared>>
+    %24 = tt.make_tensor_descriptor %arg8, [%15, %18], [%19, %c1_i64] : !tt.ptr<f32>, !tt.tensordesc<tensor<64x128xf32, #shared1>>
+    %25 = arith.addi %9, %c63_i32 : i32
+    %26 = arith.divsi %25, %c64_i32 : i32
+    %27 = arith.addi %26, %c1_i32 : i32
+    %28 = arith.divsi %27, %c2_i32 : i32
+    %29 = arith.muli %28, %c128_i32 : i32
+    %30 = arith.muli %2, %arg14 : i32
+    %31 = arith.cmpi slt, %2, %c2_i32 : i32
+    %32:2 = scf.if %31 -> (!tt.ptr<f32>, !tt.ptr<f32>) {
+      %48 = tt.addptr %arg28, %2 : !tt.ptr<f32>, i32
+      %49 = arith.muli %12, %arg30 : i32
+      %50 = tt.addptr %48, %49 : !tt.ptr<f32>, i32
+      %51 = tt.addptr %arg29, %2 : !tt.ptr<f32>, i32
+      %52 = tt.addptr %51, %49 : !tt.ptr<f32>, i32
+      scf.yield %52, %50 : !tt.ptr<f32>, !tt.ptr<f32>
+    } else {
+      scf.yield %arg29, %arg28 : !tt.ptr<f32>, !tt.ptr<f32>
+    }
+    %33 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #linear1}>>
+    %34 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #linear1}>>
+    %35 = arith.mulf %arg25, %cst_0 : f32
+    %36 = tt.splat %16 : i32 -> tensor<64xi32, #ttg.slice<{dim = 0, parent = #linear1}>>
+    %37 = arith.muli %2, %arg12 : i32
+    %38 = arith.muli %2, %arg18 : i32
+    %39 = tt.splat %16 : i32 -> tensor<1x64xi32, #linear1>
+    %40 = tt.splat %9 : i32 -> tensor<64x1xi32, #linear1>
+    %41 = tt.splat %35 : f32 -> tensor<64x64xf32, #linear1>
+    %42 = tt.splat %arg30 : i32 -> tensor<64xi32, #ttg.slice<{dim = 0, parent = #linear1}>>
+    %43 = tt.splat %32#1 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #linear1}>>
+    %44 = tt.splat %32#0 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #linear1}>>
+    %45 = tt.splat %arg25 : f32 -> tensor<64x64xf32, #linear1>
+    %46 = arith.muli %2, %c128_i32 : i32
+    %47 = arith.muli %2, %c128_i32 : i32
+    scf.for %arg35 = %c0_i32 to %29 step %c128_i32  : i32 {
+      %48 = arith.addi %5, %arg35 : i32
+      %49 = arith.addi %48, %c64_i32 : i32
+      %50 = tt.descriptor_load %21[%48, %30] : !tt.tensordesc<tensor<64x128xbf16, #shared>> -> tensor<64x128xbf16, #blocked>
+      %51 = ttg.local_alloc %50 : (tensor<64x128xbf16, #blocked>) -> !ttg.memdesc<64x128xbf16, #shared, #smem>
+      %52 = tt.descriptor_load %21[%49, %30] : !tt.tensordesc<tensor<64x128xbf16, #shared>> -> tensor<64x128xbf16, #blocked>
+      %53 = ttg.local_alloc %52 : (tensor<64x128xbf16, #blocked>) -> !ttg.memdesc<64x128xbf16, #shared, #smem>
+      %54 = tt.splat %arg35 : i32 -> tensor<64xi32, #ttg.slice<{dim = 1, parent = #linear1}>>
+      %55 = arith.addi %54, %34 : tensor<64xi32, #ttg.slice<{dim = 1, parent = #linear1}>>
+      %56 = arith.addi %arg35, %c64_i32 : i32
+      %57 = tt.splat %56 : i32 -> tensor<64xi32, #ttg.slice<{dim = 1, parent = #linear1}>>
+      %58 = arith.addi %57, %34 : tensor<64xi32, #ttg.slice<{dim = 1, parent = #linear1}>>
+      %59 = tt.expand_dims %55 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #linear1}>> -> tensor<64x1xi32, #linear1>
+      %60 = arith.cmpi slt, %59, %40 : tensor<64x1xi32, #linear1>
+      %61 = tt.broadcast %60 : tensor<64x1xi1, #linear1> -> tensor<64x64xi1, #linear1>
+      %62 = tt.expand_dims %58 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #linear1}>> -> tensor<64x1xi32, #linear1>
+      %63 = arith.cmpi slt, %62, %40 : tensor<64x1xi32, #linear1>
+      %64 = tt.broadcast %63 : tensor<64x1xi1, #linear1> -> tensor<64x64xi1, #linear1>
+      %65 = ttg.memdesc_trans %51 {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xbf16, #shared, #smem> -> !ttg.memdesc<128x64xbf16, #shared2, #smem>
+      %66 = ttg.memdesc_trans %53 {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xbf16, #shared, #smem> -> !ttg.memdesc<128x64xbf16, #shared2, #smem>
+      %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %result_3, %token_4 = ttng.tmem_alloc : () -> (!ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %result_5, %token_6 = ttng.tmem_alloc : () -> (!ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %result_7, %token_8 = ttng.tmem_alloc : () -> (!ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %result_9, %token_10 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %result_11, %token_12 = ttng.tmem_alloc : () -> (!ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %result_13, %token_14 = ttng.tmem_alloc : () -> (!ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %67 = ttng.tmem_store %cst_2, %result_13[%token_14], %true : tensor<64x128xf32, #linear2> -> !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>
+      %68 = ttng.tmem_store %cst_2, %result_11[%token_12], %true : tensor<64x128xf32, #linear2> -> !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>
+      %69:8 = scf.for %arg36 = %c0_i32 to %16 step %c64_i32 iter_args(%arg37 = %false, %arg38 = %token, %arg39 = %token_4, %arg40 = %token_6, %arg41 = %token_8, %arg42 = %token_10, %arg43 = %68, %arg44 = %67) -> (i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+        %78 = tt.splat %arg36 : i32 -> tensor<64xi32, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %79 = arith.addi %78, %33 : tensor<64xi32, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %80 = arith.cmpi slt, %79, %36 : tensor<64xi32, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %81 = arith.addi %12, %arg36 : i32
+        %82 = tt.descriptor_load %20[%81, %37] : !tt.tensordesc<tensor<64x128xbf16, #shared>> -> tensor<64x128xbf16, #blocked>
+        %83 = ttg.local_alloc %82 : (tensor<64x128xbf16, #blocked>) -> !ttg.memdesc<64x128xbf16, #shared, #smem>
+        %84 = tt.descriptor_load %22[%81, %38] : !tt.tensordesc<tensor<64x128xbf16, #shared>> -> tensor<64x128xbf16, #blocked>
+        %85 = ttg.local_alloc %84 : (tensor<64x128xbf16, #blocked>) -> !ttg.memdesc<64x128xbf16, #shared, #smem>
+        %86 = ttg.memdesc_trans %83 {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xbf16, #shared, #smem> -> !ttg.memdesc<128x64xbf16, #shared2, #smem>
+        %87 = ttng.tc_gen5_mma %51, %86, %result[%arg38], %false, %true {tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndD,tmem,1,2\22]}"} : !ttg.memdesc<64x128xbf16, #shared, #smem>, !ttg.memdesc<128x64xbf16, #shared2, #smem>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+        %88 = tt.expand_dims %79 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x64xi32, #linear1>
+        %89 = arith.cmpi slt, %88, %39 : tensor<1x64xi32, #linear1>
+        %90 = tt.broadcast %89 : tensor<1x64xi1, #linear1> -> tensor<64x64xi1, #linear1>
+        %91 = arith.andi %90, %61 : tensor<64x64xi1, #linear1>
+        %result_19, %token_20 = ttng.tmem_load %result[%87] : !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x64xf32, #linear1>
+        %92 = arith.mulf %result_19, %41 : tensor<64x64xf32, #linear1>
+        %93 = arith.muli %79, %42 : tensor<64xi32, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %94 = tt.addptr %43, %93 : tensor<64x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #linear1}>>, tensor<64xi32, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %95 = tt.load %94, %80 : tensor<64x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %96 = tt.expand_dims %95 {axis = 0 : i32} : tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x64xf32, #linear1>
+        %97 = tt.broadcast %96 : tensor<1x64xf32, #linear1> -> tensor<64x64xf32, #linear1>
+        %98 = tt.load %94, %80 : tensor<64x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %99 = tt.expand_dims %98 {axis = 0 : i32} : tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x64xf32, #linear1>
+        %100 = tt.broadcast %99 : tensor<1x64xf32, #linear1> -> tensor<64x64xf32, #linear1>
+        %101 = arith.subf %92, %100 : tensor<64x64xf32, #linear1>
+        %102 = math.exp2 %101 : tensor<64x64xf32, #linear1>
+        %103 = arith.select %91, %102, %cst_1 : tensor<64x64xi1, #linear1>, tensor<64x64xf32, #linear1>
+        %104 = arith.truncf %103 : tensor<64x64xf32, #linear1> to tensor<64x64xbf16, #linear1>
+        %result_21 = ttng.tmem_alloc %104 : (tensor<64x64xbf16, #linear1>) -> !ttg.memdesc<64x64xbf16, #tmem, #ttng.tensor_memory>
+        %105 = ttg.memdesc_trans %85 {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xbf16, #shared, #smem> -> !ttg.memdesc<128x64xbf16, #shared2, #smem>
+        %106 = ttng.tc_gen5_mma %51, %105, %result_3[%arg39], %false, %true {tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndD,tmem,1,5\22]}"} : !ttg.memdesc<64x128xbf16, #shared, #smem>, !ttg.memdesc<128x64xbf16, #shared2, #smem>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+        %107 = tt.addptr %44, %93 : tensor<64x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #linear1}>>, tensor<64xi32, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %108 = tt.load %107, %80 : tensor<64x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %109 = tt.expand_dims %108 {axis = 0 : i32} : tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x64xf32, #linear1>
+        %110 = tt.broadcast %109 : tensor<1x64xf32, #linear1> -> tensor<64x64xf32, #linear1>
+        %result_22, %token_23 = ttng.tmem_load %result_3[%106] : !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x64xf32, #linear1>
+        %111 = tt.load %107, %80 : tensor<64x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %112 = tt.expand_dims %111 {axis = 0 : i32} : tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x64xf32, #linear1>
+        %113 = tt.broadcast %112 : tensor<1x64xf32, #linear1> -> tensor<64x64xf32, #linear1>
+        %114 = arith.subf %result_22, %113 : tensor<64x64xf32, #linear1>
+        %115 = arith.mulf %103, %114 : tensor<64x64xf32, #linear1>
+        %116 = ttng.tc_gen5_mma %53, %86, %result_5[%arg40], %false, %true {tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndD,tmem,1,12\22]}"} : !ttg.memdesc<64x128xbf16, #shared, #smem>, !ttg.memdesc<128x64xbf16, #shared2, #smem>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+        %117 = arith.andi %90, %64 : tensor<64x64xi1, #linear1>
+        %result_24, %token_25 = ttng.tmem_load %result_5[%116] : !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x64xf32, #linear1>
+        %118 = arith.mulf %result_24, %41 : tensor<64x64xf32, #linear1>
+        %119 = arith.subf %118, %97 : tensor<64x64xf32, #linear1>
+        %120 = math.exp2 %119 : tensor<64x64xf32, #linear1>
+        %121 = arith.select %117, %120, %cst_1 : tensor<64x64xi1, #linear1>, tensor<64x64xf32, #linear1>
+        %122 = arith.truncf %121 : tensor<64x64xf32, #linear1> to tensor<64x64xbf16, #linear1>
+        %result_26 = ttng.tmem_alloc %122 : (tensor<64x64xbf16, #linear1>) -> !ttg.memdesc<64x64xbf16, #tmem, #ttng.tensor_memory>
+        %123 = ttng.tc_gen5_mma %53, %105, %result_7[%arg41], %false, %true {tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndD,tmem,1,15\22]}"} : !ttg.memdesc<64x128xbf16, #shared, #smem>, !ttg.memdesc<128x64xbf16, #shared2, #smem>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+        %result_27, %token_28 = ttng.tmem_load %result_7[%123] : !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<64x64xf32, #linear1>
+        %124 = arith.subf %result_27, %110 : tensor<64x64xf32, #linear1>
+        %125 = arith.mulf %121, %124 : tensor<64x64xf32, #linear1>
+        %126 = arith.mulf %115, %45 : tensor<64x64xf32, #linear1>
+        %127 = arith.truncf %126 : tensor<64x64xf32, #linear1> to tensor<64x64xbf16, #linear1>
+        %128 = ttg.local_alloc %127 : (tensor<64x64xbf16, #linear1>) -> !ttg.memdesc<64x64xbf16, #shared, #smem>
+        %129 = ttng.tmem_store %cst, %result_9[%arg42], %true : tensor<128x64xf32, #linear> -> !ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory, mutable>
+        %130 = ttng.tc_gen5_mma %65, %128, %result_9[%129], %false, %true {tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndB,smem,1,8\22, \22opndD,tmem,1,11\22]}"} : !ttg.memdesc<128x64xbf16, #shared2, #smem>, !ttg.memdesc<64x64xbf16, #shared, #smem>, !ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory, mutable>
+        %131 = ttng.tc_gen5_mma %result_21, %85, %result_11[%arg43], %arg37, %true {tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}"} : !ttg.memdesc<64x64xbf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<64x128xbf16, #shared, #smem>, !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>
+        %132 = ttng.tc_gen5_mma %128, %83, %result_11[%131], %true, %true {tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,7\22]}"} : !ttg.memdesc<64x64xbf16, #shared, #smem>, !ttg.memdesc<64x128xbf16, #shared, #smem>, !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>
+        %133 = arith.mulf %125, %45 : tensor<64x64xf32, #linear1>
+        %134 = arith.truncf %133 : tensor<64x64xf32, #linear1> to tensor<64x64xbf16, #linear1>
+        %135 = ttg.local_alloc %134 : (tensor<64x64xbf16, #linear1>) -> !ttg.memdesc<64x64xbf16, #shared, #smem>
+        %136 = ttng.tc_gen5_mma %66, %135, %result_9[%130], %true, %true {tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndB,smem,1,9\22, \22opndD,tmem,1,11\22]}"} : !ttg.memdesc<128x64xbf16, #shared2, #smem>, !ttg.memdesc<64x64xbf16, #shared, #smem>, !ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory, mutable>
+        %137 = ttng.tc_gen5_mma %result_26, %85, %result_13[%arg44], %arg37, %true {tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,12\22, \22opndD,tmem,1,17\22]}"} : !ttg.memdesc<64x64xbf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<64x128xbf16, #shared, #smem>, !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>
+        %138 = ttng.tc_gen5_mma %135, %83, %result_13[%137], %true, %true {tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,9\22, \22opndD,tmem,1,17\22]}"} : !ttg.memdesc<64x64xbf16, #shared, #smem>, !ttg.memdesc<64x128xbf16, #shared, #smem>, !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>
+        %result_29, %token_30 = ttng.tmem_load %result_9[%136] : !ttg.memdesc<128x64xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #linear>
+        %139 = tt.trans %result_29 {order = array<i32: 1, 0>} : tensor<128x64xf32, #linear> -> tensor<64x128xf32, #linear3>
+        %140 = ttg.convert_layout %139 : tensor<64x128xf32, #linear3> -> tensor<64x128xf32, #blocked1>
+        %141 = ttg.local_alloc %140 : (tensor<64x128xf32, #blocked1>) -> !ttg.memdesc<64x128xf32, #shared1, #smem, mutable>
+        %142 = ttng.async_tma_reduce add, %24[%81, %46] %141 : !tt.tensordesc<tensor<64x128xf32, #shared1>>, !ttg.memdesc<64x128xf32, #shared1, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %142   : !ttg.async.token
+        scf.yield %true, %token_20, %token_23, %token_25, %token_28, %token_30, %132, %138 : i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
+      } {tt.list_schedule_pick = 0 : i32, tt.num_stages = 1 : i32, tt.warp_specialize}
+      %result_15, %token_16 = ttng.tmem_load %result_11[%69#6] : !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear2>
+      %70 = arith.truncf %result_15 : tensor<64x128xf32, #linear2> to tensor<64x128xbf16, #linear2>
+      %71 = ttg.convert_layout %70 : tensor<64x128xbf16, #linear2> -> tensor<64x128xbf16, #blocked>
+      %72 = ttg.local_alloc %71 : (tensor<64x128xbf16, #blocked>) -> !ttg.memdesc<64x128xbf16, #shared, #smem, mutable>
+      %73 = ttng.async_tma_copy_local_to_global %23[%48, %47] %72 : !tt.tensordesc<tensor<64x128xbf16, #shared>>, !ttg.memdesc<64x128xbf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %73   : !ttg.async.token
+      %result_17, %token_18 = ttng.tmem_load %result_13[%69#7] : !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear2>
+      %74 = arith.truncf %result_17 : tensor<64x128xf32, #linear2> to tensor<64x128xbf16, #linear2>
+      %75 = ttg.convert_layout %74 : tensor<64x128xbf16, #linear2> -> tensor<64x128xbf16, #blocked>
+      %76 = ttg.local_alloc %75 : (tensor<64x128xbf16, #blocked>) -> !ttg.memdesc<64x128xbf16, #shared, #smem, mutable>
+      %77 = ttng.async_tma_copy_local_to_global %23[%49, %47] %76 : !tt.tensordesc<tensor<64x128xbf16, #shared>>, !ttg.memdesc<64x128xbf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %77   : !ttg.async.token
+    }
+    tt.return
+  }
+}
+

--- a/test/Hopper/WarpSpecialization/ws_code_partition_chained_accum_channels.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_chained_accum_channels.mlir
@@ -1,0 +1,114 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=1 post-channel-creation=1" | FileCheck %s
+
+// Simplified (no-attention) audit of the chained operand-D accumulator channel
+// behavior in handleOperandD (T278685041). Two MMAv5 ops write the SAME tmem
+// accumulator in one loop (acc = A@B; acc += C@D). Both are in the gemm
+// partition (task 1); a tmem_load of the accumulator is in the computation
+// partition (task 0). This is the minimal load/mma/store shape (no attention)
+// requested in the D111277168 review, exercising both the "no intermediate" and
+// "with intermediate output" cases and showing the produced channels.
+//
+// How the channel is (not) created between the two MMAs: handleOperandD walks
+// every op whose accumulator IS this tmem tile (each is a D-writer / chain link)
+// and calls needsChannel(producerTask, consumerTask) for consecutive writers.
+// Both dots carry the same async_task_id (gemm, task 1), so needsChannel is
+// false for that pair -> NO MMA->MMA channel; the second dot just extends the
+// producer set (chains in place). A channel is emitted ONLY when the accumulator
+// is read from a DIFFERENT partition, i.e. a tmem_load in the computation
+// partition (task 0) -> a cross-partition MMA->tmem_load channel. So an
+// intermediate read between the dots does not create an MMA->MMA channel; it
+// creates an extra cross-partition read channel (case 2 below).
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared32 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i32} {
+
+// ---- Case 1: chained accumulator, NO intermediate output between the dots ----
+// The two dots share one gemm partition (partition0); the accumulator handoff
+// between them is same-partition, so NO MMA->MMA channel (wait_barrier) is
+// emitted. The only channel is the cross-partition MMA -> tmem_load read into
+// the computation partition (default region: wait_barrier, tmem_load).
+//
+// CHECK-LABEL: @chained_accum_no_intermediate
+// CHECK: ttg.warp_specialize
+// computation partition (default region): waits on the one cross-partition
+// accumulator channel, then reads it.
+// CHECK: ttng.wait_barrier
+// CHECK: ttng.tmem_load
+// gemm partition: both chained dots, with NO wait_barrier (no MMA->MMA channel)
+// between them.
+// CHECK: partition0
+// CHECK: ttng.tc_gen5_mma
+// CHECK-NOT: ttng.wait_barrier
+// CHECK: ttng.tc_gen5_mma
+  tt.func public @chained_accum_no_intermediate(
+      %a: !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>,
+      %b: !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>,
+      %c: !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>,
+      %d: !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>,
+      %o: !ttg.memdesc<128x128xf32, #shared32, #smem, mutable>,
+      %lb: i32, %ub: i32, %step: i32) attributes {noinline = false} {
+    %true = arith.constant {async_task_id = array<i32: 0, 1>} true
+    %false = arith.constant {async_task_id = array<i32: 0, 1>} false
+    %acc, %acc_tok = ttng.tmem_alloc {async_task_id = array<i32: 1>, buffer.copy = 1 : i32, buffer.id = 1 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    scf.for %iv = %lb to %ub step %step iter_args(%tok = %acc_tok) -> (!ttg.async.token) : i32 {
+      // MMA1: use_acc = false -> first producer, overwrites the accumulator.
+      %t1 = ttng.tc_gen5_mma %a, %b, %acc[%tok], %false, %true {async_task_id = array<i32: 1>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      // MMA2: use_acc = true into the SAME acc -> chained; same task -> no channel.
+      %t2 = ttng.tc_gen5_mma %c, %d, %acc[%t1], %true, %true {async_task_id = array<i32: 1>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      // cross-partition read of the finished accumulator (computation, task 0)
+      %val, %t3 = ttng.tmem_load %acc[%t2] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      ttg.local_store %val, %o {async_task_id = array<i32: 0>} : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #shared32, #smem, mutable>
+      scf.yield %t3 : !ttg.async.token
+    } {async_task_id = array<i32: 0, 1>}
+    tt.return
+  }
+
+// ---- Case 2: an intermediate tmem_load of the acc BETWEEN the two dots ----
+// The intermediate read (task 0) after the first dot forces a cross-partition
+// channel; the second dot still chains into the same accumulator in the gemm
+// partition (still NO MMA->MMA channel), and the final read is a second
+// cross-partition channel. So: two tmem_loads (two channels), two dots in one
+// partition.
+//
+// CHECK-LABEL: @chained_accum_with_intermediate
+// CHECK: ttg.warp_specialize
+// two cross-partition accumulator reads in the computation partition:
+// CHECK: ttng.tmem_load
+// CHECK: ttng.tmem_load
+// both chained dots in the gemm partition, no MMA->MMA channel between them:
+// CHECK: partition0
+// CHECK: ttng.tc_gen5_mma
+// CHECK-NOT: ttng.wait_barrier
+// CHECK: ttng.tc_gen5_mma
+  tt.func public @chained_accum_with_intermediate(
+      %a: !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>,
+      %b: !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>,
+      %c: !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>,
+      %d: !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>,
+      %o0: !ttg.memdesc<128x128xf32, #shared32, #smem, mutable>,
+      %o1: !ttg.memdesc<128x128xf32, #shared32, #smem, mutable>,
+      %lb: i32, %ub: i32, %step: i32) attributes {noinline = false} {
+    %true = arith.constant {async_task_id = array<i32: 0, 1>} true
+    %false = arith.constant {async_task_id = array<i32: 0, 1>} false
+    %cst_half = arith.constant {async_task_id = array<i32: 0>} dense<5.000000e-01> : tensor<128x128xf32, #blocked>
+    %acc, %acc_tok = ttng.tmem_alloc {async_task_id = array<i32: 1>, buffer.copy = 1 : i32, buffer.id = 1 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    scf.for %iv = %lb to %ub step %step iter_args(%tok = %acc_tok) -> (!ttg.async.token) : i32 {
+      %t1 = ttng.tc_gen5_mma %a, %b, %acc[%tok], %false, %true {async_task_id = array<i32: 1>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      // intermediate read of the partial accumulator (task 0), BETWEEN the dots,
+      // with a compute + store on it (mirrors `output = acc / 2.0; store(output)`).
+      %mid, %t2 = ttng.tmem_load %acc[%t1] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      %half = arith.mulf %mid, %cst_half {async_task_id = array<i32: 0>} : tensor<128x128xf32, #blocked>
+      ttg.local_store %half, %o0 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #shared32, #smem, mutable>
+      // second dot chains into the same acc, same task -> still no MMA->MMA channel
+      %t3 = ttng.tc_gen5_mma %c, %d, %acc[%t2], %true, %true {async_task_id = array<i32: 1>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %val, %t4 = ttng.tmem_load %acc[%t3] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      ttg.local_store %val, %o1 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #shared32, #smem, mutable>
+      scf.yield %t4 : !ttg.async.token
+    } {async_task_id = array<i32: 0, 1>}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_code_partition_operand_d_chained_accum.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_operand_d_chained_accum.mlir
@@ -1,0 +1,287 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=1 post-channel-creation=1" | FileCheck %s
+//
+// Regression for T278685041: a two-MMA chained accumulator sharing one operand-D
+// TMEM tile. The HSTU reduce_dq compute fold coalesces the dv and dk_attn dots
+// into a single in-place dk accumulator, so two MMAv5 ops write the same
+// tmem_alloc as operand D (dv with use_acc=flag, then dk_attn with use_acc=true),
+// followed by a cross-partition tmem_load. Both writers execute in the gemm
+// partition (task 1); the load runs in a computation partition (task 4 for the
+// dk_0 DP half, task 3 for dk_1).
+//
+// Before the fix, handleOperandD classified operand-D writers by identity
+// (== the single representative mmaOp) and rejected the second writer with
+//   "handleOperandD: unexpected MMA using same TMEM as operand D".
+// After the fix it classifies by role (accumulator == this alloc): both MMAs are
+// producer+consumer links in the operand-D chain. Because they share a task, the
+// needsChannel check skips a (redundant) MMA->MMA channel -- the same-task W->W
+// handoff is left to program order + hardware MMA ordering -- and only the
+// cross-partition MMA->tmem_load channels are emitted.
+//
+// CHECK-LABEL: @_hstu_attn_bwd_redq
+//
+// dk_0 tile: folded-dv writer (reads opndA tmem channel 2, produces opndD
+// channel 3) and dk_attn writer (produces opndD channel 4), both in task 1.
+// Neither carries a tmem.end for the other's operand-D channel, i.e. no
+// MMA->MMA channel is created for the same-task chain.
+// CHECK: ttng.tc_gen5_mma {{.*}}async_task_id = array<i32: 1>{{.*}}tmem.end = array<i32: 2>, tmem.start = array<i32: 3>
+// CHECK: ttng.tc_gen5_mma {{.*}}async_task_id = array<i32: 1>{{.*}}tmem.start = array<i32: 4>
+// The task-4 consumer waits on both writers via the operand-D channels.
+// CHECK: ttng.tmem_load {{.*}}async_task_id = array<i32: 4>{{.*}}tmem.end = array<i32: 3, 4, 5>
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [128, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @_hstu_attn_bwd_redq(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: !tt.ptr<i64> {tt.divisibility = 16 : i32}, %arg7: !tt.ptr<i64> {tt.divisibility = 16 : i32}, %arg8: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg9: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg10: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg11: i32 {tt.divisibility = 16 : i32}, %arg12: i32 {tt.divisibility = 16 : i32}, %arg13: i32 {tt.divisibility = 16 : i32}, %arg14: i32 {tt.divisibility = 16 : i32}, %arg15: i32 {tt.divisibility = 16 : i32}, %arg16: i32 {tt.divisibility = 16 : i32}, %arg17: i32 {tt.divisibility = 16 : i32}, %arg18: i32 {tt.divisibility = 16 : i32}, %arg19: i32 {tt.divisibility = 16 : i32}, %arg20: i32 {tt.divisibility = 16 : i32}, %arg21: i32 {tt.divisibility = 16 : i32}, %arg22: i32 {tt.divisibility = 16 : i32}, %arg23: i32 {tt.divisibility = 16 : i32}, %arg24: i32 {tt.divisibility = 16 : i32}, %arg25: f32, %arg26: i32 {tt.divisibility = 16 : i32}, %arg27: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg28: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg29: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg30: i32, %arg31: i32, %arg32: i32, %arg33: i32, %arg34: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant {async_task_id = array<i32: 0>} dense<0.000000e+00> : tensor<128x128xf32, #linear>
+    %cst_0 = arith.constant {async_task_id = array<i32: 0>} 1.44269502 : f32
+    %c2_i32 = arith.constant {async_task_id = array<i32: 0>} 2 : i32
+    %c256_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3, 4>} 256 : i32
+    %c1_i64 = arith.constant {async_task_id = array<i32: 0, 2, 3, 4>} 1 : i64
+    %c128_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3, 4>} 128 : i32
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3, 4>} 0 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3, 4>} 1 : i32
+    %true = arith.constant {async_task_id = array<i32: 0, 1>} true
+    %false = arith.constant {async_task_id = array<i32: 1>} false
+    %0 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 24 : i32} : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 25 : i32} : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+    %result, %token = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 14 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %result_1, %token_2 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 15 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %2 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 26 : i32} : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+    %result_3, %token_4 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %result_5, %token_6 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %3 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 27 : i32} : () -> !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>
+    %4 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 28 : i32} : () -> !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>
+    %result_7 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32, buffer.offset = 0 : i32} : () -> !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory, mutable>
+    %result_8 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32, buffer.offset = 0 : i32} : () -> !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory, mutable>
+    %5 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 29 : i32} : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+    %result_9, %token_10 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 22 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %result_11, %token_12 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 23 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %6 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 30 : i32} : () -> !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>
+    %7 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 31 : i32} : () -> !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>
+    %8 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+    %9 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+    %result_13, %token_14 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 22 : i32, buffer.offset = 0 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %result_15, %token_16 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 23 : i32, buffer.offset = 0 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %10 = tt.get_program_id x {async_task_id = array<i32: 0, 1, 2, 3, 4>} : i32
+    %11 = arith.divsi %10, %arg33 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : i32
+    %12 = arith.remsi %10, %arg33 {async_task_id = array<i32: 0, 2, 3, 4>} : i32
+    %13 = tt.addptr %arg6, %11 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : !tt.ptr<i64>, i32
+    %14 = tt.load %13 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : !tt.ptr<i64>
+    %15 = arith.trunci %14 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : i64 to i32
+    %16 = tt.addptr %13, %c1_i32 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : !tt.ptr<i64>, i32
+    %17 = tt.load %16 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : !tt.ptr<i64>
+    %18 = arith.trunci %17 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : i64 to i32
+    %19 = arith.subi %18, %15 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : i32
+    %20 = tt.addptr %arg7, %11 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : !tt.ptr<i64>, i32
+    %21 = tt.load %20 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : !tt.ptr<i64>
+    %22 = arith.trunci %21 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : i64 to i32
+    %23 = tt.addptr %20, %c1_i32 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : !tt.ptr<i64>, i32
+    %24 = tt.load %23 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : !tt.ptr<i64>
+    %25 = arith.trunci %24 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : i64 to i32
+    %26 = arith.subi %25, %22 {async_task_id = array<i32: 0, 1, 2, 3, 4>} : i32
+    %27 = arith.cmpi eq, %19, %c0_i32 : i32
+    cf.cond_br %27, ^bb1, ^bb2
+  ^bb1:  // pred: ^bb0
+    tt.return
+  ^bb2:  // pred: ^bb0
+    %28 = arith.muli %arg33, %c128_i32 {async_task_id = array<i32: 0, 2, 3, 4>} : i32
+    %29 = arith.extsi %28 {async_task_id = array<i32: 0, 2, 3, 4>} : i32 to i64
+    %30 = tt.make_tensor_descriptor %arg0, [%arg4, %28], [%29, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+    %31 = tt.make_tensor_descriptor %arg1, [%arg5, %28], [%29, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+    %32 = tt.make_tensor_descriptor %arg1, [%arg5, %28], [%29, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+    %33 = tt.make_tensor_descriptor %arg3, [%arg4, %28], [%29, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+    %34 = tt.make_tensor_descriptor %arg9, [%18, %28], [%29, %c1_i64] {async_task_id = array<i32: 4>} : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+    %35 = tt.make_tensor_descriptor %arg9, [%18, %28], [%29, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<bf16>, !tt.tensordesc<tensor<128x128xbf16, #shared>>
+    %36 = tt.make_tensor_descriptor %arg8, [%25, %28], [%29, %c1_i64] {async_task_id = array<i32: 0>} : !tt.ptr<f32>, !tt.tensordesc<tensor<128x128xf32, #shared3>>
+    %37 = arith.muli %12, %arg14 {async_task_id = array<i32: 2>} : i32
+    %38 = arith.cmpi slt, %12, %c2_i32 {async_task_id = array<i32: 0>} : i32
+    %39:2 = scf.if %38 -> (!tt.ptr<f32>, !tt.ptr<f32>) {
+      %64 = tt.addptr %arg28, %12 {async_task_id = array<i32: 0>} : !tt.ptr<f32>, i32
+      %65 = arith.muli %22, %arg30 {async_task_id = array<i32: 0>} : i32
+      %66 = tt.addptr %64, %65 {async_task_id = array<i32: 0>} : !tt.ptr<f32>, i32
+      %67 = tt.addptr %arg29, %12 {async_task_id = array<i32: 0>} : !tt.ptr<f32>, i32
+      %68 = tt.addptr %67, %65 {async_task_id = array<i32: 0>} : !tt.ptr<f32>, i32
+      scf.yield {async_task_id = array<i32: 0>} %68, %66 : !tt.ptr<f32>, !tt.ptr<f32>
+    } else {
+      scf.yield {async_task_id = array<i32: 0>} %arg29, %arg28 : !tt.ptr<f32>, !tt.ptr<f32>
+    } {async_task_id = array<i32: 0>}
+    %40 = tt.make_range {async_task_id = array<i32: 0>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #linear}>>
+    %41 = tt.make_range {async_task_id = array<i32: 0>, end = 256 : i32, start = 128 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #linear}>>
+    %42 = arith.mulf %arg25, %cst_0 {async_task_id = array<i32: 0>} : f32
+    %43 = tt.make_range {async_task_id = array<i32: 0>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #linear}>>
+    %44 = tt.make_range {async_task_id = array<i32: 0>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked>
+    %45 = tt.splat %26 {async_task_id = array<i32: 0>} : i32 -> tensor<128xi32, #blocked>
+    %46 = arith.muli %12, %arg12 {async_task_id = array<i32: 2>} : i32
+    %47 = tt.splat %26 {async_task_id = array<i32: 0>} : i32 -> tensor<1x128xi32, #linear>
+    %48 = tt.splat %19 {async_task_id = array<i32: 0>} : i32 -> tensor<128x1xi32, #linear>
+    %49 = tt.splat %19 {async_task_id = array<i32: 0>} : i32 -> tensor<128x1xi32, #linear>
+    %50 = tt.splat %42 {async_task_id = array<i32: 0>} : f32 -> tensor<128x128xf32, #linear>
+    %51 = tt.splat %42 {async_task_id = array<i32: 0>} : f32 -> tensor<128x128xf32, #linear>
+    %52 = tt.splat %arg30 {async_task_id = array<i32: 0>} : i32 -> tensor<128xi32, #blocked>
+    %53 = tt.splat %39#1 {async_task_id = array<i32: 0>} : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked>
+    %54 = arith.muli %12, %arg18 {async_task_id = array<i32: 2>} : i32
+    %55 = tt.splat %39#0 {async_task_id = array<i32: 0>} : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked>
+    %56 = tt.splat %arg25 {async_task_id = array<i32: 0>} : f32 -> tensor<128x128xf32, #linear>
+    %57 = tt.splat %arg25 {async_task_id = array<i32: 0>} : f32 -> tensor<128x128xf32, #linear>
+    %58 = arith.muli %12, %c128_i32 {async_task_id = array<i32: 0>} : i32
+    %59 = arith.muli %12, %c128_i32 {async_task_id = array<i32: 3, 4>} : i32
+    %60 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 34 : i32, buffer.tmaStaging = 2 : i32} : () -> !ttg.memdesc<128x128xf32, #shared3, #smem, mutable>
+    %61 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 35 : i32, buffer.tmaStaging = 2 : i32} : () -> !ttg.memdesc<128x128xf32, #shared3, #smem, mutable>
+    %62 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 36 : i32, buffer.tmaStaging = 1 : i32} : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+    %63 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 37 : i32, buffer.tmaStaging = 1 : i32} : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+    scf.for %arg35 = %c0_i32 to %19 step %c256_i32  : i32 {
+      %64 = arith.addi %15, %arg35 {async_task_id = array<i32: 2, 3, 4>} : i32
+      %65 = arith.addi %64, %c128_i32 {async_task_id = array<i32: 3>} : i32
+      %66 = arith.addi %64, %c128_i32 {async_task_id = array<i32: 2>} : i32
+      %67 = tt.descriptor_load %31[%64, %37] {async_task_id = array<i32: 2>} : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked1>
+      %68 = tt.descriptor_load %32[%66, %37] {async_task_id = array<i32: 2>} : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked1>
+      ttg.local_store %67, %0 {async_task_id = array<i32: 2>} : tensor<128x128xbf16, #blocked1> -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+      ttg.local_store %68, %1 {async_task_id = array<i32: 2>} : tensor<128x128xbf16, #blocked1> -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+      %69 = tt.splat %arg35 {async_task_id = array<i32: 0>} : i32 -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #linear}>>
+      %70 = tt.splat %arg35 {async_task_id = array<i32: 0>} : i32 -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #linear}>>
+      %71 = arith.addi %69, %40 {async_task_id = array<i32: 0>} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #linear}>>
+      %72 = arith.addi %70, %41 {async_task_id = array<i32: 0>} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #linear}>>
+      %73 = tt.expand_dims %71 {async_task_id = array<i32: 0>, axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #linear}>> -> tensor<128x1xi32, #linear>
+      %74 = tt.expand_dims %72 {async_task_id = array<i32: 0>, axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #linear}>> -> tensor<128x1xi32, #linear>
+      %75 = arith.cmpi slt, %73, %48 {async_task_id = array<i32: 0>} : tensor<128x1xi32, #linear>
+      %76 = arith.cmpi slt, %74, %49 {async_task_id = array<i32: 0>} : tensor<128x1xi32, #linear>
+      %77 = tt.broadcast %75 {async_task_id = array<i32: 0>} : tensor<128x1xi1, #linear> -> tensor<128x128xi1, #linear>
+      %78 = tt.broadcast %76 {async_task_id = array<i32: 0>} : tensor<128x1xi1, #linear> -> tensor<128x128xi1, #linear>
+      %79 = ttg.memdesc_trans %0 {async_task_id = array<i32: 1>, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>
+      %80 = ttg.memdesc_trans %1 {async_task_id = array<i32: 1>, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>
+      %81 = ttg.convert_layout %cst {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> -> tensor<128x128xf32, #linear1>
+      %82 = ttng.tmem_store %81, %result[%token], %true {async_task_id = array<i32: 0>, tmem.end = array<i32: 6>, tmem.start = array<i32: 2, 5>} : tensor<128x128xf32, #linear1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %83 = ttg.convert_layout %cst {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> -> tensor<128x128xf32, #linear1>
+      %84 = ttng.tmem_store %83, %result_1[%token_2], %true {async_task_id = array<i32: 0>, tmem.end = array<i32: 11>, tmem.start = array<i32: 7, 10>} : tensor<128x128xf32, #linear1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %85:9 = scf.for %arg36 = %c0_i32 to %26 step %c128_i32 iter_args(%arg37 = %false, %arg38 = %token_4, %arg39 = %token_10, %arg40 = %82, %arg41 = %token_14, %arg42 = %token_6, %arg43 = %token_12, %arg44 = %84, %arg45 = %token_16) -> (i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+        %94 = tt.splat %arg36 {async_task_id = array<i32: 0>} : i32 -> tensor<128xi32, #ttg.slice<{dim = 0, parent = #linear}>>
+        %95 = tt.splat %arg36 {async_task_id = array<i32: 0>} : i32 -> tensor<128xi32, #blocked>
+        %96 = arith.addi %94, %43 {async_task_id = array<i32: 0>} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #linear}>>
+        %97 = arith.addi %95, %44 {async_task_id = array<i32: 0>} : tensor<128xi32, #blocked>
+        %98 = arith.cmpi slt, %97, %45 {async_task_id = array<i32: 0>} : tensor<128xi32, #blocked>
+        %99 = arith.addi %22, %arg36 {async_task_id = array<i32: 0, 2>} : i32
+        %100 = tt.descriptor_load %30[%99, %46] {async_task_id = array<i32: 2>} : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked1>
+        ttg.local_store %100, %2 {async_task_id = array<i32: 2>} : tensor<128x128xbf16, #blocked1> -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+        %101 = ttg.memdesc_trans %2 {async_task_id = array<i32: 1>, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>
+        %102 = ttng.tc_gen5_mma %0, %101, %result_3[%arg38], %false, %true {async_task_id = array<i32: 1>, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndD,tmem,1,4\22]}"} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %103 = ttng.tc_gen5_mma %1, %101, %result_5[%arg42], %false, %true {async_task_id = array<i32: 1>, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndD,tmem,1,5\22]}"} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %104 = tt.expand_dims %96 {async_task_id = array<i32: 0>, axis = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xi32, #linear>
+        %105 = arith.cmpi slt, %104, %47 {async_task_id = array<i32: 0>} : tensor<1x128xi32, #linear>
+        %106 = tt.broadcast %105 {async_task_id = array<i32: 0>} : tensor<1x128xi1, #linear> -> tensor<128x128xi1, #linear>
+        %107 = tt.broadcast %105 {async_task_id = array<i32: 0>} : tensor<1x128xi1, #linear> -> tensor<128x128xi1, #linear>
+        %108 = arith.andi %106, %77 {async_task_id = array<i32: 0>} : tensor<128x128xi1, #linear>
+        %109 = arith.andi %107, %78 {async_task_id = array<i32: 0>} : tensor<128x128xi1, #linear>
+        %result_21, %token_22 = ttng.tmem_load %result_3[%102] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %110 = ttg.convert_layout %result_21 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear1> -> tensor<128x128xf32, #linear>
+        %result_23, %token_24 = ttng.tmem_load %result_5[%103] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %111 = ttg.convert_layout %result_23 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear1> -> tensor<128x128xf32, #linear>
+        %112 = arith.mulf %110, %50 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear>
+        %113 = arith.mulf %111, %51 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear>
+        %114 = arith.muli %97, %52 {async_task_id = array<i32: 0>} : tensor<128xi32, #blocked>
+        %115 = tt.addptr %53, %114 {async_task_id = array<i32: 0>} : tensor<128x!tt.ptr<f32>, #blocked>, tensor<128xi32, #blocked>
+        %116 = tt.descriptor_load %33[%99, %54] {async_task_id = array<i32: 2>} : !tt.tensordesc<tensor<128x128xbf16, #shared>> -> tensor<128x128xbf16, #blocked1>
+        %117 = tt.load %115, %98 {async_task_id = array<i32: 0>} : tensor<128x!tt.ptr<f32>, #blocked>
+        %118 = ttg.convert_layout %117 {async_task_id = array<i32: 0>} : tensor<128xf32, #blocked> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+        %119 = tt.expand_dims %118 {async_task_id = array<i32: 0>, axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+        %120 = tt.broadcast %119 {async_task_id = array<i32: 0>} : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+        %121 = arith.subf %112, %120 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear>
+        %122 = tt.load %115, %98 {async_task_id = array<i32: 0>} : tensor<128x!tt.ptr<f32>, #blocked>
+        %123 = ttg.convert_layout %122 {async_task_id = array<i32: 0>} : tensor<128xf32, #blocked> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+        %124 = tt.expand_dims %123 {async_task_id = array<i32: 0>, axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+        %125 = tt.broadcast %124 {async_task_id = array<i32: 0>} : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+        %126 = arith.subf %113, %125 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear>
+        %127 = math.exp2 %121 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear>
+        %128 = math.exp2 %126 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear>
+        %129 = ttg.convert_layout %81 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear1> -> tensor<128x128xf32, #linear>
+        %130 = arith.select %108, %127, %129 {async_task_id = array<i32: 0>} : tensor<128x128xi1, #linear>, tensor<128x128xf32, #linear>
+        ttg.local_store %130, %3 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>
+        %131 = ttg.convert_layout %83 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear1> -> tensor<128x128xf32, #linear>
+        %132 = arith.select %109, %128, %131 {async_task_id = array<i32: 0>} : tensor<128x128xi1, #linear>, tensor<128x128xf32, #linear>
+        ttg.local_store %132, %4 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>
+        %133 = ttg.local_load %3 {async_task_id = array<i32: 4>} : !ttg.memdesc<128x128xf32, #shared1, #smem, mutable> -> tensor<128x128xf32, #linear>
+        %134 = arith.truncf %133 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear> to tensor<128x128xbf16, #linear>
+        %135 = ttg.local_load %4 {async_task_id = array<i32: 3>} : !ttg.memdesc<128x128xf32, #shared1, #smem, mutable> -> tensor<128x128xf32, #linear>
+        %136 = arith.truncf %135 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear> to tensor<128x128xbf16, #linear>
+        %137 = ttg.convert_layout %134 {async_task_id = array<i32: 4>} : tensor<128x128xbf16, #linear> -> tensor<128x128xbf16, #linear1>
+        ttng.tmem_store %137, %result_7, %true {async_task_id = array<i32: 4>} : tensor<128x128xbf16, #linear1> -> !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory, mutable>
+        %138 = ttg.convert_layout %136 {async_task_id = array<i32: 3>} : tensor<128x128xbf16, #linear> -> tensor<128x128xbf16, #linear1>
+        ttng.tmem_store %138, %result_8, %true {async_task_id = array<i32: 3>} : tensor<128x128xbf16, #linear1> -> !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory, mutable>
+        ttg.local_store %116, %5 {async_task_id = array<i32: 2>} : tensor<128x128xbf16, #blocked1> -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+        %139 = ttg.memdesc_trans %5 {async_task_id = array<i32: 1>, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>
+        %140 = ttng.tc_gen5_mma %0, %139, %result_9[%arg39], %false, %true {async_task_id = array<i32: 1>, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndD,tmem,1,22\22]}"} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %141 = ttng.tc_gen5_mma %1, %139, %result_11[%arg43], %false, %true {async_task_id = array<i32: 1>, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndD,tmem,1,23\22]}"} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %142 = ttng.tc_gen5_mma %result_7, %5, %result[%arg40], %arg37, %true {async_task_id = array<i32: 1>, tmem.end = array<i32: 2>, tmem.start = array<i32: 3>, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,4\22, \22opndD,tmem,1,14\22]}"} : !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %143 = ttng.tc_gen5_mma %result_8, %5, %result_1[%arg44], %arg37, %true {async_task_id = array<i32: 1>, tmem.end = array<i32: 7>, tmem.start = array<i32: 8>, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,5\22, \22opndD,tmem,1,15\22]}"} : !ttg.memdesc<128x128xbf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %144 = tt.addptr %55, %114 {async_task_id = array<i32: 0>} : tensor<128x!tt.ptr<f32>, #blocked>, tensor<128xi32, #blocked>
+        %result_25, %token_26 = ttng.tmem_load %result_9[%140] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %145 = ttg.convert_layout %result_25 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear1> -> tensor<128x128xf32, #linear>
+        %result_27, %token_28 = ttng.tmem_load %result_11[%141] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %146 = ttg.convert_layout %result_27 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear1> -> tensor<128x128xf32, #linear>
+        %147 = tt.load %144, %98 {async_task_id = array<i32: 0>} : tensor<128x!tt.ptr<f32>, #blocked>
+        %148 = ttg.convert_layout %147 {async_task_id = array<i32: 0>} : tensor<128xf32, #blocked> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+        %149 = tt.expand_dims %148 {async_task_id = array<i32: 0>, axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+        %150 = tt.broadcast %149 {async_task_id = array<i32: 0>} : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+        %151 = arith.subf %145, %150 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear>
+        %152 = tt.load %144, %98 {async_task_id = array<i32: 0>} : tensor<128x!tt.ptr<f32>, #blocked>
+        %153 = ttg.convert_layout %152 {async_task_id = array<i32: 0>} : tensor<128xf32, #blocked> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+        %154 = tt.expand_dims %153 {async_task_id = array<i32: 0>, axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+        %155 = tt.broadcast %154 {async_task_id = array<i32: 0>} : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+        %156 = arith.subf %146, %155 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear>
+        %157 = arith.mulf %130, %151 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear>
+        %158 = arith.mulf %132, %156 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear>
+        %159 = arith.mulf %157, %56 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear>
+        %160 = arith.mulf %158, %57 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear>
+        %161 = arith.truncf %159 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> to tensor<128x128xbf16, #linear>
+        ttg.local_store %161, %6 {async_task_id = array<i32: 0>} : tensor<128x128xbf16, #linear> -> !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>
+        %162 = arith.truncf %160 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> to tensor<128x128xbf16, #linear>
+        ttg.local_store %162, %7 {async_task_id = array<i32: 0>} : tensor<128x128xbf16, #linear> -> !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>
+        %163 = ttg.local_load %6 {async_task_id = array<i32: 4>} : !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable> -> tensor<128x128xbf16, #linear>
+        ttg.local_store %163, %8 {async_task_id = array<i32: 4>} : tensor<128x128xbf16, #linear> -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+        %164 = ttg.local_load %7 {async_task_id = array<i32: 3>} : !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable> -> tensor<128x128xbf16, #linear>
+        ttg.local_store %164, %9 {async_task_id = array<i32: 3>} : tensor<128x128xbf16, #linear> -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+        %165 = ttng.tc_gen5_mma %79, %8, %result_13[%arg41], %false, %true {async_task_id = array<i32: 1>, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndB,smem,1,8\22, \22opndD,tmem,1,22\22]}"} : !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %166 = ttng.tc_gen5_mma %80, %9, %result_15[%arg45], %false, %true {async_task_id = array<i32: 1>, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndB,smem,1,8\22, \22opndD,tmem,1,23\22]}"} : !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %167 = ttng.tc_gen5_mma %8, %2, %result[%142], %true, %true {async_task_id = array<i32: 1>, tmem.start = array<i32: 4>, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,14\22]}"} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %168 = ttng.tc_gen5_mma %9, %2, %result_1[%143], %true, %true {async_task_id = array<i32: 1>, tmem.start = array<i32: 9>, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,15\22]}"} : !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %result_29, %token_30 = ttng.tmem_load %result_13[%165] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %result_31, %token_32 = ttng.tmem_load %result_15[%166] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %169 = tt.trans %result_29 {async_task_id = array<i32: 0>, order = array<i32: 1, 0>} : tensor<128x128xf32, #linear1> -> tensor<128x128xf32, #linear2>
+        %170 = tt.trans %result_31 {async_task_id = array<i32: 0>, order = array<i32: 1, 0>} : tensor<128x128xf32, #linear1> -> tensor<128x128xf32, #linear2>
+        %171 = ttg.convert_layout %169 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear2> -> tensor<128x128xf32, #blocked2>
+        %172 = ttg.convert_layout %170 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear2> -> tensor<128x128xf32, #blocked2>
+        ttg.local_store %171, %60 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #blocked2> -> !ttg.memdesc<128x128xf32, #shared3, #smem, mutable>
+        %173 = ttng.async_tma_reduce add, %36[%99, %58] %60 {async_task_id = array<i32: 0>} : !tt.tensordesc<tensor<128x128xf32, #shared3>>, !ttg.memdesc<128x128xf32, #shared3, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %173   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        ttg.local_store %172, %61 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #blocked2> -> !ttg.memdesc<128x128xf32, #shared3, #smem, mutable>
+        %174 = ttng.async_tma_reduce add, %36[%99, %58] %61 {async_task_id = array<i32: 0>} : !tt.tensordesc<tensor<128x128xf32, #shared3>>, !ttg.memdesc<128x128xf32, #shared3, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %174   {async_task_id = array<i32: 3>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        scf.yield {async_task_id = array<i32: 0, 1, 3, 4>} %true, %token_22, %token_26, %167, %token_30, %token_24, %token_28, %168, %token_32 : i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
+      } {async_task_id = array<i32: 0, 1, 2, 3, 4>, tt.merge_epilogue = true}
+      %result_17, %token_18 = ttng.tmem_load %result[%85#3] {async_task_id = array<i32: 4>, tmem.end = array<i32: 3, 4, 5>, tmem.start = array<i32: 6>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+      %86 = ttg.convert_layout %result_17 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear1> -> tensor<128x128xf32, #linear>
+      %result_19, %token_20 = ttng.tmem_load %result_1[%85#7] {async_task_id = array<i32: 3>, tmem.end = array<i32: 8, 9, 10>, tmem.start = array<i32: 11>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+      %87 = ttg.convert_layout %result_19 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear1> -> tensor<128x128xf32, #linear>
+      %88 = arith.truncf %86 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear> to tensor<128x128xbf16, #linear>
+      %89 = arith.truncf %87 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear> to tensor<128x128xbf16, #linear>
+      %90 = ttg.convert_layout %88 {async_task_id = array<i32: 4>} : tensor<128x128xbf16, #linear> -> tensor<128x128xbf16, #blocked1>
+      %91 = ttg.convert_layout %89 {async_task_id = array<i32: 3>} : tensor<128x128xbf16, #linear> -> tensor<128x128xbf16, #blocked1>
+      ttg.local_store %90, %62 {async_task_id = array<i32: 4>} : tensor<128x128xbf16, #blocked1> -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+      %92 = ttng.async_tma_copy_local_to_global %34[%64, %59] %62 {async_task_id = array<i32: 4>} : !tt.tensordesc<tensor<128x128xbf16, #shared>>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %92   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+      ttg.local_store %91, %63 {async_task_id = array<i32: 3>} : tensor<128x128xbf16, #blocked1> -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+      %93 = ttng.async_tma_copy_local_to_global %35[%65, %59] %63 {async_task_id = array<i32: 3>} : !tt.tensordesc<tensor<128x128xbf16, #shared>>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %93   {async_task_id = array<i32: 3>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+    } {async_task_id = array<i32: 0, 1, 2, 3, 4>, tt.data_partition_factor = 2 : i32, tt.merge_correction = true, tt.merge_epilogue_to_computation = true, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "load", "computation", "computation"], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}
+

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -2879,8 +2879,15 @@ handleOperandD(ttng::TMEMAllocOp tmemAllocOp, ttng::MMAv5OpInterface mmaOp,
       continue;
     handledUsers.insert(&op);
     if (auto mmaOpT = dyn_cast<ttng::MMAv5OpInterface>(&op)) {
-      if (&op == mmaOp.getOperation()) {
-        // This uses and defines D. Will be both producer and consumer.
+      if (mmaOpT.getAccumulator() == tmemAllocOp.getResult()) {
+        // Any MMA whose accumulator IS this alloc writes operand D, so it is a
+        // producer+consumer link in the operand-D chain. Classify by role
+        // (writes D), not identity (== mmaOp): a second chained accumulator MMA
+        // (e.g. the HSTU reduce_dq fold coalesces dv then dk_attn into one TMEM
+        // tile) is handled here as another producer in the chain rather than
+        // rejected as an aliasing MMA. When two D-writers share a task the
+        // needsChannel check below skips the (redundant) same-task MMA->MMA
+        // channel and just extends currentProds. See T278685041.
         // If useAcc is false, the MMA doesn't read the accumulator - it
         // overwrites it completely. In this case, the MMA is the first
         // producer and doesn't need a prior producer.
@@ -2918,7 +2925,7 @@ handleOperandD(ttng::TMEMAllocOp tmemAllocOp, ttng::MMAv5OpInterface mmaOp,
           }
         }
         if (currentProds.empty()) {
-          mmaOp->emitError(
+          op.emitError(
               "handleOperandD: no producer found for MMA operand D. "
               "Expected a tmem_store before the loop or use_acc=false.");
           return failure();
@@ -2927,7 +2934,7 @@ handleOperandD(ttng::TMEMAllocOp tmemAllocOp, ttng::MMAv5OpInterface mmaOp,
         auto producerTaskIds = getAsyncTaskIds(currentProds.front());
         auto consumerIds = getAsyncTaskIds(&op);
         if (producerTaskIds.size() != 1) {
-          mmaOp->emitError(
+          op.emitError(
               "handleOperandD: expected exactly one producer task ID, got ")
               << producerTaskIds.size();
           return failure();
@@ -2947,12 +2954,9 @@ handleOperandD(ttng::TMEMAllocOp tmemAllocOp, ttng::MMAv5OpInterface mmaOp,
           currentProds.push_back(&op);
         }
       } else {
-        if (mmaOpT.getAccumulator() == tmemAllocOp.getResult()) {
-          mmaOp->emitError(
-              "handleOperandD: unexpected MMA using same TMEM as operand D");
-          return failure();
-        }
-        // This uses tmem. mark as tmem.end = channel_id
+        // This MMA reads the alloc as an A/B operand (its own accumulator is a
+        // different TMEM tile): consumer only.
+        // mark as tmem.end = channel_id
         if (currentProds.empty()) {
           mmaOpT->emitError(
               "handleOperandD: no producer found for MMA consumer");

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -45,6 +45,56 @@ inline bool isMMAOp(Operation *op) {
   return isa<ttng::MMAv5OpInterface>(op) || isa<ttng::WarpGroupDotOp>(op);
 }
 
+/// Return a stable identity for an MMAv5 op's accumulator buffer: the backing
+/// tensor-memory allocation (tracing through memdesc view/index ops), or null
+/// for non-MMAv5 ops (e.g. Hopper WarpGroupDot, whose accumulator lives in
+/// registers). Two MMAv5 ops that resolve to the same buffer share a
+/// tensor-memory accumulator and therefore form a serial reduction chain
+/// (e.g. dq += K0^T·dS0 then dq += K1^T·dS1 into one dq tile). Such MMAs must
+/// not be placed in different warp-specialization partitions: concurrent
+/// accumulating MMAs into one accumulator race on the shared tile.
+inline Operation *getAccumulatorBuffer(Operation *op) {
+  auto mma = dyn_cast<ttng::MMAv5OpInterface>(op);
+  if (!mma)
+    return nullptr;
+  Value acc = mma.getAccumulator();
+  while (acc) {
+    Operation *def = acc.getDefiningOp();
+    if (!def)
+      return nullptr; // block/iter arg — no static buffer identity here
+    if (isa<ttng::TMEMAllocOp>(def))
+      return def; // backing allocation: canonical buffer identity
+    // Trace ONLY through region-preserving, metadata-only views (same tile,
+    // same offset), so the identity is stable across them. Restrict to the
+    // known view ops instead of "any op whose operand 0 is a memdesc": an op
+    // with several memdesc inputs would otherwise be traversed by blindly
+    // following operand 0 and yield a wrong identity.
+    if (isa<triton::gpu::MemDescTransOp, triton::gpu::MemDescReinterpretOp>(
+            def)) {
+      acc = def->getOperand(0);
+      continue;
+    }
+    // Offset-selecting views (memdesc_index) alias the SAME allocation at a
+    // DIFFERENT offset: two such views are DISJOINT sub-tiles, not one shared
+    // accumulator. Do NOT trace to the backing alloc — that would collapse
+    // distinct offsets and falsely group (or hard-error in the Layer-2
+    // backstop) independent sub-accumulators. Use the view op itself as the
+    // identity: the same view value => the same tile; different offset ops =>
+    // different identities.
+    if (isa<triton::gpu::MemDescIndexOp>(def))
+      return def;
+    // Unrecognized producer: do NOT guess an identity. A wrong guess could
+    // fabricate an aliasing pair (false backstop error) or, if two distinct
+    // ops alias the same tile, silently miss a real one. Bail conservatively
+    // (no known buffer) and log so the shape can be handled explicitly.
+    LDBG("getAccumulatorBuffer: unrecognized accumulator producer, no buffer "
+         "identity: "
+         << *def);
+    return nullptr;
+  }
+  return nullptr;
+}
+
 /// Strip all warp specialization annotations from a function.
 /// Removes partition attributes from ops and tt.warp_specialize from loops.
 static void dropWarpSpec(triton::FuncOp funcOp) {
@@ -536,6 +586,26 @@ private:
           }
         }
       }
+    }
+
+    // Accumulator-chained MMAs must share a data-partition group. Two MMAs
+    // whose accumulators alias the same tensor-memory buffer form a serial
+    // reduction (e.g. dq += K0^T·dS0 then dq += K1^T·dS1 into one dq tile).
+    // The forward walk above stops at MMAs and never sees this dependency (it
+    // flows through the accumulator memdesc/token, not an SSA result operand),
+    // so without this the two dq dots would be counted as independent groups
+    // and split across partitions, racing on the shared accumulator. Union
+    // MMAs that write the same accumulator buffer so they stay together.
+    DenseMap<Operation *, unsigned> accBufToMma;
+    for (unsigned i = 0; i < n; ++i) {
+      Operation *buf = getAccumulatorBuffer(loopMmas[i]);
+      if (!buf)
+        continue;
+      auto it = accBufToMma.find(buf);
+      if (it == accBufToMma.end())
+        accBufToMma[buf] = i;
+      else
+        unite(i, it->second);
     }
 
     // Count distinct groups that have exclusive (non-shared) ops
@@ -2770,6 +2840,71 @@ void PartitionSchedulingMeta::runOnOperation() {
         }
       }
 
+      // Backstop: verify no two accumulator-chained MMAs were assigned to
+      // partitions that cannot be co-located. The data-partition grouping
+      // (Layer 1) should keep them together, but any other assignment path
+      // (preassignment/flex) that splits a shared tensor-memory accumulator
+      // would silently corrupt the reduction — concurrent accumulating MMAs
+      // race on the shared tile. Turn that into a hard compile error.
+      //
+      // All MMAs that write one accumulator are co-locatable iff a SINGLE
+      // partition is common to every one of them, i.e. the intersection of all
+      // their partition-id sets is non-empty. Comparing each MMA only against
+      // the first-seen set is both unsound and over-eager for chains of 3+:
+      // e.g. {0,1},{0,2},{0,3} share partition 0 (fine) but pairwise-vs-first
+      // would need care, while {0,1},{0,2},{2,3} has empty overall intersection
+      // (no common partition) yet every pair overlaps. So track the RUNNING
+      // intersection across all MMAs writing the same buffer and error the
+      // moment it empties. Store the first writer to point the diagnostic at it.
+      DenseMap<Operation *, std::pair<Operation *, SetVector<int>>> accOwner;
+      auto idsToStr = [](const SetVector<int> &ids) {
+        std::string s;
+        llvm::raw_string_ostream os(s);
+        llvm::interleaveComma(ids, os);
+        return os.str();
+      };
+      WalkResult vr = loop.walk([&](Operation *op) -> WalkResult {
+        Operation *buf = getAccumulatorBuffer(op);
+        if (!buf)
+          return WalkResult::advance();
+        SetVector<int> ids = safeGetPartitionIds(op);
+        if (ids.empty())
+          return WalkResult::advance();
+        auto it = accOwner.find(buf);
+        if (it == accOwner.end()) {
+          accOwner[buf] = {op, ids};
+          return WalkResult::advance();
+        }
+        Operation *firstWriter = it->second.first;
+        SetVector<int> &running = it->second.second;
+        // Narrow the running intersection by this MMA's partition set.
+        SetVector<int> next;
+        for (int id : running)
+          if (ids.contains(id))
+            next.insert(id);
+        if (next.empty()) {
+          InFlightDiagnostic diag =
+              op->emitError()
+              << "warp specialization assigned accumulator-chained MMAs with no "
+                 "common partition (running intersection {"
+              << idsToStr(running) << "} does not meet this MMA's {"
+              << idsToStr(ids)
+              << "}): they all accumulate into the same tensor-memory tile. "
+                 "Concurrent accumulating MMAs into one accumulator race and "
+                 "produce incorrect results. Co-locate them in a single "
+                 "partition (lower data_partition_factor) or give each "
+                 "partition its own accumulator and reduce at the end.";
+          diag.attachNote(firstWriter->getLoc())
+              << "first accumulator-chained MMA writing this tensor-memory tile "
+                 "is here";
+          return WalkResult::interrupt();
+        }
+        running = std::move(next);
+        return WalkResult::advance();
+      });
+      if (vr.wasInterrupted())
+        return signalPassFailure();
+
       // Estimate total warps for the WS schedule. If the estimate exceeds
       // the hardware warp limit, skip WS for the entire function.
       constexpr int kMaxWarps = 16;
@@ -2800,7 +2935,12 @@ void PartitionSchedulingMeta::runOnOperation() {
       for (auto [id, warps] : partitionWarps)
         estimatedTotal += warps;
 
-      LDBG("Warp budget estimate: " << estimatedTotal << " / " << kMaxWarps);
+      LDBG("Warp budget estimate: " << estimatedTotal << " / " << kMaxWarps
+                                    << " (numPartitions=" << numPartitions
+                                    << ", defaultNumWarps=" << defaultNumWarps
+                                    << ")");
+      for (auto [id, warps] : partitionWarps)
+        LDBG("  [budget] partition " << id << " warps=" << warps);
 
       if (estimatedTotal > kMaxWarps) {
         LDBG("Warp budget exceeded. Skipping warp specialization.");

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
@@ -167,6 +167,20 @@ rescaling) are not stolen by the data partition categorizer.
    in separate computation partitions. Following the specific operand index
    (rather than the whole `scf.if`) keeps distinct data partitions separate
    for cases like flex attention.
+
+   A **second union-find edge** groups MMAs that write the **same accumulator
+   TMEM buffer**. Accumulator-chained MMAs (e.g. `dq += K0ᵀ·dS0` then
+   `dq += K1ᵀ·dS1` into one `dq` tile, or `acc = A@B; acc += C@D`) form a serial
+   reduction whose dependency flows through the accumulator memdesc/token, *not*
+   an SSA result operand — so the forward-user-set walk above stops at each MMA
+   and never sees it. Without this edge the chained dots would be counted as
+   independent groups and split across partitions, racing on the shared tile.
+   `getAccumulatorBuffer` resolves each MMA's accumulator to a canonical buffer
+   identity: it stops at the backing `TMEMAllocOp`; traces through
+   region/offset-preserving views only (`MemDescTransOp`, `MemDescReinterpretOp`);
+   treats an offset-selecting `MemDescIndexOp` as its **own** identity (so two
+   different-offset sub-tiles of one allocation are *not* collapsed); and bails
+   to `nullptr` (logged) on any unrecognized producer rather than guessing.
 3. **Builds `opToDpId` map** for ALL reachable ops:
    - **Inner-loop ops**: From backward slices, using normalized group IDs.
      Ops appearing in multiple groups get `SHARED_DPID` sentinel.
@@ -182,14 +196,35 @@ which auto-resolves the dpId when not explicitly provided.
 
 1. **Collect backward slices** for each MMA.
 2. **Identify shared ops** — ops appearing in multiple slices.
-3. **Union-find grouping** — MMAs whose forward user sets overlap another MMA's
-   backward slice are grouped together.
+3. **Union-find grouping** — MMAs are grouped by two edges: (a) forward user
+   sets that overlap another MMA's backward slice, and (b) writing the same
+   accumulator buffer (`getAccumulatorBuffer`, see above). Edge (b) keeps
+   accumulator-chained MMAs in one group even when no slice overlap exists.
 4. **Count groups with exclusive ops** — only groups with at least one
    non-shared, non-constant op count. This becomes `dataPartitionFactor`.
 
 For FA forward with `data_partition_factor=2`, this yields `dpFactor=2`.
 For FA backward, MMAs are data-dependent (QK feeds PV via the same accumulator),
 so all MMAs group together → `dpFactor=1`.
+
+### Accumulator-chain backstop
+
+After all partition assignments are finalized (post `propagatePartitions` +
+`optimizeSchedule`, before serialization), a verification walk guards against
+any assignment path — union-find above, preassignment, or flex — that splits a
+shared tensor-memory accumulator across partitions that cannot be co-located.
+Concurrent accumulating MMAs into one tile race and silently corrupt the
+reduction, so this is turned into a **hard compile error** rather than a latent
+accuracy bug.
+
+The check maintains, per accumulator buffer, the **running intersection** of the
+partition-id sets of every MMA that writes it, and errors the moment that
+intersection becomes empty (no single partition is common to the whole chain).
+This is correct for chains of 3+ writers: `{0,1},{0,2},{2,3}` is flagged (empty
+overall intersection) while `{0,1},{0,2},{0,3}` passes on common partition `0`.
+The diagnostic attaches a note pointing at the first MMA on the chain. The fix
+is to co-locate the chain in one partition (lower `data_partition_factor`) or to
+give each partition its own accumulator and reduce at the end.
 
 ## Phase 2: Partition Layout (`createPartitionLayout`)
 

--- a/third_party/tlx/tutorials/hstu_cross_attn/triton_bw_cross_attention.py
+++ b/third_party/tlx/tutorials/hstu_cross_attn/triton_bw_cross_attention.py
@@ -1,7 +1,6 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 # pyre-unsafe
-
 """
 Cross-attention kernels with optional TMA (Tensor Memory Accelerator) support.
 
@@ -64,6 +63,7 @@ HAS_TENSOR_DESCRIPTOR = hasattr(tl, "make_tensor_descriptor")
 # triton.Config kwarg. Supports .get(key) like a dict but is hashable for Triton's
 # JIT cache key. Mirrors the pattern in fused_attention_ws_device_tma.py.
 class FrozenDotAttrs:
+
     def __init__(self, d):
         import json as _json
 
@@ -95,16 +95,14 @@ class FrozenDotAttrs:
 #
 # DEFAULT: the schedule this kernel shipped with (FA-derived; dq^T on its own
 # single-copy TMEM buffer id 11, dP on id 5).
-_HSTU_BWD_DOT_ATTRS_DEFAULT = FrozenDotAttrs(
-    {
-        "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]},
-        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
-        "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,5"]},
-        "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]},
-        "dk_shared": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,7"]},
-        "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,8", "opndD,tmem,1,11"]},
-    }
-)
+_HSTU_BWD_DOT_ATTRS_DEFAULT = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]},
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
+    "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,5"]},
+    "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]},
+    "dk_shared": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,7"]},
+    "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,8", "opndD,tmem,1,11"]},
+})
 
 # TLX-aligned: mirror the hand-written TLX kernel (attn_bwd_ws) TMEM buffer scheme.
 # TLX reuses the dP tile in dq's TMEM slot (`dp_tiles reuse=dq_tiles`): dP is fully
@@ -113,16 +111,14 @@ _HSTU_BWD_DOT_ATTRS_DEFAULT = FrozenDotAttrs(
 # (the larger 128x64 tile, which subsumes dP's 64x64) instead of a separate id 5.
 # Stages/order match DEFAULT (== TLX: qkT/dpT/dv "current", dq/dk one iteration
 # behind). Everything single-copy, as in TLX (NUM_BUFFERS_TMEM=1).
-_HSTU_BWD_DOT_ATTRS_TLX = FrozenDotAttrs(
-    {
-        "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]},
-        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
-        "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,11"]},
-        "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]},
-        "dk_shared": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,7"]},
-        "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,8", "opndD,tmem,1,11"]},
-    }
-)
+_HSTU_BWD_DOT_ATTRS_TLX = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]},
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
+    "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,11"]},
+    "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]},
+    "dk_shared": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,7"]},
+    "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,8", "opndD,tmem,1,11"]},
+})
 
 # for SHARED_KV + DP and _HSTU_COMPUTE_FOLD
 # --> we can do dk += dot(...) dk += dot(...)
@@ -132,17 +128,14 @@ _HSTU_BWD_DOT_ATTRS_TLX = FrozenDotAttrs(
 # over KV blocks -- like the hand-written attn_bwd_ws_2kv), then ONE store. So
 # dpT must NOT time-share id 11 with dq (as the single-KV _TLX schedule does); it
 # gets its own tile (id 5). Everything else (qkT/S+P id 2, dv/dk id 7) is b0's.
-_HSTU_BWD_DOT_ATTRS_2KV = FrozenDotAttrs(
-    {
-        "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]},
-        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
-        "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,5"]},
-        "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]},
-        "dk_shared": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,7"]},
-        "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,8", "opndD,tmem,1,11"]},
-    }
-)
-
+_HSTU_BWD_DOT_ATTRS_2KV = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]},
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]},
+    "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,5"]},
+    "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]},
+    "dk_shared": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,7"]},
+    "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,8", "opndD,tmem,1,11"]},
+})
 
 # Triton's @jit frontend accepts `attrs=` only as a dict literal or a bare
 # module-global name bound to a dict -- it rejects passing a FrozenDotAttrs (or
@@ -190,20 +183,18 @@ _HSTU_ATTRS_DQ_2KV = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV.get("dq"))
 #     (576 -> 512). The planner packs dp1 at colOffset 0 in dp0's tile and
 #     inserts the reuse WAR barrier that serializes dp0-consume -> dp1-write.
 #     (qk stays split/depth-2 for overlap, as in TLX.)
-_HSTU_BWD_DOT_ATTRS_2KV_B1 = FrozenDotAttrs(
-    {
-        "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,12"]},
-        "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,12", "opndD,tmem,1,17"]},
-        # dpT opndD id 5 is SHARED with b0 (dp0/dp1 reuse one TMEM tile, TLX-style)
-        # so BLOCK_N=128 fits TMEM; see the module comment above.
-        "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,5"]},
-        "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,9", "opndD,tmem,1,20"]},
-        "dk_shared": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,9", "opndD,tmem,1,17"]},
-        # dq opndD id 11 is SHARED with b0 (single dq accumulator over both KV
-        # blocks); only its input operand (opndB smem) is b1's own (id 9).
-        "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,9", "opndD,tmem,1,11"]},
-    }
-)
+_HSTU_BWD_DOT_ATTRS_2KV_B1 = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndD,tmem,1,12"]},
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,12", "opndD,tmem,1,17"]},
+    # dpT opndD id 5 is SHARED with b0 (dp0/dp1 reuse one TMEM tile, TLX-style)
+    # so BLOCK_N=128 fits TMEM; see the module comment above.
+    "dpT": {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,5"]},
+    "dk": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,9", "opndD,tmem,1,20"]},
+    "dk_shared": {"stage": "1", "order": "1", "channels": ["opndA,smem,1,9", "opndD,tmem,1,17"]},
+    # dq opndD id 11 is SHARED with b0 (single dq accumulator over both KV
+    # blocks); only its input operand (opndB smem) is b1's own (id 9).
+    "dq": {"stage": "1", "order": "1", "channels": ["opndB,smem,1,9", "opndD,tmem,1,11"]},
+})
 _HSTU_ATTRS_QKT_2KV_B1 = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV_B1.get("qkT"))
 _HSTU_ATTRS_DV_2KV_B1 = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV_B1.get("dv"))
 _HSTU_ATTRS_DPT_2KV_B1 = tl.constexpr(_HSTU_BWD_DOT_ATTRS_2KV_B1.get("dpT"))
@@ -221,9 +212,7 @@ _HSTU_COMPUTE_FOLD = tl.constexpr(os.environ.get("HSTU_COMPUTE_FOLD", "0") == "1
 # NOT emit the user tt.autows annotations on the MMAs: they pin the schedule and
 # make the modulo pass skip the loop (hasExistingAnnotation), turning the picked
 # variant into a no-op. Dropping them lets the modulo scheduler own the schedule.
-_HSTU_MODULO_TOPK = tl.constexpr(
-    int(os.environ.get("TRITON_MODULO_TOPK", "1")) > 1
-)
+_HSTU_MODULO_TOPK = tl.constexpr(int(os.environ.get("TRITON_MODULO_TOPK", "1")) > 1)
 
 
 def set_bwd_dot_attrs(cfg: "FrozenDotAttrs") -> None:
@@ -239,8 +228,6 @@ def set_bwd_dot_attrs(cfg: "FrozenDotAttrs") -> None:
     _HSTU_ATTRS_DK = tl.constexpr(cfg.get("dk"))
     _HSTU_ATTRS_DK_SHARED = tl.constexpr(cfg.get("dk_shared"))
     _HSTU_ATTRS_DQ = tl.constexpr(cfg.get("dq"))
-
-
 
 
 class FwdVariant(Enum):
@@ -338,8 +325,6 @@ def _compute_offsets(
     )
 
 
-
-
 def get_fwd_triton_configs() -> List[triton.Config]:
     configs = [
         triton.Config(
@@ -366,9 +351,7 @@ def get_fwd_triton_configs() -> List[triton.Config]:
 
 
 @triton.jit
-def forward_valid_mask_trans(
-    offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL: tl.constexpr
-):
+def forward_valid_mask_trans(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL: tl.constexpr):
     valid_mask = (offs_m[None, :] < seq_len_q) & (offs_n[:, None] < seq_len_kv)
     if HAS_CAUSAL:
         offs_m = offs_m + seq_len_kv - uih_len_q
@@ -449,20 +432,15 @@ def _attn_fwd_compute(
     # Main loop - no masking needed for non-last kv blocks
     for start_n in tl.range(0, last_block_start_n, BLOCK_N):
         if ENABLE_TMA:
-            k = desc_k.load(
-                [
-                    (seq_start_kv + start_n).to(tl.int32),
-                    off_h_kv * stride_kh,
-                ]
-            )
+            k = desc_k.load([
+                (seq_start_kv + start_n).to(tl.int32),
+                off_h_kv * stride_kh,
+            ])
         else:
             offs_n_load = start_n + tl.arange(0, BLOCK_N)
             offs_qk_d = tl.arange(0, HEAD_DIM)
-            k_ptrs = (
-                K
-                + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_kn
-                + (off_h_kv * stride_kh + offs_qk_d)[None, :]
-            )
+            k_ptrs = (K + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_kn +
+                      (off_h_kv * stride_kh + offs_qk_d)[None, :])
             k = tl.load(k_ptrs)
 
         if TRANS:
@@ -472,13 +450,9 @@ def _attn_fwd_compute(
         if HAS_CAUSAL:
             offs_n = offs_n_0 + start_n
             if TRANS:
-                causal_mask = (offs_m[None, :] + seq_len_kv - uih_len_q) >= offs_n[
-                    :, None
-                ]
+                causal_mask = (offs_m[None, :] + seq_len_kv - uih_len_q) >= offs_n[:, None]
             else:
-                causal_mask = (offs_m[:, None] + seq_len_kv - uih_len_q) >= offs_n[
-                    None, :
-                ]
+                causal_mask = (offs_m[:, None] + seq_len_kv - uih_len_q) >= offs_n[None, :]
             if IS_SOFTMAX:
                 qk = tl.where(causal_mask, qk, float("-inf"))
             else:
@@ -508,20 +482,15 @@ def _attn_fwd_compute(
             v = k
         else:
             if ENABLE_TMA:
-                v = desc_v.load(
-                    [
-                        (seq_start_kv + start_n).to(tl.int32),
-                        off_h_kv * stride_vh,
-                    ]
-                )
+                v = desc_v.load([
+                    (seq_start_kv + start_n).to(tl.int32),
+                    off_h_kv * stride_vh,
+                ])
             else:
                 offs_n_load = start_n + tl.arange(0, BLOCK_N)
                 offs_v_d = tl.arange(0, BLOCK_D_V)
-                v_ptrs = (
-                    V
-                    + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_vn
-                    + (off_h_kv * stride_vh + offs_v_d)[None, :]
-                )
+                v_ptrs = (V + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_vn +
+                          (off_h_kv * stride_vh + offs_v_d)[None, :])
                 v = tl.load(v_ptrs)
         act_qk = act_qk.to(v.dtype)
         if TRANS:
@@ -533,20 +502,15 @@ def _attn_fwd_compute(
     # q masking is not needed here because we mask when storing results.
     start_n = last_block_start_n
     if ENABLE_TMA:
-        k = desc_k.load(
-            [
-                (seq_start_kv + start_n).to(tl.int32),
-                off_h_kv * stride_kh,
-            ]
-        )
+        k = desc_k.load([
+            (seq_start_kv + start_n).to(tl.int32),
+            off_h_kv * stride_kh,
+        ])
     else:
         offs_n_load = start_n + tl.arange(0, BLOCK_N)
         offs_qk_d = tl.arange(0, HEAD_DIM)
-        k_ptrs = (
-            K
-            + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_kn
-            + (off_h_kv * stride_kh + offs_qk_d)[None, :]
-        )
+        k_ptrs = (K + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_kn +
+                  (off_h_kv * stride_kh + offs_qk_d)[None, :])
         k = tl.load(
             k_ptrs,
             mask=(offs_n_load < seq_len_kv)[:, None],
@@ -578,13 +542,9 @@ def _attn_fwd_compute(
         )
     if IS_SOFTMAX:
         if TRANS:
-            act_qk, acc, l_i, m_i = forward_softmax_activation_trans_scaled_alpha(
-                qk, alpha, valid_mask, m_i, acc, l_i
-            )
+            act_qk, acc, l_i, m_i = forward_softmax_activation_trans_scaled_alpha(qk, alpha, valid_mask, m_i, acc, l_i)
         else:
-            act_qk, acc, l_i, m_i = forward_softmax_activation_scaled_alpha(
-                qk, alpha, valid_mask, m_i, acc, l_i
-            )
+            act_qk, acc, l_i, m_i = forward_softmax_activation_scaled_alpha(qk, alpha, valid_mask, m_i, acc, l_i)
     else:
         masked_alpha = tl.where(valid_mask, alpha, 0.0)
         qk = qk * masked_alpha
@@ -593,20 +553,15 @@ def _attn_fwd_compute(
         v = k
     else:
         if ENABLE_TMA:
-            v = desc_v.load(
-                [
-                    (seq_start_kv + start_n).to(tl.int32),
-                    off_h_kv * stride_vh,
-                ]
-            )
+            v = desc_v.load([
+                (seq_start_kv + start_n).to(tl.int32),
+                off_h_kv * stride_vh,
+            ])
         else:
             offs_n_load = start_n + tl.arange(0, BLOCK_N)
             offs_v_d = tl.arange(0, BLOCK_D_V)
-            v_ptrs = (
-                V
-                + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_vn
-                + (off_h_kv * stride_vh + offs_v_d)[None, :]
-            )
+            v_ptrs = (V + (seq_start_kv + offs_n_load).to(tl.int64)[:, None] * stride_vn +
+                      (off_h_kv * stride_vh + offs_v_d)[None, :])
             v = tl.load(
                 v_ptrs,
                 mask=(offs_n_load < seq_len_kv)[:, None],
@@ -707,12 +662,8 @@ def _attn_fwd_triton_inner(
             q = desc_q.load([qo_offset_y_split.to(tl.int32), off_h * stride_qh])
         else:
             offs_qk_d = tl.arange(0, HEAD_DIM)
-            q_ptrs = (
-                Q
-                + (qo_offset_y_split + tl.arange(0, BLOCK_M)).to(tl.int64)[:, None]
-                * stride_qm
-                + (off_h * stride_qh + offs_qk_d)[None, :]
-            )
+            q_ptrs = (Q + (qo_offset_y_split + tl.arange(0, BLOCK_M)).to(tl.int64)[:, None] * stride_qm +
+                      (off_h * stride_qh + offs_qk_d)[None, :])
             q = tl.load(
                 q_ptrs,
                 mask=(offs_m < seq_len_q)[:, None],
@@ -946,9 +897,7 @@ def _attn_fwd_triton(
         seq_start_q,
         seq_len_q,
         off_z,
-    ) = _compute_offsets(
-        H, G, BLOCK_M, seq_offsets_q, seq_offsets, max_seq_len, TRUNCATE_METHOD
-    )
+    ) = _compute_offsets(H, G, BLOCK_M, seq_offsets_q, seq_offsets, max_seq_len, TRUNCATE_METHOD)
     if HAS_CAUSAL:
         n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
         uih_len_q = uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
@@ -1001,8 +950,6 @@ def _attn_fwd_triton(
     )
 
 
-
-
 def get_fwd_triton_spec_configs() -> List[triton.Config]:
     if torch.version.hip:
         configs = []
@@ -1030,8 +977,7 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                                         },
                                         num_stages=num_stages,
                                         num_warps=num_warps,
-                                    )
-                                )
+                                    ))
         return configs
     if get_full_autotune():
         configs = [
@@ -1355,9 +1301,7 @@ def _attn_fwd_triton_spec(
         seq_start_q,
         seq_len_q,
         off_z,
-    ) = _compute_offsets(
-        H, G, BLOCK_M, seq_offsets_q, seq_offsets, max_seq_len, TRUNCATE_METHOD
-    )
+    ) = _compute_offsets(H, G, BLOCK_M, seq_offsets_q, seq_offsets, max_seq_len, TRUNCATE_METHOD)
     if HAS_CAUSAL:
         n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
         uih_len_q = uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
@@ -1490,8 +1434,7 @@ def _get_triton_bw_configs() -> List[triton.Config]:
             num_stages=ns,
             num_warps=nw,
             pre_hook=_bwd_pre_hook_v3,
-        )
-        for (M, N, M1, N1) in [
+        ) for (M, N, M1, N1) in [
             (128, 64, 32, 128),
             (128, 64, 64, 64),
             (64, 128, 32, 128),
@@ -1499,9 +1442,7 @@ def _get_triton_bw_configs() -> List[triton.Config]:
             (64, 64, 32, 128),
             (32, 64, 32, 64),
             (32, 128, 32, 128),
-        ]
-        for ns in [2, 3]
-        for nw in [4, 8]
+        ] for ns in [2, 3] for nw in [4, 8]
     ]
     return configs
 
@@ -1618,9 +1559,9 @@ def _get_triton_bw_redq_configs() -> List[triton.Config]:
             num_warps=nw,
             pre_hook=_bwd_pre_hook_redq_v3,
         )
-        for M in [64]#, 32]
-        for N in [128]#, 128]
-        for ns in [2]#, 3]
+        for M in [64]  #, 32]
+        for N in [128]  #, 128]
+        for ns in [2]  #, 3]
         # EXPERIMENT (autoWS): force nw=4 only to test whether the PSM warp-budget
         # guard (skip WS if estimate > 16) is what suppresses warp specialization.
         for nw in [4]
@@ -1785,42 +1726,34 @@ def _hstu_attn_bwd_redq(  # noqa C901
                     scaled_alpha = alpha * 1.44269504
                 else:
                     scaled_alpha = alpha
-                M_off, Delta_off = backward_common_preprocess(
-                    M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
-                )
+                M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q,
+                                                              stride_mm)
                 # EXPERIMENT (autoWS): warp_specialize the inner Q loop. The
                 # `warp_specialize` kwarg only exists in beta triton, so this
                 # variant must be built with -m ovr_config//triton:beta. Guard
                 # before landing (constexpr-branch the tl.range on AUTOWS).
-                for start_m in tl.range(
-                    0, seq_len_q, BLOCK_M, num_stages=1, warp_specialize=WS_ON
-                ):
+                for start_m in tl.range(0, seq_len_q, BLOCK_M, num_stages=1, warp_specialize=WS_ON):
                     offs_m = start_m + tl.arange(0, BLOCK_M)
                     mask_m = offs_m < seq_len_q
-                    valid_mask_trans = backward_valid_mask(
-                        offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL
-                    )
+                    valid_mask_trans = backward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
                     q_offset = (seq_start_q + start_m).to(tl.int32)
                     q = desc_q.load([q_offset, off_h * stride_qh])
                     do = desc_do.load([q_offset, off_h * stride_doh])
                     qk_trans = tl.dot(k, tl.trans(q), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        qk_trans, act_qk_trans, pT = (
-                            backward_softmax_activation_scaled_alpha(
-                                qk_trans,
-                                scaled_alpha,
-                                valid_mask_trans,
-                                M_off,
-                                offs_m,
-                                stride_mm,
-                                mask_m,
-                                k,
-                            )
-                        )
+                        qk_trans, act_qk_trans, pT = (backward_softmax_activation_scaled_alpha(
+                            qk_trans,
+                            scaled_alpha,
+                            valid_mask_trans,
+                            M_off,
+                            offs_m,
+                            stride_mm,
+                            mask_m,
+                            k,
+                        ))
                     else:
-                        qk_trans, act_qk_trans, pT = backward_silu_activation(
-                            qk_trans, alpha, valid_mask_trans, k.dtype, scale
-                        )
+                        qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans,
+                                                                              k.dtype, scale)
                     if SHARED_KV:
                         dk += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
                     else:
@@ -1828,37 +1761,26 @@ def _hstu_attn_bwd_redq(  # noqa C901
                         dv += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
                     dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        dqk_trans = backward_d_softmax_activation(
-                            dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
-                        )
+                        dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m,
+                                                                  pT)
                     else:
-                        dqk_trans = backward_d_silu_activation(
-                            dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
-                        )
+                        dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
                     dqk_trans = dqk_trans.to(k.dtype)
                     dk += tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32) * alpha
-                    dq_trans = (
-                        tl.dot(tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32) * alpha
-                    )
+                    dq_trans = (tl.dot(tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32) * alpha)
                     dq = tl.trans(dq_trans)
                     desc_dq.store(
                         [q_offset, DimQ * off_h],
                         dq.to(desc_dq.dtype),
                         store_reduce="add",
                     )
-            DK_off = (
-                DK
-                + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64)
-                + off_h_kv * tl.cast(stride_dkh, tl.int64)
-            )
+            DK_off = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
+                      off_h_kv * tl.cast(stride_dkh, tl.int64))
             dk_ptrs = DK_off + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
             tl.store(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None])
             if not SHARED_KV:
-                DV_off = (
-                    DV
-                    + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64)
-                    + off_h_kv * tl.cast(stride_dvh, tl.int64)
-                )
+                DV_off = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
+                          off_h_kv * tl.cast(stride_dvh, tl.int64))
                 dv_ptrs = DV_off + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
                 # pyrefly: ignore [unbound-name]
                 tl.store(dv_ptrs, dv.to(k.dtype), mask=mask_n[:, None])
@@ -1945,17 +1867,17 @@ def _hstu_attn_bwd_redq(  # noqa C901
         # loop — masking is a no-op for full blocks. Kept autoWS-only (constexpr)
         # so the non-WS peeled fast path is unchanged.
         for start_n in tl.range(
-            0,
-            seq_len_kv,
-            BLOCK_N,
-            warp_specialize=WS_ON,
-            merge_epilogue_to_computation=WS_ON,
-            # With the compute fold, the dk accumulator's cross-iteration
-            # tmem_load is categorized as a correction op; merge it into the
-            # computation partition instead of spawning a separate correction
-            # partition (which would exceed the 16-warp budget).
-            merge_correction=WS_ON,
-            data_partition_factor=(2 if BLOCK_N >= 256 else 1),
+                0,
+                seq_len_kv,
+                BLOCK_N,
+                warp_specialize=WS_ON,
+                merge_epilogue_to_computation=WS_ON,
+                # With the compute fold, the dk accumulator's cross-iteration
+                # tmem_load is categorized as a correction op; merge it into the
+                # computation partition instead of spawning a separate correction
+                # partition (which would exceed the 16-warp budget).
+                merge_correction=WS_ON,
+                data_partition_factor=(2 if BLOCK_N >= 256 else 1),
         ):
             _hstu_attn_bwd_inner(
                 start_n,
@@ -2480,21 +2402,13 @@ def _hstu_attn_bwd(  # noqa C901
         mask_m = offs_m < seq_len_q
         tl.static_assert(ATTN_SCALE_TYPE == "scalar")
         scale = tl.load(attn_scale).to(tl.float32)
-        M_off, Delta_off = backward_common_preprocess(
-            M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
-        )
-        DK_off = (
-            DK
-            + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64)
-            + off_h_kv * tl.cast(stride_dkh, tl.int64)
-        )
+        M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm)
+        DK_off = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
+                  off_h_kv * tl.cast(stride_dkh, tl.int64))
         DV_off = DV
         if not SHARED_KV:
-            DV_off = (
-                DV
-                + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64)
-                + off_h_kv * tl.cast(stride_dvh, tl.int64)
-            )
+            DV_off = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
+                      off_h_kv * tl.cast(stride_dvh, tl.int64))
         dq_acc = tl.zeros([DimQ, BLOCK_M], dtype=tl.float32)
         if off_h < num_softmax_heads:
             scaled_alpha = alpha * 1.44269504
@@ -2512,9 +2426,7 @@ def _hstu_attn_bwd(  # noqa C901
                 v = desc_v.load([k_offset, off_h_kv * stride_vh])
             qk_trans = tl.dot(k, q_trans)
             offs_n = start_n + tl.arange(0, BLOCK_N)
-            valid_mask_trans = (offs_n[:, None] < seq_len_kv) & (
-                offs_m[None, :] < seq_len_q
-            )
+            valid_mask_trans = (offs_n[:, None] < seq_len_kv) & (offs_m[None, :] < seq_len_q)
             if off_h < num_softmax_heads:
                 qk_trans, act_qk_trans, pT = backward_softmax_activation_scaled_alpha(
                     qk_trans,
@@ -2527,22 +2439,16 @@ def _hstu_attn_bwd(  # noqa C901
                     k,
                 )
             else:
-                qk_trans, act_qk_trans, pT = backward_silu_activation(
-                    qk_trans, alpha, valid_mask_trans, k.dtype, scale
-                )
+                qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans, k.dtype, scale)
             if SHARED_KV:
                 dk = tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
             else:
                 dv = tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
             dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
             if off_h < num_softmax_heads:
-                dqk_trans = backward_d_softmax_activation(
-                    dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
-                )
+                dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT)
             else:
-                dqk_trans = backward_d_silu_activation(
-                    dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
-                )
+                dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
             dqk_trans = dqk_trans.to(k.dtype)
             if SHARED_KV:
                 dk_attn = tl.dot(dqk_trans, tl.trans(q_trans), allow_tf32=ALLOW_TF32)
@@ -2554,9 +2460,7 @@ def _hstu_attn_bwd(  # noqa C901
             dk_ptrs = DK_off + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
             mask_n = offs_n < seq_len_kv
             if G > 1:
-                tl.atomic_add(
-                    dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None], sem="relaxed"
-                )
+                tl.atomic_add(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None], sem="relaxed")
             else:
                 tl.store(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None])
             if not SHARED_KV:
@@ -2578,12 +2482,7 @@ def _hstu_attn_bwd(  # noqa C901
             dq_trans = dq_trans * alpha
             dq_acc += dq_trans
         dq = tl.trans(dq_acc)
-        dq_ptrs = (
-            DQ
-            + (seq_start_q + offs_m[:, None]) * stride_dqm
-            + off_h * stride_dqh
-            + tl.arange(0, DimQ)[None, :]
-        )
+        dq_ptrs = (DQ + (seq_start_q + offs_m[:, None]) * stride_dqm + off_h * stride_dqh + tl.arange(0, DimQ)[None, :])
         tl.store(dq_ptrs, dq.to(DQ.dtype.element_ty), mask=mask_m[:, None])
     else:
         for start_n in tl.range(0, last_block_start_n, BLOCK_N):
@@ -2808,9 +2707,7 @@ def _hstu_attn_bwd_redkv(
             for start_n in tl.range(0, seq_len_kv, BLOCK_N):
                 offs_n = start_n + tl.arange(0, BLOCK_N)
                 mask_n = offs_n < seq_len_kv
-                valid_mask_trans = backward_valid_mask(
-                    offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL
-                )
+                valid_mask_trans = backward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
                 k_offset = (seq_start_kv + start_n).to(tl.int32)
                 k = desc_k.load([k_offset, off_h_kv * stride_kh])
                 if SHARED_KV:
@@ -2825,80 +2722,55 @@ def _hstu_attn_bwd_redkv(
                         scaled_alpha = alpha * 1.44269504
                     else:
                         scaled_alpha = alpha
-                    M_off, Delta_off = backward_common_preprocess(
-                        M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
-                    )
+                    M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q,
+                                                                  stride_mm)
                     q = desc_q.load([seq_start_q, off_h * stride_qh])
                     do = desc_do.load([seq_start_q, off_h * stride_doh])
                     qk_trans = tl.dot(k, tl.trans(q), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        qk_trans, act_qk_trans, pT = (
-                            backward_softmax_activation_scaled_alpha(
-                                qk_trans,
-                                scaled_alpha,
-                                valid_mask_trans,
-                                M_off,
-                                offs_m,
-                                stride_mm,
-                                mask_m,
-                                k,
-                            )
-                        )
+                        qk_trans, act_qk_trans, pT = (backward_softmax_activation_scaled_alpha(
+                            qk_trans,
+                            scaled_alpha,
+                            valid_mask_trans,
+                            M_off,
+                            offs_m,
+                            stride_mm,
+                            mask_m,
+                            k,
+                        ))
                     else:
-                        qk_trans, act_qk_trans, pT = backward_silu_activation(
-                            qk_trans, alpha, valid_mask_trans, k.dtype, scale
-                        )
+                        qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans,
+                                                                              k.dtype, scale)
                     if SHARED_KV:
                         dk += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
                     else:
                         dv += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
                     dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        dqk_trans = backward_d_softmax_activation(
-                            dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
-                        )
+                        dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m,
+                                                                  pT)
                     else:
-                        dqk_trans = backward_d_silu_activation(
-                            dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
-                        )
+                        dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
                     dqk_trans = dqk_trans.to(k.dtype)
                     dk += tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32) * alpha
                     # dq for head g
                     dq_g = tl.dot(tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32)
-                    dq_acc += tl.where(
-                        (offs_g == g)[None, :, None], dq_g[:, None, :], 0.0
-                    )
-                DK_off = (
-                    DK
-                    + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64)
-                    + off_h_kv * tl.cast(stride_dkh, tl.int64)
-                )
+                    dq_acc += tl.where((offs_g == g)[None, :, None], dq_g[:, None, :], 0.0)
+                DK_off = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
+                          off_h_kv * tl.cast(stride_dkh, tl.int64))
                 dk_ptrs = DK_off + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
                 tl.store(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None])
                 if not SHARED_KV:
-                    DV_off = (
-                        DV
-                        + tl.cast(seq_start_kv, tl.int64)
-                        * tl.cast(stride_dvn, tl.int64)
-                        + off_h_kv * tl.cast(stride_dvh, tl.int64)
-                    )
-                    dv_ptrs = DV_off + (
-                        offs_n[:, None] * stride_dvn + offs_v_d[None, :]
-                    )
+                    DV_off = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
+                              off_h_kv * tl.cast(stride_dvh, tl.int64))
+                    dv_ptrs = DV_off + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
                     tl.store(dv_ptrs, dv.to(k.dtype), mask=mask_n[:, None])
             # Write dq per head from the accumulator.
             for g in range(G):
                 off_h = off_h_kv * G + g
-                dq_trans = tl.sum(
-                    tl.where((offs_g == g)[None, :, None], dq_acc, 0.0), axis=1
-                )
+                dq_trans = tl.sum(tl.where((offs_g == g)[None, :, None], dq_acc, 0.0), axis=1)
                 dq = tl.trans(dq_trans) * alpha
-                dq_ptrs = (
-                    DQ
-                    + (seq_start_q + offs_m[:, None]) * stride_dqm
-                    + off_h * stride_dqh
-                    + offs_qk_d[None, :]
-                )
+                dq_ptrs = (DQ + (seq_start_q + offs_m[:, None]) * stride_dqm + off_h * stride_dqh + offs_qk_d[None, :])
                 tl.store(dq_ptrs, dq.to(DQ.dtype.element_ty), mask=mask_m[:, None])
             return
 
@@ -2920,64 +2792,49 @@ def _hstu_attn_bwd_redkv(
                     scaled_alpha = alpha * 1.44269504
                 else:
                     scaled_alpha = alpha
-                M_off, Delta_off = backward_common_preprocess(
-                    M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
-                )
+                M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q,
+                                                              stride_mm)
                 for start_m in tl.range(0, seq_len_q, BLOCK_M):
                     offs_m = start_m + tl.arange(0, BLOCK_M)
                     mask_m = offs_m < seq_len_q
-                    valid_mask_trans = backward_valid_mask(
-                        offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL
-                    )
+                    valid_mask_trans = backward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
                     q_offset = (seq_start_q + start_m).to(tl.int32)
                     q = desc_q.load([q_offset, off_h * stride_qh])
                     do = desc_do.load([q_offset, off_h * stride_doh])
                     qk_trans = tl.dot(k, tl.trans(q), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        qk_trans, act_qk_trans, pT = (
-                            backward_softmax_activation_scaled_alpha(
-                                qk_trans,
-                                scaled_alpha,
-                                valid_mask_trans,
-                                M_off,
-                                offs_m,
-                                stride_mm,
-                                mask_m,
-                                k,
-                            )
-                        )
+                        qk_trans, act_qk_trans, pT = (backward_softmax_activation_scaled_alpha(
+                            qk_trans,
+                            scaled_alpha,
+                            valid_mask_trans,
+                            M_off,
+                            offs_m,
+                            stride_mm,
+                            mask_m,
+                            k,
+                        ))
                     else:
-                        qk_trans, act_qk_trans, pT = backward_silu_activation(
-                            qk_trans, alpha, valid_mask_trans, k.dtype, scale
-                        )
+                        qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans,
+                                                                              k.dtype, scale)
                     if SHARED_KV:
                         dk += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
                     else:
                         dv += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
                     dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        dqk_trans = backward_d_softmax_activation(
-                            dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
-                        )
+                        dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m,
+                                                                  pT)
                     else:
-                        dqk_trans = backward_d_silu_activation(
-                            dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
-                        )
+                        dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
                     dqk_trans = dqk_trans.to(k.dtype)
                     dk += tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32) * alpha
-            DK_off = (
-                DK
-                + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64)
-                + off_h_kv * tl.cast(stride_dkh, tl.int64)
-            )
+            DK_off = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
+                      off_h_kv * tl.cast(stride_dkh, tl.int64))
             dk_ptrs = DK_off + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
             tl.store(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None])
             if not SHARED_KV:
-                DV_off = (
-                    DV
-                    + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64)
-                    + off_h_kv * tl.cast(stride_dvh, tl.int64)
-                )
+                DV_off = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
+                          off_h_kv * tl.cast(stride_dvh, tl.int64))
                 dv_ptrs = DV_off + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
                 tl.store(dv_ptrs, dv.to(k.dtype), mask=mask_n[:, None])
         # Phase 2: dq (per head, tile over Q).
@@ -2987,9 +2844,7 @@ def _hstu_attn_bwd_redkv(
                 scaled_alpha = alpha * 1.44269504
             else:
                 scaled_alpha = alpha
-            M_off, Delta_off = backward_common_preprocess(
-                M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
-            )
+            M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm)
             for start_m in tl.range(0, seq_len_q, BLOCK_M):
                 offs_m = start_m + tl.arange(0, BLOCK_M)
                 mask_m = offs_m < seq_len_q
@@ -3000,9 +2855,7 @@ def _hstu_attn_bwd_redkv(
                 dq_trans = tl.zeros([DimQ, BLOCK_M], dtype=tl.float32)
                 for start_n in tl.range(0, seq_len_kv, BLOCK_N):
                     offs_n = start_n + tl.arange(0, BLOCK_N)
-                    valid_mask_trans = backward_valid_mask(
-                        offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL
-                    )
+                    valid_mask_trans = backward_valid_mask(offs_m, offs_n, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
                     k_offset = (seq_start_kv + start_n).to(tl.int32)
                     k = desc_k.load([k_offset, off_h_kv * stride_kh])
                     if SHARED_KV:
@@ -3011,40 +2864,29 @@ def _hstu_attn_bwd_redkv(
                         v = desc_v.load([k_offset, off_h_kv * stride_vh])
                     qk_trans = tl.dot(k, q_trans, allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        qk_trans, act_qk_trans, pT = (
-                            backward_softmax_activation_scaled_alpha(
-                                qk_trans,
-                                scaled_alpha,
-                                valid_mask_trans,
-                                M_off,
-                                offs_m,
-                                stride_mm,
-                                mask_m,
-                                k,
-                            )
-                        )
+                        qk_trans, act_qk_trans, pT = (backward_softmax_activation_scaled_alpha(
+                            qk_trans,
+                            scaled_alpha,
+                            valid_mask_trans,
+                            M_off,
+                            offs_m,
+                            stride_mm,
+                            mask_m,
+                            k,
+                        ))
                     else:
-                        qk_trans, act_qk_trans, pT = backward_silu_activation(
-                            qk_trans, alpha, valid_mask_trans, k.dtype, scale
-                        )
+                        qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans,
+                                                                              k.dtype, scale)
                     dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
                     if off_h < num_softmax_heads:
-                        dqk_trans = backward_d_softmax_activation(
-                            dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
-                        )
+                        dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m,
+                                                                  pT)
                     else:
-                        dqk_trans = backward_d_silu_activation(
-                            dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
-                        )
+                        dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
                     dqk_trans = dqk_trans.to(k.dtype)
                     dq_trans += tl.dot(tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32)
                 dq = tl.trans(dq_trans) * alpha
-                dq_ptrs = (
-                    DQ
-                    + (seq_start_q + offs_m[:, None]) * stride_dqm
-                    + off_h * stride_dqh
-                    + offs_qk_d[None, :]
-                )
+                dq_ptrs = (DQ + (seq_start_q + offs_m[:, None]) * stride_dqm + off_h * stride_dqh + offs_qk_d[None, :])
                 tl.store(dq_ptrs, dq.to(DQ.dtype.element_ty), mask=mask_m[:, None])
         return
 
@@ -3258,17 +3100,11 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
     offs_m = start_m + tl.arange(0, BLOCK_M)
     # Offset DQ, DK, DV pointers by sequence start and head offset
     DQ = DQ + seq_start_q * stride_dqm + off_h * stride_dqh
-    DK = (
-        DK
-        + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64)
-        + off_h_kv * tl.cast(stride_dkh, tl.int64)
-    )
+    DK = (DK + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dkn, tl.int64) +
+          off_h_kv * tl.cast(stride_dkh, tl.int64))
     if not SHARED_KV:
-        DV = (
-            DV
-            + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64)
-            + off_h_kv * tl.cast(stride_dvh, tl.int64)
-        )
+        DV = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
+              off_h_kv * tl.cast(stride_dvh, tl.int64))
     mask_m = offs_m < seq_len_q
     if ATTN_SCALE_TYPE == "scalar":
         scale = tl.load(attn_scale).to(tl.float32)
@@ -3277,9 +3113,7 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
         scale = tl.load(attn_scale + offs_m, mask=mask_m).to(tl.float32)
 
     # Preprocess M and Delta offsets for softmax
-    M_off, Delta_off = backward_common_preprocess(
-        M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
-    )
+    M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm)
 
     if HAS_CAUSAL:
         high_kv = start_m + BLOCK_M + seq_len_kv - uih_len_q
@@ -3338,9 +3172,7 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
                     seq_len_kv,
                     HAS_CAUSAL,
                 )
-                qk_trans, act_qk_trans, pT = backward_silu_activation(
-                    qk_trans, alpha, valid_mask_trans, k.dtype, scale
-                )
+                qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans, k.dtype, scale)
             else:
                 qk_trans = qk_trans * alpha
                 pT = fast_silu(qk_trans, MULT_BY_X=False)
@@ -3372,9 +3204,7 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
 
         dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
         if off_h < num_softmax_heads:
-            dqk_trans = backward_d_softmax_activation(
-                dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
-            )
+            dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT)
         else:
             if q_needs_mask or HAS_CAUSAL:
                 valid_mask_trans = backward_valid_mask(
@@ -3393,9 +3223,7 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
                     valid_mask_trans,
                 )
             else:
-                dqk_trans = (
-                    dact_qk_trans * pT * (1 + qk_trans * (1 - pT)) * scale[None, :]
-                )
+                dqk_trans = (dact_qk_trans * pT * (1 + qk_trans * (1 - pT)) * scale[None, :])
         dqk_trans = dqk_trans.to(k.dtype)
         if SHARED_KV:
             dk_attn = tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32)
@@ -3450,9 +3278,7 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
                 k,
             )
         else:
-            qk_trans, act_qk_trans, pT = backward_silu_activation(
-                qk_trans, alpha, valid_mask_trans, k.dtype, scale
-            )
+            qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans, k.dtype, scale)
         if SHARED_KV:
             dk = tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
             v = k
@@ -3475,13 +3301,9 @@ def _hstu_attn_bwd_redkv_inner(  # noqa C901
 
         dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
         if off_h < num_softmax_heads:
-            dqk_trans = backward_d_softmax_activation(
-                dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
-            )
+            dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT)
         else:
-            dqk_trans = backward_d_silu_activation(
-                dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
-            )
+            dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
         dqk_trans = dqk_trans.to(k.dtype)
         if SHARED_KV:
             dk_attn = tl.dot(dqk_trans, q, allow_tf32=ALLOW_TF32)
@@ -3585,17 +3407,12 @@ def _hstu_attn_bwd_inner(  # noqa C901
         dv = tl.zeros([BLOCK_N, DimV], dtype=tl.float32)
     # Offset DV pointers by sequence start and head offset
     if not SHARED_KV:
-        DV = (
-            DV
-            + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64)
-            + off_h_kv * tl.cast(stride_dvh, tl.int64)
-        )
+        DV = (DV + tl.cast(seq_start_kv, tl.int64) * tl.cast(stride_dvn, tl.int64) +
+              off_h_kv * tl.cast(stride_dvh, tl.int64))
     tl.static_assert(ATTN_SCALE_TYPE == "scalar")
     scale = tl.load(attn_scale).to(tl.float32)
 
-    M_off, Delta_off = backward_common_preprocess(
-        M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
-    )
+    M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm)
 
     offs_n = start_n + tl.arange(0, BLOCK_N)
     # EXPERIMENT (autoWS): for the all-or-nothing softmax shape (num_softmax_heads
@@ -3617,9 +3434,7 @@ def _hstu_attn_bwd_inner(  # noqa C901
     # partition (Meta partition-scheduler merge-epilogue knob) so autoWS has the
     # same 4-partition layout as the hand-TLX kernel (which stores dk/dv in the
     # reduction/default task) instead of a separate epilogue partition.
-    for start_m in tl.range(
-        low_q, seq_len_q, BLOCK_M, warp_specialize=WS_ON, merge_epilogue=WS_ON
-    ):
+    for start_m in tl.range(low_q, seq_len_q, BLOCK_M, warp_specialize=WS_ON, merge_epilogue=WS_ON):
         offs_m = start_m + tl.arange(0, BLOCK_M)
         mask_m = offs_m < seq_len_q
         q_offset = seq_start_q + start_m
@@ -3627,8 +3442,8 @@ def _hstu_attn_bwd_inner(  # noqa C901
         qk_trans = tl.dot(
             k,
             tl.trans(q),
-            attrs=(_HSTU_ATTRS_QKT_2KV if (SHARED_KV and _HSTU_COMPUTE_FOLD)
-                   else _HSTU_ATTRS_QKT) if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+            attrs=(_HSTU_ATTRS_QKT_2KV if (SHARED_KV and _HSTU_COMPUTE_FOLD) else _HSTU_ATTRS_QKT) if
+            (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
         if MASK_KV or HAS_CAUSAL:
             valid_mask_trans = backward_valid_mask(
@@ -3653,65 +3468,77 @@ def _hstu_attn_bwd_inner(  # noqa C901
                 k,
             )
         else:
-            qk_trans, act_qk_trans, pT = backward_silu_activation(
-                qk_trans, alpha, valid_mask_trans, k.dtype, scale
-            )
+            qk_trans, act_qk_trans, pT = backward_silu_activation(qk_trans, alpha, valid_mask_trans, k.dtype, scale)
         do = desc_do.load([q_offset.to(tl.int32), off_h * stride_doh])
 
         dact_qk_trans = tl.dot(
-            v, tl.trans(do), allow_tf32=ALLOW_TF32,
-            attrs=(_HSTU_ATTRS_DPT_2KV if (SHARED_KV and _HSTU_COMPUTE_FOLD)
-                   else _HSTU_ATTRS_DPT) if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+            v,
+            tl.trans(do),
+            allow_tf32=ALLOW_TF32,
+            attrs=(_HSTU_ATTRS_DPT_2KV if (SHARED_KV and _HSTU_COMPUTE_FOLD) else _HSTU_ATTRS_DPT) if
+            (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
         if SHARED_KV:
             dk = tl.dot(
-                act_qk_trans, do, dk, allow_tf32=ALLOW_TF32,
-                attrs=(_HSTU_ATTRS_DV_2KV if _HSTU_COMPUTE_FOLD
-                       else _HSTU_ATTRS_DV) if (WS_ON and not _HSTU_MODULO_TOPK) else None,
+                act_qk_trans,
+                do,
+                dk,
+                allow_tf32=ALLOW_TF32,
+                attrs=(_HSTU_ATTRS_DV_2KV if _HSTU_COMPUTE_FOLD else _HSTU_ATTRS_DV) if
+                (WS_ON and not _HSTU_MODULO_TOPK) else None,
             )
         else:
             # pyrefly: ignore [unbound-name]
             dv = tl.dot(
-                act_qk_trans, do, dv, allow_tf32=ALLOW_TF32,
+                act_qk_trans,
+                do,
+                dv,
+                allow_tf32=ALLOW_TF32,
                 attrs=_HSTU_ATTRS_DV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
             )
 
         if num_softmax_heads > 0:  # autoWS: constexpr (see note above)
-            dqk_trans = backward_d_softmax_activation(
-                dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT
-            )
+            dqk_trans = backward_d_softmax_activation(dact_qk_trans, Delta_off, offs_m, stride_mm, mask_m, pT)
         else:
-            dqk_trans = backward_d_silu_activation(
-                dact_qk_trans, pT, qk_trans, scale, valid_mask_trans
-            )
+            dqk_trans = backward_d_silu_activation(dact_qk_trans, pT, qk_trans, scale, valid_mask_trans)
         if SHARED_KV and _HSTU_COMPUTE_FOLD:
             # Fold dk_attn into dk: pre-scale alpha into dqk_trans (fp32) so both
             # the dq and dk_attn dots carry alpha, then accumulate dk_attn
             # directly into the dv/dk accumulator (dk_shared -> buffer id 7).
             dqk_trans = (dqk_trans * alpha).to(k.dtype)
             dq_trans = tl.dot(
-                tl.trans(k), dqk_trans,
+                tl.trans(k),
+                dqk_trans,
                 attrs=_HSTU_ATTRS_DQ_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
             )
             dk = tl.dot(
-                dqk_trans, q, dk, allow_tf32=ALLOW_TF32,
+                dqk_trans,
+                q,
+                dk,
+                allow_tf32=ALLOW_TF32,
                 attrs=_HSTU_ATTRS_DK_SHARED_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
             )
         else:
             dqk_trans = dqk_trans.to(k.dtype)
             dq_trans = tl.dot(
-                tl.trans(k), dqk_trans,
+                tl.trans(k),
+                dqk_trans,
                 attrs=_HSTU_ATTRS_DQ if (WS_ON and not _HSTU_MODULO_TOPK) else None,
             )
             if SHARED_KV:
                 dk_attn = tl.dot(
-                    dqk_trans, q, allow_tf32=ALLOW_TF32,
+                    dqk_trans,
+                    q,
+                    allow_tf32=ALLOW_TF32,
                     attrs=_HSTU_ATTRS_DK if (WS_ON and not _HSTU_MODULO_TOPK) else None,
                 )
                 dk = dk + dk_attn * alpha
             else:
                 dk = tl.dot(
-                    dqk_trans, q, dk, allow_tf32=ALLOW_TF32,
+                    dqk_trans,
+                    q,
+                    dk,
+                    allow_tf32=ALLOW_TF32,
                     attrs=_HSTU_ATTRS_DK if (WS_ON and not _HSTU_MODULO_TOPK) else None,
                 )
             dq_trans = dq_trans * alpha
@@ -3839,9 +3666,7 @@ def _hstu_attn_bwd_inner_2kv(  # noqa C901
 
     scale = tl.load(attn_scale).to(tl.float32)
 
-    M_off, Delta_off = backward_common_preprocess(
-        M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm
-    )
+    M_off, Delta_off = backward_common_preprocess(M, Delta, off_h, num_softmax_heads, seq_start_q, stride_mm)
 
     offs_n0 = start_n + tl.arange(0, BLOCK_N)
     offs_n1 = start_n + BLOCK_N + tl.arange(0, BLOCK_N)
@@ -3874,8 +3699,12 @@ def _hstu_attn_bwd_inner_2kv(  # noqa C901
     # the pipeliner ("local_alloc can't predicate") on the doubled operand
     # allocs, so the loop pipeline depth is pinned to 1 regardless of num_stages.
     for start_m in tl.range(
-        low_q, seq_len_q, BLOCK_M, num_stages=1,
-        warp_specialize=WS_ON, merge_epilogue=False,
+            low_q,
+            seq_len_q,
+            BLOCK_M,
+            num_stages=1,
+            warp_specialize=WS_ON,
+            merge_epilogue=False,
     ):
         offs_m = start_m + tl.arange(0, BLOCK_M)
         mask_m = offs_m < seq_len_q
@@ -3886,79 +3715,79 @@ def _hstu_attn_bwd_inner_2kv(  # noqa C901
 
         # ---- KV block b0 (SHARED_KV + compute fold) ----
         qk_trans0 = tl.dot(
-            k0, tl.trans(q),
+            k0,
+            tl.trans(q),
             attrs=_HSTU_ATTRS_QKT_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
 
         ######### computation/activation for P0
         if MASK_KV or HAS_CAUSAL:
-            valid_mask_trans0 = backward_valid_mask(
-                offs_m, offs_n0, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL
-            )
+            valid_mask_trans0 = backward_valid_mask(offs_m, offs_n0, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
         else:
             valid_mask_trans0 = offs_m[None, :] < seq_len_q
         if num_softmax_heads > 0:
-            qk_trans0, act_qk_trans0, pT0 = (
-                backward_softmax_activation_scaled_alpha(
-                    qk_trans0, scaled_alpha, valid_mask_trans0, M_off, offs_m,
-                    stride_mm, mask_m, k0,
-                )
-            )
+            qk_trans0, act_qk_trans0, pT0 = (backward_softmax_activation_scaled_alpha(
+                qk_trans0,
+                scaled_alpha,
+                valid_mask_trans0,
+                M_off,
+                offs_m,
+                stride_mm,
+                mask_m,
+                k0,
+            ))
         else:
-            qk_trans0, act_qk_trans0, pT0 = backward_silu_activation(
-                qk_trans0, alpha, valid_mask_trans0, k0.dtype, scale
-            )
+            qk_trans0, act_qk_trans0, pT0 = backward_silu_activation(qk_trans0, alpha, valid_mask_trans0, k0.dtype,
+                                                                     scale)
         dact_qk_trans0 = tl.dot(
-            v0, tl.trans(do), allow_tf32=ALLOW_TF32,
+            v0,
+            tl.trans(do),
+            allow_tf32=ALLOW_TF32,
             attrs=_HSTU_ATTRS_DPT_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
         if num_softmax_heads > 0:
-            dqk_trans0 = backward_d_softmax_activation(
-                dact_qk_trans0, Delta_off, offs_m, stride_mm, mask_m, pT0
-            )
+            dqk_trans0 = backward_d_softmax_activation(dact_qk_trans0, Delta_off, offs_m, stride_mm, mask_m, pT0)
         else:
-            dqk_trans0 = backward_d_silu_activation(
-                dact_qk_trans0, pT0, qk_trans0, scale, valid_mask_trans0
-            )
+            dqk_trans0 = backward_d_silu_activation(dact_qk_trans0, pT0, qk_trans0, scale, valid_mask_trans0)
         ######### computation/activation for P1
         # ---- KV block b1 (SHARED_KV + compute fold) ----
         # WS on: b1 uses DISJOINT buffer.ids (_B1) so its concurrently-live
         # tiles never alias b0's (which stays on _2KV).
         qk_trans1 = tl.dot(
-            k1, tl.trans(q),
+            k1,
+            tl.trans(q),
             attrs=_HSTU_ATTRS_QKT_2KV_B1 if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
         if MASK_KV or HAS_CAUSAL:
-            valid_mask_trans1 = backward_valid_mask(
-                offs_m, offs_n1, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL
-            )
+            valid_mask_trans1 = backward_valid_mask(offs_m, offs_n1, uih_len_q, seq_len_q, seq_len_kv, HAS_CAUSAL)
         else:
             valid_mask_trans1 = offs_m[None, :] < seq_len_q
         # calculate pT
         if num_softmax_heads > 0:
-            qk_trans1, act_qk_trans1, pT1 = (
-                backward_softmax_activation_scaled_alpha(
-                    qk_trans1, scaled_alpha, valid_mask_trans1, M_off, offs_m,
-                    stride_mm, mask_m, k1,
-                )
-            )
+            qk_trans1, act_qk_trans1, pT1 = (backward_softmax_activation_scaled_alpha(
+                qk_trans1,
+                scaled_alpha,
+                valid_mask_trans1,
+                M_off,
+                offs_m,
+                stride_mm,
+                mask_m,
+                k1,
+            ))
         else:
-            qk_trans1, act_qk_trans1, pT1 = backward_silu_activation(
-                qk_trans1, alpha, valid_mask_trans1, k1.dtype, scale
-            )
+            qk_trans1, act_qk_trans1, pT1 = backward_silu_activation(qk_trans1, alpha, valid_mask_trans1, k1.dtype,
+                                                                     scale)
         dact_qk_trans1 = tl.dot(
-            v1, tl.trans(do), allow_tf32=ALLOW_TF32,
+            v1,
+            tl.trans(do),
+            allow_tf32=ALLOW_TF32,
             attrs=_HSTU_ATTRS_DPT_2KV_B1 if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
         # calculate dqk_trans
         if num_softmax_heads > 0:
-            dqk_trans1 = backward_d_softmax_activation(
-                dact_qk_trans1, Delta_off, offs_m, stride_mm, mask_m, pT1
-            )
+            dqk_trans1 = backward_d_softmax_activation(dact_qk_trans1, Delta_off, offs_m, stride_mm, mask_m, pT1)
         else:
-            dqk_trans1 = backward_d_silu_activation(
-                dact_qk_trans1, pT1, qk_trans1, scale, valid_mask_trans1
-            )
+            dqk_trans1 = backward_d_silu_activation(dact_qk_trans1, pT1, qk_trans1, scale, valid_mask_trans1)
 
         # compute fold: pre-scale alpha into dqk so both dq and dk_attn carry it.
         dqk_trans0 = (dqk_trans0 * alpha).to(k0.dtype)
@@ -3967,16 +3796,23 @@ def _hstu_attn_bwd_inner_2kv(  # noqa C901
         # cross-partition register sum (dq0 and dq1 land in different warp
         # partitions under WS) and a two-store race, and needs one TMEM tile.
         dq_trans = tl.dot(
-            tl.trans(k0), dqk_trans0,
+            tl.trans(k0),
+            dqk_trans0,
             attrs=_HSTU_ATTRS_DQ_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
         # dv fold: accumulate dv into the shared dk accumulator.
         dk0 = tl.dot(
-            act_qk_trans0, do, dk0, allow_tf32=ALLOW_TF32,
+            act_qk_trans0,
+            do,
+            dk0,
+            allow_tf32=ALLOW_TF32,
             attrs=_HSTU_ATTRS_DV_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
         dk0 = tl.dot(
-            dqk_trans0, q, dk0, allow_tf32=ALLOW_TF32,
+            dqk_trans0,
+            q,
+            dk0,
+            allow_tf32=ALLOW_TF32,
             attrs=_HSTU_ATTRS_DK_SHARED_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
 
@@ -3987,15 +3823,23 @@ def _hstu_attn_bwd_inner_2kv(  # noqa C901
         # Accumulate b1's dq into the SAME dq_trans TMEM tile (opndD id 11 via
         # _B1), reducing both KV blocks' contributions in TMEM.
         dq_trans = tl.dot(
-            tl.trans(k1), dqk_trans1, dq_trans,
+            tl.trans(k1),
+            dqk_trans1,
+            dq_trans,
             attrs=_HSTU_ATTRS_DQ_2KV_B1 if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
         dk1 = tl.dot(
-            act_qk_trans1, do, dk1, allow_tf32=ALLOW_TF32,
+            act_qk_trans1,
+            do,
+            dk1,
+            allow_tf32=ALLOW_TF32,
             attrs=_HSTU_ATTRS_DV_2KV_B1 if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
         dk1 = tl.dot(
-            dqk_trans1, q, dk1, allow_tf32=ALLOW_TF32,
+            dqk_trans1,
+            q,
+            dk1,
+            allow_tf32=ALLOW_TF32,
             attrs=_HSTU_ATTRS_DK_SHARED_2KV_B1 if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
 
@@ -4035,12 +3879,7 @@ def triton_hstu_cross_attn_v3_fwd(
     num_targets: Optional[torch.Tensor] = None,
     causal: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, int]:
-    enable_tma = (
-        enable_tma
-        and HAS_TENSOR_DESCRIPTOR
-        and is_sm90_plus()
-        and not torch.version.hip
-    )
+    enable_tma = (enable_tma and HAS_TENSOR_DESCRIPTOR and is_sm90_plus() and not torch.version.hip)
     q = switch_to_contiguous_if_needed(q)
     k = switch_to_contiguous_if_needed(k)
     v = switch_to_contiguous_if_needed(v)
@@ -4192,14 +4031,9 @@ def triton_hstu_cross_attn_v3_bwd(
     bwd_variant = get_bwd_variant()
     if (bwd_variant == BwdVariant.AUTO) and (max_q_len < 128):
         bwd_variant = BwdVariant.TRITON_REDKV
-    use_per_kv_head = (
-        bwd_variant in (BwdVariant.AUTO, BwdVariant.TRITON_REDKV)
-        and G > 1
-        and (max_q_len < 192 or (num_softmax_heads == 0 and max_q_len <= 256))
-    )
-    use_redq_per_kv_head = (
-        bwd_variant in (BwdVariant.TRITON_REDQ, BwdVariant.TRITON_AUTOWS) and G > 1
-    )
+    use_per_kv_head = (bwd_variant in (BwdVariant.AUTO, BwdVariant.TRITON_REDKV) and G > 1
+                       and (max_q_len < 192 or (num_softmax_heads == 0 and max_q_len <= 256)))
+    use_redq_per_kv_head = (bwd_variant in (BwdVariant.TRITON_REDQ, BwdVariant.TRITON_AUTOWS) and G > 1)
     if use_per_kv_head:
         dq_dtype = q.dtype
         dkdv_dtype = k.dtype
@@ -4258,7 +4092,7 @@ def triton_hstu_cross_attn_v3_bwd(
     if use_per_kv_head or bwd_variant == BwdVariant.TRITON_REDKV:
         if use_per_kv_head:
             H_kv = H // G
-            grid = lambda meta: (Z * H_kv,)  # noqa E731
+            grid = lambda meta: (Z * H_kv, )  # noqa E731
         else:
             grid = lambda meta: (  # noqa E731
                 triton.cdiv(max_q_len, meta["BLOCK_M"]),
@@ -4319,7 +4153,7 @@ def triton_hstu_cross_attn_v3_bwd(
     elif bwd_variant in (BwdVariant.TRITON_REDQ, BwdVariant.TRITON_AUTOWS):
         if use_redq_per_kv_head:
             H_kv = H // G
-            grid = lambda meta: (Z * H_kv,)  # noqa E731
+            grid = lambda meta: (Z * H_kv, )  # noqa E731
         else:
             grid = lambda meta: (Z * H, 1)  # noqa E731
         _hstu_attn_bwd_redq[grid](
@@ -4374,10 +4208,7 @@ def triton_hstu_cross_attn_v3_bwd(
             AUTOWS=(bwd_variant == BwdVariant.TRITON_AUTOWS),
             # WS_ON == AUTOWS normally; set HSTU_AUTOWS_WS_OFF=1 to run the autoWS
             # loop STRUCTURE with warp specialization DISABLED (isolation reference).
-            WS_ON=(
-                (bwd_variant == BwdVariant.TRITON_AUTOWS)
-                and os.environ.get("HSTU_AUTOWS_WS_OFF", "0") != "1"
-            ),
+            WS_ON=((bwd_variant == BwdVariant.TRITON_AUTOWS) and os.environ.get("HSTU_AUTOWS_WS_OFF", "0") != "1"),
         )
     elif bwd_variant == BwdVariant.TRITON_AUTOWS_2KV:
         # MANUAL 2-KV-block data-partition variant. Shared-KV only; G == 1
@@ -4500,6 +4331,7 @@ def triton_hstu_cross_attn_v3_bwd(
 
 
 class AttentionFunction(torch.autograd.Function):
+
     @staticmethod
     # pyre-fixme[14]: `forward` overrides method defined in `Function` inconsistently.
     def forward(
@@ -4527,7 +4359,6 @@ class AttentionFunction(torch.autograd.Function):
             v = switch_to_contiguous_if_needed(v)
         else:
             v = k
-        Z = seq_offsets.numel() - 1
         total_seq_len_q, H, DimQ = q.shape
         _, H_kv, DimV = v.shape
         assert H % H_kv == 0, f"H ({H}) must be divisible by H_kv ({H_kv})"
@@ -4536,12 +4367,7 @@ class AttentionFunction(torch.autograd.Function):
             out = torch.zeros(total_seq_len_q, H, DimV, device=q.device, dtype=q.dtype)
             return out
 
-        if (
-            G > 1
-            and H_kv == 1
-            and (num_softmax_heads == 0 or num_softmax_heads == H)
-            and not causal
-        ):
+        if (G > 1 and H_kv == 1 and (num_softmax_heads == 0 or num_softmax_heads == H) and not causal):
             # GQA can not enabled with causal masking
             seq_offsets_q = seq_offsets_q * G
             max_q_len = max_q_len * G
@@ -4604,33 +4430,28 @@ class AttentionFunction(torch.autograd.Function):
     def backward(
         ctx, dout: torch.Tensor
     ) -> Tuple[
-        None,
-        None,
-        torch.Tensor,
-        torch.Tensor,
-        Optional[torch.Tensor],
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
+            None,
+            None,
+            torch.Tensor,
+            torch.Tensor,
+            Optional[torch.Tensor],
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
     ]:
         saved_tensors = ctx.saved_tensors
         q, k, v, seq_offsets, attn_scale, seq_offsets_q = saved_tensors[:6]
         idx = 6
         num_softmax_heads = ctx.num_softmax_heads
         # Reshape dout from [T, H, DimV] to folded [T*G, H_kv, DimV]
-        if (
-            ctx.H > 1
-            and ctx.H_kv == 1
-            and (num_softmax_heads == 0 or num_softmax_heads == ctx.H)
-            and not ctx.causal
-        ):
+        if (ctx.H > 1 and ctx.H_kv == 1 and (num_softmax_heads == 0 or num_softmax_heads == ctx.H) and not ctx.causal):
             dout = dout.view(ctx.total_seq_len_q * ctx.H, -1, dout.shape[-1])
         if num_softmax_heads > 0:
             M = saved_tensors[idx]
@@ -4640,12 +4461,7 @@ class AttentionFunction(torch.autograd.Function):
             Delta = torch.empty_like(M)
             pre_grid = (triton.cdiv(out.shape[0], 128), num_softmax_heads)
             _attn_bwd_preprocess[pre_grid](
-                out,
-                dout,
-                Delta,
-                out.shape[0],
-                H=out.shape[1],
-                softmax_heads=num_softmax_heads,
+                out, dout, Delta, out.shape[0], H=out.shape[1], softmax_heads=num_softmax_heads,
                 BLOCK_M=128,  # pyre-ignore [6]
                 HEAD_DIM=out.shape[2],  # pyre-ignore [6]
             )
@@ -4666,9 +4482,7 @@ class AttentionFunction(torch.autograd.Function):
             from tlx_bw_cross_attention import tlx_bw_reduce_dq
 
             use_2kv = get_bwd_variant() == BwdVariant.TLX_2KV
-            assert not use_2kv or ctx.shared_kv, (
-                "BwdVariant.TLX_2KV (attn_bwd_ws_2kv) requires shared_kv"
-            )
+            assert not use_2kv or ctx.shared_kv, ("BwdVariant.TLX_2KV (attn_bwd_ws_2kv) requires shared_kv")
             out_t = out if num_softmax_heads > 0 else None
             M_t = M if num_softmax_heads > 0 else None
             dq, dk, dv = tlx_bw_reduce_dq(
@@ -4809,7 +4623,3 @@ def triton_bw_hstu_mha_wrapper(
         actual_max_seq_len=actual_max_seq_len,
         truncate_method=truncate_method,
     )
-
-
-
-


### PR DESCRIPTION
Summary:

Data-partition detection grouped MMAs by disjoint compute slices and never
looked at their accumulators, so two MMAs that accumulate into the SAME
tensor-memory tile (e.g. the HSTU 2-KV reduce_dq kernel: dq += K0^T·dS0 then
dq += K1^T·dS1 into one dq accumulator) were counted as independent data
partitions. Their compute was then split into two computation partitions even
though the two streams converge on a single serialized reduction and gain no
real parallelism -- inflating the partition count and warp budget (18/16 for
2-KV reduce_dq, which pushed the whole loop off WS).

Layer 1 unions MMAs that write the same accumulator buffer during group
detection, so such streams collapse into one data-partition group (dpFactor
drops), the compute merges into a single computation partition, and the budget
fits (14/16). Layer 2 adds a verification backstop: if any assignment path
still places accumulator-chained MMAs in different partitions, the pass emits
an error at the offending op.

Scope: this is a partition-count / warp-budget lever (and a cleaner grouping
invariant), NOT a correctness fix. On Blackwell the MMAs already co-locate in
the gemm partition regardless of dpFactor, so this does not change dq's data
flow. The 2-KV kernel's dq is corrupted under WS by a separate cross-partition
gemm->reduction store-reduce handoff of the shared dq accumulator (rel-L2 ~89,
tracked in T279388065). Because this change lowers the budget enough for WS to
fire and expose that bug, the 2-KV inner loop is kept warp_specialize=off until
the handoff is fixed; it stays correct via the non-WS fallback.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D111727755


