### PR TITLE
[TLX][AMD] warp-pipe bmm Inductor template (baseline for aten.bmm autotune)

### DIFF
--- a/python/test/unit/language/test_tlx_async_load_partial_mask.py
+++ b/python/test/unit/language/test_tlx_async_load_partial_mask.py
@@ -1,0 +1,133 @@
+# Owner(s): ["module: inductor"]
+# Repro (gfx950 / AMD MI350X): a MASKED (partial) tlx.async_load fails to lower, and the
+# "sync-load the tail" workaround (use tl.load for the partial tile) compiles + is correct.
+#
+# Root cause of the warp-pipe addmm/bmm compile failure ("blocker 2"): when a K-tile is
+# only partially in-bounds (i.e. K is not a multiple of BLOCK_K), the template emits a
+# masked `tlx.async_load`; that `ttg.async_copy_global_to_local` into a padded_shared LDS
+# layout fails to legalize -> `builtin.unrealized_conversion_cast` / "failed to translate
+# module to LLVM IR". It is NOT int32-related (int32 offset overflow is a separate,
+# runtime fault on >2**31-element tensors). Confirmed via a standalone harness.
+import unittest
+
+import torch
+import triton  # @manual
+import triton.language as tl  # @manual
+
+# Use "cuda" directly instead of torch.testing._internal.inductor_utils.GPU_TYPE,
+# which is not available in the py_unit_language_tests dep graph.
+GPU_TYPE = "cuda"
+
+
+def has_tlx() -> bool:
+    try:
+        import triton.language.extra.tlx  # noqa: F401  # @manual
+
+        return True
+    except ImportError:
+        return False
+
+
+def is_gfx950() -> bool:
+    if torch.version.hip is None:
+        return False
+    try:
+        return "gfx95" in torch.cuda.get_device_properties(0).gcnArchName
+    except Exception:
+        return False
+
+
+if has_tlx():
+    import triton.language.extra.tlx as tlx  # @manual
+
+    @triton.jit
+    def _async_load_kernel(
+        a_ptr,
+        out_ptr,
+        VALID_K: tl.constexpr,
+        USE_MASK: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+    ):
+        offs_m = tl.arange(0, BLOCK_M)
+        offs_k = tl.arange(0, BLOCK_K)
+        offs = offs_m[:, None] * BLOCK_K + offs_k[None, :]
+        smem = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(a_ptr), 1)
+        if USE_MASK:
+            tok = tlx.async_load(
+                a_ptr + offs, tlx.local_view(smem, 0), mask=offs_k[None, :] < VALID_K
+            )
+        else:
+            tok = tlx.async_load(a_ptr + offs, tlx.local_view(smem, 0))
+        tlx.async_load_commit_group([tok])
+        tlx.async_load_wait_group(0)
+        t = tlx.local_load(tlx.local_view(smem, 0))
+        tl.store(out_ptr + offs, t)
+
+    @triton.jit
+    def _sync_load_kernel(
+        a_ptr,
+        out_ptr,
+        VALID_K: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+    ):
+        # The "sync-load the tail" fix: a masked *synchronous* tl.load lowers fine, so a
+        # partial K-tile is handled by tl.load instead of tlx.async_load.
+        offs_m = tl.arange(0, BLOCK_M)
+        offs_k = tl.arange(0, BLOCK_K)
+        offs = offs_m[:, None] * BLOCK_K + offs_k[None, :]
+        t = tl.load(a_ptr + offs, mask=offs_k[None, :] < VALID_K, other=0.0)
+        tl.store(out_ptr + offs, t)
+
+
+@unittest.skipIf(not is_gfx950(), "Need AMD MI350X (gfx950)")
+@unittest.skipIf(not has_tlx(), "TLX not available")
+class TlxAsyncLoadPartialMaskTest(unittest.TestCase):
+    BLOCK_M = 128
+    BLOCK_K = 64
+
+    def _a_out(self):
+        a = torch.randn(self.BLOCK_M, self.BLOCK_K, device=GPU_TYPE, dtype=torch.float16)
+        return a, torch.zeros_like(a)
+
+    def test_async_load_no_mask_ok(self):
+        a, out = self._a_out()
+        _async_load_kernel[(1,)](
+            a, out, VALID_K=self.BLOCK_K, USE_MASK=False,
+            BLOCK_M=self.BLOCK_M, BLOCK_K=self.BLOCK_K, num_warps=4,
+        )
+        torch.testing.assert_close(out, a)
+
+    def test_async_load_all_true_mask_ok(self):
+        # mask present but all-true (like an ALIGNED K, where every K-tile is full).
+        a, out = self._a_out()
+        _async_load_kernel[(1,)](
+            a, out, VALID_K=self.BLOCK_K, USE_MASK=True,
+            BLOCK_M=self.BLOCK_M, BLOCK_K=self.BLOCK_K, num_warps=4,
+        )
+        torch.testing.assert_close(out, a)
+
+    def test_async_load_partial_mask_fails_to_lower(self):
+        # THE REPRO: a partial mask (some lanes compile-time false -> what an UNALIGNED K
+        # produces) makes tlx.async_load fail to translate to LLVM IR.
+        a, out = self._a_out()
+        with self.assertRaises(Exception):
+            _async_load_kernel[(1,)](
+                a, out, VALID_K=5, USE_MASK=True,
+                BLOCK_M=self.BLOCK_M, BLOCK_K=self.BLOCK_K, num_warps=4,
+            )
+            torch.cuda.synchronize()
+
+    def test_sync_load_partial_mask_fix_ok(self):
+        # THE FIX: the same partial mask via a synchronous tl.load compiles and is correct.
+        a, out = self._a_out()
+        _sync_load_kernel[(1,)](
+            a, out, VALID_K=5, BLOCK_M=self.BLOCK_M, BLOCK_K=self.BLOCK_K, num_warps=4,
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out[:, :5], a[:, :5])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -308,6 +308,43 @@ class TestTLXTemplates(TestCase):
             with self.assertRaises(Exception):
                 run_and_get_code(torch.compile(addmm), bias, a, w)
 
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX warp-pipe bmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    def test_tlx_bmm_warppipe(self, dtype: torch.dtype):
+        """TLX warp-pipelined bmm template (AMD MI350X / gfx950).
+
+        Batched C[b] = A[b] @ B[b], standard torch.bmm layout (B [batch,K,N] row-major, no
+        transpose). Same warp-pipe core as the addmm + a batch axis + per-batch int64 base
+        advance. K=272 is a multiple of 16 (the heuristic's alignment gate) but of no BLOCK_K in
+        the config set, so every config exercises the sync-tail. Verifies the TLX bmm lowers to a
+        Triton template (never extern/aten in force mode) and is numerically correct.
+        """
+        batch, M, K, N = 8, 256, 272, 256  # K=272 = 16*17: passes the ÷16 gate, exercises the tail
+        a = torch.randn(batch, M, K, device=GPU_TYPE, dtype=dtype)
+        b = torch.randn(batch, K, N, device=GPU_TYPE, dtype=dtype)
+
+        def bmm(a, b):
+            return torch.bmm(a, b)
+
+        with (config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+        }), ):
+            c_actual, code = run_and_get_code(torch.compile(bmm), a, b)
+
+        c_expected = torch.bmm(a.float(), b.float()).to(dtype)
+        torch.testing.assert_close(c_actual, c_expected, atol=2e-2, rtol=2e-2)
+
+        code_str = "\n".join(code)
+        self.assertIn("triton_tem", code_str)
+
 
 class TestWarpPipeSplitKCodegen(TestCase):
     """Deterministic codegen check for the AMD warp-pipe split-K template.

--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -218,6 +218,96 @@ class TestTLXTemplates(TestCase):
         # ...and the undersaturated grid takes the split-K path -> separate reduce kernel.
         self.assertIn("_reduce_k_kernel", code_str)
 
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    def test_tlx_addmm_warppipe_unaligned_k(self, dtype: torch.dtype):
+        """Unaligned K (K % BLOCK_K != 0) on the TLX warp-pipe addmm (gfx950).
+
+        A masked (partial-K) tlx.async_load fails to lower on gfx950, so the template
+        walks only the FULL K-tiles with unmasked async_load and folds the leftover K
+        columns in via a synchronous masked tl.load ("sync-load the tail"). K=2312 is a
+        multiple of 8 but of no BLOCK_K in the config set (32/64/128), so every config
+        has a partial last K-tile and exercises the tail. Before the fix this raised
+        "failed to legalize operation 'ttg.async_copy_global_to_local'".
+
+        NOTE: K must be a multiple of 8 (16-byte row alignment: stride = K elems * 2 B).
+        An odd K (e.g. the production compression bmm's K=2309) additionally hits a
+        SEPARATE, deeper limit -- the col-major B's async_copy into the swizzled
+        padded_shared LDS layout cannot legalize with a non-16-byte-aligned row stride
+        (builtin.unrealized_conversion_cast on arg_B) -- which the sync-tail does NOT
+        address (it needs an AMD-backend async_copy alignment fix).
+        """
+        M, K, N = 4096, 2312, 192  # K=2312: multiple of 8, but not of 32/64/128 -> partial tail
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
+        # w.t() => B is [K, N] col-major (stride_bk == 1) -- the nn.Linear weight layout.
+        w = torch.randn(N, K, device=GPU_TYPE, dtype=dtype)
+        bias = torch.randn(N, device=GPU_TYPE, dtype=dtype)
+
+        def addmm(bias, a, w):
+            return torch.addmm(bias, a, w.t())
+
+        with (config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+        }), ):
+            c_actual, code = run_and_get_code(torch.compile(addmm), bias, a, w)
+
+        c_expected = (a.float() @ w.t().float() + bias.float()).to(dtype)
+        torch.testing.assert_close(c_actual, c_expected, atol=2e-2, rtol=2e-2)
+
+        # force mode keeps only the TLX template, so an unaligned-K addmm must still
+        # lower through the warp-pipe Triton template (never falling back to extern/aten).
+        code_str = "\n".join(code)
+        self.assertIn("triton_tem", code_str)
+
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_tlx_addmm_warppipe_odd_k_async_copy_alignment_repro(self):
+        """REPRO of the residual odd-K async_copy 16-byte-alignment failure (gfx950).
+
+        The sync-load-the-tail fix handles K % BLOCK_K != 0, but ONLY when the row stride is
+        16-byte aligned (K a multiple of 8). K=2309 (odd; the production compression bmm's K) is
+        NOT: A [M,K] and col-major B [K,N] both have row stride K, so a row spans 2309*2 = 4618 B,
+        not a multiple of 16. The col-major B's async_copy into the swizzled #ttg.padded_shared
+        LDS layout then cannot legalize -> builtin.unrealized_conversion_cast on arg_B -> "failed
+        to translate module to LLVM IR". In tlx_mode=force (TRITON-only) every config fails to
+        compile, so select_algorithm raises NoValidChoicesError.
+
+        This documents a KNOWN residual -- an AMD-backend async_copy alignment fix, out of scope
+        for the sync-tail kernel change. When that fix lands this test will start passing
+        (NoValidChoicesError no longer raised); convert it to a correctness check then.
+        compile_threads=1 keeps the compile in-process so the real MLIR error is visible in the
+        test log (subprocess autotune otherwise swallows it behind NoValidChoicesError).
+        """
+        M, K, N = 4096, 2309, 192  # odd K -> 2309*2 = 4618 B row stride, NOT 16-byte aligned
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=torch.float16)
+        w = torch.randn(N, K, device=GPU_TYPE, dtype=torch.float16)
+        bias = torch.randn(N, device=GPU_TYPE, dtype=torch.float16)
+
+        def addmm(bias, a, w):
+            return torch.addmm(bias, a, w.t())
+
+        with config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+                "compile_threads": 1,
+        }):
+            with self.assertRaises(Exception):
+                run_and_get_code(torch.compile(addmm), bias, a, w)
+
 
 class TestWarpPipeSplitKCodegen(TestCase):
     """Deterministic codegen check for the AMD warp-pipe split-K template.

--- a/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
@@ -5,10 +5,25 @@
     # transposed via tlx.local_trans for the MFMA. Bias is applied by store_output via the
     # epilogue_fn / prefix_args supplied by the heuristic (not referenced here). num_stages=1.
     #
-    # NOTE: tlx.async_load lowers to a 32-bit block pointer (flat-offset pattern, like the AMD
-    # warp-pipeline tutorials). It cannot represent 64-bit offsets, and a pre-advanced base pointer
-    # is miscompiled, so this template is restricted (by the heuristic) to shapes Inductor indexes
-    # with int32 (M*K and N*K statically < 2**31, i.e. static/bounded shapes).
+    # NOTE: tlx.async_load's flat offset is int32 here, so this template is restricted (by the
+    # heuristic) to shapes Inductor indexes with int32 (M*K and N*K statically < 2**31). An int32
+    # offset that overflows faults at runtime (GPU memory access fault), which is why the bound is
+    # enforced. (A 64-bit *base* advance -- e.g. `a_ptr + batch*stride` cast to int64 -- DOES lower
+    # and read correctly on gfx950, verified separately, so a future batched bmm can address
+    # per-batch bases that way; only the 32-bit within-tile offset is the hard limit.)
+    #
+    # UNALIGNED K: a MASKED (partial-K) async_load fails to lower on gfx950 (the partial
+    # ttg.async_copy_global_to_local into a padded_shared LDS layout is marked illegal). So the
+    # warp-pipe walks only FULL K-tiles (K_ITERS = K // BLOCK_K, UNMASKED async_load) and the
+    # leftover K columns (K % BLOCK_K) are handled once, after the pipeline, by a synchronous
+    # masked tl.load + one extra dot ("sync-load the tail"). For K that IS a multiple of BLOCK_K
+    # the tail is a no-op (all-false mask), so aligned-K codegen is unchanged.
+    #
+    # CAVEAT: this needs K to be a multiple of 8 (16-byte row alignment; A [M,K] and col-major
+    # B [K,N] both have row stride K, so K*2 bytes must be 16-aligned). An odd/non-8 K hits a
+    # SEPARATE limit -- B's async_copy into the swizzled padded_shared layout cannot legalize a
+    # non-16-byte-aligned row (builtin.unrealized_conversion_cast on arg_B) -- which the sync
+    # tail does NOT fix (it is an AMD-backend async_copy alignment issue).
     M = {{size("A", 0)}}
     N = {{size("B", 1)}}
     K = {{size("A", 1)}}
@@ -68,7 +83,7 @@
     a_base = offs_m[:, None] * stride_am
     b_base = offs_n[:, None] * stride_bn          # B as (BLOCK_N, BLOCK_K): n is the row of the [N,K] view
 
-    K_ITERS = tl.cdiv(K, BLOCK_K)
+    K_ITERS = K // BLOCK_K   # FULL K-tiles only; the partial-K tail is handled after the pipeline
 {% if SPLIT_K > 1 %}
     # this split's contiguous K-iteration range [k_lo, k_lo + n_iters). BALANCED
     # partition: the first `rem` splits get (base + 1) iters, the rest get `base`.
@@ -96,9 +111,10 @@
         k_start = (k_lo + i) * BLOCK_K
         a_offs = a_base + (k_start + offs_k[None, :]) * stride_ak
         b_offs = b_base + (k_start + offs_k[None, :]) * stride_bk
-        # int32 cast is lossless: the heuristic only emits this template when offsets fit int32.
-        tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, i), mask=offs_k[None, :] < K - k_start)
-        tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, i), mask=offs_k[None, :] < K - k_start)
+        # Full tiles only (k_start + BLOCK_K <= K_ITERS*BLOCK_K <= K) -> UNMASKED: a masked
+        # (partial-K) async_load fails to lower on gfx950. int32 cast is lossless (heuristic bound).
+        tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, i))
+        tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, i))
         tlx.async_load_commit_group([tok_a, tok_b])
 
     tlx.async_load_wait_group(NUM_BUFFERS - 2)
