### PR TITLE
 [AutoWS] [Isolation] Add a config to disable TMA store wait pipelining (#2279)

### DIFF
--- a/python/src/passes.h
+++ b/python/src/passes.h
@@ -59,3 +59,10 @@
                  ty3 val3, ty4 val4, ty5 val5, ty6 val6) {                     \
     pm.addPass(builder({val0, val1, val2, val3, val4, val5, val6}));           \
   })
+
+#define ADD_PASS_OPTION_WRAPPER_8(name, builder, ty0, ty1, ty2, ty3, ty4, ty5, \
+                                  ty6, ty7)                                    \
+  m.def(name, [](mlir::PassManager &pm, ty0 val0, ty1 val1, ty2 val2,          \
+                 ty3 val3, ty4 val4, ty5 val5, ty6 val6, ty7 val7) {           \
+    pm.addPass(builder({val0, val1, val2, val3, val4, val5, val6, val7}));     \
+  })

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -1043,6 +1043,7 @@ class Config:
         reg_inc_consumer=0,
         ctas_per_cga=None,
         early_tma_store_lowering=None,
+        tma_store_pipelining=None,
         generate_subtiled_region=None,
         preferred_ctas_per_cga=None,
         multicast=False,
@@ -1062,6 +1063,7 @@ class Config:
         self.pingpongAutoWS = pingpongAutoWS
         self.ctas_per_cga = ctas_per_cga
         self.early_tma_store_lowering = early_tma_store_lowering
+        self.tma_store_pipelining = tma_store_pipelining
         self.generate_subtiled_region = generate_subtiled_region
         self.preferred_ctas_per_cga = preferred_ctas_per_cga
         self.multicast = multicast
@@ -1082,6 +1084,7 @@ class Config:
         self.pingpongAutoWS = state.get("pingpongAutoWS", None)
         self.ctas_per_cga = state.get("ctas_per_cga", None)
         self.early_tma_store_lowering = state.get("early_tma_store_lowering", None)
+        self.tma_store_pipelining = state.get("tma_store_pipelining", None)
         self.generate_subtiled_region = state.get("generate_subtiled_region", None)
         self.preferred_ctas_per_cga = state.get("preferred_ctas_per_cga", None)
         self.multicast = state.get("multicast", False)
@@ -1103,6 +1106,7 @@ class Config:
                     ("pingpongAutoWS", self.pingpongAutoWS),
                     ("ctas_per_cga", self.ctas_per_cga),
                     ("early_tma_store_lowering", self.early_tma_store_lowering),
+                    ("tma_store_pipelining", self.tma_store_pipelining),
                     ("generate_subtiled_region", self.generate_subtiled_region),
                     ("preferred_ctas_per_cga", self.preferred_ctas_per_cga),
                     ("multicast", self.multicast),
@@ -1124,6 +1128,7 @@ class Config:
         res.append(f"pingpongAutoWS: {self.pingpongAutoWS}")
         res.append(f"ctas_per_cga: {self.ctas_per_cga}")
         res.append(f"early_tma_store_lowering: {self.early_tma_store_lowering}")
+        res.append(f"tma_store_pipelining: {self.tma_store_pipelining}")
         res.append(f"generate_subtiled_region: {self.generate_subtiled_region}")
         res.append(f"preferred_ctas_per_cga: {self.preferred_ctas_per_cga}")
         res.append(f"multicast: {self.multicast}")

--- a/test/Hopper/WarpSpecialization/ws_tma_store_pipelining_option.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_pipelining_option.mlir
@@ -1,0 +1,24 @@
+// RUN: triton-opt %s --nvgpu-warp-specialization="num-stages=2 capability=90" | FileCheck %s --check-prefix=DEFAULT
+// RUN: triton-opt %s --nvgpu-warp-specialization="num-stages=2 capability=90 tma-store-pipelining=false" | FileCheck %s --check-prefix=DISABLED
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // DEFAULT-LABEL: @preannotated_wait
+  // DEFAULT: ttng.async_tma_store_token_wait
+  // DEFAULT-NOT: can_rotate_by_buffer_count
+  // DISABLED-LABEL: @preannotated_wait
+  // DISABLED: ttng.async_tma_store_token_wait
+  // DISABLED-SAME: can_rotate_by_buffer_count = 1
+  tt.func public @preannotated_wait(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %lb: index, %ub: index, %step: index, %i: i32) {
+    %seed = arith.constant {async_task_id = array<i32: 0>} 0 : i32
+    scf.for %iv = %lb to %ub step %step {
+      %tok = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src {async_task_id = array<i32: 0>, "loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok {async_task_id = array<i32: 0>, "can_rotate_by_buffer_count" = 1 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 1 : i32} : !ttg.async.token
+    } {"tt.scheduled_max_stage" = 1 : i32}
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -200,6 +200,7 @@ class CUDAOptions:
     arch: str = None
     instrumentation_mode: str = ""
     early_tma_store_lowering: Optional[None] = None
+    tma_store_pipelining: Optional[bool] = None
     generate_subtiled_region: bool = False
     multicast: bool = False
     # Per-config auto-TMA toggle (autotunable). Falls back to the global
@@ -856,6 +857,7 @@ class CUDABackend(BaseBackend):
                 nvidia.passes.hopper.add_partition_scheduling_meta(pm)
             smem_budget = _max_shared_mem_for_capability(capability)
             generate_subtiled = (opt.generate_subtiled_region or knobs.nvidia.generate_subtiled_region)
+            tma_store_pipelining = True if opt.tma_store_pipelining is None else opt.tma_store_pipelining
             nvidia.passes.hopper.add_hopper_warpspec(
                 pm,
                 opt.num_stages,
@@ -865,6 +867,7 @@ class CUDABackend(BaseBackend):
                 smem_budget,
                 generate_subtiled,
                 knobs.nvidia.ws_tile_prefetch_depth,
+                tma_store_pipelining,
             )
             if not knobs.nvidia.use_meta_ws:
                 passes.ttgpuir.add_assign_latencies(pm, opt.num_stages, knobs.nvidia.use_meta_ws)
@@ -930,6 +933,7 @@ class CUDABackend(BaseBackend):
                 nvidia.passes.hopper.add_partition_scheduling_meta(pm)
                 smem_budget = _max_shared_mem_for_capability(capability)
                 generate_subtiled = (opt.generate_subtiled_region or knobs.nvidia.generate_subtiled_region)
+                tma_store_pipelining = True if opt.tma_store_pipelining is None else opt.tma_store_pipelining
                 nvidia.passes.hopper.add_hopper_warpspec(
                     pm,
                     opt.num_stages,
@@ -939,6 +943,7 @@ class CUDABackend(BaseBackend):
                     smem_budget,
                     generate_subtiled,
                     knobs.nvidia.ws_tile_prefetch_depth,
+                    tma_store_pipelining,
                 )
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
             passes.ttgpuir.add_optimize_partition_warps(pm)

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -38,7 +38,10 @@ def NVGPUWarpSpecialization : Pass<"nvgpu-warp-specialization", "mlir::ModuleOp"
     Option<"tilePrefetchDepth", "tile-prefetch-depth",
              "int32_t", /*default*/"1",
              "Number of buffers for the dynamic-persistent tile-id broadcast "
-             "channel (cross-partition run-once atomic support)">
+             "channel (cross-partition run-once atomic support)">,
+    Option<"tmaStorePipelining", "tma-store-pipelining",
+             "bool", /*default*/"true",
+             "Enable TMA store wait annotation, validation, and reordering">
     ];
 }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -227,11 +227,13 @@ public:
       dumpAfter(moduleOp, "doGenerateSubtiledRegion");
     }
 
