### PR TITLE
[modulo] Jointly schedule issue cycles and warp groups

### DIFF
--- a/test/TritonGPU/modulo-schedule-nested.mlir
+++ b/test/TritonGPU/modulo-schedule-nested.mlir
@@ -1,10 +1,11 @@
 // REQUIRES: asserts
-// RUN: triton-opt %s -allow-unregistered-dialect -nvgpu-modulo-schedule -debug-only=nvgpu-modulo-schedule 2>&1 | FileCheck %s
+// RUN: triton-opt %s -allow-unregistered-dialect -nvgpu-modulo-schedule | FileCheck %s
+// RUN: triton-opt %s -allow-unregistered-dialect -nvgpu-modulo-schedule -debug-only=nvgpu-modulo-schedule 2>&1 | FileCheck %s --check-prefix=DBG
 
 //===----------------------------------------------------------------------===//
-// Test: Nested loop (persistent GEMM) — outer tile loop + inner K-loop
-//   Verify that both loops are scheduled and the kernel-wide SMEM budget
-//   check accounts for outer + inner buffers simultaneously.
+// Test: Nested loop GEMM with an outer tile loop and inner K-loop.
+//   Verify nested outer-loop pipelining/dataflow and that the kernel-wide
+//   SMEM budget check accounts for outer + inner buffers simultaneously.
 //===----------------------------------------------------------------------===//
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -17,20 +18,27 @@
 
 module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
 
-// CHECK: [PASS-A] === Loop ScheduleGraph ===
-// CHECK: modulo.schedule @loop0 {
-//
-// CHECK: [PASS-A] === Loop ScheduleGraph ===
-// CHECK: modulo.schedule @loop0 {
-//
-// Inner loop gets tt.num_stages (no loop.stage — uses emitMMAAnnotations).
+// Inner loop gets tt.num_stages (no loop.stage; uses emitMMAAnnotations).
 // Outer loop gets loop.stage attrs via emitScheduleAttributes.
+// Regression coverage for the real nested GEMM's existing three-role
+// partition structure after scheduling:
+//   * inner tensor-core work in partition 1,
+//   * the inner loop wrapper/hand-off in partition 2,
+//   * the outer epilogue/store group in partition 3.
+// This real nested case covers non-register separation across the TMEM hand-off.
+// It does not directly exercise the register timing accept/reject branch; the
+// checks use emitted partition metadata instead of exact cycle/II values, which
+// are more sensitive to latency-model tuning.
+// DBG: [nested-wg] reject consumer WG {{.*}}register=0, non-register=1
 // CHECK-LABEL: @persistent_gemm_nested
