### PR TITLE
[triton] Gate NVIDIA-only beta unit tests correctly on AMD

### DIFF
--- a/python/test/unit/language/test_layout.py
+++ b/python/test/unit/language/test_layout.py
@@ -25,6 +25,7 @@ import torch
 import triton
 import triton.language as tl
 from triton.language.extra import libdevice
+from triton._internal_testing import is_hip
 
 # ---------------------------------------------------------------------------
 # Layout Parsing Utilities
@@ -1274,6 +1275,12 @@ def test_flash_attn_bwd_layout(HEAD_DIM, num_warps):
 
     grid = (N_CTX // BLOCK_N1, 1, Z * H)
 
+    # AMD MI300 (gfx942) has 64 KiB of LDS per workgroup. num_stages=5 with these
+    # NVIDIA-sized blocks needs ~68 KiB and overflows AMD's LDS (OutOfResources).
+    # Fewer pipeline stages fit AMD while producing the same blocked layouts (the
+    # coalesced layout is independent of pipeline depth); NVIDIA keeps 5.
+    num_stages = 2 if is_hip() else 5
+
     compiled_kernel = _flash_attn_bwd_layout_test[grid](
         q,
         k_scaled,
@@ -1299,7 +1306,7 @@ def test_flash_attn_bwd_layout(HEAD_DIM, num_warps):
         HEAD_DIM=HEAD_DIM,
         CAUSAL=CAUSAL,
         num_warps=num_warps,
-        num_stages=5,
+        num_stages=num_stages,
     )
 
     ttgir = compiled_kernel.asm["ttgir"]

--- a/python/test/unit/runtime/test_autotuner_constraint_prune.py
+++ b/python/test/unit/runtime/test_autotuner_constraint_prune.py
@@ -194,7 +194,7 @@ def test_ir_prune_count():
 # ---------------------------------------------------------------------------
 # GPU end-to-end tests (real Triton compile)
 # ---------------------------------------------------------------------------
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA GPU")
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA GPU")
 def test_gpu_ir_prune_on_real_ir(device="cuda"):
     N = 1024
     src = torch.randn(N, device=device, dtype=torch.float32)
@@ -235,7 +235,7 @@ def test_gpu_ir_prune_on_real_ir(device="cuda"):
 # BLOCK_SIZE>=512 -> v4, 256 -> v2, 128 -> scalar. Arch-independent (H100 fine). We record
 # the predicate's per-config verdict and assert the prune outcome matches it exactly.
 # ---------------------------------------------------------------------------
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA GPU")
+@pytest.mark.skipif(not is_cuda(), reason="requires CUDA GPU")
 def test_gpu_vectorization_filter(device="cuda"):
     N = 1 << 20
     src = torch.randn(N, device=device, dtype=torch.float32)


### PR DESCRIPTION
Summary:
Two beta unit tests fail on the AMD (gfx942 / MI300) CI host because they assume NVIDIA:
- test_autotuner_constraint_prune.py::{test_gpu_ir_prune_on_real_ir,
  test_gpu_vectorization_filter} gate on torch.cuda.is_available() (True on ROCm) and
  then assert NVIDIA asm keys (ttgir/ptx). Switch the guard to is_cuda() (backend ==
  "cuda") so they skip on HIP.
- test_layout.py::test_flash_attn_bwd_layout uses num_stages=5, which needs ~68 KiB of
  LDS and overflows MI300's 64 KiB (OutOfResources). Use num_stages=2 on HIP; the
  blocked layouts under test are independent of pipeline depth. NVIDIA keeps 5.

Drafted with Claude Code.

Reviewed By: njriasan

Differential Revision: D112050698


