### PR TITLE
[Triton] Autotune POT and NPOT wave-quant tile frontiers (#2340)

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -7,7 +7,7 @@ import pytest
 import pathlib
 import uuid
 from triton._internal_testing import is_cuda, is_hip_cdna
-from triton.runtime import autotuner as _autotuner
+from triton.runtime import _wave_quant
 
 
 def do_bench(kernel_call, quantiles, use_cuda_graph=False):
@@ -657,32 +657,32 @@ def test_dump_best_config_ir(device, tmp_path):
         knobs.cache.dump_dir = original_dump_dir
 
 
-# --- NPOT autotuner: wave-quant candidate generation + bench-path prune gating ---
+# --- NPOT autotuner: resource-aware wave frontier + bench-path prune gating ---
 
 
 def test_wave_efficiency_and_pre_check():
     # Full waves -> 1.0; just over a boundary -> a near-empty trailing wave.
-    assert _autotuner._wave_efficiency(64, 64) == 1.0
-    assert _autotuner._wave_efficiency(65, 64) < 0.55
+    assert _wave_quant.wave_efficiency(64, 64) == 1.0
+    assert _wave_quant.wave_efficiency(65, 64) < 0.55
     # A cleanly-tiling pow2 shape yields no NPOT candidates (no autotune tax on POT shapes).
-    assert _autotuner._wave_quant_npot_candidates(128, 128, 1024, 1024, 64) == []
+    assert _wave_quant.wave_quant_npot_candidates(128, 128, 1024, 1024, 64) == []
     # A single-wave shape cannot be improved by re-tiling -> none, even when it underfills the wave.
-    assert _autotuner._wave_quant_npot_candidates(128, 128, 100, 100, 64) == []
+    assert _wave_quant.wave_quant_npot_candidates(128, 128, 100, 100, 64) == []
 
 
 def test_wave_quant_candidates_target_bad_tail():
     # 9x8 = 72 tiles over 64 units -> 2 waves, ~0.56 efficiency: a real wave-quant tail.
     M, N, U = 1152, 1024, 64
-    cands = _autotuner._wave_quant_npot_candidates(128, 128, M, N, U)
+    cands = _wave_quant.wave_quant_npot_candidates(128, 128, M, N, U)
     assert cands, "expected NPOT candidates for a bad wave tail"
-    pow2_tiles = _autotuner._cdiv(M, 128) * _autotuner._cdiv(N, 128)
-    pow2_waves = _autotuner._cdiv(pow2_tiles, U)
-    pow2_eff = _autotuner._wave_efficiency(pow2_tiles, U)
+    pow2_tiles = _wave_quant.cdiv(M, 128) * _wave_quant.cdiv(N, 128)
+    pow2_waves = _wave_quant.cdiv(pow2_tiles, U)
+    pow2_eff = _wave_quant.wave_efficiency(pow2_tiles, U)
     for bm, bn in cands:
         assert bm % 16 == 0 and bn % 16 == 0  # legal-snapped
-        tiles = _autotuner._cdiv(M, bm) * _autotuner._cdiv(N, bn)
-        waves = _autotuner._cdiv(tiles, U)
-        eff = _autotuner._wave_efficiency(tiles, U)
+        tiles = _wave_quant.cdiv(M, bm) * _wave_quant.cdiv(N, bn)
+        waves = _wave_quant.cdiv(tiles, U)
+        eff = _wave_quant.wave_efficiency(tiles, U)
         # every candidate strictly improves on (fewer waves, then higher efficiency)
         assert waves < pow2_waves or (waves == pow2_waves and eff > pow2_eff)
 
@@ -693,32 +693,236 @@ def test_generate_wave_quant_candidates_appends_npot_and_noop():
     try:
         triton.knobs.language.allow_npot = True
         # Clean shape -> unchanged (no tax). Unknown shape / no SMs -> no-op.
-        assert _autotuner._generate_wave_quant_candidates([base], {'M': 1024, 'N': 1024}, 64) == [base]
-        assert _autotuner._generate_wave_quant_candidates([base], {}, 64) == [base]
-        assert _autotuner._generate_wave_quant_candidates([base], {'M': 1152, 'N': 1024}, 0) == [base]
+        assert _wave_quant.generate_wave_quant_candidates([base], {'M': 1024, 'N': 1024}, 64) == [base]
+        assert _wave_quant.generate_wave_quant_candidates([base], {}, 64) == [base]
+        assert _wave_quant.generate_wave_quant_candidates([base], {'M': 1152, 'N': 1024}, 0) == [base]
         # Bad tail -> NPOT candidates appended; original preserved (and stays pow2).
-        out = _autotuner._generate_wave_quant_candidates([base], {'M': 1152, 'N': 1024}, 64)
+        out = _wave_quant.generate_wave_quant_candidates([base], {'M': 1152, 'N': 1024}, 64)
     finally:
         triton.knobs.language.allow_npot = prev
     assert base in out
-    assert not _autotuner._config_has_npot_block(base)
-    npot = [c for c in out if c is not base and _autotuner._config_has_npot_block(c)]
+    assert not _wave_quant.config_has_npot_block(base)
+    npot = [c for c in out if c is not base and _wave_quant.config_has_npot_block(c)]
     assert npot, "expected wave-quant NPOT candidates for a bad tail"
 
 
-def test_npot_runtime_error_prunable_gating():
+def test_wave_frontier_resource_model_changes_occupancy_and_rejects_over_budget():
+    limits = _wave_quant.WaveDeviceLimits(
+        num_sms=64,
+        max_shared_mem=232448,
+        max_num_regs=65536,
+        warp_size=32,
+        max_threads_per_sm=2048,
+    )
+    dims = {'M': 4096, 'N': 4096, 'K': 1024}
+    shallow = triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 64}, num_warps=4, num_stages=2)
+    deep = _wave_quant.clone_config(shallow)
+    deep.num_stages = 4
+    shallow_point = _wave_quant.estimate_wave_frontier_point(shallow, dims, limits)
+    deep_point = _wave_quant.estimate_wave_frontier_point(deep, dims, limits)
+    assert shallow_point is not None and deep_point is not None
+    assert shallow_point.shared_mem < deep_point.shared_mem
+    assert shallow_point.ctas_per_sm > deep_point.ctas_per_sm
+    assert shallow_point.wave_capacity > deep_point.wave_capacity
+    assert shallow_point.waves < deep_point.waves
+
+    clustered = triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 64}, num_warps=4, num_stages=2, num_ctas=2)
+    clustered_point = _wave_quant.estimate_wave_frontier_point(clustered, dims, limits)
+    assert clustered_point is not None
+    assert clustered_point.ctas_per_sm == shallow_point.ctas_per_sm
+    assert clustered_point.wave_capacity == shallow_point.wave_capacity // 2
+    assert clustered_point.waves == _wave_quant.cdiv(clustered_point.num_tiles, clustered_point.wave_capacity)
+
+    oversized = triton.Config({'BLOCK_M': 256, 'BLOCK_N': 256, 'BLOCK_K': 128}, num_warps=4, num_stages=3)
+    assert _wave_quant.estimate_wave_frontier_point(oversized, dims, limits) is None
+
+    block_limited = _wave_quant.WaveDeviceLimits(
+        num_sms=64,
+        max_shared_mem=232448,
+        max_num_regs=65536,
+        warp_size=32,
+        max_threads_per_sm=2048,
+        max_shared_mem_per_block=65536,
+        max_num_regs_per_block=65536,
+        max_ctas_per_sm=16,
+    )
+    # The shallow config fits the whole-SM budget but exceeds this per-block launch limit.
+    assert shallow_point.shared_mem < block_limited.max_shared_mem
+    assert _wave_quant.estimate_wave_frontier_point(shallow, dims, block_limited) is None
+
+
+def test_device_wave_limits_use_explicit_per_sm_properties(monkeypatch):
+    props = {
+        "multiprocessor_count": 120,
+        "max_shared_mem": 99000,
+        "max_shared_mem_per_sm": 228000,
+        "max_num_regs": 65536,
+        "max_num_regs_per_sm": 131072,
+        "warpSize": 32,
+        "max_threads_per_sm": 2048,
+        "max_blocks_per_sm": 24,
+    }
+
+    class Utils:
+
+        @staticmethod
+        def get_device_properties(device):
+            return props
+
+    class Active:
+        utils = Utils()
+
+        @staticmethod
+        def get_current_device():
+            return 0
+
+        @staticmethod
+        def get_current_target():
+            return type("Target", (), {"warp_size": 32})()
+
+    monkeypatch.setattr(_wave_quant, "driver", type("Driver", (), {"active": Active()})())
+    limits = _wave_quant.device_wave_limits()
+    assert limits is not None
+    assert limits.max_shared_mem == 228000
+    assert limits.max_shared_mem_per_block == 99000
+    assert limits.max_num_regs == 131072
+    assert limits.max_num_regs_per_block == 65536
+    del props["max_num_regs_per_sm"]
+    with pytest.warns(RuntimeWarning, match="wave-frontier generation disabled"):
+        assert _wave_quant.device_wave_limits() is None
+
+
+def test_coupled_wave_frontier_includes_pot_npot_and_stage_choices():
+    limits = _wave_quant.WaveDeviceLimits(
+        num_sms=64,
+        max_shared_mem=232448,
+        max_num_regs=65536,
+        warp_size=32,
+        max_threads_per_sm=2048,
+    )
+    dims = {'M': 1152, 'N': 1024, 'K': 1024}
+    base = triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 128}, num_warps=4, num_stages=3)
+    base_point = _wave_quant.estimate_wave_frontier_point(base, dims, limits)
+    frontier = _wave_quant.coupled_wave_frontier(base, dims, limits, allow_npot=True)
+
+    assert base_point is not None and frontier
+    assert len(frontier) <= _wave_quant.MAX_GENERATED_CANDIDATES
+    assert any(not _wave_quant.config_has_npot_block(config) and (config.kwargs['BLOCK_M'],
+                                                                  config.kwargs['BLOCK_N']) != (128, 128)
+               for config in frontier)
+    assert any(_wave_quant.config_has_npot_block(config) for config in frontier)
+    assert any(config.num_stages > base.num_stages for config in frontier)
+    assert sum(_wave_quant.config_has_npot_block(config) for config in frontier) <= _wave_quant.MAX_NPOT_CANDIDATES
+    stages_by_tile = {}
+    for config in frontier:
+        tile = tuple(config.kwargs[name] for name in ('BLOCK_M', 'BLOCK_N', 'BLOCK_K'))
+        stages_by_tile.setdefault(tile, set()).add(config.num_stages)
+    assert any(len(stages) > 1 for stages in stages_by_tile.values())
+    for config in frontier:
+        assert all(config.kwargs[name] % 16 == 0 for name in ('BLOCK_M', 'BLOCK_N', 'BLOCK_K'))
+        point = _wave_quant.estimate_wave_frontier_point(config, dims, limits)
+        assert point is not None
+        assert point.shared_mem <= limits.max_shared_mem
+        assert point.registers <= limits.max_num_regs
+        assert point.estimated_cost < base_point.estimated_cost
+
+
+def test_generate_coupled_frontier_gates_only_npot_blocks_and_skips_clean_wave():
+    limits = _wave_quant.WaveDeviceLimits(
+        num_sms=64,
+        max_shared_mem=232448,
+        max_num_regs=65536,
+        warp_size=32,
+        max_threads_per_sm=2048,
+    )
+    base = triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 128}, num_warps=4, num_stages=3)
+    prev = triton.knobs.language.allow_npot
+    try:
+        triton.knobs.language.allow_npot = False
+        pot_only = _wave_quant.generate_wave_quant_candidates([base], {'M': 1152, 'N': 1024, 'K': 1024}, limits)
+        assert len(pot_only) > 1
+        assert all(not _wave_quant.config_has_npot_block(config) for config in pot_only)
+        # 64 tiles at modeled occupancy one is a full wave.
+        assert _wave_quant.generate_wave_quant_candidates([base], {'M': 1024, 'N': 1024, 'K': 1024}, limits) == [base]
+        triton.knobs.language.allow_npot = True
+        expanded = _wave_quant.generate_wave_quant_candidates([base], {'M': 1152, 'N': 1024, 'K': 1024}, limits)
+        seeds = [
+            base,
+            triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 64}, num_warps=8, num_stages=2),
+            triton.Config({'BLOCK_M': 64, 'BLOCK_N': 128, 'BLOCK_K': 64}, num_warps=4, num_stages=2),
+        ]
+        multi_seed = _wave_quant.generate_wave_quant_candidates(seeds, {'M': 1152, 'N': 1024, 'K': 1024}, limits)
+    finally:
+        triton.knobs.language.allow_npot = prev
+    assert len(expanded) > 1
+    assert len(expanded) <= 1 + _wave_quant.MAX_GENERATED_CANDIDATES
+    assert any(_wave_quant.config_has_npot_block(config) for config in expanded)
+    assert sum(_wave_quant.config_has_npot_block(config) for config in expanded) == 1
+    assert len(multi_seed) <= len(seeds) + _wave_quant.MAX_GENERATED_CANDIDATES
+    assert any(_wave_quant.config_has_npot_block(config) for config in multi_seed)
+
+
+def test_single_seed_include_npot_benchmarks_generated_frontier(device, monkeypatch):
+    base = triton.Config({'BLOCK_SIZE': 16})
+    alternative = triton.Config({'BLOCK_SIZE': 32})
+
+    @triton.autotune(configs=[base], key=['N'], include_npot=True)
+    @triton.jit
+    def kernel(out, N, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.arange(0, BLOCK_SIZE)
+        tl.store(out + offsets, offsets, mask=offsets < N)
+
+    monkeypatch.setattr(kernel, '_add_wave_quant_npot_configs', lambda configs, named_args: [base, alternative])
+    benchmarked = []
+
+    def fake_bench(*args, config, **kwargs):
+        benchmarked.append(config)
+        value = 1.0 if config is alternative else 2.0
+        return [value, value, value]
+
+    monkeypatch.setattr(kernel, '_bench', fake_bench)
+    out = torch.empty(16, device=device, dtype=torch.int32)
+    previous = triton.knobs.language.allow_npot
+    try:
+        triton.knobs.language.allow_npot = True
+        kernel[(1, )](out, 16)
+    finally:
+        triton.knobs.language.allow_npot = previous
+
+    assert benchmarked == [base, alternative]
+    assert kernel.best_config is alternative
+
+
+def test_npot_compile_error_prunable_requires_generated_provenance():
     pow2_cfg = triton.Config(kwargs={'BLOCK_M': 128})
-    npot_cfg = _autotuner._clone_config(pow2_cfg, BLOCK_M=96)
-    # A pow2 config must re-raise even a device error (never be masked).
-    assert _autotuner._npot_runtime_error_prunable(pow2_cfg, RuntimeError("Triton Error [CUDA]: out of memory"),
-                                                   allow_npot=True) is False
-    # An NPOT config under the flag is prunable on a device failure -- case-insensitively and across
-    # both backends (CUDA and HIP).
+    npot_cfg = _wave_quant.clone_config(pow2_cfg, BLOCK_M=96)
+    generated = _wave_quant.mark_generated_config(_wave_quant.clone_config(pow2_cfg, BLOCK_M=96))
+    unmarked = _wave_quant.clone_config(pow2_cfg, BLOCK_M=96)
+    marked = _wave_quant.mark_generated_config(unmarked)
+    assert marked is not unmarked
+    assert _wave_quant.is_generated_config(marked)
+    assert not _wave_quant.is_generated_config(unmarked)
+    assert _wave_quant.npot_compile_error_prunable(npot_cfg,
+                                                   RuntimeError("Number of elements must be power-of-two")) is False
+    assert _wave_quant.npot_compile_error_prunable(pow2_cfg,
+                                                   RuntimeError("Number of elements must be power-of-two")) is False
+    # Runtime/device failures always propagate, including for generated candidates.
     for msg in ("Triton Error [CUDA]: misaligned address", "Triton Error [HIP]: out of memory range.", "Out Of Memory",
-                "an illegal memory access was encountered"):
-        assert _autotuner._npot_runtime_error_prunable(npot_cfg, RuntimeError(msg), allow_npot=True) is True
-    # Flag off, or a non-device RuntimeError -> re-raise.
-    assert _autotuner._npot_runtime_error_prunable(npot_cfg, RuntimeError("Triton Error [CUDA]: x"),
-                                                   allow_npot=False) is False
-    assert _autotuner._npot_runtime_error_prunable(npot_cfg, RuntimeError("invalid config value"),
-                                                   allow_npot=True) is False
+                "an illegal memory access was encountered", "device-side assert"):
+        assert _wave_quant.npot_compile_error_prunable(generated, RuntimeError(msg)) is False
+    # Only explicit backend compile-legality rejects are prunable.
+    assert _wave_quant.npot_compile_error_prunable(
+        generated,
+        RuntimeError("Number of elements must be power-of-two, but tt.make_range has 112 elements"),
+    ) is True
+    assert _wave_quant.npot_compile_error_prunable(
+        generated,
+        RuntimeError("NPOT layout not yet supported: tensor shape 112, 48"),
+    ) is True
+    assert _wave_quant.npot_compile_error_prunable(
+        generated,
+        RuntimeError("Layout has 128 threads per warp, but the module specifies 64 threads per warp"),
+    ) is True
+    assert _wave_quant.npot_compile_error_prunable(generated, IndexError("map::at")) is True
+    assert _wave_quant.npot_compile_error_prunable(generated, IndexError("list index out of range")) is False
+    assert _wave_quant.npot_compile_error_prunable(generated, RuntimeError("invalid config value")) is False

