### PR TITLE
[TLX] Fix Fa4 bwd register spilling

### DIFF
--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -1356,3 +1356,52 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     tt.return
   }
 }
+
+// -----
+
+// Regression test for "Shorten live range of SMEM operand of MMA".
+//
+// The MMA SMEM operand base address is computed with a *side-effecting* inline
+// PTX `add.s32` instead of a plain `llvm.add`. The side effect is what stops
+// LLVM from CSE-ing the address across MMAs: two MMAs reading the same SMEM
+// operand would otherwise share one address computation, giving that value a
+// very long live range and spilling registers in MMA-heavy kernels.
+//
+// The two tc_gen5_mma ops below share the same A and B SMEM operands at the same
+// offsets, so their per-operand address computations are structurally identical
+// -- exactly what CSE folds (this file's RUN line runs -cse). Each MMA still
+// emits its own side-effecting add.s32 for A and B, so all FOUR survive: a plain
+// (non-side-effecting) add would let CSE collapse them to 2.
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 256, 32]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 64, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: @two_mma_shared_smem_operand_no_cse
+  // Two MMAs, one side-effecting add.s32 per SMEM operand each -> 4 total, none
+  // folded by CSE despite the shared operands.
+  // CHECK-COUNT-4: llvm.inline_asm has_side_effects {{.*}}"add.s32 $0, $1, $2;", "=r,r,r"
+  // CHECK-NOT: "add.s32 $0, $1, $2;"
+  tt.func @two_mma_shared_smem_operand_no_cse(%a: !ttg.memdesc<64x16xf16, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<16x64xf16, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>,
+                       %barrierPred: i1) {
+    // Both MMAs read the same %a and %b, so the operand-descriptor addresses are
+    // identical CSE candidates; the side effect keeps them separate.
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred, %barrier[%barrierPred] {is_async} :
+       !ttg.memdesc<64x16xf16, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<16x64xf16, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred, %barrier[%barrierPred] {is_async} :
+       !ttg.memdesc<64x16xf16, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<16x64xf16, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
+    tt.return
+  }
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -175,10 +175,25 @@ public:
     currDesc.matrixBaseOffset = (smemByteOffsetb8 / 128) & mask;
     currDesc.baseAddress = 0;
     int32_t smemByteOffsetb128 = smemByteOffsetb8 >> 4;
+
     // Compute the base address at runtime to prevent LLVM from folding the
     // per-tile offset into a unique 64-bit constant. This produces a short
     // dependency chain (add→and→zext→add) that helps hide WGMMA latency.
