### PR TITLE
[TLX] Disable generic software pipelining

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -16,6 +16,8 @@ namespace triton {
 
 static const char *kLoopStageAttrName = "loop.stage";
 static const char *kLoopClusterAttrName = "loop.cluster";
+static const char *kSkipGenericPipelineAttrName =
+    "triton.skip_generic_pipeline";
 class CoarseSchedule;
 class ModuleAxisInfoAnalysis;
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -189,6 +189,9 @@ struct PipelinePass : public impl::TritonGPUPipelineBase<PipelinePass> {
 
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
+    if (moduleOp->hasAttr(kSkipGenericPipelineAttrName))
+      return;
+
     // Transform the loop by introducing async operations to prepare it for
     // pipeline expansion.
     lowerLoops(moduleOp);

--- a/test/TLX/attach-metadata.mlir
+++ b/test/TLX/attach-metadata.mlir
@@ -2,6 +2,7 @@
 // RUN: triton-opt -split-input-file -pass-pipeline='builtin.module(triton-tlx-fixup{num-warps=8 target=cuda:90 num-ctas=1 threads-per-warp=32})' %s| FileCheck %s
 
 // CHECK: module attributes {
+// CHECK-SAME: "triton.skip_generic_pipeline"
 // CHECK-SAME: tlx.has_tlx_ops = true
 // CHECK-SAME: "ttg.num-ctas" = 1
 // CHECK-SAME: "ttg.num-warps" = 8
@@ -29,6 +30,7 @@ module {
 // -----
 
 // CHECK: module {
+// CHECK-NOT: triton.skip_generic_pipeline
 // CHECK-NOT: tlx.has_explicit_local_mem_access
 // CHECK-NOT: tlx.has_tlx_ops
 // CHECK-NOT: "ttg.num-ctas"
@@ -52,6 +54,7 @@ module {
 // -----
 
 // CHECK: module attributes {
+// CHECK-SAME: "triton.skip_generic_pipeline"
 // CHECK-SAME: tlx.has_explicit_local_mem_access = true
 // CHECK-NOT: tlx.has_tlx_ops
 // CHECK-SAME: "ttg.num-ctas" = 1
@@ -116,6 +119,7 @@ module {
 // -----
 
 // CHECK: module attributes {
+// CHECK-SAME: "triton.skip_generic_pipeline"
 // CHECK-SAME: tlx.has_warp_spec_ops = true
 // CHECK-NOT: tlx.has_explicit_local_mem_access
 // CHECK-NOT: tlx.has_tlx_ops

--- a/test/TLX/attach-metadata.mlir
+++ b/test/TLX/attach-metadata.mlir
@@ -2,12 +2,12 @@
 // RUN: triton-opt -split-input-file -pass-pipeline='builtin.module(triton-tlx-fixup{num-warps=8 target=cuda:90 num-ctas=1 threads-per-warp=32})' %s| FileCheck %s
 
 // CHECK: module attributes {
-// CHECK-SAME: "triton.skip_generic_pipeline"
-// CHECK-SAME: tlx.has_tlx_ops = true
-// CHECK-SAME: "ttg.num-ctas" = 1
-// CHECK-SAME: "ttg.num-warps" = 8
-// CHECK-SAME: ttg.target = "cuda:90"
-// CHECK-SAME: "ttg.threads-per-warp" = 32
+// CHECK-DAG: triton.skip_generic_pipeline
+// CHECK-DAG: tlx.has_tlx_ops = true
+// CHECK-DAG: "ttg.num-ctas" = 1
+// CHECK-DAG: "ttg.num-warps" = 8
+// CHECK-DAG: ttg.target = "cuda:90"
+// CHECK-DAG: "ttg.threads-per-warp" = 32
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [0, 1]}>
 module {
     tt.func @kernel_tlx(%arg0: tensor<256x!tt.ptr<f32>>, %arg1: i32) {
@@ -54,13 +54,13 @@ module {
 // -----
 
 // CHECK: module attributes {
-// CHECK-SAME: "triton.skip_generic_pipeline"
-// CHECK-SAME: tlx.has_explicit_local_mem_access = true
+// CHECK-DAG: triton.skip_generic_pipeline
+// CHECK-DAG: tlx.has_explicit_local_mem_access = true
+// CHECK-DAG: "ttg.num-ctas" = 1
+// CHECK-DAG: "ttg.num-warps" = 8
+// CHECK-DAG: ttg.target = "cuda:90"
+// CHECK-DAG: "ttg.threads-per-warp" = 32
 // CHECK-NOT: tlx.has_tlx_ops
-// CHECK-SAME: "ttg.num-ctas" = 1
-// CHECK-SAME: "ttg.num-warps" = 8
-// CHECK-SAME: ttg.target = "cuda:90"
-// CHECK-SAME: "ttg.threads-per-warp" = 32
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module {
@@ -119,8 +119,8 @@ module {
 // -----
 
 // CHECK: module attributes {
-// CHECK-SAME: "triton.skip_generic_pipeline"
-// CHECK-SAME: tlx.has_warp_spec_ops = true
+// CHECK-DAG: triton.skip_generic_pipeline
+// CHECK-DAG: tlx.has_warp_spec_ops = true
 // CHECK-NOT: tlx.has_explicit_local_mem_access
 // CHECK-NOT: tlx.has_tlx_ops
 module attributes {tlx.has_warp_spec_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {

--- a/test/TritonGPU/amd/pipeline-skip-generic.mlir
+++ b/test/TritonGPU/amd/pipeline-skip-generic.mlir
@@ -19,7 +19,7 @@ module attributes {
       // CHECK: scf.yield %[[SUM]] : f32
       scf.yield %sum : f32
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32}
-    // CHECK-NEXT: tt.return %[[RESULT]] : f32
+    // CHECK: tt.return %[[RESULT]] : f32
     tt.return %result : f32
   }
 }

--- a/test/TritonGPU/amd/pipeline-skip-generic.mlir
+++ b/test/TritonGPU/amd/pipeline-skip-generic.mlir
@@ -1,0 +1,25 @@
+// RUN: triton-opt %s -tritonamdgpu-pipeline | FileCheck %s
+
+module attributes {
+  "triton.skip_generic_pipeline",
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  "ttg.target" = "hip:gfx942",
+  "ttg.threads-per-warp" = 64 : i32
+} {
+  // CHECK-LABEL: tt.func @skip_generic_pipeline
+  tt.func @skip_generic_pipeline(%lb: index, %ub: index, %step: index, %ptr: !tt.ptr<f32>, %init: f32) -> f32 {
+    // CHECK-NEXT: %[[RESULT:.*]] = scf.for
+    // CHECK-SAME: iter_args
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %init) -> f32 {
+      // CHECK: %[[LOAD:.*]] = tt.load %{{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+      %value = tt.load %ptr {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.ptr<f32>
+      // CHECK: %[[SUM:.*]] = arith.addf %[[LOAD]], %{{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+      %sum = arith.addf %value, %acc {loop.cluster = 0 : i32, loop.stage = 1 : i32} : f32
+      // CHECK: scf.yield %[[SUM]] : f32
+      scf.yield %sum : f32
+    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32}
+    // CHECK-NEXT: tt.return %[[RESULT]] : f32
+    tt.return %result : f32
+  }
+}

--- a/test/TritonGPU/pipeline-skip-generic.mlir
+++ b/test/TritonGPU/pipeline-skip-generic.mlir
@@ -19,7 +19,7 @@ module attributes {
       // CHECK: scf.yield %[[SUM]] : f32
       scf.yield %sum : f32
     } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32}
-    // CHECK-NEXT: tt.return %[[RESULT]] : f32
+    // CHECK: tt.return %[[RESULT]] : f32
     tt.return %result : f32
   }
 }

--- a/test/TritonGPU/pipeline-skip-generic.mlir
+++ b/test/TritonGPU/pipeline-skip-generic.mlir
@@ -1,0 +1,25 @@
+// RUN: triton-opt %s -tritongpu-pipeline | FileCheck %s
+
+module attributes {
+  "triton.skip_generic_pipeline",
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  "ttg.target" = "cuda:90",
+  "ttg.threads-per-warp" = 32 : i32
+} {
+  // CHECK-LABEL: tt.func @skip_generic_pipeline
+  tt.func @skip_generic_pipeline(%lb: index, %ub: index, %step: index, %ptr: !tt.ptr<f32>, %init: f32) -> f32 {
+    // CHECK-NEXT: %[[RESULT:.*]] = scf.for
+    // CHECK-SAME: iter_args
+    %result = scf.for %iv = %lb to %ub step %step iter_args(%acc = %init) -> f32 {
+      // CHECK: %[[LOAD:.*]] = tt.load %{{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+      %value = tt.load %ptr {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.ptr<f32>
+      // CHECK: %[[SUM:.*]] = arith.addf %[[LOAD]], %{{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+      %sum = arith.addf %value, %acc {loop.cluster = 0 : i32, loop.stage = 1 : i32} : f32
+      // CHECK: scf.yield %[[SUM]] : f32
+      scf.yield %sum : f32
+    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32}
+    // CHECK-NEXT: tt.return %[[RESULT]] : f32
+    tt.return %result : f32
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
@@ -188,6 +188,9 @@ struct PipelinePass : impl::TritonAMDGPUPipelineBase<PipelinePass> {
 
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
+    if (moduleOp->hasAttr(tt::kSkipGenericPipelineAttrName))
+      return;
+
     lowerLoops(moduleOp, useAsyncCopy, usePingpong);
     expandLoops(moduleOp);
 

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -13,6 +13,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "llvm/Support/LogicalResult.h"
 
@@ -608,6 +609,7 @@ public:
 
     // Attach metadata to the module.
     Builder b(&getContext());
+    mod->setAttr(kSkipGenericPipelineAttrName, b.getUnitAttr());
     mod->setAttr(ttg::AttrNumWarpsName, b.getI32IntegerAttr(numWarps));
     mod->setAttr(ttg::AttrNumThreadsPerWarp,
                  b.getI32IntegerAttr(threadsPerWarp));


### PR DESCRIPTION
Mark TLX modules during fixup and make the NVIDIA and AMD generic software pipeline passes no-op for those modules. Explicit TLX async operations and warp pipelining remain unchanged.
