### PR TITLE
[sched2tlx] Add perf_harness compare subcommand + harness usage skill

### DIFF
--- a/.claude/skills/sched2tlx-perf-testing/SKILL.md
+++ b/.claude/skills/sched2tlx-perf-testing/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: sched2tlx-perf-testing
+description: >
+  Run the sched2tlx perf/correctness harness over the modulo-scheduling
+  example corpus (case1-8: GEMM, persistent GEMM, FA fwd/bwd, addmm+bias,
+  LayerNorm, wgrad+bias, multiphase GEMM). Use when the user asks to
+  benchmark generated-vs-handwritten kernels, check corpus correctness,
+  compare emitter revisions, or regenerate schedule_graph.json fixtures.
+  Never run perf unless explicitly asked.
+disable-model-invocation: true
+---
+
+# sched2tlx Perf & Correctness Harness
+
+**Never run performance tests unless the user explicitly asks.**
+
+Harness: `third_party/tlx/tools/sched2tlx/examples/testing/perf_regression/perf_harness.py`
+Corpus: `third_party/tlx/tools/sched2tlx/examples/case*/`
+
+## Environment (this cluster — critical)
+
+The login shell's lmod modules break both build and runtime. Prefix EVERY
+python/triton-opt invocation with `env -u LD_LIBRARY_PATH` and use the repo
+venv python (`$REPO/.venv/bin/python`). Ignore the lua/posix noise every
+command prints. C++ changes require rebuild first:
+`env -u LD_LIBRARY_PATH PATH="$REPO/.venv/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin" VIRTUAL_ENV=$REPO/.venv CC=/usr/bin/gcc CXX=/usr/bin/g++ MAX_JOBS=14 uv pip install -e . --no-build-isolation`
+
+## Subcommands
+
+Run from `examples/testing/perf_regression/`:
+
+- **bench** — committed `generated.py` vs `handwritten.py`, per-case table
+  (`shape | gen | hw | gen/hw | rel | ok`; correctness is checked before
+  timing). Auto-discovers cases with a `bench_spec.py`
+  (currently case1,2,3,5,6,7):
+  `env -u LD_LIBRARY_PATH $REPO/.venv/bin/python perf_harness.py bench [--cases case6_layernorm,...]`
+- **compare** — one row per case, two columns: `--rev`'s committed
+  `generated.py` (default `origin/main`) vs the working tree's, cells =
+  per-shape gen/handwritten ratios. Scans EVERY `case*/` in examples/
+  (cases without bench_spec are listed as such); byte-identical kernels are
+  measured once and shown "unchanged". Both columns run under the CURRENT
+  build — it compares fixtures, not toolchains (use `regression`/`e2e` for
+  that): `... perf_harness.py compare [--rev origin/main] [--cases ...]`
+- **regression** — before/after emitter check for a diff that touches
+  sched2tlx (re-emits every case both sides; only true regressions fail):
+  `... perf_harness.py regression [--diff REV | --before X --after Y] [--perf-tol 0.05]`
+- **e2e** — full pipeline from TTGIR (dump → emit → bench) with the current
+  build: `... perf_harness.py e2e --skip-master --cases case6_layernorm`.
+  The master-comparison mode (`--master-repo`) needs a separately built
+  master checkout and is buck/fbsource-oriented.
+
+## Cases the harness does NOT cover
+
+- **case4_FA_bwd**: `cd examples/case4_FA_bwd && ... python perf_generated.py`
+  (gen vs no-WS baseline vs handwritten WS); correctness via `run_generated.py`.
+- **case8_multiphase_gemm**: `cd examples/case8_multiphase_gemm && ... python
+  bench_general.py` (correctness + pool-vs-sum A/B; no handwritten reference).
+- Correctness-only for any case: `cd examples/<case> && ... python run_generated.py`.
+
+## Comparing against another revision's kernel
+
+`run_bench(case_dir, generated_path)` takes the generated.py path separately,
+so to bench another revision's kernel under identical methodology:
+`git show <rev>:<path>/generated.py > /tmp/gen.py`, then in python:
+`perf_harness._print_table(perf_harness.run_bench(CASE_DIR, Path("/tmp/gen.py")))`.
+Cheap shortcut when only fixtures differ: kernels whose generated.py is
+byte-identical across revisions need no re-measurement.
+
+## Regenerating fixtures
+
+```
+TRITON_MODULO_DUMP_SCHEDULE=<case>/schedule_graph.json \
+  build/cmake.*/bin/triton-opt -allow-unregistered-dialect \
+  --nvgpu-modulo-schedule <case>/<kernel>_pre_modulo.ttgir -o /dev/null
+env -u LD_LIBRARY_PATH PYTHONPATH=third_party/tlx/tools/sched2tlx \
+  $REPO/.venv/bin/python -m sched2tlx <case>/schedule_graph.json -o <case>/generated.py
+```
+JSON op ids are pointer-derived and never byte-stable — regen always churns
+schedule_graph.json; the meaningful diff signal is `generated.py`.
+Known: case3 may need `TRITON_MODULO_SELECT_VARIANT=2`; case2 fixtures are
+ancient (fresh dumps differ, pre-existing).
+
+## Methodology warnings
+
+- `bench`/`run_bench` use `triton.testing.do_bench` (cold-L2). Ad-hoc
+  CUDA-event loops (e.g. `perf_generated_vs_handwritten.py`) are hot-L2 and
+  read higher. NEVER cross-compare numbers from the two.
+- Check `nvidia-smi` first; if a run hangs for minutes, run
+  `third_party/tlx/killgpu.sh`.
+- One bench at a time — timing runs must not share the GPU.

