### PR TITLE
[TLX][AMD] Optimize paged decode for MI350: wide async tiles + tuned split-K

### DIFF
--- a/third_party/tlx/tutorials/amd_pa_decode.py
+++ b/third_party/tlx/tutorials/amd_pa_decode.py
@@ -37,6 +37,7 @@ def _pa_decode_partition_kernel(
     CtxLens,  # [num_seqs]
     Mid,  # [num_seqs, num_kv_heads, NUM_SPLITS, M_POW2, HEAD_DIM] (fp32)
     Lse,  # [num_seqs, num_kv_heads, NUM_SPLITS, M_POW2] (fp32)
+    Out,  # [num_tokens, num_q_heads, HEAD_DIM] (used only when FUSED)
     sm_scale,
     num_splits,  # runtime int (== grid dim 2)
     stride_q_t,
@@ -61,6 +62,9 @@ def _pa_decode_partition_kernel(
     stride_lse_h,
     stride_lse_k,
     stride_lse_m,
+    stride_o_t,
+    stride_o_h,
+    stride_o_d,
     HEAD_DIM: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -71,6 +75,7 @@ def _pa_decode_partition_kernel(
     QLEN: tl.constexpr,
     QLEN_POW2: tl.constexpr,
     M_POW2: tl.constexpr,
+    FUSED: tl.constexpr,
 ):
     seq = tl.program_id(0)
     kv_head = tl.program_id(1)
@@ -85,7 +90,6 @@ def _pa_decode_partition_kernel(
     offs_d = tl.arange(0, HEAD_DIM)
     offs_g = tl.arange(0, GROUP_POW2)
     offs_ql = tl.arange(0, QLEN_POW2)
-    offs_p = tl.arange(0, PAGE_SIZE)
     offs_n = tl.arange(0, BLOCK_N)
     offs_m = tl.arange(0, M_POW2)
 
@@ -99,7 +103,11 @@ def _pa_decode_partition_kernel(
     q = tl.reshape(q, (M_POW2, HEAD_DIM))
 
     QK_SCALE = sm_scale * 1.44269504089  # 1/log(2), for exp2-based softmax
+    # Pre-scale q once (M_POW2 x HEAD_DIM) so the q@k^T dot already yields
+    # scaled scores, instead of scaling the M_POW2 x BLOCK_N score matrix per tile.
+    q = (q.to(tl.float32) * QK_SCALE).to(Kc.dtype.element_ty)
     m_qpos = offs_m // GROUP_POW2  # query position per row
+    vis_limit = ctx_len - QLEN  # min visible abs key index over rows (m_qpos >= 0)
 
     m_i = tl.full([M_POW2], float("-inf"), tl.float32)
     l_i = tl.zeros([M_POW2], tl.float32)
@@ -108,103 +116,90 @@ def _pa_decode_partition_kernel(
     k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), Kc.dtype.element_ty, BUFFER_DEPTH)
     v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), Vc.dtype.element_ty, BUFFER_DEPTH)
 
-    if PAGES_PER_TILE == 4:
-        for pidx in tl.range(start_page, end_page, PAGES_PER_TILE):
-            k_view = tlx.local_view(k_buf, 0)
-            v_view = tlx.local_view(v_buf, 0)
-            logical_page = pidx + offs_n // PAGE_SIZE
-            safe_page = tl.minimum(logical_page, end_page - 1)
-            physical = tl.load(BlockTables + seq * stride_bt_s + safe_page * stride_bt_p)
-            page_row = offs_n % PAGE_SIZE
-            k_ptrs = (Kc + physical[:, None] * stride_kc_b + kv_head * stride_kc_h +
-                      page_row[:, None] * stride_kc_p + offs_d[None, :] * stride_kc_d)
-            v_ptrs = (Vc + physical[:, None] * stride_vc_b + kv_head * stride_vc_h +
-                      page_row[:, None] * stride_vc_p + offs_d[None, :] * stride_vc_d)
-            tlx.local_store(k_view, tl.load(k_ptrs))
-            tlx.local_store(v_view, tl.load(v_ptrs))
-            tl.debug_barrier()
-            kt = tlx.local_load(tlx.local_trans(k_view))
-            v = tlx.local_load(v_view)
-
-            qk = tl.dot(q, kt)
-            kt_abs = pidx * PAGE_SIZE + offs_n
-            vis = ((kt_abs[None, :] < end_page * PAGE_SIZE) &
-                   (kt_abs[None, :] <= (ctx_len - QLEN + m_qpos[:, None])))
-            qk = tl.where(vis, qk * QK_SCALE, float("-inf"))
-            m_ij = tl.max(qk, 1)
-            m_new = tl.maximum(m_i, m_ij)
-            p = tl.math.exp2(qk - m_new[:, None])
-            alpha = tl.math.exp2(m_i - m_new)
-            l_i = l_i * alpha + tl.sum(p, 1)
-            acc = acc * alpha[:, None] + tl.dot(p.to(v.dtype), v)
-            m_i = m_new
-            tl.debug_barrier()
-    elif start_page < end_page:
-        physical = tl.load(BlockTables + seq * stride_bt_s + start_page * stride_bt_p)
-        k_ptrs = (Kc + physical * stride_kc_b + kv_head * stride_kc_h + offs_p[:, None] * stride_kc_p +
-                  offs_d[None, :] * stride_kc_d)
-        v_ptrs = (Vc + physical * stride_vc_b + kv_head * stride_vc_h + offs_p[:, None] * stride_vc_p +
-                  offs_d[None, :] * stride_vc_d)
-        tok_k = tlx.async_load(k_ptrs, tlx.local_view(k_buf, 0))
-        tok_v = tlx.async_load(v_ptrs, tlx.local_view(v_buf, 0))
+    # Decouple the KV compute tile (BLOCK_N keys) from PAGE_SIZE: row r of a tile
+    # maps to logical page (tile_page0 + r // PAGE_SIZE) at offset (r % PAGE_SIZE),
+    # gathered in one async load so the MFMA K-dim stays BLOCK_N-wide even at
+    # small PAGE_SIZE. Depth-2 software pipeline: prefetch tile N+1 while computing
+    # tile N (wait_group(1) keeps only the prefetch outstanding).
+    row_page = offs_n // PAGE_SIZE
+    row_in_page = offs_n % PAGE_SIZE
+    num_tiles = tl.cdiv(end_page - start_page, PAGES_PER_TILE)
+    if num_tiles > 0:
+        physical = tl.load(BlockTables + seq * stride_bt_s +
+                           tl.where(row_page < end_page - start_page, start_page + row_page, end_page - 1) *
+                           stride_bt_p)
+        tok_k = tlx.async_load(
+            Kc + physical[:, None] * stride_kc_b + kv_head * stride_kc_h + row_in_page[:, None] * stride_kc_p +
+            offs_d[None, :] * stride_kc_d, tlx.local_view(k_buf, 0))
+        tok_v = tlx.async_load(
+            Vc + physical[:, None] * stride_vc_b + kv_head * stride_vc_h + row_in_page[:, None] * stride_vc_p +
+            offs_d[None, :] * stride_vc_d, tlx.local_view(v_buf, 0))
         tlx.async_load_commit_group([tok_k, tok_v])
 
-        num_pages_this_split = end_page - start_page
-        for rel_page in tl.range(0, num_pages_this_split - 1, num_stages=0):
-            slot_cur = rel_page % 2
-            slot_nxt = (rel_page + 1) % 2
-            wait_tok = tlx.async_load_wait_group(0)
-            kt = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, slot_cur)), token=wait_tok)
-            v = tlx.local_load(tlx.local_view(v_buf, slot_cur), token=wait_tok)
+        for tidx in tl.range(0, num_tiles):
+            slot = tidx % BUFFER_DEPTH
+            nxt = tidx + 1
+            if nxt < num_tiles:
+                nslot = nxt % BUFFER_DEPTH
+                n_page_of_row = start_page + nxt * PAGES_PER_TILE + row_page
+                n_physical = tl.load(BlockTables + seq * stride_bt_s +
+                                     tl.where(n_page_of_row < end_page, n_page_of_row, end_page - 1) * stride_bt_p)
+                ntok_k = tlx.async_load(
+                    Kc + n_physical[:, None] * stride_kc_b + kv_head * stride_kc_h +
+                    row_in_page[:, None] * stride_kc_p + offs_d[None, :] * stride_kc_d, tlx.local_view(k_buf, nslot))
+                ntok_v = tlx.async_load(
+                    Vc + n_physical[:, None] * stride_vc_b + kv_head * stride_vc_h +
+                    row_in_page[:, None] * stride_vc_p + offs_d[None, :] * stride_vc_d, tlx.local_view(v_buf, nslot))
+                tlx.async_load_commit_group([ntok_k, ntok_v])
+                tlx.async_load_wait_group(1)
+            else:
+                tlx.async_load_wait_group(0)
 