--- a/python/triton/runtime/_wave_quant.py
+++ b/python/triton/runtime/_wave_quant.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import copy
+import warnings
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from .. import knobs
+from .driver import driver
+
+
+def is_pow2(value):
+    return value > 0 and (value & (value - 1)) == 0
+
+
+def cdiv(lhs, rhs):
+    return -(-lhs // rhs)
+
+
+def clone_config(config, **kwargs_override):
+    """Clone a Config while carrying fields added by future Triton versions."""
+    new_config = copy.copy(config)
+    new_config.kwargs = {**config.kwargs, **kwargs_override}
+    return new_config
+
+
+def config_has_npot_block(config):
+    """True if any of the config's BLOCK_* tile sizes is non-power-of-2."""
+    return any(
+        isinstance(value, int) and not is_pow2(value)
+        for name, value in config.kwargs.items()
+        if "BLOCK" in name.upper())
+
+
+# Generated candidates are speculative. Provenance is stored only on a cloned Config so
+# user-provided NPOT configs never inherit the speculative failure policy.
+_GENERATED_CONFIG_ATTR = "_wave_quant_generated"
+_NPOT_COMPILE_REJECT_MARKERS = (
+    "number of elements must be power-of-two",
+    "number of elements must be a power of two",
+    "npot layout not yet supported",
+    "threads per warp, but the module specifies",
+    "map::at",
+)
+
+
+def mark_generated_config(config):
+    generated = clone_config(config)
+    setattr(generated, _GENERATED_CONFIG_ATTR, True)
+    return generated
+
+
+def is_generated_config(config):
+    return getattr(config, _GENERATED_CONFIG_ATTR, False) is True
+
+
+def npot_compile_error_prunable(config, error):
+    """Whether a speculative NPOT config hit a known compile-legality rejection."""
+    if not (is_generated_config(config) and config_has_npot_block(config)):
+        return False
+    text = str(error).strip().lower()
+    if isinstance(error, IndexError):
+        return text == "map::at"
+    return isinstance(error, RuntimeError) and any(marker in text for marker in _NPOT_COMPILE_REJECT_MARKERS)
+
+
+def wave_efficiency(num_tiles, num_units):
+    """Useful work fraction: tiles / (waves * units)."""
+    if num_tiles <= 0 or num_units <= 0:
+        return 1.0
+    waves = cdiv(num_tiles, num_units)
+    return num_tiles / (waves * num_units)
+
+
+def legal_npot_blocks(base, legal_multiple):
+    """Legal NPOT multiples in [base / 2, base * 2], excluding base and powers of two."""
+    lo = max(legal_multiple, base // 2)
+    hi = base * 2
+    value = lo + ((legal_multiple - lo % legal_multiple) % legal_multiple)
+    out = []
+    while value <= hi:
+        if value != base and not is_pow2(value):
+            out.append(value)
+        value += legal_multiple
+    return out
+
+
+# Only intervene when the base tiling spans more than one wave and wastes at least 10% of the
+# available wave slots. Existing seed configs do not count against the generated-candidate cap.
+WAVE_EFFICIENCY_THRESHOLD = 0.9
+MAX_GENERATED_CANDIDATES = 4
+MAX_NPOT_CANDIDATES = 1
+MAX_NPOT_VALUES_PER_DIM = 4
+MAX_PIPELINE_STAGES = 8
+GEMM_SMEM_OVERHEAD = 1024
+GEMM_BASE_REGS_PER_THREAD = 16
+
+
+@dataclass(frozen=True)
+class WaveDeviceLimits:
+    num_sms: int
+    # These two fields are whole-SM/CU budgets used to estimate residency.
+    max_shared_mem: int
+    max_num_regs: int
+    warp_size: int
+    max_threads_per_sm: int
+    # Per-block limits reject candidates that cannot launch even when the SM/CU has room overall.
+    max_shared_mem_per_block: Optional[int] = None
+    max_num_regs_per_block: Optional[int] = None
+    max_ctas_per_sm: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class WaveFrontierPoint:
+    config: Any
+    num_tiles: int
+    ctas_per_sm: int
+    wave_capacity: int
+    waves: int
+    wave_efficiency: float
+    shared_mem: int
+    registers: int
+    estimated_cost: float
+
+
+def wave_quant_npot_candidates(base_m, base_n, problem_m, problem_n, num_units, legal_m=16, legal_n=16):
+    """Return legal NPOT spatial tiles that improve wave count, then wave efficiency."""
+    if not (base_m and base_n and problem_m and problem_n and num_units):
+        return []
+    base_tiles = cdiv(problem_m, base_m) * cdiv(problem_n, base_n)
+    base_waves = cdiv(base_tiles, num_units)
+    base_efficiency = base_tiles / (base_waves * num_units)
+    if base_waves <= 1 or base_efficiency >= WAVE_EFFICIENCY_THRESHOLD:
+        return []
+
+    scored = []
+    for block_m in [base_m] + legal_npot_blocks(base_m, legal_m):
+        for block_n in [base_n] + legal_npot_blocks(base_n, legal_n):
+            if block_m == base_m and block_n == base_n:
+                continue
+            tiles = cdiv(problem_m, block_m) * cdiv(problem_n, block_n)
+            waves = cdiv(tiles, num_units)
+            efficiency = tiles / (waves * num_units)
+            if waves < base_waves or (waves == base_waves and efficiency > base_efficiency):
+                scored.append(((waves, -efficiency), (block_m, block_n)))
+
+    scored.sort(key=lambda item: item[0])
+    out = []
+    for _, pair in scored:
+        if pair not in out:
+            out.append(pair)
+        if len(out) >= MAX_NPOT_CANDIDATES:
+            break
+    return out
+
+
+def frontier_block_values(base, legal_multiple, allow_npot):
+    pot_values = [
+        value for value in (base // 2, base * 2)
+        if value >= legal_multiple and value % legal_multiple == 0 and is_pow2(value)
+    ]
+    npot_values = legal_npot_blocks(base, legal_multiple) if allow_npot else []
+    npot_values.sort(key=lambda value: (abs(value - base), value))
+    return [base] + pot_values + npot_values[:MAX_NPOT_VALUES_PER_DIM]
+
+
+def estimate_wave_frontier_point(config, problem_dims, limits, element_bytes=2):
+    """Estimate GEMM resource use, residency, and wave cost for one config."""
+    block_m = config.kwargs.get("BLOCK_M")
+    block_n = config.kwargs.get("BLOCK_N")
+    block_k = config.kwargs.get("BLOCK_K")
+    problem_m = problem_dims.get("M")
+    problem_n = problem_dims.get("N")
+    problem_k = problem_dims.get("K")
+    if not all(
+            isinstance(value, int) and value > 0
+            for value in (block_m, block_n, block_k, problem_m, problem_n, problem_k)):
+        return None
+
+    num_warps = config.num_warps
+    num_stages = config.num_stages
+    num_ctas = config.num_ctas
+    if not all(isinstance(value, int) and value > 0 for value in (num_warps, num_stages, num_ctas)):
+        return None
+
+    threads = num_warps * limits.warp_size
+    if threads > limits.max_threads_per_sm:
+        return None
+
+    # A/B pipeline buffers do not coexist with the output staging buffer. The accumulator plus a
+    # small per-thread baseline dominate registers. Compilation remains the final resource arbiter.
+    operand_smem = (block_m * block_k + block_n * block_k) * element_bytes * num_stages
+    output_smem = block_m * block_n * element_bytes
+    shared_mem = max(operand_smem, output_smem) + GEMM_SMEM_OVERHEAD
+    registers = block_m * block_n + GEMM_BASE_REGS_PER_THREAD * threads
+    regs_per_thread = cdiv(registers, threads)
+    block_shared_limit = limits.max_shared_mem_per_block or limits.max_shared_mem
+    block_register_limit = limits.max_num_regs_per_block or limits.max_num_regs
+    if shared_mem > block_shared_limit or registers > block_register_limit:
+        return None
+    if limits.warp_size == 32 and regs_per_thread > 256:
+        return None
+
+    residency_limits = [
+        limits.max_shared_mem // shared_mem,
+        limits.max_num_regs // registers,
+        limits.max_threads_per_sm // threads,
+    ]
+    if limits.max_ctas_per_sm is not None:
+        residency_limits.append(limits.max_ctas_per_sm)
+    ctas_per_sm = min(residency_limits)
+    if ctas_per_sm <= 0:
+        return None
+
+    num_tiles = cdiv(problem_m, block_m) * cdiv(problem_n, block_n)
+    resident_ctas = limits.num_sms * ctas_per_sm
+    if resident_ctas < num_ctas:
+        return None
+    wave_capacity = resident_ctas // num_ctas
+    waves = cdiv(num_tiles, wave_capacity)
+    efficiency = wave_efficiency(num_tiles, wave_capacity)
+
+    padded_k = cdiv(problem_k, block_k) * block_k
+    padded_work = num_tiles * block_m * block_n * padded_k
+    pipeline_gain = 1.0 + 0.06 * min(num_stages - 1, 4)
+    residency_gain = 1.0 + 0.04 * min(ctas_per_sm - 1, 3)
+    loop_penalty = 1.0 + 0.015 * cdiv(problem_k, block_k)
+    tile_scale = min(block_m, 128) / 128 * min(block_n, 128) / 128
+    tile_efficiency = 0.75 + 0.25 * tile_scale
+    estimated_cost = padded_work * loop_penalty / (efficiency * pipeline_gain * residency_gain * tile_efficiency)
+    return WaveFrontierPoint(
+        config,
+        num_tiles,
+        ctas_per_sm,
+        wave_capacity,
+        waves,
+        efficiency,
+        shared_mem,
+        registers,
+        estimated_cost,
+    )
+
+
+def point_dominates(lhs, rhs):
+    lhs_metrics = (lhs.estimated_cost, lhs.shared_mem, lhs.registers, lhs.waves)
+    rhs_metrics = (rhs.estimated_cost, rhs.shared_mem, rhs.registers, rhs.waves)
+    return all(a <= b for a, b in zip(lhs_metrics, rhs_metrics)) and any(a < b
+                                                                         for a, b in zip(lhs_metrics, rhs_metrics))
+
+
+def coupled_wave_frontier(
+    config,
+    problem_dims,
+    limits,
+    element_bytes=2,
+    legal_m=16,
+    legal_n=16,
+    legal_k=16,
+    allow_npot=False,
+):
+    """Return a bounded POT/NPOT Pareto set over tiles and pipeline depth."""
+    if config_has_npot_block(config):
+        return []
+    base = estimate_wave_frontier_point(config, problem_dims, limits, element_bytes)
+    if base is None or base.wave_efficiency >= WAVE_EFFICIENCY_THRESHOLD:
+        return []
+    if base.waves <= 1 and base.num_tiles < max(2, limits.num_sms // 2):
+        return []
+
+    block_m = config.kwargs["BLOCK_M"]
+    block_n = config.kwargs["BLOCK_N"]
+    block_k = config.kwargs["BLOCK_K"]
+    stages = sorted({
+        max(1, config.num_stages - 1),
+        config.num_stages,
+        min(MAX_PIPELINE_STAGES, config.num_stages + 1),
+    })
+    points = []
+    for next_m in frontier_block_values(block_m, legal_m, allow_npot):
+        for next_n in frontier_block_values(block_n, legal_n, allow_npot):
+            for next_k in frontier_block_values(block_k, legal_k, allow_npot):
+                for num_stages in stages:
+                    if (next_m, next_n, next_k, num_stages) == (
+                            block_m,
+                            block_n,
+                            block_k,
+                            config.num_stages,
+                    ):
+                        continue
+                    candidate = clone_config(config, BLOCK_M=next_m, BLOCK_N=next_n, BLOCK_K=next_k)
+                    candidate.num_stages = num_stages
+                    point = estimate_wave_frontier_point(candidate, problem_dims, limits, element_bytes)
+                    if point is not None and point.estimated_cost < base.estimated_cost * 0.995:
+                        points.append(point)
+
+    frontier = [
+        point for point in points if not any(point_dominates(other, point) for other in points if other is not point)
+    ]
+    frontier.sort(key=lambda point: (
+        point.estimated_cost,
+        point.waves,
+        -point.wave_efficiency,
+        -point.config.num_stages,
+        point.shared_mem,
+        point.registers,
+    ))
+    required = []
+
+    def add_first(predicate):
+        point = next((candidate for candidate in frontier if predicate(candidate)), None)
+        if point is not None and point not in required:
+            required.append(point)
+
+    add_first(lambda point: not config_has_npot_block(point.config) and
+              (point.config.kwargs["BLOCK_M"], point.config.kwargs["BLOCK_N"]) != (block_m, block_n))
+    add_first(lambda point: config_has_npot_block(point.config))
+    add_first(lambda point: point.config.num_stages > config.num_stages)
+
+    selected = []
+    for point in required + frontier:
+        if config_has_npot_block(point.config) and sum(
+                config_has_npot_block(candidate.config) for candidate in selected) >= MAX_NPOT_CANDIDATES:
+            continue
+        if point not in selected:
+            selected.append(point)
+        if len(selected) >= MAX_GENERATED_CANDIDATES:
+            break
+    selected.sort(key=lambda point: (point.estimated_cost, point.waves, -point.wave_efficiency))
+    return [point.config for point in selected]
+
+
+def fixed_occupancy_limits(num_units):
+    """Compatibility model for phase-one callers that provide only a unit count."""
+    unbounded = 1 << 60
+    return WaveDeviceLimits(num_units, unbounded, unbounded, 32, unbounded, max_ctas_per_sm=1)
+
+
+def generate_wave_quant_candidates(configs, problem_dims, limits_or_units, element_bytes=2):
+    """Append up to four candidates from resource limits or a compatibility unit count."""
+    if not limits_or_units:
+        return configs
+    problem_m = problem_dims.get("M")
+    problem_n = problem_dims.get("N")
+    if not (isinstance(problem_m, int) and isinstance(problem_n, int)):
+        return configs
+    limits = fixed_occupancy_limits(limits_or_units) if isinstance(limits_or_units, int) else limits_or_units
+    expanded = list(configs)
+    generated = []
+    for config in configs:
+        block_m = config.kwargs.get("BLOCK_M")
+        block_n = config.kwargs.get("BLOCK_N")
+        if not (isinstance(block_m, int) and isinstance(block_n, int)):
+            continue
+        if isinstance(config.kwargs.get("BLOCK_K"), int) and isinstance(problem_dims.get("K"), int):
+            candidates = coupled_wave_frontier(
+                config,
+                problem_dims,
+                limits,
+                element_bytes,
+                allow_npot=knobs.language.allow_npot,
+            )
+        else:
+            pairs = (wave_quant_npot_candidates(block_m, block_n, problem_m, problem_n, limits.num_sms)
+                     if knobs.language.allow_npot else [])
+            candidates = [clone_config(config, BLOCK_M=next_m, BLOCK_N=next_n) for next_m, next_n in pairs]
+        for candidate in candidates:
+            if candidate in expanded or any(candidate == existing for existing, _ in generated):
+                continue
+            point = estimate_wave_frontier_point(candidate, problem_dims, limits, element_bytes)
+            if point is not None:
+                rank = (
+                    point.estimated_cost,
+                    point.waves,
+                    -point.wave_efficiency,
+                    point.shared_mem,
+                    point.registers,
+                )
+            else:
+                candidate_m = candidate.kwargs["BLOCK_M"]
+                candidate_n = candidate.kwargs["BLOCK_N"]
+                tiles = cdiv(problem_m, candidate_m) * cdiv(problem_n, candidate_n)
+                waves = cdiv(tiles, limits.num_sms)
+                efficiency = wave_efficiency(tiles, limits.num_sms)
+                rank = (tiles * candidate_m * candidate_n / efficiency, waves, -efficiency, 0, 0)
+            generated.append((candidate, rank))
+
+    generated.sort(key=lambda item: item[1])
+    ordered = [candidate for candidate, _ in generated]
+    selected = []
+
+    def add_first(predicate):
+        candidate = next((config for config in ordered if predicate(config)), None)
+        if candidate is not None and candidate not in selected:
+            selected.append(candidate)
+
+    add_first(lambda config: not config_has_npot_block(config))
+    if knobs.language.allow_npot:
+        add_first(config_has_npot_block)
+    for candidate in ordered:
+        if config_has_npot_block(candidate) and sum(config_has_npot_block(config)
+                                                    for config in selected) >= MAX_NPOT_CANDIDATES:
+            continue
+        if candidate not in selected:
+            selected.append(candidate)
+        if len(selected) >= MAX_GENERATED_CANDIDATES:
+            break
+    selected = selected[:MAX_GENERATED_CANDIDATES]
+    selected = [mark_generated_config(candidate) for candidate in selected]
+    expanded.extend(selected)
+    return expanded
+
+
+def device_wave_limits():
+    """Read exact per-block and per-SM/CU resource limits; return None if unavailable."""
+    try:
+        device = driver.active.get_current_device()
+        props = driver.active.utils.get_device_properties(device)
+        warp_size = props.get("warpSize")
+        if warp_size is None:
+            warp_size = driver.active.get_current_target().warp_size
+        limits = WaveDeviceLimits(
+            num_sms=int(props["multiprocessor_count"]),
+            max_shared_mem=int(props["max_shared_mem_per_sm"]),
+            max_num_regs=int(props["max_num_regs_per_sm"]),
+            warp_size=int(warp_size),
+            max_threads_per_sm=int(props["max_threads_per_sm"]),
+            max_shared_mem_per_block=int(props["max_shared_mem"]),
+            max_num_regs_per_block=int(props["max_num_regs"]),
+            max_ctas_per_sm=int(props["max_blocks_per_sm"]),
+        )
+        values = (
+            limits.num_sms,
+            limits.max_shared_mem,
+            limits.max_num_regs,
+            limits.warp_size,
+            limits.max_threads_per_sm,
+            limits.max_shared_mem_per_block,
+            limits.max_num_regs_per_block,
+            limits.max_ctas_per_sm,
+        )
+        return limits if all(value is not None and value > 0 for value in values) else None
+    except (AttributeError, KeyError, RuntimeError, TypeError, ValueError) as error:
+        warnings.warn(f"wave-frontier generation disabled: incomplete device limits ({error})", RuntimeWarning,
+                      stacklevel=2)
+        return None
+
+
+def problem_element_bytes(named_args):
+    """Best-effort input element width; two bytes is the conservative GEMM default."""
+    for value in named_args.values():
+        element_size = getattr(value, "element_size", None)
+        if callable(element_size):
+            try:
+                size = int(element_size())
+                if 0 < size <= 16:
+                    return size
+            except (TypeError, ValueError):
+                pass
+    return 2

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import builtins
-import copy
 import math
 import time
 import inspect
@@ -17,6 +16,7 @@ from .jit import KernelInterface, JITFunction, _compile_iq_suppress_competition
 from .errors import OutOfResources, PTXASError, AutotunerError
 from .driver import driver
 from .cache import get_cache_manager, triton_key
+from . import _wave_quant
 
 try:
     from triton._C.libtriton import native_create_autotune_proxy, native_autotune_proxy_insert, native_autotune_proxy_set_grid
@@ -531,12 +531,12 @@ class Autotuner(KernelInterface):
             if verbose:
                 print(f"Autotuning failed with {e}")
             return [float("inf"), float("inf"), float("inf")]
-        except RuntimeError as e:
-            # Prune an NPOT candidate to inf if it hit a device compile/launch failure so the sweep
-            # continues; pow2 configs (and non-device errors) re-raise.
-            if _npot_runtime_error_prunable(config, e, knobs.language.allow_npot):
+        except (RuntimeError, IndexError) as e:
+            # Only speculative frontier configs may turn a known compile-legality reject into inf.
+            # User configs and all device/runtime failures propagate.
+            if _wave_quant.npot_compile_error_prunable(config, e):
                 if verbose:
-                    print(f"Autotuning pruned NPOT config after runtime error: {e}")
+                    print(f"Autotuning pruned generated NPOT config after compile rejection: {e}")
                 return [float("inf"), float("inf"), float("inf")]
             raise
         self._last_compiled_kernel = captured[-1] if captured else None
@@ -772,7 +772,11 @@ class Autotuner(KernelInterface):
     def run(self, *args, **kwargs):
         self.nargs = dict(zip(self.arg_names, args))
         used_cached_result = True
-        if len(self.configs) > 1:
+        allow_npot = knobs.language.allow_npot
+        wave_quant = allow_npot and getattr(self, "include_npot", False)
+        # An opted-in single seed can expand into a bounded wave frontier, so it must take the
+        # tuning path rather than the legacy one-config fast path.
+        if len(self.configs) > 1 or wave_quant:
             all_args = {**self.nargs, **kwargs}
             _args = {k: v for (k, v) in all_args.items() if k in self.arg_names}
             # Keep self.nargs as positional-only named args (the contract
@@ -788,8 +792,8 @@ class Autotuner(KernelInterface):
             key = tuple(key)
             if key not in self.cache:
                 used_cached_result = False
-                if getattr(self, "include_npot", False) and knobs.language.allow_npot:
-                    # Prune the NPOT-augmented list via the helper (keeps prune_configs 1-arg).
+                if wave_quant:
+                    # Prune the wave-frontier-augmented list via the helper (keeps prune_configs 1-arg).
                     configs = self._add_wave_quant_npot_configs(self.configs, _args)
                     pruned_configs = self._prune_configs(kwargs, configs)
                 else:
@@ -912,17 +916,20 @@ class Autotuner(KernelInterface):
         return ret
 
     def _add_wave_quant_npot_configs(self, configs, named_args):
-        """Append wave-quant NPOT BLOCK_M/N candidates at tune time. No-op on missing shape/SMs or exception."""
-        try:
-            # Spatial grid dims are M and N; the reduction dim K is a loop, not a grid dim.
-            problem_dims = {d: named_args.get(d) for d in ("M", "N") if isinstance(named_args.get(d), int)}
-            if len(problem_dims) < 2:
-                return configs
-            # SM count on NVIDIA / CU count on AMD; None on backends that don't report it, which
-            # makes _generate_wave_quant_candidates a no-op. ctas_per_sm is estimated as 1.
-            return _generate_wave_quant_candidates(configs, problem_dims, _device_num_sms())
-        except Exception:
+        """Append POT/NPOT GEMM candidates at tune time.
+
+        M/N/K problems use the resource-constrained coupled frontier. Legacy kernels that expose
+        only M/N retain the BLOCK_M/BLOCK_N compatibility fallback and do not vary BLOCK_K or
+        ``num_stages``.
+        """
+        problem_dims = {d: named_args.get(d) for d in ("M", "N", "K") if isinstance(named_args.get(d), int)}
+        if not all(d in problem_dims for d in ("M", "N")):
             return configs
+        limits = _wave_quant.device_wave_limits()
+        if limits is None:
+            return configs
+        return _wave_quant.generate_wave_quant_candidates(configs, problem_dims, limits,
+                                                          _wave_quant.problem_element_bytes(named_args))
 
     def _ir_prune_after_bench(self, configs: List[Config], timings: Dict, compiled: Dict) -> None:
         """Apply ``ir_config_prune`` after benchmarking, reusing each config's already-compiled
@@ -1176,144 +1183,6 @@ class Config:
         return self_tuple == other_tuple
 
 
-def _is_pow2(x):
-    return x > 0 and (x & (x - 1)) == 0
-
-
-def _cdiv(a, b):
-    return -(-a // b)
-
-
-def _clone_config(config, **kwargs_override):
-    """Clone a Config with kwargs overrides; copy.copy carries future Config fields, replace kwargs to avoid alias."""
-    new_config = copy.copy(config)
-    new_config.kwargs = {**config.kwargs, **kwargs_override}
-    return new_config
-
-
-def _config_has_npot_block(config):
-    """True if any of the config's BLOCK_* tile sizes is non-power-of-2."""
-    return any(isinstance(v, int) and not _is_pow2(v) for k, v in config.kwargs.items() if 'BLOCK' in k.upper())
-
-
-# Markers of a device compile/launch failure (vs a logic bug), matched case-insensitively. The
-# NVIDIA and AMD drivers tag every device RuntimeError with "Triton Error [CUDA]"/"[HIP]"; the rest
-# cover common HW failure signatures (including torch-surfaced wordings).
-_DEVICE_ERROR_MARKERS = (
-    "triton error [cuda]",
-    "triton error [hip]",
-    "out of memory",
-    "misaligned",
-    "illegal memory access",
-    "illegal instruction",
-    "device-side assert",
-)
-
-
-def _npot_runtime_error_prunable(config, err, allow_npot):
-    """Prune only an NPOT config, under the flag, on a device error; else re-raise."""
-    if not (allow_npot and _config_has_npot_block(config)):
-        return False
-    text = str(err).lower()
-    return any(marker in text for marker in _DEVICE_ERROR_MARKERS)
-
-
-def _wave_efficiency(num_tiles, num_units):
-    """Useful work fraction = tiles / (waves * units). 1.0 = full waves."""
-    if num_tiles <= 0 or num_units <= 0:
-        return 1.0
-    waves = _cdiv(num_tiles, num_units)
-    return num_tiles / (waves * num_units)
-
-
-def _legal_npot_blocks(base, legal_multiple):
-    """Legal NPOT multiples of ``legal_multiple`` in [base/2, base*2], excluding base and pow2."""
-    lo = max(legal_multiple, base // 2)
-    hi = base * 2
-    v = lo + ((legal_multiple - lo % legal_multiple) % legal_multiple)  # first legal multiple >= lo
-    out = []
-    while v <= hi:
-        if v != base and not _is_pow2(v):
-            out.append(v)
-        v += legal_multiple
-    return out
-
-
-# Only intervene when the pow2 tiling spans more than one wave and wastes more than (1 - threshold)
-# of capacity; a single wave cannot be improved by re-tiling.
-_WAVE_EFFICIENCY_THRESHOLD = 0.9
-
-# Per-config cap on proposed NPOT tiles (the top-ranked few). This bounds candidate GENERATION; the
-# overall sweep size is then governed by the autotuner's normal pruning (early_config_prune/top_k).
-_MAX_NPOT_CANDIDATES = 4
-
-
-def _wave_quant_npot_candidates(base_m, base_n, problem_m, problem_n, num_units, legal_m=16, legal_n=16):
-    """Up to _MAX_NPOT_CANDIDATES legal NPOT (BLOCK_M, BLOCK_N) improving wave count then efficiency
-    over the pow2 base; [] if pow2 is already efficient (>1 wave and >= threshold)."""
-    if not (base_m and base_n and problem_m and problem_n and num_units):
-        return []
-    pow2_tiles = _cdiv(problem_m, base_m) * _cdiv(problem_n, base_n)
-    pow2_waves = _cdiv(pow2_tiles, num_units)
-    pow2_eff = pow2_tiles / (pow2_waves * num_units)
-    if pow2_waves <= 1 or pow2_eff >= _WAVE_EFFICIENCY_THRESHOLD:
-        return []
-    scored = []
-    for bm in [base_m] + _legal_npot_blocks(base_m, legal_m):
-        for bn in [base_n] + _legal_npot_blocks(base_n, legal_n):
-            if bm == base_m and bn == base_n:
-                continue
-            tiles = _cdiv(problem_m, bm) * _cdiv(problem_n, bn)
-            waves = _cdiv(tiles, num_units)
-            eff = tiles / (waves * num_units)
-            if waves < pow2_waves or (waves == pow2_waves and eff > pow2_eff):
-                scored.append(((waves, -eff), (bm, bn)))
-    scored.sort(key=lambda x: x[0])
-    out, seen = [], set()
-    for _, pair in scored:
-        if pair in seen:
-            continue
-        seen.add(pair)
-        out.append(pair)
-        if len(out) >= _MAX_NPOT_CANDIDATES:
-            break
-    return out
-
-
-def _generate_wave_quant_candidates(configs, problem_dims, num_units):
-    """Append wave-quant NPOT BLOCK_M/N candidates for each pow2 config; no-op if flag off or M/N shape/units unknown.
-
-    ``problem_dims`` = {'M': int, 'N': int} (spatial grid dims; K is a reduction loop)."""
-    if not knobs.language.allow_npot or not num_units:
-        return configs
-    pm = problem_dims.get('M')
-    pn = problem_dims.get('N')
-    if not (isinstance(pm, int) and isinstance(pn, int)):
-        return configs
-    expanded = list(configs)
-    for config in configs:
-        bm = config.kwargs.get('BLOCK_M')
-        bn = config.kwargs.get('BLOCK_N')
-        if not (isinstance(bm, int) and isinstance(bn, int)):
-            continue
-        for (nbm, nbn) in _wave_quant_npot_candidates(bm, bn, pm, pn, num_units):
-            new_config = _clone_config(config, BLOCK_M=nbm, BLOCK_N=nbn)
-            if new_config not in expanded:
-                expanded.append(new_config)
-    return expanded
-
-
-def _device_num_sms():
-    """Best-effort device SM count (from the Triton driver) for the wave-quant model; None ->
-    wave-quant is skipped."""
-    try:
-        dev = driver.active.get_current_device()
-        n = driver.active.utils.get_device_properties(dev).get("multiprocessor_count")
-        return int(n) if n else None
-    except Exception:
-        return None
-
-
 def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_value=None, pre_hook=None, post_hook=None,
              warmup=None, rep=None, use_cuda_graph=False, do_bench=None, cache_results=False, include_npot=False):
     """
@@ -1373,9 +1242,10 @@ def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_va
     :type do_bench: lambda fn, quantiles
     :param cache_results: whether to cache autotune timings to disk.  Defaults to False.
     "type cache_results: bool
-    :param include_npot: when True and TRITON_ALLOW_NPOT=1, the autotuner adds wave-quant-targeted
-        NPOT BLOCK_M/BLOCK_N candidates at tune time, but ONLY when the pow2 tiling has a real
-        wave-quantization tail. No-op otherwise, so pow2 autotuning is unchanged. Defaults to False.
+    :param include_npot: when True and TRITON_ALLOW_NPOT is on, add a globally capped wave-quant
+        Pareto frontier over BLOCK_M/BLOCK_N/BLOCK_K and num_stages, including NPOT block
+        alternatives. Occupancy is constrained by modeled register/SMEM use and live device limits.
+        No-op when the base tiling has no useful wave tail. Defaults to False.
     :type include_npot: bool
     """
 

--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -440,12 +440,16 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
 
   // create a struct to hold device properties
   return Py_BuildValue(
-      "{s:i, s:i, s:i, s:i, s:i, s:i, s:s, s:i, s:i, s:i}", "max_shared_mem",
-      props.sharedMemPerBlock, "max_num_regs", props.regsPerBlock,
+      "{s:K, s:K, s:i, s:i, s:i, s:i, s:i, s:i, s:s, s:i, s:i, s:i, s:i}",
+      "max_shared_mem", (unsigned long long)props.sharedMemPerBlock,
+      "max_shared_mem_per_sm",
+      (unsigned long long)props.sharedMemPerMultiprocessor, "max_num_regs",
+      props.regsPerBlock, "max_num_regs_per_sm", props.regsPerMultiprocessor,
       "multiprocessor_count", props.multiProcessorCount, "sm_clock_rate",
       props.clockRate, "mem_clock_rate", props.memoryClockRate, "mem_bus_width",
       props.memoryBusWidth, "arch", props.gcnArchName, "warpSize",
       props.warpSize, "max_threads_per_sm", props.maxThreadsPerMultiProcessor,
+      "max_blocks_per_sm", props.maxBlocksPerMultiProcessor,
       "cooperativeLaunch", props.cooperativeLaunch);
 }
 

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -137,9 +137,13 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
 
   // create a struct to hold device properties
   int max_shared_mem;
+  int max_shared_mem_per_sm;
   int max_num_regs;
+  int max_num_regs_per_sm;
   int multiprocessor_count;
   int warp_size;
+  int max_threads_per_sm;
+  int max_blocks_per_sm;
   int sm_clock_rate;
   int mem_clock_rate;
   int mem_bus_width;
@@ -147,11 +151,23 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
       &max_shared_mem, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
       device));
   CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
+      &max_shared_mem_per_sm,
+      CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR, device));
+  CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
       &max_num_regs, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK, device));
