### PR TITLE
[triton][AutoWS] Use kAsyncTaskIdAttrName constant in WS detection walk

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -127,7 +127,7 @@ public:
     // suffices.
     bool enabled = false;
     funcOp->walk([&](Operation *op) {
-      if (op->getAttrOfType<DenseI32ArrayAttr>("async_task_id") ||
+      if (op->getAttrOfType<DenseI32ArrayAttr>(kAsyncTaskIdAttrName) ||
           op->getAttrOfType<DenseI32ArrayAttr>(
               triton::gpu::kPartitionAttrName) ||
           (isa<scf::ForOp>(op) &&


### PR DESCRIPTION
Summary: Minor nit (non-blocking): WarpSpecialization.cpp:130 still hard-codes the "async_task_id" string literal in the detection walk instead of the new kAsyncTaskIdAttrName constant it introduces — same value, just partially undercuts the "single source of truth" goal.

Differential Revision: D112557219


