### PR TITLE
[Triton] Increase C dispatcher limits for kernels with many TensorDescriptor args

### DIFF
--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -2162,9 +2162,9 @@ static PyObject *register_tensor_bridge(PyObject *self, PyObject *arg) {
   Py_RETURN_NONE;
 }
 
-#define TD_MAX_KERNEL_ARGS 64
+#define TD_MAX_KERNEL_ARGS 128
 #define TD_FIXED_ARGS 4          /* grid_x, grid_y, grid_z, stream */
-#define TD_MAX_TMA_DESCS 8       /* max nvTmaDesc args per kernel */
+#define TD_MAX_TMA_DESCS 16      /* max nvTmaDesc args per kernel */
 #define TD_MAX_TENSORDESC_NDIM 5 /* max dimensionality for TensorDescriptor */
 
 /* Per-TMA-slot metadata for inline expansion of TensorDescriptor objects */


### PR DESCRIPTION
Summary:
The _attn_bwd_ws kernel (Blackwell FA backward, warp-specialized pipelined
persistent) has 13 TensorDescriptor args that each expand to 1 + 2*ndim flat
args in the C dispatcher. After expansion the total exceeds the old limit of
62 (TD_MAX_KERNEL_ARGS=64 minus 2 reserved for scratch), causing the dispatcher
to fall back to the slower Python launch path for every invocation.

Similarly, 13 TMA descriptors exceeds TD_MAX_TMA_DESCS=8.

This diff:
- Increases TD_MAX_KERNEL_ARGS from 64 to 128
- Increases TD_MAX_TMA_DESCS from 8 to 16
- Adds INFO-level diagnostic logging in the compiler to report dispatcher creation status

The memory cost is negligible (~1.5KB extra per dispatcher instance).

**Kernel time (profiler mode, i.e. `--latency-measure-mode=profiler`, 3 runs each, rep=3000)** — performance neutral:

| Input | Before avg | After avg | Δ |
| --- | --- | --- | --- |
| (4,48,48,1024,1024,128) | 562.87 | 558.28 | -0.8% |
| (4,48,48,2048,2048,128) | 709.31 | 708.17 | -0.2% |
| (4,48,48,4096,4096,128) | 829.77 | 826.81 | -0.4% |
| (4,48,48,8192,8192,128) | 893.37 | 890.77 | -0.3% |
| (4,48,48,16384,16384,128) | 937.75 | 936.63 | -0.1% |
| **average** | **786.61** | **784.13** | **-0.3%** |

**Wall-clock latency (includes launch overhead, rep=3000)** — C dispatcher reduces launch overhead:

| Input | Before latency (ms) | After latency (ms) | Δ latency | Before TFLOPs | After TFLOPs | Δ TFLOPs |
| --- | --- | --- | --- | --- | --- | --- |
| (4,48,48,1024,1024,128) | 0.532 | 0.513 | **-3.5%** | 484.8 | 502.3 | +3.6% |
| (4,48,48,2048,2048,128) | 1.577 | 1.553 | **-1.5%** | 653.7 | 663.6 | +1.5% |
| (4,48,48,4096,4096,128) | 5.301 | 5.202 | **-1.9%** | 777.8 | 792.6 | +1.9% |
| (4,48,48,8192,8192,128) | 19.067 | 18.885 | -1.0% | 865.0 | 873.3 | +1.0% |
| (4,48,48,16384,16384,128) | 72.172 | 71.789 | -0.5% | 914.1 | 919.0 | +0.5% |

Small kernels see ~3.5% latency reduction (~19µs) consistent with the C dispatcher's ~20-30µs launch overhead savings. The 'Too many kernel args' warning is gone and the C dispatcher is now used for all autotuning configs.

Reviewed By: htyu

Differential Revision: D113622903


