### PR TITLE
[AMD][gfx950][TLX] Pin a16w16 epilogue store to coalesced SIMD layout

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -288,10 +288,11 @@ def TT_StoreOp : TT_Op<"store", [
   SameLoadStoreOperandsShape,
   SameLoadStoreOperandsEncoding,
   TypesMatchWith<"value type matches ptr type", "ptr", "value",
-                 "getPointeeType($_self)">,
+                 "getPointeeType($_self)",
+                 "mlir::triton::tlxAwareTypesEqual">,
   TypesMatchWith<"mask type matches ptr type", "ptr", "mask",
                  "getI1SameShape(getPointeeType($_self))",
-                 "($_op.getOperands().size() <= 2) || std::equal_to<>()">
+                 "($_op.getOperands().size() <= 2) || mlir::triton::tlxAwareTypesEqual">
 ]> {
     let summary = "Store through a pointer or tensor of pointers";
 

--- a/include/triton/Dialect/Triton/IR/Utility.h
+++ b/include/triton/Dialect/Triton/IR/Utility.h
@@ -214,6 +214,15 @@ bool encodingContainsTlxPlaceholder(Attribute attr);
 // skipping verification entirely.
 Attribute unwrapTlxWrappers(Attribute attr);
 
+// Type comparator for op verifiers (e.g. tt.store's ptr/value/mask
+// TypesMatchWith): equal if `a == b`, or *deferred* (returns true) if either
+// type carries a TLX placeholder encoding (#tlx.user_layout / #tlx.no_verify) --
+// the concrete layouts are only reconciled later by resolve-placeholder-layouts
+// (make_ttgir). Mirrors the placeholder-deferral D112454240 added to
+// ReshapeOp::verify / verifySameEncoding, extended here to TypesMatchWith
+// constraints. A real (non-placeholder) mismatch still fails.
+bool tlxAwareTypesEqual(Type a, Type b);
+
 // If the value "anchor" is compared against a statically-computed bound, return
 // inclusive lower and upper bounds lb <= anchor <= ub. Depending on the
 // comparison operator, one of the bounds is a computed one while the other is

--- a/lib/Dialect/Triton/IR/Traits.cpp
+++ b/lib/Dialect/Triton/IR/Traits.cpp
@@ -36,24 +36,33 @@ LogicalResult OpTrait::impl::verifyEquivalentTensorType(Type typeA,
 }
 
 static LogicalResult verifySameEncoding(Type typeA, Type typeB) {
-  auto getEncoding = [=](Type type) -> Attribute {
-    Attribute ret;
-    if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
-      ret = tensorType.getEncoding();
-    }
-    // Peel any TLX placeholder wrapper(s) (#tlx.user_layout / no_verify) and
-    // verify the underlying concrete layout, rather than skipping verification.
-    // The wrapper itself is retired later by resolve-placeholder-layouts; a
-    // still-null inner (unresolved) is accepted by the null short-circuit
-    // below.
-    ret = triton::unwrapTlxWrappers(ret);
-    return ret;
+  auto getRawEncoding = [=](Type type) -> Attribute {
+    if (auto tensorType = dyn_cast<RankedTensorType>(type))
+      return tensorType.getEncoding();
+    return {};
   };
-  auto encodingA = getEncoding(typeA);
-  auto encodingB = getEncoding(typeB);
+  Attribute rawA = getRawEncoding(typeA);
+  Attribute rawB = getRawEncoding(typeB);
+  // Peel any TLX placeholder wrapper(s) (#tlx.user_layout / no_verify) and
+  // verify the underlying concrete layout, rather than skipping verification.
+  // The wrapper itself is retired later by resolve-placeholder-layouts; a
+  // still-null inner (unresolved) is accepted by the null short-circuit below.
+  Attribute encodingA = triton::unwrapTlxWrappers(rawA);
+  Attribute encodingB = triton::unwrapTlxWrappers(rawB);
   if (!encodingA || !encodingB)
     return success();
-  return encodingA == encodingB ? success() : failure();
+  if (encodingA == encodingB)
+    return success();
+  // Concrete layouts differ. Defer (accept) if either operand still carries a
+  // TLX placeholder wrapper: a user-pinned operand (e.g. a tl.store value pinned
+  // via local_load(layout=)) can legitimately mismatch a peer operand here until
+  // the pin is propagated to the peers and the wrappers retired later in
+  // make_ttgir (tlx-propagate-layout / tlx-finalize-user-layouts). A genuine
+  // (both-concrete) mismatch still fails.
+  if (triton::encodingContainsTlxPlaceholder(rawA) ||
+      triton::encodingContainsTlxPlaceholder(rawB))
+    return success();
+  return failure();
 }
 
 LogicalResult OpTrait::impl::verifySameOperandsEncoding(Operation *op) {

--- a/lib/Dialect/Triton/IR/Utility.cpp
+++ b/lib/Dialect/Triton/IR/Utility.cpp
@@ -157,3 +157,18 @@ Attribute tt::unwrapTlxWrappers(Attribute attr) {
   }
   return attr;
 }
+
+bool tt::tlxAwareTypesEqual(Type a, Type b) {
+  if (a == b)
+    return true;
+  // Defer (accept) if either type carries a TLX placeholder encoding: a pinned
+  // store value (#tlx.user_layout / no_verify) can legitimately meet a still
+  // concrete/absent ptr or mask encoding here; the concrete layouts are
+  // reconciled later by resolve-placeholder-layouts (make_ttgir). A genuine
+  // (non-placeholder) mismatch still fails.
+  auto hasPlaceholder = [](Type t) {
+    auto rt = dyn_cast<RankedTensorType>(t);
+    return rt && encodingContainsTlxPlaceholder(rt.getEncoding());
+  };
+  return hasPlaceholder(a) || hasPlaceholder(b);
+}

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -135,13 +135,36 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
             &getContext(), resultType.getShape(), sizePerThread, order,
             numWarps, threadsPerWarp, CGALayout);
       } else {
-        auto tensorType = cast<RankedTensorType>(ptr.getType());
-        CGAEncodingAttr cgaLayout = getCGALayout(tensorType.getEncoding());
-        SmallVector<int64_t> shapePerCTA = getShapePerCTA(tensorType);
-        auto layout = buildCoalescedEncoding(axisInfoAnalysis, curr, numWarps,
-                                             threadsPerWarp, cgaLayout,
-                                             shapePerCTA, maxVecBits);
-        layoutMap[curr] = layout;
+        // Respect a user-pinned store value layout. A tt.store has no result to
+        // carry a PinnedEncodingTrait, so the pin (TLX #tlx.user_layout, e.g.
+        // from local_load(layout=)) rides on the value operand. When present,
+        // store in that peeled concrete layout instead of a freshly-coalesced
+        // one: convertDistributedOpEncoding then converts ptr/mask to match, and
+        // the value's bridging convert folds away -- so the user's chosen store
+        // layout survives to codegen (and AMD OptimizeEpilogue leaves it alone
+        // since it is no longer a #blocked store).
+        Attribute pinned;
+        if (auto store = dyn_cast<triton::StoreOp>(curr)) {
+          if (auto vt =
+                  dyn_cast<RankedTensorType>(store.getValue().getType())) {
+            if (isa_and_nonnull<PinnedEncodingTrait>(vt.getEncoding())) {
+              Attribute concrete = triton::unwrapTlxWrappers(vt.getEncoding());
+              if (isa_and_nonnull<DistributedEncodingTrait>(concrete))
+                pinned = concrete;
+            }
+          }
+        }
+        if (pinned) {
+          layoutMap[curr] = pinned;
+        } else {
+          auto tensorType = cast<RankedTensorType>(ptr.getType());
+          CGAEncodingAttr cgaLayout = getCGALayout(tensorType.getEncoding());
+          SmallVector<int64_t> shapePerCTA = getShapePerCTA(tensorType);
+          auto layout = buildCoalescedEncoding(axisInfoAnalysis, curr, numWarps,
+                                               threadsPerWarp, cgaLayout,
+                                               shapePerCTA, maxVecBits);
+          layoutMap[curr] = layout;
+        }
       }
     });
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
@@ -126,8 +126,17 @@ public:
     Value mask = stOp.getMask();
     auto ptrType = dyn_cast<RankedTensorType>(ptr.getType());
     auto valType = dyn_cast<RankedTensorType>(val.getType());
