### PR TITLE
[backports] Add the fbtriton-backport skill + dependency tooling

### DIFF
--- a/.claude/skills/fbtriton-backport/SKILL.md
+++ b/.claude/skills/fbtriton-backport/SKILL.md
@@ -1,0 +1,535 @@
+---
+name: fbtriton-backport
+description: >
+  Use when backporting commits onto an fbtriton release branch (release/3.7.x etc.):
+  planning which commits/PRs to bring over, a cherry-pick that conflicts or comes out a
+  franken-commit, a pick that drags in unrelated files, or a commit whose test or
+  machinery is missing on the release branch. Applies to both routine point-release
+  updates and targeted (e.g. AMD-perf) backports.
+---
+
+# fbtriton backport — pick, map dependencies, resolve into clean shims
+
+The full arc of a release backport in one place:
+**Phase 1 triage → Phase 2 map dependencies → Phase 3 pick clean → Phase 4 resolve the
+messy ones (match-main or a documented shim) → Phase 5 build & validate → Phase 6 finalize.**
+
+**Finalizing the pick list is two steps** (Phase 1 = candidates, Phase 2 = machinery):
+1. **The candidate list** — *what we actually want*: either a point-release scan of all **fix**
+   commits between the cut and `main`, or an **LLM-curated** list for a stated purpose (e.g. the
+   AMD-perf commits). These are the "selected" picks.
+2. **The machinery** — *what those candidates need*: the dependency commits each candidate sits
+   on top of (base kernels, refactors, prereqs) that aren't on the release branch yet. Found by
+   tracing each candidate's touched-file history back to the cut (codified in Phase 2).
+
+Worked case study of the nastiest dependency class:
+[`partial-port-collision.md`](partial-port-collision.md).
+
+## Golden rules (govern every phase)
+
+1. **Lower divergence from Meta `main`.** `main` is the answer key: every pick /
+   resolution should move release *toward* `main`, never into a franken-state that
+   matches neither `main` nor clean release. A region that matches `main` exactly
+   (modulo unrelated later evolution) is safe. *Caveat:* `main` lags OpenAI, often a
+   lot — see Phase 4 for when "match main" does and does not apply.
+2. **Prefer an explicit `[partial]`/`[shim]` commit over a wholesale pick or a
+   hand-merge.** When a commit conflicts or is *mixed* (wanted change bundled with
+   unrelated CI/lint/other-subsystem changes), extract only the wanted slice into its
+   own tagged commit — don't cherry-pick the whole thing and resolve/drop files.
+   (`[partial]` = subset of one PR · `[shim]` = bridge assembled from >1 source.)
+3. **Document the divergence.** Every shim/resolution records (a) why the clean pick
+   fails and (b) the reasoning (slice taken, from where, what's omitted and why) — in
+   the commit message, and for a batch in `.backports/<version>/backport_<version>.md`. No
+   silent surgery.
+4. **Never re-pick a change already on release.** If release inherited an adapted form
+   (pre-cut), re-picking the upstream original double-applies / regresses it. Confirm
+   with the Phase 2 probe before picking.
+
+## Where things live
+
+Artifacts under `.backports/<version>/` (e.g. `.backports/3.7.2/`, `.backports/3.7.3/`):
+- `candidates.tsv` — sweep input (written by `backport-sync.sh`; deterministic mode only).
+- **`backport_<version>.md`** — the single living doc, **built up over multiple rounds — don't
+  try to fill it all at once.** Start it with just the purpose & scope + initial candidate list,
+  then append each phase's output as you get it: dependency stacks, pick/skip decisions, shim
+  resolutions, land order, build/test results, perf numbers. Sections left empty/TBD between
+  rounds are expected. Format it like `.backports/3.7.3/backport_3.7.3.md`.
+- `commit-dag.html` — an interactive pick/dependency DAG for review (same dir).
+
+Don't build during triage.
+
+## The two repos
+
+- **OpenAI Triton**: upstream `triton-lang/triton`, cloned at `~/github/triton`.
+- **Meta Triton**: our fork `facebookexperimental/triton`, cloned at `~/github/fbtriton`.
+  Release branch e.g. `release/3.7.x`; fork point (branch cut) e.g. `3e55adf1b`.
+
+## Data & network rule (if run in a sandboxed session)
+
+Read only what the task needs: local git repos, and for commit/PR lookups the upstream
+GitHub repos `triton-lang/triton` and `llvm/llvm-project`. **Don't push or send data
+anywhere** (no `git push`, no `gh pr create`/comment, no uploads). Everything produced
+stays as local files. If a lookup is blocked, say so and stop — don't route around it.
+
+---
+
+## Phase 1 — Step 1: build the candidate list (what we want)
+
+### Start here — ask the user two things
+
+Before gathering any candidates, confirm with the user (don't guess — the answer picks a
+very different commit set, fixes-only vs features):
+
+1. **Purpose of the backport** — a *regular point-release update* (catch the release branch
+   up), or a *specific ask* (e.g. "the AMD perf commits", a named feature / set of PRs)?
+2. **Target release branch** — which `release/X.Y.z`? That fixes the fork/cut point
+   (`CUT=$(git merge-base origin/release/X.Y.z origin/main)`) every later step uses.
+
+Route on the answer:
+
+- **Regular point update → run the deterministic sweep** (candidate source (a) below).
+- **Specific ask → scan `CUT..main_head` yourself** and curate a goal-scoped pool (source
+  (b) below).
+
+Both then funnel into the same job (drop → scope → map dependencies → order); only the
+input pool differs.
+
+### Candidate source (a) — regular point update: deterministic sweep
+
+Run `.claude/skills/fbtriton-backport/backport-sync.sh` (pass `RELEASE=release/X.Y.z`). It fetches live, resolves
+the frontier, and writes `candidates.tsv`: *everything* on the frontier since the last sync,
+from two sources — `source=openai` (OpenAI's release branch) and `source=meta-main` (our
+`main`). Columns: `source  present  class  sha  subject`; the `#` header pins the range SHAs.
+Filtering the sweep down (Step "Drop"/"Scope" below) is the main work.
+
+### Candidate source (b) — specific ask: scan `CUT..main_head`
+
+Start from the user's intent (e.g. "the AMD perf work prod needs", often sourced from a chat
+/ PRs / Phabricator diffs) and *gather* the relevant commits yourself, scoped to the goal:
+```bash
+CUT=$(git merge-base origin/release/X.Y.z origin/main)
+git log --oneline "$CUT"..origin/main -- <goal-paths>          # e.g. third_party/amd third_party/tlx
+git log --oneline "$CUT"..origin/main | grep -iE '<keywords>'  # e.g. amd|gfx9|mfma|decode|gemm
+```
+Cross-check the hits against the user's named PRs/diffs, then group into feature stacks. The
+pool is already goal-scoped, so the main work is **dependency mapping** (Phase 2) and
+confirming each candidate is **landable** (on `main`; flag anything "not on main yet ⏳").
+Capture the result in `backport_<version>.md` (format like `.backports/3.7.3/backport_3.7.3.md`).
+
+The `present`/scope hints are *hints* — verify against real code and real dependencies;
+never trust a PR-number grep (squashed bundles break it).
+
+### Read the PR + commit message for every candidate (don't decide from the diff alone)
+
+The message carries what the diff can't, and it drives the pick decision:
+
+```bash
+git show -s <sha>                          # fbtriton commit msg — intent, deps, Differential Revision
+gh pr view <PR> --repo triton-lang/triton  # upstream PR discussion (openai candidates only)
+```
+Read it for: **intent** (fix vs feature), **stated dependencies** ("depends on #X",
+stacked-diff parents → feed Phase 2), whether a **revert** is a provisional fallback that
+names its real fix (→ likely reject), whether the change was **superseded/reverted later**,
+and **what tests it ships**. Decide pick/skip from the message + real code, not the diff alone.
+
+- **Tests are part of the pick.** A PR's own tests are what validate the change — keep them
+  with the code (never drop a PR's test as "noise") and run them in Phase 5. Note which tests
+  each pick adds/edits now. A test file a PR *depends on* (created by an earlier PR) is often
+  the silent machinery that makes the pick conflict — Phase 2 surfaces it (e.g. #2153's
+  asyncmark test ← #10081).
+
+### Drop what we don't need (both modes)
+
+- **Already in the fork.** We pull OpenAI history in as squash commits titled
+  `[Cherry-pick][BUNDLE] …`; each bundle's message lists the PR numbers it carried, so
+  most AMD/CUDA/backend fixes are already here, buried in a bundle. Confirm by *code*,
+  not SHA/PR number:
+  ```bash
+  git log origin/release/X.Y.z --grep='Cherry-pick.*BUNDLE' --oneline   # bundles on release
+  git show <bundle-sha> | grep -oE '#[0-9]+' | sort -un                 # PRs a bundle brought
+  git show <cand-sha> -- <file> | grep '^+'                             # what the candidate adds
+  git show origin/release/X.Y.z:<file> | grep -F '<distinctive line>'   # already there?
+  ```
+  If present, drop. (A probe cherry-pick that comes out **empty** also = already there.)
+- **Reverted inside the range.** If X is reverted by "Revert X" in-range, drop both; for
+  revert→re-land chains keep only the net result.
+- **Absent path.** Skip a fix that only touches code not on the release branch — check
+  the file/symbol exists on `origin/release/X.Y.z` first.
+
+### Decide what's in scope
+
+**Deterministic mode:**
+- **OpenAI commits — take everything else.** OpenAI already decided what belongs on
+  their release branch; don't second-guess fix-vs-feature. Only skip release plumbing
+  *we* own (version bumps, PyPI publishing, wheel CI).
+- **Meta-main commits — fixes only** (per `RELEASE.md`): regressions & critical fixes
+  (crashes, deadlocks, wrong results, leaks), fixes to just-shipped features, docs,
+  release/CI fixes. **No new features.**
+
+**LLM-curated mode:** the pool is already goal-scoped → scope = **in service of the goal
++ landable**. Keep a candidate if it advances the goal (an AMD-perf kernel or its
+enabler) **and** it is on `main` (can't cherry-pick what hasn't landed — flag "not on
+main yet ⏳" and hold). The fixes-only rule does *not* bind (a targeted feature backport
+is features by definition), but every **Drop** rule above still applies.
+
+**Reverts are a triage decision, not a rubber stamp.** A release-branch revert is often a
+provisional fallback that names its own real fix ("in the hopes of fixing…", "so we have
+a fallback"). Read the message and check whether Meta `main` **kept** the reverted code.
+If main didn't revert, matching main means *rejecting* the revert. Cautionary **#9445**:
+reverted async-copy-by-default on gfx950, called itself a fallback for #9431 (already in
+our LLVM), main keeps async-copy on — taking it broke the MI350 FA kernels.
+
+**The LLVM pin is a special case** — skip the OpenAI pin commit, but don't ignore it. Our
+pin lives in `cmake/llvm-info.json` (`llvm_hash` + `build_number`); we build/host our own
+prebuilt LLVM. OpenAI pins a different LLVM in `cmake/llvm-hash.txt` — cherry-picking it
+edits a file our build ignores and points at an LLVM we never built. So skip the commit
+but **flag the pin delta** (old vs new hash) so a human can decide to advance our own LLVM
+(a deliberate infra step: bump `llvm-info.json`, rebuild — not a cherry-pick).
+
+---
+
+## Phase 2 — Step 2: find the machinery the candidates need
+
+Every Step-1 candidate rides on commits that landed on `main` before it. Any that aren't on
+the release branch yet are **machinery** you must pull in (or shim) — miss one and the pick
+conflicts, comes out empty, or builds a broken tree. This step's product is the
+**dependency graph + land order**. Do it in two passes: **(1) codified trace** (predict the
+machinery up front), then **(2) probe** (confirm on a clean release tip).
+
+### Kinds of dependency
+
+- **Base** — the feature's own foundational commit (`#2040` base decode; `#2157` base
+  a16w16 GEMM). Always precedes its follow-ups.
+- **Prereq feature** — a sibling the commit builds on, usually named in the PR stack
+  (`#2157` needs `#2152` AGPR + `#2156` pinned layouts + `#2153` async_wait).
+- **Cross-chain** — a prereq in *another* group, so one stack must land before another
+  (GEMM's `#2156` needs layout-infra `#2017` → the GEMM stack depends on the layout stack).
+- **Machinery (silent)** — an intervening commit that *doesn't look related* but the
+  file's history reveals it; never in a PR description, surfaces only as a conflict/empty
+  on probe (`#2281` needs `#2149`'s decode rewrite; `#2158` needs `#2054`/`#2146`/`#2151`;
+  `#2153` needs `#10081`'s asyncmark test file).
+
+### Codify it — trace each candidate's touched-file history back to the cut
+
+Silent machinery is findable mechanically, before any cherry-pick: a candidate's diff hunks are
+written against `main`'s version of each file it touches, so a commit that landed on that file
+between the cut and the candidate is a dependency **iff** its change makes the candidate no
+longer 3-way-merge cleanly onto release.
+
+**Use the helper** [`find-machinery.sh`](find-machinery.sh) — it **recursively unfolds the full
+machinery down to the cut** and prints a **suggested plan** (heuristic, each line labeled with
+commit + PR#) — the pick / `[partial]` / `[shim]` call stays yours:
+**③** shim / pick-upstream-original first (bundle ⇒ find the real upstream PR; inherited-partial
+collision ⇒ Phase 4b) · **①** `git cherry-pick -x` in the given order (oldest→newest; each is clean
+once the ones above it are in) · **✓** already present (identity-checked via ancestry / the `-x`
+trailer — *not* PR number, which collides). If the candidate itself is already on the baseline it
+says so and stops.
+```bash
+.claude/skills/fbtriton-backport/find-machinery.sh <candidate-sha> --onto <wip-stack-tip>
+# --onto = your WIP pick-stack during Step 2 (so the closure is the EXTRA machinery beyond
+# candidates already picked). Omit it to measure vs bare release (pulls in every other candidate).
+```
+Under the hood, per commit: `CUT=$(git merge-base release main)`; for each modified file, 3-way
+merge (base=`<sha>^`, ours=onto, theirs=`<sha>`) — if it conflicts, its deps are
+`git log "$CUT".."<sha>^" -- <file>`; the tool BFS-expands each dep the same way until the cut.
+
+The plan's buckets are suggestions, not orders — treat them as a starting point and decide per
+commit:
+- **③ worth a judgment call** — a squashed `[Cherry-pick][BUNDLE]` (usually better to pick the
+  *real upstream PR* it contains, not the bundle — `git log --all --oneline --grep='(#<upstream-PR>)'`),
+  or a commit that collides with an inherited partial port → often a `[shim]`/`[partial]` (Phase 4b).
+- **① likely clean picks** — `git cherry-pick -x` in the printed order (oldest→newest); still
+  confirm, and a "clean" one may read better as a `[partial]`/`[shim]`.
+- **✓ already present** — skip (identity-verified).
+
+Worked example: `find-machinery.sh #2290 --onto <stack>` unfolds in one run to ③ bundle `#1981`
+(whose `getMaxElementsPerThread` is upstream `#10059`) → ① `#2150` → candidate `#2290` —
+the clean chain `#10059 → #2150 → #2290`.
+
+### The probe — confirm on a CLEAN release tip (not your WIP branch)
+
+```bash
+git checkout -b probe origin/release/X.Y.z
+git cherry-pick -x <sha>
+git diff --name-only --diff-filter=U               # which files conflict
+git status --porcelain | grep -E '^(DU|UD|AU|UA)'  # add/del (absent-on-branch) conflicts
+# clean   → pick it.
+# empty   → already present → drop (already-in-fork).
+# conflict on <file> → something landed between the cut and <sha>:
+git log --oneline <fork-point>..<sha> -- <conflicting-file>   # the intervening commit(s) = the dep
+git cherry-pick --abort; git checkout -; git branch -D probe
+```
+Attribute the conflict:
+```bash
+git log origin/release/X.Y.z --oneline -1 -- <file>   # who put it on release
+git merge-base --is-ancestor <that-sha> <fork-point> && echo "INHERITED at cut"
+git show -s <that-sha>                                 # "Port … from <branch>" = hand-port
+```
+Also check the true upstream (`~/github/triton`) for the *current* form (flag names,
+logic) to pick the divergence reference correctly — usually fbtriton `main`, not upstream.
+
+### What the probe tells you (→ which phase resolves it)
+
+- **Clean** → pick in Phase 3.
+- **Empty** → already present → drop.
+- **Missing dependency, clean-pickable** → pull the intervening commit into the stack
+  (Phase 3). E.g. `#2158` ← `#2054`/`#2146`/`#2151` (`Fixup.cpp`).
+- **Collision or mixed commit → a shim (Phase 4b).** Two triggers:
+  - **A. Collision with an inherited partial port** — the commit conflicts because an
+    earlier *adapted* slice is already on release (pre-cut hand-port). Shim = the
+    *un-ported* slice. (`#2153`/`#10081` vs inherited `#1847` — see
+    [`partial-port-collision.md`](partial-port-collision.md).)
+  - **B. Wholesale import of a mixed commit** — it applies but bundles wanted + unrelated
+    changes (a `[CI]`-titled commit that also rewrites a kernel). Tell:
+    `git show --stat <sha>` lists files *outside* the subsystem you're backporting. Shim =
+    the *wanted* slice only. (`#2149`.)
+
+### Group into stacks + land order
+
+Cluster picks into dependency stacks (base + follow-ups + machinery). Order
+**topologically**: base → prereqs → feature → follow-ups; cross-chain deps set the order
+*between* stacks (foundational stack first). Record it — Phase 3 just replays it. (v3.7.3
+landed as `L → B → A → M`: layout infra first because GEMM depends on it; decode and addmm
+independent.)
+
+---
+
+## Phase 3 — Pick (two-pass)
+
+Work on a throwaway branch off `origin/release/X.Y.z`, `git cherry-pick -x`, in the order
+Phase 2 produced. Two passes because clean picks are low-risk and hand edits are where
+things break:
+
+- **Pass 1 — clean picks in bulk.** Apply the list; clean → keep; conflict → record and
+  `--abort` (defer to pass 2); empty → drop. Build+test **once** at the end (Phase 5); if the
+  build breaks, bisect.
+- **Pass 2 — troubled picks, one at a time.** Resolve each (Phase 4), then build+test that
+  one commit before the next, so a failure maps to a single resolution. Log every outcome
+  in `.backports/<version>/backport_<version>.md`: picked / reduced-to-slice (what dropped & why) /
+  rejected (why).
+
+A pass-1 conflict is often a **missed dependency** — re-run the Phase 2 probe rather than
+forcing the merge.
+
+---
+
+## Phase 4 — Resolve the messy picks
+
+Two resolution shapes. Pick by what the Phase 2 probe found.
+
+### 4a. Ordinary drift conflict → resolve to match `main`
+
+Our fork drifted from OpenAI (FpSan bundle, lint-autofix, newer APIs), so a fine fix may
+not apply cleanly — but the same fix is usually already integrated on Meta `main`, which
+shows the correct end result.
+
+1. Resolve so the changed region matches `main`, then prove it (empty diff = same as main):
+   ```bash
+   diff <(git show <main_head>:<file> | sed -n '/<region start>/,/<region end>/p') \
+        <(sed -n '/<region start>/,/<region end>/p' <file>)
+   ```
+2. **Keep both the fix and our fork-only additions** (e.g. `runDeadIterArgElimination`,
+   `PruneLocalStoreOfReshapeConvert`). A plain auto-merge can silently keep a line main
+   removed — the diff-against-main catches that.
+3. **Upstream reshuffle:** when upstream splits/renames something we also changed (one
+   `RewritePatternSet` → `convertCleanup` + `scfCleanup`), place our addition into the new
+   structure the way main did, then diff against main.
+4. **Prefer the real upstream commit** over another repo's release adaptation — it's often
+   already in our repo on a merge branch with its honest SHA:
+   `git log --all --oneline --grep='(#<upstream-PR>)'`. (#10132: prefer upstream
+   `ca21b1b95`'s `runDeadIterArgElimination` over OpenAI's older
+   `populateForOpDeadArgumentElimination`.)
+5. **Caveat — `main` lags OpenAI.** For a recent OpenAI commit main hasn't bundled yet,
+   there is nothing on main to match — resolve to OpenAI's intent while preserving fork
+   adaptations (pybind11 isolation in `PluginUtils.h`, FpSan, newer APIs). "Not on main" is
+   **not** a reason to skip. And **don't invert the answer key**: `merge-base
+   --is-ancestor` first — if main lags, "matches main" can mean "reverted a fix main hasn't
+   caught up to."
+
+### 4b. Mixed/collision → author a `[partial]`/`[shim]` commit
+
+For trigger A (collision with inherited partial port) or B (mixed commit): extract only
+the wanted slice, don't import wholesale.
+
+**Convergence test — which slices to include.** Include a file's slice only if it
+*meaningfully converges that file to `main`*:
+```bash
+git diff origin/release/X.Y.z origin/main -- <file> | grep -c '^[+-]'   # total gap
+git show <sha> -- <file>                            | grep -c '^[+-]'   # this slice
+```
+- slice ≈ whole gap → the commit is the file's only delta → **include** (→ `== main`).
+- slice ≪ gap → the file is dominated by other divergence you're not backporting → **skip**.
+- (v3.7.3: `amd_pa_decode.py` slice = whole gap → include; `h100.yml`/`mi350.yml` 6/34 &
+  12/129 → skip.)
+
+**Title tag + PR#.** Keep the source PR's original subject + PR# so `backport-sync`'s
+PR#/title matching still recognizes it; prefix a tag saying *how* it's partial:
+- **`[partial]`** — a documented subset of one PR (`[partial] [CI] Isolate torchTLX … (#2149)`
+  = its decode files only).
+- **`[shim]`** — a bridge assembled from >1 source (`[shim] [AMD][gfx9] Restore token-aware
+  … (#10081)` = #10081's `Pipeline.cpp` call + the test from `origin/main`, to enable #2153).
+
+**Build it** — take only the wanted files; materialize support files from `origin/main` (the
+fork's adapted form), not the raw upstream commit:
+```bash
+git show <sha> -- <wanted-file> [<wanted-file> ...] | git apply --3way   # wanted code/tests
+git show origin/main:<path> > <path>                                     # support file, fork's form
+git add <wanted files> && git commit -F - <<'MSG' … MSG
+```
+Before applying a C++ hunk, confirm the symbols it references exist on release:
+`git grep -c <symbol> origin/release/X.Y.z -- <dirs>`.
+
+**Commit message template:**
+```
+[partial|shim] <ORIGINAL PR subject> (#NNNN)   # [partial]=subset of 1 PR · [shim]=bridge from >1 source
+
+Divergence: <why a clean pick of <#PR/sha> fails or is wrong here>. E.g. release
+inherited <#PR/sha> pre-cut (a partial, adapted port that rewrote <files> with
+<flag/behavior changes>); or <#PR> is a mixed commit that also drags <unrelated
+files>. Verified on a clean release tip (conflict is from <source>, not our picks).
+
+Shim: takes only <wanted slice/files> from <#PR / origin/main>; OMITS <files>
+because <reason>. Lowers divergence: release gains only <the needed change>, keeps
+<inherited lineage> untouched. Shimmed files verified == origin/main (modulo unrelated
+later evolution).
+```
+
+**Verify:**
+```bash
+git diff --quiet origin/main HEAD -- <shimmed-file> && echo "== main (faithful)"
+```
+A match (modulo features/refactors that landed on `main` after the cut) confirms the shim
+equals what the routine bundle would have brought, minus the collisions/irrelevant parts.
+Re-run the deferred tail to confirm dependent picks now apply clean.
+
+### Red flags — STOP and re-check
+
+If you catch yourself doing any of these, stop — it violates a Golden Rule and you're about
+to raise divergence from `main`:
+
+- **Wholesale import + resolve/drop** of a mixed commit → drags unrelated divergence, leaves
+  a franken-commit. Shim the slice (rule 2).
+- **Re-pick a commit already present in adapted form** (inherited pre-cut) → double-apply /
+  regress; maximal divergence (rule 4).
+- **"Match main" when main lags** → inverts the answer key; check `merge-base --is-ancestor`
+  first (rule 1 caveat).
+- **Silent conflict surgery** → undocumented resolution (rule 3): put it in the commit message
+  + `backport_<version>.md`.
+
+---
+
+## Phase 5 — Build & validate
+
+Don't finalize on green cherry-picks alone — a clean apply can still miscompile or fail a
+kernel test. Build the wheel and run the tests, **including the ones the picked PRs ship**.
+
+### Build the wheel
+
+```bash
+.claude/skills/fbtriton-backport/build-wheel.sh   # prompts default sensibly; override via env vars
+```
+Stages googletest + the prebuilt LLVM matching `cmake/llvm-info.json` + gcc-toolset-14 (all
+cached after the first run), then `uv build --wheel` → `dist/`. Builds off the current branch
+(your pick-stack tip). Off a `release/*` branch the wheel carries a `+git<sha>` suffix — fine
+for testing; the real `<X.Y.Z>+fb` bump is Phase 6. If it breaks, bisect the pick stack.
+
+### Test the wheel
+
+```bash
+.claude/skills/fbtriton-backport/test-wheel.sh    # or: WHEEL=dist/<wheel>.whl .claude/skills/fbtriton-backport/test-wheel.sh
+```
+Installs the wheel into a throwaway venv with the torch build matching the GPU (auto: ROCm on
+AMD, CUDA on NVIDIA) and runs: a smoke kernel, the launch.h crash tests, and the **arch-gated
+TLX correctness suite** (on AMD only `amd`/`ikbo` kernels run, `-k "amd or ikbo"`; the rest
+auto-skip). On hang: `third_party/tlx/killgpu.sh`. (v3.7.3 baseline: smoke ✓, launch.h
+42-skip on AMD, TLX 69 passed / 4 skip on gfx950.)
+
+### Run the tests the picked PRs ship (the generic suite is not enough)
+
+Each picked PR usually adds/updates its own tests — those are what actually exercise what you
+backported, and they may not be in the arch-gated suite. From each pick, find and run them:
+```bash
+git show <sha> --stat | grep -E 'test|\.mlir'      # tests this pick adds/edits
+# MLIR/LIT (C++): build triton-opt, then   llvm-lit -v test/<path>/<file>.mlir
+# python kernels:  pytest -q third_party/tlx/tutorials/testing/test_correctness.py -k "<kernel>"
+```
+A **shim that materialized a test from `main`** (Phase 4b) *must* make that test pass — it's
+the proof the shimmed machinery works (e.g. the #10081 asyncmark LIT under the #2153 shim). If
+a pick's test isn't covered by the arch-gated run, run it explicitly and record it.
+
+### Perf validation — two comparisons (required for a perf-motivated backport)
+
+Correctness green doesn't mean fast. Run **two** GPU comparisons (optional for a routine point update):
+
+1. **main HEAD ↔ backport — completeness:** did we capture every perf commit the target cases need?
+2. **prior release ↔ backport — no regression:** shared/standard kernels must not regress. (The
+   backported kernels are usually *net-new* on the old release — they can't even run there, so the
+   regression check is on the shared paths + the comparison is "absent → present".)
+
+Give each section a one-line **Status** verdict in the doc.
+
+**Build every reference wheel FROM SOURCE at the exact SHA — do NOT use the published nightly pip
+wheel.** The nightly lags `main` HEAD and can be *older* than your backport (missing your just-picked
+commits), so it is an invalid reference and will mislead you. Build with `build-wheel.sh` from a
+detached `git worktree` at the SHA (copy the skill dir in so the script resolves), install each wheel
+in its own venv, and de-shadow the `triton-rocm` that ROCm torch drags in (see `test-wheel.sh`).
+
+**Completeness check.** `git fetch` first, then per target-kernel file:
+`git log --cherry-pick --right-only <branch>...origin/main -- <file>` → the commits on main not in the
+backport. A kernel **byte-identical** to main HEAD ⇒ no kernel commit missed. Confirm on-GPU that each
+missing commit is immaterial (or pick it).
+
+**Know how each harness imports its kernel (this is a trap that silently invalidates A/Bs):**
+- `test_amd_*_perf.py` imports the kernel from the **installed wheel** (`triton.language.extra.tlx…`)
+  → each wheel runs *its own bundled kernel*; driving it with a different venv swaps the kernel. To
+  isolate the *compiler*, the two wheels' kernels must be **byte-identical** (`diff` them first).
+- `gfx9_gemm/**/bench.py` imports `from matmul_kernel import …` → the kernel **next to the bench**;
+  run each wheel's own bench+kernel (if `bench.py` is identical and only `matmul_kernel.py` differs,
+  that's a clean shipped-vs-shipped comparison).
+- **Byte-identical kernel source ≠ identical compiled perf** — the compiler differs; *measure*, never
+  claim "parity by construction."
+
+**Measurement hygiene (AMD/MI350):**
+- Wrap runs in `third_party/tlx/denoise.sh` (NUMA pin + clock lock). It locks via
+  `sudo rocm-smi --setperfdeterminism <MHz>` — **`--setperflevel high` is "Not supported" on MI350**.
+  Select the GPU with `HIP_VISIBLE_DEVICES` (ROCm torch also honors `CUDA_VISIBLE_DEVICES`).
+- perfdeterminism locks **sclk only, not mclk** → bandwidth-bound kernels (paged decode) stay noisy;
+  compute-bound (GEMM) lock cleanly.
+- **Noise floor:** run the same config twice (A/B/A) and trust a delta only if it exceeds the A-vs-B
+  spread. **Warm up** first — a `TRITON_USE_C_DISPATCHER` cold-start fallback corrupts the first
+  timing (produces implausible 0.2–0.5× outliers). Prefer the **within-run TLX/rocBLAS ratio**
+  (DVFS-robust) over cross-run absolutes. Same-GPU-sequential avoids device variance but risks
+  thermal ordering; two locked GPUs in parallel avoid ordering but add ~2% device bias — report the caveat.
+- **tritonbench** covers standard ops (`gemm`, …) for the no-regression check; its `decoding_attention`
+  needs CUDA-only `xformers` → unrunnable on ROCm. Per-op harnesses under `tutorials/testing/*_perf.py`
+  are the targeted counterpart. Commands: `kernel-perf-testing` skill. `killgpu.sh` on hang.
+
+**Record:** side-by-side numbers (`prev | backport | main`, with Δ) + the exact commands, in
+`.backports/<version>/backport_<version>.md`. **Flag any regression before Phase 6** — it's a pick
+decision to revisit (missing machinery / wrong shim slice / missing perf commit), not something to ship.
+
+Record correctness pass/fail (with numbers + skips) and the perf signal in
+`.backports/<version>/backport_<version>.md`.
+
+---
+
+## Phase 6 — Finalize
+
+### Bump the version (two independent files — update both)
+
+- `python/triton/__init__.py` — `__version__ = '<X.Y.Z>+fb'` (keep the `+fb` fork marker).
+- `setup.py` — `TRITON_VERSION = "<X.Y.Z>" + get_triton_version_suffix()`. setup.py hardcodes
+  the base *independently*, so it won't pick up the bump on its own — miss it and the wheel
+  keeps the stale base. On a `release/*` branch the git suffix is empty (`triton-<X.Y.Z>`);
+  off a release branch it appends `+git<sha>`.
+
+Do **not** touch `docs/conf.py` (its `version`/`release` are empty and `smv_tag_whitelist`
+tracks upstream's "Advance version" cadence, not point-release backports).
+
+### Record it
+
+Commit the bump with the backport doc (`.backports/<version>/backport_<version>.md` +
+`commit-dag.html`). That doc is the running record — every pick/skip, shim/resolution
+(target pick, conflict source, slice / omissions, `== main` verification), and build/test
++ perf results. Keep the class of problem documented in
+[`partial-port-collision.md`](partial-port-collision.md).

--- a/.claude/skills/fbtriton-backport/SKILL.md
+++ b/.claude/skills/fbtriton-backport/SKILL.md
@@ -44,6 +44,13 @@ Worked case study of the nastiest dependency class:
 4. **Never re-pick a change already on release.** If release inherited an adapted form
    (pre-cut), re-picking the upstream original double-applies / regresses it. Confirm
    with the Phase 2 probe before picking.
+5. **A pick that isn't clean means diagnose before you resolve — never hand-edit blind.**
+   A conflict / empty / franken result is a *signal*: a related commit is missing (machinery)
+   or collides. Run `find-machinery.sh` + the probe to **locate the related commit(s) first**,
+   then decide — pick the missing commit (often the whole conflict vanishes, as with
+   `#2337 → #2336`), skip the candidate, or author a `[partial]`/`[shim]`. Hand-resolving a
+   conflict without first identifying the commit that caused it is the anti-pattern this whole
+   skill exists to prevent.
 
 ## Where things live
 

--- a/.claude/skills/fbtriton-backport/SKILL.md
+++ b/.claude/skills/fbtriton-backport/SKILL.md
@@ -109,6 +109,14 @@ from two sources — `source=openai` (OpenAI's release branch) and `source=meta-
 `main`). Columns: `source  present  class  sha  subject`; the `#` header pins the range SHAs.
 Filtering the sweep down (Step "Drop"/"Scope" below) is the main work.
 
+**Freshness is not optional — regenerate, never reuse.** The `#` header pins `main_head`.
+A `candidates.tsv` produced for an earlier point release is stale the moment `main` moves:
+**re-run the sweep for every release** and confirm its `main_head` equals
+`git rev-parse origin/main` before triaging. A fix that lands between a stale `main_head`
+and the cut is invisible to triage — this is exactly how the gfx950 async-copy fix
+(#2285, `CoalesceAsyncCopy` fallback) was missed by **v3.7.3**, whose triage reused a
+candidate list frozen ~12 days before the cut.
+
 ### Candidate source (b) — specific ask: scan `CUT..main_head`
 
 Start from the user's intent (e.g. "the AMD perf work prod needs", often sourced from a chat
@@ -125,6 +133,34 @@ Capture the result in `backport_<version>.md` (format like `.backports/3.7.3/bac
 
 The `present`/scope hints are *hints* — verify against real code and real dependencies;
 never trust a PR-number grep (squashed bundles break it).
+
+### Candidate source (c) — test-diff cross-check (catches fixes hiding as tests)
+
+Run this **in addition** to (a)/(b), on every backport. A fix and its regression test
+almost always land together; a title or the classifier can hide the *fix*, but the *new
+test* is hard to hide. Diff the TLX / warp-spec test surfaces between the release branch and
+`main` — a test on `main` but not on the release is a fix candidate; read the commit that
+added it.
+
+```bash
+TESTS='python/test/unit/language/test_tlx_amd.py \
+       python/test/unit/language/test_tlx_*.py \
+       python/test/unit/language/test_warp_specialization.py \
+       python/test/unit/language/test_tutorial09_warp_specialization.py'
+for f in $TESTS; do
+  comm -13 \
+    <(git show origin/release/X.Y.z:"$f" 2>/dev/null | grep -oE '^def test_[A-Za-z0-9_]+' | sort) \
+    <(git show origin/main:"$f"           2>/dev/null | grep -oE '^def test_[A-Za-z0-9_]+' | sort)
+done
+# map each missing test back to the commit that added it, then read that commit:
+git log --oneline -S'def <missing_test_name>' -- <file>
+```
+
+`test_tlx_amd.py` is the **AMD / gfx950** surface; its **NVIDIA (Hopper/Blackwell)
+counterparts** are the rest of the `test_tlx_*.py` family plus `test_warp_specialization.py`
+and `test_tutorial09_warp_specialization.py`. A missing test in any of them is a missing
+**fix** candidate — the commit that added it is almost always fix-bearing even when titled
+`Repro:` / `Test:`.
 
 ### Read the PR + commit message for every candidate (don't decide from the diff alone)
 
@@ -144,6 +180,11 @@ and **what tests it ships**. Decide pick/skip from the message + real code, not 
   each pick adds/edits now. A test file a PR *depends on* (created by an earlier PR) is often
   the silent machinery that makes the pick conflict — Phase 2 surfaces it (e.g. #2153's
   asyncmark test ← #10081).
+- **A test-looking commit can *be* the fix.** A commit titled `Repro:` / `Test:` that also
+  edits compiler code (`lib/…`, `third_party/*/lib/…/Transforms/…`) is fix-bearing — the
+  sweep flags these `[tlx-test]` and promotes them to `class=fix`. Never skip one as "just a
+  test"; read it. (#2285 shipped its `CoalesceAsyncCopy` fallback under a `Repro: … fails to
+  legalize on gfx950` title — classified `amd`, and was missed by v3.7.3.)
 
 ### Drop what we don't need (both modes)
 

--- a/.claude/skills/fbtriton-backport/backport-sync.sh
+++ b/.claude/skills/fbtriton-backport/backport-sync.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Deterministic discovery for the release backport sync.
+# Judgment prompt supplied to Claude: .claude/skills/fbtriton-backport/SKILL.md
+#
+# Runs in YOUR shell (real network) — not Claude's sandbox — so the fetch +
+# enumerate git ops are reliable and reproducible. It:
+#   1. Fetches OpenAI's release branch live from github + Meta's release/main.
+#   2. Resolves the OpenAI frontier (see "Frontier" below) and prints how.
+#   3. Enumerates candidate commits `frontier..head` for each source.
+#   4. Classifies each (fix / amd / plumbing / revert / bundle) + a presence hint.
+#   5. Writes a candidates file and opens an INTERACTIVE Claude session for the
+#      judgment + report (HEADLESS=1 for one-shot `claude -p`; NO_CLAUDE=1 to skip).
+#      Claude is launched with --secure-internet-mode: it keeps the internet
+#      access the triage needs (git/gh reads) but sandboxes egress so no repo data
+#      can be pushed off-box. The prompt also instructs the agent accordingly.
+#
+# TWO frontiers (START of each range), both tracked in $ENV_FILE, resolved:
+#   OpenAI-release: --openai-frontier -> env file -> bootstrap (match Meta release-tip
+#     commits to OpenAI's release by inline hash / PR# / title) -> fork-point fallback
+#   Meta-main:      --meta-frontier   -> env file -> bootstrap (release fork-point on main)
+# Candidates = frontier..head for each. After a sync LANDS, advance BOTH:
+#   .claude/skills/fbtriton-backport/backport-sync.sh --advance-head    (OpenAI->openai head, Meta->main head)
+#
+# The script does NO cherry-pick/build — those are Claude's job, or a later step.
+#
+# Usage:
+#   .claude/skills/fbtriton-backport/backport-sync.sh                        # auto (env file / bootstrap)
+#   .claude/skills/fbtriton-backport/backport-sync.sh --openai-frontier <sha|tag> --meta-frontier <sha>
+#   .claude/skills/fbtriton-backport/backport-sync.sh --advance-head         # after a sync: frontiers := heads
+# Artifacts: .backports/<version>/{candidates.tsv,report.md,.backport-sync.env}
+# Env/flags: RELEASE, VERSION, OUTDIR, OPENAI_FRONTIER, META_FRONTIER, OPENAI_URL,
+#            OPENAI_REPO, MAIN_REF, OUT, ENV_FILE, PROMPT_FILE, HEADLESS=1, NO_CLAUDE=1
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+RELEASE="${RELEASE:-release/3.7.x}"
+OPENAI_URL="${OPENAI_URL:-https://github.com/triton-lang/triton.git}"
+OPENAI_REPO="${OPENAI_REPO:-$HOME/github/triton}"   # local OpenAI clone (for fork-point merge-base)
+MAIN_REF="${MAIN_REF:-origin/main}"
+OPENAI_FRONTIER="${OPENAI_FRONTIER:-}"
+META_FRONTIER="${META_FRONTIER:-}"
+VERSION="${VERSION:-}"          # defaults to the release version (release/3.7.x -> 3.7.x)
+OUTDIR="${OUTDIR:-}"            # defaults to .backports/<version>
+OUT="${OUT:-}"                  # defaults to <outdir>/candidates.tsv
+ENV_FILE="${ENV_FILE:-}"        # defaults to <outdir>/.backport-sync.env
+PROMPT_FILE="${PROMPT_FILE:-$REPO_ROOT/.claude/skills/fbtriton-backport/SKILL.md}"
+ADVANCE_HEAD=""
+
+while [[ $# -gt 0 ]]; do case "$1" in
+  --release)         RELEASE="$2"; shift 2;;
+  --openai-frontier) OPENAI_FRONTIER="$2"; shift 2;;
+  --meta-frontier)   META_FRONTIER="$2"; shift 2;;
+  --openai-url)      OPENAI_URL="$2"; shift 2;;
+  --openai-repo)     OPENAI_REPO="$2"; shift 2;;
+  --main-ref)        MAIN_REF="$2"; shift 2;;
+  --out)             OUT="$2"; shift 2;;
+  --outdir)          OUTDIR="$2"; shift 2;;
+  --version)         VERSION="$2"; shift 2;;
+  --env-file)        ENV_FILE="$2"; shift 2;;
+  --prompt-file)     PROMPT_FILE="$2"; shift 2;;
+  --advance-head)    ADVANCE_HEAD=1; shift;;
+  --no-claude)       NO_CLAUDE=1; shift;;
+  -h|--help) sed -n '2,30p' "$0"; exit 0;;
+  *) echo "unknown arg: $1" >&2; exit 2;;
+esac; done
+
+cd "$REPO_ROOT"
+VERSION="${VERSION:-${RELEASE#release/}}"; VERSION="${VERSION//\//-}"   # release/3.7.x -> 3.7.x
+OUTDIR="${OUTDIR:-$REPO_ROOT/.backports/$VERSION}"
+OUT="${OUT:-$OUTDIR/candidates.tsv}"
+ENV_FILE="${ENV_FILE:-$OUTDIR/.backport-sync.env}"
+mkdir -p "$OUTDIR"
+
+# env-file vars for this release (slug: release/3.7.x -> release_3_7_x)
+SLUG="$(printf '%s' "$RELEASE" | tr '/.-' '___')"
+OPENAI_VAR="OPENAI_FRONTIER_$SLUG"      # last-synced OpenAI-release commit
+META_VAR="META_MAIN_FRONTIER_$SLUG"     # last-triaged Meta-main commit
+
+record_kv() {   # upsert KEY=VAL in the env file, preserving other keys
+  local key="$1" val="$2" tmp; tmp="$(mktemp)"
+  { echo "# backport-sync frontier state (per release branch)"
+    [[ -f "$ENV_FILE" ]] && grep -vE "^(#|$key=)" "$ENV_FILE" || true
+    echo "$key=$val"; } > "$tmp"
+  mv "$tmp" "$ENV_FILE"
+}
+
+echo ">>> [1] Fetch heads live (not from a stale mirror)"
+git fetch -f "$OPENAI_URL" "$RELEASE:refs/remotes/openai/$RELEASE"
+git fetch origin "$RELEASE" main
+OPENAI_HEAD="$(git rev-parse openai/"$RELEASE")"
+REL_REF="origin/$RELEASE"                        # Meta release: freshly-fetched remote-tracking ref
+REL_HEAD="$(git rev-parse "$REL_REF")"
+MAIN_HEAD="$(git rev-parse "$MAIN_REF")"
+
+# --advance-head: record both heads as the new frontiers and exit (run after a sync lands)
+if [[ -n "$ADVANCE_HEAD" ]]; then
+  record_kv "$OPENAI_VAR" "$OPENAI_HEAD"
+  record_kv "$META_VAR"   "$MAIN_HEAD"
+  echo ">>> Advanced frontiers in $ENV_FILE:"
+  echo "      OpenAI -> $(git rev-parse --short "$OPENAI_HEAD")   Meta-main -> $(git rev-parse --short "$MAIN_HEAD")"
+  exit 0
+fi
+
+# bootstrap: newest Meta release-tip commit that maps to a commit on OpenAI's release
+bootstrap_frontier() {
+  local oair="openai/$RELEASE" H S B h pr m
+  while IFS=$'\t' read -r H S; do
+    B="$(git log -1 --format='%b' "$H")"
+    for h in $(printf '%s\n' "$B" | grep -oiE 'cherry picked from commit [0-9a-f]{7,40}' | awk '{print $NF}'); do
+      git merge-base --is-ancestor "$h" "$oair" 2>/dev/null && { echo "$h"; return 0; }
+    done
+    for pr in $(printf '%s\n%s\n' "$S" "$B" | grep -oE '#[0-9]+' | tr -d '#' | sort -urn); do
+      m="$(git log "$oair" -1 --format='%H' --extended-regexp --grep="#${pr}([^0-9]|\$)" 2>/dev/null || true)"
+      [[ -n "$m" ]] && { echo "$m"; return 0; }
+    done
+    m="$(git log "$oair" -1 --format='%H' --fixed-strings --grep="$S" 2>/dev/null || true)"
+    [[ -n "$m" ]] && { echo "$m"; return 0; }
+  done < <(git log "$REL_REF" --format='%H%x09%s' | head -80)
+  return 1
+}
+
+echo ">>> [2] Resolve frontiers"
+# Check the target branch's frontier state file FIRST — it's the source of truth;
+# only bootstrap if it's missing (or a specific frontier isn't recorded yet).
+if [[ -f "$ENV_FILE" ]]; then
+  echo "    frontier state: $ENV_FILE (checked first)"
+  # shellcheck disable=SC1090
+  source "$ENV_FILE" 2>/dev/null || true
+else
+  echo "    frontier state: none at $ENV_FILE -> will bootstrap"
+fi
+
+# --- OpenAI-release frontier ---  (override flag > env file > bootstrap)
+OPENAI_SRC="override"
+if [[ -z "$OPENAI_FRONTIER" ]]; then
+  OPENAI_FRONTIER="${!OPENAI_VAR:-}"; [[ -n "$OPENAI_FRONTIER" ]] && OPENAI_SRC="env file"
+fi
+if [[ -z "$OPENAI_FRONTIER" ]]; then
+  if OPENAI_FRONTIER="$(bootstrap_frontier)" && [[ -n "$OPENAI_FRONTIER" ]]; then
+    OPENAI_SRC="bootstrap (hash/PR#/title match)"; record_kv "$OPENAI_VAR" "$OPENAI_FRONTIER"
+  else
+    echo "    !! OpenAI bootstrap match failed — falling back to the release fork-point" >&2
+    # fork-point = merge-base(release, main) on the OpenAI clone's remote refs (ancestor of openai/$RELEASE)
+    OPENAI_FRONTIER="$(git -C "$OPENAI_REPO" merge-base "origin/$RELEASE" origin/main 2>/dev/null || true)"
+    [[ -z "$OPENAI_FRONTIER" ]] && OPENAI_FRONTIER="$(git rev-list --max-parents=0 "openai/$RELEASE" | tail -1)"
+    OPENAI_SRC="FALLBACK: release fork-point via $OPENAI_REPO (review everything since the branch cut!)"
+    record_kv "$OPENAI_VAR" "$OPENAI_FRONTIER"
+  fi
+fi
+git rev-parse -q --verify "$OPENAI_FRONTIER^{commit}" >/dev/null 2>&1 || {
+  echo "ERROR: OpenAI frontier '$OPENAI_FRONTIER' is not a valid commit." >&2; exit 2; }
+
+# --- Meta-main frontier (symmetric) ---  (override flag > env file > bootstrap)
+META_SRC="override"
+if [[ -z "$META_FRONTIER" ]]; then
+  META_FRONTIER="${!META_VAR:-}"; [[ -n "$META_FRONTIER" ]] && META_SRC="env file"
+fi
+if [[ -z "$META_FRONTIER" ]]; then
+  META_FRONTIER="$(git merge-base "$REL_REF" "$MAIN_REF")"   # bootstrap = release fork-point on main
+  META_SRC="bootstrap (release fork-point on main)"; record_kv "$META_VAR" "$META_FRONTIER"
+fi
+git rev-parse -q --verify "$META_FRONTIER^{commit}" >/dev/null 2>&1 || {
+  echo "ERROR: Meta-main frontier '$META_FRONTIER' is not a valid commit." >&2; exit 2; }
+
+echo ">>> [3] Anchors  (candidates = frontier..head for each)"
+printf '    OpenAI    %s : frontier %s .. head %s   (via %s)\n' "$RELEASE" \
+  "$(git rev-parse --short "$OPENAI_FRONTIER")" "$(git rev-parse --short "$OPENAI_HEAD")" "$OPENAI_SRC"
+printf '    Meta-main %s : frontier %s .. head %s   (via %s)\n' "$RELEASE" \
+  "$(git rev-parse --short "$META_FRONTIER")" "$(git rev-parse --short "$MAIN_HEAD")" "$META_SRC"
+echo "    (override: --openai-frontier / --meta-frontier <sha>; both tracked in $ENV_FILE)"
+
+# reads "sha|subject" on stdin, emits "present<TAB>class<TAB>sha<TAB>subject"
+classify() {
+  local relref="$1" h s fixpr present class
+  while IFS='|' read -r h s; do
+    fixpr="$(printf '%s' "$s" | grep -oE '#[0-9]+' | head -1 | tr -d '#' || true)"
+    present="new"
+    if [[ -n "$fixpr" ]] && git log "$relref" --oneline | grep -qE "#${fixpr}\b"; then present="in-fork"; fi
+    case "$s" in
+      *Cherry-pick*BUNDLE*|*Cherry-pick*upstream*)                                  class="bundle";;
+      *[Vv]ersion*|*pypi*|*PyPI*|*Release\ Only*|*Release-only*|*wheel*|*Wheels*|*timeout*|*DOCKER*|*examples/*|*Pin\ LLVM*|*toolchain-version*) class="plumbing";;
+      *Revert*|*revert*)                                                            class="revert";;
+      *AMD*|*MFMA*|*WMMA*|*gfx*|*GFX*)                                              class="amd";;
+      *[Ff]ix*|*crash*|*SIGSEGV*|*assert*|*deadlock*|*race*|*hang*|*verify*|*correct*) class="fix";;
+      *)                                                                            class="other";;
+    esac
+    printf '%s\t%s\t%s\t%s\n' "$present" "$class" "$h" "$s"
+  done
+}
+
+echo ">>> [4] Enumerate + classify -> $OUT"
+{
+  printf '# release=%s\topenai_frontier=%s\topenai_head=%s\tmeta_frontier=%s\tmain_head=%s\n' \
+    "$RELEASE" "$(git rev-parse "$OPENAI_FRONTIER")" "$OPENAI_HEAD" "$(git rev-parse "$META_FRONTIER")" "$MAIN_HEAD"
+  printf '#source\tpresent\tclass\tsha\tsubject\n'
+  git log --reverse --format='%h|%s' "$OPENAI_FRONTIER..openai/$RELEASE" | classify "$REL_REF" | sed 's/^/openai\t/'
+  git log --reverse --format='%h|%s' "$META_FRONTIER..$MAIN_REF"         | classify "$REL_REF" | sed 's/^/meta-main\t/'
+} > "$OUT"
+echo "    OpenAI candidates: $(git rev-list --count "$OPENAI_FRONTIER..openai/$RELEASE")" \
+     "| Meta-main candidates: $(git rev-list --count "$META_FRONTIER..$MAIN_REF")"
+
+echo ">>> [5] Hand off to Claude (interactive by default; HEADLESS=1 for one-shot)"
+[[ -f "$PROMPT_FILE" ]] || { echo "ERROR: prompt file not found: $PROMPT_FILE" >&2; exit 2; }
+RUN_CONTEXT="Candidates for $RELEASE are in $OUT (pinned frontiers/heads in its header line). Write audit-report.md and pick-list.txt into $OUTDIR."
+FULL_PROMPT="$(cat "$PROMPT_FILE")
+
+$RUN_CONTEXT"
+
+if [[ -n "${NO_CLAUDE:-}" ]] || ! command -v claude >/dev/null 2>&1; then
+  echo "    (claude not invoked — NO_CLAUDE set or 'claude' not on PATH). Artifact: $OUTDIR/candidates.tsv"
+  echo "    Triage manually:  claude --secure-internet-mode \"\$(cat $PROMPT_FILE)\"   (candidates in $OUT; write to $OUTDIR)"
+elif [[ -n "${HEADLESS:-}" ]]; then
+  # --secure-internet-mode: allow the git/gh reads the triage needs, but sandbox
+  # egress so the agent can't send our data off-box (see the prompt's data rule).
+  claude --secure-internet-mode -p "$FULL_PROMPT" | tee "$OUTDIR/report.md"
+  echo ">>> Artifacts in $OUTDIR:  candidates.tsv, audit-report.md, pick-list.txt, report.md"
+else
+  echo ">>> Starting interactive Claude session for triage (needs a TTY)."
+  claude --secure-internet-mode "$FULL_PROMPT"
+  echo ">>> Session ended. Artifacts in $OUTDIR:  candidates.tsv, audit-report.md, pick-list.txt"
+fi
+
+echo ">>> [6] Format all files with pre-commit (repo venv) + auto-commit fixes"
+PRE_COMMIT="$REPO_ROOT/.venv/bin/pre-commit"
+if [[ -x "$PRE_COMMIT" ]]; then
+  # pre-commit reformats in place and exits non-zero when it changes files.
+  "$PRE_COMMIT" run --all-files || true
+  git add -u                        # stage the reformatted (tracked) files only
+  if git diff --cached --quiet; then
+    echo "    no formatting changes to commit."
+  else
+    git commit -m "[lint] Auto-fix pre-commit formatting issues" \
+               -m "Generated by backport-sync.sh step [6] (pre-commit run --all-files)."
+    echo "    committed formatting fixes: $(git rev-parse --short HEAD)"
+  fi
+else
+  echo "    (skipped: $PRE_COMMIT not found — create the venv or adjust the path)"
+fi

--- a/.claude/skills/fbtriton-backport/backport-sync.sh
+++ b/.claude/skills/fbtriton-backport/backport-sync.sh
@@ -8,6 +8,9 @@
 #   2. Resolves the OpenAI frontier (see "Frontier" below) and prints how.
 #   3. Enumerates candidate commits `frontier..head` for each source.
 #   4. Classifies each (fix / amd / plumbing / revert / bundle) + a presence hint.
+#      `fix` is matched before `amd` so an AMD/gfx *fix* isn't swallowed by the arch
+#      bucket; a commit that edits a watched TLX/WS test AND compiler code is promoted to
+#      `fix` and its subject gets a `[tlx-test]` flag (a fix can hide as a "Repro"; #2285).
 #   5. Writes a candidates file and opens an INTERACTIVE Claude session for the
 #      judgment + report (HEADLESS=1 for one-shot `claude -p`; NO_CLAUDE=1 to skip).
 #      Claude is launched with --secure-internet-mode: it keeps the internet
@@ -171,20 +174,32 @@ echo "    (override: --openai-frontier / --meta-frontier <sha>; both tracked in 
 
 # reads "sha|subject" on stdin, emits "present<TAB>class<TAB>sha<TAB>subject"
 classify() {
-  local relref="$1" h s fixpr present class
+  local relref="$1" h s fixpr present class files test_touch lib_touch tflag
   while IFS='|' read -r h s; do
     fixpr="$(printf '%s' "$s" | grep -oE '#[0-9]+' | head -1 | tr -d '#' || true)"
     present="new"
     if [[ -n "$fixpr" ]] && git log "$relref" --oneline | grep -qE "#${fixpr}\b"; then present="in-fork"; fi
+    # Files the commit touches -- used to spot fix-bearing "test/repro" commits (see #2285:
+    # a CoalesceAsyncCopy fallback shipped under a "Repro: ... fails to legalize" title).
+    files="$(git diff-tree --no-commit-id --name-only -r "$h" 2>/dev/null || true)"
+    test_touch="$(printf '%s\n' "$files" | grep -cE 'test/unit/language/(test_tlx.*|test_warp_specialization|test_tutorial09_warp_specialization)\.py' || true)"
+    lib_touch="$(printf '%s\n' "$files" | grep -cE '(^|/)lib/|/lib/Transforms/|TritonAMDGPUTransforms|TritonAMDGPUToLLVM|TritonGPUToLLVM' || true)"
     case "$s" in
       *Cherry-pick*BUNDLE*|*Cherry-pick*upstream*)                                  class="bundle";;
       *[Vv]ersion*|*pypi*|*PyPI*|*Release\ Only*|*Release-only*|*wheel*|*Wheels*|*timeout*|*DOCKER*|*examples/*|*Pin\ LLVM*|*toolchain-version*) class="plumbing";;
       *Revert*|*revert*)                                                            class="revert";;
+      # fix BEFORE amd: an AMD/gfx *fix* must classify as fix, not get swallowed by the arch
+      # bucket. Keywords include lowering/legalization failures (the #2285 failure mode).
+      *[Ff]ix*|*crash*|*SIGSEGV*|*assert*|*deadlock*|*race*|*hang*|*verify*|*correct*|*legaliz*|*[Uu]nrealized*|*lower*|*translate*) class="fix";;
       *AMD*|*MFMA*|*WMMA*|*gfx*|*GFX*)                                              class="amd";;
-      *[Ff]ix*|*crash*|*SIGSEGV*|*assert*|*deadlock*|*race*|*hang*|*verify*|*correct*) class="fix";;
       *)                                                                            class="other";;
     esac
-    printf '%s\t%s\t%s\t%s\n' "$present" "$class" "$h" "$s"
+    # A commit that edits a watched TLX/WS test AND compiler code is fix-bearing even when
+    # titled "Repro"/"Test" -- promote it, and always flag any watched-test touch so triage
+    # (and the test-diff cross-check in SKILL.md) never skips it as "just a test".
+    if [[ "$class" != "bundle" && "$test_touch" -gt 0 && "$lib_touch" -gt 0 ]]; then class="fix"; fi
+    tflag=""; [[ "$test_touch" -gt 0 ]] && tflag=" [tlx-test]"
+    printf '%s\t%s\t%s\t%s\n' "$present" "$class" "$h" "$s$tflag"
   done
 }
 

--- a/.claude/skills/fbtriton-backport/build-wheel.sh
+++ b/.claude/skills/fbtriton-backport/build-wheel.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Build the meta-triton wheel locally on a CentOS 9 / RHEL 9 devgpu.
+#
+# Steps:
+#   1. Prompt for paths (googletest, Triton cache, GCC toolset).
+#   2. Verify prereqs: uv, gcc-toolset-14, and proxy env if a fetch is needed.
+#   3. Clone googletest v1.17.0 into GOOGLETEST_DIR (skipped if present).
+#   4. Download the prebuilt LLVM tarball matching cmake/llvm-info.json into
+#      $TRITON_CACHE/llvm/<name>/ and write a version.txt so setup.py picks
+#      it up instead of trying to fetch (skipped if already cached).
+#   5. Optionally clean prior build/ and dist/*.whl.
+#   6. Source gcc-toolset-14 (provides GLIBCXX_3.4.30 + __glibcxx_assert_fail
+#      that the prebuilt LLVM static libs depend on).
+#   7. Run `uv build --wheel`, which spins up a fresh PEP 517 build env under
+#      ~/.cache/uv/builds-v0/ (NOT a persistent venv), installs the build deps
+#      from pyproject.toml (setuptools/cmake/ninja/pybind11), invokes
+#      setuptools.build_meta.build_wheel which runs cmake/ninja, and writes
+#      the wheel to dist/. The build env is discarded after.
+#
+# Interactive: prompts for paths / decisions when not provided. Override via
+# env vars to skip prompts: GOOGLETEST_DIR, TRITON_CACHE, GCC_TOOLSET, CLEAN.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+mkdir -p "$REPO_ROOT/dist"
+LOG_FILE="$REPO_ROOT/dist/build-$(date +%Y%m%d-%H%M%S).log"
+
+# --- prompt helpers ----------------------------------------------------------
+
+is_tty() { [[ -t 0 && -t 1 ]]; }
+
+# prompt_path VAR DEFAULT QUESTION
+prompt_path() {
+  local var="$1" default="$2" question="$3" answer
+  if [[ -n "${!var:-}" ]]; then
+    return
+  fi
+  if ! is_tty; then
+    printf -v "$var" '%s' "$default"
+    return
+  fi
+  read -rp "${question} [${default}]: " answer
+  printf -v "$var" '%s' "${answer:-$default}"
+}
+
+# prompt_yn VAR DEFAULT QUESTION   (DEFAULT = y or n)
+prompt_yn() {
+  local var="$1" default="$2" question="$3" answer prompt
+  if [[ -n "${!var:-}" ]]; then
+    return
+  fi
+  if ! is_tty; then
+    printf -v "$var" '%s' "$default"
+    return
+  fi
+  if [[ "$default" == "y" ]]; then prompt="[Y/n]"; else prompt="[y/N]"; fi
+  read -rp "${question} ${prompt}: " answer
+  answer="${answer:-$default}"
+  case "$answer" in
+    [Yy]*) printf -v "$var" 'y' ;;
+    *)     printf -v "$var" 'n' ;;
+  esac
+}
+
+# --- gather inputs -----------------------------------------------------------
+
+cat <<'EOF'
+============================================================
+ meta-triton local wheel build
+============================================================
+This script will:
+  1. Stage googletest v1.17.0 (clone if missing).
+  2. Stage the prebuilt LLVM matching cmake/llvm-info.json
+     into the Triton cache (download if missing).
+  3. Activate gcc-toolset-14 (newer libstdc++ symbols that
+     the prebuilt LLVM libs reference).
+  4. Run `uv build --wheel`, which uses an ephemeral PEP 517
+     build env under ~/.cache/uv/builds-v0/ (NOT a persistent
+     venv) to invoke setuptools -> cmake -> ninja, and writes
+     the resulting wheel to dist/.
+
+Network fetches (steps 1-2) require Meta's `with-proxy` wrapper
+on the first run; subsequent builds reuse the local cache.
+============================================================
+
+EOF
+
+prompt_path GOOGLETEST_DIR "$REPO_ROOT/.googletest" \
+  "Where should googletest live?"
+prompt_path TRITON_CACHE   "${TRITON_HOME:-$HOME/.triton}" \
+  "Triton cache root (LLVM tarball will be staged here)?"
+prompt_path GCC_TOOLSET    "/opt/rh/gcc-toolset-14" \
+  "GCC toolset prefix?"
+
+if [[ -d "$REPO_ROOT/build" || -n "$(echo "$REPO_ROOT"/dist/*.whl 2>/dev/null)" ]]; then
+  prompt_yn CLEAN "n" "Clean previous build/ and dist/*.whl before building?"
+else
+  CLEAN="n"
+fi
+
+LLVM_SUFFIX="almalinux-x64"
+# LLVM pin source: newer branches use cmake/llvm-info.json (llvm_hash +
+# build_number; the tarball name includes the build number). Older branches use
+# the bare cmake/llvm-hash.txt (no build number). Support both.
+if [[ -f "$REPO_ROOT/cmake/llvm-info.json" ]]; then
+  LLVM_HASH="$(python3 -c "import json;print(json.load(open('$REPO_ROOT/cmake/llvm-info.json'))['llvm_hash'][:8])")"
+  LLVM_BUILD="$(python3 -c "import json;print(json.load(open('$REPO_ROOT/cmake/llvm-info.json'))['build_number'])")"
+  LLVM_NAME="llvm-${LLVM_HASH}-${LLVM_SUFFIX}-${LLVM_BUILD}"
+else
+  LLVM_HASH="$(cut -c1-8 "$REPO_ROOT/cmake/llvm-hash.txt")"
+  LLVM_NAME="llvm-${LLVM_HASH}-${LLVM_SUFFIX}"
+fi
+LLVM_URL="https://oaitriton.blob.core.windows.net/public/llvm-builds/${LLVM_NAME}.tar.gz"
+LLVM_DIR="${TRITON_CACHE}/llvm/${LLVM_NAME}"
+
+cat <<EOF
+
+Plan:
+  Repo:           $REPO_ROOT
+  googletest:     $GOOGLETEST_DIR  $( [[ -d "$GOOGLETEST_DIR/.git" ]] && echo "(present)" || echo "(will clone v1.17.0)" )
+  Triton cache:   $TRITON_CACHE
+  LLVM:           $LLVM_DIR  $( [[ -f "$LLVM_DIR/version.txt" ]] && echo "(cached)" || echo "(will download)" )
+  GCC toolset:    $GCC_TOOLSET
+  Clean rebuild:  $CLEAN
+
+EOF
+
+prompt_yn PROCEED "y" "Proceed?"
+[[ "$PROCEED" == "y" ]] || { echo "Aborted."; exit 0; }
+
+# Interactive phase done; tee everything else (clone, download, build) to the log.
+echo "Logging to: $LOG_FILE"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+# --- prereq checks -----------------------------------------------------------
+
+if ! command -v uv >/dev/null; then
+  echo "ERROR: 'uv' not found on PATH. Install from https://docs.astral.sh/uv/" >&2
+  exit 1
+fi
+
+if [[ ! -f "$GCC_TOOLSET/enable" ]]; then
+  echo "ERROR: $GCC_TOOLSET/enable not found." >&2
+  echo "Install with: sudo dnf install -y gcc-toolset-14" >&2
+  exit 1
+fi
+
+# Network access: github.com (googletest) and oaitriton.blob.core.windows.net
+# (LLVM tarball) are not reachable directly from Meta devgpus. Re-run via
+# /usr/bin/with-proxy if a fetch is needed and proxy env isn't set.
+NEED_NET=0
+[[ ! -d "$GOOGLETEST_DIR/.git" ]] && NEED_NET=1
+{ [[ ! -f "$LLVM_DIR/version.txt" ]] || [[ "$(cat "$LLVM_DIR/version.txt")" != "$LLVM_URL" ]]; } && NEED_NET=1
+if [[ "$NEED_NET" == 1 && -z "${HTTPS_PROXY:-${https_proxy:-}}" && -x /usr/bin/with-proxy ]]; then
+  echo "ERROR: network fetch needed (googletest and/or LLVM) but no proxy is set." >&2
+  echo "Re-run via with-proxy:" >&2
+  echo "  with-proxy $0 $*" >&2
+  exit 1
+fi
+
+# --- googletest --------------------------------------------------------------
+
+if [[ ! -d "$GOOGLETEST_DIR/.git" ]]; then
+  echo ">>> Cloning googletest v1.17.0 to $GOOGLETEST_DIR"
+  git clone --depth 1 --branch v1.17.0 \
+    https://github.com/google/googletest.git "$GOOGLETEST_DIR"
+else
+  echo ">>> googletest already at $GOOGLETEST_DIR"
+fi
+
+# --- prebuilt LLVM matching cmake/llvm-info.json -----------------------------
+
+if [[ ! -f "$LLVM_DIR/version.txt" ]] || [[ "$(cat "$LLVM_DIR/version.txt")" != "$LLVM_URL" ]]; then
+  echo ">>> Downloading $LLVM_NAME"
+  mkdir -p "${TRITON_CACHE}/llvm"
+  curl -fL -o "${TRITON_CACHE}/llvm/${LLVM_NAME}.tar.gz" "$LLVM_URL"
+  tar -xzf "${TRITON_CACHE}/llvm/${LLVM_NAME}.tar.gz" -C "${TRITON_CACHE}/llvm"
+  printf '%s' "$LLVM_URL" > "$LLVM_DIR/version.txt"
+else
+  echo ">>> LLVM already cached at $LLVM_DIR"
+fi
+
+# --- clean (optional) --------------------------------------------------------
+
+if [[ "$CLEAN" == "y" ]]; then
+  echo ">>> Cleaning build/ and dist/*.whl"
+  rm -rf "$REPO_ROOT/build" "$REPO_ROOT"/dist/*.whl
+fi
+
+# --- build -------------------------------------------------------------------
+
+# shellcheck disable=SC1091
+source "$GCC_TOOLSET/enable"
+
+echo ">>> Building wheel ($(c++ --version | head -1))"
+cd "$REPO_ROOT"
+TRITON_LLVM_SYSTEM_SUFFIX="$LLVM_SUFFIX" \
+TRITON_APPEND_CMAKE_ARGS="-DGOOGLETEST_DIR=$GOOGLETEST_DIR -DTRITON_BUILD_UT=OFF" \
+  uv build --wheel . -o dist/ -p python3
+
+echo
+echo ">>> Done:"
+ls -lh "$REPO_ROOT/dist/"*.whl
+echo
+echo "Build log saved to: $LOG_FILE"
+echo "To test the wheel:  $REPO_ROOT/.claude/skills/fbtriton-backport/test-wheel.sh"

--- a/.claude/skills/fbtriton-backport/find-machinery.sh
+++ b/.claude/skills/fbtriton-backport/find-machinery.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# find-machinery.sh — Phase-2 (Step 2) helper for the fbtriton-backport skill.
+# Given a candidate commit, RECURSIVELY unfold the full set of machinery commits it needs
+# (all the way down to the release-branch cut) and print one ordered action plan:
+#   ① cherry-pick (clean, oldest→newest)   ③ shim / pick-upstream-original (bundles/collisions)
+#   ✓ already present (skip)
+#
+# "Machinery" = a commit on <main> since the cut whose change to a file the candidate touches
+# makes the candidate no longer 3-way-merge cleanly onto <onto> (real `git merge-file` check —
+# the same algorithm cherry-pick uses). Each such commit is then unfolded the same way.
+#
+# Usage:  find-machinery.sh <candidate-sha> [--release <ref>] [--onto <ref>] [--main <ref>]
+#   defaults: --release origin/release/3.7.x   --main origin/main   --onto <=release>
+#   --onto : 3-way-merge against THIS ref instead of bare release. Point it at your WIP pick-stack
+#            so the closure is the EXTRA machinery beyond candidates already picked (much smaller;
+#            vs bare release the closure also pulls in every other candidate).
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"; cd "$REPO_ROOT"
+
+RELEASE="origin/release/3.7.x"; MAIN="origin/main"; ONTO=""; CAND=""; MAX=400
+while [[ $# -gt 0 ]]; do case "$1" in
+  --release) RELEASE="$2"; shift 2;;
+  --onto)    ONTO="$2"; shift 2;;
+  --main)    MAIN="$2"; shift 2;;
+  --max)     MAX="$2"; shift 2;;
+  -h|--help) sed -n '2,19p' "$0"; exit 0;;
+  *)         CAND="$1"; shift;;
+esac; done
+[[ -n "$CAND" ]] || { echo "usage: $0 <candidate-sha|#PR> [--release <ref>] [--onto <ref>] [--main <ref>]" >&2; exit 2; }
+ONTO="${ONTO:-$RELEASE}"
+
+# accept "#2289" or "2289" (a PR number) → resolve to the commit on <main> for that PR.
+if [[ "$CAND" =~ ^#?[0-9]+$ ]]; then
+  pr="${CAND#\#}"
+  mapfile -t _m < <(git log "$MAIN" --fixed-strings --grep="(#$pr)" --format='%H %s' 2>/dev/null)
+  [[ ${#_m[@]} -gt 0 ]] || { echo "no commit on $MAIN mentions (#$pr) — pass a SHA instead" >&2; exit 2; }
+  CAND="${_m[0]%% *}"
+  echo "resolved #$pr → $(git rev-parse --short "$CAND")  ${_m[0]#* }"
+  (( ${#_m[@]} > 1 )) && { echo "note: ${#_m[@]} commits mention (#$pr) (PR#s can collide) — using the newest; pass a SHA to override:";
+                           printf '      %s\n' "${_m[@]}"; }
+  echo
+fi
+CUT="$(git merge-base "$RELEASE" "$MAIN")"
+
+# already_on_onto <sha> <onto> : present by IDENTITY (ancestor, or -x cherry-pick trailer carries
+# its full SHA). NOT by PR number — fbtriton/upstream reuse numbers (old "[DOCS] (#2320)" != coalesce #2320).
+already_on_onto() {
+  local full; full="$(git rev-parse "$1" 2>/dev/null)" || return 1
+  git merge-base --is-ancestor "$1" "$2" 2>/dev/null && return 0
+  git log "$2" --fixed-strings --grep="cherry picked from commit $full" --oneline 2>/dev/null | grep -q .
+}
+
+# machinery_of <sha> : print "shorthash<TAB>subject" for each commit on a file <sha> touches that
+# CONFLICTS 3-way onto ONTO. Empty output ⇒ <sha> cherry-picks clean onto ONTO.
+machinery_of() {
+  local sha="$1" st f base ours theirs
+  while IFS=$'\t' read -r st f; do
+    [[ -n "$f" ]] || continue
+    case "$st" in A*|D*) continue;; esac
+    base="$(mktemp)"; ours="$(mktemp)"; theirs="$(mktemp)"
+    git show "$sha^:$f" >"$base"   2>/dev/null || :
+    git show "$sha:$f"  >"$theirs" 2>/dev/null || :
+    if git cat-file -e "$ONTO:$f" 2>/dev/null; then
+      git show "$ONTO:$f" >"$ours" 2>/dev/null || :
+      if git merge-file -q -p "$ours" "$base" "$theirs" >/dev/null 2>&1; then
+        rm -f "$base" "$ours" "$theirs"; continue          # clean → not a conflicting file
+      fi
+    fi
+    rm -f "$base" "$ours" "$theirs"
+    # conflicting file → precise deps: only commits that touched the SAME LINES the candidate edits
+    # (git log -L on each hunk's old-side range). Pure additions (count 0) depend on no prior line.
+    git diff -U0 "$sha^" "$sha" -- "$f" 2>/dev/null \
+      | sed -nE 's/^@@ -([0-9]+),?([0-9]*) .*/\1 \2/p' | while read -r s c; do
+        c="${c:-1}"; [[ "$c" -eq 0 ]] && continue
+        git log -L "$s,$((s + c - 1)):$f" -s --format='%h%x09%s' "$CUT..$sha^" 2>/dev/null \
+          | grep -aE "^[0-9a-f]{7,}$(printf '\t')"
+      done
+  done < <(git diff-tree --no-commit-id --name-status -r "$sha")
+}
+
+if already_on_onto "$CAND" "$ONTO"; then
+  echo "candidate $(git rev-parse --short "$CAND") $(git show -s --format='%s' "$CAND" | grep -oE '\(#[0-9]+\)' | tail -1) is already present on ${ONTO##*/} — nothing to do."
+  exit 0
+fi
+
+# is_mixed <sha> : touches CI/build/meta files alongside code ⇒ likely a [partial] target — a
+# full pick would drag its unrelated machinery, so treat as terminal (don't recurse) and flag ③.
+is_mixed() {
+  git diff-tree --no-commit-id --name-only -r "$1" | grep -qE '^\.github/|^\.pre-commit-config|^\.ci/|(^|/)(BUCK|TARGETS)$'
+}
+
+# --- BFS transitive closure from the candidate down to the cut ---
+declare -A SEEN CLASS CSUBJ CTS REASON
+queue=()
+enq() { local l; while IFS= read -r l; do [[ -n "$l" ]] && queue+=("$l"); done < <(machinery_of "$1" | sort -u); }
+enq "$CAND"
+count=0; capped=0
+while ((${#queue[@]})); do
+  entry="${queue[0]}"; queue=("${queue[@]:1}")
+  h="${entry%%$'\t'*}"; subj="${entry#*$'\t'}"
+  full="$(git rev-parse "$h" 2>/dev/null)" || continue
+  [[ -n "${SEEN[$full]:-}" ]] && continue
+  SEEN[$full]=1; CSUBJ[$full]="$subj"; CTS[$full]="$(git show -s --format=%ct "$full" 2>/dev/null || echo 0)"
+  count=$((count+1)); if (( count > MAX )); then capped=1; break; fi
+  if already_on_onto "$h" "$ONTO"; then CLASS[$full]=skip; continue; fi
+  if grep -q '\[BUNDLE\]' <<<"$subj"; then
+    CLASS[$full]=shim; REASON[$full]="squashed bundle → pick the real upstream PR it contains, not the bundle"; continue
+  fi
+  if is_mixed "$h"; then
+    CLASS[$full]=shim; REASON[$full]="mixed (CI/build + code) → likely a [partial]: slice only the files you need (not recursing its unrelated machinery)"; continue
+  fi
+  CLASS[$full]=pick
+  enq "$h"                                                 # unfold this commit's own machinery
+done
+
+# --- gather + print ---
+picks=(); shims=(); skips=()
+for full in "${!SEEN[@]}"; do
+  row="${CTS[$full]}|$(git rev-parse --short "$full")|${CSUBJ[$full]}|${REASON[$full]:-}"
+  case "${CLASS[$full]}" in pick) picks+=("$row");; shim) shims+=("$row");; skip) skips+=("$row");; esac
+done
+emit() { local title="$1"; local -n a="$2"; [[ ${#a[@]} -eq 0 ]] && return
+  echo "$title"
+  printf '%s\n' "${a[@]}" | sort -t'|' -k1,1n | while IFS='|' read -r _ sha subj note; do
+    [[ -n "$note" ]] && printf '     %s  %-7s %s\n            ↳ %s\n' "$sha" "$(grep -oE '\(#[0-9]+\)' <<<"$subj" | tail -1 | tr -d '()' || echo —)" "${subj:0:60}" "$note" && continue
+    pr="$(grep -oE '\(#[0-9]+\)' <<<"$subj" | tail -1 | tr -d '()' || true)"
+    printf '     %s  %-7s %s\n' "$sha" "${pr:-—}" "${subj:0:66}"; done; }
+
+echo "candidate : $(git rev-parse --short "$CAND")  $(git show -s --format='%s' "$CAND")"
+echo "release   : $RELEASE  (cut $(git rev-parse --short "$CUT"))   onto: ${ONTO}"
+echo
+echo "=== SUGGESTED PLAN (heuristic from file-level 3-way merges — verify each; you decide pick / [partial] / [shim]) ==="
+if [[ ${#picks[@]} -eq 0 && ${#shims[@]} -eq 0 ]]; then
+  echo "  Looks clean — $(git rev-parse --short "$CAND") appears to merge with no extra machinery."
+  echo "  Suggest: git cherry-pick -x $(git rev-parse --short "$CAND")  (then probe/build to confirm)."
+else
+  emit "  ③ WORTH A JUDGMENT CALL — bundle or likely collision; consider the upstream original or a [partial]/[shim] (Phase 4b):" shims
+  emit "  ① LIKELY CLEAN PICKS — suggested order (oldest→newest); should apply once the ones above are in:" picks
+  emit "  ✓ ALREADY PRESENT — skip:" skips
+  echo
+  echo "  A workable order: consider the ${#shims[@]} item(s) in ③, then the ${#picks[@]} in ① top-to-bottom, then the candidate ($(git rev-parse --short "$CAND"))."
+  echo "  These come from file-level 3-way merges — confirm with a probe. A ① 'clean' one may still read better as a"
+  echo "  [partial]/[shim], and a ③ item may pick clean; the pick/partial/shim call is yours (Phase 3/4)."
+fi
+if [[ $capped -eq 1 ]]; then
+  echo "  ⚠️  stopped at --max=$MAX nodes — closure is huge; re-run with --onto <your pick-stack> to narrow it."
+fi
+exit 0

--- a/.claude/skills/fbtriton-backport/find-machinery.sh
+++ b/.claude/skills/fbtriton-backport/find-machinery.sh
@@ -67,13 +67,23 @@ machinery_of() {
       fi
     fi
     rm -f "$base" "$ours" "$theirs"
-    # conflicting file → precise deps: only commits that touched the SAME LINES the candidate edits
-    # (git log -L on each hunk's old-side range). Pure additions (count 0) depend on no prior line.
+    # conflicting file → precise deps: the commit(s) that own the lines the candidate's edit sits
+    # against, between the cut and the candidate (git log -L over each hunk).
+    #   - replace/delete hunk (old-count>0) → blame the old-side line range it rewrites.
+    #   - PURE ADDITION (old-count 0) → NOT dependency-free: an insertion still attaches to an
+    #     ANCHOR in the base (sha^). Blame a small window at/just before the insertion point, so an
+    #     append whose preceding block was created by an earlier PR surfaces that PR as machinery
+    #     (e.g. #2336's a4w4 tests append after #2337's test_tlx_gfx9_gemm_bench_* block → #2337).
     git diff -U0 "$sha^" "$sha" -- "$f" 2>/dev/null \
       | sed -nE 's/^@@ -([0-9]+),?([0-9]*) .*/\1 \2/p' | while read -r s c; do
-        c="${c:-1}"; [[ "$c" -eq 0 ]] && continue
-        git log -L "$s,$((s + c - 1)):$f" -s --format='%h%x09%s' "$CUT..$sha^" 2>/dev/null \
-          | grep -aE "^[0-9a-f]{7,}$(printf '\t')"
+        c="${c:-1}"
+        if [[ "$c" -eq 0 ]]; then
+          lo=$(( s > 3 ? s - 3 : 1 )); hi=$(( s > 0 ? s : 1 )); rng="$lo,$hi"   # anchor window in base
+        else
+          rng="$s,$((s + c - 1))"                                              # rewritten range
+        fi
+        git log -L "$rng:$f" -s --format='%h%x09%s' "$CUT..$sha^" 2>/dev/null \
+          | grep -aE "^[0-9a-f]{7,}$(printf '\t')" || true   # no-match hunk must not abort the loop (set -e)
       done
   done < <(git diff-tree --no-commit-id --name-status -r "$sha")
 }

--- a/.claude/skills/fbtriton-backport/partial-port-collision.md
+++ b/.claude/skills/fbtriton-backport/partial-port-collision.md
@@ -1,0 +1,168 @@
+# Backport hazard: split-lineage partial-port collision
+
+A recurring, hard-to-diagnose class of backport/cherry-pick problem. Written up from the
+v3.7.3 `#2153` / `#10081` / `#10194` / `#1847` case (2026-07) so the next person recognizes it
+fast instead of re-deriving it over a dozen probes.
+
+## Name / category
+
+**Split-lineage partial-port collision** — also: *inherited adapted-port divergence*,
+*out-of-order dependency ingestion across a branch cut*.
+
+A fix enters the fork **twice, by two different paths**, and a **branch cut lands between them**,
+so the release branch inherits a *partial, adapted* slice of the fix while the *full/original*
+version stays on `main`. Later, cherry-picking the original (or a follow-up that depends on it)
+**collides with the inherited slice** on the overlapping files — even though the branch "already
+has the fix" and "never picked the bundle."
+
+## Why it's confusing (the tells)
+
+- "We never picked that bundle, so why is there a conflict?" — the conflict isn't from the bundle;
+  it's from a *different, earlier* commit that carried an adapted slice of the same change.
+- Part of the commit cherry-picks **clean**, part **conflicts** — the split maps exactly onto
+  *which files the earlier partial port already touched*.
+- The conflicting file often has **more/renamed content** than the commit you're picking
+  (release is "ahead" on that file), so naive "match main" resolution would **regress** it.
+- The dependency looks like a deep cascade in `git log <file>` history, but on *your branch* only
+  one or two files actually conflict. (Don't confuse file *history* with branch *conflicts*.)
+
+## Anatomy of the v3.7.3 case (worked example)
+
+Upstream dependency chain: **#10081** (base: token-aware asyncmark wait counts, adds the SWP
+`updateWaits` call + 3 tests) → **#10194** (follow-up BlockPingpong fix).
+
+Two ingestion paths into fbtriton:
+1. **Early hand-port (partial + adapted):** `#1847` ported *#10194's block-pingpong half* from a
+   feature branch onto `main` on **06-30**, adapting it (flag renamed `gfx-arch` →
+   `arch-generation-name`, behavior tuned to conservative `num=0`). It did **not** bring #10081's
+   SWP `Pipeline.cpp` call or the standalone asyncmark tests.
+2. **Routine upstream bundle (full):** bundle `#2031` brought **#10081 + #10194 together** on
+   **07-15** — correct, but late, and it was later *dropped* from the v3.7.2 backport (fixes-only).
+
+**The branch cut (`release/3.7.x`, 07-06) fell between them.** So release inherited `#1847` (the
+adapted partial slice) and never got #10081.
+
+Result when trying to backport later:
+- `#10081` → conflicts on **only** `amd-block-pingpong-asyncmark-multi-token.mlir` (the file #1847
+  rewrote); its `Pipeline.cpp` + 2 new tests apply **clean** (the un-ported slice).
+- `#10194` → conflicts on `WGMMAPipeline.cpp` + `BlockPingpong.cpp` (exactly what #1847 ported).
+- Verified on a **clean release tip** (no local picks) → the collision is purely the inherited
+  `#1847`, not the bundle and not our own picks.
+
+## Diagnosis playbook
+
+1. **Reproduce on a clean release tip**, not your WIP branch, to rule out your own picks:
+   `git checkout -b probe origin/release/<x>; git cherry-pick -x <sha>; git diff --name-only --diff-filter=U`
+2. **Find who put the conflicting file on release:**
+   `git log origin/release/<x> --oneline -1 -- <conflicting-file>` → usually an *inherited* commit.
+3. **Is that commit inherited or backported?**
+   `git merge-base --is-ancestor <that-sha> <fork-point>` → YES = inherited at the cut.
+4. **Read that commit's message** — a "Port … from <feature-branch>" description = a hand-port;
+   check which upstream PRs it claims vs which files it actually touched (the *partial* set).
+5. **Split clean-vs-conflict by file** — the clean files are the un-ported slice; the conflicting
+   files are the already-ported (adapted) slice.
+6. **Check the true upstream** (`~/github/triton`) for the *current* form (flag names, logic) — it
+   may differ from both your branch and the commit you're picking; decide divergence direction
+   against the right reference (usually fbtriton `main`, not upstream).
+
+## Resolution: least-divergence shim, not a re-pick
+
+Do **not** cherry-pick the original commit wholesale — it re-applies the already-present slice in
+an older/foreign form, producing a **franken-state that matches neither `main` nor the branch**
+(maximal divergence), and may regress the adapted file.
+
+Instead, **build a minimal shim = only the un-ported slice, adapted to the branch's lineage:**
+- Apply just the hunks/files the branch is genuinely missing (here: #10081's `Pipeline.cpp`
+  `updateWaits` call), verifying the referenced symbols exist on the branch.
+- Materialize any needed test/support file from **fbtriton `main`** (not the raw upstream commit),
+  so it matches the fork's adapted form (flag names, etc.).
+- **Deliberately omit** the files the inherited partial port already owns (here: BlockPingpong.cpp
+  and the block-pingpong test) so nothing collides with it.
+- Land it as a clearly-labeled `[shim]` commit documenting what slice it takes, from where, and
+  what it omits and why.
+
+This lands the target fix (#2153, with its test) while keeping the inherited (#1847) lineage
+untouched — the lowest-divergence outcome.
+
+## Two triggers, one remedy (the shim)
+
+The "extract the minimal slice as a shim" remedy applies to **two** distinct situations. Both
+showed up in v3.7.3:
+
+- **Variant A — collision with an inherited partial port** (the #10081/#2153 case above). The
+  commit you want *conflicts* because an earlier adapted slice is already on the branch. Shim =
+  the **un-ported** slice (the files that apply clean), adapted to the branch's lineage.
+- **Variant B — wholesale import of a mixed commit** (the **#2149** case). The commit applies
+  *cleanly* but **bundles wanted + unrelated changes**. #2149 is titled "[CI] Isolate torchTLX…"
+  yet also carries the 226-line `amd_pa_decode.py` rewrite that #2281/#2288 depend on. Importing
+  it wholesale (even with the DU/conflict files resolved) drags **unrelated CI/lint divergence**
+  (`.github/workflows/*.yml`, `.pre-commit-config.yaml`) onto the release branch and leaves a
+  franken-commit (some files dropped, some kept-ours). Shim = the **wanted** slice only
+  (`git show <sha> -- <wanted files> | git apply --3way`), omitting everything else.
+
+Tell for Variant B: after the import, `git show --stat <your-commit>` lists files **outside** the
+subsystem you were backporting. If a "[CI]"/"[BE]"/"lint" commit is touching kernel code (or vice
+versa), it's a mixed commit — shim the slice, don't import the whole thing.
+
+## Which slices to include — the convergence test
+
+Aim the shim at **lowest divergence from Meta `main`**, not "smallest change to release."
+For each file a mixed commit touches, include its slice **only if that slice meaningfully
+converges the file to `main`**:
+
+```bash
+git diff origin/release/<x> origin/main -- <file> | grep -c '^[+-]'   # total gap to main
+git show <sha> -- <file>                          | grep -c '^[+-]'   # what this slice closes
+```
+
+- **slice ≈ whole gap** → the commit is the file's only delta → **include** (file becomes
+  `== main`; future picks touching it apply clean — this is the "easier next pick" payoff).
+- **slice ≪ gap** → the file is dominated by *other* divergence you are **not** backporting →
+  **skip**. Partial convergence there does **not** ease the next pick (the file still conflicts
+  on the rest) and only adds unwanted content.
+
+v3.7.3 #2149: `amd_pa_decode.py` slice = the file's whole gap → included (== main). The CI files
+`h100.yml`/`mi350.yml` had 34-/129-line gaps to main of which #2149 closed only 6/12 (main moved
+far ahead via other CI commits) → excluded; converging them is a separate CI-scope backport, not
+this shim's fragment.
+
+## Shim commit conventions
+
+- **Title = the source PR's original subject + PR#**, prefixed with a tag that says *how*
+  it's partial (keeps `backport-sync`'s PR#/title matching working — PR recognized as handled,
+  not re-offered — and preserves provenance):
+  - **`[partial]`** — a subset of a single PR (e.g. `[partial] [CI] Isolate torchTLX … (#2149)`,
+    decode files only).
+  - **`[shim]`** — a constructed bridge assembled from >1 source to enable a pick
+    (e.g. `[shim] [AMD][gfx9] Restore token-aware … (#10081)` = #10081's `Pipeline.cpp` call
+    + the test from `main`, to enable #2153).
+  - Rule of thumb: slice of one commit → `[partial]`; glued from multiple sources → `[shim]`.
+- **Body records both** the divergence reason and the shim reasoning (slice taken, files
+  omitted + why, `== main` verification). See the commit-message template in the
+  `fbtriton-backport` skill (Phase 4b), which this file is co-located under (`SKILL.md`).
+
+## Verify the shim is faithful
+
+A shim should reproduce exactly the base commit's slice that the routine bundle would have given —
+no more, no less. Confirm by diffing the shimmed files against fbtriton `main`:
+
+```bash
+git diff --quiet origin/main HEAD -- <shimmed-file>   # match = faithful
+```
+
+A match (modulo unrelated later evolution that postdates the release cut) means the shim equals
+"what the bundle would have brought, minus the collisions/irrelevant parts" — and you correctly
+avoided a wholesale bundle/commit pick. In v3.7.3 the asyncmark test file was byte-identical to
+`main`; the `Pipeline.cpp`/`WGMMAPipeline.cpp` files differed only by unrelated features/refactors
+that landed on `main` after the cut (the normal release-lag baseline every pick shares).
+
+## Prevention
+
+- **Don't hand-port a follow-up (#10194) ahead of its base (#10081).** If an urgent port is
+  needed, port the base first, or clearly mark the port as partial + adapted and file the base as
+  a follow-up so the routine bundle sync reconciles it.
+- **Bundle dependency-complete slices in order** so `base → follow-up` never split across bundles.
+- **Record adapted forks** (flag renames like `gfx-arch` → `arch-generation-name`) somewhere the
+  next backporter will see them — silent renames are what turn a clean pick into a conflict.
+- **Cut release branches at a bundle boundary**, not mid-window between a hand-port and the bundle
+  that completes it.

--- a/.claude/skills/fbtriton-backport/test-wheel.sh
+++ b/.claude/skills/fbtriton-backport/test-wheel.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Test a locally-built meta-triton wheel (produced by .claude/skills/fbtriton-backport/build-wheel.sh).
+#
+# Installs the wheel (arg > $WHEEL > newest in dist/) into a throwaway uv venv
+# alongside the torch build matching the GPU on this box (auto-detected: CUDA
+# torch for NVIDIA, ROCm torch for AMD — the default PyPI torch is CUDA-only and
+# reports torch.cuda.is_available()==False on an AMD box), then runs:
+#   1. a smoke kernel,
+#   2. the launch.h crash-fix tests (#1816),
+#   3. the TLX correctness suite (arch-gated: on AMD only amd/ikbo kernels run;
+#      on NVIDIA only Hopper/Blackwell — the rest auto-skip either way).
+#
+# Standalone: it sources gcc-toolset so the wheel's libtriton.so finds the newer
+# libstdc++ (GLIBCXX_3.4.30+ / __glibcxx_assert_fail) the prebuilt LLVM static
+# libs depend on at runtime — the same toolchain the build used.
+#
+# Usage:
+#   ./.claude/skills/fbtriton-backport/test-wheel.sh [path/to/wheel.whl]
+# Env overrides: WHEEL, TEST_VENV, GCC_TOOLSET, CUDA_VISIBLE_DEVICES, TLX_TIMEOUT,
+#                GPU_VENDOR (nvidia|amd, else auto-detected),
+#                TORCH_INDEX_URL (torch wheel index; else picked from the GPU).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+GCC_TOOLSET="${GCC_TOOLSET:-/opt/rh/gcc-toolset-14}"
+TLX_TIMEOUT="${TLX_TIMEOUT:-1800}"
+
+# --- detect GPU vendor + pick the matching torch wheel index -----------------
+# NVIDIA -> default PyPI (CUDA) torch. AMD -> ROCm torch, on an index matching
+# the gfx arch: gfx950 (MI350/CDNA4) and gfx12xx need ROCm 7.0; older cards work
+# with ROCm 6.4. Override GPU_VENDOR / TORCH_INDEX_URL to bypass detection.
+# Capture rocminfo once (grep'ing its pipe directly would SIGPIPE it and, under
+# pipefail, make the detection conditional falsely fail).
+ROCMINFO_OUT="$(command -v rocminfo >/dev/null 2>&1 && rocminfo 2>/dev/null || true)"
+
+GPU_VENDOR="${GPU_VENDOR:-}"
+if [[ -z "$GPU_VENDOR" ]]; then
+  if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
+    GPU_VENDOR="nvidia"
+  elif grep -q 'Name:.*gfx' <<<"$ROCMINFO_OUT"; then
+    GPU_VENDOR="amd"
+  else
+    echo "ERROR: no NVIDIA or AMD GPU detected (need nvidia-smi or rocminfo)." >&2
+    echo "Set GPU_VENDOR=nvidia|amd to override." >&2
+    exit 1
+  fi
+fi
+
+TORCH_INDEX_URL="${TORCH_INDEX_URL:-}"
+if [[ -z "$TORCH_INDEX_URL" ]]; then
+  case "$GPU_VENDOR" in
+    nvidia) TORCH_INDEX_URL="https://download.pytorch.org/whl" ;;  # CUDA (PyPI default)
+    amd)
+      GFX_ARCH="$(grep -oE -m1 'gfx[0-9a-f]+' <<<"$ROCMINFO_OUT" || true)"
+      case "$GFX_ARCH" in
+        gfx950|gfx12*) TORCH_INDEX_URL="https://download.pytorch.org/whl/rocm7.0" ;;
+        *)             TORCH_INDEX_URL="https://download.pytorch.org/whl/rocm6.4" ;;
+      esac
+      echo ">>> AMD GPU $GFX_ARCH -> torch index $TORCH_INDEX_URL"
+      ;;
+    *) echo "ERROR: unknown GPU_VENDOR '$GPU_VENDOR' (want nvidia|amd)." >&2; exit 1 ;;
+  esac
+fi
+echo ">>> GPU vendor: $GPU_VENDOR"
+
+# --- locate the wheel: positional arg > $WHEEL > newest in dist/ --------------
+WHEEL="${1:-${WHEEL:-}}"
+if [[ -z "$WHEEL" ]]; then
+  WHEEL="$(ls -t "$REPO_ROOT"/dist/*.whl 2>/dev/null | head -1 || true)"
+fi
+if [[ -z "$WHEEL" || ! -f "$WHEEL" ]]; then
+  echo "ERROR: no wheel found. Build one first (.claude/skills/fbtriton-backport/build-wheel.sh) or pass a path." >&2
+  exit 1
+fi
+
+# --- prereqs -----------------------------------------------------------------
+command -v uv >/dev/null || { echo "ERROR: 'uv' not found on PATH." >&2; exit 1; }
+if [[ ! -f "$GCC_TOOLSET/enable" ]]; then
+  echo "ERROR: $GCC_TOOLSET/enable not found (install: sudo dnf install -y gcc-toolset-14)." >&2
+  exit 1
+fi
+
+# gcc-toolset supplies the newer libstdc++ the wheel needs at runtime.
+# shellcheck disable=SC1091
+source "$GCC_TOOLSET/enable"
+
+# --- install the wheel into a throwaway venv ---------------------------------
+echo ">>> Installing $(basename "$WHEEL") into $REPO_ROOT/.venv"
+uv venv -p python3.13 --clear
+source .venv/bin/activate
+uv pip install torch --index-url "$TORCH_INDEX_URL"
+uv pip install pytest pytest-xdist numpy torchao
+
+# ROCm torch pulls in the upstream 'triton-rocm' package (ships its own triton/),
+# and the CUDA torch pulls in 'pytorch-triton'; either would shadow our wheel.
+# Drop both (plus any prior 'triton') before installing the wheel under test.
+uv pip uninstall triton triton-rocm pytorch-triton >/dev/null 2>&1 || true
+uv pip install "$WHEEL"
+
+# --- 1. smoke ----------------------------------------------------------------
+echo ">>> Smoke: compile + run a trivial kernel"
+# Real .py file: @triton.jit needs inspect.getsourcelines(), which fails on stdin.
+cat > /tmp/triton_smoke.py <<'PYEOF'
+import triton, triton.language as tl, torch
+print("triton", triton.__version__)
+@triton.jit
+def add1(x_ptr, y_ptr, n, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    m = offs < n
+    tl.store(y_ptr + offs, tl.load(x_ptr + offs, mask=m) + 1.0, mask=m)
+x = torch.arange(1024, device="cuda", dtype=torch.float32); y = torch.empty_like(x)
+add1[(4,)](x, y, x.numel(), BLOCK=256)
+assert torch.allclose(y, x + 1.0), "smoke mismatch"
+print("SMOKE OK")
+PYEOF
+python /tmp/triton_smoke.py
+
+# --- 2. launch.h crash-fix (#1816) -------------------------------------------
+echo ">>> launch.h crash-fix tests (#1816)"
+pytest -q \
+  "$REPO_ROOT/python/test/unit/runtime/test_launch_metadata.py" \
+  "$REPO_ROOT/python/test/unit/runtime/test_launch_kernel_core.py"
+
+# --- 3. TLX correctness suite ------------------------------------------------
+# The suite is arch-gated via @pytest.mark.skipif. On AMD, select the kernels
+# that actually run on this arch with -k "amd or ikbo" (IKBO node ids contain no
+# "amd", so both selectors are needed); on NVIDIA, run the whole file and let the
+# Hopper/Blackwell gating decide.
+TLX_KFILTER=()
+[[ "$GPU_VENDOR" == "amd" ]] && TLX_KFILTER=(-k "amd or ikbo")
+echo ">>> TLX correctness suite (${GPU_VENDOR}, ${TLX_TIMEOUT}s cap)"
+if timeout "$TLX_TIMEOUT" pytest -q "${TLX_KFILTER[@]}" \
+     "$REPO_ROOT/third_party/tlx/tutorials/testing/test_correctness.py"; then
+  echo "TLX SUITE OK"
+else
+  echo "TLX suite failed/timed out; killing GPU stragglers"
+fi
+
+echo ">>> Tests done."


### PR DESCRIPTION
Port the `fbtriton-backport` skill to main: a self-contained skill for backporting commits onto a `release/*` branch (triage → map dependencies → pick → shim → build/perf-validate → finalize), plus tooling:
- `find-machinery.sh` — dependency-closure finder (content-following, no worktree)
- `backport-sync.sh` — frontier sweep of candidate commits
- `build-wheel.sh` / `test-wheel.sh` — local wheel build + arch-gated validation
- `partial-port-collision.md` — worked case study

Ported from the v3.7.3 backport work (PR #2335); lands as new files under `.claude/skills/`. Authored with Claude.