### PR TITLE
[triton][bitequiv] Eval suite: add gemm_all combined-knob GEMM spec (#2377)

### DIFF
--- a/bitequiv/evaluation/eval_kernels.py
+++ b/bitequiv/evaluation/eval_kernels.py
@@ -665,6 +665,24 @@ def _gemm_num_warps_filter(config):
     return config.num_warps in (4, 8)
 
 
+def _gemm_all_filter(config):
+    """num_warps filter PLUS a Blackwell TMEM (512-column) guard for the combined gemm_all
+    cross-product: the accumulator (block_m x block_n) plus the K-pipeline (block_k x num_stages)
+    can overflow tensor memory, and unlike a compile error a run/launch OOM is NOT caught by
+    evaluate_precision. The dropped boundary (block_k=64 with num_stages>=3; the 256-wide accumulator
+    with num_stages>=5) is calibrated for this spec's default precision_size (256^3), where it leaves
+    0 launch-OOM. NOTE: TMEM use is TENSOR-dependent -- a large K runs the full num_stages pipeline
+    (short K-loops collapse it), so at a much bigger tensor some surviving configs still OOM; a driver
+    that overrides the tensor size must skip run-OOM configs itself (this filter cannot see the size)."""
+    if not _gemm_num_warps_filter(config):
+        return False
+    if config.gemm_block_k == 64 and (config.num_stages or 1) >= 3:
+        return False
+    if config.gemm_block_n == 256 and (config.num_stages or 1) >= 5:
+        return False
+    return True
+
+
 def _gemm_blocks(config, default_bk):
     """Resolve the tile from the config, defaulting axes the spec does not sweep."""
     bm = config.gemm_block_m if config.gemm_block_m is not None else 128
@@ -996,6 +1014,25 @@ REGISTRY = {
         compile_fn=_gemm_tma_store_compile,
         run_fn=_gemm_tma_store_run,
         config_filter=_gemm_num_warps_filter,
+    ),
+    "gemm_all":
+    KernelSpec(
+        name="gemm_all",
+        description=("f32 GEMM varying ALL co-existing knobs together (M/N/K tiling x input_precision x "
+                     "enable_fp_fusion x num_warps x num_stages) -- the real autotuner cross-product, to "
+                     "stress the MMA fence with cross-knob interactions. The per-knob GEMM specs above "
+                     "isolate one knob each for clean attribution; this crosses them (~1300 configs at heavy). "
+                     "fp8 stays a separate spec (a distinct dtype path that cannot co-vary with input_precision)."),
+        output_arity=1,
+        axes=("enable_fp_fusion", "num_warps", "num_stages", "gemm_block_m", "gemm_block_n", "gemm_block_k",
+              "input_precision"),
+        precision_size=(256, 256, 256),
+        perf_size=(256, 256, 256),
+        known_limitation="",
+        compile_fn=_gemm_prec_compile,
+        run_fn=_gemm_prec_run,
+        config_filter=_gemm_all_filter,
+        axis_values={"gemm_block_k": (16, 32, 64), "enable_fp_fusion": (True, False)},
     ),
 }
 


### PR DESCRIPTION
Summary:

Adds a `gemm_all` kernel spec to the evaluation suite. The existing GEMM specs each isolate ONE knob (free_tiling = M/N, kloop = block_k, input_precision, bias_relu_fp_fusion, fp8_imprecise_acc, tma_store) for clean per-knob attribution, so each is only 12-72 configs. `gemm_all` crosses the co-existing f32-path knobs — M/N/K tiling x input_precision x enable_fp_fusion x num_warps x num_stages — to exercise the MMA fence on the real autotuner cross-product with cross-knob interactions (~912 configs at heavy after the TMEM filter). fp8 stays its own spec (a distinct dtype path that cannot co-vary with input_precision).

It reuses the f32 `_gemm_prec_compile` / `_gemm_prec_run` (which already read tiling, num_stages, fp_fusion, and input_precision from the config), and adds `_gemm_all_filter`: the num_warps filter plus a conservative Blackwell TMEM (512-column) guard. Some tile+pipeline combos in the cross-product have an accumulator (block_m x block_n) + K-pipeline (block_k x num_stages) that overflows tensor memory at run/launch — and a launch OOM is NOT caught by `evaluate_precision` (only compile is), so it would crash the kernel's evaluation. The filter drops the measured OOM boundary (block_k=64 with num_stages>=3; the 256-wide accumulator with num_stages>=5).

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D112786604


