### PR TITLE
[AutoWS][HSTU] Enable autoWS on self-attn backward + TLX-matching dq-reduce (#2309)

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -2468,6 +2468,29 @@ void propagatePartitions(LoopLikeOpInterface loop, PartitionSet &schedule,
   }
 }
 
+// An op is cheap enough to rematerialize into a consumer partition (instead of
+// routing its value through a cross-partition channel) if it is a
+// layout/metadata rearrangement or a pure integer index/mask computation.
+// Restricting the arithmetic to integer/index results excludes float compute
+// (softmax/SiLU) and reductions, which must stay channeled (cloning those would
+// cascade expensive work into compute partitions and break channel invariants).
+static bool isRematerializableForClone(Operation *defOp) {
+  if (isa<ConvertLayoutOp, BroadcastOp, ExpandDimsOp, MakeRangeOp, SplatOp>(
+          defOp))
+    return true;
+  if (defOp->getDialect() && defOp->getDialect()->getNamespace() == "arith") {
+    for (Value res : defOp->getResults()) {
+      Type t = res.getType();
+      if (auto tt = dyn_cast<RankedTensorType>(t))
+        t = tt.getElementType();
+      if (!t.isIntOrIndex())
+        return false;
+    }
+    return true;
+  }
+  return false;
+}
+
 /// Walk over \p loop and clone cheap ops into each partition that uses them,
 /// rematerializing metadata-only or layout-only values instead of routing
 /// them through a cross-partition memory channel.