-            next_page = start_page + rel_page + 1
-            physical_next = tl.load(BlockTables + seq * stride_bt_s + next_page * stride_bt_p)
-            k_ptrs_next = (Kc + physical_next * stride_kc_b + kv_head * stride_kc_h +
-                           offs_p[:, None] * stride_kc_p + offs_d[None, :] * stride_kc_d)
-            v_ptrs_next = (Vc + physical_next * stride_vc_b + kv_head * stride_vc_h +
-                           offs_p[:, None] * stride_vc_p + offs_d[None, :] * stride_vc_d)
-            tok_k = tlx.async_load(k_ptrs_next, tlx.local_view(k_buf, slot_nxt))
-            tok_v = tlx.async_load(v_ptrs_next, tlx.local_view(v_buf, slot_nxt))
-            tlx.async_load_commit_group([tok_k, tok_v])
+            kt = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, slot)))
+            v = tlx.local_load(tlx.local_view(v_buf, slot))
 
-            pidx = start_page + rel_page
-            qk = tl.dot(q, kt)
-            kt_abs = pidx * PAGE_SIZE + offs_n
-            qk = tl.where(kt_abs[None, :] <= (ctx_len - QLEN + m_qpos[:, None]), qk * QK_SCALE, float("-inf"))
-            m_ij = tl.max(qk, 1)
+            tile_page0 = start_page + tidx * PAGES_PER_TILE
+            qk = tl.dot(q, kt)  # q pre-scaled -> qk already in log2 units
+            # An interior tile fully at/below the causal limit skips
+            # the per-element visibility compare + select; only boundary tiles pay.
+            tile_max_abs = tile_page0 * PAGE_SIZE + (BLOCK_N - 1)
+            is_full = (tile_max_abs <= vis_limit) & ((tile_page0 + PAGES_PER_TILE) <= end_page)
+            if is_full:
+                qks = qk
+            else:
+                page_ok = (tile_page0 + row_page) < end_page
+                kt_abs = tile_page0 * PAGE_SIZE + offs_n
+                vis = page_ok[None, :] & (kt_abs[None, :] <= (vis_limit + m_qpos[:, None]))
+                qks = tl.where(vis, qk, float("-inf"))
+            m_ij = tl.max(qks, 1)
             m_new = tl.maximum(m_i, m_ij)
