### PR TITLE
[triton] Fix pre-existing tut09 + TritonGPU LIT test failures

### DIFF
--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -1195,7 +1195,11 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(
         B = torch.randn((N, K), dtype=dtype, device=device)
         C = torch.empty((M, N), dtype=dtype, device=device)
 
-        num_tiles = triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N // NUM_CTAS)
+        # Count 256-wide (BLOCK_SIZE_N) tiles, matching the kernel's num_pid_n and
+        # _unified_num_tiles. A 2-CTA cluster cooperates on ONE such tile, so the grid
+        # is the tile count (NonPersistent launches exactly one cluster per tile and,
+        # unlike the persistent schedulers, has no is_valid guard to drop the surplus).
+        num_tiles = triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)
         num_tiles = triton.cdiv(num_tiles, NUM_CTAS) * NUM_CTAS
         if SCHEDULE in (tl.NonPersistentScheduler, tl.ClcTileScheduler):
             grid_size = num_tiles
@@ -1261,8 +1265,14 @@ def test_tutorial09_matmul_tma_unified_persistent_while_loop_warp_specialize(
             assert "ttng.clc_try_cancel" in ttgir, "Expected CLC scheduling in IR"
             assert "tt.atomic_rmw" not in ttgir, "CLC must not use the atomic tile counter"
         if SCHEDULE in (tl.DynamicPersistent1DScheduler, tl.ClcTileScheduler):
-            assert "tt.scheduled_max_stage" in ttgir, "Expected the nested K loop to retain its stage count"
-            assert "loop.stage" in ttgir, "Expected the nested K loop operations to retain their stage assignments"
+            # A warp-specialized outer scf.while keeps its inner K loop physically
+            # warp-specialized (ttg.partition.stages, asserted via ttg.warp_specialize
+            # below) but NOT software-pipelined, so the pipeliner's stage bookkeeping
+            # is intentionally absent (see partition-scheduler bugs #14/#15). The
+            # SoftwarePipeliner also strips these attrs in removePipeliningAttributes
+            # for every schedule, so their presence is never a valid final-IR check.
+            assert "tt.scheduled_max_stage" not in ttgir, "Outer-while K loop must be left unpipelined (no stage count)"
+            assert "loop.stage" not in ttgir, "Outer-while K loop must carry no software-pipeliner stage assignments"
         assert "ttg.warp_specialize" in ttgir, "Expected warp specialization in IR"
         assert "ttng.tc_gen5_mma" in ttgir or "ttng.warp_group_dot" in ttgir, "Expected an MMA instruction"
         assert "ttng.async_tma_copy_global_to_local" in ttgir, "Expected TMA copy"

--- a/test/TritonGPU/coalesce-npot.mlir
+++ b/test/TritonGPU/coalesce-npot.mlir
@@ -14,7 +14,7 @@
 // carries the vectorized load.
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  // CHECK: [[COALESCED:#.*]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+  // CHECK: [[$COALESCED:#.*]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
   // CHECK-LABEL: @npot_load_48_vec8
   tt.func public @npot_load_48_vec8(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
     %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
@@ -28,7 +28,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %7 = arith.addi %5, %6 : tensor<64x48xi32, #blocked>
     %8 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x48x!tt.ptr<f16>, #blocked>
     %9 = tt.addptr %8, %7 : tensor<64x48x!tt.ptr<f16>, #blocked>, tensor<64x48xi32, #blocked>
-    // CHECK: tt.load {{.*}} : tensor<64x48x!tt.ptr<f16>, [[COALESCED]]>
+    // CHECK: tt.load {{.*}} : tensor<64x48x!tt.ptr<f16>, [[$COALESCED]]>
     %10 = tt.load %9 : tensor<64x48x!tt.ptr<f16>, #blocked>
     tt.return
   }
@@ -40,12 +40,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // (32) and the strided dim takes the remaining 2 lanes: threadsPerWarp = [2, 32].
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  // CHECK: [[COALESCED:#.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+  // CHECK: [[$COALESCED:#.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
   // CHECK-LABEL: @npot_load_48
   tt.func public @npot_load_48(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<64x48xi32, #blocked>) {
     %0 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x48x!tt.ptr<f16>, #blocked>
     %1 = tt.addptr %0, %arg1 : tensor<64x48x!tt.ptr<f16>, #blocked>, tensor<64x48xi32, #blocked>
-    // CHECK: tt.load {{.*}} : tensor<64x48x!tt.ptr<f16>, [[COALESCED]]>
+    // CHECK: tt.load {{.*}} : tensor<64x48x!tt.ptr<f16>, [[$COALESCED]]>
     %2 = tt.load %1 : tensor<64x48x!tt.ptr<f16>, #blocked>
     tt.return
   }
@@ -58,12 +58,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // remaining warps spread over both dims. This case worked before the fix.
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  // CHECK: [[COALESCED:#.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [2, 2], order = [1, 0]}>
+  // CHECK: [[$COALESCED:#.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [2, 2], order = [1, 0]}>
   // CHECK-LABEL: @npot_load_192
   tt.func public @npot_load_192(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<64x192xi32, #blocked>) {
     %0 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x192x!tt.ptr<f16>, #blocked>
     %1 = tt.addptr %0, %arg1 : tensor<64x192x!tt.ptr<f16>, #blocked>, tensor<64x192xi32, #blocked>
-    // CHECK: tt.load {{.*}} : tensor<64x192x!tt.ptr<f16>, [[COALESCED]]>
+    // CHECK: tt.load {{.*}} : tensor<64x192x!tt.ptr<f16>, [[$COALESCED]]>
     %2 = tt.load %1 : tensor<64x192x!tt.ptr<f16>, #blocked>
     tt.return
   }
@@ -77,12 +77,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // the flag is on or off (see coalesce.mlir for the flag-off pow2 suite).
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  // CHECK: [[POW2LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+  // CHECK: [[$POW2LAYOUT:#.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
   // CHECK-LABEL: @pow2_load_64
   tt.func public @pow2_load_64(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: tensor<64x64xi32, #blocked>) {
     %0 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x64x!tt.ptr<f16>, #blocked>
     %1 = tt.addptr %0, %arg1 : tensor<64x64x!tt.ptr<f16>, #blocked>, tensor<64x64xi32, #blocked>
-    // CHECK: tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>, [[POW2LAYOUT]]>
+    // CHECK: tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>, [[$POW2LAYOUT]]>
     %2 = tt.load %1 : tensor<64x64x!tt.ptr<f16>, #blocked>
     tt.return
   }
@@ -97,10 +97,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // warps there.
 #blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 64], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  // CHECK: [[RANK3:#.*]] = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 16, 4], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+  // CHECK: [[$RANK3:#.*]] = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 16, 4], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
   // CHECK-LABEL: @npot_rank3_uses_assigned_threads
   tt.func public @npot_rank3_uses_assigned_threads(%arg0: tensor<1x64x5x!tt.ptr<f16>, #blocked> {tt.contiguity = dense<[1, 1, 1]> : tensor<3xi32>}) {
-    // CHECK: tt.load {{.*}} : tensor<1x64x5x!tt.ptr<f16>, [[RANK3]]>
+    // CHECK: tt.load {{.*}} : tensor<1x64x5x!tt.ptr<f16>, [[$RANK3]]>
     %0 = tt.load %arg0 : tensor<1x64x5x!tt.ptr<f16>, #blocked>
     tt.return
   }

--- a/test/TritonGPU/optimize-reduction-layout.mlir
+++ b/test/TritonGPU/optimize-reduction-layout.mlir
@@ -7,7 +7,7 @@
 // (threadsPerWarp = [32, 1], warpsPerCTA = [1, 4]) via a convert_layout. Bit-identical
 // because inner_tree is layout-invariant.
 
-// CHECK-DAG: #[[MOVED:blocked[0-9]*]] = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+// CHECK-DAG: #[[$MOVED:blocked[0-9]*]] = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
@@ -28,9 +28,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %x_9 = tt.addptr %x_7, %x_8 : tensor<128x32x!tt.ptr<f32>, #blocked>, tensor<128x32xi32, #blocked>
     %x_10 = tt.load %x_9 : tensor<128x32x!tt.ptr<f32>, #blocked>
     // The pass converts the operand to the moved layout and keeps axis + ordering.
-    // CHECK: ttg.convert_layout %{{[0-9]+}} : {{.*}} -> tensor<128x32xf32, #[[MOVED]]>
+    // CHECK: ttg.convert_layout %{{[0-9]+}} : {{.*}} -> tensor<128x32xf32, #[[$MOVED]]>
     // CHECK: "tt.reduce"({{.*}}) <{axis = 0 : i32, reduction_ordering = "inner_tree"}>
-    // CHECK: (tensor<128x32xf32, #[[MOVED]]>)
+    // CHECK: (tensor<128x32xf32, #[[$MOVED]]>)
     %s = "tt.reduce"(%x_10) <{axis = 0 : i32, reduction_ordering = "inner_tree"}> ({
     ^bb0(%s_11: f32, %s_12: f32):
       %s_13 = arith.addf %s_11, %s_12 : f32


### PR DESCRIPTION
Summary:
Three pre-existing test failures on the current baseline, all test-only (no
compiler change) -- the pass/kernel output is correct in every case.

`test_tutorial09_warp_specialization.py` (unified outer-while AutoWS, from PR
#2145) had 32 failures on GB200. The dynamic/CLC configs asserted the inner K
loop retains `tt.scheduled_max_stage`/`loop.stage`, but a warp-specialized outer
`scf.while` keeps its K loop physically warp-specialized and NOT
software-pipelined (unannotated), and `SoftwarePipeliner` strips those attrs for
every schedule in `removePipeliningAttributes` -- so the assertion is inverted;
it now requires them absent. The `nonpersistent-2cta` config hit an illegal
instruction because the grid was sized to `cdiv(N, BLOCK_SIZE_N // NUM_CTAS)`
clusters while the kernel computes half as many `BLOCK_SIZE_N`-wide tiles, and
NonPersistent (unlike the persistent schedulers) has no `is_valid` guard to drop
the surplus programs -- size the grid by `BLOCK_SIZE_N`-wide tiles. That crash
was also the source of a CUDA-context-corruption cascade across the file.

`coalesce-npot.mlir` (PR #2320) and `optimize-reduction-layout.mlir` (PR #2312)
defined FileCheck capture variables before a `CHECK-LABEL` and referenced them
after it; under `--enable-var-scope` (the lit default) non-`$` variables are
cleared at each `CHECK-LABEL`, so the references were undefined. Make the
cross-label variables global (`$`-prefixed).

Authored with Claude.

Differential Revision: D113633673


