### PR TITLE
 [AutoWS] Convert tt.descriptor_load to nvws.descriptor_load in AutoWS (#2267)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
@@ -20,6 +20,10 @@ triton::gpu::SharedEncodingTrait
 getEncodingFromDescriptor(Operation *op, RankedTensorType tensorType,
                           Value desc);
 
+int64_t getDescriptorLoadBytes(Operation *op, RankedTensorType tensorType,
+                               Value desc);
+int64_t getDescriptorLoadBytes(triton::gpu::MemDescType memDescType);
+
 bool hasCGABroadcast(gpu::MemDescType memDescType);
 
 Value sextI16ToI32Indices(Value indices, OpBuilder &builder, Location loc);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
@@ -4,6 +4,7 @@
 #include <triton/Tools/LayoutUtils.h>
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
@@ -27,6 +28,20 @@ ttg::SharedEncodingTrait getEncodingFromDescriptor(Operation *op,
     return sharedEnc;
 
   return ttg::updateEncodingForShape(op, sharedEnc, tensorType);
+}
+
+int64_t getDescriptorLoadBytes(Operation *op, RankedTensorType tensorType,
+                               Value desc) {
+  auto encoding = getEncodingFromDescriptor(op, tensorType, desc);
+  auto shapePerCTA = ttg::getShapePerCTA(encoding, tensorType.getShape());
+  return product(shapePerCTA) *
+         getIntOrFloatOrPtrBitWidth(tensorType.getElementType()) / 8;
+}
+
+int64_t getDescriptorLoadBytes(ttg::MemDescType memDescType) {
+  auto shapePerCTA = ttg::getShapePerCTA(memDescType);
+  return product(shapePerCTA) *
+         getIntOrFloatOrPtrBitWidth(memDescType.getElementType()) / 8;
 }
 
 Value sextI16ToI32Indices(Value indices, OpBuilder &builder, Location loc) {

--- a/test/Hopper/WarpSpecialization/autows_addmm_warp_specialization.mlir
+++ b/test/Hopper/WarpSpecialization/autows_addmm_warp_specialization.mlir
@@ -21,8 +21,10 @@
 // CHECK: constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}
 // CHECK: ttng.async_tma_copy_local_to_global
 // CHECK: partition2
-// CHECK: ttng.async_tma_copy_global_to_local
-// CHECK: tt.descriptor_load
+// CHECK-COUNT-6: ttng.async_tma_copy_global_to_local
+// CHECK: ttg.local_load {{.*}} -> tensor<128x32xf16
+// CHECK-NOT: tt.descriptor_load
+// CHECK-NOT: nvws.descriptor_load
 // CHECK: constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2>, dstTask = 0 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/test/Hopper/WarpSpecialization/swap_transposed_local_alloc.mlir
+++ b/test/Hopper/WarpSpecialization/swap_transposed_local_alloc.mlir
@@ -9,12 +9,11 @@
 // CHECK-LABEL: @swap_transposed_alloc
 //
 // After buffer allocation, the dsT alloc is swapped to non-transposed #shared
-// layout and hoisted above the loop. The first two allocs are the original
-// k_smem/q_smem buffers; dsT remains after them because hoisting preserves
-// producer order.
-// CHECK: ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
-// CHECK: ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+// layout and hoisted above the loop. Descriptor conversion now precedes
+// hoisting, so the cross-partition dsT/dq buffer is placed before the
+// descriptor destination buffers.
 // CHECK: %[[B0:.*]] = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+// CHECK: ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
 //
 // Inside the loop, memdesc_trans goes from #shared (non-transposed) to #shared1
 // (transposed), confirming the swap happened:

--- a/test/Hopper/WarpSpecialization/ws_buffer_allocation_hoist_order.mlir
+++ b/test/Hopper/WarpSpecialization/ws_buffer_allocation_hoist_order.mlir
@@ -1,15 +1,15 @@
 // RUN: triton-opt %s --nvgpu-test-ws-buffer-allocation | FileCheck %s
 
-// createBuffer sorts channels by producer program order before hoisting their
-// buffers. Hoisting must insert each new allocation after the previous hoisted
-// allocation; otherwise every allocation is inserted at function entry and the
-// final order is reversed.
+// Each register-consumed descriptor load is converted to an nvws.descriptor_load
+// that writes its own SMEM buffer, in producer program order. The A load's
+// buffer/load must be emitted before the B load's; otherwise the producer order
+// is reversed (e.g. every allocation hoisted to function entry in reverse).
 
 // CHECK-LABEL: @hoist_preserves_producer_order
-// CHECK: %[[A_BUF:.*]] = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16
-// CHECK: %[[B_BUF:.*]] = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16
-// CHECK: ttg.local_store {{.*}}, %[[A_BUF]]
-// CHECK: ttg.local_store {{.*}}, %[[B_BUF]]
+// CHECK: %[[A_BUF:.*]] = ttg.local_alloc {{.*}}: () -> !ttg.memdesc<128x64xf16
+// CHECK: nvws.descriptor_load {{.*}} %[[A_BUF]]
+// CHECK: %[[B_BUF:.*]] = ttg.local_alloc {{.*}}: () -> !ttg.memdesc<64x128xf16
+// CHECK: nvws.descriptor_load {{.*}} %[[B_BUF]]
 
 #blocked_a = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked_b = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/test/Hopper/WarpSpecialization/ws_code_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition.mlir
@@ -153,7 +153,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttg.memdesc_trans
 // CHECK: ttng.warp_group_dot
 // CHECK: partition1
-// CHECK: ttg.local_load
+// CHECK-NOT: ttg.local_load
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>

--- a/test/Hopper/WarpSpecialization/ws_code_partition_merged_barrier.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_merged_barrier.mlir
@@ -28,6 +28,8 @@
 // CHECK: ttng.tmem_load
 // CHECK: tt.descriptor_store
 // CHECK: tt.descriptor_store
+// CHECK-NOT: tt.descriptor_load
+// CHECK-NOT: nvws.descriptor_load
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 256], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/test/Hopper/WarpSpecialization/ws_lower_mem_tma_multi_consumer_task_ids.mlir
+++ b/test/Hopper/WarpSpecialization/ws_lower_mem_tma_multi_consumer_task_ids.mlir
@@ -14,6 +14,8 @@
 // CHECK: ttng.wait_barrier {{.*}}async_task_id = array<i32: 2>
 // CHECK: %[[LOCAL1:.*]] = ttg.local_load {{.*}}async_task_id = array<i32: 2>
 // CHECK: arith.subf %[[LOCAL1]], %[[LOCAL1]] {{.*}}async_task_id = array<i32: 2>
+// CHECK-NOT: tt.descriptor_load
+// CHECK-NOT: nvws.descriptor_load
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_bwd.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_bwd.mlir
@@ -46,23 +46,23 @@
 // SMEM allocations
 // CHECK: %do = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32}
 // CHECK: %q = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 2 : i32}
-// CHECK: %k_42 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
-// CHECK: %v_43 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
+// CHECK: %k_41 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32}
+// CHECK: %v = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32}
 //
 // TMEM allocations: qkT owns buffer 7
-// CHECK: %qkT, %qkT_44 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 7 : i32}
+// CHECK: %qkT, %qkT_42 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 7 : i32}
 //
 // TMEM allocation: dv_45 (f32 accumulator) owns buffer 6
-// CHECK: %dv_45, %dv_46 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 6 : i32}
+// CHECK: %dv_43, %dv_44 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 6 : i32}
 //
 // TMEM allocation: dpT owns buffer 8
-// CHECK: %dpT, %dpT_47 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32}
+// CHECK: %dpT, %dpT_45 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32}
 //
 // TMEM allocation: dk owns buffer 5
-// CHECK: %dk, %dk_48 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 5 : i32}
+// CHECK: %dk, %dk_46 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 5 : i32}
 //
 // TMEM allocation: dq reuses dpT (buffer.id=8, buffer.offset=0) — key verification
-// CHECK: %dq, %dq_49 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32}
+// CHECK: %dq, %dq_47 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32}
 
 // FLOOR: warning: cross-stage SMEM buffer requires buffer.copy=2, exceeding configured num-buffers=1; enforcing the correctness floor
 // FLOOR-LABEL: tt.func public @_attn_bwd

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_merged_barrier.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_merged_barrier.mlir
@@ -15,6 +15,8 @@
 // CHECK-SAME: 64x256xf16
 // CHECK: ttg.local_alloc {buffer.copy = 3 : i32, buffer.id = 0 : i32}
 // CHECK-SAME: 128x64xf16
+// CHECK-COUNT-2: nvws.descriptor_load
+// CHECK-NOT: tt.descriptor_load
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 256], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/test/Hopper/WarpSpecialization/ws_subtiled_region_buffer_reuse_collapse.mlir
+++ b/test/Hopper/WarpSpecialization/ws_subtiled_region_buffer_reuse_collapse.mlir
@@ -23,10 +23,10 @@
 // Exactly one shared epilogue staging buffer survives (the reuse-group
 // representative), hoisted to function entry ahead of ttg.warp_specialize.
 // Before the fix there were two, each tagged allocation.shareGroup (the bug).
