### PR TITLE
[AMD][gfx950][TLX] a16w16: 128x128 tile for thin-N shapes (fill-based selection) (#2289)

### DIFF
--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
@@ -45,6 +45,44 @@ MIN_K = 2 * BLOCK_K  # pipeline prefetches 2 whole K-tiles; the rest goes to the
 KERNEL_NAME = "a16w16_8wave"
 
 
+def _swz_offset_bases(shape, contig_dim):
+    """Padded-shared swizzle offset bases for a 2D fp16 half-tile, derived from the
+    tile shape so both tile sizes share one path (no per-size branch).
+
+    `contig_dim` is the K-contiguous axis (0 or 1); its bits come first (fastest),
+    then the free axis contributes its high bits (>= bit 4) before its low bits --
+    the row/col permutation that makes the direct-to-LDS ds_reads bank-conflict-free
+    on the 128x64 / 64x128 halves. A 128-wide free axis simply carries the extra top
+    bit ([64,0] resp. [0,64]) that a 64-wide one omits. Used for both operands: the
+    a half-tile [HALF_M, BLOCK_K] has K on dim 1, the b half-tile [BLOCK_K, HALF_N]
+    has K on dim 0."""
+
+    def basis(dim, i):
+        return [1 << i, 0] if dim == 0 else [0, 1 << i]
+
+    free_dim = 1 - contig_dim
+    # log2 of each extent: int(n).bit_length() - 1 == floor(log2(n)), exact for the
+    # power-of-two tile extents here (integer math, no float log2).
+    cb = int(shape[contig_dim]).bit_length() - 1
+    fb = int(shape[free_dim]).bit_length() - 1
+    contig = [basis(contig_dim, i) for i in range(cb)]
+    free = ([basis(free_dim, i) for i in range(4, fb)] + [basis(free_dim, i) for i in range(min(4, fb))])
+    return contig + free
+
+
+# Swizzle offset bases per (square) tile size, computed once from the tile shape by
+# _swz_offset_bases. The @jit body can't call the generator (only constexpr module
+# values are referenceable inside @jit), so precompute the base lists here and build
+# the layout in-body, selecting by the constexpr tile size.
+# The bases are built for a half-tile (2x2 quadrant tiling): HALF = tile // 2.
+_HALF_256 = 256 // 2  # half of the 256x256 tile
+_HALF_128 = 128 // 2  # half of the 128x128 tile
+_A_BASES_256 = tl.constexpr(_swz_offset_bases([_HALF_256, BLOCK_K], 1))
+_A_BASES_128 = tl.constexpr(_swz_offset_bases([_HALF_128, BLOCK_K], 1))
+_B_BASES_256 = tl.constexpr(_swz_offset_bases([BLOCK_K, _HALF_256], 0))
+_B_BASES_128 = tl.constexpr(_swz_offset_bases([BLOCK_K, _HALF_128], 0))
+
+
 @triton.jit
 def a16w16_8wave(
     a_ptr,
@@ -122,20 +160,24 @@ def a16w16_8wave(
     HALF_N: tl.constexpr = BLOCK_N // 2
 
     # Four separate double-buffered LDS allocations — one per operand half-tile.
-    # Pin the *swizzled* padded_shared layout (row/col-permuted offset bases,
-    # identical to the Gluon reference) so the ds_reads feeding the MFMAs are
-    # bank-conflict-free. The default inferred padded layout ({order, shape})
+    # Pin the *swizzled* padded_shared layout (row/col-permuted offset bases) so
+    # the ds_reads feeding the MFMAs are bank-conflict-free. The default inferred
+    # padded layout ({order, shape})
     # conflicts on CDNA4 (measured 50M SQ_LDS_BANK_CONFLICT vs 0 for this one).
-    a_shared: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
-        [(512, 16)],
-        [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [16, 0], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0]],
-        [HALF_M, BLOCK_K],
-    )
-    b_shared: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
-        [(512, 16)],
-        [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [0, 16], [0, 32], [0, 64], [0, 1], [0, 2], [0, 4], [0, 8]],
-        [BLOCK_K, HALF_N],
-    )
+    # Swizzle bases are derived from the half-tile shape (_swz_offset_bases), so the
+    # 256x256 (128x64 / 64x128 halves) and thin-N 128x128 (64x64 halves) tiles share
+    # one path -- the 64-wide free axis just drops the top bit the 128-wide one adds.
+    # TODO(perf): the 64x64 swizzle still shows ~1.5M SQ_LDS_BANK_CONFLICT (10%
+    # LDS stall) vs 0 for 128x64. It can't be made conflict-free as a padded layout
+    # (direct-to-LDS needs pad interval >=512, but 64x64 lacks a high offset bit for
+    # the 4th MFMA row-bit); a swizzled_shared layout is conflict-free but slower
+    # (gfx950 has no direct-to-LDS scattering -> extra write swizzle). Net: this
+    # padded layout is the fastest option and still beats vendor -- the stall is the
+    # price of the cheap direct-to-LDS write on a small square tile.
+    a_bases: tl.constexpr = _A_BASES_256 if BLOCK_M == 256 else _A_BASES_128
+    b_bases: tl.constexpr = _B_BASES_256 if BLOCK_N == 256 else _B_BASES_128
+    a_shared: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases([(512, 16)], a_bases, [HALF_M, BLOCK_K])
+    b_shared: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases([(512, 16)], b_bases, [BLOCK_K, HALF_N])
     smem_a_top = tlx.local_alloc((HALF_M, BLOCK_K), tl.float16, 2, layout=a_shared)
     smem_a_bot = tlx.local_alloc((HALF_M, BLOCK_K), tl.float16, 2, layout=a_shared)
     smem_b_left = tlx.local_alloc((BLOCK_K, HALF_N), tl.float16, 2, layout=b_shared)
