### PR TITLE
[nightly] file an issue when the wheel build/publish errors out

### DIFF
--- a/.github/workflows/nightly-fbtriton.yml
+++ b/.github/workflows/nightly-fbtriton.yml
@@ -120,3 +120,34 @@ jobs:
       event_name: "schedule"
       run_attempt: "${{ github.run_attempt }}"
       summary: "No commit in the walked window had all four required checks green as of the cut."
+
+  # A commit was selected (status == 'ship') but the wheel build or the publish
+  # step errored out — e.g. a compiler error that the GCC-built required checks
+  # miss but the Clang wheel build catches. Files/updates one issue per broken
+  # commit (title keyed on the selected SHA), with an auto-computed suspect-PR
+  # list from the last green nightly.
+  report-build-failure:
+    needs: [select, build, publish]
+    if: >-
+      always() && needs.select.outputs.status == 'ship' &&
+      (needs.build.result == 'failure' || needs.publish.result == 'failure')
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    uses: ./.github/workflows/report-nightly-failure.yml
+    with:
+      issue_title: "Nightly fbtriton: wheel build/publish failed for ${{ needs.select.outputs.sha }}"
+      normalized_failure_id: "nightly-fbtriton-build-failure"
+      workflow_name: "Nightly fbtriton"
+      job_name: "build"
+      run_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      ref: "refs/heads/main"
+      sha: "${{ needs.select.outputs.sha }}"
+      event_name: "schedule"
+      run_attempt: "${{ github.run_attempt }}"
+      summary: >-
+        The wheel build or publish job failed for selected commit
+        ${{ needs.select.outputs.sha }} (version ${{ needs.select.outputs.version }}).
+        See the run log for the build error (often a Clang-only compiler error that
+        the GCC-built required checks do not catch).


### PR DESCRIPTION
## What

Adds a `report-build-failure` job to the Nightly fbtriton workflow that files (or updates) a tracking issue when a selected commit's wheel **build** or **publish** job errors out.

## Why

The nightly only opened an issue for the `nogreen` selection case. When a commit *was* selected (`status == 'ship'`) but the wheel build then failed, it errored out silently with no ticket. This is exactly what happened on 2026-07-21: a **Clang-only** compiler error (`-Werror,-Wswitch` on `DescriptorReduceKind::NONE`) broke all four wheel jobs, but the required selection gates all build with **GCC** and were green, so the break slipped through selection and was never ticketed.

## How

The new job reuses the existing `report-nightly-failure.yml` filer:
- `needs: [select, build, publish]` with `if: always() && status == 'ship' && (build or publish failed)`.
- Keyed on the **selected** SHA, so each broken commit gets one idempotent issue and the reusable workflow's suspect-PR computation (`last-green-nightly..bad_sha`) points at the culprit range automatically.
- No `platform` input, so GPU deep-bisection is skipped (this catches CPU compile breaks); the ranked suspect list is still produced.

## Note / follow-up

Because `build` is a reusable-workflow call, this job can't scrape the exact compiler error line into the issue body — it passes a descriptive summary plus the run URL (whose annotations show the error), consistent with the existing `nogreen` path. A `steps:`-based log-scraping job could add the literal error line later if desired.

Authored with Claude.