### PR TITLE
[TLX][AMD] Add paged-attention decode kernel

### DIFF
--- a/third_party/tlx/tutorials/amd_pa_decode.py
+++ b/third_party/tlx/tutorials/amd_pa_decode.py
@@ -1,0 +1,326 @@
+"""AMD CDNA4 paged-attention decode kernel written with TLX.
+
+Two-phase split-K decode, ported from the algorithm in ROCm/aiter
+``pa_decode_gluon`` but expressed with Triton + TLX low-level primitives.
+Phase 1 (``_pa_decode_partition_kernel``) has each program handle one
+``(sequence, kv_head, split)``: it streams the split's KV pages into LDS with
+``tlx.async_load`` (double-buffered), does ``q @ k^T`` via MFMA, a base-2
+online softmax, then ``p @ v``, and writes a normalized partial output plus a
+base-2 log-sum-exp for that split. Phase 2 (``_pa_decode_reduce_kernel``) is a
+plain ``@triton.jit`` kernel that merges the per-split partials for each output
+``(token, query_head)`` via the standard LSE trick.
+
+Scope: bf16/fp16 KV cache, GQA, and MTP query_length in 1..4 (causal across the
+query positions). Not covered: FP8, sliding window, ALiBi, sinks, per-token
+quantization. KV cache layout is contiguous
+``[num_blocks, num_kv_heads, PAGE_SIZE, HEAD_DIM]``.
+
+Consumed by the correctness suite (``test_correctness.py``) and the perf script
+(``test_amd_pa_decode_perf.py``).
+"""
+
+import torch
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+BUF_DEPTH = tl.constexpr(2)
+
+
+@triton.jit
+def _pa_decode_partition_kernel(
+    Q,             # [num_tokens, num_q_heads, HEAD_DIM]
+    Kc,            # [num_blocks, num_kv_heads, PAGE_SIZE, HEAD_DIM]
+    Vc,            # [num_blocks, num_kv_heads, PAGE_SIZE, HEAD_DIM]
+    BlockTables,   # [num_seqs, max_pages]
+    CtxLens,       # [num_seqs]
+    Mid,           # [num_seqs, num_kv_heads, NUM_SPLITS, M_POW2, HEAD_DIM] (fp32)
+    Lse,           # [num_seqs, num_kv_heads, NUM_SPLITS, M_POW2] (fp32)
+    sm_scale,
+    num_splits,    # runtime int (== grid dim 2)
+    stride_q_t, stride_q_h, stride_q_d,
+    stride_kc_b, stride_kc_h, stride_kc_p, stride_kc_d,
+    stride_vc_b, stride_vc_h, stride_vc_p, stride_vc_d,
+    stride_bt_s, stride_bt_p,
+    stride_mid_s, stride_mid_h, stride_mid_k, stride_mid_m, stride_mid_d,
+    stride_lse_s, stride_lse_h, stride_lse_k, stride_lse_m,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    QUERY_GROUP_SIZE: tl.constexpr,
+    GROUP_POW2: tl.constexpr,
+    QLEN: tl.constexpr,
+    QLEN_POW2: tl.constexpr,
+    M_POW2: tl.constexpr,
+):
+    seq = tl.program_id(0)
+    kv_head = tl.program_id(1)
+    split = tl.program_id(2)
+
+    ctx_len = tl.load(CtxLens + seq)
+    num_pages = tl.cdiv(ctx_len, PAGE_SIZE)
+    pages_per_split = tl.cdiv(num_pages, num_splits)
+    start_page = split * pages_per_split
+    end_page = tl.minimum(num_pages, start_page + pages_per_split)
+
+    offs_d = tl.arange(0, HEAD_DIM)
+    offs_g = tl.arange(0, GROUP_POW2)
+    offs_ql = tl.arange(0, QLEN_POW2)
+    offs_p = tl.arange(0, PAGE_SIZE)
+    offs_m = tl.arange(0, M_POW2)
+
+    # Load Q for this (seq, kv_head): [QLEN_POW2, GROUP_POW2, HEAD_DIM].
+    q_head = kv_head * QUERY_GROUP_SIZE + offs_g          # [GROUP_POW2]
+    q_tok = seq * QLEN + offs_ql                          # [QLEN_POW2]
+    q_ptrs = (
+        Q
+        + q_tok[:, None, None] * stride_q_t
+        + q_head[None, :, None] * stride_q_h
+        + offs_d[None, None, :] * stride_q_d
+    )
+    q_mask = (offs_ql[:, None, None] < QLEN) & (offs_g[None, :, None] < QUERY_GROUP_SIZE)
+    q = tl.load(q_ptrs, mask=q_mask, other=0.0)
+    q = tl.reshape(q, (M_POW2, HEAD_DIM))
+
+    QK_SCALE = sm_scale * 1.44269504089  # 1/log(2), for exp2-based softmax
+    m_qpos = offs_m // GROUP_POW2                          # query position per row
+
+    m_i = tl.full([M_POW2], float("-inf"), tl.float32)
+    l_i = tl.zeros([M_POW2], tl.float32)
+    acc = tl.zeros([M_POW2, HEAD_DIM], tl.float32)
+
+    k_buf = tlx.local_alloc((PAGE_SIZE, HEAD_DIM), Kc.dtype.element_ty, BUF_DEPTH)
+    v_buf = tlx.local_alloc((PAGE_SIZE, HEAD_DIM), Vc.dtype.element_ty, BUF_DEPTH)
+
+    for pidx in tl.range(start_page, end_page):
+        slot = (pidx - start_page) % BUF_DEPTH
+        physical = tl.load(BlockTables + seq * stride_bt_s + pidx * stride_bt_p)
+        k_ptrs = (
+            Kc + physical * stride_kc_b + kv_head * stride_kc_h
+            + offs_p[:, None] * stride_kc_p + offs_d[None, :] * stride_kc_d
+        )
+        v_ptrs = (
+            Vc + physical * stride_vc_b + kv_head * stride_vc_h
+            + offs_p[:, None] * stride_vc_p + offs_d[None, :] * stride_vc_d
+        )
+        tok_k = tlx.async_load(k_ptrs, tlx.local_view(k_buf, slot))
+        tok_v = tlx.async_load(v_ptrs, tlx.local_view(v_buf, slot))
+        tlx.async_load_commit_group([tok_k, tok_v])
+        tlx.async_load_wait_group(0)
+
+        kt = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, slot)))  # [HEAD_DIM, PAGE_SIZE]
+        v = tlx.local_load(tlx.local_view(v_buf, slot))                    # [PAGE_SIZE, HEAD_DIM]
+
+        qk = tl.dot(q, kt)                                                 # [M_POW2, PAGE_SIZE] fp32
+        kt_abs = pidx * PAGE_SIZE + offs_p                                 # absolute key index
+        vis = kt_abs[None, :] <= (ctx_len - QLEN + m_qpos[:, None])
+        qk = tl.where(vis, qk * QK_SCALE, float("-inf"))
+
+        m_ij = tl.max(qk, 1)
+        m_new = tl.maximum(m_i, m_ij)
+        p = tl.math.exp2(qk - m_new[:, None])
+        alpha = tl.math.exp2(m_i - m_new)
+        l_i = l_i * alpha + tl.sum(p, 1)
+        acc = acc * alpha[:, None] + tl.dot(p.to(v.dtype), v)
+        m_i = m_new
+        tl.debug_barrier()
+
+    # Store the normalized partial output + base-2 lse for this split.
+    has_kv = l_i > 0.0
+    o_part = tl.where(has_kv[:, None], acc / tl.where(has_kv[:, None], l_i[:, None], 1.0), 0.0)
+    lse_part = tl.where(has_kv, m_i + tl.math.log2(tl.where(has_kv, l_i, 1.0)), float("-inf"))
+
+    mid_ptrs = (
+        Mid + seq * stride_mid_s + kv_head * stride_mid_h + split * stride_mid_k
+        + offs_m[:, None] * stride_mid_m + offs_d[None, :] * stride_mid_d
+    )
+    tl.store(mid_ptrs, o_part)
+    lse_ptrs = Lse + seq * stride_lse_s + kv_head * stride_lse_h + split * stride_lse_k + offs_m * stride_lse_m
+    tl.store(lse_ptrs, lse_part)
+
+
+@triton.jit
+def _pa_decode_reduce_kernel(
+    Out,           # [num_tokens, num_q_heads, HEAD_DIM]
+    Mid,           # [num_seqs, num_kv_heads, NUM_SPLITS, M_POW2, HEAD_DIM]
+    Lse,           # [num_seqs, num_kv_heads, NUM_SPLITS, M_POW2]
+    num_splits,
+    stride_o_t, stride_o_h, stride_o_d,
+    stride_mid_s, stride_mid_h, stride_mid_k, stride_mid_m, stride_mid_d,
+    stride_lse_s, stride_lse_h, stride_lse_k, stride_lse_m,
+    HEAD_DIM: tl.constexpr,
+    QUERY_GROUP_SIZE: tl.constexpr,
+    GROUP_POW2: tl.constexpr,
+    QLEN: tl.constexpr,
+    SPLITS_POW2: tl.constexpr,
+):
+    gt = tl.program_id(0)       # global token = seq * QLEN + qpos
+    qh = tl.program_id(1)       # query head
+
+    seq = gt // QLEN
+    qpos = gt % QLEN
+    kv_head = qh // QUERY_GROUP_SIZE
+    hgrp = qh % QUERY_GROUP_SIZE
+    m_row = qpos * GROUP_POW2 + hgrp
+
+    offs_k = tl.arange(0, SPLITS_POW2)
+    offs_d = tl.arange(0, HEAD_DIM)
+    kmask = offs_k < num_splits
+
+    lse = tl.load(
+        Lse + seq * stride_lse_s + kv_head * stride_lse_h + offs_k * stride_lse_k + m_row * stride_lse_m,
+        mask=kmask, other=float("-inf"),
+    )
+    gmax = tl.max(lse, 0)
+    gmax_safe = tl.where(gmax == float("-inf"), 0.0, gmax)
+    w = tl.where(kmask, tl.math.exp2(lse - gmax_safe), 0.0)      # [SPLITS_POW2]
+    wsum = tl.sum(w, 0)
+
+    o = tl.load(
+        Mid + seq * stride_mid_s + kv_head * stride_mid_h
+        + offs_k[:, None] * stride_mid_k + m_row * stride_mid_m + offs_d[None, :] * stride_mid_d,
+        mask=kmask[:, None], other=0.0,
+    )                                                            # [SPLITS_POW2, HEAD_DIM]
+    out = tl.sum(o * w[:, None], 0) / tl.where(wsum > 0, wsum, 1.0)
+
+    tl.store(Out + gt * stride_o_t + qh * stride_o_h + offs_d * stride_o_d, out.to(Out.dtype.element_ty))
+
+
+def _next_pow2(x):
+    return 1 << (max(1, x) - 1).bit_length()
+
+
+def get_num_splits(num_seqs, num_kv_heads, max_ctx_len=None, page_size=None, partition_size=256, cap=8):
+    """Pick split count purely from occupancy (mirrors aiter's
+    get_recommended_splits): enough KV splits to fill the CUs, capped at ``cap``.
+
+    Deliberately independent of context length so the host launcher needs no
+    device->host sync. ``max_ctx_len``/``page_size`` are accepted for backward
+    compatibility but ignored; empty splits at short context are handled by the
+    kernel's ``has_kv`` guard and skipped in the reduce."""
+    props = torch.cuda.get_device_properties(0)
+    num_cu = props.multi_processor_count
+    by_occupancy = max(1, (num_cu * 2) // max(1, num_seqs * num_kv_heads))
+    return max(1, min(cap, by_occupancy))
+
+
+def pa_decode_tlx(
+    output,        # [num_tokens, num_q_heads, HEAD_DIM]
+    query,         # [num_tokens, num_q_heads, HEAD_DIM]
+    key_cache,     # [num_blocks, num_kv_heads, PAGE_SIZE, HEAD_DIM]
+    value_cache,   # [num_blocks, num_kv_heads, PAGE_SIZE, HEAD_DIM]
+    context_lens,  # [num_seqs] int32
+    block_tables,  # [num_seqs, max_pages] int32
+    sm_scale,
+    query_length=1,
+    num_splits=None,
+    num_warps=4,
+    waves_per_eu=0,
+):
+    num_tokens, num_q_heads, head_dim = query.shape
+    num_blocks, num_kv_heads, page_size, _ = key_cache.shape
+    num_seqs = num_tokens // query_length
+    query_group_size = num_q_heads // num_kv_heads
+
+    qlen_pow2 = _next_pow2(query_length)
+    group_pow2 = max(16 // qlen_pow2, _next_pow2(query_group_size))
+    m_pow2 = qlen_pow2 * group_pow2
+    assert m_pow2 >= 16, f"M_POW2={m_pow2} must be >= 16 for MFMA"
+    assert query_length * query_group_size <= 64
+
+    if num_splits is None:
+        num_splits = get_num_splits(num_seqs, num_kv_heads)
+    splits_pow2 = _next_pow2(num_splits)
+
+    mid = torch.empty((num_seqs, num_kv_heads, num_splits, m_pow2, head_dim), dtype=torch.float32, device=query.device)
+    lse = torch.empty((num_seqs, num_kv_heads, num_splits, m_pow2), dtype=torch.float32, device=query.device)
+
+    grid_p = (num_seqs, num_kv_heads, num_splits)
+    _pa_decode_partition_kernel[grid_p](
+        query, key_cache, value_cache, block_tables, context_lens, mid, lse,
+        sm_scale, num_splits,
+        query.stride(0), query.stride(1), query.stride(2),
+        key_cache.stride(0), key_cache.stride(1), key_cache.stride(2), key_cache.stride(3),
+        value_cache.stride(0), value_cache.stride(1), value_cache.stride(2), value_cache.stride(3),
+        block_tables.stride(0), block_tables.stride(1),
+        mid.stride(0), mid.stride(1), mid.stride(2), mid.stride(3), mid.stride(4),
+        lse.stride(0), lse.stride(1), lse.stride(2), lse.stride(3),
+        HEAD_DIM=head_dim, PAGE_SIZE=page_size,
+        QUERY_GROUP_SIZE=query_group_size, GROUP_POW2=group_pow2,
+        QLEN=query_length, QLEN_POW2=qlen_pow2, M_POW2=m_pow2,
+        num_warps=num_warps, waves_per_eu=waves_per_eu,
+    )
+
+    grid_r = (num_tokens, num_q_heads)
+    _pa_decode_reduce_kernel[grid_r](
+        output, mid, lse, num_splits,
+        output.stride(0), output.stride(1), output.stride(2),
+        mid.stride(0), mid.stride(1), mid.stride(2), mid.stride(3), mid.stride(4),
+        lse.stride(0), lse.stride(1), lse.stride(2), lse.stride(3),
+        HEAD_DIM=head_dim,
+        QUERY_GROUP_SIZE=query_group_size, GROUP_POW2=group_pow2,
+        QLEN=query_length, SPLITS_POW2=splits_pow2,
+    )
+    return output
+
+
+# Test/benchmark helpers: paged inputs + a dense fp32 reference, consumed by the
+# correctness suite (test_correctness.py) and the perf harness
+# (test_amd_pa_decode_perf.py).
+def build_inputs(num_seqs, ctx_lens, num_q_heads, num_kv_heads, head_dim, page_size,
+                 query_length=1, dtype=torch.bfloat16, device="cuda", seed=0,
+                 pool_pages=None):
+    """Build paged decode inputs. If ``pool_pages`` is set, physical pages are
+    drawn from a shared pool of that size (bounds memory for large sweeps); the
+    dense reference uses the same ``block_tables`` so correctness is unaffected.
+    """
+    torch.manual_seed(seed)
+    assert len(ctx_lens) == num_seqs
+    num_tokens = num_seqs * query_length
+
+    query = torch.randn(num_tokens, num_q_heads, head_dim, dtype=dtype, device=device) * 0.2
+
+    max_pages = (max(ctx_lens) + page_size - 1) // page_size
+    distinct = num_seqs * max_pages
+    total_pages = distinct if pool_pages is None else min(distinct, pool_pages)
+    key_cache = torch.randn(total_pages, num_kv_heads, page_size, head_dim, dtype=dtype, device=device) * 0.2
+    value_cache = torch.randn(total_pages, num_kv_heads, page_size, head_dim, dtype=dtype, device=device) * 0.2
+
+    block_tables = torch.zeros(num_seqs, max_pages, dtype=torch.int32, device=device)
+    for s in range(num_seqs):
+        npag = (ctx_lens[s] + page_size - 1) // page_size
+        for p in range(max_pages):
+            phys = (s * max_pages + (p if p < npag else 0)) % total_pages
+            block_tables[s, p] = phys
+    context_lens = torch.tensor(ctx_lens, dtype=torch.int32, device=device)
+    return query, key_cache, value_cache, context_lens, block_tables
+
+
+def ref_decode(query, key_cache, value_cache, context_lens, block_tables, sm_scale,
+               num_q_heads, num_kv_heads, query_length):
+    """Dense fp32 reference: gather full K/V from the page table, causal over qlen."""
+    head_dim = query.shape[-1]
+    page_size = key_cache.shape[2]
+    group = num_q_heads // num_kv_heads
+    num_seqs = query.shape[0] // query_length
+    out = torch.empty_like(query, dtype=torch.float32)
+
+    for s in range(num_seqs):
+        ctx = int(context_lens[s].item())
+        npag = (ctx + page_size - 1) // page_size
+        phys = block_tables[s, :npag]
+        k = key_cache[phys].to(torch.float32)      # [npag, kvh, page, d]
+        v = value_cache[phys].to(torch.float32)
+        k = k.permute(1, 0, 2, 3).reshape(num_kv_heads, npag * page_size, head_dim)[:, :ctx]
+        v = v.permute(1, 0, 2, 3).reshape(num_kv_heads, npag * page_size, head_dim)[:, :ctx]
+        for qpos in range(query_length):
+            gt = s * query_length + qpos
+            limit = ctx - query_length + qpos       # inclusive last visible key index
+            for qh in range(num_q_heads):
+                kvh = qh // group
+                q = query[gt, qh].to(torch.float32)         # [d]
+                scores = (q[None, :] * k[kvh]).sum(-1) * sm_scale  # [ctx]
+                scores = scores[: limit + 1]
+                p = torch.softmax(scores, dim=0)
+                out[gt, qh] = (p[:, None] * v[kvh, : limit + 1]).sum(0)
+    return out

--- a/third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py
+++ b/third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py
@@ -1,0 +1,105 @@
+import argparse
+
+import torch
+
+import triton
+
+from triton.language.extra.tlx.tutorials.amd_pa_decode import (
+    pa_decode_tlx as _pa_decode_tlx,
+    build_inputs as _build_inputs,
+)
+
+from triton._internal_testing import is_hip
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+# Fixed decode problem geometry (GQA, bf16 KV), matching the paged-decode
+# correctness case. The sweep varies batch x context x query_length.
+NUM_KV_HEADS = 8
+QUERY_GROUP_SIZE = 8
+NUM_Q_HEADS = NUM_KV_HEADS * QUERY_GROUP_SIZE
+HEAD_DIM = 128
+PAGE_SIZE = 64
+
+DECODE_METHODS = {
+    "tlx":
+    lambda out, q, kc, vc, ctx, bt, sm, qlen: _pa_decode_tlx(out, q, kc, vc, ctx, bt, sm, query_length=qlen),
+}
+DEFAULT_DECODE_VERSIONS = ["tlx"]
+
+
+def create_benchmark(versions, qlen):
+    line_vals = list(versions)
+    line_names = list(versions)
+    # (BATCH, N_CTX)
+    x_vals = [
+        (1, 8192),
+        (8, 8192),
+        (32, 8192),
+        (128, 8192),
+        (1, 32768),
+        (8, 32768),
+        (32, 32768),
+        (8, 131072),
+    ]
+
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=["BATCH", "N_CTX"],
+            x_vals=x_vals,
+            line_arg="provider",
+            line_vals=line_vals,
+            line_names=line_names,
+            ylabel="TB/s (effective HBM read)",
+            plot_name=f"paged-decode-performance-bf16-qlen{qlen}",
+            args={},
+        ))
+    def benchmark(BATCH, N_CTX, provider):
+        sm_scale = 1.0 / (HEAD_DIM ** 0.5)
+        # Bound physical KV memory for large sweeps via a shared page pool.
+        pool = 4 * ((N_CTX + PAGE_SIZE - 1) // PAGE_SIZE) + 16
+        q, kc, vc, ctx, bt = _build_inputs(
+            BATCH, [N_CTX] * BATCH, NUM_Q_HEADS, NUM_KV_HEADS, HEAD_DIM, PAGE_SIZE,
+            query_length=qlen, device=DEVICE, pool_pages=pool)
+        out = torch.empty_like(q)
+        fn = DECODE_METHODS[provider]
+        quantiles = [0.5, 0.2, 0.8]
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: fn(out, q, kc, vc, ctx, bt, sm_scale, qlen),
+            quantiles=quantiles, warmup=100, rep=200)
+
+        # Decode reads the whole KV cache once (K + V, bf16): report effective
+        # HBM read bandwidth, the meaningful metric for this memory-bound op.
+        kv_bytes = 2 * BATCH * NUM_KV_HEADS * N_CTX * HEAD_DIM * 2
+        tbps = lambda ms: kv_bytes * 1e-12 / (ms * 1e-3)
+        return tbps(ms), tbps(max_ms), tbps(min_ms)
+
+    return benchmark
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Benchmark TLX AMD paged-attention decode")
+    parser.add_argument(
+        "--version",
+        type=str,
+        nargs="+",
+        choices=list(DECODE_METHODS.keys()),
+        help=f"Run only the specified version(s). Choices: {list(DECODE_METHODS.keys())}",
+    )
+    parser.add_argument(
+        "--qlens",
+        type=int,
+        nargs="+",
+        default=[1],
+        help="Query lengths to sweep (multi-token prediction: 1-4).",
+    )
+    args = parser.parse_args()
+
+    if is_hip():
+        versions = args.version if args.version else DEFAULT_DECODE_VERSIONS
+        print(f"Running paged-decode benchmarks for: {versions}, qlens={args.qlens}")
+        for qlen in args.qlens:
+            print(f"\n=== query_length = {qlen} ===")
+            create_benchmark(versions, qlen).run(print_data=True)
+    else:
+        print("Skipping benchmarks, no AMD GPU found.")

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -63,6 +63,11 @@ from triton.language.extra.tlx.tutorials.amd_fa_cluster import (
     attention as _amd_fa_cluster, )
 from triton.language.extra.tlx.tutorials.amd_fa_cluster import (
     persistent_attention as _amd_fa_cluster_persistent, )
