### PR TITLE
[tritonbench][flex_attention] torch_tlx_flex_attention provider + Blackwell TLX flex fixes (#2143)

### DIFF
--- a/third_party/tlx/language/tlx/inductor/flex_attention_templates.py
+++ b/third_party/tlx/language/tlx/inductor/flex_attention_templates.py
@@ -56,9 +56,10 @@ def append_tlx_flex_attention_choice(
       - "allow":   add TLX candidates alongside the standard template.
       - "force":   drop the standard choices and use only TLX.
 
-    Two warp-specialization shapes are offered as autotuning candidates: a
-    2-MMA-group variant (one per base config) and a single 1-MMA-group variant
-    (fewer barriers, 8 warps).
+    One 2-MMA-group warp-specialization candidate is offered per base config.
+    The kernel body hard-codes NUM_MMA_GROUPS=2 and splits BLOCK_M across the two
+    groups, so only base configs whose per-group tile meets the tcgen05 MMA
+    minimum (M >= 64, i.e. BLOCK_M >= 128) yield a candidate.
 
     ``input_nodes`` is the standard flex-attention forward input list:
     (query, key, value, logsumexp, max_scores, kv_num_blocks, kv_indices,
@@ -110,23 +111,20 @@ def append_tlx_flex_attention_choice(
         )
 
     # 4-task warp specialization, 2 MMA groups: one candidate per base config.
+    # The kernel body hard-codes NUM_MMA_GROUPS=2 and splits BLOCK_M across the
+    # two groups (BLOCK_M_SPLIT = BLOCK_M // 2). The Blackwell tcgen05 MMA
+    # requires M >= 64, so skip base configs whose per-group tile is smaller.
+    NUM_MMA_GROUPS = 2
+    MIN_MMA_M = 64
     for conf in configs:
+        if conf.block_m // NUM_MMA_GROUPS < MIN_MMA_M:
+            continue
         opts = tlx_options()
         opts["num_warps"] = conf.num_warps
         opts["num_stages"] = conf.num_stages
         opts["BLOCK_M"] = conf.block_m
         opts["BLOCK_N"] = conf.block_n
         append(opts)
-
-    # 4-task warp specialization, 1 MMA group (fewer barriers): 8 warps.
-    last_conf = configs[-1]
-    opts = tlx_options()
-    opts["num_warps"] = 8
-    opts["num_stages"] = 1
-    opts["NUM_MMA_GROUPS"] = 1
-    opts["BLOCK_M"] = last_conf.block_m
-    opts["BLOCK_N"] = last_conf.block_n
-    append(opts)
 
 
 def _append_amd_flex_choices(


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/tritonbench/pull/1186


Adds a TLX flex-attention provider to tritonbench, fixes the beta-Triton TLX flex template so the Blackwell WS kernel is actually selected, unifies the PT2 baseline name, and corrects the eager accuracy baseline.

- **New provider**: `torch_tlx_flex_attention` — PT2 max-autotune with `triton.tlx_mode="allow"` so the TLX WS template competes in flex autotuning; gated `IS_BLACKWELL and has_tlx()`.
- **TLX flex template**: drop the unsupported 1-MMA-group candidate (`NUM_MMA_GROUPS` constexpr reassignment) and skip `BLOCK_M < 128` (tcgen05 requires `M >= 64`). The auto-TMA launcher `schema` fix this depended on has since landed in base.
- **Baseline alias**: `pt2_triton_flex_attention` added as an additive alias of `compiled` (mirrors gemm's `pt2_triton_matmul`); `compiled` kept unchanged for back-compat.
- **Accuracy baseline fixes**: `eager` now passes `score_mod` (rel/alibi were compared against a bias-free reference), and `eager` is skipped cleanly where it cannot produce a reference (16384 OOM; the Nvidia approx-tanh softcap score_mod has no vmap rule).
- **TFLOPS parity**: sparsity-aware flop count for `pt2_triton_flex_attention` and `torch_tlx_flex_attention`, matching `compiled`.
- **--input-loader support**: `flex_attention` `InputLoader` + `SUPPORTED_INPUT_OPS` entry; a shared `_build_input` keeps the loader and `get_input_iter` in sync.
- **Shape file + doc**: `fb/nvidia_b200/flex_attention_sweep.json` (49 shapes = 7 masks x 7 seqlens 128-8192, restricted to cases with a valid eager reference — excludes softcap and 16384) and `fb/README.md` with the unified B200 commands.

🤖 Authored with Claude Code.

Reviewed By: dhruvak3, xuzhao9

Differential Revision: D112346323


