### PR TITLE
[triton][tlx] Expose tlx.sched_barrier (used in split-M ping-pong) (#2354)

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,12 @@ Binary wheels are available for CPython 3.10-3.14.
 
     Perform the arrive operation on an mbarrier. If `remote_cta_rank` is provided, signals the barrier in the specified remote CTA's shared memory (useful for multi-CTA synchronization).
 
+- `tlx.amd_sched_barrier(mask=0)`  **[AMD]**
+
+    Prevents selected AMD machine-instruction classes from crossing a source
+    boundary. It is a scheduling marker, not a workgroup barrier or memory
+    fence.
+
 ### Memory Fences
 
 - `tlx.fence(scope)` **[Hopper+]** issues a memory fence. The `scope` argument is required:

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -1288,3 +1288,20 @@ def test_a4w4_inter_wave_skinny_correctness_gfx950(device):
     actual = _a4w4_inter_wave_matmul(a, b, a_scales, b_scales)
     expected = _a4w4_reference(a, b, a_scales, b_scales)
     torch.testing.assert_close(actual, expected, atol=0.1, rtol=0.0)
+
+
+@triton.jit
+def _amd_sched_barrier_kernel(x_ptr, y_ptr, BLOCK: tl.constexpr):
+    offsets = tl.arange(0, BLOCK)
+    values = tl.load(x_ptr + offsets)
+    tlx.amd_sched_barrier()
+    tl.store(y_ptr + offsets, values)
+
+
+def test_amd_sched_barrier_compiles_gfx950():
+    compiled = compile_for_gfx950(
+        _amd_sched_barrier_kernel,
+        signature={"x_ptr": "*bf16", "y_ptr": "*bf16", "BLOCK": "constexpr"},
+        constexprs={"BLOCK": 64},
+    )
+    assert "llvm.amdgcn.sched.barrier" in compiled.asm["llir"]

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -2,6 +2,7 @@
 #include "Transforms/Passes.h"
 #include "amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "ir.h" // TritonOpBuilder
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Pass/PassManager.h"
 #include "nvidia/include/Dialect/NVGPU/IR/Dialect.h"
 #include "passes.h"
@@ -653,6 +654,10 @@ void init_triton_tlx_ir(py::module &&m) {
       .def("create_named_barrier_arrive",
            [](TritonOpBuilder &self, Value barrier, Value numThreads) -> void {
              self.create<ttng::NamedBarrierArriveOp>(barrier, numThreads);
+           })
+      .def("create_amd_sched_barrier",
+           [](TritonOpBuilder &self, int32_t mask) {
+             self.create<ROCDL::SchedBarrier>(mask);
            })
       .def("create_barrier_expect",
            [](TritonOpBuilder &self, Value mbarrerLoc, int expectBytes,

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -10,6 +10,7 @@ from .barrier import (
     fence_mbarrier_init_cluster,
     named_barrier_arrive,
     named_barrier_wait,
+    amd_sched_barrier,
 )
 from .dynamic_launch import (
     _alloc_clc_responses,
@@ -192,6 +193,7 @@ __all__ = [
     "fence_mbarrier_init_cluster",
     "named_barrier_wait",
     "named_barrier_arrive",
+    "amd_sched_barrier",
     # mma_ops
     "async_dot",
     "async_dot_scaled",

--- a/third_party/tlx/language/tlx/barrier.py
+++ b/third_party/tlx/language/tlx/barrier.py
@@ -211,3 +211,19 @@ def named_barrier_arrive(
     bar_handle = _semantic._convert_elem_to_ir_value(bar, require_i64=False)
     arrive_count_handle = _semantic._convert_elem_to_ir_value(arrive_count, require_i64=False)
     _semantic.builder.create_named_barrier_arrive(bar_handle, arrive_count_handle)
+
+
+@tl.builtin
+def amd_sched_barrier(mask: tl.constexpr = 0, _semantic=None):
+    """Prevent AMD machine instructions from crossing this source boundary.
+
+    This is a compiler scheduling marker, not a workgroup barrier or a memory
+    fence. It adds no synchronization between waves. ``mask=0`` blocks every
+    instruction class from crossing the boundary in either direction.
+    """
+    if _semantic.builder.options.backend_name != "hip":
+        raise NotImplementedError("tlx.amd_sched_barrier is only supported on AMD (HIP) backends")
+    mask = tl._unwrap_if_constexpr(mask)
+    assert isinstance(mask, int), f"mask must be a constexpr integer, got {type(mask).__name__}"
+    assert 0 <= mask <= 0xFFF, f"mask must use only AMD scheduling-class bits 0..11, got {mask:#x}"
+    _semantic.builder.create_amd_sched_barrier(mask)

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel_split_m.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel_split_m.py
@@ -170,11 +170,13 @@ def matmul_kernel_pingpong(
         cur = j % 2
         oth = 1 - cur
         with tlx.warp_pipeline_stage("mem", priority=1):
+            b_cur = tlx.local_load(tlx.local_view(smemB, cur))
+            tlx.amd_sched_barrier()
             tlx.async_load(ab_ptrs, tlx.local_view(smemA_bot, oth))
             tlx.async_load_commit_group()
-            ab_ptrs += BLOCK_K * stride_ak
+            tlx.amd_sched_barrier()
             at_cur = tlx.local_load(tlx.local_view(smemA_top, cur))
-            b_cur = tlx.local_load(tlx.local_view(smemB, cur))
+            ab_ptrs += BLOCK_K * stride_ak
 
         tlx.async_load_wait_group(3)
         with tlx.warp_pipeline_stage("mfma", priority=0):
@@ -183,11 +185,13 @@ def matmul_kernel_pingpong(
         with tlx.warp_pipeline_stage("mem", priority=1):
             tlx.async_load(b_ptrs, tlx.local_view(smemB, cur))
             tlx.async_load_commit_group()
+            tlx.amd_sched_barrier()
+            ab_cur = tlx.local_load(tlx.local_view(smemA_bot, cur))
+            tlx.amd_sched_barrier()
             tlx.async_load(at_ptrs, tlx.local_view(smemA_top, cur))
             tlx.async_load_commit_group()
             b_ptrs += BLOCK_K * stride_bk
             at_ptrs += BLOCK_K * stride_ak
-            ab_cur = tlx.local_load(tlx.local_view(smemA_bot, cur))
 
         tlx.async_load_wait_group(3)
         with tlx.warp_pipeline_stage("mfma", priority=0):


### PR DESCRIPTION
Summary:

Add tlx.sched_barrier(mask), an AMD/HIP instruction-scheduling fence that lowers
to rocdl.sched.barrier: frontend builtin, __init__ export, and the
create_sched_barrier dialect binding (with the ROCDL include). The split-M
ping-pong kernel uses it to pin the load/dot interleave.

Reviewed By: htyu

Differential Revision: D113562948
