### PR TITLE
[AutoWS] Form N-way TMEM sibling reuse via post-pass repair (fixes BM128) (#2360)

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
@@ -42,11 +42,15 @@ static StringRef getOpndAMemType(Operation *op) {
     if (!str)
       continue;
     if (str->starts_with("opndA,")) {
-      // Format: "opndA,memType,numCopies,bufferId"
+      // Format: "opndA,memType[,numCopies,bufferId]". The copies/id fields are
+      // optional: a memtype-only annotation ("opndA,smem"/"opndA,tmem") marks
+      // just the memory space (the planner decides copies/id/grouping).
       auto comma = str->find(',');
       auto comma2 = str->find(',', comma + 1);
-      if (comma != StringRef::npos && comma2 != StringRef::npos)
-        return str->slice(comma + 1, comma2);
+      if (comma != StringRef::npos) {
+        size_t end = (comma2 != StringRef::npos) ? comma2 : str->size();
+        return str->slice(comma + 1, end);
+      }
     }
   }
   return "";

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -566,6 +566,15 @@ class nvidia_knobs(base_knobs):
     # Number of buffers for the dynamic-persistent tile-id broadcast channel
     # (cross-partition run-once atomic support). 1 = single-stage.
     ws_tile_prefetch_depth: env_int = env_int("TRITON_WS_TILE_PREFETCH_DEPTH", 1)
+    # TMEM memory-planner top-K packing search. topk>1 enumerates the top-K
+    # column packings; pick selects which rank to apply (0 = cost/occupancy-best,
+    # == the default first-fit result); topk_dump writes the ranked packings as
+    # JSON for a harness. Prefer these knobs over the TRITON_WS_MEM_PLAN_* env
+    # vars so tests can scope them (knobs.nvidia.scope()) without leaking global
+    # env state across a batch run.
+    ws_mem_plan_topk: env_int = env_int("TRITON_WS_MEM_PLAN_TOPK", 1)
+    ws_mem_plan_pick: env_int = env_int("TRITON_WS_MEM_PLAN_PICK", 0)
+    ws_mem_plan_topk_dump: env_opt_str = env_opt_str("TRITON_WS_MEM_PLAN_TOPK_DUMP")
     use_modulo_schedule: env_opt_str = env_opt_str("TRITON_USE_MODULO_SCHEDULE")
     use_list_schedule: env_bool = env_bool("TRITON_USE_LIST_SCHEDULE")
     use_llm_schedule: env_bool = env_bool("TRITON_USE_LLM_SCHEDULE")

--- a/test/Hopper/WarpSpecialization/ws_mem_plan_verify_reuse_groups.mlir
+++ b/test/Hopper/WarpSpecialization/ws_mem_plan_verify_reuse_groups.mlir
@@ -1,0 +1,47 @@
+// Memory-planner-side companion to verify_reuse_group_decisions.mlir (which
+// exercises the SAME unified predicate through the code-partition pass). Here we
+// drive the predicate from inside the MEMORY PLANNER: TRITON_WS_MEM_PLAN_VERIFY_
+// GROUPS makes the planner enumerate every candidate pair/triple of a loop's
+// TMEM allocs and run orderReuseGroupChain on each, emitting one
+// "[ws-mem-plan-verify] group {..} => ACCEPT/REJECT" line per group. It changes
+// NO planning decision, so it is safe to keep on a regular RUN line.
+//
+// The planner calls orderReuseGroupChain with crossPartitionProgOrder=false --
+// the SOUND group-FORMATION gate: an edge between two channels requires a real
+// data dependency, or program order WITHIN a single partition; cross-partition
+// textual order (which is not a happens-before) is NOT an edge. This refuses to
+// order data-independent cross-partition siblings, which is exactly what makes
+// the FA-bwd badgroups below rejectable. Code partitioning keeps the default
+// (crossPartitionProgOrder=true) and is unaffected -- see
+// verify_reuse_group_decisions.mlir.
+//
+// Fixture reuse: ws_memory_planner_bwd_buffer_reuse.mlir is the only bwd
+// memory-planner fixture that puts dsT (the dk operand) in TMEM. Note dsT is NOT
+// multi-buffered here: %dsT_0 is a rank-2 single-buffered TMEM copy read by the
+// dk MMA, while dq reads a SEPARATE SMEM copy (%dsT_1) via memdesc_trans -- both
+// derived from the same source value but distinct base buffers. So the dk side
+// forms a real dpT->dsT_0->dk chain, while dq is a common-ancestor sibling with
+// no dsT_0->dq edge (in the live BM128 kernel dq reads the TMEM dsT, so there
+// {dpT,dsT,dq} ACCEPTs -- see verify_reuse_group_decisions.mlir CASE 3).
+//
+// No assertions build needed: the harness prints via llvm::errs(), not LDBG, so
+// it runs on any build configuration.
+//
+// RUN: env TRITON_WS_MEM_PLAN_VERIFY_GROUPS=1 triton-opt %S/ws_memory_planner_bwd_buffer_reuse.mlir --nvgpu-test-ws-memory-planner="num-buffers=2 smem-budget=231000" --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s
+
+// Real N-way chain still ACCEPTs (proves the sound gate is not rejecting
+// everything): dpT -> dsT_0 -> dk are genuine data dependencies.
+// CHECK-DAG: [ws-mem-plan-verify] group {dk,dpT,dsT_0} => ACCEPT order=dpT->dsT_0->dk
+
+// Badgroup 1 -- qkT is independent of dpT: no data dep, and their producers are
+// cross-partition, so cross-partition textual order is (correctly) not an edge.
+// CHECK-DAG: [ws-mem-plan-verify] group {qkT,dpT,dq} => REJECT
+
+// Badgroup 2 -- ppT is independent of dsT (the {qkT,ppT,dsT} group the planner
+// wrongly formed for BM128): rejected for the same reason.
+// CHECK-DAG: [ws-mem-plan-verify] group {qkT,ppT,dsT_0} => REJECT
+
+// Target {dpT,dsT,dq}: rejected IN THIS FIXTURE because dq reads the SMEM copy
+// (%dsT_1), so there is no dsT_0->dq edge. On the live BM128 kernel dq reads the
+// TMEM dsT and this group ACCEPTs (dpT->dsT_0->dq).
+// CHECK-DAG: [ws-mem-plan-verify] group {dpT,dq,dsT_0} => REJECT

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_bwd_hd64.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_bwd_hd64.mlir
@@ -1,4 +1,10 @@
 // RUN: triton-opt %s --nvgpu-test-ws-memory-planner=num-buffers=2 --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s
+// Top-K TMEM packing enumeration (mem_plan_pick over TMEM): with TOPK>1 the
+// planner enumerates distinct feasible packings, ranked by occupancy. Rank 0 is
+// the occupancy-best packing and matches the default first-fit; rank 1 is the
+// alternative (looser) packing. mem_plan_pick selects the rank.
+// RUN: env TRITON_WS_MEM_PLAN_TOPK=8 TRITON_WS_MEM_PLAN_PICK=0 triton-opt %s --nvgpu-test-ws-memory-planner=num-buffers=2 --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s
+// RUN: env TRITON_WS_MEM_PLAN_TOPK=8 TRITON_WS_MEM_PLAN_PICK=1 triton-opt %s --nvgpu-test-ws-memory-planner=num-buffers=2 --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s --check-prefix=PICK1
 
 // Test case: FA BWD with HEAD_DIM=64 — dq reuses a larger tmem buffer at a col offset.
 //
@@ -19,6 +25,15 @@
 // CHECK-LABEL: tt.func public @_attn_bwd
 // CHECK: %dq, %dq_0 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32, buffer.offset = 0 : i32}
 // CHECK: %dpT, %dpT_1 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 8 : i32}
+//
+// Enumeration rank 1 selects the *other* legal packing: dq reuses qkT's block
+// (buffer.id 7) at column offset 64 instead of dpT's block at offset 0. This
+// pins that mem_plan_pick surfaces distinct TMEM packings. Note this is exactly
+// the offset-64 packing described above as runtime-unsafe (it aliases a co-live
+// region) — so non-default picks are model-legal but NOT correctness-guaranteed;
+// a harness sweeping mem_plan_pick must validate each pick at runtime.
+// PICK1-LABEL: tt.func public @_attn_bwd
+// PICK1: %dq, %dq_0 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 64 : i32}
 // CHECK: %dv = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32, buffer.offset = 0 : i32}
 // CHECK: %qkT, %qkT_2 = ttng.tmem_alloc {{{.*}}buffer.copy = 1 : i32, buffer.id = 7 : i32}
 // CHECK: %dv_3, %dv_4 = ttng.tmem_alloc {{{.*}}buffer.copy = 2 : i32, buffer.id = 6 : i32}

--- a/test/TritonGPU/promote-lhs-to-tmem.mlir
+++ b/test/TritonGPU/promote-lhs-to-tmem.mlir
@@ -222,4 +222,60 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %res_f16 = arith.truncf %res : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1>
     tt.return %res_f16 : tensor<128x128xf16, #blocked1>
   }