-            p = tl.math.exp2(qk - m_new[:, None])
+            p = tl.math.exp2(qks - m_new[:, None])
             alpha = tl.math.exp2(m_i - m_new)
             l_i = l_i * alpha + tl.sum(p, 1)
             acc = acc * alpha[:, None] + tl.dot(p.to(v.dtype), v)
             m_i = m_new
 
-        last_rel_page = num_pages_this_split - 1
-        wait_tok = tlx.async_load_wait_group(0)
-        kt = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, last_rel_page % 2)), token=wait_tok)
-        v = tlx.local_load(tlx.local_view(v_buf, last_rel_page % 2), token=wait_tok)
-        last_page = start_page + last_rel_page
-        qk = tl.dot(q, kt)
-        kt_abs = last_page * PAGE_SIZE + offs_n
-        qk = tl.where(kt_abs[None, :] <= (ctx_len - QLEN + m_qpos[:, None]), qk * QK_SCALE, float("-inf"))
-        m_ij = tl.max(qk, 1)
-        m_new = tl.maximum(m_i, m_ij)
-        p = tl.math.exp2(qk - m_new[:, None])
-        alpha = tl.math.exp2(m_i - m_new)
-        l_i = l_i * alpha + tl.sum(p, 1)
-        acc = acc * alpha[:, None] + tl.dot(p.to(v.dtype), v)
-        m_i = m_new
-
-    # Store the normalized partial output + base-2 lse for this split.
     has_kv = l_i > 0.0
     o_part = tl.where(has_kv[:, None], acc / tl.where(has_kv[:, None], l_i[:, None], 1.0), 0.0)
-    lse_part = tl.where(has_kv, m_i + tl.math.log2(tl.where(has_kv, l_i, 1.0)), float("-inf"))
 
