### PR TITLE
[triton][tlx] Propagate & auto-release user-pinned register layouts

### DIFF
--- a/include/triton/Dialect/Triton/IR/Utility.h
+++ b/include/triton/Dialect/Triton/IR/Utility.h
@@ -199,6 +199,20 @@ bool isKernel(FunctionOpInterface funcOp);
 
 unsigned getBitwidth(RankedTensorType ty);
 
+// True if `attr` is, or nests anywhere, a TLX placeholder encoding wrapper
+// (#tlx.user_layout / #tlx.no_verify_layout). These defer layout verification to
+// resolve-placeholder-layouts (make_ttgir). Detected by dialect namespace
+// (scanning the whole attribute tree) because triton core cannot depend on the
+// TLX dialect for typed isa<> checks.
+bool encodingContainsTlxPlaceholder(Attribute attr);
+
+// Peel any TLX placeholder wrapper(s) (#tlx.user_layout / #tlx.no_verify_layout,
+// which live in the "tlx" dialect and wrap a single inner layout) off the top of
+// `attr`, returning the underlying concrete encoding (or `attr` unchanged if it
+// is not tlx-wrapped). Lets a verifier check the real layout under a still-
+// unresolved placeholder instead of skipping verification entirely.
+Attribute unwrapTlxWrappers(Attribute attr);
+
 // If the value "anchor" is compared against a statically-computed bound, return
 // inclusive lower and upper bounds lb <= anchor <= ub. Depending on the
 // comparison operator, one of the bounds is a computed one while the other is

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -938,6 +938,14 @@ LogicalResult ReshapeOp::verify() {
 
   Attribute srcEnc = srcTy.getEncoding();
   Attribute dstEnc = dstTy.getEncoding();
+  // If either side carries a TLX placeholder wrapper (#tlx.user_layout /
+  // #tlx.no_verify_layout) -- at the top or nested inside a ttg encoding (e.g. a
+  // slice/expand parent) -- defer all reshape layout verification to
+  // resolve-placeholder-layouts (make_ttgir); the concrete src/dst may not be
+  // consistent yet at this point.
+  if (encodingContainsTlxPlaceholder(srcEnc) ||
+      encodingContainsTlxPlaceholder(dstEnc))
+    return success();
   if (!!srcEnc != !!dstEnc) {
     return emitError("Op requires that either (a) src and dst both have "
                      "encodings, or (b) neither does.");

--- a/lib/Dialect/Triton/IR/Traits.cpp
+++ b/lib/Dialect/Triton/IR/Traits.cpp
@@ -41,6 +41,11 @@ static LogicalResult verifySameEncoding(Type typeA, Type typeB) {
     if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
       ret = tensorType.getEncoding();
     }
+    // Peel any TLX placeholder wrapper(s) (#tlx.user_layout / no_verify) and
+    // verify the underlying concrete layout, rather than skipping verification.
+    // The wrapper itself is retired later by resolve-placeholder-layouts; a
+    // still-null inner (unresolved) is accepted by the null short-circuit below.
+    ret = triton::unwrapTlxWrappers(ret);
     return ret;
   };
   auto encodingA = getEncoding(typeA);

--- a/lib/Dialect/Triton/IR/Utility.cpp
+++ b/lib/Dialect/Triton/IR/Utility.cpp
@@ -129,3 +129,31 @@ std::optional<ConstantIntRanges> tt::getBoundFromCmpOp(arith::CmpIOp cmpOp,
   }
   return {};
 }
+
+bool tt::encodingContainsTlxPlaceholder(Attribute attr) {
+  if (!attr)
+    return false;
+  if (attr.getDialect().getNamespace() == "tlx")
+    return true;
+  bool found = false;
+  attr.walkImmediateSubElements(
+      [&](Attribute sub) { found |= tt::encodingContainsTlxPlaceholder(sub); },
+      [](Type) {});
+  return found;
+}
+
+Attribute tt::unwrapTlxWrappers(Attribute attr) {
+  while (attr && attr.getDialect().getNamespace() == "tlx") {
+    Attribute inner;
+    attr.walkImmediateSubElements(
+        [&](Attribute sub) {
+          if (!inner)
+            inner = sub;
+        },
+        [](Type) {});
+    if (!inner || inner == attr)
+      break;
+    attr = inner;
+  }
+  return attr;
+}

--- a/python/test/unit/language/test_tlx_layout.py
+++ b/python/test/unit/language/test_tlx_layout.py
@@ -66,6 +66,298 @@ def test_layout_shape_stride_maps_to_linear():
     assert _SEPARABLE_QK_LINEAR in ttgir
 
 
