### PR TITLE
[TLX] Add async-task mbarrier suspend hints on Blackwell (#2256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,7 @@ Examples: how mbarriers are communicated in warp specialization
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `exclusive`              | Assert this is the only one `tlx.async_tasks` in the kernel for more efficient PTX. Default to False.                                                                                            |
 | `no_ending_cluster_sync` | This suppresses compiler generated cluster sync at end of Warp Spec. Should only be used if user guarantees all cross CTA SMEM/TMEM access are done by end of WS default task. Default to False. |
+| `mbarrier_try_wait_suspend_ns` | On Blackwell, use the four-operand `mbarrier.try_wait.parity` form with this suspend hint for waits in the kernel. `None` is unspecified, `0` explicitly disables the hint, and positive values enable it. If multiple `async_tasks` regions specify a value, the minimum explicit value is used module-wide. Default to None. |
 
 #### async_task Parameters
 

--- a/test/Conversion/tritonnvidiagpu_to_llvm_barrier_suspend.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm_barrier_suspend.mlir
@@ -1,0 +1,19 @@
+// RUN: triton-opt %s --convert-triton-gpu-to-llvm=compute-capability=100 -reconcile-unrealized-casts | FileCheck %s
+
+#shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @wait_barrier(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>, %phase: i32, %pred: i1) {
+    // CHECK: mbarrier.try_wait.parity.shared::cta.b64 complete, [$0], $1;
+    // CHECK-NOT: nanosleep.u32
+    // CHECK: @!complete bra.uni waitLoop
+    // CHECK: %{{[0-9]+}}, %arg1 :
+    ttng.wait_barrier %alloc, %phase : !ttg.memdesc<1xi64, #shared0, #smem>
+
+    // CHECK: @!$2 bra.uni skipWait
+    // CHECK: mbarrier.try_wait.parity.shared::cta.b64 complete, [$0], $1;
+    // CHECK: %{{[0-9]+}}, %arg1, %arg2 :
+    ttng.wait_barrier %alloc, %phase, %pred : !ttg.memdesc<1xi64, #shared0, #smem>
+    tt.return
+  }
+}

--- a/test/Conversion/tritonnvidiagpu_to_llvm_barrier_suspend_attr.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm_barrier_suspend_attr.mlir
@@ -1,0 +1,19 @@
+// RUN: triton-opt %s --convert-triton-gpu-to-llvm=compute-capability=100 -reconcile-unrealized-casts | FileCheck %s --check-prefix=SUSPEND
+
+#shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"tlx.mbarrier_try_wait_suspend_ns" = 50000 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @wait_barrier(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>, %phase: i32, %pred: i1) {
+    // SUSPEND: mbarrier.try_wait.parity.shared::cta.b64 complete, [$0], $1, $2;
+    // SUSPEND-NOT: nanosleep.u32
+    // SUSPEND: %{{[0-9]+}}, %arg1, %{{[0-9]+}} :
+    ttng.wait_barrier %alloc, %phase : !ttg.memdesc<1xi64, #shared0, #smem>
+
+    // SUSPEND: @!$3 bra.uni skipWait
+    // SUSPEND: mbarrier.try_wait.parity.shared::cta.b64 complete, [$0], $1, $2;
+    // SUSPEND-NOT: nanosleep.u32
+    // SUSPEND: %{{[0-9]+}}, %arg1, %{{[0-9]+}}, %arg2 :
+    ttng.wait_barrier %alloc, %phase, %pred : !ttg.memdesc<1xi64, #shared0, #smem>
+    tt.return
+  }
+}

