### PR TITLE
 [AutoWS] [Tile-Scheduler] Add e2e tests for unsupported Atomic schedule cases (#2277)

### DIFF
--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -275,6 +275,71 @@ def matmul_kernel_tma_dynamic_persistent_ws_while(
 
 
 # ============================================================================
+# Kernel 2c-bailout: matmul_kernel_tma_dynamic_persistent_ws_while_scatter
+# Same dynamic-persistent shape as matmul_kernel_tma_dynamic_persistent_ws_while,
+# but (1) the outer while requests AutoWS via tl.condition(warp_specialize=True)
+# and (2) the tile claim is a NON-scalar (scatter) atomic: a 1-element tensor
+# atomic reduced back to a scalar. AutoWS cannot broadcast a scatter atomic, so
+# doDynamicTileBroadcast rejects and the orchestrator gracefully strips WS
+# metadata -- the kernel must still compile and compute the correct GEMM as a
+# plain (non-WS) dynamic-persistent kernel.
+# ============================================================================
+@triton.jit
+def matmul_kernel_tma_dynamic_persistent_ws_while_scatter(
+    a_desc,
+    b_desc,
+    c_desc,
+    tile_counter,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    EPILOGUE_SUBTILE: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+):
+    dtype = tl.float16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    tile_id = start_pid
+
+    # Outer while requests AutoWS; the scatter tile claim below forces a graceful
+    # bail-out to a non-WS kernel.
+    while tl.condition(tile_id < num_tiles, warp_specialize=True):
+        pid_m, pid_n = _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS)
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        acc_slices = _split_n_2D(accumulator, EPILOGUE_SUBTILE)
+        slice_size: tl.constexpr = BLOCK_SIZE_N // EPILOGUE_SUBTILE
+        for slice_id in tl.static_range(0, EPILOGUE_SUBTILE):
+            c_desc.store(
+                [offs_am, offs_bn + slice_id * slice_size],
+                acc_slices[slice_id].to(dtype),
+            )
+        # Scatter (non-scalar) atomic tile claim: a 1-element tensor atomic that is
+        # reduced back to a scalar. Same work-stealing semantics as the scalar
+        # claim, but classifyAtomic sees a non-scalar atomic replicated across
+        # partitions and rejects AutoWS (graceful bail-out).
+        claimed = tl.atomic_add(tile_counter + tl.arange(0, 1), 1)
+        tile_id = tl.sum(claimed, axis=0)
+
+
+# ============================================================================
 # Kernel 2d: matmul_kernel_tma_clc_persistent_ws_while
 # Dynamic (work-stealing) persistent TMA matmul whose while-loop tile id is
 # claimed via the core CLC tile scheduler (tl.clc_tile_scheduler) instead of a
@@ -1068,6 +1133,86 @@ def test_tutorial09_matmul_tma_clc_persistent_while_loop_warp_specialize(EPILOGU
         assert "ttng.async_tma_copy_global_to_local" in ttgir, "Expected TMA copy"
         assert "ttng.clc_try_cancel" in ttgir, "Expected CLC scheduling in IR"
 
+        ref_out = torch.matmul(A.to(torch.float32), B.T.to(torch.float32)).to(dtype)
+        torch.testing.assert_close(ref_out, C, atol=0.03, rtol=0.03)
+
+
+# ============================================================================
+# Test 2c-bailout: dynamic-persistent outer-while AutoWS must gracefully bail out
+# (leave a compilable, correct non-WS kernel) when the atomic tile claim is an
+# unsupported shape. Here the claim is a scatter (non-scalar) atomic, which
+# classifyAtomic rejects -> removeWarpSpecMetadata strips all WS metadata.
+# ============================================================================
+@pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell")
+@pytest.mark.parametrize("EPILOGUE_SUBTILE", [1, 2])
+def test_tutorial09_matmul_tma_dynamic_persistent_while_loop_warp_specialize_bailout(EPILOGUE_SUBTILE, capfd):
+    """A scatter-atomic tile claim forces AutoWS to bail out to a non-WS kernel."""
+    M, N, K = 2048, 2048, 256
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 128
+    BLOCK_SIZE_K = 64
+    GROUP_SIZE_M = 8
+    num_stages = 3
+    num_warps = 4
+
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.use_meta_partition = True
+
+        dtype = torch.float16
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        device = "cuda"
+
+        torch.manual_seed(42)
+        A = torch.randn((M, K), dtype=dtype, device=device)
+        B = torch.randn((N, K), dtype=dtype, device=device)
+        C = torch.empty((M, N), dtype=dtype, device=device)
+        # Work counter seeded to NUM_SMS: CTAs claim initial tiles 0..NUM_SMS-1 by
+        # program id, then atomically claim NUM_SMS, NUM_SMS+1, ...
+        tile_counter = torch.full((1, ), NUM_SMS, dtype=torch.int32, device=device)
+
+        def alloc_fn(size, align, stream):
+            return torch.empty(size, dtype=torch.int8, device="cuda")
+
+        triton.set_allocator(alloc_fn)
+
+        a_desc = TensorDescriptor(A, A.shape, A.stride(), [BLOCK_SIZE_M, BLOCK_SIZE_K])
+        b_desc = TensorDescriptor(B, B.shape, B.stride(), [BLOCK_SIZE_N, BLOCK_SIZE_K])
+        c_desc = TensorDescriptor(C, C.shape, C.stride(), [BLOCK_SIZE_M, BLOCK_SIZE_N // EPILOGUE_SUBTILE])
+
+        grid = lambda META: (min(
+            NUM_SMS,
+            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        ), )
+
+        kernel = matmul_kernel_tma_dynamic_persistent_ws_while_scatter[grid](
+            a_desc,
+            b_desc,
+            c_desc,
+            tile_counter,
+            M,
+            N,
+            K,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=GROUP_SIZE_M,
+            EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
+            NUM_SMS=NUM_SMS,
+            num_stages=num_stages,
+            num_warps=num_warps,
+        )
+
+        ttgir = kernel.asm["ttgir"]
+        # The dynamic-persistent path was exercised...
+        assert "scf.while" in ttgir, "Expected persistent outer loop to lower to scf.while"
+        assert "atomic" in ttgir, "Expected the (unsupported) atomic tile claim to remain"
+        # ...but AutoWS gracefully bailed out: no warp specialization / partition
+        # metadata survives, and the kernel still compiled.
+        assert "ttg.warp_specialize" not in ttgir, "Expected AutoWS to bail out (no warp specialization)"
+        assert "async_task_id" not in ttgir, "Expected WS metadata to be stripped on bail-out"
+
+        # The bailed-out kernel still computes the correct GEMM.
         ref_out = torch.matmul(A.to(torch.float32), B.T.to(torch.float32)).to(dtype)
         torch.testing.assert_close(ref_out, C, atol=0.03, rtol=0.03)
 

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -1077,7 +1077,7 @@ def test_tutorial09_matmul_tma_clc_persistent_while_loop_warp_specialize(EPILOGU
 # dynamic persistent keeps the outer while and pipelines its nested K loop.
 # ============================================================================
 _UNIFIED_OUTER_AUTOWS_CONFIGS = [
-    pytest.param(tl.NonPersistentScheduler, 128, 128, 1, 1, 1, False, False, id="nonpersistent-baseline"),
+    pytest.param(tl.NonPersistentScheduler, 128, 128, 1, 1, 1, False, False, 1, False, id="nonpersistent-baseline"),
     pytest.param(
         tl.NonPersistentScheduler,
         128,
@@ -1086,6 +1086,8 @@ _UNIFIED_OUTER_AUTOWS_CONFIGS = [
         1,
         1,
         False,
+        False,
+        1,
         True,
         id="nonpersistent-epilogue-subtile-4",
     ),
@@ -1097,6 +1099,8 @@ _UNIFIED_OUTER_AUTOWS_CONFIGS = [
         2,
         1,
         False,
+        False,
+        1,
         True,
         id="nonpersistent-data-partition-2-subtile-2",
     ),
@@ -1108,10 +1112,12 @@ _UNIFIED_OUTER_AUTOWS_CONFIGS = [
         2,
         2,
         False,
+        False,
+        1,
         True,
         id="nonpersistent-2cta-data-partition-2",
     ),
-    pytest.param(tl.StaticPersistent1DScheduler, 128, 128, 1, 1, 1, False, False, id="static-baseline"),
+    pytest.param(tl.StaticPersistent1DScheduler, 128, 128, 1, 1, 1, False, True, 1, False, id="static-baseline"),
     pytest.param(
         tl.StaticPersistent1DScheduler,
         128,
@@ -1120,6 +1126,8 @@ _UNIFIED_OUTER_AUTOWS_CONFIGS = [
         1,
         1,
         True,
+        True,
+        1,
         True,
         id="static-epilogue-subtile-4",
     ),
@@ -1132,6 +1140,8 @@ _UNIFIED_OUTER_AUTOWS_CONFIGS = [
         1,
         True,
         True,
+        1,
+        True,
         id="static-data-partition-2-subtile-2",
     ),
     pytest.param(
@@ -1143,21 +1153,37 @@ _UNIFIED_OUTER_AUTOWS_CONFIGS = [
         2,
         False,
         True,
+        1,
+        True,
         id="static-2cta-data-partition-2",
     ),
-    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 1, 1, 1, False, False, id="dynamic-subtile-1"),
-    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 2, 1, 1, False, False, id="dynamic-subtile-2"),
-    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 4, 1, 1, False, False, id="dynamic-subtile-4"),
-    pytest.param(tl.ClcTileScheduler, 128, 128, 1, 1, 1, False, True, id="clc-subtile-1"),
-    pytest.param(tl.ClcTileScheduler, 128, 128, 2, 1, 1, False, True, id="clc-subtile-2"),
-    pytest.param(tl.ClcTileScheduler, 128, 128, 4, 1, 1, False, True, id="clc-subtile-4"),
+    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 1, 1, 1, False, False, 1, False, id="dynamic-subtile-1"),
+    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 2, 1, 1, False, False, 1, True,
+                 id="dynamic-subtile-2"),
+    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 4, 1, 1, False, False, 1, True,
+                 id="dynamic-subtile-4"),
+    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 4, 1, 1, False, False, 1, True,
+                 id="dynamic-epilogue-subtile-4"),
+    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 4, 1, 1, False, True, 1, True,
+                 id="dynamic-separate-epilogue-subtile-4"),
+    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 4, 1, 1, True, False, 1, True,
+                 id="dynamic-generated-subtile-4"),
+    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 4, 1, 1, True, True, 1, True,
+                 id="dynamic-generated-separate-subtile-4"),
+    pytest.param(tl.DynamicPersistent1DScheduler, 256, 128, 2, 2, 1, True, True, 1, True,
+                 id="dynamic-dp2-generated-separate-subtile-2"),
+    pytest.param(tl.DynamicPersistent1DScheduler, 128, 128, 1, 1, 1, False, False, 2, False,
+                 id="dynamic-broadcast-depth-2"),
+    pytest.param(tl.ClcTileScheduler, 128, 128, 1, 1, 1, False, False, 1, True, id="clc-subtile-1"),
+    pytest.param(tl.ClcTileScheduler, 128, 128, 2, 1, 1, False, False, 1, True, id="clc-subtile-2"),
+    pytest.param(tl.ClcTileScheduler, 128, 128, 4, 1, 1, False, False, 1, True, id="clc-subtile-4"),
 ]
 
 
 @pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell")
 @pytest.mark.parametrize(
     "SCHEDULE,BLOCK_SIZE_M,BLOCK_SIZE_N,EPILOGUE_SUBTILE,DATA_PARTITION_FACTOR,NUM_CTAS,"
-    "generate_subtiled_region,blackwell_only",
+    "generate_subtiled_region,separate_epilogue_store,tile_prefetch_depth,blackwell_only",
     _UNIFIED_OUTER_AUTOWS_CONFIGS,
 )
 def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(
@@ -1168,6 +1194,8 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(
     DATA_PARTITION_FACTOR,
     NUM_CTAS,
     generate_subtiled_region,
+    separate_epilogue_store,
+    tile_prefetch_depth,
     blackwell_only,
 ):
     """Exercise outer-loop AutoWS with each unified scheduler."""
@@ -1185,6 +1213,7 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(
     with triton.knobs.nvidia.scope():
         triton.knobs.nvidia.use_meta_ws = True
         triton.knobs.nvidia.use_meta_partition = True
+        triton.knobs.nvidia.ws_tile_prefetch_depth = tile_prefetch_depth
 
         dtype = torch.float16
         NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
@@ -1243,7 +1272,7 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(
             NUM_CTAS=NUM_CTAS,
             TWO_CTAS=NUM_CTAS == 2,
             SMEM_ALLOC_ALGO=1 if NUM_CTAS == 2 else None,
-            SEPARATE_EPILOGUE_STORE=SCHEDULE is tl.StaticPersistent1DScheduler,
+            SEPARATE_EPILOGUE_STORE=separate_epilogue_store,
             **launch_options,
         )
 

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-no-computation.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-gemm-no-computation.mlir
@@ -30,28 +30,28 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // CHECK: ttg.memdesc_trans {{.*}}ttg.partition = array<i32: [[GEMM:[0-9]+]]>
 // CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: [[GEMM]]>
 //
-// --- Epilogue: tmem_load, reshape, trans, split → computation partition ---
-// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[COMP:[0-9]+]]>
-// CHECK: tt.reshape {{.*}}ttg.partition = array<i32: [[COMP]]>
-// CHECK: tt.trans {{.*}}ttg.partition = array<i32: [[COMP]]>
-// CHECK: tt.split {{.*}}ttg.partition = array<i32: [[COMP]]>
-// --- Epilogue: truncf, convert_layout, local_alloc → computation partition ---
-// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
-// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMP]]>
-// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[COMP]]>
+// --- Epilogue: tmem_load, reshape, trans, split → logical default partition ---
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: [[EPIL]]>
+// CHECK: tt.reshape {{.*}}ttg.partition = array<i32: [[EPIL]]>
+// CHECK: tt.trans {{.*}}ttg.partition = array<i32: [[EPIL]]>
+// CHECK: tt.split {{.*}}ttg.partition = array<i32: [[EPIL]]>
+// --- Epilogue: truncf, convert_layout, local_alloc → logical default partition ---
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[EPIL]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[EPIL]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[EPIL]]>
 // --- Epilogue: TMA store → epilogue partition ---
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}}ttg.partition = array<i32: [[EPIL_STORE:[0-9]+]]>
 // CHECK: ttng.async_tma_store_token_wait {{.*}}ttg.partition = array<i32: [[EPIL_STORE]]>