+from triton.language.extra.tlx.tutorials.amd_pa_decode import (
+    pa_decode_tlx as _amd_pa_decode,
+    build_inputs as _amd_pa_decode_build_inputs,
+    ref_decode as _amd_pa_decode_ref,
+)
 from triton.language.extra.tlx.tutorials.amd_tdm_gemm_pipelined import (
     matmul as _amd_tdm_gemm_pipelined, )
 from triton.language.extra.tlx.tutorials.amd_gemm_warp_pipeline import (
@@ -1068,6 +1073,39 @@ def test_amd_fa_cluster_persistent_scheduler_knobs(causal, HEAD_DIM):
     ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=causal, scale=sm)
     out = _amd_fa_cluster_persistent(q, k, v, sm, causal, config={"NUM_SMS": 16, "NUM_XCDS": 4})
     torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+# =============================================================================
+# AMD Paged-Attention Decode Tests (gfx950)
+# =============================================================================
+
+
+@pytest.mark.parametrize("query_length", [1, 2, 3, 4], ids=lambda q: f"qlen{q}")
+@pytest.mark.parametrize("num_splits", [1, 4], ids=["split1", "split4"])
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_pa_decode(num_splits, query_length):
+    """Split-K paged decode with bf16 KV cache and GQA, incl. multi-token
+    prediction (query_length 1-4). Reference is dense fp32 attention gathered
+    from the page table with bottom-right causal masking over the query block.
+    """
+    num_kv_heads, group = 2, 4
+    num_q_heads = num_kv_heads * group
+    head_dim, page_size = 128, 16
+    ctx_lens = [40, 71]
+    num_seqs = len(ctx_lens)
+    sm_scale = 1.0 / math.sqrt(head_dim)
+
+    query, key_cache, value_cache, context_lens, block_tables = _amd_pa_decode_build_inputs(
+        num_seqs, ctx_lens, num_q_heads, num_kv_heads, head_dim, page_size,
+        query_length=query_length, device=DEVICE)
+
+    out = torch.empty_like(query)
+    _amd_pa_decode(out, query, key_cache, value_cache, context_lens, block_tables, sm_scale,
+                   query_length=query_length, num_splits=num_splits)
+
+    ref = _amd_pa_decode_ref(query, key_cache, value_cache, context_lens, block_tables, sm_scale,
+                             num_q_heads, num_kv_heads, query_length)
+    torch.testing.assert_close(out.float(), ref, atol=2e-2, rtol=2e-2)
 
 
 # =============================================================================


