### PR TITLE
[AMD][gfx950][TLX] a16w16: keep the FP16 epilogue store coalesced (dwordx4) (#2290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1031,6 +1031,23 @@ TLX uses **CUDA-native cluster semantics** which differs from Triton's approach:
     tlx.dump_layout(v)                  # -> // cute: _64:_1
     ```
 
+- `x = tlx.require_layout(x, layout)` **[Hopper+, MI300+]**
+
+    Pin a register tensor `x`'s layout as a hard user anchor. `layout` is a
+    `tlx.layout(...)` (Shape:Stride) mapped to a `#linear` encoding and wrapped as
+    `#tlx.no_verify_layout(#tlx.user_layout(...))`. The inner `#tlx.user_layout`
+    carries `PinnedEncodingTrait`, so the downstream layout passes
+    (`tritongpu-coalesce`, `remove-layout-conversions`, AMD `optimize-epilogue`)
+    treat it as fixed and never rewrite it; the outer `#tlx.no_verify_layout` defers
+    operand-layout verification until the pin is peeled by
+    `TLXResolvePlaceholderLayouts` in `make_ttgir`. Example: pin an FP16 epilogue
+    `tl.store` to a coalesced layout so `OptimizeEpilogue` keeps the wide
+    `buffer_store_dwordx4` instead of narrowing it to the MMA-accumulator store,
+    without staging the value through LDS.
+
+    Pair with `tlx.assert_same_layout(x, layout)` (below) to statically verify the
+    pin survived to the final TTGIR.
+
 - `tlx.assert_same_layout(lhs, rhs)` **[Hopper+, MI300+]**
 
     Compile-time assertion that two layouts are equivalent after layout

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -69,6 +69,29 @@ static void pickDescriptorLoadStoreLayout(
   });
 }
 
+// A value pinned via tlx.require_layout(pin=True) carries a PinnedEncodingTrait
+// (#tlx.user_layout), possibly under a #tlx.no_verify_layout wrapper that
+// resolve-placeholder-layouts peels only after coalesce runs. Walk the TLX
+// wrapper chain to detect the pin (used for both a pinned load result and a
+// pinned store value operand).
+static bool hasRecursivePin(Attribute enc) {
+  for (Attribute e = enc; e && e.getDialect().getNamespace() == "tlx";) {
+    if (isa<PinnedEncodingTrait>(e))
+      return true;
+    Attribute inner;
+    e.walkImmediateSubElements(
+        [&](Attribute sub) {
+          if (!inner)
+            inner = sub;
+        },
+        [](Type) {});
+    if (!inner || inner == e)
+      break;
+    e = inner;
+  }
+  return false;
+}
+
 struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
   using impl::TritonGPUCoalesceBase<CoalescePass>::TritonGPUCoalesceBase;
 
@@ -128,10 +151,11 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
             dyn_cast<RankedTensorType>(localLoad.getResult().getType());
         if (!resultType)
           return;