@@ -120,10 +136,9 @@
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_offs = a_base + (k_prefetch + offs_k[None, :]) * stride_ak
             b_offs = b_base + (k_prefetch + offs_k[None, :]) * stride_bk
-            tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, prefetch_buf),
-                                   mask=offs_k[None, :] < K - k_prefetch)
-            tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, prefetch_buf),
-                                   mask=offs_k[None, :] < K - k_prefetch)
+            # full tile (see prologue) -> UNMASKED async_load.
+            tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, prefetch_buf))
+            tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, prefetch_buf))
             tlx.async_load_commit_group([tok_a, tok_b])
             a_tile = tlx.local_load(tlx.local_view(smemA, next_buf))
             b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, next_buf)))
@@ -143,6 +158,27 @@
         a_tile = tlx.local_load(tlx.local_view(smemA, buf))
         b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, buf)))
         acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+
+    # --- partial-K tail ("sync-load the tail") ---
+    # The warp-pipe above covered [0, K_ITERS*BLOCK_K); the leftover K columns (K % BLOCK_K, if
+    # any) are loaded here with a SYNCHRONOUS masked tl.load (async_load cannot lower a partial-K
+    # tile) and folded into acc with one extra dot. tail_width == 0 when K is a multiple of BLOCK_K,
+    # giving an all-false mask (a no-op), so aligned-K shapes are unaffected. Under split-K only the
+    # last split owns the tail -- every other split zeroes tail_width so it is not double-counted.
+    k_tail = K_ITERS * BLOCK_K
+{% if SPLIT_K > 1 %}
+    tail_width = (K - k_tail) * (split_id == SPLIT_K - 1).to(INDEX_DTYPE)
+{% else %}
+    tail_width = K - k_tail
+{% endif %}
+    a_offs = a_base + (k_tail + offs_k[None, :]) * stride_ak          # (BLOCK_M, BLOCK_K)
+    a_tail = tl.load(A + a_offs.to(tl.int32), mask=offs_k[None, :] < tail_width, other=0.0)
+    # Load B's tail directly as (BLOCK_K, BLOCK_N) (K along rows) so it feeds tl.dot without a
+    # transpose -- the warp-pipe uses tlx.local_trans, but that is LDS-only; here a plain tl.load
+    # with a transposed index is simplest for the one-off tail.
+    b_offs = (k_tail + offs_k[:, None]) * stride_bk + offs_n[None, :] * stride_bn
+    b_tail = tl.load(B + b_offs.to(tl.int32), mask=offs_k[:, None] < tail_width, other=0.0)
+    acc = tl.dot(a_tail, b_tail, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
 
     # rematerialize rm and rn to save registers
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)

