### PR TITLE
[tlx] Trivial no-op comment to diagnose mirror CI (#2394)

### DIFF
--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -16,6 +16,7 @@ using namespace mlir::triton::tlx;
 namespace ttg = mlir::triton::gpu;
 
 namespace {
+// Return the enclosing ModuleOp for `op`, or `op` itself if it is a ModuleOp.
 ModuleOp getModuleOp(Operation *op) {
   auto module = dyn_cast<ModuleOp>(op);
   if (!module) {


### PR DESCRIPTION
Summary:

Deliberately trivial, comment-only change to a TLX compiler source file.
Its sole purpose is to exercise the fbsource -> facebookexperimental/triton
export path and the mirror's GitHub CI (Compiler LIT) so we can read the CI
signals back and diagnose the mirror's failing tests. No behavior change.

Authored with Claude.

Reviewed By: stashuk-olek

Differential Revision: D113925641