-        // Respect a user-pinned result layout (PinnedEncodingTrait, e.g. TLX's
-        // #tlx.user_layout): don't coalesce it to a "full contiguity" blocked
-        // layout -- the user chose this register layout on purpose.
-        if (isa_and_nonnull<PinnedEncodingTrait>(resultType.getEncoding()))
+        // Respect a user-pinned result layout: don't coalesce it to a "full
+        // contiguity" blocked layout -- the user chose this register layout on
+        // purpose. The pin (PinnedEncodingTrait) may sit under a
+        // #tlx.no_verify_layout wrapper here (peeled later by resolve-placeholder).
+        if (hasRecursivePin(resultType.getEncoding()))
           return;
       } else {
         // Not a memory operation we handle
@@ -162,13 +186,38 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
             &getContext(), resultType.getShape(), sizePerThread, order,
             numWarps, threadsPerWarp, CGALayout);
       } else {
-        auto tensorType = cast<RankedTensorType>(ptr.getType());
-        CGAEncodingAttr cgaLayout = getCGALayout(tensorType.getEncoding());
-        SmallVector<int64_t> shapePerCTA = getShapePerCTA(tensorType);
-        auto layout = buildCoalescedEncoding(axisInfoAnalysis, curr, numWarps,
-                                             threadsPerWarp, cgaLayout,
-                                             shapePerCTA, maxVecBits);
-        layoutMap[curr] = layout;
+        // Respect a user-pinned store value layout. A tt.store has no result to
+        // carry a PinnedEncodingTrait, so the pin rides on the value operand,
+        // wrapped as #tlx.no_verify_layout(#tlx.user_layout): the outer no-verify
+        // defers store operand-layout verification until resolve-placeholder-layouts
+        // peels it, and it is still present here because coalesce runs before that
+        // pass. Find the pin (hasRecursivePin), then store in the peeled concrete
+        // layout instead of a freshly-coalesced one: convertDistributedOpEncoding
+        // then converts ptr/mask to match, the value's bridging convert folds away,
+        // and the user's chosen store layout survives to codegen (AMD
+        // OptimizeEpilogue leaves it alone since it is no longer a #blocked store).
+        Attribute pinned;
+        if (auto store = dyn_cast<triton::StoreOp>(curr)) {
+          if (auto vt =
+                  dyn_cast<RankedTensorType>(store.getValue().getType())) {
+            if (hasRecursivePin(vt.getEncoding())) {
+              Attribute concrete = triton::unwrapTlxWrappers(vt.getEncoding());
+              if (isa_and_nonnull<DistributedEncodingTrait>(concrete))
+                pinned = concrete;
+            }
+          }
+        }
+        if (pinned) {
+          layoutMap[curr] = pinned;
+        } else {
+          auto tensorType = cast<RankedTensorType>(ptr.getType());
+          CGAEncodingAttr cgaLayout = getCGALayout(tensorType.getEncoding());
+          SmallVector<int64_t> shapePerCTA = getShapePerCTA(tensorType);
+          auto layout = buildCoalescedEncoding(axisInfoAnalysis, curr, numWarps,
+                                               threadsPerWarp, cgaLayout,
+                                               shapePerCTA, maxVecBits);
+          layoutMap[curr] = layout;
+        }
       }
     });
 

--- a/python/test/unit/language/test_tlx_layout.py
+++ b/python/test/unit/language/test_tlx_layout.py
@@ -738,3 +738,44 @@ def test_buffer_load_to_local_infers_offset_layout_amd():
     # It lowers all the way to amdgcn (the direct-to-LDS width/alignment
     # requirements are met by the inferred offset layout).
     assert compiled.asm.get("amdgcn")
