### PR TITLE
[triton][beta] [Cherry-pick] '[Rubin] Misc MMA enhancement and `mbarrier.arrive.multicast` support (#10941)' (#2254)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -85,6 +85,12 @@ inline bool is2CTA(Operation *op) {
   return is2CTA(op->getParentOfType<ModuleOp>());
 }
 
+// Returns the required ordering of repeated TMEM scale blocks for one
+// tcgen05 scaled-MMA operand.
+TensorMemoryScalesBlockRepOrder getTensorMemoryScalesBlockRepOrder(
+    Operation *op, bool isA, ScaleDotElemType aType, ScaleDotElemType bType,
+    Type aScaleElemType, Type bScaleElemType);
+
 struct TensorMemory : public SideEffects::Resource::Base<TensorMemory> {
   StringRef getName() const final { return "<TensorMemory>"; }
   SideEffects::Resource *getParent() const override { return nullptr; }

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -58,6 +58,19 @@ public:
     return computeCapability >= 103 && computeCapability / 10 != 12;
   }
 
+  bool supportsI8Tcgen05MMA() const { return computeCapability == 100; }
+  bool supportsExclusiveTMEMAlloc() const { return computeCapability == 107; }
+  int getMaxTMEMColumns() const {
+    return supportsExclusiveTMEMAlloc() ? 576 : 512;
+  }
+  bool requiresFp4Padding() const {
+    return computeCapability == 100 || computeCapability == 103 ||
+           computeCapability == 110;
+  }
+  bool supports4xFp4Tcgen05MMA() const { return computeCapability == 107; }
+  bool supports2xFp8Tcgen05MMA() const { return computeCapability == 107; }
+  bool supportsReuseB() const { return computeCapability == 107; }
+
 private:
   static constexpr char kTargetPrefix[] = "cuda:";
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUAttrDefs.td
@@ -70,6 +70,21 @@ def TTNG_TMEMLoadReduceModifierEnum : EnumAttr<TritonNvidiaGPU_Dialect, TTNG_TME
   let assemblyFormat = "`<` $value `>`";
 }
 
+def TTNG_TensorMemoryScalesBlockRepOrderAttr : I32EnumAttr<
+    "TensorMemoryScalesBlockRepOrder", "",
+    [
+        I32EnumAttrCase<"MN_THEN_K", 0, "mnThenK">,
+        I32EnumAttrCase<"K_THEN_MN", 1, "kThenMn">,
+    ]> {
+    let cppNamespace = "::mlir::triton::nvidia_gpu";
+    let genSpecializedAttr = 0;
+}
+def TTNG_TensorMemoryScalesBlockRepOrderEnum
+    : EnumAttr<TritonNvidiaGPU_Dialect,
+               TTNG_TensorMemoryScalesBlockRepOrderAttr, "blockRepOrder"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
 def TTNG_CGALayoutRankTwoParam
     : AttrOrTypeParameter<"::mlir::triton::gpu::CGAEncodingAttr",
                           "rank-2 CGA layout"> {
@@ -120,14 +135,29 @@ def TTG_TensorMemoryScalesEncodingAttr
   let description = [{
     An encoding to represent the layout of tensor memory scales.
     As described in the PTX doc, blocked scales in TMEM must be in a special layout. They are organized
-    as a multiple copies of "chunk", each of which having the size 32x4x4B. Moreover, such chunks are duplicated
+    as a multiple copies of a block, each of which having the size 32x4x4B. Moreover, such blocks are duplicated
     over 4 warps to fill entire 128 rows of TMEM. This encoding indicates that a tensor in TMEM is in such a special
     layout.
+    The parameter blockRepOrder determines the ordering of repeated scale blocks along TMEM columns. Here `mn`
+    denotes the MMA instruction's non-K matrix dimension: `M` for A scales and `N` for B scales. `mnThenK`
+    advances along that dimension before advancing K, while `kThenMn` advances along K before advancing the
+    non-K dimension. When one MMA instruction consumes only one scale block along K, the value of this parameter
+    does not matter. Otherwise, it must match the hardware instruction layout. For example, Rubin NVFP4 A scales
+    with `BLOCK_M = 256` require `kThenMn`, while B scales keep the default `mnThenK`.
   }];
   let parameters = (
     ins
-    TTNG_CGALayoutRankTwoParam:$CGALayout
+    TTNG_CGALayoutRankTwoParam:$CGALayout,
+    DefaultValuedParameter<
+        "::mlir::triton::nvidia_gpu::TensorMemoryScalesBlockRepOrder",
+        "::mlir::triton::nvidia_gpu::TensorMemoryScalesBlockRepOrder::MN_THEN_K">:$blockRepOrder
   );
+  let builders = [
+    AttrBuilder<(ins "::mlir::triton::gpu::CGAEncodingAttr":$CGALayout), [{
+      return get(context, CGALayout,
+                 ::mlir::triton::nvidia_gpu::TensorMemoryScalesBlockRepOrder::MN_THEN_K);
+    }]>
+  ];
   let genVerifyDecl = 1;
   let assemblyFormat = "`<` struct(params) `>`";
 }

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -485,6 +485,14 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier"> {
     of at least 1, and decreasing the pending arrival count of the mbarrier by
     the specific count.
 
+    When `ctaMask` is non-zero, the arrive is multicast across the cluster.
+    Each bit set in the mask identifies a CTA ID dimension to multicast
+    along. CTA IDs `a` and `b` belong to the same equivalence class iff
+    `a & ~ctaMask == b & ~ctaMask`; all CTAs in a class multicast to each
+    other. Multicast requires `numCTAs > 1`, `0 < ctaMask <= numCTAs - 1`,
+    and the barrier must have the identity CGA layout `[[1], [2], ...]`. The
+    default value of `ctaMask` is 0 (no multicast).
+
     The operation accepts an optional predicate.
 
     Example:
@@ -492,12 +500,14 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier"> {
     ```mlir
     ttng.arrive_barrier %barrier, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttng.arrive_barrier %barrier, 1, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %barrier, 1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64, #shared, #smem, mutable>
     ```
   }];
 
   let arguments = (ins
     Arg<TTG_MemDescType, "", [MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$alloc,
     I32Attr:$count,
+    DefaultValuedOptionalAttr<I32Attr, "0">:$ctaMask,
     Optional<I1>:$pred,
     UnitAttr:$perThread,
     OptionalAttr<DictionaryAttr>:$constraints
@@ -509,18 +519,30 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier"> {
 
   let builders = [
     OpBuilder<(ins "Value":$alloc, "uint32_t":$count), [{
-      return build($_builder, $_state, alloc, count, /*pred=*/Value(), /*perThread=*/false, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), /*perThread=*/false, /*constraints=*/DictionaryAttr());
     }]>,
     OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred), [{
-      return build($_builder, $_state, alloc, count, pred, /*perThread=*/false, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, /*perThread=*/false, /*constraints=*/DictionaryAttr());
+    }]>,
+    OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "uint32_t":$ctaMask,
+                   "Value":$pred), [{
+      return build($_builder, $_state, alloc, count, ctaMask, pred, /*perThread=*/false, /*constraints=*/DictionaryAttr());
     }]>,
     OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "bool":$perThread), [{
-      return build($_builder, $_state, alloc, count, /*pred=*/Value(), perThread, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), perThread, /*constraints=*/DictionaryAttr());
     }]>,
     OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred, "bool":$perThread), [{
-      return build($_builder, $_state, alloc, count, pred, perThread, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, /*constraints=*/DictionaryAttr());
+    }]>,
+    OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred,
+                   "bool":$perThread, "DictionaryAttr":$constraints), [{
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, constraints);
     }]>
   ];
+
+  let extraClassDeclaration = [{
+    bool isMulticast() { return getCtaMask() != 0; }
+  }];
 
   let hasVerifier = 1;
 }

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -17,6 +17,7 @@
 #include "llvm/Support/MathExtras.h"
 
 using mlir::triton::nvidia_gpu::TensorMemoryEncodingAttr;
