### PR TITLE
[AutoWS] [Tile-Scheduler] Add explicit testing for validating the atomic broadcast path with AutoWS (#2264) (#2264)

### DIFF
--- a/docs/programming-guide/chapter-3/fpsan.rst
+++ b/docs/programming-guide/chapter-3/fpsan.rst
@@ -280,7 +280,7 @@ Exact preserved properties:
 - ``exp2(-x) = 1.0 / exp2(x)``
 
 ``exp``
-=======
+-------
 
 Supported operation:
 

--- a/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
+++ b/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
@@ -6,6 +6,30 @@
 
 namespace mlir::triton {
 
+inline constexpr StringLiteral kNumStagesAttrName = "tt.num_stages";
+inline constexpr StringLiteral kDisallowAccMultiBufferAttrName =
+    "tt.disallow_acc_multi_buffer";
+inline constexpr StringLiteral kWarpSpecializeAttrName = "tt.warp_specialize";
+inline constexpr StringLiteral kScheduledMaxStageAttrName =
+    "tt.scheduled_max_stage";
+
+enum class AutoWSLoopAttrPropagation {
+  NotForwarded,
+  ForwardToInnerLoop,
+};
+
+struct AutoWSLoopAttrInfo {
+  StringLiteral name;
+  AutoWSLoopAttrPropagation propagation;
+};
+
+// Returns every loop attribute emitted by AutoWSLoopOptions and whether it must
+// be propagated when an annotated scheduler loop is removed.
+ArrayRef<AutoWSLoopAttrInfo> getAutoWSLoopAttrs();
+
+[[nodiscard]] SmallVector<NamedAttribute>
+filterAutoWSLoopAttrs(Operation *op, AutoWSLoopAttrPropagation propagation);
+
 // Filter out attributes from the given operation that are not present in
 // the allowList.
 [[nodiscard]] SmallVector<NamedAttribute>

--- a/include/triton/Dialect/Triton/Transforms/Passes.td
+++ b/include/triton/Dialect/Triton/Transforms/Passes.td
@@ -78,6 +78,14 @@ def TritonSimplifySingleTripWhile : Pass</*cli-arg*/"triton-simplify-single-trip
     again on the yielded values to produce them. Broader conditions (computed
     condition expressions) are not handled and could be added later via constant
     folding of the condition.
+
+    When the while carries `tt.warp_specialize`, the pass forwards the AutoWS
+    attributes that still have downstream consumers to `scf.for` loops exactly
+    one loop-nesting level inside it. Intervening non-loop control flow such as
+    `scf.if` does not add a nesting level. The shared AutoWS loop attribute
+    registry defines the complete attribute inventory and whether each
+    attribute needs forwarding. If no such loop exists, the annotated while is
+    preserved rather than silently dropping warp specialization.
   }];
 
   let dependentDialects = [

--- a/include/triton/Dialect/TritonGPU/Transforms/Partition.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Partition.h
@@ -8,13 +8,11 @@
 #include "llvm/ADT/StringRef.h"
 
 namespace mlir {
+class LoopLikeOpInterface;
 class Operation;
 class OpOperand;
 class OpResult;
 class Region;
-namespace scf {
-class ForOp;
-} // namespace scf
 } // namespace mlir
 
 static constexpr char kPartitionTypesAttrName[] = "ttg.partition.types";
@@ -46,23 +44,23 @@ public:
   // from a different partition or a previous iteration of the current
   // partition. E.g. partition B(i) may have inputs from A(i) or B(i-1). Note
   // that the same value may be visited more than once.
-  void iterateInputs(scf::ForOp loop,
+  void iterateInputs(LoopLikeOpInterface loop,
                      function_ref<void(OpOperand &)> callback) const;
   // Iterate the outputs of the partition. Output values are those that are
   // consumed by a different partition or a future iteration of the current
   // partition. E.g. partition A(i) may have outputs to B(i) or A(i+1). Note
   // that the same value may be visited more than once.
   void
-  iterateOutputs(scf::ForOp loop,
+  iterateOutputs(LoopLikeOpInterface loop,
                  function_ref<void(Operation *, OpOperand &)> callback) const;
   // Iterate the defining ops of the inputs to the partition in the current and
   // previous iterations, including the distance in the past.
-  void iterateDefs(scf::ForOp loop,
+  void iterateDefs(LoopLikeOpInterface loop,
                    function_ref<void(OpResult, unsigned)> callback) const;
   // Iterate the uses of all outputs of the partition in the current iteration
   // and in future iterations, including the distance in the future.
   void iterateUses(
-      scf::ForOp loop,
+      LoopLikeOpInterface loop,
       function_ref<void(OpResult, OpOperand &, unsigned)> callback) const;
 
 private:
@@ -101,12 +99,12 @@ public:
   // Get the number of partitions.
   unsigned getNumPartitions() const { return partitions.size(); }
 
-  // Deserialize a partition set from an `scf.for` op using the attributes
-  // tagged on operations in its body.
-  static FailureOr<PartitionSet> fromLoop(scf::ForOp loop);
+  // Deserialize a partition set from a supported loop using the attributes
+  // tagged on operations in its scheduled body.
+  static FailureOr<PartitionSet> fromLoop(LoopLikeOpInterface loop);
 
   // Serialize the partition set to the loop attributes.
-  void serialize(scf::ForOp loop) const;
+  void serialize(LoopLikeOpInterface loop) const;
 
   // Debug dump the partition set.
   LLVM_DUMP_METHOD void dump() const;
@@ -115,7 +113,7 @@ public:
   Partition *getPartition(Operation *op);
 
   // Swap two partitions' indices and update all op annotations in the loop.
-  void swapPartitions(unsigned idxA, unsigned idxB, scf::ForOp loop);
+  void swapPartitions(unsigned idxA, unsigned idxB, LoopLikeOpInterface loop);
 
 private:
   // WarpSpecialization tag

--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -3,6 +3,7 @@
 
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/DiscardableAttributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include <optional>
 #include <utility>
@@ -13,13 +14,8 @@ class DominanceInfo;
 class ImplicitLocOpBuilder;
 namespace triton {
 
-static const char *kNumStagesAttrName = "tt.num_stages";
-static const char *kDisallowAccMultiBufferAttrName =
-    "tt.disallow_acc_multi_buffer";
-static const char *kWarpSpecializeAttrName = "tt.warp_specialize";
 static const char *kLoopStageAttrName = "loop.stage";
 static const char *kLoopClusterAttrName = "loop.cluster";
-static const char *kScheduledMaxStageAttrName = "tt.scheduled_max_stage";
 class CoarseSchedule;
 class ModuleAxisInfoAnalysis;
 //===----------------------------------------------------------------------===//

--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -9,6 +9,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include <algorithm>
 #include <numeric>
+#include <utility>
 
 namespace mlir {
 class DominanceInfo;
@@ -208,6 +209,31 @@ struct LoopCarriedSlot {
 // Build the slot descriptor for iter-arg index `k`
 // (k < loop.getRegionIterArgs().size()).
 LoopCarriedSlot getLoopCarriedSlot(LoopLikeOpInterface loop, unsigned k);
+
+// Return the single block/region that partition scheduling treats as the loop
+// body. For scf.while this is the "after" region; the "before" region is loop
+// control and is replicated later by task-id propagation.
+Block *getLoopBodyBlock(LoopLikeOpInterface loop);
+Region &getLoopBodyRegion(LoopLikeOpInterface loop);
+Operation *getLoopBodyTerminator(LoopLikeOpInterface loop);
+ValueRange getLoopYieldedValues(LoopLikeOpInterface loop);
+
+// Return the induction variable for scf.for, or a null Value for scf.while.
+Value getLoopInductionVar(LoopLikeOpInterface loop);
+
+// Trace a loop-carried value to its defining result and iteration distance.
+// Returns a null result and zero distance for non-carried values and cycles.
+std::pair<OpResult, int64_t>
+getLoopDefinitionAndDistance(LoopLikeOpInterface loop, Value value);
+
+// Map carried-value slot `k` to its argument in the scheduled body.
+BlockArgument getLoopCarriedBodyArg(LoopLikeOpInterface loop, unsigned k);
+
+// Partition scheduling supports scf.while only when scf.condition forwards
+// every before-region argument exactly once and in the same order. scf.for is
+// identity-carry by construction; other LoopLikeOpInterface implementations
+// are unsupported.
+bool hasIdentityLoopCarry(LoopLikeOpInterface loop);
 
 Operation *cloneWithInferType(mlir::OpBuilder &rewriter, Operation *op,
                               IRMapping &mapping);

--- a/lib/Dialect/Triton/IR/DiscardableAttributes.cpp
+++ b/lib/Dialect/Triton/IR/DiscardableAttributes.cpp
@@ -1,7 +1,44 @@
-#include "mlir/Support/LLVM.h"
-#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/DiscardableAttributes.h"
 
 namespace mlir::triton {
+
+static constexpr AutoWSLoopAttrInfo kAutoWSLoopAttrs[] = {
+    {kNumStagesAttrName, AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.loop_unroll_factor", AutoWSLoopAttrPropagation::NotForwarded},
+    {kDisallowAccMultiBufferAttrName,
+     AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.flatten", AutoWSLoopAttrPropagation::NotForwarded},
+    {kWarpSpecializeAttrName, AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.multi_cta", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"llvm.loop_annotation", AutoWSLoopAttrPropagation::NotForwarded},
+    {"tt.data_partition_factor", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.list_schedule_pick", AutoWSLoopAttrPropagation::NotForwarded},
+    {"tt.mem_plan_pick", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.merge_epilogue", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.merge_epilogue_to_computation",
+     AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.merge_correction", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.separate_epilogue_store",
+     AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.tmem_alloc_algo", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.smem_alloc_algo", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.smem_budget", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    {"tt.smem_circular_reuse", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+};
+
+ArrayRef<AutoWSLoopAttrInfo> getAutoWSLoopAttrs() { return kAutoWSLoopAttrs; }
+
+SmallVector<NamedAttribute>
+filterAutoWSLoopAttrs(Operation *op, AutoWSLoopAttrPropagation propagation) {
+  SmallVector<NamedAttribute> attrs;
+  for (const AutoWSLoopAttrInfo &attrInfo : getAutoWSLoopAttrs()) {
+    if (attrInfo.propagation != propagation)
+      continue;
+    if (Attribute attr = op->getDiscardableAttr(attrInfo.name))
+      attrs.emplace_back(attrInfo.name, attr);
+  }
+  return attrs;
+}
 
 SmallVector<NamedAttribute>
 filterDiscardableAttrs(Operation *op, ArrayRef<StringRef> allowList) {

--- a/lib/Dialect/Triton/Transforms/SimplifySingleTripWhile.cpp
+++ b/lib/Dialect/Triton/Transforms/SimplifySingleTripWhile.cpp
@@ -2,9 +2,11 @@
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/DiscardableAttributes.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"
 #include "llvm/Support/Debug.h"
 
@@ -65,6 +67,34 @@ static bool isSingleTripConstantFlip(scf::WhileOp whileOp) {
     return false;
   return isConstantBool(whileOp.getInits()[c], /*expected=*/true) &&
          isConstantBool(yieldOp.getResults()[c], /*expected=*/false);
+}
+
+// Forward AutoWS to for loops exactly one loop-nesting level inside the
+// scheduler while. Intervening non-loop control flow, such as scf.if, does not
+// add a nesting level. Existing inner-loop settings take precedence.
+static bool forwardAutoWSToInnerLoops(scf::WhileOp whileOp) {
+  if (!whileOp->hasAttr(kWarpSpecializeAttrName))
+    return true;
+
+  SmallVector<scf::ForOp> innerLoops;
+  whileOp.getAfter().walk([&](scf::ForOp forOp) {
+    LoopLikeOpInterface parentLoop =
+        forOp->getParentOfType<LoopLikeOpInterface>();
+    if (parentLoop && parentLoop.getOperation() == whileOp.getOperation())
+      innerLoops.push_back(forOp);
+  });
+  if (innerLoops.empty())
+    return false;
+
+  SmallVector<NamedAttribute> attrs = filterAutoWSLoopAttrs(
+      whileOp, AutoWSLoopAttrPropagation::ForwardToInnerLoop);
+  for (scf::ForOp forOp : innerLoops) {
+    for (NamedAttribute attr : attrs) {
+      if (!forOp->hasAttr(attr.getName()))
+        forOp->setAttr(attr.getName(), attr.getValue());
+    }
+  }
+  return true;
 }
 
 // Clone the (pure) before-region ops under `argMap` (before-arg -> concrete
@@ -129,12 +159,18 @@ class SimplifySingleTripWhilePass
 public:
   void runOnOperation() override {
     SmallVector<scf::WhileOp> loops;
-    getOperation()->walk([&](scf::WhileOp whileOp) {
+    getOperation()->walk<WalkOrder::PostOrder>([&](scf::WhileOp whileOp) {
       if (isSingleTripConstantFlip(whileOp))
         loops.push_back(whileOp);
     });
 
     for (scf::WhileOp whileOp : loops) {
+      if (!forwardAutoWSToInnerLoops(whileOp)) {
+        LDBG("Keeping annotated single-trip while without a first-level inner "
+             "loop: "
+             << whileOp);
+        continue;
+      }
       LDBG("Simplifying single-trip while: " << whileOp);
       rewriteSingleTripWhile(whileOp);
     }

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -903,6 +903,89 @@ LoopCarriedSlot getLoopCarriedSlot(LoopLikeOpInterface loop, unsigned k) {
   return slot;
 }
 
+Block *getLoopBodyBlock(LoopLikeOpInterface loop) {
+  if (auto forOp = dyn_cast<scf::ForOp>(loop.getOperation()))
+    return forOp.getBody();
+  if (auto whileOp = dyn_cast<scf::WhileOp>(loop.getOperation()))
+    return whileOp.getAfterBody();
+  llvm_unreachable("unsupported loop type");
+}
+
+Region &getLoopBodyRegion(LoopLikeOpInterface loop) {
+  if (auto forOp = dyn_cast<scf::ForOp>(loop.getOperation()))
+    return forOp.getBodyRegion();
+  if (auto whileOp = dyn_cast<scf::WhileOp>(loop.getOperation()))
+    return whileOp.getAfter();
+  llvm_unreachable("unsupported loop type");
+}
+
+Operation *getLoopBodyTerminator(LoopLikeOpInterface loop) {
+  return getLoopBodyBlock(loop)->getTerminator();
+}
+
+ValueRange getLoopYieldedValues(LoopLikeOpInterface loop) {
+  return getLoopBodyTerminator(loop)->getOperands();
+}
+
+Value getLoopInductionVar(LoopLikeOpInterface loop) {
+  if (auto forOp = dyn_cast<scf::ForOp>(loop.getOperation()))
+    return forOp.getInductionVar();
+  if (isa<scf::WhileOp>(loop.getOperation()))
+    return {};
+  llvm_unreachable("unsupported loop type");
+}
+
+std::pair<OpResult, int64_t>
+getLoopDefinitionAndDistance(LoopLikeOpInterface loop, Value value) {
+  int64_t distance = 0;
+  DenseSet<Value> seen;
+  Block *body = getLoopBodyBlock(loop);
+  Value inductionVar = getLoopInductionVar(loop);
+  while (auto arg = dyn_cast<BlockArgument>(value)) {
+    if (arg.getOwner() != body || arg == inductionVar)
+      return {nullptr, 0};
+    unsigned slot = arg.getArgNumber();
+    if (isa<scf::ForOp>(loop.getOperation())) {
+      assert(slot > 0 && "expected a carried argument, not the induction var");
+      --slot;
+    }
+    ++distance;
+    value = getLoopYieldedValues(loop)[slot];
+    if (!seen.insert(value).second)
+      return {nullptr, 0};
+  }
+  return {dyn_cast<OpResult>(value), distance};
+}
+
+BlockArgument getLoopCarriedBodyArg(LoopLikeOpInterface loop, unsigned k) {
+  if (auto forOp = dyn_cast<scf::ForOp>(loop.getOperation()))
+    return forOp.getRegionIterArg(k);
+  if (isa<scf::WhileOp>(loop.getOperation())) {
+    BlockArgument afterArg = getLoopCarriedSlot(loop, k).afterArg;
+    assert(afterArg && "scf.while must identity-forward every carried value");
+    return afterArg;
+  }
+  llvm_unreachable("unsupported loop type");
+}
+
+bool hasIdentityLoopCarry(LoopLikeOpInterface loop) {
+  if (isa<scf::ForOp>(loop.getOperation()))
+    return true;
+  auto whileOp = dyn_cast<scf::WhileOp>(loop.getOperation());
+  if (!whileOp)
+    return false;
+
+  auto beforeArgs = loop.getRegionIterArgs();
+  auto forwarded = whileOp.getConditionOp().getArgs();
+  if (forwarded.size() != beforeArgs.size() ||
+      whileOp.getAfterArguments().size() != beforeArgs.size() ||
+      getLoopYieldedValues(loop).size() != beforeArgs.size())
+    return false;
+  return llvm::all_of(llvm::enumerate(forwarded), [&](auto indexedValue) {
+    return indexedValue.value() == beforeArgs[indexedValue.index()];
+  });
+}
+
 scf::IfOp replaceIfOpWithNewSignature(OpBuilder &rewriter, scf::IfOp ifOp,
                                       TypeRange newResultTypes) {
   SmallVector<std::tuple<Value, Value>> replacements;

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/Partition.cpp
@@ -24,8 +24,9 @@ bool Partition::hasOp(Operation *op) const {
   return partitionIds.contains(getIndex());
 }
 
-void Partition::iterateInputs(scf::ForOp loop,
+void Partition::iterateInputs(LoopLikeOpInterface loop,
                               function_ref<void(OpOperand &)> callback) const {
+  Block *body = getLoopBodyBlock(loop);
   for (Operation *op : getOps()) {
     visitNestedOperands(op, [&](OpOperand &operand) {
       // Ignore implicit captures.
@@ -33,21 +34,20 @@ void Partition::iterateInputs(scf::ForOp loop,
       std::optional<SetVector<int>> partitionIds;
       if (hasPartition(value.getDefiningOp()))
         partitionIds = getPartitionIds(value.getDefiningOp());
-      if (value.getParentBlock() != loop.getBody())
+      if (value.getParentBlock() != body)
         return;
       if (auto arg = dyn_cast<BlockArgument>(value)) {
-        assert(arg.getOwner() == loop.getBody());
+        assert(arg.getOwner() == body);
         // Ignore the induction variable.
-        if (arg == loop.getInductionVar())
+        if (arg == getLoopInductionVar(loop))
           return;
         // This value originates from a previous iteration.
-        assert(llvm::is_contained(loop.getRegionIterArgs(), arg));
         callback(operand);
       } else {
         if (!partitionIds || !partitionIds->contains(getIndex())) {
           // This value originates from a different partition in the same
           // iteration.
-          assert(value.getDefiningOp()->getParentOp() == loop);
+          assert(value.getDefiningOp()->getParentOp() == loop.getOperation());
           callback(operand);
         }
       }
@@ -56,11 +56,13 @@ void Partition::iterateInputs(scf::ForOp loop,
 }
 
 void Partition::iterateOutputs(
-    scf::ForOp loop,
+    LoopLikeOpInterface loop,
     function_ref<void(Operation *, OpOperand &)> callback) const {
+  Block *body = getLoopBodyBlock(loop);
+  Operation *terminator = getLoopBodyTerminator(loop);
   for (Operation *op : getOps()) {
     for (OpOperand &use : op->getUses()) {
-      Operation *owner = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
+      Operation *owner = body->findAncestorOpInBlock(*use.getOwner());
 
       // Handle post-loop operations.
       if (!owner) {
@@ -76,7 +78,7 @@ void Partition::iterateOutputs(
       std::optional<SetVector<int>> partitionIds;
       if (hasPartition(owner))
         partitionIds = getPartitionIds(owner);
-      if (isa<scf::YieldOp>(owner)) {
+      if (owner == terminator) {
         // This value is used in a subsequent iteration.
         callback(owner, use);
       } else {
@@ -90,16 +92,17 @@ void Partition::iterateOutputs(
 }
 
 void Partition::iterateDefs(
-    scf::ForOp loop, function_ref<void(OpResult, unsigned)> callback) const {
+    LoopLikeOpInterface loop,
+    function_ref<void(OpResult, unsigned)> callback) const {
   iterateInputs(loop, [&](OpOperand &input) {
-    auto [def, distance] = getDefinitionAndDistance(loop, input.get());
-    if (def && def.getParentBlock() == loop.getBody())
+    auto [def, distance] = getLoopDefinitionAndDistance(loop, input.get());
+    if (def && def.getParentBlock() == getLoopBodyBlock(loop))
       callback(def, distance);
   });
 }
 
 void Partition::iterateUses(
-    scf::ForOp loop,
+    LoopLikeOpInterface loop,
     function_ref<void(OpResult, OpOperand &, unsigned)> callback) const {
   SmallVector<std::tuple<OpResult, OpOperand *, unsigned>> uses;
   iterateOutputs(loop, [&](Operation *owner, OpOperand &use) {
@@ -107,7 +110,8 @@ void Partition::iterateUses(
   });
   while (!uses.empty()) {
     auto [output, use, distance] = uses.pop_back_val();
-    Operation *owner = loop.getBody()->findAncestorOpInBlock(*use->getOwner());
+    Operation *owner =
+        getLoopBodyBlock(loop)->findAncestorOpInBlock(*use->getOwner());
 
     // Handle post-loop operations.
     if (!owner) {
@@ -116,11 +120,11 @@ void Partition::iterateUses(
       continue;
     }
 
-    if (!isa<scf::YieldOp>(owner)) {
+    if (owner != getLoopBodyTerminator(loop)) {
       callback(output, *use, distance);
       continue;
     }
-    BlockArgument arg = loop.getRegionIterArg(use->getOperandNumber());
+    BlockArgument arg = getLoopCarriedBodyArg(loop, use->getOperandNumber());
     for (OpOperand &use : arg.getUses())
       uses.emplace_back(output, &use, distance + 1);
   }
@@ -150,7 +154,7 @@ Partition *PartitionSet::getPartition(Operation *op) {
 }
 
 void PartitionSet::swapPartitions(unsigned idxA, unsigned idxB,
-                                  scf::ForOp loop) {
+                                  LoopLikeOpInterface loop) {
   if (idxA == idxB)
     return;
 
@@ -183,7 +187,11 @@ void PartitionSet::swapPartitions(unsigned idxA, unsigned idxB,
   });
 }
 
-FailureOr<PartitionSet> PartitionSet::fromLoop(scf::ForOp loop) {
+FailureOr<PartitionSet> PartitionSet::fromLoop(LoopLikeOpInterface loop) {
+  // Validate at this API boundary even when the caller already gated the loop.
+  if (!isa<scf::ForOp, scf::WhileOp>(loop.getOperation()) ||
+      !hasIdentityLoopCarry(loop))
+    return failure();
   auto stages = loop->getAttrOfType<ArrayAttr>(kPartitionStagesAttrName);
   if (!stages)
     return failure();
@@ -191,6 +199,11 @@ FailureOr<PartitionSet> PartitionSet::fromLoop(scf::ForOp loop) {
   auto tag = loop->getAttrOfType<IntegerAttr>(kWarpSpecializeTagAttrName);
   if (!tag)
     return failure();
+
+  auto types = loop->getAttrOfType<ArrayAttr>(kPartitionTypesAttrName);
+  if (types && types.size() != stages.size())
+    return mlir::emitError(loop.getLoc(), "partition types attribute '")
+           << kPartitionTypesAttrName << "' must match partition stages size";
 
   PartitionSet result;
   result.tag = tag.getInt();
@@ -201,12 +214,20 @@ FailureOr<PartitionSet> PartitionSet::fromLoop(scf::ForOp loop) {
              << kPartitionStagesAttrName << "' has invalid element " << attr;
     }
 
-    result.partitions.push_back(
-        std::make_unique<Partition>(idx, stage.getInt()));
+    auto partition = std::make_unique<Partition>(idx, stage.getInt());
+    if (types) {
+      auto type = dyn_cast<StringAttr>(types[idx]);
+      if (!type)
+        return mlir::emitError(loop.getLoc(), "partition types attribute '")
+               << kPartitionTypesAttrName << "' has invalid element "
+               << types[idx];
+      partition->setType(type.getValue());
+    }
+    result.partitions.push_back(std::move(partition));
   }
 
   SmallVector<Operation *> annotatedOps;
-  loop->walk([&](Operation *op) {
+  getLoopBodyRegion(loop).walk([&](Operation *op) {
     if (hasPartition(op)) {
       annotatedOps.push_back(op);
     }
@@ -224,12 +245,12 @@ FailureOr<PartitionSet> PartitionSet::fromLoop(scf::ForOp loop) {
   return result;
 }
 
-void PartitionSet::serialize(scf::ForOp loop) const {
+void PartitionSet::serialize(LoopLikeOpInterface loop) const {
   // In the new PartitionSet system, per-op partition attributes are already set
   // by setPartition(). We only need to serialize the partition stages array.
   SmallVector<Attribute> stages;
   SmallVector<Attribute> types;
-  Builder b(loop.getContext());
+  Builder b(loop->getContext());
   for (const Partition &partition : getPartitions()) {
     stages.push_back(b.getI32IntegerAttr(partition.getStage()));
     types.push_back(b.getStringAttr(partition.getType()));

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -368,6 +368,7 @@ def matmul_kernel_tma_unified_persistent_ws_while(
     EPILOGUE_SUBTILE: tl.constexpr,
     NUM_SMS: tl.constexpr,
     SCHEDULE: tl.constexpr,
+    OUTER_WARP_SPECIALIZE: tl.constexpr,
 ):
     dtype = tl.float16
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
@@ -377,13 +378,13 @@ def matmul_kernel_tma_unified_persistent_ws_while(
 
     lowering_args = _MatmulTileArgs(M, N, BLOCK_SIZE_M, BLOCK_SIZE_N)
     sched = SCHEDULE.initialize(lowering_args, _unified_num_tiles, tile_counter)
-    while sched.is_valid():
+    while tl.condition(sched.is_valid(), warp_specialize=OUTER_WARP_SPECIALIZE):
         pid_m, pid_n = _compute_pid(sched.tile_id[0], num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
         offs_am = pid_m * BLOCK_SIZE_M
         offs_bn = pid_n * BLOCK_SIZE_N
 
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-        for ki in tl.range(k_tiles, warp_specialize=True):
+        for ki in tl.range(k_tiles, warp_specialize=not OUTER_WARP_SPECIALIZE):
             offs_k = ki * BLOCK_SIZE_K
             a = a_desc.load([offs_am, offs_k])
             b = b_desc.load([offs_bn, offs_k])
@@ -1143,6 +1144,7 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(EPI
             EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
             NUM_SMS=NUM_SMS,
             SCHEDULE=SCHEDULE,
+            OUTER_WARP_SPECIALIZE=SCHEDULE is tl.NonPersistentScheduler,
             num_stages=num_stages,
             num_warps=num_warps,
         )
@@ -1151,7 +1153,7 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(EPI
         if SCHEDULE is tl.NonPersistentScheduler:
             # The non-persistent schedule's outer loop provably runs exactly once
             # (`_valid` flips True->False), so triton-simplify-single-trip-while
-            # optimizes the `scf.while` away at the TTIR stage.
+            # optimizes the `scf.while` away after TTGIR loop scheduling.
             assert "scf.while" not in ttgir, "Expected single-trip outer while to be optimized away"
         elif SCHEDULE is tl.StaticPersistent1DScheduler:
             # The static-persistent schedule is a countable loop (`_x < num_tiles`,

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -194,13 +194,13 @@ def matmul_kernel_tma_static_persistent_ws_while(
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
     tile_id = start_pid
 
-    while tile_id < num_tiles:
+    while tl.condition(tile_id < num_tiles, warp_specialize=True):
         pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
         offs_am = pid_m * BLOCK_SIZE_M
         offs_bn = pid_n * BLOCK_SIZE_N
 
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-        for ki in tl.range(k_tiles, warp_specialize=True):
+        for ki in range(k_tiles):
             offs_k = ki * BLOCK_SIZE_K
             a = a_desc.load([offs_am, offs_k])
             b = b_desc.load([offs_bn, offs_k])
@@ -329,13 +329,7 @@ def matmul_kernel_tma_clc_persistent_ws_while(
 
 # ============================================================================
 # Kernel 2e: matmul_kernel_tma_unified_persistent_ws_while
-# A SINGLE warp-specialized persistent matmul kernel that works with ANY of the
-# unified tile schedules (non-persistent, static/dynamic persistent, CLC): the
-# schedule class is passed as the `SCHEDULE` constexpr and the loop body is
-# identical regardless of which schedule is selected. This is the whole point of
-# the unified tile-scheduler stdlib (triton.language.schedule) -- one kernel,
-# swap the schedule to autotune. `tile_counter` is only used by the dynamic
-# schedule; the others ignore it.
+# A single outer-loop AutoWS kernel for the unified schedules.
 # ============================================================================
 class _MatmulTileArgs(NamedTuple):
     """Named ``lowering_args`` for the schedule -- the fields ``_unified_num_tiles``
@@ -345,11 +339,14 @@ class _MatmulTileArgs(NamedTuple):
     N: tl.tensor
     BLOCK_SIZE_M: tl.constexpr
     BLOCK_SIZE_N: tl.constexpr
+    NUM_CTAS: tl.constexpr
 
 
 @triton.jit
 def _unified_num_tiles(lowering_args):
-    return tl.cdiv(lowering_args.M, lowering_args.BLOCK_SIZE_M) * tl.cdiv(lowering_args.N, lowering_args.BLOCK_SIZE_N)
+    num_tiles = tl.cdiv(lowering_args.M, lowering_args.BLOCK_SIZE_M) * tl.cdiv(lowering_args.N,
+                                                                               lowering_args.BLOCK_SIZE_N)
+    return tl.cdiv(num_tiles, lowering_args.NUM_CTAS) * lowering_args.NUM_CTAS
 
 
 @triton.jit
@@ -368,7 +365,11 @@ def matmul_kernel_tma_unified_persistent_ws_while(
     EPILOGUE_SUBTILE: tl.constexpr,
     NUM_SMS: tl.constexpr,
     SCHEDULE: tl.constexpr,
-    OUTER_WARP_SPECIALIZE: tl.constexpr,
+    DATA_PARTITION_FACTOR: tl.constexpr,
+    NUM_CTAS: tl.constexpr,
+    TWO_CTAS: tl.constexpr,
+    SMEM_ALLOC_ALGO: tl.constexpr,
+    SEPARATE_EPILOGUE_STORE: tl.constexpr,
 ):
     dtype = tl.float16
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
@@ -376,19 +377,25 @@ def matmul_kernel_tma_unified_persistent_ws_while(
     k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
 
-    lowering_args = _MatmulTileArgs(M, N, BLOCK_SIZE_M, BLOCK_SIZE_N)
+    lowering_args = _MatmulTileArgs(M, N, BLOCK_SIZE_M, BLOCK_SIZE_N, NUM_CTAS)
     sched = SCHEDULE.initialize(lowering_args, _unified_num_tiles, tile_counter)
-    while tl.condition(sched.is_valid(), warp_specialize=OUTER_WARP_SPECIALIZE):
+    while tl.condition(
+            sched.is_valid(),
+            warp_specialize=True,
+            data_partition_factor=DATA_PARTITION_FACTOR,
+            separate_epilogue_store=SEPARATE_EPILOGUE_STORE,
+            smem_alloc_algo=SMEM_ALLOC_ALGO,
+    ):
         pid_m, pid_n = _compute_pid(sched.tile_id[0], num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
         offs_am = pid_m * BLOCK_SIZE_M
         offs_bn = pid_n * BLOCK_SIZE_N
 
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-        for ki in tl.range(k_tiles, warp_specialize=not OUTER_WARP_SPECIALIZE):
+        for ki in range(k_tiles):
             offs_k = ki * BLOCK_SIZE_K
             a = a_desc.load([offs_am, offs_k])
             b = b_desc.load([offs_bn, offs_k])
-            accumulator = tl.dot(a, b.T, accumulator)
+            accumulator = tl.dot(a, b.T, accumulator, two_ctas=TWO_CTAS)
 
         acc_slices = _split_n_2D(accumulator, EPILOGUE_SUBTILE)
         slice_size: tl.constexpr = BLOCK_SIZE_N // EPILOGUE_SUBTILE
@@ -1066,30 +1073,109 @@ def test_tutorial09_matmul_tma_clc_persistent_while_loop_warp_specialize(EPILOGU
 
 
 # ============================================================================
-# Test 2e: One kernel, any schedule -- pass the unified tile-scheduler class as a
-# constexpr argument. Parametrized over BOTH EPILOGUE_SUBTILE and the schedule
-# type to show the same kernel is reused across all four schedules.
+# Test 2e: Outer-loop AutoWS through a unified scheduler while.
 # ============================================================================
-_UNIFIED_SCHEDULES = [
-    tl.NonPersistentScheduler,
-    tl.StaticPersistent1DScheduler,
-    tl.DynamicPersistent1DScheduler,
-    tl.ClcTileScheduler,
+_UNIFIED_OUTER_AUTOWS_CONFIGS = [
+    pytest.param(tl.NonPersistentScheduler, 128, 128, 1, 1, 1, False, False, id="nonpersistent-baseline"),
+    pytest.param(
+        tl.NonPersistentScheduler,
+        128,
+        128,
+        4,
+        1,
+        1,
+        False,
+        True,
+        id="nonpersistent-epilogue-subtile-4",
+    ),
+    pytest.param(
+        tl.NonPersistentScheduler,
+        256,
+        128,
+        2,
+        2,
+        1,
+        False,
+        True,
+        id="nonpersistent-data-partition-2-subtile-2",
+    ),
+    pytest.param(
+        tl.NonPersistentScheduler,
+        256,
+        256,
+        1,
+        2,
+        2,
+        False,
+        True,
+        id="nonpersistent-2cta-data-partition-2",
+    ),
+    pytest.param(tl.StaticPersistent1DScheduler, 128, 128, 1, 1, 1, False, False, id="static-baseline"),
+    pytest.param(
+        tl.StaticPersistent1DScheduler,
+        128,
+        128,
+        4,
+        1,
+        1,
+        True,
+        True,
+        id="static-epilogue-subtile-4",
+    ),
+    pytest.param(
+        tl.StaticPersistent1DScheduler,
+        256,
+        128,
+        2,
+        2,
+        1,
+        True,
+        True,
+        id="static-data-partition-2-subtile-2",
+    ),
+    pytest.param(
+        tl.StaticPersistent1DScheduler,
+        256,
+        256,
+        1,
+        2,
+        2,
+        False,
+        True,
+        id="static-2cta-data-partition-2",
+    ),
+    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 1, 1, 1, False, False, id="dynamic-subtile-1"),
+    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 2, 1, 1, False, False, id="dynamic-subtile-2"),
+    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 4, 1, 1, False, False, id="dynamic-subtile-4"),
+    pytest.param(tl.ClcTileScheduler, 128, 128, 1, 1, 1, False, True, id="clc-subtile-1"),
+    pytest.param(tl.ClcTileScheduler, 128, 128, 2, 1, 1, False, True, id="clc-subtile-2"),
+    pytest.param(tl.ClcTileScheduler, 128, 128, 4, 1, 1, False, True, id="clc-subtile-4"),
 ]
 
 
 @pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell")
-@pytest.mark.parametrize("EPILOGUE_SUBTILE", [1, 2, 4])
-@pytest.mark.parametrize("SCHEDULE", _UNIFIED_SCHEDULES, ids=lambda s: s.__name__)
-def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(EPILOGUE_SUBTILE, SCHEDULE):
-    """One warp-specialized persistent matmul kernel reused across all four unified
-    tile schedules by passing the schedule class as a constexpr argument."""
-    if SCHEDULE is tl.ClcTileScheduler and is_hopper():
-        pytest.skip("CLC requires Blackwell (SM100+); not supported on Hopper")
+@pytest.mark.parametrize(
+    "SCHEDULE,BLOCK_SIZE_M,BLOCK_SIZE_N,EPILOGUE_SUBTILE,DATA_PARTITION_FACTOR,NUM_CTAS,"
+    "generate_subtiled_region,blackwell_only",
+    _UNIFIED_OUTER_AUTOWS_CONFIGS,
+)
+def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(
+    SCHEDULE,
+    BLOCK_SIZE_M,
+    BLOCK_SIZE_N,
+    EPILOGUE_SUBTILE,
+    DATA_PARTITION_FACTOR,
+    NUM_CTAS,
+    generate_subtiled_region,
+    blackwell_only,
+):
+    """Exercise outer-loop AutoWS with each unified scheduler."""
+    if blackwell_only and not is_blackwell():
+        pytest.skip("Subtiled regions, BLOCK_M=256 data partitioning, and 2-CTA require Blackwell")
+    if NUM_CTAS == 2 and SCHEDULE in (tl.DynamicPersistent1DScheduler, tl.ClcTileScheduler):
+        pytest.skip("2-CTA is not supported for dynamic or CLC scheduling")
 
     M, N, K = 2048, 2048, 256
-    BLOCK_SIZE_M = 128
-    BLOCK_SIZE_N = 128
     BLOCK_SIZE_K = 64
     GROUP_SIZE_M = 8
     num_stages = 3
@@ -1097,6 +1183,7 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(EPI
 
     with triton.knobs.nvidia.scope():
         triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.use_meta_partition = True
 
         dtype = torch.float16
         NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
@@ -1107,13 +1194,8 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(EPI
         B = torch.randn((N, K), dtype=dtype, device=device)
         C = torch.empty((M, N), dtype=dtype, device=device)
 
-        # Grid + workspace are the caller's responsibility and depend on the
-        # schedule: non-persistent / CLC launch one program per tile (CLC
-        # over-subscribes so pending clusters can be stolen); the static / dynamic
-        # persistent schedules launch min(NUM_SMS, num_tiles). The dynamic schedule
-        # additionally needs a shared atomic counter seeded past the statically
-        # launched tiles (== the number of launched programs).
-        num_tiles = triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)
+        num_tiles = triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N // NUM_CTAS)
+        num_tiles = triton.cdiv(num_tiles, NUM_CTAS) * NUM_CTAS
         if SCHEDULE in (tl.NonPersistentScheduler, tl.ClcTileScheduler):
             grid_size = num_tiles
         else:
@@ -1128,6 +1210,14 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(EPI
         a_desc = TensorDescriptor(A, A.shape, A.stride(), [BLOCK_SIZE_M, BLOCK_SIZE_K])
         b_desc = TensorDescriptor(B, B.shape, B.stride(), [BLOCK_SIZE_N, BLOCK_SIZE_K])
         c_desc = TensorDescriptor(C, C.shape, C.stride(), [BLOCK_SIZE_M, BLOCK_SIZE_N // EPILOGUE_SUBTILE])
+
+        launch_options = {
+            "num_stages": num_stages,
+            "num_warps": num_warps,
+            "generate_subtiled_region": generate_subtiled_region,
+        }
+        if NUM_CTAS == 2:
+            launch_options["ctas_per_cga"] = (2, 1, 1)
 
         kernel = matmul_kernel_tma_unified_persistent_ws_while[(grid_size, )](
             a_desc,
@@ -1144,9 +1234,12 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(EPI
             EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
             NUM_SMS=NUM_SMS,
             SCHEDULE=SCHEDULE,
-            OUTER_WARP_SPECIALIZE=SCHEDULE is tl.NonPersistentScheduler,
-            num_stages=num_stages,
-            num_warps=num_warps,
+            DATA_PARTITION_FACTOR=DATA_PARTITION_FACTOR,
+            NUM_CTAS=NUM_CTAS,
+            TWO_CTAS=NUM_CTAS == 2,
+            SMEM_ALLOC_ALGO=1 if NUM_CTAS == 2 else None,
+            SEPARATE_EPILOGUE_STORE=SCHEDULE is tl.StaticPersistent1DScheduler,
+            **launch_options,
         )
 
         ttgir = kernel.asm["ttgir"]
@@ -1161,19 +1254,24 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(EPI
             # num_tiles out of the before-region) rewrites it into an `scf.for`.
             assert "scf.while" not in ttgir, "Expected countable static-persistent while to uplift to scf.for"
         else:
-            # Dynamic (atomic advance) and CLC (hardware valid) are not countable
-            # and stay as `scf.while`.
-            assert "scf.while" in ttgir, "Expected persistent outer loop to lower to scf.while"
+            assert "scf.while" in ttgir, "Expected dynamic and CLC schedules to retain their outer while"
         assert "ttg.warp_specialize" in ttgir, "Expected warp specialization in IR"
         assert "ttng.tc_gen5_mma" in ttgir or "ttng.warp_group_dot" in ttgir, "Expected an MMA instruction"
         assert "ttng.async_tma_copy_global_to_local" in ttgir, "Expected TMA copy"
-        # Schedule-specific IR markers confirm the chosen schedule was actually used.
         if SCHEDULE is tl.ClcTileScheduler:
             assert "ttng.clc_try_cancel" in ttgir, "Expected CLC scheduling in IR"
         else:
             assert "ttng.clc_" not in ttgir, "Expected non-CLC scheduling"
         if SCHEDULE is tl.DynamicPersistent1DScheduler:
             assert "atomic" in ttgir, "Expected an atomic op driving the dynamic tile id"
+
+        mma_op = "ttng.tc_gen5_mma" if is_blackwell() else "ttng.warp_group_dot"
+        assert ttgir.count(mma_op) >= DATA_PARTITION_FACTOR, "Expected one MMA per data partition"
+        expected_stores = EPILOGUE_SUBTILE * DATA_PARTITION_FACTOR
+        assert ttgir.count("ttng.async_tma_copy_local_to_global") >= expected_stores, (
+            "Expected every epilogue subtile and data partition to emit a TMA store")
+        if NUM_CTAS == 2:
+            assert ttgir.count("two_ctas") >= DATA_PARTITION_FACTOR, "Expected 2-CTA MMA per data partition"
 
         ref_out = torch.matmul(A.to(torch.float32), B.T.to(torch.float32)).to(dtype)
         torch.testing.assert_close(ref_out, C, atol=0.03, rtol=0.03)

--- a/test/Hopper/WarpSpecialization/ws_atomic_broadcast_from_psm.mlir
+++ b/test/Hopper/WarpSpecialization/ws_atomic_broadcast_from_psm.mlir
@@ -1,0 +1,78 @@
+// RUN: triton-opt %s -split-input-file --nvgpu-partition-scheduling-meta --nvgpu-test-taskid-propagate=num-warp-groups=2 --nvgpu-test-ws-atomic-broadcast | FileCheck %s --check-prefix=BCAST
+// RUN: triton-opt %s -split-input-file --nvgpu-partition-scheduling-meta --nvgpu-test-taskid-propagate=num-warp-groups=2 --nvgpu-test-ws-atomic-broadcast=tile-prefetch-depth=2 | FileCheck %s --check-prefix=DEPTH2
+
+// Dynamic-persistent GEMM: an outer scf.while claims each tile with a scalar
+// atomic, starting UNPARTITIONED. This exercises the full front half of the
+// outer-while AutoWS path end to end -- PartitionSchedulingMeta assigns the
+// partitions directly on the scf.while (no inner-loop annotation workaround),
+// task-id propagation materializes async_task_ids, and the atomic-broadcast
+// transform turns the loop-carried scalar tile claim into a run-once-in-owner +
+// broadcast-to-all-partitions operation. Regression guard for the metadata
+// contract between PSM/task-id propagation and doDynamicTileBroadcast: the
+// atomic must reach the transform carrying the full partition union so it is
+// classified as a broadcast (not passed through per-partition, which would
+// deadlock).
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // BCAST-LABEL: @while_atomic_broadcast
+  // A single function-scope SMEM slot carries the broadcast tile id.
+  // BCAST: ttg.local_alloc : () -> !ttg.memdesc<1xi32
+  // The nested TMA loads pin the owner partition.
+  // BCAST: tt.descriptor_load {{.*}}async_task_id = array<i32: [[LOAD:[0-9]+]]>
+  // The run-once atomic executes in exactly one (the TMA-load) partition...
+  // BCAST: tt.atomic_rmw {{.*}}async_task_id = array<i32: [[LOAD]]>
+  // BCAST-NOT: tt.atomic_rmw
+  // ...splats + stores its result into the slot in that same owner partition...
+  // BCAST: tt.splat {{.*}}async_task_id = array<i32: [[LOAD]]>
+  // BCAST: ttg.local_store {{.*}}async_task_id = array<i32: [[LOAD]]>
+  // ...and every partition loads + unsplats the broadcast tile id.
+  // BCAST: ttg.local_load {{.*}}async_task_id = array<i32: 0, 1>
+  // BCAST: tt.unsplat {{.*}}async_task_id = array<i32: 0, 1>
+  // BCAST: scf.yield {{.*}}async_task_id = array<i32: 0, 1>
+  // BCAST: } attributes {
+  // BCAST-SAME: tt.warp_specialize
+  // BCAST-SAME: ttg.partition.types = ["computation", "load"]
+
+  // DEPTH2-LABEL: @while_atomic_broadcast
+  // tile-prefetch-depth=2 tags the slot for 2-deep multi-buffering (consumed by
+  // the memory planner later in the full pipeline).
+  // DEPTH2: ttg.local_alloc {ttg.atomic_broadcast_copies = 2 : i32}
+  // DEPTH2: tt.atomic_rmw
+  // DEPTH2-NOT: tt.atomic_rmw
+  // DEPTH2: tt.unsplat
+  tt.func public @while_atomic_broadcast(
+      %a_desc: !tt.tensordesc<128x64xf16, #shared>,
+      %b_desc: !tt.tensordesc<64x256xf16, #shared>,
+      %out: !tt.ptr<f32>, %counter: !tt.ptr<i32>, %k_tiles: i32, %num_tiles: i32) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %acc_init = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %start = tt.get_program_id x : i32
+    %result = scf.while (%tile = %start) : (i32) -> i32 {
+      %valid = arith.cmpi slt, %tile, %num_tiles : i32
+      scf.condition(%valid) %tile : i32
+    } do {
+    ^bb0(%tile: i32):
+      %inner = scf.for %ki = %c0 to %k_tiles step %c1 iter_args(%acc = %acc_init) -> (tensor<128x256xf32, #mma>) : i32 {
+        %a = tt.descriptor_load %a_desc[%tile, %ki] : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+        %a_alloc = ttg.local_alloc %a : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %b = tt.descriptor_load %b_desc[%ki, %tile] : !tt.tensordesc<64x256xf16, #shared> -> tensor<64x256xf16, #blocked1>
+        %b_alloc = ttg.local_alloc %b : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+        %dot = ttng.warp_group_dot %a_alloc, %b_alloc, %acc {inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+        scf.yield %dot : tensor<128x256xf32, #mma>
+      }
+      %ptrs = tt.splat %out : !tt.ptr<f32> -> tensor<128x256x!tt.ptr<f32>, #blocked1>
+      %cvt = ttg.convert_layout %inner : tensor<128x256xf32, #mma> -> tensor<128x256xf32, #blocked1>
+      tt.store %ptrs, %cvt : tensor<128x256x!tt.ptr<f32>, #blocked1>
+      %next = tt.atomic_rmw add, acq_rel, gpu, %counter, %c1, %true : (!tt.ptr<i32>, i32, i1) -> i32
+      scf.yield %next : i32
+    } attributes {tt.warp_specialize}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_while_loop_autows.mlir
+++ b/test/Hopper/WarpSpecialization/ws_while_loop_autows.mlir
@@ -1,6 +1,7 @@
 // RUN: triton-opt %s -split-input-file --nvgpu-test-taskid-propagate=num-warp-groups=2 | FileCheck %s --check-prefix=TASKID
 // RUN: triton-opt %s -split-input-file --nvgpu-ws-data-partition=num-warp-groups=3 | FileCheck %s --check-prefix=DATAPART
 // RUN: triton-opt %s -split-input-file --nvgpu-test-ws-code-partition="num-buffers=1" | FileCheck %s --check-prefix=CODEPART
+// RUN: triton-opt %s -split-input-file --nvgpu-ws-data-partition=num-warp-groups=3 --triton-simplify-single-trip-while --nvgpu-partition-scheduling-meta | FileCheck %s --check-prefix=DEFERRED
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
@@ -28,6 +29,54 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %use = arith.addi %new_off, %arg0 {async_task_id = array<i32: 1>} : i32
       scf.yield %use, %false : i32, i1
     }
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Data partitioning must see the outer while's factor before simplification.
+  // Partition scheduling must then see warp_specialize on the forwarded loop.
+  // DEFERRED-LABEL: @deferred_single_trip_while
+  // DEFERRED-NOT: scf.while
+  // DEFERRED: scf.for
+  // DEFERRED: ttng.warp_group_dot
+  // DEFERRED-SAME: ttg.partition
+  // DEFERRED: ttng.warp_group_dot
+  // DEFERRED-SAME: ttg.partition
+  // DEFERRED: } {tt.data_partition_factor = 2 : i32
+  // DEFERRED-SAME: tt.warp_specialize
+  tt.func public @deferred_single_trip_while(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %out: !tt.ptr<f32>, %k_tiles: index) {
+    %true = arith.constant true
+    %false = arith.constant false
+    %c0 = arith.constant 0 : i32
+    %c0_idx = arith.constant 0 : index
+    %c1_idx = arith.constant 1 : index
+    scf.while (%valid = %true) : (i1) -> () {
+      scf.condition(%valid)
+    } do {
+      %acc_init = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+      %inner = scf.for %ki = %c0_idx to %k_tiles step %c1_idx iter_args(%iter_acc = %acc_init) -> (tensor<128x256xf32, #mma>) {
+        %a_ptrs = tt.splat %arg0 : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+        %a = tt.load %a_ptrs : tensor<128x64x!tt.ptr<f16>, #blocked>
+        %a_alloc = ttg.local_alloc %a : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %b_ptrs = tt.splat %arg1 : !tt.ptr<f16> -> tensor<64x256x!tt.ptr<f16>, #blocked1>
+        %b = tt.load %b_ptrs : tensor<64x256x!tt.ptr<f16>, #blocked1>
+        %b_alloc = ttg.local_alloc %b : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+        %dot = ttng.warp_group_dot %a_alloc, %b_alloc, %iter_acc {inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+        scf.yield %dot : tensor<128x256xf32, #mma>
+      }
+      %ptrs = tt.splat %out : !tt.ptr<f32> -> tensor<128x256x!tt.ptr<f32>, #blocked1>
+      %cvt = ttg.convert_layout %inner : tensor<128x256xf32, #mma> -> tensor<128x256xf32, #blocked1>
+      tt.store %ptrs, %cvt : tensor<128x256x!tt.ptr<f32>, #blocked1>
+      scf.yield %false : i1
+    } attributes {tt.warp_specialize, tt.data_partition_factor = 2 : i32}
     tt.return
   }
 }

--- a/test/Hopper/WarpSpecialization/ws_while_loop_autows.mlir
+++ b/test/Hopper/WarpSpecialization/ws_while_loop_autows.mlir
@@ -2,6 +2,9 @@
 // RUN: triton-opt %s -split-input-file --nvgpu-ws-data-partition=num-warp-groups=3 | FileCheck %s --check-prefix=DATAPART
 // RUN: triton-opt %s -split-input-file --nvgpu-test-ws-code-partition="num-buffers=1" | FileCheck %s --check-prefix=CODEPART
 // RUN: triton-opt %s -split-input-file --nvgpu-ws-data-partition=num-warp-groups=3 --triton-simplify-single-trip-while --nvgpu-partition-scheduling-meta | FileCheck %s --check-prefix=DEFERRED
+// RUN: triton-opt %s -split-input-file --nvgpu-partition-scheduling-meta | FileCheck %s --check-prefix=PSM
+// RUN: triton-opt %s -split-input-file --nvgpu-partition-scheduling-meta --nvgpu-test-taskid-propagate=num-warp-groups=2 | FileCheck %s --check-prefix=PSM-TASKID
+// RUN: triton-opt %s -split-input-file --nvgpu-partition-scheduling-meta --nvgpu-partition-scheduling-meta | FileCheck %s --check-prefix=PSM-ROUNDTRIP
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
@@ -29,6 +32,155 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %use = arith.addi %new_off, %arg0 {async_task_id = array<i32: 1>} : i32
       scf.yield %use, %false : i32, i1
     }
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [8, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 4], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [16, 1], instrShape = [16, 256, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 16 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // PSM-LABEL: @while_partition_warp_budget_rejected
+  // PSM-NOT: tt.warp_specialize
+  // PSM-NOT: ttg.partition
+  // PSM: tt.return
+  tt.func public @while_partition_warp_budget_rejected(
+      %a_ptr: !tt.ptr<f16>, %b_ptr: !tt.ptr<f16>, %num_tiles: i32) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %acc_init = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %result:2 = scf.while (%tile = %c0, %acc = %acc_init) : (i32, tensor<128x256xf32, #mma>) -> (i32, tensor<128x256xf32, #mma>) {
+      %valid = arith.cmpi slt, %tile, %num_tiles : i32
+      scf.condition(%valid) %tile, %acc : i32, tensor<128x256xf32, #mma>
+    } do {
+    ^bb0(%tile: i32, %acc: tensor<128x256xf32, #mma>):
+      %a_ptrs = tt.splat %a_ptr : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+      %a = tt.load %a_ptrs : tensor<128x64x!tt.ptr<f16>, #blocked>
+      %a_alloc = ttg.local_alloc %a : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %b_ptrs = tt.splat %b_ptr : !tt.ptr<f16> -> tensor<64x256x!tt.ptr<f16>, #blocked1>
+      %b = tt.load %b_ptrs : tensor<64x256x!tt.ptr<f16>, #blocked1>
+      %b_alloc = ttg.local_alloc %b : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+      %dot = ttng.warp_group_dot %a_alloc, %b_alloc, %acc {inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+      %next = arith.addi %tile, %c1 : i32
+      scf.yield %next, %dot : i32, tensor<128x256xf32, #mma>
+    } attributes {tt.warp_specialize}
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // PSM-LABEL: @while_partition_scheduling
+  // PSM: scf.while
+  // PSM: arith.cmpi
+  // PSM: scf.condition
+  // PSM: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD:[0-9]+]]>
+  // PSM: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
+  // PSM: ttng.warp_group_dot {{.*}}ttg.partition = array<i32: [[COMPUTE:[0-9]+]]>
+  // PSM: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMPUTE]]>
+  // PSM: } attributes {
+  // PSM-SAME: tt.warp_specialize
+  // PSM-SAME: ttg.partition.stages
+  // PSM-SAME: ttg.partition.types = ["computation", "load"]
+  // PSM-SAME: ttg.warp_specialize.tag
+
+  // PSM-ROUNDTRIP-LABEL: @while_partition_scheduling
+  // PSM-ROUNDTRIP: tt.descriptor_load {{.*}}ttg.partition = array<i32: 1>
+  // PSM-ROUNDTRIP: ttng.warp_group_dot {{.*}}ttg.partition = array<i32: 0>
+  // PSM-ROUNDTRIP: } attributes {
+  // PSM-ROUNDTRIP-SAME: tt.warp_specialize
+  // PSM-ROUNDTRIP-SAME: ttg.partition.types = ["computation", "load"]
+
+  // PSM-TASKID-LABEL: @while_partition_scheduling
+  // PSM-TASKID: scf.while
+  // PSM-TASKID: arith.cmpi
+  // PSM-TASKID-SAME: async_task_id = array<i32: 0, 1>
+  // PSM-TASKID: scf.condition
+  // PSM-TASKID-SAME: async_task_id = array<i32: 0, 1>
+  // PSM-TASKID: arith.addi
+  // PSM-TASKID-SAME: async_task_id = array<i32: 0, 1>
+  // PSM-TASKID-NEXT: scf.yield
+  // PSM-TASKID-SAME: async_task_id = array<i32: 0, 1>
+  tt.func public @while_partition_scheduling(
+      %a_desc: !tt.tensordesc<128x64xf16, #shared>,
+      %b_desc: !tt.tensordesc<64x256xf16, #shared>,
+      %out: !tt.ptr<f32>, %k_tiles: i32, %num_tiles: i32) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %acc_init = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %result = scf.while (%tile = %c0) : (i32) -> i32 {
+      %valid = arith.cmpi slt, %tile, %num_tiles : i32
+      scf.condition(%valid) %tile : i32
+    } do {
+    ^bb0(%tile: i32):
+      %inner = scf.for %ki = %c0 to %k_tiles step %c1 iter_args(%acc = %acc_init) -> (tensor<128x256xf32, #mma>) : i32 {
+        %a = tt.descriptor_load %a_desc[%tile, %ki] : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+        %a_alloc = ttg.local_alloc %a : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %b = tt.descriptor_load %b_desc[%ki, %tile] : !tt.tensordesc<64x256xf16, #shared> -> tensor<64x256xf16, #blocked1>
+        %b_alloc = ttg.local_alloc %b : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+        %dot = ttng.warp_group_dot %a_alloc, %b_alloc, %acc {inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
+        scf.yield %dot : tensor<128x256xf32, #mma>
+      }
+      %ptrs = tt.splat %out : !tt.ptr<f32> -> tensor<128x256x!tt.ptr<f32>, #blocked1>
+      %cvt = ttg.convert_layout %inner : tensor<128x256xf32, #mma> -> tensor<128x256xf32, #blocked1>
+      tt.store %ptrs, %cvt : tensor<128x256x!tt.ptr<f32>, #blocked1>
+      %next = arith.addi %tile, %c1 : i32
+      scf.yield %next : i32
+    } attributes {tt.warp_specialize}
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // PSM-LABEL: @while_partition_reordered_rejected
+  // PSM-NOT: tt.warp_specialize
+  // PSM-NOT: ttg.partition
+  // PSM: tt.return
+  tt.func public @while_partition_reordered_rejected() {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %result:2 = scf.while (%i = %c0, %j = %c1) : (i32, i32) -> (i32, i32) {
+      scf.condition(%true) %j, %i : i32, i32
+    } do {
+    ^bb0(%j: i32, %i: i32):
+      %next = arith.addi %i, %j {ttg.partition = array<i32: 0>} : i32
+      scf.yield %next, %j : i32, i32
+    } attributes {tt.warp_specialize, ttg.partition.stages = [0 : i32], ttg.partition.types = ["computation"], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // PSM-LABEL: @while_partition_subset_rejected
+  // PSM-NOT: tt.warp_specialize
+  // PSM-NOT: ttg.partition
+  // PSM: tt.return
+  tt.func public @while_partition_subset_rejected() {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %result = scf.while (%i = %c0, %j = %c1) : (i32, i32) -> i32 {
+      scf.condition(%true) %i : i32
+    } do {
+    ^bb0(%i: i32):
+      %next = arith.addi %i, %c1 {ttg.partition = array<i32: 0>} : i32
+      scf.yield %next, %i : i32, i32
+    } attributes {tt.warp_specialize, ttg.partition.stages = [0 : i32], ttg.partition.types = ["computation"], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
 }

--- a/test/Triton/simplify-single-trip-while.mlir
+++ b/test/Triton/simplify-single-trip-while.mlir
@@ -1,4 +1,6 @@
 // RUN: triton-opt --split-input-file %s -triton-simplify-single-trip-while | FileCheck %s
+// RUN: triton-opt --split-input-file %s -triton-simplify-single-trip-while | FileCheck %s --check-prefix=NO-EARLY
+// RUN: triton-opt --split-input-file %s -triton-simplify-single-trip-while | FileCheck %s --check-prefix=ONE-LEVEL
 
 // The "constant-flip" pattern: the loop-carried condition is a constant `true`
 // on entry and a constant `false` after the body, and scf.condition forwards all
@@ -99,4 +101,117 @@ tt.func @computed_condition(%arg0: i32) -> i32 {
     scf.yield %false, %n : i1, i32
   }
   tt.return %r#1 : i32
+}
+
+// -----
+
+// An annotated scheduler while forwards AutoWS to the for loop exactly one
+// loop-nesting level inside it, even with non-loop control flow outside the
+// while and between it and the for. A nested second-level for does not receive
+// the attributes, and explicit inner settings win over the outer loop's
+// defaults.
+// CHECK-LABEL: @forwards_autows
+// CHECK-NOT: scf.while
+// CHECK: scf.if
+// CHECK: scf.for
+// CHECK: } {tt.data_partition_factor = 2 : i32
+// CHECK-SAME: tt.disallow_acc_multi_buffer
+// CHECK-SAME: tt.mem_plan_pick = 3 : i32
+// CHECK-SAME: tt.merge_correction = true
+// CHECK-SAME: tt.merge_epilogue = true
+// CHECK-SAME: tt.merge_epilogue_to_computation = true
+// CHECK-SAME: tt.multi_cta
+// CHECK-SAME: tt.num_stages = 5 : i32
+// CHECK-SAME: tt.separate_epilogue_store = true
+// CHECK-SAME: tt.smem_alloc_algo = 1 : i32
+// CHECK-SAME: tt.smem_budget = 65536 : i32
+// CHECK-SAME: tt.smem_circular_reuse = true
+// CHECK-SAME: tt.tmem_alloc_algo = 2 : i32
+// CHECK-SAME: tt.warp_specialize
+// NO-EARLY-LABEL: @forwards_autows
+// NO-EARLY-NOT: llvm.loop_annotation
+// NO-EARLY-NOT: tt.flatten
+// NO-EARLY-NOT: tt.list_schedule_pick
+// NO-EARLY-NOT: tt.loop_unroll_factor
+// NO-EARLY: tt.return
+// ONE-LEVEL-LABEL: @forwards_autows
+// ONE-LEVEL: tt.warp_specialize
+// ONE-LEVEL-NOT: tt.warp_specialize
+// ONE-LEVEL: tt.return
+tt.func @forwards_autows(%arg0: i32) -> i32 {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %r = scf.if %true -> (i32) {
+    %while_result = scf.while (%valid = %true, %acc = %arg0) : (i1, i32) -> i32 {
+      scf.condition(%valid) %acc : i32
+    } do {
+    ^bb0(%acc: i32):
+      %inner = scf.if %true -> (i32) {
+        %loop = scf.for %i = %c0 to %c1 step %c1 iter_args(%v = %acc) -> (i32) {
+          %nested = scf.for %j = %c0 to %c1 step %c1 iter_args(%nv = %v) -> (i32) {
+            %nested_next = arith.addi %nv, %nv : i32
+            scf.yield %nested_next : i32
+          }
+          %next = arith.addi %nested, %nested : i32
+          scf.yield %next : i32
+        } {tt.num_stages = 5 : i32}
+        scf.yield %loop : i32
+      } else {
+        scf.yield %acc : i32
+      }
+      scf.yield %false, %inner : i1, i32
+    } attributes {tt.warp_specialize, tt.num_stages = 3 : i32, tt.loop_unroll_factor = 4 : i32, tt.disallow_acc_multi_buffer, tt.flatten, tt.multi_cta, llvm.loop_annotation = true, tt.data_partition_factor = 2 : i32, tt.list_schedule_pick = 1 : i32, tt.mem_plan_pick = 3 : i32, tt.merge_epilogue = true, tt.merge_epilogue_to_computation = true, tt.merge_correction = true, tt.separate_epilogue_store = true, tt.tmem_alloc_algo = 2 : i32, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 65536 : i32, tt.smem_circular_reuse = true}
+    scf.yield %while_result : i32
+  } else {
+    scf.yield %arg0 : i32
+  }
+  tt.return %r : i32
+}
+
+// -----
+
+// Do not silently discard a WS request when no first-level inner loop exists.
+// CHECK-LABEL: @annotated_without_forward_target
+// CHECK: scf.while
+// CHECK: } attributes {tt.warp_specialize}
+tt.func @annotated_without_forward_target(%arg0: !tt.ptr<i32>) {
+  %true = arith.constant true
+  %false = arith.constant false
+  %c1 = arith.constant 1 : i32
+  scf.while (%valid = %true) : (i1) -> () {
+    scf.condition(%valid)
+  } do {
+    tt.store %arg0, %c1 : !tt.ptr<i32>
+    scf.yield %false : i1
+  } attributes {tt.warp_specialize}
+  tt.return
+}
+
+// -----
+
+// Matching nested whiles are processed from the inside out, so erasing the
+// inner loop cannot leave a stale handle in the pass worklist.
+// CHECK-LABEL: @nested_single_trip
+// CHECK-NOT: scf.while
+// CHECK-COUNT-2: arith.addi
+tt.func @nested_single_trip(%arg0: i32) -> i32 {
+  %true = arith.constant true
+  %false = arith.constant false
+  %outer = scf.while (%valid = %true, %acc = %arg0) : (i1, i32) -> i32 {
+    scf.condition(%valid) %acc : i32
+  } do {
+  ^bb0(%acc: i32):
+    %inner = scf.while (%inner_valid = %true, %inner_acc = %acc) : (i1, i32) -> i32 {
+      scf.condition(%inner_valid) %inner_acc : i32
+    } do {
+    ^bb0(%inner_acc: i32):
+      %next = arith.addi %inner_acc, %inner_acc : i32
+      scf.yield %false, %next : i1, i32
+    }
+    %next = arith.addi %inner, %inner : i32
+    scf.yield %false, %next : i1, i32
+  }
+  tt.return %outer : i32
 }

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -752,7 +752,6 @@ class CUDABackend(BaseBackend):
         if (opt.auto_tma or knobs.nvidia.auto_tma) and capability // 10 >= 9:
             nvidia.passes.ttnvgpuir.add_promote_load_to_tma(pm)
         passes.common.add_canonicalizer(pm)
-        passes.ttir.add_simplify_single_trip_while(pm)
         passes.ttir.add_combine(pm)
         passes.ttir.add_reorder_broadcast(pm)
         passes.common.add_cse(pm)
@@ -849,6 +848,10 @@ class CUDABackend(BaseBackend):
             passes.ttgpuir.add_combine_tensor_select_and_if(pm)
             if knobs.nvidia.use_meta_ws:
                 nvidia.passes.hopper.add_data_partitioning(pm, 1)
+            # Support simplify trip while after data partitioning to
+            # enable using this loop to data partition.
+            passes.ttir.add_simplify_single_trip_while(pm)
+            if knobs.nvidia.use_meta_ws:
                 passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, knobs.nvidia.use_meta_ws)
                 passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, knobs.nvidia.use_meta_ws)
             nvidia.passes.hopper.add_tma_store_lowering(pm)
@@ -904,6 +907,7 @@ class CUDABackend(BaseBackend):
                 # the picked one (TRITON_LIST_SCHEDULE_PICK, default best).
                 nvidia.passes.hopper.add_list_schedule(pm)
             nvidia.passes.hopper.add_data_partitioning(pm, 1)
+            passes.ttir.add_simplify_single_trip_while(pm)
             # The modulo / LLM / list scheduler above already produced the full
             # loop schedule (loop.stage / loop.cluster). Re-running
             # assign_latencies + schedule_loops here would recompute and OVERRIDE

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -107,6 +107,28 @@ def NVGPUTestWSTaskIdPropagate : Pass<"nvgpu-test-taskid-propagate", "mlir::Modu
   ];
 }
 
+def NVGPUTestWSAtomicBroadcast : Pass<"nvgpu-test-ws-atomic-broadcast", "mlir::ModuleOp"> {
+  let summary = "test warp specialization dynamic-tile atomic/CLC broadcast";
+
+  let description = [{
+    Runs the cross-partition run-once broadcast transform
+    (`doDynamicTileBroadcast`) in isolation for testing. It rewrites a
+    loop-carried scalar `tt.atomic_rmw` tile counter (or CLC fetch) so the claim
+    runs once in the owner/producer partition and the result is broadcast to
+    every partition through a shared-memory slot. Intended to be run after
+    `nvgpu-partition-scheduling-meta` and `nvgpu-test-taskid-propagate`, which
+    supply the op-level `async_task_id` metadata this transform consumes.
+  }];
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect"];
+
+  let options = [
+    Option<"tilePrefetchDepth", "tile-prefetch-depth",
+           "int32_t", /*default*/"1",
+           "broadcast channel depth (SMEM slot multi-buffering)">
+  ];
+}
+
 def NVGPUWSDataPartition : Pass<"nvgpu-ws-data-partition", "mlir::ModuleOp"> {
   let summary = "warp specialization data partition";
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -130,7 +130,7 @@ public:
       if (op->getAttrOfType<DenseI32ArrayAttr>(kAsyncTaskIdAttrName) ||
           op->getAttrOfType<DenseI32ArrayAttr>(
               triton::gpu::kPartitionAttrName) ||
-          (isa<scf::ForOp>(op) &&
+          (isa<scf::ForOp, scf::WhileOp>(op) &&
            op->hasAttr(mlir::triton::kWarpSpecializeAttrName))) {
         enabled = true;
         return WalkResult::interrupt();

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -112,6 +112,24 @@ inline Operation *getAccumulatorBuffer(Operation *op) {
   return nullptr;
 }
 
+static void dropWarpSpec(LoopLikeOpInterface loop) {
+  loop->removeAttr(triton::kWarpSpecializeAttrName);
+  loop->removeAttr(kPartitionStagesAttrName);
+  loop->removeAttr(kPartitionTypesAttrName);
+  loop->removeAttr(kWarpSpecializeTagAttrName);
+  loop->walk([](Operation *op) {
+    op->removeAttr(kPartitionAttrName);
+    op->removeAttr(kPartitionOutputsAttrName);
+  });
+}
+
+static LoopLikeOpInterface getEnclosingSupportedLoop(Operation *op) {
+  auto loop = op->getParentOfType<LoopLikeOpInterface>();
+  if (loop && isa<scf::ForOp, scf::WhileOp>(loop.getOperation()))
+    return loop;
+  return {};
+}
+
 //===----------------------------------------------------------------------===//
 // Op Categories and Scheduling Template Infrastructure
 //===----------------------------------------------------------------------===//
@@ -168,7 +186,7 @@ static llvm::StringRef toString(OpCategory category) {
 /// follow yield operands in the then/else blocks backward. This captures
 /// ops like tmem_load QK and mulf(QK*scale) in flex attention that feed
 /// into scf.if yield operands but are missed by standard getBackwardSlice.
-static SetVector<Operation *> collectMMABackwardSlice(scf::ForOp loop,
+static SetVector<Operation *> collectMMABackwardSlice(LoopLikeOpInterface loop,
                                                       Operation *mmaOp) {
   SetVector<Operation *> slice;
   BackwardSliceOptions options;
@@ -358,7 +376,7 @@ struct PartitionLayout {
   /// swapping it with whatever is currently at index 0. Call after ops
   /// have been assigned so that op annotations are updated correctly.
   void makeDefaultPartition(PartitionSet &schedule, Partition *part,
-                            scf::ForOp loop) {
+                            LoopLikeOpInterface loop) {
     if (!part || part->getIndex() == 0)
       return;
     schedule.swapPartitions(0, part->getIndex(), loop);
@@ -381,11 +399,11 @@ struct CategorizedOp {
 /// Categorizes operations in a loop for partition scheduling.
 class OpCategorizer {
 public:
-  OpCategorizer(scf::ForOp mainLoop, ArrayRef<Operation *> mmaOps)
+  OpCategorizer(LoopLikeOpInterface mainLoop, ArrayRef<Operation *> mmaOps)
       : mainLoop(mainLoop), mmas(mmaOps.begin(), mmaOps.end()) {
     // Collect all loops (nested + main)
-    for (auto nestedLoop : mainLoop.getOps<scf::ForOp>())
-      loops.push_back(nestedLoop);
+    for (auto nestedLoop : getLoopBodyBlock(mainLoop)->getOps<scf::ForOp>())
+      loops.push_back(cast<LoopLikeOpInterface>(nestedLoop.getOperation()));
     loops.push_back(mainLoop);
   }
 
@@ -431,8 +449,8 @@ public:
     if (!mmas.empty())
       return false;
     // Copy the lightweight op handle: walk() is non-const but this method is.
-    scf::ForOp loop = mainLoop;
-    return loop.walk([](triton::ReduceOp) { return WalkResult::interrupt(); })
+    LoopLikeOpInterface loop = mainLoop;
+    return loop->walk([](triton::ReduceOp) { return WalkResult::interrupt(); })
         .wasInterrupted();
   }
 
@@ -486,7 +504,7 @@ public:
 private:
   void collectMMABackwardSlices() {
     // Only process innermost loop's MMAs for data partitioning
-    scf::ForOp innermostLoop = loops.empty() ? mainLoop : loops[0];
+    LoopLikeOpInterface innermostLoop = loops.empty() ? mainLoop : loops[0];
 
     SmallVector<Operation *> loopMmas;
     for (auto mmaOp : mmas) {
@@ -540,9 +558,9 @@ private:
 
       // Also follow cross-iteration paths: MMA result → yield → iter arg
       for (OpOperand &use : mmaOp->getUses()) {
-        if (use.getOwner() == innermostLoop.getBody()->getTerminator()) {
+        if (use.getOwner() == getLoopBodyTerminator(innermostLoop)) {
           worklist.push_back(
-              innermostLoop.getRegionIterArg(use.getOperandNumber()));
+              getLoopCarriedBodyArg(innermostLoop, use.getOperandNumber()));
         }
       }
 
@@ -708,7 +726,7 @@ private:
 
       // Assign dpId to post-loop ops: follow loop results forward.
       // Each loop result traces back to a specific MMA group's yield.
-      auto yieldOp = innermostLoop.getBody()->getTerminator();
+      auto yieldOp = getLoopBodyTerminator(innermostLoop);
       // Helper: find dpId for an in-loop op by walking backward through its
       // operand chain until we find an op in opToDpId. This handles ops like
       // l_i0 (softmax sum accumulation) that are not in any MMA's backward
@@ -731,7 +749,7 @@ private:
         }
         return SHARED_DPID;
       };
-      for (unsigned argIdx = 0; argIdx < innermostLoop.getNumResults();
+      for (unsigned argIdx = 0; argIdx < innermostLoop->getNumResults();
            ++argIdx) {
         Value yieldVal = yieldOp->getOperand(argIdx);
         Operation *yieldDef = yieldVal.getDefiningOp();
@@ -752,7 +770,7 @@ private:
         if (yieldDpId == SHARED_DPID)
           continue;
         // Follow the loop result to post-loop consumers.
-        Value loopResult = innermostLoop.getResult(argIdx);
+        Value loopResult = innermostLoop->getResult(argIdx);
         SmallVector<Operation *> postWorklist;
         for (Operation *user : loopResult.getUsers())
           postWorklist.push_back(user);
@@ -790,7 +808,7 @@ private:
 
   void categorizeLoads() {
     for (auto loop : loops) {
-      for (Operation &op : loop.getOps()) {
+      for (Operation &op : *getLoopBodyBlock(loop)) {
         if (!isa<DescriptorLoadOp, DescriptorGatherOp>(op))
           continue;
 
@@ -840,7 +858,7 @@ private:
   void categorizeEpilogueStores() {
     // Collect stores inside the loops.
     for (auto loop : loops) {
-      loop.walk([&](Operation *op) {
+      getLoopBodyRegion(loop).walk([&](Operation *op) {
         if (isEpilogueStoreOp(op))
           addCategorizedOp(op, epilogueStoreCategoryFor(op));
       });
@@ -882,14 +900,14 @@ private:
 
   void categorizeCorrectionOps() {
     for (auto mmaOp : mmas) {
-      scf::ForOp loop = mmaOp->getParentOfType<scf::ForOp>();
+      LoopLikeOpInterface loop = getEnclosingSupportedLoop(mmaOp);
       unsigned dpId = getDpId(mmaOp);
       for (OpOperand &use : mmaOp->getUses()) {
-        if (use.getOwner() != loop.getBody()->getTerminator())
+        if (use.getOwner() != getLoopBodyTerminator(loop))
           continue;
         // MMA result is yielded - find users in next iteration
         for (OpOperand &iterUse :
-             loop.getRegionIterArg(use.getOperandNumber()).getUses()) {
+             getLoopCarriedBodyArg(loop, use.getOperandNumber()).getUses()) {
           Operation *user = iterUse.getOwner();
           if (!opCategories.contains(user)) {
             addCategorizedOp(user, OpCategory::Correction, dpId, mmaOp);
@@ -906,15 +924,15 @@ private:
     auto isReductionOp = [](Operation *op) {
       return isa<DescriptorReduceOp, ttng::AsyncTMAReduceOp>(op);
     };
-    for (scf::ForOp loop : loops) {
-      loop.walk([&](Operation *op) {
+    for (LoopLikeOpInterface loop : loops) {
+      getLoopBodyRegion(loop).walk([&](Operation *op) {
         if (isReductionOp(op))
           addCategorizedOp(op, OpCategory::TMAReduction);
       });
     }
     // Also check the main loop if not in loops
     if (loops.empty()) {
-      mainLoop.walk([&](Operation *op) {
+      getLoopBodyRegion(mainLoop).walk([&](Operation *op) {
         if (isReductionOp(op))
           addCategorizedOp(op, OpCategory::TMAReduction);
       });
@@ -933,8 +951,8 @@ private:
     opCategories[op] = CategorizedOp{op, cat, dataPartitionId, parentMMA};
   }
 
-  scf::ForOp mainLoop;
-  SmallVector<scf::ForOp> loops;
+  LoopLikeOpInterface mainLoop;
+  SmallVector<LoopLikeOpInterface> loops;
   SmallVector<Operation *> mmas;
   DenseMap<Operation *, CategorizedOp> opCategories;
   DenseMap<Operation *, SetVector<Operation *>> mmaToSlice;
@@ -1035,46 +1053,50 @@ static PartitionLayout createPartitionLayout(PartitionSet &schedule,
 // assignPartitions
 //===----------------------------------------------------------------------===//
 
-// Find the last operation in the loop body that defined this value, with a
-// maximum of distance 1.
-static Operation *findDefOpInLoop(scf::ForOp loop, Value value,
+static Operation *findDefOpInLoop(LoopLikeOpInterface loop, Value value,
                                   int distance = 0) {
   if (auto arg = dyn_cast<BlockArgument>(value)) {
-    if (arg.getParentBlock() != loop.getBody())
+    if (arg.getParentBlock() != getLoopBodyBlock(loop) ||
+        arg == getLoopInductionVar(loop))
       return {};
     // Don't look back more than distance 1.
     if (distance == 1)
       return {};
-    return findDefOpInLoop(
-        loop, loop.getYieldedValues()[arg.getArgNumber() - 1], distance + 1);
+    unsigned slot = arg.getArgNumber();
+    if (isa<scf::ForOp>(loop.getOperation()))
+      --slot;
+    return findDefOpInLoop(loop, getLoopYieldedValues(loop)[slot],
+                           distance + 1);
   }
   Operation *defOp = value.getDefiningOp();
-  if (!loop.getBodyRegion().isAncestor(defOp->getParentRegion()))
+  if (!defOp || !getLoopBodyRegion(loop).isAncestor(defOp->getParentRegion()))
     return {};
   return defOp;
 }
 
 // For `op`, invoke `callback` on all the definitions of its inputs from within
 // `loop`, which might not be in the same iteration.
-static void iterateDefs(scf::ForOp loop, Operation *op,
+static void iterateDefs(LoopLikeOpInterface loop, Operation *op,
                         function_ref<void(OpResult)> callback) {
+  Block *body = getLoopBodyBlock(loop);
   visitNestedOperands(op, [&](OpOperand &operand) {
     Value value = operand.get();
-    if (value.getParentBlock() != loop.getBody())
+    if (value.getParentBlock() != body)
       return;
     auto arg = dyn_cast<BlockArgument>(value);
-    if (arg == loop.getInductionVar())
+    if (arg == getLoopInductionVar(loop))
       return;
-    auto [def, distance] = getDefinitionAndDistance(loop, operand.get());
-    if (def && def.getParentBlock() == loop.getBody())
+    auto [def, distance] = getLoopDefinitionAndDistance(loop, operand.get());
+    if (def && def.getParentBlock() == body)
       callback(def);
   });
 }
 
 // For `op`, invoke `callback` on all its transitive users within `loop`, which
 // may be in a future iteration.
-static void iterateUsers(scf::ForOp loop, Operation *op,
+static void iterateUsers(LoopLikeOpInterface loop, Operation *op,
                          function_ref<void(Operation *)> callback) {
+  Block *body = getLoopBodyBlock(loop);
   SmallVector<OpOperand *> uses;
   DenseSet<OpOperand *> visited;
   for (OpOperand &use : op->getUses())
@@ -1083,7 +1105,7 @@ static void iterateUsers(scf::ForOp loop, Operation *op,
     OpOperand *use = uses.pop_back_val();
     if (!visited.insert(use).second)
       continue;
-    Operation *owner = loop.getBody()->findAncestorOpInBlock(*use->getOwner());
+    Operation *owner = body->findAncestorOpInBlock(*use->getOwner());
     if (auto nestedFor = dyn_cast<scf::ForOp>(owner)) {
       // For captured values used inside nested loops, walk the use
       // chain inside the loop to find partitioned consumers.
@@ -1107,11 +1129,11 @@ static void iterateUsers(scf::ForOp loop, Operation *op,
       }
       continue;
     }
-    if (!isa<scf::YieldOp>(owner)) {
+    if (owner != getLoopBodyTerminator(loop)) {
       callback(owner);
       continue;
     }
-    BlockArgument arg = loop.getRegionIterArg(use->getOperandNumber());
+    BlockArgument arg = getLoopCarriedBodyArg(loop, use->getOperandNumber());
     for (OpOperand &use : arg.getUses())
       uses.emplace_back(&use);
   }
@@ -1135,7 +1157,7 @@ static bool tryScheduleOp(Partition *partition, Operation *op) {
 }
 
 // Check if any of the inputs to `op` are reachable from a non-null partition.
-static bool hasDefPartition(scf::ForOp loop, Operation *op,
+static bool hasDefPartition(LoopLikeOpInterface loop, Operation *op,
                             PartitionSet &schedule) {
   SmallVector<Operation *> worklist{op};
   DenseSet<Operation *> seen;
@@ -1154,18 +1176,20 @@ static bool hasDefPartition(scf::ForOp loop, Operation *op,
 // Recursively schedule the users of an operation, stopping when
 // encountering an operation that is already assigned.
 // If \p partition is null, a new partition will be created if needed.
-static Partition *scheduleUsers(scf::ForOp loop, PartitionSet &schedule,
-                                Partition *partition, Operation *op) {
+static Partition *scheduleUsers(LoopLikeOpInterface loop,
+                                PartitionSet &schedule, Partition *partition,
+                                Operation *op) {
   SmallVector<OpOperand *> uses;
   for (OpOperand &use : op->getUses())
     uses.push_back(&use);
   while (!uses.empty()) {
     OpOperand *use = uses.pop_back_val();
-    Operation *user = loop.getBody()->findAncestorOpInBlock(*use->getOwner());
+    Operation *user =
+        getLoopBodyBlock(loop)->findAncestorOpInBlock(*use->getOwner());
 
-    if (user == loop.getBody()->getTerminator()) {
+    if (user == getLoopBodyTerminator(loop)) {
       for (OpOperand &use :
-           loop.getRegionIterArg(use->getOperandNumber()).getUses())
+           getLoopCarriedBodyArg(loop, use->getOperandNumber()).getUses())
         uses.push_back(&use);
       continue;
     }
@@ -1192,7 +1216,7 @@ static Partition *scheduleUsers(scf::ForOp loop, PartitionSet &schedule,
 // requires full warp group).
 
 static void
-schedulePostLoopOps(scf::ForOp loop, PartitionSet &schedule,
+schedulePostLoopOps(LoopLikeOpInterface loop, PartitionSet &schedule,
                     const PartitionLayout &layout,
                     const SchedulingOptions &options,
                     const DenseMap<Operation *, unsigned> &opToDpId,
@@ -1264,12 +1288,12 @@ schedulePostLoopOps(scf::ForOp loop, PartitionSet &schedule,
 
   SmallVector<OpOperand *> uses;
   // For persistent kernels, seed from nested inner loop results.
-  for (auto &op : loop.getOps())
+  for (auto &op : *getLoopBodyBlock(loop))
     if (auto innerLoop = dyn_cast<scf::ForOp>(op))
       for (OpResult result : innerLoop.getResults())
         for (OpOperand &use : result.getUses())
           uses.push_back(&use);
-  for (OpResult result : loop.getResults())
+  for (OpResult result : loop->getResults())
     for (OpOperand &use : result.getUses())
       uses.push_back(&use);
 
@@ -1282,8 +1306,8 @@ schedulePostLoopOps(scf::ForOp loop, PartitionSet &schedule,
     // Skip ops inside loops nested deeper than `loop`. Ops directly in
     // `loop`'s body, in an enclosing loop (persistent tile loop), or at
     // function level are all valid post-loop epilogue candidates.
-    if (auto parentLoop = user->getParentOfType<scf::ForOp>())
-      if (loop->isProperAncestor(parentLoop))
+    if (auto parentLoop = user->getParentOfType<LoopLikeOpInterface>())
+      if (loop->isProperAncestor(parentLoop.getOperation()))
         continue;
 
     { // Schedule post-loop op (override earlier phase assignments)
@@ -1364,7 +1388,8 @@ preScheduleDpOps(SmallVector<CategorizedOp> &dpOps,
 // first-order partition assignment to the operations in the scheme and its
 // users and/or dependencies. This sets up the initial partitioning of the ops.
 static std::optional<ScheduleResult>
-getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
+getInitialSchedule(LoopLikeOpInterface mainLoop,
+                   const SchedulingOptions &schedOpts) {
   // Check for an existing schedule.
   if (FailureOr<PartitionSet> scheduleOr = PartitionSet::fromLoop(mainLoop);
       succeeded(scheduleOr))
@@ -1391,13 +1416,15 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   }
 
   // Collect all loops (nested + main)
-  SmallVector<scf::ForOp> loops{mainLoop.getOps<scf::ForOp>()};
+  SmallVector<LoopLikeOpInterface> loops;
+  for (scf::ForOp nestedLoop : getLoopBodyBlock(mainLoop)->getOps<scf::ForOp>())
+    loops.push_back(cast<LoopLikeOpInterface>(nestedLoop.getOperation()));
   loops.push_back(mainLoop);
 
   // Collect all MMAs
   SmallVector<Operation *> mmas;
   for (auto loop : loops) {
-    for (auto &op : loop.getOps()) {
+    for (auto &op : *getLoopBodyBlock(loop)) {
       if (isMMAOp(&op))
         mmas.push_back(&op);
     }
@@ -1590,7 +1617,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
 
   // In-loop loads
   for (auto loop : loops) {
-    for (Operation &op : loop.getOps()) {
+    for (Operation &op : *getLoopBodyBlock(loop)) {
       if (!isa<DescriptorLoadOp, DescriptorGatherOp>(op))
         continue;
       tryScheduleOp(loadPartition, &op);
@@ -1619,7 +1646,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
     // Stores inside loops (both pre-lowering DescriptorStoreOp and
     // post-lowering AsyncTMACopyLocalToGlobalOp)
     for (auto loop : loops) {
-      loop.walk([&](Operation *op) {
+      getLoopBodyRegion(loop).walk([&](Operation *op) {
         // A reduce's token_wait belongs in the reduction partition with its
         // reduce (see isReduceTokenWait); do NOT pull it into the epilogue
         // partition here, or doCodePartition clones the reduce into the
@@ -1639,7 +1666,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
 
       // Only schedule backward slice for post-loop stores (not inside any loop)
       // This captures ops like tmem_load, truncf that prepare data for storing
-      bool isPostLoop = !catOp.op->getParentOfType<scf::ForOp>();
+      bool isPostLoop = !mainLoop->isAncestor(catOp.op);
       if (isPostLoop) {
         SetVector<Operation *> slice;
         BackwardSliceOptions options;
@@ -1676,7 +1703,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
     // computation partition to avoid cross-partition TMEM overhead.
     if (epiloguePartition->getOps().empty()) {
       for (auto loop : loops)
-        for (StoreOp op : loop.getOps<StoreOp>())
+        for (StoreOp op : getLoopBodyBlock(loop)->getOps<StoreOp>())
           tryScheduleOp(epiloguePartition, op);
     }
   }
@@ -1691,7 +1718,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   // channel. Gated to the no-MMA case so MMA kernels are untouched.
   if (mmas.empty() && layout.epilogueStorePartition) {
     for (auto loop : loops) {
-      loop.walk([&](Operation *op) {
+      getLoopBodyRegion(loop).walk([&](Operation *op) {
         if (isEpilogueStoreOp(op))
           tryScheduleOp(layout.epilogueStorePartition, op);
       });
@@ -1700,7 +1727,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
 
   // Schedule MMAs and their associated stores
   for (auto loop : loops) {
-    for (auto &op : loop.getOps()) {
+    for (auto &op : *getLoopBodyBlock(loop)) {
       if (!isMMAOp(&op))
         continue;
       if (mmaPartition)
@@ -1712,8 +1739,11 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
       if (auto mmaOp = dyn_cast<ttng::MMAv5OpInterface>(&op)) {
         auto storeOp = dyn_cast_or_null<ttng::TMEMStoreOp>(
             findDefOpInLoop(loop, mmaOp.getAccDep()));
-        if (mmaPartition && reductionPartition == nullptr &&
-            !ttng::hasAccReadModifyWrite(mmaOp, loop) && storeOp &&
+        auto forLoop = dyn_cast<scf::ForOp>(loop.getOperation());
+        // MMAs in a scheduled while live in its nested K-loop. Conservatively
+        // skip this scf.for-specific hoist for MMAs directly in a while body.
+        if (mmaPartition && reductionPartition == nullptr && forLoop &&
+            !ttng::hasAccReadModifyWrite(mmaOp, forLoop) && storeOp &&
             loop.isDefinedOutsideOfLoop(storeOp.getSrc()))
           tryScheduleOp(mmaPartition, storeOp);
       }
@@ -1724,7 +1754,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   // memdesc views are a Blackwell TMEM concept, not used on Hopper).
   if (mmaPartition) {
     for (auto loop : loops) {
-      for (auto &mmaOp : loop.getOps()) {
+      for (auto &mmaOp : *getLoopBodyBlock(loop)) {
         if (!isMMAOp(&mmaOp))
           continue;
         SmallVector<Operation *> operandViews;
@@ -1780,7 +1810,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
       (!layout.reductionPartition || defaultPartition != reductionPartition ||
        mmas.empty())) {
     for (Operation *loadOrAlloc : loadsAndAllocs) {
-      scf::ForOp parentLoop = loadOrAlloc->getParentOfType<scf::ForOp>();
+      LoopLikeOpInterface parentLoop = getEnclosingSupportedLoop(loadOrAlloc);
       if (!parentLoop) {
         // Skip pre-loop ops that don't have a parent loop
         continue;
@@ -1797,11 +1827,11 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   if (corrDest) {
     for (auto mmaOp : mmas) {
       for (OpOperand &use : mmaOp->getUses()) {
-        auto loop = mmaOp->getParentOfType<scf::ForOp>();
-        if (use.getOwner() != loop.getBody()->getTerminator())
+        auto loop = getEnclosingSupportedLoop(mmaOp);
+        if (use.getOwner() != getLoopBodyTerminator(loop))
           continue;
         for (OpOperand &use :
-             loop.getRegionIterArg(use.getOperandNumber()).getUses()) {
+             getLoopCarriedBodyArg(loop, use.getOperandNumber()).getUses()) {
           tryScheduleOp(corrDest, use.getOwner());
           scheduleUsers(loop, schedule, corrDest, use.getOwner());
         }
@@ -1835,7 +1865,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
           if (hasPartition(op))
             continue;
           // Skip ops outside the loop.
-          if (!op->getParentOfType<scf::ForOp>())
+          if (!mainLoop->isAncestor(op))
             continue;
           tryScheduleOp(reductionDest, op);
           // Add operand definitions to worklist.
@@ -1878,7 +1908,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   }
 
   for (auto mmaOp : llvm::reverse(mmas)) {
-    if (mmaOp->getParentOfType<scf::ForOp>() == loops[0]) {
+    if (getEnclosingSupportedLoop(mmaOp) == loops[0]) {
       Partition *targetPart = nullptr;
       LDBG("[phase5] Processing MMA: "
            << prettyOp(mmaOp) << " dpId=" << categorizer.getDpId(mmaOp)
@@ -1947,7 +1977,7 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
         // bwd: all MMA users share one partition
         targetPart = sharedComputePartition;
       }
-      auto part = scheduleUsers(mmaOp->getParentOfType<scf::ForOp>(), schedule,
+      auto part = scheduleUsers(getEnclosingSupportedLoop(mmaOp), schedule,
                                 targetPart, mmaOp);
       if (dataPartitionFactor <= 1 && !sharedComputePartition)
         sharedComputePartition = part;
@@ -1982,10 +2012,9 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
   // loop
   unsigned Idx = 0;
   for (auto mmaOp : llvm::reverse(mmas)) {
-    if (loops.size() == 3 && mmaOp->getParentOfType<scf::ForOp>() == loops[1]) {
+    if (loops.size() == 3 && getEnclosingSupportedLoop(mmaOp) == loops[1]) {
       auto *part = mmaToPartition[inFirstLoop[Idx]];
-      scheduleUsers(mmaOp->getParentOfType<scf::ForOp>(), schedule, part,
-                    mmaOp);
+      scheduleUsers(getEnclosingSupportedLoop(mmaOp), schedule, part, mmaOp);
       ++Idx;
     }
   }
@@ -2040,8 +2069,8 @@ getInitialSchedule(scf::ForOp mainLoop, const SchedulingOptions &schedOpts) {
       return dpId; // fallback to original (may be 0)
     };
 
-    scf::ForOp innermostLoop = loops[0];
-    for (Operation &op : innermostLoop.getOps()) {
+    LoopLikeOpInterface innermostLoop = loops[0];
+    for (Operation &op : *getLoopBodyBlock(innermostLoop)) {
       if (hasPartition(&op))
         continue;
       if (isa<arith::ConstantOp, scf::YieldOp>(&op))
@@ -2180,7 +2209,7 @@ static bool isScalarOp(Operation *op) {
   });
 }
 
-void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
+void propagatePartitions(LoopLikeOpInterface loop, PartitionSet &schedule,
                          bool createComputePartitions) {
   OpClusters opClusters;
 
@@ -2199,7 +2228,8 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
     // For each partition, place users of its outputs in a cluster if it is
     // not already assigned to a partition.
     auto useCallback = [&](OpResult result, OpOperand &use, unsigned distance) {
-      Operation *user = loop.getBody()->findAncestorOpInBlock(*use.getOwner());
+      Operation *user =
+          getLoopBodyBlock(loop)->findAncestorOpInBlock(*use.getOwner());
       // Skip users outside the loop — they are handled by
       // schedulePostLoopOps.
       if (!user)
@@ -2446,7 +2476,7 @@ void propagatePartitions(scf::ForOp loop, PartitionSet &schedule,
 /// encodings), also walk backward and clone the operand chain
 /// (ConvertLayoutOp, ExpandDimsOp, BroadcastOp) to avoid creating an
 /// unintended cross-partition boundary.
-void optimizeSchedule(scf::ForOp loop, PartitionSet &schedule) {
+void optimizeSchedule(LoopLikeOpInterface loop, PartitionSet &schedule) {
   // Helper to get partition for an op, returning null if unscheduled.
   auto getPartition = [&](Operation *op) -> Partition * {
     if (!hasPartition(op))
@@ -2493,35 +2523,37 @@ void optimizeSchedule(scf::ForOp loop, PartitionSet &schedule) {
 
   // Walk everything in reverse so that operations are visited before their
   // operands.
-  loop.walk<WalkOrder::PostOrder, ReverseIterator>([&](Operation *op) {
-    if (!isa<MemDescTransOp, ConvertLayoutOp, BroadcastOp, ExpandDimsOp>(op))
-      return;
+  getLoopBodyRegion(loop).walk<WalkOrder::PostOrder, ReverseIterator>(
+      [&](Operation *op) {
+        if (!isa<MemDescTransOp, ConvertLayoutOp, BroadcastOp, ExpandDimsOp>(
+                op))
+          return;
 
-    Partition *partition = getPartition(op);
-    if (!partition)
-      return;
+        Partition *partition = getPartition(op);
+        if (!partition)
+          return;
 
-    // Record all the other partitions in which we have users.
-    llvm::SmallDenseSet<Partition *, 2> userPartitions;
-    for (OpOperand &use : op->getUses()) {
-      Partition *userPartition = getPartition(use.getOwner());
-      if (!userPartition || userPartition == partition)
-        continue;
-      userPartitions.insert(userPartition);
-    }
+        // Record all the other partitions in which we have users.
+        llvm::SmallDenseSet<Partition *, 2> userPartitions;
+        for (OpOperand &use : op->getUses()) {
+          Partition *userPartition = getPartition(use.getOwner());
+          if (!userPartition || userPartition == partition)
+            continue;
+          userPartitions.insert(userPartition);
+        }
 
-    for (auto *userPartition : userPartitions) {
-      // Clone the instruction into each user partition.
-      Operation *clone = OpBuilder(op).clone(*op);
-      scheduleOp(userPartition, clone);
-      // Replace all users in that partition with the clone.
-      op->replaceUsesWithIf(clone->getResults(), [&](OpOperand &otherUse) {
-        return getPartition(otherUse.getOwner()) == userPartition;
+        for (auto *userPartition : userPartitions) {
+          // Clone the instruction into each user partition.
+          Operation *clone = OpBuilder(op).clone(*op);
+          scheduleOp(userPartition, clone);
+          // Replace all users in that partition with the clone.
+          op->replaceUsesWithIf(clone->getResults(), [&](OpOperand &otherUse) {
+            return getPartition(otherUse.getOwner()) == userPartition;
+          });
+          // Walk backward and clone any cheap layout ops feeding the clone.
+          cloneOperandChain(clone, userPartition);
+        }
       });
-      // Walk backward and clone any cheap layout ops feeding the clone.
-      cloneOperandChain(clone, userPartition);
-    }
-  });
 }
 
 /// Split scf.if ops whose results feed different computation partitions
@@ -2554,10 +2586,11 @@ void optimizeSchedule(scf::ForOp loop, PartitionSet &schedule) {
 ///   } {ttg.partition = [4]}  // dp1 computation partition
 ///   use(%r0) {ttg.partition = [3]}
 ///   use(%r1) {ttg.partition = [4]}
-void splitDataPartitionedIfOps(scf::ForOp loop, PartitionSet &schedule) {
+void splitDataPartitionedIfOps(LoopLikeOpInterface loop,
+                               PartitionSet &schedule) {
   SmallVector<scf::IfOp> ifsToSplit;
 
-  loop.walk([&](scf::IfOp ifOp) {
+  getLoopBodyRegion(loop).walk([&](scf::IfOp ifOp) {
     if (ifOp.getNumResults() < 2)
       return;
 
@@ -2758,10 +2791,18 @@ struct PartitionSchedulingMeta
 } // namespace
 
 void PartitionSchedulingMeta::runOnOperation() {
-  SmallVector<scf::ForOp> loops;
-  getOperation().walk([&](scf::ForOp loop) {
-    if (loop->hasAttr(kWarpSpecializeAttrName))
-      loops.push_back(loop);
+  SmallVector<LoopLikeOpInterface> loops;
+  getOperation().walk([&](LoopLikeOpInterface loop) {
+    if (!isa<scf::ForOp, scf::WhileOp>(loop.getOperation()) ||
+        !loop->hasAttr(kWarpSpecializeAttrName))
+      return;
+    if (!hasIdentityLoopCarry(loop)) {
+      LDBG("Skipping non-identity scf.while warp-specialize loop at "
+           << loop.getLoc());
+      dropWarpSpec(loop);
+      return;
+    }
+    loops.push_back(loop);
   });
   for (auto [idx, loop] : llvm::enumerate(loops)) {
     // Build SchedulingOptions from pass options and per-loop attributes.
@@ -2810,7 +2851,7 @@ void PartitionSchedulingMeta::runOnOperation() {
       // from AsyncTMAReduceOp which was categorized as TMAReduction, but
       // the wait itself wasn't categorized or propagated. Copy the partition
       // from the token's defining op.
-      loop.walk([&](ttng::TMAStoreTokenWaitOp waitOp) {
+      getLoopBodyRegion(loop).walk([&](ttng::TMAStoreTokenWaitOp waitOp) {
         if (hasPartition(waitOp))
           return;
         Value token = waitOp.getToken();
@@ -2846,7 +2887,7 @@ void PartitionSchedulingMeta::runOnOperation() {
         bool changed = true;
         while (changed) {
           changed = false;
-          loop.walk([&](Operation *op) {
+          getLoopBodyRegion(loop).walk([&](Operation *op) {
             if (op->getNumResults() == 0 || hasPartition(op))
               return;
             SetVector<int> unionIds;
@@ -2976,19 +3017,20 @@ void PartitionSchedulingMeta::runOnOperation() {
       schedule.serialize(loop);
       loop->setAttr(
           kWarpSpecializeTagAttrName,
-          IntegerAttr::get(IntegerType::get(loop.getContext(), 32), idx));
+          IntegerAttr::get(IntegerType::get(loop->getContext(), 32), idx));
       // Clean ops left with no users after optimizeSchedule, waiting until
       // after serialize() so we don't invalidate pointers held by the
       // schedule. LocalAllocOp is impure but a use-empty alloc is dead, so
       // it is erased explicitly alongside the pure ops.
-      loop.walk<WalkOrder::PostOrder, ReverseIterator>([](Operation *op) {
-        // By default, the walk is in postorder so it is safe to delete ops
-        // while we walk.
-        if (op->use_empty() && op->getNumResults() == 1 &&
-            !isa<scf::YieldOp, scf::ForOp, scf::IfOp>(op) &&
-            (isPure(op) || isa<LocalAllocOp>(op)))
-          op->erase();
-      });
+      getLoopBodyRegion(loop).walk<WalkOrder::PostOrder, ReverseIterator>(
+          [](Operation *op) {
+            // By default, the walk is in postorder so it is safe to delete ops
+            // while we walk.
+            if (op->use_empty() && op->getNumResults() == 1 &&
+                !isa<scf::YieldOp, scf::ForOp, scf::WhileOp, scf::IfOp>(op) &&
+                (isPure(op) || isa<LocalAllocOp>(op)))
+              op->erase();
+          });
     }
   }
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSAtomicBroadcast.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSAtomicBroadcast.cpp
@@ -36,6 +36,8 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Pass/Pass.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Partition.h"
@@ -443,5 +445,29 @@ LogicalResult doDynamicTileBroadcast(triton::FuncOp funcOp,
   }
   return success();
 }
+
+#define GEN_PASS_DEF_NVGPUTESTWSATOMICBROADCAST
+#include "nvidia/hopper/include/Transforms/Passes.h.inc"
+
+// Test-only wrapper that runs `doDynamicTileBroadcast` in isolation so the
+// outer-`scf.while` broadcast path can be validated with lit, chained after
+// `nvgpu-partition-scheduling-meta` + `nvgpu-test-taskid-propagate`. Mirrors
+// `nvgpu-test-taskid-propagate`: a reject (unsupported atomic/CLC shape)
+// surfaces as a pass failure rather than performing the orchestrator's
+// WS-metadata teardown, which the full `nvgpu-warp-specialization` pass owns.
+class NVGPUTestWSAtomicBroadcastPass
+    : public impl::NVGPUTestWSAtomicBroadcastBase<
+          NVGPUTestWSAtomicBroadcastPass> {
+public:
+  using impl::NVGPUTestWSAtomicBroadcastBase<
+      NVGPUTestWSAtomicBroadcastPass>::NVGPUTestWSAtomicBroadcastBase;
+
+  void runOnOperation() override {
+    getOperation()->walk([&](triton::FuncOp funcOp) {
+      if (failed(doDynamicTileBroadcast(funcOp, tilePrefetchDepth)))
+        signalPassFailure();
+    });
+  }
+};
 
 } // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskIdPropagate.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskIdPropagate.cpp
@@ -315,7 +315,9 @@ public:
 
   void runOnFuncOp(triton::FuncOp funcOp) {
     llvm::DenseSet<Operation *> anchorOps;
+    bool hasPartitionAnchors = false;
     funcOp.walk([&](mlir::Operation *op) {
+      hasPartitionAnchors |= op->hasAttr(ttg::kPartitionAttrName);
       auto asyncTasks = getAsyncTaskIds(op);
       if (!asyncTasks.empty()) {
         std::sort(asyncTasks.begin(), asyncTasks.end());
@@ -326,7 +328,7 @@ public:
           op->removeAttr("async_task_id");
       }
     });
-    if (numWarpGroups == 0 || anchorOps.empty())
+    if (numWarpGroups == 0 || (anchorOps.empty() && !hasPartitionAnchors))
       return;
     if (failed(doTaskIdPropagate(funcOp)))
       signalPassFailure();

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWSAnnotations.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWSAnnotations.md
@@ -24,11 +24,21 @@ while tl.condition(sched.is_valid(), warp_specialize=True, data_partition_factor
 ```
 
 Both `tl.range` (for loops) and `tl.condition` (while loops) inherit a single
-dataclass, **`AutoWSLoopOptions`** (`core.py`), which is the *one* place the
-option set, defaults, and IR-attribute mapping are defined. `visit_For` and
-`visit_While` both emit them via the shared `_apply_loop_options` helper, so a
-`for` and a `while` receive byte-identical attributes. Adding a new knob is a
-single new field on `AutoWSLoopOptions`.
+dataclass, **`AutoWSLoopOptions`** (`core.py`), which owns the frontend option
+set, defaults, and IR-attribute mapping. `visit_For` and `visit_While` both emit
+them via the shared `_apply_loop_options` helper, so a `for` and a `while`
+receive byte-identical attributes.
+
+The C++ inventory and scheduler-loop propagation policy are centralized in
+`include/triton/Dialect/Triton/IR/DiscardableAttributes.h` and
+`lib/Dialect/Triton/IR/DiscardableAttributes.cpp`. The registry contains every
+attribute emitted by `AutoWSLoopOptions`, including attributes consumed before
+the single-trip rewrite and those that must be forwarded to the inner compute
+loop. A new frontend option must add one registry entry and choose its
+propagation policy; transforms such as `SimplifySingleTripWhile` filter this
+registry instead of maintaining private allowlists. Internal scheduling
+metadata such as `tt.scheduled_max_stage` remains separate from the frontend
+AutoWS inventory.
 
 ## Annotation → IR attribute → consumer
 
@@ -44,6 +54,7 @@ single new field on `AutoWSLoopOptions`.
 | `merge_epilogue` / `merge_epilogue_to_computation` / `merge_correction` | `tt.merge_*` | `PartitionSchedulingMeta` (`SchedulingOptions`) | epilogue/correction routing |
 | `separate_epilogue_store` | `tt.separate_epilogue_store` | `PartitionSchedulingMeta` | epilogue store gets own partition |
 | `tmem_alloc_algo` / `smem_alloc_algo` / `smem_budget` / `smem_circular_reuse` | `tt.{tmem,smem}_alloc_algo`, `tt.smem_budget`, `tt.smem_circular_reuse` | `WSMemoryPlanner` | allocation heuristics |
+| `list_schedule_pick` / `mem_plan_pick` | `tt.list_schedule_pick` / `tt.mem_plan_pick` | list scheduler / `WSMemoryPlanner` | ranked schedule and memory-plan selection |
 | `disable_licm` | `llvm.loop_annotation` | LICM | suppress hoisting |
 
 See `PartitionSchedulingMeta.md` for how the `merge_*` / `separate_epilogue_store`
@@ -56,12 +67,28 @@ kernel with an `scf.while` outer loop. The annotations are *attached* to the
 `while` identically to a `for` (via `tl.condition`) and survive into TTGIR, but
 whether they take *effect* depends on the schedule:
 
-| Schedule | outer loop after `make_ttir` | annotations effective? |
+| Schedule | outer-loop handling | annotations effective? |
 |---|---|---|
 | static persistent | uplifted to `scf.for` (`triton-uplift-while-to-for`) | **yes** — treated as a normal `for` |
 | dynamic persistent | stays `scf.while` (atomic advance) | **partial** — see below |
 | CLC | stays `scf.while` (hardware `_valid`) | **partial** — see below |
-| non-persistent | single-trip `while` eliminated (`triton-simplify-single-trip-while`) | n/a — no loop |
+| non-persistent | kept through data partitioning, then eliminated before the default loop schedule | **yes** — AutoWS is forwarded to the first-level inner loop |
+
+For non-persistent schedules on Hopper and Blackwell,
+`triton-simplify-single-trip-while` deliberately runs in TTGIR after data
+partitioning and before default latency assignment and loop scheduling. Before
+inlining the single-trip while, it forwards the still-live AutoWS attributes to
+`scf.for` loops exactly one loop-nesting level inside the scheduler while. This
+is based on the nearest enclosing loop, so intervening non-loop control flow
+such as `scf.if` is transparent, while a nested second-level loop is excluded.
+This lets downstream scheduling and warp-specialization passes operate on the
+inner loop without hiding the outer loop from data partitioning. An annotated
+while with no first-level inner target is preserved rather than silently losing
+warp specialization. Attributes whose
+consumers already ran, such as `tt.list_schedule_pick`, are not forwarded;
+later consumers such as the memory planner and multi-CTA reduction still
+receive `tt.mem_plan_pick` and `tt.multi_cta`, respectively. Existing
+attributes on the selected inner loop take precedence over outer defaults.
 
 ### `warp_specialize` on a non-countable `while`: **no-op today**
 
@@ -94,12 +121,13 @@ regions correctly. This is verified by the lit tests `@while_data_partition`,
 mirrors the CLC scheduler shape with `ttng.clc_advance`) in
 `test/Hopper/WarpSpecialization/ws_while_loop_autows.mlir`.
 
-However, `WSDataPartition` runs *after* `PartitionSchedulingMeta` has assigned
-partitions and `tt.warp_specialize` has been consumed. Because that does not
-happen for a non-uplifted `while` (previous section), end-to-end data
-partitioning of a dynamic/CLC `while` is gated on the same
-`PartitionSchedulingMeta` generalization. In other words: the data-partition
-mechanism is ready for `while`; the partition-*assignment* front-end is not.
+`WSDataPartition` runs before `PartitionSchedulingMeta`, while the annotated
+outer loop still exists. For a non-persistent schedule the subsequent
+single-trip rewrite forwards AutoWS to the inner loop, so partition assignment
+can continue there. Dynamic/CLC loops are not eliminated and remain gated on
+the `PartitionSchedulingMeta` generalization described above. In other words:
+the data-partition mechanism is ready for `while`; persistent while
+partition-*assignment* is not.
 
 > Known cosmetic artifact: data-partitioning a `while` leaves the original
 > full-width dot as a *dead* loop result (not DCE'd, because removing a dead
@@ -110,9 +138,12 @@ mechanism is ready for `while`; the partition-*assignment* front-end is not.
 ## Summary
 
 - **Annotations are unified** across `for`/`while` via `AutoWSLoopOptions`; the
-  frontend and IR emission are in lockstep.
+  frontend and IR emission are in lockstep, while the shared C++ registry owns
+  their scheduler-loop propagation policy.
 - **On `scf.for`** (including a static `while` uplifted to `for`): all
   annotations work.
+- **On a non-persistent `scf.while`**: data partitioning sees the while before
+  it is eliminated, then AutoWS is forwarded to the scheduled inner loop.
 - **On a raw `scf.while`** (dynamic/CLC): the annotations attach and survive,
   `WSDataPartition` already understands `while`, but `warp_specialize` /
   `data_partition_factor` do not yet take effect end-to-end because

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWSAnnotations.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWSAnnotations.md
@@ -90,20 +90,15 @@ later consumers such as the memory planner and multi-CTA reduction still
 receive `tt.mem_plan_pick` and `tt.multi_cta`, respectively. Existing
 attributes on the selected inner loop take precedence over outer defaults.
 
-### `warp_specialize` on a non-countable `while`: **no-op today**
+### `warp_specialize` on a non-countable `while`
 
 `ttg.warp_specialize` is emitted by the pipeline `ScheduleLoops` →
-`PartitionSchedulingMeta` → `hopper_warpspec`. `ScheduleLoops` and
-`PartitionSchedulingMeta` walk **`scf::ForOp` only**, so a `tt.warp_specialize`
-on a raw `scf.while` (dynamic/CLC) is never consumed — no partitions are
-assigned and no `ttg.warp_specialize` is produced. Only the *static* schedule,
-which is uplifted to an `scf.for` before these passes run, is warp-specialized.
-
-This is a code-scope limitation, not a fundamental one, and **not** a software-
-pipelining requirement (the partition scheduler derives partitions structurally
-and ignores the SWP `distance`). Closing it means generalizing
-`PartitionSchedulingMeta` (and `ScheduleLoops`) to `scf.while`. The full plan is
-in **[WarpSpecializeWhileLoops.md](WarpSpecializeWhileLoops.md)**.
+`PartitionSchedulingMeta` → `hopper_warpspec`. `PartitionSchedulingMeta` accepts
+identity-carry `scf.while` and derives its partitions structurally from the
+after region. `ScheduleLoops` remains `scf.for`-only: the non-countable outer
+while is not software-pipelined, while its nested K-loop retains the existing
+for-loop software pipeline. Downstream dynamic/CLC validation is tracked in
+**[WarpSpecializeWhileLoops.md](WarpSpecializeWhileLoops.md)**.
 
 ### `num_stages` / pipelining on a `while`: not applicable
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/DynamicPersistentAutoWSGaps.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/DynamicPersistentAutoWSGaps.md
@@ -1,0 +1,268 @@
+# Dynamic Persistent AutoWS Support Gaps
+
+**Files**: `PartitionSchedulingMeta.cpp`, `WSAtomicBroadcast.cpp`,
+`WarpSpecialization.cpp`, `WSDataPartition.cpp`, `WSSpecialize.cpp`,
+`WSBuffer.cpp`, `WSCodePartition.cpp`, and TritonGPU's
+`WarpSpecialization/Partition.{h,cpp}`.
+
+## Scope
+
+This document describes the remaining work for making a non-countable dynamic
+persistent `scf.while` the loop selected for automatic warp specialization.
+The target frontend shape is:
+
+```python
+sched = tl.DynamicPersistent1DScheduler.initialize(...)
+while tl.condition(
+    sched.is_valid(),
+    warp_specialize=True,
+    data_partition_factor=...,
+):
+    ... one output tile ...
+    sched = sched.advance()  # scalar atomic tile claim
+```
+
+This is distinct from the dynamic persistent path that works today. The current
+GEMM test marks the nested K `scf.for` with `warp_specialize=True`; the outer
+dynamic `scf.while` is cloned as surrounding control flow after partitions have
+already been assigned from that inner loop.
+
+## What Works Today
+
+The existing inner-loop path supports dynamic persistent GEMM on Hopper and
+Blackwell:
+
+1. `PartitionSchedulingMeta` assigns partitions from the annotated K
+   `scf.for`.
+2. Task-id propagation extends those assignments over the enclosing
+   `scf.while`.
+3. `doDynamicTileBroadcast` retags the loop-carried scalar atomic to one owner
+   partition and broadcasts its result through an SMEM channel to every
+   partition.
+4. Code specialization clones the persistent while for each partition.
+5. While-aware accumulation counters rotate channel buffers and mbarrier phases
+   across persistent iterations.
+
+The following pieces already understand `scf.while` and are not the primary
+blocker:
+
+- task-id propagation;
+- data partition slicing and while-carried result updates;
+- physical warp-group cloning (`SpecializeWhileOp`);
+- channel discovery and code partitioning;
+- accumulation-counter threading through the before/after regions;
+- direct-while channel buffer index and phase calculation;
+- run-once scalar atomic and CLC result broadcast.
+
+Existing coverage includes:
+
+- `test_tutorial09_matmul_tma_dynamic_persistent_while_loop_warp_specialize`
+  with `EPILOGUE_SUBTILE` 1, 2, and 4;
+- `ws_atomic_broadcast_transform.mlir`, including broadcast depth 2;
+- `ws_atomic_broadcast_reject.mlir` for graceful rejection of an unsupported
+  scatter atomic;
+- simple while task-id, data-partition, and code-partition cases in
+  `ws_while_loop_autows.mlir`.
+
+## Partition Assignment Foundation
+
+`PartitionSchedulingMeta` now discovers annotated `scf::ForOp` and
+identity-carry `scf::WhileOp` loops. Its categorization, cross-iteration
+tracing, partition propagation, schedule optimization, and serialization APIs
+use `LoopLikeOpInterface`, while nested software-pipelined K-loops remain
+`scf::ForOp`.
+
+The pass and its helpers need a loop-body abstraction over
+`LoopLikeOpInterface`:
+
+| Concept | `scf.for` | `scf.while` |
+|---|---|---|
+| scheduled body | body region | after region |
+| carried body arguments | body args after the IV | all after-region args |
+| next-iteration values | body `scf.yield` | after-region `scf.yield` |
+| condition forwarding | implicit | before-region `scf.condition` args |
+| induction variable | explicit body arg 0 | none |
+
+The partition scheduler may only use the simple identity-carry while shape:
+every before-region argument must be forwarded by `scf.condition` in the same
+order. Other shapes must retain a documented, safe no-op behavior rather than
+risk incorrect cross-iteration dependency tracing.
+
+### Implemented PSM changes
+
+- Collect annotated `scf::ForOp` and `scf::WhileOp` loops.
+- Generalize `getInitialSchedule`, `OpCategorizer`, MMA backward-slice
+  collection, partition propagation, schedule optimization, and serialization.
+- Discover nested K `scf.for` loops from the while after-region.
+- Trace carried definitions and users through `yield -> before arg ->
+  condition arg -> after arg` without the for-loop induction-variable offset.
+- Assign partitions to before-region condition computation and terminators so
+  every specialized partition evaluates the same broadcast tile ID.
+- Generalize `Partition`, `PartitionSet::fromLoop`, `serialize`,
+  `swapPartitions`, and the `iterate*` helpers.
+- Keep the existing `scf.for` behavior unchanged.
+
+Focused lit coverage validates direct outer-while scheduling, schedule
+round-tripping, condition/task replication, warp-budget cleanup, and graceful
+rejection of reordered or subset condition forwarding.
+
+The atomic-broadcast half of the outer-while path is now also validated in
+isolation (`ws_atomic_broadcast_from_psm.mlir`): starting from an
+**unpartitioned** dynamic-persistent GEMM `scf.while` with a scalar
+`tt.atomic_rmw` tile claim, the chain `nvgpu-partition-scheduling-meta ->
+nvgpu-test-taskid-propagate -> nvgpu-test-ws-atomic-broadcast` transforms the
+claim into run-once-in-owner + broadcast-to-all. **Key finding:** no PSM change
+was needed to feed the broadcast — task-id propagation already flows the full
+partition union backward from the loop-carried value (used by every partition)
+onto the atomic, so `classifyAtomic` sees `taskIds.size() == allParts.size()`
+and classifies it `Transform`. The owner resolves to the TMA-load partition via
+`getOwnerPartition`, exactly as intended. (`nvgpu-test-ws-atomic-broadcast` is a
+new thin test pass wrapping `doDynamicTileBroadcast`, mirroring
+`nvgpu-test-taskid-propagate`; the step has no standalone pass otherwise.)
+
+The remaining gap is end-to-end validation through **code partitioning**
+(channel/barrier synthesis, while accumulation counters) and physical
+specialization for a full GEMM while body.
+
+## Cleanup and Bailout Foundation
+
+PSM's local `dropWarpSpec` helper strips loop metadata from both `scf.for` and
+`scf.while`, including:
+
+- `tt.warp_specialize`;
+- `ttg.partition.stages`;
+- `ttg.partition.types`;
+- `ttg.warp_specialize.tag`.
+
+It also removes op-level partition metadata, so warp-budget rejection and
+invalid condition forwarding cannot leave a half-specialized function.
+
+The post-scheduling dead-op cleanup treats `scf.while` as structural control
+flow and never erases it as a use-empty, single-result operation.
+
+The physical `NVGPUWarpSpecialization` fallback scan recognizes annotated
+`scf.for` and `scf.while` loops when no partition/task attributes exist.
+
+## Software-Pipeline Boundary
+
+The non-countable outer while should not be software-pipelined: it has no static
+trip count, and the atomic broadcast channel provides cross-tile producer
+run-ahead. The nested K `scf.for` remains the software-pipelined loop.
+
+Consequently, full while support is not required in `AssignLatencies`,
+`ScheduleLoops`, or the software-pipeline expander. The required audit is
+narrower:
+
+- preserve the inner K-loop schedule while the outer while is partitioned and
+  cloned;
+- make post-WS loop-schedule preprocessing recognize that the specialized
+  outer control flow can be an `scf.while`;
+- do not interpret `tt.num_stages` on the outer dynamic while as a request to
+  software-pipeline that while.
+
+## Atomic Broadcast Restrictions
+
+`doDynamicTileBroadcast` is ready for the standard scheduler shape, but it is
+intentionally narrow. A replicated atomic is transformable only when it is:
+
+- scalar (not a tensor/scatter atomic);
+- directly yielded as a carried value of an enclosing `scf.while`;
+- mapped to every partition, not a strict subset;
+- suitable for ownership by one partition and broadcast to the others.
+
+Any other replicated atomic causes a transactional, graceful rejection of
+AutoWS for the function. This means outer-while support will not automatically
+cover arbitrary work queues, transformed/cast atomic results, or bodies with
+unrelated replicated atomics.
+
+The owner-selection heuristic prefers the partition containing a TMA load and
+otherwise uses the lowest partition ID. That is correct for the current GEMM
+shape but needs validation for dynamic persistent kernels without TMA loads.
+
+Broadcast depth defaults to one, which keeps partitions in lockstep at the tile
+claim. Depth greater than one is covered by lit but lacks runtime correctness
+and performance coverage.
+
+## 2-CTA Gap
+
+Dynamic persistence with a 2-CTA MMA requires one logical tile claim per CTA
+cluster. The current scheduler seeds work from physical program IDs, and the
+atomic broadcast synchronizes warp partitions within a CTA. It does not define:
+
+- physical-CTA to logical-cluster tile mapping;
+- which CTA owns the cluster's atomic claim;
+- how the claimed tile ID is distributed to the peer CTA;
+- counter initialization and termination accounting per cluster.
+
+Therefore dynamic 2-CTA should be treated as a separate feature after basic
+outer-while AutoWS works. Reusing the intra-CTA atomic broadcast without a
+cluster-level ownership protocol would allow both CTAs to advance the global
+counter independently.
+
+## Frontend and Configuration Gaps
+
+Because the current workaround annotates the inner K loop, outer-while options
+do not have a complete end-to-end contract for dynamic persistence. This
+includes:
+
+- `data_partition_factor`;
+- `merge_epilogue`, `merge_epilogue_to_computation`, and `merge_correction`;
+- `separate_epilogue_store`;
+- SMEM/TMEM allocation options;
+- generated subtiled regions;
+- register-budget and ping-pong combinations.
+
+`num_stages` on the dynamic outer while should remain inert or produce a clear
+frontend diagnostic; stages belong on the nested K loop.
+
+## Test Gaps
+
+The current E2E dynamic GEMM test validates the manual atomic scheduler shape
+with inner-loop AutoWS. It does not prove that an annotated outer while is the
+selected AutoWS loop. The unified `DynamicPersistent1DScheduler` currently has
+frontend IR-shape coverage, but no outer-while AutoWS E2E coverage.
+
+Required coverage:
+
+1. **PSM lit** [done]: an annotated identity-carry `scf.while` with a nested MMA
+   loop; check partitions on condition, tile mapping, loads, MMA, epilogue,
+   atomic, and while terminators. (`ws_while_loop_autows.mlir`.)
+2. **Negative PSM lit** [done]: reordered/subset condition forwarding is skipped
+   without partial metadata. (`ws_while_loop_autows.mlir`.)
+3. **Atomic integration lit** [partial]: PSM + task propagation + atomic
+   broadcast from an initially unpartitioned outer while is done
+   (`ws_atomic_broadcast_from_psm.mlir`, accept + depth-2). Extending the same
+   chain through **code partitioning** is still pending.
+4. **Unified E2E**: `DynamicPersistent1DScheduler` with outer
+   `tl.condition(..., warp_specialize=True)` and an unannotated K loop.
+5. **Feature E2E**: epilogue subtiles, DP=2, separate epilogue store, generated
+   subtiled regions, and broadcast depths greater than one.
+6. **Bailout E2E/lit**: scatter, strict-subset, non-carried, and unrelated
+   replicated atomics leave a compilable non-WS kernel.
+7. **Hopper and Blackwell**: correctness on both architectures; CLC remains a
+   Blackwell-only sibling path.
+8. **Performance**: compare static persistent, dynamic inner-loop AutoWS,
+   dynamic outer-loop AutoWS at depth 1, and tuned broadcast depth.
+
+## Recommended Implementation Order
+
+1. Validate the existing atomic broadcast and while accumulation-counter paths
+   against the newly assigned outer schedule. **Atomic broadcast is validated in
+   isolation** (`ws_atomic_broadcast_from_psm.mlir`); the accumulation-counter /
+   code-partition half of this step is still open.
+2. Add unified dynamic E2E and feature combinations.
+3. Address dynamic 2-CTA as a separate cluster-level design.
+
+## Definition of Done
+
+Basic dynamic outer-loop AutoWS is complete when a unified scheduler kernel can
+place `warp_specialize=True` only on its dynamic `tl.condition`, leave the K
+loop unannotated, and satisfy all of the following:
+
+- PSM serializes a valid partition schedule on the `scf.while`;
+- exactly one atomic tile claim executes per logical CTA iteration;
+- all partitions evaluate the same current and terminating tile IDs;
+- physical `ttg.warp_specialize` regions are emitted;
+- buffer slots and mbarrier phases rotate correctly across persistent tiles;
+- correctness passes for epilogue subtiles on Hopper and Blackwell;
+- unsupported while/atomic shapes cleanly fall back without residual metadata.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -32,6 +32,13 @@ Data partitioning is not Hopper-only; it can run as the separate
 `nvgpu-ws-data-partition` pass when an explicit data partition factor or warp
 group configuration requires per-consumer slices.
 
+For a non-persistent unified scheduler, the single-trip `scf.while` is kept
+through data partitioning and the initial loop schedule. The
+`triton-simplify-single-trip-while` pass then forwards the outer AutoWS
+attributes to the scheduled inner `scf.for` loop and inlines the while before
+`PartitionSchedulingMeta` assigns partitions. Physical `ttg.warp_specialize`
+regions are created later by `specializeRegion` during `doCodePartitionPost`.
+
 Before `PartitionSchedulingMeta`, the Meta WS backend runs
 `nvgpu-sink-broadcast` to move `tt.broadcast` producer chains next to their
 elementwise users. This keeps broadcasts and their value materialization, such

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -77,7 +77,7 @@ recognizes the `scf.while` outer loop (same doc).
 |------|----------------|-------------|
 | `WarpSpecialization.cpp` | `NVGPUWarpSpecialization` | Top-level pipeline orchestration |
 | `SinkBroadcast.cpp` | `nvgpu-sink-broadcast` | Pre-partition peephole that sinks `tt.broadcast` producer chains to elementwise users |
-| `PartitionSchedulingMeta.cpp` | `nvgpu-partition-scheduling-meta` | Partition scheduling for Blackwell (assigns `ttg.partition` attributes). See [PartitionSchedulingMeta.md](PartitionSchedulingMeta.md); [WarpSpecializeWhileLoops.md](WarpSpecializeWhileLoops.md) covers extending it to `scf.while` (in progress) |
+| `PartitionSchedulingMeta.cpp` | `nvgpu-partition-scheduling-meta` | Partition scheduling for Blackwell (assigns `ttg.partition` attributes), including identity-carry `scf.while`. See [PartitionSchedulingMeta.md](PartitionSchedulingMeta.md); downstream dynamic/CLC validation is tracked in [WarpSpecializeWhileLoops.md](WarpSpecializeWhileLoops.md) |
 | (frontend) | `tl.range` / `tl.condition` → `tt.*` loop attrs | The user-facing AutoWS/pipelining annotations, their IR attributes and consumers, and what works on `scf.while` today: [AutoWSAnnotations.md](AutoWSAnnotations.md) |
 | `WSTaskPartition.cpp` | `doTaskPartition` | Assigns `async_task_id` to anchor ops (loads, dots, stores) — Hopper only |
 | `TaskIdPropagation.cpp` | — | `TaskIdBackwardPropagation` sparse dataflow analysis |
@@ -130,6 +130,7 @@ recognizes the `scf.while` outer loop (same doc).
 
 - [Task Partitioning & ID Propagation](TaskPartitionAndPropagation.md) — how ops are assigned to partitions
 - [Cross-Partition Run-Once Atomic Support](CrossPartitionAtomicSupport.md) — dynamic-persistent tile-id `atomic_add` broadcast
+- [Dynamic Persistent AutoWS Gaps](DynamicPersistentAutoWSGaps.md) — current inner-loop support, outer-while blockers, and completion criteria
 - [Data Partitioning](DataPartition.md) — splitting tensor dimensions across consumer warp groups
 - [Code Partitioning](CodePartition.md) — channel discovery, buffer creation, sync insertion
 - [Code Specialization](CodeSpecialization.md) — how ops are cloned into WarpSpecializeOp regions

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
@@ -8,9 +8,10 @@ pipeline — it determines which warp group each operation will execute on.
 
 ## Overview
 
-The pass walks all `scf.for` loops with the `tt.warp_specialize` attribute and
-assigns each operation inside the loop (and post-loop consumers) to a
-**partition**. Each partition maps to a warp group at runtime.
+The pass walks supported loop-like operations with the `tt.warp_specialize`
+attribute and assigns each operation inside the scheduled body (and post-loop
+consumers) to a **partition**. Each partition maps to a warp group at runtime.
+The supported forms are `scf.for` and identity-carry `scf.while`.
 
 ```
 Phase 1: Categorize operations         (OpCategorizer + collectMMABackwardSlices)
@@ -22,6 +23,24 @@ Phase 6: Schedule post-loop ops        (schedulePostLoopOps — epilogue routing
   ─── end of getInitialSchedule ───
 Post:    propagatePartitions + optimizeSchedule + splitDataPartitionedIfOps
 ```
+
+## Supported Loop Forms
+
+Partition scheduling uses `LoopLikeOpInterface` at its API boundary, but does
+not accept arbitrary loop-like operations. `scf.for` uses its body region and
+retains the existing induction-variable offset. `scf.while` uses its after
+region as the scheduled body and has no induction variable.
+
+An `scf.while` is schedulable only when `scf.condition` forwards every
+before-region argument once, in the same order. This makes yield slot `k`,
+before argument `k`, after argument `k`, and the next-iteration carried value
+unambiguous. Reordered or subset forwarding is rejected by stripping the
+loop-local warp-specialization metadata and leaving a plain while loop.
+
+The before region remains loop control rather than a PSM partition. Task-ID
+propagation marks the while, its condition computation, `scf.condition`, and
+`scf.yield` with the union of tasks after the single-partition PSM anchors have
+been converted to task IDs.
 
 ## Tuning Knobs
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WarpSpecializeWhileLoops.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WarpSpecializeWhileLoops.md
@@ -37,7 +37,7 @@ work-stealing) and **CLC** (hardware `_valid`) — whose outer loop stays an
 `scf.while`. Today they are *not* warp-specialized. This doc describes making
 `PartitionSchedulingMeta` (the first AutoWS pass) schedule an `scf.while`.
 
-## Why it doesn't work today (and why SWP is *not* the blocker)
+## Implemented boundary (and why SWP is *not* the blocker)
 
 `PartitionSchedulingMeta` derives the partition schedule **structurally**
 (op categorization + MMA backward slices — see `PartitionSchedulingMeta.md`); it
@@ -47,7 +47,7 @@ only reads a pre-serialized schedule (`ttg.partition.stages` /
 its own. So warp-specializing the `while` does **not** require software
 pipelining it.
 
-The actual blocker is purely that the pass is typed on `scf::ForOp` and assumes
+The original blocker was that the pass was typed on `scf::ForOp` and assumed
 the single-region for-loop shape:
 
 - Entry walk: `getOperation().walk([&](scf::ForOp loop){ if hasAttr(tt.warp_specialize) })`
@@ -58,7 +58,9 @@ the single-region for-loop shape:
   body via `loop.getBody()`, `loop.getRegionIterArg(n)`, `loop.getInductionVar()`,
   `loop.getYieldedValues()`, `loop.getOps<scf::ForOp>()`.
 
-Everything downstream of the partition schedule already handles `scf.while`:
+The partition and PSM APIs now use `LoopLikeOpInterface` for the supported
+`scf.for` and identity-carry `scf.while` forms. Everything downstream of the
+partition schedule already handles `scf.while`:
 task-id propagation, data partition, and code partition each have `scf.while`
 lit tests (`ws_while_loop_autows.mlir`). So the change is concentrated in this
 one pass.
@@ -217,5 +219,5 @@ empirical follow-on work — not a known blocker.
 
 - [x] Frontend annotation on `while` (`AutoWSLoopOptions` + `tl.condition`) — done.
 - [x] `uplift-while-to-for` attribute transfer (static path) — done.
-- [ ] Loop-body abstraction + `PartitionSchedulingMeta` generalization — this doc.
+- [x] Loop-body abstraction + `PartitionSchedulingMeta` generalization — done.
 - [ ] Downstream end-to-end validation for dynamic/CLC.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WarpSpecializeWhileLoops.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WarpSpecializeWhileLoops.md
@@ -220,4 +220,10 @@ empirical follow-on work — not a known blocker.
 - [x] Frontend annotation on `while` (`AutoWSLoopOptions` + `tl.condition`) — done.
 - [x] `uplift-while-to-for` attribute transfer (static path) — done.
 - [x] Loop-body abstraction + `PartitionSchedulingMeta` generalization — done.
-- [ ] Downstream end-to-end validation for dynamic/CLC.
+- [x] Atomic broadcast validated in isolation from a PSM-assigned outer while
+  (`ws_atomic_broadcast_from_psm.mlir`, via the new `nvgpu-test-ws-atomic-broadcast`
+  test pass). Task-id propagation already supplies the full-union `async_task_id`
+  the broadcast needs — no PSM change was required. See
+  `docs/DynamicPersistentAutoWSGaps.md`.
+- [ ] Downstream end-to-end validation for dynamic/CLC (code partition + physical
+  specialization for a full GEMM while body).

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WarpSpecializeWhileLoops.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WarpSpecializeWhileLoops.md
@@ -27,8 +27,10 @@ Two of the four schedules are already covered without touching AutoWS:
 - **Static persistent** — the while is *countable*, so `triton-uplift-while-to-for`
   rewrites it to an `scf.for` (carrying the annotations) before AutoWS runs. It is
   then warp-specialized by the existing `scf.for` path.
-- **Non-persistent** — the while is single-trip and eliminated by
-  `triton-simplify-single-trip-while`; there is no persistent loop to specialize.
+- **Non-persistent** — the while is kept through data partitioning and initial
+  loop scheduling, then `triton-simplify-single-trip-while` forwards AutoWS to
+  the scheduled inner loop and eliminates the single-trip outer loop before
+  partition scheduling.
 
 That leaves the **genuinely non-countable** schedules — **dynamic** (atomic
 work-stealing) and **CLC** (hardware `_valid`) — whose outer loop stays an

--- a/third_party/tlx/tools/sched2tlx/examples/case2_persistent_gemm/pre_modulo.ttgir
+++ b/third_party/tlx/tools/sched2tlx/examples/case2_persistent_gemm/pre_modulo.ttgir
@@ -112,5 +112,3 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
 #loc54 = loc(callsite(#loc10 at #loc39))
 #loc55 = loc(callsite(#loc8 at #loc33))
 #loc56 = loc(callsite(#loc10 at #loc33))
-
-

--- a/third_party/tlx/tools/sched2tlx/examples/case8_multiphase_gemm/triple_gemm_nows_pre_modulo.ttgir
+++ b/third_party/tlx/tools/sched2tlx/examples/case8_multiphase_gemm/triple_gemm_nows_pre_modulo.ttgir
@@ -143,5 +143,3 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
 #loc67 = loc("acc3"(#loc2))
 #loc68 = loc("a"(#loc29))
 #loc69 = loc("b"(#loc30))
-
-

--- a/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/generated.py
+++ b/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/generated.py
@@ -121,7 +121,7 @@ def _scaled_mm_blockwise(
         # Async task: role=TMA ← inner wg3 (Phase 4 plan)
         with tlx.async_task(num_warps=4, num_regs=152):
             smem_accum = 0
-            # Re-materialize function-scope register tensors locally (a 
+            # Re-materialize function-scope register tensors locally (a
             # non-default warp group cannot capture RankedTensorType).
             _wgloc600 = tl.arange(0, 128)
             # Outer persistent loop (loop 1, II=45824). Each task replays it; body trimmed to this WG's ops.
@@ -143,7 +143,7 @@ def _scaled_mm_blockwise(
         with tlx.async_task("default"):
             smem_accum = 0
             tmem_accum_cnt = 0
-            # Re-materialize function-scope register tensors locally (a 
+            # Re-materialize function-scope register tensors locally (a
             # non-default warp group cannot capture RankedTensorType).
             _wgloc600 = tl.arange(0, 128)
             # Outer persistent loop (loop 1, II=45824). Each task replays it; body trimmed to this WG's ops.

--- a/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/scaled_mm_blockwise_pre_modulo.ttgir
+++ b/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/scaled_mm_blockwise_pre_modulo.ttgir
@@ -160,5 +160,3 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
 #loc83 = loc(callsite(#loc9 at #loc55))
 #loc84 = loc(callsite(#loc7 at #loc57))
 #loc85 = loc(callsite(#loc9 at #loc57))
-
-


### PR DESCRIPTION
Summary: Adds testing beyond e2e testing that the atomic broadcast path works as intended with AutoWS by placing the AutoWS logic in the outer while loop.

Pulled By:
njriasan


njriasan

Reviewed By: manman-ren

Differential Revision: D112888969
