### PR TITLE
[triton][bitequiv] M3: TTGIR checker — split enable_fp_fusion (fma contraction)

### DIFF
--- a/bitequiv/evaluation/evaluate.py
+++ b/bitequiv/evaluation/evaluate.py
@@ -87,6 +87,7 @@ EXAMPLES
 import argparse
 import datetime
 import importlib
+import inspect
 import os
 import sys
 
@@ -120,6 +121,26 @@ def load_checker(spec):
     return getattr(module, func_name)
 
 
+def make_run_checker(checker):
+    """Adapt a checker to a uniform ``run(asm_text, config) -> hashable`` call.
+
+    A checker that takes a second parameter (the TTGIR checker, which folds
+    ``enable_fp_fusion`` — invisible in the IR — into its descriptor) is handed the config;
+    a one-argument checker (the PTX checker, which reads fusion straight from the PTX) is
+    called with the IR text alone, so it is completely unaffected by this plumbing."""
+    try:
+        params = [
+            p for p in inspect.signature(checker).parameters.values()
+            if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD, p.VAR_POSITIONAL)
+        ]
+        wants_config = len(params) >= 2 or any(p.kind == p.VAR_POSITIONAL for p in params)
+    except (TypeError, ValueError):
+        wants_config = False
+    if wants_config:
+        return lambda asm_text, config: checker(asm_text, config)
+    return lambda asm_text, config: checker(asm_text)
+
+
 def _descriptor_verdict(desc):
     """Heuristic SUPPORTED/LIMITED/UNSUPPORTED from a checker descriptor alone.
 
@@ -141,7 +162,7 @@ def _descriptor_verdict(desc):
     return "SUPPORTED", "checker reconstructed a reduction descriptor"
 
 
-def kernel_support(spec, checker, artifact="ptx"):
+def kernel_support(spec, run_checker, artifact="ptx"):
     """Stage 1 verdict for one kernel: (verdict, detail).
 
     A declared ``known_limitation`` (the author knows the checker can't model this
@@ -152,7 +173,7 @@ def kernel_support(spec, checker, artifact="ptx"):
     ref = spec.config_space("light")[0]
     try:
         ck = spec.compile(ref, spec.precision_size)
-        desc = checker(ck.asm[artifact])
+        desc = run_checker(ck.asm[artifact], ref)
     except Exception as exc:  # noqa: BLE001
         return "UNSUPPORTED", f"reference config failed to compile or check: {type(exc).__name__}"
     verdict, detail = _descriptor_verdict(desc)
@@ -174,7 +195,7 @@ def _spanned_axes(configs):
     return spans
 
 
-def evaluate_precision(spec, checker, config_effort, fuzzer_effort, artifact="ptx"):
+def evaluate_precision(spec, run_checker, config_effort, fuzzer_effort, artifact="ptx"):
     """Compile + checker-partition + fuzz one kernel; return a result dict."""
     size = spec.precision_size
     configs = spec.config_space(config_effort)
@@ -186,7 +207,7 @@ def evaluate_precision(spec, checker, config_effort, fuzzer_effort, artifact="pt
             fails += 1
             continue
         compiled[config] = ck
-        checker_key[config] = checker(ck.asm[artifact])
+        checker_key[config] = run_checker(ck.asm[artifact], config)
     ok = list(compiled)
     if not ok:
         return dict(name=spec.name, attempted=len(configs), ok=0, fails=fails)
@@ -209,7 +230,7 @@ def evaluate_precision(spec, checker, config_effort, fuzzer_effort, artifact="pt
 # --------------------------------------------------------------------------- #
 # Stage 3 — performance
 # --------------------------------------------------------------------------- #
-def evaluate_performance(spec, checker, artifact="ptx", config_effort="light"):
+def evaluate_performance(spec, run_checker, artifact="ptx", config_effort="light"):
     """Benchmark a kernel across its config space; compare within-set spread to the global ceiling."""
     size = spec.perf_size
     configs = spec.config_space(config_effort)
@@ -220,7 +241,7 @@ def evaluate_performance(spec, checker, artifact="ptx", config_effort="light"):
         except Exception:  # noqa: BLE001
             fails += 1
             continue
-        ms[config], bits[config], checker_key[config] = milliseconds, output_bytes, checker(asm[artifact])
+        ms[config], bits[config], checker_key[config] = milliseconds, output_bytes, run_checker(asm[artifact], config)
     ok = list(ms)
     if not ok:
         return dict(name=spec.name, ok=0, fails=fails)
@@ -246,7 +267,7 @@ def evaluate_performance(spec, checker, artifact="ptx", config_effort="light"):
 # --------------------------------------------------------------------------- #
 # Stage 4 — equivalence under register pressure (post-ptxas / the PTX->SASS gap)
 # --------------------------------------------------------------------------- #
-def evaluate_ptxas_robustness(spec, checker, config_effort, fuzzer_effort, artifact, maxnreg_sweep):
+def evaluate_ptxas_robustness(spec, run_checker, config_effort, fuzzer_effort, artifact, maxnreg_sweep):
     """Does the checker's equivalence verdict survive ptxas across a WHOLE diverse set?
 
     Take the full ``config_effort`` config space (diverse num_warps / num_stages /
@@ -276,7 +297,7 @@ def evaluate_ptxas_robustness(spec, checker, config_effort, fuzzer_effort, artif
                 fails += 1
                 continue
             compiled[key] = ck
-            checker_key[key] = checker(ck.asm[artifact])
+            checker_key[key] = run_checker(ck.asm[artifact], cfg)
             nregs[key], nspills[key] = getattr(ck, "n_regs", None), getattr(ck, "n_spills", None)
             items.append(key)
     attempted = len(base) * len(caps)
@@ -474,6 +495,7 @@ def main(argv=None):
     stages = {int(s) for s in args.stages.split(",") if s.strip()}
     specs = resolve_kernels(args.kernels)
     checker = load_checker(args.checker)
+    run_checker = make_run_checker(checker)
     repeats = equivalence_fuzzer.effort_repeats(args.fuzzer_effort)
     device = torch.cuda.get_device_name()
 
@@ -500,7 +522,7 @@ def main(argv=None):
         print("== Stage 1: support ==", flush=True)
         results = []
         for spec in specs:
-            verdict, detail = kernel_support(spec, checker, args.artifact)
+            verdict, detail = kernel_support(spec, run_checker, args.artifact)
             results.append(dict(name=spec.name, verdict=verdict, detail=detail))
             print(f"  {spec.name}: {verdict} — {detail}", flush=True)
         sections.append(render_stage1(results))
@@ -511,7 +533,7 @@ def main(argv=None):
         for spec in specs:
             n_configs = len(spec.config_space(args.config_effort))
             print(f"  {spec.name}: {n_configs} configs x {repeats} fuzz seeds ...", flush=True)
-            r = evaluate_precision(spec, checker, args.config_effort, args.fuzzer_effort, args.artifact)
+            r = evaluate_precision(spec, run_checker, args.config_effort, args.fuzzer_effort, args.artifact)
             results.append(r)
             if r.get("ok"):
                 total_over_merges += r["over_merges"]
@@ -532,7 +554,7 @@ def main(argv=None):
                 print(f"  {spec.name}: no perf hook; skipping.", flush=True)
                 continue
             print(f"  {spec.name}: benchmarking {len(spec.config_space(args.config_effort))} configs ...", flush=True)
-            results.append(evaluate_performance(spec, checker, args.artifact, args.config_effort))
+            results.append(evaluate_performance(spec, run_checker, args.artifact, args.config_effort))
         if results:
             sections.append(render_stage3(results))
 
@@ -545,7 +567,7 @@ def main(argv=None):
             print(
                 f"  {spec.name}: ~{members} (config x maxnreg{['none'] + maxnreg_sweep}) members "
                 f"x {repeats} fuzz seeds ...", flush=True)
-            r = evaluate_ptxas_robustness(spec, checker, args.config_effort, args.fuzzer_effort, args.artifact,
+            r = evaluate_ptxas_robustness(spec, run_checker, args.config_effort, args.fuzzer_effort, args.artifact,
                                           maxnreg_sweep)
             results.append(r)
             if r.get("ok"):

--- a/bitequiv/tests/test_ttgir_reduction.py
+++ b/bitequiv/tests/test_ttgir_reduction.py
@@ -23,6 +23,13 @@ def _eq(a, b):
     return ttgir_reductions_equivalent(_load(a), _load(b))
 
 
+class _Cfg:
+    """Minimal stand-in for an autotuner config exposing just ``enable_fp_fusion``."""
+
+    def __init__(self, enable_fp_fusion):
+        self.enable_fp_fusion = enable_fp_fusion
+
+
 # --- single-operand reductions (the in-scope core) ---
 def test_unordered_different_warps_not_equivalent():
     assert not _eq("sum_uno_nw2", "sum_uno_nw4")
@@ -68,3 +75,26 @@ def test_gemm_mma_sound():
     assert ttgir_reduction_descriptor(_load("gemm_ieee")) != ()
     assert not _eq("gemm_ieee", "gemm_tf32")  # precision differs -> not merged
     assert _eq("gemm_ieee", "gemm_ieee")  # reflexive
+
+
+# --- enable_fp_fusion (invisible in TTGIR) folded in from the config (diff 2a) ---
+def test_fp_fusion_splits_fma_eligible():
+    # GEMM (warp_group_dot) is fma-eligible: fma contraction is decided below TTGIR, so
+    # fp_fusion on vs off compile to the SAME IR but different bits. With the config
+    # supplied they must NOT merge; with the same config they must.
+    ir = _load("gemm_ieee")
+    assert ttgir_reduction_descriptor(ir, _Cfg(True)) != ttgir_reduction_descriptor(ir, _Cfg(False))
+    assert ttgir_reduction_descriptor(ir, _Cfg(True)) == ttgir_reduction_descriptor(ir, _Cfg(True))
+
+
+def test_fp_fusion_not_split_for_pure_add():
+    # a pure-add reduction has no multiply to contract, so fp_fusion cannot change its
+    # bits -- on and off must stay equal (no over-split).
+    ir = _load("sum_uno_nw4")
+    assert ttgir_reduction_descriptor(ir, _Cfg(True)) == ttgir_reduction_descriptor(ir, _Cfg(False))
+
+
+def test_config_none_is_backward_compatible():
+    # no config -> exactly the pre-2a descriptor (the PTX-checker / autotuner path).
+    ir = _load("gemm_ieee")
+    assert ttgir_reduction_descriptor(ir, None) == ttgir_reduction_descriptor(ir)

--- a/bitequiv/ttgir_reduction.py
+++ b/bitequiv/ttgir_reduction.py
@@ -58,18 +58,42 @@ def _context():
     return _ctx
 
 
-def ttgir_reduction_descriptor(ttgir):
+def _fma_eligible(ttgir):
+    """True iff the module has a float multiply that ``enable_fp_fusion`` could contract
+    into an adjacent add — a ``dot``/``warp_group_dot`` accumulation or a plain
+    ``arith.mulf``. A pure-add reduction has no such multiply, so its bits are invariant to
+    fp fusion and must NOT be split on it (that would over-split). Deliberately a broad
+    text test: a ``mulf`` that does not actually feed an add only causes an always-sound
+    over-split, never an over-merge."""
+    return "dot" in ttgir or "arith.mulf" in ttgir
+
+
+def ttgir_reduction_descriptor(ttgir, config=None):
     """Canonical, hashable reduction-order descriptor of a TTGIR module: a tuple of
     per-``tt.reduce`` signature strings built by the MLIR-native C++ analysis (one
     per reduce, plus a conservative entry for any MMA/dot accumulation). Two TTGIRs
     with equal descriptors perform identical reduction trees (sound). ``()`` when
-    the module has no reduction-like op."""
+    the module has no reduction-like op.
+
+    ``config`` (optional autotuner config): FMA contraction is decided BELOW TTGIR (ptxas
+    fuses ``mul``+``add`` into ``fma`` per ``enable_fp_fusion``), so it is invisible in the
+    IR — two configs that differ only in ``enable_fp_fusion`` compile to the SAME TTGIR yet
+    produce DIFFERENT bits. When a config is supplied and the module is fma-eligible, its
+    ``enable_fp_fusion`` value is folded into the descriptor so those configs split (the M1
+    ``dot`` reduction and the GEMM epilogue). The PTX checker reads fusion from the PTX
+    directly and is called without this arg, so it is unaffected."""
     if not ttgir:
         return ()
-    return tuple(_libtriton().bitequiv.reduction_order_signatures(ttgir, _context()))
+    sigs = tuple(_libtriton().bitequiv.reduction_order_signatures(ttgir, _context()))
+    if config is not None and sigs:
+        fp_fusion = getattr(config, "enable_fp_fusion", None)
+        if fp_fusion is not None and _fma_eligible(ttgir):
+            sigs = sigs + (f"enable_fp_fusion={fp_fusion}", )
+    return sigs
 
 
-def ttgir_reductions_equivalent(ttgir_a, ttgir_b):
+def ttgir_reductions_equivalent(ttgir_a, ttgir_b, config_a=None, config_b=None):
     """True iff the two TTGIRs reduce in the same (bitwise-equivalent) order,
-    decided statically from the parsed MLIR (no kernel launch, no inputs)."""
-    return ttgir_reduction_descriptor(ttgir_a) == ttgir_reduction_descriptor(ttgir_b)
+    decided statically from the parsed MLIR (no kernel launch, no inputs). Pass the
+    per-module configs to also decide the fp-fusion split (see ``ttgir_reduction_descriptor``)."""
+    return ttgir_reduction_descriptor(ttgir_a, config_a) == ttgir_reduction_descriptor(ttgir_b, config_b)


### PR DESCRIPTION
Summary:
FMA contraction is decided BELOW TTGIR: ptxas fuses a `mul` and an `add` into one `fma` according to `enable_fp_fusion`, so the choice is invisible in the TTGIR text — two autotuner configs that differ only in `enable_fp_fusion` compile to the SAME TTGIR yet produce different output bits. The M1 TTGIR reduction checker therefore over-merged them. This shows up on the mul-fed reductions (the `dot` reduction `tl.sum(x*y)`, `col_dot`) and on the GEMM `relu(acc*alpha+bias)` epilogue.

The fix folds `enable_fp_fusion` into the reduction descriptor, but ONLY for fma-eligible modules — a module that contains a `dot`/`warp_group_dot` or an `arith.mulf` that could contract into an adjacent add. A pure-add reduction has no multiply to fuse, so its bits are invariant to fp fusion and it is left untouched; that is what keeps the fix from over-splitting the pure-add reductions. To reach the config value, the evaluation harness now adapts each checker through `make_run_checker`: a checker that accepts a second parameter receives the autotuner config, while the one-argument PTX checker (which reads fusion straight from the PTX) is called exactly as before and is unaffected.

This is the first of two TTGIR diffs for GEMM support. It is the part that also improves the M1 result; the next diff replaces the conservative unanalyzed-mma guard with a real `warp_group_dot` accumulation signature so the GEMM configs partition tightly.

This PR was authored with Claude.

Reviewed By: njriasan

Differential Revision: D111999973


