### PR TITLE
[triton][bitequiv] Fence recovery: only fence FP-accumulation loops (drop tiling/parallel loops) (#2378)

### DIFF
--- a/bitequiv/evaluation/eval_kernels.py
+++ b/bitequiv/evaluation/eval_kernels.py
@@ -665,6 +665,24 @@ def _gemm_num_warps_filter(config):
     return config.num_warps in (4, 8)
 
 
+def _gemm_all_filter(config):
+    """num_warps filter PLUS a Blackwell TMEM (512-column) guard for the combined gemm_all
+    cross-product: the accumulator (block_m x block_n) plus the K-pipeline (block_k x num_stages)
+    can overflow tensor memory, and unlike a compile error a run/launch OOM is NOT caught by
+    evaluate_precision. The dropped boundary (block_k=64 with num_stages>=3; the 256-wide accumulator
+    with num_stages>=5) is calibrated for this spec's default precision_size (256^3), where it leaves
+    0 launch-OOM. NOTE: TMEM use is TENSOR-dependent -- a large K runs the full num_stages pipeline
+    (short K-loops collapse it), so at a much bigger tensor some surviving configs still OOM; a driver
+    that overrides the tensor size must skip run-OOM configs itself (this filter cannot see the size)."""
+    if not _gemm_num_warps_filter(config):
+        return False
+    if config.gemm_block_k == 64 and (config.num_stages or 1) >= 3:
+        return False
+    if config.gemm_block_n == 256 and (config.num_stages or 1) >= 5:
+        return False
+    return True
+
+
 def _gemm_blocks(config, default_bk):
     """Resolve the tile from the config, defaulting axes the spec does not sweep."""
     bm = config.gemm_block_m if config.gemm_block_m is not None else 128
@@ -996,6 +1014,25 @@ REGISTRY = {
         compile_fn=_gemm_tma_store_compile,
         run_fn=_gemm_tma_store_run,
         config_filter=_gemm_num_warps_filter,
+    ),
+    "gemm_all":
+    KernelSpec(
+        name="gemm_all",
+        description=("f32 GEMM varying ALL co-existing knobs together (M/N/K tiling x input_precision x "
+                     "enable_fp_fusion x num_warps x num_stages) -- the real autotuner cross-product, to "
+                     "stress the MMA fence with cross-knob interactions. The per-knob GEMM specs above "
+                     "isolate one knob each for clean attribution; this crosses them (~1300 configs at heavy). "
+                     "fp8 stays a separate spec (a distinct dtype path that cannot co-vary with input_precision)."),
+        output_arity=1,
+        axes=("enable_fp_fusion", "num_warps", "num_stages", "gemm_block_m", "gemm_block_n", "gemm_block_k",
+              "input_precision"),
+        precision_size=(256, 256, 256),
+        perf_size=(256, 256, 256),
+        known_limitation="",
+        compile_fn=_gemm_prec_compile,
+        run_fn=_gemm_prec_run,
+        config_filter=_gemm_all_filter,
+        axis_values={"gemm_block_k": (16, 32, 64), "enable_fp_fusion": (True, False)},
     ),
 }
 

