### PR TITLE
[TLX][AMD] Split-K for the warp-pipe addmm template (Inductor E2E) (#2273)

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -170,6 +170,98 @@ class TestTLXTemplates(TestCase):
         code_str = "\n".join(code)
         self.assertIn("triton_tem", code_str)
 
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    def test_tlx_addmm_warppipe_split_k(self, dtype: torch.dtype):
+        """Split-K path of the TLX warp-pipe addmm (AMD MI350X / gfx950), col-major B.
+
+        An undersaturated grid (few MN tiles) + large K makes the heuristic offer
+        SPLIT_K > 1 candidates (registry gate: `tiles < NUM_SMS`). On a 2-tile shape
+        the split-K configs win autotune, so the addmm lowers to the split-K path: a
+        partial-GEMM kernel that writes an fp32 workspace + a separate
+        `_reduce_k_kernel` that sums the partials, re-adds bias, and casts. Verifies
+        the 2-kernel split-K reduce is (a) actually taken and (b) numerically correct.
+        """
+        # 256x4096x256: 2 MN tiles (128x256) on 256 CUs -> deeply undersaturated, so
+        # split-K (up to SK=8 -> 16 workgroups) is far faster than SK=1 (2 workgroups)
+        # and wins the autotune. K=4096 keeps each split > NUM_BUFFERS K-iters.
+        M, K, N = 256, 4096, 256
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
+        # w.t() => B is [K, N] col-major (stride_bk == 1) -- the nn.Linear weight layout.
+        w = torch.randn(N, K, device=GPU_TYPE, dtype=dtype)
+        bias = torch.randn(N, device=GPU_TYPE, dtype=dtype)
+
+        def addmm(bias, a, w):
+            return torch.addmm(bias, a, w.t())
+
+        with (config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+        }), ):
+            c_actual, code = run_and_get_code(torch.compile(addmm), bias, a, w)
+
+        # fp32 reference; the split-K fp32 workspace reduction is order-different from a
+        # single-pass accumulation, so allow a modest tolerance (benign reduction noise).
+        c_expected = (a.float() @ w.t().float() + bias.float()).to(dtype)
+        torch.testing.assert_close(c_actual, c_expected, atol=3e-2, rtol=3e-2)
+
+        code_str = "\n".join(code)
+        # force mode keeps only the TLX template (never extern/aten)...
+        self.assertIn("triton_tem", code_str)
+        # ...and the undersaturated grid takes the split-K path -> separate reduce kernel.
+        self.assertIn("_reduce_k_kernel", code_str)
+
+
+class TestWarpPipeSplitKCodegen(TestCase):
+    """Deterministic codegen check for the AMD warp-pipe split-K template.
+
+    The e2e test above relies on autotune *selecting* a SPLIT_K > 1 config (highly
+    reliable on a 2-tile shape, but a timing decision). This test renders the
+    `amd_addmm_warppipe` jinja template directly with SPLIT_K=2 vs SPLIT_K=1 -- no
+    GPU, no autotune -- so the split-K branches are *guaranteed* covered even if
+    autotune ever stops picking split-K, and it runs on any host (not gfx950-gated).
+    """
+
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_warppipe_split_k_template_render(self):
+        import jinja2
+        from triton.language.extra.tlx.inductor.mm_templates import load_tlx_template
+
+        source = load_tlx_template("amd_addmm_warppipe")
+
+        # Stub the Inductor render hooks; the split-K branches are pure jinja that
+        # only depends on SPLIT_K, so the stubs just need to be present + callable.
+        hooks = {
+            "def_kernel": lambda *a, **k: "def _kernel(A, B, out_ptr0):",
+            "size": lambda *a, **k: "0",
+            "stride": lambda *a, **k: "1",
+            "output_ptr": lambda *a, **k: "out_ptr0",
+            "store_output": lambda *a, **k: "# store_output(...)",
+        }
+        tmpl = jinja2.Environment().from_string(source)
+        split = tmpl.render(SPLIT_K=2, **hooks)
+        nosplit = tmpl.render(SPLIT_K=1, **hooks)
+
+        # SPLIT_K > 1 must emit: split-id decode, balanced K-partition, fp32 workspace store.
+        self.assertIn("split_id = (pid % SPLIT_K)", split)
+        self.assertIn("base = K_ITERS // SPLIT_K", split)
+        self.assertIn("k_lo = split_id * base", split)
+        self.assertIn("tl.store(split_k_ws + ws_off, acc", split)
+
+        # SPLIT_K == 1 must take the plain data-parallel path: no split-id, no workspace,
+        # full-K loop, and store via store_output (not the reduce workspace).
+        self.assertNotIn("split_id = (pid % SPLIT_K)", nosplit)
+        self.assertNotIn("split_k_ws", nosplit)
+        self.assertIn("k_lo = 0", nosplit)
+        self.assertIn("store_output", nosplit)
+
 
 class TestInterleaveEpilogue(TestCase):
     """Test that INTERLEAVE_EPILOGUE produces correct results and interleaved stores."""
