### PR TITLE
[ci] use the correct integration test workflow id

### DIFF
--- a/.github/workflows/runner-preparation.yml
+++ b/.github/workflows/runner-preparation.yml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           REPO_NAME="${{ github.repository }}"
           # ID of integration-tests workflow
-          WORKFLOW_ID="11678186"
+          WORKFLOW_ID="160583305"
 
           # Fetch the last run time of this workflow
           LAST_RUN=$(curl -s \


### PR DESCRIPTION
Get the correct workflow ID.

```
 gh api repos/facebookexperimental/triton/actions/workflows/ci.yml --jq '.id' | tee 1.txt
160583305
```