--- a/third_party/tlx/tools/sched2tlx/examples/testing/perf_regression/perf_harness.py
+++ b/third_party/tlx/tools/sched2tlx/examples/testing/perf_regression/perf_harness.py
@@ -383,6 +383,94 @@ def bench_main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def compare_main(argv: list[str] | None = None) -> int:
+    """``compare`` subcommand: one row per case, ``--rev`` vs working tree.
+
+    Compares committed KERNELS (each side's generated.py fixture), both run
+    under the CURRENT build with the CURRENT bench_spec — cheap and exact when
+    a diff only changes what the emitter produces. It does NOT rebuild the
+    other revision's toolchain; for a full before/after of the emitter itself
+    use ``regression``, and for a separately built master use ``e2e``.
+
+    Scans every ``case*/`` dir in examples/ so new cases appear automatically;
+    cases without a bench_spec.py are listed (not silently dropped). A case
+    whose generated.py is byte-identical on both sides is measured once and
+    reported "unchanged" — anything else would just be re-measuring noise.
+    """
+    ap = argparse.ArgumentParser(
+        prog="perf_harness.py compare",
+        description="per-case gen/hw summary table: a git revision's generated.py vs the working tree's",
+    )
+    ap.add_argument("--rev", default="origin/main", help="git revision for the left column (default: origin/main)")
+    ap.add_argument("--cases", help="comma-separated case dir names (default: every case*/ in examples/)")
+    args = ap.parse_args(argv)
+
+    examples_dir = Path(__file__).resolve().parents[2]
+    repo_root = Path(
+        subprocess.check_output(
+            ["git", "-C", str(examples_dir), "rev-parse", "--show-toplevel"], text=True
+        ).strip()
+    )
+    names = args.cases.split(",") if args.cases else sorted(
+        p.name for p in examples_dir.iterdir() if p.is_dir() and p.name.startswith("case")
+    )
+
+    def _cell(result: dict[str, Any]) -> str:
+        # Per-shape gen/hw ratios in SHAPES order; raw throughput when the
+        # case has no handwritten baseline. Any correctness failure taints
+        # the whole cell — a fast wrong kernel must not read as a win.
+        parts = []
+        for r in result["shapes"]:
+            if r["hw_throughput"]:
+                parts.append(f"{r['throughput'] / r['hw_throughput']:.2f}x")
+            else:
+                parts.append(f"{r['throughput']:.0f} {r['unit']}")
+        if not all(r["ok"] for r in result["shapes"]):
+            parts.append("FAIL")
+        return ", ".join(parts) if parts else "-"
+
+    rows: list[tuple[str, str, str]] = []
+    for name in names:
+        case_dir = examples_dir / name
+        gen = case_dir / "generated.py"
+        if not (case_dir / "bench_spec.py").exists() or not gen.exists():
+            rows.append((name, "(no bench_spec)", "(no bench_spec)"))
+            continue
+        relpath = gen.resolve().relative_to(repo_root).as_posix()
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "show", f"{args.rev}:{relpath}"],
+            capture_output=True,
+        )
+        if proc.returncode != 0:
+            rows.append((name, f"(not on {args.rev})", _cell(run_bench(case_dir, gen))))
+        elif proc.stdout == gen.read_bytes():
+            rows.append((name, _cell(run_bench(case_dir, gen)), "unchanged"))
+        else:
+            with tempfile.TemporaryDirectory() as td:
+                rev_gen = Path(td) / "generated.py"
+                rev_gen.write_bytes(proc.stdout)
+                left = _cell(run_bench(case_dir, rev_gen))
+            rows.append((name, left, _cell(run_bench(case_dir, gen))))
+
+    left_hdr = (
+        "master"
+        if args.rev in ("origin/main", "main", "origin/master", "master")
+        else args.rev
+    )
+    right_hdr = "branch"
+    w0 = max(len("case"), *(len(r[0]) for r in rows)) + 2
+    w1 = max(len(left_hdr), *(len(r[1]) for r in rows)) + 2
+    print(f"\n{'case':<{w0}}{left_hdr:<{w1}}{right_hdr}")
+    print("-" * (w0 + w1 + len(right_hdr)))
+    for name, left, right in rows:
+        print(f"{name:<{w0}}{left:<{w1}}{right}")
+    print(
+        "\ncells: per-shape gen/handwritten ratios (SHAPES order); both columns run"
+        "\nunder the current build; 'unchanged' = byte-identical generated.py."
+    )
+    return 0
+
+
 # ===========================================================================
 # Regression driver (``regression`` subcommand) — before-vs-after emitter check.
 #
