### PR TITLE
[AutoWS][NFC] Extract shared dependsThroughMemory; planner delegates to it

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -796,9 +796,82 @@ int channelInReuseGroup(Channel *channel, ReuseConfig *config,
   return -1;
 }
 
+// Shared reuse-legality primitive (see CodePartitionUtility.h): is `dstOp` in
+// the forward slice of `srcOp`, following SSA results AND memory (store ->
+// buffer -> load)?  This is the single source of truth for "one op's value
+// flows into another", used by both the memory planner (hasPotentialReuse) and
+// code partitioning (hasDependencyChain).  A memory hop is needed for chains
+// that pass through a shared buffer, e.g. dpT -> dsT (stored to smem) -> read
+// by the dq MMA. Climb memdesc view ops (index/subslice/reinterpret/trans) to
+// the underlying buffer value, so different slots/views of one multi-buffered
+// alloc share a root.
+static Value getRootBuffer(Value v) {
+  while (auto *def = v.getDefiningOp()) {
+    if (isa<ttg::MemDescIndexOp, ttg::MemDescSubsliceOp,
+            ttg::MemDescReinterpretOp, ttg::MemDescTransOp>(def))
+      v = def->getOperand(0);
+    else
+      break;
+  }
+  return v;
+}
+
+bool dependsThroughMemory(Operation *srcOp, Operation *dstOp,
+                          bool followBufferReuse) {
+  if (!srcOp || !dstOp)
+    return false;
+  DenseSet<Operation *> visited;
+  SmallVector<Operation *> worklist;
+  auto enqueue = [&](Operation *op) {
+    for (auto result : op->getResults())
+      for (auto *user : result.getUsers())
+        if (visited.insert(user).second)
+          worklist.push_back(user);
+    // A store publishes its value to a buffer; connect it to the buffer's
+    // readers so a dependency that flows through memory is discovered.
+    //
+    // By default (followBufferReuse=false) we only follow the store's *own*
+    // memdesc operand -- the exact slot written. With followBufferReuse we
+    // climb to the root buffer and fan out to readers of ANY view/slot of it,
+    // needed when a value is written to memdesc_index(base, i) and read from
+    // memdesc_index(base, j) (e.g. dsT stored by the softmax partition, read by
+    // the dq MMA through a different subview).
+    //
+    // The wider walk is used ONLY to ORDER an already-decided reuse (code
+    // partitioning's hasDependencyChain). It must NOT gate the memory planner's
+    // packing decision (isDataDependent): fanning across a buffer's whole
+    // lifetime would tie a store to unrelated later readers of a reused slot
+    // and over-form reuse groups (observed: HSTU 2-KV reduce_dq wrong results).
+    if (isa<ttg::LocalStoreOp, ttng::TMEMStoreOp>(op))
+      for (auto operand : op->getOperands())
+        if (isa<ttg::MemDescType>(operand.getType())) {
+          Value buf = followBufferReuse ? getRootBuffer(operand) : operand;
+          for (auto *user : buf.getUsers())
+            if (user != op && visited.insert(user).second)
+              worklist.push_back(user);
+        }
+  };
+  enqueue(srcOp);
+  while (!worklist.empty()) {
+    auto *op = worklist.pop_back_val();
+    if (op == dstOp)
+      return true;
+    enqueue(op);
+  }
+  return false;
+}
+
 // Check whether there is a dependency chain from the consumer of channel A
 // to the producer of channel B: A.dstOp -> ... -> B.srcOp.
-// We check whether B.srcOp is a transitive user of A.dstOp's result.
+//
+// Ordering evidence, in order of soundness:
+//   (1) a real data dependency (SSA or through memory) from A's consumer to B's
+//       producer -- valid ACROSS partitions (a genuine happens-before), OR
+//   (2) program order WITHIN a single partition -- one warp group executes its
+//       ops sequentially, so textual order is a real happens-before there.
+// Program order is NOT used across partitions: distinct async tasks run
+// concurrently, so their relative text position is not a happens-before (and
+// op-id/liveness intervals are likewise meaningless across partitions).
 static bool hasDependencyChain(Channel *A, Channel *B) {
   Operation *aConsumer = A->getDstOp();
   Operation *bProducer = B->getSrcOp();
@@ -948,7 +1021,8 @@ bool verifyReuseGroup2(ReuseGroup *group) {
     }
     bool chain = hasDependencyChain(chA, chB) || hasDependencyChain(chB, chA);
     LDBG("verifyReuseGroup2: TMEM channels "
-         << chA->uniqID << "/" << chB->uniqID << " overlap=1 chain=" << chain);
+         << chA->uniqID << "/" << chB->uniqID << " (" << chA->srcName << "/"
+         << chB->srcName << ") overlap=1 chain=" << chain);
     return chain;
   }
 
@@ -1150,8 +1224,9 @@ bool needExplicitReuseWait(Channel *earlyChannel, Channel *lateChannel) {
   }
 
   LDBG("needExplicitReuseWait: explicit wait needed for "
-       << "earlyChannel " << earlyChannel->uniqID << " and lateChannel "
-       << lateChannel->uniqID);
+       << "earlyChannel " << earlyChannel->uniqID << " ("
+       << earlyChannel->srcName << ") and lateChannel " << lateChannel->uniqID
+       << " (" << lateChannel->srcName << ")");
   return true;
 }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -353,6 +353,18 @@ void fuseTcgen05CommitBarriers(triton::FuncOp &funcOp);
 void doTMAStoreLowering(triton::FuncOp &funcOp);
 bool appearsBefore(Operation *A, Operation *B);
 
