### PR TITLE
[CI] Bump TLX tutorial correctness test timeout 5→15 min (b200, h100)

### DIFF
--- a/.github/workflows/b200.yml
+++ b/.github/workflows/b200.yml
@@ -117,7 +117,7 @@ jobs:
           python -m pytest python/test/unit/language/test_tlx_*.py -v --junitxml=/tmp/tlx-unit.xml
       - name: Run TLX tutorial correctness tests
         id: run_correctness_tests
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: |
           . "${SETUP_SCRIPT}"
           python -m pytest third_party/tlx/tutorials/testing/test_correctness.py -v --junitxml=/tmp/tlx-correctness.xml

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -123,7 +123,7 @@ jobs:
           python -m pytest python/test/unit/language/test_tlx_*.py -v --junitxml=/tmp/tlx-unit.xml
       - name: Run TLX tutorial correctness tests
         id: run_correctness_tests
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: |
           . "${SETUP_SCRIPT}"
           python -m pytest third_party/tlx/tutorials/testing/test_correctness.py -v --junitxml=/tmp/tlx-correctness.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,5 +80,5 @@ exclude: |
     ^python/test/gluon/|
     ^python/triton/experimental/gluon/|
     ^third_party/tlx/tools/|
-    ^bitequiv/evaluation/.*_kernels\.py$
+    ^bitequiv/
   )

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-shared-accumulator-dp.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-shared-accumulator-dp.mlir
@@ -235,4 +235,3 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
     tt.return
   }
 }
-

--- a/test/Hopper/WarpSpecialization/ws_code_partition_operand_d_chained_accum.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_operand_d_chained_accum.mlir
@@ -284,4 +284,3 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
     tt.return
   }
 }
-

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -3736,14 +3736,15 @@ static int getDumpTopN() {
   return n < 1 ? 1 : n;
 }
 
-/// Which partition variant to COMMIT for lowering, by cost-model rank — 0-based,
-/// matching `variant_id` in the TRITON_MODULO_DUMP_TOPN dump (0 = the rank-0
-/// winner). Default -1 = commit the winner. Set TRITON_MODULO_SELECT_VARIANT=k
-/// to instead lower the k-th-ranked partition as a single schedule, so you can
-/// empirically test whether the cost model's rank 0 is really the fastest (dump
-/// top-N, pick a variant_id, re-run with this flag to run just that one).
-/// Out-of-range clamps to the last available variant. Only the exhaustive
-/// partitioner enumerates variants; the greedy fallback has just one.
+/// Which partition variant to COMMIT for lowering, by cost-model rank —
+/// 0-based, matching `variant_id` in the TRITON_MODULO_DUMP_TOPN dump (0 = the
+/// rank-0 winner). Default -1 = commit the winner. Set
+/// TRITON_MODULO_SELECT_VARIANT=k to instead lower the k-th-ranked partition as
+/// a single schedule, so you can empirically test whether the cost model's rank
+/// 0 is really the fastest (dump top-N, pick a variant_id, re-run with this
+/// flag to run just that one). Out-of-range clamps to the last available
+/// variant. Only the exhaustive partitioner enumerates variants; the greedy
+/// fallback has just one.
 static int getSelectVariant() {
   auto v = triton::tools::getStrEnv("TRITON_MODULO_SELECT_VARIANT");
   if (v.empty())
@@ -3884,10 +3885,11 @@ static void partitionExhaustive(ttg::ScheduleLoop &loop,
   });
   const auto &winner = scored.front();
 