@@ -2502,11 +2525,16 @@ void optimizeSchedule(LoopLikeOpInterface loop, PartitionSet &schedule) {
   // passes insert a ConvertLayoutOp between ExpandDimsOp and BroadcastOp,
   // which would otherwise break the cloning chain and create a
   // cross-partition boundary.
+  // Walk backward from a cloned op and rematerialize its cross-partition cheap
+  // operand producers into the user partition. A worklist (not a single linear
+  // chain) is used so multi-operand index ops (e.g. arith.addi of a make_range
+  // and a splat, as in a causal-mask column-index chain) are fully pulled in;
+  // otherwise the un-pulled operand stays cross-partition and forces a register
+  // channel whose layout transfer can break downstream expand_dims inference.
   auto cloneOperandChain = [&](Operation *clonedOp, Partition *userPartition) {
-    Operation *current = clonedOp;
-    while (true) {
-      Operation *toPull = nullptr;
-      unsigned operandIdx = 0;
+    SmallVector<Operation *> worklist{clonedOp};
+    while (!worklist.empty()) {
+      Operation *current = worklist.pop_back_val();
       for (auto [idx, operand] : llvm::enumerate(current->getOperands())) {
         auto *defOp = operand.getDefiningOp();
         if (!defOp)
@@ -2514,18 +2542,13 @@ void optimizeSchedule(LoopLikeOpInterface loop, PartitionSet &schedule) {
         Partition *defPartition = getPartition(defOp);
         if (!defPartition || defPartition == userPartition)
           continue;
-        if (!isa<ConvertLayoutOp, BroadcastOp, ExpandDimsOp>(defOp))
+        if (!isRematerializableForClone(defOp))
           continue;
-        toPull = defOp;
-        operandIdx = idx;
-        break;
+        Operation *pullClone = OpBuilder(defOp).clone(*defOp);
+        setPartition(pullClone, userPartition);
+        current->setOperand(idx, pullClone->getResult(0));
+        worklist.push_back(pullClone);
       }
-      if (!toPull)
-        break;
-      Operation *pullClone = OpBuilder(toPull).clone(*toPull);
-      setPartition(pullClone, userPartition);
-      current->setOperand(operandIdx, pullClone->getResult(0));
-      current = pullClone;
     }
   };
 

--- a/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
@@ -16,9 +16,9 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-os.environ.pop("TRITON_USE_META_WS", None)  # TLX is hand-WS, not compiler-WS
 
 import torch  # noqa: E402
+import triton  # noqa: E402
 
 import triton_hstu_attention as A  # noqa: E402
 import tlx_bw_hstu_attention as T  # noqa: E402
@@ -101,8 +101,14 @@ def run_tlx(q, k, v, so, L, asc, causal=True):
 def grads(run, q, k, v, so, L, asc, do, **kw):
     for t in (q, k, v):
         t.grad = None
-    out = run(q, k, v, so, L, asc, **kw)
-    out.backward(do)
+    # TLX and plain Triton are not compiler-warp-specialized: force meta-WS off
+    # (and the WS-barrier reorder off, which TLX lowering needs) through a knobs
+    # scope so the override is auto-isolated instead of leaking into os.environ.
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = False
+        triton.knobs.nvidia.disable_wsbarrier_reorder = True
+        out = run(q, k, v, so, L, asc, **kw)
+        out.backward(do)
     return out.detach(), q.grad.clone(), k.grad.clone(), v.grad.clone()
 
 

--- a/third_party/tlx/tutorials/hstu_self_attn/hstu_autows_config.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/hstu_autows_config.py
@@ -1,0 +1,27 @@
+"""Pre-import HSTU autoWS config hook (no triton import).
+
+Lets callers/tests set the HSTU autoWS config as a dict *before* importing
+``triton_hstu_attention`` -- replacing the old ``HSTU_SELF_*`` environment
+variables. ``triton_hstu_attention`` merges ``pop_overrides()`` into its
+``HSTUAutoWSConfig`` at import (autoWS structural flags + the autotune tile config
+are read at import / decoration, so they must be set before the kernel module is
+imported). After import, use ``triton_hstu_attention.configure_autows()`` or the
+``autows_cfg=`` argument on the entrypoints instead.
+
+    import hstu_autows_config as C
+    C.set_config(autows=True, dp=1, dq_reduce=True, dq_reuse=True, dq_iters=4,
+                 warps=4, bwd_bm=128, bwd_bn=128, bwd_stages=2, pin=True)
+    import triton_hstu_attention as A   # picks up the config
+"""
+
+_OVERRIDES: dict = {}
+
+
+def set_config(**kwargs) -> None:
+    """Set HSTU autoWS config overrides (field names of HSTUAutoWSConfig)."""
+    _OVERRIDES.update(kwargs)
+
+
+def pop_overrides() -> dict:
+    """Return (a copy of) the pending overrides for triton_hstu_attention import."""
+    return dict(_OVERRIDES)

--- a/third_party/tlx/tutorials/hstu_self_attn/tlx_bw_hstu_attention.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/tlx_bw_hstu_attention.py
@@ -2419,7 +2419,7 @@ def get_hstu_bwd_configs() -> List[triton.Config]:
             pre_hook=_hstu_bwd_host_descriptor_pre_hook,
         )
         # HSTU_SELF_PIN=1 -> one config (fast compile for tritonbench --mode bwd).
-        for er in ([1] if os.environ.get("HSTU_SELF_PIN") else [1, 2])
+        for er in ([1] if os.environ.get("HSTU_SELF_PIN") == "1" else [1, 2])
     ] + [
         triton.Config(
             {
@@ -2443,7 +2443,7 @@ def get_hstu_bwd_configs() -> List[triton.Config]:
             pre_hook=_hstu_bwd_host_descriptor_pre_hook,
         )
         # HSTU_SELF_PIN=1 -> one config (fast compile for tritonbench --mode bwd).
-        for er in ([1] if os.environ.get("HSTU_SELF_PIN") else [1, 2])
+        for er in ([1] if os.environ.get("HSTU_SELF_PIN") == "1" else [1, 2])
     ]
 
 
@@ -4877,6 +4877,7 @@ def tlx_hstu_attention_bwd(
     max_attn_len: int = 0,
     full_attn_size: int = 0,
     contextual_seq_len: int = 0,
+    use_persistent: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Backward pass for HSTU attention with jagged sequences."""
     q = switch_to_contiguous_if_needed(q)
@@ -4976,7 +4977,6 @@ def tlx_hstu_attention_bwd(
 
     stage = 3 if causal else 1
 
-    use_persistent = True
     if use_persistent:
         grid = lambda meta: (  # noqa E731
             H * Z * triton.cdiv(max_seq_len, meta["BLOCK_N1"]), )

--- a/third_party/tlx/tutorials/hstu_self_attn/triton_attention_utils.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/triton_attention_utils.py
@@ -10,15 +10,6 @@ import triton
 # @manual=//triton:triton
 import triton.language as tl
 
-try:
-    # @manual=//triton:triton
-    import triton.language.extra.tlx as tlx  # type: ignore[attr-defined]
-
-    HAS_TLX = True
-except ImportError:
-    tlx = None
-    HAS_TLX = False
-
 from triton.language.extra.libdevice import (  # @manual=//triton:triton
     fast_dividef, fast_expf,
 )

--- a/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
@@ -35,17 +35,146 @@ from stubs import (
 )
 from stubs import acc_dq
 from triton.language.extra.libdevice import fast_dividef  # @manual=//triton:triton
+from triton.language.extra.subtile_ops import _split_n_2D  # @manual=//triton:triton
+
+from dataclasses import dataclass, replace as _dc_replace
+
+
+@dataclass
+class HSTUAutoWSConfig:
+    """AutoWS configuration for the HSTU self-attn kernels.
+
+    Replaces the former scattered HSTU_SELF_* environment variables with a single
+    config object, settable via configure_autows() or the `autows_cfg` argument on
+    the public entrypoints (triton_hstu_mha / triton_hstu_attention_fwd|bwd). The
+    env vars are still read once by from_env() as import-time defaults for
+    back-compat. Structural fields are tl.constexpr (read inside @triton.jit) and
+    the tile fields feed the autotune config list (built at import per Triton), so
+    configure_autows() must run before the first kernel launch.
+    """
+
+    autows: bool = False  # enable meta-WS on the KV loop
+    dp: int = 1  # data-partition factor (MMA groups)
+    dq_reduce: bool = False  # bwd dq via TMA reduce-add (vs in-loop RMW)
+    dq_reuse: bool = False  # FA-style TMEM reuse for the dq-reduce bwd
+    dq_iters: int = 1  # dq TMA-reduce column subtiles
+    warps: int = 8  # num_warps for the autoWS config
+    bn: int = 128  # fwd DP BLOCK_N
+    bwd_bm: int = 64  # bwd autoWS BLOCK_M
+    bwd_bn: int = 64  # bwd autoWS BLOCK_N
+    bwd_stages: int = 1  # bwd autoWS num_stages
+    sp: bool = False  # bwd SEQUENCE_PARALLEL
+    pin: bool = False  # pin autotune to one config (fast compile)
+
+    @classmethod
+    def from_env(cls) -> "HSTUAutoWSConfig":
+        g = os.environ.get
+        autows = g("HSTU_SELF_AUTOWS") == "1"
+        return cls(
+            autows=autows,
+            dp=int(g("HSTU_SELF_DP", "2" if autows else "1")),
+            dq_reduce=g("HSTU_SELF_DQ_REDUCE") == "1",
+            dq_reuse=g("HSTU_SELF_DQ_REUSE", "0") == "1",
+            dq_iters=int(g("HSTU_SELF_DQ_ITERS", "1")),
+            warps=int(g("HSTU_SELF_AUTOWS_WARPS", "8")),
+            bn=int(g("HSTU_SELF_AUTOWS_BN", "128")),
+            bwd_bm=int(g("HSTU_SELF_AUTOWS_BWD_BM", "64")),
+            bwd_bn=int(g("HSTU_SELF_AUTOWS_BWD_BN", "64")),
+            bwd_stages=int(g("HSTU_SELF_AUTOWS_BWD_STAGES", "1")),
+            sp=g("HSTU_SELF_AUTOWS_SP") == "1",
+            pin=g("HSTU_SELF_PIN") == "1",
+        )
+
+
+_AUTOWS_CFG = HSTUAutoWSConfig.from_env()
+# Merge any pre-import overrides set via hstu_autows_config.set_config(...) so
+# callers/tests can pass the config as a dict instead of HSTU_SELF_* env vars.
+try:
+    import hstu_autows_config as _hstu_autows_config_hook
+
+    _AUTOWS_CFG = _dc_replace(_AUTOWS_CFG, **_hstu_autows_config_hook.pop_overrides())
+except Exception:  # noqa: BLE001 -- hook is optional
+    pass
+
+
+def _sync_autows_constexprs() -> None:
+    # Re-derive the tl.constexpr views (read inside @triton.jit) from _AUTOWS_CFG.
+    global _HSTU_SELF_AUTOWS, _HSTU_SELF_DP, _HSTU_SELF_DQ_REDUCE
+    global _HSTU_SELF_DQ_ITERS, _HSTU_DQ_REUSE
+    _HSTU_SELF_AUTOWS = tl.constexpr(_AUTOWS_CFG.autows)
+    _HSTU_SELF_DP = tl.constexpr(_AUTOWS_CFG.dp)
+    _HSTU_SELF_DQ_REDUCE = tl.constexpr(_AUTOWS_CFG.dq_reduce)
+    _HSTU_SELF_DQ_ITERS = tl.constexpr(_AUTOWS_CFG.dq_iters)
+    _HSTU_DQ_REUSE = tl.constexpr(_AUTOWS_CFG.dq_reduce and _AUTOWS_CFG.dq_reuse)
+
+
+def configure_autows(cfg=None, **kwargs) -> "HSTUAutoWSConfig":
+    """Set the active HSTU autoWS config (replaces the HSTU_SELF_* env vars).
+
+    Accepts an HSTUAutoWSConfig, a dict of overrides, or keyword overrides. Call
+    before the first kernel launch.
+    """
+    global _AUTOWS_CFG
+    if cfg is not None:
+        if isinstance(cfg, HSTUAutoWSConfig):
+            _AUTOWS_CFG = cfg
+        else:
+            _AUTOWS_CFG = _dc_replace(_AUTOWS_CFG, **cfg)
+    if kwargs:
+        _AUTOWS_CFG = _dc_replace(_AUTOWS_CFG, **kwargs)
+    _sync_autows_constexprs()
+    return _AUTOWS_CFG
+
 
 # HSTU_SELF_AUTOWS=1 turns on Meta-Triton autoWS on the main KV loop (needs
 # TRITON_USE_META_WS=1 + TRITON_DISABLE_WSBARRIER_REORDER=1 at runtime, and a
 # num_stages>=1 config -- pair with HSTU_SELF_PIN=1). Default off -> identical to
 # the plain-Triton kernel. Must be a tl.constexpr to be read inside @triton.jit.
-_HSTU_SELF_AUTOWS = tl.constexpr(os.environ.get("HSTU_SELF_AUTOWS") == "1")
+_HSTU_SELF_AUTOWS = tl.constexpr(_AUTOWS_CFG.autows)
 # Data-partition factor for autoWS: splits the loop's MMAs into N groups (the
 # autoWS analog of TLX's replicate=NUM_MMA_GROUPS). Default 2 when autoWS is on
 # (matches TLX's 2 MMA groups), 1 otherwise; override with HSTU_SELF_DP.
-_HSTU_SELF_DP = tl.constexpr(
-    int(os.environ.get("HSTU_SELF_DP", "2" if os.environ.get("HSTU_SELF_AUTOWS") == "1" else "1")))
+_HSTU_SELF_DP = tl.constexpr(_AUTOWS_CFG.dp)
+# EXPERIMENTAL, opt-in via HSTU_SELF_DQ_REDUCE=1 (OFF by default): dq via TMA
+# reduce-add instead of the in-loop global RMW, mirroring the cross-attn autoWS
+# bwd (triton_bw_cross_attention.py: natural dq_trans = trans(k)@dqk MMA, then
+# tl.trans of the *result*, then store_reduce="add" -- transpose the result, not
+# the dqk register operand, or meta-WS declines to partition). DQ is pre-zeroed.
+# NOTE: the reduce adds a reduction partition, so PSM's warp-budget check
+# (kMaxWarps=16) needs the default partition small -- pair with
+# HSTU_SELF_AUTOWS_WARPS=4 (num_warps=8 overflows the budget -> WS silently
+# falls back to SIMT). Still needs a TMEM-fitting config (TLX-style dq subtiling)
+# to compile at 64x64; left off by default so the shipped autoWS path keeps the
+# faster RMW dq (which warp-specializes at num_warps=8).
+_HSTU_SELF_DQ_REDUCE = tl.constexpr(_AUTOWS_CFG.dq_reduce)
+# Subtile count for the dq TMA reduce, matching FA bwd's DQ_SUBTILE. The store is
+# split into _HSTU_SELF_DQ_ITERS contiguous column-subtiles via _split_n_2D (the
+# same helper FA bwd uses; register-tensor slicing `dq[:, a:b]` is unsupported).
+# Each subtile is an independent store_reduce the compiler can stage. Must be a
+# power of 2 dividing HEAD_DIM. Default 1 (whole tile); override HSTU_SELF_DQ_ITERS.
+_HSTU_SELF_DQ_ITERS = tl.constexpr(_AUTOWS_CFG.dq_iters)
+# EXPERIMENTAL, opt-in via HSTU_SELF_DQ_REUSE=1 (default OFF): when set (and
+# dq-reduce is on), annotate the bwd MMAs' opndD with FA-bwd-style tt.autows
+# channel attrs (see WarpSpecialization/docs/AnnotationBasedBufferPreAssignment.md)
+# forming a TMEM reuse scheme that mirrors _BWD_DOT_ATTRS in
+# fused_attention_ws_device_tma.py + TLX REUSE_DP_FOR_DQ / NUM_BUFFERS_TMEM=1. At
+# BM=BN=HEAD_DIM=128 every opndD accumulator is [128,128] f32 = 128 cols; four
+# reuse groups pack to exactly 512 cols:
+#   id2 : qk_trans (f32) -> reused by act_qk_trans (bf16, dv's opndA)
+#   id5 : dp (dact_qk_trans) -> reused by dq_trans          [REUSE_DP_FOR_DQ]
+#   id7 : dv  (persistent accumulator, live across the inner loop)
+#   id10: dk  (persistent accumulator, live across the inner loop)
+# Sharing id5 also gives the otherwise-standalone single-buffered dq accumulator
+# dp's cross-iteration WAR barrier (the fix for the gemm->reduction ping-pong
+# deadlock). dp/dq have disjoint liveness (dp is consumed into dqk_trans before dq
+# is produced) and dk is emitted before dq, so nothing reads id5 after dq
+# overwrites it (BwdTmemReuseSlotHazard.md). Reuse validity needs dp and dq
+# shape-compatible, which holds only at BLOCK_N==HEAD_DIM==128 (dp=[BLOCK_N,BLOCK_M],
+# dq=[HEAD_DIM,BLOCK_M]); at BLOCK_N=64 the shapes differ and the reuse falls back.
+# The attrs are inline dict literals gated by a constexpr bool -- tl.dot's attrs=
+# is a trace-time literal, so this avoids referencing a (dict) JIT global, which
+# is unsupported. None (reuse off) leaves the dots unannotated (heuristic alloc).
+_HSTU_DQ_REUSE = tl.constexpr(_AUTOWS_CFG.dq_reduce and _AUTOWS_CFG.dq_reuse)
 
 
 def _get_fw_configs() -> List[triton.Config]:  # noqa: C901
@@ -220,15 +349,15 @@ def _get_fw_configs() -> List[triton.Config]:  # noqa: C901
     # split into producer/consumer partitions (the tiny default config with
     # num_warps=2/BLOCK_M=16 does NOT warp-specialize). Pin to a num_warps>=4,
     # BLOCK_M>=64 config.
-    if os.environ.get("HSTU_SELF_AUTOWS") == "1":
-        _w = int(os.environ.get("HSTU_SELF_AUTOWS_WARPS", "8"))
-        _dp = int(os.environ.get("HSTU_SELF_DP", "2"))
+    if _AUTOWS_CFG.autows:
+        _w = _AUTOWS_CFG.warps
+        _dp = _AUTOWS_CFG.dp
         if _dp >= 2:
             # DP splits BLOCK_M by _dp; each slice must be >= the TMEM blockM
             # (128) or WSDataPartition skips (WSDataPartition.cpp). So set
             # BLOCK_M = 128 * _dp (doubling the split dim) -> each partition tile
             # is 128 rows, matching TLX (BLOCK_M=256, 2 groups of 128).
-            _bn = int(os.environ.get("HSTU_SELF_AUTOWS_BN", "128"))
+            _bn = _AUTOWS_CFG.bn
             return [triton.Config(
                 {"BLOCK_M": 128 * _dp, "BLOCK_N": _bn},
                 num_stages=1,
@@ -249,7 +378,7 @@ def _get_fw_configs() -> List[triton.Config]:  # noqa: C901
         return configs[:1]
     # HSTU_SELF_PIN=1 shrinks the fwd autotune to one config (fast compile for
     # tritonbench --mode bwd, which recompiles fwd+bwd).
-    if os.environ.get("HSTU_SELF_PIN"):
+    if _AUTOWS_CFG.pin:
         return configs[:1]
     return configs
 
@@ -466,9 +595,39 @@ def _get_bw_configs() -> List[triton.Config]:
         ]
     else:
         print("WARNING: temporarily disabled some autotune configs for CUDA 12.8+")
+    # HSTU_SELF_AUTOWS needs a big-enough tile + enough warps or meta-WS silently
+    # does NOT partition the bwd M-loop (the tiny default BLOCK_M=16/num_warps=2
+    # config stays SIMT). Pin one num_warps>=8, BLOCK_M>=64, num_stages>=1 config.
+    # DP is left at 1 for bwd (TLX bwd uses replicate=1), so no split-dim doubling.
+    # Use the non-SEQUENCE_PARALLEL path (single program per (z,h); dq is a direct
+    # global RMW, ATOMIC_ADD=False) and UNROLL=1 (no unroll under WS).
+    if _AUTOWS_CFG.autows:
+        _w = _AUTOWS_CFG.warps
+        _bm = _AUTOWS_CFG.bwd_bm
+        _bn = _AUTOWS_CFG.bwd_bn
+        _ns = _AUTOWS_CFG.bwd_stages
+        # SEQUENCE_PARALLEL=True -> one KV block per program => a single M loop
+        # (no outer start_n loop), matching FA bwd's flat reduction loop; the
+        # nested (SP=False) path is where the dq-reduce reduction partition's
+        # phase lockstep breaks. Default False (RMW path); set HSTU_SELF_AUTOWS_SP=1
+        # for the FA-like single-loop structure (pair with HSTU_SELF_DQ_REDUCE=1).
+        _sp = _AUTOWS_CFG.sp
+        return [
+            triton.Config(
+                {
+                    "BLOCK_M": _bm,
+                    "BLOCK_N": _bn,
+                    "SEQUENCE_PARALLEL": _sp,
+                    "UNROLL": 1,
+                },
+                num_stages=_ns,
+                num_warps=_w,
+                pre_hook=_bwd_pre_hook,
+            )
+        ]
     # HSTU_SELF_PIN=1 shrinks the bwd autotune to one config so tritonbench
     # --mode bwd compiles fast instead of building all ~29 configs.
-    if os.environ.get("HSTU_SELF_PIN"):
+    if _AUTOWS_CFG.pin:
         return configs[:1]
     return configs
 
@@ -724,6 +883,7 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
     do_ptrs,
     device_desc_q,
     device_desc_do,
+    device_desc_dq,
     dk,
     dv,
     k,
@@ -737,6 +897,7 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
     stride_qm,
     stride_dom,
     stride_dqm,
+    stride_dqh,
     alpha,
     attn_scale,
     max_q_len,
@@ -779,7 +940,9 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
             mask=mask_m[None, :],
             other=0.0,
         )
-    qk_trans = tl.dot(k, q_trans, allow_tf32=ALLOW_TF32)
+    qk_trans = tl.dot(
+        k, q_trans, allow_tf32=ALLOW_TF32, attrs=({"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]} if _HSTU_DQ_REUSE else None)
+    )
     valid_mask_trans = backward_valid_mask(
         offs_m,
         pos_offs_n,
@@ -806,29 +969,80 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
             mask=mask_m[:, None],
             other=0.0,
         )
-    dv += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+    # dp (dact_qk_trans) is emitted BEFORE dv: dp and dv are both stage 0 with the
+    # SAME `order`, so the `order` annotation does NOT reorder them -- same-stage
+    # dots keep PROGRAM order. Emitting dp first makes the final-ttgir schedule match
+    # TLX's dp-before-dv body order (dv/dp were the only swapped pair vs TLX).
+    dact_qk_trans = tl.dot(
+        v, tl.trans(do), allow_tf32=ALLOW_TF32, attrs=({"stage": "0", "order": "2", "channels": ["opndD,tmem,1,5"]} if _HSTU_DQ_REUSE else None)
+    )
+    dv += tl.dot(
+        act_qk_trans, do, allow_tf32=ALLOW_TF32, attrs=(
+            {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]}
+            if _HSTU_DQ_REUSE
+            else None
+        )
+    )
 
     # compute dk and dq
-    dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
     dqk_trans = backward_d_activation(dact_qk_trans, sig_trans, qk_trans, scale, valid_mask_trans)
     dqk_trans = dqk_trans.to(k.dtype)
 
     # Note: the factor `alpha` is delayed until the end of the function to reduce the cost
-    dk += tl.dot(dqk_trans, tl.trans(q_trans), allow_tf32=ALLOW_TF32)
-    acc_dq(
-        dq_ptrs_trans=dq_ptrs_trans,
-        start_m=start_m,
-        stride_dqm=stride_dqm,
-        k=k,
-        dqk_trans=dqk_trans,
-        alpha=alpha,
-        mask_m=mask_m,
-        MAX_SEQ_LEN=max_q_len,
-        LOCK=LOCK,
-        BLOCK_M=BLOCK_M,
-        ATOMIC_ADD=ATOMIC_ADD,
-        ALLOW_TF32=ALLOW_TF32,
+    dk += tl.dot(
+        dqk_trans, tl.trans(q_trans), allow_tf32=ALLOW_TF32,
+        # dsT (opndA) MUST live in SMEM, not TMEM. Left unannotated it defaults to
+        # TMEM and the planner column-packs it into id2 (the qk_trans buffer), where
+        # the qk MMA's useAcc=false full-overwrite races this cross-stage (stage-1)
+        # read -> corrupt grads. TLX keeps dsT in a dedicated SMEM buffer (ds_tiles);
+        # opndA,smem,1,8 mirrors that (and FA bwd's dsT-in-smem convention).
+        attrs=({"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]} if _HSTU_DQ_REUSE else None),
     )
+    if _HSTU_SELF_DQ_REDUCE and ENABLE_TMA:
+        # dq via TMA reduce-add. Compute dq TRANSPOSED with the SAME dot as acc_dq
+        # (tl.trans(k) is a cheap memdesc_trans on the SMEM k tile), then transpose
+        # the small [BLOCK_D_Q, BLOCK_M] result to [BLOCK_M, BLOCK_D_Q] and atomic-add
+        # into global dq. Transposing the *result* (not the dqk register operand)
+        # keeps the MMA structure meta-WS can partition. DQ is pre-zeroed; the head
+        # slice is selected by the store column offset (device_desc_dq base has only
+        # the seq offset). Mirrors triton_bw_cross_attention.py's autoWS dq reduce.
+        dq_trans = (
+            tl.dot(
+                tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32,
+                attrs=({"stage": "1", "order": "1", "channels": ["opndD,tmem,1,5"]} if _HSTU_DQ_REUSE else None),
+            )
+            * alpha
+        )
+        dq = tl.trans(dq_trans).to(k.dtype)
+        # Subtile the dq reduce into _HSTU_SELF_DQ_ITERS contiguous column-subtiles
+        # (matches FA bwd's DQ_SUBTILE); each is an independent store_reduce the
+        # compiler stages separately (the source-level analog of TLX's subtiled +
+        # depth-2 dq_store_buf staging). _split_n_2D does the register split that
+        # `dq[:, a:b]` cannot.
+        dq_slice_size: tl.constexpr = BLOCK_D_Q // _HSTU_SELF_DQ_ITERS
+        dqs = _split_n_2D(dq, _HSTU_SELF_DQ_ITERS)
+        for _s in tl.static_range(_HSTU_SELF_DQ_ITERS):
+            tl._experimental_descriptor_store(
+                device_desc_dq,
+                dqs[_s],
+                [start_m, (off_h * stride_dqh + _s * dq_slice_size).to(tl.int32)],
+                store_reduce="add",
+            )
+    else:
+        acc_dq(
+            dq_ptrs_trans=dq_ptrs_trans,
+            start_m=start_m,
+            stride_dqm=stride_dqm,
+            k=k,
+            dqk_trans=dqk_trans,
+            alpha=alpha,
+            mask_m=mask_m,
+            MAX_SEQ_LEN=max_q_len,
+            LOCK=LOCK,
+            BLOCK_M=BLOCK_M,
+            ATOMIC_ADD=ATOMIC_ADD,
+            ALLOW_TF32=ALLOW_TF32,
+        )
     return dk, dv
 
 
@@ -1268,6 +1482,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
     device_desc_do,
     device_desc_dk,
     device_desc_dv,
+    device_desc_dq,
     LOCK,
     off_h,
     off_z,
@@ -1282,6 +1497,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
     stride_vn,
     stride_dom,
     stride_dqm,
+    stride_dqh,
     stride_dkn,
     stride_dvn,
     alpha,
@@ -1358,6 +1574,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
                 do_ptrs=do_ptrs,
                 device_desc_q=device_desc_q,
                 device_desc_do=device_desc_do,
+                device_desc_dq=device_desc_dq,
                 dk=dk,
                 dv=dv,
                 k=k,
@@ -1371,6 +1588,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
                 stride_qm=stride_qm,
                 stride_dom=stride_dom,
                 stride_dqm=stride_dqm,
+                stride_dqh=stride_dqh,
                 alpha=alpha,
                 attn_scale=attn_scale,
                 max_q_len=max_q_len,
@@ -1409,7 +1627,21 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
         contextual_block_end = tl.cdiv(contextual_seq_len, BLOCK_M) * BLOCK_M
         if low < contextual_block_end:
             low = contextual_block_end
-    for start_m in tl.range(low, high, BLOCK_M, loop_unroll_factor=UNROLL):
+    for start_m in tl.range(
+        low,
+        high,
+        BLOCK_M,
+        loop_unroll_factor=UNROLL,
+        # autoWS on the bwd compute loop (dk/dv/dq MMAs). DP=1 (bwd uses TLX
+        # replicate=1); pair with a num_warps>=8, BLOCK_M>=64, num_stages>=1
+        # config from _get_bw_configs() (HSTU_SELF_AUTOWS branch).
+        warp_specialize=_HSTU_SELF_AUTOWS,
+        # For the dq TMA-reduce path (which adds a reduction partition), fold the
+        # dk/dv epilogue into the computation partition (as TLX does) so the total
+        # warp count stays <= 16 (reduction4+gemm1+load1+compute8=14 vs the
+        # 5-partition 18 that overflows PSM's warp budget). No-op for the RMW path.
+        merge_epilogue_to_computation=_HSTU_SELF_DQ_REDUCE,
+    ):
         start_m = tl.multiple_of(start_m, BLOCK_M)
         dk, dv = _hstu_attn_bwd_one_block_0(
             start_m=start_m,
@@ -1420,6 +1652,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
             do_ptrs=do_ptrs,
             device_desc_q=device_desc_q,
             device_desc_do=device_desc_do,
+            device_desc_dq=device_desc_dq,
             dk=dk,
             dv=dv,
             k=k,
@@ -1433,6 +1666,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
             stride_qm=stride_qm,
             stride_dom=stride_dom,
             stride_dqm=stride_dqm,
+            stride_dqh=stride_dqh,
             alpha=alpha,
             attn_scale=attn_scale,
             max_q_len=max_q_len,
@@ -1555,7 +1789,12 @@ def _hstu_attn_bwd(  # noqa C901
     K = K + seq_start_kv * stride_kn
     V = V + seq_start_kv * stride_vn
     DOut = DOut + seq_start_q * stride_dom
-    DQ = DQ + seq_start_q * stride_dqm + off_h * stride_dqh
+    if _HSTU_SELF_DQ_REDUCE and ENABLE_TMA:
+        # TMA-reduce dq: the descriptor base carries only the seq offset; the head
+        # slice is selected by the store column offset (off_h*stride_dqh).
+        DQ = DQ + seq_start_q * stride_dqm
+    else:
+        DQ = DQ + seq_start_q * stride_dqm + off_h * stride_dqh
     DK = DK + seq_start_kv * stride_dkn
     DV = DV + seq_start_kv * stride_dvn
     device_desc_q = None
@@ -1564,8 +1803,11 @@ def _hstu_attn_bwd(  # noqa C901
     device_desc_do = None
     device_desc_dk = None
     device_desc_dv = None
+    device_desc_dq = None
     if ENABLE_TMA:
-        workspace_base = tma_workspace_ptr + TMA_DESC_SIZE * 6 * (tl.program_id(1) +
+        # 7 descriptor slots per program (q,k,v,do,dk,dv,dq); dq only used by the
+        # autoWS TMA-reduce path (gated below).
+        workspace_base = tma_workspace_ptr + TMA_DESC_SIZE * 7 * (tl.program_id(1) +
                                                                   tl.program_id(0) * tl.num_programs(1))
         device_desc_q = workspace_base
         device_desc_k = workspace_base + 1 * TMA_DESC_SIZE
@@ -1573,6 +1815,7 @@ def _hstu_attn_bwd(  # noqa C901
         device_desc_do = workspace_base + 3 * TMA_DESC_SIZE
         device_desc_dk = workspace_base + 4 * TMA_DESC_SIZE
         device_desc_dv = workspace_base + 5 * TMA_DESC_SIZE
+        device_desc_dq = workspace_base + 6 * TMA_DESC_SIZE
 
         # pyre-ignore [20]
         tl.extra.cuda.experimental_device_tensormap_create2d(
@@ -1652,6 +1895,22 @@ def _hstu_attn_bwd(  # noqa C901
         )
         # pyre-ignore [20]
         tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_dv)
+        if _HSTU_SELF_DQ_REDUCE:
+            # dq TMA reduce-add target: non-transposed [seq_len_q, H*DimQ]; base
+            # (DQ) carries only the seq offset, head via the store column.
+            # pyre-ignore [20]
+            tl.extra.cuda.experimental_device_tensormap_create2d(
+                desc_ptr=device_desc_dq,
+                global_address=DQ,
+                load_size=[
+                    BLOCK_M,
+                    BLOCK_D_Q // _HSTU_SELF_DQ_ITERS,
+                ],
+                global_size=[seq_len_q, H * DimQ],
+                element_ty=DQ.dtype.element_ty,
+            )
+            # pyre-ignore [20]
+            tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_dq)
     else:
         Q += off_h * stride_qh
         K += off_h * stride_kh
@@ -1680,6 +1939,7 @@ def _hstu_attn_bwd(  # noqa C901
             device_desc_do=device_desc_do,
             device_desc_dk=device_desc_dk,
             device_desc_dv=device_desc_dv,
+            device_desc_dq=device_desc_dq,
             LOCK=LOCK,
             off_h=off_h,
             off_z=off_z,
@@ -1694,6 +1954,7 @@ def _hstu_attn_bwd(  # noqa C901
             stride_vn=stride_vn,
             stride_dom=stride_dom,
             stride_dqm=stride_dqm,
+            stride_dqh=stride_dqh,
             stride_dkn=stride_dkn,
             stride_dvn=stride_dvn,
             alpha=alpha,
@@ -1735,6 +1996,7 @@ def _hstu_attn_bwd(  # noqa C901
                 device_desc_do=device_desc_do,
                 device_desc_dk=device_desc_dk,
                 device_desc_dv=device_desc_dv,
+                device_desc_dq=device_desc_dq,
                 LOCK=LOCK,
                 off_h=off_h,
                 off_z=off_z,
@@ -1749,6 +2011,7 @@ def _hstu_attn_bwd(  # noqa C901
                 stride_vn=stride_vn,
                 stride_dom=stride_dom,
                 stride_dqm=stride_dqm,
+                stride_dqh=stride_dqh,
                 stride_dkn=stride_dkn,
                 stride_dvn=stride_dvn,
                 alpha=alpha,
@@ -1919,8 +2182,10 @@ def triton_hstu_attention_bwd(
     tma_workspace = None
     if enable_tma:
         MIN_BLOCK_N = 16
+        # 7 TMA descriptor slots (q,k,v,do,dk,dv,dq); the 7th (dq) is used by the
+        # autoWS TMA-reduce dq path. Allocating it unconditionally is cheap.
         tma_workspace = torch.empty(
-            6 * TMA_DESC_SIZE * (triton.cdiv(max_seq_len, MIN_BLOCK_N) * Z * H),
+            7 * TMA_DESC_SIZE * (triton.cdiv(max_seq_len, MIN_BLOCK_N) * Z * H),
             dtype=torch.uint8,
             device="cuda",
         )
@@ -2140,7 +2405,13 @@ def triton_hstu_mha(
     num_targets: Optional[torch.Tensor] = None,
     max_attn_len: int = 0,
     contextual_seq_len: int = 0,
+    autows_cfg=None,
 ) -> torch.Tensor:
+    # AutoWS knobs: pass an HSTUAutoWSConfig/dict here (or via configure_autows())
+    # instead of the HSTU_SELF_* env vars. Applies the structural flags before the
+    # kernel launch; call before the first launch so it also affects tracing.
+    if autows_cfg is not None:
+        configure_autows(autows_cfg)
     return _AttentionFunction.apply(
         max_seq_len,
         alpha,

--- a/third_party/tlx/tutorials/test_self_attention_autows.py
+++ b/third_party/tlx/tutorials/test_self_attention_autows.py
@@ -6,6 +6,15 @@ Enables autoWS on the hammer-template Triton self-attn kernel via the
 baked as a tl.constexpr at import) and asserts the fwd output AND the dq/dk/dv
 gradients match a torch-autograd float causal-SiLU reference.
 
+Two configs are covered:
+- The DEFAULT autoWS config (in-process): `test_self_attention_fwd_autows`.
+- The TLX-matching dq-reduce config (BM=BN=128, num_stages=2, TMEM reuse, dsT in
+  SMEM): `test_self_attention_bwd_autows_dqreduce`. Its flags
+  (HSTU_SELF_DQ_REDUCE / HSTU_SELF_DQ_REUSE / the BWD tile knobs) are baked as
+  tl.constexpr / read into the autotune configs AT IMPORT, so they can't coexist
+  with the default config in one interpreter -> that case runs in a SUBPROCESS
+  (this same file re-invoked with `--run-dqreduce`) with the env set first.
+
 Notes:
 - autoWS needs TRITON_USE_META_WS=1 + TRITON_DISABLE_WSBARRIER_REORDER=1; these
   are set BEFORE importing the kernel so the constexpr/config pick see them.
@@ -13,23 +22,54 @@ Notes:
   >=128 TMEM rows) which OOMs TMEM on this kernel, so DP is off here.
 - The TLX self-attn *fwd* uses num_stages=0 and asserts under meta-WS, so it
   cannot be compiled in the same (META_WS) process; the accuracy oracle here is
-  the torch reference (as in test_cross_attention_bwd_autows.py).
+  the torch reference (as in test_cross_attention_bwd_autows.py). The dq-reduce
+  config's grads match this torch ref to bf16 precision, i.e. the same numerics
+  the hand-written TLX bwd produces.
 
 Run: pytest third_party/tlx/tutorials/test_self_attention_autows.py
 """
 import os
+import subprocess
 import sys
 
 _HSTU_DIR = os.path.join(os.path.dirname(__file__), "hstu_self_attn")
 sys.path.insert(0, _HSTU_DIR)
 
-# Enable autoWS + its env BEFORE importing the kernel (the flag/config are read
-# at import / first compile).
-os.environ["HSTU_SELF_AUTOWS"] = "1"
-os.environ["HSTU_SELF_DP"] = "1"
-os.environ["HSTU_SELF_PIN"] = "1"
+# HSTU autoWS config as a dict (replaces the HSTU_SELF_* env vars), applied via
+# hstu_autows_config.set_config() BEFORE importing the kernel -- the autoWS
+# structural flags and the autotune tile config are read at import. Only the
+# Triton *compiler* knobs (meta-WS on, wsbarrier-reorder off) stay as env; they
+# are generic triton knobs, not HSTU_SELF_* config.
+import hstu_autows_config as _C  # noqa: E402
+
+# The TLX-matching dq-reduce config: BM=BN=128 with num_stages=2 (annotation-
+# driven SWP schedule), FA-style TMEM reuse (id2={qk,act}, id5={dp,dq}, id7=dv,
+# id10=dk) with dsT pinned to SMEM (opndA,smem) so it does NOT column-pack into
+# the qk reuse buffer, and dq via TMA reduce-add subtiled x4. This is the config
+# whose final ttgir matches the hand-written TLX bwd (prologue/body/epilogue
+# structure + reuse groups) and whose grads match the torch/TLX numerics.
+_DQREDUCE_CFG = dict(
+    autows=True,
+    dq_reduce=True,
+    dq_reuse=True,
+    dp=1,
+    bwd_bm=128,
+    bwd_bn=128,
+    bwd_stages=2,
+    warps=4,
+    dq_iters=4,
+    pin=True,
+)
+_DEFAULT_CFG = dict(autows=True, dp=1, pin=True)
+
+# The dq-reduce case re-invokes this file as a subprocess (--run-dqreduce); pick
+# its config before the kernel import below.
+_IS_DQREDUCE = "--run-dqreduce" in sys.argv
+_C.set_config(**(_DQREDUCE_CFG if _IS_DQREDUCE else _DEFAULT_CFG))
 os.environ["TRITON_USE_META_WS"] = "1"
 os.environ["TRITON_DISABLE_WSBARRIER_REORDER"] = "1"
+if _IS_DQREDUCE:
+    os.environ["TRITON_WS_SMEM_PLAN_SEARCH"] = "1"
 
 import pytest  # noqa: E402
 import torch  # noqa: E402
@@ -63,15 +103,12 @@ def _rel_l2(a, b):
     return (torch.norm(a.float() - b.float()) / (torch.norm(b.float()) + 1e-12)).item()
 
 
-@pytest.mark.parametrize("L,Z", [(256, 4), (512, 2)])
-def test_self_attention_fwd_autows(L, Z):
-    if not torch.cuda.is_available():
-        pytest.skip("requires CUDA")
-    assert bool(A._HSTU_SELF_AUTOWS), "autoWS flag not baked on"
-
+def _run_autows_bwd(L, Z):
+    """Run the (already-imported) autoWS kernel fwd+bwd and return the grads plus
+    the torch-float reference grads. Config is whatever env was baked at import."""
     torch.manual_seed(0)
     t = Z * L
-    g = lambda: torch.randn(t, H, D, device="cuda", dtype=torch.bfloat16)
+    g = lambda: torch.randn(t, H, D, device="cuda", dtype=torch.bfloat16)  # noqa: E731
     q, k, v = g().requires_grad_(True), g().requires_grad_(True), g().requires_grad_(True)
     so = torch.arange(0, t + 1, L, device="cuda", dtype=torch.int64)
     asc = torch.tensor(1.0 / L, device="cuda", dtype=torch.float32)
@@ -92,8 +129,68 @@ def test_self_attention_fwd_autows(L, Z):
         enable_tma=True,
     )
     o.backward(do)
-    dq, dk, dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+    return (q.grad.clone(), k.grad.clone(), v.grad.clone()), (rq, rk, rv)
+
+
+@pytest.mark.parametrize("L,Z", [(256, 4), (512, 2)])
+def test_self_attention_fwd_autows(L, Z):
+    """DEFAULT autoWS config (in-process): fwd + grads vs torch reference."""
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    assert bool(A._HSTU_SELF_AUTOWS), "autoWS flag not baked on"
+
+    (dq, dk, dv), (rq, rk, rv) = _run_autows_bwd(L, Z)
 
     for name, got, want in (("dq", dq, rq), ("dk", dk, rk), ("dv", dv, rv)):
         rl2 = _rel_l2(got, want)
         assert rl2 < 1e-2, f"autoWS {name} rel-L2 {rl2:.2e} too high (L={L} Z={Z})"
+
+
+@pytest.mark.parametrize("L,Z", [(256, 2)])
+def test_self_attention_bwd_autows_dqreduce(L, Z):
+    """TLX-matching dq-reduce config (BM=BN=128, ns=2, TMEM reuse, dsT-in-SMEM).
+
+    Runs in a SUBPROCESS because its flags are constexpr-baked at import and
+    cannot share an interpreter with the default config above. Asserts the bwd
+    grads match the torch-float reference (== TLX numerics) to bf16 precision;
+    this is the case that previously produced dv rel-L2 ~0.5 before the
+    dsT-in-SMEM / mmaSelfLatency fixes.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    # The subprocess re-runs this file with --run-dqreduce, which selects
+    # _DQREDUCE_CFG via hstu_autows_config.set_config() before importing the kernel
+    # (no HSTU_SELF_* env needed).
+    r = subprocess.run(
+        [sys.executable, __file__, "--run-dqreduce", str(L), str(Z)],
+        env=dict(os.environ), capture_output=True, text=True, timeout=900,
+    )
+    # Surface the child's REL_L2 line (and any error) in the pytest output.
+    sys.stdout.write(r.stdout)
+    sys.stderr.write(r.stderr)
+    assert r.returncode == 0, (
+        f"dq-reduce autoWS bwd failed (L={L} Z={Z}):\n{r.stdout}\n{r.stderr}"
+    )
+
+
+if __name__ == "__main__":
+    # Subprocess entry point for the dq-reduce config. The env (_DQREDUCE_ENV) is
+    # already in os.environ before this file's top-level import ran, so the kernel
+    # was imported with the dq-reduce constexprs baked on.
+    if len(sys.argv) >= 4 and sys.argv[1] == "--run-dqreduce":
+        _L, _Z = int(sys.argv[2]), int(sys.argv[3])
+        assert bool(A._HSTU_DQ_REUSE), "dq-reduce reuse flag not baked on"
+        (dq, dk, dv), (rq, rk, rv) = _run_autows_bwd(_L, _Z)
+        rls = {n: _rel_l2(g_, w) for n, g_, w in
+               (("dq", dq, rq), ("dk", dk, rk), ("dv", dv, rv))}
+        print(
+            f"REL_L2 dq/dk/dv = {rls['dq']:.2e} / {rls['dk']:.2e} / {rls['dv']:.2e} "
+            f"(L={_L} Z={_Z})"
+        )
+        bad = {n: v for n, v in rls.items() if not (v < 1e-2)}
+        if bad:
+            print(f"FAIL: rel-L2 too high: {bad}")
+            sys.exit(1)
+        print("OK")
+        sys.exit(0)
+    sys.exit("usage: test_self_attention_autows.py --run-dqreduce L Z")

--- a/third_party/tlx/tutorials/test_self_attention_bwd.py
+++ b/third_party/tlx/tutorials/test_self_attention_bwd.py
@@ -15,11 +15,14 @@ import sys
 _HSTU_DIR = os.path.join(os.path.dirname(__file__), "hstu_self_attn")
 sys.path.insert(0, _HSTU_DIR)
 
-# plain Triton + TLX (no autoWS, no meta-WS); TLX needs the wsbarrier-reorder off.
-os.environ.pop("HSTU_SELF_AUTOWS", None)
-os.environ.pop("TRITON_USE_META_WS", None)
-os.environ["HSTU_SELF_PIN"] = "1"
-os.environ["TRITON_DISABLE_WSBARRIER_REORDER"] = "1"
+# HSTU autoWS config as a dict (replaces HSTU_SELF_* env vars), applied via
+# hstu_autows_config.set_config() before importing the kernel (config is read at
+# import). This is the non-autoWS path (plain-Triton vs TLX): autoWS off, pinned
+# for fast compile. The Triton compiler knobs (use_meta_ws off, wsbarrier-reorder
+# off for TLX) are applied per-run via a knobs scope in bench_self.grads().
+import hstu_autows_config as _C  # noqa: E402
+
+_C.set_config(autows=False, pin=True)
 
 import pytest  # noqa: E402
 import torch  # noqa: E402


### PR DESCRIPTION
Summary:

Enable Meta-Triton automatic warp specialization on the HSTU self-attention
backward: add warp_specialize to the start_m compute loop and a big-enough
HSTU_SELF_AUTOWS bwd autotune config (the tiny default config stays SIMT).
autoWS self-attn bwd is correct (vs torch) and, on GB200, matches/beats the
hand-written TLX bwd at seq 256/512.

dq is computed via TMA reduce-add (opt-in, mirrors TLX) instead of an in-loop
global read-modify-write, with the FA-style TMEM reuse, stage/order schedule,
and dp-before-dv ordering needed to avoid a deadlock at BM=BN=128 and match the
TLX bwd; the dk dsT operand is pinned to SMEM to fix a dq-reduce dv corruption.

Updates the correctness tests (test_self_attention_autows.py TLX-matching
dq-reduce config; test_self_attention_bwd.py) and removes the dead
autows_check.py / fwd_check.py helpers.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D112707449


