### PR TITLE
[triton][bitequiv] Unified model Step 1: Mma + LoopReduce treeir nodes + collapse guards (#2379)

### DIFF
--- a/bitequiv/evaluation/eval_kernels.py
+++ b/bitequiv/evaluation/eval_kernels.py
@@ -665,6 +665,24 @@ def _gemm_num_warps_filter(config):
     return config.num_warps in (4, 8)
 
 
+def _gemm_all_filter(config):
+    """num_warps filter PLUS a Blackwell TMEM (512-column) guard for the combined gemm_all
+    cross-product: the accumulator (block_m x block_n) plus the K-pipeline (block_k x num_stages)
+    can overflow tensor memory, and unlike a compile error a run/launch OOM is NOT caught by
+    evaluate_precision. The dropped boundary (block_k=64 with num_stages>=3; the 256-wide accumulator
+    with num_stages>=5) is calibrated for this spec's default precision_size (256^3), where it leaves
+    0 launch-OOM. NOTE: TMEM use is TENSOR-dependent -- a large K runs the full num_stages pipeline
+    (short K-loops collapse it), so at a much bigger tensor some surviving configs still OOM; a driver
+    that overrides the tensor size must skip run-OOM configs itself (this filter cannot see the size)."""
+    if not _gemm_num_warps_filter(config):
+        return False
+    if config.gemm_block_k == 64 and (config.num_stages or 1) >= 3:
+        return False
+    if config.gemm_block_n == 256 and (config.num_stages or 1) >= 5:
+        return False
+    return True
+
+
 def _gemm_blocks(config, default_bk):
     """Resolve the tile from the config, defaulting axes the spec does not sweep."""
     bm = config.gemm_block_m if config.gemm_block_m is not None else 128
@@ -996,6 +1014,25 @@ REGISTRY = {
         compile_fn=_gemm_tma_store_compile,
         run_fn=_gemm_tma_store_run,
         config_filter=_gemm_num_warps_filter,
+    ),
+    "gemm_all":
+    KernelSpec(
+        name="gemm_all",
+        description=("f32 GEMM varying ALL co-existing knobs together (M/N/K tiling x input_precision x "
+                     "enable_fp_fusion x num_warps x num_stages) -- the real autotuner cross-product, to "
+                     "stress the MMA fence with cross-knob interactions. The per-knob GEMM specs above "
+                     "isolate one knob each for clean attribution; this crosses them (~1300 configs at heavy). "
+                     "fp8 stays a separate spec (a distinct dtype path that cannot co-vary with input_precision)."),
+        output_arity=1,
+        axes=("enable_fp_fusion", "num_warps", "num_stages", "gemm_block_m", "gemm_block_n", "gemm_block_k",
+              "input_precision"),
+        precision_size=(256, 256, 256),
+        perf_size=(256, 256, 256),
+        known_limitation="",
+        compile_fn=_gemm_prec_compile,
+        run_fn=_gemm_prec_run,
+        config_filter=_gemm_all_filter,
+        axis_values={"gemm_block_k": (16, 32, 64), "enable_fp_fusion": (True, False)},
     ),
 }
 

--- a/bitequiv/ptx/builder.py
+++ b/bitequiv/ptx/builder.py
@@ -18,7 +18,8 @@ from pyptx.ir.nodes import RegisterOperand, VectorOperand
 from bitequiv.ptx.affine import AffineEval, canon, reqntid_of
 from bitequiv.ptx.leaves import leaf_coord, leaf_columns
 from bitequiv.ptx.linker import Def, DefUse
-from bitequiv.ptx.treeir import FpOp, ITreeReduce, Leaf, OpaqueLeaf, OpaqueOp, ShflCombine, SmemExchange
+from bitequiv.ptx.treeir import (FpOp, ITreeReduce, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp,
+                                 ShflCombine, SmemExchange)
 
 _FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f64", ".bf16", ".bf16x2"})
 _FP_KINDS = frozenset({"add", "sub", "mul", "div", "min", "max"})