-    mid_ptrs = (Mid + seq * stride_mid_s + kv_head * stride_mid_h + split * stride_mid_k +
-                offs_m[:, None] * stride_mid_m + offs_d[None, :] * stride_mid_d)
-    tl.store(mid_ptrs, o_part)
-    lse_ptrs = Lse + seq * stride_lse_s + kv_head * stride_lse_h + split * stride_lse_k + offs_m * stride_lse_m
-    tl.store(lse_ptrs, lse_part)
+    if FUSED:
+        # Single split -> o_part is already the final normalized output, so
+        # write it straight to Out and skip the Mid/LSE round-trip + reduce launch.
+        qpos_m = offs_m // GROUP_POW2
+        hgrp_m = offs_m % GROUP_POW2
+        valid_m = (qpos_m < QLEN) & (hgrp_m < QUERY_GROUP_SIZE)
+        gt_m = seq * QLEN + qpos_m
+        qh_m = kv_head * QUERY_GROUP_SIZE + hgrp_m
+        out_ptrs = (Out + gt_m[:, None] * stride_o_t + qh_m[:, None] * stride_o_h + offs_d[None, :] * stride_o_d)
+        tl.store(out_ptrs, o_part.to(Out.dtype.element_ty), mask=valid_m[:, None])
+    else:
+        # Store the normalized partial output + base-2 lse for this split.
+        lse_part = tl.where(has_kv, m_i + tl.math.log2(tl.where(has_kv, l_i, 1.0)), float("-inf"))
+        mid_ptrs = (Mid + seq * stride_mid_s + kv_head * stride_mid_h + split * stride_mid_k +
+                    offs_m[:, None] * stride_mid_m + offs_d[None, :] * stride_mid_d)
+        tl.store(mid_ptrs, o_part)
+        lse_ptrs = Lse + seq * stride_lse_s + kv_head * stride_lse_h + split * stride_lse_k + offs_m * stride_lse_m
+        tl.store(lse_ptrs, lse_part)
 
 
 @triton.jit
@@ -269,23 +264,35 @@ def _next_pow2(x):
     return 1 << (max(1, x) - 1).bit_length()
 
 
-def get_num_splits(num_seqs, num_kv_heads, max_ctx_len=None, page_size=None, cap=128):
-    """Choose enough splits to expose CTA parallelism without creating empty work.
+def get_num_splits(num_seqs, num_kv_heads, max_ctx_len=None, page_size=None, pages_per_tile=1, cap=64):
+    """Choose the KV split-K count.
 
