### PR TITLE
[AMD][gfx950][TLX] a16w16: reduce-aware, non-pow2 split-K tile selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1031,6 +1031,23 @@ TLX uses **CUDA-native cluster semantics** which differs from Triton's approach:
     tlx.dump_layout(v)                  # -> // cute: _64:_1
     ```
 
+- `x = tlx.require_layout(x, layout)` **[Hopper+, MI300+]**
+
+    Pin a register tensor `x`'s layout as a hard user anchor. `layout` is a
+    `tlx.layout(...)` (Shape:Stride) mapped to a `#linear` encoding and wrapped as
+    `#tlx.no_verify_layout(#tlx.user_layout(...))`. The inner `#tlx.user_layout`
+    carries `PinnedEncodingTrait`, so the downstream layout passes
+    (`tritongpu-coalesce`, `remove-layout-conversions`, AMD `optimize-epilogue`)
+    treat it as fixed and never rewrite it; the outer `#tlx.no_verify_layout` defers
+    operand-layout verification until the pin is peeled by
+    `TLXResolvePlaceholderLayouts` in `make_ttgir`. Example: pin an FP16 epilogue
+    `tl.store` to a coalesced layout so `OptimizeEpilogue` keeps the wide
+    `buffer_store_dwordx4` instead of narrowing it to the MMA-accumulator store,
+    without staging the value through LDS.
+
+    Pair with `tlx.assert_same_layout(x, layout)` (below) to statically verify the
+    pin survived to the final TTGIR.
+
 - `tlx.assert_same_layout(lhs, rhs)` **[Hopper+, MI300+]**
 
     Compile-time assertion that two layouts are equivalent after layout

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -69,6 +69,29 @@ static void pickDescriptorLoadStoreLayout(
   });
 }
 
+// A value pinned via tlx.require_layout(pin=True) carries a PinnedEncodingTrait
+// (#tlx.user_layout), possibly under a #tlx.no_verify_layout wrapper that
+// resolve-placeholder-layouts peels only after coalesce runs. Walk the TLX
+// wrapper chain to detect the pin (used for both a pinned load result and a
+// pinned store value operand).
+static bool hasRecursivePin(Attribute enc) {
+  for (Attribute e = enc; e && e.getDialect().getNamespace() == "tlx";) {
+    if (isa<PinnedEncodingTrait>(e))
+      return true;
+    Attribute inner;
+    e.walkImmediateSubElements(
+        [&](Attribute sub) {
+          if (!inner)
+            inner = sub;
+        },
+        [](Type) {});
+    if (!inner || inner == e)
+      break;
+    e = inner;
+  }
+  return false;
+}
+
 struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
   using impl::TritonGPUCoalesceBase<CoalescePass>::TritonGPUCoalesceBase;
 
@@ -128,10 +151,11 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
             dyn_cast<RankedTensorType>(localLoad.getResult().getType());
         if (!resultType)
           return;
