### PR TITLE
[AutoWS] Fix use-after-free on reuse-folded channel endpoints (#2298)

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -119,6 +119,8 @@ Operation *skipIdxOp(Operation *op) {
 }
 
 Operation *AllocChannel::getSrcOp() {
+  if (defunct)
+    return nullptr; // alloc erased by reuse folding; endpoints are dangling.
   // Prefer the producer cached at channel-creation time. This is the only
   // reliable source for a producer inside a ttng.subtiled_region: once a
   // sibling channel (sharing the same in-body template store and per-tile
@@ -224,6 +226,8 @@ bool appearsBefore(Operation *A, Operation *B) {
 // must be in the same region and the taskIds must be the same. We can have
 // a representative consumer in the channel.
 Operation *AllocChannel::getDstOp() {
+  if (defunct)
+    return nullptr; // alloc erased by reuse folding; endpoints are dangling.
   SmallVector<Operation *> consumers;
   getAllConsumers(this, consumers, false);
   if (consumers.size() == 1)
@@ -284,6 +288,8 @@ static Operation *findTmemStartEnd(ttng::TmemAllocChannel *ch,
 }
 
 Operation *ttng::TmemAllocChannel::getSrcOp() {
+  if (defunct)
+    return nullptr; // alloc erased by reuse folding; endpoints are dangling.
   if (isOperandD) { // is inout
     // Find tmem.start for this channel ID.
     return findTmemStartEnd(this, "tmem.start");
@@ -321,6 +327,8 @@ static void getAllConsumers(ttng::TmemAllocChannel *ch,
 }
 
 Operation *ttng::TmemAllocChannel::getDstOp() {
+  if (defunct)
+    return nullptr; // alloc erased by reuse folding; endpoints are dangling.
   if (isOperandD) {
     // Find tmem.end for this channel ID.
     return findTmemStartEnd(this, "tmem.end");
@@ -387,23 +395,34 @@ static bool needAccumCntForReuse(Operation *ctrlOp, ReuseGroup *group) {
     return false;
   // Goes through each channel in the ResuseGroup, check srcOp and dstOp to
   // see if it is inside ctrlOp.
+  //
+  // getSrcOp()/getDstOp() may be null: a sibling channel's lowering can rewire
+  // or erase this channel's producer before we reach here (see AllocChannel's
+  // cachedSrcOp note), so the alloc-walk finds nothing. `enclosing` would then
+  // deref null in isProperAncestor. A null endpoint is not enclosed by ctrlOp,
+  // so skip it. (Which endpoints are already-rewired is iteration-order
+  // dependent, so an unguarded deref is a layout-sensitive crash.)
   for (auto *ch : group->channels) {
+    if (ch->defunct)
+      continue; // alloc folded into the representative and erased; skip.
+    Operation *src = ch->getSrcOp();
+    Operation *dst = ch->getDstOp();
     if (auto forOp = dyn_cast<scf::ForOp>(ctrlOp)) {
-      if (enclosing(forOp, ch->getSrcOp()))
+      if (src && enclosing(forOp, src))
         return true;
-      if (enclosing(forOp, ch->getDstOp()))
+      if (dst && enclosing(forOp, dst))
         return true;
     }
     if (auto ifOp = dyn_cast<scf::IfOp>(ctrlOp)) {
-      if (enclosing(ifOp, ch->getSrcOp()))
+      if (src && enclosing(ifOp, src))
         return true;
-      if (enclosing(ifOp, ch->getDstOp()))
+      if (dst && enclosing(ifOp, dst))
         return true;
     }
     if (auto whileOp = dyn_cast<scf::WhileOp>(ctrlOp)) {
-      if (enclosing(whileOp, ch->getSrcOp()))
+      if (src && enclosing(whileOp, src))
         return true;
-      if (enclosing(whileOp, ch->getDstOp()))
+      if (dst && enclosing(whileOp, dst))
         return true;
     }
   }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -89,6 +89,14 @@ public:
   DataChannelKind channelKind = DataChannelKind::SMEM;
   unsigned uniqID;
   std::string srcName; // Producer name captured at channel creation
+
+  // Set once this channel's allocOp has been folded into a reuse-group
+  // representative and erased (replaceBufferReuse). The channel's alloc — and
+  // any producer/consumer op reached through it — is then dangling, so
+  // getSrcOp()/getDstOp() must not walk it. Any pass step that iterates reuse
+  // groups after folding (e.g. needAccumCntForReuse) should skip defunct
+  // channels; the representative covers their space.
+  bool defunct = false;
 };
 
 // A few assumptions, a channel can have multiple consumers, but the consumers

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
@@ -673,6 +673,11 @@ scf::ForOp createNewLoop(scf::ForOp forOp, scf::ForOp &parentForOp,
 void collectRegionsWithChannels(const SmallVector<Channel *> &channels,
                                 DenseSet<Operation *> &regionsWithChannels) {
   for (auto *channel : channels) {
+    // A defunct channel's alloc was folded into a reuse representative and
+    // erased; its allocOp/endpoints are dangling, so skip it (the
+    // representative already contributes its regions).
+    if (channel->defunct)
+      continue;
     if (channel->channelKind == DataChannelKind::TMEMAlloc) {
       ttng::TmemAllocChannel *tmemChannel =
           static_cast<ttng::TmemAllocChannel *>(channel);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -2279,6 +2279,9 @@ void replaceBufferReuse(triton::FuncOp funcOp, ReuseConfig *config) {
                                     repCh->getAllocOp()->getResult(0));
           }
           channel->getAllocOp()->erase();
+          // The alloc (and endpoints reached through it) is now dangling; mark
+          // the channel so later reuse-group walks don't deref freed ops.
+          channel->defunct = true;
           continue;
         }
         // Types don't match for SMEM - cannot reinterpret SMEM like TMEM
@@ -2377,6 +2380,9 @@ void replaceBufferReuse(triton::FuncOp funcOp, ReuseConfig *config) {
 
       // All users were successfully replaced, safe to erase
       channel->getAllocOp()->erase();
+      // The alloc (and endpoints reached through it) is now dangling; mark the
+      // channel so later reuse-group walks don't deref freed ops.
+      channel->defunct = true;
     }
   }
 }
@@ -3083,14 +3089,25 @@ void insertAsyncComm(
           // reading from the shared buffer before overwriting it.
           //
           // All source ops must be in the same block to establish program
-          // order.
+          // order. Skip defunct channels (alloc folded into a reuse
+          // representative and erased): their endpoints are dangling and
+          // getSrcOp() returns null; the representative covers their space.
           bool allSameBlock = true;
           if (group->channels.size() > 1) {
-            auto *refBlock = group->channels.front()->getSrcOp()->getBlock();
-            allSameBlock =
-                llvm::all_of(group->channels, [refBlock](Channel *ch) {
-                  return ch->getSrcOp()->getBlock() == refBlock;
-                });
+            Block *refBlock = nullptr;
+            for (Channel *ch : group->channels) {
+              if (ch->defunct)
+                continue;
+              Operation *src = ch->getSrcOp();
+              if (!src)
+                continue;
+              if (!refBlock) {
+                refBlock = src->getBlock();
+              } else if (src->getBlock() != refBlock) {
+                allSameBlock = false;
+                break;
+              }
+            }
           }
           // A TMEM reuse group with >= 3 buffers is a temporal, full-overlap
           // reuse of ONE TMEM slot by >= 3 producers (e.g. FA-bwd


### PR DESCRIPTION
Summary:

When a reuse group is folded into its representative, the non-representative
channel's allocOp is erased (replaceBufferReuse), leaving that Channel's
endpoints dangling. A later reuse-group walk (needAccumCntForReuse ->
enclosing -> isProperAncestor) dereferenced the freed op. Whether a given
endpoint was already erased is iteration-order dependent, so the crash was a
layout-sensitive heisenbug.

Mark the channel defunct at both erase sites; getSrcOp()/getDstOp() return
null when defunct and needAccumCntForReuse skips defunct channels (the
representative covers their space). Also null-guard the endpoints in
needAccumCntForReuse.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D112393654


