### PR TITLE
[TritonGPU][NPOT] Select one modular alias for atomics

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -355,6 +355,14 @@ Value emitRedundantThreadPredicate(
     ConversionPatternRewriter &rewriter, Location loc,
     const TargetInfoBase &targetInfo);
 
+// For a modular tensor layout, return one predicate per register that selects
+// exactly one physical representative of each logical tensor element. The
+// predicates include redundantThreadPredicate. Returns an empty vector for
+// non-modular layouts and failure for unsupported modular layouts.
+FailureOr<SmallVector<Value>> emitCanonicalIndexPredicates(
+    Location loc, RewriterBase &rewriter, const TargetInfoBase &targetInfo,
+    RankedTensorType tensorTy, Value redundantThreadPredicate);
+
 // Takes two values that may be boolean, or null to represent constant True.
 Value maybeAnd(OpBuilder &builder, Location loc, Value a, Value b);
 

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -336,6 +336,163 @@ Value emitRedundantThreadPredicate(
   return pred;
 }
 
+struct CanonicalOwnerBasis {
+  StringAttr inDim;
+  int bit;
+  int32_t value;
+};
+
+struct CanonicalOwnerBound {
+  SmallVector<CanonicalOwnerBasis> bases;
+  int32_t upperBound;
+};
+
+static FailureOr<SmallVector<CanonicalOwnerBound>>
+getCanonicalOwnerBounds(const LinearLayout &layout) {
+  SmallVector<CanonicalOwnerBound> bounds;
+
+  // Distributed layouts decompose into binary coordinates, optionally joined
+  // by mixed-radix stages. For example, a 48-element dimension split across
+  // two CTAs has bases [1, 2, 4, 8, 16] for a 24-element CTA-local coordinate
+  // and basis [24] for the block coordinate. Each NPOT stage needs its own
+  // pre-modulo bound.
+  for (StringAttr outDim : layout.getOutDimNames()) {
+    SmallVector<CanonicalOwnerBasis> nonzeroBases;
+    for (StringAttr inDim : layout.getInDimNames()) {
+      for (int bit = 0; bit < layout.getInDimSizeLog2(inDim); ++bit) {
+        int32_t basis = layout.getBasis(inDim, bit, outDim);
+        if (basis != 0)
+          nonzeroBases.push_back({inDim, bit, basis});
+      }
+    }
+    llvm::sort(nonzeroBases, [](const CanonicalOwnerBasis &lhs,
+                                const CanonicalOwnerBasis &rhs) {
+      return lhs.value < rhs.value;
+    });
+
+    int64_t stride = 1;
+    int basisStart = 0;
+    while (basisStart < nonzeroBases.size()) {
+      int basisCount = 0;
+      while (basisStart + basisCount < nonzeroBases.size() &&
+             nonzeroBases[basisStart + basisCount].value ==
+                 stride * (int64_t{1} << basisCount)) {
+        ++basisCount;
+      }
+      if (basisCount == 0)
+        return failure();
+
+      int64_t stageExtent;
+      if (basisStart + basisCount < nonzeroBases.size()) {
+        int64_t nextStride = nonzeroBases[basisStart + basisCount].value;
+        if (nextStride % stride != 0)
+          return failure();
+        stageExtent = nextStride / stride;
+      } else {
+        int64_t outDimSize = layout.getOutDimSize(outDim);
+        if (outDimSize % stride != 0)
+          return failure();
+        stageExtent = outDimSize / stride;
+      }
+      if (stageExtent <= 0 || llvm::Log2_64_Ceil(stageExtent) != basisCount)
+        return failure();
+
+      if (!llvm::isPowerOf2_64(stageExtent)) {
+        CanonicalOwnerBound &bound = bounds.emplace_back();
+        bound.upperBound = stageExtent;
+        for (int i = 0; i < basisCount; ++i) {
+          CanonicalOwnerBasis basis = nonzeroBases[basisStart + i];
+          basis.value /= stride;
+          bound.bases.push_back(basis);
+        }
+      }
+
+      stride *= stageExtent;
+      basisStart += basisCount;
+    }
+    if (stride != layout.getOutDimSize(outDim))
+      return failure();
+  }
+  return bounds;
+}
+
+FailureOr<SmallVector<Value>> emitCanonicalIndexPredicates(
+    Location loc, RewriterBase &rewriter, const TargetInfoBase &targetInfo,
+    RankedTensorType tensorTy, Value redundantThreadPredicate) {
+  LinearLayout layout = toLinearLayout(tensorTy);
+  if (!layout.isModular())
+    return SmallVector<Value>{};
+
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  MLIRContext *ctx = rewriter.getContext();
+  auto kRegister = str_attr("register");
+  auto kLane = str_attr("lane");
+  auto kWarp = str_attr("warp");
+  auto kBlock = str_attr("block");
+  SmallVector<StringAttr> expectedInDims = {kRegister, kLane, kWarp, kBlock};
+  if (!llvm::equal(layout.getInDimNames(), expectedInDims))
+    return failure();
+  for (const auto &basis : llvm::make_second_range(layout.getBases())) {
+    for (const auto &values : basis) {
+      if (llvm::count_if(values, [](int32_t value) { return value != 0; }) > 1)
+        return failure();
+    }
+  }
+  FailureOr<SmallVector<CanonicalOwnerBound>> ownerBounds =
+      getCanonicalOwnerBounds(layout);
+  if (failed(ownerBounds))
+    return failure();
+
+  Value zero = b.i32_val(0);
+  auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+  Value blockId = layout.getInDimSize(kBlock) == 1
+                      ? zero
+                      : targetInfo.getClusterCTAId(rewriter, loc);
+
+  SmallVector<Value> predicates(layout.getInDimSize(kRegister),
+                                redundantThreadPredicate);
+  auto inputValue = [&](StringAttr inDim) {
+    if (inDim == kLane)
+      return laneId;
+    if (inDim == kWarp)
+      return warpId;
+    assert(inDim == kBlock);
+    return blockId;
+  };
+
+  for (const CanonicalOwnerBound &bound : *ownerBounds) {
+    Value dynamicCoordinate = zero;
+    for (const CanonicalOwnerBasis &basis : bound.bases) {
+      if (basis.inDim == kRegister)
+        continue;
+      Value bit =
+          b.and_(inputValue(basis.inDim), b.i32_val(uint32_t{1} << basis.bit));
+      int sourceBit = basis.bit;
+      int targetBit = llvm::Log2_32(basis.value);
+      if (targetBit > sourceBit)
+        bit = b.shl(bit, b.i32_val(targetBit - sourceBit));
+      else if (targetBit < sourceBit)
+        bit = b.lshr(bit, b.i32_val(sourceBit - targetBit));
+      dynamicCoordinate = b.or_(dynamicCoordinate, bit, /*disjoint=*/true);
+    }
+    for (int reg = 0; reg < layout.getInDimSize(kRegister); ++reg) {
+      int32_t registerCoordinate = 0;
+      for (const CanonicalOwnerBasis &basis : bound.bases) {
+        if (basis.inDim == kRegister &&
+            (static_cast<uint64_t>(reg) & (uint64_t{1} << basis.bit)))
+          registerCoordinate |= basis.value;
+      }
+      Value coordinate = dynamicCoordinate;
+      if (registerCoordinate != 0)
+        coordinate = b.or_(coordinate, b.i32_val(registerCoordinate),
+                           /*disjoint=*/true);
+      Value inBounds = b.icmp_ult(coordinate, b.i32_val(bound.upperBound));
+      predicates[reg] = maybeAnd(rewriter, loc, predicates[reg], inBounds);
+    }
+  }
+  return predicates;
+}
+
 } // namespace triton::gpu
 
 // Cheap modulo for inputs provably < 2N: compare-and-subtract (2 ops vs