-        // Respect a user-pinned result layout (PinnedEncodingTrait, e.g. TLX's
-        // #tlx.user_layout): don't coalesce it to a "full contiguity" blocked
-        // layout -- the user chose this register layout on purpose.
-        if (isa_and_nonnull<PinnedEncodingTrait>(resultType.getEncoding()))
+        // Respect a user-pinned result layout: don't coalesce it to a "full
+        // contiguity" blocked layout -- the user chose this register layout on
+        // purpose. The pin (PinnedEncodingTrait) may sit under a
+        // #tlx.no_verify_layout wrapper here (peeled later by resolve-placeholder).
+        if (hasRecursivePin(resultType.getEncoding()))
           return;
       } else {
         // Not a memory operation we handle
@@ -162,13 +186,38 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
             &getContext(), resultType.getShape(), sizePerThread, order,
             numWarps, threadsPerWarp, CGALayout);
       } else {
-        auto tensorType = cast<RankedTensorType>(ptr.getType());
-        CGAEncodingAttr cgaLayout = getCGALayout(tensorType.getEncoding());
-        SmallVector<int64_t> shapePerCTA = getShapePerCTA(tensorType);
-        auto layout = buildCoalescedEncoding(axisInfoAnalysis, curr, numWarps,
-                                             threadsPerWarp, cgaLayout,
-                                             shapePerCTA, maxVecBits);
-        layoutMap[curr] = layout;
+        // Respect a user-pinned store value layout. A tt.store has no result to
+        // carry a PinnedEncodingTrait, so the pin rides on the value operand,
+        // wrapped as #tlx.no_verify_layout(#tlx.user_layout): the outer no-verify
+        // defers store operand-layout verification until resolve-placeholder-layouts
+        // peels it, and it is still present here because coalesce runs before that
+        // pass. Find the pin (hasRecursivePin), then store in the peeled concrete
+        // layout instead of a freshly-coalesced one: convertDistributedOpEncoding
+        // then converts ptr/mask to match, the value's bridging convert folds away,
+        // and the user's chosen store layout survives to codegen (AMD
+        // OptimizeEpilogue leaves it alone since it is no longer a #blocked store).
+        Attribute pinned;
+        if (auto store = dyn_cast<triton::StoreOp>(curr)) {
+          if (auto vt =
+                  dyn_cast<RankedTensorType>(store.getValue().getType())) {
+            if (hasRecursivePin(vt.getEncoding())) {
+              Attribute concrete = triton::unwrapTlxWrappers(vt.getEncoding());
+              if (isa_and_nonnull<DistributedEncodingTrait>(concrete))
+                pinned = concrete;
+            }
+          }
+        }
+        if (pinned) {
+          layoutMap[curr] = pinned;
+        } else {
+          auto tensorType = cast<RankedTensorType>(ptr.getType());
+          CGAEncodingAttr cgaLayout = getCGALayout(tensorType.getEncoding());
+          SmallVector<int64_t> shapePerCTA = getShapePerCTA(tensorType);
+          auto layout = buildCoalescedEncoding(axisInfoAnalysis, curr, numWarps,
+                                               threadsPerWarp, cgaLayout,
+                                               shapePerCTA, maxVecBits);
+          layoutMap[curr] = layout;
+        }
       }
     });
 

--- a/python/test/unit/language/test_tlx_layout.py
+++ b/python/test/unit/language/test_tlx_layout.py
@@ -738,3 +738,44 @@ def test_buffer_load_to_local_infers_offset_layout_amd():
     # It lowers all the way to amdgcn (the direct-to-LDS width/alignment
     # requirements are met by the inferred offset layout).
     assert compiled.asm.get("amdgcn")
+
+
+# a16w16 epilogue-store pin: the coalesced #linear register layout the inter_wave
+# kernel pins on the FP16 store so AMD OptimizeEpilogue keeps buffer_store_dwordx4
+# (a [128, 128] fp16 quadrant on num_warps=8; each thread holds 8 contiguous N).
+_A16W16_STORE_SHAPE = ((16, 4, 8), (8, 4))
+_A16W16_STORE_STRIDE = ((8, 128, 512), (1, 4096))
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Need gfx950 (CDNA4)")
+def test_require_layout_pins_epilogue_store_amd():
+    """A store *value* pinned via tlx.require_layout survives coalesce /
+    remove-layout-conversions / optimize-epilogue as the exact coalesced #linear,
+    so the FP16 epilogue store stays a wide buffer_store_dwordx4 (the a16w16
+    scenario) instead of being narrowed to the MMA-accumulator layout. The
+    in-kernel tlx.assert_same_layout(c, L) compares final LinearLayouts and fails
+    compilation if the pin is dropped."""
+
+    @triton.jit
+    def kernel(a_ptr, b_ptr, c_ptr, K: tl.constexpr, L: tl.constexpr):
+        offs_m = tl.arange(0, 128)
+        offs_n = tl.arange(0, 128)
+        offs_k = tl.arange(0, K)
+        a = tl.load(a_ptr + offs_m[:, None] * K + offs_k[None, :])
+        b = tl.load(b_ptr + offs_k[:, None] * 128 + offs_n[None, :])
+        acc = tl.dot(a, b)  # MMA accumulator -> the store OptimizeEpilogue rewrites
+        c = tlx.require_layout(acc.to(tl.float16), L)  # pin the store value to L
+        tlx.assert_same_layout(c, L)  # fails compilation if the pin didn't survive
+        tl.store(c_ptr + offs_m[:, None] * 128 + offs_n[None, :], c)
+
+    L = tlx.layout(shape=_A16W16_STORE_SHAPE, stride=_A16W16_STORE_STRIDE)
+    a = torch.randn((128, 64), device=DEVICE, dtype=torch.float16)
+    b = torch.randn((64, 128), device=DEVICE, dtype=torch.float16)
+    c = torch.empty((128, 128), device=DEVICE, dtype=torch.float16)
+    compiled = kernel.warmup(a, b, c, 64, L, grid=(1, ), num_warps=8)
+    # assert_same_layout would have failed compilation if the pin were dropped; the
+    # epilogue store lowers to the wide coalesced dwordx4, not the narrow dwordx2
+    # fallback OptimizeEpilogue would otherwise produce.
+    amdgcn = compiled.asm["amdgcn"]
+    assert "buffer_store_dwordx4" in amdgcn
+    assert "buffer_store_dwordx2" not in amdgcn

