### PR TITLE
[triton] Re-sync test_line_info FileCheck line numbers

### DIFF
--- a/python/test/unit/language/test_line_info.py
+++ b/python/test/unit/language/test_line_info.py
@@ -263,7 +263,7 @@ def test_use_name_loc_as_prefix(fresh_triton_cache):
 
     @triton.jit
     def kernel_basic(src, N, BLOCK_SIZE: tl.constexpr):
-        # CHECK: #loc = loc("{{.*}}":261:5)
+        # CHECK: #loc = loc("{{.*}}":265:5)
         # CHECK-LABEL:  tt.func public @kernel_basic(
         # CHECK-SAME:                                %src: !tt.ptr<f32> loc("src"(#loc)), %N: i32 loc("N"(#loc)))
         # CHECK:          %x_plus_1 = arith.constant dense<1.000000e+00> : tensor<16xf32> loc(#loc12)
@@ -501,7 +501,7 @@ def test_line_and_column_numbers(fresh_triton_cache):
 
     @triton.jit
     def kernel_basic(src, N, BLOCK_SIZE: tl.constexpr):
-        # CHECK: #loc = loc("{{.*}}":489:5)
+        # CHECK: #loc = loc("{{.*}}":503:5)
         # CHECK: #loc10 = loc("src"(#loc))
         # CHECK: #loc11 = loc("N"(#loc))
         # CHECK-LABEL:  tt.func public @kernel_basic(
@@ -524,15 +524,15 @@ def test_line_and_column_numbers(fresh_triton_cache):
         # CHECK:          } loc(#loc)
         # CHECK:         } loc(#loc)
 
-        # CHECK: #loc1 = loc({{.*}}:535:20)
+        # CHECK: #loc1 = loc({{.*}}:549:20)
         # CHECK: #loc2 = loc(unknown)
-        # CHECK: #loc3 = loc({{.*}}:530:15)
-        # CHECK: #loc4 = loc({{.*}}:531:18)
-        # CHECK: #loc5 = loc({{.*}}:532:28)
-        # CHECK: #loc6 = loc({{.*}}:532:19)
-        # CHECK: #loc7 = loc({{.*}}:533:30)
-        # CHECK: #loc8 = loc({{.*}}:534:16)
-        # CHECK: #loc9 = loc({{.*}}:536:9)
+        # CHECK: #loc3 = loc({{.*}}:544:15)
+        # CHECK: #loc4 = loc({{.*}}:545:18)
+        # CHECK: #loc5 = loc({{.*}}:546:28)
+        # CHECK: #loc6 = loc({{.*}}:546:19)
+        # CHECK: #loc7 = loc({{.*}}:547:30)
+        # CHECK: #loc8 = loc({{.*}}:548:16)
+        # CHECK: #loc9 = loc({{.*}}:550:9)
         # CHECK: #loc12 = loc("x_plus_1"(#loc1))
         # CHECK: #loc13 = loc("pid"(#loc3))
         # CHECK: #loc14 = loc("offset"(#loc4))


### PR DESCRIPTION
Summary:
test_line_info.py::{test_line_and_column_numbers,test_use_name_loc_as_prefix} hardcode
absolute source line:col in their `# CHECK: loc(...)` strings. A vendored-Triton
cherry-pick inserted lines above the kernel bodies (shifting them +4 / +14) without
updating the CHECK numbers, so FileCheck reports "no match found". Recompute the numbers
from the current source (each verified against the actual statement line; columns
unchanged).

Drafted with Claude Code.

Differential Revision: D112050817


