### PR TITLE
[TLX] Enable linear warp-specialization lowering

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -1189,7 +1189,7 @@ def matmul_kernel_tma_ws_blackwell(
         tmem_empty_bars = tlx.alloc_barriers(num_barriers=NUM_TMEM_BUFFERS * NUM_MMA_GROUPS,
                                              arrive_count=EPILOGUE_SUBTILE)
 
-    with tlx.async_tasks():
+    with tlx.async_tasks(exclusive=True, no_ending_cluster_sync=True):
         with tlx.async_task("default"):  # epilogue consumer
             (
                 start_pid,


### PR DESCRIPTION
Summary:
Enable the linear warp-specialization lowering used by the Blackwell TLX GEMM schedule.

For fp16 TT GEMM with M/N/K = 1024/12800/1152, the saved linear-WS-lowering profile improves duration by 1.88%, elapsed cycles by 2.08%, compute throughput by 1.79 percentage points, and memory bandwidth by 1.92% versus the saved baseline. Barrier and membar samples fall sharply, while register usage is unchanged and dynamic shared memory decreases slightly.

Reviewed By: wlei-llvm

Differential Revision: D112669788


