### PR TITLE
[TritonGPU] Fix NPOT crash in ensureLayoutNotSmallerThan on modular layouts

### DIFF
--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -142,10 +142,18 @@ LinearLayout ensureLayoutNotSmallerThan(
   for (StringAttr outDimName : layout.getOutDimNames()) {
     int32_t actualSize = layout.getOutDimSize(outDimName);
     int32_t desiredSize = shape.lookup(outDimName);
-    // actualSize is always pow2, so grow to the next pow2 >= an NPOT
-    // desiredSize (else desiredSize/actualSize floors, e.g. 192/128 == 1, and
-    // the register dim never grows, dropping real elements). A later
-    // ensureLayoutNotLargerThan clamps to the true NPOT size. Pow2: no-op.
+    // Already covers the shape. This also handles a modular NPOT actualSize
+    // (e.g. re-lowering an already-built modular LinearEncodingAttr whose
+    // out-dim equals the shape): such a layout needs no growth, and the
+    // pow2 grow path below does not apply to it. Symmetric with
+    // ensureLayoutNotLargerThan's true-size early-exit.
+    if (actualSize >= desiredSize)
+      continue;
+    // Only a pow2 layout can still be too small here; grow it to the next
+    // pow2 >= an NPOT desiredSize (else desiredSize/actualSize floors, e.g.
+    // 192/128 == 1, and the register dim never grows, dropping real
+    // elements). A later ensureLayoutNotLargerThan clamps to the true NPOT
+    // size. Pow2: no-op.
     assert(llvm::isPowerOf2_32(actualSize));
     int32_t growTarget =
         llvm::isPowerOf2_32(desiredSize)


### PR DESCRIPTION

The NPOT elementwise lowering (#1892) builds a modular LinearLayout whose out-dim is the true non-power-of-2 size (e.g. 48), wrapped in a LinearEncodingAttr. When that encoding is re-lowered during type conversion (convertTritonTensorType -> getTotalElemsPerThread -> LinearEncodingAttr::getElemsPerThread -> toLinearLayout), its stored NPOT out-dim flows into ensureLayoutNotSmallerThan as actualSize, tripping `assert(isPowerOf2_32(actualSize))` and aborting triton-opt. This made test/Conversion/tritongpu_to_llvm_npot.mlir crash rather than run its CHECK lines.

The root cause is an asymmetry between two sibling functions: ensureLayoutNotLargerThan was made NPOT-aware for both the desired and the actual size (true-size early-exit, NextPowerOf2 basis span), but ensureLayoutNotSmallerThan was only made NPOT-aware for desiredSize -- it still assumed actualSize is always a power of two.

Fix: short-circuit when the layout already covers the shape (actualSize >= desiredSize) before the pow2 assert, the symmetric analog of ensureLayoutNotLargerThan's early-exit. A modular NPOT layout whose out-dim already equals the shape needs no growth; the pow2 grow-to-next-pow2 path now only runs for genuinely-too-small pow2 layouts, which is what it was written for.

Verified: Conversion/tritongpu_to_llvm_npot.mlir now passes (no crash, all CHECK/CHECK-NOT lines match); no regressions across the Conversion (76), TritonGPU (158), and Tools (1) lit suites.

Authored with Claude.