### PR TITLE
[Triton] Default-on C dispatcher/cache + TRITON_CACHE_STATS dispatch observability (#2238)

### DIFF
--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <functional>
+#include <mutex>
 #include <pybind11/pybind11.h>
 #include <string>
 #include <string_view>
@@ -38,6 +39,64 @@ specialize_arg(PyObject *backend, PyObject *arg, bool is_const,
                bool specialize_value, bool align);
 
 static bool init_called = false;
+
+// --- dispatch/cache stats (opt-in via TRITON_CACHE_STATS=1) ------------------
+// Counts hit vs fallback per dispatch path, per kernel, so owners can find
+// kernels that silently miss the C fast path once the flags are on by default.
+// When off (the default) every record site is guarded by a single
+// `if (g_cache_stats)` branch, so no map/mutex/name work happens on the hot
+// path.
+static const bool g_cache_stats = [] {
+  const char *v = std::getenv("TRITON_CACHE_STATS");
+  return v != nullptr && v[0] == '1' && v[1] == '\0';
+}();
+static std::mutex g_cache_stats_mu;
+// kernel name -> (event -> count), e.g. event "jit_proxy_hit" /
+// "jit_proxy_fallback"
+static std::unordered_map<std::string,
+                          std::unordered_map<std::string, uint64_t>>
+    g_cache_stats_map;
+
+static void cache_stats_record(PyObject *name_obj, const char *event) {
+  // Caller must guard with `if (g_cache_stats)`.
+  const char *name = (name_obj && PyUnicode_Check(name_obj))
+                         ? PyUnicode_AsUTF8(name_obj)
+                         : nullptr;
+  std::lock_guard<std::mutex> lk(g_cache_stats_mu);
+  g_cache_stats_map[name ? name : "<unknown>"][event]++;
+}
+
+// native_dump_cache_stats() -> {kernel: {event: count}}
+static PyObject *native_dump_cache_stats(PyObject *, PyObject *) {
+  PyObject *outer = PyDict_New();
+  if (!outer)
+    return nullptr;
+  std::lock_guard<std::mutex> lk(g_cache_stats_mu);
+  for (const auto &kv : g_cache_stats_map) {
+    PyObject *inner = PyDict_New();
+    if (!inner) {
+      Py_DECREF(outer);
+      return nullptr;
+    }
+    for (const auto &ev : kv.second) {
+      PyObject *cnt = PyLong_FromUnsignedLongLong(ev.second);
+      if (cnt) {
+        PyDict_SetItemString(inner, ev.first.c_str(), cnt);
+        Py_DECREF(cnt);
+      }
+    }
+    PyDict_SetItemString(outer, kv.first.c_str(), inner);
+    Py_DECREF(inner);
+  }
+  return outer;
+}
+
+// native_reset_cache_stats() -> None
+static PyObject *native_reset_cache_stats(PyObject *, PyObject *) {
+  std::lock_guard<std::mutex> lk(g_cache_stats_mu);
+  g_cache_stats_map.clear();
+  Py_RETURN_NONE;
+}
 
 static PyObject *constexpr_cls = nullptr;
 static PyObject *jit_callable_cls = nullptr;
@@ -1518,6 +1577,7 @@ typedef struct {
   PyObject *stream_getter;     // driver.active.get_current_stream
   PyObject *device_getter;     // driver.active.get_current_device
   PyObject *param_name_to_idx; // dict: param_name → positional index
+  PyObject *kernel_name;       // interned _fn_name for stats (may be NULL)
   uint64_t options_hash;
   int n_params;
 } JITCacheProxy;
@@ -1661,12 +1721,16 @@ static PyObject *JITCacheProxy_vectorcall(PyObject *callable,
     }
     Py_DECREF(result);
     Py_INCREF(kernel);
+    if (g_cache_stats)
+      cache_stats_record(self->kernel_name, "jit_proxy_hit");
     return kernel;
   }
 
 fallback:
   // Fall through to Python: self.run(*args, grid=grid, warmup=False, **kwargs)
   // Use Vectorcall to preserve any keyword arguments from kwnames.
+  if (g_cache_stats)
+    cache_stats_record(self->kernel_name, "jit_proxy_fallback");
   return PyObject_Vectorcall(self->run_partial, args, nargsf, kwnames);
 }
 
@@ -1682,6 +1746,7 @@ static void JITCacheProxy_dealloc(PyObject *o) {
   Py_XDECREF(self->stream_getter);
   Py_XDECREF(self->device_getter);
   Py_XDECREF(self->param_name_to_idx);
+  Py_XDECREF(self->kernel_name);
   Py_TYPE(o)->tp_free(o);
 }
 
@@ -1696,6 +1761,7 @@ static int JITCacheProxy_traverse(PyObject *o, visitproc visit, void *arg) {
   Py_VISIT(self->stream_getter);
   Py_VISIT(self->device_getter);
   Py_VISIT(self->param_name_to_idx);
+  Py_VISIT(self->kernel_name);
   return 0;
 }
 
