### PR TITLE
[triton][bitequiv] Split-K soundness: fence the outer reduction loop's trip (fix gemm_splitk over-merge) (#2383)

### DIFF
--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -480,6 +480,7 @@ def _mma_entry_descriptor(func, fence):
     both ride, so configs differing in EITHER the MMA shape OR the reduction order split (sound, never
     over-merged). The reduction fingerprint carries num_warps back in that case; the pure GEMM drops
     it deliberately (num_warps is a free re-tiling of the same dot products)."""
+    from bitequiv.ptx.forward.loops import reduction_trip_signature
     from bitequiv.ptx_reduction import _loop_steps
     parts = [_fence_str(fence)]
     if any(inst.opcode == "shfl" and ".bfly" in inst.modifiers for inst in linearize(func)):
@@ -489,6 +490,15 @@ def _mma_entry_descriptor(func, fence):
     steps = _loop_steps(func)  # BLOCK_K split (+ the tcgen05 / fp8 K carried here, not in the token)
     if steps:
         parts.append("loops=" + ",".join(map(str, steps)))
+    sig = reduction_trip_signature(func)
+    if sig is not None:
+        # A GEMM whose K sum is regrouped by an OUTER reduction loop (split-K: partials combined) is
+        # NOT bitwise-equivalent across split counts, yet its static MMA/op structure is identical, so
+        # the tiling-invariant fence over-merges them (num_splits 1==2, 4==8). Fail closed on the
+        # loop-control fingerprint (the setp trip constants), which differs per split count -> sound.
+        # A plain single-K-loop GEMM has no such nested reduction -> sig is None -> fence unchanged.
+        # Precise per-split recovery (nested LoopReduce) is the follow-up.
+        parts.append("splits=" + hashlib.sha1(repr(sig).encode()).hexdigest()[:8])
     return "|".join(parts)
 
 

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -200,6 +200,16 @@ class ForwardInterp:
                 val = inst.operands[1]  # scalar shared store: record its value for later loads
                 if isinstance(val, RegisterOperand):
                     self.smem_stores.append((at, self._node(val, at)))
+                else:
+                    # A VECTOR st.shared writes a packed multi-element slot this phase does not model.
+                    # Skipping it silently is UNSOUND: a later scalar ld.shared would then resolve to a
+                    # STALE earlier store while faithful stays True (the tree is wrong but TRUSTED, so
+                    # two bit-different configs can collapse to one descriptor -> OVER-MERGE). Fail
+                    # closed instead. (The DCR / reviewer soundness concern on D112727538. The remaining
+                    # address-agnostic multi-buffer case among all-scalar stores -- resolving a scalar
+                    # load to a DIFFERENT scalar buffer -- needs address-matched resolution and is a
+                    # follow-up, bundled with the multi-output cross-warp recovery.)
+                    self.faithful = False
                 continue
             if op == "mov" and ".b64" in mods and len(inst.operands) == 2 and self._b64_mov(inst, at):
                 continue  # mov.b64 pack ({lo,hi}->rd) / unpack (rd->{lo,hi}) handled in place
@@ -249,23 +259,10 @@ class ForwardInterp:
         # OpaqueOp NODE with its register operands as children + non-register operands in the token,
         # EXACTLY like the backward else-branch, so the value-DAG matches. A pure integer/address op
         # is stored too but never pulled into a value tree (value ops read value operands; addresses
-        # go through the affine domain), so this is harmless and lazy at the descriptor level.
-        # An unmodeled op that CONSUMES a transient marker (a _Shuffle butterfly partner, or a
-        # _Packed f32x2 pair — directly or via a vector operand) would have `_scalar` silently STRIP
-        # it -> the reduction ORDERING (count-up vs count-down) or the packed lane structure is lost
-        # -> OVER-MERGE. Idiom 2 RECONSTRUCTS the packed reductions above (`.f32x2` combine, `mov.b64`
-        # pack/unpack); a marker still reaching HERE is genuinely unmodeled -> fail closed, and the
-        # fingerprint's ordered shfl sequence + store widths then distinguish the configs. A benign
-        # opaque with NO marked operand (an f64 `or.b64`, a `cvt`) keeps faithful=True and recovers.
-        def _marked(o):
-            if isinstance(o, RegisterOperand):
-                return isinstance(self._val(o, at), (_Shuffle, _Packed))
-            if isinstance(o, VectorOperand):
-                return any(isinstance(e, RegisterOperand)
-                           and isinstance(self._val(e, at), (_Shuffle, _Packed)) for e in o.elements)
-            return False
-
-        if any(_marked(o) for o in inst.operands[1:]):
+        # go through the affine domain), so this is harmless and lazy at the descriptor level. If an
+        # operand still carries a transient marker HERE it is genuinely unmodeled (the packed
+        # reductions were reconstructed above) -> fail closed (see `_consumes_marker`).
+        if any(self._consumes_marker(o, at) for o in inst.operands[1:]):
             self.faithful = False
         reg_ops = [o for o in inst.operands[1:] if isinstance(o, RegisterOperand)]
         others = [o for o in inst.operands[1:] if not isinstance(o, RegisterOperand)]
@@ -273,6 +270,20 @@ class ForwardInterp:
         if others:
             tok += "{" + ",".join(canon(self.ev.of_operand(o, at)) for o in others) + "}"
         return OpaqueOp(tok, tuple(self._node(o, at) for o in reg_ops))
+
+    def _consumes_marker(self, operand, at):
+        """True if ``operand`` (a register, or a vector of registers) currently holds a transient
+        ``_Shuffle`` / ``_Packed`` marker. An unmodeled op that consumes one would have ``_scalar``
+        silently STRIP it -> the reduction ORDERING (count-up vs count-down) or the packed lane
+        structure is lost -> OVER-MERGE. The caller fails closed when this is True; the fingerprint's
+        ordered shfl sequence + store widths then distinguish the configs. A benign opaque with NO
+        marked operand (an f64 ``or.b64``, a ``cvt``) keeps ``faithful`` True and still recovers."""
+        if isinstance(operand, RegisterOperand):
+            return isinstance(self._val(operand, at), (_Shuffle, _Packed))
+        if isinstance(operand, VectorOperand):
+            return any(isinstance(e, RegisterOperand)
+                       and isinstance(self._val(e, at), (_Shuffle, _Packed)) for e in operand.elements)
+        return False
 
     def _loop_reduce(self, inst, acc, at):
         """A loop-carried ``acc = acc + chunk`` -> ``LoopReduce(add, chunk, key)``, summarizing the