### PR DESCRIPTION
TLX paged-attention decode kernel for AMD CDNA4 (gfx950) with a bf16 paged KV cache, split-K + LSE reduce, GQA, and multi-token prediction (query length 1-4). Async double-buffered global->shared KV streaming keeps the per-iteration KV tile small for high occupancy on memory-bound decode.

## query_seq_len = 1

| batch | ctx | TLX µs | aiter µs | speedup |
|------:|-------:|-------:|---------:|--------:|
| 1 | 1024 | 13.9 | 23.4 | 1.68× |
| 2 | 1024 | 15.6 | 24.7 | 1.58× |
| 4 | 1024 | 18.5 | 30.5 | 1.65× |
| 8 | 1024 | 19.1 | 30.9 | 1.62× |
| 16 | 1024 | 24.5 | 38.6 | 1.58× |
| 32 | 1024 | 32.4 | 63.2 | 1.95× |
| 64 | 1024 | 39.0 | 98.9 | 2.54× |
| 128 | 1024 | 79.6 | 195.2 | 2.45× |
| 256 | 1024 | 130.2 | 325.3 | 2.50× |
| 1 | 8192 | 45.3 | 51.0 | 1.13× |
| 2 | 8192 | 53.0 | 54.7 | 1.03× |
| 4 | 8192 | 66.7 | 59.6 | 0.89× |
| 8 | 8192 | 67.3 | 110.6 | 1.64× |
| 16 | 8192 | 83.2 | 195.1 | 2.34× |
| 32 | 8192 | 148.8 | 391.4 | 2.63× |
| 64 | 8192 | 384.3 | 815.6 | 2.12× |
| 128 | 8192 | 680.5 | 1565.0 | 2.30× |
| 256 | 8192 | 1363.1 | 3189.5 | 2.34× |
| 1 | 32768 | 144.2 | 187.8 | 1.30× |
| 2 | 32768 | 148.4 | 185.6 | 1.25× |
| 4 | 32768 | 168.8 | 201.9 | 1.20× |
| 8 | 32768 | 236.3 | 383.8 | 1.62× |
| 16 | 32768 | 419.0 | 744.3 | 1.78× |
| 32 | 32768 | 741.2 | 1499.5 | 2.02× |
| 64 | 32768 | 1389.1 | 3042.3 | 2.19× |
| 128 | 32768 | 2683.3 | 6099.2 | 2.27× |
| 256 | 32768 | 5405.8 | 12395.9 | 2.29× |
| 1 | 131072 | 488.6 | 698.8 | 1.43× |
| 2 | 131072 | 488.7 | 719.6 | 1.47× |
| 4 | 131072 | 575.5 | 774.6 | 1.35× |
| 8 | 131072 | 755.8 | 1464.0 | 1.94× |
| 16 | 131072 | 1349.5 | 3043.2 | 2.25× |
| 32 | 131072 | 2479.3 | 5876.6 | 2.37× |
| 64 | 131072 | 4575.7 | 12443.7 | 2.72× |
| 128 | 131072 | 9388.0 | 24771.0 | 2.64× |
| 256 | 131072 | 19080.3 | 51852.6 | 2.72× |