--- a/test/TLX/attach-mbarrier-suspend-metadata.mlir
+++ b/test/TLX/attach-mbarrier-suspend-metadata.mlir
@@ -1,0 +1,47 @@
+// RUN: triton-opt %s -split-input-file --triton-tlx-fixup="target=cuda:100" | FileCheck %s
+
+// CHECK: module attributes {
+// CHECK-SAME: tlx.mbarrier_try_wait_suspend_ns = 30000 : i32
+module {
+  tt.func @minimum_explicit_value() {
+    ttg.warp_specialize() attributes {tlx.mbarrier_try_wait_suspend_ns = 50000 : i32}
+    default { ttg.warp_yield }
+    partition0() num_warps(1) { ttg.warp_return } : () -> ()
+    ttg.warp_specialize() attributes {tlx.mbarrier_try_wait_suspend_ns = 30000 : i32}
+    default { ttg.warp_yield }
+    partition0() num_warps(1) { ttg.warp_return } : () -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: module attributes {
+// CHECK-SAME: tlx.mbarrier_try_wait_suspend_ns = 50000 : i32
+module {
+  tt.func @unspecified_does_not_participate() {
+    ttg.warp_specialize() attributes {tlx.mbarrier_try_wait_suspend_ns = 50000 : i32}
+    default { ttg.warp_yield }
+    partition0() num_warps(1) { ttg.warp_return } : () -> ()
+    ttg.warp_specialize()
+    default { ttg.warp_yield }
+    partition0() num_warps(1) { ttg.warp_return } : () -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK: module attributes {
+// CHECK-SAME: tlx.mbarrier_try_wait_suspend_ns = 0 : i32
+module {
+  tt.func @explicit_zero_wins() {
+    ttg.warp_specialize() attributes {tlx.mbarrier_try_wait_suspend_ns = 50000 : i32}
+    default { ttg.warp_yield }
+    partition0() num_warps(1) { ttg.warp_return } : () -> ()
+    ttg.warp_specialize() attributes {tlx.mbarrier_try_wait_suspend_ns = 0 : i32}
+    default { ttg.warp_yield }
+    partition0() num_warps(1) { ttg.warp_return } : () -> ()
+    tt.return
+  }
+}

--- a/test/TLX/attach-metadata.mlir
+++ b/test/TLX/attach-metadata.mlir
@@ -93,6 +93,25 @@ module {
   }
 }
 
+// -----
+
+// A suspend hint on tlx.async_tasks is propagated from warp_specialize to the
+// module so waits introduced by later warp-specialization passes also see it.
+// CHECK: module attributes {
+// CHECK-SAME: tlx.mbarrier_try_wait_suspend_ns = 50000 : i32
+module {
+  tt.func @kernel_mbarrier_try_wait_suspend() {
+    ttg.warp_specialize() attributes {tlx.mbarrier_try_wait_suspend_ns = 50000 : i32}
+    default {
+      ttg.warp_yield
+    }
+    partition0() num_warps(1) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+
 
 // -----
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -31,6 +31,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Tools/Sys/GetEnv.h"
 
 #include "Utility.h"
 
@@ -289,6 +290,14 @@ struct WaitBarrierOpConversion
       pred = b.and_(pred, *leaderPred);
 
     bool predicated = pred && !matchPattern(pred, m_NonZero());
+    int suspendNs = 0;
+    if (targetInfo->getComputeCapability() >= 100) {
+      auto mod = op->getParentOfType<ModuleOp>();
+      if (auto attr = mod->getAttrOfType<IntegerAttr>(
+              "tlx.mbarrier_try_wait_suspend_ns"))
+        suspendNs = attr.getInt();
+    }
+    bool useSuspendHint = suspendNs > 0;
     std::string ptx;
     if (targetInfo->getComputeCapability() < 90) {
       if (!predicated) {
@@ -315,23 +324,30 @@ struct WaitBarrierOpConversion
 )";
       }
     } else {
+      // SM90+ polls with try_wait in a spin loop. Blackwell can opt into the
+      // four-operand form, whose suspend hint lowers to NANOSLEEP.SYNCS.
+      std::string tryWait = useSuspendHint
+                                ? "\tmbarrier.try_wait.parity.shared::cta.b64 "
+                                  "complete, [$0], $1, $2;\n"
+                                : "\tmbarrier.try_wait.parity.shared::cta.b64 "
+                                  "complete, [$0], $1;\n";
       if (!predicated) {
-        ptx = R"(
+        ptx = std::string(R"(
 {
 	.reg .pred complete;
 	waitLoop:
-	mbarrier.try_wait.parity.shared::cta.b64 complete, [$0], $1;
-	@!complete bra.uni waitLoop;
+)") + tryWait +
+              R"(	@!complete bra.uni waitLoop;
 }
 )";
       } else {
-        ptx = R"(
-{
-	@!$2 bra.uni skipWait;
+        std::string predOperand = useSuspendHint ? "$3" : "$2";
+        ptx = std::string("\n{\n\t@!") + predOperand +
+              R"( bra.uni skipWait;
 	.reg .pred complete;
 	waitLoop:
-	mbarrier.try_wait.parity.shared::cta.b64 complete, [$0], $1;
-	@!complete bra.uni waitLoop;
+)" + tryWait +
+              R"(	@!complete bra.uni waitLoop;
 	skipWait:
 }
 )";
@@ -339,9 +355,11 @@ struct WaitBarrierOpConversion
     }
     ::mlir::triton::PTXBuilder ptxBuilder;
     auto &waitLoop = *ptxBuilder.create(ptx);
-    SmallVector<::mlir::triton::PTXBuilder::Operand *, 3> operands = {
+    SmallVector<::mlir::triton::PTXBuilder::Operand *, 4> operands = {
         ptxBuilder.newOperand(smemObj.getBase(), "r"),
         ptxBuilder.newOperand(adaptor.getPhase(), "r")};
+    if (useSuspendHint)
+      operands.push_back(ptxBuilder.newOperand(b.i32_val(suspendNs), "r"));
     if (predicated)
       operands.push_back(ptxBuilder.newOperand(pred, "b"));
 

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -604,13 +604,24 @@ public:
       int numWarpSpecializeOps = 0;
       bool hasExclusiveWS = false;
       bool hasNoEndingClusterSync = false;
+      std::optional<int32_t> mbarrierTryWaitSuspendNs;
       mod.walk([&](ttg::WarpSpecializeOp op) {
         ++numWarpSpecializeOps;
         if (op->hasAttr("tlx.exclusive"))
           hasExclusiveWS = true;
         if (op->hasAttr("tlx.no_ending_cluster_sync"))
           hasNoEndingClusterSync = true;
+        if (auto attr = op->getAttrOfType<IntegerAttr>(
+                "tlx.mbarrier_try_wait_suspend_ns")) {
+          int32_t value = attr.getInt();
+          if (!mbarrierTryWaitSuspendNs ||
+              value < *mbarrierTryWaitSuspendNs)
+            mbarrierTryWaitSuspendNs = value;
+        }
       });
+      if (mbarrierTryWaitSuspendNs)
+        mod->setAttr("tlx.mbarrier_try_wait_suspend_ns",
+                     b.getI32IntegerAttr(*mbarrierTryWaitSuspendNs));
       if (hasExclusiveWS) {
         if (numWarpSpecializeOps != 1) {
           mod.emitError()

--- a/third_party/tlx/doc/tlx_barriers.md
+++ b/third_party/tlx/doc/tlx_barriers.md
@@ -261,6 +261,17 @@ while !done:
 - ***tlx.barrier_wait(bar, phase)***
   Wait until the *bar*’s phase has moved ahead of the *phase* argument.
 
+  On Blackwell (compute capability 100 or newer), waits inside
+  `tlx.async_tasks(mbarrier_try_wait_suspend_ns=N)` use the four-operand
+  `mbarrier.try_wait.parity` form. The suspend hint lets ptxas emit
+  `NANOSLEEP.SYNCS`, allowing a waiting warp to yield instead of busy-spinning.
+
+  `None` leaves the policy unspecified and does not participate when a kernel
+  contains multiple `async_tasks` regions. An explicit `0` disables the fused
+  suspend hint. Positive values are combined module-wide by selecting the
+  minimum explicit value. If no region specifies a value, waits use the default
+  busy-spin lowering.
+
 - ***tlx.barrier_arrive(bar, arrive_count=1)***
   Performs an arrive operation on *bar*, by decrementing *arrive_count*
   from the *bar*’s arrival count. The phase of *bar* is flipped if

--- a/third_party/tlx/language/tlx/async_task_utils.py
+++ b/third_party/tlx/language/tlx/async_task_utils.py
@@ -49,9 +49,20 @@ class async_task:
 
 class async_tasks:
 
-    def __init__(self, *args, exclusive=False, no_ending_cluster_sync=False, **kwargs):
+    def __init__(
+        self,
+        *args,
+        exclusive=False,
+        no_ending_cluster_sync=False,
+        mbarrier_try_wait_suspend_ns=None,
+        **kwargs,
+    ):
         self.exclusive = core._unwrap_if_constexpr(exclusive)
         self.no_ending_cluster_sync = core._unwrap_if_constexpr(no_ending_cluster_sync)
+        self.mbarrier_try_wait_suspend_ns = core._unwrap_if_constexpr(mbarrier_try_wait_suspend_ns)
+        if self.mbarrier_try_wait_suspend_ns is not None:
+            if not isinstance(self.mbarrier_try_wait_suspend_ns, int) or self.mbarrier_try_wait_suspend_ns < 0:
+                raise ValueError("mbarrier_try_wait_suspend_ns must be a non-negative integer")
 
     def __enter__(self):
         return self

--- a/third_party/tlx/language/tlx/compiler/code_generator.py
+++ b/third_party/tlx/language/tlx/compiler/code_generator.py
@@ -162,18 +162,21 @@ def visit_withAsyncTasks(self, node):
     from triton.compiler.code_generator import enter_sub_region, _is_list_like, _is_constexpr
     from triton.language.core import _unwrap_if_constexpr
 
-    # `tlx.async_tasks(exclusive=..., no_ending_cluster_sync=...)`: mark the
-    # warp_specialize op so the Fixup pass can propagate these to module
-    # attributes (`exclusive` -> single-warp-specialize lowering;
-    # `no_ending_cluster_sync` -> user provides the post-WS sync).
+    # Mark the warp_specialize op so the Fixup pass can propagate async-task
+    # policy to module attributes consumed by later lowering passes.
     ws_context = node.items[0].context_expr
     exclusive = False
     no_ending_cluster_sync = False
+    mbarrier_try_wait_suspend_ns = None
     for kw in getattr(ws_context, "keywords", []):
         if kw.arg == "exclusive":
             exclusive = bool(_unwrap_if_constexpr(self.visit(kw.value)))
         elif kw.arg == "no_ending_cluster_sync":
             no_ending_cluster_sync = bool(_unwrap_if_constexpr(self.visit(kw.value)))
+        elif kw.arg == "mbarrier_try_wait_suspend_ns":
+            mbarrier_try_wait_suspend_ns = _unwrap_if_constexpr(self.visit(kw.value))
+            if not isinstance(mbarrier_try_wait_suspend_ns, int) or mbarrier_try_wait_suspend_ns < 0:
+                raise ValueError("mbarrier_try_wait_suspend_ns must be a non-negative integer")
 
     with enter_sub_region(self) as sr:
         liveins, _ = sr
@@ -289,6 +292,11 @@ def visit_withAsyncTasks(self, node):
             ws_op.set_attr("tlx.exclusive", self.builder.get_unit_attr())
         if no_ending_cluster_sync:
             ws_op.set_attr("tlx.no_ending_cluster_sync", self.builder.get_unit_attr())
+        if mbarrier_try_wait_suspend_ns is not None:
+            ws_op.set_attr(
+                "tlx.mbarrier_try_wait_suspend_ns",
+                self.builder.get_int32_attr(mbarrier_try_wait_suspend_ns),
+            )
 
         # dry visit async task body to calculate captures
         index = 0

--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -1228,7 +1228,11 @@ def matmul_kernel_tma_ws_blackwell(
     # Each of the three async tasks consumes CLC responses on both cluster CTAs.
     clc_context = tlx.clc_create_context(num_consumers=3 * NUM_CTAS, num_stages=NUM_CLC_STAGES)
 
-    with tlx.async_tasks(exclusive=True, no_ending_cluster_sync=True):
+    with tlx.async_tasks(
+        exclusive=True,
+        no_ending_cluster_sync=True,
+        mbarrier_try_wait_suspend_ns=50000,
+    ):
         with tlx.async_task("default"):  # epilogue consumer
             (
                 start_pid,


### PR DESCRIPTION
Summary:

Add `mbarrier_try_wait_suspend_ns` to `tlx.async_tasks` for Blackwell mbarrier waits. Positive values select the four-operand PTX `mbarrier.try_wait.parity` form, allowing ptxas to emit `NANOSLEEP.SYNCS` instead of a pure busy-spin loop. The policy is carried from the warp-specialize region to module metadata so waits introduced by later warp-specialization passes also use it.

When a kernel contains multiple `async_tasks` regions, the compiler selects the minimum explicitly specified value. `None` does not participate, while explicit `0` wins the minimum and disables the fused suspend hint. If no region specifies a value, waits retain the default busy-spin lowering. The API is enabled only on compute capability 100 and newer.

Retire the standalone `TRITON_MBARRIER_WAIT_BACKOFF_NS` and `TRITON_MBARRIER_TRY_WAIT_SUSPEND_NS` environment knobs. The legacy fixed `nanosleep.u32 20` path for pre-SM90 targets remains unchanged.

For fp16 TT GEMM with M/N/K = 1024/12800/1152, an async-task suspend hint of 50000 improves duration by 1.00% and elapsed cycles by 0.92% versus the default busy-spin baseline. It reduces TRYWAIT instructions by 27,661 and branches by 30,923 while leaving total dynamic instructions effectively unchanged.

Reviewed By: shunting314

Differential Revision: D112828024