+  CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
+      &max_num_regs_per_sm,
+      CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR, device));
   CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
       &multiprocessor_count, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, device));
   CUDA_CHECK_AND_RETURN_NULL(
       cuDeviceGetAttribute(&warp_size, CU_DEVICE_ATTRIBUTE_WARP_SIZE, device));
+  CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
+      &max_threads_per_sm, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR,
+      device));
+  CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
+      &max_blocks_per_sm, CU_DEVICE_ATTRIBUTE_MAX_BLOCKS_PER_MULTIPROCESSOR,
+      device));
   CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
       &sm_clock_rate, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, device));
   CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
@@ -159,12 +175,15 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
   CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
       &mem_bus_width, CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH, device));
 
-  return Py_BuildValue("{s:i, s:i, s:i, s:i, s:i, s:i, s:i}", "max_shared_mem",
-                       max_shared_mem, "max_num_regs", max_num_regs,
-                       "multiprocessor_count", multiprocessor_count, "warpSize",
-                       warp_size, "sm_clock_rate", sm_clock_rate,
-                       "mem_clock_rate", mem_clock_rate, "mem_bus_width",
-                       mem_bus_width);
+  return Py_BuildValue(
+      "{s:i, s:i, s:i, s:i, s:i, s:i, s:i, s:i, s:i, s:i, s:i}",
+      "max_shared_mem", max_shared_mem, "max_shared_mem_per_sm",
+      max_shared_mem_per_sm, "max_num_regs", max_num_regs,
+      "max_num_regs_per_sm", max_num_regs_per_sm, "multiprocessor_count",
+      multiprocessor_count, "warpSize", warp_size, "max_threads_per_sm",
+      max_threads_per_sm, "max_blocks_per_sm", max_blocks_per_sm,
+      "sm_clock_rate", sm_clock_rate, "mem_clock_rate", mem_clock_rate,
+      "mem_bus_width", mem_bus_width);
 
 cleanup:
   return NULL;


### PR DESCRIPTION
Summary:

Add a smarter wave quantization approach to the autotune, most logic in a new file. works on a fixed (M, N, K) problem

  1. It activates only when both include_npot=True and TRITON_ALLOW_NPOT are enabled.
  2. It reads the real SM/CU count and separate per-block versus per-SM/CU register, shared-memory, thread, and block limits. Missing data means no expansion; it does not guess.
  3. For each POT seed config, it estimates tile count, resource use, residency, waves, and trailing-wave efficiency.
  4. It explores nearby POT and legal multiple-of-16 NPOT values for BLOCK_M/N/K, plus adjacent pipeline-stage counts.
  5. It rejects candidates that exceed launch/resource limits, scores the rest for padded work and wave utilization, and keeps a small Pareto frontier.
  6. It sends at most four extra distinct tile configurations to the real autotuner, with at most one NPOT tile.
  7. Actual benchmark timings decide the winner. Known backend rejections are converted to infinite time only for generated NPOT configs; POT or unrelated failures still propagate.
  8. The selected config is cached and launched through the normal autotuner path. With the option or flag off, existing control flow is unchanged.

Differential Revision: D113340948
