### PR TITLE
[TLX] Add entry barrier before remote SMEM store

### DIFF
--- a/python/test/unit/language/test_tlx_cluster.py
+++ b/python/test/unit/language/test_tlx_cluster.py
@@ -85,6 +85,22 @@ def test_remote_shmem_store(device):
         offset = tl.arange(0, 1) + cluster_cta_rank
         value = tl.load(x + offset) + (cluster_cta_rank + 1) * 100
 
+        # Delay one CTA before it initializes its DSM so a missing cluster
+        # barrier is observable: an early remote store would be overwritten.
+        if cluster_cta_rank == 1:
+            tl.inline_asm_elementwise(
+                "nanosleep.u32 1000000; mov.u32 $0, 0;",
+                "=r",
+                [],
+                dtype=tl.int32,
+                is_pure=False,
+                pack=1,
+            )
+        local_init_view = tlx.local_view(local_buff, cluster_cta_rank)
+        tlx.local_store(local_init_view, tl.full((1, ), -1.0, tl.float32))
+
+        # Ensure every CTA has entered and initialized its DSM before access.
+        tlx.cluster_barrier()
         tlx.remote_shmem_store(
             dst=remote_store_view,
             src=value,


### PR DESCRIPTION
## Summary

`test_remote_shmem_store` has a distributed-shared-memory (DSM) entry-ordering
race. Each CTA immediately issues `tlx.remote_shmem_store()` into a peer CTA's
shared memory (`remote_cta_rank = cluster_cta_rank ^ 1`), but nothing proves
that the destination CTA has entered and initialized its DSM first.

This adds a `tlx.cluster_barrier()` before the remote store. It is distinct
from the existing post-store barrier, which orders the remote stores before the
subsequent local loads.

## Observable regression

The test now makes deletion of the entry barrier visible to ordinary pytest:

1. Delay CTA rank 1 for 1 ms before its local DSM initialization.
2. Initialize each CTA's destination buffer to `-1`.
3. Synchronize the cluster.
4. Perform the existing peer exchange and assert the original values.

With the barrier, all initialization completes before any remote store. In a
controlled mutation that removes only this barrier, CTA 0's early remote store
is overwritten by CTA 1's delayed initialization and the existing assertion
fails with `y[1] == -1` instead of `142`.

The initialization is a timing/observability amplifier. Compute Sanitizer
remains the exact oracle for the target-CTA entry contract.

## Evidence

Rebased head/base:

- head: `7f5ff3c57`
- base: `a8edbe073`

Committed fixed test:

- ordinary pytest: `1 passed`;
- CUDA 13.3 Compute Sanitizer 2026.2.1 racecheck:
  `0 hazards displayed (0 errors, 0 warnings)`.

Controlled mutation, removing only the first cluster barrier:

- ordinary pytest: `1 failed`, `y[1] == -1`;
- racecheck retains the original
  `block that might not have entered yet` diagnostics;
- the observable initialization conflict is also reported as WAW;
- `7 hazards displayed (7 errors, 0 warnings)`, exit 86.

### CUTracer A/B

Fresh B200 captures with the source-built Case 28 CUTracer detector used
`reg_trace,mem_addr_trace` and runtime `getctarank.shared::cluster`
attribution:

- baseline without the entry barrier: one grouped
  `[REMOTE_DSM_ENTRY:MISSING:ERROR]` at SASS PC `0x150` / source line 88,
  aggregated from two exact peer-store occurrences across the two CTAs;
- fixed test: zero remote-DSM-entry findings, with both peer accesses recorded
  as entry-proven and the barrier dominating the store on all CFG paths;
- comparison: `Remote DSM entry: 1 -> 0` (`fixed=1`, `regressed=0`,
  `persistent=0`).

The deterministic detector and its Phase-2 AI analysis both identify the same
root cause: the original peer `ST.E` executes before cluster entry, while the
existing post-store barrier only orders the subsequent local load and cannot
legalize the earlier access.

Environment: B200, driver 580.82.07, CUDA 13.3, Compute Sanitizer
2026.2.1.0, Python 3.12.13, PyTorch 2.14.0.dev20260719+cu130.

## Test plan

```bash
python -m pytest -s --tb=short \
  python/test/unit/language/test_tlx_cluster.py::test_remote_shmem_store

compute-sanitizer --tool racecheck --error-exitcode 86 \
  --target-processes all --check-tensor-ops yes --racecheck-report all \
  python -m pytest -s --tb=short \
  python/test/unit/language/test_tlx_cluster.py::test_remote_shmem_store
```