--- a/test/TLX/coalesce-local-memory.mlir
+++ b/test/TLX/coalesce-local-memory.mlir
@@ -19,3 +19,40 @@ tt.func @local_load_coalesce(%arg0: !ttg.memdesc<128x64xf16, #shared, #smem>) ->
 }
 
 }
+
+// -----
+
+// A tt.store whose value is pinned via tlx.require_layout (wrapped
+// #tlx.no_verify_layout<#tlx.user_layout<...>>) keeps the user's layout through
+// coalesce: coalesce commits the store to the peeled concrete layout and converts
+// ptr/mask to match, instead of choosing its own (contiguity-coalesced) layout.
+#pinned = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#user = #tlx.user_layout<#pinned>
+#nv = #tlx.no_verify_layout<#user>
+// CHECK-DAG: #[[$PIN:.+]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @pinned_store
+  // CHECK: tt.store {{.*}} : tensor<128x64x!tt.ptr<f16>, #[[$PIN]]>
+  tt.func @pinned_store(%ptr: tensor<128x64x!tt.ptr<f16>, #nv>, %val: tensor<128x64xf16, #nv>) {
+    tt.store %ptr, %val : tensor<128x64x!tt.ptr<f16>, #nv>
+    tt.return
+  }
+}
+
+// -----
+
+// A pinned local_load result is likewise not re-coalesced: coalesce leaves the
+// pinned layout in place (peeled later by resolve-placeholder-layouts).
+#pinned = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#user = #tlx.user_layout<#pinned>
+#nv = #tlx.no_verify_layout<#user>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @pinned_load
+  // CHECK: ttg.local_load {{.*}} -> tensor<128x64xf16, #tlx.no_verify_layout<{{.+}}>>
+  tt.func @pinned_load(%arg0: !ttg.memdesc<128x64xf16, #shared, #smem>) -> tensor<128x64xf16, #nv> {
+    %0 = ttg.local_load %arg0 : !ttg.memdesc<128x64xf16, #shared, #smem> -> tensor<128x64xf16, #nv>
+    tt.return %0 : tensor<128x64xf16, #nv>
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
@@ -126,8 +126,17 @@ public:
     Value mask = stOp.getMask();
     auto ptrType = dyn_cast<RankedTensorType>(ptr.getType());
     auto valType = dyn_cast<RankedTensorType>(val.getType());
-    if (!ptrType || !valType ||
-        !isa<triton::gpu::BlockedEncodingAttr>(ptrType.getEncoding()) ||
+    if (!ptrType || !valType)
+      return mlir::failure();
+    // Respect a user-pinned store layout (PinnedEncodingTrait, e.g. TLX's
+    // #tlx.user_layout): the author chose this store layout deliberately, so do
+    // not rewrite it to the MMA accumulator layout. Mirrors Coalesce /
+    // RemoveLayoutConversions / OptimizeTMemLayouts, which already anchor on this
+    // trait (D112032532).
+    if (isa_and_nonnull<triton::gpu::PinnedEncodingTrait>(valType.getEncoding()) ||
+        isa_and_nonnull<triton::gpu::PinnedEncodingTrait>(ptrType.getEncoding()))
+      return mlir::failure();
+    if (!isa<triton::gpu::BlockedEncodingAttr>(ptrType.getEncoding()) ||
         !isa<triton::gpu::BlockedEncodingAttr>(valType.getEncoding()))
       return mlir::failure();
 

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -201,6 +201,27 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
         }
         return;
       }
