### PR TITLE
[TLX][AMD] Support split-K in the AOTInductor C++ wrapper (#2527)

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -223,6 +223,41 @@ class TestTLXTemplates(TestCase):
         "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
     )
     @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_tlx_addmm_warppipe_split_k_cpp_wrapper(self):
+        M, K, N = 256, 4096, 256
+        dtype = torch.float16
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
+        w = torch.randn(N, K, device=GPU_TYPE, dtype=dtype)
+        bias = torch.randn(N, device=GPU_TYPE, dtype=dtype)
+
+        def addmm(bias, a, w):
+            return torch.addmm(bias, a, w.t())
+
+        with (config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+                "cpp_wrapper": True,
+        }), ):
+            c_actual, code = run_and_get_code(torch.compile(addmm), bias, a, w)
+
+        c_expected = (a.float() @ w.t().float() + bias.float()).to(dtype)
+        torch.testing.assert_close(c_actual, c_expected, atol=3e-2, rtol=3e-2)
+
+        code_str = "\n".join(code)
+        self.assertIn("split_k_ws", code_str)
+        self.assertIn("call__reduce_k_kernel_", code_str)
+        self.assertNotIn(
+            "from triton.language.extra.tlx.inductor.reduce_k import", code_str
+        )
+
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
     @parametrize("dtype", (torch.float16, torch.bfloat16))
     def test_tlx_addmm_warppipe_unaligned_k(self, dtype: torch.dtype):
         """Unaligned K (K % BLOCK_K != 0) on the TLX warp-pipe addmm (gfx950).
@@ -596,7 +631,51 @@ class TestSplitK(TestCase):
 
 
 class TestReduceKKernel(TestCase):
-    """Direct unit test for the split-K reduction kernel."""
+    """Direct unit tests for the split-K reduction kernel."""
+
+    def test_aoti_reduce_k_emission(self):
+        from triton.language.extra.tlx.inductor.reduce_k import (
+            emit_aoti_reduce_k_call,
+        )
+
+        wrapper = mock.MagicMock()
+        wrapper.define_user_defined_triton_kernel.return_value = (
+            "_reduce_k_kernel_0",
+            {"signature": {}},
+            {"grid_type": "FixedGrid"},
+            [],
+        )
+        workspace = mock.MagicMock()
+        workspace.outer_name = "split_k_ws_0"
+        workspace.dtype = torch.float32
+        output = mock.MagicMock()
+        output.get_name.return_value = "buf_out"
+        output.get_dtype.return_value = torch.float16
+        output.get_device.return_value = torch.device("cuda")
+        bias = mock.MagicMock()
+        bias.get_name.return_value = "arg_bias"
+        bias.get_dtype.return_value = torch.float16
+
+        emit_aoti_reduce_k_call(
+            wrapper,
+            workspace_arg=workspace,
+            output_node=output,
+            bias_node=bias,
+            M=256,
+            N=256,
+            split_k=4,
+            output_triton_dtype="tl.float16",
+        )
+
+        wrapper.define_user_defined_triton_kernel.assert_called_once()
+        wrapper.generate_kernel_call.assert_called_once()
+        call = wrapper.generate_kernel_call.call_args
+        self.assertEqual("_reduce_k_kernel_0", call.args[0])
+        self.assertEqual(
+            ["split_k_ws_0", "buf_out", "arg_bias", 256, 256],
+            call.args[1],
+        )
+        self.assertTrue(call.kwargs["triton"])
 
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),

--- a/third_party/tlx/language/tlx/inductor/reduce_k.py
+++ b/third_party/tlx/language/tlx/inductor/reduce_k.py
@@ -14,8 +14,10 @@ Ported from upstream:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
+import sympy
+import torch
 import triton
 import triton.language as tl
 
@@ -103,4 +105,80 @@ def emit_reduce_k_call(
         f" OUTPUT_DTYPE={output_triton_dtype},"
         f" HAS_BIAS={has_bias}, STRIDE_BIAS_M={stride_bias_m},"
         f" STRIDE_BIAS_N={stride_bias_n})"
+    )
+
+
+def emit_aoti_reduce_k_call(
+    wrapper: "WrapperCodeGen",
+    workspace_arg: Any,
+    output_node: Any,
+    bias_node: Any | None,
+    M: Any,
+    N: Any,
+    split_k: int,
+    output_triton_dtype: str,
+    stride_bias_m: int = 0,
+    stride_bias_n: int = 1,
+) -> None:
+    """Register and launch the split-K reducer through the AOTI C++ wrapper."""
+    from torch._inductor import ir
+    from torch.utils._sympy.functions import CeilDiv
+
+    has_bias = bias_node is not None
+    bias_arg = bias_node if has_bias else output_node
+    workspace_buffer = ir.Buffer(
+        name=workspace_arg.outer_name,
+        layout=workspace_arg.get_layout(),
+    )
+    kwargs = {
+        "workspace_ptr": workspace_buffer,
+        "c_ptr": output_node,
+        "bias_ptr": bias_arg,
+        "M": M,
+        "N": N,
+        "SPLIT_K": split_k,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "OUTPUT_DTYPE": getattr(tl, output_triton_dtype.removeprefix("tl.")),
+        "HAS_BIAS": has_bias,
+        "STRIDE_BIAS_M": stride_bias_m,
+        "STRIDE_BIAS_N": stride_bias_n,
+    }
+    grid = [[CeilDiv(M, 32), CeilDiv(N, 32), sympy.Integer(1)]]
+    name, triton_meta, inductor_meta, grid_args = (
+        wrapper.define_user_defined_triton_kernel(
+            _reduce_k_kernel,
+            [triton.Config({})],
+            kwargs,
+            restore_value_args=(),
+            reset_to_zero_args=(),
+            grids=grid,
+            epilogue_fusion=None,
+            launch_kwargs=(),
+        )
+    )
+    call_args = [
+        workspace_arg.outer_name,
+        output_node.get_name(),
+        bias_arg.get_name(),
+        M,
+        N,
+        *grid_args,
+    ]
+    arg_types = [
+        workspace_arg.dtype,
+        output_node.get_dtype(),
+        bias_arg.get_dtype(),
+        type(M),
+        type(N),
+        *map(type, grid_args),
+    ]
+    wrapper.generate_kernel_call(
+        name,
+        call_args,
+        arg_types=arg_types,
+        triton_meta=triton_meta,
+        inductor_meta=inductor_meta,
+        triton=True,
+        device=output_node.get_device(),
     )

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1238,7 +1238,17 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
         # to that case -- unit-scalar addmm and plain mm both qualify. sympy Symbol == 1
         # returns a plain False, so this stays safe for symbolic scalars.
         scalars = getattr(kernel_inputs, "_scalars", None) or {}
-        allow_split_k = scalars.get("alpha", 1) == 1 and scalars.get("beta", 1) == 1
+        # split-K needs the JIT Python wrapper: its _reduce_k_kernel is emitted via a Python
+        # `import` (emit_reduce_k_call / _tlx_emit_post_kernel_code), which is ILLEGAL in the
+        # AOTInductor C++ wrapper -- emitting `from ...reduce_k import _reduce_k_kernel` there yields
+        # "unknown type name 'from'" + dropped split_k_ws buffer decls, breaking the C++ compile
+        # (T280910119, seen in the merge-net E2E). So only offer split-K under the Python wrapper;
+        # cpp_wrapper (AOTI, the production path) uses SPLIT_K=1. Proper AOTI-C++ reduce-k is a follow-up.
+        allow_split_k = (
+            scalars.get("alpha", 1) == 1
+            and scalars.get("beta", 1) == 1
+            and not config.cpp_wrapper
+        )
         m_hint = sizevars.optimization_hint(m, fallback=NUM_SMS)
         n_hint = sizevars.optimization_hint(n, fallback=NUM_SMS)
         for (

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1238,17 +1238,7 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
         # to that case -- unit-scalar addmm and plain mm both qualify. sympy Symbol == 1
         # returns a plain False, so this stays safe for symbolic scalars.
         scalars = getattr(kernel_inputs, "_scalars", None) or {}
-        # split-K needs the JIT Python wrapper: its _reduce_k_kernel is emitted via a Python
-        # `import` (emit_reduce_k_call / _tlx_emit_post_kernel_code), which is ILLEGAL in the
-        # AOTInductor C++ wrapper -- emitting `from ...reduce_k import _reduce_k_kernel` there yields
-        # "unknown type name 'from'" + dropped split_k_ws buffer decls, breaking the C++ compile
-        # (T280910119, seen in the merge-net E2E). So only offer split-K under the Python wrapper;
-        # cpp_wrapper (AOTI, the production path) uses SPLIT_K=1. Proper AOTI-C++ reduce-k is a follow-up.
-        allow_split_k = (
-            scalars.get("alpha", 1) == 1
-            and scalars.get("beta", 1) == 1
-            and not config.cpp_wrapper
-        )
+        allow_split_k = scalars.get("alpha", 1) == 1 and scalars.get("beta", 1) == 1
         m_hint = sizevars.optimization_hint(m, fallback=NUM_SMS)
         n_hint = sizevars.optimization_hint(n, fallback=NUM_SMS)
         for (
@@ -2005,7 +1995,7 @@ def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-u
     split_k = getattr(self, "_tlx_split_k", 1)
     if split_k > 1 and self.workspace_arg is not None:
         from torch._inductor.codegen.triton import triton_type
-        from .reduce_k import emit_reduce_k_call
+        from .reduce_k import emit_aoti_reduce_k_call, emit_reduce_k_call
 
         # Determine output buffer name and dtype
         out_name = self.output_node.get_name()
@@ -2022,6 +2012,7 @@ def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-u
         # split-K bypasses -> it must be re-added in the reduction. For addmm the bias is
         # the prefix input node (input_nodes[0], prefix_args=1); plain mm has none.
         bias_name = None
+        bias_node = None
         stride_bias_m = 0
         stride_bias_n = 1
         if getattr(self, "prefix_args", 0) >= 1 and self.input_nodes:
@@ -2043,18 +2034,32 @@ def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-u
             else:
                 bias_name = None  # unexpected rank; skip (should not happen for addmm)
 
-        emit_reduce_k_call(
-            wrapper,
-            ws_name=self.workspace_arg.outer_name,
-            output_name=out_name,
-            M_expr=M_expr,
-            N_expr=N_expr,
-            split_k=split_k,
-            output_triton_dtype=output_triton_dtype,
-            bias_name=bias_name,
-            stride_bias_m=stride_bias_m,
-            stride_bias_n=stride_bias_n,
-        )
+        if config.cpp_wrapper:
+            emit_aoti_reduce_k_call(
+                wrapper,
+                workspace_arg=self.workspace_arg,
+                output_node=self.output_node,
+                bias_node=bias_node if bias_name is not None else None,
+                M=self.call_sizes[0],
+                N=self.call_sizes[1],
+                split_k=split_k,
+                output_triton_dtype=output_triton_dtype,
+                stride_bias_m=stride_bias_m,
+                stride_bias_n=stride_bias_n,
+            )
+        else:
+            emit_reduce_k_call(
+                wrapper,
+                ws_name=self.workspace_arg.outer_name,
+                output_name=out_name,
+                M_expr=M_expr,
+                N_expr=N_expr,
+                split_k=split_k,
+                output_triton_dtype=output_triton_dtype,
+                bias_name=bias_name,
+                stride_bias_m=stride_bias_m,
+                stride_bias_n=stride_bias_n,
+            )
     _orig_emit_post_kernel(self, wrapper, kernel_name)
 
 


### PR DESCRIPTION
Summary:

Keep the existing split-K fp32 workspace path under AOTInductor and register `_reduce_k_kernel` as an Inductor-visible Triton kernel. Emit the post-GEMM reduction through `wrapper.generate_kernel_call`, which gives the C++ wrapper a native GPU launch instead of injecting Python imports and JIT syntax into `wrapper.cpp`.

The Python wrapper keeps its existing JIT reduction call. The AOTI path preserves workspace lifetime, output dtype, optional addmm bias, and symbolic M/N grid expressions. Split-K candidates are enabled again when `config.cpp_wrapper` is set.

Reviewed By: rocketerfb

Differential Revision: D113851999