-// Inner loop has tt.num_stages:
-// CHECK: scf.for
-// CHECK: tt.num_stages
-// Outer loop has schedule attrs:
-// CHECK: tt.modulo_ii
+// CHECK: ttng.tmem_alloc {{.*}}ttg.partition = array<i32: 3>
+// CHECK: ttng.tmem_store {{.*}}ttg.partition = array<i32: 2>
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: 1>
+// CHECK: } {{.*}}ttg.partition = array<i32: 2>{{.*}}ttg.partition_num_warps
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: 3>
+// CHECK: tt.descriptor_store {{.*}}ttg.partition = array<i32: 3>
+// Outer loop has schedule attrs after the epilogue/store group.
+// CHECK: } {tt.flatten, tt.modulo_ii = {{[0-9]+}} : i32, tt.num_stages = {{[0-9]+}} : i32
   tt.func public @persistent_gemm_nested(
       %a_desc: !tt.tensordesc<256x64xf16, #shared>,
       %b_desc: !tt.tensordesc<256x64xf16, #shared>,

--- a/test/TritonGPU/modulo-ws-partition.mlir
+++ b/test/TritonGPU/modulo-ws-partition.mlir
@@ -1,4 +1,6 @@
+// REQUIRES: asserts
 // RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -nvgpu-modulo-schedule -nvgpu-modulo-ws-partition | FileCheck %s
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -nvgpu-modulo-schedule -debug-only=modulo-scheduling-rau,nvgpu-modulo-schedule 2>&1 | FileCheck %s --check-prefix=JOINT
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
@@ -19,6 +21,21 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // CHECK: tt.modulo_ii = {{[0-9]+}} : i32
 // CHECK-SAME: tt.scheduled_max_stage = {{[0-9]+}} : i32
 // CHECK: tt.warp_specialize
+//
+// The scheduler constructs one `(cycle, warp group)` assignment directly for
+// this leaf/control case. This preserves coverage for candidate-free scheduling
+// output but does not directly exercise register hand-off rejection. The real
+// nested test covers non-register separation across a TMEM hand-off.
+// N0-N4 fit on wg0 at their globally ready cycles. N5 cannot issue on wg0 at
+// its required cycle, so the scheduler creates wg1 and places the remaining
+// chain there after accounting for cross-warp synchronization latency.
+// JOINT: Placed N4 {{.*}} at cycle=653 stage=0 wg=0
+// JOINT-NEXT: {{.*}} Placed N5 {{.*}} at cycle=0 stage=0 wg=1
+// JOINT-NEXT: {{.*}} Placed N6 {{.*}} at cycle=713 stage=0 wg=1
+// JOINT-NEXT: {{.*}} Placed N7 {{.*}} at cycle=1272 stage=1 wg=1
+// JOINT-NEXT: {{.*}} SUCCESS at II=1091 wgs=2 warps=9
+// JOINT-NOT: [nested-wg]
+// JOINT-NOT: cand[
 tt.func @persistent_gemm_ws_partition(
   %a_desc: !tt.tensordesc<128x64xf16>,
   %b_desc: !tt.tensordesc<64x128xf16>,

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
@@ -2,13 +2,12 @@
 
 #include "ModuloReservationTable.h"
 
-#include "ExhaustiveScheduler.h"
-#include "SwingScheduler.h"
-#include "triton/Tools/Sys/GetEnv.h"
+#include "triton/Dialect/Triton/IR/Types.h"
 #include "llvm/Support/Debug.h"
 #include <algorithm>
 #include <climits>
 #include <numeric>
+#include <optional>
 
 #define DEBUG_TYPE "modulo-scheduling-rau"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -90,26 +89,294 @@ int ModuloReservationTable::findFreeSlot(int earliest, HWPipeline pipeline,
   return -1;
 }
 
-// ── Rau's Iterative Modulo Scheduling ───────────────────────────────────────
+// ── Constructive joint cycle+warp scheduling ────────────────────────────────
 
-/// Compute the earliest start time for a node given its predecessors'
-/// scheduled cycles, respecting loop-carried distances.
-static int computeEarliestStart(unsigned nodeIdx,
-                                const DataDependenceGraph &ddg,
-                                const llvm::DenseMap<unsigned, int> &scheduled,
-                                int II) {
+namespace {
+
+constexpr int kDefaultWarpGroupWarps = 4;
+constexpr int kMaxHardwareWarps = 64;
+constexpr int kRegisterSyncBaseCycles = 150;
+constexpr int kRegisterSyncCyclesPerKB = 16;
+constexpr int kOtherCrossWGSyncCycles = 60;
+
+/// Per-warp-group circular issue stream. Every instruction contends with every
+/// other instruction in the same warp group, regardless of hardware pipeline.
+class WarpIssueReservationStream {
+public:
+  explicit WarpIssueReservationStream(int II) : II{II}, slots(II, -1) {}
+
+  bool isIntervalFree(int cycle, int duration) const {
+    for (int t = cycle; t < cycle + duration; ++t) {
+      if (slots[t % II] >= 0)
+        return false;
+    }
+    return true;
+  }
+
+  void reserve(int cycle, unsigned nodeIdx, int duration) {
+    for (int t = cycle; t < cycle + duration; ++t)
+      slots[t % II] = static_cast<int>(nodeIdx);
+  }
+
+  void unreserve(int cycle, int duration) {
+    for (int t = cycle; t < cycle + duration; ++t)
+      slots[t % II] = -1;
+  }
+
+  int getOccupant(int cycle) const { return slots[cycle % II]; }
+
+private:
+  int II{};
+  llvm::SmallVector<int> slots;
+};
+
+struct JointCandidate {
+  int cycle{-1};
+  int warpGroup{-1};
+};
+
+static int getPipelineDuration(const DDGNode &node) {
+  return pipelineOccupancy(node);
+}
+
+static int getWarpIssueDuration(const DDGNode &node) {
+  return std::max(node.selfLatency, 1);
+}
+
+static int roundRequiredWarps(int minWarps) {
+  if (minWarps <= 1)
+    return 1;
+  if (minWarps <= 2)
+    return 2;
+  if (minWarps <= 4)
+    return 4;
+  return 8;
+}
+
+static int getRequiredWarpsForNode(const DDGNode &node) {
+  return roundRequiredWarps(std::max(node.minWarps, 1));
+}
+
+static int getUsedHardwareWarps(llvm::ArrayRef<int> wgRequiredWarps) {
+  return kDefaultWarpGroupWarps +
+         std::accumulate(wgRequiredWarps.begin(), wgRequiredWarps.end(), 0);
+}
+
+static bool canReplaceWarpGroupRequirement(llvm::ArrayRef<int> wgRequiredWarps,
+                                           int warpGroup,
+                                           int newRequiredWarps) {
+  int usedWarps = kDefaultWarpGroupWarps;
+  for (int wg = 0, e = wgRequiredWarps.size(); wg < e; ++wg)
+    usedWarps += (wg == warpGroup) ? newRequiredWarps : wgRequiredWarps[wg];
+  return usedWarps <= kMaxHardwareWarps;
+}
+
+static int recomputeWarpGroupRequirement(
+    int warpGroup, const DataDependenceGraph &ddg,
+    const llvm::DenseMap<unsigned, int> &nodeToWarpGroup) {
+  int requiredWarps = 0;
+  for (auto [scheduledNodeIdx, scheduledWarpGroup] : nodeToWarpGroup) {
+    if (scheduledWarpGroup != warpGroup)
+      continue;
+    requiredWarps =
+        std::max(requiredWarps, getRequiredWarpsForNode(ddg.getNode(
+                                    static_cast<unsigned>(scheduledNodeIdx))));
+  }
+  return requiredWarps;
+}
+
+static std::optional<int64_t> getRegisterTensorBytes(Value value) {
+  auto tensorType = dyn_cast<RankedTensorType>(value.getType());
+  if (!tensorType)
+    return std::nullopt;
+
+  Type elementType = tensorType.getElementType();
+  if (isa<triton::PointerType>(elementType))
+    return std::nullopt;
+  if (!elementType.isIntOrFloat())
+    return std::nullopt;
+
+  int64_t numElements = tensorType.getNumElements();
+  if (numElements < 0)
+    return std::nullopt;
+  return llvm::divideCeil(numElements * tensorType.getElementTypeBitWidth(),
+                          int64_t{8});
+}
+
+static int getCrossWarpGroupLatency(const DDGNode &producer) {
+  if (!producer.op)
+    return kOtherCrossWGSyncCycles;
+
+  if (producer.pipeline != HWPipeline::CUDA &&
+      producer.pipeline != HWPipeline::SFU &&
+      producer.pipeline != HWPipeline::VALU)
+    return kOtherCrossWGSyncCycles;
+
+  int64_t resultBytes = 0;
+  bool sawRegisterTensor = false;
+  for (Value result : producer.op->getResults()) {
+    std::optional<int64_t> bytes = getRegisterTensorBytes(result);
+    if (!bytes)
+      continue;
+    sawRegisterTensor = true;
+    resultBytes += *bytes;
+  }
+
+  if (!sawRegisterTensor)
+    return kOtherCrossWGSyncCycles;
+
+  int64_t kilobytes = llvm::divideCeil(resultBytes, int64_t{1024});
+  return kRegisterSyncBaseCycles +
+         static_cast<int>(kilobytes * kRegisterSyncCyclesPerKB);
+}
+
+static int computeEarliestStartForWarpGroup(
+    unsigned nodeIdx, int warpGroup, const DataDependenceGraph &ddg,
+    const llvm::DenseMap<unsigned, int> &scheduled,
+    const llvm::DenseMap<unsigned, int> &nodeToWarpGroup, int II) {
   int earliest = 0;
   for (const auto *edge : ddg.getInEdges(nodeIdx)) {
-    auto it = scheduled.find(edge->srcIdx);
-    if (it == scheduled.end())
+    auto cycleIt = scheduled.find(edge->srcIdx);
+    if (cycleIt == scheduled.end())
       continue;
-    // constraint: dst_start >= src_start + latency - distance * II
+
+    int latency = edge->latency;
+    auto wgIt = nodeToWarpGroup.find(edge->srcIdx);
+    if (wgIt != nodeToWarpGroup.end() && wgIt->second != warpGroup)
+      latency += getCrossWarpGroupLatency(ddg.getNode(edge->srcIdx));
+
     int constraint =
-        it->second + edge->latency - static_cast<int>(edge->distance) * II;
+        cycleIt->second + latency - static_cast<int>(edge->distance) * II;
     earliest = std::max(earliest, constraint);
   }
   return earliest;
 }
+
+static bool
+hasScheduledConsumer(unsigned nodeIdx, const DataDependenceGraph &ddg,
+                     const llvm::DenseMap<unsigned, int> &scheduled) {
+  for (const auto *edge : ddg.getOutEdges(nodeIdx)) {
+    if (scheduled.contains(edge->dstIdx))
+      return true;
+  }
+  return false;
+}
+
+static std::optional<JointCandidate> getExactCandidate(
+    unsigned nodeIdx, int warpGroup, const DataDependenceGraph &ddg,
+    const ModuloReservationTable &globalTable,
+    ArrayRef<WarpIssueReservationStream> issueStreams,
+    ArrayRef<int> wgRequiredWarps,
+    const llvm::DenseMap<unsigned, int> &scheduled,
+    const llvm::DenseMap<unsigned, int> &nodeToWarpGroup, int II) {
+  const DDGNode &node = ddg.getNode(nodeIdx);
+  int newRequiredWarps =
+      std::max(wgRequiredWarps[warpGroup], getRequiredWarpsForNode(node));
+  if (!canReplaceWarpGroupRequirement(wgRequiredWarps, warpGroup,
+                                      newRequiredWarps))
+    return std::nullopt;
+  int earliest = computeEarliestStartForWarpGroup(
+      nodeIdx, warpGroup, ddg, scheduled, nodeToWarpGroup, II);
+  int cycle = globalTable.findFreeSlot(earliest, node.pipeline,
+                                       getPipelineDuration(node));
+  if (cycle < 0)
+    return std::nullopt;
+  if (!issueStreams[warpGroup].isIntervalFree(cycle,
+                                              getWarpIssueDuration(node)))
+    return std::nullopt;
+  return JointCandidate{cycle, warpGroup};
+}
+
+static JointCandidate
+findCandidate(unsigned nodeIdx, const DataDependenceGraph &ddg,
+              const ModuloReservationTable &globalTable,
+              ArrayRef<WarpIssueReservationStream> issueStreams,
+              ArrayRef<int> wgRequiredWarps,
+              const llvm::DenseMap<unsigned, int> &scheduled,
+              const llvm::DenseMap<unsigned, int> &nodeToWarpGroup, int II) {
+  JointCandidate best;
+  for (int wg = 0, e = issueStreams.size(); wg < e; ++wg) {
+    std::optional<JointCandidate> candidate =
+        getExactCandidate(nodeIdx, wg, ddg, globalTable, issueStreams,
+                          wgRequiredWarps, scheduled, nodeToWarpGroup, II);
+    if (!candidate)
+      continue;
+    if (best.cycle < 0 || candidate->cycle < best.cycle ||
+        (candidate->cycle == best.cycle && wg < best.warpGroup)) {
+      best = *candidate;
+    }
+  }
+  return best;
+}
+
+static int
+findEjectionVictim(unsigned nodeIdx, const DataDependenceGraph &ddg,
+                   const ModuloReservationTable &globalTable,
+                   ArrayRef<WarpIssueReservationStream> issueStreams,
+                   ArrayRef<int> wgRequiredWarps,
+                   const llvm::DenseMap<unsigned, int> &scheduled,
+                   const llvm::DenseMap<unsigned, int> &nodeToWarpGroup,
+                   const llvm::DenseMap<unsigned, int> &heights, int II) {
+  int bestVictim = -1;
+  int bestVictimHeight = INT_MAX;
+  int currentHeight = heights.lookup(nodeIdx);
+  const auto &node = ddg.getNode(nodeIdx);
+
+  for (int wg = 0, e = issueStreams.size(); wg < e; ++wg) {
+    int newRequiredWarps =
+        std::max(wgRequiredWarps[wg], getRequiredWarpsForNode(node));
+    if (!canReplaceWarpGroupRequirement(wgRequiredWarps, wg, newRequiredWarps))
+      continue;
+
+    int earliest = computeEarliestStartForWarpGroup(nodeIdx, wg, ddg, scheduled,
+                                                    nodeToWarpGroup, II);
+    int cycle = globalTable.findFreeSlot(earliest, node.pipeline,
+                                         getPipelineDuration(node));
+    if (cycle < 0)
+      continue;
+
+    int issueDuration = getWarpIssueDuration(node);
+    llvm::SmallVector<int, 8> occupants;
+    for (int t = cycle; t < cycle + issueDuration; ++t) {
+      int occupant = issueStreams[wg].getOccupant(t);
+      if (occupant >= 0)
+        occupants.push_back(occupant);
+    }
+
+    for (int occupant : occupants) {
+      unsigned occupantIdx = static_cast<unsigned>(occupant);
+      // Conservatively eject only leaves: moving a node with scheduled
+      // consumers would invalidate their cycle and warp-group constraints.
+      if (hasScheduledConsumer(occupantIdx, ddg, scheduled))
+        continue;
+
+      int occHeight = heights.lookup(occupantIdx);
+      if (occHeight < currentHeight && occHeight < bestVictimHeight) {
+        bestVictimHeight = occHeight;
+        bestVictim = occupant;
+      }
+    }
+  }
+  return bestVictim;
+}
+
+static void
+reserveNode(ModuloReservationTable &globalTable,
+            MutableArrayRef<WarpIssueReservationStream> issueStreams,
+            const DDGNode &node, unsigned nodeIdx, int cycle, int warpGroup) {
+  globalTable.reserve(cycle, node.pipeline, nodeIdx, getPipelineDuration(node));
+  issueStreams[warpGroup].reserve(cycle, nodeIdx, getWarpIssueDuration(node));
+}
+
+static void
+unreserveNode(ModuloReservationTable &globalTable,
+              MutableArrayRef<WarpIssueReservationStream> issueStreams,
+              const DDGNode &node, int cycle, int warpGroup) {
+  globalTable.unreserve(cycle, node.pipeline, getPipelineDuration(node));
+  issueStreams[warpGroup].unreserve(cycle, getWarpIssueDuration(node));
+}
+
+} // namespace
 
 static FailureOr<ModuloScheduleResult> runRauIMS(const DataDependenceGraph &ddg,
                                                  int minII, int maxII,
@@ -118,19 +385,12 @@ static FailureOr<ModuloScheduleResult> runRauIMS(const DataDependenceGraph &ddg,
   auto heights = ddg.computeCriticalPathHeights();
   LLVM_DEBUG(DBGS() << "Heights computed for " << heights.size() << " nodes\n");
 
-  // Sort ALL nodes (including NONE-pipeline) by decreasing critical-path
-  // height. NONE ops must be scheduled together with pipeline ops so that
-  // dependency constraints (e.g., load → local_alloc → MMA) are respected.
   llvm::SmallVector<unsigned> priorityOrder;
   for (unsigned i = 0; i < ddg.getNumNodes(); ++i)
     priorityOrder.push_back(i);
   llvm::sort(priorityOrder, [&](unsigned a, unsigned b) {
     if (heights[a] != heights[b])
       return heights[a] > heights[b];
-    // Tiebreaker: lower index first (producers before consumers
-    // in program order). This ensures that when a predecessor and
-    // successor have equal heights, the predecessor is scheduled
-    // first so its cycle is known when the successor is placed.
     return a < b;
   });
 
@@ -140,106 +400,126 @@ static FailureOr<ModuloScheduleResult> runRauIMS(const DataDependenceGraph &ddg,
     DBGS() << "ResMII=" << ddg.computeResMII()
            << " RecMII=" << ddg.computeRecMII() << "\n";
   });
-  // Show per-pipeline resource usage for ResMII breakdown
   LLVM_DEBUG({
     llvm::DenseMap<HWPipeline, int> pipeLoad;
+    int issueLoad = 0;
     for (const auto &node : ddg.getNodes()) {
       if (node.pipeline != HWPipeline::NONE)
-        pipeLoad[node.pipeline] += std::max(node.selfLatency, 1);
+        pipeLoad[node.pipeline] += getPipelineDuration(node);
+      issueLoad += getWarpIssueDuration(node);
     }
-    for (auto &[pipe, load] : pipeLoad) {
+    for (auto &[pipe, load] : pipeLoad)
       DBGS() << "  " << getPipelineName(pipe) << " total_load=" << load << "\n";
-    }
+    DBGS() << "  warp_issue total_load=" << issueLoad << "\n";
   });
 
   for (int II = minII; II <= maxII; ++II) {
-    ModuloReservationTable table{II};
+    ModuloReservationTable globalTable{II};
+    llvm::SmallVector<WarpIssueReservationStream> issueStreams;
+    llvm::SmallVector<int> wgRequiredWarps;
     llvm::DenseMap<unsigned, int> scheduled;
+    llvm::DenseMap<unsigned, int> nodeToWarpGroup;
     bool success = true;
     int backtracks = 0;
 
-    // Use index-based iteration instead of range-for because ejection
-    // may insert evicted nodes back into priorityOrder for re-scheduling.
-    // Range-for would be UB (iterator invalidation on SmallVector insert).
+    auto addWarpGroup = [&]() {
+      issueStreams.emplace_back(II);
+      wgRequiredWarps.push_back(0);
+      return static_cast<int>(issueStreams.size()) - 1;
+    };
+
     for (unsigned i = 0; i < priorityOrder.size(); ++i) {
       unsigned nodeIdx = priorityOrder[i];
       const auto &node = ddg.getNode(nodeIdx);
-      int duration = std::max(node.selfLatency, 1); // at least 1 slot
-      if (node.pipeline == HWPipeline::NONE)
-        duration = 1; // NONE ops don't occupy any pipeline
+      JointCandidate candidate =
+          findCandidate(nodeIdx, ddg, globalTable, issueStreams,
+                        wgRequiredWarps, scheduled, nodeToWarpGroup, II);
 
-      int earliest = computeEarliestStart(nodeIdx, ddg, scheduled, II);
-      int slot = table.findFreeSlot(earliest, node.pipeline, duration);
-
-      if (slot < 0 && backtracks < maxBacktracks) {
-        // Rau's ejection: find the least-critical occupant in a
-        // conflicting slot, evict it, place current node, then
-        // re-schedule the evicted node later.
-        int bestVictim = -1;
-        int bestVictimHeight = INT_MAX;
-        int currentHeight = heights.lookup(nodeIdx);
-        for (int t = earliest; t < earliest + II; ++t) {
-          int occupant = table.getOccupant(t, node.pipeline);
-          if (occupant < 0)
-            continue;
-          int occHeight = heights.lookup(static_cast<unsigned>(occupant));
-          // Only eject nodes with strictly lower priority (smaller height)
-          // than the current node. This prevents priority inversion where
-          // a less-critical node evicts a more-critical one.
-          if (occHeight < currentHeight && occHeight < bestVictimHeight) {
-            bestVictimHeight = occHeight;
-            bestVictim = occupant;
-          }
-        }
-        if (bestVictim >= 0) {
-          // Evict the victim.
-          const auto &victim = ddg.getNode(bestVictim);
-          int victimDur = std::max(victim.selfLatency, 1);
-          if (victim.pipeline == HWPipeline::NONE)
-            victimDur = 1;
-          int victimCycle = scheduled[bestVictim];
-          table.unreserve(victimCycle, victim.pipeline, victimDur);
-          scheduled.erase(bestVictim);
-
-          // Place current node at the freed slot.
-          slot = table.findFreeSlot(earliest, node.pipeline, duration);
-          if (slot >= 0) {
-            // Insert evicted node right after current position for
-            // re-scheduling. Index-based iteration handles the growth
-            // safely (no iterator invalidation).
-            priorityOrder.insert(priorityOrder.begin() + i + 1,
-                                 static_cast<unsigned>(bestVictim));
-            ++backtracks;
-            LLVM_DEBUG(DBGS() << "  Ejected N" << bestVictim
-                              << " (height=" << bestVictimHeight
-                              << ") to place N" << nodeIdx << "\n");
-          } else {
-            // Could not place even after ejection — restore victim.
-            table.reserve(victimCycle, victim.pipeline,
-                          static_cast<unsigned>(bestVictim), victimDur);
-            scheduled[bestVictim] = victimCycle;
+      if (candidate.cycle < 0) {
+        int newWGWarps = getRequiredWarpsForNode(node);
+        if (getUsedHardwareWarps(wgRequiredWarps) + newWGWarps <=
+            kMaxHardwareWarps) {
+          int wg = addWarpGroup();
+          wgRequiredWarps[wg] = newWGWarps;
+          std::optional<JointCandidate> newCandidate = getExactCandidate(
+              nodeIdx, wg, ddg, globalTable, issueStreams, wgRequiredWarps,
+              scheduled, nodeToWarpGroup, II);
+          if (newCandidate)
+            candidate = *newCandidate;
+          if (candidate.cycle < 0) {
+            issueStreams.pop_back();
+            wgRequiredWarps.pop_back();
           }
         }
       }
-      if (slot < 0) {
+
+      if (candidate.cycle < 0 && backtracks < maxBacktracks &&
+          !issueStreams.empty()) {
+        int victim = findEjectionVictim(nodeIdx, ddg, globalTable, issueStreams,
+                                        wgRequiredWarps, scheduled,
+                                        nodeToWarpGroup, heights, II);
+        if (victim >= 0) {
+          const auto &victimNode = ddg.getNode(static_cast<unsigned>(victim));
+          int victimCycle = scheduled.lookup(static_cast<unsigned>(victim));
+          int victimWG = nodeToWarpGroup.lookup(static_cast<unsigned>(victim));
+          unreserveNode(globalTable, issueStreams, victimNode, victimCycle,
+                        victimWG);
+          scheduled.erase(static_cast<unsigned>(victim));
+          nodeToWarpGroup.erase(static_cast<unsigned>(victim));
+          wgRequiredWarps[victimWG] =
+              recomputeWarpGroupRequirement(victimWG, ddg, nodeToWarpGroup);
+
+          candidate =
+              findCandidate(nodeIdx, ddg, globalTable, issueStreams,
+                            wgRequiredWarps, scheduled, nodeToWarpGroup, II);
+          if (candidate.cycle >= 0) {
+            priorityOrder.insert(priorityOrder.begin() + i + 1,
+                                 static_cast<unsigned>(victim));
+            ++backtracks;
+            LLVM_DEBUG(DBGS() << "  Ejected N" << victim << " (height="
+                              << heights.lookup(static_cast<unsigned>(victim))
+                              << ") to place N" << nodeIdx << "\n");
+          } else {
+            reserveNode(globalTable, issueStreams, victimNode,
+                        static_cast<unsigned>(victim), victimCycle, victimWG);
+            scheduled[static_cast<unsigned>(victim)] = victimCycle;
+            nodeToWarpGroup[static_cast<unsigned>(victim)] = victimWG;
+            wgRequiredWarps[victimWG] =
+                recomputeWarpGroupRequirement(victimWG, ddg, nodeToWarpGroup);
+          }
+        }
+      }
+
+      if (candidate.cycle < 0) {
         success = false;
         break;
       }
 
-      table.reserve(slot, node.pipeline, nodeIdx, duration);
-      scheduled[nodeIdx] = slot;
+      wgRequiredWarps[candidate.warpGroup] = std::max(
+          wgRequiredWarps[candidate.warpGroup], getRequiredWarpsForNode(node));
+      reserveNode(globalTable, issueStreams, node, nodeIdx, candidate.cycle,
+                  candidate.warpGroup);
+      scheduled[nodeIdx] = candidate.cycle;
+      nodeToWarpGroup[nodeIdx] = candidate.warpGroup;
       LLVM_DEBUG(DBGS() << "  II=" << II << " Placed N" << nodeIdx << " ("
-                        << getPipelineName(node.pipeline) << " dur=" << duration
-                        << ") at cycle=" << slot << " stage=" << slot / II
-                        << "\n");
+                        << getPipelineName(node.pipeline)
+                        << " pipe_dur=" << getPipelineDuration(node)
+                        << " issue_dur=" << getWarpIssueDuration(node)
+                        << ") at cycle=" << candidate.cycle
+                        << " stage=" << candidate.cycle / II
+                        << " wg=" << candidate.warpGroup << "\n");
     }
 
     if (success) {
-      LLVM_DEBUG(DBGS() << "SUCCESS at II=" << II << "\n");
+      LLVM_DEBUG(DBGS() << "SUCCESS at II=" << II
+                        << " wgs=" << issueStreams.size() << " warps="
+                        << getUsedHardwareWarps(wgRequiredWarps) << "\n");
 
       ModuloScheduleResult result;
       result.II = II;
       result.nodeToCycle = std::move(scheduled);
+      result.nodeToWarpGroup = std::move(nodeToWarpGroup);
+      result.numWarpGroups = static_cast<int>(issueStreams.size());
       return result;
     }
 
@@ -282,29 +562,7 @@ runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
            << " RecMII=" << ddg.computeRecMII() << "\n";
   });
 
-  // TRITON_USE_MODULO_SCHEDULE selects the scheduling algorithm:
-  //   "sms"        → Swing Modulo Scheduling (Llosa et al., PACT 1996)
-  //   "exhaustive" → Exhaustive search with joint memory feasibility
-  //   "random"     → Random sampling with greedy placement
-  //   "1" or other → Rau's Iterative Modulo Scheduling (Rau, 1994)
-  auto algo = mlir::triton::tools::getStrEnv("TRITON_USE_MODULO_SCHEDULE");
-
-  if (algo == "exhaustive") {
-    LLVM_DEBUG(DBGS() << "Using exhaustive search with memory feasibility\n");
-    return runExhaustiveSearch(ddg, maxII);
-  }
-
-  if (algo == "random") {
-    LLVM_DEBUG(DBGS() << "Using random sampling search\n");
-    return runRandomSearch(ddg, maxII);
-  }
-
-  if (algo == "sms") {
-    LLVM_DEBUG(DBGS() << "Using Swing Modulo Scheduling (SMS)\n");
-    return runSMS(ddg, minII, maxII);
-  }
-
-  LLVM_DEBUG(DBGS() << "Using Rau's Iterative Modulo Scheduling (IMS)\n");
+  LLVM_DEBUG(DBGS() << "Using joint Rau cycle+warp scheduling\n");
   return runRauIMS(ddg, minII, maxII, maxBacktracks);
 }
 

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
@@ -41,6 +41,8 @@ private:
 struct ModuloScheduleResult {
   int II{};
   llvm::DenseMap<unsigned, int> nodeToCycle; // DDG node idx -> absolute cycle
+  llvm::DenseMap<unsigned, int> nodeToWarpGroup;
+  int numWarpGroups{};
 
   int getStage(unsigned nodeIdx) const {
     auto it = nodeToCycle.find(nodeIdx);
@@ -55,13 +57,10 @@ struct ModuloScheduleResult {
   }
 };
 
-/// Run modulo scheduling on the DDG.
-/// Algorithm selected by TRITON_USE_MODULO_SCHEDULE env var value:
-///   "sms"        → Swing Modulo Scheduling (Llosa et al., PACT 1996)
-///   "exhaustive" → Exhaustive search with joint memory feasibility
-///   "random"     → Random sampling with greedy placement
-///   "1" or other → Rau's Iterative Modulo Scheduling (Rau, 1994)
-/// maxII defaults to 2 * MinII. maxBacktracks limits ejection in Rau's IMS.
+/// Run the constructive joint Rau scheduler on the DDG.
+/// The scheduler assigns both modulo cycles and warp groups in one placement
+/// pass, so every successful result includes nodeToWarpGroup for direct
+/// partitioning. maxII defaults to 2 * MinII. maxBacktracks limits ejection.
 FailureOr<ModuloScheduleResult>
 runModuloScheduling(const DataDependenceGraph &ddg, int maxII = 0,
                     int maxBacktracks = 20);

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -7,6 +7,7 @@
 // attributes for downstream pipelining passes.
 
 #include <cmath>
+#include <map>
 #include <set>
 #include <tuple>
 
@@ -589,6 +590,9 @@ convertDDGNode(const ttg::DDGNode &ddgNode, unsigned nodeId,
     sn.cycle = cycleIt->second;
     sn.stage = cycleIt->second / sched.II;
   }
+  auto warpGroupIt = sched.nodeToWarpGroup.find(ddgNode.idx);
+  if (warpGroupIt != sched.nodeToWarpGroup.end())
+    sn.warpGroup = warpGroupIt->second;
 
   if (ddgNode.isSuperNode) {
     sn.prologueLatency = ddgNode.prologueLatency;
@@ -4812,200 +4816,321 @@ static void clampOuterStagesAndClusters(scf::ForOp outerLoop) {
   }
 }
 
-/// Whole-nest epilogue warp-group unification (cost-model, storage-class-priced).
+/// Whole-nest consumer warp-group resolution for inner-loop hand-offs.
 ///
-/// A persistent outer loop's epilogue may consume a value V produced by its
-/// inner loop. If V is a REGISTER value, running the epilogue in a warp group
-/// separate from V's producer forces V through an SMEM materialization
-/// round-trip (a local_store in the producer plus a local_load + 2 barriers in
-/// the consumer) — a real cost that scales with bytes(V). Co-locating the
-/// epilogue into the inner producer's warp group removes that hand-off.
+/// An outer loop may consume values produced by an inner loop super-node. If an
+/// inner result is a register-resident tensor, running its outer consumers in a
+/// warp group separate from the inner producer forces that value through an
+/// SMEM materialization round-trip. Co-locating the whole outer consumer group
+/// into the inner producer's warp group removes that hand-off.
 ///
-/// The decision is priced by V's storage class, NOT by a "register → same WG"
-/// rule (that would just be pattern matching):
-///   Register V  → co-locating saves the full materialization (~2·bytes),
-///                 which is otherwise pure overhead → co-locate.
-///   TMEM/SMEM V → the consumer needs a barrier to read V regardless of which
-///                 warp group runs the epilogue, so co-location saves ~nothing.
-///                 A GEMM's TMEM accumulator therefore legitimately keeps its
-///                 own epilogue WG → stay separate.
-/// Overlap benefit is left implicit in the loop II/makespan (the epilogue work
-/// is scheduled either way); we price only the hand-off co-location removes.
+/// TMEM/SMEM values keep their distinct behavior: their consumers need memory
+/// synchronization regardless of warp-group identity, so they are not treated
+/// as register hand-offs. Async tokens, memdesc values, and other
+/// non-ranked-tensor results are also not register hand-offs.
 ///
-/// The decision is expressed by RENUMBERING the epilogue-owning outer warp
-/// group so its id is meaningful across the super-node boundary — no side field:
-///   co-locate → the inner producer's warp-group id (the epilogue now SHARES it,
-///               which is exactly the co-location signal the emitter reads),
-///   separate  → a FRESH id above every id in the nest, guaranteed not to alias
-///               any inner id (so "epilogue wg == an inner wg" unambiguously
-///               means co-located, never a coincidence).
-/// The whole epilogue-owning group is renumbered together, so no intra-outer
-/// edge becomes cross-WG (no spurious barriers on super-node→epilogue or
-/// index-math→store). sched2tlx then just reads the warp-group id.
-static void unifyNestEpilogueWarpGroup(ttg::ScheduleGraph &graph) {
-  for (auto &outer : graph.loops) {
-    // Outer (persistent) loop = owns a descriptor_store AND wraps an inner-loop
-    // super-node.
-    tt::DescriptorStoreOp storeOp;
-    unsigned storeNodeId = 0;
-    scf::ForOp innerFor;
-    int innerId = -1;
-    for (auto &n : outer.nodes) {
-      if (n.op && isa<tt::DescriptorStoreOp>(n.op)) {
-        storeOp = cast<tt::DescriptorStoreOp>(n.op);
-        storeNodeId = n.id;
-      }
-      if (n.childPipelineId != UINT_MAX && n.op)
-        if (auto f = dyn_cast<scf::ForOp>(n.op)) {
-          innerFor = f;
-          innerId = static_cast<int>(n.childPipelineId);
-        }
+/// The decision is expressed by renumbering the complete outer consumer warp
+/// group so its id is meaningful across the super-node boundary:
+///   co-locate -> the inner producer's warp-group id,
+///   separate  -> a fresh id above every id in the nest.
+/// Renumbering the whole existing group preserves intra-outer dependencies and
+/// lets barrier synthesis consume the final ids directly.
+static std::optional<int>
+computeNextInnerTcIssueDeadline(const ttg::ScheduleLoop &outer,
+                                const ttg::ScheduleLoop &inner,
+                                int childPipelineId, int producerWg) {
+  std::optional<int> superNodeCycle;
+  for (const auto &n : outer.nodes)
+    if (static_cast<int>(n.childPipelineId) == childPipelineId) {
+      superNodeCycle = n.cycle;
+      break;
     }
-    if (!storeOp || !innerFor || innerId < 0)
+  if (!superNodeCycle)
+    return std::nullopt;
+
+  std::optional<int> firstInnerTcCycle;
+  for (const auto &n : inner.nodes)
+    if (n.pipeline == ttg::HWPipeline::TC && n.warpGroup == producerWg)
+      firstInnerTcCycle =
+          firstInnerTcCycle ? std::min(*firstInnerTcCycle, n.cycle) : n.cycle;
+  if (!firstInnerTcCycle)
+    return std::nullopt;
+
+  return *superNodeCycle + outer.II + *firstInnerTcCycle;
+}
+
+static int computeWarpGroupDrainCycle(const ttg::ScheduleLoop &loop, int wg) {
+  int drain = 0;
+  for (const auto &n : loop.nodes)
+    if (n.warpGroup == wg)
+      // This is the warp issue-stream drain for register hand-off safety. Keep
+      // it based on selfLatency; async-engine occupancy is enforced separately
+      // as a global pipeline constraint by the modulo scheduler.
+      drain = std::max(drain, n.cycle + std::max(n.selfLatency, 1) *
+                                            std::max(n.frequencyMultiplier, 1));
+  return drain;
+}
+
+static int64_t getRankedTensorBytes(RankedTensorType tensorTy) {
+  if (!tensorTy || !tensorTy.hasStaticShape())
+    return 0;
+  int64_t elems = 1;
+  for (int64_t d : tensorTy.getShape())
+    elems *= d;
+  return elems * (tensorTy.getElementTypeBitWidth() / 8);
+}
+
+static bool isRegisterResidentInnerResult(scf::ForOp innerFor, int resultIdx) {
+  auto tensorTy =
+      dyn_cast<RankedTensorType>(innerFor.getResult(resultIdx).getType());
+  if (!tensorTy || getRankedTensorBytes(tensorTy) <= 0)
+    return false;
+
+  auto yield = cast<scf::YieldOp>(innerFor.getBody()->getTerminator());
+  Operation *yieldDef = yield.getOperand(resultIdx).getDefiningOp();
+  if (!yieldDef)
+    return false;
+
+  ttg::MemoryKind memoryKind = classifyMemoryKind(yieldDef);
+  return memoryKind != ttg::MemoryKind::TMEM &&
+         memoryKind != ttg::MemoryKind::SMEM;
+}
+
+static int getInnerResultProducerWg(const ttg::ScheduleLoop &innerLoop,
+                                    scf::ForOp innerFor, int resultIdx) {
+  auto yield = cast<scf::YieldOp>(innerFor.getBody()->getTerminator());
+  Operation *yieldDef = yield.getOperand(resultIdx).getDefiningOp();
+  if (!yieldDef)
+    return -1;
+  for (const auto &n : innerLoop.nodes)
+    if (n.op == yieldDef && n.warpGroup >= 0)
+      return n.warpGroup;
+  return -1;
+}
+
+struct OuterConsumerGroupInfo {
+  std::set<int> resultIndices;
+  SmallVector<unsigned> nodeIds;
+};
+
+static std::map<int, OuterConsumerGroupInfo>
+collectOuterConsumersByWarpGroup(const ttg::ScheduleLoop &outer,
+                                 scf::ForOp innerFor) {
+  llvm::DenseMap<Operation *, int> opToWg;
+  llvm::DenseMap<Operation *, unsigned> opToNodeId;
+  for (const auto &n : outer.nodes) {
+    if (!n.op || n.warpGroup < 0)
       continue;
+    opToWg[n.op] = n.warpGroup;
+    opToNodeId[n.op] = n.id;
+  }
 
-    // The epilogue-owning outer warp group (the group that runs the store).
-    int epiWg = -1;
-    for (auto &n : outer.nodes)
-      if (n.id == storeNodeId) {
-        epiWg = n.warpGroup;
-        break;
-      }
-    if (epiWg < 0)
-      continue;
-
-    // Inner warp-group ids + a fresh id above every id in the whole nest.
-    int freshId = 0;
-    const ttg::ScheduleLoop *innerLoop = nullptr;
-    for (auto &l : graph.loops) {
-      for (auto &n : l.nodes)
-        freshId = std::max(freshId, n.warpGroup + 1);
-      if (static_cast<int>(l.id) == innerId)
-        innerLoop = &l;
-    }
-
-    // Default: SEPARATE — a fresh non-aliasing id.
-    int newWg = freshId;
-
-    // Trace the store's source back to the inner-loop result it consumes. If
-    // that result is a REGISTER tensor, co-locate into its producer partition.
-    int resultIdx = -1;
-    SmallVector<Value> work{storeOp.getSrc()};
-    llvm::SmallPtrSet<Value, 8> seen;
-    while (!work.empty()) {
-      Value v = work.pop_back_val();
-      if (!seen.insert(v).second)
+  std::map<int, OuterConsumerGroupInfo> groups;
+  for (auto result : llvm::enumerate(innerFor.getResults())) {
+    int resultIdx = static_cast<int>(result.index());
+    SmallVector<Value> worklist{result.value()};
+    llvm::SmallPtrSet<Value, 16> seenValues;
+    llvm::SmallPtrSet<Operation *, 16> seenOps;
+    while (!worklist.empty()) {
+      Value v = worklist.pop_back_val();
+      if (!seenValues.insert(v).second)
         continue;
-      if (auto res = dyn_cast<OpResult>(v))
-        if (res.getOwner() == innerFor.getOperation()) {
-          resultIdx = static_cast<int>(res.getResultNumber());
+      SmallVector<OpOperand *> uses;
+      for (OpOperand &use : v.getUses())
+        uses.push_back(&use);
+      llvm::sort(uses, [](OpOperand *a, OpOperand *b) {
+        if (a->getOwner()->isBeforeInBlock(b->getOwner()))
+          return true;
+        if (b->getOwner()->isBeforeInBlock(a->getOwner()))
+          return false;
+        return a->getOperandNumber() < b->getOperandNumber();
+      });
+      for (OpOperand *use : uses) {
+        Operation *user = use->getOwner();
+        if (user == innerFor.getOperation())
+          continue;
+        if (auto yield = dyn_cast<scf::YieldOp>(user)) {
+          // Bridge values yielded from scf.if regions back to the corresponding
+          // parent result so outer consumers after the if are discovered.
+          if (auto ifOp = dyn_cast<scf::IfOp>(yield->getParentOp())) {
+            if (ifOp->getParentRegion() == innerFor->getParentRegion()) {
+              unsigned operandIdx = use->getOperandNumber();
+              if (operandIdx < ifOp.getNumResults())
+                worklist.push_back(ifOp.getResult(operandIdx));
+            }
+          }
           continue;
         }
-      Operation *def = v.getDefiningOp();
-      if (!def || def == innerFor.getOperation())
-        continue; // block arg / iv, or the inner loop itself.
-      // Only descend ops in the outer loop body — never into the inner loop.
-      if (def->getParentRegion() != innerFor->getParentRegion())
-        continue;
-      for (Value operand : def->getOperands())
-        work.push_back(operand);
+        if (user->getParentRegion() != innerFor->getParentRegion())
+          continue;
+        if (!seenOps.insert(user).second)
+          continue;
+        auto wgIt = opToWg.find(user);
+        if (wgIt != opToWg.end()) {
+          auto &info = groups[wgIt->second];
+          info.resultIndices.insert(resultIdx);
+          info.nodeIds.push_back(opToNodeId[user]);
+        }
+        for (Value out : user->getResults())
+          worklist.push_back(out);
+      }
     }
+  }
 
-    if (resultIdx >= 0 && innerLoop) {
-      Value innerResult = innerFor.getResult(resultIdx);
-      if (auto tensorTy = dyn_cast<RankedTensorType>(innerResult.getType())) {
-        int64_t elems = 1;
-        for (auto d : tensorTy.getShape())
-          elems *= d;
-        int64_t bytes = elems * (tensorTy.getElementTypeBitWidth() / 8);
-        auto yield =
-            cast<scf::YieldOp>(innerFor.getBody()->getTerminator());
-        Operation *yieldDef = yield.getOperand(resultIdx).getDefiningOp();
-        int producerWg = -1;
-        if (yieldDef)
-          for (auto &n : innerLoop->nodes)
-            if (n.op == yieldDef && n.warpGroup >= 0) {
-              producerWg = n.warpGroup;
-              break;
-            }
-        if (bytes > 0 && producerWg >= 0) {
-          newWg = producerWg; // co-locate: share the producer's WG id.
+  for (auto &[wg, info] : groups) {
+    llvm::sort(info.nodeIds);
+    info.nodeIds.erase(llvm::unique(info.nodeIds), info.nodeIds.end());
+  }
+  return groups;
+}
+
+static void renumberWarpGroup(ttg::ScheduleLoop &loop, int oldWg, int newWg) {
+  if (oldWg == newWg)
+    return;
+  for (auto &n : loop.nodes)
+    if (n.warpGroup == oldWg)
+      n.warpGroup = newWg;
+}
+
+static void resolveNestedConsumerWarpGroups(ttg::ScheduleGraph &graph) {
+  for (auto &outer : graph.loops) {
+    SmallVector<std::pair<int, scf::ForOp>> children;
+    for (const auto &n : outer.nodes)
+      if (n.childPipelineId != UINT_MAX && n.op)
+        if (auto f = dyn_cast<scf::ForOp>(n.op))
+          children.push_back({static_cast<int>(n.childPipelineId), f});
+    llvm::sort(children,
+               [](const auto &a, const auto &b) { return a.first < b.first; });
+
+    for (auto [innerId, innerFor] : children) {
+      ttg::ScheduleLoop *innerLoop = nullptr;
+      for (auto &l : graph.loops)
+        if (static_cast<int>(l.id) == innerId) {
+          innerLoop = &l;
+          break;
+        }
+      if (!innerLoop)
+        continue;
+
+      int freshId = 0;
+      for (const auto &l : graph.loops)
+        for (const auto &n : l.nodes)
+          freshId = std::max(freshId, n.warpGroup + 1);
+
+      auto consumerGroups = collectOuterConsumersByWarpGroup(outer, innerFor);
+      llvm::SmallPtrSet<const OuterConsumerGroupInfo *, 8> processedGroups;
+      for (const auto &[consumerWg, info] : consumerGroups) {
+        if (consumerWg < 0)
+          continue;
+        bool stillCurrent = false;
+        for (unsigned nodeId : info.nodeIds)
+          if (nodeId < outer.nodes.size() &&
+              outer.nodes[nodeId].warpGroup == consumerWg) {
+            stillCurrent = true;
+            break;
+          }
+        if (!stillCurrent || !processedGroups.insert(&info).second)
+          continue;
+
+        bool sawRegister = false;
+        bool sawNonRegister = false;
+        std::optional<int> producerWg;
+        int64_t registerBytes = 0;
+        for (int resultIdx : info.resultIndices) {
+          bool isRegister = isRegisterResidentInnerResult(innerFor, resultIdx);
+          sawRegister |= isRegister;
+          sawNonRegister |= !isRegister;
+          if (!isRegister)
+            continue;
+
+          int resultProducerWg =
+              getInnerResultProducerWg(*innerLoop, innerFor, resultIdx);
+          if (resultProducerWg < 0) {
+            sawNonRegister = true;
+            continue;
+          }
+          if (producerWg && *producerWg != resultProducerWg) {
+            LLVM_DEBUG(llvm::dbgs()
+                       << "[nested-wg] mixed-producer consumer WG "
+                       << consumerWg << " result " << resultIdx
+                       << " producer WG " << resultProducerWg << " vs "
+                       << *producerWg << "; keep separate\n");
+            producerWg = std::nullopt;
+            sawNonRegister = true;
+            break;
+          }
+          producerWg = resultProducerWg;
+          registerBytes += getRankedTensorBytes(dyn_cast<RankedTensorType>(
+              innerFor.getResult(resultIdx).getType()));
+        }
+
+        int newWg = freshId++;
+        if (!sawRegister || sawNonRegister || !producerWg) {
           LLVM_DEBUG(llvm::dbgs()
-                     << "[colocate] outer epilogue → inner WG " << producerWg
-                     << " (register hand-off " << bytes << " B removed)\n");
+                     << "[nested-wg] reject consumer WG " << consumerWg
+                     << " (register=" << sawRegister
+                     << ", non-register=" << sawNonRegister
+                     << "); keep separate as WG " << newWg << "\n");
+          renumberWarpGroup(outer, consumerWg, newWg);
+          continue;
+        }
+
+        int consumerDrain = computeWarpGroupDrainCycle(outer, consumerWg);
+        std::optional<int> nextTcDeadline = computeNextInnerTcIssueDeadline(
+            outer, *innerLoop, innerId, *producerWg);
+        if (!nextTcDeadline) {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "[nested-wg] no-TC consumer WG " << consumerWg
+                     << " -> inner WG " << *producerWg << " (register hand-off "
+                     << registerBytes << " B, drain=" << consumerDrain
+                     << "); co-locate\n");
+          renumberWarpGroup(outer, consumerWg, *producerWg);
+          continue;
+        }
+
+        if (consumerDrain <= *nextTcDeadline) {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "[nested-wg] co-locate consumer WG " << consumerWg
+                     << " -> inner WG " << *producerWg << " (register hand-off "
+                     << registerBytes << " B, drain=" << consumerDrain
+                     << ", deadline=" << *nextTcDeadline << ")\n");
+          renumberWarpGroup(outer, consumerWg, *producerWg);
+        } else {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "[nested-wg] reject consumer WG " << consumerWg
+                     << " -> inner WG " << *producerWg << " (register hand-off "
+                     << registerBytes << " B, drain=" << consumerDrain
+                     << ", deadline=" << *nextTcDeadline
+                     << "); keep separate as WG " << newWg << "\n");
+          renumberWarpGroup(outer, consumerWg, newWg);
         }
       }
     }
-
-    if (newWg == epiWg)
-      continue; // already correct.
-
-    // Renumber the WHOLE epilogue-owning group together.
-    for (auto &n : outer.nodes)
-      if (n.warpGroup == epiWg)
-        n.warpGroup = newWg;
   }
 }
 
-/// Pass B: Per-loop warp-group partition + cross-group barriers. Each
-/// ScheduleLoop gets its own Phase 4 partition run with its own II.
-/// Nested kernels (case2/case5) get inner-partition (e.g., 3-WG GEMM
-/// split) decided at inner II without being drowned by the outer II.
-/// Single-loop kernels (case1/case3) reduce to a single partition run
-/// over that one loop. The acc_tmem TC↔default hand-off is the emitter's
-/// legacy carve-out — no cross-loop barrier rebuild needed.
-///
-/// `TRITON_MODULO_EXHAUSTIVE_PARTITION=0|off|false` opts into the greedy
-/// fallback partitioner. Default is the exhaustive Phase 4 search.
+/// Pass B: Finalize constructively selected warp groups and materialize
+/// communication. Each ScheduleLoop keeps the warp groups assigned during
+/// modulo scheduling; this pass only demotes/propagates infra ops, reconciles
+/// nested epilogues, inserts cross-group barriers, and merges channel buffers.
 static void
 applyGlobalWarpPartition(MutableArrayRef<ScheduledLoop> scheduledLoops) {
-  auto exhaustiveEnv =
-      triton::tools::getStrEnv("TRITON_MODULO_EXHAUSTIVE_PARTITION");
-  bool useGreedy = (exhaustiveEnv == "0" || exhaustiveEnv == "false" ||
-                    exhaustiveEnv == "off");
-  // Whole-kernel committed SMEM: a loop's partition candidates must fit
-  // alongside every OTHER loop's buffers (nested/sibling loops coexist in
-  // the CTA — the budget reducers already enforce the limit jointly, see
-  // reduceBuffersForGlobalBudget; the channel-capacity gate must too).
-  int64_t allLoopsSmem = 0;
-  for (auto &sl : scheduledLoops)
-    for (auto &schedLoop : sl.graph.loops)
-      allLoopsSmem += computeTotalSmem(schedLoop);
   for (auto &sl : scheduledLoops) {
     for (auto &schedLoop : sl.graph.loops) {
       if (schedLoop.II <= 0)
         continue;
-      // Every loop — inner AND outer — goes through the same cost-model
-      // partitioner: the makespan (single-iteration latency chain over each
-      // WG's pipeAvail) plus barrier cost decides the split uniformly, and
-      // all candidates carry the same RecMII'-floor / launchability terms.
-      // No env flag, no hard override, no outer-loop special case: sched2tlx
-      // lowers multi-WG outer bodies, and its task-coverage check hard-errors
-      // on any scheduled op no task owns rather than dropping it silently.
-      // This rewards warp specialization wherever it overlaps independent
-      // pipelines across groups: GEMM/FA (MEM/TC/softmax) AND memory-bound
-      // loops like LayerNorm, where putting TMA-load, compute, and TMA-store
-      // on separate warp groups frees the compute warps and removes the
-      // in-stream store drain (measured ~1.2x over 1-WG software
-      // pipelining).
-      if (useGreedy) {
-        partitionIntoWarpGroups(schedLoop);
-      } else {
-        partitionExhaustive(schedLoop,
-                            allLoopsSmem - computeTotalSmem(schedLoop));
-      }
       demoteScalarArithToInfra(schedLoop);
       propagateWarpGroupToInfraOps(schedLoop);
       coLocateOperandAllocsWithLoads(schedLoop);
     }
   }
 
-  // Cross-loop reconciliation: now that every loop has warp groups, unify each
-  // outer epilogue's warp-group id with its inner producer (storage-class-priced
+  // Cross-loop reconciliation: now that every loop has warp groups, resolve
+  // outer consumer warp-group ids against inner producers (storage-class-priced
   // hand-off cost model). Runs before barrier insertion so the renumbered ids
   // drive barrier synthesis and the emitter reads them directly.
   for (auto &sl : scheduledLoops)
-    unifyNestEpilogueWarpGroup(sl.graph);
+    resolveNestedConsumerWarpGroups(sl.graph);
 
   // Run barrier insertion per-loop using the now-globally-consistent
   // warp-group IDs. Cross-loop barriers (from Phase 2 edges) are still


### PR DESCRIPTION
Summary:
Replace the two-phase modulo-scheduling flow, where instruction cycles were fixed first and warp partitions were enumerated and scored afterward, with a constructive scheduler that assigns each instruction both an issue cycle and a warp group.

For each target II, the scheduler maintains one global reservation table for shared hardware pipelines and a separate circular issue stream for every warp group. It tries existing groups at the instruction's earliest globally available pipeline cycle, creates another group only when no existing group can issue at that time, and incorporates cross-group register or synchronization latency before placing consumers. Warp usage is checked against the hardware limit, and bounded dependency-safe ejection can reconsider lower-priority leaf placements without invalidating already-scheduled consumers.

Carry the resulting node-to-warp-group assignment through ScheduleGraph and directly into downstream partition, barrier, and channel generation. The runtime path no longer enumerates, sorts, or commits cluster-partition candidates, and cycle-only alternate scheduler modes no longer bypass the joint assignment contract.

Resolve nested outer-consumer grouping from inner-result dataflow rather than kernel categories, function names, or descriptor-store patterns. Discover outer consumer groups transitively, including values crossing scf.if results, and preserve TMEM/SMEM handoffs as separate groups. For register handoffs, co-locate the consumer with its inner producer only when the consumer issue stream drains before the next outer iteration's inner-TC issue deadline; otherwise assign a fresh group. This lets nested loop pipelining choose fewer or more groups automatically from schedule timing while leaf loops remain unchanged.