+
+
+# a16w16 epilogue-store pin: the coalesced #linear register layout the inter_wave
+# kernel pins on the FP16 store so AMD OptimizeEpilogue keeps buffer_store_dwordx4
+# (a [128, 128] fp16 quadrant on num_warps=8; each thread holds 8 contiguous N).
+_A16W16_STORE_SHAPE = ((16, 4, 8), (8, 4))
+_A16W16_STORE_STRIDE = ((8, 128, 512), (1, 4096))
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Need gfx950 (CDNA4)")
+def test_require_layout_pins_epilogue_store_amd():
+    """A store *value* pinned via tlx.require_layout survives coalesce /
+    remove-layout-conversions / optimize-epilogue as the exact coalesced #linear,
+    so the FP16 epilogue store stays a wide buffer_store_dwordx4 (the a16w16
+    scenario) instead of being narrowed to the MMA-accumulator layout. The
+    in-kernel tlx.assert_same_layout(c, L) compares final LinearLayouts and fails
+    compilation if the pin is dropped."""
+
+    @triton.jit
+    def kernel(a_ptr, b_ptr, c_ptr, K: tl.constexpr, L: tl.constexpr):
+        offs_m = tl.arange(0, 128)
+        offs_n = tl.arange(0, 128)
+        offs_k = tl.arange(0, K)
+        a = tl.load(a_ptr + offs_m[:, None] * K + offs_k[None, :])
+        b = tl.load(b_ptr + offs_k[:, None] * 128 + offs_n[None, :])
+        acc = tl.dot(a, b)  # MMA accumulator -> the store OptimizeEpilogue rewrites
+        c = tlx.require_layout(acc.to(tl.float16), L)  # pin the store value to L
+        tlx.assert_same_layout(c, L)  # fails compilation if the pin didn't survive
+        tl.store(c_ptr + offs_m[:, None] * 128 + offs_n[None, :], c)
+
+    L = tlx.layout(shape=_A16W16_STORE_SHAPE, stride=_A16W16_STORE_STRIDE)
+    a = torch.randn((128, 64), device=DEVICE, dtype=torch.float16)
+    b = torch.randn((64, 128), device=DEVICE, dtype=torch.float16)
+    c = torch.empty((128, 128), device=DEVICE, dtype=torch.float16)
+    compiled = kernel.warmup(a, b, c, 64, L, grid=(1, ), num_warps=8)
+    # assert_same_layout would have failed compilation if the pin were dropped; the
+    # epilogue store lowers to the wide coalesced dwordx4, not the narrow dwordx2
+    # fallback OptimizeEpilogue would otherwise produce.
+    amdgcn = compiled.asm["amdgcn"]
+    assert "buffer_store_dwordx4" in amdgcn
+    assert "buffer_store_dwordx2" not in amdgcn

--- a/test/TLX/coalesce-local-memory.mlir
+++ b/test/TLX/coalesce-local-memory.mlir
@@ -19,3 +19,40 @@ tt.func @local_load_coalesce(%arg0: !ttg.memdesc<128x64xf16, #shared, #smem>) ->
 }
 
 }
+
+// -----
+
+// A tt.store whose value is pinned via tlx.require_layout (wrapped
+// #tlx.no_verify_layout<#tlx.user_layout<...>>) keeps the user's layout through
+// coalesce: coalesce commits the store to the peeled concrete layout and converts
+// ptr/mask to match, instead of choosing its own (contiguity-coalesced) layout.
+#pinned = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#user = #tlx.user_layout<#pinned>
+#nv = #tlx.no_verify_layout<#user>
+// CHECK-DAG: #[[$PIN:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @pinned_store
+  // CHECK: tt.store {{.*}} : tensor<128x64x!tt.ptr<f16>, #[[$PIN]]>
+  tt.func @pinned_store(%ptr: tensor<128x64x!tt.ptr<f16>, #nv>, %val: tensor<128x64xf16, #nv>) {
+    tt.store %ptr, %val : tensor<128x64x!tt.ptr<f16>, #nv>
+    tt.return
+  }
+}
+
+// -----
+
+// A pinned local_load result is likewise not re-coalesced: coalesce leaves the
+// pinned layout in place (peeled later by resolve-placeholder-layouts).
+#pinned = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#user = #tlx.user_layout<#pinned>
+#nv = #tlx.no_verify_layout<#user>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @pinned_load
+  // CHECK: ttg.local_load {{.*}} -> tensor<128x64xf16, #tlx.no_verify_layout<{{.+}}>>
+  tt.func @pinned_load(%arg0: !ttg.memdesc<128x64xf16, #shared, #smem>) -> tensor<128x64xf16, #nv> {
+    %0 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf16, #shared, #smem> -> tensor<128x64xf16, #nv>
+    tt.return %0 : tensor<128x64xf16, #nv>
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
@@ -126,8 +126,17 @@ public:
     Value mask = stOp.getMask();
     auto ptrType = dyn_cast<RankedTensorType>(ptr.getType());
     auto valType = dyn_cast<RankedTensorType>(val.getType());
-    if (!ptrType || !valType ||
-        !isa<triton::gpu::BlockedEncodingAttr>(ptrType.getEncoding()) ||
+    if (!ptrType || !valType)
+      return mlir::failure();
+    // Respect a user-pinned store layout (PinnedEncodingTrait, e.g. TLX's
+    // #tlx.user_layout): the author chose this store layout deliberately, so do
+    // not rewrite it to the MMA accumulator layout. Mirrors Coalesce /
+    // RemoveLayoutConversions / OptimizeTMemLayouts, which already anchor on this
+    // trait (D112032532).
+    if (isa_and_nonnull<triton::gpu::PinnedEncodingTrait>(valType.getEncoding()) ||
+        isa_and_nonnull<triton::gpu::PinnedEncodingTrait>(ptrType.getEncoding()))
+      return mlir::failure();
+    if (!isa<triton::gpu::BlockedEncodingAttr>(ptrType.getEncoding()) ||
         !isa<triton::gpu::BlockedEncodingAttr>(valType.getEncoding()))
       return mlir::failure();
 

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -201,6 +201,27 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
         }
         return;
       }