@@ -393,30 +435,54 @@ NUM_CU = 256  # gfx950 (CDNA4) compute units
 # starts to dominate (measured: Router SPLIT_K=16 (8 tiles/split) beats 32 (4)).
 MIN_KTILES_PER_SPLIT = 8
 
+# Tile candidates, largest first. The big tile is the tuned default; the smaller
+# one is used only when the big tile can't fill the CUs (see choose_tile).
+# choose_tile scans the fallbacks generically, so adding another tile here (e.g.
+# (64, 64)) needs no logic change; today only the 128x128 fallback is used.
+TILE_CANDIDATES = ((256, 256), (128, 128))
 
-def choose_split_k(M, N, K):
-    """Pick SPLIT_K from the shape: add K-parallelism only when the M/N tile grid
-    can't fill the CUs, and cap it so each split keeps enough K-tiles to stay
-    efficient and the reduce stays cheap. Returns 1 (no split-K) for shapes that
-    already fill the machine."""
-    grid_mn = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
-    if grid_mn >= NUM_CU:
-        return 1
+
+def _split_k_for(grid_mn, K):
+    """Largest power-of-two SPLIT_K keeping grid_mn*SK within one CU wave and each
+    split a whole, BLOCK_K-aligned chunk of >= MIN_KTILES_PER_SPLIT tiles."""
     min_ks = MIN_KTILES_PER_SPLIT * BLOCK_K
-    # TODO: only powers of two are considered here. That is optimal for pure-pow2
-    # K (e.g. 8192, 4096 -- every divisor is a power of two), but for K with odd
-    # factors (18432 = 2^11*3^2, 12800 = 2^9*5^2) a non-pow2 SPLIT_K can divide K
-    # and fill the CUs more precisely. Generalize to enumerate divisors of K (or
-    # K/BLOCK_K), or autotune SPLIT_K over a candidate set with this as the seed.
+    # TODO: only powers of two are considered. Optimal for pure-pow2 K (8192, 4096
+    # -- every divisor is pow2); for K with odd factors a non-pow2 SPLIT_K could
+    # divide K and fill more precisely. Generalize to enumerate divisors of K.
     sk = 1
     while True:
         nxt = sk * 2
         ks = K // nxt
-        # stop at one full wave of workgroups, and keep splits whole/aligned/efficient
         if grid_mn * nxt > NUM_CU or K % nxt != 0 or ks < min_ks or ks % BLOCK_K != 0:
             break
         sk = nxt
     return sk