-    Value fullAddrb128 = tb.add(baseSrcb128, tb.i32_val(smemByteOffsetb128));
+
+    // NOTE: intentionally use inline PTX with *side-effecting* here to
+    // compute an address. This hack is to prevent LLVM CSE which could
+    // cause two distant MMA sharing the same SMEM operand which would have
+    // a very long live range and cause register spill when there're many mma
+    // instructions. This way each MMA computes its own operand.
+    // TODO: do it for TMEM operand too?
+    PTXBuilder ptxBuilder;
+    auto &addInstr = *ptxBuilder.create("add.s32");
+    auto *addOut = ptxBuilder.newOperand("=r");
+    auto *addLhs = ptxBuilder.newOperand(baseSrcb128, "r");
+    auto *addRhs = ptxBuilder.newOperand(tb.i32_val(smemByteOffsetb128), "r");
+    addInstr(addOut, addLhs, addRhs);
+    Value fullAddrb128 =
+        ptxBuilder.launch(rewriter, loc, i32_ty, /*hasSideEffect=*/true);
     Value addrMasked = tb.and_(fullAddrb128, tb.i32_val(0x3FFF));
     Value addr64 = tb.zext(i64_ty, addrMasked);
     Value descVal = tb.add(tb.int_val(64, currDesc.descriptor), addr64);

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -1384,8 +1384,14 @@ def _bwd_mma_dots_2cta(
     tlx.barrier_wait(qt_fulls[q_buf_id], q_phase)
     tlx.barrier_wait(qk_empties[tmem_buf_id], tmem_phase ^ 1)
     qT = tlx.local_trans(qt_tiles[q_buf_id])
-    tlx.async_dot(k_tiles[kv_buf_id], qT, qk_tiles[tmem_buf_id], use_acc=False,
-                  mBarriers=[qk_fulls[tmem_buf_id], qt_empties[q_buf_id]], two_ctas=True)
+    tlx.async_dot(
+        k_tiles[kv_buf_id],
+        qT,
+        qk_tiles[tmem_buf_id],
+        use_acc=False,
+        mBarriers=[qk_fulls[tmem_buf_id], qt_empties[q_buf_id]],
+        two_ctas=True,
+    )
 
     # Dot 2: dpT = tl.dot(v, tl.trans(do))
     tlx.barrier_wait(dot_fulls[do_buf_id], do_phase)
@@ -1997,8 +2003,6 @@ def _bwd_compute_inner_loop(
     QK_READ_DONE_BAR: tl.constexpr = 10
     DP_READ_DONE_BAR: tl.constexpr = 11
     NUM_COMPUTE_THREADS: tl.constexpr = 8 * 32
-    # Column (query-axis) sub-tile width for the register-pressure split.
-    SUB_M: tl.constexpr = BLOCK_M1 // NUM_COMPUTE_SLICES
     if num_steps_override > 0:
         num_steps = num_steps_override
     else:
@@ -2015,36 +2019,26 @@ def _bwd_compute_inner_loop(
         tlx.barrier_wait(qk_fulls[tmem_buf_id], tmem_phase)
         tlx.barrier_wait(m_fulls[m_buf_id], m_phase)
 
-        # Register-pressure split: load/process part of the columns each time
-        for i in tl.static_range(NUM_COMPUTE_SLICES):
-            # ---  pT = exp2(qkT - m) for column slice i. ---
-            qkT = tlx.local_load(tlx.subslice(qk_tiles[tmem_buf_id], i * SUB_M, SUB_M))
-            m = tlx.local_load(tlx.local_slice(sM_tiles[m_buf_id], [i * SUB_M], [SUB_M]))
-            # qkT/pT are transposed: [BLOCK_N1 (keys), SUB_M (queries)]. Apply the
-            # causal mask to the logits via the R2P bitmask helper (keep query-cols m >= key-row
-            # n), then exp2 (exp2(-inf) = 0), avoiding the per-element
-            # ISETP arithmetic of `offs_m >= offs_n`. The per-key left bound is shifted by
-            # the slice's column base so the helper's local arange(0, SUB_M) maps
-            # to global queries [i*SUB_M, (i+1)*SUB_M).
-            sT = _sub_f32x2(qkT, m[None, :])
-            if STAGE == 1:
-                col_limit_left = (offs_n - curr_m - i * SUB_M)[:, None]
-                sT = _apply_causal_mask(sT, col_limit_left, SUB_M, keep_ge=True)
-            pT = tl.math.exp2(sT)
-            if i == 0:
-                pT0 = pT
-            else:  # NOTE: this is written in a way that assumes NUM_COMPUTE_SLICES is 2
-                pT1 = pT
+        qkT = tlx.local_load(qk_tiles[tmem_buf_id])
+        m = tlx.local_load(sM_tiles[m_buf_id])
+        # qkT/pT are transposed: [BLOCK_N1 (keys), BLOCK_M1 (queries)]. Apply the
+        # causal mask to the logits via the R2P bitmask helper (keep query-cols
+        # m >= key-row n), then exp2 (exp2(-inf) = 0), avoiding the per-element
+        # ISETP arithmetic of `offs_m >= offs_n`.
+        sT = _sub_f32x2(qkT, m[None, :])
+        if STAGE == 1:
+            col_limit_left = (offs_n - curr_m)[:, None]
+            sT = _apply_causal_mask(sT, col_limit_left, BLOCK_M1, keep_ge=True)
+        pT = tl.math.exp2(sT)
 
-            # Store P to TMEM.
-            ppT = pT.to(do_out_dtype)
-            # Hazard 1 (intra-task WAR): P (f16) aliases the upper half of the qk
-            # (f32) TMEM region; tcgen05 ld/st warp->chunk maps differ, so a fast
-            # warp's P store can overwrite a 32x32 chunk a slow warp has not read as
-            # qkT. Rendezvous all 8 compute warps between the read and the store.
-            # todo: check if it's sufficient to do this only for i==0
-            tlx.named_barrier_wait(QK_READ_DONE_BAR, NUM_COMPUTE_THREADS)
-            tlx.local_store(tlx.subslice(p_tiles[tmem_buf_id + P_BUF_OFFSET], i * SUB_M, SUB_M), ppT)
+        # Store P to TMEM.
+        ppT = pT.to(do_out_dtype)
+        # Hazard 1 (intra-task WAR): P (f16) aliases the upper half of the qk
+        # (f32) TMEM region; tcgen05 ld/st warp->chunk maps differ, so a fast
+        # warp's P store can overwrite a 32x32 chunk a slow warp has not read as
+        # qkT. Rendezvous all 8 compute warps between the read and the store.
+        tlx.named_barrier_wait(QK_READ_DONE_BAR, NUM_COMPUTE_THREADS)
+        tlx.local_store(p_tiles[tmem_buf_id + P_BUF_OFFSET], ppT)
         # P aliases the QK TMEM region, so qk_empties (which frees that region for
         # reuse) must be signaled after P is stored, not before. The
         # local_store->TMEM lowering auto-emits tcgen05.wait::st, so p_fulls
@@ -2056,36 +2050,19 @@ def _bwd_compute_inner_loop(
             tlx.barrier_arrive(qk_empties[tmem_buf_id])
             tlx.barrier_arrive(p_fulls[tmem_buf_id])
 
-        # --- Phase 3: dS = pT * (dpT - Di) for column slice i. ---
+        # --- Phase 3: Compute dS = pT * (dpT - Di). ---
         tlx.barrier_wait(dp_fulls[tmem_buf_id], tmem_phase)
-        for i in tl.static_range(NUM_COMPUTE_SLICES):
-            dpT = tlx.local_load(tlx.subslice(dp_tiles[tmem_buf_id], i * SUB_M, SUB_M))
-            if i == 0:
-                # only need to wait during the first slice
-                tlx.barrier_wait(d_fulls[d_buf_id], d_phase)
-
-            Di = tlx.local_load(tlx.local_slice(sD_tiles[d_buf_id], [i * SUB_M], [SUB_M]))
-            if i == NUM_COMPUTE_SLICES - 1:
-                # the last slice of Di is loaded
-                tlx.barrier_arrive(m_empties[m_buf_id])
-                tlx.barrier_arrive(d_empties[d_buf_id])
-            if i == 0:
-                pT = pT0
-            else:  # NOTE: this is written in a way that assumes NUM_COMPUTE_SLICES is 2
-                pT = pT1
-            dsT = _mul_f32x2(pT, _sub_f32x2(dpT, Di[None, :]))
-            dsT = dsT.to(q_out_dtype)
-            # Hazard 1 (intra-task WAR): dsT (f16) aliases dp's (f32) region -- same
-            # warp->chunk mismatch as the P store above.
-            # todo: check if it's sufficient to do this only for i==0
-            tlx.named_barrier_wait(DP_READ_DONE_BAR, NUM_COMPUTE_THREADS)
-            tlx.local_store(tlx.subslice(dsT_tmem_tiles[ds_buf_id], i * SUB_M, SUB_M), dsT)
-            if not USE_2CTA:
-                # 1-CTA: assemble the full transposed dS in SMEM (ds_tiles) one
-                # query-column slice at a time, so the MMA task reads the complete
-                # [BLOCK_N1, BLOCK_M1] tile.
-                tlx.local_store(tlx.local_slice(ds_tiles[ds_buf_id], [0, i * SUB_M], [BLOCK_N1, SUB_M]), dsT)
-
+        dpT = tlx.local_load(dp_tiles[tmem_buf_id])
+        tlx.barrier_wait(d_fulls[d_buf_id], d_phase)
+        Di = tlx.local_load(sD_tiles[d_buf_id])
+        tlx.barrier_arrive(m_empties[m_buf_id])
+        tlx.barrier_arrive(d_empties[d_buf_id])
+        dsT = _mul_f32x2(pT, _sub_f32x2(dpT, Di[None, :]))
+        dsT = dsT.to(q_out_dtype)
+        # Hazard 1 (intra-task WAR): dsT (f16) aliases dp's (f32) region -- same
+        # warp->chunk mismatch as the P store above.
+        tlx.named_barrier_wait(DP_READ_DONE_BAR, NUM_COMPUTE_THREADS)
+        tlx.local_store(dsT_tmem_tiles[ds_buf_id], dsT)
         # dsT aliases the dP TMEM region, so dp_empties (which frees that region
         # for reuse) must be signaled after dsT is stored, not before. The
         # local_store->TMEM lowering auto-emits tcgen05.wait::st (+barrier), so the
@@ -2130,8 +2107,7 @@ def _bwd_compute_inner_loop(
             )
             # NOTE: ds_peer_fulls wait + ds_fulls signal moved to relay task.
         else:
-            # ds_tiles was filled query-column slice by slice in the compute loop
-            # above; publish it once all slices are in SMEM.
+            tlx.local_store(ds_tiles[ds_buf_id], dsT)
             tlx.fence("async_shared")
             tlx.barrier_arrive(ds_fulls[ds_buf_id])
             tlx.barrier_arrive(dsT_tmem_fulls[ds_buf_id])
@@ -2459,7 +2435,7 @@ def _attn_bwd_ws(
         cluster_cta_rank = 0
         is_leader = True  # noqa: F841
 
-    with tlx.async_tasks(exclusive=True):
+    with tlx.async_tasks():
         # compute
         with tlx.async_task("default"):
             blk_idx = 0
@@ -2668,7 +2644,7 @@ def _attn_bwd_ws(
                 tlx.barrier_arrive(dk_empties[kv_buf_id])
 
         # reduction
-        with tlx.async_task(num_warps=4, registers=104):
+        with tlx.async_task(num_warps=4, registers=88):
             blk_idx = 0
             curr_m = start_m
             step_m = BLOCK_M1
@@ -2743,7 +2719,7 @@ def _attn_bwd_ws(
             tlx.async_descriptor_store_wait(0)
 
         # mma
-        with tlx.async_task(num_warps=1, registers=136):
+        with tlx.async_task(num_warps=1, registers=88):
             blk_idx = 0
             if is_leader:
                 kv_buf_id, kv_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_KV)
@@ -2850,7 +2826,7 @@ def _attn_bwd_ws(
                 tile_count += 1
 
         # load
-        with tlx.async_task(num_warps=1, registers=136):
+        with tlx.async_task(num_warps=1, registers=88):
             blk_idx = 0
             if USE_2CTA:
                 blk_idx = _bwd_load_2cta(
@@ -2970,7 +2946,7 @@ def _attn_bwd_ws(
         # relay — waits for peer's DSMEM to arrive, then signals ds_fulls
         # so the MMA task can read the combined ds_tiles.
         if USE_2CTA:
-            with tlx.async_task(num_warps=1, registers=136):
+            with tlx.async_task(num_warps=1, registers=40):
                 for blk_idx_relay in range(num_steps):
                     ds_buf_id_relay, ds_phase_relay = get_bufidx_phase(blk_idx_relay, NUM_BUFFERS_DS)
                     tlx.barrier_wait(ds_peer_fulls[ds_buf_id_relay], ds_phase_relay)

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -2435,7 +2435,7 @@ def _attn_bwd_ws(
         cluster_cta_rank = 0
         is_leader = True  # noqa: F841
 
-    with tlx.async_tasks():
+    with tlx.async_tasks(exclusive=True):
         # compute
         with tlx.async_task("default"):
             blk_idx = 0

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -1384,14 +1384,8 @@ def _bwd_mma_dots_2cta(
     tlx.barrier_wait(qt_fulls[q_buf_id], q_phase)
     tlx.barrier_wait(qk_empties[tmem_buf_id], tmem_phase ^ 1)
     qT = tlx.local_trans(qt_tiles[q_buf_id])
-    tlx.async_dot(
-        k_tiles[kv_buf_id],
-        qT,
-        qk_tiles[tmem_buf_id],
-        use_acc=False,
-        mBarriers=[qk_fulls[tmem_buf_id], qt_empties[q_buf_id]],
-        two_ctas=True,
-    )
+    tlx.async_dot(k_tiles[kv_buf_id], qT, qk_tiles[tmem_buf_id], use_acc=False,
+                  mBarriers=[qk_fulls[tmem_buf_id], qt_empties[q_buf_id]], two_ctas=True)
 
     # Dot 2: dpT = tl.dot(v, tl.trans(do))
     tlx.barrier_wait(dot_fulls[do_buf_id], do_phase)
@@ -2003,6 +1997,8 @@ def _bwd_compute_inner_loop(
     QK_READ_DONE_BAR: tl.constexpr = 10
     DP_READ_DONE_BAR: tl.constexpr = 11
     NUM_COMPUTE_THREADS: tl.constexpr = 8 * 32
+    # Column (query-axis) sub-tile width for the register-pressure split.
+    SUB_M: tl.constexpr = BLOCK_M1 // NUM_COMPUTE_SLICES
     if num_steps_override > 0:
         num_steps = num_steps_override
     else:
@@ -2019,26 +2015,36 @@ def _bwd_compute_inner_loop(
         tlx.barrier_wait(qk_fulls[tmem_buf_id], tmem_phase)
         tlx.barrier_wait(m_fulls[m_buf_id], m_phase)
 
-        qkT = tlx.local_load(qk_tiles[tmem_buf_id])
-        m = tlx.local_load(sM_tiles[m_buf_id])
-        # qkT/pT are transposed: [BLOCK_N1 (keys), BLOCK_M1 (queries)]. Apply the
-        # causal mask to the logits via the R2P bitmask helper (keep query-cols
-        # m >= key-row n), then exp2 (exp2(-inf) = 0), avoiding the per-element
-        # ISETP arithmetic of `offs_m >= offs_n`.
-        sT = _sub_f32x2(qkT, m[None, :])
-        if STAGE == 1:
-            col_limit_left = (offs_n - curr_m)[:, None]
-            sT = _apply_causal_mask(sT, col_limit_left, BLOCK_M1, keep_ge=True)
-        pT = tl.math.exp2(sT)
+        # Register-pressure split: load/process part of the columns each time
+        for i in tl.static_range(NUM_COMPUTE_SLICES):
+            # ---  pT = exp2(qkT - m) for column slice i. ---
+            qkT = tlx.local_load(tlx.subslice(qk_tiles[tmem_buf_id], i * SUB_M, SUB_M))
+            m = tlx.local_load(tlx.local_slice(sM_tiles[m_buf_id], [i * SUB_M], [SUB_M]))
+            # qkT/pT are transposed: [BLOCK_N1 (keys), SUB_M (queries)]. Apply the
+            # causal mask to the logits via the R2P bitmask helper (keep query-cols m >= key-row
+            # n), then exp2 (exp2(-inf) = 0), avoiding the per-element
+            # ISETP arithmetic of `offs_m >= offs_n`. The per-key left bound is shifted by
+            # the slice's column base so the helper's local arange(0, SUB_M) maps
+            # to global queries [i*SUB_M, (i+1)*SUB_M).
+            sT = _sub_f32x2(qkT, m[None, :])
+            if STAGE == 1:
+                col_limit_left = (offs_n - curr_m - i * SUB_M)[:, None]
+                sT = _apply_causal_mask(sT, col_limit_left, SUB_M, keep_ge=True)
+            pT = tl.math.exp2(sT)
+            if i == 0:
+                pT0 = pT
+            else:  # NOTE: this is written in a way that assumes NUM_COMPUTE_SLICES is 2
+                pT1 = pT
 
-        # Store P to TMEM.
-        ppT = pT.to(do_out_dtype)
-        # Hazard 1 (intra-task WAR): P (f16) aliases the upper half of the qk
-        # (f32) TMEM region; tcgen05 ld/st warp->chunk maps differ, so a fast
-        # warp's P store can overwrite a 32x32 chunk a slow warp has not read as
-        # qkT. Rendezvous all 8 compute warps between the read and the store.
-        tlx.named_barrier_wait(QK_READ_DONE_BAR, NUM_COMPUTE_THREADS)
-        tlx.local_store(p_tiles[tmem_buf_id + P_BUF_OFFSET], ppT)
+            # Store P to TMEM.
+            ppT = pT.to(do_out_dtype)
+            # Hazard 1 (intra-task WAR): P (f16) aliases the upper half of the qk
+            # (f32) TMEM region; tcgen05 ld/st warp->chunk maps differ, so a fast
+            # warp's P store can overwrite a 32x32 chunk a slow warp has not read as
+            # qkT. Rendezvous all 8 compute warps between the read and the store.
+            # todo: check if it's sufficient to do this only for i==0
+            tlx.named_barrier_wait(QK_READ_DONE_BAR, NUM_COMPUTE_THREADS)
+            tlx.local_store(tlx.subslice(p_tiles[tmem_buf_id + P_BUF_OFFSET], i * SUB_M, SUB_M), ppT)
         # P aliases the QK TMEM region, so qk_empties (which frees that region for
         # reuse) must be signaled after P is stored, not before. The
         # local_store->TMEM lowering auto-emits tcgen05.wait::st, so p_fulls
@@ -2050,19 +2056,36 @@ def _bwd_compute_inner_loop(
             tlx.barrier_arrive(qk_empties[tmem_buf_id])
             tlx.barrier_arrive(p_fulls[tmem_buf_id])
 
-        # --- Phase 3: Compute dS = pT * (dpT - Di). ---
+        # --- Phase 3: dS = pT * (dpT - Di) for column slice i. ---
         tlx.barrier_wait(dp_fulls[tmem_buf_id], tmem_phase)
-        dpT = tlx.local_load(dp_tiles[tmem_buf_id])
-        tlx.barrier_wait(d_fulls[d_buf_id], d_phase)
-        Di = tlx.local_load(sD_tiles[d_buf_id])
-        tlx.barrier_arrive(m_empties[m_buf_id])
-        tlx.barrier_arrive(d_empties[d_buf_id])
-        dsT = _mul_f32x2(pT, _sub_f32x2(dpT, Di[None, :]))
-        dsT = dsT.to(q_out_dtype)
-        # Hazard 1 (intra-task WAR): dsT (f16) aliases dp's (f32) region -- same
-        # warp->chunk mismatch as the P store above.
-        tlx.named_barrier_wait(DP_READ_DONE_BAR, NUM_COMPUTE_THREADS)
-        tlx.local_store(dsT_tmem_tiles[ds_buf_id], dsT)
+        for i in tl.static_range(NUM_COMPUTE_SLICES):
+            dpT = tlx.local_load(tlx.subslice(dp_tiles[tmem_buf_id], i * SUB_M, SUB_M))
+            if i == 0:
+                # only need to wait during the first slice
+                tlx.barrier_wait(d_fulls[d_buf_id], d_phase)
+
+            Di = tlx.local_load(tlx.local_slice(sD_tiles[d_buf_id], [i * SUB_M], [SUB_M]))
+            if i == NUM_COMPUTE_SLICES - 1:
+                # the last slice of Di is loaded
+                tlx.barrier_arrive(m_empties[m_buf_id])
+                tlx.barrier_arrive(d_empties[d_buf_id])
+            if i == 0:
+                pT = pT0
+            else:  # NOTE: this is written in a way that assumes NUM_COMPUTE_SLICES is 2
+                pT = pT1
+            dsT = _mul_f32x2(pT, _sub_f32x2(dpT, Di[None, :]))
+            dsT = dsT.to(q_out_dtype)
+            # Hazard 1 (intra-task WAR): dsT (f16) aliases dp's (f32) region -- same
+            # warp->chunk mismatch as the P store above.
+            # todo: check if it's sufficient to do this only for i==0
+            tlx.named_barrier_wait(DP_READ_DONE_BAR, NUM_COMPUTE_THREADS)
+            tlx.local_store(tlx.subslice(dsT_tmem_tiles[ds_buf_id], i * SUB_M, SUB_M), dsT)
+            if not USE_2CTA:
+                # 1-CTA: assemble the full transposed dS in SMEM (ds_tiles) one
+                # query-column slice at a time, so the MMA task reads the complete
+                # [BLOCK_N1, BLOCK_M1] tile.
+                tlx.local_store(tlx.local_slice(ds_tiles[ds_buf_id], [0, i * SUB_M], [BLOCK_N1, SUB_M]), dsT)
+
         # dsT aliases the dP TMEM region, so dp_empties (which frees that region
         # for reuse) must be signaled after dsT is stored, not before. The
         # local_store->TMEM lowering auto-emits tcgen05.wait::st (+barrier), so the
@@ -2107,7 +2130,8 @@ def _bwd_compute_inner_loop(
             )
             # NOTE: ds_peer_fulls wait + ds_fulls signal moved to relay task.
         else:
-            tlx.local_store(ds_tiles[ds_buf_id], dsT)
+            # ds_tiles was filled query-column slice by slice in the compute loop
+            # above; publish it once all slices are in SMEM.
             tlx.fence("async_shared")
             tlx.barrier_arrive(ds_fulls[ds_buf_id])
             tlx.barrier_arrive(dsT_tmem_fulls[ds_buf_id])
@@ -2435,7 +2459,7 @@ def _attn_bwd_ws(
         cluster_cta_rank = 0
         is_leader = True  # noqa: F841
 
-    with tlx.async_tasks():
+    with tlx.async_tasks(exclusive=True):
         # compute
         with tlx.async_task("default"):
             blk_idx = 0
@@ -2644,7 +2668,7 @@ def _attn_bwd_ws(
                 tlx.barrier_arrive(dk_empties[kv_buf_id])
 
         # reduction
-        with tlx.async_task(num_warps=4, registers=88):
+        with tlx.async_task(num_warps=4, registers=104):
             blk_idx = 0
             curr_m = start_m
             step_m = BLOCK_M1
@@ -2719,7 +2743,7 @@ def _attn_bwd_ws(
             tlx.async_descriptor_store_wait(0)
 
         # mma
-        with tlx.async_task(num_warps=1, registers=88):
+        with tlx.async_task(num_warps=1, registers=136):
             blk_idx = 0
             if is_leader:
                 kv_buf_id, kv_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_KV)
@@ -2826,7 +2850,7 @@ def _attn_bwd_ws(
                 tile_count += 1
 
         # load
-        with tlx.async_task(num_warps=1, registers=88):
+        with tlx.async_task(num_warps=1, registers=136):
             blk_idx = 0
             if USE_2CTA:
                 blk_idx = _bwd_load_2cta(
@@ -2946,7 +2970,7 @@ def _attn_bwd_ws(
         # relay — waits for peer's DSMEM to arrive, then signals ds_fulls
         # so the MMA task can read the combined ds_tiles.
         if USE_2CTA:
-            with tlx.async_task(num_warps=1, registers=40):
+            with tlx.async_task(num_warps=1, registers=136):
                 for blk_idx_relay in range(num_steps):
                     ds_buf_id_relay, ds_phase_relay = get_bufidx_phase(blk_idx_relay, NUM_BUFFERS_DS)
                     tlx.barrier_wait(ds_peer_fulls[ds_buf_id_relay], ds_phase_relay)


### PR DESCRIPTION

We fix the TLX FA4 bwd 2cta register spilling issue. It involves a few parts:
- follow CuteDSL FA4's way to sutile registers in compute loop
- tune the reg allocation among ws tasks
- fix MMA operand live range as ptx level to reduce MMA task's reg pressure
- revert `follow CuteDSL FA4's way to sutile registers in compute loop`

## Step 0: enable `exclusive=True` 
This enables faster WS and is just something we missed in an earlier commit.

Now this serves as the baseline of this commit. Picking `B=4, H=48, Seq=1024, D=128`, run 
with ncu and then show kernel duration and local memory access:

```
ncu --import /data/users/pchen7e4/staging_ncu_trace.ncu-rep  --print-summary per-kernel --page raw --metrics gpu__time_duration.sum,l1tex__t_sectors_pipe_lsu_mem_local_op_ld.sum,l1tex__t_sectors_pipe_lsu_mem_local_op_st.sum
...
_attn_bwd_ws (8, 48, 4)x(512, 1, 1), Device 0, CC 10.0, Invocations 1
Metric Name                                   Metric Unit Minimum        Maximum        Average
  --------------------------------------------- ----------- -------------- -------------- --------------
gpu__time_duration.sum                        us          424.512000     424.512000     424.512000    
l1tex__t_sectors_pipe_lsu_mem_local_op_ld.sum sector      2700288.000000 2700288.000000 2700288.000000
l1tex__t_sectors_pipe_lsu_mem_local_op_st.sum sector      543744.000000  543744.000000  543744.000000
```
## Step 1: compute loop subtiling and reg

CuteDSL FA4 is dividing the tensor into 2 stages(slices): https://github.com/Dao-AILab/flash-attention/blob/890f23878394cbff75a92e415f7b7e99b8fbccba/flash_attn/cute/flash_bwd_sm100.py#L3109

Since the arith ops in the middle can easily increase reg pressure, it's a good idea to do a slice at a time to 
reduce peak reg usage. Notably we need to keep full `pT` (i.e. pT0 and pT1) for dS calculation, but other 
intermediate tensors will not be kept in full anytime.

This indeed reduced the reg requirement of compute_loop from over 160 to about 128:
<img width="1521" height="256" alt="Screenshot 2026-07-24 at 10 02 42" src="https://github.com/user-attachments/assets/89fb53a8-57a5-4ab8-a595-d44d5f68485d" />

vs

<img width="1427" height="376" alt="Screenshot 2026-07-24 at 10 03 25" src="https://github.com/user-attachments/assets/ddc0d864-2b56-49e1-9499-1160aa424105" />



Then we tune the WS reg allocations to give more to other tasks.
Now somehow the register spilling gets worse, possibly due to less regs allocated to compute loop, but we still see lots of spilling happening in MMA warp anyway.

```
_attn_bwd_ws (8, 48, 4)x(512, 1, 1), Device 0, CC 10.0, Invocations 1
  Metric Name                                   Metric Unit Minimum        Maximum        Average       
  --------------------------------------------- ----------- -------------- -------------- --------------
  gpu__time_duration.sum                        us          442.016000     442.016000     442.016000    
  l1tex__t_sectors_pipe_lsu_mem_local_op_ld.sum sector      6049536.000000 6049536.000000 6049536.000000
  l1tex__t_sectors_pipe_lsu_mem_local_op_st.sum sector      1041408.000000 1041408.000000 1041408.000000
```

## Step 2: fix MMA operand live range

Suppose we have a kernel structure like this:
```
dot(a1, b1)
... lots of other ops ...
dot(a1, b1)
```
When lowering each MMA, compiler tries to generate a few arith ops to bake address offset into a value to be the 
final mem desc value passed to MMA instruction.

```
desc_a = compute(a1)
dot(desc_a, ...)
...
desc_a = compute(a1)
dot(desc_a, ...)
```

Since the two dots share the same operand, compiler is smart enough to do CSE and reuse the same memdesc value:
```
desc_a = compute(a1)
dot(desc_a, ...)
...
dot(desc_a, ...)
```
This causes `desc_a` to have a very long live range. In FA4 bwd, there're many dot ops, each generating multiple MMA 
instructions (atoms) so we're seeing a steady live reg increase eventually leading to spilling:
<img width="1610" height="467" alt="Screenshot 2026-07-24 at 10 09 14" src="https://github.com/user-attachments/assets/82faa65d-20e5-4121-a9c6-c54cf675d691" />

The fix is a hack to replace desc_a calculation with inline ptx marked with side effect to prevent CSE. It significantly 
reduced the reg pressure of MMA warp:
<img width="1768" height="511" alt="Screenshot 2026-07-24 at 10 10 33" src="https://github.com/user-attachments/assets/ff3d310e-3187-49d4-be6e-9769501d8f23" />


And ncu shows 0 reg pressure and a 2.7% tflops improvement eventually:
```
_attn_bwd_ws (8, 48, 4)x(512, 1, 1), Device 0, CC 10.0, Invocations 1
  Metric Name                                   Metric Unit Minimum    Maximum    Average   
  --------------------------------------------- ----------- ---------- ---------- ----------
  gpu__time_duration.sum                        us          413.184000 413.184000 413.184000
  l1tex__t_sectors_pipe_lsu_mem_local_op_ld.sum sector      0.000000   0.000000   0.000000  
  l1tex__t_sectors_pipe_lsu_mem_local_op_st.sum sector      0.000000   0.000000   0.000000
  ```
<img width="813" height="296" alt="Screenshot 2026-07-24 at 10 11 16" src="https://github.com/user-attachments/assets/4cdd6331-b4f6-4611-982d-44c3a128b586" />



### Perf result for sqe_len=8192

```
_attn_bwd_ws (64, 48, 4)x(512, 1, 1), Device 0, CC 10.0, Invocations 1
  Metric Name                                   Metric Unit Minimum          Maximum          Average         
  --------------------------------------------- ----------- ---------------- ---------------- ----------------
  gpu__time_duration.sum                        ms          16.869408        16.869408        16.869408       
  l1tex__t_sectors_pipe_lsu_mem_local_op_ld.sum sector      152150016.000000 152150016.000000 152150016.000000
  l1tex__t_sectors_pipe_lsu_mem_local_op_st.sum sector      15802368.000000  15802368.000000  15802368.000000
```

vs

```
Metric Name                                   Metric Unit Minimum   Maximum   Average  
  --------------------------------------------- ----------- --------- --------- ---------
  gpu__time_duration.sum                        ms          17.243136 17.243136 17.243136
  l1tex__t_sectors_pipe_lsu_mem_local_op_ld.sum sector      0.000000  0.000000  0.000000 
  l1tex__t_sectors_pipe_lsu_mem_local_op_st.sum sector      0.000000  0.000000  0.000000
```
A 2.2% regression. 

This is due to the bubble coming from compute loop subtiling.

## Step 3: revert step 1

Due to step 2, we're doing a fantastic job reducing reg requirement from mma warp, so we indeed can give sufficient registers to compute loop to avoid introducing bubble. CuteDSL FA4 gives 104 registers to mma warp while we're not having any spilling keeping the 88 registers.

So, we do NOT need to strictly follow CuteDSL for compute loop here.

## Final result:
seq_len=8192
```
_attn_bwd_ws (64, 48, 4)x(512, 1, 1), Device 0, CC 10.0, Invocations 1
  Metric Name                                   Metric Unit Minimum   Maximum   Average  
  --------------------------------------------- ----------- --------- --------- ---------
  gpu__time_duration.sum                        ms          16.323424 16.323424 16.323424
  l1tex__t_sectors_pipe_lsu_mem_local_op_ld.sum sector      0.000000  0.000000  0.000000 
  l1tex__t_sectors_pipe_lsu_mem_local_op_st.sum sector      0.000000  0.000000  0.000000
```

Tflops gain is **3.3%**

seq_len=1024
```
Metric Name                                   Metric Unit Minimum    Maximum    Average   
  --------------------------------------------- ----------- ---------- ---------- ----------
  gpu__time_duration.sum                        us          400.416000 400.416000 400.416000
  l1tex__t_sectors_pipe_lsu_mem_local_op_ld.sum sector      0.000000   0.000000   0.000000  
  l1tex__t_sectors_pipe_lsu_mem_local_op_st.sum sector      0.000000   0.000000   0.000000  
```

Tflops gain is **6%**


Test plan: `pytest   third_party/tlx/tutorials/testing/test_correctness.py::test_blackwell_fa_ws_pipelined_persistent_bwd`