### PR TITLE
[magnon] Version-tag the ACF store by ptxas version

### DIFF
--- a/include/triton/Dialect/Triton/IR/Utility.h
+++ b/include/triton/Dialect/Triton/IR/Utility.h
@@ -200,17 +200,18 @@ bool isKernel(FunctionOpInterface funcOp);
 unsigned getBitwidth(RankedTensorType ty);
 
 // True if `attr` is, or nests anywhere, a TLX placeholder encoding wrapper
-// (#tlx.user_layout / #tlx.no_verify_layout). These defer layout verification to
-// resolve-placeholder-layouts (make_ttgir). Detected by dialect namespace
+// (#tlx.user_layout / #tlx.no_verify_layout). These defer layout verification
+// to resolve-placeholder-layouts (make_ttgir). Detected by dialect namespace
 // (scanning the whole attribute tree) because triton core cannot depend on the
 // TLX dialect for typed isa<> checks.
 bool encodingContainsTlxPlaceholder(Attribute attr);
 
-// Peel any TLX placeholder wrapper(s) (#tlx.user_layout / #tlx.no_verify_layout,
-// which live in the "tlx" dialect and wrap a single inner layout) off the top of
-// `attr`, returning the underlying concrete encoding (or `attr` unchanged if it
-// is not tlx-wrapped). Lets a verifier check the real layout under a still-
-// unresolved placeholder instead of skipping verification entirely.
+// Peel any TLX placeholder wrapper(s) (#tlx.user_layout /
+// #tlx.no_verify_layout, which live in the "tlx" dialect and wrap a single
+// inner layout) off the top of `attr`, returning the underlying concrete
+// encoding (or `attr` unchanged if it is not tlx-wrapped). Lets a verifier
+// check the real layout under a still- unresolved placeholder instead of
+// skipping verification entirely.
 Attribute unwrapTlxWrappers(Attribute attr);
 
 // If the value "anchor" is compared against a statically-computed bound, return

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -939,8 +939,8 @@ LogicalResult ReshapeOp::verify() {
   Attribute srcEnc = srcTy.getEncoding();
   Attribute dstEnc = dstTy.getEncoding();
   // If either side carries a TLX placeholder wrapper (#tlx.user_layout /
-  // #tlx.no_verify_layout) -- at the top or nested inside a ttg encoding (e.g. a
-  // slice/expand parent) -- defer all reshape layout verification to
+  // #tlx.no_verify_layout) -- at the top or nested inside a ttg encoding (e.g.
+  // a slice/expand parent) -- defer all reshape layout verification to
   // resolve-placeholder-layouts (make_ttgir); the concrete src/dst may not be
   // consistent yet at this point.
   if (encodingContainsTlxPlaceholder(srcEnc) ||

--- a/lib/Dialect/Triton/IR/Traits.cpp
+++ b/lib/Dialect/Triton/IR/Traits.cpp
@@ -44,7 +44,8 @@ static LogicalResult verifySameEncoding(Type typeA, Type typeB) {
     // Peel any TLX placeholder wrapper(s) (#tlx.user_layout / no_verify) and
     // verify the underlying concrete layout, rather than skipping verification.
     // The wrapper itself is retired later by resolve-placeholder-layouts; a
-    // still-null inner (unresolved) is accepted by the null short-circuit below.
+    // still-null inner (unresolved) is accepted by the null short-circuit
+    // below.
     ret = triton::unwrapTlxWrappers(ret);
     return ret;
   };

--- a/python/triton/magnon/consume.py
+++ b/python/triton/magnon/consume.py
@@ -35,11 +35,11 @@ def acf_args_for(ptx: str, arch: str | None, ptxas_version: str) -> list[str]:
                 "--apply-controls (set TRITON_PTXAS_BLACKWELL_PATH / COMPILE_IQ_PTXAS_MIN_VERSION)")
             return []
         sha = store.ptx_sha256(ptx)
-        p = store.acf_path(sha, arch)
+        p = store.acf_path(sha, arch, ptxas_version)  # version-tagged: match the ptxas that minted the ACF
         if not os.path.exists(p):
-            store.dlog("consume", f"MISS {sha[:16]} {arch}")
+            store.dlog("consume", f"MISS {sha[:16]} {arch} ptxas={ptxas_version}")
             return []
-        store.dlog("consume", f"HIT {sha[:16]} {arch}")
+        store.dlog("consume", f"HIT {sha[:16]} {arch} ptxas={ptxas_version}")
         return [f"--apply-controls={p}"]
     except Exception as e:  # never break compilation
         store.dlog("consume", f"error (fail-open): {type(e).__name__}: {e}")

--- a/python/triton/magnon/store.py
+++ b/python/triton/magnon/store.py
@@ -1,12 +1,15 @@
-"""ACF store: content-addressed by sha256(PTX), partitioned by GPU arch.
+"""ACF store: content-addressed by sha256(PTX), partitioned by GPU arch, scoped by ptxas version.
 
 Layout:
-    $COMPILE_IQ_STORE/<arch>/<ptx_sha256>.acf          # the best ACF (opaque bytes)
-    $COMPILE_IQ_STORE/<arch>/<ptx_sha256>.acf.json     # provenance metadata
+    $COMPILE_IQ_STORE/<arch>/<ptx_sha256>.<ptxas>.acf        # the best ACF (opaque bytes), version-tagged
+    $COMPILE_IQ_STORE/<arch>/<ptx_sha256>.<ptxas>.acf.json   # provenance metadata
+    $COMPILE_IQ_STORE/<arch>/<ptx_sha256>.<ptxas>.acf.cubin  # optional assembled-cubin cache
+    $COMPILE_IQ_STORE/<arch>/<ptx_sha256>.acf                # legacy untagged (no version given)
 
-PINNED (hash-key design): the key is sha256(PTX) x arch today. PTX subsumes the
-autotune config + dtype/alignment specialization, but NOT runtime shape (M,N,K).
-If per-shape ACFs are wanted later, extend the key with shape/identity.
+PINNED (hash-key design): kernel identity is sha256(PTX) x arch. PTX subsumes the autotune config +
+dtype/alignment specialization, but NOT runtime shape (M,N,K). The ptxas version scopes the artifact
+(an ACF is only valid for the ptxas that produced it), so different toolchains keep distinct ACFs for
+the same kernel instead of colliding. If per-shape ACFs are wanted later, extend the key with shape.
 """
 
 import hashlib
@@ -68,25 +71,29 @@ def store_root() -> str:
     return os.environ.get("COMPILE_IQ_STORE", os.path.expanduser("~/.compile_iq/store"))
 
 
-def acf_path(ptx_sha: str, arch: str) -> str:
-    return os.path.join(store_root(), arch, f"{ptx_sha}.acf")
+def acf_path(ptx_sha: str, arch: str, ptxas_version: str = "") -> str:
+    # Version-tagged ("<sha>.<ptxas>.acf") when a ptxas version is given: an ACF is bound to the ptxas
+    # that produced it (a mismatched ptxas rejects it), so one kernel keeps a distinct ACF per ptxas and
+    # different toolchains coexist. Falls back to legacy untagged "<sha>.acf" when no version is given.
+    name = f"{ptx_sha}.{_ptxas_tag(ptxas_version)}.acf" if ptxas_version else f"{ptx_sha}.acf"
+    return os.path.join(store_root(), arch, name)
 
 
-def has_acf(ptx_sha: str, arch: str) -> bool:
-    return os.path.exists(acf_path(ptx_sha, arch))
+def has_acf(ptx_sha: str, arch: str, ptxas_version: str = "") -> bool:
+    return os.path.exists(acf_path(ptx_sha, arch, ptxas_version))
 
 
-def read_acf(ptx_sha: str, arch: str) -> bytes | None:
-    p = acf_path(ptx_sha, arch)
+def read_acf(ptx_sha: str, arch: str, ptxas_version: str = "") -> bytes | None:
+    p = acf_path(ptx_sha, arch, ptxas_version)
     if not os.path.exists(p):
         return None
     with open(p, "rb") as f:
         return f.read()
 
 
-def read_meta(ptx_sha: str, arch: str) -> dict | None:
+def read_meta(ptx_sha: str, arch: str, ptxas_version: str = "") -> dict | None:
     """The provenance metadata (baseline_ms, best_ms, ...) for a stored ACF, or None if absent."""
-    p = acf_path(ptx_sha, arch) + ".json"
+    p = acf_path(ptx_sha, arch, ptxas_version) + ".json"
     if not os.path.exists(p):
         return None
     try:
@@ -96,8 +103,8 @@ def read_meta(ptx_sha: str, arch: str) -> dict | None:
         return None
 
 
-def write_acf(ptx_sha: str, arch: str, data: bytes, meta: dict | None = None) -> str:
-    p = acf_path(ptx_sha, arch)
+def write_acf(ptx_sha: str, arch: str, data: bytes, meta: dict | None = None, ptxas_version: str = "") -> str:
+    p = acf_path(ptx_sha, arch, ptxas_version)
     os.makedirs(os.path.dirname(p), exist_ok=True)
     with open(p, "wb") as f:
         f.write(data)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -4778,10 +4778,10 @@ static bool allocateTmemBuffersViaSearch(triton::FuncOp funcOp,
   auto cost = wsplan::createLatencyCostModel(model, getModuloII(funcOp));
   auto copies = wsplan::createGreedyCopySolver();
   wsplan::Budget budget;
-  // Coarse over-approximation, not a physical row count: this pre-gate sums each
-  // block's row footprint, but the real allocator (allocateTMemAllocs2) packs
-  // blocks along columns across 2 row groups of 64. 512 keeps the gate loose;
-  // exact feasibility is enforced by the downstream allocator.
+  // Coarse over-approximation, not a physical row count: this pre-gate sums
+  // each block's row footprint, but the real allocator (allocateTMemAllocs2)
+  // packs blocks along columns across 2 row groups of 64. 512 keeps the gate
+  // loose; exact feasibility is enforced by the downstream allocator.
   budget.tmemRows = 512;
   budget.tmemCols = 512;
 

--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -93,8 +93,8 @@ struct TLXInferLayoutInterface : public triton::DialectInferLayoutInterface {
         });
   }
 
-  // reduce/expand_dims produce or consume a `slice` encoding whose parent is the
-  // full-tensor encoding. The TLX wrapper must stay on the slice's *parent*
+  // reduce/expand_dims produce or consume a `slice` encoding whose parent is
+  // the full-tensor encoding. The TLX wrapper must stay on the slice's *parent*
   // (standard inference: slice<parent=user_layout<L>>) so the result is
   // structurally stable across resolve-placeholder-layouts (which strips
   // no_verify) and matches the op's own inference on both sides.

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -1,8 +1,8 @@
-#include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/IR/Builders.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
@@ -45,15 +45,15 @@ static bool isEncodingUniformArithOp(Operation *op) {
   if (isa<arith::ConstantOp>(op))
     return false; // handled as a leaf when retyped, not as a consumer
   // Propagate the placeholder across ops whose generic MLIR verifier compares
-  // operand/result *types* (ignoring the TLX wrapper) and would otherwise reject
-  // a placeholder meeting a null/concrete sibling: same-type elementwise
+  // operand/result *types* (ignoring the TLX wrapper) and would otherwise
+  // reject a placeholder meeting a null/concrete sibling: same-type elementwise
   // (SameOperandsAndResultType), select/cmp (whose condition / i1 result differ
-  // in type), and the arith cast ops (which change the element type but preserve
-  // shape/layout). Keyed on the trait + explicit op list rather than a hard-coded
-  // dialect name. NB: deliberately NOT the broad Elementwise trait -- it also
-  // matches ops that legitimately mix a pinned and an unpinned operand, which
-  // would over-propagate the pin. The element type may differ across the op
-  // (casts); only the encoding is propagated.
+  // in type), and the arith cast ops (which change the element type but
+  // preserve shape/layout). Keyed on the trait + explicit op list rather than a
+  // hard-coded dialect name. NB: deliberately NOT the broad Elementwise trait
+  // -- it also matches ops that legitimately mix a pinned and an unpinned
+  // operand, which would over-propagate the pin. The element type may differ
+  // across the op (casts); only the encoding is propagated.
   if (!op->hasTrait<mlir::OpTrait::SameOperandsAndResultType>() &&
       !isa<arith::SelectOp, arith::CmpFOp, arith::CmpIOp, arith::ExtFOp,
            arith::TruncFOp, arith::ExtUIOp, arith::ExtSIOp, arith::TruncIOp,
@@ -97,8 +97,7 @@ static bool isPlaceholderEncoding(Attribute enc) {
     return true;
   bool found = false;
   enc.walkImmediateSubElements(
-      [&](Attribute sub) { found |= isPlaceholderEncoding(sub); },
-      [](Type) {});
+      [&](Attribute sub) { found |= isPlaceholderEncoding(sub); }, [](Type) {});
   return found;
 }
 
@@ -161,7 +160,8 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
     bool isCall = v.getDefiningOp<::mlir::triton::CallOp>() != nullptr;
     if (forceBridge || isConst || isCall) {
       OpBuilder b(user);
-      auto convTy = RankedTensorType::get(t.getShape(), t.getElementType(), enc);
+      auto convTy =
+          RankedTensorType::get(t.getShape(), t.getElementType(), enc);
       Value conv = RequireLayoutOp::create(b, user->getLoc(), convTy, v);
       user->setOperand(operandIdx, conv);
       changed = true;
@@ -210,7 +210,8 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
           Value iterArg = forOp.getRegionIterArg(i);
           Value yieldV = yield.getOperand(i);
           Value resV = forOp.getResult(i);
-          Attribute enc = findPlaceholder({initV, iterArg, yieldV, resV}, forOp);
+          Attribute enc =
+              findPlaceholder({initV, iterArg, yieldV, resV}, forOp);
           if (!enc)
             continue;
           // init is an external operand and the yield operand is loop-body
@@ -250,9 +251,10 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
       }
       // tt.expand_dims / tt.broadcast: their result type was fixed at build
       // time, but the operand may only receive a placeholder via the arith/scf
-      // propagation above. Re-infer the result via the op's InferTypeOpInterface
-      // (broadcast preserves the encoding; expand_dims maps slice<->parent
-      // through the TLX infer interface) so operand and result stay consistent.
+      // propagation above. Re-infer the result via the op's
+      // InferTypeOpInterface (broadcast preserves the encoding; expand_dims
+      // maps slice<->parent through the TLX infer interface) so operand and
+      // result stay consistent.
       if (isa<::mlir::triton::ExpandDimsOp, ::mlir::triton::BroadcastOp,
               ::mlir::triton::ReduceOp>(op)) {
         auto ot = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
@@ -284,10 +286,10 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
       //       does not need an explicit tlx.release_layout.
       //   (B/C) it is elementwise (fast_fma) or a reduction (standard.max/sum):
       //       specialize the callee params, then sync the call result to the
-      //       callee return -- forcing the placeholder for an elementwise result
-      //       (shape matches the arg) or mirroring the fixpoint-inferred return
-      //       for a reduction result (shape differs, slice of the pin). This
-      //       keeps the kernel on natural tl.max/tl.sum and fast_fma.
+      //       callee return -- forcing the placeholder for an elementwise
+      //       result (shape matches the arg) or mirroring the fixpoint-inferred
+      //       return for a reduction result (shape differs, slice of the pin).
+      //       This keeps the kernel on natural tl.max/tl.sum and fast_fma.
       if (auto callOp = dyn_cast<::mlir::triton::CallOp>(op)) {
         Attribute enc;
         ArrayRef<int64_t> encShape;
@@ -330,8 +332,8 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
 
         // (B/C) elementwise / reduction: specialize the callee.
         // If the monomorphized helper is shared with other call sites (possibly
-        // unpinned or pinned to a different layout), defer privatizing it: clone
-        // a private copy after the walk and point this call at it, so
+        // unpinned or pinned to a different layout), defer privatizing it:
+        // clone a private copy after the walk and point this call at it, so
         // specializing never changes types out from under other callers or
         // toggles a shared callee between two pins across fixpoint iterations.
         if (auto symUses = SymbolTable::getSymbolUses(callee, mod)) {
@@ -351,8 +353,9 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
         // callee body (e.g. the reduction's tt.reduce) are re-inferred by the
         // fixpoint once their params are set.
         Block &entry = callee.getBody().front();
-        SmallVector<Type> newInputs(callee.getFunctionType().getInputs().begin(),
-                                    callee.getFunctionType().getInputs().end());
+        SmallVector<Type> newInputs(
+            callee.getFunctionType().getInputs().begin(),
+            callee.getFunctionType().getInputs().end());
         bool inputsChanged = false;
         for (unsigned i = 0; i < callOp.getNumOperands(); ++i) {
           Type at = callOp.getOperand(i).getType();
@@ -379,7 +382,8 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
             callee.getFunctionType().getResults().end());
         bool sigChanged = inputsChanged;
         for (unsigned i = 0; i < callOp.getNumResults(); ++i) {
-          auto callRt = dyn_cast<RankedTensorType>(callOp.getResult(i).getType());
+          auto callRt =
+              dyn_cast<RankedTensorType>(callOp.getResult(i).getType());
           // Reduction: mirror the callee's return operand once the fixpoint has
           // re-inferred it to a placeholder (slice of the pin).
           RankedTensorType retT;
@@ -389,7 +393,8 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
           if (retT && isPlaceholderEncoding(retT.getEncoding()))
             target = retT;
           else if (callRt && callRt.getShape() == encShape)
-            // Elementwise: result shares the arg shape -> force the placeholder.
+            // Elementwise: result shares the arg shape -> force the
+            // placeholder.
             target = RankedTensorType::get(callRt.getShape(),
                                            callRt.getElementType(), enc);
           else
@@ -409,8 +414,8 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
             }
         }
         if (sigChanged) {
-          callee.setType(FunctionType::get(callee.getContext(), newInputs,
-                                           newResults));
+          callee.setType(
+              FunctionType::get(callee.getContext(), newInputs, newResults));
           changed = true;
         }
         return;
@@ -420,8 +425,9 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
     // each pinned call site its own copy of the helper, so specializing it
     // cannot change types out from under other callers.
     for (auto callOp : pendingClones) {
-      auto callee = SymbolTable::lookupNearestSymbolFrom<::mlir::triton::FuncOp>(
-          callOp, callOp.getCalleeAttr());
+      auto callee =
+          SymbolTable::lookupNearestSymbolFrom<::mlir::triton::FuncOp>(
+              callOp, callOp.getCalleeAttr());
       if (!callee)
         continue;
       OpBuilder b(callee);

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -260,7 +260,8 @@ void init_triton_tlx_ir(py::module &&m) {
               std::vector<std::vector<int32_t>> offsetBases,
               std::vector<std::vector<int32_t>> blockBases, int rank) {
              // Build #ttg.padded_shared from explicit linear bases ({offset,
-             // block}), so a caller can pin a swizzled layout, not just identity.
+             // block}), so a caller can pin a swizzled layout, not just
+             // identity.
              if (intervals.size() != paddings.size())
                throw std::runtime_error(
                    "make_padded_shared_encoding_attr_with_bases: intervals and "


### PR DESCRIPTION
Summary:
Scope the magnon ACF store by ptxas version so ACFs minted by different toolchains coexist instead of colliding -- an ACF is only valid for the ptxas that produced it. Split out of D112767951 (the consumer/fbtriton half of the version-tagged store; the factory-side write lives in the ptx-anneal stack).

- **store.py**: `acf_path` / `has_acf` / `read_acf` / `read_meta` / `write_acf` take an optional `ptxas_version`; the path becomes `<sha>.<ptxas>.acf` when a version is given, falling back to the legacy untagged `<sha>.acf` otherwise.
- **consume.py**: pass the resolved `ptxas_version` into `acf_path`; HIT/MISS debug logs include it.
- **back-compat**: no version given -> legacy untagged path, so existing stores and the fail-open path are unchanged.

Differential Revision: D112840541