### PR TITLE
[triton][beta] [Cherry-pick] '[AMD] Generalize in-thread tree reduction to support ternary grouping for max/min (#9897)' (#2391)

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -110,6 +110,14 @@ public:
   virtual bool supportLdStMatrixB8() const { return false; }
   virtual bool supportBitwidth16Elementwise() const { return false; }
   virtual bool supportBitwidth32Elementwise() const { return false; }
+
+  // Returns the preferred arity of the in-thread reduction tree for the given
+  // combiner operation. The default is 2 (binary tree). Targets that have
+  // native ternary instructions (e.g. AMD v_maximum3/v_minimum3) can return 3
+  // to generate a ternary reduction tree that maps directly to hardware.
+  virtual unsigned getReductionTreeArity(Operation *combinerOp) const {
+    return 2;
+  }
   virtual bool isCuda() const { return false; }
 
   // Returns the shared memory partition size in bytes. A value of 0 means

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -703,6 +703,9 @@ def TTNG_AsyncTMACopyGlobalToLocalOp : TTNG_Op<"async_tma_copy_global_to_local",
                    CArg<"triton::CacheModifier", "triton::CacheModifier::NONE">:$cache,
                    CArg<"triton::EvictionPolicy", "triton::EvictionPolicy::NORMAL">:$evict,
                    CArg<"bool", "false">:$isVolatile), [{
+      multicast &= ::mlir::triton::nvidia_gpu::hasCGABroadcast(
+                                   ::mlir::cast<::mlir::triton::gpu::MemDescType>(
+                                       result.getType()));
       build($_builder, $_state, /*multicastTargets=*/Value(), desc, coord,
             /*offsets=*/ValueRange{}, barrier, result, pred, multicast, cache,
             evict, isVolatile, /*two_cta=*/false,

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h
@@ -1,6 +1,7 @@
 #ifndef TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_CLUSTERBARRIERINSERTION_H_
 #define TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_CLUSTERBARRIERINSERTION_H_
 
+#include "mlir/Support/LogicalResult.h"
 #include "triton/Analysis/Allocation.h"
 
 namespace mlir {
@@ -11,6 +12,13 @@ namespace nvidia_gpu {
 /// shared-memory allocation analysis.
 void runClusterBarrierInsertion(ModuleAllocation &moduleAllocation,
                                 int computeCapability);
+
+/// Inserts the mbarrier-init sequencing ops
+/// (fence_mbarrier_init_release_cluster + cluster_arrive/wait(relaxed=true))
+/// for cross-CTA mbarriers using the provided allocation analysis.
+LogicalResult
+runCrossCTAMBarrierInitSyncInsertion(ModuleAllocation &moduleAllocation,
+                                     int computeCapability);
 
 } // namespace nvidia_gpu
 } // namespace triton

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h
@@ -24,6 +24,8 @@ bool hasCGABroadcast(gpu::MemDescType memDescType);
 
 Value sextI16ToI32Indices(Value indices, OpBuilder &builder, Location loc);
 
+bool hasCGABroadcast(gpu::MemDescType memDescType);
+
 inline SmallVector<int64_t> getTMABlockShape(Attribute encoding,
                                              ArrayRef<int64_t> shapePerCTA,
                                              bool packedSize,

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -210,18 +210,28 @@ private:
     return success();
   }
 
-  SmallVector<Value>
-  treeReduceBinary(Location loc, ConversionPatternRewriter &rewriter,
-                   Region &combineOp,
-                   SmallVector<SmallVector<Value>> values) const {
-    // The number of elements is always a power of two
-    assert(llvm::isPowerOf2_64(values.size()) && !values.empty());
+  // Reduce values using a tree of the given arity. Arity=3 generates
+  // combine(combine(a, b), c) groups that LLVM folds into ternary
+  // instructions (e.g. v_maximum3_f32 on AMD).
+  SmallVector<Value> treeReduce(Location loc,
+                                ConversionPatternRewriter &rewriter,
+                                Region &combineOp,
+                                SmallVector<SmallVector<Value>> values,
+                                unsigned arity) const {
+    assert(!values.empty() && arity >= 2);
     while (values.size() > 1) {
       SmallVector<SmallVector<Value>> next;
-      for (size_t i = 0; i + 1 < values.size(); i += 2) {
-        SmallVector<Value> acc = values[i];
-        accumulate(loc, rewriter, combineOp, acc, values[i + 1]);
-        next.push_back(std::move(acc));
+      for (size_t i = 0; i < values.size(); i += arity) {
+        size_t remaining = values.size() - i;
+        size_t groupSize = std::min(static_cast<size_t>(arity), remaining);
+        if (groupSize == 1) {
+          next.push_back(std::move(values[i]));
+        } else {
+          SmallVector<Value> acc = std::move(values[i]);
+          for (size_t j = 1; j < groupSize; ++j)
+            accumulate(loc, rewriter, combineOp, acc, values[i + j]);
+          next.push_back(std::move(acc));
+        }
       }
       values = std::move(next);
     }
@@ -636,9 +646,10 @@ private:
       auto elemTy = operandType.getElementType();
       auto vectorCombineRegion = createVectorCombineRegion(
           op.getLoc(), elemTy, vectorizeKind, rewriter);
-      auto reduced =
-          treeReduceBinary(op.getLoc(), rewriter, *vectorCombineRegion,
-                           std::move(packedValues));
+      Operation &combinerOp = vectorCombineRegion->front().front();
+      unsigned arity = targetInfo.getReductionTreeArity(&combinerOp);
+      auto reduced = treeReduce(op.getLoc(), rewriter, *vectorCombineRegion,
+                                std::move(packedValues), arity);
 
       SmallVector<SmallVector<Value>> reducedByOperand(numOperands);
       for (unsigned opIdx = 0; opIdx < numOperands; ++opIdx)
@@ -715,6 +726,10 @@ private:
     Region &combineRegion =
         vectorCombineRegion ? *vectorCombineRegion : op.getCombineOp();
 
+    Operation &combinerOp = combineRegion.front().front();
+    unsigned arity = targetInfo.getReductionTreeArity(&combinerOp);
+
+    // Perform a tree reduction
     unsigned numOperands = accs.size();
     SmallVector<SmallVector<Value>> reduced(numOperands);
     unsigned regs = accs.front().size();
@@ -727,7 +742,7 @@ private:
         vals.push_back(std::move(cur));
       }
       auto acc =
-          treeReduceBinary(loc, rewriter, combineRegion, std::move(vals));
+          treeReduce(loc, rewriter, combineRegion, std::move(vals), arity);
       for (unsigned opIdx = 0; opIdx < numOperands; ++opIdx)
         reduced[opIdx].push_back(acc[opIdx]);
     }

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -201,6 +201,14 @@ LogicalResult InitBarrierOp::verify() {
     return failure();
   if (getCount() < 1)
     return emitOpError("count must be greater than or equal to 1");
+  auto barrierTy = cast<MemDescType>(getAlloc().getType());
+  // We cannot place cluster barriers inside warp-specialize regions, and we
+  // need to place a relaxed cluster barrier between barrier.init and the first
+  // barrier use.
+  bool crossCTA = barrierTy.getShape()[0] != gpu::lookupNumCTAs(getOperation());
+  if (crossCTA &&
+      getOperation()->getParentOfType<mlir::triton::gpu::WarpSpecializeOp>())
+    return emitOpError("cannot be used inside `ttg.warp_specialize`");
   return success();
 }
 
@@ -599,6 +607,9 @@ LogicalResult AsyncTMACopyGlobalToLocalOp::verify() {
                            isIm2Col ? TensorMode::IM2COL : TensorMode::TILED,
                            getCoord(), getOffsets())))
     return failure();
+  if (getMulticast() && !hasCGABroadcast(resultType))
+    return emitOpError(
+        "multicast requires the shared layout to broadcast across CTAs");
   return success();
 }
 
@@ -897,6 +908,9 @@ void TCGen5MMAOp::getEffects(
   }
   effects.emplace_back(MemoryEffects::Read::get(), &getBMutable(),
                        SharedMemory::get());
+  for (auto &barrierMutable : getBarriersMutable())
+    effects.emplace_back(MemoryEffects::Write::get(), &barrierMutable,
+                         SharedMemory::get());
 }
 
 bool TCGen5MMAOp::verifyDims() {
@@ -1132,6 +1146,9 @@ void TCGen5MMAScaledOp::getEffects(
                        TensorMemory::get());
   effects.emplace_back(MemoryEffects::Read::get(), &getBScaleMutable(),
                        TensorMemory::get());
+  for (auto &barrierMutable : getBarriersMutable())
+    effects.emplace_back(MemoryEffects::Write::get(), &barrierMutable,
+                         SharedMemory::get());
 }
 
 bool TCGen5MMAScaledOp::verifyDims() {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -5,8 +5,12 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
+#include "mlir/IR/Dominance.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ErrorHandling.h"
 
@@ -57,6 +61,244 @@ static bool isPreAllocAliasSliceFilter(const AllocationSlice &lhsSlice,
   return bufferId != Allocation::InvalidBufferId &&
          bufferId == rhsSlice.getBufferId() &&
          allocation->isExplicitBuffer(bufferId);
+}
+
+static bool isCrossCTAMBarrier(ttng::InitBarrierOp initBarrierOp, int numCTAs) {
+  auto barrierTy = cast<ttg::MemDescType>(initBarrierOp.getAlloc().getType());
+  return barrierTy.getShape()[0] != numCTAs;
+}
+
+static bool valueAliasesTrackedBuffers(Value value,
+                                       const Allocation::BufferIdSetT &tracked,
+                                       Allocation *allocation) {
+  for (auto bufferId : allocation->getAllBufferIdsWithAliases(value)) {
+    if (bufferId != Allocation::InvalidBufferId && tracked.contains(bufferId))
+      return true;
+  }
+  return false;
+}
+
+static bool
+usesTrackedBarrierInCrossCTAConsumerOp(Operation *op,
+                                       const Allocation::BufferIdSetT &tracked,
+                                       Allocation *allocation) {
+  auto aliasesTracked = [&](Value value) {
+    return value && valueAliasesTrackedBuffers(value, tracked, allocation);
+  };
+
+  if (auto mma = dyn_cast<ttng::TCGen5MMAOp>(op)) {
+    return mma.getTwoCtas() && llvm::any_of(mma.getBarriers(), aliasesTracked);
+  }
+  if (auto mmaScaled = dyn_cast<ttng::TCGen5MMAScaledOp>(op)) {
+    return mmaScaled.getTwoCtas() &&
+           llvm::any_of(mmaScaled.getBarriers(), aliasesTracked);
+  }
+  if (auto commit = dyn_cast<ttng::TCGen5CommitOp>(op)) {
+    return ttng::getModuleTwoCTAs(op) && aliasesTracked(commit.getBarrier());
+  }
+  if (auto tma = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+    return tma.getMulticast() && aliasesTracked(tma.getBarrier());
+  }
+  return false;
+}
+
+static bool requiresCrossCTAMBarrierInitSync(ttng::InitBarrierOp initBarrierOp,
+                                             FunctionOpInterface funcOp,
+                                             Allocation *allocation,
+                                             int numCTAs) {
+  // Barrier init sync is needed for barriers that are themselves cross-CTA,
+  // and also for per-CTA barriers consumed by multi-CTA ops that multicast or
+  // otherwise fan out barrier state across the cluster.
+  if (isCrossCTAMBarrier(initBarrierOp, numCTAs))
+    return true;
+
+  Allocation::BufferIdSetT initBarrierBuffers;
+  for (auto bufferId :
+       allocation->getAllBufferIdsWithAliases(initBarrierOp.getAlloc())) {
+    assert(bufferId != Allocation::InvalidBufferId);
+    initBarrierBuffers.insert(bufferId);
+  }
+
+  // Or if it's used by a multi-CTA consumer that broadcasts barrier state
+  // across CTAs even though the barrier allocation itself looks per-CTA.
+  return funcOp
+      ->walk<WalkOrder::PreOrder>([&](Operation *op) {
+        if (usesTrackedBarrierInCrossCTAConsumerOp(op, initBarrierBuffers,
+                                                   allocation)) {
+          return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      })
+      .wasInterrupted();
+}
+
+static bool nestedOpUsesTrackedMBarrier(Operation *op,
+                                        const Allocation::BufferIdSetT &tracked,
+                                        Allocation *allocation) {
+  if (isa<ttng::InitBarrierOp, ttg::LocalAllocOp>(op))
+    return false;
+
+  if (auto memEffects = dyn_cast<MemoryEffectOpInterface>(op)) {
+    SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>> effects;
+    memEffects.getEffects(effects);
+    for (const auto &effect : effects) {
+      Value value = effect.getValue();
+      if (value && valueAliasesTrackedBuffers(value, tracked, allocation))
+        return true;
+    }
+  }
+  return false;
+}
+
+static bool opUsesTrackedMBarrier(Operation *op,
+                                  const Allocation::BufferIdSetT &tracked,
+                                  Allocation *allocation) {
+  return op
+      ->walk<WalkOrder::PreOrder>([&](Operation *nestedOp) {
+        if (nestedOpUsesTrackedMBarrier(nestedOp, tracked, allocation))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      })
+      .wasInterrupted();
+}
+
+static LogicalResult
+insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
+                                          Allocation *allocation, int numCTAs,
+                                          OpBuilder &builder) {
+  if (!funcOp || funcOp->getNumRegions() != 1) {
+    return funcOp.emitOpError(
+        "cross-CTA mbarrier init sync insertion requires a single function "
+        "top-level region");
+  }
+  Region &topLevelRegion = funcOp->getRegion(0);
+  llvm::SetVector<Operation *> crossCTAInitAnchors;
+  Allocation::BufferIdSetT trackedBarrierBuffers;
+
+  // Find all cross-CTA mbarrier.init ops and map each
+  // one to the containing top-level op that bounds the insertion window.
+  funcOp.walk([&](ttng::InitBarrierOp initBarrierOp) {
+    if (!requiresCrossCTAMBarrierInitSync(initBarrierOp, funcOp, allocation,
+                                          numCTAs))
+      return;
+    Operation *topLevelAnchor =
+        topLevelRegion.findAncestorOpInRegion(*initBarrierOp.getOperation());
+    assert(topLevelAnchor && "init op must be inside the function region");
+    crossCTAInitAnchors.insert(topLevelAnchor);
+    for (auto bufferId :
+         allocation->getAllBufferIdsWithAliases(initBarrierOp.getAlloc())) {
+      assert(bufferId != Allocation::InvalidBufferId);
+      trackedBarrierBuffers.insert(bufferId);
+    }
+  });
+  // Nothing to do
+  if (crossCTAInitAnchors.empty())
+    return success();
+
+  llvm::SetVector<Operation *> trackedUseAnchors;
+  for (Block &block : topLevelRegion) {
+    for (Operation &op : block) {
+      if (opUsesTrackedMBarrier(&op, trackedBarrierBuffers, allocation))
+        trackedUseAnchors.insert(&op);
+    }
+  }
+  if (trackedUseAnchors.empty()) {
+    return funcOp.emitOpError("found at least one mbarrier.init op but could "
+                              "not find any mbarrier use");
+  }
+
+  // Find the earliest insertion point that postdominates every tracked init.
+  PostDominanceInfo postDomInfo(funcOp);
+  llvm::SmallPtrSet<Block *, 8> initBlocks;
+  for (Operation *crossCTAInitAnchor : crossCTAInitAnchors)
+    initBlocks.insert(crossCTAInitAnchor->getBlock());
+  Block *firstInsertionBlock =
+      postDomInfo.findNearestCommonDominator(initBlocks);
+  if (!firstInsertionBlock) {
+    return funcOp.emitOpError(
+        "could not find a common post-dominating insertion block for "
+        "cross-CTA mbarrier.init");
+  }
+
+  Operation *lastInitInInsertionBlock = nullptr;
+  for (Operation *crossCTAInitAnchor : crossCTAInitAnchors) {
+    if (crossCTAInitAnchor->getBlock() != firstInsertionBlock)
+      continue;
+    if (!lastInitInInsertionBlock ||
+        lastInitInInsertionBlock->isBeforeInBlock(crossCTAInitAnchor)) {
+      lastInitInInsertionBlock = crossCTAInitAnchor;
+    }
+  }
+  Operation *firstInsertionAnchor =
+      lastInitInInsertionBlock ? lastInitInInsertionBlock->getNextNode()
+                               : &firstInsertionBlock->front();
+
+  // Find the latest insertion point that still dominates every tracked use.
+  DominanceInfo domInfo(funcOp);
+  llvm::SmallPtrSet<Block *, 8> useBlocks;
+  for (Operation *trackedUseAnchor : trackedUseAnchors)
+    useBlocks.insert(trackedUseAnchor->getBlock());
+  Block *lastInsertionBlock = domInfo.findNearestCommonDominator(useBlocks);
+  if (!lastInsertionBlock) {
+    return funcOp.emitOpError(
+        "could not find a common insertion block that dominates all tracked "
+        "mbarrier uses");
+  }
+
+  Operation *firstTrackedUseInInsertionBlock = nullptr;
+  for (Operation *trackedUseAnchor : trackedUseAnchors) {
+    if (trackedUseAnchor->getBlock() != lastInsertionBlock)
+      continue;
+    if (!firstTrackedUseInInsertionBlock ||
+        trackedUseAnchor->isBeforeInBlock(firstTrackedUseInInsertionBlock)) {
+      firstTrackedUseInInsertionBlock = trackedUseAnchor;
+    }
+  }
+  Operation *lastInsertionAnchor = firstTrackedUseInInsertionBlock
+                                       ? firstTrackedUseInInsertionBlock
+                                       : lastInsertionBlock->getTerminator();
+
+  if (!domInfo.dominates(firstInsertionAnchor, lastInsertionAnchor)) {
+    return funcOp.emitOpError(
+        "could not find an insertion point between cross-CTA mbarrier.init "
+        "ops and tracked mbarrier uses");
+  }
+
+  // Reuse the latest cluster barrier that lies between the init-side and
+  // use-side insertion boundaries.
+  ttng::ClusterBarrierOp reusedClusterBarrier;
+  for (Block &block : topLevelRegion) {
+    for (Operation &op : block) {
+      auto clusterBarrier = dyn_cast<ttng::ClusterBarrierOp>(&op);
+      if (!clusterBarrier)
+        continue;
+      if (!postDomInfo.postDominates(clusterBarrier.getOperation(),
+                                     firstInsertionAnchor))
+        continue;
+      if (!domInfo.dominates(clusterBarrier.getOperation(),
+                             lastInsertionAnchor))
+        continue;
+      if (!reusedClusterBarrier ||
+          domInfo.properlyDominates(reusedClusterBarrier.getOperation(),
+                                    clusterBarrier.getOperation())) {
+        reusedClusterBarrier = clusterBarrier;
+      }
+    }
+  }
+
+  OpBuilder::InsertionGuard guard(builder);
+  Operation *fenceInsertionPoint =
+      reusedClusterBarrier && reusedClusterBarrier.getRelaxed()
+          ? reusedClusterBarrier.getOperation()
+          : lastInsertionAnchor;
+  builder.setInsertionPoint(fenceInsertionPoint);
+  Location loc = lastInitInInsertionBlock
+                     ? lastInitInInsertionBlock->getLoc()
+                     : crossCTAInitAnchors.front()->getLoc();
+  ttng::FenceMBarrierInitReleaseClusterOp::create(builder, loc);
+  if (!reusedClusterBarrier)
+    ttng::ClusterBarrierOp::create(builder, loc, /*relaxed=*/true);
+  return success();
 }
 
 class ClusterBarrierAnalysis : public MembarOrFenceAnalysis {
@@ -187,6 +429,32 @@ void runClusterBarrierInsertion(ModuleAllocation &moduleAllocation,
   ModuleMembarOrFenceAnalysis<ClusterBarrierAnalysis> analysis(
       &moduleAllocation, filterFn);
   analysis.run();
+}
+
+LogicalResult
+runCrossCTAMBarrierInitSyncInsertion(ModuleAllocation &moduleAllocation,
+                                     int computeCapability) {
+  ModuleOp mod = moduleAllocation.getModuleOp();
+  if (computeCapability < 90)
+    return success();
+  int numCTAs = ttg::TritonGPUDialect::getNumCTAs(mod);
+  if (numCTAs == 1)
+    return success();
+
+  LogicalResult status = success();
+  moduleAllocation.walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
+      [](CallOpInterface callOp, FunctionOpInterface funcOp) {},
+      [&](FunctionOpInterface funcOp) {
+        if (failed(status))
+          return;
+        auto *allocation = moduleAllocation.getFuncData(funcOp);
+        OpBuilder builder(funcOp);
+        if (failed(insertCrossCTAMBarrierInitSyncForFunction(
+                funcOp, allocation, numCTAs, builder))) {
+          status = failure();
+        }
+      });
+  return status;
 }
 
 } // namespace nvidia_gpu

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.cpp
@@ -37,6 +37,13 @@ Value sextI16ToI32Indices(Value indices, OpBuilder &builder, Location loc) {
       builder, loc, indicesType.clone(builder.getI32Type()), indices);
 }
 