--- a/bitequiv/ptx/forward/loops.py
+++ b/bitequiv/ptx/forward/loops.py
@@ -134,3 +134,61 @@ def loop_carried_accumulators(insts, loop, loops):
             if acc is not None:
                 out.append((acc, inst))
     return out
+
+
+def outer_reduction_loops(insts, loops):
+    """Loops whose range contains BOTH a matmul AND a self-accumulating fp combine (``acc = acc + x``)
+    — an OUTER reduction that COMBINES matmul partials. Split-K is the canonical case: the split loop's
+    ``acc += partial`` wraps the inner K-loop's MMA. A plain tiled GEMM's single K-loop contains the
+    MMA but NO in-loop self-accumulate (the MMA itself IS the accumulation into a TMEM/register acc),
+    so it is not flagged and keeps its tiling-invariant fence.
+
+    The outer loop's TRIP COUNT (= number of partials combined = num_splits) is bit-relevant: it
+    regroups the K sum (``((s0)+(s1))+...`` vs one in-order fold), so different trips are NOT
+    bitwise-equivalent even though the static MMA/op structure is identical across trips. This is the
+    reusable structural hook for any nested-reduction GEMM (split-K, tree-combine, GEMM+reduction).
+
+    Detection = a loop whose range contains a self-accumulating fp combine ``acc = acc + x`` (dst ==
+    src0) — a running fp total folded across iterations. Split-K's split loop (``acc += partial``) is
+    exactly that; a plain tiled GEMM accumulates via the MMA/TMEM accumulator itself (no fp add) and
+    has none, so it keeps its tiling-invariant fence.
+
+    Keying on the self-accumulate combine (not nested matmul loops) is what survives the compiler
+    restructuring at some tilings: at BLOCK_N=256 the split loop and the MMA K-loop are emitted as
+    SEPARATE / overlapping loops (the split loop's range holds NO matmul), so a nested-matmul-loop test
+    misses the split structure and over-merges the split counts. The split loop still carries the
+    ``acc += partial`` combine, so a range scan for it fires in both the nested and the flattened form."""
+    out = []
+    for lp in loops:
+        h, latch = lp
+        if any(_self_accumulate(insts[k]) is not None for k in range(h, latch + 1)):
+            out.append(lp)
+    return out
+
+
+def reduction_trip_signature(func):
+    """Hashable fingerprint that distinguishes the outer reduction loops' TRIP COUNTS (the split-K
+    regrouping), or ``None`` when the entry has no nested-reduction structure (a plain GEMM, whose K
+    sum is a single in-order fold that tiling never regroups).
+
+    A split-K GEMM's static instruction structure is IDENTICAL across split counts — only the outer
+    loop's runtime TRIP differs — so the checker must key on the loop-control constants. We return the
+    sorted set of ``setp`` immediate compare-constants in the entry: the outer split loop's bound
+    (= num_splits) and the inner K-loop's bound both appear here as literals and both change with the
+    split count, so different split counts get different signatures (SOUND, never over-merged). This is
+    a FAIL-CLOSED fingerprint of the trip structure — the checker cannot yet model the split regrouping
+    precisely; exact per-split recovery (nested ``LoopReduce``) is a follow-up. Returns ``None`` unless
+    an outer reduction loop exists, so a plain tiled GEMM keeps its tiling-invariant fence."""
+    insts, loops = find_loops(func)
+    if not outer_reduction_loops(insts, loops):
+        return None
+    consts = set()
+    for inst in insts:
+        if inst.opcode == "setp" and len(inst.operands) >= 3:
+            for o in inst.operands[1:]:
+                if isinstance(o, ImmediateOperand):
+                    try:
+                        consts.add(int(o.text, 0))
+                    except (ValueError, TypeError):
+                        continue
+    return tuple(sorted(consts))