--- a/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
@@ -571,6 +571,19 @@ public:
     Value threadPred = ttg::emitRedundantThreadPredicate(freeVarMasks, rewriter,
                                                          loc, *targetInfo);
     uint32_t regMask = freeVarMasks.lookup(str_attr("reg"));
+    auto ptrTensorTy = dyn_cast<RankedTensorType>(op.getPtr().getType());
+    SmallVector<Value> canonicalPredicates;
+    if (ptrTensorTy) {
+      auto predicates = ttg::emitCanonicalIndexPredicates(
+          loc, rewriter, *targetInfo, ptrTensorTy, threadPred);
+      if (failed(predicates))
+        return rewriter.notifyMatchFailure(
+            op, "modular layout has no supported canonical atomic owner");
+      canonicalPredicates = std::move(*predicates);
+      if (!canonicalPredicates.empty() && !op.getResult().use_empty())
+        return rewriter.notifyMatchFailure(
+            op, "results of modular atomics require alias redistribution");
+    }
     auto sourceLoc = materializeSourceLocation(rewriter, loc);
     auto eventStateTy = getGSanAtomicEventStateType(rewriter);
     Value eventState = LLVM::AllocaOp::create(rewriter, loc, ptr_ty(ctx),
@@ -587,8 +600,9 @@ public:
       }
 
       Value pred =
-          llMask ? ttg::maybeAnd(rewriter, loc, threadPred, maskElements[i])
-                 : threadPred;
+          !canonicalPredicates.empty() ? canonicalPredicates[i] : threadPred;
+      if (llMask)
+        pred = ttg::maybeAnd(rewriter, loc, pred, maskElements[i]);
       Value rmwPtr = ptrElements[i];
       Value rmwVal = valElements[i];
 
@@ -673,6 +687,19 @@ public:
     Value threadPred = ttg::emitRedundantThreadPredicate(freeVarMasks, rewriter,
                                                          loc, *targetInfo);
     uint32_t regMask = freeVarMasks.lookup(str_attr("reg"));
+    auto ptrTensorTy = dyn_cast<RankedTensorType>(op.getPtr().getType());
+    SmallVector<Value> canonicalPredicates;
+    if (ptrTensorTy) {
+      auto predicates = ttg::emitCanonicalIndexPredicates(
+          loc, rewriter, *targetInfo, ptrTensorTy, threadPred);
+      if (failed(predicates))
+        return rewriter.notifyMatchFailure(
+            op, "modular layout has no supported canonical atomic owner");
+      canonicalPredicates = std::move(*predicates);
+      if (!canonicalPredicates.empty() && !op.getResult().use_empty())
+        return rewriter.notifyMatchFailure(
+            op, "results of modular atomics require alias redistribution");
+    }
     auto sourceLoc = materializeSourceLocation(rewriter, loc);
     auto eventStateTy = getGSanAtomicEventStateType(rewriter);
     Value eventState = LLVM::AllocaOp::create(rewriter, loc, ptr_ty(ctx),
@@ -688,7 +715,8 @@ public:
         continue;
       }
 
-      Value pred = threadPred;
+      Value pred =
+          !canonicalPredicates.empty() ? canonicalPredicates[i] : threadPred;
       Value casPtr = ptrElements[i];
       Value casCmp = cmpElements[i];
       Value casVal = valElements[i];

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -105,9 +105,10 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
     ModuleOp moduleOp = getOperation();
 
     // Modular layouts can have multiple physical slots for one logical tensor
-    // element. Loads and stores tolerate equivalent duplicate values, but an
-    // atomic would apply the update more than once. Reject until lowering can
-    // predicate a canonical representative for every modular alias class.
+    // element. Result-unused atomics select one canonical representative in
+    // lowering. Consumed results still require redistributing the owner's old
+    // value to its aliases. Multi-CTA ownership remains gated until validated
+    // on cluster-capable hardware.
     if (triton::tools::getBoolEnv("TRITON_ALLOW_NPOT")) {
       bool hasUnsupportedAtomic = false;
       moduleOp.walk([&](Operation *op) {
@@ -119,9 +120,24 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
               return llvm::isPowerOf2_64(dim);
             }))
           return;