-// The reuse-group buffers share buffer.id = 2; the first CHECK matches the
+// The reuse-group buffers share buffer.id = 0; the first CHECK matches the
 // representative and CHECK-NOT forbids any second shared buffer through EOF (and
 // also fails loudly if warp specialization / buffering did not run at all).
-// CHECK: ttg.local_alloc {allocation.shareGroup = 0 : i32, buffer.copy = 3 : i32, buffer.id = 2 : i32{{.*}}} : () -> !ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>
+// CHECK: ttg.local_alloc {allocation.shareGroup = 0 : i32, buffer.copy = 3 : i32, buffer.id = 0 : i32{{.*}}} : () -> !ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>
 // CHECK-NOT: allocation.shareGroup
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/test/Hopper/WarpSpecialization/ws_subtiled_region_dp2_both_subtiled.mlir
+++ b/test/Hopper/WarpSpecialization/ws_subtiled_region_dp2_both_subtiled.mlir
@@ -26,8 +26,8 @@
 // Two independent per-partition staging multibuffers (distinct buffer.id), each
 // 128x64xf16 -- the cross-partition reuse-group split. These are hoisted to
 // function entry, before the ttg.warp_specialize op.
-// CHECK-DAG: ttg.local_alloc {{.*}}buffer.id = 3 : i32{{.*}} : () -> !ttg.memdesc<{{[0-9]+}}x128x64xf16, #shared
-// CHECK-DAG: ttg.local_alloc {{.*}}buffer.id = 4 : i32{{.*}} : () -> !ttg.memdesc<{{[0-9]+}}x128x64xf16, #shared
+// CHECK-DAG: ttg.local_alloc {allocation.shareGroup = 0 : i32, {{.*}}buffer.id = 0 : i32{{.*}}} : () -> !ttg.memdesc<{{[0-9]+}}x128x64xf16, #shared
+// CHECK-DAG: ttg.local_alloc {allocation.shareGroup = 1 : i32, {{.*}}buffer.id = 1 : i32{{.*}}} : () -> !ttg.memdesc<{{[0-9]+}}x128x64xf16, #shared
 // CHECK: ttg.warp_specialize
 //
 // All four epilogue subtile stores (2 data partitions x 2 subtiles) are

--- a/test/Hopper/WarpSpecialization/ws_subtiled_region_per_tile_buffer_index.mlir
+++ b/test/Hopper/WarpSpecialization/ws_subtiled_region_per_tile_buffer_index.mlir
@@ -29,7 +29,7 @@
 // CHECK-LABEL: @matmul_kernel_tma_persistent_ws
 //
 // The epilogue staging buffer is a single shared 3-deep 128x32 alloc.
-// CHECK: ttg.local_alloc {allocation.shareGroup = 0 : i32, buffer.copy = 3 : i32, buffer.id = 2 : i32{{.*}}} : () -> !ttg.memdesc<3x128x32xf16
+// CHECK: ttg.local_alloc {allocation.shareGroup = 0 : i32, buffer.copy = 3 : i32, buffer.id = 0 : i32{{.*}}} : () -> !ttg.memdesc<3x128x32xf16
 //
 // In the epilogue partition (async_task_id = 0): the numTiles factor lives on the
 // loop-carried reuse-group counter, which advances by numTiles(4) per iteration
@@ -74,7 +74,7 @@
 // WHILE-LABEL: @matmul_kernel_tma_persistent_ws_while
 //
 // The epilogue staging buffer is a single shared 3-deep 128x32 alloc.
-// WHILE: ttg.local_alloc {allocation.shareGroup = 0 : i32, buffer.copy = 3 : i32, buffer.id = 2 : i32{{.*}}} : () -> !ttg.memdesc<3x128x32xf16
+// WHILE: ttg.local_alloc {allocation.shareGroup = 0 : i32, buffer.copy = 3 : i32, buffer.id = 0 : i32{{.*}}} : () -> !ttg.memdesc<3x128x32xf16
 //
 // The kernel is physically warp specialized.
 // WHILE: ttg.warp_specialize

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -63,7 +63,8 @@ def NVGPUTestWSMemoryPlanner : Pass<"nvgpu-test-ws-memory-planner", "mlir::Modul
 
   let description = "This pass computes a memory configuration for autoWS";
 
