### PR TITLE
[AutoWS][HSTU self] Fwd fold + FA-style manual data-partition + harness + tests (#2310)

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -2468,6 +2468,29 @@ void propagatePartitions(LoopLikeOpInterface loop, PartitionSet &schedule,
   }
 }
 
+// An op is cheap enough to rematerialize into a consumer partition (instead of
+// routing its value through a cross-partition channel) if it is a
+// layout/metadata rearrangement or a pure integer index/mask computation.
+// Restricting the arithmetic to integer/index results excludes float compute
+// (softmax/SiLU) and reductions, which must stay channeled (cloning those would
+// cascade expensive work into compute partitions and break channel invariants).
+static bool isRematerializableForClone(Operation *defOp) {
+  if (isa<ConvertLayoutOp, BroadcastOp, ExpandDimsOp, MakeRangeOp, SplatOp>(
+          defOp))
+    return true;
+  if (defOp->getDialect() && defOp->getDialect()->getNamespace() == "arith") {
+    for (Value res : defOp->getResults()) {
+      Type t = res.getType();
+      if (auto tt = dyn_cast<RankedTensorType>(t))
+        t = tt.getElementType();
+      if (!t.isIntOrIndex())
+        return false;
+    }
+    return true;
+  }
+  return false;
+}
+
 /// Walk over \p loop and clone cheap ops into each partition that uses them,
 /// rematerializing metadata-only or layout-only values instead of routing
 /// them through a cross-partition memory channel.
