### PR TITLE
[triton][TMA-Multicast] Plan multicast from cluster geometry (#2261)

### DIFF
--- a/docs/design/triton-clc-tile-scheduler.md
+++ b/docs/design/triton-clc-tile-scheduler.md
@@ -133,6 +133,13 @@ def TTNG_CLCAdvanceOp : TTNG_Op<"clc_advance", []> {
 Effectful (it claims a pending cluster) so it is neither DCE'd nor hoisted out of
 the loop; one per persistent-loop iteration. It references no mbarrier or buffer.
 
+For a clustered launch, `clc_advance` represents one cluster-scoped claim.
+Lowering elects exactly one CTA to issue the hardware request and distributes
+the response to the entire cluster. The returned `isValid` bit is therefore
+cluster-uniform. The `(x, y, z)` coordinates are reconstructed per CTA from the
+claimed cluster base and may differ along clustered dimensions. Electing rank
+zero is the current lowering strategy, not part of the operation contract.
+
 ### Initial TTIR
 
 ```mlir
@@ -167,9 +174,12 @@ Two ops model the intermediate form; together they are exactly `clc_advance`
 
 - `ttng.clc_try_cancel_async : !ttg.async_token` — issue the async CLC request.
   Returns **only a token**, nothing else. Effectful (claims a pending cluster).
+  For a clustered launch, the token represents one cluster-scoped request;
+  which CTA issues it is a lowering detail.
 - `ttng.clc_read(!ttg.async_token) -> (i1 isValid, i32 x, i32 y, i32 z)` — await
   the token and return the decoded tile. Same results as `clc_advance` (it must
-  return `is_valid` too).
+  return `is_valid` too). For a cluster-scoped token, every CTA observes the
+  same `isValid`, while coordinates are reconstructed per CTA.
 
 The token is `!ttg.async_token`, the same completion-handle type used by
 `cp.async` / TMA / `tcgen05` — so the existing async-dependency machinery applies.

--- a/docs/design/triton_tma_multicast.md
+++ b/docs/design/triton_tma_multicast.md
@@ -234,15 +234,19 @@ tile expressions between CTA ranks.
 
 The implementation flows through the compiler as follows:
 
-1. The Python frontend records a load-local `tt.multicast` boolean when
-   `TensorDescriptor.load(..., multicast=...)` overrides the kernel policy. The
-   NVIDIA backend records the kernel default as `ttg.multicast` and the exact
-   physical cluster shape through `ctas_per_cga` module attributes.
+1. The Python frontend resolves each
+   `TensorDescriptor.load(..., multicast=...)` policy against the selected
+   kernel configuration and records the ODS-declared `multicast` boolean on
+   `tt.descriptor_load`. Every descriptor load therefore has a complete `true`
+   or `false` policy in IR. The planner reads the exact physical shape from the
+   existing cluster dimension attributes.
 2. `TritonNvidiaGPUTMAMulticastPass`, implemented in
    `lib/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.cpp`, runs after
    descriptor-encoding optimization. For each enabled `tt.descriptor_load`, it
-   computes program-ID dependencies and records the proven broadcast axes in
-   the internal `tt.multicast_axes` attribute.
+   reads the ODS-declared policy, computes program-ID dependencies, and records
+   the proven broadcast axes in the internal `tt.multicast_axes` attribute.
+   The load retains its `multicast` policy and carries `tt.multicast_axes`
+   only when the planner proves a valid multicast plan.
 3. TMA lowering and software-pipelining preserve that attribute, allocate a
    local completion barrier in every recipient CTA, and insert cluster barriers
    around the multicast transaction. Loads with different broadcast axes are
@@ -256,7 +260,7 @@ The implementation flows through the compiler as follows:
    its local barrier before the following cluster rendezvous.
 
 The planner accepts only tiled `tt.descriptor_load` operations, an exact
-power-of-two `ctas_per_cga` shape containing 2 to 16 CTAs, and index/control-flow
+power-of-two physical cluster shape containing 2 to 16 CTAs, and index/control-flow
 expressions whose program-ID dependencies it can prove. It understands CLC
 schedule results and cluster-uniform `scf.for`/`scf.while` control flow, and it
 preserves plans through Meta AutoWS channels. It conservatively rejects

--- a/include/triton/Dialect/Triton/IR/TMAMulticast.h
+++ b/include/triton/Dialect/Triton/IR/TMAMulticast.h
@@ -1,0 +1,12 @@
+#ifndef TRITON_DIALECT_TRITON_IR_TMAMULTICAST_H_
+#define TRITON_DIALECT_TRITON_IR_TMAMULTICAST_H_
+
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir::triton {
+
+inline constexpr llvm::StringLiteral kMulticastAxesAttrName =
+    "tt.multicast_axes";
+} // namespace mlir::triton
+
+#endif // TRITON_DIALECT_TRITON_IR_TMAMULTICAST_H_

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -1208,7 +1208,8 @@ def TT_DescriptorLoadOp
           DefaultValuedAttr<TT_CacheModifierAttr,
                             "::mlir::triton::CacheModifier::NONE">:$cache,
           DefaultValuedAttr<TT_EvictionPolicyAttr,
-                            "::mlir::triton::EvictionPolicy::NORMAL">:$evict);
+                            "::mlir::triton::EvictionPolicy::NORMAL">:$evict,
+          DefaultValuedAttr<BoolAttr, "false">:$multicast);
 
   let results = (outs TT_Tensor:$result);
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -319,6 +319,14 @@ def TTNG_CLCAdvanceOp
     splits the fetch into an (overlap-hoisted) async issue and a wait+load+decode,
     infers the phase, and drops unused coordinates. One per persistent-loop
     iteration.
+
+    In a clustered launch, this operation represents one cluster-scoped claim.
+    Lowering elects exactly one CTA to issue the request and distributes the
+    response to every CTA in the cluster. `isValid` is therefore
+    cluster-uniform. The (`x`, `y`, `z`) results are reconstructed for each CTA
+    from the claimed cluster base and may differ along clustered dimensions.
+    Which CTA issues the request is a lowering detail and is not observable in
+    the operation semantics.
   }];
 
   let results = (outs I1:$isValid, I32:$x, I32:$y, I32:$z);
@@ -348,6 +356,9 @@ def TTNG_CLCTryCancelAsyncOp
     `clc_read` awaits it and returns the decoded tile. References no mbarrier or
     buffer. Effectful (claims a pending cluster) so it is neither DCE'd nor
     hoisted out of the persistent loop.
+
+    In a clustered launch, the token represents one cluster-scoped request.
+    Exactly one CTA issues it; CTA election is a lowering detail.
   }];
 
   let results = (outs TTG_AsyncToken:$token);
@@ -363,6 +374,11 @@ def TTNG_CLCReadOp
     Consumer half of the async CLC fetch started by `clc_try_cancel_async`: awaits
     the token and returns the decoded tile -- `isValid` plus the (`x`, `y`, `z`)
     program-id coordinates. References no mbarrier or buffer.
+
+    For a cluster-scoped token, the response is distributed to every CTA in the
+    cluster. `isValid` is identical for every CTA, while (`x`, `y`, `z`) are
+    reconstructed per CTA from the claimed cluster base. The identity of the
+    issuing CTA is not part of this operation's semantics.
   }];
 
   let arguments = (ins TTG_AsyncToken:$token);

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -131,6 +131,14 @@ def TritonNvidiaGPUTMALoweringPass : Pass<"triton-nvidia-tma-lowering", "mlir::M
   ];
 }
 
+def TritonNvidiaGPUTMAMulticastPass : Pass<"triton-nvidia-plan-tma-multicast", "mlir::ModuleOp"> {
+  let summary = "Plan compiler-selected TMA multicast groups";
+  let description = [{
+    Annotates eligible descriptor loads with cluster axes across which their
+    source tile is statically invariant.
+  }];
+}
+
 def TritonNvidiaGPUTMAStoreBufferReusePass
     : Pass<"triton-nvidia-tma-store-buffer-reuse", "mlir::ModuleOp"> {
   let summary = "Reuse SMEM buffers across sequential TMA stores";

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.h
@@ -1,0 +1,37 @@
+#ifndef TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_TMAMULTICAST_H
+#define TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_TMAMULTICAST_H
+
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include <cstdint>
+
+namespace mlir {
+class ModuleOp;
+class Value;
+namespace triton {
+class DescriptorLoadOp;
+namespace nvidia_gpu {
+
+struct TMAClusterGeometry {
+  llvm::SmallVector<int, 3> dims;
+
+  static FailureOr<TMAClusterGeometry> get(ModuleOp module);
+  unsigned size() const;
+  llvm::SmallVector<int, 3> coordinates(unsigned rank) const;
+  uint16_t maskFor(unsigned rank,
+                   const llvm::SmallBitVector &broadcastAxes) const;
+  unsigned leaderFor(unsigned rank,
+                     const llvm::SmallBitVector &broadcastAxes) const;
+};
+
+struct TMAMulticastPlan {
+  TMAClusterGeometry geometry;
+  llvm::SmallBitVector broadcastAxes;
+};
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir
+
+#endif

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   TMemBarrierInsertion.cpp
   TensorMemoryAllocation.cpp
   TMALowering.cpp
+  TMAMulticast.cpp
   TMAStoreBufferReuse.cpp
   TMAUtilities.cpp
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.cpp
@@ -1,0 +1,315 @@
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/TMAMulticast.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace ttng = mlir::triton::nvidia_gpu;
+
+namespace {
+
+class ProgramIdDependencyAnalysis {
+public:
+  explicit ProgramIdDependencyAnalysis(ArrayRef<int> clusterDims)
+      : clusterDims(clusterDims) {}
+
+  FailureOr<llvm::SmallBitVector> get(Value value) {
+    if (auto it = cache.find(value); it != cache.end())
+      return it->second;
+    bool isRoot = active.empty();
+    if (isRoot)
+      backEdgeEpoch = 0;
+    unsigned epochAtEntry = backEdgeEpoch;
+    // A loop-carried back-edge contributes no new dependency to this monotone
+    // union. Do not cache intermediate values while the cycle is open: their
+    // result does not yet include the loop argument's initial dependencies.
+    if (!active.insert(value).second) {
+      ++backEdgeEpoch;
+      return llvm::SmallBitVector(3);
+    }
+
+    FailureOr<llvm::SmallBitVector> result = analyze(value);
+    active.erase(value);
+    if (succeeded(result) && (isRoot || epochAtEntry == backEdgeEpoch))
+      cache.try_emplace(value, *result);
+    return result;
+  }
+
+private:
+  FailureOr<llvm::SmallBitVector> analyze(Value value) {
+    if (auto arg = dyn_cast<BlockArgument>(value)) {
+      Operation *parent = arg.getOwner()->getParentOp();
+      if (isa<tt::FuncOp>(parent))
+        return llvm::SmallBitVector(3);
+      if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+        if (arg == forOp.getInductionVar()) {
+          auto lowerDeps = get(forOp.getLowerBound());
+          auto stepDeps = get(forOp.getStep());
+          if (failed(lowerDeps) || failed(stepDeps))
+            return failure();
+          *lowerDeps |= *stepDeps;
+          return *lowerDeps;
+        }
+        unsigned index = arg.getArgNumber() - 1;
+        return mergeLoopValues(
+            forOp.getInitArgs()[index],
+            forOp.getBody()->getTerminator()->getOperand(index));
+      }
+      if (auto whileOp = dyn_cast<scf::WhileOp>(parent)) {
+        unsigned index = arg.getArgNumber();
+        if (arg.getOwner() == whileOp.getBeforeBody())
+          return mergeLoopValues(
+              whileOp.getInits()[index],
+              whileOp.getAfterBody()->getTerminator()->getOperand(index));
+        return get(
+            whileOp.getBeforeBody()->getTerminator()->getOperand(index + 1));
+      }
+      return failure();
+    }
+
+    Operation *op = value.getDefiningOp();
+    if (!op)
+      return failure();
+    if (auto pid = dyn_cast<tt::GetProgramIdOp>(op)) {
+      llvm::SmallBitVector deps(3);
+      deps.set(static_cast<unsigned>(pid.getAxis()));
+      return deps;
+    }
+    if (isa<ttng::CLCAdvanceOp, ttng::CLCReadOp>(op)) {
+      unsigned resultNumber = cast<OpResult>(value).getResultNumber();
+      llvm::SmallBitVector deps(3);
+      // CLC operation semantics define a clustered claim as one cluster-scoped
+      // request whose response has a group-uniform validity bit followed by
+      // per-CTA X/Y/Z coordinates reconstructed from the claimed cluster base.
+      // The identity of the elected issuing CTA is a lowering detail.
+      if (resultNumber != 0)
+        deps.set(resultNumber - 1);
+      return deps;
+    }
+    if (isa<arith::ConstantOp, tt::GetNumProgramsOp>(op))
+      return llvm::SmallBitVector(3);
+
+    auto analyzeClusterQuotient = [&](Value lhs, Value rhs)
+        -> FailureOr<llvm::SmallBitVector> {
+      auto pid = lhs.getDefiningOp<tt::GetProgramIdOp>();
+      auto constant = rhs.getDefiningOp<arith::ConstantOp>();
+      auto divisor = constant
+                         ? dyn_cast<IntegerAttr>(constant.getValue())
+                         : IntegerAttr();
+      if (!pid || !divisor)
+        return failure();
+      unsigned axis = static_cast<unsigned>(pid.getAxis());
+      if (divisor.getInt() != clusterDims[axis])
+        return failure();
+      // Physical clusters are aligned to their shape, so dividing a physical
+      // program coordinate by the exact cluster dimension yields the same
+      // cluster coordinate for every CTA in that cluster.
+      return llvm::SmallBitVector(3);
+    };
+    if (auto div = dyn_cast<arith::DivSIOp>(op)) {
+      auto deps = analyzeClusterQuotient(div.getLhs(), div.getRhs());
+      if (succeeded(deps))
+        return deps;
+    }
+    if (auto div = dyn_cast<arith::DivUIOp>(op)) {
+      auto deps = analyzeClusterQuotient(div.getLhs(), div.getRhs());
+      if (succeeded(deps))
+        return deps;
+    }
+
+    // TODO: Model CLC and mutable-memory dependencies using the latest
+    // schedule instead of rejecting them conservatively.
+    if (isa<ttng::CLCTryCancelOp, ttng::CLCLoadResultOp,
+            ttng::CLCIsCanceledOp, ttng::CLCGetProgramIdOp,
+            ttng::CLCTryCancelAsyncOp, ttng::CLCQueryCancelOp,
+            tt::AtomicRMWOp, tt::AtomicCASOp, tt::LoadOp>(op))
+      return failure();
+    if (!isa<arith::ArithDialect>(op->getDialect()) &&
+        !isa<tt::SplatOp, tt::BroadcastOp, tt::ExpandDimsOp,
+             tt::MakeTensorDescOp, ttng::ReinterpretTensorDescOp>(op))
+      return failure();
+    if (!isMemoryEffectFree(op))
+      return failure();
+
+    llvm::SmallBitVector deps(3);
+    for (Value operand : op->getOperands()) {
+      auto operandDeps = get(operand);
+      if (failed(operandDeps))
+        return failure();
+      deps |= *operandDeps;
+    }
+    return deps;
+  }
+
+  FailureOr<llvm::SmallBitVector> mergeLoopValues(Value init, Value next) {
+    auto initDeps = get(init);
+    auto nextDeps = get(next);
+    if (failed(initDeps) || failed(nextDeps))
+      return failure();
+    *initDeps |= *nextDeps;
+    return *initDeps;
+  }
+
+  DenseMap<Value, llvm::SmallBitVector> cache;
+  llvm::SmallPtrSet<Value, 16> active;
+  llvm::SmallVector<int, 3> clusterDims;
+  unsigned backEdgeEpoch = 0;
+};
+
+} // namespace
+
+namespace mlir::triton::nvidia_gpu {
+
+FailureOr<TMAClusterGeometry> TMAClusterGeometry::get(ModuleOp module) {
+  TMAClusterGeometry geometry{ttg::TritonGPUDialect::getClusterDims(module)};
+  if (geometry.dims.size() != 3 ||
+      llvm::any_of(geometry.dims, [](int dim) { return dim <= 0; }) ||
+      llvm::any_of(geometry.dims,
+                   [](int dim) { return !llvm::isPowerOf2_32(dim); }) ||
+      geometry.size() <= 1 || geometry.size() > 16)
+    return failure();
+  return geometry;
+}
+
+unsigned TMAClusterGeometry::size() const {
+  return static_cast<unsigned>(dims[0] * dims[1] * dims[2]);
+}
+
+llvm::SmallVector<int, 3> TMAClusterGeometry::coordinates(unsigned rank) const {
+  llvm::SmallVector<int, 3> coord(3);
+  coord[0] = rank % dims[0];
+  rank /= dims[0];
+  coord[1] = rank % dims[1];
+  coord[2] = rank / dims[1];
+  return coord;
+}
+
+uint16_t
+TMAClusterGeometry::maskFor(unsigned rank,
+                            const llvm::SmallBitVector &broadcastAxes) const {
+  auto source = coordinates(rank);
+  uint16_t mask = 0;
+  for (unsigned candidate = 0; candidate < size(); ++candidate) {
+    auto target = coordinates(candidate);
+    bool sameGroup = true;
+    for (unsigned axis = 0; axis < 3; ++axis)
+      if (!broadcastAxes.test(axis) && source[axis] != target[axis])
+        sameGroup = false;
+    if (sameGroup)
+      mask |= uint16_t(1u << candidate);
+  }
+  return mask;
+}
+
+unsigned
+TMAClusterGeometry::leaderFor(unsigned rank,
+                              const llvm::SmallBitVector &broadcastAxes) const {
+  uint16_t mask = maskFor(rank, broadcastAxes);
+  return llvm::countr_zero(static_cast<unsigned>(mask));
+}
+
+static FailureOr<TMAMulticastPlan>
+analyzeTMAMulticast(tt::DescriptorLoadOp load) {
+  if (!load.getMulticast())
+    return failure();
+  auto module = load->getParentOfType<ModuleOp>();
+  auto func = load->getParentOfType<tt::FuncOp>();
+  if (!func || !tt::isKernel(func) || !func.getBody().hasOneBlock())
+    return failure();
+  auto geometry = TMAClusterGeometry::get(module);
+  if (failed(geometry))
+    return failure();
+
+  ProgramIdDependencyAnalysis analysis(geometry->dims);
+  llvm::SmallBitVector varyingAxes(3);
+  for (Value index : load.getIndices()) {
+    auto deps = analysis.get(index);
+    if (failed(deps))
+      return failure();
+    varyingAxes |= *deps;
+  }
+
+  // Pid-invariant indices are not sufficient: a descriptor whose base / shape /
+  // strides derive from program_id (e.g. `base + pid * stride`) can be loaded at
+  // identical indices across CTAs yet address different tiles, so multicasting
+  // the leader's tile would corrupt the others. Fold the descriptor operand's
+  // pid-dependence into varyingAxes as well; a computed descriptor whose
+  // invariance the analysis cannot prove fails here and the load is rejected
+  // (no multicast) rather than being assumed broadcastable.
+  auto descDeps = analysis.get(load.getDesc());
+  if (failed(descDeps))
+    return failure();
+  varyingAxes |= *descDeps;
+
+  llvm::SmallBitVector broadcastAxes(3);
+  llvm::SmallBitVector synchronizationAxes(3);
+  for (unsigned axis = 0; axis < 3; ++axis)
+    if (geometry->dims[axis] > 1) {
+      synchronizationAxes.set(axis);
+      if (!varyingAxes.test(axis))
+        broadcastAxes.set(axis);
+    }
+
+  for (Operation *parent = load->getParentOp();
+       parent && !isa<tt::FuncOp>(parent); parent = parent->getParentOp()) {
+    SmallVector<Value> controls;
+    if (auto ifOp = dyn_cast<scf::IfOp>(parent))
+      controls.push_back(ifOp.getCondition());
+    else if (auto forOp = dyn_cast<scf::ForOp>(parent))
+      controls.append(
+          {forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep()});
+    else if (auto whileOp = dyn_cast<scf::WhileOp>(parent)) {
+      auto condition =
+          cast<scf::ConditionOp>(whileOp.getBeforeBody()->getTerminator());
+      controls.push_back(condition.getCondition());
+    } else if (parent->getNumRegions() != 0)
+      return failure();
+    for (Value control : controls) {
+      auto deps = analysis.get(control);
+      // Lowering brackets multicast with full-cluster barriers, including axes
+      // outside a data recipient subgroup.
+      if (failed(deps) || deps->anyCommon(synchronizationAxes))
+        return failure();
+    }
+  }
+
+  if (broadcastAxes.none())
+    return failure();
+  return TMAMulticastPlan{*geometry, broadcastAxes};
+}
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUTMAMULTICASTPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+class TritonNvidiaGPUTMAMulticastPass
+    : public impl::TritonNvidiaGPUTMAMulticastPassBase<
+          TritonNvidiaGPUTMAMulticastPass> {
+  void runOnOperation() override {
+    getOperation().walk([](tt::DescriptorLoadOp load) {
+      load->removeAttr(tt::kMulticastAxesAttrName);
+      if (!load.getMulticast())
+        return;
+      auto plan = analyzeTMAMulticast(load);
+      if (failed(plan))
+        return;
+      SmallVector<int32_t> axes;
+      for (int axis : plan->broadcastAxes.set_bits())
+        axes.push_back(axis);
+      load->setAttr(tt::kMulticastAxesAttrName,
+                    DenseI32ArrayAttr::get(load.getContext(), axes));
+    });
+  }
+};
+
+} // namespace mlir::triton::nvidia_gpu

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1770,10 +1770,8 @@ void init_triton_ir(py::module_ &m) {
             auto descTy = cast<triton::TensorDescType>(desc.getType());
             auto resTy = descTy.getSignlessBlockType();
             auto op = self.create<DescriptorLoadOp>(
-                resTy, desc, indices, cacheModifier, evictionPolicy);
-            if (multicast)
-              op->setAttr("tt.multicast",
-                          self.getBuilder().getBoolAttr(*multicast));
+                resTy, desc, indices, cacheModifier, evictionPolicy,
+                multicast.value_or(false));
             return op;
           },
           py::arg("desc"), py::arg("indices"), py::arg("cacheModifier"),

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1111,7 +1111,9 @@ class TritonSemantic(Generic[TensorTy]):
         assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
 
         offsets = self._convert_to_ir_values(offsets, require_i64=False)
-        if multicast is not None and not isinstance(multicast, bool):
+        if multicast is None:
+            multicast = getattr(self.builder.options, "multicast", False)
+        if not isinstance(multicast, bool):
             raise TypeError(f"multicast must be a constexpr bool or None, got {multicast}")
         x = self.builder.create_descriptor_load(
             desc.handle,

--- a/test/TritonNvidiaGPU/tma_multicast_analysis.mlir
+++ b/test/TritonNvidiaGPU/tma_multicast_analysis.mlir
@@ -1,0 +1,251 @@
+// RUN: triton-opt %s --triton-nvidia-plan-tma-multicast | FileCheck %s
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {
+  "ttg.cluster-dim-x" = 2 : i32,
+  "ttg.cluster-dim-y" = 4 : i32,
+  "ttg.cluster-dim-z" = 1 : i32,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  ttg.target = "cuda:90",
+  "ttg.threads-per-warp" = 32 : i32
+} {
+  // CHECK-LABEL: @rectangular
+  tt.func public @rectangular(
+      %a: !tt.tensordesc<128x64xf16, #shared>,
+      %b: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %y = tt.get_program_id y : i32
+    %k = arith.constant 0 : i32
+    // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+    %av = tt.descriptor_load %a[%x, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 0>}
+    %bv = tt.descriptor_load %b[%y, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @no_reuse
+  tt.func public @no_reuse(%a: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %y = tt.get_program_id y : i32
+    // CHECK-NOT: tt.multicast_axes
+    %v = tt.descriptor_load %a[%x, %y] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @per_load_disable
+  tt.func public @per_load_disable(%a: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %k = arith.constant 0 : i32
+    // CHECK-NOT: tt.multicast_axes
+    %v = tt.descriptor_load %a[%x, %k] {multicast = false} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @dynamic_tile
+  tt.func public @dynamic_tile(
+      %a: !tt.tensordesc<128x64xf16, #shared>, %counter: !tt.ptr<i32>) {
+    %tile = tt.load %counter : !tt.ptr<i32>
+    %k = arith.constant 0 : i32
+    // CHECK-NOT: tt.multicast_axes
+    %v = tt.descriptor_load %a[%tile, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @divergent_loop
+  tt.func public @divergent_loop(
+      %a: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %y = tt.get_program_id y : i32
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    scf.for %i = %c0 to %y step %c1 : i32 {
+      // CHECK-NOT: tt.multicast_axes
+      %v = tt.descriptor_load %a[%x, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // The load's recipient groups span Y at a fixed X, but lowering uses a
+  // full-cluster barrier. An X-dependent branch is therefore unsafe even
+  // though it is uniform within each data recipient group.
+  // CHECK-LABEL: @subgroup_uniform_cluster_divergent
+  tt.func public @subgroup_uniform_cluster_divergent(
+      %a: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %c0 = arith.constant 0 : i32
+    %is_x0 = arith.cmpi eq, %x, %c0 : i32
+    scf.if %is_x0 {
+      // CHECK-NOT: tt.multicast_axes
+      %v = tt.descriptor_load %a[%x, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @cluster_uniform_condition
+  tt.func public @cluster_uniform_condition(
+      %a: !tt.tensordesc<128x64xf16, #shared>, %enabled: i1) {
+    %x = tt.get_program_id x : i32
+    %c0 = arith.constant 0 : i32
+    scf.if %enabled {
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+      %v = tt.descriptor_load %a[%x, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @induction_dependency
+  tt.func public @induction_dependency(
+      %a: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c4 = arith.constant 4 : i32
+    scf.for %i = %x to %c4 step %c1 : i32 {
+      // CHECK-NOT: tt.multicast_axes
+      %v = tt.descriptor_load %a[%i, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // Dividing each physical program coordinate by its exact cluster dimension
+  // produces a cluster-uniform work id suitable for a persistent loop bound.
+  // CHECK-LABEL: @cluster_uniform_quotient
+  tt.func public @cluster_uniform_quotient(
+      %a: !tt.tensordesc<128x64xf16, #shared>, %limit: i32) {
+    %x = tt.get_program_id x : i32
+    %y = tt.get_program_id y : i32
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c2 = arith.constant 2 : i32
+    %c4 = arith.constant 4 : i32
+    %cluster_x = arith.divsi %x, %c2 : i32
+    %cluster_y = arith.divui %y, %c4 : i32
+    %start = arith.addi %cluster_x, %cluster_y : i32
+    scf.for %i = %start to %limit step %c1 : i32 {
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+      %v = tt.descriptor_load %a[%x, %i] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @wrong_cluster_divisor
+  tt.func public @wrong_cluster_divisor(
+      %a: !tt.tensordesc<128x64xf16, #shared>, %limit: i32) {
+    %x = tt.get_program_id x : i32
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c3 = arith.constant 3 : i32
+    %bad_cluster_x = arith.divui %x, %c3 : i32
+    scf.for %i = %bad_cluster_x to %limit step %c1 : i32 {
+      // CHECK-NOT: tt.multicast_axes
+      %v = tt.descriptor_load %a[%x, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @clc_cluster_schedule
+  tt.func public @clc_cluster_schedule(
+      %a: !tt.tensordesc<128x64xf16, #shared>,
+      %b: !tt.tensordesc<128x64xf16, #shared>) {
+    %true = arith.constant true
+    %x0 = tt.get_program_id x : i32
+    %y0 = tt.get_program_id y : i32
+    %z0 = tt.get_program_id z : i32
+    %k = arith.constant 0 : i32
+    %results:4 = scf.while (%valid = %true, %x = %x0, %y = %y0, %z = %z0) :
+        (i1, i32, i32, i32) -> (i1, i32, i32, i32) {
+      scf.condition(%valid) %valid, %x, %y, %z : i1, i32, i32, i32
+    } do {
+    ^bb0(%valid: i1, %x: i32, %y: i32, %z: i32):
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+      %av = tt.descriptor_load %a[%x, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 0>}
+      %bv = tt.descriptor_load %b[%y, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      %next_valid, %next_x, %next_y, %next_z = ttng.clc_advance : i1, i32, i32, i32
+      scf.yield %next_valid, %next_x, %next_y, %next_z : i1, i32, i32, i32
+    }
+    tt.return
+  }
+}
+
+module attributes {
+  "ttg.cluster-dim-x" = 1 : i32,
+  "ttg.cluster-dim-y" = 1 : i32,
+  "ttg.cluster-dim-z" = 2 : i32,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  "ttg.threads-per-warp" = 32 : i32,
+  ttg.target = "cuda:90"
+} {
+  // CHECK-LABEL: @z_axis_broadcast
+  tt.func public @z_axis_broadcast(
+      %a: !tt.tensordesc<128x64xf16, #shared>) {
+    %c0 = arith.constant 0 : i32
+    // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 2>}
+    %v = tt.descriptor_load %a[%c0, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @z_axis_dependent
+  tt.func public @z_axis_dependent(
+      %a: !tt.tensordesc<128x64xf16, #shared>) {
+    %z = tt.get_program_id z : i32
+    %c0 = arith.constant 0 : i32
+    // CHECK-NOT: tt.multicast_axes
+    %v = tt.descriptor_load %a[%z, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @z_axis_uniform_quotient
+  tt.func public @z_axis_uniform_quotient(
+      %a: !tt.tensordesc<128x64xf16, #shared>, %limit: i32) {
+    %z = tt.get_program_id z : i32
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c2 = arith.constant 2 : i32
+    %cluster_z = arith.divui %z, %c2 : i32
+    scf.for %i = %cluster_z to %limit step %c1 : i32 {
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 2>}
+      %v = tt.descriptor_load %a[%c0, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @z_axis_wrong_divisor
+  tt.func public @z_axis_wrong_divisor(
+      %a: !tt.tensordesc<128x64xf16, #shared>, %limit: i32) {
+    %z = tt.get_program_id z : i32
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c3 = arith.constant 3 : i32
+    %bad_cluster_z = arith.divui %z, %c3 : i32
+    scf.for %i = %bad_cluster_z to %limit step %c1 : i32 {
+      // CHECK-NOT: tt.multicast_axes
+      %v = tt.descriptor_load %a[%c0, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+}
+
+module attributes {
+  "ttg.cluster-dim-x" = 2 : i32,
+  "ttg.cluster-dim-y" = 2 : i32,
+  "ttg.cluster-dim-z" = 1 : i32,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  "ttg.threads-per-warp" = 32 : i32,
+  ttg.target = "cuda:90"
+} {
+  // CHECK-LABEL: @meta_ws_plan
+  tt.func public @meta_ws_plan(
+      %a: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %k = arith.constant 0 : i32
+    // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+    %v = tt.descriptor_load %a[%x, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/tma_multicast_computed_descriptors.mlir
+++ b/test/TritonNvidiaGPU/tma_multicast_computed_descriptors.mlir
@@ -1,0 +1,163 @@
+// RUN: triton-opt %s --triton-nvidia-plan-tma-multicast | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+
+module attributes {
+  "ttg.cluster-dim-x" = 2 : i32,
+  "ttg.cluster-dim-y" = 2 : i32,
+  "ttg.cluster-dim-z" = 1 : i32,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  "ttg.threads-per-warp" = 32 : i32,
+  ttg.target = "cuda:90"
+} {
+  // CHECK-LABEL: @invariant_computed_descriptors
+  tt.func public @invariant_computed_descriptors(
+      %base: !tt.ptr<f16>, %raw_desc: !tt.ptr<i8>) {
+    %pid_x = tt.get_program_id x : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c64_i64 = arith.constant 64 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %desc = tt.make_tensor_descriptor %base, [%c128_i32, %c64_i32],
+        [%c64_i64, %c1_i64] : !tt.ptr<f16>,
+        !tt.tensordesc<128x64xf16, #shared>
+    // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+    %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+        !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    %reinterpreted = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+    %1 = tt.descriptor_load %reinterpreted[%pid_x, %c0_i32] {multicast = true} :
+        !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // The recipient group spans Y at a fixed X, but lowering synchronizes the
+  // full cluster. An X-dependent branch must therefore remain non-multicast.
+  // CHECK-LABEL: @subgroup_uniform_cluster_divergent
+  tt.func public @subgroup_uniform_cluster_divergent(
+      %raw_desc: !tt.ptr<i8>) {
+    %pid_x = tt.get_program_id x : i32
+    %c0_i32 = arith.constant 0 : i32
+    %is_x0 = arith.cmpi eq, %pid_x, %c0_i32 : i32
+    %desc = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    scf.if %is_x0 {
+      // CHECK-NOT: tt.multicast_axes
+      // CHECK: tt.descriptor_load
+      %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+          !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @cluster_uniform_condition
+  tt.func public @cluster_uniform_condition(
+      %raw_desc: !tt.ptr<i8>, %enabled: i1) {
+    %pid_x = tt.get_program_id x : i32
+    %c0_i32 = arith.constant 0 : i32
+    %desc = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    scf.if %enabled {
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+      %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+          !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @cluster_divergent_while_condition
+  tt.func public @cluster_divergent_while_condition(
+      %raw_desc: !tt.ptr<i8>) {
+    %pid_x = tt.get_program_id x : i32
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %desc = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    %result = scf.while (%keep = %true) : (i1) -> i1 {
+      %next = arith.cmpi eq, %pid_x, %c0_i32 : i32
+      scf.condition(%next) %next : i1
+    } do {
+    ^bb0(%keep: i1):
+      // CHECK-NOT: tt.multicast_axes
+      // CHECK: tt.descriptor_load
+      %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+          !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      scf.yield %keep : i1
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @cluster_uniform_while_condition
+  tt.func public @cluster_uniform_while_condition(
+      %raw_desc: !tt.ptr<i8>, %enabled: i1) {
+    %pid_x = tt.get_program_id x : i32
+    %c0_i32 = arith.constant 0 : i32
+    %desc = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    %result = scf.while (%keep = %enabled) : (i1) -> i1 {
+      scf.condition(%keep) %keep : i1
+    } do {
+    ^bb0(%keep: i1):
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+      %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+          !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      scf.yield %keep : i1
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @pid_dependent_descriptor
+  tt.func public @pid_dependent_descriptor(
+      %base0: !tt.ptr<f16>, %base1: !tt.ptr<f16>) {
+    %pid_x = tt.get_program_id x : i32
+    %pid_y = tt.get_program_id y : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c64_i64 = arith.constant 64 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %is_y0 = arith.cmpi eq, %pid_y, %c0_i32 : i32
+    %base = arith.select %is_y0, %base0, %base1 : !tt.ptr<f16>
+    %desc = tt.make_tensor_descriptor %base, [%c128_i32, %c64_i32],
+        [%c64_i64, %c1_i64] : !tt.ptr<f16>,
+        !tt.tensordesc<128x64xf16, #shared>
+    // CHECK-NOT: tt.multicast_axes
+    // CHECK: tt.descriptor_load
+    %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+        !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @unsupported_region
+  tt.func public @unsupported_region(%raw_desc: !tt.ptr<i8>) {
+    %pid_x = tt.get_program_id x : i32
+    %c0_i32 = arith.constant 0 : i32
+    %desc = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    // CHECK: scf.execute_region
+    // CHECK-NOT: tt.multicast_axes
+    // CHECK: tt.descriptor_load
+    scf.execute_region {
+      %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+          !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      scf.yield
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @private_helper
+  tt.func private @private_helper(%raw_desc: !tt.ptr<i8>, %offset: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %desc = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    // CHECK-NOT: tt.multicast_axes
+    // CHECK: tt.descriptor_load
+    %0 = tt.descriptor_load %desc[%offset, %c0_i32] {multicast = true} :
+        !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -886,6 +886,7 @@ class CUDABackend(BaseBackend):
                 and opt.ctas_per_cga is not None and opt.allowDependentTwoCTA):
             nvidia.passes.hopper.add_plan_2cta_exchange(pm)
         nvidia.passes.ttnvgpuir.add_optimize_descriptor_encoding(pm)
+        nvidia.passes.ttnvgpuir.add_tma_multicast(pm)
         passes.ttir.add_loop_aware_cse(pm)
         if capability // 10 in [8, 9]:
             passes.ttgpuir.add_fuse_nested_loops(pm)

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -198,6 +198,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module_ &m) {
                      ttng::createTritonNvidiaGPUTMemBarrierInsertionPass);
   ADD_PASS_WRAPPER_0("add_tma_lowering",
                      ttng::createTritonNvidiaGPUTMALoweringPass);
+  ADD_PASS_WRAPPER_0("add_tma_multicast",
+                     ttng::createTritonNvidiaGPUTMAMulticastPass);
   ADD_PASS_WRAPPER_1("add_promote_load_to_tma", createPromoteLoadToTMAWrapper,
                      bool);
   ADD_PASS_WRAPPER_0("add_tma_store_buffer_reuse",

--- a/unittest/Analysis/CMakeLists.txt
+++ b/unittest/Analysis/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_triton_ut(
   NAME TestTritonAnalysis
-  SRCS UtilityTest.cpp
+  SRCS UtilityTest.cpp TMAMulticastTest.cpp
   LIBS
     TritonAnalysis
     TritonIR

--- a/unittest/Analysis/TMAMulticastTest.cpp
+++ b/unittest/Analysis/TMAMulticastTest.cpp
@@ -1,0 +1,65 @@
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.h"
+
+#include "llvm/ADT/SmallBitVector.h"
+#include <gtest/gtest.h>
+
+using mlir::triton::nvidia_gpu::TMAClusterGeometry;
+
+namespace {
+
+llvm::SmallBitVector axes(std::initializer_list<unsigned> values) {
+  llvm::SmallBitVector result(3);
+  for (unsigned value : values)
+    result.set(value);
+  return result;
+}
+
+TEST(TMAMulticastGeometry, RankCoordinatesAreXMajor) {
+  TMAClusterGeometry geometry{{2, 4, 1}};
+  EXPECT_EQ(geometry.size(), 8u);
+  EXPECT_EQ(geometry.coordinates(0), (llvm::SmallVector<int, 3>{0, 0, 0}));
+  EXPECT_EQ(geometry.coordinates(3), (llvm::SmallVector<int, 3>{1, 1, 0}));
+  EXPECT_EQ(geometry.coordinates(7), (llvm::SmallVector<int, 3>{1, 3, 0}));
+}
+
+TEST(TMAMulticastGeometry, OneDimensionalGroups) {
+  for (int size : {2, 4, 8}) {
+    TMAClusterGeometry geometry{{size, 1, 1}};
+    uint16_t fullMask = uint16_t((1u << size) - 1);
+    for (unsigned rank = 0; rank < geometry.size(); ++rank) {
+      EXPECT_EQ(geometry.maskFor(rank, axes({0})), fullMask);
+      EXPECT_EQ(geometry.leaderFor(rank, axes({0})), 0u);
+    }
+  }
+}
+
+TEST(TMAMulticastGeometry, RectangularOperandGroups) {
+  TMAClusterGeometry geometry{{2, 4, 1}};
+  EXPECT_EQ(geometry.maskFor(0, axes({1})), 0x55);
+  EXPECT_EQ(geometry.maskFor(1, axes({1})), 0xaa);
+  EXPECT_EQ(geometry.leaderFor(7, axes({1})), 1u);
+  EXPECT_EQ(geometry.maskFor(0, axes({0})), 0x03);
+  EXPECT_EQ(geometry.maskFor(5, axes({0})), 0x30);
+  EXPECT_EQ(geometry.leaderFor(7, axes({0})), 6u);
+}
+
+TEST(TMAMulticastGeometry, ThreeDimensionalGroups) {
+  TMAClusterGeometry geometry{{2, 2, 2}};
+  EXPECT_EQ(geometry.coordinates(4), (llvm::SmallVector<int, 3>{0, 0, 1}));
+  EXPECT_EQ(geometry.coordinates(7), (llvm::SmallVector<int, 3>{1, 1, 1}));
+  EXPECT_EQ(geometry.maskFor(0, axes({2})), 0x11);
+  EXPECT_EQ(geometry.maskFor(3, axes({2})), 0x88);
+  EXPECT_EQ(geometry.leaderFor(7, axes({2})), 3u);
+  EXPECT_EQ(geometry.maskFor(0, axes({1, 2})), 0x55);
+  EXPECT_EQ(geometry.maskFor(1, axes({1, 2})), 0xaa);
+}
+
+TEST(TMAMulticastGeometry, SingletonWhenNoAxisBroadcasts) {
+  TMAClusterGeometry geometry{{4, 2, 1}};
+  for (unsigned rank = 0; rank < geometry.size(); ++rank) {
+    EXPECT_EQ(geometry.maskFor(rank, axes({})), uint16_t(1u << rank));
+    EXPECT_EQ(geometry.leaderFor(rank, axes({})), rank);
+  }
+}
+
+} // namespace


### PR DESCRIPTION
Summary:

Adds fail-closed TMA multicast planning with consolidated CLC coordinate semantics, cluster-uniform control-flow proofs, static persistent coordinate recognition, and X/Y/Z plus multi-axis coverage. Unsupported dependencies conservatively retain per-CTA loads.

Reviewed By: manman-ren

Differential Revision: D112873506