+// Shared reuse-legality primitive: is `dstOp` in the forward slice of `srcOp`,
+// following SSA results AND memory (store -> buffer -> load)?  Single source of
+// truth for "one op's value flows into another"; used by both the memory
+// planner (hasPotentialReuse) and code partitioning (hasDependencyChain).
+//
+// `followBufferReuse` widens the memory hop from the store's own slot to any
+// view/slot of the root buffer (see the .cpp). Use it only to ORDER an
+// already-decided reuse (code partitioning), never to gate the planner's
+// packing decision -- the wider walk over-forms reuse groups.
+bool dependsThroughMemory(Operation *srcOp, Operation *dstOp,
+                          bool followBufferReuse = false);
+
 // Verify that an A1 (SMEM circular reuse) group is well-formed:
 // - Multi-buffered (channels[0]->getNumBuffers() > 1).
 // - Every producer/consumer of every channel lives in one common basic block.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -1979,21 +1979,13 @@ public:
     Operation *from = records[a].producer, *to = records[b].producer;
     if (!from || !to || from == to)
       return false;
-    // Backward def-use reachability: does `from` transitively consume `to`?
-    SmallVector<Operation *> worklist{from};
-    DenseSet<Operation *> seen;
-    while (!worklist.empty()) {
-      Operation *op = worklist.pop_back_val();
-      for (Value operand : op->getOperands()) {
-        Operation *def = operand.getDefiningOp();
-        if (!def || !seen.insert(def).second)
-          continue;
-        if (def == to)
-          return true;
-        worklist.push_back(def);
-      }
-    }
-    return false;
+    // "a depends on b" == b's producer is in the backward slice of a's producer
+    // == a's producer is in the forward slice of b's producer. Delegate to the
+    // shared dependsThroughMemory so this matches the proven reuse predicate
+    // (isDataDependent / hasPotentialReuse): it follows SSA results AND memory
+    // (store -> buffer -> load), which a plain operand walk misses for values
+    // that flow between buffers through SMEM/TMEM (e.g. FA-bwd dsT -> dq).
+    return dependsThroughMemory(to, from);
   }
 
 private:
@@ -2912,20 +2904,10 @@ public:
     Operation *from = records[a].producer, *to = records[b].producer;
     if (!from || !to || from == to)
       return false;
-    SmallVector<Operation *> worklist{from};
-    DenseSet<Operation *> seen;
-    while (!worklist.empty()) {
-      Operation *op = worklist.pop_back_val();
-      for (Value operand : op->getOperands()) {
-        Operation *def = operand.getDefiningOp();
-        if (!def || !seen.insert(def).second)
-          continue;
-        if (def == to)
-          return true;
-        worklist.push_back(def);
-      }
-    }
-    return false;
+    // See SmemBufferModel::dependsOn: delegate to the shared memory-aware
+    // predicate so the TMEM reuse-legality gate (TmemPacker::legalJoin) accepts
+    // sibling reuse whose dependency flows through a buffer, not only via SSA.
+    return dependsThroughMemory(to, from);
   }
 
 private:
@@ -2990,39 +2972,13 @@ private:
   SmallVector<BufferT *> buffers;
   DenseMap<Operation *, ttng::TmemAllocChannel *> allocToChannel;
 
-  /// Check whether dstOp is in the forward SSA slice of srcOp,
-  /// i.e. dstOp transitively uses a result of srcOp.  Also follows
-  /// memory dependencies (local_store, tmem_store).
+  /// Check whether dstOp is in the forward SSA slice of srcOp, i.e. dstOp
+  /// transitively uses a result of srcOp.  Also follows memory dependencies
+  /// (local_store, tmem_store).  Delegates to the shared `dependsThroughMemory`
+  /// (CodePartitionUtility) so the planner and code partitioning use one source
+  /// of truth for reuse-chain data dependencies.
   static bool isDataDependent(Operation *srcOp, Operation *dstOp) {
-    SmallVector<Operation *, 16> worklist;
-    DenseSet<Operation *> visited;
-    auto enqueueUsers = [&](Operation *op) {
-      for (Value result : op->getResults()) {
-        for (Operation *user : result.getUsers()) {
-          if (visited.insert(user).second)
-            worklist.push_back(user);
-        }
-      }
-      if (isa<triton::gpu::LocalStoreOp>(op) ||
-          isa<triton::nvidia_gpu::TMEMStoreOp>(op)) {
-        for (Value operand : op->getOperands()) {
-          if (isa<triton::gpu::MemDescType>(operand.getType())) {
-            for (Operation *user : operand.getUsers()) {
-              if (user != op && visited.insert(user).second)
-                worklist.push_back(user);
-            }
-          }
-        }
-      }
-    };
-    enqueueUsers(srcOp);
-    while (!worklist.empty()) {
-      Operation *op = worklist.pop_back_val();
-      if (op == dstOp)
-        return true;
-      enqueueUsers(op);
-    }
-    return false;
+    return dependsThroughMemory(srcOp, dstOp);
   }
 
   /// Look up the BufferT for a given alloc operation.


### PR DESCRIPTION
Summary:
Factor the memory-aware forward-slice walk (SSA results + store->buffer->load,
with a getRootBuffer subview-climb behind followBufferReuse) into one shared
dependsThroughMemory primitive in CodePartitionUtility. The memory planner's
isDataDependent now delegates to it with followBufferReuse=false, which is
behavior-identical to the previous isDataDependent (same direct-operand walk) --
no default-behavior change. Also name each channel in the verifyReuseGroup2 /
needExplicitReuseWait debug output. hasDependencyChain is unchanged here; the
functional switch to the shared walk is the next commit.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D112237577


