### PR TITLE
[triton] Derive NVIDIA launch signature from object signature, not str(ty) (#2045)

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -453,20 +453,21 @@ class CudaLauncher(object):
         signature = {idx: value for idx, value in src.signature.items()}
         tensordesc_meta = getattr(metadata, "tensordesc_meta", None)
 
-        # Compute Level 0 schema — the canonical ABI description for this kernel.
-        from triton.compiler.compiler import make_backend
-
-        backend = make_backend(metadata.target)
-        schema = backend.make_launch_metadata(metadata._asdict(), src)
-
         launcher = triton.runtime.driver.active.utils.launch
 
-        # kernel_signature: derived from Level 0 schema (single source of truth).
-        self.kernel_signature = build_kernel_signature_from_schema(schema)
-
-        # arg_annotations: still needs structural info from src.signature
-        # (tuple grouping is a Python calling convention, not kernel ABI).
+        # kernel_signature + arg_annotations are both derived from the object
+        # signature (src.signature): expand_signature flattens tensordescs, then
+        # make_kernel_signature / annotate_arguments walk the actual argument-type
+        # OBJECTS via isinstance(...). A NamedTuple *is* a tuple, so it flattens
+        # structurally like any other tuple -- no reliance on str(ty). Deriving the
+        # signature from the Level 0 schema's stringified types is a repr blind
+        # spot: a NamedTuple stringifies to a class repr ("Function(fn=...,
+        # captured=...)") rather than a tuple literal, so a string parser silently
+        # mis-flattens it. For every non-NamedTuple case this is byte-identical to
+        # the old schema path (asserted by
+        # test_launch_metadata.py::test_schema_derived_signature_matches_legacy).
         expanded_signature = expand_signature(signature.values(), tensordesc_meta)
+        self.kernel_signature = make_kernel_signature(expanded_signature)
         self.arg_annotations = annotate_arguments(expanded_signature)
 
         self.launch = wrap_handle_tensordesc(launcher, signature, tensordesc_meta)

--- a/third_party/nvidia/backend/triton_dispatcher_factory.py
+++ b/third_party/nvidia/backend/triton_dispatcher_factory.py
@@ -78,6 +78,19 @@ def _expand_schema_arg_types(schema):
                 for _ in range(ndim):
                     flat_types.append("i64")
         else:
+            # Structured (tuple / NamedTuple) arg types cannot be expressed by the
+            # C dispatcher's flat "one schema arg == one scalar leaf" model (see the
+            # flat_pos bookkeeping below and the a["index"] mapping in
+            # CompiledKernel._build_dispatcher). Their str(ty) is either a tuple
+            # literal ("('i32', 'constexpr')") or a NamedTuple class repr
+            # ("Function(fn='constexpr', captured=('*fp32',))") -- both contain "(",
+            # which scalar/pointer/tensordesc types never do. Rather than re-parse
+            # the repr (the same fragile repr blind spot that broke the launcher
+            # path), decline the C dispatcher by returning (None, None) so make_triton_dispatcher
+            # returns None and the caller falls back to the Python launcher, which
+            # flattens the object signature structurally.
+            if "(" in ty:
+                return None, None
             flat_types.append(ty)
 
     return flat_types, tensordesc_info if tensordesc_info else None


### PR DESCRIPTION
Summary:

CudaLauncher derived kernel_signature from the Level-0 schema's stringified arg types
(build_kernel_signature_from_schema -> _flatten_schema_arg_type, parsing str(ty)). A
NamedTuple stringifies to a class repr (Function(fn=..., captured=...)), not a tuple
literal, so the string parser mis-flattened it -> "RuntimeError: Unknown data type"
(test_tuple.py::test_namedtuple).

Derive kernel_signature from the object signature instead --
make_kernel_signature(expand_signature(...)) -- which flattens the actual argument-type
OBJECTS via isinstance(sig, tuple) (a NamedTuple *is* a tuple), exactly as upstream and
this repo's own blessed byte-equivalence test do. No str(ty) on the path, so the whole
class of repr-blind-spot bugs cannot recur; zero ABI change for existing cases (same
flatten order + constexpr drop). Also fix the twin C-dispatcher path
(triton_dispatcher_factory._expand_schema_arg_types): decline structured args
("(" in ty -> return None) so make_triton_dispatcher falls back to the robust Python
launcher instead of feeding a repr into the launcher metadata.

Standalone robust replacement for the now-abandoned point-fix D110466782.

Drafted with Claude Code.

Differential Revision: D112050872
