### PR TITLE
[TLX][AMD] Make split-K addmm work under AOTInductor

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -258,6 +258,54 @@ class TestTLXTemplates(TestCase):
         "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
     )
     @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_tlx_addmm_warppipe_split_k_epilogue_not_fused(self):
+        """Split-K addmm with a fused pointwise epilogue (gelu), JIT and AOTI.
+
+        The split-K reduce kernel only sums fp32 partials + re-adds bias; it cannot
+        replay a fused epilogue. Fusing an epilogue onto a split-K choice leaves the
+        epilogue's output buffer used-before-defined -- UnboundLocalError under the
+        JIT Python wrapper, "use of undeclared identifier buf###" under the AOTI C++
+        wrapper -- and would silently drop the epilogue. The MultiTemplateBuffer
+        allow_epilogue_fusion gate disables epilogue fusion for split-K choices, so
+        the epilogue runs as a separate kernel: split-K stays for the GEMM and the
+        result is correct. Regression guard for both wrappers.
+        """
+        M, K, N = 256, 4096, 256
+        dtype = torch.float16
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
+        w = torch.randn(N, K, device=GPU_TYPE, dtype=dtype)
+        bias = torch.randn(N, device=GPU_TYPE, dtype=dtype)
+
+        def addmm_gelu(bias, a, w):
+            return torch.nn.functional.gelu(torch.addmm(bias, a, w.t()))
+
+        c_expected = torch.nn.functional.gelu(
+            a.float() @ w.t().float() + bias.float()
+        ).to(dtype)
+
+        for cpp_wrapper in (False, True):
+            with config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+                "cpp_wrapper": cpp_wrapper,
+            }):
+                c_actual, code = run_and_get_code(
+                    torch.compile(addmm_gelu), bias, a, w
+                )
+
+            # epilogue applied correctly (not dropped) and no use-before-def crash
+            torch.testing.assert_close(c_actual, c_expected, atol=3e-2, rtol=3e-2)
+            # split-K still used for the GEMM (gelu runs in a separate kernel)
+            self.assertIn("_reduce_k_kernel", "\n".join(code))
+
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
     @parametrize("dtype", (torch.float16, torch.bfloat16))
     def test_tlx_addmm_warppipe_unaligned_k(self, dtype: torch.dtype):
         """Unaligned K (K % BLOCK_K != 0) on the TLX warp-pipe addmm (gfx950).

--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -223,6 +223,41 @@ class TestTLXTemplates(TestCase):
         "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
     )
     @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_tlx_addmm_warppipe_split_k_cpp_wrapper(self):
+        M, K, N = 256, 4096, 256
+        dtype = torch.float16
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
+        w = torch.randn(N, K, device=GPU_TYPE, dtype=dtype)
+        bias = torch.randn(N, device=GPU_TYPE, dtype=dtype)
+
+        def addmm(bias, a, w):
+            return torch.addmm(bias, a, w.t())
+
+        with (config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+                "cpp_wrapper": True,
+        }), ):
+            c_actual, code = run_and_get_code(torch.compile(addmm), bias, a, w)
+
+        c_expected = (a.float() @ w.t().float() + bias.float()).to(dtype)
+        torch.testing.assert_close(c_actual, c_expected, atol=3e-2, rtol=3e-2)
+
+        code_str = "\n".join(code)
+        self.assertIn("split_k_ws", code_str)
+        self.assertIn("call__reduce_k_kernel_", code_str)
+        self.assertNotIn(
+            "from triton.language.extra.tlx.inductor.reduce_k import", code_str
+        )
+
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
     @parametrize("dtype", (torch.float16, torch.bfloat16))
     def test_tlx_addmm_warppipe_unaligned_k(self, dtype: torch.dtype):
         """Unaligned K (K % BLOCK_K != 0) on the TLX warp-pipe addmm (gfx950).
@@ -596,7 +631,51 @@ class TestSplitK(TestCase):
 
 
 class TestReduceKKernel(TestCase):
