### PR TITLE
[TLX] More efficient cluster sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,9 +777,10 @@ Examples: how mbarriers are communicated in warp specialization
 
 #### async_tasks Parameters
 
-| Parameter   | Description                                                                                           |
-|-------------|-------------------------------------------------------------------------------------------------------|
-| `exclusive` | Assert this is the only one `tlx.async_tasks` in the kernel for more efficient PTX. Default to False. |
+| Parameter                | Description                                                                                                                                                                                      |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `exclusive`              | Assert this is the only one `tlx.async_tasks` in the kernel for more efficient PTX. Default to False.                                                                                            |
+| `no_ending_cluster_sync` | This suppresses compiler generated cluster sync at end of Warp Spec. Should only be used if user guarantees all cross CTA SMEM/TMEM access are done by end of WS default task. Default to False. |
 
 #### async_task Parameters
 

--- a/python/test/unit/language/test_tlx_cluster.py
+++ b/python/test/unit/language/test_tlx_cluster.py
@@ -766,9 +766,12 @@ def test_explicit_cluster_sync_ws(device):
     # 1 user fence + 1 compiler-inserted fence from maybeInsertClusterSync
     assert ptx.count("fence.mbarrier_init.release.cluster") == 2, (
         f"Expected exactly 2 fence.mbarrier_init.release.cluster in PTX:\n{ptx}")
-    # 3 user cluster_barrier + 1 compiler-inserted + 1 WS non-default warp arrive
-    assert ptx.count("barrier.cluster.arrive.aligned") == 5, (
-        f"Expected exactly 5 barrier.cluster.arrive.aligned in PTX:\n{ptx}")
+    # 3 user cluster_barrier arrives (non-relaxed)
+    assert ptx.count("barrier.cluster.arrive.aligned") == 3, (
+        f"Expected exactly 3 barrier.cluster.arrive.aligned in PTX:\n{ptx}")
+    # 1 compiler-inserted entry arrive + 1 WS non-default warp arrive, both relaxed
+    assert ptx.count("barrier.cluster.arrive.relaxed.aligned") == 2, (
+        f"Expected exactly 2 barrier.cluster.arrive.relaxed.aligned in PTX:\n{ptx}")
     # 3 user cluster_barrier + 1 compiler-inserted
     assert ptx.count("barrier.cluster.wait.aligned") == 4, (
         f"Expected exactly 4 barrier.cluster.wait.aligned in PTX:\n{ptx}")

--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -557,14 +557,17 @@ def test_async_dot_blackwell_2cta_tma(device, A_TMEM, SAMPLE_M):
 
     ptx = kernel.asm["ptx"]
     assert ptx.count("fence.mbarrier_init.release.cluster") == 1
-    # Verify ordering: fences → cluster sync → tmem alloc
+    # Verify ordering: fences → cluster sync → tmem alloc. The entry-block arrive
+    # is relaxed; the cleanup arrive before tmem dealloc stays non-relaxed.
     fence_mbar_pos = ptx.index("fence.mbarrier_init.release.cluster")
-    cluster_arrive_pos = ptx.index("barrier.cluster.arrive.aligned")
+    cluster_arrive_pos = ptx.index("barrier.cluster.arrive.relaxed.aligned")
     cluster_wait_pos = ptx.index("barrier.cluster.wait.aligned")
     tmem_alloc_pos = ptx.index("tcgen05.alloc.cta_group::2")
     assert fence_mbar_pos < cluster_arrive_pos < cluster_wait_pos < tmem_alloc_pos