--- a/bitequiv/ptx_reduction.py
+++ b/bitequiv/ptx_reduction.py
@@ -48,25 +48,101 @@ different launch geometries or un-modeled accumulations never collapse to an emp
 contract/reorder. PTX is the practical check, not absolute ground truth (SASS via
 ``cuobjdump`` would be); ``--fmad=false`` pins the fusion decision. See ``design-doc.md``.
 """
-from pyptx.ir.nodes import Function, ImmediateOperand, RegisterOperand
+from pyptx.ir.nodes import Block, Function, ImmediateOperand, Label, RegisterOperand
 from pyptx.parser import parse
 from pyptx.parser.parser import ParseError
 
 from bitequiv.ptx.affine import reqntid_of
 from bitequiv.ptx.builder import entry_signatures
 from bitequiv.ptx.linker import linearize
+from bitequiv.ptx.mma import _is_mma
+
+# fp combine ops + widths, used to detect a loop-carried floating-point accumulation.
+_FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f32x2", ".f64", ".bf16", ".bf16x2"})
+_FP_COMBINE = frozenset({"add", "sub", "mul", "div", "min", "max", "fma"})
+
+
+def _instrs_and_labels(func):
+    """Linearized instructions (recursing into ``Block`` scopes, like :func:`linearize`) PLUS a map
+    ``label name -> index of the instruction at/after that label``. ``linearize`` drops labels; we
+    need their positions to find loop back-edges."""
+    insts, label_at, pending = [], {}, []
+
+    def walk(stmts):
+        for s in stmts:
+            if isinstance(s, Block):
+                walk(s.body)
+            elif isinstance(s, Label):
+                pending.append(s.name)
+            elif type(s).__name__ == "Instruction":
+                while pending:
+                    label_at[pending.pop()] = len(insts)
+                insts.append(s)
+
+    walk(func.body)
+    for name in pending:  # a trailing label points just past the last instruction
+        label_at[name] = len(insts)
+    return insts, label_at
+
+
+def _back_edges(insts, label_at):
+    """(header_idx, latch_idx) for each backward branch — a ``bra`` to a label at/before it = a loop."""
+    loops = []
+    for i, inst in enumerate(insts):
+        if inst.opcode == "bra":
+            for o in inst.operands:
+                name = getattr(o, "name", None) or getattr(o, "text", None)
+                j = label_at.get(name)
+                if j is not None and j <= i:
+                    loops.append((j, i))
+    return loops
+
+
+def _innermost_loop(idx, loops):
+    """The smallest loop range (header, latch) containing ``idx``, or None."""
+    best = None
+    for lp in loops:
+        if lp[0] <= idx <= lp[1] and (best is None or (lp[1] - lp[0]) < (best[1] - best[0])):
+            best = lp
+    return best
+
+
+def _loop_accumulates(insts, loop, loops):
+    """True iff the loop's OWN body (its range MINUS nested loops) carries a floating-point
+    accumulation: an MMA, or an fp combine whose destination is also one of its sources (a
+    loop-carried running total). This is what separates a K-reduction loop (its chunk size is
+    bit-relevant) from an output-tiling / parallelization loop (each iteration is an independent
+    output; its step is bit-free). Conservative direction is 'accumulates' -> keep."""
+    h, latch = loop
+    for k in range(h, latch + 1):
+        if _innermost_loop(k, loops) != loop:  # this instruction belongs to a NESTED loop
+            continue
+        inst = insts[k]
+        if _is_mma(inst):
+            return True
+        if inst.opcode in _FP_COMBINE and inst.modifiers and inst.modifiers[-1] in _FP_WIDTHS and inst.operands:
+            dname = getattr(inst.operands[0], "name", None)
+            if dname and any(getattr(s, "name", None) == dname for s in inst.operands[1:]):
+                return True
+    return False
 
 
 def _loop_steps(func):
-    """Sorted multiset of loop-induction SELF-INCREMENT constants: every ``add R, R, IMM``
-    where dst==src0 is a loop counter stepped by a compile-time constant (for a chunked
-    reduction this is exactly BLOCK_N — the cross-chunk column stride). This is a LAYOUT-/
-    num_warps-INVARIANT, BLOCK_N-FAITHFUL fence: the reconstruction cannot follow the loop
-    back-edge, so a collapsed per-chunk reduction loses the chunk SIZE; folding the loop step
-    into the entry signature restores it. Adding it can only SPLIT classes further (it is extra
-    distinguishing info), so it is monotonically sound — it never causes an over-merge."""
+    """Sorted multiset of loop-induction SELF-INCREMENT constants (``add R, R, IMM``, dst==src0),
+    but ONLY for loops that carry a floating-point ACCUMULATION. A self-increment inside an
+    output-tiling / parallelization loop (no loop-carried fp total in its own body) is bit-free and
+    dropped — so the fence stops over-splitting on BLOCK_M / num_warps — while the reduction chunk
+    step (BLOCK_N for a chunked reduction, BLOCK_K for a GEMM K-loop) is kept.
+
+    Sound / monotone: a step is DROPPED only when its self-increment sits inside a DETECTED loop
+    that provably does not accumulate. If no loop is recovered around a self-increment (loops
+    unrolled, or structure not recovered), the step is KEPT — so this can only reduce over-split,
+    never introduce an over-merge (dropping a bit-relevant chunk step)."""
+    insts, label_at = _instrs_and_labels(func)
+    loops = _back_edges(insts, label_at)
+    accumulates = {lp: _loop_accumulates(insts, lp, loops) for lp in set(loops)}
     steps = []
-    for inst in linearize(func):
+    for i, inst in enumerate(insts):
         if inst.opcode == "add" and len(inst.operands) == 3:
             d, a, b = inst.operands
             if (isinstance(d, RegisterOperand) and isinstance(a, RegisterOperand) and d.name == a.name
@@ -75,8 +151,12 @@ def _loop_steps(func):
                     v = int(b.text, 0)
                 except (ValueError, TypeError):
                     continue
-                if v != 0:
-                    steps.append(v)
+                if v == 0:
+                    continue
+                lp = _innermost_loop(i, loops)
+                if lp is not None and not accumulates[lp]:
+                    continue  # self-increment in a non-accumulating (tiling / parallel) loop -> drop
+                steps.append(v)
     return tuple(sorted(steps))
 
 


### PR DESCRIPTION
Summary:

Fixes the biggest GEMM over-split source. `_loop_steps` used to fold EVERY `add R, R, IMM` self-increment (every loop counter) into the fence, but only a loop that carries a floating-point ACCUMULATION is bit-relevant: its chunk size changes the reduction order. An output-tiling loop (BLOCK_M) or a parallelization stride (num_warps) computes independent outputs with no loop-carried FP value, so its step is bit-free and pollutes the fence.

`_loop_steps` now recovers the loop structure (back-edges via labels in `func.body`) and keeps a self-increment's step ONLY if its innermost loop's own body (its range minus nested loops) carries an FP accumulation — an MMA, or an fp combine whose destination is one of its sources (a running total). It is monotone/sound: a step is dropped ONLY when it sits inside a detected loop that provably does not accumulate; if no loop is recovered around it, the step is KEPT, so this can only reduce over-split, never introduce an over-merge (dropping a bit-relevant chunk step). Reductions are unchanged (their accumulation chunk step, e.g. BLOCK_N=4096 for the persistent reduction, is still kept).

Measured on the gemm_all combined-knob spec (heavy config, 832 runnable configs @ 2048^3, R=30 fuzzer): total over-merges = 0 (refines True), and the dominant tf32/tcgen05 path is fully recovered — its largest equivalence class went from 64 to 304 = the empirical ceiling (num_warps + BLOCK_M/N + BLOCK_K + num_stages + fp_fusion all merge). Overall checker classes 100 -> 78. The residual over-split is in the higher-precision paths (tf32x3 3-pass emulation and ieee scalar-fma f32), which use different codegen and are a separate follow-up.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D112943405


