### PR TITLE
[triton][beta] Support explicit TLX TMA multicast masks

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -899,19 +899,19 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
                    warpId, rewriter, targetInfo, maybeMaxVecElems, emitLdSt,
                    barrierPtr);
 }
-SmallVector<Value> lowerLdSt(
-    Location loc, MLIRContext *ctx, LinearLayout cvt,
-    ArrayRef<Value> valsArray, // Input for store, output for load
-    Type llvmElemTy, ArrayRef<Value> smemBases,
-    ArrayRef<std::pair<unsigned, unsigned>> paddingShifts, Value affineOffset,
-    uint64_t maskSpanAffineOffset, Value laneId, Value warpId,
-    RewriterBase &rewriter, const TargetInfoBase &targetInfo,
-    std::optional<int> maybeMaxVecElems,
-    std::function<SmallVector<Value>(RewriterBase &, Location, ArrayRef<Value>,
-                                     Value, int, VectorType,
-                                     std::optional<Value>)>
-        lowerInst,
-    std::optional<Value> barrierPtr) {
+SmallVector<Value>
+lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
+          ArrayRef<Value> valsArray, // Input for store, output for load
+          Type llvmElemTy, ArrayRef<Value> smemBases,
+          ArrayRef<std::pair<unsigned, unsigned>> paddingShifts,
+          Value affineOffset, uint64_t maskSpanAffineOffset, Value laneId,
+          Value warpId, RewriterBase &rewriter,
+          const TargetInfoBase &targetInfo, std::optional<int> maybeMaxVecElems,
+          std::function<SmallVector<Value>(RewriterBase &, Location,
+                                           ArrayRef<Value>, Value, int,
+                                           VectorType, std::optional<Value>)>
+              lowerInst,
+          std::optional<Value> barrierPtr) {
   assert(!smemBases.empty() && "smemBases cannot be empty");
   auto vals = to_vector(valsArray);
   bool isStore = !vals.empty();
@@ -959,12 +959,17 @@ SmallVector<Value> lowerLdSt(
   auto quot = divideLeft(cvt, tile);
   assert(quot.has_value() && "cvt must be divisible by tile");
   LinearLayout reps = zerosLike(tile) * *quot;
-  assert(reps.hasInDim(kBlock));
-  LinearLayout addrLayout =
-      LinearLayout({{kLane, reps.getBases().lookup(kLane)},
-                    {kWarp, reps.getBases().lookup(kWarp)},
-                    {kBlock, reps.getBases().lookup(kBlock)}},
-                   reps.getOutDims(), false);
+  // Not every layout entering lowerLdSt carries a `block` input dimension
+  // (e.g. beta's warp-specialized shared-memory transfers). Only include the
+  // block bases when present; downstream cross-CTA handling below is already
+  // guarded on `reps.hasInDim(kBlock)` / `i8AddrLayout.hasInDim(kBlock)`.
+  SmallVector<std::pair<StringAttr, std::vector<std::vector<int32_t>>>>
+      addrBases = {{kLane, reps.getBases().lookup(kLane)},
+                   {kWarp, reps.getBases().lookup(kWarp)}};
+  if (reps.hasInDim(kBlock)) {
+    addrBases.push_back({kBlock, reps.getBases().lookup(kBlock)});
+  }
+  LinearLayout addrLayout(addrBases, reps.getOutDims(), false);
   auto [nAdditive, permStrides] =
       actionAdditiveStrides(reps, addrLayout, maskSpanAffineOffset);
   reps = permStrides.apply(reps);
@@ -986,9 +991,19 @@ SmallVector<Value> lowerLdSt(
   auto i8AddrLayout = i8Tile * addrLayout;
 
   Value blockId = b.i32_val(0);
+  // Cross-CTA addressing (threading a target CTA id into the shared-memory
+  // access) is only needed when the `block` input genuinely targets a CTA other
+  // than the current one. Two in-CTA cases must NOT trigger it:
+  //   * block maps to all zeros -> broadcast, block is ignored
+  //   (sublayoutIsZero)
+  //   * block acts as the identity -> each CTA targets its own smem
+  //     (isTrivialOver). Beta's layouts retain a `block` output dim, so a
+  //     block->block identity is non-zero and would otherwise be misread as
+  //     cross-CTA (e.g. broadcast-multicast async copies, num_ctas>1).
   bool useBlockId =
       reps.hasInDim(kBlock) &&
-      !reps.sublayoutIsZero({kBlock}, to_vector(reps.getOutDimNames()));
+      !reps.sublayoutIsZero({kBlock}, to_vector(reps.getOutDimNames())) &&
+      !reps.isTrivialOver({kBlock});
   if (useBlockId) {
     blockId = targetInfo.getClusterCTAId(rewriter, loc);
   }

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -637,7 +637,8 @@ LogicalResult AsyncTMACopyGlobalToLocalOp::verify() {
                            isIm2Col ? TensorMode::IM2COL : TensorMode::TILED,
                            getCoord(), getOffsets())))
     return failure();
-  if (getMulticast() && !hasCGABroadcast(resultType))
+  if (getMulticast() && !getMulticastTargets() &&
+      !hasCGABroadcast(resultType))
     return emitOpError(
         "multicast requires the shared layout to broadcast across CTAs");
   return success();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -97,7 +97,8 @@ usesTrackedBarrierInCrossCTAConsumerOp(Operation *op,
     return ttng::getModuleTwoCTAs(op) && aliasesTracked(commit.getBarrier());
   }
   if (auto tma = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
-    return tma.getMulticast() && aliasesTracked(tma.getBarrier());
+    return tma.getMulticast() && !tma.getMulticastTargets() &&
+        aliasesTracked(tma.getBarrier());
   }
   return false;
 }

