### PR TITLE
[TLX][AMD] Fix warp-pipe addmm RAW race in async_load pipeline (unblocks all shapes) (#2058)

### DIFF
--- a/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
@@ -66,18 +66,20 @@
     smemA = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(A), NUM_BUFFERS)
     smemB = tlx.local_alloc((BLOCK_N, BLOCK_K), tlx.dtype_of(B), NUM_BUFFERS)   # holds Bᵀ tile
 
-    # prologue: prefetch the first NUM_BUFFERS K-tiles (heuristic guarantees K_ITERS > NUM_BUFFERS)
+    # prologue: prefetch the first NUM_BUFFERS K-tiles (heuristic guarantees K_ITERS > NUM_BUFFERS).
+    # A and B share a SINGLE async_load_commit_group per K-tile -- Hongtao's P2419921423 structure.
+    # One group/iter means the wait counts tiles directly (no *2), and it lets the wait live at the
+    # loop tail (below), which is what makes the pipeline race-free across all NUM_BUFFERS (incl. 2).
     for i in tl.range(0, NUM_BUFFERS, loop_unroll_factor=NUM_BUFFERS):
         k_start = i * BLOCK_K
         a_offs = a_base + (k_start + offs_k[None, :]) * stride_ak
         b_offs = b_base + (k_start + offs_k[None, :]) * stride_bk
         # int32 cast is lossless: the heuristic only emits this template when offsets fit int32.
         tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, i), mask=offs_k[None, :] < K - k_start)
-        tlx.async_load_commit_group([tok_a])
         tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, i), mask=offs_k[None, :] < K - k_start)
-        tlx.async_load_commit_group([tok_b])
+        tlx.async_load_commit_group([tok_a, tok_b])
 
-    tlx.async_load_wait_group((NUM_BUFFERS - 1) * 2)
+    tlx.async_load_wait_group(NUM_BUFFERS - 2)
     a_tile = tlx.local_load(tlx.local_view(smemA, 0))
     b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, 0)))
 
@@ -93,19 +95,24 @@
         with tlx.warp_pipeline_stage("mfma", priority=0):
             acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
 
-        tlx.async_load_wait_group(2)
-
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_offs = a_base + (k_prefetch + offs_k[None, :]) * stride_ak
             b_offs = b_base + (k_prefetch + offs_k[None, :]) * stride_bk
             tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, prefetch_buf),
                                    mask=offs_k[None, :] < K - k_prefetch)
-            tlx.async_load_commit_group([tok_a])
             tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, prefetch_buf),
                                    mask=offs_k[None, :] < K - k_prefetch)
-            tlx.async_load_commit_group([tok_b])
+            tlx.async_load_commit_group([tok_a, tok_b])
             a_tile = tlx.local_load(tlx.local_view(smemA, next_buf))
             b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, next_buf)))
+
+        # loop-tail wait (Hongtao P2419921423): keep NUM_BUFFERS-2 commit groups in flight. With
+        # single A+B commits this counts tiles directly. Race-free because local_load(next_buf)
+        # above reads a buffer committed >=2 iters ago, made complete by the PREVIOUS iteration's
+        # tail wait; NUM_BUFFERS=2 -> wait(0) fully drains each iter (correct, serial). Replaces
+        # the earlier in-loop async_load_wait_group((NUM_BUFFERS-2)*2) before local_load, which
+        # fixed the same RAW race with separate A/B commits.
+        tlx.async_load_wait_group(NUM_BUFFERS - 2)
 
     acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
     tlx.async_load_wait_group(0)


### PR DESCRIPTION
Summary:

Fixes a read-after-write (RAW) race in the AMD warp-pipe `addmm` template (`amd_addmm_warppipe.py.jinja`) that produced roughly one-third garbage output tiles on larger GEMMs on gfx950/MI350X, making the kernel numerically incorrect (`Accuracy: False`) end-to-end.

Root cause. In the original pipeline, A and B were committed as two separate `async_load_commit_group`s per K-tile, and the drain barrier sat *before* the prefetch commits. At that point the oldest pending groups are exactly `next_buf`'s A and B loads — the tile the loop is about to `local_load` and feed to the MFMA — so for the winning `NUM_BUFFERS=2` config the barrier left `next_buf`'s own loads in flight and `local_load(next_buf)` read a half-filled LDS buffer. The result is non-deterministic garbage that only manifests under memory contention (large shapes with many concurrent CTAs), which is why smaller tritonbench shapes appeared to pass while the full model failed.

Fix (Hongtao's P2419921423 structure). Combine A and B into a SINGLE `async_load_commit_group` per K-tile and move the drain to the loop tail as `tlx.async_load_wait_group(NUM_BUFFERS - 2)`. With one commit group per tile the wait counts tiles directly (no `*2`), and placing it at the loop boundary — after the mem stage issues the next prefetch and `local_load`s `next_buf` — means the buffer consumed each iteration was already made complete by the PREVIOUS iteration's tail wait. For `NUM_BUFFERS=2` this is `async_load_wait_group(0)`, i.e. a full drain each iteration (correct, serial); for `NUM_BUFFERS >= 3` it keeps `NUM_BUFFERS-2` groups in flight for overlap. This is the structure validated in the standalone Stream-K sweep (P2420762579), so conda and Inductor now run the same kernel. `tlx.warp_pipeline_stage` is only a scheduling marker (`s_setprio`); load/consume ordering is the kernel author's responsibility, which is what this barrier enforces.

(This supersedes the earlier fix that kept separate A/B commits and used an in-loop `async_load_wait_group((NUM_BUFFERS - 2) * 2)` before `local_load`; both fix the same race, but Hongtao's single-commit / loop-tail form is cleaner, is the upstream-intended structure, and is what the split-K work builds on.)

Determinism check confirmed the race (not an addressing/int32 bug): the same shape produced different wrong fractions and locations across identical back-to-back runs. After the fix the kernel is deterministic and correct on the previously-failing shapes; residual diffs are benign fp16 tolerance. The warp-pipe result now matches stock Triton and rocBLAS numerically.

Authored with Claude.

Reviewed By: z1sz, dshi7

Differential Revision: D111541877


