### PR TITLE
[TritonNvidiaGPU] Fix build break on DescriptorReduceKind::NONE

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -528,8 +528,6 @@ bool AsyncTMAReduceOp::isSupportedReduceKind(DescriptorReduceKind kind,
       elementType.isInteger(64) && !elementType.isSignedInteger();
   bool isF16OrBF16 = elementType.isF16() || elementType.isBF16();
   switch (kind) {
-  case DescriptorReduceKind::NONE:
-    return false;
   case DescriptorReduceKind::ADD:
     return isInt32 || isNotSignedInt64 || elementType.isF32() || isF16OrBF16;
   case DescriptorReduceKind::MIN:
@@ -542,8 +540,10 @@ bool AsyncTMAReduceOp::isSupportedReduceKind(DescriptorReduceKind kind,
   case DescriptorReduceKind::INC:
   case DescriptorReduceKind::DEC:
     return false;
+  case DescriptorReduceKind::NONE:
+    break;
   }
-  llvm_unreachable("unknown descriptor reduce kind");
+  llvm_unreachable("unexpected reduce kind for async_tma_reduce");
 }
 
 // -- AsyncTMACopyGlobalToLocalOp --

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -528,6 +528,8 @@ bool AsyncTMAReduceOp::isSupportedReduceKind(DescriptorReduceKind kind,
       elementType.isInteger(64) && !elementType.isSignedInteger();
   bool isF16OrBF16 = elementType.isF16() || elementType.isBF16();
   switch (kind) {
+  case DescriptorReduceKind::NONE:
+    return false;
   case DescriptorReduceKind::ADD:
     return isInt32 || isNotSignedInt64 || elementType.isF32() || isF16OrBF16;
   case DescriptorReduceKind::MIN:


### PR DESCRIPTION
## Summary
The OSS CMake build (make dev-install-llvm) fails to compile `lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp` with:
`error: enumeration value 'NONE' not handled in switch [-Werror,-Wswitch]`

This is a cross-fork enum mismatch. The fork's `DescriptorReduceKind` enum has a `NONE=0` case that OSS upstream lacks (added by internal re-sync 6067faedf). It is load-bearing: `descriptor_store`'s `reduce_kind` defaults to it and `WSTMAStoreLowering` branches on it. But `AsyncTMAReduceOp::isSupportedReduceKind`, cherry-picked from upstream in 8c65c77f5, was written against the upstream enum and never handled NONE, so -Wswitch with -Werror breaks the build.

NONE is never a valid reduce kind for `async_tma_reduce`, so this adds the missing case returning false. Removing NONE to match upstream is not an option since it would break `descriptor_store` and `WSTMAStoreLowering`.

## Test plan:
`make dev-install-llvm` now compiles cleanly; the previously failing Ops.cpp.o builds without the -Wswitch error.