## query_seq_len = 2

| batch | ctx | TLX µs | aiter µs | speedup |
|------:|-------:|-------:|---------:|--------:|
| 1 | 1024 | 14.2 | 18.2 | 1.28× |
| 2 | 1024 | 15.2 | 18.1 | 1.19× |
| 4 | 1024 | 18.0 | 18.2 | 1.01× |
| 8 | 1024 | 19.5 | 31.5 | 1.62× |
| 16 | 1024 | 23.6 | 39.3 | 1.67× |
| 32 | 1024 | 33.8 | 64.5 | 1.91× |
| 64 | 1024 | 39.9 | 87.1 | 2.18× |
| 128 | 1024 | 69.6 | 160.4 | 2.30× |
| 256 | 1024 | 131.7 | 283.3 | 2.15× |
| 1 | 8192 | 47.8 | 52.1 | 1.09× |
| 2 | 8192 | 52.0 | 54.9 | 1.06× |
| 4 | 8192 | 67.2 | 61.7 | 0.92× |
| 8 | 8192 | 69.9 | 113.1 | 1.62× |
| 16 | 8192 | 85.0 | 199.7 | 2.35× |
| 32 | 8192 | 150.8 | 400.9 | 2.66× |
| 64 | 8192 | 346.5 | 658.7 | 1.90× |
| 128 | 8192 | 667.5 | 1342.8 | 2.01× |
| 256 | 8192 | 1315.0 | 2649.4 | 2.01× |
| 1 | 32768 | 145.3 | 186.3 | 1.28× |
| 2 | 32768 | 149.9 | 191.9 | 1.28× |
| 4 | 32768 | 167.5 | 201.2 | 1.20× |
| 8 | 32768 | 239.4 | 388.5 | 1.62× |
| 16 | 32768 | 411.6 | 759.0 | 1.84× |
| 32 | 32768 | 734.0 | 1491.0 | 2.03× |
| 64 | 32768 | 1372.3 | 2507.8 | 1.83× |
| 128 | 32768 | 2648.4 | 5398.7 | 2.04× |
| 256 | 32768 | 5240.3 | 10124.3 | 1.93× |
| 1 | 131072 | 488.8 | 713.0 | 1.46× |
| 2 | 131072 | 486.2 | 721.9 | 1.48× |
| 4 | 131072 | 562.0 | 762.3 | 1.36× |
| 8 | 131072 | 774.4 | 1534.8 | 1.98× |
| 16 | 131072 | 1392.5 | 3049.7 | 2.19× |
| 32 | 131072 | 2553.4 | 6246.3 | 2.45× |
| 64 | 131072 | 4653.7 | 10465.2 | 2.25× |
| 128 | 131072 | 9683.2 | 21233.6 | 2.19× |
| 256 | 131072 | 19993.5 | 42116.0 | 2.11× |

