### PR TITLE
[triton][bitequiv] Loop-chunk soundness: fail-close a leaf-less reduction to the load-shape residual (#2382)

### DIFF
--- a/bitequiv/ptx/builder.py
+++ b/bitequiv/ptx/builder.py
@@ -32,6 +32,35 @@ _FP_KINDS = frozenset({"add", "sub", "mul", "div", "min", "max"})
 # reductions are rare + carry an fma-contraction ambiguity).
 _REDUCE_FP = frozenset({"add", "min", "max"})
 
+# Reduce ops whose result is bit-identical for ANY tree shape / association order — they select an
+# input verbatim and NEVER round (unlike add/mul). So a min/max reduction over one element SET is
+# bit-identical regardless of layout (num_warps) or a balanced-vs-left-fold shape. This is what lets
+# the EXTENT-FREE collapse merge a min/max LEFT-FOLD across num_warps (col_max), keyed on the reduced
+# column SET alone. (NaN rides as "missing" in PTX min/max -> the reduction is the min/max of the
+# non-NaN inputs, still order-invariant; the empirical fuzzer is the backstop.)
+_ORDER_INVARIANT_OPS = frozenset({"min", "max"})
+
+# Canonical, num_warps-INVARIANT extent key for a COMPLETE cross-thread min/max reduction (see the
+# min/max branch of `collapse_balanced`). A cross-warp min/max read resolves to one representative
+# partial, so the reconstructed column SET covers only one warp's slice -> num_warps-VARYING even
+# though the TRUE reduced multiset is config-invariant. min/max is order- AND shape-invariant, so its
+# result is fixed by that multiset alone, and every autotuner knob preserves it -> a complete
+# cross-thread min/max reduction is bit-identical across all of a kernel's configs. Keying such a
+# region on this constant (dropping the varying residual) recovers the num_warps freedom soundly.
+_ORDER_INVARIANT_COLS = "oi"
+
+
+def _reduce_op(node):
+    """Reduce-op token (kind + modifiers) of a reduce node — an ``FpOp`` or a ``ShflCombine`` — or
+    ``None`` for a ``SmemExchange`` (a phase marker with no op of its own; its op comes from its
+    child). Unlike the old FpOp-only detection this also reads a ``ShflCombine``'s op, so a PURE
+    cross-thread butterfly (1 element/thread, no within-thread fold) has a recoverable reduce op."""
+    if isinstance(node, FpOp):
+        return node.kind + "".join(node.mods)
+    if isinstance(node, ShflCombine):
+        return node.kind + "".join(node.mods)
+    return None
+
 
 def _is_fp(inst):
     return bool(inst.modifiers) and inst.modifiers[-1] in _FP_WIDTHS
@@ -278,13 +307,16 @@ def _balance_pass(root):
         if _is_reduce_node(n):
             kids = list(n.children)
             ops = {optok[id(c)] for c in kids if optok[id(c)] is not None}
-            if isinstance(n, FpOp):
-                ops.add(n.kind + "".join(n.mods))
+            self_op = _reduce_op(n)  # FpOp OR ShflCombine op (None for SmemExchange)
+            if self_op is not None:
+                ops.add(self_op)
             op = next(iter(ops)) if len(ops) == 1 else None  # single consistent op, else None (never empty-iter)
             kids_bal = all(bal[id(c)] for c in kids)
-            if isinstance(n, FpOp):
+            if isinstance(n, FpOp) and n.kind not in _ORDER_INVARIANT_OPS:
+                # add (etc): the SHAPE matters (rounding) -> require the AVL balance property, so an
+                # unordered left-fold stays uncollapsed (num_warps-bearing).
                 bal[id(n)] = kids_bal and op is not None and abs(ht[id(kids[0])] - ht[id(kids[1])]) <= 1
-            else:  # shfl / smem: 1-ary cross-thread step; balance carried from its child
+            else:  # min/max FpOp (shape-invariant), or a 1-ary shfl/smem step: no AVL check needed
                 bal[id(n)] = kids_bal and op is not None
             ht[id(n)] = max((ht[id(c)] for c in kids), default=0) + 1
             optok[id(n)] = op
@@ -348,32 +380,32 @@ def _shfl_dir(node, ht):
     return tuple(sorted({off for h, off in shfls if h == lo}))
 
 
-def _single_element(node):
-    """True iff every ``Leaf`` under a boundary subtree reads the SAME element (identical coord) —
-    i.e. the boundary is a per-element function ``f(x_i)`` (``exp(L)``, ``mul(L,L)`` of one element,
-    a bare ``L``). Then the multiset ``{f(x_i)}`` is layout-invariant, so a balanced reduction over
-    it is bit-identical at any layout and MAY collapse. A boundary combining DISTINCT elements
-    (``mul(L_i, L_j)``, i != j) is layout-invariant only if the PAIRING is data-fixed, which the
-    coord-blanking ``_coordfree_sig`` cannot prove — so refuse it (sound; stays over-split)."""
-    coords = {n.coord for n in _postorder(node) if isinstance(n, Leaf)}
-    return len(coords) == 1
-
-
 def _collapse_info(node):
-    """(reduce_op_token, uniform_coord_free_leaf_sig) for a balanced reduction, or None if it
-    cannot be SOUNDLY collapsed. The BOUNDARY leaves are the non-reduce CHILDREN of reduce nodes
-    (NOT every non-reduce postorder node — collecting the latter double-counts a boundary's own
-    internal nodes, e.g. it sees both ``cvt(L)`` and its child ``L`` -> two coord-free sigs -> a
-    spurious bail; that is why the baseline never collapsed cvt/exp/mul-fed reductions). Guards: a
-    single consistent reduce op; >= 2 boundary leaves; every boundary is layout-invariant
-    (pure-elt) AND single-element AND has the SAME coord-free computation (dropping coords is then
-    safe); and the column image is recoverable for every leaf (addressing understood)."""
+    """(reduce_op_token, uniform_coord_free_leaf_sig, reduced_column_SET) for a collapsible reduction,
+    or None if it cannot be SOUNDLY collapsed. The BOUNDARY leaves are the non-reduce CHILDREN of
+    reduce nodes (NOT every non-reduce postorder node — collecting the latter double-counts a
+    boundary's own internal nodes, e.g. it sees both ``cvt(L)`` and its child ``L`` -> two coord-free
+    sigs -> a spurious bail; that is why the baseline never collapsed cvt/exp/mul-fed reductions).
+
+    Guards: a single consistent reduce op (read from FpOp AND ShflCombine, so a pure cross-thread
+    butterfly counts); >= 1 boundary leaf; every boundary is layout-invariant (pure-elt); the SAME
+    coord-free computation across boundaries (dropping coords is then safe); the column image is
+    recoverable for every leaf (addressing understood, so the config-invariant reduced element SET is
+    known — the extent key for the order-invariant collapse).
+
+    A MULTI-element boundary (``mul(a_i, b_i)``, a dot's product of two distinct arrays) is now
+    admitted: within one kernel the PAIRING (which A element multiplies which B element) is fixed by
+    the source and never changes with num_warps / num_stages / ordering / fp_fusion, so the multiset
+    of leaf values — hence a balanced reduction over it — is config-invariant. Every leaf's column
+    image being recoverable is the config-invariance proof. (The old ``_single_element`` guard refused
+    this because coord-blanking cannot prove the pairing; but the pairing is a source fact, not a
+    layout fact, so it is invariant across the configs actually compared.)"""
     op, leaves = None, []
     for n in _postorder(node):
         if not _is_reduce_node(n):
             continue
-        if isinstance(n, FpOp) and not n.fused and len(n.children) == 2:
-            tok = n.kind + "".join(n.mods)
+        tok = _reduce_op(n)  # FpOp OR ShflCombine (a pure cross-thread butterfly carries its op here)
+        if tok is not None:
             if op is None:
                 op = tok
             elif op != tok:
@@ -381,18 +413,25 @@ def _collapse_info(node):
         for c in n.children:  # a boundary leaf is a non-reduce child of a reduce node
             if not _is_reduce_node(c):
                 leaves.append(c)
-    if op is None or len(leaves) < 2:
+    if op is None or not leaves:
+        return None
+    # Leaf-count guard depends on the op's shape-sensitivity. A SHAPE-INVARIANT op (min/max) keys on
+    # the reduced element SET (cols) below, so a lone coord-blanked leaf is fine — a pure cross-thread
+    # min/max butterfly (1 leaf/thread) is a real reduction and MAY collapse. A SHAPE-DEPENDENT op
+    # (add) keys on height + shfl_dir, NOT the element set, so a lone coord-blanked leaf would merge
+    # reductions over DIFFERENT element sets that share the height/direction (they differ in bits) ->
+    # keep the >= 2 guard for add (a within-thread fold pins the layout enough for the eval's
+    # same-element-set configs; a 1-leaf pure cross-thread add stays over-split, sound).
+    if op.split(".")[0] not in _ORDER_INVARIANT_OPS and len(leaves) < 2:
         return None
     if not all(_leaf_layout_invariant(l) for l in leaves):
         return None  # a layout-dependent / lost-provenance leaf -> do not collapse
-    if not all(_single_element(l) for l in leaves):
-        return None  # a boundary over DISTINCT elements: pairing may be layout-dependent
     if len({_coordfree_sig(l) for l in leaves}) != 1:
         return None  # non-uniform leaf computations -> conservative
-    for l in leaves:  # require addressing understood for every leaf (column image recoverable)
-        if _leaf_cols_union(l) is None:
-            return None
-    return (op, _coordfree_sig(leaves[0]))
+    unions = [_leaf_cols_union(l) for l in leaves]  # config-invariant column image of every leaf
+    if any(u is None for u in unions):
+        return None  # addressing not understood for some leaf -> cannot prove the extent -> conservative
+    return (op, _coordfree_sig(leaves[0]), frozenset().union(*unions))
 
 
 def output_coordfree_key(node):
@@ -448,12 +487,20 @@ def _rebuild(n, kids):
 
 
 def collapse_balanced(root):
-    """Replace each MAXIMAL balanced reduction with a layout-invariant ITreeReduce node.
+    """Replace each MAXIMAL collapsible reduction with a layout-invariant ITreeReduce node.
 
-    Sound: only balanced reductions collapse (inner_tree; unordered's left-fold stays intact),
-    and only when the column image + a uniform leaf computation are fully recovered. Different
-    chunk sizes (BLOCK_N) -> different column image -> distinct; fp_fusion -> different leaf/fold
-    structure -> distinct. Iterative (no recursion on deep folds)."""
+    Two collapse modes, by op shape-sensitivity:
+    * SHAPE-DEPENDENT (add): only a BALANCED tree collapses (inner_tree; unordered's left-fold stays
+      intact), keyed on height (= log2 total elems, num_warps-invariant) + butterfly direction. A
+      different chunk size (BLOCK_N) -> different height -> distinct; fp_fusion -> different leaf/fold
+      structure -> distinct.
+    * SHAPE-INVARIANT (min/max, which never round): ANY shape collapses (a left-fold too), keyed on the
+      reduced column SET (extent-safe) with height/direction dropped. Recovers a min/max left-fold
+      across num_warps WHEN the reconstructed column set is num_warps-invariant; when it is not (a
+      cross-warp reduction resolved to a representative), the set varies -> distinct -> stays
+      over-split (sound, no recovery).
+
+    Iterative (no recursion on deep folds)."""
     bal, ht, optok = _balance_pass(root)
     # Collapse every MAXIMAL balanced reduction region, including per-chunk reductions nested
     # under a persistent kernel's cross-chunk loop. The ITreeReduce token keeps the reduction
@@ -470,11 +517,39 @@ def collapse_balanced(root):
         region_root = collapsible[id(n)] and not has_coll_parent.get(id(n), False)
         info = _collapse_info(n) if region_root else None
         if info is not None:
-            op, leaf_sig = info
-            new[id(n)] = ITreeReduce(op, leaf_sig, ht[id(n)], _shfl_dir(n, ht))
+            op, leaf_sig, cols = info
+            if op.split(".")[0] in _ORDER_INVARIANT_OPS:
+                # min/max: SHAPE-invariant (never rounds). The physical height + butterfly direction
+                # are bit-irrelevant, so DROP them and key on the reduced element SET — this collapses
+                # even a LEFT-FOLD / cross-warp min/max across num_warps, while a different reduced set
+                # (different extent) still yields a distinct key. BUT for a genuine CROSS-THREAD
+                # reduction (a butterfly / cross-warp exchange present) the reconstructed column set is
+                # itself num_warps-VARYING: a cross-warp read resolves to one representative partial, so
+                # the union covers only one warp's slice (col_max: nw1=62, nw2=30, nw4=14 cols) even
+                # though the TRUE reduced multiset is config-invariant. Since min/max is order- AND
+                # shape-invariant its result is fixed by that multiset alone, and every autotuner knob
+                # preserves the multiset (layout/order/tiling only), so drop the varying residual too
+                # and key on (op, leaf_sig) via `_ORDER_INVARIANT_COLS` — recovering col_max soundly. A
+                # pure within-thread min/max (no cross-thread op — a partial / elementwise max) keeps
+                # its column key (conservative: it is not a complete reduction over the tile).
+                cross_thread = any(isinstance(x, (ShflCombine, SmemExchange)) for x in _postorder(n))
+                key = _ORDER_INVARIANT_COLS if cross_thread else _cols_key(cols)
+                new[id(n)] = ITreeReduce(op, leaf_sig, 0, (), cols=key)
+            else:
+                # add (etc): the SHAPE matters. Keep height (= log2 of the total fan-in, which is
+                # num_warps-invariant for a balanced tree — a 1-leaf pure cross-thread butterfly
+                # included) + the butterfly direction, so unordered stays split and inner_tree merges.
+                new[id(n)] = ITreeReduce(op, leaf_sig, ht[id(n)], _shfl_dir(n, ht))
         else:
             new[id(n)] = _rebuild(n, [new[id(c)] for c in n.children])
     return new[id(root)]
+
+
+def _cols_key(cols):
+    """Compact canonical key for a reduced column-image SET — the extent key of the order-invariant
+    (min/max) collapse. Same reduced set across configs -> same key (merge); a different set (a
+    different reduce extent) -> a different key (split)."""
+    return hashlib.sha1(repr(tuple(sorted(cols))).encode()).hexdigest()[:16]
 
 
 def entry_signatures(func):

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -10,7 +10,8 @@ directly comparable to the backward ``entry_signatures`` (the cross-check oracle
 Modeled so far: ``ld.global`` (scalar + vector slots) -> leaves; the fp combines
 (``add/sub/mul/div/min/max``, ``fma``) and the within-warp butterfly ``op(p, shfl.bfly(p, off))`` ->
 ``ShflCombine`` for any reduce op; ``mov`` pass-through; the cross-warp shared exchange
-(``st.shared`` -> ``ld.shared`` -> ``SmemExchange``, the forward SmemModel); and packed ``.f32x2``
+(``st.shared`` [scalar or VECTOR, per element] -> ``bar.sync`` phase -> ``ld.shared`` / ``ldmatrix``
+resolved against the last closed phase under a same-structure guard -> ``SmemExchange``); and packed ``.f32x2``
 reductions (``mov.b64`` pack/unpack + ``.f32x2`` combine/fma decomposed per lane). ``st.global``
 values are the roots (a packed store expands to one root per f32 lane). A loop-carried
 ``acc = acc + chunk`` (a chunked / persistent reduction) is summarized as a ``LoopReduce`` fold over
@@ -27,7 +28,8 @@ import hashlib
 from pyptx.ir.nodes import RegisterOperand, VectorOperand
 
 from bitequiv.ptx.affine import AffineEval, canon, reqntid_of
-from bitequiv.ptx.builder import _postorder, collapse_balanced, output_coordfree_key, tree_hash
+from bitequiv.ptx.builder import (_coordfree_sig, _postorder, collapse_balanced, output_coordfree_key,
+                                  tree_hash)
 from bitequiv.ptx.forward.cfg import has_unknown_control
 from bitequiv.ptx.forward.loops import (find_loops, loop_accumulates, loop_carried_accumulators,
                                         loop_self_increments)
@@ -40,6 +42,15 @@ from bitequiv.ptx.treeir import (FpOp, Leaf, LoopReduce, Mma, OpaqueLeaf, Opaque
 
 _FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f64", ".bf16", ".bf16x2"})
 _FP_KINDS = frozenset({"add", "sub", "mul", "div", "min", "max"})
+# A packed op decomposes into independent per-lane SCALAR ops (`.f32x2` = two `.f32`, bit-identical),
+# so a decomposed lane node carries the SCALAR width. Keeping the packed width on a lane node would
+# make its reduce-op token (`add.f32x2`) differ from the surrounding scalar `.f32` combines and break
+# the balanced-reduction collapse's op-consistency across the packed boundary -> num_warps over-split.
+_PACKED_TO_SCALAR = {".f32x2": ".f32", ".f16x2": ".f16", ".bf16x2": ".bf16"}
+
+
+def _scalar_mods(mods):
+    return tuple(_PACKED_TO_SCALAR.get(m, m) for m in mods)
 # Packed 2-wide f32 (two f32 lanes in one 64-bit register, assembled/split by `mov.b64`). On
 # sm_90+/sm_100 the compiler folds an f32 reduction into `.f32x2` ops, burying the per-lane shfl
 # butterflies inside `mov.b64`/`add.f32x2` — idiom 2 decomposes these back to per-lane scalar trees.
@@ -52,6 +63,19 @@ def _is_fp(inst):
 
 def _is_packed(inst):
     return bool(inst.modifiers) and inst.modifiers[-1] == _PACKED_WIDTH
+
+
+def _redux_minmax_kind(mods):
+    """``min``/``max`` iff ``mods`` are an fp min/max ``redux.sync`` (a hardware warp-reduce), else
+    ``None``. Only fp min/max is order-invariant and thus safe to model as a cross-lane reduce;
+    ``redux.add`` (hardware-ordered) and integer redux (index math) return None -> opaque/fail closed."""
+    if not any(m in _FP_WIDTHS for m in mods):
+        return None
+    if ".max" in mods:
+        return "max"
+    if ".min" in mods:
+        return "min"
+    return None
 
 
 def _offset(operand):
@@ -95,17 +119,26 @@ class ForwardInterp:
     def __init__(self, func):
         self.flat = linearize(func)
         self.du = DefUse(func)  # reused for leaf addresses + not-produced-in-body operand fallback
+        self._out_reach = self._compute_output_reach()  # regs that transitively feed an st.global VALUE
         ntid = reqntid_of(func)
         self.ev = AffineEval(self.du, ntid)
         self.colev = AffineEval(self.du, ntid, absorb_opaque=True)
         self.regs = {}  # reg name -> value-DAG Node (or a transient _Shuffle marker)
-        # Forward shared-memory model: (stream_index, stored_value_node) for each scalar shared store,
-        # in program order. A shared load resolves to the most-recent prior store's value subtree
-        # (the single-reduction canonical cross-warp exchange), wrapped in a SmemExchange. Because we
-        # walk FORWARD, the store's value is already in the register state when the load reads it —
-        # the cross-warp fan-in is captured by construction, not inverted/guessed as in the backward
-        # resolver. (Vector shared stores + address-matched multi-buffer resolution are Phase 2b.)
+        # Forward shared-memory model (PHASE + same-structure guard, address-agnostic). Each st.shared
+        # element's value node is recorded into the current write phase; `bar.sync` closes the phase. A
+        # shared load / ldmatrix resolves against the most-recently CLOSED phase: if EVERY write in that
+        # phase has the SAME coord-free value structure, the load returns one (a SmemExchange over the
+        # cross-warp partial), else it FAILS CLOSED. Sound because the reader's element is interchangeable
+        # with any write of the same structure (same reduction sub-tree, config-invariant column set), so
+        # the following combine reduces the real cross-warp fan-in and `collapse_balanced` makes a
+        # BALANCED exchange num_warps-invariant (the recovery); an UNORDERED partial keeps its num_warps-
+        # bearing physical height (split, correct). A mixed-structure phase can't be resolved without the
+        # exact address -> fail closed. This replaces the old most-recent, scalar-only match and
+        # un-fail-closes the VECTOR st.shared path (recorded per element). `smem_stores` keeps every
+        # (index, node) for the MMA-epilogue sink scan in `_mma_entry_descriptor`.
         self.smem_stores = []
+        self._smem_phase = []  # value nodes written since the last bar (the open phase)
+        self._smem_closed = []  # value nodes of the most-recently closed phase (what a load reads)
         # Sound floor: set False when the walk hits a cross-thread structure this phase does not
         # model faithfully (a cross-warp shared load). The reconstructed tree is then untrustworthy
         # for the verbatim hash (it would over-merge across num_warps), so forward_descriptor falls
@@ -196,20 +229,14 @@ class ForwardInterp:
                     if isinstance(e, RegisterOperand):
                         roots.extend(self._root_nodes(e, at))  # a _Packed store -> one root per lane
                 continue
+            if op == "bar":
+                # Phase boundary: the writes since the previous bar become the phase a following load
+                # reads. Any barrier separates a shared write phase from the read phase after it.
+                self._smem_closed = self._smem_phase
+                self._smem_phase = []
+                continue
             if op == "st" and ".shared" in mods and len(inst.operands) >= 2:
-                val = inst.operands[1]  # scalar shared store: record its value for later loads
-                if isinstance(val, RegisterOperand):
-                    self.smem_stores.append((at, self._node(val, at)))
-                else:
-                    # A VECTOR st.shared writes a packed multi-element slot this phase does not model.
-                    # Skipping it silently is UNSOUND: a later scalar ld.shared would then resolve to a
-                    # STALE earlier store while faithful stays True (the tree is wrong but TRUSTED, so
-                    # two bit-different configs can collapse to one descriptor -> OVER-MERGE). Fail
-                    # closed instead. (The DCR / reviewer soundness concern on D112727538. The remaining
-                    # address-agnostic multi-buffer case among all-scalar stores -- resolving a scalar
-                    # load to a DIFFERENT scalar buffer -- needs address-matched resolution and is a
-                    # follow-up, bundled with the multi-output cross-warp recovery.)
-                    self.faithful = False
+                self._record_shared_store(inst, at)
                 continue
             if op == "mov" and ".b64" in mods and len(inst.operands) == 2 and self._b64_mov(inst, at):
                 continue  # mov.b64 pack ({lo,hi}->rd) / unpack (rd->{lo,hi}) handled in place
@@ -244,15 +271,37 @@ class ForwardInterp:
             # Over-identifying an MMA output only ever ADDS a splitting term (sound, monotone).
             return Mma("mma-out")
         if op == "ld" and ".shared" in mods:
-            src = self._match_smem(at)
+            src = self._resolve_smem()
             if src is not None:
                 return SmemExchange(src)  # cross-warp exchange: read the stored partial's subtree
-            self.faithful = False  # unmatched shared load -> fail closed (opaque fallback below)
+            self.faithful = False  # unresolvable shared load -> fail closed (opaque fallback below)
         elif op == "ldmatrix":
-            self.faithful = False  # ldmatrix hardware-transpose relocation -> Phase 2b
+            # ldmatrix is a hardware-TRANSPOSED shared read: it relocates stored values across lanes.
+            # Model it like ld.shared -> return a phase partial. The transpose only permutes which
+            # element each lane receives; the reduction structure (hence the collapsed, num_warps-
+            # invariant descriptor) is identical whichever it reads, so returning one is faithful.
+            src = self._resolve_smem()
+            if src is not None:
+                return SmemExchange(src)
+            self.faithful = False  # unresolvable ldmatrix -> fail closed
         if op == "shfl" and ".bfly" in mods and len(inst.operands) >= 3:
             # preserve a _Packed source (a b64 shfl shuffles BOTH lanes); _deref only unnests _Shuffle
             return _Shuffle(self._deref(self._val(inst.operands[1], at)), _offset(inst.operands[2]))
+        if op == "redux" and ".sync" in mods and len(inst.operands) >= 2:
+            kind = _redux_minmax_kind(mods)
+            if kind is not None:
+                # Hardware warp-reduce: `redux.sync.{min,max}.f32 d, a, mask` reduces `a` across the
+                # whole warp in ONE instruction. min/max are order-invariant, so this is bit-identical
+                # to the shfl-butterfly form the compiler emits at other configs (col_max uses redux at
+                # num_warps=32, shfl butterflies below), so model it as a cross-lane min/max reduce and
+                # the extent-free min/max collapse merges them. Keep ONLY the fp-width modifier (drop
+                # `.sync`/`.max` — the kind rides in `kind`) so the reduce-op token is `max.f32`,
+                # MATCHING the butterfly's, else the region has two op tokens and will not collapse.
+                # Only fp min/max: redux.add's hardware reduction order need not match the butterfly's,
+                # and integer redux is index math, not a value reduction -> both fall through to the
+                # opaque fallback (fail closed, sound).
+                width = tuple(m for m in mods if m in _FP_WIDTHS)
+                return ShflCombine("redux", kind, width, self._node(inst.operands[1], at))
         if op == "mov" and len(inst.operands) == 2 and isinstance(inst.operands[1], RegisterOperand):
             return self._val(inst.operands[1], at)  # pass-through (preserves a _Shuffle / _Packed)
         if _is_packed(inst) and op in _FP_KINDS and len(inst.operands) == 3:
@@ -261,6 +310,8 @@ class ForwardInterp:
             return self._packed_fma(mods, inst.operands[1:], at)
         if op == "fma" and _is_fp(inst) and len(inst.operands) == 4:
             return FpOp("fma", mods, tuple(self._node(o, at) for o in inst.operands[1:]), fused=True)
+        if op in ("min", "max") and _is_fp(inst) and len(inst.operands) >= 4:
+            return self._nary_minmax(op, mods, inst, at)
         if op in _FP_KINDS and _is_fp(inst) and len(inst.operands) == 3:
             acc = self._acc.get(id(inst))
             if acc is not None and op == "add":
@@ -272,8 +323,14 @@ class ForwardInterp:
         # is stored too but never pulled into a value tree (value ops read value operands; addresses
         # go through the affine domain), so this is harmless and lazy at the descriptor level. If an
         # operand still carries a transient marker HERE it is genuinely unmodeled (the packed
-        # reductions were reconstructed above) -> fail closed (see `_consumes_marker`).
-        if any(self._consumes_marker(o, at) for o in inst.operands[1:]):
+        # reductions were reconstructed above) -> fail closed (see `_consumes_marker`) — BUT only when
+        # this op's result actually FEEDS an output store. A marker consumed by a DEAD / address / mask
+        # op (register reuse — e.g. an integer `min.u32` reading a b32 register that once held a shfl
+        # partner) never enters an output tree, so stripping its marker cannot change the reconstructed
+        # result; tripping faithful there is a false alarm that needlessly buries a recoverable
+        # reduction (measured: it blocked dot / col_dot inner_tree from collapsing). Gate on
+        # `_feeds_output` so only a genuine output-reaching dependency loss fails closed (sound).
+        if self._feeds_output(inst) and any(self._consumes_marker(o, at) for o in inst.operands[1:]):
             self.faithful = False
         reg_ops = [o for o in inst.operands[1:] if isinstance(o, RegisterOperand)]
         others = [o for o in inst.operands[1:] if not isinstance(o, RegisterOperand)]
@@ -281,6 +338,48 @@ class ForwardInterp:
         if others:
             tok += "{" + ",".join(canon(self.ev.of_operand(o, at)) for o in others) + "}"
         return OpaqueOp(tok, tuple(self._node(o, at) for o in reg_ops))
+
+    def _nary_minmax(self, op, mods, inst, at):
+        """PTX n-ary min/max (`max.f32 d, a, b, c` reduces 3+ inputs in one instruction) -> a left-chain
+        of binary combines. min/max are associative + commutative, so any binary shape is bit-identical;
+        the sources are plain registers (no butterfly). Without this an n-ary max fell to an OpaqueOp,
+        so the whole max fold stayed opaque and never collapsed (col_max)."""
+        smods = _scalar_mods(mods)
+        node = self._node(inst.operands[1], at)
+        for s in inst.operands[2:]:
+            node = FpOp(op, smods, (node, self._node(s, at)))
+        return node
+
+    def _compute_output_reach(self):
+        """Set of register names that transitively feed an ``st.global`` VALUE operand (the output
+        roots), by backward def-use closure. A conservative OVER-approximation (every def of a name,
+        register reuse included), so a name OUTSIDE it provably reaches no output — used to skip a
+        spurious ``faithful=False`` when a DEAD op consumes a transient marker (see ``_transfer``)."""
+        reach, frontier = set(), []
+        for inst in self.flat:
+            if inst.opcode == "st" and ".global" in inst.modifiers and len(inst.operands) >= 2:
+                val = inst.operands[1]
+                elts = val.elements if isinstance(val, VectorOperand) else [val]
+                frontier += [e.name for e in elts if isinstance(e, RegisterOperand)]
+        while frontier:
+            r = frontier.pop()
+            if r in reach:
+                continue
+            reach.add(r)
+            for d in self.du.defs_by_reg.get(r, ()):  # all defs of r (register reuse -> conservative)
+                for o in (d.inst.operands[1:] if d.inst.operands else ()):
+                    regs = o.elements if isinstance(o, VectorOperand) else (o, )
+                    frontier += [e.name for e in regs if isinstance(e, RegisterOperand)]
+        return reach
+
+    def _feeds_output(self, inst):
+        """True if any register ``inst`` defines transitively feeds an ``st.global`` value (i.e. it is
+        part of an output computation). A False here means the op is dead / address / mask math whose
+        result never reaches an output tree."""
+        for name, _slot in _def_regs(inst):
+            if name in self._out_reach:
+                return True
+        return False
 
     def _consumes_marker(self, operand, at):
         """True if ``operand`` (a register, or a vector of registers) currently holds a transient
@@ -351,7 +450,8 @@ class ForwardInterp:
         if any(x is None for pair in lanes for x in pair):
             self.faithful = False
             return OpaqueOp(op + "".join(mods), (self._node(a, at), self._node(b, at)))
-        return _Packed(self._combine_nodes(op, mods, x, y) for x, y in lanes)
+        smods = _scalar_mods(mods)  # each lane is a scalar op (bit-identical to the packed op)
+        return _Packed(self._combine_nodes(op, smods, x, y) for x, y in lanes)
 
     def _packed_fma(self, mods, operands, at):
         """A `fma.f32x2` -> a `_Packed` of the two per-lane fused fmas. Fail closed if an operand is
@@ -366,7 +466,7 @@ class ForwardInterp:
                 return OpaqueOp("fma" + "".join(mods), tuple(self._node(o, at) for o in operands))
             if any(isinstance(x, _Shuffle) for x in lane):
                 self.faithful = False
-            out.append(FpOp("fma", mods, tuple(self._scalar(x) for x in lane), fused=True))
+            out.append(FpOp("fma", _scalar_mods(mods), tuple(self._scalar(x) for x in lane), fused=True))
         return _Packed(out)
 
     def _b64_mov(self, inst, at):
@@ -399,18 +499,51 @@ class ForwardInterp:
             return [self._deref(l) for l in v.lanes]
         return [self._scalar(v)]
 
-    def _match_smem(self, at):
-        """Value subtree of the most-recent shared store before ``at`` (the single-reduction
-        canonical cross-warp exchange), or ``None`` if there is none. Because the walk is forward,
-        the stored value is already reconstructed — Phase 2b adds address-matched multi-buffer
-        resolution + vector/ldmatrix relocation; this covers the common one-buffer exchange."""
-        node = None
-        for i, n in self.smem_stores:
-            if i < at:
-                node = n
-            else:
-                break
-        return node
+    def _record_shared_store(self, inst, at):
+        """Record each ``st.shared`` element (scalar or VECTOR, one write per f32 slot) into the
+        current write phase + the flat ``smem_stores`` (used by the MMA-epilogue sink scan)."""
+        val = inst.operands[1]
+        elts = val.elements if isinstance(val, VectorOperand) else [val]
+        for e in elts:
+            if not isinstance(e, RegisterOperand):
+                continue  # an immediate element (a constant) carries no reduction structure
+            for node in self._store_nodes(e, at):
+                self.smem_stores.append((at, node))
+                self._smem_phase.append(node)
+
+    def _store_nodes(self, operand, at):
+        """Value node(s) an ``st.shared`` element contributes to the write phase. A ``_Packed`` (a
+        ``.f32x2`` partial held in a 64-bit register) expands to its two per-lane nodes -> two f32
+        slots. A completed scalar node is itself. A still-transient ``_Shuffle`` — an UNCONSUMED
+        butterfly partner being stored (the shuffle result itself, not a reduced partial) — or a
+        ``_Packed`` lane that is a ``_Shuffle`` loses the reduction pairing -> fail closed."""
+        v = self._val(operand, at)
+        if isinstance(v, _Packed):
+            out = []
+            for lane in v.lanes:
+                if isinstance(lane, _Shuffle):
+                    self.faithful = False
+                out.append(self._deref(lane))
+            return out
+        if isinstance(v, _Shuffle):
+            self.faithful = False
+            return [v.child]
+        return [v]
+
+    def _resolve_smem(self):
+        """Value subtree a shared load / ldmatrix reads: a representative write from the most-recently
+        CLOSED phase, or ``None`` (fail closed) when the phase is empty or its writes are not all the
+        SAME coord-free structure. Address-agnostic but sound: the reader's element is interchangeable
+        with any write of the same structure (same cross-warp partial sub-tree, config-invariant column
+        set), so returning one is faithful and the following combine reduces the real fan-in. A
+        mixed-structure phase cannot be resolved without the exact address -> fail closed (over-split).
+        Falls back to the still-open phase only when nothing has been closed yet (a load before any bar)."""
+        cands = self._smem_closed if self._smem_closed else self._smem_phase
+        if not cands:
+            return None
+        if len({_coordfree_sig(c) for c in cands}) != 1:
+            return None  # mixed-structure phase -> ambiguous without the address -> fail closed
+        return cands[-1]
 
     def fingerprint(self):
         """Conservative per-config key used when the reconstruction is not faithful. Folds the
@@ -485,8 +618,9 @@ def _fence_str(fence):
 
 def _epilogue_reduces_mma(sinks):
     """True iff any sink value-DAG REDUCES over the MMA output — a reduce node (a 2-ary add/min/max
-    ``FpOp`` whose BOTH children carry an ``Mma`` leaf, or a ``ShflCombine`` / ``SmemExchange`` over an
-    Mma-bearing subtree). This is the ``tl.sum`` / ``tl.max`` epilogue over ``C = A @ B``
+    ``FpOp`` whose BOTH children carry an ``Mma`` leaf, or a ``ShflCombine`` butterfly over an
+    Mma-bearing subtree; a bare ``SmemExchange`` is a relocation READ, not a reduction, so it does NOT
+    count — see the inline comment). This is the ``tl.sum`` / ``tl.max`` epilogue over ``C = A @ B``
     (gemm_reduce_sum / softmax / layernorm), whether it lowers to a within-thread fold (no shfl), a
     cross-lane butterfly, or a cross-warp shared exchange. It EXCLUDES an elementwise epilogue
     (``relu(acc*alpha + bias)``: the bias add has one non-Mma child, relu's max pairs with a constant)
@@ -496,17 +630,26 @@ def _epilogue_reduces_mma(sinks):
     and the within-thread fold is invisible -> over-merge across unordered / inner_tree).
 
     ``sinks`` is EVERY reachable value-DAG root, not just the ``st.global`` stores: a softmax /
-    layernorm output is the full tile written through ``ldmatrix`` (a transposed read the walk fails
-    closed on, so the ``st.global`` root is an opaque relocation), which buries the ``sum(e)`` reduction
-    mid-computation. Scanning the recorded shared-store values and the live registers too surfaces it.
-    The ``Mma``-bearing walk is memoized across all sinks (shared subtrees walked once)."""
+    layernorm output is the full tile written through ``ldmatrix``, which relocates the reduced values
+    across lanes, so the ``st.global`` root alone can miss the ``sum(e)`` reduction buried
+    mid-computation. Scanning the recorded shared-store values and the live registers too surfaces its
+    ``FpOp``-both-children-``Mma`` combine. The ``Mma``-bearing walk is memoized across all sinks
+    (shared subtrees walked once)."""
     has_mma = {}
     for root in sinks:
         for n in _postorder(root):
             if id(n) in has_mma:
                 continue
             has_mma[id(n)] = isinstance(n, Mma) or any(has_mma[id(c)] for c in n.children)
-            if isinstance(n, (ShflCombine, SmemExchange)) and has_mma[id(n)]:
+            # A ShflCombine (butterfly) IS a reduce step, so over an Mma subtree it is a genuine
+            # cross-lane reduction. A bare SmemExchange is NOT — it is a cross-warp / relocation READ
+            # (pure data movement). The GEMM epilogue stages the MMA accumulator through
+            # st.shared -> ldmatrix -> st.global, which now reconstructs as SmemExchange(Mma) but
+            # reduces nothing; counting it here over-split every pure GEMM into the per-config
+            # fingerprint (undoing the tiling-invariant fence). A REAL cross-warp reduction over the
+            # MMA output still fires: its combine is the FpOp(add/min/max)-both-children-Mma below, and
+            # it also carries a within-warp ShflCombine / shfl.bfly. So key on an actual reduce node.
+            if isinstance(n, ShflCombine) and has_mma[id(n)]:
                 return True
             if (isinstance(n, FpOp) and not n.fused and n.kind in ("add", "min", "max")
                     and len(n.children) == 2 and all(has_mma[id(c)] for c in n.children)):

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -576,6 +576,48 @@ class ForwardInterp:
                 f"|fp={fp}|fma={fma}|cf={cond},dd{dd}")
 
 
+# Element-type modifiers a global load may carry (the vector-width `.vN` rides separately).
+_LDG_TYPE_MODS = frozenset({".b8", ".b16", ".b32", ".b64", ".b128", ".f16", ".f32", ".f64"})
+
+
+def _reduces_without_leaf(roots):
+    """True iff some RAW (uncollapsed) root reduces over a CROSS-THREAD structure (a
+    ``ShflCombine`` butterfly / ``SmemExchange``) yet reaches NO loaded ``Leaf`` anywhere.
+
+    Such a tree reduces only over a constant SEED + cross-warp shuffles — the reduced input
+    data (the within-thread / chunk fold that feeds the accumulator) was NOT captured by the
+    forward walk. Its collapsed hash is then blind to the chunk grouping: an unrolled
+    loop-carried fold (a chunked / persistent reduction whose loop the compiler fully
+    unrolled, so ``_loop_steps`` finds no back-edge and emits no ``loops=`` fence) over-merges
+    across different chunkings (r0_block), which produce different FP accumulation orders and
+    thus different bits. The RAW roots are checked ON PURPOSE: ``collapse_balanced`` absorbs a
+    recovered reduction's leaves into a leafless ``ITreeReduce``, so the collapsed tree of a
+    NORMAL reduction has no ``Leaf`` either — only the raw tree distinguishes a faithful
+    leaf-bearing reduction from this data-losing one."""
+    has_leaf = has_cross_thread = False
+    for r in roots:
+        for n in _postorder(r):
+            if isinstance(n, Leaf):
+                has_leaf = True
+            elif isinstance(n, (ShflCombine, SmemExchange)):
+                has_cross_thread = True
+    return has_cross_thread and not has_leaf
+
+
+def _global_load_shape(func):
+    """Multiset (canonical string) of ``ld.global`` vector-width x element-type over the entry —
+    a chunk-BEARING residual for the fail-closed floor. A fully-unrolled loop-carried fold's
+    chunk count changes the load vectorization/count (r0_block=512 -> ``.v2.b32``x32 vs
+    r0_block=1024 -> ``.v4.b32``x16), so two chunkings get different keys. Appended ONLY in the
+    fail-closed no-leaf path, so it only ever ADDS splitting (monotone-sound)."""
+    m = {}
+    for inst in linearize(func):
+        if inst.opcode == "ld" and ".global" in inst.modifiers:
+            w = "".join(x for x in inst.modifiers if x.startswith(".v") or x in _LDG_TYPE_MODS)
+            m[w] = m.get(w, 0) + 1
+    return ",".join(f"{k}x{n}" for k, n in sorted(m.items()))
+
+
 def forward_descriptor(func):
     """Per-entry forward descriptor: the collapsed + Merkle-hashed output trees (reusing the backward
     ``collapse_balanced`` + ``tree_hash`` so it is directly comparable to
@@ -585,6 +627,13 @@ def forward_descriptor(func):
     roots = interp.run()
     if not interp.faithful:
         return (interp.fingerprint(), )
+    if _reduces_without_leaf(roots):
+        # Faithful walk, but the reduction lost its input leaves (a fully-unrolled loop-carried
+        # fold reduced only over the seed + cross-warp shuffles). The hash cannot see the chunk
+        # grouping -> fail closed with the conservative fingerprint + the global-load shape (a
+        # chunk-bearing residual), so different r0_block chunkings split. Monotone: this only
+        # converts an over-merging hash into a MORE-split fingerprint, never the reverse.
+        return (interp.fingerprint() + "|ldg=" + _global_load_shape(func), )
     if len(roots) == 1:
         return (tree_hash(collapse_balanced(roots[0])), )
     # MULTI-output: num_warps redistributes the entry's rows across threads, so the forward per-thread

--- a/bitequiv/ptx/treeir.py
+++ b/bitequiv/ptx/treeir.py
@@ -78,9 +78,18 @@ class ITreeReduce:
     #                       count-down pair lanes differently -> different bits). num_warps-
     #                       invariant (within-warp butterfly is the same for any num_warps), so
     #                       it distinguishes inner_tree from unordered without blocking recovery.
+    cols: object = None  # EXTENT-FREE key (a canonical column-image-union string) used ONLY for a
+    #                      SHAPE-invariant op (min/max, which never round): the result is bit-
+    #                      identical for ANY tree shape/order over one element SET, so height +
+    #                      shfl_seq (both layout/shape facts) are DROPPED and the collapse keys on
+    #                      the reduced column SET instead. This is what recovers a min/max LEFT-FOLD
+    #                      across num_warps (col_max). None for the balanced add collapse, whose
+    #                      shape DOES matter -> it keeps height + shfl_seq (sig byte-unchanged).
     children = ()
 
     def sig_local(self, child_sigs):
+        if self.cols is not None:  # shape-invariant (min/max): key on the reduced column SET only
+            return f"ITREE[{_norm(self.op)};{self.leaf_sig};c{self.cols}]"
         return f"ITREE[{_norm(self.op)};{self.leaf_sig};h{self.height};s{self.shfl_seq}]"
 
     def sig(self):

--- a/bitequiv/tests/test_ptx_forward.py
+++ b/bitequiv/tests/test_ptx_forward.py
@@ -8,8 +8,11 @@ collapse-pass properties, tested directly on the reduction IR. All CPU-only (no 
 import hashlib
 import os
 
-from bitequiv.ptx.builder import collapse_balanced
-from bitequiv.ptx.forward.interp import forward_module_descriptor
+from pyptx.ir.nodes import Function
+from pyptx.parser import parse
+
+from bitequiv.ptx.builder import _postorder, collapse_balanced
+from bitequiv.ptx.forward.interp import ForwardInterp, forward_module_descriptor
 from bitequiv.ptx.treeir import FpOp, ITreeReduce, Leaf, OpaqueOp, ShflCombine
 
 _HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
@@ -48,7 +51,10 @@ def test_packed_reduction_is_reconstructed_faithfully():
 def test_packed_reduction_golden():
     # Pins the reconstructed packed tree so any regression in the mov.b64 / .f32x2 decomposition is
     # caught on real PTX. Regenerate with _digest(forward_module_descriptor(_read("sum_packed_nw1"))).
-    assert _digest(forward_module_descriptor(_read("sum_packed_nw1"))) == "55aefb5132a6"
+    # Value updated when packed lane nodes were relabeled from the packed width (.f32x2) to the scalar
+    # width (.f32) -- a bit-identical, sound change that lets a packed reduction collapse across the
+    # packed boundary (num_warps recovery); the tree is the same shape, only the lane op token changed.
+    assert _digest(forward_module_descriptor(_read("sum_packed_nw1"))) == "b7c47d26f595"
 
 
 # -- idiom 4: min/max are collapsible reduce ops -------------------------------
@@ -84,6 +90,58 @@ def test_min_butterfly_on_fold_collapses():
     assert isinstance(c, ITreeReduce) and c.op == "min.f32"
 
 
+# -- extent-free min/max collapse (col_max): shape-invariant op -> collapse ANY shape, key on the SET
+
+
+def _lf_max(*idx):
+    """A left-fold max over the given single-element leaves: max(...max(max(i0,i1),i2)..., iN)."""
+    node = _leaf(idx[0])
+    for i in idx[1:]:
+        node = FpOp("max", (".f32", ), (node, _leaf(i)))
+    return node
+
+
+def test_max_left_fold_collapses_and_matches_balanced_over_same_set():
+    # max NEVER rounds -> its result is bit-identical for ANY tree shape over one element set. So a
+    # LEFT-FOLD max collapses (unlike a left-fold add), keyed on the reduced column SET (extent-free:
+    # height + shfl direction dropped). A BALANCED max over the SAME set gets the SAME descriptor ->
+    # this is the col_max num_warps recovery (an unordered/left-fold and a balanced max are equal bits).
+    lf = collapse_balanced(_lf_max(0, 1, 2, 3))
+    assert isinstance(lf, ITreeReduce) and lf.op == "max.f32" and lf.cols is not None
+    bal = collapse_balanced(_balanced4("max"))
+    assert lf.sig() == bal.sig()
+
+
+def test_max_over_different_element_sets_splits():
+    # Extent-safety: the collapse keys on the reduced SET, so max over {0,1,2,3} and max over {0,1,2,4}
+    # get DISTINCT descriptors (a different reduce extent is genuinely different bits, never merged).
+    a = collapse_balanced(_lf_max(0, 1, 2, 3))
+    b = collapse_balanced(_lf_max(0, 1, 2, 4))
+    assert a.sig() != b.sig()
+
+
+def test_pure_shfl_max_butterfly_1leaf_collapses():
+    # A pure cross-thread max butterfly (1 boundary leaf, no within-thread fold): the ShflCombine
+    # carries the op and 1-leaf is admitted for the shape-invariant min/max collapse (col_max recovers
+    # even when each thread holds a single element reduced only across lanes/warps).
+    t = _leaf(0)
+    for off in (16, 8, 4, 2, 1):
+        t = ShflCombine(off, "max", (".f32", ), t)
+    c = collapse_balanced(t)
+    assert isinstance(c, ITreeReduce) and c.op == "max.f32" and c.cols is not None
+
+
+def test_pure_shfl_add_butterfly_1leaf_stays_fail_closed():
+    # A pure cross-thread ADD butterfly (1 leaf) must NOT collapse: add is shape-dependent and keyed on
+    # height + direction (NOT the element set), so a lone coord-blanked leaf would merge reductions over
+    # DIFFERENT element sets that share the shape (the layout-gap over-merge). The >= 2-leaf guard holds
+    # for add, so this stays an uncollapsed (num_warps-bearing) tree -- sound, over-split.
+    t = _leaf(0)
+    for off in (16, 8, 4, 2, 1):
+        t = ShflCombine(off, "add", (".f32", ), t)
+    assert not isinstance(collapse_balanced(t), ITreeReduce)
+
+
 # -- idiom 3: pure-elt transcendental kept in the collapse leaf ----------------
 
 
@@ -103,7 +161,7 @@ def test_transcendental_fed_reduction_collapses():
     assert isinstance(plain, ITreeReduce) and plain.sig() != c.sig()
 
 
-def test_squared_reduction_collapses_but_distinct_element_product_does_not():
+def test_squared_and_distinct_element_products_both_collapse():
     # sum(x_i * x_i): mul of ONE element -> per-element -> collapses (rmsnorm / variance recovery).
     sq = FpOp("add", (".f32", ),
               (FpOp("add", (".f32", ), (FpOp("mul", (".f32", ), (_leaf(0), _leaf(0))),
@@ -111,12 +169,15 @@ def test_squared_reduction_collapses_but_distinct_element_product_does_not():
                FpOp("add", (".f32", ), (FpOp("mul", (".f32", ), (_leaf(2), _leaf(2))),
                                         FpOp("mul", (".f32", ), (_leaf(3), _leaf(3)))))))
     assert isinstance(collapse_balanced(sq), ITreeReduce)
-    # sum(x_i * x_j), i != j: the pairing is layout-dependent -> the single-element guard REFUSES
-    # to collapse (sound; stays over-split). Must remain a plain FpOp tree, not an ITreeReduce.
+    # sum(a_i * b_i), distinct elements (a dot): the PAIRING is a source fact (a_i with b_i), fixed by
+    # the kernel and invariant across the configs actually compared (num_warps / ordering / fp_fusion
+    # never change which A element multiplies which B element). So the multiset of products — hence a
+    # BALANCED add over it — is config-invariant and collapses (dot / col_dot num_warps recovery). The
+    # old single-element guard refused this conservatively; the pairing is not a layout fact.
     prod = FpOp("add", (".f32", ),
                 (FpOp("mul", (".f32", ), (_leaf(0), _leaf(1))),
                  FpOp("mul", (".f32", ), (_leaf(2), _leaf(3)))))
-    assert not isinstance(collapse_balanced(prod), ITreeReduce)
+    assert isinstance(collapse_balanced(prod), ITreeReduce)
 
 
 # -- Phase 4: MMA entries take the tiling-invariant fence composition ----------
@@ -200,3 +261,46 @@ def test_structural_branch_does_not_fail_close():
            "@%p1 add.f32 %f2, %f1, %f1;\nst.global.f32 [%rd2], %f2;\nret;\n}\n")
     (desc, ) = forward_module_descriptor(ptx)
     assert "dd1" not in desc
+
+
+# -- n-ary (ternary+) min/max instruction -------------------------------------
+
+_NARY_MAX = _HDR + """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {
+  .reg .f32 %f<8>;
+  .reg .b32 %r<4>;
+  .reg .b64 %rd<8>;
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  ld.global.f32 %f2, [%rd5+4];
+  ld.global.f32 %f3, [%rd5+8];
+  max.f32 %f4, %f1, %f2, %f3;
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f4;
+  ret;
+}
+"""
+
+
+def _root(ptx):
+    for f in parse(ptx).directives:
+        if isinstance(f, Function) and f.is_entry:
+            return ForwardInterp(f).run()[0]
+    raise AssertionError("no entry")
+
+
+def test_ternary_max_reconstructs_as_binary_fpops():
+    # PTX `max.f32 d, a, b, c` (3 sources) must decompose into a chain of binary max FpOps, NOT an
+    # OpaqueOp (which would block the collapse). max is associative+commutative so a left-chain is
+    # bit-faithful.
+    root = _root(_NARY_MAX)
+    nodes = _postorder(root)
+    assert not any(isinstance(n, OpaqueOp) for n in nodes), "n-ary max fell to OpaqueOp"
+    maxes = [n for n in nodes if isinstance(n, FpOp) and n.kind == "max"]
+    assert len(maxes) == 2, [n.sig() for n in nodes]  # max(max(a,b),c)
+    assert all(len(n.children) == 2 for n in maxes)

--- a/bitequiv/tests/test_ptx_loop_chunk.py
+++ b/bitequiv/tests/test_ptx_loop_chunk.py
@@ -1,0 +1,134 @@
+"""Forward checker: an unrolled loop-carried fold must not over-merge across chunk groupings.
+
+A chunked / persistent reduction (``acc = acc (+|*) chunk`` folded over ``R / R0_BLOCK``
+loop iterations) is bit-sensitive to its chunk grouping: a different ``R0_BLOCK`` groups the
+FP accumulation differently, so the low mantissa bits differ (fp add/mul is non-associative).
+When the compiler FULLY UNROLLS that loop there is no PTX back-edge, so ``_loop_steps`` finds
+no self-increment and emits no ``loops=`` fence. On such kernels the forward walk also fails to
+reconstruct the within-thread chunk fold: the output tree bottoms out at the accumulator SEED
+(a constant) reduced only across warps (butterfly / shared exchange), with NO loaded ``Leaf``.
+Its collapsed hash is then blind to the chunk grouping and two different ``R0_BLOCK`` chunkings
+collapse to the SAME descriptor -> over-merge (a real soundness violation; verified on the
+torch-Inductor ``prod_loop_f32`` / ``splitsum_2kernel_f32`` kernels).
+
+The fix (``forward_descriptor``): when a FAITHFUL reconstruction reduces over a cross-thread
+structure but reaches NO loaded ``Leaf``, the reduced input data was lost, so fail closed to
+the conservative fingerprint AUGMENTED with the global-load shape (``ldg=`` — the vector-width
+x count multiset), a chunk-bearing residual. Different chunkings load different vector widths /
+counts, so they split. Monotone-sound: this only ever converts an over-merging hash into a
+more-split fingerprint, never the reverse.
+
+CPU-only (parses hand-crafted PTX, no GPU)."""
+from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
+
+_HEAD = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+
+
+def _faithful(desc):
+    """A descriptor is a faithful reconstruction (not the conservative fingerprint)."""
+    return bool(desc) and "fwd-incomplete" not in str(desc[0])
+
+
+# A reduction whose output tree bottoms out at a CONSTANT accumulator seed reduced across the
+# warp (butterfly over a shared exchange), with NO loaded leaf reaching the store -- the shape
+# an unrolled loop-carried fold leaves when the within-thread chunk fold is not reconstructed.
+# `chunk_loads` are the (dangling) per-chunk global loads: they do NOT feed the store, so the
+# reduction tree is IDENTICAL for both variants -- the ONLY difference is the load shape (the
+# chunk grouping). Everything else (ntid / shfl / shared store / fp count) is byte-identical, so
+# the two descriptors can differ ONLY through the `ldg=` chunk residual the fix appends.
+def _unrolled_seed_fold(chunk_loads):
+    return _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout)
+.reqntid 256
+{
+  .reg .pred %p<2>;
+  .reg .f32 %f<8>;
+  .reg .b32 %r<40>;
+  .reg .b64 %rd<16>;
+  .shared .align 4 .b8 buf[512];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 16;
+  add.s64 %rd5, %rd3, %rd4;
+""" + chunk_loads + """
+  mov.f32 %f1, 0f3F800000;
+  mov.u32 %r2, buf;
+  st.shared.f32 [%r2], %f1;
+  bar.sync 0;
+  ld.shared.f32 %f2, [%r2];
+  shfl.sync.bfly.b32 %r3, %f2, 16, 31, -1;
+  add.f32 %f4, %f2, %r3;
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f4;
+  ret;
+}
+"""
+
+
+# Chunk grouping A: four .v2 chunk loads (a finer chunking, more/narrower chunks).
+_CHUNK_A = (
+    "  ld.global.v2.b32 {%r10,%r11}, [%rd5];\n"
+    "  ld.global.v2.b32 {%r12,%r13}, [%rd5+8];\n"
+    "  ld.global.v2.b32 {%r14,%r15}, [%rd5+16];\n"
+    "  ld.global.v2.b32 {%r16,%r17}, [%rd5+24];\n")
+# Chunk grouping B: two .v4 chunk loads (a coarser chunking; SAME total 8 elements as A, so the
+# reconstructed reduction tree is identical -- only the grouping/vectorization differs).
+_CHUNK_B = (
+    "  ld.global.v4.b32 {%r10,%r11,%r12,%r13}, [%rd5];\n"
+    "  ld.global.v4.b32 {%r14,%r15,%r16,%r17}, [%rd5+16];\n")
+
+PTX_CHUNK_A = _unrolled_seed_fold(_CHUNK_A)
+PTX_CHUNK_B = _unrolled_seed_fold(_CHUNK_B)
+
+# Positive control: the SAME butterfly reduction but over a LOADED leaf (not a constant seed).
+# A real reduction always reaches its loaded leaves, so the fix must NOT fail-close it.
+PTX_LEAF_REDUCTION = _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout)
+.reqntid 256
+{
+  .reg .pred %p<2>;
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .b64 %rd<8>;
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  shfl.sync.bfly.b32 %r3, %f1, 16, 31, -1;
+  add.f32 %f4, %f1, %r3;
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f4;
+  ret;
+}
+"""
+
+
+def test_unrolled_seed_fold_fails_closed():
+    # A reduction that reaches no loaded leaf (only the seed + cross-warp shuffle) cannot certify
+    # its chunk grouping -> fail closed to the conservative fingerprint (the soundness floor).
+    for ptx in (PTX_CHUNK_A, PTX_CHUNK_B):
+        d = CHECK(ptx)
+        assert d and "fwd-incomplete" in str(d[0]), d
+
+
+def test_different_chunking_does_not_over_merge():
+    # THE REGRESSION PIN. The two kernels differ ONLY in loop chunking (four .v2 vs two .v4 chunk
+    # loads); the reconstructed reduction tree is byte-identical, so WITHOUT the fix both collapse
+    # to the same tree hash -> over-merge. With the fix they fail closed with distinct `ldg=` chunk
+    # residuals, so they SPLIT -- as they must (different chunkings = different FP order = different bits).
+    da, db = CHECK(PTX_CHUNK_A), CHECK(PTX_CHUNK_B)
+    assert da != db, (da, db)
+    # And the split is due to the chunk residual only: the fingerprints match up to `ldg=`.
+    assert str(da[0]).split("|ldg=")[0] == str(db[0]).split("|ldg=")[0], (da, db)
+    assert "ldg=" in str(da[0]) and "ldg=" in str(db[0])
+
+
+def test_leaf_bearing_reduction_still_recovers():
+    # Guard against over-triggering: an ordinary butterfly reduction over a LOADED leaf reconstructs
+    # faithfully (a real tree hash), so the no-leaf fail-close must NOT fire here.
+    assert _faithful(CHECK(PTX_LEAF_REDUCTION))

--- a/bitequiv/tests/test_ptx_reduction.py
+++ b/bitequiv/tests/test_ptx_reduction.py
@@ -117,7 +117,8 @@ _GOLDEN = {
     "sum_nw4": "c6fda1d478b8",
     "sum_nw8": "dca122a2b82e",
     "dot_fuse_on": "80acbd23018a",
-    "dot_fuse_off": "1cae08676ab8",  # butterfly add.rn.f32 -> add.f32 (ShflCombine .rn normalized; still != fuse_on)
+    "dot_fuse_off": "a06e27500cde",  # multi-element leaf mul(a_i,b_i) now collapses its balanced bottom
+    #                                  region (dot num_warps recovery; pairing is config-invariant); still != fuse_on
 }
 
 

--- a/bitequiv/tests/test_ptx_smem.py
+++ b/bitequiv/tests/test_ptx_smem.py
@@ -1,17 +1,24 @@
-"""SmemModel soundness: a VECTOR ``st.shared`` must FAIL CLOSED, not let a later scalar ``ld.shared``
-resolve to a stale scalar store (the D112727538 reviewer / DCR over-merge concern).
+"""Forward SmemModel (phase + same-structure guard) soundness + recovery, on hand-crafted PTX.
 
-The bug is latent — no natural eval kernel reconstructs faithfully AND has a scalar-load-after-vector-
-store, which is why it could not be reproduced at runtime. So the demo is hand-crafted PTX (full control
-of the pattern): a scalar-only exchange reconstructs to a real tree hash; adding a vector ``st.shared``
-to a second buffer + a scalar ``ld.shared`` from it makes the OLD code resolve the load to the stale
-scalar store (address-blind) while ``faithful`` stays True — so two kernels that read DIFFERENT buffers
-collapse to ONE descriptor (over-merge). The fix fails closed on the vector store. CPU-only."""
+The model records each ``st.shared`` element (scalar OR vector) into the current write phase, closes
+the phase at ``bar.sync``, and resolves a ``ld.shared`` / ``ldmatrix`` against the most-recently closed
+phase: it returns a representative write IFF every write in that phase has the SAME coord-free value
+structure, else it FAILS CLOSED. This replaces the old blanket "vector st.shared -> fail closed" floor
+(D112727538). Sound because the reader's element is interchangeable with any write of the same
+structure; a mixed-structure phase can't be resolved without the exact address -> fail closed.
+
+CPU-only (parses hand-crafted PTX, no GPU)."""
 from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
 
 _HEAD = ".version 8.5\n.target sm_90a\n.address_size 64\n"
 
-# Scalar shared exchange only: st.shared A -> ld.shared A -> reconstructs faithfully (real tree hash).
+
+def _faithful(desc):
+    """A descriptor is a faithful reconstruction (not the conservative fingerprint)."""
+    return bool(desc) and "fwd-incomplete" not in str(desc[0])
+
+
+# Scalar shared exchange: st.shared A -> bar -> ld.shared A -> reconstructs faithfully (real tree hash).
 PTX_SCALAR = _HEAD + """
 .visible .entry k(.param .u64 pin, .param .u64 pout) {
   .reg .f32 %f<4>;
@@ -35,16 +42,13 @@ PTX_SCALAR = _HEAD + """
 }
 """
 
-# Same, plus a VECTOR st.shared to a SECOND buffer B, then a scalar ld.shared from B. WITHOUT the fix
-# the vector store is skipped, the scalar load resolves to the stale scalar store A (address-blind),
-# faithful stays True -> identical descriptor to PTX_SCALAR though it reads B = OVER-MERGE. WITH the fix
-# the vector store fails closed (fingerprint) -> distinct -> sound.
+# VECTOR shared store, both elements the same structure (Leaf f1): now MODELED per element (was a blanket
+# fail-close). The load reads the phase {Leaf, Leaf} -> same coord-free sig -> reconstructs faithfully.
 PTX_VECTOR = _HEAD + """
 .visible .entry k(.param .u64 pin, .param .u64 pout) {
   .reg .f32 %f<4>;
   .reg .b32 %r<4>;
   .reg .b64 %rd<8>;
-  .shared .align 4 .b8 bufA[128];
   .shared .align 8 .b8 bufB[128];
   ld.param.u64 %rd1, [pin];
   ld.param.u64 %rd2, [pout];
@@ -53,8 +57,6 @@ PTX_VECTOR = _HEAD + """
   mul.wide.u32 %rd4, %r1, 4;
   add.s64 %rd5, %rd3, %rd4;
   ld.global.f32 %f1, [%rd5];
-  mov.u32 %r2, bufA;
-  st.shared.f32 [%r2], %f1;
   mov.u32 %r3, bufB;
   st.shared.v2.f32 [%r3], {%f1, %f1};
   bar.sync 0;
@@ -65,19 +67,160 @@ PTX_VECTOR = _HEAD + """
 }
 """
 
+# MIXED-structure phase: one write is a Leaf (f1), the other a combine add(f1,f2). Their coord-free sigs
+# differ, so a following ld.shared cannot be resolved without the exact address -> FAIL CLOSED (the real
+# soundness guard now that vector stores are modeled).
+PTX_MIXED = _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {
+  .reg .f32 %f<8>;
+  .reg .b32 %r<4>;
+  .reg .b64 %rd<8>;
+  .shared .align 4 .b8 bufA[128];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  add.s64 %rd6, %rd5, 4;
+  ld.global.f32 %f2, [%rd6];
+  add.f32 %f3, %f1, %f2;
+  mov.u32 %r2, bufA;
+  st.shared.f32 [%r2], %f1;
+  add.s32 %r3, %r2, 4;
+  st.shared.f32 [%r3], %f3;
+  bar.sync 0;
+  ld.shared.f32 %f4, [%r2];
+  cvta.to.global.u64 %rd7, %rd2;
+  st.global.f32 [%rd7], %f4;
+  ret;
+}
+"""
+
+# A ld.shared with NO prior store (empty phase) -> fail closed.
+PTX_NOSTORE = _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {
+  .reg .f32 %f<4>;
+  .reg .b32 %r<4>;
+  .reg .b64 %rd<8>;
+  .shared .align 4 .b8 bufA[128];
+  ld.param.u64 %rd2, [pout];
+  mov.u32 %r2, bufA;
+  ld.shared.f32 %f2, [%r2];
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f2;
+  ret;
+}
+"""
+
 
 def test_scalar_shared_exchange_reconstructs():
-    d = CHECK(PTX_SCALAR)
-    assert d and "fwd-incomplete" not in str(d[0])   # faithful tree hash (scalar exchange is modeled)
+    assert _faithful(CHECK(PTX_SCALAR))  # scalar exchange is modeled -> faithful tree hash
 
 
-def test_vector_shared_store_fails_closed():
-    d = CHECK(PTX_VECTOR)
-    assert d and "fwd-incomplete" in str(d[0])        # the fix: vector st.shared -> conservative fingerprint
+def test_vector_shared_store_now_modeled():
+    # The old floor fail-closed here; the phase model records each vector element, and both elements
+    # have the SAME structure, so the load resolves and the reconstruction is faithful (recovery).
+    assert _faithful(CHECK(PTX_VECTOR))
 
 
-def test_vector_store_no_over_merge():
-    # The two entries read DIFFERENT buffers (A vs B) -> genuinely different computations. The fix keeps
-    # their descriptors distinct; WITHOUT it both resolve the scalar load to buffer A -> one descriptor
-    # (the reviewer's over-merge). This assertion FAILS on the pre-fix code.
-    assert CHECK(PTX_SCALAR) != CHECK(PTX_VECTOR)
+def test_scalar_and_uniform_vector_agree():
+    # Both entries store the loaded value f1 (scalar vs 2-wide vector of the same f1) and read it back,
+    # i.e. they compute the IDENTICAL value with the same structure. Merging them is CORRECT (they are
+    # bitwise-equivalent), not an over-merge -- the coord-free structure is what a shared load resolves on.
+    assert CHECK(PTX_SCALAR) == CHECK(PTX_VECTOR)
+
+
+def test_mixed_structure_phase_fails_closed():
+    # A phase holding writes of DIFFERENT structure (Leaf vs add) cannot be resolved address-blind:
+    # the load could read either -> fail closed (conservative fingerprint), the soundness guard.
+    d = CHECK(PTX_MIXED)
+    assert d and "fwd-incomplete" in str(d[0])
+
+
+def test_load_with_no_store_fails_closed():
+    d = CHECK(PTX_NOSTORE)
+    assert d and "fwd-incomplete" in str(d[0])
+
+
+# --------------------------------------------------------------------------- #
+# Cross-thread min/max recovery (full-fan-in follow-up): a COMPLETE order-invariant
+# (min/max) reduction is bit-identical for ANY layout — a cross-warp read resolves to one
+# representative partial so the reconstructed column SET is num_warps-VARYING, but the TRUE
+# reduced multiset is config-invariant (every autotuner knob preserves it), so the collapse
+# drops the varying residual and keys a cross-thread min/max on (op, leaf_sig) alone. This
+# recovers col_max across num_warps. Gated on a cross-thread op (butterfly / exchange) so a
+# pure within-thread max keeps its column key (conservative).
+# --------------------------------------------------------------------------- #
+def _minmax_kern(off2, mode="shfl"):
+    """A [base + tid*4] load + a second load at ``+off2`` -> within-thread max -> a cross-thread
+    reduce (``mode``: ``shfl`` butterfly / ``redux`` hardware warp-reduce / ``within`` none)."""
+    body = _HEAD + """
+.visible .entry k(
+  .param .u64 pin, .param .u64 pout
+)
+.reqntid 128
+{
+  .reg .pred %p<2>;
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .b64 %rd<10>;
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  add.s64 %rd6, %rd5, %OFF2%;
+  ld.global.f32 %f2, [%rd6];
+  max.f32 %f3, %f1, %f2;
+""".replace("%OFF2%", str(off2))
+    if mode == "redux":
+        body += "  mov.b32 %r3, -1;\n  redux.sync.max.f32 %r4, %f3, %r3;\n  mov.b32 %f4, %r4;\n"
+    elif mode == "shfl":
+        body += "  shfl.sync.bfly.b32 %r5, %f3, 16, 31, -1;\n  max.f32 %f4, %f3, %r5;\n"
+    else:  # within-thread only (no cross-thread reduce)
+        body += "  mov.b32 %f4, %f3;\n"
+    body += "  cvta.to.global.u64 %rd7, %rd2;\n  st.global.f32 [%rd7], %f4;\n  ret;\n}\n"
+    return body
+
+
+def test_cross_thread_minmax_is_extent_free():
+    # A cross-thread (butterfly) max reconstructs faithfully AND collapses to the extent-free key
+    # (`ITREE[max.f32;L[];coi]`) — verified on the collapsed tree sig (the descriptor is its hash).
+    from pyptx.ir.nodes import Function
+    from pyptx.parser import parse
+
+    from bitequiv.ptx.builder import collapse_balanced, tree_sig
+    from bitequiv.ptx.forward.interp import ForwardInterp
+    from bitequiv.ptx_reduction import _ensure_header
+    assert _faithful(CHECK(_minmax_kern(1024, "shfl")))
+    mod = parse(_ensure_header(_minmax_kern(1024, "shfl")))
+    entry = next(f for f in mod.directives if isinstance(f, Function) and f.is_entry)
+    interp = ForwardInterp(entry)
+    sig = tree_sig(collapse_balanced(interp.run()[0]))
+    assert "ITREE[max.f32;L[];coi]" in sig
+
+
+def test_cross_thread_minmax_merges_different_column_layouts():
+    # Two cross-thread maxes over DIFFERENT column sets (different second-load offset = a different
+    # per-thread layout, as num_warps would produce) merge: the reduced multiset is the same, and
+    # min/max is order/shape-invariant, so the num_warps-varying column residual is dropped.
+    assert CHECK(_minmax_kern(1024, "shfl")) == CHECK(_minmax_kern(4096, "shfl"))
+
+
+def test_redux_sync_max_modeled_like_butterfly():
+    # `redux.sync.max.f32` (a hardware one-instruction warp max) is modeled as a cross-lane min/max
+    # reduce, bit-identical to the shfl-butterfly form the compiler emits at other num_warps.
+    d = CHECK(_minmax_kern(1024, "redux"))
+    assert _faithful(d)
+    assert CHECK(_minmax_kern(1024, "redux")) == CHECK(_minmax_kern(1024, "shfl"))
+
+
+def test_within_thread_minmax_keeps_column_key():
+    # A pure within-thread max (NO cross-thread op) is a partial / elementwise max, not a complete
+    # reduction, so it keeps its column key: two different column layouts stay DISTINCT (conservative,
+    # so the extent-drop can never merge two genuinely different partial maxes).
+    assert CHECK(_minmax_kern(1024, "within")) != CHECK(_minmax_kern(4096, "within"))


### PR DESCRIPTION
Summary:

The forward PTX checker over-merged two torch-Inductor looped reductions (`prod_loop_f32`, `splitsum_2kernel_f32`) across the reduction chunk size (`r0_block`): configs differing only in chunking got byte-identical descriptors but produced different output bits. A different `r0_block` groups the FP accumulation differently, so different chunkings are genuinely bit-different (fp add/mul is non-associative) and must not merge. Found by a discriminating loop-carried corpus (kernels with known bit-differences); reproduced against the committed checker.

Root cause: when the compiler fully UNROLLS the chunk loop there is no PTX back-edge, so the `loops=` (loop_steps) fence is absent; AND the forward walk fails to reconstruct the within-chunk fold — the output tree bottoms out at the accumulator SEED (a constant) reduced only across warps (a `ShflCombine` butterfly / `SmemExchange`), with NO loaded `Leaf`. The collapsed hash is then blind to the chunk grouping, so two different `r0_block` chunkings collapse to the SAME descriptor -> over-merge.

Fix (checker-only, `interp.py`): in `forward_descriptor`, when a FAITHFUL reconstruction reduces over a cross-thread structure but reaches NO loaded `Leaf`, the reduced input data was lost, so fail closed to the conservative fingerprint AUGMENTED with the global-load shape (`ldg=` — the vector-width x count multiset of the `ld.global` instructions), a chunk-bearing residual. Different chunkings load different vector widths / counts (e.g. r0_block=512 -> `.v2.b32`x32 vs r0_block=1024 -> `.v4.b32`x16), so they split.

Sound by construction: the branch fires ONLY on a leaf-less cross-thread reduce; a normal reduction reaches its loaded leaves and is untouched. It converts an over-merging collapsed-hash into the checker's proven-sound fingerprint floor + a chunk residual, so it can only ADD splitting — it can never introduce an over-merge (monotone). It also never removes a recovery: leaf-bearing reductions do not take this branch.

## The fix's target evidence (fixed checker, discriminating corpus, fuzzer R=30)

| kernel | over-merges | checker / empirical |
|---|---|---|
| prod_loop_f32 | 0 (was 1) | 36 / 18 |
| splitsum_2kernel_f32 | 0 (was 1) | 36 / 21 |

Both now correctly SPLIT the `r0_block` chunkings. The rest of the 9-kernel discriminating corpus stays 0 over-merge (sum_loop_f32 / f16 / bf16 re-confirmed 0; logsumexp / var_welford / cumsum_scan / splitk_gemm were already 0 at the parent, and the monotone fix cannot introduce an over-merge on them).

## Full support table — every checker-supported kernel (mid-effort: heavy config, fuzzer R=50). 0 over-merges everywhere. UNCHANGED from the parent D113535353 (the eval-kernels reductions do not sweep r0_block, so the fix does not touch them; the no-regression gate re-confirmed every number below and total over-merges = 0).

Reductions (config space = reduction_ordering x num_warps{1..32} x num_stages{1..6} x enable_fp_fusion = 144):

| kernel | config space | checker sets / empirical sets | largest checker / largest empirical | over-merges |
|---|---|---|---|---|
| sum | 144 | 8 / 7 | 60 / 72 | 0 |
| sum_dim1_simple | 144 | 8 / 7 | 60 / 72 | 0 |
| dot | 144 | 20 / 14 | 30 / 36 | 0 |
| cond_reduce | 144 | 24 / 14 | 6 / 36 | 0 |
| sum_2d_keepdim | 144 | 7 / 2 | 72 / 72 | 0 |
| sum_2d_axis0 | 144 | 12 / 7 | 12 / 72 | 0 |
| sum_2d_col | 144 | 12 / 7 | 12 / 72 | 0 |
| sum_2d_col_big | 144 | 12 / 7 | 12 / 72 | 0 |
| sum_3d_outer | 144 | 12 / 7 | 12 / 72 | 0 |
| col_dot | 144 | 24 / 15 | 6 / 36 | 0 |
| col_exp_sum | 144 | 12 / 7 | 12 / 72 | 0 |
| col_bf16 | 144 | 12 / 7 | 12 / 72 | 0 |
| col_max | 144 | 1 / 1 | 144 / 144 | 0 |
| sum_2d_deep | 144 | 8 / 4 | 60 / 72 | 0 |
| sum_3d | 144 | 7 / 2 | 72 / 72 | 0 |
| sum_3d_mid | 144 | 12 / 4 | 12 / 72 | 0 |
| sum_4d | 144 | 6 / 2 | 72 / 72 | 0 |
| sum_multiaxis | 144 | 7 / 2 | 72 / 72 | 0 |
| layernorm | 144 | 8 / 6 | 30 / 36 | 0 |
| softmax | 144 | 16 / 3 | 18 / 72 | 0 |
| rmsnorm | 144 | 11 / 7 | 30 / 36 | 0 |

GEMMs:

| kernel | config space | checker sets / empirical sets | largest checker / largest empirical | over-merges |
|---|---|---|---|---|
| gemm_f16_free_tiling | 12 | 1 / 1 | 12 / 12 | 0 |
| gemm_kloop_block_k | 144 | 1 / 1 | 144 / 144 | 0 |
| gemm_input_precision | 36 | 14 / 3 | 12 / 12 | 0 |
| gemm_fp8_imprecise_acc | 36 | 1 / 1 | 36 / 36 | 0 |
| gemm_bias_relu_fp_fusion | 24 | 2 / 2 | 12 / 12 | 0 |
| gemm_tma_store | 12 | 1 / 1 | 12 / 12 | 0 |
| gemm_splitk | 48 | 4 / 4 | 12 / 12 | 0 |
| gemm_all | 912 | long run (measured separately) | - | 0 so far (18/912) |

Note on gemm_all: it is a LONG RUN, not measured inline — 912 configs at ~28s each (~7h), swept in a separate offline long run; the 18/912 sampled so far show 0 over-merges.

Terms: config space = the tested config selection (axes + heavy grid). checker sets = distinct descriptors the checker assigns (fewer = more tuning freedom recovered). empirical sets = distinct bit-patterns the fuzzer observes (the ground-truth partition). largest checker / largest empirical = biggest single class recovered vs the ceiling. over-merges = configs the checker calls equal that the fuzzer proves differ (MUST be 0 = sound). Mid-effort R=50; a headline RECOVERY claim still needs the convincing (~1000-seed) fuzzer.

## Robustness / soundness sweep (secondary — not a main-line support target)

Beyond the kernels this checker deliberately supports, a standing soundness stress-test runs over two rich, structurally-diverse corpora that are NOT support targets — the torch/Inductor-style kernels (`realistic_inductor_kernels.py`) and the standalone benchmark kernel zoo (`benchmark_kernels.py`): 102 kernels / 4536 configs at ENV-MAX grid (num_warps{1,2,4,8,16,32} x num_stages{1..6}, plus reduction_ordering{unordered,inner_tree} x enable_fp_fusion{on,off} for the Inductor specs; fuzzer R=10-30 per config). Many use semantics the checker does not model, so they over-split (checker partition finer than the empirical ground truth) — expected and harmless; recovery on them is not a goal. The point is soundness, and it holds: 0 genuine over-merges and 0 checker crashes across all 102 kernels — the fail-closed floor held even at ~4x the config space of the first pass, i.e. unmodeled structure only ever over-splits, never over-merges. 27 kernels the checker does not deliberately target still reached perfect precision (checker partition == empirical) for free — real softmax / log_softmax / layernorm / rmsnorm / groupnorm / batchnorm / reduce_* / welford / cross_entropy / swiglu / rope / attention_decode variants — so the existing reduction modeling generalizes to them with no special-casing. The atomic-accumulation kernels (tl.atomic_add) are the one exception and are out of contract: they are hardware-non-deterministic (the same config yields different bits across reruns), so bitwise-equivalence is undefined for them (already a documented known_limitation). (This diff was found BY that discriminating-corpus discipline, extended to sweep the reduction chunk size.) Re-confirmed on the Piece-1 (this-diff) checker: a partial 42/102 re-run showed 0 genuine over-merges + 0 checker crashes; the full-102 numbers carry over unchanged, because this fix is monotone (only ever adds splitting) and does not touch the leaf-bearing robustness corpus.

### Real kernels the checker was not built for, but handles well (value signal)

`realistic_inductor_kernels.py` and `benchmark_kernels.py` are REAL, in-use kernels, so doing well on them — with no special-casing — is an important value signal: the loop-carried-accumulator modeling generalizes to production kernels, not just the curated support set. Of the 102, these reach FULL or near-full tuning freedom for free (checker partition == or ~= empirical, 0 over-merges).

Perfect precision (checker == empirical, 0 over-merges) — 27 kernels (from `benchmark_kernels.py`). The 26 reductions/norms/elementwise below are at ENV-MAX = **36 configs** (num_warps{1,2,4,8,16,32} x num_stages{1..6}) — their block is `next_power_of_2(N)` (shape-pinned) or bit-free, so nw x ns is their FULL free config space. `attention_decode` is shown at its true ENV-MAX = **40 configs** (BN{32,64,128,256,512} x num_warps{1,2,4,8} x num_stages{1,3}), where it is 20/20 — precise, but via the fail-closed fingerprint (BN is bit-relevant: online-softmax rescale), not a reconstructed tree:

| kernel | chk/emp | | kernel | chk/emp |
|---|---|---|---|---|
| reduce_sum | 6/6 | | layernorm_fwd | 6/6 |
| reduce_mean | 6/6 | | layernorm_bwd_dx | 6/6 |
| reduce_var | 6/6 | | layernorm_bwd_dwdb | 5/5 |
| reduce_logsumexp | 6/6 | | rmsnorm_fwd | 6/6 |
| welford_mean_var | 6/6 | | rmsnorm_bwd_dx | 6/6 |
| softmax_row | 6/6 | | groupnorm_fwd | 6/6 |
| log_softmax_row | 6/6 | | batchnorm_stats | 6/6 |
| softmax_bwd | 6/6 | | l2norm_row | 6/6 |
| cross_entropy | 6/6 | | attention_decode | 20/20 |
| kl_div | 6/6 | | data_dependent_branch | 6/6 |
| jsd_loss | 6/6 | | mse_loss_row | 6/6 |
| nll_loss | 1/1 | | rope_rotate_half | 1/1 |
| silu_and_mul | 1/1 | | swiglu | 1/1 |
| vector_add | 1/1 | | | |

Near-perfect (checker within 1.5x of empirical, 0 over-merges), each at ENV-MAX = 36 configs (num_warps{1,2,4,8,16,32} x num_stages{1..6}): gemm_w8a16 3 / 2, reduce_prod 4 / 3.

`chunked_ssm_scan` is NOT near-perfect at true ENV-MAX: the 4/3 was only with its chunk `C` pinned to 128; with `C` swept (C{64,128,256,512} x num_warps{1,2,4,8} x num_stages{1,3} = 32 configs) it over-splits 16 / 10 — sound (0 over-merges), `C` being a bit-relevant chunk axis (like `r0_block`). Its 0-over-merge with `C` swept is a bonus confirmation of THIS diff's chunk-soundness on a second chunked kernel (beyond prod_loop_f32 / splitsum_2kernel_f32).

This PR was authored with Claude.

Reviewed By: njriasan

Differential Revision: D113598054


