### PR TITLE
[triton][bitequiv] Forward interpreter Phase 4+5: MMA fence composition + control-flow floor (#2376)

### DIFF
--- a/bitequiv/ptx/forward/cfg.py
+++ b/bitequiv/ptx/forward/cfg.py
@@ -1,0 +1,41 @@
+"""Control-flow analysis for the forward interpreter's sound floor.
+
+The forward interpreter walks the linearized instruction stream in program order and DROPS
+predicates / branches. That is sound EXACTLY when all control flow is thread-STRUCTURAL — the
+taken-set of every branch is a function of tid / ctaid / ntid / kernel params (already captured by
+the leaf coordinates, the shuffle sequence, and reqntid). It is UNSOUND when control flow is
+data-dependent (a branch on a loaded value) or unresolved (an indirect branch), because then the
+straight-line trace does not represent what every thread actually computes.
+
+This module detects the unresolved case (:func:`has_unknown_control`) and enumerates the predicated
+instructions (:func:`predicated_insts`); :mod:`bitequiv.ptx.forward.predicate` classifies each
+predicate as structural or data-dependent. The interpreter fails closed when either fires. A full
+basic-block CFG (blocks, edges, back-edges) for loop-carry widening is future work; the floor needs
+only these two scans.
+"""
+from pyptx.ir.nodes import RegisterOperand
+
+from bitequiv.ptx.linker import linearize
+
+
+def has_unknown_control(func):
+    """True if the entry contains control flow the straight-line walk cannot resolve statically: an
+    indirect branch (``brx``) or a ``bra`` to a computed (register) target rather than a static
+    label. The caller must then fail closed — the trace cannot be trusted to cover every path."""
+    for inst in linearize(func):
+        op = inst.opcode
+        if op == "brx" or op.startswith("brx"):
+            return True
+        if op == "bra" and any(isinstance(o, RegisterOperand) for o in inst.operands):
+            return True  # a register (computed) branch target, not a static label
+    return False
+
+
+def predicated_insts(func):
+    """Every guarded instruction paired with its ``Predicate`` (``@%p inst``), in program order."""
+    out = []
+    for inst in linearize(func):
+        pred = getattr(inst, "predicate", None)
+        if pred is not None:
+            out.append((inst, pred))
+    return out

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -23,8 +23,11 @@ from pyptx.ir.nodes import RegisterOperand, VectorOperand
 
 from bitequiv.ptx.affine import AffineEval, canon, reqntid_of
 from bitequiv.ptx.builder import collapse_balanced, tree_hash
+from bitequiv.ptx.forward.cfg import has_unknown_control
+from bitequiv.ptx.forward.predicate import PredicateDecoder
 from bitequiv.ptx.leaves import leaf_coord, leaf_columns
 from bitequiv.ptx.linker import DefUse, _def_regs, linearize
+from bitequiv.ptx.mma import _mma_fence
 from bitequiv.ptx.treeir import FpOp, Leaf, OpaqueLeaf, OpaqueOp, ShflCombine, SmemExchange
 
 _FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f64", ".bf16", ".bf16x2"})
@@ -100,6 +103,13 @@ class ForwardInterp:
         # for the verbatim hash (it would over-merge across num_warps), so forward_descriptor falls
         # back to the conservative per-config fingerprint. Phase 2 models these -> faithful stays True.
         self.faithful = True
+        # Phase 5 control-flow floor: the straight-line walk DROPS predicates / branches, which is
+        # sound only when all control flow is thread-structural. An unresolved branch (brx / computed
+        # target) or a predicate that depends on runtime DATA (a load / MMA / atomic) makes the trace
+        # untrustworthy -> fail closed. A purely tid/param/lane-derived guard stays dropped (safe).
+        self._unknown_ctrl = has_unknown_control(func)
+        self.pred = PredicateDecoder(self.ev, self.du)
+        self._ddb = None  # cached _has_data_dependent_branch() result
 
     # -- operand lookup -------------------------------------------------------
 
@@ -136,8 +146,25 @@ class ForwardInterp:
 
     # -- driver ---------------------------------------------------------------
 
+    def _has_data_dependent_branch(self):
+        """True if control flow makes the straight-line trace unsound: an unresolved branch (brx /
+        computed target), or any predicated instruction whose guard depends on runtime DATA (a load /
+        MMA / atomic). A purely thread-structural guard (tid / param / lane arithmetic) is safe to
+        drop and does not trip this. Cached — used by both :meth:`run` and :meth:`fingerprint`."""
+        if self._ddb is None:
+            self._ddb = self._unknown_ctrl
+            if not self._ddb:
+                for i, inst in enumerate(self.flat):
+                    p = getattr(inst, "predicate", None)
+                    if p is not None and not self.pred.decode(p.register, i).is_structural:
+                        self._ddb = True
+                        break
+        return self._ddb
+
     def run(self):
         """Forward-simulate the entry; return the value-DAG root of each ``st.global`` value."""
+        if self._has_data_dependent_branch():
+            self.faithful = False  # Phase 5 floor: data-dependent / unresolved control flow
         roots = []
         for at, inst in enumerate(self.flat):
             op, mods = inst.opcode, inst.modifiers
@@ -346,7 +373,12 @@ class ForwardInterp:
             elif inst.opcode in _FP_KINDS and is_fp:
                 fp += 1
         stores_s = ",".join(f"{w}x{n}" for w, n in sorted(stores.items()))
-        return f"fwd-incomplete|ntid={ntid}|shfl={','.join(shfl)}|st={stores_s}|fp={fp}|fma={fma}"
+        # Control-flow term (Phase 5): the predicated-instruction count + a data-dependent flag, so two
+        # fail-closed configs that differ in control flow still split (extra key -> monotone sound).
+        cond = sum(1 for inst in self.flat if getattr(inst, "predicate", None) is not None)
+        dd = 1 if self._has_data_dependent_branch() else 0
+        return (f"fwd-incomplete|ntid={ntid}|shfl={','.join(shfl)}|st={stores_s}"
+                f"|fp={fp}|fma={fma}|cf={cond},dd{dd}")
 
 
 def forward_descriptor(func):
@@ -369,6 +401,40 @@ def forward_descriptor(func):
     return tuple(sorted(tree_hash(t) for t in collapsed))
 
 
+def _fence_str(fence):
+    """Canonical string for an :func:`bitequiv.ptx.mma._mma_fence` tuple (frozensets sorted so the
+    string is deterministic across runs). The ratio is (mma : fma : add/mul) — fma kept apart from
+    add/mul so enable_fp_fusion on/off never collide."""
+    if fence[0] == "mma":
+        _, tokens, flags, ratio = fence
+        return (f"mma|tok={'/'.join(sorted(tokens))}|fl={','.join(sorted(flags))}"
+                f"|r={ratio[0]}:{ratio[1]}:{ratio[2]}")
+    _, counts, flags, fa = fence  # mma-fp8 fallback: raw per-token counts + (fma, add/mul) (more split)
+    counts_s = "/".join(f"{t}x{n}" for t, n in counts)
+    return f"mma-fp8|tok={counts_s}|fl={','.join(sorted(flags))}|fma_addmul={fa[0]},{fa[1]}"
+
+
+def _mma_entry_descriptor(func, fence):
+    """Descriptor for an entry containing MMA (tensor-core) ops, via the tiling-invariant fence.
+
+    A PURE GEMM (MMA, no reduction butterfly) is the fence ALONE -> num_warps + BLOCK_M/BLOCK_N are
+    free (recovered), with ``loops=`` kept (BLOCK_K is a real, bit-relevant K split). An MMA + a
+    ``shfl.bfly`` reduction (e.g. FA softmax) is FAIL-CLOSED: the fence AND the reduction fingerprint
+    both ride, so configs differing in EITHER the MMA shape OR the reduction order split (sound, never
+    over-merged). The reduction fingerprint carries num_warps back in that case; the pure GEMM drops
+    it deliberately (num_warps is a free re-tiling of the same dot products)."""
+    from bitequiv.ptx_reduction import _loop_steps
+    parts = [_fence_str(fence)]
+    if any(inst.opcode == "shfl" and ".bfly" in inst.modifiers for inst in linearize(func)):
+        interp = ForwardInterp(func)
+        interp.run()
+        parts.append("mma+red|" + interp.fingerprint())
+    steps = _loop_steps(func)  # BLOCK_K split (+ the tcgen05 / fp8 K carried here, not in the token)
+    if steps:
+        parts.append("loops=" + ",".join(map(str, steps)))
+    return "|".join(parts)
+
+
 def forward_module_descriptor(ptx):
     """Module-level forward descriptor, mirroring :func:`bitequiv.ptx_reduction.ptx_reduction_descriptor`
     so the eval framework can drive the forward checker via ``--checker
@@ -379,7 +445,7 @@ def forward_module_descriptor(ptx):
     from pyptx.parser import parse
     from pyptx.parser.parser import ParseError
 
-    from bitequiv.ptx_reduction import _ensure_header, _loop_steps, _mma_guard, _Unparseable
+    from bitequiv.ptx_reduction import _ensure_header, _loop_steps, _Unparseable
     if not ptx:
         return ()
     try:
@@ -390,6 +456,10 @@ def forward_module_descriptor(ptx):
     for f in module.directives:
         if not (isinstance(f, Function) and f.is_entry):
             continue
+        fence = _mma_fence(f)  # Phase 4: an MMA entry takes the tiling-invariant fence composition
+        if fence is not None:
+            out.append(_mma_entry_descriptor(f, fence))
+            continue
         parts = list(forward_descriptor(f))
         if not parts:  # no reconstructed reduction -> keep launch geometry as the empty-sig guard
             ntid = reqntid_of(f)
@@ -397,8 +467,5 @@ def forward_module_descriptor(ptx):
         steps = _loop_steps(f)  # BLOCK_N cross-chunk fence: the straight-line walk cannot follow the
         if steps:               # loop back-edge, so a looped/persistent reduction (sum_dim1_persistent)
             parts.append("loops=" + ",".join(map(str, steps)))  # would over-merge without this (sound)
-        guard = _mma_guard(f)  # conservative MMA fence until Phase 4 models the collective op forward
-        if guard:
-            parts.append(guard)
         out.append("|".join(parts))
     return tuple(sorted(out))

--- a/bitequiv/ptx/forward/predicate.py
+++ b/bitequiv/ptx/forward/predicate.py
@@ -1,0 +1,82 @@
+"""Predicate classification for the forward interpreter's sound floor.
+
+A dropped predicate is sound iff it is thread-STRUCTURAL (its truth is a function of
+tid / ctaid / ntid / kernel params). It is DATA-DEPENDENT — unsound to drop — iff its value derives
+from a runtime memory load (``ld.global`` / ``ld.shared``), an MMA output, or an atomic. We classify
+by def-use PROVENANCE: trace the predicate register back through its source operands; if any source
+is produced by a data op the predicate is data-dependent. Special registers (``%tid`` / ``%laneid`` /
+``%ctaid`` ...), kernel params, and pure integer arithmetic over them (even non-affine idioms like
+``tid & 31``) have no data op in their provenance, so they are structural.
+
+Conservative by construction (over-split, never over-merge): any predicate whose provenance reaches a
+data op is data-dependent; only a purely param / thread-index-derived predicate is structural. Finer
+structural kinds (warp-leader, first-N, loop induction variable) that would let the interpreter
+RECOVER more freedom are a later extension; the floor needs only the structural-vs-data-dependent
+split so the interpreter can fail closed on data-dependent control flow.
+"""
+from dataclasses import dataclass
+
+from pyptx.ir.nodes import RegisterOperand, VectorOperand
+
+from bitequiv.ptx.mma import _is_mma
+
+DATA_DEPENDENT = "DATA_DEPENDENT"
+STRUCTURAL = "STRUCTURAL"
+
+
+@dataclass(frozen=True)
+class PredInfo:
+    """The classification of one predicate. ``is_structural`` is what the sound floor consumes."""
+
+    kind: str
+
+    @property
+    def is_structural(self):
+        return self.kind != DATA_DEPENDENT
+
+
+def _is_data_source(inst):
+    """True if ``inst`` produces a value from runtime DATA (a global/shared memory load, an MMA
+    output, or an atomic) — the thing that makes a predicate over it unsound to drop."""
+    op, mods = inst.opcode, inst.modifiers
+    if op == "ld" and (".global" in mods or ".shared" in mods):
+        return True
+    if op.startswith("atom") or op == "red":
+        return True
+    return _is_mma(inst)
+
+
+class PredicateDecoder:
+    """Classify a predicate register as structural or data-dependent by def-use provenance."""
+
+    def __init__(self, ev, du):
+        self.ev = ev  # AffineEval — reserved for the finer structural kinds (later recovery work)
+        self.du = du
+
+    def decode(self, pred_reg, before_index):
+        """``PredInfo`` for the predicate held in ``pred_reg`` at ``before_index`` (a program point in
+        the same linearized stream the interpreter walks)."""
+        dd = self._depends_on_data(pred_reg, before_index)
+        return PredInfo(DATA_DEPENDENT if dd else STRUCTURAL)
+
+    def _depends_on_data(self, reg, before_index):
+        """True iff the value in ``reg`` traces back (through def-use) to a data source. Iterative
+        with a seen-set so a shared/cyclic def graph terminates."""
+        stack, seen = [(reg, before_index)], set()
+        while stack:
+            r, at = stack.pop()
+            if (r, at) in seen:
+                continue
+            seen.add((r, at))
+            d = self.du.last_writer(r, at)
+            if d is None:
+                continue  # kernel param / special register (%tid, %laneid, ...) -> structural leaf
+            if _is_data_source(d.inst):
+                return True
+            for o in (d.inst.operands[1:] if d.inst.operands else []):  # source operands
+                if isinstance(o, RegisterOperand):
+                    stack.append((o.name, d.index))
+                elif isinstance(o, VectorOperand):
+                    stack.extend((e.name, d.index) for e in o.elements
+                                 if isinstance(e, RegisterOperand))
+        return False

--- a/bitequiv/ptx/mma.py
+++ b/bitequiv/ptx/mma.py
@@ -1,0 +1,148 @@
+"""Shared MMA (tensor-core) fence for the bitwise-equivalence checker.
+
+An MMA op (``wgmma`` / ``mma.sync`` / ``wmma`` / ``tcgen05.mma``) is a COLLECTIVE matmul whose
+internal accumulation order we do not reconstruct. Instead we summarize an entry's MMA ops with a
+tiling-invariant FENCE: a conjunction of facts that can only SPLIT equivalence classes, never merge
+them. This lets the autotuner keep MMA configs that differ ONLY in a bit-irrelevant tiling choice
+(BLOCK_M / BLOCK_N re-tiling, num_warps) in one class, while separating anything that changes the
+bits (K split, operand/accumulator dtype, scale/accumulate flags).
+
+Soundness (over-split, never over-merge):
+- Each KEPT token piece is bit-relevant: K (the products summed per hardware pass — regrouping K
+  changes the sum) and the operand + accumulator dtypes (rounding). tcgen05 keeps ``.kind::`` (dtype
+  family) and ``.cta_group::`` (2-CTA changes the accumulation).
+- Each DROPPED piece is tiling-free: the m/n tile dims (retiling the SAME dot products across a
+  different BLOCK_M / BLOCK_N is bit-identical) and the issue/transpose mods
+  (``.mma_async`` / ``.sync`` / ``.aligned`` / ``.row`` / ``.col``).
+- The ``(mma_count, f32-fp-count)`` ratio is GCD-reduced, so proportional M/N tiling (n128 ->
+  2x n64 doubles BOTH counts) reduces to the same ratio (sound merge), while a real K split (which
+  changes the counts disproportionately) stays distinct.
+- fp8 (e4m3/e5m2/...): the ``max_num_imprecise_acc`` periodic-flush cadence is invisible to the
+  reduced ratio, so we FALL BACK to the raw per-token count map + raw fp count (strictly more
+  splitting).
+- tcgen05 M/N/K live in a runtime descriptor, not the modifiers, so tcgen05 K rides the ratio + the
+  caller's ``loops=`` (BLOCK_K) fence rather than the token — conservative.
+
+This module is the single source of truth for both the forward interpreter and the backward
+``_entry_signature`` (which currently uses the coarser ``_mma_guard``).
+"""
+import re
+from math import gcd
+
+from bitequiv.ptx.linker import linearize
+
+# The four tensor-core op families. wgmma/wmma/tcgen05 are families with non-matmul members
+# (fences, commits, loads) that _is_mma filters out; bare `mma` (mma.sync) is always the matmul.
+_MMA_OPCODES = frozenset({"wgmma", "mma", "wmma", "tcgen05"})
+
+# Operand / accumulator element dtypes that appear as MMA modifier tokens. KEPT in the fence token
+# (rounding is bit-relevant). fp8 additionally trips the conservative fallback.
+_FP8_DTYPES = frozenset({".e4m3", ".e5m2", ".e3m2", ".e2m3", ".e2m1"})
+_MMA_DTYPES = frozenset({".f64", ".f32", ".tf32", ".f16", ".bf16", ".s32", ".s8", ".u8", ".s4",
+                         ".u4", ".b1"}) | _FP8_DTYPES
+
+# The single tile+K modifier token, e.g. `.m64n128k16` (wgmma / mma.sync / wmma).
+_TILE_RE = re.compile(r"^\.m(\d+)n(\d+)k(\d+)$")
+
+# fp reduce/epilogue ops whose count scales with the MMA tile count, so the GCD-reduced
+# (mma_count, fp_count) ratio cancels proportional M/N tiling. f32 family only (the accumulate /
+# epilogue precision that matters).
+_FP_EPI_OPS = frozenset({"add", "sub", "mul", "fma"})
+_FP_EPI_WIDTHS = frozenset({".f32", ".f32x2"})
+
+
+def _is_mma(inst):
+    """True iff ``inst`` is a tensor-core MATMUL (not a fence / commit / load member of the family)."""
+    op = inst.opcode
+    if op == "mma":
+        return True  # mma.sync — the bare opcode is the matmul
+    if op == "wgmma":
+        return any(m.startswith(".mma") for m in inst.modifiers)  # .mma_async (not .fence/.commit/.wait)
+    if op == "wmma":
+        return ".mma" in inst.modifiers  # not .load / .store
+    if op == "tcgen05":
+        return ".mma" in inst.modifiers  # not .commit / .ld / .st / .fence / .cp / .wait
+    return False
+
+
+def _k_of(mods):
+    """The K tile dim (int) from the `.m<M>n<N>k<K>` token, or None if absent (e.g. tcgen05)."""
+    for m in mods:
+        mo = _TILE_RE.match(m)
+        if mo:
+            return int(mo.group(3))
+    return None
+
+
+def _mma_token(opcode, mods):
+    """Tiling-INVARIANT fence token: keep the bit-relevant facts, drop the free ones.
+
+    tcgen05: M/N/K live in a runtime descriptor (not the modifiers), so they ride the ratio +
+    ``loops=`` instead; keep ``.kind::`` (dtype family -> rounding) and ``.cta_group::`` (2-CTA
+    changes the accumulation). wgmma / mma.sync / wmma: keep K and the operand/accumulator dtypes;
+    drop the m/n tile dims and the issue/transpose mods."""
+    if opcode == "tcgen05":
+        keep = sorted(m for m in mods if m.startswith(".kind::") or m.startswith(".cta_group::"))
+        return "tcgen05|" + ",".join(keep)
+    k = _k_of(mods)
+    dtypes = [m for m in mods if m in _MMA_DTYPES]
+    return f"{opcode}|k{k}|{','.join(dtypes)}"
+
+
+def _imm(operand):
+    """The integer-immediate text of an operand (e.g. a wgmma scale/accumulate flag), or None for a
+    register / vector / address / non-numeric operand."""
+    txt = getattr(operand, "text", None) or getattr(operand, "name", None) or str(operand)
+    txt = str(txt).strip()
+    return txt if txt.lstrip("-").isdigit() else None
+
+
+def _mma_flags(inst):
+    """The set of immediate flag operands (scale-D / scale-A / scale-B / transpose imms). These are
+    kernel-fixed (not autotuner knobs), so they never split configs of one kernel spuriously; kept
+    as a belt so a config that DID differ in an accumulate/overwrite flag would still separate."""
+    return {v for v in (_imm(o) for o in inst.operands) if v is not None}
+
+
+def _fp_epi_counts(func):
+    """(fma_count, addmul_count) of f32-family epilogue fp ops, counted SEPARATELY. enable_fp_fusion
+    flips fma <-> mul+add in the epilogue, and the compiler can emit the SAME TOTAL count either way
+    (measured on gemm_bias_relu_fp_fusion: 16 fma fused vs 16 add/mul unfused) — so a single lumped
+    count collides and over-merges (fma is single-rounded, mul+add double-rounded -> different bits).
+    Keeping fma apart splits fp_fusion on/off. Both scale with the MMA tile count, so the GCD-reduced
+    ratio still cancels proportional M/N tiling."""
+    fma, addmul = 0, 0
+    for inst in linearize(func):
+        if not (inst.modifiers and inst.modifiers[-1] in _FP_EPI_WIDTHS):
+            continue
+        if inst.opcode == "fma":
+            fma += 1
+        elif inst.opcode in _FP_EPI_OPS:  # add / sub / mul
+            addmul += 1
+    return fma, addmul
+
+
+def _mma_fence(func):
+    """Tiling-invariant fence for an entry's MMA ops, or ``None`` if the entry has no MMA.
+
+    Returns a hashable tuple. Two entries with equal fences differ only in a bit-IRRELEVANT tiling
+    choice; any bit-relevant difference (K split, dtype, flag, or a non-proportional op-count change)
+    yields a distinct fence. fp8 falls back to the raw per-token count map + raw fp count (strictly
+    more splitting) because its imprecise-acc flush cadence is invisible to the reduced ratio."""
+    insts = [i for i in linearize(func) if _is_mma(i)]
+    if not insts:
+        return None
+    tokens = tuple(sorted(_mma_token(i.opcode, i.modifiers) for i in insts))
+    flags = set()
+    for i in insts:
+        flags |= _mma_flags(i)
+    flags = frozenset(flags)
+    fma, addmul = _fp_epi_counts(func)
+    if any(any(d in t for d in _FP8_DTYPES) for t in tokens):
+        counts = {}
+        for t in tokens:
+            counts[t] = counts.get(t, 0) + 1
+        return ("mma-fp8", tuple(sorted(counts.items())), flags, (fma, addmul))
+    n = len(insts)
+    g = gcd(gcd(n, fma), addmul) or 1  # GCD over all three -> proportional M/N tiling cancels
+    return ("mma", frozenset(tokens), flags, (n // g, fma // g, addmul // g))

--- a/bitequiv/tests/test_ptx_forward.py
+++ b/bitequiv/tests/test_ptx_forward.py
@@ -12,6 +12,8 @@ from bitequiv.ptx.builder import collapse_balanced
 from bitequiv.ptx.forward.interp import forward_module_descriptor
 from bitequiv.ptx.treeir import FpOp, ITreeReduce, Leaf, OpaqueOp, ShflCombine
 
+_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+
 _FIX = os.path.join(os.path.dirname(__file__), "fixtures", "ptx")
 
 
@@ -115,3 +117,38 @@ def test_squared_reduction_collapses_but_distinct_element_product_does_not():
                 (FpOp("mul", (".f32", ), (_leaf(0), _leaf(1))),
                  FpOp("mul", (".f32", ), (_leaf(2), _leaf(3)))))
     assert not isinstance(collapse_balanced(prod), ITreeReduce)
+
+
+# -- Phase 4: MMA entries take the tiling-invariant fence composition ----------
+
+
+def test_mma_entry_gets_fence_descriptor():
+    # A wgmma entry -> the tiling-invariant fence (K + dtypes kept, m/n dropped), not a tree hash or
+    # the old coarse unanalyzed-mma guard.
+    ptx = (_HDR + ".visible .entry k()\n{\n.reg .b32 %r<8>;\n"
+           "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r1}, %r2, %r3;\nret;\n}\n")
+    (desc, ) = forward_module_descriptor(ptx)
+    assert desc.startswith("mma|tok=") and "k16" in desc and "m64" not in desc
+
+
+# -- Phase 5: data-dependent control flow fails closed (sound floor) -----------
+
+
+def test_data_dependent_branch_fails_closed():
+    # A predicate on a LOADED value -> the straight-line walk is unsound -> fingerprint with dd1.
+    ptx = (_HDR + ".visible .entry k()\n{\n.reg .b32 %r<4>;\n.reg .b64 %rd<4>;\n"
+           ".reg .pred %p<2>;\n.reg .f32 %f<4>;\n"
+           "ld.global.f32 %f1, [%rd1];\nsetp.lt.f32 %p1, %f1, 0f3F000000;\n"
+           "@%p1 add.f32 %f2, %f1, %f1;\nst.global.f32 [%rd2], %f2;\nret;\n}\n")
+    (desc, ) = forward_module_descriptor(ptx)
+    assert "fwd-incomplete" in desc and "dd1" in desc
+
+
+def test_structural_branch_does_not_fail_close():
+    # A tid-guarded (structural) predicate is safe to drop -> NOT fail-closed for control flow (dd1).
+    ptx = (_HDR + ".visible .entry k()\n{\n.reg .b32 %r<4>;\n.reg .b64 %rd<4>;\n"
+           ".reg .pred %p<2>;\n.reg .f32 %f<4>;\n"
+           "ld.global.f32 %f1, [%rd1];\nmov.u32 %r1, %tid.x;\nsetp.lt.s32 %p1, %r1, 64;\n"
+           "@%p1 add.f32 %f2, %f1, %f1;\nst.global.f32 [%rd2], %f2;\nret;\n}\n")
+    (desc, ) = forward_module_descriptor(ptx)
+    assert "dd1" not in desc

--- a/bitequiv/tests/test_ptx_forward_cfg.py
+++ b/bitequiv/tests/test_ptx_forward_cfg.py
@@ -1,0 +1,66 @@
+"""Tests for the forward interpreter's control-flow sound floor (cfg + predicate). CPU-only."""
+from pyptx.parser import parse
+
+from bitequiv.ptx.affine import AffineEval, reqntid_of
+from bitequiv.ptx.forward.cfg import has_unknown_control, predicated_insts
+from bitequiv.ptx.forward.predicate import PredicateDecoder
+from bitequiv.ptx.linker import DefUse, linearize
+
+_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+
+
+def _entry(body):
+    ptx = _HDR + ".visible .entry k()\n{\n" + body + "}\n"
+    return [d for d in parse(ptx).directives if getattr(d, "is_entry", False)][0]
+
+
+def _decode_first_pred(func):
+    du = DefUse(func)
+    dec = PredicateDecoder(AffineEval(du, reqntid_of(func)), du)
+    for i, inst in enumerate(linearize(func)):
+        pred = getattr(inst, "predicate", None)
+        if pred is not None:
+            return dec.decode(pred.register, i)
+    return None
+
+
+# tid < 64: purely thread-index derived -> safe to drop.
+_STRUCT = (".reg .b32 %r<4>;\n.reg .pred %p<2>;\n.reg .f32 %f<4>;\n"
+           "mov.u32 %r1, %tid.x;\nsetp.lt.s32 %p1, %r1, 64;\n@%p1 bra LBL;\n"
+           "add.f32 %f1, %f2, %f3;\nLBL:\nret;\n")
+
+# (tid & 31) == 0: warp-leader idiom. AffineEval makes the `and` opaque, but there is no DATA load in
+# its provenance, so it is structural (must NOT fail closed -- warp-leader stores are everywhere).
+_LANE_LEADER = (".reg .b32 %r<4>;\n.reg .pred %p<2>;\n.reg .f32 %f<4>;\n"
+                "mov.u32 %r1, %tid.x;\nand.b32 %r2, %r1, 31;\nsetp.eq.s32 %p1, %r2, 0;\n"
+                "@%p1 bra LBL;\nadd.f32 %f1, %f2, %f3;\nLBL:\nret;\n")
+
+# branch on a LOADED value -> data-dependent -> must fail closed.
+_DATA_DEP = (".reg .b32 %r<4>;\n.reg .b64 %rd<4>;\n.reg .pred %p<2>;\n.reg .f32 %f<4>;\n"
+             "ld.global.f32 %f1, [%rd1];\nsetp.lt.f32 %p1, %f1, 0f3F000000;\n@%p1 bra LBL;\n"
+             "add.f32 %f2, %f3, %f4;\nLBL:\nret;\n")
+
+
+def test_structural_tid_guard_is_structural():
+    assert _decode_first_pred(_entry(_STRUCT)).is_structural
+
+
+def test_warp_leader_guard_is_structural():
+    assert _decode_first_pred(_entry(_LANE_LEADER)).is_structural
+
+
+def test_data_dependent_guard_is_not_structural():
+    assert not _decode_first_pred(_entry(_DATA_DEP)).is_structural
+
+
+def test_normal_bra_is_known_control():
+    assert not has_unknown_control(_entry(_STRUCT))
+
+
+def test_brx_is_unknown_control():
+    body = ".reg .b32 %r<4>;\nmov.u32 %r1, %tid.x;\nbrx.idx %r1, tab;\nret;\n"
+    assert has_unknown_control(_entry(body))
+
+
+def test_predicated_insts_counts_the_guard():
+    assert len(predicated_insts(_entry(_STRUCT))) == 1

--- a/bitequiv/tests/test_ptx_mma.py
+++ b/bitequiv/tests/test_ptx_mma.py
@@ -1,0 +1,84 @@
+"""Tests for the shared MMA fence (bitequiv.ptx.mma). CPU-only, inline PTX."""
+from pyptx.parser import parse
+
+from bitequiv.ptx.linker import linearize
+from bitequiv.ptx.mma import _is_mma, _mma_fence, _mma_token
+
+_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+
+
+def _entry(body):
+    ptx = _HDR + ".visible .entry k()\n{\n.reg .b32 %r<16>;\n.reg .f32 %f<16>;\n" + body + "ret;\n}\n"
+    return [d for d in parse(ptx).directives if getattr(d, "is_entry", False)][0]
+
+
+def _mma_insts(body):
+    return [x for x in linearize(_entry(body)) if _is_mma(x)]
+
+
+def _tok(body):
+    (i, ) = _mma_insts(body)
+    return _mma_token(i.opcode, i.modifiers)
+
+
+_WGMMA = "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r1}, %r2, %r3;\n"
+_MMA_SYNC = "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%r1}, {%r2}, {%r3}, {%r4};\n"
+
+
+def test_k_kept_tile_dropped_dtypes_kept():
+    tok = _tok(_WGMMA)
+    assert "k16" in tok and "m64" not in tok and "n128" not in tok and ".f16" in tok
+
+
+def test_wgmma_vs_mma_sync_distinct():
+    assert _tok(_WGMMA) != _tok(_MMA_SYNC)
+
+
+def test_tcgen05_keeps_kind_and_cta_group():
+    tok = _tok("tcgen05.mma.cta_group::1.kind::f16 [%r1], %r2, %r3;\n")
+    assert "kind::f16" in tok and "cta_group::1" in tok and tok.startswith("tcgen05|")
+
+
+def test_wgmma_fence_wait_is_not_a_matmul():
+    # A wgmma.wait_group / wgmma.fence is NOT a matmul: it must not enter the fence.
+    assert _mma_insts("wgmma.wait_group.sync.aligned 0;\n") == []
+
+
+def test_non_mma_entry_has_no_fence():
+    assert _mma_fence(_entry("add.f32 %f1, %f2, %f3;\n")) is None
+
+
+def test_proportional_tiling_reduces_to_same_ratio():
+    # n128 + 1 epilogue add  ==  2x n64 + 2 epilogue adds: same K/dtypes (m/n dropped) and the
+    # GCD-reduced (mma_count, fp_count) ratio is equal -> same fence (bit-irrelevant re-tiling).
+    one = _mma_fence(_entry(_WGMMA + "add.f32 %f1, %f2, %f3;\n"))
+    two = _mma_fence(_entry(
+        "wgmma.mma_async.sync.aligned.m64n64k16.f32.f16.f16 {%r1}, %r2, %r3;\n"
+        "wgmma.mma_async.sync.aligned.m64n64k16.f32.f16.f16 {%r4}, %r5, %r6;\n"
+        "add.f32 %f1, %f2, %f3;\n"
+        "add.f32 %f4, %f5, %f6;\n"))
+    assert one == two
+
+
+def test_k_split_stays_distinct():
+    k16 = _mma_fence(_entry(_WGMMA + "add.f32 %f1, %f2, %f3;\n"))
+    k32 = _mma_fence(_entry(
+        "wgmma.mma_async.sync.aligned.m64n128k32.f32.f16.f16 {%r1}, %r2, %r3;\n"
+        "add.f32 %f1, %f2, %f3;\n"))
+    assert k16 != k32
+
+
+def test_fp8_falls_back_to_conservative():
+    f = _mma_fence(_entry(
+        "wgmma.mma_async.sync.aligned.m64n128k32.f32.e4m3.e4m3 {%r1}, %r2, %r3;\n"
+        "add.f32 %f1, %f2, %f3;\n"))
+    assert f is not None and f[0] == "mma-fp8"
+
+
+def test_fp_fusion_splits_at_equal_op_count():
+    # The measured gemm_bias_relu_fp_fusion over-merge: enable_fp_fusion on emits N fma, off emits N
+    # add/mul -- the SAME total count -- so a single lumped fp count collides. Counting fma apart from
+    # add/mul (ratio mma:fma:addmul) splits them (fma single-rounded vs mul+add double-rounded).
+    fused = _mma_fence(_entry(_WGMMA + "fma.rn.f32 %f1, %f2, %f3, %f4;\nfma.rn.f32 %f5, %f6, %f7, %f8;\n"))
+    unfused = _mma_fence(_entry(_WGMMA + "add.f32 %f1, %f2, %f3;\nadd.f32 %f5, %f6, %f7;\n"))
+    assert fused != unfused  # (1 mma, 2 fma, 0 addmul) vs (1 mma, 0 fma, 2 addmul)


### PR DESCRIPTION
Summary:

Integrates the Phase 4 (MMA) and Phase 5 (control-flow) modules into the forward interpreter. They share `bitequiv/ptx/forward/interp.py`, so they land together.

Phase 4 adds a shared, tiling-invariant MMA fence (`bitequiv/ptx/mma.py`): for a tensor-core op (wgmma / mma.sync / wmma / tcgen05) it keeps the bit-relevant facts (K, operand/accumulator dtypes; tcgen05 `.kind::` / `.cta_group::`) and drops the free ones (the m/n tile dims, issue/transpose mods), plus a GCD-reduced (mma_count, f32-fp-count) ratio that cancels proportional M/N tiling. fp8 falls back to raw per-token counts (its imprecise-acc flush cadence is invisible to the ratio). `forward_module_descriptor` now routes an MMA entry to this fence: a pure GEMM is the fence alone (num_warps + BLOCK_M/N free, BLOCK_K kept), while an MMA plus a shfl reduction is fail-closed (fence AND reduction fingerprint both ride). This replaces the coarse `unanalyzed-mma` guard, which kept the tile dims and so over-split every re-tiling.

Phase 5 adds the control-flow sound floor (`bitequiv/ptx/forward/cfg.py` + `predicate.py`): the straight-line walk drops predicates, which is sound only when control flow is thread-structural. A data-dependent predicate (its value traces through def-use to a load / MMA / atomic) or an unresolved branch (brx) now trips `faithful=False` -> the conservative fingerprint (hardened with a control-flow term). A purely tid / param / lane-derived guard (even `tid & 31`) stays dropped, so there is no new over-split on the common warp-leader idiom.

CPU validation: 86 tests pass (incl. new MMA-fence, cfg/predicate, and forward MMA/branch tests). GPU gate: the Phase 3 heavy + convincing run is in flight; Phase 4/5 get an initial light (R=30) fuzzer validation here, with the full heavy + convincing gate to follow.

The `Mma` treeir node + reduction-over-MMA-output tree composition (needed only when a real reduction consumes an MMA output as a tree) is deferred to Phase 6 / FA; the current fence composition covers pure-GEMM recovery and fail-closes MMA + reduction.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D112765110


