### PR TITLE
[triton][tlx] Emit ttg.memdesc_index as tlx.local_view in TTGIR-to-TLX

### DIFF
--- a/test/TLX/print-ttgir-to-tlx-memdesc-index.mlir
+++ b/test/TLX/print-ttgir-to-tlx-memdesc-index.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-opt --tlx-print-ttgir-to-tlx %s | FileCheck %s
+
+// Regression test for emitting ttg.memdesc_index as tlx.local_view.
+//
+// A ttg.memdesc_index indexes into a buffer/barrier array to produce the view
+// referenced later in the kernel. It must be emitted as tlx.local_view when a
+// real consumer needs that view, and skipped when every user is a barrier
+// lifecycle op (init_barrier / inval_barrier, folded into alloc_barriers) or
+// when it has no users at all.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // A view consumed by wait_barrier (a real consumer) must be emitted, even
+  // though the same view is also init'd here.
+  // CHECK-LABEL: def shared_barrier_view_emitted(
+  // CHECK: tlx.alloc_barriers(
+  // CHECK: tlx.local_view(
+  // CHECK: tlx.barrier_wait(
+  tt.func public @shared_barrier_view_emitted() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1x1xi64, #shared, #smem, mutable>
+    %view = ttg.memdesc_index %bar[%c0_i32] : !ttg.memdesc<1x1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %view, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %view, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // A view used only by init_barrier folds into alloc_barriers and is NOT
+  // emitted as a local_view.
+  // CHECK-LABEL: def barrier_lifecycle_view_skipped(
+  // CHECK: tlx.alloc_barriers(
+  // CHECK-NOT: tlx.local_view(
+  tt.func public @barrier_lifecycle_view_skipped() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1x1xi64, #shared, #smem, mutable>
+    %view = ttg.memdesc_index %bar[%c0_i32] : !ttg.memdesc<1x1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %view, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // A view with no users is skipped (not emitted as a dead local_view).
+  // CHECK-LABEL: def unused_view_skipped(
+  // CHECK-NOT: tlx.local_view(
+  tt.func public @unused_view_skipped() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1x1xi64, #shared, #smem, mutable>
+    %view = ttg.memdesc_index %bar[%c0_i32] : !ttg.memdesc<1x1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -766,10 +766,27 @@ bool shouldSkipOp(
       "ttng.inval_barrier",
       "tt.splat",
       "tt.broadcast",
-      "ttg.memdesc_index",
       "tt.map_elementwise.return",
       "ttng.tcgen5_global_alloc",
   };
+  // Emit ttg.memdesc_index as tlx.local_view when a real consumer needs the
+  // view (MMA, wait, local_store, loop iter-arg, ...). Skip it when it has no
+  // users, or when every user is a barrier-lifecycle op (init_barrier /
+  // inval_barrier) that folds into the alloc_barriers() for the barrier alloc.
+  if (opName == "ttg.memdesc_index") {
+    bool hasUser = false, allBarrierLifecycle = true;
+    for (Value result : op->getResults()) {
+      for (Operation *user : result.getUsers()) {
+        hasUser = true;
+        StringRef userName = user->getName().getStringRef();
+        if (userName != "ttng.init_barrier" && userName != "ttng.inval_barrier")
+          allBarrierLifecycle = false;
+      }
+    }
+    if (!hasUser || allBarrierLifecycle)
+      return true;
+    return skippedOps.count(op) > 0;
+  }
   if (opsToSkip.contains(opName)) {
     // Don't skip arith.constant with DenseElementsAttr (tensor splat constants)
     // — they need to be printed as explicit tl.full() assignments


### PR DESCRIPTION
Summary:
The printer blanket-skipped `ttg.memdesc_index`. That op indexes into a buffer/barrier array to produce the views referenced later in the kernel body: `barrier_wait`, `local_store`, MMA accumulators, etc. Skipping it left those views undefined in the emitted Python (use-before-def), e.g. `blackwell_fa_ws_persistent`'s output-staging buffer view `var_3`.

Emit `ttg.memdesc_index` as `tlx.local_view(base, idx)` (the op mapping already exists), and skip only the barrier-init views whose result feeds `ttng.init_barrier`, as those are folded into the `alloc_barriers()` emitted for the barrier allocation so re-emitting them would be redundant.

Authored with Claude, iterated initially by squashing two dependent commits, clarifying the comment, and adding complete braces to the nested `for` loops for clarity, followed by generating the new LIT test `print-ttgir-to-tlx-memdesc-index`.

Reviewed By: njriasan

Differential Revision: D113598227


