### PR TITLE
[TLX][AMD] warp-pipe bmm: add BLOCK_K=32 configs for the odd-K register path

### DIFF
--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1321,6 +1321,18 @@ class ROCmBMMWarpPipeTemplateConfigHeuristic(ROCmMMTemplateConfigHeuristic):
 
     # (BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M, num_warps, NUM_BUFFERS)
     WARPPIPE_CONFIGS = [
+        # BLOCK_K=32 tiles: the register-path (odd-K) winners. On the production
+        # compression bmm (1024x1195x2309, odd K -> register branch) the bare register
+        # prototype's autotune optimum is 256x256x32 (~0.80x hipBLASLt); the template
+        # previously offered only BLOCK_K in {64,128} and stalled at 256x256x64 (0.64x).
+        # Finer K granularity cuts the K%BLOCK_K tail waste and schedules the register
+        # path better. (NUM_BUFFERS is moot on the register path -- it allocates no LDS
+        # multi-buffer; matters only if the async branch selects these on an aligned-K
+        # shape, where LDS still fits gfx950's 160KB.)
+        (256, 256, 32, 8, 8, 2),
+        (128, 256, 32, 8, 8, 2),
+        (256, 128, 32, 8, 8, 2),
+        (128, 128, 32, 8, 8, 3),
         (256, 256, 64, 16, 8, 2),
         (256, 128, 64, 8, 8, 2),
         (128, 256, 64, 8, 8, 2),


### PR DESCRIPTION
Summary:
The AMD warp-pipe bmm template's config set
(`ROCmBMMWarpPipeTemplateConfigHeuristic.WARPPIPE_CONFIGS`) offered `BLOCK_K` in
{64, 128} only. On the register-path branch (`USE_ASYNC=0`, taken for odd/unaligned
K), the optimum is a finer `BLOCK_K=32` tile the template could not reach.

Concretely, the HI OC merge-net production compression bmm
`bmm(1024x1195x2309, 1024x2309x256)` has odd `K=2309`, so it takes the register
path; its autotune optimum is `256x256x32`, but the template was stuck at
`256x256x64`.

Rationale: finer K granularity cuts the `K % BLOCK_K` tail waste and schedules the
register path (`tl.load -> tl.dot`, auto-pipelined at `num_stages=3`) better.
`NUM_BUFFERS` is moot on the register path (it allocates no LDS multi-buffer); if
the async branch ever selects a `BLOCK_K=32` tile on an aligned-K shape, the LDS
footprint `(BM+BN)*BK*itemsize*NUM_BUFFERS` still fits gfx950's 160KB.

Result (MI350X/gfx950, `torch.compile` with `TORCHINDUCTOR_TLX_MODE=force`, the
production broadcast-A layout, hipBLASLt baseline `TORCH_BLAS_PREFER_HIPBLASLT=1`):
the compression bmm `1024x1195x2309x256` improves TLX `3060 -> 2400 us`, i.e.
`0.64x -> 0.86x` of hipBLASLt, matching/edging the standalone register prototype
(0.80x). Correctness verified (`allclose` vs `torch.bmm`). Note `0.86x < 1.0`, so
hipBLASLt still wins this bmm in allow-mode; the change closes the kernel-quality
gap and benefits all odd-K register-path bmms.

Differential Revision: D113688969