## query_seq_len = 3

| batch | ctx | TLX µs | aiter µs | speedup |
|------:|-------:|-------:|---------:|--------:|
| 1 | 1024 | 17.0 | 21.3 | 1.25× |
| 2 | 1024 | 19.3 | 20.1 | 1.04× |
| 4 | 1024 | 23.2 | 20.3 | 0.88× |
| 8 | 1024 | 25.2 | 34.9 | 1.38× |
| 16 | 1024 | 30.6 | 43.3 | 1.42× |
| 32 | 1024 | 42.0 | 71.5 | 1.70× |
| 64 | 1024 | 56.9 | 104.6 | 1.84× |
| 128 | 1024 | 102.2 | 190.9 | 1.87× |
| 256 | 1024 | 209.1 | 346.6 | 1.66× |
| 1 | 8192 | 52.3 | 55.4 | 1.06× |
| 2 | 8192 | 59.2 | 59.1 | 1.00× |
| 4 | 8192 | 73.3 | 65.4 | 0.89× |
| 8 | 8192 | 77.3 | 121.3 | 1.57× |
| 16 | 8192 | 110.7 | 216.7 | 1.96× |
| 32 | 8192 | 206.7 | 428.5 | 2.07× |
| 64 | 8192 | 386.4 | 799.1 | 2.07× |
| 128 | 8192 | 774.5 | 1584.8 | 2.05× |
| 256 | 8192 | 1526.1 | 3176.1 | 2.08× |
| 1 | 32768 | 167.6 | 205.8 | 1.23× |
| 2 | 32768 | 171.6 | 210.8 | 1.23× |
| 4 | 32768 | 183.0 | 225.2 | 1.23× |
| 8 | 32768 | 283.6 | 411.2 | 1.45× |
| 16 | 32768 | 516.6 | 855.9 | 1.66× |
| 32 | 32768 | 960.0 | 1641.1 | 1.71× |
| 64 | 32768 | 1836.6 | 3116.6 | 1.70× |
| 128 | 32768 | 3487.0 | 6202.0 | 1.78× |
| 256 | 32768 | 6118.2 | 12308.4 | 2.01× |
| 1 | 131072 | 582.6 | 786.3 | 1.35× |
| 2 | 131072 | 580.6 | 800.6 | 1.38× |
| 4 | 131072 | 656.0 | 826.8 | 1.26× |
| 8 | 131072 | 1022.0 | 1646.9 | 1.61× |
| 16 | 131072 | 1854.7 | 3296.8 | 1.78× |
| 32 | 131072 | 3517.9 | 6487.5 | 1.84× |
| 64 | 131072 | 6576.2 | 12459.2 | 1.89× |
| 128 | 131072 | 13124.0 | 25329.5 | 1.93× |
| 256 | 131072 | 25948.3 | 49671.9 | 1.91× |