-    """Direct unit test for the split-K reduction kernel."""
+    """Direct unit tests for the split-K reduction kernel."""
+
+    def test_aoti_reduce_k_emission(self):
+        from triton.language.extra.tlx.inductor.reduce_k import (
+            emit_aoti_reduce_k_call,
+        )
+
+        wrapper = mock.MagicMock()
+        wrapper.define_user_defined_triton_kernel.return_value = (
+            "_reduce_k_kernel_0",
+            {"signature": {}},
+            {"grid_type": "FixedGrid"},
+            [],
+        )
+        workspace = mock.MagicMock()
+        workspace.outer_name = "split_k_ws_0"
+        workspace.dtype = torch.float32
+        output = mock.MagicMock()
+        output.get_name.return_value = "buf_out"
+        output.get_dtype.return_value = torch.float16
+        output.get_device.return_value = torch.device("cuda")
+        bias = mock.MagicMock()
+        bias.get_name.return_value = "arg_bias"
+        bias.get_dtype.return_value = torch.float16
+
+        emit_aoti_reduce_k_call(
+            wrapper,
+            workspace_arg=workspace,
+            output_node=output,
+            bias_node=bias,
+            M=256,
+            N=256,
+            split_k=4,
+            output_triton_dtype="tl.float16",
+        )
+
+        wrapper.define_user_defined_triton_kernel.assert_called_once()
+        wrapper.generate_kernel_call.assert_called_once()
+        call = wrapper.generate_kernel_call.call_args
+        self.assertEqual("_reduce_k_kernel_0", call.args[0])
+        self.assertEqual(
+            ["split_k_ws_0", "buf_out", "arg_bias", 256, 256],
+            call.args[1],
+        )
+        self.assertTrue(call.kwargs["triton"])
 
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),

--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -272,24 +272,18 @@ class TestTLXTemplates(TestCase):
         "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
     )
     @unittest.skipIf(not has_tlx(), "TLX not available")
-    def test_tlx_addmm_warppipe_odd_k_async_copy_alignment_repro(self):
-        """REPRO of the residual odd-K async_copy 16-byte-alignment failure (gfx950).
+    def test_tlx_addmm_warppipe_regpath_odd_k(self):
+        """Odd K on the TLX addmm template -> register-path branch (USE_ASYNC=0), T280910119.
 
