### PR TITLE
[TLX][AMD] warp-pipe bmm: register-path fallback for unaligned K (T280910119) (#2348)

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -345,6 +345,56 @@ class TestTLXTemplates(TestCase):
         code_str = "\n".join(code)
         self.assertIn("triton_tem", code_str)
 
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX warp-pipe bmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    def test_tlx_bmm_warppipe_regpath_odd_k(self, dtype: torch.dtype):
+        """Odd K on the TLX bmm template -> register-path branch (USE_ASYNC=0), T280910119.
+
+        K=2309 (odd; the production compression bmm's K) has a 2309*2 = 4618 B row stride that is
+        never 16-byte aligned, so the direct-to-LDS async_load path cannot legalize on CDNA4. The
+        heuristic sets USE_ASYNC=0 and the template takes the register-path fallback (tl.load ->
+        registers -> tl.dot, auto-pipelined), which lowers for ANY alignment. In tlx_mode=force
+        (TRITON-only) this must still lower to the Triton template (never extern/aten) and be
+        numerically correct -- exactly the shape the aligned-K async path could not compile.
+        """
+        batch, M, K, N = 8, 256, 2309, 256  # odd K -> register-path branch (USE_ASYNC=0)
+        a = torch.randn(batch, M, K, device=GPU_TYPE, dtype=dtype)
+        b = torch.randn(batch, K, N, device=GPU_TYPE, dtype=dtype)
+
+        def bmm(a, b):
+            return torch.bmm(a, b)
+
+        with (config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+        }), ):
+            c_actual, code = run_and_get_code(torch.compile(bmm), a, b)
+
+        c_expected = torch.bmm(a.float(), b.float()).to(dtype)
+        torch.testing.assert_close(c_actual, c_expected, atol=2e-2, rtol=2e-2)
+
+        code_str = "\n".join(code)
+        self.assertIn("triton_tem", code_str)
+
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_tlx_bmm_warppipe_dual_path_source(self):
+        """The non-persistent bmm template carries BOTH branches: the async_load direct-to-LDS path
+        (aligned K) and the register-path fallback (unaligned/odd K, T280910119). Source check --
+        no GPU needed."""
+        from triton.language.extra.tlx.inductor.mm_templates import load_tlx_template
+
+        src = load_tlx_template("amd_bmm_warppipe")
+        self.assertIn("USE_ASYNC", src)  # dual-path selector constexpr
+        self.assertIn("tlx.async_load", src)  # aligned-K async path
+        self.assertIn("a_reg = tl.load", src)  # register-path fallback load
+
 
 class TestWarpPipeSplitKCodegen(TestCase):
     """Deterministic codegen check for the AMD warp-pipe split-K template.

--- a/third_party/tlx/language/tlx/inductor/amd_bmm_warppipe.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/amd_bmm_warppipe.py.jinja
@@ -8,8 +8,14 @@
     #
     # NOTE: tlx.async_load's flat offset is int32, so the heuristic restricts this template to
     # per-batch M*K and N*K < 2**31. The per-batch base advance is done in int64 (batch*M*K can
-    # exceed 2**31). The heuristic also requires (K*itemsize) % 16 == 0 (K % 8 for fp16/bf16, i.e. 16-byte-aligned rows) so the direct-to-LDS
-    # async_copy vectorizes legally on CDNA4; the K % BLOCK_K remainder is a synchronous sync-tail.
+    # exceed 2**31).
+    #
+    # DUAL PATH (selected by the USE_ASYNC constexpr the heuristic sets from K's alignment):
+    #  * USE_ASYNC=1  (K % 8 == 0, i.e. (K*itemsize) % 16 == 0, 16-byte-aligned rows): the fast
+    #    async_load direct-to-LDS warp-pipe below; the K % BLOCK_K remainder is a synchronous sync-tail.
+    #  * USE_ASYNC=0  (unaligned K, e.g. odd K): a register-path fallback (tl.load -> registers ->
+    #    tl.dot, auto-pipelined) that lowers for ANY alignment where the async_copy path cannot
+    #    (T280910119). Same register-staged data path rocBLAS uses; ~0.76x rocBLAS on odd K.
     M = {{size("A", -2)}}
     N = {{size("B", -1)}}
     K = {{size("A", -1)}}
@@ -64,6 +70,8 @@
     a_base = offs_m[:, None] * stride_am
     b_base = offs_n[None, :] * stride_bn          # B as (BLOCK_K, BLOCK_N): n is the col of [K,N]
 
+{% if USE_ASYNC %}
+    # --- async_load direct-to-LDS warp-pipe path (USE_ASYNC=1: K % 8 == 0, 16-byte-aligned rows) ---
     K_ITERS = K // BLOCK_K   # FULL K-tiles (unmasked); the K % BLOCK_K remainder -> sync-tail below
 
     smemA = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(A), NUM_BUFFERS)
@@ -122,6 +130,22 @@
         b_offs = (k_tail + offs_k[:, None]) * stride_bk + b_base
         b_tail = tl.load(B + b_offs.to(tl.int32), mask=offs_k[:, None] < tail_width, other=0.0)
         acc = tl.dot(a_tail, b_tail, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+{% else %}
+    # --- register-path fallback (USE_ASYNC=0: K % 8 != 0, e.g. odd K) ---
+    # buffer_load (tl.load) is element-granular, so it lowers for ANY row-stride alignment -- no
+    # direct-to-LDS 16-byte constraint -- and the masked tail handles K % BLOCK_K in the same loop.
+    # num_stages>1 (set by the heuristic) lets Triton's auto-pipeliner overlap the loads across
+    # K-iters; this is the register-staged path rocBLAS itself uses (buffer_load->registers->MFMA).
+    # ~0.76x rocBLAS on the odd-K compression bmm (T280910119) vs the async path's near-parity -- a
+    # working Triton candidate for shapes the async_copy path cannot legalize.
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+    for k in range(0, K, BLOCK_K):
+        a_offs = a_base + (k + offs_k[None, :]) * stride_ak
+        b_offs = (k + offs_k[:, None]) * stride_bk + b_base
+        a_reg = tl.load(A + a_offs.to(tl.int32), mask=offs_k[None, :] < K - k, other=0.0)
+        b_reg = tl.load(B + b_offs.to(tl.int32), mask=offs_k[:, None] < K - k, other=0.0)
+        acc = tl.dot(a_reg, b_reg, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+{% endif %}
 
     # rematerialize rm/rn to save registers
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)

--- a/third_party/tlx/language/tlx/inductor/mm_templates.py
+++ b/third_party/tlx/language/tlx/inductor/mm_templates.py
@@ -74,8 +74,11 @@ amd_addmm_warppipe_template = TritonTemplate(
 
 # TLX warp-pipelined bmm template (AMD / MI350X gfx950). Same warp-pipe core as the addmm, plus a
 # batch axis on the grid + a per-batch int64 base advance. B is the standard torch.bmm [BATCH,K,N]
-# row-major layout (loaded as (BLOCK_K, BLOCK_N) tiles, no transpose). Selection via TLX_MODE; the
-# heuristic (registry.py) gates on K % 16 == 0 + int32-representable per-batch offsets.
+# row-major layout (loaded as (BLOCK_K, BLOCK_N) tiles, no transpose). Selection via TLX_MODE.
+# Dual path (USE_ASYNC constexpr from the heuristic): aligned K (K % 8 for fp16/bf16) uses the fast
+# async_load direct-to-LDS warp-pipe; unaligned/odd K -- which async_copy can't legalize on CDNA4 --
+# uses a register-path fallback (tl.load->tl.dot, T280910119). Gate: int32-representable per-batch
+# offsets.
 amd_bmm_warppipe_template = TritonTemplate(
     name="tlx_amd_bmm_warppipe",
     grid=_bmm_grid_warppipe,

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1307,11 +1307,16 @@ class ROCmBMMWarpPipeTemplateConfigHeuristic(ROCmMMTemplateConfigHeuristic):
     Same warp-pipe core as the addmm (async_load prefetch into multi-buffered LDS + MFMA via
     tlx.warp_pipeline_stage), plus a batch axis and a per-batch int64 base advance. No bias, no
     col-major transpose (bmm B is [BATCH,K,N] row-major), no split-K -- a plain data-parallel
-    baseline for Inductor autotune iteration. Gates (fp16/bf16 only): per-batch M*K and N*K fit
-    int32 (async_load's flat offset); (K*itemsize) % 16 == 0 (K % 8 for fp16/bf16) so the direct-to-LDS async_copy vectorizes
-    legally on CDNA4 (an unaligned K makes the vectorizer pick an illegal 16-bit layout, so decline
-    and fall back to stock bmm/aten rather than miscompile); and K_ITERS = K // BLOCK_K >=
-    NUM_BUFFERS so the prologue prefetch is well-formed (the K % BLOCK_K remainder is a sync-tail).
+    baseline for Inductor autotune iteration.
+
+    Dual path selected by K's 16-byte alignment (the template's USE_ASYNC constexpr):
+      * (K*itemsize) % 16 == 0 (K % 8 for fp16/bf16): USE_ASYNC=1, the direct-to-LDS async_load
+        warp-pipe (needs K_ITERS = K // BLOCK_K >= NUM_BUFFERS for a well-formed prologue; the
+        K % BLOCK_K remainder is a sync-tail).
+      * otherwise (unaligned K -- the direct-to-LDS async_copy cannot legalize on CDNA4 -- or
+        dynamic K): USE_ASYNC=0, the register-path fallback (tl.load->tl.dot, auto-pipelined),
+        correct for ANY K (T280910119). Common gate (fp16/bf16 only): per-batch M*K and N*K fit
+        int32 (the within-batch offset is int32 on both paths).
     """
 
     # (BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M, num_warps, NUM_BUFFERS)
