### PR TITLE
[triton] denoise.sh: add GB300 (1400W) and default unknown NVIDIA GPUs to rated power

### DIFF
--- a/third_party/tlx/denoise.sh
+++ b/third_party/tlx/denoise.sh
@@ -18,6 +18,7 @@ if [[ "$GPU_VENDOR" == "nvidia" ]]; then
 
     CURRENT_POWER=$(nvidia-smi --query-gpu=power.limit --format=csv,noheader,nounits -i "$CUDA_VISIBLE_DEVICES")
     MAX_POWER=$(nvidia-smi --query-gpu=power.max_limit  --format=csv,noheader,nounits -i "$CUDA_VISIBLE_DEVICES")
+    DEFAULT_POWER=$(nvidia-smi --query-gpu=power.default_limit --format=csv,noheader,nounits -i "$CUDA_VISIBLE_DEVICES")
     MAX_SM_CLOCK=$(nvidia-smi --query-gpu=clocks.max.graphics --format=csv,noheader,nounits  -i "$CUDA_VISIBLE_DEVICES")
 
     GPU_MODEL=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -n1 | awk '{print $2}')
@@ -27,10 +28,21 @@ if [[ "$GPU_VENDOR" == "nvidia" ]]; then
             DESIRED_POWER=700
         elif [[ "$GPU_MODEL" == "GB200" ]]; then
             DESIRED_POWER=1200
+        elif [[ "$GPU_MODEL" == "GB300" ]]; then
+            DESIRED_POWER=1400
         elif [[ "$GPU_MODEL" == "B200" ]]; then
             DESIRED_POWER=750
         else
-            DESIRED_POWER=500
+            # Unknown GPU: use the card's rated power (power.default_limit) so the
+            # locked max clock runs at the power it is designed to sustain, rather
+            # than an arbitrary 500 W that power-throttles large parts (a GB300,
+            # for example, reports default_limit = max = 1400 W). Fall back to
+            # 500 W only if the query did not return a number.
+            if [[ "$DEFAULT_POWER" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+                DESIRED_POWER="$DEFAULT_POWER"
+            else
+                DESIRED_POWER=500
+            fi
         fi
     fi
 


### PR DESCRIPTION
Summary:
`denoise.sh` picks a per-GPU `DESIRED_POWER` and then locks the SM clock to its max. The model table only knew `H100`/`GB200`/`B200`, so a GB300 (whose `nvidia-smi` name is `NVIDIA GB300`) fell through to the `else` branch and was capped to **500 W** — on a part whose `default_limit == max_limit == 1400 W`. That power-throttles the locked 2070 MHz clock, roughly halving throughput (measured cuBLAS GEMM ~617 tflops at 500 W vs ~1600-2174 tflops at 1400 W) and silently biasing any cross-arch benchmark comparison.

Two changes:
- Add an explicit `GB300 -> 1400` branch, matching the existing convention of setting the cap to the card's rated power (`B200 -> 750`, `GB200 -> 1200`, per D77961370).
- For any still-unknown NVIDIA GPU, default `DESIRED_POWER` to the card's `power.default_limit` (its rated power) instead of a hardcoded 500 W, falling back to 500 W only if the query returns no number. This auto-corrects future parts so they lock the max clock at the power they are designed to sustain.

`POWER_CAP` is still `min(DESIRED_POWER, power.max_limit)`, so this can never exceed what the board allows.

Differential Revision: D111943428