-        The sync-load-the-tail fix handles K % BLOCK_K != 0, but ONLY when the row stride is
-        16-byte aligned (K a multiple of 8). K=2309 (odd; the production compression bmm's K) is
-        NOT: A [M,K] and col-major B [K,N] both have row stride K, so a row spans 2309*2 = 4618 B,
-        not a multiple of 16. The col-major B's async_copy into the swizzled #ttg.padded_shared
-        LDS layout then cannot legalize -> builtin.unrealized_conversion_cast on arg_B -> "failed
-        to translate module to LLVM IR". In tlx_mode=force (TRITON-only) every config fails to
-        compile, so select_algorithm raises NoValidChoicesError.
-
-        This documents a KNOWN residual -- an AMD-backend async_copy alignment fix, out of scope
-        for the sync-tail kernel change. When that fix lands this test will start passing
-        (NoValidChoicesError no longer raised); convert it to a correctness check then.
-        compile_threads=1 keeps the compile in-process so the real MLIR error is visible in the
-        test log (subprocess autotune otherwise swallows it behind NoValidChoicesError).
+        K=2309 (odd) has a 2309*2 = 4618 B row stride that is never 16-byte aligned, so the
+        direct-to-LDS async_load path cannot legalize on CDNA4 (col-major B's async_copy into the
+        swizzled #ttg.padded_shared LDS layout). The heuristic sets USE_ASYNC=0 and the template
+        takes the register-path fallback (tl.load -> tl.dot, auto-pipelined), which lowers for ANY
+        alignment -- same mechanism as the bmm template. In tlx_mode=force (TRITON-only) this must
+        lower to the Triton template (never extern/aten) and be numerically correct. (Previously
+        this shape declined -> NoValidChoicesError; the addmm register-path fallback fixed it.)
         """
-        M, K, N = 4096, 2309, 192  # odd K -> 2309*2 = 4618 B row stride, NOT 16-byte aligned
+        M, K, N = 4096, 2309, 192  # odd K -> 4618 B row stride, not 16-byte aligned -> register path
         a = torch.randn(M, K, device=GPU_TYPE, dtype=torch.float16)
         w = torch.randn(N, K, device=GPU_TYPE, dtype=torch.float16)
         bias = torch.randn(N, device=GPU_TYPE, dtype=torch.float16)
@@ -303,10 +297,13 @@ class TestTLXTemplates(TestCase):
                 "max_autotune": True,
                 "max_autotune_gemm_backends": "TRITON",
                 "enable_caching_generated_triton_templates": False,
-                "compile_threads": 1,
         }):
-            with self.assertRaises(Exception):
-                run_and_get_code(torch.compile(addmm), bias, a, w)
+            c_actual, code = run_and_get_code(torch.compile(addmm), bias, a, w)
+
+        c_expected = (a.float() @ w.t().float() + bias.float()).to(torch.float16)
+        torch.testing.assert_close(c_actual, c_expected, atol=2e-2, rtol=2e-2)
+        # force mode keeps only the TLX template -> odd-K addmm must lower via the register branch.
+        self.assertIn("triton_tem", "\n".join(code))
 
     @unittest.skipIf(
         not is_gfx950(),

--- a/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/amd_addmm_warppipe.py.jinja
@@ -19,11 +19,11 @@
     # masked tl.load + one extra dot ("sync-load the tail"). For K that IS a multiple of BLOCK_K
     # the tail is a no-op (all-false mask), so aligned-K codegen is unchanged.
     #
-    # CAVEAT: this needs K to be a multiple of 8 (16-byte row alignment; A [M,K] and col-major
-    # B [K,N] both have row stride K, so K*2 bytes must be 16-aligned). An odd/non-8 K hits a
-    # SEPARATE limit -- B's async_copy into the swizzled padded_shared layout cannot legalize a
-    # non-16-byte-aligned row (builtin.unrealized_conversion_cast on arg_B) -- which the sync
-    # tail does NOT fix (it is an AMD-backend async_copy alignment issue).
+    # DUAL PATH (USE_ASYNC constexpr, set by the heuristic from K's alignment): K % 8 == 0 uses the
+    # async_load direct-to-LDS warp-pipe below (needs 16-byte-aligned rows: A [M,K] + col-major
+    # B [K,N] have row stride K, so K*2 B must be 16-aligned). Unaligned/odd/sliced/small/dynamic K
+    # -- which the async_copy path can't legalize on CDNA4 -- uses the register-path fallback
+    # (tl.load->tl.dot, auto-pipelined), same mechanism as the bmm template (T280910119).
     M = {{size("A", 0)}}
     N = {{size("B", 1)}}
     K = {{size("A", 1)}}
@@ -83,6 +83,8 @@
     a_base = offs_m[:, None] * stride_am
     b_base = offs_n[:, None] * stride_bn          # B as (BLOCK_N, BLOCK_K): n is the row of the [N,K] view
 
+{% if USE_ASYNC %}
+    # --- async_load direct-to-LDS warp-pipe path (USE_ASYNC=1: K % 8 == 0, 16-byte-aligned rows) ---
     K_ITERS = K // BLOCK_K   # FULL K-tiles only; the partial-K tail is handled after the pipeline
 {% if SPLIT_K > 1 %}
     # this split's contiguous K-iteration range [k_lo, k_lo + n_iters). BALANCED
@@ -179,6 +181,22 @@
     b_offs = (k_tail + offs_k[:, None]) * stride_bk + offs_n[None, :] * stride_bn
     b_tail = tl.load(B + b_offs.to(tl.int32), mask=offs_k[:, None] < tail_width, other=0.0)
     acc = tl.dot(a_tail, b_tail, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+{% else %}
+    # --- register-path fallback (USE_ASYNC=0: (K*itemsize) % 16 != 0, e.g. odd/sliced/small K) ---
+    # buffer_load (tl.load) is element-granular, so it lowers for ANY row-stride alignment where the
+    # direct-to-LDS async_load cannot -- same mechanism as the bmm register branch (T280910119).
+    # A is loaded [BLOCK_M, BLOCK_K]; col-major B [K,N] is loaded [BLOCK_K, BLOCK_N] with K along rows
+    # (same index as the sync-tail above) so it feeds tl.dot directly (no local_trans). The masked
+    # load handles K % BLOCK_K inline. num_stages>1 (set by the heuristic) auto-pipelines the loads.
+    # SPLIT_K is always 1 on this path (the heuristic only emits SPLIT_K=1 register configs).
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+    for k in range(0, K, BLOCK_K):
+        a_offs = a_base + (k + offs_k[None, :]) * stride_ak
+        a_reg = tl.load(A + a_offs.to(tl.int32), mask=offs_k[None, :] < K - k, other=0.0)
+        b_offs = (k + offs_k[:, None]) * stride_bk + offs_n[None, :] * stride_bn
+        b_reg = tl.load(B + b_offs.to(tl.int32), mask=offs_k[:, None] < K - k, other=0.0)
+        acc = tl.dot(a_reg, b_reg, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+{% endif %}
 
     # rematerialize rm and rn to save registers
     rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)

--- a/third_party/tlx/language/tlx/inductor/reduce_k.py
+++ b/third_party/tlx/language/tlx/inductor/reduce_k.py
@@ -14,8 +14,10 @@ Ported from upstream:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
+import sympy
+import torch
 import triton
 import triton.language as tl
 
@@ -103,4 +105,80 @@ def emit_reduce_k_call(
         f" OUTPUT_DTYPE={output_triton_dtype},"
         f" HAS_BIAS={has_bias}, STRIDE_BIAS_M={stride_bias_m},"
         f" STRIDE_BIAS_N={stride_bias_n})"
+    )
+
+
+def emit_aoti_reduce_k_call(
+    wrapper: "WrapperCodeGen",
+    workspace_arg: Any,
+    output_node: Any,
+    bias_node: Any | None,
+    M: Any,
+    N: Any,
+    split_k: int,
+    output_triton_dtype: str,
+    stride_bias_m: int = 0,
+    stride_bias_n: int = 1,
+) -> None:
+    """Register and launch the split-K reducer through the AOTI C++ wrapper."""
+    from torch._inductor import ir
+    from torch.utils._sympy.functions import CeilDiv
+
+    has_bias = bias_node is not None
+    bias_arg = bias_node if has_bias else output_node
+    workspace_buffer = ir.Buffer(
+        name=workspace_arg.outer_name,
+        layout=workspace_arg.get_layout(),
+    )
+    kwargs = {
+        "workspace_ptr": workspace_buffer,
+        "c_ptr": output_node,
+        "bias_ptr": bias_arg,
+        "M": M,
+        "N": N,
+        "SPLIT_K": split_k,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "OUTPUT_DTYPE": getattr(tl, output_triton_dtype.removeprefix("tl.")),
+        "HAS_BIAS": has_bias,
+        "STRIDE_BIAS_M": stride_bias_m,
+        "STRIDE_BIAS_N": stride_bias_n,
+    }
+    grid = [[CeilDiv(M, 32), CeilDiv(N, 32), sympy.Integer(1)]]
+    name, triton_meta, inductor_meta, grid_args = (
+        wrapper.define_user_defined_triton_kernel(
+            _reduce_k_kernel,
+            [triton.Config({})],
+            kwargs,
+            restore_value_args=(),
+            reset_to_zero_args=(),
+            grids=grid,
+            epilogue_fusion=None,
+            launch_kwargs=(),
+        )
+    )
+    call_args = [
+        workspace_arg.outer_name,
+        output_node.get_name(),
+        bias_arg.get_name(),
+        M,
+        N,
+        *grid_args,
+    ]
+    arg_types = [
+        workspace_arg.dtype,
+        output_node.get_dtype(),
+        bias_arg.get_dtype(),
+        type(M),
+        type(N),
+        *map(type, grid_args),
+    ]
+    wrapper.generate_kernel_call(
+        name,
+        call_args,
+        arg_types=arg_types,
+        triton_meta=triton_meta,
+        inductor_meta=inductor_meta,
+        triton=True,
+        device=output_node.get_device(),
     )

--- a/third_party/tlx/language/tlx/inductor/reduce_k.py
+++ b/third_party/tlx/language/tlx/inductor/reduce_k.py
@@ -121,17 +121,16 @@ def emit_aoti_reduce_k_call(
     stride_bias_n: int = 1,
 ) -> None:
     """Register and launch the split-K reducer through the AOTI C++ wrapper."""
-    from torch._inductor import ir
     from torch.utils._sympy.functions import CeilDiv
 
     has_bias = bias_node is not None
     bias_arg = bias_node if has_bias else output_node
-    workspace_buffer = ir.Buffer(
-        name=workspace_arg.outer_name,
-        layout=workspace_arg.get_layout(),
-    )
+    # Pass the WorkspaceArg itself (not an ir.Buffer wrapper) so the kernel
+    # signature carries it as a WorkspaceArg: config_of then short-circuits it
+    # instead of resolving its layout via scheduler.name_to_buf (which has no
+    # entry for a self-allocated workspace -> KeyError under cpp_wrapper).
     kwargs = {
-        "workspace_ptr": workspace_buffer,
+        "workspace_ptr": workspace_arg,
         "c_ptr": output_node,
         "bias_ptr": bias_arg,
         "M": M,

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1217,14 +1217,16 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
             and _sizevar_hint(sizevars, n * k, int32_max) < int32_max
         ):
             return
-        # 16-byte (128-bit transaction) alignment: the fp16/bf16 padded direct-to-LDS async_copy
-        # lowers to 128-bit loads, so each row start must be 16-byte aligned -- i.e. the row stride
-        # K*itemsize bytes must be a multiple of 16 (K % 8 == 0 for fp16/bf16). Without this guard
-        # an unaligned K reaches the template and fails at async_copy legalization (T280910119);
-        # decline up front so it falls back to aten cleanly. Also declines dynamic/unknown K.
+        # DUAL PATH by K alignment (the USE_ASYNC constexpr picks the template branch), mirroring
+        # the bmm template: (K*itemsize) % 16 == 0 (K % 8 for fp16/bf16) -> USE_ASYNC=1, the fast
+        # direct-to-LDS async_load warp-pipe (+ optional split-K). Otherwise (unaligned/odd/sliced/
+        # small or dynamic K, which the direct-to-LDS async_copy can't legalize on CDNA4) ->
+        # USE_ASYNC=0, the register-path fallback (tl.load->tl.dot, auto-pipelined, SPLIT_K=1) so
+        # those addmm shapes still get a Triton candidate instead of only aten (T280910119).
         itemsize = torch.finfo(kernel_inputs.dtype(kernel_inputs._mat1_idx)).bits // 8
-        if not sizevars.statically_known_true(sympy.Eq(sympy.Mod(k * itemsize, 16), 0)):
-            return
+        use_async = sizevars.statically_known_true(
+            sympy.Eq(sympy.Mod(k * itemsize, 16), 0)
+        )
         num_xcds = _amd_num_xcds()
         # split-K only helps grids that leave CUs idle. NUM_SMS is the device CU count
         # (get_num_sms() maps to multi_processor_count = CUs on ROCm; 256 on gfx950/MI350X);
@@ -1250,37 +1252,37 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
             # MFMA requires block_m/block_n be multiples of matrix_instr_nonkdim (16).
             if block_m % 16 != 0 or block_n % 16 != 0:
                 continue
-            # warp-pipeline correctness guard: K_ITERS > NUM_BUFFERS.
-            if not sizevars.statically_known_true(sympy.Gt(k, num_buffers * block_k)):
-                continue
-            # SPLIT_K=1 (plain data-parallel) is always offered. Add split candidates
-            # only for undersaturated grids, and only when each split still runs
-            # K_ITERS/SPLIT_K > NUM_BUFFERS iters (statically checked via k > NB*BK*SK)
-            # so the warp-pipeline prologue/drain stays well-formed.
-            tiles = ((m_hint + block_m - 1) // block_m) * (
-                (n_hint + block_n - 1) // block_n
-            )
-            split_ks = [1]
-            if allow_split_k and tiles < NUM_SMS:
-                for sk in (2, 4, 8):
-                    # Cap at ~4 waves. For memory-bound large-K the sweet spot is
-                    # often >1 wave (more concurrent HBM requests -> higher effective
-                    # bandwidth); the standalone sweep's winners filled to 300%
-                    # (e.g. 1024x6144x22272 at SK=4 -> 768 wg / 3 waves). A 2-wave cap
-                    # excluded exactly those, so autotune fell back to a slower SK=1.
-                    if tiles * sk > 4 * NUM_SMS:
-                        break
-                    # correctness: the balanced K-partition gives each split
-                    # base = K_ITERS // SK iters; require base > NUM_BUFFERS so every
-                    # split's warp-pipeline prologue/drain is well-formed. Sufficient
-                    # static condition on K: k > (NUM_BUFFERS + 1) * BLOCK_K * SK.
-                    if sizevars.statically_known_true(
-                        sympy.Gt(k, (num_buffers + 1) * block_k * sk)
-                    ):
-                        split_ks.append(sk)
+            if use_async:
+                # async warp-pipeline correctness guard: K_ITERS > NUM_BUFFERS (well-formed
+                # prologue/drain). SPLIT_K=1 always; add split candidates for undersaturated grids
+                # only when each split still runs K_ITERS/SPLIT_K > NUM_BUFFERS iters (k > NB*BK*SK).
+                if not sizevars.statically_known_true(sympy.Gt(k, num_buffers * block_k)):
+                    continue
+                tiles = ((m_hint + block_m - 1) // block_m) * (
+                    (n_hint + block_n - 1) // block_n
+                )
+                split_ks = [1]
+                if allow_split_k and tiles < NUM_SMS:
+                    for sk in (2, 4, 8):
+                        # Cap at ~4 waves (memory-bound large-K sweet spot is often >1 wave;
+                        # e.g. 1024x6144x22272 at SK=4 -> 768 wg / 3 waves).
+                        if tiles * sk > 4 * NUM_SMS:
+                            break
+                        # correctness: balanced K-partition gives each split base = K_ITERS // SK
+                        # iters; require base > NUM_BUFFERS (k > (NUM_BUFFERS+1)*BLOCK_K*SK).
+                        if sizevars.statically_known_true(
+                            sympy.Gt(k, (num_buffers + 1) * block_k * sk)
+                        ):
+                            split_ks.append(sk)
+            else:
+                # register path: no prologue -> handles ANY K (odd/sliced/small/dynamic); no split-K
+                # (its reduction path is only wired for the async warp-pipe), so SPLIT_K=1 only.
+                split_ks = [1]
             for split_k in split_ks:
                 triton_config = self.triton_config(
-                    1,  # num_stages=1: TLX is hand-pipelined; auto software-pipelining must be off
+                    # async is hand-pipelined (num_stages=1, auto software-pipelining off); the
+                    # register path relies on the auto-pipeliner (num_stages=3) to overlap tl.loads.
+                    1 if use_async else 3,
                     num_warps,
                     BLOCK_M=block_m,
                     BLOCK_N=block_n,
@@ -1289,6 +1291,7 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
                     NUM_BUFFERS=num_buffers,
                     NUM_XCDS=num_xcds,
                     SPLIT_K=split_k,
+                    USE_ASYNC=use_async,
                     matrix_instr_nonkdim=16,
                     waves_per_eu=0,
                     kpack=get_default_kpack(block_k),

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1238,7 +1238,17 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
         # to that case -- unit-scalar addmm and plain mm both qualify. sympy Symbol == 1
         # returns a plain False, so this stays safe for symbolic scalars.
         scalars = getattr(kernel_inputs, "_scalars", None) or {}
-        allow_split_k = scalars.get("alpha", 1) == 1 and scalars.get("beta", 1) == 1
+        # split-K needs the JIT Python wrapper: its _reduce_k_kernel is emitted via a Python
+        # `import` (emit_reduce_k_call / _tlx_emit_post_kernel_code), which is ILLEGAL in the
+        # AOTInductor C++ wrapper -- emitting `from ...reduce_k import _reduce_k_kernel` there yields
+        # "unknown type name 'from'" + dropped split_k_ws buffer decls, breaking the C++ compile
+        # (T280910119, seen in the merge-net E2E). So only offer split-K under the Python wrapper;
+        # cpp_wrapper (AOTI, the production path) uses SPLIT_K=1. Proper AOTI-C++ reduce-k is a follow-up.
+        allow_split_k = (
+            scalars.get("alpha", 1) == 1
+            and scalars.get("beta", 1) == 1
+            and not config.cpp_wrapper
+        )
         m_hint = sizevars.optimization_hint(m, fallback=NUM_SMS)
         n_hint = sizevars.optimization_hint(n, fallback=NUM_SMS)
         for (

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1238,17 +1238,7 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
         # to that case -- unit-scalar addmm and plain mm both qualify. sympy Symbol == 1
         # returns a plain False, so this stays safe for symbolic scalars.
         scalars = getattr(kernel_inputs, "_scalars", None) or {}
-        # split-K needs the JIT Python wrapper: its _reduce_k_kernel is emitted via a Python
-        # `import` (emit_reduce_k_call / _tlx_emit_post_kernel_code), which is ILLEGAL in the
-        # AOTInductor C++ wrapper -- emitting `from ...reduce_k import _reduce_k_kernel` there yields
-        # "unknown type name 'from'" + dropped split_k_ws buffer decls, breaking the C++ compile
-        # (T280910119, seen in the merge-net E2E). So only offer split-K under the Python wrapper;
-        # cpp_wrapper (AOTI, the production path) uses SPLIT_K=1. Proper AOTI-C++ reduce-k is a follow-up.
-        allow_split_k = (
-            scalars.get("alpha", 1) == 1
-            and scalars.get("beta", 1) == 1
-            and not config.cpp_wrapper
-        )
+        allow_split_k = scalars.get("alpha", 1) == 1 and scalars.get("beta", 1) == 1
         m_hint = sizevars.optimization_hint(m, fallback=NUM_SMS)
         n_hint = sizevars.optimization_hint(n, fallback=NUM_SMS)
         for (
@@ -2005,7 +1995,7 @@ def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-u
     split_k = getattr(self, "_tlx_split_k", 1)
     if split_k > 1 and self.workspace_arg is not None:
         from torch._inductor.codegen.triton import triton_type
-        from .reduce_k import emit_reduce_k_call
+        from .reduce_k import emit_aoti_reduce_k_call, emit_reduce_k_call
 
         # Determine output buffer name and dtype
         out_name = self.output_node.get_name()
@@ -2022,6 +2012,7 @@ def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-u
         # split-K bypasses -> it must be re-added in the reduction. For addmm the bias is
         # the prefix input node (input_nodes[0], prefix_args=1); plain mm has none.
         bias_name = None
+        bias_node = None
         stride_bias_m = 0
         stride_bias_n = 1
         if getattr(self, "prefix_args", 0) >= 1 and self.input_nodes:
@@ -2043,18 +2034,32 @@ def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-u
             else:
                 bias_name = None  # unexpected rank; skip (should not happen for addmm)
 
-        emit_reduce_k_call(
-            wrapper,
-            ws_name=self.workspace_arg.outer_name,
-            output_name=out_name,
-            M_expr=M_expr,
-            N_expr=N_expr,
-            split_k=split_k,
-            output_triton_dtype=output_triton_dtype,
-            bias_name=bias_name,
-            stride_bias_m=stride_bias_m,
-            stride_bias_n=stride_bias_n,
-        )
+        if config.cpp_wrapper:
+            emit_aoti_reduce_k_call(
+                wrapper,
+                workspace_arg=self.workspace_arg,
+                output_node=self.output_node,
+                bias_node=bias_node if bias_name is not None else None,
+                M=self.call_sizes[0],
+                N=self.call_sizes[1],
+                split_k=split_k,
+                output_triton_dtype=output_triton_dtype,
+                stride_bias_m=stride_bias_m,
+                stride_bias_n=stride_bias_n,
+            )
+        else:
+            emit_reduce_k_call(
+                wrapper,
+                ws_name=self.workspace_arg.outer_name,
+                output_name=out_name,
+                M_expr=M_expr,
+                N_expr=N_expr,
+                split_k=split_k,
+                output_triton_dtype=output_triton_dtype,
+                bias_name=bias_name,
+                stride_bias_m=stride_bias_m,
+                stride_bias_n=stride_bias_n,
+            )
     _orig_emit_post_kernel(self, wrapper, kernel_name)
 
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/191547

Two fixes on top of D113851999 let TLX split-K addmm compile and run correctly under AOTInductor (and JIT), flipping more addmm autotune selections from rocBLAS to TLX with no accuracy gap.

1. Workspace arg (`KeyError: 'workspace_1070'`): `emit_aoti_reduce_k_call` wrapped the split-K workspace in an `ir.Buffer`, which becomes a `TensorArg` in the kernel signature; on HIP `config_of` then resolves its layout via `scheduler.get_buffer_layout` -> `name_to_buf` and KeyErrors, because a `WorkspaceArg` is not a scheduler buffer. Pass the real `WorkspaceArg` from `emit_aoti_reduce_k_call`, and add a `WorkspaceArg` branch to `define_user_defined_triton_kernel` (`add_to_signature`) so `config_of` short-circuits it (as it does for template workspaces).

2. Split-K vs epilogue fusion (`buf693` / correctness): split-K bypasses `store_output` and reduces in a separate `_reduce_k_kernel` that only sums fp32 partials + re-adds bias. It cannot replay a fused pointwise epilogue (gelu, etc.), so fusing one onto a split-K choice leaves the epilogue's output buffer used-before-defined -- `UnboundLocalError` under the JIT Python wrapper, "use of undeclared identifier buf###" under the AOTI C++ wrapper -- and would silently drop the epilogue. This is not AOTI-specific. Fix: expose `SPLIT_K` on `TritonTemplateCaller`, and set `allow_epilogue_fusion = False` on a `MultiTemplateBuffer` when any of its choices is split-K; the existing `_is_epilogue_fusion_enabled` gate then blocks epilogue fusion onto split-K choices across both wrapper paths. The epilogue runs as a separate kernel; split-K stays selectable for the GEMM.

Net behavior: split-K addmm is now selectable under AOTInductor and wins more addmm over rocBLAS, but a split-K node does not additionally fuse an epilogue (the reduce kernel cannot replay it). No accuracy gap.

Follow-ups (T282209364): the gate is slightly over-broad (a split-K-offering node also loses epilogue fusion for its SK=1 choice); recovering that per-choice, or replaying the epilogue inside `_reduce_k_kernel` to keep split-K + epilogue fused, are perf follow-ups.

Authored with an AI coding assistant.

Differential Revision: D113910767