-  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect"];
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::nvws::NVWSDialect"];
   let options = [
     Option<"numBuffers", "num-buffers",
            "int32_t", /*default*/"0",
@@ -196,7 +197,8 @@ def NVGPUTestWSBufferAllocation : Pass<"nvgpu-test-ws-buffer-allocation", "mlir:
 
   let description = "This pass creates buffers for each async task channel.";
 
-  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect"];
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::nvws::NVWSDialect"];
 }
 
 def NVGPUTestWSHoistTMEMStore : Pass<"nvgpu-test-ws-hoist-tmem-store", "mlir::ModuleOp"> {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -209,9 +209,18 @@ public:
     // persistent kernels.
     removeRedundantTmemZeroStores(funcOp);
 
+    if (failed(doConvertDescriptorLoadsToNVWS(funcOp))) {
+      signalPassFailure();
+      return;
+    }
+    dumpAfter(moduleOp, "doConvertDescriptorLoadsToNVWS");
+
     // Canonicalize the SMEM/TEM buffers.
     // Create buffers for register channels.
-    doBufferAllocation(funcOp);
+    if (failed(doBufferAllocation(funcOp))) {
+      signalPassFailure();
+      return;
+    }
     dumpAfter(moduleOp, "doBufferAllocation");
 
     doHoistLoopInvariantTMEMStore(funcOp);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -13,6 +13,7 @@
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
 namespace ttng = ::mlir::triton::nvidia_gpu;
+namespace ttnvws = ::mlir::triton::nvws;
 namespace mlir {
 
 #define DEBUG_TYPE "nvgpu-ws-utility"
@@ -139,7 +140,7 @@ Operation *AllocChannel::getSrcOp() {
     Operation *user = skipIdxOp(usr);
     if (!user)
       continue;
-    if (isa<ttg::LocalStoreOp>(user))
+    if (isa<ttg::LocalStoreOp, ttnvws::DescriptorLoadOp>(user))
       return user;
     if (isa<ttng::AsyncTMACopyGlobalToLocalOp>(user))
       return user;
@@ -163,7 +164,7 @@ static void getAllConsumers(AllocChannel *ch,
     Operation *user = skipIdxOp(usr);
     if (!user)
       continue;
-    if (!isa<ttg::LocalStoreOp>(user) &&
+    if (!isa<ttg::LocalStoreOp, ttnvws::DescriptorLoadOp>(user) &&
         !isa<ttng::AsyncTMACopyGlobalToLocalOp>(user))
       consumers.push_back(user);
   }
@@ -1764,8 +1765,8 @@ static bool isKeyOp(Operation *op) {
     return true;
 
   // Load operations
-  if (isa<tt::DescriptorLoadOp, tt::LoadOp, ttng::TMEMLoadOp, ttg::LocalLoadOp>(
-          op))
+  if (isa<ttnvws::DescriptorLoadOp, tt::LoadOp, ttng::TMEMLoadOp,
+          ttg::LocalLoadOp>(op))
     return true;
 
   // Store operations
@@ -1870,9 +1871,10 @@ static std::string getKeyOpDescription(Operation *op) {
   }
 
   // For loads, show source and result
-  if (auto loadOp = dyn_cast<tt::DescriptorLoadOp>(op)) {
+  if (auto loadOp = dyn_cast<ttnvws::DescriptorLoadOp>(op)) {
+    // NVWS "result" is the destination memdesc operand, not an SSA result.
     ss << opName << " " << formatInput(loadOp.getDesc()) << " -> "
-       << formatOutput(loadOp.getResult());
+       << formatInput(loadOp.getResult());
     return result;
   }
   if (auto loadOp = dyn_cast<tt::LoadOp>(op)) {
@@ -2093,7 +2095,7 @@ static std::string getKeyOpLabel(Operation *op) {
     std::string aName = getValueDisplayName(mmaOp.getA());
     std::string bName = getValueDisplayName(mmaOp.getB());
     label += outputName + " = " + opName + "(" + aName + ", " + bName + ")";
-  } else if (isa<tt::DescriptorLoadOp, tt::LoadOp, ttng::TMEMLoadOp,
+  } else if (isa<ttnvws::DescriptorLoadOp, tt::LoadOp, ttng::TMEMLoadOp,
                  ttg::LocalLoadOp>(op)) {
     // Load: out = load(src)
     std::string inputs = getTensorInputs(op);
@@ -3488,7 +3490,7 @@ static void createAllocChannel(Operation *allocOp, mlir::DominanceInfo &dom,
         // Alloc associated with operand D can have multiple producers.
         assert(mmaOp.getAccumulator() != allocOp->getResult(0));
         consumers.push_back(user);
-      } else if (isa<ttg::LocalStoreOp>(user)) {
+      } else if (isa<ttg::LocalStoreOp, ttnvws::DescriptorLoadOp>(user)) {
         assert(producerOp == nullptr);
         producerOp = user;
       } else if (auto subtiled = dyn_cast<ttng::SubtiledRegionOp>(user)) {
@@ -3551,9 +3553,16 @@ static void createAllocChannel(Operation *allocOp, mlir::DominanceInfo &dom,
   SmallVector<int> consumerTaskIds;
   DenseSet<int> seenTaskIds;
   for (auto *consumer : consumers) {
-    for (int id : getAsyncTaskIds(consumer)) {
-      if (seenTaskIds.insert(id).second)
-        consumerTaskIds.push_back(id);
+    SmallVector<Operation *> taskOwners = {consumer};
+    // A memdesc view can carry boundary task IDs that do not all consume the
+    // buffer. Descriptor channels synchronize with the terminal consumers.
+    if (isa<ttnvws::DescriptorLoadOp>(producerOp))
+      taskOwners = getActualConsumers(consumer);
+    for (Operation *taskOwner : taskOwners) {
+      for (int id : getAsyncTaskIds(taskOwner)) {
+        if (seenTaskIds.insert(id).second)
+          consumerTaskIds.push_back(id);
+      }
     }
   }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -1,6 +1,7 @@
 #ifndef NV_DIALECT_HOPPER_TRANSFORMS_CODEPARTITIONUTILITY_H_
 #define NV_DIALECT_HOPPER_TRANSFORMS_CODEPARTITIONUTILITY_H_
 
+#include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "triton/Analysis/Allocation.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -307,15 +308,14 @@ void getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder, Operation *op,
 Value getBarrierForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
                                  Value barrierAlloc, Value bufferIdx);
 
-Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
-                            SmallVector<tt::DescriptorLoadOp> &tmaLoads,
-                            SmallVector<Value> &buffers, Value barrierAlloc,
-                            Value bufferIdx, Value bufferIdxExtract,
-                            Value phase, Operation *headProducer,
-                            Operation *headConsumer,
-                            Operation *headConsumerSameLevel,
-                            ArrayRef<int> additionalConsumerTaskIds = {},
-                            DictionaryAttr consumerWaitConstraints = {});
+Operation *
+optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
+                 SmallVector<triton::nvws::DescriptorLoadOp> &tmaLoads,
+                 Value barrierAlloc, Value bufferIdx, Value bufferIdxExtract,
+                 Value phase, Operation *headProducer, Operation *headConsumer,
+                 Operation *headConsumerSameLevel,
+                 ArrayRef<int> additionalConsumerTaskIds = {},
+                 DictionaryAttr consumerWaitConstraints = {});
 void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters);
 Value createBufferView(OpBuilderWithAsyncTaskIds &builder, Value alloc,
                        Value idx);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -268,7 +268,7 @@ void createChannel(Operation *producerOp, mlir::DominanceInfo &dom,
 
 // Can be one end of the channel.
 static bool isChannelAnchorOp(Operation *op) {
-  if (isa<tt::LoadOp, tt::DescriptorLoadOp>(op) ||
+  if (isa<tt::LoadOp>(op) ||
       isa<mlir::triton::DotOpInterface, ttng::TMEMStoreOp>(op))
     return true;
   // Local alloc op with a register operand can be the producer of a channel.
@@ -760,19 +760,12 @@ static Operation *ProducerIsGen5(Operation *producerOp) {
   return nullptr;
 }
 
-// Return the TMA descriptor load feeding this allocation-backed channel's
-// local_store producer. Channel collection must never expose a descriptor_load
-// directly because buffer allocation stages it through local_store.
+// Return the buffered TMA descriptor load producing this allocation-backed
+// channel.
 static Operation *findTMAProducer(Channel *ch) {
   Operation *producerOp = ch->getSrcOp();
-  assert(!isa<tt::DescriptorLoadOp>(producerOp) &&
-         "allocation-backed TMA channel must be staged through local_store");
-  if (auto ls = dyn_cast<ttg::LocalStoreOp>(producerOp)) {
-    Operation *def = ls.getSrc().getDefiningOp();
-    if (def && isa<tt::DescriptorLoadOp>(def))
-      return def;
-  }
-  return nullptr;
+  return dyn_cast_or_null<ttnvws::DescriptorLoadOp>(producerOp) ? producerOp
+                                                                : nullptr;
 }
 
 // Handle buffer index and phase computation for operations outside loops
@@ -1346,6 +1339,23 @@ static Value hoistLocalAlloc(
   return newBuf;
 }
 
+// After doConvertDescriptorLoadsToNVWS, a value that was produced by a TMA
+// descriptor load no longer appears as a `tt.descriptor_load`: it is a
+// local_load of an SMEM buffer written by an `nvws.descriptor_load`. Return
+// that nvws load (or null) so register-channel code can treat such a value like
+// the pre-conversion `tt::DescriptorLoadOp` -- otherwise these paths silently
+// dead-end (wrong SMEM encoding / spurious TMEM promotion) once the conversion
+// runs ahead of buffer allocation.
+static ttnvws::DescriptorLoadOp getConvertedDescriptorLoad(Operation *srcOp) {
+  auto localLoad = dyn_cast_or_null<ttg::LocalLoadOp>(srcOp);
+  if (!localLoad)
+    return nullptr;
+  for (Operation *user : localLoad.getSrc().getUsers())
+    if (auto nvwsLoad = dyn_cast<ttnvws::DescriptorLoadOp>(user))
+      return nvwsLoad;
+  return nullptr;
+}
+
 // Create a local buffer for register channels. Return the allocated buffer and
 // the new producer (reloaded value).
 static std::pair<Value, Value>
@@ -1437,9 +1447,11 @@ createLocalAlloc(OpBuilderWithAsyncTaskIds &builder, Channel *channel,
     } else if (tmaStore) {
       sharedLayout = ttng::getEncodingFromDescriptor(tmaStore, tensorType,
                                                      tmaStore.getDesc());
-    } else if (auto tmaLoad = dyn_cast<tt::DescriptorLoadOp>(srcOp)) {
-      sharedLayout = ttng::getEncodingFromDescriptor(tmaLoad, tmaLoad.getType(),
-                                                     tmaLoad.getDesc());
+    } else if (auto nvwsLoad = getConvertedDescriptorLoad(srcOp)) {
+      // TMA descriptor load (converted to nvws.descriptor_load before buffer
+      // allocation): use the descriptor's shared encoding.
+      sharedLayout = ttng::getEncodingFromDescriptor(nvwsLoad, tensorType,
+                                                     nvwsLoad.getDesc());
     } else {
       // Create an unswizzled layout for now.
       // TODO: optimize it based on the consumer.
@@ -1735,9 +1747,13 @@ DenseMap<Channel *, Value> createBuffer(const SmallVector<Channel *> &channels,
     } else if (auto tensorType =
                    dyn_cast<RankedTensorType>(srcValue.getType())) {
       int cc = getNVIDIAComputeCapability(funcOp->getParentOfType<ModuleOp>());
+      // Keep TMA-descriptor-loaded 1-D values (e.g. the m/Di softmax metadata)
+      // in SMEM rather than promoting them to TMEM. After conversion these
+      // appear as a local_load of an nvws.descriptor_load buffer; otherwise
+      // such a channel overflows the 512-column TMEM limit in FA backward.
       bool useTMEM = cc >= 100 && tensorType.getShape().size() == 1 &&
                      tensorType.getElementType().isIntOrFloat() &&
-                     !isa<tt::DescriptorLoadOp>(srcOp);
+                     !getConvertedDescriptorLoad(srcOp);
       auto res = createLocalAlloc(builder, channel, useTMEM);
       buffer = res.first;
       newProducer = res.second;
@@ -2757,14 +2773,12 @@ void insertAsyncComm(
     }
     builder.setAsynTaskIdsFromArray(asyncTasksPC);
 
-    SmallVector<tt::DescriptorLoadOp> tmaLoads;
-    SmallVector<Value> buffers;
+    SmallVector<ttnvws::DescriptorLoadOp> tmaLoads;
     // Go through all channels in this channel group.
     for (auto &c : kv.second) {
       if (auto *tmaLoadOp = findTMAProducer(c)) {
-        auto tmaLoad = cast<tt::DescriptorLoadOp>(tmaLoadOp);
+        auto tmaLoad = cast<ttnvws::DescriptorLoadOp>(tmaLoadOp);
         tmaLoads.push_back(tmaLoad);
-        buffers.push_back(bufferMap.find(c)->second);
       }
     }
 
@@ -4423,7 +4437,7 @@ void insertAsyncComm(
               funcOp.getContext(), masterChannel->relation.first,
               WSBarrierAttr::kDirectionForward)
               .build(funcOp.getContext());
-      optimizeTMALoads(builder, tmaLoads, buffers, *commChannel.producerBarrier,
+      optimizeTMALoads(builder, tmaLoads, *commChannel.producerBarrier,
                        bufferIdx, bufferIdx, phase, tmaHeadProducer,
                        headConsumer, consumerWaitPoint,
                        additionalConsumerTaskIds, waitConstraints);
@@ -4879,7 +4893,44 @@ void removeRedundantTmemZeroStores(triton::FuncOp funcOp) {
   }
 }
 
-void doBufferAllocation(triton::FuncOp funcOp) {
+static LogicalResult hoistDescriptorLoadBuffers(triton::FuncOp funcOp) {
+  SmallVector<ttg::LocalAllocOp> buffers;
+  DenseSet<Operation *> seen;
+  WalkResult result = funcOp.walk([&](ttnvws::DescriptorLoadOp load) {
+    Value buffer = load.getResult();
+    while (Operation *def = buffer.getDefiningOp()) {
+      if (!isa<ttg::MemDescIndexOp, ttg::MemDescSubsliceOp, ttg::MemDescTransOp,
+               ttg::MemDescReshapeOp, ttg::MemDescReinterpretOp>(def))
+        break;
+      buffer = def->getOperand(0);
+    }
+    auto alloc = buffer.getDefiningOp<ttg::LocalAllocOp>();
+    if (!alloc) {
+      load.emitError("expected descriptor load destination to be backed by "
+                     "ttg.local_alloc before buffer hoisting");
+      return WalkResult::interrupt();
+    }
+    if (!isa<triton::FuncOp>(alloc->getParentOp()) && seen.insert(alloc).second)
+      buffers.push_back(alloc);
+    return WalkResult::advance();
+  });
+  if (result.wasInterrupted())
+    return failure();
+
+  OpBuilderWithAsyncTaskIds builder(funcOp.getContext());
+  Operation *lastHoistedAlloc = nullptr;
+  for (ttg::LocalAllocOp alloc : buffers) {
+    if (lastHoistedAlloc)
+      builder.setInsertionPointAfter(lastHoistedAlloc);
+    else
+      builder.setInsertionPointToStart(&funcOp.getBody().front());
+    Value buffer = hoistLocalAlloc(builder, alloc);
+    lastHoistedAlloc = buffer.getDefiningOp();
+  }
+  return success();
+}
+
+LogicalResult doBufferAllocation(triton::FuncOp funcOp) {
   // Step 0: Swap transposed local_alloc + memdesc_trans patterns so that
   // allocs that share the same source value can also share a buffer.
   swapTransposedLocalAllocs(funcOp);
@@ -4887,6 +4938,12 @@ void doBufferAllocation(triton::FuncOp funcOp) {
   // Step 0.5: Merge duplicate local_allocs with same src and layout.
   // This must be done after swapTransposedLocalAllocs which normalizes layouts.
   mergeDuplicateLocalAllocs(funcOp);
+
+  // Step 0.75: Descriptor loads already write explicit SMEM buffers. Hoist
+  // those destinations before discovering the remaining tensor channels so
+  // memory planning sees the canonical allocation from the outset.
+  if (failed(hoistDescriptorLoadBuffers(funcOp)))
+    return failure();
 
   // Step 1: collect all communications between producers and consumers.
   SmallVector<std::unique_ptr<Channel>> channelsOrigin;
@@ -4906,6 +4963,7 @@ void doBufferAllocation(triton::FuncOp funcOp) {
   // Step 4: Split remaining local_alloc with tensor source into
   // local_alloc + local_store for downstream channel detection.
   separateLocalAllocWithSrc(funcOp);
+  return success();
 }
 
 namespace {
@@ -5644,8 +5702,29 @@ public:
 
   void runOnFuncOp(triton::FuncOp funcOp) {
     // Disable code partitioning when numBuffers is 0.
-    if (numBuffers > 0)
+    if (numBuffers > 0) {
+      bool descriptorBuffersArePlanned = true;
+      funcOp.walk([&](tt::DescriptorLoadOp load) {
+        if (!load->hasOneUse()) {
+          descriptorBuffersArePlanned = false;
+          return;
+        }
+        Operation *user = *load->getUsers().begin();
+        Operation *alloc = nullptr;
+        if (auto store = dyn_cast<ttg::LocalStoreOp>(user))
+          alloc = store.getDst().getDefiningOp();
+        else if (auto localAlloc = dyn_cast<ttg::LocalAllocOp>(user))
+          alloc = localAlloc;
+        if (!alloc || !alloc->hasAttr("buffer.id"))
+          descriptorBuffersArePlanned = false;
+      });
+      if (descriptorBuffersArePlanned &&
+          failed(doConvertDescriptorLoadsToNVWS(funcOp))) {
+        signalPassFailure();
+        return;
+      }
       doCodePartition(funcOp, numBuffers);
+    }
     // Set NameLoc("accum_cnt") on ForOp block arguments whose corresponding
     // yield operand already has an "accum_cnt" NameLoc. This must be done at
     // the end because earlier steps may replace ForOps and lose block arg locs.
@@ -5693,7 +5772,16 @@ public:
   using impl::NVGPUTestWSBufferAllocationBase<
       NVGPUTestWSBufferAllocationPass>::NVGPUTestWSBufferAllocationBase;
 
-  void runOnFuncOp(triton::FuncOp funcOp) { doBufferAllocation(funcOp); }
+  void runOnFuncOp(triton::FuncOp funcOp) {
+    if (failed(doConvertDescriptorLoadsToNVWS(funcOp))) {
+      signalPassFailure();
+      return;
+    }
+    if (failed(doBufferAllocation(funcOp))) {
+      signalPassFailure();
+      return;
+    }
+  }
 
   void runOnOperation() override {
     getOperation()->walk([&](triton::FuncOp funcOp) { runOnFuncOp(funcOp); });

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -15,12 +15,14 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 #include "mlir/Transforms/RegionUtils.h"
+#include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "triton/Tools/Sys/GetEnv.h"
 #include <list>
 #include <unordered_set>
@@ -28,11 +30,101 @@
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
 namespace ttng = ::mlir::triton::nvidia_gpu;
+namespace ttnvws = ::mlir::triton::nvws;
 namespace mlir {
 
 #define DEBUG_TYPE "nvgpu-ws-lower-mem"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+LogicalResult doConvertDescriptorLoadsToNVWS(triton::FuncOp funcOp) {
+  SmallVector<tt::DescriptorLoadOp> loads;
+  funcOp.walk([&](tt::DescriptorLoadOp load) { loads.push_back(load); });
+
+  for (tt::DescriptorLoadOp load : loads) {
+    auto tensorType = dyn_cast<RankedTensorType>(load.getType());
+    if (!tensorType)
+      return load.emitError("expected a ranked tensor descriptor load result");
+
+    ttg::LocalStoreOp soleStore;
+    ttg::LocalAllocOp soleAlloc;
+    if (load->hasOneUse())
+      soleStore = dyn_cast<ttg::LocalStoreOp>(*load->getUsers().begin());
+    if (load->hasOneUse())
+      soleAlloc = dyn_cast<ttg::LocalAllocOp>(*load->getUsers().begin());
+
+    OpBuilderWithAsyncTaskIds builder(load);
+    builder.setInsertionPoint(load);
+    Value buffer;
+    if (soleStore) {
+      buffer = soleStore.getDst();
+    } else if (soleAlloc) {
+      auto oldType = cast<ttg::MemDescType>(soleAlloc.getType());
+      auto bufferType = ttg::MemDescType::get(
+          oldType.getShape(), oldType.getElementType(), oldType.getEncoding(),
+          oldType.getMemorySpace(), /*mutableMemory=*/true);
+      auto newAlloc = builder.createWithAsyncTaskIds<ttg::LocalAllocOp>(
+          soleAlloc.getLoc(), bufferType);
+      newAlloc->setAttrs(soleAlloc->getAttrs());
+      triton::replaceUsesAndPropagateType(builder, soleAlloc,
+                                          newAlloc.getResult());
+      buffer = newAlloc.getResult();
+      builder.setInsertionPointAfter(newAlloc);
+    } else {
+      auto encoding =
+          ttng::getEncodingFromDescriptor(load, tensorType, load.getDesc());
+      auto memorySpace = ttg::SharedMemorySpaceAttr::get(load.getContext());
+      auto bufferType = ttg::MemDescType::get(
+          tensorType.getShape(), tensorType.getElementType(), encoding,
+          memorySpace, /*mutableMemory=*/true);
+      buffer = builder
+                   .createWithAsyncTaskIds<ttg::LocalAllocOp>(load.getLoc(),
+                                                              bufferType)
+                   .getResult();
+    }
+
+    if (Operation *bufferDef = buffer.getDefiningOp();
+        bufferDef && bufferDef->getBlock() == load->getBlock() &&
+        load->isBeforeInBlock(bufferDef))
+      bufferDef->moveBefore(load);
+
+    int64_t txCount =
+        ttng::getDescriptorLoadBytes(cast<ttg::MemDescType>(buffer.getType()));
+    auto nvwsLoad = builder.createWithAsyncTaskIds<ttnvws::DescriptorLoadOp>(
+        load.getLoc(), load.getDesc(), load.getIndices(), txCount, buffer,
+        load.getCache(), load.getEvict());
+    nvwsLoad->setAttrs(load->getAttrs());
+
+    if (soleStore) {
+      soleStore.erase();
+    } else if (soleAlloc) {
+      soleAlloc.erase();
+    } else {
+      // Register-consumed load (e.g. the m/Di softmax metadata). Tag the
+      // local_load with the *consumer* partitions and their loop schedule --
+      // not the producer's -- so the nvws.descriptor_load's SMEM buffer serves
+      // directly as the cross-partition channel (one buffer). Inheriting the
+      // producer task id instead materializes the value in the producer
+      // partition and forces doBufferAllocation to create a *second*
+      // cross-partition channel buffer, doubling the SMEM footprint that the
+      // original tt.descriptor_load path kept unified (SMEM/TMEM overflow in FA
+      // backward).
+      builder.setAsyncTaskIdsFromValueUsers(load.getResult());
+      builder.setLoopScheduleInfoFromOp(*load->getUsers().begin());
+      auto localLoad = builder.createWithAsyncTaskIds<ttg::LocalLoadOp>(
+          load.getLoc(), load.getType(), buffer);
+      load.replaceAllUsesWith(localLoad.getResult());
+    }
+    load.erase();
+  }
+
+  bool hasUnconvertedLoad = false;
+  funcOp.walk([&](tt::DescriptorLoadOp load) {
+    load.emitError("descriptor load was not converted for AutoWS");
+    hasUnconvertedLoad = true;
+  });
+  return failure(hasUnconvertedLoad);
+}
 
 Value createBufferView(OpBuilderWithAsyncTaskIds &builder, Value alloc,
                        Value idx) {
@@ -53,62 +145,30 @@ Value createBufferView(OpBuilderWithAsyncTaskIds &builder, Value alloc,
 
 namespace {
 
-int getTMALoadSize(tt::DescriptorLoadOp &tmaLoad) {
-  auto tensorTy = cast<RankedTensorType>(tmaLoad->getResult(0).getType());
-  int loadSize = product(tensorTy.getShape());
-  return loadSize * tensorTy.getElementType().getIntOrFloatBitWidth() / 8;
-}
-
-Value getBufferForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
-                                Type loadType, Value buffer, Value bufferIdx,
-                                bool mutableMem) {
-  auto context = buffer.getContext();
-  auto tensorType = dyn_cast<RankedTensorType>(loadType);
-  assert(tensorType);
-
-  auto order = ttg::getOrderForMemory(tensorType);
-  auto CGALayout = ttg::getCGALayout(tensorType.getEncoding());
-  auto elemType = tensorType.getElementType();
-
-  // Get shape, layout and type of a slice
-  auto sliceShape = tensorType.getShape();
-  auto sharedLayout =
-      dyn_cast<triton::gpu::MemDescType>(buffer.getType()).getEncoding();
-  auto sliceType = RankedTensorType::get(sliceShape, elemType, sharedLayout);
-
-  Attribute sharedMemorySpace =
-      cast<ttg::MemDescType>(buffer.getType()).getMemorySpace();
-  ttg::MemDescType subviewTy =
-      ttg::MemDescType::get(sliceType.getShape(), sliceType.getElementType(),
-                            sliceType.getEncoding(), sharedMemorySpace,
-                            /*mutableMemOry=*/mutableMem);
-
-  auto desc = builder.createWithAsyncTaskIds<ttg::MemDescIndexOp>(
-      buffer.getLoc(), subviewTy, buffer, bufferIdx);
-  return desc;
+Value getTMALoadBufferForStage(OpBuilderWithAsyncTaskIds &builder, Value buffer,
+                               Value bufferIdx) {
+  auto currentView = buffer.getDefiningOp<ttg::MemDescIndexOp>();
+  if (!currentView)
+    return buffer;
+  return createBufferView(builder, currentView.getSrc(), bufferIdx);
 }
 
 } // namespace
 
 Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
-                            SmallVector<tt::DescriptorLoadOp> &tmaLoads,
-                            SmallVector<Value> &buffers, Value barrierAlloc,
-                            Value bufferIdx, Value bufferIdxExtract,
-                            Value phase, Operation *headProducer,
-                            Operation *headConsumer,
+                            SmallVector<ttnvws::DescriptorLoadOp> &tmaLoads,
+                            Value barrierAlloc, Value bufferIdx,
+                            Value bufferIdxExtract, Value phase,
+                            Operation *headProducer, Operation *headConsumer,
                             Operation *headConsumerSameLevel,
                             ArrayRef<int> additionalConsumerTaskIds,
                             DictionaryAttr consumerWaitConstraints) {
   auto loc = barrierAlloc.getLoc();
 
   // Compute the total size of the loads.
-  int sizeInBytes = 0;
-  for (auto &tmaLoad : tmaLoads) {
-    sizeInBytes += getTMALoadSize(tmaLoad);
-  }
-
-  // For each of the following ops, we will operate on a subview of each value
-  // according to the pipeline stage.
+  int64_t sizeInBytes = 0;
+  for (auto tmaLoad : tmaLoads)
+    sizeInBytes += tmaLoad.getTxCount();
 
   // Create a barrier_expect with the appropriate size and insert it before the
   // first load.
@@ -123,13 +183,14 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
 
   // Convert all the producers to async_tma_copy_global_to_local
   Operation *copy = nullptr;
-  for (auto [tmaLoad, buffer] : zip(tmaLoads, buffers)) {
+  for (auto tmaLoad : tmaLoads) {
     builder.setInsertionPoint(tmaLoad);
+    builder.setAsyncTaskIdsFromOp(tmaLoad);
     builder.setLoopScheduleInfoFromOp(tmaLoad);
-    auto pipelineBuffer = getBufferForPipelineStage(builder, tmaLoad.getType(),
-                                                    buffer, bufferIdx, true);
+    Value pipelineBuffer =
+        getTMALoadBufferForStage(builder, tmaLoad.getResult(), bufferIdx);
     copy = builder.createWithAsyncTaskIds<ttng::AsyncTMACopyGlobalToLocalOp>(
-        loc, tmaLoad.getDesc(), tmaLoad.getIndices(), prodBarrier,
+        tmaLoad.getLoc(), tmaLoad.getDesc(), tmaLoad.getIndices(), prodBarrier,
         pipelineBuffer, pred);
   }
 
@@ -163,21 +224,8 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
         /*deps=*/ValueRange{}, consumerWaitConstraints);
   }
 
-  // Convert all the consumers. The descriptor_load's single user is the
-  // local_store into the pipeline buffer, and the async TMA copy now writes
-  // that buffer directly, so erase both.
-  for (auto [tmaLoad, buffer] : zip(tmaLoads, buffers)) {
-    unsigned cnt = 0;
-    Operation *localSt = nullptr;
-    for (auto *usr : tmaLoad->getUsers()) {
-      assert(isa<ttg::LocalStoreOp>(usr));
-      localSt = usr;
-      ++cnt;
-    }
-    assert(cnt == 1);
-    localSt->erase();
+  for (auto tmaLoad : tmaLoads)
     tmaLoad.erase();
-  }
   builder.clearLoopScheduleInfo();
   return copy;
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -8,6 +8,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
+#include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "triton/Analysis/Allocation.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -32,6 +33,8 @@
 #define DEBUG_TYPE "nvgpu-ws-memory-planner"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace ttnvws = mlir::triton::nvws;
 
 // Environment variable to dump DOT files: TRITON_DUMP_WS_GRAPHS
 // When set to a directory path, dumps visualization files there.
@@ -188,6 +191,8 @@ static Operation *findOriginalLoadForChannel(Channel *ch) {
   Operation *srcOp = ch->getSrcOp();
   if (!srcOp)
     return nullptr;
+  if (isa<ttnvws::DescriptorLoadOp>(srcOp))
+    return srcOp;
   if (auto storeOp = dyn_cast<ttg::LocalStoreOp>(srcOp))
     return findOriginalLoadOp(storeOp.getSrc());
   return nullptr;
@@ -1238,12 +1243,7 @@ static bool isSmemTMAChannel(Operation *alloc,
     return false;
   if (isa<ttng::AsyncTMACopyGlobalToLocalOp>(srcOp))
     return true;
-  if (auto storeOp = dyn_cast<ttg::LocalStoreOp>(srcOp)) {
-    Value stored = storeOp.getSrc();
-    if (auto *defOp = stored.getDefiningOp())
-      return isa<tt::DescriptorLoadOp>(defOp);
-  }
-  return false;
+  return isa<ttnvws::DescriptorLoadOp>(srcOp);
 }
 
 /// Helper to read the loop.stage attribute from an op. Returns -1 if absent.
@@ -1767,6 +1767,41 @@ static bool areReuseEncodingsCompatible(const WSBuffer &candidate,
          candTy.getElementType() == tgtTy.getElementType();
 }
 
+static bool isDataDependent(Operation *srcOp, Operation *dstOp) {
+  return dependsThroughMemory(srcOp, dstOp);
+}
+
+static bool isOrderedDescriptorReuseTarget(const WSBuffer &candidate,
+                                           const WSBuffer &target,
+                                           SmallVector<Channel *> &channels) {
+  if (candidate.tmaStaging == 0)
+    return false;
+
+  Channel *targetChannel = findChannelForOp(target.allocOp, channels);
+  Channel *candidateChannel = findChannelForOp(candidate.allocOp, channels);
+  if (!targetChannel || !candidateChannel ||
+      !isa<ttnvws::DescriptorLoadOp>(targetChannel->getSrcOp()))
+    return false;
+
+  Operation *candidateProducer = getLogicalProducerOp(candidateChannel);
+  if (!candidateProducer)
+    return false;
+
+  SmallVector<Operation *> targetConsumers;
+  targetChannel->getDstOps(targetConsumers);
+  if (targetConsumers.empty()) {
+    if (Operation *consumer = targetChannel->getDstOp())
+      targetConsumers.push_back(consumer);
+  }
+  for (Operation *consumer : targetConsumers) {
+    for (Operation *actualConsumer : getActualConsumers(consumer)) {
+      if (isDataDependent(actualConsumer, candidateProducer))
+        return true;
+    }
+  }
+  return false;
+}
+
 /// Find an allocated buffer that a non-innermost candidate can reuse.
 /// The candidate must NOT be innermost (partition-unaware liveness is
 /// inaccurate within the inner loop). Can scan allocated innermost buffers
@@ -1834,7 +1869,15 @@ findReuseCandidate(WSBuffer &candidate, SmallVector<WSBuffer> &wsBuffers,
     }
 
     auto order = getLastConsumerOrderDetailed(buf, channels, numClusters);
-    int effectiveOrder = order.linearOrder < 0 ? INT_MAX : order.linearOrder;
+    int effectiveOrder = order.linearOrder;
+    if (effectiveOrder < 0) {
+      if (!isOrderedDescriptorReuseTarget(candidate, buf, channels))
+        effectiveOrder = INT_MAX;
+      else
+        // Sort a dependency-ordered, unstaged descriptor target after every
+        // target with an explicit pipeline order, but keep it selectable.
+        effectiveOrder = INT_MAX - 1;
+    }
     LDBG("  findReuseCandidate: target bufferId="
          << buf.bufferId << " size=" << buf.sizeBytes << "*" << buf.numCopies
          << " lastConsumerOrder=" << order.linearOrder
@@ -2237,6 +2280,20 @@ static unsigned allocateSmemBuffersViaSearch(
          << id << " members=" << blk.members.size() << " copy=" << blk.copies);
   }
   return nextId;
+}
+
+// doConvertDescriptorLoadsToNVWS always runs before the memory planner, so a
+// value fed by a TMA descriptor load is no longer a `tt.descriptor_load`
+// result: when the load has more than one use it becomes a local_load of the
+// SMEM buffer written by an `nvws.descriptor_load`. Match that shape so
+// descriptor-load staging buffers are still recognized for hoisting.
+static bool isFedByDescriptorLoad(Value stored) {
+  auto localLoad = stored.getDefiningOp<ttg::LocalLoadOp>();
+  if (!localLoad)
+    return false;
+  return llvm::any_of(localLoad.getSrc().getUsers(), [](Operation *user) {
+    return isa<ttnvws::DescriptorLoadOp>(user);
+  });
 }
 
 static unsigned allocateSmemBuffers(
@@ -2740,11 +2797,14 @@ static unsigned allocateSmemBuffers(
           continue;
         for (Operation *user : value.getUsers()) {
           if (auto store = dyn_cast<ttg::LocalStoreOp>(user)) {
-            if (isa_and_nonnull<tt::DescriptorLoadOp>(
-                    store.getSrc().getDefiningOp())) {
+            if (isFedByDescriptorLoad(store.getSrc())) {
               feedsTMA = true;
               break;
             }
+          }
+          if (isa<ttnvws::DescriptorLoadOp>(user)) {
+            feedsTMA = true;
+            break;
           }
           if (isa<ttng::AsyncTMACopyLocalToGlobalOp, ttng::AsyncTMAReduceOp>(
                   user)) {
@@ -5506,6 +5566,10 @@ public:
 
   void runOnFuncOp(triton::FuncOp funcOp) {
     if (numBuffers >= 1 || !readDecisionFile.empty()) {
+      if (failed(doConvertDescriptorLoadsToNVWS(funcOp))) {
+        signalPassFailure();
+        return;
+      }
       MemoryPlannerOptions options;
       options.readDecisionFile = readDecisionFile;
       options.writeDecisionFile = writeDecisionFile;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WarpSpecializationPipeline.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WarpSpecializationPipeline.h
@@ -52,7 +52,8 @@ LogicalResult doMemoryPlanner(triton::FuncOp funcOp, unsigned numBuffers,
                               unsigned smemBudget,
                               const MemoryPlannerOptions &options = {});
 
-void doBufferAllocation(triton::FuncOp funcOp);
+LogicalResult doBufferAllocation(triton::FuncOp funcOp);
+LogicalResult doConvertDescriptorLoadsToNVWS(triton::FuncOp funcOp);
 void doHoistLoopInvariantTMEMStore(triton::FuncOp funcOp);
 void removeRedundantTmemZeroStores(triton::FuncOp funcOp);
 void doCodePartition(triton::FuncOp funcOp, unsigned numBuffers);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BarrierFusion.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BarrierFusion.md
@@ -47,7 +47,8 @@ The **ready barriers** ("full barriers") signal that data is available. The
 **File**: `WSLowerMem.cpp` (`optimizeTMALoads`)
 
 TMA (Tensor Memory Accelerator) barrier fusion is the most common form of
-barrier fusion. When multiple TMA loads share the same dominant consumer
+barrier fusion. At this point TMA producers are buffered
+`nvws.descriptor_load` operations. When multiple loads share the same dominant consumer
 operation (e.g., they all feed into the same MMA), they are fused onto a
 **single mbarrier** with a **single `BarrierExpectOp`** whose byte count is
 the sum of all loads' sizes.
@@ -66,7 +67,8 @@ to their sum, a single barrier wait covers all loads.
    are grouped together. Each group gets a single barrier pair (ready + empty).
 
 2. **Compute combined byte count**: `BarrierExpectOp` is emitted once with
-   the total `txCount` summed across all TMA loads in the group.
+   the `txCount` attributes summed across all NVWS loads in the group. Each
+   count is computed from the descriptor's CTA-local shape.
 
 3. **Issue TMA copies**: All `AsyncTMACopyGlobalToLocalOp` operations in the
    group reference the same ready barrier. The hardware auto-arrives on this
@@ -79,7 +81,11 @@ to their sum, a single barrier wait covers all loads.
 
 `optimizeTMALoads` is called from `insertAsyncComm` in `WSCodePartition.cpp`
 during the `doCodePartition` pass. It processes groups of channels whose
-producers are TMA descriptor loads.
+producers are `nvws.descriptor_load` operations. Each operation already owns
+its destination memdesc, so planner buffer replacement cannot be bypassed by a
+separate lowering-side buffer lookup. Lowering derives the allocation from
+that destination and rebuilds its stage view with the fused barrier's buffer
+index, keeping the copy slot and barrier phase aligned.
 
 ## tcgen05_commit Barrier Fusion
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BufferAllocation.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BufferAllocation.md
@@ -12,6 +12,7 @@ normalizes `local_alloc` ops for downstream code partitioning passes.
 
 ```
 doTaskIdPropagate       ← assigns async_task_id to all ops
+  → doConvertDescriptorLoadsToNVWS
   → doBufferAllocation  ← THIS STEP: channels + alloc hoisting
   → doMemoryPlanner     ← decides multi-buffering (buffer.copy)
   → doCodePartition ← inserts accumCnts, async copies, sync ops
@@ -43,6 +44,14 @@ source that already use `#shared` layout.
 After layout normalization, merge `LocalAllocOp`s that have the same
 source value and the same `MemDescType` — replace duplicates with the
 first alloc.
+
+### Step 0.75: `hoistDescriptorLoadBuffers`
+
+Descriptor conversion has already replaced every `tt.descriptor_load` with a
+buffer-writing `nvws.descriptor_load`. Trace each NVWS destination through
+memdesc views to its backing `local_alloc` and hoist nested allocations to
+function scope. This makes descriptor buffers canonical before remaining
+tensor channels are discovered and before memory planning.
 
 ### Step 1: `collectAsyncChannels`
 
@@ -100,6 +109,14 @@ This models a 1-producer to N-consumer channel — one TMA load writes the
 shared buffer and every consumer partition reads it — instead of duplicating
 the buffer per consumer.
 
+Before buffer allocation, `doConvertDescriptorLoadsToNVWS` replaces every
+`tt.descriptor_load` with a buffer-writing `nvws.descriptor_load`. A load whose
+only user is `local_store` writes directly to that store's allocation. Other
+loads, including bias loads followed by arithmetic, receive a descriptor-layout
+SMEM allocation and a `local_load` preserving the original tensor uses. This
+makes their transfer buffers visible to memory planning. No unconverted
+descriptor load is allowed past this point.
+
 ## Key Distinction
 
 `doBufferAllocation` does **not** insert:
@@ -116,6 +133,7 @@ Those are handled by `doCodePartition` / `doCodePartition`.
 | `doBufferAllocation` | `WSCodePartition.cpp` | Entry point |
 | `swapTransposedLocalAllocs` | `WSCodePartition.cpp` | Layout normalization for buffer sharing |
 | `mergeDuplicateLocalAllocs` | `WSCodePartition.cpp` | Dedup same-source allocs |
+| `hoistDescriptorLoadBuffers` | `WSCodePartition.cpp` | Hoist explicit NVWS descriptor destinations |
 | `collectAsyncChannels` | `WSCodePartition.cpp` | Channel discovery |
 | `reorderEpilogOps` | `WSCodePartition.cpp` | Epilogue store reordering |
 | `createBuffer` | `WSCodePartition.cpp` | Buffer creation / hoisting |

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/CodePartition.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/CodePartition.md
@@ -56,6 +56,7 @@ See [Buffer Allocation](BufferAllocation.md) for details.
 ```
 Step 0:   swapTransposedLocalAllocs   — normalize transposed alloc layouts
 Step 0.5: mergeDuplicateLocalAllocs   — deduplicate allocs with same source
+Step 0.75: hoistDescriptorLoadBuffers — hoist pre-converted NVWS destinations
 Step 1:   collectAsyncChannels        — discover channels
 Step 2:   reorderEpilogOps            — interleave epilogue stores
 Step 3:   createBuffer                — allocate buffers (single copy)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/MemoryLowering.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/MemoryLowering.md
@@ -22,12 +22,18 @@ memory.
 In the current pipeline there is no single `insertAsyncCopy`
 dispatcher. Copies are materialized by two mechanisms:
 
-- **`optimizeTMALoads`** — for TMA descriptor-load producers. Called from
+- **`doConvertDescriptorLoadsToNVWS`** — runs before buffer allocation, after
+  AutoWS has passed its final eligibility bailout. It converts every
+  tensor-producing `tt.descriptor_load` into `nvws.descriptor_load`, whose
+  destination is an explicit SMEM memdesc and whose `txCount` is the CTA-local
+  transfer size.
+- **`optimizeTMALoads`** — for buffered NVWS descriptor-load producers. Called from
   `insertAsyncComm` (`WSCodePartition.cpp`) during the code-partition phase.
-  Emits `barrier_expect` + `AsyncTMACopyGlobalToLocalOp` writing directly into
-  the pipeline SMEM buffer, and a `wait_barrier` before the consumers (the
-  descriptor_load's single `local_store` user and the descriptor_load itself are
-  erased, since the async copy writes the buffer directly). See below.
+  Emits `barrier_expect` + `AsyncTMACopyGlobalToLocalOp`. The copy uses the
+  planner-rewritten NVWS destination allocation and rebuilds its stage view
+  with the fused barrier's buffer index, followed by a `wait_barrier` before
+  the consumers. The NVWS operation is then erased; there is no tensor-result
+  or `local_store` cleanup path. See below.
 - **`createLocalAlloc`** — for non-TMA (register/plain-load) producers. Called
   from `createBuffer` during the buffer-allocation phase; it creates the SMEM (or
   1D-TMEM) buffer and inserts the producer-side `LocalStoreOp` + consumer-side
@@ -55,8 +61,8 @@ loads for the same MMA), they are fused onto a single barrier:
    grouped together.
 2. **Shared barrier**: A single pair of barriers (ready + empty) is allocated
    for the group.
-3. **Combined expect**: One `BarrierExpectOp` is emitted with the total byte
-   count across all loads.
+3. **Combined expect**: One `BarrierExpectOp` is emitted with the sum of the
+   NVWS loads' `txCount` attributes.
 4. **Multiple copies, one wait**: Each `AsyncTMACopyGlobalToLocalOp` references
    the shared barrier. The consumer issues a single `WaitBarrierOp`.
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -18,6 +18,7 @@ doTaskPartition          (Hopper only; skipped on Blackwell)
   → doDynamicTileBroadcast  (run-once tile-id: atomic counter + CLC fetch)
   → doDataPartition      (via nvgpu-ws-data-partition when requested)
   → doPingPongPrep       (optional, if pingpongAutoWS is set)
+  → doConvertDescriptorLoadsToNVWS
   → doBufferAllocation
   → doMemoryPlanner
   → doCodePartition
@@ -89,7 +90,7 @@ recognizes the `scf.while` outer loop (same doc).
 | `WSBuffer.cpp` | `appendAccumCntsForOps` | Accumulation counter infrastructure for multi-buffer indexing |
 | `WSMemoryPlanner.cpp` | `doMemoryPlanner` | Plans SMEM and TMEM allocation (multi-buffering, liveness) |
 | `WSCodePartition.cpp` | `doCodePartition` | Creates channels, inserts async copies and barriers |
-| `WSLowerMem.cpp` | — | Memory lowering: async copies between global/shared/tensor memory |
+| `WSLowerMem.cpp` | `doConvertDescriptorLoadsToNVWS` / `optimizeTMALoads` | Converts `tt.descriptor_load` to buffered `nvws.descriptor_load` before buffer hoisting, then lowers it to async TMA copies after planning |
 | `WSSpecialize.cpp` | `specializeRegion` | Clones ops into `ttg.WarpSpecializeOp` regions |
 | `WSLowerToken.cpp` | `doTokenLowering` | Lowers `ProducerAcquireOp`/`ConsumerWaitOp` to hardware barriers |
 | `WSTMAStoreLowering.cpp` | `doTMAStoreLowering` | Pre-pass lowering of `tt.descriptor_store` for WS visibility |

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/SmemAllocationDesign.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/SmemAllocationDesign.md
@@ -92,13 +92,15 @@ budget check is performed in this phase; the total SMEM may temporarily exceed
 the budget afterwards.
 
 Budget is reconciled later (Phase 3.6) by reusing **discretionary** SMEM — the
-TMA store/reduce staging buffers (write → TMA op → dead). Co-live operand buffers
-(loaded once per outer iteration and read across the whole inner loop, e.g.
-`q`/`k`/`v`) are explicitly excluded from that reuse, since aliasing them is
-unsafe. If, even after staging reuse, the floored allocation still exceeds the
-budget, the planner emits a warning and **ships it anyway** rather than dropping
-a floor — the real hardware SMEM limit (an `OutOfResources` at codegen) is the
-backstop.
+TMA store/reduce staging buffers (write → TMA op → dead). A staging buffer may
+reuse an unstaged NVWS descriptor destination when their encodings match and a
+forward SSA/memory dependency proves that the descriptor consumer completes
+before the staging producer. Co-live operand buffers (loaded once per outer
+iteration and read across the whole inner loop, e.g. `q`/`k`/`v`) are explicitly
+excluded from that reuse, since aliasing them is unsafe. If, even after staging
+reuse, the floored allocation still exceeds the budget, the planner emits a
+warning and **ships it anyway** rather than dropping a floor — the real hardware
+SMEM limit (an `OutOfResources` at codegen) is the backstop.
 
 > Earlier revision: a budget-gated revert here silently downgraded the
 > cross-stage `q` buffer to a single copy and deadlocked `_attn_bwd_persist`

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
@@ -157,10 +157,7 @@ int getTxCount(Operation *descOp) {
     }
   };
   auto [tensorType, desc] = getTensorTypeAndDesc(descOp);
-  auto encoding = getEncodingFromDescriptor(descOp, tensorType, desc);
-  auto shapePerCTA = getShapePerCTA(encoding, tensorType.getShape());
-  return product(shapePerCTA) *
-         getIntOrFloatOrPtrBitWidth(tensorType.getElementType()) / 8;
+  return getDescriptorLoadBytes(descOp, tensorType, desc);
 }
 
 void createNVWSDescriptorLoadOp(OpBuilder &builder, Operation *ttDescLoadOp,


### PR DESCRIPTION
Summary:
Fully translates the tt.descriptor_load usage to nvws.descriptor_load for the AutoWS codepath.


Reviewed By: manman-ren

Differential Revision: D112909940

Pulled By: njriasan


