### PR TITLE
 [TLX] Fix blackwell_scaled_mm_ws blockwise SMEM OOR at large K (#2311)

### DIFF
--- a/third_party/tlx/tutorials/blackwell_scaled_mm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_scaled_mm_ws.py
@@ -1,21 +1,22 @@
-# TLX warp-specialized FP8 scaled_mm for Blackwell (SM100), mirroring the CUTLASS
-# KernelTmaWarpSpecialized structure. Computes D = (A @ B^T) * scales in bf16 from
-# A[M,K] / B[N,K] fp8 e4m3, for three scaling recipes (scale_mode=):
+# TLX warp-specialized FP8 scaled_mm for Blackwell (SM100). Computes
+# D = (A @ B^T) * scales in bf16 from A[M,K] / B[N,K] fp8 e4m3, for three scaling
+# recipes (scale_mode=):
 #   "blockwise" (DeepSeek): scale_a[M,K//128] M-major + scale_b[N//128,K//128]. The
-#       scale is K-dependent, so each 128-K group's dot is rescaled by sa[m,g]*sb[n,g]
-#       and summed in a pipelined per-group promotion.
-#   "rowwise":    scale_a[M] per-row, scale_b[N] per-col (K-independent).
-#   "tensorwise": scalar scale_a, scale_b (K-independent).
-#   K-independent modes accumulate all K in one TMEM accumulator and apply the scale
-#   once in the epilogue.
+#       scale changes along K, so each 128-wide K group's dot must be rescaled by
+#       sa[m,g]*sb[n,g] BEFORE it is summed -- a per-group rescale-then-accumulate.
+#   "rowwise":    scale_a[M] per-row, scale_b[N] per-col (constant along K).
+#   "tensorwise": scalar scale_a, scale_b (constant along K).
+#   The two K-independent recipes share one scale across the whole K reduction, so they
+#   sum all of K in a single accumulator and scale once at the end -- far cheaper than
+#   blockwise's per-group promotion.
 #
-# Warp-specialized tasks (register-donation split, CUTLASS-style):
-#   LOAD   : TMA-loads A/B per 128-K group into SMEM.
-#   SFLoad : stages blockwise scales in SMEM (no-op for rowwise/tensorwise).
-#   MMA    : producer of the NUM_ACC_BUFFERS-deep accumulator pipeline.
-#   PROMO  : consumer -- rescales / accumulates the partials and stores.
-# NUM_SMEM_BUFFERS / NUM_ACC_BUFFERS / GROUP_SIZE_M / num_warps are @triton.autotune-
-# managed (keyed on M, N, K, SCALE_MODE).
+# Work is split across specialized warps so each stays lean and the stages overlap:
+#   LOAD   : bulk-copies A/B for one K group into SMEM.
+#   SFLoad : streams the blockwise scales, one K group at a time (idle for row/tensorwise).
+#   MMA    : runs the tensor-core dots, producing accumulator partials.
+#   PROMO  : rescales / sums those partials and writes the output tile.
+# Pipeline depths and tiling (NUM_SMEM_BUFFERS / NUM_ACC_BUFFERS / GROUP_SIZE_M /
+# num_warps) are autotuned per (M, N, K, SCALE_MODE).
 
 import torch
 import triton
@@ -24,19 +25,16 @@ import triton.language.extra.tlx as tlx
 from triton.language.extra.tlx.warp_spec import get_bufidx_phase
 from triton.tools.tensor_descriptor import TensorDescriptor
 
-# Register split (mirrors CUTLASS setmaxnreg): the lean load/MMA warps cap at 48
-# regs and donate the surplus to the promotion warpgroup (the "default" task),
-# which inherits it implicitly for the heavy fp32 math.
+# The load/MMA warps do almost no arithmetic, so cap them at 48 registers and give the
+# freed registers to the PROMO warpgroup, which needs them for the heavy fp32 math.
 LOAD_REGS = tl.constexpr(48)
 MMA_REGS = tl.constexpr(48)
 
 
 def _autotune_configs():
-    # Autotune the pure IN-KERNEL knobs (no effect on host-side TMA descriptors or
-    # grid, so no pre_hook needed). EPI_SUB / NUM_CTAS stay fixed at their proven
-    # optima (EPI_SUB=2, NUM_CTAS=1). NUM_PROMO_WARPS must equal the launch num_warps.
-    # Curated list centred on the square-GEMM optimum (4/4/8/8) + diversity for other
-    # shapes; keep small to bound first-call benchmarking cost.
+    # Autotune only the in-kernel knobs (no host TMA-descriptor/grid effect -> no
+    # pre_hook). EPI_SUB=2 / NUM_CTAS=1 are fixed; NUM_PROMO_WARPS must equal num_warps.
+    # Curated around the square-GEMM optimum (4/4/8/8), kept small to bound first-call cost.
     specs = [(4, 4, 8, 8),  # proven optimum for square (e.g. 4096^3)
              (4, 4, 1, 8),  # GSM=1: better L2 for tall/skinny M
              (4, 4, 16, 8),  # GSM=16: wide-N shapes
@@ -62,11 +60,10 @@ def _blackwell_scaled_mm_ws_kernel(
     BLOCK_K: tl.constexpr,  # == 128 (one DeepSeek K-group per iteration)
     GROUP_SIZE_M: tl.constexpr, NUM_SMEM_BUFFERS: tl.constexpr,  # A/B load pipeline depth
     NUM_ACC_BUFFERS: tl.constexpr,  # TMEM accumulator pipeline depth (autotuned)
-    NUM_SMS: tl.constexpr, NUM_CTAS: tl.constexpr = 1,  # 2 -> cluster of 2 SMs cooperate (CUTLASS 2-SM)
-    USE_CLC: tl.constexpr = False,  # True -> CLC dynamic-persistent scheduler (CUTLASS Sched
-    # warp); wins on ragged/grouped/variable-M. Default off (static grid-stride).
-    EPI_SUB: tl.constexpr = 2,  # N sub-tiles for the promotion/epilogue (CUTLASS epi_n loop)
-    K_GROUPS: tl.constexpr = 1,  # = K//BLOCK_K (constexpr): scales staged once per tile
+    NUM_SMS: tl.constexpr, NUM_CTAS: tl.constexpr = 1,  # 2 -> a pair of SMs cooperate on one MMA
+    USE_CLC: tl.constexpr = False,  # True -> hardware dynamic-persistent tile scheduler;
+    # wins on ragged/grouped/variable-M work. Default off (static grid-stride).
+    EPI_SUB: tl.constexpr = 2,  # split the N tile into this many epilogue sub-tiles
     NUM_PROMO_WARPS: tl.constexpr = 8,  # = num_warps; for acc_empty warp-barrier (per-thread arrive)
     SCALE_MODE: tl.constexpr = 0,  # 0=BLOCKWISE (K-dependent, per-group promotion);
     # 1=ROWWISE and 2=TENSORWISE (both K-independent: accumulate ALL K in one accumulator,
@@ -95,9 +92,8 @@ def _blackwell_scaled_mm_ws_kernel(
         pred_cta0 = False
         cta_bars = None
 
-    # TLX two_ctas is N-split ONLY (semantic.py: rhs must be [K, N/2], output N is
-    # doubled back): the 2 SMs split the output N of a shared-A tile, each holding
-    # half of B. CUTLASS's M-split (shared/multicast B) is NOT expressible here.
+    # TLX two_ctas is N-split ONLY. The 2 SMs split the output N of a shared-A tile, each holding
+    # half of B.
     BLOCK_N_CTA: tl.constexpr = BLOCK_N // NUM_CTAS  # each CTA loads/holds this N-slice of B
 
     # ---- SMEM operand buffers (A/B), multi-buffered load pipeline ----
@@ -106,58 +102,57 @@ def _blackwell_scaled_mm_ws_kernel(
 
     # ---- TMEM accumulator pipeline: NUM_ACC_BUFFERS rotating [BLOCK_M,BLOCK_N] fp32 slots ----
     acc_tmem = tlx.local_alloc((BLOCK_M, BLOCK_N), tl.float32, NUM_ACC_BUFFERS, storage=tlx.storage_kind.tmem)
-    # ---- Sub-tiled promotion: N split into EPI_SUB pieces so only a sub-tile
-    # partial is live at once (CUTLASS epilogue sub-tiling). EPI_SUB is a param. ----
+    # ---- Sub-tiled promotion: handle the N tile in EPI_SUB pieces so only one sub-tile's
+    # fp32 partials are live at a time, keeping register/SMEM pressure down. ----
     SUB_N: tl.constexpr = BLOCK_N // EPI_SUB
     # SMEM store buffers, one per sub-tile (multi-buffered TMA store)
     c_smem = tlx.local_alloc((BLOCK_M, SUB_N), tlx.dtype_of(c_desc), EPI_SUB)
 
-    # ---- Scale (SF) SMEM pipeline: the SFLoad warp stages the WHOLE tile's scales
-    # (all K_GROUPS) ONCE per tile; PROMO then reads sa[g]/sb[g] from SMEM per K-group
-    # with NO per-K-group barrier -> only a per-TILE sf handshake (cuts ~2 warpgroup
-    # BAR.SYNC per K-group in the 8-warp PROMO group). Flat buffer arrays indexed
-    # [tbuf*K_GROUPS + g]; NUM_SF_BUF tile-buffers for cross-tile overlap.
-    NUM_SF_BUF: tl.constexpr = 3
-    sa_smem = tlx.local_alloc((BLOCK_M, ), tl.float32, NUM_SF_BUF * K_GROUPS)
-    sb_smem = tlx.local_alloc((1, ), tl.float32, NUM_SF_BUF * K_GROUPS)
+    # ---- Scale (SF) SMEM pipeline: stream the blockwise scales one K group at a time,
+    # NUM_SF_BUF slots deep, so scale SMEM stays small regardless of K. Holding every K
+    # group's scales at once would grow with K and overflow SMEM on large-K problems.
+    NUM_SF_BUF: tl.constexpr = 4  # K-group pipeline depth
+    sa_smem = tlx.local_alloc((BLOCK_M, ), tl.float32, NUM_SF_BUF)
+    sb_smem = tlx.local_alloc((1, ), tl.float32, NUM_SF_BUF)
 
     # ---- Barriers ----
     # A/B load pipeline: producer(load) -> consumer(mma)
-    ab_full = tlx.alloc_barriers(NUM_SMEM_BUFFERS, arrive_count=1)  # TMA fills (expect_bytes)
+    ab_full = tlx.alloc_barriers(NUM_SMEM_BUFFERS, arrive_count=1)  # signalled when A/B are loaded
     ab_empty = tlx.alloc_barriers(NUM_SMEM_BUFFERS, arrive_count=1)  # mma releases
-    # scale (SF) pipeline: producer(sf_load) -> consumer(promo), now PER-TILE
-    sf_full = tlx.alloc_barriers(NUM_SF_BUF, arrive_count=1)  # cp.async.bulk fills (expect_bytes)
-    sf_empty = tlx.alloc_barriers(NUM_SF_BUF, arrive_count=1)  # promo releases
+    # scale (SF) pipeline: producer(sf_load) -> consumer(promo), per K-group.
+    sf_full = tlx.alloc_barriers(NUM_SF_BUF, arrive_count=1)  # signalled when the scales are loaded
+    # sf_empty: a per-thread barrier -- each PROMO thread signals only after its own scale
+    # read, so SFLoad can't overwrite a slot while a slower reader is still using it (and it
+    # avoids a full-warpgroup sync).
+    sf_empty = tlx.alloc_warp_barrier(NUM_SF_BUF, num_warps=NUM_PROMO_WARPS, num_arrivals=1)
     # accumulator pipeline: producer(mma) -> consumer(promo)
     acc_full = tlx.alloc_barriers(NUM_ACC_BUFFERS, arrive_count=1)  # mma commits a slot
-    # acc_empty: PROMO releases each slot with a PER-THREAD (warp-barrier) arrive, so no
-    # CTA BAR.SYNC. alloc_warp_barrier sets arrive_count = NUM_PROMO_WARPS*32; every thread
-    # arrives independently (safe: each warp's TMEM read is fenced by its own tcgen05.wait::ld).
+    # acc_empty: a per-thread barrier -- each PROMO thread frees the accumulator slot right
+    # after its own read, so MMA can refill it without waiting on a full-warpgroup sync.
     acc_empty = tlx.alloc_warp_barrier(NUM_ACC_BUFFERS, num_warps=NUM_PROMO_WARPS, num_arrivals=1)
 
     dsize_a: tl.constexpr = tlx.size_of(tlx.dtype_of(a_desc))
     dsize_b: tl.constexpr = tlx.size_of(tlx.dtype_of(b_desc))
 
-    # ---- CLC dynamic-persistent tile scheduler (CUTLASS Sched warp) ----
-    # A dedicated 1-warp SCHED partition (below) is the CLC pipeline producer (issues
-    # try_cancel) AND a consumer (reads its own next tile to terminate); the 4 work
-    # partitions (LOAD, SFLoad, MMA, PROMO) are the other consumers -> 5 CLC consumers.
-    # Mirrors CUTLASS's WarpCategory::Sched. Wins on ragged/grouped/variable-M.
+    # ---- Optional dynamic-persistent tile scheduler ----
+    # A dedicated scheduler warp asks the hardware for the next tile and hands it to the
+    # four work warps, so tiles are dealt out on demand instead of by a fixed stride --
+    # this keeps the SMs balanced when tiles do uneven work (ragged / grouped / variable-M).
     clc_multi_ctas: tl.constexpr = NUM_CTAS == 2
     if USE_CLC:
         clc_context = tlx.clc_create_context(num_consumers=5)
 
     with tlx.async_tasks():
-        # ============ SCHED warp (dedicated CLC producer, CUTLASS Sched) ============
+        # ============ SCHED warp (hands out the next tile to run) ============
         if USE_CLC:
             with tlx.async_task(num_warps=1, num_regs=LOAD_REGS):
                 tile_id = start_pid
                 clc_phase_producer = 1
                 clc_phase_consumer = 0
                 while tile_id != -1:
-                    # issue the try_cancel for the NEXT tile, then read it (also our
-                    # own termination signal). No GEMM work here -> the try_cancel
-                    # latency overlaps the work warps' compute for this tile.
+                    # Request the next tile, then read the answer (-1 means "no more, stop").
+                    # This warp does no math, so the request latency hides behind the other
+                    # warps' compute on the current tile.
                     tlx.clc_producer(clc_context, clc_phase_producer, multi_ctas=clc_multi_ctas)
                     clc_phase_producer ^= 1
                     tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=clc_multi_ctas)
@@ -193,34 +188,33 @@ def _blackwell_scaled_mm_ws_kernel(
                     if tile_id >= num_tiles:
                         tile_id = -1
 
-        # ============ SFLoad warp (cp.async.bulk scale_a -> SMEM) ============
-        # Dedicated scale-load partition (CUTLASS MainloopSFLoad): keeps the scale
-        # global load fully off the promotion warp's critical path.
+        # ============ SFLoad warp (loads the blockwise scales) ============
+        # A separate warp for the scale loads keeps their global-memory latency hidden and
+        # off PROMO's critical path.
         with tlx.async_task(num_warps=1, num_regs=LOAD_REGS):
-            sf_tile = 0
+            sf_cnt = 0
             tile_id = start_pid
             clc_phase = 0
             while tile_id != -1:
                 pid_m, pid_n = _pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
                 offs_am = pid_m * BLOCK_M
-                nblk = pid_n  # BLOCK_N==128 -> one N-block per tile; sb row = scale_b[nblk, :]
-                if SCALE_MODE == 0:  # BLOCKWISE: stage per-(row,K-group) sa + per-block sb.
+                # which 128-wide scale_b N-block this tile falls in. BLOCK_N==128 -> nblk==pid_n;
+                # BLOCK_N<128 -> adjacent tiles share (re-read) the same block. (constexpr fold)
+                nblk = pid_n * BLOCK_N // 128
+                if SCALE_MODE == 0:  # BLOCKWISE: pipeline per-(row,K-group) sa + per-block sb.
                     # ROWWISE loads its tiny K-independent sa/sb directly in PROMO.
-                    tbuf, tphase = get_bufidx_phase(sf_tile, NUM_SF_BUF)
-                    base = tbuf * K_GROUPS
-                    tlx.barrier_wait(sf_empty[tbuf], tphase ^ 1)
-                    # sb: K_GROUPS scalars via regular loads -> flat SMEM slots, fenced before
-                    # the sa bulk signals sf_full. (These loads are in the SFLoad producer,
-                    # already hidden by NUM_SF_BUF prefetch -> not on PROMO's critical path.)
                     for g in range(0, k_groups):
+                        sf_buf, sf_phase = get_bufidx_phase(sf_cnt, NUM_SF_BUF)
+                        tlx.barrier_wait(sf_empty[sf_buf], sf_phase ^ 1)  # slot drained by PROMO
+                        # sb is one scalar per group; write it to SMEM and fence before the sa
+                        # bulk load so both scales become visible to PROMO together.
                         sb_val = tl.load(scale_b_ptr + nblk * num_k_groups_scale + g + tl.arange(0, 1))
-                        tlx.local_store(sb_smem[base + g], sb_val)
-                    tlx.fence_async_shared()
-                    tlx.barrier_expect_bytes(sf_full[tbuf], 4 * BLOCK_M * K_GROUPS)
-                    for g in range(0, k_groups):
-                        tlx.async_load(scale_a_ptr + offs_am + g * M, sa_smem[base + g], bulk=True,
-                                       barrier=sf_full[tbuf])
-                sf_tile += 1
+                        tlx.local_store(sb_smem[sf_buf], sb_val)
+                        tlx.fence_async_shared()
+                        tlx.barrier_expect_bytes(sf_full[sf_buf], 4 * BLOCK_M)
+                        tlx.async_load(scale_a_ptr + offs_am + g * M, sa_smem[sf_buf], bulk=True,
+                                       barrier=sf_full[sf_buf])
+                        sf_cnt += 1
                 if USE_CLC:
                     tile_id = tlx.clc_consumer(clc_context, clc_phase, multi_ctas=clc_multi_ctas)
                     clc_phase ^= 1
@@ -237,8 +231,9 @@ def _blackwell_scaled_mm_ws_kernel(
             clc_phase = 0
             while tile_id != -1:
                 if SCALE_MODE == 0:
-                    # BLOCKWISE: FRESH MMA per K-group into a rotating acc slot -> the
-                    # producer of the NUM_ACC_BUFFERS-deep pipeline PROMO rescales+sums.
+                    # BLOCKWISE: every K group has its own scale, so its dot must be kept
+                    # separate rather than summed in the tensor core. Write each group's
+                    # product to its own accumulator slot; PROMO rescales it, then sums.
                     for g in range(0, k_groups):
                         ld_buf, ld_phase = get_bufidx_phase(ld_cnt, NUM_SMEM_BUFFERS)
                         ac_buf, ac_phase = get_bufidx_phase(acc_cnt, NUM_ACC_BUFFERS)
@@ -295,16 +290,16 @@ def _blackwell_scaled_mm_ws_kernel(
                     if tile_id >= num_tiles:
                         tile_id = -1
 
-        # ============ PROMOTION warp group (consumer: rescale + accumulate + store) ============
-        # "default" task = the launch num_warps warpgroup; it inherits the register
-        # surplus donated by the lean load/MMA warps (CUTLASS setmaxnreg 256 analog).
+        # ============ PROMOTION warpgroup (rescale + accumulate + store) ============
+        # The "default" task is the full num_warps warpgroup; it inherits the registers the
+        # lean load/MMA warps gave up and spends them on the fp32 rescale math.
         with tlx.async_task("default"):
             acc_cnt = 0
             tile_id = start_pid
             clc_phase_consumer = 0
-            sf_tile = 0
+            sf_cnt = 0
             while tile_id != -1:
-                # PROMO is a CLC consumer only; the dedicated SCHED warp produces.
+                # PROMO just reads the next tile id; the scheduler warp requests it.
                 pid_m, pid_n = _pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M)
                 offs_am = pid_m * BLOCK_M
                 offs_bn = pid_n * BLOCK_N
@@ -314,29 +309,29 @@ def _blackwell_scaled_mm_ws_kernel(
                     # One [BLOCK_M, SUB_N] register running-sum per N sub-tile (EPI_SUB
                     # of them), loop-carried across the K-group loop.
                     accs = [tl.zeros((BLOCK_M, SUB_N), dtype=tl.float32) for _ in range(EPI_SUB)]
-                    # Scales staged in SMEM by SFLoad; wait ONCE per tile, then read
-                    # sa[g]/sb[g] per K-group with NO barrier -> fewer warpgroup BAR.SYNC.
-                    tbuf, tphase = get_bufidx_phase(sf_tile, NUM_SF_BUF)
-                    base = tbuf * K_GROUPS
-                    tlx.barrier_wait(sf_full[tbuf], tphase)
                     for g in range(0, k_groups):
                         ac_buf, ac_phase = get_bufidx_phase(acc_cnt, NUM_ACC_BUFFERS)
-                        sa = tlx.local_load(sa_smem[base + g])  # [BLOCK_M]
-                        sb = tlx.local_load(sb_smem[base + g])  # [1]
+                        # Scales pipelined per K-group by SFLoad; slot released below once read.
+                        sf_buf, sf_phase = get_bufidx_phase(sf_cnt, NUM_SF_BUF)
+                        tlx.barrier_wait(sf_full[sf_buf], sf_phase)
+                        sa = tlx.local_load(sa_smem[sf_buf])  # [BLOCK_M]
+                        sb = tlx.local_load(sb_smem[sf_buf])  # [1]
                         sasb = sa * sb  # [BLOCK_M] (broadcast [1])
                         tlx.barrier_wait(acc_full[ac_buf], ac_phase)
-                        # Synchronous T2R load: overlapping it across K-groups (async-T2R or a
-                        # manual SW pipeline) is neutral -- the acc pipeline + warp scheduler
-                        # already hide the tcgen05.ld latency.
+                        # Read the partial straight from tensor memory; the deep accumulator
+                        # pipeline already hides this read's latency, so overlapping it by
+                        # hand would buy nothing.
                         ps = [
                             tlx.local_load(tlx.local_slice(acc_tmem[ac_buf], [0, s * SUB_N], [BLOCK_M, SUB_N]))
                             for s in range(EPI_SUB)
                         ]
                         accs = [accs[s] + ps[s] * sasb[:, None] for s in range(EPI_SUB)]
-                        tlx.barrier_arrive(acc_empty[ac_buf])  # warp barrier, no CTA BAR.SYNC
+                        tlx.barrier_arrive(acc_empty[ac_buf])  # per-thread, no warpgroup sync
+                        # free the scale slot now that sa/sb are consumed -- per-thread, so a
+                        # slower reader is never overwritten.
+                        tlx.barrier_arrive(sf_empty[sf_buf])  # per-thread, no warpgroup sync
                         acc_cnt += 1
-                    tlx.barrier_arrive(sf_empty[tbuf], 1)  # SFLoad may reload the sf buffer
-                    sf_tile += 1
+                        sf_cnt += 1
                     # sub-tiled store, deferred TMA-store wait (double-buffered c_smem):
                     # this tile's stores drain during the NEXT tile's compute.
                     for s in tl.static_range(EPI_SUB):
@@ -394,7 +389,7 @@ def _pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M):
     return pid_m, pid_n
 
 
-def blackwell_scaled_mm_ws(a, b, scale_a, scale_b, out_dtype=torch.bfloat16, BLOCK_M=128, BLOCK_N=128, NUM_CTAS=1,
+def blackwell_scaled_mm_ws(a, b, scale_a, scale_b, out_dtype=torch.bfloat16, BLOCK_M=None, BLOCK_N=128, NUM_CTAS=1,
                            USE_CLC=False, EPI_SUB=2, persistent=True, scale_mode="blockwise"):
     # NOTE: NUM_SMEM_BUFFERS, NUM_ACC_BUFFERS, GROUP_SIZE_M, num_warps are now
     # @triton.autotune-managed (keyed on M,N,K,SCALE_MODE) -- see _autotune_configs().
@@ -405,11 +400,15 @@ def blackwell_scaled_mm_ws(a, b, scale_a, scale_b, out_dtype=torch.bfloat16, BLO
     scale_mode="rowwise":    scale_a [M] (or [M,1]) per-row, scale_b [N] (or [1,N]) per-col; K-independent.
     scale_mode="tensorwise": scale_a, scale_b are scalars (one fp32 each); K-independent.
     NUM_CTAS=2 -> cluster of 2 SMs cooperate on the MMA (blockwise only).
+    BLOCK_M=None -> occupancy-aware M tile (64 on small shapes, 128 otherwise); pass an int to force.
     """
     SCALE_MODE = {"blockwise": 0, "rowwise": 1, "tensorwise": 2}[scale_mode]
     M, K = a.shape
     N, Kb = b.shape
     assert K == Kb and K % 128 == 0 and N % 128 == 0
+    # Blockwise uses one 128-wide scale_b block per N tile, so a tile must fit within a
+    # single block -> BLOCK_N must divide 128 (BLOCK_N<128 tiles re-read the shared block).
+    assert SCALE_MODE != 0 or 128 % BLOCK_N == 0, "blockwise requires BLOCK_N to divide 128"
     c = torch.empty((M, N), dtype=out_dtype, device=a.device)
     if SCALE_MODE == 1:
         # rowwise: kernel reads scale_a[off_m], scale_b[off_n] directly -> need contiguous 1-D.
@@ -426,6 +425,19 @@ def blackwell_scaled_mm_ws(a, b, scale_a, scale_b, out_dtype=torch.bfloat16, BLO
 
     BLOCK_K = 128
     num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+
+    # Occupancy-aware M tile. The 128x128 tile leaves most SMs idle on small problems
+    # (e.g. 1024^3 -> 64 tiles on ~148 SMs, <50% of the GPU). A 64-tall tile doubles the
+    # tile count to fill those SMs -- but only when the doubled count still fits in ONE
+    # wave, so we don't trade idle SMs for a second, poorly-occupied wave. Larger shapes
+    # keep 128, whose higher MMA efficiency wins once the GPU is already full.
+    if BLOCK_M is None:
+        num_pid_n = triton.cdiv(N, BLOCK_N)
+        tiles_128 = triton.cdiv(M, 128) * num_pid_n
+        tiles_64 = triton.cdiv(M, 64) * num_pid_n
+        # Only the 1-CTA path is modeled here; a 2-CTA cluster occupies NUM_CTAS SMs per
+        # tile (a different occupancy model we don't tune), so leave it at 128.
+        BLOCK_M = 64 if (NUM_CTAS == 1 and tiles_128 < num_sms and tiles_64 <= num_sms) else 128
 
     def alloc_fn(size, alignment, stream):
         return torch.empty(size, device=a.device, dtype=torch.int8)
@@ -451,10 +463,10 @@ def blackwell_scaled_mm_ws(a, b, scale_a, scale_b, out_dtype=torch.bfloat16, BLO
         grid = (min(num_sms // NUM_CTAS * NUM_CTAS, num_tiles), )
         stride_sms = grid[0]
     else:
-        # non-persistent (vLLM/CUTLASS model): one CTA per tile (NUM_SMS==num_tiles ends
-        # each CTA's grid-stride after one tile). Slower here -- our WS prologue (register
-        # donation + deep pipeline fill) only amortizes over many tiles per CTA. Persistent
-        # is the default; kept for experimentation.
+        # non-persistent: one CTA per tile (NUM_SMS==num_tiles ends the grid-stride after one
+        # tile). Slower here -- the warp-specialized prologue (register donation + filling the
+        # deep pipeline) only pays off when amortized over many tiles per CTA. Kept for
+        # experimentation.
         grid = (num_tiles, )
         stride_sms = num_tiles
     # GROUP_SIZE_M, NUM_SMEM_BUFFERS, NUM_ACC_BUFFERS, NUM_PROMO_WARPS (+ launch
@@ -475,7 +487,6 @@ def blackwell_scaled_mm_ws(a, b, scale_a, scale_b, out_dtype=torch.bfloat16, BLO
         NUM_CTAS=NUM_CTAS,
         USE_CLC=USE_CLC,
         EPI_SUB=EPI_SUB,
-        K_GROUPS=K // BLOCK_K,  # scales staged once per tile
         SCALE_MODE=SCALE_MODE,
     )
     return c

--- a/third_party/tlx/tutorials/testing/test_blackwell_scaled_mm_perf.py
+++ b/third_party/tlx/tutorials/testing/test_blackwell_scaled_mm_perf.py
@@ -85,9 +85,6 @@ def create_benchmark(modes):
         ))
     def benchmark(M, N, K, provider):
         backend, mode = provider.split("-")
-        # TLX blockwise stages per-K-group scales in SMEM (~12*K bytes); it OOMs at large K.
-        if backend == "tlx" and mode == "blockwise" and K >= 12288:
-            return float("nan"), float("nan"), float("nan")
         a = (torch.randn((M, K), device=DEVICE) * 0.1).to(torch.float8_e4m3fn)
         b = (torch.randn((N, K), device=DEVICE) * 0.1).to(torch.float8_e4m3fn)
         scale_a, scale_b = _make_scales(M, N, K, mode)

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -408,6 +408,7 @@ class ScaledMM:
     # (M, N, K), N and K multiples of 128: square (small/large) plus igctr
     # production moderate / tall (large N, small K) / wide (small N, large K).
     SHAPES = [
+        (1024, 1024, 1024),  # small: exercises the occupancy-aware BLOCK_M=64 tile
         (2048, 2048, 2048),
         (8192, 8192, 8192),
         (4096, 6144, 4608),
@@ -1011,9 +1012,6 @@ def test_blackwell_fa_ws_pipelined_persistent_mxfp8_bwd(Z, H, N_CTX, causal):
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_blackwell_scaled_mm_ws(shape, scale_mode):
     M, N, K = shape
-    # Blockwise stages per-K-group scales in SMEM (~12*K bytes); it OOMs at large K.
-    if scale_mode == "blockwise" and K >= 12288:
-        pytest.skip("blockwise scale SMEM does not fit at large K")
     ScaledMM.run_test(scale_mode, shapes=[shape])
 
 


### PR DESCRIPTION
Summary:
### Problem
Blockwise (DeepSeek) scaled_mm failed to compile for K ≥ 12288 with shared memory out of resource(Required: 312964, Hardware limit: 232448).

In blockwise mode the scale factors change along K, so every 128-wide K group needs its own scale. The kernel was loading all of a tile's K-group scales into shared memory up front, so that buffer grew with K. Past K=12288 it alone was ~147 KB and blew the shared-memory budget.

### Fix
Stream the scales through a small fixed-depth pipeline instead: load one K group's scales per iteration. The shared memory usage for scales is now constant regardless of K (~2 KB), so large-K tiles fit. This is the same streaming pattern the A/B operands already use. 

We also remove the now-obsolete K >= 12288 blockwise skips in the correctness and perf tests.


Test Plan:
tritonbench accuracy
```
CUDA_VISIBLE_DEVICES=4 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 python run.py --op fp8_gemm --scaling-pair BlockWise1x128,BlockWise128x128 --only vllm_cutlass_fp8_gemm,tlx_scaled_mm_fp8_gemm --metrics accuracy --baseline vllm_cutlass_fp8_gemm --atol 1e-4 --rtol 0.016 --simple-output
```
shows 
```
                x_val    tlx_scaled_mm_fp8_gemm-accuracy
---------------------  ---------------------------------
   (1024, 1024, 1024)                                  1
   (1280, 1280, 1280)                                  1
   (1536, 1536, 1536)                                  1
   (1792, 1792, 1792)                                  1
   (2048, 2048, 2048)                                  1
   (2560, 2560, 2560)                                  1
   (3072, 3072, 3072)                                  1
   (3584, 3584, 3584)                                  1
   (4096, 4096, 4096)                                  1
   (5120, 5120, 5120)                                  1
   (6144, 6144, 6144)                                  1
   (7168, 7168, 7168)                                  1
   (8192, 8192, 8192)                                  1
(10240, 10240, 10240)                                  1
(12288, 12288, 12288)                                  1
(14336, 14336, 14336)                                  1
(16384, 16384, 16384)                                  1
(20480, 20480, 20480)                                  1
(24576, 24576, 24576)                                  1
(28672, 28672, 28672)                                  1
                  1.0
```
### tritonbench performance
```
CUDA_VISIBLE_DEVICES=4 TRITON_ALWAYS_COMPILE=1 TRITON_USE_META_WS=1 python run.py --op fp8_gemm --scaling-pair BlockWise1x128,BlockWise128x128 --only vllm_cutlass_fp8_gemm,tlx_scaled_mm_fp8_gemm --metrics tflops --simple-output --rep 1000 --cudagraph
```
shows
```
                               x_val    vllm_cutlass_fp8_gemm-tflops    tlx_scaled_mm_fp8_gemm-tflops
------------------------------------  ------------------------------  -------------------------------
                  (1024, 1024, 1024)                         366.178                          303.497
                  (1280, 1280, 1280)                         606.389                          542.732
                  (1536, 1536, 1536)                         800.57                           785.417
                  (1792, 1792, 1792)                         801.058                          801.598
                  (2048, 2048, 2048)                         940.826                          931.012
                  (2560, 2560, 2560)                        1085                             1087.92
                  (3072, 3072, 3072)                        1193.87                          1205
                  (3584, 3584, 3584)                        1224.14                          1228.7
                  (4096, 4096, 4096)                        1316.09                          1331.17
                  (5120, 5120, 5120)                        1376.2                           1396
                  (6144, 6144, 6144)                        1426.18                          1425.71
                  (7168, 7168, 7168)                        1385.66                          1433.76
                  (8192, 8192, 8192)                        1233.61                          1375.81
               (10240, 10240, 10240)                        1002.9                           1392.81
               (12288, 12288, 12288)                         888.763                         1380.53
               (14336, 14336, 14336)                         851.112                         1368.01
               (16384, 16384, 16384)                         827.841                         1319.91
               (20480, 20480, 20480)                         820.744                         1274.35
               (24576, 24576, 24576)                         822.111                         1276.5
               (28672, 28672, 28672)                         821.083                         1279.54
989.5164307753439,1156.9982189359487
```

Reviewed By: njriasan

Differential Revision: D113313069

Pulled By: Sibylau