+      // tt.store: value / ptr / mask must share one encoding
+      // (SameLoadStoreOperandsEncoding). If the value carries a user pin,
+      // propagate it to ptr/mask so make_ttir's verifier accepts the store
+      // without a per-op tolerance; concrete layouts resolve later in make_ttgir.
+      // Bridge (require_layout convert) the ptr/mask for this use only, leaving
+      // their producers (addptr / mask cmp, with their own same-encoding
+      // verifiers) untouched.
+      if (auto store = dyn_cast<::mlir::triton::StoreOp>(op)) {
+        SmallVector<Value> linked{store.getValue(), store.getPtr()};
+        if (store.getMask())
+          linked.push_back(store.getMask());
+        Attribute enc = findPlaceholder(linked, op);
+        if (enc) {
+          bridgeOrRetype(store.getPtr(), enc, op, /*operandIdx=*/0,
+                         /*forceBridge=*/true);
+          if (store.getMask())
+            bridgeOrRetype(store.getMask(), enc, op, /*operandIdx=*/2,
+                           /*forceBridge=*/true);
+        }
+        return;
+      }
       // scf.for: init / region iter-arg / yield operand / result of each
       // loop-carried value must share the encoding.
       if (auto forOp = dyn_cast<scf::ForOp>(op)) {

--- a/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
@@ -384,14 +384,32 @@ static bool containsUserLayout(Type type) {
 /// `slice<parent = #tlx.user_layout<...>>`) and inside a constant's `value`
 /// DenseElementsAttr type. Stripping only top-level result encodings would
 /// leave nested wrappers behind and produce inconsistent op types.
+// Recursively strip a chain of TLX wrapper attrs (user_layout / no_verify) down
+// to the concrete layout. AttrTypeReplacer applies each replacement only once
+// per matched attr, so a *nested* wrapper -- e.g.
+// no_verify<user_layout<no_verify<L>>>, produced when a require_layout store pin
+// also carries a tlx.assert_same_layout -- would keep an inner user_layout after
+// a single getLayout(), which the residual check below then flags as
+// "unresolved TLX user layout". Unwrapping the whole chain here resolves it
+// (wrappers nested inside ttg encodings are still reached by the replacer's own
+// sub-element recursion, which re-invokes this on the inner wrapper).
+static Attribute deepUnwrapTlxWrappers(Attribute attr) {
+  if (auto u = dyn_cast<UserLayoutAttr>(attr))
+    return deepUnwrapTlxWrappers(u.getLayout());
+  if (auto n = dyn_cast<NoVerifyLayoutAttr>(attr))
+    return deepUnwrapTlxWrappers(n.getLayout());
+  return attr;
+}
+
 static LogicalResult finalizeUserLayouts(ModuleOp moduleOp) {
   mlir::AttrTypeReplacer replacer;
-  replacer.addReplacement(
-      [](UserLayoutAttr wrapper) -> Attribute { return wrapper.getLayout(); });
+  replacer.addReplacement([](UserLayoutAttr wrapper) -> Attribute {
+    return deepUnwrapTlxWrappers(wrapper);
+  });
   // Defensively also strip any no-verify wrapper that reached this point (e.g.
   // nested under a user-layout that resolve-placeholder-layouts left in place).
   replacer.addReplacement([](NoVerifyLayoutAttr wrapper) -> Attribute {
-    return wrapper.getLayout();
+    return deepUnwrapTlxWrappers(wrapper);
   });
 
   moduleOp->walk([&](Operation *op) {

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -98,7 +98,8 @@ void init_triton_tlx_ir(py::module &&m) {
                                                         offsets);
            })
       .def("create_require_layout",
-           [](TritonOpBuilder &self, Value &v, Attribute &encoding) -> Value {
+           [](TritonOpBuilder &self, Value &v, Attribute &encoding,
+              bool pin) -> Value {
              Type newType;
              if (auto type = dyn_cast<ttg::MemDescType>(v.getType())) {
                // consider allocation type for subslice
@@ -111,14 +112,25 @@ void init_triton_tlx_ir(py::module &&m) {
                    type.getMemorySpace(), type.getMutableMemory(), allocShape);
                return self.create<tlx::RequireLayoutOp>(newType, v);
              } else if (auto type = dyn_cast<RankedTensorType>(v.getType())) {
-               Attribute tensorEncoding = tlx::wrapNoVerifyLayout(encoding);
+               // `pin`: wrap in #tlx.no_verify_layout(#tlx.user_layout) -- the
+               // #tlx.user_layout carries PinnedEncodingTrait so the requirement is
+               // honored as a hard anchor by Coalesce / RemoveLayoutConversions /
+               // OptimizeEpilogue (e.g. to pin an epilogue store's register layout),
+               // and the outer #tlx.no_verify_layout defers operand-layout
+               // verification until ResolvePlaceholderLayouts peels it (so a pinned
+               // store whose ptr/mask layouts don't yet match verifies fine). Non-pin
+               // is a soft requirement (#tlx.no_verify_layout only, e.g. dot operands).
+               Attribute tensorEncoding =
+                   pin ? tlx::wrapNoVerifyLayout(tlx::wrapUserLayout(encoding))
+                       : tlx::wrapNoVerifyLayout(encoding);
                newType = RankedTensorType::get(
                    type.getShape(), type.getElementType(), tensorEncoding);
                return self.create<tlx::RequireLayoutOp>(newType, v);
              } else {
                throw std::runtime_error("Unsupported type");
              }
-           })
+           },
+           py::arg("v"), py::arg("encoding"), py::arg("pin") = false)
       .def("create_release_layout",
            [](TritonOpBuilder &self, Value &v) -> Value {
              if (auto type = dyn_cast<RankedTensorType>(v.getType())) {

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -61,7 +61,7 @@ from .mem_ops import (
     subslice,
     tmem_copy,
 )
-from .mma_ops import async_dot, async_dot_scaled, async_dot_wait, tcgen05_commit
+from .mma_ops import async_dot, async_dot_scaled, async_dot_wait, require_layout, tcgen05_commit
 from .types import (
     async_token,
     buffered_tensor,
@@ -188,6 +188,7 @@ __all__ = [
     "async_dot",
     "async_dot_scaled",
     "async_dot_wait",
+    "require_layout",
     "tcgen05_commit",
     # utility
     "cluster_cta_rank",

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -4,6 +4,24 @@ from . import types as tlx
 from .utility import cuda_parse_arch
 
 
+@tl.builtin
+def require_layout(x, layout, _semantic=None):
+    """Pin a register tensor's layout as a hard user anchor.
+
+    ``layout`` is a ``tlx.layout(...)`` (Shape:Stride) mapped to a ``#linear``
+    encoding and wrapped as ``#tlx.user_layout`` (PinnedEncodingTrait), so the
+    downstream layout passes (tritongpu-coalesce, remove-layout-conversions, AMD
+    optimize-epilogue) treat it as fixed and never rewrite it. Unlike a plain
+    (no_verify) require_layout, this survives to Coalesce and lets you pin an
+    epilogue ``tl.store`` to a coalesced register layout *without* staging the
+    value through LDS.
+    """
+    layout = tl._unwrap_if_constexpr(layout)
+    enc = layout.to_ir(_semantic.builder, x.shape, x.dtype)
+    handle = _semantic.builder.create_require_layout(x.handle, enc, pin=True)
+    return tl.tensor(handle, x.type)
+
+
 def require_nv_mma_shared_layout(x: tlx.buffered_tensor, swizzled: bool, _builder=None, fp4Padded: bool = False):
     assert isinstance(x.type.layout, tlx.shared_layout_encoding), "input must be a shared tensor"
     rank = len(x.shape)

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
@@ -405,8 +405,8 @@ def a16w16_8wave(
             # remove-layout-conversions / AMD optimize-epilogue so the store stays
             # a wide dwordx4. Fails compilation if a future change drops the pin.
             tlx.assert_same_layout(c_tl, L)
-            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_left[None, :],
-                     c_tl, mask=m_top & n_left)
+            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_left[None, :], c_tl,
+                     mask=m_top & n_left)
             tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_left[None, :],
                      tlx.require_layout(acc_bl.to(et), L), mask=m_bot & n_left)
             tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_right[None, :],
@@ -414,14 +414,14 @@ def a16w16_8wave(
             tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_right[None, :],
                      tlx.require_layout(acc_br.to(et), L), mask=m_bot & n_right)
         else:
-            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_left[None, :],
-                     acc_tl.to(et), mask=m_top & n_left)
-            tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_left[None, :],
-                     acc_bl.to(et), mask=m_bot & n_left)
-            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_right[None, :],
-                     acc_tr.to(et), mask=m_top & n_right)
-            tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_right[None, :],
-                     acc_br.to(et), mask=m_bot & n_right)
+            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_left[None, :], acc_tl.to(et),
+                     mask=m_top & n_left)
+            tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_left[None, :], acc_bl.to(et),
+                     mask=m_bot & n_left)
+            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_right[None, :], acc_tr.to(et),
+                     mask=m_top & n_right)
+            tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_right[None, :], acc_br.to(et),
+                     mask=m_bot & n_right)
     else:
         # Split-K: every split writes its fp32 partial into its workspace slice
         # (rows [split_id*M, split_id*M+M)). Mask stays in relative-M coords; the