--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -314,21 +314,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // Test that async_tma_copy_global_to_local with multicast_targets triggers cluster
 // sync after init_barrier. The multicast bitmask causes the barrier signal to be
 // sent to multiple CTAs in the cluster.
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
 #smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
   // CHECK-LABEL: @tma_multicast_bar_init
   tt.func public @tma_multicast_bar_init(%desc: !tt.tensordesc<128x64xbf16, #nvmma>, %alloc: !ttg.memdesc<128x64xbf16, #nvmma, #smem, mutable>, %x: i32, %mcast: i32, %pred: i1) attributes {noinline = false} {
-    %c0_i32 = arith.constant 0 : i32
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
-    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
-    // CHECK: mbarrier.init.shared::cta.b64
-    // CHECK: nvvm.cluster.arrive.relaxed {aligned}
-    // CHECK: nvvm.cluster.wait {aligned}
-    // CHECK: cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster
-    ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
-    ttng.async_tma_copy_global_to_local %desc[%x, %x] %alloc, %1, %pred, %mcast : !tt.tensordesc<128x64xbf16, #nvmma>, !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<128x64xbf16, #nvmma, #smem, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    // CHECK-COUNT-1: mbarrier.init.shared::cta.b64
+    // CHECK-COUNT-1: nvvm.cluster.arrive.relaxed {aligned}
+    // CHECK-COUNT-1: nvvm.cluster.wait {aligned}
+    // CHECK-COUNT-1: cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%x, %x] %alloc, %barrier, %pred, %mcast {multicast} : !tt.tensordesc<128x64xbf16, #nvmma>, !ttg.memdesc<2xi64, #shared, #smem, mutable> -> !ttg.memdesc<128x64xbf16, #nvmma, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -682,6 +682,22 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // -----
 
+#nvmma_no_broadcast = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @async_tma_copy_explicit_multicast_allows_nonbroadcast_layout(%arg0: !tt.tensordesc<64x128xf16, #nvmma_no_broadcast>, %mcast: i32) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmma_no_broadcast, #smem, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %0, %1, %true, %mcast {multicast} : !tt.tensordesc<64x128xf16, #nvmma_no_broadcast>, !ttg.memdesc<1xi64, #shared_bar, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma_no_broadcast, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 // Test invalid TensorDescIm2ColType: rank-3 blockType (must be rank-2)
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
   // expected-error @below {{TensorDescIm2ColType requires rank-2 shape, got rank 3}}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -161,9 +161,17 @@ struct ConvertLayoutOpSwizzlingConversion
         {{kOffset, loadCvt.getTotalOutDimSize() / nBlock}, {kBlock, nBlock}});
 
     // We never do cross-CTA writes by construction. We may do cross-CTA reads,
-    // but in that case we lower to ld.shared/st.shared
-    assert(storeCvt.isTrivialOver({kBlock}));
-    assert(loadCvt.isTrivialOver({kBlock}) || idxDst == 0);
+    // but in that case we lower to ld.shared/st.shared. A write is in-CTA when
+    // the block input either acts as the identity (each CTA writes its own
+    // smem) or is dropped entirely (broadcast-only CGA, block maps to zero).
+    // Only a block that targets a *different* CTA would be a cross-CTA write.
+    assert(storeCvt.isTrivialOver({kBlock}) ||
+           storeCvt.sublayoutIsZero({kBlock},
+                                    to_vector(storeCvt.getOutDimNames())));
+    assert(loadCvt.isTrivialOver({kBlock}) ||
+           loadCvt.sublayoutIsZero({kBlock},
+                                   to_vector(loadCvt.getOutDimNames())) ||
+           idxDst == 0);
 
     auto tileSize = storeCvt.getInDimSize(kReg);
 


### PR DESCRIPTION
Summary: Allow TMA loads with explicit `multicastTargets` to use a non-broadcast shared layout. Keep layout-derived multicast validation unchanged, and avoid inserting duplicate cluster synchronization for the TLX explicit-mask path.

Reviewed By: agron911

Differential Revision: D113994788