-  // Default: commit the cost-model winner (rank 0). TRITON_MODULO_SELECT_VARIANT
-  // overrides this to commit the k-th-ranked partition instead (0-based,
-  // matching variant_id in the TOPN dump) so a specific variant can be lowered
-  // and tested. Out-of-range clamps to the last available.
+  // Default: commit the cost-model winner (rank 0).
+  // TRITON_MODULO_SELECT_VARIANT overrides this to commit the k-th-ranked
+  // partition instead (0-based, matching variant_id in the TOPN dump) so a
+  // specific variant can be lowered and tested. Out-of-range clamps to the last
+  // available.
   size_t commitIdx = 0;
   if (int sel = getSelectVariant(); sel >= 0) {
     commitIdx = std::min<size_t>(sel, scored.size() - 1);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -3026,14 +3026,15 @@ handleOperandD(ttng::TMEMAllocOp tmemAllocOp, ttng::MMAv5OpInterface mmaOp,
             firstProducer = currentProds.front();
           lastConsumer = &op;
           numChannelsCreated++;
-          // Chained accumulator (T279388065): several same-task MMA writers into
-          // one operand-D tile, the first use_acc=false (fresh overwrite),
-          // consumed in-loop by this tmem_load. Emit ONE forward channel from the
-          // LAST writer (full commit from the last MMA, like TLX dq_fulls on n1)
-          // and place the reuse/empty producer_acquire before the FIRST writer
-          // via acquireBeforeOp (like TLX's single dq_empties acquire before n0),
-          // instead of one full/empty pair per writer -- the per-writer shape
-          // fails to serialize the fresh overwrite against the consumer's read.
+          // Chained accumulator (T279388065): several same-task MMA writers
+          // into one operand-D tile, the first use_acc=false (fresh overwrite),
+          // consumed in-loop by this tmem_load. Emit ONE forward channel from
+          // the LAST writer (full commit from the last MMA, like TLX dq_fulls
+          // on n1) and place the reuse/empty producer_acquire before the FIRST
+          // writer via acquireBeforeOp (like TLX's single dq_empties acquire
+          // before n0), instead of one full/empty pair per writer -- the
+          // per-writer shape fails to serialize the fresh overwrite against the
+          // consumer's read.
           if (currentProds.size() > 1 &&
               isFreshOverwriteMMA(currentProds.front()) &&
               isa<ttng::MMAv5OpInterface>(currentProds.back())) {
@@ -3049,8 +3050,9 @@ handleOperandD(ttng::TMEMAllocOp tmemAllocOp, ttng::MMAv5OpInterface mmaOp,
             setTmemChannelAttr(currentProds.back(), channelID, "tmem.start");
             setTmemChannelAttr(&op, channelID, "tmem.end");
           } else {
-            createChannelsForProducers(currentProds, producerTaskId, consumerIds,
-                                       tmemAllocOp.getOperation(), &op, channels);
+            createChannelsForProducers(currentProds, producerTaskId,
+                                       consumerIds, tmemAllocOp.getOperation(),
+                                       &op, channels);
           }
         } else {
           // Channel skipped - append to producers vector

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -205,10 +205,11 @@ struct TmemDataChannelPost : Channel {
   // For a collapsed chained-accumulator channel (multiple same-task MMA writers
   // into one operand-D tile, first writer use_acc=false): the channel's forward
   // commit comes from the LAST writer (getSrcOp), but the reuse/empty
-  // producer_acquire must be placed before the FIRST (fresh-overwrite) writer so
-  // the whole chain waits for the consumer's read of the previous iteration
-  // (mirrors TLX attn_bwd_ws_2kv: one dq_empties acquire before n0, one dq_fulls
-  // from n1). When set, insertAsyncComm relocates producer_acquire here.
+  // producer_acquire must be placed before the FIRST (fresh-overwrite) writer
+  // so the whole chain waits for the consumer's read of the previous iteration
+  // (mirrors TLX attn_bwd_ws_2kv: one dq_empties acquire before n0, one
+  // dq_fulls from n1). When set, insertAsyncComm relocates producer_acquire
+  // here.
   Operation *acquireBeforeOp = nullptr;
   Operation *allocOp;
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -2890,7 +2890,8 @@ void PartitionSchedulingMeta::runOnOperation() {
       // would need care, while {0,1},{0,2},{2,3} has empty overall intersection
       // (no common partition) yet every pair overlaps. So track the RUNNING
       // intersection across all MMAs writing the same buffer and error the
-      // moment it empties. Store the first writer to point the diagnostic at it.
+      // moment it empties. Store the first writer to point the diagnostic at
+      // it.
       DenseMap<Operation *, std::pair<Operation *, SetVector<int>>> accOwner;
       auto idsToStr = [](const SetVector<int> &ids) {
         std::string s;
@@ -2920,7 +2921,8 @@ void PartitionSchedulingMeta::runOnOperation() {
         if (next.empty()) {
           InFlightDiagnostic diag =
               op->emitError()
-              << "warp specialization assigned accumulator-chained MMAs with no "
+              << "warp specialization assigned accumulator-chained MMAs with "
+                 "no "
                  "common partition (running intersection {"
               << idsToStr(running) << "} does not meet this MMA's {"
               << idsToStr(ids)
@@ -2930,7 +2932,8 @@ void PartitionSchedulingMeta::runOnOperation() {
                  "partition (lower data_partition_factor) or give each "
                  "partition its own accumulator and reduce at the end.";
           diag.attachNote(firstWriter->getLoc())
-              << "first accumulator-chained MMA writing this tensor-memory tile "
+              << "first accumulator-chained MMA writing this tensor-memory "
+                 "tile "
                  "is here";
           return WalkResult::interrupt();
         }


### PR DESCRIPTION
The 5-minute step timeout was too tight: the suite (207 passed, 74 skipped) runs in ~3:19 on a B200 devgpu, and the slower/colder CI runner reaches ~98% right at the 5:00 wall before timing out. 15 min gives ~3x headroom over observed runtime and room for future kernels. mi350 is left at its existing 10-min limit (runs only the AMD subset).

A recent [Blackwell CI (TLX tutorial correctness tests)](https://github.com/facebookexperimental/triton/actions/runs/29359117681/job/87174470351?fbclid=IwY2xjawTDhd9wZG9mA2V4dG4DYWVtAjExAGJyaWQRMnIzV1Y4cmplUk1KQTlnVzJzcnRjBmFwcF9pZAEwAAEewfADSv9M3rbipAInvjo18EuYwP0kQ_axIeRb8tdGueOG0kEBGTo3_BpA1XA_aem_XEhsrB70Drhr1gE3PjnCrw) failed by timeout as below. 

```
...
third_party/tlx/tutorials/testing/test_correctness.py::test_multi_cta_layer_norm[2cta] PASSED [ 97%]
third_party/tlx/tutorials/testing/test_correctness.py::test_multi_cta_layer_norm[4cta] PASSED [ 97%]
third_party/tlx/tutorials/testing/test_correctness.py::test_multi_cta_layer_norm_2d[2cta] PASSED [ 98%]
third_party/tlx/tutorials/testing/test_correctness.py::test_multi_cta_layer_norm_2d[4cta] PASSED [ 98%]
Error: The action 'Run TLX tutorial correctness tests' has timed out after 5 minutes.
```

And ... fixing some left-over linters errors.

Authored with Claude.