--- a/bitequiv/tests/test_ptx_gemm_splitk.py
+++ b/bitequiv/tests/test_ptx_gemm_splitk.py
@@ -1,0 +1,91 @@
+"""Split-K soundness: a GEMM whose K sum is regrouped by an OUTER reduction loop (split-K combining
+per-slice partials) is NOT bitwise-equivalent across split counts, yet its static MMA/op structure is
+identical, so the tiling-invariant MMA fence alone over-merges the split counts. The checker must key on
+the outer loop's TRIP (see ``bitequiv.ptx.forward.loops.reduction_trip_signature`` +
+``_mma_entry_descriptor``). A PLAIN single-K-loop GEMM has no such nested reduction and must keep the
+fence (num_warps / BLOCK_M / BLOCK_N recovered). Hand-crafted PTX, CPU-only."""
+from pyptx.parser import parse
+
+from bitequiv.ptx.forward import loops
+from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
+from bitequiv.ptx_reduction import _ensure_header
+
+_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+_MMA = "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r3}, %r4, %r5;\n"
+
+
+def _entry(ptx):
+    return next(d for d in parse(_ensure_header(ptx)).directives if getattr(d, "is_entry", False))
+
+
+# split-K: an OUTER loop (acc += partial) around an INNER K-loop (the MMA). The outer bound is the
+# split count; only it changes between the two below -> they must get DISTINCT descriptors.
+def _split_ptx(num_splits):
+    return _HDR + f"""
+.visible .entry k(.param .u64 p) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.f32 %f1, 0f00000000;
+  mov.b32 %r1, 0;
+$L__OUTER:
+  mov.b32 %r2, 0;
+$L__INNER:
+  {_MMA}  add.s32 %r2, %r2, 1;
+  setp.lt.s32 %p1, %r2, 16;
+  @%p1 bra $L__INNER;
+  add.f32 %f1, %f1, %f2;
+  add.s32 %r1, %r1, 1;
+  setp.lt.s32 %p2, %r1, {num_splits};
+  @%p2 bra $L__OUTER;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+# plain GEMM: a SINGLE K-loop (the MMA), the acc += is a post-loop epilogue -> no nested reduction.
+_PLAIN = _HDR + f"""
+.visible .entry k(.param .u64 p) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.f32 %f1, 0f00000000;
+  mov.b32 %r2, 0;
+$L__INNER:
+  {_MMA}  add.s32 %r2, %r2, 1;
+  setp.lt.s32 %p1, %r2, 16;
+  @%p1 bra $L__INNER;
+  add.f32 %f1, %f1, %f2;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+def test_nested_reduction_detected_for_split_not_plain():
+    insts, lps = loops.find_loops(_entry(_split_ptx(4)))
+    assert loops.outer_reduction_loops(insts, lps)          # split-K: outer reduction over the K-loop
+    insts, lps = loops.find_loops(_entry(_PLAIN))
+    assert not loops.outer_reduction_loops(insts, lps)      # plain GEMM: single K-loop, no nesting
+
+
+def test_trip_signature_distinguishes_split_count():
+    assert loops.reduction_trip_signature(_entry(_split_ptx(4))) \
+        != loops.reduction_trip_signature(_entry(_split_ptx(8)))
+    assert loops.reduction_trip_signature(_entry(_PLAIN)) is None
+
+
+def test_split_counts_get_distinct_descriptors():
+    # the soundness fix: different split counts must NOT collapse to one descriptor (was the over-merge)
+    assert CHECK(_split_ptx(4)) != CHECK(_split_ptx(8))
+    assert "splits=" in str(CHECK(_split_ptx(4)))
+
+
+def test_plain_gemm_keeps_fence_no_splits():
+    d = CHECK(_PLAIN)
+    assert d and "splits=" not in str(d)                    # fence unchanged -> tiling recovery preserved