@@ -2502,11 +2525,16 @@ void optimizeSchedule(LoopLikeOpInterface loop, PartitionSet &schedule) {
   // passes insert a ConvertLayoutOp between ExpandDimsOp and BroadcastOp,
   // which would otherwise break the cloning chain and create a
   // cross-partition boundary.
+  // Walk backward from a cloned op and rematerialize its cross-partition cheap
+  // operand producers into the user partition. A worklist (not a single linear
+  // chain) is used so multi-operand index ops (e.g. arith.addi of a make_range
+  // and a splat, as in a causal-mask column-index chain) are fully pulled in;
+  // otherwise the un-pulled operand stays cross-partition and forces a register
+  // channel whose layout transfer can break downstream expand_dims inference.
   auto cloneOperandChain = [&](Operation *clonedOp, Partition *userPartition) {
-    Operation *current = clonedOp;
-    while (true) {
-      Operation *toPull = nullptr;
-      unsigned operandIdx = 0;
+    SmallVector<Operation *> worklist{clonedOp};
+    while (!worklist.empty()) {
+      Operation *current = worklist.pop_back_val();
       for (auto [idx, operand] : llvm::enumerate(current->getOperands())) {
         auto *defOp = operand.getDefiningOp();
         if (!defOp)
@@ -2514,18 +2542,13 @@ void optimizeSchedule(LoopLikeOpInterface loop, PartitionSet &schedule) {
         Partition *defPartition = getPartition(defOp);
         if (!defPartition || defPartition == userPartition)
           continue;
-        if (!isa<ConvertLayoutOp, BroadcastOp, ExpandDimsOp>(defOp))
+        if (!isRematerializableForClone(defOp))
           continue;
-        toPull = defOp;
-        operandIdx = idx;
-        break;
+        Operation *pullClone = OpBuilder(defOp).clone(*defOp);
+        setPartition(pullClone, userPartition);
+        current->setOperand(idx, pullClone->getResult(0));
+        worklist.push_back(pullClone);
       }
-      if (!toPull)
-        break;
-      Operation *pullClone = OpBuilder(toPull).clone(*toPull);
-      setPartition(pullClone, userPartition);
-      current->setOperand(operandIdx, pullClone->getResult(0));
-      current = pullClone;
     }
   };
 

--- a/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
@@ -16,9 +16,9 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-os.environ.pop("TRITON_USE_META_WS", None)  # TLX is hand-WS, not compiler-WS
 
 import torch  # noqa: E402
+import triton  # noqa: E402
 
 import triton_hstu_attention as A  # noqa: E402
 import tlx_bw_hstu_attention as T  # noqa: E402
@@ -101,8 +101,14 @@ def run_tlx(q, k, v, so, L, asc, causal=True):
 def grads(run, q, k, v, so, L, asc, do, **kw):
     for t in (q, k, v):
         t.grad = None
-    out = run(q, k, v, so, L, asc, **kw)
-    out.backward(do)
+    # TLX and plain Triton are not compiler-warp-specialized: force meta-WS off
+    # (and the WS-barrier reorder off, which TLX lowering needs) through a knobs
+    # scope so the override is auto-isolated instead of leaking into os.environ.
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = False
+        triton.knobs.nvidia.disable_wsbarrier_reorder = True
+        out = run(q, k, v, so, L, asc, **kw)
+        out.backward(do)
     return out.detach(), q.grad.clone(), k.grad.clone(), v.grad.clone()
 
 

--- a/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
@@ -1,16 +1,26 @@
-"""Accuracy harness for the ported HSTU SELF-attention kernels (MetaMain2 OSS).
+"""Accuracy + perf harness for the ported HSTU SELF-attention kernels (MetaMain2 OSS).
 
 Variants:
   * triton - hammer-template Triton self-attn (triton_hstu_mha), fwd+bwd. Trusted ref.
   * tlx    - hand-written TLX warp-specialized self-attn (tlx_bw_hstu_mha), Blackwell.
+  * autows - the SAME triton_hstu_mha compiled under meta-WS (HSTU_SELF_AUTOWS=1) +
+             the TLX-matching dq-reduce bwd config (BM=BN=128, ns=2, TMEM reuse,
+             mem-plan search).
 
-Checks fwd output + dq/dk/dv grads:
-  - triton vs a torch-float HSTU-SiLU reference (both causal and non-causal, to
-    identify which masking the kernel uses),
+Accuracy (--acc, default): checks fwd output + dq/dk/dv grads
+  - triton vs a torch-float HSTU-SiLU reference (both causal and non-causal),
   - tlx vs triton (the byte-ish correctness check; same hammer math).
 
+Perf (--perf): fwd + bwd latency per variant via triton.testing.do_bench, N-rep
+  mean/std, and speedup vs TLX (mirrors hstu_cross_attn/bench_bwd.py run_perf).
+  Because autoWS (meta-WS on; HSTU_SELF_AUTOWS is a tl.constexpr baked at import)
+  cannot share a process with TLX (TLX asserts under meta-WS), EACH variant is
+  timed in its OWN subprocess with the right env, and this parent tabulates.
+
 Usage (from this dir, on a Blackwell GPU):
-  CUDA_VISIBLE_DEVICES=1 ~/.conda/envs/metamain2/bin/python bench_self.py
+  CUDA_VISIBLE_DEVICES=1 ~/.conda/envs/metamain2/bin/python bench_self.py            # accuracy
+  CUDA_VISIBLE_DEVICES=1 ~/.conda/envs/metamain2/bin/python bench_self.py --perf --nrep 5
+  ... --perf --variants autows,tlx --seqlens 512,1024,4096 --batch 2
 """
 import os
 import sys
@@ -24,17 +34,46 @@ import triton_hstu_attention as A  # noqa: E402
 import tlx_bw_hstu_attention as T  # noqa: E402
 
 D = 128
-H = 2
+# heads/sparsity are env-driven so they flow to the per-variant perf subprocesses
+# (D102650040 production shape: heads=4, seq=4096, sparsity=0.95, batch=512).
+H = int(os.environ.get("BENCH_HEADS", "2"))
 
 
-def make(L, Z, dtype=torch.bfloat16):
-    t = Z * L
-    g = lambda: torch.randn(t, H, D, device="cuda", dtype=dtype)
+def generate_sparse_seq_len(size, max_seq_len, sparsity, device, generator=None):
+    """Port of generative_recommenders.common.generate_sparse_seq_len (the
+    fbsource HSTU bench / D102650040 shape). `sparsity` is a DENSITY knob --
+    higher => LONGER sequences. Uniform: sparsity>=0.5 -> U[(2s-1)*max, max);
+    sparsity<0.5 -> U[0, 2s*max). Clamped >=1 so every segment is non-empty."""
+    if sparsity == 0.0:
+        return torch.ones(size, device=device, dtype=torch.int64)
+    if sparsity == 1.0:
+        return torch.full((size,), max_seq_len, device=device, dtype=torch.int64)
+    if sparsity >= 0.5:
+        lo, hi = int((2 * sparsity - 1.0) * max_seq_len), max_seq_len
+    else:
+        lo, hi = 0, int(2 * sparsity * max_seq_len)
+    lo, hi = max(lo, 1), max(hi, 2)
+    return torch.randint(lo, hi, (size,), device=device, dtype=torch.int64, generator=generator)
+
+
+def make(L, Z, dtype=torch.bfloat16, sparsity=None, seed=1001):
+    """Build (q,k,v,do,so,asc). Default (sparsity=None) = uniform dense segments
+    (every batch item seq-len = L). sparsity set = jagged variable-length segments
+    (perf-only; torch_ref assumes uniform L). L is the per-item MAX seq-len."""
+    dev = "cuda"
+    if sparsity is None:
+        lens = torch.full((Z,), L, device=dev, dtype=torch.int64)
+    else:
+        gen = torch.Generator(device=dev).manual_seed(seed)
+        lens = generate_sparse_seq_len(Z, L, sparsity, dev, gen)
+    so = torch.zeros(Z + 1, device=dev, dtype=torch.int64)
+    torch.cumsum(lens, 0, out=so[1:])
+    t = int(so[-1])
+    g = lambda: torch.randn(t, H, D, device=dev, dtype=dtype)  # noqa: E731
     q = g().requires_grad_(True)
     k = g().requires_grad_(True)
     v = g().requires_grad_(True)
-    so = torch.arange(0, t + 1, L, device="cuda", dtype=torch.int64)
-    asc = torch.tensor(1.0 / L, device="cuda", dtype=torch.float32)
+    asc = torch.tensor(1.0 / L, device=dev, dtype=torch.float32)
     do = g()
     return q, k, v, do, so, asc
 
@@ -65,7 +104,7 @@ def rel_l2(a, b):
     return (torch.norm(a.float() - b.float()) / (torch.norm(b.float()) + 1e-12)).item()
 
 
-def run_triton(q, k, v, so, L, asc):
+def run_triton(q, k, v, so, L, asc, num_targets=None):
     return A.triton_hstu_mha(
         max_seq_len=L,
         alpha=1.0 / D,
@@ -74,14 +113,14 @@ def run_triton(q, k, v, so, L, asc):
         v=v,
         seq_offsets=so,
         attn_scale=asc,
-        num_targets=None,
+        num_targets=num_targets,
         max_attn_len=0,
         contextual_seq_len=0,
         enable_tma=True,
     )
 
 
-def run_tlx(q, k, v, so, L, asc, causal=True):
+def run_tlx(q, k, v, so, L, asc, causal=True, num_targets=None):
     return T.tlx_bw_hstu_mha(
         max_seq_len=L,
         alpha=1.0 / D,
@@ -91,7 +130,7 @@ def run_tlx(q, k, v, so, L, asc, causal=True):
         seq_offsets=so,
         attn_scale=asc,
         num_softmax_heads=0,
-        num_targets=None,
+        num_targets=num_targets,
         max_attn_len=0,
         contextual_seq_len=0,
         causal=causal,
@@ -112,8 +151,8 @@ def grads(run, q, k, v, so, L, asc, do, **kw):
     return out.detach(), q.grad.clone(), k.grad.clone(), v.grad.clone()
 
 
-def main():
-    for (L, Z) in [(256, 4), (512, 2)]:
+def run_accuracy(shapes):
+    for (L, Z) in shapes:
         print(f"\n=== L={L} Z={Z} H={H} D={D} ===")
         torch.manual_seed(0)
         q, k, v, do, so, asc = make(L, Z)
@@ -143,6 +182,151 @@ def main():
                 print(line)
             except Exception as e:
                 print(f"  tlx(causal={causal}) ERROR {type(e).__name__}: {str(e)[:120]}")
+
+
+# ---- perf ---------------------------------------------------------------
+# Per-variant env applied BEFORE the child imports the kernel (autoWS flags are
+# tl.constexpr baked at import). "autows" uses the TLX-matching dq-reduce config.
+_PERF_ENV = {
+    "triton": {},
+    "tlx": {},
+    "autows": {
+        "HSTU_SELF_AUTOWS": "1", "HSTU_SELF_DQ_REDUCE": "1", "HSTU_SELF_DQ_REUSE": "1",
+        "HSTU_SELF_DP": "1", "HSTU_SELF_AUTOWS_BWD_BM": "128", "HSTU_SELF_AUTOWS_BWD_BN": "128",
+        "HSTU_SELF_AUTOWS_BWD_STAGES": "2", "HSTU_SELF_AUTOWS_WARPS": "4",
+        "HSTU_SELF_PIN": "1", "HSTU_SELF_DQ_ITERS": "4", "TRITON_WS_SMEM_PLAN_SEARCH": "1",
+    },
+}
+
+
+def _bench_one(variant, L, Z, nrep):
+    """Time fwd + bwd of ONE variant in THIS process (env already set by parent).
+    Prints a machine-parseable PERF line."""
+    import statistics
+    torch.manual_seed(0)
+    _sp = os.environ.get("BENCH_SPARSITY")
+    q, k, v, do, so, asc = make(L, Z, sparsity=float(_sp) if _sp else None)
+    run = run_tlx if variant == "tlx" else run_triton  # triton & autows share triton_hstu_mha
+    kw = {"causal": True} if variant == "tlx" else {}
+    # Optional targets (BENCH_TARGET_SIZE>0): per-batch target counts like the
+    # fbsource HSTU bench, clamped to each jagged seq-len. Setting this exercises
+    # the num_targets/target-masking path (the autoWS compile trigger).
+    _ts = int(os.environ.get("BENCH_TARGET_SIZE", "0"))
+    if _ts > 0:
+        lens = so[1:] - so[:-1]
+        lo = 1 if _ts < 400 else _ts // 2
+        nt = torch.randint(lo, _ts + 1, (Z,), device=so.device, dtype=torch.int64)
+        kw["num_targets"] = torch.minimum(nt, lens)
+    meta_ws = variant == "autows"
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = meta_ws
+        triton.knobs.nvidia.disable_wsbarrier_reorder = True
+        fwd = lambda: run(q, k, v, so, L, asc, **kw)  # noqa: E731
+        out = fwd()  # warm / compile / autotune
+        torch.cuda.synchronize()
+        fwd_s = [triton.testing.do_bench(fwd, warmup=25, rep=100) for _ in range(nrep)]
+
+        def bwd():
+            for t in (q, k, v):
+                t.grad = None
+            out.backward(do, retain_graph=True)
+
+        bwd()  # warm
+        bwd_s = [triton.testing.do_bench(bwd, warmup=25, rep=100) for _ in range(nrep)]
+    fm, bm = statistics.mean(fwd_s), statistics.mean(bwd_s)
+    fsd = statistics.stdev(fwd_s) if len(fwd_s) > 1 else 0.0
+    bsd = statistics.stdev(bwd_s) if len(bwd_s) > 1 else 0.0
+    print(f"PERF {variant} L={L} Z={Z} fwd={fm:.4f} fwd_sd={fsd:.4f} bwd={bm:.4f} bwd_sd={bsd:.4f}")
+
+
+def run_perf(shapes, variants, nrep=1, heads=None, sparsity=None, timeout=3600):
+    """Time each variant's fwd+bwd in its own subprocess and tabulate (speedup vs tlx).
+    heads/sparsity flow to the children via env (BENCH_HEADS / BENCH_SPARSITY)."""
+    import re
+    import subprocess
+
+    hh = heads if heads is not None else H
+    inp = "uniform-dense" if sparsity is None else f"jagged sparsity={sparsity}"
+    print(f"\n=== Perf (self-attn fwd/bwd latency, nrep={nrep}, heads={hh}, {inp}) "
+          f"— each variant in its own process ===")
+    for (L, Z) in shapes:
+        print(f"\n  maxL={L} Z={Z} H={hh} D={D}")
+        hdr = f"  {'variant':<10}{'fwd ms':>10}{'bwd ms':>10}"
+        hdr += f"{'fwd sd':>9}{'bwd sd':>9}" if nrep > 1 else f"{'fwd/tlx':>9}{'bwd/tlx':>9}"
+        print(hdr)
+        rows = []
+        for var in variants:
+            env = dict(os.environ)
+            env.update(_PERF_ENV[var])
+            if heads is not None:
+                env["BENCH_HEADS"] = str(heads)
+            if sparsity is not None:
+                env["BENCH_SPARSITY"] = str(sparsity)
+            try:
+                r = subprocess.run(
+                    [sys.executable, os.path.abspath(__file__), "--bench-one", var,
+                     str(L), str(Z), str(nrep)],
+                    env=env, capture_output=True, text=True, timeout=timeout,
+                )
+            except subprocess.TimeoutExpired:
+                print(f"  {var:<10} TIMEOUT/HANG")
+                continue
+            m = re.search(r"PERF \S+ L=\d+ Z=\d+ fwd=(\S+) fwd_sd=(\S+) bwd=(\S+) bwd_sd=(\S+)",
+                          r.stdout)
+            if not m:
+                tail = (r.stdout + r.stderr).strip().splitlines()[-1:] or ["(no output)"]
+                print(f"  {var:<10} ERROR: {tail[0][:70]}")
+                continue
+            fm, fsd, bm, bsd = map(float, m.groups())
+            rows.append((var, fm, fsd, bm, bsd))
+        tlx = next((x for x in rows if x[0] == "tlx"), None)
+        for var, fm, fsd, bm, bsd in rows:
+            if nrep > 1:
+                print(f"  {var:<10}{fm:>10.4f}{bm:>10.4f}{fsd:>9.4f}{bsd:>9.4f}")
+            else:
+                fx = f"{tlx[1] / fm:.2f}x" if tlx and fm else "-"
+                bx = f"{tlx[3] / bm:.2f}x" if tlx and bm else "-"
+                print(f"  {var:<10}{fm:>10.3f}{bm:>10.3f}{fx:>9}{bx:>9}")
+
+
+def main():
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--perf", action="store_true", help="run the fwd/bwd latency benchmark")
+    ap.add_argument("--acc", action="store_true", help="run the accuracy check (default)")
+    ap.add_argument("--nrep", type=int, default=1,
+                    help="do_bench repetitions per point; >1 reports mean + std")
+    ap.add_argument("--variants", default="autows,tlx,triton",
+                    help="comma subset of autows,tlx,triton (perf)")
+    ap.add_argument("--seqlens", default=None, help="comma L list, e.g. 256,512,1024,4096")
+    ap.add_argument("--batch", type=int, default=None, help="batch Z (default 2)")
+    ap.add_argument("--heads", type=int, default=None, help="num heads H (perf; default 2)")
+    ap.add_argument("--sparsity", type=float, default=None,
+                    help="jagged density knob (0.95 = D102650040); omit for uniform-dense")
+    # hidden per-variant subprocess entry: --bench-one <variant> <L> <Z> <nrep>
+    ap.add_argument("--bench-one", nargs=4, default=None, help=argparse.SUPPRESS,
+                    metavar=("VARIANT", "L", "Z", "NREP"))
+    args = ap.parse_args()
+
+    if args.bench_one:
+        var, L, Z, nrep = args.bench_one
+        _bench_one(var, int(L), int(Z), int(nrep))
+        return
+
+    Z = args.batch if args.batch is not None else 2
+    if args.seqlens:
+        shapes = [(int(x), Z) for x in args.seqlens.split(",")]
+    else:
+        shapes = [(256, 4), (512, 2)] if args.batch is None else [(256, Z), (512, Z)]
+
+    do_acc = args.acc or not args.perf
+    do_perf = args.perf or not args.acc
+    if do_acc:
+        run_accuracy(shapes)
+    if do_perf:
+        variants = [v.strip() for v in args.variants.split(",") if v.strip()]
+        run_perf(shapes, variants, nrep=args.nrep, heads=args.heads, sparsity=args.sparsity)
 
 
 if __name__ == "__main__":

--- a/third_party/tlx/tutorials/hstu_self_attn/hstu_autows_config.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/hstu_autows_config.py
@@ -1,0 +1,27 @@
+"""Pre-import HSTU autoWS config hook (no triton import).
+
+Lets callers/tests set the HSTU autoWS config as a dict *before* importing
+``triton_hstu_attention`` -- replacing the old ``HSTU_SELF_*`` environment
+variables. ``triton_hstu_attention`` merges ``pop_overrides()`` into its
+``HSTUAutoWSConfig`` at import (autoWS structural flags + the autotune tile config
+are read at import / decoration, so they must be set before the kernel module is
+imported). After import, use ``triton_hstu_attention.configure_autows()`` or the
+``autows_cfg=`` argument on the entrypoints instead.
+
+    import hstu_autows_config as C
+    C.set_config(autows=True, dp=1, dq_reduce=True, dq_reuse=True, dq_iters=4,
+                 warps=4, bwd_bm=128, bwd_bn=128, bwd_stages=2, pin=True)
+    import triton_hstu_attention as A   # picks up the config
+"""
+
+_OVERRIDES: dict = {}
+
+
+def set_config(**kwargs) -> None:
+    """Set HSTU autoWS config overrides (field names of HSTUAutoWSConfig)."""
+    _OVERRIDES.update(kwargs)
+
+
+def pop_overrides() -> dict:
+    """Return (a copy of) the pending overrides for triton_hstu_attention import."""
+    return dict(_OVERRIDES)

--- a/third_party/tlx/tutorials/hstu_self_attn/tlx_bw_hstu_attention.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/tlx_bw_hstu_attention.py
@@ -2419,7 +2419,7 @@ def get_hstu_bwd_configs() -> List[triton.Config]:
             pre_hook=_hstu_bwd_host_descriptor_pre_hook,
         )
         # HSTU_SELF_PIN=1 -> one config (fast compile for tritonbench --mode bwd).
-        for er in ([1] if os.environ.get("HSTU_SELF_PIN") else [1, 2])
+        for er in ([1] if os.environ.get("HSTU_SELF_PIN") == "1" else [1, 2])
     ] + [
         triton.Config(
             {
@@ -2443,7 +2443,7 @@ def get_hstu_bwd_configs() -> List[triton.Config]:
             pre_hook=_hstu_bwd_host_descriptor_pre_hook,
         )
         # HSTU_SELF_PIN=1 -> one config (fast compile for tritonbench --mode bwd).
-        for er in ([1] if os.environ.get("HSTU_SELF_PIN") else [1, 2])
+        for er in ([1] if os.environ.get("HSTU_SELF_PIN") == "1" else [1, 2])
     ]
 
 
@@ -4877,6 +4877,7 @@ def tlx_hstu_attention_bwd(
     max_attn_len: int = 0,
     full_attn_size: int = 0,
     contextual_seq_len: int = 0,
+    use_persistent: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Backward pass for HSTU attention with jagged sequences."""
     q = switch_to_contiguous_if_needed(q)
@@ -4976,7 +4977,6 @@ def tlx_hstu_attention_bwd(
 
     stage = 3 if causal else 1
 
-    use_persistent = True
     if use_persistent:
         grid = lambda meta: (  # noqa E731
             H * Z * triton.cdiv(max_seq_len, meta["BLOCK_N1"]), )

--- a/third_party/tlx/tutorials/hstu_self_attn/triton_attention_utils.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/triton_attention_utils.py
@@ -10,15 +10,6 @@ import triton
 # @manual=//triton:triton
 import triton.language as tl
 
-try:
-    # @manual=//triton:triton
-    import triton.language.extra.tlx as tlx  # type: ignore[attr-defined]
-
-    HAS_TLX = True
-except ImportError:
-    tlx = None
-    HAS_TLX = False
-
 from triton.language.extra.libdevice import (  # @manual=//triton:triton
     fast_dividef, fast_expf,
 )

--- a/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
@@ -55,6 +55,7 @@ class HSTUAutoWSConfig:
 
     autows: bool = False  # enable meta-WS on the KV loop
     dp: int = 1  # data-partition factor (MMA groups)
+    fa_dp: bool = False  # FA-style manual fwd data partition (split-M, shared K/V)
     dq_reduce: bool = False  # bwd dq via TMA reduce-add (vs in-loop RMW)
     dq_reuse: bool = False  # FA-style TMEM reuse for the dq-reduce bwd
     dq_iters: int = 1  # dq TMA-reduce column subtiles
@@ -73,6 +74,7 @@ class HSTUAutoWSConfig:
         return cls(
             autows=autows,
             dp=int(g("HSTU_SELF_DP", "2" if autows else "1")),
+            fa_dp=bool(int(g("HSTU_SELF_FA_DP", "0"))),
             dq_reduce=g("HSTU_SELF_DQ_REDUCE") == "1",
             dq_reuse=g("HSTU_SELF_DQ_REUSE", "0") == "1",
             dq_iters=int(g("HSTU_SELF_DQ_ITERS", "1")),
@@ -99,10 +101,11 @@ except Exception:  # noqa: BLE001 -- hook is optional
 
 def _sync_autows_constexprs() -> None:
     # Re-derive the tl.constexpr views (read inside @triton.jit) from _AUTOWS_CFG.
-    global _HSTU_SELF_AUTOWS, _HSTU_SELF_DP, _HSTU_SELF_DQ_REDUCE
+    global _HSTU_SELF_AUTOWS, _HSTU_SELF_DP, _HSTU_SELF_FA_DP, _HSTU_SELF_DQ_REDUCE
     global _HSTU_SELF_DQ_ITERS, _HSTU_DQ_REUSE
     _HSTU_SELF_AUTOWS = tl.constexpr(_AUTOWS_CFG.autows)
     _HSTU_SELF_DP = tl.constexpr(_AUTOWS_CFG.dp)
+    _HSTU_SELF_FA_DP = tl.constexpr(_AUTOWS_CFG.fa_dp)
     _HSTU_SELF_DQ_REDUCE = tl.constexpr(_AUTOWS_CFG.dq_reduce)
     _HSTU_SELF_DQ_ITERS = tl.constexpr(_AUTOWS_CFG.dq_iters)
     _HSTU_DQ_REUSE = tl.constexpr(_AUTOWS_CFG.dq_reduce and _AUTOWS_CFG.dq_reuse)
@@ -135,6 +138,11 @@ _HSTU_SELF_AUTOWS = tl.constexpr(_AUTOWS_CFG.autows)
 # autoWS analog of TLX's replicate=NUM_MMA_GROUPS). Default 2 when autoWS is on
 # (matches TLX's 2 MMA groups), 1 otherwise; override with HSTU_SELF_DP.
 _HSTU_SELF_DP = tl.constexpr(_AUTOWS_CFG.dp)
+# FA-style manual data partition (opt-in via cfg.fa_dp, default OFF): split BLOCK_M
+# into two halves processed in one program, sharing one K/V load per KV block
+# (mirrors fused_attention_ws_device_tma_dp.py). Two accumulators, two output
+# stores; the shared KV loop is warp-specialized (load group + 2 MMA groups).
+_HSTU_SELF_FA_DP = tl.constexpr(_AUTOWS_CFG.fa_dp)
 # EXPERIMENTAL, opt-in via HSTU_SELF_DQ_REDUCE=1 (OFF by default): dq via TMA
 # reduce-add instead of the in-loop global RMW, mirroring the cross-attn autoWS
 # bwd (triton_bw_cross_attention.py: natural dq_trans = trans(k)@dqk MMA, then
@@ -874,6 +882,45 @@ def _hstu_attn_fwd_one_block_0(  # noqa: C901
 
 
 @triton.jit
+def _hstu_attn_fwd_subtile(  # noqa: C901
+    q,
+    k,
+    v,
+    offs_m,
+    offs_n,
+    seq_len_q,
+    alpha,
+    scale,
+    acc,
+    max_attn_len,
+    contextual_seq_len,
+    n_targets,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+):
+    # FA-style DP subtile: k/v are PRE-LOADED (shared across the two M-halves) so
+    # each KV block is fetched once. k is [BLOCK_N, BLOCK_D_Q] in TMA order.
+    qk = tl.dot(q, tl.trans(k), allow_tf32=ALLOW_TF32)
+    valid_mask = forward_valid_mask(
+        offs_m,
+        offs_n,
+        seq_len_q,
+        contextual_seq_len,
+        max_attn_len,
+        n_targets,
+        HAS_CONTEXTUAL_SEQ_LEN,
+        HAS_NUM_TARGETS,
+        HAS_MAX_ATTN_LEN,
+    )
+    act_qk = forward_activation(qk, alpha, scale, valid_mask)
+    act_qk = act_qk.to(v.dtype)
+    acc += tl.dot(act_qk, v, allow_tf32=ALLOW_TF32)
+    return acc
+
+
+@triton.jit
 def _hstu_attn_bwd_one_block_0(  # noqa C901
     start_m,
     offs_n,
@@ -1226,20 +1273,39 @@ def _hstu_attn_fwd_compute(  # noqa C901
                 uih_end = (uih_end + BLOCK_N - 1) // BLOCK_N * BLOCK_N
                 if uih_end < start_m:
                     high = seq_len_q - n_targets
-        offset = low
-        # single loop compute
-        if offset > 0:
-            if not ENABLE_TMA:
-                K_block_ptr = tl.advance(K_block_ptr, (0, offset))
-                V_block_ptr = tl.advance(V_block_ptr, (offset, 0))
-        end_n = low
-        for start_n in tl.range(
-                low,
-                high,
-                BLOCK_N,
-                warp_specialize=_HSTU_SELF_AUTOWS,
-                data_partition_factor=_HSTU_SELF_DP,
+        # Folded single-ForOp KV loop (option A): visit the uih blocks
+        # [low, high) and then the target diagonal block [start_m, start_m+BLOCK_M)
+        # in ONE loop, so the PV accumulator lives in a single WS scope / single
+        # TMEM tile -- mirrors TLX's single GEMM loop; removes the scf.if operand-D
+        # round-trip AND the cross-loop SMEM reuse group. The iteration index is
+        # remapped to the exact same start_n set the previous two loops visited, so
+        # results are unchanged (no extra/gap blocks, no new masking assumptions).
+        uih_lo = low
+        uih_hi = high
+        n_uih = (uih_hi - uih_lo + BLOCK_N - 1) // BLOCK_N
+        n_tgt = 0
+        tgt_lo = uih_hi
+        if HAS_NUM_TARGETS:
+            has_tgt = uih_end < start_m
+            n_tgt = tl.where(has_tgt, (BLOCK_M + BLOCK_N - 1) // BLOCK_N, 0)
+            tgt_lo = start_m
+        n_iters = n_uih + n_tgt
+        ptr_pos = 0  # non-TMA: absolute key position the K/V block ptrs point at
+        for it in tl.range(
+            0,
+            n_iters,
+            warp_specialize=_HSTU_SELF_AUTOWS,
+            data_partition_factor=_HSTU_SELF_DP,
         ):
+            is_tgt = it >= n_uih
+            blk = tl.where(is_tgt, it - n_uih, it)
+            start_n = tl.where(is_tgt, tgt_lo + blk * BLOCK_N, uih_lo + blk * BLOCK_N)
+            if not ENABLE_TMA:
+                adv = (start_n - ptr_pos).to(tl.int32)
+                if adv != 0:
+                    K_block_ptr = tl.advance(K_block_ptr, (0, adv))
+                    V_block_ptr = tl.advance(V_block_ptr, (adv, 0))
+                ptr_pos = start_n
             acc = _hstu_attn_fwd_one_block_0(
                 start_n=start_n,
                 seq_len_q=seq_len_q,
@@ -1275,62 +1341,6 @@ def _hstu_attn_fwd_compute(  # noqa C901
                 BLOCK_N=BLOCK_N,
                 ENABLE_TMA=ENABLE_TMA,
             )
-            if not ENABLE_TMA:
-                K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
-                V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
-            end_n += BLOCK_N
-        if HAS_NUM_TARGETS:
-            if uih_end < start_m:
-                low = start_m
-                high = start_m + BLOCK_M
-                offset = (low - end_n).to(tl.int32)
-                # single loop compute
-                if offset > 0:
-                    if not ENABLE_TMA:
-                        K_block_ptr = tl.advance(K_block_ptr, (0, offset))
-                        V_block_ptr = tl.advance(V_block_ptr, (offset, 0))
-                end_n = low
-                for start_n in tl.range(low, high, BLOCK_N, num_stages=0):
-                    acc = _hstu_attn_fwd_one_block_0(
-                        start_n=start_n,
-                        seq_len_q=seq_len_q,
-                        seq_len_kv=seq_len_kv,
-                        offs_m=offs_m,
-                        offs_n=offs_n + start_n,
-                        off_h=off_h,
-                        q=q,
-                        K=K,
-                        V=V,
-                        acc=acc,
-                        K_block_ptr=K_block_ptr,
-                        V_block_ptr=V_block_ptr,
-                        device_desc_k=device_desc_k,
-                        device_desc_v=device_desc_v,
-                        offset_kh=off_h * stride_kh,
-                        offset_vh=off_h * stride_vh,
-                        seq_start_q=seq_start_q,
-                        seq_start_kv=seq_start_kv,
-                        alpha=alpha,
-                        scale=scale,
-                        num_targets=num_targets,
-                        max_attn_len=max_attn_len,
-                        contextual_seq_len=contextual_seq_len,
-                        n_targets=n_targets,
-                        uih_end=uih_end,
-                        HAS_NUM_TARGETS=HAS_NUM_TARGETS,
-                        HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
-                        HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
-                        ALLOW_TF32=ALLOW_TF32,
-                        BLOCK_D_Q=BLOCK_D_Q,
-                        BLOCK_D_V=BLOCK_D_V,
-                        BLOCK_N=BLOCK_N,
-                        ENABLE_TMA=ENABLE_TMA,
-                    )
-                    if not ENABLE_TMA:
-                        K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
-                        V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
-                    end_n += BLOCK_N
-
         if not ENABLE_TMA:
             # rematerialize offsets to save registers
             start_m = pid * BLOCK_M
@@ -1363,6 +1373,221 @@ def _hstu_attn_fwd_compute(  # noqa C901
                     (off_h * stride_oh).to(tl.int32),
                 ],
             )
+
+
+@triton.jit
+def _hstu_attn_fwd_compute_dp(  # noqa C901
+    Q,
+    K,
+    V,
+    H,
+    DimQ,
+    DimV,
+    workspace_ptr,
+    seq_offsets,
+    seq_offsets_q,
+    Out,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_om,
+    stride_oh,
+    alpha,
+    attn_scale,
+    off_z,
+    off_h,
+    pid,
+    num_targets,
+    max_attn_len,
+    contextual_seq_len,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    ENABLE_TMA: tl.constexpr,
+    TMA_DESC_SIZE: tl.constexpr,
+):
+    # FA-style manual data partition (TMA only): split BLOCK_M into two halves of
+    # BLOCK_M_H each, processed in one program. Each KV block is loaded ONCE and
+    # shared by both halves' MMAs; the shared KV loop is warp-specialized with
+    # data_partition_factor=1 (manual split, not the compiler's 2*BLOCK_M split).
+    tl.static_assert(ENABLE_TMA, "FA-DP path requires ENABLE_TMA")
+    BLOCK_M_H: tl.constexpr = BLOCK_M // 2
+    off_h = off_h.to(tl.int64)
+    off_z = off_z.to(tl.int64)
+    seq_start_kv = tl.load(seq_offsets + off_z).to(tl.int64)
+    seq_end_kv = tl.load(seq_offsets + off_z + 1)
+    seq_len_kv = (seq_end_kv - seq_start_kv).to(tl.int32)
+    seq_start_q = tl.load(seq_offsets_q + off_z).to(tl.int64)
+    seq_end_q = tl.load(seq_offsets_q + off_z + 1)
+    seq_len_q = (seq_end_q - seq_start_q).to(tl.int32)
+
+    workspace_base = workspace_ptr + TMA_DESC_SIZE * 4 * (
+        tl.program_id(1) + tl.program_id(0) * tl.num_programs(1)
+    )
+    device_desc_q = workspace_base
+    device_desc_k = workspace_base + 1 * TMA_DESC_SIZE
+    device_desc_v = workspace_base + 2 * TMA_DESC_SIZE
+    device_desc_o = workspace_base + 3 * TMA_DESC_SIZE
+    # pyre-ignore [20]
+    tl.extra.cuda.experimental_device_tensormap_create2d(
+        desc_ptr=device_desc_k,
+        global_address=K,
+        load_size=[BLOCK_N, BLOCK_D_Q],
+        global_size=[seq_end_kv.to(tl.int32), H * DimQ],
+        element_ty=K.dtype.element_ty,
+    )
+    # pyre-ignore [20]
+    tl.extra.cuda.experimental_device_tensormap_create2d(
+        desc_ptr=device_desc_v,
+        global_address=V,
+        load_size=[BLOCK_N, BLOCK_D_V],
+        global_size=[seq_end_kv.to(tl.int32), H * DimV],
+        element_ty=V.dtype.element_ty,
+    )
+    # pyre-ignore [20]
+    tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_k)
+    # pyre-ignore [20]
+    tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_v)
+
+    start_m = pid * BLOCK_M
+    if start_m < seq_len_q:
+        offs_m0 = start_m + tl.arange(0, BLOCK_M_H)
+        offs_m1 = start_m + BLOCK_M_H + tl.arange(0, BLOCK_M_H)
+        offs_n = tl.arange(0, BLOCK_N)
+        if ATTN_SCALE_TYPE == "scalar":
+            scale0 = tl.load(attn_scale).to(tl.float32)
+            scale1 = scale0
+        else:
+            tl.static_assert(ATTN_SCALE_TYPE == "dynamic")
+            scale0 = tl.load(
+                attn_scale + seq_start_q + offs_m0, mask=offs_m0 < seq_len_q
+            ).to(tl.float32)
+            scale1 = tl.load(
+                attn_scale + seq_start_q + offs_m1, mask=offs_m1 < seq_len_q
+            ).to(tl.float32)
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_device_tensormap_create2d(
+            desc_ptr=device_desc_q,
+            global_address=Q,
+            load_size=[BLOCK_M_H, BLOCK_D_Q],
+            global_size=[seq_end_q.to(tl.int32), H * DimQ],
+            element_ty=Q.dtype.element_ty,
+        )
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_q)
+        q0 = tl._experimental_descriptor_load(
+            device_desc_q,
+            [(seq_start_q + start_m).to(tl.int32), (off_h * stride_qh).to(tl.int32)],
+            [BLOCK_M_H, BLOCK_D_Q],
+            Q.dtype.element_ty,
+        )
+        q1 = tl._experimental_descriptor_load(
+            device_desc_q,
+            [
+                (seq_start_q + start_m + BLOCK_M_H).to(tl.int32),
+                (off_h * stride_qh).to(tl.int32),
+            ],
+            [BLOCK_M_H, BLOCK_D_Q],
+            Q.dtype.element_ty,
+        )
+        acc0 = tl.zeros([BLOCK_M_H, BLOCK_D_V], dtype=tl.float32)
+        acc1 = tl.zeros([BLOCK_M_H, BLOCK_D_V], dtype=tl.float32)
+        n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
+        uih_end = forward_uih_common_preprocess(n_targets, seq_len_q, HAS_NUM_TARGETS)
+        if HAS_CONTEXTUAL_SEQ_LEN is True and start_m < contextual_seq_len:
+            low = 0
+            high = seq_len_q
+        else:
+            low = 0
+            high = start_m + BLOCK_M
+            if HAS_MAX_ATTN_LEN:
+                if start_m > uih_end:
+                    low = uih_end - max_attn_len
+                else:
+                    low = start_m - max_attn_len
+                if HAS_CONTEXTUAL_SEQ_LEN:
+                    low = low if low > contextual_seq_len else 0
+                else:
+                    low = low if low > 0 else 0
+            if HAS_NUM_TARGETS:
+                uih_end = (uih_end + BLOCK_N - 1) // BLOCK_N * BLOCK_N
+                if uih_end < start_m:
+                    high = seq_len_q - n_targets
+        uih_lo = low
+        uih_hi = high
+        n_uih = (uih_hi - uih_lo + BLOCK_N - 1) // BLOCK_N
+        n_tgt = 0
+        tgt_lo = uih_hi
+        if HAS_NUM_TARGETS:
+            has_tgt = uih_end < start_m
+            n_tgt = tl.where(has_tgt, (BLOCK_M + BLOCK_N - 1) // BLOCK_N, 0)
+            tgt_lo = start_m
+        n_iters = n_uih + n_tgt
+        for it in tl.range(
+            0,
+            n_iters,
+            warp_specialize=_HSTU_SELF_AUTOWS,
+            data_partition_factor=1,
+        ):
+            is_tgt = it >= n_uih
+            blk = tl.where(is_tgt, it - n_uih, it)
+            start_n = tl.where(is_tgt, tgt_lo + blk * BLOCK_N, uih_lo + blk * BLOCK_N)
+            k = tl._experimental_descriptor_load(
+                device_desc_k,
+                [(seq_start_kv + start_n).to(tl.int32), (off_h * stride_kh).to(tl.int32)],
+                [BLOCK_N, BLOCK_D_Q],
+                K.dtype.element_ty,
+            )
+            v = tl._experimental_descriptor_load(
+                device_desc_v,
+                [(seq_start_kv + start_n).to(tl.int32), (off_h * stride_vh).to(tl.int32)],
+                [BLOCK_N, BLOCK_D_V],
+                V.dtype.element_ty,
+            )
+            acc0 = _hstu_attn_fwd_subtile(
+                q0, k, v, offs_m0, offs_n + start_n, seq_len_q, alpha, scale0, acc0,
+                max_attn_len, contextual_seq_len, n_targets,
+                HAS_NUM_TARGETS, HAS_MAX_ATTN_LEN, HAS_CONTEXTUAL_SEQ_LEN, ALLOW_TF32,
+            )
+            acc1 = _hstu_attn_fwd_subtile(
+                q1, k, v, offs_m1, offs_n + start_n, seq_len_q, alpha, scale1, acc1,
+                max_attn_len, contextual_seq_len, n_targets,
+                HAS_NUM_TARGETS, HAS_MAX_ATTN_LEN, HAS_CONTEXTUAL_SEQ_LEN, ALLOW_TF32,
+            )
+        acc0 = acc0.to(Out.dtype.element_ty)
+        acc1 = acc1.to(Out.dtype.element_ty)
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_device_tensormap_create2d(
+            desc_ptr=device_desc_o,
+            global_address=Out,
+            load_size=[BLOCK_M_H, BLOCK_D_V],
+            global_size=[seq_end_q.to(tl.int32), H * DimV],
+            element_ty=Out.dtype.element_ty,
+        )
+        # pyre-ignore [20]
+        tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_o)
+        tl._experimental_descriptor_store(
+            device_desc_o,
+            acc0,
+            [(seq_start_q + start_m).to(tl.int32), (off_h * stride_oh).to(tl.int32)],
+        )
+        tl._experimental_descriptor_store(
+            device_desc_o,
+            acc1,
+            [
+                (seq_start_q + start_m + BLOCK_M_H).to(tl.int32),
+                (off_h * stride_oh).to(tl.int32),
+            ],
+        )
 
 
 @triton_autotune(
@@ -1423,45 +1648,40 @@ def _hstu_attn_fwd(  # noqa C901
         off_z = tl.load(sort_by_length_indices + off_z)
     off_h = off_hz % H
     pid = tl.program_id(0)
-    _hstu_attn_fwd_compute(
-        Q=Q,
-        K=K,
-        V=V,
-        H=H,
-        DimQ=DimQ,
-        DimV=DimV,
-        workspace_ptr=workspace_ptr,
-        seq_offsets=seq_offsets,
-        seq_offsets_q=seq_offsets_q,
-        Out=Out,
-        stride_qm=stride_qm,
-        stride_qh=stride_qh,
-        stride_kn=stride_kn,
-        stride_kh=stride_kh,
-        stride_vn=stride_vn,
-        stride_vh=stride_vh,
-        stride_om=stride_om,
-        stride_oh=stride_oh,
-        alpha=alpha,
-        attn_scale=attn_scale,
-        off_z=off_z,
-        off_h=off_h,
-        pid=pid,
-        num_targets=num_targets,
-        max_attn_len=max_attn_len,
-        contextual_seq_len=contextual_seq_len,
-        HAS_NUM_TARGETS=HAS_NUM_TARGETS,
-        HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
-        HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
-        ATTN_SCALE_TYPE=ATTN_SCALE_TYPE,
-        ALLOW_TF32=ALLOW_TF32,
-        BLOCK_D_Q=BLOCK_D_Q,
-        BLOCK_D_V=BLOCK_D_V,
-        BLOCK_M=BLOCK_M,
-        BLOCK_N=BLOCK_N,
-        ENABLE_TMA=ENABLE_TMA,
-        TMA_DESC_SIZE=TMA_DESC_SIZE,
-    )
+    if _HSTU_SELF_FA_DP:
+        _hstu_attn_fwd_compute_dp(
+            Q=Q, K=K, V=V, H=H, DimQ=DimQ, DimV=DimV,
+            workspace_ptr=workspace_ptr, seq_offsets=seq_offsets,
+            seq_offsets_q=seq_offsets_q, Out=Out,
+            stride_qm=stride_qm, stride_qh=stride_qh, stride_kn=stride_kn,
+            stride_kh=stride_kh, stride_vn=stride_vn, stride_vh=stride_vh,
+            stride_om=stride_om, stride_oh=stride_oh, alpha=alpha,
+            attn_scale=attn_scale, off_z=off_z, off_h=off_h, pid=pid,
+            num_targets=num_targets, max_attn_len=max_attn_len,
+            contextual_seq_len=contextual_seq_len,
+            HAS_NUM_TARGETS=HAS_NUM_TARGETS, HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+            HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+            ATTN_SCALE_TYPE=ATTN_SCALE_TYPE, ALLOW_TF32=ALLOW_TF32,
+            BLOCK_D_Q=BLOCK_D_Q, BLOCK_D_V=BLOCK_D_V, BLOCK_M=BLOCK_M,
+            BLOCK_N=BLOCK_N, ENABLE_TMA=ENABLE_TMA, TMA_DESC_SIZE=TMA_DESC_SIZE,
+        )
+    else:
+        _hstu_attn_fwd_compute(
+            Q=Q, K=K, V=V, H=H, DimQ=DimQ, DimV=DimV,
+            workspace_ptr=workspace_ptr, seq_offsets=seq_offsets,
+            seq_offsets_q=seq_offsets_q, Out=Out,
+            stride_qm=stride_qm, stride_qh=stride_qh, stride_kn=stride_kn,
+            stride_kh=stride_kh, stride_vn=stride_vn, stride_vh=stride_vh,
+            stride_om=stride_om, stride_oh=stride_oh, alpha=alpha,
+            attn_scale=attn_scale, off_z=off_z, off_h=off_h, pid=pid,
+            num_targets=num_targets, max_attn_len=max_attn_len,
+            contextual_seq_len=contextual_seq_len,
+            HAS_NUM_TARGETS=HAS_NUM_TARGETS, HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+            HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+            ATTN_SCALE_TYPE=ATTN_SCALE_TYPE, ALLOW_TF32=ALLOW_TF32,
+            BLOCK_D_Q=BLOCK_D_Q, BLOCK_D_V=BLOCK_D_V, BLOCK_M=BLOCK_M,
+            BLOCK_N=BLOCK_N, ENABLE_TMA=ENABLE_TMA, TMA_DESC_SIZE=TMA_DESC_SIZE,
+        )
 
 
 @triton.jit

--- a/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
@@ -35,17 +35,146 @@ from stubs import (
 )
 from stubs import acc_dq
 from triton.language.extra.libdevice import fast_dividef  # @manual=//triton:triton
+from triton.language.extra.subtile_ops import _split_n_2D  # @manual=//triton:triton
+
+from dataclasses import dataclass, replace as _dc_replace
+
+
+@dataclass
+class HSTUAutoWSConfig:
+    """AutoWS configuration for the HSTU self-attn kernels.
+
+    Replaces the former scattered HSTU_SELF_* environment variables with a single
+    config object, settable via configure_autows() or the `autows_cfg` argument on
+    the public entrypoints (triton_hstu_mha / triton_hstu_attention_fwd|bwd). The
+    env vars are still read once by from_env() as import-time defaults for
+    back-compat. Structural fields are tl.constexpr (read inside @triton.jit) and
+    the tile fields feed the autotune config list (built at import per Triton), so
+    configure_autows() must run before the first kernel launch.
+    """
+
+    autows: bool = False  # enable meta-WS on the KV loop
+    dp: int = 1  # data-partition factor (MMA groups)
+    dq_reduce: bool = False  # bwd dq via TMA reduce-add (vs in-loop RMW)
+    dq_reuse: bool = False  # FA-style TMEM reuse for the dq-reduce bwd
+    dq_iters: int = 1  # dq TMA-reduce column subtiles
+    warps: int = 8  # num_warps for the autoWS config
+    bn: int = 128  # fwd DP BLOCK_N
+    bwd_bm: int = 64  # bwd autoWS BLOCK_M
+    bwd_bn: int = 64  # bwd autoWS BLOCK_N
+    bwd_stages: int = 1  # bwd autoWS num_stages
+    sp: bool = False  # bwd SEQUENCE_PARALLEL
+    pin: bool = False  # pin autotune to one config (fast compile)
+
+    @classmethod
+    def from_env(cls) -> "HSTUAutoWSConfig":
+        g = os.environ.get
+        autows = g("HSTU_SELF_AUTOWS") == "1"
+        return cls(
+            autows=autows,
+            dp=int(g("HSTU_SELF_DP", "2" if autows else "1")),
+            dq_reduce=g("HSTU_SELF_DQ_REDUCE") == "1",
+            dq_reuse=g("HSTU_SELF_DQ_REUSE", "0") == "1",
+            dq_iters=int(g("HSTU_SELF_DQ_ITERS", "1")),
+            warps=int(g("HSTU_SELF_AUTOWS_WARPS", "8")),
+            bn=int(g("HSTU_SELF_AUTOWS_BN", "128")),
+            bwd_bm=int(g("HSTU_SELF_AUTOWS_BWD_BM", "64")),
+            bwd_bn=int(g("HSTU_SELF_AUTOWS_BWD_BN", "64")),
+            bwd_stages=int(g("HSTU_SELF_AUTOWS_BWD_STAGES", "1")),
+            sp=g("HSTU_SELF_AUTOWS_SP") == "1",
+            pin=g("HSTU_SELF_PIN") == "1",
+        )
+
+
+_AUTOWS_CFG = HSTUAutoWSConfig.from_env()
+# Merge any pre-import overrides set via hstu_autows_config.set_config(...) so
+# callers/tests can pass the config as a dict instead of HSTU_SELF_* env vars.
+try:
+    import hstu_autows_config as _hstu_autows_config_hook
+
+    _AUTOWS_CFG = _dc_replace(_AUTOWS_CFG, **_hstu_autows_config_hook.pop_overrides())
+except Exception:  # noqa: BLE001 -- hook is optional
+    pass
+
+
+def _sync_autows_constexprs() -> None:
+    # Re-derive the tl.constexpr views (read inside @triton.jit) from _AUTOWS_CFG.
+    global _HSTU_SELF_AUTOWS, _HSTU_SELF_DP, _HSTU_SELF_DQ_REDUCE
+    global _HSTU_SELF_DQ_ITERS, _HSTU_DQ_REUSE
+    _HSTU_SELF_AUTOWS = tl.constexpr(_AUTOWS_CFG.autows)
+    _HSTU_SELF_DP = tl.constexpr(_AUTOWS_CFG.dp)
+    _HSTU_SELF_DQ_REDUCE = tl.constexpr(_AUTOWS_CFG.dq_reduce)
+    _HSTU_SELF_DQ_ITERS = tl.constexpr(_AUTOWS_CFG.dq_iters)
+    _HSTU_DQ_REUSE = tl.constexpr(_AUTOWS_CFG.dq_reduce and _AUTOWS_CFG.dq_reuse)
+
+
+def configure_autows(cfg=None, **kwargs) -> "HSTUAutoWSConfig":
+    """Set the active HSTU autoWS config (replaces the HSTU_SELF_* env vars).
+
+    Accepts an HSTUAutoWSConfig, a dict of overrides, or keyword overrides. Call
+    before the first kernel launch.
+    """
+    global _AUTOWS_CFG
+    if cfg is not None:
+        if isinstance(cfg, HSTUAutoWSConfig):
+            _AUTOWS_CFG = cfg
+        else:
+            _AUTOWS_CFG = _dc_replace(_AUTOWS_CFG, **cfg)
+    if kwargs:
+        _AUTOWS_CFG = _dc_replace(_AUTOWS_CFG, **kwargs)
+    _sync_autows_constexprs()
+    return _AUTOWS_CFG
+
 
 # HSTU_SELF_AUTOWS=1 turns on Meta-Triton autoWS on the main KV loop (needs
 # TRITON_USE_META_WS=1 + TRITON_DISABLE_WSBARRIER_REORDER=1 at runtime, and a
 # num_stages>=1 config -- pair with HSTU_SELF_PIN=1). Default off -> identical to
 # the plain-Triton kernel. Must be a tl.constexpr to be read inside @triton.jit.
-_HSTU_SELF_AUTOWS = tl.constexpr(os.environ.get("HSTU_SELF_AUTOWS") == "1")
+_HSTU_SELF_AUTOWS = tl.constexpr(_AUTOWS_CFG.autows)
 # Data-partition factor for autoWS: splits the loop's MMAs into N groups (the
 # autoWS analog of TLX's replicate=NUM_MMA_GROUPS). Default 2 when autoWS is on
 # (matches TLX's 2 MMA groups), 1 otherwise; override with HSTU_SELF_DP.
-_HSTU_SELF_DP = tl.constexpr(
-    int(os.environ.get("HSTU_SELF_DP", "2" if os.environ.get("HSTU_SELF_AUTOWS") == "1" else "1")))
+_HSTU_SELF_DP = tl.constexpr(_AUTOWS_CFG.dp)
+# EXPERIMENTAL, opt-in via HSTU_SELF_DQ_REDUCE=1 (OFF by default): dq via TMA
+# reduce-add instead of the in-loop global RMW, mirroring the cross-attn autoWS
+# bwd (triton_bw_cross_attention.py: natural dq_trans = trans(k)@dqk MMA, then
+# tl.trans of the *result*, then store_reduce="add" -- transpose the result, not
+# the dqk register operand, or meta-WS declines to partition). DQ is pre-zeroed.
+# NOTE: the reduce adds a reduction partition, so PSM's warp-budget check
+# (kMaxWarps=16) needs the default partition small -- pair with
+# HSTU_SELF_AUTOWS_WARPS=4 (num_warps=8 overflows the budget -> WS silently
+# falls back to SIMT). Still needs a TMEM-fitting config (TLX-style dq subtiling)
+# to compile at 64x64; left off by default so the shipped autoWS path keeps the
+# faster RMW dq (which warp-specializes at num_warps=8).
+_HSTU_SELF_DQ_REDUCE = tl.constexpr(_AUTOWS_CFG.dq_reduce)
+# Subtile count for the dq TMA reduce, matching FA bwd's DQ_SUBTILE. The store is
+# split into _HSTU_SELF_DQ_ITERS contiguous column-subtiles via _split_n_2D (the
+# same helper FA bwd uses; register-tensor slicing `dq[:, a:b]` is unsupported).
+# Each subtile is an independent store_reduce the compiler can stage. Must be a
+# power of 2 dividing HEAD_DIM. Default 1 (whole tile); override HSTU_SELF_DQ_ITERS.
+_HSTU_SELF_DQ_ITERS = tl.constexpr(_AUTOWS_CFG.dq_iters)
+# EXPERIMENTAL, opt-in via HSTU_SELF_DQ_REUSE=1 (default OFF): when set (and
+# dq-reduce is on), annotate the bwd MMAs' opndD with FA-bwd-style tt.autows
+# channel attrs (see WarpSpecialization/docs/AnnotationBasedBufferPreAssignment.md)
+# forming a TMEM reuse scheme that mirrors _BWD_DOT_ATTRS in
+# fused_attention_ws_device_tma.py + TLX REUSE_DP_FOR_DQ / NUM_BUFFERS_TMEM=1. At
+# BM=BN=HEAD_DIM=128 every opndD accumulator is [128,128] f32 = 128 cols; four
+# reuse groups pack to exactly 512 cols:
+#   id2 : qk_trans (f32) -> reused by act_qk_trans (bf16, dv's opndA)
+#   id5 : dp (dact_qk_trans) -> reused by dq_trans          [REUSE_DP_FOR_DQ]
+#   id7 : dv  (persistent accumulator, live across the inner loop)
+#   id10: dk  (persistent accumulator, live across the inner loop)
+# Sharing id5 also gives the otherwise-standalone single-buffered dq accumulator
+# dp's cross-iteration WAR barrier (the fix for the gemm->reduction ping-pong
+# deadlock). dp/dq have disjoint liveness (dp is consumed into dqk_trans before dq
+# is produced) and dk is emitted before dq, so nothing reads id5 after dq
+# overwrites it (BwdTmemReuseSlotHazard.md). Reuse validity needs dp and dq
+# shape-compatible, which holds only at BLOCK_N==HEAD_DIM==128 (dp=[BLOCK_N,BLOCK_M],
+# dq=[HEAD_DIM,BLOCK_M]); at BLOCK_N=64 the shapes differ and the reuse falls back.
+# The attrs are inline dict literals gated by a constexpr bool -- tl.dot's attrs=
+# is a trace-time literal, so this avoids referencing a (dict) JIT global, which
+# is unsupported. None (reuse off) leaves the dots unannotated (heuristic alloc).
+_HSTU_DQ_REUSE = tl.constexpr(_AUTOWS_CFG.dq_reduce and _AUTOWS_CFG.dq_reuse)
 
 
 def _get_fw_configs() -> List[triton.Config]:  # noqa: C901
@@ -220,15 +349,15 @@ def _get_fw_configs() -> List[triton.Config]:  # noqa: C901
     # split into producer/consumer partitions (the tiny default config with
     # num_warps=2/BLOCK_M=16 does NOT warp-specialize). Pin to a num_warps>=4,
     # BLOCK_M>=64 config.
-    if os.environ.get("HSTU_SELF_AUTOWS") == "1":
-        _w = int(os.environ.get("HSTU_SELF_AUTOWS_WARPS", "8"))
-        _dp = int(os.environ.get("HSTU_SELF_DP", "2"))
+    if _AUTOWS_CFG.autows:
+        _w = _AUTOWS_CFG.warps
+        _dp = _AUTOWS_CFG.dp
         if _dp >= 2:
             # DP splits BLOCK_M by _dp; each slice must be >= the TMEM blockM
             # (128) or WSDataPartition skips (WSDataPartition.cpp). So set
             # BLOCK_M = 128 * _dp (doubling the split dim) -> each partition tile
             # is 128 rows, matching TLX (BLOCK_M=256, 2 groups of 128).
-            _bn = int(os.environ.get("HSTU_SELF_AUTOWS_BN", "128"))
+            _bn = _AUTOWS_CFG.bn
             return [triton.Config(
                 {"BLOCK_M": 128 * _dp, "BLOCK_N": _bn},
                 num_stages=1,
@@ -249,7 +378,7 @@ def _get_fw_configs() -> List[triton.Config]:  # noqa: C901
         return configs[:1]
     # HSTU_SELF_PIN=1 shrinks the fwd autotune to one config (fast compile for
     # tritonbench --mode bwd, which recompiles fwd+bwd).
-    if os.environ.get("HSTU_SELF_PIN"):
+    if _AUTOWS_CFG.pin:
         return configs[:1]
     return configs
 
@@ -466,9 +595,39 @@ def _get_bw_configs() -> List[triton.Config]:
         ]
     else:
         print("WARNING: temporarily disabled some autotune configs for CUDA 12.8+")
+    # HSTU_SELF_AUTOWS needs a big-enough tile + enough warps or meta-WS silently
+    # does NOT partition the bwd M-loop (the tiny default BLOCK_M=16/num_warps=2
+    # config stays SIMT). Pin one num_warps>=8, BLOCK_M>=64, num_stages>=1 config.
+    # DP is left at 1 for bwd (TLX bwd uses replicate=1), so no split-dim doubling.
+    # Use the non-SEQUENCE_PARALLEL path (single program per (z,h); dq is a direct
+    # global RMW, ATOMIC_ADD=False) and UNROLL=1 (no unroll under WS).
+    if _AUTOWS_CFG.autows:
+        _w = _AUTOWS_CFG.warps
+        _bm = _AUTOWS_CFG.bwd_bm
+        _bn = _AUTOWS_CFG.bwd_bn
+        _ns = _AUTOWS_CFG.bwd_stages
+        # SEQUENCE_PARALLEL=True -> one KV block per program => a single M loop
+        # (no outer start_n loop), matching FA bwd's flat reduction loop; the
+        # nested (SP=False) path is where the dq-reduce reduction partition's
+        # phase lockstep breaks. Default False (RMW path); set HSTU_SELF_AUTOWS_SP=1
+        # for the FA-like single-loop structure (pair with HSTU_SELF_DQ_REDUCE=1).
+        _sp = _AUTOWS_CFG.sp
+        return [
+            triton.Config(
+                {
+                    "BLOCK_M": _bm,
+                    "BLOCK_N": _bn,
+                    "SEQUENCE_PARALLEL": _sp,
+                    "UNROLL": 1,
+                },
+                num_stages=_ns,
+                num_warps=_w,
+                pre_hook=_bwd_pre_hook,
+            )
+        ]
     # HSTU_SELF_PIN=1 shrinks the bwd autotune to one config so tritonbench
     # --mode bwd compiles fast instead of building all ~29 configs.
-    if os.environ.get("HSTU_SELF_PIN"):
+    if _AUTOWS_CFG.pin:
         return configs[:1]
     return configs
 
@@ -724,6 +883,7 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
     do_ptrs,
     device_desc_q,
     device_desc_do,
+    device_desc_dq,
     dk,
     dv,
     k,
@@ -737,6 +897,7 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
     stride_qm,
     stride_dom,
     stride_dqm,
+    stride_dqh,
     alpha,
     attn_scale,
     max_q_len,
@@ -779,7 +940,9 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
             mask=mask_m[None, :],
             other=0.0,
         )
-    qk_trans = tl.dot(k, q_trans, allow_tf32=ALLOW_TF32)
+    qk_trans = tl.dot(
+        k, q_trans, allow_tf32=ALLOW_TF32, attrs=({"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]} if _HSTU_DQ_REUSE else None)
+    )
     valid_mask_trans = backward_valid_mask(
         offs_m,
         pos_offs_n,
@@ -806,29 +969,80 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
             mask=mask_m[:, None],
             other=0.0,
         )
-    dv += tl.dot(act_qk_trans, do, allow_tf32=ALLOW_TF32)
+    # dp (dact_qk_trans) is emitted BEFORE dv: dp and dv are both stage 0 with the
+    # SAME `order`, so the `order` annotation does NOT reorder them -- same-stage
+    # dots keep PROGRAM order. Emitting dp first makes the final-ttgir schedule match
+    # TLX's dp-before-dv body order (dv/dp were the only swapped pair vs TLX).
+    dact_qk_trans = tl.dot(
+        v, tl.trans(do), allow_tf32=ALLOW_TF32, attrs=({"stage": "0", "order": "2", "channels": ["opndD,tmem,1,5"]} if _HSTU_DQ_REUSE else None)
+    )
+    dv += tl.dot(
+        act_qk_trans, do, allow_tf32=ALLOW_TF32, attrs=(
+            {"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]}
+            if _HSTU_DQ_REUSE
+            else None
+        )
+    )
 
     # compute dk and dq
-    dact_qk_trans = tl.dot(v, tl.trans(do), allow_tf32=ALLOW_TF32)
     dqk_trans = backward_d_activation(dact_qk_trans, sig_trans, qk_trans, scale, valid_mask_trans)
     dqk_trans = dqk_trans.to(k.dtype)
 
     # Note: the factor `alpha` is delayed until the end of the function to reduce the cost
-    dk += tl.dot(dqk_trans, tl.trans(q_trans), allow_tf32=ALLOW_TF32)
-    acc_dq(
-        dq_ptrs_trans=dq_ptrs_trans,
-        start_m=start_m,
-        stride_dqm=stride_dqm,
-        k=k,
-        dqk_trans=dqk_trans,
-        alpha=alpha,
-        mask_m=mask_m,
-        MAX_SEQ_LEN=max_q_len,
-        LOCK=LOCK,
-        BLOCK_M=BLOCK_M,
-        ATOMIC_ADD=ATOMIC_ADD,
-        ALLOW_TF32=ALLOW_TF32,
+    dk += tl.dot(
+        dqk_trans, tl.trans(q_trans), allow_tf32=ALLOW_TF32,
+        # dsT (opndA) MUST live in SMEM, not TMEM. Left unannotated it defaults to
+        # TMEM and the planner column-packs it into id2 (the qk_trans buffer), where
+        # the qk MMA's useAcc=false full-overwrite races this cross-stage (stage-1)
+        # read -> corrupt grads. TLX keeps dsT in a dedicated SMEM buffer (ds_tiles);
+        # opndA,smem,1,8 mirrors that (and FA bwd's dsT-in-smem convention).
+        attrs=({"stage": "1", "order": "1", "channels": ["opndA,smem,1,8", "opndD,tmem,1,10"]} if _HSTU_DQ_REUSE else None),
     )
+    if _HSTU_SELF_DQ_REDUCE and ENABLE_TMA:
+        # dq via TMA reduce-add. Compute dq TRANSPOSED with the SAME dot as acc_dq
+        # (tl.trans(k) is a cheap memdesc_trans on the SMEM k tile), then transpose
+        # the small [BLOCK_D_Q, BLOCK_M] result to [BLOCK_M, BLOCK_D_Q] and atomic-add
+        # into global dq. Transposing the *result* (not the dqk register operand)
+        # keeps the MMA structure meta-WS can partition. DQ is pre-zeroed; the head
+        # slice is selected by the store column offset (device_desc_dq base has only
+        # the seq offset). Mirrors triton_bw_cross_attention.py's autoWS dq reduce.
+        dq_trans = (
+            tl.dot(
+                tl.trans(k), dqk_trans, allow_tf32=ALLOW_TF32,
+                attrs=({"stage": "1", "order": "1", "channels": ["opndD,tmem,1,5"]} if _HSTU_DQ_REUSE else None),
+            )
+            * alpha
+        )
+        dq = tl.trans(dq_trans).to(k.dtype)
+        # Subtile the dq reduce into _HSTU_SELF_DQ_ITERS contiguous column-subtiles
+        # (matches FA bwd's DQ_SUBTILE); each is an independent store_reduce the
+        # compiler stages separately (the source-level analog of TLX's subtiled +
+        # depth-2 dq_store_buf staging). _split_n_2D does the register split that
+        # `dq[:, a:b]` cannot.
+        dq_slice_size: tl.constexpr = BLOCK_D_Q // _HSTU_SELF_DQ_ITERS
+        dqs = _split_n_2D(dq, _HSTU_SELF_DQ_ITERS)
+        for _s in tl.static_range(_HSTU_SELF_DQ_ITERS):
+            tl._experimental_descriptor_store(
+                device_desc_dq,
+                dqs[_s],
+                [start_m, (off_h * stride_dqh + _s * dq_slice_size).to(tl.int32)],
+                store_reduce="add",
+            )
+    else:
+        acc_dq(
+            dq_ptrs_trans=dq_ptrs_trans,
+            start_m=start_m,
+            stride_dqm=stride_dqm,
+            k=k,
+            dqk_trans=dqk_trans,
+            alpha=alpha,
+            mask_m=mask_m,
+            MAX_SEQ_LEN=max_q_len,
+            LOCK=LOCK,
+            BLOCK_M=BLOCK_M,
+            ATOMIC_ADD=ATOMIC_ADD,
+            ALLOW_TF32=ALLOW_TF32,
+        )
     return dk, dv
 
 
@@ -1268,6 +1482,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
     device_desc_do,
     device_desc_dk,
     device_desc_dv,
+    device_desc_dq,
     LOCK,
     off_h,
     off_z,
@@ -1282,6 +1497,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
     stride_vn,
     stride_dom,
     stride_dqm,
+    stride_dqh,
     stride_dkn,
     stride_dvn,
     alpha,
@@ -1358,6 +1574,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
                 do_ptrs=do_ptrs,
                 device_desc_q=device_desc_q,
                 device_desc_do=device_desc_do,
+                device_desc_dq=device_desc_dq,
                 dk=dk,
                 dv=dv,
                 k=k,
@@ -1371,6 +1588,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
                 stride_qm=stride_qm,
                 stride_dom=stride_dom,
                 stride_dqm=stride_dqm,
+                stride_dqh=stride_dqh,
                 alpha=alpha,
                 attn_scale=attn_scale,
                 max_q_len=max_q_len,
@@ -1409,7 +1627,21 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
         contextual_block_end = tl.cdiv(contextual_seq_len, BLOCK_M) * BLOCK_M
         if low < contextual_block_end:
             low = contextual_block_end
-    for start_m in tl.range(low, high, BLOCK_M, loop_unroll_factor=UNROLL):
+    for start_m in tl.range(
+        low,
+        high,
+        BLOCK_M,
+        loop_unroll_factor=UNROLL,
+        # autoWS on the bwd compute loop (dk/dv/dq MMAs). DP=1 (bwd uses TLX
+        # replicate=1); pair with a num_warps>=8, BLOCK_M>=64, num_stages>=1
+        # config from _get_bw_configs() (HSTU_SELF_AUTOWS branch).
+        warp_specialize=_HSTU_SELF_AUTOWS,
+        # For the dq TMA-reduce path (which adds a reduction partition), fold the
+        # dk/dv epilogue into the computation partition (as TLX does) so the total
+        # warp count stays <= 16 (reduction4+gemm1+load1+compute8=14 vs the
+        # 5-partition 18 that overflows PSM's warp budget). No-op for the RMW path.
+        merge_epilogue_to_computation=_HSTU_SELF_DQ_REDUCE,
+    ):
         start_m = tl.multiple_of(start_m, BLOCK_M)
         dk, dv = _hstu_attn_bwd_one_block_0(
             start_m=start_m,
@@ -1420,6 +1652,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
             do_ptrs=do_ptrs,
             device_desc_q=device_desc_q,
             device_desc_do=device_desc_do,
+            device_desc_dq=device_desc_dq,
             dk=dk,
             dv=dv,
             k=k,
@@ -1433,6 +1666,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
             stride_qm=stride_qm,
             stride_dom=stride_dom,
             stride_dqm=stride_dqm,
+            stride_dqh=stride_dqh,
             alpha=alpha,
             attn_scale=attn_scale,
             max_q_len=max_q_len,
@@ -1555,7 +1789,12 @@ def _hstu_attn_bwd(  # noqa C901
     K = K + seq_start_kv * stride_kn
     V = V + seq_start_kv * stride_vn
     DOut = DOut + seq_start_q * stride_dom
-    DQ = DQ + seq_start_q * stride_dqm + off_h * stride_dqh
+    if _HSTU_SELF_DQ_REDUCE and ENABLE_TMA:
+        # TMA-reduce dq: the descriptor base carries only the seq offset; the head
+        # slice is selected by the store column offset (off_h*stride_dqh).
+        DQ = DQ + seq_start_q * stride_dqm
+    else:
+        DQ = DQ + seq_start_q * stride_dqm + off_h * stride_dqh
     DK = DK + seq_start_kv * stride_dkn
     DV = DV + seq_start_kv * stride_dvn
     device_desc_q = None
@@ -1564,8 +1803,11 @@ def _hstu_attn_bwd(  # noqa C901
     device_desc_do = None
     device_desc_dk = None
     device_desc_dv = None
+    device_desc_dq = None
     if ENABLE_TMA:
-        workspace_base = tma_workspace_ptr + TMA_DESC_SIZE * 6 * (tl.program_id(1) +
+        # 7 descriptor slots per program (q,k,v,do,dk,dv,dq); dq only used by the
+        # autoWS TMA-reduce path (gated below).
+        workspace_base = tma_workspace_ptr + TMA_DESC_SIZE * 7 * (tl.program_id(1) +
                                                                   tl.program_id(0) * tl.num_programs(1))
         device_desc_q = workspace_base
         device_desc_k = workspace_base + 1 * TMA_DESC_SIZE
@@ -1573,6 +1815,7 @@ def _hstu_attn_bwd(  # noqa C901
         device_desc_do = workspace_base + 3 * TMA_DESC_SIZE
         device_desc_dk = workspace_base + 4 * TMA_DESC_SIZE
         device_desc_dv = workspace_base + 5 * TMA_DESC_SIZE
+        device_desc_dq = workspace_base + 6 * TMA_DESC_SIZE
 
         # pyre-ignore [20]
         tl.extra.cuda.experimental_device_tensormap_create2d(
@@ -1652,6 +1895,22 @@ def _hstu_attn_bwd(  # noqa C901
         )
         # pyre-ignore [20]
         tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_dv)
+        if _HSTU_SELF_DQ_REDUCE:
+            # dq TMA reduce-add target: non-transposed [seq_len_q, H*DimQ]; base
+            # (DQ) carries only the seq offset, head via the store column.
+            # pyre-ignore [20]
+            tl.extra.cuda.experimental_device_tensormap_create2d(
+                desc_ptr=device_desc_dq,
+                global_address=DQ,
+                load_size=[
+                    BLOCK_M,
+                    BLOCK_D_Q // _HSTU_SELF_DQ_ITERS,
+                ],
+                global_size=[seq_len_q, H * DimQ],
+                element_ty=DQ.dtype.element_ty,
+            )
+            # pyre-ignore [20]
+            tl.extra.cuda.experimental_tensormap_fenceproxy_acquire(device_desc_dq)
     else:
         Q += off_h * stride_qh
         K += off_h * stride_kh
@@ -1680,6 +1939,7 @@ def _hstu_attn_bwd(  # noqa C901
             device_desc_do=device_desc_do,
             device_desc_dk=device_desc_dk,
             device_desc_dv=device_desc_dv,
+            device_desc_dq=device_desc_dq,
             LOCK=LOCK,
             off_h=off_h,
             off_z=off_z,
@@ -1694,6 +1954,7 @@ def _hstu_attn_bwd(  # noqa C901
             stride_vn=stride_vn,
             stride_dom=stride_dom,
             stride_dqm=stride_dqm,
+            stride_dqh=stride_dqh,
             stride_dkn=stride_dkn,
             stride_dvn=stride_dvn,
             alpha=alpha,
@@ -1735,6 +1996,7 @@ def _hstu_attn_bwd(  # noqa C901
                 device_desc_do=device_desc_do,
                 device_desc_dk=device_desc_dk,
                 device_desc_dv=device_desc_dv,
+                device_desc_dq=device_desc_dq,
                 LOCK=LOCK,
                 off_h=off_h,
                 off_z=off_z,
@@ -1749,6 +2011,7 @@ def _hstu_attn_bwd(  # noqa C901
                 stride_vn=stride_vn,
                 stride_dom=stride_dom,
                 stride_dqm=stride_dqm,
+                stride_dqh=stride_dqh,
                 stride_dkn=stride_dkn,
                 stride_dvn=stride_dvn,
                 alpha=alpha,
@@ -1919,8 +2182,10 @@ def triton_hstu_attention_bwd(
     tma_workspace = None
     if enable_tma:
         MIN_BLOCK_N = 16
+        # 7 TMA descriptor slots (q,k,v,do,dk,dv,dq); the 7th (dq) is used by the
+        # autoWS TMA-reduce dq path. Allocating it unconditionally is cheap.
         tma_workspace = torch.empty(
-            6 * TMA_DESC_SIZE * (triton.cdiv(max_seq_len, MIN_BLOCK_N) * Z * H),
+            7 * TMA_DESC_SIZE * (triton.cdiv(max_seq_len, MIN_BLOCK_N) * Z * H),
             dtype=torch.uint8,
             device="cuda",
         )
@@ -2140,7 +2405,13 @@ def triton_hstu_mha(
     num_targets: Optional[torch.Tensor] = None,
     max_attn_len: int = 0,
     contextual_seq_len: int = 0,
+    autows_cfg=None,
 ) -> torch.Tensor:
+    # AutoWS knobs: pass an HSTUAutoWSConfig/dict here (or via configure_autows())
+    # instead of the HSTU_SELF_* env vars. Applies the structural flags before the
+    # kernel launch; call before the first launch so it also affects tracing.
+    if autows_cfg is not None:
+        configure_autows(autows_cfg)
     return _AttentionFunction.apply(
         max_seq_len,
         alpha,

--- a/third_party/tlx/tutorials/test_self_attention_autows.py
+++ b/third_party/tlx/tutorials/test_self_attention_autows.py
@@ -6,7 +6,7 @@ Enables autoWS on the hammer-template Triton self-attn kernel via the
 baked as a tl.constexpr at import) and asserts the fwd output AND the dq/dk/dv
 gradients match a torch-autograd float causal-SiLU reference.
 
-Two configs are covered:
+Four configs are covered:
 - The DEFAULT autoWS config (in-process): `test_self_attention_fwd_autows`.
 - The TLX-matching dq-reduce config (BM=BN=128, num_stages=2, TMEM reuse, dsT in
   SMEM): `test_self_attention_bwd_autows_dqreduce`. Its flags
@@ -14,6 +14,17 @@ Two configs are covered:
   tl.constexpr / read into the autotune configs AT IMPORT, so they can't coexist
   with the default config in one interpreter -> that case runs in a SUBPROCESS
   (this same file re-invoked with `--run-dqreduce`) with the env set first.
+- The FA-style manual data-partition FWD config (HSTU_SELF_FA_DP=1, DP=2, WARPS=4):
+  `test_self_attention_fwd_autows_fadp`. Splits BLOCK_M=256 into two 128-row halves
+  sharing one K/V load, warp-specialized into load + 2 MMA groups -- the working
+  alternative to the broken compiler data_partition_factor=2 path. Also
+  constexpr-baked at import -> SUBPROCESS (`--run-fadp`); fwd-only output check.
+- The compiler DP=2 config (HSTU_SELF_DP=2, no FA_DP):
+  `test_self_attention_fwd_autows_compiler_dp2`. The compiler's
+  data_partition_factor=2 splits the 256-row tile into two 128-row groups. Was
+  broken (TMA descriptor box_dim left at 256 -> SMEM overrun -> stall/OOB); fixed
+  in WSDataPartition by scaling box_dim by the partition factor. SUBPROCESS,
+  `--run-fwd`, fwd-only output check.
 
 Notes:
 - autoWS needs TRITON_USE_META_WS=1 + TRITON_DISABLE_WSBARRIER_REORDER=1; these
@@ -35,41 +46,43 @@ import sys
 _HSTU_DIR = os.path.join(os.path.dirname(__file__), "hstu_self_attn")
 sys.path.insert(0, _HSTU_DIR)
 
-# HSTU autoWS config as a dict (replaces the HSTU_SELF_* env vars), applied via
+# HSTU autoWS config as dicts (replaces the HSTU_SELF_* env vars), applied via
 # hstu_autows_config.set_config() BEFORE importing the kernel -- the autoWS
 # structural flags and the autotune tile config are read at import. Only the
 # Triton *compiler* knobs (meta-WS on, wsbarrier-reorder off) stay as env; they
 # are generic triton knobs, not HSTU_SELF_* config.
 import hstu_autows_config as _C  # noqa: E402
 
-# The TLX-matching dq-reduce config: BM=BN=128 with num_stages=2 (annotation-
-# driven SWP schedule), FA-style TMEM reuse (id2={qk,act}, id5={dp,dq}, id7=dv,
-# id10=dk) with dsT pinned to SMEM (opndA,smem) so it does NOT column-pack into
-# the qk reuse buffer, and dq via TMA reduce-add subtiled x4. This is the config
-# whose final ttgir matches the hand-written TLX bwd (prologue/body/epilogue
-# structure + reuse groups) and whose grads match the torch/TLX numerics.
-_DQREDUCE_CFG = dict(
-    autows=True,
-    dq_reduce=True,
-    dq_reuse=True,
-    dp=1,
-    bwd_bm=128,
-    bwd_bn=128,
-    bwd_stages=2,
-    warps=4,
-    dq_iters=4,
-    pin=True,
-)
+# DEFAULT autoWS config (in-process fwd+grads test).
 _DEFAULT_CFG = dict(autows=True, dp=1, pin=True)
+# TLX-matching dq-reduce config: BM=BN=128, num_stages=2 (annotation-driven SWP),
+# FA-style TMEM reuse (id2={qk,act}, id5={dp,dq}, id7=dv, id10=dk) with dsT pinned
+# to SMEM, dq via TMA reduce-add subtiled x4 -- final ttgir matches the hand-written
+# TLX bwd and its grads match torch/TLX numerics.
+_DQREDUCE_CFG = dict(
+    autows=True, dq_reduce=True, dq_reuse=True, dp=1,
+    bwd_bm=128, bwd_bn=128, bwd_stages=2, warps=4, dq_iters=4, pin=True,
+)
+# FA-style manual data-partition fwd: split BLOCK_M=256 into two 128-row halves
+# sharing one K/V load, warp-specialized (load + 2 MMA groups).
+_FADP_CFG = dict(autows=True, fa_dp=True, dp=2, warps=4, pin=True)
+# Compiler data_partition_factor=2 fwd (no FA_DP): the compiler splits the 256 tile
+# (fixed via the WSDataPartition box_dim scaling).
+_COMPILER_DP2_CFG = dict(autows=True, dp=2, warps=4, pin=True)
 
-# The dq-reduce case re-invokes this file as a subprocess (--run-dqreduce); pick
-# its config before the kernel import below.
-_IS_DQREDUCE = "--run-dqreduce" in sys.argv
-_C.set_config(**(_DQREDUCE_CFG if _IS_DQREDUCE else _DEFAULT_CFG))
+# The dq-reduce / fadp / compiler-dp2 cases re-invoke this file as a subprocess;
+# select the config (before the kernel import below) from argv.
+if "--run-dqreduce" in sys.argv:
+    _C.set_config(**_DQREDUCE_CFG)
+    os.environ["TRITON_WS_SMEM_PLAN_SEARCH"] = "1"
+elif "--run-fadp" in sys.argv:
+    _C.set_config(**_FADP_CFG)
+elif "--run-fwd" in sys.argv:
+    _C.set_config(**_COMPILER_DP2_CFG)
+else:
+    _C.set_config(**_DEFAULT_CFG)
 os.environ["TRITON_USE_META_WS"] = "1"
 os.environ["TRITON_DISABLE_WSBARRIER_REORDER"] = "1"
-if _IS_DQREDUCE:
-    os.environ["TRITON_WS_SMEM_PLAN_SEARCH"] = "1"
 
 import pytest  # noqa: E402
 import torch  # noqa: E402
@@ -132,6 +145,39 @@ def _run_autows_bwd(L, Z):
     return (q.grad.clone(), k.grad.clone(), v.grad.clone()), (rq, rk, rv)
 
 
+def _torch_ref_fwd(q, k, v, so, asc):
+    """Float HSTU-SiLU causal self-attention forward reference (output only)."""
+    qf, kf, vf = q.float(), k.float(), v.float()
+    alpha, scale = 1.0 / D, asc.item()
+    outs = []
+    for z in range(so.numel() - 1):
+        s, e = int(so[z]), int(so[z + 1])
+        n = e - s
+        qk = torch.einsum("qhd,khd->hqk", qf[s:e], kf[s:e]) * alpha
+        sig = qk * torch.sigmoid(qk) * scale
+        i = torch.arange(n, device=qk.device)
+        sig = sig * (i[:, None] >= i[None, :]).float()[None]
+        outs.append(torch.einsum("hqk,khd->qhd", sig, vf[s:e]))
+    return torch.cat(outs, 0)
+
+
+def _run_autows_fwd(L, Z):
+    """Run the (already-imported) autoWS kernel forward-only and return the fwd
+    output plus the torch-float reference output. Config = env baked at import."""
+    torch.manual_seed(0)
+    t = Z * L
+    g = lambda: torch.randn(t, H, D, device="cuda", dtype=torch.bfloat16)  # noqa: E731
+    q, k, v = g(), g(), g()
+    so = torch.arange(0, t + 1, L, device="cuda", dtype=torch.int64)
+    asc = torch.tensor(1.0 / L, device="cuda", dtype=torch.float32)
+    ref = _torch_ref_fwd(q, k, v, so, asc)
+    o = A.triton_hstu_mha(
+        max_seq_len=L, alpha=1.0 / D, q=q, k=k, v=v, seq_offsets=so,
+        attn_scale=asc, enable_tma=True,
+    )
+    return o, ref
+
+
 @pytest.mark.parametrize("L,Z", [(256, 4), (512, 2)])
 def test_self_attention_fwd_autows(L, Z):
     """DEFAULT autoWS config (in-process): fwd + grads vs torch reference."""
@@ -173,10 +219,63 @@ def test_self_attention_bwd_autows_dqreduce(L, Z):
     )
 
 
+@pytest.mark.parametrize("L,Z", [(256, 4), (512, 2)])
+def test_self_attention_fwd_autows_fadp(L, Z):
+    """FA-style manual data-partition fwd (split BLOCK_M=256 -> 2x128, shared K/V,
+    warp-specialized 2 MMA groups; env HSTU_SELF_FA_DP=1 + HSTU_SELF_DP=2).
+
+    Runs in a SUBPROCESS because HSTU_SELF_* are constexpr-baked at import and
+    cannot share an interpreter with the default (DP=1) config above. FA-DP is a
+    forward-only change, so this checks the forward OUTPUT vs the torch-float
+    reference (the compiler data_partition_factor=2 path is broken on this kernel;
+    this manual split is the working, warp-specialized alternative).
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    # The subprocess selects _FADP_CFG via set_config() (argv --run-fadp) before
+    # importing the kernel; no HSTU_SELF_* env needed.
+    r = subprocess.run(
+        [sys.executable, __file__, "--run-fadp", str(L), str(Z)],
+        env=dict(os.environ), capture_output=True, text=True, timeout=900,
+    )
+    # Surface the child's REL_L2 line (and any error) in the pytest output.
+    sys.stdout.write(r.stdout)
+    sys.stderr.write(r.stderr)
+    assert r.returncode == 0, (
+        f"FA-DP autoWS fwd failed (L={L} Z={Z}):\n{r.stdout}\n{r.stderr}"
+    )
+
+
+@pytest.mark.parametrize("L,Z", [(256, 4), (512, 2)])
+def test_self_attention_fwd_autows_compiler_dp2(L, Z):
+    """Compiler data-partition fwd (HSTU_SELF_DP=2, no FA_DP): the compiler splits
+    the 2*BLOCK_M=256 tile into two 128-row groups. Runs in a SUBPROCESS
+    (constexpr-baked config). Forward-only output check vs the torch reference.
+
+    This path was previously broken -- the DP transform left the device-side TMA
+    descriptor box_dim at the un-partitioned 256, so the TMA overran the 128-row
+    SMEM buffer (tcgen05 TMEM-alloc stall / epilogue-store OOB). Fixed in
+    WSDataPartition by scaling the tensormap box_dim by the partition factor.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    # The subprocess selects _COMPILER_DP2_CFG via set_config() (argv --run-fwd)
+    # before importing the kernel; no HSTU_SELF_* env needed.
+    r = subprocess.run(
+        [sys.executable, __file__, "--run-fwd", str(L), str(Z)],
+        env=dict(os.environ), capture_output=True, text=True, timeout=900,
+    )
+    sys.stdout.write(r.stdout)
+    sys.stderr.write(r.stderr)
+    assert r.returncode == 0, (
+        f"compiler DP=2 fwd failed (L={L} Z={Z}):\n{r.stdout}\n{r.stderr}"
+    )
+
+
 if __name__ == "__main__":
-    # Subprocess entry point for the dq-reduce config. The env (_DQREDUCE_ENV) is
-    # already in os.environ before this file's top-level import ran, so the kernel
-    # was imported with the dq-reduce constexprs baked on.
+    # Subprocess entry point for the dq-reduce config. _DQREDUCE_CFG was applied
+    # via set_config() at the top of this file (argv --run-dqreduce) before the
+    # kernel import, so the dq-reduce constexprs / autotune config are baked on.
     if len(sys.argv) >= 4 and sys.argv[1] == "--run-dqreduce":
         _L, _Z = int(sys.argv[2]), int(sys.argv[3])
         assert bool(A._HSTU_DQ_REUSE), "dq-reduce reuse flag not baked on"
@@ -193,4 +292,34 @@ if __name__ == "__main__":
             sys.exit(1)
         print("OK")
         sys.exit(0)
-    sys.exit("usage: test_self_attention_autows.py --run-dqreduce L Z")
+    # Subprocess entry point for the FA-style manual-DP fwd config (_FADP_CFG
+    # applied via set_config() at import). Forward-only check vs the torch ref.
+    if len(sys.argv) >= 4 and sys.argv[1] == "--run-fadp":
+        _L, _Z = int(sys.argv[2]), int(sys.argv[3])
+        assert bool(A._HSTU_SELF_FA_DP), "FA-DP flag not baked on"
+        o, ref = _run_autows_fwd(_L, _Z)
+        rl2 = _rel_l2(o, ref)
+        print(f"REL_L2 fwd = {rl2:.2e} (L={_L} Z={_Z})")
+        if not (rl2 < 1e-2):
+            print(f"FAIL: fwd rel-L2 too high: {rl2:.2e}")
+            sys.exit(1)
+        print("OK")
+        sys.exit(0)
+    # Generic fwd-only entry (config = whatever env was baked at import). Used by
+    # the compiler-DP=2 fwd check (now expected to pass -- fixed by the
+    # WSDataPartition box_dim scaling); _rel_l2 forces a sync so a numeric
+    # mismatch or a device fault (illegal address) surfaces here as a nonzero exit.
+    if len(sys.argv) >= 4 and sys.argv[1] == "--run-fwd":
+        _L, _Z = int(sys.argv[2]), int(sys.argv[3])
+        o, ref = _run_autows_fwd(_L, _Z)
+        rl2 = _rel_l2(o, ref)
+        print(f"REL_L2 fwd = {rl2:.2e} (L={_L} Z={_Z})")
+        if not (rl2 < 1e-2):
+            print(f"FAIL: fwd rel-L2 too high: {rl2:.2e}")
+            sys.exit(1)
+        print("OK")
+        sys.exit(0)
+    sys.exit(
+        "usage: test_self_attention_autows.py "
+        "--run-dqreduce|--run-fadp|--run-fwd L Z"
+    )

--- a/third_party/tlx/tutorials/test_self_attention_autows.py
+++ b/third_party/tlx/tutorials/test_self_attention_autows.py
@@ -6,6 +6,15 @@ Enables autoWS on the hammer-template Triton self-attn kernel via the
 baked as a tl.constexpr at import) and asserts the fwd output AND the dq/dk/dv
 gradients match a torch-autograd float causal-SiLU reference.
 
+Two configs are covered:
+- The DEFAULT autoWS config (in-process): `test_self_attention_fwd_autows`.
+- The TLX-matching dq-reduce config (BM=BN=128, num_stages=2, TMEM reuse, dsT in
+  SMEM): `test_self_attention_bwd_autows_dqreduce`. Its flags
+  (HSTU_SELF_DQ_REDUCE / HSTU_SELF_DQ_REUSE / the BWD tile knobs) are baked as
+  tl.constexpr / read into the autotune configs AT IMPORT, so they can't coexist
+  with the default config in one interpreter -> that case runs in a SUBPROCESS
+  (this same file re-invoked with `--run-dqreduce`) with the env set first.
+
 Notes:
 - autoWS needs TRITON_USE_META_WS=1 + TRITON_DISABLE_WSBARRIER_REORDER=1; these
   are set BEFORE importing the kernel so the constexpr/config pick see them.
@@ -13,23 +22,54 @@ Notes:
   >=128 TMEM rows) which OOMs TMEM on this kernel, so DP is off here.
 - The TLX self-attn *fwd* uses num_stages=0 and asserts under meta-WS, so it
   cannot be compiled in the same (META_WS) process; the accuracy oracle here is
-  the torch reference (as in test_cross_attention_bwd_autows.py).
+  the torch reference (as in test_cross_attention_bwd_autows.py). The dq-reduce
+  config's grads match this torch ref to bf16 precision, i.e. the same numerics
+  the hand-written TLX bwd produces.
 
 Run: pytest third_party/tlx/tutorials/test_self_attention_autows.py
 """
 import os
+import subprocess
 import sys
 
 _HSTU_DIR = os.path.join(os.path.dirname(__file__), "hstu_self_attn")
 sys.path.insert(0, _HSTU_DIR)
 
-# Enable autoWS + its env BEFORE importing the kernel (the flag/config are read
-# at import / first compile).
-os.environ["HSTU_SELF_AUTOWS"] = "1"
-os.environ["HSTU_SELF_DP"] = "1"
-os.environ["HSTU_SELF_PIN"] = "1"
+# HSTU autoWS config as a dict (replaces the HSTU_SELF_* env vars), applied via
+# hstu_autows_config.set_config() BEFORE importing the kernel -- the autoWS
+# structural flags and the autotune tile config are read at import. Only the
+# Triton *compiler* knobs (meta-WS on, wsbarrier-reorder off) stay as env; they
+# are generic triton knobs, not HSTU_SELF_* config.
+import hstu_autows_config as _C  # noqa: E402
+
+# The TLX-matching dq-reduce config: BM=BN=128 with num_stages=2 (annotation-
+# driven SWP schedule), FA-style TMEM reuse (id2={qk,act}, id5={dp,dq}, id7=dv,
+# id10=dk) with dsT pinned to SMEM (opndA,smem) so it does NOT column-pack into
+# the qk reuse buffer, and dq via TMA reduce-add subtiled x4. This is the config
+# whose final ttgir matches the hand-written TLX bwd (prologue/body/epilogue
+# structure + reuse groups) and whose grads match the torch/TLX numerics.
+_DQREDUCE_CFG = dict(
+    autows=True,
+    dq_reduce=True,
+    dq_reuse=True,
+    dp=1,
+    bwd_bm=128,
+    bwd_bn=128,
+    bwd_stages=2,
+    warps=4,
+    dq_iters=4,
+    pin=True,
+)
+_DEFAULT_CFG = dict(autows=True, dp=1, pin=True)
+
+# The dq-reduce case re-invokes this file as a subprocess (--run-dqreduce); pick
+# its config before the kernel import below.
+_IS_DQREDUCE = "--run-dqreduce" in sys.argv
+_C.set_config(**(_DQREDUCE_CFG if _IS_DQREDUCE else _DEFAULT_CFG))
 os.environ["TRITON_USE_META_WS"] = "1"
 os.environ["TRITON_DISABLE_WSBARRIER_REORDER"] = "1"
+if _IS_DQREDUCE:
+    os.environ["TRITON_WS_SMEM_PLAN_SEARCH"] = "1"
 
 import pytest  # noqa: E402
 import torch  # noqa: E402
@@ -63,15 +103,12 @@ def _rel_l2(a, b):
     return (torch.norm(a.float() - b.float()) / (torch.norm(b.float()) + 1e-12)).item()
 
 
-@pytest.mark.parametrize("L,Z", [(256, 4), (512, 2)])
-def test_self_attention_fwd_autows(L, Z):
-    if not torch.cuda.is_available():
-        pytest.skip("requires CUDA")
-    assert bool(A._HSTU_SELF_AUTOWS), "autoWS flag not baked on"
-
+def _run_autows_bwd(L, Z):
+    """Run the (already-imported) autoWS kernel fwd+bwd and return the grads plus
+    the torch-float reference grads. Config is whatever env was baked at import."""
     torch.manual_seed(0)
     t = Z * L
-    g = lambda: torch.randn(t, H, D, device="cuda", dtype=torch.bfloat16)
+    g = lambda: torch.randn(t, H, D, device="cuda", dtype=torch.bfloat16)  # noqa: E731
     q, k, v = g().requires_grad_(True), g().requires_grad_(True), g().requires_grad_(True)
     so = torch.arange(0, t + 1, L, device="cuda", dtype=torch.int64)
     asc = torch.tensor(1.0 / L, device="cuda", dtype=torch.float32)
@@ -92,8 +129,68 @@ def test_self_attention_fwd_autows(L, Z):
         enable_tma=True,
     )
     o.backward(do)
-    dq, dk, dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+    return (q.grad.clone(), k.grad.clone(), v.grad.clone()), (rq, rk, rv)
+
+
+@pytest.mark.parametrize("L,Z", [(256, 4), (512, 2)])
+def test_self_attention_fwd_autows(L, Z):
+    """DEFAULT autoWS config (in-process): fwd + grads vs torch reference."""
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    assert bool(A._HSTU_SELF_AUTOWS), "autoWS flag not baked on"
+
+    (dq, dk, dv), (rq, rk, rv) = _run_autows_bwd(L, Z)
 
     for name, got, want in (("dq", dq, rq), ("dk", dk, rk), ("dv", dv, rv)):
         rl2 = _rel_l2(got, want)
         assert rl2 < 1e-2, f"autoWS {name} rel-L2 {rl2:.2e} too high (L={L} Z={Z})"
+
+
+@pytest.mark.parametrize("L,Z", [(256, 2)])
+def test_self_attention_bwd_autows_dqreduce(L, Z):
+    """TLX-matching dq-reduce config (BM=BN=128, ns=2, TMEM reuse, dsT-in-SMEM).
+
+    Runs in a SUBPROCESS because its flags are constexpr-baked at import and
+    cannot share an interpreter with the default config above. Asserts the bwd
+    grads match the torch-float reference (== TLX numerics) to bf16 precision;
+    this is the case that previously produced dv rel-L2 ~0.5 before the
+    dsT-in-SMEM / mmaSelfLatency fixes.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    # The subprocess re-runs this file with --run-dqreduce, which selects
+    # _DQREDUCE_CFG via hstu_autows_config.set_config() before importing the kernel
+    # (no HSTU_SELF_* env needed).
+    r = subprocess.run(
+        [sys.executable, __file__, "--run-dqreduce", str(L), str(Z)],
+        env=dict(os.environ), capture_output=True, text=True, timeout=900,
+    )
+    # Surface the child's REL_L2 line (and any error) in the pytest output.
+    sys.stdout.write(r.stdout)
+    sys.stderr.write(r.stderr)
+    assert r.returncode == 0, (
+        f"dq-reduce autoWS bwd failed (L={L} Z={Z}):\n{r.stdout}\n{r.stderr}"
+    )
+
+
+if __name__ == "__main__":
+    # Subprocess entry point for the dq-reduce config. The env (_DQREDUCE_ENV) is
+    # already in os.environ before this file's top-level import ran, so the kernel
+    # was imported with the dq-reduce constexprs baked on.
+    if len(sys.argv) >= 4 and sys.argv[1] == "--run-dqreduce":
+        _L, _Z = int(sys.argv[2]), int(sys.argv[3])
+        assert bool(A._HSTU_DQ_REUSE), "dq-reduce reuse flag not baked on"
+        (dq, dk, dv), (rq, rk, rv) = _run_autows_bwd(_L, _Z)
+        rls = {n: _rel_l2(g_, w) for n, g_, w in
+               (("dq", dq, rq), ("dk", dk, rk), ("dv", dv, rv))}
+        print(
+            f"REL_L2 dq/dk/dv = {rls['dq']:.2e} / {rls['dk']:.2e} / {rls['dv']:.2e} "
+            f"(L={_L} Z={_Z})"
+        )
+        bad = {n: v for n, v in rls.items() if not (v < 1e-2)}
+        if bad:
+            print(f"FAIL: rel-L2 too high: {bad}")
+            sys.exit(1)
+        print("OK")
+        sys.exit(0)
+    sys.exit("usage: test_self_attention_autows.py --run-dqreduce L Z")

--- a/third_party/tlx/tutorials/test_self_attention_bwd.py
+++ b/third_party/tlx/tutorials/test_self_attention_bwd.py
@@ -15,11 +15,14 @@ import sys
 _HSTU_DIR = os.path.join(os.path.dirname(__file__), "hstu_self_attn")
 sys.path.insert(0, _HSTU_DIR)
 
-# plain Triton + TLX (no autoWS, no meta-WS); TLX needs the wsbarrier-reorder off.
-os.environ.pop("HSTU_SELF_AUTOWS", None)
-os.environ.pop("TRITON_USE_META_WS", None)
-os.environ["HSTU_SELF_PIN"] = "1"
-os.environ["TRITON_DISABLE_WSBARRIER_REORDER"] = "1"
+# HSTU autoWS config as a dict (replaces HSTU_SELF_* env vars), applied via
+# hstu_autows_config.set_config() before importing the kernel (config is read at
+# import). This is the non-autoWS path (plain-Triton vs TLX): autoWS off, pinned
+# for fast compile. The Triton compiler knobs (use_meta_ws off, wsbarrier-reorder
+# off for TLX) are applied per-run via a knobs scope in bench_self.grads().
+import hstu_autows_config as _C  # noqa: E402
+
+_C.set_config(autows=False, pin=True)
 
 import pytest  # noqa: E402
 import torch  # noqa: E402


### PR DESCRIPTION
Summary:

- Fold the fwd uih + target loops into one ForOp (single WS scope/accumulator).
- FA-style manual data partition (opt-in HSTU_SELF_FA_DP, default off): split BLOCK_M
  into two halves in one program, load each KV block once and feed both halves' MMAs
  (shared K/V), two accumulators/stores; the shared KV loop is warp-specialized
  (mirrors fused_attention_ws_device_tma_dp.py). _hstu_attn_fwd_subtile +
  _hstu_attn_fwd_compute_dp; _hstu_attn_fwd dispatches on the flag.
- bench_self.py: fwd/bwd perf harness (autoWS vs TLX) + jagged/target coverage.
- test_self_attention_autows.py: adds the FA-DP fwd case and the (compiler)
  data_partition_factor=2 fwd case, both fwd-output checks in a subprocess vs the
  torch reference; env uses setdefault so subprocess variants can override HSTU_SELF_DP.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D113256799