@@ -1705,6 +1771,7 @@ static int JITCacheProxy_clear(PyObject *o) {
   Py_CLEAR(self->params_list);
   Py_CLEAR(self->run_partial);
   Py_CLEAR(self->param_name_to_idx);
+  Py_CLEAR(self->kernel_name);
   Py_CLEAR(self->grid_py[0]);
   Py_CLEAR(self->grid_py[1]);
   Py_CLEAR(self->grid_py[2]);
@@ -1845,6 +1912,12 @@ PyObject *native_create_jit_proxy(PyObject *self_unused, PyObject *const *args,
   PyObject *pnti = PyObject_GetAttr(jit_fn, pnti_str);
   proxy->param_name_to_idx = pnti; // may be NULL if attr missing
   if (!pnti)
+    PyErr_Clear();
+  static PyObject *fn_name_str = nullptr;
+  if (!fn_name_str)
+    fn_name_str = PyUnicode_InternFromString("_fn_name");
+  proxy->kernel_name = PyObject_GetAttr(jit_fn, fn_name_str);
+  if (!proxy->kernel_name)
     PyErr_Clear();
   proxy->options_hash = opts_hash;
   proxy->n_params = n_params;
@@ -2017,6 +2090,7 @@ typedef struct {
   int *dtype_indices; // positions of tensor args (for dtype in key)
   int n_dtype_indices;
   int n_params;                  // total params of inner JITFunction
+  PyObject *kernel_name;         // interned _fn_name for stats (may be NULL)
   std::vector<ATEntry> at_table; // autotune dispatch table
   size_t at_count;               // number of occupied entries
   // Old table buffers retained (never freed) across resizes so that a
@@ -2340,6 +2414,8 @@ static PyObject *AutotuneCacheProxy_vectorcall(PyObject *callable,
       Py_DECREF(result);
       Py_XDECREF(e_pre_hook);
       Py_INCREF(fc_entry->kernel);
+      if (g_cache_stats)
+        cache_stats_record(self->kernel_name, "autotune_proxy_hit");
       return fc_entry->kernel;
     }
 
@@ -2350,6 +2426,8 @@ static PyObject *AutotuneCacheProxy_vectorcall(PyObject *callable,
 
 fallback:
   Py_XDECREF(e_pre_hook);
+  if (g_cache_stats)
+    cache_stats_record(self->kernel_name, "autotune_proxy_fallback");
   return PyObject_Vectorcall(self->fallback_run, args, nargsf, kwnames);
 }
 
@@ -2364,6 +2442,7 @@ static void AutotuneCacheProxy_dealloc(PyObject *o) {
   Py_XDECREF(self->grid_fn);
   Py_XDECREF(self->grid_static);
   Py_XDECREF(self->param_name_to_idx);
+  Py_XDECREF(self->kernel_name);
   free(self->key_indices);
   free(self->dtype_indices);
   for (size_t i = 0; i < self->at_table.size(); i++) {
@@ -2388,6 +2467,7 @@ static int AutotuneCacheProxy_traverse(PyObject *o, visitproc visit,
   Py_VISIT(self->grid_fn);
   Py_VISIT(self->grid_static);
   Py_VISIT(self->param_name_to_idx);
+  Py_VISIT(self->kernel_name);
   for (size_t i = 0; i < self->at_table.size(); i++) {
     if (self->at_table[i].occupied) {
       ATEntry *entry = &self->at_table[i];
@@ -2411,6 +2491,7 @@ static int AutotuneCacheProxy_clear(PyObject *o) {
   Py_CLEAR(self->grid_fn);
   Py_CLEAR(self->grid_static);
   Py_CLEAR(self->param_name_to_idx);
+  Py_CLEAR(self->kernel_name);
   for (size_t i = 0; i < self->at_table.size(); i++) {
     if (self->at_table[i].occupied) {
       ATEntry *entry = &self->at_table[i];
@@ -2519,6 +2600,12 @@ PyObject *native_create_autotune_proxy(PyObject *self_unused,
   PyObject *pnti = PyObject_GetAttr(jit_fn, pnti_str);
   proxy->param_name_to_idx = pnti; // may be NULL if attr missing
   if (!pnti)
+    PyErr_Clear();
+  static PyObject *at_fn_name_str = nullptr;
+  if (!at_fn_name_str)
+    at_fn_name_str = PyUnicode_InternFromString("_fn_name");
+  proxy->kernel_name = PyObject_GetAttr(jit_fn, at_fn_name_str);
+  if (!proxy->kernel_name)
     PyErr_Clear();
   proxy->key_indices = key_indices;
   proxy->n_key_indices = (int)n_keys;
@@ -2804,6 +2891,12 @@ static PyMethodDef module_methods[] = {
      METH_FASTCALL, nullptr},
     {"native_autotune_proxy_set_grid",
      (PyCFunction)native_autotune_proxy_set_grid, METH_FASTCALL, nullptr},
+    {"native_dump_cache_stats", (PyCFunction)native_dump_cache_stats,
+     METH_NOARGS,
+     "Return {kernel: {event: count}} of C dispatch hit/fallback stats "
+     "(TRITON_CACHE_STATS=1)"},
+    {"native_reset_cache_stats", (PyCFunction)native_reset_cache_stats,
+     METH_NOARGS, "Clear the C dispatch stats counters"},
     {"register_tensor_access_api",
      (PyCFunction) + [](PyObject *self, PyObject *arg) -> PyObject * {
        (void)self;

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -573,9 +573,13 @@ class nvidia_knobs(base_knobs):
     dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
     dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     use_no_compile_launcher: env_bool = env_bool("TRITON_USE_NO_COMPILE_LAUNCHER")
-    use_triton_dispatcher: env_bool = env_bool("TRITON_USE_C_DISPATCHER")
+    # Default ON; opt out with TRITON_USE_C_DISPATCHER=0.
+    use_triton_dispatcher: env_bool = env_bool("TRITON_USE_C_DISPATCHER", True)
     auto_tma: env_bool = env_bool("TRITON_AUTO_TMA")
-    use_autotune_c_cache: env_bool = env_bool("TRITON_AUTOTUNE_USE_C_CACHE")
+    # Default ON; opt out with TRITON_AUTOTUNE_USE_C_CACHE=0.
+    use_autotune_c_cache: env_bool = env_bool("TRITON_AUTOTUNE_USE_C_CACHE", True)
+    # Default ON; opt out with TRITON_ENABLE_C_CACHE=0.
+    enable_c_cache: env_bool = env_bool("TRITON_ENABLE_C_CACHE", True)
     generate_subtiled_region: env_bool = env_bool("TRITON_GENERATE_SUBTILED_REGION")
     # When True, run the triton-nvidia-interleave-tmem pass on Blackwell.
     # Default ON; set TRITON_ENABLE_INTERLEAVE_TMEM=0 to opt out for A/B

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -241,6 +241,26 @@ def _timed_measurement(kernel_call, clear_cache, n_repeat, torch):
     return torch.tensor([s.elapsed_time(e) for s, e in zip(start_ev, end_ev)], dtype=torch.float)
 
 
+class _AutotuneCache(dict):
+    """dict that invalidates C autotune proxy when cleared."""
+
+    def __init__(self, autotuner):
+        super().__init__()
+        self._autotuner = autotuner
+
+    def __reduce__(self):
+        return (dict, ())
+
+    def clear(self):
+        super().clear()
+        if hasattr(self._autotuner, '_autotune_proxy'):
+            del self._autotuner._autotune_proxy
+        if hasattr(self._autotuner, '_at_proxy_seeded'):
+            self._autotuner._at_proxy_seeded = set()
+        if hasattr(self._autotuner, '_fc_seeded'):
+            self._autotuner._fc_seeded = set()
+
+
 class Autotuner(KernelInterface):
 
     def __init__(self, fn, arg_names, configs, key, reset_to_zero, restore_value, pre_hook=None, post_hook=None,
@@ -280,7 +300,7 @@ class Autotuner(KernelInterface):
             self.configs = configs
         self.keys = key
         self.include_npot = include_npot
-        self.cache: Dict[Tuple, Config] = {}
+        self.cache: Dict[Tuple, Config] = _AutotuneCache(self)
         self.arg_names = arg_names
         self.cache_results = (cache_results or knobs.autotuning.cache) and not knobs.runtime.interpret
 
@@ -563,7 +583,8 @@ class Autotuner(KernelInterface):
         """Return C-level AutotuneCacheProxy for fast dispatch if available."""
         # Check if we can use the C-level autotune proxy
         if (native_create_autotune_proxy is not None and getattr(self.fn, 'c_cache', False)
-                and knobs.nvidia.use_autotune_c_cache and knobs.nvidia.use_triton_dispatcher and len(self.configs) > 1):
+                and knobs.nvidia.use_autotune_c_cache and knobs.nvidia.use_triton_dispatcher and len(self.configs) > 1
+                and knobs.autotuning.listener is None):
             proxy = getattr(self, '_autotune_proxy', None)
             if proxy is None:
                 # Compute key_indices: positions in arg_names for autotuner key fields

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -28,6 +28,65 @@ try:
 except ImportError:
     native_create_jit_proxy = None
 
+# --- dispatch/cache stats (opt-in via TRITON_CACHE_STATS=1) ------------------
+# Counts, per kernel, the outcome of the Python run() dispatch once a C proxy has
+# fallen back into Python (or for callable-grid / first-call cases). Combined with
+# the C-side proxy hit/fallback counters (native_dump_cache_stats), this gives a
+# per-path, per-kernel picture of where the C fast path is / isn't taken — so
+# owners can find kernels that silently miss it now that the flags default on.
+# Zero work when off: a single module-level bool checked at each count site.
+_CACHE_STATS_ON = os.environ.get("TRITON_CACHE_STATS", "0") == "1"
+_CACHE_STATS_PY: dict = {}  # kernel name -> {event: count}
+
+
+def _cache_stats_record(name: str, event: str) -> None:
+    # Callers must guard with `if _CACHE_STATS_ON`.
+    k = _CACHE_STATS_PY.get(name)
+    if k is None:
+        k = {}
+        _CACHE_STATS_PY[name] = k
+    k[event] = k.get(event, 0) + 1
+
+
+def dump_cache_stats() -> dict:
+    """Merged {kernel: {event: count}} of C proxy + Python run() dispatch stats.
+
+    Enable collection with TRITON_CACHE_STATS=1. Events:
+      autotune_proxy_hit / autotune_proxy_fallback  (C, autotuned kernels)
+      jit_proxy_hit / jit_proxy_fallback            (C, bare kernels)
+      run_fast_hit_c / run_fast_py_fallback         (Python run() fast path)
+      run_slow_c / run_slow_py_fallback             (Python run() slow path)
+    """
+    merged: dict = {}
+    try:
+        from triton._C.libtriton import native_dump_cache_stats
+        for kname, events in native_dump_cache_stats().items():
+            merged.setdefault(kname, {}).update(events)
+    except (ImportError, AttributeError):
+        pass
+    for kname, events in _CACHE_STATS_PY.items():
+        dst = merged.setdefault(kname, {})
+        for ev, n in events.items():
+            dst[ev] = dst.get(ev, 0) + n
+    return merged
+
+
+if _CACHE_STATS_ON:
+    import atexit as _atexit
+
+    @_atexit.register
+    def _dump_cache_stats_atexit() -> None:
+        stats = dump_cache_stats()
+        if not stats:
+            return
+        import sys as _sys
+        print("[TRITON_CACHE_STATS] per-kernel dispatch hit/fallback:", file=_sys.stderr, flush=True)
+        for kname in sorted(stats):
+            events = stats[kname]
+            summary = ", ".join(f"{ev}={events[ev]}" for ev in sorted(events))
+            print(f"  {kname}: {summary}", file=_sys.stderr, flush=True)
+
+
 # Fast tensor access API — lazily registered on first use.
 # Provides ~10x faster dtype/data_ptr extraction via direct C struct access.
 _torch_bridge_loaded = False
@@ -415,8 +474,21 @@ class KernelInterface(Generic[T]):
         # Fast C proxy: bypasses Python run() entirely for cache hits.
         # Only useful when dispatcher is available — without it the proxy
         # does a redundant C cache lookup then falls back to run() anyway.
+        #
+        # Skip the proxy when the kernel reads module-level globals: the C proxy
+        # launches a cache hit without re-validating used_global_vals, so a
+        # changed global would be silently ignored. Routing such kernels through
+        # run() preserves the "Global variable ... has changed" RuntimeError.
+        #
+        # Also skip it whenever run() would do per-launch work the proxy bypasses
+        # — launch hooks, pre-run hooks, launch_metadata, or a stages-inspection
+        # hook — so those still fire (mirrors the run() c_cache fast-path guard).
         if native_create_jit_proxy is not None and getattr(self, 'c_cache', False) \
                 and knobs.nvidia.use_triton_dispatcher \
+                and not self.used_global_vals \
+                and not self.pre_run_hooks and not self.launch_metadata \
+                and not knobs.runtime.launch_enter_hook and not knobs.runtime.launch_exit_hook \
+                and knobs.runtime.add_stages_inspection_hook is None \
                 and not callable(grid) and hasattr(self, '_fc_options_hash') and hasattr(self, 'params'):
             cache = getattr(self, '_jit_proxy_cache', None)
             if cache is None:
@@ -699,6 +771,41 @@ def convert_to_tuple_if_list(item):
     return tuple(item)
 
 
+class _DeviceCaches(defaultdict):
+    """defaultdict of per-device compiled-kernel caches that also invalidates the
+    C fast caches (JITCacheProxy cache + native FastCache) when cleared.
+
+    The C fast cache mirrors the compiled kernels held here, so callers that
+    clear the in-memory device caches to force a re-fetch/recompile (e.g. tests
+    exercising the disk cache + compilation listener) must not be silently
+    short-circuited by a stale C cache entry. Keeps the two caches consistent.
+    """
+
+    def __init__(self, jit_fn, default_factory):
+        super().__init__(default_factory)
+        self._jit_fn = jit_fn
+
+    def __reduce__(self):
+        # Return an EMPTY defaultdict for pickling/deepcopy.  The compiled
+        # kernels inside this cache contain _TritonDispatcher C objects whose
+        # kernel_params are interior pointers into arg_storage — deep-copying
+        # them produces dangling pointers and crashes.  An empty cache is fine
+        # for snapshots (e.g. torch._inductor's TritonBundler.deepcopy).
+        return (defaultdict, ())
+
+    def clear(self):
+        super().clear()
+        jit_fn = self._jit_fn
+        proxy_cache = getattr(jit_fn, "_jit_proxy_cache", None)
+        if proxy_cache is not None:
+            proxy_cache.clear()
+        # Drop the native FastCache capsule so it is recreated empty on next use.
+        try:
+            del jit_fn._fc_cache
+        except AttributeError:
+            pass
+
+
 class JITFunction(JITCallable, KernelInterface[T]):
 
     def is_gluon(self):
@@ -835,7 +942,9 @@ class JITFunction(JITCallable, KernelInterface[T]):
         # NOTE: This block is only reached when JITCacheProxy cannot be used
         # (callable grid, first call, or C extension unavailable).
         # Static-grid repeat calls go through JITCacheProxy directly.
-        if not _skip_fc and self.c_cache and not warmup and not self.pre_run_hooks and not knobs.compilation.always_compile \
+        if not _skip_fc and self.c_cache and not warmup \
+                and not self.pre_run_hooks and not knobs.compilation.always_compile \
+                and not self.used_global_vals \
                 and knobs.runtime.add_stages_inspection_hook is None \
                 and not knobs.runtime.launch_enter_hook and not knobs.runtime.launch_exit_hook \
                 and not self.launch_metadata:
@@ -891,6 +1000,8 @@ class JITFunction(JITCallable, KernelInterface[T]):
                     if _globals_ok:
                         kernel = result
                         if not getattr(kernel, '_dispatcher', None):
+                            if _CACHE_STATS_ON:
+                                _cache_stats_record(self._fn_name, "run_fast_py_fallback")
                             if knobs.nvidia.use_triton_dispatcher:
                                 warnings.warn(
                                     f"[Triton] TRITON_USE_C_DISPATCHER=1 but kernel '{self._fn_name}' has no C "
@@ -903,6 +1014,8 @@ class JITFunction(JITCallable, KernelInterface[T]):
                             grid_2 = _fc_grid[2] if grid_size > 2 else 1
                             kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, None,
                                        None, None, *_fc_args)
+                        elif _CACHE_STATS_ON:
+                            _cache_stats_record(self._fn_name, "run_fast_hit_c")
                         return kernel
         elif not _skip_fc and self.c_cache and not warmup:
             reasons = []
@@ -1025,10 +1138,14 @@ class JITFunction(JITCallable, KernelInterface[T]):
             # when available and hooks are not needed.
             _disp = getattr(kernel, '_dispatcher', None)
             if _disp is not None and not knobs.runtime.launch_enter_hook and not knobs.runtime.launch_exit_hook:
+                if _CACHE_STATS_ON:
+                    _cache_stats_record(self._fn_name, "run_slow_c")
                 _vals = tuple(bound_args.values())
                 _indices = kernel._dispatch_arg_indices
                 _disp(grid_0, grid_1, grid_2, stream, *[_vals[i] for i in _indices])
             else:
+                if _CACHE_STATS_ON:
+                    _cache_stats_record(self._fn_name, "run_slow_py_fallback")
                 if knobs.nvidia.use_triton_dispatcher and _disp is None:
                     warnings.warn(
                         f"[Triton] TRITON_USE_C_DISPATCHER=1 but kernel '{self._fn_name}' has no C dispatcher, "
@@ -1071,7 +1188,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
         return self._fn_name if self._repr is None else self._repr(_)
 
     def __init__(self, fn, version=None, do_not_specialize=None, do_not_specialize_on_alignment=None, debug=None,
-                 noinline=None, repr=None, launch_metadata=None, c_cache=False):
+                 noinline=None, repr=None, launch_metadata=None, c_cache=None):
         do_not_specialize = do_not_specialize if do_not_specialize else []
         do_not_specialize_on_alignment = do_not_specialize_on_alignment if do_not_specialize_on_alignment else []
 
@@ -1082,7 +1199,13 @@ class JITFunction(JITCallable, KernelInterface[T]):
         self.do_not_specialize_on_alignment = do_not_specialize_on_alignment
         self._repr = repr
         self.launch_metadata = launch_metadata
-        self.c_cache = c_cache or (os.environ.get("TRITON_ENABLE_C_CACHE", "0") == "1")
+        # C cache defaults ON (opt out with TRITON_ENABLE_C_CACHE=0). An explicit
+        # c_cache=True/False on @triton.jit always wins over the env default;
+        # c_cache=None (not specified) falls back to the env-controlled default.
+        if c_cache is None:
+            self.c_cache = knobs.nvidia.enable_c_cache
+        else:
+            self.c_cache = c_cache
         if self.c_cache:
             _ensure_torch_bridge()
         # Register for simple deserialization of JITFunction constants
@@ -1095,7 +1218,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
             self.params.append(KernelParam(i, param, dns, dns_oa))
 
         # cache of just-in-time compiled kernels
-        self.device_caches = defaultdict(self.create_binder)
+        self.device_caches = _DeviceCaches(self, self.create_binder)
 
         # Options hash for C fast dispatch cache.
         # Constant 0: kernel options (num_warps, num_stages, etc.) are fixed
@@ -1243,7 +1366,7 @@ def jit(
     do_not_specialize_on_alignment: Optional[Iterable[int | str]] = None,
     debug: Optional[bool] = None,
     noinline: Optional[bool] = None,
-    c_cache: bool = False,
+    c_cache: Optional[bool] = None,
 ) -> Callable[[T], JITFunction[T]]:
     ...
 
@@ -1258,7 +1381,7 @@ def jit(
     do_not_specialize_on_alignment: Optional[Iterable[int | str]] = None,
     debug: Optional[bool] = None,
     noinline: Optional[bool] = None,
-    c_cache: bool = False,
+    c_cache: Optional[bool] = None,
 ) -> KernelInterface[T]:
     """
     Decorator for JIT-compiling a function using the Triton compiler.

--- a/third_party/nvidia/backend/_torch_bridge.cpp
+++ b/third_party/nvidia/backend/_torch_bridge.cpp
@@ -28,6 +28,11 @@ struct TritonTensorAccessAPI {
   int (*extract_tensordesc)(PyObject *td_obj, uint64_t *out_data_ptr,
                             int64_t *out_shape, int64_t *out_strides,
                             int max_ndim);
+  // Cheap device check (no CUDA driver call — reads the tensor's device off
+  // the c10::TensorImpl struct). Returns 1 if obj is a torch tensor on a CUDA
+  // device, 0 if it is a torch tensor NOT on CUDA (e.g. a cpu tensor), and -1
+  // if obj is not a torch tensor at all (device unknown — caller decides).
+  int8_t (*is_cuda_tensor)(PyObject *obj);
 };
 
 // ============================================================================
@@ -49,6 +54,15 @@ static uint64_t fast_get_data_ptr(PyObject *obj) {
     return 0;
   const auto &tensor = THPVariable_Unpack(obj);
   return reinterpret_cast<uint64_t>(tensor.data_ptr());
+}
+
+static int8_t fast_is_cuda_tensor(PyObject *obj) {
+  // Use Check (not CheckExact) so tensor subclasses (nn.Parameter, DTensor,
+  // ...) are validated too — they share the at::Tensor memory layout.
+  if (!THPVariable_Check(obj))
+    return -1; // not a torch tensor — device unknown to the bridge
+  const auto &tensor = THPVariable_Unpack(obj);
+  return tensor.is_cuda() ? 1 : 0;
 }
 
 // Interned attribute name strings for fast dict lookup
@@ -115,6 +129,7 @@ static TritonTensorAccessAPI g_api = {
     fast_get_scalar_type,
     fast_get_data_ptr,
     fast_extract_tensordesc,
+    fast_is_cuda_tensor,
 };
 
 // ============================================================================

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -1277,6 +1277,8 @@ static PyObject *data_ptr_str = NULL;
 static PyObject *td_get_str = NULL;  /* interned "get" for allocator.get() */
 static PyObject *padding_str = NULL; /* interned "padding" for TMA fill mode */
 static PyObject *nan_str = NULL; /* interned "nan" for NaN fill comparison */
+static PyObject *round_f32_to_tf32_str =
+    NULL; /* interned "round_f32_to_tf32" */
 
 // Extract a CUDA device pointer from a pointer-like PyObject obj, and store
 // it to the memory location pointed by ptr.
@@ -2139,6 +2141,10 @@ typedef struct {
   int (*extract_tensordesc)(PyObject *td_obj, uint64_t *out_data_ptr,
                             int64_t *out_shape, int64_t *out_strides,
                             int max_ndim);
+  /* Returns 1 if obj is a CUDA torch tensor, 0 if a non-CUDA (e.g. cpu) torch
+   * tensor, -1 if obj is not a torch tensor. Cheap: reads the tensor's device
+   * off the struct, no CUDA driver call. May be NULL for older bridges. */
+  int8_t (*is_cuda_tensor)(PyObject *);
 } TritonTensorAccessAPI;
 
 static TritonTensorAccessAPI *g_td_bridge = NULL;
@@ -2199,7 +2205,7 @@ typedef struct {
   unsigned grid_mult;   /* num_ctas — grid_x multiplied by this */
   unsigned block_dim_x; /* 32 * num_warps */
   unsigned shared_mem;
-  CUlaunchAttribute launch_attrs[5];
+  CUlaunchAttribute launch_attrs[6];
   unsigned num_launch_attrs;
   int arg_types[TD_MAX_KERNEL_ARGS]; /* ExtractorTypeIndex values */
   int num_args;      /* total kernel param slots (excluding scratch) */
@@ -2252,6 +2258,34 @@ static inline CUdeviceptr td_get_ptr(PyObject *obj) {
   CUdeviceptr p = (CUdeviceptr)PyLong_AsUnsignedLongLong(r);
   Py_DECREF(r);
   return p;
+}
+
+/* Validate that a pointer arg is device-accessible via cuPointerGetAttribute,
+ * matching the compiled launcher's extractPointer / the ctypes launcher's
+ * _get_device_pointer. This correctly accepts pinned (page-locked) host memory
+ * — which is device-accessible but has is_cuda == False — and rejects only true
+ * pageable cpu tensors. Requires a current CUDA context; callers ensure one via
+ * ensureCudaContext() at the top of td_convert_args. Used for the dev != 1 case
+ * (bridge unavailable, or a non-CUDA torch tensor such as a pinned tensor).
+ * Writes the pointer to *out on success. Returns 0 to accept, -1 on
+ * reject/error (Python exception set). */
+static inline int td_get_ptr_checked(PyObject *obj, CUdeviceptr *out) {
+  CUdeviceptr p = td_get_ptr(obj);
+  if (PyErr_Occurred())
+    return -1;
+  *out = p;
+  if (p == 0)
+    return 0; /* valid nullptr */
+  CUdeviceptr dev = p;
+  CUresult status =
+      cuPointerGetAttribute(&dev, CU_POINTER_ATTRIBUTE_DEVICE_POINTER, p);
+  if (status == CUDA_ERROR_INVALID_VALUE) {
+    PyErr_Format(PyExc_ValueError,
+                 "Pointer argument cannot be accessed from Triton (cpu "
+                 "tensor?)");
+    return -1;
+  }
+  return gpuAssert(status, __FILE__, __LINE__) ? 0 : -1;
 }
 
 /* Fast fp16/bf16 packing (equivalent to extractFP16/BF16 but returns value) */
@@ -2357,6 +2391,18 @@ static int td_extract_tensordesc(TritonDispatcher *self, int i, PyObject *a) {
     PyErr_Clear();
   }
 
+  /* Check round_f32_to_tf32: overrides elem_type to TFLOAT32_FTZ (11).
+   * Mirrors the Python launcher's make_tensordesc_arg (driver.py). */
+  int runtime_elem_type = meta->elem_type;
+  PyObject *tf32_obj = PyObject_GetAttr(a, round_f32_to_tf32_str);
+  if (tf32_obj) {
+    if (PyObject_IsTrue(tf32_obj))
+      runtime_elem_type = 11; /* CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ */
+    Py_DECREF(tf32_obj);
+  } else {
+    PyErr_Clear();
+  }
+
   /* Encode (or reuse cached) the CUtensorMap via the shared launch.h encoder.
    * Pack base ptr + shape + strides into a flat args_buf in the layout the
    * recipe offsets below describe (same layout as testConstructTmaDesc): the
@@ -2367,7 +2413,7 @@ static int td_extract_tensordesc(TritonDispatcher *self, int i, PyObject *a) {
   memset(&recipe, 0, sizeof(recipe));
   recipe.ndim = ndim;
   recipe.swizzle = meta->swizzle;
-  recipe.elem_type = meta->elem_type;
+  recipe.elem_type = runtime_elem_type;
   recipe.elem_size = meta->elem_size;
   recipe.fp4_padded = meta->fp4_padded;
   recipe.fill_mode =
@@ -2411,6 +2457,16 @@ static int td_extract_tensordesc(TritonDispatcher *self, int i, PyObject *a) {
 
 static inline int td_convert_args(TritonDispatcher *self,
                                   PyObject *const *kargs) {
+  /* Ensure a CUDA context is current in this thread before
+   * extracting/validating pointers or launching. In a fresh thread (e.g.
+   * ThreadPoolExecutor) the driver has no context bound, so both
+   * cuPointerGetAttribute (pointer validation below) and cuLaunchKernelEx would
+   * fail with CUDA_ERROR_INVALID_CONTEXT (201). Mirrors the non-dispatcher
+   * launcher (launchKernel), which calls ensureCudaContext() on every launch;
+   * no-op when a context is already current. */
+  ensureCudaContext();
+  if (PyErr_Occurred())
+    return -1;
   int user_idx = 0; /* index into kargs[] (Python-visible args) */
   for (int i = 0; i < self->num_args; i++) {
     if (self->arg_types[i] == EXTRACTOR_SKIP_INDEX) {
@@ -2420,9 +2476,33 @@ static inline int td_convert_args(TritonDispatcher *self,
     PyObject *a = kargs[user_idx++];
     TDArgSlot *s = &self->arg_storage[i];
     switch (self->arg_types[i]) {
-    case EXTRACTOR_POINTER_INDEX:
-      s->ptr = td_get_ptr(a);
+    case EXTRACTOR_POINTER_INDEX: {
+      /* Reject non-device-accessible (pageable cpu) tensors before launch,
+       * matching the validated launcher path (extractPointer ->
+       * cuPointerGetAttribute). The dispatcher's plain td_get_ptr skips that
+       * check for speed, so without this a cpu tensor's host pointer would be
+       * passed straight to cuLaunchKernelEx (silent for a no-op kernel, an
+       * illegal/misaligned device access for any kernel that dereferences it).
+       *
+       * Fast path: if the torch bridge confirms a CUDA tensor (dev == 1), it is
+       * always device-accessible, so skip the driver call. Otherwise (dev == 0:
+       * a non-CUDA torch tensor such as a *pinned* host tensor, which IS device
+       * accessible; or dev == -1: bridge unavailable / non-torch object) verify
+       * via cuPointerGetAttribute, which correctly accepts pinned host memory
+       * and rejects only pageable cpu tensors. A current context is guaranteed
+       * by ensureCudaContext() at the top of td_convert_args. */
+      int8_t dev = (g_td_bridge && g_td_bridge->is_cuda_tensor)
+                       ? g_td_bridge->is_cuda_tensor(a)
+                       : -1;
+      if (dev == 1) {
+        s->ptr = td_get_ptr(a);
+        if (PyErr_Occurred())
+          return -1;
+      } else if (td_get_ptr_checked(a, &s->ptr) != 0) {
+        return -1;
+      }
       break;
+    }
     case EXTRACTOR_INT8_INDEX:
       s->i8 = (int8_t)PyLong_AsLong(a);
       break;
@@ -2523,6 +2603,8 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
   int num_warps, num_ctas, shared_mem;
   int launch_pdl, launch_coop, launch_cluster;
   int cluster_dim_x = 1, cluster_dim_y = 1, cluster_dim_z = 1;
+  int preferred_cluster_dim_x = 0, preferred_cluster_dim_y = 0,
+      preferred_cluster_dim_z = 0;
   PyObject *arg_type_codes;
   int has_global_scratch, has_profile_scratch;
   unsigned global_scratch_size = 0, global_scratch_align = 1;
@@ -2549,16 +2631,21 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
                            "cluster_dim_x",
                            "cluster_dim_y",
                            "cluster_dim_z",
+                           "preferred_cluster_dim_x",
+                           "preferred_cluster_dim_y",
+                           "preferred_cluster_dim_z",
                            NULL};
   PyObject *tma_meta_list = NULL;
 
   if (!PyArg_ParseTupleAndKeywords(
-          args, kwargs, "KiiiiiiOpp|IIIIOOOiii", kwlist, &func_ptr, &num_warps,
-          &num_ctas, &shared_mem, &launch_pdl, &launch_coop, &launch_cluster,
-          &arg_type_codes, &has_global_scratch, &has_profile_scratch,
-          &global_scratch_size, &global_scratch_align, &profile_scratch_size,
-          &profile_scratch_align, &allocator_obj, &profile_allocator_obj,
-          &tma_meta_list, &cluster_dim_x, &cluster_dim_y, &cluster_dim_z))
+          args, kwargs, "KiiiiiiOpp|IIIIOOOiiiiii", kwlist, &func_ptr,
+          &num_warps, &num_ctas, &shared_mem, &launch_pdl, &launch_coop,
+          &launch_cluster, &arg_type_codes, &has_global_scratch,
+          &has_profile_scratch, &global_scratch_size, &global_scratch_align,
+          &profile_scratch_size, &profile_scratch_align, &allocator_obj,
+          &profile_allocator_obj, &tma_meta_list, &cluster_dim_x,
+          &cluster_dim_y, &cluster_dim_z, &preferred_cluster_dim_x,
+          &preferred_cluster_dim_y, &preferred_cluster_dim_z))
     return NULL;
 
   TritonDispatcher *self = (TritonDispatcher *)type->tp_alloc(type, 0);
@@ -2714,7 +2801,7 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
     na++;
   }
   if (launch_cluster || num_ctas > 1 || cluster_dim_x > 1 ||
-      cluster_dim_y > 1 || cluster_dim_z > 1) {
+      cluster_dim_y > 1 || cluster_dim_z > 1 || preferred_cluster_dim_x > 0) {
     if (num_ctas > 1) {
       /* Legacy num_ctas path: 1-D cluster along x */
       self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
@@ -2736,6 +2823,18 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
         CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
     na++;
   }
+#if CUDA_VERSION >= 12080
+  if (preferred_cluster_dim_x > 0) {
+    self->launch_attrs[na].id = CU_LAUNCH_ATTRIBUTE_PREFERRED_CLUSTER_DIMENSION;
+    self->launch_attrs[na].value.preferredClusterDim.x =
+        preferred_cluster_dim_x;
+    self->launch_attrs[na].value.preferredClusterDim.y =
+        preferred_cluster_dim_y;
+    self->launch_attrs[na].value.preferredClusterDim.z =
+        preferred_cluster_dim_z;
+    na++;
+  }
+#endif
   self->num_launch_attrs = na;
 
   /* Build a shared-core launch descriptor so this dispatcher can launch via
@@ -2759,13 +2858,17 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
     self->core_desc.shared_mem = (unsigned)shared_mem;
     self->core_desc.launch_pdl = launch_pdl;
     self->core_desc.launch_cooperative_grid = launch_coop;
-    self->core_desc.launch_cluster = launch_cluster;
+    self->core_desc.launch_cluster =
+        launch_cluster || (preferred_cluster_dim_x > 0);
     /* Explicit multi-dim cluster (ctas_per_cga). When all <= 1, the core uses
      * the 1-D num_ctas path; num_ctas takes priority, so 1-D and multi-dim are
      * never both applied. */
     self->core_desc.cluster_dims[0] = cluster_dim_x;
     self->core_desc.cluster_dims[1] = cluster_dim_y;
     self->core_desc.cluster_dims[2] = cluster_dim_z;
+    self->core_desc.preferred_cluster_dims[0] = preferred_cluster_dim_x;
+    self->core_desc.preferred_cluster_dims[1] = preferred_cluster_dim_y;
+    self->core_desc.preferred_cluster_dims[2] = preferred_cluster_dim_z;
     self->core_desc.num_params = self->total_params;
     self->core_desc.num_tma_recipes = 0;
     /* params is a pointer; point it at the dispatcher-owned core_params storage
@@ -3515,6 +3618,10 @@ PyMODINIT_FUNC PyInit_cuda_utils(void) {
   }
   nan_str = PyUnicode_InternFromString("nan");
   if (nan_str == NULL) {
+    return NULL;
+  }
+  round_f32_to_tf32_str = PyUnicode_InternFromString("round_f32_to_tf32");
+  if (round_f32_to_tf32_str == NULL) {
     return NULL;
   }
 

--- a/third_party/nvidia/backend/launch.h
+++ b/third_party/nvidia/backend/launch.h
@@ -422,6 +422,7 @@ typedef struct {
   int64_t shape[TRITON_MAX_TMA_DIMS];
   int64_t stride[TRITON_MAX_TMA_DIMS];
   int fill_mode;
+  int elem_type;
 } triton_tma_cache_entry_t;
 
 /**
@@ -453,7 +454,8 @@ static inline CUresult triton_construct_tma_desc_cached(
   }
 
   if (cache->valid && cache->ptr == cur_ptr &&
-      cache->fill_mode == recipe->fill_mode) {
+      cache->fill_mode == recipe->fill_mode &&
+      cache->elem_type == recipe->elem_type) {
     int same = 1;
     for (int d = 0; d < recipe->ndim; d++) {
       if (cache->shape[d] != cur_shape[d] ||
@@ -471,6 +473,7 @@ static inline CUresult triton_construct_tma_desc_cached(
     cache->valid = 1;
     cache->ptr = cur_ptr;
     cache->fill_mode = recipe->fill_mode;
+    cache->elem_type = recipe->elem_type;
     for (int d = 0; d < recipe->ndim; d++) {
       cache->shape[d] = cur_shape[d];
       cache->stride[d] = cur_stride[d];

--- a/third_party/nvidia/backend/triton_dispatcher_factory.py
+++ b/third_party/nvidia/backend/triton_dispatcher_factory.py
@@ -61,9 +61,13 @@ def _expand_schema_arg_types(schema):
 
             if meta is None:
                 # Host-side path: base pointer + shape + strides + padding flag
+                # + round_f32_to_tf32 flag. Must mirror expand_signature()'s
+                # host TMA path (two i1 flags) and decompose_descriptor()'s
+                # arg layout: (arg.padding == "nan", arg.round_f32_to_tf32).
                 flat_types.append("*" + dtype)
                 for _ in range(2 * ndim):
                     flat_types.append("i64")
+                flat_types.append("i1")
                 flat_types.append("i1")
                 # Host-side also appends shapes (i32) + strides (i64) as explicit kernel args
                 for _ in range(ndim):
@@ -117,11 +121,14 @@ class _TensorDescDispatcherWrapper:
             if info is not None:
                 _, meta = info
                 assert meta is None, "TMA tensordesc should be handled in C, not Python wrapper"
-                # Host-side tensordesc: base ptr, shape, strides, padding, shape, strides
+                # Host-side tensordesc: base ptr, shape, strides, padding,
+                # round_f32_to_tf32, shape, strides — must mirror
+                # decompose_descriptor() in triton.backends.driver.
                 expanded.append(arg.base)
                 expanded.extend(arg.shape)
                 expanded.extend(arg.strides)
                 expanded.append(arg.padding == "nan")
+                expanded.append(arg.round_f32_to_tf32)
                 expanded.extend(arg.shape)
                 expanded.extend(arg.strides)
             else:
@@ -164,7 +171,7 @@ def make_triton_dispatcher(schema, cu_function: int):
                 _, ndim_td, meta_td = tensordesc_info[td_iter]
                 flat_pos_for_td.append(current_flat_pos)
                 if meta_td is None:
-                    current_flat_pos += 1 + 2 * ndim_td + 1 + ndim_td + ndim_td
+                    current_flat_pos += 1 + 2 * ndim_td + 2 + ndim_td + ndim_td
                 else:
                     current_flat_pos += 1 + ndim_td + ndim_td
                 td_iter += 1
@@ -208,6 +215,7 @@ def make_triton_dispatcher(schema, cu_function: int):
             tma_meta_list = None
 
     cluster_dims = schema.get("cluster_dims", [1, 1, 1])
+    preferred_cluster_dims = schema.get("preferred_cluster_dims", [0, 0, 0])
 
     c_dispatcher = mod._TritonDispatcher(
         function=cu_function,
@@ -230,6 +238,9 @@ def make_triton_dispatcher(schema, cu_function: int):
         cluster_dim_x=int(cluster_dims[0]) if len(cluster_dims) > 0 else 1,
         cluster_dim_y=int(cluster_dims[1]) if len(cluster_dims) > 1 else 1,
         cluster_dim_z=int(cluster_dims[2]) if len(cluster_dims) > 2 else 1,
+        preferred_cluster_dim_x=int(preferred_cluster_dims[0]) if len(preferred_cluster_dims) > 0 else 0,
+        preferred_cluster_dim_y=int(preferred_cluster_dims[1]) if len(preferred_cluster_dims) > 1 else 0,
+        preferred_cluster_dim_z=int(preferred_cluster_dims[2]) if len(preferred_cluster_dims) > 2 else 0,
     )
 
     # If there are host-side tensordescs (no TMA meta) that still need Python expansion,


### PR DESCRIPTION
Summary:

Turn the three Triton C fast-path flags ON by default and add a zero-overhead-when-off
stats mode so the (silent) fallbacks the fast path can take are discoverable.

Defaults flipped (opt-out with `=0`):
- TRITON_USE_C_DISPATCHER      (knobs.nvidia.use_triton_dispatcher)
- TRITON_AUTOTUNE_USE_C_CACHE  (knobs.nvidia.use_autotune_c_cache)
- TRITON_ENABLE_C_CACHE        (JITFunction.c_cache)

These move most Python kernel-launch overhead (TensorDescriptor build, workspace alloc,
split-K reduction launch, autotuner wrapper) off the measured/hot path. They were opt-in
and easy to mis-set (the eval docs used the non-existent `TRITON_USE_TRITON_DISPATCHER`),
so most callers never got the win.

Per-kernel opt-out preserved: `triton.jit(c_cache=False)` still disables the C cache for
that kernel. The env default only applies when c_cache is unspecified. (Implemented with a
None sentinel: `c_cache=None` -> env default; `True`/`False` -> honored. Previously the
default-on env would have overridden an explicit `c_cache=False` — fixed here.)

Motivation for the stats: the C fast paths **silently fall back** to slow Python launch on
unsupported inputs (e.g. a bare triton.jit kernel launched with a meta-kwarg like
`num_warps=` — see D112229431). Once the flags are on by default, owners need a way to
find kernels that miss the fast path. `TRITON_CACHE_STATS=1` counts, **per dispatch path,
per kernel**, hit vs fallback.

Design note (why C + Python): steady-state HITs happen entirely in C
(JITCacheProxy/AutotuneCacheProxy return without re-entering Python), so hit counting must
live in C (specialize.cc); fallbacks re-enter Python, so the finer Python-run() outcome is
counted there too. Events:
- autotune_proxy_hit / autotune_proxy_fallback   (C, autotuned kernels)
- jit_proxy_hit / jit_proxy_fallback             (C, bare kernels)
- run_fast_hit_c / run_fast_py_fallback          (Python run() fast path)
- run_slow_c / run_slow_py_fallback              (Python run() slow path)
Dump via `triton.runtime.jit.dump_cache_stats()` (merges C `native_dump_cache_stats()`
with the Python counters) or an atexit print (only when the flag is set).

Zero overhead when off: a single module-level bool (`g_cache_stats` in C,
`_CACHE_STATS_ON` in Python), read once; every record site is a single guarded branch, so
no map/mutex/name work happens unless TRITON_CACHE_STATS=1.

Blast radius: this changes the default for ALL Triton kernels at Meta. Opt-out is
`TRITON_USE_C_DISPATCHER=0` / `TRITON_ENABLE_C_CACHE=0` / `TRITON_AUTOTUNE_USE_C_CACHE=0`.
The stats mode is the mitigation for "silent fallback" — recommend canarying.

Files:
- python/triton/knobs.py       — two knob defaults -> True
- python/triton/runtime/jit.py — c_cache default on (None sentinel); Python stats + dump_cache_stats() + atexit
- python/src/specialize.cc     — C per-kernel hit/fallback counters on both proxies + native_dump_cache_stats()/native_reset_cache_stats()

Reviewed By: htyu

Differential Revision: D112435085


