### PR TITLE
Harden TLX GEMM perf harness measurement methodology

### DIFF
--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -620,8 +620,7 @@ public:
         if (auto attr = op->getAttrOfType<IntegerAttr>(
                 "tlx.mbarrier_try_wait_suspend_ns")) {
           int32_t value = attr.getInt();
-          if (!mbarrierTryWaitSuspendNs ||
-              value < *mbarrierTryWaitSuspendNs)
+          if (!mbarrierTryWaitSuspendNs || value < *mbarrierTryWaitSuspendNs)
             mbarrierTryWaitSuspendNs = value;
         }
       });

--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -1229,9 +1229,9 @@ def matmul_kernel_tma_ws_blackwell(
     clc_context = tlx.clc_create_context(num_consumers=3 * NUM_CTAS, num_stages=NUM_CLC_STAGES)
 
     with tlx.async_tasks(
-        exclusive=True,
-        no_ending_cluster_sync=True,
-        mbarrier_try_wait_suspend_ns=50000,
+            exclusive=True,
+            no_ending_cluster_sync=True,
+            mbarrier_try_wait_suspend_ns=50000,
     ):
         with tlx.async_task("default"):  # epilogue consumer
             (

--- a/third_party/tlx/tutorials/testing/test_blackwell_gemm_perf.py
+++ b/third_party/tlx/tutorials/testing/test_blackwell_gemm_perf.py
@@ -37,10 +37,9 @@ ref_lib = "cuBLAS"
 # (a "fixed-frequency" architectural test). For that test type CUTLASS says to
 # fill inputs with ZEROS (low entropy -> low power -> the locked clock is not
 # power-throttled). Use --fill uniform for a "fixed-power" test (no clock lock).
-WARMUP_S = 3.0     # >= 3 s of continuous execution so clocks/power settle
-REP_S = 2.0        # timed window; yields ~1000-4000 iters depending on kernel
-COOLDOWN_S = 1.0   # idle between (provider, shape) cells
-
+WARMUP_S = 3.0  # >= 3 s of continuous execution so clocks/power settle
+REP_S = 2.0  # timed window; yields ~1000-4000 iters depending on kernel
+COOLDOWN_S = 1.0  # idle between (provider, shape) cells
 """
 This script is used for benchmarking the performance of TLX tutorial kernels.
 It's recommended to run with `third_party/tlx/denoise.sh third_party/tlx/tutorials/testing/test_blackwell_gemm_perf.py`
@@ -85,8 +84,7 @@ class GpuMonitor:
         while not self._stop.is_set():
             try:
                 out = subprocess.check_output(
-                    ["nvidia-smi", f"--query-gpu={self.QUERY}",
-                     "--format=csv,noheader,nounits", "-i", self.gpu],
+                    ["nvidia-smi", f"--query-gpu={self.QUERY}", "--format=csv,noheader,nounits", "-i", self.gpu],
                     stderr=subprocess.DEVNULL, timeout=1.0).decode().strip()
                 parts = [p.strip() for p in out.split(",")]
                 self.sm_clocks.append(float(parts[0]))
@@ -108,13 +106,13 @@ class GpuMonitor:
             self._thread.join(timeout=2.0)
 
     def summary(self):
+
         def stats(xs):
             if not xs:
                 return (float("nan"), float("nan"), float("nan"))
             return (min(xs), statistics.mean(xs), max(xs))
 
-        active = sorted(t for t in self.throttles
-                        if t and t not in ("Not Active", ""))
+        active = sorted(t for t in self.throttles if t and t not in ("Not Active", ""))
         return {
             "sm_clock": stats(self.sm_clocks),
             "power": stats(self.powers),
@@ -238,8 +236,7 @@ def create_benchmark(versions, dtype=torch.float16, fill="zeros"):
             f"clk[min/mean/max]={sm[0]:.0f}/{sm[1]:.0f}/{sm[2]:.0f}MHz "
             f"pwr={pw[0]:.0f}/{pw[1]:.0f}/{pw[2]:.0f}W "
             f"throttle={mon['throttle'] or 'none'} "
-            f"-> {tflops(med):.1f} TFLOPS",
-            flush=True)
+            f"-> {tflops(med):.1f} TFLOPS", flush=True)
 
         time.sleep(COOLDOWN_S)  # cooldown before next cell
         return tflops(med), tflops(hi_t), tflops(lo_t)

--- a/third_party/tlx/tutorials/testing/test_blackwell_gemm_perf.py
+++ b/third_party/tlx/tutorials/testing/test_blackwell_gemm_perf.py
@@ -1,4 +1,9 @@
 import argparse
+import os
+import statistics
+import subprocess
+import threading
+import time
 
 import torch
 
@@ -26,15 +31,173 @@ MATMUL_METHODS = {
 }
 
 ref_lib = "cuBLAS"
+
+# --- Benchmark methodology knobs (CUTLASS GEMM perf guidelines) ------------
+# Run under third_party/tlx/denoise.sh, which locks the clock and caps power
+# (a "fixed-frequency" architectural test). For that test type CUTLASS says to
+# fill inputs with ZEROS (low entropy -> low power -> the locked clock is not
+# power-throttled). Use --fill uniform for a "fixed-power" test (no clock lock).
+WARMUP_S = 3.0     # >= 3 s of continuous execution so clocks/power settle
+REP_S = 2.0        # timed window; yields ~1000-4000 iters depending on kernel
+COOLDOWN_S = 1.0   # idle between (provider, shape) cells
+
 """
 This script is used for benchmarking the performance of TLX tutorial kernels.
-It's recommended to run with `third_party/tlx/denoise.sh third_party/tlx/tutorials/blackwell_gemm_perf_test.py`
+It's recommended to run with `third_party/tlx/denoise.sh third_party/tlx/tutorials/testing/test_blackwell_gemm_perf.py`
 
 Facebook: If you are developing in fbsource, use tritonbench instead to collect perf numbers.
 """
 
 
-def create_benchmark(versions, dtype=torch.float16):
+def _phys_gpu_index():
+    """Physical GPU id for nvidia-smi (denoise.sh exports CUDA_VISIBLE_DEVICES)."""
+    cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+    if cvd:
+        first = cvd.split(",")[0].strip()
+        if first.isdigit():
+            return first
+    return "0"
+
+
+class GpuMonitor:
+    """Sample SM clock (MHz), power (W), temperature (C) and active throttle
+    reasons via nvidia-smi on a background thread, so we can verify the GPU was
+    not silently throttled during timing (CUTLASS: always co-measure clock and
+    power). pynvml is unavailable here; nvidia-smi queries need no sudo and the
+    background thread issues no work on the compute stream. NOTE: L2 hit-rate is
+    not exposed by NVML/nvidia-smi (needs ncu), so cold-cache behavior is instead
+    documented via the rotation-buffer footprint vs 2x L2 in the per-cell log."""
+
+    QUERY = ("clocks.sm,power.draw,temperature.gpu,"
+             "clocks_throttle_reasons.active")
+
+    def __init__(self, interval=0.1):
+        self.interval = interval
+        self.gpu = _phys_gpu_index()
+        self._stop = threading.Event()
+        self._thread = None
+        self.sm_clocks = []
+        self.powers = []
+        self.temps = []
+        self.throttles = set()
+
+    def _poll(self):
+        while not self._stop.is_set():
+            try:
+                out = subprocess.check_output(
+                    ["nvidia-smi", f"--query-gpu={self.QUERY}",
+                     "--format=csv,noheader,nounits", "-i", self.gpu],
+                    stderr=subprocess.DEVNULL, timeout=1.0).decode().strip()
+                parts = [p.strip() for p in out.split(",")]
+                self.sm_clocks.append(float(parts[0]))
+                self.powers.append(float(parts[1]))
+                self.temps.append(float(parts[2]))
+                self.throttles.add(parts[3])
+            except Exception:
+                pass
+            self._stop.wait(self.interval)
+
+    def __enter__(self):
+        self._thread = threading.Thread(target=self._poll, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+
+    def summary(self):
+        def stats(xs):
+            if not xs:
+                return (float("nan"), float("nan"), float("nan"))
+            return (min(xs), statistics.mean(xs), max(xs))
+
+        active = sorted(t for t in self.throttles
+                        if t and t not in ("Not Active", ""))
+        return {
+            "sm_clock": stats(self.sm_clocks),
+            "power": stats(self.powers),
+            "temp": stats(self.temps),
+            "throttle": active,
+            "n": len(self.sm_clocks),
+        }
+
+
+def _elem_size(dtype):
+    return torch.empty((), dtype=dtype).element_size()
+
+
+def _rotations_for(M, N, K, dtype):
+    """Number of (a, b) copies whose footprint totals >= 2x L2, forcing cold
+    caches (DRAM fetch) every iteration. At least 2 so buffers actually rotate."""
+    l2 = int(torch.cuda.get_device_properties(DEVICE).L2_cache_size)
+    per = (M * K + K * N) * _elem_size(dtype)
+    n = max(2, -(-(2 * l2) // per))  # ceil(2*L2 / per), >= 2
+    return n, l2, per
+
+
+def _make_inputs(M, N, K, dtype, fill, n_copies):
+    bufs = []
+    for _ in range(n_copies):
+        if fill == "zeros":
+            a = torch.zeros((M, K), device=DEVICE, dtype=dtype)
+            b = torch.zeros((K, N), device=DEVICE, dtype=dtype)
+        elif fill == "uniform":
+            a = torch.empty((M, K), device=DEVICE, dtype=dtype).uniform_(-1.0, 1.0)
+            b = torch.empty((K, N), device=DEVICE, dtype=dtype).uniform_(-1.0, 1.0)
+        else:  # "randn" (legacy behavior)
+            a = torch.randn((M, K), device=DEVICE, dtype=dtype)
+            b = torch.randn((K, N), device=DEVICE, dtype=dtype)
+        bufs.append((a, b))
+    return bufs
+
+
+def _bench_rotating(call, bufs, quantiles):
+    """Time `call(a, b)` rotating through `bufs`. Warm up for >= WARMUP_S, then
+    time n_rep iterations with NO per-iteration allocation or cache memset
+    (zero inter-launch overhead); cold L2 comes from rotating buffers whose
+    total footprint exceeds 2x L2. Clocks/power are monitored throughout."""
+    n = len(bufs)
+    call(*bufs[0])
+    torch.cuda.synchronize()
+
+    # Estimate per-iteration cost to size warmup / rep iteration counts.
+    s = torch.cuda.Event(enable_timing=True)
+    e = torch.cuda.Event(enable_timing=True)
+    s.record()
+    for i in range(5):
+        call(*bufs[i % n])
+    e.record()
+    torch.cuda.synchronize()
+    est_ms = max(s.elapsed_time(e) / 5, 1e-3)
+
+    n_warmup = max(1, int(WARMUP_S * 1000 / est_ms))
+    n_rep = max(50, int(REP_S * 1000 / est_ms))
+
+    for i in range(n_warmup):
+        call(*bufs[i % n])
+    torch.cuda.synchronize()
+
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(n_rep)]
+    ends = [torch.cuda.Event(enable_timing=True) for _ in range(n_rep)]
+    with GpuMonitor() as mon:
+        for i in range(n_rep):
+            starts[i].record()
+            call(*bufs[i % n])
+            ends[i].record()
+        torch.cuda.synchronize()
+    times = sorted(st.elapsed_time(en) for st, en in zip(starts, ends))
+
+    def q(frac):
+        idx = min(len(times) - 1, max(0, int(frac * len(times))))
+        return times[idx]
+
+    med, lo_t, hi_t = q(quantiles[0]), q(quantiles[1]), q(quantiles[2])
+    return med, lo_t, hi_t, n_rep, mon.summary()
+
+
+def create_benchmark(versions, dtype=torch.float16, fill="zeros"):
     line_vals = [ref_lib.lower()] + versions
     line_names = [ref_lib] + versions
     dtype_name = {torch.float16: "fp16", torch.bfloat16: "bf16"}[dtype]
@@ -51,21 +214,35 @@ def create_benchmark(versions, dtype=torch.float16):
             args={},
         ))
     def benchmark(M, N, K, provider):
-        a = torch.randn((M, K), device=DEVICE, dtype=dtype)
-        b = torch.randn((K, N), device=DEVICE, dtype=dtype)
+        n_copies, l2, per = _rotations_for(M, N, K, dtype)
+        bufs = _make_inputs(M, N, K, dtype, fill, n_copies)
         quantiles = [0.5, 0.2, 0.8]
+
         if provider == ref_lib.lower():
-            ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles, warmup=2000,
-                                                         rep=2000)
-        elif provider in MATMUL_METHODS:
+            call = lambda a, b: torch.matmul(a, b)  # noqa: E731
+        else:
             matmul = MATMUL_METHODS[provider]
-            ms, min_ms, max_ms = triton.testing.do_bench(lambda: matmul(a, b), quantiles=quantiles, warmup=2000,
-                                                         rep=2000)
+            call = lambda a, b: matmul(a, b)  # noqa: E731
+
+        med, lo_t, hi_t, n_rep, mon = _bench_rotating(call, bufs, quantiles)
 
         def tflops(ms):
             return 2 * M * N * K * 1e-12 / (ms * 1e-3)
 
-        return tflops(ms), tflops(max_ms), tflops(min_ms)
+        sm, pw = mon["sm_clock"], mon["power"]
+        tot_mb = n_copies * per / 1024 / 1024
+        print(
+            f"[monitor] {provider:>9} M=N=K={M:<5} fill={fill} "
+            f"rot={n_copies}x({tot_mb:.0f}MB>=2*L2={2 * l2 / 1024 / 1024:.0f}MB) "
+            f"iters={n_rep} "
+            f"clk[min/mean/max]={sm[0]:.0f}/{sm[1]:.0f}/{sm[2]:.0f}MHz "
+            f"pwr={pw[0]:.0f}/{pw[1]:.0f}/{pw[2]:.0f}W "
+            f"throttle={mon['throttle'] or 'none'} "
+            f"-> {tflops(med):.1f} TFLOPS",
+            flush=True)
+
+        time.sleep(COOLDOWN_S)  # cooldown before next cell
+        return tflops(med), tflops(hi_t), tflops(lo_t)
 
     return benchmark
 
@@ -86,14 +263,22 @@ if __name__ == "__main__":
         choices=["fp16", "bf16"],
         help="Data type for the benchmark (default: fp16)",
     )
+    parser.add_argument(
+        "--fill",
+        type=str,
+        default="zeros",
+        choices=["zeros", "uniform", "randn"],
+        help="Input fill: zeros (fixed-frequency, matches denoise.sh clock lock), "
+        "uniform [-1,1] (fixed-power), or randn (legacy). Default: zeros.",
+    )
     args = parser.parse_args()
 
     dtype = {"fp16": torch.float16, "bf16": torch.bfloat16}[args.dtype]
 
     if is_blackwell():
         versions = args.version if args.version else list(MATMUL_METHODS.keys())
-        print(f"Running benchmarks for: {versions} (dtype={args.dtype})")
-        benchmark = create_benchmark(versions, dtype=dtype)
+        print(f"Running benchmarks for: {versions} (dtype={args.dtype}, fill={args.fill})")
+        benchmark = create_benchmark(versions, dtype=dtype, fill=args.fill)
         benchmark.run(print_data=True)
     else:
         print("Skipping benchmarks, no Blackwell GPU found.")


### PR DESCRIPTION
Comparing TLX GEMM perf harness vs. CUTLASS methodology https://docs.nvidia.com/cutlass/latest/media/docs/cpp/gemm_performance_measurement_methodology_guidelines.html

```

  ┌─────┬────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────┬─────────────────┐                                        
  │  #  │              CUTLASS requirement               │                                        Current state                                        │     Verdict     │
  ├─────┼────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────┤
  │ 1   │ Buffer rotation, ≥2× L2, cold caches           │ Single input buffer; do_bench instead flushes a fixed 256 MB scratch buffer (driver.py:621) │ ⚠️ Divergent    │                                        
  ├─────┼────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────┤
  │ 2   │ Warm-up ~3 s to settle clocks                  │ warmup=2000 ms (~2 s)                                                                       │ ⚠️ Slightly low │                                        
  ├─────┼────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────┤
  │ 3   │ 1000–4000+ profiling iterations                │ rep=2000 ms → ~1000–4000 iters depending on kernel time                                     │ ✅ OK           │┤
  ├─────┼────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────┤
  │ 4   │ Zero overhead between launches                 │ cache.zero_() (256 MB memset) runs between every launch (testing.py:297)                    │ ❌ Violated     │┤
  ├─────┼────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────┤
  │ 5   │ Fill: uniform[-1,1] (power) / zeros (freq)     │ torch.randn = Gaussian(0,1), unbounded tails                                                │ ❌ Mismatched   │┤
  ├─────┼────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────┤
  │ 6   │ Collect FLOPS + GPC freq + power + L2 hit-rate │ TFLOPS only (test_*_perf.py:65-68)                                                          │ ❌ Missing      │┤
  ├─────┼────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────┤
  │ 7   │ Cool-down idle between tests                   │ None between shapes/providers                                                               │ ⚠️ Minor        │
  └─────┴────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────┴─────────────────┘
```
  
Fixes implemented (all in third_party/tlx/tutorials/testing/test_blackwell_gemm_perf.py, +197/−12)                                                                                                              
                                                                                                                                                                                                                  
  1. Fill matches test type — --fill zeros is now the default (low-entropy → low power → the denoise.sh-locked clock isn't                                                                                        
  power-throttled, per CUTLASS fixed-frequency guidance). uniform/randn selectable.                                                                                                                               
  2. Clock/power/throttle monitoring — background nvidia-smi sampler reports SM-clock/power/temp min-mean-max + active                                                                                            
  throttle reasons per cell (pynvml unavailable; L2 hit-rate needs ncu, so cold-cache is instead documented via rotation                                                                                          
  footprint vs 2×L2).                                                                                                                                                                                             
  3. Warm-up ≥3 s + 1 s cool-down between cells (was 2 s, no cool-down).                                                                                                                                          
  4. Buffer rotation — allocates ≥2×L2 (253 MB) of input copies and rotates them, replacing do_bench's 256 MB between-launch                                                                                      
  memset → genuinely cold caches with zero inter-launch overhead.                                                                                                                                                 
                                                                                                                                                                                                                  
  Before vs after (5 runs each, TFLOPS)                                                                                                                                                                           
```                                                                                                                                                                                                                  
   shape   provider | BEFORE mean  cv% |  AFTER mean  cv% |  d_mean%                                                                                                                                              
    2048     cuBLAS |      479.2   0.1 |     568.1   0.0 |    +18.6                                                                                                                                               
    2048         ws |      454.0   0.1 |     282.7   1.9 |    -37.7                                                                                                                                               
    2048        clc |      453.1   0.0 |     282.2   2.2 |    -37.7                                                                                                                                               
    2048  pipelined |      408.9   0.0 |     450.7   2.7 |    +10.2                                                                                                                                               
    2048       2cta |      294.2   0.0 |     304.7   1.3 |     +3.6                                                                                                                                               
    4096     cuBLAS |      816.6   1.3 |     936.3   0.0 |    +14.7                                                                                                                                               
    4096         ws |      815.4   1.9 |     911.0   0.0 |    +11.7                                                                                                                                               
    4096        clc |      782.8   0.2 |     869.8   0.3 |    +11.1                                                                                                                                               
    4096  pipelined |      645.8   1.0 |     714.5   0.4 |    +10.6                                                                                                                                               
    4096       2cta |      515.8   0.6 |     532.9   0.1 |     +3.3                                                                                                                                               
    8192     cuBLAS |      776.8  33.1 |    1167.8   0.0 |    +50.3   <- baseline min 262!                                                                                                                        
    8192         ws |      846.7  18.8 |    1157.7   0.1 |    +36.7   <- baseline min 539                                                                                                                         
    8192        clc |      721.0  34.9 |    1075.9   0.0 |    +49.2   <- baseline min 218                                                                                                                         
    8192  pipelined |      694.7  31.3 |     935.8   0.0 |    +34.7                                                                                                                                               
    8192       2cta |      546.4  29.0 |     632.5   0.0 |    +15.8    
```
run-to-run variance from up to ~35% CV -- large shapes were silently throttling, collapsing to 218-262 TFLOPS -- to <=2.7% across all shapes (mean CV 10.2% -> 0.6%).

## Ablation study

  - fill=zeros is the load-bearing fix. It alone eliminates the large-shape power-cap throttle (750 W cap → 500 W, clock 630→990 MHz) and delivers the entire +23–29% on 8192. Without it, the locked-clock
  test is silently power-throttled and misleading. Our hypothesis: _**Pipeline is data-independent so the effect probably comes from lower dynamic power (fewer state flips) in CMOS transistors.**_
  - buffer rotation is the correctness fix for small shapes. It alone forces cold caches, dropping 2048-ws by −37% (454→286) to the realistic DRAM-bound number instead of the inflated L2-resident one. It's
  the only patch that does this.
  - warmup/cooldown has ~zero impact here — under a hard clock lock there's nothing left to settle. It's cheap insurance for cold-start/unlocked scenarios, not a driver.
  - monitoring changes no numbers by design — but it's what made the whole diagnosis possible: it identified throttle reason 0x4 = SW power cap as the root cause. Without it the throttling is invisible.

  One-liner for the PR: the variance win comes almost entirely from fill=zeros (kills power-cap throttling on large shapes) and the realism win from buffer rotation (cold caches on small shapes);
  warmup/cooldown and monitoring are correctness/observability support with no direct effect on the numbers.


Authored with Claude.