### PR TITLE
[TLX][AMD] Preserve tokenless async_wait counts in updateWaits

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
@@ -111,8 +111,12 @@ static int minNumInterleavedCommitOps(Operation *waitOp) {
     return 0;
   };
 
+  // For AsyncWaitOp ops that do not come with a token to track the specific
+  // copy group, respect the original pending number. Such case is most likely
+  // from user code. The compiler should not generate a non-zero pending number
+  // if it does not know exactly which group to track.
   if (waitOp->getNumOperands() == 0)
-    return 0;
+    return cast<ttg::AsyncWaitOp>(waitOp).getNum();
 
   // Multi-token waits: take the min of minOverHistories across operands. Both
   // the captured `minCommitNumber` and the returned bailout-0s are folded in.

--- a/test/TritonGPU/amd/amd-pipeline-asyncmark-wait-num.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-asyncmark-wait-num.mlir
@@ -58,3 +58,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return %result : tensor<16x32xf32, #mma>
   }
 }
+
+// -----
+
+// Complement of the cases above, which check that updateWaits *derives* the
+// count for pipeliner-created, token-carrying waits. A *tokenless* async_wait
+// has an author-supplied num and no token graph to analyze, so leave it as-is.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: tokenless_async_wait_preserved
+  // CHECK: ttg.async_wait {num = 5 : i32}
+  tt.func @tokenless_async_wait_preserved() {
+    ttg.async_wait {num = 5 : i32}
+    tt.return
+  }
+}


### PR DESCRIPTION
## Summary
`mlir::triton::updateWaits` (run in the AMD software-pipeliner cleanup) recomputes each `ttg.async_wait`'s pending count via `minNumInterleavedCommitOps`, which walks the async-token dependency graph. Pipeliner-created waits carry that token; hand-scheduled TLX/Gluon warp-pipeline kernels instead emit *tokenless* `ttg.async_wait {num = N}`, where `N` ("keep N committed load groups in flight so loads overlap MFMA compute") is author-authoritative. For a tokenless wait there is no token graph to analyze, so `minNumInterleavedCommitOps` took its zero-operand bailout and returned `0`, clobbering `N`. Since `UpdateAsyncWaitCount` is a no-op on asyncmark arches (CDNA3/CDNA4), that `0` lowers straight to `wait.asyncmark(0)` / `s_waitcnt vmcnt(0)` -- a full memory drain every iteration that serializes the hand-written pipeline (~2x slower).

**Fix (following Hongtao Yu's facebookexperimental/triton#179):** a wait with no token operand has no specific copy group to track, so its author-supplied `num` is authoritative. The zero-operand bailout in `minNumInterleavedCommitOps` (`lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp`) now returns the wait's existing `num` instead of `0`, so `updateWaits` leaves it unchanged. Token-carrying (pipeliner-created) waits are reconciled exactly as before, so auto-pipelined GEMM/FA kernels are unaffected.

## Test
`test/TritonGPU/amd/amd-pipeline-asyncmark-wait-num.mlir`: added a case asserting a tokenless `ttg.async_wait {num = 5}` survives the AMD pipeline pass unchanged. The token-carrying recompute path stays covered by the existing cases in the same file.

## Test plan
- [x] `lit test/TritonGPU/amd/amd-pipeline-asyncmark-wait-num.mlir`

Co-authored with @htyu (approach from facebookexperimental/triton#179).