-// --- Second half: truncf, convert_layout, local_alloc → computation; TMA store → epilogue ---
-// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[COMP]]>
-// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[COMP]]>
-// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[COMP]]>
+// --- Second half: truncf, convert_layout, local_alloc → default; TMA store → epilogue store ---
+// CHECK: arith.truncf {{.*}}ttg.partition = array<i32: [[EPIL]]>
+// CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: [[EPIL]]>
+// CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[EPIL]]>
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}}ttg.partition = array<i32: [[EPIL_STORE]]>
 // CHECK: ttng.async_tma_store_token_wait {{.*}}ttg.partition = array<i32: [[EPIL_STORE]]>
 //
 // --- Partition types ---
 // CHECK: tt.warp_specialize
-// CHECK-SAME: ttg.partition.types = ["epilogue", "gemm", "epilogue_store", "load", "computation"]
+// CHECK-SAME: ttg.partition.types = ["epilogue", "gemm", "epilogue_store", "load"]
 tt.func public @persistent_gemm_no_computation_partition(
   %a_desc: !tt.tensordesc<128x64xf16, #shared>,
   %b_desc: !tt.tensordesc<256x64xf16, #shared>,

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-hopper-while-default-epilogue.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-hopper-while-default-epilogue.mlir
@@ -1,0 +1,67 @@
+// RUN: triton-opt %s --nvgpu-partition-scheduling-meta | FileCheck %s
+
+// A Hopper dynamic-persistent GEMM combines WGMMA and its epilogue in the
+// logical default partition. The inner loop shell must use that partition;
+// its load and compute dependencies must not create an empty third partition.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 16]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_trans = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @hopper_while_default_epilogue
+  // CHECK: scf.while
+  // CHECK: scf.for
+  // CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: 1>
+  // CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: 1>
+  // CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: 1>
+  // CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: 1>
+  // CHECK: ttg.memdesc_trans {{.*}}ttg.partition = array<i32: 0>
+  // CHECK: ttng.warp_group_dot {{.*}}ttg.partition = array<i32: 0>
+  // CHECK: scf.yield {{.*}}ttg.partition = array<i32: 0>
+  // CHECK: } {tt.scheduled_max_stage = 2 : i32, ttg.partition = array<i32: 0>}
+  // CHECK: arith.truncf {{.*}}ttg.partition = array<i32: 0>
+  // CHECK: ttg.convert_layout {{.*}}ttg.partition = array<i32: 0>
+  // CHECK: ttng.async_tma_copy_local_to_global {{.*}}ttg.partition = array<i32: 0>
+  // CHECK: } attributes {
+  // CHECK-SAME: tt.warp_specialize
+  // CHECK-SAME: ttg.partition.types = ["epilogue", "load"]
+  tt.func public @hopper_while_default_epilogue(
+      %a_desc: !tt.tensordesc<128x64xf16, #shared>,
+      %b_desc: !tt.tensordesc<128x64xf16, #shared>,
+      %c_desc: !tt.tensordesc<128x128xf16, #shared>,
+      %counter: !tt.ptr<i32>, %k_tiles: i32, %num_tiles: i32) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %acc_init = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma>
+    %start = tt.get_program_id x : i32
+    %result = scf.while (%tile = %start) : (i32) -> i32 {
+      %valid = arith.cmpi slt, %tile, %num_tiles : i32
+      scf.condition(%valid) %tile : i32
+    } do {
+    ^bb0(%tile: i32):
+      %inner = scf.for %ki = %c0 to %k_tiles step %c1
+          iter_args(%acc = %acc_init) -> (tensor<128x128xf32, #mma>) : i32 {
+        %a = tt.descriptor_load %a_desc[%tile, %ki] {loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+        %a_smem = ttg.local_alloc %a {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %b = tt.descriptor_load %b_desc[%tile, %ki] {loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+        %b_smem = ttg.local_alloc %b {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %b_trans = ttg.memdesc_trans %b_smem {loop.cluster = 0 : i32, loop.stage = 2 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared_trans, #smem>
+        %dot = ttng.warp_group_dot %a_smem, %b_trans, %acc {inputPrecision = 0 : i32, loop.cluster = 0 : i32, loop.stage = 2 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x128xf16, #shared_trans, #smem> -> tensor<128x128xf32, #mma>
+        scf.yield %dot : tensor<128x128xf32, #mma>
+      } {tt.scheduled_max_stage = 2 : i32}
+      %out = arith.truncf %inner : tensor<128x128xf32, #mma> to tensor<128x128xf16, #mma>
+      %out_blocked = ttg.convert_layout %out : tensor<128x128xf16, #mma> -> tensor<128x128xf16, #blocked1>
+      %out_smem = ttg.local_alloc %out_blocked : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %store = ttng.async_tma_copy_local_to_global %c_desc[%tile, %c0] %out_smem : !tt.tensordesc<128x128xf16, #shared>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %store : !ttg.async.token
+      %next = tt.atomic_rmw add, acq_rel, gpu, %counter, %c1, %true : (!tt.ptr<i32>, i32, i1) -> i32
+      scf.yield %next : i32
+    } attributes {tt.data_partition_factor = 1 : i32, tt.warp_specialize}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_atomic_broadcast_reject.mlir
+++ b/test/Hopper/WarpSpecialization/ws_atomic_broadcast_reject.mlir
@@ -5,6 +5,14 @@
 // cannot broadcast a data-dependent scatter, so it must bail out of warp
 // specialization and leave a plain, compilable (non-WS) kernel: no
 // ttg.warp_specialize op and no leftover partition ids / async_task_ids.
+//
+// This is the representative full-pass graceful-teardown proof. The teardown
+// (bailOut -> removeWarpSpecMetadata) is one shared, category-independent path,
+// so the OTHER classifyAtomic/classifyCLC reject branches (strict-subset,
+// non-carried, and the CLC rejects) are pinned deterministically via the
+// test pass in ws_atomic_broadcast_reject_classify.mlir, and the E2E scatter
+// bail-out (non-WS + correctness) lives in
+// test_tutorial09_matmul_tma_dynamic_persistent_while_loop_warp_specialize_bailout.
 
 // CHECK-LABEL: @reject_scatter_atomic
 // CHECK-NOT: ttg.warp_specialize

--- a/test/Hopper/WarpSpecialization/ws_atomic_broadcast_reject_classify.mlir
+++ b/test/Hopper/WarpSpecialization/ws_atomic_broadcast_reject_classify.mlir
@@ -1,0 +1,96 @@
+// RUN: triton-opt %s -split-input-file | FileCheck %s
+// RUN: not triton-opt %s -split-input-file --nvgpu-test-ws-atomic-broadcast
+
+// Deterministic coverage for the `classifyAtomic` / `classifyCLC` REJECT
+// branches (WSAtomicBroadcast.cpp). The tile op already carries explicit
+// `async_task_id` (post task-id-propagation shape), so the lit-only
+// `--nvgpu-test-ws-atomic-broadcast` pass reads the partition sets directly (via
+// getAsyncTaskIds) with no PSM/propagation needed and hits exactly one reject
+// guard per module. That test pass `signalPassFailure`s on reject (it does NOT
+// do the orchestrator's graceful teardown -- that shared teardown path is proven
+// once, on the scatter case, in ws_atomic_broadcast_reject.mlir), so the second
+// RUN uses `not` to assert the pass fails on every shape here.
+//
+// The first RUN (round-trip + FileCheck) guarantees each module is valid IR, so
+// the `not` on the second RUN reflects a genuine reject and not a parse error.
+
+// A scalar, loop-carried atomic replicated to a STRICT SUBSET of the while's
+// partitions -> reject (taskIds.size() != allParts.size()), WSAtomicBroadcast.cpp
+// :114-118. Atomic is {0,1}; the while spans {0,1,2}.
+// CHECK-LABEL: @reject_subset_atomic
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @reject_subset_atomic(%counter: !tt.ptr<i32>, %n: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %true = arith.constant true
+    %r = scf.while (%arg0 = %c0_i32) : (i32) -> i32 {
+      %cond = arith.cmpi slt, %arg0, %n : i32
+      scf.condition(%cond) %arg0 : i32
+    } do {
+    ^bb0(%arg0: i32):
+      %next = tt.atomic_rmw add, acq_rel, gpu, %counter, %c1_i32, %true {async_task_id = array<i32: 0, 1>} : (!tt.ptr<i32>, i32, i1) -> i32
+      scf.yield %next : i32
+    } attributes {async_task_id = array<i32: 0, 1, 2>}
+    tt.return
+  }
+}
+
+// -----
+
+// A scalar atomic replicated to ALL partitions, but whose result is NOT the
+// loop-carried yield of the while (the while yields an unrelated value) ->
+// reject (getLoopCarryingWhile == nullptr), WSAtomicBroadcast.cpp :109-113. This
+// is also the "unrelated replicated atomic" shape (same code check).
+// CHECK-LABEL: @reject_non_carried_atomic
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @reject_non_carried_atomic(%counter: !tt.ptr<i32>, %n: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %true = arith.constant true
+    %r = scf.while (%arg0 = %c0_i32) : (i32) -> i32 {
+      %cond = arith.cmpi slt, %arg0, %n : i32
+      scf.condition(%cond) %arg0 : i32
+    } do {
+    ^bb0(%arg0: i32):
+      %next = tt.atomic_rmw add, acq_rel, gpu, %counter, %c1_i32, %true {async_task_id = array<i32: 0, 1>} : (!tt.ptr<i32>, i32, i1) -> i32
+      %other = arith.addi %arg0, %c1_i32 {async_task_id = array<i32: 0, 1>} : i32
+      scf.yield %other : i32
+    } attributes {async_task_id = array<i32: 0, 1>}
+    tt.return
+  }
+}
+
+// -----
+
+// A CLC fetch (clc_read) replicated across partitions but NOT inside a while ->
+// reject (classifyCLC not-in-while), WSAtomicBroadcast.cpp :267-271.
+// CHECK-LABEL: @reject_clc_not_in_while
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @reject_clc_not_in_while() {
+    %tok = ttng.clc_try_cancel_async {async_task_id = array<i32: 0, 1>} : !ttg.async.token
+    %valid, %x, %y, %z = ttng.clc_read %tok {async_task_id = array<i32: 0, 1>} : !ttg.async.token -> i1, i32, i32, i32
+    tt.return
+  }
+}
+
+// -----
+
+// A CLC fetch inside a while, token from clc_try_cancel_async, but replicated to
+// a STRICT SUBSET of the while's partitions -> reject (classifyCLC subset),
+// WSAtomicBroadcast.cpp :276-280. clc_read is {0,1}; the while spans {0,1,2}.
+// CHECK-LABEL: @reject_clc_subset
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @reject_clc_subset(%n: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %r = scf.while (%arg0 = %c0_i32) : (i32) -> i32 {
+      %cond = arith.cmpi slt, %arg0, %n : i32
+      scf.condition(%cond) %arg0 : i32
+    } do {
+    ^bb0(%arg0: i32):
+      %tok = ttng.clc_try_cancel_async {async_task_id = array<i32: 0, 1, 2>} : !ttg.async.token
+      %valid, %x, %y, %z = ttng.clc_read %tok {async_task_id = array<i32: 0, 1>} : !ttg.async.token -> i1, i32, i32, i32
+      scf.yield %arg0 : i32
+    } attributes {async_task_id = array<i32: 0, 1, 2>}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_subtiled_region_per_tile_buffer_index.mlir
+++ b/test/Hopper/WarpSpecialization/ws_subtiled_region_per_tile_buffer_index.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --nvgpu-warp-specialization="generate-subtiled-region=true num-stages=3 smem-budget=232448" | FileCheck %s
+// RUN: triton-opt %s --split-input-file --nvgpu-warp-specialization="generate-subtiled-region=true num-stages=3 smem-budget=232448" | FileCheck %s --check-prefixes=CHECK,WHILE
 
 // Test: with EPILOGUE_SUBTILE=4 (numTiles=4) the N epilogue subtiles form a
 // reuse group that shares ONE physical SMEM staging buffer (buffer.copy=3) AND
@@ -51,6 +51,57 @@
 // CHECK:      arith.addi %[[CNT]], %c1_i64 {async_task_id = array<i32: 0>}
 // CHECK:      arith.addi %[[CNT]], %c2_i64 {async_task_id = array<i32: 0>}
 // CHECK:      arith.addi %[[CNT]], %c3_i64 {async_task_id = array<i32: 0>}
+
+// Companion coverage for the SAME reuse-group invariant when the persistent
+// outer loop is a dynamic scf.while instead of an scf.for. It lives in its own
+// split-input-file module (separated by the dashed marker below) because
+// doGenerateSubtiledRegion runs its nested pass over the whole enclosing module;
+// keeping the two subtiled-region kernels in one module would make that pass
+// process both at once. This function is the
+// real pre-warp-specialization IR captured immediately before
+// nvgpu-warp-specialization for the passing Python configuration
+// test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize with
+// generate_subtiled_region=True and separate_epilogue_store=True (the
+// separate-epilogue-store variant is the one that forms the shared reuse group,
+// matching the scf.for coverage above). The generated same-task
+// ttng.subtiled_region nested directly in the persistent scf.while must resolve
+// its channel counter to the while's loop-carried accumulation counter, NOT
+// assign an index to the ttng.subtiled_region itself. The while carries trailing
+// i64 accumulation counters; the shared reuse-group counter advances by
+// numTiles(4) per persistent iteration and each of the four subtiles flattens to
+// that counter + {0,1,2,3}, taken % numBuffers(3), indexing BOTH the shared
+// 3-deep staging buffer and its barrier at the same slot.
+// WHILE-LABEL: @matmul_kernel_tma_persistent_ws_while
+//
+// The epilogue staging buffer is a single shared 3-deep 128x32 alloc.
+// WHILE: ttg.local_alloc {allocation.shareGroup = 0 : i32, buffer.copy = 3 : i32, buffer.id = 2 : i32{{.*}}} : () -> !ttg.memdesc<3x128x32xf16
+//
+// The kernel is physically warp specialized.
+// WHILE: ttg.warp_specialize
+//
+// The dynamic persistent outer loop stays an scf.while and receives the trailing
+// i64 accumulation-counter carries. The reuse-group counter is the last i64.
+// WHILE: scf.while
+// WHILE: ^bb0({{.*}}%[[CNT:arg[0-9]+]]: i64):
+//
+// The reuse-group counter advances by numTiles(4) per persistent iteration.
+// WHILE:      arith.addi %[[CNT]], %c4_i64 {async_task_id = array<i32: 0>}
+//
+// Subtile 0 (flattened = %CNT + 0) mod numBuffers(3) indexes BOTH the 3x128x32
+// data staging buffer and the 3x1xi64 barrier at the SAME slot (data slot ==
+// barrier slot), all derived from the while's loop-carried counter.
+// WHILE:      %[[DIV:[0-9]+]] = arith.divui %[[CNT]], %c3_i64 {async_task_id = array<i32: 0>}
+// WHILE:      %[[MUL:[0-9]+]] = arith.muli %[[DIV]], %c3_i64 {async_task_id = array<i32: 0>}
+// WHILE:      %[[MOD:[0-9]+]] = arith.subi %[[CNT]], %[[MUL]] {async_task_id = array<i32: 0>}
+// WHILE:      %[[IDX:[0-9]+]] = arith.trunci %[[MOD]] {async_task_id = array<i32: 0>} : i64 to i32
+// WHILE:      ttg.memdesc_index %{{[0-9]+}}[%[[IDX]]] {async_task_id = array<i32: 0>} : !ttg.memdesc<3x128x32xf16
+// WHILE:      ttg.memdesc_index %{{[0-9]+}}[%[[IDX]]] {async_task_id = array<i32: 0>} : !ttg.memdesc<3x1xi64
+//
+// Subtiles 1-3 flatten to %CNT + {1,2,3}: four DISTINCT generations of the shared
+// buffer per persistent iteration.
+// WHILE:      arith.addi %[[CNT]], %c1_i64 {async_task_id = array<i32: 0>}
+// WHILE:      arith.addi %[[CNT]], %c2_i64 {async_task_id = array<i32: 0>}
+// WHILE:      arith.addi %[[CNT]], %c3_i64 {async_task_id = array<i32: 0>}
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
@@ -147,6 +198,112 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
       %s3 = ttng.async_tma_copy_local_to_global %arg10[%17, %cn3] %a3 {ttg.partition = array<i32: 2>} : !tt.tensordesc<128x32xf16, #shared1>, !ttg.memdesc<128x32xf16, #shared1, #smem, mutable> -> !ttg.async.token
       ttng.async_tma_store_token_wait %s3   {ttg.partition = array<i32: 2>} : !ttg.async.token
     } {tt.data_partition_factor = 1 : i32, tt.separate_epilogue_store = true, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["epilogue", "gemm", "epilogue_store", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 1, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear3 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear4 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 1, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear5 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear6 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_kernel_tma_persistent_ws_while(%arg0: !tt.tensordesc<128x64xf16, #shared>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<128x64xf16, #shared>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64, %arg10: !tt.tensordesc<128x32xf16, #shared1>, %arg11: i32, %arg12: i32, %arg13: i64, %arg14: i64, %arg15: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %arg16: i32 {tt.divisibility = 16 : i32}, %arg17: i32 {tt.divisibility = 16 : i32}, %arg18: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant false
+    %c127_i32 = arith.constant 127 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c96_i32 = arith.constant 96 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c63_i32 = arith.constant 63 : i32
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #linear>
+    %0 = arith.addi %arg16, %c127_i32 : i32
+    %1 = arith.divsi %0, %c128_i32 : i32
+    %2 = arith.addi %arg17, %c127_i32 : i32
+    %3 = arith.divsi %2, %c128_i32 : i32
+    %4 = arith.addi %arg18, %c63_i32 : i32
+    %5 = arith.divsi %4, %c64_i32 : i32
+    %6 = arith.muli %3, %c8_i32 : i32
+    %7 = tt.get_program_id x : i32
+    %8 = arith.muli %1, %3 : i32
+    %9 = scf.while (%arg19 = %7) : (i32) -> i32 {
+      %10 = arith.cmpi slt, %arg19, %8 : i32
+      scf.condition(%10) %arg19 : i32
+    } do {
+    ^bb0(%arg19: i32):
+      %10 = arith.divsi %arg19, %6 : i32
+      %11 = arith.muli %10, %c8_i32 : i32
+      %12 = arith.subi %1, %11 : i32
+      %13 = arith.minsi %12, %c8_i32 : i32
+      %14 = arith.remsi %arg19, %13 : i32
+      %15 = arith.addi %11, %14 : i32
+      %16 = arith.remsi %arg19, %6 : i32
+      %17 = arith.divsi %16, %13 : i32
+      %18 = arith.muli %15, %c128_i32 : i32
+      %19 = arith.muli %17, %c128_i32 : i32
+      %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %20 = ttng.tmem_store %cst, %result[%token], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %21:2 = scf.for %arg20 = %c0_i32 to %5 step %c1_i32 iter_args(%arg21 = %false, %arg22 = %20) -> (i1, !ttg.async.token)  : i32 {
+        %48 = arith.muli %arg20, %c64_i32 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32
+        %49 = tt.descriptor_load %arg0[%18, %48] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+        %50 = ttg.local_alloc %49 {loop.cluster = 0 : i32, loop.stage = 2 : i32, ttg.partition = array<i32: 3>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %51 = tt.descriptor_load %arg5[%19, %48] {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+        %52 = ttg.local_alloc %51 {loop.cluster = 0 : i32, loop.stage = 2 : i32, ttg.partition = array<i32: 3>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %53 = ttg.memdesc_trans %52 {loop.cluster = 0 : i32, loop.stage = 2 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared2, #smem>
+        %54 = ttng.tc_gen5_mma %50, %53, %result[%arg22], %arg21, %true {loop.cluster = 0 : i32, loop.stage = 2 : i32, tt.self_latency = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared2, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        scf.yield %true, %54 : i1, !ttg.async.token
+      } {tt.scheduled_max_stage = 2 : i32}
+      %result_0, %token_1 = ttng.tmem_load %result[%21#1] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %22 = tt.reshape %result_0 {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear1>
+      %23 = tt.trans %22 {order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 0>} : tensor<128x2x64xf32, #linear1> -> tensor<128x64x2xf32, #linear2>
+      %outLHS, %outRHS = tt.split %23 {ttg.partition = array<i32: 0>} : tensor<128x64x2xf32, #linear2> -> tensor<128x64xf32, #linear3>
+      %24 = tt.reshape %outLHS {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #linear3> -> tensor<128x2x32xf32, #linear4>
+      %25 = tt.trans %24 {order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 0>} : tensor<128x2x32xf32, #linear4> -> tensor<128x32x2xf32, #linear5>
+      %outLHS_2, %outRHS_3 = tt.split %25 {ttg.partition = array<i32: 0>} : tensor<128x32x2xf32, #linear5> -> tensor<128x32xf32, #linear6>
+      %26 = tt.reshape %outRHS {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #linear3> -> tensor<128x2x32xf32, #linear4>
+      %27 = tt.trans %26 {order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 0>} : tensor<128x2x32xf32, #linear4> -> tensor<128x32x2xf32, #linear5>
+      %outLHS_4, %outRHS_5 = tt.split %27 {ttg.partition = array<i32: 0>} : tensor<128x32x2xf32, #linear5> -> tensor<128x32xf32, #linear6>
+      %28 = arith.truncf %outLHS_2 {ttg.partition = array<i32: 0>} : tensor<128x32xf32, #linear6> to tensor<128x32xf16, #linear6>
+      %29 = ttg.convert_layout %28 {ttg.partition = array<i32: 0>} : tensor<128x32xf16, #linear6> -> tensor<128x32xf16, #blocked1>
+      %30 = ttg.local_alloc %29 {ttg.partition = array<i32: 0>} : (tensor<128x32xf16, #blocked1>) -> !ttg.memdesc<128x32xf16, #shared1, #smem, mutable>
+      %31 = ttng.async_tma_copy_local_to_global %arg10[%18, %19] %30 {ttg.partition = array<i32: 2>} : !tt.tensordesc<128x32xf16, #shared1>, !ttg.memdesc<128x32xf16, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %31   {ttg.partition = array<i32: 2>} : !ttg.async.token
+      %32 = arith.addi %19, %c32_i32 : i32
+      %33 = arith.truncf %outRHS_3 {ttg.partition = array<i32: 0>} : tensor<128x32xf32, #linear6> to tensor<128x32xf16, #linear6>
+      %34 = ttg.convert_layout %33 {ttg.partition = array<i32: 0>} : tensor<128x32xf16, #linear6> -> tensor<128x32xf16, #blocked1>
+      %35 = ttg.local_alloc %34 {ttg.partition = array<i32: 0>} : (tensor<128x32xf16, #blocked1>) -> !ttg.memdesc<128x32xf16, #shared1, #smem, mutable>
+      %36 = ttng.async_tma_copy_local_to_global %arg10[%18, %32] %35 {ttg.partition = array<i32: 2>} : !tt.tensordesc<128x32xf16, #shared1>, !ttg.memdesc<128x32xf16, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %36   {ttg.partition = array<i32: 2>} : !ttg.async.token
+      %37 = arith.addi %19, %c64_i32 : i32
+      %38 = arith.truncf %outLHS_4 {ttg.partition = array<i32: 0>} : tensor<128x32xf32, #linear6> to tensor<128x32xf16, #linear6>
+      %39 = ttg.convert_layout %38 {ttg.partition = array<i32: 0>} : tensor<128x32xf16, #linear6> -> tensor<128x32xf16, #blocked1>
+      %40 = ttg.local_alloc %39 {ttg.partition = array<i32: 0>} : (tensor<128x32xf16, #blocked1>) -> !ttg.memdesc<128x32xf16, #shared1, #smem, mutable>
+      %41 = ttng.async_tma_copy_local_to_global %arg10[%18, %37] %40 {ttg.partition = array<i32: 2>} : !tt.tensordesc<128x32xf16, #shared1>, !ttg.memdesc<128x32xf16, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %41   {ttg.partition = array<i32: 2>} : !ttg.async.token
+      %42 = arith.addi %19, %c96_i32 : i32
+      %43 = arith.truncf %outRHS_5 {ttg.partition = array<i32: 0>} : tensor<128x32xf32, #linear6> to tensor<128x32xf16, #linear6>
+      %44 = ttg.convert_layout %43 {ttg.partition = array<i32: 0>} : tensor<128x32xf16, #linear6> -> tensor<128x32xf16, #blocked1>
+      %45 = ttg.local_alloc %44 {ttg.partition = array<i32: 0>} : (tensor<128x32xf16, #blocked1>) -> !ttg.memdesc<128x32xf16, #shared1, #smem, mutable>
+      %46 = ttng.async_tma_copy_local_to_global %arg10[%18, %42] %45 {ttg.partition = array<i32: 2>} : !tt.tensordesc<128x32xf16, #shared1>, !ttg.memdesc<128x32xf16, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %46   {ttg.partition = array<i32: 2>} : !ttg.async.token
+      %47 = tt.atomic_rmw add, acq_rel, gpu, %arg15, %c1_i32, %true : (!tt.ptr<i32>, i32, i1) -> i32
+      scf.yield %47 : i32
+    } attributes {tt.data_partition_factor = 1 : i32, tt.separate_epilogue_store = true, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["epilogue", "gemm", "epilogue_store", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
     tt.return
   }
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -393,12 +393,7 @@ bool immediateEnclosing(scf::IfOp ifOp, Operation *subOp) {
 // Control Ops can be replaced during the pass, but channel srcOp/dstOp should
 // be valid.
 static bool needAccumCntForReuse(Operation *ctrlOp, ReuseGroup *group) {
-  // A collapsed both-endpoints-subtiled channel is the sole member of its group
-  // and still needs a shared accumCnt (the numTiles counter stride feeds the
-  // in-body per-tile slot/phase rotation) even at buffer.copy == 1. Only plain
-  // single-buffered groups carry no accumCnt.
-  if (group->channels[0]->getNumBuffers() <= 1 &&
-      !channelIsCollapsedBothSubtiled(group->channels[0]))
+  if (!reuseGroupNeedsAccumCnt(group))
     return false;
   // Goes through each channel in the ResuseGroup, check srcOp and dstOp to
   // see if it is inside ctrlOp.
@@ -554,21 +549,26 @@ bool channelIsCollapsedBothSubtiled(Channel *ch) {
   return static_cast<AllocChannel *>(ch)->isCollapsedBothSubtiled;
 }
 
+bool reuseGroupNeedsAccumCnt(ReuseGroup *group) {
+  if (!group || group->channels.empty())
+    return false;
+  Channel *representative = group->channels.front();
+  // A collapsed both-endpoints-subtiled channel still needs its numTiles
+  // counter stride when it is the sole group member and buffer.copy == 1.
+  if (representative->getNumBuffers() <= 1 &&
+      !channelIsCollapsedBothSubtiled(representative))
+    return false;
+  if (group->channels.size() <= 1 && !channelIsSubtiled(representative))
+    return false;
+  return true;
+}
+
 void getReuseChannels(ReuseGroup *group, Operation *regionOp,
                       SmallVector<Operation *> &chList) {
   if (!isa<scf::ForOp>(regionOp) && !isa<scf::IfOp>(regionOp) &&
       !isa<scf::WhileOp>(regionOp))
     return;
-  // A collapsed subtiled channel needs its dst region threaded into chList for
-  // the numTiles counter stride even at buffer.copy == 1 (single physical slot,
-  // alternating barrier phase); only plain single-buffered groups bail here.
-  if (group->channels[0]->getNumBuffers() <= 1 &&
-      !channelIsCollapsedBothSubtiled(group->channels[0]))
-    return;
-  // Size-1 reuse groups normally carry no shared circular buffer, but a
-  // collapsed subtiled channel is intentionally alone in its group and still
-  // needs its dst region threaded into chList for the numTiles counter stride.
-  if (group->channels.size() <= 1 && !channelIsSubtiled(group->channels[0]))
+  if (!reuseGroupNeedsAccumCnt(group))
     return;
   // Goes through body of regionOp, if the body op is a regionOp, check
   // to see if it contains a channel in the reuse group.
@@ -742,6 +742,17 @@ std::pair<Value, Value> getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder,
 //     ThenYield ForC.arg[accumIfB] + 1
 //     ElseYield ForC.arg[accumIfB]
 //   Channel D --> uses ForA.arg[accumForA]
+static Operation *
+getAccumCntRegion(Operation *op, Operation *parentLoop,
+                  const DenseSet<Operation *> &regionsWithChannels) {
+  Operation *region = op->getParentOp();
+  while (region && region != parentLoop &&
+         !regionsWithChannels.contains(region))
+    region = region->getParentOp();
+  assert(region && "operation must be nested under its accumulation loop");
+  return region;
+}
+
 Value getAccumCount(OpBuilderWithAsyncTaskIds &builder, Operation *op,
                     const DenseSet<Operation *> &regionsWithChannels,
                     ReuseConfig *config, int reuseGroupIdx) {
@@ -753,7 +764,8 @@ Value getAccumCount(OpBuilderWithAsyncTaskIds &builder, Operation *op,
     // carried across persistent iterations.
     if (auto parentWhileOp = op->getParentOfType<scf::WhileOp>()) {
       Block *afterBlk = parentWhileOp.getAfterBody();
-      auto *pOp = op->getParentOp();
+      Operation *pOp = getAccumCntRegion(op, parentWhileOp.getOperation(),
+                                         regionsWithChannels);
       unsigned tSize = afterBlk->getNumArguments();
       unsigned parentTCnts =
           getAccumCnts(parentWhileOp, regionsWithChannels, config);
@@ -770,7 +782,8 @@ Value getAccumCount(OpBuilderWithAsyncTaskIds &builder, Operation *op,
     return arith::ConstantIndexOp::create(builder, op->getLoc(), 0);
   }
 
-  auto *pOp = op->getParentOp();
+  Operation *pOp =
+      getAccumCntRegion(op, parentForOp.getOperation(), regionsWithChannels);
   // Get parentForOp.arg[pOp]
   unsigned tSize = parentForOp.getBody()->getArguments().size();
   unsigned parentTCnts = getAccumCnts(parentForOp, regionsWithChannels, config);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -271,6 +271,11 @@ bool channelIsSubtiled(Channel *ch);
 // buffer.copy == 1 without misfiring on consumer-only-subtiled channels.
 bool channelIsCollapsedBothSubtiled(Channel *ch);
 
+// True when a reuse group needs a loop-carried accumulation counter. Keep this
+// predicate shared by counter counting, channel discovery, and loop rewriting
+// so collapsed subtiled groups cannot make their argument counts disagree.
+bool reuseGroupNeedsAccumCnt(ReuseGroup *group);
+
 // Skip the accumCnt for unique channels.
 unsigned getReuseAccumArgIdx(Operation *regionOp,
                              const DenseSet<Operation *> &regionsWithChannels,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -2218,7 +2218,8 @@ static bool isScalarOp(Operation *op) {
 }
 
 void propagatePartitions(LoopLikeOpInterface loop, PartitionSet &schedule,
-                         bool createComputePartitions) {
+                         bool createComputePartitions,
+                         Partition *defaultPartition) {
   OpClusters opClusters;
 
   for (Partition &partition : schedule.getPartitions()) {
@@ -2371,6 +2372,10 @@ void propagatePartitions(LoopLikeOpInterface loop, PartitionSet &schedule,
             }
           }
         }
+        // Partition types describe semantic roles, so the logical default may
+        // be named "epilogue", "correction", or "reduction".
+        if (!fallbackPartition)
+          fallbackPartition = defaultPartition;
         if (fallbackPartition) {
           for (Operation *op : cluster.ops) {
             if (isScalarOp(op))
@@ -2851,7 +2856,8 @@ void PartitionSchedulingMeta::runOnOperation() {
     {
       PartitionSet &schedule = result->schedule;
       currentPhase = "propagate";
-      propagatePartitions(loop, schedule, result->createComputePartitions);
+      propagatePartitions(loop, schedule, result->createComputePartitions,
+                          result->layout.defaultPartition);
 
       // Assign partition to TMAStoreTokenWaitOp ops that have no partition.
       // These arise from early TMA reduce lowering: the wait's token comes

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
@@ -413,7 +413,7 @@ Value getAccumForReuseGroup(Operation *op, SmallVector<Operation *> &chList,
         getAccumCnts(whileOp.getOperation(), regionsWithChannels, config);
     Value arg = whileOp.getAfterBody()->getArgument(numArgs - tCnts + argIdx);
     Value lit = builder.createWithAsyncTaskIds<arith::ConstantIntOp>(
-        whileOp.getLoc(), before ? opIdx : opIdx + 1, 64);
+        whileOp.getLoc(), (before ? opIdx : opIdx + 1) * stride, 64);
     Value endAccum = builder.createWithAsyncTaskIds<arith::AddIOp>(
         accumCntLoc(whileOp.getLoc()), arg, lit);
     return endAccum;
@@ -852,18 +852,7 @@ scf::ForOp createNewLoopWrapper(scf::ForOp origForOp,
   }
   // Handle reuse groups.
   for (unsigned idx = 0; idx < config->getGroupSize(); ++idx) {
-    // A collapsed both-subtiled channel is the sole member of its group but
-    // still carries a shared accumCnt (numTiles stride); keep it. This must
-    // match getAccumCnts / getReuseChannels, which also special-case size-1
-    // subtiled groups, or the loop arg count and accumCnt indices disagree.
-    if (config->getGroup(idx)->channels.size() <= 1 &&
-        !channelIsSubtiled(config->getGroup(idx)->channels[0]))
-      continue;
-    // A collapsed subtiled channel carries its shared accumCnt (numTiles
-    // stride) even at buffer.copy == 1; keep its loop arg so the count matches
-    // getAccumCnts / getReuseChannels. Plain single-buffered groups skip.
-    if (config->getGroup(idx)->channels[0]->getNumBuffers() <= 1 &&
-        !channelIsCollapsedBothSubtiled(config->getGroup(idx)->channels[0]))
+    if (!reuseGroupNeedsAccumCnt(config->getGroup(idx)))
       continue;
     Operation *parentOp = origForOp->getParentOp();
 #if 0
@@ -1109,8 +1098,6 @@ scf::WhileOp createNewWhileWrapper(scf::WhileOp origWhileOp,
   getAccumCntsPreOrder(origWhileOp.getOperation(), regionsWithChannels,
                        preOrderOps);
   unsigned tCnts = preOrderOps.size();
-  if (tCnts == 0)
-    return origWhileOp;
 
   OpBuilderWithAsyncTaskIds builder(origWhileOp->getContext());
   builder.setAsynTaskIdsFromArray(getNestedAsyncTaskIds(origWhileOp));
@@ -1128,9 +1115,7 @@ scf::WhileOp createNewWhileWrapper(scf::WhileOp origWhileOp,
   // per-region counters. Mirrors createNewLoopWrapper. The while is outermost,
   // so the prior value resolves to a constant 0.
   for (unsigned idx = 0; idx < config->getGroupSize(); ++idx) {
-    if (config->getGroup(idx)->channels.size() <= 1)
-      continue;
-    if (config->getGroup(idx)->channels[0]->getNumBuffers() <= 1)
+    if (!reuseGroupNeedsAccumCnt(config->getGroup(idx)))
       continue;
     SmallVector<Operation *> chList;
     getReuseChannels(config->getGroup(idx), origWhileOp.getOperation(), chList);
@@ -1146,6 +1131,12 @@ scf::WhileOp createNewWhileWrapper(scf::WhileOp origWhileOp,
                               regionsWithChannels, config, idx, true);
     initialAccums.push_back(prevAccum);
   }
+
+  // A same-task generated subtiled region can need only a reuse-group counter,
+  // with no ordinary channel-bearing region in preOrderOps. Do not skip that
+  // counter merely because tCnts is zero.
+  if (initialAccums.empty())
+    return origWhileOp;
 
   unsigned totalCnts = initialAccums.size();
   scf::WhileOp newWhileOp = createNewWhileLoop(origWhileOp, initialAccums);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AccumulationCounters.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AccumulationCounters.md
@@ -149,6 +149,12 @@ reuse handling end-to-end:
 - `createNewWhileWrapper` appends a reuse-group counter to `initialAccums`
   (seeded via `getAccumForReuseGroup`, which is a constant 0 for the outermost
   while) and wires its yield with the staggered next value.
+- The while reuse counter advances by `getReuseGroupStride` per persistent
+  iteration, exactly like the `scf.for` path. `getAccumForReuseGroup` multiplies
+  the per-op offset by that stride (`(before ? opIdx : opIdx + 1) * stride`) so a
+  subtiled group with `numTiles` tiles steps by `numTiles`, not by 1. Without the
+  stride factor the while counter would advance by one while the `scf.for` path
+  advanced by `numTiles`, so the slot/phase rotation diverged from the barrier.
 - `getReuseChannels`, `needAccumCntForReuse`, and `getAccumForReuseGroup` accept
   `scf::WhileOp` (iterating / indexing the after region).
 - `getStaggeredAccumCnt` finds the enclosing loop as `scf::ForOp` **or**
@@ -159,6 +165,40 @@ Missing any of these makes the per-channel accumCnt index run past the counters
 actually threaded into the while (an out-of-bounds after-region argument /
 non-integer accumCnt), the same failure class the `getAccumCount` `isIntOrIndex`
 assertion guards against.
+
+#### Reuse-only counter case
+
+A generated same-task subtiled region can need **only** a reuse-group counter,
+with no ordinary channel-bearing region contributing to the while. In that case
+`getAccumCntsPreOrder` returns `tCnts == 0`, but the reuse group still needs its
+counter threaded. `createNewWhileWrapper` therefore defers its empty-return
+decision: instead of bailing out early on `tCnts == 0`, it first builds
+`initialAccums` (per-region counters **plus** reuse-group counters) and only
+returns the original while unchanged when `initialAccums` is empty. Bailing on
+`tCnts == 0` alone would drop the reuse counter for a while whose only
+multibuffered channel is the subtiled epilogue.
+
+### Shared reuse-group eligibility predicate
+
+Whether a reuse group carries a loop-carried accumulation counter is decided by
+one shared predicate, `reuseGroupNeedsAccumCnt(group)` (`CodePartitionUtility`),
+used by **counter counting** (`needAccumCntForReuse`), **channel discovery**
+(`getReuseChannels`), and **both loop wrappers** (`createNewLoopWrapper`,
+`createNewWhileWrapper`). It returns true unless:
+
+- the representative channel is plain single-buffered (`getNumBuffers() <= 1`)
+  and is *not* a collapsed both-endpoints-subtiled channel — a collapsed subtiled
+  channel still needs its `numTiles` counter stride even at `buffer.copy == 1`
+  (single physical slot, alternating barrier phase); or
+- the group has a single member that is not subtiled — a size-1 group normally
+  carries no shared circular buffer, but a collapsed subtiled channel is
+  intentionally alone in its group and still needs its counter.
+
+Keeping this in one predicate is a correctness requirement, not just cleanup: the
+three call sites must agree on the counter count exactly, or the loop argument
+count and the per-channel accumCnt indices disagree (out-of-bounds after-region
+argument / non-integer accumCnt). Previously each site inlined the same two
+special cases; drift between them was the failure mode this predicate removes.
 
 ### Redundant accumulator zero-store removal
 
@@ -173,6 +213,26 @@ in the while's after region, so its enclosing loop is found via
 token (`getDep()`) to its result token (`getToken()`) so the accumulator
 dependency chain skips the removed store; forwarding the wrong operand leaves the
 store un-erased and reintroduces the cross-tile race.
+
+## Resolving the counter-bearing region
+
+`getAccumCount` indexes an op's accumCnt from the arguments of the control-flow
+region that actually *carries* counters (the enclosing `scf.for` body or
+`scf.while` after region). To find that region it does **not** simply take
+`op->getParentOp()`: an op can be nested inside a *structural* region that carries
+no counters — most importantly `ttng.subtiled_region`, which a generated subtiled
+epilogue wraps around its per-tile stores. Indexing the subtiled region as if it
+were a counter-bearing region would compute the wrong argument (or index a region
+with no accumCnt arguments at all).
+
+`getAccumCntRegion(op, parentLoop, regionsWithChannels)` walks outward from
+`op->getParentOp()` until it reaches either the enclosing accumulation loop
+(`parentLoop`) or a region recorded in `regionsWithChannels`, skipping any
+non-counter structural region such as `ttng.subtiled_region` on the way. Both the
+`scf.while` and `scf.for` branches of `getAccumCount` use it, so an op nested in a
+subtiled region resolves its counter to the nearest real counter-bearing region
+(e.g. the persistent while's after region) rather than to the subtiled region
+itself.
 
 ## Interaction with Reuse Groups
 
@@ -227,6 +287,8 @@ mbarrier rotation tolerates any K.
 | `updateAccumLoopCount` | Recursively threads counters through nested control flow |
 | `generateYieldCntsForForOp` | Generates loop yield values for counters |
 | `generateYieldCntsForIfOp` | Generates if-op yield values for counters |
+| `reuseGroupNeedsAccumCnt` | Shared predicate: does a reuse group carry a loop-carried accumCnt? Used by counter counting, channel discovery, and both loop wrappers |
+| `getAccumCntRegion` | Walks outward from an op to the nearest counter-bearing region, skipping non-counter structural regions like `ttng.subtiled_region` |
 | `getAccumCount` | Retrieves the accumCnt value for an op from its enclosing loop |
 | `getAccumCnts` | Returns the number of accumCnt arguments for a control flow op |
 | `getAccumArgIdx` | Returns the starting index of accumCnt arguments in a block argument list |

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/DynamicPersistentAutoWSGaps.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/DynamicPersistentAutoWSGaps.md
@@ -249,8 +249,19 @@ Required coverage:
    `dynamic-generated-separate-subtile-4`,
    `dynamic-dp2-generated-separate-subtile-2`, and `dynamic-broadcast-depth-2`,
    all passing on Blackwell. Hopper feature-combination runtime remains pending.
-6. **Bailout E2E/lit**: scatter, strict-subset, non-carried, and unrelated
-   replicated atomics leave a compilable non-WS kernel.
+6. **Bailout E2E/lit** [done]: unsupported replicated atomics/CLC fetches leave a
+   compilable non-WS kernel. Coverage: (a) **E2E** — a scatter-atomic
+   dynamic-persistent outer-while GEMM
+   (`test_tutorial09_matmul_tma_dynamic_persistent_while_loop_warp_specialize_bailout`)
+   asserts `ttg.warp_specialize`/`async_task_id` absent **and** numerical
+   correctness on Blackwell; (b) **classify-branch lit** —
+   `ws_atomic_broadcast_reject_classify.mlir` pins strict-subset, non-carried,
+   and CLC (not-in-while, subset) rejects via `not triton-opt
+   --nvgpu-test-ws-atomic-broadcast` (the test pass `signalPassFailure`s on
+   reject); (c) **full-pass teardown** — the scatter case in
+   `ws_atomic_broadcast_reject.mlir` proves the shared, category-independent
+   `bailOut`/`removeWarpSpecMetadata` teardown. ("non-carried" and
+   "unrelated-replicated" are the same `getLoopCarryingWhile==null` check.)
 7. **Hopper and Blackwell**: CLC sibling correctness is covered on Blackwell;
    unified dynamic atomic correctness remains to be run on Hopper.
 8. **Performance**: compare static persistent, dynamic inner-loop AutoWS,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/DynamicPersistentAutoWSGaps.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/DynamicPersistentAutoWSGaps.md
@@ -206,16 +206,15 @@ counter independently.
 
 ## Frontend and Configuration Gaps
 
-Because the current workaround annotates the inner K loop, outer-while options
-do not have a complete end-to-end contract for dynamic persistence. This
-includes:
+The unified outer-while path now has Blackwell end-to-end coverage for
+`data_partition_factor`, `separate_epilogue_store`, generated subtiled regions,
+and broadcast depth greater than one (the 16-configuration unified matrix). The
+following remain without a complete end-to-end contract for dynamic persistence:
 
-- `data_partition_factor`;
 - `merge_epilogue`, `merge_epilogue_to_computation`, and `merge_correction`;
-- `separate_epilogue_store`;
 - SMEM/TMEM allocation options;
-- generated subtiled regions;
-- register-budget and ping-pong combinations.
+- register-budget and ping-pong combinations;
+- all of the above on Hopper (the Blackwell matrix does not run on Hopper).
 
 `num_stages` on the dynamic outer while should remain inert or produce a clear
 frontend diagnostic; stages belong on the nested K loop.
@@ -242,8 +241,14 @@ Required coverage:
 4. **Unified E2E** [Blackwell done]: `DynamicPersistent1DScheduler` and
    `ClcTileScheduler` with outer `tl.condition(..., warp_specialize=True)` and
    an unannotated K loop. The dynamic scheduler remains pending on Hopper.
-5. **Feature E2E**: epilogue subtiles, DP=2, separate epilogue store, generated
-   subtiled regions, and broadcast depths greater than one.
+5. **Feature E2E** [Blackwell done]: epilogue subtiles, DP=2, separate epilogue
+   store, generated subtiled regions, and broadcast depths greater than one are
+   all exercised by the 16-configuration unified matrix
+   (`test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize`),
+   including `dynamic-generated-subtile-4`,
+   `dynamic-generated-separate-subtile-4`,
+   `dynamic-dp2-generated-separate-subtile-2`, and `dynamic-broadcast-depth-2`,
+   all passing on Blackwell. Hopper feature-combination runtime remains pending.
 6. **Bailout E2E/lit**: scatter, strict-subset, non-carried, and unrelated
    replicated atomics leave a compilable non-WS kernel.
 7. **Hopper and Blackwell**: CLC sibling correctness is covered on Blackwell;
@@ -254,7 +259,9 @@ Required coverage:
 ## Recommended Implementation Order
 
 1. Complete unified dynamic E2E coverage on Hopper.
-2. Add feature combinations.
+2. Add feature combinations. [Blackwell done — the unified matrix covers epilogue
+   subtiles, DP=2, separate epilogue store, generated subtiled regions, and
+   broadcast depth 2; Hopper still pending.]
 3. Address dynamic 2-CTA as a separate cluster-level design.
 
 ## Definition of Done


### PR DESCRIPTION
Summary:
Adds explicit testing for ensuring unsupport atomic patterns aren't generated.


Reviewed By: manman-ren

Differential Revision: D113029306

Pulled By: njriasan


