### PR TITLE
[TLX][AMD] Accelerate page-16 paged decode with 64-token tile aggregation

### DIFF
--- a/third_party/tlx/tutorials/amd_pa_decode.py
+++ b/third_party/tlx/tutorials/amd_pa_decode.py
@@ -63,6 +63,9 @@ def _pa_decode_partition_kernel(
     stride_lse_m,
     HEAD_DIM: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    PAGES_PER_TILE: tl.constexpr,
+    BUFFER_DEPTH: tl.constexpr,
     QUERY_GROUP_SIZE: tl.constexpr,
     GROUP_POW2: tl.constexpr,
     QLEN: tl.constexpr,
@@ -83,6 +86,7 @@ def _pa_decode_partition_kernel(
     offs_g = tl.arange(0, GROUP_POW2)
     offs_ql = tl.arange(0, QLEN_POW2)
     offs_p = tl.arange(0, PAGE_SIZE)
+    offs_n = tl.arange(0, BLOCK_N)
     offs_m = tl.arange(0, M_POW2)
 
     # Load Q for this (seq, kv_head): [QLEN_POW2, GROUP_POW2, HEAD_DIM].
@@ -101,27 +105,45 @@ def _pa_decode_partition_kernel(
     l_i = tl.zeros([M_POW2], tl.float32)
     acc = tl.zeros([M_POW2, HEAD_DIM], tl.float32)
 
-    k_buf = tlx.local_alloc((PAGE_SIZE, HEAD_DIM), Kc.dtype.element_ty, BUF_DEPTH)
-    v_buf = tlx.local_alloc((PAGE_SIZE, HEAD_DIM), Vc.dtype.element_ty, BUF_DEPTH)
+    k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), Kc.dtype.element_ty, BUFFER_DEPTH)
+    v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), Vc.dtype.element_ty, BUFFER_DEPTH)
 
-    for pidx in tl.range(start_page, end_page):
-        slot = (pidx - start_page) % BUF_DEPTH
-        physical = tl.load(BlockTables + seq * stride_bt_s + pidx * stride_bt_p)
-        k_ptrs = (Kc + physical * stride_kc_b + kv_head * stride_kc_h + offs_p[:, None] * stride_kc_p +
-                  offs_d[None, :] * stride_kc_d)
-        v_ptrs = (Vc + physical * stride_vc_b + kv_head * stride_vc_h + offs_p[:, None] * stride_vc_p +
-                  offs_d[None, :] * stride_vc_d)
-        tok_k = tlx.async_load(k_ptrs, tlx.local_view(k_buf, slot))
-        tok_v = tlx.async_load(v_ptrs, tlx.local_view(v_buf, slot))
-        tlx.async_load_commit_group([tok_k, tok_v])
-        tlx.async_load_wait_group(0)
+    for pidx in tl.range(start_page, end_page, PAGES_PER_TILE):
+        slot = ((pidx - start_page) // PAGES_PER_TILE) % BUFFER_DEPTH
+        k_view = tlx.local_view(k_buf, slot)
+        v_view = tlx.local_view(v_buf, slot)
+        if PAGES_PER_TILE == 4:
+            logical_page = pidx + offs_n // PAGE_SIZE
+            safe_page = tl.minimum(logical_page, end_page - 1)
+            physical = tl.load(BlockTables + seq * stride_bt_s + safe_page * stride_bt_p)
+            page_row = offs_n % PAGE_SIZE
+            k_ptrs = (Kc + physical[:, None] * stride_kc_b + kv_head * stride_kc_h +
+                      page_row[:, None] * stride_kc_p + offs_d[None, :] * stride_kc_d)
+            v_ptrs = (Vc + physical[:, None] * stride_vc_b + kv_head * stride_vc_h +
+                      page_row[:, None] * stride_vc_p + offs_d[None, :] * stride_vc_d)
+            tlx.local_store(k_view, tl.load(k_ptrs))
+            tlx.local_store(v_view, tl.load(v_ptrs))
+            tl.debug_barrier()
+            kt = tlx.local_load(tlx.local_trans(k_view))
+            v = tlx.local_load(v_view)
+        else:
+            physical = tl.load(BlockTables + seq * stride_bt_s + pidx * stride_bt_p)
+            k_ptrs = (Kc + physical * stride_kc_b + kv_head * stride_kc_h + offs_p[:, None] * stride_kc_p +
+                      offs_d[None, :] * stride_kc_d)
+            v_ptrs = (Vc + physical * stride_vc_b + kv_head * stride_vc_h + offs_p[:, None] * stride_vc_p +
+                      offs_d[None, :] * stride_vc_d)
+            tok_k = tlx.async_load(k_ptrs, k_view)
+            tok_v = tlx.async_load(v_ptrs, v_view)
+            tlx.async_load_commit_group([tok_k, tok_v])
+            wait_tok = tlx.async_load_wait_group(0)
+            kt = tlx.local_load(tlx.local_trans(k_view), token=wait_tok)
+            v = tlx.local_load(v_view, token=wait_tok)
 
-        kt = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, slot)))  # [HEAD_DIM, PAGE_SIZE]
-        v = tlx.local_load(tlx.local_view(v_buf, slot))  # [PAGE_SIZE, HEAD_DIM]
-
-        qk = tl.dot(q, kt)  # [M_POW2, PAGE_SIZE] fp32
-        kt_abs = pidx * PAGE_SIZE + offs_p  # absolute key index
-        vis = kt_abs[None, :] <= (ctx_len - QLEN + m_qpos[:, None])
+        qk = tl.dot(q, kt)  # [M_POW2, BLOCK_N] fp32
+        kt_abs = pidx * PAGE_SIZE + offs_n  # absolute key index
+        split_end_token = end_page * PAGE_SIZE
+        vis = ((kt_abs[None, :] < split_end_token) &
+               (kt_abs[None, :] <= (ctx_len - QLEN + m_qpos[:, None])))
         qk = tl.where(vis, qk * QK_SCALE, float("-inf"))
 
         m_ij = tl.max(qk, 1)