+      // tt.store: value / ptr / mask must share one encoding
+      // (SameLoadStoreOperandsEncoding). If the value carries a user pin,
+      // propagate it to ptr/mask so make_ttir's verifier accepts the store
+      // without a per-op tolerance; concrete layouts resolve later in make_ttgir.
+      // Bridge (require_layout convert) the ptr/mask for this use only, leaving
+      // their producers (addptr / mask cmp, with their own same-encoding
+      // verifiers) untouched.
+      if (auto store = dyn_cast<::mlir::triton::StoreOp>(op)) {
+        SmallVector<Value> linked{store.getValue(), store.getPtr()};
+        if (store.getMask())
+          linked.push_back(store.getMask());
+        Attribute enc = findPlaceholder(linked, op);
+        if (enc) {
+          bridgeOrRetype(store.getPtr(), enc, op, /*operandIdx=*/0,
+                         /*forceBridge=*/true);
+          if (store.getMask())
+            bridgeOrRetype(store.getMask(), enc, op, /*operandIdx=*/2,
+                           /*forceBridge=*/true);
+        }
+        return;
+      }
       // scf.for: init / region iter-arg / yield operand / result of each
       // loop-carried value must share the encoding.
       if (auto forOp = dyn_cast<scf::ForOp>(op)) {

--- a/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
@@ -384,14 +384,32 @@ static bool containsUserLayout(Type type) {
 /// `slice<parent = #tlx.user_layout<...>>`) and inside a constant's `value`
 /// DenseElementsAttr type. Stripping only top-level result encodings would
 /// leave nested wrappers behind and produce inconsistent op types.
+// Recursively strip a chain of TLX wrapper attrs (user_layout / no_verify) down
+// to the concrete layout. AttrTypeReplacer applies each replacement only once
+// per matched attr, so a *nested* wrapper -- e.g.
+// no_verify<user_layout<no_verify<L>>>, produced when a require_layout store pin
+// also carries a tlx.assert_same_layout -- would keep an inner user_layout after
+// a single getLayout(), which the residual check below then flags as
+// "unresolved TLX user layout". Unwrapping the whole chain here resolves it
+// (wrappers nested inside ttg encodings are still reached by the replacer's own
+// sub-element recursion, which re-invokes this on the inner wrapper).
+static Attribute deepUnwrapTlxWrappers(Attribute attr) {
+  if (auto u = dyn_cast<UserLayoutAttr>(attr))
+    return deepUnwrapTlxWrappers(u.getLayout());
+  if (auto n = dyn_cast<NoVerifyLayoutAttr>(attr))
+    return deepUnwrapTlxWrappers(n.getLayout());
+  return attr;
+}
+
 static LogicalResult finalizeUserLayouts(ModuleOp moduleOp) {
   mlir::AttrTypeReplacer replacer;
-  replacer.addReplacement(
-      [](UserLayoutAttr wrapper) -> Attribute { return wrapper.getLayout(); });
+  replacer.addReplacement([](UserLayoutAttr wrapper) -> Attribute {
+    return deepUnwrapTlxWrappers(wrapper);
+  });
   // Defensively also strip any no-verify wrapper that reached this point (e.g.
   // nested under a user-layout that resolve-placeholder-layouts left in place).
   replacer.addReplacement([](NoVerifyLayoutAttr wrapper) -> Attribute {
-    return wrapper.getLayout();
+    return deepUnwrapTlxWrappers(wrapper);
   });
 
   moduleOp->walk([&](Operation *op) {

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -98,7 +98,8 @@ void init_triton_tlx_ir(py::module &&m) {
                                                         offsets);
            })
       .def("create_require_layout",
-           [](TritonOpBuilder &self, Value &v, Attribute &encoding) -> Value {
+           [](TritonOpBuilder &self, Value &v, Attribute &encoding,
+              bool pin) -> Value {
              Type newType;
              if (auto type = dyn_cast<ttg::MemDescType>(v.getType())) {
                // consider allocation type for subslice
@@ -111,14 +112,25 @@ void init_triton_tlx_ir(py::module &&m) {
                    type.getMemorySpace(), type.getMutableMemory(), allocShape);
                return self.create<tlx::RequireLayoutOp>(newType, v);
              } else if (auto type = dyn_cast<RankedTensorType>(v.getType())) {
-               Attribute tensorEncoding = tlx::wrapNoVerifyLayout(encoding);
+               // `pin`: wrap in #tlx.no_verify_layout(#tlx.user_layout) -- the
+               // #tlx.user_layout carries PinnedEncodingTrait so the requirement is
+               // honored as a hard anchor by Coalesce / RemoveLayoutConversions /
+               // OptimizeEpilogue (e.g. to pin an epilogue store's register layout),
+               // and the outer #tlx.no_verify_layout defers operand-layout
+               // verification until ResolvePlaceholderLayouts peels it (so a pinned
+               // store whose ptr/mask layouts don't yet match verifies fine). Non-pin
+               // is a soft requirement (#tlx.no_verify_layout only, e.g. dot operands).
+               Attribute tensorEncoding =
+                   pin ? tlx::wrapNoVerifyLayout(tlx::wrapUserLayout(encoding))
+                       : tlx::wrapNoVerifyLayout(encoding);
                newType = RankedTensorType::get(
                    type.getShape(), type.getElementType(), tensorEncoding);
                return self.create<tlx::RequireLayoutOp>(newType, v);
              } else {
                throw std::runtime_error("Unsupported type");
              }
-           })
+           },
+           py::arg("v"), py::arg("encoding"), py::arg("pin") = false)
       .def("create_release_layout",
            [](TritonOpBuilder &self, Value &v) -> Value {
              if (auto type = dyn_cast<RankedTensorType>(v.getType())) {

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -61,7 +61,7 @@ from .mem_ops import (
     subslice,
     tmem_copy,
 )
-from .mma_ops import async_dot, async_dot_scaled, async_dot_wait, tcgen05_commit
+from .mma_ops import async_dot, async_dot_scaled, async_dot_wait, require_layout, tcgen05_commit
 from .types import (
     async_token,
     buffered_tensor,
@@ -188,6 +188,7 @@ __all__ = [
     "async_dot",
     "async_dot_scaled",
     "async_dot_wait",
+    "require_layout",
     "tcgen05_commit",
     # utility
     "cluster_cta_rank",

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -4,6 +4,24 @@ from . import types as tlx
 from .utility import cuda_parse_arch
 
 
+@tl.builtin
+def require_layout(x, layout, _semantic=None):
+    """Pin a register tensor's layout as a hard user anchor.
+
+    ``layout`` is a ``tlx.layout(...)`` (Shape:Stride) mapped to a ``#linear``
+    encoding and wrapped as ``#tlx.user_layout`` (PinnedEncodingTrait), so the
+    downstream layout passes (tritongpu-coalesce, remove-layout-conversions, AMD
+    optimize-epilogue) treat it as fixed and never rewrite it. Unlike a plain
+    (no_verify) require_layout, this survives to Coalesce and lets you pin an
+    epilogue ``tl.store`` to a coalesced register layout *without* staging the
+    value through LDS.
+    """
+    layout = tl._unwrap_if_constexpr(layout)
+    enc = layout.to_ir(_semantic.builder, x.shape, x.dtype)
+    handle = _semantic.builder.create_require_layout(x.handle, enc, pin=True)
+    return tl.tensor(handle, x.type)
+
+
 def require_nv_mma_shared_layout(x: tlx.buffered_tensor, swizzled: bool, _builder=None, fp4Padded: bool = False):
     assert isinstance(x.type.layout, tlx.shared_layout_encoding), "input must be a shared tensor"
     rank = len(x.shape)

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
@@ -44,6 +44,14 @@ NUM_XCDS = 8
 MIN_K = 2 * BLOCK_K  # pipeline prefetches 2 whole K-tiles; the rest goes to the masked tail
 KERNEL_NAME = "a16w16_8wave"
 
+# Coalesced SIMD register layout for the [HALF_M, HALF_N] = [128, 128] fp16 quadrant
+# store (num_warps=8, warp_size=64): each thread holds 8 contiguous N elements ->
+# 128-bit buffer_store_dwordx4. Applied to the epilogue store via tlx.require_layout
+# so tritongpu-coalesce sets the store to this #linear layout and AMD
+# OptimizeEpilogue leaves it alone (it only rewrites #blocked stores) -- keeping the
+# wide coalesced store instead of the narrow MMA-accumulator (dwordx2) fallback.
+_C_STORE_SIMD_LAYOUT = tlx.layout(shape=((16, 4, 8), (8, 4)), stride=((8, 128, 512), (1, 4096)))
+
 
 def _swz_offset_bases(shape, contig_dim):
     """Padded-shared swizzle offset bases for a 2D fp16 half-tile, derived from the
@@ -385,14 +393,35 @@ def a16w16_8wave(
     if SPLIT_K == 1:
         # Direct store to C -- exact no-op vs the champion kernel.
         et = c_ptr.dtype.element_ty
-        tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_left[None, :], acc_tl.to(et),
-                 mask=m_top & n_left)
-        tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_left[None, :], acc_bl.to(et),
-                 mask=m_bot & n_left)
-        tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_right[None, :], acc_tr.to(et),
-                 mask=m_top & n_right)
-        tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_right[None, :], acc_br.to(et),
-                 mask=m_bot & n_right)
+        if HALF_M == 128 and HALF_N == 128:
+            # Pin each 128x128 quadrant to the coalesced SIMD #linear layout (no LDS
+            # staging) so OptimizeEpilogue keeps the wide dwordx4 store.
+            # _C_STORE_SIMD_LAYOUT is derived for the 128x128 quadrant, so it only
+            # applies to the 256x256 tile; a smaller tile (64x64 quadrant) uses a
+            # plain store.
+            L: tl.constexpr = _C_STORE_SIMD_LAYOUT
+            c_tl = tlx.require_layout(acc_tl.to(et), L)
+            # Static guard (no device code): the pin must survive coalesce /
+            # remove-layout-conversions / AMD optimize-epilogue so the store stays
+            # a wide dwordx4. Fails compilation if a future change drops the pin.
+            tlx.assert_same_layout(c_tl, L)
+            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_left[None, :],
+                     c_tl, mask=m_top & n_left)
+            tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_left[None, :],
+                     tlx.require_layout(acc_bl.to(et), L), mask=m_bot & n_left)
+            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_right[None, :],
+                     tlx.require_layout(acc_tr.to(et), L), mask=m_top & n_right)
+            tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_right[None, :],
+                     tlx.require_layout(acc_br.to(et), L), mask=m_bot & n_right)
+        else:
+            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_left[None, :],
+                     acc_tl.to(et), mask=m_top & n_left)
+            tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_left[None, :],
+                     acc_bl.to(et), mask=m_bot & n_left)
+            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_right[None, :],
+                     acc_tr.to(et), mask=m_top & n_right)
+            tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_right[None, :],
+                     acc_br.to(et), mask=m_bot & n_right)
     else:
         # Split-K: every split writes its fp32 partial into its workspace slice
         # (rows [split_id*M, split_id*M+M)). Mask stays in relative-M coords; the


### PR DESCRIPTION
Summary:

The FP16 epilogue store of the a16w16 GEMM lands as buffer_store_dwordx2 on the
tile-full (SPLIT_K=1) shapes: TritonAMDGPUOptimizeEpilogue rewrites the coalesced
#blocked store into the MMA-accumulator layout, and the wide permlane store
(chooseMfmaLikeStoreLayout) does not fire for this MFMA config, so it lands on the
narrow store (~1.5-3% slower than the coalesced dwordx4).

The fix keeps the store coalesced. It adds a general primitive --
tlx.require_layout(x, layout) -- that pins a register tensor's layout as a hard
user anchor, applied to the epilogue store so it stays a wide dwordx4. For a pin
the value is wrapped as #tlx.no_verify_layout(#tlx.user_layout(L)): the inner
#tlx.user_layout (PinnedEncodingTrait) survives to tritongpu-coalesce, which
commits the store to L, and AMD OptimizeEpilogue then leaves it alone (it only
rewrites #blocked stores); the outer #tlx.no_verify_layout defers operand-layout
verification until the TLX placeholder pass reconciles the store's ptr/mask to L
and peels the wrappers. This is explicit, per-store, source-level control (vs
globally disabling a pass).

Stacked on D113111412 (128x128 tile for thin-N). This diff drives the three
SPLIT_K=1 shapes; Router (N=256) is from the stacked 128-tile diff.

Review order:
- triton_tlx.cc: create_require_layout gains pin=; wraps a register requirement as
  #tlx.no_verify_layout(#tlx.user_layout(L)) -- user_layout is the hard anchor that
  survives to coalesce, no_verify defers verification until it is peeled.
- tlx/{mma_ops,__init__}.py: tlx.require_layout frontend builtin.
- Fixup.cpp (propagatePlaceholderLayouts): propagate a pinned tt.store value's
  placeholder to its ptr/mask so make_ttir's verifier accepts the store -- the same
  early reconcile this pass already does for elementwise / select / scf values.
- Coalesce.cpp: honor a pinned store *value* operand (tt.store has no result) and a
  pinned load *result*, via a shared tlxChainHasPin helper that peels the no_verify
  wrapper to find the pin.
- OptimizeEpilogue.cpp: skip a pinned (non-#blocked) store.
- a16w16/matmul_kernel.py: apply tlx.require_layout to the SPLIT_K==1 (256x256)
  store; the 128x128 tile (64x64 quadrant) keeps a plain store.
- doc/PlaceholderLayouts.md: document the tlx.require_layout frontend builtin
  (soft requirement vs pin=True hard anchor).
- test/TLX/coalesce-local-memory.mlir: lit tests that coalesce honors a pinned
  store value and a pinned load result.

Per review, this supersedes an earlier variant that deferred verification with a
tlxAwareTypesEqual comparator and reconciled the operands in a dedicated
PropagateLayout transform; both are dropped in favor of the no_verify wrapper +
the existing early placeholder-propagation fixup.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D113115691