--- a/third_party/tlx/language/tlx/inductor/amd_bmm_warppipe.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/amd_bmm_warppipe.py.jinja
@@ -1,0 +1,135 @@
+{{def_kernel("A", "B")}}
+    # TLX warp-pipelined bmm for AMD (MI350X / gfx950). C[b] = A[b] @ B[b].
+    # A:[BATCH,M,K] row-major, B:[BATCH,K,N] row-major (the standard torch.bmm layout, so B is
+    # loaded as (BLOCK_K, BLOCK_N) tiles directly -- no transpose, unlike the col-major addmm).
+    # Same warp-pipe compute core as amd_addmm_warppipe (async_load prefetch into multi-buffered
+    # LDS + tlx.warp_pipeline_stage); the only differences are a batch axis on the grid and a
+    # per-batch int64 base advance. num_stages=1.
+    #
+    # NOTE: tlx.async_load's flat offset is int32, so the heuristic restricts this template to
+    # per-batch M*K and N*K < 2**31. The per-batch base advance is done in int64 (batch*M*K can
+    # exceed 2**31). The heuristic also requires (K*itemsize) % 16 == 0 (K % 8 for fp16/bf16, i.e. 16-byte-aligned rows) so the direct-to-LDS
+    # async_copy vectorizes legally on CDNA4; the K % BLOCK_K remainder is a synchronous sync-tail.
+    M = {{size("A", -2)}}
+    N = {{size("B", -1)}}
+    K = {{size("A", -1)}}
+    BATCH = {{size("A", 0)}}
+    if M * N == 0:
+        return
+    stride_aq = {{stride("A", 0)}}
+    stride_am = {{stride("A", 1)}}
+    stride_ak = {{stride("A", 2)}}
+    stride_bq = {{stride("B", 0)}}
+    stride_bk = {{stride("B", 1)}}
+    stride_bn = {{stride("B", 2)}}
+    tl.assume(stride_am > 0)
+    tl.assume(stride_ak > 0)
+    tl.assume(stride_bk > 0)
+    tl.assume(stride_bn > 0)
+
+    pid = tl.program_id(0).to(INDEX_DTYPE)
+    grid_m = (M + BLOCK_M - 1) // BLOCK_M
+    grid_n = (N + BLOCK_N - 1) // BLOCK_N
+    grid_mn = grid_m * grid_n
+    batch_id = pid // grid_mn      # 1-D grid: BATCH * grid_mn programs
+    pid = pid % grid_mn
+
+    # L2 chiplet swizzle on the within-batch pid (same as amd_addmm_warppipe). NUM_XCDS is injected
+    # by the heuristic (8 for gfx942/gfx950, else 1 -> identity). Trailing remainder passes through.
+    XCD_CHUNK: tl.constexpr = 8
+    aligned = (grid_mn // (NUM_XCDS * XCD_CHUNK)) * (NUM_XCDS * XCD_CHUNK)
+    if pid < aligned:
+        xcd = pid % NUM_XCDS
+        local_pid = pid // NUM_XCDS
+        pid = (local_pid // XCD_CHUNK) * (NUM_XCDS * XCD_CHUNK) + xcd * XCD_CHUNK + (local_pid % XCD_CHUNK)
+
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // (group_size)
+    tl.assume(pid_m >= 0)
+    tl.assume(pid_n >= 0)
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)) % M
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N).to(INDEX_DTYPE)) % N
+    offs_k = tl.arange(0, BLOCK_K).to(INDEX_DTYPE)
+
+    # per-batch base advance -- int64 because batch * M*K (or N*K) can exceed 2**31; the
+    # within-tile offsets below stay int32 (heuristic-bounded), matching the addmm 32-bit path.
+    batch_i64 = batch_id.to(tl.int64)
+    A = A + batch_i64 * stride_aq
+    B = B + batch_i64 * stride_bq
+
+    a_base = offs_m[:, None] * stride_am
+    b_base = offs_n[None, :] * stride_bn          # B as (BLOCK_K, BLOCK_N): n is the col of [K,N]
+
+    K_ITERS = K // BLOCK_K   # FULL K-tiles (unmasked); the K % BLOCK_K remainder -> sync-tail below
+
+    smemA = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(A), NUM_BUFFERS)
+    smemB = tlx.local_alloc((BLOCK_K, BLOCK_N), tlx.dtype_of(B), NUM_BUFFERS)
+
+    # prologue: prefetch the first NUM_BUFFERS full K-tiles (heuristic guarantees K_ITERS >= NUM_BUFFERS).
+    for i in tl.range(0, NUM_BUFFERS, loop_unroll_factor=NUM_BUFFERS):
+        k_start = i * BLOCK_K
+        a_offs = a_base + (k_start + offs_k[None, :]) * stride_ak
+        b_offs = (k_start + offs_k[:, None]) * stride_bk + b_base
+        tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, i))
+        tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, i))
+        tlx.async_load_commit_group([tok_a, tok_b])
+
+    tlx.async_load_wait_group(NUM_BUFFERS - 2)
+    a_tile = tlx.local_load(tlx.local_view(smemA, 0))
+    b_tile = tlx.local_load(tlx.local_view(smemB, 0))
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+
+    for tile_id in tl.range(0, K_ITERS - NUM_BUFFERS):
+        prefetch_buf = (tile_id % NUM_BUFFERS).to(tl.int32)
+        next_buf = ((tile_id + 1) % NUM_BUFFERS).to(tl.int32)
+        k_prefetch = (tile_id + NUM_BUFFERS) * BLOCK_K
+
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_offs = a_base + (k_prefetch + offs_k[None, :]) * stride_ak
+            b_offs = (k_prefetch + offs_k[:, None]) * stride_bk + b_base
+            tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, prefetch_buf))
+            tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, prefetch_buf))
+            tlx.async_load_commit_group([tok_a, tok_b])
+            a_tile = tlx.local_load(tlx.local_view(smemA, next_buf))
+            b_tile = tlx.local_load(tlx.local_view(smemB, next_buf))
+
+        tlx.async_load_wait_group(NUM_BUFFERS - 2)
+
+    acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+    tlx.async_load_wait_group(0)
+    for i in tl.range(0, NUM_BUFFERS - 1, loop_unroll_factor=NUM_BUFFERS - 1):
+        buf = ((K_ITERS - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS).to(tl.int32)
+        a_tile = tlx.local_load(tlx.local_view(smemA, buf))
+        b_tile = tlx.local_load(tlx.local_view(smemB, buf))
+        acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+
+    # --- partial-K tail ("sync-load the tail") ---
+    # K % BLOCK_K leftover columns: a masked async_load cannot lower on gfx950, so load them with a
+    # synchronous masked tl.load + one dot. Guarded on tail_width>0 so K % BLOCK_K == 0 pays nothing.
+    k_tail = K_ITERS * BLOCK_K
+    tail_width = K - k_tail
+    if tail_width > 0:
+        a_offs = a_base + (k_tail + offs_k[None, :]) * stride_ak
+        a_tail = tl.load(A + a_offs.to(tl.int32), mask=offs_k[None, :] < tail_width, other=0.0)
+        b_offs = (k_tail + offs_k[:, None]) * stride_bk + b_base
+        b_tail = tl.load(B + b_offs.to(tl.int32), mask=offs_k[:, None] < tail_width, other=0.0)
+        acc = tl.dot(a_tail, b_tail, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+
+    # rematerialize rm/rn to save registers
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N).to(INDEX_DTYPE)
+    idx_q = batch_id
+    idx_m = rm[:, None]
+    idx_n = rn[None, :]
+    mask = (idx_m < M) & (idx_n < N)
+
+    # inductor generates a suffix (cast + batched store)
+    {{store_output(("idx_q", "idx_m", "idx_n"), "acc", "mask", val_shape=("BLOCK_M", "BLOCK_N"))}}

--- a/third_party/tlx/language/tlx/inductor/mm_templates.py
+++ b/third_party/tlx/language/tlx/inductor/mm_templates.py
@@ -45,6 +45,16 @@ def _mm_grid_split_k(m, n, meta, *, cdiv):
     )
 
 