+
+  // Memtype-only tt.autows channel ("opndA,tmem" / "opndA,smem", no copies/id):
+  // the annotation controls only the operand-A memory space; there is no
+  // buffer.id/copies to pin, so the memory planner decides those downstream.
+  // Same IR as @promote_lhs (which promotes via heuristic); here the annotation
+  // drives the decision explicitly.
+
+  // opndA,smem SUPPRESSES promotion: operand A stays a shared-memory local_alloc.
+  // CHECK-LABEL: @promote_lhs_opnda_smem
+  // CHECK: %[[A:.+]] = tt.load
+  // CHECK: %[[A_SH:.+]] = ttg.local_alloc %[[A]]
+  // CHECK: ttng.tc_gen5_mma %[[A_SH]],
+  tt.func public @promote_lhs_opnda_smem(%A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1>, %arg3: i32) -> tensor<128x128xf16, #blocked1> {
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %B_multibuf = ttg.local_alloc : () -> !ttg.memdesc<1x128x128xf16, #shared, #ttg.shared_memory, mutable>
+    %res = scf.for %i = %c0_i32 to %arg3 step %c1_i32 iter_args(%acc = %cst) -> (tensor<128x128xf32, #blocked1>)  : i32 {
+      %A = tt.load %A_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+      %A_sh = ttg.local_alloc %A : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>
+      %B_sh = ttg.memdesc_index %B_multibuf[%c0_i32] : !ttg.memdesc<1x128x128xf16, #shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>
+      %acc_tm = ttng.tmem_alloc %acc : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      ttng.tc_gen5_mma %A_sh, %B_sh, %acc_tm, %true, %true {tt.autows = "{\22channels\22: [\22opndA,smem\22]}"} : !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %acc_res = ttng.tmem_load %acc_tm : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+      scf.yield %acc_res : tensor<128x128xf32, #blocked1>
+    }
+    ttg.local_dealloc %B_multibuf : !ttg.memdesc<1x128x128xf16, #shared, #ttg.shared_memory, mutable>
+    %res_f16 = arith.truncf %res : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1>
+    tt.return %res_f16 : tensor<128x128xf16, #blocked1>
+  }
+
+  // opndA,tmem FORCES promotion: operand A becomes a tmem_alloc (no id/copies pinned).
+  // CHECK-LABEL: @promote_lhs_opnda_tmem
+  // CHECK: %[[A:.+]] = tt.load
+  // CHECK: %[[A_TMEM:.+]] = ttng.tmem_alloc %[[A]]
+  // CHECK: ttng.tc_gen5_mma %[[A_TMEM]],
+  tt.func public @promote_lhs_opnda_tmem(%A_ptr: tensor<128x128x!tt.ptr<f16>, #blocked1>, %arg3: i32) -> tensor<128x128xf16, #blocked1> {
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %B_multibuf = ttg.local_alloc : () -> !ttg.memdesc<1x128x128xf16, #shared, #ttg.shared_memory, mutable>
+    %res = scf.for %i = %c0_i32 to %arg3 step %c1_i32 iter_args(%acc = %cst) -> (tensor<128x128xf32, #blocked1>)  : i32 {
+      %A = tt.load %A_ptr : tensor<128x128x!tt.ptr<f16>, #blocked1>
+      %A_sh = ttg.local_alloc %A : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>
+      %B_sh = ttg.memdesc_index %B_multibuf[%c0_i32] : !ttg.memdesc<1x128x128xf16, #shared, #ttg.shared_memory, mutable> -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>
+      %acc_tm = ttng.tmem_alloc %acc : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      ttng.tc_gen5_mma %A_sh, %B_sh, %acc_tm, %true, %true {tt.autows = "{\22channels\22: [\22opndA,tmem\22]}"} : !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %acc_res = ttng.tmem_load %acc_tm : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked1>
+      scf.yield %acc_res : tensor<128x128xf32, #blocked1>
+    }
+    ttg.local_dealloc %B_multibuf : !ttg.memdesc<1x128x128xf16, #shared, #ttg.shared_memory, mutable>
+    %res_f16 = arith.truncf %res : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1>
+    tt.return %res_f16 : tensor<128x128xf16, #blocked1>
+  }
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -242,6 +242,8 @@ Operation *AllocChannel::getDstOp() {
 }
 
 Operation *AllocChannel::getDstOpLast() {
+  if (defunct)
+    return nullptr; // alloc erased by reuse folding; endpoints are dangling.
   SmallVector<Operation *> consumers;
   getAllConsumers(this, consumers);
   if (consumers.size() == 1)
@@ -342,7 +344,12 @@ Operation *ttng::TmemAllocChannel::getDstOp() {
 }
 
 Operation *ttng::TmemAllocChannel::getDstOpLast() {
-  assert(!isOperandD);
+  if (defunct)
+    return nullptr; // alloc erased by reuse folding; endpoints are dangling.
+  if (isOperandD)
+    // The tmem.end marker is the last use of an inout (operand-D) accumulator,
+    // matching getDstOp()'s operand-D handling (getAllConsumers excludes it).
+    return findTmemStartEnd(this, "tmem.end");
   SmallVector<Operation *> consumers;
   getAllConsumers(this, consumers);
   if (consumers.size() == 1)
@@ -891,8 +898,25 @@ bool dependsThroughMemory(Operation *srcOp, Operation *dstOp,
 // Program order is NOT used across partitions: distinct async tasks run
 // concurrently, so their relative text position is not a happens-before (and
 // op-id/liveness intervals are likewise meaningless across partitions).
-static bool hasDependencyChain(Channel *A, Channel *B) {
-  Operation *aConsumer = A->getDstOp();
+// `crossPartitionProgOrder` controls the program-order fallback (2):
+//   true  (default): same-block textual order is an edge even across partitions
+//                    -- what code partitioning uses to ORDER an already-decided
+//                    reuse (some real kernels, e.g. HSTU 2-KV reduce_dq, rely
+//                    on it; dropping it globally regressed FA-bwd + HSTU).
+//   false: program order is an edge only WITHIN one partition (a common
+//          async_task_id, where textual order is a genuine happens-before).
+//          This is the SOUND gate for DECIDING whether to FORM an N-way group:
+//          it refuses to order independent cross-partition siblings (FA-bwd
+//          {qkT,ppT,dsT}: ppT,dsT are cross-partition and data-independent, so
+//          no edge -> the group is correctly rejected), while a real chain
+//          ({dpT,dsT,dq}: dpT->dsT and dsT->dq are data deps) still orders.
+static bool hasDependencyChain(Channel *A, Channel *B,
+                               bool crossPartitionProgOrder = true) {
+  // Reuse safety needs A's LAST consumer (the point after which A's slot is
+  // free) to precede B's producer -- getDstOp() returns the earliest/list-order
+  // consumer, which under-orders multi-consumer channels (e.g. dsT read by both
+  // the dk and dq MMAs) and can admit an overlapping reuse group.
+  Operation *aConsumer = A->getDstOpLast();
   Operation *bProducer = B->getSrcOp();
   if (!aConsumer || !bProducer)
     return false;
@@ -902,14 +926,21 @@ static bool hasDependencyChain(Channel *A, Channel *B) {
   if (dependsThroughMemory(aConsumer, bProducer, /*followBufferReuse=*/true))
     return true;
 
-  // (2) program order within the same block (cross-partition included).
-  // NOTE: restricting this to the same partition is UNSOUND -- it drops
-  // legitimate cross-partition program-order reuse edges that real kernels rely
-  // on (regressed FA-bwd previously and HSTU 2-KV reduce_dq: wrong dq). The
-  // cost is that a hand-pinned unorderable group (t_bwd_badgroup) is not
-  // fast-failed here; that is the still-open N-way ordering crux (T279873316).
-  if (aConsumer->getBlock() == bProducer->getBlock())
+  // (2) program order within the same block.
+  if (aConsumer->getBlock() == bProducer->getBlock()) {
+    if (!crossPartitionProgOrder) {
+      // Sound-gate mode: only accept textual order when a single partition runs
+      // both ops (shared async_task_id) -- otherwise the ops run concurrently
+      // and their relative text position is not a happens-before.
+      auto aTasks = getAsyncTaskIds(aConsumer);
+      auto bTasks = getAsyncTaskIds(bProducer);
+      bool sharePartition = llvm::any_of(
+          aTasks, [&](int t) { return llvm::is_contained(bTasks, t); });
+      if (!sharePartition)
+        return false;
+    }
     return appearsBefore(aConsumer, bProducer);
+  }
 
   return false;
 }
@@ -1069,7 +1100,8 @@ std::pair<Channel *, Channel *> orderReuseGroup2(ReuseGroup *group) {
       "direction (overlapping but temporally unordered reuse pair)");
 }
 
-SmallVector<Channel *> orderReuseGroupChain(ReuseGroup *group) {
+SmallVector<Channel *> orderReuseGroupChain(ReuseGroup *group,
+                                            bool crossPartitionProgOrder) {
   // Topologically order the group's channels into one dependency chain:
   // channel i's consumer reaches channel i+1's producer (via SSA use-def or
   // same-block program order — both captured by hasDependencyChain). This
@@ -1077,13 +1109,19 @@ SmallVector<Channel *> orderReuseGroupChain(ReuseGroup *group) {
   // sort, works across partitions (e.g. FA-bwd {dpT,dsT,dq}: dpT->dsT by SSA,
   // dsT->dq by gemm-partition op order). Returns the ordered channels, or an
   // empty vector when no unique total chain order exists (caller falls back).
+  //
+  // `crossPartitionProgOrder` (default true) preserves code partitioning's
+  // ordering behavior. Pass false when DECIDING whether to form a group (the
+  // planner's N-way gate) so cross-partition textual order cannot spuriously
+  // order data-independent siblings — see hasDependencyChain.
   unsigned n = group->channels.size();
   SmallVector<Channel *> chans(group->channels.begin(), group->channels.end());
   SmallVector<SmallVector<bool>> edge(n, SmallVector<bool>(n, false));
   SmallVector<unsigned> indeg(n, 0);
   for (unsigned i = 0; i < n; ++i)
     for (unsigned j = 0; j < n; ++j)
-      if (i != j && hasDependencyChain(chans[i], chans[j])) {
+      if (i != j &&
+          hasDependencyChain(chans[i], chans[j], crossPartitionProgOrder)) {
         edge[i][j] = true;
         ++indeg[j];
       }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -396,7 +396,12 @@ std::pair<Channel *, Channel *> orderReuseGroup2(ReuseGroup *group);
 // (channel i's consumer reaches channel i+1's producer). Generalizes
 // orderReuseGroup2 to N channels and across partitions. Returns the ordered
 // channels, or an empty vector if no unique total chain order exists.
-SmallVector<Channel *> orderReuseGroupChain(ReuseGroup *group);
+//
+// `crossPartitionProgOrder` (default true) matches code partitioning's edge
+// policy. Pass false for the planner's group-FORMATION gate so cross-partition
+// textual order cannot spuriously order data-independent siblings.
+SmallVector<Channel *>
+orderReuseGroupChain(ReuseGroup *group, bool crossPartitionProgOrder = true);
 
 // Verify that a reuse group with N channels (N >= 2) is well-formed:
 // - At least 2 channels, each with a single copy (getNumBuffers() == 1).

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TMEMAlloc1D.cpp
@@ -229,13 +229,37 @@ sliceAndReinterpretMDTMEM(OpBuilderWithAsyncTaskIds &builder,
   auto newShape = newType.getShape();
   auto blockN = newShape[shape.size() - 1];
 
+  // The subslice below is taken from the representative (allocOp) in *its*
+  // column units, and `offset` is likewise expressed in the representative's
+  // columns (that is how the memory planner assigns buffer.offset). When the
+  // reuser has a narrower element type than the representative — e.g. an f16
+  // reuser packed inside an f32 owner — two reuser elements share one 32-bit
+  // TMEM column, so the reuser only occupies `blockN / 2` of the owner's
+  // columns (see the `oldElemTyWidth == elemTyWidth * 2` subslice branch
+  // below). Validate against that same physical width; using the logical
+  // `blockN` here spuriously rejects a spatially-packed reuser at a non-zero
+  // offset (e.g. offset=64, blockN=128, oldBlockN=128 → 192 > 128) even though
+  // the subslice [64, 64+64) fits the owner exactly.
+  auto elemTyWidth = newType.getElementType().getIntOrFloatBitWidth();
+  auto oldElemTyWidth = allocType.getElementType().getIntOrFloatBitWidth();
+  // A reuser narrower than the representative packs `colRatio` reuser elements
+  // into one owner column (e.g. two f16 in one f32 column -> colRatio 2), so it
+  // occupies `blockN / colRatio` of the owner's columns. This generalizes the
+  // former f32->f16 (== *2) special case to any integer width ratio; same- or
+  // wider-typed reusers keep colRatio == 1 (validated against the logical
+  // blockN, and rejected below if actually wider).
+  int64_t colRatio =
+      std::max<int64_t>(int64_t(oldElemTyWidth) / int64_t(elemTyWidth), 1);
+  int64_t sliceCols = blockN / colRatio;
+
   // Validate the allocation is valid before attempting to create subslice
-  if (oldBlockN < blockN || oldBlockN % blockN != 0 ||
-      (offset + blockN) > oldBlockN) {
+  if (oldBlockN < sliceCols || oldBlockN % sliceCols != 0 ||
+      (offset + sliceCols) > oldBlockN) {
     // Cannot use this TMEM allocation - return nullptr to signal failure
     // Caller should try another TMEM allocation or fall back to SMEM
     LDBG("TMEM allocation validation failed: oldBlockN="
-         << oldBlockN << ", blockN=" << blockN << ", offset=" << offset);
+         << oldBlockN << ", blockN=" << blockN << ", sliceCols=" << sliceCols
+         << ", offset=" << offset);
     return nullptr;
   }
 
@@ -245,21 +269,19 @@ sliceAndReinterpretMDTMEM(OpBuilderWithAsyncTaskIds &builder,
   // reinterpret to 128x64xbf16.
   auto tmemDesc = createTMEMDesc(builder, newType, newShape[shape.size() - 2],
                                  newShape[shape.size() - 1]);
-  // slice from oldBlockN to blockN
-  auto elemTyWidth = newType.getElementType().getIntOrFloatBitWidth();
-  auto oldElemTyWidth = allocType.getElementType().getIntOrFloatBitWidth();
-  if (oldElemTyWidth == elemTyWidth * 2) {
+  // Subslice `sliceCols` owner columns (blockN / colRatio, computed above) and
+  // reinterpret to the reuser's type. Supports any owner element type that is an
+  // integer-width multiple of the reuser's: f32->f16 (colRatio 2), same width
+  // (1), f32->f8 (4), etc. A wider reuser (or a non-integer width ratio) is
+  // unsupported.
+  if (oldElemTyWidth >= elemTyWidth && oldElemTyWidth % elemTyWidth == 0) {
     auto subSlice = ttng::TMEMSubSliceOp::create(
-        builder, allocOp->getLoc(), allocResult, offset, blockN / 2);
-    return ttg::MemDescReinterpretOp::create(builder, allocOp->getLoc(),
-                                             tmemDesc, subSlice);
-  } else if (elemTyWidth == oldElemTyWidth) {
-    auto subSlice = ttng::TMEMSubSliceOp::create(builder, allocOp->getLoc(),
-                                                 allocResult, offset, blockN);
+        builder, allocOp->getLoc(), allocResult, offset, sliceCols);
     return ttg::MemDescReinterpretOp::create(builder, allocOp->getLoc(),
                                              tmemDesc, subSlice);
   } else {
-    // Unsupported element type conversion
+    // Unsupported element type conversion (reuser wider than owner, or the
+    // width ratio is not an integer).
     return nullptr;
   }
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -895,13 +895,19 @@ getWSBufferUsageOrder(const WSBuffer &buf, SmallVector<Channel *> &channels,
 }
 
 /// Parsed channel annotation from tt.autows JSON on an MMA op.
-/// Format: "opndA,smem,2,0" → operand=opndA, memType=smem, numCopies=2,
-/// bufferId=0.
+/// Two forms:
+///   "opndA,smem,2,0"  → full pin: memType=smem, numCopies=2, bufferId=0.
+///   "opndA,smem"      → memtype-only: mark the operand's memory space
+///   (consumed
+///                       by PromoteLHSToTMem for opndA promotion) and let the
+///                       memory planner decide copies/id/grouping. hasBufferPin
+///                       is false and numCopies/bufferId are unset.
 struct ChannelAnnotation {
-  std::string operand; // "opndA", "opndB", "opndD", or scaled-MMA scales
-  std::string memType; // "smem", "tmem"
-  unsigned numCopies;
-  unsigned bufferId;
+  std::string operand;      // "opndA", "opndB", "opndD", or scaled-MMA scales
+  std::string memType;      // "smem", "tmem"
+  unsigned numCopies = 0;   // valid only if hasBufferPin
+  unsigned bufferId = 0;    // valid only if hasBufferPin
+  bool hasBufferPin = true; // false for memtype-only ("opndA,smem") annotations
 };
 
 static std::optional<unsigned> parseUnsignedAnnotationField(StringRef field) {
@@ -961,21 +967,27 @@ parseChannelAnnotations(Operation *parentOp) {
         continue;
       SmallVector<StringRef, 4> parts;
       StringRef(*str).split(parts, ',');
-      if (parts.size() != 4)
+      // Two accepted forms: full pin "opnd,mem,copies,id" (4 fields) or
+      // memtype-only "opnd,mem" (2 fields — planner decides copies/id).
+      if (parts.size() != 4 && parts.size() != 2)
         continue;
       ChannelAnnotation ann;
       ann.operand = parts[0].str();
       ann.memType = parts[1].str();
-      std::optional<unsigned> numCopies =
-          parseUnsignedAnnotationField(parts[2]);
-      std::optional<unsigned> bufferId = parseUnsignedAnnotationField(parts[3]);
-      if (!numCopies || !bufferId) {
-        LDBG("WARNING: invalid numeric field in channel annotation '" << *str
-                                                                      << "'");
-        continue;
+      ann.hasBufferPin = (parts.size() == 4);
+      if (ann.hasBufferPin) {
+        std::optional<unsigned> numCopies =
+            parseUnsignedAnnotationField(parts[2]);
+        std::optional<unsigned> bufferId =
+            parseUnsignedAnnotationField(parts[3]);
+        if (!numCopies || !bufferId) {
+          LDBG("WARNING: invalid numeric field in channel annotation '" << *str
+                                                                        << "'");
+          continue;
+        }
+        ann.numCopies = *numCopies;
+        ann.bufferId = *bufferId;
       }
-      ann.numCopies = *numCopies;
-      ann.bufferId = *bufferId;
 
       // Validate operand name.
       auto opIdx = getChannelAnnotationOperandIdx(ann.operand);
@@ -1002,21 +1014,24 @@ parseChannelAnnotations(Operation *parentOp) {
              << ann.memType << "," << ann.numCopies << "," << ann.bufferId);
       }
 
-      // Check for same bufferId with conflicting numCopies across all MMA ops.
-      auto bufIt = bufferIdToInfo.find(ann.bufferId);
-      if (bufIt != bufferIdToInfo.end()) {
-        if (bufIt->second.first != ann.numCopies) {
-          LDBG("WARNING: bufferId="
-               << ann.bufferId
-               << " has conflicting numCopies: " << bufIt->second.first
-               << " vs " << ann.numCopies << " — using max("
-               << bufIt->second.first << ", " << ann.numCopies << ")");
-          unsigned maxCopies = std::max(bufIt->second.first, ann.numCopies);
-          ann.numCopies = maxCopies;
-          bufIt->second.first = maxCopies;
+      // Check for same bufferId with conflicting numCopies across all MMA ops
+      // (only for pinned annotations — memtype-only ones carry no bufferId).
+      if (ann.hasBufferPin) {
+        auto bufIt = bufferIdToInfo.find(ann.bufferId);
+        if (bufIt != bufferIdToInfo.end()) {
+          if (bufIt->second.first != ann.numCopies) {
+            LDBG("WARNING: bufferId="
+                 << ann.bufferId
+                 << " has conflicting numCopies: " << bufIt->second.first
+                 << " vs " << ann.numCopies << " — using max("
+                 << bufIt->second.first << ", " << ann.numCopies << ")");
+            unsigned maxCopies = std::max(bufIt->second.first, ann.numCopies);
+            ann.numCopies = maxCopies;
+            bufIt->second.first = maxCopies;
+          }
+        } else {
+          bufferIdToInfo[ann.bufferId] = {ann.numCopies, op};
         }
-      } else {
-        bufferIdToInfo[ann.bufferId] = {ann.numCopies, op};
       }
 
       // Check for operand D annotated as SMEM (always TMEM).
@@ -1078,6 +1093,11 @@ static DenseMap<Operation *, ChannelAnnotation> buildAllocToAnnotationMap(
     return result;
 
   for (auto &[key, ann] : annotations) {
+    // Memtype-only annotations ("opndA,smem") carry no buffer.id/copies to pin;
+    // they only steer promotion (PromoteLHSToTMem). Leave the buffer to the
+    // planner.
+    if (!ann.hasBufferPin)
+      continue;
     auto [mmaOp, opIdx] = key;
     auto mma = dyn_cast<ttng::MMAv5OpInterface>(mmaOp);
     if (!mma)
@@ -3855,6 +3875,160 @@ public:
     }
   }
 
+  // ---- Top-K TMEM packing enumeration (prototype: mem_plan_pick over TMEM)
+  // ----
+  //
+  // tryAllocate returns the first feasible packing. TMEM packing is genuinely
+  // multi-solution (which liveness-disjoint buffers share a block + 2D
+  // placement), so to expose alternatives as a sweep axis we enumerate the
+  // distinct feasible packings, rank them, and let mem_plan_pick choose. This
+  // reuses tryAllocate's exact legality (hasPotentialReuse / computeColOffset /
+  // findPlacements), so every enumerated packing is as legal as the first-fit.
+
+  struct ScoredTMemState {
+    AllocationState state;
+    size_t peak;  // peak column extent (ranking key; lower = tighter)
+    uint64_t sig; // canonical placement signature (dedup + stable tiebreak)
+  };
+
+  // Peak column extent across both row groups.
+  size_t tmemStatePeakCols(const AllocationState &state) const {
+    size_t peak = 0;
+    for (int rg = 0; rg < kNumRowGroups; ++rg)
+      for (auto &iv : state.rowGroupCols[rg])
+        peak = std::max(peak, iv.second);
+    return peak;
+  }
+
+  // Canonical signature: each alloc's absolute physical column in a fixed alloc
+  // order. This is canonical w.r.t. the emitted allocation (buffer.id partition
+  // + buffer.offset): two states that apply to the same IR hash equally.
+  // rowGroup is intentionally excluded — it is not emitted as an IR attribute
+  // and does not change codegen, so branching on it (e.g. a 64-row owner that
+  // fits in either row group) would otherwise over-count physically-equivalent
+  // packings. Owner-vs-reuser labeling collapses too, since both members share
+  // one column.
+  uint64_t tmemStateSignature(SmallVectorImpl<ttng::TMEMAllocOp> &allocs,
+                              const AllocationState &state) {
+    uint64_t h = 1469598103934665603ull;
+    auto mix = [&](uint64_t x) {
+      h ^= x;
+      h *= 1099511628211ull;
+    };
+    for (auto alloc : allocs) {
+      BufferT *b = getBuffer(alloc.getOperation());
+      size_t col = std::numeric_limits<size_t>::max();
+      auto oit = state.owners.find(b);
+      if (oit != state.owners.end()) {
+        col = oit->second.colStart;
+      } else if (auto ait = state.assignment.find(b);
+                 ait != state.assignment.end()) {
+        auto pit = state.owners.find(ait->second.first);
+        if (pit != state.owners.end())
+          col = pit->second.colStart + ait->second.second;
+      }
+      mix(col);
+    }
+    return h;
+  }
+
+  // Enumerate distinct feasible packings into `sols` (deduped by signature).
+  // `budget` bounds total recursive calls as a backstop against combinatorial
+  // blowup; `sols` is capped so memory stays bounded. Mirrors tryAllocate's
+  // candidate logic but never early-returns at the first solution.
+  void enumerateTMemAllocations(SmallVectorImpl<ttng::TMEMAllocOp> &allocs,
+                                size_t idx, AllocationState &state,
+                                size_t maxCols, Operation *ctrlOp,
+                                SmallVectorImpl<ScoredTMemState> &sols,
+                                DenseSet<uint64_t> &seen, unsigned &budget) {
+    if (budget == 0)
+      return;
+    --budget;
+    if (idx == allocs.size()) {
+      uint64_t sig = tmemStateSignature(allocs, state);
+      if (seen.insert(sig).second) {
+        sols.push_back({state, tmemStatePeakCols(state), sig});
+        if (sols.size() >= 512)
+          budget = 0; // enough distinct packings; stop
+      }
+      return;
+    }
+    BufferT *buf = getBuffer(allocs[idx].getOperation());
+
+    // Reuse candidates, in the same deterministic order as tryAllocate.
+    struct ReuseCand {
+      BufferT *owner;
+      int priority;
+      size_t colOffset;
+    };
+    SmallVector<ReuseCand> candidates;
+    for (auto &[owner, placement] : state.owners) {
+      int priority = hasPotentialReuse(owner, buf, ctrlOp);
+      if (priority <= 0)
+        continue;
+      size_t colOffset = computeColOffset(buf, owner, state, ctrlOp);
+      if (colOffset == std::numeric_limits<size_t>::max())
+        continue;
+      candidates.push_back({owner, priority, colOffset});
+    }
+    llvm::sort(candidates, [&](const ReuseCand &a, const ReuseCand &b) {
+      if (a.priority != b.priority)
+        return a.priority > b.priority;
+      if (a.colOffset != b.colOffset)
+        return a.colOffset < b.colOffset;
+      return bufferRange[a.owner].start() < bufferRange[b.owner].start();
+    });
+    for (auto &c : candidates) {
+      AllocationState newState = state;
+      newState.assignment[buf] = {c.owner, c.colOffset};
+      enumerateTMemAllocations(allocs, idx + 1, newState, maxCols, ctrlOp, sols,
+                               seen, budget);
+      if (budget == 0)
+        return;
+    }
+    // New-space placements.
+    for (auto &placement : findPlacements(buf, state, maxCols)) {
+      AllocationState newState = state;
+      addOwnerToState(newState, buf, placement);
+      enumerateTMemAllocations(allocs, idx + 1, newState, maxCols, ctrlOp, sols,
+                               seen, budget);
+      if (budget == 0)
+        return;
+    }
+  }
+
+  // Append the ranked TMEM packings to TRITON_WS_MEM_PLAN_TOPK_DUMP (one JSON
+  // per rank, pool "tmem") so an external harness can see what each pick does.
+  void dumpTMemEnumPlans(SmallVectorImpl<ttng::TMEMAllocOp> &allocs,
+                         ArrayRef<ScoredTMemState> sols) {
+    auto path = triton::tools::getStrEnv("TRITON_WS_MEM_PLAN_TOPK_DUMP");
+    if (path.empty() || sols.empty())
+      return;
+    std::error_code ec;
+    llvm::raw_fd_ostream os(path, ec, llvm::sys::fs::OF_Append);
+    if (ec)
+      return;
+    for (unsigned r = 0; r < sols.size(); ++r) {
+      const AllocationState &s = sols[r].state;
+      // Count members per physical owner (owner = self if not a reuser).
+      std::map<size_t, unsigned> groupMembers; // key: owner's liveness start
+      for (auto alloc : allocs) {
+        BufferT *b = getBuffer(alloc.getOperation());
+        BufferT *owner = b;
+        if (auto ait = s.assignment.find(b); ait != s.assignment.end())
+          owner = ait->second.first;
+        groupMembers[bufferRange[owner].start()]++;
+      }
+      os << "{\"pool\": \"tmem\", \"rank\": " << r
+         << ", \"peak_cols\": " << sols[r].peak
+         << ", \"blocks\": " << groupMembers.size() << ", \"members\": [";
+      unsigned bi = 0;
+      for (auto &[k, cnt] : groupMembers)
+        os << (bi++ ? ", " : "") << cnt;
+      os << "]}\n";
+    }
+  }
+
   FailureOr<unsigned> allocateTMemAllocs2(
       SmallVector<ttng::TMEMAllocOp> &allocs, SmallVector<BufferT *> &buffers,
       DenseMap<Operation *, ttng::TmemAllocChannel *> &allocToChannel,
@@ -3918,7 +4092,70 @@ public:
     // Start from the seeded state (includes pre-assigned owners)
     AllocationState state = initialState;
 
-    if (!tryAllocate(allocs, 0, state, kMaxTMemCols, ctrlOp)) {
+    // Top-K packing search (opt-in): when TRITON_WS_MEM_PLAN_TOPK>1 or a
+    // mem_plan_pick is set, enumerate distinct feasible packings and apply the
+    // picked rank. Default (topK=1, pick=0) keeps the exact first-fit path so
+    // non-search compiles are byte-identical.
+    unsigned topK = getMemPlanTopK();
+    triton::FuncOp funcOp = ctrlOp->getParentOfType<triton::FuncOp>();
+    unsigned pick = funcOp ? getMemPlanPick(funcOp) : 0;
+    bool enumerated = false;
+    if (topK > 1 || pick > 0) {
+      // Rank 0 is ALWAYS the deterministic first-fit (the validated-safe
+      // default), so pick 0 == the default topK=1 result even under search.
+      // Alternatives follow, ordered by occupancy then signature. This matters
+      // because equal-occupancy packings are common (peak columns tie), and a
+      // raw signature tiebreak could otherwise float a runtime-unsafe packing
+      // to rank 0.
+      AllocationState firstFit = initialState;
+      bool haveFirstFit =
+          tryAllocate(allocs, 0, firstFit, kMaxTMemCols, ctrlOp);
+      SmallVector<ScoredTMemState, 0> sols;
+      DenseSet<uint64_t> seen;
+      unsigned budget = 100000;
+      AllocationState enumStart = initialState;
+      enumerateTMemAllocations(allocs, 0, enumStart, kMaxTMemCols, ctrlOp, sols,
+                               seen, budget);
+      if (budget == 0)
+        LDBG("TMEM top-K enumeration hit call/solution budget; truncated");
+      if (haveFirstFit && !sols.empty()) {
+        llvm::stable_sort(
+            sols, [](const ScoredTMemState &a, const ScoredTMemState &b) {
+              if (a.peak != b.peak)
+                return a.peak < b.peak;
+              return a.sig < b.sig;
+            });
+        // Pin the true first-fit STATE (not merely a column-signature match) to
+        // rank 0, so pick 0 is byte-identical to the default topK=1 result --
+        // including the physical rowOffset. tmemStateSignature deliberately
+        // excludes rowGroup, so an enumerated solution sharing firstFit's column
+        // signature may live in a different row group (a 64-row owner fits either
+        // group); rotating that solution to rank 0 would apply its rowGroup, not
+        // firstFit's. Instead drop the signature-equivalent enumerated solution
+        // (deduped to one by the column-only signature) and insert firstFit
+        // itself at rank 0, so sols[0].state == firstFit exactly.
+        uint64_t ffSig = tmemStateSignature(allocs, firstFit);
+        for (unsigned i = 0; i < sols.size(); ++i) {
+          if (sols[i].sig == ffSig) {
+            sols.erase(sols.begin() + i);
+            break;
+          }
+        }
+        sols.insert(sols.begin(),
+                    {firstFit, tmemStatePeakCols(firstFit), ffSig});
+        dumpTMemEnumPlans(allocs, sols);
+        unsigned r = std::min<unsigned>(pick, sols.size() - 1);
+        LDBG("TMEM top-K: "
+             << sols.size() << " distinct packings; applying rank " << r
+             << " of " << sols.size() << " (peak_cols " << sols[r].peak << ")");
+        state = sols[r].state;
+        enumerated = true;
+      } else {
+        LDBG("TMEM top-K: no packing enumerated; falling back to tryAllocate");
+      }
+    }
+
+    if (!enumerated && !tryAllocate(allocs, 0, state, kMaxTMemCols, ctrlOp)) {
       return allocs[0].emitError(
           "allocateTMemAllocs2: failed to allocate TMEM buffers");
     }
@@ -4894,7 +5131,8 @@ LogicalResult doMemoryPlanner(triton::FuncOp funcOp, unsigned numBuffers,
       smemAllocAnnotations =
           buildAllocToAnnotationMap(channels, mmaAnnotations);
       for (auto &[key, ann] : mmaAnnotations)
-        annotationMaxId = std::max(annotationMaxId, ann.bufferId + 1);
+        if (ann.hasBufferPin)
+          annotationMaxId = std::max(annotationMaxId, ann.bufferId + 1);
     }
 
     bufferId = smemPlanSearch

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -3370,6 +3370,67 @@ public:
            << ctrlInt.end());
       for (auto t : allocsForThisLoop)
         LLVM_DEBUG(t.getOperation()->dump());
+
+      // ---- Test-only: run the unified group-level reuse predicate
+      // (orderReuseGroupChain) over EVERY candidate pair/triple of this loop's
+      // TMEM allocs and emit one CHECK-able verdict line each. This changes NO
+      // planning decision (observation only) — it is the fast-iteration harness
+      // for wiring the shared predicate into the planner (step 1 of the N-way
+      // reuse-grouping plan). Gated by TRITON_WS_MEM_PLAN_VERIFY_GROUPS so the
+      // default path is byte-identical (no regression by construction).
+      if (::getenv("TRITON_WS_MEM_PLAN_VERIFY_GROUPS")) {
+        // This loop's allocs that carry a TMEM channel, in a stable (index)
+        // order, each with a readable name for the verdict line. Scan by
+        // liveness interval rather than `allocsForThisLoop` so PRE-ASSIGNED
+        // (annotation-pinned) allocs — which are already in `handledAllocs` and
+        // thus dropped from `allocsForThisLoop` — are still observed. The
+        // hand-pinned {dpT,dsT,dq} fixtures pin every alloc, so without this
+        // the harness would see nothing there.
+        SmallVector<std::pair<Channel *, std::string>> members;
+        unsigned vIdx = 0;
+        for (auto alloc : allocs) {
+          auto allocInt = bufferRange.lookup(buffers[vIdx]);
+          ++vIdx;
+          bool inLoop = ctrlInt.intersects(allocInt) ||
+                        ctrlIdx == innermostLoops.size() - 1;
+          if (!inLoop)
+            continue;
+          auto it = allocToChannel.find(alloc.getOperation());
+          if (it == allocToChannel.end() || !it->second)
+            continue;
+          members.push_back({it->second, getLocName(alloc.getOperation())});
+        }
+        auto emit = [&](ArrayRef<unsigned> idxs) {
+          ReuseGroup g;
+          std::string names;
+          for (unsigned k : idxs) {
+            g.channels.push_back(members[k].first);
+            names += (names.empty() ? "" : ",") + members[k].second;
+          }
+          // Sound group-FORMATION gate: drop cross-partition program order so
+          // data-independent cross-partition siblings are not spuriously
+          // ordered (see hasDependencyChain / orderReuseGroupChain).
+          auto order =
+              orderReuseGroupChain(&g, /*crossPartitionProgOrder=*/false);
+          llvm::errs() << "[ws-mem-plan-verify] group {" << names << "} => ";
+          if (order.empty()) {
+            llvm::errs() << "REJECT (no unique dependency-chain order)\n";
+          } else {
+            std::string ord;
+            for (auto *ch : order)
+              ord += (ord.empty() ? "" : "->") + getLocName(ch->getAllocOp());
+            llvm::errs() << "ACCEPT order=" << ord << "\n";
+          }
+        };
+        unsigned m = members.size();
+        for (unsigned i = 0; i < m; ++i)
+          for (unsigned j = i + 1; j < m; ++j) {
+            emit(SmallVector<unsigned, 3>{i, j});
+            for (unsigned k = j + 1; k < m; ++k)
+              emit(SmallVector<unsigned, 3>{i, j, k});
+          }
+      }
+
       // Check for per-loop tt.tmem_alloc_algo attribute on the forOp
       // or its parent ForOps (e.g., the WS loop wrapping the innermost
       // scheduled loop in persistent kernels).

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -3775,6 +3775,140 @@ public:
     return maxColOffset;
   }
 
+  /// N-way group formation: can `candidate` join `owner`'s reuse group as a
+  /// time-multiplexed (offset 0) member even without a pairwise data dependency
+  /// to any current member? This is the case for common-ancestor siblings like
+  /// FA-bwd {dpT,dsT,dq} (dq reads dsT from SMEM, dk from TMEM, so dq<->dsT
+  /// have no direct producer->consumer edge), which hasPotentialReuse cannot
+  /// form.
+  ///
+  /// Accept only when the WHOLE prospective group admits a unique dependency-
+  /// chain order under BOTH edge policies. Chain order is a happens-before, so
+  /// the members are not co-live and time-multiplexing the shared slot is safe.
+  /// Requires >=3 members (pairwise is handled by hasPotentialReuse) and that
+  /// candidate fits the owner's columns.
+  ///
+  /// Two gates, both required:
+  ///   (1) crossPartitionProgOrder=false (SOUND formation gate): refuses to
+  ///       order data-independent cross-partition siblings, so we never form a
+  ///       spurious group.
+  ///   (2) crossPartitionProgOrder=true (code partitioning's edge policy): the
+  ///       loose gate has MORE edges than the strict one, so a strict-orderable
+  ///       group is NOT guaranteed loose-orderable -- an added cross-partition
+  ///       program-order edge can create a cycle. If it does, insertAsyncComm
+  ///       (WSCodePartition) would later hit its report_fatal_error on this
+  ///       very group. Requiring loose-orderability here refuses such a group
+  ///       up front so a repair can never manufacture a group code partitioning
+  ///       then rejects.
+  ///
+  /// Called only by repairUnsafeReuseGroups, which runs on the default path but
+  /// is INERT unless first-fit produced an unorderable (>=3) group, so packings
+  /// first-fit already gets right never reach here (default compiles
+  /// unchanged).
+  bool canJoinReuseGroupChain(BufferT *owner, BufferT *candidate,
+                              const AllocationState &state) {
+    if (candidate->colSize > owner->colSize)
+      return false;
+    if (bufferRange[owner].intersects(bufferRange[candidate]))
+      return false;
+    ReuseGroup g;
+    SmallVector<BufferT *, 4> members{owner};
+    for (auto &[reuser, asg] : state.assignment)
+      if (asg.first == owner)
+        members.push_back(reuser);
+    members.push_back(candidate);
+    if (members.size() < 3)
+      return false;
+    for (auto *m : members) {
+      auto *ch = allocToChannel.lookup(m->owner);
+      if (!ch)
+        return false;
+      g.channels.push_back(ch);
+    }
+    return !orderReuseGroupChain(&g, /*crossPartitionProgOrder=*/false)
+                .empty() &&
+           !orderReuseGroupChain(&g, /*crossPartitionProgOrder=*/true).empty();
+  }
+
+  /// Post-pass repair: first-fit builds reuse groups incrementally in buffer
+  /// order, which cannot assemble a common-ancestor sibling group whose bridge
+  /// member sorts last -- FA-bwd BM128 lands dsT in {qkT,ppT,dsT} (ppT<->dsT
+  /// make it unorderable) instead of {dpT,dsT,dq}. This order-independent pass
+  /// repairs it: for each unorderable group, relocate a reuser to another group
+  /// where it forms a chain-orderable slot, provided the source group is left
+  /// orderable too. One relocation per call; the caller loops to a fixpoint
+  /// (each move takes a member from an unsafe group to a safe one, so it
+  /// terminates).
+  ///
+  /// INERT unless first-fit produced an unorderable (>=3, single-copy) group,
+  /// so packings first-fit already gets right are byte-identical (no
+  /// regression).
+  bool repairUnsafeReuseGroups(SmallVectorImpl<ttng::TMEMAllocOp> &allocs,
+                               AllocationState &state) {
+    auto membersOf = [&](BufferT *owner) {
+      SmallVector<BufferT *, 4> m{owner};
+      for (auto &[r, a] : state.assignment)
+        if (a.first == owner)
+          m.push_back(r);
+      return m;
+    };
+    auto orderable = [&](ArrayRef<BufferT *> mem) -> bool {
+      if (mem.size() < 3)
+        return true; // 2-way is covered by pairwise legality at formation
+      ReuseGroup g;
+      for (auto *b : mem) {
+        auto *c = allocToChannel.lookup(b->owner);
+        if (!c)
+          return false;
+        g.channels.push_back(c);
+      }
+      // Require BOTH the sound formation gate AND the loose (code-partition)
+      // gate: a group that is strict-orderable but loose-unorderable would still
+      // trip insertAsyncComm's report_fatal_error, so the residual left after a
+      // relocation must be orderable under both (mirrors canJoinReuseGroupChain).
+      return !orderReuseGroupChain(&g, /*crossPartitionProgOrder=*/false)
+                  .empty() &&
+             !orderReuseGroupChain(&g, /*crossPartitionProgOrder=*/true).empty();
+    };
+    // Iterate owners in a stable order: state.owners is a DenseMap (pointer
+    // order), so which relocation the repair picks must not depend on heap
+    // layout -- the same Heisenbug class fixed for tryAllocate. Sort by the
+    // owner's liveness start for a deterministic total order.
+    SmallVector<BufferT *, 8> ownerOrder;
+    for (auto &[owner, pl] : state.owners)
+      ownerOrder.push_back(owner);
+    llvm::sort(ownerOrder, [&](BufferT *a, BufferT *b) {
+      return bufferRange[a].start() < bufferRange[b].start();
+    });
+    for (BufferT *owner : ownerOrder) {
+      SmallVector<BufferT *, 4> mem = membersOf(owner);
+      if (orderable(mem))
+        continue; // group is safe
+      // Relocate a reuser member (never the owner -- it holds the slot).
+      for (BufferT *m : mem) {
+        if (m == owner)
+          continue;
+        SmallVector<BufferT *, 4> rest;
+        for (auto *b : mem)
+          if (b != m)
+            rest.push_back(b);
+        if (!orderable(rest))
+          continue; // removing m alone doesn't make the source orderable
+        for (BufferT *dOwner : ownerOrder) {
+          if (dOwner == owner)
+            continue;
+          if (canJoinReuseGroupChain(dOwner, m, state)) {
+            LDBG("repairUnsafeReuseGroups: relocating a reuser from an "
+                 "unorderable group into a chain-orderable group");
+            state.assignment[m] = {dOwner, 0};
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
   /// Recursive backtracking search for buffer allocation.
   bool tryAllocate(SmallVectorImpl<ttng::TMEMAllocOp> &allocs, size_t idx,
                    AllocationState &state, size_t maxCols, Operation *ctrlOp) {
@@ -4219,6 +4353,10 @@ public:
     if (!enumerated && !tryAllocate(allocs, 0, state, kMaxTMemCols, ctrlOp)) {
       return allocs[0].emitError(
           "allocateTMemAllocs2: failed to allocate TMEM buffers");
+    }
+
+    // Repair any unorderable reuse group first-fit produced (inert otherwise).
+    while (repairUnsafeReuseGroups(allocs, state)) {
     }
 
     // Apply the final allocation state (skip pre-assigned buffers)

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -648,6 +648,33 @@ _BWD_DOT_ATTRS_SCHED = FrozenDotAttrs({
     "dk": {"stage": "1", "order": "1"},
 })
 
+# Memtype-only variant of _BWD_DOT_ATTRS_BM64_TMEM: the operand-A channels carry
+# ONLY the memory space (no copies/id), so PromoteLHSToTMem still promotes ppT/dsT
+# to TMEM while the memory planner decides the copies/id/reuse-grouping. The
+# planner reproduces _BWD_DOT_ATTRS_BM64_TMEM's packing ([dpT,dsT],[ppT,qkT])
+# without the hand-pinned buffer ids.
+_BWD_DOT_ATTRS_BM64_MEMTYPE = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0"},
+    "dpT": {"stage": "0", "order": "2"},
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem"]},  # ppT -> tmem
+    "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem"]},  # dsT^T -> smem
+    "dk": {"stage": "1", "order": "1", "channels": ["opndA,tmem"]},  # dsT -> tmem
+})
+
+# BM128 memtype-only variant (same intent as _BWD_DOT_ATTRS_BM64_MEMTYPE but for
+# BLOCK_M1=128). PromoteLHSToTMem promotes dsT to TMEM, but at BM128 the planner
+# cannot yet form the tight {dpT,dq,dsT} reuse group that the hand-pinned
+# _BWD_DOT_ATTRS_TMEM config achieves, so it OOBs TMEM. Kept as a motivating case
+# for the memory-planner search-space work (see test_bwd_bm128_memtype_only_xfail
+# and task T279873316).
+_BWD_DOT_ATTRS_BM128_MEMTYPE = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0"},
+    "dpT": {"stage": "0", "order": "2"},
+    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem"]},  # ppT -> tmem
+    "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem"]},  # dsT^T -> smem
+    "dk": {"stage": "1", "order": "1", "channels": ["opndA,tmem"]},  # dsT -> tmem
+})
+
 
 @triton.jit
 def _attn_bwd_dkdv_inner(
@@ -955,6 +982,34 @@ configs_bwd_persist = [
             "EPILOGUE_SUBTILE": 2,
             "DQ_SUBTILE": 4,
             "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_BM64,
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+    triton.Config(  # BM64, schedule-only attrs (stage/order, no channels) -> memory planner / search decides buffers
+        {
+            "BLOCK_M1": 64,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 2,
+            "DQ_SUBTILE": 4,
+            "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_SCHED,
+        },
+        num_warps=4,
+        num_stages=2,
+        pre_hook=_bwd_host_descriptor_pre_hook,
+    ),
+    triton.Config(  # BM64, memtype-only opndA channels (no copies/id) -> planner decides grouping
+        {
+            "BLOCK_M1": 64,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 2,
+            "DQ_SUBTILE": 4,
+            "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_BM64_MEMTYPE,
         },
         num_warps=4,
         num_stages=2,
@@ -1775,6 +1830,107 @@ def test_bwd_early_tma_staging_depth2_persistent():
         bwd_config_idx=0,
         smem_budget=220000,
     )
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
+def test_bwd_tmem_plan_pick_enumeration():
+    # Prototype: top-K TMEM packing enumeration in the WS memory planner
+    # (WSMemoryPlanner.cpp allocateTMemAllocs2). With TRITON_WS_MEM_PLAN_TOPK>1
+    # the backtracking allocator enumerates the DISTINCT feasible TMEM packings
+    # (deduped by physical column layout) instead of returning the first, ranks
+    # them by occupancy, and applies TRITON_WS_MEM_PLAN_PICK. The default
+    # topK=1 / pick=0 path is unchanged (first-fit), so normal compiles are
+    # unaffected.
+    #
+    # Runs the BM64 schedule-only config (_BWD_DOT_ATTRS_SCHED, no channels — the
+    # planner decides the TMEM packing) at HEAD_DIM=64, which admits several
+    # genuinely-distinct packings. Asserts (1) the enumeration surfaces >=2
+    # distinct packings and (2) the occupancy-best pick 0 is correct end-to-end.
+    #
+    # It deliberately does NOT sweep non-default picks: they are legal per the
+    # op-id liveness model but not correctness-guaranteed at runtime (they can
+    # deadlock / miscompile — the same model insufficiency behind the reuse
+    # hazards). The distinct-packing pin lives in
+    # test/Hopper/WarpSpecialization/ws_memory_planner_bwd_hd64.mlir (PICK1).
+    import os
+    import tempfile
+    idx = next(i for i, c in enumerate(configs_bwd_persist)
+               if c.kwargs.get("BLOCK_M1") == 64 and c.kwargs.get("BWD_DOT_ATTRS") is _BWD_DOT_ATTRS_SCHED)
+    with tempfile.TemporaryDirectory() as td:
+        dump = os.path.join(td, "plans.json")
+        # Scope the mem-planner knobs (and always_compile) so they auto-restore
+        # and don't leak global env state across a batched test run.
+        with triton.knobs.nvidia.scope(), triton.knobs.compilation.scope():
+            triton.knobs.nvidia.ws_mem_plan_topk = 8
+            triton.knobs.nvidia.ws_mem_plan_pick = 0  # occupancy-best / safe
+            triton.knobs.nvidia.ws_mem_plan_topk_dump = dump
+            triton.knobs.compilation.always_compile = True
+            # N_CTX=512 (with Z=4,H=8) gives a compile key no other test uses, so
+            # the memory planner (and its top-K enumeration/dump) is guaranteed to
+            # run fresh here rather than hit a cached kernel from the parametrized
+            # sweep above.
+            test_op(
+                Z=4, H=8, N_CTX=512, HEAD_DIM=64, causal=False, mode="bwd",
+                baseVariant="ws", provider="triton-fp16", SUBTILING=False,
+                VECT_MUL=0, FADD2_REDUCE=False, bwd_config_idx=idx,
+            )
+            tmem_plans = 0
+            if os.path.exists(dump):
+                with open(dump) as f:
+                    tmem_plans = sum(1 for line in f if '"pool": "tmem"' in line)
+            assert tmem_plans >= 2, f"expected >=2 enumerated TMEM packings, got {tmem_plans}"
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
+def test_bwd_memtype_only_annotation():
+    # Memtype-only channel annotations ("opndA,tmem" / "opndA,smem", no copies/id):
+    # the annotation controls only the operand memory space (consumed by
+    # PromoteLHSToTMem), while the memory planner decides copies/id/reuse-grouping.
+    # _BWD_DOT_ATTRS_BM64_MEMTYPE marks dv/dk opndA as tmem and dq opndA as smem;
+    # the planner then reproduces _BWD_DOT_ATTRS_BM64_TMEM's packing (dsT reuses
+    # dpT, ppT reuses qkT) with no pinned buffer ids. Assert correctness at both
+    # head dims. (The PromoteLHSToTMem-level pin is in
+    # test/TritonGPU/promote-lhs-to-tmem.mlir: @promote_lhs_opnda_{smem,tmem}.)
+    idx = next(i for i, c in enumerate(configs_bwd_persist)
+               if c.kwargs.get("BWD_DOT_ATTRS") is _BWD_DOT_ATTRS_BM64_MEMTYPE)
+    for hd in (64, 128):
+        test_op(
+            Z=8, H=16, N_CTX=1024, HEAD_DIM=hd, causal=False, mode="bwd",
+            baseVariant="ws", provider="triton-fp16", SUBTILING=False,
+            VECT_MUL=0, FADD2_REDUCE=False, bwd_config_idx=idx,
+        )
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
+@pytest.mark.xfail(strict=False, reason="Memory-planner search-space gap (T279873316): "
+                   "BM128 memtype-only promotes dsT to TMEM, but the planner cannot form "
+                   "the tight {dpT,dq,dsT} reuse group that hand _BWD_DOT_ATTRS_TMEM pins, "
+                   "so it OOBs TMEM. dq (accumulator) and the tmem dsT (dk operand) relate "
+                   "only through a common ancestor, which the planner's data-dependency "
+                   "reuse check rejects; a naive same-partition relaxation is unsafe (op-id "
+                   "liveness underestimates qkT's lifetime via pT). Expected to pass once "
+                   "the planner learns to form the group safely.")
+def test_bwd_bm128_memtype_only_xfail():
+    # Motivating case kept for the memory-planner search-space work. Builds a
+    # BM128 memtype-only config (opndA,tmem on dv/dk, opndA,smem on dq — no
+    # copies/id) and runs the bwd; currently OOBs TMEM (xfail). Appends the config
+    # transiently so it is not swept by the parametrized test_op matrix.
+    cfg = triton.Config(
+        {
+            "BLOCK_M1": 128, "BLOCK_N1": 128, "BLOCK_M2": 128, "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 2, "DQ_SUBTILE": 4, "SMEM_BUDGET": 220000,
+            "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_BM128_MEMTYPE,
+        },
+        num_warps=4, num_stages=2, pre_hook=_bwd_host_descriptor_pre_hook)
+    configs_bwd_persist.append(cfg)
+    try:
+        test_op(
+            Z=8, H=16, N_CTX=1024, HEAD_DIM=128, causal=False, mode="bwd",
+            baseVariant="ws", provider="triton-fp16", SUBTILING=False,
+            VECT_MUL=0, FADD2_REDUCE=False, bwd_config_idx=len(configs_bwd_persist) - 1,
+        )
+    finally:
+        configs_bwd_persist.pop()
 
 
 try:

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -654,23 +654,20 @@ _BWD_DOT_ATTRS_SCHED = FrozenDotAttrs({
 # planner reproduces _BWD_DOT_ATTRS_BM64_TMEM's packing ([dpT,dsT],[ppT,qkT])
 # without the hand-pinned buffer ids.
 _BWD_DOT_ATTRS_BM64_MEMTYPE = FrozenDotAttrs({
-    "qkT": {"stage": "0", "order": "0"},
-    "dpT": {"stage": "0", "order": "2"},
-    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem"]},  # ppT -> tmem
+    "qkT": {"stage": "0", "order": "0"}, "dpT": {"stage": "0", "order": "2"}, "dv":
+    {"stage": "0", "order": "2", "channels": ["opndA,tmem"]},  # ppT -> tmem
     "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem"]},  # dsT^T -> smem
     "dk": {"stage": "1", "order": "1", "channels": ["opndA,tmem"]},  # dsT -> tmem
 })
 
 # BM128 memtype-only variant (same intent as _BWD_DOT_ATTRS_BM64_MEMTYPE but for
-# BLOCK_M1=128). PromoteLHSToTMem promotes dsT to TMEM, but at BM128 the planner
-# cannot yet form the tight {dpT,dq,dsT} reuse group that the hand-pinned
-# _BWD_DOT_ATTRS_TMEM config achieves, so it OOBs TMEM. Kept as a motivating case
-# for the memory-planner search-space work (see test_bwd_bm128_memtype_only_xfail
-# and task T279873316).
+# BLOCK_M1=128). PromoteLHSToTMem promotes dsT to TMEM; the planner forms the
+# tight {dpT,dq,dsT} reuse group that the hand-pinned _BWD_DOT_ATTRS_TMEM config
+# expresses via the repairUnsafeReuseGroups post-pass (see
+# test_bwd_bm128_memtype_only and task T279873316).
 _BWD_DOT_ATTRS_BM128_MEMTYPE = FrozenDotAttrs({
-    "qkT": {"stage": "0", "order": "0"},
-    "dpT": {"stage": "0", "order": "2"},
-    "dv": {"stage": "0", "order": "2", "channels": ["opndA,tmem"]},  # ppT -> tmem
+    "qkT": {"stage": "0", "order": "0"}, "dpT": {"stage": "0", "order": "2"}, "dv":
+    {"stage": "0", "order": "2", "channels": ["opndA,tmem"]},  # ppT -> tmem
     "dq": {"stage": "1", "order": "1", "channels": ["opndA,smem"]},  # dsT^T -> smem
     "dk": {"stage": "1", "order": "1", "channels": ["opndA,tmem"]},  # dsT -> tmem
 })
@@ -1870,9 +1867,18 @@ def test_bwd_tmem_plan_pick_enumeration():
             # run fresh here rather than hit a cached kernel from the parametrized
             # sweep above.
             test_op(
-                Z=4, H=8, N_CTX=512, HEAD_DIM=64, causal=False, mode="bwd",
-                baseVariant="ws", provider="triton-fp16", SUBTILING=False,
-                VECT_MUL=0, FADD2_REDUCE=False, bwd_config_idx=idx,
+                Z=4,
+                H=8,
+                N_CTX=512,
+                HEAD_DIM=64,
+                causal=False,
+                mode="bwd",
+                baseVariant="ws",
+                provider="triton-fp16",
+                SUBTILING=False,
+                VECT_MUL=0,
+                FADD2_REDUCE=False,
+                bwd_config_idx=idx,
             )
             tmem_plans = 0
             if os.path.exists(dump):
@@ -1895,39 +1901,56 @@ def test_bwd_memtype_only_annotation():
                if c.kwargs.get("BWD_DOT_ATTRS") is _BWD_DOT_ATTRS_BM64_MEMTYPE)
     for hd in (64, 128):
         test_op(
-            Z=8, H=16, N_CTX=1024, HEAD_DIM=hd, causal=False, mode="bwd",
-            baseVariant="ws", provider="triton-fp16", SUBTILING=False,
-            VECT_MUL=0, FADD2_REDUCE=False, bwd_config_idx=idx,
+            Z=8,
+            H=16,
+            N_CTX=1024,
+            HEAD_DIM=hd,
+            causal=False,
+            mode="bwd",
+            baseVariant="ws",
+            provider="triton-fp16",
+            SUBTILING=False,
+            VECT_MUL=0,
+            FADD2_REDUCE=False,
+            bwd_config_idx=idx,
         )
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
-@pytest.mark.xfail(strict=False, reason="Memory-planner search-space gap (T279873316): "
-                   "BM128 memtype-only promotes dsT to TMEM, but the planner cannot form "
-                   "the tight {dpT,dq,dsT} reuse group that hand _BWD_DOT_ATTRS_TMEM pins, "
-                   "so it OOBs TMEM. dq (accumulator) and the tmem dsT (dk operand) relate "
-                   "only through a common ancestor, which the planner's data-dependency "
-                   "reuse check rejects; a naive same-partition relaxation is unsafe (op-id "
-                   "liveness underestimates qkT's lifetime via pT). Expected to pass once "
-                   "the planner learns to form the group safely.")
-def test_bwd_bm128_memtype_only_xfail():
-    # Motivating case kept for the memory-planner search-space work. Builds a
-    # BM128 memtype-only config (opndA,tmem on dv/dk, opndA,smem on dq — no
-    # copies/id) and runs the bwd; currently OOBs TMEM (xfail). Appends the config
-    # transiently so it is not swept by the parametrized test_op matrix.
+def test_bwd_bm128_memtype_only():
+    # Memory-planner N-way TMEM reuse gate (T279873316). BM128 memtype-only
+    # config (opndA,tmem on dv/dk, opndA,smem on dq — no copies/id): the planner
+    # must form the tight {dpT,dq,dsT} reuse group that the hand-pinned
+    # _BWD_DOT_ATTRS_TMEM config expresses. First-fit lands dsT in the
+    # unorderable {qkT,ppT,dsT}; the repairUnsafeReuseGroups post-pass relocates
+    # dsT into {dpT,dq} -> {dpT,dsT,dq}, leaving {qkT,ppT}, so this now passes.
+    # Appended transiently so it is not swept by the parametrized test_op matrix.
     cfg = triton.Config(
         {
-            "BLOCK_M1": 128, "BLOCK_N1": 128, "BLOCK_M2": 128, "BLOCK_N2": 128,
-            "EPILOGUE_SUBTILE": 2, "DQ_SUBTILE": 4, "SMEM_BUDGET": 220000,
+            "BLOCK_M1": 128,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 2,
+            "DQ_SUBTILE": 4,
+            "SMEM_BUDGET": 220000,
             "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_BM128_MEMTYPE,
-        },
-        num_warps=4, num_stages=2, pre_hook=_bwd_host_descriptor_pre_hook)
+        }, num_warps=4, num_stages=2, pre_hook=_bwd_host_descriptor_pre_hook)
     configs_bwd_persist.append(cfg)
     try:
         test_op(
-            Z=8, H=16, N_CTX=1024, HEAD_DIM=128, causal=False, mode="bwd",
-            baseVariant="ws", provider="triton-fp16", SUBTILING=False,
-            VECT_MUL=0, FADD2_REDUCE=False, bwd_config_idx=len(configs_bwd_persist) - 1,
+            Z=8,
+            H=16,
+            N_CTX=1024,
+            HEAD_DIM=128,
+            causal=False,
+            mode="bwd",
+            baseVariant="ws",
+            provider="triton-fp16",
+            SUBTILING=False,
+            VECT_MUL=0,
+            FADD2_REDUCE=False,
+            bwd_config_idx=len(configs_bwd_persist) - 1,
         )
     finally:
         configs_bwd_persist.pop()


### PR DESCRIPTION
Summary:

First-fit builds reuse groups incrementally in buffer-sort order and cannot
assemble a common-ancestor sibling group whose bridge member sorts last: FA-bwd
BM128 lands dsT in the unorderable {qkT,ppT,dsT} instead of {dpT,dsT,dq}.

Add canJoinReuseGroupChain (a candidate may join a group with no pairwise dep
when the whole group is a unique dependency chain under the sound predicate,
crossPartitionProgOrder=false) and repairUnsafeReuseGroups, an order-independent
post-pass over the finalized packing that relocates a reuser out of any
non-chain-orderable group into one where it forms a chain-orderable slot. For
BM128 this moves dsT into {dpT,dq} -> {dpT,dsT,dq}, leaving {qkT,ppT} -- the
packing hand-pinned _BWD_DOT_ATTRS_TMEM expresses.

Two correctness properties of the repair:
- The residual left after a relocation must be orderable under BOTH the sound
  formation gate and the loose (code-partition) gate. A strict-orderable but
  loose-unorderable residual would still trip insertAsyncComm's
  report_fatal_error, so orderable() checks both (mirrors canJoinReuseGroupChain).
- The pass iterates owners in a stable liveness-start order rather than the
  state.owners DenseMap (pointer order), so which reuser is relocated -- and thus
  the final packing -- is deterministic, not dependent on heap layout.

The repair only fires when first-fit produced an unorderable (>=3, single-copy)
group; packings first-fit already gets right are unchanged. Flip the former
test_bwd_bm128_memtype_only_xfail to a normal passing test
(test_bwd_bm128_memtype_only).

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D112393657


