### PR TITLE
[TLX][AMD] Add BLOCK_N=256 warp-pipe addmm configs (gfx950)

### DIFF
--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1146,11 +1146,17 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
     """
 
     # (BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M, num_warps, NUM_BUFFERS)
+    # BLOCK_N=256 tiles mirror the amd_addmm_glu tutorial winners for the M=1024
+    # regime; on gfx950 they beat the BLOCK_N<=128 tiles on large-N shapes (e.g.
+    # 1024x22272x1024 reaches ~98% of rocBLAS, up from ~92%). LDS: (128x256x64,NB2)
+    # = 96KB, (128x256x32,NB3) = 72KB -- both fit gfx950 (256x256x64 does not).
     WARPPIPE_CONFIGS = [
         (64, 64, 128, 8, 8, 3),
         (64, 64, 64, 8, 8, 3),
         (128, 128, 64, 8, 8, 2),
         (64, 128, 64, 8, 8, 2),
+        (128, 256, 64, 8, 8, 2),
+        (128, 256, 32, 8, 8, 3),
     ]
 
     def adjust_kernel_inputs(


### PR DESCRIPTION
Summary:
Adds two `BLOCK_N=256` tiles to `ROCmAddMMWarpPipeTemplateConfigHeuristic.WARPPIPE_CONFIGS`, which previously capped at `BLOCK_N=128`. The `amd_addmm_glu` TLX tutorial — same M=1024 regime as production merge nets — wins with `BLOCK_N=256` on large-N shapes ("BN=256/BK=32 beats BN=128/BK=64 at all K"), so our config list was leaving those tiles on the table.

New configs: `(BM=128, BN=256, BK=64, GROUP_M=8, num_warps=8, NB=2)` (96KB LDS) and `(BM=128, BN=256, BK=32, GROUP_M=8, num_warps=8, NB=3)` (72KB LDS). Both fit the gfx950 LDS budget; `256x256x64` does not, so `BLOCK_M` stays 128. Autotune picks the best tile per shape, so smaller shapes are unaffected.

Stacked on the RAW-race fix because the `BLOCK_N=256` tiles use the same `async_load_wait_group` drain and would be numerically unsafe without it.

Measured in tritonbench (`--op addmm --col-major --bias-1D-y`, fp16, Inductor autotune do_bench) on the merge net's fusable-epilogue GEMM shapes. `BLOCK_N=256` improves the warp-pipe kernel on large-N shapes with no regression elsewhere:

| shape M,N,K | TLX before (BN<=128) | TLX after (+BN256) | rocBLAS | TLX % of rocBLAS |
|---|---|---|---|---|
| 1024,22272,1024 | 0.0751 ms | 0.0710 ms (BN256 wins) | 0.0696 ms | 92% -> 98% |
| 1024,6144,22272 | 0.4508 ms | 0.3935 ms (BN256 wins) | 0.3088 ms | 69% -> 78% |
| 1024,16384,1024 | 0.0519 ms | 0.0504 ms (BN256 wins) | 0.0412 ms | 79% -> 82% |

`1024x22272x1024` reaches ~98% of rocBLAS. For context, the fully-optimized TLX GEMM reference (`gfx9_gemm/a16w16` v9) tops out at ~89% of rocBLAS on a compute-bound square shape, so our compute-bound addmm shapes (92-105%) are at or above the TLX ceiling. The residual gap on large-K shapes (K >= 6144) is a separate, general Triton-vs-rocBLAS issue (rocBLAS uses Stream-K / `SK3`; both stock `triton_mm` and the TLX warp-pipe use a single-CTA K reduction) and is out of scope for this config change.

Authored with Claude.

Reviewed By: z1sz

Differential Revision: D111541872


