### PR TITLE
[ModuloSchedule] Redesign SMEM buffer-depth computation around full load-to-consume occupancy (#2343)

### DIFF
--- a/docs/design/modulo_schedule/buffer_depth_model.md
+++ b/docs/design/modulo_schedule/buffer_depth_model.md
@@ -1,0 +1,293 @@
+# Buffer-Depth Model for the Modulo Scheduler
+
+How the modulo scheduler sizes multi-buffered SMEM/TMEM rings, why the
+`lifetime/II + 1` formula under-provisioned them, the fix, and the open
+questions.
+
+## 1. Problem
+
+The scheduler chose SMEM prefetch-ring depths that were too shallow. For the
+`case1` fp16 GEMM (128x64 / 64x128 tiles, II=256) it allocated **3** buffers,
+while an autotuned hand-written kernel peaks at **5–6**. Measured on B200, going
+from depth 3 → 5/6 is worth **+14–18%** — the generated kernel was leaving that
+on the table purely from ring depth (structure was otherwise ~equal at equal
+depth).
+
+The depth is set by `computeBufferCount` (`ModuloSchedulePass.cpp`):
+
+```
+num_buffers = lifetime / II + 1
+lifetime    = lastConsumerEnd - producerStart
+```
+
+The bug: `producerStart` was the `local_alloc` cycle (data-**ready**), which
+already folds in the TMA latency. That drops the whole load-transfer window from
+the lifetime. The fix (`bufferOccupancyStart`) walks back through the producer's
+incoming TMA-load edge and starts the lifetime at the load **issue** cycle.
+
+## 2. The core model: two clocks
+
+A ring buffer's depth is governed by two independent quantities. Conflating them
+is the source of most of the confusion.
+
+### 2.1 `R` — the resident span (a serial dependency chain)
+
+`R` is how long **one** buffer slot is occupied, from the moment its load is
+issued to the moment it is freed:
+
+```
+load_issue ──transfer──▶ data_ready ──▶ MMA_issue ──compute──▶ MMA_done ──▶ slot freed
+|<----------------------------- R ----------------------------->|
+```
+
+`R` uses **latencies** (result-available delays), because it is a true
+dependency chain that **cannot overlap within itself**:
+
+- MMA depends on the load's result (RAW): `MMA_issue ≥ data_ready`.
+- The next load into this slot depends on the MMA finishing with it (WAR):
+  `next_load_issue ≥ MMA_done`.
+
+For `case1`: `R = load_latency(556) + gap(30) + MMA_latency(559) = 1145`.
+
+Critically, `R` is **not** "just the TMA time" nor "just the MMA time" — it is
+the whole `load→MMA` span. The pre-fix code used only the MMA half
+(`R = 589 = gap + MMA_latency`), which is exactly why it undercounted.
+
+### 2.2 `II` — the initiation interval (a pipelined start rate)
+
+`II` is how often a **new** iteration (a new chain) may start. Unlike `R`, this
+*is* pipelined: both the TMA engine and the tensor core are multi-outstanding,
+so successive loads/MMAs overlap. `II` therefore uses **occupancies**
+(issue-to-issue throughput), not latencies. (Details in §3.)
+
+For `case1`: `II = 256`.
+
+### 2.3 depth = how many chains overlap
+
+New chains start every `II`; each chain occupies its slot for `R`. During one
+slot's life, `R/II` other chains launch, each needing its own slot:
+
+```
+cycle:   0        256       512       768      1024      1280
+chain0:  |============ R = 1145 ============|                      slot0
+chain1:            |============ R ============|                   slot1
+chain2:                      |============ R ============|         slot2
+chain3:                                |=========== R ...          slot3
+chain4:                                          |======= R ...    slot4
+                             ^ up to ~5 chains simultaneously live
+```
+
+```
+depth = ceil(R / II)            (Little's law / interval-overlap)
+      = ceil(1145 / 256) = 5
+```
+
+(The code currently writes `floor(R/II) + 1`, which equals `ceil` except when
+`R` divides `II` evenly, where it yields one extra. See §6.4.)
+
+**This is the whole model.** Everything below is about computing `R` and `II`
+correctly and knowing when `ceil(R/II)` is not the final answer.
+
+## 3. Computing `II` precisely
+
+`II = max(ResMII, RecMII, SuperNodeII)`.
+
+### 3.1 ResMII — resource pressure
+
+For each hardware pipeline `P ∈ {TMA, TC, CUDA, SFU}`:
+
+```
+ResMII(P) = Σ_{op on P} occupancy(op)          (per iteration)
+ResMII    = max_P ResMII(P)
+```
+
+`occupancy(op)` is the number of cycles the op *holds its pipeline* before the
+next op of that class can issue — **not** its latency. This is where
+multi-outstanding is modeled:
+
+| op                | occupancy                              | latency (for `R`, §4)        |
+|-------------------|----------------------------------------|------------------------------|
+| TMA load          | `max(30, 6·KB)`  (HBM bandwidth share) | `460 + 6·KB + 240·min(insts-1,2)` |
+| TMA store         | `max(30, 52·KB)`                       | `130 + 52·KB`                |
+| MMA (tcgen05)     | `MACs / MACs_per_cycle` (fp16 4096/cyc), clamped `[30, 4096]` | `900` (K≥128) / `559` (K=64) |
+| CUDA elementwise  | `selfLatency` (NCU pipe-active)        | RAW chain cost               |
+| SFU (exp2/log2)   | `selfLatency` (insts/4 subpartitions)  | transcendental wait          |
+
+Worked example, `case1`:
+- TMA pipeline: two 16 KB loads → `2 · (6·16) = 192`.
+- TC pipeline: one 128x128x64 fp16 MMA → `128·128·64 / 4096 = 256`.
+- `ResMII = max(192, 256) = 256`.
+
+If loads were (incorrectly) charged their **latency** for ResMII, TMA would read
+`2·556 = 1112` and II would be ~1112 — the classic "serial load" mistake. The
+model already avoids it; that is why II is 256 and not ~1100.
+
+### 3.2 RecMII — dependency recurrences
+
+For each recurrence circuit `C` (a dependency cycle across loop iterations):
+
+```
+RecMII(C) = Σ_{e in C} latency(e) / Σ_{e in C} distance(e)
+RecMII    = max_C RecMII(C)
+```
+
+`case1` has one recurrence: the MMA accumulating into the same TMEM tile across
+K-iterations — a self-edge `MMA → MMA`, `distance=1`, `latency=256`. So
+`RecMII = 256/1 = 256`.
+
+### 3.3 `case1` result
+
+`II = max(ResMII=256, RecMII=256) = 256`. Confirmed by the DDG debug log:
+`[DDG] Pipeline TMA load: 192  Pipeline TC load: 256  RecMII=256  ResMII=256  MinII=256`.
+
+## 4. Computing `R` precisely
+
+```
+R = liveEnd - liveStart
+liveStart = bufferOccupancyStart(producer)
+          = min over the producer's incoming TMA-load edges of (load.cycle)
+          = load ISSUE cycle   (data_ready - load_latency)
+liveEnd   = walkLastConsumerEnd(producer)
+          = max over consumers of (consumer.cycle + consumer.latency + dist·II)
+```
+
+`liveStart` uses the fix; `liveEnd` was already correct (it uses the consumer's
+**latency**, e.g. MMA 559 — the completion/free point, not the MMA occupancy).
+
+Note the asymmetry, and it is deliberate:
+- `II` uses **occupancy** (throughput; overlappable).
+- `R` uses **latency** (completion; the non-overlappable chain).
+
+## 5. Compute-bound vs memory-bound
+
+`depth = ceil(R/II)` holds in **both** regimes; only the *composition* changes.
+This directly answers "what if it's compute-bound, load slow vs MMA slow."
+
+| regime          | what sets `II`            | dominant term in `R`     | typical depth behavior |
+|-----------------|---------------------------|--------------------------|------------------------|
+| **compute-bound** (case1) | TC occupancy / MMA recurrence (256) | MMA latency (559)        | II is small relative to `R` → deeper rings needed to feed the fast-draining consumer |
+| **memory-bound** | TMA occupancy (`6·KB` × #loads) | load latency             | II is large (loads slow) → `R/II` smaller → shallower rings, but II itself is the thing to attack |
+
+Worked hypothetical (memory-bound, low arithmetic intensity):
+`II_TMA = 400`, `II_TC = 200` → `II = 400`. `R = load_lat(900) + MMA(300) = 1200`
+→ `depth = ceil(1200/400) = 3`. Fewer buffers, because the consumer is starved
+by bandwidth, not by ring depth — adding buffers wouldn't help; **lowering II
+would** (see §6.2).
+
+The key insight: in the compute-bound regime the ring depth is the lever
+(feed the hungry tensor core); in the memory-bound regime the ring depth
+saturates and the lever moves to `II` (bandwidth / split-K / bigger loads).
+`ceil(R/II)` self-adjusts between the two, but it does **not** by itself do the
+memory-bound "buy lower II with more buffers" trade — that is §6.2.
+
+## 6. Where `ceil(R/II)` is not the final answer (open questions)
+
+These are the iteration points. `ceil(R/II)` is the steady-state, mean-latency
+**minimum** to not stall; it is a floor, not always the optimum.
+
+### 6.1 Latency variance → a slack margin
+
+`R` uses *mean* modeled latency. Real TMA latency has variance (L2/DRAM
+contention across 148 SMs, TLB, bank conflicts). The model predicts `case1`
+depth **5**; empirically **5–6** is best — the extra slot absorbs jitter so a
+slow load doesn't stall the MMA. Options: a small additive/multiplicative slack
+(`ceil(R/II) + k`, or `ceil(R·(1+ε)/II)`), capped by the SMEM budget. We should
+calibrate `ε`/`k` on measured data, not guess.
+
+### 6.2 Latency-bound regime: buy lower II with more buffers
+
+`depth = ceil(R/II)` treats `II` as fixed. But in the memory-bound regime, `II`
+*is a function of ring depth*: with `N` buffers you can sustain `II = max(II_floor, R/N)`.
+Today the code fixes `II` from ResMII/RecMII and then derives `N`, and the budget
+reducer only ever *cuts* `N`. A fuller design would, when load-bound, **fill `N`
+toward the SMEM budget** and recompute `II = R/N`:
+
+```
+if R / N_fit > II_res:        # load-bound: buffers are the bottleneck
+    N  = N_fit                # N_fit = floor(SMEM_budget / buffer_bytes)
+    II = ceil(R / N)          # deeper pipe → lower II
+else:                         # resource-bound (case1)
+    N  = ceil(R / II_res)
+    II = II_res
+```
+
+This is the II(N) curve — throughput is concave/saturating in N ("1 buffer ≠ A,
+2 buffers ≠ 2A"): `II(N) = max(II_floor, R/N)`, flat once `N ≥ R/II_floor`.
+
+### 6.3 SMEM ring depth vs TMEM accumulator depth are separate
+
+`R/II` sizes the **SMEM operand ring** (load→MMA). The **TMEM accumulator**
+(MMA→epilogue) is a different buffer with its own lifetime (produced by the MMA,
+consumed by the epilogue store) and should be sized by the same model applied to
+*that* chain. They interact through the shared SMEM budget but are not the same
+number. Current code sizes both via `computeBufferCount`; verify the accumulator
+path also gets the right `R` (its producer is the MMA, not a TMA load, so the
+§4 walk-back does not apply — good, but confirm its `R` is complete).
+
+### 6.4 `floor(R/II) + 1` vs `ceil(R/II)`
+
+When `R` is an exact multiple of `II`, `floor+1` gives one extra buffer vs
+`ceil`. Decide whether that extra is desired (a free half-slot of slack) or a
+rounding artifact to remove. Minor, but it should be intentional.
+
+### 6.5 Per-operand vs shared ring depth
+
+A/B operands feed the same MMA and today are equalized to a common depth
+(co-consumed group). If A and B have different `R` (different tile bytes →
+different load latency), the shared depth is `max`. That is correct for
+correctness; confirm it is not over-allocating the cheaper operand.
+
+### 6.6 Interaction with the budget reducer — FIXED
+
+`reduceBuffersForBudget` cuts the cheapest ring when SMEM overflows and then
+recomputes `II = R/depth`. Deeper default rings from this model make the reducer
+fire for the first time on large tiles (e.g. BK=128), which exposed a **latent
+bug**: `computeTotalSmem` charges each merge-group's *physical* footprint, but
+the reducer decremented only the *logical* `buf.count` and never refreshed the
+physical buffers — so the total never dropped, the reducer over-reduced every
+ring to depth 1, and recomputed a serial `II` (≈ MMA latency). Net: any
+over-budget tile collapsed to a non-pipelined depth-1 schedule (worse than
+pre-fix).
+
+Fix: call `buildPhysicalBuffers(loop)` after each reduction step (the forward
+decl already anticipated this), and make `computeBufferLifetime` use
+`bufferOccupancyStart` so the post-reduction `II` recompute uses the same `R` as
+`computeBufferCount`. Result on BK=128: reduces 4→3, sees 192 KB fits the 227 KB
+budget, stops, raises II 512→528 — depth 3, pipelined. This is the graceful cap:
+**over-budget → largest depth that fits, keep pipelining; never collapse to
+serial.**
+
+## 7. Validation plan
+
+1. **Mechanism** (done): `case1` depth 3→5, II unchanged at 256, clean build.
+2. **Perf** (done, case1/case2): case1 gen/hw 0.80→0.95 @2048³, 0.83→0.88
+   @4096³; case2 generated +15% (hw also improved so ratio flat — case2's
+   residual is not depth).
+3. **Falsification** (DONE — PASSED): on the unseen BLOCK_K=128 tile the model
+   predicts depth **3** (ceil(1582/512)=4, capped to 3 by the SMEM budget), and
+   the hand-written autotune optimum is **3** (depth ≥4 OOMs). BK=64 stays 5.
+   Prediction matches measurement on a tile the model was not tuned to →
+   principle, not pattern-match. (A first attempt on a hand-edited BK=128 ttgir
+   gave a false negative — the edited input broke the TC→TC recurrence and the
+   budget reducer collapsed to depth 1; both were artifacts, not the model.)
+4. **Regression** (DONE): regenerated + revalidated on master (post-tensordesc-
+   migration, with the fix) for case1/2/3/4/6/7/9 — deeper rings confirmed
+   (case1 3→5, case2 3→5, case3 buf1 1→2, case4 3→4, case7 3→5, case9 1→2; case6
+   unchanged), all correctness PASS on B200, II unchanged, no budget cap fired,
+   no OOM. case5 excluded (epilogue-subtile emitter bug, tracked separately).
+   The emitter needed no change (its descriptor regex already matches the
+   migrated tensordesc syntax).
+5. **Memory-bound** (todo): a load-bound shape to test §6.2 (does II have
+   headroom that filling buffers would recover?).
+
+## 8. Current status
+
+- Implemented: `bufferOccupancyStart` + `computeBufferCount` using it; the
+  budget-reducer graceful cap (§6.6: `buildPhysicalBuffers` refresh +
+  `computeBufferLifetime` consistency) — all in `ModuloSchedulePass.cpp`.
+- Validated: case1 (mechanism + perf, 3→5, +15%); falsification passed on BK=128
+  (predicts 3, measured 3); BK=64 no regression; II independently confirmed
+  correct (occupancy-based, MMA-bound).
+- Fixtures regenerated on master for case1/2/3/4/6/7/9 (§7.4); case5 pending its
+  epilogue-subtile emitter bug.
+- Not yet: variance margin (§6.1), latency-bound fill-to-budget (§6.2), case5.

--- a/test/TritonGPU/list-schedule-graph.mlir
+++ b/test/TritonGPU/list-schedule-graph.mlir
@@ -16,31 +16,25 @@
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
-// --- Graph: makespan=2767, all stage 0 ---
-// CHECK: [A.6] === List ScheduleGraph ===
-// CHECK-NEXT: modulo.schedule @loop0 {
-// CHECK-NEXT:   ii = 2767, max_stage = 0
+// --- Schedule: makespan=1402, all ops stage 0 ---
+// --- List-schedule debug summary: makespan only (no II), single default heuristic ---
+// CHECK: [nvgpu-list-schedule]: List scheduling loop with 8 nodes (genK=1, pick=0, ranked=0)
+// CHECK: [nvgpu-list-schedule]: List schedule: makespan=1402 nodes=8
+// CHECK: [nvgpu-list-schedule]: List schedule: applying rank 0 of 1 (makespan=1402)
+// CHECK: [nvgpu-list-schedule]: reorderByCluster: permuted 8 body ops into schedule order
 //
-// --- All ops in single stage, cluster IDs 0-5 by cycle ---
-// CHECK: modulo.stage @s0 {
-// CHECK:   tt.descriptor_load  {pipe: MEM, cycle: 0, cluster: 0, latency: 1218, selfLatency: 518}
-// CHECK:   tt.descriptor_load  {pipe: MEM, cycle: 518, cluster: 1, latency: 1218, selfLatency: 518}
-// CHECK:   ttg.local_alloc  {pipe: MEM, cycle: 1036, cluster: 2, latency: 700}
-// CHECK:   ttg.local_alloc  {pipe: MEM, cycle: 1037, cluster: 3, latency: 700}
-// CHECK:   ttng.tc_gen5_mma  {pipe: TC, cycle: 1737, cluster: 4, latency: 900, selfLatency: 900}
-// CHECK:   ttng.tmem_load  {pipe: CUDA, cycle: 2637, cluster: 5, latency: 130, selfLatency: 130}
-// CHECK: }
-//
-// --- Edges ---
-// CHECK: edges {
-// CHECK-DAG: N0 -> N1  lat=0  dist=0
-// CHECK-DAG: N1 -> N3  lat=518  dist=0
-// CHECK-DAG: N2 -> N4  lat=518  dist=0
-// CHECK-DAG: N3 -> N6  lat=700  dist=0
-// CHECK-DAG: N4 -> N6  lat=700  dist=0
-// CHECK-DAG: N6 -> N7  lat=900  dist=0
-// CHECK: }
-// CHECK: }
+// --- Transformed IR: all ops at stage 0, cluster IDs as dense rank of cycle ---
+// --- MEM (loads) get earliest clusters, TC (MMA) later, CUDA (tmem_load) last ---
+// CHECK-LABEL: @gemm_list_schedule_graph
+// CHECK:      ttng.tmem_alloc {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32}
+// CHECK:      tt.descriptor_load {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+// CHECK:      tt.descriptor_load {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK:      ttg.local_alloc {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32}
+// CHECK:      ttg.local_alloc {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
+// CHECK:      ttng.tc_gen5_mma {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
+// CHECK:      ttng.tmem_load {{.*}} {loop.cluster = 5 : i32, loop.stage = 0 : i32}
+// CHECK:      tt.list_schedule_makespan = 1402 : i32
+// CHECK-SAME: tt.modulo_ii = 1402 : i32
 tt.func @gemm_list_schedule_graph(
   %a_desc: !tt.tensordesc<128x64xf16>,
   %b_desc: !tt.tensordesc<64x128xf16>

--- a/test/TritonGPU/modulo-schedule-graph-budget-reduction.mlir
+++ b/test/TritonGPU/modulo-schedule-graph-budget-reduction.mlir
@@ -1,0 +1,144 @@
+// REQUIRES: asserts
+// RUN: TRITON_MODULO_SMEM_BUDGET_KB=448 triton-opt %s -allow-unregistered-dialect -split-input-file -nvgpu-modulo-schedule -debug-only=nvgpu-modulo-schedule 2>&1 | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Regression tests for Step 4.6 budget reduction (reduceBufferGroup +
+// post-reduction fixed-point II recompute). Both cases run with an inflated
+// SMEM budget (TRITON_MODULO_SMEM_BUDGET_KB=448 = 458752 B) so the reduction
+// path fires at a controlled, self-documenting threshold instead of relying on
+// the hardware default.
+//===----------------------------------------------------------------------===//
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#acc_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+//===----------------------------------------------------------------------===//
+// Issue 1: loop-carried II under budget reduction.
+//
+// A software-prefetch GEMM: the A tile loaded in iteration i is consumed by the
+// MMA in iteration i+1, so buf2 (the 128x512xf16 A ring) has a loop-carried
+// consumer edge (N7 -> N4, dist=1). Its lifetime therefore grows with II:
+//   lifetime(II) = base + distance*II,   base = 1714 (intra-iteration span).
+// At the initial II=1166 the ring wants count=3 (393216 B); together with the
+// 512x64 B ring and barriers the loop needs 524344 B > 458752, so the reducer
+// drops buf2 to count=2. buf2 is the binding buffer for the recomputed II:
+//   - single-pass (the OLD bug) would use the lifetime measured at the old II:
+//       ceil(lifetime(1166)/2) = ceil((1714+1166)/2) = ceil(2880/2) = 1440,
+//     an UNDER-estimate: at II=1440, depth*II = 2*1440 = 2880 < lifetime(1440)
+//     = 1714+1440 = 3154, so the loader would reclaim a slot before the
+//     loop-carried consumer finished.
+//   - the fixed-point recompute solves depth*II >= base + distance*II, i.e.
+//       2*II >= 1714 + II  =>  II >= 1714,
+//     converging to II = 1714, where 2*1714 = 3428 >= 1714+1714 = 3428.
+//
+// CHECK: [Step4.6] Reduced SMEM buf2 (+ co-consumed/merge peers) to count=2
+// CHECK: [Step4.6] Raising II from 1166 to 1714 due to buffer depth reduction
+// The schedule graph carries the fixed-point II, and the loop-carried operand
+// ring is double-buffered (count=2) at that raised II:
+// CHECK: ii = 1714, max_stage = 1
+// CHECK: %buf2 = modulo.alloc SMEM [2 x 128x512 x f16]
+tt.func @prefetch_carried_ii(
+  %a_desc: !tt.tensordesc<128x512xf16>,
+  %b_desc: !tt.tensordesc<512x64xf16>
+) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %true = arith.constant true
+  %k_tiles = arith.constant 32 : i32
+  %zero = arith.constant dense<0.0> : tensor<128x64xf32, #acc_layout>
+
+  // Prefetch iteration 0's A tile before the loop.
+  %a0 = tt.descriptor_load %a_desc[%c0_i32, %c0_i32] : !tt.tensordesc<128x512xf16> -> tensor<128x512xf16, #blocked>
+  %a0_sh = ttg.local_alloc %a0 : (tensor<128x512xf16, #blocked>) -> !ttg.memdesc<128x512xf16, #shared, #smem>
+
+  scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%a_prev = %a0_sh, %acc = %zero) -> (!ttg.memdesc<128x512xf16, #shared, #smem>, tensor<128x64xf32, #acc_layout>) : i32 {
+    %off_k = arith.muli %k, %c1_i32 : i32
+
+    %b = tt.descriptor_load %b_desc[%off_k, %c0_i32] : !tt.tensordesc<512x64xf16> -> tensor<512x64xf16, #blocked>
+    %b_sh = ttg.local_alloc %b : (tensor<512x64xf16, #blocked>) -> !ttg.memdesc<512x64xf16, #shared, #smem>
+
+    %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x64xf32, #acc_layout>) -> (!ttg.memdesc<128x64xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    // Consume the PREVIOUS iteration's prefetched A tile.
+    %mma_tok = ttng.tc_gen5_mma %a_prev, %b_sh, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x512xf16, #shared, #smem>, !ttg.memdesc<512x64xf16, #shared, #smem>, !ttg.memdesc<128x64xf32, #acc_tmem, #ttng.tensor_memory, mutable>
+    %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x64xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #acc_layout>
+
+    // Prefetch the next iteration's A tile.
+    %a_next = tt.descriptor_load %a_desc[%c0_i32, %off_k] : !tt.tensordesc<128x512xf16> -> tensor<128x512xf16, #blocked>
+    %a_next_sh = ttg.local_alloc %a_next : (tensor<128x512xf16, #blocked>) -> !ttg.memdesc<128x512xf16, #shared, #smem>
+
+    scf.yield %a_next_sh, %c : !ttg.memdesc<128x512xf16, #shared, #smem>, tensor<128x64xf32, #acc_layout>
+  }
+  tt.return
+}
+
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#acc_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+//===----------------------------------------------------------------------===//
+// Issue 2: co-consumed / merge-group peers reduced together.
+//
+// A and B both feed the same MMA, so they form one co-consumed ring group that
+// must stay equal depth (and, once merged, one physical allocation whose size
+// is max(member)). At the initial II both want count=3:
+//   buf0 (128x512xf16) = 3*131072 = 393216 B,  buf1 (512x64xf16) = 3*65536 =
+//   196608 B, so the loop needs ~589896 B > 458752.
+// reduceBufferGroup must drop the WHOLE group by one step and refresh the
+// physical buffers so computeTotalSmem sees the smaller footprint. At count=2
+// the group is 262144 + 131072 = 393216 B (+ barriers) = 393272 B <= 458752, so
+// the reducer stops — capping the ring at the largest depth that fits.
+//
+// The regression guard: BOTH members drop together to the SAME count (2), and
+// the reported footprint actually falls below budget. Before the fix (reduce a
+// single member, no physical refresh) one member would be hammered down to
+// count=1 while its peer stayed high and the shared physical footprint never
+// dropped.
+//
+// CHECK: [Step4.6] Reduced SMEM buf1 (+ co-consumed/merge peers) to count=2
+// Footprint dropped below the 458752 B budget after refreshing physical buffers:
+// CHECK: [Step4.6] Budget: SMEM 393272/458752 OK
+// Both co-consumed operands end at the SAME count=2 (not one collapsed to 1):
+// CHECK-DAG: %buf0 = modulo.alloc SMEM [2 x 128x512 x f16]
+// CHECK-DAG: %buf1 = modulo.alloc SMEM [2 x 512x64 x f16]
+tt.func @coconsumed_group_reduce(
+  %a_desc: !tt.tensordesc<128x512xf16>,
+  %b_desc: !tt.tensordesc<512x64xf16>
+) {
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %true = arith.constant true
+  %k_tiles = arith.constant 32 : i32
+  %zero = arith.constant dense<0.0> : tensor<128x64xf32, #acc_layout>
+
+  scf.for %k = %c0_i32 to %k_tiles step %c1_i32 iter_args(%acc = %zero) -> (tensor<128x64xf32, #acc_layout>) : i32 {
+    %off_k = arith.muli %k, %c1_i32 : i32
+
+    %a = tt.descriptor_load %a_desc[%c0_i32, %off_k] : !tt.tensordesc<128x512xf16> -> tensor<128x512xf16, #blocked>
+    %b = tt.descriptor_load %b_desc[%off_k, %c0_i32] : !tt.tensordesc<512x64xf16> -> tensor<512x64xf16, #blocked>
+
+    %a_sh = ttg.local_alloc %a : (tensor<128x512xf16, #blocked>) -> !ttg.memdesc<128x512xf16, #shared, #smem>
+    %b_sh = ttg.local_alloc %b : (tensor<512x64xf16, #blocked>) -> !ttg.memdesc<512x64xf16, #shared, #smem>
+
+    %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x64xf32, #acc_layout>) -> (!ttg.memdesc<128x64xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %mma_tok = ttng.tc_gen5_mma %a_sh, %b_sh, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x512xf16, #shared, #smem>, !ttg.memdesc<512x64xf16, #shared, #smem>, !ttg.memdesc<128x64xf32, #acc_tmem, #ttng.tensor_memory, mutable>
+    %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x64xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #acc_layout>
+
+    scf.yield %c : tensor<128x64xf32, #acc_layout>
+  }
+  tt.return
+}
+
+}

--- a/test/TritonGPU/modulo-schedule-graph-budget.mlir
+++ b/test/TritonGPU/modulo-schedule-graph-budget.mlir
@@ -16,8 +16,10 @@
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // Step 4.5: Merge first (before budget check — reduces memory footprint)
-// Step 4.6: Budget check passes (SMEM ~65KB << 232KB, TMEM ~196KB << 256KB)
+// Step 4.6: Budget check passes (SMEM ~64KB << 227KB, TMEM ~128KB << 256KB)
 //
+// 6 buffers = 3 data (A/B SMEM operand rings now double-buffered + TMEM acc,
+// each count=2) plus their 3 paired barriers; they merge to 3 physical groups.
 // CHECK: [Step4.5] 6 buffers -> 3 physical groups
 // CHECK: [Step4.6] Budget: SMEM {{[0-9]+}}/{{[0-9]+}} OK, TMEM {{[0-9]+}}/{{[0-9]+}} OK
 tt.func @test_budget_and_merge(

--- a/test/TritonGPU/modulo-schedule-graph-buffers.mlir
+++ b/test/TritonGPU/modulo-schedule-graph-buffers.mlir
@@ -4,7 +4,7 @@
 //===----------------------------------------------------------------------===//
 // Test: Buffer allocations and barrier pairing
 //   SMEM buffers for A (128x64xf16) and B (64x128xf16) tiles,
-//   TMEM buffer for accumulator (128x128xf32), each with paired barriers.
+//   TMEM buffer for accumulator (128x128xf32) with a paired barrier.
 //===----------------------------------------------------------------------===//
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -15,8 +15,9 @@
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
-// --- SMEM buffers: count=2, shapes match tiles, live=[start, end) per
-//     design doc §215 worked example. ---
+// --- SMEM buffers: count=2 (the operand rings are double-buffered — SMEM
+//     ring depth = ceil(full-load-to-consume lifetime / II)), shapes match
+//     tiles, live=[start, end) per design doc §215 worked example. ---
 // CHECK: %buf0 = modulo.alloc SMEM [2 x 128x64 x f16]
 // CHECK-SAME: live=[
 // CHECK-SAME: bytes total
@@ -24,22 +25,23 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // CHECK-SAME: live=[
 // CHECK-SAME: bytes total
 //
-// --- TMEM buffer: count=3 for accumulator ---
-// CHECK: %buf2 = modulo.alloc TMEM [3 x 128x128 x f32]
+// --- TMEM buffer: count=2 for accumulator ---
+// CHECK: %buf2 = modulo.alloc TMEM [2 x 128x128 x f32]
 // CHECK-SAME: live=[
-// CHECK-SAME: 196608 bytes total
+// CHECK-SAME: 131072 bytes total
 //
-// --- Paired barriers carry the same live interval as their data buffer ---
+// --- Each count>1 data buffer gets a paired barrier carrying the same live
+//     interval; the accumulator's barrier is now bar5. ---
 // CHECK: %bar3 = modulo.alloc BARRIER [2] for buf0
 // CHECK-SAME: live=[
 // CHECK: %bar4 = modulo.alloc BARRIER [2] for buf1
 // CHECK-SAME: live=[
-// CHECK: %bar5 = modulo.alloc BARRIER [3] for buf2
+// CHECK: %bar5 = modulo.alloc BARRIER [2] for buf2
 // CHECK-SAME: live=[
 //
 // --- Producers: local_alloc → ->buf ---
-// CHECK: ttg.local_alloc  {pipe: TMA, {{.*}}->buf0}
-// CHECK: ttg.local_alloc  {pipe: TMA, {{.*}}->buf1}
+// CHECK: ttg.local_alloc  {pipe: NONE, {{.*}}->buf0}
+// CHECK: ttg.local_alloc  {pipe: NONE, {{.*}}->buf1}
 //
 // --- Consumer: MMA consumes all three buffers ---
 // CHECK: ttng.tc_gen5_mma  {pipe: TC, {{.*}}<-buf0, <-buf1, <-buf2}

--- a/test/TritonGPU/modulo-schedule-graph-edge.mlir
+++ b/test/TritonGPU/modulo-schedule-graph-edge.mlir
@@ -3,8 +3,8 @@
 
 //===----------------------------------------------------------------------===//
 // Edge case 0: Single-stage schedule (maxStage=0).
-// MMA-only loop: no TMA copy, no result use. With selfLatency=1,
-// II = 1 (single TC op) and the MMA lands at cycle 0, stage 0.
+// MMA-only loop: no TMA copy, no result use. With selfLatency=30,
+// II = 256 (single TC op) and the MMA lands at cycle 0, stage 0.
 //
 // Regression test for Devmate review: tt.num_stages must be set even when
 // maxStage = 0 so downstream pipelining recognises the loop as scheduled.
@@ -17,7 +17,7 @@
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // Verify the maxStage=0 dump and the loop's tt.num_stages=1 attribute.
-// CHECK: ii = 1, max_stage = 0
+// CHECK: ii = 256, max_stage = 0
 // CHECK: @maxstage_0_mma_only
 // CHECK: tt.num_stages = 1 : i32
 tt.func @maxstage_0_mma_only(

--- a/test/TritonGPU/modulo-schedule-graph.mlir
+++ b/test/TritonGPU/modulo-schedule-graph.mlir
@@ -13,37 +13,37 @@
 
 module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
-// --- Graph structure: II=1005, max_stage=1, trip_count=32 ---
-// With selfLatency=1, loads issue every cycle (not every 518 cycles),
+// --- Graph structure: II=1091, max_stage=1, trip_count=32 ---
+// With load selfLatency=30, loads issue every 30 cycles (not every 556 cycles),
 // so II is driven by RecMII (loop-carried dep: MMA→tmem_load→tmem_alloc→MMA).
-// CHECK: [PASS-A] === Loop ScheduleGraph ===
+// CHECK: [PASS-A] === Inner ScheduleGraph ===
 // CHECK-NEXT: modulo.schedule @loop0 {
-// CHECK-NEXT:   ii = 1005, max_stage = 1, prologue_latency = 703, trip_count = 32
+// CHECK-NEXT:   ii = 1091, max_stage = 1, prologue_latency = 587, trip_count = 32
 //
 // --- Nodes: loads+allocs+MMA@s0, tmem_load@s1 ---
 // CHECK: modulo.stage @s0 {
-// CHECK:   tt.descriptor_load  {pipe: TMA, cycle: 0, cluster: 0, latency: 1218, selfLatency: 1}
-// CHECK:   tt.descriptor_load  {pipe: TMA, cycle: 1, cluster: 1, latency: 1218, selfLatency: 1}
-// CHECK:   ttg.local_alloc  {pipe: TMA, cycle: 2, cluster: 2, latency: 700
-// CHECK:   ttg.local_alloc  {pipe: TMA, cycle: 3, cluster: 3, latency: 700
-// CHECK:   ttng.tc_gen5_mma  {pipe: TC, cycle: 703, cluster: 4, latency: 900, selfLatency: 1
+// CHECK:   %N1 = tt.descriptor_load  {pipe: TMA, cycle: 1, cluster: 1, latency: 556, selfLatency: 30}
+// CHECK:   %N2 = tt.descriptor_load  {pipe: TMA, cycle: 31, cluster: 2, latency: 556, selfLatency: 30}
+// CHECK:   %N3 = ttg.local_alloc  {pipe: NONE, cycle: 557, cluster: 3, ->buf0}
+// CHECK:   %N4 = ttg.local_alloc  {pipe: NONE, cycle: 587, cluster: 4, ->buf1}
+// CHECK:   %N6 = ttng.tc_gen5_mma  {pipe: TC, cycle: 587, cluster: 4, latency: 559, selfLatency: 30, <-buf0, <-buf1, <-buf2}
 // CHECK: }
 // CHECK: modulo.stage @s1 {
-// CHECK:   ttng.tmem_load  {pipe: CUDA, cycle: 1603, cluster: 0, latency: 105, selfLatency: 1
+// CHECK:   %N7 = ttng.tmem_load  {pipe: CUDA, cycle: 1146, cluster: 0, latency: 532, selfLatency: 256, <-buf2}
 // CHECK: }
 //
 // --- Edges: SSA + loop-carried ---
 // CHECK: edges {
-// CHECK-DAG: N0 -> N1  lat=0  dist=0
-// CHECK-DAG: N0 -> N2  lat=0  dist=0
-// CHECK-DAG: N1 -> N3  lat=1  dist=0
-// CHECK-DAG: N2 -> N4  lat=1  dist=0
-// CHECK-DAG: N3 -> N6  lat=700  dist=0
-// CHECK-DAG: N4 -> N6  lat=700  dist=0
+// CHECK-DAG: N0 -> N1  lat=1  dist=0
+// CHECK-DAG: N0 -> N2  lat=1  dist=0
+// CHECK-DAG: N1 -> N3  lat=556  dist=0
+// CHECK-DAG: N2 -> N4  lat=556  dist=0
+// CHECK-DAG: N3 -> N6  lat=0  dist=0
+// CHECK-DAG: N4 -> N6  lat=0  dist=0
 // CHECK-DAG: N5 -> N6  lat=0  dist=0
 // CHECK-DAG: N5 -> N7  lat=0  dist=0
-// CHECK-DAG: N6 -> N7  lat=900  dist=0
-// CHECK-DAG: N7 -> N5  lat=105  dist=1
+// CHECK-DAG: N6 -> N7  lat=559  dist=0
+// CHECK-DAG: N7 -> N5  lat=532  dist=1
 // CHECK: }
 // CHECK: }
 tt.func @test_basic_graph(

--- a/test/TritonGPU/modulo-schedule-nested.mlir
+++ b/test/TritonGPU/modulo-schedule-nested.mlir
@@ -17,10 +17,10 @@
 
 module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
 
-// CHECK: [PASS-A] === Loop ScheduleGraph ===
+// CHECK: [PASS-A] === Inner ScheduleGraph ===
 // CHECK: modulo.schedule @loop0 {
 //
-// CHECK: [PASS-A] === Loop ScheduleGraph ===
+// CHECK: [PASS-A] === Outer ScheduleGraph ===
 // CHECK: modulo.schedule @loop0 {
 //
 // Inner loop gets tt.num_stages (no loop.stage — uses emitMMAAnnotations).

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -847,27 +847,57 @@ static int walkLastConsumerEnd(const ttg::ScheduleLoop &loop, unsigned startId,
   return lastEnd;
 }
 
+/// The cycle at which a buffer's storage first becomes occupied.
+///
+/// For a TMA-loaded SMEM ring this is the load's ISSUE cycle, NOT the
+/// local_alloc's data-ready cycle. The TMA engine is multi-outstanding: it
+/// commits the ring slot for the whole transfer, and independent loads to
+/// different slots run concurrently, so the in-flight transfer window is part
+/// of the buffer's occupancy. The producer node (local_alloc) is a
+/// zero-latency rename scheduled AFTER the load completes, so its cycle already
+/// folds in the TMA latency — starting the lifetime there omits the transfer
+/// and under-provisions the prefetch ring (e.g. GEMM depth 3 vs the 5-6
+/// throughput optimum). Walk back through the producer's incoming data edges to
+/// any feeding TMA load and take the earliest issue cycle. (Scaling the modeled
+/// TMA latency does NOT help: it shifts both the load and the alloc by the same
+/// amount, leaving this span fixed.)
+static int bufferOccupancyStart(const ttg::ScheduleLoop &loop,
+                                unsigned producerNodeId) {
+  int start = loop.getNode(producerNodeId).cycle;
+  for (const auto &edge : loop.edges) {
+    if (edge.dstId != producerNodeId)
+      continue;
+    const auto &pred = loop.getNode(edge.srcId);
+    if (pred.pipeline == ttg::HWPipeline::TMA)
+      start = std::min(start, pred.cycle);
+  }
+  return start;
+}
+
 /// Step 3: Compute buffer count from cycle-level lifetime.
 ///
 /// Design doc formula:
 ///   lifetime(R) = lastConsumerEnd - producerStart
 ///   num_buffers(R) = floor(lifetime(R) / II) + 1
 ///
+/// producerStart is the buffer's occupancy start (bufferOccupancyStart), which
+/// for a TMA-loaded ring is the load issue cycle, not data-ready.
+///
 /// For loop-carried edges (distance > 0), the consumer in iteration i+d
 /// effectively ends at: consumerEnd + d * II (in absolute time).
 /// This is equivalent to adding d * II to the lifetime.
 static unsigned computeBufferCount(const ttg::ScheduleLoop &loop,
                                    unsigned producerNodeId) {
-  const auto &producer = loop.getNode(producerNodeId);
-  int prodCycle = producer.cycle;
   int II = loop.II;
   if (II <= 0)
     return 1;
 
+  int prodCycle = bufferOccupancyStart(loop, producerNodeId);
+
   llvm::DenseSet<unsigned> seen;
   seen.insert(producerNodeId);
-  int lastConsumerEnd =
-      walkLastConsumerEnd(loop, producerNodeId, prodCycle, II, 0, seen);
+  int lastConsumerEnd = walkLastConsumerEnd(
+      loop, producerNodeId, loop.getNode(producerNodeId).cycle, II, 0, seen);
 
   int lifetime = lastConsumerEnd - prodCycle;
   int numBuffers = lifetime / II + 1;
@@ -1286,11 +1316,14 @@ static int64_t computeTotalTmem(const ttg::ScheduleLoop &loop) {
 /// computed by computeBufferCount.
 static int computeBufferLifetime(const ttg::ScheduleLoop &loop,
                                  unsigned producerNodeId) {
-  const auto &producer = loop.getNode(producerNodeId);
-  int prodCycle = producer.cycle;
+  // Occupancy starts at the TMA load issue for a TMA-loaded ring (matches
+  // computeBufferCount / bufferOccupancyStart), so the post-reduction II
+  // recompute sees the same resident span the depth was derived from.
+  int prodCycle = bufferOccupancyStart(loop, producerNodeId);
   llvm::DenseSet<unsigned> seen;
-  int lastConsumerEnd =
-      walkLastConsumerEnd(loop, producerNodeId, prodCycle, loop.II, 0, seen);
+  int lastConsumerEnd = walkLastConsumerEnd(
+      loop, producerNodeId, loop.getNode(producerNodeId).cycle, loop.II, 0,
+      seen);
   return lastConsumerEnd - prodCycle;
 }
 
@@ -1398,14 +1431,43 @@ buildCoConsumedGroups(const ttg::ScheduleLoop &loop) {
   return groups;
 }
 
-/// Reduce all buffers in a co-consumed group to the given depth.
-static void reduceGroupToDepth(ttg::ScheduleLoop &loop,
-                               const llvm::SmallVector<unsigned> &group,
-                               unsigned newDepth) {
-  for (unsigned bufId : group) {
-    if (loop.buffers[bufId].count > newDepth) {
-      loop.buffers[bufId].count = newDepth;
-      unsigned barId = loop.buffers[bufId].pairedBufferId;
+/// Reduce `bestIdx` together with every buffer it must stay equal-depth with,
+/// to `newDepth`. That set is the transitive closure over two relations:
+///   - co-consumed group: buffers feeding the same pipeline op share a ring
+///     depth;
+///   - merge group: buffers sharing one physical allocation, whose footprint is
+///     max(member.count) and whose members must stay equal for the emitter's
+///     reuse= aliasing (mergeNonOverlappingBuffers only groups equal counts).
+/// Reducing a single member would leave the physical footprint unchanged (so
+/// the budget loop would keep hammering that one member down to 1) and break
+/// the equal-count invariant. Paired barriers follow their data buffer.
+static void reduceBufferGroup(
+    ttg::ScheduleLoop &loop, unsigned bestIdx,
+    const llvm::SmallVector<llvm::SmallVector<unsigned>> &coGroups,
+    const llvm::DenseMap<unsigned, unsigned> &bufToGroupIdx, unsigned newDepth) {
+  llvm::DenseSet<unsigned> toReduce;
+  llvm::SmallVector<unsigned> work;
+  work.push_back(bestIdx);
+  while (!work.empty()) {
+    unsigned b = work.pop_back_val();
+    if (b >= loop.buffers.size() || !toReduce.insert(b).second)
+      continue;
+    // Co-consumed peers (same ring depth).
+    auto git = bufToGroupIdx.find(b);
+    if (git != bufToGroupIdx.end())
+      for (unsigned m : coGroups[git->second])
+        work.push_back(m);
+    // Merge-group peers (same physical allocation).
+    unsigned mg = loop.buffers[b].mergeGroupId;
+    if (mg != UINT_MAX)
+      for (unsigned j = 0; j < loop.buffers.size(); ++j)
+        if (loop.buffers[j].mergeGroupId == mg)
+          work.push_back(j);
+  }
+  for (unsigned b : toReduce) {
+    if (loop.buffers[b].count > newDepth) {
+      loop.buffers[b].count = newDepth;
+      unsigned barId = loop.buffers[b].pairedBufferId;
       if (barId != UINT_MAX)
         loop.buffers[barId].count = newDepth;
     }
@@ -1420,21 +1482,6 @@ static void reduceGroupToDepth(ttg::ScheduleLoop &loop,
 /// The schedule (op placement) stays fixed — only II and buffer depths change.
 static bool reduceBuffersForBudget(ttg::ScheduleLoop &loop,
                                    int64_t smemReserved = 0) {
-  // Precompute buffer lifetimes (from the original schedule, before reduction).
-  llvm::DenseMap<unsigned, int> bufLifetimes;
-  for (unsigned i = 0; i < loop.buffers.size(); ++i) {
-    auto &buf = loop.buffers[i];
-    if (buf.kind == ttg::MemoryKind::BARRIER ||
-        buf.kind == ttg::MemoryKind::Register)
-      continue;
-    for (const auto &node : loop.nodes) {
-      if (node.producesBuffer == buf.id) {
-        bufLifetimes[i] = computeBufferLifetime(loop, node.id);
-        break;
-      }
-    }
-  }
-
   // Build co-consumed groups so we reduce them together.
   auto coGroups = buildCoConsumedGroups(loop);
   // Map bufId → group index for quick lookup.
@@ -1480,21 +1527,18 @@ static bool reduceBuffersForBudget(ttg::ScheduleLoop &loop,
     if (bestIdx < 0)
       break;
     unsigned newDepth = loop.buffers[bestIdx].count - 1;
-    // If this buffer is in a co-consumed group, reduce the whole group.
-    auto groupIt = bufToGroupIdx.find(bestIdx);
-    if (groupIt != bufToGroupIdx.end()) {
-      reduceGroupToDepth(loop, coGroups[groupIt->second], newDepth);
-      LLVM_DEBUG(llvm::dbgs()
-                 << "[Step4.6] Reduced co-consumed group (buf" << bestIdx
-                 << " + partners) to count=" << newDepth << "\n");
-    } else {
-      loop.buffers[bestIdx].count = newDepth;
-      unsigned barId = loop.buffers[bestIdx].pairedBufferId;
-      if (barId != UINT_MAX)
-        loop.buffers[barId].count = newDepth;
-      LLVM_DEBUG(llvm::dbgs() << "[Step4.6] Reduced SMEM buf" << bestIdx
-                              << " to count=" << newDepth << "\n");
-    }
+    // Reduce bestIdx together with its co-consumed AND merge-group peers, so the
+    // physical footprint actually drops and the equal-count invariants hold.
+    reduceBufferGroup(loop, bestIdx, coGroups, bufToGroupIdx, newDepth);
+    LLVM_DEBUG(llvm::dbgs()
+               << "[Step4.6] Reduced SMEM buf" << bestIdx
+               << " (+ co-consumed/merge peers) to count=" << newDepth << "\n");
+    // Refresh physical buffers so the next computeTotalSmem() reflects the
+    // reduced logical count. Without this the merge-group footprint stays
+    // frozen at the pre-reduction depth, the total never drops below budget,
+    // and the loop over-reduces every ring to count=1 — collapsing the pipeline
+    // to a serial (non-buffered) schedule.
+    buildPhysicalBuffers(loop);
   }
 
   // TMEM reduction
@@ -1513,33 +1557,49 @@ static bool reduceBuffersForBudget(ttg::ScheduleLoop &loop,
     }
     if (bestIdx < 0)
       break;
-    loop.buffers[bestIdx].count--;
-    unsigned barId = loop.buffers[bestIdx].pairedBufferId;
-    if (barId != UINT_MAX)
-      loop.buffers[barId].count = loop.buffers[bestIdx].count;
+    unsigned newDepth = loop.buffers[bestIdx].count - 1;
+    reduceBufferGroup(loop, bestIdx, coGroups, bufToGroupIdx, newDepth);
     LLVM_DEBUG(llvm::dbgs()
                << "[Step4.6] Reduced TMEM buf" << bestIdx
-               << " to count=" << loop.buffers[bestIdx].count << "\n");
+               << " (+ co-consumed/merge peers) to count=" << newDepth << "\n");
+    // Refresh physical buffers so the next computeTotalTmem() reflects the
+    // reduced logical count (see the SMEM loop above).
+    buildPhysicalBuffers(loop);
   }
 
-  // Recompute II from reduced buffer depths.
-  // new_II = max over all buffers of ceil(lifetime / depth).
+  // Recompute II from the reduced buffer depths:
+  //   new_II = max over buffers of ceil(lifetime / depth).
+  // For a loop-carried buffer (consumer distance d > 0) the lifetime itself
+  // grows with II -- lastConsumerEnd includes d*II -- so a single pass using
+  // lifetimes measured at the old II under-estimates II and can let the loader
+  // reclaim a slot before its loop-carried consumer finishes. Iterate to a
+  // fixed point: set the trial II, recompute lifetimes AT that II, take the
+  // tightest ceil(lifetime/depth), repeat. II only increases, so this
+  // converges; the iteration cap guards the depth <= d case (no feasible II --
+  // the budget check below then reports the residual overflow).
   int newII = originalII;
-  for (unsigned i = 0; i < loop.buffers.size(); ++i) {
-    auto &buf = loop.buffers[i];
-    if (buf.kind == ttg::MemoryKind::BARRIER ||
-        buf.kind == ttg::MemoryKind::Register)
-      continue;
-    auto it = bufLifetimes.find(i);
-    if (it == bufLifetimes.end() || buf.count <= 0)
-      continue;
-    int requiredII = (it->second + buf.count - 1) / buf.count;
-    if (requiredII > newII) {
-      LLVM_DEBUG(llvm::dbgs() << "[Step4.6] buf" << i << " lifetime="
-                              << it->second << " depth=" << buf.count
-                              << " → requires II=" << requiredII << "\n");
-      newII = requiredII;
+  for (int iter = 0; iter < 64; ++iter) {
+    loop.II = newII;
+    int trialII = originalII;
+    for (unsigned i = 0; i < loop.buffers.size(); ++i) {
+      auto &buf = loop.buffers[i];
+      if (buf.kind == ttg::MemoryKind::BARRIER ||
+          buf.kind == ttg::MemoryKind::Register || buf.count <= 0)
+        continue;
+      int lifetime = -1;
+      for (const auto &node : loop.nodes)
+        if (node.producesBuffer == buf.id) {
+          lifetime = computeBufferLifetime(loop, node.id);
+          break;
+        }
+      if (lifetime < 0)
+        continue;
+      trialII = std::max(trialII,
+                         static_cast<int>((lifetime + buf.count - 1) / buf.count));
     }
+    if (trialII == newII)
+      break;
+    newII = trialII;
   }
 
   if (newII != originalII) {
@@ -1792,7 +1852,10 @@ static void computeBufferLifetimes(ttg::ScheduleLoop &loop) {
     for (const auto &node : loop.nodes) {
       if (node.producesBuffer != buf.id)
         continue;
-      buf.liveStart = node.cycle;
+      // Occupancy starts at the TMA load issue for a TMA-loaded ring (see
+      // bufferOccupancyStart), not the local_alloc's data-ready cycle. Keeps the
+      // merge-analysis live interval consistent with the buffer count.
+      buf.liveStart = bufferOccupancyStart(loop, node.id);
       // Walk transitively through transparent view ops (memdesc_trans /
       // memdesc_subview) so the buffer's live range reaches the actual
       // MMA / load / store that holds the SMEM, not just the metadata

--- a/third_party/tlx/tools/sched2tlx/examples/case1_simple_gemm/generated.py
+++ b/third_party/tlx/tools/sched2tlx/examples/case1_simple_gemm/generated.py
@@ -32,20 +32,20 @@ def gemm_kernel(
     mul_8 = (pid_1 * 128)
 
     # ── Multi-buffered allocations (from modulo's lifetime analysis) ──
-    # inner-loop buf 0: SMEM count=3 (modulo lifetime [556..1145], II=256)
-    L0_smem_0 = tlx.local_alloc((128, 64), tl.float16, 3)
-    # inner-loop buf 1: SMEM count=3 (modulo lifetime [586..1145], II=256)
-    L0_smem_1 = tlx.local_alloc((64, 128), tl.float16, 3)
+    # inner-loop buf 0: SMEM count=5 (modulo lifetime [0..1145], II=256)
+    L0_smem_0 = tlx.local_alloc((128, 64), tl.float16, 5)
+    # inner-loop buf 1: SMEM count=5 (modulo lifetime [30..1145], II=256)
+    L0_smem_1 = tlx.local_alloc((64, 128), tl.float16, 5)
     acc_tmem = tlx.local_alloc((128, 128), tl.float32, 1, tlx.storage_kind.tmem)
     c_smem = tlx.local_alloc((128, 128), tl.float16, 1)
 
     # ── Mbarriers (SemIR: full+empty pair per semaphore) ──
     # L0_smem_0: N1→N4  ttg.local_alloc→ttng.tc_gen5_mma  cyc556→cyc586  forward  buf=0  kind=mbarrier
-    L0_smem_0_full = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
-    L0_smem_0_empty = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
+    L0_smem_0_full = tlx.alloc_barriers(num_barriers=5, arrive_count=1)
+    L0_smem_0_empty = tlx.alloc_barriers(num_barriers=5, arrive_count=1)
     # L0_smem_1: N3→N4  ttg.local_alloc→ttng.tc_gen5_mma  cyc586→cyc586  forward  buf=1  kind=mbarrier
-    L0_smem_1_full = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
-    L0_smem_1_empty = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
+    L0_smem_1_full = tlx.alloc_barriers(num_barriers=5, arrive_count=1)
+    L0_smem_1_empty = tlx.alloc_barriers(num_barriers=5, arrive_count=1)
     # acc_tmem: cross-region TC-loop → default-epilogue hand-off, depth=1 (legacy carve-out)
     acc_tmem_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
     acc_tmem_empty = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
@@ -68,8 +68,8 @@ def gemm_kernel(
         with tlx.async_task(num_warps=1, num_regs=24):
             for tile_id in range(0, K, 64):
                 _it = (tile_id - 0) // 64
-                buf = _it % 3
-                phase = (_it // 3) & 1
+                buf = _it % 5
+                phase = (_it // 5) & 1
                 # load → L0_smem_0
                 tlx.barrier_wait(L0_smem_0_empty[buf], phase ^ 1)
                 tlx.barrier_expect_bytes(L0_smem_0_full[buf], 16384)
@@ -78,8 +78,8 @@ def gemm_kernel(
         with tlx.async_task(num_warps=1, num_regs=24):
             for tile_id in range(0, K, 64):
                 _it = (tile_id - 0) // 64
-                buf = _it % 3
-                phase = (_it // 3) & 1
+                buf = _it % 5
+                phase = (_it // 5) & 1
                 # load → L0_smem_1
                 tlx.barrier_wait(L0_smem_1_empty[buf], phase ^ 1)
                 tlx.barrier_expect_bytes(L0_smem_1_full[buf], 16384)
@@ -90,12 +90,12 @@ def gemm_kernel(
             i0_0 = False
             for tile_id in range(0, K, 64):
                 _it = (tile_id - 0) // 64
-                buf = _it % 3
-                phase = (_it // 3) & 1
+                buf = _it % 5
+                phase = (_it // 5) & 1
                 # MMA
-                tlx.barrier_wait(L0_smem_0_full[(_it % 3)], ((_it // 3) & 1))
-                tlx.barrier_wait(L0_smem_1_full[(_it % 3)], ((_it // 3) & 1))
+                tlx.barrier_wait(L0_smem_0_full[(_it % 5)], ((_it // 5) & 1))
+                tlx.barrier_wait(L0_smem_1_full[(_it % 5)], ((_it // 5) & 1))
                 use_acc = (tile_id > 0)
-                tlx.async_dot(L0_smem_0[buf], L0_smem_1[buf], acc_tmem[0], use_acc=use_acc, mBarriers=[L0_smem_0_empty[(_it % 3)], L0_smem_1_empty[(_it % 3)]])
+                tlx.async_dot(L0_smem_0[buf], L0_smem_1[buf], acc_tmem[0], use_acc=use_acc, mBarriers=[L0_smem_0_empty[(_it % 5)], L0_smem_1_empty[(_it % 5)]])
                 i0_0 = True
             tlx.tcgen05_commit(acc_tmem_full[0])

--- a/third_party/tlx/tools/sched2tlx/examples/case1_simple_gemm/schedule_graph.json
+++ b/third_party/tlx/tools/sched2tlx/examples/case1_simple_gemm/schedule_graph.json
@@ -19,231 +19,231 @@
     ]
   },
   "ops": {
-    "op_259872640": {
+    "op_246728032": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i1"],
       "attributes": {"value": 0}
     },
-    "op_259873248": {
+    "op_246728672": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i1"],
       "attributes": {"value": -1}
     },
-    "op_259880496": {
+    "op_246735792": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i64"],
       "attributes": {"value": 1}
     },
-    "op_259882992": {
+    "op_246738288": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 128}
     },
-    "op_259883168": {
+    "op_246739664": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 64}
     },
-    "op_259881744": {
+    "op_246737040": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 0}
     },
-    "op_259888048": {
+    "op_246744512": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"value": "dense<0.000000e+00> : tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}
     },
-    "op_259889392": {
+    "op_246744720": {
       "kind": "tt.get_program_id",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"axis": 0}
     },
-    "op_259889584": {
+    "op_246746048": {
       "kind": "tt.get_program_id",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"axis": 1}
     },
-    "op_259826224": {
+    "op_246677968": {
       "kind": "arith.extsi",
       "scope": "function",
       "operands": [{"arg": "stride_am"}],
       "result_types": ["i64"],
       "attributes": {}
     },
-    "op_259897664": {
+    "op_246754528": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "A"}, {"arg": "M"}, {"arg": "K"}, {"op": "op_259826224"}, {"const": 1, "type": "i64"}],
+      "operands": [{"arg": "A"}, {"arg": "M"}, {"arg": "K"}, {"op": "op_246677968"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_259899184": {
+    "op_246757184": {
       "kind": "arith.extsi",
       "scope": "function",
       "operands": [{"arg": "stride_bk"}],
       "result_types": ["i64"],
       "attributes": {}
     },
-    "op_259901696": {
+    "op_246758560": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "B"}, {"arg": "K"}, {"arg": "N"}, {"op": "op_259899184"}, {"const": 1, "type": "i64"}],
+      "operands": [{"arg": "B"}, {"arg": "K"}, {"arg": "N"}, {"op": "op_246757184"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_259808784": {
+    "op_246662704": {
       "kind": "arith.muli",
       "scope": "function",
-      "operands": [{"op": "op_259889392"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246744720"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_259697328": {
+    "op_246663408": {
       "kind": "arith.muli",
       "scope": "function",
-      "operands": [{"op": "op_259889584"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246746048"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_259923936": {
+    "op_246786624": {
       "kind": "ttng.tmem_alloc",
       "scope": "function",
       "operands": [],
       "result_types": ["!ttg.memdesc<128x128xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
       "attributes": {}
     },
-    "op_259311504": {
+    "op_246662976": {
       "kind": "ttng.tmem_store",
       "scope": "function",
-      "operands": [{"op": "op_259923936", "result": 0}, {"op": "op_259923936", "result": 1}, {"const": 0, "type": "tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246786624", "result": 0}, {"op": "op_246786624", "result": 1}, {"const": 0, "type": "tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {}
     },
-    "op_259583024": {
+    "op_246483712": {
       "kind": "tt.descriptor_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_259897664"}, {"op": "op_259808784"}, {"iv": 0}],
+      "operands": [{"op": "op_246754528"}, {"op": "op_246662704"}, {"iv": 0}],
       "result_types": ["tensor<128x64xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1, "loop.cluster": 0, "loop.stage": 0, "ttg.partition": [1]}
     },
-    "op_259918560": {
+    "op_246776384": {
       "kind": "ttg.local_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_259583024"}],
+      "operands": [{"op": "op_246483712"}],
       "result_types": ["!ttg.memdesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
-      "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 0, "loop.stage": 2, "tt.num_buffers": 3, "ttg.partition": [1]}
+      "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 0, "loop.stage": 2, "tt.num_buffers": 5, "ttg.partition": [1]}
     },
-    "op_259549072": {
+    "op_246439920": {
       "kind": "tt.descriptor_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_259901696"}, {"iv": 0}, {"op": "op_259697328"}],
+      "operands": [{"op": "op_246758560"}, {"iv": 0}, {"op": "op_246663408"}],
       "result_types": ["tensor<64x128xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1, "loop.cluster": 1, "loop.stage": 0, "ttg.partition": [2]}
     },
-    "op_259928208": {
+    "op_246770272": {
       "kind": "ttg.local_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_259549072"}],
+      "operands": [{"op": "op_246439920"}],
       "result_types": ["!ttg.memdesc<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
-      "attributes": {"buffer.id": 1, "buffer.merge_group_id": 1, "loop.cluster": 1, "loop.stage": 2, "tt.num_buffers": 3, "ttg.partition": [2]}
+      "attributes": {"buffer.id": 1, "buffer.merge_group_id": 1, "loop.cluster": 1, "loop.stage": 2, "tt.num_buffers": 5, "ttg.partition": [2]}
     },
-    "op_259231904": {
+    "op_246124896": {
       "kind": "ttng.tc_gen5_mma",
       "scope": "loop:0",
-      "operands": [{"op": "op_259918560"}, {"op": "op_259928208"}, {"op": "op_259923936", "result": 0}, {"iter_arg": {"loop": 0, "idx": 1}}, {"iter_arg": {"loop": 0, "idx": 0}}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246776384"}, {"op": "op_246770272"}, {"op": "op_246786624", "result": 0}, {"iter_arg": {"loop": 0, "idx": 1}}, {"iter_arg": {"loop": 0, "idx": 0}}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 1, "loop.stage": 2, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [3]}
     },
-    "op_259928624": {
+    "op_246770720": {
       "kind": "scf.yield",
       "scope": "loop:0",
-      "operands": [{"const": -1, "type": "i1"}, {"op": "op_259231904"}],
+      "operands": [{"const": -1, "type": "i1"}, {"op": "op_246124896"}],
       "result_types": [],
       "attributes": {}
     },
-    "op_259915536": {
+    "op_246771008": {
       "kind": "scf.for",
       "scope": "function",
-      "operands": [{"const": 0, "type": "i32"}, {"arg": "K"}, {"const": 64, "type": "i32"}, {"const": 0, "type": "i1"}, {"op": "op_259311504"}],
+      "operands": [{"const": 0, "type": "i32"}, {"arg": "K"}, {"const": 64, "type": "i32"}, {"const": 0, "type": "i1"}, {"op": "op_246662976"}],
       "result_types": ["i1", "!ttg.async.token"],
-      "attributes": {"tt.modulo_ii": 256, "tt.num_stages": 3, "tt.scheduled_max_stage": 2, "tt.warp_specialize": "unit", "ttg.partition.stages": [0, 2, 2, 2], "ttg.partition_num_warps": [4, 1, 1, 1], "ttg.warp_specialize.tag": 0}
+      "attributes": {"tt.modulo_ii": 256, "tt.num_stages": 5, "tt.scheduled_max_stage": 2, "tt.warp_specialize": "unit", "ttg.partition.stages": [0, 2, 2, 2], "ttg.partition_num_warps": [4, 1, 1, 1], "ttg.warp_specialize.tag": 0}
     },
-    "op_259927824": {
+    "op_246773216": {
       "kind": "ttng.tmem_load",
       "scope": "function",
-      "operands": [{"op": "op_259923936", "result": 0}, {"op": "op_259915536", "result": 1}],
+      "operands": [{"op": "op_246786624", "result": 0}, {"op": "op_246771008", "result": 1}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
       "attributes": {"resultSegmentSizes": [1, 1, 0], "ttg.partition": [0]}
     },
-    "op_259931920": {
+    "op_246763248": {
       "kind": "arith.extsi",
       "scope": "function",
       "operands": [{"arg": "stride_cm"}],
       "result_types": ["i64"],
       "attributes": {}
     },
-    "op_259915952": {
+    "op_246763488": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "C"}, {"arg": "M"}, {"arg": "N"}, {"op": "op_259931920"}, {"const": 1, "type": "i64"}],
+      "operands": [{"arg": "C"}, {"arg": "M"}, {"arg": "N"}, {"op": "op_246763248"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<128x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_259924048": {
+    "op_246778640": {
       "kind": "arith.muli",
       "scope": "function",
-      "operands": [{"op": "op_259889392"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246744720"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_259924384": {
+    "op_246779008": {
       "kind": "arith.muli",
       "scope": "function",
-      "operands": [{"op": "op_259889584"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246746048"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_259916240": {
+    "op_246763872": {
       "kind": "arith.truncf",
       "scope": "function",
-      "operands": [{"op": "op_259927824", "result": 0}],
+      "operands": [{"op": "op_246773216", "result": 0}],
       "result_types": ["tensor<128x128xf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"ttg.partition": [0]}
     },
-    "op_259916464": {
+    "op_246764032": {
       "kind": "ttg.convert_layout",
       "scope": "function",
-      "operands": [{"op": "op_259916240"}],
+      "operands": [{"op": "op_246763872"}],
       "result_types": ["tensor<128x128xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"ttg.partition": [0]}
     },
-    "op_259547744": {
+    "op_246405728": {
       "kind": "tt.descriptor_store",
       "scope": "function",
-      "operands": [{"op": "op_259915952"}, {"op": "op_259916464"}, {"op": "op_259924048"}, {"op": "op_259924384"}],
+      "operands": [{"op": "op_246763488"}, {"op": "op_246764032"}, {"op": "op_246778640"}, {"op": "op_246779008"}],
       "result_types": [],
       "attributes": {"reduce_kind": 0, "ttg.partition": [0]}
     },
-    "op_259916656": {
+    "op_246787984": {
       "kind": "tt.return",
       "scope": "function",
       "operands": [],
@@ -261,7 +261,7 @@
       "id": 0,
       "II": 256,
       "partition_cost": 255.9970,
-      "max_stage": 2,
+      "max_stage": 4,
       "prologue_latency": 256,
       "trip_count": 4,
       "trip_count_estimated": true,
@@ -270,18 +270,18 @@
       "upper_bound": {"arg": "K"},
       "step": {"const": 64, "type": "i32"},
       "buffers": [
-        {"id": 0, "kind": "smem", "shape": [128, 64], "element_bits": 16, "count": 3, "size_bytes": 16384, "total_bytes": 49152, "merge_group_id": 0, "paired_buffer_id": 2, "live_start": 556, "live_end": 1145, "def_op": "op_259918560"},
-        {"id": 1, "kind": "smem", "shape": [64, 128], "element_bits": 16, "count": 3, "size_bytes": 16384, "total_bytes": 49152, "merge_group_id": 1, "paired_buffer_id": 3, "live_start": 586, "live_end": 1145, "def_op": "op_259928208"},
-        {"id": 2, "kind": "barrier", "shape": [], "element_bits": 16, "count": 3, "size_bytes": 8, "total_bytes": 24, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 556, "live_end": 1145, "def_op": "op_259918560"},
-        {"id": 3, "kind": "barrier", "shape": [], "element_bits": 16, "count": 3, "size_bytes": 8, "total_bytes": 24, "merge_group_id": null, "paired_buffer_id": 1, "live_start": 586, "live_end": 1145, "def_op": "op_259928208"}
+        {"id": 0, "kind": "smem", "shape": [128, 64], "element_bits": 16, "count": 5, "size_bytes": 16384, "total_bytes": 81920, "merge_group_id": 0, "paired_buffer_id": 2, "live_start": 0, "live_end": 1145, "def_op": "op_246776384"},
+        {"id": 1, "kind": "smem", "shape": [64, 128], "element_bits": 16, "count": 5, "size_bytes": 16384, "total_bytes": 81920, "merge_group_id": 1, "paired_buffer_id": 3, "live_start": 30, "live_end": 1145, "def_op": "op_246770272"},
+        {"id": 2, "kind": "barrier", "shape": [], "element_bits": 16, "count": 5, "size_bytes": 8, "total_bytes": 40, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 0, "live_end": 1145, "def_op": "op_246776384"},
+        {"id": 3, "kind": "barrier", "shape": [], "element_bits": 16, "count": 5, "size_bytes": 8, "total_bytes": 40, "merge_group_id": null, "paired_buffer_id": 1, "live_start": 30, "live_end": 1145, "def_op": "op_246770272"}
       ],
       "graph": {
         "nodes": [
-          {"id": 0, "op_ref": "op_259583024", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 1, "op_ref": "op_259918560", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 0, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 556, "stage": 2, "cluster": 0}, "produces_buffer": 0, "consumes_buffers": []},
-          {"id": 2, "op_ref": "op_259549072", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 1, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 30, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 3, "op_ref": "op_259928208", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 586, "stage": 2, "cluster": 1}, "produces_buffer": 1, "consumes_buffers": []},
-          {"id": 4, "op_ref": "op_259231904", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 2, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 586, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": [0, 1]}
+          {"id": 0, "op_ref": "op_246483712", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 1, "op_ref": "op_246776384", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 0, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 556, "stage": 2, "cluster": 0}, "produces_buffer": 0, "consumes_buffers": []},
+          {"id": 2, "op_ref": "op_246439920", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 1, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 30, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 3, "op_ref": "op_246770272", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 586, "stage": 2, "cluster": 1}, "produces_buffer": 1, "consumes_buffers": []},
+          {"id": 4, "op_ref": "op_246124896", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 2, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 586, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": [0, 1]}
         ],
         "edges": [
           {"src": 0, "dst": 1, "kind": "data", "distance": 0, "latency": 556},
@@ -291,8 +291,8 @@
           {"src": 4, "dst": 4, "kind": "data", "distance": 1, "latency": 256}
         ],
         "cross_wg_barriers": [
-          {"producer_node": 1, "consumer_node": 4, "producer_wg": 0, "consumer_wg": 2, "kind": "mbarrier", "depth": 3, "paired_buffer_id": 0, "expect_bytes": 16384},
-          {"producer_node": 3, "consumer_node": 4, "producer_wg": 1, "consumer_wg": 2, "kind": "mbarrier", "depth": 3, "paired_buffer_id": 1, "expect_bytes": 16384}
+          {"producer_node": 1, "consumer_node": 4, "producer_wg": 0, "consumer_wg": 2, "kind": "mbarrier", "depth": 5, "paired_buffer_id": 0, "expect_bytes": 16384},
+          {"producer_node": 3, "consumer_node": 4, "producer_wg": 1, "consumer_wg": 2, "kind": "mbarrier", "depth": 5, "paired_buffer_id": 1, "expect_bytes": 16384}
         ]
       }
     }

--- a/third_party/tlx/tools/sched2tlx/examples/case2_persistent_gemm/generated.py
+++ b/third_party/tlx/tools/sched2tlx/examples/case2_persistent_gemm/generated.py
@@ -35,10 +35,10 @@ def _gemm_persistent(
     div_14 = (add_13 // 64)
 
     # ── Multi-buffered allocations (from modulo's lifetime analysis) ──
-    # inner-loop buf 0: SMEM count=3 (modulo lifetime [557..1146], II=256)
-    L0_smem_0 = tlx.local_alloc((128, 64), tl.float16, 3)
-    # inner-loop buf 1: SMEM count=3 (modulo lifetime [587..1146], II=256)
-    L0_smem_1 = tlx.local_alloc((64, 128), tl.float16, 3)
+    # inner-loop buf 0: SMEM count=5 (modulo lifetime [1..1146], II=256)
+    L0_smem_0 = tlx.local_alloc((128, 64), tl.float16, 5)
+    # inner-loop buf 1: SMEM count=5 (modulo lifetime [31..1146], II=256)
+    L0_smem_1 = tlx.local_alloc((64, 128), tl.float16, 5)
 
     # acc_tmem: outer-loop buf 0, count=2 (TC writes / default reads across 2 tiles)
     acc_tmem = tlx.local_alloc((128, 128), tl.float32, 2, tlx.storage_kind.tmem)
@@ -46,11 +46,11 @@ def _gemm_persistent(
 
     # ── Mbarriers (SemIR: full+empty pair per semaphore) ──
     # L0_smem_0: N2→N5  ttg.local_alloc→ttng.tc_gen5_mma  cyc557→cyc587  forward  buf=0  kind=mbarrier
-    L0_smem_0_full = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
-    L0_smem_0_empty = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
+    L0_smem_0_full = tlx.alloc_barriers(num_barriers=5, arrive_count=1)
+    L0_smem_0_empty = tlx.alloc_barriers(num_barriers=5, arrive_count=1)
     # L0_smem_1: N4→N5  ttg.local_alloc→ttng.tc_gen5_mma  cyc587→cyc587  forward  buf=1  kind=mbarrier
-    L0_smem_1_full = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
-    L0_smem_1_empty = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
+    L0_smem_1_full = tlx.alloc_barriers(num_barriers=5, arrive_count=1)
+    L0_smem_1_empty = tlx.alloc_barriers(num_barriers=5, arrive_count=1)
     # acc_tmem: cross-region TC-loop → default-epilogue hand-off, depth=2 (legacy carve-out)
     acc_tmem_full = tlx.alloc_barriers(num_barriers=2, arrive_count=1)
     acc_tmem_empty = tlx.alloc_barriers(num_barriers=2, arrive_count=1)
@@ -80,11 +80,11 @@ def _gemm_persistent(
             smem_accum = 0
             # Outer persistent loop (loop 1, II=8192). Each task replays it; body trimmed to this WG's ops.
             for tile_id in range(pid_0, mul_12, 148):
-                # Inner K-loop (loop 0, II=256). SMEM ring depth=3; smem_accum persists across outer tiles.
+                # Inner K-loop (loop 0, II=256). SMEM ring depth=5; smem_accum persists across outer tiles.
                 for k in range(0, div_14, 1):
                     _it = smem_accum
-                    buf = smem_accum % 3
-                    phase = (smem_accum // 3) & 1
+                    buf = smem_accum % 5
+                    phase = (smem_accum // 5) & 1
                     # load → L0_smem_0
                     tlx.barrier_wait(L0_smem_0_empty[buf], phase ^ 1)
                     tlx.barrier_expect_bytes(L0_smem_0_full[buf], 16384)
@@ -95,11 +95,11 @@ def _gemm_persistent(
             smem_accum = 0
             # Outer persistent loop (loop 1, II=8192). Each task replays it; body trimmed to this WG's ops.
             for tile_id in range(pid_0, mul_12, 148):
-                # Inner K-loop (loop 0, II=256). SMEM ring depth=3; smem_accum persists across outer tiles.
+                # Inner K-loop (loop 0, II=256). SMEM ring depth=5; smem_accum persists across outer tiles.
                 for k in range(0, div_14, 1):
                     _it = smem_accum
-                    buf = smem_accum % 3
-                    phase = (smem_accum // 3) & 1
+                    buf = smem_accum % 5
+                    phase = (smem_accum // 5) & 1
                     # load → L0_smem_1
                     tlx.barrier_wait(L0_smem_1_empty[buf], phase ^ 1)
                     tlx.barrier_expect_bytes(L0_smem_1_full[buf], 16384)
@@ -115,16 +115,16 @@ def _gemm_persistent(
                 tmem_phase = (tmem_accum_cnt // 2) & 1
                 tlx.barrier_wait(acc_tmem_empty[tmem_buf], tmem_phase ^ 1)
                 i0_0 = False
-                # Inner K-loop (loop 0, II=256). SMEM ring depth=3; smem_accum persists across outer tiles.
+                # Inner K-loop (loop 0, II=256). SMEM ring depth=5; smem_accum persists across outer tiles.
                 for k in range(0, div_14, 1):
                     _it = smem_accum
-                    buf = smem_accum % 3
-                    phase = (smem_accum // 3) & 1
+                    buf = smem_accum % 5
+                    phase = (smem_accum // 5) & 1
                     # MMA
-                    tlx.barrier_wait(L0_smem_0_full[(_it % 3)], ((_it // 3) & 1))
-                    tlx.barrier_wait(L0_smem_1_full[(_it % 3)], ((_it // 3) & 1))
+                    tlx.barrier_wait(L0_smem_0_full[(_it % 5)], ((_it // 5) & 1))
+                    tlx.barrier_wait(L0_smem_1_full[(_it % 5)], ((_it // 5) & 1))
                     use_acc = (k > 0)
-                    tlx.async_dot(L0_smem_0[buf], L0_smem_1[buf], acc_tmem[tmem_buf], use_acc=use_acc, mBarriers=[L0_smem_0_empty[(_it % 3)], L0_smem_1_empty[(_it % 3)]])
+                    tlx.async_dot(L0_smem_0[buf], L0_smem_1[buf], acc_tmem[tmem_buf], use_acc=use_acc, mBarriers=[L0_smem_0_empty[(_it % 5)], L0_smem_1_empty[(_it % 5)]])
                     smem_accum += 1
                     i0_0 = True
                 tlx.tcgen05_commit(acc_tmem_full[tmem_buf])

--- a/third_party/tlx/tools/sched2tlx/examples/case2_persistent_gemm/schedule_graph.json
+++ b/third_party/tlx/tools/sched2tlx/examples/case2_persistent_gemm/schedule_graph.json
@@ -16,322 +16,322 @@
     ]
   },
   "ops": {
-    "op_140748016": {
+    "op_246734752": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i1"],
       "attributes": {"value": 0}
     },
-    "op_140748128": {
+    "op_246734864": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i1"],
       "attributes": {"value": -1}
     },
-    "op_140755472": {
+    "op_246740448": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i64"],
       "attributes": {"value": 1}
     },
-    "op_140758000": {
+    "op_246741840": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 128}
     },
-    "op_140748864": {
+    "op_246735600": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 64}
     },
-    "op_140756720": {
+    "op_246741696": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 63}
     },
-    "op_140761184": {
+    "op_246748432": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 127}
     },
-    "op_140762528": {
+    "op_246749776": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 1}
     },
-    "op_140762736": {
+    "op_246751120": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 0}
     },
-    "op_140764480": {
+    "op_246752864": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 148}
     },
-    "op_140771120": {
+    "op_246759504": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"value": "dense<0.000000e+00> : tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}
     },
-    "op_140696128": {
+    "op_246682224": {
       "kind": "arith.extsi",
       "scope": "function",
       "operands": [{"arg": "stride_am"}],
       "result_types": ["i64"],
       "attributes": {}
     },
-    "op_140775104": {
+    "op_246764624": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "A"}, {"arg": "M"}, {"arg": "K"}, {"op": "op_140696128"}, {"const": 1, "type": "i64"}],
-      "result_types": ["!tt.tensordesc<tensor<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"],
+      "operands": [{"arg": "A"}, {"arg": "M"}, {"arg": "K"}, {"op": "op_246682224"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_140777760": {
+    "op_246766144": {
       "kind": "arith.extsi",
       "scope": "function",
       "operands": [{"arg": "stride_bk"}],
       "result_types": ["i64"],
       "attributes": {}
     },
-    "op_140780272": {
+    "op_246767520": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "B"}, {"arg": "K"}, {"arg": "N"}, {"op": "op_140777760"}, {"const": 1, "type": "i64"}],
-      "result_types": ["!tt.tensordesc<tensor<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"],
+      "operands": [{"arg": "B"}, {"arg": "K"}, {"arg": "N"}, {"op": "op_246766144"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_140780656": {
+    "op_246767904": {
       "kind": "arith.extsi",
       "scope": "function",
       "operands": [{"arg": "stride_cm"}],
       "result_types": ["i64"],
       "attributes": {}
     },
-    "op_140783632": {
+    "op_246769744": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "C"}, {"arg": "M"}, {"arg": "N"}, {"op": "op_140780656"}, {"const": 1, "type": "i64"}],
-      "result_types": ["!tt.tensordesc<tensor<128x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"],
+      "operands": [{"arg": "C"}, {"arg": "M"}, {"arg": "N"}, {"op": "op_246767904"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<128x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_140784832": {
+    "op_246772080": {
       "kind": "tt.get_program_id",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"axis": 0}
     },
-    "op_140690192": {
+    "op_246666912": {
       "kind": "arith.addi",
       "scope": "function",
       "operands": [{"arg": "M"}, {"const": 127, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_140693040": {
+    "op_246679184": {
       "kind": "arith.divsi",
       "scope": "function",
-      "operands": [{"op": "op_140690192"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246666912"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {}
     },
-    "op_140696272": {
+    "op_246682368": {
       "kind": "arith.addi",
       "scope": "function",
       "operands": [{"arg": "N"}, {"const": 127, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_140702208": {
+    "op_246687728": {
       "kind": "arith.divsi",
       "scope": "function",
-      "operands": [{"op": "op_140696272"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246682368"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {}
     },
-    "op_140786512": {
+    "op_246773760": {
       "kind": "arith.muli",
       "scope": "function",
-      "operands": [{"op": "op_140693040"}, {"op": "op_140702208"}],
+      "operands": [{"op": "op_246679184"}, {"op": "op_246687728"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_140786784": {
+    "op_246774032": {
       "kind": "arith.addi",
       "scope": "function",
       "operands": [{"arg": "K"}, {"const": 63, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_140787056": {
+    "op_246774304": {
       "kind": "arith.divsi",
       "scope": "function",
-      "operands": [{"op": "op_140786784"}, {"const": 64, "type": "i32"}],
+      "operands": [{"op": "op_246774032"}, {"const": 64, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {}
     },
-    "op_140787792": {
+    "op_246775040": {
       "kind": "arith.divsi",
       "scope": "loop:1",
-      "operands": [{"iv": 1}, {"op": "op_140702208"}],
+      "operands": [{"iv": 1}, {"op": "op_246687728"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 1, "loop.stage": 0, "ttg.partition": [4]}
     },
-    "op_140788064": {
+    "op_246775312": {
       "kind": "arith.remsi",
       "scope": "loop:1",
-      "operands": [{"iv": 1}, {"op": "op_140702208"}],
+      "operands": [{"iv": 1}, {"op": "op_246687728"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 2, "loop.stage": 0, "ttg.partition": [4]}
     },
-    "op_140789472": {
+    "op_246775584": {
       "kind": "arith.muli",
       "scope": "loop:1",
-      "operands": [{"op": "op_140787792"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246775040"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 3, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [4]}
     },
-    "op_140789744": {
+    "op_246775856": {
       "kind": "arith.muli",
       "scope": "loop:1",
-      "operands": [{"op": "op_140788064"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246775312"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 4, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [4]}
     },
-    "op_140815248": {
+    "op_246801360": {
       "kind": "ttng.tmem_alloc",
       "scope": "loop:1",
       "operands": [],
       "result_types": ["!ttg.memdesc<128x128xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
       "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 0, "loop.stage": 0, "tt.num_buffers": 2, "ttg.partition": [4]}
     },
-    "op_140701904": {
+    "op_246665920": {
       "kind": "ttng.tmem_store",
       "scope": "loop:1",
-      "operands": [{"op": "op_140815248", "result": 0}, {"op": "op_140815248", "result": 1}, {"const": 0, "type": "tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246801360", "result": 0}, {"op": "op_246801360", "result": 1}, {"const": 0, "type": "tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 0, "loop.stage": 0, "ttg.partition": [4]}
     },
-    "op_140807264": {
+    "op_246793376": {
       "kind": "arith.muli",
       "scope": "loop:0",
       "operands": [{"iv": 0}, {"const": 64, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 0, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [1]}
     },
-    "op_140501456": {
+    "op_246486880": {
       "kind": "tt.descriptor_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140775104"}, {"op": "op_140789472"}, {"op": "op_140807264"}],
+      "operands": [{"op": "op_246764624"}, {"op": "op_246775584"}, {"op": "op_246793376"}],
       "result_types": ["tensor<128x64xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1, "loop.cluster": 1, "loop.stage": 0, "ttg.partition": [1]}
     },
-    "op_140806832": {
+    "op_246792944": {
       "kind": "ttg.local_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_140501456"}],
+      "operands": [{"op": "op_246486880"}],
       "result_types": ["!ttg.memdesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
-      "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 0, "loop.stage": 2, "tt.num_buffers": 3, "ttg.partition": [1]}
+      "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 0, "loop.stage": 2, "tt.num_buffers": 5, "ttg.partition": [1]}
     },
-    "op_140457888": {
+    "op_246443088": {
       "kind": "tt.descriptor_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140780272"}, {"op": "op_140807264"}, {"op": "op_140789744"}],
+      "operands": [{"op": "op_246767520"}, {"op": "op_246793376"}, {"op": "op_246775856"}],
       "result_types": ["tensor<64x128xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1, "loop.cluster": 2, "loop.stage": 0, "ttg.partition": [2]}
     },
-    "op_140805152": {
+    "op_246791264": {
       "kind": "ttg.local_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_140457888"}],
+      "operands": [{"op": "op_246443088"}],
       "result_types": ["!ttg.memdesc<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
-      "attributes": {"buffer.id": 1, "buffer.merge_group_id": 1, "loop.cluster": 1, "loop.stage": 2, "tt.num_buffers": 3, "ttg.partition": [2]}
+      "attributes": {"buffer.id": 1, "buffer.merge_group_id": 1, "loop.cluster": 1, "loop.stage": 2, "tt.num_buffers": 5, "ttg.partition": [2]}
     },
-    "op_140145920": {
+    "op_246124896": {
       "kind": "ttng.tc_gen5_mma",
       "scope": "loop:0",
-      "operands": [{"op": "op_140806832"}, {"op": "op_140805152"}, {"op": "op_140815248", "result": 0}, {"iter_arg": {"loop": 0, "idx": 1}}, {"iter_arg": {"loop": 0, "idx": 0}}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246792944"}, {"op": "op_246791264"}, {"op": "op_246801360", "result": 0}, {"iter_arg": {"loop": 0, "idx": 1}}, {"iter_arg": {"loop": 0, "idx": 0}}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 1, "loop.stage": 2, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [3]}
     },
-    "op_140812992": {
+    "op_246799104": {
       "kind": "scf.yield",
       "scope": "loop:0",
-      "operands": [{"const": -1, "type": "i1"}, {"op": "op_140145920"}],
+      "operands": [{"const": -1, "type": "i1"}, {"op": "op_246124896"}],
       "result_types": [],
       "attributes": {}
     },
-    "op_140800976": {
+    "op_246787088": {
       "kind": "scf.for",
       "scope": "loop:1",
-      "operands": [{"const": 0, "type": "i32"}, {"op": "op_140787056"}, {"const": 1, "type": "i32"}, {"const": 0, "type": "i1"}, {"op": "op_140701904"}],
+      "operands": [{"const": 0, "type": "i32"}, {"op": "op_246774304"}, {"const": 1, "type": "i32"}, {"const": 0, "type": "i1"}, {"op": "op_246665920"}],
       "result_types": ["i1", "!ttg.async.token"],
-      "attributes": {"loop.cluster": 5, "loop.stage": 0, "tt.modulo_ii": 256, "tt.num_stages": 3, "tt.scheduled_max_stage": 2, "ttg.partition": [4], "ttg.partition.stages": [0, 2, 2, 2], "ttg.partition_num_warps": [4, 1, 1, 1], "ttg.warp_specialize.tag": 0}
+      "attributes": {"loop.cluster": 5, "loop.stage": 0, "tt.modulo_ii": 256, "tt.num_stages": 5, "tt.scheduled_max_stage": 2, "ttg.partition": [4], "ttg.partition.stages": [0, 2, 2, 2], "ttg.partition_num_warps": [4, 1, 1, 1], "ttg.warp_specialize.tag": 0}
     },
-    "op_140804752": {
+    "op_246790864": {
       "kind": "ttng.tmem_load",
       "scope": "loop:1",
-      "operands": [{"op": "op_140815248", "result": 0}, {"op": "op_140800976", "result": 1}],
+      "operands": [{"op": "op_246801360", "result": 0}, {"op": "op_246787088", "result": 1}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
       "attributes": {"loop.cluster": 0, "loop.stage": 1, "resultSegmentSizes": [1, 1, 0], "ttg.partition": [4]}
     },
-    "op_140801392": {
+    "op_246787504": {
       "kind": "arith.truncf",
       "scope": "loop:1",
-      "operands": [{"op": "op_140804752", "result": 0}],
+      "operands": [{"op": "op_246790864", "result": 0}],
       "result_types": ["tensor<128x128xf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"loop.cluster": 1, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_140801552": {
+    "op_246787760": {
       "kind": "ttg.convert_layout",
       "scope": "loop:1",
-      "operands": [{"op": "op_140801392"}],
+      "operands": [{"op": "op_246787504"}],
       "result_types": ["tensor<128x128xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"loop.cluster": 2, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_140787440": {
+    "op_246774688": {
       "kind": "tt.descriptor_store",
       "scope": "loop:1",
-      "operands": [{"op": "op_140783632"}, {"op": "op_140801552"}, {"op": "op_140789472"}, {"op": "op_140789744"}],
+      "operands": [{"op": "op_246769744"}, {"op": "op_246787760"}, {"op": "op_246775584"}, {"op": "op_246775856"}],
       "result_types": [],
       "attributes": {"buffer.id": 1, "loop.cluster": 3, "loop.stage": 1, "reduce_kind": 0, "tt.num_buffers": 1, "ttg.partition": [4]}
     },
-    "op_140790608": {
+    "op_246776720": {
       "kind": "scf.yield",
       "scope": "loop:1",
       "operands": [],
       "result_types": [],
       "attributes": {}
     },
-    "op_140424608": {
+    "op_246408896": {
       "kind": "scf.for",
       "scope": "function",
-      "operands": [{"op": "op_140784832"}, {"op": "op_140786512"}, {"const": 148, "type": "i32"}],
+      "operands": [{"op": "op_246772080"}, {"op": "op_246773760"}, {"const": 148, "type": "i32"}],
       "result_types": [],
       "attributes": {"tt.modulo_ii": 8192, "tt.num_stages": 2, "tt.scheduled_max_stage": 1, "tt.warp_specialize": "unit", "ttg.partition.stages": [0, 0, 0, 0, 1], "ttg.partition_num_warps": [4, 1, 1, 1, 4], "ttg.warp_specialize.tag": 0}
     },
-    "op_140790704": {
+    "op_246776816": {
       "kind": "tt.return",
       "scope": "function",
       "operands": [],
@@ -339,6 +339,7 @@
       "attributes": {}
     }
   },
+  "data_partition_candidates": [],
   "loops": [
     {
       "loop_id": 0,
@@ -347,29 +348,29 @@
       "schedule_loop":     {
       "id": 0,
       "II": 256,
-      "partition_cost": 255.9970,
-      "max_stage": 2,
+      "partition_cost": 10128431.9970,
+      "max_stage": 4,
       "prologue_latency": 256,
       "trip_count": 4,
       "trip_count_estimated": true,
       "induction_var": {"name": "iv", "type": "i32"},
       "lower_bound": {"const": 0, "type": "i32"},
-      "upper_bound": {"op": "op_140787056"},
+      "upper_bound": {"op": "op_246774304"},
       "step": {"const": 1, "type": "i32"},
       "buffers": [
-        {"id": 0, "kind": "smem", "shape": [128, 64], "element_bits": 16, "count": 3, "size_bytes": 16384, "total_bytes": 49152, "merge_group_id": 0, "paired_buffer_id": 2, "live_start": 557, "live_end": 1146, "def_op": "op_140806832"},
-        {"id": 1, "kind": "smem", "shape": [64, 128], "element_bits": 16, "count": 3, "size_bytes": 16384, "total_bytes": 49152, "merge_group_id": 1, "paired_buffer_id": 3, "live_start": 587, "live_end": 1146, "def_op": "op_140805152"},
-        {"id": 2, "kind": "barrier", "shape": [], "element_bits": 16, "count": 3, "size_bytes": 8, "total_bytes": 24, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 557, "live_end": 1146, "def_op": "op_140806832"},
-        {"id": 3, "kind": "barrier", "shape": [], "element_bits": 16, "count": 3, "size_bytes": 8, "total_bytes": 24, "merge_group_id": null, "paired_buffer_id": 1, "live_start": 587, "live_end": 1146, "def_op": "op_140805152"}
+        {"id": 0, "kind": "smem", "shape": [128, 64], "element_bits": 16, "count": 5, "size_bytes": 16384, "total_bytes": 81920, "merge_group_id": 0, "paired_buffer_id": 2, "live_start": 1, "live_end": 1146, "def_op": "op_246792944"},
+        {"id": 1, "kind": "smem", "shape": [64, 128], "element_bits": 16, "count": 5, "size_bytes": 16384, "total_bytes": 81920, "merge_group_id": 1, "paired_buffer_id": 3, "live_start": 31, "live_end": 1146, "def_op": "op_246791264"},
+        {"id": 2, "kind": "barrier", "shape": [], "element_bits": 16, "count": 5, "size_bytes": 8, "total_bytes": 40, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 1, "live_end": 1146, "def_op": "op_246792944"},
+        {"id": 3, "kind": "barrier", "shape": [], "element_bits": 16, "count": 5, "size_bytes": 8, "total_bytes": 40, "merge_group_id": null, "paired_buffer_id": 1, "live_start": 31, "live_end": 1146, "def_op": "op_246791264"}
       ],
       "graph": {
         "nodes": [
-          {"id": 0, "op_ref": "op_140807264", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": -2, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 1, "op_ref": "op_140501456", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 1, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 2, "op_ref": "op_140806832", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 0, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 557, "stage": 2, "cluster": 0}, "produces_buffer": 0, "consumes_buffers": []},
-          {"id": 3, "op_ref": "op_140457888", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 1, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 31, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 4, "op_ref": "op_140805152", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 587, "stage": 2, "cluster": 1}, "produces_buffer": 1, "consumes_buffers": []},
-          {"id": 5, "op_ref": "op_140145920", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 2, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 587, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": [0, 1]}
+          {"id": 0, "op_ref": "op_246793376", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": -2, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 1, "op_ref": "op_246486880", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 1, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 2, "op_ref": "op_246792944", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 0, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 557, "stage": 2, "cluster": 0}, "produces_buffer": 0, "consumes_buffers": []},
+          {"id": 3, "op_ref": "op_246443088", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 1, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 31, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 4, "op_ref": "op_246791264", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 587, "stage": 2, "cluster": 1}, "produces_buffer": 1, "consumes_buffers": []},
+          {"id": 5, "op_ref": "op_246124896", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 2, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 587, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": [0, 1]}
         ],
         "edges": [
           {"src": 0, "dst": 1, "kind": "data", "distance": 0, "latency": 1},
@@ -381,8 +382,8 @@
           {"src": 5, "dst": 5, "kind": "data", "distance": 1, "latency": 256}
         ],
         "cross_wg_barriers": [
-          {"producer_node": 2, "consumer_node": 5, "producer_wg": 0, "consumer_wg": 2, "kind": "mbarrier", "depth": 3, "paired_buffer_id": 0, "expect_bytes": 16384},
-          {"producer_node": 4, "consumer_node": 5, "producer_wg": 1, "consumer_wg": 2, "kind": "mbarrier", "depth": 3, "paired_buffer_id": 1, "expect_bytes": 16384}
+          {"producer_node": 2, "consumer_node": 5, "producer_wg": 0, "consumer_wg": 2, "kind": "mbarrier", "depth": 5, "paired_buffer_id": 0, "expect_bytes": 16384},
+          {"producer_node": 4, "consumer_node": 5, "producer_wg": 1, "consumer_wg": 2, "kind": "mbarrier", "depth": 5, "paired_buffer_id": 1, "expect_bytes": 16384}
         ]
       }
     }
@@ -394,33 +395,33 @@
       "schedule_loop":     {
       "id": 1,
       "II": 8192,
-      "partition_cost": 958.9990,
+      "partition_cost": 10129134.9990,
       "max_stage": 1,
       "prologue_latency": 96,
       "trip_count": 4,
       "trip_count_estimated": true,
       "induction_var": {"name": "iv", "type": "i32"},
-      "lower_bound": {"op": "op_140784832"},
-      "upper_bound": {"op": "op_140786512"},
+      "lower_bound": {"op": "op_246772080"},
+      "upper_bound": {"op": "op_246773760"},
       "step": {"const": 148, "type": "i32"},
       "buffers": [
-        {"id": 0, "kind": "tmem", "shape": [128, 128], "element_bits": 32, "count": 2, "size_bytes": 65536, "total_bytes": 131072, "merge_group_id": 0, "paired_buffer_id": 2, "live_start": 0, "live_end": 8820, "def_op": "op_140815248"},
-        {"id": 1, "kind": "smem", "shape": [128, 128], "element_bits": 16, "count": 1, "size_bytes": 32768, "total_bytes": 32768, "merge_group_id": null, "paired_buffer_id": null, "live_start": 9030, "live_end": 9030, "def_op": "op_140787440"},
-        {"id": 2, "kind": "barrier", "shape": [], "element_bits": 16, "count": 2, "size_bytes": 8, "total_bytes": 16, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 0, "live_end": 8820, "def_op": "op_140815248"}
+        {"id": 0, "kind": "tmem", "shape": [128, 128], "element_bits": 32, "count": 2, "size_bytes": 65536, "total_bytes": 131072, "merge_group_id": 0, "paired_buffer_id": 2, "live_start": 0, "live_end": 8820, "def_op": "op_246801360"},
+        {"id": 1, "kind": "smem", "shape": [128, 128], "element_bits": 16, "count": 1, "size_bytes": 32768, "total_bytes": 32768, "merge_group_id": null, "paired_buffer_id": null, "live_start": 9030, "live_end": 9030, "def_op": "op_246774688"},
+        {"id": 2, "kind": "barrier", "shape": [], "element_bits": 16, "count": 2, "size_bytes": 8, "total_bytes": 16, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 0, "live_end": 8820, "def_op": "op_246801360"}
       ],
       "graph": {
         "nodes": [
-          {"id": 0, "op_ref": "op_140787792", "op_kind": "arith.divsi", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 48, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 1, "op_ref": "op_140788064", "op_kind": "arith.remsi", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 49, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 2, "op_ref": "op_140789472", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 50, "stage": 0, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 3, "op_ref": "op_140789744", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 51, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 4, "op_ref": "op_140815248", "op_kind": "ttng.tmem_alloc", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": 0, "consumes_buffers": []},
-          {"id": 5, "op_ref": "op_140701904", "op_kind": "ttng.tmem_store", "pipeline": "CUDA", "warp_group": 3, "latency": 96, "self_latency": 48, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": [0]},
-          {"id": 6, "op_ref": "op_140800976", "op_kind": "scf.for", "pipeline": "NONE", "warp_group": 3, "latency": 8192, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 96, "stage": 0, "cluster": 5}, "produces_buffer": null, "consumes_buffers": [], "child_pipeline_id": 1, "prologue_latency": 256},
-          {"id": 7, "op_ref": "op_140804752", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 3, "latency": 532, "self_latency": 256, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 8288, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": [0]},
-          {"id": 8, "op_ref": "op_140801392", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 3, "latency": 105, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 8820, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 9, "op_ref": "op_140801552", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "warp_group": 3, "latency": 105, "self_latency": 105, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 8925, "stage": 1, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 10, "op_ref": "op_140787440", "op_kind": "tt.descriptor_store", "pipeline": "TMA", "warp_group": 3, "latency": 1794, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 9030, "stage": 1, "cluster": 3}, "produces_buffer": 1, "consumes_buffers": []}
+          {"id": 0, "op_ref": "op_246775040", "op_kind": "arith.divsi", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 48, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 1, "op_ref": "op_246775312", "op_kind": "arith.remsi", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 49, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 2, "op_ref": "op_246775584", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 50, "stage": 0, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 3, "op_ref": "op_246775856", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 51, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 4, "op_ref": "op_246801360", "op_kind": "ttng.tmem_alloc", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": 0, "consumes_buffers": []},
+          {"id": 5, "op_ref": "op_246665920", "op_kind": "ttng.tmem_store", "pipeline": "CUDA", "warp_group": 3, "latency": 96, "self_latency": 48, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": [0]},
+          {"id": 6, "op_ref": "op_246787088", "op_kind": "scf.for", "pipeline": "NONE", "warp_group": 3, "latency": 8192, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 96, "stage": 0, "cluster": 5}, "produces_buffer": null, "consumes_buffers": [], "child_pipeline_id": 1, "prologue_latency": 256},
+          {"id": 7, "op_ref": "op_246790864", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 3, "latency": 532, "self_latency": 256, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 8288, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": [0]},
+          {"id": 8, "op_ref": "op_246787504", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 3, "latency": 105, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 8820, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 9, "op_ref": "op_246787760", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "warp_group": 3, "latency": 105, "self_latency": 105, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 8925, "stage": 1, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 10, "op_ref": "op_246774688", "op_kind": "tt.descriptor_store", "pipeline": "TMA", "warp_group": 3, "latency": 1794, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 9030, "stage": 1, "cluster": 3}, "produces_buffer": 1, "consumes_buffers": []}
         ],
         "edges": [
           {"src": 0, "dst": 2, "kind": "data", "distance": 0, "latency": 1},

--- a/third_party/tlx/tools/sched2tlx/examples/case3_FA/generated.py
+++ b/third_party/tlx/tools/sched2tlx/examples/case3_FA/generated.py
@@ -31,16 +31,16 @@ def fa_fwd_kernel_nows(
     out_desc = tl.make_tensor_descriptor(Out, [mul_7, 128], [128, 1], [128, 128])
 
     # ── Multi-buffered allocations (from modulo's lifetime analysis) ──
-    # inner-loop buf 0: SMEM count=3 (modulo lifetime [588..3566], II=1325)
+    # inner-loop buf 0: SMEM count=3 (modulo lifetime [32..3566], II=1325)
     L0_smem_0 = tlx.local_alloc((64, 128), tl.bfloat16, 3)
-    # inner-loop buf 1: SMEM count=1 (modulo lifetime [558..1458], II=1325)
-    L0_smem_1 = tlx.local_alloc((64, 128), tl.bfloat16, 1)
+    # inner-loop buf 1: SMEM count=2 (modulo lifetime [2..1458], II=1325)
+    L0_smem_1 = tlx.local_alloc((64, 128), tl.bfloat16, 2)
     # inner-loop buf 2: TMEM count=1 (producer→consumer pipelining across iters)
     L0_acc_tmem_2 = tlx.local_alloc((128, 64), tl.bfloat16, 1, tlx.storage_kind.tmem)
-    # inner-loop buf 4: SMEM count=1 (channel for cross-WG hand-off)
-    L0_smem_4 = tlx.local_alloc((128,), tl.float32, 1)
     # inner-loop buf 5: SMEM count=1 (channel for cross-WG hand-off)
-    L0_smem_5 = tlx.local_alloc((128, 64), tl.bfloat16, 1)
+    L0_smem_5 = tlx.local_alloc((128,), tl.float32, 1)
+    # inner-loop buf 6: SMEM count=1 (channel for cross-WG hand-off)
+    L0_smem_6 = tlx.local_alloc((128, 64), tl.bfloat16, 1)
     acc_tmem = tlx.local_alloc((128, 128), tl.float32, 1, tlx.storage_kind.tmem)
     acc_tmem_4 = tlx.local_alloc((128, 64), tl.float32, 1, tlx.storage_kind.tmem)
     # q_smem_5: function-scope SMEM alloc (e.g., per-tile resident Q tile in non-persistent FA)
@@ -53,19 +53,19 @@ def fa_fwd_kernel_nows(
     epi_l_i_0_smem = tlx.local_alloc((128,), tl.float32, 1)
     # ── Mbarriers (SemIR: full+empty pair per semaphore) ──
     # L0_smem_1: N5→N6  ttg.local_alloc→ttg.memdesc_trans  cyc558→cyc558  forward  buf=1  kind=mbarrier
-    L0_smem_1_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
-    L0_smem_1_empty = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+    L0_smem_1_full = tlx.alloc_barriers(num_barriers=2, arrive_count=1)
+    L0_smem_1_empty = tlx.alloc_barriers(num_barriers=2, arrive_count=1)
     # sem1: N7→N8  ttng.tc_gen5_mma→ttng.tmem_load  cyc558→cyc1458  forward  buf=None  kind=named
     sem1_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
-    # sem2_b4: N13→N20  math.exp2→tt.expand_dims  cyc2596→cyc2604  forward  buf=4  kind=mbarrier
-    sem2_b4_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
-    sem2_b4_empty = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+    # sem2_b5: N13→N20  math.exp2→tt.expand_dims  cyc2596→cyc2604  forward  buf=5  kind=mbarrier
+    sem2_b5_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+    sem2_b5_empty = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
     # L0_smem_0: N4→N28  ttg.local_alloc→ttng.tc_gen5_mma  cyc588→cyc3007  forward  buf=0  kind=mbarrier
     L0_smem_0_full = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
     L0_smem_0_empty = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
     # sem4: N27→N28  ttng.tmem_store→ttng.tc_gen5_mma  cyc2911→cyc3007  forward  buf=None  kind=mbarrier
     sem4_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
-    # sem5: N8→N7  ttng.tmem_load→ttng.tc_gen5_mma  cyc1458→cyc558  LOOP-CARRY  buf=6  kind=mbarrier
+    # sem5: N8→N7  ttng.tmem_load→ttng.tc_gen5_mma  cyc1458→cyc558  LOOP-CARRY  buf=7  kind=mbarrier
     sem5_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
     # sem6: N28→N23  ttng.tc_gen5_mma→ttng.tmem_load  cyc3007→cyc1014  LOOP-CARRY  buf=None  kind=named
     sem6_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
@@ -107,12 +107,12 @@ def fa_fwd_kernel_nows(
             tlx.async_descriptor_load(q_desc, q_smem_5[0], [add_5, 0], q_smem_5_full[0])
             for tile_id in range(0, div_6, 1):
                 _it = (tile_id - 0) // 1
-                buf = _it % 1
-                phase = (_it // 1) & 1
+                buf = _it % 2
+                phase = (_it // 2) & 1
                 # load → L0_smem_1
-                tlx.barrier_wait(L0_smem_1_empty[0], (_it & 1) ^ 1)
-                tlx.barrier_expect_bytes(L0_smem_1_full[0], 16384)
-                tlx.async_descriptor_load(k_desc, L0_smem_1[0], [(mul_3 + (tile_id * 64)), 0], L0_smem_1_full[0])
+                tlx.barrier_wait(L0_smem_1_empty[buf], phase ^ 1)
+                tlx.barrier_expect_bytes(L0_smem_1_full[buf], 16384)
+                tlx.async_descriptor_load(k_desc, L0_smem_1[buf], [(mul_3 + (tile_id * 64)), 0], L0_smem_1_full[buf])
         # Async task: role=TMA ← inner wg1 (Phase 4 plan)
         with tlx.async_task(num_warps=1, num_regs=24):
             for tile_id in range(0, div_6, 1):
@@ -129,14 +129,14 @@ def fa_fwd_kernel_nows(
             tlx.barrier_arrive(sem5_full[0], 1)  # is_released=True (loop-carry init)
             for tile_id in range(0, div_6, 1):
                 _it = (tile_id - 0) // 1
-                buf = _it % 1
-                phase = (_it // 1) & 1
+                buf = _it % 2
+                phase = (_it // 2) & 1
                 mdt_15 = tlx.local_trans(L0_smem_1[0])
                 # MMA
-                tlx.barrier_wait(L0_smem_1_full[0], (_it & 1))
+                tlx.barrier_wait(L0_smem_1_full[(_it % 2)], ((_it // 2) & 1))
                 tlx.barrier_wait(sem5_full[0], (_it & 1))
                 use_acc = False
-                tlx.async_dot(q_smem_5[0], tlx.local_trans(L0_smem_1[0]), acc_tmem_4[0], use_acc=use_acc, mBarriers=[L0_smem_1_empty[0], sem1_full[0]])
+                tlx.async_dot(q_smem_5[0], tlx.local_trans(L0_smem_1[buf]), acc_tmem_4[0], use_acc=use_acc, mBarriers=[L0_smem_1_empty[(_it % 2)], sem1_full[0]])
         # Async task: role=CUDA+NONE+SFU ← inner wg3 (Phase 4 plan)
         with tlx.async_task(num_warps=4, num_regs=152):
             m_i_0 = tl.full((128,), float('-inf'), tl.float32)
@@ -162,9 +162,9 @@ def fa_fwd_kernel_nows(
                 mulf_28 = (l_i_0 * exp2_26)
                 red_29 = tl.sum(exp2_24, 1)
                 addf_30 = (mulf_28 + red_29)
-                tlx.barrier_wait(sem2_b4_empty[0], ((_it & 1) ^ 1))
-                tlx.local_store(L0_smem_4[0], exp2_26)
-                tlx.barrier_arrive(sem2_b4_full[0], 1)
+                tlx.barrier_wait(sem2_b5_empty[0], ((_it & 1) ^ 1))
+                tlx.local_store(L0_smem_5[0], exp2_26)
+                tlx.barrier_arrive(sem2_b5_full[0], 1)
                 tlx.barrier_wait(L0_acc_tmem_2_empty[0], (_it & 1) ^ 1)  # TMEM bridge
                 tlx.local_store(L0_acc_tmem_2[0], trunc_27)
                 tlx.barrier_arrive(L0_acc_tmem_2_full[0], 1)
@@ -183,10 +183,10 @@ def fa_fwd_kernel_nows(
                 phase = (_it // 1) & 1
                 tlx.barrier_wait(sem6_full[0], (_it & 1))  # N28→N23  ttng.tc_gen5_mma→ttng.tmem_load  cyc3007→cyc1014  LOOP-CARRY  buf=None  kind=named
                 tmload_31 = tlx.local_load(acc_tmem[0])
-                tlx.barrier_wait(sem2_b4_full[0], (_it & 1))
-                chan_sem2_b4_0 = tlx.local_load(L0_smem_4[0])
-                tlx.barrier_arrive(sem2_b4_empty[0], 1)
-                expand_32 = chan_sem2_b4_0[:, None]
+                tlx.barrier_wait(sem2_b5_full[0], (_it & 1))
+                chan_sem2_b5_0 = tlx.local_load(L0_smem_5[0])
+                tlx.barrier_arrive(sem2_b5_empty[0], 1)
+                expand_32 = chan_sem2_b5_0[:, None]
                 cvt_33 = expand_32
                 bcast_34 = cvt_33
                 mulf_35 = (tmload_31 * bcast_34)

--- a/third_party/tlx/tools/sched2tlx/examples/case3_FA/schedule_graph.json
+++ b/third_party/tlx/tools/sched2tlx/examples/case3_FA/schedule_graph.json
@@ -15,609 +15,609 @@
     ]
   },
   "ops": {
-    "op_750567872": {
+    "op_246742304": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i1"],
       "attributes": {"value": 0}
     },
-    "op_750567984": {
+    "op_246742416": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i1"],
       "attributes": {"value": -1}
     },
-    "op_750574144": {
+    "op_246750784": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 128}
     },
-    "op_750575488": {
+    "op_246752128": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 64}
     },
-    "op_750575696": {
+    "op_246752336": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i64"],
       "attributes": {"value": 128}
     },
-    "op_750572704": {
+    "op_246742960": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i64"],
       "attributes": {"value": 1}
     },
-    "op_750572912": {
+    "op_246743168": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 0}
     },
-    "op_750577840": {
+    "op_246754480": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["f32"],
       "attributes": {"value": "1.44269502 : f32"}
     },
-    "op_750578048": {
+    "op_246754688": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 1}
     },
-    "op_750582912": {
+    "op_246759552": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"value": "dense<1.000000e+00> : tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"}
     },
-    "op_750585424": {
+    "op_246762064": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"value": "dense<0xFF800000> : tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"}
     },
-    "op_750586784": {
+    "op_246766832": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"value": "dense<0.000000e+00> : tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}
     },
-    "op_750586992": {
+    "op_246767040": {
       "kind": "tt.get_program_id",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"axis": 0}
     },
-    "op_750587184": {
+    "op_246768368": {
       "kind": "tt.get_program_id",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"axis": 1}
     },
-    "op_750249360": {
+    "op_246426096": {
       "kind": "arith.muli",
       "scope": "function",
-      "operands": [{"op": "op_750587184"}, {"arg": "N_CTX"}],
+      "operands": [{"op": "op_246768368"}, {"arg": "N_CTX"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_750497232": {
+    "op_246673456": {
       "kind": "arith.muli",
       "scope": "function",
-      "operands": [{"op": "op_750586992"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246767040"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_750497408": {
+    "op_246673632": {
       "kind": "arith.addi",
       "scope": "function",
-      "operands": [{"op": "op_750249360"}, {"op": "op_750497232"}],
+      "operands": [{"op": "op_246426096"}, {"op": "op_246673456"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_750516000": {
+    "op_246691936": {
       "kind": "arith.divsi",
       "scope": "function",
       "operands": [{"arg": "N_CTX"}, {"const": 64, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {}
     },
-    "op_750593872": {
+    "op_246774320": {
       "kind": "arith.muli",
       "scope": "function",
       "operands": [{"arg": "H"}, {"arg": "N_CTX"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_750598880": {
+    "op_246777056": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "Q"}, {"op": "op_750593872"}, {"const": 128, "type": "i32"}, {"const": 128, "type": "i64"}, {"const": 1, "type": "i64"}],
+      "operands": [{"arg": "Q"}, {"op": "op_246774320"}, {"const": 128, "type": "i32"}, {"const": 128, "type": "i64"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<128x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_750601536": {
+    "op_246779712": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "K"}, {"op": "op_750593872"}, {"const": 128, "type": "i32"}, {"const": 128, "type": "i64"}, {"const": 1, "type": "i64"}],
+      "operands": [{"arg": "K"}, {"op": "op_246774320"}, {"const": 128, "type": "i32"}, {"const": 128, "type": "i64"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<64x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_750603056": {
+    "op_246780096": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "V"}, {"op": "op_750593872"}, {"const": 128, "type": "i32"}, {"const": 128, "type": "i64"}, {"const": 1, "type": "i64"}],
+      "operands": [{"arg": "V"}, {"op": "op_246774320"}, {"const": 128, "type": "i32"}, {"const": 128, "type": "i64"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<64x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_750603440": {
+    "op_246780480": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "Out"}, {"op": "op_750593872"}, {"const": 128, "type": "i32"}, {"const": 128, "type": "i64"}, {"const": 1, "type": "i64"}],
+      "operands": [{"arg": "Out"}, {"op": "op_246774320"}, {"const": 128, "type": "i32"}, {"const": 128, "type": "i64"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<128x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_750256016": {
+    "op_246476544": {
       "kind": "tt.descriptor_load",
       "scope": "function",
-      "operands": [{"op": "op_750598880"}, {"op": "op_750497408"}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246777056"}, {"op": "op_246673632"}, {"const": 0, "type": "i32"}],
       "result_types": ["tensor<128x128xbf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1}
     },
-    "op_750500192": {
+    "op_246677232": {
       "kind": "ttg.local_alloc",
       "scope": "function",
-      "operands": [{"op": "op_750256016"}],
+      "operands": [{"op": "op_246476544"}],
       "result_types": ["!ttg.memdesc<128x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
       "attributes": {}
     },
-    "op_750608560": {
+    "op_246785600": {
       "kind": "arith.mulf",
       "scope": "function",
       "operands": [{"arg": "sm_scale"}, {"const": 1.4427, "type": "f32"}],
       "result_types": ["f32"],
       "attributes": {"fastmath": "#arith.fastmath<none>"}
     },
-    "op_750504384": {
+    "op_246680368": {
       "kind": "tt.splat",
       "scope": "function",
-      "operands": [{"op": "op_750608560"}],
+      "operands": [{"op": "op_246785600"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {}
     },
-    "op_750610864": {
+    "op_246789040": {
       "kind": "tt.splat",
       "scope": "function",
-      "operands": [{"op": "op_750608560"}],
+      "operands": [{"op": "op_246785600"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {}
     },
-    "op_750619440": {
+    "op_246805584": {
       "kind": "ttng.tmem_alloc",
       "scope": "function",
       "operands": [],
       "result_types": ["!ttg.memdesc<128x64xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
       "attributes": {}
     },
-    "op_750612720": {
+    "op_246806192": {
       "kind": "ttng.tmem_alloc",
       "scope": "function",
       "operands": [],
       "result_types": ["!ttg.memdesc<128x128xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
       "attributes": {}
     },
-    "op_750505488": {
+    "op_246681472": {
       "kind": "ttng.tmem_store",
       "scope": "function",
-      "operands": [{"op": "op_750612720", "result": 0}, {"op": "op_750612720", "result": 1}, {"const": 0, "type": "tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246806192", "result": 0}, {"op": "op_246806192", "result": 1}, {"const": 0, "type": "tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {}
     },
-    "op_750612464": {
+    "op_246804144": {
       "kind": "arith.muli",
       "scope": "loop:0",
       "operands": [{"iv": 0}, {"const": 64, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 0, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>"}
     },
-    "op_750612832": {
+    "op_246790512": {
       "kind": "arith.addi",
       "scope": "loop:0",
-      "operands": [{"op": "op_750249360"}, {"op": "op_750612464"}],
+      "operands": [{"op": "op_246426096"}, {"op": "op_246804144"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 1, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [1]}
     },
-    "op_750222256": {
+    "op_246432752": {
       "kind": "tt.descriptor_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_750601536"}, {"op": "op_750612832"}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246779712"}, {"op": "op_246790512"}, {"const": 0, "type": "i32"}],
       "result_types": ["tensor<64x128xbf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1, "loop.cluster": 2, "loop.stage": 0, "ttg.partition": [1]}
     },
-    "op_750220944": {
+    "op_246398576": {
       "kind": "tt.descriptor_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_750603056"}, {"op": "op_750612832"}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246780096"}, {"op": "op_246790512"}, {"const": 0, "type": "i32"}],
       "result_types": ["tensor<64x128xbf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1, "loop.cluster": 3, "loop.stage": 0, "ttg.partition": [2]}
     },
-    "op_750630416": {
+    "op_246804688": {
       "kind": "ttg.local_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_750220944"}],
+      "operands": [{"op": "op_246398576"}],
       "result_types": ["!ttg.memdesc<64x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
       "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 5, "loop.stage": 0, "tt.num_buffers": 3, "ttg.partition": [2]}
     },
-    "op_750622256": {
+    "op_246804896": {
       "kind": "ttg.local_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_750222256"}],
+      "operands": [{"op": "op_246432752"}],
       "result_types": ["!ttg.memdesc<64x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
-      "attributes": {"buffer.id": 1, "buffer.merge_group_id": 1, "loop.cluster": 4, "loop.stage": 0, "tt.num_buffers": 1, "ttg.partition": [1]}
+      "attributes": {"buffer.id": 1, "buffer.merge_group_id": 1, "loop.cluster": 4, "loop.stage": 0, "tt.num_buffers": 2, "ttg.partition": [1]}
     },
-    "op_750622496": {
+    "op_246805296": {
       "kind": "ttg.memdesc_trans",
       "scope": "loop:0",
-      "operands": [{"op": "op_750622256"}],
+      "operands": [{"op": "op_246804896"}],
       "result_types": ["!ttg.memdesc<128x64xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>, #ttg.shared_memory>"],
       "attributes": {"loop.cluster": 4, "loop.stage": 0, "order": [1, 0], "ttg.partition": [3]}
     },
-    "op_749912224": {
+    "op_246124896": {
       "kind": "ttng.tc_gen5_mma",
       "scope": "loop:0",
-      "operands": [{"op": "op_750500192"}, {"op": "op_750622496"}, {"op": "op_750619440", "result": 0}, {"iter_arg": {"loop": 0, "idx": 3}}, {"const": 0, "type": "i1"}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246677232"}, {"op": "op_246805296"}, {"op": "op_246805584", "result": 0}, {"iter_arg": {"loop": 0, "idx": 3}}, {"const": 0, "type": "i1"}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 4, "loop.stage": 0, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [3]}
     },
-    "op_750630048": {
+    "op_246821104": {
       "kind": "ttng.tmem_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_750619440", "result": 0}, {"op": "op_749912224"}],
+      "operands": [{"op": "op_246805584", "result": 0}, {"op": "op_246124896"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
       "attributes": {"loop.cluster": 0, "loop.stage": 1, "resultSegmentSizes": [1, 1, 0], "ttg.partition": [4]}
     },
-    "op_750634000": {
+    "op_246812176": {
       "kind": "arith.maxnumf",
       "scope": "loop:0",
       "operands": [{"unknown_block_arg": true}, {"unknown_block_arg": true}],
       "result_types": ["f32"],
       "attributes": {"fastmath": "#arith.fastmath<none>"}
     },
-    "op_750612320": {
+    "op_246801632": {
       "kind": "tt.reduce.return",
       "scope": "loop:0",
-      "operands": [{"op": "op_750634000"}],
+      "operands": [{"op": "op_246812176"}],
       "result_types": [],
       "attributes": {}
     },
-    "op_750626016": {
+    "op_246803776": {
       "kind": "tt.reduce",
       "scope": "loop:0",
-      "operands": [{"op": "op_750630048", "result": 0}],
+      "operands": [{"op": "op_246821104", "result": 0}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"axis": 1, "loop.cluster": 1, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_750625456": {
+    "op_246801872": {
       "kind": "arith.mulf",
       "scope": "loop:0",
-      "operands": [{"op": "op_750626016"}, {"op": "op_750504384"}],
+      "operands": [{"op": "op_246803776"}, {"op": "op_246680368"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 3, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_750641216": {
+    "op_246819472": {
       "kind": "arith.maxnumf",
       "scope": "loop:0",
-      "operands": [{"iter_arg": {"loop": 0, "idx": 0}}, {"op": "op_750625456"}],
+      "operands": [{"iter_arg": {"loop": 0, "idx": 0}}, {"op": "op_246801872"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 4, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_750639792": {
+    "op_246815744": {
       "kind": "arith.subf",
       "scope": "loop:0",
-      "operands": [{"iter_arg": {"loop": 0, "idx": 0}}, {"op": "op_750641216"}],
+      "operands": [{"iter_arg": {"loop": 0, "idx": 0}}, {"op": "op_246819472"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 7, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_750617504": {
+    "op_246816000": {
       "kind": "math.exp2",
       "scope": "loop:0",
-      "operands": [{"op": "op_750639792"}],
+      "operands": [{"op": "op_246815744"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 8, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_750617712": {
+    "op_246816208": {
       "kind": "arith.mulf",
       "scope": "loop:0",
-      "operands": [{"op": "op_750630048", "result": 0}, {"op": "op_750610864"}],
+      "operands": [{"op": "op_246821104", "result": 0}, {"op": "op_246789040"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 2, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_750631760": {
+    "op_246816464": {
       "kind": "tt.expand_dims",
       "scope": "loop:0",
-      "operands": [{"op": "op_750641216"}],
+      "operands": [{"op": "op_246819472"}],
       "result_types": ["tensor<128x1xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"axis": 1, "loop.cluster": 5, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_750631968": {
+    "op_246816672": {
       "kind": "tt.broadcast",
       "scope": "loop:0",
-      "operands": [{"op": "op_750631760"}],
+      "operands": [{"op": "op_246816464"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"loop.cluster": 5, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_750632176": {
+    "op_246816880": {
       "kind": "arith.subf",
       "scope": "loop:0",
-      "operands": [{"op": "op_750617712"}, {"op": "op_750631968"}],
+      "operands": [{"op": "op_246816208"}, {"op": "op_246816672"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 5, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_750642400": {
+    "op_246817136": {
       "kind": "math.exp2",
       "scope": "loop:0",
-      "operands": [{"op": "op_750632176"}],
+      "operands": [{"op": "op_246816880"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 6, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_750632432": {
+    "op_246818160": {
       "kind": "arith.addf",
       "scope": "loop:0",
       "operands": [{"unknown_block_arg": true}, {"unknown_block_arg": true}],
       "result_types": ["f32"],
       "attributes": {"fastmath": "#arith.fastmath<none>"}
     },
-    "op_750617952": {
+    "op_246818400": {
       "kind": "tt.reduce.return",
       "scope": "loop:0",
-      "operands": [{"op": "op_750632432"}],
+      "operands": [{"op": "op_246818160"}],
       "result_types": [],
       "attributes": {}
     },
-    "op_750641424": {
+    "op_246819872": {
       "kind": "tt.reduce",
       "scope": "loop:0",
-      "operands": [{"op": "op_750642400"}],
+      "operands": [{"op": "op_246817136"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"axis": 1, "loop.cluster": 4, "loop.stage": 2, "ttg.partition": [4]}
     },
-    "op_750632688": {
+    "op_246818544": {
       "kind": "tt.expand_dims",
       "scope": "loop:0",
-      "operands": [{"op": "op_750617504"}],
+      "operands": [{"op": "op_246816000"}],
       "result_types": ["tensor<128x1xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"axis": 1, "loop.cluster": 9, "loop.stage": 1, "ttg.partition": [5]}
     },
-    "op_750636112": {
+    "op_246818784": {
       "kind": "ttg.convert_layout",
       "scope": "loop:0",
-      "operands": [{"op": "op_750632688"}],
+      "operands": [{"op": "op_246818544"}],
       "result_types": ["tensor<128x1xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"loop.cluster": 9, "loop.stage": 1, "ttg.partition": [5]}
     },
-    "op_750636256": {
+    "op_246818928": {
       "kind": "tt.broadcast",
       "scope": "loop:0",
-      "operands": [{"op": "op_750636112"}],
+      "operands": [{"op": "op_246818784"}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"loop.cluster": 9, "loop.stage": 1, "ttg.partition": [5]}
     },
-    "op_750642624": {
+    "op_246795520": {
       "kind": "ttng.tmem_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_750612720", "result": 0}, {"iter_arg": {"loop": 0, "idx": 4}}],
+      "operands": [{"op": "op_246806192", "result": 0}, {"iter_arg": {"loop": 0, "idx": 4}}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
       "attributes": {"loop.cluster": 6, "loop.stage": 0, "resultSegmentSizes": [1, 1, 0], "ttg.partition": [5]}
     },
-    "op_750648272": {
+    "op_246831024": {
       "kind": "arith.mulf",
       "scope": "loop:0",
-      "operands": [{"op": "op_750642624", "result": 0}, {"op": "op_750636256"}],
+      "operands": [{"op": "op_246795520", "result": 0}, {"op": "op_246818928"}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 0, "loop.stage": 2, "ttg.partition": [5]}
     },
-    "op_750509680": {
+    "op_246685664": {
       "kind": "arith.truncf",
       "scope": "loop:0",
-      "operands": [{"op": "op_750642400"}],
+      "operands": [{"op": "op_246817136"}],
       "result_types": ["tensor<128x64xbf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"loop.cluster": 10, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_750648656": {
+    "op_246831632": {
       "kind": "ttng.tmem_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_750509680"}],
+      "operands": [{"op": "op_246685664"}],
       "result_types": ["!ttg.memdesc<128x64xbf16, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory>"],
       "attributes": {"buffer.id": 2, "buffer.merge_group_id": 2, "loop.cluster": 1, "loop.stage": 2, "tt.num_buffers": 1, "ttg.partition": [6]}
     },
-    "op_749992288": {
+    "op_246421472": {
       "kind": "ttng.tmem_store",
       "scope": "loop:0",
-      "operands": [{"op": "op_750612720", "result": 0}, {"op": "op_750642624", "result": 1}, {"op": "op_750648272"}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246806192", "result": 0}, {"op": "op_246795520", "result": 1}, {"op": "op_246831024"}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 2, "loop.stage": 2, "ttg.partition": [5]}
     },
-    "op_749918512": {
+    "op_246126688": {
       "kind": "ttng.tc_gen5_mma",
       "scope": "loop:0",
-      "operands": [{"op": "op_750648656"}, {"op": "op_750630416"}, {"op": "op_750612720", "result": 0}, {"op": "op_749992288"}, {"iter_arg": {"loop": 0, "idx": 2}}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246831632"}, {"op": "op_246804688"}, {"op": "op_246806192", "result": 0}, {"op": "op_246421472"}, {"iter_arg": {"loop": 0, "idx": 2}}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 3, "loop.stage": 2, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [6]}
     },
-    "op_750649200": {
+    "op_246834256": {
       "kind": "arith.mulf",
       "scope": "loop:0",
-      "operands": [{"iter_arg": {"loop": 0, "idx": 1}}, {"op": "op_750617504"}],
+      "operands": [{"iter_arg": {"loop": 0, "idx": 1}}, {"op": "op_246816000"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 11, "loop.stage": 1, "ttg.partition": [4]}
     },
-    "op_750649456": {
+    "op_246834512": {
       "kind": "arith.addf",
       "scope": "loop:0",
-      "operands": [{"op": "op_750649200"}, {"op": "op_750641424"}],
+      "operands": [{"op": "op_246834256"}, {"op": "op_246819872"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 0, "loop.stage": 3, "ttg.partition": [4]}
     },
-    "op_750256320": {
+    "op_246433056": {
       "kind": "scf.yield",
       "scope": "loop:0",
-      "operands": [{"op": "op_750641216"}, {"op": "op_750649456"}, {"const": -1, "type": "i1"}, {"op": "op_750630048", "result": 1}, {"op": "op_749918512"}],
+      "operands": [{"op": "op_246819472"}, {"op": "op_246834512"}, {"const": -1, "type": "i1"}, {"op": "op_246821104", "result": 1}, {"op": "op_246126688"}],
       "result_types": [],
       "attributes": {}
     },
-    "op_750551376": {
+    "op_246726848": {
       "kind": "scf.for",
       "scope": "function",
-      "operands": [{"const": 0, "type": "i32"}, {"op": "op_750516000"}, {"const": 1, "type": "i32"}, {"const": "-inf", "type": "tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"}, {"const": 1, "type": "tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"}, {"const": 0, "type": "i1"}, {"op": "op_750619440", "result": 1}, {"op": "op_750505488"}],
+      "operands": [{"const": 0, "type": "i32"}, {"op": "op_246691936"}, {"const": 1, "type": "i32"}, {"const": "-inf", "type": "tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"}, {"const": 1, "type": "tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"}, {"const": 0, "type": "i1"}, {"op": "op_246805584", "result": 1}, {"op": "op_246681472"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>", "tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>", "i1", "!ttg.async.token", "!ttg.async.token"],
       "attributes": {"tt.modulo_ii": 1325, "tt.num_stages": 3, "tt.scheduled_max_stage": 3, "ttg.partition.stages": [0, 0, 0, 0, 3, 2, 2], "ttg.partition_num_warps": [4, 1, 1, 1, 4, 4, 1], "ttg.warp_specialize.tag": 0}
     },
-    "op_750616464": {
+    "op_246801216": {
       "kind": "ttng.tmem_load",
       "scope": "function",
-      "operands": [{"op": "op_750612720", "result": 0}, {"op": "op_750551376", "result": 4}],
+      "operands": [{"op": "op_246806192", "result": 0}, {"op": "op_246726848", "result": 4}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
       "attributes": {"resultSegmentSizes": [1, 1, 0], "ttg.partition": [0]}
     },
-    "op_750649904": {
+    "op_246834960": {
       "kind": "tt.expand_dims",
       "scope": "function",
-      "operands": [{"op": "op_750551376", "result": 1}],
+      "operands": [{"op": "op_246726848", "result": 1}],
       "result_types": ["tensor<128x1xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"axis": 1, "ttg.partition": [0]}
     },
-    "op_750650048": {
+    "op_246835104": {
       "kind": "ttg.convert_layout",
       "scope": "function",
-      "operands": [{"op": "op_750649904"}],
+      "operands": [{"op": "op_246834960"}],
       "result_types": ["tensor<128x1xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"ttg.partition": [0]}
     },
-    "op_750650192": {
+    "op_246835248": {
       "kind": "tt.broadcast",
       "scope": "function",
-      "operands": [{"op": "op_750650048"}],
+      "operands": [{"op": "op_246835104"}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"ttg.partition": [0]}
     },
-    "op_750650336": {
+    "op_246835392": {
       "kind": "arith.divf",
       "scope": "function",
-      "operands": [{"op": "op_750616464", "result": 0}, {"op": "op_750650192"}],
+      "operands": [{"op": "op_246801216", "result": 0}, {"op": "op_246835248"}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "ttg.partition": [0]}
     },
-    "op_750628128": {
+    "op_246806336": {
       "kind": "arith.truncf",
       "scope": "function",
-      "operands": [{"op": "op_750650336"}],
+      "operands": [{"op": "op_246835392"}],
       "result_types": ["tensor<128x128xbf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"ttg.partition": [0]}
     },
-    "op_750648800": {
+    "op_246819312": {
       "kind": "ttg.convert_layout",
       "scope": "function",
-      "operands": [{"op": "op_750628128"}],
+      "operands": [{"op": "op_246806336"}],
       "result_types": ["tensor<128x128xbf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"ttg.partition": [0]}
     },
-    "op_749910464": {
+    "op_246397248": {
       "kind": "tt.descriptor_store",
       "scope": "function",
-      "operands": [{"op": "op_750603440"}, {"op": "op_750648800"}, {"op": "op_750497408"}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246780480"}, {"op": "op_246819312"}, {"op": "op_246673632"}, {"const": 0, "type": "i32"}],
       "result_types": [],
       "attributes": {"reduce_kind": 0, "ttg.partition": [0]}
     },
-    "op_750585536": {
+    "op_246763312": {
       "kind": "tt.make_range",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<128xi32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
       "attributes": {"end": 128, "start": 0}
     },
-    "op_750639456": {
+    "op_246829184": {
       "kind": "tt.splat",
       "scope": "function",
-      "operands": [{"op": "op_750497232"}],
+      "operands": [{"op": "op_246673456"}],
       "result_types": ["tensor<128xi32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
       "attributes": {}
     },
-    "op_750636864": {
+    "op_246826512": {
       "kind": "arith.addi",
       "scope": "function",
-      "operands": [{"op": "op_750639456"}, {"op": "op_750585536"}],
+      "operands": [{"op": "op_246829184"}, {"op": "op_246763312"}],
       "result_types": ["tensor<128xi32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_750636464": {
+    "op_246819136": {
       "kind": "tt.addptr",
       "scope": "function",
-      "operands": [{"arg": "M_lse"}, {"op": "op_750249360"}],
+      "operands": [{"arg": "M_lse"}, {"op": "op_246426096"}],
       "result_types": ["!tt.ptr<f32>"],
       "attributes": {}
     },
-    "op_750637488": {
+    "op_246795952": {
       "kind": "tt.splat",
       "scope": "function",
-      "operands": [{"op": "op_750636464"}],
+      "operands": [{"op": "op_246819136"}],
       "result_types": ["tensor<128x!tt.ptr<f32>, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
       "attributes": {}
     },
-    "op_750637712": {
+    "op_246829408": {
       "kind": "tt.addptr",
       "scope": "function",
-      "operands": [{"op": "op_750637488"}, {"op": "op_750636864"}],
+      "operands": [{"op": "op_246795952"}, {"op": "op_246826512"}],
       "result_types": ["tensor<128x!tt.ptr<f32>, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
       "attributes": {}
     },
-    "op_750625824": {
+    "op_246829584": {
       "kind": "math.log2",
       "scope": "function",
-      "operands": [{"op": "op_750551376", "result": 1}],
+      "operands": [{"op": "op_246726848", "result": 1}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "ttg.partition": [0]}
     },
-    "op_750648464": {
+    "op_246831216": {
       "kind": "arith.addf",
       "scope": "function",
-      "operands": [{"op": "op_750551376", "result": 0}, {"op": "op_750625824"}],
+      "operands": [{"op": "op_246726848", "result": 0}, {"op": "op_246829584"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "ttg.partition": [0]}
     },
-    "op_750636640": {
+    "op_246814192": {
       "kind": "ttg.convert_layout",
       "scope": "function",
-      "operands": [{"op": "op_750648464"}],
+      "operands": [{"op": "op_246831216"}],
       "result_types": ["tensor<128xf32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
       "attributes": {"ttg.partition": [0]}
     },
-    "op_750637296": {
+    "op_246828992": {
       "kind": "tt.store",
       "scope": "function",
-      "operands": [{"op": "op_750637712"}, {"op": "op_750636640"}],
+      "operands": [{"op": "op_246829408"}, {"op": "op_246814192"}],
       "result_types": [],
       "attributes": {"cache": 1, "evict": 1, "ttg.partition": [0]}
     },
-    "op_750616304": {
+    "op_246790864": {
       "kind": "tt.return",
       "scope": "function",
       "operands": [],
@@ -641,50 +641,51 @@
       "trip_count_estimated": true,
       "induction_var": {"name": "iv", "type": "i32"},
       "lower_bound": {"const": 0, "type": "i32"},
-      "upper_bound": {"op": "op_750516000"},
+      "upper_bound": {"op": "op_246691936"},
       "step": {"const": 1, "type": "i32"},
       "buffers": [
-        {"id": 0, "kind": "smem", "shape": [64, 128], "element_bits": 16, "count": 3, "size_bytes": 16384, "total_bytes": 49152, "merge_group_id": 0, "paired_buffer_id": 3, "live_start": 588, "live_end": 3566, "def_op": "op_750630416"},
-        {"id": 1, "kind": "smem", "shape": [64, 128], "element_bits": 16, "count": 1, "size_bytes": 16384, "total_bytes": 16384, "merge_group_id": 1, "paired_buffer_id": null, "live_start": 558, "live_end": 1458, "def_op": "op_750622256"},
-        {"id": 2, "kind": "tmem", "shape": [128, 64], "element_bits": 16, "count": 1, "size_bytes": 16384, "total_bytes": 16384, "merge_group_id": 2, "paired_buffer_id": null, "live_start": 2657, "live_end": 3566, "def_op": "op_750648656"},
-        {"id": 3, "kind": "barrier", "shape": [], "element_bits": 16, "count": 3, "size_bytes": 8, "total_bytes": 24, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 588, "live_end": 3566, "def_op": "op_750630416"},
-        {"id": 4, "kind": "smem", "shape": [128], "element_bits": 32, "count": 1, "size_bytes": 512, "total_bytes": 512, "merge_group_id": 3, "paired_buffer_id": null, "live_start": 2596, "live_end": 2604, "def_op": null},
-        {"id": 5, "kind": "smem", "shape": [128, 64], "element_bits": 16, "count": 1, "size_bytes": 16384, "total_bytes": 16384, "merge_group_id": 4, "paired_buffer_id": null, "live_start": 2605, "live_end": 2657, "def_op": null},
-        {"id": 6, "kind": "smem", "shape": [128, 64], "element_bits": 32, "count": 1, "size_bytes": 32768, "total_bytes": 32768, "merge_group_id": null, "paired_buffer_id": null, "live_start": 1458, "live_end": 1458, "def_op": null}
+        {"id": 0, "kind": "smem", "shape": [64, 128], "element_bits": 16, "count": 3, "size_bytes": 16384, "total_bytes": 49152, "merge_group_id": 0, "paired_buffer_id": 3, "live_start": 32, "live_end": 3566, "def_op": "op_246804688"},
+        {"id": 1, "kind": "smem", "shape": [64, 128], "element_bits": 16, "count": 2, "size_bytes": 16384, "total_bytes": 32768, "merge_group_id": 1, "paired_buffer_id": 4, "live_start": 2, "live_end": 1458, "def_op": "op_246804896"},
+        {"id": 2, "kind": "tmem", "shape": [128, 64], "element_bits": 16, "count": 1, "size_bytes": 16384, "total_bytes": 16384, "merge_group_id": 2, "paired_buffer_id": null, "live_start": 2657, "live_end": 3566, "def_op": "op_246831632"},
+        {"id": 3, "kind": "barrier", "shape": [], "element_bits": 16, "count": 3, "size_bytes": 8, "total_bytes": 24, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 32, "live_end": 3566, "def_op": "op_246804688"},
+        {"id": 4, "kind": "barrier", "shape": [], "element_bits": 16, "count": 2, "size_bytes": 8, "total_bytes": 16, "merge_group_id": null, "paired_buffer_id": 1, "live_start": 2, "live_end": 1458, "def_op": "op_246804896"},
+        {"id": 5, "kind": "smem", "shape": [128], "element_bits": 32, "count": 1, "size_bytes": 512, "total_bytes": 512, "merge_group_id": 3, "paired_buffer_id": null, "live_start": 2596, "live_end": 2604, "def_op": null},
+        {"id": 6, "kind": "smem", "shape": [128, 64], "element_bits": 16, "count": 1, "size_bytes": 16384, "total_bytes": 16384, "merge_group_id": 4, "paired_buffer_id": null, "live_start": 2605, "live_end": 2657, "def_op": null},
+        {"id": 7, "kind": "smem", "shape": [128, 64], "element_bits": 32, "count": 1, "size_bytes": 32768, "total_bytes": 32768, "merge_group_id": null, "paired_buffer_id": null, "live_start": 1458, "live_end": 1458, "def_op": null}
       ],
       "graph": {
         "nodes": [
-          {"id": 0, "op_ref": "op_750612464", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": -1, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 1, "op_ref": "op_750612832", "op_kind": "arith.addi", "pipeline": "CUDA", "warp_group": -2, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 1, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 2, "op_ref": "op_750222256", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 3, "op_ref": "op_750220944", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 1, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 32, "stage": 0, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 4, "op_ref": "op_750630416", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 588, "stage": 0, "cluster": 5}, "produces_buffer": 0, "consumes_buffers": []},
-          {"id": 5, "op_ref": "op_750622256", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 0, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 558, "stage": 0, "cluster": 4}, "produces_buffer": 1, "consumes_buffers": []},
-          {"id": 6, "op_ref": "op_750622496", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 558, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": [1]},
-          {"id": 7, "op_ref": "op_749912224", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 2, "latency": 900, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 558, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 8, "op_ref": "op_750630048", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 3, "latency": 266, "self_latency": 128, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1458, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 9, "op_ref": "op_750626016", "op_kind": "tt.reduce", "pipeline": "CUDA", "warp_group": 3, "latency": 230, "self_latency": 152, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1724, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 10, "op_ref": "op_750625456", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1954, "stage": 1, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 11, "op_ref": "op_750641216", "op_kind": "arith.maxnumf", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1955, "stage": 1, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 12, "op_ref": "op_750639792", "op_kind": "arith.subf", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2595, "stage": 1, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 13, "op_ref": "op_750617504", "op_kind": "math.exp2", "pipeline": "SFU", "warp_group": 3, "latency": 8, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2596, "stage": 1, "cluster": 8}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 14, "op_ref": "op_750617712", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 3, "latency": 69, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1876, "stage": 1, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 15, "op_ref": "op_750631760", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1956, "stage": 1, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 16, "op_ref": "op_750631968", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1956, "stage": 1, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 17, "op_ref": "op_750632176", "op_kind": "arith.subf", "pipeline": "CUDA", "warp_group": 3, "latency": 65, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1956, "stage": 1, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 18, "op_ref": "op_750642400", "op_kind": "math.exp2", "pipeline": "SFU", "warp_group": 3, "latency": 570, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2021, "stage": 1, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 19, "op_ref": "op_750641424", "op_kind": "tt.reduce", "pipeline": "CUDA", "warp_group": 3, "latency": 845, "self_latency": 319, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 3345, "stage": 2, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 20, "op_ref": "op_750632688", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2604, "stage": 1, "cluster": 9}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 21, "op_ref": "op_750636112", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2604, "stage": 1, "cluster": 9}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 22, "op_ref": "op_750636256", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2604, "stage": 1, "cluster": 9}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 23, "op_ref": "op_750642624", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 4, "latency": 532, "self_latency": 256, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1014, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 24, "op_ref": "op_750648272", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 4, "latency": 138, "self_latency": 128, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2652, "stage": 2, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 25, "op_ref": "op_750509680", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 3, "latency": 52, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2605, "stage": 1, "cluster": 10}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 26, "op_ref": "op_750648656", "op_kind": "ttng.tmem_alloc", "pipeline": "NONE", "warp_group": 5, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2657, "stage": 2, "cluster": 1}, "produces_buffer": 2, "consumes_buffers": []},
-          {"id": 27, "op_ref": "op_749992288", "op_kind": "ttng.tmem_store", "pipeline": "CUDA", "warp_group": 4, "latency": 96, "self_latency": 48, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2911, "stage": 2, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 28, "op_ref": "op_749918512", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 5, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 3007, "stage": 2, "cluster": 3}, "produces_buffer": null, "consumes_buffers": [0, 2]},
-          {"id": 29, "op_ref": "op_750649200", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2637, "stage": 1, "cluster": 11}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 30, "op_ref": "op_750649456", "op_kind": "arith.addf", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 4284, "stage": 3, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []}
+          {"id": 0, "op_ref": "op_246804144", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": -1, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 1, "op_ref": "op_246790512", "op_kind": "arith.addi", "pipeline": "CUDA", "warp_group": -2, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 1, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 2, "op_ref": "op_246432752", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 3, "op_ref": "op_246398576", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 1, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 32, "stage": 0, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 4, "op_ref": "op_246804688", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 588, "stage": 0, "cluster": 5}, "produces_buffer": 0, "consumes_buffers": []},
+          {"id": 5, "op_ref": "op_246804896", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 0, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 558, "stage": 0, "cluster": 4}, "produces_buffer": 1, "consumes_buffers": []},
+          {"id": 6, "op_ref": "op_246805296", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 558, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": [1]},
+          {"id": 7, "op_ref": "op_246124896", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 2, "latency": 900, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 558, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 8, "op_ref": "op_246821104", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 3, "latency": 266, "self_latency": 128, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1458, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 9, "op_ref": "op_246803776", "op_kind": "tt.reduce", "pipeline": "CUDA", "warp_group": 3, "latency": 230, "self_latency": 152, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1724, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 10, "op_ref": "op_246801872", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1954, "stage": 1, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 11, "op_ref": "op_246819472", "op_kind": "arith.maxnumf", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1955, "stage": 1, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 12, "op_ref": "op_246815744", "op_kind": "arith.subf", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2595, "stage": 1, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 13, "op_ref": "op_246816000", "op_kind": "math.exp2", "pipeline": "SFU", "warp_group": 3, "latency": 8, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2596, "stage": 1, "cluster": 8}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 14, "op_ref": "op_246816208", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 3, "latency": 69, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1876, "stage": 1, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 15, "op_ref": "op_246816464", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1956, "stage": 1, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 16, "op_ref": "op_246816672", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1956, "stage": 1, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 17, "op_ref": "op_246816880", "op_kind": "arith.subf", "pipeline": "CUDA", "warp_group": 3, "latency": 65, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1956, "stage": 1, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 18, "op_ref": "op_246817136", "op_kind": "math.exp2", "pipeline": "SFU", "warp_group": 3, "latency": 570, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2021, "stage": 1, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 19, "op_ref": "op_246819872", "op_kind": "tt.reduce", "pipeline": "CUDA", "warp_group": 3, "latency": 845, "self_latency": 319, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 3345, "stage": 2, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 20, "op_ref": "op_246818544", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2604, "stage": 1, "cluster": 9}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 21, "op_ref": "op_246818784", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2604, "stage": 1, "cluster": 9}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 22, "op_ref": "op_246818928", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2604, "stage": 1, "cluster": 9}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 23, "op_ref": "op_246795520", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 4, "latency": 532, "self_latency": 256, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1014, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 24, "op_ref": "op_246831024", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 4, "latency": 138, "self_latency": 128, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2652, "stage": 2, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 25, "op_ref": "op_246685664", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 3, "latency": 52, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2605, "stage": 1, "cluster": 10}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 26, "op_ref": "op_246831632", "op_kind": "ttng.tmem_alloc", "pipeline": "NONE", "warp_group": 5, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2657, "stage": 2, "cluster": 1}, "produces_buffer": 2, "consumes_buffers": []},
+          {"id": 27, "op_ref": "op_246421472", "op_kind": "ttng.tmem_store", "pipeline": "CUDA", "warp_group": 4, "latency": 96, "self_latency": 48, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2911, "stage": 2, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 28, "op_ref": "op_246126688", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 5, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 3007, "stage": 2, "cluster": 3}, "produces_buffer": null, "consumes_buffers": [0, 2]},
+          {"id": 29, "op_ref": "op_246834256", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2637, "stage": 1, "cluster": 11}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 30, "op_ref": "op_246834512", "op_kind": "arith.addf", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 4284, "stage": 3, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []}
         ],
         "edges": [
           {"src": 0, "dst": 1, "kind": "data", "distance": 0, "latency": 1},
@@ -729,13 +730,13 @@
           {"src": 28, "dst": 23, "kind": "data", "distance": 1, "latency": 559}
         ],
         "cross_wg_barriers": [
-          {"producer_node": 5, "consumer_node": 6, "producer_wg": 0, "consumer_wg": 2, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 1, "expect_bytes": 16384},
+          {"producer_node": 5, "consumer_node": 6, "producer_wg": 0, "consumer_wg": 2, "kind": "mbarrier", "depth": 2, "paired_buffer_id": 1, "expect_bytes": 16384},
           {"producer_node": 7, "consumer_node": 8, "producer_wg": 2, "consumer_wg": 3, "kind": "named", "depth": 1, "paired_buffer_id": null, "expect_bytes": 0},
-          {"producer_node": 13, "consumer_node": 20, "producer_wg": 3, "consumer_wg": 4, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 4, "expect_bytes": 512},
-          {"producer_node": 25, "consumer_node": 26, "producer_wg": 3, "consumer_wg": 5, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 5, "expect_bytes": 16384},
+          {"producer_node": 13, "consumer_node": 20, "producer_wg": 3, "consumer_wg": 4, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 5, "expect_bytes": 512},
+          {"producer_node": 25, "consumer_node": 26, "producer_wg": 3, "consumer_wg": 5, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 6, "expect_bytes": 16384},
           {"producer_node": 4, "consumer_node": 28, "producer_wg": 1, "consumer_wg": 5, "kind": "mbarrier", "depth": 3, "paired_buffer_id": 0, "expect_bytes": 16384},
           {"producer_node": 27, "consumer_node": 28, "producer_wg": 4, "consumer_wg": 5, "kind": "mbarrier", "depth": 1, "paired_buffer_id": null, "expect_bytes": 0},
-          {"producer_node": 8, "consumer_node": 7, "producer_wg": 3, "consumer_wg": 2, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 6, "expect_bytes": 32768},
+          {"producer_node": 8, "consumer_node": 7, "producer_wg": 3, "consumer_wg": 2, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 7, "expect_bytes": 32768},
           {"producer_node": 28, "consumer_node": 23, "producer_wg": 5, "consumer_wg": 4, "kind": "named", "depth": 1, "paired_buffer_id": null, "expect_bytes": 0}
         ]
       }

--- a/third_party/tlx/tools/sched2tlx/examples/case4_FA_bwd/generated.py
+++ b/third_party/tlx/tools/sched2tlx/examples/case4_FA_bwd/generated.py
@@ -36,14 +36,14 @@ def fa_bwd_dkdv_5mma(
     range_12 = tl.arange(0, 64)
 
     # ── Multi-buffered allocations (from modulo's lifetime analysis) ──
-    # inner-loop buf 0: SMEM count=3 (modulo lifetime [508..3273], II=1033)
-    L0_smem_0 = tlx.local_alloc((64, 64), tl.float16, 3)
-    # inner-loop buf 1: SMEM count=3 (modulo lifetime [538..2678], II=1033)
+    # inner-loop buf 0: SMEM count=4 (modulo lifetime [0..3273], II=1033)
+    L0_smem_0 = tlx.local_alloc((64, 64), tl.float16, 4)
+    # inner-loop buf 1: SMEM count=3 (modulo lifetime [30..2678], II=1033)
     L0_smem_1 = tlx.local_alloc((64, 64), tl.float16, 3)
     # inner-loop buf 2: TMEM count=1 (producer→consumer pipelining across iters)
     L0_acc_tmem_2 = tlx.local_alloc((128, 64), tl.float16, 1, tlx.storage_kind.tmem)
-    # inner-loop buf 3: SMEM count=3 (modulo lifetime [2684..3584], II=1033)
-    L0_smem_3 = tlx.local_alloc((128, 64), tl.float16, 3)
+    # inner-loop buf 3: SMEM count=4 (modulo lifetime [2684..3584], II=1033)
+    L0_smem_3 = tlx.local_alloc((128, 64), tl.float16, 4)
     # inner-loop buf 6: SMEM count=1 (channel for cross-WG hand-off)
     L0_smem_6 = tlx.local_alloc((128, 64), tl.float16, 1)
     # inner-loop buf 7: SMEM count=1 (channel for cross-WG hand-off; reuses L0_smem_6 (group 4))
@@ -62,8 +62,8 @@ def fa_bwd_dkdv_5mma(
 
     # ── Mbarriers (SemIR: full+empty pair per semaphore) ──
     # L0_smem_0: fan-out: producer N1 → N10, N36
-    L0_smem_0_full = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
-    L0_smem_0_empty = tlx.alloc_barriers(num_barriers=3, arrive_count=2)
+    L0_smem_0_full = tlx.alloc_barriers(num_barriers=4, arrive_count=1)
+    L0_smem_0_empty = tlx.alloc_barriers(num_barriers=4, arrive_count=2)
     # sem1: N11→N12  ttng.tc_gen5_mma→ttng.tmem_load  cyc508→cyc1067  forward  buf=None  kind=named
     sem1_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
     # L0_smem_1: fan-out: producer N3 → N20, N22
@@ -72,8 +72,8 @@ def fa_bwd_dkdv_5mma(
     # sem3: N21→N25  ttng.tc_gen5_mma→ttng.tmem_load  cyc538→cyc1195  forward  buf=None  kind=named
     sem3_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
     # sem4_b3: N28→N29  arith.truncf→ttg.local_alloc  cyc2632→cyc2684  forward  buf=7  kind=mbarrier
-    sem4_b3_full = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
-    sem4_b3_empty = tlx.alloc_barriers(num_barriers=3, arrive_count=2)
+    sem4_b3_full = tlx.alloc_barriers(num_barriers=4, arrive_count=1)
+    sem4_b3_empty = tlx.alloc_barriers(num_barriers=4, arrive_count=2)
     # sem5: N31→N32  ttng.tc_gen5_mma→ttng.tmem_load  cyc2684→cyc3697  forward  buf=None  kind=named
     sem5_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
     # sem6: N12→N11  ttng.tmem_load→ttng.tc_gen5_mma  cyc1067→cyc508  LOOP-CARRY  buf=8  kind=mbarrier
@@ -95,6 +95,9 @@ def fa_bwd_dkdv_5mma(
     # acc_tmem_7_full: epilogue accumulator handoff (TC → default)
     acc_tmem_7_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
     acc_tmem_7_empty = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+    # acc_tmem_5_full: epilogue accumulator handoff (TC → default)
+    acc_tmem_5_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+    acc_tmem_5_empty = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
     with tlx.async_tasks():
         # Async task: role=default ← (none) (Phase 4 plan)
         with tlx.async_task("default"):
@@ -102,19 +105,20 @@ def fa_bwd_dkdv_5mma(
             tlx.barrier_wait(acc_tmem_7_full[0], 0)
             acc_13 = tlx.local_load(acc_tmem_7[0])
             tlx.barrier_arrive(acc_tmem_7_empty[0], 1)
-            acc = tlx.local_load(acc_tmem[0])
-            tlx.barrier_arrive(acc_tmem_empty[0], 1)
-            desc_14 = tl.make_tensor_descriptor((dK + mul_4), [N_CTX, 64], [ext_6, 1], [128, 64])
-            desc_15 = tl.make_tensor_descriptor((dV + mul_4), [N_CTX, 64], [ext_6, 1], [128, 64])
-            trunc_16 = acc.to(tl.float16)
-            tlx.local_store(c_smem[0], trunc_16)
-            tlx.fence_async_shared()
-            tlx.async_descriptor_store(desc_14, c_smem[0], [mul_5, 0])
-            tlx.async_descriptor_store_wait(0)
-            trunc_17 = acc_13.to(tl.float16)
+            tlx.barrier_wait(acc_tmem_5_full[0], 0)
+            acc_14 = tlx.local_load(acc_tmem_5[0])
+            tlx.barrier_arrive(acc_tmem_5_empty[0], 1)
+            desc_15 = tl.make_tensor_descriptor((dK + mul_4), [N_CTX, 64], [ext_6, 1], [128, 64])
+            desc_16 = tl.make_tensor_descriptor((dV + mul_4), [N_CTX, 64], [ext_6, 1], [128, 64])
+            trunc_17 = acc_14.to(tl.float16)
             tlx.local_store(c_smem[0], trunc_17)
             tlx.fence_async_shared()
             tlx.async_descriptor_store(desc_15, c_smem[0], [mul_5, 0])
+            tlx.async_descriptor_store_wait(0)
+            trunc_18 = acc_13.to(tl.float16)
+            tlx.local_store(c_smem[0], trunc_18)
+            tlx.fence_async_shared()
+            tlx.async_descriptor_store(desc_16, c_smem[0], [mul_5, 0])
             tlx.async_descriptor_store_wait(0)
         # Async task: role=TMA ← inner wg0 (Phase 4 plan)
         with tlx.async_task(num_warps=1, num_regs=24):
@@ -126,8 +130,8 @@ def fa_bwd_dkdv_5mma(
             tlx.async_descriptor_load(desc_8, q_smem_10[0], [mul_5, 0], q_smem_10_full[0])
             for tile_id in range(0, N_CTX, 64):
                 _it = (tile_id - 0) // 64
-                buf = _it % 3
-                phase = (_it // 3) & 1
+                buf = _it % 4
+                phase = (_it // 4) & 1
                 # load → L0_smem_0
                 tlx.barrier_wait(L0_smem_0_empty[buf], phase ^ 1)
                 tlx.barrier_expect_bytes(L0_smem_0_full[buf], 8192)
@@ -144,90 +148,91 @@ def fa_bwd_dkdv_5mma(
                 tlx.async_descriptor_load(desc_11, L0_smem_1[buf], [tile_id, 0], L0_smem_1_full[buf])
         # Async task: role=TMA ← inner wg2 (Phase 4 plan)
         with tlx.async_task(num_warps=4, num_regs=152):
-            # Re-materialize function-scope register tensors locally (a
+            # Re-materialize function-scope register tensors locally (a 
             # non-default warp group cannot capture RankedTensorType).
             _wgloc600 = tl.arange(0, 64)
             for tile_id in range(0, N_CTX, 64):
                 _it = (tile_id - 0) // 64
                 buf = _it % 1
                 phase = (_it // 1) & 1
-                splat_18 = tile_id
-                add_19 = (splat_18 + _wgloc600)
-                addptr_20 = ((M + mul_3) + add_19)
-                addptr_21 = ((D + mul_3) + add_19)
-                v_22 = tl.load(addptr_20)
+                splat_19 = tile_id
+                add_20 = (splat_19 + _wgloc600)
+                addptr_21 = ((M + mul_3) + add_20)
+                addptr_22 = ((D + mul_3) + add_20)
                 v_23 = tl.load(addptr_21)
-                expand_24 = v_22[None, :]
-                bcast_25 = expand_24
-                expand_26 = v_23[None, :]
-                bcast_27 = expand_26
+                v_24 = tl.load(addptr_22)
+                expand_25 = v_23[None, :]
+                bcast_26 = expand_25
+                expand_27 = v_24[None, :]
+                bcast_28 = expand_27
                 tlx.barrier_wait(sem1_full[0], (_it & 1))  # N11→N12  ttng.tc_gen5_mma→ttng.tmem_load  cyc508→cyc1067  forward  buf=None  kind=named
-                tmload_28 = tlx.local_load(acc_tmem_6[0])
+                tmload_29 = tlx.local_load(acc_tmem_6[0])
                 tlx.barrier_arrive(sem6_full[0], 1)
                 tlx.barrier_wait(sem3_full[0], (_it & 1))  # N21→N25  ttng.tc_gen5_mma→ttng.tmem_load  cyc538→cyc1195  forward  buf=None  kind=named
-                tmload_29 = tlx.local_load(acc_tmem_5[0])
+                tmload_30 = tlx.local_load(acc_tmem[0])
                 tlx.barrier_arrive(sem7_full[0], 1)
-                mulf_30 = (tmload_28 * tl.full((128, 64), 1.4427, tl.float32))
-                subf_31 = (mulf_30 - bcast_25)
-                subf_32 = (tmload_29 - bcast_27)
-                exp2_33 = tl.math.exp2(subf_31)
-                trunc_34 = exp2_33.to(tl.float16)
-                mulf_35 = (exp2_33 * subf_32)
-                trunc_36 = mulf_35.to(tl.float16)
+                mulf_31 = (tmload_29 * tl.full((128, 64), 1.4427, tl.float32))
+                subf_32 = (mulf_31 - bcast_26)
+                subf_33 = (tmload_30 - bcast_28)
+                exp2_34 = tl.math.exp2(subf_32)
+                trunc_35 = exp2_34.to(tl.float16)
+                mulf_36 = (exp2_34 * subf_33)
+                trunc_37 = mulf_36.to(tl.float16)
                 tlx.barrier_wait(L0_acc_tmem_2_empty[0], (_it & 1) ^ 1)  # TMEM bridge
-                tlx.local_store(L0_acc_tmem_2[0], trunc_34)
+                tlx.local_store(L0_acc_tmem_2[0], trunc_35)
                 tlx.barrier_arrive(L0_acc_tmem_2_full[0], 1)
-                tlx.barrier_wait(sem4_b3_empty[(_it % 3)], (((_it // 3) & 1) ^ 1))
-                tlx.local_store(L0_smem_3[(_it % 3)], trunc_36)
-                tlx.barrier_arrive(sem4_b3_full[(_it % 3)], 1)
+                tlx.barrier_wait(sem4_b3_empty[(_it % 4)], (((_it // 4) & 1) ^ 1))
+                tlx.local_store(L0_smem_3[(_it % 4)], trunc_37)
+                tlx.barrier_arrive(sem4_b3_full[(_it % 4)], 1)
         # Async task: role=TC ← inner wg3 (Phase 4 plan)
         with tlx.async_task(num_warps=1, num_regs=24):
             tlx.barrier_wait(q_smem_9_full[0], 0)  # wait Q tile loaded
-            tlx.barrier_wait(acc_tmem_empty[0], 1)
             tlx.barrier_arrive(sem6_full[0], 1)  # is_released=True (loop-carry init)
             tlx.barrier_arrive(sem8_full[0], 1)  # is_released=True (loop-carry init)
             i0_0 = False
             for tile_id in range(0, N_CTX, 64):
                 _it = (tile_id - 0) // 64
-                buf = _it % 3
-                phase = (_it // 3) & 1
-                mdt_37 = tlx.local_trans(L0_smem_0[0])
+                buf = _it % 4
+                phase = (_it // 4) & 1
+                mdt_38 = tlx.local_trans(L0_smem_0[0])
                 # MMA
-                tlx.barrier_wait(L0_smem_0_full[(_it % 3)], ((_it // 3) & 1))
+                tlx.barrier_wait(L0_smem_0_full[(_it % 4)], ((_it // 4) & 1))
                 tlx.barrier_wait(sem6_full[0], (_it & 1))
                 use_acc = False
-                tlx.async_dot(q_smem_9[0], tlx.local_trans(L0_smem_0[buf]), acc_tmem_6[0], use_acc=use_acc, mBarriers=[L0_smem_0_empty[(_it % 3)], sem1_full[0]])
-                mdt_38 = tlx.local_trans(L0_smem_3[0])
+                tlx.async_dot(q_smem_9[0], tlx.local_trans(L0_smem_0[buf]), acc_tmem_6[0], use_acc=use_acc, mBarriers=[L0_smem_0_empty[(_it % 4)], sem1_full[0]])
+                mdt_39 = tlx.local_trans(L0_smem_3[0])
                 # MMA
-                tlx.barrier_wait(sem4_b3_full[(_it % 3)], ((_it // 3) & 1))
+                tlx.barrier_wait(sem4_b3_full[(_it % 4)], ((_it // 4) & 1))
                 tlx.barrier_wait(sem8_full[0], (_it & 1))
                 use_acc = False
-                tlx.async_dot(tlx.local_trans(L0_smem_3[buf]), q_smem_9[0], acc_tmem_8[0], use_acc=use_acc, mBarriers=[sem4_b3_empty[(_it % 3)], sem5_full[0]])
+                tlx.async_dot(tlx.local_trans(L0_smem_3[buf]), q_smem_9[0], acc_tmem_8[0], use_acc=use_acc, mBarriers=[sem4_b3_empty[(_it % 4)], sem5_full[0]])
                 # MMA
                 use_acc = (tile_id > 0)
-                tlx.async_dot(L0_smem_3[buf], L0_smem_0[buf], acc_tmem[0], use_acc=use_acc, mBarriers=[sem4_b3_empty[(_it % 3)], L0_smem_0_empty[(_it % 3)]])
+                tlx.async_dot(L0_smem_3[buf], L0_smem_0[buf], acc_tmem_5[0], use_acc=use_acc, mBarriers=[sem4_b3_empty[(_it % 4)], L0_smem_0_empty[(_it % 4)]])
                 i0_0 = True
-            tlx.tcgen05_commit(acc_tmem_full[0])
+            tlx.tcgen05_commit(acc_tmem_5_full[0])
         # Async task: role=TC ← inner wg4 (Phase 4 plan)
         with tlx.async_task(num_warps=1, num_regs=24):
             tlx.barrier_wait(q_smem_10_full[0], 0)  # wait Q tile loaded
+            tlx.barrier_wait(acc_tmem_empty[0], 1)
             tlx.barrier_arrive(sem7_full[0], 1)  # is_released=True (loop-carry init)
             i0_0 = False
             for tile_id in range(0, N_CTX, 64):
                 _it = (tile_id - 0) // 64
                 buf = _it % 3
                 phase = (_it // 3) & 1
-                mdt_39 = tlx.local_trans(L0_smem_1[0])
+                mdt_40 = tlx.local_trans(L0_smem_1[0])
                 # MMA
                 tlx.barrier_wait(L0_smem_1_full[(_it % 3)], ((_it // 3) & 1))
                 tlx.barrier_wait(sem7_full[0], (_it & 1))
                 use_acc = False
-                tlx.async_dot(q_smem_10[0], tlx.local_trans(L0_smem_1[buf]), acc_tmem_5[0], use_acc=use_acc, mBarriers=[L0_smem_1_empty[(_it % 3)], sem3_full[0]])
+                tlx.async_dot(q_smem_10[0], tlx.local_trans(L0_smem_1[buf]), acc_tmem[0], use_acc=use_acc, mBarriers=[L0_smem_1_empty[(_it % 3)], sem3_full[0]])
                 # MMA
                 tlx.barrier_wait(L0_acc_tmem_2_full[0], _it & 1)  # TMEM bridge operand
                 use_acc = (tile_id > 0)
                 tlx.async_dot(L0_acc_tmem_2[0], L0_smem_1[buf], acc_tmem_7[0], use_acc=use_acc, mBarriers=[L0_acc_tmem_2_empty[0], L0_smem_1_empty[(_it % 3)]])
                 i0_0 = True
+            tlx.tcgen05_commit(acc_tmem_full[0])
             tlx.tcgen05_commit(acc_tmem_7_full[0])
         # Async task: role=CUDA ← inner wg5 (Phase 4 plan)
         with tlx.async_task(num_warps=4, num_regs=152):
@@ -236,12 +241,12 @@ def fa_bwd_dkdv_5mma(
                 buf = _it % 1
                 phase = (_it // 1) & 1
                 tlx.barrier_wait(sem5_full[0], (_it & 1))  # N31→N32  ttng.tc_gen5_mma→ttng.tmem_load  cyc2684→cyc3697  forward  buf=None  kind=named
-                tmload_40 = tlx.local_load(acc_tmem_8[0])
+                tmload_41 = tlx.local_load(acc_tmem_8[0])
                 tlx.barrier_arrive(sem8_full[0], 1)
-                trunc_41 = tmload_40.to(tl.float16)
-                cvt_42 = trunc_41
-                desc_43 = tl.make_tensor_descriptor((dQ + mul_4), [N_CTX, 64], [ext_9, 1], [64, 64])
-                tlx.local_store(dq_smem[0], cvt_42)
+                trunc_42 = tmload_41.to(tl.float16)
+                cvt_43 = trunc_42
+                desc_44 = tl.make_tensor_descriptor((dQ + mul_4), [N_CTX, 64], [ext_9, 1], [64, 64])
+                tlx.local_store(dq_smem[0], cvt_43)
                 tlx.fence_async_shared()
-                tlx.async_descriptor_store(desc_43, dq_smem[0], [tile_id, 0], store_reduce="add")
+                tlx.async_descriptor_store(desc_44, dq_smem[0], [tile_id, 0], store_reduce="add")
                 tlx.async_descriptor_store_wait(0)

--- a/third_party/tlx/tools/sched2tlx/examples/case4_FA_bwd/schedule_graph.json
+++ b/third_party/tlx/tools/sched2tlx/examples/case4_FA_bwd/schedule_graph.json
@@ -19,651 +19,651 @@
     ]
   },
   "ops": {
-    "op_140748928": {
+    "op_246719456": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i1"],
       "attributes": {"value": 0}
     },
-    "op_140749504": {
+    "op_246731760": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i1"],
       "attributes": {"value": -1}
     },
-    "op_140754784": {
+    "op_246739904": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 64}
     },
-    "op_140757280": {
+    "op_246742400": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 128}
     },
-    "op_140759728": {
+    "op_246743776": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i64"],
       "attributes": {"value": 1}
     },
-    "op_140756032": {
+    "op_246741152": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 0}
     },
-    "op_140764640": {
+    "op_246748656": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"value": "dense<1.44269502> : tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}
     },
-    "op_140771200": {
+    "op_246754080": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"value": "dense<0.000000e+00> : tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}
     },
-    "op_140771408": {
+    "op_246756560": {
       "kind": "tt.get_program_id",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"axis": 0}
     },
-    "op_140773136": {
+    "op_246757152": {
       "kind": "tt.get_program_id",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"axis": 1}
     },
-    "op_140773296": {
+    "op_246758448": {
       "kind": "arith.muli",
       "scope": "function",
-      "operands": [{"op": "op_140773136"}, {"arg": "N_CTX"}],
+      "operands": [{"op": "op_246757152"}, {"arg": "N_CTX"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_140775840": {
+    "op_246759856": {
       "kind": "arith.muli",
       "scope": "function",
-      "operands": [{"op": "op_140773296"}, {"const": 64, "type": "i32"}],
+      "operands": [{"op": "op_246758448"}, {"const": 64, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_140777248": {
+    "op_246760128": {
       "kind": "arith.muli",
       "scope": "function",
-      "operands": [{"op": "op_140771408"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246756560"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_140779120": {
+    "op_246762000": {
       "kind": "tt.addptr",
       "scope": "function",
-      "operands": [{"arg": "K"}, {"op": "op_140775840"}],
+      "operands": [{"arg": "K"}, {"op": "op_246759856"}],
       "result_types": ["!tt.ptr<f16>"],
       "attributes": {}
     },
-    "op_140688128": {
+    "op_246672560": {
       "kind": "arith.extsi",
       "scope": "function",
       "operands": [{"arg": "stride_n"}],
       "result_types": ["i64"],
       "attributes": {}
     },
-    "op_140783200": {
+    "op_246767216": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"op": "op_140779120"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_140688128"}, {"const": 1, "type": "i64"}],
+      "operands": [{"op": "op_246762000"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_246672560"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_140784720": {
+    "op_246768736": {
       "kind": "tt.addptr",
       "scope": "function",
-      "operands": [{"arg": "V"}, {"op": "op_140775840"}],
+      "operands": [{"arg": "V"}, {"op": "op_246759856"}],
       "result_types": ["!tt.ptr<f16>"],
       "attributes": {}
     },
-    "op_140785776": {
+    "op_246769792": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"op": "op_140784720"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_140688128"}, {"const": 1, "type": "i64"}],
+      "operands": [{"op": "op_246768736"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_246672560"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_140786160": {
+    "op_246770176": {
       "kind": "tt.addptr",
       "scope": "function",
-      "operands": [{"arg": "Q"}, {"op": "op_140775840"}],
+      "operands": [{"arg": "Q"}, {"op": "op_246759856"}],
       "result_types": ["!tt.ptr<f16>"],
       "attributes": {}
     },
-    "op_140786432": {
+    "op_246770448": {
       "kind": "arith.extsi",
       "scope": "function",
       "operands": [{"arg": "stride_m"}],
       "result_types": ["i64"],
       "attributes": {}
     },
-    "op_140788944": {
+    "op_246770688": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"op": "op_140786160"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_140786432"}, {"const": 1, "type": "i64"}],
+      "operands": [{"op": "op_246770176"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_246770448"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<64x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_140789328": {
+    "op_246771072": {
       "kind": "tt.addptr",
       "scope": "function",
-      "operands": [{"arg": "dO"}, {"op": "op_140775840"}],
+      "operands": [{"arg": "dO"}, {"op": "op_246759856"}],
       "result_types": ["!tt.ptr<f16>"],
       "attributes": {}
     },
-    "op_140789600": {
+    "op_246771344": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"op": "op_140789328"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_140786432"}, {"const": 1, "type": "i64"}],
+      "operands": [{"op": "op_246771072"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_246770448"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<64x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_140789984": {
+    "op_246771728": {
       "kind": "tt.addptr",
       "scope": "function",
-      "operands": [{"arg": "dQ"}, {"op": "op_140775840"}],
+      "operands": [{"arg": "dQ"}, {"op": "op_246759856"}],
       "result_types": ["!tt.ptr<f16>"],
       "attributes": {}
     },
-    "op_140790256": {
+    "op_246772000": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"op": "op_140789984"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_140786432"}, {"const": 1, "type": "i64"}],
+      "operands": [{"op": "op_246771728"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_246770448"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<64x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_140541936": {
+    "op_246476544": {
       "kind": "tt.descriptor_load",
       "scope": "function",
-      "operands": [{"op": "op_140783200"}, {"op": "op_140777248"}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246767216"}, {"op": "op_246760128"}, {"const": 0, "type": "i32"}],
       "result_types": ["tensor<128x64xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1}
     },
-    "op_140794144": {
+    "op_246775888": {
       "kind": "ttg.local_alloc",
       "scope": "function",
-      "operands": [{"op": "op_140541936"}],
+      "operands": [{"op": "op_246476544"}],
       "result_types": ["!ttg.memdesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
       "attributes": {}
     },
-    "op_140491136": {
+    "op_246432752": {
       "kind": "tt.descriptor_load",
       "scope": "function",
-      "operands": [{"op": "op_140785776"}, {"op": "op_140777248"}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246769792"}, {"op": "op_246760128"}, {"const": 0, "type": "i32"}],
       "result_types": ["tensor<128x64xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1}
     },
-    "op_140794480": {
+    "op_246776224": {
       "kind": "ttg.local_alloc",
       "scope": "function",
-      "operands": [{"op": "op_140491136"}],
+      "operands": [{"op": "op_246432752"}],
       "result_types": ["!ttg.memdesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
       "attributes": {}
     },
-    "op_140779488": {
+    "op_246764640": {
       "kind": "tt.make_range",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"end": 64, "start": 0}
     },
-    "op_140797088": {
+    "op_246778832": {
       "kind": "tt.addptr",
       "scope": "function",
-      "operands": [{"arg": "M"}, {"op": "op_140773296"}],
+      "operands": [{"arg": "M"}, {"op": "op_246758448"}],
       "result_types": ["!tt.ptr<f32>"],
       "attributes": {}
     },
-    "op_140797360": {
+    "op_246780240": {
       "kind": "tt.splat",
       "scope": "function",
-      "operands": [{"op": "op_140797088"}],
+      "operands": [{"op": "op_246778832"}],
       "result_types": ["tensor<64x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {}
     },
-    "op_140798736": {
+    "op_246780480": {
       "kind": "tt.addptr",
       "scope": "function",
-      "operands": [{"arg": "D"}, {"op": "op_140773296"}],
+      "operands": [{"arg": "D"}, {"op": "op_246758448"}],
       "result_types": ["!tt.ptr<f32>"],
       "attributes": {}
     },
-    "op_140800560": {
+    "op_246782304": {
       "kind": "tt.splat",
       "scope": "function",
-      "operands": [{"op": "op_140798736"}],
+      "operands": [{"op": "op_246780480"}],
       "result_types": ["tensor<64x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {}
     },
-    "op_140817216": {
+    "op_246798960": {
       "kind": "ttng.tmem_alloc",
       "scope": "function",
       "operands": [],
       "result_types": ["!ttg.memdesc<128x64xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
       "attributes": {}
     },
-    "op_140815424": {
+    "op_246797168": {
       "kind": "ttng.tmem_alloc",
       "scope": "function",
       "operands": [],
       "result_types": ["!ttg.memdesc<128x64xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
       "attributes": {}
     },
-    "op_140817792": {
+    "op_246799536": {
       "kind": "ttng.tmem_alloc",
       "scope": "function",
       "operands": [],
       "result_types": ["!ttg.memdesc<128x64xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
       "attributes": {}
     },
-    "op_140809392": {
+    "op_246790656": {
       "kind": "ttng.tmem_alloc",
       "scope": "function",
       "operands": [],
       "result_types": ["!ttg.memdesc<64x64xf32, #ttng.tensor_memory_encoding<blockM = 64, blockN = 64, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
       "attributes": {}
     },
-    "op_140810080": {
+    "op_246797920": {
       "kind": "ttng.tmem_alloc",
       "scope": "function",
       "operands": [],
       "result_types": ["!ttg.memdesc<128x64xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
       "attributes": {}
     },
-    "op_140702800": {
+    "op_246671904": {
       "kind": "ttng.tmem_store",
       "scope": "function",
-      "operands": [{"op": "op_140810080", "result": 0}, {"op": "op_140810080", "result": 1}, {"const": 0, "type": "tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246797920", "result": 0}, {"op": "op_246797920", "result": 1}, {"const": 0, "type": "tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {}
     },
-    "op_140692032": {
+    "op_246421472": {
       "kind": "ttng.tmem_store",
       "scope": "function",
-      "operands": [{"op": "op_140817792", "result": 0}, {"op": "op_140817792", "result": 1}, {"const": 0, "type": "tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246799536", "result": 0}, {"op": "op_246799536", "result": 1}, {"const": 0, "type": "tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {}
     },
-    "op_140447568": {
+    "op_246398576": {
       "kind": "tt.descriptor_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140788944"}, {"iv": 0}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246770688"}, {"iv": 0}, {"const": 0, "type": "i32"}],
       "result_types": ["tensor<64x64xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1, "loop.cluster": 0, "loop.stage": 0, "ttg.partition": [1]}
     },
-    "op_140828352": {
+    "op_246798624": {
       "kind": "ttg.local_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_140447568"}],
+      "operands": [{"op": "op_246398576"}],
       "result_types": ["!ttg.memdesc<64x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
-      "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 4, "loop.stage": 0, "tt.num_buffers": 3, "ttg.partition": [1]}
+      "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 4, "loop.stage": 0, "tt.num_buffers": 4, "ttg.partition": [1]}
     },
-    "op_140414304": {
+    "op_246397264": {
       "kind": "tt.descriptor_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140789600"}, {"iv": 0}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246771344"}, {"iv": 0}, {"const": 0, "type": "i32"}],
       "result_types": ["tensor<64x64xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1, "loop.cluster": 1, "loop.stage": 0, "ttg.partition": [2]}
     },
-    "op_140828624": {
+    "op_246808448": {
       "kind": "ttg.local_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_140414304"}],
+      "operands": [{"op": "op_246397264"}],
       "result_types": ["!ttg.memdesc<64x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
       "attributes": {"buffer.id": 1, "buffer.merge_group_id": 1, "loop.cluster": 6, "loop.stage": 0, "tt.num_buffers": 3, "ttg.partition": [2]}
     },
-    "op_140804208": {
+    "op_246808656": {
       "kind": "tt.splat",
       "scope": "loop:0",
       "operands": [{"iv": 0}],
       "result_types": ["tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"loop.cluster": 0, "loop.stage": 0, "ttg.partition": [3]}
     },
-    "op_140823648": {
+    "op_246805392": {
       "kind": "arith.addi",
       "scope": "loop:0",
-      "operands": [{"op": "op_140804208"}, {"op": "op_140779488"}],
+      "operands": [{"op": "op_246808656"}, {"op": "op_246764640"}],
       "result_types": ["tensor<64xi32, #ttg.slice<{dim = 0, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"loop.cluster": 0, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [3]}
     },
-    "op_140817600": {
+    "op_246799344": {
       "kind": "tt.addptr",
       "scope": "loop:0",
-      "operands": [{"op": "op_140797360"}, {"op": "op_140823648"}],
+      "operands": [{"op": "op_246780240"}, {"op": "op_246805392"}],
       "result_types": ["tensor<64x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"loop.cluster": 0, "loop.stage": 0, "ttg.partition": [3]}
     },
-    "op_140804992": {
+    "op_246793280": {
       "kind": "tt.load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140817600"}],
+      "operands": [{"op": "op_246799344"}],
       "result_types": ["tensor<64xf32, #ttg.slice<{dim = 0, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"cache": 1, "evict": 1, "isVolatile": 0, "loop.cluster": 2, "loop.stage": 0, "operandSegmentSizes": [1, 0, 0], "ttg.partition": [3]}
     },
-    "op_140812704": {
+    "op_246793680": {
       "kind": "tt.addptr",
       "scope": "loop:0",
-      "operands": [{"op": "op_140800560"}, {"op": "op_140823648"}],
+      "operands": [{"op": "op_246782304"}, {"op": "op_246805392"}],
       "result_types": ["tensor<64x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"loop.cluster": 0, "loop.stage": 0, "ttg.partition": [3]}
     },
-    "op_140812944": {
+    "op_246793856": {
       "kind": "tt.load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140812704"}],
+      "operands": [{"op": "op_246793680"}],
       "result_types": ["tensor<64xf32, #ttg.slice<{dim = 0, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>}>>"],
       "attributes": {"cache": 1, "evict": 1, "isVolatile": 0, "loop.cluster": 3, "loop.stage": 0, "operandSegmentSizes": [1, 0, 0], "ttg.partition": [3]}
     },
-    "op_140813440": {
+    "op_246784960": {
       "kind": "ttg.memdesc_trans",
       "scope": "loop:0",
-      "operands": [{"op": "op_140828352"}],
+      "operands": [{"op": "op_246798624"}],
       "result_types": ["!ttg.memdesc<64x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>, #ttg.shared_memory>"],
       "attributes": {"loop.cluster": 4, "loop.stage": 0, "order": [1, 0], "ttg.partition": [4]}
     },
-    "op_140145920": {
+    "op_246124896": {
       "kind": "ttng.tc_gen5_mma",
       "scope": "loop:0",
-      "operands": [{"op": "op_140794144"}, {"op": "op_140813440"}, {"op": "op_140817216", "result": 0}, {"iter_arg": {"loop": 0, "idx": 1}}, {"const": 0, "type": "i1"}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246775888"}, {"op": "op_246784960"}, {"op": "op_246798960", "result": 0}, {"iter_arg": {"loop": 0, "idx": 1}}, {"const": 0, "type": "i1"}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 4, "loop.stage": 0, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [4]}
     },
-    "op_140827760": {
+    "op_246798144": {
       "kind": "ttng.tmem_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140817216", "result": 0}, {"op": "op_140145920"}],
+      "operands": [{"op": "op_246798960", "result": 0}, {"op": "op_246124896"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
       "attributes": {"loop.cluster": 0, "loop.stage": 1, "resultSegmentSizes": [1, 1, 0], "ttg.partition": [3]}
     },
-    "op_139875712": {
+    "op_246817296": {
       "kind": "arith.mulf",
       "scope": "loop:0",
-      "operands": [{"op": "op_140827760", "result": 0}, {"const": 1.4427, "type": "tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}],
+      "operands": [{"op": "op_246798144", "result": 0}, {"const": 1.4427, "type": "tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 2, "loop.stage": 1, "ttg.partition": [3]}
     },
-    "op_140836656": {
+    "op_246817744": {
       "kind": "tt.expand_dims",
       "scope": "loop:0",
-      "operands": [{"op": "op_140804992"}],
+      "operands": [{"op": "op_246793280"}],
       "result_types": ["tensor<1x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"axis": 0, "loop.cluster": 5, "loop.stage": 0, "ttg.partition": [3]}
     },
-    "op_140836864": {
+    "op_246817952": {
       "kind": "tt.broadcast",
       "scope": "loop:0",
-      "operands": [{"op": "op_140836656"}],
+      "operands": [{"op": "op_246817744"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"loop.cluster": 5, "loop.stage": 0, "ttg.partition": [3]}
     },
-    "op_140837072": {
+    "op_246818160": {
       "kind": "arith.subf",
       "scope": "loop:0",
-      "operands": [{"op": "op_139875712"}, {"op": "op_140836864"}],
+      "operands": [{"op": "op_246817296"}, {"op": "op_246817952"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 3, "loop.stage": 1, "ttg.partition": [3]}
     },
-    "op_140838128": {
+    "op_246819216": {
       "kind": "math.exp2",
       "scope": "loop:0",
-      "operands": [{"op": "op_140837072"}],
+      "operands": [{"op": "op_246818160"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 5, "loop.stage": 1, "ttg.partition": [3]}
     },
-    "op_140824048": {
+    "op_246805792": {
       "kind": "arith.truncf",
       "scope": "loop:0",
-      "operands": [{"op": "op_140838128"}],
+      "operands": [{"op": "op_246819216"}],
       "result_types": ["tensor<128x64xf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"loop.cluster": 0, "loop.stage": 2, "ttg.partition": [3]}
     },
-    "op_140840928": {
+    "op_246823088": {
       "kind": "ttng.tmem_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_140824048"}],
+      "operands": [{"op": "op_246805792"}],
       "result_types": ["!ttg.memdesc<128x64xf16, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory>"],
       "attributes": {"buffer.id": 2, "buffer.merge_group_id": 2, "loop.cluster": 1, "loop.stage": 2, "tt.num_buffers": 1, "ttg.partition": [5]}
     },
-    "op_140841136": {
+    "op_246823296": {
       "kind": "ttg.memdesc_trans",
       "scope": "loop:0",
-      "operands": [{"op": "op_140828624"}],
+      "operands": [{"op": "op_246808448"}],
       "result_types": ["!ttg.memdesc<64x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>, #ttg.shared_memory>"],
       "attributes": {"loop.cluster": 6, "loop.stage": 0, "order": [1, 0], "ttg.partition": [5]}
     },
-    "op_140147712": {
+    "op_246126688": {
       "kind": "ttng.tc_gen5_mma",
       "scope": "loop:0",
-      "operands": [{"op": "op_140794480"}, {"op": "op_140841136"}, {"op": "op_140815424", "result": 0}, {"iter_arg": {"loop": 0, "idx": 2}}, {"const": 0, "type": "i1"}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246776224"}, {"op": "op_246823296"}, {"op": "op_246797168", "result": 0}, {"iter_arg": {"loop": 0, "idx": 2}}, {"const": 0, "type": "i1"}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 6, "loop.stage": 0, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [5]}
     },
-    "op_140030784": {
+    "op_246009760": {
       "kind": "ttng.tc_gen5_mma",
       "scope": "loop:0",
-      "operands": [{"op": "op_140840928"}, {"op": "op_140828624"}, {"op": "op_140817792", "result": 0}, {"iter_arg": {"loop": 0, "idx": 3}}, {"iter_arg": {"loop": 0, "idx": 0}}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246823088"}, {"op": "op_246808448"}, {"op": "op_246799536", "result": 0}, {"iter_arg": {"loop": 0, "idx": 3}}, {"iter_arg": {"loop": 0, "idx": 0}}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 1, "loop.stage": 2, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [5]}
     },
-    "op_140843760": {
+    "op_246824768": {
       "kind": "tt.expand_dims",
       "scope": "loop:0",
-      "operands": [{"op": "op_140812944"}],
+      "operands": [{"op": "op_246793856"}],
       "result_types": ["tensor<1x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"axis": 0, "loop.cluster": 7, "loop.stage": 0, "ttg.partition": [3]}
     },
-    "op_140816336": {
+    "op_246821664": {
       "kind": "tt.broadcast",
       "scope": "loop:0",
-      "operands": [{"op": "op_140843760"}],
+      "operands": [{"op": "op_246824768"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"loop.cluster": 7, "loop.stage": 0, "ttg.partition": [3]}
     },
-    "op_140413008": {
+    "op_246122896": {
       "kind": "ttng.tmem_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140815424", "result": 0}, {"op": "op_140147712"}],
+      "operands": [{"op": "op_246797168", "result": 0}, {"op": "op_246126688"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
       "attributes": {"loop.cluster": 1, "loop.stage": 1, "resultSegmentSizes": [1, 1, 0], "ttg.partition": [3]}
     },
-    "op_140799424": {
+    "op_246781168": {
       "kind": "arith.subf",
       "scope": "loop:0",
-      "operands": [{"op": "op_140413008", "result": 0}, {"op": "op_140816336"}],
+      "operands": [{"op": "op_246122896", "result": 0}, {"op": "op_246821664"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 4, "loop.stage": 1, "ttg.partition": [3]}
     },
-    "op_140799680": {
+    "op_246781424": {
       "kind": "arith.mulf",
       "scope": "loop:0",
-      "operands": [{"op": "op_140838128"}, {"op": "op_140799424"}],
+      "operands": [{"op": "op_246819216"}, {"op": "op_246781168"}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 2, "loop.stage": 2, "ttg.partition": [3]}
     },
-    "op_140688272": {
+    "op_246672704": {
       "kind": "arith.truncf",
       "scope": "loop:0",
-      "operands": [{"op": "op_140799680"}],
+      "operands": [{"op": "op_246781424"}],
       "result_types": ["tensor<128x64xf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"loop.cluster": 3, "loop.stage": 2, "ttg.partition": [3]}
     },
-    "op_140800000": {
+    "op_246781744": {
       "kind": "ttg.local_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_140688272"}],
+      "operands": [{"op": "op_246672704"}],
       "result_types": ["!ttg.memdesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
-      "attributes": {"buffer.id": 3, "buffer.merge_group_id": 3, "loop.cluster": 4, "loop.stage": 2, "tt.num_buffers": 3, "ttg.partition": [4]}
+      "attributes": {"buffer.id": 3, "buffer.merge_group_id": 3, "loop.cluster": 4, "loop.stage": 2, "tt.num_buffers": 4, "ttg.partition": [4]}
     },
-    "op_140800208": {
+    "op_246781952": {
       "kind": "ttg.memdesc_trans",
       "scope": "loop:0",
-      "operands": [{"op": "op_140800000"}],
+      "operands": [{"op": "op_246781744"}],
       "result_types": ["!ttg.memdesc<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>, #ttg.shared_memory>"],
       "attributes": {"loop.cluster": 4, "loop.stage": 2, "order": [1, 0], "ttg.partition": [4]}
     },
-    "op_140025904": {
+    "op_246004880": {
       "kind": "ttng.tc_gen5_mma",
       "scope": "loop:0",
-      "operands": [{"op": "op_140800208"}, {"op": "op_140794144"}, {"op": "op_140809392", "result": 0}, {"iter_arg": {"loop": 0, "idx": 4}}, {"const": 0, "type": "i1"}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246781952"}, {"op": "op_246775888"}, {"op": "op_246790656", "result": 0}, {"iter_arg": {"loop": 0, "idx": 4}}, {"const": 0, "type": "i1"}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 4, "loop.stage": 2, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [4]}
     },
-    "op_140144592": {
+    "op_246123568": {
       "kind": "ttng.tmem_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140809392", "result": 0}, {"op": "op_140025904"}],
+      "operands": [{"op": "op_246790656", "result": 0}, {"op": "op_246004880"}],
       "result_types": ["tensor<64x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 32]], warp = [[16, 0], [32, 0]], block = []}>>", "!ttg.async.token"],
       "attributes": {"loop.cluster": 0, "loop.stage": 3, "resultSegmentSizes": [1, 1, 0], "ttg.partition": [6]}
     },
-    "op_140694000": {
+    "op_246677856": {
       "kind": "arith.truncf",
       "scope": "loop:0",
-      "operands": [{"op": "op_140144592", "result": 0}],
+      "operands": [{"op": "op_246123568", "result": 0}],
       "result_types": ["tensor<64x64xf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 32]], warp = [[16, 0], [32, 0]], block = []}>>"],
       "attributes": {"loop.cluster": 1, "loop.stage": 3, "ttg.partition": [6]}
     },
-    "op_140818928": {
+    "op_246800672": {
       "kind": "ttg.convert_layout",
       "scope": "loop:0",
-      "operands": [{"op": "op_140694000"}],
+      "operands": [{"op": "op_246677856"}],
       "result_types": ["tensor<64x64xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"loop.cluster": 2, "loop.stage": 3, "ttg.partition": [6]}
     },
-    "op_140145232": {
+    "op_246124208": {
       "kind": "tt.descriptor_reduce",
       "scope": "loop:0",
-      "operands": [{"op": "op_140790256"}, {"op": "op_140818928"}, {"iv": 0}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246772000"}, {"op": "op_246800672"}, {"iv": 0}, {"const": 0, "type": "i32"}],
       "result_types": [],
       "attributes": {"kind": 1, "loop.cluster": 3, "loop.stage": 3}
     },
-    "op_140141136": {
+    "op_246120112": {
       "kind": "ttng.tc_gen5_mma",
       "scope": "loop:0",
-      "operands": [{"op": "op_140800000"}, {"op": "op_140828352"}, {"op": "op_140810080", "result": 0}, {"iter_arg": {"loop": 0, "idx": 5}}, {"iter_arg": {"loop": 0, "idx": 0}}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246781744"}, {"op": "op_246798624"}, {"op": "op_246797920", "result": 0}, {"iter_arg": {"loop": 0, "idx": 5}}, {"iter_arg": {"loop": 0, "idx": 0}}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 5, "loop.stage": 2, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [4]}
     },
-    "op_140823264": {
+    "op_246832128": {
       "kind": "scf.yield",
       "scope": "loop:0",
-      "operands": [{"const": -1, "type": "i1"}, {"op": "op_140827760", "result": 1}, {"op": "op_140413008", "result": 1}, {"op": "op_140030784"}, {"op": "op_140144592", "result": 1}, {"op": "op_140141136"}],
+      "operands": [{"const": -1, "type": "i1"}, {"op": "op_246798144", "result": 1}, {"op": "op_246122896", "result": 1}, {"op": "op_246009760"}, {"op": "op_246123568", "result": 1}, {"op": "op_246120112"}],
       "result_types": [],
       "attributes": {}
     },
-    "op_139935968": {
+    "op_245914944": {
       "kind": "scf.for",
       "scope": "function",
-      "operands": [{"const": 0, "type": "i32"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"const": 0, "type": "i1"}, {"op": "op_140817216", "result": 1}, {"op": "op_140815424", "result": 1}, {"op": "op_140692032"}, {"op": "op_140809392", "result": 1}, {"op": "op_140702800"}],
+      "operands": [{"const": 0, "type": "i32"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"const": 0, "type": "i1"}, {"op": "op_246798960", "result": 1}, {"op": "op_246797168", "result": 1}, {"op": "op_246421472"}, {"op": "op_246790656", "result": 1}, {"op": "op_246671904"}],
       "result_types": ["i1", "!ttg.async.token", "!ttg.async.token", "!ttg.async.token", "!ttg.async.token", "!ttg.async.token"],
-      "attributes": {"tt.modulo_ii": 1033, "tt.num_stages": 3, "tt.scheduled_max_stage": 3, "tt.warp_specialize": "unit", "ttg.partition.stages": [0, 0, 0, 2, 2, 2, 3], "ttg.partition_num_warps": [4, 1, 1, 4, 1, 1, 4], "ttg.warp_specialize.tag": 0}
+      "attributes": {"tt.modulo_ii": 1033, "tt.num_stages": 4, "tt.scheduled_max_stage": 3, "tt.warp_specialize": "unit", "ttg.partition.stages": [0, 0, 0, 2, 2, 2, 3], "ttg.partition_num_warps": [4, 1, 1, 4, 1, 1, 4], "ttg.warp_specialize.tag": 0}
     },
-    "op_140851152": {
+    "op_246832448": {
       "kind": "ttng.tmem_load",
       "scope": "function",
-      "operands": [{"op": "op_140817792", "result": 0}, {"op": "op_139935968", "result": 3}],
+      "operands": [{"op": "op_246799536", "result": 0}, {"op": "op_245914944", "result": 3}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
       "attributes": {"resultSegmentSizes": [1, 1, 0], "ttg.partition": [0]}
     },
-    "op_140851376": {
+    "op_246832672": {
       "kind": "ttng.tmem_load",
       "scope": "function",
-      "operands": [{"op": "op_140810080", "result": 0}, {"op": "op_139935968", "result": 5}],
+      "operands": [{"op": "op_246797920", "result": 0}, {"op": "op_245914944", "result": 5}],
       "result_types": ["tensor<128x64xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
       "attributes": {"resultSegmentSizes": [1, 1, 0], "ttg.partition": [0]}
     },
-    "op_140816160": {
+    "op_246785168": {
       "kind": "tt.addptr",
       "scope": "function",
-      "operands": [{"arg": "dK"}, {"op": "op_140775840"}],
+      "operands": [{"arg": "dK"}, {"op": "op_246759856"}],
       "result_types": ["!tt.ptr<f16>"],
       "attributes": {}
     },
-    "op_140851584": {
+    "op_246832880": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"op": "op_140816160"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_140688128"}, {"const": 1, "type": "i64"}],
+      "operands": [{"op": "op_246785168"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_246672560"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_140816560": {
+    "op_246785600": {
       "kind": "tt.addptr",
       "scope": "function",
-      "operands": [{"arg": "dV"}, {"op": "op_140775840"}],
+      "operands": [{"arg": "dV"}, {"op": "op_246759856"}],
       "result_types": ["!tt.ptr<f16>"],
       "attributes": {}
     },
-    "op_140851872": {
+    "op_246833168": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"op": "op_140816560"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_140688128"}, {"const": 1, "type": "i64"}],
+      "operands": [{"op": "op_246785600"}, {"arg": "N_CTX"}, {"const": 64, "type": "i32"}, {"op": "op_246672560"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_140819136": {
+    "op_246800880": {
       "kind": "arith.truncf",
       "scope": "function",
-      "operands": [{"op": "op_140851376", "result": 0}],
+      "operands": [{"op": "op_246832672", "result": 0}],
       "result_types": ["tensor<128x64xf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"ttg.partition": [0]}
     },
-    "op_140852160": {
+    "op_246833456": {
       "kind": "ttg.convert_layout",
       "scope": "function",
-      "operands": [{"op": "op_140819136"}],
+      "operands": [{"op": "op_246800880"}],
       "result_types": ["tensor<128x64xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"ttg.partition": [0]}
     },
-    "op_140852288": {
+    "op_246833584": {
       "kind": "tt.descriptor_store",
       "scope": "function",
-      "operands": [{"op": "op_140851584"}, {"op": "op_140852160"}, {"op": "op_140777248"}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246832880"}, {"op": "op_246833456"}, {"op": "op_246760128"}, {"const": 0, "type": "i32"}],
       "result_types": [],
       "attributes": {"reduce_kind": 0, "ttg.partition": [0]}
     },
-    "op_140818160": {
+    "op_246799904": {
       "kind": "arith.truncf",
       "scope": "function",
-      "operands": [{"op": "op_140851152", "result": 0}],
+      "operands": [{"op": "op_246832448", "result": 0}],
       "result_types": ["tensor<128x64xf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"ttg.partition": [0]}
     },
-    "op_140852528": {
+    "op_246833824": {
       "kind": "ttg.convert_layout",
       "scope": "function",
-      "operands": [{"op": "op_140818160"}],
+      "operands": [{"op": "op_246799904"}],
       "result_types": ["tensor<128x64xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"ttg.partition": [0]}
     },
-    "op_140852656": {
+    "op_246833952": {
       "kind": "tt.descriptor_store",
       "scope": "function",
-      "operands": [{"op": "op_140851872"}, {"op": "op_140852528"}, {"op": "op_140777248"}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246833168"}, {"op": "op_246833824"}, {"op": "op_246760128"}, {"const": 0, "type": "i32"}],
       "result_types": [],
       "attributes": {"reduce_kind": 0, "ttg.partition": [0]}
     },
-    "op_140852880": {
+    "op_246834176": {
       "kind": "tt.return",
       "scope": "function",
       "operands": [],
@@ -690,12 +690,12 @@
       "upper_bound": {"arg": "N_CTX"},
       "step": {"const": 64, "type": "i32"},
       "buffers": [
-        {"id": 0, "kind": "smem", "shape": [64, 64], "element_bits": 16, "count": 3, "size_bytes": 8192, "total_bytes": 24576, "merge_group_id": 0, "paired_buffer_id": 4, "live_start": 508, "live_end": 3273, "def_op": "op_140828352"},
-        {"id": 1, "kind": "smem", "shape": [64, 64], "element_bits": 16, "count": 3, "size_bytes": 8192, "total_bytes": 24576, "merge_group_id": 1, "paired_buffer_id": 5, "live_start": 538, "live_end": 2678, "def_op": "op_140828624"},
-        {"id": 2, "kind": "tmem", "shape": [128, 64], "element_bits": 16, "count": 1, "size_bytes": 16384, "total_bytes": 16384, "merge_group_id": 2, "paired_buffer_id": null, "live_start": 2119, "live_end": 2678, "def_op": "op_140840928"},
-        {"id": 3, "kind": "smem", "shape": [128, 64], "element_bits": 16, "count": 3, "size_bytes": 16384, "total_bytes": 49152, "merge_group_id": 3, "paired_buffer_id": null, "live_start": 2684, "live_end": 3584, "def_op": "op_140800000"},
-        {"id": 4, "kind": "barrier", "shape": [], "element_bits": 16, "count": 3, "size_bytes": 8, "total_bytes": 24, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 508, "live_end": 3273, "def_op": "op_140828352"},
-        {"id": 5, "kind": "barrier", "shape": [], "element_bits": 16, "count": 3, "size_bytes": 8, "total_bytes": 24, "merge_group_id": null, "paired_buffer_id": 1, "live_start": 538, "live_end": 2678, "def_op": "op_140828624"},
+        {"id": 0, "kind": "smem", "shape": [64, 64], "element_bits": 16, "count": 4, "size_bytes": 8192, "total_bytes": 32768, "merge_group_id": 0, "paired_buffer_id": 4, "live_start": 0, "live_end": 3273, "def_op": "op_246798624"},
+        {"id": 1, "kind": "smem", "shape": [64, 64], "element_bits": 16, "count": 3, "size_bytes": 8192, "total_bytes": 24576, "merge_group_id": 1, "paired_buffer_id": 5, "live_start": 30, "live_end": 2678, "def_op": "op_246808448"},
+        {"id": 2, "kind": "tmem", "shape": [128, 64], "element_bits": 16, "count": 1, "size_bytes": 16384, "total_bytes": 16384, "merge_group_id": 2, "paired_buffer_id": null, "live_start": 2119, "live_end": 2678, "def_op": "op_246823088"},
+        {"id": 3, "kind": "smem", "shape": [128, 64], "element_bits": 16, "count": 4, "size_bytes": 16384, "total_bytes": 65536, "merge_group_id": 3, "paired_buffer_id": null, "live_start": 2684, "live_end": 3584, "def_op": "op_246781744"},
+        {"id": 4, "kind": "barrier", "shape": [], "element_bits": 16, "count": 4, "size_bytes": 8, "total_bytes": 32, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 0, "live_end": 3273, "def_op": "op_246798624"},
+        {"id": 5, "kind": "barrier", "shape": [], "element_bits": 16, "count": 3, "size_bytes": 8, "total_bytes": 24, "merge_group_id": null, "paired_buffer_id": 1, "live_start": 30, "live_end": 2678, "def_op": "op_246808448"},
         {"id": 6, "kind": "smem", "shape": [128, 64], "element_bits": 16, "count": 1, "size_bytes": 16384, "total_bytes": 16384, "merge_group_id": 4, "paired_buffer_id": null, "live_start": 2067, "live_end": 2119, "def_op": null},
         {"id": 7, "kind": "smem", "shape": [128, 64], "element_bits": 16, "count": 1, "size_bytes": 16384, "total_bytes": 16384, "merge_group_id": 4, "paired_buffer_id": null, "live_start": 2632, "live_end": 2684, "def_op": null},
         {"id": 8, "kind": "smem", "shape": [128, 64], "element_bits": 32, "count": 1, "size_bytes": 32768, "total_bytes": 32768, "merge_group_id": null, "paired_buffer_id": null, "live_start": 1067, "live_end": 1067, "def_op": null},
@@ -704,43 +704,43 @@
       ],
       "graph": {
         "nodes": [
-          {"id": 0, "op_ref": "op_140447568", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 508, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 1, "op_ref": "op_140828352", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 0, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 508, "stage": 0, "cluster": 4}, "produces_buffer": 0, "consumes_buffers": []},
-          {"id": 2, "op_ref": "op_140414304", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 1, "latency": 508, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 30, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 3, "op_ref": "op_140828624", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 538, "stage": 0, "cluster": 6}, "produces_buffer": 1, "consumes_buffers": []},
-          {"id": 4, "op_ref": "op_140804208", "op_kind": "tt.splat", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 5, "op_ref": "op_140823648", "op_kind": "arith.addi", "pipeline": "CUDA", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 6, "op_ref": "op_140817600", "op_kind": "tt.addptr", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 7, "op_ref": "op_140804992", "op_kind": "tt.load", "pipeline": "TMA", "warp_group": 2, "latency": 460, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 60, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 8, "op_ref": "op_140812704", "op_kind": "tt.addptr", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 9, "op_ref": "op_140812944", "op_kind": "tt.load", "pipeline": "TMA", "warp_group": 2, "latency": 460, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 90, "stage": 0, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 10, "op_ref": "op_140813440", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 508, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": [0]},
-          {"id": 11, "op_ref": "op_140145920", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 3, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 508, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 12, "op_ref": "op_140827760", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 2, "latency": 266, "self_latency": 128, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1067, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 13, "op_ref": "op_139875712", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 2, "latency": 69, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1333, "stage": 1, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 14, "op_ref": "op_140836656", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 520, "stage": 0, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 15, "op_ref": "op_140836864", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 520, "stage": 0, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 16, "op_ref": "op_140837072", "op_kind": "arith.subf", "pipeline": "CUDA", "warp_group": 2, "latency": 65, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1402, "stage": 1, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 17, "op_ref": "op_140838128", "op_kind": "math.exp2", "pipeline": "SFU", "warp_group": 2, "latency": 570, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1467, "stage": 1, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 18, "op_ref": "op_140824048", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 2, "latency": 52, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2067, "stage": 2, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 19, "op_ref": "op_140840928", "op_kind": "ttng.tmem_alloc", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2119, "stage": 2, "cluster": 1}, "produces_buffer": 2, "consumes_buffers": []},
-          {"id": 20, "op_ref": "op_140841136", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 538, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": [1]},
-          {"id": 21, "op_ref": "op_140147712", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 4, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 538, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 22, "op_ref": "op_140030784", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 4, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2119, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": [1, 2]},
-          {"id": 23, "op_ref": "op_140843760", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 550, "stage": 0, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 24, "op_ref": "op_140816336", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 550, "stage": 0, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 25, "op_ref": "op_140413008", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 2, "latency": 266, "self_latency": 128, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1195, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 26, "op_ref": "op_140799424", "op_kind": "arith.subf", "pipeline": "CUDA", "warp_group": 2, "latency": 65, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1466, "stage": 1, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 27, "op_ref": "op_140799680", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 2, "latency": 69, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2563, "stage": 2, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 28, "op_ref": "op_140688272", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 2, "latency": 52, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2632, "stage": 2, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 29, "op_ref": "op_140800000", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2684, "stage": 2, "cluster": 4}, "produces_buffer": 3, "consumes_buffers": []},
-          {"id": 30, "op_ref": "op_140800208", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2684, "stage": 2, "cluster": 4}, "produces_buffer": null, "consumes_buffers": [3]},
-          {"id": 31, "op_ref": "op_140025904", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 3, "latency": 900, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2684, "stage": 2, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 32, "op_ref": "op_140144592", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 5, "latency": 133, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 3697, "stage": 3, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 33, "op_ref": "op_140694000", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 5, "latency": 26, "self_latency": 16, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 3830, "stage": 3, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 34, "op_ref": "op_140818928", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "warp_group": 5, "latency": 26, "self_latency": 26, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 3856, "stage": 3, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 35, "op_ref": "op_140145232", "op_kind": "tt.descriptor_reduce", "pipeline": "NONE", "warp_group": -1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 3882, "stage": 3, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 36, "op_ref": "op_140141136", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 3, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2714, "stage": 2, "cluster": 5}, "produces_buffer": null, "consumes_buffers": [0, 3]}
+          {"id": 0, "op_ref": "op_246398576", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 508, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 1, "op_ref": "op_246798624", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 0, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 508, "stage": 0, "cluster": 4}, "produces_buffer": 0, "consumes_buffers": []},
+          {"id": 2, "op_ref": "op_246397264", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 1, "latency": 508, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 30, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 3, "op_ref": "op_246808448", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 538, "stage": 0, "cluster": 6}, "produces_buffer": 1, "consumes_buffers": []},
+          {"id": 4, "op_ref": "op_246808656", "op_kind": "tt.splat", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 5, "op_ref": "op_246805392", "op_kind": "arith.addi", "pipeline": "CUDA", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 6, "op_ref": "op_246799344", "op_kind": "tt.addptr", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 7, "op_ref": "op_246793280", "op_kind": "tt.load", "pipeline": "TMA", "warp_group": 2, "latency": 460, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 60, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 8, "op_ref": "op_246793680", "op_kind": "tt.addptr", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 9, "op_ref": "op_246793856", "op_kind": "tt.load", "pipeline": "TMA", "warp_group": 2, "latency": 460, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 90, "stage": 0, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 10, "op_ref": "op_246784960", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 508, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": [0]},
+          {"id": 11, "op_ref": "op_246124896", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 3, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 508, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 12, "op_ref": "op_246798144", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 2, "latency": 266, "self_latency": 128, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1067, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 13, "op_ref": "op_246817296", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 2, "latency": 69, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1333, "stage": 1, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 14, "op_ref": "op_246817744", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 520, "stage": 0, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 15, "op_ref": "op_246817952", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 520, "stage": 0, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 16, "op_ref": "op_246818160", "op_kind": "arith.subf", "pipeline": "CUDA", "warp_group": 2, "latency": 65, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1402, "stage": 1, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 17, "op_ref": "op_246819216", "op_kind": "math.exp2", "pipeline": "SFU", "warp_group": 2, "latency": 570, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1467, "stage": 1, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 18, "op_ref": "op_246805792", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 2, "latency": 52, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2067, "stage": 2, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 19, "op_ref": "op_246823088", "op_kind": "ttng.tmem_alloc", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2119, "stage": 2, "cluster": 1}, "produces_buffer": 2, "consumes_buffers": []},
+          {"id": 20, "op_ref": "op_246823296", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 538, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": [1]},
+          {"id": 21, "op_ref": "op_246126688", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 4, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 538, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 22, "op_ref": "op_246009760", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 4, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2119, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": [1, 2]},
+          {"id": 23, "op_ref": "op_246824768", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 550, "stage": 0, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 24, "op_ref": "op_246821664", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 550, "stage": 0, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 25, "op_ref": "op_246122896", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 2, "latency": 266, "self_latency": 128, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1195, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 26, "op_ref": "op_246781168", "op_kind": "arith.subf", "pipeline": "CUDA", "warp_group": 2, "latency": 65, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1466, "stage": 1, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 27, "op_ref": "op_246781424", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 2, "latency": 69, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2563, "stage": 2, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 28, "op_ref": "op_246672704", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 2, "latency": 52, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2632, "stage": 2, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 29, "op_ref": "op_246781744", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2684, "stage": 2, "cluster": 4}, "produces_buffer": 3, "consumes_buffers": []},
+          {"id": 30, "op_ref": "op_246781952", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2684, "stage": 2, "cluster": 4}, "produces_buffer": null, "consumes_buffers": [3]},
+          {"id": 31, "op_ref": "op_246004880", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 3, "latency": 900, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2684, "stage": 2, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 32, "op_ref": "op_246123568", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 5, "latency": 133, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 3697, "stage": 3, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 33, "op_ref": "op_246677856", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 5, "latency": 26, "self_latency": 16, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 3830, "stage": 3, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 34, "op_ref": "op_246800672", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "warp_group": 5, "latency": 26, "self_latency": 26, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 3856, "stage": 3, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 35, "op_ref": "op_246124208", "op_kind": "tt.descriptor_reduce", "pipeline": "NONE", "warp_group": -1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 3882, "stage": 3, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 36, "op_ref": "op_246120112", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 3, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2714, "stage": 2, "cluster": 5}, "produces_buffer": null, "consumes_buffers": [0, 3]}
         ],
         "edges": [
           {"src": 0, "dst": 1, "kind": "data", "distance": 0, "latency": 508},
@@ -789,7 +789,7 @@
           {"src": 36, "dst": 36, "kind": "data", "distance": 1, "latency": 128}
         ],
         "cross_wg_barriers": [
-          {"producer_node": 1, "consumer_node": 10, "producer_wg": 0, "consumer_wg": 3, "kind": "mbarrier", "depth": 3, "paired_buffer_id": 0, "expect_bytes": 8192},
+          {"producer_node": 1, "consumer_node": 10, "producer_wg": 0, "consumer_wg": 3, "kind": "mbarrier", "depth": 4, "paired_buffer_id": 0, "expect_bytes": 8192},
           {"producer_node": 11, "consumer_node": 12, "producer_wg": 3, "consumer_wg": 2, "kind": "named", "depth": 1, "paired_buffer_id": null, "expect_bytes": 0},
           {"producer_node": 18, "consumer_node": 19, "producer_wg": 2, "consumer_wg": 4, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 6, "expect_bytes": 16384},
           {"producer_node": 3, "consumer_node": 20, "producer_wg": 1, "consumer_wg": 4, "kind": "mbarrier", "depth": 3, "paired_buffer_id": 1, "expect_bytes": 8192},
@@ -797,7 +797,7 @@
           {"producer_node": 21, "consumer_node": 25, "producer_wg": 4, "consumer_wg": 2, "kind": "named", "depth": 1, "paired_buffer_id": null, "expect_bytes": 0},
           {"producer_node": 28, "consumer_node": 29, "producer_wg": 2, "consumer_wg": 3, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 7, "expect_bytes": 16384},
           {"producer_node": 31, "consumer_node": 32, "producer_wg": 3, "consumer_wg": 5, "kind": "named", "depth": 1, "paired_buffer_id": null, "expect_bytes": 0},
-          {"producer_node": 1, "consumer_node": 36, "producer_wg": 0, "consumer_wg": 3, "kind": "mbarrier", "depth": 3, "paired_buffer_id": 0, "expect_bytes": 8192},
+          {"producer_node": 1, "consumer_node": 36, "producer_wg": 0, "consumer_wg": 3, "kind": "mbarrier", "depth": 4, "paired_buffer_id": 0, "expect_bytes": 8192},
           {"producer_node": 12, "consumer_node": 11, "producer_wg": 2, "consumer_wg": 3, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 8, "expect_bytes": 32768},
           {"producer_node": 25, "consumer_node": 21, "producer_wg": 2, "consumer_wg": 4, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 9, "expect_bytes": 32768},
           {"producer_node": 32, "consumer_node": 31, "producer_wg": 5, "consumer_wg": 3, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 10, "expect_bytes": 16384}

--- a/third_party/tlx/tools/sched2tlx/examples/case6_layernorm/schedule_graph.json
+++ b/third_party/tlx/tools/sched2tlx/examples/case6_layernorm/schedule_graph.json
@@ -13,406 +13,406 @@
     ]
   },
   "ops": {
-    "op_1185094304": {
+    "op_246634720": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 512}
     },
-    "op_1185063200": {
+    "op_246702240": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i64"],
       "attributes": {"value": 512}
     },
-    "op_1185128432": {
+    "op_246702448": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i64"],
       "attributes": {"value": 1}
     },
-    "op_1185129776": {
+    "op_246702656": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 8}
     },
-    "op_1185129984": {
+    "op_246702864": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 0}
     },
-    "op_1185130192": {
+    "op_246704208": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 7}
     },
-    "op_1185135008": {
+    "op_246709024": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"value": "dense<1.000000e+00> : tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"}
     },
-    "op_1185125184": {
+    "op_246698912": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"value": "dense<5.120000e+02> : tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"}
     },
-    "op_1185125360": {
+    "op_246699088": {
       "kind": "tt.get_program_id",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"axis": 0}
     },
-    "op_1185139456": {
+    "op_246712336": {
       "kind": "tt.get_num_programs",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"axis": 0}
     },
-    "op_1185140800": {
+    "op_246713680": {
       "kind": "arith.addi",
       "scope": "function",
       "operands": [{"arg": "M"}, {"const": 7, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_1185142176": {
+    "op_246716192": {
       "kind": "arith.divsi",
       "scope": "function",
-      "operands": [{"op": "op_1185140800"}, {"const": 8, "type": "i32"}],
+      "operands": [{"op": "op_246713680"}, {"const": 8, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {}
     },
-    "op_1185148320": {
+    "op_246722544": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
       "operands": [{"arg": "X"}, {"arg": "M"}, {"const": 512, "type": "i32"}, {"const": 512, "type": "i64"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<8x512xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_1185150976": {
+    "op_246725200": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
       "operands": [{"arg": "Y"}, {"arg": "M"}, {"const": 512, "type": "i32"}, {"const": 512, "type": "i64"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<8x512xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_1185140688": {
+    "op_246713568": {
       "kind": "tt.make_range",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<512xi32, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"end": 512, "start": 0}
     },
-    "op_1185093696": {
+    "op_246675984": {
       "kind": "tt.splat",
       "scope": "function",
       "operands": [{"arg": "W"}],
       "result_types": ["tensor<512x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {}
     },
-    "op_1185153824": {
+    "op_246730720": {
       "kind": "tt.addptr",
       "scope": "function",
-      "operands": [{"op": "op_1185093696"}, {"op": "op_1185140688"}],
+      "operands": [{"op": "op_246675984"}, {"op": "op_246713568"}],
       "result_types": ["tensor<512x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {}
     },
-    "op_1185154096": {
+    "op_246732128": {
       "kind": "tt.load",
       "scope": "function",
-      "operands": [{"op": "op_1185153824"}],
+      "operands": [{"op": "op_246730720"}],
       "result_types": ["tensor<512xf16, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"cache": 1, "evict": 1, "isVolatile": 0, "operandSegmentSizes": [1, 0, 0]}
     },
-    "op_1185154368": {
+    "op_246732400": {
       "kind": "tt.splat",
       "scope": "function",
       "operands": [{"arg": "B"}],
       "result_types": ["tensor<512x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {}
     },
-    "op_1185156208": {
+    "op_246735376": {
       "kind": "tt.addptr",
       "scope": "function",
-      "operands": [{"op": "op_1185154368"}, {"op": "op_1185140688"}],
+      "operands": [{"op": "op_246732400"}, {"op": "op_246713568"}],
       "result_types": ["tensor<512x!tt.ptr<f16>, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {}
     },
-    "op_1185157616": {
+    "op_246735648": {
       "kind": "tt.load",
       "scope": "function",
-      "operands": [{"op": "op_1185156208"}],
+      "operands": [{"op": "op_246735376"}],
       "result_types": ["tensor<512xf16, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"cache": 1, "evict": 1, "isVolatile": 0, "operandSegmentSizes": [1, 0, 0]}
     },
-    "op_1185157888": {
+    "op_246735920": {
       "kind": "tt.splat",
       "scope": "function",
       "operands": [{"arg": "eps"}],
       "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {}
     },
-    "op_1185160400": {
+    "op_246736160": {
       "kind": "tt.expand_dims",
       "scope": "function",
-      "operands": [{"op": "op_1185154096"}],
+      "operands": [{"op": "op_246732128"}],
       "result_types": ["tensor<1x512xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"axis": 0}
     },
-    "op_1185160640": {
+    "op_246736400": {
       "kind": "arith.extf",
       "scope": "function",
-      "operands": [{"op": "op_1185160400"}],
+      "operands": [{"op": "op_246736160"}],
       "result_types": ["tensor<1x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {}
     },
-    "op_1185161664": {
+    "op_246738560": {
       "kind": "tt.broadcast",
       "scope": "function",
-      "operands": [{"op": "op_1185160640"}],
+      "operands": [{"op": "op_246736400"}],
       "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {}
     },
-    "op_1185161904": {
+    "op_246738800": {
       "kind": "tt.expand_dims",
       "scope": "function",
-      "operands": [{"op": "op_1185157616"}],
+      "operands": [{"op": "op_246735648"}],
       "result_types": ["tensor<1x512xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"axis": 0}
     },
-    "op_1185163280": {
+    "op_246739040": {
       "kind": "arith.extf",
       "scope": "function",
-      "operands": [{"op": "op_1185161904"}],
+      "operands": [{"op": "op_246738800"}],
       "result_types": ["tensor<1x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {}
     },
-    "op_1185163520": {
+    "op_246739280": {
       "kind": "tt.broadcast",
       "scope": "function",
-      "operands": [{"op": "op_1185163280"}],
+      "operands": [{"op": "op_246739040"}],
       "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {}
     },
-    "op_1185164224": {
+    "op_246739984": {
       "kind": "arith.muli",
       "scope": "loop:0",
       "operands": [{"iv": 0}, {"const": 8, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 0, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [1]}
     },
-    "op_1184874224": {
+    "op_246489664": {
       "kind": "tt.descriptor_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185148320"}, {"op": "op_1185164224"}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246722544"}, {"op": "op_246739984"}, {"const": 0, "type": "i32"}],
       "result_types": ["tensor<8x512xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1, "loop.cluster": 1, "loop.stage": 0, "ttg.partition": [1]}
     },
-    "op_1185164592": {
+    "op_246741488": {
       "kind": "arith.extf",
       "scope": "loop:0",
-      "operands": [{"op": "op_1184874224"}],
+      "operands": [{"op": "op_246489664"}],
       "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"loop.cluster": 0, "loop.stage": 1, "ttg.partition": [2]}
     },
-    "op_1185167552": {
+    "op_246745584": {
       "kind": "arith.addf",
       "scope": "loop:0",
       "operands": [{"unknown_block_arg": true}, {"unknown_block_arg": true}],
       "result_types": ["f32"],
       "attributes": {"fastmath": "#arith.fastmath<none>"}
     },
-    "op_1185173072": {
+    "op_246746992": {
       "kind": "tt.reduce.return",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185167552"}],
+      "operands": [{"op": "op_246745584"}],
       "result_types": [],
       "attributes": {}
     },
-    "op_1185166000": {
+    "op_246744032": {
       "kind": "tt.reduce",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185164592"}],
+      "operands": [{"op": "op_246741488"}],
       "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"axis": 1, "loop.cluster": 2, "loop.stage": 1, "reduction_ordering": "unordered", "ttg.partition": [2]}
     },
-    "op_1185166176": {
+    "op_246744208": {
       "kind": "arith.divf",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185166000"}, {"const": 512, "type": "tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"}],
+      "operands": [{"op": "op_246744032"}, {"const": 512, "type": "tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"}],
       "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 1, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185166368": {
+    "op_246744400": {
       "kind": "arith.mulf",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185164592"}, {"op": "op_1185164592"}],
+      "operands": [{"op": "op_246741488"}, {"op": "op_246741488"}],
       "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 1, "loop.stage": 1, "ttg.partition": [2]}
     },
-    "op_1185175536": {
+    "op_246754704": {
       "kind": "arith.addf",
       "scope": "loop:0",
       "operands": [{"unknown_block_arg": true}, {"unknown_block_arg": true}],
       "result_types": ["f32"],
       "attributes": {"fastmath": "#arith.fastmath<none>"}
     },
-    "op_1185175808": {
+    "op_246754976": {
       "kind": "tt.reduce.return",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185175536"}],
+      "operands": [{"op": "op_246754704"}],
       "result_types": [],
       "attributes": {}
     },
-    "op_1185166704": {
+    "op_246744736": {
       "kind": "tt.reduce",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185166368"}],
+      "operands": [{"op": "op_246744400"}],
       "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"axis": 1, "loop.cluster": 0, "loop.stage": 2, "reduction_ordering": "unordered", "ttg.partition": [2]}
     },
-    "op_1185173216": {
+    "op_246752384": {
       "kind": "arith.divf",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185166704"}, {"const": 512, "type": "tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"}],
+      "operands": [{"op": "op_246744736"}, {"const": 512, "type": "tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"}],
       "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 4, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185174960": {
+    "op_246754128": {
       "kind": "arith.mulf",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185166176"}, {"op": "op_1185166176"}],
+      "operands": [{"op": "op_246744208"}, {"op": "op_246744208"}],
       "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 3, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185176992": {
+    "op_246755120": {
       "kind": "arith.subf",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185173216"}, {"op": "op_1185174960"}],
+      "operands": [{"op": "op_246752384"}, {"op": "op_246754128"}],
       "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 5, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185177248": {
+    "op_246755312": {
       "kind": "arith.addf",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185176992"}, {"op": "op_1185157888"}],
+      "operands": [{"op": "op_246755120"}, {"op": "op_246735920"}],
       "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 6, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185177504": {
+    "op_246755504": {
       "kind": "math.sqrt",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185177248"}],
+      "operands": [{"op": "op_246755312"}],
       "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 6, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185163888": {
+    "op_246739648": {
       "kind": "arith.divf",
       "scope": "loop:0",
-      "operands": [{"const": 1, "type": "tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"}, {"op": "op_1185177504"}],
+      "operands": [{"const": 1, "type": "tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"}, {"op": "op_246755504"}],
       "result_types": ["tensor<8xf32, #ttg.slice<{dim = 1, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 7, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185179328": {
+    "op_246757360": {
       "kind": "tt.expand_dims",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185166176"}],
+      "operands": [{"op": "op_246744208"}],
       "result_types": ["tensor<8x1xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"axis": 1, "loop.cluster": 1, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185181136": {
+    "op_246759168": {
       "kind": "tt.broadcast",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185179328"}],
+      "operands": [{"op": "op_246757360"}],
       "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"loop.cluster": 1, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185181376": {
+    "op_246759408": {
       "kind": "arith.subf",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185164592"}, {"op": "op_1185181136"}],
+      "operands": [{"op": "op_246741488"}, {"op": "op_246759168"}],
       "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 2, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185181664": {
+    "op_246759696": {
       "kind": "tt.expand_dims",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185163888"}],
+      "operands": [{"op": "op_246739648"}],
       "result_types": ["tensor<8x1xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"axis": 1, "loop.cluster": 7, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185181904": {
+    "op_246759936": {
       "kind": "tt.broadcast",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185181664"}],
+      "operands": [{"op": "op_246759696"}],
       "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"loop.cluster": 7, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185182144": {
+    "op_246760176": {
       "kind": "arith.mulf",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185181376"}, {"op": "op_1185181904"}],
+      "operands": [{"op": "op_246759408"}, {"op": "op_246759936"}],
       "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 8, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185182432": {
+    "op_246760464": {
       "kind": "arith.mulf",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185182144"}, {"op": "op_1185161664"}],
+      "operands": [{"op": "op_246760176"}, {"op": "op_246738560"}],
       "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 9, "loop.stage": 2, "ttg.partition": [2]}
     },
-    "op_1185182720": {
+    "op_246760752": {
       "kind": "arith.addf",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185182432"}, {"op": "op_1185163520"}],
+      "operands": [{"op": "op_246760464"}, {"op": "op_246739280"}],
       "result_types": ["tensor<8x512xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 0, "loop.stage": 3, "ttg.partition": [2]}
     },
-    "op_1185183008": {
+    "op_246761040": {
       "kind": "arith.truncf",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185182720"}],
+      "operands": [{"op": "op_246760752"}],
       "result_types": ["tensor<8x512xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>>"],
       "attributes": {"loop.cluster": 0, "loop.stage": 4, "ttg.partition": [2]}
     },
-    "op_1185167056": {
+    "op_246745088": {
       "kind": "tt.descriptor_store",
       "scope": "loop:0",
-      "operands": [{"op": "op_1185150976"}, {"op": "op_1185183008"}, {"op": "op_1185164224"}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246725200"}, {"op": "op_246761040"}, {"op": "op_246739984"}, {"const": 0, "type": "i32"}],
       "result_types": [],
       "attributes": {"buffer.id": 0, "loop.cluster": 1, "loop.stage": 4, "reduce_kind": 0, "tt.num_buffers": 1, "ttg.partition": [3]}
     },
-    "op_1185183248": {
+    "op_246761280": {
       "kind": "scf.yield",
       "scope": "loop:0",
       "operands": [],
       "result_types": [],
       "attributes": {}
     },
-    "op_1184840256": {
+    "op_246445856": {
       "kind": "scf.for",
       "scope": "function",
-      "operands": [{"op": "op_1185125360"}, {"op": "op_1185142176"}, {"op": "op_1185139456"}],
+      "operands": [{"op": "op_246699088"}, {"op": "op_246716192"}, {"op": "op_246712336"}],
       "result_types": [],
       "attributes": {"tt.modulo_ii": 534, "tt.num_stages": 2, "tt.scheduled_max_stage": 4, "ttg.partition.stages": [0, 0, 4, 4], "ttg.partition_num_warps": [4, 1, 4, 1], "ttg.warp_specialize.tag": 0}
     },
-    "op_1185183344": {
+    "op_246761376": {
       "kind": "tt.return",
       "scope": "function",
       "operands": [],
@@ -435,39 +435,39 @@
       "trip_count": 4,
       "trip_count_estimated": true,
       "induction_var": {"name": "iv", "type": "i32"},
-      "lower_bound": {"op": "op_1185125360"},
-      "upper_bound": {"op": "op_1185142176"},
-      "step": {"op": "op_1185139456"},
+      "lower_bound": {"op": "op_246699088"},
+      "upper_bound": {"op": "op_246716192"},
+      "step": {"op": "op_246712336"},
       "buffers": [
-        {"id": 0, "kind": "smem", "shape": [8, 512], "element_bits": 16, "count": 1, "size_bytes": 8192, "total_bytes": 8192, "merge_group_id": null, "paired_buffer_id": null, "live_start": 2357, "live_end": 2357, "def_op": "op_1185167056"},
+        {"id": 0, "kind": "smem", "shape": [8, 512], "element_bits": 16, "count": 1, "size_bytes": 8192, "total_bytes": 8192, "merge_group_id": null, "paired_buffer_id": null, "live_start": 2357, "live_end": 2357, "def_op": "op_246745088"},
         {"id": 1, "kind": "smem", "shape": [8, 512], "element_bits": 16, "count": 2, "size_bytes": 8192, "total_bytes": 16384, "merge_group_id": 0, "paired_buffer_id": null, "live_start": 1, "live_end": 775, "def_op": null},
         {"id": 2, "kind": "smem", "shape": [8, 512], "element_bits": 16, "count": 2, "size_bytes": 8192, "total_bytes": 16384, "merge_group_id": 1, "paired_buffer_id": null, "live_start": 2331, "live_end": 2903, "def_op": null}
       ],
       "graph": {
         "nodes": [
-          {"id": 0, "op_ref": "op_1185164224", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": -2, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 1, "op_ref": "op_1184874224", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 748, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 1, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 2, "op_ref": "op_1185164592", "op_kind": "arith.extf", "pipeline": "CUDA", "warp_group": 1, "latency": 26, "self_latency": 16, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 749, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 3, "op_ref": "op_1185166000", "op_kind": "tt.reduce", "pipeline": "CUDA", "warp_group": 1, "latency": 422, "self_latency": 159, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 807, "stage": 1, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 4, "op_ref": "op_1185166176", "op_kind": "arith.divf", "pipeline": "CUDA", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1229, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 5, "op_ref": "op_1185166368", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 1, "latency": 34, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 775, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 6, "op_ref": "op_1185166704", "op_kind": "tt.reduce", "pipeline": "CUDA", "warp_group": 1, "latency": 422, "self_latency": 159, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1069, "stage": 2, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 7, "op_ref": "op_1185173216", "op_kind": "arith.divf", "pipeline": "CUDA", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1500, "stage": 2, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 8, "op_ref": "op_1185174960", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1262, "stage": 2, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 9, "op_ref": "op_1185176992", "op_kind": "arith.subf", "pipeline": "CUDA", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1501, "stage": 2, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 10, "op_ref": "op_1185177248", "op_kind": "arith.addf", "pipeline": "CUDA", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1502, "stage": 2, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 11, "op_ref": "op_1185177504", "op_kind": "math.sqrt", "pipeline": "SFU", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1502, "stage": 2, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 12, "op_ref": "op_1185163888", "op_kind": "arith.divf", "pipeline": "CUDA", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1503, "stage": 2, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 13, "op_ref": "op_1185179328", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1229, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 14, "op_ref": "op_1185181136", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1229, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 15, "op_ref": "op_1185181376", "op_kind": "arith.subf", "pipeline": "CUDA", "warp_group": 1, "latency": 32, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1230, "stage": 2, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 16, "op_ref": "op_1185181664", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1503, "stage": 2, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 17, "op_ref": "op_1185181904", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1503, "stage": 2, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 18, "op_ref": "op_1185182144", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 1, "latency": 34, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1504, "stage": 2, "cluster": 8}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 19, "op_ref": "op_1185182432", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 1, "latency": 34, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1538, "stage": 2, "cluster": 9}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 20, "op_ref": "op_1185182720", "op_kind": "arith.addf", "pipeline": "CUDA", "warp_group": 1, "latency": 32, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2104, "stage": 3, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 21, "op_ref": "op_1185183008", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 1, "latency": 26, "self_latency": 16, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2331, "stage": 4, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 22, "op_ref": "op_1185167056", "op_kind": "tt.descriptor_store", "pipeline": "TMA", "warp_group": 2, "latency": 546, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2357, "stage": 4, "cluster": 1}, "produces_buffer": 0, "consumes_buffers": []}
+          {"id": 0, "op_ref": "op_246739984", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": -2, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 1, "op_ref": "op_246489664", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 748, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 1, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 2, "op_ref": "op_246741488", "op_kind": "arith.extf", "pipeline": "CUDA", "warp_group": 1, "latency": 26, "self_latency": 16, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 749, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 3, "op_ref": "op_246744032", "op_kind": "tt.reduce", "pipeline": "CUDA", "warp_group": 1, "latency": 422, "self_latency": 159, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 807, "stage": 1, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 4, "op_ref": "op_246744208", "op_kind": "arith.divf", "pipeline": "CUDA", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1229, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 5, "op_ref": "op_246744400", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 1, "latency": 34, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 775, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 6, "op_ref": "op_246744736", "op_kind": "tt.reduce", "pipeline": "CUDA", "warp_group": 1, "latency": 422, "self_latency": 159, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1069, "stage": 2, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 7, "op_ref": "op_246752384", "op_kind": "arith.divf", "pipeline": "CUDA", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1500, "stage": 2, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 8, "op_ref": "op_246754128", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1262, "stage": 2, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 9, "op_ref": "op_246755120", "op_kind": "arith.subf", "pipeline": "CUDA", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1501, "stage": 2, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 10, "op_ref": "op_246755312", "op_kind": "arith.addf", "pipeline": "CUDA", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1502, "stage": 2, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 11, "op_ref": "op_246755504", "op_kind": "math.sqrt", "pipeline": "SFU", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1502, "stage": 2, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 12, "op_ref": "op_246739648", "op_kind": "arith.divf", "pipeline": "CUDA", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1503, "stage": 2, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 13, "op_ref": "op_246757360", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1229, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 14, "op_ref": "op_246759168", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1229, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 15, "op_ref": "op_246759408", "op_kind": "arith.subf", "pipeline": "CUDA", "warp_group": 1, "latency": 32, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1230, "stage": 2, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 16, "op_ref": "op_246759696", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1503, "stage": 2, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 17, "op_ref": "op_246759936", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1503, "stage": 2, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 18, "op_ref": "op_246760176", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 1, "latency": 34, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1504, "stage": 2, "cluster": 8}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 19, "op_ref": "op_246760464", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 1, "latency": 34, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1538, "stage": 2, "cluster": 9}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 20, "op_ref": "op_246760752", "op_kind": "arith.addf", "pipeline": "CUDA", "warp_group": 1, "latency": 32, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2104, "stage": 3, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 21, "op_ref": "op_246761040", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 1, "latency": 26, "self_latency": 16, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2331, "stage": 4, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 22, "op_ref": "op_246745088", "op_kind": "tt.descriptor_store", "pipeline": "TMA", "warp_group": 2, "latency": 546, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 2357, "stage": 4, "cluster": 1}, "produces_buffer": 0, "consumes_buffers": []}
         ],
         "edges": [
           {"src": 0, "dst": 1, "kind": "data", "distance": 0, "latency": 1},

--- a/third_party/tlx/tools/sched2tlx/examples/case7_wgrad_bias/generated.py
+++ b/third_party/tlx/tools/sched2tlx/examples/case7_wgrad_bias/generated.py
@@ -31,10 +31,10 @@ def wgrad_bias_nows(
     dw_desc = tl.make_tensor_descriptor(DW, [K_out, N_in], [ext_10, 1], [128, 32])
 
     # ── Multi-buffered allocations (from modulo's lifetime analysis) ──
-    # inner-loop buf 0: SMEM count=3 (modulo lifetime [586..1145], II=256)
-    L0_smem_0 = tlx.local_alloc((64, 128), tl.float16, 3)
-    # inner-loop buf 1: SMEM count=3 (modulo lifetime [556..1145], II=256)
-    L0_smem_1 = tlx.local_alloc((64, 128), tl.float16, 3)
+    # inner-loop buf 0: SMEM count=5 (modulo lifetime [30..1145], II=256)
+    L0_smem_0 = tlx.local_alloc((64, 128), tl.float16, 5)
+    # inner-loop buf 1: SMEM count=5 (modulo lifetime [0..1145], II=256)
+    L0_smem_1 = tlx.local_alloc((64, 128), tl.float16, 5)
 
     # acc_tmem: outer-loop buf 0, count=2 (TC writes / default reads across 2 tiles)
     acc_tmem = tlx.local_alloc((128, 128), tl.float32, 2, tlx.storage_kind.tmem)
@@ -42,11 +42,11 @@ def wgrad_bias_nows(
 
     # ── Mbarriers (SemIR: full+empty pair per semaphore) ──
     # L0_smem_1: N3→N4  ttg.local_alloc→ttg.memdesc_trans  cyc556→cyc556  forward  buf=1  kind=mbarrier
-    L0_smem_1_full = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
-    L0_smem_1_empty = tlx.alloc_barriers(num_barriers=3, arrive_count=2)
+    L0_smem_1_full = tlx.alloc_barriers(num_barriers=5, arrive_count=1)
+    L0_smem_1_empty = tlx.alloc_barriers(num_barriers=5, arrive_count=2)
     # L0_smem_0: N2→N5  ttg.local_alloc→ttng.tc_gen5_mma  cyc586→cyc586  forward  buf=0  kind=mbarrier
-    L0_smem_0_full = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
-    L0_smem_0_empty = tlx.alloc_barriers(num_barriers=3, arrive_count=1)
+    L0_smem_0_full = tlx.alloc_barriers(num_barriers=5, arrive_count=1)
+    L0_smem_0_empty = tlx.alloc_barriers(num_barriers=5, arrive_count=1)
     # acc_tmem: cross-region TC-loop → default-epilogue hand-off, depth=2 (legacy carve-out)
     acc_tmem_full = tlx.alloc_barriers(num_barriers=2, arrive_count=1)
     acc_tmem_empty = tlx.alloc_barriers(num_barriers=2, arrive_count=1)
@@ -100,26 +100,26 @@ def wgrad_bias_nows(
             smem_accum = 0
             # Outer persistent loop (loop 1, II=8192). Each task replays it; body trimmed to this WG's ops.
             for tile_id in range(pid_0, mul_7, nprog_0):
-                # Inner K-loop (loop 0, II=256). SMEM ring depth=3; smem_accum persists across outer tiles.
+                # Inner K-loop (loop 0, II=256). SMEM ring depth=5; smem_accum persists across outer tiles.
                 for k in range(0, M, 64):
                     _it = smem_accum
-                    buf = smem_accum % 3
-                    phase = (smem_accum // 3) & 1
-                    tlx.barrier_wait(L0_smem_1_empty[(_it % 3)], (((_it // 3) & 1) ^ 1))
-                    tlx.barrier_expect_bytes(L0_smem_1_full[(_it % 3)], 16384)
+                    buf = smem_accum % 5
+                    phase = (smem_accum // 5) & 1
+                    tlx.barrier_wait(L0_smem_1_empty[(_it % 5)], (((_it // 5) & 1) ^ 1))
+                    tlx.barrier_expect_bytes(L0_smem_1_full[(_it % 5)], 16384)
                     # load → L0_smem_1
-                    tlx.async_descriptor_load(dout_desc, L0_smem_1[buf], [k, ((tile_id // div_6) * 128)], L0_smem_1_full[(_it % 3)])
+                    tlx.async_descriptor_load(dout_desc, L0_smem_1[buf], [k, ((tile_id // div_6) * 128)], L0_smem_1_full[(_it % 5)])
                     smem_accum += 1
         # Async task: role=TMA ← inner wg1 (Phase 4 plan)
         with tlx.async_task(num_warps=1, num_regs=24):
             smem_accum = 0
             # Outer persistent loop (loop 1, II=8192). Each task replays it; body trimmed to this WG's ops.
             for tile_id in range(pid_0, mul_7, nprog_0):
-                # Inner K-loop (loop 0, II=256). SMEM ring depth=3; smem_accum persists across outer tiles.
+                # Inner K-loop (loop 0, II=256). SMEM ring depth=5; smem_accum persists across outer tiles.
                 for k in range(0, M, 64):
                     _it = smem_accum
-                    buf = smem_accum % 3
-                    phase = (smem_accum // 3) & 1
+                    buf = smem_accum % 5
+                    phase = (smem_accum // 5) & 1
                     # load → L0_smem_0
                     tlx.barrier_wait(L0_smem_0_empty[buf], phase ^ 1)
                     tlx.barrier_expect_bytes(L0_smem_0_full[buf], 16384)
@@ -135,16 +135,16 @@ def wgrad_bias_nows(
                 tmem_phase = (tmem_accum_cnt // 2) & 1
                 tlx.barrier_wait(acc_tmem_empty[tmem_buf], tmem_phase ^ 1)
                 i0_1 = False
-                # Inner K-loop (loop 0, II=256). SMEM ring depth=3; smem_accum persists across outer tiles.
+                # Inner K-loop (loop 0, II=256). SMEM ring depth=5; smem_accum persists across outer tiles.
                 for k in range(0, M, 64):
                     _it = smem_accum
-                    buf = smem_accum % 3
-                    phase = (smem_accum // 3) & 1
+                    buf = smem_accum % 5
+                    phase = (smem_accum // 5) & 1
                     # MMA
-                    tlx.barrier_wait(L0_smem_1_full[(_it % 3)], ((_it // 3) & 1))
-                    tlx.barrier_wait(L0_smem_0_full[(_it % 3)], ((_it // 3) & 1))
+                    tlx.barrier_wait(L0_smem_1_full[(_it % 5)], ((_it // 5) & 1))
+                    tlx.barrier_wait(L0_smem_0_full[(_it % 5)], ((_it // 5) & 1))
                     use_acc = (k > 0)
-                    tlx.async_dot(tlx.local_trans(L0_smem_1[buf]), L0_smem_0[buf], acc_tmem[tmem_buf], use_acc=use_acc, mBarriers=[L0_smem_1_empty[(_it % 3)], L0_smem_0_empty[(_it % 3)]])
+                    tlx.async_dot(tlx.local_trans(L0_smem_1[buf]), L0_smem_0[buf], acc_tmem[tmem_buf], use_acc=use_acc, mBarriers=[L0_smem_1_empty[(_it % 5)], L0_smem_0_empty[(_it % 5)]])
                     smem_accum += 1
                     i0_1 = True
                 tlx.tcgen05_commit(acc_tmem_full[tmem_buf])
@@ -155,14 +155,14 @@ def wgrad_bias_nows(
             # Outer persistent loop (loop 1, II=8192). Each task replays it; body trimmed to this WG's ops.
             for tile_id in range(pid_0, mul_7, nprog_0):
                 i0_0 = tl.full((128,), 0, tl.float32)
-                # Inner K-loop (loop 0, II=256). SMEM ring depth=3; smem_accum persists across outer tiles.
+                # Inner K-loop (loop 0, II=256). SMEM ring depth=5; smem_accum persists across outer tiles.
                 for k in range(0, M, 64):
                     _it = smem_accum
-                    buf = smem_accum % 3
-                    phase = (smem_accum // 3) & 1
-                    tlx.barrier_wait(L0_smem_1_full[(_it % 3)], ((_it // 3) & 1))
-                    chan_L0_smem_1_0 = tlx.local_load(L0_smem_1[(_it % 3)])
-                    tlx.barrier_arrive(L0_smem_1_empty[(_it % 3)], 1)
+                    buf = smem_accum % 5
+                    phase = (smem_accum // 5) & 1
+                    tlx.barrier_wait(L0_smem_1_full[(_it % 5)], ((_it // 5) & 1))
+                    chan_L0_smem_1_0 = tlx.local_load(L0_smem_1[(_it % 5)])
+                    tlx.barrier_arrive(L0_smem_1_empty[(_it % 5)], 1)
                     ext_21 = chan_L0_smem_1_0.to(tl.float32)
                     red_22 = tl.sum(ext_21, 0)
                     addf_23 = (i0_0 + red_22)

--- a/third_party/tlx/tools/sched2tlx/examples/case7_wgrad_bias/schedule_graph.json
+++ b/third_party/tlx/tools/sched2tlx/examples/case7_wgrad_bias/schedule_graph.json
@@ -14,393 +14,393 @@
     ]
   },
   "ops": {
-    "op_1281417728": {
+    "op_246745360": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i1"],
       "attributes": {"value": 0}
     },
-    "op_1281417840": {
+    "op_246745472": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i1"],
       "attributes": {"value": -1}
     },
-    "op_1281450576": {
+    "op_246747584": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i64"],
       "attributes": {"value": 1}
     },
-    "op_1281451920": {
+    "op_246748928": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 128}
     },
-    "op_1281452128": {
+    "op_246749136": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 0}
     },
-    "op_1281453472": {
+    "op_246750480": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 64}
     },
-    "op_1281448064": {
+    "op_246746272": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 127}
     },
-    "op_1281461840": {
+    "op_246755872": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>}>>"],
       "attributes": {"value": "dense<0.000000e+00> : tensor<128xf32, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>}>>"}
     },
-    "op_1281463184": {
+    "op_246762464": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"value": "dense<0.000000e+00> : tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}
     },
-    "op_1281463392": {
+    "op_246762672": {
       "kind": "tt.get_program_id",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"axis": 0}
     },
-    "op_1281464752": {
+    "op_246764032": {
       "kind": "tt.get_num_programs",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"axis": 0}
     },
-    "op_1281393920": {
+    "op_246666272": {
       "kind": "arith.addi",
       "scope": "function",
       "operands": [{"arg": "K_out"}, {"const": 127, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_1281396704": {
+    "op_246556144": {
       "kind": "arith.divsi",
       "scope": "function",
-      "operands": [{"op": "op_1281393920"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246666272"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {}
     },
-    "op_1281399888": {
+    "op_246694752": {
       "kind": "arith.addi",
       "scope": "function",
       "operands": [{"arg": "N_in"}, {"const": 127, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_1281405248": {
+    "op_246700080": {
       "kind": "arith.divsi",
       "scope": "function",
-      "operands": [{"op": "op_1281399888"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246694752"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {}
     },
-    "op_1281472192": {
+    "op_246768064": {
       "kind": "arith.muli",
       "scope": "function",
-      "operands": [{"op": "op_1281396704"}, {"op": "op_1281405248"}],
+      "operands": [{"op": "op_246556144"}, {"op": "op_246700080"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_1281396560": {
+    "op_246694608": {
       "kind": "arith.extsi",
       "scope": "function",
       "operands": [{"arg": "K_out"}],
       "result_types": ["i64"],
       "attributes": {}
     },
-    "op_1281476160": {
+    "op_246772032": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "DOUT"}, {"arg": "M"}, {"arg": "K_out"}, {"op": "op_1281396560"}, {"const": 1, "type": "i64"}],
+      "operands": [{"arg": "DOUT"}, {"arg": "M"}, {"arg": "K_out"}, {"op": "op_246694608"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_1281399744": {
+    "op_246776688": {
       "kind": "arith.extsi",
       "scope": "function",
       "operands": [{"arg": "N_in"}],
       "result_types": ["i64"],
       "attributes": {}
     },
-    "op_1281479376": {
+    "op_246776928": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "ACT"}, {"arg": "M"}, {"arg": "N_in"}, {"op": "op_1281399744"}, {"const": 1, "type": "i64"}],
+      "operands": [{"arg": "ACT"}, {"arg": "M"}, {"arg": "N_in"}, {"op": "op_246776688"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_1281480896": {
+    "op_246778448": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "DW"}, {"arg": "K_out"}, {"arg": "N_in"}, {"op": "op_1281399744"}, {"const": 1, "type": "i64"}],
+      "operands": [{"arg": "DW"}, {"arg": "K_out"}, {"arg": "N_in"}, {"op": "op_246776688"}, {"const": 1, "type": "i64"}],
       "result_types": ["!tt.tensordesc<128x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_1281481744": {
+    "op_246780432": {
       "kind": "arith.divsi",
       "scope": "loop:1",
-      "operands": [{"iv": 1}, {"op": "op_1281405248"}],
+      "operands": [{"iv": 1}, {"op": "op_246700080"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 1, "loop.stage": 0, "ttg.partition": [5]}
     },
-    "op_1281482016": {
+    "op_246780704": {
       "kind": "arith.remsi",
       "scope": "loop:1",
-      "operands": [{"iv": 1}, {"op": "op_1281405248"}],
+      "operands": [{"iv": 1}, {"op": "op_246700080"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 2, "loop.stage": 0, "ttg.partition": [5]}
     },
-    "op_1281483424": {
+    "op_246782112": {
       "kind": "arith.muli",
       "scope": "loop:1",
-      "operands": [{"op": "op_1281481744"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246780432"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 3, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [5]}
     },
-    "op_1281483696": {
+    "op_246782384": {
       "kind": "arith.muli",
       "scope": "loop:1",
-      "operands": [{"op": "op_1281482016"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246780704"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 4, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [5]}
     },
-    "op_1281500976": {
+    "op_246807888": {
       "kind": "ttng.tmem_alloc",
       "scope": "loop:1",
       "operands": [],
       "result_types": ["!ttg.memdesc<128x128xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
       "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 0, "loop.stage": 0, "tt.num_buffers": 2, "ttg.partition": [5]}
     },
-    "op_1281394192": {
+    "op_246666544": {
       "kind": "ttng.tmem_store",
       "scope": "loop:1",
-      "operands": [{"op": "op_1281500976", "result": 0}, {"op": "op_1281500976", "result": 1}, {"const": 0, "type": "tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246807888", "result": 0}, {"op": "op_246807888", "result": 1}, {"const": 0, "type": "tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 0, "loop.stage": 0, "ttg.partition": [5]}
     },
-    "op_1281150896": {
+    "op_246489936": {
       "kind": "tt.descriptor_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_1281476160"}, {"iv": 0}, {"op": "op_1281483424"}],
+      "operands": [{"op": "op_246772032"}, {"iv": 0}, {"op": "op_246782112"}],
       "result_types": ["tensor<64x128xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1, "loop.cluster": 0, "loop.stage": 0, "ttg.partition": [1]}
     },
-    "op_1281116944": {
+    "op_246446144": {
       "kind": "tt.descriptor_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_1281479376"}, {"iv": 0}, {"op": "op_1281483696"}],
+      "operands": [{"op": "op_246776928"}, {"iv": 0}, {"op": "op_246782384"}],
       "result_types": ["tensor<64x128xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1, "loop.cluster": 1, "loop.stage": 0, "ttg.partition": [2]}
     },
-    "op_1281495568": {
+    "op_246797696": {
       "kind": "ttg.local_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_1281116944"}],
+      "operands": [{"op": "op_246446144"}],
       "result_types": ["!ttg.memdesc<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
-      "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 1, "loop.stage": 2, "tt.num_buffers": 3, "ttg.partition": [2]}
+      "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 1, "loop.stage": 2, "tt.num_buffers": 5, "ttg.partition": [2]}
     },
-    "op_1281495712": {
+    "op_246797840": {
       "kind": "ttg.local_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_1281150896"}],
+      "operands": [{"op": "op_246489936"}],
       "result_types": ["!ttg.memdesc<64x128xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>, #ttg.shared_memory>"],
-      "attributes": {"buffer.id": 1, "buffer.merge_group_id": 1, "loop.cluster": 0, "loop.stage": 2, "tt.num_buffers": 3, "ttg.partition": [1]}
+      "attributes": {"buffer.id": 1, "buffer.merge_group_id": 1, "loop.cluster": 0, "loop.stage": 2, "tt.num_buffers": 5, "ttg.partition": [1]}
     },
-    "op_1281505520": {
+    "op_246799472": {
       "kind": "ttg.memdesc_trans",
       "scope": "loop:0",
-      "operands": [{"op": "op_1281495712"}],
+      "operands": [{"op": "op_246797840"}],
       "result_types": ["!ttg.memdesc<128x64xf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>, #ttg.shared_memory>"],
       "attributes": {"loop.cluster": 0, "loop.stage": 2, "order": [1, 0], "ttg.partition": [3]}
     },
-    "op_1280791296": {
+    "op_246124896": {
       "kind": "ttng.tc_gen5_mma",
       "scope": "loop:0",
-      "operands": [{"op": "op_1281505520"}, {"op": "op_1281495568"}, {"op": "op_1281500976", "result": 0}, {"iter_arg": {"loop": 0, "idx": 2}}, {"iter_arg": {"loop": 0, "idx": 1}}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246799472"}, {"op": "op_246797696"}, {"op": "op_246807888", "result": 0}, {"iter_arg": {"loop": 0, "idx": 2}}, {"iter_arg": {"loop": 0, "idx": 1}}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 1, "loop.stage": 2, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [3]}
     },
-    "op_1281508000": {
+    "op_246803520": {
       "kind": "arith.extf",
       "scope": "loop:0",
-      "operands": [{"op": "op_1281150896"}],
+      "operands": [{"op": "op_246489936"}],
       "result_types": ["tensor<64x128xf32, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"loop.cluster": 0, "loop.stage": 2, "ttg.partition": [4]}
     },
-    "op_1281503440": {
+    "op_246784416": {
       "kind": "arith.addf",
       "scope": "loop:0",
       "operands": [{"unknown_block_arg": true}, {"unknown_block_arg": true}],
       "result_types": ["f32"],
       "attributes": {"fastmath": "#arith.fastmath<none>"}
     },
-    "op_1281447888": {
+    "op_246745920": {
       "kind": "tt.reduce.return",
       "scope": "loop:0",
-      "operands": [{"op": "op_1281503440"}],
+      "operands": [{"op": "op_246784416"}],
       "result_types": [],
       "attributes": {}
     },
-    "op_1281497088": {
+    "op_246795824": {
       "kind": "tt.reduce",
       "scope": "loop:0",
-      "operands": [{"op": "op_1281508000"}],
+      "operands": [{"op": "op_246803520"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>}>>"],
       "attributes": {"axis": 0, "loop.cluster": 2, "loop.stage": 2, "reduction_ordering": "unordered", "ttg.partition": [4]}
     },
-    "op_1281503824": {
+    "op_246784672": {
       "kind": "arith.addf",
       "scope": "loop:0",
-      "operands": [{"iter_arg": {"loop": 0, "idx": 0}}, {"op": "op_1281497088"}],
+      "operands": [{"iter_arg": {"loop": 0, "idx": 0}}, {"op": "op_246795824"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 0, "loop.stage": 4, "ttg.partition": [4]}
     },
-    "op_1281508608": {
+    "op_246790720": {
       "kind": "scf.yield",
       "scope": "loop:0",
-      "operands": [{"op": "op_1281503824"}, {"const": -1, "type": "i1"}, {"op": "op_1280791296"}],
+      "operands": [{"op": "op_246784672"}, {"const": -1, "type": "i1"}, {"op": "op_246124896"}],
       "result_types": [],
       "attributes": {}
     },
-    "op_1280797616": {
+    "op_246126720": {
       "kind": "scf.for",
       "scope": "loop:1",
-      "operands": [{"const": 0, "type": "i32"}, {"arg": "M"}, {"const": 64, "type": "i32"}, {"const": 0, "type": "tensor<128xf32, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>}>>"}, {"const": 0, "type": "i1"}, {"op": "op_1281394192"}],
+      "operands": [{"const": 0, "type": "i32"}, {"arg": "M"}, {"const": 64, "type": "i32"}, {"const": 0, "type": "tensor<128xf32, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>}>>"}, {"const": 0, "type": "i1"}, {"op": "op_246666544"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 0, parent = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>}>>", "i1", "!ttg.async.token"],
-      "attributes": {"loop.cluster": 7, "loop.stage": 0, "tt.modulo_ii": 256, "tt.num_stages": 3, "tt.scheduled_max_stage": 4, "ttg.partition": [5], "ttg.partition.stages": [0, 2, 2, 2, 4], "ttg.partition_num_warps": [4, 1, 1, 1, 4], "ttg.warp_specialize.tag": 0}
+      "attributes": {"loop.cluster": 7, "loop.stage": 0, "tt.modulo_ii": 256, "tt.num_stages": 5, "tt.scheduled_max_stage": 4, "ttg.partition": [5], "ttg.partition.stages": [0, 2, 2, 2, 4], "ttg.partition_num_warps": [4, 1, 1, 1, 4], "ttg.warp_specialize.tag": 0}
     },
-    "op_1281504976": {
+    "op_246797392": {
       "kind": "ttng.tmem_load",
       "scope": "loop:1",
-      "operands": [{"op": "op_1281500976", "result": 0}, {"op": "op_1280797616", "result": 2}],
+      "operands": [{"op": "op_246807888", "result": 0}, {"op": "op_246126720", "result": 2}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>", "!ttg.async.token"],
       "attributes": {"loop.cluster": 0, "loop.stage": 1, "resultSegmentSizes": [1, 1, 0], "ttg.partition": [5]}
     },
-    "op_1281485200": {
+    "op_246784864": {
       "kind": "arith.truncf",
       "scope": "loop:1",
-      "operands": [{"op": "op_1281504976", "result": 0}],
+      "operands": [{"op": "op_246797392", "result": 0}],
       "result_types": ["tensor<128x128xf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>>"],
       "attributes": {"loop.cluster": 1, "loop.stage": 1, "ttg.partition": [5]}
     },
-    "op_1281508928": {
+    "op_246812896": {
       "kind": "ttg.convert_layout",
       "scope": "loop:1",
-      "operands": [{"op": "op_1281485200"}],
+      "operands": [{"op": "op_246784864"}],
       "result_types": ["tensor<128x128xf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>"],
       "attributes": {"loop.cluster": 2, "loop.stage": 1, "ttg.partition": [5]}
     },
-    "op_1281481392": {
+    "op_246780080": {
       "kind": "tt.descriptor_store",
       "scope": "loop:1",
-      "operands": [{"op": "op_1281480896"}, {"op": "op_1281508928"}, {"op": "op_1281483424"}, {"op": "op_1281483696"}],
+      "operands": [{"op": "op_246778448"}, {"op": "op_246812896"}, {"op": "op_246782112"}, {"op": "op_246782384"}],
       "result_types": [],
       "attributes": {"buffer.id": 1, "loop.cluster": 3, "loop.stage": 1, "reduce_kind": 0, "tt.epilogue_subtile": 4, "tt.num_buffers": 2, "ttg.partition": [5]}
     },
-    "op_1281501504": {
+    "op_246800272": {
       "kind": "arith.cmpi",
       "scope": "loop:1",
-      "operands": [{"op": "op_1281482016"}, {"const": 0, "type": "i32"}],
+      "operands": [{"op": "op_246780704"}, {"const": 0, "type": "i32"}],
       "result_types": ["i1"],
       "attributes": {"loop.cluster": 5, "loop.stage": 0, "predicate": 0}
     },
-    "op_1281507424": {
+    "op_246806160": {
       "kind": "tt.addptr",
       "scope": "loop:1",
-      "operands": [{"arg": "DB"}, {"op": "op_1281483424"}],
+      "operands": [{"arg": "DB"}, {"op": "op_246782112"}],
       "result_types": ["!tt.ptr<f32>"],
       "attributes": {}
     },
-    "op_1281469520": {
+    "op_246766528": {
       "kind": "tt.make_range",
       "scope": "loop:1",
       "operands": [],
       "result_types": ["tensor<128xi32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
       "attributes": {"end": 128, "start": 0}
     },
-    "op_1281517168": {
+    "op_246813680": {
       "kind": "tt.splat",
       "scope": "loop:1",
-      "operands": [{"op": "op_1281507424"}],
+      "operands": [{"op": "op_246806160"}],
       "result_types": ["tensor<128x!tt.ptr<f32>, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
       "attributes": {}
     },
-    "op_1281499424": {
+    "op_246798160": {
       "kind": "tt.addptr",
       "scope": "loop:1",
-      "operands": [{"op": "op_1281517168"}, {"op": "op_1281469520"}],
+      "operands": [{"op": "op_246813680"}, {"op": "op_246766528"}],
       "result_types": ["tensor<128x!tt.ptr<f32>, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
       "attributes": {}
     },
-    "op_1281517312": {
+    "op_246813824": {
       "kind": "ttg.convert_layout",
       "scope": "loop:1",
-      "operands": [{"op": "op_1280797616", "result": 0}],
+      "operands": [{"op": "op_246126720", "result": 0}],
       "result_types": ["tensor<128xf32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>"],
       "attributes": {"ttg.partition": [0]}
     },
-    "op_1281501152": {
+    "op_246799888": {
       "kind": "tt.store",
       "scope": "loop:1",
-      "operands": [{"op": "op_1281499424"}, {"op": "op_1281517312"}],
+      "operands": [{"op": "op_246798160"}, {"op": "op_246813824"}],
       "result_types": [],
       "attributes": {"cache": 1, "evict": 1, "ttg.partition": [0]}
     },
-    "op_1281517440": {
+    "op_246818224": {
       "kind": "scf.yield",
       "scope": "loop:1",
       "operands": [],
       "result_types": [],
       "attributes": {}
     },
-    "op_1281507808": {
+    "op_246806544": {
       "kind": "scf.if",
       "scope": "loop:1",
-      "operands": [{"op": "op_1281501504"}],
+      "operands": [{"op": "op_246800272"}],
       "result_types": [],
       "attributes": {"loop.cluster": 6, "loop.stage": 0},
       "then_yields": []
     },
-    "op_1281517536": {
+    "op_246813024": {
       "kind": "scf.yield",
       "scope": "loop:1",
       "operands": [],
       "result_types": [],
       "attributes": {}
     },
-    "op_1281485760": {
+    "op_246813440": {
       "kind": "scf.for",
       "scope": "function",
-      "operands": [{"op": "op_1281463392"}, {"op": "op_1281472192"}, {"op": "op_1281464752"}],
+      "operands": [{"op": "op_246762672"}, {"op": "op_246768064"}, {"op": "op_246764032"}],
       "result_types": [],
       "attributes": {"tt.modulo_ii": 8192, "tt.num_stages": 2, "tt.scheduled_max_stage": 1, "ttg.partition.stages": [0, 0, 0, 0, 0, 1], "ttg.partition_num_warps": [4, 1, 1, 1, 1, 4], "ttg.warp_specialize.tag": 0}
     },
-    "op_1281517632": {
+    "op_246813120": {
       "kind": "tt.return",
       "scope": "function",
       "operands": [],
@@ -417,7 +417,7 @@
       "schedule_loop":     {
       "id": 0,
       "II": 256,
-      "partition_cost": 578.9960,
+      "partition_cost": 10112386.9960,
       "max_stage": 4,
       "prologue_latency": 256,
       "trip_count": 4,
@@ -427,22 +427,22 @@
       "upper_bound": {"arg": "M"},
       "step": {"const": 64, "type": "i32"},
       "buffers": [
-        {"id": 0, "kind": "smem", "shape": [64, 128], "element_bits": 16, "count": 3, "size_bytes": 16384, "total_bytes": 49152, "merge_group_id": 0, "paired_buffer_id": 2, "live_start": 586, "live_end": 1145, "def_op": "op_1281495568"},
-        {"id": 1, "kind": "smem", "shape": [64, 128], "element_bits": 16, "count": 3, "size_bytes": 16384, "total_bytes": 49152, "merge_group_id": 1, "paired_buffer_id": 3, "live_start": 556, "live_end": 1145, "def_op": "op_1281495712"},
-        {"id": 2, "kind": "barrier", "shape": [], "element_bits": 16, "count": 3, "size_bytes": 8, "total_bytes": 24, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 586, "live_end": 1145, "def_op": "op_1281495568"},
-        {"id": 3, "kind": "barrier", "shape": [], "element_bits": 16, "count": 3, "size_bytes": 8, "total_bytes": 24, "merge_group_id": null, "paired_buffer_id": 1, "live_start": 556, "live_end": 1145, "def_op": "op_1281495712"}
+        {"id": 0, "kind": "smem", "shape": [64, 128], "element_bits": 16, "count": 5, "size_bytes": 16384, "total_bytes": 81920, "merge_group_id": 0, "paired_buffer_id": 2, "live_start": 30, "live_end": 1145, "def_op": "op_246797696"},
+        {"id": 1, "kind": "smem", "shape": [64, 128], "element_bits": 16, "count": 5, "size_bytes": 16384, "total_bytes": 81920, "merge_group_id": 1, "paired_buffer_id": 3, "live_start": 0, "live_end": 1145, "def_op": "op_246797840"},
+        {"id": 2, "kind": "barrier", "shape": [], "element_bits": 16, "count": 5, "size_bytes": 8, "total_bytes": 40, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 30, "live_end": 1145, "def_op": "op_246797696"},
+        {"id": 3, "kind": "barrier", "shape": [], "element_bits": 16, "count": 5, "size_bytes": 8, "total_bytes": 40, "merge_group_id": null, "paired_buffer_id": 1, "live_start": 0, "live_end": 1145, "def_op": "op_246797840"}
       ],
       "graph": {
         "nodes": [
-          {"id": 0, "op_ref": "op_1281150896", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 1, "op_ref": "op_1281116944", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 1, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 30, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 2, "op_ref": "op_1281495568", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 586, "stage": 2, "cluster": 1}, "produces_buffer": 0, "consumes_buffers": []},
-          {"id": 3, "op_ref": "op_1281495712", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 0, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 556, "stage": 2, "cluster": 0}, "produces_buffer": 1, "consumes_buffers": []},
-          {"id": 4, "op_ref": "op_1281505520", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 556, "stage": 2, "cluster": 0}, "produces_buffer": null, "consumes_buffers": [1]},
-          {"id": 5, "op_ref": "op_1280791296", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 2, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 586, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": [0]},
-          {"id": 6, "op_ref": "op_1281508000", "op_kind": "arith.extf", "pipeline": "CUDA", "warp_group": 3, "latency": 52, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 556, "stage": 2, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 7, "op_ref": "op_1281497088", "op_kind": "tt.reduce", "pipeline": "CUDA", "warp_group": 3, "latency": 481, "self_latency": 181, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 608, "stage": 2, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 8, "op_ref": "op_1281503824", "op_kind": "arith.addf", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1100, "stage": 4, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []}
+          {"id": 0, "op_ref": "op_246489936", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 1, "op_ref": "op_246446144", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 1, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 30, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 2, "op_ref": "op_246797696", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 586, "stage": 2, "cluster": 1}, "produces_buffer": 0, "consumes_buffers": []},
+          {"id": 3, "op_ref": "op_246797840", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 0, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 556, "stage": 2, "cluster": 0}, "produces_buffer": 1, "consumes_buffers": []},
+          {"id": 4, "op_ref": "op_246799472", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 556, "stage": 2, "cluster": 0}, "produces_buffer": null, "consumes_buffers": [1]},
+          {"id": 5, "op_ref": "op_246124896", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 2, "latency": 559, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 586, "stage": 2, "cluster": 1}, "produces_buffer": null, "consumes_buffers": [0]},
+          {"id": 6, "op_ref": "op_246803520", "op_kind": "arith.extf", "pipeline": "CUDA", "warp_group": 3, "latency": 52, "self_latency": 32, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 556, "stage": 2, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 7, "op_ref": "op_246795824", "op_kind": "tt.reduce", "pipeline": "CUDA", "warp_group": 3, "latency": 481, "self_latency": 181, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 608, "stage": 2, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 8, "op_ref": "op_246784672", "op_kind": "arith.addf", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1100, "stage": 4, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []}
         ],
         "edges": [
           {"src": 1, "dst": 2, "kind": "data", "distance": 0, "latency": 556},
@@ -457,9 +457,9 @@
           {"src": 5, "dst": 5, "kind": "data", "distance": 1, "latency": 256}
         ],
         "cross_wg_barriers": [
-          {"producer_node": 3, "consumer_node": 4, "producer_wg": 0, "consumer_wg": 2, "kind": "mbarrier", "depth": 3, "paired_buffer_id": 1, "expect_bytes": 16384},
-          {"producer_node": 2, "consumer_node": 5, "producer_wg": 1, "consumer_wg": 2, "kind": "mbarrier", "depth": 3, "paired_buffer_id": 0, "expect_bytes": 16384},
-          {"producer_node": 0, "consumer_node": 6, "producer_wg": 0, "consumer_wg": 3, "kind": "mbarrier", "depth": 3, "paired_buffer_id": 1, "expect_bytes": 16384}
+          {"producer_node": 3, "consumer_node": 4, "producer_wg": 0, "consumer_wg": 2, "kind": "mbarrier", "depth": 5, "paired_buffer_id": 1, "expect_bytes": 16384},
+          {"producer_node": 2, "consumer_node": 5, "producer_wg": 1, "consumer_wg": 2, "kind": "mbarrier", "depth": 5, "paired_buffer_id": 0, "expect_bytes": 16384},
+          {"producer_node": 0, "consumer_node": 6, "producer_wg": 0, "consumer_wg": 3, "kind": "mbarrier", "depth": 5, "paired_buffer_id": 1, "expect_bytes": 16384}
         ]
       }
     }
@@ -471,36 +471,36 @@
       "schedule_loop":     {
       "id": 1,
       "II": 8192,
-      "partition_cost": 959.9990,
+      "partition_cost": 10112767.9990,
       "max_stage": 1,
       "prologue_latency": 96,
       "trip_count": 4,
       "trip_count_estimated": true,
       "induction_var": {"name": "iv", "type": "i32"},
-      "lower_bound": {"op": "op_1281463392"},
-      "upper_bound": {"op": "op_1281472192"},
-      "step": {"op": "op_1281464752"},
+      "lower_bound": {"op": "op_246762672"},
+      "upper_bound": {"op": "op_246768064"},
+      "step": {"op": "op_246764032"},
       "buffers": [
-        {"id": 0, "kind": "tmem", "shape": [128, 128], "element_bits": 32, "count": 2, "size_bytes": 65536, "total_bytes": 131072, "merge_group_id": 0, "paired_buffer_id": 2, "live_start": 0, "live_end": 8820, "def_op": "op_1281500976"},
-        {"id": 1, "kind": "smem", "shape": [128, 32], "element_bits": 16, "count": 2, "size_bytes": 8192, "total_bytes": 16384, "merge_group_id": null, "paired_buffer_id": 3, "live_start": 9030, "live_end": 9030, "def_op": "op_1281481392"},
-        {"id": 2, "kind": "barrier", "shape": [], "element_bits": 16, "count": 2, "size_bytes": 8, "total_bytes": 16, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 0, "live_end": 8820, "def_op": "op_1281500976"},
-        {"id": 3, "kind": "barrier", "shape": [], "element_bits": 16, "count": 2, "size_bytes": 8, "total_bytes": 16, "merge_group_id": null, "paired_buffer_id": 1, "live_start": 9030, "live_end": 9030, "def_op": "op_1281481392"}
+        {"id": 0, "kind": "tmem", "shape": [128, 128], "element_bits": 32, "count": 2, "size_bytes": 65536, "total_bytes": 131072, "merge_group_id": 0, "paired_buffer_id": 2, "live_start": 0, "live_end": 8820, "def_op": "op_246807888"},
+        {"id": 1, "kind": "smem", "shape": [128, 32], "element_bits": 16, "count": 2, "size_bytes": 8192, "total_bytes": 16384, "merge_group_id": null, "paired_buffer_id": 3, "live_start": 9030, "live_end": 9030, "def_op": "op_246780080"},
+        {"id": 2, "kind": "barrier", "shape": [], "element_bits": 16, "count": 2, "size_bytes": 8, "total_bytes": 16, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 0, "live_end": 8820, "def_op": "op_246807888"},
+        {"id": 3, "kind": "barrier", "shape": [], "element_bits": 16, "count": 2, "size_bytes": 8, "total_bytes": 16, "merge_group_id": null, "paired_buffer_id": 1, "live_start": 9030, "live_end": 9030, "def_op": "op_246780080"}
       ],
       "graph": {
         "nodes": [
-          {"id": 0, "op_ref": "op_1281481744", "op_kind": "arith.divsi", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 48, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 1, "op_ref": "op_1281482016", "op_kind": "arith.remsi", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 49, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 2, "op_ref": "op_1281483424", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 50, "stage": 0, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 3, "op_ref": "op_1281483696", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 51, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 4, "op_ref": "op_1281500976", "op_kind": "ttng.tmem_alloc", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": 0, "consumes_buffers": []},
-          {"id": 5, "op_ref": "op_1281394192", "op_kind": "ttng.tmem_store", "pipeline": "CUDA", "warp_group": 4, "latency": 96, "self_latency": 48, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": [0]},
-          {"id": 6, "op_ref": "op_1280797616", "op_kind": "scf.for", "pipeline": "NONE", "warp_group": 4, "latency": 8192, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 96, "stage": 0, "cluster": 7}, "produces_buffer": null, "consumes_buffers": [], "child_pipeline_id": 1, "prologue_latency": 256},
-          {"id": 7, "op_ref": "op_1281504976", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 4, "latency": 532, "self_latency": 256, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 8288, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": [0], "subtile_index": -1, "subtile_count": 4, "n_offset": 0, "n_size": 32},
-          {"id": 8, "op_ref": "op_1281485200", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 4, "latency": 105, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 8820, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": [], "subtile_index": -1, "subtile_count": 4, "n_offset": 0, "n_size": 32},
-          {"id": 9, "op_ref": "op_1281508928", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "warp_group": 4, "latency": 105, "self_latency": 105, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 8925, "stage": 1, "cluster": 2}, "produces_buffer": null, "consumes_buffers": [], "subtile_index": -1, "subtile_count": 4, "n_offset": 0, "n_size": 32},
-          {"id": 10, "op_ref": "op_1281481392", "op_kind": "tt.descriptor_store", "pipeline": "TMA", "warp_group": 4, "latency": 1794, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 9030, "stage": 1, "cluster": 3}, "produces_buffer": 1, "consumes_buffers": [], "subtile_index": -1, "subtile_count": 4, "n_offset": 0, "n_size": 32},
-          {"id": 11, "op_ref": "op_1281501504", "op_kind": "arith.cmpi", "pipeline": "CUDA", "warp_group": -1, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 52, "stage": 0, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 12, "op_ref": "op_1281507808", "op_kind": "scf.if", "pipeline": "NONE", "warp_group": -1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 53, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []}
+          {"id": 0, "op_ref": "op_246780432", "op_kind": "arith.divsi", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 48, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 1, "op_ref": "op_246780704", "op_kind": "arith.remsi", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 49, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 2, "op_ref": "op_246782112", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 50, "stage": 0, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 3, "op_ref": "op_246782384", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 51, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 4, "op_ref": "op_246807888", "op_kind": "ttng.tmem_alloc", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": 0, "consumes_buffers": []},
+          {"id": 5, "op_ref": "op_246666544", "op_kind": "ttng.tmem_store", "pipeline": "CUDA", "warp_group": 4, "latency": 96, "self_latency": 48, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": [0]},
+          {"id": 6, "op_ref": "op_246126720", "op_kind": "scf.for", "pipeline": "NONE", "warp_group": 4, "latency": 8192, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 96, "stage": 0, "cluster": 7}, "produces_buffer": null, "consumes_buffers": [], "child_pipeline_id": 1, "prologue_latency": 256},
+          {"id": 7, "op_ref": "op_246797392", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 4, "latency": 532, "self_latency": 256, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 8288, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": [0], "subtile_index": -1, "subtile_count": 4, "n_offset": 0, "n_size": 32},
+          {"id": 8, "op_ref": "op_246784864", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 4, "latency": 105, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 8820, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": [], "subtile_index": -1, "subtile_count": 4, "n_offset": 0, "n_size": 32},
+          {"id": 9, "op_ref": "op_246812896", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "warp_group": 4, "latency": 105, "self_latency": 105, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 8925, "stage": 1, "cluster": 2}, "produces_buffer": null, "consumes_buffers": [], "subtile_index": -1, "subtile_count": 4, "n_offset": 0, "n_size": 32},
+          {"id": 10, "op_ref": "op_246780080", "op_kind": "tt.descriptor_store", "pipeline": "TMA", "warp_group": 4, "latency": 1794, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 9030, "stage": 1, "cluster": 3}, "produces_buffer": 1, "consumes_buffers": [], "subtile_index": -1, "subtile_count": 4, "n_offset": 0, "n_size": 32},
+          {"id": 11, "op_ref": "op_246800272", "op_kind": "arith.cmpi", "pipeline": "CUDA", "warp_group": -1, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 52, "stage": 0, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 12, "op_ref": "op_246806544", "op_kind": "scf.if", "pipeline": "NONE", "warp_group": -1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 53, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []}
         ],
         "edges": [
           {"src": 0, "dst": 2, "kind": "data", "distance": 0, "latency": 1},

--- a/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/generated.py
+++ b/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/generated.py
@@ -40,12 +40,12 @@ def _scaled_mm_blockwise(
     range_15 = tl.arange(0, 128)
 
     # ── Multi-buffered allocations (from modulo's lifetime analysis) ──
-    # inner-loop buf 0: SMEM count=1 (modulo lifetime [557..1487], II=1432)
-    L0_smem_0 = tlx.local_alloc((128, 128), tl.float8e4nv, 1)
-    # inner-loop buf 1: SMEM count=1 (modulo lifetime [587..1487], II=1432)
-    L0_smem_1 = tlx.local_alloc((128, 128), tl.float8e4nv, 1)
-    # inner-loop buf 2: SMEM count=1 (channel for cross-WG hand-off)
-    L0_smem_2 = tlx.local_alloc((128,), tl.float32, 1)
+    # inner-loop buf 0: SMEM count=2 (modulo lifetime [1..1487], II=1432)
+    L0_smem_0 = tlx.local_alloc((128, 128), tl.float8e4nv, 2)
+    # inner-loop buf 1: SMEM count=2 (modulo lifetime [31..1487], II=1432)
+    L0_smem_1 = tlx.local_alloc((128, 128), tl.float8e4nv, 2)
+    # inner-loop buf 4: SMEM count=1 (channel for cross-WG hand-off)
+    L0_smem_4 = tlx.local_alloc((128,), tl.float32, 1)
 
     # acc_tmem: outer-loop buf 0, count=2 (TC writes / default reads across 2 tiles)
     acc_tmem = tlx.local_alloc((128, 128), tl.float32, 2, tlx.storage_kind.tmem)
@@ -53,17 +53,17 @@ def _scaled_mm_blockwise(
 
     # ── Mbarriers (SemIR: full+empty pair per semaphore) ──
     # L0_smem_1: N4→N5  ttg.local_alloc→ttg.memdesc_trans  cyc587→cyc587  forward  buf=1  kind=mbarrier
-    L0_smem_1_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
-    L0_smem_1_empty = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+    L0_smem_1_full = tlx.alloc_barriers(num_barriers=2, arrive_count=1)
+    L0_smem_1_empty = tlx.alloc_barriers(num_barriers=2, arrive_count=1)
     # L0_smem_0: N2→N6  ttg.local_alloc→ttng.tc_gen5_mma  cyc557→cyc587  forward  buf=0  kind=mbarrier
-    L0_smem_0_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
-    L0_smem_0_empty = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
-    # sem2_b2: N10→N14  tt.load→arith.mulf  cyc61→cyc521  forward  buf=2  kind=mbarrier
-    sem2_b2_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
-    sem2_b2_empty = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+    L0_smem_0_full = tlx.alloc_barriers(num_barriers=2, arrive_count=1)
+    L0_smem_0_empty = tlx.alloc_barriers(num_barriers=2, arrive_count=1)
+    # sem2_b4: N10→N14  tt.load→arith.mulf  cyc61→cyc521  forward  buf=4  kind=mbarrier
+    sem2_b4_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
+    sem2_b4_empty = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
     # sem3: N6→N17  ttng.tc_gen5_mma→ttng.tmem_load  cyc587→cyc1487  forward  buf=None  kind=named
     sem3_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
-    # sem4: N17→N6  ttng.tmem_load→ttng.tc_gen5_mma  cyc1487→cyc587  LOOP-CARRY  buf=3  kind=mbarrier
+    # sem4: N17→N6  ttng.tmem_load→ttng.tc_gen5_mma  cyc1487→cyc587  LOOP-CARRY  buf=5  kind=mbarrier
     sem4_full = tlx.alloc_barriers(num_barriers=1, arrive_count=1)
     with tlx.async_tasks():
         # Async task: role=TMA ← inner wg0 (Phase 4 plan)
@@ -71,30 +71,30 @@ def _scaled_mm_blockwise(
             smem_accum = 0
             # Outer persistent loop (loop 1, II=45824). Each task replays it; body trimmed to this WG's ops.
             for tile_id in range(pid_0, mul_12, 148):
-                # Inner K-loop (loop 0, II=1432). SMEM ring depth=1; smem_accum persists across outer tiles.
+                # Inner K-loop (loop 0, II=1432). SMEM ring depth=2; smem_accum persists across outer tiles.
                 for k in range(0, div_14, 1):
                     _it = smem_accum
-                    buf = smem_accum % 1
-                    phase = (smem_accum // 1) & 1
+                    buf = smem_accum % 2
+                    phase = (smem_accum // 2) & 1
                     # load → L0_smem_0
-                    tlx.barrier_wait(L0_smem_0_empty[0], (_it & 1) ^ 1)
-                    tlx.barrier_expect_bytes(L0_smem_0_full[0], 16384)
-                    tlx.async_descriptor_load(a_desc, L0_smem_0[0], [((tile_id // div_11) * 128), (k * 128)], L0_smem_0_full[0])
+                    tlx.barrier_wait(L0_smem_0_empty[buf], phase ^ 1)
+                    tlx.barrier_expect_bytes(L0_smem_0_full[buf], 16384)
+                    tlx.async_descriptor_load(a_desc, L0_smem_0[buf], [((tile_id // div_11) * 128), (k * 128)], L0_smem_0_full[buf])
                     smem_accum += 1
         # Async task: role=TMA ← inner wg1 (Phase 4 plan)
         with tlx.async_task(num_warps=1, num_regs=24):
             smem_accum = 0
             # Outer persistent loop (loop 1, II=45824). Each task replays it; body trimmed to this WG's ops.
             for tile_id in range(pid_0, mul_12, 148):
-                # Inner K-loop (loop 0, II=1432). SMEM ring depth=1; smem_accum persists across outer tiles.
+                # Inner K-loop (loop 0, II=1432). SMEM ring depth=2; smem_accum persists across outer tiles.
                 for k in range(0, div_14, 1):
                     _it = smem_accum
-                    buf = smem_accum % 1
-                    phase = (smem_accum // 1) & 1
+                    buf = smem_accum % 2
+                    phase = (smem_accum // 2) & 1
                     # load → L0_smem_1
-                    tlx.barrier_wait(L0_smem_1_empty[0], (_it & 1) ^ 1)
-                    tlx.barrier_expect_bytes(L0_smem_1_full[0], 16384)
-                    tlx.async_descriptor_load(b_desc, L0_smem_1[0], [((tile_id % div_11) * 128), (k * 128)], L0_smem_1_full[0])
+                    tlx.barrier_wait(L0_smem_1_empty[buf], phase ^ 1)
+                    tlx.barrier_expect_bytes(L0_smem_1_full[buf], 16384)
+                    tlx.async_descriptor_load(b_desc, L0_smem_1[buf], [((tile_id % div_11) * 128), (k * 128)], L0_smem_1_full[buf])
                     smem_accum += 1
         # Async task: role=TC ← inner wg2 (Phase 4 plan)
         with tlx.async_task(num_warps=1, num_regs=24):
@@ -105,17 +105,17 @@ def _scaled_mm_blockwise(
             for tile_id in range(pid_0, mul_12, 148):
                 tmem_buf = tmem_accum_cnt % 1
                 tmem_phase = (tmem_accum_cnt // 1) & 1
-                # Inner K-loop (loop 0, II=1432). SMEM ring depth=1; smem_accum persists across outer tiles.
+                # Inner K-loop (loop 0, II=1432). SMEM ring depth=2; smem_accum persists across outer tiles.
                 for k in range(0, div_14, 1):
                     _it = smem_accum
-                    buf = smem_accum % 1
-                    phase = (smem_accum // 1) & 1
+                    buf = smem_accum % 2
+                    phase = (smem_accum // 2) & 1
                     # MMA
-                    tlx.barrier_wait(L0_smem_1_full[0], (_it & 1))
-                    tlx.barrier_wait(L0_smem_0_full[0], (_it & 1))
+                    tlx.barrier_wait(L0_smem_1_full[(_it % 2)], ((_it // 2) & 1))
+                    tlx.barrier_wait(L0_smem_0_full[(_it % 2)], ((_it // 2) & 1))
                     tlx.barrier_wait(sem4_full[0], (_it & 1))
                     use_acc = False
-                    tlx.async_dot(L0_smem_0[0], tlx.local_trans(L0_smem_1[0]), acc_tmem[0], use_acc=use_acc, mBarriers=[L0_smem_1_empty[0], L0_smem_0_empty[0], sem3_full[0]])
+                    tlx.async_dot(L0_smem_0[buf], tlx.local_trans(L0_smem_1[buf]), acc_tmem[0], use_acc=use_acc, mBarriers=[L0_smem_1_empty[(_it % 2)], L0_smem_0_empty[(_it % 2)], sem3_full[0]])
                     smem_accum += 1
                 tmem_accum_cnt += 1
         # Async task: role=TMA ← inner wg3 (Phase 4 plan)
@@ -126,18 +126,18 @@ def _scaled_mm_blockwise(
             _wgloc600 = tl.arange(0, 128)
             # Outer persistent loop (loop 1, II=45824). Each task replays it; body trimmed to this WG's ops.
             for tile_id in range(pid_0, mul_12, 148):
-                # Inner K-loop (loop 0, II=1432). SMEM ring depth=1; smem_accum persists across outer tiles.
+                # Inner K-loop (loop 0, II=1432). SMEM ring depth=2; smem_accum persists across outer tiles.
                 for k in range(0, div_14, 1):
                     _it = smem_accum
-                    buf = smem_accum % 1
-                    phase = (smem_accum // 1) & 1
+                    buf = smem_accum % 2
+                    phase = (smem_accum // 2) & 1
                     mul_16 = (k * stride_sa_g)
                     splat_17 = mul_16
                     addptr_18 = ((ScaleA + (((tile_id // div_11) * 128) + _wgloc600)) + splat_17)
                     v_19 = tl.load(addptr_18)
-                    tlx.barrier_wait(sem2_b2_empty[0], ((_it & 1) ^ 1))
-                    tlx.local_store(L0_smem_2[0], v_19)
-                    tlx.barrier_arrive(sem2_b2_full[0], 1)
+                    tlx.barrier_wait(sem2_b4_empty[0], ((_it & 1) ^ 1))
+                    tlx.local_store(L0_smem_4[0], v_19)
+                    tlx.barrier_arrive(sem2_b4_full[0], 1)
                     smem_accum += 1
         # Async task: role=default ← outer wg4 (Phase 4 plan)
         with tlx.async_task("default"):
@@ -157,18 +157,18 @@ def _scaled_mm_blockwise(
                 mul_24 = (rem_21 * stride_sb_n)
                 mul_25 = (rem_21 * 128)
                 i0_0 = tl.full((128, 128), 0, tl.float32)
-                # Inner K-loop (loop 0, II=1432). SMEM ring depth=1; smem_accum persists across outer tiles.
+                # Inner K-loop (loop 0, II=1432). SMEM ring depth=2; smem_accum persists across outer tiles.
                 for k in range(0, div_14, 1):
                     _it = smem_accum
-                    buf = smem_accum % 1
-                    phase = (smem_accum // 1) & 1
+                    buf = smem_accum % 2
+                    phase = (smem_accum // 2) & 1
                     addptr_26 = ((ScaleB + mul_24) + k)
                     v_27 = tl.load(addptr_26)
                     splat_28 = v_27
-                    tlx.barrier_wait(sem2_b2_full[0], (_it & 1))
-                    chan_sem2_b2_0 = tlx.local_load(L0_smem_2[0])
-                    tlx.barrier_arrive(sem2_b2_empty[0], 1)
-                    mulf_29 = (chan_sem2_b2_0 * splat_28)
+                    tlx.barrier_wait(sem2_b4_full[0], (_it & 1))
+                    chan_sem2_b4_0 = tlx.local_load(L0_smem_4[0])
+                    tlx.barrier_arrive(sem2_b4_empty[0], 1)
+                    mulf_29 = (chan_sem2_b4_0 * splat_28)
                     expand_30 = mulf_29[:, None]
                     bcast_31 = expand_30
                     tlx.barrier_wait(sem3_full[0], (_it & 1))  # N6→N17  ttng.tc_gen5_mma→ttng.tmem_load  cyc587→cyc1487  forward  buf=None  kind=named

--- a/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/handwritten.py
+++ b/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/handwritten.py
@@ -23,8 +23,15 @@ import torch
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton.language.extra.tlx.warp_spec import get_bufidx_phase
 from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+# Local definition (matches case2/case4) instead of importing from
+# tlx.warp_spec, so the kernel is self-contained and doesn't depend on that
+# module exporting the helper.
+@triton.jit
+def get_bufidx_phase(i, n: tl.constexpr):
+    return i % n, (i // n) & 1
 
 # Register split (mirrors CUTLASS setmaxnreg 48 / 256): lean load+MMA warps
 # donate registers so the promotion warpgroup can run heavy fp32 math.

--- a/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/schedule_graph.json
+++ b/third_party/tlx/tools/sched2tlx/examples/case9_scaled_mm/blockwise/schedule_graph.json
@@ -20,441 +20,441 @@
     ]
   },
   "ops": {
-    "op_140759104": {
+    "op_246745680": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i1"],
       "attributes": {"value": 0}
     },
-    "op_140759216": {
+    "op_246745792": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i1"],
       "attributes": {"value": -1}
     },
-    "op_140766256": {
+    "op_246757632": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i64"],
       "attributes": {"value": 1}
     },
-    "op_140774000": {
+    "op_246757888": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 128}
     },
-    "op_140775344": {
+    "op_246758096": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 127}
     },
-    "op_140767504": {
+    "op_246757744": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 1}
     },
-    "op_140777920": {
+    "op_246760672": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 0}
     },
-    "op_140778128": {
+    "op_246760880": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"value": 148}
     },
-    "op_140781792": {
+    "op_246764544": {
       "kind": "arith.constant",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>>"],
       "attributes": {"value": "dense<0.000000e+00> : tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>>"}
     },
-    "op_140701968": {
+    "op_246691104": {
       "kind": "arith.extsi",
       "scope": "function",
       "operands": [{"arg": "stride_am"}],
       "result_types": ["i64"],
       "attributes": {}
     },
-    "op_140787312": {
+    "op_246770064": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "A"}, {"arg": "M"}, {"arg": "K"}, {"op": "op_140701968"}, {"const": 1, "type": "i64"}],
-      "result_types": ["!tt.tensordesc<tensor<128x128xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>>>"],
+      "operands": [{"arg": "A"}, {"arg": "M"}, {"arg": "K"}, {"op": "op_246691104"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<128x128xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_140788832": {
+    "op_246773856": {
       "kind": "arith.extsi",
       "scope": "function",
       "operands": [{"arg": "stride_bn"}],
       "result_types": ["i64"],
       "attributes": {}
     },
-    "op_140791808": {
+    "op_246775696": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "B"}, {"arg": "N"}, {"arg": "K"}, {"op": "op_140788832"}, {"const": 1, "type": "i64"}],
-      "result_types": ["!tt.tensordesc<tensor<128x128xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>>>"],
+      "operands": [{"arg": "B"}, {"arg": "N"}, {"arg": "K"}, {"op": "op_246773856"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<128x128xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_140792192": {
+    "op_246776080": {
       "kind": "arith.extsi",
       "scope": "function",
       "operands": [{"arg": "stride_cm"}],
       "result_types": ["i64"],
       "attributes": {}
     },
-    "op_140793568": {
+    "op_246777456": {
       "kind": "tt.make_tensor_descriptor",
       "scope": "function",
-      "operands": [{"arg": "C"}, {"arg": "M"}, {"arg": "N"}, {"op": "op_140792192"}, {"const": 1, "type": "i64"}],
-      "result_types": ["!tt.tensordesc<tensor<128x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>>"],
+      "operands": [{"arg": "C"}, {"arg": "M"}, {"arg": "N"}, {"op": "op_246776080"}, {"const": 1, "type": "i64"}],
+      "result_types": ["!tt.tensordesc<128x128xbf16, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>>"],
       "attributes": {"operandSegmentSizes": [1, 2, 2, 0], "padding": 1}
     },
-    "op_140793984": {
+    "op_246779008": {
       "kind": "tt.get_program_id",
       "scope": "function",
       "operands": [],
       "result_types": ["i32"],
       "attributes": {"axis": 0}
     },
-    "op_140794144": {
+    "op_246671616": {
       "kind": "arith.addi",
       "scope": "function",
       "operands": [{"arg": "M"}, {"const": 127, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_140796336": {
+    "op_246781184": {
       "kind": "arith.divsi",
       "scope": "function",
-      "operands": [{"op": "op_140794144"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246671616"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {}
     },
-    "op_140796608": {
+    "op_246781456": {
       "kind": "arith.addi",
       "scope": "function",
       "operands": [{"arg": "N"}, {"const": 127, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_140796880": {
+    "op_246781728": {
       "kind": "arith.divsi",
       "scope": "function",
-      "operands": [{"op": "op_140796608"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246781456"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {}
     },
-    "op_140798288": {
+    "op_246783136": {
       "kind": "arith.muli",
       "scope": "function",
-      "operands": [{"op": "op_140796336"}, {"op": "op_140796880"}],
+      "operands": [{"op": "op_246781184"}, {"op": "op_246781728"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_140798560": {
+    "op_246783408": {
       "kind": "arith.addi",
       "scope": "function",
       "operands": [{"arg": "K"}, {"const": 127, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"overflowFlags": "#arith.overflow<none>"}
     },
-    "op_140798832": {
+    "op_246784816": {
       "kind": "arith.divsi",
       "scope": "function",
-      "operands": [{"op": "op_140798560"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246783408"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {}
     },
-    "op_140783600": {
+    "op_246766352": {
       "kind": "tt.make_range",
       "scope": "function",
       "operands": [],
       "result_types": ["tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>}>>"],
       "attributes": {"end": 128, "start": 0}
     },
-    "op_140801472": {
+    "op_246787456": {
       "kind": "tt.splat",
       "scope": "function",
       "operands": [{"arg": "ScaleA"}],
       "result_types": ["tensor<128x!tt.ptr<f32>, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>}>>"],
       "attributes": {}
     },
-    "op_140802176": {
+    "op_246788160": {
       "kind": "arith.divsi",
       "scope": "loop:1",
-      "operands": [{"iv": 1}, {"op": "op_140796880"}],
+      "operands": [{"iv": 1}, {"op": "op_246781728"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 1, "loop.stage": 0, "ttg.partition": [5]}
     },
-    "op_140802448": {
+    "op_246788432": {
       "kind": "arith.remsi",
       "scope": "loop:1",
-      "operands": [{"iv": 1}, {"op": "op_140796880"}],
+      "operands": [{"iv": 1}, {"op": "op_246781728"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 2, "loop.stage": 0, "ttg.partition": [5]}
     },
-    "op_140802720": {
+    "op_246788704": {
       "kind": "arith.muli",
       "scope": "loop:1",
-      "operands": [{"op": "op_140802176"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246788160"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 3, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [5]}
     },
-    "op_140802992": {
+    "op_246788976": {
       "kind": "arith.muli",
       "scope": "loop:1",
-      "operands": [{"op": "op_140802448"}, {"const": 128, "type": "i32"}],
+      "operands": [{"op": "op_246788432"}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 4, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [5]}
     },
-    "op_140803264": {
+    "op_246789248": {
       "kind": "tt.splat",
       "scope": "loop:1",
-      "operands": [{"op": "op_140802720"}],
+      "operands": [{"op": "op_246788704"}],
       "result_types": ["tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>}>>"],
       "attributes": {"loop.cluster": 4, "loop.stage": 0, "ttg.partition": [5]}
     },
-    "op_140803504": {
+    "op_246789488": {
       "kind": "arith.addi",
       "scope": "loop:1",
-      "operands": [{"op": "op_140803264"}, {"op": "op_140783600"}],
+      "operands": [{"op": "op_246789248"}, {"op": "op_246766352"}],
       "result_types": ["tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>}>>"],
       "attributes": {"loop.cluster": 5, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [5]}
     },
-    "op_140803776": {
+    "op_246789760": {
       "kind": "tt.addptr",
       "scope": "loop:1",
-      "operands": [{"op": "op_140801472"}, {"op": "op_140803504"}],
+      "operands": [{"op": "op_246787456"}, {"op": "op_246789488"}],
       "result_types": ["tensor<128x!tt.ptr<f32>, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>}>>"],
       "attributes": {"loop.cluster": 6, "loop.stage": 0}
     },
-    "op_140804048": {
+    "op_246790032": {
       "kind": "arith.muli",
       "scope": "loop:1",
-      "operands": [{"op": "op_140802448"}, {"arg": "stride_sb_n"}],
+      "operands": [{"op": "op_246788432"}, {"arg": "stride_sb_n"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 6, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>"}
     },
-    "op_140805872": {
+    "op_246791856": {
       "kind": "tt.addptr",
       "scope": "loop:1",
-      "operands": [{"arg": "ScaleB"}, {"op": "op_140804048"}],
+      "operands": [{"arg": "ScaleB"}, {"op": "op_246790032"}],
       "result_types": ["!tt.ptr<f32>"],
       "attributes": {"loop.cluster": 7, "loop.stage": 0}
     },
-    "op_140831488": {
+    "op_246817472": {
       "kind": "ttng.tmem_alloc",
       "scope": "loop:1",
       "operands": [],
       "result_types": ["!ttg.memdesc<128x128xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>, #ttng.tensor_memory, mutable>", "!ttg.async.token"],
       "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 0, "loop.stage": 0, "tt.num_buffers": 2, "ttg.partition": [5]}
     },
-    "op_140819424": {
+    "op_246805408": {
       "kind": "arith.muli",
       "scope": "loop:0",
       "operands": [{"iv": 0}, {"const": 128, "type": "i32"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 0, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [1]}
     },
-    "op_140506128": {
+    "op_246491584": {
       "kind": "tt.descriptor_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140787312"}, {"op": "op_140802720"}, {"op": "op_140819424"}],
+      "operands": [{"op": "op_246770064"}, {"op": "op_246788704"}, {"op": "op_246805408"}],
       "result_types": ["tensor<128x128xf8E4M3FN, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1, "loop.cluster": 1, "loop.stage": 0, "ttg.partition": [1]}
     },
-    "op_140823680": {
+    "op_246798256": {
       "kind": "ttg.local_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_140506128"}],
+      "operands": [{"op": "op_246491584"}],
       "result_types": ["!ttg.memdesc<128x128xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory>"],
-      "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 7, "loop.stage": 0, "tt.num_buffers": 1, "ttg.partition": [1]}
+      "attributes": {"buffer.id": 0, "buffer.merge_group_id": 0, "loop.cluster": 7, "loop.stage": 0, "tt.num_buffers": 2, "ttg.partition": [1]}
     },
-    "op_140462560": {
+    "op_246447792": {
       "kind": "tt.descriptor_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140791808"}, {"op": "op_140802992"}, {"op": "op_140819424"}],
+      "operands": [{"op": "op_246775696"}, {"op": "op_246788976"}, {"op": "op_246805408"}],
       "result_types": ["tensor<128x128xf8E4M3FN, #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>>"],
       "attributes": {"cache": 1, "evict": 1, "loop.cluster": 3, "loop.stage": 0, "ttg.partition": [2]}
     },
-    "op_140825840": {
+    "op_246809664": {
       "kind": "ttg.local_alloc",
       "scope": "loop:0",
-      "operands": [{"op": "op_140462560"}],
+      "operands": [{"op": "op_246447792"}],
       "result_types": ["!ttg.memdesc<128x128xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>, #ttg.shared_memory>"],
-      "attributes": {"buffer.id": 1, "buffer.merge_group_id": 1, "loop.cluster": 8, "loop.stage": 0, "tt.num_buffers": 1, "ttg.partition": [2]}
+      "attributes": {"buffer.id": 1, "buffer.merge_group_id": 1, "loop.cluster": 8, "loop.stage": 0, "tt.num_buffers": 2, "ttg.partition": [2]}
     },
-    "op_140826208": {
+    "op_246812112": {
       "kind": "ttg.memdesc_trans",
       "scope": "loop:0",
-      "operands": [{"op": "op_140825840"}],
+      "operands": [{"op": "op_246809664"}],
       "result_types": ["!ttg.memdesc<128x128xf8E4M3FN, #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>, #ttg.shared_memory>"],
       "attributes": {"loop.cluster": 8, "loop.stage": 0, "order": [1, 0], "ttg.partition": [3]}
     },
-    "op_140145920": {
+    "op_246124896": {
       "kind": "ttng.tc_gen5_mma",
       "scope": "loop:0",
-      "operands": [{"op": "op_140823680"}, {"op": "op_140826208"}, {"op": "op_140831488", "result": 0}, {"iter_arg": {"loop": 0, "idx": 1}}, {"const": 0, "type": "i1"}, {"const": -1, "type": "i1"}],
+      "operands": [{"op": "op_246798256"}, {"op": "op_246812112"}, {"op": "op_246817472", "result": 0}, {"iter_arg": {"loop": 0, "idx": 1}}, {"const": 0, "type": "i1"}, {"const": -1, "type": "i1"}],
       "result_types": ["!ttg.async.token"],
       "attributes": {"loop.cluster": 8, "loop.stage": 0, "operandSegmentSizes": [1, 1, 1, 1, 1, 1, 0, 0], "ttg.partition": [3]}
     },
-    "op_140823872": {
+    "op_246809856": {
       "kind": "arith.muli",
       "scope": "loop:0",
       "operands": [{"iv": 0}, {"arg": "stride_sa_g"}],
       "result_types": ["i32"],
       "attributes": {"loop.cluster": 1, "loop.stage": 0, "overflowFlags": "#arith.overflow<none>", "ttg.partition": [4]}
     },
-    "op_140817584": {
+    "op_246803504": {
       "kind": "tt.splat",
       "scope": "loop:0",
-      "operands": [{"op": "op_140823872"}],
+      "operands": [{"op": "op_246809856"}],
       "result_types": ["tensor<128xi32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>}>>"],
       "attributes": {"loop.cluster": 2, "loop.stage": 0, "ttg.partition": [4]}
     },
-    "op_140829760": {
+    "op_246815744": {
       "kind": "tt.addptr",
       "scope": "loop:0",
-      "operands": [{"op": "op_140803776"}, {"op": "op_140817584"}],
+      "operands": [{"op": "op_246789760"}, {"op": "op_246803504"}],
       "result_types": ["tensor<128x!tt.ptr<f32>, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>}>>"],
       "attributes": {"loop.cluster": 2, "loop.stage": 0, "ttg.partition": [4]}
     },
-    "op_140821760": {
+    "op_246807744": {
       "kind": "tt.load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140829760"}],
+      "operands": [{"op": "op_246815744"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>}>>"],
       "attributes": {"cache": 1, "evict": 1, "isVolatile": 0, "loop.cluster": 4, "loop.stage": 0, "operandSegmentSizes": [1, 0, 0], "ttg.partition": [4]}
     },
-    "op_140823504": {
+    "op_246809488": {
       "kind": "tt.addptr",
       "scope": "loop:0",
-      "operands": [{"op": "op_140805872"}, {"iv": 0}],
+      "operands": [{"op": "op_246791856"}, {"iv": 0}],
       "result_types": ["!tt.ptr<f32>"],
       "attributes": {"loop.cluster": 0, "loop.stage": 0, "ttg.partition": [5]}
     },
-    "op_140830160": {
+    "op_246816144": {
       "kind": "tt.load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140823504"}],
+      "operands": [{"op": "op_246809488"}],
       "result_types": ["f32"],
       "attributes": {"cache": 1, "evict": 1, "isVolatile": 0, "loop.cluster": 0, "loop.stage": 0, "operandSegmentSizes": [1, 0, 0], "ttg.partition": [5]}
     },
-    "op_140814080": {
+    "op_246807472": {
       "kind": "tt.splat",
       "scope": "loop:0",
-      "operands": [{"op": "op_140830160"}],
+      "operands": [{"op": "op_246816144"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>}>>"],
       "attributes": {"loop.cluster": 0, "loop.stage": 0, "ttg.partition": [5]}
     },
-    "op_140699040": {
+    "op_245857088": {
       "kind": "arith.mulf",
       "scope": "loop:0",
-      "operands": [{"op": "op_140821760"}, {"op": "op_140814080"}],
+      "operands": [{"op": "op_246807744"}, {"op": "op_246807472"}],
       "result_types": ["tensor<128xf32, #ttg.slice<{dim = 1, parent = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 5, "loop.stage": 0, "ttg.partition": [5]}
     },
-    "op_140814288": {
+    "op_246801296": {
       "kind": "tt.expand_dims",
       "scope": "loop:0",
-      "operands": [{"op": "op_140699040"}],
+      "operands": [{"op": "op_245857088"}],
       "result_types": ["tensor<128x1xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>>"],
       "attributes": {"axis": 1, "loop.cluster": 6, "loop.stage": 0, "ttg.partition": [5]}
     },
-    "op_140817856": {
+    "op_246801536": {
       "kind": "tt.broadcast",
       "scope": "loop:0",
-      "operands": [{"op": "op_140814288"}],
+      "operands": [{"op": "op_246801296"}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>>"],
       "attributes": {"loop.cluster": 6, "loop.stage": 0, "ttg.partition": [5]}
     },
-    "op_140822992": {
+    "op_246808976": {
       "kind": "ttng.tmem_load",
       "scope": "loop:0",
-      "operands": [{"op": "op_140831488", "result": 0}, {"op": "op_140145920"}],
+      "operands": [{"op": "op_246817472", "result": 0}, {"op": "op_246124896"}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>>", "!ttg.async.token"],
       "attributes": {"loop.cluster": 0, "loop.stage": 1, "resultSegmentSizes": [1, 1, 0], "ttg.partition": [5]}
     },
-    "op_139873632": {
+    "op_246793824": {
       "kind": "arith.mulf",
       "scope": "loop:0",
-      "operands": [{"op": "op_140822992", "result": 0}, {"op": "op_140817856"}],
+      "operands": [{"op": "op_246808976", "result": 0}, {"op": "op_246801536"}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 1, "loop.stage": 1, "ttg.partition": [5]}
     },
-    "op_140807840": {
+    "op_246794080": {
       "kind": "arith.addf",
       "scope": "loop:0",
-      "operands": [{"iter_arg": {"loop": 0, "idx": 0}}, {"op": "op_139873632"}],
+      "operands": [{"iter_arg": {"loop": 0, "idx": 0}}, {"op": "op_246793824"}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>>"],
       "attributes": {"fastmath": "#arith.fastmath<none>", "loop.cluster": 2, "loop.stage": 1, "ttg.partition": [5]}
     },
-    "op_140702096": {
+    "op_246691232": {
       "kind": "scf.yield",
       "scope": "loop:0",
-      "operands": [{"op": "op_140807840"}, {"op": "op_140822992", "result": 1}],
+      "operands": [{"op": "op_246794080"}, {"op": "op_246808976", "result": 1}],
       "result_types": [],
       "attributes": {}
     },
-    "op_140808112": {
+    "op_246824016": {
       "kind": "scf.for",
       "scope": "loop:1",
-      "operands": [{"const": 0, "type": "i32"}, {"op": "op_140798832"}, {"const": 1, "type": "i32"}, {"const": 0, "type": "tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>>"}, {"op": "op_140831488", "result": 1}],
+      "operands": [{"const": 0, "type": "i32"}, {"op": "op_246784816"}, {"const": 1, "type": "i32"}, {"const": 0, "type": "tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>>"}, {"op": "op_246817472", "result": 1}],
       "result_types": ["tensor<128x128xf32, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>>", "!ttg.async.token"],
-      "attributes": {"loop.cluster": 0, "loop.stage": 0, "tt.modulo_ii": 1432, "tt.num_stages": 1, "tt.scheduled_max_stage": 1, "ttg.partition": [5], "ttg.partition.stages": [0, 0, 0, 0, 0, 1], "ttg.partition_num_warps": [4, 1, 1, 1, 4, 4], "ttg.warp_specialize.tag": 0}
+      "attributes": {"loop.cluster": 0, "loop.stage": 0, "tt.modulo_ii": 1432, "tt.num_stages": 2, "tt.scheduled_max_stage": 1, "ttg.partition": [5], "ttg.partition.stages": [0, 0, 0, 0, 0, 1], "ttg.partition_num_warps": [4, 1, 1, 1, 4, 4], "ttg.warp_specialize.tag": 0}
     },
-    "op_140708064": {
+    "op_246696624": {
       "kind": "arith.truncf",
       "scope": "loop:1",
-      "operands": [{"op": "op_140808112", "result": 0}],
+      "operands": [{"op": "op_246824016", "result": 0}],
       "result_types": ["tensor<128x128xbf16, #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>>"],
       "attributes": {"loop.cluster": 0, "loop.stage": 1, "ttg.partition": [5]}
     },
-    "op_140838432": {
+    "op_246824736": {
       "kind": "ttg.convert_layout",
       "scope": "loop:1",
-      "operands": [{"op": "op_140708064"}],
+      "operands": [{"op": "op_246696624"}],
       "result_types": ["tensor<128x128xbf16, #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0]}>>"],
       "attributes": {"loop.cluster": 1, "loop.stage": 1, "ttg.partition": [5]}
     },
-    "op_140801824": {
+    "op_246787808": {
       "kind": "tt.descriptor_store",
       "scope": "loop:1",
-      "operands": [{"op": "op_140793568"}, {"op": "op_140838432"}, {"op": "op_140802720"}, {"op": "op_140802992"}],
+      "operands": [{"op": "op_246777456"}, {"op": "op_246824736"}, {"op": "op_246788704"}, {"op": "op_246788976"}],
       "result_types": [],
       "attributes": {"buffer.id": 1, "loop.cluster": 2, "loop.stage": 1, "reduce_kind": 0, "tt.num_buffers": 1, "ttg.partition": [5]}
     },
-    "op_140808400": {
+    "op_246824304": {
       "kind": "scf.yield",
       "scope": "loop:1",
       "operands": [],
       "result_types": [],
       "attributes": {}
     },
-    "op_140430416": {
+    "op_246414736": {
       "kind": "scf.for",
       "scope": "function",
-      "operands": [{"op": "op_140793984"}, {"op": "op_140798288"}, {"const": 148, "type": "i32"}],
+      "operands": [{"op": "op_246779008"}, {"op": "op_246783136"}, {"const": 148, "type": "i32"}],
       "result_types": [],
       "attributes": {"tt.modulo_ii": 45824, "tt.num_stages": 2, "tt.scheduled_max_stage": 1, "tt.warp_specialize": "unit", "ttg.partition.stages": [0, 0, 0, 0, 0, 1], "ttg.partition_num_warps": [4, 1, 1, 1, 1, 4], "ttg.warp_specialize.tag": 0}
     },
-    "op_140838560": {
+    "op_246824400": {
       "kind": "tt.return",
       "scope": "function",
       "operands": [],
@@ -462,6 +462,7 @@
       "attributes": {}
     }
   },
+  "data_partition_candidates": [],
   "loops": [
     {
       "loop_id": 0,
@@ -477,36 +478,38 @@
       "trip_count_estimated": true,
       "induction_var": {"name": "iv", "type": "i32"},
       "lower_bound": {"const": 0, "type": "i32"},
-      "upper_bound": {"op": "op_140798832"},
+      "upper_bound": {"op": "op_246784816"},
       "step": {"const": 1, "type": "i32"},
       "buffers": [
-        {"id": 0, "kind": "smem", "shape": [128, 128], "element_bits": 8, "count": 1, "size_bytes": 16384, "total_bytes": 16384, "merge_group_id": 0, "paired_buffer_id": null, "live_start": 557, "live_end": 1487, "def_op": "op_140823680"},
-        {"id": 1, "kind": "smem", "shape": [128, 128], "element_bits": 8, "count": 1, "size_bytes": 16384, "total_bytes": 16384, "merge_group_id": 1, "paired_buffer_id": null, "live_start": 587, "live_end": 1487, "def_op": "op_140825840"},
-        {"id": 2, "kind": "smem", "shape": [128], "element_bits": 32, "count": 1, "size_bytes": 512, "total_bytes": 512, "merge_group_id": 2, "paired_buffer_id": null, "live_start": 61, "live_end": 522, "def_op": null},
-        {"id": 3, "kind": "smem", "shape": [128, 128], "element_bits": 32, "count": 1, "size_bytes": 65536, "total_bytes": 65536, "merge_group_id": null, "paired_buffer_id": null, "live_start": 1487, "live_end": 1487, "def_op": null}
+        {"id": 0, "kind": "smem", "shape": [128, 128], "element_bits": 8, "count": 2, "size_bytes": 16384, "total_bytes": 32768, "merge_group_id": 0, "paired_buffer_id": 2, "live_start": 1, "live_end": 1487, "def_op": "op_246798256"},
+        {"id": 1, "kind": "smem", "shape": [128, 128], "element_bits": 8, "count": 2, "size_bytes": 16384, "total_bytes": 32768, "merge_group_id": 1, "paired_buffer_id": 3, "live_start": 31, "live_end": 1487, "def_op": "op_246809664"},
+        {"id": 2, "kind": "barrier", "shape": [], "element_bits": 16, "count": 2, "size_bytes": 8, "total_bytes": 16, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 1, "live_end": 1487, "def_op": "op_246798256"},
+        {"id": 3, "kind": "barrier", "shape": [], "element_bits": 16, "count": 2, "size_bytes": 8, "total_bytes": 16, "merge_group_id": null, "paired_buffer_id": 1, "live_start": 31, "live_end": 1487, "def_op": "op_246809664"},
+        {"id": 4, "kind": "smem", "shape": [128], "element_bits": 32, "count": 1, "size_bytes": 512, "total_bytes": 512, "merge_group_id": 2, "paired_buffer_id": null, "live_start": 61, "live_end": 522, "def_op": null},
+        {"id": 5, "kind": "smem", "shape": [128, 128], "element_bits": 32, "count": 1, "size_bytes": 65536, "total_bytes": 65536, "merge_group_id": null, "paired_buffer_id": null, "live_start": 1487, "live_end": 1487, "def_op": null}
       ],
       "graph": {
         "nodes": [
-          {"id": 0, "op_ref": "op_140819424", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": -2, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 1, "op_ref": "op_140506128", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 1, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 2, "op_ref": "op_140823680", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 0, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 557, "stage": 0, "cluster": 7}, "produces_buffer": 0, "consumes_buffers": []},
-          {"id": 3, "op_ref": "op_140462560", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 1, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 31, "stage": 0, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 4, "op_ref": "op_140825840", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 587, "stage": 0, "cluster": 8}, "produces_buffer": 1, "consumes_buffers": []},
-          {"id": 5, "op_ref": "op_140826208", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 587, "stage": 0, "cluster": 8}, "produces_buffer": null, "consumes_buffers": [1]},
-          {"id": 6, "op_ref": "op_140145920", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 2, "latency": 900, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 587, "stage": 0, "cluster": 8}, "produces_buffer": null, "consumes_buffers": [0]},
-          {"id": 7, "op_ref": "op_140823872", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 1, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 8, "op_ref": "op_140817584", "op_kind": "tt.splat", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 9, "op_ref": "op_140829760", "op_kind": "tt.addptr", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 10, "op_ref": "op_140821760", "op_kind": "tt.load", "pipeline": "TMA", "warp_group": 3, "latency": 460, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 61, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 11, "op_ref": "op_140823504", "op_kind": "tt.addptr", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 12, "op_ref": "op_140830160", "op_kind": "tt.load", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 13, "op_ref": "op_140814080", "op_kind": "tt.splat", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 14, "op_ref": "op_140699040", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 521, "stage": 0, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 15, "op_ref": "op_140814288", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 522, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 16, "op_ref": "op_140817856", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 522, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 17, "op_ref": "op_140822992", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 4, "latency": 532, "self_latency": 256, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1487, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 18, "op_ref": "op_139873632", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 4, "latency": 138, "self_latency": 128, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2019, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 19, "op_ref": "op_140807840", "op_kind": "arith.addf", "pipeline": "CUDA", "warp_group": 4, "latency": 130, "self_latency": 128, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2157, "stage": 1, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []}
+          {"id": 0, "op_ref": "op_246805408", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": -2, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 1, "op_ref": "op_246491584", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 0, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 1, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 2, "op_ref": "op_246798256", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 0, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 557, "stage": 0, "cluster": 7}, "produces_buffer": 0, "consumes_buffers": []},
+          {"id": 3, "op_ref": "op_246447792", "op_kind": "tt.descriptor_load", "pipeline": "TMA", "warp_group": 1, "latency": 556, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 31, "stage": 0, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 4, "op_ref": "op_246809664", "op_kind": "ttg.local_alloc", "pipeline": "NONE", "warp_group": 1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 587, "stage": 0, "cluster": 8}, "produces_buffer": 1, "consumes_buffers": []},
+          {"id": 5, "op_ref": "op_246812112", "op_kind": "ttg.memdesc_trans", "pipeline": "NONE", "warp_group": 2, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 587, "stage": 0, "cluster": 8}, "produces_buffer": null, "consumes_buffers": [1]},
+          {"id": 6, "op_ref": "op_246124896", "op_kind": "ttng.tc_gen5_mma", "pipeline": "TC", "warp_group": 2, "latency": 900, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 587, "stage": 0, "cluster": 8}, "produces_buffer": null, "consumes_buffers": [0]},
+          {"id": 7, "op_ref": "op_246809856", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 3, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 1, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 8, "op_ref": "op_246803504", "op_kind": "tt.splat", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 9, "op_ref": "op_246815744", "op_kind": "tt.addptr", "pipeline": "NONE", "warp_group": 3, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 10, "op_ref": "op_246807744", "op_kind": "tt.load", "pipeline": "TMA", "warp_group": 3, "latency": 460, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 61, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 11, "op_ref": "op_246809488", "op_kind": "tt.addptr", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 12, "op_ref": "op_246816144", "op_kind": "tt.load", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 13, "op_ref": "op_246807472", "op_kind": "tt.splat", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 14, "op_ref": "op_245857088", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 521, "stage": 0, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 15, "op_ref": "op_246801296", "op_kind": "tt.expand_dims", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 522, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 16, "op_ref": "op_246801536", "op_kind": "tt.broadcast", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 522, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 17, "op_ref": "op_246808976", "op_kind": "ttng.tmem_load", "pipeline": "CUDA", "warp_group": 4, "latency": 532, "self_latency": 256, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 1487, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 18, "op_ref": "op_246793824", "op_kind": "arith.mulf", "pipeline": "CUDA", "warp_group": 4, "latency": 138, "self_latency": 128, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2019, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 19, "op_ref": "op_246794080", "op_kind": "arith.addf", "pipeline": "CUDA", "warp_group": 4, "latency": 130, "self_latency": 128, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 2157, "stage": 1, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []}
         ],
         "edges": [
           {"src": 0, "dst": 1, "kind": "data", "distance": 0, "latency": 1},
@@ -533,11 +536,11 @@
           {"src": 17, "dst": 6, "kind": "data", "distance": 1, "latency": 532}
         ],
         "cross_wg_barriers": [
-          {"producer_node": 4, "consumer_node": 5, "producer_wg": 1, "consumer_wg": 2, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 1, "expect_bytes": 16384},
-          {"producer_node": 2, "consumer_node": 6, "producer_wg": 0, "consumer_wg": 2, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 0, "expect_bytes": 16384},
-          {"producer_node": 10, "consumer_node": 14, "producer_wg": 3, "consumer_wg": 4, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 2, "expect_bytes": 512},
+          {"producer_node": 4, "consumer_node": 5, "producer_wg": 1, "consumer_wg": 2, "kind": "mbarrier", "depth": 2, "paired_buffer_id": 1, "expect_bytes": 16384},
+          {"producer_node": 2, "consumer_node": 6, "producer_wg": 0, "consumer_wg": 2, "kind": "mbarrier", "depth": 2, "paired_buffer_id": 0, "expect_bytes": 16384},
+          {"producer_node": 10, "consumer_node": 14, "producer_wg": 3, "consumer_wg": 4, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 4, "expect_bytes": 512},
           {"producer_node": 6, "consumer_node": 17, "producer_wg": 2, "consumer_wg": 4, "kind": "named", "depth": 1, "paired_buffer_id": null, "expect_bytes": 0},
-          {"producer_node": 17, "consumer_node": 6, "producer_wg": 4, "consumer_wg": 2, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 3, "expect_bytes": 65536}
+          {"producer_node": 17, "consumer_node": 6, "producer_wg": 4, "consumer_wg": 2, "kind": "mbarrier", "depth": 1, "paired_buffer_id": 5, "expect_bytes": 65536}
         ]
       }
     }
@@ -555,30 +558,30 @@
       "trip_count": 4,
       "trip_count_estimated": true,
       "induction_var": {"name": "iv", "type": "i32"},
-      "lower_bound": {"op": "op_140793984"},
-      "upper_bound": {"op": "op_140798288"},
+      "lower_bound": {"op": "op_246779008"},
+      "upper_bound": {"op": "op_246783136"},
       "step": {"const": 148, "type": "i32"},
       "buffers": [
-        {"id": 0, "kind": "tmem", "shape": [128, 128], "element_bits": 32, "count": 2, "size_bytes": 65536, "total_bytes": 131072, "merge_group_id": 0, "paired_buffer_id": 2, "live_start": 0, "live_end": 45824, "def_op": "op_140831488"},
-        {"id": 1, "kind": "smem", "shape": [128, 128], "element_bits": 16, "count": 1, "size_bytes": 32768, "total_bytes": 32768, "merge_group_id": null, "paired_buffer_id": null, "live_start": 46034, "live_end": 46034, "def_op": "op_140801824"},
-        {"id": 2, "kind": "barrier", "shape": [], "element_bits": 16, "count": 2, "size_bytes": 8, "total_bytes": 16, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 0, "live_end": 45824, "def_op": "op_140831488"}
+        {"id": 0, "kind": "tmem", "shape": [128, 128], "element_bits": 32, "count": 2, "size_bytes": 65536, "total_bytes": 131072, "merge_group_id": 0, "paired_buffer_id": 2, "live_start": 0, "live_end": 45824, "def_op": "op_246817472"},
+        {"id": 1, "kind": "smem", "shape": [128, 128], "element_bits": 16, "count": 1, "size_bytes": 32768, "total_bytes": 32768, "merge_group_id": null, "paired_buffer_id": null, "live_start": 46034, "live_end": 46034, "def_op": "op_246787808"},
+        {"id": 2, "kind": "barrier", "shape": [], "element_bits": 16, "count": 2, "size_bytes": 8, "total_bytes": 16, "merge_group_id": null, "paired_buffer_id": 0, "live_start": 0, "live_end": 45824, "def_op": "op_246817472"}
       ],
       "graph": {
         "nodes": [
-          {"id": 0, "op_ref": "op_140802176", "op_kind": "arith.divsi", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 64, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 1, "op_ref": "op_140802448", "op_kind": "arith.remsi", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 65, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 2, "op_ref": "op_140802720", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 66, "stage": 0, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 3, "op_ref": "op_140802992", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 67, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 4, "op_ref": "op_140803264", "op_kind": "tt.splat", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 67, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 5, "op_ref": "op_140803504", "op_kind": "arith.addi", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 68, "stage": 0, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 6, "op_ref": "op_140803776", "op_kind": "tt.addptr", "pipeline": "NONE", "warp_group": -1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 69, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 7, "op_ref": "op_140804048", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": -1, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 69, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 8, "op_ref": "op_140805872", "op_kind": "tt.addptr", "pipeline": "NONE", "warp_group": -1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 70, "stage": 0, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 9, "op_ref": "op_140831488", "op_kind": "ttng.tmem_alloc", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": 0, "consumes_buffers": []},
-          {"id": 10, "op_ref": "op_140808112", "op_kind": "scf.for", "pipeline": "NONE", "warp_group": 4, "latency": 45824, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": [0], "child_pipeline_id": 1, "prologue_latency": 587},
-          {"id": 11, "op_ref": "op_140708064", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 4, "latency": 105, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 45824, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 12, "op_ref": "op_140838432", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "warp_group": 4, "latency": 105, "self_latency": 105, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 45929, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
-          {"id": 13, "op_ref": "op_140801824", "op_kind": "tt.descriptor_store", "pipeline": "TMA", "warp_group": 4, "latency": 1794, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 46034, "stage": 1, "cluster": 2}, "produces_buffer": 1, "consumes_buffers": []}
+          {"id": 0, "op_ref": "op_246788160", "op_kind": "arith.divsi", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 64, "stage": 0, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 1, "op_ref": "op_246788432", "op_kind": "arith.remsi", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 65, "stage": 0, "cluster": 2}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 2, "op_ref": "op_246788704", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 66, "stage": 0, "cluster": 3}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 3, "op_ref": "op_246788976", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 67, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 4, "op_ref": "op_246789248", "op_kind": "tt.splat", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 67, "stage": 0, "cluster": 4}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 5, "op_ref": "op_246789488", "op_kind": "arith.addi", "pipeline": "CUDA", "warp_group": 4, "latency": 1, "self_latency": 1, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 68, "stage": 0, "cluster": 5}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 6, "op_ref": "op_246789760", "op_kind": "tt.addptr", "pipeline": "NONE", "warp_group": -1, "latency": 0, "self_latency": 0, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 69, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 7, "op_ref": "op_246790032", "op_kind": "arith.muli", "pipeline": "CUDA", "warp_group": -1, "latency": 1, "self_latency": 1, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 69, "stage": 0, "cluster": 6}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 8, "op_ref": "op_246791856", "op_kind": "tt.addptr", "pipeline": "NONE", "warp_group": -1, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 70, "stage": 0, "cluster": 7}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 9, "op_ref": "op_246817472", "op_kind": "ttng.tmem_alloc", "pipeline": "NONE", "warp_group": 4, "latency": 0, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": 0, "consumes_buffers": []},
+          {"id": 10, "op_ref": "op_246824016", "op_kind": "scf.for", "pipeline": "NONE", "warp_group": 4, "latency": 45824, "self_latency": 0, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 0, "stage": 0, "cluster": 0}, "produces_buffer": null, "consumes_buffers": [0], "child_pipeline_id": 1, "prologue_latency": 587},
+          {"id": 11, "op_ref": "op_246696624", "op_kind": "arith.truncf", "pipeline": "CUDA", "warp_group": 4, "latency": 105, "self_latency": 64, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 45824, "stage": 1, "cluster": 0}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 12, "op_ref": "op_246824736", "op_kind": "ttg.convert_layout", "pipeline": "CUDA", "warp_group": 4, "latency": 105, "self_latency": 105, "min_warps": 4, "frequency_multiplier": 1, "schedule": {"cycle": 45929, "stage": 1, "cluster": 1}, "produces_buffer": null, "consumes_buffers": []},
+          {"id": 13, "op_ref": "op_246787808", "op_kind": "tt.descriptor_store", "pipeline": "TMA", "warp_group": 4, "latency": 1794, "self_latency": 30, "min_warps": 1, "frequency_multiplier": 1, "schedule": {"cycle": 46034, "stage": 1, "cluster": 2}, "produces_buffer": 1, "consumes_buffers": []}
         ],
         "edges": [
           {"src": 0, "dst": 2, "kind": "data", "distance": 0, "latency": 1},


### PR DESCRIPTION
Summary:

A warp-specialized GEMM streams its A/B tiles through a ring of SMEM buffers: the loader fills them, the tensor core drains them. The modulo scheduler decides how many buffers that ring needs, and it was picking too few -- a GEMM that wants ~5-6 buffers got 3, so the tensor core kept stalling on memory (~15-20% left on the table).

The rule for ring depth is:

    buffers = ceil(buffer_lifetime / II) + 1

(II = how often a new loop iteration starts.) The bug was in what "buffer_lifetime" means. It started the clock when the loaded data is READY:

    before:  lifetime = (tensor core done) - (data ready)     ->  589 / 256  ->  3 buffers

But a TMA load is asynchronous and multi-outstanding -- several transfers are in flight at once, and a buffer slot is occupied from the moment its load is FIRED, not when the data lands. The whole transfer time is part of the slot's life. Counting it:

    after:   lifetime = (tensor core done) - (load issued)    -> 1145 / 256  ->  5 buffers

That is the core design change: measure a buffer's life from load-issue, not data-ready, so each overlapping in-flight transfer gets its own slot. Deeper rings let the loader run ahead and hide memory latency. II itself is unchanged.

Deeper rings can now exceed the SMEM budget, which surfaced a chain of budget-reduction fixes:
- The budget check was collapsing an over-budget ring all the way to a single, un-pipelined buffer (it decremented the logical count but never refreshed the physical merge-group footprint the check reads). It now caps to the largest depth that still fits and stays pipelined.
- (review) The post-reduction II is now solved by fixed-point iteration: a loop-carried consumer's lifetime grows with II (it includes distance*II), so a single ceil(lifetime/depth) pass under-estimated II and could reuse a slot before that consumer finished.
- (review) Reduction is now atomic over a buffer's co-consumed and merge-group peers, so the footprint actually drops and the equal-count invariant that reuse= aliasing relies on is preserved, instead of hammering one member down to depth 1.

Regenerates the sched2tlx example fixtures (generated.py + schedule_graph.json) for case1/2/3/4/6/7/9 to reflect the deeper rings (case1 3->5, case2 3->5, case3 buf1 1->2, case4 3->4, case7 3->5, case9 1->2; case6 unchanged), all correctness-validated on B200. Updates the modulo-schedule LIT tests for the deeper rings and adds budget-reduction regression tests (loop-carried II, co-consumed group). Also hardens case9's hand-written reference (local `get_bufidx_phase`). Design rationale in `docs/design/modulo_schedule/buffer_depth_model.md`.

case5 is excluded: its deeper rings flip it into the epilogue-subtile path, which hits a pre-existing addmm subtile emitter bug (tracked separately), so it keeps its committed fixtures.

Authored with Claude.

Reviewed By: mark14wu

Differential Revision: D113369274


