### PR TITLE
[TLX][AMD] warp-pipe addmm: register-path fallback for unaligned K (T280910119) (#2367)

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -272,24 +272,18 @@ class TestTLXTemplates(TestCase):
         "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
     )
     @unittest.skipIf(not has_tlx(), "TLX not available")
-    def test_tlx_addmm_warppipe_odd_k_async_copy_alignment_repro(self):
-        """REPRO of the residual odd-K async_copy 16-byte-alignment failure (gfx950).
+    def test_tlx_addmm_warppipe_regpath_odd_k(self):
+        """Odd K on the TLX addmm template -> register-path branch (USE_ASYNC=0), T280910119.
 
-        The sync-load-the-tail fix handles K % BLOCK_K != 0, but ONLY when the row stride is
-        16-byte aligned (K a multiple of 8). K=2309 (odd; the production compression bmm's K) is
-        NOT: A [M,K] and col-major B [K,N] both have row stride K, so a row spans 2309*2 = 4618 B,
-        not a multiple of 16. The col-major B's async_copy into the swizzled #ttg.padded_shared
-        LDS layout then cannot legalize -> builtin.unrealized_conversion_cast on arg_B -> "failed
-        to translate module to LLVM IR". In tlx_mode=force (TRITON-only) every config fails to
-        compile, so select_algorithm raises NoValidChoicesError.
-
-        This documents a KNOWN residual -- an AMD-backend async_copy alignment fix, out of scope
-        for the sync-tail kernel change. When that fix lands this test will start passing
-        (NoValidChoicesError no longer raised); convert it to a correctness check then.
-        compile_threads=1 keeps the compile in-process so the real MLIR error is visible in the
-        test log (subprocess autotune otherwise swallows it behind NoValidChoicesError).
+        K=2309 (odd) has a 2309*2 = 4618 B row stride that is never 16-byte aligned, so the
+        direct-to-LDS async_load path cannot legalize on CDNA4 (col-major B's async_copy into the
+        swizzled #ttg.padded_shared LDS layout). The heuristic sets USE_ASYNC=0 and the template
+        takes the register-path fallback (tl.load -> tl.dot, auto-pipelined), which lowers for ANY
+        alignment -- same mechanism as the bmm template. In tlx_mode=force (TRITON-only) this must
+        lower to the Triton template (never extern/aten) and be numerically correct. (Previously
+        this shape declined -> NoValidChoicesError; the addmm register-path fallback fixed it.)
         """
-        M, K, N = 4096, 2309, 192  # odd K -> 2309*2 = 4618 B row stride, NOT 16-byte aligned
+        M, K, N = 4096, 2309, 192  # odd K -> 4618 B row stride, not 16-byte aligned -> register path
         a = torch.randn(M, K, device=GPU_TYPE, dtype=torch.float16)
         w = torch.randn(N, K, device=GPU_TYPE, dtype=torch.float16)
         bias = torch.randn(N, device=GPU_TYPE, dtype=torch.float16)
@@ -303,10 +297,13 @@ class TestTLXTemplates(TestCase):
                 "max_autotune": True,
                 "max_autotune_gemm_backends": "TRITON",
                 "enable_caching_generated_triton_templates": False,
-                "compile_threads": 1,
         }):
-            with self.assertRaises(Exception):
-                run_and_get_code(torch.compile(addmm), bias, a, w)
+            c_actual, code = run_and_get_code(torch.compile(addmm), bias, a, w)
+
+        c_expected = (a.float() @ w.t().float() + bias.float()).to(torch.float16)
+        torch.testing.assert_close(c_actual, c_expected, atol=2e-2, rtol=2e-2)
+        # force mode keeps only the TLX template -> odd-K addmm must lower via the register branch.
+        self.assertIn("triton_tem", "\n".join(code))
 
     @unittest.skipIf(
         not is_gfx950(),
@@ -423,8 +420,8 @@ class TestWarpPipeSplitKCodegen(TestCase):
             "store_output": lambda *a, **k: "# store_output(...)",
         }
         tmpl = jinja2.Environment().from_string(source)
-        split = tmpl.render(SPLIT_K=2, **hooks)
-        nosplit = tmpl.render(SPLIT_K=1, **hooks)
+        split = tmpl.render(SPLIT_K=2, USE_ASYNC=True, **hooks)
+        nosplit = tmpl.render(SPLIT_K=1, USE_ASYNC=True, **hooks)
 
         # SPLIT_K > 1 must emit: split-id decode, balanced K-partition, fp32 workspace store.
         self.assertIn("split_id = (pid % SPLIT_K)", split)

--- a/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
@@ -19,11 +19,11 @@
     # masked tl.load + one extra dot ("sync-load the tail"). For K that IS a multiple of BLOCK_K
     # the tail is a no-op (all-false mask), so aligned-K codegen is unchanged.
     #
-    # CAVEAT: this needs K to be a multiple of 8 (16-byte row alignment; A [M,K] and col-major
-    # B [K,N] both have row stride K, so K*2 bytes must be 16-aligned). An odd/non-8 K hits a
-    # SEPARATE limit -- B's async_copy into the swizzled padded_shared layout cannot legalize a
-    # non-16-byte-aligned row (builtin.unrealized_conversion_cast on arg_B) -- which the sync
-    # tail does NOT fix (it is an AMD-backend async_copy alignment issue).
+    # DUAL PATH (USE_ASYNC constexpr, set by the heuristic from K's alignment): K % 8 == 0 uses the
+    # async_load direct-to-LDS warp-pipe below (needs 16-byte-aligned rows: A [M,K] + col-major
+    # B [K,N] have row stride K, so K*2 B must be 16-aligned). Unaligned/odd/sliced/small/dynamic K
+    # -- which the async_copy path can't legalize on CDNA4 -- uses the register-path fallback
+    # (tl.load->tl.dot, auto-pipelined), same mechanism as the bmm template (T280910119).
     M = {{size("A", 0)}}
     N = {{size("B", 1)}}
     K = {{size("A", 1)}}
@@ -83,6 +83,8 @@
     a_base = offs_m[:, None] * stride_am
     b_base = offs_n[:, None] * stride_bn          # B as (BLOCK_N, BLOCK_K): n is the row of the [N,K] view
 
+{% if USE_ASYNC %}
+    # --- async_load direct-to-LDS warp-pipe path (USE_ASYNC=1: K % 8 == 0, 16-byte-aligned rows) ---
     K_ITERS = K // BLOCK_K   # FULL K-tiles only; the partial-K tail is handled after the pipeline
 {% if SPLIT_K > 1 %}
     # this split's contiguous K-iteration range [k_lo, k_lo + n_iters). BALANCED
@@ -179,6 +181,22 @@
     b_offs = (k_tail + offs_k[:, None]) * stride_bk + offs_n[None, :] * stride_bn
     b_tail = tl.load(B + b_offs.to(tl.int32), mask=offs_k[:, None] < tail_width, other=0.0)
     acc = tl.dot(a_tail, b_tail, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+{% else %}
+    # --- register-path fallback (USE_ASYNC=0: (K*itemsize) % 16 != 0, e.g. odd/sliced/small K) ---
+    # buffer_load (tl.load) is element-granular, so it lowers for ANY row-stride alignment where the
+    # direct-to-LDS async_load cannot -- same mechanism as the bmm register branch (T280910119).
+    # A is loaded [BLOCK_M, BLOCK_K]; col-major B [K,N] is loaded [BLOCK_K, BLOCK_N] with K along rows
+    # (same index as the sync-tail above) so it feeds tl.dot directly (no local_trans). The masked
+    # load handles K % BLOCK_K inline. num_stages>1 (set by the heuristic) auto-pipelines the loads.
+    # SPLIT_K is always 1 on this path (the heuristic only emits SPLIT_K=1 register configs).
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+    for k in range(0, K, BLOCK_K):
+        a_offs = a_base + (k + offs_k[None, :]) * stride_ak
+        a_reg = tl.load(A + a_offs.to(tl.int32), mask=offs_k[None, :] < K - k, other=0.0)
+        b_offs = (k + offs_k[:, None]) * stride_bk + offs_n[None, :] * stride_bn
+        b_reg = tl.load(B + b_offs.to(tl.int32), mask=offs_k[:, None] < K - k, other=0.0)
+        acc = tl.dot(a_reg, b_reg, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+{% endif %}
 
     # rematerialize rm and rn to save registers
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1217,14 +1217,16 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
             and _sizevar_hint(sizevars, n * k, int32_max) < int32_max
         ):
             return
-        # 16-byte (128-bit transaction) alignment: the fp16/bf16 padded direct-to-LDS async_copy
-        # lowers to 128-bit loads, so each row start must be 16-byte aligned -- i.e. the row stride
-        # K*itemsize bytes must be a multiple of 16 (K % 8 == 0 for fp16/bf16). Without this guard
-        # an unaligned K reaches the template and fails at async_copy legalization (T280910119);
-        # decline up front so it falls back to aten cleanly. Also declines dynamic/unknown K.
+        # DUAL PATH by K alignment (the USE_ASYNC constexpr picks the template branch), mirroring
+        # the bmm template: (K*itemsize) % 16 == 0 (K % 8 for fp16/bf16) -> USE_ASYNC=1, the fast
+        # direct-to-LDS async_load warp-pipe (+ optional split-K). Otherwise (unaligned/odd/sliced/
+        # small or dynamic K, which the direct-to-LDS async_copy can't legalize on CDNA4) ->
+        # USE_ASYNC=0, the register-path fallback (tl.load->tl.dot, auto-pipelined, SPLIT_K=1) so
+        # those addmm shapes still get a Triton candidate instead of only aten (T280910119).
         itemsize = torch.finfo(kernel_inputs.dtype(kernel_inputs._mat1_idx)).bits // 8
-        if not sizevars.statically_known_true(sympy.Eq(sympy.Mod(k * itemsize, 16), 0)):
-            return
+        use_async = sizevars.statically_known_true(
+            sympy.Eq(sympy.Mod(k * itemsize, 16), 0)
+        )
         num_xcds = _amd_num_xcds()
         # split-K only helps grids that leave CUs idle. NUM_SMS is the device CU count
         # (get_num_sms() maps to multi_processor_count = CUs on ROCm; 256 on gfx950/MI350X);
@@ -1250,37 +1252,37 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
             # MFMA requires block_m/block_n be multiples of matrix_instr_nonkdim (16).
             if block_m % 16 != 0 or block_n % 16 != 0:
                 continue
-            # warp-pipeline correctness guard: K_ITERS > NUM_BUFFERS.
-            if not sizevars.statically_known_true(sympy.Gt(k, num_buffers * block_k)):
-                continue
-            # SPLIT_K=1 (plain data-parallel) is always offered. Add split candidates
-            # only for undersaturated grids, and only when each split still runs
-            # K_ITERS/SPLIT_K > NUM_BUFFERS iters (statically checked via k > NB*BK*SK)
-            # so the warp-pipeline prologue/drain stays well-formed.
-            tiles = ((m_hint + block_m - 1) // block_m) * (
-                (n_hint + block_n - 1) // block_n
-            )
-            split_ks = [1]
-            if allow_split_k and tiles < NUM_SMS:
-                for sk in (2, 4, 8):
-                    # Cap at ~4 waves. For memory-bound large-K the sweet spot is
-                    # often >1 wave (more concurrent HBM requests -> higher effective
-                    # bandwidth); the standalone sweep's winners filled to 300%
-                    # (e.g. 1024x6144x22272 at SK=4 -> 768 wg / 3 waves). A 2-wave cap
-                    # excluded exactly those, so autotune fell back to a slower SK=1.
-                    if tiles * sk > 4 * NUM_SMS:
-                        break
-                    # correctness: the balanced K-partition gives each split
-                    # base = K_ITERS // SK iters; require base > NUM_BUFFERS so every
-                    # split's warp-pipeline prologue/drain is well-formed. Sufficient
-                    # static condition on K: k > (NUM_BUFFERS + 1) * BLOCK_K * SK.
-                    if sizevars.statically_known_true(
-                        sympy.Gt(k, (num_buffers + 1) * block_k * sk)
-                    ):
-                        split_ks.append(sk)
+            if use_async:
+                # async warp-pipeline correctness guard: K_ITERS > NUM_BUFFERS (well-formed
+                # prologue/drain). SPLIT_K=1 always; add split candidates for undersaturated grids
+                # only when each split still runs K_ITERS/SPLIT_K > NUM_BUFFERS iters (k > NB*BK*SK).
+                if not sizevars.statically_known_true(sympy.Gt(k, num_buffers * block_k)):
+                    continue
+                tiles = ((m_hint + block_m - 1) // block_m) * (
+                    (n_hint + block_n - 1) // block_n
+                )
+                split_ks = [1]
+                if allow_split_k and tiles < NUM_SMS:
+                    for sk in (2, 4, 8):
+                        # Cap at ~4 waves (memory-bound large-K sweet spot is often >1 wave;
+                        # e.g. 1024x6144x22272 at SK=4 -> 768 wg / 3 waves).
+                        if tiles * sk > 4 * NUM_SMS:
+                            break
+                        # correctness: balanced K-partition gives each split base = K_ITERS // SK
+                        # iters; require base > NUM_BUFFERS (k > (NUM_BUFFERS+1)*BLOCK_K*SK).
+                        if sizevars.statically_known_true(
+                            sympy.Gt(k, (num_buffers + 1) * block_k * sk)
+                        ):
+                            split_ks.append(sk)
+            else:
+                # register path: no prologue -> handles ANY K (odd/sliced/small/dynamic); no split-K
+                # (its reduction path is only wired for the async warp-pipe), so SPLIT_K=1 only.
+                split_ks = [1]
             for split_k in split_ks:
                 triton_config = self.triton_config(
-                    1,  # num_stages=1: TLX is hand-pipelined; auto software-pipelining must be off
+                    # async is hand-pipelined (num_stages=1, auto software-pipelining off); the
+                    # register path relies on the auto-pipeliner (num_stages=3) to overlap tl.loads.
+                    1 if use_async else 3,
                     num_warps,
                     BLOCK_M=block_m,
                     BLOCK_N=block_n,
@@ -1289,6 +1291,7 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
                     NUM_BUFFERS=num_buffers,
                     NUM_XCDS=num_xcds,
                     SPLIT_K=split_k,
+                    USE_ASYNC=use_async,
                     matrix_instr_nonkdim=16,
                     waves_per_eu=0,
                     kpack=get_default_kpack(block_k),


### PR DESCRIPTION
Summary:

Fix the lowering failure of misaligned K shape in addmm, same as bmm TLX template in D113371191

Ports the bmm register-path dual-path (D113371191) to the addmm template. Before this, the addmm
warp-pipe template DECLINED any K where (K*itemsize) % 16 != 0 (K % 8 for fp16/bf16) -- odd, sliced,
small, or dynamic K -- because the direct-to-LDS async_load cannot legalize a non-16-byte-aligned
row on CDNA4. In tlx_mode=force that decline is fatal (NoValidChoicesError) -- e.g. the merge net's
`addmm(K=92)` from a feature slice, which blocked forcing TLX across the model.

The addmm template is now dual-path via the `USE_ASYNC` constexpr the heuristic sets from K's
alignment (same mechanism as the bmm template):
- `USE_ASYNC=1` (K % 8 == 0): the existing async_load direct-to-LDS warp-pipe (+ optional split-K).
- `USE_ASYNC=0` (unaligned/odd/sliced/small/dynamic K): a register-path fallback -- `tl.load`
  (buffer_load, element-granular -> ANY alignment) of A [BM,BK] + col-major B as [BK,BN] (same index
  as the sync-tail), then `tl.dot`, auto-pipelined (num_stages=3). SPLIT_K=1 only (the split-K
  reduction path is wired only for the async warp-pipe).

The heuristic drops the K%8 decline gate (keeps the int32-offset gate + col-major-B requirement,
which both paths need) and picks the branch + num_stages per shape.

Reviewed By: htyu

Differential Revision: D113635877