@@ -320,8 +321,8 @@ def _leaf_layout_invariant(node):
     and a single product mul(L,L) / fma(L,L;const) while refusing anything whose value could
     depend on the thread/lane layout."""
     for n in _postorder(node):
-        if isinstance(n, (ShflCombine, SmemExchange)):
-            return False
+        if isinstance(n, (ShflCombine, SmemExchange, Mma, LoopReduce)):
+            return False  # cross-thread / opaque-chunk / loop-fold node: not a per-element leaf
         if isinstance(n, OpaqueLeaf):
             return False
         if isinstance(n, OpaqueOp) and not _tok_is_pure(n.token):
@@ -406,6 +407,10 @@ def _rebuild(n, kids):
         return ShflCombine(n.offset, n.kind, n.mods, kids[0])
     if isinstance(n, SmemExchange):
         return SmemExchange(kids[0])
+    if isinstance(n, Mma):
+        return Mma(n.token, n.flags, tuple(kids))
+    if isinstance(n, LoopReduce):
+        return LoopReduce(n.op, kids[0], n.key)
     return n
 
 

--- a/bitequiv/ptx/treeir.py
+++ b/bitequiv/ptx/treeir.py
@@ -187,3 +187,53 @@ class SmemExchange:
 
     def sig(self):
         return self.sig_local([self.child.sig()])
+
+
+@dataclass(frozen=True)
+class Mma:
+    """A tensor-core matmul chunk (wgmma / mma.sync / wmma / tcgen05). Its internal accumulation is
+    hardware-opaque, so it is NOT a reconstructable per-element tree — it is a tiling-invariant fence
+    ``token`` (K + operand/acc dtypes + kind, from :mod:`bitequiv.ptx.mma`) + ``flags`` (scale /
+    accumulate immediates) + its register-operand ``children`` (so a reduction OVER mma outputs
+    composes in the same DAG). NOT a layout-invariant per-element value: a reduction covering an Mma
+    must not collapse it as a uniform leaf (see :func:`bitequiv.ptx.builder._leaf_layout_invariant`)."""
+
+    token: str
+    flags: tuple = ()
+    children: tuple = ()
+
+    def sig_local(self, child_sigs):
+        f = ";fl=" + ",".join(self.flags) if self.flags else ""
+        body = "(" + ",".join(child_sigs) + ")" if child_sigs else ""
+        return f"MMA[{self.token}{f}]{body}"
+
+    def sig(self):
+        return self.sig_local([c.sig() for c in self.children])
+
+
+@dataclass(frozen=True)
+class LoopReduce:
+    """A loop-carried floating-point accumulation (a fold over chunks), summarized WITHOUT unrolling:
+    a GEMM's K-reduction, or a chunked / persistent reduction. ``chunk`` is the value-DAG of ONE
+    iteration's contribution (the accumulator input removed); ``op`` is the fold op (+ modifiers).
+    ``key`` sets the chunk sensitivity:
+
+    * chunk-BEARING ``(step, trip)`` — a different chunk size (BLOCK_K / BLOCK_N) gives a different
+      key -> split. Default; sound whenever re-chunking could change the accumulation order.
+    * chunk-INVARIANT ``()`` — chunk size dropped -> different chunk sizes MERGE. Only when the
+      accumulation is provably order-invariant (e.g. a tensor-core f32 accumulator), gated hard by
+      the empirical fuzzer."""
+
+    op: str
+    chunk: object
+    key: tuple = ()
+
+    @property
+    def children(self):
+        return (self.chunk, )
+
+    def sig_local(self, child_sigs):
+        return f"LOOP[{self.op};{child_sigs[0]};{self.key}]"
+
+    def sig(self):
+        return self.sig_local([self.chunk.sig()])

--- a/bitequiv/ptx_reduction.py
+++ b/bitequiv/ptx_reduction.py
@@ -48,25 +48,101 @@ different launch geometries or un-modeled accumulations never collapse to an emp
 contract/reorder. PTX is the practical check, not absolute ground truth (SASS via
 ``cuobjdump`` would be); ``--fmad=false`` pins the fusion decision. See ``design-doc.md``.
 """
-from pyptx.ir.nodes import Function, ImmediateOperand, RegisterOperand
+from pyptx.ir.nodes import Block, Function, ImmediateOperand, Label, RegisterOperand
 from pyptx.parser import parse
 from pyptx.parser.parser import ParseError
 
 from bitequiv.ptx.affine import reqntid_of
 from bitequiv.ptx.builder import entry_signatures
 from bitequiv.ptx.linker import linearize
