### PR TITLE
[TLX][AMD] Pipeline page-64 decode and tune splits

### DIFF
--- a/third_party/tlx/tutorials/amd_pa_decode.py
+++ b/third_party/tlx/tutorials/amd_pa_decode.py
@@ -108,11 +108,10 @@ def _pa_decode_partition_kernel(
     k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), Kc.dtype.element_ty, BUFFER_DEPTH)
     v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), Vc.dtype.element_ty, BUFFER_DEPTH)
 
-    for pidx in tl.range(start_page, end_page, PAGES_PER_TILE):
-        slot = ((pidx - start_page) // PAGES_PER_TILE) % BUFFER_DEPTH
-        k_view = tlx.local_view(k_buf, slot)
-        v_view = tlx.local_view(v_buf, slot)
-        if PAGES_PER_TILE == 4:
+    if PAGES_PER_TILE == 4:
+        for pidx in tl.range(start_page, end_page, PAGES_PER_TILE):
+            k_view = tlx.local_view(k_buf, 0)
+            v_view = tlx.local_view(v_buf, 0)
             logical_page = pidx + offs_n // PAGE_SIZE
             safe_page = tl.minimum(logical_page, end_page - 1)
             physical = tl.load(BlockTables + seq * stride_bt_s + safe_page * stride_bt_p)
@@ -126,26 +125,68 @@ def _pa_decode_partition_kernel(
             tl.debug_barrier()
             kt = tlx.local_load(tlx.local_trans(k_view))
             v = tlx.local_load(v_view)
-        else:
-            physical = tl.load(BlockTables + seq * stride_bt_s + pidx * stride_bt_p)
-            k_ptrs = (Kc + physical * stride_kc_b + kv_head * stride_kc_h + offs_p[:, None] * stride_kc_p +
-                      offs_d[None, :] * stride_kc_d)
-            v_ptrs = (Vc + physical * stride_vc_b + kv_head * stride_vc_h + offs_p[:, None] * stride_vc_p +
-                      offs_d[None, :] * stride_vc_d)
-            tok_k = tlx.async_load(k_ptrs, k_view)
-            tok_v = tlx.async_load(v_ptrs, v_view)
-            tlx.async_load_commit_group([tok_k, tok_v])
+
+            qk = tl.dot(q, kt)
+            kt_abs = pidx * PAGE_SIZE + offs_n
+            vis = ((kt_abs[None, :] < end_page * PAGE_SIZE) &
+                   (kt_abs[None, :] <= (ctx_len - QLEN + m_qpos[:, None])))
+            qk = tl.where(vis, qk * QK_SCALE, float("-inf"))
+            m_ij = tl.max(qk, 1)
+            m_new = tl.maximum(m_i, m_ij)
+            p = tl.math.exp2(qk - m_new[:, None])
+            alpha = tl.math.exp2(m_i - m_new)
+            l_i = l_i * alpha + tl.sum(p, 1)
+            acc = acc * alpha[:, None] + tl.dot(p.to(v.dtype), v)
+            m_i = m_new
+            tl.debug_barrier()
+    elif start_page < end_page:
+        physical = tl.load(BlockTables + seq * stride_bt_s + start_page * stride_bt_p)
+        k_ptrs = (Kc + physical * stride_kc_b + kv_head * stride_kc_h + offs_p[:, None] * stride_kc_p +
+                  offs_d[None, :] * stride_kc_d)
+        v_ptrs = (Vc + physical * stride_vc_b + kv_head * stride_vc_h + offs_p[:, None] * stride_vc_p +
+                  offs_d[None, :] * stride_vc_d)
+        tok_k = tlx.async_load(k_ptrs, tlx.local_view(k_buf, 0))
+        tok_v = tlx.async_load(v_ptrs, tlx.local_view(v_buf, 0))
+        tlx.async_load_commit_group([tok_k, tok_v])
+
+        num_pages_this_split = end_page - start_page
+        for rel_page in tl.range(0, num_pages_this_split - 1, num_stages=0):
+            slot_cur = rel_page % 2
+            slot_nxt = (rel_page + 1) % 2
             wait_tok = tlx.async_load_wait_group(0)
-            kt = tlx.local_load(tlx.local_trans(k_view), token=wait_tok)
-            v = tlx.local_load(v_view, token=wait_tok)
+            kt = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, slot_cur)), token=wait_tok)
+            v = tlx.local_load(tlx.local_view(v_buf, slot_cur), token=wait_tok)
 
