### PR TITLE
[ci] run HSTU self-attention compiler DP on b200

### DIFF
--- a/.ci/tritonbench/fbtriton_skip_tests.yaml
+++ b/.ci/tritonbench/fbtriton_skip_tests.yaml
@@ -60,7 +60,8 @@ mx4_to_fp32:
     - cuda
 # cuda covers all NVIDIA (keeps existing coverage); the literal b200 entry is
 # required for the b200-only CI filter. This exercises hstu_tlx plus the
-# default, manual-DP, and DQ-reduce AutoWS self-attention backends on b200.
+# default, manual-DP, compiler-DP, and DQ-reduce AutoWS self-attention backends
+# on b200.
 ragged_attention:
   devices:
     - cuda


### PR DESCRIPTION
Summary:
Enable the existing hstu_triton_autows_dp2 forward backend on Blackwell so the ragged_attention b200 CI coverage added by D113302925 exercises compiler-generated data partitioning alongside the default, manual-DP, and DQ-reduce variants.

Update both TritonBench CI skip-list descriptions to match the enabled backend set.

Authored with Claude.

Reviewed By: xuzhao9

Differential Revision: D113991746


