### PR TITLE
  [AutoWS] [Tile-Schedule] Propagate non-persistent warpspec information (#2051) (#2051)

### DIFF
--- a/docs/programming-guide/chapter-3/fpsan.rst
+++ b/docs/programming-guide/chapter-3/fpsan.rst
@@ -280,7 +280,7 @@ Exact preserved properties:
 - ``exp2(-x) = 1.0 / exp2(x)``
 
 ``exp``
-=======
+-------
 
 Supported operation:
 

--- a/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
+++ b/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
@@ -6,6 +6,30 @@
 
 namespace mlir::triton {
 
+inline constexpr StringLiteral kNumStagesAttrName = "tt.num_stages";
+inline constexpr StringLiteral kDisallowAccMultiBufferAttrName =
+    "tt.disallow_acc_multi_buffer";
+inline constexpr StringLiteral kWarpSpecializeAttrName = "tt.warp_specialize";
+inline constexpr StringLiteral kScheduledMaxStageAttrName =
+    "tt.scheduled_max_stage";
+
+enum class AutoWSLoopAttrPropagation {
+  NotForwarded,
+  ForwardToInnerLoop,
+};
+
+struct AutoWSLoopAttrInfo {
+  StringLiteral name;
+  AutoWSLoopAttrPropagation propagation;
+};
+
+// Returns every loop attribute emitted by AutoWSLoopOptions and whether it must
+// be propagated when an annotated scheduler loop is removed.
+ArrayRef<AutoWSLoopAttrInfo> getAutoWSLoopAttrs();
+
+[[nodiscard]] SmallVector<NamedAttribute>
+filterAutoWSLoopAttrs(Operation *op, AutoWSLoopAttrPropagation propagation);
+
 // Filter out attributes from the given operation that are not present in
 // the allowList.
 [[nodiscard]] SmallVector<NamedAttribute>

--- a/include/triton/Dialect/Triton/Transforms/Passes.td
+++ b/include/triton/Dialect/Triton/Transforms/Passes.td
@@ -78,6 +78,14 @@ def TritonSimplifySingleTripWhile : Pass</*cli-arg*/"triton-simplify-single-trip
     again on the yielded values to produce them. Broader conditions (computed
     condition expressions) are not handled and could be added later via constant
     folding of the condition.
+
+    When the while carries `tt.warp_specialize`, the pass forwards the AutoWS
+    attributes that still have downstream consumers to `scf.for` loops exactly
+    one loop-nesting level inside it. Intervening non-loop control flow such as
+    `scf.if` does not add a nesting level. The shared AutoWS loop attribute
+    registry defines the complete attribute inventory and whether each
+    attribute needs forwarding. If no such loop exists, the annotated while is
+    preserved rather than silently dropping warp specialization.
   }];
 
   let dependentDialects = [

--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -3,6 +3,7 @@
 
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/DiscardableAttributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include <optional>
 #include <utility>
@@ -13,13 +14,8 @@ class DominanceInfo;
 class ImplicitLocOpBuilder;
 namespace triton {
 
-static const char *kNumStagesAttrName = "tt.num_stages";
-static const char *kDisallowAccMultiBufferAttrName =
-    "tt.disallow_acc_multi_buffer";
-static const char *kWarpSpecializeAttrName = "tt.warp_specialize";
 static const char *kLoopStageAttrName = "loop.stage";
 static const char *kLoopClusterAttrName = "loop.cluster";
-static const char *kScheduledMaxStageAttrName = "tt.scheduled_max_stage";
 class CoarseSchedule;
 class ModuleAxisInfoAnalysis;
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Triton/IR/DiscardableAttributes.cpp
+++ b/lib/Dialect/Triton/IR/DiscardableAttributes.cpp
@@ -1,7 +1,44 @@
-#include "mlir/Support/LLVM.h"
-#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/DiscardableAttributes.h"
 
 namespace mlir::triton {
+
+static constexpr AutoWSLoopAttrInfo kAutoWSLoopAttrs[] = {
+    {kNumStagesAttrName, AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.loop_unroll_factor", AutoWSLoopAttrPropagation::NotForwarded},
+    {kDisallowAccMultiBufferAttrName,
+     AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.flatten", AutoWSLoopAttrPropagation::NotForwarded},
+    {kWarpSpecializeAttrName, AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.multi_cta", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"llvm.loop_annotation", AutoWSLoopAttrPropagation::NotForwarded},
+    {"tt.data_partition_factor", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.list_schedule_pick", AutoWSLoopAttrPropagation::NotForwarded},
+    {"tt.mem_plan_pick", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.merge_epilogue", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.merge_epilogue_to_computation",
+     AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.merge_correction", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.separate_epilogue_store",
+     AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.tmem_alloc_algo", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.smem_alloc_algo", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.smem_budget", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.smem_circular_reuse", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+};
+
+ArrayRef<AutoWSLoopAttrInfo> getAutoWSLoopAttrs() { return kAutoWSLoopAttrs; }
+
+SmallVector<NamedAttribute>
+filterAutoWSLoopAttrs(Operation *op, AutoWSLoopAttrPropagation propagation) {
+  SmallVector<NamedAttribute> attrs;
+  for (const AutoWSLoopAttrInfo &attrInfo : getAutoWSLoopAttrs()) {
+    if (attrInfo.propagation != propagation)
+      continue;
+    if (Attribute attr = op->getDiscardableAttr(attrInfo.name))
+      attrs.emplace_back(attrInfo.name, attr);
+  }
+  return attrs;
+}
 
 SmallVector<NamedAttribute>
 filterDiscardableAttrs(Operation *op, ArrayRef<StringRef> allowList) {

--- a/lib/Dialect/Triton/Transforms/SimplifySingleTripWhile.cpp
+++ b/lib/Dialect/Triton/Transforms/SimplifySingleTripWhile.cpp
@@ -2,9 +2,11 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/DiscardableAttributes.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"
 #include "llvm/Support/Debug.h"
 
@@ -65,6 +67,34 @@ static bool isSingleTripConstantFlip(scf::WhileOp whileOp) {
     return false;
   return isConstantBool(whileOp.getInits()[c], /*expected=*/true) &&
          isConstantBool(yieldOp.getResults()[c], /*expected=*/false);
+}
+
+// Forward AutoWS to for loops exactly one loop-nesting level inside the
+// scheduler while. Intervening non-loop control flow, such as scf.if, does not
+// add a nesting level. Existing inner-loop settings take precedence.
+static bool forwardAutoWSToInnerLoops(scf::WhileOp whileOp) {
+  if (!whileOp->hasAttr(kWarpSpecializeAttrName))
+    return true;
+
+  SmallVector<scf::ForOp> innerLoops;
+  whileOp.getAfter().walk([&](scf::ForOp forOp) {
+    LoopLikeOpInterface parentLoop =
+        forOp->getParentOfType<LoopLikeOpInterface>();
+    if (parentLoop && parentLoop.getOperation() == whileOp.getOperation())
+      innerLoops.push_back(forOp);
+  });
+  if (innerLoops.empty())
+    return false;
+
+  SmallVector<NamedAttribute> attrs = filterAutoWSLoopAttrs(
+      whileOp, AutoWSLoopAttrPropagation::ForwardToInnerLoop);
+  for (scf::ForOp forOp : innerLoops) {
+    for (NamedAttribute attr : attrs) {
+      if (!forOp->hasAttr(attr.getName()))
+        forOp->setAttr(attr.getName(), attr.getValue());
+    }
+  }
+  return true;
 }
 
 // Clone the (pure) before-region ops under `argMap` (before-arg -> concrete
@@ -129,12 +159,18 @@ class SimplifySingleTripWhilePass
 public:
   void runOnOperation() override {
     SmallVector<scf::WhileOp> loops;
-    getOperation()->walk([&](scf::WhileOp whileOp) {
+    getOperation()->walk<WalkOrder::PostOrder>([&](scf::WhileOp whileOp) {
       if (isSingleTripConstantFlip(whileOp))
         loops.push_back(whileOp);
     });
 
     for (scf::WhileOp whileOp : loops) {
+      if (!forwardAutoWSToInnerLoops(whileOp)) {
+        LDBG("Keeping annotated single-trip while without a first-level inner "
+             "loop: "
+             << whileOp);
+        continue;
+      }
       LDBG("Simplifying single-trip while: " << whileOp);
       rewriteSingleTripWhile(whileOp);
     }

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -368,6 +368,7 @@ def matmul_kernel_tma_unified_persistent_ws_while(
     EPILOGUE_SUBTILE: tl.constexpr,
     NUM_SMS: tl.constexpr,
     SCHEDULE: tl.constexpr,
+    OUTER_WARP_SPECIALIZE: tl.constexpr,
 ):
     dtype = tl.float16
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
@@ -377,13 +378,13 @@ def matmul_kernel_tma_unified_persistent_ws_while(
 
     lowering_args = _MatmulTileArgs(M, N, BLOCK_SIZE_M, BLOCK_SIZE_N)
     sched = SCHEDULE.initialize(lowering_args, _unified_num_tiles, tile_counter)
-    while sched.is_valid():
+    while tl.condition(sched.is_valid(), warp_specialize=OUTER_WARP_SPECIALIZE):
         pid_m, pid_n = _compute_pid(sched.tile_id[0], num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
         offs_am = pid_m * BLOCK_SIZE_M
         offs_bn = pid_n * BLOCK_SIZE_N
 
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-        for ki in tl.range(k_tiles, warp_specialize=True):
+        for ki in tl.range(k_tiles, warp_specialize=not OUTER_WARP_SPECIALIZE):
             offs_k = ki * BLOCK_SIZE_K
             a = a_desc.load([offs_am, offs_k])
             b = b_desc.load([offs_bn, offs_k])
@@ -1143,6 +1144,7 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(EPI
             EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
             NUM_SMS=NUM_SMS,
             SCHEDULE=SCHEDULE,
+            OUTER_WARP_SPECIALIZE=SCHEDULE is tl.NonPersistentScheduler,
             num_stages=num_stages,
             num_warps=num_warps,
         )
@@ -1151,7 +1153,7 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(EPI
         if SCHEDULE is tl.NonPersistentScheduler:
             # The non-persistent schedule's outer loop provably runs exactly once
             # (`_valid` flips True->False), so triton-simplify-single-trip-while
-            # optimizes the `scf.while` away at the TTIR stage.
+            # optimizes the `scf.while` away after TTGIR loop scheduling.
             assert "scf.while" not in ttgir, "Expected single-trip outer while to be optimized away"
         elif SCHEDULE is tl.StaticPersistent1DScheduler:
             # The static-persistent schedule is a countable loop (`_x < num_tiles`,

--- a/test/Hopper/WarpSpecialization/ws_while_loop_autows.mlir
+++ b/test/Hopper/WarpSpecialization/ws_while_loop_autows.mlir
@@ -1,6 +1,7 @@
 // RUN: triton-opt %s -split-input-file --nvgpu-test-taskid-propagate=num-warp-groups=2 | FileCheck %s --check-prefix=TASKID
 // RUN: triton-opt %s -split-input-file --nvgpu-ws-data-partition=num-warp-groups=3 | FileCheck %s --check-prefix=DATAPART
 // RUN: triton-opt %s -split-input-file --nvgpu-test-ws-code-partition="num-buffers=1" | FileCheck %s --check-prefix=CODEPART
+// RUN: triton-opt %s -split-input-file --nvgpu-ws-data-partition=num-warp-groups=3 --triton-simplify-single-trip-while --nvgpu-partition-scheduling-meta | FileCheck %s --check-prefix=DEFERRED
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
@@ -28,6 +29,54 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %use = arith.addi %new_off, %arg0 {async_task_id = array<i32: 1>} : i32
       scf.yield %use, %false : i32, i1
     }
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Data partitioning must see the outer while's factor before simplification.
+  // Partition scheduling must then see warp_specialize on the forwarded loop.
+  // DEFERRED-LABEL: @deferred_single_trip_while
+  // DEFERRED-NOT: scf.while
+  // DEFERRED: scf.for
+  // DEFERRED: ttng.warp_group_dot
+  // DEFERRED-SAME: ttg.partition
+  // DEFERRED: ttng.warp_group_dot
+  // DEFERRED-SAME: ttg.partition
+  // DEFERRED: } {tt.data_partition_factor = 2 : i32
+  // DEFERRED-SAME: tt.warp_specialize
+  tt.func public @deferred_single_trip_while(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %out: !tt.ptr<f32>, %k_tiles: index) {
+    %true = arith.constant true
+    %false = arith.constant false
+    %c0 = arith.constant 0 : i32
+    %c0_idx = arith.constant 0 : index
+    %c1_idx = arith.constant 1 : index
+    scf.while (%valid = %true) : (i1) -> () {
+      scf.condition(%valid)
+    } do {
+      %acc_init = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+      %inner = scf.for %ki = %c0_idx to %k_tiles step %c1_idx iter_args(%iter_acc = %acc_init) -> (tensor<128x256xf32, #mma>) {
+        %a_ptrs = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+        %a = tt.load %a_ptrs : tensor<128x64x!tt.ptr<f16>, #blocked>
+        %a_alloc = ttg.local_alloc %a : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %b_ptrs = tt.splat %arg1 : !tt.ptr<f16> -> tensor<64x256x!tt.ptr<f16>, #blocked1>
+        %b = tt.load %b_ptrs : tensor<64x256x!tt.ptr<f16>, #blocked1>
+        %b_alloc = ttg.local_alloc %b : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+        %dot = ttng.warp_group_dot %a_alloc, %b_alloc, %iter_acc {inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+        scf.yield %dot : tensor<128x256xf32, #mma>
+      }
+      %ptrs = tt.splat %out : !tt.ptr<f32> -> tensor<128x256x!tt.ptr<f32>, #blocked1>
+      %cvt = ttg.convert_layout %inner : tensor<128x256xf32, #mma> -> tensor<128x256xf32, #blocked1>
+      tt.store %ptrs, %cvt : tensor<128x256x!tt.ptr<f32>, #blocked1>
+      scf.yield %false : i1
+    } attributes {tt.warp_specialize, tt.data_partition_factor = 2 : i32}
     tt.return
   }
 }

--- a/test/Triton/simplify-single-trip-while.mlir
+++ b/test/Triton/simplify-single-trip-while.mlir
@@ -1,4 +1,6 @@
 // RUN: triton-opt --split-input-file %s -triton-simplify-single-trip-while | FileCheck %s
+// RUN: triton-opt --split-input-file %s -triton-simplify-single-trip-while | FileCheck %s --check-prefix=NO-EARLY
+// RUN: triton-opt --split-input-file %s -triton-simplify-single-trip-while | FileCheck %s --check-prefix=ONE-LEVEL
 
 // The "constant-flip" pattern: the loop-carried condition is a constant `true`
 // on entry and a constant `false` after the body, and scf.condition forwards all
@@ -99,4 +101,117 @@ tt.func @computed_condition(%arg0: i32) -> i32 {
     scf.yield %false, %n : i1, i32
   }
   tt.return %r#1 : i32
+}
+
+// -----
+
+// An annotated scheduler while forwards AutoWS to the for loop exactly one
+// loop-nesting level inside it, even with non-loop control flow outside the
+// while and between it and the for. A nested second-level for does not receive
+// the attributes, and explicit inner settings win over the outer loop's
+// defaults.
+// CHECK-LABEL: @forwards_autows
+// CHECK-NOT: scf.while
+// CHECK: scf.if
+// CHECK: scf.for
+// CHECK: } {tt.data_partition_factor = 2 : i32
+// CHECK-SAME: tt.disallow_acc_multi_buffer
+// CHECK-SAME: tt.mem_plan_pick = 3 : i32
+// CHECK-SAME: tt.merge_correction = true
+// CHECK-SAME: tt.merge_epilogue = true
+// CHECK-SAME: tt.merge_epilogue_to_computation = true
+// CHECK-SAME: tt.multi_cta
+// CHECK-SAME: tt.num_stages = 5 : i32
+// CHECK-SAME: tt.separate_epilogue_store = true
+// CHECK-SAME: tt.smem_alloc_algo = 1 : i32
+// CHECK-SAME: tt.smem_budget = 65536 : i32
+// CHECK-SAME: tt.smem_circular_reuse = true
+// CHECK-SAME: tt.tmem_alloc_algo = 2 : i32
+// CHECK-SAME: tt.warp_specialize
+// NO-EARLY-LABEL: @forwards_autows
+// NO-EARLY-NOT: llvm.loop_annotation
+// NO-EARLY-NOT: tt.flatten
+// NO-EARLY-NOT: tt.list_schedule_pick
+// NO-EARLY-NOT: tt.loop_unroll_factor
+// NO-EARLY: tt.return
+// ONE-LEVEL-LABEL: @forwards_autows
+// ONE-LEVEL: tt.warp_specialize
+// ONE-LEVEL-NOT: tt.warp_specialize
+// ONE-LEVEL: tt.return
+tt.func @forwards_autows(%arg0: i32) -> i32 {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %r = scf.if %true -> (i32) {
+    %while_result = scf.while (%valid = %true, %acc = %arg0) : (i1, i32) -> i32 {
+      scf.condition(%valid) %acc : i32
+    } do {
+    ^bb0(%acc: i32):
+      %inner = scf.if %true -> (i32) {
+        %loop = scf.for %i = %c0 to %c1 step %c1 iter_args(%v = %acc) -> (i32) {
+          %nested = scf.for %j = %c0 to %c1 step %c1 iter_args(%nv = %v) -> (i32) {
+            %nested_next = arith.addi %nv, %nv : i32
+            scf.yield %nested_next : i32
+          }
+          %next = arith.addi %nested, %nested : i32
+          scf.yield %next : i32
+        } {tt.num_stages = 5 : i32}
+        scf.yield %loop : i32
+      } else {
+        scf.yield %acc : i32
+      }
+      scf.yield %false, %inner : i1, i32
+    } attributes {tt.warp_specialize, tt.num_stages = 3 : i32, tt.loop_unroll_factor = 4 : i32, tt.disallow_acc_multi_buffer, tt.flatten, tt.multi_cta, llvm.loop_annotation = true, tt.data_partition_factor = 2 : i32, tt.list_schedule_pick = 1 : i32, tt.mem_plan_pick = 3 : i32, tt.merge_epilogue = true, tt.merge_epilogue_to_computation = true, tt.merge_correction = true, tt.separate_epilogue_store = true, tt.tmem_alloc_algo = 2 : i32, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 65536 : i32, tt.smem_circular_reuse = true}
+    scf.yield %while_result : i32
+  } else {
+    scf.yield %arg0 : i32
+  }
+  tt.return %r : i32
+}
+
+// -----
+
+// Do not silently discard a WS request when no first-level inner loop exists.
+// CHECK-LABEL: @annotated_without_forward_target
+// CHECK: scf.while
+// CHECK: } attributes {tt.warp_specialize}
+tt.func @annotated_without_forward_target(%arg0: !tt.ptr<i32>) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c1 = arith.constant 1 : i32
+  scf.while (%valid = %true) : (i1) -> () {
+    scf.condition(%valid)
+  } do {
+    tt.store %arg0, %c1 : !tt.ptr<i32>
+    scf.yield %false : i1
+  } attributes {tt.warp_specialize}
+  tt.return
+}
+
+// -----
+
+// Matching nested whiles are processed from the inside out, so erasing the
+// inner loop cannot leave a stale handle in the pass worklist.
+// CHECK-LABEL: @nested_single_trip
+// CHECK-NOT: scf.while
+// CHECK-COUNT-2: arith.addi
+tt.func @nested_single_trip(%arg0: i32) -> i32 {
+  %true = arith.constant true
+  %false = arith.constant false
+  %outer = scf.while (%valid = %true, %acc = %arg0) : (i1, i32) -> i32 {
+    scf.condition(%valid) %acc : i32
+  } do {
+  ^bb0(%acc: i32):
+    %inner = scf.while (%inner_valid = %true, %inner_acc = %acc) : (i1, i32) -> i32 {
+      scf.condition(%inner_valid) %inner_acc : i32
+    } do {
+    ^bb0(%inner_acc: i32):
+      %next = arith.addi %inner_acc, %inner_acc : i32
+      scf.yield %false, %next : i1, i32
+    }
+    %next = arith.addi %inner, %inner : i32
+    scf.yield %false, %next : i1, i32
+  }
+  tt.return %outer : i32
 }

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -752,7 +752,6 @@ class CUDABackend(BaseBackend):
         if (opt.auto_tma or knobs.nvidia.auto_tma) and capability // 10 >= 9:
             nvidia.passes.ttnvgpuir.add_promote_load_to_tma(pm)
         passes.common.add_canonicalizer(pm)
-        passes.ttir.add_simplify_single_trip_while(pm)
         passes.ttir.add_combine(pm)
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)
@@ -849,6 +848,10 @@ class CUDABackend(BaseBackend):
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
             if knobs.nvidia.use_meta_ws:
                 nvidia.passes.hopper.add_data_partitioning(pm, 1)
+            # Support simplify trip while after data partitioning to
+            # enable using this loop to data partition.
+            passes.ttir.add_simplify_single_trip_while(pm)
+            if knobs.nvidia.use_meta_ws:
                 passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, knobs.nvidia.use_meta_ws)
                 passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, knobs.nvidia.use_meta_ws)
             nvidia.passes.hopper.add_tma_store_lowering(pm)
@@ -904,6 +907,7 @@ class CUDABackend(BaseBackend):
                 # the picked one (TRITON_LIST_SCHEDULE_PICK, default best).
                 nvidia.passes.hopper.add_list_schedule(pm)
             nvidia.passes.hopper.add_data_partitioning(pm, 1)
+            passes.ttir.add_simplify_single_trip_while(pm)
             # The modulo / LLM / list scheduler above already produced the full
             # loop schedule (loop.stage / loop.cluster). Re-running
             # assign_latencies + schedule_loops here would recompute and OVERRIDE

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWSAnnotations.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWSAnnotations.md
@@ -24,11 +24,21 @@ while tl.condition(sched.is_valid(), warp_specialize=True, data_partition_factor
 ```
 
 Both `tl.range` (for loops) and `tl.condition` (while loops) inherit a single
-dataclass, **`AutoWSLoopOptions`** (`core.py`), which is the *one* place the
-option set, defaults, and IR-attribute mapping are defined. `visit_For` and
-`visit_While` both emit them via the shared `_apply_loop_options` helper, so a
-`for` and a `while` receive byte-identical attributes. Adding a new knob is a
-single new field on `AutoWSLoopOptions`.
+dataclass, **`AutoWSLoopOptions`** (`core.py`), which owns the frontend option
+set, defaults, and IR-attribute mapping. `visit_For` and `visit_While` both emit
+them via the shared `_apply_loop_options` helper, so a `for` and a `while`
+receive byte-identical attributes.
+
+The C++ inventory and scheduler-loop propagation policy are centralized in
+`include/triton/Dialect/Triton/IR/DiscardableAttributes.h` and
+`lib/Dialect/Triton/IR/DiscardableAttributes.cpp`. The registry contains every
+attribute emitted by `AutoWSLoopOptions`, including attributes consumed before
+the single-trip rewrite and those that must be forwarded to the inner compute
+loop. A new frontend option must add one registry entry and choose its
+propagation policy; transforms such as `SimplifySingleTripWhile` filter this
+registry instead of maintaining private allowlists. Internal scheduling
+metadata such as `tt.scheduled_max_stage` remains separate from the frontend
+AutoWS inventory.
 
 ## Annotation → IR attribute → consumer
 
@@ -44,6 +54,7 @@ single new field on `AutoWSLoopOptions`.
 | `merge_epilogue` / `merge_epilogue_to_computation` / `merge_correction` | `tt.merge_*` | `PartitionSchedulingMeta` (`SchedulingOptions`) | epilogue/correction routing |
 | `separate_epilogue_store` | `tt.separate_epilogue_store` | `PartitionSchedulingMeta` | epilogue store gets own partition |
 | `tmem_alloc_algo` / `smem_alloc_algo` / `smem_budget` / `smem_circular_reuse` | `tt.{tmem,smem}_alloc_algo`, `tt.smem_budget`, `tt.smem_circular_reuse` | `WSMemoryPlanner` | allocation heuristics |
+| `list_schedule_pick` / `mem_plan_pick` | `tt.list_schedule_pick` / `tt.mem_plan_pick` | list scheduler / `WSMemoryPlanner` | ranked schedule and memory-plan selection |
 | `disable_licm` | `llvm.loop_annotation` | LICM | suppress hoisting |
 
 See `PartitionSchedulingMeta.md` for how the `merge_*` / `separate_epilogue_store`
@@ -56,12 +67,28 @@ kernel with an `scf.while` outer loop. The annotations are *attached* to the
 `while` identically to a `for` (via `tl.condition`) and survive into TTGIR, but
 whether they take *effect* depends on the schedule:
 
-| Schedule | outer loop after `make_ttir` | annotations effective? |
+| Schedule | outer-loop handling | annotations effective? |
 |---|---|---|
 | static persistent | uplifted to `scf.for` (`triton-uplift-while-to-for`) | **yes** — treated as a normal `for` |
 | dynamic persistent | stays `scf.while` (atomic advance) | **partial** — see below |
 | CLC | stays `scf.while` (hardware `_valid`) | **partial** — see below |
-| non-persistent | single-trip `while` eliminated (`triton-simplify-single-trip-while`) | n/a — no loop |
+| non-persistent | kept through data partitioning, then eliminated before the default loop schedule | **yes** — AutoWS is forwarded to the first-level inner loop |
+
+For non-persistent schedules on Hopper and Blackwell,
+`triton-simplify-single-trip-while` deliberately runs in TTGIR after data
+partitioning and before default latency assignment and loop scheduling. Before
+inlining the single-trip while, it forwards the still-live AutoWS attributes to
+`scf.for` loops exactly one loop-nesting level inside the scheduler while. This
+is based on the nearest enclosing loop, so intervening non-loop control flow
+such as `scf.if` is transparent, while a nested second-level loop is excluded.
+This lets downstream scheduling and warp-specialization passes operate on the
+inner loop without hiding the outer loop from data partitioning. An annotated
+while with no first-level inner target is preserved rather than silently losing
+warp specialization. Attributes whose
+consumers already ran, such as `tt.list_schedule_pick`, are not forwarded;
+later consumers such as the memory planner and multi-CTA reduction still
+receive `tt.mem_plan_pick` and `tt.multi_cta`, respectively. Existing
+attributes on the selected inner loop take precedence over outer defaults.
 
 ### `warp_specialize` on a non-countable `while`: **no-op today**
 
@@ -94,12 +121,13 @@ regions correctly. This is verified by the lit tests `@while_data_partition`,
 mirrors the CLC scheduler shape with `ttng.clc_advance`) in
 `test/Hopper/WarpSpecialization/ws_while_loop_autows.mlir`.
 
-However, `WSDataPartition` runs *after* `PartitionSchedulingMeta` has assigned
-partitions and `tt.warp_specialize` has been consumed. Because that does not
-happen for a non-uplifted `while` (previous section), end-to-end data
-partitioning of a dynamic/CLC `while` is gated on the same
-`PartitionSchedulingMeta` generalization. In other words: the data-partition
-mechanism is ready for `while`; the partition-*assignment* front-end is not.
+`WSDataPartition` runs before `PartitionSchedulingMeta`, while the annotated
+outer loop still exists. For a non-persistent schedule the subsequent
+single-trip rewrite forwards AutoWS to the inner loop, so partition assignment
+can continue there. Dynamic/CLC loops are not eliminated and remain gated on
+the `PartitionSchedulingMeta` generalization described above. In other words:
+the data-partition mechanism is ready for `while`; persistent while
+partition-*assignment* is not.
 
 > Known cosmetic artifact: data-partitioning a `while` leaves the original
 > full-width dot as a *dead* loop result (not DCE'd, because removing a dead
@@ -110,9 +138,12 @@ mechanism is ready for `while`; the partition-*assignment* front-end is not.
 ## Summary
 
 - **Annotations are unified** across `for`/`while` via `AutoWSLoopOptions`; the
-  frontend and IR emission are in lockstep.
+  frontend and IR emission are in lockstep, while the shared C++ registry owns
+  their scheduler-loop propagation policy.
 - **On `scf.for`** (including a static `while` uplifted to `for`): all
   annotations work.
+- **On a non-persistent `scf.while`**: data partitioning sees the while before
+  it is eliminated, then AutoWS is forwarded to the scheduled inner loop.
 - **On a raw `scf.while`** (dynamic/CLC): the annotations attach and survive,
   `WSDataPartition` already understands `while`, but `warp_specialize` /
   `data_partition_factor` do not yet take effect end-to-end because

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -32,6 +32,13 @@ Data partitioning is not Hopper-only; it can run as the separate
 `nvgpu-ws-data-partition` pass when an explicit data partition factor or warp
 group configuration requires per-consumer slices.
 
+For a non-persistent unified scheduler, the single-trip `scf.while` is kept
+through data partitioning and the initial loop schedule. The
+`triton-simplify-single-trip-while` pass then forwards the outer AutoWS
+attributes to the scheduled inner `scf.for` loop and inlines the while before
+`PartitionSchedulingMeta` assigns partitions. Physical `ttg.warp_specialize`
+regions are created later by `specializeRegion` during `doCodePartitionPost`.
+
 Before `PartitionSchedulingMeta`, the Meta WS backend runs
 `nvgpu-sink-broadcast` to move `tt.broadcast` producer chains next to their
 elementwise users. This keeps broadcasts and their value materialization, such

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WarpSpecializeWhileLoops.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WarpSpecializeWhileLoops.md
@@ -27,8 +27,10 @@ Two of the four schedules are already covered without touching AutoWS:
 - **Static persistent** — the while is *countable*, so `triton-uplift-while-to-for`
   rewrites it to an `scf.for` (carrying the annotations) before AutoWS runs. It is
   then warp-specialized by the existing `scf.for` path.
-- **Non-persistent** — the while is single-trip and eliminated by
-  `triton-simplify-single-trip-while`; there is no persistent loop to specialize.
+- **Non-persistent** — the while is kept through data partitioning and initial
+  loop scheduling, then `triton-simplify-single-trip-while` forwards AutoWS to
+  the scheduled inner loop and eliminates the single-trip outer loop before
+  partition scheduling.
 
 That leaves the **genuinely non-countable** schedules — **dynamic** (atomic
 work-stealing) and **CLC** (hardware `_valid`) — whose outer loop stays an

--- a/third_party/tlx/tools/sched2tlx/examples/case2_persistent_gemm/pre_modulo.ttgir
+++ b/third_party/tlx/tools/sched2tlx/examples/case2_persistent_gemm/pre_modulo.ttgir
@@ -112,5 +112,3 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
 #loc54 = loc(callsite(#loc10 at #loc39))
 #loc55 = loc(callsite(#loc8 at #loc33))
 #loc56 = loc(callsite(#loc10 at #loc33))
-
-

--- a/third_party/tlx/tools/sched2tlx/examples/case8_multiphase_gemm/triple_gemm_nows_pre_modulo.ttgir
+++ b/third_party/tlx/tools/sched2tlx/examples/case8_multiphase_gemm/triple_gemm_nows_pre_modulo.ttgir
@@ -143,5 +143,3 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
 #loc67 = loc("acc3"(#loc2))
 #loc68 = loc("a"(#loc29))
 #loc69 = loc("b"(#loc30))
-
-

--- a/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/generated.py
+++ b/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/generated.py
@@ -121,7 +121,7 @@ def _scaled_mm_blockwise(
         # Async task: role=TMA ← inner wg3 (Phase 4 plan)
         with tlx.async_task(num_warps=4, num_regs=152):
             smem_accum = 0
-            # Re-materialize function-scope register tensors locally (a 
+            # Re-materialize function-scope register tensors locally (a
             # non-default warp group cannot capture RankedTensorType).
             _wgloc600 = tl.arange(0, 128)
             # Outer persistent loop (loop 1, II=45824). Each task replays it; body trimmed to this WG's ops.
@@ -143,7 +143,7 @@ def _scaled_mm_blockwise(
         with tlx.async_task("default"):
             smem_accum = 0
             tmem_accum_cnt = 0
-            # Re-materialize function-scope register tensors locally (a 
+            # Re-materialize function-scope register tensors locally (a
             # non-default warp group cannot capture RankedTensorType).
             _wgloc600 = tl.arange(0, 128)
             # Outer persistent loop (loop 1, II=45824). Each task replays it; body trimmed to this WG's ops.

--- a/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/scaled_mm_blockwise_pre_modulo.ttgir
+++ b/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/scaled_mm_blockwise_pre_modulo.ttgir
@@ -160,5 +160,3 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
 #loc83 = loc(callsite(#loc9 at #loc55))
 #loc84 = loc(callsite(#loc7 at #loc57))
 #loc85 = loc(callsite(#loc9 at #loc57))
-
-


### PR DESCRIPTION
Summary: Adds support for propagating warpspec information in a non-persistent while to the inner for loop. This ensure data partitioning will run at an outer level (can be scheduled outside the inner loop) and then deletes the outer loop afterwards. This also refuses to delete the loop if there is no inner loop to propagate to (which could occur if the inner loop is optimized out due to constants).

Pulled By:
njriasan


njriasan

Reviewed By: manman-ren

Differential Revision: D112198109


