### PR TITLE
[triton][bitequiv] M2: reduction-layout optimization pass

### DIFF
--- a/bitequiv/evaluation/evaluate_opt.py
+++ b/bitequiv/evaluation/evaluate_opt.py
@@ -230,18 +230,25 @@ def optimization(resolved):
 
 
 def _clear_jit_caches():
-    """Drop the eval kernels' in-memory compile caches so the next warmup recompiles."""
+    """Drop the eval kernels' in-memory compile caches so the next warmup recompiles.
+
+    A stale in-memory hit would silently reuse the baseline compile and mask the pass
+    under test (the make_ttgir patch/env is not part of the compile-cache key). Every
+    kernel evaluate_opt evaluates lives in ``eval_kernels`` (its REGISTRY /
+    resolve_kernels), so clearing that one module is sufficient; if a module of eval
+    @triton.jit kernels is ever added to the REGISTRY, add it to the tuple below."""
     from triton.runtime.jit import JITFunction
 
-    for obj in vars(eval_kernels).values():
-        if isinstance(obj, JITFunction):
-            for attr in ("device_caches", "cache"):
-                cache = getattr(obj, attr, None)
-                if hasattr(cache, "clear"):
-                    try:
-                        cache.clear()
-                    except Exception:  # noqa: BLE001
-                        pass
+    for mod in (eval_kernels, ):
+        for obj in vars(mod).values():
+            if isinstance(obj, JITFunction):
+                for attr in ("device_caches", "cache"):
+                    cache = getattr(obj, attr, None)
+                    if hasattr(cache, "clear"):
+                        try:
+                            cache.clear()
+                        except Exception:  # noqa: BLE001
+                            pass
 
 
 @contextlib.contextmanager
@@ -353,8 +360,15 @@ def correctness(spec, base_variant, opt_variant, config_effort, fuzzer_effort, o
 # --------------------------------------------------------------------------- #
 # Stage 3 — performance (opt-in)
 # --------------------------------------------------------------------------- #
-def performance(spec, base_variant, opt_variant, config_effort, ordering):
-    """Benchmark baseline vs optimized per in-scope config; report speedups."""
+def performance(spec, base_variant, opt_variant, config_effort, ordering, ceiling=False):
+    """Benchmark baseline vs optimized per in-scope config; report speedups.
+
+    With ``ceiling`` the 3-way comparison also times the per-config UNORDERED
+    "ceiling" (the same kernel/config compiled ``reduction_ordering=unordered`` =
+    what the compiler picks when free of the ordering constraint) and reports how
+    much of the ordered-vs-unordered gap the optimization closed:
+    ``gap_closed = (base_ms - opt_ms) / (base_ms - ceil_ms)`` (1.0 = fully closed).
+    """
     if not spec.supports_perf:
         return dict(name=spec.name, no_perf=True)
     size = spec.perf_size
@@ -370,10 +384,21 @@ def performance(spec, base_variant, opt_variant, config_effort, ordering):
             _clear_jit_caches()
             with opt_variant():
                 opt_ms, opt_bytes, _ = spec.benchmark(config, size)
+            ceil_ms = None
+            if ceiling and config.reduction_ordering is not None:
+                # The ceiling is measured on the STANDARD pipeline (base_variant),
+                # only the ordering constraint is dropped.
+                ceil_cfg = config._replace(reduction_ordering="unordered")
+                _clear_jit_caches()
+                with base_variant():
+                    ceil_ms, _, _ = spec.benchmark(ceil_cfg, size)
         except Exception:  # noqa: BLE001
             fails += 1
             continue
-        rows.append(dict(config=config, base_ms=base_ms, opt_ms=opt_ms, bit_identical=base_bytes == opt_bytes))
+        row = dict(config=config, base_ms=base_ms, opt_ms=opt_ms, bit_identical=base_bytes == opt_bytes)
+        if ceil_ms is not None:
+            row["ceil_ms"] = ceil_ms
+        rows.append(row)
     return dict(name=spec.name, size=size, rows=rows, fails=fails)
 
 
@@ -437,7 +462,7 @@ def render_performance(results):
             continue
         rows, cols = r["size"]
         lines.append(f"{r['name']}  (size {rows}x{cols}, do_bench min-of-medians)")
-        speedups = []
+        speedups, gaps = [], []
         for row in r["rows"]:
             valid = math.isfinite(row["opt_ms"]) and row["opt_ms"] > 0
             if valid:
@@ -446,11 +471,24 @@ def render_performance(results):
                 tail = f"= {speedup:.2f}x  bit_identical={row['bit_identical']}"
             else:
                 tail = "opt timing invalid (excluded from summary)"
+            # 3-way ceiling: how much of the ordered-vs-unordered gap did we close?
+            ceil_str = ""
+            if "ceil_ms" in row:
+                denom = row["base_ms"] - row["ceil_ms"]
+                if abs(denom) > 1e-9 and valid:
+                    gap = (row["base_ms"] - row["opt_ms"]) / denom
+                    gaps.append(gap)
+                    ceil_str = f"  ceil {row['ceil_ms']:.3f} ms  gap_closed={gap:.2f}"
+                else:
+                    ceil_str = f"  ceil {row['ceil_ms']:.3f} ms  (no gap)"
             lines.append(f"  {config_label(row['config'])}: base {row['base_ms']:.3f} ms -> opt "
-                         f"{row['opt_ms']:.3f} ms  {tail}")
+                         f"{row['opt_ms']:.3f} ms  {tail}{ceil_str}")
         if speedups:
-            lines.append(f"  -> speedup min {min(speedups):.2f}x | median "
-                         f"{statistics.median(speedups):.2f}x | max {max(speedups):.2f}x")
+            summary = (f"  -> speedup min {min(speedups):.2f}x | median "
+                       f"{statistics.median(speedups):.2f}x | max {max(speedups):.2f}x")
+            if gaps:
+                summary += f" | median gap_closed {statistics.median(gaps):.2f}"
+            lines.append(summary)
         else:
             lines.append("  -> no valid timings")
         lines.append("")
@@ -489,6 +527,10 @@ def parse_args(argv):
     p.add_argument("--fuzzer-effort", default="fast", choices=("fast", "convincing"))
     p.add_argument("--ordering", default="inner_tree", choices=("inner_tree", "unordered", "all"),
                    help="which reduction ordering to evaluate (default inner_tree = M2's target)")
+    p.add_argument("--ceiling", action="store_true",
+                   help="Stage 3 only: also time the per-config UNORDERED ceiling (the layout the "
+                   "compiler picks free of the ordering constraint) and report gap_closed = "
+                   "(base-opt)/(base-ceil). This is M2's goal metric: drive gap_closed -> 1.")
     p.add_argument("--out", default=_DEFAULT_OUT, help="result table path")
     return p.parse_args(argv)
 
@@ -635,7 +677,8 @@ def main(argv=None):
         print("== Stage 3: performance ==", flush=True)
         results = []
         for spec in specs:
-            results.append(performance(spec, base_variant, opt_variant, args.config_effort, args.ordering))
+            results.append(
+                performance(spec, base_variant, opt_variant, args.config_effort, args.ordering, args.ceiling))
         sections.append(render_performance(results))
 
     write_report(args.out, header, sections)