@@ -1351,12 +1356,17 @@ class ROCmBMMWarpPipeTemplateConfigHeuristic(ROCmMMTemplateConfigHeuristic):
             and _sizevar_hint(sizevars, n * k, int32_max) < int32_max
         ):
             return
-        # 16-byte (128-bit transaction) alignment: the row stride K*itemsize bytes must be a
-        # multiple of 16 (K % 8 == 0 for fp16/bf16) for a legal direct-to-LDS async_copy on CDNA4.
-        # Also declines dynamic/unknown K.
+        # DUAL PATH by K alignment (the USE_ASYNC constexpr picks the template branch):
+        #  * (K*itemsize) % 16 == 0 (K % 8 for fp16/bf16, 16-byte-aligned rows) -> USE_ASYNC=1, the
+        #    fast direct-to-LDS async_load warp-pipe.
+        #  * otherwise (e.g. odd K -- which the direct-to-LDS async_copy cannot legalize on CDNA4 --
+        #    or dynamic/unknown K, treated as unaligned) -> USE_ASYNC=0, the register-path fallback
+        #    (tl.load->registers->tl.dot, auto-pipelined; ~0.76x rocBLAS, T280910119). This is
+        #    correct for ANY K, so unaligned-K bmm still gets a Triton candidate rather than only aten.
         itemsize = torch.finfo(kernel_inputs.dtype(kernel_inputs._mat1_idx)).bits // 8
