### PR TITLE
[TLX][Blackwell GEMM WS] Allow 2-CTA configs for M>>N shapes in the autotune pruner

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -394,7 +394,7 @@ def get_cuda_autotune_config():
         for num_ctas in [1, 2]
         for split_k in [1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 19, 24]  # pruning selects one optimal SPLIT_K per tile group
         for interleave in [0, 1]
-        for g in [1, 8, 64]
+        for g in [1, 2, 8, 64]
         for uwb in [False, True]
     ]
 
@@ -595,8 +595,11 @@ def preprocess_configs(configs, named_args, **kwargs):
     if pruned_configs:
         IMBALANCE_THRESHOLD = 10  # ratio at which we enforce the rule
         if M > N * IMBALANCE_THRESHOLD:
-            # M >> N: keep only small GROUP_SIZE_M to sweep M
-            pruned_configs = [c for c in pruned_configs if c.kwargs["GROUP_SIZE_M"] == 1]
+            # M >> N: keep the smallest GROUP_SIZE_M to sweep M. 2-CTA requires
+            # GROUP_SIZE_M to be a multiple of NUM_CTAS (see the pairing gate
+            # above), so its smallest valid value is NUM_CTAS (2), not 1 —
+            # forcing 1 here would silently prune every 2-CTA config.
+            pruned_configs = [c for c in pruned_configs if c.kwargs["GROUP_SIZE_M"] == c.kwargs["NUM_CTAS"]]
         elif N > M * IMBALANCE_THRESHOLD:
             # N >> M: keep only large GROUP_SIZE_M to sweep N
             pruned_configs = [c for c in pruned_configs if c.kwargs["GROUP_SIZE_M"] >= 32]


### PR DESCRIPTION
Summary:
On B300 (sm_103), `matmul_kernel_tma_ws_blackwell` was ~15% slower than cuBLAS on large M>>N shapes (e.g. `32768x1024x1152`: ws/cuBLAS 0.85 in cudagraph mode). ncu showed the cause is MMA duty cycle: TLX ran at 66.6% tensor-pipe utilization vs cuBLAS's 80.1%, because the autotuner was stuck on a shallow-pipeline single-CTA tile (256x128, `NUM_SMEM_BUFFERS=4`), while cuBLAS uses `nvjet_sm103_tst_128x256_64x6_2x1_2cta` — a 128x256 tile with a 6-stage pipeline and a 2-CTA cluster.

The 2-CTA + deep-pipeline config is reachable in principle (a 128x256 tile with 2-CTA costs only 32KB/stage, so 6 stages fit the ~232KB SMEM budget), but `preprocess_configs` silently pruned every 2-CTA config for M>>N shapes. Two rules collided: the 2-CTA pairing gate requires `GROUP_SIZE_M % NUM_CTAS == 0` (i.e. an even group), while the golden-rule filter kept only `GROUP_SIZE_M == 1` when `M > N*10`. Since 1 is not a multiple of 2, all 2-CTA candidates were dropped and the autotuner never saw them.

This changes the M>>N branch to keep `GROUP_SIZE_M == NUM_CTAS` (1 for single-CTA — identical to before; 2 for 2-CTA), and adds `2` to the `GROUP_SIZE_M` search space so a minimal even group exists. The balanced and N>>M branches are unchanged, so config selection for all non-M>>N shapes is byte-for-byte identical; the raw config list grows ~33% (Python-side only), and GPU autotuning grows only for M>>N shapes, by the handful of 2-CTA candidates that survive pruning — which is the intent.

With the fix the autotuner picks `BM128 BN256 BK64 NUM_CTAS=2 NUM_SMEM_BUFFERS=6 NUM_MMA_GROUPS=1 GROUP_SIZE_M=2` (the cuBLAS geometry), lifting tensor-pipe utilization to 79.0% and closing the gap to ~0.95.

Differential Revision: D113164662