+using mlir::triton::nvidia_gpu::TensorMemoryScalesBlockRepOrder;
 using mlir::triton::nvidia_gpu::TensorMemoryScalesEncodingAttr;
 
 namespace mlir::triton::gpu {
@@ -1154,13 +1155,27 @@ tensorMemoryScalesToLinearLayout(ArrayRef<int64_t> shape,
               LinearLayout::zeros1D(4, kRow, dims[0]) *
               LinearLayout::identity1D(4, kCol, dims[1]) *
               LinearLayout::identity1D(2, kCol, dims[0]);
-  // We choose repOrder = [0, 1]
-  tile *= LinearLayout::identity1D(
-              llvm::divideCeil(shapePerCTA[0], tile.getOutDimSize(dims[0])),
-              kCol, dims[0]) *
-          LinearLayout::identity1D(
-              llvm::divideCeil(shapePerCTA[1], tile.getOutDimSize(dims[1])),
-              kCol, dims[1]);
+  auto repsMn = llvm::divideCeil(shapePerCTA[0], tile.getOutDimSize(dims[0]));
+  auto repsK = llvm::divideCeil(shapePerCTA[1], tile.getOutDimSize(dims[1]));
+
+  if (repsMn > 1) {
+    // blockRepOrder applies after this normalization step. First merge the two
+    // MN-adjacent 64x4 pieces into the repeated scale block, then order the
+    // remaining block repetitions along MN and K.
+    tile *= LinearLayout::identity1D(2, kCol, dims[0]);
+    repsMn /= 2;
+  }
+
+  if (encoding.getBlockRepOrder() ==
+      TensorMemoryScalesBlockRepOrder::K_THEN_MN) {
+    // kThenMn uses repOrder = [1, 0] at the repeated block level.
+    tile *= LinearLayout::identity1D(repsK, kCol, dims[1]) *
+            LinearLayout::identity1D(repsMn, kCol, dims[0]);
+  } else {
+    // mnThenK uses repOrder = [0, 1] at the repeated block level.
+    tile *= LinearLayout::identity1D(repsMn, kCol, dims[0]) *
+            LinearLayout::identity1D(repsK, kCol, dims[1]);
+  }
   // Add a trivial block dimension
   tile *= LinearLayout::identity1D(1, kBlock, dims[0]);
   // See [Zeros in TMEM LinearLayouts]

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -31,7 +31,7 @@ namespace gpu {
 namespace {
 
 static bool isUnsupportedMMAv5Int8Dot(int computeCapability, DotOp op) {
-  if (computeCapability != 103)
+  if (nvidia_gpu::TargetFeatures(computeCapability).supportsI8Tcgen05MMA())
     return false;
   auto aElemTy = op.getA().getType().getElementType();
   auto bElemTy = op.getB().getType().getElementType();
@@ -843,10 +843,29 @@ public:
       else if (isBFP4)
         IsBMixedPrecFp4 = true;
     }
-    // If we use txgen05.mma.kind.mxf864 we need to padd the fp4 operands:
+
+    bool isFp4MMA = isAFP4 && isBFP4;
+    bool requiresFp4Padding =
+        nvidia_gpu::TargetFeatures(computeCapability).requiresFp4Padding();
+
+    // On Blackwell, if we use mixed-precision MMA we need to pad the fp4
+    // operand
     // https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-packing-formats-mxf8f6f4-smem
-    bool isMMAv5Fp4PaddedLhs = IsAMixedPrecFp4 || !dotOp.getLhsKPack();
-    bool isMMAv5Fp4PaddedRhs = IsBMixedPrecFp4 || !dotOp.getRhsKPack();
+    // On Rubin, the fp4 operand must be packed in SMEM if MMA_K = 64 is used.
+    // However, MMA_K = 64 with MN-major fp4 is not supported. In this case,
+    // the fp4 operand must be padded and MMA_K = 32 must be used.
+    // MMA_K = 64 is also not supported when BLOCK_M = 64.
+    auto blockK = dotOp.getA().getType().getShape().back() * (isAFP4 ? 2 : 1);
+    auto blockM = dotOp.getA().getType().getShape()[0];
+    bool isMMAv5Fp4PaddedLhs =
+        (isFp4MMA && !dotOp.getLhsKPack()) || // fp4  x fp4 with M-major A
+        (IsAMixedPrecFp4 && (requiresFp4Padding || blockM == 64 ||
+                             blockK == 32 || !dotOp.getLhsKPack()));
+    bool isMMAv5Fp4PaddedRhs =
+        (isFp4MMA && !dotOp.getRhsKPack()) || // fp4  x fp4 with N-major B
+        (IsBMixedPrecFp4 &&
+         (requiresFp4Padding || blockK == 32 || !dotOp.getRhsKPack()));
+
     // For mixed-precision fp4 operands, set allowTranspose = false, to force
     // the packed axis, K, to be contiguous in SMEM
     a = getSharedMemoryMMAOperand(a, rewriter, 0,

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -18,6 +18,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/StrUtil.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -906,16 +907,27 @@ public:
     RankedTensorType oldScaleAType = dotOp.getAScale().getType();
     RankedTensorType oldScaleBType = dotOp.getBScale().getType();
 
-    Attribute scaleEncoding =
-        triton::nvidia_gpu::TensorMemoryScalesEncodingAttr::get(context,
-                                                                CGALayout);
+    auto aScaleBlockRepOrder =
+        triton::nvidia_gpu::getTensorMemoryScalesBlockRepOrder(
+            dotOp, /*isA=*/true, dotOp.getAElemType(), dotOp.getBElemType(),
+            oldScaleAType.getElementType(), oldScaleBType.getElementType());
+    auto bScaleBlockRepOrder =
+        triton::nvidia_gpu::getTensorMemoryScalesBlockRepOrder(
+            dotOp, /*isA=*/false, dotOp.getAElemType(), dotOp.getBElemType(),
+            oldScaleAType.getElementType(), oldScaleBType.getElementType());
+    Attribute scaleAEncoding =
+        triton::nvidia_gpu::TensorMemoryScalesEncodingAttr::get(
+            context, CGALayout, aScaleBlockRepOrder);
+    Attribute scaleBEncoding =
+        triton::nvidia_gpu::TensorMemoryScalesEncodingAttr::get(
+            context, CGALayout, bScaleBlockRepOrder);
     MemDescType scaleAType = triton::gpu::MemDescType::get(
-        oldScaleAType.getShape(), oldScaleAType.getElementType(), scaleEncoding,
-        tensorMemorySpace,
+        oldScaleAType.getShape(), oldScaleAType.getElementType(),
+        scaleAEncoding, tensorMemorySpace,
         /*mutableMemory=*/false);
     MemDescType scaleBType = triton::gpu::MemDescType::get(
-        oldScaleBType.getShape(), oldScaleBType.getElementType(), scaleEncoding,
-        tensorMemorySpace,
+        oldScaleBType.getShape(), oldScaleBType.getElementType(),
+        scaleBEncoding, tensorMemorySpace,
         /*mutableMemory=*/false);
     Attribute scaleALayout =
         nvidia_gpu::getDefaultLayoutForTmemLdSt(scaleAType, numWarps);

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -62,6 +62,21 @@ void printCGALayoutRankTwo(AsmPrinter &printer, gpu::CGAEncodingAttr cgaAttr) {
   gpu::printCGAAttr(printer, cgaAttr);
 }
 
+TensorMemoryScalesBlockRepOrder getTensorMemoryScalesBlockRepOrder(
+    Operation *op, bool isA, ScaleDotElemType aType, ScaleDotElemType bType,
+    Type aScaleElemType, Type bScaleElemType) {
+  ModuleOp mod = op->getParentOfType<ModuleOp>();
+  auto targetAttr = mod->getAttrOfType<StringAttr>(gpu::AttrTargetName);
+  bool isRubin = targetAttr && targetAttr.getValue() == "cuda:107";
+  bool isRubinNVFP4xNVFP4 = isRubin && aType == ScaleDotElemType::E2M1 &&
+                            bType == ScaleDotElemType::E2M1 &&
+                            isa<Float8E4M3FNType>(aScaleElemType) &&
+                            isa<Float8E4M3FNType>(bScaleElemType);
+  return (isRubinNVFP4xNVFP4 && isA)
+             ? TensorMemoryScalesBlockRepOrder::K_THEN_MN
+             : TensorMemoryScalesBlockRepOrder::MN_THEN_K;
+}
+
 TMemAllocation getTmemAllocSizes(MemDescType memDescType) {
   auto *ctx = memDescType.getContext();
   auto S = [&](StringRef str) { return StringAttr::get(ctx, str); };
@@ -462,7 +477,7 @@ LogicalResult TensorMemoryEncodingAttr::verify(
 
 LogicalResult TensorMemoryScalesEncodingAttr::verify(
     function_ref<InFlightDiagnostic()> emitError,
-    gpu::CGAEncodingAttr cgaLayout) {
+    gpu::CGAEncodingAttr cgaLayout, TensorMemoryScalesBlockRepOrder) {
   if (cgaLayout.getRank() != 2) {
     return emitError() << "CGALayout must have rank 2";
   }

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -41,6 +41,7 @@
 #include "triton/Tools/StrUtil.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace mlir::triton::gpu;
 
@@ -265,12 +266,34 @@ LogicalResult WaitBarrierOp::verify() {
   return success();
 }
 
+// Forward declaration. The single (beta-adapted) definition lives below near
+// verifyTMABarrierLayout; beta deliberately tolerates an unset CGA layout, so we
+// keep that version rather than the upstream hard-failing one this cherry-pick
+// carried.
+static LogicalResult verifyBarrierCGALayout(Operation *op, Value barrier,
+                                            CGAEncodingAttr expectedCGALayout,
+                                            StringRef barrierName);
+
 // -- ArriveBarrierOp --
 LogicalResult ArriveBarrierOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))
     return failure();
   if (getCount() < 1)
     return emitOpError("count must be greater than or equal to 1");
+  if (isMulticast()) {
+    if (getPerThread())
+      return emitOpError("multicast arrive does not support perThread");
+    int numCTAs = triton::gpu::lookupNumCTAs(getOperation());
+    if (numCTAs <= 1)
+      return emitOpError("multicast arrive requires num_ctas > 1");
+    if (getCtaMask() > static_cast<uint32_t>(numCTAs - 1))
+      return emitOpError("ctaMask exceeds numCTAs - 1");
+    auto expectedCGALayout =
+        CGAEncodingAttr::get1DLayout(getContext(), numCTAs);
+    if (failed(verifyBarrierCGALayout(*this, getAlloc(), expectedCGALayout,
+                                      "multicast barrier")))
+      return failure();
+  }
   return success();
 }
 
@@ -1014,6 +1037,28 @@ static Type getScaledMMAOperandType(Type elementType,
   llvm_unreachable("Unsupported type.");
 };
 
+static LogicalResult
+verifyScaleBlockRepOrder(TCGen5MMAScaledOp op,
+                         TensorMemoryScalesEncodingAttr encoding, bool isA) {
+  auto aScaleType = cast<MemDescType>(op.getAScale().getType());
+  auto bScaleType = cast<MemDescType>(op.getBScale().getType());
+  auto expectedOrder = getTensorMemoryScalesBlockRepOrder(
+      op.getOperation(), isA, op.getAType(), op.getBType(),
+      aScaleType.getElementType(), bScaleType.getElementType());
+  if (encoding.getBlockRepOrder() != expectedOrder) {
+    StringRef operandName = isA ? "A" : "B";
+    StringRef expectedOrderName =
+        expectedOrder == TensorMemoryScalesBlockRepOrder::K_THEN_MN ? "kThenMn"
+                                                                    : "mnThenK";
+    return op.emitOpError()
+           << operandName
+           << " scales in tensor memory must use "
+              "#ttng.tensor_memory_scales_encoding<blockRepOrder = "
+           << expectedOrderName << ">";
+  }
+  return success();
+}
+
 LogicalResult TCGen5MMAScaledOp::verify() {
   Type atype =
       getScaledMMAOperandType(getA().getType().getElementType(), getAType());
@@ -1029,6 +1074,35 @@ LogicalResult TCGen5MMAScaledOp::verify() {
   }
   if (enc.getBlockM() != 128)
     return emitOpError("only supports instruction shape blockM=128");
+  auto aScaleType = cast<MemDescType>(getAScale().getType());
+  auto bScaleType = cast<MemDescType>(getBScale().getType());
+  auto isScaleBlockRepOrderRelevant = [](MemDescType scaleType) {
+    auto shapePerCTA = getShapePerCTA(scaleType);
+    assert(shapePerCTA.size() >= 2);
+    int64_t rowsPerCTA = shapePerCTA[shapePerCTA.size() - 2];
+    int64_t scalesPerCTA = shapePerCTA.back();
+    return rowsPerCTA > 128 && scalesPerCTA > 4;
+  };
+  if (isa<TensorMemorySpaceAttr>(aScaleType.getMemorySpace()) &&
+      isScaleBlockRepOrderRelevant(aScaleType)) {
+    auto encoding =
+        dyn_cast<TensorMemoryScalesEncodingAttr>(aScaleType.getEncoding());
+    if (!encoding)
+      return emitOpError("A scales in tensor memory must use "
+                         "#ttng.tensor_memory_scales_encoding");
+    if (failed(verifyScaleBlockRepOrder(*this, encoding, /*isA=*/true)))
+      return failure();
+  }
+  if (isa<TensorMemorySpaceAttr>(bScaleType.getMemorySpace()) &&
+      isScaleBlockRepOrderRelevant(bScaleType)) {
+    auto encoding =
+        dyn_cast<TensorMemoryScalesEncodingAttr>(bScaleType.getEncoding());
+    if (!encoding)
+      return emitOpError("B scales in tensor memory must use "
+                         "#ttng.tensor_memory_scales_encoding");
+    if (failed(verifyScaleBlockRepOrder(*this, encoding, /*isA=*/false)))
+      return failure();
+  }
   return success();
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
@@ -3,6 +3,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 
@@ -58,8 +59,8 @@ struct TCGen5MMAScaleSharedToTmemConversion
 
   // Create a tmem_copy of scales from shared memory to tmem. `rows` is the M or
   // N of the MMA operation (for LHS or RHS respectively).
-  bool lowerScaleToTmem(OpOperand &operand, PatternRewriter &rewriter,
-                        int rows) const {
+  bool lowerScaleToTmem(OpOperand &operand, PatternRewriter &rewriter, int rows,
+                        TensorMemoryScalesBlockRepOrder blockRepOrder) const {
     Location loc = operand.getOwner()->getLoc();
     MLIRContext *context = operand.getOwner()->getContext();
     Attribute tensorMemorySpace = TensorMemorySpaceAttr::get(context);
@@ -88,7 +89,7 @@ struct TCGen5MMAScaleSharedToTmemConversion
     // Distribute the scales across the rows of the MMA operation.
     SmallVector<int64_t> shape = {rows, numElems / rows};
     Attribute scaleEncoding =
-        TensorMemoryScalesEncodingAttr::get(context, CGALayout);
+        TensorMemoryScalesEncodingAttr::get(context, CGALayout, blockRepOrder);
     Type scaleAType =
         ttg::MemDescType::get(shape, elType, scaleEncoding, tensorMemorySpace,
                               /*mutableMemory=*/true);
@@ -110,12 +111,22 @@ struct TCGen5MMAScaleSharedToTmemConversion
     }
     int blockM = op.getBlockM();
     int blockN = op.getBlockN();
+    auto aScaleBlockRepOrder = getTensorMemoryScalesBlockRepOrder(
+        op, /*isA=*/true, op.getAType(), op.getBType(),
+        aScaleType.getElementType(), bScaleType.getElementType());
+    auto bScaleBlockRepOrder = getTensorMemoryScalesBlockRepOrder(
+        op, /*isA=*/false, op.getAType(), op.getBType(),
+        aScaleType.getElementType(), bScaleType.getElementType());
     bool anyChanged = false;
     if (isa<ttg::SharedMemorySpaceAttr>(aScaleType.getMemorySpace())) {
-      anyChanged = lowerScaleToTmem(op.getAScaleMutable(), rewriter, blockM);
+      anyChanged = lowerScaleToTmem(op.getAScaleMutable(), rewriter, blockM,
+                                    aScaleBlockRepOrder) ||
+                   anyChanged;
     }
     if (isa<ttg::SharedMemorySpaceAttr>(bScaleType.getMemorySpace())) {
-      anyChanged = lowerScaleToTmem(op.getBScaleMutable(), rewriter, blockN);
+      anyChanged = lowerScaleToTmem(op.getBScaleMutable(), rewriter, blockN,
+                                    bScaleBlockRepOrder) ||
+                   anyChanged;
     }
     return LogicalResult::success(anyChanged);
   }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
@@ -9,6 +9,7 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Traits.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "llvm/ADT/EquivalenceClasses.h"
@@ -488,11 +489,12 @@ public:
     // TODO: handle cases with multiple function with TMEMAllocOp.
     int totalMemorySize = allocateTMem(mod, offsets);
 
-    std::array<int, 6> possibleAllocations = {0, 32, 64, 128, 256, 512};
-    // NOTE: if totalMemorySize > 512 we exceeded the maximum amount of tensor
-    // memory, but we let the compilation finish so that we can raise an
+    std::vector<int> possibleAllocations = {0, 32, 64, 128, 256, 512, 576};
+    // NOTE: if totalMemorySize > the maximum available for the target (512
+    // for Blackwell and 576 for Rubin), we exceeded the maximum amount of
+    // tensor memory, but we let the compilation finish so that we can raise an
     // exception in python for the auto-tuner.
-    if (totalMemorySize <= 512) {
+    if (totalMemorySize <= possibleAllocations.back()) {
       for (int size : possibleAllocations) {
         if (totalMemorySize <= size) {
           totalMemorySize = size;

--- a/python/examples/gluon/05-moe-bmm1-fused-gather.py
+++ b/python/examples/gluon/05-moe-bmm1-fused-gather.py
@@ -1500,7 +1500,7 @@ def test_op(c: MLPConfig, batch_size: tuple[int, ...]):
     assert_close(
         ref_y.to(torch.float32),
         cand_y.to(torch.float32),
-        maxtol=0.125,
+        maxtol=0.126,
         rmstol=None,
         description=f"{description}:out",
         verbose=False,

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -303,8 +303,13 @@ py::object layoutToGluon(Attribute layout) {
         partitioned.getPartitionDim(), partitionLayout);
   } else if (auto tmemScales =
                  dyn_cast<ttng::TensorMemoryScalesEncodingAttr>(layout)) {
+    StringRef blockRepOrder =
+        tmemScales.getBlockRepOrder() ==
+                ttng::TensorMemoryScalesBlockRepOrder::K_THEN_MN
+            ? "kThenMn"
+            : "mnThenK";
     return layouts.TensorMemoryScalesLayout(
-        getCgaLayoutBases(tmemScales.getCGALayout()));
+        getCgaLayoutBases(tmemScales.getCGALayout()), blockRepOrder);
   } else if (auto tmem = dyn_cast<ttng::TensorMemoryEncodingAttr>(layout)) {
     return layouts.TensorMemoryLayout(
         std::vector<unsigned>{tmem.getBlockM(), tmem.getBlockN()},
@@ -576,14 +581,24 @@ void init_gluon_ir(py::module &&m) {
                  ctx, block[0], block[1], colStride, cgaLayout, twoCTAs,
                  ttng::TensorMemoryCTAMode::DEFAULT);
            })
-      .def("get_tensor_memory_scales_layout",
-           [](GluonOpBuilder &self,
-              std::vector<std::vector<int32_t>> &cgaBases) -> Attribute {
-             auto ctx = self.getContext();
-             auto cgaLayout = buildCgaLayoutAttr(ctx, cgaBases, /*rank=*/2);
-             return self.getChecked<ttng::TensorMemoryScalesEncodingAttr>(
-                 ctx, cgaLayout);
-           })
+      .def(
+          "get_tensor_memory_scales_layout",
+          [](GluonOpBuilder &self, std::vector<std::vector<int32_t>> &cgaBases,
+             const std::string &blockRepOrder) -> Attribute {
+            auto ctx = self.getContext();
+            auto cgaLayout = buildCgaLayoutAttr(ctx, cgaBases, /*rank=*/2);
+            auto repOrder =
+                blockRepOrder == "mnThenK"
+                    ? ttng::TensorMemoryScalesBlockRepOrder::MN_THEN_K
+                : blockRepOrder == "kThenMn"
+                    ? ttng::TensorMemoryScalesBlockRepOrder::K_THEN_MN
+                    : throw py::value_error(
+                          "block_rep_order must be either 'mnThenK' or "
+                          "'kThenMn'");
+            return self.getChecked<ttng::TensorMemoryScalesEncodingAttr>(
+                ctx, cgaLayout, repOrder);
+          },
+          py::arg("cga_bases"), py::arg("block_rep_order") = "mnThenK")
       .def("get_shape_from_tensor",
            [](GluonOpBuilder &self, Value tensor) -> std::vector<int64_t> {
              auto ty = dyn_cast<RankedTensorType>(tensor.getType());
@@ -911,8 +926,9 @@ void init_gluon_ir(py::module &&m) {
              self.create<ttng::WaitBarrierOp>(memDesc, phase, pred, deps);
            })
       .def("create_mbarrier_arrive",
-           [](GluonOpBuilder &self, Value memDesc, int count, Value pred) {
-             self.create<ttng::ArriveBarrierOp>(memDesc, count, pred);
+           [](GluonOpBuilder &self, Value memDesc, uint32_t count,
+              uint32_t ctaMask, Value pred) {
+             self.create<ttng::ArriveBarrierOp>(memDesc, count, ctaMask, pred);
            })
       .def("create_fence_mbarrier_init_release_cluster",
            [](GluonOpBuilder &self) {

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -527,6 +527,74 @@ def test_async_copy_mbarrier():
     torch.testing.assert_close(out[20:], torch.zeros((12, 32), **tensor_opts))
 
 
+# Equivalence-class multicast: cta_mask selects which CTA-ID bits to multicast
+# along.  Two CTAs share a class when (id_a & ~mask) == (id_b & ~mask).
+#
+#   CTA ID   0x0  0x1  0x2  0x3  0x4  0x5  0x6  0x7
+#   & ~0x5   0x0  0x0  0x2  0x2  0x0  0x0  0x2  0x2
+#   classes: {0,1,4,5}, {2,3,6,7}  (groups of 4)
+#
+# Multicast requires the identity CGA layout, so two_ctas barriers are not
+# supported. All legal cta_mask values are tested; cta_mask=0 exercises the
+# non-multicast path.
+@pytest.mark.parametrize("num_ctas", [2, 4, 8])
+@pytest.mark.parametrize("cta_mask", range(8))
+@pytest.mark.skipif(not is_rubin(), reason="Requires Rubin")
+def test_mbarrier_arrive_multicast(num_ctas, cta_mask):
+    if cta_mask >= num_ctas:
+        pytest.skip("cta_mask must be < num_ctas")
+    init_count = 1 << cta_mask.bit_count()
+
+    @gluon.jit
+    def kernel(out_ptr, cta_mask: ttgl.constexpr, init_count: ttgl.constexpr):
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=init_count)
+        mbarrier.arrive(bar, cta_mask=cta_mask)
+        mbarrier.wait(bar, 0)
+        mbarrier.invalidate(bar)
+        ttgl.store(out_ptr + ttgl.program_id(0), ttgl.program_id(0))
+
+    out = torch.zeros(num_ctas, device="cuda", dtype=torch.int32)
+    compiled = kernel[(num_ctas, )](out, cta_mask, init_count, num_ctas=num_ctas, num_warps=4)
+
+    ttgir = compiled.asm["ttgir"]
+    if cta_mask:
+        assert f"ctaMask = {cta_mask} : i32" in ttgir, "Expected ctaMask in TTGIR"
+    else:
+        assert "ctaMask" not in ttgir, "Expected no ctaMask in TTGIR"
+
+    torch.testing.assert_close(out, torch.arange(num_ctas, device="cuda", dtype=torch.int32))
+
+
+@pytest.mark.parametrize("num_ctas", [2, 4, 8])
+@pytest.mark.skipif(not is_rubin(), reason="Requires Rubin")
+def test_mbarrier_arrive_broadcast_one_cta(num_ctas):
+
+    @gluon.jit
+    def kernel(out_ptr, cta_mask: ttgl.constexpr):
+        pid = ttgl.program_id(0)
+        cta_rank = ttgl.inline_asm_elementwise(
+            "mov.u32 $0, %cluster_ctarank;",
+            "=r",
+            [],
+            dtype=ttgl.int32,
+            is_pure=True,
+            pack=1,
+        )
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+        # CTA 0 does a multicast arrive, all CTAs wait.
+        mbarrier.arrive(bar, cta_mask=cta_mask, pred=cta_rank == 0)
+        mbarrier.wait(bar, 0)
+        mbarrier.invalidate(bar)
+        ttgl.store(out_ptr + pid, pid)
+
+    out = torch.zeros(num_ctas, device="cuda", dtype=torch.int32)
+    kernel[(num_ctas, )](out, num_ctas - 1, num_ctas=num_ctas, num_warps=4)
+
+    torch.testing.assert_close(out, torch.arange(num_ctas, device="cuda", dtype=torch.int32))
+
+
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
 def test_device_tma_load():
 

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -11,6 +11,7 @@ from triton._internal_testing import (
     is_ampere_or_newer,
     is_blackwell,
     is_blackwell_ultra,
+    is_rubin,
     is_hip_rdna,
     is_hip_rdna3,
     is_hip_rdna4,
@@ -3910,7 +3911,7 @@ def tmem_reduction_kernel(
     ttgl.store(red_ptr + offs_1d, reduced)
 
 
-@pytest.mark.skipif(not is_blackwell_ultra(), reason="Requires Blackwell Ultra")
+@pytest.mark.skipif(not (is_blackwell_ultra() or is_rubin()), reason="Requires Blackwell Ultra or Rubin")
 @pytest.mark.parametrize("red_op", ["min", "max"])
 @pytest.mark.parametrize("use_abs", [False, True])
 @pytest.mark.parametrize("propagate_nan", [tl.PropagateNan.NONE, tl.PropagateNan.ALL])
@@ -4001,7 +4002,8 @@ def test_clc_basic(num_ctas):
 
     dev_props = torch.cuda.get_device_properties("cuda")
     num_sms = dev_props.multi_processor_count
-    smem_size = dev_props.shared_memory_per_block_optin
+    device = triton.runtime.driver.active.get_current_device()
+    smem_size = max_shared_mem(device)
     grid = 2 * (num_sms // num_ctas)
 
     was_launched = torch.zeros([grid], dtype=torch.bool, device="cuda")
@@ -4276,3 +4278,140 @@ def test_mma_scaled_tcgen05_copy(M, N, K, BLOCK_K, a_format, b_format, ctas_per_
     C_ref = A_ref @ B_ref.T
     C = mma_scaled_tcgen05_copy(A, B, A_scale, B_scale, VEC_SIZE, BLOCK_M, BLOCK_N, BLOCK_K, ctas_per_cga, multicast)
     torch.testing.assert_close(C_ref, C.to(torch.float32), atol=1e-3, rtol=1e-3)
+
+
+@gluon.jit
+def tmem288k_simple_kernel(in_ptr, out_ptr, M: ttgl.constexpr, Ncol1: ttgl.constexpr, Ncol2: ttgl.constexpr,
+                           num_warps: ttgl.constexpr):
+    global_memory_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 32], [1, num_warps], [1, 0])
+
+    offs_m = ttgl.arange(0, M, ttgl.SliceLayout(1, global_memory_layout))
+    offs_n128 = ttgl.arange(0, 128, ttgl.SliceLayout(0, global_memory_layout))
+    offs_n32 = ttgl.arange(0, 32, ttgl.SliceLayout(0, global_memory_layout))
+
+    N: ttgl.constexpr = Ncol1 + Ncol2
+
+    # Allocate some tensor memory.
+    tmem_layout: ttgl.constexpr = TensorMemoryLayout(
+        block=(128, 32),
+        col_stride=32 // in_ptr.dtype.element_ty.primitive_bitwidth,
+    )
+
+    tmem1 = allocate_tensor_memory(
+        element_ty=in_ptr.dtype.element_ty,
+        shape=[M, Ncol1],
+        layout=tmem_layout,
+    )
+    if Ncol2 > 0:
+        tmem2 = allocate_tensor_memory(
+            element_ty=in_ptr.dtype.element_ty,
+            shape=[M, Ncol2],
+            layout=tmem_layout,
+        )
+
+    # Get the register layout needed to access tensor memory from descriptors.
+    tmem_reg_layout1: ttgl.constexpr = tmem1.slice(0, 128).get_reg_layout(num_warps=num_warps)
+    if Ncol2 > 0:
+        tmem_reg_layout2: ttgl.constexpr = tmem2.slice(0, 32).get_reg_layout(num_warps=num_warps)
+
+    assert Ncol1 == 128 or Ncol1 == 256 or Ncol1 == 512
+
+    n1a: ttgl.constexpr = 0
+    offs = offs_m[:, None] * N + n1a + offs_n128[None, :]
+    input = ttgl.load(in_ptr + offs)
+    input = ttgl.convert_layout(input, tmem_reg_layout1)
+    tmem_slice = tmem1.slice(n1a, 128)
+    tmem_slice.store(input)
+
+    if Ncol1 > 128:
+        n1b: ttgl.constexpr = 128
+        offs = offs_m[:, None] * N + n1b + offs_n128[None, :]
+        input = ttgl.load(in_ptr + offs)
+        input = ttgl.convert_layout(input, tmem_reg_layout1)
+        tmem_slice = tmem1.slice(n1b, 128)
+        tmem_slice.store(input)
+
+    if Ncol1 > 256:
+        n1c: ttgl.constexpr = 256
+        offs = offs_m[:, None] * N + n1c + offs_n128[None, :]
+        input = ttgl.load(in_ptr + offs)
+        input = ttgl.convert_layout(input, tmem_reg_layout1)
+        tmem_slice = tmem1.slice(n1c, 128)
+        tmem_slice.store(input)
+
+        n1d: ttgl.constexpr = 384
+        offs = offs_m[:, None] * N + n1d + offs_n128[None, :]
+        input = ttgl.load(in_ptr + offs)
+        input = ttgl.convert_layout(input, tmem_reg_layout1)
+        tmem_slice = tmem1.slice(n1d, 128)
+        tmem_slice.store(input)
+
+    if Ncol2 > 0:
+        n2a: ttgl.constexpr = 0
+        offs = offs_m[:, None] * N + Ncol1 + n2a + offs_n32[None, :]
+        input = ttgl.load(in_ptr + offs)
+        input = ttgl.convert_layout(input, tmem_reg_layout2)
+        tmem_slice = tmem2.slice(n2a, 32)
+        tmem_slice.store(input)
+
+    if Ncol2 > 32:
+        n2b: ttgl.constexpr = 32
+        offs = offs_m[:, None] * N + Ncol1 + n2b + offs_n32[None, :]
+        input = ttgl.load(in_ptr + offs)
+        input = ttgl.convert_layout(input, tmem_reg_layout2)
+        tmem_slice = tmem2.slice(n2b, 32)
+        tmem_slice.store(input)
+
+    offs = offs_m[:, None] * N + n1a + offs_n128[None, :]
+    tmem_slice = tmem1.slice(n1a, 128)
+    output = tmem_slice.load(tmem_reg_layout1)
+    output = ttgl.convert_layout(output, global_memory_layout)
+    ttgl.store(out_ptr + offs, output)
+
+    if Ncol1 > 128:
+        offs = offs_m[:, None] * N + n1b + offs_n128[None, :]
+        tmem_slice = tmem1.slice(n1b, 128)
+        output = tmem_slice.load(tmem_reg_layout1)
+        output = ttgl.convert_layout(output, global_memory_layout)
+        ttgl.store(out_ptr + offs, output)
+
+    if Ncol1 > 256:
+        offs = offs_m[:, None] * N + n1c + offs_n128[None, :]
+        tmem_slice = tmem1.slice(n1c, 128)
+        output = tmem_slice.load(tmem_reg_layout1)
+        output = ttgl.convert_layout(output, global_memory_layout)
+        ttgl.store(out_ptr + offs, output)
+
+        offs = offs_m[:, None] * N + n1d + offs_n128[None, :]
+        tmem_slice = tmem1.slice(n1d, 128)
+        output = tmem_slice.load(tmem_reg_layout1)
+        output = ttgl.convert_layout(output, global_memory_layout)
+        ttgl.store(out_ptr + offs, output)
+
+    if Ncol2 > 0:
+        offs = offs_m[:, None] * N + Ncol1 + n2a + offs_n32[None, :]
+        tmem_slice = tmem2.slice(n2a, 32)
+        output = tmem_slice.load(tmem_reg_layout2)
+        output = ttgl.convert_layout(output, global_memory_layout)
+        ttgl.store(out_ptr + offs, output)
+
+    if Ncol2 > 32:
+        offs = offs_m[:, None] * N + Ncol1 + n2b + offs_n32[None, :]
+        tmem_slice = tmem2.slice(n2b, 32)
+        output = tmem_slice.load(tmem_reg_layout2)
+        output = ttgl.convert_layout(output, global_memory_layout)
+        ttgl.store(out_ptr + offs, output)
+
+
+@pytest.mark.skipif(not is_rubin(), reason="Requires Rubin")
+@pytest.mark.parametrize("Ncol1", [256, 512])
+@pytest.mark.parametrize("Ncol2", [32, 64])
+def test_tmem288k_simple(Ncol1: int, Ncol2: int):
+    M = 128
+    N = Ncol1 + Ncol2
+    input = torch.randn(M, N, dtype=torch.float32).to(device="cuda")
+    output = torch.empty_like(input)
+
+    num_warps = 4
+    tmem288k_simple_kernel[(1, )](input, output, M, Ncol1, Ncol2, num_warps=num_warps)
+    torch.testing.assert_close(input.cpu(), output.cpu(), atol=0, rtol=0)

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -7,6 +7,7 @@ from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia import blackwell
 from triton.experimental.gluon.language.nvidia import hopper
+from triton.experimental.gluon.language.nvidia.ampere import mbarrier as ampere_mbarrier
 from triton.experimental.gluon.language.nvidia.hopper import cluster
 from triton.experimental.gluon.language.nvidia.blackwell import (
     mbarrier,
@@ -725,6 +726,75 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 }
 """,
     )
+
+
+@gluon.jit
+def ampere_mbarrier_arrive_kernel():
+    bar = ttgl.allocate_shared_memory(ttgl.int64, [1], ampere_mbarrier.MBarrierLayout())
+    ampere_mbarrier.init(bar, count=1)
+    ampere_mbarrier.arrive(bar)
+    phase = 0
+    ampere_mbarrier.wait(bar, phase)
+    ampere_mbarrier.invalidate(bar)
+
+
+@pytest.mark.parametrize("target", [AMPERE_TARGET, HOPPER_TARGET, BLACKWELL_TARGET])
+def test_ampere_mbarrier_arrive(target):
+    # Smoke test that the Ampere mbarrier.arrive wrapper still wires through
+    # to the create_mbarrier_arrive binding after the multicast signature change.
+    run_parser(ampere_mbarrier_arrive_kernel, target=target)
+
+
+def test_mbarrier_arrive_multicast_unsupported_target():
+
+    @gluon.jit
+    def kernel():
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
+        mbarrier.arrive(bar, count=1, cta_mask=0x1)
+
+    with pytest.raises(CompilationError) as e:
+        run_parser(kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
+
+    assert "multicast arrive requires Rubin" in str(e.value)
+
+
+def test_mbarrier_arrive_multicast_negative_mask():
+
+    @gluon.jit
+    def kernel():
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
+        mbarrier.arrive(bar, count=1, cta_mask=-1)
+
+    with pytest.raises(CompilationError) as e:
+        run_parser(kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
+
+    assert "cta_mask must be positive" in str(e.value)
+
+
+def test_mbarrier_arrive_multicast_mask_too_large():
+
+    @gluon.jit
+    def kernel():
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
+        mbarrier.arrive(bar, count=1, cta_mask=2)
+
+    with pytest.raises(CompilationError) as e:
+        run_parser(kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
+
+    assert "cta_mask must be <= num_ctas - 1" in str(e.value)
+
+
+def test_mbarrier_arrive_multicast_non_int_mask():
+
+    @gluon.jit
+    def kernel():
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
+        mbarrier.arrive(bar, count=1, cta_mask=1.5)
+
+    with pytest.raises(CompilationError) as e:
+        run_parser(kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
+
+    assert "cta_mask must be an int" in str(e.value)
 
 
 @gluon.jit

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -1,3 +1,4 @@
+import pytest
 import triton
 import triton.language as tl
 from triton.backends.compiler import GPUTarget
@@ -170,7 +171,6 @@ def test_compile_only_k_loop() -> None:
 
 
 def test_compile_only_dot_mxfp() -> None:
-
     @triton.jit
     def simple_dot_mxfp(
         a_base,
@@ -221,7 +221,11 @@ def test_compile_only_dot_mxfp() -> None:
     assert re.search(pattern, str(ttgir)), "The TTGIR does not match the expected pattern."
 
     ptx = k.asm["ptx"]
-    pattern = r"tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X"
+    version_match = re.search(r"\.version (\d+)\.(\d+)", ptx)
+    assert version_match is not None
+    ptx_version = tuple(int(component) for component in version_match.groups())
+    scale_kind = "block32" if ptx_version >= (8, 8) else "scale_vec::1X"
+    pattern = rf"tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.{scale_kind}"
     assert re.search(pattern, str(ptx)), "The PTX does not match the expected pattern."
     assert k.asm["cubin"] != b""
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4411,7 +4411,7 @@ def test_dot(
                 ptx,
             )
     elif in_dtype == "int8":
-        if is_tcgen5 and capability[0:2] != (10, 3):
+        if is_tcgen5 and capability[1] not in (3, 7):
             assert re.search(r"tcgen05.mma.cta_group::1.kind::i8", ptx)
         elif capability[0] == 7 and capability[1] == 5:  # Turing
             assert "mma.sync.aligned.m8n8k16.row.col.satfinite.s32.s8.s8.s32" in ptx

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -5,7 +5,7 @@ import triton
 import triton.language as tl
 from test_mxfp import MXFP4Tensor, MXScaleTensor
 import re
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_cdna, is_hip_gfx1250
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna3, is_hip_cdna4, is_hip_cdna, is_hip_gfx1250, is_rubin, is_blackwell
 
 
 def f8_to_f16(x, dtype):
@@ -113,7 +113,9 @@ def get_src_element_ty_size(dtype_str):
         (64, 512, 32, 2),
         (512, 64, 32, 2),
         (64, 16, 32, 4),
-    ],
+        (64, 16, 64, 4),
+    ]
+    + ([(256, 128, 128, 3)] if is_rubin() else []),
 )
 @pytest.mark.parametrize("NUM_CTAS", [1, 2])
 @pytest.mark.parametrize("NUM_WARPS", [4, 8])
@@ -442,7 +444,7 @@ def fp8e8m0_to_float32(scale):
 @pytest.mark.parametrize(
     "BLOCK_M, BLOCK_N, BLOCK_K",
     [(128, 128, 128), (256, 128, 128), (128, 256, 128), (128, 256, 256), (128, 128, 64), (128, 64, 128), (128, 16, 256),
-     (128, 16, 64)],
+     (128, 16, 64), (128, 16, 64)] + ([(256, 256, 128)] if is_rubin() else []),
 )
 @pytest.mark.parametrize("NUM_STAGES", [1, 3])
 @pytest.mark.parametrize("NUM_WARPS", [4, 8])
@@ -463,7 +465,7 @@ def test_mxfp(BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, nonKDim, NUM_WARPS, device)
         if (BLOCK_M == 256 or BLOCK_N == 256) and BLOCK_K == 256:
             pytest.skip("Config requires too much shared memory")
 
-    if BLOCK_N == 256 and BLOCK_K == 256:
+    if not is_rubin() and BLOCK_N == 256 and BLOCK_K == 256:
         NUM_STAGES = min(NUM_STAGES, 2)
     torch.manual_seed(42)
     dtype_src_str = "float8e5"
@@ -908,10 +910,11 @@ def test_preshuffle_scale_mxfp_cdna4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, DTYPE_A
 @pytest.mark.parametrize("USE_2D_SCALE_LOAD", [False, True])
 @pytest.mark.skipif(is_hip() or torch.cuda.get_device_capability()[0] != 10, reason="Requires compute capability == 10")
 def test_blocked_scale_mxfp(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, USE_2D_SCALE_LOAD, device):
-    if BLOCK_N == 256 and BLOCK_K == 256:
-        NUM_STAGES = min(NUM_STAGES, 2)
-    elif BLOCK_K == 256:
-        NUM_STAGES = min(NUM_STAGES, 3)
+    if not is_rubin():
+        if BLOCK_N == 256 and BLOCK_K == 256:
+            NUM_STAGES = min(NUM_STAGES, 2)
+        elif BLOCK_K == 256:
+            NUM_STAGES = min(NUM_STAGES, 3)
     # since the block size are big we use num_warps = 8 to avoid pressure problems.
     num_warps = 8
     torch.manual_seed(42)
@@ -1464,7 +1467,7 @@ def test_mxfp8_mxfp4_matmul(
             pytest.skip("Config requires too much shared memory")
     if not PACK_B_ALONG_K and B_DATA_TYPE != "float4":
         pytest.skip("Pack along K can only be False for float4")
-    if BLOCK_N == 256 and BLOCK_K == 256:
+    if not is_rubin() and BLOCK_N == 256 and BLOCK_K == 256:
         NUM_STAGES = 2
 
     torch.manual_seed(42)
@@ -1557,7 +1560,7 @@ def test_mxfp8_mxfp4_matmul(
         NUM_STAGES=NUM_STAGES,
         **kernel_kwargs,
     )
-    if is_cuda():
+    if is_blackwell() and not is_rubin():
         ttgir = out.asm["ttgir"]
         assert "fp4Padded = true" in ttgir
 

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -1228,18 +1228,24 @@ def block_scale_fp4_matmul(  #
 @pytest.mark.parametrize("with_a_scale", [True, False])
 @pytest.mark.parametrize("with_b_scale", [True, False])
 @pytest.mark.parametrize("pack_along_k", [True, False])
-@pytest.mark.parametrize(("scale_type", "VEC_SIZE"), [("float8_e8m0fnu", 32), ("float8_e4m3fn", 16)],
-                         ids=["mxfp4", "nvfp4"])
+@pytest.mark.parametrize(
+    ("scale_type", "VEC_SIZE"),
+    [("float8_e8m0fnu", 32), ("float8_e4m3fn", 16), ("float8_e4m3fn", 32)],
+    ids=["mxfp4", "nvfp4", "nvfp4_vec32_rubin"],
+)
 @pytest.mark.parametrize("nonKDim", ([0, 16, 32] if (is_hip_cdna() or is_hip_gfx1250()) else [0]))
 def test_block_scale_fp4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, VEC_SIZE, with_a_scale, with_b_scale, pack_along_k,
                          scale_type, nonKDim, device):
     assert M % BLOCK_M == 0
     assert N % BLOCK_N == 0
     assert K % BLOCK_K == 0
+    is_rubin = is_cuda() and torch.cuda.get_device_capability() == (10, 7)
 
     if is_cuda():
         if BLOCK_M < 128 and not pack_along_k:
             pytest.skip("Packing along M/N with BLOCK_M < 128 is not supported on CUDA")
+        if scale_type == "float8_e4m3fn" and VEC_SIZE == 32 and not is_rubin:
+            pytest.skip("NVFP4 vec32 is only supported on Rubin")
         if scale_type == "float8_e4m3fn" and not pack_along_k:
             pytest.skip("Packing along K is required for float8_e4m3fn")
         if scale_type == "float8_e4m3fn" and torch.cuda.get_device_capability()[0] < 9:
@@ -1329,6 +1335,8 @@ def test_block_scale_fp4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, VEC_SIZE, with_a_sc
     if is_cuda() and torch.cuda.get_device_capability()[0] in (10, 12) and not nvfp4_fallback:
         ptx = k.asm["ptx"]
         if pack_along_k:
+            if scale_type == "float8_e4m3fn" and VEC_SIZE == 32 and is_rubin:
+                assert "kind::mxf4nvf4.block_scale.block32" in ptx
             assert "kind::mxf4" in ptx
         else:
             assert "kind::mxf8f6f4" in ptx
@@ -1708,3 +1716,111 @@ def test_batched_mxfp(BATCH_SIZE, BLOCK_BATCH_SIZE, BLOCK_M, BLOCK_N, BLOCK_K, N
     if is_cuda() and torch.cuda.get_device_capability()[0] == 12:
         ptx = out.asm["ptx"]
         assert "mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X" in ptx
+
+
+@triton.jit
+def nvfp4_ue5m3_matmul(a_ptr, b_ptr, output_ptr, a_scale, b_scale, M, N, K, stride_scale, stride_am, stride_ak,
+                       stride_bk, stride_bn, stride_cm, stride_cn, VEC_SIZE: tl.constexpr, BLOCK_M: tl.constexpr,
+                       BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    pid_m = pid % num_pid_m
+    pid_n = pid // num_pid_m
+    offs_am = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_bn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k_packed = tl.arange(0, BLOCK_K // 2)
+    offs_scale_k = tl.arange(0, BLOCK_K // VEC_SIZE)
+
+    a_ptrs = a_ptr + offs_am[:, None] * stride_am + offs_k_packed[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k_packed[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+    a_scale_ptrs = a_scale + offs_am[:, None] * stride_scale + offs_scale_k[None, :]
+    b_scale_ptrs = b_scale + offs_bn[:, None] * stride_scale + offs_scale_k[None, :]
+
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for _ in tl.range(0, tl.cdiv(K, BLOCK_K)):
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs)
+        scale_a = tl.load(a_scale_ptrs)
+        scale_b = tl.load(b_scale_ptrs)
+        accumulator = tl.dot_scaled(a, scale_a, "e2m1", b, scale_b, "e2m1", accumulator, lhs_k_pack=True,
+                                    rhs_k_pack=True)
+        a_ptrs += (BLOCK_K // 2) * stride_ak
+        b_ptrs += (BLOCK_K // 2) * stride_bk
+        a_scale_ptrs += BLOCK_K // VEC_SIZE
+        b_scale_ptrs += BLOCK_K // VEC_SIZE
+
+    offs_cm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    output_ptrs = output_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(output_ptrs, accumulator, mask=mask)
+
+
+@pytest.mark.skipif(not is_rubin(), reason="Requires Rubin")
+def test_nvfp4_ue5m3_matmul():
+
+    def ue5m3_to_float32(data):
+        data = data.to(torch.uint8)
+        exp = ((data >> 3) & 0x1F).to(torch.int32)
+        mant = (data & 0x7).to(torch.float32)
+        out = torch.empty_like(mant, dtype=torch.float32)
+        is_subnormal = exp == 0
+        is_nan = (exp == 0x1F) & (mant == 7)
+        is_normal = ~(is_subnormal | is_nan)
+        out[is_subnormal] = mant[is_subnormal] * (2.0**-17)
+        out[is_normal] = (1.0 + mant[is_normal] / 8.0) * torch.pow(2.0, exp[is_normal].to(torch.float32) - 15.0)
+        out[is_nan] = torch.nan
+        return out
+
+    def random_ue5m3_scale_tensor(size, device):
+        exp = torch.randint(13, 16, size=size, dtype=torch.uint8, device=device)
+        mant = torch.zeros(size, dtype=torch.uint8, device=device)
+        data = (exp << 3) | mant
+        return data, ue5m3_to_float32(data)
+
+    m, n, k = 1024, 1024, 1024
+    block_m, block_n, block_k = 128, 256, 128
+    num_warps = 8
+    vec_size = 16
+
+    torch.manual_seed(0)
+    a_mxfp4 = MXFP4Tensor(size=(m, k), device="cuda").random()
+    b_mxfp4 = MXFP4Tensor(size=(n, k), device="cuda").random()
+    a = a_mxfp4.to_packed_tensor(dim=1)
+    b = b_mxfp4.to_packed_tensor(dim=1).T.contiguous()
+    a_ref = a_mxfp4.to(torch.float32)
+    b_ref = b_mxfp4.to(torch.float32).T
+
+    a_scale, a_scale_ref = random_ue5m3_scale_tensor((m, k // vec_size), "cuda")
+    b_scale, b_scale_ref = random_ue5m3_scale_tensor((n, k // vec_size), "cuda")
+    a_scale_ref = a_scale_ref.repeat_interleave(vec_size, dim=1)[:m, :k]
+    b_scale_ref = b_scale_ref.repeat_interleave(vec_size, dim=1).T.contiguous()[:k, :n]
+
+    out = torch.empty((m, n), dtype=torch.float32, device="cuda")
+    grid = (triton.cdiv(m, block_m) * triton.cdiv(n, block_n), 1)
+    kernel = nvfp4_ue5m3_matmul[grid](
+        a,
+        b,
+        out,
+        a_scale,
+        b_scale,
+        m,
+        n,
+        k,
+        a_scale.stride(0),
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        out.stride(0),
+        out.stride(1),
+        vec_size,
+        block_m,
+        block_n,
+        block_k,
+        num_warps=num_warps,
+    )
+
+    ref = torch.matmul(a_ref * a_scale_ref, b_ref * b_scale_ref)
+    torch.testing.assert_close(ref, out, atol=1e-3, rtol=1e-3)
+    assert "kind::mxf4nvf4.block_scale.block16" in kernel.asm["ptx"]

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -6,7 +6,7 @@ import pytest
 
 import pathlib
 import uuid
-from triton._internal_testing import is_cuda, is_hip_cdna
+from triton._internal_testing import is_cuda, is_hip_cdna, is_rubin
 from triton.runtime import autotuner as _autotuner
 
 
@@ -468,9 +468,10 @@ def test_exceed_tmem(device):
         tl.store(dst + tl.arange(0, BLOCK_SIZE * BLOCK_SIZE), c)
 
     dot_kernel[(1, )](dst)
+    tmem_size = 576 if is_rubin() else 512
     assert exception_out_of_resource is not None and str(
         exception_out_of_resource
-    ) == "out of resource: tensor memory, Required: 640, Hardware limit: 512. Reducing block sizes or `num_stages` may help."
+    ) == f"out of resource: tensor memory, Required: 640, Hardware limit: {tmem_size}. Reducing block sizes or `num_stages` may help."
 
 
 def test_exceed_threads(device):

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -58,6 +58,10 @@ def is_blackwell_ultra():
     return is_cuda() and torch.cuda.get_device_capability()[0:2] == (10, 3)
 
 
+def is_rubin():
+    return is_cuda() and torch.cuda.get_device_capability()[0:2] == (10, 7)
+
+
 def is_hopper_or_newer():
     return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
 

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -592,6 +592,8 @@ class CompiledKernel:
         if hasattr(self.metadata, "tmem_size") and self.metadata.tmem_size is not None:
             # Use blackwell max tmem size for now, this should be moved in device properties
             max_tmem_size = 512  # tmem size in number of columns
+            if self.metadata.target.arch == 107:
+                max_tmem_size = 576
             if self.metadata.tmem_size > max_tmem_size:
                 raise_(OutOfResources(self.metadata.tmem_size, max_tmem_size, "tensor memory"))
         if knobs.runtime.kernel_load_start_hook is not None:

--- a/python/triton/experimental/gluon/language/nvidia/ampere/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/ampere/mbarrier.py
@@ -117,5 +117,6 @@ def arrive(mbarrier, *, pred=True, _semantic=None):
         pred (bool): Predicate. Operation is skipped if predicate is False. Defaults to True.
     """
     count = 1
+    cta_mask = 0
     pred = _semantic.to_tensor(pred)
-    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, pred.handle)
+    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle)

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -88,22 +88,27 @@ class TensorMemoryScalesLayout:
 
     Args:
         cga_layout (Optional[List[List[int]]]): CGA layout bases. Defaults to [].
+        block_rep_order (str): Order of repeated scale blocks. Must be either
+            ``"mnThenK"`` or ``"kThenMn"``. Defaults to ``"mnThenK"``.
     """
     cga_layout: List[List[int]] = field(default_factory=list)
+    block_rep_order: str = "mnThenK"
 
     def __post_init__(self):
         super().__setattr__("cga_layout", _unwrap_if_constexpr(self.cga_layout))
+        super().__setattr__("block_rep_order", _unwrap_if_constexpr(self.block_rep_order))
         assert all(len(basis) == 2 for basis in self.cga_layout)
+        assert self.block_rep_order in ("mnThenK", "kThenMn")
 
     def _to_ir(self, builder):
-        return builder.get_tensor_memory_scales_layout([list(basis) for basis in self.cga_layout])
+        return builder.get_tensor_memory_scales_layout([list(basis) for basis in self.cga_layout], self.block_rep_order)
 
     def mangle(self) -> str:
         cga_layout_str = "_".join("~".join(map(str, basis)) for basis in self.cga_layout)
-        return f"TLS{cga_layout_str}TLS"
+        return f"TLS{self.block_rep_order}_{cga_layout_str}TLS"
 
     def __hash__(self):
-        return hash(tuple(tuple(b) for b in self.cga_layout))
+        return hash((tuple(tuple(b) for b in self.cga_layout), self.block_rep_order))
 
 
 @dataclass(frozen=True)

--- a/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
@@ -32,18 +32,41 @@ def expect(mbarrier, bytes_per_cta=None, pred=True, _semantic=None):
 
 
 @builtin
-def arrive(mbarrier, *, count=1, pred=True, _semantic=None):
+def arrive(mbarrier, *, count=1, cta_mask=0, pred=True, _semantic=None):
     """
     Arrive at an mbarrier with a specified count.
+
+    When ``cta_mask`` is non-zero, the arrive is multicast across the cluster.
+    Each bit set in the mask identifies a CTA ID dimension to multicast
+    along. CTA IDs ``a`` and ``b`` belong to the same equivalence class iff
+    ``a & ~cta_mask == b & ~cta_mask``; all CTAs in a class multicast to each
+    other. Multicast requires ``num_ctas > 1``, ``0 < cta_mask <= num_ctas - 1``,
+    and the barrier must have the identity CGA layout ``[[1], [2], ...]``. The
+    default value of ``cta_mask`` is 0 (no multicast).
 
     Args:
         mbarrier (shared_memory_descriptor): Barrier to be signalled.
         count (int): Count to arrive with. Defaults to 1.
+        cta_mask (int): CTA broadcast dimension bits (see above). Defaults
+            to 0 (no multicast). Must satisfy ``0 < cta_mask <= num_ctas - 1``
+            when non-zero.
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
     """
     count = _unwrap_if_constexpr(count)
+    cta_mask = _unwrap_if_constexpr(cta_mask)
+    if not isinstance(cta_mask, int) or isinstance(cta_mask, bool):
+        raise TypeError(f"cta_mask must be an int, got {type(cta_mask).__name__}")
+    if cta_mask:
+        num_ctas = _semantic.builder.options.num_ctas
+        if cta_mask < 0:
+            raise ValueError(f"cta_mask must be positive, got {cta_mask}")
+        if cta_mask > num_ctas - 1:
+            raise ValueError(f"cta_mask must be <= num_ctas - 1 ({num_ctas - 1}), got {cta_mask}")
+        sm = int(_semantic.builder.options.arch.removeprefix("sm"))
+        if sm < 107:
+            raise ValueError(f"multicast arrive requires Rubin (sm_107+), got sm_{sm}")
     pred = _semantic.to_tensor(pred)
-    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, pred.handle)
+    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle)
 
 
 @builtin

--- a/python/tutorials/10-block-scaled-matmul.py
+++ b/python/tutorials/10-block-scaled-matmul.py
@@ -140,6 +140,10 @@ def supports_block_scaling():
     return (is_cuda() and torch.cuda.get_device_capability()[0] in [10, 11]) or is_hip_cdna4()
 
 
+def is_rubin():
+    return torch.cuda.get_device_capability() == (10, 7)
+
+
 if is_cuda() and torch.cuda.get_device_capability()[0] in [10, 11]:
     from triton._C.libtriton import nvidia
     cublas_workspace = torch.empty(32 * 1024 * 1024, device="cuda", dtype=torch.uint8)
@@ -188,6 +192,7 @@ def block_scaled_matmul_kernel(  #
         rep_n: tl.constexpr,  #
         rep_k: tl.constexpr,  #
         NUM_STAGES: tl.constexpr,  #
+        disallow_acc_multi_buffer: tl.constexpr,  #
 ):  #
     if output_type == 0:
         output_dtype = tl.float32
@@ -211,7 +216,8 @@ def block_scaled_matmul_kernel(  #
     MIXED_PREC: tl.constexpr = ELEM_PER_BYTE_A == 1 and ELEM_PER_BYTE_B == 2
 
     accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    for k in tl.range(0, tl.cdiv(K, BLOCK_K), num_stages=NUM_STAGES):
+    for k in tl.range(0, tl.cdiv(K, BLOCK_K), num_stages=NUM_STAGES,
+                      disallow_acc_multi_buffer=disallow_acc_multi_buffer):
         a = a_desc.load([offs_am, offs_k_a])
         b = b_desc.load([offs_bn, offs_k_b])
         scale_a = a_scale_desc.load([0, offs_scale_m, offs_scale_k, 0, 0])
@@ -270,6 +276,7 @@ def block_scaled_matmul(a_desc, a_scale_desc, b_desc, b_scale_desc, dtype_dst, M
         rep_n,
         rep_k,
         configs["num_stages"],
+        disallow_acc_multi_buffer=configs["disallow_acc_multi_buffer"],
     )
     return output
 
@@ -410,14 +417,20 @@ def initialize_block_scaled(M, N, K, block_scale_type="nvfp4", compute_reference
         b_scale_ref = unpack_scale(b_scale_ref).repeat_interleave(VEC_SIZE, dim=1).T.contiguous()[:K, :N]
         reference = torch.matmul(a_ref.to(torch.float32) * a_scale_ref, b_ref * b_scale_ref)
 
+    if is_rubin():
+        num_stages = 6
+    else:
+        num_stages = 4
+
     configs = {
         "BLOCK_SIZE_M": BLOCK_M,
         "BLOCK_SIZE_N": BLOCK_N,
         "BLOCK_SIZE_K": BLOCK_K,
-        "num_stages": 4,
+        "num_stages": num_stages,
         "ELEM_PER_BYTE_A": ELEM_PER_BYTE_A,
         "ELEM_PER_BYTE_B": ELEM_PER_BYTE_B,
         "VEC_SIZE": VEC_SIZE,
+        "disallow_acc_multi_buffer": not is_rubin(),
     }
 
     # Flatten scales for cuBLAS

--- a/test/Conversion/nvgpu_to_llvm.mlir
+++ b/test/Conversion/nvgpu_to_llvm.mlir
@@ -137,6 +137,56 @@ llvm.func @tensor_memory_base_warpgroup() attributes {nvvm.kernel = 1 : ui1, nvv
 
 }
 
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:107", ttg.tensor_memory_size = 576 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tensor_memory_exclusive_rubin
+  //      CHECK:    %[[TID:.+]] = nvvm.read.ptx.sreg.tid.x : i32
+  //      CHECK:    %[[C32:.+]] = llvm.mlir.constant(32 : i32) : i32
+  //      CHECK:    %[[PRED:.+]] = llvm.icmp "ult" %[[TID]], %[[C32]] : i32
+  //      CHECK:    %[[SHMEM:.+]] = llvm.mlir.addressof @global_smem : !llvm.ptr<3>
+  //      CHECK:    %[[A:.+]] = llvm.inline_asm has_side_effects
+  // CHECK-SAME:    "@$0 tcgen05.alloc.exclusive.cta_group::1.sync.aligned.shared::cta.b32 [$1], 576;", "b,r" %[[PRED]], %[[SHMEM]] : (i1, !llvm.ptr<3>) -> !llvm.void
+  //      CHECK:    %[[AR:.+]] = llvm.load %[[SHMEM]] : !llvm.ptr<3> -> i32
+  //      CHECK:    nvvm.barrier
+  //      CHECK:    "@$0 tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;", "b" %[[PRED]]  : (i1) -> !llvm.void
+  //      CHECK:    nvvm.barrier
+  //      CHECK:    llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "@$0 tcgen05.dealloc.exclusive.cta_group::1.sync.aligned.b32 $1, 576;", "b,r" %[[PRED]], %{{.+}} : (i1, !llvm.ptr<6>) -> !llvm.void
+  llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  llvm.func @tensor_memory_exclusive_rubin() -> i32 attributes {nvvm.kernel = 1 : ui1, nvvm.maxntid = array<i32: 128>} {
+    %263 = nvg.tensor_memory_base
+    %264 = llvm.ptrtoint %263 : !llvm.ptr<6> to i32
+    llvm.return %264 : i32
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:107", ttg.tensor_memory_size = 512 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @tensor_memory_no_exclusive_rubin
+  //      CHECK:    %[[TID:.+]] = nvvm.read.ptx.sreg.tid.x : i32
+  //      CHECK:    %[[C32:.+]] = llvm.mlir.constant(32 : i32) : i32
+  //      CHECK:    %[[PRED:.+]] = llvm.icmp "ult" %[[TID]], %[[C32]] : i32
+  //      CHECK:    %[[SHMEM:.+]] = llvm.mlir.addressof @global_smem : !llvm.ptr<3>
+  //      CHECK:    %[[A:.+]] = llvm.inline_asm has_side_effects
+  // CHECK-SAME:    "@$0 tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [$1], 512;", "b,r" %[[PRED]], %[[SHMEM]] : (i1, !llvm.ptr<3>) -> !llvm.void
+  //      CHECK-NOT:  .exclusive
+  //      CHECK:    %[[AR:.+]] = llvm.load %[[SHMEM]] : !llvm.ptr<3> -> i32
+  //      CHECK:    nvvm.barrier
+  //      CHECK:    "@$0 tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;", "b" %[[PRED]]  : (i1) -> !llvm.void
+  //      CHECK:    nvvm.barrier
+  //      CHECK:    llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "@$0 tcgen05.dealloc.cta_group::1.sync.aligned.b32 $1, 512;", "b,r" %[[PRED]], %{{.+}} : (i1, !llvm.ptr<6>) -> !llvm.void
+  //      CHECK-NOT:  .exclusive
+  llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>
+  llvm.func @tensor_memory_no_exclusive_rubin() -> i32 attributes {nvvm.kernel = 1 : ui1, nvvm.maxntid = array<i32: 128>} {
+    %263 = nvg.tensor_memory_base
+    %264 = llvm.ptrtoint %263 : !llvm.ptr<6> to i32
+    llvm.return %264 : i32
+  }
+}
+
+// -----
+
 module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
 
 // CHECK-LABEL: @one_warp

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -1,4 +1,5 @@
-// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm=compute-capability=100 -cse | FileCheck %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=100 ptx-version=87' -cse | FileCheck %s
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=100 ptx-version=88' -cse | FileCheck %s --check-prefix=PTX88
 
 #mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 256, 32]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
@@ -332,6 +333,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: %[[TRUE:.+]] = llvm.mlir.constant(true) : i1
   // CHECK: %[[DESC1:.+]] = llvm.mlir.constant(681579536 : i32) : i32
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC1]], %{{.+}}, %{{.+}}, %[[TRUE]]
+  // PTX88-LABEL: @tc_gen5_mma_block_scale
+  // PTX88: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32
   tt.func @tc_gen5_mma_block_scale(%a: !ttg.memdesc<128x64xf8E4M3FN, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<32x128xi8, #shared1, #ttg.shared_memory>,
                        %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
@@ -540,6 +543,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: %[[DESC0:.+]] = llvm.mlir.constant(138413184 : i32) : i32
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
+  // PTX88-LABEL: @tc_gen5_mma_block_scale_nvfp4
+  // PTX88: tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16
   tt.func @tc_gen5_mma_block_scale_nvfp4(%a: !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<64x256xi8, #shared1, #ttg.shared_memory>,
                        %c: !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>,
@@ -574,6 +579,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC0]]
   // CHECK: %[[DESC1:.+]] = llvm.mlir.constant(1220543648 : i32) : i32
   // CHECK: @$7 tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [ $0 + 0 ], $1, $2, $3, [ $4 + 0 ], [ $5 + 0 ], $6;", "r,l,l,r,r,r,b,b" %[[TMEM_BASE]], %{{.+}}, %{{.+}}, %[[DESC1]]
+  // PTX88-LABEL: @tc_gen5_mma_block_scale_mxfp4
+  // PTX88: tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32
   tt.func @tc_gen5_mma_block_scale_mxfp4(%a: !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<64x256xi8, #shared1, #ttg.shared_memory>,
                        %c: !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>,

--- a/test/Conversion/tritongpu_to_llvm_rubin.mlir
+++ b/test/Conversion/tritongpu_to_llvm_rubin.mlir
@@ -36,12 +36,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
-#tmem_scales_a = #ttng.tensor_memory_scales_encoding<>
+#tmem_scales_a = #ttng.tensor_memory_scales_encoding<blockRepOrder = kThenMn>
 #tmem_scales_b = #ttng.tensor_memory_scales_encoding<>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
   // CHECK-LABEL: @tc_gen5_mma_block_scale_nvfp4_sm107_m256
-  // Verify that we select MMA_K = 64 for NVFP4 with M = 256
-  // CHECK-COUNT-4: tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16
+  // CHECK: %[[DESC:.+]] = llvm.mlir.constant(136316040 : i32) : i32
+  // CHECK-COUNT-4: tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32
+  // CHECK-NOT: tcgen05.mma
   tt.func @tc_gen5_mma_block_scale_nvfp4_sm107_m256(%a: !ttg.memdesc<256x128xi8, #shared, #ttg.shared_memory>,
                        %b: !ttg.memdesc<128x128xi8, #shared1, #ttg.shared_memory>,
                        %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
@@ -128,7 +129,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:107"} {
   // CHECK-LABEL: @tc_gen5_mma_breuse
   // CHECK: tcgen05.mma.cta_group::1.kind::f16.collector::b::fill
   // CHECK: tcgen05.mma.cta_group::1.kind::f16.collector::b::lastuse
@@ -155,7 +156,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
   // CHECK-LABEL: @tc_gen5_mma_block_scale_breuse
   // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::b::fill
   // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::b::lastuse
@@ -175,6 +176,43 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     !ttg.memdesc<256x2xi8, #tmem_scales, #ttng.tensor_memory>,
     !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
     !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:107"} {
+  // CHECK-LABEL: @tc_gen5_mma_block_scale_nvfp4_ue5m3_sm107
+  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
+  // UE5M3 uses i8 block16 scales, so split-K lowering must keep the UE5M3
+  // scale kind in the descriptor for both K=128 sub-instructions of a
+  // logical BLOCK_K=256 tile.
+  // CHECK: %[[DESC:.+]] = llvm.mlir.constant(153093256 : i32) : i32
+  // CHECK-COUNT-2: tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16
+  // CHECK-NOT: tcgen05.mma
+  tt.func @tc_gen5_mma_block_scale_nvfp4_ue5m3_sm107(%a: !ttg.memdesc<128x128xi8, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<128x128xi8, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %scale_a: !ttg.memdesc<128x16xi8, #tmem_scales, #ttng.tensor_memory>,
+                       %scale_b: !ttg.memdesc<128x16xi8, #tmem_scales, #ttng.tensor_memory>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>,
+                       %barrierPred: i1) {
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e2m1 rhs = e2m1, %barrier[%barrierPred] {is_async} :
+    !ttg.memdesc<128x128xi8, #shared, #ttg.shared_memory>,
+    !ttg.memdesc<128x128xi8, #shared1, #ttg.shared_memory>,
+    !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    !ttg.memdesc<128x16xi8, #tmem_scales, #ttng.tensor_memory>,
+    !ttg.memdesc<128x16xi8, #tmem_scales, #ttng.tensor_memory>,
+    !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm_rubin.mlir
+++ b/test/Conversion/tritongpu_to_llvm_rubin.mlir
@@ -1,0 +1,180 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm='compute-capability=107 ptx-version=94' -cse | FileCheck %s
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
+  // CHECK-LABEL: @tc_gen5_mma_block_scale_fp8_sm107
+  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
+  // CHECK-COUNT-2: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32
+  // CHECK-NOT: tcgen05.mma
+  tt.func @tc_gen5_mma_block_scale_fp8_sm107(%a: !ttg.memdesc<128x128xf8E4M3FN, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<64x128xi8, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %scale_a: !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>,
+                       %scale_b: !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+                       %barrierPred: i1) {
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e4m3 rhs = e2m1, %barrier[%barrierPred] {is_async} :
+    !ttg.memdesc<128x128xf8E4M3FN, #shared, #ttg.shared_memory>,
+    !ttg.memdesc<64x128xi8, #shared1, #ttg.shared_memory>,
+    !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    !ttg.memdesc<128x8xi8, #tmem_scales, #ttng.tensor_memory>,
+    !ttg.memdesc<128x4xi8, #tmem_scales, #ttng.tensor_memory>,
+    !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem_scales_a = #ttng.tensor_memory_scales_encoding<>
+#tmem_scales_b = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
+  // CHECK-LABEL: @tc_gen5_mma_block_scale_nvfp4_sm107_m256
+  // Verify that we select MMA_K = 64 for NVFP4 with M = 256
+  // CHECK-COUNT-4: tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16
+  tt.func @tc_gen5_mma_block_scale_nvfp4_sm107_m256(%a: !ttg.memdesc<256x128xi8, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<128x128xi8, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %scale_a: !ttg.memdesc<256x8xf8E4M3FN, #tmem_scales_a, #ttng.tensor_memory>,
+                       %scale_b: !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales_b, #ttng.tensor_memory>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>,
+                       %barrierPred: i1) {
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e2m1 rhs = e2m1, %barrier[%barrierPred] {is_async} :
+    !ttg.memdesc<256x128xi8, #shared, #ttg.shared_memory>,
+    !ttg.memdesc<128x128xi8, #shared1, #ttg.shared_memory>,
+    !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    !ttg.memdesc<256x8xf8E4M3FN, #tmem_scales_a, #ttng.tensor_memory>,
+    !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales_b, #ttng.tensor_memory>,
+    !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107"} {
+  // CHECK-LABEL: @tc_gen5_mma_fp8_sm107
+  // CHECK: %[[TMEM_BASE:.+]] = llvm.ptrtoint %arg2 : !llvm.ptr<3> to i32
+  // FP8 x FP8 (non-scaled) with K=128 on sm107, generates 2 MMA instructions
+  // CHECK-COUNT-2: tcgen05.mma.cta_group::1.kind::f8f6f4
+  // CHECK-NOT: tcgen05.mma
+  tt.func @tc_gen5_mma_fp8_sm107(%a: !ttg.memdesc<128x128xf8E4M3FN, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<128x128xf8E4M3FN, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>,
+                       %barrierPred: i1) {
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred, %barrier[%barrierPred] {is_async} :
+       !ttg.memdesc<128x128xf8E4M3FN, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<128x128xf8E4M3FN, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
+    tt.return
+  }
+}
+
+// -----
+
+// MMA codegen recognizes a fp4-padded SharedLinear A operand and selects
+// the padded mxf8f6f4 MMA_K = 32 variant
+#shared_fp4_padded_sl = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [0, 0], [0, 8], [0, 16], [0, 32], [1, 8], [2, 16], [4, 32], [8, 0], [16, 0], [32, 0], [64, 0]], block = [[128, 0]]}, alignment = 1024>
+#shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8, CGALayout = [[0, 1]]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 32, colStride = 1, CGALayout = [[1, 0]], twoCTAs = true>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<CGALayout = [[0, 0]]>
+#tmem_scales1 = #ttng.tensor_memory_scales_encoding<CGALayout = [[1, 0]]>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  // CHECK-LABEL: @tc_gen5_mma_scaled_fp4_padded_shared_linear_a
+  // CHECK-COUNT-4: tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.block32
+  // CHECK-NOT: tcgen05.mma
+  tt.func @tc_gen5_mma_scaled_fp4_padded_shared_linear_a(
+      %a: !ttg.memdesc<256x64xi8, #shared_fp4_padded_sl, #smem, mutable>,
+      %b: !ttg.memdesc<128x32xf8E4M3FN, #shared_b, #smem, mutable>,
+      %d: !ttg.memdesc<256x32xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %sa: !ttg.memdesc<256x4xi8, #tmem_scales1, #ttng.tensor_memory, mutable>,
+      %sb: !ttg.memdesc<32x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>,
+      %useAcc: i1, %pred: i1) {
+    ttng.tc_gen5_mma_scaled %a, %b, %d, %sa, %sb, %useAcc, %pred lhs = e2m1 rhs = e4m3 {two_ctas} :
+      !ttg.memdesc<256x64xi8, #shared_fp4_padded_sl, #smem, mutable>,
+      !ttg.memdesc<128x32xf8E4M3FN, #shared_b, #smem, mutable>,
+      !ttg.memdesc<256x32xf32, #tmem, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<256x4xi8, #tmem_scales1, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<32x4xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 256, 32]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_breuse
+  // CHECK: tcgen05.mma.cta_group::1.kind::f16.collector::b::fill
+  // CHECK: tcgen05.mma.cta_group::1.kind::f16.collector::b::lastuse
+  tt.func @tc_gen5_mma_breuse(%a: !ttg.memdesc<256x128xf16, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<128x128xf16, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>,
+                       %barrierPred: i1) {
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred, %barrier[%barrierPred] {is_async} :
+       !ttg.memdesc<256x128xf16, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<128x128xf16, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tc_gen5_mma_block_scale_breuse
+  // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::b::fill
+  // CHECK: tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::b::lastuse
+  tt.func @tc_gen5_mma_block_scale_breuse(%a: !ttg.memdesc<256x64xf8E4M3FN, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<32x128xi8, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %scale_a: !ttg.memdesc<256x2xi8, #tmem_scales, #ttng.tensor_memory>,
+                       %scale_b: !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
+                       %barrierPred: i1) {
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e4m3 rhs = e2m1, %barrier[%barrierPred] {is_async} :
+    !ttg.memdesc<256x64xf8E4M3FN, #shared, #ttg.shared_memory>,
+    !ttg.memdesc<32x128xi8, #shared1, #ttg.shared_memory>,
+    !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    !ttg.memdesc<256x2xi8, #tmem_scales, #ttng.tensor_memory>,
+    !ttg.memdesc<128x2xi8, #tmem_scales, #ttng.tensor_memory>,
+    !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -175,6 +175,42 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: arrive_barrier_multicast_absent
+  tt.func public @arrive_barrier_multicast_absent(%alloc: !ttg.memdesc<2xi64, #shared0, #smem, mutable>) {
+    // No ctaMask → non-multicast path.
+    // CHECK-NOT: fence.mbarrier_init.release.cluster
+    // CHECK-NOT: nvvm.cluster.arrive
+    // CHECK: mbarrier.arrive.shared::cta.b64
+    // CHECK-NOT: mbarrier.arrive.shared::cluster.multicast
+    ttng.init_barrier %alloc, 1 : !ttg.memdesc<2xi64, #shared0, #smem, mutable>
+    ttng.arrive_barrier %alloc, 1 : !ttg.memdesc<2xi64, #shared0, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: arrive_barrier_multicast
+  tt.func public @arrive_barrier_multicast(%alloc: !ttg.memdesc<2xi64, #shared0, #smem, mutable>) {
+    // CHECK: fence.mbarrier_init.release.cluster
+    // CHECK: nvvm.cluster.arrive.relaxed
+    // CHECK-NEXT: nvvm.cluster.wait
+    // CHECK: mbarrier.arrive.release.cluster.shared::cluster.multicast::cluster::32b.b64 _, [${{.*}}], ${{.*}};
+    // CHECK-NOT: mbarrier.arrive.release.cluster.shared::cta.b64
+    ttng.init_barrier %alloc, 1 : !ttg.memdesc<2xi64, #shared0, #smem, mutable>
+    ttng.arrive_barrier %alloc, 1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64, #shared0, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {

--- a/test/NVWS/aref-tmem-insertion.mlir
+++ b/test/NVWS/aref-tmem-insertion.mlir
@@ -959,7 +959,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
       %val, %tok5 = ttng.tmem_load %res[%tok4] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x256xf32, #blocked>
       "use"(%val) {ttg.partition = array<i32: 0>} : (tensor<128x256xf32, #blocked>) -> ()
       scf.yield {ttg.partition = array<i32: 0, 1, 2>} %tok5 : !ttg.async.token
-    } {tt.warp_specialize, ttg.partition = array<i32: 0, 1, 2>, ttg.partition.outputs = [array<i32: 2>], ttg.warp_specialize.tag = 0 : i32}
+    } {tt.disallow_acc_multi_buffer, tt.warp_specialize, ttg.partition = array<i32: 0, 1, 2>, ttg.partition.outputs = [array<i32: 2>], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
 }

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -987,3 +987,41 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     tt.return %d : tensor<64x8xf32, #blocked_fp16_n8>
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  // On sm107 (Rubin), with blockK >= 64 for mixed-precision, fp4Padded should NOT be true
+  // CHECK-DAG: #[[$B:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+  // CHECK-DAG: #[[$S:.+]] = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+  tt.func public @mmav5_block_scaled_mixed_prec_sm107_k64(%a: tensor<128x128xi8, #blocked2>, %scale_a: tensor<128x4xi8, #blocked1>, %b: tensor<64x128xi8, #blocked>, %scale_b: tensor<128x4xi8, #blocked1>) -> tensor<128x128xf32, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    // CHECK: ttg.local_alloc {{.*}} : (tensor<64x128xi8, #[[$B]]>) -> !ttg.memdesc<64x128xi8, #[[$S]], #smem>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e4m3 rhs = e2m1 {fastMath = false} : tensor<128x128xi8, #blocked2>, tensor<128x4xi8, #blocked1> * tensor<64x128xi8, #blocked>, tensor<128x4xi8, #blocked1> -> tensor<128x128xf32, #blocked>
+    tt.return %d : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
+// On Rubin, fp4Padded = true is needed when the fp4 operand is MN-major
+
+// LAYOUT_16x256{LITERAL}: #ttg.linear<{register = [[0, 1], [8, 0], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128], [16, 0]], lane = [[0, 2], [0, 4], [1, 0], [2, 0], [4, 0]], warp = [[32, 0], [64, 0]], block = []}>
+// CHECK-DAG: #[[$SHARED_A:.+]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+// CHECK-DAG: #[[$SHARED_B:.+]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8, fp4Padded = true}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: mmav5_scaled_n_packing_rubin
+  tt.func public @mmav5_scaled_n_packing_rubin(%arg0: tensor<128x256xf8E5M2, #blocked>, %arg1: tensor<128x8xi8, #blocked1>, %arg2: tensor<256x128xi8, #blocked>, %arg3: tensor<256x8xi8, #blocked1>, %arg4: tensor<128x256xf32, #blocked>) -> tensor<128x256xf32, #blocked> {
+    // CHECK-DAG: %[[A:.+]] = ttg.local_alloc %{{.+}} : (tensor<128x256xf8E5M2, #{{.+}}>) -> !ttg.memdesc<128x256xf8E5M2, #[[$SHARED_A]], #smem>
+    // CHECK-DAG: %[[B:.+]] = ttg.local_alloc %{{.+}} : (tensor<256x128xi8, #{{.+}}>) -> !ttg.memdesc<256x128xi8, #[[$SHARED_B]], #smem>
+    // CHECK: ttng.tc_gen5_mma_scaled %[[A]], %[[B]],
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %0 = tt.dot_scaled %arg0 scale %arg1, %arg2 scale %arg3, %arg4 lhs = e5m2 rhs = e2m1 {fastMath = false, rhs_k_pack = false} : tensor<128x256xf8E5M2, #blocked>, tensor<128x8xi8, #blocked1> * tensor<256x128xi8, #blocked>, tensor<256x8xi8, #blocked1> -> tensor<128x256xf32, #blocked>
+    tt.return %0 : tensor<128x256xf32, #blocked>
+  }
+}

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -469,6 +469,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-DAG: #[[$TMEM_A:.+]] = #ttng.tensor_memory_scales_encoding<blockRepOrder = kThenMn>
+  // CHECK-DAG: #[[$TMEM_B:.+]] = #ttng.tensor_memory_scales_encoding<>
+  // CHECK-LABEL: mmav5_block_scaled_nvfp4_sm107
+  // CHECK: %[[SCALEA:.+]] = ttng.tmem_alloc %{{.*}} : (tensor<128x16xf8E4M3FN, #{{.*}}>) -> !ttg.memdesc<128x16xf8E4M3FN, #[[$TMEM_A]], #ttng.tensor_memory>
+  // CHECK: %[[SCALEB:.+]] = ttng.tmem_alloc %{{.*}} : (tensor<128x16xf8E4M3FN, #{{.*}}>) -> !ttg.memdesc<128x16xf8E4M3FN, #[[$TMEM_B]], #ttng.tensor_memory>
+  // CHECK: ttng.tc_gen5_mma_scaled {{.*}}, %[[SCALEA]], %[[SCALEB]], {{.*}} lhs = e2m1 rhs = e2m1
+  tt.func public @mmav5_block_scaled_nvfp4_sm107(%a: tensor<128x128xi8, #blocked2>, %scale_a: tensor<128x16xf8E4M3FN, #blocked1>, %b: tensor<128x128xi8, #blocked>, %scale_b: tensor<128x16xf8E4M3FN, #blocked1>) -> tensor<128x128xf32, #blocked> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<128x128xi8, #blocked2>, tensor<128x16xf8E4M3FN, #blocked1> * tensor<128x128xi8, #blocked>, tensor<128x16xf8E4M3FN, #blocked1> -> tensor<128x128xf32, #blocked>
+    tt.return %d : tensor<128x128xf32, #blocked>
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -146,6 +146,145 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // -----
 
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#sharedT = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tcgen5_mma_scaled_rubin_wrong_a_scale_block_rep_order(
+      %a: !ttg.memdesc<256x128xi8, #shared, #ttg.shared_memory>,
+      %b: !ttg.memdesc<128x256xi8, #sharedT, #ttg.shared_memory>,
+      %c: !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %scale_a: !ttg.memdesc<256x8xf8E4M3FN, #tmem_scales, #ttng.tensor_memory>,
+      %scale_b: !ttg.memdesc<256x8xf8E4M3FN, #tmem_scales, #ttng.tensor_memory>,
+      %useAcc: i1,
+      %pred: i1,
+      %bar: !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>,
+      %barPred: i1) {
+    // expected-error @below {{A scales in tensor memory must use #ttng.tensor_memory_scales_encoding<blockRepOrder = kThenMn>}}
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e2m1 rhs = e2m1, %bar[%barPred] {is_async} :
+      !ttg.memdesc<256x128xi8, #shared, #ttg.shared_memory>,
+      !ttg.memdesc<128x256xi8, #sharedT, #ttg.shared_memory>,
+      !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<256x8xf8E4M3FN, #tmem_scales, #ttng.tensor_memory>,
+      !ttg.memdesc<256x8xf8E4M3FN, #tmem_scales, #ttng.tensor_memory>,
+      !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#sharedT = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
+#tmem_scales_k_then_mn = #ttng.tensor_memory_scales_encoding<blockRepOrder = kThenMn>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:107", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tcgen5_mma_scaled_rubin_wrong_b_scale_block_rep_order(
+      %a: !ttg.memdesc<256x128xi8, #shared, #ttg.shared_memory>,
+      %b: !ttg.memdesc<128x256xi8, #sharedT, #ttg.shared_memory>,
+      %c: !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %scale_a: !ttg.memdesc<256x8xf8E4M3FN, #tmem_scales_k_then_mn, #ttng.tensor_memory>,
+      %scale_b: !ttg.memdesc<256x8xf8E4M3FN, #tmem_scales_k_then_mn, #ttng.tensor_memory>,
+      %useAcc: i1,
+      %pred: i1,
+      %bar: !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>,
+      %barPred: i1) {
+    // expected-error @below {{B scales in tensor memory must use #ttng.tensor_memory_scales_encoding<blockRepOrder = mnThenK>}}
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e2m1 rhs = e2m1, %bar[%barPred] {is_async} :
+      !ttg.memdesc<256x128xi8, #shared, #ttg.shared_memory>,
+      !ttg.memdesc<128x256xi8, #sharedT, #ttg.shared_memory>,
+      !ttg.memdesc<256x256xf32, #tmem, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<256x8xf8E4M3FN, #tmem_scales_k_then_mn, #ttng.tensor_memory>,
+      !ttg.memdesc<256x8xf8E4M3FN, #tmem_scales_k_then_mn, #ttng.tensor_memory>,
+      !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+  tt.func @arrive_barrier_multicast_invalid() {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    // expected-error @below {{multicast arrive requires num_ctas > 1}}
+    ttng.arrive_barrier %bar, 1 {ctaMask = 1 : i32} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+  tt.func @arrive_barrier_multicast_zero_count() {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    // expected-error @below {{count must be greater than or equal to 1}}
+    ttng.arrive_barrier %bar, 0 {ctaMask = 3 : i32} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+  tt.func @arrive_barrier_multicast_mask_overflow() {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    // expected-error @below {{ctaMask exceeds numCTAs - 1}}
+    ttng.arrive_barrier %bar, 1 {ctaMask = 7 : i32} : !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+  tt.func @arrive_barrier_multicast_negative_mask() {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    // Negative masks are invalid and are rejected by the mask bounds check.
+    // expected-error @below {{ctaMask exceeds numCTAs - 1}}
+    ttng.arrive_barrier %bar, 1 {ctaMask = -1 : i32} : !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+  tt.func @arrive_barrier_multicast_non_identity_cga() {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    // expected-error @below {{multicast barrier cga_layout must be [[1]], got [[0]]}}
+    ttng.arrive_barrier %bar, 1 {ctaMask = 1 : i32} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+  tt.func @arrive_barrier_multicast_per_thread() {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    // expected-error @below {{multicast arrive does not support perThread}}
+    ttng.arrive_barrier %bar, 1 {ctaMask = 1 : i32, perThread} : !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 8}>
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>

--- a/test/TritonNvidiaGPU/ops.mlir
+++ b/test/TritonNvidiaGPU/ops.mlir
@@ -176,6 +176,41 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   }
 }
 
+#shared_cga = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: @arrive_barrier_multicast_absent
+  tt.func @arrive_barrier_multicast_absent(%alloc: !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>) {
+    // CHECK: ttng.arrive_barrier %arg0, 1 :
+    // CHECK-NOT: ctaMask
+    ttng.arrive_barrier %alloc, 1 : !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>
+    tt.return
+  }
+
+  // Explicit ctaMask = 0 is valid and elides on print like the default.
+  // CHECK-LABEL: @arrive_barrier_multicast_zero
+  tt.func @arrive_barrier_multicast_zero(%alloc: !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>) {
+    // CHECK: ttng.arrive_barrier %arg0, 1 :
+    // CHECK-NOT: ctaMask
+    ttng.arrive_barrier %alloc, 1 {ctaMask = 0 : i32} : !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @arrive_barrier_multicast
+  tt.func @arrive_barrier_multicast(%alloc: !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>) {
+    // CHECK: ttng.arrive_barrier %arg0, 1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64,
+    ttng.arrive_barrier %alloc, 1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>
+    tt.return
+  }
+
+  // Round-trip the optional-pred-then-attr-dict spelling.
+  // CHECK-LABEL: @arrive_barrier_multicast_pred
+  tt.func @arrive_barrier_multicast_pred(%alloc: !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>, %pred: i1) {
+    // CHECK: ttng.arrive_barrier %arg0, 1, %arg1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64,
+    ttng.arrive_barrier %alloc, 1, %pred {ctaMask = 1 : i32} : !ttg.memdesc<2xi64, #shared_cga, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
 // Tests for TMA im2col (3D/4D/5D) and tiled mode
 #nvmma_128 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared3 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1180,8 +1180,13 @@ class CUDABackend(BaseBackend):
             raise RuntimeError(
                 "Address Sanitizer Error: Address sanitizer is currently only supported on the AMD backend")
         llvm_mod = llvm.to_module(mod, context)
-        proc = sm_arch_from_capability(capability)
-        features = get_features(options, self.target.arch)
+        if capability == 107:
+            cap_llvm = 100
+        else:
+            cap_llvm = capability
+
+        proc = sm_arch_from_capability(cap_llvm)
+        features = get_features(options, cap_llvm)
         triple = "nvptx64-nvidia-cuda"
         nvidia.set_short_ptr()
         llvm.attach_datalayout(llvm_mod, triple, proc, features)
@@ -1214,8 +1219,14 @@ class CUDABackend(BaseBackend):
         ptx_version = get_ptx_version_from_options(opt, self.target.arch)
 
         triple = "nvptx64-nvidia-cuda"
-        proc = sm_arch_from_capability(capability)
-        features = get_features(opt, self.target.arch)
+
+        if capability == 107:
+            cap_llvm = 100
+        else:
+            cap_llvm = capability
+
+        proc = sm_arch_from_capability(cap_llvm)
+        features = get_features(opt, cap_llvm)
         flags = ["nvptx-mad-wide-opt"]
         ret = llvm.translate_to_asm(src, triple, proc, features, flags, opt.enable_fp_fusion, False)
         # Find kernel names (there should only be one)

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -13,6 +13,16 @@
  * The same core is used by TritonCC / AOT-T via make_launcher_src. */
 #include "nvidia/backend/launch.h"
 
+#ifndef CU_FUNC_ATTRIBUTE_SHARED_MEMORY_MODE
+#define CU_FUNC_ATTRIBUTE_SHARED_MEMORY_MODE 17
+#endif
+#ifndef CU_SHARED_MEMORY_MODE_ALLOW_OVERSIZED_SHARED_MEMORY
+#define CU_SHARED_MEMORY_MODE_ALLOW_OVERSIZED_SHARED_MEMORY 3
+#endif
+#ifndef CU_LAUNCH_ATTRIBUTE_SHARED_MEMORY_MODE
+#define CU_LAUNCH_ATTRIBUTE_SHARED_MEMORY_MODE 18
+#endif
+
 typedef struct {
   PyObject_HEAD;
   _Alignas(alignof(CUtensorMap)) CUtensorMap tensorMap;
@@ -143,9 +153,18 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
   int sm_clock_rate;
   int mem_clock_rate;
   int mem_bus_width;
-  CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
-      &max_shared_mem, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
-      device));
+
+  // XXX: remove attribute enum def once latest cuda.h is in use
+  int CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK = 150;
+  if (CUDA_SUCCESS !=
+      cuDeviceGetAttribute(
+          &max_shared_mem,
+          CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, device)) {
+    CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
+        &max_shared_mem, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
+        device));
+  }
+
   CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
       &max_num_regs, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK, device));
   CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
@@ -283,18 +302,28 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuDeviceGetAttribute(
       &shared_optin, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
       device));
+  assert(shared_optin <= 228 * 1024 && "sanity check");
   if (shared > 49152 && shared_optin > 49152) {
-    CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(
-        cuFuncSetCacheConfig(fun, CU_FUNC_CACHE_PREFER_SHARED));
-    int shared_total, shared_static;
-    CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuDeviceGetAttribute(
-        &shared_total, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR,
-        device));
-    CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuFuncGetAttribute(
-        &shared_static, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, fun));
-    CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(
-        cuFuncSetAttribute(fun, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
-                           shared_optin - shared_static));
+    // XXX: remove attribute enum defs once latest cuda.h is in use
+    // try to use oversized shared memory via new API
+    // L1$ size is set to 8KB, CGA scheduling must be in SPREAD mode.
+    if (CUDA_SUCCESS !=
+        cuFuncSetAttribute(
+            fun, CU_FUNC_ATTRIBUTE_SHARED_MEMORY_MODE,
+            CU_SHARED_MEMORY_MODE_ALLOW_OVERSIZED_SHARED_MEMORY)) {
+      // use legacy api if cuda doesn't support oversized shared memory
+      CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(
+          cuFuncSetCacheConfig(fun, CU_FUNC_CACHE_PREFER_SHARED));
+      int shared_total, shared_static;
+      CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuDeviceGetAttribute(
+          &shared_total,
+          CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR, device));
+      CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuFuncGetAttribute(
+          &shared_static, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, fun));
+      CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(cuFuncSetAttribute(
+          fun, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+          shared_optin - shared_static));
+    }
   }
   Py_END_ALLOW_THREADS;
 
@@ -1211,6 +1240,18 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps,
     config.hStream = stream;
     config.attrs = launchAttr;
     int num_attrs = 0;
+
+    if (shared_memory > 228 * 1024) {
+      {
+        // XXX: remove attribute defs once driver with new API is in use
+        // L1$ size is set to 8KB, CGA scheduling must be in SPREAD mode.
+        CUlaunchAttribute attr = {
+            .id = CU_LAUNCH_ATTRIBUTE_SHARED_MEMORY_MODE,
+            .value = CU_SHARED_MEMORY_MODE_ALLOW_OVERSIZED_SHARED_MEMORY};
+        launchAttr[num_attrs] = attr;
+        ++num_attrs;
+      }
+    }
 
     if (launch_pdl != 0) {
       CUlaunchAttribute pdlAttr = {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -121,14 +121,19 @@ Operation *skipIdxOp(Operation *op) {
 Operation *AllocChannel::getSrcOp() {
   if (defunct)
     return nullptr; // alloc erased by reuse folding; endpoints are dangling.
-  // Prefer the producer cached at channel-creation time. This is the only
-  // reliable source for a producer inside a ttng.subtiled_region: once a
-  // sibling channel (sharing the same in-body template store and per-tile
-  // buffer position) is lowered, insertAsyncComm rewires that store and removes
-  // the shared per-tile position, so the alloc-walk below would no longer reach
-  // it.
-  if (cachedSrcOp)
-    return cachedSrcOp;
+  // Re-derive the producer from the (stable) alloc first, and use cachedSrcOp
+  // only as a fallback. The alloc is the durable anchor: buffer creation can
+  // REWRITE a channel's producer store (erase the original local_store /
+  // tma_copy that cachedSrcOp was set to at channel-creation time and emit a
+  // fresh one into the multi-buffered alloc), which leaves cachedSrcOp dangling
+  // while the alloc stays live. Returning the stale cached pointer is a
+  // use-after-free (later deref, e.g. needAccumCntForReuse -> enclosing ->
+  // getParentOp, segfaults). The alloc-walk returns the current live producer.
+  // cachedSrcOp remains the fallback for a producer inside a
+  // ttng.subtiled_region: once a sibling channel (sharing the in-body template
+  // store and per-tile buffer position) is lowered, the store is rewired and
+  // the alloc-walk no longer reaches it, so the surviving cached template op is
+  // the only source. (Both paths agree when both resolve.)
   for (auto usr : allocOp->getUsers()) {
     Operation *user = skipIdxOp(usr);
     if (!user)
@@ -147,7 +152,7 @@ Operation *AllocChannel::getSrcOp() {
       }
     }
   }
-  return nullptr;
+  return cachedSrcOp;
 }
 
 static void getAllConsumers(AllocChannel *ch,

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertTmemAref.cpp
@@ -575,21 +575,6 @@ insertTmemArefImpl(TmemAccessDag::Node *node,
   return node;
 }
 
-bool canDoubleBufferAcc(MMAv5OpInterface mmaOp, int numTmemBlocks) {
-  auto tmemDesc = mmaOp.getAccumulator().getType();
-  auto blockM = tmemDesc.getShape()[0];
-  auto blockN = tmemDesc.getShape()[1];
-  constexpr int numTMEMColumns = 512;
-  constexpr int numTMEMRows = 128;
-  if (numTmemBlocks + (blockM * blockN * 2) > numTMEMRows * numTMEMColumns) {
-    return false;
-  }
-  if (isa<TCGen5MMAScaledOp>(mmaOp) && blockN == 256) {
-    return false;
-  }
-  return true;
-};
-
 bool hasProducerConsumerPartitioning(TmemAccessDag &accessDag) {
   // TMEM partitioning follows a producer-consumer pattern if it has this
   // structure:
@@ -675,8 +660,7 @@ int insertTmemAref(TmemAccessDag &accessDag, int numTmemBlocks) {
               // multibuffering.
               isAccMultibufferingPossible(mmaOp, loop) &&
               // The user didn't disable it with a flag.
-              !getDisallowAccMultiBuffer(wsLoop) &&
-              canDoubleBufferAcc(mmaOp, numTmemBlocks);
+              !getDisallowAccMultiBuffer(wsLoop);
           isMultiStaged = isMultiStaged && accIsMultiBuffered;
         }
       }

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -7,8 +7,9 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h"
 
 #include "nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h"
 #include "tlx/dialect/include/IR/Dialect.h"
@@ -530,8 +531,8 @@ public:
 };
 
 static Value createTMAlloc(IRRewriter &rewriter, LLVM::LLVMFuncOp func,
-                           size_t size, Value pred, bool twoCTAs,
-                           int smemOffset = 0) {
+                           std::string exclusive, size_t size, Value pred,
+                           bool twoCTAs, int smemOffset = 0) {
   PTXBuilder ptxBuilder;
   Location loc = func.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -541,9 +542,10 @@ static Value createTMAlloc(IRRewriter &rewriter, LLVM::LLVMFuncOp func,
     sharedMem = LLVM::GEPOp::create(rewriter, loc, ptrTy, i8_ty, sharedMem,
                                     b.i32_val(smemOffset));
   }
-  std::string ptxString =
-      "@$0 tcgen05.alloc.cta_group::" + std::to_string(twoCTAs ? 2 : 1) +
-      ".sync.aligned.shared::cta.b32 [$1], " + std::to_string(size) + ";";
+  std::string ptxString = "@$0 tcgen05.alloc" + exclusive +
+                          ".cta_group::" + std::to_string(twoCTAs ? 2 : 1) +
+                          ".sync.aligned.shared::cta.b32 [$1], " +
+                          std::to_string(size) + ";";
 
   auto &allocOp = *ptxBuilder.create(ptxString);
   allocOp(
@@ -568,8 +570,8 @@ static void createRelinquishAlloc(IRRewriter &rewriter, Location loc,
   ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
 }
 
-void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, size_t size, Value pred,
-                 bool twoCTAs, bool tlxPairedMMA) {
+void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, std::string exclusive,
+                 size_t size, Value pred, bool twoCTAs, bool tlxPairedMMA) {
   func.walk([&](LLVM::ReturnOp ret) {
     OpBuilder b(ret);
     auto ctx = ret->getContext();
@@ -605,9 +607,10 @@ void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, size_t size, Value pred,
     PTXBuilder ptxBuilder;
     // Calculate the predicate in the inline asm to avoid creating long
     // liveranges.
-    std::string ptxString =
-        "@$0 tcgen05.dealloc.cta_group::" + std::to_string(twoCTAs ? 2 : 1) +
-        ".sync.aligned.b32 $1, " + std::to_string(size) + ";";
+    std::string ptxString = "@$0 tcgen05.dealloc" + exclusive +
+                            ".cta_group::" + std::to_string(twoCTAs ? 2 : 1) +
+                            ".sync.aligned.b32 $1, " + std::to_string(size) +
+                            ";";
     auto &dealloc = *ptxBuilder.create(ptxString);
     dealloc(
         {ptxBuilder.newOperand(pred, "b"), ptxBuilder.newOperand(alloc, "r")},
@@ -634,9 +637,14 @@ static Value initTensorMemory(LLVM::LLVMFuncOp func,
   auto ctx = mod.getContext();
   auto loc = func.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
+  int computeCapability = 100;
+  if (mod->hasAttr("ttg.target"))
+    computeCapability = getNVIDIAComputeCapability(mod);
+  triton::nvidia_gpu::TargetFeatures targetFeatures(computeCapability);
+  auto tmemMaxSize = targetFeatures.getMaxTMEMColumns();
   // A proper error will be raised by the frontend, but to allow compilation to
   // continue we emit a trap.
-  if (size > 512) {
+  if (size > tmemMaxSize) {
     LLVM::Trap::create(rewriter, loc);
     return LLVM::UndefOp::create(rewriter, loc, ptr_ty(ctx, 6));
   }
@@ -645,15 +653,19 @@ static Value initTensorMemory(LLVM::LLVMFuncOp func,
   bool useTwoCTAs =
       mlir::triton::nvidia_gpu::getModuleTwoCTAs(mod) || isTlxPairedMMA;
 
+  std::string exclusive =
+      size == tmemMaxSize && targetFeatures.supportsExclusiveTMEMAlloc()
+          ? ".exclusive"
+          : "";
   // This code is only executed by the default warp group.
   Value threadId = NVVM::ThreadIdXOp::create(rewriter, loc, i32_ty);
   Value pred = b.icmp_ult(threadId, b.i32_val(32));
-  Value alloc =
-      createTMAlloc(rewriter, func, size, pred, useTwoCTAs, smemOffset);
+  Value alloc = createTMAlloc(rewriter, func, exclusive, size, pred,
+                              useTwoCTAs, smemOffset);
   createRelinquishAlloc(rewriter, loc, pred, useTwoCTAs);
   // TODO: pred will have a long liverange, we need to check if this is a
   // problem and how it can be fixed.
-  freeTMAlloc(func, alloc, size, pred, useTwoCTAs, isTlxPairedMMA);
+  freeTMAlloc(func, alloc, exclusive, size, pred, useTwoCTAs, isTlxPairedMMA);
   return alloc;
 }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -469,12 +469,20 @@ struct ArriveBarrierOpConversion
           loc, rewriter, smemObj.getBase(), barrierTy);
 
       std::stringstream ptxAsm;
-      ptxAsm << "@$0 mbarrier.arrive.shared::"
-             << (isRemoteBarrier || isCrossCluster ? "cluster" : "cta")
-             << ".b64 _, [$1]";
+      ptxAsm << "@$0 mbarrier.arrive.";
+      if (op.isMulticast())
+        ptxAsm << "release.cluster.";
+      ptxAsm << (isRemoteBarrier || isCrossCluster || op.isMulticast()
+                     ? "shared::cluster"
+                     : "shared::cta");
+      if (op.isMulticast())
+        ptxAsm << ".multicast::cluster::32b";
+      ptxAsm << ".b64 _, [$1]";
       if (op.getCount() > 1) {
         ptxAsm << ", " << op.getCount();
       }
+      if (op.isMulticast())
+        ptxAsm << ", $2";
       ptxAsm << ";";
 
       Value id = getThreadId(rewriter, loc);
@@ -483,9 +491,14 @@ struct ArriveBarrierOpConversion
         pred = b.and_(pred, adaptor.getPred());
 
       PTXBuilder ptxBuilder;
-      SmallVector<PTXBuilder::Operand *, 2> operands = {
+      SmallVector<PTXBuilder::Operand *, 3> operands = {
           ptxBuilder.newOperand(pred, "b"),
           ptxBuilder.newOperand(barrierPtr, "r")};
+      if (op.isMulticast()) {
+        Value mask = LLVM::NVIDIA::createTMAMulticastMask(
+            loc, rewriter, static_cast<uint16_t>(op.getCtaMask()));
+        operands.push_back(ptxBuilder.newOperand(mask, "r"));
+      }
 
       auto arriveOp = *ptxBuilder.create<>(ptxAsm.str());
       arriveOp(operands, /*onlyAttachMLIRArgs=*/true);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -199,7 +199,7 @@ public:
     addInstr(addOut, addLhs, addRhs);
     Value fullAddrb128 =
         ptxBuilder.launch(rewriter, loc, i32_ty, /*hasSideEffect=*/true);
-    Value addrMasked = tb.and_(fullAddrb128, tb.i32_val(0x3FFF));
+    Value addrMasked = tb.and_(fullAddrb128, tb.i32_val(0x7FFF));
     Value addr64 = tb.zext(i64_ty, addrMasked);
     Value descVal = tb.add(tb.int_val(64, currDesc.descriptor), addr64);
     return descVal;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -84,7 +84,7 @@ inline mxfpKind getMXFPKind(ScaleDotElemType typeA, ScaleDotElemType typeB,
 
 static Value createInstDescriptor(ConversionPatternRewriter &rewriter,
                                   ttng::TCGen5MMAOp op, int M, int N,
-                                  bool transposeA, bool transposeB) {
+                                  bool transposeA, bool transposeB, int kSize) {
   Location loc = op.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   union TCGen5InstructionDescriptor {
@@ -104,7 +104,7 @@ static Value createInstDescriptor(ConversionPatternRewriter &rewriter,
       uint32_t N : 6;
       uint32_t : 1;
       uint32_t M : 5;
-      uint32_t : 1;
+      uint32_t kSize : 1;
       uint32_t shift : 2;
     };
   };
@@ -142,15 +142,18 @@ static Value createInstDescriptor(ConversionPatternRewriter &rewriter,
   } else {
     desc.dType = dstElType.isF16() ? 0 : 1;
   }
+  if (kSize == 64)
+    desc.kSize = 1;
+
   return b.int_val(32, desc.descriptor);
 }
 
-static Value createScaleInstDescriptor(ConversionPatternRewriter &rewriter,
-                                       ttng::TCGen5MMAScaledOp op, int M, int N,
-                                       bool transposeA, bool transposeB,
-                                       int scaleFactorsubIdxA,
-                                       int scaleFactorsubIdxB,
-                                       mxfpKind mxfpInstKind) {
+static Value createScaleInstDescriptorFp8(ConversionPatternRewriter &rewriter,
+                                          ttng::TCGen5MMAScaledOp op, int M,
+                                          int N, bool transposeA,
+                                          bool transposeB,
+                                          int scaleFactorsubIdxA,
+                                          int scaleFactorsubIdxB, int kSize) {
   Location loc = op.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   union TCGen5InstructionDescriptor {
@@ -168,13 +171,13 @@ static Value createScaleInstDescriptor(ConversionPatternRewriter &rewriter,
       uint32_t transposeA : 1;
       uint32_t transposeB : 1;
       uint32_t N : 6;
-      uint32_t scaleType : 1;
-      uint32_t M : 5;
+      uint32_t scaleType : 2;
+      uint32_t M : 4;
       uint32_t AScaleFactor : 2;
-      uint32_t : 1;
+      uint32_t kSize : 1;
     };
   };
-  auto getTypeEncoding = [](ScaleDotElemType type, bool isMXF4) {
+  auto getTypeEncoding = [](ScaleDotElemType type) {
     switch (type) {
     case ScaleDotElemType::E4M3:
       return 0;
@@ -185,7 +188,7 @@ static Value createScaleInstDescriptor(ConversionPatternRewriter &rewriter,
     case ScaleDotElemType::E3M2:
       return 4;
     case ScaleDotElemType::E2M1:
-      return !isMXF4 ? 5 : 1;
+      return 5;
     default:
       break;
     }
@@ -197,40 +200,96 @@ static Value createScaleInstDescriptor(ConversionPatternRewriter &rewriter,
   desc.descriptor = 0;
   desc.transposeA = transposeA;
   desc.transposeB = transposeB;
-  desc.M = M >> 4;
+  desc.M = M >> 5;
   desc.N = N >> 3;
-  desc.aType =
-      getTypeEncoding(op.getAType(), mxfpInstKind != mxfpKind::mxf8f6f4);
-  desc.bType =
-      getTypeEncoding(op.getBType(), mxfpInstKind != mxfpKind::mxf8f6f4);
+  desc.aType = getTypeEncoding(op.getAType());
+  desc.bType = getTypeEncoding(op.getBType());
   desc.AScaleFactor = scaleFactorsubIdxA;
   desc.BScaleFactor = scaleFactorsubIdxB;
-  // Hardcoded UE8M0 scale type.
-  desc.scaleType = 1;
+  desc.scaleType = 1; // E8M0
 
-  if (mxfpInstKind != mxfpKind::mxf8f6f4) {
-    assert(desc.aType == 1 && desc.bType == 1);
-    assert(desc.AScaleFactor <= 1 && desc.BScaleFactor <= 1);
-    assert(desc.transposeA == 0 &&
-           "MMAv5 with kind=mxf4 does not support transpose");
-    assert(desc.transposeB == 0 &&
-           "MMAv5 with kind=mxf4 does not support transpose");
-    if (mxfpInstKind == mxfpKind::mxf4) {
-      desc.AScaleFactor *= 2;
-      desc.BScaleFactor *= 2;
-      assert(desc.AScaleFactor == 0 ||
-             desc.AScaleFactor == 2 &&
-                 "MMAv5 with kind=mxf4 only supports SFA_ID 0 or 2");
-      assert(desc.BScaleFactor == 0 ||
-             desc.BScaleFactor == 2 &&
-                 "MMAv5 with kind=mxf4 only supports SFB_ID 0 or 2");
-    } else if (mxfpInstKind == mxfpKind::mxf4nvf4) {
-      desc.scaleType = 0; // UE4M3
-      assert(desc.AScaleFactor == 0 &&
-             "MMAv5 with kind=mxf4nvf4 currently only supports SFA_ID 0");
-      assert(desc.BScaleFactor == 0 &&
-             "MMAv5 with kind=mxf4nvf4 currently only supports SFB_ID 0");
-    }
+  assert(kSize == 32 || kSize == 64);
+  if (kSize == 64) {
+    desc.kSize = 1;
+    desc.AScaleFactor *= 2;
+    desc.BScaleFactor *= 2;
+  }
+
+  return b.int_val(32, desc.descriptor);
+}
+
+static Value createScaleInstDescriptorFp4(
+    ConversionPatternRewriter &rewriter, ttng::TCGen5MMAScaledOp op, int M,
+    int N, bool transposeA, bool transposeB, int scaleFactorsubIdxA,
+    int scaleFactorsubIdxB, mxfpKind mxfpInstKind, int blockK, int kSize) {
+  Location loc = op.getLoc();
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  union TCGen5InstructionDescriptor {
+    uint32_t descriptor;
+    struct {
+      uint32_t sparsitySelector : 2;
+      uint32_t sparsity : 1;
+      uint32_t kSizeUpper : 1;
+      uint32_t BScaleFactor : 2;
+      uint32_t : 1;
+      uint32_t aType : 3;
+      uint32_t bType : 2;
+      uint32_t : 1;
+      uint32_t negateA : 1;
+      uint32_t negateB : 1;
+      uint32_t transposeA : 1;
+      uint32_t transposeB : 1;
+      uint32_t N : 6;
+      uint32_t scaleType : 2;
+      uint32_t M : 4;
+      uint32_t AScaleFactor : 2;
+      uint32_t kSizeLower : 1;
+    };
+  };
+  static_assert(sizeof(TCGen5InstructionDescriptor) == 4,
+                "instruction descriptor size should be 32 bits.");
+  TCGen5InstructionDescriptor desc;
+  desc.descriptor = 0;
+  desc.transposeA = transposeA;
+  desc.transposeB = transposeB;
+  desc.M = M >> 5;
+  desc.N = N >> 3;
+  desc.aType = 1;
+  desc.bType = 1;
+  desc.AScaleFactor = scaleFactorsubIdxA;
+  desc.BScaleFactor = scaleFactorsubIdxB;
+  desc.scaleType =
+      llvm::isa<Float8E4M3FNType>(op.getAScale().getType().getElementType())
+          ? 0
+          : 1;
+
+  assert(kSize == 64 || kSize == 128);
+  if (kSize == 128) {
+    desc.kSizeUpper = 1;
+  }
+
+  assert(desc.AScaleFactor <= 1 && desc.BScaleFactor <= 1);
+  assert(desc.transposeA == 0 &&
+         "MMAv5 with kind=mxf4 does not support transpose");
+  assert(desc.transposeB == 0 &&
+         "MMAv5 with kind=mxf4 does not support transpose");
+
+  if (mxfpInstKind == mxfpKind::mxf4) {
+    desc.AScaleFactor *= 2;
+    desc.BScaleFactor *= 2;
+    assert(desc.AScaleFactor == 0 || desc.AScaleFactor == 2 &&
+                                         "MMAv5 with kind=mxf4 or "
+                                         "kind=mxf4nvf4 and .block32 only "
+                                         "supports SFA_ID 0 or 2");
+    assert(desc.BScaleFactor == 0 || desc.BScaleFactor == 2 &&
+                                         "MMAv5 with kind=mxf4 or "
+                                         "kind=mxf4nvf4 and .block32 only "
+                                         "supports SFB_ID 0 or 2");
+  } else if (mxfpInstKind == mxfpKind::mxf4nvf4) {
+    assert(desc.AScaleFactor == 0 &&
+           "MMAv5 with kind=mxf4nvf4 and .block16 only supports SFA_ID 0");
+    assert(desc.BScaleFactor == 0 &&
+           "MMAv5 with kind=mxf4nvf4 and .block16 only supports SFB_ID 0");
   }
 
   return b.int_val(32, desc.descriptor);
@@ -243,7 +302,8 @@ static Value createScaleInstDescriptor(ConversionPatternRewriter &rewriter,
 static void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
                           ttng::TCGen5MMAOp op, MemDescOperand a, Value b,
                           MemDescOperand d, Value pred, Value instDescriptor,
-                          Value useInitAcc, bool aInTMem, bool twoCTAs) {
+                          Value useInitAcc, bool aInTMem, bool twoCTAs,
+                          std::string collectorB) {
   PTXBuilder ptxBuilder;
   std::string opcode =
       "tcgen05.mma.cta_group::" + std::to_string(twoCTAs ? 2 : 1) + ".kind::";
@@ -261,6 +321,7 @@ static void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
   } else {
     assert(0 && "Unsupported type.");
   }
+  opcode += collectorB;
   auto *accOp = ptxBuilder.newAddrOperand(d.base, "r", *d.offset);
   assert(a.offset.has_value() == aInTMem);
   auto *aOp = aInTMem ? ptxBuilder.newAddrOperand(a.base, "r", *a.offset)
@@ -279,19 +340,25 @@ static void createScaledGen5MMA(ConversionPatternRewriter &rewriter,
                                 Value scaleA, Value scaleB, Value pred,
                                 Value instDescriptor, Value useInitAcc,
                                 bool aInTmem, mxfpKind mxfpInstKind,
-                                bool twoCTAs) {
+                                bool twoCTAs, std::string collectorB,
+                                int ptxVersion) {
   PTXBuilder ptxBuilder;
   std::string opcode =
       "tcgen05.mma.cta_group::" + std::to_string(twoCTAs ? 2 : 1) + ".kind::";
+  bool useBlockScaleSyntax = ptxVersion >= 88;
   if (mxfpInstKind == mxfpKind::mxf8f6f4) {
-    opcode += "mxf8f6f4.block_scale.scale_vec::1X";
+    opcode += useBlockScaleSyntax ? "mxf8f6f4.block_scale.block32"
+                                  : "mxf8f6f4.block_scale.scale_vec::1X";
   } else if (mxfpInstKind == mxfpKind::mxf4) {
-    opcode += "mxf4.block_scale.scale_vec::2X";
+    opcode += useBlockScaleSyntax ? "mxf4.block_scale.block32"
+                                  : "mxf4.block_scale.scale_vec::2X";
   } else if (mxfpInstKind == mxfpKind::mxf4nvf4) {
-    opcode += "mxf4nvf4.block_scale.scale_vec::4X";
+    opcode += useBlockScaleSyntax ? "mxf4nvf4.block_scale.block16"
+                                  : "mxf4nvf4.block_scale.scale_vec::4X";
   } else {
     assert(0 && "Unsupported mxfp kind.");
   }
+  opcode += collectorB;
   auto *accOp = ptxBuilder.newAddrOperand(d.base, "r", *d.offset);
   assert(aInTmem == a.offset.has_value());
   auto *aOp = aInTmem ? ptxBuilder.newAddrOperand(a.base, "r", *a.offset)
@@ -360,6 +427,13 @@ static void createMMACommit(ConversionPatternRewriter &rewriter, Location loc,
 // MMAv5 Conversion
 //===----------------------------------------------------------------------===//
 
+enum class ReuseB {
+  None,
+  Keep,
+  Use,
+  Lastuse,
+};
+
 // Information about how to lower a dot operation, shared between regular and
 // scaled dot.
 struct DotConversion {
@@ -380,7 +454,7 @@ struct DotConversion {
       ConversionPatternRewriter &, Location, int, int, const InstDesc &)>;
   using CreateMMAInstFn = std::function<void(
       ConversionPatternRewriter &, Location, MemDescOperand, MemDescOperand,
-      Value, Value, Value, const InstDesc &, int, int, int)>;
+      Value, Value, Value, const InstDesc &, int, int, int, ReuseB)>;
 
   struct {
     unsigned M;
@@ -403,6 +477,7 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
                              ValueRange barriers, ValueRange barrierPreds,
                              bool twoCTAs, bool tlxPairedMMA,
                              ValueRange commitDescs, bool opKindIsMXFP4,
+                             const ttng::TargetFeatures &targetFeatures,
                              const DotConversion &op) {
   auto tb = TritonLLVMOpBuilder(loc, rewriter);
 
@@ -523,18 +598,41 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
 
   DotConversion::InstDesc desc{mmaSizeM, mmaSizeN, {numRepM, numRepN, numRepK},
                                transA,   transB,   aInTmem};
-  for (int m = 0; m < numRepM; m++) {
+
+  // B reuse requires M = 128 for 1CTA or 256 for 2CTA, which corresponds to
+  // the condition mmaSizeM == 128 here
+  if (numRepM == 2 && mmaSizeM == 128 && targetFeatures.supportsReuseB()) {
     for (int n = 0; n < numRepN; n++) {
       Value useInitAcc = useDFlag;
-      MemDescOperand accAddress = op.getAccAddress(rewriter, loc, m, n, desc);
       for (int k = 0; k < numRepK; k++) {
-        MemDescOperand a = aLoader->memLoad(
-            m * aOperandShape[0], k * aOperandShape[1], rewriter, loc);
         Value b = bLoader->smemLoad(k * bOperandShape[0], n * bOperandShape[1],
                                     rewriter, loc);
-        op.createMMAInst(rewriter, loc, accAddress, a, b, elect, useInitAcc,
-                         desc, m, n, k);
+        for (int m = 0; m < 2; m++) {
+          MemDescOperand accAddress =
+              op.getAccAddress(rewriter, loc, m, n, desc);
+          MemDescOperand a =
+              aLoader->memLoad(m * mmaSizeM, k * mmaSizeK, rewriter, loc);
+          ReuseB reuseB = m == 0 ? ReuseB::Keep : ReuseB::Lastuse;
+          op.createMMAInst(rewriter, loc, accAddress, a, b, elect, useInitAcc,
+                           desc, m, n, k, reuseB);
+        }
         useInitAcc = tb.i1_val(1);
+      }
+    }
+  } else {
+    for (int m = 0; m < numRepM; m++) {
+      for (int n = 0; n < numRepN; n++) {
+        Value useInitAcc = useDFlag;
+        MemDescOperand accAddress = op.getAccAddress(rewriter, loc, m, n, desc);
+        for (int k = 0; k < numRepK; k++) {
+          MemDescOperand a = aLoader->memLoad(
+              m * aOperandShape[0], k * aOperandShape[1], rewriter, loc);
+          Value b = bLoader->smemLoad(k * bOperandShape[0],
+                                      n * bOperandShape[1], rewriter, loc);
+          op.createMMAInst(rewriter, loc, accAddress, a, b, elect, useInitAcc,
+                           desc, m, n, k, ReuseB::None);
+          useInitAcc = tb.i1_val(1);
+        }
       }
     }
   }
@@ -550,10 +648,22 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
   return success();
 }
 
+std::string getCollectorBModifer(ReuseB reuseB) {
+  if (reuseB == ReuseB::Keep) {
+    return ".collector::b::fill";
+  } else if (reuseB == ReuseB::Use) {
+    return ".collector::b::use";
+  } else if (reuseB == ReuseB::Lastuse) {
+    return ".collector::b::lastuse";
+  }
+  return "";
+}
+
 LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
                          ConversionPatternRewriter &rewriter, Location loc,
                          ttng::TCGen5MMAOp op,
-                         ttng::TCGen5MMAOpAdaptor &adaptor) {
+                         ttng::TCGen5MMAOpAdaptor &adaptor,
+                         const ttng::TargetFeatures &targetFeatures) {
   MemDescType aTensorTy = op.getA().getType();
   MemDescType bTensorTy = op.getB().getType();
   MemDescType dTensorTy = op.getD().getType();
@@ -575,6 +685,18 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
   dot.shape.K = aTensorTy.getDimSize(1);
   dot.mmaSizeK = 256 / aTensorTy.getElementTypeBitWidth();
 
+  auto tensorMemAttr =
+      cast<ttng::TensorMemoryEncodingAttr>(dTensorTy.getEncoding());
+  unsigned mmaSizeM = tensorMemAttr.getBlockM();
+
+  // 2xfp8 requires M = 128 for 1CTA or 256 for 2CTA, which corresponds to
+  // the condition mmaSizeM == 128 here
+  if (targetFeatures.supports2xFp8Tcgen05MMA() &&
+      aTensorTy.getElementTypeBitWidth() == 8 &&
+      aTensorTy.getDimSize(1) >= 64 && mmaSizeM == 128) {
+    dot.mmaSizeK = 64;
+  }
+
   dot.shapeA = getShapePerCTA(aTensorTy);
   dot.shapeB = getShapePerCTA(bTensorTy);
   dot.numBitsPerElementA = aTensorTy.getElementTypeBitWidth();
@@ -592,16 +714,18 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
                           MemDescOperand accAddress, MemDescOperand a, Value b,
                           Value pred, Value useInitAcc,
                           const DotConversion::InstDesc &desc, int m, int n,
-                          int k) {
+                          int k, ReuseB reuseB) {
     // mmaSizeM/N is the per-cta size M/N, while the 2CTA instruction expects
     // the 2CTA size mmaSize is always 64 / 128 so we double it for 2CTA
     auto mmaSizeM = twoCTAs ? desc.mmaSizeM * 2 : desc.mmaSizeM;
     auto mmaSizeN = desc.mmaSizeN;
     assert(desc.mmaSizeM == 64 || desc.mmaSizeM == 128);
-    Value instDescriptor = createInstDescriptor(
-        rewriter, op, mmaSizeM, mmaSizeN, desc.transA, desc.transB);
+    Value instDescriptor =
+        createInstDescriptor(rewriter, op, mmaSizeM, mmaSizeN, desc.transA,
+                             desc.transB, dot.mmaSizeK);
+    auto collectorB = getCollectorBModifer(reuseB);
     createGen5MMA(rewriter, loc, op, a, b, accAddress, pred, instDescriptor,
-                  useInitAcc, desc.aInTmem, twoCTAs);
+                  useInitAcc, desc.aInTmem, twoCTAs, collectorB);
   };
 
   return convertDotImpl(typeConverter, rewriter, loc, op.getA(), op.getB(),
@@ -609,7 +733,7 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
                         adaptor.getUseD(), adaptor.getPred(),
                         adaptor.getBarriers(), adaptor.getBarrierPreds(),
                         twoCTAs, tlx::tlxEnablePairedMMA(op), commitDescs,
-                        /*opKindIsMXFP4=*/false, dot);
+                        /*opKindIsMXFP4=*/false, targetFeatures, dot);
 }
 
 int64_t getFormatBitSize(ScaleDotElemType type) {
@@ -629,12 +753,13 @@ int64_t getFormatBitSize(ScaleDotElemType type) {
   }
 }
 
-int getScaleFactorColsPerSet(mxfpKind kind) {
+int getScaleFactorColsPerSet(mxfpKind kind, ttng::TCGen5MMAScaledOp op,
+                             int kSize) {
   switch (kind) {
   case mxfpKind::mxf8f6f4:
-    return 1;
+    return kSize == 32 ? 1 : 2;
   case mxfpKind::mxf4:
-    return 2;
+    return kSize == 64 ? 2 : 4;
   case mxfpKind::mxf4nvf4:
     return 4;
   default:
@@ -642,13 +767,32 @@ int getScaleFactorColsPerSet(mxfpKind kind) {
   }
 };
 
+bool isFp4Padded(MemDescType operand) {
+  auto encoding = operand.getEncoding();
+  if (auto shared = dyn_cast<NVMMASharedEncodingAttr>(encoding))
+    return shared.getFp4Padded();
+  if (auto sharedLinear = dyn_cast<SharedLinearEncodingAttr>(encoding)) {
+    auto kOffset = StringAttr::get(encoding.getContext(), "offset");
+    const auto &layout = sharedLinear.getLinearLayout();
+    // FP4 padding becomes a broadcast offset bit when materialized as a
+    // SharedLinearEncodingAttr.
+    return layout.removeZeroBasesAlongDim(kOffset).getInDimSize(kOffset) !=
+           layout.getInDimSize(kOffset);
+  }
+  assert(isa<ttng::TensorMemoryEncodingAttr>(encoding));
+  return false;
+}
+
 LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
                                ConversionPatternRewriter &rewriter,
                                Location loc, ttng::TCGen5MMAScaledOp op,
-                               ttng::TCGen5MMAScaledOpAdaptor &adaptor) {
+                               ttng::TCGen5MMAScaledOpAdaptor &adaptor,
+                               const ttng::TargetFeatures &targetFeatures,
+                               int ptxVersion) {
   MemDescType aTensorTy = op.getA().getType();
   MemDescType bTensorTy = op.getB().getType();
   MemDescType dTensorTy = op.getD().getType();
+  int blockK = op.getBlockK();
 
   mxfpKind mxfpInstKind = getMXFPKind(
       op.getAType(), op.getBType(), op.getAScale().getType().getElementType(),
@@ -658,17 +802,42 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
 
   DotConversion dot;
 
+  auto tensorMemAttr =
+      cast<ttng::TensorMemoryEncodingAttr>(dTensorTy.getEncoding());
+  unsigned mmaSizeM = tensorMemAttr.getBlockM();
+  unsigned mmaSizeN = tensorMemAttr.getBlockN();
+
+  // Use per-CTA shape to correctly handle 2-CTA mode. getBlockM/N() returns
+  // the full block shape (e.g., 256 for 2-CTA), but we need the per-CTA shape
+  // (e.g., 128) to compute the correct number of MMA repetitions.
   SmallVector<int64_t> dstPerCTA = triton::gpu::getShapePerCTA(dTensorTy);
   dot.shape.M = dstPerCTA[0];
   dot.shape.N = dstPerCTA[1];
-  dot.shape.K = op.getBlockK();
-  dot.mmaSizeK = !opKindIsMXFP4 ? 32 : 64;
+  dot.shape.K = blockK; // K is not split across CTAs
 
   dot.shapeA = triton::gpu::getAllocationShapePerCTA(aTensorTy);
   dot.shapeB = triton::gpu::getAllocationShapePerCTA(bTensorTy);
   if (opKindIsMXFP4) {
     dot.shapeA[1] *= 2;
     dot.shapeB[0] *= 2;
+  }
+
+  bool hasFp4PaddedOperand = isFp4Padded(aTensorTy) || isFp4Padded(bTensorTy);
+
+  if (!targetFeatures.supports4xFp4Tcgen05MMA() || hasFp4PaddedOperand ||
+      // M = 64 for 1CTA or 128 for 2CTA not supported for 2xfp8 / 4xfp4
+      mmaSizeM == 64 ||
+      // There are several cases where we need to disable 4xNVFP4 on Rubin:
+      // * MMA_N < 128 requires a special unpacked layout for scales B in TMEM
+      // (currently undocumented). tensorMemoryScalesToLinearLayout and lowering
+      // of tcgen05.cp need to be updated for this.
+      // * When BLOCK_M = 256, tensorMemoryScalesToLinearLayout returns an
+      // incorrect layout for scale A.
+      (mxfpInstKind == mxfpKind::mxf4nvf4 &&
+       (mmaSizeN < 128 || dot.shape.M == 256))) {
+    dot.mmaSizeK = opKindIsMXFP4 ? 64 : 32;
+  } else {
+    dot.mmaSizeK = opKindIsMXFP4 ? std::min(blockK, 128) : std::min(blockK, 64);
   }
 
   dot.numBitsPerElementA = getFormatBitSize(op.getAType());
@@ -695,9 +864,10 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
                           MemDescOperand accAddress, MemDescOperand a, Value b,
                           Value pred, Value useInitAcc,
                           const DotConversion::InstDesc &desc, int m, int n,
-                          int k) {
+                          int k, ReuseB reuseB) {
     auto [numRepM, numRepN, numRepK] = desc.repShape;
-    int scaleFactorColsPerSet = getScaleFactorColsPerSet(mxfpInstKind);
+    int scaleFactorColsPerSet =
+        getScaleFactorColsPerSet(mxfpInstKind, op, dot.mmaSizeK);
     int numColPerScaleBlockA = ceil<int>(
         ttng::getTmemAllocSizes(cast<MemDescType>(op.getAScale().getType()))
             .numCols,
@@ -713,20 +883,32 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
         baseScaleA, tb.i32_val((m + wordIdx * numRepM) * numColPerScaleBlockA));
     Value scaleB = tb.add(
         baseScaleB, tb.i32_val((n + wordIdx * numRepN) * numColPerScaleBlockB));
-    Value instDescriptor = createScaleInstDescriptor(
-        rewriter, op, op.getTwoCtas() ? desc.mmaSizeM * 2 : desc.mmaSizeM,
-        desc.mmaSizeN, desc.transA, desc.transB, subWordIdx, subWordIdx,
-        mxfpInstKind);
+    Value instDescriptor;
+    // For 2CTA mode, the M dimension in the instruction descriptor must be
+    // doubled to match the hardware's expectation for cta_group::2 operations.
+    int mmaM = twoCTAs ? desc.mmaSizeM * 2 : desc.mmaSizeM;
+    if (mxfpInstKind == mxfpKind::mxf8f6f4) {
+      instDescriptor = createScaleInstDescriptorFp8(
+          rewriter, op, mmaM, desc.mmaSizeN, desc.transA, desc.transB,
+          subWordIdx, subWordIdx, dot.mmaSizeK);
+    } else {
+      instDescriptor = createScaleInstDescriptorFp4(
+          rewriter, op, mmaM, desc.mmaSizeN, desc.transA, desc.transB,
+          subWordIdx, subWordIdx, mxfpInstKind, blockK, dot.mmaSizeK);
+    }
+
+    auto collectorB = getCollectorBModifer(reuseB);
     createScaledGen5MMA(rewriter, loc, op, a, b, accAddress, scaleA, scaleB,
                         pred, instDescriptor, useInitAcc, desc.aInTmem,
-                        mxfpInstKind, twoCTAs);
+                        mxfpInstKind, twoCTAs, collectorB, ptxVersion);
   };
 
   return convertDotImpl(
       typeConverter, rewriter, loc, op.getA(), op.getB(), adaptor.getA(),
       adaptor.getB(), dTensorTy, adaptor.getUseD(), adaptor.getPred(),
       adaptor.getBarriers(), adaptor.getBarrierPreds(), twoCTAs,
-      tlx::tlxEnablePairedMMA(op), ValueRange{}, opKindIsMXFP4, dot);
+      tlx::tlxEnablePairedMMA(op), ValueRange{}, opKindIsMXFP4,
+      targetFeatures, dot);
 }
 
 //===----------------------------------------------------------------------===//
@@ -737,30 +919,48 @@ struct TCGen5MMAOpConversion
     : public ConvertOpToLLVMPattern<ttng::TCGen5MMAOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
+  TCGen5MMAOpConversion(LLVMTypeConverter &converter, PatternBenefit benefit,
+                        const ttng::TargetFeatures &targetFeatures)
+      : ConvertOpToLLVMPattern<ttng::TCGen5MMAOp>(converter, benefit),
+        targetFeatures(targetFeatures) {}
+
   LogicalResult
   matchAndRewrite(ttng::TCGen5MMAOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (failed(convertDot(*getTypeConverter(), rewriter, op.getLoc(), op,
-                          adaptor)))
+                          adaptor, targetFeatures)))
       return failure();
     rewriter.eraseOp(op);
     return success();
   }
+
+  ttng::TargetFeatures targetFeatures;
 };
 
 struct TCGen5MMAScaledOpConversion
     : public ConvertOpToLLVMPattern<ttng::TCGen5MMAScaledOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
+  TCGen5MMAScaledOpConversion(LLVMTypeConverter &converter,
+                              PatternBenefit benefit,
+                              const ttng::TargetFeatures &targetFeatures,
+                              int ptxVersion)
+      : ConvertOpToLLVMPattern<ttng::TCGen5MMAScaledOp>(converter, benefit),
+        targetFeatures(targetFeatures), ptxVersion(ptxVersion) {}
+
   LogicalResult
   matchAndRewrite(ttng::TCGen5MMAScaledOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (failed(convertScaledDot(*getTypeConverter(), rewriter, op.getLoc(), op,
-                                adaptor)))
+                                adaptor, targetFeatures, ptxVersion)))
       return failure();
     rewriter.eraseOp(op);
     return success();
   }
+
+private:
+  ttng::TargetFeatures targetFeatures;
+  int ptxVersion;
 };
 
 struct TCGen5CommitOpConversion
@@ -801,9 +1001,14 @@ namespace NVIDIA {
 
 void populateTCGen5MMAOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                       RewritePatternSet &patterns,
-                                      PatternBenefit benefit) {
-  patterns.add<TCGen5MMAOpConversion, TCGen5MMAScaledOpConversion,
-               TCGen5CommitOpConversion>(typeConverter, benefit);
+                                      PatternBenefit benefit,
+                                      const TargetInfo &targetInfo) {
+  patterns.add<TCGen5MMAOpConversion>(typeConverter, benefit,
+                                      targetInfo.getTargetFeatures());
+  patterns.add<TCGen5MMAScaledOpConversion>(
+      typeConverter, benefit, targetInfo.getTargetFeatures(),
+      targetInfo.getPtxVersion());
+  patterns.add<TCGen5CommitOpConversion>(typeConverter, benefit);
 }
 
 } // namespace NVIDIA

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -48,6 +48,7 @@ MemDescOperand mlir::triton::NVIDIA::DotOpMmaV5TmemLoader::tmemLoad(
 namespace {
 
 enum class mxfpKind { mxf8f6f4 = 0, mxf4 = 1, mxf4nvf4 = 2 };
+enum class scaleKind : uint32_t { ue4m3 = 0, e8m0 = 1, ue5m3 = 2 };
 
 static bool isTransposed(Value operand) {
   auto tensorTy = cast<MemDescType>(operand.getType());
@@ -67,11 +68,36 @@ static bool isTransposed(Value operand) {
   return false;
 }
 
+static int getScaleFactor(Type scaleType, int blockK) {
+  auto shapedType = cast<ShapedType>(scaleType);
+  int64_t scaleCols = shapedType.getShape().back();
+  assert(blockK % scaleCols == 0);
+  return blockK / scaleCols;
+}
+
+static int getScaleVecSize(ttng::TCGen5MMAScaledOp op) {
+  return getScaleFactor(op.getAScale().getType(), op.getBlockK());
+}
+
+static bool isBlock16Scale(Type scaleType, int blockK) {
+  auto shapedType = dyn_cast<ShapedType>(scaleType);
+  if (!shapedType || !shapedType.hasRank())
+    return false;
+  return shapedType.getShape().back() * 16 == blockK;
+}
+
 inline mxfpKind getMXFPKind(ScaleDotElemType typeA, ScaleDotElemType typeB,
-                            Type scaleAType, Type scaleBType, bool transpose) {
+                            Type scaleAType, Type scaleBType, int blockK,
+                            bool transpose) {
   if (typeA == ScaleDotElemType::E2M1 && typeB == ScaleDotElemType::E2M1) {
-    if (llvm::isa<Float8E4M3FNType>(scaleAType) &&
-        llvm::isa<Float8E4M3FNType>(scaleBType)) {
+    auto scaleAElemType = cast<ShapedType>(scaleAType).getElementType();
+    auto scaleBElemType = cast<ShapedType>(scaleBType).getElementType();
+    bool isUE4M3 = llvm::isa<Float8E4M3FNType>(scaleAElemType) &&
+                   llvm::isa<Float8E4M3FNType>(scaleBElemType);
+    bool isUE5M3 = scaleAElemType.isInteger(8) && scaleBElemType.isInteger(8) &&
+                   isBlock16Scale(scaleAType, blockK) &&
+                   isBlock16Scale(scaleBType, blockK);
+    if (isUE4M3 || isUE5M3) {
       assert(!transpose &&
              "MMAv5 with kind=mxf4nvf4 does not support transpose");
       return mxfpKind::mxf4nvf4;
@@ -81,6 +107,16 @@ inline mxfpKind getMXFPKind(ScaleDotElemType typeA, ScaleDotElemType typeB,
   }
   return mxfpKind::mxf8f6f4;
 };
+
+static scaleKind getScaleKind(ttng::TCGen5MMAScaledOp op, int blockK) {
+  Type scaleType = op.getAScale().getType();
+  Type elemType = cast<ShapedType>(scaleType).getElementType();
+  if (llvm::isa<Float8E4M3FNType>(elemType))
+    return scaleKind::ue4m3;
+  if (elemType.isInteger(8) && isBlock16Scale(scaleType, blockK))
+    return scaleKind::ue5m3;
+  return scaleKind::e8m0;
+}
 
 static Value createInstDescriptor(ConversionPatternRewriter &rewriter,
                                   ttng::TCGen5MMAOp op, int M, int N,
@@ -258,10 +294,7 @@ static Value createScaleInstDescriptorFp4(
   desc.bType = 1;
   desc.AScaleFactor = scaleFactorsubIdxA;
   desc.BScaleFactor = scaleFactorsubIdxB;
-  desc.scaleType =
-      llvm::isa<Float8E4M3FNType>(op.getAScale().getType().getElementType())
-          ? 0
-          : 1;
+  desc.scaleType = static_cast<uint32_t>(getScaleKind(op, blockK));
 
   assert(kSize == 64 || kSize == 128);
   if (kSize == 128) {
@@ -274,7 +307,9 @@ static Value createScaleInstDescriptorFp4(
   assert(desc.transposeB == 0 &&
          "MMAv5 with kind=mxf4 does not support transpose");
 
-  if (mxfpInstKind == mxfpKind::mxf4) {
+  int scaleVecSize = getScaleVecSize(op);
+  if (mxfpInstKind == mxfpKind::mxf4 || (mxfpInstKind == mxfpKind::mxf4nvf4 &&
+                                         scaleVecSize == 32 && kSize == 64)) {
     desc.AScaleFactor *= 2;
     desc.BScaleFactor *= 2;
     assert(desc.AScaleFactor == 0 || desc.AScaleFactor == 2 &&
@@ -353,8 +388,14 @@ static void createScaledGen5MMA(ConversionPatternRewriter &rewriter,
     opcode += useBlockScaleSyntax ? "mxf4.block_scale.block32"
                                   : "mxf4.block_scale.scale_vec::2X";
   } else if (mxfpInstKind == mxfpKind::mxf4nvf4) {
-    opcode += useBlockScaleSyntax ? "mxf4nvf4.block_scale.block16"
-                                  : "mxf4nvf4.block_scale.scale_vec::4X";
+    int scaleVecSize = getScaleVecSize(op);
+    if (useBlockScaleSyntax) {
+      opcode += scaleVecSize == 32 ? "mxf4nvf4.block_scale.block32"
+                                   : "mxf4nvf4.block_scale.block16";
+    } else {
+      opcode += scaleVecSize == 32 ? "mxf4nvf4.block_scale.scale_vec::2X"
+                                   : "mxf4nvf4.block_scale.scale_vec::4X";
+    }
   } else {
     assert(0 && "Unsupported mxfp kind.");
   }
@@ -761,7 +802,7 @@ int getScaleFactorColsPerSet(mxfpKind kind, ttng::TCGen5MMAScaledOp op,
   case mxfpKind::mxf4:
     return kSize == 64 ? 2 : 4;
   case mxfpKind::mxf4nvf4:
-    return 4;
+    return getScaleVecSize(op) == 32 && kSize == 64 ? 2 : 4;
   default:
     llvm_unreachable("Unsupported mxfp kind.");
   }
@@ -783,6 +824,16 @@ bool isFp4Padded(MemDescType operand) {
   return false;
 }
 
+int linearizeScaleBlockIdx(Value scale, int mnIdx, int wordIdx, int numRepMn,
+                           int numRepKWords) {
+  auto enc = cast<ttng::TensorMemoryScalesEncodingAttr>(
+      cast<MemDescType>(scale.getType()).getEncoding());
+  return enc.getBlockRepOrder() ==
+                 ttng::TensorMemoryScalesBlockRepOrder::K_THEN_MN
+             ? (wordIdx + mnIdx * numRepKWords)
+             : (mnIdx + wordIdx * numRepMn);
+}
+
 LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
                                ConversionPatternRewriter &rewriter,
                                Location loc, ttng::TCGen5MMAScaledOp op,
@@ -794,10 +845,10 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
   MemDescType dTensorTy = op.getD().getType();
   int blockK = op.getBlockK();
 
-  mxfpKind mxfpInstKind = getMXFPKind(
-      op.getAType(), op.getBType(), op.getAScale().getType().getElementType(),
-      op.getBScale().getType().getElementType(),
-      isTransposed(op.getA()) || !isTransposed(op.getB()));
+  mxfpKind mxfpInstKind =
+      getMXFPKind(op.getAType(), op.getBType(), op.getAScale().getType(),
+                  op.getBScale().getType(), blockK,
+                  isTransposed(op.getA()) || !isTransposed(op.getB()));
   bool opKindIsMXFP4 = mxfpInstKind != mxfpKind::mxf8f6f4;
 
   DotConversion dot;
@@ -827,14 +878,11 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
   if (!targetFeatures.supports4xFp4Tcgen05MMA() || hasFp4PaddedOperand ||
       // M = 64 for 1CTA or 128 for 2CTA not supported for 2xfp8 / 4xfp4
       mmaSizeM == 64 ||
-      // There are several cases where we need to disable 4xNVFP4 on Rubin:
-      // * MMA_N < 128 requires a special unpacked layout for scales B in TMEM
+      // We need to disable MMA_K = 128 for NVFP4 on Rubin when MMA_N < 128,
+      // which requires a special unpacked layout for scales B in TMEM
       // (currently undocumented). tensorMemoryScalesToLinearLayout and lowering
       // of tcgen05.cp need to be updated for this.
-      // * When BLOCK_M = 256, tensorMemoryScalesToLinearLayout returns an
-      // incorrect layout for scale A.
-      (mxfpInstKind == mxfpKind::mxf4nvf4 &&
-       (mmaSizeN < 128 || dot.shape.M == 256))) {
+      (mxfpInstKind == mxfpKind::mxf4nvf4 && mmaSizeN < 128)) {
     dot.mmaSizeK = opKindIsMXFP4 ? 64 : 32;
   } else {
     dot.mmaSizeK = opKindIsMXFP4 ? std::min(blockK, 128) : std::min(blockK, 64);
@@ -868,21 +916,26 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
     auto [numRepM, numRepN, numRepK] = desc.repShape;
     int scaleFactorColsPerSet =
         getScaleFactorColsPerSet(mxfpInstKind, op, dot.mmaSizeK);
+    int numRepKWords = ceil<int>(numRepK, 4 / scaleFactorColsPerSet);
     int numColPerScaleBlockA = ceil<int>(
         ttng::getTmemAllocSizes(cast<MemDescType>(op.getAScale().getType()))
             .numCols,
-        numRepM * (ceil<int>(numRepK, 4 / scaleFactorColsPerSet)));
+        numRepM * numRepKWords);
     int numColPerScaleBlockB = ceil<int>(
         ttng::getTmemAllocSizes(cast<MemDescType>(op.getBScale().getType()))
             .numCols,
-        numRepN * (ceil<int>(numRepK, 4 / scaleFactorColsPerSet)));
+        numRepN * numRepKWords);
     numColPerScaleBlockB = std::max(numColPerScaleBlockB, 2);
     int subWordIdx = k % (4 / scaleFactorColsPerSet);
     int wordIdx = k / (4 / scaleFactorColsPerSet);
-    Value scaleA = tb.add(
-        baseScaleA, tb.i32_val((m + wordIdx * numRepM) * numColPerScaleBlockA));
-    Value scaleB = tb.add(
-        baseScaleB, tb.i32_val((n + wordIdx * numRepN) * numColPerScaleBlockB));
+    int scaleIdxA = linearizeScaleBlockIdx(op.getAScale(), m, wordIdx, numRepM,
+                                           numRepKWords);
+    int scaleIdxB = linearizeScaleBlockIdx(op.getBScale(), n, wordIdx, numRepN,
+                                           numRepKWords);
+    Value scaleA =
+        tb.add(baseScaleA, tb.i32_val(scaleIdxA * numColPerScaleBlockA));
+    Value scaleB =
+        tb.add(baseScaleB, tb.i32_val(scaleIdxB * numColPerScaleBlockB));
     Value instDescriptor;
     // For 2CTA mode, the M dimension in the instruction descriptor must be
     // doubled to match the hardware's expectation for cta_group::2 operations.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -70,7 +70,8 @@ void populateClampFOpToLLVMPattern(LLVMTypeConverter &typeConverter,
 
 void populateTCGen5MMAOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                       RewritePatternSet &patterns,
-                                      PatternBenefit benefit);
+                                      PatternBenefit benefit,
+                                      const TargetInfo &targetInfo);
 
 void populateTensorMemoryOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                          RewritePatternSet &patterns,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -8,6 +8,8 @@ namespace mlir::triton::NVIDIA {
 
 class TargetInfo : public mlir::triton::TargetInfoBase {
 public:
+  explicit TargetInfo(int computeCapability)
+      : TargetInfo(computeCapability, /*ptxVersion=*/0) {}
   TargetInfo(int computeCapability, int ptxVersion)
       : targetFeatures(computeCapability), ptxVersion(ptxVersion) {}
 
@@ -94,6 +96,9 @@ public:
   int getPtxVersion() const { return ptxVersion; }
   int getComputeCapability() const {
     return targetFeatures.getComputeCapability();
+  }
+  const triton::nvidia_gpu::TargetFeatures &getTargetFeatures() const {
+    return targetFeatures;
   }
 
   bool isCuda() const override { return true; }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -183,8 +183,8 @@ struct ConvertTritonGPUToLLVM
         typeConverter, patterns, benefit);
     mlir::triton::populateMakeRangeOpToLLVMPattern(typeConverter, targetInfo,
                                                    patterns, benefit);
-    mlir::triton::NVIDIA::populateTCGen5MMAOpToLLVMPattern(typeConverter,
-                                                           patterns, benefit);
+    mlir::triton::NVIDIA::populateTCGen5MMAOpToLLVMPattern(
+        typeConverter, patterns, benefit, targetInfo);
     mlir::triton::NVIDIA::populateFp4ToFpToLLVMPatterns(typeConverter, patterns,
                                                         benefit);
     mlir::triton::populateInstrumentationToLLVMPatterns(typeConverter, patterns,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -419,8 +419,14 @@ private:
     }
 
     bool hasRemoteBar = false;
-    // Find if we have a remote bar
+    bool hasMulticastArrive = false;
+    // Find if we have a remote bar or multicast arrive.
     mod.walk([&](Operation *op) {
+      if (auto arrive = dyn_cast<ttng::ArriveBarrierOp>(op);
+          arrive && arrive.isMulticast()) {
+        hasMulticastArrive = true;
+        return WalkResult::interrupt();
+      }
       SetVector<Operation *> ops;
       auto remoteBar = getRemoteBarrier(op);
       if (remoteBar.has_value()) {
@@ -429,10 +435,10 @@ private:
       }
       return WalkResult::advance();
     });
-
-    // If we have remote mbar/SMEM access, or if we have 2cta TMEM allocation,
-    // we need a cluster sync after mbar init and before TMEM alloc
-    bool shouldInsert = hasRemoteBar || tlx::tlxEnablePairedMMA(mod);
+    // If we have remote mbar/SMEM access, a multicast arrive, or 2cta TMEM
+    // allocation, we need a cluster sync after mbar init and before use.
+    bool shouldInsert = hasRemoteBar || hasMulticastArrive ||
+                        tlx::tlxEnablePairedMMA(mod);
     if (!shouldInsert) {
       return success();
     }

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -3368,6 +3368,32 @@ TEST_F(LinearLayoutConversionsTest, TensorMemory_CTASplit) {
                 LinearLayout::identity1D(2, kBlock, d1));
 }
 
+TEST_F(LinearLayoutConversionsTest, TensorMemoryScales_BlockRepOrder) {
+  auto d0 = S("dim0");
+  auto d1 = S("dim1");
+  auto kBlock = S("block");
+  auto kRow = S("row");
+  auto kCol = S("col");
+  auto cgaLayout = CGAEncodingAttr::get1CTALayout(&ctx, /*rank=*/2);
+  auto encKThenMn = TensorMemoryScalesEncodingAttr::get(
+      &ctx, cgaLayout, nvidia_gpu::TensorMemoryScalesBlockRepOrder::K_THEN_MN);
+  auto encMnThenK = TensorMemoryScalesEncodingAttr::get(
+      &ctx, cgaLayout, nvidia_gpu::TensorMemoryScalesBlockRepOrder::MN_THEN_K);
+
+  LinearLayout expectedKThenMn = LinearLayout::identity1D(32, kRow, d0) *
+                                 LinearLayout::zeros1D(4, kRow, d0) *
+                                 LinearLayout::identity1D(4, kCol, d1) *
+                                 LinearLayout::identity1D(2, kCol, d0) *
+                                 LinearLayout::identity1D(2, kCol, d0) *
+                                 LinearLayout::identity1D(2, kCol, d1) *
+                                 LinearLayout::identity1D(2, kCol, d0) *
+                                 LinearLayout::identity1D(1, kBlock, d0);
+  EXPECT_EQ(toLinearLayout({256, 8}, encKThenMn), expectedKThenMn);
+
+  EXPECT_NE(toLinearLayout({256, 8}, encKThenMn),
+            toLinearLayout({256, 8}, encMnThenK));
+}
+
 // Tests for SM120 DotScaled Scale Layout
 TEST_F(LinearLayoutConversionsTest, SM120DotScaledScaleLayout) {
   LinearLayout layout, ll;


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/10941

Upstream commit message:
```
> [Rubin] Misc MMA enhancement and `mbarrier.arrive.multicast` support (#10941)

> Following up the initial Rubin PR
> https://github.com/triton-lang/triton/pull/10936 to add more Rubin
> features.

> * A new scale layout for 4xNVFP4 with `BLOCK_M = 256`, see
> https://docs.nvidia.com/cuda/developer-preview/13.4/parallel-thread-execution/index.html#tcgen05-mma-scale-factor-a-layout-block16-k128-256
> * NVFP4 with VEC_SIZE = 32 e4m3 scale
> * Preliminary e5m3 scale support. The current convention is that a scale
> tensor with i8 dtype and VEC_SIZE = 16 is identified as e5m3 scale. The
> support will be revised after MLIR and PyTorch add support for the new
> scale type.
> * Add multicast semantics to `mbarrier.arrive`, a more efficient
> alternative to signal an arrival to a set of CTAs sequentially.
```

***Do not remove the following line from this commit***
Reactor Backport Revision: 694c0c3bd4da68600ed7028f1be65f72df05a56a
 ---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 10941
```

Reviewed By: dshi7

Differential Revision: D112829304