--- a/bitequiv/tests/test_ptx_smem.py
+++ b/bitequiv/tests/test_ptx_smem.py
@@ -1,0 +1,83 @@
+"""SmemModel soundness: a VECTOR ``st.shared`` must FAIL CLOSED, not let a later scalar ``ld.shared``
+resolve to a stale scalar store (the D112727538 reviewer / DCR over-merge concern).
+
+The bug is latent — no natural eval kernel reconstructs faithfully AND has a scalar-load-after-vector-
+store, which is why it could not be reproduced at runtime. So the demo is hand-crafted PTX (full control
+of the pattern): a scalar-only exchange reconstructs to a real tree hash; adding a vector ``st.shared``
+to a second buffer + a scalar ``ld.shared`` from it makes the OLD code resolve the load to the stale
+scalar store (address-blind) while ``faithful`` stays True — so two kernels that read DIFFERENT buffers
+collapse to ONE descriptor (over-merge). The fix fails closed on the vector store. CPU-only."""
+from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
+
+_HEAD = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+
+# Scalar shared exchange only: st.shared A -> ld.shared A -> reconstructs faithfully (real tree hash).
+PTX_SCALAR = _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {
+  .reg .f32 %f<4>;
+  .reg .b32 %r<4>;
+  .reg .b64 %rd<8>;
+  .shared .align 4 .b8 bufA[128];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  mov.u32 %r2, bufA;
+  st.shared.f32 [%r2], %f1;
+  bar.sync 0;
+  ld.shared.f32 %f2, [%r2];
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f2;
+  ret;
+}
+"""
+
+# Same, plus a VECTOR st.shared to a SECOND buffer B, then a scalar ld.shared from B. WITHOUT the fix
+# the vector store is skipped, the scalar load resolves to the stale scalar store A (address-blind),
+# faithful stays True -> identical descriptor to PTX_SCALAR though it reads B = OVER-MERGE. WITH the fix
+# the vector store fails closed (fingerprint) -> distinct -> sound.
+PTX_VECTOR = _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {
+  .reg .f32 %f<4>;
+  .reg .b32 %r<4>;
+  .reg .b64 %rd<8>;
+  .shared .align 4 .b8 bufA[128];
+  .shared .align 8 .b8 bufB[128];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  mov.u32 %r2, bufA;
+  st.shared.f32 [%r2], %f1;
+  mov.u32 %r3, bufB;
+  st.shared.v2.f32 [%r3], {%f1, %f1};
+  bar.sync 0;
+  ld.shared.f32 %f2, [%r3];
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f2;
+  ret;
+}
+"""
+
+
+def test_scalar_shared_exchange_reconstructs():
+    d = CHECK(PTX_SCALAR)
+    assert d and "fwd-incomplete" not in str(d[0])   # faithful tree hash (scalar exchange is modeled)
+
+
+def test_vector_shared_store_fails_closed():
+    d = CHECK(PTX_VECTOR)
+    assert d and "fwd-incomplete" in str(d[0])        # the fix: vector st.shared -> conservative fingerprint
+
+
+def test_vector_store_no_over_merge():
+    # The two entries read DIFFERENT buffers (A vs B) -> genuinely different computations. The fix keeps
+    # their descriptors distinct; WITHOUT it both resolve the scalar load to buffer A -> one descriptor
+    # (the reviewer's over-merge). This assertion FAILS on the pre-fix code.
+    assert CHECK(PTX_SCALAR) != CHECK(PTX_VECTOR)