+bool hasCGABroadcast(ttg::MemDescType memDescType) {
+  auto kBlock = StringAttr::get(memDescType.getContext(), "block");
+  return ttg::toLinearLayout(memDescType)
+             .getFreeVariableMasks()
+             .lookup(kBlock) != 0;
+}
+
 FailureOr<int> getTMASwizzleMode(Location loc, tt::TensorDescInterface ty) {
   auto encoding = ty.getSharedLayout();
   auto mmaEncoding =

--- a/python/examples/gluon/03-matmul-multicta.py
+++ b/python/examples/gluon/03-matmul-multicta.py
@@ -523,8 +523,6 @@ def _matmul_kernel(
     clc_result_buffers = gl.allocate_shared_memory(gl.int64, [clc_barriers.shape[0], 2], clc_layout)
     clc_planar_pid_buffers = gl.allocate_shared_memory(gl.int64, [clc_barriers.shape[0], 1], clc_layout)
 
-    if gl.num_ctas() > 1:
-        mbarrier.sync_cluster_init()
     p = PartitionArgs(
         a_desc,
         b_desc,

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -21,6 +21,7 @@
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "triton/Tools/GenericSwizzling.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/LinearLayout.h"
@@ -992,16 +993,19 @@ void init_gluon_ir(py::module &&m) {
              self.create<ttng::TCGen5CommitOp>(barrier, pred, descs);
            })
 
-      .def("create_async_tma_copy_global_to_local",
-           [](GluonOpBuilder &self, Value descPtr, std::vector<Value> &coord,
-              Value barrier, Value result, Value pred, bool multicast,
-              std::optional<std::vector<Value>> offsets) {
-             ValueRange offsetsRange =
-                 offsets.has_value() ? ValueRange(*offsets) : ValueRange{};
-             self.create<ttng::AsyncTMACopyGlobalToLocalOp>(
-                 /*multicastTargets*/ Value(), descPtr, coord, offsetsRange,
-                 barrier, result, pred);
-           })
+      .def(
+          "create_async_tma_copy_global_to_local",
+          [](GluonOpBuilder &self, Value descPtr, std::vector<Value> &coord,
+             Value barrier, Value result, Value pred, bool multicast,
+             std::optional<std::vector<Value>> offsets) {
+            multicast &=
+                ttng::hasCGABroadcast(cast<ttg::MemDescType>(result.getType()));
+            ValueRange offsetsRange =
+                offsets.has_value() ? ValueRange(*offsets) : ValueRange{};
+            self.create<ttng::AsyncTMACopyGlobalToLocalOp>(
+                /*multicastTargets=*/Value(), descPtr, coord, offsetsRange,
+                barrier, result, pred, multicast);
+          })
       .def("create_async_tma_copy_local_to_global",
            [](GluonOpBuilder &self, Value descPtr, std::vector<Value> &coord,
               Value src) {

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -26,7 +26,7 @@ from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia.ampere import async_copy, mma_v2
-from triton.experimental.gluon.language.nvidia.hopper import tma, mbarrier
+from triton.experimental.gluon.language.nvidia.hopper import tma, mbarrier, fence_async_shared
 from triton.experimental.gluon.language.nvidia import hopper
 from triton.experimental.gluon.language.amd.cdna4 import async_copy as cdna4_async_copy
 from triton.experimental.gluon.language.extra import libdevice
@@ -273,9 +273,6 @@ def tma_multicast_copy_kernel(in_desc, out_desc):
 
     bar = mbarrier.allocate_mbarrier()
     mbarrier.init(bar, count=1)
-    # Need to synchronise all the CTAs after the mbarrier initialisation
-    # so that they all see it before tma.async_copy_global_to_shared(multicast=True)
-    ttgl.barrier(cluster=True)
 
     mbarrier.expect(bar, in_desc.nbytes_per_cta)
     tma.async_copy_global_to_shared(in_desc, [0, 0], bar, smem, multicast=True)
@@ -331,10 +328,6 @@ def tcgen05_mma_multicast_commit_kernel(a_desc, b_desc, out_ptrs, BLOCK_M: ttgl.
     mbarrier.init(tma_bar, count=1)
     mma_bar = mbarrier.allocate_mbarrier()
     mbarrier.init(mma_bar, count=tcgen05_mma_barrier_count([smem_a, smem_b], True))
-
-    # Need to synchronise all the CTAs after the mbarrier initialisation
-    # so that they all see it before tma.async_copy_global_to_shared(multicast=True)
-    mbarrier.sync_cluster_init()
 
     mbarrier.expect(tma_bar, a_desc.nbytes_per_cta + b_desc.nbytes_per_cta)
     tma.async_copy_global_to_shared(a_desc, [0, 0], tma_bar, smem_a, multicast=True)
@@ -449,6 +442,8 @@ def test_tcgen05_mma_multicast_commit(ctas_per_cga, two_ctas):
     )
 
     assert "tcgen05.commit.cta_group::" + ("2" if two_ctas else "1") in compiled.asm["ptx"]
+    if two_ctas:
+        assert "fence.mbarrier_init.release.cluster" in compiled.asm["ptx"]
     # For [2, 1] and two_ctas we don't multicast as there are not enough tiles
     # but we do a commit.multicast::cluster so let's grep that one instead
     assert ("multicast::cluster" in compiled.asm["ptx"])
@@ -702,12 +697,9 @@ def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexp
 
     if USE_TCGEN05:
         two_ctas: ttgl.constexpr = acc_layout.two_ctas
+        fence_async_shared(cluster=two_ctas)
         mma_barrier = mbarrier.allocate_mbarrier()
         mbarrier.init(mma_barrier, count=1)
-        # Need to synchronise all the CTAs after the mbarrier initialisation
-        # so that they all see it
-        if two_ctas:
-            ttgl.barrier(cluster=True)
 
         acc_tmem = allocate_tensor_memory(acc_dtype, [M, N], acc_layout)
 
@@ -850,11 +842,6 @@ def tma_mma_shared_inputs_kernel(a_desc, b_desc, out_ptr, BLOCK_M: ttgl.constexp
         )
     else:
         acc = ttgl.zeros([BLOCK_M, BLOCK_N], dtype=ttgl.float32, layout=acc_layout)
-
-    # Need to synchronise all the CTAs after the mbarrier initialisation before we do
-    # cross-CTA ops
-    if (multicast and ttgl.num_ctas() > 1) or two_ctas:
-        mbarrier.sync_cluster_init()
 
     for k in range(NUM_K_TILES):
         mbarrier.expect(tma_bar, a_desc.nbytes_per_cta + b_desc.nbytes_per_cta)
@@ -1210,6 +1197,8 @@ def test_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps,
     )
 
     assert two_ctas == ("two_ctas" in compiled.asm["ttgir"])
+    if two_ctas:
+        assert "fence.mbarrier_init.release.cluster" in compiled.asm["ptx"]
 
     try:
         allow_tf32 = torch.backends.cuda.matmul.allow_tf32

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -702,32 +702,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 """,
     )
 
-
-@gluon.jit
-def mbarrier_sync_cluster_init_kernel():
-    mbarrier.sync_cluster_init()
-
-
-def test_mbarrier_sync_cluster_init():
-    mod = run_parser(mbarrier_sync_cluster_init_kernel, *make_args(num_ctas=2), target=HOPPER_TARGET)
-    expecttest.assert_expected_inline(
-        anonymize_ir(mod.str_nodebug()),
-        """\
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @mbarrier_sync_cluster_init_kernel() attributes {noinline = false} {
-    tt.call @triton.experimental.gluon.language.nvidia.hopper.mbarrier.sync_cluster_init____() : () -> ()
-    tt.return
-  }
-  tt.func private @triton.experimental.gluon.language.nvidia.hopper.mbarrier.sync_cluster_init____() attributes {noinline = false} {
-    ttng.fence_mbarrier_init_release_cluster
-    ttng.cluster_barrier {relaxed = true}
-    tt.return
-  }
-}
-""",
-    )
-
-
 @gluon.jit
 def ampere_mbarrier_arrive_kernel():
     bar = ttgl.allocate_shared_memory(ttgl.int64, [1], ampere_mbarrier.MBarrierLayout())

--- a/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
@@ -1,7 +1,5 @@
 from ..ampere.mbarrier import MBarrierLayout, allocate_mbarrier, init, invalidate, wait
-from triton.experimental.gluon._runtime import jit
 from ..._core import _unwrap_if_constexpr, builtin
-from . import cluster
 
 __all__ = [
     "allocate_mbarrier",
@@ -77,12 +75,3 @@ def fence_init_release_cluster(_semantic=None):
     Needs to be called together with cluster.barrier(relaxed=True).
     """
     _semantic.builder.create_fence_mbarrier_init_release_cluster()
-
-
-@jit
-def sync_cluster_init():
-    """
-    Ensure mbarrier initialization is visible across the CTA cluster.
-    """
-    fence_init_release_cluster()
-    cluster.barrier(relaxed=True)

--- a/test/Conversion/amd/reduce_tree_vectorize.mlir
+++ b/test/Conversion/amd/reduce_tree_vectorize.mlir
@@ -59,4 +59,59 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     }) : (tensor<1x128xf32, #blocked_reduce>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
     tt.return
   }