-        if not sizevars.statically_known_true(sympy.Eq(sympy.Mod(k * itemsize, 16), 0)):
-            return
+        use_async = sizevars.statically_known_true(
+            sympy.Eq(sympy.Mod(k * itemsize, 16), 0)
+        )
         num_xcds = _amd_num_xcds()
         for (
             block_m,
@@ -1369,13 +1379,16 @@ class ROCmBMMWarpPipeTemplateConfigHeuristic(ROCmMMTemplateConfigHeuristic):
             # MFMA requires block_m/block_n be multiples of matrix_instr_nonkdim (16).
             if block_m % 16 != 0 or block_n % 16 != 0:
                 continue
-            # prologue prefetches NUM_BUFFERS full K-tiles: require K_ITERS = K // BLOCK_K >= NB.
-            if not sizevars.statically_known_true(
+            # async path only: its prologue prefetches NUM_BUFFERS full K-tiles, so require
+            # K_ITERS = K // BLOCK_K >= NB. The register path has no prologue -> it takes any K.
+            if use_async and not sizevars.statically_known_true(
                 sympy.Ge(k, num_buffers * block_k)
             ):
                 continue
             triton_config = self.triton_config(
-                1,  # num_stages=1: TLX is hand-pipelined; auto software-pipelining must be off
+                # async is hand-pipelined (num_stages=1, auto software-pipelining off); the register
+                # path relies on the auto-pipeliner (num_stages=3) to overlap its tl.loads.
+                1 if use_async else 3,
                 num_warps,
                 BLOCK_M=block_m,
                 BLOCK_N=block_n,
@@ -1383,6 +1396,7 @@ class ROCmBMMWarpPipeTemplateConfigHeuristic(ROCmMMTemplateConfigHeuristic):
                 GROUP_M=group_m,
                 NUM_BUFFERS=num_buffers,
                 NUM_XCDS=num_xcds,
+                USE_ASYNC=use_async,
                 matrix_instr_nonkdim=16,
                 waves_per_eu=0,
                 kpack=get_default_kpack(block_k),


### PR DESCRIPTION
Summary:

The warp-pipe bmm template's async_load direct-to-LDS path needs 16-byte-aligned rows
((K*itemsize) % 16 == 0, i.e. K % 8 for fp16/bf16), so the heuristic previously DECLINED
unaligned K -- notably the production compression bmm's odd K=2309 -- and fell back to aten.

This adds a register-path fallback so unaligned/odd K still gets a Triton candidate. The bmm
template is now dual-path, selected by a `USE_ASYNC` constexpr the heuristic sets from K's
alignment:

- `USE_ASYNC=1` (K % 8 == 0): the existing fast async_load direct-to-LDS warp-pipe (num_stages=1).
- `USE_ASYNC=0` (unaligned/odd K, or dynamic K): a register-path branch -- `tl.load` (buffer_load,
  element-granular, so it lowers for ANY row-stride alignment) into registers, then `tl.dot`, with
  num_stages=3 so Triton's auto software-pipeliner overlaps the loads. This is the same
  register-staged data path rocBLAS itself uses (buffer_load -> registers -> MFMA).

The heuristic drops the K % 8 decline gate (keeping only the int32-offset gate, which both paths
need) and picks the branch + num_stages per shape. The persistent bmm variant stays async-only, so
its heuristic skips the parent's `USE_ASYNC=0` register configs.

Perf: on the odd-K compression bmm (1024x1195x2309x256) the register path is ~0.76x rocBLAS --
stock-Triton-quality; it makes odd-K WORK where async cannot lower, rather than beating rocBLAS.
Reaching rocBLAS parity on odd K needs a rocBLAS-level-tuned register path (persistent + tuned
GLVW + PLR/PGR pipelining), a follow-up. See T280910119 for the full feasibility datapoint.

Reviewed By: htyu

Differential Revision: D113371191