--- a/bitequiv/experiments/m2_convert_removal/README.md
+++ b/bitequiv/experiments/m2_convert_removal/README.md
@@ -1,0 +1,45 @@
+# M2 convert-removal experiment (approach A vs approach B)
+
+Evidence artifacts for one M2 design decision: **keep A (convert-based); reject B
+(convert removal).** Full write-up: `M2_DESIGN.en.md` / `M2_DESIGN.zh.md` §5.3–§5.5
+and the standalone protocol `M2_approach_B_experiment.md` (both in the bitequiv
+knowledge base).
+
+## The question
+
+The M2 pass `tritongpu-optimize-reduction-layout` inserts one `ttg.convert_layout`
+on a reduction's operand (coalesced load → reduce-friendly layout). Approach B
+asked: can we remove that convert by making the *load* produce the reduce-friendly
+layout directly (pinning it upstream, à la `OptimizeThreadLocality`)?
+
+## The two kernels here
+
+Real compiled TTGIR for `sum_2d_col` [256×32], reduce axis 0 (M non-contiguous,
+C contiguous), `num_warps=4`, `reduction_ordering="inner_tree"`:
+
+- `sum_2d_col.A.ttgir` — **approach A**: coalesced load → `ttg.convert_layout` →
+  warp-synchronous reduce (what the pass emits).
+- `sum_2d_col.B.ttgir` — **approach B**: load *directly* in the reduce-friendly
+  layout (uncoalesced) → reduce, **no convert**.
+
+The only difference is the load layout and the presence of the convert. B removes
+the convert but forces an uncoalesced load: 32 lanes on the strided M axis ≈ 32×
+the memory transactions.
+
+## Result (GB300, `do_bench` min-of-medians; 6 kernels × num_warps ∈ {2,4,8} = 17 configs)
+
+- A: **1.6–5.3×** over base, 0 regressions.
+- B: **0.41–1.92×** over base (usually *slower* than base); **2.5–4.8× slower than A**.
+- All 17 configs: `base == A == B` bytewise (`inner_tree` makes layout a free knob).
+
+**Conclusion.** For a reduction over a non-contiguous axis, "no convert" is only
+reachable by an uncoalesced load, which costs more than the cross-warp stage it
+removes. A's convert is the cheaper of the two unavoidable bridges between a
+coalesced load layout and a warp-synchronous reduce layout. A chosen; B rejected.
+
+## Reproduce
+
+`bexp.py` builds the B variant from A's ideal layout, injects it via a
+`make_ttgir` patch (same hook `evaluate_opt` uses for A), and times base/A/B.
+Run from an activated venv on a GPU box; see `M2_approach_B_experiment.md` for the
+exact command, environment, and per-config data.

--- a/bitequiv/experiments/m2_convert_removal/bexp.py
+++ b/bitequiv/experiments/m2_convert_removal/bexp.py
@@ -1,0 +1,180 @@
+"""3-way experiment: base vs A(convert) vs B(ideal-on-load, no convert).
+
+B is emulated faithfully: take the baseline TTGIR and swap the LOAD layout's
+definition body for the ideal (reduce-friendly) layout that A converts to. That
+makes the load produce the reduce-friendly layout directly with ZERO convert --
+exactly what approach B wants in its best case. We inject that TTGIR by patching
+CUDABackend.make_ttgir to return our parsed module (same mechanism evaluate_opt
+uses to inject A's pass), so the rest of the pipeline (ttgir->llir->ptx->cubin,
+incl. shared-memory allocation) is recomputed from the B TTGIR.
+
+For each (kernel, num_warps) we record base_ms / A_ms / B_ms and check base==A==B
+bitwise on plain data (must hold: inner_tree makes layout a free knob) -- both a
+validity check on the B edit and the bit-safety sanity check. Results append to a
+TSV per config (resumable across a killgpu reap from the sibling session).
+"""
+
+import ast
+import os
+import re
+import sys
+
+os.environ["TRITON_ALWAYS_COMPILE"] = "1"
+
+# repo root: this file is <root>/bitequiv/experiments/m2_convert_removal/bexp.py
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.insert(0, _REPO)
+
+import contextlib  # noqa: E402
+
+import torch  # noqa: E402
+
+from bitequiv.evaluation import evaluate_opt  # noqa: E402
+from bitequiv.evaluation.eval_kernels import resolve_kernels  # noqa: E402
+from triton.compiler.compiler import parse  # noqa: E402
+
+PASS = "tritongpu-optimize-reduction-layout"
+BDIR = "/tmp/m2_probe/b_ttgir"
+TSV = "/tmp/m2_probe/bexp_results.tsv"
+os.makedirs(BDIR, exist_ok=True)
+
+# The pass takes 3 Options (strategy, min-underparallel, max-elems-per-thread);
+# pass the defaults so the binding resolves. Empty args would be classified as
+# needs-args and the pass would be treated as baseline (a silent no-op).
+resolved, _na, _un = evaluate_opt._classify([(PASS, ["ideal", 8, 256])])
+assert resolved, "M2 pass binding not found"
+
+
+def _cfg(spec, num_warps):
+    cs = [c for c in spec.config_space("light")
+          if c.reduction_ordering == "inner_tree" and c.num_warps == num_warps]
+    assert cs, f"no inner_tree/nw={num_warps} config"
+    return cs[0]
+
+
+def _def_of(ttgir, name):
+    m = re.search(rf"^#{name}\s*=\s*(#ttg\.blocked<.*>)\s*$", ttgir, re.M)
+    assert m, f"no def for #{name}"
+    return m.group(1)
+
+
+def _load_layout_name(ttgir):
+    m = re.search(r"tt\.load.*,\s*#(\w+)>", ttgir)
+    assert m, "no tt.load layout"
+    return m.group(1)
+
+
+def _reduce_operand_name(ttgir):
+    m = re.search(r"\}\)\s*:\s*\(tensor<[^)]*?,\s*#(\w+)>\)\s*->", ttgir)
+    assert m, "no tt.reduce operand layout"
+    return m.group(1)
+
+
+def _compile(spec, cfg, size, ctx):
+    evaluate_opt._clear_jit_caches()
+    with ctx:
+        return spec.compile(cfg, size)
+
+
+@contextlib.contextmanager
+def optimization_B(path):
+    """Inject the B TTGIR: patch make_ttgir to return the parsed B module."""
+    from triton.backends.nvidia.compiler import CUDABackend
+    original = CUDABackend.make_ttgir
+
+    def patched(mod, metadata, opt, capability):
+        m = original(mod, metadata, opt, capability)  # keep metadata side effects
+        return parse(path, "ttgir", m.context)
+
+    CUDABackend.make_ttgir = staticmethod(patched)
+    try:
+        yield
+    finally:
+        CUDABackend.make_ttgir = staticmethod(original)
+
+
+def build_B(spec, cfg):
+    """Return (b_path, load_body, ideal_body) or (None, reason, None)."""
+    size = spec.precision_size
+    off = _compile(spec, cfg, size, evaluate_opt.optimization([])).asm["ttgir"]
+    on = _compile(spec, cfg, size, evaluate_opt.optimization(resolved)).asm["ttgir"]
+
+    load_name = _load_layout_name(off)
+    ideal_name = _reduce_operand_name(on)
+    ideal_body = _def_of(on, ideal_name)
+    load_body = _def_of(off, load_name)
+    if load_body == ideal_body:
+        return None, "A did not change the reduce layout (pass skipped this config)", None
+
+    b_ttgir = re.sub(rf"^#{load_name}\s*=\s*#ttg\.blocked<.*>\s*$",
+                     f"#{load_name} = {ideal_body}", off, count=1, flags=re.M)
+    assert b_ttgir != off, "B edit did not apply"
+    b_path = f"{BDIR}/{spec.name}_nw{cfg.num_warps}.ttgir"
+    with open(b_path, "w") as f:
+        f.write(b_ttgir)
+    return b_path, load_body, ideal_body
+
+
+def _bench(spec, cfg, ctx):
+    evaluate_opt._clear_jit_caches()
+    with ctx:
+        return spec.benchmark(cfg, spec.perf_size)  # (ms, bytes, asm)
+
+
+def _already_done(kernel, num_warps):
+    if not os.path.exists(TSV):
+        return False
+    with open(TSV) as f:
+        return any(line.startswith(f"{kernel}\t{num_warps}\t") for line in f)
+
+
+def run(kernel, num_warps):
+    if _already_done(kernel, num_warps):
+        print(f"  {kernel} nw{num_warps}: already in TSV, skip")
+        return
+    spec = resolve_kernels(kernel)[0]
+    cfg = _cfg(spec, num_warps)
+
+    b_path, load_body, ideal_body = build_B(spec, cfg)
+    if b_path is None:
+        print(f"  {kernel} nw{num_warps}: SKIP -- {load_body}")
+        return
+
+    base_ms, base_bytes, _ = _bench(spec, cfg, evaluate_opt.optimization([]))
+    a_ms, a_bytes, _ = _bench(spec, cfg, evaluate_opt.optimization(resolved))
+
+    ck_b = _compile(spec, cfg, spec.perf_size, optimization_B(b_path))
+    b_ttgir = ck_b.asm["ttgir"]
+    b_is_ideal = (_def_of(b_ttgir, _load_layout_name(b_ttgir)) == ideal_body)
+    b_pre_conv = b_ttgir[:b_ttgir.index("tt.reduce")].count("convert_layout")
+    b_ms, b_bytes, _ = _bench(spec, cfg, optimization_B(b_path))
+
+    bit_ok = (base_bytes == a_bytes == b_bytes)
+    a_sp, b_sp = base_ms / a_ms, base_ms / b_ms
+    print(f"\n  {kernel} nw{num_warps}  size={spec.perf_size}")
+    print(f"    load(off)= {load_body}")
+    print(f"    ideal(A) = {ideal_body}")
+    print(f"    B load-is-ideal={b_is_ideal}  B pre-reduce converts={b_pre_conv}  bit_ok(base==A==B)={bit_ok}")
+    print(f"    base {base_ms:.4f}ms | A {a_ms:.4f}ms ({a_sp:.2f}x) | B {b_ms:.4f}ms ({b_sp:.2f}x)   B/A = {b_ms/a_ms:.2f}x slower")
+
+    new = not os.path.exists(TSV)
+    with open(TSV, "a") as f:
+        if new:
+            f.write("kernel\tnum_warps\tbase_ms\tA_ms\tB_ms\tA_speedup\tB_speedup\tB_over_A\tbit_ok\tB_is_ideal\tB_pre_converts\n")
+        f.write(f"{kernel}\t{num_warps}\t{base_ms:.5f}\t{a_ms:.5f}\t{b_ms:.5f}\t{a_sp:.3f}\t{b_sp:.3f}\t{b_ms/a_ms:.3f}\t{bit_ok}\t{b_is_ideal}\t{b_pre_conv}\n")
+
+
+TARGETS = ast.literal_eval(os.environ.get("BEXP_TARGETS", "[('sum_2d_col',[4])]"))
+
+if __name__ == "__main__":
+    if not torch.cuda.is_available():
+        print("no GPU"); sys.exit(1)
+    print(f"device: {torch.cuda.get_device_name()}")
+    for kernel, nws in TARGETS:
+        for nw in nws:
+            try:
+                run(kernel, nw)
+            except Exception as exc:
+                import traceback
+                print(f"  {kernel} nw{nw}: ERROR {type(exc).__name__}: {exc}")
+                traceback.print_exc()