+
+  // Ternary tree reduction for max/min: generates a chain of 3 dependent ops
+  // per group so LLVM can fold into v_maximum3/v_minimum3/v_max3/v_min3.
+
+  // GFX1250-LABEL: reduce_maximum_f32_ternary
+  // GFX1250: %[[A:.*]] = llvm.intr.maximum(%{{.*}}, %{{.*}}) : (f32, f32) -> f32
+  // GFX1250-NEXT: %[[B:.*]] = llvm.intr.maximum(%[[A]], %{{.*}}) : (f32, f32) -> f32
+  // GFX1250-NEXT: %[[C:.*]] = llvm.intr.maximum(%[[B]], %{{.*}}) : (f32, f32) -> f32
+  tt.func public @reduce_maximum_f32_ternary(%arg0: tensor<1x128xf32, #blocked_reduce>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%a: f32, %b: f32):
+      %max = arith.maximumf %a, %b : f32
+      tt.reduce.return %max : f32
+    }) : (tensor<1x128xf32, #blocked_reduce>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    tt.return
+  }
+
+  // GFX1250-LABEL: reduce_minimum_f32_ternary
+  // GFX1250: %[[A:.*]] = llvm.intr.minimum(%{{.*}}, %{{.*}}) : (f32, f32) -> f32
+  // GFX1250-NEXT: %[[B:.*]] = llvm.intr.minimum(%[[A]], %{{.*}}) : (f32, f32) -> f32
+  // GFX1250-NEXT: %[[C:.*]] = llvm.intr.minimum(%[[B]], %{{.*}}) : (f32, f32) -> f32
+  tt.func public @reduce_minimum_f32_ternary(%arg0: tensor<1x128xf32, #blocked_reduce>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%a: f32, %b: f32):
+      %min = arith.minimumf %a, %b : f32
+      tt.reduce.return %min : f32
+    }) : (tensor<1x128xf32, #blocked_reduce>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    tt.return
+  }
+
+  // GFX1250-LABEL: reduce_maxnum_f32_ternary
+  // GFX1250: %[[A:.*]] = llvm.intr.maxnum(%{{.*}}, %{{.*}}) : (f32, f32) -> f32
+  // GFX1250-NEXT: %[[B:.*]] = llvm.intr.maxnum(%[[A]], %{{.*}}) : (f32, f32) -> f32
+  // GFX1250-NEXT: %[[C:.*]] = llvm.intr.maxnum(%[[B]], %{{.*}}) : (f32, f32) -> f32
+  tt.func public @reduce_maxnum_f32_ternary(%arg0: tensor<1x128xf32, #blocked_reduce>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%a: f32, %b: f32):
+      %max = arith.maxnumf %a, %b : f32
+      tt.reduce.return %max : f32
+    }) : (tensor<1x128xf32, #blocked_reduce>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    tt.return
+  }
+
+  // GFX1250-LABEL: reduce_minnum_f32_ternary
+  // GFX1250: %[[A:.*]] = llvm.intr.minnum(%{{.*}}, %{{.*}}) : (f32, f32) -> f32
+  // GFX1250-NEXT: %[[B:.*]] = llvm.intr.minnum(%[[A]], %{{.*}}) : (f32, f32) -> f32
+  // GFX1250-NEXT: %[[C:.*]] = llvm.intr.minnum(%[[B]], %{{.*}}) : (f32, f32) -> f32
+  tt.func public @reduce_minnum_f32_ternary(%arg0: tensor<1x128xf32, #blocked_reduce>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%a: f32, %b: f32):
+      %min = arith.minnumf %a, %b : f32
+      tt.reduce.return %min : f32
+    }) : (tensor<1x128xf32, #blocked_reduce>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    tt.return
+  }
 }