-    if (!ptrType || !valType ||
-        !isa<triton::gpu::BlockedEncodingAttr>(ptrType.getEncoding()) ||
+    if (!ptrType || !valType)
+      return mlir::failure();
+    // Respect a user-pinned store layout (PinnedEncodingTrait, e.g. TLX's
+    // #tlx.user_layout): the author chose this store layout deliberately (like a
+    // Gluon convert_layout before the store), so do not rewrite it to the MMA
+    // accumulator layout. Mirrors Coalesce / RemoveLayoutConversions /
+    // OptimizeTMemLayouts, which already anchor on this trait (D112032532).
+    if (isa_and_nonnull<triton::gpu::PinnedEncodingTrait>(valType.getEncoding()) ||
+        isa_and_nonnull<triton::gpu::PinnedEncodingTrait>(ptrType.getEncoding()))
+      return mlir::failure();
+    if (!isa<triton::gpu::BlockedEncodingAttr>(ptrType.getEncoding()) ||
         !isa<triton::gpu::BlockedEncodingAttr>(valType.getEncoding()))
       return mlir::failure();
 

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -4,6 +4,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "tlx/dialect/include/Analysis/LayoutPropagation.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/IR/Types.h"
@@ -63,6 +64,79 @@ public:
     rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(
         releaseLayoutOp, releaseLayoutOp.getType(), releaseLayoutOp.getSrc());
     return success();
+  }
+};
+
+// Reconcile a tt.store whose *value* is pinned to a user register layout
+// (#tlx.user_layout / no_verify, e.g. from local_load(layout=)) but whose ptr /
+// mask operands still carry a different (default #blocked) encoding. The store's
+// SameLoadStoreOperandsEncoding trait requires all operands share one encoding;
+// convert_to_ttgpuir assigns the pin only to the value, so we insert a
+// convert_layout on the peer operands to the value's peeled concrete layout.
+// Runs before unwrapUserLayoutEncodings retires the wrapper, so the peers are in
+// place by the time the value becomes concrete. Without this the store is
+// silently rewritten by AMD OptimizeEpilogue (to the narrow MMA-accumulator
+// store) or fails verification once the pin is retired.
+class ReconcilePinnedStoreOperands
+    : public mlir::OpRewritePattern<triton::StoreOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(triton::StoreOp storeOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    Value value = storeOp.getValue();
+    auto valType = dyn_cast<RankedTensorType>(value.getType());
+    if (!valType)
+      return failure();
+    Attribute valEnc = valType.getEncoding();
+    // Only act on a value carrying a user register-layout pin.
+    if (!triton::encodingContainsTlxPlaceholder(valEnc))
+      return failure();
+    Attribute concrete = triton::unwrapTlxWrappers(valEnc);
+    if (!concrete || triton::encodingContainsTlxPlaceholder(concrete))
+      return failure();
+
+    // The value must be produced by an op we can retag (e.g. the pinned
+    // local_load); a bare block argument we cannot retire here.
+    Operation *valDef = value.getDefiningOp();
+    if (!valDef)
+      return failure();
+
+    bool changed = false;
+    auto reconcile = [&](Value operand, unsigned idx) {
+      if (!operand)
+        return;
+      auto opType = dyn_cast<RankedTensorType>(operand.getType());
+      if (!opType || opType.getEncoding() == concrete)
+        return;
+      auto newType = RankedTensorType::get(opType.getShape(),
+                                           opType.getElementType(), concrete);
+      Value cvt = ttg::ConvertLayoutOp::create(rewriter, operand.getLoc(),
+                                               newType, operand);
+      storeOp.setOperand(idx, cvt);
+      changed = true;
+    };
+    // Operand order: ptr(0), value(1), mask(2) (mask optional).
+    reconcile(storeOp.getPtr(), 0);
+    if (storeOp.getMask())
+      reconcile(storeOp.getMask(), 2);
+
+    // Retire the value's register pin to its concrete layout now. The pin's
+    // purpose (staying a non-#blocked layout so AMD OptimizeEpilogue leaves the
+    // store alone) is served equally by the concrete #linear; retiring it here,
+    // rather than later in tlx-finalize-user-layouts, keeps every intervening
+    // pass (e.g. tlx-rewrite-local-alias, which computes a linear layout) from
+    // tripping over the still-wrapped placeholder encoding.
+    auto concreteValType = RankedTensorType::get(
+        valType.getShape(), valType.getElementType(), concrete);
+    if (value.getType() != concreteValType) {
+      rewriter.modifyOpInPlace(valDef,
+                               [&]() { value.setType(concreteValType); });
+      changed = true;
+    }
+
+    return changed ? success() : failure();
   }
 };
 