## query_seq_len = 4

| batch | ctx | TLX µs | aiter µs | speedup |
|------:|-------:|-------:|---------:|--------:|
| 1 | 1024 | 17.1 | 18.2 | 1.06× |
| 2 | 1024 | 18.7 | 19.0 | 1.02× |
| 4 | 1024 | 23.3 | 20.3 | 0.87× |
| 8 | 1024 | 25.3 | 38.2 | 1.51× |
| 16 | 1024 | 30.5 | 44.0 | 1.44× |
| 32 | 1024 | 42.9 | 72.4 | 1.69× |
| 64 | 1024 | 58.0 | 102.5 | 1.77× |
| 128 | 1024 | 109.5 | 184.2 | 1.68× |
| 256 | 1024 | 208.9 | 347.3 | 1.66× |
| 1 | 8192 | 52.5 | 55.5 | 1.06× |
| 2 | 8192 | 59.3 | 59.2 | 1.00× |
| 4 | 8192 | 71.9 | 64.7 | 0.90× |
| 8 | 8192 | 78.0 | 124.5 | 1.60× |
| 16 | 8192 | 112.2 | 215.5 | 1.92× |
| 32 | 8192 | 200.5 | 438.0 | 2.18× |
| 64 | 8192 | 387.7 | 819.6 | 2.11× |
| 128 | 8192 | 780.6 | 1601.9 | 2.05× |
| 256 | 8192 | 1540.5 | 3171.7 | 2.06× |
| 1 | 32768 | 166.4 | 205.2 | 1.23× |
| 2 | 32768 | 175.5 | 210.0 | 1.20× |
| 4 | 32768 | 189.3 | 214.2 | 1.13× |
| 8 | 32768 | 286.6 | 428.4 | 1.49× |
| 16 | 32768 | 516.1 | 825.5 | 1.60× |
| 32 | 32768 | 954.9 | 1609.8 | 1.69× |
| 64 | 32768 | 1784.1 | 3133.7 | 1.76× |
| 128 | 32768 | 3470.8 | 6352.0 | 1.83× |
| 256 | 32768 | 5983.1 | 12313.7 | 2.06× |
| 1 | 131072 | 588.4 | 777.9 | 1.32× |
| 2 | 131072 | 594.0 | 788.1 | 1.33× |
| 4 | 131072 | 668.3 | 819.8 | 1.23× |
| 8 | 131072 | 1025.7 | 1636.2 | 1.60× |
| 16 | 131072 | 1876.4 | 3245.3 | 1.73× |
| 32 | 131072 | 3470.2 | 6539.2 | 1.88× |
| 64 | 131072 | 6635.3 | 12354.5 | 1.86× |
| 128 | 131072 | 13181.7 | 25131.7 | 1.91× |
| 256 | 131072 | 26315.9 | 50522.9 | 1.92× |

Signed-off-by: Yu-Zhewen <zhewenyu@amd.com>