### PR TITLE
[AutoWS][NFC][test] LIT for reuse-group decisions and the getRootBuffer subview-climb (#2297)

### DIFF
--- a/test/Hopper/WarpSpecialization/reuse_group_2buffer_multibuf.mlir
+++ b/test/Hopper/WarpSpecialization/reuse_group_2buffer_multibuf.mlir
@@ -1,17 +1,21 @@
-// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=1" --mlir-print-debuginfo --mlir-use-nameloc-as-prefix | FileCheck %s
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=1" --mlir-use-nameloc-as-prefix | FileCheck %s
 //
-// Verify that 2-buffer reuse group logic moves the late buffer's (dq)
-// producer_acquire before the early buffer's (dpT) producer.
-// Before this change, the ordering was:
-//   producer_acquire(dpT) -> dpT MMA -> ... -> producer_acquire(dq) -> dq MMA
-// After this change, the ordering is:
-//   producer_acquire(dq) -> producer_acquire(dpT) -> dpT MMA -> ... -> dq MMA
+// Multi-buffer variant of reuse_group_2buffer.mlir: the shared dsT buffer is a
+// MULTI-buffered alloc (1x128x128) accessed through memdesc_index slot views.
+// The dsT store and the dq read go through SEPARATE memdesc_index ops of the
+// same base alloc, so the dpT -> dsT -> dq data dependency is only discoverable
+// if dependsThroughMemory (CodePartitionUtility) climbs the store's subview to
+// the base buffer and fans out to the reader's subview (getRootBuffer). Without
+// that, dpT.consumer -> dq.producer has no chain, the {dpT,dq} TMEM reuse is
+// lost, and dq's producer_acquire is NOT hoisted before dpT's producer.
 //
-// dpT and dq share the same buffer.id in a reuse group with buffer.copy=1.
-// dpT's consumer feeds into dq's producer, so dpT is the early channel.
-// dq's producer_acquire must come before dpT's producer to ensure the
-// shared token prevents dq's old data from being overwritten before it
-// is consumed.
+// This is the exact multi-buffer/subview shape that occurs in FA-bwd
+// (early_tma_staging): dsT is written by the softmax partition into
+// memdesc_index(base,i) and read by the dq MMA from memdesc_index(base,j).
+//
+// dpT and dq share the same TMEM buffer.id in a reuse group with buffer.copy=1.
+// dpT's consumer (through dsT) feeds dq's producer, so dpT is the early channel;
+// dq's producer_acquire must come before dpT's producer.
 //
 // CHECK: nvws.producer_acquire {{.*}}%dq_{{[0-9]+}}, %dq_{{[0-9]+}}
 // CHECK: nvws.producer_acquire {{.*}}%dpT_{{[0-9]+}}, %dpT_{{[0-9]+}}
@@ -36,7 +40,7 @@
 module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @_attn_bwd_persist(%desc_q: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_k: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_v: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %sm_scale: f32, %desc_do: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_dq: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %desc_dk: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_dv: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %M: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %D: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %stride_z: i32 {tt.divisibility = 16 : i32}, %stride_h: i32 {tt.divisibility = 16 : i32}, %stride_tok: i32 {tt.divisibility = 16 : i32}, %BATCH: i32, %H: i32 {tt.divisibility = 16 : i32}, %N_CTX: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
     %dq, %dq_0 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc("dq")
-    %dsT = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %dsT = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>
     %dpT, %dpT_1 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc("dpT")
     %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
     %do = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
@@ -145,9 +149,11 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
         %dsT_100 = arith.subf %dpT_98, %dsT_97 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1>
         %dsT_101 = arith.mulf %pT_87, %dsT_100 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1>
         %dsT_102 = arith.truncf %dsT_101 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1>
-        ttg.local_store %dsT_102, %dsT {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
-        %dk_103 = ttng.tc_gen5_mma %dsT, %q, %dk[%dk_71], %arg20, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, tmem.end = array<i32: 9>, tmem.start = array<i32: 10>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-        %dq_104 = ttg.memdesc_trans %dsT {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared3, #smem, mutable> loc("dq")
+        %dsT_ws = ttg.memdesc_index %dsT[%c0_i32] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        ttg.local_store %dsT_102, %dsT_ws {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %dk_103 = ttng.tc_gen5_mma %dsT_ws, %q, %dk[%dk_71], %arg20, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, tmem.end = array<i32: 9>, tmem.start = array<i32: 10>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dsT_rs = ttg.memdesc_index %dsT[%c0_i32] {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc("dq")
+        %dq_104 = ttg.memdesc_trans %dsT_rs {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared3, #smem, mutable> loc("dq")
         %dq_105 = ttng.tc_gen5_mma %dq_104, %k, %dq[%dq_72], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> loc("dq")
         %dq_106, %dq_107 = ttng.tmem_load %dq[%dq_105] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1> loc("dq")
         %dqs = tt.reshape %dq_106 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked4>

--- a/test/Hopper/WarpSpecialization/verify_reuse_group_decisions.mlir
+++ b/test/Hopper/WarpSpecialization/verify_reuse_group_decisions.mlir
@@ -1,0 +1,39 @@
+// REQUIRES: asserts
+//
+// Directly checks the verifyReuseGroup2 / orderReuseGroupChain DECISIONS (via the
+// `nvgpu-ws-utility` debug output, which now names each channel) for the
+// reuse-legality cases, so a change to the shared dependency predicate
+// (dependsThroughMemory / getRootBuffer) or the N-way chain ordering is caught
+// here. Each RUN reuses an existing sibling fixture (no IR duplicated).
+//
+// ------------------------------------------------------------------------------
+// CASE 1 - real 2-way reuse (ACCEPT): dpT and dq share one TMEM slot; dpT's
+// consumer feeds dq's producer (dpT -> dsT -> dq), so a dependency chain exists.
+// RUN: triton-opt %S/reuse_group_2buffer.mlir --nvgpu-test-ws-code-partition="num-buffers=1" --debug-only=nvgpu-ws-utility 2>&1 | FileCheck %s --check-prefix=ACCEPT2
+// ACCEPT2: verifyReuseGroup2: TMEM channels {{[0-9]+}}/{{[0-9]+}} (dpT/dq) overlap=1 chain=1
+//
+// ------------------------------------------------------------------------------
+// CASE 2 - real 2-way reuse through a MULTI-BUFFER subview (ACCEPT): same dpT->dq
+// chain but dsT lives in a 1x128x128 alloc and the store/read use separate
+// memdesc_index slot-views; only getRootBuffer connects them -> chain=1.
+// RUN: triton-opt %S/reuse_group_2buffer_multibuf.mlir --nvgpu-test-ws-code-partition="num-buffers=1" --debug-only=nvgpu-ws-utility 2>&1 | FileCheck %s --check-prefix=MULTIBUF
+// MULTIBUF: verifyReuseGroup2: TMEM channels {{[0-9]+}}/{{[0-9]+}} (dpT/dq) overlap=1 chain=1
+//
+// ------------------------------------------------------------------------------
+// CASE 3 - orderable N>=3 reuse (ACCEPT): {dpT,dsT,dq} share one TMEM slot and dk
+// reads dsT before dq overwrites it, so orderReuseGroupChain finds a unique order
+// and emits the reuse WAR (no fatal).
+// RUN: triton-opt %S/ws_code_partition_tmem_3group_chain.mlir --nvgpu-test-ws-code-partition="num-buffers=1" --debug-only=nvgpu-ws-utility 2>&1 | FileCheck %s --check-prefix=ACCEPTN
+// ACCEPTN-NOT: no unique dependency-chain order
+// ACCEPTN: needExplicitReuseWait: explicit wait needed for earlyChannel {{[0-9]+}} (dpT) and lateChannel {{[0-9]+}} (dq)
+//
+// ------------------------------------------------------------------------------
+// CASE 4 - unorderable N>=3 reuse (REJECT/fast-fail): same {dpT,dsT,dq} slot but
+// dq overwrites BEFORE dk reads dsT, so no unique order exists and code
+// partitioning must fail fast instead of emitting an unsafe/deadlocking barrier.
+// RUN: not --crash triton-opt %S/ws_code_partition_tmem_3group_no_chain.mlir --nvgpu-test-ws-code-partition="num-buffers=1" 2>&1 | FileCheck %s --check-prefix=REJECTN
+// REJECTN: TMEM reuse group with >= 3 buffers has no unique dependency-chain order
+// REJECTN-SAME: buffer.id=8
+// REJECTN-SAME: dpT
+// REJECTN-SAME: dsT
+// REJECTN-SAME: dq

--- a/test/Hopper/WarpSpecialization/ws_code_partition_tmem_3group_chain.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_tmem_3group_chain.mlir
@@ -1,21 +1,16 @@
-// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=1" --mlir-print-debuginfo --mlir-use-nameloc-as-prefix | FileCheck %s
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=1" --mlir-use-nameloc-as-prefix | FileCheck %s
 //
-// Verify that 2-buffer reuse group logic moves the late buffer's (dq)
-// producer_acquire before the early buffer's (dpT) producer.
-// Before this change, the ordering was:
-//   producer_acquire(dpT) -> dpT MMA -> ... -> producer_acquire(dq) -> dq MMA
-// After this change, the ordering is:
-//   producer_acquire(dq) -> producer_acquire(dpT) -> dpT MMA -> ... -> dq MMA
+// Orderable complement of ws_code_partition_tmem_3group_no_chain.mlir. {dpT, dsT,
+// dq} share one TMEM slot (buffer.id = 8):
+//   dpT (gemm, task1) -> dsT (computation tmem_store, task3) -> dq (gemm, task1)
+// Here the dk MMA (which READS dsT from the shared slot) is emitted BEFORE the dq
+// MMA (which overwrites the slot), so the chain has a UNIQUE order
+// (dpT -> dsT -> dq) and orderReuseGroupChain accepts it. Code partitioning must
+// NOT fatal, and must emit the reuse WAR that hoists dq's producer_acquire onto
+// the shared (dpT) reuse token so dq waits for dsT's consumer before overwriting.
 //
-// dpT and dq share the same buffer.id in a reuse group with buffer.copy=1.
-// dpT's consumer feeds into dq's producer, so dpT is the early channel.
-// dq's producer_acquire must come before dpT's producer to ensure the
-// shared token prevents dq's old data from being overwritten before it
-// is consumed.
-//
+// CHECK-NOT: no unique dependency-chain order
 // CHECK: nvws.producer_acquire {{.*}}%dq_{{[0-9]+}}, %dq_{{[0-9]+}}
-// CHECK: nvws.producer_acquire {{.*}}%dpT_{{[0-9]+}}, %dpT_{{[0-9]+}}
-// CHECK: %dpT_{{[0-9]+}} = ttng.tc_gen5_mma
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
@@ -38,6 +33,7 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
     %dq, %dq_0 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc("dq")
     %dsT = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     %dpT, %dpT_1 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc("dpT")
+    %dsT_t, %dsT_t_tok = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> (!ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
     %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
     %do = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     %qkT, %qkT_2 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
@@ -146,7 +142,11 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
         %dsT_101 = arith.mulf %pT_87, %dsT_100 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1>
         %dsT_102 = arith.truncf %dsT_101 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1>
         ttg.local_store %dsT_102, %dsT {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
-        %dk_103 = ttng.tc_gen5_mma %dsT, %q, %dk[%dk_71], %arg20, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, tmem.end = array<i32: 9>, tmem.start = array<i32: 10>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        // computation (task3) materializes dsT into the shared buf8 TMEM slot.
+        ttng.tmem_store %dsT_102, %dsT_t, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        // HAZARD: dq (writes buf8) emitted BEFORE dk reads dsT from buf8 -> the
+        // {dpT,dsT,dq} chain has no unique order (dsT and dq are incomparable).
+        %dk_103 = ttng.tc_gen5_mma %dsT_t, %q, %dk[%dk_71], %arg20, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, tmem.end = array<i32: 9>, tmem.start = array<i32: 10>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
         %dq_104 = ttg.memdesc_trans %dsT {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared3, #smem, mutable> loc("dq")
         %dq_105 = ttng.tc_gen5_mma %dq_104, %k, %dq[%dq_72], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> loc("dq")
         %dq_106, %dq_107 = ttng.tmem_load %dq[%dq_105] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1> loc("dq")

--- a/test/Hopper/WarpSpecialization/ws_code_partition_tmem_3group_no_chain.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_tmem_3group_no_chain.mlir
@@ -23,485 +23,209 @@
 #blocked7 = #ttg.blocked<{sizePerThread = [1, 2, 32], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 2, 1]}>
 #blocked8 = #ttg.blocked<{sizePerThread = [1, 32, 2], threadsPerWarp = [32, 1, 1], warpsPerCTA = [4, 1, 1], order = [0, 1, 2]}>
 #blocked9 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-#loc = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1015:0)
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
 #shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
-#loc93 = loc("desc_q"(#loc))
-#loc94 = loc("desc_k"(#loc))
-#loc95 = loc("desc_v"(#loc))
-#loc96 = loc("sm_scale"(#loc))
-#loc97 = loc("desc_do"(#loc))
-#loc98 = loc("desc_dq"(#loc))
-#loc99 = loc("desc_dk"(#loc))
-#loc100 = loc("desc_dv"(#loc))
-#loc101 = loc("M"(#loc))
-#loc102 = loc("D"(#loc))
-#loc103 = loc("stride_z"(#loc))
-#loc104 = loc("stride_h"(#loc))
-#loc105 = loc("stride_tok"(#loc))
-#loc106 = loc("BATCH"(#loc))
-#loc107 = loc("H"(#loc))
-#loc108 = loc("N_CTX"(#loc))
 module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @_attn_bwd_persist(%desc_q: !tt.ptr<f16> {tt.divisibility = 16 : i32} loc("desc_q"(#loc)), %desc_k: !tt.ptr<f16> {tt.divisibility = 16 : i32} loc("desc_k"(#loc)), %desc_v: !tt.ptr<f16> {tt.divisibility = 16 : i32} loc("desc_v"(#loc)), %sm_scale: f32 loc("sm_scale"(#loc)), %desc_do: !tt.ptr<f16> {tt.divisibility = 16 : i32} loc("desc_do"(#loc)), %desc_dq: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("desc_dq"(#loc)), %desc_dk: !tt.ptr<f16> {tt.divisibility = 16 : i32} loc("desc_dk"(#loc)), %desc_dv: !tt.ptr<f16> {tt.divisibility = 16 : i32} loc("desc_dv"(#loc)), %M: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("M"(#loc)), %D: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("D"(#loc)), %stride_z: i32 {tt.divisibility = 16 : i32} loc("stride_z"(#loc)), %stride_h: i32 {tt.divisibility = 16 : i32} loc("stride_h"(#loc)), %stride_tok: i32 {tt.divisibility = 16 : i32} loc("stride_tok"(#loc)), %BATCH: i32 loc("BATCH"(#loc)), %H: i32 {tt.divisibility = 16 : i32} loc("H"(#loc)), %N_CTX: i32 {tt.divisibility = 16 : i32} loc("N_CTX"(#loc))) attributes {noinline = false} {
-    %dq, %dq_0 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc211)
-    %dsT = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc212)
-    %dpT, %dpT_1 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc213)
-    %dsT_t, %dsT_t_tok = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> (!ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc212)
-    %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc214)
-    %do = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc215)
-    %qkT, %qkT_2 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc216)
-    %q = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc217)
-    %dv_3, %dv_4 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 6 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc214)
-    %dk, %dk_5 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc218)
-    %v = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc185)
-    %k = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc186)
-    %false = arith.constant {async_task_id = array<i32: 1>} false loc(#loc14)
-    %true = arith.constant {async_task_id = array<i32: 0, 1>} true loc(#loc14)
-    %n_tile_num = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 127 : i32 loc(#loc187)
-    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 1 : i32 loc(#loc14)
-    %c128_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 128 : i32 loc(#loc14)
-    %c128_i64 = arith.constant {async_task_id = array<i32: 0, 2, 3>} 128 : i64 loc(#loc14)
-    %c1_i64 = arith.constant {async_task_id = array<i32: 0, 2, 3>} 1 : i64 loc(#loc14)
-    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 0 : i32 loc(#loc14)
-    %cst = arith.constant {async_task_id = array<i32: 0>} dense<0.693147182> : tensor<128x32xf32, #blocked> loc(#loc14)
-    %cst_6 = arith.constant {async_task_id = array<i32: 0>} dense<0.000000e+00> : tensor<128x128xf32, #blocked1> loc(#loc14)
-    %n_tile_num_7 = arith.addi %N_CTX, %n_tile_num {async_task_id = array<i32: 0, 1, 2, 3>} : i32 loc(#loc187)
-    %n_tile_num_8 = arith.divsi %n_tile_num_7, %c128_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : i32 loc(#loc188)
-    %prog_id = tt.get_program_id x {async_task_id = array<i32: 0, 1, 2, 3>} : i32 loc(#loc121)
-    %num_progs = tt.get_num_programs x {async_task_id = array<i32: 0, 1, 2, 3>} : i32 loc(#loc122)
-    %total_tiles = arith.muli %n_tile_num_8, %BATCH {async_task_id = array<i32: 0, 1, 2, 3>} : i32 loc(#loc123)
-    %total_tiles_9 = arith.muli %total_tiles, %H {async_task_id = array<i32: 0, 1, 2, 3>} : i32 loc(#loc124)
-    %tiles_per_sm = arith.divsi %total_tiles_9, %num_progs {async_task_id = array<i32: 0, 1, 2, 3>} : i32 loc(#loc189)
-    %0 = arith.remsi %total_tiles_9, %num_progs {async_task_id = array<i32: 0, 1, 2, 3>} : i32 loc(#loc23)
-    %1 = arith.cmpi slt, %prog_id, %0 {async_task_id = array<i32: 0, 1, 2, 3>} : i32 loc(#loc24)
+  tt.func public @_attn_bwd_persist(%desc_q: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_k: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_v: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %sm_scale: f32, %desc_do: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_dq: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %desc_dk: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %desc_dv: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %M: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %D: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %stride_z: i32 {tt.divisibility = 16 : i32}, %stride_h: i32 {tt.divisibility = 16 : i32}, %stride_tok: i32 {tt.divisibility = 16 : i32}, %BATCH: i32, %H: i32 {tt.divisibility = 16 : i32}, %N_CTX: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %dq, %dq_0 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc("dq")
+    %dsT = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc("dsT")
+    %dpT, %dpT_1 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc("dpT")
+    %dsT_t, %dsT_t_tok = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> (!ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc("dsT")
+    %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+    %do = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %qkT, %qkT_2 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %q = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 2 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %dv_3, %dv_4 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 6 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %dk, %dk_5 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 5 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %v = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %k = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %false = arith.constant {async_task_id = array<i32: 1>} false
+    %true = arith.constant {async_task_id = array<i32: 0, 1>} true
+    %n_tile_num = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 127 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 1 : i32
+    %c128_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 128 : i32
+    %c128_i64 = arith.constant {async_task_id = array<i32: 0, 2, 3>} 128 : i64
+    %c1_i64 = arith.constant {async_task_id = array<i32: 0, 2, 3>} 1 : i64
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 0 : i32
+    %cst = arith.constant {async_task_id = array<i32: 0>} dense<0.693147182> : tensor<128x32xf32, #blocked>
+    %cst_6 = arith.constant {async_task_id = array<i32: 0>} dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    %n_tile_num_7 = arith.addi %N_CTX, %n_tile_num {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %n_tile_num_8 = arith.divsi %n_tile_num_7, %c128_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %prog_id = tt.get_program_id x {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %num_progs = tt.get_num_programs x {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %total_tiles = arith.muli %n_tile_num_8, %BATCH {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %total_tiles_9 = arith.muli %total_tiles, %H {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %tiles_per_sm = arith.divsi %total_tiles_9, %num_progs {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %0 = arith.remsi %total_tiles_9, %num_progs {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %1 = arith.cmpi slt, %prog_id, %0 {async_task_id = array<i32: 0, 1, 2, 3>} : i32
     %2 = scf.if %1 -> (i32) {
-      %tiles_per_sm_18 = arith.addi %tiles_per_sm, %c1_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : i32 loc(#loc190)
-      scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %tiles_per_sm_18 : i32 loc(#loc190)
+      %tiles_per_sm_18 = arith.addi %tiles_per_sm, %c1_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+      scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %tiles_per_sm_18 : i32
     } else {
-      scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %tiles_per_sm : i32 loc(#loc14)
-    } {async_task_id = array<i32: 0, 1, 2, 3>} loc(#loc25)
-    %y_dim = arith.muli %BATCH, %H {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc127)
-    %y_dim_10 = arith.muli %y_dim, %N_CTX {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc128)
-    %desc_q_11 = tt.make_tensor_descriptor %desc_q, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<128x128xf16, #shared> loc(#loc129)
-    %desc_do_12 = tt.make_tensor_descriptor %desc_do, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<128x128xf16, #shared> loc(#loc130)
-    %desc_dq_13 = tt.make_tensor_descriptor %desc_dq, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 0>} : !tt.ptr<f32>, !tt.tensordesc<128x32xf32, #shared1> loc(#loc131)
-    %desc_v_14 = tt.make_tensor_descriptor %desc_v, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<128x128xf16, #shared> loc(#loc132)
-    %desc_k_15 = tt.make_tensor_descriptor %desc_k, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<128x128xf16, #shared> loc(#loc133)
-    %desc_dv_16 = tt.make_tensor_descriptor %desc_dv, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<f16>, !tt.tensordesc<128x32xf16, #shared2> loc(#loc134)
-    %desc_dk_17 = tt.make_tensor_descriptor %desc_dk, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<f16>, !tt.tensordesc<128x32xf16, #shared2> loc(#loc135)
-    %off_bh = arith.extsi %stride_tok {async_task_id = array<i32: 0, 2, 3>} : i32 to i64 loc(#loc191)
-    %num_steps = arith.divsi %N_CTX, %c128_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : i32 loc(#loc192)
-    %offs_m = tt.make_range {async_task_id = array<i32: 3>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked2> loc(#loc219)
-    %dkN = tt.splat %sm_scale {async_task_id = array<i32: 3>} : f32 -> tensor<128x32xf32, #blocked> loc(#loc193)
+      scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %tiles_per_sm : i32
+    } {async_task_id = array<i32: 0, 1, 2, 3>}
+    %y_dim = arith.muli %BATCH, %H {async_task_id = array<i32: 0, 2, 3>} : i32
+    %y_dim_10 = arith.muli %y_dim, %N_CTX {async_task_id = array<i32: 0, 2, 3>} : i32
+    %desc_q_11 = tt.make_tensor_descriptor %desc_q, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<128x128xf16, #shared>
+    %desc_do_12 = tt.make_tensor_descriptor %desc_do, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<128x128xf16, #shared>
+    %desc_dq_13 = tt.make_tensor_descriptor %desc_dq, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 0>} : !tt.ptr<f32>, !tt.tensordesc<128x32xf32, #shared1>
+    %desc_v_14 = tt.make_tensor_descriptor %desc_v, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<128x128xf16, #shared>
+    %desc_k_15 = tt.make_tensor_descriptor %desc_k, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f16>, !tt.tensordesc<128x128xf16, #shared>
+    %desc_dv_16 = tt.make_tensor_descriptor %desc_dv, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<f16>, !tt.tensordesc<128x32xf16, #shared2>
+    %desc_dk_17 = tt.make_tensor_descriptor %desc_dk, [%y_dim_10, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<f16>, !tt.tensordesc<128x32xf16, #shared2>
+    %off_bh = arith.extsi %stride_tok {async_task_id = array<i32: 0, 2, 3>} : i32 to i64
+    %num_steps = arith.divsi %N_CTX, %c128_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %offs_m = tt.make_range {async_task_id = array<i32: 3>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked2>
+    %dkN = tt.splat %sm_scale {async_task_id = array<i32: 3>} : f32 -> tensor<128x32xf32, #blocked>
     %tile_idx = scf.for %_ = %c0_i32 to %2 step %c1_i32 iter_args(%tile_idx_18 = %prog_id) -> (i32)  : i32 {
-      %pid = arith.remsi %tile_idx_18, %n_tile_num_8 {async_task_id = array<i32: 2, 3>} : i32 loc(#loc141)
-      %bhid = arith.divsi %tile_idx_18, %n_tile_num_8 {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc142)
-      %off_chz = arith.muli %bhid, %N_CTX {async_task_id = array<i32: 3>} : i32 loc(#loc194)
-      %off_chz_19 = arith.extsi %off_chz {async_task_id = array<i32: 3>} : i32 to i64 loc(#loc195)
-      %off_bh_20 = arith.remsi %bhid, %H {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc196)
-      %off_bh_21 = arith.muli %stride_h, %off_bh_20 {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc197)
-      %off_bh_22 = arith.divsi %bhid, %H {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc198)
-      %off_bh_23 = arith.muli %stride_z, %off_bh_22 {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc199)
-      %off_bh_24 = arith.addi %off_bh_21, %off_bh_23 {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc200)
-      %off_bh_25 = arith.extsi %off_bh_24 {async_task_id = array<i32: 0, 2, 3>} : i32 to i64 loc(#loc201)
-      %off_bh_26 = arith.divsi %off_bh_25, %off_bh {async_task_id = array<i32: 0, 2, 3>} : i64 loc(#loc191)
-      %M_27 = tt.addptr %M, %off_chz_19 {async_task_id = array<i32: 3>} : !tt.ptr<f32>, i64 loc(#loc202)
-      %D_28 = tt.addptr %D, %off_chz_19 {async_task_id = array<i32: 3>} : !tt.ptr<f32>, i64 loc(#loc203)
-      %start_n = arith.muli %pid, %c128_i32 {async_task_id = array<i32: 2, 3>} : i32 loc(#loc204)
-      %k_29 = arith.extsi %start_n {async_task_id = array<i32: 2, 3>} : i32 to i64 loc(#loc205)
-      %k_30 = arith.addi %off_bh_26, %k_29 {async_task_id = array<i32: 2, 3>} : i64 loc(#loc205)
-      %k_31 = arith.trunci %k_30 {async_task_id = array<i32: 2, 3>} : i64 to i32 loc(#loc206)
-      %k_32 = tt.descriptor_load %desc_k_15[%k_31, %c0_i32] {async_task_id = array<i32: 2>} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked3> loc(#loc186)
-      ttg.local_store %k_32, %k {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked3> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc186)
-      %v_33 = tt.descriptor_load %desc_v_14[%k_31, %c0_i32] {async_task_id = array<i32: 2>} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked3> loc(#loc185)
-      ttg.local_store %v_33, %v {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked3> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc185)
-      %m = tt.splat %M_27 {async_task_id = array<i32: 3>} : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked2> loc(#loc220)
-      %Di = tt.splat %D_28 {async_task_id = array<i32: 3>} : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked2> loc(#loc221)
-      %dk_34 = ttng.tmem_store %cst_6, %dk[%dk_5], %true {async_task_id = array<i32: 0>, tmem.start = array<i32: 9>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc218)
-      %dv_35 = ttng.tmem_store %cst_6, %dv_3[%dv_4], %true {async_task_id = array<i32: 0>, tmem.start = array<i32: 7>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc214)
+      %pid = arith.remsi %tile_idx_18, %n_tile_num_8 {async_task_id = array<i32: 2, 3>} : i32
+      %bhid = arith.divsi %tile_idx_18, %n_tile_num_8 {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_chz = arith.muli %bhid, %N_CTX {async_task_id = array<i32: 3>} : i32
+      %off_chz_19 = arith.extsi %off_chz {async_task_id = array<i32: 3>} : i32 to i64
+      %off_bh_20 = arith.remsi %bhid, %H {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_bh_21 = arith.muli %stride_h, %off_bh_20 {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_bh_22 = arith.divsi %bhid, %H {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_bh_23 = arith.muli %stride_z, %off_bh_22 {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_bh_24 = arith.addi %off_bh_21, %off_bh_23 {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_bh_25 = arith.extsi %off_bh_24 {async_task_id = array<i32: 0, 2, 3>} : i32 to i64
+      %off_bh_26 = arith.divsi %off_bh_25, %off_bh {async_task_id = array<i32: 0, 2, 3>} : i64
+      %M_27 = tt.addptr %M, %off_chz_19 {async_task_id = array<i32: 3>} : !tt.ptr<f32>, i64
+      %D_28 = tt.addptr %D, %off_chz_19 {async_task_id = array<i32: 3>} : !tt.ptr<f32>, i64
+      %start_n = arith.muli %pid, %c128_i32 {async_task_id = array<i32: 2, 3>} : i32
+      %k_29 = arith.extsi %start_n {async_task_id = array<i32: 2, 3>} : i32 to i64
+      %k_30 = arith.addi %off_bh_26, %k_29 {async_task_id = array<i32: 2, 3>} : i64
+      %k_31 = arith.trunci %k_30 {async_task_id = array<i32: 2, 3>} : i64 to i32
+      %k_32 = tt.descriptor_load %desc_k_15[%k_31, %c0_i32] {async_task_id = array<i32: 2>} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked3>
+      ttg.local_store %k_32, %k {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked3> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %v_33 = tt.descriptor_load %desc_v_14[%k_31, %c0_i32] {async_task_id = array<i32: 2>} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked3>
+      ttg.local_store %v_33, %v {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked3> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %m = tt.splat %M_27 {async_task_id = array<i32: 3>} : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked2>
+      %Di = tt.splat %D_28 {async_task_id = array<i32: 3>} : !tt.ptr<f32> -> tensor<128x!tt.ptr<f32>, #blocked2>
+      %dk_34 = ttng.tmem_store %cst_6, %dk[%dk_5], %true {async_task_id = array<i32: 0>, tmem.start = array<i32: 9>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %dv_35 = ttng.tmem_store %cst_6, %dv_3[%dv_4], %true {async_task_id = array<i32: 0>, tmem.start = array<i32: 7>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       %curr_m:7 = scf.for %curr_m_67 = %c0_i32 to %num_steps step %c1_i32 iter_args(%arg19 = %c0_i32, %arg20 = %false, %qkT_68 = %qkT_2, %dv_69 = %dv_35, %dpT_70 = %dpT_1, %dk_71 = %dk_34, %dq_72 = %dq_0) -> (i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
-        %q_73 = arith.extsi %arg19 {async_task_id = array<i32: 0, 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32 to i64 loc(#loc223)
-        %q_74 = arith.addi %off_bh_26, %q_73 {async_task_id = array<i32: 0, 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i64 loc(#loc223)
-        %q_75 = arith.trunci %q_74 {async_task_id = array<i32: 0, 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i64 to i32 loc(#loc224)
-        %q_76 = tt.descriptor_load %desc_q_11[%q_75, %c0_i32] {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked3> loc(#loc217)
-        ttg.local_store %q_76, %q {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x128xf16, #blocked3> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc217)
-        %qT = ttg.memdesc_trans %q {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared3, #smem, mutable> loc(#loc225)
-        %offs_m_77 = tt.splat %arg19 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32 -> tensor<128xi32, #blocked2> loc(#loc226)
-        %offs_m_78 = arith.addi %offs_m_77, %offs_m {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128xi32, #blocked2> loc(#loc226)
-        %m_79 = tt.addptr %m, %offs_m_78 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>, tensor<128xi32, #blocked2> loc(#loc220)
-        %m_80 = tt.load %m_79 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2> loc(#loc227)
-        %qkT_81 = ttng.tc_gen5_mma %k, %qT, %qkT[%qkT_68], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc216)
-        %pT = ttg.convert_layout %m_80 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128xf32, #blocked2> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked1}>> loc(#loc228)
-        %pT_82 = tt.expand_dims %pT {async_task_id = array<i32: 3>, axis = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128xf32, #blocked1> loc(#loc229)
-        %pT_83 = tt.broadcast %pT_82 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<1x128xf32, #blocked1> -> tensor<128x128xf32, #blocked1> loc(#loc228)
-        %qkT_84, %qkT_85 = ttng.tmem_load %qkT[%qkT_81] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1> loc(#loc216)
-        %pT_86 = arith.subf %qkT_84, %pT_83 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> loc(#loc228)
-        %pT_87 = math.exp2 %pT_86 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> loc(#loc230)
-        %do_88 = tt.descriptor_load %desc_do_12[%q_75, %c0_i32] {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked3> loc(#loc215)
-        ttg.local_store %do_88, %do {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x128xf16, #blocked3> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc215)
-        %ppT = arith.truncf %pT_87 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1> loc(#loc231)
-        %dv_89 = arith.constant {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} true loc(#loc214)
-        ttng.tmem_store %ppT, %dv, %dv_89 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc214)
-        %dv_90 = ttng.tc_gen5_mma %dv, %do, %dv_3[%dv_69], %arg20, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, tmem.end = array<i32: 7>, tmem.start = array<i32: 8>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc214)
-        %Di_91 = tt.addptr %Di, %offs_m_78 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>, tensor<128xi32, #blocked2> loc(#loc221)
-        %Di_92 = tt.load %Di_91 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2> loc(#loc232)
-        %dpT_93 = ttg.memdesc_trans %do {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared3, #smem, mutable> loc(#loc233)
-        %dpT_94 = ttng.tc_gen5_mma %v, %dpT_93, %dpT[%dpT_70], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc213)
-        %dsT_95 = ttg.convert_layout %Di_92 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128xf32, #blocked2> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked1}>> loc(#loc234)
-        %dsT_96 = tt.expand_dims %dsT_95 {async_task_id = array<i32: 3>, axis = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128xf32, #blocked1> loc(#loc235)
-        %dsT_97 = tt.broadcast %dsT_96 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<1x128xf32, #blocked1> -> tensor<128x128xf32, #blocked1> loc(#loc234)
-        %dpT_98, %dpT_99 = ttng.tmem_load %dpT[%dpT_94] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1> loc(#loc213)
-        %dsT_100 = arith.subf %dpT_98, %dsT_97 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> loc(#loc234)
-        %dsT_101 = arith.mulf %pT_87, %dsT_100 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> loc(#loc236)
-        %dsT_102 = arith.truncf %dsT_101 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1> loc(#loc212)
-        ttg.local_store %dsT_102, %dsT {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc212)
+        %q_73 = arith.extsi %arg19 {async_task_id = array<i32: 0, 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32 to i64
+        %q_74 = arith.addi %off_bh_26, %q_73 {async_task_id = array<i32: 0, 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i64
+        %q_75 = arith.trunci %q_74 {async_task_id = array<i32: 0, 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i64 to i32
+        %q_76 = tt.descriptor_load %desc_q_11[%q_75, %c0_i32] {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked3>
+        ttg.local_store %q_76, %q {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x128xf16, #blocked3> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %qT = ttg.memdesc_trans %q {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>
+        %offs_m_77 = tt.splat %arg19 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : i32 -> tensor<128xi32, #blocked2>
+        %offs_m_78 = arith.addi %offs_m_77, %offs_m {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128xi32, #blocked2>
+        %m_79 = tt.addptr %m, %offs_m_78 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>, tensor<128xi32, #blocked2>
+        %m_80 = tt.load %m_79 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>
+        %qkT_81 = ttng.tc_gen5_mma %k, %qT, %qkT[%qkT_68], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %pT = ttg.convert_layout %m_80 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128xf32, #blocked2> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked1}>>
+        %pT_82 = tt.expand_dims %pT {async_task_id = array<i32: 3>, axis = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128xf32, #blocked1>
+        %pT_83 = tt.broadcast %pT_82 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<1x128xf32, #blocked1> -> tensor<128x128xf32, #blocked1>
+        %qkT_84, %qkT_85 = ttng.tmem_load %qkT[%qkT_81] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+        %pT_86 = arith.subf %qkT_84, %pT_83 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1>
+        %pT_87 = math.exp2 %pT_86 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1>
+        %do_88 = tt.descriptor_load %desc_do_12[%q_75, %c0_i32] {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked3>
+        ttg.local_store %do_88, %do {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x128xf16, #blocked3> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %ppT = arith.truncf %pT_87 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1>
+        %dv_89 = arith.constant {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} true
+        ttng.tmem_store %ppT, %dv, %dv_89 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %dv_90 = ttng.tc_gen5_mma %dv, %do, %dv_3[%dv_69], %arg20, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, tmem.end = array<i32: 7>, tmem.start = array<i32: 8>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %Di_91 = tt.addptr %Di, %offs_m_78 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>, tensor<128xi32, #blocked2>
+        %Di_92 = tt.load %Di_91 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>
+        %dpT_93 = ttg.memdesc_trans %do {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared3, #smem, mutable> loc("dpT")
+        %dpT_94 = ttng.tc_gen5_mma %v, %dpT_93, %dpT[%dpT_70], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> loc("dpT")
+        %dsT_95 = ttg.convert_layout %Di_92 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128xf32, #blocked2> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked1}>> loc("dsT")
+        %dsT_96 = tt.expand_dims %dsT_95 {async_task_id = array<i32: 3>, axis = 0 : i32, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128xf32, #blocked1> loc("dsT")
+        %dsT_97 = tt.broadcast %dsT_96 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<1x128xf32, #blocked1> -> tensor<128x128xf32, #blocked1> loc("dsT")
+        %dpT_98, %dpT_99 = ttng.tmem_load %dpT[%dpT_94] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1> loc("dpT")
+        %dsT_100 = arith.subf %dpT_98, %dsT_97 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> loc("dsT")
+        %dsT_101 = arith.mulf %pT_87, %dsT_100 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> loc("dsT")
+        %dsT_102 = arith.truncf %dsT_101 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1> loc("dsT")
+        ttg.local_store %dsT_102, %dsT {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc("dsT")
         // computation (task3) materializes dsT into the shared buf8 TMEM slot.
-        ttng.tmem_store %dsT_102, %dsT_t, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc212)
+        ttng.tmem_store %dsT_102, %dsT_t, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable> loc("dsT")
         // HAZARD: dq (writes buf8) emitted BEFORE dk reads dsT from buf8 -> the
         // {dpT,dsT,dq} chain has no unique order (dsT and dq are incomparable).
-        %dq_104 = ttg.memdesc_trans %dsT {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared3, #smem, mutable> loc(#loc237)
-        %dq_105 = ttng.tc_gen5_mma %dq_104, %k, %dq[%dq_72], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc211)
-        %dk_103 = ttng.tc_gen5_mma %dsT_t, %q, %dk[%dk_71], %arg20, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, tmem.end = array<i32: 9>, tmem.start = array<i32: 10>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc218)
-        %dq_106, %dq_107 = ttng.tmem_load %dq[%dq_105] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1> loc(#loc211)
-        %dqs = tt.reshape %dq_106 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked4> loc(#loc253)
-        %dqs_108 = tt.trans %dqs {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5> loc(#loc254)
-        %dqs_109, %dqs_110 = tt.split %dqs_108 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6> loc(#loc255)
-        %dqs_111 = tt.reshape %dqs_109 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7> loc(#loc270)
-        %dqs_112 = tt.trans %dqs_111 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8> loc(#loc271)
-        %dqs_113, %dqs_114 = tt.split %dqs_112 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked> loc(#loc272)
-        %dqs_115 = tt.reshape %dqs_110 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7> loc(#loc273)
-        %dqs_116 = tt.trans %dqs_115 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8> loc(#loc274)
-        %dqs_117, %dqs_118 = tt.split %dqs_116 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked> loc(#loc275)
-        %dqN = arith.mulf %dqs_113, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> loc(#loc239)
-        %dqN_119 = ttg.convert_layout %dqN {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> -> tensor<128x32xf32, #blocked9> loc(#loc239)
-        tt.descriptor_reduce add, %desc_dq_13[%q_75, %c0_i32], %dqN_119 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x32xf32, #shared1>, tensor<128x32xf32, #blocked9> loc(#loc240)
-        %dqN_120 = arith.mulf %dqs_114, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> loc(#loc239)
-        %dqN_121 = ttg.convert_layout %dqN_120 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> -> tensor<128x32xf32, #blocked9> loc(#loc239)
-        tt.descriptor_reduce add, %desc_dq_13[%q_75, %c0_i32], %dqN_121 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x32xf32, #shared1>, tensor<128x32xf32, #blocked9> loc(#loc240)
-        %dqN_122 = arith.mulf %dqs_117, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> loc(#loc239)
-        %dqN_123 = ttg.convert_layout %dqN_122 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> -> tensor<128x32xf32, #blocked9> loc(#loc239)
-        tt.descriptor_reduce add, %desc_dq_13[%q_75, %c0_i32], %dqN_123 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x32xf32, #shared1>, tensor<128x32xf32, #blocked9> loc(#loc240)
-        %dqN_124 = arith.mulf %dqs_118, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> loc(#loc239)
-        %dqN_125 = ttg.convert_layout %dqN_124 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> -> tensor<128x32xf32, #blocked9> loc(#loc239)
-        tt.descriptor_reduce add, %desc_dq_13[%q_75, %c0_i32], %dqN_125 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x32xf32, #shared1>, tensor<128x32xf32, #blocked9> loc(#loc240)
-        %curr_m_126 = arith.addi %arg19, %c128_i32 {async_task_id = array<i32: 0, 2, 3>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i32 loc(#loc241)
-        scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %curr_m_126, %true, %qkT_85, %dv_90, %dpT_99, %dk_103, %dq_107 : i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token loc(#loc208)
-      } {async_task_id = array<i32: 0, 1, 2, 3>, tt.scheduled_max_stage = 1 : i32} loc(#loc252)
-      %dv_36, %dv_37 = ttng.tmem_load %dv_3[%curr_m#3] {async_task_id = array<i32: 3>, tmem.end = array<i32: 8>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1> loc(#loc214)
-      %dvs = tt.reshape %dv_36 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked4> loc(#loc242)
-      %dvs_38 = tt.trans %dvs {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5> loc(#loc243)
-      %dvs_39, %dvs_40 = tt.split %dvs_38 {async_task_id = array<i32: 3>} : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6> loc(#loc244)
-      %dvs_41 = tt.reshape %dvs_40 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7> loc(#loc258)
-      %dvs_42 = tt.reshape %dvs_39 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7> loc(#loc259)
-      %dvs_43 = tt.trans %dvs_42 {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8> loc(#loc260)
-      %dvs_44, %dvs_45 = tt.split %dvs_43 {async_task_id = array<i32: 3>} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked> loc(#loc261)
-      %3 = arith.truncf %dvs_45 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked> loc(#loc178)
-      %4 = arith.truncf %dvs_44 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked> loc(#loc178)
-      %dvs_46 = tt.trans %dvs_41 {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8> loc(#loc262)
-      %dvs_47, %dvs_48 = tt.split %dvs_46 {async_task_id = array<i32: 3>} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked> loc(#loc263)
-      %5 = arith.truncf %dvs_48 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked> loc(#loc178)
-      %6 = arith.truncf %dvs_47 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked> loc(#loc178)
-      %7 = ttg.convert_layout %4 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9> loc(#loc178)
-      tt.descriptor_store %desc_dv_16[%k_31, %c0_i32], %7 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9> loc(#loc179)
-      %8 = ttg.convert_layout %3 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9> loc(#loc178)
-      tt.descriptor_store %desc_dv_16[%k_31, %c0_i32], %8 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9> loc(#loc179)
-      %9 = ttg.convert_layout %6 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9> loc(#loc178)
-      tt.descriptor_store %desc_dv_16[%k_31, %c0_i32], %9 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9> loc(#loc179)
-      %10 = ttg.convert_layout %5 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9> loc(#loc178)
-      tt.descriptor_store %desc_dv_16[%k_31, %c0_i32], %10 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9> loc(#loc179)
-      %dk_49, %dk_50 = ttng.tmem_load %dk[%curr_m#5] {async_task_id = array<i32: 3>, tmem.end = array<i32: 10>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1> loc(#loc218)
-      %dks = tt.reshape %dk_49 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked4> loc(#loc247)
-      %dks_51 = tt.trans %dks {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5> loc(#loc248)
-      %dks_52, %dks_53 = tt.split %dks_51 {async_task_id = array<i32: 3>} : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6> loc(#loc249)
-      %dks_54 = tt.reshape %dks_53 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7> loc(#loc264)
-      %dks_55 = tt.reshape %dks_52 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7> loc(#loc265)
-      %dks_56 = tt.trans %dks_55 {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8> loc(#loc266)
-      %dks_57, %dks_58 = tt.split %dks_56 {async_task_id = array<i32: 3>} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked> loc(#loc267)
-      %dkN_59 = arith.mulf %dks_58, %dkN {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> loc(#loc193)
-      %dkN_60 = arith.mulf %dks_57, %dkN {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> loc(#loc193)
-      %dks_61 = tt.trans %dks_54 {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8> loc(#loc268)
-      %dks_62, %dks_63 = tt.split %dks_61 {async_task_id = array<i32: 3>} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked> loc(#loc269)
-      %dkN_64 = arith.mulf %dks_63, %dkN {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> loc(#loc193)
-      %dkN_65 = arith.mulf %dks_62, %dkN {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> loc(#loc193)
-      %11 = arith.truncf %dkN_60 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked> loc(#loc181)
-      %12 = ttg.convert_layout %11 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9> loc(#loc181)
-      tt.descriptor_store %desc_dk_17[%k_31, %c0_i32], %12 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9> loc(#loc182)
-      %13 = arith.truncf %dkN_59 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked> loc(#loc181)
-      %14 = ttg.convert_layout %13 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9> loc(#loc181)
-      tt.descriptor_store %desc_dk_17[%k_31, %c0_i32], %14 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9> loc(#loc182)
-      %15 = arith.truncf %dkN_65 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked> loc(#loc181)
-      %16 = ttg.convert_layout %15 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9> loc(#loc181)
-      tt.descriptor_store %desc_dk_17[%k_31, %c0_i32], %16 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9> loc(#loc182)
-      %17 = arith.truncf %dkN_64 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked> loc(#loc181)
-      %18 = ttg.convert_layout %17 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9> loc(#loc181)
-      tt.descriptor_store %desc_dk_17[%k_31, %c0_i32], %18 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9> loc(#loc182)
-      %tile_idx_66 = arith.addi %tile_idx_18, %num_progs {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc183)
-      scf.yield {async_task_id = array<i32: 0, 2, 3>} %tile_idx_66 : i32 loc(#loc91)
-    } {async_task_id = array<i32: 0, 1, 2, 3>, tt.merge_epilogue = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 200000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "load", "computation"], ttg.warp_specialize.tag = 0 : i32} loc(#loc140)
-    tt.return loc(#loc92)
-  } loc(#loc)
-} loc(#loc)
-#loc1 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":671:31)
-#loc2 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":766:16)
-#loc3 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":882:8)
-#loc4 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1128:12)
-#loc5 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":669:17)
-#loc6 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":667:20)
-#loc7 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":665:22)
-#loc8 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":662:22)
-#loc9 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":657:20)
-#loc10 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":653:20)
-#loc11 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":670:22)
-#loc12 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":859:20)
-#loc13 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":858:20)
-#loc14 = loc(unknown)
-#loc15 = loc("/data/users/mren/MetaMain/triton/python/triton/language/standard.py":41:22)
-#loc16 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1044:32)
-#loc17 = loc("/data/users/mren/MetaMain/triton/python/triton/language/standard.py":41:28)
-#loc18 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1045:28)
-#loc19 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1046:32)
-#loc20 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1047:31)
-#loc21 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1047:39)
-#loc22 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1049:34)
-#loc23 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1050:31)
-#loc24 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1050:17)
-#loc25 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1050:7)
-#loc26 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1051:24)
-#loc27 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1055:20)
-#loc28 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1055:24)
-#loc29 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1057:8)
-#loc30 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1063:8)
-#loc31 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1069:8)
-#loc32 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1075:8)
-#loc33 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1081:8)
-#loc34 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1087:8)
-#loc35 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1093:8)
-#loc36 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":847:80)
-#loc37 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":860:37)
-#loc38 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":655:35)
-#loc39 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":899:30)
-#loc40 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1100:22)
-#loc41 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1101:25)
-#loc42 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1102:27)
-#loc43 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":846:22)
-#loc44 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":846:32)
-#loc45 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":847:34)
-#loc46 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":847:27)
-#loc47 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":847:59)
-#loc48 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":847:51)
-#loc49 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":847:39)
-#loc50 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":847:66)
-#loc51 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":849:9)
-#loc52 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":850:9)
-#loc53 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":855:20)
-#loc54 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":858:31)
-#loc55 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":858:43)
-#loc56 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":656:20)
-#loc57 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":666:21)
-#loc58 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":745:35)
-#loc59 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":653:31)
-#loc60 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":653:42)
-#loc61 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":654:18)
-#loc62 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":655:22)
-#loc63 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":656:16)
-#loc64 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":658:28)
-#loc65 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":658:30)
-#loc66 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":658:22)
-#loc67 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":664:17)
-#loc68 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":666:17)
-#loc69 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":667:29)
-#loc70 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":668:22)
-#loc71 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":668:25)
-#loc72 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":668:16)
-#loc73 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":671:25)
-#loc74 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":609:27)
-#loc75 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":672:23)
-#loc76 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":609:75)
-#loc77 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":609:17)
-#loc78 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":610:28)
-#loc79 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":610:62)
-#loc80 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":674:30)
-#loc81 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":675:64)
-#loc82 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":676:14)
-#loc83 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":746:12)
-#loc84 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":889:23)
-#loc85 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":894:19)
-#loc86 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":894:12)
-#loc87 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":897:23)
-#loc88 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":902:19)
-#loc89 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":902:12)
-#loc90 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1130:20)
-#loc91 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1130:8)
-#loc92 = loc("/home/mren/local/MetaMain2/triton/python/tutorials/test-ws.py":1099:4)
-#loc109 = loc("dq"(#loc1))
-#loc110 = loc(callsite(#loc3 at #loc4))
-#loc111 = loc("dsT"(#loc5))
-#loc112 = loc("dpT"(#loc6))
-#loc113 = loc("dv"(#loc7))
-#loc114 = loc("do"(#loc8))
-#loc115 = loc("qkT"(#loc9))
-#loc116 = loc("q"(#loc10))
-#loc117 = loc("dk"(#loc11))
-#loc118 = loc("v"(#loc12))
-#loc119 = loc("k"(#loc13))
-#loc120 = loc("n_tile_num"(#loc16))
-#loc121 = loc("prog_id"(#loc18))
-#loc122 = loc("num_progs"(#loc19))
-#loc123 = loc("total_tiles"(#loc20))
-#loc124 = loc("total_tiles"(#loc21))
-#loc125 = loc("tiles_per_sm"(#loc22))
-#loc126 = loc("tiles_per_sm"(#loc26))
-#loc127 = loc("y_dim"(#loc27))
-#loc128 = loc("y_dim"(#loc28))
-#loc129 = loc("desc_q"(#loc29))
-#loc130 = loc("desc_do"(#loc30))
-#loc131 = loc("desc_dq"(#loc31))
-#loc132 = loc("desc_v"(#loc32))
-#loc133 = loc("desc_k"(#loc33))
-#loc134 = loc("desc_dv"(#loc34))
-#loc135 = loc("desc_dk"(#loc35))
-#loc136 = loc("off_bh"(#loc36))
-#loc137 = loc("num_steps"(#loc37))
-#loc138 = loc("offs_m"(#loc38))
-#loc139 = loc("dkN"(#loc39))
-#loc140 = loc("tile_idx"(#loc40))
-#loc141 = loc("pid"(#loc41))
-#loc142 = loc("bhid"(#loc42))
-#loc143 = loc("off_chz"(#loc43))
-#loc144 = loc("off_chz"(#loc44))
-#loc145 = loc("off_bh"(#loc45))
-#loc146 = loc("off_bh"(#loc46))
-#loc147 = loc("off_bh"(#loc47))
-#loc148 = loc("off_bh"(#loc48))
-#loc149 = loc("off_bh"(#loc49))
-#loc150 = loc("off_bh"(#loc50))
-#loc151 = loc("M"(#loc51))
-#loc152 = loc("D"(#loc52))
-#loc153 = loc("start_n"(#loc53))
-#loc154 = loc("k"(#loc54))
-#loc155 = loc("k"(#loc55))
-#loc156 = loc("m"(#loc56))
-#loc157 = loc("Di"(#loc57))
-#loc158 = loc("dk"(#loc58))
-#loc159 = loc("q"(#loc59))
-#loc160 = loc("q"(#loc60))
-#loc161 = loc("qT"(#loc61))
-#loc162 = loc("offs_m"(#loc62))
-#loc163 = loc("m"(#loc63))
-#loc164 = loc("pT"(#loc64))
-#loc165 = loc("pT"(#loc65))
-#loc166 = loc("pT"(#loc66))
-#loc167 = loc("ppT"(#loc67))
-#loc168 = loc("Di"(#loc68))
-#loc169 = loc("dpT"(#loc69))
-#loc170 = loc("dsT"(#loc70))
-#loc171 = loc("dsT"(#loc71))
-#loc172 = loc("dsT"(#loc72))
-#loc173 = loc("dq"(#loc73))
-#loc174 = loc("dqs"(#loc75))
-#loc175 = loc("dqN"(#loc80))
-#loc176 = loc("curr_m"(#loc82))
-#loc177 = loc("dvs"(#loc84))
-#loc178 = loc(callsite(#loc85 at #loc4))
-#loc179 = loc(callsite(#loc86 at #loc4))
-#loc180 = loc("dks"(#loc87))
-#loc181 = loc(callsite(#loc88 at #loc4))
-#loc182 = loc(callsite(#loc89 at #loc4))
-#loc183 = loc("tile_idx"(#loc90))
-#loc184 = loc(callsite(#loc2 at #loc110))
-#loc185 = loc(callsite(#loc118 at #loc4))
-#loc186 = loc(callsite(#loc119 at #loc4))
-#loc187 = loc(callsite(#loc15 at #loc120))
-#loc188 = loc(callsite(#loc17 at #loc120))
-#loc189 = loc("tiles_per_sm"(#loc125))
-#loc190 = loc("tiles_per_sm"(#loc126))
-#loc191 = loc(callsite(#loc136 at #loc4))
-#loc192 = loc(callsite(#loc137 at #loc4))
-#loc193 = loc(callsite(#loc139 at #loc4))
-#loc194 = loc(callsite(#loc143 at #loc4))
-#loc195 = loc(callsite(#loc144 at #loc4))
-#loc196 = loc(callsite(#loc145 at #loc4))
-#loc197 = loc(callsite(#loc146 at #loc4))
-#loc198 = loc(callsite(#loc147 at #loc4))
-#loc199 = loc(callsite(#loc148 at #loc4))
-#loc200 = loc(callsite(#loc149 at #loc4))
-#loc201 = loc(callsite(#loc150 at #loc4))
-#loc202 = loc(callsite(#loc151 at #loc4))
-#loc203 = loc(callsite(#loc152 at #loc4))
-#loc204 = loc(callsite(#loc153 at #loc4))
-#loc205 = loc(callsite(#loc154 at #loc4))
-#loc206 = loc(callsite(#loc155 at #loc4))
-#loc207 = loc("dv"(#loc158))
-#loc208 = loc(callsite(#loc83 at #loc110))
-#loc209 = loc(callsite(#loc177 at #loc4))
-#loc210 = loc(callsite(#loc180 at #loc4))
-#loc211 = loc(callsite(#loc109 at #loc184))
-#loc212 = loc(callsite(#loc111 at #loc184))
-#loc213 = loc(callsite(#loc112 at #loc184))
-#loc214 = loc(callsite(#loc113 at #loc184))
-#loc215 = loc(callsite(#loc114 at #loc184))
-#loc216 = loc(callsite(#loc115 at #loc184))
-#loc217 = loc(callsite(#loc116 at #loc184))
-#loc218 = loc(callsite(#loc117 at #loc184))
-#loc219 = loc(callsite(#loc138 at #loc184))
-#loc220 = loc(callsite(#loc156 at #loc184))
-#loc221 = loc(callsite(#loc157 at #loc184))
-#loc222 = loc("curr_m"(#loc207))
-#loc223 = loc(callsite(#loc159 at #loc184))
-#loc224 = loc(callsite(#loc160 at #loc184))
-#loc225 = loc(callsite(#loc161 at #loc184))
-#loc226 = loc(callsite(#loc162 at #loc184))
-#loc227 = loc(callsite(#loc163 at #loc184))
-#loc228 = loc(callsite(#loc164 at #loc184))
-#loc229 = loc(callsite(#loc165 at #loc184))
-#loc230 = loc(callsite(#loc166 at #loc184))
-#loc231 = loc(callsite(#loc167 at #loc184))
-#loc232 = loc(callsite(#loc168 at #loc184))
-#loc233 = loc(callsite(#loc169 at #loc184))
-#loc234 = loc(callsite(#loc170 at #loc184))
-#loc235 = loc(callsite(#loc171 at #loc184))
-#loc236 = loc(callsite(#loc172 at #loc184))
-#loc237 = loc(callsite(#loc173 at #loc184))
-#loc238 = loc(callsite(#loc174 at #loc184))
-#loc239 = loc(callsite(#loc175 at #loc184))
-#loc240 = loc(callsite(#loc81 at #loc184))
-#loc241 = loc(callsite(#loc176 at #loc184))
-#loc242 = loc(callsite(#loc74 at #loc209))
-#loc243 = loc(callsite(#loc76 at #loc209))
-#loc244 = loc(callsite(#loc77 at #loc209))
-#loc245 = loc(callsite(#loc79 at #loc209))
-#loc246 = loc(callsite(#loc78 at #loc209))
-#loc247 = loc(callsite(#loc74 at #loc210))
-#loc248 = loc(callsite(#loc76 at #loc210))
-#loc249 = loc(callsite(#loc77 at #loc210))
-#loc250 = loc(callsite(#loc79 at #loc210))
-#loc251 = loc(callsite(#loc78 at #loc210))
-#loc252 = loc(callsite(#loc222 at #loc110))
-#loc253 = loc(callsite(#loc74 at #loc238))
-#loc254 = loc(callsite(#loc76 at #loc238))
-#loc255 = loc(callsite(#loc77 at #loc238))
-#loc256 = loc(callsite(#loc78 at #loc238))
-#loc257 = loc(callsite(#loc79 at #loc238))
-#loc258 = loc(callsite(#loc74 at #loc245))
-#loc259 = loc(callsite(#loc74 at #loc246))
-#loc260 = loc(callsite(#loc76 at #loc246))
-#loc261 = loc(callsite(#loc77 at #loc246))
-#loc262 = loc(callsite(#loc76 at #loc245))
-#loc263 = loc(callsite(#loc77 at #loc245))
-#loc264 = loc(callsite(#loc74 at #loc250))
-#loc265 = loc(callsite(#loc74 at #loc251))
-#loc266 = loc(callsite(#loc76 at #loc251))
-#loc267 = loc(callsite(#loc77 at #loc251))
-#loc268 = loc(callsite(#loc76 at #loc250))
-#loc269 = loc(callsite(#loc77 at #loc250))
-#loc270 = loc(callsite(#loc74 at #loc256))
-#loc271 = loc(callsite(#loc76 at #loc256))
-#loc272 = loc(callsite(#loc77 at #loc256))
-#loc273 = loc(callsite(#loc74 at #loc257))
-#loc274 = loc(callsite(#loc76 at #loc257))
-#loc275 = loc(callsite(#loc77 at #loc257))
+        %dq_104 = ttg.memdesc_trans %dsT {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared3, #smem, mutable> loc("dq")
+        %dq_105 = ttng.tc_gen5_mma %dq_104, %k, %dq[%dq_72], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> loc("dq")
+        %dk_103 = ttng.tc_gen5_mma %dsT_t, %q, %dk[%dk_71], %arg20, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32, tmem.end = array<i32: 9>, tmem.start = array<i32: 10>, tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dq_106, %dq_107 = ttng.tmem_load %dq[%dq_105] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1> loc("dq")
+        %dqs = tt.reshape %dq_106 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked4>
+        %dqs_108 = tt.trans %dqs {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+        %dqs_109, %dqs_110 = tt.split %dqs_108 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+        %dqs_111 = tt.reshape %dqs_109 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+        %dqs_112 = tt.trans %dqs_111 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+        %dqs_113, %dqs_114 = tt.split %dqs_112 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked>
+        %dqs_115 = tt.reshape %dqs_110 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+        %dqs_116 = tt.trans %dqs_115 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+        %dqs_117, %dqs_118 = tt.split %dqs_116 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked>
+        %dqN = arith.mulf %dqs_113, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked>
+        %dqN_119 = ttg.convert_layout %dqN {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq_13[%q_75, %c0_i32], %dqN_119 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x32xf32, #shared1>, tensor<128x32xf32, #blocked9>
+        %dqN_120 = arith.mulf %dqs_114, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked>
+        %dqN_121 = ttg.convert_layout %dqN_120 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq_13[%q_75, %c0_i32], %dqN_121 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x32xf32, #shared1>, tensor<128x32xf32, #blocked9>
+        %dqN_122 = arith.mulf %dqs_117, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked>
+        %dqN_123 = ttg.convert_layout %dqN_122 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq_13[%q_75, %c0_i32], %dqN_123 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x32xf32, #shared1>, tensor<128x32xf32, #blocked9>
+        %dqN_124 = arith.mulf %dqs_118, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked>
+        %dqN_125 = ttg.convert_layout %dqN_124 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #blocked> -> tensor<128x32xf32, #blocked9>
+        tt.descriptor_reduce add, %desc_dq_13[%q_75, %c0_i32], %dqN_125 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x32xf32, #shared1>, tensor<128x32xf32, #blocked9>
+        %curr_m_126 = arith.addi %arg19, %c128_i32 {async_task_id = array<i32: 0, 2, 3>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i32
+        scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %curr_m_126, %true, %qkT_85, %dv_90, %dpT_99, %dk_103, %dq_107 : i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
+      } {async_task_id = array<i32: 0, 1, 2, 3>, tt.scheduled_max_stage = 1 : i32}
+      %dv_36, %dv_37 = ttng.tmem_load %dv_3[%curr_m#3] {async_task_id = array<i32: 3>, tmem.end = array<i32: 8>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+      %dvs = tt.reshape %dv_36 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked4>
+      %dvs_38 = tt.trans %dvs {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+      %dvs_39, %dvs_40 = tt.split %dvs_38 {async_task_id = array<i32: 3>} : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+      %dvs_41 = tt.reshape %dvs_40 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dvs_42 = tt.reshape %dvs_39 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dvs_43 = tt.trans %dvs_42 {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dvs_44, %dvs_45 = tt.split %dvs_43 {async_task_id = array<i32: 3>} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked>
+      %3 = arith.truncf %dvs_45 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %4 = arith.truncf %dvs_44 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %dvs_46 = tt.trans %dvs_41 {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dvs_47, %dvs_48 = tt.split %dvs_46 {async_task_id = array<i32: 3>} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked>
+      %5 = arith.truncf %dvs_48 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %6 = arith.truncf %dvs_47 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %7 = ttg.convert_layout %4 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dv_16[%k_31, %c0_i32], %7 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9>
+      %8 = ttg.convert_layout %3 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dv_16[%k_31, %c0_i32], %8 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9>
+      %9 = ttg.convert_layout %6 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dv_16[%k_31, %c0_i32], %9 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9>
+      %10 = ttg.convert_layout %5 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dv_16[%k_31, %c0_i32], %10 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9>
+      %dk_49, %dk_50 = ttng.tmem_load %dk[%curr_m#5] {async_task_id = array<i32: 3>, tmem.end = array<i32: 10>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+      %dks = tt.reshape %dk_49 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #blocked1> -> tensor<128x2x64xf32, #blocked4>
+      %dks_51 = tt.trans %dks {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #blocked4> -> tensor<128x64x2xf32, #blocked5>
+      %dks_52, %dks_53 = tt.split %dks_51 {async_task_id = array<i32: 3>} : tensor<128x64x2xf32, #blocked5> -> tensor<128x64xf32, #blocked6>
+      %dks_54 = tt.reshape %dks_53 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dks_55 = tt.reshape %dks_52 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #blocked6> -> tensor<128x2x32xf32, #blocked7>
+      %dks_56 = tt.trans %dks_55 {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dks_57, %dks_58 = tt.split %dks_56 {async_task_id = array<i32: 3>} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked>
+      %dkN_59 = arith.mulf %dks_58, %dkN {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked>
+      %dkN_60 = arith.mulf %dks_57, %dkN {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked>
+      %dks_61 = tt.trans %dks_54 {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #blocked7> -> tensor<128x32x2xf32, #blocked8>
+      %dks_62, %dks_63 = tt.split %dks_61 {async_task_id = array<i32: 3>} : tensor<128x32x2xf32, #blocked8> -> tensor<128x32xf32, #blocked>
+      %dkN_64 = arith.mulf %dks_63, %dkN {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked>
+      %dkN_65 = arith.mulf %dks_62, %dkN {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked>
+      %11 = arith.truncf %dkN_60 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %12 = ttg.convert_layout %11 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dk_17[%k_31, %c0_i32], %12 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9>
+      %13 = arith.truncf %dkN_59 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %14 = ttg.convert_layout %13 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dk_17[%k_31, %c0_i32], %14 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9>
+      %15 = arith.truncf %dkN_65 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %16 = ttg.convert_layout %15 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dk_17[%k_31, %c0_i32], %16 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9>
+      %17 = arith.truncf %dkN_64 {async_task_id = array<i32: 3>} : tensor<128x32xf32, #blocked> to tensor<128x32xf16, #blocked>
+      %18 = ttg.convert_layout %17 {async_task_id = array<i32: 3>} : tensor<128x32xf16, #blocked> -> tensor<128x32xf16, #blocked9>
+      tt.descriptor_store %desc_dk_17[%k_31, %c0_i32], %18 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x32xf16, #shared2>, tensor<128x32xf16, #blocked9>
+      %tile_idx_66 = arith.addi %tile_idx_18, %num_progs {async_task_id = array<i32: 0, 2, 3>} : i32
+      scf.yield {async_task_id = array<i32: 0, 2, 3>} %tile_idx_66 : i32
+    } {async_task_id = array<i32: 0, 1, 2, 3>, tt.merge_epilogue = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 200000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -67,6 +67,21 @@ tools = [
 if config.triton_ext_enabled:
     config.available_features.add("triton-ext-enabled")
 
+# Detect an assertions build so tests that rely on `-debug-only` output (only
+# emitted when LLVM_ENABLE_ASSERTIONS is on) can guard with `REQUIRES: asserts`.
+# The `-debug-only` option itself is only registered in assertions builds, so its
+# presence in the (hidden) help is a reliable probe.
+import subprocess  # noqa: E402
+
+_opt = lit.util.which('triton-opt', config.environment['PATH'])
+if _opt:
+    try:
+        _help = subprocess.run([_opt, '--help-hidden'], capture_output=True, text=True, timeout=60).stdout
+        if '-debug-only' in _help:
+            config.available_features.add("asserts")
+    except Exception:
+        pass
+
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 
 # TODO: what's this?

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -878,27 +878,17 @@ static bool hasDependencyChain(Channel *A, Channel *B) {
   if (!aConsumer || !bProducer)
     return false;
 
-  // Walk transitive users of aConsumer's results.
-  DenseSet<Operation *> visited;
-  SmallVector<Operation *> worklist;
-  for (auto result : aConsumer->getResults()) {
-    for (auto *user : result.getUsers())
-      worklist.push_back(user);
-  }
-  while (!worklist.empty()) {
-    auto *op = worklist.pop_back_val();
-    if (!visited.insert(op).second)
-      continue;
-    if (op == bProducer)
-      return true;
-    for (auto result : op->getResults()) {
-      for (auto *user : result.getUsers())
-        worklist.push_back(user);
-    }
-  }
+  // (1) data dependency (SSA or through memory, following buffer reuse across
+  // slots), cross-partition OK.
+  if (dependsThroughMemory(aConsumer, bProducer, /*followBufferReuse=*/true))
+    return true;
 
-  // Also check program order: if both are in the same block and aConsumer
-  // appears before bProducer, there is an implicit dependency via ordering.
+  // (2) program order within the same block (cross-partition included).
+  // NOTE: restricting this to the same partition is UNSOUND -- it drops
+  // legitimate cross-partition program-order reuse edges that real kernels rely
+  // on (regressed FA-bwd previously and HSTU 2-KV reduce_dq: wrong dq). The
+  // cost is that a hand-pinned unorderable group (t_bwd_badgroup) is not
+  // fast-failed here; that is the still-open N-way ordering crux (T279873316).
   if (aConsumer->getBlock() == bProducer->getBlock())
     return appearsBefore(aConsumer, bProducer);
 


### PR DESCRIPTION
Summary:

- reuse_group_2buffer_multibuf.mlir: multi-buffered dsT (separate memdesc_index
  slot-views for the store and the dq read) so the {dpT,dq} reuse forms only if
  the shared walk climbs subview->base (getRootBuffer).
- ws_code_partition_tmem_3group_chain.mlir: orderable {dpT,dsT,dq} 3-way reuse
  (dk reads dsT before dq overwrites) -- the accept complement of the existing
  _no_chain fatal fixture.
- verify_reuse_group_decisions.mlir: asserts the verifyReuseGroup2 /
  orderReuseGroupChain verdict (by channel name, via -debug-only) for each case:
  real 2-way accept, multi-buffer accept, orderable N-way accept, unorderable
  N-way fast-fail. Guarded REQUIRES: asserts; lit.cfg.py detects an assertions
  build. Tests only -- no default behavior change.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D112237569


