### PR TITLE
[TritonGPU] Use modular identities for NPOT layout conversion

### DIFF
--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -95,6 +95,10 @@ SmallVector<StringAttr> standardOutDimNames(MLIRContext *ctx, int rank);
 SmallVector<std::pair<StringAttr, int32_t>>
 standardOutDimPairs(MLIRContext *ctx, ArrayRef<int64_t> dstShape);
 
+// Use modular identity semantics for NPOT shapes.
+LinearLayout identity1DForShape(int32_t size, StringAttr inDim,
+                                StringAttr outDim);
+
 // Return an identity mapping from `inDimName` to the standard out dimensions,
 // with the dimensions sized according to the shape. The bases are sorted
 // according to `order`, with the most minor dimension first.

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -430,11 +430,10 @@ AMDMfmaEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   // tile. Instead of switching to the M dimension now, we continue extending
   // the layout along the remaining N dimension, and only then proceed along M,
   // following the tilesPerWarp configuration.
-  // If the N dimension is not large enough to span multiple CTA tiles (i.e.,
-  // the first argument is 0), an empty layout is created, so this identity
-  // layout will not introduce any new registers.
-  tileLayout *= LinearLayout::identity1D(
-      shape[nIndex] / (nDim * warpsPerCTAN * tilesPerWarpN), kRegister, dimN);
+  int64_t nTileSize = nDim * warpsPerCTAN * tilesPerWarpN;
+  int32_t nTileRepeats =
+      static_cast<int32_t>(llvm::divideCeil(shape[nIndex], nTileSize));
+  tileLayout *= identity1DForShape(nTileRepeats, kRegister, dimN);
   tileLayout *= LinearLayout::identity1D(tilesPerWarpM, kRegister, dimM);
 
   // Finally, extend the layout across warps in the M dimension.

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -193,6 +193,13 @@ standardOutDimPairs(MLIRContext *ctx, ArrayRef<int64_t> dstShape) {
 // Returns a 1D -> ND layout into [dim0, dim1, ...] that's equivalent to
 // creating a 1D -> 1D mapping of size product(shape) and then reshaping to
 // permute(shape, order).
+LinearLayout identity1DForShape(int32_t size, StringAttr inDim,
+                                StringAttr outDim) {
+  if (size == 0 || llvm::isPowerOf2_32(size))
+    return LinearLayout::identity1D(size, inDim, outDim);
+  return LinearLayout::modularIdentity1D(size, inDim, outDim);
+}
+
 LinearLayout identityStandardND(StringAttr inDimName, ArrayRef<unsigned> shape,
                                 ArrayRef<unsigned> order) {
   assert(shape.size() == order.size());
@@ -206,7 +213,7 @@ LinearLayout identityStandardND(StringAttr inDimName, ArrayRef<unsigned> shape,
   for (int i = 0; i < shape.size(); i++) {
     // Start with the most-minor dimension, which is order[0].
     int dim = order[i];
-    ret *= LinearLayout::identity1D(shape[dim], inDimName, outDimNames[dim]);
+    ret *= identity1DForShape(shape[dim], inDimName, outDimNames[dim]);
   }
   return ret;
 }

--- a/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
+++ b/unittest/Dialect/TritonGPU/LinearLayoutConversionsTest.cpp
@@ -163,6 +163,29 @@ TEST_F(LinearLayoutConversionsTest, SimpleBlocked) {
                           {S("dim0")}));
 }
 
+TEST_F(LinearLayoutConversionsTest, NpotFmaDotUsesModularIdentity) {
+  auto parent =
+      blocked({1, 1}, {1, 32}, {1, 4}, {1, 1}, {1, 1}, {1, 0}, {1, 0});
+  auto encoding = dot(parent, /*idx=*/0, /*kWidth=*/0);
+  auto layout = toLinearLayout({16, 96}, encoding);
+  auto pow2Cover = toLinearLayout({16, 128}, encoding);
+  auto expected =
+      LinearLayout(pow2Cover.getBases(), {{S("dim0"), 16}, {S("dim1"), 96}},
+                   /*requireSurjective=*/true);
+  EXPECT_EQ(layout, expected);
+}
+
+TEST_F(LinearLayoutConversionsTest, NpotMfmaUsesModularIdentity) {
+  auto encoding = mfma(/*version=*/4, /*warps=*/{4, 1},
+                       /*instrShape=*/{32, 32, 16}, /*isTransposed=*/false);
+  auto layout = toLinearLayout({128, 96}, encoding);
+  auto pow2Cover = toLinearLayout({128, 128}, encoding);
+  auto expected =
+      LinearLayout(pow2Cover.getBases(), {{S("dim0"), 128}, {S("dim1"), 96}},
+                   /*requireSurjective=*/true);
+  EXPECT_EQ(layout, expected);
+}
+
 TEST_F(LinearLayoutConversionsTest, CTADuplication) {
   auto layout = toLinearLayout(
       {32}, blocked({1}, {4}, {4}, /*cpg=*/{4}, /*cSplit=*/{2}, {0}, {0}));

--- a/unittest/Tools/LayoutUtilsTest.cpp
+++ b/unittest/Tools/LayoutUtilsTest.cpp
@@ -45,5 +45,12 @@ TEST_F(LayoutUtilsTest, SquareSublayoutIsIdentity) {
   EXPECT_TRUE(squareSublayoutIsIdentity(l3, {S("in1"), S("in2")}));
 }
 
+TEST_F(LayoutUtilsTest, IdentityStandardNDModular) {
+  auto actual = identityStandardND(S("in"), {4, 6}, {1, 0});
+  auto expected = LinearLayout::modularIdentity1D(6, S("in"), S("dim1")) *
+                  LinearLayout::identity1D(4, S("in"), S("dim0"));
+  EXPECT_EQ(actual, expected);
+}
+
 } // namespace
 } // namespace mlir::triton


### PR DESCRIPTION
Summary:
NPOT FMA dot and AMD MFMA layout conversion passed logical extents to the pow2-only LinearLayout::identity1D API. Optimized builds compiled out its assertion and happened to produce modular-compatible bases, while dev-assert builds exposed the invalid call.

Add a shape-aware identity helper that preserves the existing identity1D path for pow2 sizes and selects modularIdentity1D for NPOT sizes. Use it in identityStandardND and for MFMA tile repetitions, retaining true logical extents rather than rounding and relying on a later clamp. Add converter-level tests that compare the full NPOT layouts with their pow2 physical covers at the true modular output size.

Pow2 behavior remains on the existing identity1D path unchanged.

Reviewed By: agron911

Differential Revision: D113484189