--- a/test/Conversion/amd/reduce_tree_vectorize.mlir
+++ b/test/Conversion/amd/reduce_tree_vectorize.mlir
@@ -1,0 +1,61 @@
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 -cse | FileCheck %s --check-prefix=GFX942
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 -cse | FileCheck %s --check-prefix=GFX950
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 -cse | FileCheck %s --check-prefix=GFX1250
+
+#blocked_reduce = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 64], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // GFX942-LABEL: reduce_f16
+  // GFX942: llvm.fadd {{.*}} : vector<2xf16>
+  // GFX950-LABEL: reduce_f16
+  // GFX950: llvm.fadd {{.*}} : vector<2xf16>
+  tt.func public @reduce_f16(%arg0: tensor<1x256xf16, #blocked_reduce>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%a: f16, %b: f16):
+      %sum = arith.addf %a, %b : f16
+      tt.reduce.return %sum : f16
+    }) : (tensor<1x256xf16, #blocked_reduce>) -> tensor<1xf16, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    tt.return
+  }
+
+  // GFX942-LABEL: reduce_f32
+  // GFX942-NOT: llvm.fadd {{.*}} : vector<2xf32>
+  // GFX942: llvm.return
+  // GFX950-LABEL: reduce_f32
+  // GFX950-NOT: llvm.fadd {{.*}} : vector<2xf32>
+  // GFX950: llvm.return
+  tt.func public @reduce_f32(%arg0: tensor<1x256xf32, #blocked_reduce>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%a: f32, %b: f32):
+      %sum = arith.addf %a, %b : f32
+      tt.reduce.return %sum : f32
+    }) : (tensor<1x256xf32, #blocked_reduce>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked_reduce = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // GFX1250-LABEL: reduce_f16_tree_vectorize
+  // GFX1250: llvm.fadd {{.*}} : vector<2xf16>
+  tt.func public @reduce_f16_tree_vectorize(%arg0: tensor<1x128xf16, #blocked_reduce>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%a: f16, %b: f16):
+      %sum = arith.addf %a, %b : f16
+      tt.reduce.return %sum : f16
+    }) : (tensor<1x128xf16, #blocked_reduce>) -> tensor<1xf16, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    tt.return
+  }
+
+  // GFX1250-LABEL: reduce_f32_tree_vectorize
+  // GFX1250: llvm.fadd {{.*}} : vector<2xf32>
+  tt.func public @reduce_f32_tree_vectorize(%arg0: tensor<1x128xf32, #blocked_reduce>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%a: f32, %b: f32):
+      %sum = arith.addf %a, %b : f32
+      tt.reduce.return %sum : f32
+    }) : (tensor<1x128xf32, #blocked_reduce>) -> tensor<1xf32, #ttg.slice<{dim = 1, parent = #blocked_reduce}>>
+    tt.return
+  }
+}

