### PR TITLE
[triton][beta] [Cherry-pick] '[Blackwell] Add pass to combine TMEM load followed by row reduction for sm103+ (#10551)'

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -53,6 +53,11 @@ public:
     return computeCapability >= 100;
   }
 
+  bool supportLdRed() const {
+    // Blackwell (sm103) and newer, but exclude sm120 and sm121.
+    return computeCapability >= 103 && computeCapability / 10 != 12;
+  }
+
 private:
   static constexpr char kTargetPrefix[] = "cuda:";
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h
@@ -32,6 +32,18 @@ computeTMemLdStEncodingInfo(RankedTensorType regTy, gpu::MemDescType memTy,
                             int maxnreg,
                             std::function<InFlightDiagnostic()> emitError = {});
 
+// Check whether a tmem_load with register layout `regTy` reading from `memTy`
+// can be supported with a fused reduction along the N dimension. This is the
+// case when the layout is packed, the per-thread register bases span the full N
+// axis and do not advance M. In other words, each thread owns one M coordinate
+// and all N values for that coordinate; N is not split across lanes/warps/CTAs,
+// and a thread does not hold multiple M rows for this fused reduction.
+// `maxnreg` is the contextual register limit and when `emitError` is provided,
+// a diagnostic describing the first failing condition is emitted.
+bool supportsTMemLoadReduce(RankedTensorType regTy, gpu::MemDescType memTy,
+                            int maxnreg,
+                            std::function<InFlightDiagnostic()> emitError = {});
+
 } // namespace mlir::triton::nvidia_gpu
 
 #endif // TRITON_DIALECT_TRITONNVIDIAGPU_IR_TENSORMEMORYUTILS_H_

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -82,6 +82,19 @@ def TritonGPUProxyFenceInsertion : Pass<"triton-nvidia-gpu-proxy-fence-insertion
   ];
 }
 
