### PR TITLE
[Triton] [TLX] Add support for 256 bit loads with proper alignment.

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/CoalesceUtils.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/CoalesceUtils.h
@@ -7,11 +7,10 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 namespace mlir::triton::gpu {
-BlockedEncodingAttr
-buildCoalescedEncoding(ModuleAxisInfoAnalysis &axisInfoAnalysis, Operation *op,
-                       int numWarps, int threadsPerWarp,
-                       triton::gpu::CGAEncodingAttr cgaLayout,
-                       SmallVector<int64_t> shapePerCTA);
+BlockedEncodingAttr buildCoalescedEncoding(
+    ModuleAxisInfoAnalysis &axisInfoAnalysis, Operation *op, int numWarps,
+    int threadsPerWarp, triton::gpu::CGAEncodingAttr cgaLayout,
+    SmallVector<int64_t> shapePerCTA, unsigned maxVecBits = 128);
 } // namespace mlir::triton::gpu
 
 #endif // TRITON_DIALECT_TRITONGPU_TRANSFORMS_COALESCINGUTILS_H_

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -278,6 +278,11 @@ def TritonGPUCoalesce: Pass<"tritongpu-coalesce", "mlir::ModuleOp"> {
   }];
 
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect"];
+
+  let options = [
+    Option<"maxVecBits", "max-vec-bits", "unsigned", /*default*/"128",
+           "Maximum vector width in bits for load/store coalescing">
+  ];
 }
 
 

--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -50,7 +50,7 @@ unsigned getElementBitWidth(RankedTensorType type);
 unsigned
 getNumElementsPerThread(Operation *op, SmallVector<unsigned> order,
                         triton::ModuleAxisInfoAnalysis &axisInfoAnalysis,
-                        ArrayRef<int64_t> shape);
+                        ArrayRef<int64_t> shape, unsigned maxVecBits = 128);
 
 // Returns whether the op is a "view op", i.e. doesn't move any data
 bool isView(Operation *op);

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -69,6 +69,8 @@ static void pickDescriptorLoadStoreLayout(
 }
 
 struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
+  using impl::TritonGPUCoalesceBase<CoalescePass>::TritonGPUCoalesceBase;
+
   static Type getNewType(Type type, Attribute encoding) {
     RankedTensorType tensorType = cast<RankedTensorType>(type);
     return tensorType.cloneWithEncoding(encoding);
@@ -136,9 +138,9 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
         auto tensorType = cast<RankedTensorType>(ptr.getType());
         CGAEncodingAttr cgaLayout = getCGALayout(tensorType.getEncoding());
         SmallVector<int64_t> shapePerCTA = getShapePerCTA(tensorType);
-        auto layout =
-            buildCoalescedEncoding(axisInfoAnalysis, curr, numWarps,
-                                   threadsPerWarp, cgaLayout, shapePerCTA);
+        auto layout = buildCoalescedEncoding(axisInfoAnalysis, curr, numWarps,
+                                             threadsPerWarp, cgaLayout,
+                                             shapePerCTA, maxVecBits);
         layoutMap[curr] = layout;
       }
     });

--- a/lib/Dialect/TritonGPU/Transforms/CoalesceAsyncCopy.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/CoalesceAsyncCopy.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/Passes.h"
 #include "triton/Analysis/AxisInfo.h"
@@ -50,25 +52,32 @@ static void retargetCopyOperandsToEncoding(
   });
 }
 
-// This pass currently only applies if the following are all true...
+// This pass currently applies in two cases.
+//
+// Case A: all of the following are true:
 //   1) Operand A for WGMMA is to be loaded in registers
 //   2) We upcast operand A in registers before the WGMMA
 //      (downcasting is not yet supported)
 //   3) Pipelining is enabled for loading A
 //
