### PR TITLE
[TLX GEMM] Fix split-K reduce kernel falling onto the slow launch path (drop redundant num_warps) (#2056)

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -1079,6 +1079,10 @@ def reduce_post_hook(nargs, exception=None):
         workspace = nargs["workspace_desc"].base
         c = nargs["c_desc"].base
         reduce_grid = (triton.cdiv(M, 32), triton.cdiv(N, 32))
+        # num_warps=4 is the default; passing it as a meta-kwarg forces the C
+        # dispatch proxy to fall back to the slow launch path (specialize.cc
+        # bails on non-param kwargs). Param kwargs below are merged in C and stay
+        # fast, so keep them but drop the redundant num_warps.
         _reduce_k_kernel[reduce_grid](
             workspace,
             c,
@@ -1088,7 +1092,6 @@ def reduce_post_hook(nargs, exception=None):
             BLOCK_SIZE_M=32,
             BLOCK_SIZE_N=32,
             OUTPUT_DTYPE=TORCH_DTYPE_TO_TRITON[workspace.dtype],
-            num_warps=4,
         )
 
 
@@ -1472,6 +1475,8 @@ def matmul(a, b, config=None):
         # Run separate reduction kernel for split-K
         if split_k > 1:
             reduce_grid = (triton.cdiv(M, 32), triton.cdiv(N, 32))
+            # num_warps=4 is the default; dropping it keeps the C dispatch proxy
+            # fast path (see reduce_post_hook).
             _reduce_k_kernel[reduce_grid](
                 workspace_desc.base,
                 c,
@@ -1481,7 +1486,6 @@ def matmul(a, b, config=None):
                 BLOCK_SIZE_M=32,
                 BLOCK_SIZE_N=32,
                 OUTPUT_DTYPE=TORCH_DTYPE_TO_TRITON[a.dtype],
-                num_warps=4,
             )
     else:
         # Pass c as dummy workspace_desc. Pre_hook dynamically allocates
@@ -1517,6 +1521,8 @@ def matmul(a, b, config=None):
         if split_k > 1:
             workspace = workspace_desc.base
             reduce_grid = (triton.cdiv(M, 32), triton.cdiv(N, 32))
+            # num_warps=4 is the default; dropping it keeps the C dispatch proxy
+            # fast path (see reduce_post_hook).
             _reduce_k_kernel[reduce_grid](
                 workspace,
                 c,
@@ -1526,6 +1532,5 @@ def matmul(a, b, config=None):
                 BLOCK_SIZE_M=32,
                 BLOCK_SIZE_N=32,
                 OUTPUT_DTYPE=TORCH_DTYPE_TO_TRITON[a.dtype],
-                num_warps=4,
             )
     return c


### PR DESCRIPTION
Summary:

The split-K reduction kernel `_reduce_k_kernel` in the Blackwell TLX WS GEMM was
taking the slow Python launch path on EVERY call, even with the C dispatcher / C
cache fully enabled. Root cause: it is launched with a `num_warps=4` meta-kwarg, and
the C fast-dispatch proxy bails to the slow path on any non-kernel-param kwarg.
`num_warps=4` is already the default, so dropping it lets the reduce kernel use the C
dispatch fast path. Behavior is unchanged (num_warps stays 4; accuracy verified).

This diff also fixes a flag-name typo in the eval docs (see below).

### Background
Follow-up to the GB200 cudagraph sweep (D112060938 / cuda_graph/ROLLUP.md), which
showed a large do_bench-vs-cudagraph gap for TLX WS GEMM and blamed Python launch/
wrapper overhead. Reproducing on GB200 we found the gap has THREE distinct causes,
only one of which is a real, fixable launch bug (the code change here):

  1. Doc/flag bug: ROLLUP.md and NVGPU_GEMM_Evaluation/README.md set
     `TRITON_USE_TRITON_DISPATCHER=1`, which is not a real env var -- knobs.py reads
     `TRITON_USE_C_DISPATCHER`. So the sweep ran with the C dispatcher silently OFF and
     TRITON_AUTOTUNE_USE_C_CACHE unset. Using the correct flags recovers most of the
     gap on its own (shard12 window: do_bench geomean 0.869 -> 0.977 vs cudagraph
     1.013). Fixed in the docs in this diff.

  2. split-K reduce kernel on the slow launch path -- the code fix here.

  3. Wide-N family (1152x12800x*, *x12800x*): remaining gap is a large per-call output
     `torch.empty((M,N))` (~29 MB for 1152x12800 bf16) plus a genuine wide-N kernel gap
     (cudagraph itself only 0.80-0.94). Not a launch-dispatch issue (C dispatch already
     ~100% HIT for these); not addressed here.

### Root cause (cause #2)
Per-kernel launch accounting (TRITON_CCACHE_DIAG=1) on 192x448x147456 do_bench:

    matmul_kernel_tma_ws_blackwell::HIT_c_launch  = 461,779   (main kernel: fast)
    matmul_kernel_tma_ws_blackwell::SLOW_c_launch =     254   (warmup only)
    _reduce_k_kernel::SLOW_c_launch               = 487,503   (100% slow, every call)

The main kernel goes through the autotuner, which merges kwargs->positional before
calling the C proxy, so it is fully fast-dispatched. `_reduce_k_kernel` is a bare
kernel launched directly with kwargs. The C JIT proxy
(specialize.cc JITCacheProxy_vectorcall, ~L1541-1568) already merges KERNEL-PARAM
kwargs into positional in C and stays fast; it only bails to the Python run() slow path
on NON-param (meta) kwargs like num_warps, because their options-hash is a Python
hash() that cannot be cheaply reproduced in C. The single `num_warps=4` is what forces
the reduce kernel onto the slow path.

### The fix
Drop the explicit `num_warps=4` from the three `_reduce_k_kernel[...]` call sites
(reduce_post_hook + the two matmul() launch paths). num_warps=4 is the Triton default,
so the compiled reduce kernel is identical, but with no meta-kwarg the C proxy's in-C
param-kwarg merge engages and the reduce kernel takes the fast dispatch path. Readable
kernel-param kwargs (SPLIT_K=, BLOCK_SIZE_*, OUTPUT_DTYPE=) are kept.

### Alternatives considered / tradeoffs
- Drop num_warps only, keep param-kwargs (CHOSEN): 0.615 -> 0.715, zero compiler risk,
  keeps readable kwargs, compiled config unchanged. Does not reach the fully-positional
  number because the C-side param-kwarg merge has a small per-call cost.
- Rewrite the reduce call fully positional: 0.615 -> 0.781 (best perf), but unreadable
  and implies a stronger "positional-only" convention than is actually required (the
  real constraint is only "no meta-kwargs").
- Compiler fix in jit.py __getitem__ (Python wrapper merging kwargs->positional +
  per-meta proxy): makes the ORIGINAL num_warps writing work and is correct, but only
  reaches 0.682 (per-call Python merge cost) and adds a Python frame to the hot
  positional path every autotuned kernel uses. Rejected.
- Zero-overhead general fix in C (specialize.cc: accept meta-kwargs matching the proxy's
  baked options): the right long-term fix, but blocked by the Python-hash-in-C problem +
  needs default-value awareness; larger C++ change + libtriton rebuild. Deferred as a
  follow-up.

### Experimental results (GB200 devgpu, isolated single shape, corrected flags,
denoise.sh, --rep 3000 --sleep 1.0, accuracy=1 for all)

192x448x147456 (split-K, launch-bound), do_bench tlx/cuBLAS:

    variant                                    speedup   reduce dispatch
    original (param-kwargs + num_warps=4)       0.615    100% SLOW (487,503)
    drop num_warps (THIS diff)                  0.715    C proxy HIT (SLOW=5)
    fully positional                            0.781    raw proxy HIT
    jit.py wrapper: kwargs -> run()             0.647    run() HIT
    jit.py wrapper: merge -> per-meta proxy     0.682    C meta-proxy HIT
    cudagraph ceiling                           0.990    (n/a)

The 5 "bad perf" shapes (isolated, corrected flags), do_bench vs cudagraph:

    shape             do_bench   cudagraph   note
    1152x12800x1024     0.514      0.804     wide-N: cause #3 (alloc + kernel gap)
    1024x12800x1152     0.550      0.938     wide-N: cause #3
    12800x1024x1152     0.507      0.872     wide-N: cause #3
    192x448x147456      0.615      0.990     split-K: cause #2 (THIS diff)
    147456x448x192      0.973      1.046     already fine (no split-K)

Reviewed By: wlei-llvm

Differential Revision: D112229431