+@triton.jit
+def _pinned_row_max_combine(a, b):
+    return tl.maximum(a, b)
+
+
+@triton.jit
+def _pinned_add_combine(a, b):
+    return a + b
+
+
+@triton.jit
+def _pinned_fma_helper(a, b, c):
+    # A @triton.jit helper -> tt.call. When called with pinned (placeholder)
+    # args whose result is consumed downstream, TritonTLXFixup specializes the
+    # monomorphized callee (params + return + FunctionType) to the placeholder.
+    return a * b + c
+
+
+# Row-per-thread layout for a [128,128] tile with 4 warps: each thread (lane l,
+# warp w) owns row w*32+l with all 128 columns in registers (matches the HSTU
+# forward softmax kernel's pinned QK layout).
+def _row_per_thread_layout():
+    return tlx.layout(shape=((32, 4), (128, )), stride=((128, 4096), (1, )))
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+def test_pinned_layout_propagates_through_elementwise():
+    """A pinned (no_verify) register layout that feeds arith/math elementwise
+    ops (where / add / sub / exp2) and a tl.reduce alongside default-layout
+    siblings must still compile.
+
+    arith/math verifiers use MLIR's generic SameOperandsAndResultType check,
+    which compares tensor encodings literally and ignores #tlx.no_verify_layout
+    (unlike triton ops, whose DialectInferLayoutInterface honors it). The
+    make_ttir TritonTLXFixup pass propagates the placeholder across these ops
+    (elementwise, select condition via require_layout, and scf region-carried
+    values) so the module verifies; the concrete layout is resolved later.
+    Before that fixup this raised: 'arith.addf' op requires the same encoding
+    for all operands and results.
+
+    Note: reductions must use tl.reduce (a direct tt.reduce, which honors
+    no_verify), not tl.max/tl.sum (which lower to a tt.call whose param is
+    null-encoded and would reject the pinned operand).
+    """
+
+    @triton.jit
+    def kernel(LAYOUT: tl.constexpr):
+        buf = tlx.local_alloc((128, 128), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
+        v = tlx.local_view(buf, 0)
+        x = tlx.local_load(v, layout=LAYOUT)  # pinned no_verify<#linear>
+        # Position mask built in the default layout, mixed into the pinned
+        # tensor via arith.select (tl.where) + arith.addf. The select condition
+        # (default-layout i1) is converted with require_layout; true/false/result
+        # take the placeholder.
+        offs = tl.arange(0, 128)
+        mask = offs[:, None] >= offs[None, :]
+        x = x + tl.where(mask, 0.0, -float("inf"))
+        # Thread-local reduce (direct tt.reduce), broadcast back (arith.subf),
+        # then math.exp2.
+        m = tl.reduce(x, 1, _pinned_row_max_combine)
+        p = tl.math.exp2(x - m[:, None])
+        tlx.local_store(v, p)
+
+    compiled = kernel.warmup(_row_per_thread_layout(), grid=(1, ), num_warps=4)
+    # Compiled successfully and the placeholder was fully resolved downstream.
+    assert "no_verify_layout" not in compiled.asm["ttgir"]
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+def test_pinned_reduce_is_thread_local():
+    """tl.reduce over axis=1 of a pinned row-per-thread layout keeps the pinned
+    #linear as the slice parent (each thread owns a full row -> the reduce is
+    thread-local, no cross-lane shuffle). Both a max and a sum reduce compile."""
+
+    @triton.jit
+    def kernel(LAYOUT: tl.constexpr):
+        buf = tlx.local_alloc((128, 128), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
+        v = tlx.local_view(buf, 0)
+        x = tlx.local_load(v, layout=LAYOUT)
+        m = tl.reduce(x, 1, _pinned_row_max_combine)
+        p = tl.math.exp2(x - m[:, None])
+        s = tl.reduce(p, 1, _pinned_add_combine)
+        p = p * s[:, None]
+        tlx.local_store(v, p)
+
+    compiled = kernel.warmup(_row_per_thread_layout(), grid=(1, ), num_warps=4)
+    ttgir = compiled.asm["ttgir"]
+    assert "no_verify_layout" not in ttgir
+    # Reduces are over axis 1 (N), i.e. thread-local for the row-per-thread pin.
+    assert "axis = 1" in ttgir
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+def test_pinned_propagates_through_jit_call():
+    """A pinned tensor fed to a @triton.jit helper (which lowers to a tt.call)
+    whose result is consumed by arith compiles. Triton monomorphizes the callee
+    with an encoding-stripped signature, so TritonTLXFixup specializes the
+    callee's params, return operand and FunctionType (and nested calls) to the
+    placeholder to keep the CallOpInterface contract."""
+
+    @triton.jit
+    def kernel(LAYOUT: tl.constexpr):
+        buf = tlx.local_alloc((128, 128), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
+        v = tlx.local_view(buf, 0)
+        x = tlx.local_load(v, layout=LAYOUT)
+        y = _pinned_fma_helper(x, x, x)  # tt.call with pinned args
+        z = tl.math.exp2(y)  # arith consumes the (pinned) call result
+        tlx.local_store(v, z)
+
+    compiled = kernel.warmup(_row_per_thread_layout(), grid=(1, ), num_warps=4)
+    assert "no_verify_layout" not in compiled.asm["ttgir"]
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+def test_pinned_scf_loop_carried_reduce():
+    """The online-softmax running-max pattern: a loop-carried accumulator updated
+    from a reduce over a pinned tensor. TritonTLXFixup propagates the placeholder
+    through scf.for init / region-iter-arg / yield / result."""
+
+    @triton.jit
+    def kernel(LAYOUT: tl.constexpr, N: tl.constexpr):
+        buf = tlx.local_alloc((128, 128), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
+        v = tlx.local_view(buf, 0)
+        x = tlx.local_load(v, layout=LAYOUT)
+        m = tl.zeros([128], dtype=tl.float32) - float("inf")
+        for _ in tl.range(0, N):
+            m = tl.maximum(m, tl.reduce(x, 1, _pinned_row_max_combine))
+        p = tl.math.exp2(x - m[:, None])
+        tlx.local_store(v, p)
+
+    compiled = kernel.warmup(_row_per_thread_layout(), 4, grid=(1, ), num_warps=4)
+    assert "no_verify_layout" not in compiled.asm["ttgir"]
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+def test_pinned_scf_loop_carried_const_init():
+    """A loop-carried accumulator initialized directly from a bare constant
+    (tl.zeros) and updated from a pinned tensor. The fixup must bridge the
+    constant init with require_layout (retyping it in place would corrupt the
+    constant's value attr once resolve strips the wrapper) while retyping the
+    loop's own iter-arg / result."""
+
+    @triton.jit
+    def kernel(LAYOUT: tl.constexpr, N: tl.constexpr):
+        buf = tlx.local_alloc((128, 128), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
+        v = tlx.local_view(buf, 0)
+        x = tlx.local_load(v, layout=LAYOUT)
+        acc = tl.zeros([128, 128], dtype=tl.float32)  # bare constant loop init
+        for _ in tl.range(0, N):
+            acc = acc + x  # pinned tensor combined in-loop
+        tlx.local_store(v, acc)
+
+    compiled = kernel.warmup(_row_per_thread_layout(), 4, grid=(1, ), num_warps=4)
+    assert "no_verify_layout" not in compiled.asm["ttgir"]
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+def test_pinned_softmax_end_to_end():
+    """End-to-end mirror of the HSTU forward softmax island: pinned load -> mask
+    (select+add) -> thread-local reduce -> fma helper (tt.call) -> exp2 -> row sum
+    -> restructuring helper (reshape/split, auto-released) -> store. Exercises
+    every propagation/relaxation path together, with no explicit release."""
+
+    @triton.jit
+    def _restructure_tail(p):
+        a, b = p.reshape([128, 2, 64]).permute(0, 2, 1).split()
+        return tl.join(a, b).reshape([128, 128])
+
+    @triton.jit
+    def kernel(LAYOUT: tl.constexpr):
+        buf = tlx.local_alloc((128, 128), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
+        v = tlx.local_view(buf, 0)
+        x = tlx.local_load(v, layout=LAYOUT)
+        offs = tl.arange(0, 128)
+        mask = offs[:, None] >= offs[None, :]
+        x = x + tl.where(mask, 0.0, -float("inf"))
+        m = tl.reduce(x, 1, _pinned_row_max_combine)
+        x = _pinned_fma_helper(x, 1.4426950408, -m[:, None])  # qk*scale - m
+        p = tl.math.exp2(x)
+        l = tl.reduce(p, 1, _pinned_add_combine)
+        p = p * l[:, None]
+        # Restructuring helper: the fixup auto-releases the pin on the call arg.
+        y = _restructure_tail(p)
+        tlx.local_store(v, y)
+
+    compiled = kernel.warmup(_row_per_thread_layout(), grid=(1, ), num_warps=4)
+    assert "no_verify_layout" not in compiled.asm["ttgir"]
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+def test_pinned_reduction_through_tl_max_sum_call():
+    """tl.max / tl.sum lower to a tt.call (standard.max / standard.sum) whose
+    monomorphized signature is encoding-stripped. With a pinned operand,
+    TritonTLXFixup specializes that reduction callee (params + the
+    fixpoint-inferred slice-of-pin return), so the natural tl.max / tl.sum
+    compile on a pinned tensor -- no tl.reduce / explicit combine needed.
+
+    This is the compiler-side alternative to a lit test: the pre-specialization
+    IR (a tt.call whose pinned operand does not match the null-encoded callee
+    param) cannot be parsed by triton-opt (CallOp verifies operand==param at
+    parse), so the reduction-callee specialization is exercised through warmup.
+    """
+
+    @triton.jit
+    def kernel(LAYOUT: tl.constexpr):
+        buf = tlx.local_alloc((128, 128), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
+        v = tlx.local_view(buf, 0)
+        x = tlx.local_load(v, layout=LAYOUT)
+        m = tl.max(x, 1)  # -> tt.call standard.max, pinned operand
+        p = tl.math.exp2(x - m[:, None])
+        s = tl.sum(p, 1)  # -> tt.call standard.sum, pinned operand
+        p = p * s[:, None]
+        tlx.local_store(v, p)
+
+    compiled = kernel.warmup(_row_per_thread_layout(), grid=(1, ), num_warps=4)
+    ttgir = compiled.asm["ttgir"]
+    assert "no_verify_layout" not in ttgir
+    # The reductions stay thread-local (over axis 1) after specialization.
+    assert "axis = 1" in ttgir
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+def test_pinned_auto_release_through_restructuring_call():
+    """A pinned tensor fed to a @triton.jit helper that restructures it
+    (reshape/permute/split, like subtile_ops._split_n_2D) compiles with no
+    explicit release: TritonTLXFixup auto-inserts tlx.release_layout on the
+    placeholder call args (the pin has no meaning across the restructure) and
+    the tail runs in a compiler-chosen layout."""
+
+    @triton.jit
+    def _restructure_helper(x):
+        a, b = x.reshape([x.shape[0], 2, x.shape[1] // 2]).permute(0, 2, 1).split()
+        return tl.join(a, b).reshape([x.shape[0], x.shape[1]])
+
+    @triton.jit
+    def kernel(LAYOUT: tl.constexpr):
+        buf = tlx.local_alloc((128, 128), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
+        v = tlx.local_view(buf, 0)
+        x = tlx.local_load(v, layout=LAYOUT)
+        x = tl.math.exp2(x)  # pinned arith
+        y = _restructure_helper(x)  # tt.call, restructuring -> auto-release the arg
+        tlx.local_store(v, y)
+
+    compiled = kernel.warmup(_row_per_thread_layout(), grid=(1, ), num_warps=4)
+    assert "no_verify_layout" not in compiled.asm["ttgir"]
+
+
+@triton.jit
+def _pinned_smem_store_helper(buf):
+    x = tl.zeros((64, 128), tl.float32)
+    tlx.local_store(buf[0], x)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+def test_pinned_smem_layout_through_jit_call():
+    """A shared-memory buffer allocated with an explicit layout
+    (tlx.local_alloc(layout=...)) is a memdesc whose encoding is wrapped as
+    #tlx.user_layout<#ttg.swizzled_shared<...>>. Passing it to a @triton.jit
+    helper (tt.call) whose monomorphized param dropped the wrapper must still
+    compile: TritonTLXFixup specializes the callee's memdesc param to the pinned
+    layout so the call operand/param types match."""
+
+    @triton.jit
+    def kernel(LAYOUT: tl.constexpr):
+        buf = tlx.local_alloc((64, 128), tl.float32, tl.constexpr(2), layout=LAYOUT)
+        _pinned_smem_store_helper(buf)
+
+    # Compiles without a tt.call operand/param type mismatch.
+    kernel.warmup(tlx.swizzled_layout(3, 0, 7, order=[1, 0]), grid=(1, ), num_warps=4)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+def test_pinned_propagates_through_cast():
+    """A cast (.to(dtype) -> arith.truncf / arith.extf) changes the element type
+    but preserves shape and layout. TritonTLXFixup propagates the pinned encoding
+    to the cast result (keeping the result's element type), so the arith cast
+    verifier accepts operand and result as cast-compatible instead of rejecting
+    the encoded-operand / unencoded-result mismatch."""
+
+    @triton.jit
+    def kernel(LAYOUT: tl.constexpr):
+        buf = tlx.local_alloc((128, 128), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
+        v = tlx.local_view(buf, 0)
+        x = tlx.local_load(v, layout=LAYOUT)  # pinned f32
+        y = (x * 2.0).to(tl.float16)  # arith.mulf (pinned) -> arith.truncf
+        z = y.to(tl.float32)  # arith.extf back to f32, still pinned
+        tlx.local_store(v, z)
+
+    compiled = kernel.warmup(_row_per_thread_layout(), grid=(1, ), num_warps=4)
+    assert "no_verify_layout" not in compiled.asm["ttgir"]
+
+
 @pytest.mark.skipif(not is_cuda(), reason="Need CUDA")
 def test_dump_layout_cute(capfd, monkeypatch):
     """`tlx.dump_layout` prints the resolved layout in CuTe Shape:Stride form to

--- a/test/TLX/placeholder-verifier-defer.mlir
+++ b/test/TLX/placeholder-verifier-defer.mlir
@@ -1,0 +1,59 @@
+// RUN: triton-opt -split-input-file %s | FileCheck %s
+
+// Verifier relaxation for TLX placeholder (deferred) layouts. A user-pinned
+// layout is wrapped as #tlx.no_verify_layout<#tlx.user_layout<...>> at the load
+// and only resolved in make_ttgir. Until then it can legitimately meet
+// concrete/absent encodings on ops whose verifiers would otherwise reject the
+// mix; those verifiers treat a TLX placeholder wrapper as "no layout" (defer).
+//
+// These modules only need to parse+verify (that is where the relaxed op
+// verifiers run) -- no pass is applied.
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#ph = #tlx.no_verify_layout<#tlx.user_layout<#linear>>
+#blocked3d = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 2, 2], order = [2, 1, 0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32} {
+  // ReshapeOp::verify defers when the src carries a placeholder, even though the
+  // dst is a concrete (blocked) 3D layout the split path chose -- exactly the
+  // P-tail case. Without the relaxation this fails with "src and dst both have
+  // encodings, or ... neither".
+  // CHECK-LABEL: @reshape_placeholder_src_concrete_dst
+  tt.func @reshape_placeholder_src_concrete_dst(%x: tensor<128x128xbf16, #ph>) -> tensor<128x2x64xbf16, #blocked3d> {
+    // CHECK: tt.reshape
+    %y = tt.reshape %x allow_reorder : tensor<128x128xbf16, #ph> -> tensor<128x2x64xbf16, #blocked3d>
+    tt.return %y : tensor<128x2x64xbf16, #blocked3d>
+  }
+}
+
+// -----
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#ph = #tlx.no_verify_layout<#tlx.user_layout<#linear>>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32} {
+  // ReshapeOp::verify also defers when the dst has no encoding (the placeholder
+  // src alone defers the whole check).
+  // CHECK-LABEL: @reshape_placeholder_src_null_dst
+  tt.func @reshape_placeholder_src_null_dst(%x: tensor<128x128xbf16, #ph>) -> tensor<128x2x64xbf16> {
+    // CHECK: tt.reshape
+    %y = tt.reshape %x allow_reorder : tensor<128x128xbf16, #ph> -> tensor<128x2x64xbf16>
+    tt.return %y : tensor<128x2x64xbf16>
+  }
+}
+
+// -----
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#ph = #tlx.no_verify_layout<#tlx.user_layout<#linear>>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32} {
+  // SameOperandsAndResultEncoding (verifySameEncoding) peels the TLX placeholder
+  // wrapper off the operand and verifies the underlying concrete layout: here the
+  // placeholder wraps #linear and the result is that same concrete #linear, so a
+  // triton elementwise-inline-asm op with a placeholder operand and concrete
+  // result verifies.
+  // CHECK-LABEL: @same_encoding_placeholder_operand
+  tt.func @same_encoding_placeholder_operand(%a: tensor<128x128xf32, #ph>) -> tensor<128x128xf32, #linear> {
+    // CHECK: tt.elementwise_inline_asm
+    %r = tt.elementwise_inline_asm "mov.b32 $0, $1;" {constraints = "=r,r", packed_element = 1 : i32, pure = true} %a : tensor<128x128xf32, #ph> -> tensor<128x128xf32, #linear>
+    tt.return %r : tensor<128x128xf32, #linear>
+  }
+}

--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -59,7 +59,22 @@ LogicalResult delegateInferredLayout(
   Attribute unwrappedResultLayout;
   if (failed(infer(delegate, unwrappedSrcLayout, unwrappedResultLayout)))
     return failure();
-  resultLayout = wrapNoVerifyLayout(unwrappedResultLayout);
+  // Re-apply only the TLX wrappers the source actually had (user_layout inside,
+  // no_verify outside), so re-inference after resolve-placeholder-layouts --
+  // which strips no_verify from operands -- stays consistent with the op's
+  // stored result type instead of unconditionally re-adding no_verify.
+  Attribute afterNoVerify = unwrapNoVerifyLayout(srcLayout);
+  bool hadUserLayout = unwrapUserLayout(afterNoVerify) != afterNoVerify;
+  // no_verify may be the top wrapper (TMEM pin: no_verify<user_layout<L>>) or
+  // nested under user_layout (SMEM pin: user_layout<no_verify<L>>); check both
+  // so the deferred placeholder is not silently downgraded to a plain anchor.
+  bool hadNoVerify = hasNoVerifyLayout(srcLayout) ||
+                     hasNoVerifyLayout(unwrapUserLayout(srcLayout));
+  if (hadUserLayout)
+    unwrappedResultLayout = wrapUserLayout(unwrappedResultLayout);
+  if (hadNoVerify)
+    unwrappedResultLayout = wrapNoVerifyLayout(unwrappedResultLayout);
+  resultLayout = unwrappedResultLayout;
   return success();
 }
 
@@ -78,35 +93,70 @@ struct TLXInferLayoutInterface : public triton::DialectInferLayoutInterface {
         });
   }
 
-  // reduce/expand_dims produce or consume a `slice` encoding whose parent is
-  // the full-tensor encoding. Keep any TLX wrapper on the slice's *parent*
-  // (matching ReduceOp/ExpandDimsOp's own result inference) rather than
-  // wrapping the whole slice, which would produce `no_verify<slice<parent=L>>`
-  // where the IR has `slice<parent=no_verify<L>>` and fail the op verifier. So
-  // we locate the concrete dialect from the unwrapped encoding but delegate
-  // with the *wrapped* operand and do not re-wrap the result.
+  // reduce/expand_dims produce or consume a `slice` encoding whose parent is the
+  // full-tensor encoding. The TLX wrapper must stay on the slice's *parent*
+  // (standard inference: slice<parent=user_layout<L>>) so the result is
+  // structurally stable across resolve-placeholder-layouts (which strips
+  // no_verify) and matches the op's own inference on both sides.
+  //
+  // When the operand carries the deferred no_verify pin, additionally keep
+  // no_verify as the *outermost* wrapper of the result (peel only the outer
+  // no_verify, run the standard inference on the user_layout<L> anchor, then
+  // re-wrap): a build-time reduce_op.verify() runs before ttg.num-warps is set,
+  // and a top-level no_verify makes it skip verifyTensorLayout. After resolve
+  // strips no_verify from both operand and result, re-inference falls into the
+  // plain branch and produces the same slice<parent=...> -- so they stay
+  // consistent.
+  template <typename InferFn>
+  LogicalResult inferSliceLike(Attribute operandEncoding,
+                               Attribute &resultEncoding, InferFn infer) const {
+    // Strip #tlx.no_verify_layout at *every* nesting level (top, under a
+    // user_layout wrapper, or inside a ttg encoding's parent), keeping
+    // user_layout / concrete encodings intact. This yields the "anchor" the
+    // standard inference runs on (so user_layout stays on the slice's parent),
+    // and tells us whether the operand carried the deferred pin at all.
+    mlir::AttrTypeReplacer stripper;
+    stripper.addReplacement(
+        [](NoVerifyLayoutAttr w) -> Attribute { return w.getLayout(); });
+    Attribute anchor = stripper.replace(operandEncoding);
+    bool deferred = anchor != operandEncoding;
+    const triton::DialectInferLayoutInterface *delegate =
+        getInferLayoutInterfaceFor(unwrapTlxLayoutWrappers(anchor));
+    if (!delegate)
+      return failure();
+    Attribute result;
+    if (failed(infer(delegate, anchor, result)))
+      return failure();
+    // Re-wrap no_verify as the outermost wrapper so a build-time verify (before
+    // ttg.num-warps is set) skips verifyTensorLayout. After resolve strips
+    // no_verify from operand and result alike, re-inference takes the plain
+    // branch and produces the same slice<parent=...>, so they stay consistent.
+    resultEncoding = deferred ? wrapNoVerifyLayout(result) : result;
+    return success();
+  }
+
   LogicalResult
   inferReduceOpEncoding(Attribute operandEncoding, unsigned axis,
                         Attribute &resultEncoding,
                         std::optional<Location> loc) const override {
-    const triton::DialectInferLayoutInterface *delegate =
-        getInferLayoutInterfaceFor(unwrapTlxLayoutWrappers(operandEncoding));
-    if (!delegate)
-      return failure();
-    return delegate->inferReduceOpEncoding(operandEncoding, axis,
-                                           resultEncoding, loc);
+    return inferSliceLike(
+        operandEncoding, resultEncoding,
+        [&](const triton::DialectInferLayoutInterface *delegate, Attribute enc,
+            Attribute &result) {
+          return delegate->inferReduceOpEncoding(enc, axis, result, loc);
+        });
   }
 
   LogicalResult
   inferExpandDimsOpEncoding(Attribute operandEncoding, unsigned axis,
                             Attribute &resultEncoding,
                             std::optional<Location> loc) const override {
-    const triton::DialectInferLayoutInterface *delegate =
-        getInferLayoutInterfaceFor(unwrapTlxLayoutWrappers(operandEncoding));
-    if (!delegate)
-      return failure();
-    return delegate->inferExpandDimsOpEncoding(operandEncoding, axis,
-                                               resultEncoding, loc);
+    return inferSliceLike(
+        operandEncoding, resultEncoding,
+        [&](const triton::DialectInferLayoutInterface *delegate, Attribute enc,
+            Attribute &result) {
+          return delegate->inferExpandDimsOpEncoding(enc, axis, result, loc);
+        });
   }
 
   LogicalResult inferDotOpEncoding(Attribute operandEncoding, unsigned opIdx,
@@ -272,7 +322,14 @@ Attribute mlir::triton::tlx::unwrapNoVerifyLayout(Attribute layout) {
 }
 
 bool mlir::triton::tlx::hasNoVerifyLayout(Attribute layout) {
-  return isa_and_nonnull<NoVerifyLayoutAttr>(layout);
+  if (!layout)
+    return false;
+  if (isa<NoVerifyLayoutAttr>(layout))
+    return true;
+  bool found = false;
+  layout.walkImmediateSubElements(
+      [&](Attribute sub) { found |= hasNoVerifyLayout(sub); }, [](Type) {});
+  return found;
 }
 
 //-- UserLayoutAttr --

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -1,5 +1,11 @@
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Dominance.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 #include "tlx/dialect/include/IR/Dialect.h"
@@ -17,6 +23,427 @@ namespace mlir::triton::tlx {
 
 #define GEN_PASS_DEF_TRITONTLXFIXUP
 #include "tlx/dialect/include/Transforms/Passes.h.inc"
+
+// ---------------------------------------------------------------------------
+// Placeholder (no_verify) layout propagation across encoding-uniform ops.
+//
+// tlx.local_load(layout=...) pins a #tlx.no_verify_layout<#linear> encoding on
+// its result already in TTIR. Triton ops (broadcast/expand_dims/reduce/reshape)
+// verify layouts through the DialectInferLayoutInterface, which honors
+// no_verify (see verifyLayoutsAreEqual). But upstream MLIR arith/math
+// elementwise ops (addf, mulf, select, cmpf, truncf, fma, ...) use the generic
+// SameOperandsAndResultType-style verifier that compares tensor encodings
+// literally and ignores no_verify. So when a pinned tensor meets a
+// null-encoded, same-shape sibling at one of those ops, make_ttir's verifier
+// would reject the module -- before the real layout resolution
+// (tlx-propagate-layout / tlx-resolve-placeholder-layouts) runs in make_ttgir.
+//
+// This runs first in make_ttir (before the verifier) and stamps the placeholder
+// encoding onto every same-shape operand/result of such ops so the module stays
+// verifiable. The concrete layout is still resolved later.
+static bool isEncodingUniformArithOp(Operation *op) {
+  if (isa<arith::ConstantOp>(op))
+    return false; // handled as a leaf when retyped, not as a consumer
+  // Propagate the placeholder across ops whose generic MLIR verifier compares
+  // operand/result *types* (ignoring the TLX wrapper) and would otherwise reject
+  // a placeholder meeting a null/concrete sibling: same-type elementwise
+  // (SameOperandsAndResultType), select/cmp (whose condition / i1 result differ
+  // in type), and the arith cast ops (which change the element type but preserve
+  // shape/layout). Keyed on the trait + explicit op list rather than a hard-coded
+  // dialect name. NB: deliberately NOT the broad Elementwise trait -- it also
+  // matches ops that legitimately mix a pinned and an unpinned operand, which
+  // would over-propagate the pin. The element type may differ across the op
+  // (casts); only the encoding is propagated.
+  if (!op->hasTrait<mlir::OpTrait::SameOperandsAndResultType>() &&
+      !isa<arith::SelectOp, arith::CmpFOp, arith::CmpIOp, arith::ExtFOp,
+           arith::TruncFOp, arith::ExtUIOp, arith::ExtSIOp, arith::TruncIOp,
+           arith::SIToFPOp, arith::FPToSIOp, arith::BitcastOp>(op))
+    return false;
+  // Encoding-uniform == every ranked-tensor operand/result shares one shape
+  // (true for elementwise / select / cmp). Scalars are ignored.
+  ArrayRef<int64_t> shape;
+  bool haveShape = false;
+  auto sameShape = [&](Type ty) -> bool {
+    if (auto t = dyn_cast<RankedTensorType>(ty)) {
+      if (!haveShape) {
+        shape = t.getShape();
+        haveShape = true;
+      } else if (t.getShape() != shape) {
+        return false;
+      }
+    }
+    return true;
+  };
+  for (Type ty : op->getOperandTypes())
+    if (!sameShape(ty))
+      return false;
+  for (Type ty : op->getResultTypes())
+    if (!sameShape(ty))
+      return false;
+  return haveShape;
+}
+
+static bool isPlaceholderEncoding(Attribute enc) {
+  if (!enc)
+    return false;
+  // The deferred pin is marked by #tlx.no_verify_layout, which may be the top
+  // wrapper (no_verify<user_layout<L>>), nested under user_layout (SMEM pin:
+  // user_layout<no_verify<L>>), or nested inside a ttg encoding produced by
+  // inference -- e.g. a reduce result slice<parent=no_verify<...>>. Scan the
+  // whole attribute tree for no_verify. Deliberately keyed on no_verify (not a
+  // bare user_layout) so a user_layout-only pin (which is not a deferred
+  // placeholder) is left untouched by this fixup.
+  if (hasNoVerifyLayout(enc))
+    return true;
+  bool found = false;
+  enc.walkImmediateSubElements(
+      [&](Attribute sub) { found |= isPlaceholderEncoding(sub); },
+      [](Type) {});
+  return found;
+}
+
+static bool retypeWithEncoding(Value v, Attribute enc) {
+  auto t = dyn_cast<RankedTensorType>(v.getType());
+  if (!t || t.getEncoding() == enc)
+    return false;
+  auto newTy = RankedTensorType::get(t.getShape(), t.getElementType(), enc);
+  // A tensor arith.constant carries its type in the value attr too; rebuild it.
+  if (auto cst = v.getDefiningOp<arith::ConstantOp>()) {
+    if (auto dense = dyn_cast<DenseElementsAttr>(cst.getValue()))
+      if (dense.isSplat())
+        cst.setValueAttr(
+            DenseElementsAttr::get(newTy, dense.getSplatValue<Attribute>()));
+  }
+  v.setType(newTy);
+  return true;
+}
+
+static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
+  bool conflict = false;
+  // Find a placeholder encoding among a set of linked values (values an op
+  // requires to share one encoding). If two of them carry *different* pinned
+  // placeholders, that is a user error (two conflicting tlx.local_load(layout=)
+  // pins meeting on one op) -- report it instead of silently retagging one.
+  auto findPlaceholder = [&](ArrayRef<Value> vs, Operation *op) -> Attribute {
+    Attribute enc;
+    for (Value v : vs)
+      if (auto t = dyn_cast<RankedTensorType>(v.getType()))
+        if (isPlaceholderEncoding(t.getEncoding())) {
+          if (enc && enc != t.getEncoding()) {
+            op->emitError("conflicting user-pinned layouts meet on this "
+                          "operation; insert tlx.release_layout to reconcile "
+                          "them before combining");
+            conflict = true;
+            return enc;
+          }
+          if (!enc)
+            enc = t.getEncoding();
+        }
+    return enc;
+  };
+
+  bool changed = true;
+  unsigned iter = 0;
+  constexpr unsigned kMaxIter = 1000;
+  // Give a linked value the placeholder encoding. Values defined by
+  // arith.constant or tt.call cannot be retyped in place (rebuilding a
+  // constant's value attr, or a call result bound to the callee signature,
+  // leaves the IR inconsistent once resolve strips the wrapper), nor can a
+  // select condition's producer -- bridge those to the consumer with a
+  // require_layout convert; everything else is retyped directly. `user`/
+  // `operandIdx` identify the use to rewrite in the bridge case.
+  auto bridgeOrRetype = [&](Value v, Attribute enc, Operation *user,
+                            unsigned operandIdx, bool forceBridge = false) {
+    auto t = dyn_cast<RankedTensorType>(v.getType());
+    if (!t || t.getEncoding() == enc)
+      return;
+    bool isConst = v.getDefiningOp<arith::ConstantOp>() != nullptr;
+    bool isCall = v.getDefiningOp<::mlir::triton::CallOp>() != nullptr;
+    if (forceBridge || isConst || isCall) {
+      OpBuilder b(user);
+      auto convTy = RankedTensorType::get(t.getShape(), t.getElementType(), enc);
+      Value conv = RequireLayoutOp::create(b, user->getLoc(), convTy, v);
+      user->setOperand(operandIdx, conv);
+      changed = true;
+      return;
+    }
+    changed |= retypeWithEncoding(v, enc);
+  };
+  while (changed) {
+    changed = false;
+    if (++iter > kMaxIter) {
+      mod.emitError(
+          "TLX placeholder layout propagation exceeded iteration limit");
+      return failure();
+    }
+    // tt.calls whose shared helper callee must be privatized (cloned) before it
+    // can be specialized. Collected during the walk and applied afterwards, so
+    // we never insert into the module while traversing it.
+    SmallVector<::mlir::triton::CallOp> pendingClones;
+    mod.walk([&](Operation *op) {
+      // arith/math elementwise, select, cmp: all same-shape tensor operands and
+      // results must share the encoding.
+      if (isEncodingUniformArithOp(op)) {
+        SmallVector<Value> linked(op->getOperands());
+        linked.append(op->getResults().begin(), op->getResults().end());
+        Attribute enc = findPlaceholder(linked, op);
+        if (!enc)
+          return;
+        for (Value v : op->getResults())
+          changed |= retypeWithEncoding(v, enc);
+        bool isSelect = isa<arith::SelectOp>(op);
+        for (auto en : llvm::enumerate(op->getOperands())) {
+          // arith.select's condition (operand 0) must carry the encoding too,
+          // but its producer may be un-retypeable (e.g. a tt.call mask), so
+          // force a require_layout bridge for it.
+          bool isSelectCond = isSelect && en.index() == 0;
+          bridgeOrRetype(en.value(), enc, op, en.index(), isSelectCond);
+        }
+        return;
+      }
+      // scf.for: init / region iter-arg / yield operand / result of each
+      // loop-carried value must share the encoding.
+      if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+        auto yield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+        for (unsigned i = 0; i < forOp.getNumRegionIterArgs(); ++i) {
+          Value initV = forOp.getInitArgs()[i];
+          Value iterArg = forOp.getRegionIterArg(i);
+          Value yieldV = yield.getOperand(i);
+          Value resV = forOp.getResult(i);
+          Attribute enc = findPlaceholder({initV, iterArg, yieldV, resV}, forOp);
+          if (!enc)
+            continue;
+          // init is an external operand and the yield operand is loop-body
+          // produced -- either may be an arith.constant (tl.zeros) or a tt.call
+          // result, so bridge those; the iter-arg and result are the loop's own
+          // SSA values and are retyped in place.
+          bridgeOrRetype(initV, enc, forOp, forOp.getNumControlOperands() + i);
+          changed |= retypeWithEncoding(iterArg, enc);
+          bridgeOrRetype(yieldV, enc, yield, i);
+          changed |= retypeWithEncoding(resV, enc);
+        }
+        return;
+      }
+      // scf.if: result / then-yield / else-yield of each value must share it.
+      if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+        auto thenY = cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator());
+        scf::YieldOp elseY =
+            ifOp.elseBlock()
+                ? cast<scf::YieldOp>(ifOp.elseBlock()->getTerminator())
+                : nullptr;
+        for (unsigned i = 0; i < ifOp.getNumResults(); ++i) {
+          SmallVector<Value> linked{ifOp.getResult(i), thenY.getOperand(i)};
+          if (elseY)
+            linked.push_back(elseY.getOperand(i));
+          Attribute enc = findPlaceholder(linked, ifOp);
+          if (!enc)
+            continue;
+          // The if result is the op's own SSA value (retype in place); the
+          // branch yields are produced values that may be arith.constant /
+          // tt.call results, so bridge them.
+          changed |= retypeWithEncoding(ifOp.getResult(i), enc);
+          bridgeOrRetype(thenY.getOperand(i), enc, thenY, i);
+          if (elseY)
+            bridgeOrRetype(elseY.getOperand(i), enc, elseY, i);
+        }
+        return;
+      }
+      // tt.expand_dims / tt.broadcast: their result type was fixed at build
+      // time, but the operand may only receive a placeholder via the arith/scf
+      // propagation above. Re-infer the result via the op's InferTypeOpInterface
+      // (broadcast preserves the encoding; expand_dims maps slice<->parent
+      // through the TLX infer interface) so operand and result stay consistent.
+      if (isa<::mlir::triton::ExpandDimsOp, ::mlir::triton::BroadcastOp,
+              ::mlir::triton::ReduceOp>(op)) {
+        auto ot = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+        if (!ot || !isPlaceholderEncoding(ot.getEncoding()))
+          return;
+        if (auto iface = dyn_cast<InferTypeOpInterface>(op)) {
+          SmallVector<Type> inferred;
+          if (succeeded(iface.inferReturnTypes(
+                  op->getContext(), op->getLoc(), op->getOperands(),
+                  op->getAttrDictionary(), op->getPropertiesStorage(),
+                  op->getRegions(), inferred)) &&
+              inferred.size() == op->getNumResults()) {
+            for (unsigned i = 0; i < inferred.size(); ++i)
+              if (op->getResult(i).getType() != inferred[i]) {
+                op->getResult(i).setType(inferred[i]);
+                changed = true;
+              }
+          }
+        }
+        return;
+      }
+      // tt.call to a @triton.jit helper carrying a pinned (placeholder) arg.
+      // Three cases, keyed on what the (monomorphized, encoding-stripped)
+      // callee does:
+      //   (A) it restructures the tensor (reshape / split / join / trans, e.g.
+      //       subtile_ops._split_n_2D): the row-per-thread pin has no meaning
+      //       across the restructure, so auto-release the placeholder args
+      //       before the call (make_ttgir picks the tail layout) -- the kernel
+      //       does not need an explicit tlx.release_layout.
+      //   (B/C) it is elementwise (fast_fma) or a reduction (standard.max/sum):
+      //       specialize the callee params, then sync the call result to the
+      //       callee return -- forcing the placeholder for an elementwise result
+      //       (shape matches the arg) or mirroring the fixpoint-inferred return
+      //       for a reduction result (shape differs, slice of the pin). This
+      //       keeps the kernel on natural tl.max/tl.sum and fast_fma.
+      if (auto callOp = dyn_cast<::mlir::triton::CallOp>(op)) {
+        Attribute enc;
+        ArrayRef<int64_t> encShape;
+        for (Value a : callOp.getOperands())
+          if (auto t = dyn_cast<RankedTensorType>(a.getType()))
+            if (isPlaceholderEncoding(t.getEncoding())) {
+              enc = t.getEncoding();
+              encShape = t.getShape();
+              break;
+            }
+        auto callee =
+            enc ? SymbolTable::lookupNearestSymbolFrom<::mlir::triton::FuncOp>(
+                      callOp, callOp.getCalleeAttr())
+                : ::mlir::triton::FuncOp();
+        if (!callee)
+          return;
+
+        // (A) restructuring callee -> release the placeholder args.
+        bool restructures = false;
+        callee.walk([&](Operation *o) {
+          if (isa<::mlir::triton::ReshapeOp, ::mlir::triton::SplitOp,
+                  ::mlir::triton::JoinOp, ::mlir::triton::TransOp>(o))
+            restructures = true;
+        });
+        if (restructures) {
+          OpBuilder b(callOp);
+          for (unsigned i = 0; i < callOp.getNumOperands(); ++i) {
+            auto t = dyn_cast<RankedTensorType>(callOp.getOperand(i).getType());
+            if (!t || !isPlaceholderEncoding(t.getEncoding()))
+              continue;
+            auto relTy =
+                RankedTensorType::get(t.getShape(), t.getElementType());
+            Value rel = ReleaseLayoutOp::create(b, callOp.getLoc(), relTy,
+                                                callOp.getOperand(i));
+            callOp.setOperand(i, rel);
+            changed = true;
+          }
+          return;
+        }
+
+        // (B/C) elementwise / reduction: specialize the callee.
+        // If the monomorphized helper is shared with other call sites (possibly
+        // unpinned or pinned to a different layout), defer privatizing it: clone
+        // a private copy after the walk and point this call at it, so
+        // specializing never changes types out from under other callers or
+        // toggles a shared callee between two pins across fixpoint iterations.
+        if (auto symUses = SymbolTable::getSymbolUses(callee, mod)) {
+          unsigned useCount = 0;
+          for (const auto &u : *symUses) {
+            (void)u;
+            ++useCount;
+          }
+          if (useCount > 1) {
+            pendingClones.push_back(callOp);
+            return;
+          }
+        }
+        // Triton monomorphizes @triton.jit helpers with encoding-stripped
+        // (null) signatures, so specialize params (entry block args +
+        // FunctionType inputs) to the placeholder; nested helper calls and the
+        // callee body (e.g. the reduction's tt.reduce) are re-inferred by the
+        // fixpoint once their params are set.
+        Block &entry = callee.getBody().front();
+        SmallVector<Type> newInputs(callee.getFunctionType().getInputs().begin(),
+                                    callee.getFunctionType().getInputs().end());
+        bool inputsChanged = false;
+        for (unsigned i = 0; i < callOp.getNumOperands(); ++i) {
+          Type at = callOp.getOperand(i).getType();
+          auto rt = dyn_cast<RankedTensorType>(at);
+          if (!rt || !isPlaceholderEncoding(rt.getEncoding()))
+            continue;
+          if (i < newInputs.size() && newInputs[i] != at) {
+            newInputs[i] = at;
+            inputsChanged = true;
+          }
+          if (i < entry.getNumArguments() &&
+              entry.getArgument(i).getType() != at) {
+            entry.getArgument(i).setType(at);
+            changed = true;
+          }
+        }
+        if (inputsChanged)
+          changed = true;
+
+        SmallVector<::mlir::triton::ReturnOp> rets;
+        callee.walk([&](::mlir::triton::ReturnOp r) { rets.push_back(r); });
+        SmallVector<Type> newResults(
+            callee.getFunctionType().getResults().begin(),
+            callee.getFunctionType().getResults().end());
+        bool sigChanged = inputsChanged;
+        for (unsigned i = 0; i < callOp.getNumResults(); ++i) {
+          auto callRt = dyn_cast<RankedTensorType>(callOp.getResult(i).getType());
+          // Reduction: mirror the callee's return operand once the fixpoint has
+          // re-inferred it to a placeholder (slice of the pin).
+          RankedTensorType retT;
+          if (!rets.empty() && i < rets[0].getNumOperands())
+            retT = dyn_cast<RankedTensorType>(rets[0].getOperand(i).getType());
+          Type target;
+          if (retT && isPlaceholderEncoding(retT.getEncoding()))
+            target = retT;
+          else if (callRt && callRt.getShape() == encShape)
+            // Elementwise: result shares the arg shape -> force the placeholder.
+            target = RankedTensorType::get(callRt.getShape(),
+                                           callRt.getElementType(), enc);
+          else
+            continue;
+          if (callOp.getResult(i).getType() != target) {
+            callOp.getResult(i).setType(target);
+            changed = true;
+          }
+          if (i < newResults.size() && newResults[i] != target) {
+            newResults[i] = target;
+            sigChanged = true;
+          }
+          for (auto r : rets)
+            if (i < r.getNumOperands() && r.getOperand(i).getType() != target) {
+              r.getOperand(i).setType(target);
+              changed = true;
+            }
+        }
+        if (sigChanged) {
+          callee.setType(FunctionType::get(callee.getContext(), newInputs,
+                                           newResults));
+          changed = true;
+        }
+        return;
+      }
+    });
+    // Privatize shared helper callees collected during the walk. Cloning gives
+    // each pinned call site its own copy of the helper, so specializing it
+    // cannot change types out from under other callers.
+    for (auto callOp : pendingClones) {
+      auto callee = SymbolTable::lookupNearestSymbolFrom<::mlir::triton::FuncOp>(
+          callOp, callOp.getCalleeAttr());
+      if (!callee)
+        continue;
+      OpBuilder b(callee);
+      auto cloneOp =
+          cast<::mlir::triton::FuncOp>(b.clone(*callee.getOperation()));
+      std::string base = (callee.getSymName() + "_tlxpin").str();
+      std::string name = base;
+      unsigned n = 0;
+      while (SymbolTable::lookupNearestSymbolFrom(
+          callOp, StringAttr::get(callee.getContext(), name)))
+        name = base + "_" + std::to_string(n++);
+      cloneOp.setSymName(name);
+      SymbolTable::setSymbolVisibility(cloneOp,
+                                       SymbolTable::Visibility::Private);
+      callOp.setCalleeAttr(FlatSymbolRefAttr::get(callee.getContext(), name));
+      changed = true;
+    }
+    if (conflict)
+      return failure();
+  }
+  return success();
+}
 
 class TritonTLXFixupPass : public impl::TritonTLXFixupBase<TritonTLXFixupPass> {
   using impl::TritonTLXFixupBase<TritonTLXFixupPass>::TritonTLXFixupBase;
@@ -245,6 +672,15 @@ public:
       if (hasNoEndingClusterSync)
         setUserPostWsSyncOnMod(mod, /*value=*/true);
     }
+
+    // Make placeholder (no_verify) layouts pinned by tlx.local_load(layout=...)
+    // consistent across arith/math elementwise, select and scf region-carried
+    // values, so make_ttir's verifier (arith verifiers don't honor no_verify)
+    // accepts the module. Runs after the ttg.num-warps metadata above is set,
+    // since validating the pinned #linear layout needs it. Concrete layouts are
+    // resolved later in make_ttgir.
+    if (failed(propagatePlaceholderLayouts(mod)))
+      return signalPassFailure();
   }
 };
 

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -559,15 +559,17 @@ void init_triton_tlx_ir(py::module &&m) {
              std::optional<Value> asyncToken, bool userLayout) -> mlir::Value {
             auto subViewType = cast<ttg::MemDescType>(subView.getType());
 
-            // layoutEncoding must be TMEM compatible. For the user-pinned case,
-            // wrap with #tlx.user_layout so generic layout passes treat it as a
-            // hard anchor (same mechanism as the SMEM local_load path), keeping
-            // the inner no-verify wrapper for inlining. resolve-placeholder-
-            // layouts strips the nested no-verify (keeping the user-layout
-            // marker) once inlining is done.
+            // layoutEncoding already carries an inner no_verify (from
+            // make_linear_encoding_attr). Strip it, wrap with #tlx.user_layout
+            // (the hard anchor), then a single outer #tlx.no_verify_layout, so
+            // the encoding is exactly no_verify<user_layout<L>> -- no-verify
+            // outermost (deferred for verifiers keyed off the top-level attr,
+            // e.g. TritonGPU verifyTensorLayout), user-layout inside.
+            // resolve-placeholder-layouts strips the no-verify (keeping the
+            // user-layout marker) once inlining is done and num-warps is set.
             Attribute tensorEncoding =
-                userLayout ? tlx::wrapUserLayout(
-                                 tlx::wrapNoVerifyLayout(layoutEncoding))
+                userLayout ? tlx::wrapNoVerifyLayout(tlx::wrapUserLayout(
+                                 tlx::unwrapNoVerifyLayout(layoutEncoding)))
                            : tlx::wrapNoVerifyLayout(layoutEncoding);
             auto newType = RankedTensorType::get(subViewType.getShape(),
                                                  subViewType.getElementType(),

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -365,6 +365,7 @@ To bypass, rewrite it to `local_alloc(..., num=tl.constexpr(2))` or `local_alloc
         # respects it (does not retag the buffer to satisfy a consumer). The
         # wrapper is unwrapped back to `layout_handle` by tlx-resolve-placeholder-layouts.
         if not getattr(layout, "_tlx_default", False):
+            layout._tlx_user_pinned = True
             layout_handle = _semantic.builder.make_user_layout_attr(layout_handle)
 
     alias_handle = None

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -1164,10 +1164,20 @@ class buffered_tensor_type(tl.block_type):
         shape = self.shape
         if self.num >= 1:
             shape = [self.num] + list(shape)
+        layout_handle = self.layout.to_ir(builder)
+        # An explicit, user-pinned shared layout (tlx.local_alloc(layout=...)) is
+        # wrapped as #tlx.user_layout<...> so layout propagation respects it. The
+        # pin is marked on the layout object by local_alloc; wrap here so the same
+        # wrapper appears wherever this type is reconstructed -- e.g. a @triton.jit
+        # callee's param rebuilt from this type, or a subview's result -- keeping
+        # tt.call operand/param and memdesc subview encodings consistent. The
+        # wrapper is stripped later by tlx-resolve-placeholder-layouts.
+        if getattr(self.layout, "_tlx_user_pinned", False):
+            layout_handle = builder.make_user_layout_attr(layout_handle)
         return builder.get_memdesc_type(
             shape,
             self.element_ty.to_ir(builder),
-            self.layout.to_ir(builder),
+            layout_handle,
             self.storage.value,
         )
 


### PR DESCRIPTION
Summary:
Let a user-pinned register layout on a TLX tmem load
(tlx.local_load(layout=tlx.layout(...))) propagate through the ops that consume
it -- so a kernel can pin a register layout on one load and otherwise stay
written normally (elementwise math, tl.max/tl.sum, triton.jit helpers, reshape/
split), with the compiler carrying the pin where it applies and releasing it
where it does not.

The pin is a #tlx.no_verify_layout<#tlx.user_layout<#linear>> placeholder that is
resolved in make_ttgir (tlx-propagate-layout / resolve-placeholder-layouts). To
let it survive make_ttir and reach that point:

- TritonTLXFixup (make_ttir pass0, before the verifier) propagates the
  placeholder across arith/math elementwise + select, scf.for / scf.if
  region-carried values, and tt.reduce / tt.expand_dims / tt.broadcast result
  re-inference. A linked value that cannot be retyped in place -- an
  arith.constant (rebuilding its value attr desyncs it once resolve strips the
  wrapper), a tt.call result (bound to the callee signature), or a select
  condition -- is bridged to its consumer with a tlx.require_layout convert
  instead; this applies uniformly to arith operands and to scf init/yield
  operands.
- tt.call handling covers the three helper shapes Triton monomorphizes with
  encoding-stripped signatures:
    * elementwise helper: specialize callee params + return + result to the
      placeholder (recursing into nested helper calls);
    * reduction helper (standard.max / standard.sum, i.e. tl.max / tl.sum):
      specialize params and mirror the fixpoint-inferred (slice-of-pin) return,
      so natural tl.max / tl.sum work on a pinned tensor;
    * restructuring helper (reshape / split / join / trans): auto-insert a
      release (tlx.ReleaseLayoutOp) on the placeholder args -- the pin has no
      meaning across a restructure, so hand off to a compiler-chosen layout. No
      user-facing release is needed in the kernel; the release lowers to
      convert_layout in make_ttgir (ReleaseLayoutPattern).
  A helper callee that is shared with other call sites is cloned first (a private
  copy per pinned call site), so specializing it never changes types out from
  under other callers or toggles a callee shared between two different pins.
- Two conflicting user pins meeting on one op (different pinned layouts combined)
  are reported (emitError + pass failure) instead of one being silently retagged;
  the fixpoint is also capped (kMaxIter) and fails the pass if exceeded.
- TLX layout inference (Dialect.cpp): inferReduce / inferExpandDims go through
  delegateInferredLayout, which re-applies only the wrappers the source had.
  no_verify is detected whether it is the top wrapper (TMEM pin:
  no_verify<user_layout<L>>) or nested under user_layout (SMEM pin:
  user_layout<no_verify<L>>). create_tmem_load pins as no_verify<user_layout<L>>.
- Verifier relaxation: ReshapeOp::verify (Ops.cpp) and verifySameEncoding
  (Traits.cpp) treat a TLX placeholder wrapper as "no layout" (defer), via a
  shared triton::encodingContainsTlxPlaceholder helper (Utility.h) that detects
  the wrapper by dialect namespace and scans the whole attribute tree -- so a
  placeholder nested inside a ttg encoding (e.g. a slice/expand parent) is also
  deferred (triton core cannot depend on the TLX dialect for typed isa<> checks).

Reviewed By: pchen7e2

Differential Revision: D112454240