-    # 2 cluster syncs: 1 for init (before tmem alloc, after bar init), 1 for cleanup (before tmem dealloc)
-    assert ptx.count("barrier.cluster.arrive.aligned") == 2
+    # 2 cluster syncs: 1 relaxed init (before tmem alloc) + 1 non-relaxed cleanup
+    # (before tmem dealloc)
+    assert ptx.count("barrier.cluster.arrive.relaxed.aligned") == 1
+    assert ptx.count("barrier.cluster.arrive.aligned") == 1
     assert ptx.count("barrier.cluster.wait.aligned") == 2
     assert ptx.count("tcgen05.dealloc.cta_group::2") == 1
     assert ptx.count("mapa.shared::cluster") == 1  # address mapping for remote_view
@@ -575,9 +578,15 @@ def test_async_dot_blackwell_2cta_tma(device, A_TMEM, SAMPLE_M):
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
-def test_async_dot_blackwell_2cta_tma_ws(device):
+@pytest.mark.parametrize("no_ending_cluster_sync", [False, True])
+def test_async_dot_blackwell_2cta_tma_ws(device, no_ending_cluster_sync):
     """
     Test 2cta collective D = A*B for 1 tile.
+
+    Also covers tlx.async_tasks(no_ending_cluster_sync=...): a 2-CTA async dot
+    triggers TLX paired-CTA mode, so the compiler normally inserts a cluster
+    arrive/wait before TMEM dealloc. With no_ending_cluster_sync=True the user
+    declares they handle that sync, and the compiler skips those cleanup arrives.
     """
 
     def alloc_fn(size: int, align: int, stream: Optional[int]):
@@ -603,6 +612,7 @@ def test_async_dot_blackwell_2cta_tma_ws(device):
         M: tl.constexpr,
         N: tl.constexpr,
         K: tl.constexpr,
+        NO_ENDING: tl.constexpr,
     ):
         # difference from 1cta
         cluster_cta_rank = tlx.cluster_cta_rank()