-    When the caller knows the maximum context length on the host, target roughly
-    six CTAs per CU and cap the result by the physical page count. Otherwise,
-    preserve the original occupancy-only policy and its cap of eight splits to
-    avoid introducing a device-to-host synchronization in production callers.
+    Default rule: pick enough splits to fill the CUs (~two waves of CTAs), capped
+    at ``cap``. This is right for small and large batches.
+
+    One case needs more splits: a medium batch of ~one wave (``progs ~ num_cu``)
+    only gets ~2 splits from the rule above, so each split has to walk a long
+    serial chain of KV tiles. When the tiles are also narrow (small
+    ``pages_per_tile``, so each tile's gather is cheap), we add splits to keep that
+    chain short, up to ~eight waves.
+
+    Notes: context length only tightens the bound here; the caller further clamps
+    splits to the KV tile count, and any split that ends up with no keys is dropped
+    by the kernel's ``has_kv`` path.
     """
     props = torch.cuda.get_device_properties(0)
     num_cu = props.multi_processor_count
-    base_programs = max(1, num_seqs * num_kv_heads)
-    if max_ctx_len is None or page_size is None:
-        return max(1, min(8, (num_cu * 2) // base_programs))
+    progs = max(1, num_seqs * num_kv_heads)
+    splits = max(1, (num_cu * 2) // progs)
 
-    num_pages = max(1, (max_ctx_len + page_size - 1) // page_size)
-    splits_for_occupancy = _next_pow2((num_cu * 6 + base_programs - 1) // base_programs)
-    return max(1, min(cap, num_pages, splits_for_occupancy))
+    if (max_ctx_len is not None and page_size is not None and pages_per_tile <= 2 and num_cu <= progs <= num_cu * 2):
+        num_pages = max(1, (max_ctx_len + page_size - 1) // page_size)
+        num_tiles = max(1, (num_pages + pages_per_tile - 1) // pages_per_tile)
+        by_tail = max(1, num_tiles // 32)  # keep the serial tail <= ~32 tiles/split
+        hi = max(1, (num_cu * 8) // progs)  # never exceed ~eight waves
+        splits = max(splits, min(hi, by_tail))
+
+    return max(1, min(cap, splits))
 
 
 def pa_decode_tlx(
@@ -313,12 +320,36 @@ def pa_decode_tlx(
     assert m_pow2 >= 16, f"M_POW2={m_pow2} must be >= 16 for MFMA"
     assert query_length * query_group_size <= 64
 
+    # KV compute tile width in keys, independent of PAGE_SIZE. Target a fixed tile
+    # of BLOCK_N * HEAD_DIM ~= 8192 elements (fits the LDS budget double-buffered),
+    # rounded up to a whole number of pages so tiles stay page-aligned.
+    target_block_n = 8192 // head_dim
+    pages_per_tile = max(1, (target_block_n + page_size - 1) // page_size)
+    block_n = pages_per_tile * page_size
+
     if num_splits is None:
-        num_splits = get_num_splits(num_seqs, num_kv_heads, max_context_len, page_size)
+        num_splits = get_num_splits(num_seqs, num_kv_heads, max_context_len, page_size, pages_per_tile)
+        # Never launch more splits than there are KV tiles to cover (host-only, no
+        # device sync), so short contexts never over-split.
+        max_pages = block_tables.shape[1]
+        max_useful_splits = max(1, (max_pages + pages_per_tile - 1) // pages_per_tile)
+        num_splits = min(num_splits, max_useful_splits)
     splits_pow2 = _next_pow2(num_splits)
 
-    mid = torch.empty((num_seqs, num_kv_heads, num_splits, m_pow2, head_dim), dtype=torch.float32, device=query.device)
-    lse = torch.empty((num_seqs, num_kv_heads, num_splits, m_pow2), dtype=torch.float32, device=query.device)
+    # One-shot fused path: with a single split the partition output is already
+    # the final normalized result, so write it straight to `output` and skip both
+    # the Mid/LSE HBM round-trip and the separate reduce launch.
+    fused = num_splits == 1
+    if fused:
+        mid = lse = output
+        mid_strides = (0, 0, 0, 0, 0)
+        lse_strides = (0, 0, 0, 0)
+    else:
+        mid = torch.empty((num_seqs, num_kv_heads, num_splits, m_pow2, head_dim), dtype=torch.float32,
+                          device=query.device)
+        lse = torch.empty((num_seqs, num_kv_heads, num_splits, m_pow2), dtype=torch.float32, device=query.device)
+        mid_strides = (mid.stride(0), mid.stride(1), mid.stride(2), mid.stride(3), mid.stride(4))
+        lse_strides = (lse.stride(0), lse.stride(1), lse.stride(2), lse.stride(3))
 
     grid_p = (num_seqs, num_kv_heads, num_splits)
     _pa_decode_partition_kernel[grid_p](
@@ -329,6 +360,7 @@ def pa_decode_tlx(
         context_lens,
         mid,
         lse,
+        output,
         sm_scale,
         num_splits,
         query.stride(0),
@@ -344,28 +376,28 @@ def pa_decode_tlx(
         value_cache.stride(3),
         block_tables.stride(0),
         block_tables.stride(1),
-        mid.stride(0),
-        mid.stride(1),
-        mid.stride(2),
-        mid.stride(3),
-        mid.stride(4),
-        lse.stride(0),
-        lse.stride(1),
-        lse.stride(2),
-        lse.stride(3),
+        *mid_strides,
+        *lse_strides,
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
         HEAD_DIM=head_dim,
         PAGE_SIZE=page_size,
-        BLOCK_N=64 if page_size == 16 else page_size,
-        PAGES_PER_TILE=4 if page_size == 16 else 1,
-        BUFFER_DEPTH=1 if page_size == 16 else BUF_DEPTH,
+        BLOCK_N=block_n,
+        PAGES_PER_TILE=pages_per_tile,
+        BUFFER_DEPTH=BUF_DEPTH,
         QUERY_GROUP_SIZE=query_group_size,
         GROUP_POW2=group_pow2,
         QLEN=query_length,
         QLEN_POW2=qlen_pow2,
         M_POW2=m_pow2,
+        FUSED=fused,
         num_warps=num_warps,
         waves_per_eu=waves_per_eu,
     )
+
+    if fused:
+        return output
 
     grid_r = (num_tokens, num_q_heads)
     _pa_decode_reduce_kernel[grid_r](

--- a/third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py
+++ b/third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py
@@ -42,9 +42,11 @@ def _pack_aiter_kv_cache(key_cache, value_cache):
 
 def _make_decode_fn(provider, out, q, kc, vc, ctx, bt, sm_scale, qlen, max_context_len):
     if provider == "tlx":
-        return lambda: _pa_decode_tlx(
-            out, q, kc, vc, ctx, bt, sm_scale, query_length=qlen, max_context_len=max_context_len
-        )
+
+        def _run_tlx():
+            return _pa_decode_tlx(out, q, kc, vc, ctx, bt, sm_scale, query_length=qlen, max_context_len=max_context_len)
+
+        return _run_tlx
 
     from aiter.ops.triton.gluon.pa_decode_gluon import pa_decode_gluon
 


### PR DESCRIPTION
## Main changes

- **Wide, page-decoupled KV tiles.** Decouple the compute tile (`BLOCK_N` keys)
  from `PAGE_SIZE`: row `r` of a tile maps to logical page `r // PAGE_SIZE` at
  offset `r % PAGE_SIZE`, gathered in a single load. This keeps the MFMA K-dim
  128-wide (previously 64) even for small page sizes.
- **Async double-buffered pipeline.** Previously page-16 used a synchronous
  gather (load → barrier → compute, no overlap) while page-64 used async; now a
  single unified `tlx.async_load` loop covers both, with a depth-2 software
  pipeline (`wait_group(1)`) that prefetches tile *N+1* while computing tile *N*.
- **Pre-scaled Q.** Scale `q` once (`M_POW2 x HEAD_DIM`) so `q @ kᵀ` already yields
  scaled scores, instead of scaling the `M_POW2 x BLOCK_N` score matrix per tile.
- **Skip masking on full tiles.** Interior tiles entirely at/below the causal
  limit bypass the per-element visibility compare + select; only boundary tiles
  pay for it.
- **Fused single-split path.** When `num_splits == 1` the partition output is
  already final, so write it straight to `Out` and skip both the Mid/LSE HBM
  round-trip and the separate reduce launch.
- **Split-K heuristic tuning.** Extends the existing context-aware heuristic with
  a serial-tail bound that deepens split-K for medium (~one-wave) batches with
  narrow tiles, the one regime the previous occupancy target under-split. Small
  and large batches are unchanged.

## Performance

Measured on **MI350 (gfx950)**, paired/drift-cancelled A/B (both variants run
back-to-back on identical inputs), median of `do_bench(warmup=100, rep=300)`.
Config: `num_kv_heads=8`, `query_group_size=8`, `head_dim=64`. `base` = `main`,
`this` = this PR. `speedup = base_us / this_us` (>1 = faster).

### page_size = 16, qlen = 1

| batch |    ctx | base_us | this_us | speedup |
|------:|-------:|--------:|--------:|--------:|
|     1 |   8192 |    20.3 |    21.1 |   0.964 |
|     8 |   8192 |    38.2 |    33.1 |   1.154 |
|    32 |   8192 |    78.3 |    90.2 |   0.868 |
|   128 |   8192 |   361.9 |   329.4 |   1.099 |
|     1 |  32768 |    39.1 |    38.1 |   1.025 |
|     8 |  32768 |   132.1 |   120.5 |   1.096 |
|    32 |  32768 |   370.1 |   299.5 |   1.236 |
|     8 | 131072 |   458.7 |   362.4 |   1.266 |
| **geomean** | | | | **1.081** |

### page_size = 16, qlen = 4

| batch |    ctx | base_us | this_us | speedup |
|------:|-------:|--------:|--------:|--------:|
|     1 |   8192 |    24.1 |    20.0 |   1.205 |
|     8 |   8192 |    51.8 |    41.9 |   1.237 |
|    32 |   8192 |   129.2 |   112.4 |   1.150 |
|   128 |   8192 |   473.7 |   374.1 |   1.266 |
|     1 |  32768 |    41.8 |    41.8 |   1.000 |
|     8 |  32768 |   156.7 |   129.3 |   1.212 |
|    32 |  32768 |   495.6 |   391.3 |   1.266 |
|     8 | 131072 |   548.8 |   459.9 |   1.193 |
| **geomean** | | | | **1.188** |

### page_size = 64, qlen = 1

| batch |    ctx | base_us | this_us | speedup |
|------:|-------:|--------:|--------:|--------:|
|     1 |   8192 |    20.2 |    23.8 |   0.850 |
|     8 |   8192 |    36.0 |    34.0 |   1.058 |
|    32 |   8192 |    82.0 |    77.0 |   1.064 |
|   128 |   8192 |   374.1 |   332.8 |   1.124 |
|     1 |  32768 |    37.6 |    37.9 |   0.990 |
|     8 |  32768 |   131.5 |   133.6 |   0.984 |
|    32 |  32768 |   324.7 |   330.7 |   0.982 |
|     8 | 131072 |   450.5 |   376.2 |   1.198 |
| **geomean** | | | | **1.027** |

### page_size = 64, qlen = 4

| batch |    ctx | base_us | this_us | speedup |
|------:|-------:|--------:|--------:|--------:|
|     1 |   8192 |    23.3 |    23.8 |   0.980 |
|     8 |   8192 |    49.5 |    42.6 |   1.164 |
|    32 |   8192 |   122.6 |   105.0 |   1.169 |
|   128 |   8192 |   455.4 |   366.7 |   1.242 |
|     1 |  32768 |    42.3 |    42.0 |   1.006 |
|     8 |  32768 |   142.0 |   142.7 |   0.995 |
|    32 |  32768 |   472.0 |   431.8 |   1.093 |
|     8 | 131072 |   556.6 |   478.6 |   1.163 |
| **geomean** | | | | **1.097** |

### Effective HBM bandwidth

Same runs as above, expressed as effective HBM bandwidth (TB/s). Traffic is the
KV-cache read `2 (K+V) × batch × num_kv_heads × ctx × head_dim × 2 B` (bf16);
`base` = `main`, `this` = this PR. Higher is better.

| page_size | qlen | batch | ctx | base TB/s | this TB/s |
|----------:|-----:|------:|-------:|----------:|----------:|
| 16 | 1 |   1 |   8192 | 0.83 | 0.80 |
| 16 | 1 |   8 |   8192 | 3.51 | 4.05 |
| 16 | 1 |  32 |   8192 | 6.86 | 5.95 |
| 16 | 1 | 128 |   8192 | 5.93 | 6.52 |
| 16 | 1 |   1 |  32768 | 1.72 | 1.76 |
| 16 | 1 |   8 |  32768 | 4.06 | 4.46 |
| 16 | 1 |  32 |  32768 | 5.80 | 7.17 |
| 16 | 1 |   8 | 131072 | 4.68 | 5.93 |
| 16 | 4 |   1 |   8192 | 0.70 | 0.84 |
| 16 | 4 |   8 |   8192 | 2.59 | 3.20 |
| 16 | 4 |  32 |   8192 | 4.16 | 4.78 |
| 16 | 4 | 128 |   8192 | 4.53 | 5.74 |
| 16 | 4 |   1 |  32768 | 1.61 | 1.61 |
| 16 | 4 |   8 |  32768 | 3.43 | 4.15 |
| 16 | 4 |  32 |  32768 | 4.33 | 5.49 |
| 16 | 4 |   8 | 131072 | 3.91 | 4.67 |
| 64 | 1 |   1 |   8192 | 0.83 | 0.70 |
| 64 | 1 |   8 |   8192 | 3.73 | 3.95 |
| 64 | 1 |  32 |   8192 | 6.55 | 6.97 |
| 64 | 1 | 128 |   8192 | 5.74 | 6.45 |
| 64 | 1 |   1 |  32768 | 1.78 | 1.77 |
| 64 | 1 |   8 |  32768 | 4.08 | 4.02 |
| 64 | 1 |  32 |  32768 | 6.61 | 6.49 |
| 64 | 1 |   8 | 131072 | 4.77 | 5.71 |
| 64 | 4 |   1 |   8192 | 0.72 | 0.70 |
| 64 | 4 |   8 |   8192 | 2.71 | 3.15 |
| 64 | 4 |  32 |   8192 | 4.38 | 5.11 |
| 64 | 4 | 128 |   8192 | 4.72 | 5.86 |
| 64 | 4 |   1 |  32768 | 1.59 | 1.60 |
| 64 | 4 |   8 |  32768 | 3.78 | 3.76 |
| 64 | 4 |  32 |  32768 | 4.55 | 4.97 |
| 64 | 4 |   8 | 131072 | 3.86 | 4.49 |