-        qk = tl.dot(q, kt)  # [M_POW2, BLOCK_N] fp32
-        kt_abs = pidx * PAGE_SIZE + offs_n  # absolute key index
-        split_end_token = end_page * PAGE_SIZE
-        vis = ((kt_abs[None, :] < split_end_token) &
-               (kt_abs[None, :] <= (ctx_len - QLEN + m_qpos[:, None])))
-        qk = tl.where(vis, qk * QK_SCALE, float("-inf"))
+            next_page = start_page + rel_page + 1
+            physical_next = tl.load(BlockTables + seq * stride_bt_s + next_page * stride_bt_p)
+            k_ptrs_next = (Kc + physical_next * stride_kc_b + kv_head * stride_kc_h +
+                           offs_p[:, None] * stride_kc_p + offs_d[None, :] * stride_kc_d)
+            v_ptrs_next = (Vc + physical_next * stride_vc_b + kv_head * stride_vc_h +
+                           offs_p[:, None] * stride_vc_p + offs_d[None, :] * stride_vc_d)
+            tok_k = tlx.async_load(k_ptrs_next, tlx.local_view(k_buf, slot_nxt))
+            tok_v = tlx.async_load(v_ptrs_next, tlx.local_view(v_buf, slot_nxt))
+            tlx.async_load_commit_group([tok_k, tok_v])
 
+            pidx = start_page + rel_page
+            qk = tl.dot(q, kt)
+            kt_abs = pidx * PAGE_SIZE + offs_n
+            qk = tl.where(kt_abs[None, :] <= (ctx_len - QLEN + m_qpos[:, None]), qk * QK_SCALE, float("-inf"))
+            m_ij = tl.max(qk, 1)
+            m_new = tl.maximum(m_i, m_ij)
+            p = tl.math.exp2(qk - m_new[:, None])
+            alpha = tl.math.exp2(m_i - m_new)
+            l_i = l_i * alpha + tl.sum(p, 1)
+            acc = acc * alpha[:, None] + tl.dot(p.to(v.dtype), v)
+            m_i = m_new
+
+        last_rel_page = num_pages_this_split - 1
+        wait_tok = tlx.async_load_wait_group(0)
+        kt = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, last_rel_page % 2)), token=wait_tok)
+        v = tlx.local_load(tlx.local_view(v_buf, last_rel_page % 2), token=wait_tok)
+        last_page = start_page + last_rel_page
+        qk = tl.dot(q, kt)
+        kt_abs = last_page * PAGE_SIZE + offs_n
+        qk = tl.where(kt_abs[None, :] <= (ctx_len - QLEN + m_qpos[:, None]), qk * QK_SCALE, float("-inf"))
         m_ij = tl.max(qk, 1)
         m_new = tl.maximum(m_i, m_ij)
         p = tl.math.exp2(qk - m_new[:, None])