-        op->emitError("NPOT atomic operations are not yet supported with "
-                      "modular tensor layouts");
-        hasUnsupportedAtomic = true;
+        Value atomicValue = isa<triton::AtomicRMWOp>(op)
+                                ? cast<triton::AtomicRMWOp>(op).getVal()
+                                : cast<triton::AtomicCASOp>(op).getVal();
+        Type elementType =
+            cast<RankedTensorType>(atomicValue.getType()).getElementType();
+        if (elementType.getIntOrFloatBitWidth() < 32) {
+          op->emitError("NPOT atomic operations do not yet support element "
+                        "types narrower than 32 bits");
+          hasUnsupportedAtomic = true;
+        } else if (!op->getResult(0).use_empty()) {
+          op->emitError("NPOT atomic results are not yet supported with "
+                        "modular tensor layouts");
+          hasUnsupportedAtomic = true;
+        } else if (triton::gpu::TritonGPUDialect::getNumCTAs(moduleOp) != 1) {
+          op->emitError("NPOT atomic operations do not yet support multiple "
+                        "CTAs per cluster");
+          hasUnsupportedAtomic = true;
+        }
       });
       if (hasUnsupportedAtomic) {
         signalPassFailure();

--- a/test/Conversion/amd/tritongpu_to_llvm_npot_atomic.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm_npot_atomic.mlir
@@ -1,0 +1,83 @@
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32, ttg.target = "hip:gfx950"} {
+  // CHECK-LABEL: llvm.func @npot_atomic_rmw_24
+  // CHECK: [[N24:%.*]] = llvm.mlir.constant(24 : i32)
+  // CHECK: [[OWNER24:%.*]] = llvm.icmp "ult" {{.*}}, [[N24]] : i32
+  // The canonical mask feeds AMD's arbitrary-mask intra-wave compaction.
+  // CHECK: [[CANON24:%.*]] = llvm.and {{%.*}}, [[OWNER24]] : i1
+  // CHECK: llvm.zext [[CANON24]] : i1 to i32
+  // CHECK: llvm.call_intrinsic "llvm.amdgcn.ds.permute"
+  // CHECK: llvm.atomicrmw add
+  tt.func @npot_atomic_rmw_24(%ptr: tensor<24x!tt.ptr<i32>, #blocked>, %val: tensor<24xi32, #blocked>) {
+    %0 = tt.atomic_rmw add, relaxed, gpu, %ptr, %val : (tensor<24x!tt.ptr<i32>, #blocked>, tensor<24xi32, #blocked>) -> tensor<24xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32, ttg.target = "hip:gfx950"} {
+  // CHECK-LABEL: llvm.func @npot_atomic_rmw_64x48
+  // CHECK: [[N2D:%.*]] = llvm.mlir.constant(48 : i32)
+  // CHECK: [[OWNER2D:%.*]] = llvm.icmp "ult" {{.*}}, [[N2D]] : i32
+  // CHECK: [[CANON2D:%.*]] = llvm.and {{%.*}}, [[OWNER2D]] : i1
+  // CHECK: llvm.zext [[CANON2D]] : i1 to i32
+  // CHECK: llvm.call_intrinsic "llvm.amdgcn.ds.permute"
+  // CHECK: llvm.atomicrmw add
+  tt.func @npot_atomic_rmw_64x48(%ptr: tensor<64x48x!tt.ptr<i32>, #blocked>, %val: tensor<64x48xi32, #blocked>) {
+    %0 = tt.atomic_rmw add, relaxed, gpu, %ptr, %val : (tensor<64x48x!tt.ptr<i32>, #blocked>, tensor<64x48xi32, #blocked>) -> tensor<64x48xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32, ttg.target = "hip:gfx950"} {
+  // CHECK-LABEL: llvm.func @npot_atomic_cas_80
+  // CHECK: [[N80:%.*]] = llvm.mlir.constant(80 : i32)
+  // CHECK: [[OWNER80:%.*]] = llvm.icmp "ult" {{.*}}, [[N80]] : i32
+  // CHECK: [[CANON80:%.*]] = llvm.and {{%.*}}, [[OWNER80]] : i1
+  // CHECK: llvm.cond_br [[CANON80]]
+  // CHECK: llvm.cmpxchg
+  tt.func @npot_atomic_cas_80(%ptr: tensor<80x!tt.ptr<i32>, #blocked>, %cmp: tensor<80xi32, #blocked>, %val: tensor<80xi32, #blocked>) {
+    %0 = tt.atomic_cas relaxed, gpu, %ptr, %cmp, %val : (tensor<80x!tt.ptr<i32>, #blocked>, tensor<80xi32, #blocked>, tensor<80xi32, #blocked>) -> tensor<80xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32, ttg.target = "hip:gfx950"} {
+  // CHECK-LABEL: llvm.func @npot_buffer_atomic_rmw_masked_48
+  // CHECK: [[N48:%.*]] = llvm.mlir.constant(48 : i32)
+  // CHECK: [[OWNER48:%.*]] = llvm.icmp "ult" {{.*}}, [[N48]] : i32
+  // CHECK: [[CANON48:%.*]] = llvm.and {{%.*}}, [[OWNER48]] : i1
+  // CHECK: [[MASKED48:%.*]] = llvm.and [[CANON48]], {{%.*}} : i1
+  // CHECK: llvm.select [[MASKED48]]
+  // CHECK: buffer.atomic
+  tt.func @npot_buffer_atomic_rmw_masked_48(%ptr: !tt.ptr<i32>, %offsets: tensor<48xi32, #blocked>, %val: tensor<48xi32, #blocked>, %mask: tensor<48xi1, #blocked>) {
+    %0 = amdg.buffer_atomic_rmw add, relaxed, gpu, %val, %ptr[%offsets], %mask : tensor<48xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32, ttg.target = "hip:gfx950"} {
+  // CHECK-LABEL: llvm.func @npot_buffer_atomic_cas_96
+  // CHECK: [[N96:%.*]] = llvm.mlir.constant(96 : i32)
+  // CHECK: [[OWNER96:%.*]] = llvm.icmp "ult" {{.*}}, [[N96]] : i32
+  // CHECK: [[CANON96:%.*]] = llvm.and {{%.*}}, [[OWNER96]] : i1
+  // CHECK: llvm.select [[CANON96]]
+  // CHECK: buffer.atomic.cmpswap
+  tt.func @npot_buffer_atomic_cas_96(%ptr: !tt.ptr<i32>, %offsets: tensor<96xi32, #blocked>, %cmp: tensor<96xi32, #blocked>, %val: tensor<96xi32, #blocked>) {
+    %0 = amdg.buffer_atomic_cas relaxed, gpu, %cmp, %val, %ptr[%offsets] : tensor<96xi32, #blocked>
+    tt.return
+  }
+}

--- a/test/Conversion/amd/tritongpu_to_llvm_npot_atomic_pow2.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm_npot_atomic_pow2.mlir
@@ -1,0 +1,12 @@
+// RUN: TRITON_ALLOW_NPOT=0 triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 > %t.off
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 > %t.on
+// RUN: diff %t.off %t.on
+
+// Enabling NPOT support must not change pow2 atomic lowering byte-for-byte.
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32, ttg.target = "hip:gfx950"} {
+  tt.func @pow2_atomic_rmw_64(%ptr: tensor<64x!tt.ptr<i32>, #blocked>, %val: tensor<64xi32, #blocked>) {
+    %0 = tt.atomic_rmw add, relaxed, gpu, %ptr, %val : (tensor<64x!tt.ptr<i32>, #blocked>, tensor<64xi32, #blocked>) -> tensor<64xi32, #blocked>
+    tt.return
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm_gsan_npot_atomic.mlir
+++ b/test/Conversion/tritongpu_to_llvm_gsan_npot_atomic.mlir
@@ -1,0 +1,36 @@
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file -tritoninstrument-global-sanitizer --allocate-shared-memory-nv --convert-triton-gpu-to-llvm | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:80"} {
+  // CHECK-LABEL: llvm.func @npot_gsan_atomic_rmw_48
+  // CHECK: [[N48:%.*]] = llvm.mlir.constant(48 : i32)
+  // CHECK: [[OWNER48:%.*]] = llvm.icmp "ult" {{.*}}, [[N48]] : i32
+  // CHECK: [[CANON48:%.*]] = llvm.and {{%.*}}, [[OWNER48]] : i1
+  // CHECK: [[CANON48_I32:%.*]] = llvm.zext [[CANON48]] : i1 to i32
+  // CHECK: llvm.call @__triton_gsan_atomic_begin_scalar({{.*}}, [[CANON48_I32]], {{.*}})
+  // CHECK: llvm.inline_asm {{.*}} [[CANON48]]
+  // CHECK: [[CANON48_END_I32:%.*]] = llvm.zext [[CANON48]] : i1 to i32
+  // CHECK: llvm.call @__triton_gsan_atomic_end_scalar({{.*}}, [[CANON48_END_I32]], {{.*}})
+  tt.func @npot_gsan_atomic_rmw_48(%ptr: tensor<48x!tt.ptr<i32>, #blocked>, %val: tensor<48xi32, #blocked>) {
+    %0 = tt.atomic_rmw add, relaxed, gpu, %ptr, %val : (tensor<48x!tt.ptr<i32>, #blocked>, tensor<48xi32, #blocked>) -> tensor<48xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:80"} {
+  // CHECK-LABEL: llvm.func @npot_gsan_atomic_cas_64x48
+  // CHECK: [[N2D:%.*]] = llvm.mlir.constant(48 : i32)
+  // CHECK: [[OWNER2D:%.*]] = llvm.icmp "ult" {{.*}}, [[N2D]] : i32
+  // CHECK: [[OWNER2D_I32:%.*]] = llvm.zext [[OWNER2D]] : i1 to i32
+  // CHECK: llvm.call @__triton_gsan_atomic_begin_scalar({{.*}}, [[OWNER2D_I32]], {{.*}})
+  // CHECK: llvm.inline_asm {{.*}} [[OWNER2D]]
+  // CHECK: [[OWNER2D_END_I32:%.*]] = llvm.zext [[OWNER2D]] : i1 to i32
+  // CHECK: llvm.call @__triton_gsan_atomic_end_scalar({{.*}}, [[OWNER2D_END_I32]], {{.*}})
+  tt.func @npot_gsan_atomic_cas_64x48(%ptr: tensor<64x48x!tt.ptr<i32>, #blocked>, %cmp: tensor<64x48xi32, #blocked>, %val: tensor<64x48xi32, #blocked>) {
+    %0 = tt.atomic_cas relaxed, gpu, %ptr, %cmp, %val : (tensor<64x48x!tt.ptr<i32>, #blocked>, tensor<64x48xi32, #blocked>, tensor<64x48xi32, #blocked>) -> tensor<64x48xi32, #blocked>
+    tt.return
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm_npot_atomic.mlir
+++ b/test/Conversion/tritongpu_to_llvm_npot_atomic.mlir
@@ -1,0 +1,89 @@
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm -reconcile-unrealized-casts 2>/dev/null | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:80"} {
+  // CHECK: ttg.shared = 0 : i32
+  // CHECK-LABEL: llvm.func @npot_atomic_rmw_24
+  // CHECK: [[N24:%.*]] = llvm.mlir.constant(24 : i32)
+  // CHECK: [[OWNER24:%.*]] = llvm.icmp "ult" {{.*}}, [[N24]] : i32
+  // CHECK: [[CANON24:%.*]] = llvm.and {{%.*}}, [[OWNER24]] : i1
+  // CHECK: llvm.inline_asm {{.*}} "=r,l,r,b" {{.*}}, [[CANON24]] :
+  tt.func @npot_atomic_rmw_24(%ptr: tensor<24x!tt.ptr<i32>, #blocked>, %val: tensor<24xi32, #blocked>) {
+    %0 = tt.atomic_rmw add, relaxed, gpu, %ptr, %val : (tensor<24x!tt.ptr<i32>, #blocked>, tensor<24xi32, #blocked>) -> tensor<24xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:80"} {
+  // CHECK-LABEL: llvm.func @npot_atomic_rmw_masked_48
+  // CHECK: [[N48:%.*]] = llvm.mlir.constant(48 : i32)
+  // CHECK: [[OWNER48:%.*]] = llvm.icmp "ult" {{.*}}, [[N48]] : i32
+  // CHECK: [[CANON48:%.*]] = llvm.and {{%.*}}, [[OWNER48]] : i1
+  // CHECK: [[MASKED48:%.*]] = llvm.and [[CANON48]], {{%.*}} : i1
+  // CHECK: llvm.inline_asm {{.*}} "=r,l,r,b" {{.*}}, [[MASKED48]] :
+  tt.func @npot_atomic_rmw_masked_48(%ptr: tensor<48x!tt.ptr<i32>, #blocked>, %val: tensor<48xi32, #blocked>, %mask: tensor<48xi1, #blocked>) {
+    %0 = tt.atomic_rmw add, relaxed, gpu, %ptr, %val, %mask : (tensor<48x!tt.ptr<i32>, #blocked>, tensor<48xi32, #blocked>, tensor<48xi1, #blocked>) -> tensor<48xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:80"} {
+  // CHECK-LABEL: llvm.func @npot_atomic_cas_80
+  // CHECK: [[N80:%.*]] = llvm.mlir.constant(80 : i32)
+  // CHECK: [[OWNER80:%.*]] = llvm.icmp "ult" {{.*}}, [[N80]] : i32
+  // CHECK: llvm.inline_asm {{.*}} "=r,l,r,r,b" {{.*}}, [[OWNER80]] :
+  tt.func @npot_atomic_cas_80(%ptr: tensor<80x!tt.ptr<i32>, #blocked>, %cmp: tensor<80xi32, #blocked>, %val: tensor<80xi32, #blocked>) {
+    %0 = tt.atomic_cas relaxed, gpu, %ptr, %cmp, %val : (tensor<80x!tt.ptr<i32>, #blocked>, tensor<80xi32, #blocked>, tensor<80xi32, #blocked>) -> tensor<80xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:80"} {
+  // CHECK-LABEL: llvm.func @npot_atomic_rmw_96
+  // CHECK: [[N96:%.*]] = llvm.mlir.constant(96 : i32)
+  // CHECK: [[OWNER96:%.*]] = llvm.icmp "ult" {{.*}}, [[N96]] : i32
+  // CHECK: llvm.inline_asm {{.*}} "=r,l,r,b" {{.*}}, [[OWNER96]] :
+  tt.func @npot_atomic_rmw_96(%ptr: tensor<96x!tt.ptr<i32>, #blocked>, %val: tensor<96xi32, #blocked>) {
+    %0 = tt.atomic_rmw add, relaxed, gpu, %ptr, %val : (tensor<96x!tt.ptr<i32>, #blocked>, tensor<96xi32, #blocked>) -> tensor<96xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:80"} {
+  // CHECK: ttg.shared = 0 : i32
+  // CHECK-LABEL: llvm.func @npot_atomic_rmw_64x48
+  // CHECK: [[N2D:%.*]] = llvm.mlir.constant(48 : i32)
+  // CHECK: [[OWNER2D:%.*]] = llvm.icmp "ult" {{.*}}, [[N2D]] : i32
+  // CHECK: llvm.inline_asm {{.*}} "=r,l,r,b" {{.*}}, [[OWNER2D]] :
+  tt.func @npot_atomic_rmw_64x48(%ptr: tensor<64x48x!tt.ptr<i32>, #blocked>, %val: tensor<64x48xi32, #blocked>) {
+    %0 = tt.atomic_rmw add, relaxed, gpu, %ptr, %val : (tensor<64x48x!tt.ptr<i32>, #blocked>, tensor<64x48xi32, #blocked>) -> tensor<64x48xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[1]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:90"} {
+  // CHECK-LABEL: llvm.func @npot_atomic_rmw_2cta
+  // CHECK: [[CTA_BOUND:%.*]] = llvm.mlir.constant(24 : i32)
+  // CHECK: [[CTA_OWNER:%.*]] = llvm.icmp "ult" {{.*}}, [[CTA_BOUND]] : i32
+  // CHECK: [[CTA_CANON:%.*]] = llvm.and {{%.*}}, [[CTA_OWNER]] : i1
+  // CHECK: llvm.inline_asm {{.*}} "=r,l,r,b" {{.*}}, [[CTA_CANON]] :
+  tt.func @npot_atomic_rmw_2cta(%ptr: tensor<48x!tt.ptr<i32>, #blocked>, %val: tensor<48xi32, #blocked>) {
+    %0 = tt.atomic_rmw add, relaxed, gpu, %ptr, %val : (tensor<48x!tt.ptr<i32>, #blocked>, tensor<48xi32, #blocked>) -> tensor<48xi32, #blocked>
+    tt.return
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm_npot_atomic_pow2.mlir
+++ b/test/Conversion/tritongpu_to_llvm_npot_atomic_pow2.mlir
@@ -1,0 +1,12 @@
+// RUN: TRITON_ALLOW_NPOT=0 triton-opt %s --allocate-shared-memory-nv --convert-triton-gpu-to-llvm -reconcile-unrealized-casts > %t.off
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s --allocate-shared-memory-nv --convert-triton-gpu-to-llvm -reconcile-unrealized-casts > %t.on
+// RUN: diff %t.off %t.on
+
+// Enabling NPOT support must not change pow2 atomic lowering byte-for-byte.
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:80"} {
+  tt.func @pow2_atomic_rmw_64(%ptr: tensor<64x!tt.ptr<i32>, #blocked>, %val: tensor<64xi32, #blocked>) {
+    %0 = tt.atomic_rmw add, relaxed, gpu, %ptr, %val : (tensor<64x!tt.ptr<i32>, #blocked>, tensor<64xi32, #blocked>) -> tensor<64xi32, #blocked>
+    tt.return
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm_npot_store.mlir
+++ b/test/Conversion/tritongpu_to_llvm_npot_store.mlir
@@ -1,0 +1,53 @@
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm -reconcile-unrealized-casts 2>/dev/null | FileCheck %s
+
+// A modular (NPOT) tensor rounds its register span up to a power of two, so the
+// phantom registers get raw out-of-range pointer offsets. A maskless store must
+// predicate every register to a single canonical owner, otherwise the phantom
+// registers overflow into the next logical element.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:80"} {
+  // CHECK: ttg.shared = 0 : i32
+  // CHECK-LABEL: llvm.func @npot_store_24
+  // CHECK: [[N24:%.*]] = llvm.mlir.constant(24 : i32)
+  // CHECK: [[OWNER24:%.*]] = llvm.icmp "ult" {{.*}}, [[N24]] : i32
+  // CHECK: [[CANON24:%.*]] = llvm.and {{%.*}}, [[OWNER24]] : i1
+  // CHECK: llvm.inline_asm {{.*}} "r,l,b" {{.*}}, [[CANON24]] :
+  tt.func @npot_store_24(%ptr: tensor<24x!tt.ptr<i32>, #blocked>, %val: tensor<24xi32, #blocked>) {
+    tt.store %ptr, %val : tensor<24x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:80"} {
+  // CHECK-LABEL: llvm.func @npot_store_masked_48
+  // CHECK: [[N48:%.*]] = llvm.mlir.constant(48 : i32)
+  // CHECK: [[OWNER48:%.*]] = llvm.icmp "ult" {{.*}}, [[N48]] : i32
+  // CHECK: [[CANON48:%.*]] = llvm.and {{%.*}}, [[OWNER48]] : i1
+  // CHECK: [[MASKED48:%.*]] = llvm.and [[CANON48]], {{%.*}} : i1
+  // CHECK: llvm.inline_asm {{.*}} "r,l,b" {{.*}}, [[MASKED48]] :
+  tt.func @npot_store_masked_48(%ptr: tensor<48x!tt.ptr<i32>, #blocked>, %val: tensor<48xi32, #blocked>, %mask: tensor<48xi1, #blocked>) {
+    tt.store %ptr, %val, %mask : tensor<48x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Rectangular 2D layout: the NPOT column dim (48) rounds up to 64, so the
+// phantom columns must be predicated by their logical column bound.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:80"} {
+  // CHECK: ttg.shared = 0 : i32
+  // CHECK-LABEL: llvm.func @npot_store_64x48
+  // CHECK: [[N2D:%.*]] = llvm.mlir.constant(48 : i32)
+  // CHECK: [[OWNER2D:%.*]] = llvm.icmp "ult" {{.*}}, [[N2D]] : i32
+  // CHECK: llvm.inline_asm {{.*}} "r,l,b" {{.*}}, {{%.*}} :
+  tt.func @npot_store_64x48(%ptr: tensor<64x48x!tt.ptr<i32>, #blocked>, %val: tensor<64x48xi32, #blocked>) {
+    tt.store %ptr, %val : tensor<64x48x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}

--- a/test/Conversion/tritongpu_to_llvm_npot_store_pow2.mlir
+++ b/test/Conversion/tritongpu_to_llvm_npot_store_pow2.mlir
@@ -1,0 +1,22 @@
+// RUN: TRITON_ALLOW_NPOT=0 triton-opt %s -split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm -reconcile-unrealized-casts > %t.off
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm -reconcile-unrealized-casts > %t.on
+// RUN: diff %t.off %t.on
+
+// Enabling NPOT support must not change pow2 store lowering byte-for-byte.
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:80"} {
+  tt.func @pow2_store_64(%ptr: tensor<64x!tt.ptr<i32>, #blocked>, %val: tensor<64xi32, #blocked>) {
+    tt.store %ptr, %val : tensor<64x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked2d = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "cuda:80"} {
+  tt.func @pow2_store_16x64(%ptr: tensor<16x64x!tt.ptr<i32>, #blocked2d>, %val: tensor<16x64xi32, #blocked2d>) {
+    tt.store %ptr, %val : tensor<16x64x!tt.ptr<i32>, #blocked2d>
+    tt.return
+  }
+}

--- a/test/TritonGPU/coalesce-npot-atomic.mlir
+++ b/test/TritonGPU/coalesce-npot-atomic.mlir
@@ -1,13 +1,74 @@
-// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -tritongpu-coalesce -verify-diagnostics
+// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file -tritongpu-coalesce -verify-diagnostics
 
-// A modular layout may map multiple physical slots to one logical element.
-// Atomics must reject until lowering predicates one canonical representative;
-// otherwise each alias applies the update again.
+// Consumed atomic results need the canonical owner's old value redistributed
+// to every modular alias and remain unsupported.
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @npot_atomic(%arg0: tensor<48x!tt.ptr<i32>, #blocked>, %arg1: tensor<48xi32, #blocked>, %arg2: tensor<48xi1, #blocked>) {
-    // expected-error@+1 {{NPOT atomic operations are not yet supported with modular tensor layouts}}
+  tt.func public @npot_atomic_result_used(%arg0: tensor<48x!tt.ptr<i32>, #blocked>, %arg1: tensor<48xi32, #blocked>, %arg2: tensor<48xi1, #blocked>) {
+    // expected-error@+1 {{NPOT atomic results are not yet supported with modular tensor layouts}}
     %0 = tt.atomic_rmw add, relaxed, gpu, %arg0, %arg1, %arg2 : (tensor<48x!tt.ptr<i32>, #blocked>, tensor<48xi32, #blocked>, tensor<48xi1, #blocked>) -> tensor<48xi32, #blocked>
+    tt.store %arg0, %0, %arg2 : tensor<48x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Consumed CAS results require the same alias redistribution as AtomicRMW.
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @npot_atomic_cas_result_used(%ptr: tensor<48x!tt.ptr<i32>, #blocked>, %cmp: tensor<48xi32, #blocked>, %val: tensor<48xi32, #blocked>) {
+    // expected-error@+1 {{NPOT atomic results are not yet supported with modular tensor layouts}}
+    %0 = tt.atomic_cas relaxed, gpu, %ptr, %cmp, %val : (tensor<48x!tt.ptr<i32>, #blocked>, tensor<48xi32, #blocked>, tensor<48xi32, #blocked>) -> tensor<48xi32, #blocked>
+    tt.store %ptr, %0 : tensor<48x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Multidimensional layouts use one pre-modulo bound per NPOT dimension.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @npot_atomic_result_unused_2d(%ptr: tensor<64x48x!tt.ptr<i32>, #blocked>, %val: tensor<64x48xi32, #blocked>) {
+    %0 = tt.atomic_rmw add, relaxed, gpu, %ptr, %val : (tensor<64x48x!tt.ptr<i32>, #blocked>, tensor<64x48xi32, #blocked>) -> tensor<64x48xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Result-unused atomics are safe once lowering predicates one canonical
+// register/lane/warp representative for every modular alias class.
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @npot_atomic_result_unused(%arg0: tensor<48x!tt.ptr<i32>, #blocked>, %arg1: tensor<48xi32, #blocked>, %arg2: tensor<48xi1, #blocked>) {
+    %0 = tt.atomic_rmw add, relaxed, gpu, %arg0, %arg1, %arg2 : (tensor<48x!tt.ptr<i32>, #blocked>, tensor<48xi32, #blocked>, tensor<48xi1, #blocked>) -> tensor<48xi32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Sub-32-bit atomics may require backend packing across an ownership boundary.
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @npot_atomic_f16(%arg0: tensor<48x!tt.ptr<f16>, #blocked>, %arg1: tensor<48xf16, #blocked>) {
+    // expected-error@+1 {{NPOT atomic operations do not yet support element types narrower than 32 bits}}
+    %0 = tt.atomic_rmw fadd, relaxed, gpu, %arg0, %arg1 : (tensor<48x!tt.ptr<f16>, #blocked>, tensor<48xf16, #blocked>) -> tensor<48xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Mixed-radix owner bounds convert correctly, but the normal pipeline remains
+// gated until cluster-capable hardware validates cross-CTA ownership.
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[1]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @npot_atomic_multicta(%arg0: tensor<48x!tt.ptr<i32>, #blocked>, %arg1: tensor<48xi32, #blocked>) {
+    // expected-error@+1 {{NPOT atomic operations do not yet support multiple CTAs per cluster}}
+    %0 = tt.atomic_rmw add, relaxed, gpu, %arg0, %arg1 : (tensor<48x!tt.ptr<i32>, #blocked>, tensor<48xi32, #blocked>) -> tensor<48xi32, #blocked>
     tt.return
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1737,6 +1737,7 @@ struct BufferAtomicRMWOpConversion
 
     // Determine the vectorization size
     Type valueTy = data.getType();
+    auto tensorTy = dyn_cast<RankedTensorType>(valueTy);
     Type valueElemTy =
         typeConverter->convertType(getElementTypeOrSelf(valueTy));
     Type ptrType = getPointerTypeWithShape(ptr, offset);
@@ -1757,6 +1758,9 @@ struct BufferAtomicRMWOpConversion
                valueElemTy.isInteger(32) || valueElemTy.isInteger(64)) {
       vec = 1u;
     }
+    if (tensorTy && toLinearLayout(tensorTy).isModular() && vec != 1)
+      return rewriter.notifyMatchFailure(
+          op, "vectorized modular buffer atomics are not supported");
 
     // Get the offsets and value
     SmallVector<Value> offsetElems = unpackLLElements(loc, llOffset, rewriter);
@@ -1795,14 +1799,28 @@ struct BufferAtomicRMWOpConversion
     Value threadPred = emitRedundantThreadPredicateNonNull(
         freeVarMasks, rewriter, loc, targetInfo);
     uint32_t regMask = freeVarMasks[str_attr("reg")];
+    SmallVector<Value> canonicalPredicates;
+    if (tensorTy) {
+      auto predicates = emitCanonicalIndexPredicates(loc, rewriter, targetInfo,
+                                                     tensorTy, threadPred);
+      if (failed(predicates))
+        return rewriter.notifyMatchFailure(
+            op, "modular layout has no supported canonical atomic owner");
+      canonicalPredicates = std::move(*predicates);
+      if (!canonicalPredicates.empty() && !op.getResult().use_empty())
+        return rewriter.notifyMatchFailure(
+            op, "results of modular atomics require alias redistribution");
+    }
     for (size_t vecStart = 0; vecStart < numElems; vecStart += vec) {
       if (!isCanonicalIndex(vecStart, regMask)) {
         // Don't emit store ops for redundant elements within a thread
         continue;
       }
 
-      Value pred =
-          llMask ? b.and_(threadPred, maskElems[vecStart]) : threadPred;
+      Value pred = !canonicalPredicates.empty() ? canonicalPredicates[vecStart]
+                                                : threadPred;
+      if (llMask)
+        pred = b.and_(pred, maskElems[vecStart]);
 
       Type vecTy = LLVM::getVectorType(valueElemTy, vec);
       Value falseVal = createZeroVector(rewriter, loc, cast<VectorType>(vecTy));
@@ -1911,10 +1929,23 @@ struct BufferAtomicCASOpConversion
     auto freeVarMasks = getFreeVariableMasks(valueTy);
     Value threadPred = emitRedundantThreadPredicateNonNull(
         freeVarMasks, rewriter, loc, targetInfo);
+    SmallVector<Value> canonicalPredicates;
+    if (auto tensorTy = dyn_cast<RankedTensorType>(valueTy)) {
+      auto predicates = emitCanonicalIndexPredicates(loc, rewriter, targetInfo,
+                                                     tensorTy, threadPred);
+      if (failed(predicates))
+        return rewriter.notifyMatchFailure(
+            op, "modular layout has no supported canonical atomic owner");
+      canonicalPredicates = std::move(*predicates);
+      if (!canonicalPredicates.empty() && !op.getResult().use_empty())
+        return rewriter.notifyMatchFailure(
+            op, "results of modular atomics require alias redistribution");
+    }
 
     for (size_t vecStart = 0; vecStart < numElems; vecStart += vec) {
       Type vecTy = LLVM::getVectorType(valueElemTy, vec);
-      Value pred = threadPred;
+      Value pred = !canonicalPredicates.empty() ? canonicalPredicates[vecStart]
+                                                : threadPred;
       // Create the store val
       Value casStoreVal = packElementRangeIntoVector(
           rewriter, this->getTypeConverter(), loc, cast<VectorType>(vecTy),
@@ -2094,6 +2125,19 @@ struct AtomicCASOpConversion
     Value threadPred = emitRedundantThreadPredicateNonNull(
         freeVarMasks, rewriter, loc, targetInfo);
     uint32_t regMask = freeVarMasks[str_attr("reg")];
+    SmallVector<Value> canonicalPredicates;
+    if (tensorTy) {
+      auto predicates = emitCanonicalIndexPredicates(
+          loc, rewriter, targetInfo,
+          cast<RankedTensorType>(op.getPtr().getType()), threadPred);
+      if (failed(predicates))
+        return rewriter.notifyMatchFailure(
+            op, "modular layout has no supported canonical atomic owner");
+      canonicalPredicates = std::move(*predicates);
+      if (!canonicalPredicates.empty() && !op.getResult().use_empty())
+        return rewriter.notifyMatchFailure(
+            op, "results of modular atomics require alias redistribution");
+    }
 
     // atomic ops
     for (size_t i = 0; i < elemsPerThread; i += 1) {
@@ -2105,6 +2149,8 @@ struct AtomicCASOpConversion
       Value casVal = valElements[i];
       Value casCmp = cmpElements[i];
       Value casPtr = ptrElements[i];
+      Value pred =
+          !canonicalPredicates.empty() ? canonicalPredicates[i] : threadPred;
       if (valueElemIntTy) {
         casVal = LLVM::BitcastOp::create(rewriter, loc, valueElemIntTy, casVal);
         casCmp = LLVM::BitcastOp::create(rewriter, loc, valueElemIntTy, casCmp);
@@ -2119,7 +2165,7 @@ struct AtomicCASOpConversion
         endBlock->addArgument({valueElemTy}, {loc});
 
         rewriter.setInsertionPointToEnd(curBlock);
-        LLVM::CondBrOp::create(rewriter, loc, threadPred, atomicBlock, endBlock,
+        LLVM::CondBrOp::create(rewriter, loc, pred, atomicBlock, endBlock,
                                undefVal);
 
         rewriter.setInsertionPointToEnd(atomicBlock);
@@ -2262,6 +2308,7 @@ struct AtomicRMWOpConversion
       maskElements = unpackLLElements(loc, llMask, rewriter);
 
     auto tensorTy = dyn_cast<RankedTensorType>(opResult.getType());
+    auto ptrTensorTy = dyn_cast<RankedTensorType>(ptr.getType());
     Type valueElemTy =
         tensorTy ? getTypeConverter()->convertType(tensorTy.getElementType())
                  : opResult.getType();
@@ -2317,13 +2364,24 @@ struct AtomicRMWOpConversion
           axisAnalysisPass.getAxisInfo(ptr)->getContiguity(threadOrder.front());
       enableIntraWaveReduce &= contigWithinLanes == 1;
     }
-
     auto vecTy = vec_ty(valueElemTy, vec);
     auto elemsPerThread = getTotalElemsPerThread(val.getType());
 
     auto freeVarMasks = getFreeVariableMasks(op.getPtr().getType());
     Value threadPred = emitRedundantThreadPredicateNonNull(
         freeVarMasks, rewriter, loc, targetInfo);
+    SmallVector<Value> canonicalPredicates;
+    if (ptrTensorTy) {
+      auto predicates = emitCanonicalIndexPredicates(loc, rewriter, targetInfo,
+                                                     ptrTensorTy, threadPred);
+      if (failed(predicates))
+        return rewriter.notifyMatchFailure(
+            op, "modular layout has no supported canonical atomic owner");
+      canonicalPredicates = std::move(*predicates);
+      if (!canonicalPredicates.empty() && !op.getResult().use_empty())
+        return rewriter.notifyMatchFailure(
+            op, "results of modular atomics require alias redistribution");
+    }
     auto tid = getThreadId(rewriter, loc);
 
     bool needLdsStaging = !tensorTy && !opResult.use_empty();
@@ -2382,7 +2440,10 @@ struct AtomicRMWOpConversion
     for (size_t i = 0; i < elemsPerThread; i += vec) {
       // TODO: in case llMask is zero we can create only one branch for all
       // elemsPerThread.
-      Value rmwMask = llMask ? b.and_(threadPred, maskElements[i]) : threadPred;
+      Value rmwMask =
+          !canonicalPredicates.empty() ? canonicalPredicates[i] : threadPred;
+      if (llMask)
+        rmwMask = b.and_(rmwMask, maskElements[i]);
       if (applyPackingF16) {
         resultVals[i] = emitter.emitPairedAtomicForEvenTID(
             rewriter, ptrElements[i], valElements[i], rmwMask);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -427,6 +427,10 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
     Type valueElemTy =
         typeConverter->convertType(getElementTypeOrSelf(valueTy));
 
+    auto ptrTensorTy = dyn_cast<RankedTensorType>(ptr.getType());
+    bool hasModularLayout =
+        ptrTensorTy && triton::gpu::toLinearLayout(ptrTensorTy).isModular();
+
     unsigned vec = getVectorSize(ptr);
     unsigned elemsPerThread = getTotalElemsPerThread(ptr.getType());
 
@@ -444,6 +448,12 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
 
       unsigned maskAlign = getMaskAlignment(mask);
       vec = std::min(vec, maskAlign);
+    }
+
+    if (hasModularLayout) {
+      // Ownership can flip at an NPOT boundary inside an otherwise
+      // vectorizable group, so predicate modular stores element by element.
+      vec = 1;
     }
 
     if (vec == 1 && elemsPerThread > 1) {
@@ -464,6 +474,22 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
     Value threadPred = emitRedundantThreadPredicate(freeVarMasks, rewriter, loc,
                                                     targetInfo, op);
     uint32_t regMask = freeVarMasks[str_attr("reg")];
+
+    // For a modular (NPOT) layout, phantom column/row registers get raw
+    // out-of-range pointer offsets that the free-variable mask does not catch.
+    // Predicate every register to a single canonical owner so a maskless store
+    // cannot overflow into a neighbouring logical element. Empty (and therefore
+    // a no-op) for non-modular layouts, so power-of-two stores are byte
+    // identical.
+    SmallVector<Value> canonicalPredicates;
+    if (ptrTensorTy) {
+      auto predicates = ttg::emitCanonicalIndexPredicates(
+          loc, rewriter, targetInfo, ptrTensorTy, threadPred);
+      if (failed(predicates))
+        return rewriter.notifyMatchFailure(
+            op, "modular layout has no canonical store owner prefix");
+      canonicalPredicates = std::move(*predicates);
+    }
 
     const int numVecs = elemsPerThread / vec;
     for (size_t vecStart = 0; vecStart < elemsPerThread; vecStart += vec) {
@@ -512,7 +538,8 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
       PTXBuilder ptxBuilder;
       auto *asmArgList = ptxBuilder.newListOperand(asmArgs);
 
-      Value pred = threadPred;
+      Value pred = !canonicalPredicates.empty() ? canonicalPredicates[vecStart]
+                                                : threadPred;
       if (llMask) {
         auto mask = maskElems[vecStart];
         pred = ttg::maybeAnd(rewriter, loc, pred, mask);
@@ -612,6 +639,19 @@ struct AtomicCASOpConversion
     Value threadPred = emitRedundantThreadPredicate(freeVarMasks, rewriter, loc,
                                                     targetInfo, op);
     uint32_t regMask = freeVarMasks[str_attr("reg")];
+    SmallVector<Value> canonicalPredicates;
+    if (tensorTy) {
+      auto predicates = ttg::emitCanonicalIndexPredicates(
+          loc, rewriter, targetInfo,
+          cast<RankedTensorType>(op.getPtr().getType()), threadPred);
+      if (failed(predicates))
+        return rewriter.notifyMatchFailure(
+            op, "modular layout has no supported canonical atomic owner");
+      canonicalPredicates = std::move(*predicates);
+      if (!canonicalPredicates.empty() && !op.getResult().use_empty())
+        return rewriter.notifyMatchFailure(
+            op, "results of modular atomics require alias redistribution");
+    }
 
     SmallVector<Value> resultVals(elemsPerThread);
 
@@ -626,9 +666,11 @@ struct AtomicCASOpConversion
       Value casVal = valElements[i];
       Value casCmp = cmpElements[i];
       Value casPtr = ptrElements[i];
-      Value old = NVIDIA::emitPtxAtomicCAS(rewriter, loc, valueElemTy, casPtr,
-                                           casCmp, casVal, op.getSem(),
-                                           op.getScope(), threadPred);
+      Value pred =
+          !canonicalPredicates.empty() ? canonicalPredicates[i] : threadPred;
+      Value old =
+          NVIDIA::emitPtxAtomicCAS(rewriter, loc, valueElemTy, casPtr, casCmp,
+                                   casVal, op.getSem(), op.getScope(), pred);
 
       if (tensorTy) {
         resultVals[i] = old;
@@ -755,6 +797,9 @@ public:
 
     auto valueTy = op.getType();
     auto tensorTy = dyn_cast<RankedTensorType>(valueTy);
+    auto ptrTensorTy = dyn_cast<RankedTensorType>(ptr.getType());
+    bool hasModularLayout =
+        ptrTensorTy && triton::gpu::toLinearLayout(ptrTensorTy).isModular();
     Type valueElemTy =
         tensorTy ? getTypeConverter()->convertType(tensorTy.getElementType())
                  : valueTy;
@@ -785,6 +830,12 @@ public:
       numElems = 1;
       packed = 1;
     }
+    if (hasModularLayout) {
+      // Ownership can change at an NPOT boundary inside an otherwise
+      // vectorizable group, so predicate modular atomics element by element.
+      vec = 1;
+      packed = 1;
+    }
     assert((packed == 1 || vec == 1) && "packed or vec must be 1");
 
     if (vec * packed == 1 && numElems > 1)
@@ -796,6 +847,18 @@ public:
     Value threadPred = emitRedundantThreadPredicate(freeVarMasks, rewriter, loc,
                                                     targetInfo, op);
     uint32_t regMask = freeVarMasks[str_attr("reg")];
+    SmallVector<Value> canonicalPredicates;
+    if (ptrTensorTy) {
+      auto predicates = ttg::emitCanonicalIndexPredicates(
+          loc, rewriter, targetInfo, ptrTensorTy, threadPred);
+      if (failed(predicates))
+        return rewriter.notifyMatchFailure(
+            op, "modular layout has no supported canonical atomic owner");
+      canonicalPredicates = std::move(*predicates);
+      if (!canonicalPredicates.empty() && !op.getResult().use_empty())
+        return rewriter.notifyMatchFailure(
+            op, "results of modular atomics require alias redistribution");
+    }
 
     auto packedTy = vec_ty(valueElemTy, packed);
     SmallVector<Value> resultVals(elemsPerThread);
@@ -822,8 +885,9 @@ public:
 
       Value rmwPtr = ptrElements[i];
       Value pred =
-          llMask ? ttg::maybeAnd(rewriter, loc, threadPred, maskElements[i])
-                 : threadPred;
+          !canonicalPredicates.empty() ? canonicalPredicates[i] : threadPred;
+      if (llMask)
+        pred = ttg::maybeAnd(rewriter, loc, pred, maskElements[i]);
 
       if (doPTXLDPromotion) {
         Type convertedValueTy =


### PR DESCRIPTION
Summary:
Modular tensor layouts can assign several physical register/lane/warp slots to one logical element. The existing free-variable mask only catches independently zero bases, so NPOT atomics can apply an update more than once.

For result-unused tensor atomics, derive pre-modulo coordinates from each output dimension's binary or mixed-radix layout stages. Predicate every non-power-of-two stage by its logical bound, then compose that canonical-owner predicate with the existing redundant-thread and user masks. This handles rectangular multidimensional layouts such as 64x48 without enumerating physical slots or imposing a compile-time size cutoff. Unsupported layout bases fail conversion conservatively.

Wire the shared helper through NVIDIA, AMD generic/buffer, and GSan RMW/CAS lowering. Retain AMD intra-wave reduction with the canonical mask and reject packed AMD modular buffer atomics defensively. Keep explicit diagnostics for consumed atomic results, sub-32-bit packed atomics, and multi-CTA clusters; mixed-radix ownership converts structurally, but normal multi-CTA lowering remains gated pending device validation. NVIDIA modular vector atomics remain conservatively scalarized when ownership may change inside a vector group. Power-of-two output is byte-identical with the flag off or on.

Upstream Touchpoints:
- Utility.h/Utility.cpp: one shared canonical-owner interface and implementation.
- Coalesce.cpp: one NPOT-gated validation block; existing pass flow is unchanged otherwise.
- NVIDIA, AMD, and GSan atomic lowerers: small helper calls at the existing predicate construction sites.
- AMD buffer RMW: one lowering-local packed modular guard.
- AMD generic RMW: remove the modular-layout exception from the existing intra-wave eligibility predicate.

Differential Revision: D113342316