+def TritonNvidiaGPUFuseTMEMLoadReducePass : Pass<"triton-nvidia-tmem-load-reduce", "mlir::ModuleOp"> {
+  let summary = "Fuse tmem_load and reduce";
+
+  let description = [{
+    Fuse ttng.tmem_load followed by a row reduction into ttng.tmem_load with a
+    reduction op, to generate tcgen05.ld.red.
+  }];
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+                           "mlir::triton::TritonDialect"];
+}
+
 def TritonNvidiaGPUTMALoweringPass : Pass<"triton-nvidia-tma-lowering", "mlir::ModuleOp"> {
   let summary = "lower to TMA load/store operations";
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1200,28 +1200,10 @@ LogicalResult TMEMLoadOp::verify() {
 
   // Validate reduction conditions
   if (redOp) {
-    auto regTy = getType();
-    auto memTy = getSrc().getType();
     auto maxnreg = getContextualMaxNReg(*this);
-    auto encodingInfoOr = computeTMemLdStEncodingInfo(regTy, memTy, maxnreg);
-    if (failed(encodingInfoOr))
-      return emitOpError("failed to compute TMEM encoding info");
-
-    if (encodingInfoOr->unpacked)
-      return emitOpError(
-          "tmem_load reduction requires packed format (unpacked=false)");
-
-    // Verify that N dimension is in registers entirely, and is not sharded
-    // across threads. This could be relaxed in the future to only reduce the
-    // kReg bases along N then cross-warp/block reduction becomes needed.
-    auto kReg = StringAttr::get(regTy.getContext(), "register");
-    int dimM = 0, dimN = 1;
-    auto regDims = toLinearEncoding(regTy).basesPerDim(kReg);
-    if (regDims[dimN] != toLinearLayout(regTy).getOutDimSizes().begin()[dimN] ||
-        regDims[dimM] != 1) {
-      return emitOpError("tmem_load reduction with N dimension sharded across "
-                         "threads is not supported.");
-    }
+    if (!supportsTMemLoadReduce(getType(), getSrc().getType(), maxnreg,
+                                [&]() { return emitOpError(); }))
+      return failure();
   }
 
   return triton::gpu::verifyMemoryOpTypes(*this, getSrc().getType(), getType());

--- a/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
@@ -318,4 +318,50 @@ computeTMemLdStEncodingInfo(RankedTensorType regTy, MemDescType memTy,
   return lowerTMemLdSt(cvt, maxnreg, bitwidth, isScales, emitError);
 }
 
+bool supportsTMemLoadReduce(RankedTensorType regTy, MemDescType memTy,
+                            int maxnreg,
+                            std::function<InFlightDiagnostic()> emitError) {
+  auto encodingInfo = computeTMemLdStEncodingInfo(regTy, memTy, maxnreg);
+  if (failed(encodingInfo)) {
+    if (emitError)
+      emitError() << "failed to compute TMEM encoding info";
+    return false;
+  }
+
+  if (encodingInfo->unpacked) {
+    if (emitError)
+      emitError() << "tmem_load reduction requires packed format "
+                     "(unpacked=false)";
+    return false;
+  }
+
+  auto kReg = StringAttr::get(regTy.getContext(), "register");
+  constexpr int dimM = 0, dimN = 1;
+  auto regDims =
+      toLinearEncoding(regTy).basesPerDim(kReg, /*skipBroadcast=*/true);
+
+  // The fused ld.red instruction reduces the values that are already local to a
+  // thread, so the N axis must live entirely in this thread's registers,
+  // otherwise the N reduction would be partial and need cross-lane/warp/CTA
+  // combining.
+  if (regDims[dimN] != toLinearLayout(regTy).getOutDimSizes().begin()[dimN]) {
+    if (emitError)
+      emitError() << "tmem_load reduction with N dimension sharded across "
+                     "threads is not supported.";
+    return false;
+  }
+
+  // regDims[dimM] is the number of distinct M coordinates a single thread holds
+  // across its registers. Require it to be 1, so each thread owns exactly one M
+  // row.
+  if (regDims[dimM] != 1) {
+    if (emitError)
+      emitError() << "tmem_load reduction with multiple M rows per thread is "
+                     "not supported.";
+    return false;
+  }
+
+  return true;
+}
+
 } // namespace mlir::triton::nvidia_gpu

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   CLCLowering.cpp
   ConSanNVIDIA.cpp
   FenceInsertion.cpp
+  FuseTMemLoadReduce.cpp
   GenerateSubtiledRegion.cpp
   InterleaveTMem.cpp
   MMALowering.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FuseTMemLoadReduce.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FuseTMemLoadReduce.cpp
@@ -1,0 +1,183 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Attributes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+
+namespace ttg = mlir::triton::gpu;
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUFUSETMEMLOADREDUCEPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+// Strip away all intermediate ttg.convert_layout ops to reach the true
+// producer.
+static Value stripConvertLayout(Value v) {
+  while (auto cvt = v.getDefiningOp<ttg::ConvertLayoutOp>())
+    v = cvt.getSrc();
+  return v;
+}
+
+// Combine "ttng.tmem_load" and "tt.reduce" into "ttng.tmem_load" if it
+// has the `redOp` attribute.  This targets the PTX `tcgen05.ld.red`
+// instruction on Blackwell (sm103+).
+//
+// Match:
+//
+//   %v = ttng.tmem_load %tmem :
+//        !ttg.memdesc<MxNxf32, #tmem, ...> -> tensor<MxNxf32, #blocked>
+//   [ %cvt = ttg.convert_layout %v ... ] // optional
+//   %r  = "tt.reduce"(%cvt or %v) ({...max/min combiner...}) {axis = 1}
+//
+// And rewrite this to:
+//
+//   %v, %r' = ttng.tmem_load %tmem {redOp = #ttng.redOp<max|min>, NaN = ...}
+//             : ... -> tensor<MxNxf32, #blocked>, tensor<Mxf32,
+//             slice(#blocked)>
+//   [ %r = ttg.convert_layout %r' ]
+//
+// I.e., the fused load operation additionally performs an
+// element-wise reduction along the N-dimension of the input and produces a
+// second result tensor %r'. For a input of shape [M, N], the
+// reduced result has shape [M], containing one reduced value per "slice"
+// of the N-dimension.
+
+class FuseTMemLoadReducePattern : public OpRewritePattern<triton::ReduceOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(triton::ReduceOp reduceOp,
+                                PatternRewriter &rewriter) const override {
+    // Instruction `tcgen05.ld.red` is only available on Blackwell sm103+.
+    auto targetFeatures =
+        TargetFeatures::fromModuleOp(reduceOp->getParentOfType<ModuleOp>());
+    if (!targetFeatures.supportLdRed())
+      return failure();
+
+    // Bail if the region isn't a trivial shape, it should have exactly one
+    // operand and one result.
+    Operation *combiner = reduceOp.getSingleCombiner();
+    if (!combiner)
+      return failure();
+
+    // Only support reduction along the N-dimension.
+    if (reduceOp.getAxis() != 1)
+      return failure();
+
+    if (reduceOp.hasDefinedOrdering())
+      return failure();
+
+    // Look through "convert_layout" to find the "tmem_load", which is
+    // guaranteed to produce a result with rank 2.
+    auto tmemLoad = stripConvertLayout(reduceOp.getOperands()[0])
+                        .getDefiningOp<TMEMLoadOp>();
+    if (!tmemLoad)
+      return failure();
+
+    // Skip if already a fused load.
+    if (tmemLoad.getRedOp())
+      return failure();
+
+    // This is not a HW/PTX restriction, tcgen05.ld.red supports integer integer
+    // types, but this is a Triton limitation: the reduction is restricted to
+    // f32, element types, see the definition of TTNG_TMEMLoadOp.
+    if (!tmemLoad.getType().getElementType().isF32())
+      return failure();
+
+    TMEMLoadReduceModifier redOpKind;
+    bool propagateNaN;
+    if (isa<arith::MaxNumFOp>(combiner)) {
+      // MaxNumFOp: if one of the arguments is NaN, the result is also NaN.
+      redOpKind = TMEMLoadReduceModifier::MAX;
+      propagateNaN = false;
+    } else if (isa<arith::MaximumFOp>(combiner)) {
+      // MaximumFOp: if one of the arguments is NaN, the result is the other
+      // argument.
+      redOpKind = TMEMLoadReduceModifier::MAX;
+      propagateNaN = true;
+    } else if (isa<arith::MinNumFOp>(combiner)) {
+      redOpKind = TMEMLoadReduceModifier::MIN;
+      propagateNaN = false;
+    } else if (isa<arith::MinimumFOp>(combiner)) {
+      redOpKind = TMEMLoadReduceModifier::MIN;
+      propagateNaN = true;
+    } else {
+      return failure();
+    }
+
+    // Verify the layout supports the fused "tcgen05.ld.red": the load must be
+    // packed, each thread's register bases must span the full N axis and must
+    // not advance M.
+    auto maxnreg = getContextualMaxNReg(tmemLoad);
+    if (!supportsTMemLoadReduce(tmemLoad.getType(), tmemLoad.getSrc().getType(),
+                                maxnreg))
+      return failure();
+
+    // Now build the fused load.
+    auto *ctx = tmemLoad.getContext();
+    auto redOpAttr = TMEMLoadReduceModifierAttr::get(ctx, redOpKind);
+    BoolAttr nanAttr = propagateNaN ? rewriter.getBoolAttr(true) : BoolAttr();
+    Type tokenTy = tmemLoad.getToken() ? tmemLoad.getToken().getType() : Type();
+    rewriter.setInsertionPoint(tmemLoad);
+    auto newLoad = TMEMLoadOp::create(rewriter, tmemLoad.getLoc(),
+                                      /*result=*/tmemLoad.getType(),
+                                      /*token=*/tokenTy,
+                                      /*src=*/tmemLoad.getSrc(),
+                                      /*dep=*/tmemLoad.getDep(), redOpAttr,
+                                      /*abs=*/BoolAttr(), nanAttr);
+
+    // Replace original load uses (result + optional token).
+    SmallVector<Value> loadReplacements{newLoad.getResult()};
+    if (tmemLoad.getToken())
+      loadReplacements.push_back(newLoad.getToken());
+    rewriter.replaceOp(tmemLoad, loadReplacements);
+
+    // Splice the reduce into the fused-load `red` result, inserting a layout
+    // conversion if the slice encodings differ.
+    Value redResult = newLoad.getRed();
+    Type expectedTy = reduceOp->getResult(0).getType();
+    if (redResult.getType() != expectedTy) {
+      rewriter.setInsertionPoint(reduceOp);
+      redResult = ttg::ConvertLayoutOp::create(rewriter, reduceOp.getLoc(),
+                                               expectedTy, redResult);
+    }
+    rewriter.replaceOp(reduceOp, redResult);
+    return success();
+  }
+};
+
+} // anonymous namespace
+
+class TritonNvidiaGPUFuseTMEMLoadReducePass
+    : public impl::TritonNvidiaGPUFuseTMEMLoadReducePassBase<
+          TritonNvidiaGPUFuseTMEMLoadReducePass> {
+public:
+  using TritonNvidiaGPUFuseTMEMLoadReducePassBase<
+      TritonNvidiaGPUFuseTMEMLoadReducePass>::
+      TritonNvidiaGPUFuseTMEMLoadReducePassBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp m = getOperation();
+
+    RewritePatternSet patterns(context);
+    patterns.add<FuseTMemLoadReducePattern>(context);
+    if (applyPatternsGreedily(m, std::move(patterns)).failed()) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/test/TritonNvidiaGPU/fuse_tmem_load_reduce.mlir
+++ b/test/TritonNvidiaGPU/fuse_tmem_load_reduce.mlir
@@ -1,0 +1,281 @@
+// RUN: triton-opt %s -split-input-file --triton-nvidia-tmem-load-reduce --allow-unregistered-dialect | FileCheck %s
+
+// Fuse tmem_load + tt.reduce -> tmem_load, with redOp=max. The combiner
+// for "arith.maxnumf" ignores NaNs, so the fused op does not set the NaN
+// attribute.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tt.func public @tmem_load_reduce_fuse_max(
+  // CHECK-SAME:    %[[ARG0:.+]]: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>)
+  // CHECK-SAME:    -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  // CHECK-NEXT:   %{{.+}}, %[[RED:.+]] = ttng.tmem_load %[[ARG0]] {redOp = #ttng.redOp<max>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  // CHECK-NEXT:   tt.return %[[RED]] : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  // CHECK-NEXT: }
+  tt.func public @tmem_load_reduce_fuse_max(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> {
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>
+    %1 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %2 = arith.maxnumf %lhs, %rhs : f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return %1 : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  }
+}
+
+// -----
+
+// Fuse (tmem_load, tt.reduce) -> tmem_load, with redOp=min
+// and NaN=true, and arith.minimumf is the NaN-propagating variant.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tt.func public @tmem_load_reduce_fuse_min_nan(
+  // CHECK-SAME:    %[[ARG0:.+]]: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>)
+  // CHECK-SAME:    -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  // CHECK-NEXT:   %{{.+}}, %[[RED:.+]] = ttng.tmem_load %[[ARG0]] {NaN = true, redOp = #ttng.redOp<min>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  // CHECK-NEXT:   tt.return %[[RED]] : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  // CHECK-NEXT: }
+  tt.func public @tmem_load_reduce_fuse_min_nan(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> {
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>
+    %1 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %2 = arith.minimumf %lhs, %rhs : f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return %1 : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  }
+}
+
+// -----
+
+// Look through "ttg.convert_layout" that sits between the "tmem_load" and the
+// "tt.reduce" and check that the combine happens.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tt.func public @tmem_load_reduce_fuse_through_cvt(
+  // CHECK-SAME:    %[[ARG0:.+]]: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>)
+  // CHECK-SAME:    -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #linear}>>
+  // CHECK-NEXT:   %{{.+}}, %[[RED:.+]] = ttng.tmem_load %[[ARG0]] {NaN = true, redOp = #ttng.redOp<max>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  // CHECK-NEXT:   %[[CVT:.+]] = ttg.convert_layout %[[RED]] : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #linear}>>
+  // CHECK-NEXT:   tt.return %[[CVT]] : tensor<128xf32, #ttg.slice<{dim = 1, parent = #linear}>>
+  // CHECK-NEXT: }
+  tt.func public @tmem_load_reduce_fuse_through_cvt(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #linear}>> {
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>
+    %cvt = ttg.convert_layout %0 : tensor<128x128xf32, #blocked> -> tensor<128x128xf32, #linear>
+    %1 = "tt.reduce"(%cvt) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %2 = arith.maximumf %lhs, %rhs : f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<128x128xf32, #linear>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #linear}>>
+    tt.return %1 : tensor<128xf32, #ttg.slice<{dim = 1, parent = #linear}>>
+  }
+}
+
+// -----
+
+// Negative test: an explicitly ordered reduction must preserve its reduction
+// tree and must not be fused into tmem_load.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tmem_load_reduce_no_fuse_inner_tree
+  // CHECK: ttng.tmem_load
+  // CHECK-NOT: redOp
+  // CHECK: "tt.reduce"
+  // CHECK-SAME: reduction_ordering = "inner_tree"
+  tt.func public @tmem_load_reduce_no_fuse_inner_tree(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> {
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>
+    %1 = "tt.reduce"(%0) <{axis = 1 : i32, reduction_ordering = "inner_tree"}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %2 = arith.maxnumf %lhs, %rhs : f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return %1 : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  }
+}
+
+// -----
+
+// Negative test: check that that we do not fuse and generate "tcgen05.ld.red" if
+// the target isn't sm103+.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tmem_load_reduce_no_fuse_sm100
+  // CHECK: ttng.tmem_load
+  // CHECK-NOT: redOp
+  // CHECK: "tt.reduce"
+  tt.func public @tmem_load_reduce_no_fuse_sm100(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> {
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>
+    %1 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %2 = arith.maxnumf %lhs, %rhs : f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return %1 : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  }
+}
+
+// -----
+
+// Negative test: sm120/sm121 are explicitly excluded by supportLdRed() even
+// though they are >= sm103, so the pass must leave "tt.reduce" unfused.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:120", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tmem_load_reduce_no_fuse_sm120
+  // CHECK: ttng.tmem_load
+  // CHECK-NOT: redOp
+  // CHECK: "tt.reduce"
+  tt.func public @tmem_load_reduce_no_fuse_sm120(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> {
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>
+    %1 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %2 = arith.maxnumf %lhs, %rhs : f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return %1 : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  }
+}
+
+// -----
+
+// Negative test: "arith.addf" is not a supported combiner.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tmem_load_reduce_no_fuse_addf
+  // CHECK: ttng.tmem_load
+  // CHECK-NOT: redOp
+  // CHECK: "tt.reduce"
+  tt.func public @tmem_load_reduce_no_fuse_addf(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> {
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>
+    %1 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %2 = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return %1 : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  }
+}
+
+// -----
+
+// Negative test and current Ttriton limitation: make sure we don't
+// fuse when the element is a i32 as the reduction on operation tmem_load
+// is documented as f32-only.
+// Even with a max/min-style integer combiner on sm103, the pattern must bail.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tmem_load_reduce_no_fuse_i32
+  // CHECK: ttng.tmem_load
+  // CHECK-NOT: redOp
+  // CHECK: "tt.reduce"
+  tt.func public @tmem_load_reduce_no_fuse_i32(%arg0: !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory>) -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>> {
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xi32, #tmem, #ttng.tensor_memory> -> tensor<128x128xi32, #blocked>
+    %1 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: i32, %rhs: i32):
+      %2 = arith.maxsi %lhs, %rhs : i32
+      tt.reduce.return %2 : i32
+    }) : (tensor<128x128xi32, #blocked>) -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return %1 : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  }
+}
+
+// -----
+
+// Negative test: reduction along axis 0 (the M axis) must not fuse. The
+// fused tcgen05.ld.red only reduces along the inner N axis.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tmem_load_reduce_no_fuse_axis0
+  // CHECK: ttng.tmem_load
+  // CHECK-NOT: redOp
+  // CHECK: "tt.reduce"
+  tt.func public @tmem_load_reduce_no_fuse_axis0(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked}>> {
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>
+    %1 = "tt.reduce"(%0) <{axis = 0 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %2 = arith.maxnumf %lhs, %rhs : f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    tt.return %1 : tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+  }
+}
+
+// -----
+
+// Negative test for the "already fused" bail-out.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tmem_load_reduce_no_fuse_already_fused
+  // CHECK: %{{.+}}, %{{.+}} = ttng.tmem_load{{.+}}redOp = #ttng.redOp<max>
+  // CHECK-NOT: ttng.tmem_load
+  // CHECK: "tt.reduce"
+  // CHECK-NOT: "tt.reduce"
+  // CHECK: tt.return
+  tt.func public @tmem_load_reduce_no_fuse_already_fused(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> (tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>) {
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>
+    %1 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %a = arith.maxnumf %lhs, %rhs : f32
+      tt.reduce.return %a : f32
+    }) : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %2 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %b = arith.maxnumf %lhs, %rhs : f32
+      tt.reduce.return %b : f32
+    }) : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return %1, %2 : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  }
+}
+
+// -----
+
+// Negative test: the layout below splits the N dimension across registers and warps,
+// 2 warps along N, so N is not entirely in register.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tmem_load_reduce_no_fuse_n_sharded_across_warps
+  // CHECK: ttng.tmem_load
+  // CHECK-NOT: redOp
+  // CHECK: "tt.reduce"
+  tt.func public @tmem_load_reduce_no_fuse_n_sharded_across_warps(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>> {
+    %0 = ttng.tmem_load %arg0 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory> -> tensor<128x128xf32, #blocked>
+    %1 = "tt.reduce"(%0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %2 = arith.maxnumf %lhs, %rhs : f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<128x128xf32, #blocked>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    tt.return %1 : tensor<128xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -955,6 +955,7 @@ class CUDABackend(BaseBackend):
         passes.ttgpuir.add_optimize_dot_operands(pm, capability >= 80)
         passes.ttgpuir.add_coalesce_async_copy(pm)
         nvidia.passes.ttnvgpuir.add_optimize_tmem_layouts(pm)
+        nvidia.passes.ttnvgpuir.add_tmem_load_reduce(pm)
         if capability // 10 >= 9:
             nvidia.passes.ttnvgpuir.add_tma_lowering(pm)
             nvidia.passes.ttnvgpuir.add_tma_store_buffer_reuse(pm)

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -163,6 +163,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      createTritonGPUFenceInsertionWrapper, int32_t);
   ADD_PASS_WRAPPER_1("add_proxy_fence_insertion",
                      createTritonGPUProxyFenceInsertionWrapper, int32_t);
+  ADD_PASS_WRAPPER_0("add_tmem_load_reduce",
+                     ttng::createTritonNvidiaGPUFuseTMEMLoadReducePass);
   ADD_PASS_WRAPPER_0("add_tma_lowering",
                      ttng::createTritonNvidiaGPUTMALoweringPass);
   ADD_PASS_WRAPPER_0("add_promote_load_to_tma",


### PR DESCRIPTION
Summary:
This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/10551

Upstream commit message:
```
> [Blackwell] Add pass to combine TMEM load followed by row reduction for sm103+ (#10551)

> This targets PTX instruction tcgen05.ld.red on Blackwell sm103+ and
> triggers for example in `tutorials/06-fused-attention.py`. A grep in the
> tmp directory shows two occurances in function `attn_fwd` in the
> generated PTX files:

> $ find . -name "*.ptx" | xargs grep -in "tcgen05.ld.red"
> _attn_fwd.ptx:389: tcgen05.ld.red.sync.aligned.32x32b.x32.max.f32 ...,
> [%r608 + 0];
> _attn_fwd.ptx:392: tcgen05.ld.red.sync.aligned.32x32b.x32.max.f32 ...,
> [%r608 + 32];

> Regarding performance, I don't see any regressions in
> `06-fused-attention.py`, and small improvements, for example:


> `fused-attention-batch4-head32-d64-fwd-causal=True-warp_specialize=False`

> | N_CTX   | Triton FP16 % | Triton FP8 % | Flash-2 % |
> | ---:    | ---:  | ---:  | ---:  |
> | 1024.0  | +0.5% | +0.9% | 0.0%  |
> | 2048.0  | -0.1% | +0.1% | +0.1% |
> | 4096.0  | +0.8% | +0.1% | 0.0%  |
> | 8192.0  | +6.2% | +2.3% | 0.0%  |
> | 16384.0 | +6.5% | +4.8% | 0.0%  |

> and


> `fused-attention-batch4-head32-d64-fwd-causal=False-warp_specialize=False`

> | N_CTX   | Triton FP16 %  | Triton FP8 % | Flash-2 % |
> | ---:    | ---:   | ---:  | ---: |
> | 1024.0  | 0.0%   | -0.3% | 0.0% |
> | 2048.0  | 0.0%   | 0.0%  | 0.0% |
> | 4096.0  | +10.5% | +0.1% | 0.0% |
> | 8192.0  | +10.7% | +4.8% | 0.0% |
> | 16384.0 | +10.1% | +5.3% | 0.0% |

> <!---
> The core Triton is a small number of people, and we receive many PRs
> (thank
> you!).  To help us review your code more quickly, **if you are a new
> contributor (less than 3 PRs merged) we ask that you complete the
> following
> tasks and include the filled-out checklist in your PR description.**

> Complete the following tasks before sending your PR, and replace `[ ]`
> with
> `[x]` to indicate you have done them.
> -->

> # New contributor declaration
> - [x] I am not making a trivial change, such as fixing a typo in a
> comment.

> - [x] I have written a PR description following these
>   [rules](https://cbea.ms/git-commit/#why-not-how).

> - [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

> - Select one of the following.
>   - [x] I have added tests.
>     - `/test` for `lit` tests
>     - `/unittest` for C++ tests
>     - `/python/test` for end-to-end tests
>   - [ ] This PR does not need a test because `FILL THIS IN`.

> - Select one of the following.
>   - [ ] I have not added any `lit` tests.
> - [x] The `lit` tests I have added follow these [best
> practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
> including the "tests should be minimal" section. (Usually running Python
> code
>     and using the instructions it generates is not minimal.)
```

***Do not remove the following line from this commit***
Reactor Backport Revision: dd04fadcac3fddc14384166822fdc86f40fe33c7
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 10551
```

Reviewed By: manman-ren

Differential Revision: D112215006