@@ -351,6 +443,7 @@ class TestReduceKKernel(TestCase):
         _reduce_k_kernel[grid](
             workspace,
             output,
+            output,  # bias_ptr (unused when HAS_BIAS=False, passed as dummy)
             M,
             N,
             SPLIT_K=SPLIT_K,

--- a/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
@@ -26,6 +26,13 @@
 
     # re-order program ID for better L2 performance
     pid = tl.program_id(0).to(INDEX_DTYPE)
+{% if SPLIT_K > 1 %}
+    # split-K: grid is grid_mn * SPLIT_K; each program owns one (tile, split) and
+    # reduces only its K-slice. Partials go to the fp32 split_k_ws workspace and are
+    # summed (+ bias) by _reduce_k_kernel (emitted after this kernel by the plumbing).
+    split_id = (pid % SPLIT_K).to(INDEX_DTYPE)
+    pid = pid // SPLIT_K
+{% endif %}
     grid_m = (M + BLOCK_M - 1) // BLOCK_M
     grid_n = (N + BLOCK_N - 1) // BLOCK_N
 
@@ -62,6 +69,21 @@
     b_base = offs_n[:, None] * stride_bn          # B as (BLOCK_N, BLOCK_K): n is the row of the [N,K] view
 
     K_ITERS = tl.cdiv(K, BLOCK_K)
+{% if SPLIT_K > 1 %}
+    # this split's contiguous K-iteration range [k_lo, k_lo + n_iters). BALANCED
+    # partition: the first `rem` splits get (base + 1) iters, the rest get `base`.
+    # This keeps every split within +-1 iter of the others, so n_iters stays > NUM_BUFFERS
+    # for all splits (the heuristic guards base > NUM_BUFFERS). A ceil-then-remainder
+    # split would instead leave the LAST split with as little as 1 iter, underflowing
+    # the prologue/drain and double-counting K-tiles.
+    base = K_ITERS // SPLIT_K
+    rem = K_ITERS - base * SPLIT_K
+    k_lo = split_id * base + tl.minimum(split_id, rem)
+    n_iters = base + (split_id < rem).to(INDEX_DTYPE)
+{% else %}
+    k_lo = 0
+    n_iters = K_ITERS
+{% endif %}
 
     smemA = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(A), NUM_BUFFERS)
     smemB = tlx.local_alloc((BLOCK_N, BLOCK_K), tlx.dtype_of(B), NUM_BUFFERS)   # holds Bᵀ tile
@@ -71,7 +93,7 @@
     # One group/iter means the wait counts tiles directly (no *2), and it lets the wait live at the
     # loop tail (below), which is what makes the pipeline race-free across all NUM_BUFFERS (incl. 2).
     for i in tl.range(0, NUM_BUFFERS, loop_unroll_factor=NUM_BUFFERS):
-        k_start = i * BLOCK_K
+        k_start = (k_lo + i) * BLOCK_K
         a_offs = a_base + (k_start + offs_k[None, :]) * stride_ak
         b_offs = b_base + (k_start + offs_k[None, :]) * stride_bk
         # int32 cast is lossless: the heuristic only emits this template when offsets fit int32.
@@ -85,12 +107,12 @@
 
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
 
