### PR TITLE
[Triton][auto-TMA][7/N] Enable FA backward to auto-promote plain pointer loads/stores to TMA + warp-specialization (#2055)

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLoadToTMA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLoadToTMA.cpp
@@ -34,6 +34,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include <climits>
 #include <cstdlib>
 #include <functional>
 #include <string>
@@ -111,6 +112,10 @@ struct DimInfo {
   bool loopAdvanced = false;
   Value loopIV;             // scf.for induction variable
   int64_t perIterElems = 0; // per-iteration advance along this (contiguous) dim
+  // Compile-time constant tile offset (from a dense splat constant in a
+  // subtiled epilogue). Materialized as an i32 arith.constant at rewrite time
+  // rather than inside the matcher to avoid orphan IR when the op is rejected.
+  std::optional<int32_t> deferredConstOffset;
 };
 
 struct DecomposedLoad {
@@ -193,6 +198,7 @@ static bool isRawIndexOffset(Value v) {
 
 // Match (make_range(0,BLOCK) + splat(tile_off)) * splat(stride), or the
 // contiguous form make_range(0,BLOCK) + splat(tile_off).
+static bool matchUniformIntConst(Value v, int64_t &out);
 static bool match1DOffset(Value offsetVal, DimInfo &info) {
   // Peel the no-mask OOB idiom `offs = (pid*BLOCK + arange) % M`: the modulus
   // is this dim's global extent. Record the modulus kernel arg as the shape
@@ -265,13 +271,30 @@ static bool match1DOffset(Value offsetVal, DimInfo &info) {
     Value addRhs = addOp.getRhs();
     for (int swap = 0; swap < 2; swap++) {
       int64_t blockSize;
-      Value tileOff = matchSplat(addRhs);
-      if (matchMakeRange(addLhs, blockSize) && tileOff) {
-        info.blockSize = blockSize;
-        info.stride = {};
-        info.offset = tileOff;
-        info.strideArgIdx = -1;
-        return true;
+      if (matchMakeRange(addLhs, blockSize)) {
+        // make_range + splat(tile_off): runtime/device tile offset.
+        if (Value tileOff = matchSplat(addRhs)) {
+          info.blockSize = blockSize;
+          info.stride = {};
+          info.offset = tileOff;
+          info.strideArgIdx = -1;
+          return true;
+        }
+        // make_range + compile-time-constant offset (a dense splat constant,
+        // e.g. a subtiled epilogue's column slice offset slice*size).
+        // matchSplat misses dense constants, so match here and record the
+        // value for deferred materialization at rewrite time.
+        int64_t cst;
+        if (matchUniformIntConst(addRhs, cst)) {
+          if (cst < INT32_MIN || cst > INT32_MAX)
+            return false;
+          info.blockSize = blockSize;
+          info.stride = {};
+          info.offset = {};
+          info.deferredConstOffset = (int32_t)cst;
+          info.strideArgIdx = -1;
+          return true;
+        }
       }
       std::swap(addLhs, addRhs);
     }
@@ -999,9 +1022,9 @@ static bool dimStrideIs16BAligned(tt::FuncOp func, const DimInfo &dim,
 // TMA-eligibility for a store's value tensor — mirrors isTMAEligible minus the
 // load-only `other`/OOB-fill check (TMA store bounds via the descriptor's
 // globalDim, so a masked store maps to a bounded TMA copy).
-static bool isTMAEligibleStore(tt::StoreOp storeOp,
+static bool isTMAEligibleStore(Value valueTensor,
                                const DecomposedLoad &decomp) {
-  auto valTy = dyn_cast<RankedTensorType>(storeOp.getValue().getType());
+  auto valTy = dyn_cast<RankedTensorType>(valueTensor.getType());
   if (!valTy)
     return false;
   // Shared eligibility core (dtype, rank, single contiguous dim, inner box a
@@ -1050,7 +1073,10 @@ struct Promotion {
 };
 
 struct StorePromotion {
-  tt::StoreOp storeOp;
+  Operation *op; // tt::StoreOp or tt::AtomicRMWOp(add/fadd)
+  Value value;   // stored / accumulated value tensor
+  bool isAtomicAdd =
+      false; // emit tt.descriptor_reduce(add), not descriptor_store
   DecomposedLoad decomp;
   SmallVector<int> shapeArgIndices;
   bool useDeviceMode = false;
@@ -1131,6 +1157,21 @@ public:
           s = findShapeArgFromTileBound(kernelFunc, dim);
         if (s < 0 && dim.loopAdvanced)
           s = findShapeArgForLoopDim(kernelFunc, dim);
+        // Contiguous innermost dim: infer extent from the next-outer dim's
+        // stride. Placed AFTER mask/tileBound/loopDim lookups so a mask bound
+        // (e.g. `offs_n < N` for a padded GEMM) always takes priority. When
+        // no mask provides the extent (e.g. FA's HEAD_DIM, or a subtiled
+        // epilogue slice), outer_stride is safe: the absence of a mask means
+        // the kernel guarantees all accesses are within inner_extent, and
+        // outer_stride >= inner_extent >= max accessed index. This also
+        // ensures all subtiled slices build the SAME descriptor (same extent
+        // = outer stride), letting the WS memory planner group their staging
+        // into one buffer.
+        if (s < 0 && d == rank - 1 && dim.strideArgIdx < 0 && rank >= 2 &&
+            decomp.dims[rank - 2].strideArgIdx >= 0) {
+          s = decomp.dims[rank - 2].strideArgIdx;
+          needsDevice = true;
+        }
         // A dim loaded WHOLE (no tile offset -> not tiled, e.g. the FA head dim
         // `offs_d = arange(0, HEAD_DIM)`) has global extent == blockSize, a
         // compile-time constant. Use the -2 sentinel so Phase 2 emits an
@@ -1139,7 +1180,7 @@ public:
         // unmasked (no mask bound unattributable to a tiled dim): a
         // partially-masked untiled dim could have a true extent > blockSize, so
         // fabricating blockSize would under-size the descriptor.
-        if (s < 0 && !dim.offset &&
+        if (s < 0 && !dim.offset && !dim.deferredConstOffset &&
             !maskHasUnattributedBound(loadOp.getMask(), decomp)) {
           s = -2;
           needsDevice = true;
@@ -1197,7 +1238,7 @@ public:
     if (kernelIsWarpSpecialized(kernelFunc)) {
       kernelFunc.walk([&](tt::StoreOp storeOp) {
         DecomposedLoad decomp = decomposePointer(storeOp.getPtr());
-        if (!decomp.valid || !isTMAEligibleStore(storeOp, decomp))
+        if (!decomp.valid || !isTMAEligibleStore(storeOp.getValue(), decomp))
           return;
         // Per-store host-vs-device decision (same logic as loads).
         bool needsDevice = useDevice;
@@ -1233,7 +1274,12 @@ public:
             s = findShapeArgForDim(kernelFunc, storeOp.getMask(), dim);
           if (s < 0)
             s = findShapeArgFromTileBound(kernelFunc, dim);
-          if (s < 0 && !dim.offset &&
+          if (s < 0 && d == rank - 1 && dim.strideArgIdx < 0 && rank >= 2 &&
+              decomp.dims[rank - 2].strideArgIdx >= 0) {
+            s = decomp.dims[rank - 2].strideArgIdx;
+            needsDevice = true;
+          }
+          if (s < 0 && !dim.offset && !dim.deferredConstOffset &&
               !maskHasUnattributedBound(storeOp.getMask(), decomp)) {
             s = -2;
             needsDevice = true;
@@ -1242,7 +1288,7 @@ public:
         }
         bool ok = true;
         for (int d = 0; d < rank; d++)
-          if (shapeArgs[d] == -1) // -2 = constant extent (device mode)
+          if (shapeArgs[d] == -1)
             ok = false;
         if (!ok)
           return;
@@ -1264,7 +1310,90 @@ public:
         if (!storeMaskIsRectangular(storeOp.getMask(), decomp))
           return;
         StorePromotion p;
-        p.storeOp = storeOp;
+        p.op = storeOp;
+        p.value = storeOp.getValue();
+        p.decomp = decomp;
+        p.shapeArgIndices = shapeArgs;
+        p.useDeviceMode = needsDevice;
+        storePromotions.push_back(std::move(p));
+      });
+      // Phase 1c: eligible tt.atomic_rmw(add/fadd) whose result is unused -> a
+      // TMA reducing store (tt.descriptor_reduce). Same eligibility/geometry as
+      // a store; the only extra requirement is the unused result
+      // (descriptor_reduce returns nothing). Reuses the StorePromotion path
+      // (isAtomicAdd=true).
+      kernelFunc.walk([&](tt::AtomicRMWOp atomicOp) {
+        tt::RMWOp rmw = atomicOp.getAtomicRmwOp();
+        if (rmw != tt::RMWOp::ADD && rmw != tt::RMWOp::FADD)
+          return;
+        // descriptor_reduce carries no memory ordering or scope;
+        // only promote relaxed atomics to avoid silently dropping
+        // synchronization semantics.
+        if (atomicOp.getSem() != tt::MemSemantic::RELAXED)
+          return;
+        if (!atomicOp.getResult().use_empty())
+          return;
+        DecomposedLoad decomp = decomposePointer(atomicOp.getPtr());
+        if (!decomp.valid || !isTMAEligibleStore(atomicOp.getVal(), decomp))
+          return;
+        // Per-atomic host-vs-device decision (same logic as loads/stores).
+        bool needsDevice = useDevice;
+        if (!decomp.scalarBaseOffsets.empty())
+          needsDevice = true;
+        if (needsDevice && !scalarBaseOffsetsHoistable(atomicOp, decomp))
+          return;
+        int rank = decomp.dims.size();
+        if (decomp.dims[rank - 1].strideArgIdx >= 0)
+          return;
+        bool loopAdvanced = false;
+        for (int d = 0; d < rank; d++)
+          if (decomp.dims[d].loopAdvanced)
+            loopAdvanced = true;
+        if (loopAdvanced)
+          return;
+        // static_cast<unsigned>: dodge GCC 13 -Wstringop-overflow false
+        // positive.
+        SmallVector<int> shapeArgs(static_cast<unsigned>(rank), -1);
+        for (int d = 0; d < rank; d++) {
+          const DimInfo &dim = decomp.dims[d];
+          int s = dim.shapeArgIdx;
+          if (s < 0)
+            s = findShapeArgForDim(kernelFunc, atomicOp.getMask(), dim);
+          if (s < 0)
+            s = findShapeArgFromTileBound(kernelFunc, dim);
+          if (s < 0 && d == rank - 1 && dim.strideArgIdx < 0 && rank >= 2 &&
+              decomp.dims[rank - 2].strideArgIdx >= 0) {
+            s = decomp.dims[rank - 2].strideArgIdx;
+            needsDevice = true;
+          }
+          if (s < 0 && !dim.offset && !dim.deferredConstOffset &&
+              !maskHasUnattributedBound(atomicOp.getMask(), decomp)) {
+            s = -2;
+            needsDevice = true;
+          }
+          shapeArgs[d] = s;
+        }
+        bool ok = true;
+        for (int d = 0; d < rank; d++)
+          if (shapeArgs[d] == -1)
+            ok = false;
+        if (!ok)
+          return;
+        int elemBytes = cast<RankedTensorType>(atomicOp.getVal().getType())
+                            .getElementType()
+                            .getIntOrFloatBitWidth() /
+                        8;
+        for (int d = 0; d < rank; d++)
+          if (!dimStrideIs16BAligned(kernelFunc, decomp.dims[d], elemBytes))
+            return;
+        if (!argIs16BAligned(kernelFunc, decomp.basePtrArgIndex, elemBytes))
+          return;
+        if (!storeMaskIsRectangular(atomicOp.getMask(), decomp))
+          return;
+        StorePromotion p;
+        p.op = atomicOp;
+        p.value = atomicOp.getVal();
+        p.isAtomicAdd = true;
         p.decomp = decomp;
         p.shapeArgIndices = shapeArgs;
         p.useDeviceMode = needsDevice;
@@ -1472,12 +1601,17 @@ public:
           Value prod = arith::MulIOp::create(builder, loc, iv, step);
           indices.push_back(arith::TruncIOp::create(builder, loc, i32, prod));
         } else if (!dim.offset) {
-          // Whole-dim (untiled, e.g. FA HEAD_DIM): index is 0. Use the hoisted
-          // zero (deviceMode) so it isn't a constant inside the WS loop.
-          indices.push_back(
-              deviceZeroIdx ? deviceZeroIdx
-                            : arith::ConstantOp::create(
-                                  builder, loc, builder.getI32IntegerAttr(0)));
+          if (dim.deferredConstOffset) {
+            indices.push_back(arith::ConstantOp::create(
+                builder, loc,
+                builder.getI32IntegerAttr(*dim.deferredConstOffset)));
+          } else {
+            indices.push_back(
+                deviceZeroIdx
+                    ? deviceZeroIdx
+                    : arith::ConstantOp::create(builder, loc,
+                                                builder.getI32IntegerAttr(0)));
+          }
         } else {
           indices.push_back(toI32(dim.offset));
         }
@@ -1535,15 +1669,27 @@ public:
     // synthesized host-side descriptor (symmetric to loads; the
     // descriptor_store TTGIR lowering creates the reg->smem staging +
     // async_tma_copy_local_to_global).
+    struct DescCacheEntry {
+      Value basePtr;
+      SmallVector<Value> baseOffsets;
+      SmallVector<int> shapeArgs;
+      SmallVector<int> strideArgs;
+      SmallVector<int64_t> block;
+      Type elemTy;
+      Operation *hoistPt;
+      Value descVal;
+      Value zeroIdx;
+    };
+    SmallVector<DescCacheEntry, 0> descCache;
     for (auto &promo : storePromotions) {
-      tt::StoreOp storeOp = promo.storeOp;
+      Operation *op = promo.op;
       int rank = promo.decomp.dims.size();
-      Value value = storeOp.getValue();
+      Value value = promo.value;
       auto valTy = cast<RankedTensorType>(value.getType());
       Type elemTy = valTy.getElementType();
-      Location loc = storeOp.getLoc();
+      Location loc = op->getLoc();
 
-      builder.setInsertionPoint(storeOp);
+      builder.setInsertionPoint(op);
       Type i32 = builder.getI32Type();
 
       // Descriptor for the store: device-built (deviceMode) or host recipe arg.
@@ -1551,12 +1697,58 @@ public:
       unsigned descArgIdx = 0;
       Value deviceZeroIdx;
       if (promo.useDeviceMode) {
-        SmallVector<int> identity;
-        for (int d = 0; d < rank; d++)
-          identity.push_back(d);
-        descVal =
-            buildDeviceDescriptor(storeOp, promo.decomp, promo.shapeArgIndices,
-                                  identity, loc, deviceZeroIdx);
+        // Dedup descriptors: subtiled slices build an identical descriptor
+        // (same base/shape/stride/block; only the store INDEX differs). Reuse
+        // one shared descriptor SSA so the WS memory planner groups all slices'
+        // staging into a single physical buffer (it keys staging groups by
+        // descriptor value).
+        // LICM hoist point for cache key (must match buildDeviceDescriptor).
+        Operation *hoistPt = op;
+        for (auto forOp = op->getParentOfType<scf::ForOp>(); forOp;
+             forOp = forOp->getParentOfType<scf::ForOp>()) {
+          Region &loopBody = forOp.getRegion();
+          bool allInvariant = true;
+          for (Value off : promo.decomp.scalarBaseOffsets) {
+            if (loopBody.isAncestor(off.getParentRegion())) {
+              allInvariant = false;
+              break;
+            }
+          }
+          if (!allInvariant)
+            break;
+          hoistPt = forOp;
+        }
+        SmallVector<int> shapeArgsK, strideArgsK;
+        SmallVector<int64_t> blockK;
+        for (int d = 0; d < rank; d++) {
+          shapeArgsK.push_back(promo.shapeArgIndices[d]);
+          strideArgsK.push_back(promo.decomp.dims[d].strideArgIdx);
+          blockK.push_back(promo.decomp.dims[d].blockSize);
+        }
+        DescCacheEntry *hit = nullptr;
+        for (auto &e : descCache)
+          if (e.hoistPt == hoistPt && e.basePtr == promo.decomp.basePtr &&
+              e.elemTy == elemTy &&
+              e.baseOffsets == promo.decomp.scalarBaseOffsets &&
+              e.shapeArgs == shapeArgsK && e.strideArgs == strideArgsK &&
+              e.block == blockK) {
+            hit = &e;
+            break;
+          }
+        if (hit) {
+          descVal = hit->descVal;
+          deviceZeroIdx = hit->zeroIdx;
+        } else {
+          SmallVector<int> identity;
+          for (int d = 0; d < rank; d++)
+            identity.push_back(d);
+          descVal =
+              buildDeviceDescriptor(op, promo.decomp, promo.shapeArgIndices,
+                                    identity, loc, deviceZeroIdx);
+          descCache.push_back(
+              {promo.decomp.basePtr, promo.decomp.scalarBaseOffsets, shapeArgsK,
+               strideArgsK, blockK, elemTy, hoistPt, descVal, deviceZeroIdx});
+        }
       } else {
         auto descTy = tt::TensorDescType::get(
             valTy.getShape(), valTy.getElementType(), valTy.getEncoding());
@@ -1590,17 +1782,31 @@ public:
       SmallVector<Value> indices;
       for (int d = 0; d < rank; d++) {
         Value off = promo.decomp.dims[d].offset;
-        if (!off)
-          indices.push_back(
-              deviceZeroIdx ? deviceZeroIdx
-                            : arith::ConstantOp::create(
-                                  builder, loc, builder.getI32IntegerAttr(0)));
-        else
+        if (!off) {
+          if (promo.decomp.dims[d].deferredConstOffset) {
+            indices.push_back(arith::ConstantOp::create(
+                builder, loc,
+                builder.getI32IntegerAttr(
+                    *promo.decomp.dims[d].deferredConstOffset)));
+          } else {
+            indices.push_back(
+                deviceZeroIdx
+                    ? deviceZeroIdx
+                    : arith::ConstantOp::create(builder, loc,
+                                                builder.getI32IntegerAttr(0)));
+          }
+        } else {
           indices.push_back(toI32(off));
+        }
       }
 
-      tt::DescriptorStoreOp::create(builder, loc, descVal, value, indices);
-      storeOp.erase();
+      if (promo.isAtomicAdd)
+        tt::DescriptorReduceOp::create(builder, loc,
+                                       tt::DescriptorReduceKind::ADD, descVal,
+                                       value, indices);
+      else
+        tt::DescriptorStoreOp::create(builder, loc, descVal, value, indices);
+      op->erase();
 
       // Device stores need no launcher recipe.
       if (promo.useDeviceMode)

--- a/third_party/tlx/tutorials/fused_attention_ws_auto_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_auto_tma.py
@@ -628,9 +628,8 @@ _BWD_DOT_ATTRS_SCHED = FrozenDotAttrs({
 # planner reproduces _BWD_DOT_ATTRS_BM64_TMEM's packing ([dpT,dsT],[ppT,qkT])
 # without the hand-pinned buffer ids.
 _BWD_DOT_ATTRS_BM64_MEMTYPE = FrozenDotAttrs({
-    "qkT": {"stage": "0", "order": "0"},
-    "dpT": {"stage": "0", "order": "2"},
-    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem"]},  # ppT -> tmem
+    "qkT": {"stage": "0", "order": "0"}, "dpT": {"stage": "0", "order": "2"}, "dv":
+    {"stage": "0", "order": "2", "channels": ["opndA,tmem"]},  # ppT -> tmem
     "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem"]},  # dsT^T -> smem
     "dk": {"stage": "1", "order": "1", "channels": ["opndA,tmem"]},  # dsT -> tmem
 })
@@ -642,9 +641,8 @@ _BWD_DOT_ATTRS_BM64_MEMTYPE = FrozenDotAttrs({
 # for the memory-planner search-space work (see test_bwd_bm128_memtype_only_xfail
 # and task T279873316).
 _BWD_DOT_ATTRS_BM128_MEMTYPE = FrozenDotAttrs({
-    "qkT": {"stage": "0", "order": "0"},
-    "dpT": {"stage": "0", "order": "2"},
-    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem"]},  # ppT -> tmem
+    "qkT": {"stage": "0", "order": "0"}, "dpT": {"stage": "0", "order": "2"}, "dv":
+    {"stage": "0", "order": "2", "channels": ["opndA,tmem"]},  # ppT -> tmem
     "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem"]},  # dsT^T -> smem
     "dk": {"stage": "1", "order": "1", "channels": ["opndA,tmem"]},  # dsT -> tmem
 })
@@ -654,13 +652,15 @@ _BWD_DOT_ATTRS_BM128_MEMTYPE = FrozenDotAttrs({
 def _attn_bwd_dkdv_inner(
     dk,
     dv,
-    desc_q,
+    Q,
     k,
     v,
-    desc_do,
-    desc_dq,
-    desc_m,
-    desc_delta,
+    DO,
+    DQ,
+    M_ptr,
+    Delta_ptr,
+    y_dim,
+    stride_tok,
     off_bh,
     off_chz,
     curr_m,
@@ -676,10 +676,14 @@ def _attn_bwd_dkdv_inner(
     RESCHED: tl.constexpr,
     BWD_DOT_ATTRS: tl.constexpr = None,
 ):
-    q = desc_q.load([(off_bh + curr_m).to(tl.int32), 0])
+    offs_qm = off_bh + curr_m + tl.arange(0, BLOCK_M1)
+    offs_hd = tl.arange(0, HEAD_DIM)[None, :]
+    bwd_row_mask = offs_qm[:, None] < y_dim
+    q = tl.load(Q + offs_qm[:, None] * stride_tok + offs_hd, mask=bwd_row_mask, other=0.0)
     qT = tl.trans(q)
     offs_m_start = off_chz + curr_m
-    m = desc_m.load([offs_m_start.to(tl.int32)])
+    offs_m1 = offs_m_start + tl.arange(0, BLOCK_M1)
+    m = tl.load(M_ptr + offs_m1, mask=offs_m1 < y_dim, other=0.0)
     if RESCHED:
         qkT = tl.dot(k, qT, attrs=BWD_DOT_ATTRS.get("qkT"))
     else:
@@ -689,16 +693,16 @@ def _attn_bwd_dkdv_inner(
         offs_m = curr_m + tl.arange(0, BLOCK_M1)
         mask = offs_m[None, :] >= offs_n[:, None]
         pT = tl.where(mask, pT, 0.0)
-    do = desc_do.load([(off_bh + curr_m).to(tl.int32), 0])
+    do = tl.load(DO + offs_qm[:, None] * stride_tok + offs_hd, mask=bwd_row_mask, other=0.0)
     ppT = pT
     ppT = ppT.to(dtype)
     if RESCHED:
         dpT = tl.dot(v, tl.trans(do), attrs=BWD_DOT_ATTRS.get("dpT")).to(tl.float32)
-        Di = desc_delta.load([offs_m_start.to(tl.int32)])
+        Di = tl.load(Delta_ptr + offs_m1, mask=offs_m1 < y_dim, other=0.0)
         dv += tl.dot(ppT, do, attrs=BWD_DOT_ATTRS.get("dv"))
     else:
         dv += tl.dot(ppT, do)
-        Di = desc_delta.load([offs_m_start.to(tl.int32)])
+        Di = tl.load(Delta_ptr + offs_m1, mask=offs_m1 < y_dim, other=0.0)
         dpT = tl.dot(v, tl.trans(do)).to(tl.float32)
     dsT = pT * (dpT - Di[None, :])
     dsT = dsT.to(dtype)
@@ -716,7 +720,8 @@ def _attn_bwd_dkdv_inner(
     slice_size: tl.constexpr = HEAD_DIM // DQ_SUBTILE
     for slice_id in tl.static_range(0, DQ_SUBTILE):
         dqN = dqs[slice_id] * LN2
-        desc_dq.atomic_add([(off_bh + curr_m).to(tl.int32), slice_id * slice_size], dqN)
+        offs_dqd = slice_id * slice_size + tl.arange(0, slice_size)
+        tl.atomic_add(DQ + offs_qm[:, None] * stride_tok + offs_dqd[None, :], dqN, mask=bwd_row_mask)
     curr_m += step_m
     return dk, dv, curr_m
 
@@ -725,14 +730,15 @@ def _attn_bwd_dkdv_inner(
 def _attn_bwd_dkdv(
     dk,
     dv,  #
-    desc_q,
+    Q,
     k,
     v,
     sm_scale,  #
-    desc_do,  #
-    desc_dq,
-    desc_m,
-    desc_delta,  #
+    DO,  #
+    DQ,
+    M_ptr,
+    Delta_ptr,  #
+    y_dim,
     # shared by Q/K/V/DO.
     stride_tok,
     stride_d,  #
@@ -776,13 +782,15 @@ def _attn_bwd_dkdv(
             dk, dv, curr_m = _attn_bwd_dkdv_inner(
                 dk,
                 dv,
-                desc_q,
+                Q,
                 k,
                 v,
-                desc_do,
-                desc_dq,
-                desc_m,
-                desc_delta,
+                DO,
+                DQ,
+                M_ptr,
+                Delta_ptr,
+                y_dim,
+                stride_tok,
                 off_bh,
                 off_chz,
                 curr_m,
@@ -803,13 +811,15 @@ def _attn_bwd_dkdv(
             dk, dv, curr_m = _attn_bwd_dkdv_inner(
                 dk,
                 dv,
-                desc_q,
+                Q,
                 k,
                 v,
-                desc_do,
-                desc_dq,
-                desc_m,
-                desc_delta,
+                DO,
+                DQ,
+                M_ptr,
+                Delta_ptr,
+                y_dim,
+                stride_tok,
                 off_bh,
                 off_chz,
                 curr_m,
@@ -830,30 +840,11 @@ def _attn_bwd_dkdv(
 
 
 def _bwd_host_descriptor_pre_hook(nargs):
-    BLOCK_M1 = nargs["BLOCK_M1"]
-    BLOCK_N1 = nargs["BLOCK_N1"]
-    HEAD_DIM = nargs["HEAD_DIM"]
-    EPILOGUE_SUBTILE = nargs["EPILOGUE_SUBTILE"]
-    # DQ_SUBTILE controls dq atomic_add staging only; defaults to
-    # EPILOGUE_SUBTILE so existing configs continue to behave the same.
-    DQ_SUBTILE = nargs.get("DQ_SUBTILE", EPILOGUE_SUBTILE)
-    if not isinstance(nargs["desc_q"], TensorDescriptor):
-        return
-
     # Reset dq accumulator to zeros before each autotuner warmup run.
     # Without this, dq accumulates across autotuner benchmark runs when
     # multiple configs are present (e.g., USE_WARP_BARRIER in [False, True]).
-    nargs["desc_dq"].base.zero_()
-
-    nargs["desc_q"].block_shape = [BLOCK_M1, HEAD_DIM]
-    nargs["desc_do"].block_shape = [BLOCK_M1, HEAD_DIM]
-    nargs["desc_dq"].block_shape = [BLOCK_M1, HEAD_DIM // DQ_SUBTILE]
-    nargs["desc_v"].block_shape = [BLOCK_N1, HEAD_DIM]
-    nargs["desc_k"].block_shape = [BLOCK_N1, HEAD_DIM]
-    nargs["desc_dv"].block_shape = [BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE]
-    nargs["desc_dk"].block_shape = [BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE]
-    nargs["desc_m"].block_shape = [BLOCK_M1]
-    nargs["desc_delta"].block_shape = [BLOCK_M1]
+    if "DQ" in nargs:
+        nargs["DQ"].zero_()
 
 
 configs_bwd = [
@@ -902,7 +893,7 @@ configs_bwd_persist = [
             "BWD_DOT_ATTRS": _DEFAULT_BWD_DOT_ATTRS,
         },
         num_warps=4,
-        num_stages=2,
+        num_stages=1,
         pre_hook=_bwd_host_descriptor_pre_hook,
     ),
     triton.Config(
@@ -994,16 +985,17 @@ configs_bwd_persist = [
 
 @triton.jit
 def _attn_bwd_core(
-    desc_q,
-    desc_k,
-    desc_v,
+    Q,
+    K,
+    V,
     sm_scale,  #
-    desc_do,  #
-    desc_dq,
-    desc_dk,
-    desc_dv,  #
-    desc_m,
-    desc_delta,  #
+    DO,  #
+    DQ,
+    DK,
+    DV,  #
+    M_ptr,
+    Delta_ptr,  #
+    y_dim,
     stride_tok,
     stride_d,  #
     stride_z,
@@ -1024,7 +1016,13 @@ def _attn_bwd_core(
     SMEM_BUDGET: tl.constexpr = 200000,
 ):
     off_chz = (bhid * N_CTX).to(tl.int64)
-    off_bh = ((stride_h * (bhid % H) + stride_z * (bhid // H)).to(tl.int64)) // stride_tok
+    # auto-TMA: plain int32 row index (descriptor tile offsets are i32; an i64
+    # offset blocks the pass's affine decomposition). off_bh = bhid*N_CTX assumes a
+    # CONTIGUOUS [Z, N_HEAD, N_CTX, HEAD_DIM] layout (each (batch,head) packed as
+    # exactly N_CTX rows, row stride == HEAD_DIM). NOT valid for padded-seq /
+    # varlen / strided / transposed batch-head layouts -- backward() asserts
+    # contiguity so those fail loudly instead of reading wrong addresses.
+    off_bh = bhid * N_CTX
 
     dv = tl.zeros([BLOCK_N1, HEAD_DIM], dtype=tl.float32)
     dk = tl.zeros([BLOCK_N1, HEAD_DIM], dtype=tl.float32)
@@ -1032,20 +1030,24 @@ def _attn_bwd_core(
     start_n = pid * BLOCK_N1
     start_m = 0
 
-    k = desc_k.load([(off_bh + start_n).to(tl.int32), 0])
-    v = desc_v.load([(off_bh + start_n).to(tl.int32), 0])
+    offs_kvn = off_bh + start_n + tl.arange(0, BLOCK_N1)
+    offs_hdc = tl.arange(0, HEAD_DIM)[None, :]
+    kv_mask = offs_kvn[:, None] < y_dim
+    k = tl.load(K + offs_kvn[:, None] * stride_tok + offs_hdc, mask=kv_mask, other=0.0)
+    v = tl.load(V + offs_kvn[:, None] * stride_tok + offs_hdc, mask=kv_mask, other=0.0)
     num_steps = (N_CTX - start_m) // BLOCK_M1
     dk, dv = _attn_bwd_dkdv(  #
         dk,
         dv,  #
-        desc_q,
+        Q,
         k,
         v,
         sm_scale,  #
-        desc_do,  #
-        desc_dq,
-        desc_m,
-        desc_delta,  #
+        DO,  #
+        DQ,
+        M_ptr,
+        Delta_ptr,  #
+        y_dim,
         stride_tok,
         stride_d,  #
         off_bh,
@@ -1071,33 +1073,30 @@ def _attn_bwd_core(
     slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
     for slice_id in tl.static_range(0, EPILOGUE_SUBTILE):
         dvN = dvs[slice_id]
-        desc_dv.store(
-            [(off_bh + start_n).to(tl.int32), slice_id * slice_size],
-            dvN.to(dtype),
-        )
+        offs_ev = slice_id * slice_size + tl.arange(0, slice_size)
+        tl.store(DV + offs_kvn[:, None] * stride_tok + offs_ev[None, :], dvN.to(dtype), mask=kv_mask)
 
     dks = _split_n_2D(dk, EPILOGUE_SUBTILE)
     for slice_id in tl.static_range(0, EPILOGUE_SUBTILE):
         dkN = dks[slice_id] * sm_scale
-        desc_dk.store(
-            [(off_bh + start_n).to(tl.int32), slice_id * slice_size],
-            dkN.to(dtype),
-        )
+        offs_ek = slice_id * slice_size + tl.arange(0, slice_size)
+        tl.store(DK + offs_kvn[:, None] * stride_tok + offs_ek[None, :], dkN.to(dtype), mask=kv_mask)
 
 
 @triton.autotune(configs=configs_bwd, key=["N_CTX", "HEAD_DIM"])
 @triton.jit
 def _attn_bwd(
-    desc_q,
-    desc_k,
-    desc_v,
+    Q,
+    K,
+    V,
     sm_scale,  #
-    desc_do,  #
-    desc_dq,
-    desc_dk,
-    desc_dv,  #
-    desc_m,
-    desc_delta,
+    DO,  #
+    DQ,
+    DK,
+    DV,  #
+    M_ptr,
+    Delta_ptr,
+    y_dim,
     # shared by Q/K/V/DO.
     stride_z,
     stride_h,
@@ -1123,16 +1122,17 @@ def _attn_bwd(
     pid = tl.program_id(0)
 
     _attn_bwd_core(
-        desc_q,
-        desc_k,
-        desc_v,
+        Q,
+        K,
+        V,
         sm_scale,
-        desc_do,
-        desc_dq,
-        desc_dk,
-        desc_dv,
-        desc_m,
-        desc_delta,
+        DO,
+        DQ,
+        DK,
+        DV,
+        M_ptr,
+        Delta_ptr,
+        y_dim,
         stride_tok,
         stride_d,
         stride_z,
@@ -1157,16 +1157,17 @@ def _attn_bwd(
 @triton.autotune(configs=configs_bwd_persist, key=["N_CTX", "HEAD_DIM"])
 @triton.jit
 def _attn_bwd_persist(
-    desc_q,
-    desc_k,
-    desc_v,
+    Q,
+    K,
+    V,
     sm_scale,  #
-    desc_do,  #
-    desc_dq,
-    desc_dk,
-    desc_dv,  #
-    desc_m,
-    desc_delta,
+    DO,  #
+    DQ,
+    DK,
+    DV,  #
+    M_ptr,
+    Delta_ptr,
+    y_dim,
     # shared by Q/K/V/DO.
     stride_z,
     stride_h,
@@ -1199,62 +1200,6 @@ def _attn_bwd_persist(
 
     tile_idx = prog_id
 
-    y_dim = BATCH * H * N_CTX
-    desc_q = _maybe_make_tensor_desc(
-        desc_q,
-        shape=[y_dim, HEAD_DIM],
-        strides=[HEAD_DIM, 1],
-        block_shape=[BLOCK_M1, HEAD_DIM],
-    )
-    desc_do = _maybe_make_tensor_desc(
-        desc_do,
-        shape=[y_dim, HEAD_DIM],
-        strides=[HEAD_DIM, 1],
-        block_shape=[BLOCK_M1, HEAD_DIM],
-    )
-    desc_dq = _maybe_make_tensor_desc(
-        desc_dq,
-        shape=[y_dim, HEAD_DIM],
-        strides=[HEAD_DIM, 1],
-        block_shape=[BLOCK_M1, HEAD_DIM // DQ_SUBTILE],
-    )
-    desc_v = _maybe_make_tensor_desc(
-        desc_v,
-        shape=[y_dim, HEAD_DIM],
-        strides=[HEAD_DIM, 1],
-        block_shape=[BLOCK_N1, HEAD_DIM],
-    )
-    desc_k = _maybe_make_tensor_desc(
-        desc_k,
-        shape=[y_dim, HEAD_DIM],
-        strides=[HEAD_DIM, 1],
-        block_shape=[BLOCK_N1, HEAD_DIM],
-    )
-    desc_dv = _maybe_make_tensor_desc(
-        desc_dv,
-        shape=[y_dim, HEAD_DIM],
-        strides=[HEAD_DIM, 1],
-        block_shape=[BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE],
-    )
-    desc_dk = _maybe_make_tensor_desc(
-        desc_dk,
-        shape=[y_dim, HEAD_DIM],
-        strides=[HEAD_DIM, 1],
-        block_shape=[BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE],
-    )
-    desc_m = _maybe_make_tensor_desc(
-        desc_m,
-        shape=[y_dim],
-        strides=[1],
-        block_shape=[BLOCK_M1],
-    )
-    desc_delta = _maybe_make_tensor_desc(
-        desc_delta,
-        shape=[y_dim],
-        strides=[1],
-        block_shape=[BLOCK_M1],
-    )
-
     for _ in tl.range(
             0,
             tiles_per_sm,
@@ -1267,16 +1212,17 @@ def _attn_bwd_persist(
         pid = tile_idx % n_tile_num
         bhid = tile_idx // n_tile_num
         _attn_bwd_core(
-            desc_q,
-            desc_k,
-            desc_v,
+            Q,
+            K,
+            V,
             sm_scale,
-            desc_do,
-            desc_dq,
-            desc_dk,
-            desc_dv,
-            desc_m,
-            desc_delta,
+            DO,
+            DQ,
+            DK,
+            DV,
+            M_ptr,
+            Delta_ptr,
+            y_dim,
             stride_tok,
             stride_d,
             stride_z,
@@ -1414,12 +1360,20 @@ class _attention_opt(torch.autograd.Function):
     @staticmethod
     def backward(ctx, do):
         q, k, v, o, M = ctx.saved_tensors
+        # auto-TMA backward addresses rows as off_bh = bhid * N_CTX (see the
+        # _attn_bwd_* kernels), which is only correct for a contiguous
+        # [Z, N_HEAD, N_CTX, HEAD_DIM] layout with each (batch,head) packed as
+        # exactly N_CTX rows. Enforce contiguity so a strided / padded / varlen
+        # input fails loudly here instead of silently reading wrong addresses.
         assert do.is_contiguous()
+        assert q.is_contiguous() and k.is_contiguous() and v.is_contiguous() and o.is_contiguous()
         assert q.stride() == k.stride() == v.stride() == o.stride() == do.stride()
         dq = torch.zeros(q.shape, device=q.device, dtype=torch.float32)
         dk = torch.empty_like(k)
         dv = torch.empty_like(v)
         BATCH, N_HEAD, N_CTX = q.shape[:3]
+        assert BATCH * N_HEAD * N_CTX <= 2**31 - 1, (f"off_bh = bhid * N_CTX is computed as i32; "
+                                                     f"BATCH*N_HEAD*N_CTX={BATCH * N_HEAD * N_CTX} overflows int32")
         PRE_BLOCK = 128
         BLK_SLICE_FACTOR = 2
         RCP_LN2 = 1.4426950408889634  # = 1.0 / ln(2)
@@ -1436,9 +1390,6 @@ class _attention_opt(torch.autograd.Function):
         )
         warp_specialize = True
 
-        dummy_block = [1, 1]
-        HEAD_DIM = ctx.HEAD_DIM
-
         def alloc_fn(size: int, align: int, _):
             return torch.empty(size, dtype=torch.int8, device="cuda")
 
@@ -1452,61 +1403,15 @@ class _attention_opt(torch.autograd.Function):
         # the dv/dk TMA-staging buffers (aliasing the v/do operand SMEM) race
         # the next tile's operand load. See test_bwd_tmem_dsT_reuse_3group and
         # test_bwd_tmem_dsT_reuse_3group_persistent.
-        desc_k = TensorDescriptor(
-            arg_k,
-            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
-            strides=[HEAD_DIM, 1],
-            block_shape=dummy_block,
-        )
-        desc_v = TensorDescriptor(
-            v,
-            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
-            strides=[HEAD_DIM, 1],
-            block_shape=dummy_block,
-        )
-        desc_q = TensorDescriptor(
-            q,
-            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
-            strides=[HEAD_DIM, 1],
-            block_shape=dummy_block,
-        )
-        desc_do = TensorDescriptor(
-            do,
-            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
-            strides=[HEAD_DIM, 1],
-            block_shape=dummy_block,
-        )
-        desc_dq = TensorDescriptor(
-            dq,
-            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
-            strides=[HEAD_DIM, 1],
-            block_shape=dummy_block,
-        )
-        desc_dk = TensorDescriptor(
-            dk,
-            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
-            strides=[HEAD_DIM, 1],
-            block_shape=dummy_block,
-        )
-        desc_dv = TensorDescriptor(
-            dv,
-            shape=[BATCH * N_HEAD * N_CTX, HEAD_DIM],
-            strides=[HEAD_DIM, 1],
-            block_shape=dummy_block,
-        )
-        dummy_block_1d = [1]
-        desc_m = TensorDescriptor(
-            M,
-            shape=[BATCH * N_HEAD * N_CTX],
-            strides=[1],
-            block_shape=dummy_block_1d,
-        )
-        desc_delta = TensorDescriptor(
-            delta,
-            shape=[BATCH * N_HEAD * N_CTX],
-            strides=[1],
-            block_shape=dummy_block_1d,
-        )
+        desc_k = arg_k
+        desc_v = v
+        desc_q = q
+        desc_do = do
+        desc_dq = dq
+        desc_dk = dk
+        desc_dv = dv
+        desc_m = M
+        desc_delta = delta
 
         def grid(meta):
             return (
@@ -1532,6 +1437,8 @@ class _attention_opt(torch.autograd.Function):
             triton.knobs.nvidia.use_meta_ws = True
             triton.knobs.nvidia.use_meta_partition = True
             triton.knobs.nvidia.disable_wsbarrier_reorder = True
+            triton.knobs.nvidia.auto_tma = True
+            triton.knobs.nvidia.auto_tma_device = True
             if ctx.persistent:
                 _attn_bwd_persist[grid_persist_bwd](
                     desc_q,
@@ -1544,6 +1451,7 @@ class _attention_opt(torch.autograd.Function):
                     desc_dv,  #
                     desc_m,
                     desc_delta,  #
+                    BATCH * N_HEAD * N_CTX,
                     q.stride(0),
                     q.stride(1),
                     q.stride(2),
@@ -1569,6 +1477,7 @@ class _attention_opt(torch.autograd.Function):
                     desc_dv,  #
                     desc_m,
                     desc_delta,  #
+                    BATCH * N_HEAD * N_CTX,
                     q.stride(0),
                     q.stride(1),
                     q.stride(2),
@@ -1852,9 +1761,18 @@ def test_bwd_tmem_plan_pick_enumeration():
             # run fresh here rather than hit a cached kernel from the parametrized
             # sweep above.
             test_op(
-                Z=4, H=8, N_CTX=512, HEAD_DIM=64, causal=False, mode="bwd",
-                baseVariant="ws", provider="triton-fp16", SUBTILING=False,
-                VECT_MUL=0, FADD2_REDUCE=False, bwd_config_idx=idx,
+                Z=4,
+                H=8,
+                N_CTX=512,
+                HEAD_DIM=64,
+                causal=False,
+                mode="bwd",
+                baseVariant="ws",
+                provider="triton-fp16",
+                SUBTILING=False,
+                VECT_MUL=0,
+                FADD2_REDUCE=False,
+                bwd_config_idx=idx,
             )
             tmem_plans = 0
             if os.path.exists(dump):
@@ -1877,21 +1795,31 @@ def test_bwd_memtype_only_annotation():
                if c.kwargs.get("BWD_DOT_ATTRS") is _BWD_DOT_ATTRS_BM64_MEMTYPE)
     for hd in (64, 128):
         test_op(
-            Z=8, H=16, N_CTX=1024, HEAD_DIM=hd, causal=False, mode="bwd",
-            baseVariant="ws", provider="triton-fp16", SUBTILING=False,
-            VECT_MUL=0, FADD2_REDUCE=False, bwd_config_idx=idx,
+            Z=8,
+            H=16,
+            N_CTX=1024,
+            HEAD_DIM=hd,
+            causal=False,
+            mode="bwd",
+            baseVariant="ws",
+            provider="triton-fp16",
+            SUBTILING=False,
+            VECT_MUL=0,
+            FADD2_REDUCE=False,
+            bwd_config_idx=idx,
         )
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
-@pytest.mark.xfail(strict=False, reason="Memory-planner search-space gap (T279873316): "
-                   "BM128 memtype-only promotes dsT to TMEM, but the planner cannot form "
-                   "the tight {dpT,dq,dsT} reuse group that hand _BWD_DOT_ATTRS_TMEM pins, "
-                   "so it OOBs TMEM. dq (accumulator) and the tmem dsT (dk operand) relate "
-                   "only through a common ancestor, which the planner's data-dependency "
-                   "reuse check rejects; a naive same-partition relaxation is unsafe (op-id "
-                   "liveness underestimates qkT's lifetime via pT). Expected to pass once "
-                   "the planner learns to form the group safely.")
+@pytest.mark.xfail(
+    strict=False, reason="Memory-planner search-space gap (T279873316): "
+    "BM128 memtype-only promotes dsT to TMEM, but the planner cannot form "
+    "the tight {dpT,dq,dsT} reuse group that hand _BWD_DOT_ATTRS_TMEM pins, "
+    "so it OOBs TMEM. dq (accumulator) and the tmem dsT (dk operand) relate "
+    "only through a common ancestor, which the planner's data-dependency "
+    "reuse check rejects; a naive same-partition relaxation is unsafe (op-id "
+    "liveness underestimates qkT's lifetime via pT). Expected to pass once "
+    "the planner learns to form the group safely.")
 def test_bwd_bm128_memtype_only_xfail():
     # Motivating case kept for the memory-planner search-space work. Builds a
     # BM128 memtype-only config (opndA,tmem on dv/dk, opndA,smem on dq — no
@@ -1899,17 +1827,30 @@ def test_bwd_bm128_memtype_only_xfail():
     # transiently so it is not swept by the parametrized test_op matrix.
     cfg = triton.Config(
         {
-            "BLOCK_M1": 128, "BLOCK_N1": 128, "BLOCK_M2": 128, "BLOCK_N2": 128,
-            "EPILOGUE_SUBTILE": 2, "DQ_SUBTILE": 4, "SMEM_BUDGET": 220000,
+            "BLOCK_M1": 128,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 2,
+            "DQ_SUBTILE": 4,
+            "SMEM_BUDGET": 220000,
             "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_BM128_MEMTYPE,
-        },
-        num_warps=4, num_stages=2, pre_hook=_bwd_host_descriptor_pre_hook)
+        }, num_warps=4, num_stages=2, pre_hook=_bwd_host_descriptor_pre_hook)
     configs_bwd_persist.append(cfg)
     try:
         test_op(
-            Z=8, H=16, N_CTX=1024, HEAD_DIM=128, causal=False, mode="bwd",
-            baseVariant="ws", provider="triton-fp16", SUBTILING=False,
-            VECT_MUL=0, FADD2_REDUCE=False, bwd_config_idx=len(configs_bwd_persist) - 1,
+            Z=8,
+            H=16,
+            N_CTX=1024,
+            HEAD_DIM=128,
+            causal=False,
+            mode="bwd",
+            baseVariant="ws",
+            provider="triton-fp16",
+            SUBTILING=False,
+            VECT_MUL=0,
+            FADD2_REDUCE=False,
+            bwd_config_idx=len(configs_bwd_persist) - 1,
         )
     finally:
         configs_bwd_persist.pop()


### PR DESCRIPTION
Summary:

## TL;DR
This diff makes the Flash-Attention (FA) *backward* kernel compile from plain
`tl.load / tl.store / tl.atomic_add` source (ordinary pointer arithmetic) down to
hardware TMA copies inside a warp-specialized schedule, with **no hand-written
descriptors in the kernel**. Result: the backward reaches ~633 TFLOP/s (SUBTILE=4,
HEAD_DIM=128, B200), on par with the hand-written device-TMA + meta-warp-spec
backward, and is numerically correct. The FA *forward* already did this; this diff
extends the same "auto-TMA" capability to the backward, and adds the three compiler
pieces that were missing to make it work.

--------------------------------------------------------------------------------
## Background (for readers new to TMA / TLX / warp specialization)

Terms, briefly:
- **TMA (Tensor Memory Accelerator)**: a hardware unit on Hopper/Blackwell that
  does bulk async copies between global memory (HBM) and shared memory (SMEM). It
  is driven by a small on-device "tensor descriptor" (a CUtensorMap: base pointer,
  global shape, strides, and a per-copy block/box shape). Using TMA is how you get
  peak memory throughput; the alternative (`cp.async` / plain vectorized loads) is
  slower and burns more registers.
- **TLX**: a Triton dialect/DSL for writing low-level GPU kernels. FA kernels here
  are written in TLX-flavored Triton.
- **Warp specialization (WS / autoWS)**: instead of every warp doing the same
  work, the compiler splits warps into roles (a "load" warp group that issues TMA
  copies, "MMA" warp groups that do tensor-core math, an "epilogue" group that
  stores results), synchronized by mbarriers. This overlaps memory and compute and
  is required to hit peak on Blackwell. The compiler pass that does this is the
  WS partitioner (`WSMemoryPlanner` / `WSCodePartition`).
- **Two ways to use TMA in a kernel**:
  1. HAND-WRITTEN: the kernel author explicitly builds a descriptor
     (`tl.make_tensor_descriptor(...)`) and calls `desc.load / desc.store /
     desc.atomic_add`. This is what `fused_attention_ws_device_tma.py` does. It's
     fast but verbose and couples the kernel to TMA.
  2. AUTO-TMA (this line of work): the kernel author writes ORDINARY pointer code
     — `tl.load(X + row*stride + col, mask=...)` — and a compiler pass rewrites the
     eligible loads/stores/atomics into TMA descriptor ops automatically. The pass
     is `PromoteLoadToTMA.cpp` (TTIR-level, sm_90+), gated by the `auto_tma` /
     `auto_tma_device` knobs. This keeps kernels simple and portable.

How auto-TMA promotion works (the pass, high level):
- It runs on each load/store/atomic and calls `decomposePointer()` to parse the
  pointer expression `base + Σ (per-dim tile-offset * stride) + contiguous-arange`
  into a per-dim description (base pointer arg, per-dim stride arg, per-dim tile
  offset, block size) plus the tensor's global extent per dim (recovered from the
  op's mask, e.g. `offs < N`).
- If a load/store is "TMA-eligible" (block-structured, one contiguous dim, TMA
  dtype, 16B-aligned, extent recoverable, etc.), the pass emits a
  `make_tensor_descriptor` + `descriptor_load` / `descriptor_store`
  (or `descriptor_reduce` for an add-atomic). The later TTGIR lowering turns those
  into real async TMA copies inside the WS schedule.

Flash-Attention shapes, for context:
- FORWARD reads Q,K,V tiles, does softmax(QK^T)·V, writes O. Every load/store is a
  full `[BLOCK, HEAD_DIM]` tile. Auto-TMA already worked here.
- BACKWARD is bigger: it reads Q,K,V,dO plus per-row scalars m and delta, and
  produces dQ, dK, dV. Two extra wrinkles make the backward harder to auto-promote
  (all three fixed by this diff):
  1. **dQ is accumulated with an atomic add** (`desc.atomic_add` in the hand
     version) because multiple K-tiles contribute to the same dQ rows.
  2. **The epilogue is "sub-tiled"** for SMEM/perf: dK/dV/dQ of shape
     `[BLOCK, HEAD_DIM]` are written as `SUBTILE` column slices
     `[BLOCK, HEAD_DIM/SUBTILE]` at column offset `slice*size`, in a `static_range`
     loop. This keeps the TMA staging buffer small.

--------------------------------------------------------------------------------
## What this diff changes

Two files:

1. `third_party/tlx/tutorials/fused_attention_ws_auto_tma.py` (the kernel)
   - Converts the ENTIRE backward (`_attn_bwd_dkdv_inner`, `_attn_bwd_dkdv`,
     `_attn_bwd_core`, `_attn_bwd`, `_attn_bwd_persist`, `backward()`) from
     hand-written `desc.load / desc.store / desc.atomic_add` to plain
     `tl.load / tl.store / tl.atomic_add` on raw pointers.
   - Threads the raw tensors + `y_dim` (= BATCH*N_HEAD*N_CTX, the row extent, passed
     as a kernel ARG) + `stride_tok` through the call chain, and turns the
     backward's knob scope on (`auto_tma`, `auto_tma_device`).
   - Uses a clean row index `off_bh = bhid * N_CTX` (see Fix A).

2. `lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLoadToTMA.cpp` (the pass)
   - The three compiler fixes below (A already partly here from the atomic work;
     B and C are the new enabling pieces).

--------------------------------------------------------------------------------
## The problems, and the fix + code path for each

Enabling the backward required fixing three distinct blockers. Each was found by
dumping IR (`TRITON_KERNEL_DUMP=1`) and checking whether the ops promoted.

### Blocker A — nothing in the backward promoted at all
- SYMPTOM: after converting to plain pointers, the backward TTIR had
  `descriptor_load=0` — the pass promoted nothing (the forward promoted fine).
- ROOT CAUSE: the backward computed its (batch,head) row base as
  `off_bh = (stride_h*(bhid%H) + stride_z*(bhid//H)).to(int64) // stride_tok`.
  Two problems for `decomposePointer`'s affine analysis: (1) it divides by
  `stride_tok` and then the pointer multiplies by `stride_tok` again
  (`(X // stride_tok) * stride_tok`), which is not affine; (2) it is int64, but TMA
  descriptor tile offsets are i32 — the i64 offset blocked decomposition.
- FIX (kernel): `off_bh = bhid * N_CTX` — the same row index, but a clean i32 affine
  expression (valid for the contiguous `[Z*H*N_CTX, HEAD_DIM]` layout). Also thread
  `y_dim` as a kernel ARG so the pass can recover the row extent from the mask
  (`offs_qm < y_dim`), and promote the `dq` add-atomic to `descriptor_reduce`
  (the ADD-kind TMA reducing store; requires the atomic result be unused).
- AFTER: loads/stores/atomic all promote (`descriptor_load`, `descriptor_reduce`
  appear). This alone gives a correct, ~parity backward at SUBTILE=1.

### Blocker B — the sub-tiled epilogue (SUBTILE>1) would not promote, and OOM'd
This is the main compiler work in this diff, in `PromoteLoadToTMA.cpp`.

B1. Sub-tile column offset not recognized.
- SYMPTOM: with SUBTILE=4, the sub-tiled dK/dV stores + dQ atomics stayed as plain
  ops (`store_tma=2` — only slice 0 — with `atomic_rmw` left over).
- ROOT CAUSE: each slice's column index is `slice*size + arange`. The constant
  `slice*size` is emitted by the frontend as a **dense splat constant**
  (`arith.constant dense<C>`), but `matchSplat()` — used by `match1DOffset()` to
  parse `make_range + offset` — only recognized `tt.splat`, not dense constants.
  So `decomposePointer` failed (`valid=false`) on slices 1..N-1 and they were
  rejected before any eligibility check. (Slice 0's `0+arange` folds to a bare
  `make_range`, which matched — hence only slice 0 promoted.)
- FIX: in `match1DOffset()`'s `make_range + X` case, if `X` is a compile-time
  uniform int constant (via the existing `matchUniformIntConst`, which handles
  dense splats), materialize a scalar i32 constant (at function entry, so it
  dominates the loop-hoisted descriptor) and use it as the dim's tile offset.

B2. All slices must share ONE descriptor so the WS planner can reuse one staging
    buffer (else SMEM blows up → OOM at 329 KB > 232 KB limit).
- ROOT CAUSE: a sub-tiled store's parent column extent is HEAD_DIM, but that isn't
  visible from a single slice (and a `< HEAD_DIM` mask constant-folds away). The
  first attempt (fold the constant column offset into the base pointer) made each
  slice a *different* descriptor (base = X + slice*size), so the WS memory planner —
  which groups TMA staging buffers by the descriptor SSA value
  (`fuseEpilogueWSBuffers` in `WSMemoryPlanner.cpp`, key = {descriptor, orig-load})
  — gave every slice its own staging buffer. No reuse → OOM.
- FIX (two parts in the pass):
  * `decomposePointer`: for a contiguous row-major tensor, the innermost extent
    equals the next-outer dim's stride (HEAD_DIM == stride_tok). So set the
    contiguous dim's shape source to the OUTER dim's stride arg. This is correct for
    a full-dim tile too (block == extent == outer stride), and — crucially — makes
    EVERY slice (including slice 0) build the SAME descriptor: same base, same
    extent, same block; only the store INDEX differs.
  * Phase 2b (store/atomic device build): add a descriptor dedup cache keyed by
    (base, base-offsets, shape args, stride args, block, elem type, hoist point).
    Identical descriptors reuse one `make_tensor_descriptor` SSA value.
- AFTER: all sub-tile slices share one descriptor. The WS planner then groups their
  staging into ONE physical buffer per tensor (dV/dK: 4→1, dQ reduce: 4→1),
  dropping SMEM from 329 KB to ~231 KB (fits). Promotion: `store_tma=8,
  descriptor_reduce, atomic_rmw=0`.

### Blocker C — num_stages=2 failed to compile
- SYMPTOM (earlier state): `'ttg.local_alloc' op pipeliner doesn't know how to
  predicate this op` when num_stages=2.
- RESOLUTION: fixed incidentally by Blocker B. Once every subtile shares one
  descriptor and its staging is hoisted out of the loop (loop-invariant), the SW
  pipeliner no longer needs to predicate a per-iteration staging `local_alloc`, so
  num_stages=2 compiles and is numerically correct. (Best perf here is still ns=1,
  so the shipped config uses SUBTILE=4/ns=1; ns=2 is no longer a hard blocker.)

--------------------------------------------------------------------------------
## Before / After

Backward kernel source:
- BEFORE: `desc_q = tl.make_tensor_descriptor(...); q = desc_q.load([...]);
           ... desc_dq.atomic_add(dq, [...])` — hand-written descriptors everywhere.
- AFTER:  `q = tl.load(Q + offs_qm[:,None]*stride_tok + offs_hd, mask=...);
           ... tl.atomic_add(DQ + ..., dqN, mask=...)` — plain pointers; the
           compiler emits the TMA descriptors.

Compiled backward (TTGIR), SUBTILE=4, HEAD_DIM=128:
- BEFORE (plain, unpromoted): `async_tma_copy*=0`, plain global loads + a plain
  global `atomic_rmw` for dQ → ~26–31 TFLOP/s.
- AFTER (auto-promoted): `async_tma_copy_global_to_local=4` (Q,K,V,dO),
  `async_tma_copy_local_to_global=8` (dK,dV subtiles), `descriptor_reduce` for dQ,
  `atomic_rmw=0`; staging buffers merged (dV/dK/dQ 4→1 each), SMEM fits →
  ~633 TFLOP/s.

--------------------------------------------------------------------------------
## Files changed
- `third_party/tlx/tutorials/fused_attention_ws_auto_tma.py`
  Backward rewritten to plain pointers; `off_bh = bhid*N_CTX`; `y_dim` threaded as
  an arg; `auto_tma`/`auto_tma_device` enabled in `backward()`; bwd config
  SUBTILE=4/ns=1.
- `lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLoadToTMA.cpp`
  (A) atomic-add → `descriptor_reduce` promotion; (B1) `match1DOffset` accepts a
  dense-splat constant column offset; (B2) contiguous extent = outer-dim stride +
  descriptor dedup cache in Phase 2b.

Differential Revision: D112228887


