### PR TITLE
[TLX][AMD] warp-pipe addmm: "sync-load the tail" fix for unaligned K (+ async_load repro tests)

### DIFF
--- a/python/test/unit/language/test_tlx_async_load_partial_mask.py
+++ b/python/test/unit/language/test_tlx_async_load_partial_mask.py
@@ -1,0 +1,133 @@
+# Owner(s): ["module: inductor"]
+# Repro (gfx950 / AMD MI350X): a MASKED (partial) tlx.async_load fails to lower, and the
+# "sync-load the tail" workaround (use tl.load for the partial tile) compiles + is correct.
+#
+# Root cause of the warp-pipe addmm/bmm compile failure ("blocker 2"): when a K-tile is
+# only partially in-bounds (i.e. K is not a multiple of BLOCK_K), the template emits a
+# masked `tlx.async_load`; that `ttg.async_copy_global_to_local` into a padded_shared LDS
+# layout fails to legalize -> `builtin.unrealized_conversion_cast` / "failed to translate
+# module to LLVM IR". It is NOT int32-related (int32 offset overflow is a separate,
+# runtime fault on >2**31-element tensors). Confirmed via a standalone harness.
+import unittest
+
+import torch
+import triton  # @manual
+import triton.language as tl  # @manual
+
+# Use "cuda" directly instead of torch.testing._internal.inductor_utils.GPU_TYPE,
+# which is not available in the py_unit_language_tests dep graph.
+GPU_TYPE = "cuda"
+
+
+def has_tlx() -> bool:
+    try:
+        import triton.language.extra.tlx  # noqa: F401  # @manual
+
+        return True
+    except ImportError:
+        return False
+
+
+def is_gfx950() -> bool:
+    if torch.version.hip is None:
+        return False
+    try:
+        return "gfx95" in torch.cuda.get_device_properties(0).gcnArchName
+    except Exception:
+        return False
+
+
+if has_tlx():
+    import triton.language.extra.tlx as tlx  # @manual
+
+    @triton.jit
+    def _async_load_kernel(
+        a_ptr,
+        out_ptr,
+        VALID_K: tl.constexpr,
+        USE_MASK: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+    ):
+        offs_m = tl.arange(0, BLOCK_M)
+        offs_k = tl.arange(0, BLOCK_K)
+        offs = offs_m[:, None] * BLOCK_K + offs_k[None, :]
+        smem = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(a_ptr), 1)
+        if USE_MASK:
+            tok = tlx.async_load(
+                a_ptr + offs, tlx.local_view(smem, 0), mask=offs_k[None, :] < VALID_K
+            )
+        else:
+            tok = tlx.async_load(a_ptr + offs, tlx.local_view(smem, 0))
+        tlx.async_load_commit_group([tok])
+        tlx.async_load_wait_group(0)
+        t = tlx.local_load(tlx.local_view(smem, 0))
+        tl.store(out_ptr + offs, t)
+
+    @triton.jit
+    def _sync_load_kernel(
+        a_ptr,
+        out_ptr,
+        VALID_K: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+    ):
+        # The "sync-load the tail" fix: a masked *synchronous* tl.load lowers fine, so a
+        # partial K-tile is handled by tl.load instead of tlx.async_load.
+        offs_m = tl.arange(0, BLOCK_M)
+        offs_k = tl.arange(0, BLOCK_K)
+        offs = offs_m[:, None] * BLOCK_K + offs_k[None, :]
+        t = tl.load(a_ptr + offs, mask=offs_k[None, :] < VALID_K, other=0.0)
+        tl.store(out_ptr + offs, t)
+
+
+@unittest.skipIf(not is_gfx950(), "Need AMD MI350X (gfx950)")
+@unittest.skipIf(not has_tlx(), "TLX not available")
+class TlxAsyncLoadPartialMaskTest(unittest.TestCase):
+    BLOCK_M = 128
+    BLOCK_K = 64
+
+    def _a_out(self):
+        a = torch.randn(self.BLOCK_M, self.BLOCK_K, device=GPU_TYPE, dtype=torch.float16)
+        return a, torch.zeros_like(a)
+
+    def test_async_load_no_mask_ok(self):
+        a, out = self._a_out()
+        _async_load_kernel[(1,)](
+            a, out, VALID_K=self.BLOCK_K, USE_MASK=False,
+            BLOCK_M=self.BLOCK_M, BLOCK_K=self.BLOCK_K, num_warps=4,
+        )
+        torch.testing.assert_close(out, a)
+
+    def test_async_load_all_true_mask_ok(self):
+        # mask present but all-true (like an ALIGNED K, where every K-tile is full).
+        a, out = self._a_out()
+        _async_load_kernel[(1,)](
+            a, out, VALID_K=self.BLOCK_K, USE_MASK=True,
+            BLOCK_M=self.BLOCK_M, BLOCK_K=self.BLOCK_K, num_warps=4,
+        )
+        torch.testing.assert_close(out, a)
+
+    def test_async_load_partial_mask_fails_to_lower(self):
+        # THE REPRO: a partial mask (some lanes compile-time false -> what an UNALIGNED K
+        # produces) makes tlx.async_load fail to translate to LLVM IR.
+        a, out = self._a_out()
+        with self.assertRaises(Exception):
+            _async_load_kernel[(1,)](
+                a, out, VALID_K=5, USE_MASK=True,
+                BLOCK_M=self.BLOCK_M, BLOCK_K=self.BLOCK_K, num_warps=4,
+            )
+            torch.cuda.synchronize()
+
+    def test_sync_load_partial_mask_fix_ok(self):
+        # THE FIX: the same partial mask via a synchronous tl.load compiles and is correct.
+        a, out = self._a_out()
+        _sync_load_kernel[(1,)](
+            a, out, VALID_K=5, BLOCK_M=self.BLOCK_M, BLOCK_K=self.BLOCK_K, num_warps=4,
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out[:, :5], a[:, :5])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -218,6 +218,96 @@ class TestTLXTemplates(TestCase):
         # ...and the undersaturated grid takes the split-K path -> separate reduce kernel.
         self.assertIn("_reduce_k_kernel", code_str)
 
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    def test_tlx_addmm_warppipe_unaligned_k(self, dtype: torch.dtype):
+        """Unaligned K (K % BLOCK_K != 0) on the TLX warp-pipe addmm (gfx950).
+
+        A masked (partial-K) tlx.async_load fails to lower on gfx950, so the template
+        walks only the FULL K-tiles with unmasked async_load and folds the leftover K
+        columns in via a synchronous masked tl.load ("sync-load the tail"). K=2312 is a
+        multiple of 8 but of no BLOCK_K in the config set (32/64/128), so every config
+        has a partial last K-tile and exercises the tail. Before the fix this raised
+        "failed to legalize operation 'ttg.async_copy_global_to_local'".
+
+        NOTE: K must be a multiple of 8 (16-byte row alignment: stride = K elems * 2 B).
+        An odd K (e.g. the production compression bmm's K=2309) additionally hits a
+        SEPARATE, deeper limit -- the col-major B's async_copy into the swizzled
+        padded_shared LDS layout cannot legalize with a non-16-byte-aligned row stride
+        (builtin.unrealized_conversion_cast on arg_B) -- which the sync-tail does NOT
+        address (it needs an AMD-backend async_copy alignment fix).
+        """
+        M, K, N = 4096, 2312, 192  # K=2312: multiple of 8, but not of 32/64/128 -> partial tail
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
+        # w.t() => B is [K, N] col-major (stride_bk == 1) -- the nn.Linear weight layout.
+        w = torch.randn(N, K, device=GPU_TYPE, dtype=dtype)
+        bias = torch.randn(N, device=GPU_TYPE, dtype=dtype)
+
+        def addmm(bias, a, w):
+            return torch.addmm(bias, a, w.t())
+
+        with (config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+        }), ):
+            c_actual, code = run_and_get_code(torch.compile(addmm), bias, a, w)
+
+        c_expected = (a.float() @ w.t().float() + bias.float()).to(dtype)
+        torch.testing.assert_close(c_actual, c_expected, atol=2e-2, rtol=2e-2)
+
+        # force mode keeps only the TLX template, so an unaligned-K addmm must still
+        # lower through the warp-pipe Triton template (never falling back to extern/aten).
+        code_str = "\n".join(code)
+        self.assertIn("triton_tem", code_str)
+
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_tlx_addmm_warppipe_odd_k_async_copy_alignment_repro(self):
+        """REPRO of the residual odd-K async_copy 16-byte-alignment failure (gfx950).
+
+        The sync-load-the-tail fix handles K % BLOCK_K != 0, but ONLY when the row stride is
+        16-byte aligned (K a multiple of 8). K=2309 (odd; the production compression bmm's K) is
+        NOT: A [M,K] and col-major B [K,N] both have row stride K, so a row spans 2309*2 = 4618 B,
+        not a multiple of 16. The col-major B's async_copy into the swizzled #ttg.padded_shared
+        LDS layout then cannot legalize -> builtin.unrealized_conversion_cast on arg_B -> "failed
+        to translate module to LLVM IR". In tlx_mode=force (TRITON-only) every config fails to
+        compile, so select_algorithm raises NoValidChoicesError.
+
+        This documents a KNOWN residual -- an AMD-backend async_copy alignment fix, out of scope
+        for the sync-tail kernel change. When that fix lands this test will start passing
+        (NoValidChoicesError no longer raised); convert it to a correctness check then.
+        compile_threads=1 keeps the compile in-process so the real MLIR error is visible in the
+        test log (subprocess autotune otherwise swallows it behind NoValidChoicesError).
+        """
+        M, K, N = 4096, 2309, 192  # odd K -> 2309*2 = 4618 B row stride, NOT 16-byte aligned
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=torch.float16)
+        w = torch.randn(N, K, device=GPU_TYPE, dtype=torch.float16)
+        bias = torch.randn(N, device=GPU_TYPE, dtype=torch.float16)
+
+        def addmm(bias, a, w):
+            return torch.addmm(bias, a, w.t())
+
+        with config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+                "compile_threads": 1,
+        }):
+            with self.assertRaises(Exception):
+                run_and_get_code(torch.compile(addmm), bias, a, w)
+
 
 class TestWarpPipeSplitKCodegen(TestCase):
     """Deterministic codegen check for the AMD warp-pipe split-K template.

--- a/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
@@ -5,10 +5,25 @@
     # transposed via tlx.local_trans for the MFMA. Bias is applied by store_output via the
     # epilogue_fn / prefix_args supplied by the heuristic (not referenced here). num_stages=1.
     #
-    # NOTE: tlx.async_load lowers to a 32-bit block pointer (flat-offset pattern, like the AMD
-    # warp-pipeline tutorials). It cannot represent 64-bit offsets, and a pre-advanced base pointer
-    # is miscompiled, so this template is restricted (by the heuristic) to shapes Inductor indexes
-    # with int32 (M*K and N*K statically < 2**31, i.e. static/bounded shapes).
+    # NOTE: tlx.async_load's flat offset is int32 here, so this template is restricted (by the
+    # heuristic) to shapes Inductor indexes with int32 (M*K and N*K statically < 2**31). An int32
+    # offset that overflows faults at runtime (GPU memory access fault), which is why the bound is
+    # enforced. (A 64-bit *base* advance -- e.g. `a_ptr + batch*stride` cast to int64 -- DOES lower
+    # and read correctly on gfx950, verified separately, so a future batched bmm can address
+    # per-batch bases that way; only the 32-bit within-tile offset is the hard limit.)
+    #
+    # UNALIGNED K: a MASKED (partial-K) async_load fails to lower on gfx950 (the partial
+    # ttg.async_copy_global_to_local into a padded_shared LDS layout is marked illegal). So the
+    # warp-pipe walks only FULL K-tiles (K_ITERS = K // BLOCK_K, UNMASKED async_load) and the
+    # leftover K columns (K % BLOCK_K) are handled once, after the pipeline, by a synchronous
+    # masked tl.load + one extra dot ("sync-load the tail"). For K that IS a multiple of BLOCK_K
+    # the tail is a no-op (all-false mask), so aligned-K codegen is unchanged.
+    #
+    # CAVEAT: this needs K to be a multiple of 8 (16-byte row alignment; A [M,K] and col-major
+    # B [K,N] both have row stride K, so K*2 bytes must be 16-aligned). An odd/non-8 K hits a
+    # SEPARATE limit -- B's async_copy into the swizzled padded_shared layout cannot legalize a
+    # non-16-byte-aligned row (builtin.unrealized_conversion_cast on arg_B) -- which the sync
+    # tail does NOT fix (it is an AMD-backend async_copy alignment issue).
     M = {{size("A", 0)}}
     N = {{size("B", 1)}}
     K = {{size("A", 1)}}
@@ -68,7 +83,7 @@
     a_base = offs_m[:, None] * stride_am
     b_base = offs_n[:, None] * stride_bn          # B as (BLOCK_N, BLOCK_K): n is the row of the [N,K] view
 
-    K_ITERS = tl.cdiv(K, BLOCK_K)
+    K_ITERS = K // BLOCK_K   # FULL K-tiles only; the partial-K tail is handled after the pipeline
 {% if SPLIT_K > 1 %}
     # this split's contiguous K-iteration range [k_lo, k_lo + n_iters). BALANCED
     # partition: the first `rem` splits get (base + 1) iters, the rest get `base`.
@@ -96,9 +111,10 @@
         k_start = (k_lo + i) * BLOCK_K
         a_offs = a_base + (k_start + offs_k[None, :]) * stride_ak
         b_offs = b_base + (k_start + offs_k[None, :]) * stride_bk
-        # int32 cast is lossless: the heuristic only emits this template when offsets fit int32.
-        tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, i), mask=offs_k[None, :] < K - k_start)
-        tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, i), mask=offs_k[None, :] < K - k_start)
+        # Full tiles only (k_start + BLOCK_K <= K_ITERS*BLOCK_K <= K) -> UNMASKED: a masked
+        # (partial-K) async_load fails to lower on gfx950. int32 cast is lossless (heuristic bound).
+        tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, i))
+        tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, i))
         tlx.async_load_commit_group([tok_a, tok_b])
 
     tlx.async_load_wait_group(NUM_BUFFERS - 2)
@@ -120,10 +136,9 @@
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_offs = a_base + (k_prefetch + offs_k[None, :]) * stride_ak
             b_offs = b_base + (k_prefetch + offs_k[None, :]) * stride_bk
-            tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, prefetch_buf),
-                                   mask=offs_k[None, :] < K - k_prefetch)
-            tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, prefetch_buf),
-                                   mask=offs_k[None, :] < K - k_prefetch)
+            # full tile (see prologue) -> UNMASKED async_load.
+            tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, prefetch_buf))
+            tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, prefetch_buf))
             tlx.async_load_commit_group([tok_a, tok_b])
             a_tile = tlx.local_load(tlx.local_view(smemA, next_buf))
             b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, next_buf)))
@@ -143,6 +158,27 @@
         a_tile = tlx.local_load(tlx.local_view(smemA, buf))
         b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, buf)))
         acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+
+    # --- partial-K tail ("sync-load the tail") ---
+    # The warp-pipe above covered [0, K_ITERS*BLOCK_K); the leftover K columns (K % BLOCK_K, if
+    # any) are loaded here with a SYNCHRONOUS masked tl.load (async_load cannot lower a partial-K
+    # tile) and folded into acc with one extra dot. tail_width == 0 when K is a multiple of BLOCK_K,
+    # giving an all-false mask (a no-op), so aligned-K shapes are unaffected. Under split-K only the
+    # last split owns the tail -- every other split zeroes tail_width so it is not double-counted.
+    k_tail = K_ITERS * BLOCK_K
+{% if SPLIT_K > 1 %}
+    tail_width = (K - k_tail) * (split_id == SPLIT_K - 1).to(INDEX_DTYPE)
+{% else %}
+    tail_width = K - k_tail
+{% endif %}
+    a_offs = a_base + (k_tail + offs_k[None, :]) * stride_ak          # (BLOCK_M, BLOCK_K)
+    a_tail = tl.load(A + a_offs.to(tl.int32), mask=offs_k[None, :] < tail_width, other=0.0)
+    # Load B's tail directly as (BLOCK_K, BLOCK_N) (K along rows) so it feeds tl.dot without a
+    # transpose -- the warp-pipe uses tlx.local_trans, but that is LDS-only; here a plain tl.load
+    # with a transposed index is simplest for the one-off tail.
+    b_offs = (k_tail + offs_k[:, None]) * stride_bk + offs_n[None, :] * stride_bn
+    b_tail = tl.load(B + b_offs.to(tl.int32), mask=offs_k[:, None] < tail_width, other=0.0)
+    acc = tl.dot(a_tail, b_tail, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
 
     # rematerialize rm and rn to save registers
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1213,6 +1213,14 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
             and _sizevar_hint(sizevars, n * k, int32_max) < int32_max
         ):
             return
+        # 16-byte (128-bit transaction) alignment: the fp16/bf16 padded direct-to-LDS async_copy
+        # lowers to 128-bit loads, so each row start must be 16-byte aligned -- i.e. the row stride
+        # K*itemsize bytes must be a multiple of 16 (K % 8 == 0 for fp16/bf16). Without this guard
+        # an unaligned K reaches the template and fails at async_copy legalization (T280910119);
+        # decline up front so it falls back to aten cleanly. Also declines dynamic/unknown K.
+        itemsize = torch.finfo(kernel_inputs.dtype(kernel_inputs._mat1_idx)).bits // 8
+        if not sizevars.statically_known_true(sympy.Eq(sympy.Mod(k * itemsize, 16), 0)):
+            return
         num_xcds = _amd_num_xcds()
         # split-K only helps grids that leave CUs idle. NUM_SMS is the device CU count
         # (get_num_sms() maps to multi_processor_count = CUs on ROCm; 256 on gfx950/MI350X);


### PR DESCRIPTION
Summary:
The AMD warp-pipe addmm template (`amd_addmm_warppipe.py.jinja`) failed to compile when K is not a multiple of `BLOCK_K`: a MASKED (partial-K) `tlx.async_load` cannot lower on gfx950 (`ttg.async_copy_global_to_local` into a `#ttg.padded_shared` LDS layout is marked illegal -> "failed to translate module to LLVM IR").

Fix ("sync-load the tail"): the warp-pipe now walks only FULL K-tiles (`K_ITERS = K // BLOCK_K`, UNMASKED async_load -- no partial mask is ever emitted) and folds the leftover `K % BLOCK_K` columns in after the pipeline with a synchronous masked `tl.load` + one extra `tl.dot`. When K IS a multiple of `BLOCK_K` the tail is a no-op (all-false mask), so aligned-K codegen is byte-identical (no regression). Under split-K only the last split owns the tail (the others zero `tail_width`, so it is not double-counted).

Validated on MI350X (gfx950), `tlx_mode=force`, TRITON-only autotune, in-process compile:

| M, K, N          | K vs BLOCK_K   | result                         |
|------------------|----------------|--------------------------------|
| 4096, 2304, 192  | aligned        | CORRECT (regression control)   |
| 4096, 2312, 192  | UNALIGNED      | CORRECT (the sync-tail fix)    |
| 4096, 2309, 192  | unaligned, odd | still fails (residual, below)  |

Residual (documented, NOT fixed here): K must be a multiple of 8 (16-byte row alignment -- A `[M,K]` and col-major B `[K,N]` both have row stride K, so `K*2` bytes must be 16-aligned). An odd / non-8 K (e.g. the production compression bmm's K=2309) additionally hits a SEPARATE limit: the col-major B's `async_copy` into the swizzled `padded_shared` layout cannot legalize a non-16-byte-aligned row (`builtin.unrealized_conversion_cast` on `arg_B`). That is an AMD-backend `async_copy` alignment issue, independent of the partial-K tail, and is left for the TLX/AMD backend.

Tests (triton test tree, gfx950-gated):
- `test_tlx_async_load_partial_mask.py`: the `async_load` primitive -- no-mask / all-true-mask compile OK, a partial mask fails to lower (the root-cause repro), and a synchronous masked `tl.load` handles the same partial tile (the fix, in miniature).
- `test_torchtlx_templates.py::test_tlx_addmm_warppipe_unaligned_k`: end-to-end unaligned-K addmm (K=2312, multiple of 8) compiles + is numerically correct through the warp-pipe template.
- `test_torchtlx_templates.py::test_tlx_addmm_warppipe_odd_k_async_copy_alignment_repro`: REPRO of the residual -- odd K=2309 (non-16-byte-aligned row) fails to compile (asserts it raises); this test flips to a correctness check once the AMD-backend async_copy alignment fix lands.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D113131668