+from bitequiv.ptx.mma import _is_mma
+
+# fp combine ops + widths, used to detect a loop-carried floating-point accumulation.
+_FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f32x2", ".f64", ".bf16", ".bf16x2"})
+_FP_COMBINE = frozenset({"add", "sub", "mul", "div", "min", "max", "fma"})
+
+
+def _instrs_and_labels(func):
+    """Linearized instructions (recursing into ``Block`` scopes, like :func:`linearize`) PLUS a map
+    ``label name -> index of the instruction at/after that label``. ``linearize`` drops labels; we
+    need their positions to find loop back-edges."""
+    insts, label_at, pending = [], {}, []
+
+    def walk(stmts):
+        for s in stmts:
+            if isinstance(s, Block):
+                walk(s.body)
+            elif isinstance(s, Label):
+                pending.append(s.name)
+            elif type(s).__name__ == "Instruction":
+                while pending:
+                    label_at[pending.pop()] = len(insts)
+                insts.append(s)
+
+    walk(func.body)
+    for name in pending:  # a trailing label points just past the last instruction
+        label_at[name] = len(insts)
+    return insts, label_at
+
+
+def _back_edges(insts, label_at):
+    """(header_idx, latch_idx) for each backward branch — a ``bra`` to a label at/before it = a loop."""
+    loops = []
+    for i, inst in enumerate(insts):
+        if inst.opcode == "bra":
+            for o in inst.operands:
+                name = getattr(o, "name", None) or getattr(o, "text", None)
+                j = label_at.get(name)
+                if j is not None and j <= i:
+                    loops.append((j, i))
+    return loops
+
+
+def _innermost_loop(idx, loops):
+    """The smallest loop range (header, latch) containing ``idx``, or None."""
+    best = None
+    for lp in loops:
+        if lp[0] <= idx <= lp[1] and (best is None or (lp[1] - lp[0]) < (best[1] - best[0])):
+            best = lp
+    return best
+
+
+def _loop_accumulates(insts, loop, loops):
+    """True iff the loop's OWN body (its range MINUS nested loops) carries a floating-point
+    accumulation: an MMA, or an fp combine whose destination is also one of its sources (a
+    loop-carried running total). This is what separates a K-reduction loop (its chunk size is
+    bit-relevant) from an output-tiling / parallelization loop (each iteration is an independent
+    output; its step is bit-free). Conservative direction is 'accumulates' -> keep."""
+    h, latch = loop
+    for k in range(h, latch + 1):
+        if _innermost_loop(k, loops) != loop:  # this instruction belongs to a NESTED loop
+            continue
+        inst = insts[k]
+        if _is_mma(inst):
+            return True
+        if inst.opcode in _FP_COMBINE and inst.modifiers and inst.modifiers[-1] in _FP_WIDTHS and inst.operands:
+            dname = getattr(inst.operands[0], "name", None)
+            if dname and any(getattr(s, "name", None) == dname for s in inst.operands[1:]):
+                return True
+    return False
 
 
 def _loop_steps(func):
-    """Sorted multiset of loop-induction SELF-INCREMENT constants: every ``add R, R, IMM``
-    where dst==src0 is a loop counter stepped by a compile-time constant (for a chunked
-    reduction this is exactly BLOCK_N — the cross-chunk column stride). This is a LAYOUT-/
-    num_warps-INVARIANT, BLOCK_N-FAITHFUL fence: the reconstruction cannot follow the loop
-    back-edge, so a collapsed per-chunk reduction loses the chunk SIZE; folding the loop step
-    into the entry signature restores it. Adding it can only SPLIT classes further (it is extra
-    distinguishing info), so it is monotonically sound — it never causes an over-merge."""
+    """Sorted multiset of loop-induction SELF-INCREMENT constants (``add R, R, IMM``, dst==src0),
+    but ONLY for loops that carry a floating-point ACCUMULATION. A self-increment inside an
+    output-tiling / parallelization loop (no loop-carried fp total in its own body) is bit-free and
+    dropped — so the fence stops over-splitting on BLOCK_M / num_warps — while the reduction chunk
+    step (BLOCK_N for a chunked reduction, BLOCK_K for a GEMM K-loop) is kept.
+
+    Sound / monotone: a step is DROPPED only when its self-increment sits inside a DETECTED loop
+    that provably does not accumulate. If no loop is recovered around a self-increment (loops
+    unrolled, or structure not recovered), the step is KEPT — so this can only reduce over-split,
+    never introduce an over-merge (dropping a bit-relevant chunk step)."""
+    insts, label_at = _instrs_and_labels(func)
+    loops = _back_edges(insts, label_at)
+    accumulates = {lp: _loop_accumulates(insts, lp, loops) for lp in set(loops)}
     steps = []