@@ -460,9 +460,14 @@ def _reduce_k_kernel(workspace_ptr, c_ptr, M, N, SPLIT_K: tl.constexpr, BLOCK_SI
 
 
 NUM_CU = 256  # gfx950 (CDNA4) compute units
-# Below this many K-tiles per split, the per-split prologue/epilogue overhead
-# starts to dominate (measured: Router SPLIT_K=16 (8 tiles/split) beats 32 (4)).
-MIN_KTILES_PER_SPLIT = 8
+# Minimum K-tiles per split. Two forces set this floor: (1) below it the per-split
+# prologue/epilogue overhead dominates the shrinking K work; (2) more splits means
+# a proportionally larger fp32 workspace for the reduce to stream back (reduce cost
+# ~ SPLIT_K*M*N), so an over-split that only marginally improves the GEMM loses the
+# gain to the reduce. Every measured production optimum uses >= 16 tiles/split
+# (e.g. K=12288 wants SPLIT_K=12 (16 tiles) not 16 (12 tiles); the latter fills the
+# CUs but its extra reduce traffic makes it net slower).
+MIN_KTILES_PER_SPLIT = 16
 
 # Tile candidates, largest first. The big tile is the tuned default; the smaller
 # one is used only when the big tile can't fill the CUs (see choose_tile).
@@ -472,35 +477,38 @@ TILE_CANDIDATES = ((256, 256), (128, 128))
 
 
 def _split_k_for(grid_mn, K):
-    """Largest power-of-two SPLIT_K keeping grid_mn*SK within one CU wave and each
-    split a whole, BLOCK_K-aligned chunk of >= MIN_KTILES_PER_SPLIT tiles."""
+    """Largest SPLIT_K keeping grid_mn*SK within one CU wave and each split a whole,
+    BLOCK_K-aligned chunk of >= MIN_KTILES_PER_SPLIT tiles.
+
+    All divisors of K are considered, not just powers of two: for K with odd factors
+    (e.g. 22272 = 64*348) a non-pow2 SPLIT_K divides K and fills the CUs far more
+    precisely than the nearest pow2 (SPLIT_K=12 -> 192 CUs vs SPLIT_K=4 -> 64 CUs).
+    The scan is <= NUM_CU/grid_mn (~20) iterations, negligible at compile time."""
     min_ks = MIN_KTILES_PER_SPLIT * BLOCK_K
-    # TODO: only powers of two are considered. Optimal for pure-pow2 K (8192, 4096
-    # -- every divisor is pow2); for K with odd factors a non-pow2 SPLIT_K could
-    # divide K and fill more precisely. Generalize to enumerate divisors of K.
-    sk = 1
-    while True:
-        nxt = sk * 2
-        ks = K // nxt
-        if grid_mn * nxt > NUM_CU or K % nxt != 0 or ks < min_ks or ks % BLOCK_K != 0:
-            break
-        sk = nxt
-    return sk
+    best = 1
+    for sk in range(2, NUM_CU // grid_mn + 1):  # grid_mn*sk <= NUM_CU
+        ks = K // sk
+        if K % sk == 0 and ks >= min_ks and ks % BLOCK_K == 0:
+            best = sk  # fill = grid_mn*sk grows with sk, so the last valid sk wins
+    return best
 
 
 def choose_tile(M, N, K):
     """Pick (BLOCK_M, BLOCK_N, SPLIT_K) by CU fill -- no shape hardcoding.
 
-    Prefer the tuned 256x256 tile. Fall back to the smaller 128x128 tile only when
-    the 256 grid cannot fill the CUs even after split-K (thin-N / small-tile-count
-    shapes, e.g. N=256): the 4x-denser MN grid then reaches full occupancy with a
-    smaller SPLIT_K (and a cheaper reduce). For shapes the big tile already fills,
-    the smaller tile only adds overhead, so it is never chosen there."""
+    Prefer the tuned 256x256 tile; it is more MFMA-efficient per work-group than the
+    128x128 tile. Fall back to the smaller tile only when the 256 grid leaves most of
+    the machine idle even after split-K (fill < NUM_CU/2) -- the genuinely thin-N /
+    small-tile-count shapes (e.g. N=256, gmn=8): the 4x-denser MN grid then reaches
+    occupancy the big tile can't. When the big tile fills at least half the CUs, its
+    efficiency beats a full grid of small tiles, so it is kept (comparing raw
+    work-group counts across tile sizes is apples-to-oranges -- a 128 tile does 1/4
+    the work -- so a bigger small-tile count does not mean it is faster)."""
     bm, bn = TILE_CANDIDATES[0]
     gmn = triton.cdiv(M, bm) * triton.cdiv(N, bn)
     sk = _split_k_for(gmn, K)
     best_fill = gmn * sk
-    if best_fill < NUM_CU:  # big tile under-fills even with split-K
+    if best_fill < NUM_CU // 2:  # big tile leaves most CUs idle even with split-K
         for cbm, cbn in TILE_CANDIDATES[1:]:
             g = triton.cdiv(M, cbm) * triton.cdiv(N, cbn)
             s = _split_k_for(g, K)

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
@@ -44,6 +44,14 @@ NUM_XCDS = 8
 MIN_K = 2 * BLOCK_K  # pipeline prefetches 2 whole K-tiles; the rest goes to the masked tail
 KERNEL_NAME = "a16w16_8wave"
 
+# Coalesced SIMD register layout for the [HALF_M, HALF_N] = [128, 128] fp16 quadrant
+# store (num_warps=8, warp_size=64): each thread holds 8 contiguous N elements ->
+# 128-bit buffer_store_dwordx4. Applied to the epilogue store via tlx.require_layout
+# so tritongpu-coalesce sets the store to this #linear layout and AMD
+# OptimizeEpilogue leaves it alone (it only rewrites #blocked stores) -- keeping the
+# wide coalesced store instead of the narrow MMA-accumulator (dwordx2) fallback.
+_C_STORE_SIMD_LAYOUT = tlx.layout(shape=((16, 4, 8), (8, 4)), stride=((8, 128, 512), (1, 4096)))
+
 
 def _swz_offset_bases(shape, contig_dim):
     """Padded-shared swizzle offset bases for a 2D fp16 half-tile, derived from the
@@ -385,14 +393,35 @@ def a16w16_8wave(
     if SPLIT_K == 1:
         # Direct store to C -- exact no-op vs the champion kernel.
         et = c_ptr.dtype.element_ty
-        tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_left[None, :], acc_tl.to(et),
-                 mask=m_top & n_left)
-        tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_left[None, :], acc_bl.to(et),
-                 mask=m_bot & n_left)
-        tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_right[None, :], acc_tr.to(et),
-                 mask=m_top & n_right)
-        tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_right[None, :], acc_br.to(et),
-                 mask=m_bot & n_right)
+        if HALF_M == 128 and HALF_N == 128:
+            # Pin each 128x128 quadrant to the coalesced SIMD #linear layout (no LDS
+            # staging) so OptimizeEpilogue keeps the wide dwordx4 store.
+            # _C_STORE_SIMD_LAYOUT is derived for the 128x128 quadrant, so it only
+            # applies to the 256x256 tile; a smaller tile (64x64 quadrant) uses a
+            # plain store.
+            L: tl.constexpr = _C_STORE_SIMD_LAYOUT
+            c_tl = tlx.require_layout(acc_tl.to(et), L)
+            # Static guard (no device code): the pin must survive coalesce /
+            # remove-layout-conversions / AMD optimize-epilogue so the store stays
+            # a wide dwordx4. Fails compilation if a future change drops the pin.
+            tlx.assert_same_layout(c_tl, L)
+            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_left[None, :],
+                     c_tl, mask=m_top & n_left)
+            tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_left[None, :],
+                     tlx.require_layout(acc_bl.to(et), L), mask=m_bot & n_left)
+            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_right[None, :],
+                     tlx.require_layout(acc_tr.to(et), L), mask=m_top & n_right)
+            tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_right[None, :],
+                     tlx.require_layout(acc_br.to(et), L), mask=m_bot & n_right)
+        else:
+            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_left[None, :],
+                     acc_tl.to(et), mask=m_top & n_left)
+            tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_left[None, :],
+                     acc_bl.to(et), mask=m_bot & n_left)
+            tl.store(c_ptr + stride_cm * offs_cm_top[:, None] + stride_cn * offs_cn_right[None, :],
+                     acc_tr.to(et), mask=m_top & n_right)
+            tl.store(c_ptr + stride_cm * offs_cm_bot[:, None] + stride_cn * offs_cn_right[None, :],
+                     acc_br.to(et), mask=m_bot & n_right)
     else:
         # Split-K: every split writes its fp32 partial into its workspace slice
         # (rows [split_id*M, split_id*M+M)). Mask stays in relative-M coords; the