+
+
+def choose_tile(M, N, K):
+    """Pick (BLOCK_M, BLOCK_N, SPLIT_K) by CU fill -- no shape hardcoding.
+
+    Prefer the tuned 256x256 tile. Fall back to the smaller 128x128 tile only when
+    the 256 grid cannot fill the CUs even after split-K (thin-N / small-tile-count
+    shapes, e.g. N=256): the 4x-denser MN grid then reaches full occupancy with a
+    smaller SPLIT_K (and a cheaper reduce). For shapes the big tile already fills,
+    the smaller tile only adds overhead, so it is never chosen there."""
+    bm, bn = TILE_CANDIDATES[0]
+    gmn = triton.cdiv(M, bm) * triton.cdiv(N, bn)
+    sk = _split_k_for(gmn, K)
+    best_fill = gmn * sk
+    if best_fill < NUM_CU:  # big tile under-fills even with split-K
+        for cbm, cbn in TILE_CANDIDATES[1:]:
+            g = triton.cdiv(M, cbm) * triton.cdiv(N, cbn)
+            s = _split_k_for(g, K)
+            if g * s > best_fill:  # smaller tile fills the machine better
+                bm, bn, sk, best_fill = cbm, cbn, s, g * s
+    return bm, bn, sk
+
+
+def choose_split_k(M, N, K):
+    """Back-compat: SPLIT_K for the auto-chosen tile."""
+    return choose_tile(M, N, K)[2]
 
 
 def matmul(a, b, SPLIT_K=None):
@@ -435,14 +501,16 @@ def matmul(a, b, SPLIT_K=None):
     M, K = a.shape
     K, N = b.shape
     if SPLIT_K is None:
-        SPLIT_K = choose_split_k(M, N, K)
+        BM, BN, SPLIT_K = choose_tile(M, N, K)
+    else:
+        BM, BN = BLOCK_M, BLOCK_N  # explicit SPLIT_K override keeps the default tile
     KS = K // SPLIT_K
     # Each split is a whole number of K-tiles, big enough for the 2-tile prologue.
     assert K % SPLIT_K == 0, f"K={K} must be divisible by SPLIT_K={SPLIT_K}"
     assert KS >= 2 * BLOCK_K, f"K/SPLIT_K={KS} must be at least {2 * BLOCK_K}"
     assert KS % BLOCK_K == 0, f"K/SPLIT_K={KS} must be a multiple of BLOCK_K={BLOCK_K} (split base alignment)"
     c = torch.empty((M, N), device=a.device, dtype=a.dtype)
-    GRID_MN = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
+    GRID_MN = triton.cdiv(M, BM) * triton.cdiv(N, BN)
     if SPLIT_K > 1:
         # fp32 workspace: partials are stored without a rounding step, so the
         # split-K result matches a single fp32-accumulated GEMM (an fp16 workspace
@@ -465,8 +533,8 @@ def matmul(a, b, SPLIT_K=None):
         b.stride(1),
         c.stride(0),
         c.stride(1),
-        BLOCK_M=BLOCK_M,
-        BLOCK_N=BLOCK_N,
+        BLOCK_M=BM,
+        BLOCK_N=BN,
         BLOCK_K=BLOCK_K,
         GROUP_SIZE_M=GROUP_SIZE_M,
         NUM_XCDS=NUM_XCDS,


### PR DESCRIPTION
Summary:

Thin-N / small-tile-count shapes can't fill the 256 CUs with the `256x256` tile
even after split-K -- e.g. `N=256` gives only 8 MN-tiles, and split-K is K-capped
at `SK16` (8 K-tiles/split) => 128 workgroups = 50% occupancy. The GEMM there is
both under-filled and split into short-K pieces.

This adds a general, fill-based tile chooser (`choose_tile`): prefer the tuned
`256x256` tile, and fall back to `128x128` only when the 256 grid can't reach one
full CU wave even with split-K. The 4x-denser MN grid then hits 100% occupancy
at a smaller `SPLIT_K` (and a cheaper reduce). The rule is purely occupancy-based
(`grid_mn * split_k < NUM_CU`) -- no shape hardcoding -- so it flips only the
shapes that need it (of the five model GEMMs, only `N=256`) and leaves every other
shape on its tuned `256x256` path untouched.

The kernel selects the swizzle bases by the (constexpr) tile size: the `64x64`
halves of the `128x128` tile use a mirrored swizzle. See the in-code TODO: that
`64x64` swizzle still has ~10% LDS bank-conflict stall (can't be made conflict-free
as a padded direct-to-LDS layout at this tile size), but it is still the fastest
option and beats vendor -- the win is occupancy, and the shape is fill-bound.

Measured on gfx950 (full GEMM+reduce, rocprofv3 median vs hipBLASLt):
`N=256` (2048x256x8192) goes 85% -> ~102%. All other shapes unchanged (`256x256`).
Correctness bit-exact / within fp32-reduce tolerance on all five shapes.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D113111412
