### PR TITLE
[triton][beta] Fix gfx950 codegen crash from incomplete #9317 backport in load/store lowering

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -959,12 +959,19 @@ SmallVector<Value> lowerLdSt(
   auto quot = divideLeft(cvt, tile);
   assert(quot.has_value() && "cvt must be divisible by tile");
   LinearLayout reps = zerosLike(tile) * *quot;
-  assert(reps.hasInDim(kBlock));
+  // D109662150 backported upstream #9317's `assert(reps.hasInDim(kBlock))`, but
+  // beta's lowerLdSt is block-optional: every other kBlock use below is guarded
+  // on reps.hasInDim(kBlock). AMD single-CTA loads/stores reach here with a
+  // block-less layout, so include kBlock in addrLayout only when present.
   LinearLayout addrLayout =
-      LinearLayout({{kLane, reps.getBases().lookup(kLane)},
-                    {kWarp, reps.getBases().lookup(kWarp)},
-                    {kBlock, reps.getBases().lookup(kBlock)}},
-                   reps.getOutDims(), false);
+      reps.hasInDim(kBlock)
+          ? LinearLayout({{kLane, reps.getBases().lookup(kLane)},
+                          {kWarp, reps.getBases().lookup(kWarp)},
+                          {kBlock, reps.getBases().lookup(kBlock)}},
+                         reps.getOutDims(), false)
+          : LinearLayout({{kLane, reps.getBases().lookup(kLane)},
+                          {kWarp, reps.getBases().lookup(kWarp)}},
+                         reps.getOutDims(), false);
   auto [nAdditive, permStrides] =
       actionAdditiveStrides(reps, addrLayout, maskSpanAffineOffset);
   reps = permStrides.apply(reps);


### PR DESCRIPTION
Summary:
The facebookexperimental/triton MI350 CI aborts while lowering a broad set
of tritonbench kernels (GEMMs, attention) on gfx950 — 9 ops crash in AMD
codegen on a hard assertion that the load/store conversion layout carries a
`block` in-dimension.

Root cause is an incomplete backport: D109662150 brought in upstream #9317,
whose shared load/store lowering assumes the block in-dim is always present
(a single assertion, then unconditional use). Beta's fork of that lowering
is block-optional — its inputs can arrive without a block in-dim on the AMD
single-CTA path — so the backport adapted the downstream uses into guards
but left the top-level assertion (and one address-layout construction)
demanding a block that may not exist. On NVIDIA the block dim is present so
it is masked; on AMD single-CTA it is absent and the assertion aborts.

This reconciles that one spot with beta's own block-optional handling:
drop the stray assertion and build the address layout with the block
component only when present. Behavior is unchanged when the block in-dim is
present (identical layout); the block-less path now lowers correctly instead
of aborting.

Authored with Claude.

Differential Revision: D113974277