@@ -550,6 +624,7 @@ public:
     RewritePatternSet patterns(context);
     patterns.add<RequireLayoutPattern>(context);
     patterns.add<ReleaseLayoutPattern>(context);
+    patterns.add<ReconcilePinnedStoreOperands>(context);
     patterns.add<FoldRetaggedLocalAllocLoad>(context);
     patterns.add<FoldLocalAllocLoadFallback>(context);
 

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
@@ -44,6 +44,19 @@ NUM_XCDS = 8
 MIN_K = 2 * BLOCK_K  # pipeline prefetches 2 whole K-tiles; the rest goes to the masked tail
 KERNEL_NAME = "a16w16_8wave"
 
+# Coalesced SIMD (register) layout for the fp16 epilogue store of a [HALF_M, HALF_N]
+# = [128, 128] quadrant (num_warps=8, warp_size=64): each thread holds 8 contiguous
+# N elements (fp16 -> 128-bit buffer_store_dwordx4). Applied via local_load(layout=)
+# after staging the accumulator through LDS -- a *surviving* user-pinned layout
+# (#tlx.user_layout) that resolves to concrete #linear, so AMD OptimizeEpilogue
+# leaves the store alone (it only rewrites #blocked stores) and we keep the wide
+# coalesced store instead of the narrow MMA-accumulator (dwordx2) store.
+# thread = (16 N-lane, 4 M-lane, 8 M-warp); value = (8 N-reg, 4 M-reg); flat = m*128+n.
+_C_STORE_SIMD_LAYOUT = tlx.layout(
+    shape=((16, 4, 8), (8, 4)),
+    stride=((8, 128, 512), (1, 4096)),
+)
+
 
 @triton.jit
 def a16w16_8wave(
@@ -341,16 +354,34 @@ def a16w16_8wave(
     n_right = offs_cn_right[None, :] < N
 
     if SPLIT_K == 1:
-        # Direct store to C -- exact no-op vs the champion kernel.
+        # Stage each quadrant of the accumulator through LDS (reusing the now-free
+        # a/b buffers) and read it back in the explicit coalesced SIMD layout via
+        # local_load(layout=) -- a surviving #tlx.user_layout pin. The store then
+        # resolves to #linear (coalesced dwordx4) and AMD OptimizeEpilogue leaves it
+        # alone. One debug_barrier covers the store->load hazard for all quadrants.
         et = c_ptr.dtype.element_ty
-        tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_left[None, :], acc_tl.to(et),
-                 mask=m_top & n_left)
-        tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_left[None, :], acc_bl.to(et),
-                 mask=m_bot & n_left)
-        tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_right[None, :], acc_tr.to(et),
-                 mask=m_top & n_right)
-        tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_right[None, :], acc_br.to(et),
-                 mask=m_bot & n_right)
+        L: tl.constexpr = _C_STORE_SIMD_LAYOUT
+        # Fresh staging buffers (no reuse=): the main-loop buffers are dead by the
+        # epilogue, so the shared-memory allocator overlaps these with them via
+        # liveness. Explicit reuse= (local_alias) tripped RewriteLocalAlias when
+        # mixing the padded A/B layouts with the swizzled staging layout.
+        cs_tl = tlx.local_alloc((HALF_M, HALF_N), tl.float16, 1)
+        cs_bl = tlx.local_alloc((HALF_M, HALF_N), tl.float16, 1)
+        cs_tr = tlx.local_alloc((HALF_M, HALF_N), tl.float16, 1)
+        cs_br = tlx.local_alloc((HALF_M, HALF_N), tl.float16, 1)
+        tlx.local_store(tlx.local_view(cs_tl, 0), acc_tl.to(et))
+        tlx.local_store(tlx.local_view(cs_bl, 0), acc_bl.to(et))
+        tlx.local_store(tlx.local_view(cs_tr, 0), acc_tr.to(et))
+        tlx.local_store(tlx.local_view(cs_br, 0), acc_br.to(et))
+        tl.debug_barrier()
+        tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_left[None, :],
+                 tlx.local_load(tlx.local_view(cs_tl, 0), layout=L), mask=m_top & n_left)
+        tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_left[None, :],
+                 tlx.local_load(tlx.local_view(cs_bl, 0), layout=L), mask=m_bot & n_left)
+        tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_right[None, :],
+                 tlx.local_load(tlx.local_view(cs_tr, 0), layout=L), mask=m_top & n_right)
+        tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_right[None, :],
+                 tlx.local_load(tlx.local_view(cs_br, 0), layout=L), mask=m_bot & n_right)
     else:
         # Split-K: every split writes its fp32 partial into its workspace slice
         # (rows [split_id*M, split_id*M+M)). Mask stays in relative-M coords; the