--- a/test/Conversion/amd/reduce_tree_vectorize.mlir
+++ b/test/Conversion/amd/reduce_tree_vectorize.mlir
@@ -1,3 +1,4 @@
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx90a -cse | FileCheck %s --check-prefix=GFX90A
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx942 -cse | FileCheck %s --check-prefix=GFX942
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx950 -cse | FileCheck %s --check-prefix=GFX950
 // RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=gfx-arch=gfx1250 -cse | FileCheck %s --check-prefix=GFX1250
@@ -17,12 +18,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     tt.return
   }
 
+  // GFX90A-LABEL: reduce_f32
+  // GFX90A: llvm.fadd {{.*}} : vector<2xf32>
   // GFX942-LABEL: reduce_f32
-  // GFX942-NOT: llvm.fadd {{.*}} : vector<2xf32>
-  // GFX942: llvm.return
+  // GFX942: llvm.fadd {{.*}} : vector<2xf32>
   // GFX950-LABEL: reduce_f32
-  // GFX950-NOT: llvm.fadd {{.*}} : vector<2xf32>
-  // GFX950: llvm.return
+  // GFX950: llvm.fadd {{.*}} : vector<2xf32>
   tt.func public @reduce_f32(%arg0: tensor<1x256xf32, #blocked_reduce>) {
     %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
     ^bb0(%a: f32, %b: f32):

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -17,10 +17,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: init_barrier_cluster_broadcast
-  tt.func @init_barrier_cluster_broadcast(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>) {
+  tt.func @init_barrier_cluster_broadcast() {
+    %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<1xi64, #shared0, #smem, mutable>
     // CHECK: nvg.cluster_id
     // CHECK: @$0 mbarrier.init.shared::cta.b64 [$1], 2;
-    ttng.init_barrier %alloc, 1 : !ttg.memdesc<1xi64, #shared0, #smem>
+    ttng.init_barrier %alloc, 1 : !ttg.memdesc<1xi64, #shared0, #smem, mutable>
+    ttng.inval_barrier %alloc : !ttg.memdesc<1xi64, #shared0, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -538,6 +538,27 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
+  tt.func @init_barrier_in_default_region_invalid() {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttg.warp_specialize()
+    default {
+      // expected-error @below {{cannot be used inside `ttg.warp_specialize`}}
+      ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+
+// -----
+
 // expected-error @+1 {{After removing the zero bases the layout must be bijective}}
 #linear = #ttg.linear<{register = [[0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 1]], warp = [[16, 0], [8, 0]], block = []}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
@@ -637,6 +658,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %0 = ttng.tmem_alloc %cst_0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x128xi32, #blocked_nan_i32>) -> !ttg.memdesc<128x128xi32, #tmem_nan_i32, #ttng.tensor_memory, mutable>
     // expected-error @below {{'NaN' requires floating-point element type (f32)}}
     %result, %red = ttng.tmem_load %0 {redOp = #ttng.redOp<min>, NaN = true} : !ttg.memdesc<128x128xi32, #tmem_nan_i32, #ttng.tensor_memory, mutable> -> tensor<128x128xi32, #blocked_nan_i32>, tensor<128xi32, #blocked_red_nan_i32>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+#nvmma_no_broadcast = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @async_tma_copy_multicast_requires_broadcast(%arg0: !tt.tensordesc<64x128xf16, #nvmma_no_broadcast>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmma_no_broadcast, #smem, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    // expected-error @below {{multicast requires the shared layout to broadcast across CTAs}}
+    ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %0, %1, %true {multicast} : !tt.tensordesc<64x128xf16, #nvmma_no_broadcast>, !ttg.memdesc<1xi64, #shared_bar, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma_no_broadcast, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -25,6 +25,117 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#barrierEncPartial = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @insert_fence_and_relaxed_cluster_barrier_at_window_end_after_existing_fence
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
+  // CHECK-NEXT: ttng.wait_barrier
+  tt.func @insert_fence_and_relaxed_cluster_barrier_at_window_end_after_existing_fence() {
+    %c0 = arith.constant 0 : i32
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEncPartial, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEncPartial, #smem, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.wait_barrier %barrier, %c0 : !ttg.memdesc<1xi64, #barrierEncPartial, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#barrierEncPartial = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Reuse an existing relaxed cluster barrier, but keep the fence immediately
+  // in front of it.
+  // CHECK-LABEL: @insert_fence_right_before_existing_relaxed_cluster_barrier
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
+  // CHECK-NEXT: ttng.wait_barrier
+  tt.func @insert_fence_right_before_existing_relaxed_cluster_barrier() {
+    %c0 = arith.constant 0 : i32
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEncPartial, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEncPartial, #smem, mutable>
+    ttng.cluster_barrier {relaxed = true}
+    ttng.wait_barrier %barrier, %c0 : !ttg.memdesc<1xi64, #barrierEncPartial, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#barrierEncWS = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @insert_fence_and_relaxed_cluster_barrier_before_warp_specialize
+  // CHECK: ttng.init_barrier
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
+  // CHECK-NEXT: ttg.warp_specialize
+  // CHECK: ttng.wait_barrier
+  tt.func @insert_fence_and_relaxed_cluster_barrier_before_warp_specialize(%idx: i32) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %barriers = ttg.local_alloc : () -> !ttg.memdesc<2x1xi64, #barrierEncWS, #smem, mutable>
+    %barrier0 = ttg.memdesc_index %barriers[%c0] : !ttg.memdesc<2x1xi64, #barrierEncWS, #smem, mutable> -> !ttg.memdesc<1xi64, #barrierEncWS, #smem, mutable>
+    ttng.init_barrier %barrier0, 1 : !ttg.memdesc<1xi64, #barrierEncWS, #smem, mutable>
+    %barrier1 = ttg.memdesc_index %barriers[%c1] : !ttg.memdesc<2x1xi64, #barrierEncWS, #smem, mutable> -> !ttg.memdesc<1xi64, #barrierEncWS, #smem, mutable>
+    ttng.init_barrier %barrier1, 1 : !ttg.memdesc<1xi64, #barrierEncWS, #smem, mutable>
+    ttg.warp_specialize()
+    default {
+      %barrier = ttg.memdesc_index %barriers[%idx] : !ttg.memdesc<2x1xi64, #barrierEncWS, #smem, mutable> -> !ttg.memdesc<1xi64, #barrierEncWS, #smem, mutable>
+      ttng.wait_barrier %barrier, %c0 : !ttg.memdesc<1xi64, #barrierEncWS, #smem, mutable>
+      ttg.warp_yield
+    }
+    partition0() num_warps(1) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#barrierEncCF = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // If branch-local init ops reconverge in CF, insert the sync at the join
+  // block before the first tracked use.
+  // CHECK-LABEL: @insert_fence_and_relaxed_cluster_barrier_at_cf_join_after_branch_inits
+  // CHECK: ttng.init_barrier
+  // CHECK: ttng.init_barrier
+  // CHECK: ^bb3:
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
+  // CHECK-NEXT: ttng.wait_barrier
+  tt.func @insert_fence_and_relaxed_cluster_barrier_at_cf_join_after_branch_inits(%pred: i1) {
+    %c0 = arith.constant 0 : i32
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEncCF, #smem, mutable>
+    cf.cond_br %pred, ^bb1, ^bb2
+  ^bb1:
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEncCF, #smem, mutable>
+    cf.br ^bb3
+  ^bb2:
+    ttng.init_barrier %barrier, 2 : !ttg.memdesc<1xi64, #barrierEncCF, #smem, mutable>
+    cf.br ^bb3
+  ^bb3:
+    ttng.wait_barrier %barrier, %c0 : !ttg.memdesc<1xi64, #barrierEncCF, #smem, mutable>
+    ttg.local_dealloc %barrier : !ttg.memdesc<1xi64, #barrierEncCF, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
 #slice0 = #ttg.slice<{dim = 0, parent = #blocked}>
 #slice1 = #ttg.slice<{dim = 1, parent = #blocked}>
@@ -103,14 +214,9 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
-  // TODO: Improve the heuristics so that we don't emit a cluster_arrive/wait when num-ctas == 2!
-  // A wait with explicit deps proves the inputs are no longer in use whenever num-ctas == 2 but
-  // we currently emit a cluster barrier
   // CHECK-LABEL: @mma_v5_two_ctas_wait_barrier_no_cluster
   // CHECK: ttng.init_barrier
-  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
-  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
-  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: ttng.tc_gen5_mma
   // CHECK: ttng.wait_barrier
   // CHECK: ttng.cluster_arrive
   // CHECK: ttng.cluster_wait
@@ -125,9 +231,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, "ttng.tw
     %true = arith.constant true
     %cst = arith.constant dense<0.000000e+00> : tensor<256x32xf16, #blocked>
     ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
-    ttng.fence_mbarrier_init_release_cluster
-    ttng.cluster_arrive {relaxed = true}
-    ttng.cluster_wait
     ttng.tc_gen5_mma %a, %b, %acc, %true, %true, %barrier[%true] {is_async, two_ctas} :
        !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>,
        !ttg.memdesc<32x128xf16, #sharedB, #smem, mutable>,
@@ -224,35 +327,28 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 #blockedTmaSrc = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 #blockedTmaDst = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
-#nvmmaTma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#nvmmaTma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
 #barrierEncTma = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // Non-distributed convert_layout followed by multicast TMA should still
   // insert a cluster barrier before the TMA.
-  // TODO: There is a world where we can do better:
-  // 1. We emit the relaxed = false cluster_arrive/wait pair automatically
-  // 2. We realise that we can avoid emitting it there as there is a cluster barrier after the convert_layout
+  // We can reuse the one already inserted after the convert_layout and only add
+  // the fence here.
   // CHECK-LABEL: @convert_layout_trivial_then_tma_multicast_cluster_barrier
   // CHECK: ttng.init_barrier
-  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
-  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
-  // CHECK-NEXT: ttng.cluster_wait
-  // CHECK-NOT: ttng.cluster_wait
-  // CHECK-NOT: ttg.barrier local
   // CHECK: ttg.convert_layout
   // CHECK: ttng.cluster_arrive
   // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
   // CHECK-NEXT: ttng.async_tma_copy_global_to_local
   tt.func @convert_layout_trivial_then_tma_multicast_cluster_barrier(%input: tensor<64x128xf16, #blockedTmaSrc>, %desc: !tt.tensordesc<64x128xf16, #nvmmaTma>) -> tensor<64x128xf16, #blockedTmaDst> {
     %c0 = arith.constant 0 : i32
     %true = arith.constant true
     %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEncTma, #smem, mutable>
     ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEncTma, #smem, mutable>
-    ttng.fence_mbarrier_init_release_cluster
-    ttng.cluster_arrive {relaxed = true}
-    ttng.cluster_wait
     %cvt = ttg.convert_layout %input : tensor<64x128xf16, #blockedTmaSrc> -> tensor<64x128xf16, #blockedTmaDst>
     %dst = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmmaTma, #smem, mutable>
     ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %dst, %barrier, %true {multicast} :
@@ -306,9 +402,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
   // Negative test: no cluster barrier should be inserted for multiCTA MMA when the twoCTAs is not set
   // CHECK-LABEL: @no_cluster_mma_without_two_ctas
   // CHECK: ttng.init_barrier
-  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
-  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
-  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NOT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NOT: ttng.cluster_barrier {relaxed = true}
   // CHECK: tt.return
   tt.func @no_cluster_mma_without_two_ctas() -> tensor<128x16xf16, #blocked> {
     %true = arith.constant true
@@ -319,9 +414,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %acc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
     ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
-    ttng.fence_mbarrier_init_release_cluster
-    ttng.cluster_arrive {relaxed = true}
-    ttng.cluster_wait
     ttng.tc_gen5_mma %a, %b, %acc, %true, %true, %barrier[%true] {is_async} :
        !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable>,
        !ttg.memdesc<16x128xf16, #sharedB, #smem, mutable>,
@@ -343,18 +435,45 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // -----
 
-#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
 #barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Multicast TMA still needs init sync even if the barrier allocation shape
+  // looks per-CTA.
+  // CHECK-LABEL: @cluster_tma_multicast_with_per_cta_barrier
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  // CHECK: tt.return
+  tt.func @cluster_tma_multicast_with_per_cta_barrier(%desc: !tt.tensordesc<64x128xf16, #nvmma>) -> tensor<64x128xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf16, #blocked>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %buf, %barrier, %true {multicast} :
+      !tt.tensordesc<64x128xf16, #nvmma>, !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %buf :
+      !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>,
+      !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttg.local_dealloc %buf : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttg.local_dealloc %barrier : !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    %buf2 = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttg.local_store %cst, %buf2 : tensor<64x128xf16, #blocked> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %ld = ttg.local_load %buf2 : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable> -> tensor<64x128xf16, #blocked>
+    tt.return %ld : tensor<64x128xf16, #blocked>
+  }
+
   // Negative test: no cluster barrier should be inserted for multiCTA TMA when the multicast is not set
   // CHECK-LABEL: @no_cluster_tma_without_multicast
   // CHECK: ttng.init_barrier
   // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
-  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
-  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
   // CHECK: tt.return
   tt.func @no_cluster_tma_without_multicast(%desc: !tt.tensordesc<64x128xf16, #nvmma>) -> tensor<64x128xf16, #blocked> {
     %c0 = arith.constant 0 : i32
@@ -363,9 +482,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %buf = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
     %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
     ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
-    ttng.fence_mbarrier_init_release_cluster
-    ttng.cluster_arrive {relaxed = true}
-    ttng.cluster_wait
     ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %buf, %barrier, %true :
       !tt.tensordesc<64x128xf16, #nvmma>, !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
     ttng.wait_barrier %barrier, %c0 deps %buf :
@@ -382,7 +498,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
 #barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 #smem = #ttg.shared_memory
@@ -393,8 +509,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK-LABEL: @no_cluster_when_same_allocation
   // CHECK: ttng.init_barrier
   // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
-  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
-  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
   // CHECK: ttng.wait_barrier
   // CHECK-NOT: ttng.cluster_arrive
   // CHECK-NOT: ttng.cluster_wait
@@ -406,9 +521,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %buf = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
     %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
     ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
-    ttng.fence_mbarrier_init_release_cluster
-    ttng.cluster_arrive {relaxed = true}
-    ttng.cluster_wait
     ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %buf, %barrier, %true {multicast} :
       !tt.tensordesc<64x128xf16, #nvmma>, !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
     ttng.wait_barrier %barrier, %c0 deps %buf :
@@ -441,9 +553,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.tw
   // CHECK: ttng.init_barrier
   // CHECK-NEXT: ttng.init_barrier
   // CHECK: ttng.tmem_alloc
-  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
-  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
-  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
   // CHECK: scf.for
   // CHECK: ttng.barrier_expect
   // CHECK-NOT: ttng.cluster_arrive {relaxed = false}
@@ -472,17 +583,14 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.tw
     ttng.init_barrier %bTMA, 1 : !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable>
     ttng.init_barrier %bMMA, 1 : !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
     %acc_tmem = ttng.tmem_alloc : () -> !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable>
-    ttng.fence_mbarrier_init_release_cluster
-    ttng.cluster_arrive {relaxed = true}
-    ttng.cluster_wait
     %phase_init = arith.constant 0 : i32
     %phase_tma = scf.for %k = %c0_idx to %c4_idx step %c1_idx iter_args(%phase = %phase_init) -> (i32) {
       %k_i32 = arith.index_cast %k : index to i32
       ttng.barrier_expect %bTMA, 5120, %true : !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable>
       %offs = arith.muli %k_i32, %c16 : i32
-      ttng.async_tma_copy_global_to_local %a_desc[%c0, %offs] %smem_a, %bTMA, %true {multicast} :
+      ttng.async_tma_copy_global_to_local %a_desc[%c0, %offs] %smem_a, %bTMA, %true :
         !tt.tensordesc<256x16xf16, #sharedA>, !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable> -> !ttg.memdesc<256x16xf16, #sharedA, #smem, mutable>
-      ttng.async_tma_copy_global_to_local %b_desc[%offs, %c0] %smem_b, %bTMA, %true {multicast} :
+      ttng.async_tma_copy_global_to_local %b_desc[%offs, %c0] %smem_b, %bTMA, %true :
         !tt.tensordesc<16x64xf16, #sharedB>, !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable> -> !ttg.memdesc<16x64xf16, #sharedB, #smem, mutable>
       ttng.wait_barrier %bTMA, %phase, %true deps %smem_a, %smem_b :
         !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable>,
@@ -511,7 +619,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.tw
 
 // -----
 
-#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
 #barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
 #smem = #ttg.shared_memory
@@ -520,10 +628,9 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // The wait just waits on the first CTA, so there should be a barrier in between
   // CHECK-LABEL: @cluster_barrier_between_lifetimes_same_offset
   // CHECK: ttng.init_barrier
-  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
-  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
-  // CHECK-NEXT: ttng.cluster_wait
   // CHECK: ttg.local_alloc
+  // CHECK: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
   // CHECK-NEXT: ttng.async_tma_copy_global_to_local
   // CHECK: ttng.wait_barrier
   // CHECK: ttg.local_dealloc
@@ -537,9 +644,6 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
     %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
     ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
-    ttng.fence_mbarrier_init_release_cluster
-    ttng.cluster_arrive {relaxed = true}
-    ttng.cluster_wait
     // a lifetime start
     %a = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
     ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %a, %barrier, %true {multicast} :

--- a/test/TritonNvidiaGPU/membar.mlir
+++ b/test/TritonNvidiaGPU/membar.mlir
@@ -152,6 +152,7 @@ tt.func @wait_after_mma(
      !ttg.memdesc<128x128xf16, #shared1, #smem>,
      !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
      !ttg.memdesc<1xi64, #shared2, #smem, mutable>
+  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.wait_barrier
   ttng.wait_barrier %barrier, %phase : !ttg.memdesc<1xi64, #shared2, #smem, mutable>
   tt.return

--- a/test/lib/Analysis/TestMembar.cpp
+++ b/test/lib/Analysis/TestMembar.cpp
@@ -41,6 +41,9 @@ struct TestMembarPass
               targetInfo));
       triton::nvidia_gpu::runClusterBarrierInsertion(allocation,
                                                      computeCapability);
+      if (failed(triton::nvidia_gpu::runCrossCTAMBarrierInitSyncInsertion(
+              allocation, computeCapability)))
+        return signalPassFailure();
     }
     ModuleMembarAnalysis membarPass(&allocation,
                                     mlir::triton::NVIDIA::canSkipBarSync);

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -879,7 +879,7 @@ def AsyncTDMScatterOp : TT_AMDGPU_Op<"async_tdm_scatter", [
     TensorOf<[I16, I32]>:$dst_row_indices,
     I32:$dst_col_offset,
     Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
-    Optional<TTG_MemDescType>:$barrier
+    Arg<Optional<TTG_MemDescType>, "", [MemWrite<SharedMemory>]>:$barrier
   );
   let results = (outs TTG_AsyncToken:$retToken);
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -702,6 +702,16 @@ bool TargetInfo::supportBitwidth32Elementwise() const {
   }
 }
 
+unsigned TargetInfo::getReductionTreeArity(Operation *combinerOp) const {
+  // AMD has native ternary max/min instructions: v_max3/v_min3 on all GFX9+,
+  // and v_maximum3/v_minimum3 additionally on GFX950 and GFX1250.
+  // Use a ternary reduction tree so these map 1:1 to hardware.
+  if (isa<arith::MaximumFOp, arith::MinimumFOp, arith::MaxNumFOp,
+          arith::MinNumFOp>(combinerOp))
+    return 3;
+  return 2;
+}
+
 bool TargetInfo::supportsDirectToLDSScattering() const {
   switch (getISAFamily()) {
   case ISAFamily::GFX1250:

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -691,7 +691,15 @@ bool TargetInfo::supportVectorizedAtomics() const {
 bool TargetInfo::supportBitwidth16Elementwise() const { return true; }
 
 bool TargetInfo::supportBitwidth32Elementwise() const {
-  return getISAFamily() == ISAFamily::GFX1250;
+  switch (getISAFamily()) {
+  case ISAFamily::CDNA2:
+  case ISAFamily::CDNA3:
+  case ISAFamily::CDNA4:
+  case ISAFamily::GFX1250:
+    return true;
+  default:
+    return false;
+  }
 }
 
 bool TargetInfo::supportsDirectToLDSScattering() const {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -688,6 +688,12 @@ bool TargetInfo::supportVectorizedAtomics() const {
   return true;
 }
 
+bool TargetInfo::supportBitwidth16Elementwise() const { return true; }
+
+bool TargetInfo::supportBitwidth32Elementwise() const {
+  return getISAFamily() == ISAFamily::GFX1250;
+}
+
 bool TargetInfo::supportsDirectToLDSScattering() const {
   switch (getISAFamily()) {
   case ISAFamily::GFX1250:

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -106,6 +106,9 @@ public:
 
   bool supportVectorizedAtomics() const override;
 
+  bool supportBitwidth16Elementwise() const override;
+  bool supportBitwidth32Elementwise() const override;
+
   // Returns true if the target supports per lane addresses into LDS for
   // direct-to-lds loads. Some architectures (e.g. GFX9) do not support
   // scattering and instead have to write warp coalesced into LDS

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -109,6 +109,8 @@ public:
   bool supportBitwidth16Elementwise() const override;
   bool supportBitwidth32Elementwise() const override;
 
+  unsigned getReductionTreeArity(Operation *combinerOp) const override;
+
   // Returns true if the target supports per lane addresses into LDS for
   // direct-to-lds loads. Some architectures (e.g. GFX9) do not support
   // scattering and instead have to write warp coalesced into LDS

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1347,12 +1347,12 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     auto zero = b.i32_val(0);
     auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
     // We multicast if the flag is on and the block layout has broadcasting
-    uint32_t maskCGABroadcast =
-        smemLayout.getFreeVariableMasks().lookup(kBlock);
-    bool multicast = op.getMulticast() && maskCGABroadcast != 0;
+    bool multicast = op.getMulticast();
     Value multicastMask;
     Value barrierPtr = barrierMemObj.getBase();
     if (multicast) {
+      uint32_t maskCGABroadcast =
+          smemLayout.getFreeVariableMasks().lookup(kBlock);
       multicastMask =
           LLVM::NVIDIA::createTMAMulticastMask(loc, rewriter, maskCGABroadcast);
       // If we multicast, we emit the full message from the representative CTA

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -102,6 +102,9 @@ struct ConvertTritonGPUToLLVM
                  targetInfo));
     mlir::triton::nvidia_gpu::runClusterBarrierInsertion(allocation,
                                                          computeCapability);
+    if (failed(mlir::triton::nvidia_gpu::runCrossCTAMBarrierInitSyncInsertion(
+            allocation, computeCapability)))
+      return signalPassFailure();
     ModuleMembarAnalysis membarPass(&allocation, canSkipBarSync);
     membarPass.run();
     if (failed(maybeInsertClusterSync(mod))) {


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/9897

Upstream commit message:
```
> [AMD] Generalize in-thread tree reduction to support ternary grouping for max/min (#9897)

> Summary

> - Generalize treeReduceBinary into treeReduce parameterized by arity,
> enabling ternary (or higher) tree reductions when the target benefits
> from it
> - Add getReductionTreeArity(Operation*) to TargetInfoBase (default: 2)
> so targets can request wider grouping per combiner op
> - AMD override returns 3 for MaximumFOp/MinimumFOp/MaxNumFOp/MinNumFOp,
> generating max(max(a,b), c) groups that LLVM folds into
> v_maximum3_f32/v_minimum3_f32

>   Motivation

> The binary tree reduction creates an alternating pattern where every
> other level produces results that LLVM's DAG combiner cannot fold into
> ternary instructions. LLVM only matches max(max(a,b), c) → v_maximum3
> when the inner max has a single use, but the balanced binary tree
> creates intermediate results consumed by the next level that alternate
> between foldable and unfoldable.

> With arity=3, every group maps directly to a ternary instruction,
> reducing max/min instruction count by ~23% (344 → 264 for a 256×256 f32
> reduction). NVIDIA has no max3 equivalent, so the default arity=2
> preserves existing behavior.

> Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```

***Do not remove the following line from this commit***
Reactor Backport Revision: bc791297ebb5d56f71fd84e09cc7bc81bc592f85
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 9897
```

Reviewed By: agron911

Differential Revision: D113855993


