### PR TITLE
Fix tritonbench blackwell_attentions_mxfp8 CI (seq>=256)

### DIFF
--- a/.ci/tritonbench/fbtriton_skip_tests.yaml
+++ b/.ci/tritonbench/fbtriton_skip_tests.yaml
@@ -31,6 +31,11 @@ flash_attention:
 blackwell_attentions_mxfp8:
   devices:
     - b200
+  # Inherits the parent op's input shapes (input-0 is N_CTX=128), which triggers
+  # the same AutoWS compiler crash and cross-tile race on the persistent
+  # Blackwell FA path (single-trip inner loop). Run seq>=256 in CI until that is
+  # fixed. See T279315890.
+  extra_args: --seq-len 256
 blackwell_attentions:
   devices:
     - b200


### PR DESCRIPTION
Summary:
blackwell_attentions_mxfp8 inherits the parent blackwell_attentions input
shapes (input-0 is N_CTX=128), which triggers the AutoWS compiler crash on the
persistent Blackwell FA path (single-trip inner loop): a getIntOrFloatBitWidth
assertion in NVGPUWarpSpecialization from a pointer-typed cross-partition
channel. Mirror the workaround already applied to blackwell_attentions in
D111530890 by running seq>=256 in CI via skip_tests.yaml extra_args until the
compiler bug is fixed.

See T279315890.

This change was authored with Claude.

Reviewed By: njriasan

Differential Revision: D112059356