@@ -632,7 +642,7 @@ def test_async_dot_blackwell_2cta_tma_ws(device):
         buffers = tlx.local_alloc((BLOCK_M, BLOCK_N), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
         acc_tmem = tlx.local_view(buffers, 0)
 
-        with tlx.async_tasks():
+        with tlx.async_tasks(no_ending_cluster_sync=NO_ENDING):
             with tlx.async_task("default"):  # epilogue consumer
                 tlx.barrier_wait(tmem_full_bars[0], phase=0)
 
@@ -679,6 +689,7 @@ def test_async_dot_blackwell_2cta_tma_ws(device):
         "M": M,
         "N": N,
         "K": K,
+        "NO_ENDING": no_ending_cluster_sync,
     }
     kernel = tcgen5_dot_kernel2cta_tma_ws[(M // BLOCK_M, N // BLOCK_N)](
         x,
@@ -711,21 +722,29 @@ def test_async_dot_blackwell_2cta_tma_ws(device):
     #   barrier.cluster.wait.aligned
     #   tcgen05.alloc.cta_group::2      (tmem alloc after cluster sync)
     fence_mbar_pos = ptx.index("fence.mbarrier_init.release.cluster")
-    cluster_arrive_pos = ptx.index("barrier.cluster.arrive.aligned", fence_mbar_pos)
+    cluster_arrive_pos = ptx.index("barrier.cluster.arrive.relaxed.aligned", fence_mbar_pos)
     cluster_wait_pos = ptx.index("barrier.cluster.wait.aligned")
     tmem_alloc_pos = ptx.index("tcgen05.alloc.cta_group::2")
     assert fence_mbar_pos < cluster_arrive_pos < cluster_wait_pos < tmem_alloc_pos
-    # 6 cluster arrives: 1 init (default) + 1 init (non-default) +
-    #   1 cleanup (default, before tmem dealloc) + 3 cleanup (non-default warps MMA/producer/idle, per partition end)
-    # 2 cluster waits: 1 init (default) + 1 cleanup (default, before tmem dealloc)
-    assert ptx.count("barrier.cluster.arrive.aligned") == 6
-    assert ptx.count("barrier.cluster.wait.aligned") == 2
+    # The 2 relaxed init arrives (default + non-default) are emitted regardless.
+    assert ptx.count("barrier.cluster.arrive.relaxed.aligned") == 2
     assert ptx.count("tcgen05.dealloc.cta_group::2") == 1
     assert ptx.count("mapa.shared::cluster") == 1  # address mapping for remote_view
     assert ptx.count("tcgen05.mma.cta_group::2") == 8  # BK=128 divided into steps of 16
 
-    ref_out = torch.matmul(x, y)
-    torch.testing.assert_close(z, ref_out)
+    if no_ending_cluster_sync:
+        # The user declares they handle the post-WS sync, so the compiler emits
+        # no non-relaxed cluster arrive before TMEM dealloc (default + the
+        # non-default per-partition-end cleanups are all skipped). This kernel
+        # does not add its own sync, so correctness is not checked here.
+        assert ptx.count("barrier.cluster.arrive.aligned") == 0
+    else:
+        # 4 non-relaxed cleanup arrives: 1 default (before tmem dealloc) + 3
+        # non-default warps (MMA/producer/idle) at partition end.
+        assert ptx.count("barrier.cluster.arrive.aligned") == 4
+        assert ptx.count("barrier.cluster.wait.aligned") == 2
+        ref_out = torch.matmul(x, y)
+        torch.testing.assert_close(z, ref_out)
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")

--- a/test/Conversion/lower_tensor_memory_to_llvm.mlir
+++ b/test/Conversion/lower_tensor_memory_to_llvm.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --convert-warp-specialize-to-llvm --convert-nv-gpu-to-llvm -allow-unregistered-dialect | FileCheck %s
+// RUN: triton-opt %s -split-input-file --convert-warp-specialize-to-llvm --convert-nv-gpu-to-llvm -allow-unregistered-dialect | FileCheck %s
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 8 : i32, ttg.tensor_memory_size = 128 : i32, "ttng.two-ctas" = true} {
   llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
@@ -11,6 +11,61 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 8 : i32, t
   // CHECK: tcgen05.dealloc.cta_group::2.sync.aligned.b32
   // CHECK-NOT: nvg.tensor_memory_base
   llvm.func @automatic_tmem_lifecycle() attributes {allocation.offset = 0 : i32, nvvm.kernel = 1 : ui1, nvvm.maxntid = array<i32: 256>} {
+    ttg.warp_specialize() attributes {warpGroupStartIds = array<i32: 4>}
+    default {
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      %0 = nvg.tensor_memory_base
+      %1 = llvm.ptrtoint %0 : !llvm.ptr<6> to i32
+      "use"(%1) : (i32) -> ()
+      ttg.warp_return
+    } : () -> ()
+    llvm.return
+  }
+}
+
+// -----
+
+// TLX paired-CTA MMA (2-CTA) warp-specialized kernel: the compiler inserts a
+// cluster arrive/wait before TMEM dealloc (baseline for the skip below).
+module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 8 : i32, ttg.tensor_memory_size = 128 : i32} {
+  llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+
+  // CHECK-LABEL: @tmem_lifecycle_paired_mma
+  // CHECK: tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned
+  // CHECK: nvvm.cluster.arrive
+  // CHECK-NEXT: nvvm.cluster.wait
+  // CHECK: tcgen05.dealloc.cta_group::2.sync.aligned.b32
+  llvm.func @tmem_lifecycle_paired_mma() attributes {allocation.offset = 0 : i32, nvvm.kernel = 1 : ui1, nvvm.maxntid = array<i32: 256>} {
+    ttg.warp_specialize() attributes {warpGroupStartIds = array<i32: 4>}
+    default {
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      %0 = nvg.tensor_memory_base
+      %1 = llvm.ptrtoint %0 : !llvm.ptr<6> to i32
+      "use"(%1) : (i32) -> ()
+      ttg.warp_return
+    } : () -> ()
+    llvm.return
+  }
+}
+
+// -----
+
+// Same kernel but with tlx.user_post_ws_sync: the user handles the
+// post-warp-specialize sync, so the compiler skips the cluster arrive/wait
+// before TMEM dealloc (tcgen05 alloc/dealloc unchanged).
+module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 8 : i32, ttg.tensor_memory_size = 128 : i32, tlx.user_post_ws_sync = true} {
+  llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+
+  // CHECK-LABEL: @tmem_lifecycle_user_post_ws_sync
+  // CHECK: tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned
+  // CHECK-NOT: nvvm.cluster.arrive
+  // CHECK-NOT: nvvm.cluster.wait
+  // CHECK: tcgen05.dealloc.cta_group::2.sync.aligned.b32
+  llvm.func @tmem_lifecycle_user_post_ws_sync() attributes {allocation.offset = 0 : i32, nvvm.kernel = 1 : ui1, nvvm.maxntid = array<i32: 256>} {
     ttg.warp_specialize() attributes {warpGroupStartIds = array<i32: 4>}
     default {
       ttg.warp_yield

--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -1207,7 +1207,7 @@ llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 :
 
 // non default warps arrive before jumping to switch loop
 // CHECK: llvm.inline_asm
-// CHECK-SAME: @!$0 barrier.cluster.arrive.aligned
+// CHECK-SAME: @!$0 barrier.cluster.arrive.relaxed.aligned
 // CHECK-NEXT: llvm.cond_br
 
 // default warps keep arrive/wait after bar init
@@ -1277,7 +1277,7 @@ llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 :
 
 // Init: non-default warps arrive before the default/partition branch
 // CHECK: llvm.inline_asm
-// CHECK-SAME: @!$0 barrier.cluster.arrive.aligned
+// CHECK-SAME: @!$0 barrier.cluster.arrive.relaxed.aligned
 // CHECK-NEXT: llvm.cond_br
 
 // Cleanup: non-default warps arrive at partition end before looping back

--- a/test/Hopper/TwoCTA/cluster_sync_mixed_ws_barriers.mlir
+++ b/test/Hopper/TwoCTA/cluster_sync_mixed_ws_barriers.mlir
@@ -17,7 +17,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
     // CHECK: mbarrier.init.shared::cta.b64
     // CHECK: fence.mbarrier_init.release.cluster
-    // CHECK-NEXT: nvvm.cluster.arrive {aligned}
+    // CHECK-NEXT: nvvm.cluster.arrive.relaxed {aligned}
     // CHECK-NEXT: nvvm.cluster.wait {aligned}
     // CHECK: nvvm.mapa
     ttng.init_barrier %entry_barrier, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>

--- a/test/TLX/attach-metadata.mlir
+++ b/test/TLX/attach-metadata.mlir
@@ -195,3 +195,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttng.tw
     tt.return
   }
 }
+
+// -----
+
+// A `tlx.no_ending_cluster_sync` marker on the warp_specialize op is propagated
+// to the `tlx.user_post_ws_sync` module attribute (NVIDIA target).
+// CHECK: module attributes {
+// CHECK-SAME: tlx.user_post_ws_sync = true
+module {
+  tt.func @kernel_no_ending_cluster_sync() {
+    ttg.warp_specialize() attributes {tlx.no_ending_cluster_sync}
+    default {
+      ttg.warp_yield
+    }
+    partition0() num_warps(1) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}

--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -12,7 +12,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     // CHECK: mbarrier.init.shared::cta.b64
-    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.arrive.relaxed {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
     // CHECK: nvvm.mapa
     ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
@@ -34,7 +34,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     // CHECK: mbarrier.init.shared::cta.b64
-    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.arrive.relaxed {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
     // CHECK: nvvm.mapa
     ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
@@ -68,7 +68,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     // CHECK: mbarrier.init.shared::cta.b64
-    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.arrive.relaxed {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
     // CHECK: nvvm.mapa
     ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
@@ -107,7 +107,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     %2 = ttg.memdesc_index %0[%c1_i32] : !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     // CHECK: mbarrier.init.shared::cta.b64
     // CHECK: fence.mbarrier_init.release.cluster
-    // CHECK-NEXT: nvvm.cluster.arrive {aligned}
+    // CHECK-NEXT: nvvm.cluster.arrive.relaxed {aligned}
     // CHECK-NEXT: nvvm.cluster.wait {aligned}
     // CHECK: nvvm.mapa
     ttng.init_barrier %2, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
@@ -147,7 +147,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     // The second init is for a local-only barrier, but cluster sync should
     // still be placed after it (i.e., after the last init).
     // CHECK: mbarrier.init.shared::cta.b64
-    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.arrive.relaxed {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
     // CHECK: nvvm.mapa
     ttng.init_barrier %2, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
@@ -231,7 +231,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     // CHECK: mbarrier.init.shared::cta.b64
-    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.arrive.relaxed {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
     // CHECK: nvvm.mapa
     ttng.init_barrier %1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
@@ -276,7 +276,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     // CHECK: mbarrier.init.shared::cta.b64
-    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.arrive.relaxed {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
     // CHECK: clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all
     ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
@@ -301,7 +301,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     // CHECK: mbarrier.init.shared::cta.b64
-    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.arrive.relaxed {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
     // CHECK: cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster
     ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
@@ -367,7 +367,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
     %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable> -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
     // CHECK: mbarrier.init.shared::cta.b64
-    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.arrive.relaxed {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
     // CHECK: tcgen05.cp
     ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
@@ -423,7 +423,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     // CHECK: mbarrier.init.shared::cta.b64
     ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
     // CHECK: mbarrier.init.shared::cta.b64
-    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.arrive.relaxed {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
     // CHECK: tcgen05.mma
     ttng.init_barrier %2, 1 : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
@@ -489,7 +489,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
     %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable> -> !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
     // CHECK: mbarrier.init.shared::cta.b64
-    // CHECK: nvvm.cluster.arrive {aligned}
+    // CHECK: nvvm.cluster.arrive.relaxed {aligned}
     // CHECK: nvvm.cluster.wait {aligned}
     // CHECK: tcgen05.mma
     ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared_bar, #ttg.shared_memory, mutable>
@@ -551,7 +551,7 @@ module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "
   // CHECK-LABEL: @reorder_multiple_bar_inits_before_tcgen5_alloc
   // CHECK: mbarrier.init.shared::cta.b64
   // CHECK: mbarrier.init.shared::cta.b64
-  // CHECK: nvvm.cluster.arrive {aligned}
+  // CHECK: nvvm.cluster.arrive.relaxed {aligned}
   // CHECK: nvvm.cluster.wait {aligned}
   // CHECK: ttng.tcgen5_global_alloc
   tt.func public @reorder_multiple_bar_inits_before_tcgen5_alloc() attributes {noinline = false} {

--- a/test/TLX/tcgen5_global_alloc_lowering.mlir
+++ b/test/TLX/tcgen5_global_alloc_lowering.mlir
@@ -15,7 +15,7 @@
 module attributes {tlx.enable_paired_cta_mma = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.tensor_memory_size" = 128 : i32} {
   // CHECK-LABEL: @tcgen5_global_alloc_lowering
   // CHECK: mbarrier.init.shared::cta.b64
-  // CHECK: nvvm.cluster.arrive {aligned}
+  // CHECK: nvvm.cluster.arrive.relaxed {aligned}
   // CHECK: nvvm.cluster.wait {aligned}
   // CHECK: tcgen05.alloc.cta_group::2
   // CHECK: nvvm.barrier

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -585,10 +585,14 @@ void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, size_t size, Value pred,
       // even in WS mode because the WS lowering inserts matching cluster
       // arrives for the non-default warps right before their warp_return
       // (gated by the cluster_sync_kernel_cleanup mod attr set below).
-      NVVM::ClusterArriveOp::create(b, loc, UnitAttr::get(ctx));
-      NVVM::ClusterWaitOp::create(b, loc, UnitAttr::get(ctx));
-      // mark mod attr so that WS lowering is aware of this cluster sync point
-      tlx::setClusterSyncKernelCleanupOnMod(func, true);
+      if (!tlx::hasUserPostWsSync(func)) {
+        // if user declares they'll handle the post WS sync, compiler skips it.
+        // Otherwise, compiler inserts a cluster sync here
+        NVVM::ClusterArriveOp::create(b, loc, UnitAttr::get(ctx));
+        NVVM::ClusterWaitOp::create(b, loc, UnitAttr::get(ctx));
+        // mark mod attr so that WS lowering is aware of this cluster sync point
+        tlx::setClusterSyncKernelCleanupOnMod(func, true);
+      }
     } else if (twoCTAs && !hasWarpSpecialize) {
       NVVM::ClusterArriveOp::create(b, loc, UnitAttr::get(ctx));
       NVVM::ClusterWaitOp::create(b, loc, UnitAttr::get(ctx));

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -190,7 +190,7 @@ static LogicalResult lowerWarpSpecialize(LLVM::LLVMFuncOp func,
     // predicate here to select only non default warps
     PTXBuilder ptxBuilder;
     auto clusterArriveOp =
-        *ptxBuilder.create("@!$0 barrier.cluster.arrive.aligned;");
+        *ptxBuilder.create("@!$0 barrier.cluster.arrive.relaxed.aligned;");
     clusterArriveOp({ptxBuilder.newOperand(isDefault, "b")},
                     /*onlyAttachMLIRArgs=*/true);
     auto voidTy = void_ty(ctx);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -481,7 +481,7 @@ private:
     // CTA_Y's bar before CTA_Y inits it, as shown in ptx doc examples:
     // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-test-wait-try-wait
     ttng::ClusterArriveOp::create(builder, lastBarInitOp.getLoc(),
-                                  /*relaxed*/ false);
+                                  /*relaxed*/ true);
     ttng::ClusterWaitOp::create(builder, lastBarInitOp.getLoc());
     // mark mod attr so that WS lowering is aware of this cluster sync point
     tlx::setClusterSyncKernelInitOnMod(mod, true);

--- a/third_party/tlx/dialect/include/IR/Dialect.h
+++ b/third_party/tlx/dialect/include/IR/Dialect.h
@@ -35,6 +35,7 @@ constexpr static char AttrClusterSyncKernelInitName[] =
     "tlx.cluster_sync_kernel_init";
 constexpr static char AttrClusterSyncKernelCleanupName[] =
     "tlx.cluster_sync_kernel_cleanup";
+constexpr static char AttrUserPostWsSyncName[] = "tlx.user_post_ws_sync";
 
 bool tlxEnablePairedMMA(Operation *op);
 
@@ -54,6 +55,13 @@ void setClusterSyncKernelInitOnMod(Operation *op, bool value);
 
 bool hasClusterSyncKernelCleanup(Operation *op);
 void setClusterSyncKernelCleanupOnMod(Operation *op, bool value);
+
+// `tlx.user_post_ws_sync`: the user provides the post-warp-specialize sync, so
+// the compiler should skip the auto cluster arrive/wait before TMEM dealloc.
+// Propagated from `tlx.async_tasks(no_ending_cluster_sync=True)` in the Fixup
+// pass.
+bool hasUserPostWsSync(Operation *op);
+void setUserPostWsSyncOnMod(Operation *op, bool value);
 
 // Returns true if the kernel uses clusters (clusterDims product > 1).
 // Subsumes tlxEnablePairedMMA: paired CTA MMA always implies clustering.

--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -383,6 +383,25 @@ void mlir::triton::tlx::setClusterSyncKernelCleanupOnMod(Operation *op,
                   BoolAttr::get(module->getContext(), value));
 }
 
+bool mlir::triton::tlx::hasUserPostWsSync(Operation *op) {
+  assert(op != nullptr &&
+         "expecting nonnull op for checking user post-WS sync");
+  auto module = getModuleOp(op);
+  assert(module != nullptr && "expecting op nested in a module for checking "
+                              "user post-WS sync marker");
+  auto attr = module->getAttrOfType<BoolAttr>(AttrUserPostWsSyncName);
+  return attr != nullptr && attr.getValue();
+}
+
+void mlir::triton::tlx::setUserPostWsSyncOnMod(Operation *op, bool value) {
+  assert(op != nullptr && "expecting nonnull op for setting user post-WS sync");
+  auto module = getModuleOp(op);
+  assert(module != nullptr && "expecting op nested in a module for setting "
+                              "user post-WS sync marker");
+  module->setAttr(AttrUserPostWsSyncName,
+                  BoolAttr::get(module->getContext(), value));
+}
+
 bool mlir::triton::tlx::tlxIsClustered(Operation *op) {
   assert(op != nullptr && "expecting nonnull op for checking cluster dims");
   auto moduleOp = getModuleOp(op);

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -221,10 +221,13 @@ public:
     if (!isAMD()) {
       int numWarpSpecializeOps = 0;
       bool hasExclusiveWS = false;
+      bool hasNoEndingClusterSync = false;
       mod.walk([&](ttg::WarpSpecializeOp op) {
         ++numWarpSpecializeOps;
         if (op->hasAttr("tlx.exclusive"))
           hasExclusiveWS = true;
+        if (op->hasAttr("tlx.no_ending_cluster_sync"))
+          hasNoEndingClusterSync = true;
       });
       if (hasExclusiveWS) {
         if (numWarpSpecializeOps != 1) {
@@ -236,6 +239,11 @@ public:
         }
         ttg::setHasSingleWarpSpecialize(mod, /*value=*/true);
       }
+      // `no_ending_cluster_sync`: the user handles the post-warp-specialize
+      // sync, so mark the module to skip the compiler's cluster arrive/wait
+      // before TMEM dealloc.
+      if (hasNoEndingClusterSync)
+        setUserPostWsSyncOnMod(mod, /*value=*/true);
     }
   }
 };

--- a/third_party/tlx/language/tlx/async_task_utils.py
+++ b/third_party/tlx/language/tlx/async_task_utils.py
@@ -49,8 +49,9 @@ class async_task:
 
 class async_tasks:
 
-    def __init__(self, *args, exclusive=False, **kwargs):
+    def __init__(self, *args, exclusive=False, no_ending_cluster_sync=False, **kwargs):
         self.exclusive = core._unwrap_if_constexpr(exclusive)
+        self.no_ending_cluster_sync = core._unwrap_if_constexpr(no_ending_cluster_sync)
 
     def __enter__(self):
         return self

--- a/third_party/tlx/language/tlx/compiler/code_generator.py
+++ b/third_party/tlx/language/tlx/compiler/code_generator.py
@@ -162,14 +162,18 @@ def visit_withAsyncTasks(self, node):
     from triton.compiler.code_generator import enter_sub_region, _is_list_like, _is_constexpr
     from triton.language.core import _unwrap_if_constexpr
 
-    # `tlx.async_tasks(exclusive=...)` marks the sole warp_specialize for the
-    # lower-overhead lowering; the Fixup pass reads it and validates that the
-    # module then contains exactly one warp_specialize op.
+    # `tlx.async_tasks(exclusive=..., no_ending_cluster_sync=...)`: mark the
+    # warp_specialize op so the Fixup pass can propagate these to module
+    # attributes (`exclusive` -> single-warp-specialize lowering;
+    # `no_ending_cluster_sync` -> user provides the post-WS sync).
     ws_context = node.items[0].context_expr
     exclusive = False
+    no_ending_cluster_sync = False
     for kw in getattr(ws_context, "keywords", []):
         if kw.arg == "exclusive":
             exclusive = bool(_unwrap_if_constexpr(self.visit(kw.value)))
+        elif kw.arg == "no_ending_cluster_sync":
+            no_ending_cluster_sync = bool(_unwrap_if_constexpr(self.visit(kw.value)))
 
     with enter_sub_region(self) as sr:
         liveins, _ = sr
@@ -283,6 +287,8 @@ def visit_withAsyncTasks(self, node):
         )
         if exclusive:
             ws_op.set_attr("tlx.exclusive", self.builder.get_unit_attr())
+        if no_ending_cluster_sync:
+            ws_op.set_attr("tlx.no_ending_cluster_sync", self.builder.get_unit_attr())
 
         # dry visit async task body to calculate captures
         index = 0


### PR DESCRIPTION
See https://github.com/facebookexperimental/triton/pull/2054 for a visual about the control flows.

TLX compiler inserts cluster sync at two places:
- Between mbarrier init and TMEM alloc. This is to make sure mbar init is visible to other CTAs in the cluster, and also make sure both CTAs are alive before performing 2cta TMEM alloc.
- Before TMEM de-alloc. This is to make sure all cross CTA SMEM/TMEM accesses are done/issued, before one of the CTAs exits.

A cluster barrier arrive op with release semantics will ensure cluster level visibility for memory ops before it. This might cause unnecessary flushing of data into L2 cache. 

For the kernel start cluster sync, we only need it to ensure mbar init visibility and ensure both CTAs alive before TMEM alloc (execution order enforcement), so a dedicated mbar init fence + relaxed cluster barrier arrive would suffice, which helps avoid some unnecessary flushing. This is the standard way to do it in cutlass: https://github.com/NVIDIA/cutlass/blob/0d2b201e8c1c4a03efa6e9c468161916e2334725/examples/88_hopper_fmha/kernel/fmha_kernel_tma_warpspecialized.hpp#L274-L284, and the fence was already added in https://github.com/facebookexperimental/triton/pull/1240.

For the kernel end cluster sync, we generate it to be a safe guard for kernels where users do not wait for all mem ops before exiting the kernels. Without the sync, kernel could hang at tmem de-alloc. However, there're some kernels where users use proper named barriers or mbarriers to guarantee the completion of memory ops before WS op exits, which then renders the cluster sync unnecessary. We provide a WS op arg for users to declare their guarantee for proper syncs, which will then prevent compiler from generating the kernel end cluster sync. This is by opt-in and requires users make informed decisions.

## Perf
On GB200 run the FA4 bwd 2cta main kernel `_attn_bwd_ws` with ncu `third_party/tlx/tutorials/testing/test_correctness.py::test_blackwell_fa_ws_pipelined_persistent_bwd`

`B=4, H=48, Seq=1024, D=128`
- Baseline: 457 us
- Then \+ https://github.com/facebookexperimental/triton/pull/2054 for less WS overhead: 443 us
- Then \+ this PR w/o `no_ending_cluster_sync`: 433 us (+5.5% tflops in total)
- Then \+ `no_ending_cluster_sync=True`: 426 us


`B=4, H=48, Seq=8192, D=128`
- Baseline: 17.17 ms
- Then \+ https://github.com/facebookexperimental/triton/pull/2054 for less WS overhead: 17.04 ms
- Then \+ this PR w/o `no_ending_cluster_sync`: 16.97 ms (+1.2% tflops in total)
- Then \+ `no_ending_cluster_sync=True`: 16.92 ms. Note this is potentially buggy because in a later commit where I removed mbar inval ops this run would error. I think it's likely the kernel has trailing unfinished memory ops so cannot use this flag.
