### PR TITLE
OSS port of hammer HSTU self-attention (triton + tlx) + tritonbench bench + autoWS/DP experiment (#2300)

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -119,6 +119,8 @@ Operation *skipIdxOp(Operation *op) {
 }
 
 Operation *AllocChannel::getSrcOp() {
+  if (defunct)
+    return nullptr; // alloc erased by reuse folding; endpoints are dangling.
   // Prefer the producer cached at channel-creation time. This is the only
   // reliable source for a producer inside a ttng.subtiled_region: once a
   // sibling channel (sharing the same in-body template store and per-tile
@@ -224,6 +226,8 @@ bool appearsBefore(Operation *A, Operation *B) {
 // must be in the same region and the taskIds must be the same. We can have
 // a representative consumer in the channel.
 Operation *AllocChannel::getDstOp() {
+  if (defunct)
+    return nullptr; // alloc erased by reuse folding; endpoints are dangling.
   SmallVector<Operation *> consumers;
   getAllConsumers(this, consumers, false);
   if (consumers.size() == 1)
@@ -284,6 +288,8 @@ static Operation *findTmemStartEnd(ttng::TmemAllocChannel *ch,
 }
 
 Operation *ttng::TmemAllocChannel::getSrcOp() {
+  if (defunct)
+    return nullptr; // alloc erased by reuse folding; endpoints are dangling.
   if (isOperandD) { // is inout
     // Find tmem.start for this channel ID.
     return findTmemStartEnd(this, "tmem.start");
@@ -321,6 +327,8 @@ static void getAllConsumers(ttng::TmemAllocChannel *ch,
 }
 
 Operation *ttng::TmemAllocChannel::getDstOp() {
+  if (defunct)
+    return nullptr; // alloc erased by reuse folding; endpoints are dangling.
   if (isOperandD) {
     // Find tmem.end for this channel ID.
     return findTmemStartEnd(this, "tmem.end");
@@ -387,23 +395,34 @@ static bool needAccumCntForReuse(Operation *ctrlOp, ReuseGroup *group) {
     return false;
   // Goes through each channel in the ResuseGroup, check srcOp and dstOp to
   // see if it is inside ctrlOp.
+  //
+  // getSrcOp()/getDstOp() may be null: a sibling channel's lowering can rewire
+  // or erase this channel's producer before we reach here (see AllocChannel's
+  // cachedSrcOp note), so the alloc-walk finds nothing. `enclosing` would then
+  // deref null in isProperAncestor. A null endpoint is not enclosed by ctrlOp,
+  // so skip it. (Which endpoints are already-rewired is iteration-order
+  // dependent, so an unguarded deref is a layout-sensitive crash.)
   for (auto *ch : group->channels) {
+    if (ch->defunct)
+      continue; // alloc folded into the representative and erased; skip.
+    Operation *src = ch->getSrcOp();
+    Operation *dst = ch->getDstOp();
     if (auto forOp = dyn_cast<scf::ForOp>(ctrlOp)) {
-      if (enclosing(forOp, ch->getSrcOp()))
+      if (src && enclosing(forOp, src))
         return true;
-      if (enclosing(forOp, ch->getDstOp()))
+      if (dst && enclosing(forOp, dst))
         return true;
     }
     if (auto ifOp = dyn_cast<scf::IfOp>(ctrlOp)) {
-      if (enclosing(ifOp, ch->getSrcOp()))
+      if (src && enclosing(ifOp, src))
         return true;
-      if (enclosing(ifOp, ch->getDstOp()))
+      if (dst && enclosing(ifOp, dst))
         return true;
     }
     if (auto whileOp = dyn_cast<scf::WhileOp>(ctrlOp)) {
-      if (enclosing(whileOp, ch->getSrcOp()))
+      if (src && enclosing(whileOp, src))
         return true;
-      if (enclosing(whileOp, ch->getDstOp()))
+      if (dst && enclosing(whileOp, dst))
         return true;
     }
   }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -89,6 +89,14 @@ public:
   DataChannelKind channelKind = DataChannelKind::SMEM;
   unsigned uniqID;
   std::string srcName; // Producer name captured at channel creation
+
+  // Set once this channel's allocOp has been folded into a reuse-group
+  // representative and erased (replaceBufferReuse). The channel's alloc — and
+  // any producer/consumer op reached through it — is then dangling, so
+  // getSrcOp()/getDstOp() must not walk it. Any pass step that iterates reuse
+  // groups after folding (e.g. needAccumCntForReuse) should skip defunct
+  // channels; the representative covers their space.
+  bool defunct = false;
 };
 
 // A few assumptions, a channel can have multiple consumers, but the consumers

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
@@ -673,6 +673,11 @@ scf::ForOp createNewLoop(scf::ForOp forOp, scf::ForOp &parentForOp,
 void collectRegionsWithChannels(const SmallVector<Channel *> &channels,
                                 DenseSet<Operation *> &regionsWithChannels) {
   for (auto *channel : channels) {
+    // A defunct channel's alloc was folded into a reuse representative and
+    // erased; its allocOp/endpoints are dangling, so skip it (the
+    // representative already contributes its regions).
+    if (channel->defunct)
+      continue;
     if (channel->channelKind == DataChannelKind::TMEMAlloc) {
       ttng::TmemAllocChannel *tmemChannel =
           static_cast<ttng::TmemAllocChannel *>(channel);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -2279,6 +2279,9 @@ void replaceBufferReuse(triton::FuncOp funcOp, ReuseConfig *config) {
                                     repCh->getAllocOp()->getResult(0));
           }
           channel->getAllocOp()->erase();
+          // The alloc (and endpoints reached through it) is now dangling; mark
+          // the channel so later reuse-group walks don't deref freed ops.
+          channel->defunct = true;
           continue;
         }
         // Types don't match for SMEM - cannot reinterpret SMEM like TMEM
@@ -2377,6 +2380,9 @@ void replaceBufferReuse(triton::FuncOp funcOp, ReuseConfig *config) {
 
       // All users were successfully replaced, safe to erase
       channel->getAllocOp()->erase();
+      // The alloc (and endpoints reached through it) is now dangling; mark the
+      // channel so later reuse-group walks don't deref freed ops.
+      channel->defunct = true;
     }
   }
 }
@@ -3083,14 +3089,25 @@ void insertAsyncComm(
           // reading from the shared buffer before overwriting it.
           //
           // All source ops must be in the same block to establish program
-          // order.
+          // order. Skip defunct channels (alloc folded into a reuse
+          // representative and erased): their endpoints are dangling and
+          // getSrcOp() returns null; the representative covers their space.
           bool allSameBlock = true;
           if (group->channels.size() > 1) {
-            auto *refBlock = group->channels.front()->getSrcOp()->getBlock();
-            allSameBlock =
-                llvm::all_of(group->channels, [refBlock](Channel *ch) {
-                  return ch->getSrcOp()->getBlock() == refBlock;
-                });
+            Block *refBlock = nullptr;
+            for (Channel *ch : group->channels) {
+              if (ch->defunct)
+                continue;
+              Operation *src = ch->getSrcOp();
+              if (!src)
+                continue;
+              if (!refBlock) {
+                refBlock = src->getBlock();
+              } else if (src->getBlock() != refBlock) {
+                allSameBlock = false;
+                break;
+              }
+            }
           }
           // A TMEM reuse group with >= 3 buffers is a temporal, full-overlap
           // reuse of ONE TMEM slot by >= 3 producers (e.g. FA-bwd

--- a/third_party/nvidia/hopper/run_all.sh
+++ b/third_party/nvidia/hopper/run_all.sh
@@ -61,5 +61,11 @@ pytest third_party/tlx/tutorials/fused_attention_ws_device_tma.py
 echo "Verifying correctness of HSTU cross-attention bwd (reduce_dq) autoWS kernel"
 pytest third_party/tlx/tutorials/test_cross_attention_bwd_autows.py
 
+echo "Verifying correctness of HSTU self-attention fwd autoWS kernel"
+pytest third_party/tlx/tutorials/test_self_attention_autows.py
+
+echo "Verifying correctness of HSTU self-attention bwd (plain Triton vs TLX vs torch)"
+pytest third_party/tlx/tutorials/test_self_attention_bwd.py
+
 echo "run for Hopper or Blackwell"
 pytest python/tutorials/fused-attention-ws-device-tma-hopper-or-blackwell.py

--- a/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
@@ -1,0 +1,126 @@
+"""Accuracy harness for the ported HSTU SELF-attention kernels (MetaMain2 OSS).
+
+Variants:
+  * triton - hammer-template Triton self-attn (triton_hstu_mha), fwd+bwd. Trusted ref.
+  * tlx    - hand-written TLX warp-specialized self-attn (tlx_bw_hstu_mha), Blackwell.
+
+Checks fwd output + dq/dk/dv grads:
+  - triton vs a torch-float HSTU-SiLU reference (both causal and non-causal, to
+    identify which masking the kernel uses),
+  - tlx vs triton (the byte-ish correctness check; same hammer math).
+
+Usage (from this dir, on a Blackwell GPU):
+  CUDA_VISIBLE_DEVICES=1 ~/.conda/envs/metamain2/bin/python bench_self.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+os.environ.pop("TRITON_USE_META_WS", None)  # TLX is hand-WS, not compiler-WS
+
+import torch  # noqa: E402
+
+import triton_hstu_attention as A  # noqa: E402
+import tlx_bw_hstu_attention as T  # noqa: E402
+
+D = 128
+H = 2
+
+
+def make(L, Z, dtype=torch.bfloat16):
+    t = Z * L
+    g = lambda: torch.randn(t, H, D, device="cuda", dtype=dtype)
+    q = g().requires_grad_(True)
+    k = g().requires_grad_(True)
+    v = g().requires_grad_(True)
+    so = torch.arange(0, t + 1, L, device="cuda", dtype=torch.int64)
+    asc = torch.tensor(1.0 / L, device="cuda", dtype=torch.float32)
+    do = g()
+    return q, k, v, do, so, asc
+
+
+def torch_ref(q, k, v, do, so, asc, causal):
+    """Float autograd HSTU-SiLU self-attention reference."""
+    qf = q.detach().float().requires_grad_(True)
+    kf = k.detach().float().requires_grad_(True)
+    vf = v.detach().float().requires_grad_(True)
+    alpha = 1.0 / D
+    scale = asc.item()
+    outs = []
+    for z in range(so.numel() - 1):
+        s, e = int(so[z]), int(so[z + 1])
+        n = e - s
+        qk = torch.einsum("qhd,khd->hqk", qf[s:e], kf[s:e]) * alpha
+        sig = qk * torch.sigmoid(qk) * scale  # SiLU(qk) * attn_scale
+        if causal:
+            i = torch.arange(n, device=qk.device)
+            valid = (i[:, None] >= i[None, :]).float()  # lower-tri incl diagonal
+            sig = sig * valid[None]
+        outs.append(torch.einsum("hqk,khd->qhd", sig, vf[s:e]))
+    torch.cat(outs, 0).backward(do.float())
+    return qf.grad, kf.grad, vf.grad
+
+
+def rel_l2(a, b):
+    return (torch.norm(a.float() - b.float()) / (torch.norm(b.float()) + 1e-12)).item()
+
+
+def run_triton(q, k, v, so, L, asc):
+    return A.triton_hstu_mha(
+        max_seq_len=L, alpha=1.0 / D, q=q, k=k, v=v, seq_offsets=so,
+        attn_scale=asc, num_targets=None, max_attn_len=0, contextual_seq_len=0,
+        enable_tma=True,
+    )
+
+
+def run_tlx(q, k, v, so, L, asc, causal=True):
+    return T.tlx_bw_hstu_mha(
+        max_seq_len=L, alpha=1.0 / D, q=q, k=k, v=v, seq_offsets=so,
+        attn_scale=asc, num_softmax_heads=0, num_targets=None,
+        max_attn_len=0, contextual_seq_len=0, causal=causal,
+    )
+
+
+def grads(run, q, k, v, so, L, asc, do, **kw):
+    for t in (q, k, v):
+        t.grad = None
+    out = run(q, k, v, so, L, asc, **kw)
+    out.backward(do)
+    return out.detach(), q.grad.clone(), k.grad.clone(), v.grad.clone()
+
+
+def main():
+    for (L, Z) in [(256, 4), (512, 2)]:
+        print(f"\n=== L={L} Z={Z} H={H} D={D} ===")
+        torch.manual_seed(0)
+        q, k, v, do, so, asc = make(L, Z)
+        rc = torch_ref(q, k, v, do, so, asc, causal=True)
+        rn = torch_ref(q, k, v, do, so, asc, causal=False)
+
+        try:
+            o_t, dq_t, dk_t, dv_t = grads(run_triton, q, k, v, so, L, asc, do)
+            print("  triton fwd vs torch:  causal dq/dk/dv relL2 = "
+                  f"{rel_l2(dq_t, rc[0]):.2e}/{rel_l2(dk_t, rc[1]):.2e}/{rel_l2(dv_t, rc[2]):.2e}"
+                  f"   noncausal = {rel_l2(dq_t, rn[0]):.2e}/{rel_l2(dk_t, rn[1]):.2e}/{rel_l2(dv_t, rn[2]):.2e}")
+        except Exception as e:
+            print(f"  triton ERROR {type(e).__name__}: {str(e)[:120]}")
+            o_t = None
+
+        for causal in (True, False):
+            try:
+                o_x, dq_x, dk_x, dv_x = grads(run_tlx, q, k, v, so, L, asc, do, causal=causal)
+                line = (f"  tlx(causal={causal}) vs torch-{'causal' if causal else 'noncausal'}: "
+                        f"dq/dk/dv relL2 = "
+                        f"{rel_l2(dq_x, (rc if causal else rn)[0]):.2e}/"
+                        f"{rel_l2(dk_x, (rc if causal else rn)[1]):.2e}/"
+                        f"{rel_l2(dv_x, (rc if causal else rn)[2]):.2e}")
+                if o_t is not None:
+                    line += (f"   vs triton: fwd {rel_l2(o_x, o_t):.2e} "
+                             f"dq {rel_l2(dq_x, dq_t):.2e} dk {rel_l2(dk_x, dk_t):.2e} dv {rel_l2(dv_x, dv_t):.2e}")
+                print(line)
+            except Exception as e:
+                print(f"  tlx(causal={causal}) ERROR {type(e).__name__}: {str(e)[:120]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/tlx/tutorials/hstu_self_attn/stubs.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/stubs.py
@@ -1,0 +1,133 @@
+# Standalone OSS stubs for the fbcode leaf deps used by the HSTU cross-attention
+# triton kernels. Lets the kernels run under OSS triton (MetaMain2) without buck.
+import triton
+import triton.language as tl
+
+
+def switch_to_contiguous_if_needed(x):
+    if x is None:
+        return x
+    return x.contiguous()
+
+
+def next_power_of_2(n: int) -> int:
+    n = int(n)
+    return 1 if n <= 1 else 1 << (n - 1).bit_length()
+
+
+def prev_power_of_2(n: int) -> int:
+    n = int(n)
+    return 1 if n < 1 else 1 << (n.bit_length() - 1)
+
+
+def autotune_max_seq_len(n) -> int:
+    return next_power_of_2(int(n))
+
+
+def triton_autotune(configs, key, **kwargs):
+    allowed = {"prune_configs_by", "reset_to_zero", "restore_value", "warmup", "rep", "use_cuda_graph"}
+    return triton.autotune(configs=configs, key=key, **{k: v for k, v in kwargs.items() if k in allowed})
+
+
+def get_full_autotune(*a, **k):
+    return False
+
+
+def is_sm90(*a, **k):
+    return False
+
+
+def is_sm90_plus(*a, **k):
+    return False
+
+
+import functools
+
+
+class _CustomOpStub:
+    """Mimics a torch custom op enough for import: callable + register_fake/register_kernel."""
+
+    def __init__(self, fn):
+        self._fn = fn
+        functools.update_wrapper(self, fn)
+
+    def __call__(self, *a, **k):
+        return self._fn(*a, **k)
+
+    def register_fake(self, f=None):
+        return f if f is not None else (lambda g: g)
+
+    def register_kernel(self, *a, **k):
+        return lambda g: g
+
+    def register_autograd(self, *a, **k):
+        return lambda g: g
+
+
+def maybe_register_custom_op(*a, **k):
+    if a and callable(a[0]):
+        return _CustomOpStub(a[0])
+
+    def deco(fn):
+        return _CustomOpStub(fn)
+
+    return deco
+
+
+# tritoncc spec stubs (only used by fwd/spec codegen paths, not the bwd reduce_dq path)
+class NamedSpecType:  # noqa
+    pass
+
+
+class VersionedSpec:  # noqa
+    def __init__(self, *a, **k):
+        pass
+
+
+def tritoncc_specs(*a, **k):
+    # used as a decorator: @tritoncc_specs(...) -> identity decorator
+    def deco(fn):
+        return fn
+    return deco
+
+
+# Real acc_dq (self-attention bwd uses it for the dq accumulation), ported from
+# generative_recommenders/ops/triton/triton_attention_utils.py.
+@triton.jit
+def acc_dq(
+    dq_ptrs_trans,
+    start_m,
+    stride_dqm,
+    k,
+    dqk_trans,
+    alpha,
+    mask_m,
+    MAX_SEQ_LEN,
+    LOCK,
+    BLOCK_M: tl.constexpr,
+    ATOMIC_ADD: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+):
+    if ATOMIC_ADD:
+        lock_id = start_m // BLOCK_M
+        stride_lock = tl.cdiv(MAX_SEQ_LEN, BLOCK_M)
+        lock = LOCK + tl.program_id(0) * stride_lock + lock_id
+        tl.debug_barrier()  # add a barrier to force sync
+        while tl.atomic_cas(lock, 0, 1) == 1:
+            pass
+    dq_trans = tl.load(
+        dq_ptrs_trans + start_m * stride_dqm,
+        mask=mask_m[None, :],
+        other=0.0,
+        eviction_policy="evict_last",
+    )
+    dq_trans += tl.dot(tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32) * alpha
+    dq_trans = dq_trans.to(k.dtype)
+    tl.store(
+        dq_ptrs_trans + start_m * stride_dqm,
+        dq_trans,
+        mask=mask_m[None, :],
+        eviction_policy="evict_last",
+    )
+    if ATOMIC_ADD:
+        tl.atomic_xchg(lock, 0)  # pyre-ignore [61]

--- a/third_party/tlx/tutorials/hstu_self_attn/tlx_bw_hstu_attention.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/tlx_bw_hstu_attention.py
@@ -1,0 +1,5601 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+
+import os
+
+from typing import List, Optional, Tuple
+
+import torch
+
+# @manual=//triton:triton
+import triton
+
+# @manual=//triton:triton
+import triton.language as tl
+
+try:
+    # @manual=//triton:triton
+    import triton.language.extra.tlx as tlx  # type: ignore[attr-defined]
+
+    HAS_TLX = True
+except ImportError:
+    tlx = None
+    HAS_TLX = False
+
+from stubs import (
+    autotune_max_seq_len,
+    switch_to_contiguous_if_needed,
+)
+from triton_attention_utils import (
+    _get_bufidx_phase,
+    fast_silu,
+)
+from triton_hstu_attention import (
+    backward_off_common_preprocess,
+    backward_valid_mask,
+    forward_uih_common_preprocess,
+    forward_valid_mask,
+    target_common_preprocess,
+)
+
+try:
+    # @manual=//triton:triton
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    TMA_AVAILABLE = True
+except ImportError:
+    TMA_AVAILABLE = False
+    pass
+
+
+def _host_descriptor_pre_hook(nargs) -> None:
+    BLOCK_M = nargs["BLOCK_M"]
+    BLOCK_N = nargs["BLOCK_N"]
+    DimQ = nargs["DimQ"]
+    if not isinstance(nargs["desc_q"], TensorDescriptor):
+        return
+    DimQ = nargs["DimQ"]
+    DimV = nargs["DimV"]
+    NUM_MMA_GROUPS = nargs["NUM_MMA_GROUPS"]
+    BLOCK_M_SPLIT = BLOCK_M // NUM_MMA_GROUPS
+    nargs["desc_q"].block_shape = [BLOCK_M_SPLIT, DimQ]
+    nargs["desc_v"].block_shape = [BLOCK_N, DimV]
+    nargs["desc_k"].block_shape = [BLOCK_N, DimQ]
+    nargs["desc_o"].block_shape = [BLOCK_M_SPLIT, DimV]
+
+
+def get_fwd_persistent_configs() -> List[triton.Config]:
+    configs = [
+        triton.Config(
+            {
+                "BLOCK_M": 256,
+                "BLOCK_N": 128,
+                "NUM_BUFFERS_Q": 1,
+                "NUM_BUFFERS_KV": kv,
+                "NUM_BUFFERS_QK": 1,
+                "NUM_MMA_GROUPS": 2,
+                "NUM_MMA_SLICES": 2,
+                "GROUP_SIZE_N": gs,
+                "NUM_REGS_CORR": corr,
+                "NUM_REGS_ACT": act,
+                "NUM_REGS_MMA": mma,
+                "NUM_REGS_LOAD": load,
+                "NUM_REGS_EPI": epi,
+                "MOVE_QK_WAIT": qk_wait,
+                "SLICE_MASK": slice_mask,
+            },
+            num_stages=0,
+            num_warps=4,
+            pre_hook=_host_descriptor_pre_hook,
+        )
+        for kv in [3, 6]
+        for gs in [1, 2, 4]
+        for corr in [168, 184]
+        for act in [184, 192]  # , 208]
+        for mma in [24]  # , 32, 64]
+        for load in [32]  # , 64]
+        for epi in [48, 64]
+        for qk_wait in [False]  # True, False]
+        for slice_mask in [True]  # , False]
+    ]
+    return configs
+
+
+def prune_configs_by_hdim(configs, named_args, **kwargs):
+    DimQ = kwargs["DimQ"]
+    STAGE = kwargs["STAGE"]
+    target_kv_buffers = 6 if DimQ == 64 else 3
+    target_group_size_n = 4 if STAGE == 3 else 1
+    return [
+        conf
+        for conf in configs
+        if conf.kwargs.get("NUM_BUFFERS_KV", 0) == target_kv_buffers
+        # and conf.kwargs.get("GROUP_SIZE_N", 0) == target_group_size_n
+    ]
+
+
+@triton.jit
+def tanh_approx_fp32(x):
+    output = tl.inline_asm_elementwise(
+        asm="""
+        tanh.approx.f32 $0, $1;
+        """,
+        constraints="=r,r",
+        args=[x],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+    return output
+
+
+@triton.jit
+def _mul_f32x2(a, b):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 ra, rb, rc;
+            mov.b64 ra, { $2, $3 };
+            mov.b64 rb, { $4, $5 };
+            mul.f32x2 rc, ra, rb;
+            mov.b64 { $0, $1 }, rc;
+        }
+        """,
+        "=r,=r,r,r,r,r",
+        [a, b],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=2,
+    )
+
+
+@triton.jit
+def _fma_f32x2(a, b, c):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 ra, rb, rc, rd;
+            mov.b64 ra, { $2, $3 };
+            mov.b64 rb, { $4, $5 };
+            mov.b64 rc, { $6, $7 };
+            fma.rn.f32x2 rd, ra, rb, rc;
+            mov.b64 { $0, $1 }, rd;
+        }
+        """,
+        "=r,=r,r,r,r,r,r,r",
+        [a, b, c],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=2,
+    )
+
+
+@triton.jit
+def _get_unfused_loop_bounds(
+    fused_lo, fused_hi, start_m, max_seq_len, BLOCK_N, STAGE: tl.constexpr
+):
+    if STAGE == 1:
+        # First part of STAGE == 3 in _get_fused_loop_bounds
+        lo = fused_lo
+        hi = (start_m - fused_lo) // BLOCK_N * BLOCK_N + fused_lo
+    elif STAGE == 2:
+        # Second part of STAGE == 3 in _get_fused_loop_bounds
+        lo = (start_m - fused_lo) // BLOCK_N * BLOCK_N + fused_lo
+        hi = fused_hi
+    else:
+        tl.static_assert(STAGE == 3)
+        # Maps to STAGE=1 in _get_fused_loop_bounds
+        lo, hi = fused_lo, fused_hi
+    return lo, hi
+
+
+@triton.jit
+def _attn_seq_info_preprocess(  # noqa C901
+    off_z,
+    num_targets,
+    start_m,
+    seq_len_q,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    max_attn_len: tl.constexpr,
+    full_attn_size: tl.constexpr,
+    contextual_seq_len: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_FULL_ATTN_SIZE: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+):
+    n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
+    uih_end = forward_uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
+    if HAS_CONTEXTUAL_SEQ_LEN is True and start_m < contextual_seq_len:
+        low = 0
+        high = seq_len_q
+    else:
+        low = 0
+        high = start_m + BLOCK_M
+        high = seq_len_q if seq_len_q < high else high
+        if HAS_MAX_ATTN_LEN:
+            if HAS_FULL_ATTN_SIZE > 0 and start_m + BLOCK_M >= uih_end - full_attn_size:
+                low = 0
+            else:
+                if start_m > uih_end:
+                    low = uih_end - max_attn_len
+                else:
+                    low = start_m - max_attn_len
+            if HAS_CONTEXTUAL_SEQ_LEN:
+                low = low if low > contextual_seq_len else 0
+            else:
+                low = low if low > 0 else 0
+        if HAS_NUM_TARGETS:
+            uih_end = (uih_end + BLOCK_N - 1) // BLOCK_N * BLOCK_N
+            if uih_end < start_m:
+                high = seq_len_q - n_targets
+    return low, high, n_targets
+
+
+@triton.jit
+def _compute_offsets(
+    tile_idx,
+    H,
+    num_pid_n,
+    num_pid_in_group,
+    seq_offsets,
+    num_targets,
+    max_attn_len,
+    full_attn_size,
+    contextual_seq_len,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    GROUP_SIZE_N: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_FULL_ATTN_SIZE: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+):
+    group_id = tile_idx // num_pid_in_group
+    first_pid_n = group_id * GROUP_SIZE_N
+    group_size_n = min(num_pid_n - first_pid_n, GROUP_SIZE_N)
+    start_m = (tile_idx % num_pid_in_group) // group_size_n
+    start_m = start_m * BLOCK_M
+    off_hz = first_pid_n + (tile_idx % group_size_n)
+    off_z = off_hz // H
+    off_h = off_hz % H
+
+    # load sequence offsets
+    seq_start = tl.load(seq_offsets + off_z)
+    seq_end = tl.load(seq_offsets + off_z + 1)
+    seq_len = (seq_end - seq_start).to(tl.int32)
+
+    if start_m < seq_len:
+        lo, hi, n_targets = _attn_seq_info_preprocess(
+            off_z,
+            num_targets,
+            start_m,
+            seq_len,
+            BLOCK_M,
+            BLOCK_N,
+            max_attn_len,
+            full_attn_size,
+            contextual_seq_len,
+            HAS_NUM_TARGETS,
+            HAS_MAX_ATTN_LEN,
+            HAS_FULL_ATTN_SIZE,
+            HAS_CONTEXTUAL_SEQ_LEN,
+        )
+    else:
+        lo, hi, n_targets = 0, 0, 0
+
+    return start_m, off_z, off_h, lo, hi, seq_start, seq_len, n_targets
+
+
+@triton.jit
+def _split_n(x, SPLIT_FACTOR: tl.constexpr):
+    if SPLIT_FACTOR == 1:
+        return (x,)
+    else:
+        x0, x1 = x.reshape([x.shape[0], 2, x.shape[1] // 2]).permute(0, 2, 1).split()
+        return _split_n(x0, SPLIT_FACTOR // 2) + _split_n(x1, SPLIT_FACTOR // 2)
+
+
+@triton.jit
+def _join_n(xs):
+    if len(xs) == 1:
+        return xs[0]
+    else:
+        x0 = _join_n(xs[: len(xs) // 2])
+        x1 = _join_n(xs[len(xs) // 2 :])
+        x = tl.join(x0, x1).permute(0, 2, 1).reshape([x0.shape[0], x0.shape[1] * 2])
+        return x
+
+
+@triton.jit
+def _mask_scalar(qk, col_limit_right, s, i):
+    col_lim_right_s = col_limit_right - s
+    col_lim_right_cur = max(col_lim_right_s, 0)
+    mask = -1 << col_lim_right_cur
+    mask_i_bit = (mask & (1 << i)) == 0
+    return tl.where(mask_i_bit, qk, -float("inf"))
+
+
+@triton.jit
+def _apply_causal_mask(qk, col_limit_right, BLOCK_N: tl.constexpr):
+    # Apply causal mask via a bitmask calculated for each block of 16 elements.
+    # This allows the efficient R2P (register to predicate) instruction to be used at the SASS level.
+    # Credit to Tri Dao,
+    # https://github.com/Dao-AILab/flash-attention/commit/bac1001e4f6caa09d70537495d6746a685a2fa78
+    #
+    # NOTE: We use map_elementiwse here in order to generate an interleaved sequence of instructions
+    # that processes one element of qk at a time. This improves ptxas's resulting SASS.
+    offs_n = tl.arange(0, BLOCK_N)[None, :]
+    s = offs_n & ~0xF
+    i = offs_n & 0xF
+    return tl.map_elementwise(_mask_scalar, qk, col_limit_right, s, i)
+
+
+@triton.jit
+def _softmax_inner_loop(
+    qk_fulls,
+    qk_tiles,
+    p_fulls,
+    p_tiles,
+    alpha_empties,
+    alpha_fulls,
+    alpha_tiles,
+    cid,
+    accum_cnt_qk,
+    qk_scale,
+    offs_m,
+    m_i,
+    l_i,
+    start_m,
+    max_seq_len,
+    fused_lo,
+    fused_hi,
+    out_dtype,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    DimQ: tl.constexpr,
+    NUM_MMA_SLICES: tl.constexpr,
+    NUM_MMA_GROUPS: tl.constexpr,
+    STAGE: tl.constexpr,
+):
+    lo, hi = _get_unfused_loop_bounds(
+        fused_lo, fused_hi, start_m, max_seq_len, BLOCK_N, STAGE
+    )
+
+    for start_n in tl.range(lo, hi, BLOCK_N):
+        _, qk_phase = _get_bufidx_phase(accum_cnt_qk, 1)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
+        # pyrefly: ignore [missing-attribute]
+        qk = tlx.local_load(tlx.local_view(qk_tiles, cid))
+
+        if STAGE == 2:
+            col_limit_right = (offs_m - start_n + 1)[:, None]
+            qk = _apply_causal_mask(qk, col_limit_right, BLOCK_N)
+
+        # compute m_i, p in registers
+        m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+
+        # -- compute correction factor
+        alpha = tl.math.exp2(m_i - m_ij)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(tlx.local_view(alpha_empties, cid), qk_phase ^ 1)
+        # Use alpha[0] for cid=0, and alpha[BLOCK_N] for cid=1
+        # pyrefly: ignore [missing-attribute]
+        tlx.local_store(tlx.local_view(alpha_tiles, cid * BLOCK_N), alpha[:, None])
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_arrive(tlx.local_view(alpha_fulls, cid))
+
+        qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
+        qks = _split_n(qk, NUM_MMA_SLICES)
+        ps = ()
+        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+            # prepare p for the v dot
+            # Use p[NUM_MMA_SLICES + slice_id] for cid=0, and
+            # p[NUM_MMA_GROUPS * NUM_MMA_SLICES + NUM_MMA_SLICES + slice_id] for cid=1
+            p_bufIdx = cid * NUM_MMA_GROUPS * NUM_MMA_SLICES + NUM_MMA_SLICES + slice_id
+            p_i = tl.math.exp2(qks[slice_id])
+            # pyrefly: ignore [missing-attribute]
+            tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), p_i.to(out_dtype))
+            # pyrefly: ignore [missing-attribute]
+            tlx.barrier_arrive(tlx.local_view(p_fulls, slice_id + cid * NUM_MMA_SLICES))
+            ps = ps + (p_i,)
+
+        p = _join_n(ps)
+        l_ij = tl.sum(p, 1)
+        l_i = l_i * alpha + l_ij
+        m_i = m_ij
+        accum_cnt_qk += 1
+
+    return m_i, l_i, accum_cnt_qk
+
+
+@triton.jit
+def _silu_inner_loop(
+    qk_fulls,
+    qk_tiles,
+    p_fulls,
+    p_tiles,
+    cid,
+    accum_cnt_qk,
+    alpha,
+    offs_m,
+    start_m,
+    seq_len,
+    lo,
+    hi,
+    out_dtype,
+    contextual_seq_len,
+    max_attn_len,
+    n_targets,
+    BLOCK_M_SPLIT: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    DimQ: tl.constexpr,
+    NUM_MMA_SLICES: tl.constexpr,
+    NUM_MMA_GROUPS: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+    MOVE_QK_WAIT: tl.constexpr,
+    SLICE_MASK: tl.constexpr,
+):
+    # NOTE: do NOT pre-scale alpha by 0.5 here. The downstream activation uses
+    # fast_silu(x, MULT_BY_X=True), which already computes the full SiLU of its
+    # argument (identity (x/2)(1+tanh(x/2)) with the *0.5 applied internally).
+    # Pre-scaling by 0.5 fed silu(y/2) instead of silu(y) -- for small qk*alpha
+    # (SiLU ~ linear) that is ~0.5x the correct forward output. See bench_self.py.
+
+    # It is numerically correct to process every block in the part 2 below with masking
+    if HAS_MAX_ATTN_LEN or start_m + (1 + cid) * BLOCK_M_SPLIT >= (seq_len - n_targets):
+        low, mid, high = lo, lo, hi
+    else:
+        low = lo
+        mid = (start_m + cid * BLOCK_M_SPLIT - lo) // BLOCK_N * BLOCK_N + lo
+        high = hi
+
+    # first part where there is no masking
+    for start_n in tl.range(low, mid, BLOCK_N):
+        _, qk_phase = _get_bufidx_phase(accum_cnt_qk, 1)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
+        # pyrefly: ignore [missing-attribute]
+        qk = tlx.local_load(tlx.local_view(qk_tiles, cid))
+
+        qk = qk * alpha
+
+        qks = _split_n(qk, NUM_MMA_SLICES)
+        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+            # prepare p for the v dot
+            # Use p[NUM_MMA_SLICES + slice_id] for cid=0, and
+            # p[NUM_MMA_GROUPS * NUM_MMA_SLICES + NUM_MMA_SLICES + slice_id] for cid=1
+            p_bufIdx = cid * NUM_MMA_GROUPS * NUM_MMA_SLICES + NUM_MMA_SLICES + slice_id
+            p_i = fast_silu(qks[slice_id], MULT_BY_X=True)
+            # pyrefly: ignore [missing-attribute]
+            tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), p_i.to(out_dtype))
+            # pyrefly: ignore [missing-attribute]
+            tlx.barrier_arrive(tlx.local_view(p_fulls, slice_id + cid * NUM_MMA_SLICES))
+        accum_cnt_qk += 1
+
+    # second part where there are causal and other maskings (target, seq_len etc.)
+    for start_n in tl.range(mid, high, BLOCK_N):
+        _, qk_phase = _get_bufidx_phase(accum_cnt_qk, 1)
+
+        if SLICE_MASK:
+            # When doing per-slice masking, load qk unconditionally
+            # pyrefly: ignore [missing-attribute]
+            tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
+            # pyrefly: ignore [missing-attribute]
+            qk = tlx.local_load(tlx.local_view(qk_tiles, cid))
+        else:
+            # When doing full-block masking, use MOVE_QK_WAIT optimization
+            if MOVE_QK_WAIT:
+                # Calculate mask first (overlapping with barrier wait), then load qk
+                offs_n = start_n + tl.arange(0, BLOCK_N)
+                valid_mask = forward_valid_mask(
+                    offs_m,
+                    offs_n,
+                    seq_len,
+                    contextual_seq_len,
+                    max_attn_len,
+                    n_targets,
+                    HAS_CONTEXTUAL_SEQ_LEN,
+                    HAS_NUM_TARGETS,
+                    HAS_MAX_ATTN_LEN,
+                )
+                masked_alpha = tl.where(valid_mask, alpha, 0.0)
+
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
+                # pyrefly: ignore [missing-attribute]
+                qk = tlx.local_load(tlx.local_view(qk_tiles, cid))
+            else:
+                # Load qk first, then calculate mask
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
+                # pyrefly: ignore [missing-attribute]
+                qk = tlx.local_load(tlx.local_view(qk_tiles, cid))
+
+                offs_n = start_n + tl.arange(0, BLOCK_N)
+                valid_mask = forward_valid_mask(
+                    offs_m,
+                    offs_n,
+                    seq_len,
+                    contextual_seq_len,
+                    max_attn_len,
+                    n_targets,
+                    HAS_CONTEXTUAL_SEQ_LEN,
+                    HAS_NUM_TARGETS,
+                    HAS_MAX_ATTN_LEN,
+                )
+                masked_alpha = tl.where(valid_mask, alpha, 0.0)
+
+            qk = qk * masked_alpha
+
+        qks = _split_n(qk, NUM_MMA_SLICES)
+        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+            # prepare p for the v dot
+            # Use p[NUM_MMA_SLICES + slice_id] for cid=0, and
+            # p[NUM_MMA_GROUPS * NUM_MMA_SLICES + NUM_MMA_SLICES + slice_id] for cid=1
+            p_bufIdx = cid * NUM_MMA_GROUPS * NUM_MMA_SLICES + NUM_MMA_SLICES + slice_id
+            if SLICE_MASK:
+                offs_n = start_n + tl.arange(
+                    slice_id * BLOCK_N // NUM_MMA_SLICES,
+                    (slice_id + 1) * BLOCK_N // NUM_MMA_SLICES,
+                )
+                valid_mask = forward_valid_mask(
+                    offs_m,
+                    offs_n,
+                    seq_len,
+                    contextual_seq_len,
+                    max_attn_len,
+                    n_targets,
+                    HAS_CONTEXTUAL_SEQ_LEN,
+                    HAS_NUM_TARGETS,
+                    HAS_MAX_ATTN_LEN,
+                )
+                masked_alpha = tl.where(valid_mask, alpha, 0.0)
+                qks_t = qks[slice_id] * masked_alpha
+                p_i = fast_silu(qks_t, MULT_BY_X=True)
+            else:
+                p_i = fast_silu(qks[slice_id], MULT_BY_X=True)
+            # pyrefly: ignore [missing-attribute]
+            tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), p_i.to(out_dtype))
+            # pyrefly: ignore [missing-attribute]
+            tlx.barrier_arrive(tlx.local_view(p_fulls, slice_id + cid * NUM_MMA_SLICES))
+        accum_cnt_qk += 1
+
+    return accum_cnt_qk
+
+
+@triton.jit
+def _softmax_correction_inner_loop(
+    desc_o,
+    lo,
+    hi,
+    accum_cnt,
+    tile_cnt,
+    start_m,
+    seq_start,
+    seq_len,
+    off_h,
+    alpha_fulls,
+    alpha_empties,
+    alpha_tiles,
+    acc_fulls,
+    acc_empties,
+    acc_tiles,
+    o_fulls,
+    o_empties,
+    o_tiles,
+    l_fulls,
+    l_tiles,
+    m_tiles,
+    qk_empties,
+    M,
+    stride_mm,
+    DimQ: tl.constexpr,
+    NUM_MMA_SLICES: tl.constexpr,
+    NUM_MMA_GROUPS: tl.constexpr,
+    BLOCK_M_SPLIT: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    for _ in tl.range(lo, hi, BLOCK_N):
+        _, phase = _get_bufidx_phase(accum_cnt, 1)
+        for cid in tl.static_range(0, NUM_MMA_GROUPS):
+            # -- update output accumulator --
+            # pyrefly: ignore [missing-attribute]
+            tlx.barrier_wait(alpha_fulls[cid], phase)
+            # Use alpha[0] for cid=0, and alpha[BLOCK_N] for cid=1
+            # pyrefly: ignore [missing-attribute]
+            alpha_1 = tlx.local_load(alpha_tiles[cid * BLOCK_N])
+            # pyrefly: ignore [missing-attribute]
+            tlx.barrier_arrive(alpha_empties[cid])
+            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                # pyrefly: ignore [missing-attribute]
+                subslice = tlx.subslice(
+                    acc_tiles[cid],
+                    DimQ * slice_id // NUM_MMA_SLICES,
+                    DimQ // NUM_MMA_SLICES,
+                )
+                # pyrefly: ignore [missing-attribute]
+                acc = tlx.local_load(subslice)
+                # acc = acc * alpha_1
+                acc = _mul_f32x2(acc, alpha_1)
+                # pyrefly: ignore [missing-attribute]
+                tlx.local_store(subslice, acc)
+            # pyrefly: ignore [missing-attribute]
+            tlx.barrier_arrive(acc_fulls[cid])
+        accum_cnt += 1
+
+    _, phase = _get_bufidx_phase(tile_cnt, 1)
+    for cid in tl.static_range(0, NUM_MMA_GROUPS):
+        # epilogue
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(l_fulls[cid], phase)
+        # Use l[1]/l[1+BLOCK_N] and m[2][2 + BLOCK_N]
+        # to disambigulate from alpha[0]/alpha[BLOCK_N]
+        # pyrefly: ignore [missing-attribute]
+        l = tlx.local_load(l_tiles[cid * BLOCK_N + 1])
+        # pyrefly: ignore [missing-attribute]
+        m = tlx.local_load(m_tiles[cid * BLOCK_N + 2])
+        # Signal qk_empties after both l and m loads complete,
+        # since both tiles share the same synchronization group.
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_arrive(qk_empties[cid])
+        m += tl.math.log2(l)
+        offs_m = start_m + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+        m_ptrs = M + (offs_m + seq_start) * stride_mm + off_h
+        m = tl.reshape(m, [BLOCK_M_SPLIT])
+        tl.store(m_ptrs, m, mask=offs_m < seq_len)
+
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(acc_empties[cid], phase)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(o_empties[cid], phase ^ 1)
+        scale = 1 / l
+        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+            # pyrefly: ignore [missing-attribute]
+            subslice = tlx.subslice(
+                acc_tiles[cid],
+                DimQ * slice_id // NUM_MMA_SLICES,
+                DimQ // NUM_MMA_SLICES,
+            )
+            # pyrefly: ignore [missing-attribute]
+            acc = tlx.local_load(subslice)
+            acc = _mul_f32x2(acc, scale)
+            # pyrefly: ignore [missing-attribute]
+            acc = acc.to(tlx.dtype_of(desc_o))
+            # pyrefly: ignore [missing-attribute]
+            subslice_o = tlx.local_slice(
+                o_tiles[cid],
+                [0, DimQ * slice_id // NUM_MMA_SLICES],
+                [BLOCK_M_SPLIT, DimQ // NUM_MMA_SLICES],
+            )
+            # pyrefly: ignore [missing-attribute]
+            tlx.local_store(subslice_o, acc)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_arrive(o_fulls[cid])
+    return accum_cnt
+
+
+@triton.autotune(
+    configs=get_fwd_persistent_configs(),
+    key=["AUTOTUNE_MAX_SEQ_LEN", "DimQ", "STAGE"],
+    prune_configs_by={"early_config_prune": prune_configs_by_hdim},
+)
+@triton.jit
+def _attn_fwd_ws(
+    Out,
+    sm_scale,
+    Z,
+    H,
+    M,  #
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    seq_offsets,
+    max_seq_len,  #
+    num_targets,
+    max_attn_len,
+    full_attn_size,
+    contextual_seq_len,
+    stride_mm,
+    stride_qh,
+    stride_kh,
+    stride_vh,
+    stride_oh,
+    attn_scale,
+    SOFTMAX: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_FULL_ATTN_SIZE: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    AUTOTUNE_MAX_SEQ_LEN: tl.constexpr,
+    DimQ: tl.constexpr,
+    DimV: tl.constexpr,
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    STAGE: tl.constexpr,  #
+    NUM_BUFFERS_Q: tl.constexpr,  #
+    NUM_BUFFERS_KV: tl.constexpr,  #
+    NUM_BUFFERS_QK: tl.constexpr,  #
+    NUM_MMA_GROUPS: tl.constexpr,  #
+    NUM_MMA_SLICES: tl.constexpr,  #
+    GROUP_SIZE_N: tl.constexpr,  #
+    NUM_REGS_CORR: tl.constexpr,
+    NUM_REGS_ACT: tl.constexpr,
+    NUM_REGS_MMA: tl.constexpr,
+    NUM_REGS_LOAD: tl.constexpr,
+    NUM_REGS_EPI: tl.constexpr,
+    MOVE_QK_WAIT: tl.constexpr,
+    SLICE_MASK: tl.constexpr,
+):
+    tl.static_assert(NUM_MMA_GROUPS == 2)
+    tl.static_assert(DimV == DimQ)
+
+    BLOCK_M_SPLIT: tl.constexpr = BLOCK_M // NUM_MMA_GROUPS
+
+    # original grid
+    #   triton.cdiv(max_seq_len, META["BLOCK_M"]),
+    #   Z * H
+    prog_id = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    num_pid_m = tl.cdiv(max_seq_len, BLOCK_M)
+    num_pid_n = Z * H
+    num_pid_in_group = num_pid_m * GROUP_SIZE_N
+    total_tiles = num_pid_m * Z * H
+
+    tiles_per_sm = total_tiles // num_progs
+    if prog_id < total_tiles % num_progs:
+        tiles_per_sm += 1
+
+    tile_idx = prog_id
+
+    # allocate SMEM buffers and barriers
+    # pyrefly: ignore [missing-attribute]
+    q_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_M_SPLIT, DimQ),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_q),
+        NUM_MMA_GROUPS * NUM_BUFFERS_Q,
+    )
+    # pyrefly: ignore [missing-attribute]
+    kv_tiles = tlx.local_alloc((BLOCK_N, DimV), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    o_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_M_SPLIT, DimV),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_o),
+        NUM_MMA_GROUPS,
+    )
+
+    # pyrefly: ignore [missing-attribute]
+    q_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_BUFFERS_Q)
+    # pyrefly: ignore [missing-attribute]
+    q_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_BUFFERS_Q)
+    # pyrefly: ignore [missing-attribute]
+    kv_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    kv_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    o_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+    # pyrefly: ignore [missing-attribute]
+    o_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+
+    # allocate TMEM buffers and barriers
+    # pyrefly: ignore [missing-attribute]
+    qk_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_M_SPLIT, BLOCK_N),
+        tl.float32,
+        NUM_MMA_GROUPS,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+    )
+    # Shared buffer for QK, P and Alpha, l, and m.
+    # A single QK buffer is split evenly:
+    #   - First half  : stores P
+    #   - Second half  : stores Alpha, l, and m
+    #     QK : |                              BLK_M/2 * BLOCK_N * fp32                  |
+    #     P:                                                |  BLK_M/2 * BLOCK_N * fp16 |
+    #  Alpha : |BLK_M/2*1*fp32|
+    #     l :                 |BLK_M/2*1*fp32|
+    #     m :                                |BLK_M/2*1*fp32|
+    # pyrefly: ignore [missing-attribute]
+    p_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, BLOCK_N // NUM_MMA_SLICES),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_v),
+        NUM_MMA_GROUPS * NUM_MMA_SLICES * 2,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    # pyrefly: ignore [missing-attribute]
+    alpha_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        BLOCK_N * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    # pyrefly: ignore [missing-attribute]
+    l_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        BLOCK_N * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    # pyrefly: ignore [missing-attribute]
+    m_tiles = tlx.local_alloc(
+        (BLOCK_M_SPLIT, 1),
+        tl.float32,
+        BLOCK_N * NUM_MMA_GROUPS * NUM_BUFFERS_QK,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+
+    # pyrefly: ignore [missing-attribute]
+    acc_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_M_SPLIT, DimV),
+        tl.float32,
+        NUM_MMA_GROUPS,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+    )
+
+    # pyrefly: ignore [missing-attribute]
+    qk_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+    # pyrefly: ignore [missing-attribute]
+    qk_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+    # pyrefly: ignore [missing-attribute]
+    p_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_MMA_SLICES)
+    # pyrefly: ignore [missing-attribute]
+    acc_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+    # pyrefly: ignore [missing-attribute]
+    acc_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+
+    # pyrefly: ignore [missing-attribute]
+    alpha_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+    # pyrefly: ignore [missing-attribute]
+    alpha_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+    # pyrefly: ignore [missing-attribute]
+    l_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+
+    # pyrefly: ignore [missing-attribute]
+    with tlx.async_tasks():
+        # correction group
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task("default"):
+            accum_cnt = 0
+            phase = 0
+            tile_cnt = 0
+            for _ in range(0, tiles_per_sm):
+                # initialize offsets
+                start_m, off_z, off_h, lo, hi, seq_start, seq_len, n_targets = (
+                    _compute_offsets(
+                        tile_idx,
+                        H,
+                        num_pid_n,
+                        num_pid_in_group,
+                        seq_offsets,
+                        num_targets,
+                        max_attn_len,
+                        full_attn_size,
+                        contextual_seq_len,
+                        BLOCK_M,
+                        BLOCK_N,
+                        GROUP_SIZE_N,
+                        HAS_NUM_TARGETS,
+                        HAS_MAX_ATTN_LEN,
+                        HAS_FULL_ATTN_SIZE,
+                        HAS_CONTEXTUAL_SEQ_LEN,
+                    )
+                )
+                if start_m < seq_len:
+                    if SOFTMAX:
+                        accum_cnt = _softmax_correction_inner_loop(
+                            desc_o,
+                            lo,
+                            hi,
+                            accum_cnt,
+                            tile_cnt,
+                            start_m,
+                            seq_start,
+                            seq_len,
+                            off_h,
+                            alpha_fulls,
+                            alpha_empties,
+                            alpha_tiles,
+                            acc_fulls,
+                            acc_empties,
+                            acc_tiles,
+                            o_fulls,
+                            o_empties,
+                            o_tiles,
+                            l_fulls,
+                            l_tiles,
+                            m_tiles,
+                            qk_empties,
+                            M,
+                            stride_mm,
+                            DimQ,
+                            NUM_MMA_SLICES,
+                            NUM_MMA_GROUPS,
+                            BLOCK_M_SPLIT,
+                            BLOCK_N,
+                        )
+                    else:
+                        # silu correction, apply attn_scale
+                        tl.static_assert(ATTN_SCALE_TYPE == "scalar")
+                        scale = tl.load(attn_scale).to(tl.float32)
+                        _, phase = _get_bufidx_phase(tile_cnt, 1)
+                        for cid in tl.static_range(0, NUM_MMA_GROUPS):
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.barrier_wait(acc_empties[cid], phase)
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.barrier_wait(o_empties[cid], phase ^ 1)
+                            # epilogue: load from TMEM, scale, store to SMEM
+
+                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                                # pyrefly: ignore [missing-attribute]
+                                subslice = tlx.subslice(
+                                    acc_tiles[cid],
+                                    DimQ * slice_id // NUM_MMA_SLICES,
+                                    DimQ // NUM_MMA_SLICES,
+                                )
+                                # pyrefly: ignore [missing-attribute]
+                                acc = tlx.local_load(subslice)
+                                acc = _mul_f32x2(acc, scale)
+                                # pyrefly: ignore [missing-attribute]
+                                acc = acc.to(tlx.dtype_of(desc_o))
+                                # pyrefly: ignore [missing-attribute]
+                                subslice_o = tlx.local_slice(
+                                    o_tiles[cid],
+                                    [0, DimQ * slice_id // NUM_MMA_SLICES],
+                                    [BLOCK_M_SPLIT, DimQ // NUM_MMA_SLICES],
+                                )
+                                # pyrefly: ignore [missing-attribute]
+                                tlx.local_store(subslice_o, acc)
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.barrier_arrive(o_fulls[cid])
+                            # Signal qk_empties so MMA group can proceed with next tile
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.barrier_arrive(qk_empties[cid])
+
+                    tile_cnt += 1
+
+                tile_idx += num_progs
+
+        # softmax/silu groups
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task(
+            num_warps=4, registers=NUM_REGS_ACT, replicate=NUM_MMA_GROUPS
+        ):
+            accum_cnt_qk = 0
+            for _ in range(0, tiles_per_sm):
+                # initialize offsets
+                start_m, off_z, off_h, lo, hi, seq_start, seq_len, n_targets = (
+                    _compute_offsets(
+                        tile_idx,
+                        H,
+                        num_pid_n,
+                        num_pid_in_group,
+                        seq_offsets,
+                        num_targets,
+                        max_attn_len,
+                        full_attn_size,
+                        contextual_seq_len,
+                        BLOCK_M,
+                        BLOCK_N,
+                        GROUP_SIZE_N,
+                        HAS_NUM_TARGETS,
+                        HAS_MAX_ATTN_LEN,
+                        HAS_FULL_ATTN_SIZE,
+                        HAS_CONTEXTUAL_SEQ_LEN,
+                    )
+                )
+                if start_m < seq_len:
+                    if SOFTMAX:
+                        # initialize pointer to m and l
+                        m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
+                        l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) + 1.0
+                        acc = tl.zeros([BLOCK_M_SPLIT, DimQ], dtype=tl.float32)
+                        qk_scale = sm_scale
+                        qk_scale *= 1.44269504  # 1/log(2)
+                        # pyrefly: ignore [missing-attribute]
+                        out_dtype = tlx.dtype_of(desc_v)
+
+                        # pyrefly: ignore [missing-attribute]
+                        cid = tlx.async_task_replica_id()
+                        offs_m = start_m + (
+                            (cid * BLOCK_M_SPLIT) + tl.arange(0, BLOCK_M_SPLIT)
+                        )
+                        if STAGE & 1:
+                            m_i, l_i, accum_cnt_qk = _softmax_inner_loop(
+                                qk_fulls,
+                                qk_tiles,
+                                p_fulls,
+                                p_tiles,
+                                alpha_empties,
+                                alpha_fulls,
+                                alpha_tiles,
+                                cid,
+                                accum_cnt_qk,
+                                qk_scale,
+                                offs_m,
+                                m_i,
+                                l_i,
+                                start_m,
+                                max_seq_len,
+                                lo,
+                                hi,
+                                out_dtype,
+                                BLOCK_M,
+                                BLOCK_N,
+                                DimQ,
+                                NUM_MMA_SLICES,
+                                NUM_MMA_GROUPS,
+                                STAGE=4 - STAGE,
+                            )
+
+                        if STAGE & 2:
+                            m_i, l_i, accum_cnt_qk = _softmax_inner_loop(
+                                qk_fulls,
+                                qk_tiles,
+                                p_fulls,
+                                p_tiles,
+                                alpha_empties,
+                                alpha_fulls,
+                                alpha_tiles,
+                                cid,
+                                accum_cnt_qk,
+                                qk_scale,
+                                offs_m,
+                                m_i,
+                                l_i,
+                                start_m,
+                                max_seq_len,
+                                lo,
+                                hi,
+                                out_dtype,
+                                BLOCK_M,
+                                BLOCK_N,
+                                DimQ,
+                                NUM_MMA_SLICES,
+                                NUM_MMA_GROUPS,
+                                STAGE=2,
+                            )
+
+                        # prepare l_i for the epilog
+                        # Use l[1]/l[1+BLOCK_N] and m[2][2 + BLOCK_N]
+                        # to disambigulate from alpha[0]/alpha[BLOCK_N]
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.local_store(l_tiles[cid * BLOCK_N + 1], l_i[:, None])
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.local_store(m_tiles[cid * BLOCK_N + 2], m_i[:, None])
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_arrive(l_fulls[cid])
+                    else:
+                        # silu
+                        # pyrefly: ignore [missing-attribute]
+                        out_dtype = tlx.dtype_of(desc_v)
+                        # pyrefly: ignore [missing-attribute]
+                        cid = tlx.async_task_replica_id()
+                        offs_m = start_m + (
+                            (cid * BLOCK_M_SPLIT) + tl.arange(0, BLOCK_M_SPLIT)
+                        )
+                        accum_cnt_qk = _silu_inner_loop(
+                            qk_fulls,
+                            qk_tiles,
+                            p_fulls,
+                            p_tiles,
+                            cid,
+                            accum_cnt_qk,
+                            sm_scale,
+                            offs_m,
+                            start_m,
+                            seq_len,
+                            lo,
+                            hi,
+                            out_dtype,
+                            contextual_seq_len,
+                            max_attn_len,
+                            n_targets,
+                            BLOCK_M_SPLIT,
+                            BLOCK_N,
+                            DimQ,
+                            NUM_MMA_SLICES,
+                            NUM_MMA_GROUPS,
+                            HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+                            HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+                            HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+                            MOVE_QK_WAIT=MOVE_QK_WAIT,
+                            SLICE_MASK=SLICE_MASK,
+                        )
+
+                tile_idx += num_progs
+
+        # mma group
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task(num_warps=1, registers=NUM_REGS_MMA):
+            accum_cnt_kv = 0
+            accum_cnt_qk = 0
+
+            tile_cnt = 0
+            for _ in range(0, tiles_per_sm):
+                # initialize offsets
+                start_m, off_z, off_h, lo, hi, seq_start, seq_len, n_targets = (
+                    _compute_offsets(
+                        tile_idx,
+                        H,
+                        num_pid_n,
+                        num_pid_in_group,
+                        seq_offsets,
+                        num_targets,
+                        max_attn_len,
+                        full_attn_size,
+                        contextual_seq_len,
+                        BLOCK_M,
+                        BLOCK_N,
+                        GROUP_SIZE_N,
+                        HAS_NUM_TARGETS,
+                        HAS_MAX_ATTN_LEN,
+                        HAS_FULL_ATTN_SIZE,
+                        HAS_CONTEXTUAL_SEQ_LEN,
+                    )
+                )
+                if start_m < seq_len:
+                    q_bufIdx, q_phase = _get_bufidx_phase(tile_cnt, NUM_BUFFERS_Q)
+                    k_bufIdx, k_phase = _get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                    v_bufIdx, v_phase = _get_bufidx_phase(
+                        accum_cnt_kv + 1, NUM_BUFFERS_KV
+                    )
+
+                    # wait for the K buffer to be populated by the producer
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(kv_fulls[k_bufIdx], k_phase)
+
+                    # wait for the Q buffer to be populated by the producer
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(q_fulls[q_bufIdx], q_phase)
+
+                    # -- compute q0 @ k ----
+                    # pyrefly: ignore [missing-attribute]
+                    k_tile = tlx.local_trans(kv_tiles[k_bufIdx])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(qk_empties[0], q_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        q_tiles[0],
+                        k_tile,
+                        qk_tiles[0],
+                        use_acc=False,
+                        mBarriers=[qk_fulls[0]],
+                    )
+
+                    # -- compute q1 @ k ----
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(q_fulls[q_bufIdx + NUM_BUFFERS_Q], q_phase)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(qk_empties[1], q_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        q_tiles[1],
+                        k_tile,
+                        qk_tiles[1],
+                        use_acc=False,
+                        mBarriers=[qk_fulls[1], kv_empties[k_bufIdx]],
+                    )
+
+                    _, qk_phase = _get_bufidx_phase(accum_cnt_qk, 1)
+
+                    # -- compute p0 @ v ----
+                    # wait for the V buffer to be populated by the producer
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(kv_fulls[v_bufIdx], v_phase)
+                    if SOFTMAX:
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(acc_fulls[0], qk_phase)
+                    # Use p[NUM_MMA_SLICES + slice_id] for cid=0, and
+                    # p[NUM_MMA_GROUPS * NUM_MMA_SLICES + NUM_MMA_SLICES + slice_id] for cid=1
+                    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(
+                            p_fulls[slice_id + 0 * NUM_MMA_SLICES], qk_phase
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        kv_slice = tlx.local_slice(
+                            kv_tiles[v_bufIdx],
+                            [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                            [BLOCK_N // NUM_MMA_SLICES, DimQ],
+                        )
+                        p_bufIdx = NUM_MMA_SLICES + slice_id
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            p_tiles[p_bufIdx],
+                            kv_slice,
+                            acc_tiles[0],
+                            use_acc=slice_id > 0,
+                        )
+
+                    acc1_init = False
+
+                    for i in tl.range(lo + BLOCK_N, hi, BLOCK_N):
+                        v_bufIdx_prev = v_bufIdx
+                        qk_phase_prev = qk_phase
+
+                        accum_cnt_qk += 1
+                        accum_cnt_kv += 2
+                        k_bufIdx, k_phase = _get_bufidx_phase(
+                            accum_cnt_kv, NUM_BUFFERS_KV
+                        )
+                        v_bufIdx, v_phase = _get_bufidx_phase(
+                            accum_cnt_kv + 1, NUM_BUFFERS_KV
+                        )
+
+                        # -- compute q0 @ k ----
+                        # wait for the K buffer to be populated by the producer
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(kv_fulls[k_bufIdx], k_phase)
+                        # pyrefly: ignore [missing-attribute]
+                        k_tile = tlx.local_trans(kv_tiles[k_bufIdx])
+                        _, qk_phase = _get_bufidx_phase(accum_cnt_qk, 1)
+
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            q_tiles[0],
+                            k_tile,
+                            qk_tiles[0],
+                            use_acc=False,
+                            mBarriers=[qk_fulls[0]],
+                        )
+
+                        # -- compute p1 @ v from the previous iteration----
+                        if SOFTMAX:
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
+                        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.barrier_wait(
+                                p_fulls[slice_id + 1 * NUM_MMA_SLICES], qk_phase_prev
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            kv_slice = tlx.local_slice(
+                                kv_tiles[v_bufIdx_prev],
+                                [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                [BLOCK_N // NUM_MMA_SLICES, DimQ],
+                            )
+                            p_bufIdx = (
+                                1 * NUM_MMA_GROUPS * NUM_MMA_SLICES
+                                + NUM_MMA_SLICES
+                                + slice_id
+                            )
+                            use_acc = acc1_init if slice_id == 0 else True
+                            mBarriers = (
+                                [kv_empties[v_bufIdx_prev]]
+                                if slice_id == NUM_MMA_SLICES - 1
+                                else []
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_dot(
+                                p_tiles[p_bufIdx],
+                                kv_slice,
+                                acc_tiles[1],
+                                use_acc=use_acc,
+                                mBarriers=mBarriers,
+                            )
+
+                        acc1_init = True
+
+                        # -- compute q1 @ k ----
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            q_tiles[1],
+                            k_tile,
+                            qk_tiles[1],
+                            use_acc=False,
+                            mBarriers=[qk_fulls[1], kv_empties[k_bufIdx]],
+                        )
+
+                        # -- compute p0 @ v ----
+                        # wait for the V buffer to be populated by the producer
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(kv_fulls[v_bufIdx], v_phase)
+
+                        if SOFTMAX:
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.barrier_wait(acc_fulls[0], qk_phase)
+                        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.barrier_wait(
+                                p_fulls[slice_id + 0 * NUM_MMA_SLICES], qk_phase
+                            )
+                            # Use p[1] for cid=0, and p[3] for cid=1
+                            # pyrefly: ignore [missing-attribute]
+                            kv_slice = tlx.local_slice(
+                                kv_tiles[v_bufIdx],
+                                [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                [BLOCK_N // NUM_MMA_SLICES, DimQ],
+                            )
+                            p_bufIdx = NUM_MMA_SLICES + slice_id
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_dot(
+                                p_tiles[p_bufIdx],
+                                kv_slice,
+                                acc_tiles[0],
+                                use_acc=True,
+                            )
+
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.tcgen05_commit(q_empties[q_bufIdx])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.tcgen05_commit(acc_empties[0])
+
+                    # -- compute p1 @ v ----
+                    if SOFTMAX:
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(acc_fulls[1], qk_phase)
+                    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(p_fulls[slice_id + NUM_MMA_SLICES], qk_phase)
+                        # Use p[1] for cid=0, and p[3] for cid=1
+                        # pyrefly: ignore [missing-attribute]
+                        kv_slice = tlx.local_slice(
+                            kv_tiles[v_bufIdx],
+                            [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                            [BLOCK_N // NUM_MMA_SLICES, DimQ],
+                        )
+                        p_bufIdx = (
+                            1 * NUM_MMA_GROUPS * NUM_MMA_SLICES
+                            + NUM_MMA_SLICES
+                            + slice_id
+                        )
+                        use_acc = acc1_init if slice_id == 0 else True
+                        mBarriers = (
+                            [acc_empties[1], kv_empties[v_bufIdx]]
+                            if slice_id == NUM_MMA_SLICES - 1
+                            else []
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            p_tiles[p_bufIdx],
+                            kv_slice,
+                            acc_tiles[1],
+                            use_acc=use_acc,
+                            mBarriers=mBarriers,
+                        )
+
+                    accum_cnt_qk += 1
+                    accum_cnt_kv += 2
+                    tile_cnt += 1
+                tile_idx += num_progs
+
+        # load
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task(num_warps=1, registers=NUM_REGS_LOAD):
+            accum_cnt_kv = 0
+            tile_cnt = 0
+            for _ in range(0, tiles_per_sm):
+                # initialize offsets
+                start_m, off_z, off_h, lo, hi, seq_start, seq_len, n_targets = (
+                    _compute_offsets(
+                        tile_idx,
+                        H,
+                        num_pid_n,
+                        num_pid_in_group,
+                        seq_offsets,
+                        num_targets,
+                        max_attn_len,
+                        full_attn_size,
+                        contextual_seq_len,
+                        BLOCK_M,
+                        BLOCK_N,
+                        GROUP_SIZE_N,
+                        HAS_NUM_TARGETS,
+                        HAS_MAX_ATTN_LEN,
+                        HAS_FULL_ATTN_SIZE,
+                        HAS_CONTEXTUAL_SEQ_LEN,
+                    )
+                )
+
+                if start_m < seq_len:
+                    # load q0
+                    q_bufIdx, q_phase = _get_bufidx_phase(tile_cnt, NUM_BUFFERS_Q)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_expect_bytes(
+                        q_fulls[q_bufIdx], 2 * BLOCK_M_SPLIT * DimQ
+                    )  # float16
+                    qo_offset_y_split = seq_start + start_m
+
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_load(
+                        desc_q,
+                        q_tiles[q_bufIdx],
+                        [qo_offset_y_split.to(tl.int32), off_h * stride_qh],
+                        q_fulls[q_bufIdx],
+                    )
+
+                    # loop over loading k, v
+                    k_bufIdx, k_phase = _get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                    # wait for the K buffer to be released by the consumer
+                    # pyrefly: ignore [missing-attribute]
+                    k_empty = tlx.local_view(kv_empties, k_bufIdx)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(k_empty, k_phase ^ 1)
+
+                    # load K
+                    kv_offset_y = seq_start + lo
+                    # pyrefly: ignore [missing-attribute]
+                    k_full = tlx.local_view(kv_fulls, k_bufIdx)
+                    # pyrefly: ignore [missing-attribute]
+                    k_tile = tlx.local_view(kv_tiles, k_bufIdx)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_expect_bytes(k_full, 2 * BLOCK_N * DimQ)  # float16
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_load(
+                        desc_k,
+                        k_tile,
+                        [kv_offset_y.to(tl.int32), off_h * stride_kh],
+                        k_full,
+                    )
+
+                    # load q1
+                    q_bufIdx += NUM_BUFFERS_Q
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_expect_bytes(
+                        q_fulls[q_bufIdx], 2 * BLOCK_M_SPLIT * DimQ
+                    )  # float16
+                    qo_offset_y_split += BLOCK_M_SPLIT
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_load(
+                        desc_q,
+                        q_tiles[q_bufIdx],
+                        [qo_offset_y_split.to(tl.int32), off_h * stride_qh],
+                        q_fulls[q_bufIdx],
+                    )
+
+                    v_bufIdx, v_phase = _get_bufidx_phase(
+                        accum_cnt_kv + 1, NUM_BUFFERS_KV
+                    )
+                    # wait for the V buffer to be released by the consumer
+                    # pyrefly: ignore [missing-attribute]
+                    v_empty = tlx.local_view(kv_empties, v_bufIdx)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(v_empty, v_phase ^ 1)
+                    # load V
+                    # pyrefly: ignore [missing-attribute]
+                    v_full = tlx.local_view(kv_fulls, v_bufIdx)
+                    # pyrefly: ignore [missing-attribute]
+                    v_tile = tlx.local_view(kv_tiles, v_bufIdx)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_expect_bytes(v_full, 2 * BLOCK_N * DimQ)  # float16
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_load(
+                        desc_v,
+                        v_tile,
+                        [kv_offset_y.to(tl.int32), off_h * stride_vh],
+                        v_full,
+                    )
+
+                    kv_offset_y += BLOCK_N
+                    accum_cnt_kv += 2
+
+                    for _ in tl.range(lo + BLOCK_N, hi, BLOCK_N):
+                        k_bufIdx, k_phase = _get_bufidx_phase(
+                            accum_cnt_kv, NUM_BUFFERS_KV
+                        )
+                        # wait for the K buffer to be released by the consumer
+                        # pyrefly: ignore [missing-attribute]
+                        k_empty = tlx.local_view(kv_empties, k_bufIdx)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(k_empty, k_phase ^ 1)
+                        # load K
+                        # pyrefly: ignore [missing-attribute]
+                        k_full = tlx.local_view(kv_fulls, k_bufIdx)
+                        # pyrefly: ignore [missing-attribute]
+                        k_tile = tlx.local_view(kv_tiles, k_bufIdx)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_expect_bytes(k_full, 2 * BLOCK_N * DimQ)  # float16
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_load(
+                            desc_k,
+                            k_tile,
+                            [kv_offset_y.to(tl.int32), off_h * stride_kh],
+                            k_full,
+                        )
+
+                        v_bufIdx, v_phase = _get_bufidx_phase(
+                            accum_cnt_kv + 1, NUM_BUFFERS_KV
+                        )
+                        # wait for the V buffer to be released by the consumer
+                        # pyrefly: ignore [missing-attribute]
+                        v_empty = tlx.local_view(kv_empties, v_bufIdx)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(v_empty, v_phase ^ 1)
+                        # load V
+                        # pyrefly: ignore [missing-attribute]
+                        v_full = tlx.local_view(kv_fulls, v_bufIdx)
+                        # pyrefly: ignore [missing-attribute]
+                        v_tile = tlx.local_view(kv_tiles, v_bufIdx)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_expect_bytes(v_full, 2 * BLOCK_N * DimQ)  # float16
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_load(
+                            desc_v,
+                            v_tile,
+                            [kv_offset_y.to(tl.int32), off_h * stride_vh],
+                            v_full,
+                        )
+
+                        kv_offset_y += BLOCK_N
+                        accum_cnt_kv += 2
+                    tile_cnt += 1
+
+                tile_idx += num_progs
+
+        # epilog group
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task(num_warps=1, registers=NUM_REGS_EPI):
+            # initialize offsets
+            tile_cnt = 0
+            for _ in range(0, tiles_per_sm):
+                # initialize offsets
+                start_m, off_z, off_h, lo, hi, seq_start, seq_len, n_targets = (
+                    _compute_offsets(
+                        tile_idx,
+                        H,
+                        num_pid_n,
+                        num_pid_in_group,
+                        seq_offsets,
+                        num_targets,
+                        max_attn_len,
+                        full_attn_size,
+                        contextual_seq_len,
+                        BLOCK_M,
+                        BLOCK_N,
+                        GROUP_SIZE_N,
+                        HAS_NUM_TARGETS,
+                        HAS_MAX_ATTN_LEN,
+                        HAS_FULL_ATTN_SIZE,
+                        HAS_CONTEXTUAL_SEQ_LEN,
+                    )
+                )
+                if start_m < seq_len:
+                    _, phase = _get_bufidx_phase(tile_cnt, 1)
+                    qo_offset_y = seq_start + start_m
+
+                    out_offset = off_h.to(tl.int64) * stride_oh
+                    end_o = seq_start + seq_len
+                    # keeping output as device TMA even for host TMA enabled for jagged
+                    o_desc = tl.make_tensor_descriptor(
+                        Out,
+                        shape=[end_o.to(tl.int32), DimV * H],
+                        # pyrefly: ignore [bad-argument-type]
+                        strides=[DimV * H, 1],
+                        block_shape=[BLOCK_M_SPLIT, DimV],
+                    )
+
+                    for cid in tl.static_range(0, NUM_MMA_GROUPS):
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(o_fulls[cid], phase)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.fence_async_shared()
+                        qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store(
+                            o_desc,
+                            o_tiles[cid],
+                            [
+                                qo_offset_y_split.to(tl.int32),
+                                (out_offset).to(tl.int32),
+                            ],
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store_wait(0)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_arrive(o_empties[cid])
+                    tile_cnt += 1
+
+                tile_idx += num_progs
+
+
+@triton.jit
+def _attn_bwd_preprocess(
+    O,
+    DO,  #
+    Delta,  #
+    N_CTX,  #
+    BLOCK_M: tl.constexpr,
+    HEAD_DIM: tl.constexpr,  #
+):
+    off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    off_hz = tl.program_id(1)
+    off_n = tl.arange(0, HEAD_DIM)
+    # load
+    o = tl.load(
+        O + off_hz * HEAD_DIM * N_CTX + off_m[:, None] * HEAD_DIM + off_n[None, :]
+    )
+    do = tl.load(
+        DO + off_hz * HEAD_DIM * N_CTX + off_m[:, None] * HEAD_DIM + off_n[None, :]
+    ).to(tl.float32)
+    delta = tl.sum(o * do, axis=1)
+    # write-back
+    tl.store(Delta + off_hz * N_CTX + off_m, delta)
+
+
+@triton.jit
+def _hstu_attn_bwd_preprocess(
+    O,
+    DO,  #
+    Delta,  #
+    seq_offsets,
+    stride_oh,
+    stride_doh,
+    stride_deltah,
+    H,
+    BLOCK_M: tl.constexpr,
+    HEAD_DIM: tl.constexpr,  #
+):
+    off_z = tl.program_id(1) // H
+    off_h = tl.program_id(1) % H
+
+    seq_start = tl.load(seq_offsets + off_z)
+    seq_end = tl.load(seq_offsets + off_z + 1)
+    seq_len = (seq_end - seq_start).to(tl.int32)
+
+    off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    off_d = tl.arange(0, HEAD_DIM)
+    mask_m = off_m < seq_len
+
+    o_offset = (
+        (seq_start + off_m[:, None]) * H * HEAD_DIM + off_h * stride_oh + off_d[None, :]
+    )
+    do_offset = (
+        (seq_start + off_m[:, None]) * H * HEAD_DIM
+        + off_h * stride_doh
+        + off_d[None, :]
+    )
+
+    # load
+    o = tl.load(O + o_offset, mask=mask_m[:, None], other=0.0)
+    do = tl.load(DO + do_offset, mask=mask_m[:, None], other=0.0).to(tl.float32)
+
+    delta = tl.sum(o * do, axis=1)
+    # write-back: Delta has shape [total_seq_len, H]
+    delta_offset = (seq_start + off_m) * H + off_h
+    tl.store(Delta + delta_offset, delta, mask=mask_m)
+
+
+@triton.jit
+def _hstu_bwd_calculate_offsets(
+    tile_idx,
+    n_tile_num,
+    num_pid_m,
+    seq_offsets,
+    num_targets,
+    max_attn_len,
+    full_attn_size,
+    contextual_seq_len,
+    H,
+    BLOCK_M1: tl.constexpr,
+    BLOCK_N1: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_FULL_ATTN_SIZE: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    STAGE: tl.constexpr,
+):
+    """Calculate offsets for HSTU backward pass with jagged sequences.
+
+    Block Range Computation for Semi-local + Global Attention
+    ==========================================================
+
+    For K/V block at start_n:
+    =========================
+
+                        max_attn_len
+                    |<-------------->|
+                    |                |
+        |---------[K/V]--------------|--------|------------------------|
+        0        start_n           high1     low2                   seq_len
+                   ↑                 ↑         ↑                       ↑
+                  low1               |         |                       |
+                   |                 |         |                      high2
+                   |<-- PART 1 ----->|  (gap)  |<------ PART 2 ------->|
+                   |    MASKED       |  skip   |       NO MASK         |
+                   |                 |         |                       |
+                   |  semi-local     |         | global UIH + targets  |
+                   |  + causal       |         | (all see everything)  |
+
+
+        Boundaries:
+        -----------
+        uih_len = seq_len - n_targets                     # End of UIH
+        low1    = start_n                                 # Causal start
+        high1   = start_n + block_n + max_attn_len        # End of semi-local window (+ BLOCK_M1)
+        low2    = uih_len - full_attn_size                # Start of global attention in UIH
+        high2   = seq_len                                 # END OF FULL SEQUENCE (includes targets!)
+
+
+    ==========================================================================
+        PART 1: MASKED (semi-local + causal)
+    ==========================================================================
+
+        Range: [low1, high1) = [start_n, min(start_n + max_attn_len + BLOCK_M1, low2))
+
+        - Q positions within semi-local window
+        - Need element-wise mask check
+
+
+    ==========================================================================
+        PART 2: NO MASK (global UIH + all targets)
+    ==========================================================================
+
+        Range: [low2, seq_len) = [uih_len - full_attn_size, seq_len)
+
+        Includes TWO regions that both have full attention:
+
+          a) Global UIH zone: [uih_len - full_attn_size, uih_len)
+             - Last full_attn_size positions of UIH
+             - Can see ALL of UIH
+
+          b) All targets: [uih_len, seq_len)
+             - All n_targets positions
+             - Targets attend to ENTIRE sequence
+
+        → Both can see K/V at start_n without any mask!
+
+    Returns:
+        off_z: batch index
+        off_h: head index
+        seq_start: start offset of this sequence in jagged tensor
+        seq_len: length of this sequence
+        n_targets: number of target positions
+        start_n: K/V block start position
+        low1: start of PART 1 (masked region)
+        high1: end of PART 1 (masked region), also start of gap
+        low2: start of PART 2 (unmasked region)
+        high2: end of PART 2 (unmasked region) = seq_len
+        num_steps_masked: number of BLOCK_M1 steps in PART 1
+        num_steps_unmasked: number of BLOCK_M1 steps in PART 2
+    """
+    bhid = tile_idx // n_tile_num
+    pid = tile_idx % n_tile_num
+    pid, bhid = tl.swizzle2d(pid, bhid, n_tile_num, num_pid_m, GROUP_SIZE_M)
+
+    off_z = bhid // H
+    off_h = bhid % H
+
+    # Load sequence offsets
+    seq_start = tl.load(seq_offsets + off_z)
+    seq_end = tl.load(seq_offsets + off_z + 1)
+    seq_len = (seq_end - seq_start).to(tl.int32)
+
+    start_n = pid * BLOCK_N1
+
+    n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
+    uih_len = forward_uih_common_preprocess(n_targets, seq_len, HAS_NUM_TARGETS)
+
+    # PART 1: Masked region (semi-local + causal)
+    low1 = start_n
+
+    causal_end = start_n + BLOCK_N1
+
+    if HAS_MAX_ATTN_LEN:
+        # Semi-local end: Q at position m can see K at position n if n >= m - max_attn_len
+        # For K/V block [start_n, start_n + BLOCK_N1), the last K is at start_n + BLOCK_N1 - 1
+        # Q can see this last K up to position (start_n + BLOCK_N1 - 1) + max_attn_len
+        semi_local_end = start_n + BLOCK_N1 + max_attn_len
+        # high1 = max(causal_end, semi_local_end)
+        high1 = semi_local_end if semi_local_end > causal_end else causal_end
+        # Round up to block boundary
+        high1 = low1 + tl.cdiv(high1 - low1, BLOCK_M1) * BLOCK_M1
+    else:
+        # No semi-local constraint: only causal masking needed in the diagonal block
+        # PART 1 covers [start_n, start_n + BLOCK_N1) where causal mask is needed
+        # Round up to block boundary
+        high1 = low1 + tl.cdiv(causal_end - low1, BLOCK_M1) * BLOCK_M1
+
+    high1 = high1 if high1 < seq_len else seq_len
+
+    # PART 2: Unmasked region
+    # This region has no masking because:
+    #   a) For positions beyond the diagonal block (>= start_n + BLOCK_N1), all K/V in the
+    #      block are causally visible (no causal mask needed)
+    #   b) Global UIH zone: last full_attn_size positions of UIH can see ALL of UIH
+    #   c) All targets: targets attend to ENTIRE sequence
+    #
+    # low2 = high1 (continue from where PART 1 ended)
+    # high2 = seq_len (extends to end of sequence)
+
+    if HAS_MAX_ATTN_LEN:
+        # With max_attn_len, PART 1 already covers the semi-local window
+        # PART 2 only needs to cover global attention zone and targets
+        if HAS_FULL_ATTN_SIZE or HAS_NUM_TARGETS:
+            if HAS_FULL_ATTN_SIZE:
+                # Start of global attention zone in UIH
+                low2 = uih_len - full_attn_size
+            else:
+                # No global attention, but targets still have no mask
+                # Targets start at uih_len
+                low2 = uih_len
+
+            # Ensure low2 doesn't overlap with PART 1 (must be >= high1)
+            low2 = low2 if low2 >= high1 else high1
+        else:
+            # No global attention and no targets, skip PART 2
+            low2 = seq_len
+    else:
+        # No max_attn_len: PART 2 must cover ALL Q positions from high1 to seq_len
+        # since there's no semi-local constraint limiting the range
+        low2 = high1
+
+    # high2 = end of sequence (includes all targets)
+    high2 = seq_len
+
+    return (
+        off_z,
+        off_h,
+        seq_start,
+        seq_len,
+        n_targets,
+        start_n,
+        low1,
+        high1,
+        low2,
+        high2,
+    )
+
+
+@triton.jit
+def _hstu_bwd_load_q_do(
+    desc_q,
+    desc_do,
+    q_tiles,
+    do_tiles,
+    q_empties,
+    q_fulls,
+    do_empties,
+    do_fulls,
+    seq_start,
+    off_h,
+    stride_qh,
+    stride_doh,
+    low,
+    high,
+    blk_idx,
+    NUM_BUFFERS_Q: tl.constexpr,
+    NUM_BUFFERS_DO: tl.constexpr,
+    BLOCK_M1: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+):
+    """Load Q and dO blocks for backward pass inner loop.
+
+    This function loads Q and dO blocks for a range of M positions [low, high).
+
+    Args:
+        desc_q: TMA descriptor for Q tensor
+        desc_do: TMA descriptor for dO tensor
+        q_tiles: Local tiles for Q
+        do_tiles: Local tiles for dO
+        q_empties: Barrier for Q empty slots
+        q_fulls: Barrier for Q full slots
+        do_empties: Barrier for dO empty slots
+        do_fulls: Barrier for dO full slots
+        seq_start: Start offset of this sequence in jagged tensor
+        off_h: Head index
+        stride_qh: Stride for Q head dimension
+        stride_doh: Stride for dO head dimension
+        low: Start of M range to load
+        high: End of M range to load (exclusive)
+        blk_idx: Current block index for buffer management
+        NUM_BUFFERS_Q: Number of Q buffers
+        NUM_BUFFERS_DO: Number of dO buffers
+        BLOCK_M1: Block size for M dimension
+        HEAD_DIM: Head dimension size
+
+    Returns:
+        blk_idx: Updated block index
+    """
+    for curr_m in tl.range(low, high, BLOCK_M1):
+        q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
+        do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
+        # Load Q
+        # pyrefly: ignore [missing-attribute]
+        q_empty = tlx.local_view(q_empties, q_buf_id)
+        # pyrefly: ignore [missing-attribute]
+        q_full = tlx.local_view(q_fulls, q_buf_id)
+        # pyrefly: ignore [missing-attribute]
+        q_tile = tlx.local_view(q_tiles, q_buf_id)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(q_empty, q_phase ^ 1)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_expect_bytes(q_full, 2 * BLOCK_M1 * HEAD_DIM)
+        # pyrefly: ignore [missing-attribute]
+        tlx.async_descriptor_load(
+            desc_q,
+            q_tile,
+            [
+                (seq_start + curr_m).to(tl.int32),
+                (off_h * stride_qh).to(tl.int32),
+            ],
+            q_full,
+        )
+
+        # Load dO
+        # pyrefly: ignore [missing-attribute]
+        do_empty = tlx.local_view(do_empties, do_buf_id)
+        # pyrefly: ignore [missing-attribute]
+        do_full = tlx.local_view(do_fulls, do_buf_id)
+        # pyrefly: ignore [missing-attribute]
+        do_tile = tlx.local_view(do_tiles, do_buf_id)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(do_empty, do_phase ^ 1)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_expect_bytes(do_full, 2 * BLOCK_M1 * HEAD_DIM)
+        # pyrefly: ignore [missing-attribute]
+        tlx.async_descriptor_load(
+            desc_do,
+            do_tile,
+            [
+                (seq_start + curr_m).to(tl.int32),
+                (off_h * stride_doh).to(tl.int32),
+            ],
+            do_full,
+        )
+        blk_idx += 1
+
+    return blk_idx
+
+
+@triton.jit
+def _hstu_bwd_compute_inner_loop_softmax(
+    start_n,
+    qk_fulls,
+    qk_tiles,
+    qk_empties,
+    p_tiles,
+    p_fulls,
+    dp_empties,
+    dp_fulls,
+    dp_tiles,
+    ds_tiles,
+    ds_fulls,
+    M,
+    D,
+    seq_start,
+    seq_len,
+    off_h,
+    stride_mh,
+    stride_deltah,
+    curr_m,
+    blk_idx,
+    step_m,
+    do_out_dtype,
+    q_out_dtype,
+    NUM_BUFFERS_TMEM: tl.constexpr,
+    NUM_BUFFERS_DS: tl.constexpr,
+    BLOCK_M1: tl.constexpr,
+    BLOCK_N1: tl.constexpr,
+    STAGE: tl.constexpr,
+    REUSE_DP_FOR_DQ: tl.constexpr,
+):
+    """Backward compute inner loop for softmax activation with jagged sequences."""
+    start_block_n = start_n
+    offs_n = start_block_n + tl.arange(0, BLOCK_N1)
+
+    # Calculate loop bounds
+    if STAGE == 1:
+        lo, hi = start_n, start_n + BLOCK_N1
+    elif STAGE == 2:
+        lo, hi = start_n + BLOCK_N1, seq_len
+    else:
+        lo, hi = 0, seq_len
+
+    num_steps = (hi - lo) // BLOCK_M1
+    for _ in range(num_steps):
+        tmem_buf_id, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
+        ds_buf_id, _ = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DS)
+
+        offs_m = curr_m + tl.arange(0, BLOCK_M1)
+        mask_m = offs_m < seq_len
+
+        # Load M (logsumexp) for softmax
+        m_offset = (seq_start + offs_m) * stride_mh + off_h
+        m = tl.load(M + m_offset, mask=mask_m, other=0.0)
+
+        # wait for qkT = tl.dot(k, qT)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(tlx.local_view(qk_fulls, tmem_buf_id), tmem_phase)
+        # pyrefly: ignore [missing-attribute]
+        qkT = tlx.local_load(tlx.local_view(qk_tiles, tmem_buf_id))
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_arrive(tlx.local_view(qk_empties, tmem_buf_id))
+
+        pT = tl.math.exp2(qkT - m[None, :])
+        if STAGE == 1:
+            mask = offs_m[None, :] >= offs_n[:, None]
+            pT = tl.where(mask, pT, 0.0)
+
+        ppT = pT
+        ppT = ppT.to(do_out_dtype)
+        # pyrefly: ignore [missing-attribute]
+        tlx.local_store(tlx.local_view(p_tiles, tmem_buf_id), ppT)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_arrive(tlx.local_view(p_fulls, tmem_buf_id))
+
+        # Load D (= delta)
+        delta_offset = (seq_start + offs_m) * stride_deltah + off_h
+        Di = tl.load(D + delta_offset, mask=mask_m, other=0.0)
+
+        # Wait for dpT = tl.dot(v, tl.trans(do))
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(tlx.local_view(dp_fulls, tmem_buf_id), tmem_phase)
+        # pyrefly: ignore [missing-attribute]
+        dpT = tlx.local_load(tlx.local_view(dp_tiles, tmem_buf_id))
+        if not REUSE_DP_FOR_DQ:
+            # pyrefly: ignore [missing-attribute]
+            tlx.barrier_arrive(tlx.local_view(dp_empties, tmem_buf_id))
+
+        dsT = pT * (dpT - Di[None, :])
+        dsT = dsT.to(q_out_dtype)
+        # pyrefly: ignore [missing-attribute]
+        tlx.local_store(tlx.local_view(ds_tiles, ds_buf_id), dsT)
+        # pyrefly: ignore [missing-attribute]
+        tlx.fence_async_shared()
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_arrive(tlx.local_view(ds_fulls, ds_buf_id))
+        curr_m += step_m
+        blk_idx += 1
+    return curr_m, blk_idx
+
+
+@triton.jit
+def _hstu_bwd_compute_inner_loop_silu(
+    start_n,
+    qk_fulls,
+    qk_tiles,
+    qk_empties,
+    p_tiles,
+    p_fulls,
+    dp_empties,
+    dp_fulls,
+    dp_tiles,
+    ds_tiles,
+    ds_fulls,
+    seq_start,
+    seq_len,
+    off_h,
+    alpha,
+    scale,
+    low,
+    high,
+    blk_idx,
+    do_out_dtype,
+    q_out_dtype,
+    contextual_seq_len,
+    max_attn_len,
+    n_targets,
+    NUM_BUFFERS_TMEM: tl.constexpr,
+    NUM_BUFFERS_DS: tl.constexpr,
+    BLOCK_M1: tl.constexpr,
+    BLOCK_N1: tl.constexpr,
+    REUSE_DP_FOR_DQ: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+    APPLY_MASK: tl.constexpr,
+    ALPHA_BWD_PRESCALE: tl.constexpr,
+):
+    """Backward compute inner loop for SiLU activation with jagged sequences.
+
+    Args:
+        start_n: K/V block start position
+        low: Start of M range to process
+        high: End of M range to process (exclusive)
+        blk_idx: Current block index for buffer management
+        APPLY_MASK: Whether to apply causal/semi-local masking in this range
+
+    Returns:
+        blk_idx: Updated block index
+    """
+    start_block_n = start_n
+    offs_n = start_block_n + tl.arange(0, BLOCK_N1)
+
+    # Precompute max_ids and pos_offs_n once before the loop
+    if APPLY_MASK:
+        max_ids, pos_offs_n = backward_off_common_preprocess(
+            seq_len,
+            contextual_seq_len,
+            n_targets,
+            offs_n,
+            HAS_CONTEXTUAL_SEQ_LEN,
+            HAS_NUM_TARGETS,
+        )
+
+    # Boundary mask for N dimension (for last K/V block)
+    mask_n = offs_n < seq_len
+
+    if ALPHA_BWD_PRESCALE:
+        # Pre-scale alpha by 0.5, matching CUTLASS (line 382: alpha = args.alpha * 0.5f).
+        # With y = alpha*0.5*QK, we store 1+tanh(y) = 2*sigmoid(2y) = 2*sigmoid(alpha*QK).
+        # Then P = y*(1+tanh(y)) = silu(alpha*QK), and the 2x and 0.5x cancel.
+        alpha = alpha * 0.5
+        half_scale = scale * 0.5
+
+    for curr_m in tl.range(low, high, BLOCK_M1):
+        tmem_buf_id, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
+        ds_buf_id, _ = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DS)
+
+        offs_m = curr_m + tl.arange(0, BLOCK_M1)
+
+        # wait for qkT = tl.dot(k, qT)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(tlx.local_view(qk_fulls, tmem_buf_id), tmem_phase)
+        # pyrefly: ignore [missing-attribute]
+        qkT = tlx.local_load(tlx.local_view(qk_tiles, tmem_buf_id))
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_arrive(tlx.local_view(qk_empties, tmem_buf_id))
+
+        # Boundary mask for M dimension (for last Q/dO block)
+        mask_m = offs_m < seq_len
+
+        if APPLY_MASK:
+            # Compute valid mask for HSTU attention (masked region)
+            valid_mask_trans = backward_valid_mask(
+                offs_m,
+                # pyre-fixme[61]: `pos_offs_n` is defined when APPLY_MASK is True
+                pos_offs_n,
+                offs_n,
+                # pyre-fixme[61]: `max_ids` is defined when APPLY_MASK is True
+                max_ids,
+                contextual_seq_len,
+                max_attn_len,
+                HAS_CONTEXTUAL_SEQ_LEN,
+                HAS_NUM_TARGETS,
+                HAS_MAX_ATTN_LEN,
+            )
+            # Also apply boundary mask for last K/V and Q/dO blocks
+            boundary_mask_trans = mask_n[:, None] & mask_m[None, :]
+            valid_mask_trans = valid_mask_trans & boundary_mask_trans
+
+            if ALPHA_BWD_PRESCALE:
+                # CUTLASS-style: scale ALL, compute 1+tanh (=2*sigmoid), then zero for masked.
+                qkT_scaled = qkT * alpha
+                one_plus_tanh = _fma_f32x2(tanh_approx_fp32(qkT_scaled), 1.0, 1.0)
+                one_plus_tanh = tl.where(valid_mask_trans, one_plus_tanh, 0.0)
+            else:
+                masked_alpha = tl.where(valid_mask_trans, alpha, 0.0)
+                qkT_scaled = qkT * masked_alpha
+        else:
+            # Unmasked region: only need boundary mask for last Q/dO and K/V blocks
+            # Interior tiles (all elements in bounds): skip masking entirely
+            is_interior = (
+                curr_m + BLOCK_M1 <= seq_len and start_block_n + BLOCK_N1 <= seq_len
+            )
+            mask_m = offs_m < seq_len
+            qkT_scaled = qkT * alpha
+            if ALPHA_BWD_PRESCALE:
+                one_plus_tanh = _fma_f32x2(tanh_approx_fp32(qkT_scaled), 1.0, 1.0)
+                if not is_interior:
+                    boundary_mask_trans = mask_n[:, None] & mask_m[None, :]
+                    one_plus_tanh = tl.where(boundary_mask_trans, one_plus_tanh, 0.0)
+            else:
+                if not is_interior:
+                    boundary_mask_trans = mask_n[:, None] & mask_m[None, :]
+                    masked_alpha = tl.where(boundary_mask_trans, alpha, 0.0)
+                    qkT_scaled = qkT * masked_alpha
+
+        if ALPHA_BWD_PRESCALE:
+            # P = y*(1+tanh(y))*scale = silu(alpha*QK)*scale
+            # pyre-fixme[61]: `one_plus_tanh` is undefined, or not always defined.
+            silu_trans = qkT_scaled * one_plus_tanh * scale
+        else:
+            sig_trans = fast_silu(qkT_scaled, MULT_BY_X=False)
+            silu_trans = qkT_scaled * sig_trans * scale
+
+        # pT = silu activation value
+        pT = silu_trans
+        ppT = pT.to(do_out_dtype)
+        # pyrefly: ignore [missing-attribute]
+        tlx.local_store(tlx.local_view(p_tiles, tmem_buf_id), ppT)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_arrive(tlx.local_view(p_fulls, tmem_buf_id))
+
+        # Wait for dpT = tl.dot(v, tl.trans(do))
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(tlx.local_view(dp_fulls, tmem_buf_id), tmem_phase)
+        # pyrefly: ignore [missing-attribute]
+        dpT = tlx.local_load(tlx.local_view(dp_tiles, tmem_buf_id))
+        if not REUSE_DP_FOR_DQ:
+            # pyrefly: ignore [missing-attribute]
+            tlx.barrier_arrive(tlx.local_view(dp_empties, tmem_buf_id))
+
+        # Derivative computation
+        if ALPHA_BWD_PRESCALE:
+            # Derivative of silu(x) = x/2*(1+tanh(x/2)) with y = x/2 = qkT_scaled:
+            # d/dx[silu(x)] = (1+tanh(y))/2 * (1 + y*(1-tanh(y)))
+            # dsT = dpT * (1+tanh(y)) * (1 + y*(1-tanh(y))) * scale * 0.5
+            # The 0.5 is folded into half_scale.
+            # Masked elements have one_plus_tanh=0, so dsT=0 automatically.
+            # Derive 1-tanh from 1+tanh: (1-tanh) = 2-(1+tanh), avoiding keeping tanh_y live.
+            # pyre-fixme[61]: `one_plus_tanh` is undefined, or not always defined.
+            one_minus_tanh = _fma_f32x2(one_plus_tanh, -1.0, 2.0)
+            dsT = (
+                dpT
+                # pyre-fixme[61]: `one_plus_tanh` is undefined, or not always defined.
+                * one_plus_tanh
+                * _fma_f32x2(qkT_scaled, one_minus_tanh, 1.0)
+                # pyre-fixme[61]: `half_scale` is undefined, or not always defined.
+                * half_scale
+            )
+        else:
+            # Old path: dsT = dpT * sig * (1 + x*(1-sig)) * scale
+            # pyre-fixme[61]: `sig_trans` is undefined, or not always defined.
+            one_minus_sig = _fma_f32x2(sig_trans, -1.0, 1.0)
+            # pyre-fixme[61]: `sig_trans` is undefined, or not always defined.
+            dsT = dpT * sig_trans * _fma_f32x2(qkT_scaled, one_minus_sig, 1.0) * scale
+            if APPLY_MASK:
+                # pyre-fixme[61]: `valid_mask_trans` is undefined, or not always
+                #  defined.
+                dsT = tl.where(valid_mask_trans, dsT, 0.0)
+            else:
+                # pyre-fixme[61]: `is_interior` is undefined, or not always defined.
+                if not is_interior:
+                    # pyre-fixme[61]: `boundary_mask_trans` is undefined, or not
+                    #  always defined.
+                    dsT = tl.where(boundary_mask_trans, dsT, 0.0)
+        dsT = dsT.to(q_out_dtype)
+        # pyrefly: ignore [missing-attribute]
+        tlx.local_store(tlx.local_view(ds_tiles, ds_buf_id), dsT)
+        # pyrefly: ignore [missing-attribute]
+        tlx.fence_async_shared()
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_arrive(tlx.local_view(ds_fulls, ds_buf_id))
+        blk_idx += 1
+
+    return blk_idx
+
+
+@triton.jit
+def _hstu_bwd_reduction_accumulate_dq(
+    desc_dq,
+    dq_fulls,
+    dq_tiles,
+    dq_empties,
+    seq_start,
+    off_h,
+    stride_dqh,
+    curr_m,
+    blk_idx,
+    sm_scale,
+    NUM_BUFFERS_TMEM: tl.constexpr,
+    BLOCK_M1: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    EPILOGUE_SUBTILE: tl.constexpr,
+):
+    """Reduction group helper for SiLU: accumulate dQ with atomic add.
+
+    Scales by sm_scale (alpha) for SiLU backward.
+    """
+    tmem_buf_id, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
+
+    # wait for dq = tl.dot(tl.trans(dsT), k)
+    # pyrefly: ignore [missing-attribute]
+    tlx.barrier_wait(dq_fulls[tmem_buf_id], tmem_phase)
+    slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
+    for slice_id in tl.static_range(EPILOGUE_SUBTILE):
+        # pyrefly: ignore [missing-attribute]
+        dq_slice = tlx.local_slice(
+            dq_tiles[tmem_buf_id],
+            [0, slice_id * slice_size],
+            [BLOCK_M1, slice_size],
+        )
+        # pyrefly: ignore [missing-attribute]
+        dq = tlx.local_load(dq_slice)
+        dq = dq * sm_scale
+        desc_dq.atomic_add(
+            [
+                (seq_start + curr_m).to(tl.int32),
+                (off_h * stride_dqh + slice_id * slice_size).to(tl.int32),
+            ],
+            dq,
+        )
+
+    # release dq
+    # pyrefly: ignore [missing-attribute]
+    tlx.barrier_arrive(dq_empties[tmem_buf_id])
+    blk_idx += 1
+
+    return blk_idx
+
+
+@triton.jit
+def bwd_calculate_offsets(
+    tile_idx,
+    n_tile_num,
+    num_pid_m,
+    stride_z,
+    stride_h,
+    stride_tok,
+    H,
+    N_CTX,  #
+    BLOCK_M1: tl.constexpr,
+    BLOCK_N1: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    STAGE: tl.constexpr,
+):
+    bhid = tile_idx // n_tile_num
+    pid = tile_idx % n_tile_num
+    pid, bhid = tl.swizzle2d(pid, bhid, n_tile_num, num_pid_m, GROUP_SIZE_M)
+    off_chz = (bhid * N_CTX).to(tl.int64)
+    off_bh = (
+        (stride_h * (bhid % H) + stride_z * (bhid // H)).to(tl.int64)
+    ) // stride_tok
+    start_n = pid
+    start_m = _get_start_m_bwd(start_n, BLOCK_N1, STAGE)
+    num_steps = (N_CTX - start_m) // BLOCK_M1
+    return off_chz, off_bh, start_m, start_n, num_steps
+
+
+@triton.jit
+def _get_start_m_bwd(start_n, BLOCK_N1, STAGE: tl.constexpr):
+    if STAGE == 1:
+        return 0
+    else:
+        tl.static_assert(STAGE == 3)
+        return start_n * BLOCK_N1
+
+
+@triton.jit
+def _get_unfused_bwd_loop_bounds(start_n, N_CTX, BLOCK_N1, STAGE: tl.constexpr):
+    if STAGE == 1:
+        # First part of STAGE == 3
+        lo, hi = start_n * BLOCK_N1, (start_n + 1) * BLOCK_N1
+    elif STAGE == 2:
+        # Second part of STAGE == 3 in this function
+        lo, hi = (start_n + 1) * BLOCK_N1, N_CTX
+    else:
+        tl.static_assert(STAGE == 3)
+        lo, hi = 0, N_CTX
+    return lo, hi
+
+
+@triton.jit
+def _bwd_compute_inner_loop(
+    start_n,
+    qk_fulls,
+    qk_tiles,
+    qk_empties,
+    p_tiles,
+    p_fulls,
+    dp_empties,
+    dp_fulls,
+    dp_tiles,
+    ds_tiles,
+    ds_fulls,
+    M,
+    D,
+    curr_m,
+    blk_idx,
+    step_m,
+    do_out_dtype,
+    q_out_dtype,
+    N_CTX,
+    NUM_BUFFERS_TMEM: tl.constexpr,
+    NUM_BUFFERS_DS: tl.constexpr,
+    BLOCK_M1: tl.constexpr,
+    BLOCK_N1: tl.constexpr,
+    STAGE: tl.constexpr,
+    REUSE_DP_FOR_DQ: tl.constexpr,
+):
+    start_block_n = start_n * BLOCK_N1
+    offs_n = start_block_n + tl.arange(0, BLOCK_N1)
+    lo, hi = _get_unfused_bwd_loop_bounds(start_n, N_CTX, BLOCK_N1, STAGE)
+    num_steps = (hi - lo) // BLOCK_M1
+    for _ in range(num_steps):
+        tmem_buf_id, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
+        ds_buf_id, _ = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DS)
+
+        offs_m = curr_m + tl.arange(0, BLOCK_M1)
+        m = tl.load(M + offs_m)
+
+        # wait for qkT = tl.dot(k, qT)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(tlx.local_view(qk_fulls, tmem_buf_id), tmem_phase)
+        # pyrefly: ignore [missing-attribute]
+        qkT = tlx.local_load(tlx.local_view(qk_tiles, tmem_buf_id))
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_arrive(tlx.local_view(qk_empties, tmem_buf_id))
+
+        pT = tl.math.exp2(qkT - m[None, :])
+        if STAGE == 1:
+            mask = offs_m[None, :] >= offs_n[:, None]
+            pT = tl.where(mask, pT, 0.0)
+
+        # ppT *= qk_scale
+        ppT = pT
+        ppT = ppT.to(do_out_dtype)
+        # pyrefly: ignore [missing-attribute]
+        tlx.local_store(tlx.local_view(p_tiles, tmem_buf_id), ppT)
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_arrive(tlx.local_view(p_fulls, tmem_buf_id))
+
+        # D (= delta) is pre-divided by ds_scale.
+        Di = tl.load(D + offs_m)
+
+        # Wait for dpT = tl.dot(v, tl.trans(do))
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_wait(tlx.local_view(dp_fulls, tmem_buf_id), tmem_phase)
+        # pyrefly: ignore [missing-attribute]
+        dpT = tlx.local_load(tlx.local_view(dp_tiles, tmem_buf_id))
+        # We can only signal the arrive if DP is not shared with DQ.
+        # Otherwise we need to wait for DQ to be done.
+        if not REUSE_DP_FOR_DQ:
+            # pyrefly: ignore [missing-attribute]
+            tlx.barrier_arrive(tlx.local_view(dp_empties, tmem_buf_id))
+        dsT = pT * (dpT - Di[None, :])
+        dsT = dsT.to(q_out_dtype)
+        # pyrefly: ignore [missing-attribute]
+        tlx.local_store(tlx.local_view(ds_tiles, ds_buf_id), dsT)
+        # pyrefly: ignore [missing-attribute]
+        tlx.fence_async_shared()
+        # pyrefly: ignore [missing-attribute]
+        tlx.barrier_arrive(tlx.local_view(ds_fulls, ds_buf_id))
+        curr_m += step_m
+        blk_idx += 1
+    return curr_m, blk_idx
+
+
+def _hstu_bwd_host_descriptor_pre_hook(nargs):
+    BLOCK_M1 = nargs["BLOCK_M1"]
+    BLOCK_N1 = nargs["BLOCK_N1"]
+    HEAD_DIM = nargs["HEAD_DIM"]
+    EPILOGUE_SUBTILE = nargs["EPILOGUE_SUBTILE"]
+    nargs["DQ"].zero_()
+
+    nargs["desc_q"].block_shape = [BLOCK_M1, HEAD_DIM]
+    nargs["desc_do"].block_shape = [BLOCK_M1, HEAD_DIM]
+    nargs["desc_v"].block_shape = [BLOCK_N1, HEAD_DIM]
+    nargs["desc_k"].block_shape = [BLOCK_N1, HEAD_DIM]
+    DQ_REDUCE_FACTOR = nargs["DQ_REDUCE_FACTOR"]
+    nargs["desc_dq"].block_shape = [
+        BLOCK_M1,
+        HEAD_DIM // (EPILOGUE_SUBTILE * DQ_REDUCE_FACTOR),
+    ]
+    nargs["desc_dv"].block_shape = [BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE]
+    nargs["desc_dk"].block_shape = [BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE]
+
+
+def get_hstu_bwd_configs() -> List[triton.Config]:
+    return [
+        triton.Config(
+            {
+                "BLOCK_M1": 128,
+                "BLOCK_N1": 128,
+                "BLOCK_M2": 128,
+                "BLOCK_N2": 128,
+                "NUM_BUFFERS_KV": 1,
+                "NUM_BUFFERS_Q": 2,
+                "NUM_BUFFERS_DO": 1,
+                "NUM_BUFFERS_DS": 1,
+                "NUM_BUFFERS_TMEM": 1,
+                "EPILOGUE_SUBTILE": 2,
+                "DQ_REDUCE_FACTOR": 2,
+                "DQ_REDUCE_STAGES": 2,
+                "EARLY_RELEASE_SUBTILES": er,
+                "ALPHA_BWD_PRESCALE": True,
+            },
+            num_warps=4,
+            num_stages=1,
+            pre_hook=_hstu_bwd_host_descriptor_pre_hook,
+        )
+        # HSTU_SELF_PIN=1 -> one config (fast compile for tritonbench --mode bwd).
+        for er in ([1] if os.environ.get("HSTU_SELF_PIN") else [1, 2])
+    ] + [
+        triton.Config(
+            {
+                "BLOCK_M1": 64,
+                "BLOCK_N1": 128,
+                "BLOCK_M2": 128,
+                "BLOCK_N2": 128,
+                "NUM_BUFFERS_KV": 1,
+                "NUM_BUFFERS_Q": 2,
+                "NUM_BUFFERS_DO": 1,
+                "NUM_BUFFERS_DS": 1,
+                "NUM_BUFFERS_TMEM": 1,
+                "EPILOGUE_SUBTILE": 2,
+                "DQ_REDUCE_FACTOR": 2,
+                "DQ_REDUCE_STAGES": 2,
+                "EARLY_RELEASE_SUBTILES": er,
+                "ALPHA_BWD_PRESCALE": True,
+            },
+            num_warps=4,
+            num_stages=1,
+            pre_hook=_hstu_bwd_host_descriptor_pre_hook,
+        )
+        # HSTU_SELF_PIN=1 -> one config (fast compile for tritonbench --mode bwd).
+        for er in ([1] if os.environ.get("HSTU_SELF_PIN") else [1, 2])
+    ]
+
+
+@triton.autotune(
+    configs=get_hstu_bwd_configs(), key=["AUTOTUNE_MAX_SEQ_LEN", "HEAD_DIM"]
+)
+@triton.jit
+def _hstu_attn_bwd_ws(
+    DQ,
+    DK,
+    DV,
+    desc_q,
+    desc_k,
+    desc_v,
+    sm_scale,  # alpha
+    desc_do,  #
+    desc_dq,
+    desc_dk,
+    desc_dv,  #
+    M,
+    D,
+    seq_offsets,
+    attn_scale,
+    num_targets,
+    max_attn_len,
+    full_attn_size,
+    contextual_seq_len,
+    # shared by Q/K/V/DO.
+    stride_qh,
+    stride_kh,
+    stride_vh,
+    stride_doh,
+    stride_dqh,
+    stride_dkn,
+    stride_dkh,
+    stride_dvn,
+    stride_dvh,
+    stride_mh,
+    stride_deltah,
+    H,
+    Z,
+    max_seq_len,  #
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    BLOCK_M2: tl.constexpr,  #
+    BLOCK_N2: tl.constexpr,  #
+    BLK_SLICE_FACTOR: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,
+    NUM_BUFFERS_KV: tl.constexpr,
+    NUM_BUFFERS_Q: tl.constexpr,
+    NUM_BUFFERS_DO: tl.constexpr,
+    NUM_BUFFERS_DS: tl.constexpr,
+    NUM_BUFFERS_TMEM: tl.constexpr,
+    EPILOGUE_SUBTILE: tl.constexpr,
+    DQ_REDUCE_FACTOR: tl.constexpr,
+    DQ_REDUCE_STAGES: tl.constexpr,
+    EARLY_RELEASE_SUBTILES: tl.constexpr,
+    ALPHA_BWD_PRESCALE: tl.constexpr,
+    STAGE: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    SOFTMAX: tl.constexpr,
+    AUTOTUNE_MAX_SEQ_LEN: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_FULL_ATTN_SIZE: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+):
+    """HSTU backward pass kernel with jagged sequences and SiLU/Softmax activation."""
+    # Kernel hangs if NUM_BUFFERS_Q != 2.
+    tl.static_assert(NUM_BUFFERS_Q == 2)
+    # Runtime error if NUM_BUFFERS_DO != 1
+    tl.static_assert(NUM_BUFFERS_DO == 1)
+    # TODO: Add support for contextual seq len
+    tl.static_assert(not HAS_CONTEXTUAL_SEQ_LEN)
+    tl.static_assert(
+        EARLY_RELEASE_SUBTILES >= 1 and EARLY_RELEASE_SUBTILES <= 2,
+        "EARLY_RELEASE_SUBTILES must be 1 or 2",
+    )
+
+    REUSE_DP_FOR_DQ: tl.constexpr = (BLOCK_M1 == 128) and (HEAD_DIM == 128)
+
+    n_tile_num = tl.cdiv(max_seq_len, BLOCK_N1)
+    num_pid_m = Z * H
+    tile_idx = tl.program_id(0)
+
+    # allocate smem buffers
+    # pyrefly: ignore [missing-attribute]
+    k_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, HEAD_DIM),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_k),
+        NUM_BUFFERS_KV,
+    )
+    # pyrefly: ignore [missing-attribute]
+    v_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, HEAD_DIM),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_v),
+        NUM_BUFFERS_KV,
+    )
+    # pyrefly: ignore [missing-attribute]
+    q_tiles = tlx.local_alloc((BLOCK_M1, HEAD_DIM), tlx.dtype_of(desc_q), NUM_BUFFERS_Q)
+    # pyrefly: ignore [missing-attribute]
+    do_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_M1, HEAD_DIM),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_do),
+        NUM_BUFFERS_DO,
+    )
+
+    # Use SMEM for dsT
+    # pyrefly: ignore [missing-attribute]
+    ds_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, BLOCK_M1),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_q),
+        NUM_BUFFERS_DS,
+    )
+
+    # SMEM staging buffer for double-buffered dQ TMA reduce-add (from D97693127)
+    DQ_REDUCE_NCOL: tl.constexpr = HEAD_DIM // (EPILOGUE_SUBTILE * DQ_REDUCE_FACTOR)
+    DQ_REDUCE_ITERS: tl.constexpr = HEAD_DIM // DQ_REDUCE_NCOL
+    # pyrefly: ignore [missing-attribute]
+    dq_store_buf = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_M1, DQ_REDUCE_NCOL),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_dq),
+        DQ_REDUCE_STAGES,
+    )
+
+    # SMEM staging buffers for dKV async TMA store (from D99341217)
+    # sdv reuses v_tiles (free after dv_fulls; MMA's last v_tiles read precedes dv_fulls)
+    # sdk reuses k_tiles (MMA's dq dot still reads k_tiles after dk_fulls,
+    #   so compute waits on k_mma_done before writing sdk)
+    DKV_STORE_NCOL: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
+    DKV_STORE_ITERS: tl.constexpr = HEAD_DIM // DKV_STORE_NCOL
+    # pyrefly: ignore [missing-attribute]
+    sdv_store_buf = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, DKV_STORE_NCOL),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_dv),
+        NUM_BUFFERS_KV,
+        reuse=v_tiles,
+    )
+    # pyrefly: ignore [missing-attribute]
+    sdk_store_buf = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, DKV_STORE_NCOL),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_dk),
+        NUM_BUFFERS_KV,
+        reuse=k_tiles,
+    )
+
+    # allocate barriers for smem buffers
+    # pyrefly: ignore [missing-attribute]
+    k_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    k_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    k_mma_done = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    v_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    q_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_Q)
+    # pyrefly: ignore [missing-attribute]
+    q_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_Q)
+    # pyrefly: ignore [missing-attribute]
+    do_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_DO)
+    # pyrefly: ignore [missing-attribute]
+    do_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_DO)
+    # pyrefly: ignore [missing-attribute]
+    ds_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+
+    # allocate tmem buffers
+    # pyrefly: ignore [missing-attribute]
+    qk_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, BLOCK_M1),
+        tl.float32,
+        NUM_BUFFERS_TMEM,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+    )
+    # pyrefly: ignore [missing-attribute]
+    p_tiles = tlx.local_alloc(
+        (BLOCK_N1, BLOCK_M1),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_do),
+        NUM_BUFFERS_TMEM,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    # pyrefly: ignore [missing-attribute]
+    dp_tiles = tlx.local_alloc(
+        (BLOCK_N1, BLOCK_M1),
+        tl.float32,
+        NUM_BUFFERS_TMEM,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+    )
+
+    # pyrefly: ignore [missing-attribute]
+    dv_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, HEAD_DIM),
+        tl.float32,
+        NUM_BUFFERS_KV,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+    )
+    # pyrefly: ignore [missing-attribute]
+    dk_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, HEAD_DIM),
+        tl.float32,
+        NUM_BUFFERS_KV,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+    )
+
+    # allocate barriers for tmem buffers
+    # pyrefly: ignore [missing-attribute]
+    qk_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    qk_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    p_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    dp_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    dq_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    dq_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+
+    # pyrefly: ignore [missing-attribute]
+    dv_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    dv_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    dk_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    dk_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+
+    if REUSE_DP_FOR_DQ:
+        # pyrefly: ignore [missing-attribute]
+        dq_tiles = tlx.local_alloc(
+            (BLOCK_M1, HEAD_DIM),
+            tl.float32,
+            NUM_BUFFERS_TMEM,
+            # pyrefly: ignore [missing-attribute]
+            tlx.storage_kind.tmem,
+            reuse=dp_tiles,
+        )
+        dp_empties = dq_empties
+    else:
+        # pyrefly: ignore [missing-attribute]
+        dq_tiles = tlx.local_alloc(
+            (BLOCK_M1, HEAD_DIM),
+            tl.float32,
+            NUM_BUFFERS_TMEM,
+            # pyrefly: ignore [missing-attribute]
+            tlx.storage_kind.tmem,
+        )
+        # pyrefly: ignore [missing-attribute]
+        dp_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+
+    # pyrefly: ignore [missing-attribute]
+    clc_context = tlx.clc_create_context(num_consumers=4)
+
+    # pyrefly: ignore [missing-attribute]
+    with tlx.async_tasks():
+        # reduction group: accumulate dq
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task("default"):
+            LN2 = 0.6931471824645996  # = ln(2)
+            blk_idx = 0
+            clc_phase_producer = 1
+            clc_phase_consumer = 0
+            while tile_idx != -1:
+                # pyrefly: ignore [missing-attribute]
+                tlx.clc_producer(clc_context, clc_phase_producer)
+                clc_phase_producer ^= 1
+                (
+                    off_z,
+                    off_h,
+                    seq_start,
+                    seq_len,
+                    n_targets,
+                    start_n,
+                    low1,
+                    high1,
+                    low2,
+                    high2,
+                ) = _hstu_bwd_calculate_offsets(
+                    tile_idx,
+                    n_tile_num,
+                    num_pid_m,
+                    seq_offsets,
+                    num_targets,
+                    max_attn_len,
+                    full_attn_size,
+                    contextual_seq_len,
+                    H,
+                    BLOCK_M1,
+                    BLOCK_N1,
+                    GROUP_SIZE_M,
+                    HAS_NUM_TARGETS,
+                    HAS_MAX_ATTN_LEN,
+                    HAS_FULL_ATTN_SIZE,
+                    HAS_CONTEXTUAL_SEQ_LEN,
+                    STAGE,
+                )
+                if start_n < seq_len:
+                    # if SOFTMAX:
+                    #     # Original softmax reduction: single fused loop
+                    #     num_steps_masked = (high1 - low1) // BLOCK_M1
+                    #     num_steps_unmasked = (high2 - low2) // BLOCK_M1
+                    #     num_steps = num_steps_masked + num_steps_unmasked
+                    #     curr_m = low1
+                    #     step_m = BLOCK_M1
+                    #     for _ in range(num_steps):
+                    #         tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                    #             blk_idx, NUM_BUFFERS_TMEM
+                    #         )
+
+                    #         # wait for dq = tl.dot(tl.trans(dsT), k)
+                    #         tlx.barrier_wait(dq_fulls[tmem_buf_id], tmem_phase)
+                    #         slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
+                    #         for slice_id in tl.static_range(EPILOGUE_SUBTILE):
+                    #             dq_slice = tlx.local_slice(
+                    #                 dq_tiles[tmem_buf_id],
+                    #                 [0, slice_id * slice_size],
+                    #                 [BLOCK_M1, slice_size],
+                    #             )
+                    #             dq = tlx.local_load(dq_slice)
+                    #             dq = dq * LN2
+                    #             desc_dq.atomic_add(
+                    #                 [
+                    #                     (seq_start + curr_m).to(tl.int32),
+                    #                     (off_h * stride_dqh + slice_id * slice_size).to(
+                    #                         tl.int32
+                    #                     ),
+                    #                 ],
+                    #                 dq,
+                    #             )
+
+                    #         # release dq
+                    #         tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                    #         # Increment pointers.
+                    #         curr_m += step_m
+                    #         blk_idx += 1
+                    # else:
+                    # SiLU reduction: two loops for PART 1 and PART 2
+                    # INLINED to avoid TLX region isolation issues with helper functions
+                    # dQ early TMEM release optimization (from D98825322):
+                    # Pre-load last EARLY_RELEASE_SUBTILES from TMEM into registers,
+                    # release TMEM early, then process from registers.
+                    # PART 1: Masked region [low1, high1)
+                    for curr_m in tl.range(low1, high1, BLOCK_M1):
+                        tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                            blk_idx, NUM_BUFFERS_TMEM
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(dq_fulls[tmem_buf_id], tmem_phase)
+                        for slice_id in tl.static_range(
+                            DQ_REDUCE_ITERS - EARLY_RELEASE_SUBTILES
+                        ):
+                            dq_smem_idx = slice_id % DQ_REDUCE_STAGES
+                            # pyrefly: ignore [missing-attribute]
+                            dq_slice = tlx.local_slice(
+                                dq_tiles[tmem_buf_id],
+                                [0, slice_id * DQ_REDUCE_NCOL],
+                                [BLOCK_M1, DQ_REDUCE_NCOL],
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            dq = tlx.local_load(dq_slice)
+                            dq = dq * sm_scale
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_store(
+                                dq_store_buf[dq_smem_idx],
+                                # pyrefly: ignore [missing-attribute]
+                                dq.to(tlx.dtype_of(desc_dq)),
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.fence_async_shared()
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store(
+                                desc_dq,
+                                dq_store_buf[dq_smem_idx],
+                                [
+                                    (seq_start + curr_m).to(tl.int32),
+                                    (slice_id * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                        tl.int32
+                                    ),
+                                ],
+                                store_reduce="add",
+                            )
+                        if EARLY_RELEASE_SUBTILES == 1:
+                            er0: tl.constexpr = DQ_REDUCE_ITERS - 1
+                            # pyrefly: ignore [missing-attribute]
+                            dq_er0 = tlx.local_load(
+                                # pyrefly: ignore [missing-attribute]
+                                tlx.local_slice(
+                                    dq_tiles[tmem_buf_id],
+                                    [0, er0 * DQ_REDUCE_NCOL],
+                                    [BLOCK_M1, DQ_REDUCE_NCOL],
+                                )
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                            dq_er0 = dq_er0 * sm_scale
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_store(
+                                dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                                # pyrefly: ignore [missing-attribute]
+                                dq_er0.to(tlx.dtype_of(desc_dq)),
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.fence_async_shared()
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store(
+                                desc_dq,
+                                dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                                [
+                                    (seq_start + curr_m).to(tl.int32),
+                                    (er0 * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                        tl.int32
+                                    ),
+                                ],
+                                store_reduce="add",
+                            )
+                        elif EARLY_RELEASE_SUBTILES == 2:
+                            er0: tl.constexpr = DQ_REDUCE_ITERS - 2
+                            er1: tl.constexpr = DQ_REDUCE_ITERS - 1
+                            # pyrefly: ignore [missing-attribute]
+                            dq_er0 = tlx.local_load(
+                                # pyrefly: ignore [missing-attribute]
+                                tlx.local_slice(
+                                    dq_tiles[tmem_buf_id],
+                                    [0, er0 * DQ_REDUCE_NCOL],
+                                    [BLOCK_M1, DQ_REDUCE_NCOL],
+                                )
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            dq_er1 = tlx.local_load(
+                                # pyrefly: ignore [missing-attribute]
+                                tlx.local_slice(
+                                    dq_tiles[tmem_buf_id],
+                                    [0, er1 * DQ_REDUCE_NCOL],
+                                    [BLOCK_M1, DQ_REDUCE_NCOL],
+                                )
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                            dq_er0 = dq_er0 * sm_scale
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_store(
+                                dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                                # pyrefly: ignore [missing-attribute]
+                                dq_er0.to(tlx.dtype_of(desc_dq)),
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.fence_async_shared()
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store(
+                                desc_dq,
+                                dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                                [
+                                    (seq_start + curr_m).to(tl.int32),
+                                    (er0 * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                        tl.int32
+                                    ),
+                                ],
+                                store_reduce="add",
+                            )
+                            dq_er1 = dq_er1 * sm_scale
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_store(
+                                dq_store_buf[er1 % DQ_REDUCE_STAGES],
+                                # pyrefly: ignore [missing-attribute]
+                                dq_er1.to(tlx.dtype_of(desc_dq)),
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.fence_async_shared()
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store(
+                                desc_dq,
+                                dq_store_buf[er1 % DQ_REDUCE_STAGES],
+                                [
+                                    (seq_start + curr_m).to(tl.int32),
+                                    (er1 * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                        tl.int32
+                                    ),
+                                ],
+                                store_reduce="add",
+                            )
+                        blk_idx += 1
+
+                    # PART 2: Unmasked region [low2, high2)
+                    for curr_m in tl.range(low2, high2, BLOCK_M1):
+                        tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                            blk_idx, NUM_BUFFERS_TMEM
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(dq_fulls[tmem_buf_id], tmem_phase)
+                        for slice_id in tl.static_range(
+                            DQ_REDUCE_ITERS - EARLY_RELEASE_SUBTILES
+                        ):
+                            dq_smem_idx = slice_id % DQ_REDUCE_STAGES
+                            # pyrefly: ignore [missing-attribute]
+                            dq_slice = tlx.local_slice(
+                                dq_tiles[tmem_buf_id],
+                                [0, slice_id * DQ_REDUCE_NCOL],
+                                [BLOCK_M1, DQ_REDUCE_NCOL],
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            dq = tlx.local_load(dq_slice)
+                            dq = dq * sm_scale
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_store(
+                                dq_store_buf[dq_smem_idx],
+                                # pyrefly: ignore [missing-attribute]
+                                dq.to(tlx.dtype_of(desc_dq)),
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.fence_async_shared()
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store(
+                                desc_dq,
+                                dq_store_buf[dq_smem_idx],
+                                [
+                                    (seq_start + curr_m).to(tl.int32),
+                                    (slice_id * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                        tl.int32
+                                    ),
+                                ],
+                                store_reduce="add",
+                            )
+                        if EARLY_RELEASE_SUBTILES == 1:
+                            er0: tl.constexpr = DQ_REDUCE_ITERS - 1
+                            # pyrefly: ignore [missing-attribute]
+                            dq_er0 = tlx.local_load(
+                                # pyrefly: ignore [missing-attribute]
+                                tlx.local_slice(
+                                    dq_tiles[tmem_buf_id],
+                                    [0, er0 * DQ_REDUCE_NCOL],
+                                    [BLOCK_M1, DQ_REDUCE_NCOL],
+                                )
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                            dq_er0 = dq_er0 * sm_scale
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_store(
+                                dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                                # pyrefly: ignore [missing-attribute]
+                                dq_er0.to(tlx.dtype_of(desc_dq)),
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.fence_async_shared()
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store(
+                                desc_dq,
+                                dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                                [
+                                    (seq_start + curr_m).to(tl.int32),
+                                    (er0 * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                        tl.int32
+                                    ),
+                                ],
+                                store_reduce="add",
+                            )
+                        elif EARLY_RELEASE_SUBTILES == 2:
+                            er0: tl.constexpr = DQ_REDUCE_ITERS - 2
+                            er1: tl.constexpr = DQ_REDUCE_ITERS - 1
+                            # pyrefly: ignore [missing-attribute]
+                            dq_er0 = tlx.local_load(
+                                # pyrefly: ignore [missing-attribute]
+                                tlx.local_slice(
+                                    dq_tiles[tmem_buf_id],
+                                    [0, er0 * DQ_REDUCE_NCOL],
+                                    [BLOCK_M1, DQ_REDUCE_NCOL],
+                                )
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            dq_er1 = tlx.local_load(
+                                # pyrefly: ignore [missing-attribute]
+                                tlx.local_slice(
+                                    dq_tiles[tmem_buf_id],
+                                    [0, er1 * DQ_REDUCE_NCOL],
+                                    [BLOCK_M1, DQ_REDUCE_NCOL],
+                                )
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                            dq_er0 = dq_er0 * sm_scale
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_store(
+                                dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                                # pyrefly: ignore [missing-attribute]
+                                dq_er0.to(tlx.dtype_of(desc_dq)),
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.fence_async_shared()
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store(
+                                desc_dq,
+                                dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                                [
+                                    (seq_start + curr_m).to(tl.int32),
+                                    (er0 * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                        tl.int32
+                                    ),
+                                ],
+                                store_reduce="add",
+                            )
+                            dq_er1 = dq_er1 * sm_scale
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_store(
+                                dq_store_buf[er1 % DQ_REDUCE_STAGES],
+                                # pyrefly: ignore [missing-attribute]
+                                dq_er1.to(tlx.dtype_of(desc_dq)),
+                            )
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.fence_async_shared()
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.async_descriptor_store(
+                                desc_dq,
+                                dq_store_buf[er1 % DQ_REDUCE_STAGES],
+                                [
+                                    (seq_start + curr_m).to(tl.int32),
+                                    (er1 * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                        tl.int32
+                                    ),
+                                ],
+                                store_reduce="add",
+                            )
+                        blk_idx += 1
+                # pyrefly: ignore [missing-attribute]
+                tile_idx = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                clc_phase_consumer ^= 1
+
+        # compute group: compute softmax/silu backward
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task(num_warps=8, registers=192, replicate=1):
+            blk_idx = 0
+            tile_cnt = 0
+            clc_phase_consumer = 0
+            while tile_idx != -1:
+                (
+                    off_z,
+                    off_h,
+                    seq_start,
+                    seq_len,
+                    n_targets,
+                    start_n,
+                    low1,
+                    high1,
+                    low2,
+                    high2,
+                ) = _hstu_bwd_calculate_offsets(
+                    tile_idx,
+                    n_tile_num,
+                    num_pid_m,
+                    seq_offsets,
+                    num_targets,
+                    max_attn_len,
+                    full_attn_size,
+                    contextual_seq_len,
+                    H,
+                    BLOCK_M1,
+                    BLOCK_N1,
+                    GROUP_SIZE_M,
+                    HAS_NUM_TARGETS,
+                    HAS_MAX_ATTN_LEN,
+                    HAS_FULL_ATTN_SIZE,
+                    HAS_CONTEXTUAL_SEQ_LEN,
+                    STAGE,
+                )
+                if start_n < seq_len:
+                    start_block_n = start_n
+
+                    curr_m = low1
+                    # pyrefly: ignore [missing-attribute]
+                    do_out_dtype = tlx.dtype_of(desc_do)
+                    # pyrefly: ignore [missing-attribute]
+                    q_out_dtype = tlx.dtype_of(desc_q)
+
+                    # SiLU activation backward
+                    scale = tl.load(attn_scale).to(tl.float32)
+                    # PART 1: Masked region [low1, high1)
+                    blk_idx = _hstu_bwd_compute_inner_loop_silu(
+                        start_n,
+                        qk_fulls,
+                        qk_tiles,
+                        qk_empties,
+                        p_tiles,
+                        p_fulls,
+                        dp_empties,
+                        dp_fulls,
+                        dp_tiles,
+                        ds_tiles,
+                        ds_fulls,
+                        seq_start,
+                        seq_len,
+                        off_h,
+                        sm_scale,  # alpha
+                        scale,
+                        low1,
+                        high1,
+                        blk_idx,
+                        do_out_dtype,
+                        q_out_dtype,
+                        contextual_seq_len,
+                        max_attn_len,
+                        n_targets,
+                        NUM_BUFFERS_TMEM,
+                        NUM_BUFFERS_DS,
+                        BLOCK_M1,
+                        BLOCK_N1,
+                        REUSE_DP_FOR_DQ=REUSE_DP_FOR_DQ,
+                        HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+                        HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+                        HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+                        APPLY_MASK=True,
+                        ALPHA_BWD_PRESCALE=ALPHA_BWD_PRESCALE,
+                    )
+                    # PART 2: Unmasked region [low2, high2)
+                    blk_idx = _hstu_bwd_compute_inner_loop_silu(
+                        start_n,
+                        qk_fulls,
+                        qk_tiles,
+                        qk_empties,
+                        p_tiles,
+                        p_fulls,
+                        dp_empties,
+                        dp_fulls,
+                        dp_tiles,
+                        ds_tiles,
+                        ds_fulls,
+                        seq_start,
+                        seq_len,
+                        off_h,
+                        sm_scale,  # alpha
+                        scale,
+                        low2,
+                        high2,
+                        blk_idx,
+                        do_out_dtype,
+                        q_out_dtype,
+                        contextual_seq_len,
+                        max_attn_len,
+                        n_targets,
+                        NUM_BUFFERS_TMEM,
+                        NUM_BUFFERS_DS,
+                        BLOCK_M1,
+                        BLOCK_N1,
+                        REUSE_DP_FOR_DQ=REUSE_DP_FOR_DQ,
+                        HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+                        HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+                        HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+                        APPLY_MASK=False,
+                        ALPHA_BWD_PRESCALE=ALPHA_BWD_PRESCALE,
+                    )
+
+                    # epilogue: dKV via SMEM staging + async TMA store (D99341217)
+                    kv_buf_id, kv_phase = _get_bufidx_phase(tile_cnt, NUM_BUFFERS_KV)
+                    tile_cnt += 1
+
+                    # Create on-device TMA descriptors for jagged sequence writes
+                    end_kv = seq_start + seq_len
+                    dv_desc = tl.make_tensor_descriptor(
+                        DV,
+                        shape=[end_kv.to(tl.int32), stride_dvh * H],
+                        # pyrefly: ignore [bad-argument-type]
+                        strides=[stride_dvn, 1],
+                        block_shape=[BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE],
+                    )
+                    dk_desc = tl.make_tensor_descriptor(
+                        DK,
+                        shape=[end_kv.to(tl.int32), stride_dkh * H],
+                        # pyrefly: ignore [bad-argument-type]
+                        strides=[stride_dkn, 1],
+                        block_shape=[BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE],
+                    )
+
+                    # dV: TMEM → regs → SMEM staging → async TMA store
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dv_fulls[kv_buf_id], kv_phase)
+                    for slice_id in tl.static_range(DKV_STORE_ITERS):
+                        # pyrefly: ignore [missing-attribute]
+                        dv_slice = tlx.local_slice(
+                            dv_tiles[kv_buf_id],
+                            [0, slice_id * DKV_STORE_NCOL],
+                            [BLOCK_N1, DKV_STORE_NCOL],
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        dv = tlx.local_load(dv_slice)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store_wait(0)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.local_store(
+                            sdv_store_buf[kv_buf_id],
+                            # pyrefly: ignore [missing-attribute]
+                            dv.to(tlx.dtype_of(dv_desc)),
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.fence_async_shared()
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store(
+                            dv_desc,
+                            sdv_store_buf[kv_buf_id],
+                            [
+                                (seq_start + start_block_n).to(tl.int32),
+                                (off_h * stride_dvh + slice_id * DKV_STORE_NCOL).to(
+                                    tl.int32
+                                ),
+                            ],
+                        )
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_arrive(dv_empties[kv_buf_id])
+
+                    # dK: wait for MMA's dQ dot (last k_tiles read) before staging
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dk_fulls[kv_buf_id], kv_phase)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(k_mma_done[kv_buf_id], kv_phase)
+                    for slice_id in tl.static_range(DKV_STORE_ITERS):
+                        # pyrefly: ignore [missing-attribute]
+                        dk_slice = tlx.local_slice(
+                            dk_tiles[kv_buf_id],
+                            [0, slice_id * DKV_STORE_NCOL],
+                            [BLOCK_N1, DKV_STORE_NCOL],
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        dk = tlx.local_load(dk_slice)
+                        dk *= sm_scale
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store_wait(0)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.local_store(
+                            sdk_store_buf[kv_buf_id],
+                            # pyrefly: ignore [missing-attribute]
+                            dk.to(tlx.dtype_of(dk_desc)),
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.fence_async_shared()
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store(
+                            dk_desc,
+                            sdk_store_buf[kv_buf_id],
+                            [
+                                (seq_start + start_block_n).to(tl.int32),
+                                (off_h * stride_dkh + slice_id * DKV_STORE_NCOL).to(
+                                    tl.int32
+                                ),
+                            ],
+                        )
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_store_wait(0)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_arrive(k_empties[kv_buf_id])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_arrive(dk_empties[kv_buf_id])
+                # pyrefly: ignore [missing-attribute]
+                tile_idx = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                clc_phase_consumer ^= 1
+        # mma group
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task(num_warps=1, registers=80):
+            blk_idx = 0
+            tile_cnt = 0
+            clc_phase_consumer = 0
+            while tile_idx != -1:
+                (
+                    off_z,
+                    off_h,
+                    seq_start,
+                    seq_len,
+                    n_targets,
+                    start_n,
+                    low1,
+                    high1,
+                    low2,
+                    high2,
+                ) = _hstu_bwd_calculate_offsets(
+                    tile_idx,
+                    n_tile_num,
+                    num_pid_m,
+                    seq_offsets,
+                    num_targets,
+                    max_attn_len,
+                    full_attn_size,
+                    contextual_seq_len,
+                    H,
+                    BLOCK_M1,
+                    BLOCK_N1,
+                    GROUP_SIZE_M,
+                    HAS_NUM_TARGETS,
+                    HAS_MAX_ATTN_LEN,
+                    HAS_FULL_ATTN_SIZE,
+                    HAS_CONTEXTUAL_SEQ_LEN,
+                    STAGE,
+                )
+                if start_n < seq_len:
+                    # Use ceiling division to match tl.range behavior
+                    # tl.range(low, high, step) gives ceil((high - low) / step) iterations
+                    num_steps_masked = tl.cdiv(high1 - low1, BLOCK_M1)
+                    num_steps_unmasked = tl.cdiv(high2 - low2, BLOCK_M1)
+                    num_steps = num_steps_masked + num_steps_unmasked
+
+                    kv_buf_id, kv_phase = _get_bufidx_phase(tile_cnt, NUM_BUFFERS_KV)
+                    tile_cnt += 1
+
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(k_fulls[kv_buf_id], kv_phase)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(v_fulls[kv_buf_id], kv_phase)
+
+                    tl.static_assert(BLOCK_N1 % BLOCK_M1 == 0)
+
+                    # Prolog
+                    q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
+                    do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
+                    tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                        blk_idx, NUM_BUFFERS_TMEM
+                    )
+
+                    # Compute qkT = tl.dot(k, qT)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(q_fulls[q_buf_id], q_phase)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(qk_empties[tmem_buf_id], tmem_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    qT = tlx.local_trans(q_tiles[q_buf_id])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        k_tiles[kv_buf_id],
+                        qT,
+                        qk_tiles[tmem_buf_id],
+                        use_acc=False,
+                        mBarriers=[qk_fulls[tmem_buf_id]],
+                    )
+
+                    # Compute dpT = tl.dot(v, tl.trans(do))
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(do_fulls[do_buf_id], do_phase)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dp_empties[tmem_buf_id], tmem_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    doT = tlx.local_trans(do_tiles[do_buf_id])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        v_tiles[kv_buf_id],
+                        doT,
+                        dp_tiles[tmem_buf_id],
+                        use_acc=False,
+                        mBarriers=[dp_fulls[tmem_buf_id]],
+                    )
+
+                    # Compute dv += tl.dot(ppT, do)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(p_fulls[tmem_buf_id], tmem_phase)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dv_empties[kv_buf_id], kv_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        p_tiles[tmem_buf_id],
+                        do_tiles[do_buf_id],
+                        dv_tiles[kv_buf_id],
+                        use_acc=False,
+                        mBarriers=[do_empties[do_buf_id]],
+                    )
+                    blk_idx += 1
+
+                    # Main loop
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dk_empties[kv_buf_id], kv_phase ^ 1)
+                    for j in range(1, num_steps):
+                        q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
+                        tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                            blk_idx, NUM_BUFFERS_TMEM
+                        )
+                        # Compute qkT = tl.dot(k, qT)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(q_fulls[q_buf_id], q_phase)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(qk_empties[tmem_buf_id], tmem_phase ^ 1)
+                        # pyrefly: ignore [missing-attribute]
+                        qT = tlx.local_trans(q_tiles[q_buf_id])
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            k_tiles[kv_buf_id],
+                            qT,
+                            qk_tiles[tmem_buf_id],
+                            use_acc=False,
+                            mBarriers=[qk_fulls[tmem_buf_id]],
+                        )
+
+                        prev_blk_idx = blk_idx - 1
+                        q_buf_id_prev, _ = _get_bufidx_phase(
+                            prev_blk_idx, NUM_BUFFERS_Q
+                        )
+                        tmem_buf_id_prev, tmem_phase_prev = _get_bufidx_phase(
+                            prev_blk_idx, NUM_BUFFERS_TMEM
+                        )
+                        ds_buf_id_prev, ds_phase_prev = _get_bufidx_phase(
+                            prev_blk_idx, NUM_BUFFERS_DS
+                        )
+
+                        # Compute dq = tl.dot(tl.trans(dsT), k)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(ds_fulls[ds_buf_id_prev], ds_phase_prev)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(
+                            dq_empties[tmem_buf_id_prev], tmem_phase_prev ^ 1
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        dsT_view = tlx.local_trans(ds_tiles[ds_buf_id_prev])
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            dsT_view,
+                            k_tiles[kv_buf_id],
+                            dq_tiles[tmem_buf_id_prev],
+                            use_acc=False,
+                            mBarriers=[
+                                dq_fulls[tmem_buf_id_prev],
+                            ],
+                        )
+
+                        # Compute dk += tl.dot(dsT, tl.trans(qT))
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            ds_tiles[ds_buf_id_prev],
+                            q_tiles[q_buf_id_prev],
+                            dk_tiles[kv_buf_id],
+                            use_acc=(j - 1) > 0,
+                            mBarriers=[
+                                q_empties[q_buf_id_prev],
+                            ],
+                        )
+
+                        do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
+                        # Compute dpT = tl.dot(v, tl.trans(do))
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(do_fulls[do_buf_id], do_phase)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(dp_empties[tmem_buf_id], tmem_phase ^ 1)
+                        # pyrefly: ignore [missing-attribute]
+                        doT = tlx.local_trans(do_tiles[do_buf_id])
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            v_tiles[kv_buf_id],
+                            doT,
+                            dp_tiles[tmem_buf_id],
+                            use_acc=False,
+                            mBarriers=[dp_fulls[tmem_buf_id]],
+                        )
+
+                        # Compute dv += tl.dot(ppT, do)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(p_fulls[tmem_buf_id], tmem_phase)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_dot(
+                            p_tiles[tmem_buf_id],
+                            do_tiles[do_buf_id],
+                            dv_tiles[kv_buf_id],
+                            use_acc=True,
+                            mBarriers=[do_empties[do_buf_id]],
+                        )
+                        blk_idx += 1
+
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.tcgen05_commit(dv_fulls[kv_buf_id])
+
+                    # Epilog
+                    prev_blk_idx = blk_idx - 1
+                    q_buf_id, _ = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_Q)
+                    tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                        prev_blk_idx, NUM_BUFFERS_TMEM
+                    )
+                    ds_buf_id, ds_phase = _get_bufidx_phase(
+                        prev_blk_idx, NUM_BUFFERS_DS
+                    )
+                    # Compute dk += tl.dot(dsT, tl.trans(qT))
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(ds_fulls[ds_buf_id], ds_phase)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        ds_tiles[ds_buf_id],
+                        q_tiles[q_buf_id],
+                        dk_tiles[kv_buf_id],
+                        use_acc=num_steps > 1,
+                        mBarriers=[q_empties[q_buf_id], dk_fulls[tmem_buf_id]],
+                    )
+
+                    # Compute dq = tl.dot(tl.trans(dsT), k)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dq_empties[tmem_buf_id], tmem_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    dsT_view = tlx.local_trans(ds_tiles[ds_buf_id])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        dsT_view,
+                        k_tiles[kv_buf_id],
+                        dq_tiles[tmem_buf_id],
+                        use_acc=False,
+                        mBarriers=[
+                            dq_fulls[tmem_buf_id],
+                        ],
+                    )
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.tcgen05_commit(k_mma_done[kv_buf_id])
+                # pyrefly: ignore [missing-attribute]
+                tile_idx = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                clc_phase_consumer ^= 1
+
+        # load group
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task(num_warps=1, registers=80):
+            blk_idx = 0
+            tile_cnt = 0
+            clc_phase_consumer = 0
+            while tile_idx != -1:
+                (
+                    off_z,
+                    off_h,
+                    seq_start,
+                    seq_len,
+                    n_targets,
+                    start_n,
+                    low1,
+                    high1,
+                    low2,
+                    high2,
+                ) = _hstu_bwd_calculate_offsets(
+                    tile_idx,
+                    n_tile_num,
+                    num_pid_m,
+                    seq_offsets,
+                    num_targets,
+                    max_attn_len,
+                    full_attn_size,
+                    contextual_seq_len,
+                    H,
+                    BLOCK_M1,
+                    BLOCK_N1,
+                    GROUP_SIZE_M,
+                    HAS_NUM_TARGETS,
+                    HAS_MAX_ATTN_LEN,
+                    HAS_FULL_ATTN_SIZE,
+                    HAS_CONTEXTUAL_SEQ_LEN,
+                    STAGE,
+                )
+                if start_n < seq_len:
+                    start_block_n = start_n
+                    # Load K
+                    kv_buf_id, kv_phase = _get_bufidx_phase(tile_cnt, NUM_BUFFERS_KV)
+                    tile_cnt += 1
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(k_empties[kv_buf_id], kv_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_expect_bytes(
+                        k_fulls[kv_buf_id], 2 * BLOCK_N1 * HEAD_DIM
+                    )  # float16
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_load(
+                        desc_k,
+                        k_tiles[kv_buf_id],
+                        [
+                            (seq_start + start_block_n).to(tl.int32),
+                            (off_h * stride_kh).to(tl.int32),
+                        ],
+                        k_fulls[kv_buf_id],
+                    )
+
+                    # Load V
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_expect_bytes(
+                        v_fulls[kv_buf_id], 2 * BLOCK_N1 * HEAD_DIM
+                    )  # float16
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_load(
+                        desc_v,
+                        v_tiles[kv_buf_id],
+                        [
+                            (seq_start + start_block_n).to(tl.int32),
+                            (off_h * stride_vh).to(tl.int32),
+                        ],
+                        v_fulls[kv_buf_id],
+                    )
+
+                    # PART 1: Load Q and dO for masked region [low1, high1)
+                    for curr_m in tl.range(low1, high1, BLOCK_M1):
+                        q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
+                        do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
+                        # Load Q
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(q_empties[q_buf_id], q_phase ^ 1)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_expect_bytes(
+                            q_fulls[q_buf_id], 2 * BLOCK_M1 * HEAD_DIM
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_load(
+                            desc_q,
+                            q_tiles[q_buf_id],
+                            [
+                                (seq_start + curr_m).to(tl.int32),
+                                (off_h * stride_qh).to(tl.int32),
+                            ],
+                            q_fulls[q_buf_id],
+                        )
+                        # Load dO
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(do_empties[do_buf_id], do_phase ^ 1)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_expect_bytes(
+                            do_fulls[do_buf_id], 2 * BLOCK_M1 * HEAD_DIM
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_load(
+                            desc_do,
+                            do_tiles[do_buf_id],
+                            [
+                                (seq_start + curr_m).to(tl.int32),
+                                (off_h * stride_doh).to(tl.int32),
+                            ],
+                            do_fulls[do_buf_id],
+                        )
+                        blk_idx += 1
+
+                    # PART 2: Load Q and dO for unmasked region [low2, high2)
+                    for curr_m in tl.range(low2, high2, BLOCK_M1):
+                        q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
+                        do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
+                        # Load Q
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(q_empties[q_buf_id], q_phase ^ 1)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_expect_bytes(
+                            q_fulls[q_buf_id], 2 * BLOCK_M1 * HEAD_DIM
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_load(
+                            desc_q,
+                            q_tiles[q_buf_id],
+                            [
+                                (seq_start + curr_m).to(tl.int32),
+                                (off_h * stride_qh).to(tl.int32),
+                            ],
+                            q_fulls[q_buf_id],
+                        )
+                        # Load dO
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_wait(do_empties[do_buf_id], do_phase ^ 1)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_expect_bytes(
+                            do_fulls[do_buf_id], 2 * BLOCK_M1 * HEAD_DIM
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_load(
+                            desc_do,
+                            do_tiles[do_buf_id],
+                            [
+                                (seq_start + curr_m).to(tl.int32),
+                                (off_h * stride_doh).to(tl.int32),
+                            ],
+                            do_fulls[do_buf_id],
+                        )
+                        blk_idx += 1
+                # pyrefly: ignore [missing-attribute]
+                tile_idx = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                clc_phase_consumer ^= 1
+
+
+@triton.autotune(
+    configs=get_hstu_bwd_configs(), key=["AUTOTUNE_MAX_SEQ_LEN", "HEAD_DIM"]
+)
+@triton.jit
+def _hstu_attn_bwd_ws_non_persistent(
+    DQ,
+    DK,
+    DV,
+    desc_q,
+    desc_k,
+    desc_v,
+    sm_scale,  # alpha
+    desc_do,  #
+    desc_dq,
+    desc_dk,
+    desc_dv,  #
+    M,
+    D,
+    seq_offsets,
+    attn_scale,
+    num_targets,
+    max_attn_len,
+    full_attn_size,
+    contextual_seq_len,
+    # shared by Q/K/V/DO.
+    stride_qh,
+    stride_kh,
+    stride_vh,
+    stride_doh,
+    stride_dqh,
+    stride_dkn,
+    stride_dkh,
+    stride_dvn,
+    stride_dvh,
+    stride_mh,
+    stride_deltah,
+    H,
+    Z,
+    max_seq_len,  #
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    BLOCK_M2: tl.constexpr,  #
+    BLOCK_N2: tl.constexpr,  #
+    BLK_SLICE_FACTOR: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,
+    NUM_BUFFERS_KV: tl.constexpr,
+    NUM_BUFFERS_Q: tl.constexpr,
+    NUM_BUFFERS_DO: tl.constexpr,
+    NUM_BUFFERS_DS: tl.constexpr,
+    NUM_BUFFERS_TMEM: tl.constexpr,
+    EPILOGUE_SUBTILE: tl.constexpr,
+    DQ_REDUCE_FACTOR: tl.constexpr,
+    DQ_REDUCE_STAGES: tl.constexpr,
+    EARLY_RELEASE_SUBTILES: tl.constexpr,
+    ALPHA_BWD_PRESCALE: tl.constexpr,
+    STAGE: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    SOFTMAX: tl.constexpr,
+    AUTOTUNE_MAX_SEQ_LEN: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_FULL_ATTN_SIZE: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+):
+    """HSTU backward pass kernel with jagged sequences and SiLU/Softmax activation."""
+    # Kernel hangs if NUM_BUFFERS_Q != 2.
+    tl.static_assert(NUM_BUFFERS_Q == 2)
+    # Runtime error if NUM_BUFFERS_DO != 1
+    tl.static_assert(NUM_BUFFERS_DO == 1)
+    # TODO: Add support for contextual seq len
+    tl.static_assert(not HAS_CONTEXTUAL_SEQ_LEN)
+    tl.static_assert(
+        EARLY_RELEASE_SUBTILES >= 1 and EARLY_RELEASE_SUBTILES <= 2,
+        "EARLY_RELEASE_SUBTILES must be 1 or 2",
+    )
+
+    REUSE_DP_FOR_DQ: tl.constexpr = (BLOCK_M1 == 128) and (HEAD_DIM == 128)
+
+    n_tile_num = tl.cdiv(max_seq_len, BLOCK_N1)
+    num_pid_m = Z * H
+    prog_id = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    total_tiles = n_tile_num * Z * H
+
+    tiles_per_sm = total_tiles // num_progs
+    if prog_id < total_tiles % num_progs:
+        tiles_per_sm += 1
+
+    tile_idx = prog_id
+
+    # allocate smem buffers
+    # pyrefly: ignore [missing-attribute]
+    k_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, HEAD_DIM),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_k),
+        NUM_BUFFERS_KV,
+    )
+    # pyrefly: ignore [missing-attribute]
+    v_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, HEAD_DIM),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_v),
+        NUM_BUFFERS_KV,
+    )
+    # pyrefly: ignore [missing-attribute]
+    q_tiles = tlx.local_alloc((BLOCK_M1, HEAD_DIM), tlx.dtype_of(desc_q), NUM_BUFFERS_Q)
+    # pyrefly: ignore [missing-attribute]
+    do_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_M1, HEAD_DIM),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_do),
+        NUM_BUFFERS_DO,
+    )
+
+    # Use SMEM for dsT
+    # pyrefly: ignore [missing-attribute]
+    ds_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, BLOCK_M1),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_q),
+        NUM_BUFFERS_DS,
+    )
+
+    # SMEM staging buffer for double-buffered dQ TMA reduce-add (from D97693127)
+    DQ_REDUCE_NCOL: tl.constexpr = HEAD_DIM // (EPILOGUE_SUBTILE * DQ_REDUCE_FACTOR)
+    DQ_REDUCE_ITERS: tl.constexpr = HEAD_DIM // DQ_REDUCE_NCOL
+    # pyrefly: ignore [missing-attribute]
+    dq_store_buf = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_M1, DQ_REDUCE_NCOL),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_dq),
+        DQ_REDUCE_STAGES,
+    )
+
+    # allocate barriers for smem buffers
+    # pyrefly: ignore [missing-attribute]
+    k_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    k_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    v_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    q_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_Q)
+    # pyrefly: ignore [missing-attribute]
+    q_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_Q)
+    # pyrefly: ignore [missing-attribute]
+    do_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_DO)
+    # pyrefly: ignore [missing-attribute]
+    do_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_DO)
+    # pyrefly: ignore [missing-attribute]
+    ds_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+
+    # allocate tmem buffers
+    # pyrefly: ignore [missing-attribute]
+    qk_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, BLOCK_M1),
+        tl.float32,
+        NUM_BUFFERS_TMEM,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+    )
+    # pyrefly: ignore [missing-attribute]
+    p_tiles = tlx.local_alloc(
+        (BLOCK_N1, BLOCK_M1),
+        # pyrefly: ignore [missing-attribute]
+        tlx.dtype_of(desc_do),
+        NUM_BUFFERS_TMEM,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+        reuse=qk_tiles,
+    )
+    # pyrefly: ignore [missing-attribute]
+    dp_tiles = tlx.local_alloc(
+        (BLOCK_N1, BLOCK_M1),
+        tl.float32,
+        NUM_BUFFERS_TMEM,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+    )
+
+    # pyrefly: ignore [missing-attribute]
+    dv_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, HEAD_DIM),
+        tl.float32,
+        NUM_BUFFERS_KV,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+    )
+    # pyrefly: ignore [missing-attribute]
+    dk_tiles = tlx.local_alloc(
+        # pyrefly: ignore [missing-attribute]
+        (BLOCK_N1, HEAD_DIM),
+        tl.float32,
+        NUM_BUFFERS_KV,
+        # pyrefly: ignore [missing-attribute]
+        tlx.storage_kind.tmem,
+    )
+
+    # allocate barriers for tmem buffers
+    # pyrefly: ignore [missing-attribute]
+    qk_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    qk_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    p_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    dp_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    dq_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+    # pyrefly: ignore [missing-attribute]
+    dq_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+
+    # pyrefly: ignore [missing-attribute]
+    dv_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    dv_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    dk_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+    # pyrefly: ignore [missing-attribute]
+    dk_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
+
+    if REUSE_DP_FOR_DQ:
+        # pyrefly: ignore [missing-attribute]
+        dq_tiles = tlx.local_alloc(
+            (BLOCK_M1, HEAD_DIM),
+            tl.float32,
+            NUM_BUFFERS_TMEM,
+            # pyrefly: ignore [missing-attribute]
+            tlx.storage_kind.tmem,
+            reuse=dp_tiles,
+        )
+        dp_empties = dq_empties
+    else:
+        # pyrefly: ignore [missing-attribute]
+        dq_tiles = tlx.local_alloc(
+            (BLOCK_M1, HEAD_DIM),
+            tl.float32,
+            NUM_BUFFERS_TMEM,
+            # pyrefly: ignore [missing-attribute]
+            tlx.storage_kind.tmem,
+        )
+        # pyrefly: ignore [missing-attribute]
+        dp_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM)
+
+    # pyrefly: ignore [missing-attribute]
+    with tlx.async_tasks():
+        # reduction group: accumulate dq
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task("default"):
+            LN2 = 0.6931471824645996  # = ln(2)
+            blk_idx = 0
+            (
+                off_z,
+                off_h,
+                seq_start,
+                seq_len,
+                n_targets,
+                start_n,
+                low1,
+                high1,
+                low2,
+                high2,
+            ) = _hstu_bwd_calculate_offsets(
+                tile_idx,
+                n_tile_num,
+                num_pid_m,
+                seq_offsets,
+                num_targets,
+                max_attn_len,
+                full_attn_size,
+                contextual_seq_len,
+                H,
+                BLOCK_M1,
+                BLOCK_N1,
+                GROUP_SIZE_M,
+                HAS_NUM_TARGETS,
+                HAS_MAX_ATTN_LEN,
+                HAS_FULL_ATTN_SIZE,
+                HAS_CONTEXTUAL_SEQ_LEN,
+                STAGE,
+            )
+            if start_n < seq_len:
+                # if SOFTMAX:
+                #     # Original softmax reduction: single fused loop
+                #     num_steps_masked = (high1 - low1) // BLOCK_M1
+                #     num_steps_unmasked = (high2 - low2) // BLOCK_M1
+                #     num_steps = num_steps_masked + num_steps_unmasked
+                #     curr_m = low1
+                #     step_m = BLOCK_M1
+                #     for _ in range(num_steps):
+                #         tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                #             blk_idx, NUM_BUFFERS_TMEM
+                #         )
+
+                #         # wait for dq = tl.dot(tl.trans(dsT), k)
+                #         tlx.barrier_wait(dq_fulls[tmem_buf_id], tmem_phase)
+                #         slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
+                #         for slice_id in tl.static_range(EPILOGUE_SUBTILE):
+                #             dq_slice = tlx.local_slice(
+                #                 dq_tiles[tmem_buf_id],
+                #                 [0, slice_id * slice_size],
+                #                 [BLOCK_M1, slice_size],
+                #             )
+                #             dq = tlx.local_load(dq_slice)
+                #             dq = dq * LN2
+                #             desc_dq.atomic_add(
+                #                 [
+                #                     (seq_start + curr_m).to(tl.int32),
+                #                     (off_h * stride_dqh + slice_id * slice_size).to(
+                #                         tl.int32
+                #                     ),
+                #                 ],
+                #                 dq,
+                #             )
+
+                #         # release dq
+                #         tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                #         # Increment pointers.
+                #         curr_m += step_m
+                #         blk_idx += 1
+                # else:
+                # SiLU reduction: two loops for PART 1 and PART 2
+                # INLINED to avoid TLX region isolation issues with helper functions
+                # dQ early TMEM release optimization (from D98825322)
+                # PART 1: Masked region [low1, high1)
+                for curr_m in tl.range(low1, high1, BLOCK_M1):
+                    tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                        blk_idx, NUM_BUFFERS_TMEM
+                    )
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dq_fulls[tmem_buf_id], tmem_phase)
+                    for slice_id in tl.static_range(
+                        DQ_REDUCE_ITERS - EARLY_RELEASE_SUBTILES
+                    ):
+                        dq_smem_idx = slice_id % DQ_REDUCE_STAGES
+                        # pyrefly: ignore [missing-attribute]
+                        dq_slice = tlx.local_slice(
+                            dq_tiles[tmem_buf_id],
+                            [0, slice_id * DQ_REDUCE_NCOL],
+                            [BLOCK_M1, DQ_REDUCE_NCOL],
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        dq = tlx.local_load(dq_slice)
+                        dq = dq * sm_scale
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.local_store(
+                            dq_store_buf[dq_smem_idx],
+                            # pyrefly: ignore [missing-attribute]
+                            dq.to(tlx.dtype_of(desc_dq)),
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.fence_async_shared()
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store(
+                            desc_dq,
+                            dq_store_buf[dq_smem_idx],
+                            [
+                                (seq_start + curr_m).to(tl.int32),
+                                (slice_id * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                    tl.int32
+                                ),
+                            ],
+                            store_reduce="add",
+                        )
+                    if EARLY_RELEASE_SUBTILES == 1:
+                        er0: tl.constexpr = DQ_REDUCE_ITERS - 1
+                        # pyrefly: ignore [missing-attribute]
+                        dq_er0 = tlx.local_load(
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_slice(
+                                dq_tiles[tmem_buf_id],
+                                [0, er0 * DQ_REDUCE_NCOL],
+                                [BLOCK_M1, DQ_REDUCE_NCOL],
+                            )
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                        dq_er0 = dq_er0 * sm_scale
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.local_store(
+                            dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                            # pyrefly: ignore [missing-attribute]
+                            dq_er0.to(tlx.dtype_of(desc_dq)),
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.fence_async_shared()
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store(
+                            desc_dq,
+                            dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                            [
+                                (seq_start + curr_m).to(tl.int32),
+                                (er0 * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                    tl.int32
+                                ),
+                            ],
+                            store_reduce="add",
+                        )
+                    elif EARLY_RELEASE_SUBTILES == 2:
+                        er0: tl.constexpr = DQ_REDUCE_ITERS - 2
+                        er1: tl.constexpr = DQ_REDUCE_ITERS - 1
+                        # pyrefly: ignore [missing-attribute]
+                        dq_er0 = tlx.local_load(
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_slice(
+                                dq_tiles[tmem_buf_id],
+                                [0, er0 * DQ_REDUCE_NCOL],
+                                [BLOCK_M1, DQ_REDUCE_NCOL],
+                            )
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        dq_er1 = tlx.local_load(
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_slice(
+                                dq_tiles[tmem_buf_id],
+                                [0, er1 * DQ_REDUCE_NCOL],
+                                [BLOCK_M1, DQ_REDUCE_NCOL],
+                            )
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                        dq_er0 = dq_er0 * sm_scale
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.local_store(
+                            dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                            # pyrefly: ignore [missing-attribute]
+                            dq_er0.to(tlx.dtype_of(desc_dq)),
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.fence_async_shared()
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store(
+                            desc_dq,
+                            dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                            [
+                                (seq_start + curr_m).to(tl.int32),
+                                (er0 * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                    tl.int32
+                                ),
+                            ],
+                            store_reduce="add",
+                        )
+                        dq_er1 = dq_er1 * sm_scale
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.local_store(
+                            dq_store_buf[er1 % DQ_REDUCE_STAGES],
+                            # pyrefly: ignore [missing-attribute]
+                            dq_er1.to(tlx.dtype_of(desc_dq)),
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.fence_async_shared()
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store(
+                            desc_dq,
+                            dq_store_buf[er1 % DQ_REDUCE_STAGES],
+                            [
+                                (seq_start + curr_m).to(tl.int32),
+                                (er1 * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                    tl.int32
+                                ),
+                            ],
+                            store_reduce="add",
+                        )
+                    blk_idx += 1
+
+                # PART 2: Unmasked region [low2, high2)
+                for curr_m in tl.range(low2, high2, BLOCK_M1):
+                    tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                        blk_idx, NUM_BUFFERS_TMEM
+                    )
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dq_fulls[tmem_buf_id], tmem_phase)
+                    for slice_id in tl.static_range(
+                        DQ_REDUCE_ITERS - EARLY_RELEASE_SUBTILES
+                    ):
+                        dq_smem_idx = slice_id % DQ_REDUCE_STAGES
+                        # pyrefly: ignore [missing-attribute]
+                        dq_slice = tlx.local_slice(
+                            dq_tiles[tmem_buf_id],
+                            [0, slice_id * DQ_REDUCE_NCOL],
+                            [BLOCK_M1, DQ_REDUCE_NCOL],
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        dq = tlx.local_load(dq_slice)
+                        dq = dq * sm_scale
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.local_store(
+                            dq_store_buf[dq_smem_idx],
+                            # pyrefly: ignore [missing-attribute]
+                            dq.to(tlx.dtype_of(desc_dq)),
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.fence_async_shared()
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store(
+                            desc_dq,
+                            dq_store_buf[dq_smem_idx],
+                            [
+                                (seq_start + curr_m).to(tl.int32),
+                                (slice_id * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                    tl.int32
+                                ),
+                            ],
+                            store_reduce="add",
+                        )
+                    if EARLY_RELEASE_SUBTILES == 1:
+                        er0: tl.constexpr = DQ_REDUCE_ITERS - 1
+                        # pyrefly: ignore [missing-attribute]
+                        dq_er0 = tlx.local_load(
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_slice(
+                                dq_tiles[tmem_buf_id],
+                                [0, er0 * DQ_REDUCE_NCOL],
+                                [BLOCK_M1, DQ_REDUCE_NCOL],
+                            )
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                        dq_er0 = dq_er0 * sm_scale
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.local_store(
+                            dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                            # pyrefly: ignore [missing-attribute]
+                            dq_er0.to(tlx.dtype_of(desc_dq)),
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.fence_async_shared()
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store(
+                            desc_dq,
+                            dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                            [
+                                (seq_start + curr_m).to(tl.int32),
+                                (er0 * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                    tl.int32
+                                ),
+                            ],
+                            store_reduce="add",
+                        )
+                    elif EARLY_RELEASE_SUBTILES == 2:
+                        er0: tl.constexpr = DQ_REDUCE_ITERS - 2
+                        er1: tl.constexpr = DQ_REDUCE_ITERS - 1
+                        # pyrefly: ignore [missing-attribute]
+                        dq_er0 = tlx.local_load(
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_slice(
+                                dq_tiles[tmem_buf_id],
+                                [0, er0 * DQ_REDUCE_NCOL],
+                                [BLOCK_M1, DQ_REDUCE_NCOL],
+                            )
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        dq_er1 = tlx.local_load(
+                            # pyrefly: ignore [missing-attribute]
+                            tlx.local_slice(
+                                dq_tiles[tmem_buf_id],
+                                [0, er1 * DQ_REDUCE_NCOL],
+                                [BLOCK_M1, DQ_REDUCE_NCOL],
+                            )
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                        dq_er0 = dq_er0 * sm_scale
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.local_store(
+                            dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                            # pyrefly: ignore [missing-attribute]
+                            dq_er0.to(tlx.dtype_of(desc_dq)),
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.fence_async_shared()
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store(
+                            desc_dq,
+                            dq_store_buf[er0 % DQ_REDUCE_STAGES],
+                            [
+                                (seq_start + curr_m).to(tl.int32),
+                                (er0 * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                    tl.int32
+                                ),
+                            ],
+                            store_reduce="add",
+                        )
+                        dq_er1 = dq_er1 * sm_scale
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.local_store(
+                            dq_store_buf[er1 % DQ_REDUCE_STAGES],
+                            # pyrefly: ignore [missing-attribute]
+                            dq_er1.to(tlx.dtype_of(desc_dq)),
+                        )
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.fence_async_shared()
+                        # pyrefly: ignore [missing-attribute]
+                        tlx.async_descriptor_store(
+                            desc_dq,
+                            dq_store_buf[er1 % DQ_REDUCE_STAGES],
+                            [
+                                (seq_start + curr_m).to(tl.int32),
+                                (er1 * DQ_REDUCE_NCOL + off_h * stride_dqh).to(
+                                    tl.int32
+                                ),
+                            ],
+                            store_reduce="add",
+                        )
+                    blk_idx += 1
+
+        # compute group: compute softmax/silu backward
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task(num_warps=8, registers=192, replicate=1):
+            blk_idx = 0
+            tile_cnt = 0
+            (
+                off_z,
+                off_h,
+                seq_start,
+                seq_len,
+                n_targets,
+                start_n,
+                low1,
+                high1,
+                low2,
+                high2,
+            ) = _hstu_bwd_calculate_offsets(
+                tile_idx,
+                n_tile_num,
+                num_pid_m,
+                seq_offsets,
+                num_targets,
+                max_attn_len,
+                full_attn_size,
+                contextual_seq_len,
+                H,
+                BLOCK_M1,
+                BLOCK_N1,
+                GROUP_SIZE_M,
+                HAS_NUM_TARGETS,
+                HAS_MAX_ATTN_LEN,
+                HAS_FULL_ATTN_SIZE,
+                HAS_CONTEXTUAL_SEQ_LEN,
+                STAGE,
+            )
+            if start_n < seq_len:
+                start_block_n = start_n
+
+                curr_m = low1
+                # pyrefly: ignore [missing-attribute]
+                do_out_dtype = tlx.dtype_of(desc_do)
+                # pyrefly: ignore [missing-attribute]
+                q_out_dtype = tlx.dtype_of(desc_q)
+
+                # SiLU activation backward
+                scale = tl.load(attn_scale).to(tl.float32)
+                # PART 1: Masked region [low1, high1)
+                blk_idx = _hstu_bwd_compute_inner_loop_silu(
+                    start_n,
+                    qk_fulls,
+                    qk_tiles,
+                    qk_empties,
+                    p_tiles,
+                    p_fulls,
+                    dp_empties,
+                    dp_fulls,
+                    dp_tiles,
+                    ds_tiles,
+                    ds_fulls,
+                    seq_start,
+                    seq_len,
+                    off_h,
+                    sm_scale,  # alpha
+                    scale,
+                    low1,
+                    high1,
+                    blk_idx,
+                    do_out_dtype,
+                    q_out_dtype,
+                    contextual_seq_len,
+                    max_attn_len,
+                    n_targets,
+                    NUM_BUFFERS_TMEM,
+                    NUM_BUFFERS_DS,
+                    BLOCK_M1,
+                    BLOCK_N1,
+                    REUSE_DP_FOR_DQ=REUSE_DP_FOR_DQ,
+                    HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+                    HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+                    HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+                    APPLY_MASK=True,
+                    ALPHA_BWD_PRESCALE=ALPHA_BWD_PRESCALE,
+                )
+                # PART 2: Unmasked region [low2, high2)
+                blk_idx = _hstu_bwd_compute_inner_loop_silu(
+                    start_n,
+                    qk_fulls,
+                    qk_tiles,
+                    qk_empties,
+                    p_tiles,
+                    p_fulls,
+                    dp_empties,
+                    dp_fulls,
+                    dp_tiles,
+                    ds_tiles,
+                    ds_fulls,
+                    seq_start,
+                    seq_len,
+                    off_h,
+                    sm_scale,  # alpha
+                    scale,
+                    low2,
+                    high2,
+                    blk_idx,
+                    do_out_dtype,
+                    q_out_dtype,
+                    contextual_seq_len,
+                    max_attn_len,
+                    n_targets,
+                    NUM_BUFFERS_TMEM,
+                    NUM_BUFFERS_DS,
+                    BLOCK_M1,
+                    BLOCK_N1,
+                    REUSE_DP_FOR_DQ=REUSE_DP_FOR_DQ,
+                    HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+                    HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+                    HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+                    APPLY_MASK=False,
+                    ALPHA_BWD_PRESCALE=ALPHA_BWD_PRESCALE,
+                )
+
+                # epilogue
+                kv_buf_id, kv_phase = _get_bufidx_phase(tile_cnt, NUM_BUFFERS_KV)
+                tile_cnt += 1
+
+                # Create on-device TMA descriptors for jagged sequence writes
+                end_kv = seq_start + seq_len
+                dv_desc = tl.make_tensor_descriptor(
+                    DV,
+                    shape=[end_kv.to(tl.int32), stride_dvh * H],
+                    # pyrefly: ignore [bad-argument-type]
+                    strides=[stride_dvn, 1],
+                    block_shape=[BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE],
+                )
+                dk_desc = tl.make_tensor_descriptor(
+                    DK,
+                    shape=[end_kv.to(tl.int32), stride_dkh * H],
+                    # pyrefly: ignore [bad-argument-type]
+                    strides=[stride_dkn, 1],
+                    block_shape=[BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE],
+                )
+
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(dv_fulls[kv_buf_id], kv_phase)
+                # pyrefly: ignore [missing-attribute]
+                tlx.fence_async_shared()
+                slice_size: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
+                for slice_id in tl.static_range(EPILOGUE_SUBTILE):
+                    # pyrefly: ignore [missing-attribute]
+                    dv_slice = tlx.local_slice(
+                        dv_tiles[kv_buf_id],
+                        [0, slice_id * slice_size],
+                        [BLOCK_N1, slice_size],
+                    )
+                    # pyrefly: ignore [missing-attribute]
+                    dv = tlx.local_load(dv_slice)
+                    dv_desc.store(
+                        [
+                            (seq_start + start_block_n).to(tl.int32),
+                            (off_h * stride_dvh + slice_id * slice_size).to(tl.int32),
+                        ],
+                        # pyrefly: ignore [missing-attribute]
+                        dv.to(tlx.dtype_of(desc_dv)),
+                    )
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_arrive(dv_empties[kv_buf_id])
+
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(dk_fulls[kv_buf_id], kv_phase)
+                for slice_id in tl.static_range(EPILOGUE_SUBTILE):
+                    # pyrefly: ignore [missing-attribute]
+                    dk_slice = tlx.local_slice(
+                        dk_tiles[kv_buf_id],
+                        [0, slice_id * slice_size],
+                        [BLOCK_N1, slice_size],
+                    )
+                    # pyrefly: ignore [missing-attribute]
+                    dk = tlx.local_load(dk_slice)
+                    dk *= sm_scale
+                    dk_desc.store(
+                        [
+                            (seq_start + start_block_n).to(tl.int32),
+                            (off_h * stride_dkh + slice_id * slice_size).to(tl.int32),
+                        ],
+                        # pyrefly: ignore [missing-attribute]
+                        dk.to(tlx.dtype_of(desc_dk)),
+                    )
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_arrive(dk_empties[kv_buf_id])
+        # mma group
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task(num_warps=1, registers=80):
+            blk_idx = 0
+            tile_cnt = 0
+            (
+                off_z,
+                off_h,
+                seq_start,
+                seq_len,
+                n_targets,
+                start_n,
+                low1,
+                high1,
+                low2,
+                high2,
+            ) = _hstu_bwd_calculate_offsets(
+                tile_idx,
+                n_tile_num,
+                num_pid_m,
+                seq_offsets,
+                num_targets,
+                max_attn_len,
+                full_attn_size,
+                contextual_seq_len,
+                H,
+                BLOCK_M1,
+                BLOCK_N1,
+                GROUP_SIZE_M,
+                HAS_NUM_TARGETS,
+                HAS_MAX_ATTN_LEN,
+                HAS_FULL_ATTN_SIZE,
+                HAS_CONTEXTUAL_SEQ_LEN,
+                STAGE,
+            )
+
+            if start_n < seq_len:
+                # Use ceiling division to match tl.range behavior
+                # tl.range(low, high, step) gives ceil((high - low) / step) iterations
+                num_steps_masked = tl.cdiv(high1 - low1, BLOCK_M1)
+                num_steps_unmasked = tl.cdiv(high2 - low2, BLOCK_M1)
+                num_steps = num_steps_masked + num_steps_unmasked
+
+                kv_buf_id, kv_phase = _get_bufidx_phase(tile_cnt, NUM_BUFFERS_KV)
+                tile_cnt += 1
+
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(k_fulls[kv_buf_id], kv_phase)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(v_fulls[kv_buf_id], kv_phase)
+
+                tl.static_assert(BLOCK_N1 % BLOCK_M1 == 0)
+
+                # Prolog
+                q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
+                do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
+                tmem_buf_id, tmem_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_TMEM)
+
+                # Compute qkT = tl.dot(k, qT)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(q_fulls[q_buf_id], q_phase)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(qk_empties[tmem_buf_id], tmem_phase ^ 1)
+                # pyrefly: ignore [missing-attribute]
+                qT = tlx.local_trans(q_tiles[q_buf_id])
+                # pyrefly: ignore [missing-attribute]
+                tlx.async_dot(
+                    k_tiles[kv_buf_id],
+                    qT,
+                    qk_tiles[tmem_buf_id],
+                    use_acc=False,
+                    mBarriers=[qk_fulls[tmem_buf_id]],
+                )
+
+                # Compute dpT = tl.dot(v, tl.trans(do))
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(do_fulls[do_buf_id], do_phase)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(dp_empties[tmem_buf_id], tmem_phase ^ 1)
+                # pyrefly: ignore [missing-attribute]
+                doT = tlx.local_trans(do_tiles[do_buf_id])
+                # pyrefly: ignore [missing-attribute]
+                tlx.async_dot(
+                    v_tiles[kv_buf_id],
+                    doT,
+                    dp_tiles[tmem_buf_id],
+                    use_acc=False,
+                    mBarriers=[dp_fulls[tmem_buf_id]],
+                )
+
+                # Compute dv += tl.dot(ppT, do)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(p_fulls[tmem_buf_id], tmem_phase)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(dv_empties[kv_buf_id], kv_phase ^ 1)
+                # pyrefly: ignore [missing-attribute]
+                tlx.async_dot(
+                    p_tiles[tmem_buf_id],
+                    do_tiles[do_buf_id],
+                    dv_tiles[kv_buf_id],
+                    use_acc=False,
+                    mBarriers=[do_empties[do_buf_id]],
+                )
+                blk_idx += 1
+
+                # Main loop
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(dk_empties[kv_buf_id], kv_phase ^ 1)
+                for j in range(1, num_steps):
+                    q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
+                    tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                        blk_idx, NUM_BUFFERS_TMEM
+                    )
+                    # Compute qkT = tl.dot(k, qT)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(q_fulls[q_buf_id], q_phase)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(qk_empties[tmem_buf_id], tmem_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    qT = tlx.local_trans(q_tiles[q_buf_id])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        k_tiles[kv_buf_id],
+                        qT,
+                        qk_tiles[tmem_buf_id],
+                        use_acc=False,
+                        mBarriers=[qk_fulls[tmem_buf_id]],
+                    )
+
+                    prev_blk_idx = blk_idx - 1
+                    q_buf_id_prev, _ = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_Q)
+                    tmem_buf_id_prev, tmem_phase_prev = _get_bufidx_phase(
+                        prev_blk_idx, NUM_BUFFERS_TMEM
+                    )
+                    ds_buf_id_prev, ds_phase_prev = _get_bufidx_phase(
+                        prev_blk_idx, NUM_BUFFERS_DS
+                    )
+
+                    # Compute dq = tl.dot(tl.trans(dsT), k)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(ds_fulls[ds_buf_id_prev], ds_phase_prev)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dq_empties[tmem_buf_id_prev], tmem_phase_prev ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    dsT_view = tlx.local_trans(ds_tiles[ds_buf_id_prev])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        dsT_view,
+                        k_tiles[kv_buf_id],
+                        dq_tiles[tmem_buf_id_prev],
+                        use_acc=False,
+                        mBarriers=[
+                            dq_fulls[tmem_buf_id_prev],
+                        ],
+                    )
+
+                    # Compute dk += tl.dot(dsT, tl.trans(qT))
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        ds_tiles[ds_buf_id_prev],
+                        q_tiles[q_buf_id_prev],
+                        dk_tiles[kv_buf_id],
+                        use_acc=(j - 1) > 0,
+                        mBarriers=[
+                            q_empties[q_buf_id_prev],
+                        ],
+                    )
+
+                    do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
+                    # Compute dpT = tl.dot(v, tl.trans(do))
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(do_fulls[do_buf_id], do_phase)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(dp_empties[tmem_buf_id], tmem_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    doT = tlx.local_trans(do_tiles[do_buf_id])
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        v_tiles[kv_buf_id],
+                        doT,
+                        dp_tiles[tmem_buf_id],
+                        use_acc=False,
+                        mBarriers=[dp_fulls[tmem_buf_id]],
+                    )
+
+                    # Compute dv += tl.dot(ppT, do)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(p_fulls[tmem_buf_id], tmem_phase)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_dot(
+                        p_tiles[tmem_buf_id],
+                        do_tiles[do_buf_id],
+                        dv_tiles[kv_buf_id],
+                        use_acc=True,
+                        mBarriers=[do_empties[do_buf_id]],
+                    )
+                    blk_idx += 1
+
+                # pyrefly: ignore [missing-attribute]
+                tlx.tcgen05_commit(dv_fulls[kv_buf_id])
+
+                # Epilog
+                prev_blk_idx = blk_idx - 1
+                q_buf_id, _ = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_Q)
+                tmem_buf_id, tmem_phase = _get_bufidx_phase(
+                    prev_blk_idx, NUM_BUFFERS_TMEM
+                )
+                ds_buf_id, ds_phase = _get_bufidx_phase(prev_blk_idx, NUM_BUFFERS_DS)
+                # Compute dk += tl.dot(dsT, tl.trans(qT))
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(ds_fulls[ds_buf_id], ds_phase)
+                # pyrefly: ignore [missing-attribute]
+                tlx.async_dot(
+                    ds_tiles[ds_buf_id],
+                    q_tiles[q_buf_id],
+                    dk_tiles[kv_buf_id],
+                    use_acc=num_steps > 1,
+                    mBarriers=[q_empties[q_buf_id], dk_fulls[tmem_buf_id]],
+                )
+
+                # Compute dq = tl.dot(tl.trans(dsT), k)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(dq_empties[tmem_buf_id], tmem_phase ^ 1)
+                # pyrefly: ignore [missing-attribute]
+                dsT_view = tlx.local_trans(ds_tiles[ds_buf_id])
+                # pyrefly: ignore [missing-attribute]
+                tlx.async_dot(
+                    dsT_view,
+                    k_tiles[kv_buf_id],
+                    dq_tiles[tmem_buf_id],
+                    use_acc=False,
+                    mBarriers=[
+                        dq_fulls[tmem_buf_id],
+                    ],
+                )
+                # pyrefly: ignore [missing-attribute]
+                tlx.tcgen05_commit(k_empties[kv_buf_id])
+
+        # load group
+        # pyrefly: ignore [missing-attribute]
+        with tlx.async_task(num_warps=1, registers=80):
+            blk_idx = 0
+            tile_cnt = 0
+            (
+                off_z,
+                off_h,
+                seq_start,
+                seq_len,
+                n_targets,
+                start_n,
+                low1,
+                high1,
+                low2,
+                high2,
+            ) = _hstu_bwd_calculate_offsets(
+                tile_idx,
+                n_tile_num,
+                num_pid_m,
+                seq_offsets,
+                num_targets,
+                max_attn_len,
+                full_attn_size,
+                contextual_seq_len,
+                H,
+                BLOCK_M1,
+                BLOCK_N1,
+                GROUP_SIZE_M,
+                HAS_NUM_TARGETS,
+                HAS_MAX_ATTN_LEN,
+                HAS_FULL_ATTN_SIZE,
+                HAS_CONTEXTUAL_SEQ_LEN,
+                STAGE,
+            )
+            if start_n < seq_len:
+                start_block_n = start_n
+                # Load K
+                kv_buf_id, kv_phase = _get_bufidx_phase(tile_cnt, NUM_BUFFERS_KV)
+                tile_cnt += 1
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_wait(k_empties[kv_buf_id], kv_phase ^ 1)
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_expect_bytes(
+                    k_fulls[kv_buf_id], 2 * BLOCK_N1 * HEAD_DIM
+                )  # float16
+                # pyrefly: ignore [missing-attribute]
+                tlx.async_descriptor_load(
+                    desc_k,
+                    k_tiles[kv_buf_id],
+                    [
+                        (seq_start + start_block_n).to(tl.int32),
+                        (off_h * stride_kh).to(tl.int32),
+                    ],
+                    k_fulls[kv_buf_id],
+                )
+
+                # Load V
+                # pyrefly: ignore [missing-attribute]
+                tlx.barrier_expect_bytes(
+                    v_fulls[kv_buf_id], 2 * BLOCK_N1 * HEAD_DIM
+                )  # float16
+                # pyrefly: ignore [missing-attribute]
+                tlx.async_descriptor_load(
+                    desc_v,
+                    v_tiles[kv_buf_id],
+                    [
+                        (seq_start + start_block_n).to(tl.int32),
+                        (off_h * stride_vh).to(tl.int32),
+                    ],
+                    v_fulls[kv_buf_id],
+                )
+
+                # PART 1: Load Q and dO for masked region [low1, high1)
+                for curr_m in tl.range(low1, high1, BLOCK_M1):
+                    q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
+                    do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
+                    # Load Q
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(q_empties[q_buf_id], q_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_expect_bytes(q_fulls[q_buf_id], 2 * BLOCK_M1 * HEAD_DIM)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_load(
+                        desc_q,
+                        q_tiles[q_buf_id],
+                        [
+                            (seq_start + curr_m).to(tl.int32),
+                            (off_h * stride_qh).to(tl.int32),
+                        ],
+                        q_fulls[q_buf_id],
+                    )
+                    # Load dO
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(do_empties[do_buf_id], do_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_expect_bytes(
+                        do_fulls[do_buf_id], 2 * BLOCK_M1 * HEAD_DIM
+                    )
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_load(
+                        desc_do,
+                        do_tiles[do_buf_id],
+                        [
+                            (seq_start + curr_m).to(tl.int32),
+                            (off_h * stride_doh).to(tl.int32),
+                        ],
+                        do_fulls[do_buf_id],
+                    )
+                    blk_idx += 1
+
+                # PART 2: Load Q and dO for unmasked region [low2, high2)
+                for curr_m in tl.range(low2, high2, BLOCK_M1):
+                    q_buf_id, q_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_Q)
+                    do_buf_id, do_phase = _get_bufidx_phase(blk_idx, NUM_BUFFERS_DO)
+                    # Load Q
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(q_empties[q_buf_id], q_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_expect_bytes(q_fulls[q_buf_id], 2 * BLOCK_M1 * HEAD_DIM)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_load(
+                        desc_q,
+                        q_tiles[q_buf_id],
+                        [
+                            (seq_start + curr_m).to(tl.int32),
+                            (off_h * stride_qh).to(tl.int32),
+                        ],
+                        q_fulls[q_buf_id],
+                    )
+                    # Load dO
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_wait(do_empties[do_buf_id], do_phase ^ 1)
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.barrier_expect_bytes(
+                        do_fulls[do_buf_id], 2 * BLOCK_M1 * HEAD_DIM
+                    )
+                    # pyrefly: ignore [missing-attribute]
+                    tlx.async_descriptor_load(
+                        desc_do,
+                        do_tiles[do_buf_id],
+                        [
+                            (seq_start + curr_m).to(tl.int32),
+                            (off_h * stride_doh).to(tl.int32),
+                        ],
+                        do_fulls[do_buf_id],
+                    )
+                    blk_idx += 1
+
+
+def backward_custom_vars(
+    dout: torch.Tensor,
+    num_softmax_heads: int,
+    idx: int,
+    saved_tensors: List[torch.Tensor],
+) -> Tuple[torch.Tensor, torch.Tensor, int]:
+    """Load M from saved tensors and compute Delta for backward pass."""
+    M = saved_tensors[idx]
+    idx += 1
+    out = saved_tensors[idx]
+
+    # Compute Delta = sum(out * dout, dim=-1)
+    Delta = torch.empty_like(M)
+    total_seq_len, H, HEAD_DIM = out.shape
+    BLOCK_M = 128
+    grid = (triton.cdiv(total_seq_len, BLOCK_M), H)
+    # For jagged, we compute delta per head
+    Delta = (out * dout).sum(dim=-1).to(torch.float32)
+
+    stride_mm = M.stride(0)
+    return M, Delta, stride_mm
+
+
+def tlx_hstu_attention_bwd(
+    dout: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    dv: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    attn_scale: torch.Tensor,
+    max_seq_len: int,
+    alpha: float,
+    M: torch.Tensor,
+    Delta: torch.Tensor,
+    stride_mm: int,
+    num_softmax_heads: int,
+    num_targets: Optional[torch.Tensor],
+    causal: bool,
+    max_attn_len: int = 0,
+    full_attn_size: int = 0,
+    contextual_seq_len: int = 0,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Backward pass for HSTU attention with jagged sequences."""
+    q = switch_to_contiguous_if_needed(q)
+    k = switch_to_contiguous_if_needed(k)
+    v = switch_to_contiguous_if_needed(v)
+    dout = switch_to_contiguous_if_needed(dout)
+
+    Z = seq_offsets.numel() - 1
+    total_seq_len_q, H, HEAD_DIM = q.shape
+    _, _, DimV = v.shape
+
+    if total_seq_len_q == 0:
+        return dq, dk, dv
+
+    HAS_NUM_TARGETS = num_targets is not None
+    if not HAS_NUM_TARGETS:
+        num_targets = torch.empty(0, device=q.device, dtype=torch.int32)
+    HAS_MAX_ATTN_LEN = max_attn_len != 0
+    HAS_CONTEXTUAL_SEQ_LEN = contextual_seq_len != 0
+
+    if dq.dtype != torch.float32:
+        # accumulate dq in fp32
+        dq = torch.empty_like(q, dtype=torch.float32)
+
+    # TMA descriptors
+    dummy_block = [1, 1]
+    desc_q = TensorDescriptor(
+        q,
+        shape=[total_seq_len_q, H * HEAD_DIM],
+        strides=[q.stride(0), 1],
+        block_shape=dummy_block,
+    )
+    desc_k = TensorDescriptor(
+        k,
+        shape=[total_seq_len_q, H * HEAD_DIM],
+        strides=[k.stride(0), 1],
+        block_shape=dummy_block,
+    )
+    desc_v = TensorDescriptor(
+        v,
+        shape=[total_seq_len_q, H * DimV],
+        strides=[v.stride(0), 1],
+        block_shape=dummy_block,
+    )
+    desc_do = TensorDescriptor(
+        dout,
+        shape=[total_seq_len_q, H * DimV],
+        strides=[dout.stride(0), 1],
+        block_shape=dummy_block,
+    )
+    desc_dq = TensorDescriptor(
+        dq,
+        shape=[total_seq_len_q, H * HEAD_DIM],
+        strides=[dq.stride(0), 1],
+        block_shape=dummy_block,
+    )
+    desc_dk = TensorDescriptor(
+        dk,
+        shape=[total_seq_len_q, H * HEAD_DIM],
+        strides=[dk.stride(0), 1],
+        block_shape=dummy_block,
+    )
+    desc_dv = TensorDescriptor(
+        dv,
+        shape=[total_seq_len_q, H * DimV],
+        strides=[dv.stride(0), 1],
+        block_shape=dummy_block,
+    )
+
+    def alloc_fn(size: int, alignment: int, _):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    # pyrefly: ignore [bad-argument-type]
+    triton.set_allocator(alloc_fn)
+
+    # Apply scaling to k for backward (only for softmax, not SiLU)
+    # For softmax: K is pre-scaled by alpha * RCP_LN2 to enable flash2 trick
+    # For SiLU: K is not pre-scaled, alpha scaling is done at the end
+    SOFTMAX = num_softmax_heads != 0
+    if SOFTMAX:
+        RCP_LN2 = 1.4426950408889634  # = 1.0 / ln(2)
+        k_scaled = k * (alpha * RCP_LN2)
+        desc_k = TensorDescriptor(
+            k_scaled,
+            shape=[total_seq_len_q, H * HEAD_DIM],
+            strides=[k.stride(0), 1],
+            block_shape=dummy_block,
+        )
+    else:
+        # SiLU case: no pre-scaling of K
+        desc_k = TensorDescriptor(
+            k,
+            shape=[total_seq_len_q, H * HEAD_DIM],
+            strides=[k.stride(0), 1],
+            block_shape=dummy_block,
+        )
+
+    BLOCK_M1 = 128
+    stage = 3 if causal else 1
+
+    num_sms = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).multi_processor_count
+
+    use_persistent = True
+    if use_persistent:
+        grid = lambda meta: (  # noqa E731
+            H * Z * triton.cdiv(max_seq_len, meta["BLOCK_N1"]),
+        )
+        bwd_kernel = _hstu_attn_bwd_ws
+    else:
+        grid = lambda meta: (  # noqa E731
+            H * Z * triton.cdiv(max_seq_len, meta["BLOCK_N1"]),
+        )
+        bwd_kernel = _hstu_attn_bwd_ws_non_persistent
+
+    bwd_kernel[grid](
+        dq,
+        dk,
+        dv,
+        desc_q=desc_q,
+        desc_k=desc_k,
+        desc_v=desc_v,
+        sm_scale=alpha,
+        desc_do=desc_do,
+        desc_dq=desc_dq,
+        desc_dk=desc_dk,
+        desc_dv=desc_dv,
+        M=M,
+        D=Delta,
+        seq_offsets=seq_offsets,
+        attn_scale=attn_scale,
+        num_targets=num_targets,
+        max_attn_len=max_attn_len,
+        full_attn_size=full_attn_size,
+        contextual_seq_len=contextual_seq_len,
+        stride_qh=q.stride(1),
+        stride_kh=k.stride(1),
+        stride_vh=v.stride(1),
+        stride_doh=dout.stride(1),
+        stride_dqh=dq.stride(1),
+        stride_dkn=dk.stride(0),
+        stride_dkh=dk.stride(1),
+        stride_dvn=dv.stride(0),
+        stride_dvh=dv.stride(1),
+        stride_mh=stride_mm,
+        stride_deltah=Delta.stride(0) if Delta.ndim > 1 else 1,
+        H=H,
+        Z=Z,
+        max_seq_len=max_seq_len,
+        BLK_SLICE_FACTOR=2,
+        HEAD_DIM=HEAD_DIM,
+        STAGE=stage,
+        GROUP_SIZE_M=1,
+        SOFTMAX=num_softmax_heads != 0,
+        AUTOTUNE_MAX_SEQ_LEN=autotune_max_seq_len(max_seq_len),
+        HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+        HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+        HAS_FULL_ATTN_SIZE=full_attn_size != 0,
+        HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+    )
+
+    return dq, dk, dv
+
+
+def forward_custom_vars(
+    q: torch.Tensor, num_softmax_heads: int, saved_tensors: List[torch.Tensor]
+) -> Tuple[torch.Tensor, int]:
+    assert num_softmax_heads <= q.shape[1]
+    M = torch.empty(
+        (q.shape[0], num_softmax_heads), device=q.device, dtype=torch.float32
+    )
+    saved_tensors.append(M)
+    stride_mm = M.stride(0)
+    return M, stride_mm
+
+
+def tlx_hstu_attention_fwd(
+    max_seq_len: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    attn_scale: torch.Tensor,
+    sort_by_length_indices: Optional[torch.Tensor],
+    M: torch.Tensor,
+    stride_mm: int,
+    num_softmax_heads: int,
+    num_targets: Optional[torch.Tensor],
+    causal: bool,
+    max_attn_len: int,
+    full_attn_size: int,
+    contextual_seq_len: int,
+) -> torch.Tensor:
+    q = switch_to_contiguous_if_needed(q)
+    k = switch_to_contiguous_if_needed(k)
+    v = switch_to_contiguous_if_needed(v)
+    Z = seq_offsets.numel() - 1
+    # Previously this is AUTOTUNE_Z=prev_power_of_2(Z)
+    # We rollback to Z to avoid the .item() call in prev_power_of_2
+    # TODO: remove this once we have a better way to handle the .item() call
+    AUTOTUNE_Z = Z
+    total_seq_len_q, H, DimQ = q.shape
+    _, _, DimV = v.shape
+    out = torch.empty(total_seq_len_q, H, DimV, device=q.device, dtype=q.dtype)
+    if total_seq_len_q == 0:
+        return out
+    if attn_scale.ndim == 0:
+        attn_scale_type = "scalar"
+    else:
+        attn_scale_type = "dynamic"
+    assert num_softmax_heads == 0 or num_softmax_heads == H, (
+        "num_softmax_heads must be 0 or H in tlx version due to a compilation issue"
+    )
+    HAS_NUM_TARGETS = num_targets is not None
+    if not HAS_NUM_TARGETS:
+        num_targets = torch.empty(0)
+    HAS_MAX_ATTN_LEN = max_attn_len != 0
+    HAS_FULL_ATTN_SIZE = full_attn_size != 0
+    HAS_CONTEXTUAL_SEQ_LEN = contextual_seq_len != 0
+    _, H, DimQ = q.shape
+    _, _, DimV = v.shape
+
+    total_seq_len_q, H, DimQ = q.shape
+    total_seq_len_kv, _, _ = k.shape
+    # TMA
+    dummy_block = [1, 1]
+    desc_q = TensorDescriptor(
+        q,
+        shape=[total_seq_len_q, H * DimQ],
+        strides=[q.stride(0), 1],
+        block_shape=dummy_block,
+    )
+    desc_o = TensorDescriptor(
+        out,
+        shape=[total_seq_len_q, H * DimV],
+        strides=[out.stride(0), 1],
+        block_shape=dummy_block,
+    )
+    desc_v = TensorDescriptor(
+        v,
+        shape=[total_seq_len_kv, H * DimV],
+        strides=[v.stride(0), 1],
+        block_shape=dummy_block,
+    )
+    desc_k = TensorDescriptor(
+        k,
+        shape=[total_seq_len_kv, H * DimQ],
+        strides=[k.stride(0), 1],
+        block_shape=dummy_block,
+    )
+
+    # TMA descriptors require a global memory allocation
+    def alloc_fn(size: int, alignment: int, _):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    # pyrefly: ignore [bad-argument-type]
+    triton.set_allocator(alloc_fn)
+
+    num_sms = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).multi_processor_count
+    grid = lambda meta: (  # noqa E731
+        min(num_sms, H * Z * triton.cdiv(max_seq_len, meta["BLOCK_M"])),
+    )
+    _attn_fwd_ws[grid](
+        Out=out,
+        sm_scale=alpha,
+        Z=Z,
+        H=H,
+        M=M,
+        desc_q=desc_q,
+        desc_k=desc_k,
+        desc_v=desc_v,
+        desc_o=desc_o,
+        seq_offsets=seq_offsets,
+        max_seq_len=max_seq_len,
+        num_targets=num_targets,
+        max_attn_len=max_attn_len,
+        full_attn_size=full_attn_size,
+        contextual_seq_len=contextual_seq_len,
+        stride_mm=stride_mm,
+        stride_qh=q.stride(1),
+        stride_kh=k.stride(1),
+        stride_vh=v.stride(1),
+        stride_oh=out.stride(1),
+        attn_scale=attn_scale,
+        SOFTMAX=num_softmax_heads != 0,
+        HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+        HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+        HAS_FULL_ATTN_SIZE=HAS_FULL_ATTN_SIZE,
+        HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+        ATTN_SCALE_TYPE=attn_scale_type,
+        AUTOTUNE_MAX_SEQ_LEN=autotune_max_seq_len(max_seq_len),
+        DimQ=DimQ,
+        DimV=DimV,
+        STAGE=3 if causal else 1,
+    )
+
+    return out
+
+
+class _AttentionFunction(torch.autograd.Function):
+    @staticmethod
+    # pyre-ignore[14]
+    def forward(
+        ctx,
+        max_seq_len: int,
+        alpha: float,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        seq_offsets: torch.Tensor,
+        attn_scale: torch.Tensor,
+        sort_by_length: bool,
+        num_softmax_heads: int,
+        num_targets: Optional[torch.Tensor],
+        causal: bool,
+        max_attn_len: int,
+        full_attn_size: int,
+        contextual_seq_len: int,
+    ) -> torch.Tensor:
+        sort_by_length_indices = None
+        if sort_by_length:
+            seq_lengths = seq_offsets[1:] - seq_offsets[:-1]
+            _, sort_by_length_indices = torch.sort(
+                seq_lengths, descending=True, stable=False
+            )
+        saved_tensors = [q, k, v, seq_offsets, attn_scale]
+        if sort_by_length_indices is not None:
+            saved_tensors.append(sort_by_length_indices)
+        ctx.num_softmax_heads = num_softmax_heads
+        if num_targets is not None:
+            saved_tensors.append(num_targets)
+        ctx.has_num_targets = num_targets is not None
+        ctx.causal = causal
+        M, stride_mm = forward_custom_vars(q, num_softmax_heads, saved_tensors)
+        ctx.alpha = alpha
+        ctx.max_seq_len = max_seq_len
+        ctx.sort_by_length = sort_by_length
+        ctx.max_attn_len = max_attn_len
+        ctx.full_attn_size = full_attn_size
+        ctx.contextual_seq_len = contextual_seq_len
+        out = tlx_hstu_attention_fwd(
+            max_seq_len=max_seq_len,
+            alpha=alpha,
+            q=q,
+            k=k,
+            v=v,
+            seq_offsets=seq_offsets,
+            attn_scale=attn_scale,
+            sort_by_length_indices=sort_by_length_indices,
+            M=M,
+            stride_mm=stride_mm,
+            num_softmax_heads=num_softmax_heads,
+            num_targets=num_targets,
+            causal=True,
+            max_attn_len=max_attn_len,
+            full_attn_size=full_attn_size,
+            contextual_seq_len=contextual_seq_len,
+        )
+        saved_tensors.append(out)
+        ctx.save_for_backward(*saved_tensors)
+        return out
+
+    @staticmethod
+    # pyre-ignore[14]
+    def backward(
+        ctx, dout: torch.Tensor
+    ) -> Tuple[
+        None,
+        None,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    ]:
+        saved_tensors = ctx.saved_tensors
+        q, k, v, seq_offsets, attn_scale = saved_tensors[:5]
+        idx = 5
+        if ctx.sort_by_length:
+            sort_by_length_indices = saved_tensors[idx]
+            idx += 1
+        else:
+            sort_by_length_indices = None
+        num_softmax_heads = ctx.num_softmax_heads
+        if ctx.has_num_targets:
+            num_targets = ctx.saved_tensors[idx]
+            idx += 1
+        else:
+            num_targets = None
+        causal = ctx.causal
+        Z, H, DimQ = q.shape
+        _, _, DimV = v.shape
+        d_qkv = torch.zeros((Z, H, DimQ * 2 + DimV), device=q.device, dtype=q.dtype)
+        dq, dk, dv = d_qkv.split([DimQ, DimQ, DimV], dim=-1)
+        M, Delta, stride_mm = backward_custom_vars(
+            dout, num_softmax_heads, idx, saved_tensors
+        )
+        dq, dk, dv = tlx_hstu_attention_bwd(
+            dout=dout,
+            q=q,
+            k=k,
+            v=v,
+            dq=dq,
+            dk=dk,
+            dv=dv,
+            seq_offsets=seq_offsets,
+            attn_scale=attn_scale,
+            max_seq_len=ctx.max_seq_len,
+            alpha=ctx.alpha,
+            M=M,
+            Delta=Delta,
+            stride_mm=stride_mm,
+            num_softmax_heads=num_softmax_heads,
+            num_targets=num_targets,
+            causal=causal,
+            max_attn_len=ctx.max_attn_len,
+            full_attn_size=ctx.full_attn_size,
+            contextual_seq_len=ctx.contextual_seq_len,
+        )
+        return (
+            None,
+            None,
+            dq,
+            dk,
+            dv,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+@torch.jit.unused
+@torch.fx.wrap
+def tlx_bw_hstu_mha(
+    max_seq_len: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    attn_scale: torch.Tensor,
+    sort_by_length: bool = False,
+    num_softmax_heads: int = 0,
+    num_targets: Optional[torch.Tensor] = None,
+    max_attn_len: int = 0,
+    full_attn_size: int = 0,
+    contextual_seq_len: int = 0,
+    causal: bool = True,
+) -> torch.Tensor:
+    return _AttentionFunction.apply(
+        max_seq_len,
+        alpha,
+        q,
+        k,
+        v,
+        seq_offsets,
+        attn_scale,
+        sort_by_length,
+        num_softmax_heads,
+        num_targets,
+        causal,
+        max_attn_len,
+        full_attn_size,
+        contextual_seq_len,
+    )
+
+
+def tlx_bw_hstu_mha_wrapper(
+    max_seq_len: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    attn_scale: torch.Tensor,
+    sort_by_length: bool = False,
+    num_softmax_heads: int = 0,
+    num_targets: Optional[torch.Tensor] = None,
+    max_attn_len: int = 0,
+    contextual_seq_len: int = 0,
+) -> torch.Tensor:
+    return tlx_bw_hstu_mha(
+        max_seq_len=max_seq_len,
+        alpha=alpha,
+        q=q,
+        k=k,
+        v=v,
+        seq_offsets=seq_offsets,
+        attn_scale=attn_scale,
+        sort_by_length=sort_by_length,
+        num_softmax_heads=num_softmax_heads,
+        num_targets=num_targets,
+        max_attn_len=max_attn_len,
+        contextual_seq_len=contextual_seq_len,
+    )

--- a/third_party/tlx/tutorials/hstu_self_attn/triton_attention_utils.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/triton_attention_utils.py
@@ -1,0 +1,249 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+import torch
+
+# @manual=//triton:triton
+import triton
+
+# @manual=//triton:triton
+import triton.language as tl
+
+try:
+    # @manual=//triton:triton
+    import triton.language.extra.tlx as tlx  # type: ignore[attr-defined]
+
+    HAS_TLX = True
+except ImportError:
+    tlx = None
+    HAS_TLX = False
+
+from triton.language.extra.libdevice import (  # @manual=//triton:triton
+    fast_dividef,
+    fast_expf,
+)
+
+HAS_FAST_TANH_INSTRUCTION = (
+    torch.version.cuda is not None
+    and torch.cuda.is_available()
+    and torch.cuda.get_device_capability()[0] >= 9  # >= H100
+)
+HAS_F32X2_INSTRUCTION = (
+    torch.version.cuda is not None
+    and torch.cuda.is_available()
+    and torch.cuda.get_device_capability()[0] >= 10  # >= B200
+)
+
+if HAS_FAST_TANH_INSTRUCTION:
+
+    @triton.jit
+    def tanh_approx_fp32(x):
+        output = tl.inline_asm_elementwise(
+            asm="""
+            tanh.approx.f32 $0, $1;
+            """,
+            constraints="=r,r",
+            args=[x],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=1,
+        )
+        return output
+
+
+if HAS_F32X2_INSTRUCTION:
+
+    @triton.jit
+    def _fma_f32x2(a, b, c):
+        return tl.inline_asm_elementwise(
+            """
+            {
+                .reg .b64 ra, rb, rc, rd;
+                mov.b64 ra, { $2, $3 };
+                mov.b64 rb, { $4, $5 };
+                mov.b64 rc, { $6, $7 };
+                fma.rn.f32x2 rd, ra, rb, rc;
+                mov.b64 { $0, $1 }, rd;
+            }
+            """,
+            "=r,=r,r,r,r,r,r,r",
+            [a, b, c],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=2,
+        )
+
+    @triton.jit
+    def _mul_f32x2(a, b):
+        return tl.inline_asm_elementwise(
+            """
+            {
+                .reg .b64 ra, rb, rc;
+                mov.b64 ra, { $2, $3 };
+                mov.b64 rb, { $4, $5 };
+                mul.f32x2 rc, ra, rb;
+                mov.b64 { $0, $1 }, rc;
+            }
+            """,
+            "=r,=r,r,r,r,r",
+            [a, b],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=2,
+        )
+
+    @triton.jit
+    def fast_fma(a, b, c):
+        return _fma_f32x2(a, b, c)
+
+    @triton.jit
+    def fast_mul(a, b):
+        return _mul_f32x2(a, b)
+
+    @triton.jit
+    def fast_silu(x, MULT_BY_X: tl.constexpr):
+        x = x * 0.5
+        if MULT_BY_X:
+            return _fma_f32x2(x, tanh_approx_fp32(x), x)
+        else:
+            return _fma_f32x2(tanh_approx_fp32(x), 0.5, 0.5)
+
+elif HAS_FAST_TANH_INSTRUCTION:
+
+    @triton.jit
+    def fast_fma(a, b, c):
+        return a * b + c
+
+    @triton.jit
+    def fast_mul(a, b):
+        return a * b
+
+    @triton.jit
+    def fast_silu(x, MULT_BY_X: tl.constexpr):
+        x = x * 0.5
+        if MULT_BY_X:
+            return x * (tanh_approx_fp32(x) + 1.0)
+        else:
+            return tanh_approx_fp32(x) * 0.5 + 0.5
+
+else:
+
+    @triton.jit
+    def fast_fma(a, b, c):
+        return a * b + c
+
+    @triton.jit
+    def fast_mul(a, b):
+        return a * b
+
+    @triton.jit
+    def fast_silu(x, MULT_BY_X: tl.constexpr):
+        if MULT_BY_X:
+            # pyre-fixme[16]: Module `math` has no attribute `fast_dividef`.
+            return fast_dividef(x, 1.0 + fast_expf(-x))
+        else:
+            # pyre-fixme[16]: Module `math` has no attribute `fast_dividef`.
+            return fast_dividef(1.0, 1.0 + fast_expf(-x))
+
+
+@triton.jit
+def _get_bufidx_phase(accum_cnt, NUM_BUFFERS_KV):
+    buf_id = accum_cnt % NUM_BUFFERS_KV
+    phase = (accum_cnt // NUM_BUFFERS_KV) & 1
+    return buf_id, phase
+
+
+@triton.jit
+def backward_d_silu_activation(
+    dact_qk_trans,
+    pT,  # pT represents sig_trans
+    qk_trans,
+    scale,
+    valid_mask_trans,
+):
+    dqk_trans = dact_qk_trans * pT * (1 + qk_trans * (1 - pT)) * scale[None, :]
+    dqk_trans = tl.where(valid_mask_trans, dqk_trans, 0)
+    return dqk_trans
+
+
+@triton.jit
+def backward_d_softmax_activation(
+    dact_qk_trans,
+    Delta_off,
+    offs_m,
+    stride_mm,
+    mask_m,
+    pT,  # pT represents sig_trans
+):
+    Di = tl.load(Delta_off + offs_m * stride_mm, mask=mask_m)
+    dqk_trans = pT * (dact_qk_trans - Di[None, :])
+    return dqk_trans
+
+
+@triton.jit
+def backward_silu_activation(qk_trans, alpha, valid_mask_trans, dtype_k, scale):
+    masked_alpha = tl.where(valid_mask_trans, alpha, 0.0)
+    qk_trans = qk_trans * masked_alpha
+    pT = fast_silu(qk_trans, MULT_BY_X=False)
+    silu_trans = qk_trans * pT * scale[None, :]
+    act_qk_trans = silu_trans.to(dtype_k)
+    return qk_trans, act_qk_trans, pT
+
+
+@triton.jit
+def backward_softmax_activation(
+    qk_trans, alpha, valid_mask_trans, M_off, offs_m, stride_mm, mask_m, k
+):
+    qk_trans = qk_trans * alpha * 1.44269504
+    m = tl.load(M_off + offs_m * stride_mm, mask=mask_m)
+    pT = tl.math.exp2(qk_trans - m[None, :])
+    pT = tl.where(valid_mask_trans, pT, 0.0)
+    act_qk_trans = pT.to(k.dtype)
+    return qk_trans, act_qk_trans, pT
+
+
+@triton.jit
+def forward_softmax_activation_scaled_alpha(
+    qk, scaled_alpha, valid_mask, m_i, acc, l_i
+):
+    qk = qk * scaled_alpha
+    qk = tl.where(valid_mask, qk, -float("inf"))
+    m_ij = tl.maximum(m_i, tl.max(qk, 1))
+    qk -= m_ij[:, None]
+    act_qk = tl.math.exp2(qk)
+    corr = tl.math.exp2(m_i - m_ij)
+    l_ij = tl.sum(act_qk, 1)
+    acc = acc * corr[:, None]
+    l_i = l_i * corr + l_ij
+    m_i = m_ij
+    return act_qk, acc, l_i, m_i
+
+
+@triton.jit
+def forward_softmax_activation_trans_scaled_alpha(
+    qk_trans, scaled_alpha, valid_mask_trans, m_i, acc, l_i
+):
+    qk_trans = qk_trans * scaled_alpha
+    qk_trans = tl.where(valid_mask_trans, qk_trans, -float("inf"))
+    m_ij = tl.maximum(m_i, tl.max(qk_trans, 0))
+    qk_trans -= m_ij[None, :]
+    act_qk = tl.math.exp2(qk_trans)
+    corr = tl.math.exp2(m_i - m_ij)
+    l_ij = tl.sum(act_qk, 0)
+    acc = acc * corr[None, :]
+    l_i = l_i * corr + l_ij
+    m_i = m_ij
+    return act_qk, acc, l_i, m_i
+
+
+@triton.jit
+def backward_softmax_activation_scaled_alpha(
+    qk_trans, scaled_alpha, valid_mask_trans, M_off, offs_m, stride_mm, mask_m, k
+):
+    qk_trans = qk_trans * scaled_alpha
+    m = tl.load(M_off + offs_m * stride_mm, mask=mask_m)
+    pT = tl.math.exp2(qk_trans - m[None, :])
+    pT = tl.where(valid_mask_trans, pT, 0.0)
+    act_qk_trans = pT.to(k.dtype)
+    return qk_trans, act_qk_trans, pT

--- a/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
@@ -1,0 +1,2218 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pyre-unsafe
+
+#!/usr/bin/env python3
+
+import os
+
+from typing import List, Optional, Tuple
+
+import torch
+
+# @manual=//triton:triton
+import triton
+
+# @manual=//triton:triton
+import triton.language as tl
+from stubs import (
+    autotune_max_seq_len,
+    prev_power_of_2,
+    switch_to_contiguous_if_needed,
+    triton_autotune,
+)
+from stubs import acc_dq
+from triton.language.extra.libdevice import fast_dividef  # @manual=//triton:triton
+
+# HSTU_SELF_AUTOWS=1 turns on Meta-Triton autoWS on the main KV loop (needs
+# TRITON_USE_META_WS=1 + TRITON_DISABLE_WSBARRIER_REORDER=1 at runtime, and a
+# num_stages>=1 config -- pair with HSTU_SELF_PIN=1). Default off -> identical to
+# the plain-Triton kernel. Must be a tl.constexpr to be read inside @triton.jit.
+_HSTU_SELF_AUTOWS = tl.constexpr(os.environ.get("HSTU_SELF_AUTOWS") == "1")
+# Data-partition factor for autoWS: splits the loop's MMAs into N groups (the
+# autoWS analog of TLX's replicate=NUM_MMA_GROUPS). Default 2 when autoWS is on
+# (matches TLX's 2 MMA groups), 1 otherwise; override with HSTU_SELF_DP.
+_HSTU_SELF_DP = tl.constexpr(
+    int(
+        os.environ.get(
+            "HSTU_SELF_DP", "2" if os.environ.get("HSTU_SELF_AUTOWS") == "1" else "1"
+        )
+    )
+)
+
+
+def _get_fw_configs() -> List[triton.Config]:  # noqa: C901
+    configs = []
+    if torch.version.hip:
+        for BLOCK_M in [32, 64, 128]:
+            for BLOCK_N in [32, 64]:
+                for num_stages in [1, 2]:
+                    for num_warps in [4, 8]:
+                        for matrix_instr_nonkdim in [16, 32]:
+                            configs.append(
+                                triton.Config(
+                                    {
+                                        "BLOCK_M": BLOCK_M,
+                                        "BLOCK_N": BLOCK_N,
+                                        "matrix_instr_nonkdim": matrix_instr_nonkdim,
+                                        "waves_per_eu": 0,
+                                        "kpack": 2,
+                                    },
+                                    num_stages=num_stages,
+                                    num_warps=num_warps,
+                                )
+                            )
+    else:
+        configs = [
+            triton.Config(
+                {"BLOCK_M": 16, "BLOCK_N": 32},
+                num_stages=2,
+                num_warps=2,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 32},
+                num_stages=2,
+                num_warps=2,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 32},
+                num_stages=4,
+                num_warps=2,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 32},
+                num_stages=2,
+                num_warps=4,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 32},
+                num_stages=4,
+                num_warps=4,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 64},
+                num_stages=2,
+                num_warps=4,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 64},
+                num_stages=4,
+                num_warps=4,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 64},
+                num_stages=4,
+                num_warps=8,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 128},
+                num_stages=2,
+                num_warps=4,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 128},
+                num_stages=2,
+                num_warps=8,
+            ),
+            triton.Config(
+                {"BLOCK_M": 64, "BLOCK_N": 32},
+                num_stages=4,
+                num_warps=2,
+            ),
+            triton.Config(
+                {"BLOCK_M": 64, "BLOCK_N": 32},
+                num_stages=2,
+                num_warps=4,
+            ),
+            triton.Config(
+                {"BLOCK_M": 64, "BLOCK_N": 32},
+                num_stages=4,
+                num_warps=4,
+            ),
+            triton.Config(
+                {"BLOCK_M": 64, "BLOCK_N": 32},
+                num_stages=2,
+                num_warps=8,
+            ),
+            triton.Config(
+                {"BLOCK_M": 64, "BLOCK_N": 64},
+                num_stages=2,
+                num_warps=2,
+            ),
+            triton.Config(
+                {"BLOCK_M": 64, "BLOCK_N": 64},
+                num_stages=2,
+                num_warps=4,
+            ),
+            triton.Config(
+                {"BLOCK_M": 64, "BLOCK_N": 64},
+                num_stages=4,
+                num_warps=4,
+            ),
+            triton.Config(
+                {"BLOCK_M": 64, "BLOCK_N": 64},
+                num_stages=4,
+                num_warps=8,
+            ),
+            triton.Config(
+                {"BLOCK_M": 128, "BLOCK_N": 32},
+                num_stages=2,
+                num_warps=2,
+            ),
+            triton.Config(
+                {"BLOCK_M": 128, "BLOCK_N": 32},
+                num_stages=4,
+                num_warps=2,
+            ),
+            triton.Config(
+                {"BLOCK_M": 128, "BLOCK_N": 32},
+                num_stages=2,
+                num_warps=4,
+            ),
+            triton.Config(
+                {"BLOCK_M": 128, "BLOCK_N": 32},
+                num_stages=4,
+                num_warps=4,
+            ),
+            triton.Config(
+                {"BLOCK_M": 128, "BLOCK_N": 32},
+                num_stages=2,
+                num_warps=8,
+            ),
+            triton.Config(
+                {"BLOCK_M": 128, "BLOCK_N": 32},
+                num_stages=4,
+                num_warps=8,
+            ),
+            triton.Config(
+                {"BLOCK_M": 128, "BLOCK_N": 64},
+                num_stages=2,
+                num_warps=4,
+            ),
+            triton.Config(
+                {"BLOCK_M": 128, "BLOCK_N": 64},
+                num_stages=2,
+                num_warps=8,
+            ),
+            triton.Config(
+                {"BLOCK_M": 128, "BLOCK_N": 64},
+                num_stages=4,
+                num_warps=8,
+            ),
+            triton.Config(
+                {"BLOCK_M": 128, "BLOCK_N": 128},
+                num_stages=4,
+                num_warps=4,
+            ),
+            triton.Config(
+                {"BLOCK_M": 128, "BLOCK_N": 128},
+                num_stages=2,
+                num_warps=8,
+            ),
+        ]
+    # HSTU_SELF_AUTOWS needs enough warps + a big enough tile for meta-WS to
+    # split into producer/consumer partitions (the tiny default config with
+    # num_warps=2/BLOCK_M=16 does NOT warp-specialize). Pin to a num_warps>=4,
+    # BLOCK_M>=64 config.
+    if os.environ.get("HSTU_SELF_AUTOWS") == "1":
+        _w = int(os.environ.get("HSTU_SELF_AUTOWS_WARPS", "8"))
+        _dp = int(os.environ.get("HSTU_SELF_DP", "2"))
+        if _dp >= 2:
+            # DP splits BLOCK_M by _dp; each slice must be >= the TMEM blockM
+            # (128) or WSDataPartition skips (WSDataPartition.cpp). So set
+            # BLOCK_M = 128 * _dp (doubling the split dim) -> each partition tile
+            # is 128 rows, matching TLX (BLOCK_M=256, 2 groups of 128).
+            _bn = int(os.environ.get("HSTU_SELF_AUTOWS_BN", "128"))
+            return [
+                triton.Config(
+                    {"BLOCK_M": 128 * _dp, "BLOCK_N": _bn},
+                    num_stages=1,
+                    num_warps=_w,
+                )
+            ]
+        # DP off: pick the largest existing tile / most warps.
+        cand = [
+            c
+            for c in configs
+            if c.num_stages >= 1 and c.kwargs.get("BLOCK_M", 0) >= 64
+        ]
+        cand.sort(
+            key=lambda c: (
+                c.kwargs.get("BLOCK_M", 0) + c.kwargs.get("BLOCK_N", 0),
+                c.num_warps == _w,
+                c.num_warps,
+            ),
+            reverse=True,
+        )
+        if cand:
+            return [cand[0]]
+        return configs[:1]
+    # HSTU_SELF_PIN=1 shrinks the fwd autotune to one config (fast compile for
+    # tritonbench --mode bwd, which recompiles fwd+bwd).
+    if os.environ.get("HSTU_SELF_PIN"):
+        return configs[:1]
+    return configs
+
+
+def _bwd_pre_hook(nargs):
+    nargs["DQ"].zero_()
+    if nargs["SEQUENCE_PARALLEL"] is True:
+        nargs["LOCK"].zero_()
+
+
+def _get_bw_configs() -> List[triton.Config]:
+    if torch.version.hip:
+        configs = []
+        for BLOCK_M in [32, 64]:
+            for BLOCK_N in [32, 64]:
+                for num_stages in [1, 2]:
+                    for num_warps in [4, 8]:
+                        for matrix_instr_nonkdim in [16, 32]:
+                            for waves_per_eu in [0, 2, 4]:
+                                for sp in [True, False]:
+                                    configs.append(
+                                        triton.Config(
+                                            {
+                                                "BLOCK_M": BLOCK_M,
+                                                "BLOCK_N": BLOCK_N,
+                                                "matrix_instr_nonkdim": matrix_instr_nonkdim,
+                                                "waves_per_eu": waves_per_eu,
+                                                "SEQUENCE_PARALLEL": sp,
+                                                "UNROLL": 1,
+                                            },
+                                            num_stages=num_stages,
+                                            num_warps=num_warps,
+                                            pre_hook=_bwd_pre_hook,
+                                        )
+                                    )
+        return configs
+
+    configs = [
+        triton.Config(
+            {"BLOCK_M": 16, "BLOCK_N": 32, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=2,
+            num_warps=2,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 16, "BLOCK_N": 16, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=2,
+            num_warps=2,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 16, "BLOCK_N": 32, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=2,
+            num_warps=4,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 16, "BLOCK_N": 32, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=1,
+            num_warps=8,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 32, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=1,
+            num_warps=4,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 32, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=2,
+            num_warps=4,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 64, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=2,
+            num_warps=4,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 64, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=2,
+            num_warps=8,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 64, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=1,
+            num_warps=4,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 64, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=2,
+            num_warps=4,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 64, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=1,
+            num_warps=8,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 64, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=2,
+            num_warps=8,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 128, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=2,
+            num_warps=8,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 128, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+            num_stages=3,
+            num_warps=8,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 128, "SEQUENCE_PARALLEL": False, "UNROLL": 4},
+            num_stages=2,
+            num_warps=8,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 16, "BLOCK_N": 32, "SEQUENCE_PARALLEL": True, "UNROLL": 1},
+            num_stages=2,
+            num_warps=2,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 32, "SEQUENCE_PARALLEL": True, "UNROLL": 1},
+            num_stages=1,
+            num_warps=4,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 32, "SEQUENCE_PARALLEL": True, "UNROLL": 1},
+            num_stages=2,
+            num_warps=4,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 64, "SEQUENCE_PARALLEL": True, "UNROLL": 1},
+            num_stages=1,
+            num_warps=4,
+            pre_hook=_bwd_pre_hook,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 64, "SEQUENCE_PARALLEL": True, "UNROLL": 1},
+            num_stages=2,
+            num_warps=4,
+            pre_hook=_bwd_pre_hook,
+        ),
+    ]
+    if torch.cuda.is_available():
+        configs += [
+            triton.Config(
+                {"BLOCK_M": 16, "BLOCK_N": 64, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+                num_stages=1,
+                num_warps=4,
+                pre_hook=_bwd_pre_hook,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 64, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+                num_stages=1,
+                num_warps=4,
+                pre_hook=_bwd_pre_hook,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 64, "SEQUENCE_PARALLEL": False, "UNROLL": 1},
+                num_stages=1,
+                num_warps=8,
+                pre_hook=_bwd_pre_hook,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 64, "SEQUENCE_PARALLEL": True, "UNROLL": 1},
+                num_stages=1,
+                num_warps=8,
+                pre_hook=_bwd_pre_hook,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 128, "SEQUENCE_PARALLEL": True, "UNROLL": 1},
+                num_stages=3,
+                num_warps=8,
+                pre_hook=_bwd_pre_hook,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 64, "SEQUENCE_PARALLEL": True, "UNROLL": 1},
+                num_stages=1,
+                num_warps=4,
+                pre_hook=_bwd_pre_hook,
+            ),
+            triton.Config(
+                {"BLOCK_M": 32, "BLOCK_N": 64, "SEQUENCE_PARALLEL": True, "UNROLL": 1},
+                num_stages=2,
+                num_warps=4,
+                pre_hook=_bwd_pre_hook,
+            ),
+            triton.Config(
+                {
+                    "BLOCK_M": 32,
+                    "BLOCK_N": 128,
+                    "SEQUENCE_PARALLEL": False,
+                    "UNROLL": 2,
+                },
+                num_stages=2,
+                num_warps=8,
+                pre_hook=_bwd_pre_hook,
+            ),
+        ]
+    else:
+        print("WARNING: temporarily disabled some autotune configs for CUDA 12.8+")
+    # HSTU_SELF_PIN=1 shrinks the bwd autotune to one config so tritonbench
+    # --mode bwd compiles fast instead of building all ~29 configs.
+    if os.environ.get("HSTU_SELF_PIN"):
+        return configs[:1]
+    return configs
+
+
+@triton.jit
+def backward_activation(qk_trans, alpha, scale, valid_mask_trans, k):
+    qk_trans = qk_trans * alpha
+    sig_trans = fast_dividef(1.0, 1.0 + tl.exp(-qk_trans))
+    silu_trans = qk_trans * sig_trans * scale
+    act_qk_trans = tl.where(valid_mask_trans, silu_trans, 0)
+    act_qk_trans = act_qk_trans.to(k.dtype)
+    return qk_trans, sig_trans, act_qk_trans
+
+
+@triton.jit
+def backward_d_activation(dact_qk_trans, sig_trans, qk_trans, scale, valid_mask_trans):
+    dqk_trans = dact_qk_trans * sig_trans * (1 + qk_trans * (1 - sig_trans)) * scale
+    dqk_trans = tl.where(valid_mask_trans, dqk_trans, 0)
+    return dqk_trans
+
+
+@triton.jit
+def backward_off_common_preprocess(
+    seq_len_q,
+    contextual_seq_len,
+    n_targets,
+    offs_n,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+):
+    max_ids = seq_len_q
+    if HAS_CONTEXTUAL_SEQ_LEN:
+        pos_offs_n = offs_n - contextual_seq_len + 1
+        pos_offs_n = tl.where(
+            pos_offs_n > 0,
+            pos_offs_n,
+            0,
+        )
+        max_ids = max_ids - contextual_seq_len + 1
+    else:
+        pos_offs_n = offs_n
+    if HAS_NUM_TARGETS:
+        max_ids = max_ids - n_targets
+        pos_offs_n = tl.where(
+            pos_offs_n < max_ids,
+            pos_offs_n,
+            max_ids,
+        )
+    return max_ids, pos_offs_n
+
+
+@triton.jit
+def backward_valid_mask(
+    offs_m,
+    pos_offs_n,
+    offs_n,
+    max_ids,
+    contextual_seq_len,
+    max_attn_len,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+):
+    valid_mask_trans = offs_m[None, :] == offs_n[:, None]
+    if HAS_CONTEXTUAL_SEQ_LEN:
+        offs_m = offs_m - contextual_seq_len + 1
+        offs_m = tl.where(
+            offs_m > 0,
+            offs_m,
+            0,
+        )
+    if HAS_NUM_TARGETS:
+        offs_m = tl.where(
+            offs_m < max_ids,
+            offs_m,
+            max_ids,
+        )
+        pos_offs_n = tl.where(
+            pos_offs_n < max_ids,
+            pos_offs_n,
+            max_ids,
+        )
+    pos_offs_m_minus_n = offs_m[None, :] - pos_offs_n[:, None]
+    valid_mask_trans = valid_mask_trans | (pos_offs_m_minus_n > 0)
+    if HAS_MAX_ATTN_LEN:
+        valid_mask_trans = valid_mask_trans & (pos_offs_m_minus_n <= max_attn_len)
+    if HAS_CONTEXTUAL_SEQ_LEN:
+        valid_mask_trans = valid_mask_trans | (
+            (offs_m[None, :] == 0) & (pos_offs_n[:, None] < max_ids)
+        )
+    return valid_mask_trans
+
+
+@triton.jit
+def forward_activation(qk, alpha, scale, valid_mask):
+    qk = qk * alpha
+    silu = fast_dividef(qk, 1.0 + tl.exp(-qk)) * scale
+    act_qk = tl.where(valid_mask, silu, 0)
+    return act_qk
+
+
+@triton.jit
+def forward_uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS: tl.constexpr):
+    if HAS_NUM_TARGETS:
+        uih_end = seq_len_q - n_targets
+    else:
+        uih_end = seq_len_q
+    return uih_end
+
+
+@triton.jit
+def forward_valid_mask(
+    offs_m,
+    offs_n,
+    seq_len_q,
+    contextual_seq_len,
+    max_attn_len,
+    n_targets,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+):
+    valid_mask = offs_m[:, None] == offs_n[None, :]
+    max_ids = seq_len_q
+    if HAS_CONTEXTUAL_SEQ_LEN:
+        offs_m = offs_m - contextual_seq_len + 1
+        offs_m = tl.where(
+            offs_m > 0,
+            offs_m,
+            0,
+        )
+        offs_n = offs_n - contextual_seq_len + 1
+        offs_n = tl.where(
+            offs_n > 0,
+            offs_n,
+            0,
+        )
+        max_ids = max_ids - contextual_seq_len + 1
+    if HAS_NUM_TARGETS:
+        max_ids = max_ids - n_targets
+        offs_m = tl.where(
+            offs_m < max_ids,
+            offs_m,
+            max_ids,
+        )
+        offs_n = tl.where(
+            offs_n < max_ids,
+            offs_n,
+            max_ids,
+        )
+    offs_m_minus_n = offs_m[:, None] - offs_n[None, :]
+    valid_mask = valid_mask | (offs_m_minus_n > 0)
+    if HAS_MAX_ATTN_LEN:
+        valid_mask = valid_mask & (offs_m_minus_n <= max_attn_len)
+    if HAS_CONTEXTUAL_SEQ_LEN:
+        valid_mask = valid_mask | ((offs_m[:, None] == 0) & (offs_n[None, :] < max_ids))
+    return valid_mask
+
+
+@triton.jit
+def target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS: tl.constexpr):
+    if HAS_NUM_TARGETS:
+        n_targets = tl.load(num_targets + off_z).to(tl.int32)
+    else:
+        n_targets = 0
+    return n_targets
+
+
+@triton.jit
+def _hstu_attn_fwd_one_block_0(  # noqa: C901
+    start_n,
+    seq_len_q,
+    seq_len_kv,
+    offs_m,
+    offs_n,
+    off_h,
+    q,
+    K,
+    V,
+    acc,
+    K_block_ptr,
+    V_block_ptr,
+    device_desc_k,
+    device_desc_v,
+    offset_kh,
+    offset_vh,
+    seq_start_q,
+    seq_start_kv,
+    alpha,
+    scale,
+    num_targets,
+    max_attn_len,
+    contextual_seq_len,
+    n_targets,
+    uih_end,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    ENABLE_TMA: tl.constexpr,
+):
+    start_n = tl.multiple_of(start_n, BLOCK_N)
+    # -- compute qk ----
+    k = None
+    qk = None
+    if ENABLE_TMA:
+        k = tl._experimental_descriptor_load(
+            device_desc_k,
+            [(seq_start_kv + start_n).to(tl.int32), offset_kh.to(tl.int32)],
+            [BLOCK_N, BLOCK_D_Q],
+            K.dtype.element_ty,
+        )
+        # tma can only be loaded in one order, use trans afterwards
+        qk = tl.dot(q, tl.trans(k), allow_tf32=ALLOW_TF32)
+    else:
+        k = tl.load(K_block_ptr, boundary_check=(1,), padding_option="zero")
+        qk = tl.dot(q, k, allow_tf32=ALLOW_TF32)
+    valid_mask = forward_valid_mask(
+        offs_m,
+        offs_n,
+        seq_len_q,
+        contextual_seq_len,
+        max_attn_len,
+        n_targets,
+        HAS_CONTEXTUAL_SEQ_LEN,
+        HAS_NUM_TARGETS,
+        HAS_MAX_ATTN_LEN,
+    )
+    act_qk = forward_activation(qk, alpha, scale, valid_mask)
+    v = None
+    if ENABLE_TMA:
+        v = tl._experimental_descriptor_load(
+            device_desc_v,
+            [(seq_start_kv + start_n).to(tl.int32), offset_vh.to(tl.int32)],
+            [BLOCK_N, BLOCK_D_V],
+            V.dtype.element_ty,
+        )
+    else:
+        v = tl.load(V_block_ptr, boundary_check=(0,), padding_option="zero")
+    act_qk = act_qk.to(v.dtype)
+    acc += tl.dot(act_qk, v, allow_tf32=ALLOW_TF32)
+    return acc
+
+
+@triton.jit
+def _hstu_attn_bwd_one_block_0(  # noqa C901
+    start_m,
+    offs_n,
+    offs_m,
+    q_ptrs_trans,
+    dq_ptrs_trans,
+    do_ptrs,
+    device_desc_q,
+    device_desc_do,
+    dk,
+    dv,
+    k,
+    v,
+    seq_len_q,
+    seq_len_kv,
+    LOCK,
+    off_h,
+    stride_qh,
+    stride_doh,
+    stride_qm,
+    stride_dom,
+    stride_dqm,
+    alpha,
+    attn_scale,
+    max_q_len,
+    num_targets,
+    max_attn_len,
+    contextual_seq_len,
+    n_targets,
+    max_ids,
+    pos_offs_n,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    ATOMIC_ADD: tl.constexpr,
+    ENABLE_TMA: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+):
+    offs_m = offs_m + start_m
+    mask_m = offs_m < seq_len_q
+    if ATTN_SCALE_TYPE == "scalar":
+        scale = tl.load(attn_scale).to(tl.float32)
+    else:
+        tl.static_assert(ATTN_SCALE_TYPE == "dynamic")
+        scale = tl.load(attn_scale + offs_m, mask=mask_m).to(tl.float32)
+    # recompute qk and silu
+    if ENABLE_TMA:
+        q = tl._experimental_descriptor_load(
+            device_desc_q,
+            [start_m, (off_h * stride_qh).to(tl.int32)],
+            [BLOCK_M, BLOCK_D_Q],
+            k.dtype,
+        )
+        q_trans = tl.trans(q)
+    else:
+        q_trans = tl.load(
+            q_ptrs_trans + start_m * stride_qm,
+            mask=mask_m[None, :],
+            other=0.0,
+        )
+    qk_trans = tl.dot(k, q_trans, allow_tf32=ALLOW_TF32)
+    valid_mask_trans = backward_valid_mask(
+        offs_m,
+        pos_offs_n,
+        offs_n,
+        max_ids,
+        contextual_seq_len,
+        max_attn_len,
+        HAS_CONTEXTUAL_SEQ_LEN,
+        HAS_NUM_TARGETS,
+        HAS_MAX_ATTN_LEN,
+    )
+    qk_trans, sig_trans, act_qk_trans = backward_activation(
+        qk_trans, alpha, scale, valid_mask_trans, k
+    )
+    # compute dv
+    if ENABLE_TMA:
+        do = tl._experimental_descriptor_load(
+            device_desc_do,
+            [start_m, (off_h * stride_doh).to(tl.int32)],
+            [BLOCK_M, BLOCK_D_V],
+            k.dtype,
+        )
+    else:
+        do = tl.load(
+            do_ptrs + start_m * stride_dom,
+            mask=mask_m[:, None],
+            other=0.0,
+        )
+    dv += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+
+    # compute dk and dq
+    dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
+    dqk_trans = backward_d_activation(
+        dact_qk_trans, sig_trans, qk_trans, scale, valid_mask_trans
+    )
+    dqk_trans = dqk_trans.to(k.dtype)
+
+    # Note: the factor `alpha` is delayed until the end of the function to reduce the cost
+    dk += tl.dot(dqk_trans, tl.trans(q_trans), allow_tf32=ALLOW_TF32)
+    acc_dq(
+        dq_ptrs_trans=dq_ptrs_trans,
+        start_m=start_m,
+        stride_dqm=stride_dqm,
+        k=k,
+        dqk_trans=dqk_trans,
+        alpha=alpha,
+        mask_m=mask_m,
+        MAX_SEQ_LEN=max_q_len,
+        LOCK=LOCK,
+        BLOCK_M=BLOCK_M,
+        ATOMIC_ADD=ATOMIC_ADD,
+        ALLOW_TF32=ALLOW_TF32,
+    )
+    return dk, dv
+
+
+@triton.jit
+def _hstu_attn_fwd_compute(  # noqa C901
+    Q,
+    K,
+    V,
+    H,
+    DimQ,
+    DimV,
+    workspace_ptr,
+    seq_offsets,
+    seq_offsets_q,
+    Out,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_om,
+    stride_oh,
+    alpha,
+    attn_scale,
+    off_z,
+    off_h,
+    pid,
+    num_targets,
+    max_attn_len,
+    contextual_seq_len,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    ENABLE_TMA: tl.constexpr,
+    TMA_DESC_SIZE: tl.constexpr,
+):
+    off_h = off_h.to(tl.int64)
+    off_z = off_z.to(tl.int64)
+    seq_start_kv = tl.load(seq_offsets + off_z).to(tl.int64)
+    seq_end_kv = tl.load(seq_offsets + off_z + 1)
+    seq_len_kv = (seq_end_kv - seq_start_kv).to(tl.int32)
+    seq_start_q = tl.load(seq_offsets_q + off_z).to(tl.int64)
+    seq_end_q = tl.load(seq_offsets_q + off_z + 1)
+    seq_len_q = (seq_end_q - seq_start_q).to(tl.int32)
+
+    device_desc_q = None
+    device_desc_k = None
+    device_desc_v = None
+    device_desc_o = None
+    if ENABLE_TMA:
+        workspace_base = workspace_ptr + TMA_DESC_SIZE * 4 * (
+            tl.program_id(1) + tl.program_id(0) * tl.num_programs(1)
+        )
+        device_desc_q = workspace_base
+        device_desc_k = workspace_base + 1 * TMA_DESC_SIZE
+        device_desc_v = workspace_base + 2 * TMA_DESC_SIZE
+        device_desc_o = workspace_base + 3 * TMA_DESC_SIZE
+
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_device_tensormap_create2d(
+            desc_ptr=device_desc_k,
+            global_address=K,
+            load_size=[
+                BLOCK_N,
+                BLOCK_D_Q,
+            ],
+            global_size=[seq_end_kv.to(tl.int32), H * DimQ],
+            element_ty=K.dtype.element_ty,
+        )
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_device_tensormap_create2d(
+            desc_ptr=device_desc_v,
+            global_address=V,
+            load_size=[
+                BLOCK_N,
+                BLOCK_D_V,
+            ],
+            global_size=[seq_end_kv.to(tl.int32), H * DimV],
+            element_ty=V.dtype.element_ty,
+        )
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_k)
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_v)
+
+    start_m = pid * BLOCK_M
+    if start_m < seq_len_q:
+        # initialize offsets
+        offs_m = start_m + tl.arange(0, BLOCK_M)
+        offs_n = tl.arange(0, BLOCK_N)
+
+        if ATTN_SCALE_TYPE == "scalar":
+            scale = tl.load(attn_scale).to(tl.float32)
+        else:
+            tl.static_assert(ATTN_SCALE_TYPE == "dynamic")
+            scale = tl.load(
+                attn_scale + seq_start_q + offs_m, mask=offs_m < seq_len_q
+            ).to(tl.float32)
+
+        Q_block_ptr = None
+        K_block_ptr = None
+        V_block_ptr = None
+        if not ENABLE_TMA:
+            Q_block_ptr = tl.make_block_ptr(
+                base=Q + off_h * stride_qh + seq_start_q * stride_qm,
+                shape=(seq_len_q, BLOCK_D_Q),
+                strides=(stride_qm, 1),
+                offsets=(start_m, 0),
+                block_shape=(BLOCK_M, BLOCK_D_Q),
+                order=(1, 0),
+            )
+            q = tl.load(Q_block_ptr, boundary_check=(0,), padding_option="zero")
+
+            K_block_ptr = tl.make_block_ptr(
+                base=K + off_h * stride_kh + seq_start_kv * stride_kn,
+                shape=(BLOCK_D_Q, seq_len_kv),
+                strides=(1, stride_kn),
+                offsets=(0, 0),
+                block_shape=(BLOCK_D_Q, BLOCK_N),
+                order=(0, 1),
+            )
+            V_block_ptr = tl.make_block_ptr(
+                base=V + off_h * stride_vh + seq_start_kv * stride_vn,
+                shape=(seq_len_kv, BLOCK_D_V),
+                strides=(stride_vn, 1),
+                offsets=(0, 0),
+                block_shape=(BLOCK_N, BLOCK_D_V),
+                order=(1, 0),
+            )
+        else:
+            # pyre-ignore [20]
+            tl.extra.cuda.experimental_device_tensormap_create2d(
+                # pyrefly: ignore [bad-argument-type]
+                desc_ptr=device_desc_q,
+                global_address=Q,
+                load_size=[
+                    BLOCK_M,
+                    BLOCK_D_Q,
+                ],
+                global_size=[seq_end_q.to(tl.int32), H * DimQ],
+                element_ty=Q.dtype.element_ty,
+            )
+            # pyre-ignore [20]
+            tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_q)
+
+            q = tl._experimental_descriptor_load(
+                device_desc_q,
+                [
+                    (seq_start_q + start_m).to(tl.int32),
+                    (off_h * stride_qh).to(tl.int32),
+                ],
+                [
+                    BLOCK_M,
+                    BLOCK_D_Q,
+                ],
+                Q.dtype.element_ty,
+            )
+        acc = tl.zeros([BLOCK_M, BLOCK_D_V], dtype=tl.float32)
+        end_n = 0
+        n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
+        uih_end = forward_uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
+        if HAS_CONTEXTUAL_SEQ_LEN is True and start_m < contextual_seq_len:
+            low = 0
+            high = seq_len_q
+        else:
+            low = 0
+            high = start_m + BLOCK_M
+            if HAS_MAX_ATTN_LEN:
+                if start_m > uih_end:
+                    low = uih_end - max_attn_len
+                else:
+                    low = start_m - max_attn_len
+                if HAS_CONTEXTUAL_SEQ_LEN:
+                    low = low if low > contextual_seq_len else 0
+                else:
+                    low = low if low > 0 else 0
+            if HAS_NUM_TARGETS:
+                uih_end = (uih_end + BLOCK_N - 1) // BLOCK_N * BLOCK_N
+                if uih_end < start_m:
+                    high = seq_len_q - n_targets
+        offset = low
+        # single loop compute
+        if offset > 0:
+            if not ENABLE_TMA:
+                K_block_ptr = tl.advance(K_block_ptr, (0, offset))
+                V_block_ptr = tl.advance(V_block_ptr, (offset, 0))
+        end_n = low
+        for start_n in tl.range(
+            low,
+            high,
+            BLOCK_N,
+            warp_specialize=_HSTU_SELF_AUTOWS,
+            data_partition_factor=_HSTU_SELF_DP,
+        ):
+            acc = _hstu_attn_fwd_one_block_0(
+                start_n=start_n,
+                seq_len_q=seq_len_q,
+                seq_len_kv=seq_len_kv,
+                offs_m=offs_m,
+                offs_n=offs_n + start_n,
+                off_h=off_h,
+                q=q,
+                K=K,
+                V=V,
+                acc=acc,
+                K_block_ptr=K_block_ptr,
+                V_block_ptr=V_block_ptr,
+                device_desc_k=device_desc_k,
+                device_desc_v=device_desc_v,
+                offset_kh=off_h * stride_kh,
+                offset_vh=off_h * stride_vh,
+                seq_start_q=seq_start_q,
+                seq_start_kv=seq_start_kv,
+                alpha=alpha,
+                scale=scale,
+                num_targets=num_targets,
+                max_attn_len=max_attn_len,
+                contextual_seq_len=contextual_seq_len,
+                n_targets=n_targets,
+                uih_end=uih_end,
+                HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+                HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+                HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+                ALLOW_TF32=ALLOW_TF32,
+                BLOCK_D_Q=BLOCK_D_Q,
+                BLOCK_D_V=BLOCK_D_V,
+                BLOCK_N=BLOCK_N,
+                ENABLE_TMA=ENABLE_TMA,
+            )
+            if not ENABLE_TMA:
+                K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+                V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+            end_n += BLOCK_N
+        if HAS_NUM_TARGETS:
+            if uih_end < start_m:
+                low = start_m
+                high = start_m + BLOCK_M
+                offset = (low - end_n).to(tl.int32)
+                # single loop compute
+                if offset > 0:
+                    if not ENABLE_TMA:
+                        K_block_ptr = tl.advance(K_block_ptr, (0, offset))
+                        V_block_ptr = tl.advance(V_block_ptr, (offset, 0))
+                end_n = low
+                for start_n in tl.range(low, high, BLOCK_N, num_stages=0):
+                    acc = _hstu_attn_fwd_one_block_0(
+                        start_n=start_n,
+                        seq_len_q=seq_len_q,
+                        seq_len_kv=seq_len_kv,
+                        offs_m=offs_m,
+                        offs_n=offs_n + start_n,
+                        off_h=off_h,
+                        q=q,
+                        K=K,
+                        V=V,
+                        acc=acc,
+                        K_block_ptr=K_block_ptr,
+                        V_block_ptr=V_block_ptr,
+                        device_desc_k=device_desc_k,
+                        device_desc_v=device_desc_v,
+                        offset_kh=off_h * stride_kh,
+                        offset_vh=off_h * stride_vh,
+                        seq_start_q=seq_start_q,
+                        seq_start_kv=seq_start_kv,
+                        alpha=alpha,
+                        scale=scale,
+                        num_targets=num_targets,
+                        max_attn_len=max_attn_len,
+                        contextual_seq_len=contextual_seq_len,
+                        n_targets=n_targets,
+                        uih_end=uih_end,
+                        HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+                        HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+                        HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+                        ALLOW_TF32=ALLOW_TF32,
+                        BLOCK_D_Q=BLOCK_D_Q,
+                        BLOCK_D_V=BLOCK_D_V,
+                        BLOCK_N=BLOCK_N,
+                        ENABLE_TMA=ENABLE_TMA,
+                    )
+                    if not ENABLE_TMA:
+                        K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+                        V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+                    end_n += BLOCK_N
+
+        if not ENABLE_TMA:
+            # rematerialize offsets to save registers
+            start_m = pid * BLOCK_M
+            offs_m = start_m + tl.arange(0, BLOCK_M)
+            offs_v_d = tl.arange(0, BLOCK_D_V)
+            off_o = Out + seq_start_q * stride_om + off_h * stride_oh
+            out_ptrs = off_o + offs_m[:, None] * stride_om + offs_v_d[None, :]
+            tl.store(out_ptrs, acc, mask=(offs_m < seq_len_q)[:, None])
+        else:
+            # Important: must cast to proper dtype. If acc is float32, but
+            # TMA descriptor specifies float16, the program will run
+            # without crashes but produce wrong results.
+            acc = acc.to(Out.dtype.element_ty)
+            # pyre-ignore [20]
+            tl.extra.cuda.experimental_device_tensormap_create2d(
+                # pyrefly: ignore [bad-argument-type]
+                desc_ptr=device_desc_o,
+                global_address=Out,
+                load_size=[BLOCK_M, BLOCK_D_V],
+                global_size=[seq_end_q.to(tl.int32), H * DimV],
+                element_ty=Out.dtype.element_ty,
+            )
+            # pyre-ignore [20]
+            tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_o)
+            tl._experimental_descriptor_store(
+                device_desc_o,
+                acc,
+                [
+                    (seq_start_q + pid * BLOCK_M).to(tl.int32),
+                    (off_h * stride_oh).to(tl.int32),
+                ],
+            )
+
+
+@triton_autotune(
+    configs=_get_fw_configs(),
+    key=[
+        "AUTOTUNE_Z",
+        "H",
+        "AUTOTUNE_MAX_SEQ_LEN",
+        "DimQ",
+        "DimV",
+    ],
+)
+@triton.jit
+def _hstu_attn_fwd(  # noqa C901
+    Q,
+    K,
+    V,
+    workspace_ptr,
+    sort_by_length_indices,
+    seq_offsets,
+    seq_offsets_q,
+    Out,
+    alpha,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_om,
+    stride_oh,
+    Z,
+    AUTOTUNE_Z,
+    H,
+    attn_scale,
+    AUTOTUNE_MAX_SEQ_LEN,  # Quantized MAX_SEQ_LEN used as an autotuning key
+    DimQ,
+    DimV,
+    num_targets,
+    max_attn_len,
+    contextual_seq_len,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HAS_SORT_BY_LENGTH_INDICES: tl.constexpr,
+    ENABLE_TMA: tl.constexpr,
+    TMA_DESC_SIZE: tl.constexpr,
+):
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    if HAS_SORT_BY_LENGTH_INDICES:
+        off_z = tl.load(sort_by_length_indices + off_z)
+    off_h = off_hz % H
+    pid = tl.program_id(0)
+    _hstu_attn_fwd_compute(
+        Q=Q,
+        K=K,
+        V=V,
+        H=H,
+        DimQ=DimQ,
+        DimV=DimV,
+        workspace_ptr=workspace_ptr,
+        seq_offsets=seq_offsets,
+        seq_offsets_q=seq_offsets_q,
+        Out=Out,
+        stride_qm=stride_qm,
+        stride_qh=stride_qh,
+        stride_kn=stride_kn,
+        stride_kh=stride_kh,
+        stride_vn=stride_vn,
+        stride_vh=stride_vh,
+        stride_om=stride_om,
+        stride_oh=stride_oh,
+        alpha=alpha,
+        attn_scale=attn_scale,
+        off_z=off_z,
+        off_h=off_h,
+        pid=pid,
+        num_targets=num_targets,
+        max_attn_len=max_attn_len,
+        contextual_seq_len=contextual_seq_len,
+        HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+        HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+        HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+        ATTN_SCALE_TYPE=ATTN_SCALE_TYPE,
+        ALLOW_TF32=ALLOW_TF32,
+        BLOCK_D_Q=BLOCK_D_Q,
+        BLOCK_D_V=BLOCK_D_V,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        ENABLE_TMA=ENABLE_TMA,
+        TMA_DESC_SIZE=TMA_DESC_SIZE,
+    )
+
+
+@triton.jit
+def _hstu_attn_bwd_one_col_block(  # noqa C901
+    start_n,
+    seq_len_q,
+    seq_len_kv,
+    Q,
+    K,
+    V,
+    DOut,
+    DQ,
+    DK,
+    DV,
+    device_desc_q,
+    device_desc_k,
+    device_desc_v,
+    device_desc_do,
+    device_desc_dk,
+    device_desc_dv,
+    LOCK,
+    off_h,
+    off_z,
+    stride_qh,
+    stride_kh,
+    stride_vh,
+    stride_doh,
+    stride_dkh,
+    stride_dvh,
+    stride_qm,
+    stride_kn,
+    stride_vn,
+    stride_dom,
+    stride_dqm,
+    stride_dkn,
+    stride_dvn,
+    alpha,
+    attn_scale,
+    max_q_len,
+    seq_start_q,
+    num_targets,
+    max_attn_len,
+    contextual_seq_len,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    UNROLL: tl.constexpr,
+    ATOMIC_ADD: tl.constexpr,
+    ENABLE_TMA: tl.constexpr,
+):
+    offs_m = tl.arange(0, BLOCK_M)
+    offs_qk_d = tl.arange(0, BLOCK_D_Q)
+    offs_v_d = tl.arange(0, BLOCK_D_V)
+    offs_n = start_n + tl.arange(0, BLOCK_N)
+
+    dq_ptrs_trans = DQ + (offs_m[None, :] * stride_dqm + offs_qk_d[:, None])
+    dv = tl.zeros([BLOCK_N, BLOCK_D_V], dtype=tl.float32)
+    dk = tl.zeros([BLOCK_N, BLOCK_D_Q], dtype=tl.float32)
+    if ENABLE_TMA:
+        q_ptrs_trans = None
+        do_ptrs = None
+        k = tl._experimental_descriptor_load(
+            device_desc_k,
+            [start_n, (off_h * stride_kh).to(tl.int32)],
+            [BLOCK_N, BLOCK_D_Q],
+            K.dtype.element_ty,
+        )
+        v = tl._experimental_descriptor_load(
+            device_desc_v,
+            [start_n, (off_h * stride_vh).to(tl.int32)],
+            [BLOCK_N, BLOCK_D_V],
+            V.dtype.element_ty,
+        )
+    else:
+        mask_n = offs_n < seq_len_kv
+        q_ptrs_trans = Q + (offs_m[None, :] * stride_qm + offs_qk_d[:, None])
+        do_ptrs = DOut + (offs_m[:, None] * stride_dom + offs_v_d[None, :])
+        k_ptrs = K + (offs_n[:, None] * stride_kn + offs_qk_d[None, :])
+        v_ptrs = V + (offs_n[:, None] * stride_vn + offs_v_d[None, :])
+        k = tl.load(k_ptrs, mask=mask_n[:, None], other=0.0)
+        v = tl.load(v_ptrs, mask=mask_n[:, None], other=0.0)
+    n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
+    max_ids, pos_offs_n = backward_off_common_preprocess(
+        seq_len_q,
+        contextual_seq_len,
+        n_targets,
+        offs_n,
+        HAS_CONTEXTUAL_SEQ_LEN,
+        HAS_NUM_TARGETS,
+    )
+    if HAS_CONTEXTUAL_SEQ_LEN:
+        low = 0
+        high = contextual_seq_len
+        for start_m in tl.range(low, high, BLOCK_M):
+            start_m = tl.multiple_of(start_m, BLOCK_M)
+            dk, dv = _hstu_attn_bwd_one_block_0(
+                start_m=start_m,
+                offs_n=offs_n,
+                offs_m=offs_m,
+                q_ptrs_trans=q_ptrs_trans,
+                dq_ptrs_trans=dq_ptrs_trans,
+                do_ptrs=do_ptrs,
+                device_desc_q=device_desc_q,
+                device_desc_do=device_desc_do,
+                dk=dk,
+                dv=dv,
+                k=k,
+                v=v,
+                seq_len_q=seq_len_q,
+                seq_len_kv=seq_len_kv,
+                LOCK=LOCK,
+                off_h=off_h,
+                stride_qh=stride_qh,
+                stride_doh=stride_doh,
+                stride_qm=stride_qm,
+                stride_dom=stride_dom,
+                stride_dqm=stride_dqm,
+                alpha=alpha,
+                attn_scale=attn_scale,
+                max_q_len=max_q_len,
+                num_targets=num_targets,
+                max_attn_len=max_attn_len,
+                contextual_seq_len=contextual_seq_len,
+                n_targets=n_targets,
+                max_ids=max_ids,
+                pos_offs_n=pos_offs_n,
+                HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+                HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+                HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+                ATTN_SCALE_TYPE=ATTN_SCALE_TYPE,
+                ALLOW_TF32=ALLOW_TF32,
+                BLOCK_M=BLOCK_M,
+                ATOMIC_ADD=ATOMIC_ADD,
+                ENABLE_TMA=ENABLE_TMA,
+                BLOCK_D_Q=BLOCK_D_Q,
+                BLOCK_D_V=BLOCK_D_V,
+            )
+    if HAS_NUM_TARGETS:
+        low = start_n
+        if HAS_MAX_ATTN_LEN:
+            high = start_n + max_attn_len + BLOCK_N
+            high = high if high + n_targets < seq_len_q else seq_len_q
+        else:
+            high = seq_len_q
+    else:
+        low = start_n
+        if HAS_MAX_ATTN_LEN:
+            high = start_n + max_attn_len + BLOCK_N
+            high = high if high < seq_len_q else seq_len_q
+        else:
+            high = seq_len_q
+    if HAS_CONTEXTUAL_SEQ_LEN:
+        contextual_block_end = tl.cdiv(contextual_seq_len, BLOCK_M) * BLOCK_M
+        if low < contextual_block_end:
+            low = contextual_block_end
+    for start_m in tl.range(low, high, BLOCK_M, loop_unroll_factor=UNROLL):
+        start_m = tl.multiple_of(start_m, BLOCK_M)
+        dk, dv = _hstu_attn_bwd_one_block_0(
+            start_m=start_m,
+            offs_n=offs_n,
+            offs_m=offs_m,
+            q_ptrs_trans=q_ptrs_trans,
+            dq_ptrs_trans=dq_ptrs_trans,
+            do_ptrs=do_ptrs,
+            device_desc_q=device_desc_q,
+            device_desc_do=device_desc_do,
+            dk=dk,
+            dv=dv,
+            k=k,
+            v=v,
+            seq_len_q=seq_len_q,
+            seq_len_kv=seq_len_kv,
+            LOCK=LOCK,
+            off_h=off_h,
+            stride_qh=stride_qh,
+            stride_doh=stride_doh,
+            stride_qm=stride_qm,
+            stride_dom=stride_dom,
+            stride_dqm=stride_dqm,
+            alpha=alpha,
+            attn_scale=attn_scale,
+            max_q_len=max_q_len,
+            num_targets=num_targets,
+            max_attn_len=max_attn_len,
+            contextual_seq_len=contextual_seq_len,
+            n_targets=n_targets,
+            max_ids=max_ids,
+            pos_offs_n=pos_offs_n,
+            HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+            HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+            HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+            ATTN_SCALE_TYPE=ATTN_SCALE_TYPE,
+            ALLOW_TF32=ALLOW_TF32,
+            BLOCK_M=BLOCK_M,
+            ATOMIC_ADD=ATOMIC_ADD,
+            ENABLE_TMA=ENABLE_TMA,
+            BLOCK_D_Q=BLOCK_D_Q,
+            BLOCK_D_V=BLOCK_D_V,
+        )
+    # write-back
+    dk = dk * alpha
+    if ENABLE_TMA:
+        tl._experimental_descriptor_store(
+            device_desc_dv,
+            dv.to(k.dtype),
+            [start_n, (off_h * stride_dvh).to(tl.int32)],
+        )
+        tl._experimental_descriptor_store(
+            device_desc_dk,
+            dk.to(k.dtype),
+            [start_n, (off_h * stride_dkh).to(tl.int32)],
+        )
+    else:
+        dv_ptrs = DV + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
+        dk_ptrs = DK + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
+        tl.store(dv_ptrs, dv.to(k.dtype), mask=mask_n[:, None])  # pyre-ignore[61]
+        tl.store(dk_ptrs, dk.to(k.dtype), mask=mask_n[:, None])  # pyre-ignore[61]
+
+
+@triton_autotune(
+    configs=_get_bw_configs(),
+    key=[
+        "AUTOTUNE_Z",
+        "H",
+        "AUTOTUNE_MAX_SEQ_LEN",
+        "DimQ",
+        "DimV",
+    ],
+)
+@triton.jit
+def _hstu_attn_bwd(  # noqa C901
+    Q,
+    K,
+    V,
+    tma_workspace_ptr,
+    sort_by_length_indices,
+    seq_offsets,
+    seq_offsets_q,
+    DOut,
+    DQ,
+    DK,
+    DV,
+    LOCK,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_dom,
+    stride_doh,
+    stride_dqm,
+    stride_dqh,
+    stride_dkn,
+    stride_dkh,
+    stride_dvn,
+    stride_dvh,
+    alpha,
+    attn_scale,
+    Z,
+    AUTOTUNE_Z,
+    H,
+    max_q_len,
+    AUTOTUNE_MAX_SEQ_LEN,  # Quantized MAX_SEQ_LEN used as an autotuning key
+    DimQ,
+    DimV,
+    num_targets,
+    max_attn_len,
+    contextual_seq_len,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    SEQUENCE_PARALLEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    UNROLL: tl.constexpr,
+    HAS_SORT_BY_LENGTH_INDICES: tl.constexpr,
+    ENABLE_TMA: tl.constexpr,
+    TMA_DESC_SIZE: tl.constexpr,
+):
+    off_hz = tl.program_id(0)
+    off_z = off_hz // H
+    if HAS_SORT_BY_LENGTH_INDICES:
+        off_z = tl.load(sort_by_length_indices + off_z)
+    off_h = off_hz % H
+    off_h = off_h.to(tl.int64)
+    seq_start_kv = tl.load(seq_offsets + off_z).to(tl.int64)
+    seq_end_kv = tl.load(seq_offsets + off_z + 1)
+    seq_len_kv = (seq_end_kv - seq_start_kv).to(tl.int32)
+    seq_start_q = tl.load(seq_offsets_q + off_z).to(tl.int64)
+    seq_end_q = tl.load(seq_offsets_q + off_z + 1)
+    seq_len_q = (seq_end_q - seq_start_q).to(tl.int32)
+    # offset pointers for batch/head
+    Q = Q + seq_start_q * stride_qm
+    K = K + seq_start_kv * stride_kn
+    V = V + seq_start_kv * stride_vn
+    DOut = DOut + seq_start_q * stride_dom
+    DQ = DQ + seq_start_q * stride_dqm + off_h * stride_dqh
+    DK = DK + seq_start_kv * stride_dkn
+    DV = DV + seq_start_kv * stride_dvn
+    device_desc_q = None
+    device_desc_k = None
+    device_desc_v = None
+    device_desc_do = None
+    device_desc_dk = None
+    device_desc_dv = None
+    if ENABLE_TMA:
+        workspace_base = tma_workspace_ptr + TMA_DESC_SIZE * 6 * (
+            tl.program_id(1) + tl.program_id(0) * tl.num_programs(1)
+        )
+        device_desc_q = workspace_base
+        device_desc_k = workspace_base + 1 * TMA_DESC_SIZE
+        device_desc_v = workspace_base + 2 * TMA_DESC_SIZE
+        device_desc_do = workspace_base + 3 * TMA_DESC_SIZE
+        device_desc_dk = workspace_base + 4 * TMA_DESC_SIZE
+        device_desc_dv = workspace_base + 5 * TMA_DESC_SIZE
+
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_device_tensormap_create2d(
+            desc_ptr=device_desc_q,
+            global_address=Q,
+            load_size=[
+                BLOCK_M,
+                BLOCK_D_Q,
+            ],
+            global_size=[seq_len_q, H * DimQ],
+            element_ty=Q.dtype.element_ty,
+        )
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_q)
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_device_tensormap_create2d(
+            desc_ptr=device_desc_do,
+            global_address=DOut,
+            load_size=[
+                BLOCK_M,
+                BLOCK_D_V,
+            ],
+            global_size=[seq_len_q, H * DimV],
+            element_ty=DOut.dtype.element_ty,
+        )
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_do)
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_device_tensormap_create2d(
+            desc_ptr=device_desc_k,
+            global_address=K,
+            load_size=[
+                BLOCK_N,
+                BLOCK_D_Q,
+            ],
+            global_size=[seq_len_kv, H * DimQ],
+            element_ty=K.dtype.element_ty,
+        )
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_k)
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_device_tensormap_create2d(
+            desc_ptr=device_desc_dk,
+            global_address=DK,
+            load_size=[
+                BLOCK_N,
+                BLOCK_D_Q,
+            ],
+            global_size=[seq_len_kv, H * DimQ],
+            element_ty=DK.dtype.element_ty,
+        )
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_dk)
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_device_tensormap_create2d(
+            desc_ptr=device_desc_v,
+            global_address=V,
+            load_size=[
+                BLOCK_N,
+                BLOCK_D_V,
+            ],
+            global_size=[seq_len_kv, H * DimV],
+            element_ty=V.dtype.element_ty,
+        )
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_v)
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_device_tensormap_create2d(
+            desc_ptr=device_desc_dv,
+            global_address=DV,
+            load_size=[
+                BLOCK_N,
+                BLOCK_D_V,
+            ],
+            global_size=[seq_len_kv, H * DimV],
+            element_ty=DV.dtype.element_ty,
+        )
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_dv)
+    else:
+        Q += off_h * stride_qh
+        K += off_h * stride_kh
+        V += off_h * stride_vh
+        DOut += off_h * stride_doh
+        DK += off_h * stride_dkh
+        DV += off_h * stride_dvh
+    if SEQUENCE_PARALLEL:
+        start_n = tl.program_id(1) * BLOCK_N
+        if start_n >= seq_len_kv:
+            return
+        _hstu_attn_bwd_one_col_block(
+            start_n=start_n,
+            seq_len_q=seq_len_q,
+            seq_len_kv=seq_len_kv,
+            Q=Q,
+            K=K,
+            V=V,
+            DOut=DOut,
+            DQ=DQ,
+            DK=DK,
+            DV=DV,
+            device_desc_q=device_desc_q,
+            device_desc_k=device_desc_k,
+            device_desc_v=device_desc_v,
+            device_desc_do=device_desc_do,
+            device_desc_dk=device_desc_dk,
+            device_desc_dv=device_desc_dv,
+            LOCK=LOCK,
+            off_h=off_h,
+            off_z=off_z,
+            stride_qh=stride_qh,
+            stride_kh=stride_kh,
+            stride_vh=stride_vh,
+            stride_doh=stride_doh,
+            stride_dkh=stride_dkh,
+            stride_dvh=stride_dvh,
+            stride_qm=stride_qm,
+            stride_kn=stride_kn,
+            stride_vn=stride_vn,
+            stride_dom=stride_dom,
+            stride_dqm=stride_dqm,
+            stride_dkn=stride_dkn,
+            stride_dvn=stride_dvn,
+            alpha=alpha,
+            attn_scale=attn_scale,
+            max_q_len=max_q_len,
+            seq_start_q=seq_start_q,
+            num_targets=num_targets,
+            max_attn_len=max_attn_len,
+            contextual_seq_len=contextual_seq_len,
+            HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+            HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+            HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+            ATTN_SCALE_TYPE=ATTN_SCALE_TYPE,
+            ALLOW_TF32=ALLOW_TF32,
+            BLOCK_D_Q=BLOCK_D_Q,
+            BLOCK_D_V=BLOCK_D_V,
+            BLOCK_M=BLOCK_M,
+            BLOCK_N=BLOCK_N,
+            UNROLL=UNROLL,
+            ATOMIC_ADD=True,
+            ENABLE_TMA=ENABLE_TMA,
+        )
+    else:
+        for start_n in range(0, seq_len_kv, BLOCK_N):
+            _hstu_attn_bwd_one_col_block(
+                start_n=start_n,
+                seq_len_q=seq_len_q,
+                seq_len_kv=seq_len_kv,
+                Q=Q,
+                K=K,
+                V=V,
+                DOut=DOut,
+                DQ=DQ,
+                DK=DK,
+                DV=DV,
+                device_desc_q=device_desc_q,
+                device_desc_k=device_desc_k,
+                device_desc_v=device_desc_v,
+                device_desc_do=device_desc_do,
+                device_desc_dk=device_desc_dk,
+                device_desc_dv=device_desc_dv,
+                LOCK=LOCK,
+                off_h=off_h,
+                off_z=off_z,
+                stride_qh=stride_qh,
+                stride_kh=stride_kh,
+                stride_vh=stride_vh,
+                stride_doh=stride_doh,
+                stride_dkh=stride_dkh,
+                stride_dvh=stride_dvh,
+                stride_qm=stride_qm,
+                stride_kn=stride_kn,
+                stride_vn=stride_vn,
+                stride_dom=stride_dom,
+                stride_dqm=stride_dqm,
+                stride_dkn=stride_dkn,
+                stride_dvn=stride_dvn,
+                alpha=alpha,
+                attn_scale=attn_scale,
+                max_q_len=max_q_len,
+                seq_start_q=seq_start_q,
+                num_targets=num_targets,
+                max_attn_len=max_attn_len,
+                contextual_seq_len=contextual_seq_len,
+                HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+                HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+                HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+                ATTN_SCALE_TYPE=ATTN_SCALE_TYPE,
+                ALLOW_TF32=ALLOW_TF32,
+                BLOCK_D_Q=BLOCK_D_Q,
+                BLOCK_D_V=BLOCK_D_V,
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+                UNROLL=UNROLL,
+                ATOMIC_ADD=False,
+                ENABLE_TMA=ENABLE_TMA,
+            )
+
+
+def triton_hstu_attention_fwd(
+    max_seq_len: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    attn_scale: torch.Tensor,
+    max_q_len: Optional[int],
+    seq_offsets_q: Optional[torch.Tensor],
+    sort_by_length_indices: Optional[torch.Tensor],
+    enable_tma: bool,
+    num_targets: Optional[torch.Tensor],
+    max_attn_len: int,
+    contextual_seq_len: int,
+) -> torch.Tensor:
+    q = switch_to_contiguous_if_needed(q)
+    k = switch_to_contiguous_if_needed(k)
+    v = switch_to_contiguous_if_needed(v)
+    Z = seq_offsets.numel() - 1
+    AUTOTUNE_Z = prev_power_of_2(Z)
+    if max_q_len is None:
+        max_q_len = max_seq_len
+        assert seq_offsets_q is None
+        seq_offsets_q = seq_offsets
+    total_seq_len_q, H, DimQ = q.shape
+    _, _, DimV = v.shape
+    out = torch.empty(total_seq_len_q, H, DimV, device=q.device, dtype=q.dtype)
+    if total_seq_len_q == 0:
+        return out
+    TMA_DESC_SIZE = 128
+    workspace = None
+    if enable_tma:
+        MIN_BLOCK_M = 16
+        workspace = torch.empty(
+            4 * TMA_DESC_SIZE * (triton.cdiv(max_q_len, MIN_BLOCK_M) * Z * H),
+            dtype=torch.uint8,
+            device="cuda",
+        )
+    if attn_scale.ndim == 0:
+        attn_scale_type = "scalar"
+    else:
+        attn_scale_type = "dynamic"
+    grid = lambda meta: (  # noqa E731
+        triton.cdiv(max_q_len, meta["BLOCK_M"]),
+        Z * H,
+    )
+    HAS_NUM_TARGETS = num_targets is not None
+    HAS_MAX_ATTN_LEN = max_attn_len != 0
+    HAS_CONTEXTUAL_SEQ_LEN = contextual_seq_len != 0
+    _hstu_attn_fwd[grid](
+        Q=q,
+        K=k,
+        V=v,
+        workspace_ptr=workspace,
+        sort_by_length_indices=sort_by_length_indices,
+        seq_offsets=seq_offsets,
+        seq_offsets_q=seq_offsets_q,
+        Out=out,
+        alpha=alpha,
+        stride_qm=q.stride(0),
+        stride_qh=q.stride(1),
+        stride_kn=k.stride(0),
+        stride_kh=k.stride(1),
+        stride_vn=v.stride(0),
+        stride_vh=v.stride(1),
+        stride_om=out.stride(0),
+        stride_oh=out.stride(1),
+        attn_scale=attn_scale,
+        Z=Z,
+        AUTOTUNE_Z=AUTOTUNE_Z,
+        H=H,
+        AUTOTUNE_MAX_SEQ_LEN=autotune_max_seq_len(max_seq_len),
+        DimQ=DimQ,
+        DimV=DimV,
+        num_targets=num_targets,
+        max_attn_len=max_attn_len,
+        contextual_seq_len=contextual_seq_len,
+        HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+        HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+        HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+        ATTN_SCALE_TYPE=attn_scale_type,
+        ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+        BLOCK_D_Q=DimQ,
+        BLOCK_D_V=DimV,
+        HAS_SORT_BY_LENGTH_INDICES=sort_by_length_indices is not None,
+        ENABLE_TMA=enable_tma,
+        TMA_DESC_SIZE=TMA_DESC_SIZE,
+    )
+    return out
+
+
+def triton_hstu_attention_bwd(
+    dout: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    dv: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    attn_scale: torch.Tensor,
+    max_seq_len: int,
+    alpha: float,
+    max_q_len: Optional[int],
+    seq_offsets_q: Optional[torch.Tensor],
+    sort_by_length_indices: Optional[torch.Tensor],
+    enable_tma: bool,
+    num_targets: Optional[torch.Tensor],
+    max_attn_len: int,
+    contextual_seq_len: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    dout = switch_to_contiguous_if_needed(dout)
+    dq = switch_to_contiguous_if_needed(dq)
+    dk = switch_to_contiguous_if_needed(dk)
+    dv = switch_to_contiguous_if_needed(dv)
+    if dout.shape[0] == 0:
+        return torch.zeros_like(q), torch.zeros_like(k), torch.zeros_like(v)
+    Z = seq_offsets.numel() - 1
+    if max_q_len is None:
+        max_q_len = max_seq_len
+        assert seq_offsets_q is None
+        seq_offsets_q = seq_offsets
+    _, H, DimQ = q.shape
+    _, _, DimV = v.shape
+    if attn_scale.ndim == 0:
+        attn_scale_type = "scalar"
+    else:
+        attn_scale_type = "dynamic"
+    grid = lambda meta: (  # noqa E731
+        Z * H,
+        (triton.cdiv(max_seq_len, meta["BLOCK_N"]) if meta["SEQUENCE_PARALLEL"] else 1),
+    )
+    # The minimum size of BLOCK_M used in `_get_bw_configs`.
+    # TODO (linjianma): avoid hardcoding the value.
+    MIN_BLOCK_M = 16
+    lock = torch.empty(
+        (Z * H, triton.cdiv(max_q_len, MIN_BLOCK_M)),
+        dtype=torch.int32,
+        device=q.device,
+    )
+    AUTOTUNE_Z = prev_power_of_2(Z)
+    TMA_DESC_SIZE = 128
+    tma_workspace = None
+    if enable_tma:
+        MIN_BLOCK_N = 16
+        tma_workspace = torch.empty(
+            6 * TMA_DESC_SIZE * (triton.cdiv(max_seq_len, MIN_BLOCK_N) * Z * H),
+            dtype=torch.uint8,
+            device="cuda",
+        )
+    HAS_NUM_TARGETS = num_targets is not None
+    HAS_MAX_ATTN_LEN = max_attn_len != 0
+    HAS_CONTEXTUAL_SEQ_LEN = contextual_seq_len != 0
+    _hstu_attn_bwd[grid](
+        Q=q,
+        K=k,
+        V=v,
+        tma_workspace_ptr=tma_workspace,
+        sort_by_length_indices=sort_by_length_indices,
+        seq_offsets=seq_offsets,
+        seq_offsets_q=seq_offsets_q,
+        DOut=dout,
+        DQ=dq,
+        DK=dk,
+        DV=dv,
+        LOCK=lock,
+        stride_qm=q.stride(0),
+        stride_qh=q.stride(1),
+        stride_kn=k.stride(0),
+        stride_kh=k.stride(1),
+        stride_vn=v.stride(0),
+        stride_vh=v.stride(1),
+        stride_dom=dout.stride(0),
+        stride_doh=dout.stride(1),
+        stride_dqm=dq.stride(0),
+        stride_dqh=dq.stride(1),
+        stride_dkn=dk.stride(0),
+        stride_dkh=dk.stride(1),
+        stride_dvn=dv.stride(0),
+        stride_dvh=dv.stride(1),
+        alpha=alpha,
+        attn_scale=attn_scale,
+        Z=Z,
+        AUTOTUNE_Z=AUTOTUNE_Z,
+        H=H,
+        max_q_len=max_q_len,
+        AUTOTUNE_MAX_SEQ_LEN=autotune_max_seq_len(max_seq_len),
+        DimQ=DimQ,
+        DimV=DimV,
+        num_targets=num_targets,
+        max_attn_len=max_attn_len,
+        contextual_seq_len=contextual_seq_len,
+        HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+        HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+        HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+        ATTN_SCALE_TYPE=attn_scale_type,
+        ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+        BLOCK_D_Q=DimQ,
+        BLOCK_D_V=DimV,
+        HAS_SORT_BY_LENGTH_INDICES=sort_by_length_indices is not None,
+        ENABLE_TMA=enable_tma,
+        TMA_DESC_SIZE=TMA_DESC_SIZE,
+    )
+
+    return dq, dk, dv
+
+
+class _AttentionFunction(torch.autograd.Function):
+    @staticmethod
+    # pyre-ignore[14]
+    def forward(
+        ctx,
+        max_seq_len: int,
+        alpha: float,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        seq_offsets: torch.Tensor,
+        attn_scale: torch.Tensor,
+        max_q_len: Optional[int],
+        seq_offsets_q: Optional[torch.Tensor],
+        sort_by_length: bool,
+        enable_tma: bool,
+        num_targets: Optional[torch.Tensor],
+        max_attn_len: int,
+        contextual_seq_len: int,
+    ) -> torch.Tensor:
+        sort_by_length_indices = None
+        if sort_by_length:
+            seq_lengths = seq_offsets[1:] - seq_offsets[:-1]
+            _, sort_by_length_indices = torch.sort(
+                seq_lengths, descending=True, stable=False
+            )
+        saved_tensors = [q, k, v, seq_offsets, attn_scale]
+        if sort_by_length_indices is not None:
+            saved_tensors.append(sort_by_length_indices)
+        if seq_offsets_q is not None:
+            saved_tensors.append(seq_offsets_q)
+        if num_targets is not None:
+            saved_tensors.append(num_targets)
+        ctx.has_num_targets = num_targets is not None
+        ctx.max_attn_len = max_attn_len
+        ctx.contextual_seq_len = contextual_seq_len
+
+        ctx.alpha = alpha
+        ctx.max_seq_len = max_seq_len
+        ctx.max_q_len = max_q_len
+        ctx.sort_by_length = sort_by_length
+        ctx.enable_tma = enable_tma
+        out = triton_hstu_attention_fwd(
+            max_seq_len=max_seq_len,
+            alpha=alpha,
+            q=q,
+            k=k,
+            v=v,
+            seq_offsets=seq_offsets,
+            attn_scale=attn_scale,
+            max_q_len=max_q_len,
+            seq_offsets_q=seq_offsets_q,
+            sort_by_length_indices=sort_by_length_indices,
+            enable_tma=enable_tma,
+            num_targets=num_targets,
+            max_attn_len=max_attn_len,
+            contextual_seq_len=contextual_seq_len,
+        )
+        saved_tensors.append(out)
+        ctx.save_for_backward(*saved_tensors)
+        return out
+
+    @staticmethod
+    # pyre-ignore[14]
+    def backward(
+        ctx, dout: torch.Tensor
+    ) -> Tuple[
+        None,
+        None,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    ]:
+        saved_tensors = ctx.saved_tensors
+        q, k, v, seq_offsets, attn_scale = saved_tensors[:5]
+        idx = 5
+        if ctx.sort_by_length:
+            sort_by_length_indices = saved_tensors[idx]
+            idx += 1
+        else:
+            sort_by_length_indices = None
+        if ctx.max_q_len is not None:
+            seq_offsets_q = saved_tensors[idx]
+            idx += 1
+        else:
+            seq_offsets_q = None
+        if ctx.has_num_targets:
+            num_targets = ctx.saved_tensors[idx]
+            idx += 1
+        else:
+            num_targets = None
+        max_attn_len = ctx.max_attn_len
+        contextual_seq_len = ctx.contextual_seq_len
+
+        dq = torch.empty_like(q)
+        dk = torch.empty_like(k)
+        dv = torch.empty_like(v)
+        dq, dk, dv = triton_hstu_attention_bwd(
+            dout=dout,
+            q=q,
+            k=k,
+            v=v,
+            dq=dq,
+            dk=dk,
+            dv=dv,
+            seq_offsets=seq_offsets,
+            attn_scale=attn_scale,
+            max_seq_len=ctx.max_seq_len,
+            alpha=ctx.alpha,
+            max_q_len=ctx.max_q_len,
+            seq_offsets_q=seq_offsets_q,
+            sort_by_length_indices=sort_by_length_indices,
+            enable_tma=ctx.enable_tma,
+            num_targets=num_targets,
+            max_attn_len=max_attn_len,
+            contextual_seq_len=contextual_seq_len,
+        )
+        return (
+            None,
+            None,
+            dq,
+            dk,
+            dv,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+@torch.fx.wrap
+def triton_hstu_mha(
+    max_seq_len: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    attn_scale: torch.Tensor,
+    max_q_len: Optional[int] = None,
+    seq_offsets_q: Optional[torch.Tensor] = None,
+    enable_tma: bool = False,
+    sort_by_length: bool = False,
+    num_targets: Optional[torch.Tensor] = None,
+    max_attn_len: int = 0,
+    contextual_seq_len: int = 0,
+) -> torch.Tensor:
+    return _AttentionFunction.apply(
+        max_seq_len,
+        alpha,
+        q,
+        k,
+        v,
+        seq_offsets,
+        attn_scale,
+        max_q_len,
+        seq_offsets_q,
+        sort_by_length,
+        enable_tma,
+        num_targets,
+        max_attn_len,
+        contextual_seq_len,
+    )
+
+
+def triton_hstu_mha_wrapper(
+    max_seq_len: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+    attn_scale: torch.Tensor,
+    max_q_len: Optional[int] = None,
+    seq_offsets_q: Optional[torch.Tensor] = None,
+    enable_tma: bool = False,
+    sort_by_length: bool = False,
+    num_targets: Optional[torch.Tensor] = None,
+    max_attn_len: int = 0,
+    contextual_seq_len: int = 0,
+) -> torch.Tensor:
+    return triton_hstu_mha(
+        max_seq_len=max_seq_len,
+        alpha=alpha,
+        q=q,
+        k=k,
+        v=v,
+        seq_offsets=seq_offsets,
+        attn_scale=attn_scale,
+        max_q_len=max_q_len,
+        seq_offsets_q=seq_offsets_q,
+        enable_tma=enable_tma,
+        sort_by_length=sort_by_length,
+        num_targets=num_targets,
+        max_attn_len=max_attn_len,
+        contextual_seq_len=contextual_seq_len,
+    )

--- a/third_party/tlx/tutorials/test_self_attention_autows.py
+++ b/third_party/tlx/tutorials/test_self_attention_autows.py
@@ -1,0 +1,94 @@
+"""Correctness test for the HSTU SELF-attention forward under automatic warp
+specialization (meta-WS).
+
+Enables autoWS on the hammer-template Triton self-attn kernel via the
+`warp_specialize=True` annotation on the main KV loop (env HSTU_SELF_AUTOWS=1,
+baked as a tl.constexpr at import) and asserts the fwd output AND the dq/dk/dv
+gradients match a torch-autograd float causal-SiLU reference.
+
+Notes:
+- autoWS needs TRITON_USE_META_WS=1 + TRITON_DISABLE_WSBARRIER_REORDER=1; these
+  are set BEFORE importing the kernel so the constexpr/config pick see them.
+- HSTU_SELF_DP=1: data_partition_factor=2 would need BLOCK_M=256 (each slice
+  >=128 TMEM rows) which OOMs TMEM on this kernel, so DP is off here.
+- The TLX self-attn *fwd* uses num_stages=0 and asserts under meta-WS, so it
+  cannot be compiled in the same (META_WS) process; the accuracy oracle here is
+  the torch reference (as in test_cross_attention_bwd_autows.py).
+
+Run: pytest third_party/tlx/tutorials/test_self_attention_autows.py
+"""
+import math
+import os
+import sys
+
+_HSTU_DIR = os.path.join(os.path.dirname(__file__), "hstu_self_attn")
+sys.path.insert(0, _HSTU_DIR)
+
+# Enable autoWS + its env BEFORE importing the kernel (the flag/config are read
+# at import / first compile).
+os.environ["HSTU_SELF_AUTOWS"] = "1"
+os.environ["HSTU_SELF_DP"] = "1"
+os.environ["HSTU_SELF_PIN"] = "1"
+os.environ["TRITON_USE_META_WS"] = "1"
+os.environ["TRITON_DISABLE_WSBARRIER_REORDER"] = "1"
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+
+import triton_hstu_attention as A  # noqa: E402
+
+D = 128
+H = 2
+
+
+def _torch_ref(q, k, v, do, so, asc):
+    """Float autograd HSTU-SiLU causal self-attention reference."""
+    qf = q.detach().float().requires_grad_(True)
+    kf = k.detach().float().requires_grad_(True)
+    vf = v.detach().float().requires_grad_(True)
+    alpha, scale = 1.0 / D, asc.item()
+    outs = []
+    for z in range(so.numel() - 1):
+        s, e = int(so[z]), int(so[z + 1])
+        n = e - s
+        qk = torch.einsum("qhd,khd->hqk", qf[s:e], kf[s:e]) * alpha
+        sig = qk * torch.sigmoid(qk) * scale
+        i = torch.arange(n, device=qk.device)
+        sig = sig * (i[:, None] >= i[None, :]).float()[None]
+        outs.append(torch.einsum("hqk,khd->qhd", sig, vf[s:e]))
+    torch.cat(outs, 0).backward(do.float())
+    return qf.grad, kf.grad, vf.grad
+
+
+def _rel_l2(a, b):
+    return (torch.norm(a.float() - b.float()) / (torch.norm(b.float()) + 1e-12)).item()
+
+
+@pytest.mark.parametrize("L,Z", [(256, 4), (512, 2)])
+def test_self_attention_fwd_autows(L, Z):
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    assert bool(A._HSTU_SELF_AUTOWS), "autoWS flag not baked on"
+
+    torch.manual_seed(0)
+    t = Z * L
+    g = lambda: torch.randn(t, H, D, device="cuda", dtype=torch.bfloat16)
+    q, k, v = g().requires_grad_(True), g().requires_grad_(True), g().requires_grad_(True)
+    so = torch.arange(0, t + 1, L, device="cuda", dtype=torch.int64)
+    asc = torch.tensor(1.0 / L, device="cuda", dtype=torch.float32)
+    do = g()
+
+    rq, rk, rv = _torch_ref(q, k, v, do, so, asc)
+
+    for tsr in (q, k, v):
+        tsr.grad = None
+    o = A.triton_hstu_mha(
+        max_seq_len=L, alpha=1.0 / D, q=q, k=k, v=v, seq_offsets=so,
+        attn_scale=asc, enable_tma=True,
+    )
+    o.backward(do)
+    dq, dk, dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+
+    for name, got, want in (("dq", dq, rq), ("dk", dk, rk), ("dv", dv, rv)):
+        rl2 = _rel_l2(got, want)
+        assert rl2 < 1e-2, f"autoWS {name} rel-L2 {rl2:.2e} too high (L={L} Z={Z})"

--- a/third_party/tlx/tutorials/test_self_attention_bwd.py
+++ b/third_party/tlx/tutorials/test_self_attention_bwd.py
@@ -1,0 +1,54 @@
+"""Correctness test for the HSTU SELF-attention BACKWARD: plain-Triton bwd vs the
+hand-written TLX bwd, and both vs a torch-autograd float causal-SiLU reference.
+
+Runs WITHOUT meta-WS (TRITON_USE_META_WS unset): the TLX self-attn fwd uses
+num_stages=0 and asserts under meta-WS, so this is the process where plain-Triton
+and TLX can coexist. (The autoWS variant is a separate process /
+test_self_attention_autows.py.) HSTU_SELF_PIN=1 pins the bwd autotune to one
+config so it compiles fast instead of building the ~29-config bwd space.
+
+Run: pytest third_party/tlx/tutorials/test_self_attention_bwd.py
+"""
+import os
+import sys
+
+_HSTU_DIR = os.path.join(os.path.dirname(__file__), "hstu_self_attn")
+sys.path.insert(0, _HSTU_DIR)
+
+# plain Triton + TLX (no autoWS, no meta-WS); TLX needs the wsbarrier-reorder off.
+os.environ.pop("HSTU_SELF_AUTOWS", None)
+os.environ.pop("TRITON_USE_META_WS", None)
+os.environ["HSTU_SELF_PIN"] = "1"
+os.environ["TRITON_DISABLE_WSBARRIER_REORDER"] = "1"
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+
+import bench_self as bs  # noqa: E402
+
+
+@pytest.mark.parametrize("L,Z", [(256, 4), (512, 2)])
+def test_self_attention_bwd_triton_vs_tlx(L, Z):
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    torch.manual_seed(0)
+    q, k, v, do, so, asc = bs.make(L, Z)
+    rq, rk, rv = bs.torch_ref(q, k, v, do, so, asc, causal=True)
+
+    _, dq_t, dk_t, dv_t = bs.grads(bs.run_triton, q, k, v, so, L, asc, do)
+    _, dq_x, dk_x, dv_x = bs.grads(bs.run_tlx, q, k, v, so, L, asc, do, causal=True)
+
+    # Each kernel's grads must match the torch-float reference (bf16 precision).
+    for name, got in (
+        ("triton dq", dq_t), ("triton dk", dk_t), ("triton dv", dv_t),
+        ("tlx dq", dq_x), ("tlx dk", dk_x), ("tlx dv", dv_x),
+    ):
+        want = {"dq": rq, "dk": rk, "dv": rv}[name.split()[1]]
+        rl2 = bs.rel_l2(got, want)
+        assert rl2 < 1e-2, f"{name} rel-L2 {rl2:.2e} too high (L={L} Z={Z})"
+
+    # TLX bwd must match the plain-Triton bwd (same math family).
+    for name, a, b in (("dq", dq_x, dq_t), ("dk", dk_x, dk_t), ("dv", dv_x, dv_t)):
+        rl2 = bs.rel_l2(a, b)
+        assert rl2 < 1e-2, f"tlx-vs-triton {name} rel-L2 {rl2:.2e} too high (L={L} Z={Z})"


### PR DESCRIPTION
Summary:

Ports the hammer HSTU SELF-attention kernels (fbcode/hammer/v2/ops/triton/
template/) to standalone OSS triton (MetaMain2) so they run without buck, and
adds the fwd/bwd correctness + perf harnesses. New dir
third_party/tlx/tutorials/hstu_self_attn/:
- triton_hstu_attention.py - hammer-template Triton self-attn (fwd+bwd)
- tlx_bw_hstu_attention.py  - hammer-template TLX Blackwell self-attn (fwd+bwd)
- triton_attention_utils.py, stubs.py (with the real acc_dq)
- bench_self.py, fwd_check.py, autows_check.py

Adds a pytest correctness test third_party/tlx/tutorials/test_self_attention_autows.py
(autoWS fwd output + dq/dk/dv vs a torch causal-SiLU reference; 2 shapes) and
wires it into third_party/nvidia/hopper/run_all.sh next to the cross-attention
autoWS test.

Only the fbcode leaf-dep imports were swapped for local stubs/relative imports;
kernel math is verbatim except one bug fix: the TLX fwd computed silu(y/2)
(~0.5x) due to a double-halve in _silu_inner_loop (redundant alpha*=0.5 before
fast_silu, which already applies the identity's *0.5); removed. After the fix TLX
fwd matches the Triton kernel (rel-L2 ~9e-5) and a torch reference (~2e-3); grads
match torch (~2e-3), causal.

Env-gated experiment knobs (default off = plain-Triton kernel unchanged):
- HSTU_SELF_AUTOWS=1: warp-specialize the main KV loop
  (tl.range(warp_specialize=...)) + select a WS-capable config. Correct; ~76
  TFLOPS fwd (behind TLX ~106 -- the gap is TLX's 2-MMA-group/register structure).
- HSTU_SELF_DP=N (default 2): data_partition_factor on the loop (autoWS analog of
  TLX replicate=NUM_MMA_GROUPS). Doubles the split dim to BLOCK_M=128*N so each
  slice is >= TMEM blockM (128). DP fires at BLOCK_M=256 but OOMs TMEM (compiler
  DP allocs the full pre-split tile vs TLX's per-group alloc) -- kept for when
  DP-aware per-partition TMEM allocation lands.
- HSTU_SELF_PIN=1: shrink fwd/bwd autotune to one config (fast tritonbench --mode
  bwd; avoids the ~29-config bwd autotune SIGTERM).

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D111731023