### PR DESCRIPTION
Summary:
choose_tile picked SPLIT_K from powers of two and gated the 128x128 fallback on a
raw work-group count, which over-split the reduce-heavy shapes and preferred the
less MFMA-efficient small tile. Three changes, all in choose_tile / _split_k_for
(no kernel or codegen change):

- _split_k_for enumerates all divisors of K, not just powers of two, so shapes with
  odd K factors (e.g. K=22272=64*348) reach the SPLIT_K that fills the CUs
  (SPLIT_K=12 -> 192 CUs) instead of the nearest pow2.
- MIN_KTILES_PER_SPLIT 8 -> 16: the split-K reduce streams an fp32 workspace of
  SPLIT_K*M*N, so an over-split that barely helps the GEMM loses the gain to the
  reduce; every measured optimum uses >= 16 K-tiles/split (K=12288: SPLIT_K=12
  (16 tiles) beats 16 (12 tiles)).
- The 128x128 fallback triggers only when the 256x256 grid leaves most of the
  machine idle (fill < NUM_CU/2), not on a raw work-group count -- the 256 tile is
  more MFMA-efficient per work-group, so a bigger small-tile count is not faster.

SPLIT_K=1 stays bit-exact; split-K keeps the fp32 workspace (within fp16 rounding,
no precision loss vs the non-split-K path). Stacked on D113115691.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D113310909