@@ -287,6 +309,9 @@ def pa_decode_tlx(
         lse.stride(3),
         HEAD_DIM=head_dim,
         PAGE_SIZE=page_size,
+        BLOCK_N=64 if page_size == 16 else page_size,
+        PAGES_PER_TILE=4 if page_size == 16 else 1,
+        BUFFER_DEPTH=1 if page_size == 16 else BUF_DEPTH,
         QUERY_GROUP_SIZE=query_group_size,
         GROUP_POW2=group_pow2,
         QLEN=query_length,

--- a/third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py
+++ b/third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py
@@ -19,8 +19,8 @@ DEVICE = triton.runtime.driver.active.get_active_torch_device()
 NUM_KV_HEADS = 8
 QUERY_GROUP_SIZE = 8
 NUM_Q_HEADS = NUM_KV_HEADS * QUERY_GROUP_SIZE
-HEAD_DIM = 128
-PAGE_SIZE = 64
+HEAD_DIM = 64
+PAGE_SIZE = 16
 
 DECODE_METHODS = ("tlx", "aiter")
 DEFAULT_DECODE_VERSIONS = list(DECODE_METHODS)

--- a/third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py
+++ b/third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py
@@ -1,4 +1,5 @@
 import argparse
+import math
 
 import torch
 
@@ -21,10 +22,58 @@ NUM_Q_HEADS = NUM_KV_HEADS * QUERY_GROUP_SIZE
 HEAD_DIM = 128
 PAGE_SIZE = 64
 
-DECODE_METHODS = {
-    "tlx": lambda out, q, kc, vc, ctx, bt, sm, qlen: _pa_decode_tlx(out, q, kc, vc, ctx, bt, sm, query_length=qlen),
-}
-DEFAULT_DECODE_VERSIONS = ["tlx"]
+DECODE_METHODS = ("tlx", "aiter")
+DEFAULT_DECODE_VERSIONS = list(DECODE_METHODS)
+
+
+def _pack_aiter_kv_cache(key_cache, value_cache):
+    """Convert [block, head, page, dim] caches to AITER's packed layouts."""
+    x = 16 // key_cache.element_size()
+    num_blocks, num_kv_heads, page_size, head_dim = key_cache.shape
+    assert head_dim % x == 0
+    assert page_size % x == 0
+
+    key_cache = key_cache.view(num_blocks, num_kv_heads, page_size, head_dim // x, x)
+    key_cache = key_cache.permute(0, 1, 3, 2, 4).contiguous()
+    value_cache = value_cache.view(num_blocks, num_kv_heads, page_size // x, x, head_dim)
+    value_cache = value_cache.permute(0, 1, 2, 4, 3).contiguous()
+    return key_cache, value_cache
+
+
+def _make_decode_fn(provider, out, q, kc, vc, ctx, bt, sm_scale, qlen):
+    if provider == "tlx":
+        return lambda: _pa_decode_tlx(out, q, kc, vc, ctx, bt, sm_scale, query_length=qlen)
+
+    from aiter.ops.triton.gluon.pa_decode_gluon import pa_decode_gluon
+
+    kc, vc = _pack_aiter_kv_cache(kc, vc)
+    num_seqs = q.shape[0] // qlen
+    equivalent_group_size = qlen * QUERY_GROUP_SIZE
+    context_partition_size = 256
+    max_context_partition_num = math.ceil(int(ctx.max().item()) / context_partition_size)
+    workspace_shape = (num_seqs, NUM_KV_HEADS, max_context_partition_num, equivalent_group_size)
+    exp_sums = torch.empty(workspace_shape, dtype=torch.float32, device=q.device)
+    max_logits = torch.empty_like(exp_sums)
+    temporary_output = torch.empty((*workspace_shape, HEAD_DIM), dtype=q.dtype, device=q.device)
+
+    return lambda: pa_decode_gluon(
+        output=out,
+        query=q,
+        key_cache=kc,
+        value_cache=vc,
+        context_lengths=ctx,
+        block_tables=bt,
+        softmax_scale=sm_scale,
+        query_length=qlen,
+        max_context_partition_num=max_context_partition_num,
+        context_partition_size=context_partition_size,
+        compute_type=q.dtype,
+        exp_sums=exp_sums,
+        max_logits=max_logits,
+        temporary_output=temporary_output,
+        sliding_window=0,
+        ps=False,
+    )
 
 
 def create_benchmark(versions, qlen):
@@ -60,10 +109,9 @@ def create_benchmark(versions, qlen):
         q, kc, vc, ctx, bt = _build_inputs(BATCH, [N_CTX] * BATCH, NUM_Q_HEADS, NUM_KV_HEADS, HEAD_DIM, PAGE_SIZE,
                                            query_length=qlen, device=DEVICE, pool_pages=pool)
         out = torch.empty_like(q)
-        fn = DECODE_METHODS[provider]
+        fn = _make_decode_fn(provider, out, q, kc, vc, ctx, bt, sm_scale, qlen)
         quantiles = [0.5, 0.2, 0.8]
-        ms, min_ms, max_ms = triton.testing.do_bench(lambda: fn(out, q, kc, vc, ctx, bt, sm_scale, qlen),
-                                                     quantiles=quantiles, warmup=100, rep=200)
+        ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles, warmup=100, rep=200)
 
         # Decode reads the whole KV cache once (K + V, bf16): report effective
         # HBM read bandwidth, the meaningful metric for this memory-bound op.
@@ -80,8 +128,8 @@ if __name__ == "__main__":
         "--version",
         type=str,
         nargs="+",
-        choices=list(DECODE_METHODS.keys()),
-        help=f"Run only the specified version(s). Choices: {list(DECODE_METHODS.keys())}",
+        choices=list(DECODE_METHODS),
+        help=f"Run only the specified version(s). Choices: {list(DECODE_METHODS)}",
     )
     parser.add_argument(
         "--qlens",
@@ -97,6 +145,14 @@ if __name__ == "__main__":
         print(f"Running paged-decode benchmarks for: {versions}, qlens={args.qlens}")
         for qlen in args.qlens:
             print(f"\n=== query_length = {qlen} ===")
-            create_benchmark(versions, qlen).run(print_data=True)
+            report = create_benchmark(versions, qlen)
+            if "tlx" in versions and "aiter" in versions:
+                df = report.run(return_df=True)
+                ylabel = "TB/s (effective HBM read)"
+                df["aiter/tlx speedup"] = df[f"aiter ({ylabel})"] / df[f"tlx ({ylabel})"]
+                print(f"paged-decode-performance-bf16-qlen{qlen}:")
+                print(df.to_string())
+            else:
+                report.run(print_data=True)
     else:
         print("Skipping benchmarks, no AMD GPU found.")

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -1197,6 +1197,24 @@ def test_amd_pa_decode(num_splits, query_length):
     torch.testing.assert_close(out.float(), ref, atol=2e-2, rtol=2e-2)
 
 
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_pa_decode_page16_tile_boundaries():
+    num_kv_heads, group = 2, 4
+    num_q_heads = num_kv_heads * group
+    head_dim, page_size = 128, 16
+    ctx_lens = [15, 16, 17, 63, 64, 65]
+    sm_scale = 1.0 / math.sqrt(head_dim)
+
+    query, key_cache, value_cache, context_lens, block_tables = _amd_pa_decode_build_inputs(
+        len(ctx_lens), ctx_lens, num_q_heads, num_kv_heads, head_dim, page_size, device=DEVICE)
+    out = torch.empty_like(query)
+    _amd_pa_decode(out, query, key_cache, value_cache, context_lens, block_tables, sm_scale, num_splits=4)
+
+    ref = _amd_pa_decode_ref(query, key_cache, value_cache, context_lens, block_tables, sm_scale, num_q_heads,
+                             num_kv_heads, 1)
+    torch.testing.assert_close(out.float(), ref, atol=2e-2, rtol=2e-2)
+
+
 # =============================================================================
 # AMD HSTU Attention Tests (gfx950)
 # =============================================================================


### PR DESCRIPTION

## Summary

This PR improves the AMD TLX paged-attention decode workflow and page-16 performance:

1. Adds AITER's Gluon paged-decode kernel as a benchmark provider, including packed K/V cache conversion, preallocated reduction workspaces, and an `aiter/tlx speedup` result column.
2. Aggregates four independently mapped 16-token KV pages into one 64-token TLX compute tile. This amortizes page-table, synchronization, softmax, and MFMA overhead while reducing LDS bank conflicts. Other page sizes retain the existing async-load path.
3. Changes the benchmark geometry to `HEAD_DIM=64` and `PAGE_SIZE=16`, exercising the new aggregation specialization against AITER.

The aggregation handles arbitrary physical page mappings, split boundaries, partial pages, and query lengths 1-4. Additional correctness coverage targets context lengths around the 16-token page and 64-token tile boundaries.

## Performance

Measured on gfx950 with bf16, query length 1, 64 query heads, 8 KV heads, `HEAD_DIM=64`, and `PAGE_SIZE=16`. Values are effective HBM bandwidth in TB/s.

| Batch | Context | TLX Before | TLX After | TLX Speedup | AITER After | TLX After / AITER |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 8,192 | 0.2437 | 0.5115 | 2.10x | 0.2927 | **1.75x** |
| 8 | 8,192 | 1.8579 | 4.2636 | 2.29x | 4.0281 | **1.06x** |
| 32 | 8,192 | 2.4161 | 5.9838 | 2.48x | 10.7890 | 0.55x |
| 128 | 8,192 | 3.9033 | 6.9278 | 1.77x | 6.5177 | **1.06x** |
| 1 | 32,768 | 0.2799 | 0.6548 | 2.34x | 1.3958 | 0.47x |
| 8 | 32,768 | 1.6099 | 4.7578 | 2.96x | 4.6442 | **1.02x** |
| 32 | 32,768 | 1.8607 | 5.7958 | 3.11x | 10.3045 | 0.56x |
| 8 | 131,072 | 1.7397 | 5.0479 | 2.90x | 5.1137 | 0.99x |

`TLX After / AITER` greater than `1.0x` means TLX is faster. TLX improves by **1.77x-3.11x** over its previous implementation and is faster than AITER on four of the eight tested shapes; the 131K case is approximately tied at `0.99x`.

For the profiled `HEAD_DIM=128`, batch 8, context 8192 case, aggregation reduced:

- Partition-kernel latency from approximately `81.84 us` to `60.92 us`, a `1.34x` improvement.
- SQ cycles to `0.54x` of baseline.
- Total waits to `0.27x` of baseline.
- LDS bank conflicts to `0.31x` of baseline.

## Implementation Notes

The original TLX kernel used the physical KV page as its compute tile. With `PAGE_SIZE=16`, each 16-token page independently incurred a block-table lookup, K/V load and synchronization, QK/PV computation, online-softmax update, and barrier.

The new specialization gathers four logical page-table entries into a 64-token tile, stages the gathered K/V values through LDS, and performs one 64-wide QK/softmax/PV update. Physical pages do not need to be contiguous.

AMD's current direct-to-LDS lowering cannot async-copy a gathered pointer tensor or target a strided `local_slice`. The aggregated path therefore uses `tl.load` followed by `tlx.local_store`. The existing async-load implementation remains in use for other page sizes.

## Test Plan

```bash
pytest -q third_party/tlx/tutorials/testing/test_correctness.py::test_amd_pa_decode -v
pytest -q third_party/tlx/tutorials/testing/test_correctness.py::test_amd_pa_decode_page16_tile_boundaries -v
python third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py --version tlx aiter --qlens 1
```

The existing paged-decode suite passes all eight query-length/split combinations. Boundary coverage for contexts `15`, `16`, `17`, `63`, `64`, and `65` also passes, as does the generic page-64 path.