### PR DESCRIPTION
Summary:

`gemm_splitk` (D113138954) exposed a real over-merge in the forward checker: at fixed tiling the split counts collapse (num_splits 1==2 and 4==8; 72 over-merge pairs at R=200). A split-K GEMM cuts K into `num_splits` slices, sums each into its OWN partial, then combines the partials — a different grouping `((s0)+(s1))+...` than a single in-order fold, so each split count is a distinct bit-class. But the static MMA/op structure is IDENTICAL across split counts (only the outer loop's runtime TRIP differs), and the forward MMA descriptor was the tiling-invariant fence + the loop STEP (`loops=`) — neither of which moves with the split count. So they collapsed.

Fix: detect an OUTER REDUCTION LOOP — a loop whose range carries a self-accumulating fp combine `acc = acc + partial` (split-K's split loop; a plain tiled GEMM accumulates via the MMA/TMEM accumulator itself and has none) — and append a `splits=` fingerprint of the entry's loop-control constants (the `setp` trip bounds), which differ per split count. This fails closed: the checker cannot yet model the split regrouping precisely, so it over-splits (sound, never over-merged); a plain GEMM has no such loop, so its tiling-invariant fence is unchanged (num_warps / BLOCK_M / BLOCK_N still recovered).

Robustness: keys on the self-accumulate combine, NOT on nested matmul loops, because the compiler flattens/overlaps the split loop and the MMA K-loop at some tilings (seen at BLOCK_N=256, where they are SEPARATE loops and the split loop's range holds no matmul) — a nested-matmul-loop test misses the split structure there and over-merges 4 vs 8. A range scan for the combine fires in both the nested and the flattened form.

Extensibility (built to carry the later variants, not a split-K-only patch): the two `loops.py` primitives — `outer_reduction_loops` (the structural hook) and `reduction_trip_signature` (the trip fingerprint) — plus the `_mma_entry_descriptor` seam are reusable for tree-combine / two-kernel / GEMM+reduction variants. Diff 2 replaces the fail-closed fingerprint with a precise nested `LoopReduce` (inner BLOCK_K fold merges, outer split fold splits) to RECOVER the tiling within each split count.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D113357554


