### PR TITLE
[triton][bitequiv] exclude corpus kernels from OSS pre-commit yapf

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,5 +79,6 @@ exclude: |
     ^third_party/tileir|
     ^python/test/gluon/|
     ^python/triton/experimental/gluon/|
-    ^third_party/tlx/tools/
+    ^third_party/tlx/tools/|
+    ^bitequiv/evaluation/.*_kernels\.py$
   )


### PR DESCRIPTION
Summary:
The open-source mirror (`facebookexperimental/triton`) runs `pre-commit`, whose `yapf` hook has no `files:` filter and therefore reformats files under `bitequiv/`. The realistic-Inductor kernel corpora are deliberately kept in verbatim Inductor style and are not yapf-clean, so the mirror's `pre-commit (code formatting)` job fails on them. Internally `bitequiv/` is gated by `arc lint` (which is clean on this style), so these diffs land as `LANDED_WITH_FAILURES` and the mirror opens a task against the author. Three corpus files trip it today: `realistic_inductor_kernels.py`, `benchmark_kernels.py`, and `eval_kernels.py`.

This adds `^bitequiv/evaluation/.*_kernels\.py$` to the `exclude:` block in `.pre-commit-config.yaml`, alongside the existing Meta-specific excludes. Every corpus file ends in `_kernels.py`, so the single pattern covers all of them plus any future ones. Non-corpus `bitequiv/` Python (the library, the tests, `evaluate.py`) stays yapf-checked.

Authored with Claude.

Differential Revision: D111983269