-    for tile_id in tl.range(0, K_ITERS - NUM_BUFFERS):
+    for tile_id in tl.range(0, n_iters - NUM_BUFFERS):
         # buffer indices MUST be int32: local_view feeds them to the block-ptr index check, which
         # rejects int64. tile_id is int64 when K (-> K_ITERS) is symbolic (dynamic shapes).
         prefetch_buf = (tile_id % NUM_BUFFERS).to(tl.int32)
         next_buf = ((tile_id + 1) % NUM_BUFFERS).to(tl.int32)
-        k_prefetch = (tile_id + NUM_BUFFERS) * BLOCK_K
+        k_prefetch = (k_lo + tile_id + NUM_BUFFERS) * BLOCK_K
 
         with tlx.warp_pipeline_stage("mfma", priority=0):
             acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
@@ -117,7 +139,7 @@
     acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
     tlx.async_load_wait_group(0)
     for i in tl.range(0, NUM_BUFFERS - 1, loop_unroll_factor=NUM_BUFFERS - 1):
-        buf = ((K_ITERS - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS).to(tl.int32)   # int32 buffer index
+        buf = ((n_iters - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS).to(tl.int32)   # int32 buffer index
         a_tile = tlx.local_load(tlx.local_view(smemA, buf))
         b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, buf)))
         acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
@@ -129,5 +151,17 @@
     idx_n = rn[None, :]
     mask = (idx_m < M) & (idx_n < N)
 
+{% if SPLIT_K > 1 %}
+    # split-K: write this split's fp32 partial to workspace[(split_id*M + m), n].
+    # _reduce_k_kernel (emitted after this kernel) sums the SPLIT_K partials, adds bias,
+    # casts, and stores the final output. store_output (and its bias epilogue) is bypassed,
+    # so bias is applied in the reduction step (see registry _tlx_emit_post_kernel_code).
+    # Referencing output_ptr() keeps out_ptr0 in the kernel signature (the autotuning
+    # harness passes `out` positionally); the real output is written by _reduce_k_kernel.
+    keep_out_ptr = {{output_ptr()}}  # noqa: F841
+    ws_off = split_id * (M * N) + idx_m * N + idx_n
+    tl.store(split_k_ws + ws_off, acc, mask=mask)
+{% else %}
     # inductor generates a suffix (bias add via epilogue_fn + prefix_args, cast, store)
     {{store_output(("idx_m", "idx_n"), "acc", "mask", val_shape=("BLOCK_M", "BLOCK_N"))}}
+{% endif %}

--- a/third_party/tlx/language/tlx/inductor/mm_templates.py
+++ b/third_party/tlx/language/tlx/inductor/mm_templates.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from torch._inductor.kernel.mm_common import mm_grid
+from torch._inductor.kernel.mm_common import mm_grid  # noqa: F401
 from torch._inductor.select_algorithm import SymbolicGridFn, TritonTemplate
 from torch._inductor.utils import load_template
 
@@ -29,6 +29,22 @@ def _persistent_mm_grid_split_k(*args, cdiv, min):
     return (min(meta["NUM_SMS"], num_mn_tiles * split_k), 1, 1)
 
 
