### PR TITLE
[TLX][AMD] Document direct-to-LDS requirements for buffer_load_to_local

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,6 +1079,11 @@ token = tlx.buffer_load_to_local(dest, ptr, offsets, mask=None, other=None, cach
 
 Lowers to `amdg.buffer_load_to_local`, which is eventually lowered to `rocdl.raw.ptr.buffer.load.async.lds` — a single hardware instruction that moves data from global memory to LDS without going through VGPRs.
 
+**Requirements.** The direct-to-LDS copy has the following hardware constraints:
+- **Vector width.** Each thread's load must reach a supported direct-to-LDS width (**32 or 128 bits**). If it can only be vectorized to a smaller width, it cannot be lowered.
+- **Provable pointer/offset alignment.** The compiler must be able to *prove* the alignment that vector width needs.
+- **Mask alignment.** If `mask` is given it must be aligned to the vector width: each group of (vector width) consecutive mask values must be identical. The copy transfers each lane's whole vector in one transaction, so a mask whose `True`/`False` boundary cannot be proven vector-aligned (e.g. `offs < K` for a runtime `K`) forces per-element vectorization and cannot lower.
+
 ### Example
 
 ```python

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -116,6 +116,16 @@ def buffer_load_to_local(
     Directly emits amdg.buffer_load_to_local. The ConvertTritonToTritonGPU pass
     adds tensor encoding, and the AMD backend lowers it to LLVM.
 
+    This lowers to a single direct-to-LDS hardware copy, which fails to lower with
+    a compile-time error unless the following requirements are met:
+    - Each thread's load must reach a supported direct-to-LDS width (32 or 128
+      bits, e.g. 2 or 8 fp16 elements). A smaller vectorization cannot be lowered.
+    - The alignment needed for that width must be statically provable.
+    - If `mask` is given it must be aligned to the vector width: each group of
+      (vector width) consecutive mask values must be identical. The copy moves
+      each lane's whole vector in one transaction, so a mask whose boundary cannot
+      be proven vector-aligned (e.g. `offs < K` for runtime `K`) cannot lower.
+
     Args:
         dest: Destination buffer in shared memory (buffered_tensor).
         ptr: Global memory scalar base pointer.


### PR DESCRIPTION
Documents the direct-to-LDS hardware constraints behind `tlx.buffer_load_to_local`
(and `async_load` on MI350), which were previously undocumented: the load must
reach a supported vector width (32/128 bits), the required alignment must be
statically provable, and any `mask` must be aligned to the vector width.

Added to the README `tlx.buffer_load_to_local` section (under Buffer Operations
(AMD)) and to its docstring.