### PR TITLE
[triton][beta] Measure gfx950 operation latencies (#2507)

### DIFF
--- a/test/TritonGPU/amd/amd-modulo-warp-pipeline-partition.mlir
+++ b/test/TritonGPU/amd/amd-modulo-warp-pipeline-partition.mlir
@@ -7,8 +7,8 @@
 // Test 1: Two pipelines (LDS + MFMA).
 // A minimal GEMM loop with LDS local_loads feeding a dot.
 //
-// CHECK: remark: amd-modulo: DDG {{[0-9]+}} nodes MFMA={{[0-9]+}} LDS={{[0-9]+}}
-// CHECK-SAME: clusters=
+// CHECK-DAG: remark: amd-modulo: DDG {{[0-9]+}} nodes MFMA={{[0-9]+}} LDS={{[0-9]+}}{{.*}}clusters=
+// CHECK-DAG: remark: amd-modulo: DDG {{[0-9]+}} nodes{{.*}}GLOBAL={{[1-9]}}{{.*}}clusters=
 // Step 4.7/4.8 annotate each op with its cluster ID and derived s_setprio: the
 // LDS local_loads and the MFMA dot land in different clusters.
 // CHECK:      ttg.local_load {{.*}}ttg.warp_pipeline_cluster = {{[0-9]+}}{{.*}}ttg.warp_pipeline_priority = {{[0-9]+}}
@@ -45,8 +45,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // Test 2: Three pipelines (GLOBAL + LDS + MFMA).
 // A GEMM loop with global loads, local stores/loads, and a dot.
 //
-// CHECK: remark: amd-modulo: DDG {{[0-9]+}} nodes{{.*}}GLOBAL={{[1-9]}}
-// CHECK-SAME: clusters=
 // GLOBAL/LDS ops and the MFMA dot are annotated with cluster + priority.
 // CHECK:      tt.load {{.*}}ttg.warp_pipeline_cluster = {{[0-9]+}}{{.*}}ttg.warp_pipeline_priority = {{[0-9]+}}
 // CHECK:      tt.dot {{.*}}ttg.warp_pipeline_cluster = {{[0-9]+}}{{.*}}ttg.warp_pipeline_priority = {{[0-9]+}}

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDLatencyModel.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDLatencyModel.cpp
@@ -1,7 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 //
-// AMD CDNA (gfx9) latency model. See AMDLatencyModel.h. Cycle counts are
-// PLACEHOLDERS pending an AMD latency microbenchmark (refactor plan Phase C).
+// AMD CDNA (gfx9) latency model. See AMDLatencyModel.h.
 
 #include "AMDLatencyModel.h"
 
@@ -40,8 +39,7 @@ HWPipeline AMDLatencyModel::classifyPipeline(Operation *op) const {
 }
 
 OpLatencyInfo AMDLatencyModel::getLatency(Operation *op) const {
-  // PLACEHOLDER cycle counts — calibrate via an AMD microbench before using for
-  // real scheduling. `latency` = result-ready delay (drives RecMII);
+  // `latency` = result-ready delay (drives RecMII);
   // `selfLatency`/`occupancy` = pipe-hold (drives ResMII).
   HWPipeline pipe = classifyPipeline(op);
   switch (pipe) {
@@ -67,35 +65,58 @@ OpLatencyInfo AMDLatencyModel::getLatency(Operation *op) const {
           int64_t iK = std::max<int64_t>(1, (int64_t)instr[2]);
           int64_t M = rt.getShape()[0], N = rt.getShape()[1];
           int64_t K = aT.getShape()[1];
-          nMfma = ((M + tileM - 1) / tileM) * ((N + tileN - 1) / tileN) *
-                  ((K + iK - 1) / iK);
+          auto saturatingMul = [](int64_t lhs, int64_t rhs) {
+            if (lhs == 0 || rhs == 0)
+              return int64_t{0};
+            if (lhs > std::numeric_limits<int64_t>::max() / rhs)
+              return std::numeric_limits<int64_t>::max();
+            return lhs * rhs;
+          };
+          int64_t mCount = (M + tileM - 1) / tileM;
+          int64_t nCount = (N + tileN - 1) / tileN;
+          int64_t kCount = (K + iK - 1) / iK;
+          nMfma = saturatingMul(saturatingMul(mCount, nCount), kCount);
           if (nMfma < 1)
             nMfma = 1;
         }
       }
     }
-    // ~16 cyc per 16x16x32 MFMA (LLIR anchor). Clamp before narrowing to the
-    // int `latency` field: nMfma is int64 (product of M/N/K tile counts), so a
-    // very large dot could overflow int and wrap to a tiny/negative value,
-    // silently defeating the MFMA-count scaling.
-    int lat =
-        (int)std::min<int64_t>(nMfma * 16, std::numeric_limits<int>::max());
-    return OpLatencyInfo{pipe, /*latency=*/lat, /*selfLatency=*/lat,
-                         /*minWarps=*/1, /*occupancy=*/lat};
+    // gfx950 measurement using tlx.clock64/s_memtime and a runtime loop:
+    //   dependent v_mfma_f32_16x16x32_f16: 18.25 ticks ~= 18 cycles
+    //   four independent streams:          16.62 ticks/MFMA ~= 17 cycles
+    // s_memtime measured at 2.183 GHz while the gfx950 shader clock reached
+    // 2.2 GHz (1.008 cycles/tick). Scale the block-level dot by its per-wave
+    // hardware MFMA count and keep dependency latency distinct from occupancy.
+    int64_t intMax = std::numeric_limits<int>::max();
+    int latency = (int)std::min<int64_t>(nMfma, intMax / 18) * 18;
+    int occupancy = (int)std::min<int64_t>(nMfma, intMax / 17) * 17;
+    return OpLatencyInfo{pipe, /*latency=*/latency,
+                         /*selfLatency=*/occupancy, /*minWarps=*/1,
+                         /*occupancy=*/occupancy};
   }
   case HWPipeline::LDS:
-    return OpLatencyInfo{pipe, /*latency=*/30, /*selfLatency=*/4,
+    // gfx950 pure LDS read measurement using tlx.local_gather over a
+    // preinitialized 1D i32 LDS table:
+    //   dependent idx_{i+1}=table[idx_i]: 68.16 ticks ~= 69 cycles
+    //   four independent streams:         28.17 ticks/gather ~= 28 cycles
+    // A CTA barrier separates table initialization from timing. The dependent
+    // case isolates result-ready ds_read latency: the timed s_memtime region
+    // contains ds_read_b32 and no ds_write. Keep occupancy at the prior
+    // conservative value because x4 does not establish the issue-rate floor.
+    return OpLatencyInfo{pipe, /*latency=*/69, /*selfLatency=*/4,
                          /*minWarps=*/1, /*occupancy=*/4};
   case HWPipeline::GLOBAL:
     // Multi-outstanding async global (HBM) load: long round-trip, short
-    // occupancy. latency=790 measured on gfx950 by
-    // claude/amd_latency_microbench.py (pointer-chase: ~360 ns/load x 2.2 GHz,
-    // stable across runs).
+    // occupancy. Keep the conservative 790-cycle estimate: the current
+    // microbenchmark measures a warm self-pointer load, not DRAM latency.
     return OpLatencyInfo{pipe, /*latency=*/790, /*selfLatency=*/8,
                          /*minWarps=*/1, /*occupancy=*/8};
   case HWPipeline::VALU:
-    return OpLatencyInfo{pipe, /*latency=*/16, /*selfLatency=*/4,
-                         /*minWarps=*/4, /*occupancy=*/4};
+    // A dependent v_fma_f32 chain measures 8.30 s_memtime ticks ~= 8 cycles.
+    // The existing four-cycle occupancy remains conservative until a dedicated
+    // instruction-counted independent-stream benchmark is available.
+    return OpLatencyInfo{pipe, /*latency=*/8, /*selfLatency=*/4,
+                         /*minWarps=*/2, /*occupancy=*/4};
   default:
     return OpLatencyInfo{HWPipeline::NONE, /*latency=*/0, /*selfLatency=*/0,
                          /*minWarps=*/1, /*occupancy=*/0};

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDLatencyModel.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDLatencyModel.h
@@ -16,12 +16,14 @@ namespace mlir::triton::gpu {
 /// are needed, this should move into the AMD backend once the core is relocated
 /// to a neutral path.
 ///
-/// Cycle counts (gfx950): GLOBAL latency=790 is MEASURED
-/// (claude/amd_latency_microbench.py, pointer-chase ~360 ns x 2.2 GHz). MFMA =
-/// 16 cyc PER hardware MFMA (LLIR 16x16x32 anchor) SCALED by the dot's per-wave
-/// MFMA count, so a block-level tt.dot's cost reflects real compute (critical:
-/// the un-scaled single-MFMA cost made II tiny -> the scheduler over-staged the
-/// prefetch). LDS=30 / VALU=16 are still coarse CDNA estimates (refine later).
+/// Cycle counts (gfx950): `third_party/tlx/tools/microbench/amd_latency.py`
+/// measures s_memtime at 2.183 GHz versus a 2.2 GHz shader clock (1.008
+/// cycles/tick). A dependent 16x16x32 fp16 MFMA measures ~18 cycles and four
+/// independent streams measure ~17 cycles/MFMA. A dependent fp32 VALU FMA
+/// measures ~8 cycles. A dependent LDS `tlx.local_gather` pointer chase
+/// over a preinitialized 1D i32 LDS table measures ~69 cycles with no timed
+/// ds_write. GLOBAL latency=790 remains the conservative DRAM estimate; the
+/// new pointer-chase result is a warm/self-pointer load and is not substituted.
 /// The accumulator hooks intentionally use the base no-op defaults: AMD
 /// accumulates MFMA results in registers, so there is no TMEM-style cross-loop
 /// hazard.

--- a/third_party/tlx/tools/microbench/amd_latency.py
+++ b/third_party/tlx/tools/microbench/amd_latency.py
@@ -1,0 +1,755 @@
+"""gfx950 TLX latency/throughput microbenchmarks.
+
+This is a pragmatic first-pass device-timed suite for instruction/model
+calibration. Kernels use ``tlx.clock64`` around the measured region and return
+raw target timer ticks from synchronized host launches. The baseline row is a
+diagnostic only; it is not subtracted from primary metrics.
+
+Coverage:
+  - baseline: clock64 + loop overhead
+  - VALU: runtime-seeded dependent recurrence and four explicit independent
+    scalar recurrences
+  - LDS: runtime-seeded pure ``tlx.local_gather`` pointer chase over a
+    preinitialized 1D i32 LDS table, plus independent gather streams
+  - GLOBAL: dependent ``tl.load`` latency, plus direct-to-LDS composite via
+    ``tlx.buffer_load_to_local`` commit/wait + ``tlx.local_load``
+  - MFMA: gfx9-style fp16 ``tl.dot`` shapes with BLOCK_K=32 and
+    ``matrix_instr_nonkdim=16`` launch metadata
+
+Example:
+  python third_party/tlx/tools/microbench/amd_latency.py --bench all --niter 256 --reps 5
+  python third_party/tlx/tools/microbench/amd_latency.py --bench valu,lds --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+
+DEFAULT_NITER = 256
+DEFAULT_WARMUP = 2
+DEFAULT_REPS = 5
+
+# Calibrated on gfx950 by comparing a long s_memtime-bracketed runtime loop
+# against host monotonic time. rocminfo reports a 2.2 GHz maximum shader clock.
+SMEMTIME_HZ = 2.183e9
+GFX950_MAX_SCLK_HZ = 2.2e9
+CYCLES_PER_TICK = GFX950_MAX_SCLK_HZ / SMEMTIME_HZ
+
+ALL_BENCHES = ("baseline", "valu", "lds", "global", "mfma")
+
+
+@triton.jit
+def _k_baseline(seed_ptr, out_ptr, check_ptr, NITER):
+    tid = tlx.thread_id(0)
+    x = tl.load(seed_ptr).to(tl.float32)
+    t0 = tlx.clock64()
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+        x += 1.0
+    t1 = tlx.clock64()
+    if tid == 0:
+        tl.store(out_ptr, t1 - t0)
+        tl.store(check_ptr, x)
+
+
+@triton.jit
+def _k_valu_dependent(seed_ptr, out_ptr, check_ptr, NITER):
+    tid = tlx.thread_id(0)
+    x = tl.load(seed_ptr).to(tl.float32)
+    mul = tl.load(seed_ptr + 1).to(tl.float32)
+    inc = tl.load(seed_ptr + 2).to(tl.float32)
+    t0 = tlx.clock64()
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+        x = x * mul + inc
+    t1 = tlx.clock64()
+    if tid == 0:
+        tl.store(out_ptr, t1 - t0)
+        tl.store(check_ptr, x)
+
+
+@triton.jit
+def _k_valu_independent_x4(seed_ptr, out_ptr, check_ptr, NITER):
+    tid = tlx.thread_id(0)
+    x0 = tl.load(seed_ptr + 0).to(tl.float32)
+    x1 = tl.load(seed_ptr + 1).to(tl.float32)
+    x2 = tl.load(seed_ptr + 2).to(tl.float32)
+    x3 = tl.load(seed_ptr + 3).to(tl.float32)
+    mul0 = tl.load(seed_ptr + 4).to(tl.float32)
+    mul1 = tl.load(seed_ptr + 5).to(tl.float32)
+    mul2 = tl.load(seed_ptr + 6).to(tl.float32)
+    mul3 = tl.load(seed_ptr + 7).to(tl.float32)
+    inc0 = tl.load(seed_ptr + 8).to(tl.float32)
+    inc1 = tl.load(seed_ptr + 9).to(tl.float32)
+    inc2 = tl.load(seed_ptr + 10).to(tl.float32)
+    inc3 = tl.load(seed_ptr + 11).to(tl.float32)
+    t0 = tlx.clock64()
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+        x0 = x0 * mul0 + inc0
+        x1 = x1 * mul1 + inc1
+        x2 = x2 * mul2 + inc2
+        x3 = x3 * mul3 + inc3
+    t1 = tlx.clock64()
+    if tid == 0:
+        tl.store(out_ptr, t1 - t0)
+        tl.store(check_ptr, x0 + x1 + x2 + x3)
+
+
+@triton.jit
+def _k_lds_dependent_gather_chase(table_ptr, out_ptr, check_ptr, NITER):
+    tid = tlx.thread_id(0)
+    offsets = tl.arange(0, 64)
+    table = tlx.local_alloc((64,), tl.int32, 1)
+    tlx.local_store(table[0], tl.load(table_ptr + offsets))
+    tl.debug_barrier()
+
+    idx = tl.load(table_ptr + 64).to(tl.int32)
+    t0 = tlx.clock64()
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+        gathered = tlx.local_gather(table[0], tl.full((1,), idx, tl.int32), 0)
+        idx = tl.sum(gathered, axis=0).to(tl.int32)
+    t1 = tlx.clock64()
+    if tid == 0:
+        tl.store(out_ptr, t1 - t0)
+        tl.store(check_ptr, idx.to(tl.float32))
+
+
+@triton.jit
+def _k_lds_independent_gather_x4(table_ptr, out_ptr, check_ptr, NITER):
+    tid = tlx.thread_id(0)
+    offsets = tl.arange(0, 64)
+    table = tlx.local_alloc((64,), tl.int32, 1)
+    tlx.local_store(table[0], tl.load(table_ptr + offsets))
+    tl.debug_barrier()
+
+    idx0 = tl.load(table_ptr + 64).to(tl.int32)
+    idx1 = tl.load(table_ptr + 65).to(tl.int32)
+    idx2 = tl.load(table_ptr + 66).to(tl.int32)
+    idx3 = tl.load(table_ptr + 67).to(tl.int32)
+    t0 = tlx.clock64()
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+        idx0 = tl.sum(tlx.local_gather(table[0], tl.full((1,), idx0, tl.int32), 0), axis=0).to(tl.int32)
+        idx1 = tl.sum(tlx.local_gather(table[0], tl.full((1,), idx1, tl.int32), 0), axis=0).to(tl.int32)
+        idx2 = tl.sum(tlx.local_gather(table[0], tl.full((1,), idx2, tl.int32), 0), axis=0).to(tl.int32)
+        idx3 = tl.sum(tlx.local_gather(table[0], tl.full((1,), idx3, tl.int32), 0), axis=0).to(tl.int32)
+    t1 = tlx.clock64()
+    if tid == 0:
+        tl.store(out_ptr, t1 - t0)
+        tl.store(check_ptr, (idx0 + idx1 + idx2 + idx3).to(tl.float32))
+
+
+@triton.jit
+def _k_global_tl_load_dependent(src_ptr, out_ptr, check_ptr, NITER):
+    tid = tlx.thread_id(0)
+    idx = tl.load(src_ptr + 1).to(tl.int64)
+    acc = tl.full((), 0, tl.int64)
+    t0 = tlx.clock64()
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+        # src contains a self pointer at 0; this creates a serialized global load
+        # dependency without changing the address range.
+        idx = tl.load(src_ptr + idx).to(tl.int64)
+        acc += idx
+    t1 = tlx.clock64()
+    if tid == 0:
+        tl.store(out_ptr, t1 - t0)
+        tl.store(check_ptr, acc + idx)
+
+
+@triton.jit
+def _k_global_direct_to_lds_composite(src_ptr, out_ptr, check_ptr, NITER):
+    tid = tlx.thread_id(0)
+    smem = tlx.local_alloc((32, 32), tl.float16, 1)
+    offs = tl.arange(0, 32)[:, None] * 32 + tl.arange(0, 32)[None, :]
+    acc = tl.zeros((32, 32), tl.float32)
+    t0 = tlx.clock64()
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+        tok = tlx.buffer_load_to_local(smem[0], src_ptr, offs)
+        tlx.async_load_commit_group([tok])
+        tlx.async_load_wait_group(0)
+        v = tlx.local_load(smem[0], relaxed=True)
+        acc += v
+    t1 = tlx.clock64()
+    s = tl.sum(tl.sum(acc, axis=1), axis=0)
+    if tid == 0:
+        tl.store(out_ptr, t1 - t0)
+        tl.store(check_ptr, s)
+
+
+@triton.jit
+def _k_mfma_dependent(a_ptr, b_ptr, out_ptr, check_ptr, NITER):
+    tid = tlx.thread_id(0)
+    offs_m = tl.arange(0, 32)
+    offs_n = tl.arange(0, 32)
+    offs_k = tl.arange(0, 32)
+    a = tl.load(a_ptr + offs_m[:, None] * 32 + offs_k[None, :])
+    b = tl.load(b_ptr + offs_k[:, None] * 32 + offs_n[None, :])
+    acc = tl.zeros((32, 32), tl.float32)
+    t0 = tlx.clock64()
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+        acc = tl.dot(a, b, acc, allow_tf32=False)
+    t1 = tlx.clock64()
+    s = tl.sum(tl.sum(acc, axis=1), axis=0)
+    if tid == 0:
+        tl.store(out_ptr, t1 - t0)
+        tl.store(check_ptr, s)
+
+
+@triton.jit
+def _k_mfma_independent_x4(a_ptr, b_ptr, out_ptr, check_ptr, NITER):
+    tid = tlx.thread_id(0)
+    offs_m = tl.arange(0, 32)
+    offs_n = tl.arange(0, 32)
+    offs_k = tl.arange(0, 32)
+    a0 = tl.load(a_ptr + offs_m[:, None] * 32 + offs_k[None, :])
+    a1 = tl.load(a_ptr + 1024 + offs_m[:, None] * 32 + offs_k[None, :])
+    a2 = tl.load(a_ptr + 2048 + offs_m[:, None] * 32 + offs_k[None, :])
+    a3 = tl.load(a_ptr + 3072 + offs_m[:, None] * 32 + offs_k[None, :])
+    b0 = tl.load(b_ptr + offs_k[:, None] * 32 + offs_n[None, :])
+    b1 = tl.load(b_ptr + 1024 + offs_k[:, None] * 32 + offs_n[None, :])
+    b2 = tl.load(b_ptr + 2048 + offs_k[:, None] * 32 + offs_n[None, :])
+    b3 = tl.load(b_ptr + 3072 + offs_k[:, None] * 32 + offs_n[None, :])
+    acc0 = tl.zeros((32, 32), tl.float32)
+    acc1 = tl.zeros((32, 32), tl.float32)
+    acc2 = tl.zeros((32, 32), tl.float32)
+    acc3 = tl.zeros((32, 32), tl.float32)
+    t0 = tlx.clock64()
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+        acc0 = tl.dot(a0, b0, acc0, allow_tf32=False)
+        acc1 = tl.dot(a1, b1, acc1, allow_tf32=False)
+        acc2 = tl.dot(a2, b2, acc2, allow_tf32=False)
+        acc3 = tl.dot(a3, b3, acc3, allow_tf32=False)
+    t1 = tlx.clock64()
+    acc = acc0 + acc1 + acc2 + acc3
+    s = tl.sum(tl.sum(acc, axis=1), axis=0)
+    if tid == 0:
+        tl.store(out_ptr, t1 - t0)
+        tl.store(check_ptr, s)
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    family: str
+    unit: str
+    kernel: Any
+    make_args: Callable[[], list[Any]]
+    ops_per_iter: int = 1
+    baseline_key: str = "baseline.loop"
+    num_warps: int = 4
+    launch_meta: dict[str, Any] = field(default_factory=dict)
+    meta: dict[str, Any] = field(default_factory=dict)
+    expected_check: Callable[[int], float] | None = None
+
+
+def _active_device() -> torch.device:
+    return triton.runtime.driver.active.get_active_torch_device()
+
+
+def _device_info() -> dict[str, Any]:
+    dev = _active_device()
+    props = torch.cuda.get_device_properties(dev)
+    return {
+        "name": torch.cuda.get_device_name(dev),
+        "device": str(dev),
+        "hip": torch.version.hip,
+        "gcn_arch_name": getattr(props, "gcnArchName", ""),
+        "multi_processor_count": props.multi_processor_count,
+    }
+
+
+def is_gfx950() -> bool:
+    if not torch.cuda.is_available() or torch.version.hip is None:
+        return False
+    try:
+        arch = str(getattr(torch.cuda.get_device_properties(_active_device()), "gcnArchName", ""))
+    except Exception:
+        return False
+    return "gfx950" in arch
+
+
+def _percentile(sorted_samples: list[float], percentile: float) -> float:
+    if len(sorted_samples) == 1:
+        return sorted_samples[0]
+    rank = (len(sorted_samples) - 1) * percentile
+    lo = int(rank)
+    hi = min(lo + 1, len(sorted_samples) - 1)
+    frac = rank - lo
+    return sorted_samples[lo] * (1.0 - frac) + sorted_samples[hi] * frac
+
+
+def _summarize(samples: list[float]) -> dict[str, Any]:
+    ordered = sorted(samples)
+    mean = statistics.mean(samples)
+    stdev = statistics.stdev(samples) if len(samples) > 1 else 0.0
+    return {
+        "median": statistics.median(samples),
+        "p20": _percentile(ordered, 0.20),
+        "p80": _percentile(ordered, 0.80),
+        "min": min(samples),
+        "max": max(samples),
+        "mean": mean,
+        "stdev": stdev,
+        "cv": stdev / mean if mean else 0.0,
+        "samples": samples,
+    }
+
+
+def _compiled_asm(compiled_or_none: Any) -> str | None:
+    asm = getattr(compiled_or_none, "asm", None)
+    if isinstance(asm, dict):
+        return "\n".join(str(value) for value in asm.values()).lower()
+    if isinstance(asm, str):
+        return asm.lower()
+    return None
+
+
+def _compiled_asm_section(compiled_or_none: Any, key: str) -> str | None:
+    asm = getattr(compiled_or_none, "asm", None)
+    if isinstance(asm, dict):
+        value = asm.get(key)
+        return str(value).lower() if value is not None else None
+    return None
+
+
+def _count_tokens(asm_text: str | None, tokens: tuple[str, ...]) -> dict[str, int] | None:
+    if not asm_text:
+        return None
+    return {token: len(re.findall(rf"\b{re.escape(token)}\b", asm_text)) for token in tokens}
+
+
+def _count_mfma(asm_text: str | None) -> int | None:
+    if not asm_text:
+        return None
+    return len(re.findall(r"\b(v_)?mfma", asm_text))
+
+
+def _timed_region_text(asm_text: str | None) -> str | None:
+    if not asm_text:
+        return None
+    first = re.search(r"\bs_memtime\b", asm_text)
+    if not first:
+        return None
+    second = re.search(r"\bs_memtime\b", asm_text[first.end() :])
+    if not second:
+        return None
+    start = first.end()
+    end = first.end() + second.start()
+    return asm_text[start:end]
+
+
+def _isa_case_sanity(case: Case, asm_text: str | None, ttgir_text: str | None = None) -> dict[str, Any]:
+    if not asm_text:
+        return {
+            "available": False,
+            "ok": None,
+            "checks": {},
+            "valu_instruction_counts": None,
+            "mfma_instruction_count": None,
+            "estimated_mfma_per_loop_iter": None,
+            "estimated_mfma_per_loop_iter_note": "assembly unavailable",
+            "timed_region_instruction_counts": None,
+        }
+    checks: dict[str, bool] = {"clock64": any(token in asm_text for token in ("s_memtime", "s.memtime", "clock64"))}
+    valu_counts = _count_tokens(asm_text, ("v_fma_f32", "v_fmac_f32", "v_mul_f32", "v_add_f32"))
+    if case.family == "valu":
+        checks["valu_arithmetic"] = any(valu_counts.values()) if valu_counts else False
+    if case.family == "mfma":
+        checks["mfma"] = "mfma" in asm_text
+    timed_region = _timed_region_text(asm_text)
+    timed_counts = _count_tokens(timed_region, ("ds_read_b32", "ds_write_b32", "ds_write"))
+    if case.family == "lds":
+        checks["ds_read"] = "ds_read" in asm_text
+        if case.meta.get("timed_stores") is False:
+            checks["ttgir_local_gather"] = ttgir_text is not None and "local_gather" in ttgir_text
+            checks["timed_ds_read_b32"] = timed_counts is not None and timed_counts["ds_read_b32"] > 0
+            checks["no_timed_ds_write"] = timed_region is not None and "ds_write" not in timed_region
+        else:
+            checks["ds_write"] = "ds_write" in asm_text
+    if case.name == "global.tl_load_dependent":
+        checks["global_or_flat_load"] = any(token in asm_text for token in ("global_load", "flat_load", "buffer_load"))
+    if case.name == "global.direct_to_lds_composite_32x32":
+        checks["direct_to_lds_hint"] = any(
+            token in asm_text for token in ("global_load_lds", "buffer_load_to_local", "ds_write")
+        )
+    return {
+        "available": True,
+        "ok": all(checks.values()),
+        "checks": checks,
+        "valu_instruction_counts": valu_counts,
+        "mfma_instruction_count": _count_mfma(asm_text),
+        "estimated_mfma_per_loop_iter": None,
+        "estimated_mfma_per_loop_iter_note": "not estimated: fixed prologue/epilogue MFMA count is not separated",
+        "timed_region_instruction_counts": timed_counts,
+    }
+
+
+def _launch(case: Case, args: list[Any]) -> Any:
+    return case.kernel[(1,)](*args, num_warps=case.num_warps, **case.launch_meta)
+
+
+def _is_known_direct_to_lds_unsupported(case: Case, exc: Exception) -> bool:
+    error = f"{type(exc).__name__}: {exc}"
+    return case.name == "global.direct_to_lds_composite_32x32" and (
+        "builtin.unrealized_conversion_cast" in error or "failed to translate module to LLVM IR" in error
+    )
+
+
+def _unsupported_result(case: Case, exc: Exception, baseline_raw_per_iter: float | None) -> dict[str, Any]:
+    error = f"{type(exc).__name__}: {exc}"
+    if case.name == "global.direct_to_lds_composite_32x32" and "failed to translate module to LLVM IR" in error:
+        error += " (compiler stderr reports builtin.unrealized_conversion_cast)"
+    return {
+        "name": case.name,
+        "family": case.family,
+        "unit": case.unit,
+        "ops_per_iter": case.ops_per_iter,
+        "ok": False,
+        "unsupported": True,
+        "error": error,
+        "stats": None,
+        "raw_ticks_per_iter": None,
+        "baseline_raw_ticks_per_iter": baseline_raw_per_iter,
+        "diagnostic_baseline_delta_ticks_per_op": None,
+        "net_ticks_per_op": None,
+        "check_values": [],
+        "expected_check": None,
+        "correctness_ok": False,
+        "isa_sanity": {"available": False, "ok": None, "checks": {}, "mfma_instruction_count": None},
+        "meta": case.meta,
+    }
+
+
+def _run_case(case: Case, niter: int, warmup: int, reps: int, baseline_raw_per_iter: float | None) -> dict[str, Any]:
+    out = torch.zeros(1, dtype=torch.int64, device=_active_device())
+    check = torch.zeros(1, dtype=torch.float32, device=_active_device())
+    args = case.make_args() + [out, check, niter]
+
+    compiled = None
+    for _ in range(warmup):
+        maybe_compiled = _launch(case, args)
+        compiled = maybe_compiled if maybe_compiled is not None else compiled
+    torch.cuda.synchronize()
+
+    raw_per_iter_samples = []
+    raw_per_op_samples = []
+    check_values = []
+    for _ in range(reps):
+        out.zero_()
+        check.zero_()
+        maybe_compiled = _launch(case, args)
+        compiled = maybe_compiled if maybe_compiled is not None else compiled
+        torch.cuda.synchronize()
+        elapsed = int(out.item())
+        raw_per_iter = elapsed / max(1, niter)
+        raw_per_iter_samples.append(raw_per_iter)
+        raw_per_op_samples.append(raw_per_iter / max(1, case.ops_per_iter))
+        check_values.append(float(check.item()))
+
+    expected_check = case.expected_check(niter) if case.expected_check is not None else None
+    correctness_ok = expected_check is None or all(value == expected_check for value in check_values)
+    ok = all(sample > 0 for sample in raw_per_iter_samples) and all(value == value for value in check_values) and correctness_ok
+    asm_text = _compiled_asm(compiled)
+    ttgir_text = _compiled_asm_section(compiled, "ttgir")
+    result = {
+        "name": case.name,
+        "family": case.family,
+        "unit": case.unit,
+        "ops_per_iter": case.ops_per_iter,
+        "ok": ok,
+        "stats": _summarize(raw_per_op_samples),
+        "normalized_cycles_per_op": _summarize([sample * CYCLES_PER_TICK for sample in raw_per_op_samples]),
+        "raw_ticks_per_iter": _summarize(raw_per_iter_samples),
+        "baseline_raw_ticks_per_iter": baseline_raw_per_iter,
+        "diagnostic_baseline_delta_ticks_per_op": None,
+        "net_ticks_per_op": None,
+        "check_values": check_values,
+        "expected_check": expected_check,
+        "correctness_ok": correctness_ok,
+        "isa_sanity": _isa_case_sanity(case, asm_text, ttgir_text),
+    }
+    if case.meta:
+        result["meta"] = case.meta
+    return result
+
+
+def _make_seed(values: list[float]) -> list[Any]:
+    return [torch.tensor(values, dtype=torch.float32, device=_active_device())]
+
+
+def _lds_table_values() -> list[int]:
+    return [((i * 17) + 5) & 63 for i in range(64)]
+
+
+def _pointer_chase_expected(starts: list[int], niter: int) -> float:
+    table = _lds_table_values()
+    total = 0
+    for start in starts:
+        idx = start
+        for _ in range(niter):
+            idx = table[idx]
+        total += idx
+    return float(total)
+
+
+def _make_lds_pointer_chase(starts: list[int]) -> list[Any]:
+    return [torch.tensor(_lds_table_values() + starts, dtype=torch.int32, device=_active_device())]
+
+
+def _make_global_pointer_chase() -> list[Any]:
+    return [torch.zeros(2, dtype=torch.int64, device=_active_device())]
+
+
+def _make_global_tile() -> list[Any]:
+    return [torch.arange(1, 32 * 32 + 1, dtype=torch.float16, device=_active_device())]
+
+
+def _make_mfma_inputs(streams: int = 1) -> list[Any]:
+    elems = streams * 32 * 32
+    a = torch.arange(1, elems + 1, dtype=torch.float16, device=_active_device()).reshape(streams, 32, 32)
+    b = torch.ones((streams, 32, 32), dtype=torch.float16, device=_active_device())
+    return [a, b]
+
+
+def _cases() -> list[Case]:
+    mfma_meta = {"matrix_instr_nonkdim": 16, "waves_per_eu": 0}
+    return [
+        Case(
+            "baseline.loop",
+            "baseline",
+            "raw_ticks_per_loop_iter",
+            _k_baseline,
+            lambda: _make_seed([1.0]),
+            baseline_key="",
+            meta={
+                "measures": "clock64 bracketing + scalar loop overhead",
+                "timer": "target-specific tlx.clock64 ticks",
+            },
+        ),
+        Case(
+            "valu.dependent_fma_expr",
+            "valu",
+            "ticks_per_high_level_fma_expression",
+            _k_valu_dependent,
+            lambda: _make_seed([1.0, 1.0000001, 0.9999999]),
+            ops_per_iter=1,
+            meta={"streams": 1, "high_level_fma_expressions_per_iter": 1, "runtime_seeded": True},
+        ),
+        Case(
+            "valu.independent_fma_expr_x4",
+            "valu",
+            "ticks_per_high_level_fma_expression",
+            _k_valu_independent_x4,
+            lambda: _make_seed([1.0, 2.0, 3.0, 4.0, 1.0000001, 1.0000002, 1.0000004, 1.0000008, 0.5, 0.75, 1.0, 1.25]),
+            ops_per_iter=4,
+            meta={"streams": 4, "high_level_fma_expressions_per_iter": 4, "runtime_seeded": True},
+        ),
+        Case(
+            "lds.dependent_gather_chase_i32",
+            "lds",
+            "ticks_per_dependent_local_gather",
+            _k_lds_dependent_gather_chase,
+            lambda: _make_lds_pointer_chase([0]),
+            ops_per_iter=1,
+            meta={
+                "table_shape": "64xi32",
+                "streams": 1,
+                "pointer_chase": "idx_{i+1}=table[idx_i]",
+                "preinitialized_lds_table": True,
+                "timed_stores": False,
+                "hardware_ops_per_iter": {"lds_gather_read": 1, "lds_store": 0},
+            },
+            expected_check=lambda niter: _pointer_chase_expected([0], niter),
+        ),
+        Case(
+            "lds.independent_gather_i32_x4",
+            "lds",
+            "ticks_per_independent_local_gather",
+            _k_lds_independent_gather_x4,
+            lambda: _make_lds_pointer_chase([0, 7, 19, 31]),
+            ops_per_iter=4,
+            meta={
+                "table_shape": "64xi32",
+                "streams": 4,
+                "preinitialized_lds_table": True,
+                "timed_stores": False,
+                "hardware_ops_per_iter": {"lds_gather_read": 4, "lds_store": 0},
+            },
+            expected_check=lambda niter: _pointer_chase_expected([0, 7, 19, 31], niter),
+        ),
+        Case(
+            "global.tl_load_dependent",
+            "global",
+            "ticks_per_tl_load",
+            _k_global_tl_load_dependent,
+            _make_global_pointer_chase,
+            meta={"path": "tl.load scalar pointer chase"},
+        ),
+        Case(
+            "global.direct_to_lds_composite_32x32",
+            "global",
+            "ticks_per_direct_to_lds_composite",
+            _k_global_direct_to_lds_composite,
+            _make_global_tile,
+            ops_per_iter=1,
+            meta={
+                "shape": "32x32xf16",
+                "path": "tlx.buffer_load_to_local + async_load_commit_group + async_load_wait_group(0) + tlx.local_load",
+                "composite_per_iter": True,
+            },
+        ),
+        Case(
+            "mfma.dependent_acc_32x32x32",
+            "mfma",
+            "ticks_per_tl_dot",
+            _k_mfma_dependent,
+            lambda: _make_mfma_inputs(1),
+            launch_meta=mfma_meta,
+            meta={"shape": "32x32x32", "matrix_instr_nonkdim": 16},
+        ),
+        Case(
+            "mfma.independent_acc_32x32x32_x4",
+            "mfma",
+            "ticks_per_tl_dot",
+            _k_mfma_independent_x4,
+            lambda: _make_mfma_inputs(4),
+            ops_per_iter=4,
+            launch_meta=mfma_meta,
+            meta={"streams": 4, "shape": "32x32x32", "matrix_instr_nonkdim": 16},
+        ),
+    ]
+
+
+def _select_cases(bench: str) -> list[Case]:
+    requested = [part.strip().lower() for part in bench.split(",") if part.strip()]
+    if not requested or requested == ["all"]:
+        requested = list(ALL_BENCHES)
+    valid = set(ALL_BENCHES)
+    unknown = sorted(set(requested) - valid)
+    if unknown:
+        raise ValueError(f"unknown --bench value(s): {', '.join(unknown)}; valid: all,{','.join(ALL_BENCHES)}")
+    return [case for case in _cases() if case.family in requested]
+
+
+def _baseline_case() -> Case:
+    for case in _cases():
+        if case.name == "baseline.loop":
+            return case
+    raise AssertionError("baseline.loop case missing")
+
+
+def run_all(
+    bench: str = "all",
+    niter: int = DEFAULT_NITER,
+    warmup: int = DEFAULT_WARMUP,
+    reps: int = DEFAULT_REPS,
+    require_gfx950: bool = True,
+) -> dict[str, Any]:
+    if require_gfx950 and not is_gfx950():
+        raise RuntimeError(
+            f"gfx950 HIP device required, got {_device_info() if torch.cuda.is_available() else 'no cuda'}"
+        )
+    selected = _select_cases(bench)
+    baseline_case = _baseline_case()
+    baseline_result = _run_case(baseline_case, niter, warmup, reps, None)
+    baseline_raw = baseline_result["raw_ticks_per_iter"]["median"]
+    benchmarks = []
+    for case in selected:
+        if case.name == baseline_case.name:
+            benchmarks.append(baseline_result)
+        else:
+            try:
+                benchmarks.append(_run_case(case, niter, warmup, reps, baseline_raw))
+            except Exception as exc:
+                if _is_known_direct_to_lds_unsupported(case, exc):
+                    benchmarks.append(_unsupported_result(case, exc, baseline_raw))
+                else:
+                    raise
+    isa_cases = {item["name"]: item["isa_sanity"] for item in benchmarks}
+    return {
+        "device": _device_info(),
+        "timer": {
+            "api": "tlx.clock64",
+            "lowering": "s_memtime",
+            "measured_hz": SMEMTIME_HZ,
+            "shader_clock_hz": GFX950_MAX_SCLK_HZ,
+            "cycles_per_tick": CYCLES_PER_TICK,
+        },
+        "niter": niter,
+        "warmup": warmup,
+        "reps": reps,
+        "bench": bench,
+        "baseline": baseline_result,
+        "benchmarks": benchmarks,
+        "isa_sanity": {"available": any(v["available"] for v in isa_cases.values()), "cases": isa_cases},
+    }
+
+
+def _print_human(result: dict[str, Any], stream=sys.stdout) -> None:
+    dev = result["device"]
+    print(
+        f"device: {dev['name']} ({dev['gcn_arch_name']}), niter={result['niter']}, "
+        f"warmup={result['warmup']}, reps={result['reps']}",
+        file=stream,
+    )
+    print(
+        f"baseline.loop raw median: {result['baseline']['raw_ticks_per_iter']['median']:.2f} ticks/iter",
+        file=stream,
+    )
+    print(
+        f"{'bench':<42} {'unit':<40} {'raw_med':>10} {'p20':>10} {'p80':>10} {'cv':>8} ok",
+        file=stream,
+    )
+    for item in result["benchmarks"]:
+        stats = item["stats"]
+        if stats is None:
+            error = item.get("error", "unsupported")
+            print(
+                f"{item['name']:<42} {item['unit']:<40} {'unsupported':>10} "
+                f"{'':>10} {'':>10} {'':>8} {item['ok']}  {error}",
+                file=stream,
+            )
+            continue
+        print(
+            f"{item['name']:<42} {item['unit']:<40} {stats['median']:>10.2f} "
+            f"{stats['p20']:>10.2f} {stats['p80']:>10.2f} {stats['cv']:>8.3f} {item['ok']}",
+            file=stream,
+        )
+    print(f"isa_sanity: {result['isa_sanity']}", file=stream)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="gfx950 TLX clock64 target-timer latency/throughput microbenchmarks")
+    parser.add_argument("--bench", default="all", help="comma list from baseline,valu,lds,global,mfma or all")
+    parser.add_argument("--niter", type=int, default=DEFAULT_NITER)
+    parser.add_argument("--warmup", type=int, default=DEFAULT_WARMUP)
+    parser.add_argument("--reps", type=int, default=DEFAULT_REPS)
+    parser.add_argument("--json", action="store_true", help="emit JSON to stdout")
+    parser.add_argument("--no-gfx950-check", action="store_true", help="allow running on non-gfx950 HIP devices")
+    args = parser.parse_args(argv)
+
+    result = run_all(
+        bench=args.bench,
+        niter=args.niter,
+        warmup=args.warmup,
+        reps=args.reps,
+        require_gfx950=not args.no_gfx950_check,
+    )
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        _print_human(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/third_party/tlx/tools/microbench/test_amd_latency.py
+++ b/third_party/tlx/tools/microbench/test_amd_latency.py
@@ -1,0 +1,222 @@
+import importlib.util
+import inspect
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_AMD_LATENCY_PATH = Path(__file__).with_name("amd_latency.py")
+_SPEC = importlib.util.spec_from_file_location("amd_latency", _AMD_LATENCY_PATH)
+amd_latency = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+sys.modules[_SPEC.name] = amd_latency
+_SPEC.loader.exec_module(amd_latency)
+
+
+def test_select_cases_by_family():
+    cases = amd_latency._select_cases("baseline,valu")
+    names = {case.name for case in cases}
+    assert "baseline.loop" in names
+    assert "valu.dependent_fma_expr" in names
+    assert "valu.independent_fma_expr_x4" in names
+    assert all(case.family in {"baseline", "valu"} for case in cases)
+
+
+def test_unknown_bench_is_rejected():
+    with pytest.raises(ValueError, match="unknown --bench"):
+        amd_latency._select_cases("bogus")
+
+
+def test_stats_json_shape():
+    stats = amd_latency._summarize([3.0, 1.0, 2.0, 4.0, 5.0])
+    encoded = json.dumps({"stats": stats})
+    decoded = json.loads(encoded)
+    assert decoded["stats"]["median"] == 3.0
+    assert decoded["stats"]["p20"] == pytest.approx(1.8)
+    assert decoded["stats"]["p80"] == pytest.approx(4.2)
+    assert decoded["stats"]["cv"] > 0.0
+    assert decoded["stats"]["min"] == 1.0
+    assert decoded["stats"]["max"] == 5.0
+    assert decoded["stats"]["samples"] == [3.0, 1.0, 2.0, 4.0, 5.0]
+
+
+def test_corrected_case_metadata():
+    cases = {case.name: case for case in amd_latency._cases()}
+    assert cases["valu.dependent_fma_expr"].ops_per_iter == 1
+    assert cases["valu.dependent_fma_expr"].unit == "ticks_per_high_level_fma_expression"
+    assert cases["valu.independent_fma_expr_x4"].ops_per_iter == 4
+    assert cases["valu.independent_fma_expr_x4"].meta["streams"] == 4
+    assert cases["lds.dependent_gather_chase_i32"].unit == "ticks_per_dependent_local_gather"
+    assert cases["lds.dependent_gather_chase_i32"].meta["timed_stores"] is False
+    assert cases["lds.dependent_gather_chase_i32"].expected_check(8) == amd_latency._pointer_chase_expected([0], 8)
+    assert cases["lds.independent_gather_i32_x4"].ops_per_iter == 4
+    assert cases["lds.independent_gather_i32_x4"].meta["timed_stores"] is False
+    assert cases["global.direct_to_lds_composite_32x32"].meta["composite_per_iter"]
+    assert cases["mfma.dependent_acc_32x32x32"].unit == "ticks_per_tl_dot"
+    assert cases["mfma.dependent_acc_32x32x32"].launch_meta["matrix_instr_nonkdim"] == 16
+    assert cases["mfma.independent_acc_32x32x32_x4"].ops_per_iter == 4
+    assert all("cycles" not in case.unit for case in cases.values())
+
+
+def test_s_memtime_cycle_normalization():
+    assert amd_latency.SMEMTIME_HZ == pytest.approx(2.183e9)
+    assert amd_latency.GFX950_MAX_SCLK_HZ == pytest.approx(2.2e9)
+    assert amd_latency.CYCLES_PER_TICK == pytest.approx(1.0078, rel=1e-3)
+
+
+def test_niter_is_runtime_loop_not_constexpr_unrolled():
+    source = inspect.getsource(amd_latency)
+    assert "NITER: tl.constexpr" not in source
+    assert "range(NITER)" not in source
+    assert "tl.range(0, NITER, loop_unroll_factor=1, num_stages=0)" in source
+
+
+def test_lds_pointer_chase_expected_matches_cpu_sequence():
+    table = amd_latency._lds_table_values()
+    idx = 0
+    for _ in range(13):
+        idx = table[idx]
+    assert amd_latency._pointer_chase_expected([0], 13) == float(idx)
+
+    starts = [0, 7, 19, 31]
+    expected_sum = 0
+    for start in starts:
+        idx = start
+        for _ in range(13):
+            idx = table[idx]
+        expected_sum += idx
+    assert amd_latency._pointer_chase_expected(starts, 13) == float(expected_sum)
+
+
+def test_lds_source_uses_gather_and_no_timed_stores():
+    source = _AMD_LATENCY_PATH.read_text()
+    function_source = source.split("def _k_lds_dependent_gather_chase", 1)[1].split("@triton.jit", 1)[0]
+    timed_region = function_source.split("t0 = tlx.clock64()", 1)[1].split("t1 = tlx.clock64()", 1)[0]
+    assert "tlx.local_gather" in timed_region
+    assert "tlx.local_store" not in timed_region
+
+
+def test_lds_isa_sanity_detects_pure_timed_gather_region():
+    case = {case.name: case for case in amd_latency._cases()}["lds.dependent_gather_chase_i32"]
+    asm = "s_memtime\nds_read_b32 v0, v1 offset:0\ns_memtime\nds_write_b32 v0, v1 offset:0"
+    sanity = amd_latency._isa_case_sanity(case, asm, "ttg.local_gather")
+    assert sanity["checks"]["ttgir_local_gather"]
+    assert sanity["checks"]["timed_ds_read_b32"]
+    assert sanity["checks"]["no_timed_ds_write"]
+    assert sanity["timed_region_instruction_counts"]["ds_read_b32"] == 1
+    assert sanity["timed_region_instruction_counts"]["ds_write_b32"] == 0
+
+
+def test_unsupported_result_schema():
+    case = amd_latency._select_cases("global")[1]
+    result = amd_latency._unsupported_result(case, RuntimeError("builtin.unrealized_conversion_cast"), 3.0)
+    assert not result["ok"]
+    assert result["unsupported"]
+    assert "builtin.unrealized_conversion_cast" in result["error"]
+    assert result["stats"] is None
+    assert result["baseline_raw_ticks_per_iter"] == 3.0
+    assert result["net_ticks_per_op"] is None
+    assert result["diagnostic_baseline_delta_ticks_per_op"] is None
+    assert result["expected_check"] is None
+    assert not result["correctness_ok"]
+
+
+def test_only_known_direct_to_lds_error_is_unsupported():
+    direct = amd_latency._select_cases("global")[1]
+    other = amd_latency._select_cases("global")[0]
+    assert amd_latency._is_known_direct_to_lds_unsupported(
+        direct, RuntimeError("failed to translate module to LLVM IR")
+    )
+    assert amd_latency._is_known_direct_to_lds_unsupported(direct, RuntimeError("builtin.unrealized_conversion_cast"))
+    assert not amd_latency._is_known_direct_to_lds_unsupported(
+        other, RuntimeError("failed to translate module to LLVM IR")
+    )
+    assert not amd_latency._is_known_direct_to_lds_unsupported(direct, RuntimeError("different compiler failure"))
+
+
+def _run_or_skip_stale_clock64(**kwargs):
+    try:
+        return amd_latency.run_all(**kwargs)
+    except RuntimeError as exc:
+        if "failed to legalize operation 'ttg.clock64'" in str(exc):
+            pytest.skip("active AMD extension does not include clock64 lowering; relink required")
+        raise
+
+
+@pytest.mark.skipif(not amd_latency.is_gfx950(), reason="requires active gfx950 HIP device")
+def test_gfx950_tiny_baseline_smoke():
+    result = _run_or_skip_stale_clock64(bench="baseline", niter=4, warmup=1, reps=1)
+    assert result["device"]["hip"] is not None
+    assert "gfx950" in result["device"]["gcn_arch_name"]
+    assert result["baseline"]["name"] == "baseline.loop"
+    assert len(result["benchmarks"]) == 1
+    bench = result["benchmarks"][0]
+    assert bench["name"] == "baseline.loop"
+    assert bench["ok"]
+    assert bench["stats"]["median"] > 0
+    assert bench["raw_ticks_per_iter"]["median"] > 0
+    assert bench["net_ticks_per_op"] is None
+
+
+@pytest.mark.skipif(not amd_latency.is_gfx950(), reason="requires active gfx950 HIP device")
+def test_gfx950_measured_op_latencies():
+    result = _run_or_skip_stale_clock64(bench="valu,lds,global,mfma", niter=512, warmup=3, reps=7)
+    benches = {bench["name"]: bench for bench in result["benchmarks"]}
+
+    assert result["timer"]["cycles_per_tick"] == pytest.approx(1.0078, rel=1e-3)
+
+    valu = benches["valu.dependent_fma_expr"]
+    assert valu["ok"]
+    assert valu["normalized_cycles_per_op"]["median"] == pytest.approx(8.0, abs=2.0)
+    assert valu["isa_sanity"]["checks"]["clock64"]
+
+    mfma_dep = benches["mfma.dependent_acc_32x32x32"]
+    assert mfma_dep["ok"]
+    assert mfma_dep["normalized_cycles_per_op"]["median"] == pytest.approx(18.0, abs=3.0)
+    assert mfma_dep["isa_sanity"]["checks"]["mfma"]
+
+    mfma_issue = benches["mfma.independent_acc_32x32x32_x4"]
+    assert mfma_issue["ok"]
+    assert mfma_issue["normalized_cycles_per_op"]["median"] == pytest.approx(17.0, abs=3.0)
+
+    lds = benches["lds.dependent_gather_chase_i32"]
+    assert lds["ok"]
+    assert lds["correctness_ok"]
+    assert lds["check_values"] == [lds["expected_check"]] * 7
+    assert lds["normalized_cycles_per_op"]["median"] == pytest.approx(69.0, abs=8.0)
+    assert lds["isa_sanity"]["checks"]["ttgir_local_gather"]
+    assert lds["isa_sanity"]["checks"]["timed_ds_read_b32"]
+    assert lds["isa_sanity"]["checks"]["no_timed_ds_write"]
+
+    lds_issue = benches["lds.independent_gather_i32_x4"]
+    assert lds_issue["ok"]
+    assert lds_issue["correctness_ok"]
+    assert lds_issue["normalized_cycles_per_op"]["median"] == pytest.approx(28.0, abs=8.0)
+
+    global_load = benches["global.tl_load_dependent"]
+    assert global_load["ok"]
+    assert 100.0 < global_load["normalized_cycles_per_op"]["median"] < 200.0
+    assert global_load["isa_sanity"]["checks"]["global_or_flat_load"]
+
+
+@pytest.mark.skipif(not amd_latency.is_gfx950(), reason="requires active gfx950 HIP device")
+def test_gfx950_tiny_global_distinguishes_load_paths():
+    result = _run_or_skip_stale_clock64(bench="global", niter=2, warmup=1, reps=1)
+    benches = {bench["name"]: bench for bench in result["benchmarks"]}
+    assert "global.tl_load_dependent" in benches
+    assert "global.direct_to_lds_composite_32x32" in benches
+
+    pointer_chase = benches["global.tl_load_dependent"]
+    assert pointer_chase["ok"]
+    assert pointer_chase["stats"]["median"] > 0
+    assert pointer_chase["net_ticks_per_op"] is None
+
+    direct_to_lds = benches["global.direct_to_lds_composite_32x32"]
+    if not direct_to_lds["ok"]:
+        assert direct_to_lds["unsupported"]
+        assert "unrealized_conversion_cast" in direct_to_lds["error"]
+    else:
+        assert direct_to_lds["stats"]["median"] > 0
+        assert direct_to_lds["net_ticks_per_op"] is None


### PR DESCRIPTION
Summary:

Add TLX s_memtime microbenchmarks and gfx950 runtime regressions for MFMA, VALU, LDS, and GLOBAL operations. Normalize timer ticks to shader cycles using a measured 2.183 GHz timer frequency and the 2.2 GHz gfx950 shader clock.

Update AMDLatencyModel with measured MFMA dependency/occupancy, LDS read latency, and VALU dependency costs while retaining the conservative GLOBAL estimate. Guard MFMA-count saturation against zero-sized dimensions and keep the LDS documentation consistent with the measured 69-cycle value.

Update the AMD modulo warp-pipeline partition lit checks so remarks from split-input modules are matched as an unordered diagnostic group; the generated schedule and cluster annotations are unchanged.

Reviewed By: wlei-llvm

Differential Revision: D113805070