@@ -1072,6 +1160,7 @@ _SUBCOMMANDS = {
     "e2e": e2e_main,
     "e2e-worker": e2e_worker_main,
     "bench": bench_main,
+    "compare": compare_main,
 }
 
 


### PR DESCRIPTION
## What

`perf_harness.py` gets a `compare` subcommand that prints a one-row-per-case summary with a **master** column and a **branch** column, where each cell is the per-shape gen/handwritten throughput ratios:

```
case                   master                                    branch
-----------------------------------------------------------------------
case1_simple_gemm      1.00x, 1.12x, 1.22x                       unchanged
case2_persistent_gemm  1.00x, 0.89x, 0.91x, 0.97x                unchanged
case3_FA               1.00x, 0.94x, 1.07x, 1.11x, 1.11x, 1.24x  unchanged
case4_FA_bwd           (no bench_spec)                           (no bench_spec)
case5_addmm_bias       1.00x, 1.13x, 1.32x, 1.38x, 1.25x, 1.40x  unchanged
case6_layernorm        0.70x, 0.60x, 0.54x                       0.88x, 1.00x, 1.00x
case7_wgrad_bias       0.83x, 0.70x, 0.70x, 0.67x                unchanged
case8_multiphase_gemm  (no bench_spec)                           (no bench_spec)
```

It compares a git revision's committed `generated.py` (default `origin/main`) against the working tree's, both benched under the current build with the current `bench_spec` — cheap and exact when a diff only changes what the emitter produces (for a full toolchain before/after, `regression`/`e2e` remain the right tools). Design choices:

- Scans every `case*/` dir in `examples/`, so future cases are picked up automatically; cases without a `bench_spec.py` are listed as such rather than silently dropped.
- Byte-identical kernels are measured once and reported `unchanged` — a deterministic claim, and it avoids re-measuring noise.
- Any correctness failure taints the cell with `FAIL`, so a fast wrong kernel cannot read as a win.

Also adds a `.claude/skills/sched2tlx-perf-testing` skill documenting how to drive this harness (`bench`/`compare`/`regression`/`e2e`, the cases the harness does not cover, fixture regeneration, and the cold-vs-hot-L2 methodology rules), mirroring the existing `kernel-perf-testing` skill.

## Test plan

- `perf_harness.py compare` run over the full corpus on a B200 (output above; the case6 delta is from the occupancy branch under test at the time — on a clean main checkout every case reports `unchanged`).
- `perf_harness.py compare --cases case4_FA_bwd,case8_multiphase_gemm` exercises the no-bench_spec path without a GPU.
- `perf_harness.py bench` unchanged and still passes on all bench_spec cases.

Authored with Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)