### PR TITLE
[nightly] fbtriton nightly dev-wheel pipeline

### DIFF
--- a/.github/scripts/nightly_build_index.py
+++ b/.github/scripts/nightly_build_index.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Fetch current 'nightly' release assets and write a PEP 503 simple index
+(root + fbtriton/) under the given output directory, for GitHub Pages.
+"""
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from nightly_gen_simple_index import render_project_index, render_root_index  # noqa: E402
+
+REPO = os.environ.get("GITHUB_REPOSITORY", "facebookexperimental/triton")
+
+
+def sh(*a):
+    return subprocess.run(a, capture_output=True, text=True).stdout
+
+
+def main(outdir):
+    rel = json.loads(sh("gh", "api", f"repos/{REPO}/releases/tags/nightly"))
+    files = [(a["name"], a["browser_download_url"], (a.get("digest") or "").replace("sha256:", ""))
+             for a in rel.get("assets", [])
+             if a["name"].endswith(".whl")]
+    os.makedirs(os.path.join(outdir, "fbtriton"), exist_ok=True)
+    with open(os.path.join(outdir, "index.html"), "w") as f:
+        f.write(render_root_index())
+    with open(os.path.join(outdir, "fbtriton", "index.html"), "w") as f:
+        f.write(render_project_index(files))
+    print(f"wrote index with {len(files)} wheels -> {outdir}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/.github/scripts/nightly_gen_simple_index.py
+++ b/.github/scripts/nightly_gen_simple_index.py
@@ -1,0 +1,19 @@
+"""Generate a minimal PEP 503 'simple' index (HTML) for GitHub Pages."""
+import html as _html
+
+_PROJECT_TMPL = ("<!DOCTYPE html><html><head>"
+                 "<meta name='pypi:repository-version' content='1.0'>"
+                 "<title>Links for fbtriton</title></head><body>"
+                 "<h1>Links for fbtriton</h1>\n{anchors}\n</body></html>\n")
+
+
+def render_project_index(files):
+    anchors = "\n".join('<a href="{url}#sha256={sha}">{name}</a><br>'.format(url=_html.escape(url), sha=_html.escape(
+        sha), name=_html.escape(name)) for name, url, sha in files)
+    return _PROJECT_TMPL.format(anchors=anchors)
+
+
+def render_root_index():
+    return ("<!DOCTYPE html><html><body>"
+            '<a href="fbtriton/">fbtriton</a><br>'
+            "</body></html>\n")

--- a/.github/scripts/nightly_prune.py
+++ b/.github/scripts/nightly_prune.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Delete wheel assets on the rolling 'nightly' release beyond the last N builds
+(grouped by dev-date). latest.json and non-dated assets are left untouched.
+"""
+import collections
+import json
+import os
+import re
+import subprocess
+import sys
+
+REPO = os.environ.get("GITHUB_REPOSITORY", "facebookexperimental/triton")
+KEEP = int(sys.argv[1]) if len(sys.argv) > 1 else 30
+
+
+def sh(*a):
+    return subprocess.run(a, capture_output=True, text=True).stdout
+
+
+def main():
+    rel = json.loads(sh("gh", "api", f"repos/{REPO}/releases/tags/nightly"))
+    by_date = collections.defaultdict(list)
+    for a in rel.get("assets", []):
+        m = re.search(r"\.dev(\d{8})", a["name"])
+        if m:
+            by_date[m.group(1)].append(a)
+    stale_dates = sorted(by_date)[:-KEEP] if len(by_date) > KEEP else []
+    for date in stale_dates:
+        for a in by_date[date]:
+            sh("gh", "api", "-X", "DELETE", f"repos/{REPO}/releases/assets/{a['id']}")
+            print("pruned", a["name"])
+    print(f"kept {min(len(by_date), KEEP)} dev-date(s); pruned {len(stale_dates)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/nightly_run.py
+++ b/.github/scripts/nightly_run.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Nightly selection entrypoint.
+
+Reads the boundary (last-shipped commit) from the rolling 'nightly' Release's
+latest.json, enumerates new commits since then, walks them newest->oldest with
+nightly_select, and emits GitHub Actions outputs: status (ship|noop|nogreen),
+sha, version.
+"""
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from nightly_select import select  # noqa: E402
+
+REQUIRED = ["LIT Tests", "h100-tlx-test", "mi350-tlx-test", "b200-tlx-test"]
+# Publish target (releases + latest.json): the repo running this workflow.
+REPO = os.environ.get("GITHUB_REPOSITORY", "facebookexperimental/triton")
+# Where CI check-runs are read from. Defaults to REPO; override for fork testing
+# (a fork's own GPU CI is guarded off, but it shares commit SHAs with upstream).
+SIGNAL_REPO = os.environ.get("TRITON_SIGNAL_REPO") or REPO
+CAP = 100
+
+
+def sh(*args):
+    return subprocess.run(args, capture_output=True, text=True).stdout
+
+
+def gh_json(path):
+    out = sh("gh", "api", path)
+    return json.loads(out) if out.strip() else None
+
+
+def boundary_commit():
+    """Full SHA of the last shipped nightly, from latest.json on the rolling release."""
+    data = gh_json(f"repos/{REPO}/releases/tags/nightly")
+    if not data:
+        return None
+    for asset in data.get("assets", []):
+        if asset["name"] == "latest.json":
+            raw = sh("gh", "api", asset["url"], "-H", "Accept: application/octet-stream")
+            try:
+                return json.loads(raw).get("commit")
+            except json.JSONDecodeError:
+                return None
+    return None
+
+
+def new_commits(boundary):
+    rng = f"{boundary}..HEAD" if boundary else "HEAD"
+    out = sh("git", "rev-list", "--max-count", str(CAP), rng)
+    return [line for line in out.split() if line]
+
+
+def fetch(sha):
+    data = gh_json(f"repos/{SIGNAL_REPO}/commits/{sha}/check-runs?per_page=100") or {}
+    by_check = {}
+    for cr in data.get("check_runs", []):
+        by_check.setdefault(cr["name"],
+                            []).append({"completed_at": cr.get("completed_at"), "conclusion": cr.get("conclusion")})
+    return by_check
+
+
+def emit(**kv):
+    with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+        for k, v in kv.items():
+            f.write(f"{k}={v}\n")
+
+
+def base_version():
+    m = re.search(r'^TRITON_VERSION = "([0-9]+\.[0-9]+\.[0-9]+)"', open("setup.py").read(), re.M)
+    return m.group(1) if m else "3.8.0"
+
+
+def main():
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cut = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    date = now.strftime("%Y%m%d")
+    shas = new_commits(boundary_commit())
+    if not shas:
+        print("no new commits since last nightly -> noop")
+        emit(status="noop")
+        return
+    sha = select(shas, fetch, REQUIRED, cut, CAP)
+    if not sha:
+        print(f"no all-green commit in {len(shas)} candidates -> nogreen")
+        emit(status="nogreen")
+        return
+    # The nightly version *scheme* is decided here (the caller); wheels_fb only
+    # applies the provided version string.
+    version = f"{base_version()}.dev{date}"
+    print(f"selected {sha} -> ship {version}")
+    emit(status="ship", sha=sha, version=version)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/nightly_select.py
+++ b/.github/scripts/nightly_select.py
@@ -1,0 +1,27 @@
+"""Point-in-time nightly commit selection (pure, unit-tested).
+
+A check is green iff its LATEST completed verdict (success/failure/timed_out)
+as of the cut time is success; cancelled runs are ignored.
+"""
+from __future__ import annotations
+
+_VERDICT = ("success", "failure", "timed_out")
+
+
+def check_green(runs, cut):
+    verdicts = sorted(
+        (x for x in runs if x.get("conclusion") in _VERDICT and x.get("completed_at") and x["completed_at"] <= cut),
+        key=lambda x: x["completed_at"],
+    )
+    return bool(verdicts) and verdicts[-1]["conclusion"] == "success"
+
+
+def commit_green(runs_by_check, required, cut):
+    return all(check_green(runs_by_check.get(name, []), cut) for name in required)
+
+
+def select(shas, fetch, required, cut, cap=100):
+    for sha in shas[:cap]:
+        if commit_green(fetch(sha), required, cut):
+            return sha
+    return None

--- a/.github/scripts/test_nightly_gen_simple_index.py
+++ b/.github/scripts/test_nightly_gen_simple_index.py
@@ -1,0 +1,16 @@
+from nightly_gen_simple_index import render_project_index, render_root_index
+
+
+def test_project_index_lists_files_with_hash():
+    html = render_project_index([
+        ("fbtriton-3.8.0.dev20260717-cp312-cp312-manylinux_2_28_x86_64.whl", "https://example/dl/fbtriton-...whl",
+         "deadbeef"),
+    ])
+    assert "fbtriton-3.8.0.dev20260717-cp312" in html
+    assert "#sha256=deadbeef" in html
+    assert "<a href=" in html
+
+
+def test_root_index_links_project():
+    html = render_root_index()
+    assert 'href="fbtriton/"' in html

--- a/.github/scripts/test_nightly_select.py
+++ b/.github/scripts/test_nightly_select.py
@@ -1,0 +1,53 @@
+from nightly_select import check_green, commit_green, select
+
+CUT = "2026-07-17T04:00:00Z"
+
+
+def r(t, c, e="schedule"):
+    return {"completed_at": t, "conclusion": c, "event": e}
+
+
+def test_latest_verdict_wins_over_earlier_success():
+    runs = [r("2026-07-16T10:00:00Z", "success"), r("2026-07-16T14:00:00Z", "failure")]
+    assert check_green(runs, CUT) is False
+
+
+def test_cancelled_is_ignored_not_a_verdict():
+    runs = [r("2026-07-16T00:59:00Z", "cancelled"), r("2026-07-17T03:01:00Z", "success")]
+    assert check_green(runs, CUT) is True
+
+
+def test_runs_after_cut_are_invisible():
+    runs = [r("2026-07-17T18:46:00Z", "success")]  # after 04:00 cut
+    assert check_green(runs, CUT) is False
+
+
+def test_no_runs_is_not_green():
+    assert check_green([], CUT) is False
+
+
+def test_commit_green_requires_all_four():
+    ok = {
+        "LIT Tests": [r("2026-07-16T01:00:00Z", "success")], "h100-tlx-test": [r("2026-07-17T03:01:00Z", "success")],
+        "mi350-tlx-test": [r("2026-07-16T01:00:00Z",
+                             "success")], "b200-tlx-test": [r("2026-07-16T01:10:00Z", "success")]
+    }
+    req = ["LIT Tests", "h100-tlx-test", "mi350-tlx-test", "b200-tlx-test"]
+    assert commit_green(ok, req, CUT) is True
+    missing = dict(ok)
+    missing["b200-tlx-test"] = []
+    assert commit_green(missing, req, CUT) is False
+
+
+def test_select_walks_to_first_green():
+    data = {
+        "newest": {"LIT Tests": []},  # not green
+        "older": {"LIT Tests": [r("2026-07-16T01:00:00Z", "success")]}
+    }
+    req = ["LIT Tests"]
+    assert select(["newest", "older"], lambda s: data[s], req, CUT) == "older"
+
+
+def test_select_returns_none_when_cap_exhausted():
+    req = ["LIT Tests"]
+    assert select(["a", "b"], lambda s: {"LIT Tests": []}, req, CUT) is None

--- a/.github/workflows/nightly-fbtriton.yml
+++ b/.github/workflows/nightly-fbtriton.yml
@@ -1,0 +1,122 @@
+name: Nightly fbtriton
+# Selects the newest commit on main whose four required checks are all green
+# (latest-verdict, SHA-keyed, trigger-agnostic), builds a shrunk wheel matrix,
+# and publishes it to the rolling 'nightly' GitHub Release behind a GitHub Pages
+# PEP 503 index. No PyPI, no PAT.
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      signal_repo:
+        description: "Read CI check-runs from this repo (blank = this repo). For fork testing, set to facebookexperimental/triton."
+        required: false
+        default: ""
+
+# Top-level defaults to read-all so the `build` job satisfies wheels_fb's own
+# `permissions: read-all` (a reusable workflow cannot request more than its caller).
+# Jobs that need writes narrow their scope explicitly below.
+permissions: read-all
+
+concurrency:
+  group: nightly-fbtriton
+  cancel-in-progress: false
+
+jobs:
+  select:
+    # Scheduled runs only fire on the upstream repo; manual dispatch works anywhere
+    # (e.g. a fork, for end-to-end testing).
+    if: github.event_name == 'workflow_dispatch' || github.repository_owner == 'facebookexperimental'
+    runs-on: ubuntu-latest
+    outputs:
+      sha:     ${{ steps.pick.outputs.sha }}
+      version: ${{ steps.pick.outputs.version }}   # derived here: <base>.dev<date>
+      status:  ${{ steps.pick.outputs.status }}    # 'ship' | 'noop' | 'nogreen'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Pick commit
+        id: pick
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRITON_SIGNAL_REPO: ${{ inputs.signal_repo }}
+        run: python3 .github/scripts/nightly_run.py
+
+  build:
+    needs: select
+    if: needs.select.outputs.status == 'ship'
+    uses: ./.github/workflows/wheels_fb.yml
+    with:
+      ref:     ${{ needs.select.outputs.sha }}
+      version: ${{ needs.select.outputs.version }}
+      pythons: '["cp312","cp313"]'
+      arches:  '["x86_64","aarch64"]'
+
+  publish:
+    needs: [select, build]
+    # Per-repo Releases/Pages: a fork publishes only to its own. The select
+    # guard already blocks forks on schedule, so this fires on upstream schedule
+    # or on a deliberate dispatch (incl. a fork building its own nightly).
+    if: needs.select.outputs.status == 'ship'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create/update the rolling Release + assets
+      pages: write
+      id-token: write
+      actions: read      # download-artifact
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v6
+        with:
+          path: dist
+          pattern: wheels-*
+          merge-multiple: true
+      - name: Ensure rolling 'nightly' release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release view nightly || gh release create nightly --title "fbtriton nightly" --notes "Rolling nightly wheels." --latest=false
+      - name: Upload wheels + latest.json
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload nightly dist/*.whl --clobber
+          printf '{"commit":"%s","version":"%s"}\n' \
+            "${{ needs.select.outputs.sha }}" "${{ needs.select.outputs.version }}" > latest.json
+          gh release upload nightly latest.json --clobber
+      - name: Prune assets older than retention window
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/nightly_prune.py 30
+      - name: Generate simple index from current assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/nightly_build_index.py public/nightly/simple
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+      - id: deploy
+        uses: actions/deploy-pages@v4
+
+  report-nogreen:
+    needs: select
+    if: needs.select.outputs.status == 'nogreen'
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    uses: ./.github/workflows/report-nightly-failure.yml
+    with:
+      issue_title: "Nightly fbtriton: no green commit in the last 100 commits"
+      normalized_failure_id: "nightly-fbtriton-nogreen"
+      workflow_name: "Nightly fbtriton"
+      job_name: "select"
+      run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      ref: "refs/heads/main"
+      sha: "${{ github.sha }}"
+      event_name: "schedule"
+      run_attempt: "${{ github.run_attempt }}"
+      summary: "No commit in the walked window had all four required checks green as of the cut."

--- a/.github/workflows/wheels_fb.yml
+++ b/.github/workflows/wheels_fb.yml
@@ -15,6 +15,14 @@ name: Wheels (fbtriton)
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      ref:      { type: string, required: false, default: "" }
+      # Caller-provided clean version to pin (e.g. nightly '3.8.0.dev20260717').
+      # The version *scheme* is decided by the caller; this workflow only applies it.
+      version:  { type: string, required: false, default: "" }
+      # Optional ABI-matrix overrides; default to the full fork matrix.
+      pythons:  { type: string, required: false, default: '["cp310","cp311","cp312","cp313","cp314"]' }
+      arches:   { type: string, required: false, default: '["x86_64","aarch64"]' }
   pull_request:
     paths:
       - .github/workflows/wheels_fb.yml
@@ -32,12 +40,26 @@ jobs:
       # ABIs/arches work and which break.
       fail-fast: false
       matrix:
-        python: [cp310, cp311, cp312, cp313, cp314]
-        arch: [x86_64, aarch64]
+        python: ${{ fromJSON(inputs.pythons || '["cp310","cp311","cp312","cp313","cp314"]') }}
+        arch:   ${{ fromJSON(inputs.arches  || '["x86_64","aarch64"]') }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      # Apply the caller-provided version: pin the clean wheel version and stamp
+      # the short commit hash into the runtime __version__ (HEAD is the
+      # checked-out target commit). Generic — the version scheme is the caller's.
+      - name: Pin version + runtime __version__ (workflow_call builds)
+        if: ${{ inputs.version != '' }}
+        run: |
+          short="$(git rev-parse --short=8 HEAD)"
+          sed -i "s:^TRITON_VERSION = .*:TRITON_VERSION = '${{ inputs.version }}':" setup.py
+          sed -i "s:^__version__ = .*:__version__ = '${{ inputs.version }}+fb.git${short}':" python/triton/__init__.py
+          grep '^TRITON_VERSION' setup.py
+          grep '^__version__' python/triton/__init__.py
 
       # Tag-triggered builds (via publish.yml) need a clean PEP 440 version
       # (no +gitHASH suffix) for PyPI. Bypass setup.py's dynamic version

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ Primarily targeting NVIDIA GPUs (for now), TLX extends Triton to support:
 While this approach places more responsibility on the user, it reduces the compiler's role as a performance bottleneck. Although it may introduce divergence across hardware platforms, it empowers users to perform deeper, architecture-specific optimizations without relying solely on compiler heuristics.
 
 
+## Nightly builds (fbtriton)
+
+Nightly `.dev` wheels are published to a self-managed index (not PyPI):
+
+    pip install --pre fbtriton \
+      --index-url https://facebookexperimental.github.io/triton/nightly/simple/
+
+Each nightly is built from the newest `main` commit whose GPU/CI checks are all
+green. `triton.__version__` reports `3.8.0.dev<YYYYMMDD>+fb.git<hash>`. Nightlies
+are retained for ~30 days. Formal releases remain on PyPI (`pip install fbtriton`).
+
+
 ## Gluon support
 
 [Gluon](https://github.com/triton-lang/triton/tree/main/python/triton/experimental/gluon)

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,5 +1,5 @@
 """isort:skip_file"""
-__version__ = '3.7.0+fb.beta'
+__version__ = '3.8.0+fb'
 
 # ---------------------------------------
 # Note: import order is significant here.

--- a/setup.py
+++ b/setup.py
@@ -572,7 +572,7 @@ def get_triton_version_suffix():
 
 
 # keep it separate for easy substitution
-TRITON_VERSION = "3.7.0" + get_triton_version_suffix()
+TRITON_VERSION = "3.8.0" + get_triton_version_suffix()
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 10)

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -260,7 +260,8 @@ void init_triton_tlx_ir(py::module &&m) {
               std::vector<std::vector<int32_t>> offsetBases,
               std::vector<std::vector<int32_t>> blockBases, int rank) {
              // Build #ttg.padded_shared from explicit linear bases ({offset,
-             // block}), so a caller can pin a swizzled layout, not just identity.
+             // block}), so a caller can pin a swizzled layout, not just
+             // identity.
              if (intervals.size() != paddings.size())
                throw std::runtime_error(
                    "make_padded_shared_encoding_attr_with_bases: intervals and "


### PR DESCRIPTION
## Summary

Automated nightly `.dev` wheel pipeline for fbtriton, independent of PyPI.

`nightly-fbtriton.yml` (cron 04:00 UTC + manual dispatch) selects the newest `main`
commit whose four required checks (`LIT Tests`, `h100-tlx-test`, `mi350-tlx-test`,
`b200-tlx-test`) are all green — per-commit `check-runs`, latest-verdict, SHA-keyed,
trigger-agnostic, with a `latest.json` boundary read back from a rolling `nightly`
GitHub Release. It builds a shrunk matrix (cp312/cp313 × x86_64/aarch64) via the
extended reusable `wheels_fb.yml` and publishes wheels to that Release behind a
GitHub Pages PEP 503 index (pruned to the last 30). No new commits → exit; new but
none green → files a tracking issue (reuses `report-nightly-failure.yml`).

Formal releases still go to PyPI via `publish_fbtriton.yml` (untouched).
`GITHUB_TOKEN` only — no PAT/App token, no PyPI dependency for nightlies.

**Version model:** base bumped to `3.8.0`; nightly wheel = clean `3.8.0.dev<date>`
(PyPI-compatible), runtime `triton.__version__` = `3.8.0.dev<date>+fb.git<hash>`
(applied via `setup.py`'s existing substitution hook).

## Test Plan

- `cd .github/scripts && python3 -m pytest -q` → 31 passed
- Selection dry-run (read-only): `nightly_run.py` picks the newest green commit
- **End-to-end validated on a fork** (`wychi/triton`, signals from `facebookexperimental/triton`):
  - Happy: build (4 wheels) → Release → Pages; then
    `uv pip install --pre fbtriton --index-url https://wychi.github.io/triton/nightly/simple/`
    → `fbtriton==3.8.0.dev20260718` (clean packaging version),
    `triton.__version__ == 3.8.0.dev20260718+fb.git82b44af2` (runtime local segment)
  - Error: forced `nogreen` → `build`/`publish` skipped, `report-nogreen` filed the tracking issue

## Deployment prerequisite

⚠️ Enable GitHub Pages (Actions source) on this repo before the first run, or `publish` fails:
`gh api -X POST repos/facebookexperimental/triton/pages -f build_type=workflow` (needs admin).

🤖 Authored with Claude Code.
