### PR TITLE
[TLX][AMD] Improve f16 gemm benchmark harness

### DIFF
--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -7,7 +7,11 @@ an explicit GPUTarget and verify the generated TTGIR/AMDGCN. No AMD hardware is
 required for the compilation checks. Correctness checks (actual execution) run
 only when the corresponding hardware is available.
 """
+import importlib.util
 import re
+import sys
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -35,6 +39,36 @@ def compile_for_gfx950(fn, signature, constexprs):
     """Compile a TLX kernel for gfx950 and return the compiled object."""
     src = ASTSource(fn=fn, signature=signature, constexprs=constexprs)
     return triton_compile(src, target=GFX950)
+
+
+def _load_tlx_gfx9_gemm_bench_module(module_name="_tlx_amd_test_gfx9_bench"):
+    repo_root = Path(__file__).resolve().parents[4]
+    bench_path = (repo_root / "third_party" / "tlx" / "tutorials" / "gfx9_gemm" / "a16w16" / "bench.py")
+    spec = importlib.util.spec_from_file_location(module_name, bench_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_tlx_gfx9_inter_wave_bench_module(module_name="_tlx_amd_test_gfx9_inter_wave_bench"):
+    repo_root = Path(__file__).resolve().parents[4]
+    bench_path = (repo_root / "third_party" / "tlx" / "tutorials" / "gfx9_gemm" / "inter_wave" / "a16w16" / "bench.py")
+    previous_kernel_module = sys.modules.get("matmul_kernel")
+    try:
+        sys.modules["matmul_kernel"] = SimpleNamespace(
+            matmul=lambda _a, _b: None,
+            MIN_K=128,
+            KERNEL_NAME="a16w16_8wave",
+        )
+        spec = importlib.util.spec_from_file_location(module_name, bench_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if previous_kernel_module is None:
+            sys.modules.pop("matmul_kernel", None)
+        else:
+            sys.modules["matmul_kernel"] = previous_kernel_module
 
 
 # ---------------------------------------------------------------------------
@@ -733,3 +767,211 @@ def test_mxgemm_tdm_pipelined_compiles_gfx1250(device):
     assert "tt.dot_scaled" in ttgir
     assert "tensor_load_to_lds" in amdgcn or "tensor.load.to.lds" in amdgcn
     assert "wmma" in amdgcn
+
+
+def test_tlx_gfx9_gemm_bench_parses_shapes_and_defaults():
+    bench = _load_tlx_gfx9_gemm_bench_module()
+
+    assert not hasattr(bench, "DEVICE")
+    assert set(bench.VERSION_MAP) == set(range(10))
+    assert set(bench.PROVIDER_LABELS) == {"rocblas", "tlx"}
+    assert bench.provider_defaults(9) == ["rocblas", "tlx"]
+    assert bench.provider_defaults(0) == ["rocblas", "tlx"]
+    assert bench.parse_shape("128x256x64") == (128, 256, 64)
+    assert bench.parse_shape("128,256,64") == (128, 256, 64)
+    with pytest.raises(Exception, match="shape dimensions must be positive"):
+        bench.parse_shape("128x0x64")
+    with pytest.raises(Exception, match="shape must be MxNxK"):
+        bench.parse_shape("128x256")
+    bench.validate_shape_for_providers((256, 256, 64), 0, ["tlx"])
+    bench.validate_shape_for_providers((128, 128, 64), 9, ["rocblas"])
+    with pytest.raises(Exception, match="M to be a multiple of 256"):
+        bench.validate_shape_for_providers((128, 256, 64), 9, ["tlx"])
+    with pytest.raises(Exception, match="N to be a multiple of 256"):
+        bench.validate_shape_for_providers((256, 128, 64), 9, ["tlx"])
+    with pytest.raises(Exception, match="K to be a multiple of 64"):
+        bench.validate_shape_for_providers((256, 256, 96), 2, ["tlx"])
+    with pytest.raises(Exception, match="prefetch two 64-wide K tiles"):
+        bench.validate_shape_for_providers((256, 256, 64), 9, ["tlx"])
+    bench.validate_shape_for_providers((256, 256, 128), 9, ["tlx"])
+
+
+def test_tlx_gfx9_gemm_bench_input_modes_are_deterministic():
+    bench = _load_tlx_gfx9_gemm_bench_module("_tlx_amd_test_gfx9_bench_inputs")
+    inter_wave = _load_tlx_gfx9_inter_wave_bench_module("_tlx_amd_test_gfx9_inter_wave_bench_inputs")
+    assert inter_wave.INPUT_MODES == bench.INPUT_MODES
+    normal_seed_zero = None
+
+    for input_mode in bench.INPUT_MODES:
+        a, b = bench.make_inputs(
+            2,
+            4,
+            8,
+            torch.device("cpu"),
+            "transposed",
+            input_mode=input_mode,
+            seed=0,
+        )
+        repeat_a, repeat_b = bench.make_inputs(
+            2,
+            4,
+            8,
+            torch.device("cpu"),
+            "transposed",
+            input_mode=input_mode,
+            seed=0,
+        )
+        torch.testing.assert_close(a, repeat_a)
+        torch.testing.assert_close(b, repeat_b)
+        inter_wave_a, inter_wave_b = inter_wave.make_inputs(
+            2,
+            4,
+            8,
+            torch.device("cpu"),
+            "transposed",
+            input_mode=input_mode,
+            seed=0,
+        )
+        torch.testing.assert_close(inter_wave_a, a)
+        torch.testing.assert_close(inter_wave_b, b)
+        assert b.shape == (8, 4)
+        assert b.stride() == (1, 8)
+        if input_mode == "normal":
+            normal_seed_zero = a
+
+    normal_a, _ = bench.make_inputs(2, 4, 8, "cpu", "transposed", input_mode="normal", seed=1)
+    assert not torch.equal(normal_seed_zero, normal_a)
+
+
+def test_tlx_gfx9_gemm_bench_reproduces_hipblaslt_rand_int_inputs():
+    bench = _load_tlx_gfx9_gemm_bench_module("_tlx_amd_test_gfx9_bench_rand_int")
+
+    a, b = bench.make_inputs(
+        2,
+        4,
+        8,
+        torch.device("cpu"),
+        "transposed",
+        input_mode="rand-int",
+        seed=0,
+    )
+
+    expected_a = torch.tensor(
+        [
+            [-2, -2, 0, 0, 1, 0, 1, 2],
+            [-1, -2, 0, -1, -2, -2, 0, -1],
+        ],
+        dtype=torch.float16,
+    )
+    expected_b_storage = torch.tensor(
+        [
+            [2, -2, 0, 0, -1, 0, -1, 2],
+            [-1, 2, 0, 1, -2, 2, 0, 1],
+            [2, 0, -2, -1, 1, 2, 0, 2],
+            [2, -1, -1, 1, 2, 2, 1, 2],
+        ],
+        dtype=torch.float16,
+    )
+    torch.testing.assert_close(a, expected_a)
+    torch.testing.assert_close(b.T, expected_b_storage)
+
+
+def test_tlx_gfx9_gemm_bench_launch_reuses_output():
+    bench = _load_tlx_gfx9_gemm_bench_module("_tlx_amd_test_gfx9_bench_output")
+    call = {}
+
+    class FakeKernel:
+
+        def __getitem__(self, grid):
+            call["grid"] = grid
+
+            def launch(*args, **kwargs):
+                call["args"] = args
+                call["kwargs"] = kwargs
+
+            return launch
+
+    module = SimpleNamespace(v9_beyond_hotloop=FakeKernel())
+    a = torch.empty((256, 128), dtype=torch.float16)
+    b = torch.empty((128, 256), dtype=torch.float16)
+    out = torch.empty((256, 256), dtype=torch.float16)
+
+    result = bench.launch_tutorial_matmul(module, "v9_beyond_hotloop", a, b, out=out)
+
+    assert result is out
+    assert call["args"][2] is out
+    assert call["grid"] == (1, )
+
+
+def test_tlx_gfx9_gemm_bench_batched_timing_uses_one_event_span_per_repeat():
+    bench = _load_tlx_gfx9_gemm_bench_module("_tlx_amd_test_gfx9_bench_timing")
+    state = {"launches": 0, "synchronizes": 0, "events": 0}
+
+    class FakeEvent:
+
+        def __init__(self):
+            self.launch = None
+
+        def record(self):
+            self.launch = state["launches"]
+
+        def elapsed_time(self, other):
+            return (other.launch - self.launch) * 0.25
+
+    class FakeDeviceInterface:
+
+        def Event(self, *, enable_timing):
+            assert enable_timing
+            state["events"] += 1
+            return FakeEvent()
+
+        def synchronize(self):
+            state["synchronizes"] += 1
+
+    def launch():
+        state["launches"] += 1
+
+    ms = bench.do_bench_batched(
+        launch,
+        warmup_launches=2,
+        timed_launches=4,
+        repeats=3,
+        device_interface=FakeDeviceInterface(),
+    )
+
+    assert ms == 0.25
+    assert state == {"launches": 18, "synchronizes": 6, "events": 6}
+
+
+def test_tlx_gfx9_gemm_bench_triton_timing_reports_median(monkeypatch):
+    bench = _load_tlx_gfx9_gemm_bench_module("_tlx_amd_test_gfx9_bench_median")
+    call = {}
+
+    def do_bench(fn, **kwargs):
+        call["fn"] = fn
+        call["kwargs"] = kwargs
+        return 0.75
+
+    monkeypatch.setattr(bench.triton.testing, "do_bench", do_bench)
+    fn = lambda: None
+    ms = bench.measure_provider(
+        SimpleNamespace(timing_mode="triton", warmup=13, rep=29),
+        fn,
+    )
+
+    assert ms == 0.75
+    assert call == {
+        "fn": fn,
+        "kwargs": {"warmup": 13, "rep": 29, "return_mode": "median"},
+    }
+
+
+def test_tlx_gfx9_gemm_bench_loads_modules_without_import_leaks():
+    bench = _load_tlx_gfx9_gemm_bench_module("_tlx_amd_test_gfx9_bench_imports")
+    before_path = list(sys.path)
+
+    module = bench.load_matmul_module("v0_naive", "test")
+
+    assert hasattr(module, "matmul")
+    assert list(sys.path) == before_path
+    assert module.__name__ not in sys.modules

--- a/third_party/tlx/tutorials/gfx9_gemm/a16w16/bench.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/a16w16/bench.py
@@ -1,9 +1,34 @@
-"""Benchmark harness matching Gluon's bench.py format."""
+"""Benchmark harness for the gfx9 TLX GEMM tutorial kernels."""
 
 import argparse
