### PR TITLE
[TritonNvidiaGPU] Validate and insert aliased-TMEM WAR barriers (issue #1996)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h
@@ -27,6 +27,13 @@ struct TMemLdStEncodingInfo {
   bool padding = false;
 };
 
+// Return the physical (register, lane, warp) -> (row, col) TMEM layout used by
+// tcgen05 load/store lowering. This includes the implicit warp-to-row mapping
+// required by the hardware access atoms.
+FailureOr<LinearLayout> computeTMemLdStPhysicalLayout(
+    RankedTensorType regTy, gpu::MemDescType memTy,
+    std::function<InFlightDiagnostic()> emitError = {});
+
 FailureOr<TMemLdStEncodingInfo>
 computeTMemLdStEncodingInfo(RankedTensorType regTy, gpu::MemDescType memTy,
                             int maxnreg,

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -242,6 +242,28 @@ def TritonNvidiaGPUPruneUnusedBarriersPass
   ];
 }
 
+def TritonNvidiaGPUInsertTMemAliasWARBarrierPass
+    : Pass<"triton-nvidia-gpu-insert-tmem-alias-war-barrier", "mlir::ModuleOp"> {
+  let summary = "Insert intra-task barriers for aliased-TMEM write-after-read hazards";
+
+  let description = [{
+    In a warp-specialized task, a TMEM region read (tcgen05.ld) then overwritten
+    by an aliased store (tcgen05.st) into the same TMEM root can race across
+    warps. This pass compares the accesses in physical TMEM row/32-bit-column
+    coordinates, including constant view offsets, and inserts a task-scoped
+    ttg.barrier for a cross-warp overlap when the same basic block has no
+    intervening full-task synchronization. A ttg.barrier or a named bar.sync
+    whose thread count covers the whole task is sufficient; partial named
+    barriers and producer/consumer mbarriers are not. Existing synchronization
+    is preserved and no duplicate barrier is inserted.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::gpu::TritonGPUDialect",
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+  ];
+}
+
 def TritonNvidiaGPUCheckMatmulTwoCTAPass : Pass<"triton-nvidia-check-matmul-two-cta", "mlir::ModuleOp"> {
   let summary = "Verify legal and consistent two_ctas usage across matmuls";
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
@@ -271,10 +271,9 @@ lowerTMemLdSt(const LinearLayout &cvt, int maxnreg, int bitwidth, bool isScales,
   return info;
 }
 
-FailureOr<TMemLdStEncodingInfo>
-computeTMemLdStEncodingInfo(RankedTensorType regTy, MemDescType memTy,
-                            int maxnreg,
-                            std::function<InFlightDiagnostic()> emitError) {
+FailureOr<LinearLayout>
+computeTMemLdStPhysicalLayout(RankedTensorType regTy, MemDescType memTy,
+                              std::function<InFlightDiagnostic()> emitError) {
   auto memLayout = toLinearLayout(memTy);
   auto regLayout = toLinearLayout(regTy);
   auto *ctx = regTy.getContext();
@@ -313,9 +312,20 @@ computeTMemLdStEncodingInfo(RankedTensorType regTy, MemDescType memTy,
   cvt = LinearLayout(std::move(bases), cvt.getOutDims(),
                      /*isSurjective=*/cvt.isSurjective());
 
+  return cvt;
+}
+
+FailureOr<TMemLdStEncodingInfo>
+computeTMemLdStEncodingInfo(RankedTensorType regTy, MemDescType memTy,
+                            int maxnreg,
+                            std::function<InFlightDiagnostic()> emitError) {
+  auto cvt = computeTMemLdStPhysicalLayout(regTy, memTy, emitError);
+  if (failed(cvt))
+    return failure();
+
   bool isScales = isa<TensorMemoryScalesEncodingAttr>(memTy.getEncoding());
   int bitwidth = memTy.getElementTypeBitWidth();
-  return lowerTMemLdSt(cvt, maxnreg, bitwidth, isScales, emitError);
+  return lowerTMemLdSt(*cvt, maxnreg, bitwidth, isScales, emitError);
 }
 
 bool supportsTMemLoadReduce(RankedTensorType regTy, MemDescType memTy,

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   FenceInsertion.cpp
   FuseTMemLoadReduce.cpp
   GenerateSubtiledRegion.cpp
+  InsertTMemAliasWARBarrier.cpp
   InterleaveTMem.cpp
   MMALowering.cpp
   OptimizeDescriptorEncoding.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InsertTMemAliasWARBarrier.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InsertTMemAliasWARBarrier.cpp
@@ -1,0 +1,241 @@
+#include "mlir/IR/Matchers.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+#include "llvm/ADT/DenseSet.h"
+
+namespace ttg = mlir::triton::gpu;
+namespace ttng = mlir::triton::nvidia_gpu;
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUINSERTTMEMALIASWARBARRIERPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+struct TMemBase {
+  int64_t row = 0;
+  int64_t col = 0;
+};
+
+struct TMemView {
+  Value root;
+  std::optional<TMemBase> base;
+};
+
+// Resolve a TMEM view to its root and physical base address. TMEM pointers use
+// the low 16 bits for a 32-bit column offset and the high 16 bits for a row
+// offset. Reinterpret/transpose/reshape views do not move the base pointer.
+static TMemView resolveTMemView(Value v) {
+  TMemBase base;
+  bool knownBase = true;
+  llvm::DenseSet<Value> visited;
+  while (v && visited.insert(v).second) {
+    if (auto ba = dyn_cast<BlockArgument>(v)) {
+      Operation *parent = ba.getOwner()->getParentOp();
+      if (auto part = dyn_cast<ttg::WarpSpecializePartitionsOp>(parent)) {
+        auto captures = part.getExplicitCaptures();
+        if (ba.getArgNumber() >= captures.size())
+          break;
+        v = captures[ba.getArgNumber()];
+        continue;
+      }
+      break;
+    }
+    Operation *def = v.getDefiningOp();
+    if (!def)
+      break;
+    if (auto index = dyn_cast<ttg::MemDescIndexOp>(def)) {
+      APInt indexValue;
+      if (matchPattern(index.getIndex(), m_ConstantInt(&indexValue))) {
+        auto size = ttng::getTmemAllocSizes(index.getType());
+        base.col += indexValue.getSExtValue() * size.numCols;
+      } else {
+        knownBase = false;
+      }
+      v = index.getSrc();
+      continue;
+    }
+    if (auto subslice = dyn_cast<ttng::TMEMSubSliceOp>(def)) {
+      uint32_t offset = ttng::getTMemSubSliceOffset(subslice.getSrc().getType(),
+                                                    subslice.getN());
+      base.col += offset & 0xffff;
+      base.row += offset >> 16;
+      v = subslice.getSrc();
+      continue;
+    }
+    if (isa<ttg::MemDescReinterpretOp, ttg::MemDescTransOp,
+            ttg::MemDescReshapeOp>(def)) {
+      v = def->getOperand(0);
+      continue;
+    }
+    if (def->hasTrait<OpTrait::MemDescViewTrait>()) {
+      // Preserve the root for conservative aliasing, but do not pretend an
+      // unsupported view has a known physical base.
+      knownBase = false;
+      v = def->getOperand(0);
+      continue;
+    }
+    break;
+  }
+  return {v, knownBase ? std::optional<TMemBase>(base) : std::nullopt};
+}
+
+// Return true for a synchronization point that covers every warp in the
+// current task. Producer/consumer mbarriers and partial named barriers are not
+// sufficient: they do not rendezvous all warps that can share a TMEM lane.
+static bool isFullTaskBarrier(Operation *op) {
+  if (isa<ttg::BarrierOp>(op))
+    return true;
+  auto named = dyn_cast<ttng::NamedBarrierWaitOp>(op);
+  if (!named)
+    return false;
+
+  APInt count;
+  if (!matchPattern(named.getNumThreads(), m_ConstantInt(&count)))
+    return false;
+  ModuleOp mod = op->getParentOfType<ModuleOp>();
+  int taskThreads =
+      ttg::lookupNumWarps(op) * ttg::TritonGPUDialect::getThreadsPerWarp(mod);
+  return count.getSExtValue() == taskThreads;
+}
+
+using WarpFootprint = SmallVector<llvm::DenseSet<uint64_t>>;
+
+// Compute the 32-bit TMEM cells touched by each warp. The physical layout is
+// shared with tcgen05 lowering, including its implicit warp-to-row mapping.
+static LogicalResult computeWarpFootprint(RankedTensorType regTy,
+                                          ttg::MemDescType tmemTy,
+                                          TMemBase base,
+                                          WarpFootprint &warpFp) {
+  MLIRContext *ctx = regTy.getContext();
+  auto physical = ttng::computeTMemLdStPhysicalLayout(regTy, tmemTy);
+  if (failed(physical))
+    return failure();
+  StringAttr kWarp = StringAttr::get(ctx, "warp");
+  StringAttr kReg = StringAttr::get(ctx, "register");
+  StringAttr kLane = StringAttr::get(ctx, "lane");
+  StringAttr kRow = StringAttr::get(ctx, "row");
+  StringAttr kCol = StringAttr::get(ctx, "col");
+  if (!llvm::is_contained(physical->getInDimNames(), kWarp) ||
+      !llvm::is_contained(physical->getInDimNames(), kReg) ||
+      !llvm::is_contained(physical->getInDimNames(), kLane) ||
+      !llvm::is_contained(physical->getOutDimNames(), kRow) ||
+      !llvm::is_contained(physical->getOutDimNames(), kCol))
+    return failure();
+  int nWarp = physical->getInDimSize(kWarp);
+  int nReg = physical->getInDimSize(kReg);
+  int nLane = physical->getInDimSize(kLane);
+  int bitWidth = tmemTy.getElementTypeBitWidth();
+  warpFp.assign(nWarp, {});
+  SmallVector<std::pair<StringAttr, int32_t>> pt;
+  for (StringAttr d : physical->getInDimNames())
+    pt.push_back({d, 0});
+  for (int w = 0; w < nWarp; ++w)
+    for (int r = 0; r < nReg; ++r)
+      for (int l = 0; l < nLane; ++l) {
+        for (auto &p : pt)
+          p.second = (p.first == kReg)    ? r
+                     : (p.first == kLane) ? l
+                     : (p.first == kWarp) ? w
+                                          : 0;
+        int64_t row = 0, col = 0;
+        for (auto &o : physical->apply(pt)) {
+          if (o.first == kRow)
+            row = o.second;
+          else if (o.first == kCol)
+            col = o.second;
+        }
+        uint64_t physicalRow = base.row + row;
+        uint64_t physicalCol = base.col + (col * bitWidth) / 32;
+        warpFp[w].insert((physicalRow << 32) | physicalCol);
+      }
+  return success();
+}
+
+static bool hasCrossWarpOverlap(ttng::TMEMLoadOp rd, ttng::TMEMStoreOp st) {
+  TMemView readView = resolveTMemView(rd.getSrc());
+  TMemView writeView = resolveTMemView(st.getDst());
+  if (readView.root != writeView.root)
+    return false;
+  if (!readView.base || !writeView.base)
+    return true;
+
+  WarpFootprint readFp, writeFp;
+  if (failed(computeWarpFootprint(rd.getResult().getType(),
+                                  rd.getSrc().getType(), *readView.base,
+                                  readFp)) ||
+      failed(computeWarpFootprint(st.getSrc().getType(), st.getDst().getType(),
+                                  *writeView.base, writeFp)))
+    return true;
+  for (size_t a = 0; a < writeFp.size(); ++a)
+    for (size_t b = 0; b < readFp.size(); ++b) {
+      if (a == b)
+        continue;
+      for (uint64_t cell : writeFp[a])
+        if (readFp[b].contains(cell))
+          return true;
+    }
+  return false;
+}
+
+// Scan a block in program order. Multiple reads of one allocation remain live
+// until a full-task barrier; a non-overlapping store does not prove that an
+// earlier read has completed in another warp.
+static unsigned processBlock(Block &block) {
+  unsigned inserted = 0;
+  DenseMap<Value, SmallVector<ttng::TMEMLoadOp>> liveReads;
+  for (Operation &opRef : llvm::make_early_inc_range(block)) {
+    Operation *op = &opRef;
+    if (auto ld = dyn_cast<ttng::TMEMLoadOp>(op)) {
+      Value root = resolveTMemView(ld.getSrc()).root;
+      if (root)
+        liveReads[root].push_back(ld);
+    } else if (isFullTaskBarrier(op)) {
+      liveReads.clear();
+    } else if (auto st = dyn_cast<ttng::TMEMStoreOp>(op)) {
+      Value root = resolveTMemView(st.getDst()).root;
+      auto it = liveReads.find(root);
+      if (it != liveReads.end()) {
+        bool hazard = llvm::any_of(it->second, [&](ttng::TMEMLoadOp ld) {
+          return hasCrossWarpOverlap(ld, st);
+        });
+        if (hazard) {
+          OpBuilder b(op);
+          ttg::BarrierOp::create(b, op->getLoc(), ttg::AddrSpace::All);
+          ++inserted;
+          liveReads.clear();
+        }
+      }
+    }
+    for (Region &region : op->getRegions())
+      for (Block &nested : region)
+        inserted += processBlock(nested);
+  }
+  return inserted;
+}
+
+} // namespace
+
+class TritonNvidiaGPUInsertTMemAliasWARBarrierPass
+    : public impl::TritonNvidiaGPUInsertTMemAliasWARBarrierPassBase<
+          TritonNvidiaGPUInsertTMemAliasWARBarrierPass> {
+public:
+  using TritonNvidiaGPUInsertTMemAliasWARBarrierPassBase::
+      TritonNvidiaGPUInsertTMemAliasWARBarrierPassBase;
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    for (Region &region : mod->getRegions())
+      for (Block &block : region)
+        processBlock(block);
+  }
+};
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/test/TritonNvidiaGPU/insert_tmem_alias_war_barrier.mlir
+++ b/test/TritonNvidiaGPU/insert_tmem_alias_war_barrier.mlir
@@ -1,0 +1,268 @@
+// RUN: triton-opt %s -split-input-file --triton-nvidia-gpu-insert-tmem-alias-war-barrier | FileCheck %s
+
+// Cross-warp overlap: an f32 qk read reused as an aliased f16 P store (different
+// frame -> row-level footprint overlap across warps) with no barrier between.
+// A task-scoped ttg.barrier must be inserted between the read and the store.
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @aliased_f32_read_f16_store
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier all
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @aliased_f32_read_f16_store(%val: tensor<128x128xf16, #linear>, %pred: i1) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %root = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable>
+    %f32v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %f16v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %rd = ttg.memdesc_index %f32v[%c0] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %f16v[%c1] : !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %qk = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    ttng.tmem_store %val, %wr, %pred : tensor<128x128xf16, #linear> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// A dynamic view offset cannot prove non-aliasing and must conservatively keep
+// the WAR protection.
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @dynamic_index_conservative_insert
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier all
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @dynamic_index_conservative_insert(%val: tensor<128x128xf16, #linear>, %idx: i32, %pred: i1) {
+    %c0 = arith.constant 0 : i32
+    %root = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable>
+    %f32v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %f16v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %rd = ttg.memdesc_index %f32v[%c0] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %f16v[%idx] : !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %read = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    ttng.tmem_store %val, %wr, %pred : tensor<128x128xf16, #linear> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Same-frame accumulator read-modify-write (f32 read + f32 store, same memdesc):
+// compared at (row, col) cell granularity; each warp only rewrites its own
+// cells -> no cross-warp overlap -> NO barrier inserted.
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @accumulator_rmw_no_barrier
+  // CHECK-NOT: ttg.barrier
+  tt.func @accumulator_rmw_no_barrier(%val: tensor<128x128xf32, #linear>, %pred: i1) {
+    %root = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %acc = ttng.tmem_load %root : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    ttng.tmem_store %val, %root, %pred : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Already guarded by a barrier -> idempotent: exactly one barrier, no extra.
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @already_guarded_idempotent
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier all
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttg.barrier
+  tt.func @already_guarded_idempotent(%val: tensor<128x128xf16, #linear>, %pred: i1) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %root = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable>
+    %f32v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %f16v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %rd = ttg.memdesc_index %f32v[%c0] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %f16v[%c1] : !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %qk = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    ttg.barrier all
+    ttng.tmem_store %val, %wr, %pred : tensor<128x128xf16, #linear> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// A named bar.sync covering all eight task warps is sufficient. The pass must
+// preserve it without adding a second barrier.
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @full_named_barrier_no_insert
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.wait_barrier_named
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttg.barrier
+  tt.func @full_named_barrier_no_insert(%val: tensor<128x128xf16, #linear>, %pred: i1) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %bar = arith.constant 10 : i32
+    %threads = arith.constant 256 : i32
+    %root = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable>
+    %f32v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %f16v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %rd = ttg.memdesc_index %f32v[%c0] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %f16v[%c1] : !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %qk = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    ttng.wait_barrier_named %bar, %threads : i32, i32
+    ttng.tmem_store %val, %wr, %pred : tensor<128x128xf16, #linear> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Four of eight warps are insufficient, so a full-task barrier is still
+// required after the partial named barrier.
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @partial_named_barrier_still_inserts
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.wait_barrier_named
+  // CHECK-NEXT: ttg.barrier all
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @partial_named_barrier_still_inserts(%val: tensor<128x128xf16, #linear>, %pred: i1) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %bar = arith.constant 10 : i32
+    %threads = arith.constant 128 : i32
+    %root = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable>
+    %f32v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %f16v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %rd = ttg.memdesc_index %f32v[%c0] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %f16v[%c1] : !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %qk = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    ttng.wait_barrier_named %bar, %threads : i32, i32
+    ttng.tmem_store %val, %wr, %pred : tensor<128x128xf16, #linear> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// A producer/consumer mbarrier does not rendezvous the eight consumer warps.
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @producer_consumer_barrier_still_inserts
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-NEXT: ttg.barrier all
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @producer_consumer_barrier_still_inserts(%val: tensor<128x128xf16, #linear>, %pred: i1) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    %root = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable>
+    %f32v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %f16v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %rd = ttg.memdesc_index %f32v[%c0] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %f16v[%c1] : !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %qk = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    ttng.wait_barrier %bar, %c0 : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    ttng.tmem_store %val, %wr, %pred : tensor<128x128xf16, #linear> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// A later safe load must not replace an earlier hazardous pending read.
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @multiple_pending_reads
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier all
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @multiple_pending_reads(%val: tensor<128x128xf16, #linear>, %pred: i1) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %root = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable>
+    %f32v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %f16v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %rd = ttg.memdesc_index %f32v[%c0] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %f16v[%c1] : !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %hazardous = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    %safe = ttng.tmem_load %wr : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf16, #linear>
+    ttng.tmem_store %val, %wr, %pred : tensor<128x128xf16, #linear> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// A non-overlapping store must not discard a pending read needed by a later
+// aliased store.
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @safe_store_keeps_pending_read
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NEXT: ttg.barrier all
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @safe_store_keeps_pending_read(%f32: tensor<128x128xf32, #linear>, %f16: tensor<128x128xf16, #linear>, %pred: i1) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %root = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable>
+    %f32v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %f16v = ttg.memdesc_reinterpret %root : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %rd = ttg.memdesc_index %f32v[%c0] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %f16v[%c1] : !ttg.memdesc<2x128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %hazardous = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    ttng.tmem_store %f32, %rd, %pred : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %f16, %wr, %pred : tensor<128x128xf16, #linear> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Different indexed views of one root can be physically disjoint even when
+// their element types differ.
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @disjoint_indexed_views_no_insert
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttg.barrier
+  tt.func @disjoint_indexed_views_no_insert(%val: tensor<128x128xf16, #linear>, %pred: i1) {
+    %c0 = arith.constant 0 : i32
+    %c2 = arith.constant 2 : i32
+    %root = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xi32, #tmem, #ttng.tensor_memory, mutable>
+    %f32v = ttg.memdesc_reinterpret %root : !ttg.memdesc<256x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %f16v = ttg.memdesc_reinterpret %root : !ttg.memdesc<256x128xi32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<4x128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %rd = ttg.memdesc_index %f32v[%c0] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %f16v[%c2] : !ttg.memdesc<4x128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %read = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    ttng.tmem_store %val, %wr, %pred : tensor<128x128xf16, #linear> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -974,6 +974,9 @@ class CUDABackend(BaseBackend):
         # that any local loads eliminated by TMA lowering do not inflate them.
         if capability // 10 >= 9 and knobs.nvidia.use_meta_ws:
             passes.ttgpuir.add_optimize_partition_warps(pm)
+        # Run after all TMEM and warp-layout rewrites so the physical
+        # per-warp footprints used for aliased-TMEM WAR detection are final.
+        nvidia.passes.ttnvgpuir.add_insert_tmem_alias_war_barrier(pm)
         nvidia.passes.ttnvgpuir.add_fence_insertion(pm, capability)
         nvidia.passes.ttnvgpuir.add_lower_mma(pm)
         passes.common.add_sccp(pm)

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -193,6 +193,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      ttng::createTritonNvidiaGPUInterleaveTMemPass);
   ADD_PASS_WRAPPER_0("add_prune_unused_barriers",
                      ttng::createTritonNvidiaGPUPruneUnusedBarriersPass);
+  ADD_PASS_WRAPPER_0("add_insert_tmem_alias_war_barrier",
+                     ttng::createTritonNvidiaGPUInsertTMemAliasWARBarrierPass);
   ADD_PASS_WRAPPER_0("add_clc_split", ttng::createTritonNvidiaGPUCLCSplitPass);
   ADD_PASS_WRAPPER_0("add_clc_hoist", ttng::createTritonNvidiaGPUCLCHoistPass);
   ADD_PASS_WRAPPER_0("add_clc_materialize",


### PR DESCRIPTION
## Summary

Fixes #1996 in the compiler without modifying the TLX Flash Attention kernels.

This PR adds `insert-tmem-alias-war-barrier` after warp partitioning/interleaving and before fence insertion. The pass checks whether a TMEM store can overwrite cells that are still being read by another warp in the same task. It inserts `ttg.barrier` only when the accesses may alias and no existing full-task barrier already orders them.

The current repaired FA-bwd kernel therefore remains unchanged. Its existing barriers are validated rather than duplicated; a kernel that has only producer/consumer synchronization receives the missing intra-task barrier automatically.

## Detection and barrier semantics

- Resolve TMEM allocs, constant indexed views, subslices, reinterpret casts, transposes, and reshapes to a root allocation and base offset.
- Compare per-warp physical `(row, 32-bit column)` footprints using the same TMEM layout calculation as lowering, including the implicit warp-to-row mapping.
- Treat unsupported or dynamic footprints conservatively as possible aliases.
- Accept `ttg.barrier` as a full-task barrier.
- Accept `ttng.wait_barrier_named` only when its constant participant count equals `num_warps * threads_per_warp` for the containing task.
- Do not treat producer/consumer mbarriers or partial named barriers as intra-task ordering.
- Preserve non-overlapping pending reads and make repeated pass execution idempotent.

The analysis is deliberately block-local. Within a block, an unknown footprint is handled conservatively.

## Tests

The new lit test covers:

- insertion when no ordering barrier exists;
- no insertion for an existing full task barrier;
- insertion for a partial named barrier or producer/consumer mbarrier;
- physical TMEM view offsets and disjoint indexed views;
- multiple outstanding reads and non-overlapping stores;
- conservative dynamic-view handling; and
- idempotence.

Blackwell runtime verification covers both requested kernel states:

1. Current kernel with both fixes: the two 256-thread named waits remain and the pass adds zero `ttg.barrier` operations.
2. Derived 8-warp variant with the two intra-task waits removed but producer/consumer barriers retained: the pass inserts exactly two `ttg.barrier` operations. All 12 parameter combinations passed, the native-shape pressure run passed 30/30, and CUTracer passed 3/3. With the pass disabled, the same variant reproduced 3,115,245 mismatches out of 4,194,304 elements.

Additional verification: full build passed, the new lit test passed, and 83 Blackwell correctness tests passed.