-    doAnnotateTMAStoreWaits(funcOp);
-    dumpAfter(moduleOp, "doAnnotateTMAStoreWaits");
+    if (tmaStorePipelining) {
+      doAnnotateTMAStoreWaits(funcOp);
+      dumpAfter(moduleOp, "doAnnotateTMAStoreWaits");
 
-    doValidateTMAStoreAnnotations(funcOp);
-    dumpAfter(moduleOp, "doValidateTMAStoreAnnotations");
+      doValidateTMAStoreAnnotations(funcOp);
+      dumpAfter(moduleOp, "doValidateTMAStoreAnnotations");
+    }
 
     doCodePartition(funcOp, numStages);
     dumpAfter(moduleOp, "doCodePartition");
@@ -261,8 +263,10 @@ public:
     }
     dumpAfter(moduleOp, "cleanupWarpSpecializedLoops");
 
-    doTMAStoreWaitReorder(funcOp);
-    dumpAfter(moduleOp, "doTMAStoreWaitReorder");
+    if (tmaStorePipelining) {
+      doTMAStoreWaitReorder(funcOp);
+      dumpAfter(moduleOp, "doTMAStoreWaitReorder");
+    }
   }
 
   void runOnOperation() override {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -38,6 +38,11 @@ elementwise users. This keeps broadcasts and their value materialization, such
 as a descriptor load followed by an extend, associated with their use after
 other operands, such as TMEM loads, have been prepared.
 
+The TMA store wait pipeline is enabled by default and can be disabled with the
+`nvgpu-warp-specialization` pass option `tma-store-pipelining=false`. Disabling
+it skips wait annotation, annotation validation, and wait reordering; it does
+not disable early TMA store lowering.
+
 ## Register Budgets
 
 `minRegAutoWS` and `maxRegAutoWS` control the per-thread register budgets used

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMAStoreWaitPipeline.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMAStoreWaitPipeline.md
@@ -173,6 +173,13 @@ doMemoryPlanner
   → doTMAStoreWaitReorder         ← move waits using the SWP schedule
 ```
 
+This sequence is controlled by the `nvgpu-warp-specialization` pass option
+`tma-store-pipelining`, which defaults to `true`. When set to `false`, AutoWS
+skips all three steps: annotation, validation, and post-schedule reordering.
+This option is independent of `early_tma_store_lowering`, which controls
+whether descriptor stores are lowered into async TMA store operations before
+warp specialization.
+
 Each function is also available as a standalone MLIR pass for use outside
 the monolithic pipeline.
 

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -214,9 +214,9 @@ void init_triton_nvidia_passes_nvws(py::module &&m) {
 
 void init_triton_hopper_passes(py::module &&m) {
   // Meta's autoWS
-  ADD_PASS_OPTION_WRAPPER_7("add_hopper_warpspec",
+  ADD_PASS_OPTION_WRAPPER_8("add_hopper_warpspec",
                             mlir::createNVGPUWarpSpecialization, int, int, bool,
-                            bool, int, bool, int);
+                            bool, int, bool, int, bool);
   ADD_PASS_OPTION_WRAPPER_1("add_data_partitioning",
                             mlir::createNVGPUWSDataPartition, int);
   ADD_PASS_WRAPPER_0("add_tma_store_lowering",


### PR DESCRIPTION
Summary:
Adds a per-config NVIDIA option to disable TMA store wait annotation, validation, and reordering while preserving the default enabled behavior.

This is aimed to ensure we can disable individual features as part of the production process.

Authored with Claude.


Reviewed By: manman-ren

Differential Revision: D113056081

Pulled By: njriasan