-import importlib
+import concurrent.futures
+import importlib.util
+import multiprocessing
+import os
+from pathlib import Path
+import statistics
+import time
+
 import torch
 import triton
+from triton import knobs
+from triton.runtime.jit import MockTensor
+
+
+def _load_f16_inputs():
+    path = Path(__file__).resolve().parent.parent / "f16_inputs.py"
+    spec = importlib.util.spec_from_file_location("_tlx_gfx9_f16_inputs", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import f16 input helpers from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_f16_inputs = _load_f16_inputs()
+INPUT_MODES = _f16_inputs.INPUT_MODES
+DEFAULT_INPUT_SEED = _f16_inputs.DEFAULT_INPUT_SEED
+make_inputs = _f16_inputs.make_inputs
 
 VERSION_MAP = {
     0: "v0_naive",
@@ -18,7 +43,50 @@ VERSION_MAP = {
     9: "v9_beyond_hotloop",
 }
 
-DEVICE = triton.runtime.driver.active.get_active_torch_device()
+PROVIDER_LABELS = {
+    "rocblas": "rocBLAS",
+    "tlx": "TLX",
+}
+
+BENCH_DIR = Path(__file__).resolve().parent
+TILE_M = 256
+TILE_N = 256
+TILE_K = 64
+TWO_STAGE_K = 2 * TILE_K
+TUTORIAL_PROVIDERS = frozenset({"tlx"})
+TWO_STAGE_K_VERSIONS = frozenset(range(5, 10))
+UNTILED_K_VERSIONS = frozenset({0, 1})
+GROUPED_PID_VERSIONS = frozenset({"v9_beyond_hotloop"})
+EIGHT_WARP_VERSIONS = frozenset({"v8_warp_pipeline", "v9_beyond_hotloop"})
+DEFAULT_COMPILE_WORKERS = max(1, min(8, os.cpu_count() or 1))
+TIMING_MODES = ("triton", "batched")
+DEFAULT_WARMUP_LAUNCHES = 25
+DEFAULT_TIMED_LAUNCHES = 1000
+DEFAULT_TIMING_REPEATS = 7
+
+
+class StridedMockTensor(MockTensor):
+
+    def __init__(self, dtype, shape, strides):
+        super().__init__(dtype, shape)
+        self._strides = tuple(int(stride) for stride in strides)
+
+    def stride(self):
+        return self._strides
+
+
+def nonnegative_int(text):
+    value = int(text)
+    if value < 0:
+        raise argparse.ArgumentTypeError(f"expected a non-negative integer, got {text!r}")
+    return value
+
+
+def positive_int(text):
+    value = int(text)
+    if value <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {text!r}")
+    return value
 
 
 def get_x_vals():
@@ -30,42 +98,480 @@ def get_x_vals():
     ]
 
 
+def parse_shape(text):
+    parts = text.replace("x", ",").split(",")
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError(f"shape must be MxNxK or M,N,K, got {text!r}")
+    try:
+        shape = tuple(int(part) for part in parts)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"shape must contain integer M/N/K values, got {text!r}") from exc
+    if any(dim <= 0 for dim in shape):
+        raise argparse.ArgumentTypeError(f"shape dimensions must be positive: {text!r}")
+    return shape
+
+
+def validate_shape_for_providers(shape, version, providers):
+    if not TUTORIAL_PROVIDERS.intersection(providers):
+        return
+    M, N, K = shape
+    if M % TILE_M:
+        raise argparse.ArgumentTypeError(f"tutorial kernels require M to be a multiple of {TILE_M}, got {M}")
+    if N % TILE_N:
+        raise argparse.ArgumentTypeError(f"tutorial kernels require N to be a multiple of {TILE_N}, got {N}")
+    if version not in UNTILED_K_VERSIONS and K % TILE_K:
+        raise argparse.ArgumentTypeError(f"tutorial kernels v{version} require K to be a multiple of "
+                                         f"{TILE_K}, got {K}")
+    if version in TWO_STAGE_K_VERSIONS and (K < TWO_STAGE_K or K % TWO_STAGE_K):
+        raise argparse.ArgumentTypeError(f"tutorial kernels v{version} prefetch two {TILE_K}-wide K tiles; "
+                                         f"K must be at least {TWO_STAGE_K} and a multiple of {TWO_STAGE_K}, "
+                                         f"got {K}")
+
+
+def validate_shapes_for_providers(shapes, version, providers):
+    for shape in shapes:
+        validate_shape_for_providers(shape, version, providers)
+
+
+def load_matmul_module(version_dir, suffix):
+    kernel_path = BENCH_DIR / version_dir / "matmul_kernel.py"
+    spec = importlib.util.spec_from_file_location(
+        f"_tlx_gfx9_gemm_{version_dir}_{suffix}_{time.time_ns()}",
+        kernel_path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import benchmark kernel from {kernel_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def provider_defaults(_version):
+    return ["rocblas", "tlx"]
+
+
+def launch_tutorial_matmul(module, version_dir, a, b, out=None):
+    assert a.shape[1] == b.shape[0], "Incompatible dimensions"
+    M, K = a.shape
+    K, N = b.shape
+    if out is None:
+        out = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    else:
+        assert out.shape == (M, N), "Output shape must match the GEMM result"
+        assert out.device == a.device, "Output must be on the same device as the inputs"
+        assert out.dtype == a.dtype, "Output dtype must match the input dtype"
+    BLOCK_M, BLOCK_N, BLOCK_K = 256, 256, 64
+    grid_m = triton.cdiv(M, BLOCK_M)
+    grid_n = triton.cdiv(N, BLOCK_N)
+    grid_mn = grid_m * grid_n
+    compile_kwargs = {
+        "BLOCK_M": BLOCK_M,
+        "BLOCK_N": BLOCK_N,
+        "BLOCK_K": BLOCK_K,
+        "num_warps": 8 if version_dir in EIGHT_WARP_VERSIONS else 4,
+        "num_stages": 1,
+        "matrix_instr_nonkdim": 16,
+    }
+    if version_dir in GROUPED_PID_VERSIONS:
+        compile_kwargs.update({
+            "GROUP_SIZE_M": 4,
+            "NUM_XCDS": 8,
+            "GRID_MN": grid_mn,
+        })
+
+    kernel = getattr(module, version_dir)
+    kernel[(grid_mn, )](
+        a,
+        b,
+        out,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        out.stride(0),
+        out.stride(1),
+        **compile_kwargs,
+    )
+    return out
+
+
+def provider_matmul(provider, module, version_dir, a, b, out=None):
+    if provider == "rocblas":
+        return torch.matmul(a, b, out=out)
+    return launch_tutorial_matmul(module, version_dir, a, b, out=out)
+
+
+def do_bench_batched(
+    fn,
+    *,
+    warmup_launches=DEFAULT_WARMUP_LAUNCHES,
+    timed_launches=DEFAULT_TIMED_LAUNCHES,
+    repeats=DEFAULT_TIMING_REPEATS,
+    device_interface=None,
+):
+    """Time one event span per batch and return the median per-launch time."""
+    if warmup_launches < 0:
+        raise ValueError("warmup_launches must be non-negative")
+    if timed_launches <= 0:
+        raise ValueError("timed_launches must be positive")
+    if repeats <= 0:
+        raise ValueError("repeats must be positive")
+
+    di = device_interface or triton.runtime.driver.active.get_device_interface()
+    samples = []
+    for _ in range(repeats):
+        for _ in range(warmup_launches):
+            fn()
+        di.synchronize()
+
+        start_event = di.Event(enable_timing=True)
+        end_event = di.Event(enable_timing=True)
+        start_event.record()
+        for _ in range(timed_launches):
+            fn()
+        end_event.record()
+        di.synchronize()
+        samples.append(start_event.elapsed_time(end_event) / timed_launches)
+    return statistics.median(samples)
+
+
+def measure_provider(args, fn):
+    if args.timing_mode == "triton":
+        return triton.testing.do_bench(
+            fn,
+            warmup=args.warmup,
+            rep=args.rep,
+            return_mode="median",
+        )
+    return do_bench_batched(
+        fn,
+        warmup_launches=args.warmup_launches,
+        timed_launches=args.timed_launches,
+        repeats=args.timing_repeats,
+    )
+
+
+def benchmark_provider(args, provider, version_dir, a, b, ref, M, N, K):
+    module = None
+    if provider != "rocblas":
+        module = load_matmul_module(version_dir, provider)
+    cache_dir = compile_cache_dir(args.cache_dir, version_dir, provider, M, N, K)
+
+    with knobs.cache.scope(), knobs.runtime.scope():
+        if cache_dir is not None:
+            knobs.cache.dir = str(cache_dir)
+        if args.arch is not None:
+            knobs.runtime.override_arch = args.arch
+        c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+        provider_matmul(provider, module, version_dir, a, b, out=c)
+        torch.cuda.synchronize()
+        ok = torch.allclose(c, ref, atol=args.atol, rtol=args.rtol)
+        max_err = (c - ref).abs().max().item()
+        if not ok:
+            bad = int((~torch.isclose(c, ref, atol=args.atol, rtol=args.rtol)).sum().item())
+            return {
+                "ok": False,
+                "max_err": max_err,
+                "bad": bad,
+                "ms": None,
+                "tflops": None,
+            }
+        ms = measure_provider(
+            args,
+            lambda: provider_matmul(provider, module, version_dir, a, b, out=c),
+        )
+    return {
+        "ok": True,
+        "max_err": max_err,
+        "bad": 0,
+        "ms": ms,
+        "tflops": tflops(ms, M, N, K),
+    }
+
+
+def tflops(ms, M, N, K):
+    return 2 * M * N * K * 1e-12 / (ms * 1e-3)
+
+
+def make_mock_inputs(M, N, K, b_layout):
+    a = MockTensor(torch.float16, [M, K])
+    if b_layout == "contiguous":
+        b = MockTensor(torch.float16, [K, N])
+    else:
+        b = StridedMockTensor(torch.float16, [K, N], (1, K))
+    c = MockTensor(torch.float16, [M, N])
+    return a, b, c
+
+
+def compile_cache_dir(cache_root, version_dir, provider, M, N, K):
+    if cache_root is None:
+        return None
+    return Path(cache_root) / version_dir / provider / f"M{M}_N{N}_K{K}"
+
+
+def compile_provider_shape(provider, version_dir, shape, b_layout, cache_root, arch):
+    if provider == "rocblas":
+        return shape, provider, 0.0
+
+    M, N, K = shape
+    module = load_matmul_module(version_dir, f"compile_{provider}")
+    kernel = getattr(module, version_dir)
+    cache_dir = compile_cache_dir(cache_root, version_dir, provider, M, N, K)
+    a, b, c = make_mock_inputs(M, N, K, b_layout)
+    BLOCK_M, BLOCK_N, BLOCK_K = 256, 256, 64
+    grid_m = triton.cdiv(M, BLOCK_M)
+    grid_n = triton.cdiv(N, BLOCK_N)
+    grid_mn = grid_m * grid_n
+    compile_kwargs = {
+        "BLOCK_M": BLOCK_M,
+        "BLOCK_N": BLOCK_N,
+        "BLOCK_K": BLOCK_K,
+        "num_warps": 8 if version_dir in EIGHT_WARP_VERSIONS else 4,
+        "num_stages": 1,
+        "matrix_instr_nonkdim": 16,
+        "grid": (grid_mn, ),
+    }
+    if version_dir in GROUPED_PID_VERSIONS:
+        compile_kwargs.update({
+            "GROUP_SIZE_M": 4,
+            "NUM_XCDS": 8,
+            "GRID_MN": grid_mn,
+        })
+
+    start = time.monotonic()
+    with knobs.cache.scope(), knobs.runtime.scope():
+        if cache_dir is not None:
+            knobs.cache.dir = str(cache_dir)
+        if arch is not None:
+            knobs.runtime.override_arch = arch
+        a_strides = a.stride()
+        b_strides = b.stride()
+        c_strides = c.stride()
+        kernel.warmup(
+            a,
+            b,
+            c,
+            M,
+            N,
+            K,
+            a_strides[0],
+            a_strides[1],
+            b_strides[0],
+            b_strides[1],
+            c_strides[0],
+            c_strides[1],
+            **compile_kwargs,
+        )
+    return shape, provider, time.monotonic() - start
+
+
+def precompile_shapes(args, version_dir, providers, sizes):
+    if args.compile_workers == 0:
+        return
+
+    jobs = [(provider, shape) for shape in sizes for provider in providers if provider != "rocblas"]
+    if not jobs:
+        return
+
+    workers = min(args.compile_workers, len(jobs))
+    print(f"\nPrecompiling {len(jobs)} provider/shape job(s) with {workers} worker(s):", flush=True)
+
+    if workers == 1:
+        for provider, shape in jobs:
+            compiled_shape, compiled_provider, elapsed = compile_provider_shape(
+                provider,
+                version_dir,
+                shape,
+                args.b_layout,
+                args.cache_dir,
+                args.arch,
+            )
+            M, N, K = compiled_shape
+            print(f"  compiled {compiled_provider} {M}x{N}x{K} in {elapsed:.1f}s", flush=True)
+        return
+
+    context = multiprocessing.get_context("spawn")
+    with concurrent.futures.ProcessPoolExecutor(max_workers=workers, mp_context=context) as executor:
+        futures = [
+            executor.submit(
+                compile_provider_shape,
+                provider,
+                version_dir,
+                shape,
+                args.b_layout,
+                args.cache_dir,
+                args.arch,
+            ) for provider, shape in jobs
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            compiled_shape, compiled_provider, elapsed = future.result()
+            M, N, K = compiled_shape
+            print(f"  compiled {compiled_provider} {M}x{N}x{K} in {elapsed:.1f}s", flush=True)
+
+
 def main():
     parser = argparse.ArgumentParser(description="TLX GEMM benchmark")
     parser.add_argument("--K", type=int, default=None)
-    parser.add_argument("--shape", type=int, nargs=3, action="append", metavar=("M", "N", "K"),
-                        help="Custom M N K shape (repeatable). Overrides default sizes.")
     parser.add_argument("--version", type=int, default=0, choices=range(0, 10))
+    parser.add_argument(
+        "--providers",
+        nargs="+",
+        choices=tuple(PROVIDER_LABELS),
+        default=None,
+        help="providers to benchmark; default: rocblas tlx",
+    )
+    parser.add_argument(
+        "--shape",
+        action="append",
+        type=parse_shape,
+        default=None,
+        help=("custom shape as MxNxK or M,N,K. Can be repeated. "
+              "The TLX provider requires tutorial tile-compatible shapes."),
+    )
+    parser.add_argument(
+        "--b-layout",
+        choices=("transposed", "contiguous"),
+        default="transposed",
+        help="layout used for B input; transposed matches the tutorial benchmark",
+    )
+    parser.add_argument(
+        "--input-mode",
+        choices=INPUT_MODES,
+        default="normal",
+        help=("input distribution; hpl and rand-int reproduce hipBLASLt seed-zero data, "
+              "and rand-int applies its alternating sign to B"),
+    )
+    parser.add_argument(
+        "--seed",
+        type=nonnegative_int,
+        default=DEFAULT_INPUT_SEED,
+        help=f"deterministic input seed; default: {DEFAULT_INPUT_SEED}",
+    )
+    parser.add_argument(
+        "--timing-mode",
+        choices=TIMING_MODES,
+        default="triton",
+        help=("triton records every launch and clears L2; batched records one event span "
+              "around many back-to-back launches"),
+    )
+    parser.add_argument(
+        "--rep",
+        "--rep-ms",
+        dest="rep",
+        type=positive_int,
+        default=200,
+        help="timed duration in milliseconds for --timing-mode=triton; default: 200",
+    )
+    parser.add_argument(
+        "--warmup",
+        "--warmup-ms",
+        dest="warmup",
+        type=nonnegative_int,
+        default=25,
+        help="warmup duration in milliseconds for --timing-mode=triton; default: 25",
+    )
+    parser.add_argument(
+        "--warmup-launches",
+        type=nonnegative_int,
+        default=DEFAULT_WARMUP_LAUNCHES,
+        help=("warmup launches before each batched timing repeat; "
+              f"default: {DEFAULT_WARMUP_LAUNCHES}"),
+    )
+    parser.add_argument(
+        "--timed-launches",
+        type=positive_int,
+        default=DEFAULT_TIMED_LAUNCHES,
+        help=f"launches in each batched event span; default: {DEFAULT_TIMED_LAUNCHES}",
+    )
+    parser.add_argument(
+        "--timing-repeats",
+        type=positive_int,
+        default=DEFAULT_TIMING_REPEATS,
+        help=f"batched timing samples whose median is reported; default: {DEFAULT_TIMING_REPEATS}",
+    )
+    # Larger reductions can differ from torch by one or two fp16 ulps. Keep the
+    # default tolerance aligned with that backend-independent drift.
+    parser.add_argument("--atol", type=float, default=3e-1)
+    parser.add_argument("--rtol", type=float, default=0.0)
+    parser.add_argument("--arch", default=None, help="optional Triton runtime arch override")
+    parser.add_argument("--cache-dir", default=None, help="optional Triton cache root")
+    parser.add_argument(
+        "--compile-workers",
+        type=nonnegative_int,
+        default=DEFAULT_COMPILE_WORKERS,
+        help=f"parallel workers for a precompile phase; 0 disables it; default: {DEFAULT_COMPILE_WORKERS}",
+    )
     args = parser.parse_args()
 
     version_dir = VERSION_MAP[args.version]
-    module = importlib.import_module(f"{version_dir}.matmul_kernel")
-    matmul = module.matmul
-
-    sizes = [tuple(s) for s in args.shape] if args.shape else get_x_vals()
+    providers = list(args.providers) if args.providers is not None else provider_defaults(args.version)
+    sizes = list(args.shape) if args.shape is not None else get_x_vals()
     if args.K:
         sizes = [(m, n, k) for m, n, k in sizes if k == args.K]
+    if not sizes:
+        raise SystemExit("no shapes selected")
+    try:
+        validate_shapes_for_providers(sizes, args.version, providers)
+    except argparse.ArgumentTypeError as exc:
+        parser.error(str(exc))
 
-    tflops = lambda ms, M, N, K: 2 * M * N * K * 1e-12 / (ms * 1e-3)
+    precompile_shapes(args, version_dir, providers, sizes)
 
-    # Correctness
+    device = triton.runtime.driver.active.get_active_torch_device()
+
+    if args.timing_mode == "triton":
+        timing_summary = f"triton median, {args.warmup}ms warmup/{args.rep}ms timed"
+    else:
+        timing_summary = (f"batched median, {args.timing_repeats}x"
+                          f"{args.timed_launches} timed launches, "
+                          f"{args.warmup_launches} warmups/repeat")
+    print(f"\n{version_dir} ({args.b_layout} B, input={args.input_mode}, seed={args.seed}; "
+          f"{timing_summary}):")
+    header = f"{'M':>6s} {'N':>6s} {'K':>6s}"
+    for provider in providers:
+        header += f"  {PROVIDER_LABELS[provider]:>17s}"
+    print(header)
+
     for M, N, K in sizes:
-        a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-        b = torch.randn((N, K), device=DEVICE, dtype=torch.float16).T
+        a, b = make_inputs(
+            M,
+            N,
+            K,
+            device,
+            args.b_layout,
+            input_mode=args.input_mode,
+            seed=args.seed,
+        )
         ref = torch.matmul(a, b)
-        c = matmul(a, b)
-        ok = torch.allclose(c, ref, atol=1e-1, rtol=0)
-        print(f"[{version_dir}] M={M} N={N} K={K}: {'OK' if ok else 'FAIL'}")
+        torch.cuda.synchronize()
 
-    # Performance
-    print(f"\n{version_dir}:")
-    print(f"{'M':>6s} {'N':>6s} {'K':>6s}  {'rocBLAS':>8s}  {'TLX':>8s}")
-    for M, N, K in sizes:
-        a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-        b = torch.randn((N, K), device=DEVICE, dtype=torch.float16).T
-        ms_ref = triton.testing.do_bench(lambda: torch.matmul(a, b), rep=200)
-        ms_tlx = triton.testing.do_bench(lambda: matmul(a, b), rep=200)
-        print(f"{M:6d} {N:6d} {K:6d}  {tflops(ms_ref,M,N,K):7.1f}T  {tflops(ms_tlx,M,N,K):7.1f}T")
+        row = f"{M:6d} {N:6d} {K:6d}"
+        for provider in providers:
+            try:
+                result = benchmark_provider(args, provider, version_dir, a, b, ref, M, N, K)
+            except Exception as exc:
+                result = {
+                    "ok": False,
+                    "max_err": None,
+                    "bad": None,
+                    "ms": None,
+                    "tflops": None,
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            if result["ok"]:
+                row += f"  {result['tflops']:8.1f}T/{result['ms']:6.3f}ms"
+            else:
+                row += f"  {'FAIL':>17s}"
+                if "error" in result:
+                    print(f"[{PROVIDER_LABELS[provider]}] M={M} N={N} K={K} failed: "
+                          f"{result['error']}")
+                else:
+                    print(f"[{PROVIDER_LABELS[provider]}] M={M} N={N} K={K} failed "
+                          f"correctness: max_err={result['max_err']}, bad={result['bad']}")
+        print(row, flush=True)
 
 
 if __name__ == "__main__":

--- a/third_party/tlx/tutorials/gfx9_gemm/f16_inputs.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/f16_inputs.py
@@ -1,0 +1,88 @@
+"""Deterministic input generation shared by the gfx9 f16 GEMM benchmarks."""
+
+import torch
+
+INPUT_MODES = ("normal", "hpl", "rand-int", "zero", "ones")
+DEFAULT_INPUT_SEED = 0
+
+_INPUT_INIT_CHUNK_ELEMENTS = 4 * 1024 * 1024
+_HIPBLASLT_RNG_SEED_STRIDE = 0x9E3779B9
+_UINT32_MAX = (1 << 32) - 1
+_LOGICAL_RSHIFT_17_MASK = (1 << (64 - 17)) - 1
+
+
+def _hipblaslt_random_u32(indices):
+    """Return hipBLASLt's deterministic pseudo_random_device value per index."""
+    state = indices * 1664525 + 1013904223
+    for _ in range(3):
+        logical_rshift_17 = (state >> 17) & _LOGICAL_RSHIFT_17_MASK
+        state = state ^ (state << 13) ^ logical_rshift_17 ^ (state << 5)
+    return state & _UINT32_MAX
+
+
+def _make_hipblaslt_input(rows, cols, device, input_mode, seed, *, checkerboard_sign=False):
+    """Build exact hipBLASLt HPL/rand_int data without large temporaries."""
+    result = torch.empty((rows, cols), device=device, dtype=torch.float16)
+    chunk_rows = max(1, _INPUT_INIT_CHUNK_ELEMENTS // cols)
+    seed_offset = seed * _HIPBLASLT_RNG_SEED_STRIDE
+    col_ids = None
+    if checkerboard_sign:
+        col_ids = torch.arange(cols, device=device, dtype=torch.int64)[None, :]
+
+    for row_begin in range(0, rows, chunk_rows):
+        row_end = min(rows, row_begin + chunk_rows)
+        flat_begin = row_begin * cols
+        flat_end = row_end * cols
+        indices = torch.arange(flat_begin, flat_end, device=device, dtype=torch.int64)
+        random_u32 = _hipblaslt_random_u32(indices + seed_offset)
+        if input_mode == "hpl":
+            values = random_u32.to(torch.float64) / float(_UINT32_MAX) - 0.5
+        else:
+            values = random_u32.remainder(5) - 2
+            if checkerboard_sign:
+                row_ids = torch.arange(row_begin, row_end, device=device, dtype=torch.int64)[:, None]
+                negate = ((row_ids ^ col_ids) & 1) == 0
+                values = values.reshape(row_end - row_begin, cols)
+                values = torch.where(negate, -values, values)
+        result[row_begin:row_end].copy_(values.reshape(row_end - row_begin, cols))
+    return result
+
+
+def _make_input_storage(rows, cols, device, input_mode, seed, generator, *, is_b=False):
+    if input_mode == "normal":
+        return torch.randn(
+            (rows, cols),
+            device=device,
+            dtype=torch.float16,
+            generator=generator,
+        )
+    if input_mode in {"hpl", "rand-int"}:
+        return _make_hipblaslt_input(
+            rows,
+            cols,
+            device,
+            input_mode,
+            seed,
+            checkerboard_sign=is_b and input_mode == "rand-int",
+        )
+    if input_mode == "zero":
+        return torch.zeros((rows, cols), device=device, dtype=torch.float16)
+    if input_mode == "ones":
+        return torch.ones((rows, cols), device=device, dtype=torch.float16)
+    raise ValueError(f"unsupported input mode: {input_mode}")
+
+
+def make_inputs(M, N, K, device, b_layout, input_mode="normal", seed=DEFAULT_INPUT_SEED):
+    """Create an MxK A and KxN B using one of the shared f16 input modes."""
+    generator = None
+    if input_mode == "normal":
+        generator = torch.Generator(device=device)
+        generator.manual_seed(seed)
+
+    a = _make_input_storage(M, K, device, input_mode, seed, generator)
+    if b_layout == "contiguous":
+        b = _make_input_storage(K, N, device, input_mode, seed, generator, is_b=True)
+    else:
+        b_storage = _make_input_storage(N, K, device, input_mode, seed, generator, is_b=True)
+        b = b_storage.T
+    return a, b

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/bench.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/bench.py
@@ -1,12 +1,43 @@
 """Correctness + do_bench TFLOPS harness for the 8-wave TLX GEMM (inter_wave port)."""
 
 import argparse
+import importlib.util
+from pathlib import Path
+
 import torch
 import triton
 
 from matmul_kernel import matmul, MIN_K, KERNEL_NAME
 
-DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+def _load_f16_inputs():
+    path = Path(__file__).resolve().parents[2] / "f16_inputs.py"
+    spec = importlib.util.spec_from_file_location("_tlx_gfx9_inter_wave_f16_inputs", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import f16 input helpers from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_f16_inputs = _load_f16_inputs()
+INPUT_MODES = _f16_inputs.INPUT_MODES
+DEFAULT_INPUT_SEED = _f16_inputs.DEFAULT_INPUT_SEED
+make_inputs = _f16_inputs.make_inputs
+
+
+def nonnegative_int(text):
+    value = int(text)
+    if value < 0:
+        raise argparse.ArgumentTypeError(f"expected a non-negative integer, got {text!r}")
+    return value
+
+
+def positive_int(text):
+    value = int(text)
+    if value <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {text!r}")
+    return value
 
 
 def get_x_vals():
@@ -22,6 +53,18 @@ def main():
     parser.add_argument("--K", type=int, default=None)
     parser.add_argument("--shape", type=int, nargs=3, action="append", metavar=("M", "N", "K"),
                         help="Custom M N K shape (repeatable). Overrides default sizes.")
+    parser.add_argument("--rep", type=positive_int, default=200, help="timed duration in milliseconds; default: 200")
+    parser.add_argument("--warmup", type=nonnegative_int, default=25,
+                        help="warmup duration in milliseconds; default: 25")
+    parser.add_argument(
+        "--input-mode",
+        choices=INPUT_MODES,
+        default="normal",
+        help=("input distribution; hpl and rand-int reproduce hipBLASLt seed-zero data, "
+              "and rand-int applies its alternating sign to B"),
+    )
+    parser.add_argument("--seed", type=nonnegative_int, default=DEFAULT_INPUT_SEED,
+                        help=f"deterministic input seed; default: {DEFAULT_INPUT_SEED}")
     args = parser.parse_args()
 
     sizes = [tuple(s) for s in args.shape] if args.shape else get_x_vals()
@@ -29,29 +72,46 @@ def main():
         sizes = [(m, n, k) for m, n, k in sizes if k == args.K]
 
     tflops = lambda ms, M, N, K: 2 * M * N * K * 1e-12 / (ms * 1e-3)
+    device = triton.runtime.driver.active.get_active_torch_device()
 
-    # Correctness
+    measurements = []
     for M, N, K in sizes:
         if K < MIN_K:
             print(f"[{KERNEL_NAME}] M={M} N={N} K={K}: SKIPPED (K < {MIN_K})")
             continue
-        a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-        b = torch.randn((N, K), device=DEVICE, dtype=torch.float16).T
+        a, b = make_inputs(
+            M,
+            N,
+            K,
+            device,
+            "transposed",
+            input_mode=args.input_mode,
+            seed=args.seed,
+        )
         ref = torch.matmul(a, b)
         c = matmul(a, b)
         ok = torch.allclose(c, ref, atol=1e-1, rtol=0)
         print(f"[{KERNEL_NAME}] M={M} N={N} K={K}: {'OK' if ok else 'FAIL'}")
-
-    # Performance
-    print(f"\n{KERNEL_NAME}:")
-    print(f"{'M':>6s} {'N':>6s} {'K':>6s}  {'rocBLAS':>8s}  {'TLX':>8s}")
-    for M, N, K in sizes:
-        if K < MIN_K:
+        if not ok:
             continue
-        a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
-        b = torch.randn((N, K), device=DEVICE, dtype=torch.float16).T
-        ms_ref = triton.testing.do_bench(lambda: torch.matmul(a, b), rep=200)
-        ms_tlx = triton.testing.do_bench(lambda: matmul(a, b), rep=200)
+        ms_ref = triton.testing.do_bench(
+            lambda: torch.matmul(a, b),
+            warmup=args.warmup,
+            rep=args.rep,
+            return_mode="median",
+        )
+        ms_tlx = triton.testing.do_bench(
+            lambda: matmul(a, b),
+            warmup=args.warmup,
+            rep=args.rep,
+            return_mode="median",
+        )
+        measurements.append((M, N, K, ms_ref, ms_tlx))
+
+    print(f"\n{KERNEL_NAME} (LLVM, input={args.input_mode}, seed={args.seed}; "
+          f"triton median, {args.warmup}ms warmup/{args.rep}ms timed):")
+    print(f"{'M':>6s} {'N':>6s} {'K':>6s}  {'rocBLAS':>8s}  {'TLX':>8s}")
+    for M, N, K, ms_ref, ms_tlx in measurements:
         print(f"{M:6d} {N:6d} {K:6d}  {tflops(ms_ref,M,N,K):7.1f}T  {tflops(ms_tlx,M,N,K):7.1f}T")
 
 


### PR DESCRIPTION
- modernize the existing gfx9 f16 GEMM v0-v9 benchmark harness with shape validation, reusable output buffers, parallel precompilation, and clearer reporting
- add shared deterministic input generation for normal, HPL, hipBLASLt-style integer, zero, and all-ones data with configurable seeds and B layouts
- support both Triton median timing and low-overhead batched event timing, and use the same inputs for correctness and performance measurements
- align the existing inter-wave LLVM benchmark with the shared input and timing methodology
- add focused tests for input reproducibility, launch behavior, timing, shape validation, and module loading