--- a/bitequiv/experiments/m2_convert_removal/sum_2d_col.A.ttgir
+++ b/bitequiv/experiments/m2_convert_removal/sum_2d_col.A.ttgir
@@ -1,0 +1,81 @@
+// ===========================================================================
+// M2 approach A (SHIPPED, convert-based) -- what the pass actually emits.
+// Kernel: sum_2d_col [256x32], reduce axis 0 (M non-contiguous; C contiguous),
+// num_warps=4, reduction_ordering="inner_tree". Real compiled TTGIR (GB300).
+//
+// Pattern:  coalesced load (#blocked) -> ttg.convert_layout -> reduce (#blocked2)
+//   #blocked  : coalesced load layout  -- 8 lanes on contiguous C; 4 warps on M => cross-warp stage
+//   #blocked2 : reduce-friendly layout -- 32 lanes on M; warpsPerCTA[M]=1 => warp-synchronous
+// The convert is a one-shot shared-memory round trip: the cost approach B tries to
+// remove. Compare sum_2d_col.B.ttgir; see M2_DESIGN.en.md/.zh.md §5.3-§5.5 and
+// M2_approach_B_experiment.md. Measured: A = 1.74x over base; B = 0.66x (B 2.65x slower than A).
+// ===========================================================================
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#loc = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1042:1)
+#loc1 = loc(unknown)
+#loc10 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1047:9)
+#loc15 = loc("X"(#loc))
+#loc16 = loc("Out"(#loc))
+#loc24 = loc("s"(#loc10))
+#loc26 = loc(callsite(#loc1 at #loc24))
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @_k_sum2d_axis0(%X: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("X"(#loc)), %Out: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("Out"(#loc))) attributes {noinline = false} {
+    %c8192_i32 = arith.constant 8192 : i32 loc(#loc1)
+    %c32_i32 = arith.constant 32 : i32 loc(#loc1)
+    %cst = arith.constant dense<32> : tensor<256x1xi32, #blocked> loc(#loc1)
+    %g = tt.get_program_id x : i32 loc(#loc17)
+    %m = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked}>> loc(#loc18)
+    %m_0 = tt.expand_dims %m {axis = 1 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<256x1xi32, #blocked> loc(#loc18)
+    %c = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #blocked1> loc(#loc19)
+    %c_1 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc19)
+    %c_2 = tt.expand_dims %c_1 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked> loc(#loc19)
+    %x = arith.muli %g, %c8192_i32 : i32 loc(#loc20)
+    %x_3 = tt.addptr %X, %x : !tt.ptr<f32>, i32 loc(#loc21)
+    %x_4 = arith.muli %m_0, %cst : tensor<256x1xi32, #blocked> loc(#loc22)
+    %x_5 = tt.splat %x_3 : !tt.ptr<f32> -> tensor<256x1x!tt.ptr<f32>, #blocked> loc(#loc21)
+    %x_6 = tt.addptr %x_5, %x_4 : tensor<256x1x!tt.ptr<f32>, #blocked>, tensor<256x1xi32, #blocked> loc(#loc21)
+    %x_7 = tt.broadcast %x_6 : tensor<256x1x!tt.ptr<f32>, #blocked> -> tensor<256x32x!tt.ptr<f32>, #blocked> loc(#loc21)
+    %x_8 = tt.broadcast %c_2 : tensor<1x32xi32, #blocked> -> tensor<256x32xi32, #blocked> loc(#loc21)
+    %x_9 = tt.addptr %x_7, %x_8 : tensor<256x32x!tt.ptr<f32>, #blocked>, tensor<256x32xi32, #blocked> loc(#loc21)
+    %x_10 = tt.load %x_9 : tensor<256x32x!tt.ptr<f32>, #blocked> loc(#loc23)
+    // <== approach A: the operand convert (#blocked coalesced -> #blocked2 reduce-friendly).
+    // One shared-memory round trip. This is exactly the op approach B removes (see sum_2d_col.B.ttgir).
+    %s = ttg.convert_layout %x_10 : tensor<256x32xf32, #blocked> -> tensor<256x32xf32, #blocked2> loc(#loc25)
+    %s_11 = "tt.reduce"(%s) <{axis = 0 : i32, reduction_ordering = "inner_tree"}> ({
+    ^bb0(%s_13: f32 loc(callsite(#loc1 at #loc24)), %s_14: f32 loc(callsite(#loc1 at #loc24))):
+      %s_15 = arith.addf %s_13, %s_14 : f32 loc(#loc27)
+      tt.reduce.return %s_15 : f32 loc(#loc25)
+    }) : (tensor<256x32xf32, #blocked2>) -> tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked2}>> loc(#loc25)
+    %s_12 = ttg.convert_layout %s_11 : tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked2}>> -> tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc25)
+    %0 = arith.muli %g, %c32_i32 : i32 loc(#loc12)
+    %1 = tt.addptr %Out, %0 : !tt.ptr<f32>, i32 loc(#loc13)
+    %2 = tt.splat %1 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>, #blocked1> loc(#loc13)
+    %3 = tt.addptr %2, %c : tensor<32x!tt.ptr<f32>, #blocked1>, tensor<32xi32, #blocked1> loc(#loc13)
+    %4 = ttg.convert_layout %s_12 : tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<32xf32, #blocked1> loc(#loc14)
+    tt.store %3, %4 : tensor<32x!tt.ptr<f32>, #blocked1> loc(#loc14)
+    tt.return loc(#loc)
+  } loc(#loc)
+} loc(#loc)
+#loc2 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1043:9)
+#loc3 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1044:9)
+#loc4 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1045:9)
+#loc5 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1046:21)
+#loc6 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1046:17)
+#loc7 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1046:35)
+#loc8 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1046:9)
+#loc9 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/python/triton/language/standard.py":313:12)
+#loc11 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/python/triton/language/standard.py":273:12)
+#loc12 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1048:20)
+#loc13 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1048:14)
+#loc14 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1048:5)
+#loc17 = loc("g"(#loc2))
+#loc18 = loc("m"(#loc3))
+#loc19 = loc("c"(#loc4))
+#loc20 = loc("x"(#loc5))
+#loc21 = loc("x"(#loc6))
+#loc22 = loc("x"(#loc7))
+#loc23 = loc("x"(#loc8))
+#loc25 = loc(callsite(#loc9 at #loc24))
+#loc27 = loc(callsite(#loc11 at #loc25))

--- a/bitequiv/experiments/m2_convert_removal/sum_2d_col.B.ttgir
+++ b/bitequiv/experiments/m2_convert_removal/sum_2d_col.B.ttgir
@@ -1,0 +1,82 @@
+// ===========================================================================
+// M2 approach B (REJECTED, convert removal) -- B's best case, injected for the
+// experiment. Kernel: sum_2d_col [256x32], reduce axis 0, num_warps=4,
+// reduction_ordering="inner_tree". Built from the baseline TTGIR by swapping the
+// LOAD layout's body for the reduce-friendly layout that A converts to, so the
+// load produces it directly with ZERO convert (what B wants). Injected via a
+// make_ttgir patch (see bexp.py), then lowered + timed on GB300.
+//
+// Pattern:  load (#blocked = reduce-friendly, UNCOALESCED) -> reduce, NO convert
+//   #blocked : now = reduce-friendly -- 32 lanes on the STRIDED M axis => a warp
+//              reads 32 addresses one stride apart ~= 32x memory transactions.
+// Result: removes A's convert (verified: 0 pre-reduce converts) but is 2.5-4.8x
+// slower than A and usually slower than base. See M2_DESIGN §5.5 + README.md.
+// bit-check: base == A == B bytewise (inner_tree => layout is a free knob).
+// ===========================================================================
+#blocked = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#loc = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1042:1)
+#loc1 = loc(unknown)
+#loc10 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1047:9)
+#loc15 = loc("X"(#loc))
+#loc16 = loc("Out"(#loc))
+#loc24 = loc("s"(#loc10))
+#loc26 = loc(callsite(#loc1 at #loc24))
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:103", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @_k_sum2d_axis0(%X: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("X"(#loc)), %Out: !tt.ptr<f32> {tt.divisibility = 16 : i32} loc("Out"(#loc))) attributes {noinline = false} {
+    %c8192_i32 = arith.constant 8192 : i32 loc(#loc1)
+    %c32_i32 = arith.constant 32 : i32 loc(#loc1)
+    %cst = arith.constant dense<32> : tensor<256x1xi32, #blocked> loc(#loc1)
+    %g = tt.get_program_id x : i32 loc(#loc17)
+    %m = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked}>> loc(#loc18)
+    %m_0 = tt.expand_dims %m {axis = 1 : i32} : tensor<256xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<256x1xi32, #blocked> loc(#loc18)
+    %c = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #blocked1> loc(#loc19)
+    %c_1 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc19)
+    %c_2 = tt.expand_dims %c_1 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked> loc(#loc19)
+    %x = arith.muli %g, %c8192_i32 : i32 loc(#loc20)
+    %x_3 = tt.addptr %X, %x : !tt.ptr<f32>, i32 loc(#loc21)
+    %x_4 = arith.muli %m_0, %cst : tensor<256x1xi32, #blocked> loc(#loc22)
+    %x_5 = tt.splat %x_3 : !tt.ptr<f32> -> tensor<256x1x!tt.ptr<f32>, #blocked> loc(#loc21)
+    %x_6 = tt.addptr %x_5, %x_4 : tensor<256x1x!tt.ptr<f32>, #blocked>, tensor<256x1xi32, #blocked> loc(#loc21)
+    %x_7 = tt.broadcast %x_6 : tensor<256x1x!tt.ptr<f32>, #blocked> -> tensor<256x32x!tt.ptr<f32>, #blocked> loc(#loc21)
+    %x_8 = tt.broadcast %c_2 : tensor<1x32xi32, #blocked> -> tensor<256x32xi32, #blocked> loc(#loc21)
+    %x_9 = tt.addptr %x_7, %x_8 : tensor<256x32x!tt.ptr<f32>, #blocked>, tensor<256x32xi32, #blocked> loc(#loc21)
+    // <== approach B: the load now produces the reduce-friendly layout #blocked directly
+    // (32 lanes on the STRIDED M axis) -> UNCOALESCED (~32x memory transactions). Note there
+    // is NO ttg.convert_layout before the reduce below -- B removed it, but pays in the load.
+    %x_10 = tt.load %x_9 : tensor<256x32x!tt.ptr<f32>, #blocked> loc(#loc23)
+    %s = "tt.reduce"(%x_10) <{axis = 0 : i32, reduction_ordering = "inner_tree"}> ({
+    ^bb0(%s_11: f32 loc(callsite(#loc1 at #loc24)), %s_12: f32 loc(callsite(#loc1 at #loc24))):
+      %s_13 = arith.addf %s_11, %s_12 : f32 loc(#loc27)
+      tt.reduce.return %s_13 : f32 loc(#loc25)
+    }) : (tensor<256x32xf32, #blocked>) -> tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked}>> loc(#loc25)
+    %0 = arith.muli %g, %c32_i32 : i32 loc(#loc12)
+    %1 = tt.addptr %Out, %0 : !tt.ptr<f32>, i32 loc(#loc13)
+    %2 = tt.splat %1 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>, #blocked1> loc(#loc13)
+    %3 = tt.addptr %2, %c : tensor<32x!tt.ptr<f32>, #blocked1>, tensor<32xi32, #blocked1> loc(#loc13)
+    %4 = ttg.convert_layout %s : tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<32xf32, #blocked1> loc(#loc14)
+    tt.store %3, %4 : tensor<32x!tt.ptr<f32>, #blocked1> loc(#loc14)
+    tt.return loc(#loc)
+  } loc(#loc)
+} loc(#loc)
+#loc2 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1043:9)
+#loc3 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1044:9)
+#loc4 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1045:9)
+#loc5 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1046:21)
+#loc6 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1046:17)
+#loc7 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1046:35)
+#loc8 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1046:9)
+#loc9 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/python/triton/language/standard.py":313:12)
+#loc11 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/python/triton/language/standard.py":273:12)
+#loc12 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1048:20)
+#loc13 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1048:14)
+#loc14 = loc("/data/users/youngzt/fbsource-m2/third-party/triton/beta/triton/bitequiv/evaluation/eval_kernels.py":1048:5)
+#loc17 = loc("g"(#loc2))
+#loc18 = loc("m"(#loc3))
+#loc19 = loc("c"(#loc4))
+#loc20 = loc("x"(#loc5))
+#loc21 = loc("x"(#loc6))
+#loc22 = loc("x"(#loc7))
+#loc23 = loc("x"(#loc8))
+#loc25 = loc(callsite(#loc9 at #loc24))
+#loc27 = loc(callsite(#loc11 at #loc25))

--- a/include/triton/Dialect/TritonGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonGPU/Transforms/Passes.td
@@ -338,6 +338,34 @@ def TritonGPUOptimizeThreadLocality : Pass<"tritongpu-optimize-thread-locality",
                            "mlir::triton::TritonDialect"];
 }
 
+def TritonGPUOptimizeReductionLayout : Pass<"tritongpu-optimize-reduction-layout", "mlir::ModuleOp"> {
+  let summary = "Pick a cheaper operand layout for inner_tree reductions";
+
+  let description = [{
+    An `inner_tree` reduction is layout-invariant by construction, so its operand
+    data layout is a free performance knob. This pass rewrites the operand of such
+    reduces to a layout with `warpsPerCTA[axis] = 1` (warps moved onto a kept
+    dimension), which deletes the cross-warp shared-memory reduction stage. The
+    reduction op, axis, extent and ordering are never changed, so the numeric
+    result is bit-identical. Scope: within-CTA blocked-layout reductions.
+  }];
+
+  let options = [
+    Option<"strategy", "strategy", "std::string", /*default=*/"\"ideal\"",
+           "Relayout strategy: \"ideal\" builds the warp-synchronous reduce "
+           "layout; \"off\" disables the rewrite (no-op).">,
+    Option<"minUnderparallel", "min-underparallel", "int", /*default=*/"8",
+           "Only relayout when the reduce axis is under-parallelized across the "
+           "warp: axisExtent >= threadsPerWarp[axis] * this.">,
+    Option<"maxElemsPerThread", "max-elems-per-thread", "int", /*default=*/"256",
+           "Register-pressure cap: skip when tileElems/(warpSize*num_warps) "
+           "exceeds this (the reduce-friendly layout carries the axis per thread).">
+  ];
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::TritonDialect"];
+}
+
 def TritonGPUReorderInstructions: Pass<"tritongpu-reorder-instructions", "mlir::ModuleOp"> {
   let summary = "Reorder instructions";
 

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_triton_library(TritonGPUTransforms
   ReduceDataDuplication.cpp
   OptimizeAccumulatorInit.cpp
   OptimizeDotOperands.cpp
+  OptimizeReductionLayout.cpp
   OptimizeThreadLocality.cpp
   Pipeliner/AssignLatencies.cpp
   Pipeliner/LowerLoops.cpp

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeReductionLayout.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeReductionLayout.cpp
@@ -1,0 +1,241 @@
+//===- OptimizeReductionLayout.cpp ----------------------------------------===//
+//
+// M2 (bitequiv): pick a cheaper operand layout for `inner_tree` reductions.
+//
+// An `inner_tree` reduction is LAYOUT-INVARIANT by construction: the lowering
+// (ReduceOpToLLVM) emits a balanced within-thread tree plus a count-up
+// warp-shuffle xor sequence that fixes the FP association order independent of
+// where the elements live. So for a reduce carrying `reduction_ordering =
+// "inner_tree"` we may freely change the operand's data layout WITHOUT changing
+// the result bits -- the whole valid-layout space is a free performance knob.
+// (This is exactly the freedom `OptimizeThreadLocality` exploits for *unordered*
+// reduces, which it must skip for ordered ones -- see its `hasDefinedOrdering`
+// bail. This pass fills that gap for the ordered case.)
+//
+// STRATEGY. The cost of a reduction is dominated by the cross-warp shared-memory
+// stage, which runs iff `warpsPerCTA[axis] != 1` (two barriers + smem round trip
+// + a second butterfly). We build the "ideal" reduce layout: reduce the axis
+// WITHIN a warp -- put lanes on the axis (cheap shuffles) and, crucially, no
+// warps on the axis (warpsPerCTA[axis] = 1) -- and spread the warps over the
+// kept dimensions. The remaining axis extent is carried in registers (a free
+// within-thread fold). Then a cost model decides whether the win (deleting the
+// cross-warp stage) beats the cost of the `convert_layout` we must insert on the
+// operand; if not, we leave the reduce alone.
+//
+// The reduction op, axis, extent and ordering are NEVER changed, so the numeric
+// result is bit-identical (verified by the bitequiv eval hook: correctness stage
+// must report 0 bit-changed). Scope: within-CTA blocked-layout reductions. The
+// pass runs LAST in make_ttgir so its layout is not reverted by a later pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+
+namespace mlir {
+namespace triton {
+namespace gpu {
+
+#define GEN_PASS_DEF_TRITONGPUOPTIMIZEREDUCTIONLAYOUT
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+// floor(log2(v)) for v >= 1.
+static unsigned ilog2(int64_t v) {
+  unsigned b = 0;
+  while ((int64_t(1) << (b + 1)) <= v)
+    ++b;
+  return b;
+}
+
+// Build the "ideal" reduce layout by distributing hardware bits: lanes onto the
+// axis first (reduce within a warp), then remaining lanes to kept dims; warps
+// onto kept dims (axis gets none if possible); the leftover axis extent carried
+// in registers. Powers of two throughout, so the products stay exactly warpSize
+// and numWarps. Returns {} if it cannot improve on `cur`.
+static BlockedEncodingAttr makeIdeal(triton::ReduceOp red, BlockedEncodingAttr cur,
+                                     int axis, ArrayRef<int64_t> shape,
+                                     int numWarps, int warpSize) {
+  unsigned rank = shape.size();
+  SmallVector<unsigned> laneB(rank, 0), warpB(rank, 0), sizeB(rank, 0);
+  SmallVector<unsigned> O(cur.getOrder());
+
+  // 1. Lanes: axis first, then kept dims in memory order.
+  int laneBudget = ilog2(warpSize);
+  unsigned onAxis = std::min<unsigned>(laneBudget, ilog2(shape[axis]));
+  laneB[axis] = onAxis;
+  laneBudget -= onAxis;
+  for (unsigned k : O) {
+    if (laneBudget == 0)
+      break;
+    if (int(k) == axis)
+      continue;
+    unsigned take = std::min<unsigned>(laneBudget, ilog2(shape[k]));
+    laneB[k] += take;
+    laneBudget -= take;
+  }
+  if (laneBudget > 0) // shape too small to hold a full warp: pile leftover on axis
+    laneB[axis] += laneBudget;
+
+  // 2. Warps: kept dims only (keep the axis warp-synchronous), by remaining room.
+  int warpBudget = ilog2(numWarps);
+  for (unsigned k : O) {
+    if (warpBudget == 0)
+      break;
+    if (int(k) == axis)
+      continue;
+    unsigned room = ilog2(shape[k]) > laneB[k] ? ilog2(shape[k]) - laneB[k] : 0;
+    unsigned take = std::min<unsigned>(warpBudget, room);
+    warpB[k] += take;
+    warpBudget -= take;
+  }
+  if (warpBudget > 0) // kept dims cannot absorb all warps: fall back to axis (partial)
+    warpB[axis] += warpBudget;
+
+  // 3. Registers: carry the rest of the axis extent as a contiguous fold.
+  unsigned axisCovered = laneB[axis] + warpB[axis];
+  if (ilog2(shape[axis]) > axisCovered)
+    sizeB[axis] = ilog2(shape[axis]) - axisCovered;
+
+  SmallVector<unsigned> T(rank), W(rank), S(rank);
+  for (unsigned d = 0; d < rank; ++d) {
+    T[d] = 1u << laneB[d];
+    W[d] = 1u << warpB[d];
+    S[d] = 1u << sizeB[d];
+  }
+  auto cand = BlockedEncodingAttr::get(red.getContext(), S, T, W, O, cur.getCGALayout());
+  if (cand == cur)
+    return {};
+  return cand;
+}
+
+// Rewrite `red` to consume its operands in layout `cand`. We cannot reuse
+// convertDistributedOpEncoding: it applies the operand encoding to the RESULT
+// types too, but a reduce result is a reduced-rank SliceEncoding. So: convert
+// each operand blocked->cand, clone the reduce (preserving its combine region),
+// retype the clone's results to slice-of-cand, then convert results back.
+static void rewriteOperandLayout(triton::ReduceOp red, BlockedEncodingAttr cand,
+                                 int axis) {
+  OpBuilder b(red);
+  Location loc = red.getLoc();
+  Operation *redOp = red.getOperation(); // ReduceOp is variadic: index results via Operation*
+
+  SmallVector<Value> converted;
+  for (Value operand : red.getOperands()) {
+    auto ty = cast<RankedTensorType>(operand.getType());
+    auto newTy = RankedTensorType::get(ty.getShape(), ty.getElementType(), cand);
+    converted.push_back(ConvertLayoutOp::create(b, loc, newTy, operand));
+  }
+
+  Operation *clone = b.clone(*redOp);
+  for (unsigned i = 0; i < converted.size(); ++i)
+    clone->setOperand(i, converted[i]);
+  auto sliceEnc = SliceEncodingAttr::get(red.getContext(), axis, cand);
+  for (unsigned i = 0; i < clone->getNumResults(); ++i) {
+    auto rt = cast<RankedTensorType>(redOp->getResult(i).getType());
+    clone->getResult(i).setType(
+        RankedTensorType::get(rt.getShape(), rt.getElementType(), sliceEnc));
+  }
+
+  b.setInsertionPointAfter(clone);
+  for (unsigned i = 0; i < redOp->getNumResults(); ++i) {
+    Value back = ConvertLayoutOp::create(b, loc, redOp->getResult(i).getType(),
+                                         clone->getResult(i));
+    redOp->getResult(i).replaceAllUsesWith(back);
+  }
+  redOp->erase();
+}
+
+struct OptimizeReductionLayoutPass
+    : public impl::TritonGPUOptimizeReductionLayoutBase<
+          OptimizeReductionLayoutPass> {
+  using Base = impl::TritonGPUOptimizeReductionLayoutBase<
+      OptimizeReductionLayoutPass>;
+  using Base::Base;
+  void runOnOperation() override {
+    // `strategy`, `minUnderparallel`, `maxElemsPerThread` are pass Options (see
+    // Passes.td). The in-pipeline call sets them from `knobs.nvidia` (compiler.py);
+    // LIT tests pass them as pass args. `strategy == "off"` -> no-op (bit-safe).
+    if (strategy == "off")
+      return;
+
+    ModuleOp mod = getOperation();
+    int warpSize = TritonGPUDialect::getThreadsPerWarp(mod);
+
+    SmallVector<triton::ReduceOp> targets;
+    mod.walk([&](triton::ReduceOp red) {
+      auto ord = red.getReductionOrderingAttr();
+      if (ord && ord.getValue() == "inner_tree")
+        targets.push_back(red);
+    });
+
+    for (triton::ReduceOp red : targets) {
+      auto srcTy = dyn_cast<RankedTensorType>(red.getOperands()[0].getType());
+      if (!srcTy)
+        continue;
+      auto blocked = dyn_cast<BlockedEncodingAttr>(srcTy.getEncoding());
+      if (!blocked)
+        continue;
+      // Bit-safety: a mul-fed reduce (dot product, operand = arith.mulf) can
+      // FMA-contract the mul with the combine add under enable_fp_fusion. That
+      // contraction is layout-sensitive and NOT covered by inner_tree (which only
+      // fixes the add tree), so relayouting would change the bits. Skip it.
+      // Checking operand[0] is sufficient: FMA contraction only arises for a
+      // single-operand sum(a*b); variadic reduces (e.g. welford) use non-add
+      // combines and are not inner_tree add-reduces, so no other operand can
+      // introduce the mul+add contraction this guard protects against.
+      if (auto *def = red.getOperands()[0].getDefiningOp())
+        if (isa<arith::MulFOp>(def))
+          continue;
+      int axis = red.getAxis();
+      ReduceOpHelper helper(red);
+      if (!helper.isReduceWithinCTA()) // needs CTASplitNum[axis] == 1
+        continue;
+      if (helper.isWarpSynchronous()) // already no cross-warp stage
+        continue;
+
+      int numWarps = lookupNumWarps(red);
+
+      // Register-pressure guard: the reduce-friendly layout carries the axis slice
+      // per thread, so if the tile has more elements per thread than the register
+      // file holds (~256 for f32), the relayout spills and loses. Skip those (they
+      // are the low-warp-count / very-large-tile corner). Env-tunable.
+      int64_t tileElems = 1;
+      for (int64_t d : srcTy.getShape())
+        tileElems *= d;
+      int64_t elemsPerThread = tileElems / (int64_t(warpSize) * numWarps);
+      if (elemsPerThread > maxElemsPerThread)
+        continue;
+
+      BlockedEncodingAttr cand =
+          makeIdeal(red, blocked, axis, srcTy.getShape(), numWarps, warpSize);
+      if (!cand)
+        continue;
+
+      // Cost guard: the win is converting cross-warp / register reduction work into
+      // cheap intra-warp shuffles, which only pays for the convert_layout when the
+      // axis is BOTH gaining lanes AND currently badly under-parallelized.
+      unsigned curIntra = blocked.getThreadsPerWarp()[axis];
+      unsigned newIntra = cand.getThreadsPerWarp()[axis];
+      int64_t axisExtent = srcTy.getShape()[axis];
+      if (newIntra <= curIntra)
+        continue; // candidate does not add intra-warp parallelism to the axis
+      if (axisExtent < int64_t(curIntra) * minUnderparallel)
+        continue; // axis already well spread over lanes -> convert not worth it
+
+      rewriteOperandLayout(red, cand, axis);
+    }
+  }
+};
+
+} // namespace
+} // namespace gpu
+} // namespace triton
+} // namespace mlir

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -63,6 +63,9 @@ void init_triton_passes_ttgpuir(py::module &&m) {
   ADD_PASS_OPTION_WRAPPER_1("add_coalesce", createTritonGPUCoalesce, unsigned);
   ADD_PASS_WRAPPER_0("add_optimize_thread_locality",
                      createTritonGPUOptimizeThreadLocality);
+  ADD_PASS_OPTION_WRAPPER_3("add_optimize_reduction_layout",
+                            createTritonGPUOptimizeReductionLayout,
+                            const std::string &, int, int);
   ADD_PASS_OPTION_WRAPPER_1("add_hoist_tmem_alloc",
                             createTritonGPUHoistTMEMAlloc, bool);
   ADD_PASS_OPTION_WRAPPER_2("add_assign_latencies",

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -586,6 +586,13 @@ class nvidia_knobs(base_knobs):
     # Gate opt-in perf-benchmark tests (do_bench sweeps) so unit-test runs do
     # not pay the perf-sweep cost.
     run_perf: env_bool = env_bool("TRITON_RUN_PERF")
+    # M2 (bitequiv): tritongpu-optimize-reduction-layout gate + tunables. The gate
+    # adds the pass at end of make_ttgir; the tunables are forwarded as pass Options.
+    # Off by default; the eval hook can also inject the pass via --opt-passes.
+    set_red_ordering_layouts: env_bool = env_bool("TRITON_SET_RED_ORDERING_LAYOUTS")
+    red_ordering_strategy: env_str = env_str("TRITON_RED_ORDERING_STRATEGY", "ideal")
+    red_ordering_min_underparallel: env_int = env_int("TRITON_RED_ORDERING_MIN_UNDERPARALLEL", 8)
+    red_ordering_max_elems_per_thread: env_int = env_int("TRITON_RED_ORDERING_MAX_ELEMS_PER_THREAD", 256)
 
 
 class amd_knobs(base_knobs):

--- a/test/TritonGPU/optimize-reduction-layout.mlir
+++ b/test/TritonGPU/optimize-reduction-layout.mlir
@@ -1,0 +1,45 @@
+// RUN: triton-opt %s -split-input-file --tritongpu-optimize-reduction-layout=min-underparallel=8 | FileCheck %s
+
+// A reduce over the NON-contiguous axis (axis 0) is under-parallelized within the warp:
+// only threadsPerWarp[0] = 4 lanes sit on the 128-long reduce axis, and the axis is split
+// across 4 warps (warpsPerCTA[0] = 4), so it pays the cross-warp shared-memory stage. The
+// pass rewrites the operand to put 32 lanes on the axis and the warps on the kept dim
+// (threadsPerWarp = [32, 1], warpsPerCTA = [1, 4]) via a convert_layout. Bit-identical
+// because inner_tree is layout-invariant.
+
+// CHECK-DAG: #[[MOVED:blocked[0-9]*]] = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @colreduce
+  tt.func public @colreduce(%X: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %Out: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<32> : tensor<128x1xi32, #blocked>
+    %m = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %m_0 = tt.expand_dims %m {axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<128x1xi32, #blocked>
+    %c = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #blocked1>
+    %c_1 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %c_2 = tt.expand_dims %c_1 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked>
+    %x_4 = arith.muli %m_0, %cst : tensor<128x1xi32, #blocked>
+    %x_5 = tt.splat %X : !tt.ptr<f32> -> tensor<128x1x!tt.ptr<f32>, #blocked>
+    %x_6 = tt.addptr %x_5, %x_4 : tensor<128x1x!tt.ptr<f32>, #blocked>, tensor<128x1xi32, #blocked>
+    %x_7 = tt.broadcast %x_6 : tensor<128x1x!tt.ptr<f32>, #blocked> -> tensor<128x32x!tt.ptr<f32>, #blocked>
+    %x_8 = tt.broadcast %c_2 : tensor<1x32xi32, #blocked> -> tensor<128x32xi32, #blocked>
+    %x_9 = tt.addptr %x_7, %x_8 : tensor<128x32x!tt.ptr<f32>, #blocked>, tensor<128x32xi32, #blocked>
+    %x_10 = tt.load %x_9 : tensor<128x32x!tt.ptr<f32>, #blocked>
+    // The pass converts the operand to the moved layout and keeps axis + ordering.
+    // CHECK: ttg.convert_layout %{{[0-9]+}} : {{.*}} -> tensor<128x32xf32, #[[MOVED]]>
+    // CHECK: "tt.reduce"({{.*}}) <{axis = 0 : i32, reduction_ordering = "inner_tree"}>
+    // CHECK: (tensor<128x32xf32, #[[MOVED]]>)
+    %s = "tt.reduce"(%x_10) <{axis = 0 : i32, reduction_ordering = "inner_tree"}> ({
+    ^bb0(%s_11: f32, %s_12: f32):
+      %s_13 = arith.addf %s_11, %s_12 : f32
+      tt.reduce.return %s_13 : f32
+    }) : (tensor<128x32xf32, #blocked>) -> tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %2 = tt.splat %Out : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>, #blocked1>
+    %3 = tt.addptr %2, %c : tensor<32x!tt.ptr<f32>, #blocked1>, tensor<32xi32, #blocked1>
+    %4 = ttg.convert_layout %s : tensor<32xf32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<32xf32, #blocked1>
+    tt.store %3, %4 : tensor<32x!tt.ptr<f32>, #blocked1>
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1010,6 +1010,19 @@ class CUDABackend(BaseBackend):
         # it here keeps the pin an anchor through the whole pipeline.
         tlx.tlx_passes.add_tlx_finalize_user_layouts(pm)
 
+        # M2 (bitequiv): reduction-layout optimization for inner_tree reduces. Placed
+        # after remove-layout-conversions so its layout choice is not reverted by a later
+        # conversion pass. Gated off by default (TRITON_SET_RED_ORDERING_LAYOUTS=1 to turn
+        # on in-pipeline); the bitequiv eval hook injects it via --opt-passes for a clean
+        # baseline-vs-optimized A/B. Tunables are pass Options driven by knobs.nvidia.*.
+        if knobs.nvidia.set_red_ordering_layouts:
+            passes.ttgpuir.add_optimize_reduction_layout(
+                pm,
+                knobs.nvidia.red_ordering_strategy,
+                knobs.nvidia.red_ordering_min_underparallel,
+                knobs.nvidia.red_ordering_max_elems_per_thread,
+            )
+
         # Print final TTGIR layouts for tlx.dump_layout diagnostics, then erase
         # the ops. Runs last so the reported layouts reflect all optimizations.
         tlx.tlx_passes.add_tlx_dump_layout(pm)


### PR DESCRIPTION
Summary:
## How to enable this pass

Off by default. Turn it on in the standard NVIDIA pipeline with the knob `TRITON_SET_RED_ORDERING_LAYOUTS=1` (`knobs.nvidia.set_red_ordering_layouts`). The three tunables are pass Options, defaulted from `knobs.nvidia.*`: `TRITON_RED_ORDERING_STRATEGY` (default `ideal`; `off` = no-op), `TRITON_RED_ORDERING_MIN_UNDERPARALLEL` (default 8), `TRITON_RED_ORDERING_MAX_ELEMS_PER_THREAD` (default 256). Standalone / LIT: `triton-opt ... -tritongpu-optimize-reduction-layout="min-underparallel=8 max-elems-per-thread=256"`. The bitequiv eval injects it via `--opt-passes "tritongpu-optimize-reduction-layout{ideal,8,256}"`.

# What this pass does

Adds `tritongpu-optimize-reduction-layout`, the M2 pass that picks a faster operand layout for `inner_tree` reductions without changing the result bits. An `inner_tree` reduction is layout-invariant by construction (the lowering fixes the FP association order regardless of where elements live), so the operand layout is a free performance knob — the same freedom `OptimizeThreadLocality` uses for unordered reduces but must skip for ordered ones.

For an `inner_tree`, within-CTA reduce whose operand still splits the reduce axis across warps (so it pays the cross-warp shared-memory stage), the pass builds the ideal reduce layout — lanes on the axis (reduce within a warp), warps on the kept dims (`warpsPerCTA[axis]=1`, deleting the cross-warp stage), axis remainder carried in registers — and rewrites the operand via `convert_layout`. The reduce op, axis, extent and ordering are never changed, so results are bit-identical.

The pass runs LAST in `make_ttgir` so its layout is not reverted by a later `remove-layout-conversions` (a reduce is not a layout anchor); the in-pipeline call is gated by `TRITON_SET_RED_ORDERING_LAYOUTS` (default off), and the eval hook injects it via `--opt-passes` for a clean A/B.

The apply decision is an under-parallelization guard, found empirically: apply only when the candidate adds intra-warp lanes to the axis AND the axis is badly under-parallelized today (`axisExtent >= threadsPerWarp[axis] * K`, `K = min-underparallel`, a pass option, default 8). A flat analytic cycle-count model could not separate an exposed cross-warp stage from one hidden behind memory latency; the ratio guard does. See the design doc for the v0 -> ideal-layout -> guard iteration.

A follow-up commit extends the guard to also optimize mul-fed reductions (dot products, `sum(a*b)`) when `enable_fp_fusion` is off: with fusion off there is no fma, so the reduce is a pure sum tree that `inner_tree` keeps layout-invariant. `make_ttgir` publishes `ttg.enable_fp_fusion` as a module attribute so the pass can gate on it.

# Performance

Two independent measurements — **H100** (original) and **GB300 / sm_100** (Blackwell) — plus a GB300 study of approach A vs approach B (convert removal). Definitions: `base` = `inner_tree` with no M2; `opt` = `inner_tree` + M2; `ceil` = `unordered` (no ordering constraint at all); `gap_closed = (base-opt)/(base-ceil)`, where >= 1.0 means M2 reaches or beats the unordered ceiling. Every config below is `bit_identical` unless noted. This far exceeds the M2 bar of closing the gap by ~50%.

## H100 (triton-3.7.0), do_bench min-of-medians

| kernel | speedup (num_warps 4 / 8) | gap_closed (4 / 8) |
| --- | --- | --- |
| `sum_3d_outer` | 3.27x / 3.32x | 1.01 / 1.05 |
| `sum_2d_col` | 1.44x / 1.25x | 0.94 / 0.98 |
| `sum_2d_col_big` | 1.46x / 1.32x | 0.99 / 0.79 |
| `sum_2d_axis0` | 1.34x / 1.21x | 0.96 / 1.03 |
| `col_exp_sum` | 1.43x / 1.27x | 0.94 / 0.95 |
| `col_bf16` | 1.40x | 0.96 |
| `col_sum_loop` | 1.26x / 1.25x | 0.97 / 1.11 |
| `col_dot` (mul-fed, fusion off; nw 2/4/8) | 1.12x / 1.19x / 1.09x | 0.98 / 0.89 / 0.98 |
| `I_bias_grad_dim0` (Inductor `grad.sum(0)`) | 1.29x / 1.49x | 1.00 / 0.95 |
| `J_epilogue_colsum_dim0` (Inductor `(A@B).sum(0)`) | 3.03x / 2.58x | 1.26 / 1.00 |
| `layernorm_bwd_dwdb` (zoo weight-grad) | 3.58x / 3.89x | 1.07 / 1.05 |

Several kernels beat the ceiling (gap_closed > 1.0): `inner_tree` matching `unordered` was never proof the unordered layout is optimal, and M2's reduce-friendly layout can be better than what the unordered path picks. `col_dot` with fusion on stays 1.00x (correctly skipped). Correctness: 0 bit-changed across the full Level-1 suite (92 configs) and `col_dot` heavy (72 configs), 0 compile regressions; the guard correctly no-ops already-optimal and memory-bound reductions. Raw tool output is committed in a companion diff (`bitequiv/evaluation/results/m2_pass_3way_results.txt`).

## GB300 / sm_100 (Blackwell), heavy 72 configs/kernel, do_bench min-of-medians

M2 is bit-safe on Blackwell (F32 add takes the SW `inner_tree` count-up path, not a HW `redux`, so the reduction stays layout-invariant — same as H100). Same win pattern as H100, larger magnitude.

| kernel | median | max | gap_closed |
| --- | --- | --- | --- |
| `sum_3d_outer` | 5.15x | 5.64x | 1.01 |
| `col_sum_loop` | 2.12x | 2.40x | 1.00 |
| `col_exp_sum` | 1.93x | 2.27x | 0.96 |
| `sum_2d_col` | 1.92x | 2.26x | 0.92 |
| `sum_2d_col_big` | 1.80x | 2.15x | 0.71 |
| `col_bf16` | 1.74x | 1.97x | 0.86 |
| `sum_2d_axis0` | 1.68x | 1.97x | 0.86 |

Correctness gate (source of truth): Stage 1 all SUPPORTED; Stage 2 = 72/72 checked, bit-changed 0, compile-regressions 0. `~1.00x` and 0 regressions on already-parallel / order-invariant / mul-fed-skip / memory-bound kernels (`sum_3d`, `sum_4d`, `col_max`, `col_dot`, `softmax`, `rmsnorm`, `layernorm`). Provenance: design doc §6.2 in the bitequiv knowledge base.

## GB300: approach A (convert-based, shipped) vs approach B (convert removal)

The one open follow-up was whether the operand `convert_layout` can be removed by relaying out the producing load so data arrives already in the reduce-friendly layout (approach B). B was measured at its best case — its ideal end state injected as the final TTGIR, so the convert is provably gone (0 pre-reduce converts; the load is in the reduce-friendly layout). Artifacts in this diff: `bitequiv/experiments/m2_convert_removal/` (annotated `sum_2d_col.A.ttgir` / `sum_2d_col.B.ttgir` plus the `bexp.py` 3-way driver and a `README.md`).

| kernel | A vs base | B vs base | B vs A |
| --- | --- | --- | --- |
| `sum_2d_col` [256x32] | 1.74-1.95x | 0.64-0.66x | 2.6-3.1x slower |
| `sum_2d_axis0` [128x32] | 1.67-1.93x | 0.66-0.67x | 2.5-2.9x slower |
| `sum_2d_col_big` [1024x32] | 1.62-2.16x | 0.58-0.66x | 2.5-3.7x slower |
| `sum_3d_outer` [64x8x16] | 5.15-5.29x | 1.86-1.92x | 2.7-2.8x slower |
| `col_exp_sum` (exp) | 1.67-2.09x | 0.63-0.66x | 2.5-3.3x slower |
| `col_bf16` (bf16 in) | 1.70-1.98x | 0.41-0.45x | 3.9-4.8x slower |

Median over 17 configs (6 kernels x num_warps in {2,4,8}): A = 1.89x over base; B = 0.66x over base (usually slower than doing nothing); B is 2.89x slower than A. All 17 are bit-identical (`base == A == B` bytewise). The reduce-friendly layout puts a warp's lanes on the strided (reduced) axis, so it is anti-coalesced as a load — a permanent ~32x memory-transaction cost that dwarfs the one-shot shared-memory convert it eliminates. The convert is the cheaper of the two unavoidable bridges between a coalesced load layout and a warp-synchronous reduce layout, so approach A is kept and B is rejected. Full protocol and per-config data: `M2_approach_B_experiment.md`; decision write-up: design doc §5.3-§5.5.

Also extends the eval hook `evaluate_opt.py` with a `--ceiling` 3-way comparison (`inner_tree` vs `inner_tree`+pass vs per-config `unordered` ceiling, reporting gap_closed), and fixes `_clear_jit_caches` so the optimized variant cannot reuse the baseline compile and mask the pass.

Review order: the pass declaration + implementation (`Passes.td`, `OptimizeReductionLayout.cpp`, `CMakeLists.txt`, `passes.cc`); the gated pipeline call (`compiler.py`); the LIT test; the eval-hook changes (`evaluate_opt.py`); then the A-vs-B experiment artifacts under `bitequiv/experiments/m2_convert_removal/` (evidence, not code to review).

## Deferred follow-ups (separate diffs)

- Expose the relayout to layout-conversion / the autotuner as a conditionally-optional choice — the per-config data shows it is conditionally a win, so the layout system (or autotuner) could select it per config instead of a fixed pass decision.
- Quantify the perf-win source with NCU counters (SMEM transactions, barrier stalls, achieved occupancy) on a win kernel — both `convert_layout` and the cross-warp reduction touch SMEM, so this pins down why convert+reduce is faster.

Design docs (mission, design, results) live in the bitequiv knowledge base, not in this diff.

Authored with Claude.

Reviewed By: njriasan, pchen7e2

Differential Revision: D110978754