### PR DESCRIPTION
The FP16 epilogue store of the 8-wave GEMM regressed to buffer_store_dwordx2: TritonAMDGPUOptimizeEpilogue rewrites the coalesced #blocked store into the MMA accumulator layout, and chooseMfmaLikeStoreLayout's wide permlane store does not fire for this MFMA config, so the fallback is a narrow uncoalesced store. This pins the store to an explicit coalesced #linear register layout (tlx.layout) so it stays buffer_store_dwordx4.

tt.store has no result, so a PinnedEncodingTrait cannot anchor it directly and the store layout is decided by tritongpu-coalesce. The core of the fix teaches coalesce to honor a pinned store *value* operand; the TLX placeholder machinery (the local_load(layout=) / #tlx.user_layout survival path) is extended so the pin survives the store's operand-encoding verifiers until coalesce consumes it.

Suggested review order:
- lib/Dialect/Triton/IR/Utility.{h,cpp}: tlxAwareTypesEqual -- defer op verification when a TLX placeholder encoding is present.
- include/.../TritonOps.td + lib/Dialect/Triton/IR/Traits.cpp: apply that deferral to tt.store's value/mask TypesMatchWith and to verifySameEncoding (SameLoadStoreOperandsEncoding), the two verifiers a pinned store value trips.
- lib/Dialect/TritonGPU/Transforms/Coalesce.cpp: for a store whose value carries a pin, store in the pin's peeled concrete layout instead of a freshly coalesced one (the crux -- convertDistributedOpEncoding then matches ptr/mask).
- third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp: reconcile/retire a pinned store's ptr/mask operands as a fallback path.
- third_party/amd/.../OptimizeEpilogue.cpp: leave a pinned (non-#blocked) store alone rather than rewriting it to the MMA accumulator layout.
- .../a16w16/matmul_kernel.py: stage each accumulator quadrant through LDS and read it back with local_load(layout=_C_STORE_SIMD_LAYOUT) to apply the pin.

Verified on gfx950: bit-exact vs torch.matmul on the SPLIT_K=1 shapes, and the epilogue emits 16 buffer_store_dwordx4 with 0 dwordx2.

Authored with Claude.