### PR TITLE
[triton][AMD] Emit count-up DPP order for inner_tree reductions (#2351)

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3776,6 +3776,63 @@ def test_reduction_ordering_sum_masked_multi_reg_group(num_warps, N, BLOCK_N, de
                                    f"num_warps={num_warps}")
 
 
+@pytest.mark.skipif(not is_hip(), reason="AMD-only: DPP warp-reduce count-up order for inner_tree (D113540598)")
+def test_reduction_ordering_sum_num_warps_bitwise_hip(device):
+    """AMD regression (D113540598): on gfx942/CDNA (wave64) a float `sum` with
+    INNER_TREE ordering must be bitwise-identical across num_warps.  The within-
+    warp stage lowers to a DPP butterfly; before the fix AMD always emitted the
+    count-down row_shr order (8,4,2,1) and ignored reduction_ordering, so the add
+    grouping -- and thus the result bits -- changed when num_warps / BLOCK_SIZE
+    reshaped the reduce axis (sizePerThread).  The fix emits the count-up order
+    (1,2,4,8) for inner_tree, matching the shared count-up shuffle tree.
+
+    N=1024 with a single reduced row places all warps on the reduce axis, so
+    sizePerThread on that axis shifts as num_warps grows -- the layout change
+    that used to move the result bits."""
+    BLOCK_N = 1024
+    TOTAL_ROWS = 32
+
+    @triton.jit
+    def sum_kernel_1row(X, Z, stride_row, stride_col, BLOCK_N: tl.constexpr, ORDERING: tl.constexpr):
+        pid = tl.program_id(0)
+        offs_n = tl.arange(0, BLOCK_N)
+        x = tl.load(X + pid * stride_row + offs_n * stride_col)
+        z = tl.sum(x, axis=0, reduction_ordering=ORDERING)
+        tl.store(Z + pid, z)
+
+    torch.manual_seed(42)
+    x = torch.randn((TOTAL_ROWS, BLOCK_N), device=device, dtype=torch.float32)
+    grid = (TOTAL_ROWS, )
+
+    def run(ordering, num_warps):
+        out = torch.empty(TOTAL_ROWS, device=device, dtype=torch.float32)
+        sum_kernel_1row[grid](
+            x,
+            out,
+            x.stride(0),
+            x.stride(1),
+            BLOCK_N=BLOCK_N,
+            ORDERING=ordering,
+            num_warps=num_warps,
+        )
+        return out
+
+    # INNER_TREE must be bitwise num_warps-invariant.  Compare raw bits (integer
+    # view) against the num_warps=1 reference so +0/-0 and NaN patterns count as
+    # different, not just the numeric value.
+    ref_bits = run(tl.ReductionOrdering.INNER_TREE, 1).view(torch.int32)
+    for num_warps in [1, 2, 4, 8]:
+        out_bits = run(tl.ReductionOrdering.INNER_TREE, num_warps).view(torch.int32)
+        assert torch.equal(out_bits,
+                           ref_bits), (f"INNER_TREE sum not bitwise num_warps-invariant on AMD: num_warps={num_warps}")
+
+    # Control: the UNORDERED path is deliberately NOT asserted.  It is allowed to
+    # vary across num_warps (that freedom is exactly what inner_tree removes), so
+    # requiring it to match would be wrong.  We still run it once to confirm it
+    # compiles and executes on this path.
+    run(tl.ReductionOrdering.UNORDERED, 4)
+
+
 # ---------------
 # test permute
 # ---------------

--- a/test/Conversion/amd/reduce_inner_tree_dpp.mlir
+++ b/test/Conversion/amd/reduce_inner_tree_dpp.mlir
@@ -1,0 +1,74 @@
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 --convert-builtin-func-to-llvm | FileCheck %s
+
+// Regression test for the AMD DPP warp-reduce ordering (D113540598).
+//
+// On gfx942/CDNA (wave64) a within-warp float reduction lowers to a DPP
+// butterfly of `row_shr` steps. `ROW_SHR0` is 0x110 (272), so the printed
+// dpp-control constant for `row_shr:n` is `272 + n`:
+//   row_shr:1 -> 273, row_shr:2 -> 274, row_shr:4 -> 276, row_shr:8 -> 280.
+// The two cross-row broadcast steps that follow are unchanged either way:
+//   row_bcast:15 -> 322 (BCAST15, row_mask 0xa=10), row_bcast:31 -> 323 (BCAST31).
+//
+// A reduction with `reduction_ordering = "inner_tree"` must emit the row_shr
+// steps in COUNT-UP order (1,2,4,8 -> 273,274,276,280) so adjacent lanes combine
+// first, giving a fixed tree that is bitwise num_warps-invariant. The default
+// (unordered) reduction is unchanged and stays COUNT-DOWN (8,4,2,1 ->
+// 280,276,274,273).
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: reduce_inner_tree_sum
+  tt.func @reduce_inner_tree_sum(%arg0: tensor<64xf32, #blocked>) {
+    // Count-up within-row row_shr: 1, 2, 4, 8.
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 273, 15, 15, true : f32
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 274, 15, 15, true : f32
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 276, 15, 15, true : f32
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 280, 15, 15, true : f32
+    // Cross-row broadcast steps unchanged.
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 322, 10, 15, true : f32
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 323, 15, 15, true : f32
+    // CHECK: rocdl.readlane
+    %0 = "tt.reduce"(%arg0) ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %1 = arith.addf %arg1, %arg2 : f32
+      tt.reduce.return %1 : f32
+    }) {axis = 0 : i32, reduction_ordering = "inner_tree"} : (tensor<64xf32, #blocked>) -> f32
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: reduce_unordered_sum
+  tt.func @reduce_unordered_sum(%arg0: tensor<64xf32, #blocked>) {
+    // Default (no reduction_ordering) stays count-down row_shr: 8, 4, 2, 1.
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 280, 15, 15, true : f32
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 276, 15, 15, true : f32
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 274, 15, 15, true : f32
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 273, 15, 15, true : f32
+    // Cross-row broadcast steps unchanged.
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 322, 10, 15, true : f32
+    // CHECK: rocdl.update.dpp
+    // CHECK-SAME: with 323, 15, 15, true : f32
+    // CHECK: rocdl.readlane
+    %0 = "tt.reduce"(%arg0) ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %1 = arith.addf %arg1, %arg2 : f32
+      tt.reduce.return %1 : f32
+    }) {axis = 0 : i32} : (tensor<64xf32, #blocked>) -> f32
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -376,26 +376,10 @@ static bool warpReduceSwap16or32(RewriterBase &rewriter, Location loc,
   return true;
 }
 
-bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
-                            SmallVector<Value> &acc, triton::ReduceOp op,
-                            unsigned numLaneToReduce,
-                            unsigned interleave) const {
+void TargetInfo::emitDppWarpReduce(RewriterBase &rewriter, Location loc,
+                                   SmallVector<Value> &acc, Operation *reduxOp,
+                                   ArrayRef<int> rowShrSteps) const {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-
-  if (getISAFamily() == ISAFamily::CDNA4 &&
-      warpReduceSwap16or32(rewriter, loc, acc, op, numLaneToReduce, interleave))
-    return true;
-  if (numLaneToReduce != getWarpSize())
-    return false;
-  // DPP warp reduce requires gfx90a+ (CDNA2+) or gfx11+ (RDNA3+).
-  // Pre-CDNA2 GFX9 (gfx906/gfx908) and GFX10 (RDNA1/2) are excluded.
-  auto v = getIsaVersion();
-  if (!((v.Major == 9 && (v.Minor > 0 || v.Stepping >= 0xa)) || v.Major >= 11))
-    return false;
-
-  Operation *reduxOp = op.getSingleCombiner();
-  if (!reduxOp)
-    return false;
 
   auto createDppReduxOpWithBoundCtrl = [&](Type valType, Value &src,
                                            uint32_t dppCtrl, int rowMask,
@@ -474,21 +458,15 @@ bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
 
     const uint32_t dppCtrlRowShr = static_cast<uint32_t>(DppCtrl::ROW_SHR0);
 
-    // row_shr:8
-    buf = createDppReduxOpWithBoundCtrl(valType, acc[i], 8 + dppCtrlRowShr,
-                                        allRows, allBanks);
-
-    // row_shr:4
-    buf = createDppReduxOpWithBoundCtrl(valType, buf, 4 + dppCtrlRowShr,
-                                        allRows, allBanks);
-
-    // row_shr:2
-    buf = createDppReduxOpWithBoundCtrl(valType, buf, 2 + dppCtrlRowShr,
-                                        allRows, allBanks);
-
-    // row_shr:1
-    buf = createDppReduxOpWithBoundCtrl(valType, buf, 1 + dppCtrlRowShr,
-                                        allRows, allBanks);
+    // Within-row lane reduction via row_shr, applied in the order given by
+    // `rowShrSteps` (count-down 8,4,2,1 for the default reduction; count-up
+    // 1,2,4,8 for an ordered inner_tree reduction -- see warpReduceInnerTree).
+    // The cross-row row_bcast steps below are grouping-preserving and identical
+    // for both orders.
+    buf = acc[i];
+    for (int step : rowShrSteps)
+      buf = createDppReduxOpWithBoundCtrl(valType, buf, step + dppCtrlRowShr,
+                                          allRows, allBanks);
 
     if (supportDppBroadcast()) {
       // row_bcast:15 row_mask:0xa
@@ -528,7 +506,66 @@ bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
 
     acc[i] = result;
   }
+}
 
+bool TargetInfo::warpReduceInnerTree(RewriterBase &rewriter, Location loc,
+                                     SmallVector<Value> &acc,
+                                     triton::ReduceOp op,
+                                     unsigned numLaneToReduce) const {
+  // The count-up DPP tree assumes the wave64 (4 rows x 16 lanes) layout and a
+  // full-warp, single-combiner reduction. When any of those does not hold, bail
+  // (return false) so the shared count-up shuffle tree performs the ordered
+  // reduction instead. This also covers non-wave64 targets (e.g. GFX1250
+  // wave32) and the permlane-swap fast paths, which do not implement the
+  // count-up order.
+  if (numLaneToReduce != getWarpSize() || getWarpSize() != 64)
+    return false;
+  // DPP warp reduce requires gfx90a+ (CDNA2+) or gfx11+ (RDNA3+).
+  auto v = getIsaVersion();
+  if (!((v.Major == 9 && (v.Minor > 0 || v.Stepping >= 0xa)) || v.Major >= 11))
+    return false;
+  Operation *reduxOp = op.getSingleCombiner();
+  if (!reduxOp)
+    return false;
+
+  // Count-up order (1,2,4,8): adjacent lanes combine first, building the same
+  // balanced, adjacency-defined tree as the shared count-up shuffle path, so
+  // the result is bitwise-identical no matter how num_warps / BLOCK_SIZE split
+  // the reduction axis. (fp add/mul is commutative, so operand order within a
+  // node does not change the bits; only the grouping does.)
+  emitDppWarpReduce(rewriter, loc, acc, reduxOp, {1, 2, 4, 8});
+  return true;
+}
+
+bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
+                            SmallVector<Value> &acc, triton::ReduceOp op,
+                            unsigned numLaneToReduce,
+                            unsigned interleave) const {
+  // A defined reduction ordering (currently only "inner_tree") requires a
+  // fixed, layout-invariant reduction tree so the result is bitwise-identical
+  // across num_warps / BLOCK_SIZE. Emit it via the dedicated count-up path; the
+  // permlane-swap fast path below does not implement that order and is only
+  // used for the default (unordered) reduction.
+  if (op.hasDefinedOrdering())
+    return warpReduceInnerTree(rewriter, loc, acc, op, numLaneToReduce);
+
+  if (getISAFamily() == ISAFamily::CDNA4 &&
+      warpReduceSwap16or32(rewriter, loc, acc, op, numLaneToReduce, interleave))
+    return true;
+  if (numLaneToReduce != getWarpSize())
+    return false;
+  // DPP warp reduce requires gfx90a+ (CDNA2+) or gfx11+ (RDNA3+).
+  // Pre-CDNA2 GFX9 (gfx906/gfx908) and GFX10 (RDNA1/2) are excluded.
+  auto v = getIsaVersion();
+  if (!((v.Major == 9 && (v.Minor > 0 || v.Stepping >= 0xa)) || v.Major >= 11))
+    return false;
+
+  Operation *reduxOp = op.getSingleCombiner();
+  if (!reduxOp)
+    return false;
+
+  // Default (unordered) within-warp reduction: count-down DPP order 8,4,2,1.
+  emitDppWarpReduce(rewriter, loc, acc, reduxOp, {8, 4, 2, 1});
   return true;
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -159,6 +159,24 @@ public:
   getSharedLdStTiles(int32_t vecBitwidth) const override;
 
 private:
+  // Emit the wave64 DPP butterfly warp-reduce into `acc` (in place) using the
+  // given within-row row_shr step order (count-down 8,4,2,1 for the default
+  // reduction; count-up 1,2,4,8 for an ordered inner_tree reduction). `reduxOp`
+  // is the reduction's single combiner op.
+  void emitDppWarpReduce(RewriterBase &rewriter, Location loc,
+                         SmallVector<Value> &acc, Operation *reduxOp,
+                         ArrayRef<int> rowShrSteps) const;
+
+  // Warp-reduce for a reduction with a defined ("inner_tree") ordering,
+  // emitting the fixed count-up DPP tree so the result is bitwise-identical
+  // across num_warps. Returns false when the count-up DPP tree is not
+  // applicable (partial warp, non-wave64, unsupported arch, or
+  // non-single-combiner reduce) so the shared count-up shuffle tree runs
+  // instead.
+  bool warpReduceInnerTree(RewriterBase &rewriter, Location loc,
+                           SmallVector<Value> &acc, triton::ReduceOp op,
+                           unsigned numLaneToReduce) const;
+
   void printfImpl(Value formatStrStart, int formatStrByteCount, ValueRange args,
                   ArrayRef<bool> isSigned, RewriterBase &rewriter,
                   bool useStdErr) const;


### PR DESCRIPTION
Summary:

On AMD (gfx942/CDNA, wave64), `reduction_ordering="inner_tree"` reductions were
not bitwise-identical across `num_warps`, breaking the inner_tree contract
(bitwise reproducible regardless of `num_warps` / `BLOCK_SIZE`).

The shared reduce lowering (`ReduceOpToLLVM.cpp`) runs the within-warp stage by
calling `targetInfo.warpReduce` first and returning early on success, before the
count-up shuffle path. AMD's `TargetInfo::warpReduce` emits a fixed count-DOWN
DPP butterfly (`row_shr:8,4,2,1`) and never inspects `reduction_ordering`, so it
shadowed the ordered path. DPP's count-down grouping combines stride-8 lanes
first, which is not the adjacency-defined tree inner_tree promises; when
`num_warps` / `BLOCK_SIZE` change the reduce-axis layout (`sizePerThread`), the
add association -- and thus the result bits -- changes. NVIDIA is unaffected
because its `warpReduce` declines fp add and falls through to the shared
count-up path.

This makes AMD's `warpReduce` honor inner_tree: for a defined ordering it emits
the DPP `row_shr` steps in count-UP order (`1,2,4,8`) so adjacent lanes combine
first, building the same balanced, adjacency-defined tree as the shared count-up
shuffle path. fp add/mul is commutative, so only the grouping matters; the
cross-row `row_bcast` steps are grouping-preserving and unchanged. It stays on
the pure-DPP fast path, so the instruction count is unchanged. The permlane-swap
fast paths (CDNA4/GFX1250) and the wave32 path do not implement this order, so
for inner_tree they are skipped and the shared count-up shuffle tree runs
instead. The default (unordered) path is unchanged.

Scope and known limitations:
- This fixes pure float `sum`/`prod` inner_tree, bringing AMD to parity with
  NVIDIA.
- mul-fed + fp_fusion (FMA) `num_warps`-variance is a separate, pre-existing
  cross-backend limitation (present on NVIDIA too -- inner_tree pins the
  reduction order but not FMA contraction, which tracks the layout) and is out
  of scope here.
- Validated on gfx942/CDNA3 (MI300X) only. On CDNA4 (gfx950) / GFX1250,
  inner_tree bails from the permlane-swap fast path to the shared count-up
  shuffle tree -- correct by construction but not yet validated on that
  hardware; a follow-up.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D113540598