+@SymbolicGridFn
+def _mm_grid_split_k(m, n, meta, *, cdiv):
+    """Non-persistent grid for the warp-pipe addmm: one program per (tile, K-split).
+
+    grid = grid_m * grid_n * SPLIT_K (SPLIT_K defaults to 1 = the plain data-parallel grid,
+    identical to mm_grid). Each program owns one output tile and one K-slice; partials are
+    summed by _reduce_k_kernel. Unlike _persistent_mm_grid_split_k this is NOT capped at
+    NUM_SMS -- the warp-pipe kernel is non-persistent (one tile per program).
+    """
+    return (
+        cdiv(m, meta["BLOCK_M"]) * cdiv(n, meta["BLOCK_N"]) * meta.get("SPLIT_K", 1),
+        1,
+        1,
+    )
+
+
 blackwell_gemm_ws_template = TritonTemplate(
     name="tlx_blackwell_gemm_ws",
     grid=_persistent_mm_grid_split_k,
@@ -42,7 +58,7 @@ blackwell_gemm_ws_template = TritonTemplate(
 # (see registry.py); selection/gating is via TORCHINDUCTOR_TLX_MODE (tlx_config).
 amd_addmm_warppipe_template = TritonTemplate(
     name="tlx_amd_addmm_warppipe",
-    grid=mm_grid,
+    grid=_mm_grid_split_k,  # SPLIT_K=1 -> identical to mm_grid; >1 -> grid_mn*SPLIT_K
     source=load_tlx_template("amd_addmm_warppipe"),
 )
 

--- a/third_party/tlx/language/tlx/inductor/reduce_k.py
+++ b/third_party/tlx/language/tlx/inductor/reduce_k.py
@@ -27,12 +27,16 @@ if TYPE_CHECKING:
 def _reduce_k_kernel(
     workspace_ptr,
     c_ptr,
+    bias_ptr,
     M,
     N,
     SPLIT_K: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     OUTPUT_DTYPE: tl.constexpr,
+    HAS_BIAS: tl.constexpr = False,
+    STRIDE_BIAS_M: tl.constexpr = 0,
+    STRIDE_BIAS_N: tl.constexpr = 1,
 ):
     pid_m = tl.program_id(0)
     pid_n = tl.program_id(1)
@@ -47,6 +51,12 @@ def _reduce_k_kernel(
         partial = tl.load(workspace_ptr + ws_offs, mask=mask, other=0.0)
         acc += partial.to(tl.float32)
 
+    # addmm bias: applied here because the split-K main kernel bypasses store_output
+    # (and its bias epilogue). STRIDE_BIAS_M=0 broadcasts a 1D [N] bias over M.
+    if HAS_BIAS:
+        bias_offs = offs_m[:, None] * STRIDE_BIAS_M + offs_n[None, :] * STRIDE_BIAS_N
+        acc += tl.load(bias_ptr + bias_offs, mask=mask, other=0.0).to(tl.float32)
+
     tl.store(c_ptr + base_offs, acc.to(OUTPUT_DTYPE), mask=mask)
 
 
@@ -58,6 +68,9 @@ def emit_reduce_k_call(
     N_expr: str,
     split_k: int,
     output_triton_dtype: str,
+    bias_name: str | None = None,
+    stride_bias_m: int = 0,
+    stride_bias_n: int = 1,
 ) -> None:
     """Emit wrapper code to launch the split-K reduction kernel.
 
@@ -69,15 +82,25 @@ def emit_reduce_k_call(
         N_expr: Expression string for the N dimension.
         split_k: The SPLIT_K value (compile-time constant).
         output_triton_dtype: Triton dtype string for the output (e.g. "tl.float16").
+        bias_name: Variable name of the addmm bias buffer, or None for plain mm.
+            When set, _reduce_k_kernel adds it to the reduced result.
+        stride_bias_m: Bias row stride (0 to broadcast a 1D [N] bias over M).
+        stride_bias_n: Bias column stride.
     """
     wrapper.writeline(
         "from triton.language.extra.tlx.inductor.reduce_k import _reduce_k_kernel"
     )
     wrapper.writeline("import triton")
     wrapper.writeline("import triton.language as tl")
+    # No bias (plain mm): pass the output buffer as a dummy ptr; HAS_BIAS=False
+    # means it is never dereferenced.
+    has_bias = bias_name is not None
+    bias_ptr = bias_name if has_bias else output_name
     wrapper.writeline(
         f"_reduce_k_kernel[(triton.cdiv({M_expr}, 32), triton.cdiv({N_expr}, 32))]"
-        f"({ws_name}, {output_name}, {M_expr}, {N_expr},"
+        f"({ws_name}, {output_name}, {bias_ptr}, {M_expr}, {N_expr},"
         f" SPLIT_K={split_k}, BLOCK_SIZE_M=32, BLOCK_SIZE_N=32,"
-        f" OUTPUT_DTYPE={output_triton_dtype})"
+        f" OUTPUT_DTYPE={output_triton_dtype},"
+        f" HAS_BIAS={has_bias}, STRIDE_BIAS_M={stride_bias_m},"
+        f" STRIDE_BIAS_N={stride_bias_n})"
     )

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1150,12 +1150,16 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
     # regime; on gfx950 they beat the BLOCK_N<=128 tiles on large-N shapes (e.g.
     # 1024x22272x1024 reaches ~98% of rocBLAS, up from ~92%). LDS: (128x256x64,NB2)
     # = 96KB, (128x256x32,NB3) = 72KB -- both fit gfx950 (256x256x64 does not).
+    # (128x256x64,NB3) = 144KB fits gfx950's 160KB (occupancy 1); it is the deeper-
+    # prefetch tile that won the standalone split-K sweep on low-occupancy large-K
+    # (e.g. 1024x6144x22272 at SK=4), which the NB=2 variant alone could not reach.
     WARPPIPE_CONFIGS = [
         (64, 64, 128, 8, 8, 3),
         (64, 64, 64, 8, 8, 3),
         (128, 128, 64, 8, 8, 2),
         (64, 128, 64, 8, 8, 2),
         (128, 256, 64, 8, 8, 2),
+        (128, 256, 64, 8, 8, 3),
         (128, 256, 32, 8, 8, 3),
     ]
 
@@ -1210,6 +1214,19 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
         ):
             return
         num_xcds = _amd_num_xcds()
+        # split-K only helps grids that leave CUs idle. NUM_SMS is the device CU count
+        # (get_num_sms() maps to multi_processor_count = CUs on ROCm; 256 on gfx950/MI350X);
+        # a grid with fewer MN tiles than this is undersaturated and benefits from
+        # partitioning K across extra programs (summed by _reduce_k_kernel).
+        NUM_SMS = get_num_sms()
+        # split-K bypasses store_output's bias epilogue; the reduction re-adds only a
+        # plain bias (i.e. alpha*(A@B) + beta*bias with alpha=beta=1). Restrict split-K
+        # to that case -- unit-scalar addmm and plain mm both qualify. sympy Symbol == 1
+        # returns a plain False, so this stays safe for symbolic scalars.
+        scalars = getattr(kernel_inputs, "_scalars", None) or {}
+        allow_split_k = scalars.get("alpha", 1) == 1 and scalars.get("beta", 1) == 1
+        m_hint = sizevars.optimization_hint(m, fallback=NUM_SMS)
+        n_hint = sizevars.optimization_hint(n, fallback=NUM_SMS)
         for (
             block_m,
             block_n,
@@ -1224,22 +1241,49 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
             # warp-pipeline correctness guard: K_ITERS > NUM_BUFFERS.
             if not sizevars.statically_known_true(sympy.Gt(k, num_buffers * block_k)):
                 continue
-            triton_config = self.triton_config(
-                1,  # num_stages=1: TLX is hand-pipelined; auto software-pipelining must be off
-                num_warps,
-                BLOCK_M=block_m,
-                BLOCK_N=block_n,
-                BLOCK_K=block_k,
-                GROUP_M=group_m,
-                NUM_BUFFERS=num_buffers,
-                NUM_XCDS=num_xcds,
-                matrix_instr_nonkdim=16,
-                waves_per_eu=0,
-                kpack=get_default_kpack(block_k),
+            # SPLIT_K=1 (plain data-parallel) is always offered. Add split candidates
+            # only for undersaturated grids, and only when each split still runs
+            # K_ITERS/SPLIT_K > NUM_BUFFERS iters (statically checked via k > NB*BK*SK)
+            # so the warp-pipeline prologue/drain stays well-formed.
+            tiles = ((m_hint + block_m - 1) // block_m) * (
+                (n_hint + block_n - 1) // block_n
             )
-            yield self._convert_config_to_template_kwargs(
-                triton_config, m, n, k, out_dtype
-            )
+            split_ks = [1]
+            if allow_split_k and tiles < NUM_SMS:
+                for sk in (2, 4, 8):
+                    # Cap at ~4 waves. For memory-bound large-K the sweet spot is
+                    # often >1 wave (more concurrent HBM requests -> higher effective
+                    # bandwidth); the standalone sweep's winners filled to 300%
+                    # (e.g. 1024x6144x22272 at SK=4 -> 768 wg / 3 waves). A 2-wave cap
+                    # excluded exactly those, so autotune fell back to a slower SK=1.
+                    if tiles * sk > 4 * NUM_SMS:
+                        break
+                    # correctness: the balanced K-partition gives each split
+                    # base = K_ITERS // SK iters; require base > NUM_BUFFERS so every
+                    # split's warp-pipeline prologue/drain is well-formed. Sufficient
+                    # static condition on K: k > (NUM_BUFFERS + 1) * BLOCK_K * SK.
+                    if sizevars.statically_known_true(
+                        sympy.Gt(k, (num_buffers + 1) * block_k * sk)
+                    ):
+                        split_ks.append(sk)
+            for split_k in split_ks:
+                triton_config = self.triton_config(
+                    1,  # num_stages=1: TLX is hand-pipelined; auto software-pipelining must be off
+                    num_warps,
+                    BLOCK_M=block_m,
+                    BLOCK_N=block_n,
+                    BLOCK_K=block_k,
+                    GROUP_M=group_m,
+                    NUM_BUFFERS=num_buffers,
+                    NUM_XCDS=num_xcds,
+                    SPLIT_K=split_k,
+                    matrix_instr_nonkdim=16,
+                    waves_per_eu=0,
+                    kpack=get_default_kpack(block_k),
+                )
+                yield self._convert_config_to_template_kwargs(
+                    triton_config, m, n, k, out_dtype
+                )
 
 
 @register_template_heuristic(
@@ -1407,9 +1451,14 @@ def _tlx_tt_generate(self, input_nodes, layout, *args, **kwargs):  # type: ignor
         # SPLIT_K > 1 forces TMA_EPILOGUE_STORE=0, so the TMA descriptor
         # workspace (ws_ptr) from TMAWorkspaceMixin is unused.  Replace it
         # with the split-K fp32 partial-results workspace.
+        # UNINITIALIZED (no zero-fill): every valid output element is written exactly
+        # once -- one (tile, split) program per element, masked to [0,M)x[0,N) -- and
+        # _reduce_k_kernel reads with the same mask, so a zeroed workspace is
+        # unnecessary. ZERO_ON_CALL here would re-zero the full SPLIT_K*M*N fp32 buffer
+        # every call (tens of MB), which dominates and erased the split-K win.
         kwargs["workspace_arg"] = WorkspaceArg(
             count=split_k * layout.size[0] * layout.size[1],
-            zero_mode=WorkspaceZeroMode.ZERO_ON_CALL,
+            zero_mode=WorkspaceZeroMode.UNINITIALIZED,
             device=layout.device,
             outer_name=WorkspaceArg.unique_name("split_k_ws_"),
             inner_name="split_k_ws",
@@ -1789,6 +1838,13 @@ def _tlx_render(self, template, kwargs, record_input_dependent_tracked_event=Fal
     # so they're available in the jinja template.
     if getattr(self, "async_tma_store", False):
         self._register_extra_template_env_fns(self.compute_epilogue, self.output_ptr)
+    elif getattr(self, "_tlx_split_k", 1) > 1:
+        # split-K writes partials to split_k_ws and never store_output()s, so the
+        # output arg would be pruned from the kernel signature -- but the autotuning
+        # harness still passes `out` positionally (arg-count mismatch). Expose
+        # output_ptr() so the template can reference it and keep it in the signature;
+        # the real output is written later by _reduce_k_kernel.
+        self._register_extra_template_env_fns(self.output_ptr)
     return _orig_render(self, template, kwargs, record_input_dependent_tracked_event)
 
 
@@ -1817,6 +1873,31 @@ def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-u
         M_expr = pexpr(self.call_sizes[0])
         N_expr = pexpr(self.call_sizes[1])
 
+        # addmm bias is applied by store_output's epilogue in the non-split path, which
+        # split-K bypasses -> it must be re-added in the reduction. For addmm the bias is
+        # the prefix input node (input_nodes[0], prefix_args=1); plain mm has none.
+        bias_name = None
+        stride_bias_m = 0
+        stride_bias_n = 1
+        if getattr(self, "prefix_args", 0) >= 1 and self.input_nodes:
+            bias_node = self.input_nodes[0]
+            bias_name = bias_node.get_name()
+            bsize = bias_node.get_size()
+            bstride = bias_node.get_layout().stride
+            sizevars = V.graph.sizevars
+
+            def _sh(expr):
+                return int(sizevars.optimization_hint(expr, fallback=1))
+
+            if len(bsize) == 1:
+                # [N] bias broadcast over M
+                stride_bias_m, stride_bias_n = 0, _sh(bstride[0])
+            elif len(bsize) == 2:
+                stride_bias_m = 0 if _sh(bsize[0]) == 1 else _sh(bstride[0])
+                stride_bias_n = 0 if _sh(bsize[1]) == 1 else _sh(bstride[1])
+            else:
+                bias_name = None  # unexpected rank; skip (should not happen for addmm)
+
         emit_reduce_k_call(
             wrapper,
             ws_name=self.workspace_arg.outer_name,
@@ -1825,6 +1906,9 @@ def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-u
             N_expr=N_expr,
             split_k=split_k,
             output_triton_dtype=output_triton_dtype,
+            bias_name=bias_name,
+            stride_bias_m=stride_bias_m,
+            stride_bias_n=stride_bias_n,
         )
     _orig_emit_post_kernel(self, wrapper, kernel_name)
 


### PR DESCRIPTION
Summary:

Adds a split-K path to the TLX AMD warp-pipe `addmm` template so low-occupancy large-K GEMMs can saturate the 256 CUs on gfx950/MI350X. For shapes with few MN tiles (e.g. 1024x1024xK), the data-parallel grid leaves most CUs idle; partitioning K across extra programs fills them and cuts latency.

When `SPLIT_K > 1` the non-persistent grid becomes `grid_m * grid_n * SPLIT_K` (via a new `_mm_grid_split_k`). Each program decodes `split_id = pid % SPLIT_K`, owns one output tile and one K-slice, balanced-partitions its K-iteration range (`base = K_ITERS // SPLIT_K`, first `rem` splits get `base + 1` iters so every split stays `> NUM_BUFFERS` and the warp-pipeline prologue/drain is well-formed), accumulates fp32, and `tl.store`s its partial to an injected `split_k_ws` workspace at `split_id*(M*N) + m*N + n`. A follow-up `_reduce_k_kernel` sums the `SPLIT_K` partials, adds the addmm bias, casts, and writes the output. This reuses the template-agnostic split-K plumbing (workspace injection + reduce-call emission) already used by the Blackwell GEMM template; the `SPLIT_K == 1` path is byte-for-byte the previous data-parallel kernel (including the line-102 RAW-race fix).

Files:
- `amd_addmm_warppipe.py.jinja`: `{% if SPLIT_K > 1 %}` branches for the split-id decode, balanced K-range, and the workspace-write epilogue; references `output_ptr()` in the split path so `out_ptr0` stays in the kernel signature (the autotuning harness passes `out` positionally even though the main kernel no longer stores to it -- `_reduce_k_kernel` writes the real output).
- `mm_templates.py`: `_mm_grid_split_k` (SPLIT_K=1 is identical to `mm_grid`); wired as the warp-pipe template grid.
- `reduce_k.py`: optional bias in `_reduce_k_kernel` / `emit_reduce_k_call` (`HAS_BIAS`, `STRIDE_BIAS_M/N`; `STRIDE_BIAS_M=0` broadcasts a 1D `[N]` bias over M). The addmm bias is applied here because the split path bypasses `store_output`'s bias epilogue. Backward-compatible: plain mm (Blackwell) passes no bias.
- `registry.py`: `ROCmAddMMWarpPipeTemplateConfigHeuristic` emits SPLIT_K candidates (2/4/8) only for undersaturated grids (`tiles < NUM_SMS`), only when the K-partition keeps `base > NUM_BUFFERS`, and only for unit alpha/beta; `_tlx_emit_post_kernel_code` threads the bias + strides into `emit_reduce_k_call`; `_tlx_render` exposes `output_ptr()` for split-K; the split-K workspace is `UNINITIALIZED` (no zero-fill -- every valid element is written exactly once, masked, and read masked, so re-zeroing tens of MB per call is pure overhead).

Reviewed By: dshi7

Differential Revision: D112132306