-    for inst in linearize(func):
+    for i, inst in enumerate(insts):
         if inst.opcode == "add" and len(inst.operands) == 3:
             d, a, b = inst.operands
             if (isinstance(d, RegisterOperand) and isinstance(a, RegisterOperand) and d.name == a.name
@@ -75,8 +151,12 @@ def _loop_steps(func):
                     v = int(b.text, 0)
                 except (ValueError, TypeError):
                     continue
-                if v != 0:
-                    steps.append(v)
+                if v == 0:
+                    continue
+                lp = _innermost_loop(i, loops)
+                if lp is not None and not accumulates[lp]:
+                    continue  # self-increment in a non-accumulating (tiling / parallel) loop -> drop
+                steps.append(v)
     return tuple(sorted(steps))
 
 

--- a/bitequiv/tests/test_ptx_unified.py
+++ b/bitequiv/tests/test_ptx_unified.py
@@ -1,0 +1,64 @@
+"""Unified per-element model — Step 1: Mma + LoopReduce nodes + builder guards. CPU-only."""
+from bitequiv.ptx.builder import collapse_balanced, tree_hash
+from bitequiv.ptx.treeir import FpOp, ITreeReduce, Leaf, LoopReduce, Mma
+
+
+def _leaf(i):
+    return Leaf(f"c{i}", frozenset({i}))
+
+
+# -- Mma node -----------------------------------------------------------------
+
+
+def test_mma_sig_and_hash():
+    a = Mma("wgmma|k16|.f32,.f16,.f16", (), (_leaf(0), _leaf(1)))
+    b = Mma("wgmma|k16|.f32,.f16,.f16", (), (_leaf(0), _leaf(1)))
+    assert a.sig().startswith("MMA[wgmma|k16")
+    assert tree_hash(a) == tree_hash(b)                       # same token + children -> same hash
+    assert tree_hash(a) != tree_hash(Mma("wgmma|k32|.f32,.f16,.f16", (), (_leaf(0), _leaf(1))))  # K split
+
+
+def test_mma_flags_split():
+    assert tree_hash(Mma("t", ("1",), (_leaf(0),))) != tree_hash(Mma("t", ("-1",), (_leaf(0),)))
+
+
+# -- LoopReduce node ----------------------------------------------------------
+
+
+def _chunk():
+    return FpOp("mul", (".f32", ), (_leaf(0), _leaf(1)))
+
+
+def test_loopreduce_chunk_bearing_splits_step():
+    a = LoopReduce("add.f32", _chunk(), (16, 64))
+    b = LoopReduce("add.f32", _chunk(), (32, 32))
+    assert tree_hash(a) != tree_hash(b)                       # chunk-bearing: different step -> split
+
+
+def test_loopreduce_chunk_invariant_merges_step():
+    a = LoopReduce("add.f32", _chunk(), ())                   # chunk-invariant (key dropped)
+    b = LoopReduce("add.f32", _chunk(), ())
+    assert tree_hash(a) == tree_hash(b)
+    assert tree_hash(a) != tree_hash(LoopReduce("add.f32", _chunk(), (16, 64)))  # invariant != bearing
+
+
+# -- builder guards: a reduction over Mma / LoopReduce must NOT collapse -------
+
+
+def test_reduction_over_mma_does_not_collapse():
+    t = FpOp("add", (".f32", ), (Mma("wgmma|k16|.f32", (), (_leaf(0), )),
+                                 Mma("wgmma|k16|.f32", (), (_leaf(1), ))))
+    assert not isinstance(collapse_balanced(t), ITreeReduce)  # Mma not layout-invariant -> no collapse
+
+
+def test_reduction_over_loopreduce_does_not_collapse():
+    lr0 = LoopReduce("add.f32", FpOp("mul", (".f32", ), (_leaf(0), _leaf(0))), (16, 64))
+    lr1 = LoopReduce("add.f32", FpOp("mul", (".f32", ), (_leaf(1), _leaf(1))), (16, 64))
+    assert not isinstance(collapse_balanced(FpOp("add", (".f32", ), (lr0, lr1))), ITreeReduce)
+
+
+def test_loopreduce_root_survives_collapse():
+    # single output = one LoopReduce -> collapse_balanced returns it unchanged (it IS the per-element sig)
+    lr = LoopReduce("add.f32", Mma("tcgen05|.kind::f16", (), (_leaf(0), )), ())
+    c = collapse_balanced(lr)
+    assert isinstance(c, LoopReduce) and c.sig() == lr.sig()


### PR DESCRIPTION
Summary:

First step of the unified per-element reconstruction model (GEMM-to-the-extreme + loop modeling). Adds two treeir nodes and their collapse guards; no reconstruction wiring yet (later steps).

`Mma(token, flags, children)` — a tensor-core matmul chunk (wgmma / mma.sync / wmma / tcgen05). Its internal accumulation is hardware-opaque, so it is a tiling-invariant fence token (from `bitequiv/ptx/mma.py`) + scale/accumulate flags + its register-operand children (so a reduction over MMA outputs composes in one DAG).

`LoopReduce(op, chunk, key)` — a loop-carried FP accumulation (a GEMM K-reduction, or a chunked/persistent reduction) summarized WITHOUT unrolling. `chunk` is one iteration's contribution; `key` sets chunk sensitivity: chunk-bearing `(step, trip)` splits by chunk size (default, sound), chunk-invariant `()` merges chunk sizes (only when the accumulation is provably order-invariant, gated by the fuzzer later).

Both are guarded in `builder._leaf_layout_invariant` (return False) so a reduction covering an Mma / LoopReduce never collapses it as a per-element leaf (no over-merge), and handled in `_rebuild` so `collapse_balanced` reconstructs them. A single-output LoopReduce root survives collapse unchanged (it IS the per-element signature).

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D112991064


