### PR TITLE
[TLX] 2-CTA Blackwell gemm without cta barrier (#2291)

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -699,6 +699,7 @@ def _process_tile_epilogue_inner(
     tmem_empty_bars,
     cur_tmem_buf,
     tmem_read_phase,
+    NUM_CTAS: tl.constexpr,
 ):
     """Process epilogue for a single tile."""
     mn_tile_id = tile_id if SPLIT_K == 1 else tile_id % num_mn_tiles
@@ -730,7 +731,10 @@ def _process_tile_epilogue_inner(
         tlx.barrier_wait(tmem_full_bars[buf_idx_0], tmem_read_phase)
         acc_sub = tlx.local_slice(acc_tmem_0, [0, 0 * slice_size], [BLOCK_M_SPLIT, slice_size])
         result = tlx.local_load(acc_sub)
-        tlx.barrier_arrive(tmem_empty_bars[buf_idx_0], 1)
+        if NUM_CTAS == 2:
+            tlx.barrier_arrive(tmem_empty_bars[buf_idx_0], 1, remote_cta_rank=0)
+        else:
+            tlx.barrier_arrive(tmem_empty_bars[buf_idx_0], 1)
         c = result.to(tlx.dtype_of(out_desc))
         c_smem = c_smem_buffers[0]
         tlx.local_store(c_smem, c)
@@ -745,7 +749,10 @@ def _process_tile_epilogue_inner(
         tlx.barrier_wait(tmem_full_bars[buf_idx_1], tmem_read_phase)
         acc_sub = tlx.local_slice(acc_tmem_1, [0, 0 * slice_size], [BLOCK_M_SPLIT, slice_size])
         result = tlx.local_load(acc_sub)
-        tlx.barrier_arrive(tmem_empty_bars[buf_idx_1], 1)
+        if NUM_CTAS == 2:
+            tlx.barrier_arrive(tmem_empty_bars[buf_idx_1], 1, remote_cta_rank=0)
+        else:
+            tlx.barrier_arrive(tmem_empty_bars[buf_idx_1], 1)
         c = result.to(tlx.dtype_of(out_desc))
         c_smem = c_smem_buffers[1]
         tlx.local_store(c_smem, c)
@@ -761,7 +768,10 @@ def _process_tile_epilogue_inner(
             # Group 0
             acc_sub = tlx.local_slice(acc_tmem_0, [0, slice_id * slice_size], [BLOCK_M_SPLIT, slice_size])
             result = tlx.local_load(acc_sub)
-            tlx.barrier_arrive(tmem_empty_bars[buf_idx_0], 1)
+            if NUM_CTAS == 2:
+                tlx.barrier_arrive(tmem_empty_bars[buf_idx_0], 1, remote_cta_rank=0)
+            else:
+                tlx.barrier_arrive(tmem_empty_bars[buf_idx_0], 1)
             c = result.to(tlx.dtype_of(out_desc))
             c_smem = c_smem_buffers[0]
             tlx.async_descriptor_store_wait(1)
@@ -776,7 +786,10 @@ def _process_tile_epilogue_inner(
             # Group 1
             acc_sub = tlx.local_slice(acc_tmem_1, [0, slice_id * slice_size], [BLOCK_M_SPLIT, slice_size])
             result = tlx.local_load(acc_sub)
-            tlx.barrier_arrive(tmem_empty_bars[buf_idx_1], 1)
+            if NUM_CTAS == 2:
+                tlx.barrier_arrive(tmem_empty_bars[buf_idx_1], 1, remote_cta_rank=0)
+            else:
+                tlx.barrier_arrive(tmem_empty_bars[buf_idx_1], 1)
             c = result.to(tlx.dtype_of(out_desc))
             c_smem = c_smem_buffers[1]
             tlx.async_descriptor_store_wait(1)
@@ -804,7 +817,10 @@ def _process_tile_epilogue_inner(
                     [BLOCK_M_SPLIT, slice_size],
                 )
                 result = tlx.local_load(acc_tmem_subslice)
-                tlx.barrier_arrive(tmem_empty_bars[buf_idx], 1)
+                if NUM_CTAS == 2:
+                    tlx.barrier_arrive(tmem_empty_bars[buf_idx], 1, remote_cta_rank=0)
+                else:
+                    tlx.barrier_arrive(tmem_empty_bars[buf_idx], 1)
                 c = result.to(tlx.dtype_of(out_desc))
                 c_smem = c_smem_buffers[(group_id * EPILOGUE_SUBTILE + slice_id) % 2]
                 tlx.async_descriptor_store_wait(1)
@@ -839,8 +855,6 @@ def _process_tile_mma_inner(
     tmem_write_phase,
     smem_accum_cnt,
     NUM_CTAS,
-    cta_bars,
-    pred_cta0,
     A_ROW_MAJOR: tl.constexpr = True,
     B_ROW_MAJOR: tl.constexpr = True,
 ):
@@ -871,16 +885,12 @@ def _process_tile_mma_inner(
             cur_barrier_idx = group_id * NUM_TMEM_BUFFERS + cur_tmem_buf
             tlx.barrier_wait(tmem_empty_bars[cur_barrier_idx], tmem_write_phase ^ 1)
 
-        # CTA0 waits for CTA0 and CTA1 to finish loading A and B before issuing dot op
-        if NUM_CTAS == 2:
-            tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
-            tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
-
         # Transpose SMEM buffers if inputs were column-major
         a_operand = tlx.local_trans(buffers_A[a_buf]) if not A_ROW_MAJOR else buffers_A[a_buf]
         b_operand = tlx.local_trans(buffers_B[buf]) if not B_ROW_MAJOR else buffers_B[buf]
 
-        # Perform MMA: use_acc=False for first K iteration (clears accumulator)
+        # Perform MMA: use_acc=False for first K iteration (clears accumulator).
+        # This helper only runs on CTA0 in 2-CTA mode.
         tlx.async_dot(
             a_operand,
             b_operand,
@@ -915,16 +925,11 @@ def _process_tile_mma_inner(
                 # Wait for this A subtile buffer to be loaded.
                 tlx.barrier_wait(A_smem_full_bars[a_buf], phase)
 
-            # CTA0 waits for CTA0 and CTA1 to finish loading A and B before issuing dot op
-            if NUM_CTAS == 2:
-                tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
-                tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
-
             # Transpose SMEM buffers if inputs were column-major
             a_operand = tlx.local_trans(buffers_A[a_buf]) if not A_ROW_MAJOR else buffers_A[a_buf]
             b_operand = tlx.local_trans(buffers_B[buf]) if not B_ROW_MAJOR else buffers_B[buf]
 
-            # Perform MMA: use_acc=True for remaining K iterations
+            # Perform MMA: use_acc=True for remaining K iterations.
             tlx.async_dot(
                 a_operand,
                 b_operand,
@@ -987,6 +992,8 @@ def _process_tile_producer_inner(
     BLOCK_M_SPLIT: tl.constexpr = BLOCK_SIZE_M // NUM_MMA_GROUPS
     offs_bn = pid_n * BLOCK_SIZE_N + cluster_cta_rank * (BLOCK_SIZE_N // NUM_CTAS)
     expected_bytes: tl.constexpr = dsize * BLOCK_SIZE_N * BLOCK_SIZE_K // NUM_CTAS
+    leader_only_mma: tl.constexpr = NUM_CTAS == 2
+    is_leader = cluster_cta_rank == 0
 
     local_k_tiles = k_tile_end - k_tile_start
 
@@ -1003,42 +1010,56 @@ def _process_tile_producer_inner(
             tlx.barrier_wait(A_smem_empty_bars[buf], phase ^ 1)
             # Both TMA loads contribute bytes to the same full barrier.
             a_expected_bytes: tl.constexpr = dsize * BLOCK_M_SPLIT * BLOCK_SIZE_K
-            tlx.barrier_expect_bytes(A_smem_full_bars[buf], expected_bytes + a_expected_bytes)
+            combined_bytes: tl.constexpr = expected_bytes + a_expected_bytes
+            if leader_only_mma:
+                tlx.barrier_expect_bytes(A_smem_full_bars[buf], combined_bytes * NUM_CTAS, pred=is_leader)
+            else:
+                tlx.barrier_expect_bytes(A_smem_full_bars[buf], combined_bytes)
             if not B_ROW_MAJOR:
                 tlx.async_descriptor_load(b_desc, buffers_B[buf], [offs_bn, offs_k], A_smem_full_bars[buf],
-                                          eviction_policy="evict_last")
+                                          eviction_policy="evict_last", two_ctas=leader_only_mma)
             else:
                 tlx.async_descriptor_load(b_desc, buffers_B[buf], [offs_k, offs_bn], A_smem_full_bars[buf],
-                                          eviction_policy="evict_last")
+                                          eviction_policy="evict_last", two_ctas=leader_only_mma)
 
             if not A_ROW_MAJOR:
                 tlx.async_descriptor_load(a_desc, buffers_A[buf], [offs_k, offs_am], A_smem_full_bars[buf],
-                                          eviction_policy="evict_last")
+                                          eviction_policy="evict_last", two_ctas=leader_only_mma)
             else:
                 tlx.async_descriptor_load(a_desc, buffers_A[buf], [offs_am, offs_k], A_smem_full_bars[buf],
-                                          eviction_policy="evict_last")
+                                          eviction_policy="evict_last", two_ctas=leader_only_mma)
         else:
             a0_buf = buf
             tlx.barrier_wait(A_smem_empty_bars[a0_buf], phase ^ 1)
-            tlx.barrier_expect_bytes(A_smem_full_bars[a0_buf], dsize * BLOCK_M_SPLIT * BLOCK_SIZE_K)
+            a_expected_bytes: tl.constexpr = dsize * BLOCK_M_SPLIT * BLOCK_SIZE_K
+            if leader_only_mma:
+                tlx.barrier_expect_bytes(A_smem_full_bars[a0_buf], a_expected_bytes * NUM_CTAS, pred=is_leader)
+            else:
+                tlx.barrier_expect_bytes(A_smem_full_bars[a0_buf], a_expected_bytes)
             if not A_ROW_MAJOR:
                 tlx.async_descriptor_load(a_desc, buffers_A[a0_buf], [offs_k, offs_am], A_smem_full_bars[a0_buf],
-                                          eviction_policy="evict_last")
+                                          eviction_policy="evict_last", two_ctas=leader_only_mma)
             else:
                 tlx.async_descriptor_load(a_desc, buffers_A[a0_buf], [offs_am, offs_k], A_smem_full_bars[a0_buf],
-                                          eviction_policy="evict_last")
+                                          eviction_policy="evict_last", two_ctas=leader_only_mma)
 
             a1_buf = NUM_SMEM_BUFFERS + buf
             tlx.barrier_wait(A_smem_empty_bars[a1_buf], phase ^ 1)
-            tlx.barrier_expect_bytes(B_smem_full_bars[buf], expected_bytes)
+            if leader_only_mma:
+                tlx.barrier_expect_bytes(B_smem_full_bars[buf], expected_bytes * NUM_CTAS, pred=is_leader)
+            else:
+                tlx.barrier_expect_bytes(B_smem_full_bars[buf], expected_bytes)
             if not B_ROW_MAJOR:
                 tlx.async_descriptor_load(b_desc, buffers_B[buf], [offs_bn, offs_k], B_smem_full_bars[buf],
-                                          eviction_policy="evict_last")
+                                          eviction_policy="evict_last", two_ctas=leader_only_mma)
             else:
                 tlx.async_descriptor_load(b_desc, buffers_B[buf], [offs_k, offs_bn], B_smem_full_bars[buf],
-                                          eviction_policy="evict_last")
+                                          eviction_policy="evict_last", two_ctas=leader_only_mma)
 
-            tlx.barrier_expect_bytes(A_smem_full_bars[a1_buf], dsize * BLOCK_M_SPLIT * BLOCK_SIZE_K)
+            if leader_only_mma:
+                tlx.barrier_expect_bytes(A_smem_full_bars[a1_buf], a_expected_bytes * NUM_CTAS, pred=is_leader)
+            else:
+                tlx.barrier_expect_bytes(A_smem_full_bars[a1_buf], a_expected_bytes)
             if not A_ROW_MAJOR:
                 tlx.async_descriptor_load(
                     a_desc,
@@ -1046,6 +1067,7 @@ def _process_tile_producer_inner(
                     [offs_k, offs_am + BLOCK_M_SPLIT],
                     A_smem_full_bars[a1_buf],
                     eviction_policy="evict_last",
+                    two_ctas=leader_only_mma,
                 )
             else:
                 tlx.async_descriptor_load(
@@ -1054,6 +1076,7 @@ def _process_tile_producer_inner(
                     [offs_am + BLOCK_M_SPLIT, offs_k],
                     A_smem_full_bars[a1_buf],
                     eviction_policy="evict_last",
+                    two_ctas=leader_only_mma,
                 )
 
         smem_accum_cnt += 1
@@ -1208,13 +1231,8 @@ def matmul_kernel_tma_ws_blackwell(
     # CTA pairs are placed along M dim
     if NUM_CTAS == 2:
         cluster_cta_rank = tlx.cluster_cta_rank()
-        pred_cta0 = cluster_cta_rank == 0
-        cta_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS * NUM_MMA_GROUPS,
-                                      arrive_count=2)  # CTA0 waits for CTA1's data before mma
     else:
         cluster_cta_rank = 0
-        pred_cta0 = False
-        cta_bars = None
 
     # allocate barriers - each subtile needs its own barriers
     # NUM_SMEM_BUFFERS barriers per subtile for synchronization
@@ -1227,12 +1245,13 @@ def matmul_kernel_tma_ws_blackwell(
         B_smem_full_bars = tlx.alloc_barriers(num_barriers=NUM_SMEM_BUFFERS, arrive_count=1)
     tmem_full_bars = tlx.alloc_barriers(num_barriers=NUM_TMEM_BUFFERS * NUM_MMA_GROUPS, arrive_count=1)
     # NUM_TMEM_BUFFERS (overlaps MMA and epilogue)
+    tmem_empty_arrivals: tl.constexpr = EPILOGUE_SUBTILE * NUM_CTAS
     if USE_WARP_BARRIER:
         tmem_empty_bars = tlx.alloc_warp_barrier(num_barriers=NUM_TMEM_BUFFERS * NUM_MMA_GROUPS, num_warps=4,
-                                                 num_arrivals=EPILOGUE_SUBTILE)
+                                                 num_arrivals=tmem_empty_arrivals)
     else:
         tmem_empty_bars = tlx.alloc_barriers(num_barriers=NUM_TMEM_BUFFERS * NUM_MMA_GROUPS,
-                                             arrive_count=EPILOGUE_SUBTILE)
+                                             arrive_count=tmem_empty_arrivals)
 
     # Each of the three async tasks consumes CLC responses on both cluster CTAs.
     clc_context = tlx.clc_create_context(num_consumers=3 * NUM_CTAS, num_stages=NUM_CLC_STAGES)
@@ -1307,6 +1326,7 @@ def matmul_kernel_tma_ws_blackwell(
                         tmem_empty_bars=tmem_empty_bars,
                         cur_tmem_buf=cur_tmem_buf,
                         tmem_read_phase=tmem_read_phase,
+                        NUM_CTAS=NUM_CTAS,
                     )
                     tmem_accum_cnt += 1
                 tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=NUM_CTAS == 2)
@@ -1353,30 +1373,41 @@ def matmul_kernel_tma_ws_blackwell(
 
                 # Skip tiles whose split has zero K-tiles
                 if SPLIT_K == 1 or k_tile_end > k_tile_start:
-                    cur_tmem_buf, tmem_write_phase = get_bufidx_phase(tmem_accum_cnt, NUM_TMEM_BUFFERS)
-                    smem_accum_cnt = _process_tile_mma_inner(
-                        k_tile_start=k_tile_start,
-                        k_tile_end=k_tile_end,
-                        NUM_SMEM_BUFFERS=NUM_SMEM_BUFFERS,
-                        NUM_MMA_GROUPS=NUM_MMA_GROUPS,
-                        NUM_TMEM_BUFFERS=NUM_TMEM_BUFFERS,
-                        buffers_A=buffers_A,
-                        buffers_B=buffers_B,
-                        tmem_buffers=tmem_buffers,
-                        A_smem_full_bars=A_smem_full_bars,
-                        B_smem_full_bars=B_smem_full_bars,
-                        A_smem_empty_bars=A_smem_empty_bars,
-                        tmem_full_bars=tmem_full_bars,
-                        cur_tmem_buf=cur_tmem_buf,
-                        tmem_empty_bars=tmem_empty_bars,
-                        tmem_write_phase=tmem_write_phase,
-                        smem_accum_cnt=smem_accum_cnt,
-                        NUM_CTAS=NUM_CTAS,
-                        cta_bars=cta_bars,
-                        pred_cta0=pred_cta0,
-                        A_ROW_MAJOR=A_ROW_MAJOR,
-                        B_ROW_MAJOR=B_ROW_MAJOR,
-                    )
+                    # In 2-CTA mode, only CTA0 issues the collaborative MMA. CTA1's
+                    # producer still loads its local operand slice, and cta_group::2
+                    # TMA completion routes readiness to CTA0's barriers. Skipping
+                    # the inner MMA loop on CTA1 avoids duplicating its address,
+                    # predicate, and wait bookkeeping.
+                    if NUM_CTAS == 1 or cluster_cta_rank == 0:
+                        cur_tmem_buf, tmem_write_phase = get_bufidx_phase(tmem_accum_cnt, NUM_TMEM_BUFFERS)
+                        smem_accum_cnt = _process_tile_mma_inner(
+                            k_tile_start=k_tile_start,
+                            k_tile_end=k_tile_end,
+                            NUM_SMEM_BUFFERS=NUM_SMEM_BUFFERS,
+                            NUM_MMA_GROUPS=NUM_MMA_GROUPS,
+                            NUM_TMEM_BUFFERS=NUM_TMEM_BUFFERS,
+                            buffers_A=buffers_A,
+                            buffers_B=buffers_B,
+                            tmem_buffers=tmem_buffers,
+                            A_smem_full_bars=A_smem_full_bars,
+                            B_smem_full_bars=B_smem_full_bars,
+                            A_smem_empty_bars=A_smem_empty_bars,
+                            tmem_full_bars=tmem_full_bars,
+                            cur_tmem_buf=cur_tmem_buf,
+                            tmem_empty_bars=tmem_empty_bars,
+                            tmem_write_phase=tmem_write_phase,
+                            smem_accum_cnt=smem_accum_cnt,
+                            NUM_CTAS=NUM_CTAS,
+                            A_ROW_MAJOR=A_ROW_MAJOR,
+                            B_ROW_MAJOR=B_ROW_MAJOR,
+                        )
+                    else:
+                        # Keep CTA1's ring-buffer position aligned with CTA0 so
+                        # subsequent producer/CLC iterations derive identical
+                        # buffer indices and phases, without executing MMA work.
+                        smem_accum_cnt += k_tile_end - k_tile_start
+                    # Both CTAs advance the logical TMEM tile counter because
+                    # their epilogue and CLC tasks consume the same tile stream.
                     tmem_accum_cnt += 1
                 tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=NUM_CTAS == 2)
                 clc_phase_consumer ^= 1

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -170,6 +170,23 @@ class Gemm:
             "EPILOGUE_SUBTILE": False,
             "NUM_CTAS": 1,
         },
+        "blackwell_gemm_ws_2cta_2group": {
+            "BLOCK_SIZE_M": 256,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 64,
+            "GROUP_SIZE_M": 2,
+            "NUM_SMEM_BUFFERS": 2,
+            "NUM_TMEM_BUFFERS": 2,
+            "NUM_MMA_GROUPS": 2,
+            "EPILOGUE_SUBTILE": 2,
+            "NUM_CTAS": 2,
+            "SPLIT_K": 1,
+            "INTERLEAVE_EPILOGUE": 1,
+            "USE_WARP_BARRIER": False,
+            "num_warps": 4,
+            "num_stages": 1,
+            "ctas_per_cga": (2, 1, 1),
+        },
         "blackwell_gemm_ws_warp_barrier": {
             "BLOCK_SIZE_M": 128,
             "BLOCK_SIZE_N": 256,
@@ -457,6 +474,16 @@ class ScaledMM:
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_blackwell_gemm_ws(dtype):
     Gemm.run_test(_blackwell_gemm_ws, Gemm.CONFIGS["blackwell_gemm_ws"], dtype=dtype)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
+def test_blackwell_gemm_ws_2cta_2group():
+    Gemm.run_test(
+        _blackwell_gemm_ws,
+        Gemm.CONFIGS["blackwell_gemm_ws_2cta_2group"],
+        shapes=[(1024, 12800, 1152)],
+        dtype=torch.float16,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Summary:

Enable leader-only 2-CTA protocol for the current CLC Blackwell GEMM and extend it to both one- and two-MMA-group configurations. Route both CTAs' TMA completion to leader-side B-full and per-group A-full barriers with `cta_group::2`; only the leader waits and issues collaborative MMAs. Each group retains its own A-full and TMEM-empty dependency, so group 0 can issue before group 1 becomes ready. Remove the separate per-K CTA rendezvous barriers, route epilogue TMEM-empty arrivals back to the leader, and keep non-leader counters and phases synchronized. Single-CTA behavior remains unchanged.

For fp16 TT GEMM M/N/K=1024/12800/1152 with one MMA group, the matched NCU profile is performance-neutral versus the merged A/B barrier parent: duration improves by 0.35% and elapsed cycles by 0.14%, within noise. The leader-only protocol reduces dynamic instructions by 4.24%, TRYWAIT by 25,752, NANOSLEEP.SYNCS by 18,352, branches by 30,805, and NOPs by 14,800, with unchanged registers and slightly lower shared memory.

Reviewed By: wlei-llvm

Differential Revision: D96496514