-// ...then for the AsyncCopyGlobalToLocal op, the SharedEncoding
-// vec will be less than BlockedEncoding's sizePerThread for k-dim. E.g. if
-// we're upcasting from int8 to bf16, then shared vec is 8 and sizePerThread
-// for k is 16. In this case, AsyncCopyGlobalToLocal will generate two
-// 8-byte-cp.async's for each contiguous 16B global data owned by each
-// thread. This breaks coalescing (i.e. results 2x the minimum required
-// transactions).
+// In this case, the AsyncCopyGlobalToLocal op's SharedEncoding vec is smaller
+// than the BlockedEncoding sizePerThread for the k dimension. For example, when
+// upcasting from int8 to bf16, the shared vec is 8 and sizePerThread for k is
+// 16. AsyncCopyGlobalToLocal then generates two 8-byte cp.async operations for
+// each contiguous 16B global-data chunk owned by a thread, which breaks
+// coalescing and doubles the minimum required transactions.
 //
 // This issue occurs for cp.async because it combines load and store into one
-// instruction. The fix is to clip each dim of sizePerThread by shared vec, so
-// that the vectorization of load and store are equal along the contiguous
-// dimension. In the above example, each thread will then only own 8B contiguous
-// global data.
+// instruction. Additionally, cp.async only supports copy sizes up to 16B. The
+// fix is to clip each dim of sizePerThread by shared vec and the cp.async copy
+// size limit, so that the vectorization of load and store are equal along the
+// contiguous dimension. In the above example, each thread will then only own 8B
+// contiguous global data.
+//
+// Case B: user hints or analysis can infer alignment that allows 256-bit
+// vectorized load/store operations for regular instructions. In that case,
+// sizePerThread may exceed the 128-bit cp.async hardware limit and break
+// coalescing. Again, the fix is to cap sizePerThread.
 struct ClipAsyncCopySizePerThread
     : public OpRewritePattern<AsyncCopyGlobalToLocalOp> {
   ModuleAxisInfoAnalysis &axisInfoAnalysis;
@@ -104,8 +113,11 @@ struct ClipAsyncCopySizePerThread
     // (see AsyncCopyGlobalToLocalOpConversion)
     LinearLayout regLayout = triton::gpu::toLinearLayout(srcTy);
     LinearLayout sharedLayout = triton::gpu::toLinearLayout(dstTy);
-    auto copyContigSize =
+    unsigned copyContigSize =
         regLayout.invertAndCompose(sharedLayout).getNumConsecutiveInOut();
+    unsigned cpAsyncContigSize =
+        std::max(1u, 128u / dstTy.getElementTypeBitWidth());
+    copyContigSize = std::min<unsigned>(copyContigSize, cpAsyncContigSize);
 
     // obtain block sizePerThread along contig dim
     auto contigPerThread = getContigPerThread(srcTy);
@@ -211,9 +223,9 @@ struct CoalesceAsyncCopyPass
     MLIRContext *context = &getContext();
 
     mlir::RewritePatternSet patterns(context);
-    patterns.add<ClipAsyncCopySizePerThread>(axisInfoAnalysis, context);
     patterns.add<CoalesceCheapAsyncCopyGlobalToLocal>(
         axisInfoAnalysis, coalescedAsyncCopyMap, context);
+    patterns.add<ClipAsyncCopySizePerThread>(axisInfoAnalysis, context);
 
     if (failed(applyPatternsGreedily(m, std::move(patterns))))
       signalPassFailure();

--- a/lib/Dialect/TritonGPU/Transforms/CoalesceUtils.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/CoalesceUtils.cpp
@@ -17,7 +17,7 @@ BlockedEncodingAttr
 buildCoalescedEncoding(ModuleAxisInfoAnalysis &axisInfoAnalysis, Operation *op,
                        int numWarps, int threadsPerWarp,
                        triton::gpu::CGAEncodingAttr cgaLayout,
-                       SmallVector<int64_t> shapePerCTA) {
+                       SmallVector<int64_t> shapePerCTA, unsigned maxVecBits) {
   Value ptr = getMemAccessPtr(op);
   auto refTensorType = cast<RankedTensorType>(ptr.getType());
 
@@ -60,15 +60,15 @@ buildCoalescedEncoding(ModuleAxisInfoAnalysis &axisInfoAnalysis, Operation *op,
   int numElems = product<int64_t>(shapePerCTA);
   int numThreads = numWarps * threadsPerWarp;
 
-  unsigned perThread =
-      getNumElementsPerThread(op, order, axisInfoAnalysis, shapePerCTA);
+  unsigned perThread = getNumElementsPerThread(op, order, axisInfoAnalysis,
+                                               shapePerCTA, maxVecBits);
   LDBG("perThread for op: " << perThread);
 
   for (Operation *opSameOrder : memAccessesSameOrder) {
     if (opSameOrder == op)
       continue;
     unsigned currPerThread = getNumElementsPerThread(
-        opSameOrder, order, axisInfoAnalysis, shapePerCTA);
+        opSameOrder, order, axisInfoAnalysis, shapePerCTA, maxVecBits);
     LDBG("perThread for opSameOrder: " << currPerThread);
     perThread = std::max(perThread, currPerThread);
   }
@@ -78,14 +78,14 @@ buildCoalescedEncoding(ModuleAxisInfoAnalysis &axisInfoAnalysis, Operation *op,
 
   if (!dyn_cast<triton::LoadOp>(op)) {
     // For ops that can result in a global memory write, we should enforce
-    // that each thread handles at most 128 bits, which is the widest
+    // that each thread handles at most maxVecBits bits, which is the widest
     // available vectorized store op; otherwise, the store will have "gaps"
     // in the memory write at the warp level, resulting in worse performance.
     // For loads, we can expect that the gaps won't matter due to the L1
     // cache.
     perThread = std::min<int>(
-        perThread,
-        getNumElementsPerThread(op, order, axisInfoAnalysis, shapePerCTA));
+        perThread, getNumElementsPerThread(op, order, axisInfoAnalysis,
+                                           shapePerCTA, maxVecBits));
   }
   SmallVector<unsigned> sizePerThread(refTensorType.getRank(), 1);
   sizePerThread[order[0]] = perThread;

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -161,11 +161,11 @@ getAtomicWriteElementsPerThreadCap(Operation *op) {
   return std::nullopt;
 }
 
-static unsigned getMaxElementsPerThread(Operation *op) {
+static unsigned getMaxElementsPerThread(Operation *op, unsigned maxVecBits) {
   Value val = getMemAccessPtr(op);
   auto ty = cast<RankedTensorType>(val.getType());
   unsigned elemNumBits = getElementBitWidth(ty);
-  unsigned maxElementsPerThread = 128 / elemNumBits;
+  unsigned maxElementsPerThread = maxVecBits / elemNumBits;
   // Some atomic lowerings are narrower than a plain store. TTGIR currently
   // exposes the target architecture but not the PTX version, so we only cap
   // cases that are unambiguous from the available target metadata and the
@@ -178,7 +178,8 @@ static unsigned getMaxElementsPerThread(Operation *op) {
 
 unsigned getNumElementsPerThread(Operation *op, SmallVector<unsigned> order,
                                  ModuleAxisInfoAnalysis &axisInfoAnalysis,
-                                 ArrayRef<int64_t> shapePerCTA) {
+                                 ArrayRef<int64_t> shapePerCTA,
+                                 unsigned maxVecBits) {
   Value val = getMemAccessPtr(op);
   auto ty = cast<RankedTensorType>(val.getType());
   AxisInfo &valInfo = *axisInfoAnalysis.getAxisInfo(val);
@@ -189,7 +190,7 @@ unsigned getNumElementsPerThread(Operation *op, SmallVector<unsigned> order,
   unsigned maxContig =
       std::min(valInfo.getContiguity(order[0]), shapePerCTA[order[0]]);
   unsigned alignment = std::min(maxMultiple, maxContig);
-  unsigned maxElementsPerThread = getMaxElementsPerThread(op);
+  unsigned maxElementsPerThread = getMaxElementsPerThread(op, maxVecBits);
   unsigned currPerThread = std::min(alignment, maxElementsPerThread);
   LDBG("elemNumBytes: " << elemNumBytes
                         << ", divisibility: " << maxMultipleBytes

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -57,7 +57,7 @@ void init_triton_passes_ttgpuir(py::module &&m) {
   using namespace mlir;
   using namespace mlir::triton::gpu;
   using namespace mlir::triton::instrument;
-  ADD_PASS_WRAPPER_0("add_coalesce", createTritonGPUCoalesce);
+  ADD_PASS_OPTION_WRAPPER_1("add_coalesce", createTritonGPUCoalesce, unsigned);
   ADD_PASS_WRAPPER_0("add_optimize_thread_locality",
                      createTritonGPUOptimizeThreadLocality);
   ADD_PASS_OPTION_WRAPPER_1("add_hoist_tmem_alloc",

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5359,6 +5359,87 @@ def test_vectorization_hints(has_hints, device):
         assert "ld.global.v4.b32" not in ptx
 
 
+def _ptx_version(ptx):
+    match = re.search(r"^\.version\s+(\d+)\.(\d+)", ptx, re.MULTILINE)
+    assert match is not None, "PTX is missing a .version directive"
+    return int(match.group(1)), int(match.group(2))
+
+
+def _ptx_global_access_widths(ptx, op):
+    widths = []
+    for match in re.finditer(rf"\b{op}\.global(?:\.[a-zA-Z0-9_:]+)*?(?:\.v(?P<count>\d+))?\.b(?P<bits>\d+)\b", ptx):
+        widths.append(int(match.group("count") or 1) * int(match.group("bits")))
+    return widths
+
+
+@triton.jit
+def _softmax_vectorization_kernel(output_ptr, input_ptr, input_row_stride, output_row_stride, n_rows, n_cols,
+                                  BLOCK_SIZE: tl.constexpr, num_stages: tl.constexpr, MAX_DIVISIBILITY: tl.constexpr):
+    row_start = tl.program_id(0)
+    row_step = tl.num_programs(0)
+    for row_idx in tl.range(row_start, n_rows, row_step, num_stages=num_stages):
+        col_offsets = tl.arange(0, BLOCK_SIZE)
+        row_start_ptr = input_ptr + row_idx * input_row_stride
+        input_ptrs = row_start_ptr + col_offsets
+        if MAX_DIVISIBILITY > 1:
+            n_cols = tl.multiple_of(n_cols, MAX_DIVISIBILITY)
+            input_ptrs = tl.max_contiguous(tl.multiple_of(input_ptrs, MAX_DIVISIBILITY), MAX_DIVISIBILITY)
+        mask = col_offsets < n_cols
+        row = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+        row = row - tl.max(row, axis=0)
+        numerator = tl.exp(row)
+        softmax_output = numerator / tl.sum(numerator, axis=0)
+        output_ptrs = output_ptr + row_idx * output_row_stride + col_offsets
+        if MAX_DIVISIBILITY > 1:
+            output_ptrs = tl.max_contiguous(tl.multiple_of(output_ptrs, MAX_DIVISIBILITY), MAX_DIVISIBILITY)
+        tl.store(output_ptrs, softmax_output, mask=mask)
+
+
+@pytest.mark.parametrize("n_cols", [1152, 4096])
+def test_softmax_vectorization_correctness(n_cols, device):
+    if not is_cuda():
+        pytest.skip("Requires CUDA")
+    if torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("Requires Blackwell")
+
+    torch.manual_seed(0)
+    n_rows = 32
+    x = torch.randn((n_rows, n_cols), device=device, dtype=torch.float32)
+    expected = torch.softmax(x, dim=1)
+    cases = [
+        ("triton-128", 16, 1),
+        ("triton-256", 32, 1),
+        ("triton-128-pipelined", 16, 4),
+    ]
+
+    for provider, max_divisibility, num_stages in cases:
+        y = torch.empty_like(x)
+        pgm = _softmax_vectorization_kernel[(n_rows, )](
+            y,
+            x,
+            x.stride(0),
+            y.stride(0),
+            n_rows,
+            n_cols,
+            BLOCK_SIZE=triton.next_power_of_2(n_cols),
+            num_stages=num_stages,
+            MAX_DIVISIBILITY=max_divisibility,
+            num_warps=8,
+        )
+        torch.testing.assert_close(y, expected, rtol=1e-4, atol=1e-6, msg=provider)
+        ptx = pgm.asm["ptx"]
+        assert ".target sm_100" in ptx, provider
+        if num_stages == 1:
+            assert "cp.async" not in ptx, provider
+            expected_width = 256 if provider == "triton-256" and _ptx_version(ptx) >= (8, 8) else 128
+            assert expected_width in _ptx_global_access_widths(ptx, "ld"), provider
+            assert expected_width in _ptx_global_access_widths(ptx, "st"), provider
+        else:
+            assert "cp.async.cg.shared.global" in ptx, provider
+            assert "cp.async.wait_group" in ptx, provider
+            assert 128 in _ptx_global_access_widths(ptx, "st"), provider
+
+
 @pytest.mark.interpreter
 def test_assume(device):
 

--- a/test/TLX/user-register-layout.mlir
+++ b/test/TLX/user-register-layout.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt -split-input-file -tritongpu-coalesce %s | FileCheck %s
+// RUN: triton-opt -split-input-file -tritongpu-coalesce='max-vec-bits=256' --tlx-propagate-layout %s | FileCheck %s
 
 // A user-pinned *register* layout on a local_load (#tlx.user_layout carrying
 // PinnedEncodingTrait) must not be coalesced to a "full contiguity" blocked
@@ -19,5 +19,37 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32,
     // CHECK: ttg.local_load {{.*}} -> tensor<128x128xf16, #[[$USER]]>
     %y = ttg.local_load %buf : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16, #user>
     tt.return %y : tensor<128x128xf16, #user>
+  }
+}
+
+// -----
+
+// Blackwell's 256-bit vector width applies to global memory coalescing, not
+// shared-memory local loads. TLX layout propagation runs after coalescing and
+// must preserve both choices.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+// CHECK-DAG: #[[$GLOBAL:.*]] = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+// CHECK-DAG: #[[$LOCAL:.*]] = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: @blackwell_global_and_local_vector_widths
+  tt.func @blackwell_global_and_local_vector_widths(
+      %ptr: !tt.ptr<f32> {tt.divisibility = 32 : i32},
+      %buf: !ttg.memdesc<1024xf32, #shared, #smem, mutable>)
+      -> (tensor<1024xf32, #blocked>, tensor<1024xf32, #blocked>) {
+    %range = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+    %ptrs = tt.splat %ptr : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+    %offsets = tt.addptr %ptrs, %range : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked>
+    // CHECK: tt.load {{.*}} : tensor<1024x!tt.ptr<f32>, #[[$GLOBAL]]>
+    %global = tt.load %offsets : tensor<1024x!tt.ptr<f32>, #blocked>
+    // Force tlx-propagate-layout to run; the identity constraint is removed.
+    // CHECK-NOT: tlx.require_layout
+    %required = tlx.require_layout %global : tensor<1024xf32, #blocked> -> tensor<1024xf32, #blocked>
+    // CHECK: ttg.local_load {{.*}} -> tensor<1024xf32, #[[$LOCAL]]>
+    %local = ttg.local_load %buf : !ttg.memdesc<1024xf32, #shared, #smem, mutable> -> tensor<1024xf32, #blocked>
+    tt.return %required, %local : tensor<1024xf32, #blocked>, tensor<1024xf32, #blocked>
   }
 }

--- a/test/TritonGPU/coalesce-256bit.mlir
+++ b/test/TritonGPU/coalesce-256bit.mlir
@@ -1,0 +1,88 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-coalesce='max-vec-bits=256' | FileCheck --check-prefix=VEC256 %s
+// RUN: triton-opt %s -split-input-file -tritongpu-coalesce='max-vec-bits=128' | FileCheck --check-prefix=VEC128 %s
+
+// Test that max-vec-bits=256 allows sizePerThread=8 for f32 loads with sufficient divisibility.
+// With divisibility=32 and f32 (4 bytes): alignment = min(32/4, 1024) = 8
+// With max-vec-bits=128: min(8, 128/32) = 4 -> sizePerThread=4
+// With max-vec-bits=256: min(8, 256/32) = 8 -> sizePerThread=8
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+
+// VEC256: [[LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+// VEC128: [[LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+tt.func public @coalesce_f32_load(%arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32}, %arg1: i32) {
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c1024_i32 : i32
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+    %3 = tt.splat %1 : i32 -> tensor<1024xi32, #blocked>
+    %4 = arith.addi %3, %2 : tensor<1024xi32, #blocked>
+    %5 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked>
+    %6 = tt.addptr %5, %4 : tensor<1024x!tt.ptr<f32>, #blocked>, tensor<1024xi32, #blocked>
+    // VEC256: tt.load {{.*}} : tensor<1024x!tt.ptr<f32>, [[LAYOUT]]>
+    // VEC128: tt.load {{.*}} : tensor<1024x!tt.ptr<f32>, [[LAYOUT]]>
+    %7 = tt.load %6 : tensor<1024x!tt.ptr<f32>, #blocked>
+    tt.return
+}
+
+}
+
+// -----
+
+// Test that max-vec-bits=256 allows sizePerThread=4 for f64 loads with sufficient divisibility.
+// With divisibility=32 and f64 (8 bytes): alignment = min(32/8, 1024) = 4
+// With max-vec-bits=128: min(4, 128/64) = 2 -> sizePerThread=2
+// With max-vec-bits=256: min(4, 256/64) = 4 -> sizePerThread=4
+
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+
+// VEC256: [[LAYOUT64:#.*]] = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+// VEC128: [[LAYOUT64:#.*]] = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+tt.func public @coalesce_f64_load(%arg0: !tt.ptr<f64> {tt.divisibility = 32 : i32}, %arg1: i32) {
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c1024_i32 : i32
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked1>
+    %3 = tt.splat %1 : i32 -> tensor<1024xi32, #blocked1>
+    %4 = arith.addi %3, %2 : tensor<1024xi32, #blocked1>
+    %5 = tt.splat %arg0 : !tt.ptr<f64> -> tensor<1024x!tt.ptr<f64>, #blocked1>
+    %6 = tt.addptr %5, %4 : tensor<1024x!tt.ptr<f64>, #blocked1>, tensor<1024xi32, #blocked1>
+    // VEC256: tt.load {{.*}} : tensor<1024x!tt.ptr<f64>, [[LAYOUT64]]>
+    // VEC128: tt.load {{.*}} : tensor<1024x!tt.ptr<f64>, [[LAYOUT64]]>
+    %7 = tt.load %6 : tensor<1024x!tt.ptr<f64>, #blocked1>
+    tt.return
+}
+
+}
+
+// -----
+
+// Test that max-vec-bits=256 also works for stores.
+// With divisibility=32 and f32 (4 bytes): alignment = min(32/4, 1024) = 8
+// With max-vec-bits=128: store cap min(8, 4) = 4 -> sizePerThread=4
+// With max-vec-bits=256: store cap min(8, 8) = 8 -> sizePerThread=8
+
+#blocked2 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+
+// VEC256: [[SLAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+// VEC128: [[SLAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+tt.func public @coalesce_f32_store(%arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32}, %arg1: i32) {
+    %c1024_i32 = arith.constant 1024 : i32
+    %cst = arith.constant dense<1.0> : tensor<1024xf32, #blocked2>
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c1024_i32 : i32
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked2>
+    %3 = tt.splat %1 : i32 -> tensor<1024xi32, #blocked2>
+    %4 = arith.addi %3, %2 : tensor<1024xi32, #blocked2>
+    %5 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<1024x!tt.ptr<f32>, #blocked2>
+    %6 = tt.addptr %5, %4 : tensor<1024x!tt.ptr<f32>, #blocked2>, tensor<1024xi32, #blocked2>
+    // VEC256: tt.store {{.*}} : tensor<1024x!tt.ptr<f32>, [[SLAYOUT]]>
+    // VEC128: tt.store {{.*}} : tensor<1024x!tt.ptr<f32>, [[SLAYOUT]]>
+    tt.store %6, %cst : tensor<1024x!tt.ptr<f32>, #blocked2>
+    tt.return
+}
+
+}

--- a/test/TritonGPU/coalesce-async-copy.mlir
+++ b/test/TritonGPU/coalesce-async-copy.mlir
@@ -57,3 +57,39 @@ tt.func @async_copy_i32_small(%input: tensor<64x!tt.ptr<i32>, #blocked_small>,
   tt.return
 }
 }
+
+// -----
+
+// CHECK: #[[F32_CP_ASYNC_BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+// CHECK: %{{.*}} = ttg.convert_layout %{{.*}} : {{.*}} -> tensor<1024x!tt.ptr<f32>, #[[F32_CP_ASYNC_BLOCKED]]>
+// CHECK: %{{.*}} = ttg.async_copy_global_to_local %{{.*}}: tensor<1024x!tt.ptr<f32>, #[[F32_CP_ASYNC_BLOCKED]]>
+#blocked_f32_256b = #ttg.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared_f32_256b = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+tt.func @async_copy_f32_clips_to_cp_async_limit(%input: tensor<1024x!tt.ptr<f32>, #blocked_f32_256b>,
+    %view: !ttg.memdesc<1024xf32, #shared_f32_256b, #smem, mutable>) {
+  %token = ttg.async_copy_global_to_local %input, %view
+      : tensor<1024x!tt.ptr<f32>, #blocked_f32_256b> -> <1024xf32, #shared_f32_256b, #smem, mutable>
+  tt.return
+}
+}
+
+// -----
+
+// CHECK: #[[F64_CP_ASYNC_BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+// CHECK: %{{.*}} = ttg.convert_layout %{{.*}} : {{.*}} -> tensor<1024x!tt.ptr<f64>, #[[F64_CP_ASYNC_BLOCKED]]>
+// CHECK: %{{.*}} = ttg.async_copy_global_to_local %{{.*}}: tensor<1024x!tt.ptr<f64>, #[[F64_CP_ASYNC_BLOCKED]]>
+#blocked_f64_256b = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared_f64_256b = #ttg.swizzled_shared<{vec = 4, perPhase = 1, maxPhase = 8, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+tt.func @async_copy_f64_clips_to_cp_async_limit(%input: tensor<1024x!tt.ptr<f64>, #blocked_f64_256b>,
+    %view: !ttg.memdesc<1024xf64, #shared_f64_256b, #smem, mutable>) {
+  %token = ttg.async_copy_global_to_local %input, %view
+      : tensor<1024x!tt.ptr<f64>, #blocked_f64_256b> -> <1024xf64, #shared_f64_256b, #smem, mutable>
+  tt.return
+}
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -252,7 +252,7 @@ class HIPBackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         emuTF32 = False
-        passes.ttgpuir.add_coalesce(pm)
+        passes.ttgpuir.add_coalesce(pm, 128)
         if knobs.amd.use_buffer_ops:
             amd.passes.ttgpuir.add_coalesce_buffer_ops(pm)
             passes.ttgpuir.add_remove_layout_conversions(pm, 0)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -804,7 +804,9 @@ class CUDABackend(BaseBackend):
                 and opt.ctas_per_cga is not None):
             nvidia.passes.ttnvgpuir.add_check_matmul_two_cta(pm)
         # optimize TTGIR
-        passes.ttgpuir.add_coalesce(pm)
+        ptx_version = get_ptx_version_from_options(opt, capability)
+        max_vec_bits = 256 if capability >= 100 and ptx_version >= 88 else 128
+        passes.ttgpuir.add_coalesce(pm, max_vec_bits)
         tlx.tlx_passes.add_tlx_propagate_layout(pm)
         # Storage alias lowering runs after layout propagation so the backing
         # TMEM allocation is materialized with the resolved 2-CTA storage format.


### PR DESCRIPTION
Port the non-LLVM portions of triton-lang/triton#9671 and retain TLX-specific local-load behavior. Add coverage for coalescing, cp.async clipping, Blackwell correctness, and the TLX layout pipeline.

This depends on the kernel specifying proper alignment to enable the instruction generation. Note: I'm not including benchmarks beyond my example in the other diff. 

Authored with Claude.