### PR TITLE
 [AutoWS] [CLC] [Tile-Scheduler] Support Multi-CTA in CLC (#2284)

### DIFF
--- a/docs/design/triton-clc-tile-scheduler.md
+++ b/docs/design/triton-clc-tile-scheduler.md
@@ -2,14 +2,16 @@
 
 Triton Cluster Launch Control (CLC) tile scheduler.
 
-Status: **frontend + full lowering landed (Stages 1–4), single-CTA. Runs both
-without WS and under AutoWS (Stage 3 fused into the run-once/broadcast pass).**
+Status: **frontend + full lowering landed (Stages 1–4), including explicit
+`ctas_per_cga` clusters. Runs both without WS and under AutoWS (Stage 3 fused
+into the run-once/broadcast pass).**
 
 ## Motivation
 
 Cluster Launch Control (CLC) is a Blackwell (SM100+) hardware feature for
-dynamic persistent kernels. The grid is launched with one cluster per tile
-(over-subscribed relative to the SM count). A CTA that finishes early issues
+dynamic persistent kernels. The grid is launched with one CTA per logical tile
+and is over-subscribed relative to the SM count. With `ctas_per_cga`, adjacent
+CTA coordinates are grouped into clusters. A cluster that finishes early issues
 `clusterlaunchcontrol.try_cancel`, which atomically cancels a *pending*
 (not-yet-launched) cluster and hands the caller that cluster's program id — i.e.
 it steals the pending tile's work. This load-balances better than a static
@@ -35,8 +37,45 @@ design adds a **core Triton (`tl.`) scheduler** that hides all of that.
   (`warp_specialize=False`); WS is an orthogonal, later concern.
 - **Minimal, opaque API.** The kernel author never sees a buffer, barrier,
   phase, or the `try_cancel`/`wait` split.
-- **Single CTA only (for now).** Multi-cluster / multi-CTA is not yet supported;
-  the materialization pass rejects `num-ctas > 1`. Multi-CTA is future work.
+- **CUDA-style explicit clusters.** `ctas_per_cga` is supported: every CTA has
+  its own program id, but the CLC reservation is collective for the physical
+  cluster. Triton's separate `num_ctas > 1` program-id model remains unsupported.
+
+## PTX cluster grouping contract
+
+Clustered CLC correctness follows from the PTX ISA contract, not from a software
+reservation convention:
+
+- [`clusterlaunchcontrol.try_cancel`](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-clusterlaunchcontrol-try-cancel)
+  atomically cancels the launch of a *cluster* that has not started running.
+  Two successful requests therefore cannot claim the same pending cluster or
+  split its CTAs between requesters.
+- The `multicast::cluster::all` qualifier delivers the response and completion
+  notification to every CTA in the requesting cluster. Triton emits the
+  instruction only from cluster rank zero; other CTAs wait on their local
+  completion barriers.
+- [`clusterlaunchcontrol.query_cancel`](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-clusterlaunchcontrol-query-cancel)
+  exposes `get_first_ctaid`, the first CTA coordinate of the canceled cluster.
+- PTX [`.reqnctapercluster`](https://docs.nvidia.com/cuda/parallel-thread-execution/#performance-tuning-directives-reqnctapercluster)
+  specifies the required cluster dimensions emitted for `ctas_per_cga`.
+- The PTX [`%cluster_ctarank`](https://docs.nvidia.com/cuda/parallel-thread-execution/#special-registers-cluster-ctarank)
+  and [`%cluster_nctaid`](https://docs.nvidia.com/cuda/parallel-thread-execution/#special-registers-cluster-nctaid)
+  special registers define the CTA's linear rank and cluster dimensions.
+  Triton delinearizes the PTX-defined X-major rank and adds that local
+  coordinate to `first_ctaid`, reconstructing a distinct program id for each
+  member.
+
+For example, `grid=(8,)` with `ctas_per_cga=(2,1,1)` creates the pending
+clusters `{0,1}`, `{2,3}`, `{4,5}`, and `{6,7}`. If two requesters receive
+`first_ctaid=4` and `first_ctaid=6`, their member CTAs process `{4,5}` and
+`{6,7}` respectively. Request order is nondeterministic, but PTX atomic cluster
+cancellation keeps each pair intact. Triton does not implement another software
+reservation queue.
+
+The grid is the total CTA grid, not the number of clusters. Every grid dimension
+must be divisible by its `ctas_per_cga` dimension, and every CTA must have valid
+cooperative work. Inactive padded CTAs are unsupported because they violate
+collective multi-CTA execution. All members must reach `advance()` uniformly.
 
 ## API
 
@@ -61,9 +100,10 @@ while sched.is_valid():              # more work to steal?
 There is intentionally **no `try_cancel` in the API.** Fetching the next tile
 *is* `advance`; the async issue/wait split (issue early, wait late, to overlap
 the CLC latency with compute) is a compiler optimization done during lowering,
-not something the user expresses. Problem-level "invalid/jagged tile" handling is
-just ordinary user control flow (a bounds `if` around the compute) — it is not a
-scheduler concept.
+not something the user expresses. In single-CTA mode, problem-level
+"invalid/jagged tile" handling is ordinary user control flow. Clustered mode
+requires divisible tile geometry; a bounds guard must not make a cluster member
+inactive or prevent it from reaching `advance()`.
 
 ## Frontend representation
 
@@ -202,8 +242,8 @@ pending cluster, and diverge → deadlock.
 *Enabling WS:* like the dynamic-persistent atomic kernel, WS is requested by
 `tl.range(..., warp_specialize=True)` on the inner K-loop (with `use_meta_ws`);
 the outer persistent `scf.while` is auto-cloned per partition and the CLC fetch
-is broadcast here. The grid launches one cluster per tile so there are pending
-clusters to steal.
+is broadcast here. The grid launches one CTA per logical tile; `ctas_per_cga`
+groups those CTAs into pending clusters that can be stolen.
 
 Primary scheme:
 
@@ -253,19 +293,27 @@ only handles the CLC-response completion barrier local to the producer.
 Materialization (producer partition, depth-1):
 
 1. Allocate the response buffer (`memdesc<2xi64>`) and one **completion mbarrier**
-   at function scope; init / inval.
+   at function scope; init / inval. For explicit clusters, also allocate an
+   **empty mbarrier** on which all CTAs arrive after consuming a response.
 2. `clc_try_cancel_async` → `ttng.clc_try_cancel(resp, bar)` + `barrier_expect(bar, 16)`.
 3. `clc_read %tok` → `wait_barrier(bar, phase)` + `ttng.clc_load_result(resp)` +
    `ttng.clc_is_canceled` (→ `isValid`) + `ttng.clc_get_program_id` (→ x/y/z).
 
-#### Phase handling (one-sided channel)
+#### Phase handling and clustered reuse
 
-The CLC response is written by hardware (`try_cancel`) and read by `clc_read` —
-there is only the **"full" (data-ready) side** of a channel; there is no "empty"
-(buffer-free) side, because the single response buffer is reused each iteration
-and reuse is naturally program-ordered (the next iteration's issue at the loop-body
-top follows this iteration's read at the bottom, in the same partition). So a
-single completion mbarrier suffices, and only its phase must be tracked.
+In single-CTA mode, the CLC response is a one-sided channel: program order
+ensures the response is read before the next iteration reuses its buffer, so only
+the full (data-ready) completion mbarrier is needed.
+
+With `ctas_per_cga`, program order within one CTA does not prevent rank zero
+from starting the next request before peer CTAs have consumed the multicast
+response. Materialization therefore adds an empty mbarrier initialized with the
+physical cluster size. After a successful `clc_read`, every CTA arrives on rank
+zero's empty barrier through a remote view. Before the next request, only rank
+zero waits on its local empty barrier. The first wait uses the opposite phase
+and passes immediately; subsequent waits prevent response-buffer reuse until
+all cluster members have finished. The final failed cancellation skips the
+remote arrivals because no later request will reuse the buffer.
 
 **Require the phase to be a loop-carried variable, toggled before each advance.**
 Materialization adds an `i32`/`i1` phase iter_arg to the persistent `scf.while`,
@@ -367,7 +415,8 @@ requires drain-on-exit because the CLC claim is destructive.
   `third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSAtomicBroadcast.cpp`.
   Wired into the NVIDIA Blackwell `make_ttgir` — split + hoist before WS,
   materialize after; the AutoWS broadcast runs inside WS.
-- **Restriction:** single CTA only — `clc-materialize` errors on `num-ctas > 1`.
+- **Restriction:** explicit `ctas_per_cga` clusters are supported, while
+  Triton's distinct `num_ctas > 1` program-id model remains unsupported.
 - **Tests:** `python/test/unit/language/test_triton_clc.py` (frontend IR checks +
   non-WS Blackwell execution + materialized-TTGIR) and, in
   `test_tutorial09_warp_specialization.py`,
@@ -377,7 +426,7 @@ requires drain-on-exit because the CLC claim is destructive.
 
 ## Future work
 
-- Multi-cluster / multi-CTA support (lift the single-CTA restriction).
+- Support Triton's `num_ctas > 1` cluster-level program-id model.
 - Multi-stage prefetch (`depth > 1`) with drain-on-exit (loop-carried token).
 - Cross-basic-block hoist / unification in Stage 2.
 - Channel optimizations: broadcast-and-decode-per-partition; a dedicated

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -284,20 +284,24 @@ def TritonNvidiaGPUCLCHoistPass : Pass<"triton-nvidia-gpu-clc-hoist", "mlir::Mod
 }
 
 def TritonNvidiaGPUCLCMaterializePass : Pass<"triton-nvidia-gpu-clc-materialize", "mlir::ModuleOp"> {
-  let summary = "Materialize the CLC token form into mbarrier ops (single-CTA only)";
+  let summary = "Materialize the CLC token form into response and reuse barriers";
 
   let description = [{
     Stage 4 of the CLC tile-scheduler lowering. Materializes each
     `clc_try_cancel_async` / `clc_read` pair into a response buffer + completion
-    mbarrier: the issue becomes `barrier_expect` + `clc_try_cancel`, the read
+    mbarrier. Explicit clusters also get an empty-barrier rendezvous that
+    prevents reuse until every CTA consumes the multicast. The issue becomes
+    `barrier_expect` + `clc_try_cancel`, and the read
     becomes `wait_barrier` + `clc_load_result` + `clc_is_canceled` /
     `clc_get_program_id`, with a loop-carried, per-iteration-toggled phase.
-    Supports a single CTA only; multi-cluster / multi-CTA is rejected.
+    Supports single-CTA and explicit ctas_per_cga program-id semantics;
+    Triton's num-ctas > 1 program-id model is rejected.
   }];
 
   let dependentDialects = [
     "mlir::triton::gpu::TritonGPUDialect",
     "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+    "mlir::triton::nvgpu::NVGPUDialect",
     "mlir::arith::ArithDialect",
     "mlir::scf::SCFDialect"
   ];

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CLCLowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CLCLowering.cpp
@@ -10,14 +10,17 @@
 //   Stage 4 (clc-materialize):  token form -> response buffer + completion
 //                               mbarrier + low-level try_cancel/expect (issue)
 //                               and wait/load/decode (read), with a
-//                               loop-carried, per-iteration-toggled phase.
+//                               loop-carried phase. Explicit clusters also get
+//                               an empty barrier that guards response reuse.
 //
 // Stage 3 (AutoWS handling) is intentionally NOT here; it lands in a follow-up
-// branch and slots between Stage 2 and Stage 4. Single-CTA only for now
-// (multi-cluster / multi-CTA is rejected in clc-materialize).
+// branch and slots between Stage 2 and Stage 4. The CUDA-style ctas_per_cga
+// path is supported because it keeps num-ctas == 1 and assigns a distinct
+// program id to each CTA. Triton's num-ctas > 1 path remains unsupported.
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "third_party/nvidia/include/Dialect/NVGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -40,6 +43,13 @@ namespace {
 // A CLC response is 16 bytes; the low-level ops require a rank-1 memdesc of
 // exactly 2 x i64 (see verifyCLCResultMemdesc).
 constexpr int kClcResponseBytes = 16;
+
+int getExplicitClusterSize(ModuleOp mod) {
+  if (ttg::TritonGPUDialect::getNumCTAs(mod) != 1)
+    return 1;
+  auto dims = ttg::TritonGPUDialect::getClusterDims(mod);
+  return dims[0] * dims[1] * dims[2];
+}
 
 Value createClcResponseAlloc(OpBuilder &b, Location loc) {
   MLIRContext *ctx = b.getContext();
@@ -101,14 +111,17 @@ struct CLCHoistPass
 };
 
 //===--------------------------------------------------------------------===//
-// Stage 4 - materialize the token form into mbarrier ops (single-CTA).
+// Stage 4 - materialize the token form into mbarrier ops.
 //===--------------------------------------------------------------------===//
 struct CLCMaterializePass
     : public impl::TritonNvidiaGPUCLCMaterializePassBase<CLCMaterializePass> {
   void runOnOperation() override {
     ModuleOp mod = getOperation();
 
-    // Single-CTA only for now: reject multi-cluster / multi-CTA.
+    // Triton's num-ctas path gives one program id to the whole cluster. CLC
+    // currently supports either a single CTA or the CUDA-style ctas_per_cga
+    // path, where num-ctas stays 1 and ttg.cluster-dim-* describes the physical
+    // cluster whose CTAs each have their own program id.
     if (ttg::TritonGPUDialect::getNumCTAs(mod) != 1) {
       bool hasCLC = false;
       mod.walk([&](Operation *op) {
@@ -116,9 +129,9 @@ struct CLCMaterializePass
           hasCLC = true;
       });
       if (hasCLC) {
-        mod.emitError("CLC tile scheduler currently supports a single CTA only "
-                      "(num-ctas == 1); multi-cluster / multi-CTA is not yet "
-                      "implemented");
+        mod.emitError("CLC tile scheduler does not support Triton's num-ctas "
+                      "cluster semantics; use num-ctas == 1, optionally with "
+                      "explicit ctas_per_cga cluster dimensions");
         return signalPassFailure();
       }
       return;
@@ -145,6 +158,7 @@ struct CLCMaterializePass
     Location loc = read.getLoc();
     OpBuilder b(whileOp);
     Type i32 = b.getI32Type();
+    int clusterSize = getExplicitClusterSize(read->getParentOfType<ModuleOp>());
 
     // Loop-carried phase, initialized to 0.
     Value zero =
@@ -155,10 +169,17 @@ struct CLCMaterializePass
 
     // Response buffer + completion mbarrier, allocated before the loop. The
     // barrier ops take a single-buffer view of the (1-deep) barrier allocation.
+    // Explicit clusters also use a second barrier to rendezvous before reuse.
     b.setInsertionPoint(newLoop);
     Value resp = createClcResponseAlloc(b, loc);
     Value barAlloc = createBarrierAlloc(newLoop, /*numBarriers=*/1);
     Value bar = createSingleBufferView(b, barAlloc, 0);
+    Value emptyBar;
+    if (clusterSize > 1) {
+      Value emptyBarAlloc =
+          createBarrierAlloc(newLoop, /*numBarriers=*/1, clusterSize);
+      emptyBar = createSingleBufferView(b, emptyBarAlloc, 0);
+    }
 
     // Forward the phase from the before-region into the after-region and read
     // it back as the wait phase.
@@ -169,25 +190,54 @@ struct CLCMaterializePass
     condOp.getArgsMutable().append(phaseBefore);
 
     // Materialize the issue: barrier_expect + clc_try_cancel.
-    {
-      OpBuilder ib(issue);
-      Value pred = arith::ConstantIntOp::create(ib, issue.getLoc(), /*value=*/1,
-                                                /*width=*/1);
-      BarrierExpectOp::create(ib, issue.getLoc(), bar, kClcResponseBytes, pred);
-      CLCTryCancelOp::create(ib, issue.getLoc(), resp, bar);
+    OpBuilder ib(issue);
+    if (emptyBar) {
+      // The first wait passes immediately because an initialized mbarrier has
+      // phase 0. Later waits block until every CTA has consumed the previous
+      // multicast response and arrived on the lead CTA's empty barrier.
+      Value rank =
+          mlir::triton::nvgpu::ClusterCTAIdOp::create(ib, issue.getLoc(), i32);
+      Value zero = arith::ConstantIntOp::create(ib, issue.getLoc(), 0, 32);
+      Value isLeader = arith::CmpIOp::create(
+          ib, issue.getLoc(), arith::CmpIPredicate::eq, rank, zero);
+      Value one = arith::ConstantIntOp::create(ib, issue.getLoc(), 1, 32);
+      Value emptyPhase =
+          arith::XOrIOp::create(ib, issue.getLoc(), phaseAfter, one);
+      WaitBarrierOp::create(ib, issue.getLoc(), emptyBar, emptyPhase, isLeader);
     }
+    Value pred = arith::ConstantIntOp::create(ib, issue.getLoc(), /*value=*/1,
+                                              /*width=*/1);
+    BarrierExpectOp::create(ib, issue.getLoc(), bar, kClcResponseBytes, pred);
+    CLCTryCancelOp::create(ib, issue.getLoc(), resp, bar);
 
     // Materialize the read: wait_barrier + clc_load_result + decode.
-    {
-      OpBuilder rb(read);
-      WaitBarrierOp::create(rb, loc, bar, phaseAfter);
-      Value clcResult = CLCLoadResultOp::create(rb, loc, resp);
-      Value isValid = CLCIsCanceledOp::create(rb, loc, clcResult);
-      Value x = CLCGetProgramIdOp::create(rb, loc, clcResult, 0);
-      Value y = CLCGetProgramIdOp::create(rb, loc, clcResult, 1);
-      Value z = CLCGetProgramIdOp::create(rb, loc, clcResult, 2);
-      read->replaceAllUsesWith(ValueRange{isValid, x, y, z});
+    OpBuilder rb(read);
+    WaitBarrierOp::create(rb, loc, bar, phaseAfter);
+    Value clcResult = CLCLoadResultOp::create(rb, loc, resp);
+    Value isValid = CLCIsCanceledOp::create(rb, loc, clcResult);
+    Value x = CLCGetProgramIdOp::create(rb, loc, clcResult, 0);
+    Value y = CLCGetProgramIdOp::create(rb, loc, clcResult, 1);
+    Value z = CLCGetProgramIdOp::create(rb, loc, clcResult, 2);
+    if (emptyBar) {
+      // Remote mbarrier waits are illegal, so all CTAs arrive on rank zero's
+      // empty barrier and only rank zero waits on its local view above. Skip
+      // the final arrival when cancellation failed because the loop exits and
+      // the response storage will not be reused.
+      // TODO: Represent this response-buffer release with an explicit op that
+      // links resp and emptyBar, then let ProxyFenceInsertion place the fence.
+      FenceAsyncSharedOp::create(rb, loc, /*bCluster=*/false);
+      Value zero = arith::ConstantIntOp::create(rb, loc, 0, 32);
+      auto emptyBarTy = cast<ttg::MemDescType>(emptyBar.getType());
+      auto remoteBarTy = ttg::MemDescType::get(
+          emptyBarTy.getShape(), emptyBarTy.getElementType(),
+          emptyBarTy.getEncoding(),
+          SharedClusterMemorySpaceAttr::get(rb.getContext()),
+          emptyBarTy.getMutableMemory(), emptyBarTy.getAllocShape());
+      Value remoteEmptyBar =
+          MapToRemoteBufferOp::create(rb, loc, remoteBarTy, emptyBar, zero);
+      ArriveBarrierOp::create(rb, loc, remoteEmptyBar, /*count=*/1, isValid);
     }
+    read->replaceAllUsesWith(ValueRange{isValid, x, y, z});
     read->erase();
     issue->erase();
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -30,5 +30,6 @@ add_triton_library(TritonNvidiaGPUTransforms
   TritonNvidiaGPUIR
   TritonInstrumentTransforms
   TritonInstrumentIR
+  NVGPUIR
   MLIRTransformUtils
 )

--- a/python/test/unit/language/test_triton_clc.py
+++ b/python/test/unit/language/test_triton_clc.py
@@ -4,7 +4,7 @@ CLC is a Blackwell (SM100+) feature. The scheduler (`tl.clc_tile_scheduler`)
 emits a single high-level, barrier-free op (`ttng.clc_advance`) into the initial
 TTIR; the TTGIR pipeline then lowers it in stages: split into the async-token
 form (`clc_try_cancel_async` + `clc_read`), hoist the issue for overlap, and
-materialize the token into the completion mbarrier (single-CTA only).
+materialize the token into completion and clustered-reuse mbarriers.
 
 Two kinds of tests:
 - IR-shape tests on the initial TTIR (target-independent, no GPU).
@@ -67,6 +67,25 @@ def _clc_count_kernel(counts_ptr, num_tiles):
     while sched.is_valid():
         tid = sched.tile_id[0]
         tl.atomic_add(counts_ptr + tid, 1, mask=tid < num_tiles)
+        sched = sched.advance()
+
+
+@triton.jit
+def _clc_cluster_count_kernel(counts_ptr, steals_ptr, delay_ptr, grid_x: tl.constexpr, grid_y: tl.constexpr):
+    sched = tl.clc_tile_scheduler()
+    initial_x = tl.program_id(0)
+    initial_y = tl.program_id(1)
+    initial_z = tl.program_id(2)
+    while sched.is_valid():
+        pid_x, pid_y, pid_z = sched.tile_id
+        linear_pid = pid_x + grid_x * (pid_y + grid_y * pid_z)
+        tl.atomic_add(counts_ptr + linear_pid, 1)
+        # clc_try_cancel is hoisted above the body. Keep this cluster resident
+        # long enough for the asynchronous request to cancel pending work.
+        for _ in tl.static_range(64):
+            tl.atomic_add(delay_ptr, 1)
+        is_stolen = (pid_x != initial_x) | (pid_y != initial_y) | (pid_z != initial_z)
+        tl.atomic_add(steals_ptr, 1, mask=is_stolen)
         sched = sched.advance()
 
 
@@ -149,6 +168,28 @@ def test_clc_scheduler_visits_each_tile_once(num_tiles):
 
 
 @requires_blackwell
+@pytest.mark.parametrize(
+    "grid,cluster",
+    [
+        ((8192, 1, 1), (2, 1, 1)),
+        ((2048, 2, 2), (2, 2, 2)),
+    ],
+)
+def test_clc_cluster_scheduler_visits_each_tile_once(grid, cluster):
+    # The grid is deliberately much larger than the machine so at least one
+    # pending physical cluster is canceled and processed by a running cluster.
+    num_tiles = grid[0] * grid[1] * grid[2]
+    counts = torch.zeros(num_tiles, device="cuda", dtype=torch.int32)
+    steals = torch.zeros(1, device="cuda", dtype=torch.int32)
+    delay = torch.zeros(1, device="cuda", dtype=torch.int32)
+    _clc_cluster_count_kernel[grid](counts, steals, delay, grid[0], grid[1], ctas_per_cga=cluster, launch_cluster=True)
+    counts = counts.cpu()
+    assert counts.min().item() == 1, "some clustered tile was never claimed"
+    assert counts.max().item() == 1, "some clustered tile was claimed more than once"
+    assert steals.item() > 0, "test grid did not exercise a successful cluster steal"
+
+
+@requires_blackwell
 @pytest.mark.parametrize("M, N, K", [(256, 256, 128), (512, 512, 256), (1000, 1000, 500)])
 def test_clc_gemm(M, N, K):
     torch.manual_seed(0)
@@ -177,3 +218,16 @@ def test_clc_materialized_ttgir():
         assert op not in ttgir, f"{op} should be lowered away by the TTGIR passes"
     for op in ("ttng.clc_try_cancel", "ttng.clc_load_result", "ttng.barrier_expect", "ttng.wait_barrier"):
         assert op in ttgir, f"expected {op} in the materialized TTGIR"
+
+
+@requires_blackwell
+def test_clc_cluster_materializes_multicast_request():
+    counts = torch.zeros(1024, device="cuda", dtype=torch.int32)
+    steals = torch.zeros(1, device="cuda", dtype=torch.int32)
+    delay = torch.zeros(1, device="cuda", dtype=torch.int32)
+    kernel = _clc_cluster_count_kernel[(1024, 1, 1)](counts, steals, delay, 1024, 1, ctas_per_cga=(2, 1, 1),
+                                                     launch_cluster=True)
+    ptx = kernel.asm["ptx"]
+    assert "multicast::cluster::all" in ptx
+    assert "mapa.shared::cluster" in ptx
+    assert "mbarrier.arrive.shared::cluster" in ptx

--- a/python/triton/language/schedule.py
+++ b/python/triton/language/schedule.py
@@ -182,13 +182,19 @@ _attach_tile_id(DynamicPersistent1DScheduler)
 class ClcTileScheduler(TileScheduler):
     """Cluster Launch Control (Blackwell SM100+) dynamic persistent schedule.
 
-    The grid is over-subscribed (one cluster per tile); a program that finishes
-    early cancels a pending cluster and steals its tile. The scheduler carries the
-    *decoded* current tile ``(is_valid, x, y, z)``: the seed is this program's
-    static launch id, and every later tile comes from a single high-level
+    The grid is over-subscribed with one CTA per logical tile. With
+    ``ctas_per_cga``, PTX groups adjacent CTA coordinates into indivisible
+    clusters: one request atomically cancels a pending cluster, and each member
+    derives its program id from the returned first CTA coordinate plus its local
+    cluster coordinate. The scheduler carries the *decoded* current tile
+    ``(is_valid, x, y, z)``: the seed is this program's static launch id, and
+    every later tile comes from a single high-level
     ``ttng.clc_advance`` op (the response buffer, mbarrier, phase, and issue/wait
     overlap are all materialized by a later compiler lowering pass). ``num_tiles_fn``
-    / ``tile_counter`` are ignored -- CLC termination is hardware-driven.
+    / ``tile_counter`` are ignored -- CLC termination is hardware-driven. Grid
+    dimensions and logical tile geometry must be divisible by
+    ``ctas_per_cga``; inactive padded CTAs are unsupported, and all members must
+    reach ``advance`` uniformly.
     """
     _valid: tl.tensor
     _x: tl.tensor

--- a/test/Conversion/clc_to_llvm.mlir
+++ b/test/Conversion/clc_to_llvm.mlir
@@ -29,6 +29,20 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 2 : i32, "ttg.cluster-dim-z" = 2 : i32} {
+  // CHECK-LABEL: clc_try_cancel_explicit_cluster
+  tt.func @clc_try_cancel_explicit_cluster(%result: !ttg.memdesc<2xi64, #shared0, #smem>, %mbar: !ttg.memdesc<1xi64, #shared0, #smem>) {
+    // CHECK: nvg.cluster_id
+    // CHECK: clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128
+    ttng.clc_try_cancel %result, %mbar : !ttg.memdesc<2xi64, #shared0, #smem>, !ttg.memdesc<1xi64, #shared0, #smem>
+    tt.return
+  }
+}
+
+// -----
+
+#shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: clc_load_result
   tt.func @clc_load_result(%result: !ttg.memdesc<2xi64, #shared0, #smem>) {
@@ -70,6 +84,50 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK-NEXT: %[[four:.*]] = llvm.mlir.constant(4 : i32)
     // CHECK-NEXT: llvm.sdiv %[[ctaid]], %[[four]] : i32
     %ctaid = ttng.clc_get_program_id %clcResult, x : i128 -> i32
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 3 : i32, "ttg.cluster-dim-z" = 4 : i32} {
+  // CHECK-LABEL: clc_get_program_id_x_explicit_cluster
+  tt.func @clc_get_program_id_x_explicit_cluster(%clcResult: i128) {
+    // CHECK: clusterlaunchcontrol.query_cancel.get_first_ctaid::x.b32.b128
+    // CHECK: nvg.cluster_id
+    // CHECK: llvm.urem
+    // CHECK: llvm.add
+    %ctaid = ttng.clc_get_program_id %clcResult, x : i128 -> i32
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 3 : i32, "ttg.cluster-dim-z" = 4 : i32} {
+  // CHECK-LABEL: clc_get_program_id_y_explicit_cluster
+  tt.func @clc_get_program_id_y_explicit_cluster(%clcResult: i128) {
+    // CHECK: clusterlaunchcontrol.query_cancel.get_first_ctaid::y.b32.b128
+    // CHECK: nvg.cluster_id
+    // CHECK: llvm.udiv
+    // CHECK: llvm.urem
+    // CHECK: llvm.add
+    %ctaid = ttng.clc_get_program_id %clcResult, y : i128 -> i32
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 3 : i32, "ttg.cluster-dim-z" = 4 : i32} {
+  // CHECK-LABEL: clc_get_program_id_z_explicit_cluster
+  tt.func @clc_get_program_id_z_explicit_cluster(%clcResult: i128) {
+    // CHECK: clusterlaunchcontrol.query_cancel.get_first_ctaid::z.b32.b128
+    // CHECK: nvg.cluster_id
+    // CHECK: llvm.udiv
+    // CHECK: llvm.urem
+    // CHECK: llvm.add
+    %ctaid = ttng.clc_get_program_id %clcResult, z : i128 -> i32
     tt.return
   }
 }

--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt -split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm --verify-diagnostics %s| FileCheck %s
+// RUN: triton-opt -split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm=compute-capability=100 --verify-diagnostics %s| FileCheck %s
 
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
@@ -282,6 +282,29 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     %2 = ttg.local_alloc : () -> !ttg.memdesc<1xui128, #shared, #smem, mutable>
     ttng.async_clc_try_cancel %1, %2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// The core Triton CLC scheduler materializes clc_try_cancel after barrier
+// allocation. Its multicast completion has the same cluster-init requirement.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+  // CHECK-LABEL: @core_clc_try_cancel_bar_init
+  tt.func public @core_clc_try_cancel_bar_init() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %bars = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %bar = ttg.memdesc_index %bars[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    // CHECK: mbarrier.init.shared::cta.b64
+    // CHECK: nvvm.cluster.arrive.relaxed {aligned}
+    // CHECK: nvvm.cluster.wait {aligned}
+    // CHECK: clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %result = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    ttng.clc_try_cancel %result, %bar : !ttg.memdesc<2xi64, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -878,7 +878,7 @@ class CUDABackend(BaseBackend):
             # CLC tile scheduler (Stages 1 & 2): split ttng.clc_advance into the
             # async-token form and hoist the issue for compute/CLC overlap. This
             # runs before warp specialization; the token is materialized into the
-            # completion mbarrier after WS (add_clc_materialize below).
+            # completion/reuse mbarriers after WS (add_clc_materialize below).
             nvidia.passes.ttnvgpuir.add_clc_split(pm)
             nvidia.passes.ttnvgpuir.add_clc_hoist(pm)
             if knobs.nvidia.use_llm_schedule:
@@ -943,8 +943,8 @@ class CUDABackend(BaseBackend):
             # hoist again and allow hoisting out of if statements
             passes.ttgpuir.add_hoist_tmem_alloc(pm, True)
             # CLC tile scheduler (Stage 4): materialize the async-token form into
-            # the response buffer + completion mbarrier (single-CTA only). Runs
-            # after warp specialization.
+            # the response buffer + completion mbarrier. Explicit clusters also
+            # get a reuse rendezvous. Runs after warp specialization.
             nvidia.passes.ttnvgpuir.add_clc_materialize(pm)
             nvidia.passes.ttnvgpuir.add_remove_tmem_tokens(pm)
             # 2-CTA: Insert cross-CTA sync AFTER all WS passes.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -43,6 +43,28 @@ namespace ttng = mlir::triton::nvidia_gpu;
 namespace ttg = mlir::triton::gpu;
 
 namespace {
+
+struct PhysicalClusterInfo {
+  SmallVector<int, 3> dims;
+  int size;
+  bool hasPerCTAProgramIds;
+};
+
+// num-ctas describes Triton's logical/layout cluster model. ctas_per_cga keeps
+// num-ctas == 1 and records the physical CUDA cluster in ttg.cluster-dim-*.
+// Keep those concepts separate: changing lookupNumCTAs would alter layout and
+// program-id semantics throughout the compiler.
+PhysicalClusterInfo getPhysicalClusterInfo(Operation *op) {
+  ModuleOp mod = op->getParentOfType<ModuleOp>();
+  assert(mod && "expected CLC op inside a module");
+  int numCTAs = ttg::TritonGPUDialect::getNumCTAs(mod);
+  SmallVector<int, 3> dims = ttg::TritonGPUDialect::getClusterDims(mod);
+  int explicitSize = dims[0] * dims[1] * dims[2];
+  if (explicitSize > 1)
+    return {std::move(dims), explicitSize, numCTAs == 1};
+  return {{numCTAs, 1, 1}, numCTAs, false};
+}
+
 Value getElectWarp0OrThread0(const NVIDIA::TargetInfo &targetInfo,
                              TritonLLVMOpBuilder &b) {
   if (targetInfo.getComputeCapability() >= 90) {
@@ -693,16 +715,17 @@ struct CLCTryCancelOpConversion
     // Use elect predicate - only one thread should issue CLC
     Value pred = LLVM::NVIDIA::createElectPredicateWarp0(loc, rewriter);
 
-    auto numCTAs = ttg::lookupNumCTAs(op);
-    if (numCTAs > 1) {
+    PhysicalClusterInfo cluster = getPhysicalClusterInfo(op);
+    if (cluster.size > 1) {
       TritonLLVMOpBuilder b(loc, rewriter);
-      auto clusterCtaId = targetInfo->getClusterCTAId(rewriter, loc);
+      auto clusterCtaId =
+          triton::nvgpu::ClusterCTAIdOp::create(rewriter, loc, i32_ty);
       pred = b.and_(pred, b.icmp_eq(clusterCtaId, b.i32_val(0)));
     }
 
     std::string ptxAsm = "@$2 clusterlaunchcontrol.try_cancel.async.shared::cta"
                          ".mbarrier::complete_tx::bytes";
-    if (numCTAs > 1)
+    if (cluster.size > 1)
       ptxAsm += ".multicast::cluster::all";
     ptxAsm += ".b128 [$0], [$1];";
 
@@ -826,14 +849,30 @@ struct CLCGetProgramIdOpConversion
     Value result =
         ptxBuilder.launch(rewriter, loc, i32_ty, /*hasSideEffects=*/false);
 
-    // Convert ctaid to clusterid, which is the real program id
-    // Note that all cluster CTAs are distributed in the X dim
-    if (op.getDim() == ProgramIDDim::X) {
-      auto numCTAs = ttg::lookupNumCTAs(op);
-      if (numCTAs > 1) {
-        TritonLLVMOpBuilder b(loc, rewriter);
-        result = b.sdiv(result, b.i32_val(numCTAs));
-      }
+    PhysicalClusterInfo cluster = getPhysicalClusterInfo(op);
+    if (cluster.hasPerCTAProgramIds) {
+      // CLC returns the first CTA coordinate of the canceled cluster. Under
+      // ctas_per_cga, every CTA is a distinct Triton program, so reconstruct
+      // this CTA's coordinate from the X-major linear cluster rank.
+      TritonLLVMOpBuilder b(loc, rewriter);
+      Value rank = triton::nvgpu::ClusterCTAIdOp::create(rewriter, loc, i32_ty);
+      int axis = static_cast<int>(op.getDim());
+      int stride = 1;
+      for (int i = 0; i < axis; ++i)
+        stride *= cluster.dims[i];
+      Value localCoord = rank;
+      if (stride > 1)
+        localCoord = b.udiv(localCoord, b.i32_val(stride));
+      if (cluster.dims[axis] > 1)
+        localCoord = b.urem(localCoord, b.i32_val(cluster.dims[axis]));
+      else
+        localCoord = b.i32_val(0);
+      result = b.add(result, localCoord);
+    } else if (op.getDim() == ProgramIDDim::X && cluster.size > 1) {
+      // Triton's num-ctas model assigns one program id to the whole 1-D
+      // cluster, so preserve the existing ctaid -> clusterid conversion.
+      TritonLLVMOpBuilder b(loc, rewriter);
+      result = b.sdiv(result, b.i32_val(cluster.size));
     }
 
     rewriter.replaceOp(op, result);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -350,6 +350,14 @@ private:
       llvm::SetVector<Value> bars;
       bars.insert(asyncCLCTryCancelOp.getMbarAlloc());
       return bars;
+    } else if (auto clcTryCancelOp = llvm::dyn_cast<ttng::CLCTryCancelOp>(op)) {
+      // The core Triton CLC scheduler also multicasts its response and
+      // completion signal when an explicit physical cluster is configured.
+      // All CTAs must finish initializing their local completion barriers
+      // before the lead CTA can issue the request.
+      llvm::SetVector<Value> bars;
+      bars.insert(clcTryCancelOp.getMbarrier());
+      return bars;
     } else if (auto tcgen5CommitOp = llvm::dyn_cast<ttng::TCGen5CommitOp>(op)) {
       // As of now, there're only three sources to have a tcgen05.commit
       // instruction:


### PR DESCRIPTION
Summary:
Adds support for Multi-CTA in CLC by updating the PTX APIs to group the entire cluster together.


Differential Revision: D113075815

Pulled By: njriasan


