### PR TITLE
[TLX] Fix async-token test input bounds

### DIFF
--- a/python/test/unit/language/test_tlx_warp_specialization.py
+++ b/python/test/unit/language/test_tlx_warp_specialization.py
@@ -332,8 +332,8 @@ def test_async_token_error(device):
             token = tlx.async_load(y_ptr + offsets, buffers[0])
         tlx.async_load_commit_group([token])
 
-    x = torch.tensor([128], dtype=torch.float32, device=device)
-    y = torch.tensor([128], dtype=torch.float32, device=device)
+    x = torch.full((128, ), 128, dtype=torch.float32, device=device)
+    y = torch.full((128, ), 128, dtype=torch.float32, device=device)
     grid = lambda meta: (1, )
     kernel = asycn_copy_kernel[grid](x, y, True)
     assert kernel.asm["ttgir"].count("ttg.async_copy_global_to_local") == 2


### PR DESCRIPTION
## Summary

`test_async_token_error` allocates one-element input tensors but its kernel
reads 128 elements from each pointer:

```python
offsets = tl.arange(0, 128)
token = tlx.async_load(x_ptr + offsets, buffers[0])   # reads offsets 0..127
```

`torch.tensor([128], ...)` creates a **1-element** tensor (value `128`), so the
kernel reads 127 elements past the end of both `x` and `y`. This is a test
fixture bug — the async-token / async-load implementation is fine.

## Fix

Allocate the 128 elements the kernel actually reads:

```python
x = torch.full((128, ), 128, dtype=torch.float32, device=device)
y = torch.full((128, ), 128, dtype=torch.float32, device=device)
```

## Evidence (compute-sanitizer initcheck A/B)

Baseline (3 independent runs): each reported 127 uninitialized global reads.

After the fix (3 runs): `ERROR SUMMARY: 0 errors`, and ordinary pytest passes.

Environment: FB Triton `b733302f`, B200, Compute Sanitizer 2026.2.1.0,
CUDA 13.3, Python 3.12.

## Test plan

```bash
python -m pytest -s --tb=short \
  python/test/unit/language/test_tlx_warp_specialization.py::test_async_token_error
compute-sanitizer --tool initcheck --error-exitcode 86 \
  --target-processes all python -m pytest -s --tb=short \
  python/test/unit/language/test_tlx_warp_specialization.py::test_async_token_error
```