@@ -153,7 +194,6 @@ def _pa_decode_partition_kernel(
         l_i = l_i * alpha + tl.sum(p, 1)
         acc = acc * alpha[:, None] + tl.dot(p.to(v.dtype), v)
         m_i = m_new
-        tl.debug_barrier()
 
     # Store the normalized partial output + base-2 lse for this split.
     has_kv = l_i > 0.0
@@ -229,18 +269,23 @@ def _next_pow2(x):
     return 1 << (max(1, x) - 1).bit_length()
 
 
-def get_num_splits(num_seqs, num_kv_heads, max_ctx_len=None, page_size=None, partition_size=256, cap=8):
-    """Pick split count purely from occupancy (mirrors aiter's
-    get_recommended_splits): enough KV splits to fill the CUs, capped at ``cap``.
+def get_num_splits(num_seqs, num_kv_heads, max_ctx_len=None, page_size=None, cap=128):
+    """Choose enough splits to expose CTA parallelism without creating empty work.
 
-    Deliberately independent of context length so the host launcher needs no
-    device->host sync. ``max_ctx_len``/``page_size`` are accepted for backward
-    compatibility but ignored; empty splits at short context are handled by the
-    kernel's ``has_kv`` guard and skipped in the reduce."""
+    When the caller knows the maximum context length on the host, target roughly
+    six CTAs per CU and cap the result by the physical page count. Otherwise,
+    preserve the original occupancy-only policy and its cap of eight splits to
+    avoid introducing a device-to-host synchronization in production callers.
+    """
     props = torch.cuda.get_device_properties(0)
     num_cu = props.multi_processor_count
-    by_occupancy = max(1, (num_cu * 2) // max(1, num_seqs * num_kv_heads))
-    return max(1, min(cap, by_occupancy))
+    base_programs = max(1, num_seqs * num_kv_heads)
+    if max_ctx_len is None or page_size is None:
+        return max(1, min(8, (num_cu * 2) // base_programs))
+
+    num_pages = max(1, (max_ctx_len + page_size - 1) // page_size)
+    splits_for_occupancy = _next_pow2((num_cu * 6 + base_programs - 1) // base_programs)
+    return max(1, min(cap, num_pages, splits_for_occupancy))
 
 
 def pa_decode_tlx(
@@ -253,6 +298,7 @@ def pa_decode_tlx(
     sm_scale,
     query_length=1,
     num_splits=None,
+    max_context_len=None,
     num_warps=4,
     waves_per_eu=0,
 ):
@@ -268,7 +314,7 @@ def pa_decode_tlx(
     assert query_length * query_group_size <= 64
 
     if num_splits is None:
-        num_splits = get_num_splits(num_seqs, num_kv_heads)
+        num_splits = get_num_splits(num_seqs, num_kv_heads, max_context_len, page_size)
     splits_pow2 = _next_pow2(num_splits)
 
     mid = torch.empty((num_seqs, num_kv_heads, num_splits, m_pow2, head_dim), dtype=torch.float32, device=query.device)

--- a/third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py
+++ b/third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py
@@ -40,9 +40,11 @@ def _pack_aiter_kv_cache(key_cache, value_cache):
     return key_cache, value_cache
 
 
-def _make_decode_fn(provider, out, q, kc, vc, ctx, bt, sm_scale, qlen):
+def _make_decode_fn(provider, out, q, kc, vc, ctx, bt, sm_scale, qlen, max_context_len):
     if provider == "tlx":
-        return lambda: _pa_decode_tlx(out, q, kc, vc, ctx, bt, sm_scale, query_length=qlen)
+        return lambda: _pa_decode_tlx(
+            out, q, kc, vc, ctx, bt, sm_scale, query_length=qlen, max_context_len=max_context_len
+        )
 
     from aiter.ops.triton.gluon.pa_decode_gluon import pa_decode_gluon
 
@@ -109,7 +111,7 @@ def create_benchmark(versions, qlen):
         q, kc, vc, ctx, bt = _build_inputs(BATCH, [N_CTX] * BATCH, NUM_Q_HEADS, NUM_KV_HEADS, HEAD_DIM, PAGE_SIZE,
                                            query_length=qlen, device=DEVICE, pool_pages=pool)
         out = torch.empty_like(q)
-        fn = _make_decode_fn(provider, out, q, kc, vc, ctx, bt, sm_scale, qlen)
+        fn = _make_decode_fn(provider, out, q, kc, vc, ctx, bt, sm_scale, qlen, N_CTX)
         quantiles = [0.5, 0.2, 0.8]
         ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles, warmup=100, rep=200)
 

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -1198,6 +1198,24 @@ def test_amd_pa_decode(num_splits, query_length):
 
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_pa_decode_page64_high_splits():
+    num_kv_heads, group = 2, 4
+    num_q_heads = num_kv_heads * group
+    head_dim, page_size = 64, 64
+    ctx_lens = [65, 257, 513]
+    sm_scale = 1.0 / math.sqrt(head_dim)
+
+    query, key_cache, value_cache, context_lens, block_tables = _amd_pa_decode_build_inputs(
+        len(ctx_lens), ctx_lens, num_q_heads, num_kv_heads, head_dim, page_size, device=DEVICE)
+    out = torch.empty_like(query)
+    _amd_pa_decode(out, query, key_cache, value_cache, context_lens, block_tables, sm_scale, num_splits=128)
+
+    ref = _amd_pa_decode_ref(query, key_cache, value_cache, context_lens, block_tables, sm_scale, num_q_heads,
+                             num_kv_heads, 1)
+    torch.testing.assert_close(out.float(), ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
 def test_amd_pa_decode_page16_tile_boundaries():
     num_kv_heads, group = 2, 4
     num_q_heads = num_kv_heads * group


### PR DESCRIPTION

## Summary

This change improves TLX paged-attention decode utilization for low-batch, long-context workloads.

The page-64 path previously allocated two LDS slots but loaded and immediately waited on every page, so no load/compute overlap occurred. The default split heuristic also capped the launch at eight splits, leaving too little phase-1 parallelism for shapes such as batch 1, context 32768.

This change:

- Uses host-known maximum context length to choose enough splits for GPU occupancy.
- Preserves the original occupancy-only, no-device-sync fallback when host context information is unavailable.
- Implements a two-slot page-64 async pipeline with a prologue, steady-state loop, and epilogue.
- Overlaps the next page's K/V load with the current page's QK, softmax, and PV computation.
- Keeps arbitrary physical page mappings by looking up every logical page independently in the block table.
- Keeps the existing page-16 four-page aggregation path intact.
- Adds page-64 correctness coverage for 128 splits, including empty and single-page splits.

## Performance

Measured on gfx950 with bf16, query length 1, `HEAD_DIM=64`, 64 query heads, and 8 KV heads. Values are effective HBM bandwidth in TB/s.

### PAGE_SIZE=64

| Batch | Context | TLX | AITER | TLX/AITER |
|---:|---:|---:|---:|---:|
| 1 | 8,192 | 0.4832 | 0.2999 | **1.61x** |
| 8 | 8,192 | 4.3634 | 3.9851 | **1.09x** |
| 32 | 8,192 | 7.2005 | 6.0268 | **1.19x** |
| 128 | 8,192 | 6.8970 | 6.5987 | **1.05x** |
| 1 | 32,768 | 2.2221 | 1.4364 | **1.55x** |
| 8 | 32,768 | 5.4493 | 4.3840 | **1.24x** |
| 32 | 32,768 | 7.1812 | 6.5245 | **1.10x** |
| 8 | 131,072 | 5.5324 | 5.0746 | **1.09x** |

TLX is faster than AITER on all eight tested page-64 shapes.

The original batch 1, context 32768 outlier improves from:

```text
Before: 0.6488 TB/s
After:  2.2221 TB/s
```

This is a **3.43x** improvement, and the optimized TLX path is **1.55x** faster than AITER on this shape.

### PAGE_SIZE=16 Regression Check

The page-16 implementation is not redesigned by this change, but the context-aware split policy applies when the benchmark supplies a host-known context length. The final regression sweep is:

| Batch | Context | TLX | AITER | TLX/AITER |
|---:|---:|---:|---:|---:|
| 1 | 8,192 | 0.4894 | 0.3670 | **1.33x** |
| 8 | 8,192 | 4.0920 | 3.4503 | **1.19x** |
| 32 | 8,192 | 7.2825 | 10.7892 | 0.68x |
| 128 | 8,192 | 6.7889 | 6.5154 | **1.04x** |
| 1 | 32,768 | 2.1788 | 1.3585 | **1.60x** |
| 8 | 32,768 | 4.7393 | 4.5699 | **1.04x** |
| 32 | 32,768 | 6.3072 | 10.3065 | 0.61x |
| 8 | 131,072 | 5.5347 | 5.1004 | **1.09x** |

## Implementation Notes

For batch 1, context 32768, page size 64, the old split policy selected eight splits. With eight KV heads, phase 1 launched only 64 CTAs, and each CTA processed 64 pages or 4096 KV tokens serially.

When the caller supplies a host-known maximum context length, the new policy targets approximately six CTAs per CU. It rounds the split count to a power of two and bounds it by both the physical page count and a maximum of 128 splits. Explicit `num_splits` remains the highest-priority override.

Callers that do not know the context length on the host retain the old occupancy-only policy capped at eight splits, avoiding an implicit device-to-host synchronization.

The page-64 async pipeline now follows this schedule:

1. Prologue: load the first page into LDS slot 0.
2. Steady state: wait for the current slot, issue the next page into the opposite slot, then compute the current page.
3. Epilogue: wait for and compute the final prefetched page.

Zero-page and single-page splits are handled explicitly. Logical pages continue to use independent block-table lookups, so the implementation does not assume physical page contiguity.

## Test Plan

```bash
pytest -q third_party/tlx/tutorials/testing/test_correctness.py -k pa_decode -v
python third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py --version tlx aiter --qlens 1
```

Results:

```text
10 paged-decode correctness tests passed
```

Correctness coverage includes:

- Query lengths 1-4.
- Existing split-K coverage.
- Page-64 execution with 128 splits.
- Empty and single-page splits.
- Partial final pages.
- Arbitrary physical page mappings.
- Regression coverage for the existing page-16 aggregation path.