+@SymbolicGridFn
+def _bmm_grid_warppipe(b, m, n, meta, *, cdiv):
+    """1-D grid for the warp-pipe bmm: BATCH * grid_m * grid_n programs, one per (batch, tile).
+
+    The batch index is recovered in-kernel as pid // grid_mn (grid dim 0 is not 65535-limited,
+    and BATCH*grid_mn stays well under 2**31), so no grid_y/grid_z batch split is needed.
+    """
+    return (b * cdiv(m, meta["BLOCK_M"]) * cdiv(n, meta["BLOCK_N"]), 1, 1)
+
+
 blackwell_gemm_ws_template = TritonTemplate(
     name="tlx_blackwell_gemm_ws",
     grid=_persistent_mm_grid_split_k,
@@ -62,6 +72,16 @@ amd_addmm_warppipe_template = TritonTemplate(
     source=load_tlx_template("amd_addmm_warppipe"),
 )
 
+# TLX warp-pipelined bmm template (AMD / MI350X gfx950). Same warp-pipe core as the addmm, plus a
+# batch axis on the grid + a per-batch int64 base advance. B is the standard torch.bmm [BATCH,K,N]
+# row-major layout (loaded as (BLOCK_K, BLOCK_N) tiles, no transpose). Selection via TLX_MODE; the
+# heuristic (registry.py) gates on K % 16 == 0 + int32-representable per-batch offsets.
+amd_bmm_warppipe_template = TritonTemplate(
+    name="tlx_amd_bmm_warppipe",
+    grid=_bmm_grid_warppipe,
+    source=load_tlx_template("amd_bmm_warppipe"),
+)
+
 
 def append_tlx(templates, op_name="mm"):
     # Import registry to trigger heuristic registration via decorators
@@ -77,6 +97,14 @@ def append_tlx(templates, op_name="mm"):
         uids = {getattr(t, "uid", None) for t in templates}
         if mm_template.uid in uids and amd_addmm_warppipe_template.uid not in uids:
             templates.append(amd_addmm_warppipe_template)
+    elif op_name == "bmm":
+        # Compete as an additional candidate alongside the stock bmm_template + aten. Inject once,
+        # gated on bmm_template already being present (the unified choice call).
+        from torch._inductor.kernel.bmm import bmm_template
+
+        uids = {getattr(t, "uid", None) for t in templates}
+        if bmm_template.uid in uids and amd_bmm_warppipe_template.uid not in uids:
+            templates.append(amd_bmm_warppipe_template)
     else:
         templates.append(blackwell_gemm_ws_template)
     return templates

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -50,7 +50,11 @@ def _sizevar_hint(sizevars, expr, fallback):
 
 
 from . import tlx_config
-from .mm_templates import amd_addmm_warppipe_template, blackwell_gemm_ws_template
+from .mm_templates import (
+    amd_addmm_warppipe_template,
+    amd_bmm_warppipe_template,
+    blackwell_gemm_ws_template,
+)
 
 
 @dataclasses.dataclass
@@ -1292,6 +1296,100 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
                 yield self._convert_config_to_template_kwargs(
                     triton_config, m, n, k, out_dtype
                 )
+
+
+@register_template_heuristic(
+    amd_bmm_warppipe_template.uid, "cuda", register=IS_ROCM, op_name="bmm"
+)
+class ROCmBMMWarpPipeTemplateConfigHeuristic(ROCmMMTemplateConfigHeuristic):
+    """TLX warp-pipelined bmm heuristic for ROCm (MI350X/gfx950).
+
+    Same warp-pipe core as the addmm (async_load prefetch into multi-buffered LDS + MFMA via
+    tlx.warp_pipeline_stage), plus a batch axis and a per-batch int64 base advance. No bias, no
+    col-major transpose (bmm B is [BATCH,K,N] row-major), no split-K -- a plain data-parallel
+    baseline for Inductor autotune iteration. Gates (fp16/bf16 only): per-batch M*K and N*K fit
+    int32 (async_load's flat offset); (K*itemsize) % 16 == 0 (K % 8 for fp16/bf16) so the direct-to-LDS async_copy vectorizes
+    legally on CDNA4 (an unaligned K makes the vectorizer pick an illegal 16-bit layout, so decline
+    and fall back to stock bmm/aten rather than miscompile); and K_ITERS = K // BLOCK_K >=
+    NUM_BUFFERS so the prologue prefetch is well-formed (the K % BLOCK_K remainder is a sync-tail).
+    """
+
+    # (BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M, num_warps, NUM_BUFFERS)
+    WARPPIPE_CONFIGS = [
+        (256, 256, 64, 16, 8, 2),
+        (256, 128, 64, 8, 8, 2),
+        (128, 256, 64, 8, 8, 2),
+        (128, 128, 64, 8, 8, 3),
+        (128, 128, 128, 8, 8, 2),
+        (128, 64, 128, 8, 8, 3),
+        (64, 128, 64, 8, 8, 3),
+        (64, 64, 128, 8, 4, 3),
+        (64, 64, 64, 8, 4, 3),
+        (32, 128, 128, 4, 4, 3),
+        (32, 256, 128, 4, 4, 2),
+        (16, 256, 128, 4, 4, 3),
+    ]
+
+    def _get_template_configs_impl(self, kernel_inputs, op_name):
+        import sympy
+        from torch._inductor.virtualized import V
+
+        if not isinstance(kernel_inputs, MMKernelInputs):
+            raise AssertionError(f"{self.__class__.__name__} requires MMKernelInputs")
+        if kernel_inputs.dtype(kernel_inputs._mat1_idx) not in (
+            torch.float16,
+            torch.bfloat16,
+        ):
+            return
+        m, n, k = kernel_inputs.mnk_symbolic()
+        out_dtype = kernel_inputs.out_dtype()
+        sizevars = V.graph.sizevars
+        int32_max = 2**31 - 1
+        # per-batch offsets must fit int32 (the batch offset is applied separately in int64).
+        if not (
+            _sizevar_hint(sizevars, m * k, int32_max) < int32_max
+            and _sizevar_hint(sizevars, n * k, int32_max) < int32_max
+        ):
+            return
+        # 16-byte (128-bit transaction) alignment: the row stride K*itemsize bytes must be a
+        # multiple of 16 (K % 8 == 0 for fp16/bf16) for a legal direct-to-LDS async_copy on CDNA4.
+        # Also declines dynamic/unknown K.
+        itemsize = torch.finfo(kernel_inputs.dtype(kernel_inputs._mat1_idx)).bits // 8
+        if not sizevars.statically_known_true(sympy.Eq(sympy.Mod(k * itemsize, 16), 0)):
+            return
+        num_xcds = _amd_num_xcds()
+        for (
+            block_m,
+            block_n,
+            block_k,
+            group_m,
+            num_warps,
+            num_buffers,
+        ) in self.WARPPIPE_CONFIGS:
+            # MFMA requires block_m/block_n be multiples of matrix_instr_nonkdim (16).
+            if block_m % 16 != 0 or block_n % 16 != 0:
+                continue
+            # prologue prefetches NUM_BUFFERS full K-tiles: require K_ITERS = K // BLOCK_K >= NB.
+            if not sizevars.statically_known_true(
+                sympy.Ge(k, num_buffers * block_k)
+            ):
+                continue
+            triton_config = self.triton_config(
+                1,  # num_stages=1: TLX is hand-pipelined; auto software-pipelining must be off
+                num_warps,
+                BLOCK_M=block_m,
+                BLOCK_N=block_n,
+                BLOCK_K=block_k,
+                GROUP_M=group_m,
+                NUM_BUFFERS=num_buffers,
+                NUM_XCDS=num_xcds,
+                matrix_instr_nonkdim=16,
+                waves_per_eu=0,
+                kpack=get_default_kpack(block_k),
+            )
+            yield self._convert_config_to_template_kwargs(
+                triton_config, m, n, k, out_dtype
+            )
 
 
 @register_template_heuristic(

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1213,6 +1213,14 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
             and _sizevar_hint(sizevars, n * k, int32_max) < int32_max
         ):
             return
+        # 16-byte (128-bit transaction) alignment: the fp16/bf16 padded direct-to-LDS async_copy
+        # lowers to 128-bit loads, so each row start must be 16-byte aligned -- i.e. the row stride
+        # K*itemsize bytes must be a multiple of 16 (K % 8 == 0 for fp16/bf16). Without this guard
+        # an unaligned K reaches the template and fails at async_copy legalization (T280910119);
+        # decline up front so it falls back to aten cleanly. Also declines dynamic/unknown K.
+        itemsize = torch.finfo(kernel_inputs.dtype(kernel_inputs._mat1_idx)).bits // 8
+        if not sizevars.statically_known_true(sympy.Eq(sympy.Mod(k * itemsize, 16), 0)):
+            return
         num_xcds = _amd_num_xcds()
         # split-K only helps grids that leave CUs idle. NUM_SMS is the device CU count
         # (get_num_sms() maps to multi_processor_count = CUs on ROCm; 256 on gfx950/MI350X);


### PR DESCRIPTION
Summary:
Adds a TLX warp-pipelined **bmm** Inductor template for AMD gfx950 (MI350X) that competes in `aten.bmm` autotune, alongside the stock triton bmm + rocBLAS. Landed as a **baseline** for further perf iteration; it is competitive with rocBLAS but not yet a win (see Perf).

## What / how

Four pieces, mirroring the existing addmm warp-pipe template:
- `amd_bmm_warppipe.py.jinja` -- the template. Same warp-pipe compute core as `amd_addmm_warppipe` (async_load prefetch into multi-buffered LDS + `tlx.warp_pipeline_stage("mfma"/"mem")`, num_stages=1). Differences are all addressing: a batch axis on the grid and a **per-batch int64 base advance** (`A/B += batch_id.to(int64) * stride_batch`; within-tile offsets stay int32). B is the standard `torch.bmm` `[BATCH,K,N]` row-major layout, loaded as `(BLOCK_K, BLOCK_N)` tiles directly -- **no transpose** (unlike the col-major addmm). The `K % BLOCK_K` remainder is a guarded synchronous **sync-tail**.
- `mm_templates.py` -- `amd_bmm_warppipe_template` (`TritonTemplate`) + a 1-D bmm grid (`BATCH * grid_m * grid_n`; batch recovered in-kernel as `pid // grid_mn`) + a `bmm` branch in `append_tlx` (injects once, alongside the stock `bmm_template`).
- `registry.py` -- `ROCmBMMWarpPipeTemplateConfigHeuristic` registered for `op_name="bmm"`. No bias, no col-major transpose, no split-K. Gates (fp16/bf16 only): per-batch `M*K` and `N*K < 2**31`; **`K % 16 == 0`** so the direct-to-LDS `async_copy` vectorizes legally on CDNA4 (an unaligned K makes the vectorizer pick an illegal 16-bit layout, so decline and fall back to stock bmm/aten rather than miscompile -- also declines dynamic/unknown K); and `K // BLOCK_K >= NUM_BUFFERS` for a well-formed prologue.
- `test_torchtlx_templates.py::test_tlx_bmm_warppipe` -- end-to-end gfx950 test (K=272 = 16*17 exercises the sync-tail).

Selection is via `TORCHINDUCTOR_TLX_MODE` (as for the addmm): "allow" competes vs rocBLAS in autotune, "force" keeps only TLX.

## Coverage / limitation

Covers K-aligned bmms (`K % 16 == 0`). The production compression bmm `bmm(1024x1195x2309, ...)` has an **odd K=2309** and is declined by the heuristic (falls back to rocBLAS) for two reasons:

1. A `TritonTemplate` operates on the tensors Inductor hands it -- it cannot insert a `torch`-level pad, and the async_copy of the FULL K-tiles (not just the tail) needs a 16-element-aligned row stride, which `K % BLOCK_K` sync-tail does NOT provide (the sync-tail only covers the partial last tile; the ÷16 requirement is on every full-tile async_load).
2. Padding K to a multiple of 16 (via a graph pass / `adjust_kernel_inputs`) is numerically correct but a **net perf loss** for bmm: `F.pad` copies the whole activation tensor every call (~4 ms for the compression bmm), giving ~0.3x rocBLAS, so autotune would never pick it. (Padding only pays off when amortized -- e.g. a pre-padded weight -- which does not apply to bmm activations.)

The real unlock for odd-K coverage is a **backend `async_copy` fix** that handles a non-16-aligned row stride directly (no pad) -- tracked in **T280910119** (root-cause chain + proposed fix + file:line pointers). Until then, odd-K bmm/addmm stays on rocBLAS.

## Perf -- measured THROUGH this template via the Inductor path (MI350X, full batch, fp16)

torch.bmm -> torch.compile (tlx_mode=force) vs eager rocBLAS, do_bench, on the 4 dominant bmm shapes (P2428225272 §4):

| # | shape B,M,K,N       | rocBLAS | TLX template | ratio | note |
|---|---------------------|--------:|-------------:|:-----:|------|
| 1 | 1024,1195,2309,256  | 2281 us | --           | --    | declined (K%16!=0) -> rocBLAS |
| 2 | 1024,  40,1956,256  |  257 us | --           | --    | declined (K%16!=0) -> rocBLAS |
| 3 | 1024, 395, 320,256  |  195 us |  223 us      | 0.87x | tlx template selected, correct |
| 4 |  320,1024, 256,256  |  117 us |  134 us      | 0.88x | tlx template selected, correct |

Competitive but ~12-13% behind on the aligned shapes; kernel-level rocprof (measured separately) attributes the gap to addressing VALU + rocBLAS's persistent-kernel MFMA feeding, not correctness or waste. Odd-K shapes (#1/#2) are declined by the K%16 gate and stay on rocBLAS (the template can't pad K; needs the backend async_copy alignment fix or a K-padding graph pass). Landing this as a baseline lets Inductor autotune + future kernel iteration (persistent design, addressing-VALU reduction, odd-K coverage) build on a working, tested template.

Authored with Claude.

Reviewed By: htyu

Differential Revision: D113190697


