### PR TITLE
[TLX] Remove unnecessary mbarrier inval ops

### DIFF
--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -444,11 +444,13 @@ private:
         minId = 0;
         maxId = operationId.size();
       }
-      // For barriers used in warp specialization (InitBarrierOp), extend
-      // liveness to the entire function. Barriers are initialized at the
-      // start and may be used across multiple sequential warp-specialized
-      // loops. Without this, two barriers in different loops could get the
-      // same allocation offset, causing corruption when both are initialized.
+      // For barriers, extend liveness to the entire function. By default,
+      // SMEM based mbarriers (on NV GPU) need to be invalidated before reusing.
+      // If bar inval op is not explicitly inserted, it should be assumed that
+      // the bar is alive until kernel end. Without this lifetime extension, a
+      // later bar could think an earlier bar was dead since the last explicit
+      // reference to it and reuse the buffer, causing corruption when
+      // performing bar init again on this mem location.
       if (hasOpOfAnyTypeInForwardSlice<ttng::InitBarrierOp>(defOp)) {
         minId = 0;
         maxId = operationId.size();

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -1133,4 +1133,41 @@ tt.func @barriers_no_warpspec() {
   ttng.wait_barrier %1, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
   tt.return
 }
+
+// A barrier before a warp_specialize op, then regular (non-barrier) SMEM after
+// it, then a second barrier before the return. Every InitBarrierOp extends its
+// buffer's liveness to the whole function, so all three buffers are disjoint:
+//   - the regular buffer (%1) cannot reuse the first barrier's slot, and
+//   - the second barrier (%2 @ offset 32) does NOT reuse the first barrier's
+//     SMEM (%0 @ offset 16)
+// Without the extension all three have non-overlapping liveness and pack into
+// offset 0 (total 17); with it they are disjoint (total 41).
+// expected-remark @below {{barrier_then_smem_with_warpspec}}
+// expected-remark @below {{size = 41}}
+// expected-remark @below {{scratch offset = 40, size = 1}}
+tt.func @barrier_then_smem_with_warpspec() {
+  %c0 = arith.constant 0 : i32
+  // expected-remark @below {{offset = 16, size = 8}}
+  %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.init_barrier %0, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.wait_barrier %0, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttg.warp_specialize()
+  default {
+    ttg.warp_yield
+  }
+  partition0() num_warps(1) {
+    ttg.warp_return
+  } : () -> ()
+  // Regular SMEM usage after the WS op (not a barrier).
+  // expected-remark @below {{offset = 0, size = 16}}
+  %1 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>
+  "use"(%1) : (!ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>) -> ()
+  // A second mbarrier before the return: its slot (offset 32) must be distinct
+  // from the first barrier's (offset 16) -- the first mbar's SMEM is not reused.
+  // expected-remark @below {{offset = 32, size = 8}}
+  %2 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.init_barrier %2, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.wait_barrier %2, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  tt.return
+}
 }

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -36,6 +36,7 @@
 #PARTITIONED_SHARED_PADDED = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 1, partitionDim = 1, partitionLayout = #PADDED_SHARED_0_16x32}>
 
 #smem = #ttg.shared_memory
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 
@@ -1111,6 +1112,25 @@ tt.func @partitioned_shared_padded_alloc() {
   // expected-remark @below {{offset = 2112, size = 1052}}
   // expected-remark @below {{offset = 3168, size = 1052}}
   %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_SHARED_PADDED, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// Two mbarriers with non-overlapping SSA liveness and NO warp_specialize. Each
+// has an InitBarrierOp in its forward slice, so the SMEM allocator extends both
+// to the whole function -> they must get DISTINCT offsets, unlike plain buffers
+// which reuse the slot (cf. @nonoverlapping_liveness_in_default_region above).
+// expected-remark @below {{barriers_no_warpspec}}
+// expected-remark @below {{size = 24}}
+tt.func @barriers_no_warpspec() {
+  %c0 = arith.constant 0 : i32
+  // expected-remark @below {{offset = 0, size = 8}}
+  %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.init_barrier %0, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.wait_barrier %0, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  // expected-remark @below {{offset = 16, size = 8}}
+  %1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.wait_barrier %1, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
   tt.return
 }
 }

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -84,46 +84,6 @@ public:
     return success();
   }
 
-  LogicalResult insertInvalBarrier(ModuleOp &mod) {
-    auto hasInvalBarrierOp = mod.walk([&](Operation *op) {
-                                  if (isa<ttng::InvalBarrierOp>(op)) {
-                                    return WalkResult::interrupt();
-                                  }
-                                  return WalkResult::advance();
-                                })
-                                 .wasInterrupted();
-    if (hasInvalBarrierOp) {
-      return mod.emitError() << "InvalBarrierOp unexpectedly found. Unable to "
-                                "auto insert InvalBarrierOp.";
-    }
-
-    SetVector<triton::FuncOp> funcOps;
-    mod.walk([&](triton::FuncOp op) { funcOps.insert(op); });
-    for (auto funcOp : funcOps) {
-      DominanceInfo domInfo(funcOp);
-
-      // Find all barrier init ops in the func
-      std::vector<Value> barriers;
-      funcOp.walk(
-          [&](ttng::InitBarrierOp op) { barriers.push_back(op.getAlloc()); });
-      // todo: consider removing all the inval op that's located right before
-      // return in a later pass to save a few cycles.
-      // Insert InvalBarrierOp before returnOp of
-      // entry funcOp
-      funcOp.walk([&](triton::ReturnOp op) {
-        OpBuilder builder(op); // Insert *before* returnOp
-        Location loc = op.getLoc();
-        for (auto barrier : barriers) {
-          if (domInfo.properlyDominates(barrier, op)) {
-            ttng::InvalBarrierOp::create(builder, loc, barrier);
-          }
-        }
-      });
-    }
-
-    return success();
-  }
-
   bool isAMD() const {
     // target is set up as f"hip:{options.arch}"
     return (target.getValue().find("hip:") == 0);
@@ -149,11 +109,6 @@ public:
             .wasInterrupted();
 
     if (failed(verifyModule(mod, hasTLXTwoCTAs))) {
-      return signalPassFailure();
-    }
-
-    // InvalBarrierOp insertion is not needed for AMD
-    if (!isAMD() && failed(insertInvalBarrier(mod))) {
       return signalPassFailure();
     }
 


### PR DESCRIPTION
In Fixup pass we insert mbar inval ops to the kernel end such that the lifetime of the mbarriers are extended to that point and the SMEM won't be reused. This in fact has been done more properly by https://github.com/facebookexperimental/triton/pull/861

Since the inval happens at kernel end, it's in fact not needed eventually for the kernel to run. It's not required to invalidate mbar if the memory location is not going to be reused in the same kernel.

Looking at ncu profiles the cost of these inval ops might be noticeable when the number of mbars gets larger.

In this PR, we just remove the redundant inval mbar ops inserted by Fixup pass, and add a lit test to make sure SMEM allocation works.

## Perf
On top of https://github.com/facebookexperimental/triton/pull/2146, check FA4 bwd 2cta with ncu. 

Net improvements from this PR:
`B=4, H=48, Seq=1024, D=128`: 433 us -> 423 us (+2.4% tflops)
`B=4, H=48, Seq=8192, D=128`:  16.97 ms -> 16.91 ms (+0.4% tflops)

Test plan: added lit tests and `pytest python/test/unit/language/test_tlx_barriers.py::test_barrier_live_range` 