### PR TITLE
[ci] add release testing yaml

### DIFF
--- a/.github/scripts/generate_release_testing_matrix.py
+++ b/.github/scripts/generate_release_testing_matrix.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import sys
+
+# Suites that can be released-tested, and the runners each one supports.
+SUITE_CONFIG = {
+    "tritonbench": {
+        "runners": ["h100", "mi350", "b200"],
+    },
+}
+
+RUNNER_FULL_NAMES = {
+    "h100": "linux-gcp-h100",
+    "mi350": "linux-fb-triton-mi350-1",
+    "b200": "nvidia-dgx-b200",
+}
+
+SUPPORTED_RUNNERS = {"h100", "mi350", "b200", "all"}
+SUPPORTED_TEST_TYPES = {"periodic", "single", "abtest"}
+
+
+def parse_csv(raw: str) -> list[str]:
+    if not raw:
+        return []
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def normalize_runners(runners: list[str]) -> list[str]:
+    if not runners or "all" in runners:
+        return []
+    return runners
+
+
+def validate_requested_values(
+    suites: list[str],
+    runners: list[str],
+    test_type: str,
+) -> None:
+    unknown_suites = [name for name in suites if name not in SUITE_CONFIG]
+    if unknown_suites:
+        raise ValueError(f"Unsupported suites: {', '.join(sorted(unknown_suites))}")
+
+    unknown_runners = [runner for runner in runners if runner not in SUPPORTED_RUNNERS]
+    if unknown_runners:
+        raise ValueError(f"Unsupported runners: {', '.join(sorted(unknown_runners))}")
+
+    if test_type not in SUPPORTED_TEST_TYPES:
+        raise ValueError(f"Unsupported test type: {test_type}")
+
+
+def select_suites(requested_suites: list[str]) -> list[str]:
+    if requested_suites:
+        return requested_suites
+    return ["tritonbench"]
+
+
+def filter_dimensions(
+    suite: str,
+    requested_runners: list[str],
+) -> list[dict[str, str]]:
+    config = SUITE_CONFIG[suite]
+    runners = list(config["runners"])
+
+    if requested_runners:
+        requested_runner_set = set(requested_runners)
+        runners = [runner for runner in runners if runner in requested_runner_set]
+
+    matrix_entries = []
+    for runner in runners:
+        matrix_entries.append({
+            "suite": suite,
+            "runner": runner,
+            "runner_full_name": RUNNER_FULL_NAMES[runner],
+        })
+    return matrix_entries
+
+
+def to_matrix(entries: list[dict[str, str]]) -> str:
+    return json.dumps({"include": entries}, separators=(",", ":"))
+
+
+def write_output(name: str, value: str) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
+    else:
+        print(f"{name}={value}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--suite", default="tritonbench")
+    parser.add_argument("--runners", default="")
+    parser.add_argument("--test-type", default="periodic")
+    parser.add_argument("--event-name", default="")
+    args = parser.parse_args()
+
+    requested_suites = parse_csv(args.suite)
+    requested_runners = normalize_runners(parse_csv(args.runners))
+
+    validate_requested_values(requested_suites, requested_runners, args.test_type)
+
+    suites = select_suites(requested_suites)
+
+    full_matrix_entries: list[dict[str, str]] = []
+    for suite in suites:
+        full_matrix_entries.extend(filter_dimensions(
+            suite,
+            requested_runners,
+        ))
+
+    write_output("test_matrix", to_matrix(full_matrix_entries))
+    write_output("has_test_suites", str(bool(full_matrix_entries)).lower())
+
+    if not full_matrix_entries:
+        sys.stderr.write("No benchmark matrix entries were generated.\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/_linux-release-testing.yml
+++ b/.github/workflows/_linux-release-testing.yml
@@ -1,0 +1,238 @@
+name: linux-release-testing
+on:
+  workflow_call:
+    secrets:
+      TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN:
+        required: True
+        description: |
+          Tritonbench Scribe Graph Access Token
+    inputs:
+      runner:
+        required: True
+        type: string
+        description: |
+          Runner to use for the benchmark (h100, mi350 or b200)
+      runner_full_name:
+        required: True
+        type: string
+        description: |
+          Full runner label to use for runs-on
+      test_type:
+        required: True
+        type: string
+        description: |
+          Type of the test (periodic, single or abtest)
+      suite:
+        required: True
+        type: string
+        description: |
+          Benchmark suite name
+      side_a_triton:
+        type: string
+        required: False
+        default: "facebookexperimental/triton"
+        description: |
+          Triton repository to test on side A, e.g., "facebookexperimental/triton"
+      side_a_commit:
+        type: string
+        required: False
+        default: "main"
+        description: |
+          Triton commit or tag to test on side A, e.g., "main"
+      side_b_triton:
+        type: string
+        required: False
+        default: "facebookexperimental/triton"
+        description: |
+          Triton repository to test on side B (abtest only)
+      side_b_commit:
+        type: string
+        required: False
+        default: "main"
+        description: |
+          Triton commit or tag to test on side B (abtest only)
+
+jobs:
+  linux-release-testing:
+    if: github.repository_owner == 'facebookexperimental'
+    runs-on: ${{ inputs.runner_full_name }}
+    timeout-minutes: 240
+    environment: docker-s3-upload
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      WORKSPACE_DIR: "/workspace"
+      SETUP_SCRIPT: "/workspace/setup_instance.sh"
+      TRITONBENCH_ROOT: "/workspace/tritonbench"
+      RUNNER_TYPE: ${{ inputs.runner_full_name }}
+      JOB_NAME: release-testing-${{ inputs.runner }}-${{ inputs.test_type }}-${{ inputs.suite }}
+      # For periodic runs side A is the standard meta-triton channel; for single /
+      # abtest it is the checked-out Triton source built into a dedicated env.
+      TRITON_SIDE_A_ENV: ${{ inputs.test_type != 'periodic' && 'triton-side-a' || 'meta-triton' }}
+      CONDA_ENV: ${{ inputs.test_type != 'periodic' && 'triton-side-a' || 'meta-triton' }}
+      TRITON_SIDE_B_ENV: "triton-side-b"
+      TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - name: Checkout Triton (Side A)
+        if: ${{ inputs.test_type != 'periodic' && inputs.side_a_triton && inputs.side_a_commit }}
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.side_a_triton }}
+          ref: ${{ inputs.side_a_commit }}
+          path: triton-side-a
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Checkout Triton (Side B)
+        if: ${{ inputs.test_type == 'abtest' && inputs.side_b_triton && inputs.side_b_commit }}
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.side_b_triton }}
+          ref: ${{ inputs.side_b_commit }}
+          path: triton-side-b
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Tune Nvidia GPU
+        if: ${{ inputs.runner == 'h100' || inputs.runner == 'b200' }}
+        run: |
+          sudo nvidia-smi -pm 1
+          sudo ldconfig
+          nvidia-smi
+
+      - name: Authenticate with AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results
+          role-duration-seconds: 18000
+          aws-region: us-east-1
+
+      - name: Setup tritonbench environment and compile Triton (Side A)
+        run: |
+          set -eux
+          if [ "${{ inputs.runner }}" = "h100" ] || [ "${{ inputs.runner }}" = "b200" ]; then
+            if [ "${{ inputs.test_type }}" = "periodic" ]; then
+              bash ${TRITONBENCH_ROOT}/.ci/triton/install.sh \
+                --conda-env "meta-triton" \
+                --repo facebookexperimental/triton \
+                --commit main \
+                --side single \
+                --nightly \
+                --no-clone \
+                --install-dir "${WORKSPACE_DIR}/meta-triton"
+            else
+              bash ${TRITONBENCH_ROOT}/.ci/triton/install.sh \
+                --conda-env "triton-side-a" \
+                --side a \
+                --install-dir "${GITHUB_WORKSPACE}/triton-side-a" \
+                --no-checkout
+              export TRITON_SIDE_A_ENV="triton-side-a"
+            fi
+            bash ${TRITONBENCH_ROOT}/.ci/tritonbench/setup-nvidia-path.sh
+            bash ${TRITONBENCH_ROOT}/.ci/tritonbench/install.sh --refresh-pytorch
+          elif [ "${{ inputs.runner }}" = "mi350" ]; then
+            TRITON_CHANNEL_ARGS=()
+            if [ "${{ inputs.test_type }}" = "periodic" ]; then
+              TRITON_CHANNEL_ARGS+=(--meta-triton)
+            else
+              TRITON_CHANNEL_ARGS+=(--custom-triton ${GITHUB_WORKSPACE}/triton-side-a)
+              export TRITON_SIDE_A_ENV="triton-side-a"
+            fi
+            CONDA_ENV="${TRITON_SIDE_A_ENV}" bash ${TRITONBENCH_ROOT}/.ci/tritonbench/setup-env.sh \
+              --hip \
+              "${TRITON_CHANNEL_ARGS[@]}"
+          else
+            echo "Unknown runner: ${{ inputs.runner }}"
+            exit 1
+          fi
+
+          echo "TRITON_SIDE_A_ENV=${TRITON_SIDE_A_ENV}" >> "${GITHUB_ENV}"
+          cat "${SETUP_SCRIPT}"
+
+      - name: Setup uploader dependencies
+        run: |
+          set -eux
+          . "${SETUP_SCRIPT}"
+          uv pip install --group ci
+
+      - name: Triton Testing (Side A)
+        run: |
+          set -eux
+          bash ${TRITONBENCH_ROOT}/.ci/tritonbench/run-benchmark.sh ${{ inputs.suite }} --conda-env "${TRITON_SIDE_A_ENV}"
+          mkdir -p benchmark-output
+          cp -r "${TRITONBENCH_ROOT}/.benchmarks/${{ inputs.suite }}" "benchmark-output/${TRITON_SIDE_A_ENV}"
+          sudo rm -rf "${TRITONBENCH_ROOT}/.benchmarks" || true
+
+      - name: Compile Triton side B
+        if: ${{ inputs.test_type == 'abtest' && inputs.side_b_triton && inputs.side_b_commit }}
+        run: |
+          set -eux
+          bash ${TRITONBENCH_ROOT}/.ci/triton/install.sh \
+            --conda-env "triton-side-b" \
+            --side b \
+            --install-dir "${GITHUB_WORKSPACE}/triton-side-b" \
+            --no-checkout
+          echo 'TRITON_SIDE_B_ENV=triton-side-b' >> "${GITHUB_ENV}"
+
+      - name: Triton Testing (Side B)
+        if: ${{ inputs.test_type == 'abtest' && inputs.side_b_triton && inputs.side_b_commit }}
+        run: |
+          set -eux
+          bash ${TRITONBENCH_ROOT}/.ci/tritonbench/run-benchmark.sh ${{ inputs.suite }} --conda-env "${TRITON_SIDE_B_ENV}"
+          mkdir -p benchmark-output
+          cp -r "${TRITONBENCH_ROOT}/.benchmarks/${{ inputs.suite }}" "benchmark-output/${TRITON_SIDE_B_ENV}"
+          sudo rm -rf "${TRITONBENCH_ROOT}/.benchmarks" || true
+
+      - name: Upload result to GH Actions Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.JOB_NAME }}
+          path: benchmark-output/
+
+      - name: Upload result to Scribe
+        if: ${{ contains(inputs.suite, 'tritonbench') }}
+        run: |
+          set -xeu
+          . "${SETUP_SCRIPT}"
+          if [[ -n "${TRITON_SIDE_A_ENV}" ]]; then
+            side_a_json=$(find "./benchmark-output/${TRITON_SIDE_A_ENV}" -name "result.json" | sort -r | head -n 1)
+            python3 ${TRITONBENCH_ROOT}/.ci/upload/scribe.py --json "${side_a_json}"
+          fi
+          if [[ -n "${TRITON_SIDE_B_ENV}" ]] && [[ -e "./benchmark-output/${TRITON_SIDE_B_ENV}" ]]; then
+            side_b_json=$(find "./benchmark-output/${TRITON_SIDE_B_ENV}" -name "result.json" | sort -r | head -n 1)
+            python3 ${TRITONBENCH_ROOT}/.ci/upload/scribe.py --json "${side_b_json}"
+          fi
+
+      - name: Rewrite Tritonbench json to ClickHouse style
+        if: ${{ contains(inputs.suite, 'tritonbench') }}
+        run: |
+          set -xeu
+          . "${SETUP_SCRIPT}"
+          if [[ -n "${TRITON_SIDE_A_ENV}" ]]; then
+            side_a_json=$(find "./benchmark-output/${TRITON_SIDE_A_ENV}" -name "result.json" | sort -r | head -n 1)
+            python3 ${TRITONBENCH_ROOT}/.ci/test_infra/oss_ci_benchmark_v3.py --json "${side_a_json}" \
+              --output "benchmark-output/clickhouse-results/result-${TRITON_SIDE_A_ENV}.json"
+          fi
+          if [[ -n "${TRITON_SIDE_B_ENV}" ]] && [[ -e "./benchmark-output/${TRITON_SIDE_B_ENV}" ]]; then
+            side_b_json=$(find "./benchmark-output/${TRITON_SIDE_B_ENV}" -name "result.json" | sort -r | head -n 1)
+            python3 ${TRITONBENCH_ROOT}/.ci/test_infra/oss_ci_benchmark_v3.py --json "${side_b_json}" \
+              --output "benchmark-output/clickhouse-results/result-${TRITON_SIDE_B_ENV}.json"
+          fi
+
+      - name: Upload result to ClickHouse
+        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@main
+        with:
+          benchmark-results-dir: benchmark-output/clickhouse-results
+          dry-run: false
+          schema-version: v3
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore Nvidia GPU
+        if: ${{ always() && (inputs.runner == 'h100' || inputs.runner == 'b200') }}
+        run: |
+          sudo nvidia-smi -pm 0 || true
+          sudo ldconfig
+          nvidia-smi

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -1,0 +1,110 @@
+name: Release Testing
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        type: string
+        required: false
+        description: 'Comma-separated benchmark suite(s) to run.'
+        default: 'tritonbench'
+      runners:
+        type: choice
+        required: true
+        description: 'Runner selection'
+        default: 'all'
+        options:
+          - 'all'
+          - 'h100'
+          - 'mi350'
+          - 'b200'
+      test_type:
+        type: choice
+        required: true
+        description: 'Choose advanced testing options'
+        default: 'periodic'
+        options:
+          - 'periodic'
+          - 'single'
+          - 'abtest'
+      side_a_triton:
+        type: string
+        required: false
+        description: 'Side A Triton repo'
+        default: 'facebookexperimental/triton'
+      side_a_commit:
+        type: string
+        required: false
+        description: 'Side A Triton commit'
+        default: 'main'
+      side_b_triton:
+        type: string
+        required: false
+        description: 'Side B Triton repo (abtest only)'
+        default: 'facebookexperimental/triton'
+      side_b_commit:
+        type: string
+        required: false
+        description: 'Side B Triton commit (abtest only)'
+        default: 'main'
+
+jobs:
+  set-parameters:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      test_matrix: ${{ steps.set-parameters.outputs.test_matrix }}
+      has_test_suites: ${{ steps.set-parameters.outputs.has_test_suites }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set parameters
+        id: set-parameters
+        shell: bash
+        env:
+          SUITE: ${{ inputs.suite || 'tritonbench' }}
+          RUNNERS: ${{ inputs.runners || 'all' }}
+          TEST_TYPE: ${{ inputs.test_type || 'periodic' }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -eux
+
+          python .github/scripts/generate_release_testing_matrix.py \
+            --suite "${SUITE}" \
+            --runners "${RUNNERS}" \
+            --test-type "${TEST_TYPE}" \
+            --event-name "${EVENT_NAME}"
+
+  release-testing:
+    permissions:
+      id-token: write
+      contents: read
+    needs: set-parameters
+    if: ${{ needs.set-parameters.outputs.has_test_suites == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-parameters.outputs.test_matrix) }}
+    uses: ./.github/workflows/_linux-release-testing.yml
+    with:
+      runner: ${{ matrix.runner }}
+      runner_full_name: ${{ matrix.runner_full_name }}
+      test_type: ${{ inputs.test_type || 'periodic' }}
+      suite: ${{ matrix.suite }}
+      side_a_triton: ${{ inputs.side_a_triton || 'facebookexperimental/triton' }}
+      side_a_commit: ${{ inputs.side_a_commit || 'main' }}
+      side_b_triton: ${{ inputs.side_b_triton || 'facebookexperimental/triton' }}
+      side_b_commit: ${{ inputs.side_b_commit || 'main' }}
+    secrets:
+      TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}-${{ github.event_name }}
+  cancel-in-progress: true


### PR DESCRIPTION
Migrate the abtesting workflows from Tritonbench repo to fbtriton.

Supports periodic/single-side/abtesting Tritonbench suites on given triton commits.

The data will be available at three places:

1. GitHub Action Artifacts
2. [Meta-Internal] Scuba table
3. [Public] PyTorch ClickHouse database