### PR TITLE
[triton][beta] [Cherry-pick] '[AMD] Improve codegen in shuffleXor and warpReduce (#10414)' (#2535)

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -162,16 +162,23 @@ std::optional<LinearLayout> chooseMfmaLikeStoreLayout(RankedTensorType valType);
 LinearLayout getCoreMatrixLinearLayout(NVMMASharedEncodingAttr shared,
                                        bool disableSwizzle);
 
-// Create a LinearLayout for TDM (Tensor DMA) block shapes.
-// Returns a (message, warp, block) -> (dim0, dim1, ...) layout.
+// Create a TDM (Tensor DMA) LinearLayout: (message, warp, block) ->
+// (dim0, dim1, ...).  TDM is warp-granular.  The "warp" sublayout is an
+// identity over `warpsPerCTA`, zero-padded up to log2(numWarps) so the
+// full module warpId is covered; padded rows expose the redundant bits
+// as free variables (via getFreeVariableMasks("warp")) so partial copies
+// (K < numWarps) can pred-off inactive warps.  "message" covers the
+// per-warp tile (surjectivity); "block" comes from `cgaLayout`.
 //
-// TDM operates at warp granularity. The warp dimension distributes warps across
-// output dimensions according to warpsPerCTA. The message dimension covers each
-// warp's portion of the block (blockShape / warpsPerCTA) for surjectivity. The
-// block dimension comes from cgaLayout.
+// `warpUsedHint`: power-of-two-popcount bitmask whose K = popcount(hint)
+// set bits select active warps.  The varying warpId bit positions in the
+// active set are the warp bits that contribute to per-warp offsets; all
+// other warpId bits become free variables for predicating inactive warps.
+// Empty = no-hint default (lowest log2(K) bits, K = prod(warpsPerCTA)).
 LinearLayout getTDMLinearLayout(ArrayRef<int64_t> blockShape,
                                 ArrayRef<unsigned> warpsPerCTA,
-                                const LinearLayout &cgaLayout);
+                                const LinearLayout &cgaLayout, int totalWarps,
+                                std::optional<uint32_t> warpUsedHint = {});
 
 } // namespace mlir::triton::gpu
 #endif // TRITON_DIALECT_TRITONGPU_IR_LINEARLAYOUTCONVERSIONS_H

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3034,6 +3034,36 @@ struct TritonGPUInferLayoutInterface
           applyPermutation(invOrderUnsigned, enc.getOrder()), cgaLayout);
       return success();
     }
+
+    if (auto enc = dyn_cast<PartitionedSharedEncodingAttr>(operandEncoding)) {
+      // Recurse on the inner partition layout using the shape of a single
+      // logical piece (partitionDim is divided by numLogicalPieces, all other
+      // dimensions are unchanged). Rank, divisibility, and partitionDim bounds
+      // are invariants of a valid PartitionedSharedEncodingAttr enforced by
+      // its verifier. The recursive call will checkRank against the inner
+      // partitionLayout.
+      unsigned partitionDim = enc.getPartitionDim();
+      SmallVector<int64_t> partitionShape(shape.begin(), shape.end());
+      partitionShape[partitionDim] /= enc.getNumLogicalPieces();
+
+      Attribute innerResultEncoding;
+      if (failed(inferTransOpEncoding(enc.getPartitionLayout(), partitionShape,
+                                      order, innerResultEncoding, loc)))
+        return failure();
+
+      auto innerShared = dyn_cast<SharedEncodingTrait>(innerResultEncoding);
+      if (!innerShared) {
+        return emitOptionalError(loc, "transposed partition layout is not a "
+                                      "SharedEncodingTrait");
+      }
+
+      // After the permutation, the old partitionDim axis lives at the position
+      // j where order[j] == partitionDim, i.e. invOrder[partitionDim].
+      resultEncoding = PartitionedSharedEncodingAttr::get(
+          ctx, enc.getNumPartitions(), enc.getNumGroups(),
+          invOrder[partitionDim], innerShared);
+      return success();
+    }
     // Generic case
     auto padded = dyn_cast<PaddedSharedEncodingAttr>(operandEncoding);
 

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1833,7 +1833,8 @@ chooseMfmaLikeStoreLayout(RankedTensorType valType) {
 
 LinearLayout getTDMLinearLayout(ArrayRef<int64_t> blockShape,
                                 ArrayRef<unsigned> warpsPerCTA,
-                                const LinearLayout &cgaLayout) {
+                                const LinearLayout &cgaLayout, int totalWarps,
+                                std::optional<uint32_t> warpUsedHint) {
   int numDims = blockShape.size();
   auto ctx = cgaLayout.getOutDimNames().begin()->getContext();
 
@@ -1841,13 +1842,58 @@ LinearLayout getTDMLinearLayout(ArrayRef<int64_t> blockShape,
   assert(static_cast<int>(warpsPerCTA.size()) == numDims);
 
   SmallVector<unsigned> messageShape(numDims);
-  for (int i = 0; i < numDims; ++i)
+  unsigned activeWarps = 1;
+  for (int i = 0; i < numDims; ++i) {
     messageShape[i] = blockShape[i] / warpsPerCTA[i];
+    activeWarps *= warpsPerCTA[i];
+  }
+  assert(totalWarps >= static_cast<int>(activeWarps) &&
+         "totalWarps must be >= prod(warpsPerCTA)");
+  assert(llvm::isPowerOf2_32(static_cast<unsigned>(totalWarps)) &&
+         llvm::isPowerOf2_32(activeWarps) &&
+         "totalWarps and prod(warpsPerCTA) must be powers of two");
 
   auto order = getMatrixOrder(numDims, /*rowMajor=*/false);
+  auto kWarp = S("warp");
 
-  return (identityStandardND(S("message"), messageShape, order) *
-          identityStandardND(S("warp"), warpsPerCTA, order) * cgaLayout)
+  // Place the K identity rows at the basis-bit positions picked from the
+  // hint (or at the lowest log2(K) bits if none).  Other warpId bits get
+  // zero rows; getFreeVariableMasks reports them as free variables, which
+  // the lowering uses to predicate inactive warps off.
+  LinearLayout warpLayout = identityStandardND(kWarp, warpsPerCTA, order);
+  unsigned numActiveBits = llvm::Log2_32(activeWarps);
+  unsigned numTotalBits = llvm::Log2_32(static_cast<unsigned>(totalWarps));
+  assert(!warpUsedHint ||
+         static_cast<unsigned>(llvm::popcount(*warpUsedHint)) == activeWarps);
+
+  if (numTotalBits != numActiveBits) {
+    auto bases = warpLayout.getBases();
+    auto identityRows = bases[kWarp];
+    assert(identityRows.size() == numActiveBits);
+
+    SmallVector<std::vector<int32_t>> placedRows(
+        numTotalBits, std::vector<int32_t>(numDims, 0));
+    if (warpUsedHint) {
+      uint32_t i0 = llvm::countr_zero(*warpUsedHint);
+      uint32_t support = 0;
+      for (uint32_t m = *warpUsedHint; m != 0; m &= m - 1)
+        support |= static_cast<uint32_t>(llvm::countr_zero(m) ^ i0);
+      unsigned j = 0;
+      for (uint32_t s = support; s != 0; s &= s - 1)
+        placedRows[llvm::countr_zero(s)] = identityRows[j++];
+    } else {
+      for (unsigned j = 0; j < numActiveBits; ++j)
+        placedRows[j] = identityRows[j];
+    }
+
+    bases[kWarp].assign(placedRows.begin(), placedRows.end());
+
+    warpLayout = LinearLayout(std::move(bases), warpLayout.getOutDims(),
+                              /*requireSurjective=*/false);
+  }
+
+  return (identityStandardND(S("message"), messageShape, order) * warpLayout *
+          cgaLayout)
       .transposeOuts(standardOutDimNames(ctx, numDims));
 }
 

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1113,9 +1113,15 @@ void init_gluon_ir(py::module &&m) {
       .def("create_async_tdm_copy_global_to_local",
            [](GluonOpBuilder &self, Value descPtr, std::vector<Value> &indices,
               Value result, Value pred, Value barrier,
-              tt::CacheModifier cacheModifier) {
+              tt::CacheModifier cacheModifier,
+              std::optional<uint32_t> warpUsedHint) {
+             IntegerAttr hintAttr;
+             if (warpUsedHint.has_value())
+               hintAttr = self.getBuilder().getI32IntegerAttr(
+                   static_cast<int32_t>(*warpUsedHint));
              self.create<ttag::AsyncTDMCopyGlobalToLocalOp>(
-                 descPtr, indices, result, pred, barrier, cacheModifier);
+                 descPtr, indices, result, pred, barrier, cacheModifier,
+                 hintAttr);
            })
       .def("create_async_tdm_copy_local_to_global",
            [](GluonOpBuilder &self, Value descPtr, std::vector<Value> &indices,

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -23,6 +23,10 @@ from triton.experimental.gluon.language.amd.gfx1250 import (
     async_copy as gfx1250_async_copy, )
 from triton.experimental.gluon.language.amd.gfx1250 import mbarrier as gfx1250_mbarrier
 from triton.experimental.gluon.language.amd.gfx1250 import cluster as gfx1250_cluster
+from triton.experimental.gluon.language.amd.gfx1250 import (
+    PartitionedSharedLayout,
+    make_partitioned_dot_layouts,
+)
 from triton.experimental.gluon.language.extra import libdevice
 
 from triton._filecheck import filecheck_test, run_parser
@@ -2473,6 +2477,54 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 }
 """,
     )
+
+
+@pytest.mark.parametrize("num_warps", [4, 8])
+@pytest.mark.parametrize("block_m,block_n", [(64, 64), (64, 128), (128, 128)])
+@pytest.mark.parametrize("a_transposed", [False, True])
+@pytest.mark.parametrize("b_transposed", [False, True])
+def test_make_partitioned_dot_layouts(num_warps, block_m, block_n, a_transposed, b_transposed):
+    block_k = 32
+    INSTR_M, INSTR_N, INSTR_K = 16, 16, 32
+    # WARP_TILES_M=4 and WARP_TILES_N=2 for both 4- and 8-warp cases (different
+    # warp/reg base layouts but same per-warp tile extents).
+    warp_coverage_m = 4 * INSTR_M
+    warp_coverage_n = 2 * INSTR_N
+
+    a_shape = [block_k, block_m] if a_transposed else [block_m, block_k]
+    b_shape = [block_n, block_k] if b_transposed else [block_k, block_n]
+    pa = ttgl.PaddedSharedLayout.with_identity_for([[a_shape[1], 8]], a_shape, [1, 0])
+    pb = ttgl.PaddedSharedLayout.with_identity_for([[b_shape[1], 8]], b_shape, [1, 0])
+    sla, slb, wmma = make_partitioned_dot_layouts(block_m, block_n, pa, pb, num_warps=num_warps,
+                                                  instr_shape=[INSTR_M, INSTR_N, INSTR_K], a_transposed=a_transposed,
+                                                  b_transposed=b_transposed)
+
+    a_num_groups = block_m // warp_coverage_m
+    b_num_groups = block_n // warp_coverage_n
+    a_partition_dim = 1 if a_transposed else 0
+    b_partition_dim = 0 if b_transposed else 1
+    # The non-partitioned axis of each piece is block_k, the partitioned axis is
+    # divided down to (block / num_partitions / num_groups).
+    a_inner = [block_m / 2 / a_num_groups, block_k]
+    b_inner = [block_n / 2 / b_num_groups, block_k] if b_transposed else [block_k, block_n / 2 / b_num_groups]
+    for layout, num_groups, partition_dim, inner_shape in [
+        (sla, a_num_groups, a_partition_dim, a_inner),
+        (slb, b_num_groups, b_partition_dim, b_inner),
+    ]:
+        assert isinstance(layout, PartitionedSharedLayout)
+        assert layout.num_partitions == 2
+        assert layout.num_groups == num_groups
+        assert layout.partition_dim == partition_dim
+        assert layout.partition_layout.shape == inner_shape
+
+    if num_warps == 4:
+        expected_warp_bases, expected_reg_bases = [[2, 1], [1, 0]], [[2, 0]]
+    else:
+        expected_warp_bases, expected_reg_bases = [[2, 1], [1, 0], [2, 0]], []
+    assert isinstance(wmma, amd_layouts.AMDWMMALayout)
+    assert wmma.warp_bases == expected_warp_bases
+    assert wmma.reg_bases == expected_reg_bases
+    assert wmma.instr_shape == [INSTR_M, INSTR_N, INSTR_K]
 
 
 @gluon.jit

--- a/python/test/unit/tools/test_slice_kernel.py
+++ b/python/test/unit/tools/test_slice_kernel.py
@@ -302,7 +302,7 @@ def test_slice_kernel_public_imports():
     from triton.tools.triton_to_gluon_translator.slice_kernel import slice_kernel as new_slice_kernel
     from triton.tools.triton_to_gluon_translator.translator import translate_paths
     from triton.tools.triton_to_gluon_translator.translator import convert_triton_to_gluon
-    from triton.tools.triton_to_gluon_translator.translator_helpers import convert_host_descriptor
+    from triton.tools.triton_to_gluon_translator.nvidia_helpers import convert_host_descriptor
 
     assert callable(new_slice_kernel)
     assert callable(translate_paths)

--- a/python/test/unit/tools/test_triton_to_gluon.py
+++ b/python/test/unit/tools/test_triton_to_gluon.py
@@ -7,8 +7,17 @@ import pytest
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 from triton.tools.triton_to_gluon_translator.translator import convert_triton_to_gluon
-from triton.tools.triton_to_gluon_translator.translator_helpers import convert_host_descriptor
-from triton._internal_testing import is_blackwell, is_hopper_or_newer, is_cuda, is_hip_rdna
+from triton.tools.triton_to_gluon_translator.target import TranslatorTarget
+from triton._internal_testing import (
+    is_blackwell,
+    is_cuda,
+    is_hip_cdna3_or_newer,
+    is_hip_cdna4,
+    is_hip_gfx1250,
+    is_hip_rdna,
+    is_hopper_or_newer,
+)
+from triton.language.target_info import current_target
 
 pytestmark = pytest.mark.skipif(
     is_hip_rdna(),
@@ -16,8 +25,21 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def convert_kernel(kernel, kernel_name, tmp_path):
-    converted = convert_triton_to_gluon([kernel])
+def _convert_host_descriptor(desc):
+    """Import and call the target-appropriate convert_host_descriptor."""
+    target = current_target()
+    if target is not None and target.backend == "hip":
+        from triton.tools.triton_to_gluon_translator.amd_helpers import convert_host_descriptor
+    else:
+        from triton.tools.triton_to_gluon_translator.nvidia_helpers import convert_host_descriptor
+    return convert_host_descriptor(desc)
+
+
+def convert_kernel(kernel, kernel_name, tmp_path, target=None):
+    if target is None:
+        t = current_target()
+        target = TranslatorTarget("nvidia" if t.backend == "cuda" else t.arch)
+    converted = convert_triton_to_gluon([kernel], target=target)
 
     # Write converted kernel to a file so @gluon.jit can retrieve source
     mod_path = tmp_path / "converted_kernel.py"
@@ -41,7 +63,6 @@ def add_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK: tl.constexpr):
     tl.store(out_ptr + offsets, x + y)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_simple_kernel(tmp_path):
     kernel = convert_kernel(add_kernel, "add_kernel", tmp_path)
 
@@ -75,9 +96,9 @@ def matmul_tile_kernel(a_ptr, b_ptr, c_ptr, BLOCK_M: tl.constexpr, BLOCK_N: tl.c
     impl_matmul_tile_kernel(a_ptr, b_ptr, c_ptr, BLOCK_M, BLOCK_N, BLOCK_K)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_triton_to_gluon_dot_minimal(tmp_path):
-    # Convert directly from the Triton kernel object
+    if not (is_blackwell() or is_hip_cdna3_or_newer() or is_hip_gfx1250()):
+        pytest.skip("Requires Blackwell, CDNA3+, or gfx1250")
     kernel = convert_kernel(matmul_tile_kernel, "matmul_tile_kernel", tmp_path)
     M, N, K = 128, 128, 128
     a = torch.randn((M, K), device="cuda", dtype=torch.float16)
@@ -136,8 +157,9 @@ def matmul_kernel(  #
 @pytest.mark.parametrize("dtype_dst_str", ["float32"])
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES", [(128, 128, 64, 1)])
 @pytest.mark.parametrize("NUM_WARPS", [4])
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_simple_matmul(dtype_src_str, dtype_dst_str, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, NUM_WARPS, tmp_path):
+    if not (is_blackwell() or is_hip_cdna4() or is_hip_gfx1250()):
+        pytest.skip("Requires Blackwell, CDNA4, or gfx1250")
     device = "cuda"
     M, N, K = 1024, 512, 256
     torch.manual_seed(42)
@@ -166,8 +188,15 @@ def descriptor_store_kernel(desc, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, 
     desc.store([0, 0], tile)
 
 
-@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
+def _skip_unless_descriptor_target():
+    if is_cuda() and not is_hopper_or_newer():
+        pytest.skip("Requires Hopper+")
+    elif not is_cuda() and not is_hip_gfx1250():
+        pytest.skip("Requires descriptor support")
+
+
 def test_triton_to_gluon_descriptor_roundtrip(tmp_path):
+    _skip_unless_descriptor_target()
     kernel = convert_kernel(descriptor_store_kernel, "descriptor_store_kernel", tmp_path)
 
     M = N = 64
@@ -175,7 +204,7 @@ def test_triton_to_gluon_descriptor_roundtrip(tmp_path):
     grid = (1, )
     block_shape = [M, N]
     desc = TensorDescriptor(y, y.shape, y.stride(), block_shape)
-    gluon_desc = convert_host_descriptor(desc)
+    gluon_desc = _convert_host_descriptor(desc)
     kernel[grid](gluon_desc, M, N, 1.0)
 
     y_ref = torch.zeros((M, N), device="cuda", dtype=torch.float16)
@@ -190,8 +219,8 @@ def descriptor_copy_kernel(in_desc, out_desc, BLOCK_M: tl.constexpr, BLOCK_N: tl
     out_desc.store([0, 0], tile)
 
 
-@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
 def test_triton_to_gluon_descriptor_load_roundtrip(tmp_path):
+    _skip_unless_descriptor_target()
     kernel = convert_kernel(descriptor_copy_kernel, "descriptor_copy_kernel", tmp_path)
 
     M = N = 64
@@ -201,8 +230,8 @@ def test_triton_to_gluon_descriptor_load_roundtrip(tmp_path):
     block_shape = [M, N]
 
     in_desc = TensorDescriptor(x, x.shape, x.stride(), block_shape)
-    gluon_desc = convert_host_descriptor(in_desc)
-    out_desc = convert_host_descriptor(TensorDescriptor(y, y.shape, y.stride(), block_shape))
+    gluon_desc = _convert_host_descriptor(in_desc)
+    out_desc = _convert_host_descriptor(TensorDescriptor(y, y.shape, y.stride(), block_shape))
     kernel[grid](gluon_desc, out_desc, M, N)
 
     y_ref = torch.zeros((M, N), device="cuda", dtype=torch.float16)
@@ -229,8 +258,8 @@ def make_tensor_descriptor_copy_kernel(x_ptr, y_ptr, M, N, BLOCK_M: tl.constexpr
     out_desc.store([0, 0], tile)
 
 
-@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
 def test_triton_to_gluon_make_tensor_descriptor(tmp_path, with_allocator):
+    _skip_unless_descriptor_target()
     kernel = convert_kernel(make_tensor_descriptor_copy_kernel, "make_tensor_descriptor_copy_kernel", tmp_path)
 
     M = N = 64
@@ -263,7 +292,6 @@ def reshape_trans_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK: tl.constexpr,
 
 
 @pytest.mark.parametrize("TRANS_KIND", ["trans_method", "tl_trans_separate", "tl_trans_tuple", "tl_trans"])
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_triton_reshape_trans(tmp_path, TRANS_KIND):
     kernel = convert_kernel(reshape_trans_kernel, "reshape_trans_kernel", tmp_path)
 
@@ -294,7 +322,6 @@ def split_kernel(x_ptr, out_ptr):
     tl.store(p, a)
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_split(tmp_path):
     kernel = convert_kernel(split_kernel, "split_kernel", tmp_path)
 
@@ -344,7 +371,6 @@ def reduce_to_scalar_kernel(out_ptr):
     tl.store(out_ptr, x)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_reduce_to_scalar(tmp_path):
     kernel = convert_kernel(reduce_to_scalar_kernel, "reduce_to_scalar_kernel", tmp_path)
     grid = (1, )
@@ -408,7 +434,6 @@ def atomic_add_kernel(out_ptr, BLOCK: tl.constexpr):
     tl.atomic_add(out_ptr + idx, idx, mask=scalar_mask, sem="release", scope="cta")
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_atomic_add(tmp_path):
     kernel = convert_kernel(atomic_add_kernel, "atomic_add_kernel", tmp_path)
 
@@ -419,3 +444,58 @@ def test_atomic_add(tmp_path):
     out = torch.zeros((block, ), device="cuda")
     kernel[(1, )](out, BLOCK=block)
     torch.testing.assert_close(out, ref)
+
+
+# ---- additional op coverage ----
+
+
+@triton.jit
+def cat_kernel(x_ptr, y_ptr, out_ptr, BLOCK: tl.constexpr):
+    offs = tl.arange(0, BLOCK)
+    x = tl.load(x_ptr + offs)
+    y = tl.load(y_ptr + offs)
+    z = tl.cat(x, y, can_reorder=True)
+    tl.store(out_ptr + tl.arange(0, 2 * BLOCK), z)
+
+
+def test_cat(tmp_path):
+    kernel = convert_kernel(cat_kernel, "cat_kernel", tmp_path)
+
+    BLOCK = 256
+    x = torch.randn(BLOCK, device="cuda", dtype=torch.float32)
+    y = torch.randn(BLOCK, device="cuda", dtype=torch.float32)
+    out = torch.empty(2 * BLOCK, device="cuda", dtype=torch.float32)
+    kernel[(1, )](x, y, out, BLOCK)
+
+    ref = torch.empty_like(out)
+    cat_kernel[(1, )](x, y, ref, BLOCK)
+    torch.testing.assert_close(sorted(out.cpu()), sorted(ref.cpu()), atol=0, rtol=0)
+
+
+@triton.jit
+def gather_scatter_roundtrip_kernel(out_ptr, in_ptr, idx_ptr, X: tl.constexpr, Y: tl.constexpr, BLOCK_X: tl.constexpr,
+                                    BLOCK_Y: tl.constexpr):
+    idx = tl.load(idx_ptr + tl.arange(0, BLOCK_X))
+    in_desc = tl.make_tensor_descriptor(in_ptr, [X, Y], [Y, 1], [1, BLOCK_Y])
+    out_desc = tl.make_tensor_descriptor(out_ptr, [X, Y], [Y, 1], [1, BLOCK_Y])
+    data = in_desc.gather(idx, 0)
+    out_desc.scatter(data, idx, 0)
+
+
+# TODO: parametrize over _descriptor_targets once NVIDIA gather/scatter translation is supported.
+# The translator currently routes gather/scatter to AMD-specific helpers for AMD targets only.
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires gfx1250")
+def test_gather_scatter_roundtrip(tmp_path):
+    kernel = convert_kernel(gather_scatter_roundtrip_kernel, "gather_scatter_roundtrip_kernel", tmp_path,
+                            target=TranslatorTarget.GFX1250)
+
+    X, Y, BLOCK_X, BLOCK_Y = 64, 64, 8, 64
+    inp = torch.arange(X * Y, device="cuda", dtype=torch.float16).reshape(X, Y)
+    idx = torch.tensor([0, 2, 4, 6, 1, 3, 5, 7], device="cuda", dtype=torch.int32)
+    out = torch.zeros((X, Y), device="cuda", dtype=torch.float16)
+    kernel[(1, )](out, inp, idx, X, Y, BLOCK_X, BLOCK_Y)
+
+    expected = torch.zeros_like(out)
+    for i, row in enumerate(idx.tolist()):
+        expected[row] = inp[row]
+    torch.testing.assert_close(out, expected, atol=0, rtol=0)

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -110,6 +110,10 @@ def is_hip_gfx1250():
     return target is not None and target.backend == 'hip' and 'gfx1250' in target.arch
 
 
+def is_hip_cdna3_or_newer():
+    return is_hip_cdna3() or is_hip_cdna4()
+
+
 def is_hip_cdna():
     return is_hip_cdna2() or is_hip_cdna3() or is_hip_cdna4()
 

--- a/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
@@ -5,7 +5,7 @@ from ..._core import builtin, int8, uint8, int32, float8e4nv, tensor, _unwrap_if
 from .._ops import _wmma, _verify_wmma, _mma_scaled, _scaled_upcast
 from .._layouts import AMDWMMALayout
 from ..cdna3 import buffer_load, buffer_store
-from ._layouts import PartitionedSharedLayout
+from ._layouts import PartitionedSharedLayout, make_partitioned_dot_layouts
 from . import tdm
 from . import async_copy
 from . import mbarrier
@@ -13,7 +13,7 @@ from . import cluster
 
 __all__ = [
     "async_copy", "tdm", "mbarrier", "cluster", "wmma", "wmma_scaled", "scaled_upcast", "buffer_load", "buffer_store",
-    "get_wmma_scale_layout", "PartitionedSharedLayout"
+    "get_wmma_scale_layout", "PartitionedSharedLayout", "make_partitioned_dot_layouts"
 ]
 
 

--- a/python/triton/experimental/gluon/language/amd/gfx1250/_layouts.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/_layouts.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from triton.language.core import _unwrap_if_constexpr
+from triton.runtime.jit import constexpr_function
 
-from triton.experimental.gluon.language._layouts import SharedLayout
+from triton.experimental.gluon.language._layouts import PaddedSharedLayout, SharedLayout
 
 __all__ = [
     "PartitionedSharedLayout",
+    "make_partitioned_dot_layouts",
 ]
 
 
@@ -67,3 +69,138 @@ class PartitionedSharedLayout(SharedLayout):
             self.partition_dim,
             self.partition_layout,
         ))
+
+
+@constexpr_function
+def _make_partitioned_dot_operand_layout(sublayout, partition_dim, num_partitions, block_mn_size, warp_coverage, order):
+    """Build a ``PartitionedSharedLayout`` for one GEMM operand.
+
+    The operand tile (``sublayout``) is split along ``partition_dim`` into
+    ``num_partitions * num_groups`` logical pieces, where
+    ``num_groups = block_mn_size // warp_coverage``.  Each piece carries an
+    inner ``PaddedSharedLayout`` rebuilt with an identity mapping using the
+    original sublayout's ``interval_padding_pairs`` and ``cga_layout``.
+    """
+    is_power_of_2 = lambda n: n > 0 and n & (n - 1) == 0
+    num_groups = block_mn_size // warp_coverage
+    assert num_groups >= 1, f"block dim ({block_mn_size}) must be >= {warp_coverage}"
+    assert is_power_of_2(num_groups), \
+        f"block_dim / warp_coverage = {num_groups} must be a power of 2"
+
+    num_logical_pieces = num_partitions * num_groups
+    inner_shape = list(sublayout.shape)
+    assert inner_shape[partition_dim] % num_logical_pieces == 0
+    inner_shape[partition_dim] //= num_logical_pieces
+
+    # TODO: when the partitioned dimension is the contiguous (fastest-varying)
+    # dimension, the interval_padding_pairs may need adjustment to preserve
+    # bank-conflict avoidance properties for the smaller piece shape.
+    inner = PaddedSharedLayout.with_identity_for(sublayout.interval_padding_pairs, inner_shape, order,
+                                                 sublayout.cga_layout)
+    return PartitionedSharedLayout(num_partitions, num_groups, partition_dim, inner)
+
+
+@constexpr_function
+def make_partitioned_dot_layouts(block_m, block_n, original_layout_a, original_layout_b, num_warps, instr_shape,
+                                 a_transposed=False, b_transposed=False):
+    """Create partitioned shared memory layouts and WMMA layout for a GFX1250 GEMM
+       in order to avoid LDS partition conflicts.
+
+    Args:
+        block_m: M dimension tile size.  Must be at least
+            ``WARP_TILES_M * instr_shape[0]`` (the per-CTA M extent covered by
+            one partition group), and a power-of-2 multiple thereof.
+        block_n: N dimension tile size.  Must be at least
+            ``WARP_TILES_N * instr_shape[1]``, and a power-of-2 multiple
+            thereof.
+        original_layout_a: ``PaddedSharedLayout`` for operand A.  Shape is
+            ``[block_m, block_k]`` when not transposed (K contiguous) and
+            ``[block_k, block_m]`` when transposed (M contiguous).
+        original_layout_b: ``PaddedSharedLayout`` for operand B.  Shape is
+            ``[block_k, block_n]`` when not transposed (N contiguous) and
+            ``[block_n, block_k]`` when transposed (K contiguous).
+        num_warps: Number of warps per CTA.  Currently must be 4 or 8.
+        instr_shape: WMMA instruction shape as ``[M, N, K]``.
+        a_transposed: Whether A is transposed in shared memory, i.e. M is
+            the contiguous axis instead of K.
+        b_transposed: Whether B is transposed in shared memory, i.e. K is
+            the contiguous axis instead of N.
+
+    Returns:
+        A tuple ``(shared_layout_a, shared_layout_b, wmma_layout)``.
+    """
+    from triton.experimental.gluon.language.amd._layouts import AMDWMMALayout
+
+    INSTR_SHAPE = list(instr_shape)
+
+    assert num_warps in (4, 8), f"Only 4 or 8 warps are currently supported, got {num_warps}"
+
+    NUM_PARTITIONS = 2
+
+    # The caller passes each sublayout with its contiguous axis at dim 1 of the
+    # tile (i.e. the tile's shape is already expressed in memory order):
+    #   A non-transposed: [block_m, block_k] — K contiguous at dim 1
+    #   A transposed:     [block_k, block_m] — M contiguous at dim 1
+    #   B non-transposed: [block_k, block_n] — N contiguous at dim 1
+    #   B transposed:     [block_n, block_k] — K contiguous at dim 1
+    # So the linear component is always built with order [1, 0] regardless of
+    # transposition. TDM additionally requires order [rank-1, ..., 0].
+    order = [1, 0]
+
+    # WMMA CTA layout: Below, M runs vertically (rows) and N
+    # horizontally (cols); each cell is one INSTR_SHAPE-sized instruction tile,
+    # labelled with the warp that computes it.  ``warp_bases`` map warp-id bits
+    # to (M, N) tile offsets, ``reg_bases`` map register-id
+    # (more specifically, instruction repetition registers) bits the same way.
+    #
+    # 4-warp case (warp_bases = [[2, 1], [1, 0]], reg_bases = [[2, 0]]):
+    #
+    #   M=0:  w0 w1   <- second tile computed by w1 (reg=1)
+    #   M=1:  w2 w3
+    #   M=2:  w0 w1   <- first tile computed by w1 (reg=0)
+    #   M=3:  w2 w3
+    #
+    # Such layout allows w0 and w1 as well as w2 and w3 to read different A/B
+    # operand data blocks in a single instruction, which is necessary precondition
+    # for avoiding LDS partition conflicts.
+    if num_warps == 4:
+        warp_bases = [[2, 1], [1, 0]]
+        reg_bases = [[2, 0]]
+    else:  # num_warps == 8
+        # Same idea as the 4-warp case, but the third warp bit replaces the
+        # register bit. This means there's no need to define repetition registers,
+        # single instruction CTA layout is enough to describe the layout we need.
+        # Each warp now owns a single instruction tile and the extra warp dimension
+        # is folded into the M-axis of the warp grid.
+        warp_bases = [[2, 1], [1, 0], [2, 0]]
+        reg_bases = []
+
+    # The tile extent along each dimension is 2^m, where m is the largest
+    # basis component in that dimension across both warp and register bases.
+    def _tile_extent(dim):
+        m = max((b[dim] for b in warp_bases + reg_bases), default=0)
+        return 1 << m
+
+    WARP_TILES_M = _tile_extent(0)
+    WARP_TILES_N = _tile_extent(1)
+
+    wmma_layout = AMDWMMALayout(3, True, warp_bases, reg_bases, INSTR_SHAPE)
+
+    # Per-CTA extent that one warp+register cycle covers in each dimension.
+    warp_coverage_m = WARP_TILES_M * INSTR_SHAPE[0]
+    warp_coverage_n = WARP_TILES_N * INSTR_SHAPE[1]
+
+    # Partition A along its M axis and B along its N axis.  These dims live
+    # at different positions in the tile depending on transposition (the
+    # contiguous axis is always at dim 1, so M / N moves to dim 0 or dim 1).
+    a_partition_dim = 1 if a_transposed else 0
+    b_partition_dim = 0 if b_transposed else 1
+
+    shared_layout_a = _make_partitioned_dot_operand_layout(original_layout_a, partition_dim=a_partition_dim,
+                                                           num_partitions=NUM_PARTITIONS, block_mn_size=block_m,
+                                                           warp_coverage=warp_coverage_m, order=order)
+    shared_layout_b = _make_partitioned_dot_operand_layout(original_layout_b, partition_dim=b_partition_dim,
+                                                           num_partitions=NUM_PARTITIONS, block_mn_size=block_n,
+                                                           warp_coverage=warp_coverage_n, order=order)
+
+    return shared_layout_a, shared_layout_b, wmma_layout

--- a/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
@@ -241,7 +241,8 @@ def update_tensor_descriptor(desc: tensor_descriptor, add_offsets: List[ttgl.con
 
 @builtin
 def async_load(src: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tensor], dest: shared_memory_descriptor,
-               pred=True, mbarrier: shared_memory_descriptor = None, cache_modifier="", _semantic=None) -> None:
+               pred=True, mbarrier: shared_memory_descriptor = None, warp_used_hint=None, cache_modifier="",
+               _semantic=None) -> None:
     """Load a block of tensor specified in tensor descriptor from global memory to shared memory asynchronously.
 
     Args:
@@ -250,14 +251,29 @@ def async_load(src: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tenso
         dest (shared_memory_descriptor): the shared memory destination to store the loaded data.
         pred (bool, optional): Predicate to enable or disable the load. Defaults to True.
         mbarrier (shared_memory_descriptor, optional): The barrier object to signal "arrive" on.
+        warp_used_hint (int, optional): Bitmask selecting which warps issue
+            the TDM copy (bit ``n`` => warp ``n``); cleared warps become HW
+            no-ops.  Doesn't affect the data in ``dest``, only the work split.
+            The number of active warps must be a power of two, and the active
+            warps must follow a regular bit pattern for efficient lowering.
+            Examples: ``0b00001111`` (warps 0..3), ``0b11110000`` (warps
+            4..7), ``0b01010101`` (warps 0,2,4,6).  Omit / ``None`` = all
+            warps participate; explicit ``0`` and other invalid hints are
+            rejected by the verifier.
+        cache_modifier (str, optional): Cache behavior.
     """
     offset_handles = _semantic._convert_to_ir_values(offsets, require_i64=False)
     pred = _handle_i32_pred(pred, _semantic)
     mbarrier = _unwrap_if_constexpr(mbarrier)
     mbarrier_handle = mbarrier.handle if mbarrier is not None else ttgl.ir.value()
     cache_modifier = _semantic._str_to_load_cache_modifier(cache_modifier)
+
+    warp_used_hint = _unwrap_if_constexpr(warp_used_hint)
+    if warp_used_hint is not None:
+        warp_used_hint = int(warp_used_hint)
+
     _semantic.builder.create_async_tdm_copy_global_to_local(src.handle, offset_handles, dest.handle, pred.handle,
-                                                            mbarrier_handle, cache_modifier)
+                                                            mbarrier_handle, cache_modifier, warp_used_hint)
 
 
 @builtin

--- a/python/triton/tools/triton_to_gluon_translator/amd_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/amd_helpers.py
@@ -1,0 +1,410 @@
+# type: ignore
+
+import math
+
+import triton.language as tl
+from triton.experimental import gluon
+from triton.experimental.gluon import language as ttgl
+from triton.experimental.gluon.language.amd.gfx1250 import wmma as amd_wmma
+from triton.experimental.gluon.language.amd.gfx1250 import tdm as amd_tdm
+from triton.experimental.gluon.language.amd.cdna3 import mfma as amd_mfma
+from triton.language.target_info import current_target
+
+from triton.tools.triton_to_gluon_translator.common_helpers import *  # noqa: F401,F403
+from triton.tools.triton_to_gluon_translator.common_helpers import (
+    default_blocked_layout,
+    get_num_threads_per_warp,
+    tl_dot_decomposed_scale_arg,
+    tl_trans,
+)
+
+# ---- architecture detection ----
+
+
+@gluon.constexpr_function
+def _is_gfx1250(target=None):
+    return target is not None and target.arch == "gfx1250"
+
+
+@gluon.constexpr_function
+def _is_cdna(target=None):
+    return target is not None and target.arch in ("gfx942", "gfx950")
+
+
+@gluon.constexpr_function
+def _cdna_version(target=None):
+    """Returns 3 for gfx942, 4 for gfx950."""
+    return 4 if target is not None and target.arch == "gfx950" else 3
+
+
+# ---- AMD WMMA layout helpers (gfx1250) ----
+
+
+@gluon.constexpr_function
+def compute_warp_bases(num_warps):
+    """Distribute warps across M/N: first bit to N, rest to M."""
+    n_bits = int(math.log2(num_warps))
+    if n_bits == 0:
+        return []
+    warp_bases = [[0, 1]]
+    for i in range(n_bits - 1):
+        warp_bases.append([1 << i, 0])
+    return warp_bases
+
+
+@gluon.constexpr_function
+def get_wmma_layout(shape, num_warps):
+    warp_bases = compute_warp_bases(num_warps)
+    return ttgl.amd.AMDWMMALayout(3, True, warp_bases, [], [16, 16, 32])
+
+
+@gluon.constexpr_function
+def get_wmma_k_width(a_ty, b_ty):
+    min_bitwidth = min(a_ty.element_ty.primitive_bitwidth, b_ty.element_ty.primitive_bitwidth)
+    return max(128 // min_bitwidth, 1)
+
+
+# ---- AMD MFMA layout helpers (cdna3/cdna4) ----
+
+
+@gluon.constexpr_function
+def get_mfma_instr_k(element_bitwidth, target=None):
+    """K dimension of the MFMA instruction for [32, 32, K]."""
+    k_bits = 128 if _cdna_version(target) == 3 else 256
+    return k_bits // element_bitwidth
+
+
+@gluon.constexpr_function
+def get_mfma_layout(num_warps, element_bitwidth, target=None):
+    instr_k = get_mfma_instr_k(element_bitwidth, target)
+    return ttgl.amd.AMDMFMALayout(
+        version=_cdna_version(target),
+        instr_shape=[32, 32, instr_k],
+        transposed=True,
+        warps_per_cta=[num_warps, 1],
+    )
+
+
+@gluon.constexpr_function
+def get_mfma_k_width(a_ty, b_ty, target=None):
+    min_bitwidth = min(a_ty.element_ty.primitive_bitwidth, b_ty.element_ty.primitive_bitwidth)
+    instr_k = get_mfma_instr_k(min_bitwidth, target)
+    return instr_k // 2
+
+
+# ---- AMD dot paths ----
+
+
+@gluon.jit
+def tl_dot_wmma(a, b, acc, out_dtype):
+    """gfx1250 WMMA path."""
+    M: ttgl.constexpr = a.type.shape[0]
+    N: ttgl.constexpr = b.type.shape[1]
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+
+    wmma_layout: ttgl.constexpr = get_wmma_layout([M, N], num_warps)
+    k_width: ttgl.constexpr = get_wmma_k_width(a.type, b.type)
+    a_layout: ttgl.constexpr = ttgl.DotOperandLayout(operand_index=0, parent=wmma_layout, k_width=k_width)
+    b_layout: ttgl.constexpr = ttgl.DotOperandLayout(operand_index=1, parent=wmma_layout, k_width=k_width)
+
+    a = ttgl.convert_layout(a, a_layout)
+    b = ttgl.convert_layout(b, b_layout)
+
+    if acc is not None:
+        accumulator = ttgl.convert_layout(acc, wmma_layout)
+    else:
+        accumulator = ttgl.zeros([M, N], out_dtype, layout=wmma_layout)
+
+    result = amd_wmma(a, b, accumulator)
+
+    if acc is not None:
+        ret_layout: ttgl.constexpr = acc.type.layout
+    else:
+        ret_layout: ttgl.constexpr = default_blocked_layout(result.type.shape, num_warps)
+    return ttgl.convert_layout(result, ret_layout)
+
+
+@gluon.jit
+def tl_dot_mfma(a, b, acc, out_dtype):
+    """CDNA3/CDNA4 MFMA path."""
+    M: ttgl.constexpr = a.type.shape[0]
+    N: ttgl.constexpr = b.type.shape[1]
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    min_bitwidth: ttgl.constexpr = min(a.type.element_ty.primitive_bitwidth, b.type.element_ty.primitive_bitwidth)
+    target: ttgl.constexpr = current_target()
+
+    mfma_layout: ttgl.constexpr = get_mfma_layout(num_warps, min_bitwidth, target)
+    k_width: ttgl.constexpr = get_mfma_k_width(a.type, b.type, target)
+    a_layout: ttgl.constexpr = ttgl.DotOperandLayout(operand_index=0, parent=mfma_layout, k_width=k_width)
+    b_layout: ttgl.constexpr = ttgl.DotOperandLayout(operand_index=1, parent=mfma_layout, k_width=k_width)
+
+    a = ttgl.convert_layout(a, a_layout)
+    b = ttgl.convert_layout(b, b_layout)
+
+    if acc is not None:
+        accumulator = ttgl.convert_layout(acc, mfma_layout)
+    else:
+        accumulator = ttgl.zeros([M, N], out_dtype, layout=mfma_layout)
+
+    result = amd_mfma(a, b, accumulator)
+
+    if acc is not None:
+        ret_layout: ttgl.constexpr = acc.type.layout
+    else:
+        ret_layout: ttgl.constexpr = default_blocked_layout(result.type.shape, num_warps)
+    return ttgl.convert_layout(result, ret_layout)
+
+
+# ---- AMD dot dispatch ----
+
+
+@gluon.jit
+def tl_dot(
+    a,
+    b,
+    acc=None,
+    input_precision=None,
+    allow_tf32=None,
+    max_num_imprecise_acc=None,
+    out_dtype=ttgl.float32,
+):
+    target: ttgl.constexpr = current_target()
+    if _is_gfx1250(target):
+        return tl_dot_wmma(a, b, acc, out_dtype)
+    elif _is_cdna(target):
+        return tl_dot_mfma(a, b, acc, out_dtype)
+
+
+# Defined here (not imported from common) so __globals__ resolves tl_dot to this module's version.
+@gluon.jit
+def tl_dot_decomposed_block_scales(
+    lhs,
+    lhs_scale,
+    lhs_format,
+    rhs,
+    rhs_scale,
+    rhs_format,
+    acc=None,
+    fast_math=False,
+    lhs_k_pack=True,
+    rhs_k_pack=True,
+    out_dtype=ttgl.float32,
+):
+    if lhs_scale is None and rhs_scale is not None:
+        lhs_trans = tl_trans(lhs)
+        rhs_trans = tl_trans(rhs)
+        if acc is not None:
+            orig_layout: ttgl.constexpr = acc.type.layout
+            acc = tl_trans(acc)
+        result = tl_dot_scaled(
+            rhs_trans,
+            rhs_scale,
+            rhs_format,
+            lhs_trans,
+            lhs_scale,
+            lhs_format,
+            acc,
+            fast_math,
+            lhs_k_pack,
+            rhs_k_pack,
+            out_dtype,
+        )
+        result = tl_trans(result)
+        if acc is not None:
+            result = ttgl.convert_layout(result, orig_layout)
+        return result
+    else:
+        ttgl.static_assert(not (not lhs_k_pack or not rhs_k_pack), "TODO: support m/n packed formats")
+        compute_type: ttgl.constexpr = (ttgl.float16 if
+                                        (lhs_format == "fp16" or rhs_format == "fp16") else ttgl.bfloat16)
+
+        scale_a = tl_dot_decomposed_scale_arg(lhs, lhs_scale, lhs_format, 0, compute_type, fast_math)
+        scale_b = tl_dot_decomposed_scale_arg(rhs, rhs_scale, rhs_format, 1, compute_type, fast_math)
+
+        return tl_dot(scale_a, scale_b, acc, out_dtype=out_dtype)
+
+
+@gluon.jit
+def tl_dot_scaled(
+    lhs,
+    lhs_scale,
+    lhs_format,
+    rhs,
+    rhs_scale,
+    rhs_format,
+    acc=None,
+    fast_math=False,
+    lhs_k_pack=True,
+    rhs_k_pack=True,
+    out_dtype=ttgl.float32,
+):
+    return tl_dot_decomposed_block_scales(
+        lhs,
+        lhs_scale,
+        lhs_format,
+        rhs,
+        rhs_scale,
+        rhs_format,
+        acc,
+        fast_math,
+        lhs_k_pack,
+        rhs_k_pack,
+        out_dtype,
+    )
+
+
+# ---- AMD TDM tensor descriptors (gfx1250 only) ----
+
+
+@gluon.constexpr_function
+def get_default_tdm_layout(*block_shape):
+    block_shape = list(block_shape)
+    return ttgl.PaddedSharedLayout.with_identity_for(
+        [[block_shape[-1], 4]],
+        block_shape,
+        list(range(len(block_shape) - 1, -1, -1)),
+    )
+
+
+@tl.core._aggregate
+class AMDTensorDescriptorArgs:
+    """Wraps a real TDM descriptor alongside the original base pointer.
+
+    The base_ptr is needed by gather/scatter to recreate the descriptor with a different
+    block_shape -- Triton uses block_shape=[1, N] but TDM hardware requires [num_indices, N].
+    Shape, strides, and block_shape are read from desc (type metadata gives plain Python ints
+    for block_shape, tuples for shape/strides)."""
+    desc: amd_tdm.tensor_descriptor
+    base_ptr: tl.core.tensor
+
+
+@gluon.jit
+def tl_make_tensor_descriptor(base, shape, strides, block_shape, padding_option: ttgl.constexpr = "zero"):
+    ttgl.static_assert(_is_gfx1250(current_target()), "tl_make_tensor_descriptor requires gfx1250 target")
+    layout: ttgl.constexpr = get_default_tdm_layout(*block_shape)
+    desc = amd_tdm.make_tensor_descriptor(base, shape, strides, block_shape, layout)
+    return AMDTensorDescriptorArgs(desc, base)
+
+
+# ---- AMD obj dispatch ----
+
+
+@gluon.jit
+def tl_obj_load_amd(desc, offsets):
+    smem = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout)
+    amd_tdm.async_load(desc, offsets, smem)
+    amd_tdm.async_wait(0)
+    ret_layout: ttgl.constexpr = default_blocked_layout(desc.block_shape, ttgl.num_warps())
+    return smem.load(ret_layout)
+
+
+@gluon.jit
+def tl_obj_store_amd(desc, offsets, value):
+    smem = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout, value)
+    amd_tdm.async_store(desc, offsets, smem)
+    amd_tdm.async_wait(0)
+
+
+@gluon.jit
+def tl_obj_store(obj, offsets, value):
+    if isinstance(obj, AMDTensorDescriptorArgs):
+        tl_obj_store_amd(obj.desc, offsets, value)
+    elif isinstance(obj, amd_tdm.tensor_descriptor):
+        tl_obj_store_amd(obj, offsets, value)
+    else:
+        return obj.store(offsets, value)
+
+
+@gluon.jit
+def tl_obj_load(obj, offsets):
+    if isinstance(obj, AMDTensorDescriptorArgs):
+        return tl_obj_load_amd(obj.desc, offsets)
+    elif isinstance(obj, amd_tdm.tensor_descriptor):
+        return tl_obj_load_amd(obj, offsets)
+    else:
+        return obj.load(offsets)
+
+
+@gluon.jit
+def tl_obj_gather_amd(desc_args, x_offsets, y_offset):
+    NUM_IDX: ttgl.constexpr = x_offsets.shape[0]
+    BLOCK_N: ttgl.constexpr = desc_args.desc.block_shape[1]
+    smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [1, 0])
+    gather_block_shape: ttgl.constexpr = [NUM_IDX, BLOCK_N]
+    gather_desc = amd_tdm.make_tensor_descriptor(desc_args.base_ptr, desc_args.desc.shape, desc_args.desc.strides,
+                                                 gather_block_shape, smem_layout)
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    gather_shape: ttgl.constexpr = gather_desc.block_shape
+    idx_base: ttgl.constexpr = ttgl.BlockedLayout([gather_shape[0], 1],
+                                                  [1, get_num_threads_per_warp(current_target())], [1, num_warps],
+                                                  [1, 0])
+    idx_layout: ttgl.constexpr = ttgl.SliceLayout(1, idx_base)
+    x_offsets = ttgl.convert_layout(x_offsets, idx_layout)
+    alloc = ttgl.allocate_shared_memory(desc_args.desc.dtype, list(gather_shape), smem_layout)
+    y_off = ttgl.to_tensor(y_offset)
+    amd_tdm.async_gather(gather_desc, x_offsets, y_off, alloc)
+    amd_tdm.async_wait(0)
+    ret_layout: ttgl.constexpr = default_blocked_layout(list(gather_shape), num_warps, current_target())
+    out = alloc.load(ret_layout)
+    return out
+
+
+@gluon.jit
+def tl_obj_scatter_amd(desc_args, value, x_offsets, y_offset):
+    NUM_IDX: ttgl.constexpr = x_offsets.shape[0]
+    BLOCK_N: ttgl.constexpr = desc_args.desc.block_shape[1]
+    smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [1, 0])
+    scatter_block_shape: ttgl.constexpr = [NUM_IDX, BLOCK_N]
+    scatter_desc = amd_tdm.make_tensor_descriptor(desc_args.base_ptr, desc_args.desc.shape, desc_args.desc.strides,
+                                                  scatter_block_shape, smem_layout)
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    scatter_shape: ttgl.constexpr = scatter_desc.block_shape
+    idx_base: ttgl.constexpr = ttgl.BlockedLayout([scatter_shape[0], 1],
+                                                  [1, get_num_threads_per_warp(current_target())], [1, num_warps],
+                                                  [1, 0])
+    idx_layout: ttgl.constexpr = ttgl.SliceLayout(1, idx_base)
+    x_offsets = ttgl.convert_layout(x_offsets, idx_layout)
+    alloc = ttgl.allocate_shared_memory(desc_args.desc.dtype, list(scatter_shape), smem_layout, value)
+    y_off = ttgl.to_tensor(y_offset)
+    amd_tdm.async_scatter(scatter_desc, x_offsets, y_off, alloc)
+    amd_tdm.async_wait(0)
+
+
+@gluon.jit
+def tl_obj_gather(obj, x_offsets, y_offset):
+    if isinstance(obj, AMDTensorDescriptorArgs):
+        return tl_obj_gather_amd(obj, x_offsets, y_offset)
+    else:
+        return obj.gather(x_offsets, y_offset)
+
+
+@gluon.jit
+def tl_obj_scatter(obj, value, x_offsets, y_offset):
+    if isinstance(obj, AMDTensorDescriptorArgs):
+        tl_obj_scatter_amd(obj, value, x_offsets, y_offset)
+    else:
+        obj.scatter(value, x_offsets, y_offset)
+
+
+# ---- AMD host-side descriptor ----
+
+
+def convert_host_descriptor(desc):
+
+    def torch_dtype_to_triton(dtype):
+        import torch
+
+        if dtype == torch.float8_e5m2:
+            return ttgl.float8e5
+        if dtype == torch.float8_e4m3fn:
+            return ttgl.float8e4nv
+        return getattr(ttgl, str(dtype).split(".")[1])
+
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    assert isinstance(desc, TensorDescriptor)
+    block_shape = desc.block_shape
+    tensor = desc.base
+
+    layout = get_default_tdm_layout(*block_shape)
+    return gluon.amd.gfx1250.TensorDescriptor(tensor, list(desc.shape), list(desc.strides), block_shape, layout)

--- a/python/triton/tools/triton_to_gluon_translator/common_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/common_helpers.py
@@ -1,0 +1,273 @@
+# type: ignore
+
+from triton.experimental import gluon
+from triton.experimental.gluon import language as ttgl
+
+# hack to workaround limited dependencies tracking.
+# TODO: fix this by pulling imports into the generated file.
+from triton.language.target_info import current_target  # noqa: F401
+
+# ---- layout utilities ----
+
+
+@gluon.constexpr_function
+def get_num_threads_per_warp(target=None) -> ttgl.constexpr:
+    if target is None:
+        target = current_target()
+    if target is not None and target.backend == "hip":
+        gfx_major = int(target.arch[3:-2])
+        return ttgl.constexpr(32 if gfx_major >= 10 else 64)
+    return ttgl.constexpr(32)
+
+
+@gluon.jit
+def get_num_threads_per_program():
+    return ttgl.num_warps() * get_num_threads_per_warp(current_target())
+
+
+@gluon.constexpr_function
+def default_blocked_layout(shape: ttgl.constexpr, num_warps: ttgl.constexpr, target=None) -> ttgl.constexpr:
+    rank = len(shape)
+    size_per_thread = [1] * rank
+    threads_per_warp = [1] * rank
+    # TODO: pick a better layout based on shape. Using this allows to not have to convert layout when broadcasting but may blow up register pressure.
+    threads_per_warp[rank - 1] = get_num_threads_per_warp(target)
+    warps_per_cta = [1] * rank
+    warps_per_cta[0] = num_warps
+    order = list(range(rank - 1, -1, -1))
+    return ttgl.BlockedLayout(
+        size_per_thread=size_per_thread,
+        threads_per_warp=threads_per_warp,
+        warps_per_cta=warps_per_cta,
+        order=order,
+    )
+
+
+@gluon.constexpr_function
+def get_swizzle_byte_width(bitwidth):
+    swizzle = min(bitwidth, 128)
+    swizzle = 0 if swizzle < 32 else swizzle
+    return swizzle
+
+
+@gluon.constexpr_function
+def get_int_type(bitwidth):
+    if bitwidth == 64:
+        return ttgl.int64
+    elif bitwidth == 32:
+        return ttgl.int32
+    elif bitwidth == 16:
+        return ttgl.int16
+    elif bitwidth == 8:
+        return ttgl.int8
+    else:
+        assert False, f"Unsupported bitwidth: {bitwidth}"
+
+
+# ---- portable ops ----
+
+
+@gluon.jit
+def tl_arange(start: ttgl.constexpr, stop: ttgl.constexpr = None):
+    layout: ttgl.constexpr = default_blocked_layout([stop - start], ttgl.num_warps())
+    return ttgl.arange(start, stop, layout=layout)
+
+
+@gluon.jit
+def tl_full(shape, value, dtype=None):
+    layout: ttgl.constexpr = default_blocked_layout(shape, ttgl.num_warps())
+    return ttgl.full(shape, value, dtype, layout=layout)
+
+
+@gluon.jit
+def tl_trans(value, *dims):
+    return value.trans(*dims)
+
+
+@gluon.constexpr_function
+def cat_permute_order(rank, dim):
+    order = list(range(rank))
+    order.insert(dim, rank)
+    return order
+
+
+@gluon.constexpr_function
+def cat_result_shape(input_shape, dim):
+    result_shape = list(input_shape)
+    result_shape[dim] *= 2
+    return result_shape
+
+
+@gluon.jit
+def tl_cat(input, other, can_reorder=False, dim=0):
+    c = ttgl.join(input, other)
+    order: ttgl.constexpr = cat_permute_order(len(input.shape), dim)
+    c = ttgl.permute(c, order)
+    shape: ttgl.constexpr = cat_result_shape(input.shape, dim)
+    c = ttgl.reshape(c, shape)
+    return reset_to_default_layout(c)
+
+
+@gluon.jit
+def reset_to_default_layout(value):
+    ty: ttgl.constexpr = value.type
+    if isinstance(ty, ttgl.tuple_type):
+        out = ()
+        for i in ttgl.static_range(len(value)):
+            r = ttgl.convert_layout(value[i], layout=default_blocked_layout(value[i].type.shape, ttgl.num_warps()))
+            out = out + (r, )
+        return out
+    elif isinstance(value, ttgl.tensor) and isinstance(value.type, ttgl.distributed_type):
+        layout: ttgl.constexpr = default_blocked_layout(ty.shape, ttgl.num_warps())
+        return ttgl.convert_layout(value, layout=layout)
+    else:
+        return value
+
+
+@gluon.constexpr_function
+def get_split_src_layout(shape: ttgl.constexpr, num_warps: ttgl.constexpr, target=None) -> ttgl.constexpr:
+    rank = len(shape)
+    size_per_thread = [1 if i != rank - 1 else 2 for i in range(rank)]
+    threads_per_warp = [1 for _ in range(rank)]
+    remaining_threads = get_num_threads_per_warp(target)
+    for dim in range(rank - 2, -1, -1):
+        threads_per_warp[dim] = min(shape[dim], remaining_threads)
+        remaining_threads = remaining_threads // threads_per_warp[dim]
+    warps_per_cta = [1 for _ in range(rank)]
+    warps_per_cta[0] = num_warps
+    order = list(range(rank - 1, -1, -1))
+    return ttgl.BlockedLayout(
+        size_per_thread=size_per_thread,
+        threads_per_warp=threads_per_warp,
+        warps_per_cta=warps_per_cta,
+        order=order,
+    )
+
+
+@gluon.jit
+def set_split_src_layout(value):
+    layout: ttgl.constexpr = get_split_src_layout(value.type.shape, ttgl.num_warps())
+    return ttgl.convert_layout(value, layout=layout)
+
+
+@gluon.constexpr_function
+def build_expand_dims_layout(shape, expand_dims, num_warps):
+    if isinstance(shape, ttgl.tuple):
+        shape = shape.values
+    assert isinstance(shape, list), (f"expected shape to be a list, got {shape} which is {type(shape)}")
+    parent_shape = list(shape)
+    for dim in expand_dims:
+        parent_shape.insert(dim, 1)
+    layout = default_blocked_layout(parent_shape, num_warps)
+    for dim in reversed(expand_dims):
+        layout = ttgl.SliceLayout(dim=dim, parent=layout)
+    return layout
+
+
+@gluon.jit
+def convert_to_expand_dims_layout(value, expand_dims: list[int]):
+    layout: ttgl.constexpr = build_expand_dims_layout(value.shape, expand_dims, ttgl.num_warps())
+    return ttgl.convert_layout(value, layout)
+
+
+# ---- dot-scaled sub-helpers (vendor-neutral) ----
+
+
+@gluon.jit
+def tl_dot_decomposed_scale_to_16(scale, compute_type):
+    large_fp_type: ttgl.constexpr = ttgl.float32 if compute_type == ttgl.float16 else compute_type
+    int_width: ttgl.constexpr = large_fp_type.primitive_bitwidth
+    int_type: ttgl.constexpr = get_int_type(int_width)
+
+    zexted = ttgl.cast(scale, int_type)
+    shift_value: ttgl.constexpr = large_fp_type.fp_mantissa_width
+    shl_res = zexted << shift_value
+    scale_fp = ttgl.cast(shl_res, large_fp_type, bitcast=True)
+    if large_fp_type != compute_type:
+        scale_fp = ttgl.cast(scale_fp, compute_type)
+    return scale_fp
+
+
+@gluon.constexpr_function
+def tl_dot_get_expand_dims_layout(scale_ty, num_warps, rank):
+    shape = scale_ty.shape.values + [1]
+    blocked = default_blocked_layout(shape, num_warps)
+    slice = ttgl.SliceLayout(rank, blocked)
+    return slice
+
+
+@gluon.constexpr_function
+def tl_dot_get_permute_order(rank, dim):
+    order = list(range(rank))
+    order.insert(dim + 1, rank)
+    return order
+
+
+@gluon.constexpr_function
+def tl_dot_get_reshape_shape(scale_ty, dim):
+    shape = list(scale_ty.shape.values)
+    shape.pop()
+    shape[dim] *= 32
+    return shape
+
+
+@gluon.jit
+def tl_dot_decomposed_broadcast_scale(scale, dim):
+    scale_ty: ttgl.constexpr = scale.type
+    rank: ttgl.constexpr = len(scale_ty.shape)
+
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    slice_enc: ttgl.constexpr = tl_dot_get_expand_dims_layout(scale_ty, num_warps, rank)
+    scale = ttgl.convert_layout(scale, slice_enc)
+    expand_scale = scale.expand_dims(rank)
+    broadcast_scale = expand_scale.broadcast_to(scale.type.shape + (32, ))
+    permute_order: ttgl.constexpr = tl_dot_get_permute_order(rank, dim)
+    transposed_scale = broadcast_scale.permute(permute_order)
+    reshape_shape: ttgl.constexpr = tl_dot_get_reshape_shape(broadcast_scale.type, dim)
+    return transposed_scale.reshape(reshape_shape)
+
+
+@gluon.constexpr_function
+def tl_dot_decomposed_get_transposed_order(rank):
+    assert rank >= 2
+    order = list(range(rank - 2))
+    order += [rank - 1, rank - 2]
+    return order
+
+
+@gluon.jit
+def tl_dot_decomposed_extend_and_broadcast_scale(v, scale, compute_type, operand_index):
+    rank: ttgl.constexpr = len(v.type.shape)
+    k_dim: ttgl.constexpr = rank - 1 if operand_index == 0 else rank - 2
+
+    if operand_index == 1:
+        order: ttgl.constexpr = tl_dot_decomposed_get_transposed_order(rank)
+        scale = ttgl.permute(scale, order)
+
+    scale16 = tl_dot_decomposed_scale_to_16(scale, compute_type)
+    reshape_scale = tl_dot_decomposed_broadcast_scale(scale16, k_dim)
+    return ttgl.convert_layout(reshape_scale, v.type.layout), scale
+
+
+@gluon.jit
+def tl_dot_decomposed_mask_nan(mxfp, scale, fast_math):
+    ttgl.static_assert(fast_math, "TODO: support non-fast-math")
+    return mxfp
+
+
+@gluon.jit
+def tl_dot_decomposed_scale_arg(v, scale, arg_format, operand_index, compute_type, fast_math):
+    is_fp4: ttgl.constexpr = arg_format == "e2m1"
+    rank: ttgl.constexpr = len(v.type.shape)
+    k_dim: ttgl.constexpr = rank - 1 if operand_index == 0 else rank - 2
+
+    if is_fp4:
+        v = ttgl.fp4_to_fp(v, compute_type, k_dim)
+    else:
+        v = ttgl.cast(v, compute_type)
+    if scale is None:
+        return v
+    else:
+        reshape_scale, scale = tl_dot_decomposed_extend_and_broadcast_scale(v, scale, compute_type, operand_index)
+        mxfp = ttgl.mul(v, reshape_scale)
+        return tl_dot_decomposed_mask_nan(mxfp, scale, fast_math)

--- a/python/triton/tools/triton_to_gluon_translator/inline_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/inline_helpers.py
@@ -1,25 +1,42 @@
+_torch_dtype_to_triton_def = R"""
+def _torch_dtype_to_triton(dtype):
+    import torch
+
+    if dtype == torch.float8_e5m2:
+        return gl.float8e5
+    if dtype == torch.float8_e4m3fn:
+        return gl.float8e4nv
+    return getattr(gl, str(dtype).split(".")[1])
+"""
+
 defs: dict[str, str] = {
     "convert_host_descriptor":
-    R"""
+    _torch_dtype_to_triton_def + R"""
 def convert_host_descriptor(desc):
-    def torch_dtype_to_triton(dtype):
-        import torch
-
-        if dtype == torch.float8_e5m2:
-            return gl.float8e5
-        if dtype == torch.float8_e4m3fn:
-            return gl.float8e4nv
-        return getattr(gl, str(dtype).split(".")[1])
-
     from triton.tools.tensor_descriptor import TensorDescriptor
 
     assert isinstance(desc, TensorDescriptor)
     block_shape = desc.block_shape
     dtype = desc.base.dtype
     tensor = desc.base
-    layout = gl.NVMMASharedLayout.get_default_for(block_shape, torch_dtype_to_triton(dtype))
+    layout = gl.NVMMASharedLayout.get_default_for(block_shape, _torch_dtype_to_triton(dtype))
     return gluon.nvidia.hopper.TensorDescriptor(
         tensor, desc.shape, desc.strides, block_shape, layout
     )
-"""
+""",
+    "convert_host_descriptor_amd":
+    _torch_dtype_to_triton_def + R"""
+def convert_host_descriptor(desc):
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    assert isinstance(desc, TensorDescriptor)
+    block_shape = desc.block_shape
+    dtype = desc.base.dtype
+    layout = gl.PaddedSharedLayout.with_identity_for(
+        [[block_shape[-1], 4]], list(block_shape), [1, 0]
+    )
+    return gluon.amd.gfx1250.TensorDescriptor(
+        desc.base, list(desc.shape), list(desc.strides), block_shape, layout
+    )
+""",
 }

--- a/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
@@ -14,8 +14,18 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     tcgen05_mma_scaled,
 )
 from triton.experimental.gluon.language.nvidia.blackwell import tma as tma_blackwell
-from triton.experimental.gluon.language.nvidia.hopper import mbarrier, tma
+from triton.experimental.gluon.language.nvidia.hopper import fence_async_shared, mbarrier, tma
 from triton.language.core import _unwrap_if_constexpr
+
+from triton.tools.triton_to_gluon_translator.common_helpers import *  # noqa: F401,F403
+from triton.tools.triton_to_gluon_translator.common_helpers import (
+    default_blocked_layout,
+    get_num_threads_per_warp,
+    tl_dot_decomposed_scale_arg,
+    tl_trans,
+)
+
+# ---- NVIDIA MMA sync (Ampere) ----
 
 
 @gluon.constexpr_function
@@ -57,6 +67,9 @@ def tl_dot_mma_sync(a, b, acc_init=None, input_precision=None, out_dtype=ttgl.fl
         layout: ttgl.constexpr = default_blocked_layout(result.type.shape, ttgl.num_warps())
     result = ttgl.convert_layout(result, layout)
     return result
+
+
+# ---- NVIDIA Blackwell dot ----
 
 
 @gluon.constexpr_function
@@ -145,7 +158,6 @@ def tl_dot_blackwell(
     a_smem = get_shared_memory_mma_operand(a, 0, allow_transpose)
     b_smem = get_shared_memory_mma_operand(b, 1, allow_transpose)
 
-    # MMA instruction shape
     m: ttgl.constexpr = 128 if M >= 128 else 64
     n: ttgl.constexpr = 256 if N >= 256 else N
 
@@ -166,11 +178,13 @@ def tl_dot_blackwell(
     mbarrier.wait(bar, phase=0)
     mbarrier.invalidate(bar)
 
-    # Load back from TMEM using a register layout and convert to acc layout
     out = acc_tmem.load()
     ret_layout: ttgl.constexpr = default_blocked_layout([M, N], ttgl.num_warps())
     out = ttgl.convert_layout(out, ret_layout)
     return out
+
+
+# ---- NVIDIA dot dispatch ----
 
 
 @gluon.jit
@@ -188,6 +202,9 @@ def tl_dot(
         return tl_dot_blackwell(a, b, acc, input_precision, allow_tf32, max_num_imprecise_acc, out_dtype)
     else:
         return tl_dot_mma_sync(a, b, acc, input_precision, out_dtype)
+
+
+# ---- NVIDIA dot-scaled ----
 
 
 @gluon.constexpr_function
@@ -486,7 +503,6 @@ def tl_dot_scaled_blackwell(
     tcgen05_commit(bar)
     mbarrier.wait(bar, phase=0)
     mbarrier.invalidate(bar)
-    # Load back from TMEM using a register layout and convert to acc layout
     out = acc_tmem.load()
     ret_layout: ttgl.constexpr = default_blocked_layout([M, N], ttgl.num_warps())
     out = ttgl.convert_layout(out, ret_layout)
@@ -528,63 +544,7 @@ def default_blocked_layout(shape: ttgl.constexpr, num_warps: ttgl.constexpr) -> 
         order=order,
     )
 
-
-@gluon.jit
-def tl_obj_store(obj, offsets, value):
-    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
-        return tl_store_tensor_descriptor(obj, offsets, value)
-    else:
-        return obj.store(offsets, value)
-
-
-@gluon.jit
-def tl_obj_load(obj, offsets):
-    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
-        return tl_load_tensor_descriptor(obj, offsets)
-    else:
-        return obj.load(offsets)
-
-
-@gluon.jit
-def tl_obj_gather(obj, x_offsets, y_offset):
-    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
-        desc = obj
-        desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
-        alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout)
-        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
-        mbarrier.init(bar, count=1)
-        x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
-            0,
-            ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
-        )
-        x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
-        mbarrier.expect(bar, x_offsets.shape[0] * obj.block_type.nbytes)
-        tma_blackwell.async_gather(desc, x_offsets, y_offset, bar, alloc)
-        mbarrier.wait(bar, phase=0)
-        mbarrier.invalidate(bar)
-        # Load from shared memory into a register tensor using a reasonable default layout
-        ret_layout: ttgl.constexpr = default_blocked_layout(desc.block_shape, ttgl.num_warps())
-        out = alloc.load(ret_layout)
-        return out
-    else:
-        return obj.gather(x_offsets, y_offset)
-
-
-@gluon.jit
-def tl_obj_scatter(obj, value, x_offsets, y_offset):
-    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
-        desc = obj
-        desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
-        alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout, value)
-        x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
-            0,
-            ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
-        )
-        x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
-        tma_blackwell.async_scatter(desc, x_offsets, y_offset, alloc)
-        tma.store_wait(0, read_only=False)
-    else:
-        obj.scatter(value, x_offsets, y_offset)
+# ---- NVIDIA TMA tensor descriptors ----
 
 
 @ttgl._core.builtin
@@ -606,15 +566,65 @@ def tl_load_tensor_descriptor(desc, offsets):
     smem = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout)
     bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
     mbarrier.init(bar, count=1)
-    # Issue async copy from global (descriptor) to shared memory and wait for completion
     mbarrier.expect(bar, desc.block_type.nbytes)
     tma.async_copy_global_to_shared(desc, offsets, bar, smem)
     mbarrier.wait(bar, phase=0)
     mbarrier.invalidate(bar)
-    # Load from shared memory into a register tensor using a reasonable default layout
     ret_layout: ttgl.constexpr = default_blocked_layout(desc.block_shape, ttgl.num_warps())
     out = smem.load(ret_layout)
     return out
+
+
+# ---- NVIDIA obj dispatch ----
+
+
+@gluon.jit
+def tl_obj_store(obj, offsets, value):
+    tl_store_tensor_descriptor(obj, offsets, value)
+
+
+@gluon.jit
+def tl_obj_load(obj, offsets):
+    return tl_load_tensor_descriptor(obj, offsets)
+
+
+@gluon.jit
+def tl_obj_gather(obj, x_offsets, y_offset):
+    desc = obj
+    desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
+    alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout)
+    bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
+    mbarrier.init(bar, count=1)
+    x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
+        0,
+        ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
+    )
+    x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
+    mbarrier.expect(bar, x_offsets.shape[0] * obj.block_type.nbytes)
+    tma_blackwell.async_gather(desc, x_offsets, y_offset, bar, alloc)
+    mbarrier.wait(bar, phase=0)
+    mbarrier.invalidate(bar)
+    ret_layout: ttgl.constexpr = default_blocked_layout(desc.block_shape, ttgl.num_warps())
+    out = alloc.load(ret_layout)
+    return out
+
+
+@gluon.jit
+def tl_obj_scatter(obj, value, x_offsets, y_offset):
+    desc = obj
+    desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
+    alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout, value)
+    fence_async_shared()
+    x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
+        0,
+        ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
+    )
+    x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
+    tma_blackwell.async_scatter(desc, x_offsets, y_offset, alloc)
+    tma.store_wait(0)
+
+
+# ---- NVIDIA host-side descriptor ----
 
 
 @gluon.jit

--- a/python/triton/tools/triton_to_gluon_translator/slice_kernel.py
+++ b/python/triton/tools/triton_to_gluon_translator/slice_kernel.py
@@ -26,6 +26,7 @@ from triton.tools.triton_to_gluon_translator.inline_helpers import defs as inlin
 from triton.tools.triton_to_gluon_translator.ordered_set import ordered_set
 from triton.tools.triton_to_gluon_translator.scoped_dict import scoped_dict
 from triton.tools.triton_to_gluon_translator.stable_toposort import stable_toposort
+from triton.tools.triton_to_gluon_translator.target import TranslatorTarget
 
 logger = logging.getLogger(__name__)
 
@@ -521,6 +522,7 @@ class SliceRewriter(ReferenceRewriter):
     translate_to_gluon: bool = False
     inline_helpers: ordered_set[str] = field(default_factory=ordered_set[str])
     cvt_context: list[bool] = field(default_factory=lambda: [False])
+    target: TranslatorTarget = TranslatorTarget.NVIDIA
 
     def __post_init__(self) -> None:
         # Special rules for sugaring imports.
@@ -562,7 +564,7 @@ class SliceRewriter(ReferenceRewriter):
             self.imports.add("import triton.experimental.gluon._runtime as gluon_runtime")
             new_node = parse_expr("gluon_runtime.GluonJITFunction")
         elif value is tl.tensor_descriptor:
-            self.imports.add("from triton.experimental.gluon.language.nvidia.hopper.tma import tensor_descriptor")
+            self.imports.add(self.target.tensor_descriptor_import)
             new_node = ast.Name(id="tensor_descriptor", ctx=ast.Load())
         return new_node
 
@@ -709,6 +711,7 @@ def slice_kernel(
     leaf_paths: list[str] | None = None,
     translate_to_gluon: bool = False,
     ignored_decorator_matchers: Sequence[DecoratorMatcher] | None = None,
+    target: TranslatorTarget = TranslatorTarget.NVIDIA,
 ) -> str:
     base_values: list[GlobalValue] = [get_base_value(root_path) for root_path in root_paths]
     base_value_ids: set[int] = set()
@@ -736,7 +739,7 @@ def slice_kernel(
             ignored_decorator_matchers=ignored_decorator_matchers,
         )
         jit_functions = [fn for fn in jit_functions if not fn.original_value.is_gluon()]
-        converted_functions = translate_kernels(jit_functions)
+        converted_functions = translate_kernels(jit_functions, target=target)
         module_file = tempfile.NamedTemporaryFile(delete=False, prefix="translated_", suffix=".py")
         module_path = Path(module_file.name)
         module_path.write_text(converted_functions)
@@ -782,6 +785,7 @@ def slice_kernel(
             ignored_decorator_matchers=tuple(ignored_decorator_matchers or ()),
             translate_to_gluon=translate_to_gluon,
             inline_helpers=inline_helpers,
+            target=target,
         )
         tree = rewriter.visit(tree)
         source = ast.unparse(tree)
@@ -807,6 +811,7 @@ def slice_kernel_from_trace(
     translate_to_gluon: bool,
     extra_modules: dict[str, str],
     ignored_decorator_matchers: Sequence[DecoratorMatcher] | None = None,
+    target: TranslatorTarget = TranslatorTarget.NVIDIA,
 ) -> str:
     module_remap: dict[str, str] = {}
     for name, path in extra_modules.items():
@@ -831,6 +836,7 @@ def slice_kernel_from_trace(
         leaf_paths=sorted(leaf_paths),
         translate_to_gluon=translate_to_gluon,
         ignored_decorator_matchers=ignored_decorator_matchers,
+        target=target,
     )
 
     fn_name = lambda path: path.split(":")[1]
@@ -853,6 +859,7 @@ def main(
     translate_to_gluon: bool = False,
     output_path: str = "/tmp/reference.py",
     ignored_decorator_matchers: Sequence[DecoratorMatcher] | None = None,
+    target: TranslatorTarget = TranslatorTarget.NVIDIA,
 ) -> None:
     output = slice_kernel(
         root_paths,
@@ -861,6 +868,7 @@ def main(
         leaf_paths,
         translate_to_gluon,
         ignored_decorator_matchers,
+        target=target,
     )
     with open(output_path, "w") as f:
         f.write(output)

--- a/python/triton/tools/triton_to_gluon_translator/target.py
+++ b/python/triton/tools/triton_to_gluon_translator/target.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class TranslatorTarget(str, Enum):
+    """Target architecture for the Triton-to-Gluon translator.
+
+    Known targets are listed as explicit members for discoverability.
+    Unknown ``gfx*`` strings are accepted via ``_missing_()`` so that
+    new AMD architectures work without adding an enum member.
+    """
+
+    NVIDIA = "nvidia"
+    # AMD targets currently exercised by the translator test suite:
+    GFX1250 = "gfx1250"
+    GFX942 = "gfx942"
+    GFX950 = "gfx950"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "TranslatorTarget | None":
+        """Allow any ``gfx*`` string as a valid AMD target."""
+        if isinstance(value, str) and value.startswith("gfx"):
+            obj = str.__new__(cls, value)
+            obj._value_ = value
+            return obj
+        return None
+
+    @property
+    def is_amd(self) -> bool:
+        return self != TranslatorTarget.NVIDIA
+
+    @property
+    def tensor_descriptor_import(self) -> str:
+        """Return the import statement for the target's tensor descriptor module."""
+        if self.is_amd:
+            return "from triton.experimental.gluon.language.amd.gfx1250.tdm import tensor_descriptor"
+        return "from triton.experimental.gluon.language.nvidia.hopper.tma import tensor_descriptor"
+
+    @property
+    def helpers_module(self) -> str:
+        """Return the helpers module path for this target."""
+        base = "triton.tools.triton_to_gluon_translator"
+        if self.is_amd:
+            return f"{base}.amd_helpers"
+        return f"{base}.nvidia_helpers"

--- a/python/triton/tools/triton_to_gluon_translator/translator.py
+++ b/python/triton/tools/triton_to_gluon_translator/translator.py
@@ -21,6 +21,7 @@ from triton.tools.triton_to_gluon_translator.slice_kernel import (
     mangle_reference_names,
     parse_expr,
 )
+from triton.tools.triton_to_gluon_translator.target import TranslatorTarget
 from triton.tools.triton_to_gluon_translator.stable_toposort import stable_toposort
 
 
@@ -108,6 +109,7 @@ def add_expr_rewrites(rewrites: list[RewriteFn]) -> None:
 @dataclass
 class Translator(ReferenceRewriter):
     tensor_member_match_fns: list[str] = field(default_factory=list)
+    target: TranslatorTarget = TranslatorTarget.NVIDIA
 
     def __post_init__(self) -> None:
         import triton
@@ -123,7 +125,7 @@ class Translator(ReferenceRewriter):
 
         self.imports.add("import triton.experimental.gluon as gluon")
         self.imports.add("import triton.experimental.gluon.language as gl")
-        self.imports.add("import triton.tools.triton_to_gluon_translator.translator_helpers as helpers")
+        self.imports.add(f"import {self.target.helpers_module} as helpers")
 
         self.tensor_member_match_fns = ["reshape", "trans", "permute", "split", "reduce", "sum"]
 
@@ -198,7 +200,7 @@ class Translator(ReferenceRewriter):
         return self.generic_visit(node)
 
 
-def translate_kernels(kernels: list[GlobalValue]) -> str:
+def translate_kernels(kernels: list[GlobalValue], target: TranslatorTarget = TranslatorTarget.NVIDIA) -> str:
 
     def filter(value: ModuleType | GlobalValue) -> bool:
         if isinstance(value, ModuleType):
@@ -240,6 +242,7 @@ def translate_kernels(kernels: list[GlobalValue]) -> str:
             imports,
             filter,
             value_remap={},
+            target=target,
         )
         tree = rewriter.visit(tree)
         source = ast.unparse(tree)
@@ -250,12 +253,12 @@ def translate_kernels(kernels: list[GlobalValue]) -> str:
     return output
 
 
-def translate_paths(kernel_paths: list[str]) -> str:
+def translate_paths(kernel_paths: list[str], target: TranslatorTarget = TranslatorTarget.NVIDIA) -> str:
     kernels = [get_base_value(kernel_path) for kernel_path in kernel_paths]
-    return translate_kernels(kernels)
+    return translate_kernels(kernels, target=target)
 
 
-def convert_triton_to_gluon(src: list[JITCallable]) -> str:
+def convert_triton_to_gluon(src: list[JITCallable], target: TranslatorTarget = TranslatorTarget.NVIDIA) -> str:
     kernels = [
         GlobalValue.wrap(
             kernel,
@@ -263,11 +266,11 @@ def convert_triton_to_gluon(src: list[JITCallable]) -> str:
             lambda: builtins,
         ) for kernel in src
     ]
-    return translate_kernels(kernels)
+    return translate_kernels(kernels, target=target)
 
 
-def main(kernels: list[str], output_path: str) -> None:
-    output = translate_paths(kernels)
+def main(kernels: list[str], output_path: str, target: TranslatorTarget = TranslatorTarget.NVIDIA) -> None:
+    output = translate_paths(kernels, target=target)
     with open(output_path, "w") as f:
         f.write(output)
 
@@ -276,8 +279,9 @@ def _main_cli() -> None:
     parser = argparse.ArgumentParser(description="Translate Triton kernels to Gluon source.")
     parser.add_argument("kernels", nargs="+", help="Kernel symbols in module.path:object format.")
     parser.add_argument("--output-path", required=True, help="Path to write the translated source.")
+    parser.add_argument("--target", default="nvidia", help="Target architecture (e.g. nvidia, amd_gfx1250).")
     args = parser.parse_args()
-    main(args.kernels, args.output_path)
+    main(args.kernels, args.output_path, target=TranslatorTarget(args.target))
 
 
 if __name__ == "__main__":

--- a/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
@@ -216,6 +216,67 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// Partial TDM copy: warp_used_hint = 0x0F picks K=4 active warps out of 8.
+// The warp sublayout of the TDM LinearLayout is an identity over K=4 warps
+// (low 2 bits of warpId drive offsets), so the free-variable mask for the
+// "warp" input dim is 0b100 (bit 2 is redundant).  Predication is
+// (warpId & 4) == 0, i.e. warps 0..3 are active and warps 4..7 issue a
+// no-op TDM.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tdm_load_warp_used_hint_predication
+  tt.func public @tdm_load_warp_used_hint_predication(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %c_shape = arith.constant 256 : i32
+    %c_stride0 = arith.constant 256 : i64
+    %c_stride1 = arith.constant 1 : i64
+    %c_offset = arith.constant 0 : i32
+    %c_pred = arith.constant 1 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<256x64xf16, #shared>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+    // CHECK-DAG: %[[FREE_MASK:.*]] = llvm.mlir.constant(4 : i32) : i32
+    // CHECK-DAG: %[[ZERO:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[MASKED:.*]] = llvm.and %{{.*}}, %[[FREE_MASK]] : i32
+    // CHECK: %[[IS_ACTIVE:.*]] = llvm.icmp "eq" %[[MASKED]], %[[ZERO]] : i32
+    // CHECK: %[[LAYOUT_PRED:.*]] = llvm.select %[[IS_ACTIVE]], %{{.*}}, %{{.*}} : i1, i32
+    // CHECK: llvm.and %{{.*}}, %[[LAYOUT_PRED]] : i32
+    // CHECK: "llvm.amdgcn.tensor.load.to.lds"
+    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred {warp_used_hint = 15 : i32} : !tt.tensordesc<256x64xf16, #shared> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Partial TDM copy with partitioned layout.  warp_used_hint = 0x03 selects
+// K=2 active warps out of 4, matching numLogicalPieces (2) so the copy
+// fits in a single TDM instruction.  The redundant warp bit is bit 1 of
+// warpId (free mask = 2).
+#shared_inner = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 1, partitionDim = 0, partitionLayout = #shared_inner}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tdm_load_warp_used_hint_partitioned
+  tt.func public @tdm_load_warp_used_hint_partitioned(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %c_shape = arith.constant 256 : i32
+    %c_stride0 = arith.constant 256 : i64
+    %c_stride1 = arith.constant 1 : i64
+    %c_offset = arith.constant 0 : i32
+    %c_pred = arith.constant 1 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<128x16xf16, #partitioned>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<128x16xf16, #partitioned, #smem, mutable>
+    // CHECK-DAG: %[[FREE_MASK:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-DAG: %[[ZERO:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[MASKED:.*]] = llvm.and %{{.*}}, %[[FREE_MASK]] : i32
+    // CHECK: llvm.icmp "eq" %[[MASKED]], %[[ZERO]] : i32
+    // CHECK: "llvm.amdgcn.tensor.load.to.lds"
+    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred {warp_used_hint = 3 : i32} : !tt.tensordesc<128x16xf16, #partitioned> -> !ttg.memdesc<128x16xf16, #partitioned, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 // Scatter with padded shared layout: padding interval = innermost block dim.
 #idx_parent = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #idx_layout = #ttg.slice<{dim = 1, parent = #idx_parent}>

--- a/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
@@ -64,14 +64,13 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %c_offset = arith.constant 0 : i32
     %c_pred = arith.constant 1 : i32
 
-    // CHECK-DAG: %[[STRIDE0:.*]] = llvm.mlir.constant(128 : i64) : i64
-    // CHECK-DAG: %[[STRIDE1:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK: %[[STRIDE0_TRUNC:.*]] = llvm.trunc %[[STRIDE0]] : i64 to i32
-    // CHECK: %[[OFFSET_DIM0:.*]] = llvm.mul{{.*}}%[[STRIDE0_TRUNC]]
-    // CHECK: %[[OFFSET_TMP1:.*]] = llvm.add{{.*}}%[[OFFSET_DIM0]]
-    // CHECK: %[[OFFSET_DIM1:.*]] = llvm.mul{{.*}}%[[STRIDE1]]
-    // CHECK: %[[TOTAL_OFFSET:.*]] = llvm.add %[[OFFSET_TMP1]], %[[OFFSET_DIM1]]
-    // CHECK: %[[ADJUSTED_PTR:.*]] = llvm.getelementptr %{{.*}}[%[[TOTAL_OFFSET]]]
+    // CHECK: llvm.sext %{{.*}} : i32 to i64
+    // CHECK: %[[OFFSET_DIM0:.*]] = llvm.mul %{{.*}}, %{{.*}} : i64
+    // CHECK: %[[OFFSET_TMP1:.*]] = llvm.add %[[OFFSET_DIM0]], %{{.*}} : i64
+    // CHECK: llvm.sext %{{.*}} : i32 to i64
+    // CHECK: %[[OFFSET_DIM1:.*]] = llvm.mul %{{.*}}, %{{.*}} : i64
+    // CHECK: %[[TOTAL_OFFSET:.*]] = llvm.add %[[OFFSET_TMP1]], %[[OFFSET_DIM1]] : i64
+    // CHECK: llvm.getelementptr %{{.*}}[%[[TOTAL_OFFSET]]] : (!llvm.ptr<1>, i64)
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
 
@@ -95,15 +94,14 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %c_stride1 = arith.constant 1 : i64
     %c_offset = arith.constant 0 : i32
 
-    // CHECK-DAG: %[[STRIDE0:.*]] = llvm.mlir.constant(128 : i64) : i64
-    // CHECK-DAG: %[[STRIDE1:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-DAG: rocdl.cluster.workgroup.id.x
-    // CHECK-DAG: %[[STRIDE0_TRUNC:.*]] = llvm.trunc %[[STRIDE0]] : i64 to i32
-    // CHECK: %[[OFFSET_DIM0:.*]] = llvm.mul{{.*}}%[[STRIDE0_TRUNC]]
-    // CHECK: %[[OFFSET_TMP1:.*]] = llvm.add{{.*}}%[[OFFSET_DIM0]]
-    // CHECK: %[[OFFSET_DIM1:.*]] = llvm.mul{{.*}}%[[STRIDE1]]
-    // CHECK: %[[TOTAL_OFFSET:.*]] = llvm.add %[[OFFSET_TMP1]], %[[OFFSET_DIM1]]
-    // CHECK: %[[ADJUSTED_PTR:.*]] = llvm.getelementptr %{{.*}}[%[[TOTAL_OFFSET]]]
+    // CHECK: llvm.sext %{{.*}} : i32 to i64
+    // CHECK: %[[OFFSET_DIM0:.*]] = llvm.mul %{{.*}}, %{{.*}} : i64
+    // CHECK: %[[OFFSET_TMP1:.*]] = llvm.add %[[OFFSET_DIM0]], %{{.*}} : i64
+    // CHECK: llvm.sext %{{.*}} : i32 to i64
+    // CHECK: %[[OFFSET_DIM1:.*]] = llvm.mul %{{.*}}, %{{.*}} : i64
+    // CHECK: %[[TOTAL_OFFSET:.*]] = llvm.add %[[OFFSET_TMP1]], %[[OFFSET_DIM1]] : i64
+    // CHECK: llvm.getelementptr %{{.*}}[%[[TOTAL_OFFSET]]] : (!llvm.ptr<1>, i64)
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
@@ -292,6 +290,53 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
     amdg.async_tdm_scatter %tensorDesc[%row_indices, %c0_i32] from %memDesc : tensor<8xi32, #idx_layout>, !ttg.memdesc<8x64xf16, #shared_scatter_pad, #smem_scatter_pad, mutable> -> !tt.tensordesc<8x64xf16>
     // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// TDM stride slots are 48 bits wide. Verify that an i64 stride is split
+// into low-32 and high-16 pieces and not silently truncated to i32.
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tdm_load_64bit_stride
+  // CHECK-SAME: %{{.*}}: !llvm.ptr<1> {{.*}}, %[[STRIDE:.*]]: i64,
+  tt.func public @tdm_load_64bit_stride(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                        %stride0: i64, %shape0: i32, %shape1: i32) {
+    %c_stride1 = arith.constant 1 : i64
+    %c_offset = arith.constant 0 : i32
+    %c_pred = arith.constant 1 : i32
+    // CHECK: %[[HI64:.*]] = llvm.lshr %[[STRIDE]], %{{.*}} : i64
+    // CHECK: %[[HI32:.*]] = llvm.trunc %[[HI64]] : i64 to i32
+    // CHECK: llvm.insertelement %{{.*}}, %{{.*}} : vector<8xi32>
+    %0 = tt.make_tensor_descriptor %arg0, [%shape0, %shape1], [%stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Same as above but for 3D. 4D and 5D share the logic so a test would be redundant.
+#shared = #ttg.padded_shared<[16:+4] {order = [2, 1, 0], shape = [4, 16, 64]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tdm_load_64bit_stride_3d
+  // CHECK-SAME: %{{.*}}: !llvm.ptr<1> {{.*}}, %[[S0:.*]]: i64, %[[S1:.*]]: i64,
+  tt.func public @tdm_load_64bit_stride_3d(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                                           %stride0: i64, %stride1: i64,
+                                           %shape0: i32, %shape1: i32, %shape2: i32) {
+    %c_stride2 = arith.constant 1 : i64
+    %c_offset = arith.constant 0 : i32
+    %c_pred = arith.constant 1 : i32
+    // CHECK-DAG: llvm.lshr %[[S0]], %{{.*}} : i64
+    // CHECK-DAG: llvm.lshr %[[S1]], %{{.*}} : i64
+    %0 = tt.make_tensor_descriptor %arg0, [%shape0, %shape1, %shape2], [%stride0, %stride1, %c_stride2] : !tt.ptr<f16>, !tt.tensordesc<4x16x64xf16, #shared>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<4x16x64xf16, #shared, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset, %c_offset] into %1, pred = %c_pred : !tt.tensordesc<4x16x64xf16, #shared> -> !ttg.memdesc<4x16x64xf16, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -234,24 +234,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
     // stride 8: ROW_ROR:8 (0x128 = 296)
     // CHECK: rocdl.update.dpp
-    // CHECK-SAME: with 296, 15, 15, false : i32
+    // CHECK-SAME: with 296, 15, 15, true : i32
     // CHECK: llvm.intr.maxnum
 
     // stride 4: ROW_HALF_MIRROR (0x141 = 321) + quad_perm xor 3 (27)
     // CHECK: rocdl.update.dpp
-    // CHECK-SAME: with 321, 15, 15, false : i32
+    // CHECK-SAME: with 321, 15, 15, true : i32
     // CHECK: rocdl.update.dpp
-    // CHECK-SAME: with 27, 15, 15, false : i32
+    // CHECK-SAME: with 27, 15, 15, true : i32
     // CHECK: llvm.intr.maxnum
 
     // stride 2: quad_perm xor 2 (78)
     // CHECK: rocdl.update.dpp
-    // CHECK-SAME: with 78, 15, 15, false : i32
+    // CHECK-SAME: with 78, 15, 15, true : i32
     // CHECK: llvm.intr.maxnum
 
     // stride 1: quad_perm xor 1 (177)
     // CHECK: rocdl.update.dpp
-    // CHECK-SAME: with 177, 15, 15, false : i32
+    // CHECK-SAME: with 177, 15, 15, true : i32
     %0 = "tt.reduce"(%arg0) <{axis = 0 : i32}> ({
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = arith.maxnumf %arg1, %arg2 : f32
@@ -274,19 +274,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
     // stride 8: ROW_XMASK:8
     // GFX1250: rocdl.update.dpp
-    // GFX1250-SAME: with 360, 15, 15, false
+    // GFX1250-SAME: with 360, 15, 15, true
 
     // stride 4: ROW_XMASK:4
     // GFX1250: rocdl.update.dpp
-    // GFX1250-SAME: with 356, 15, 15, false
+    // GFX1250-SAME: with 356, 15, 15, true
 
     // stride 2: ROW_XMASK:2
     // GFX1250: rocdl.update.dpp
-    // GFX1250-SAME: with 354, 15, 15, false
+    // GFX1250-SAME: with 354, 15, 15, true
 
     // stride 1: ROW_XMASK:1
     // GFX1250: rocdl.update.dpp
-    // GFX1250-SAME: with 353, 15, 15, false
+    // GFX1250-SAME: with 353, 15, 15, true
     %0 = "tt.reduce"(%arg0) <{axis = 0 : i32}> ({
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = arith.maxnumf %arg1, %arg2 : f32

--- a/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
@@ -19,7 +19,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // GFX1250-LABEL: reduce_16x16
   tt.func @reduce_16x16(%input: tensor<128x128xf32, #mma>) {
-    // GFX1250-COUNT-2: llvm.call_intrinsic "llvm.amdgcn.permlane16.swap"
+    // GFX1250-COUNT-2: rocdl.permlanex16
     %0 = "tt.reduce"(%input) <{axis = 1 : i32}> ({
       ^bb0(%arg1: f32 , %arg2: f32):
       %2 = "arith.maxnumf"(%arg1, %arg2) : (f32, f32) -> f32

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -285,6 +285,78 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// warp_used_hint validation tests
+#shared_wb = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem_wb = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // hint == 0 has no active warps; rejected.
+  tt.func @warp_used_hint_zero(
+    %tensorDesc: !tt.tensordesc<256x64xf16>,
+    %memDesc: !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>,
+    %pred: i32
+  ) {
+    %c0 = arith.constant 0 : i32
+    // expected-error @+1 {{warp_used_hint must have at least one bit set}}
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0, %c0] into %memDesc, pred = %pred {warp_used_hint = 0 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
+    tt.return
+  }
+
+  // 0x69 (warps 0,3,5,6) is rejected: K=4 is a power of two but the
+  // active set spans 3 warpId bit positions, not log2(K) = 2 -- a
+  // non axis-aligned pattern is not supported.
+  tt.func @warp_used_hint_non_axis_aligned(
+    %tensorDesc: !tt.tensordesc<256x64xf16>,
+    %memDesc: !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>,
+    %pred: i32
+  ) {
+    %c0 = arith.constant 0 : i32
+    // expected-error @+1 {{is not axis-aligned}}
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0, %c0] into %memDesc, pred = %pred {warp_used_hint = 105 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
+    tt.return
+  }
+
+  // popcount must be a power of two.  0x07 has K=3 -- rejected even
+  // though warps 0..2 are otherwise contiguous.
+  tt.func @warp_used_hint_non_pow2_k(
+    %tensorDesc: !tt.tensordesc<256x64xf16>,
+    %memDesc: !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>,
+    %pred: i32
+  ) {
+    %c0 = arith.constant 0 : i32
+    // expected-error @+1 {{popcount(warp_used_hint) = 3 must be a power of two}}
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0, %c0] into %memDesc, pred = %pred {warp_used_hint = 7 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
+    tt.return
+  }
+
+  // hint sets all 16 low bits but num_warps = 8 so bits 8..15 don't
+  // correspond to any warp.  Reported by the bits-beyond check.
+  tt.func @warp_used_hint_exceeds_num_warps(
+    %tensorDesc: !tt.tensordesc<256x64xf16>,
+    %memDesc: !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>,
+    %pred: i32
+  ) {
+    %c0 = arith.constant 0 : i32
+    // expected-error @+1 {{warp_used_hint = 0xffff sets bits beyond num_warps = 8}}
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0, %c0] into %memDesc, pred = %pred {warp_used_hint = 65535 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
+    tt.return
+  }
+
+  // Bits outside [0, num_warps) must be zero.  K=2 is otherwise valid,
+  // but warp index 9 is not in [0, 8).
+  tt.func @warp_used_hint_bits_beyond_num_warps(
+    %tensorDesc: !tt.tensordesc<256x64xf16>,
+    %memDesc: !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>,
+    %pred: i32
+  ) {
+    %c0 = arith.constant 0 : i32
+    // expected-error @+1 {{sets bits beyond num_warps = 8}}
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0, %c0] into %memDesc, pred = %pred {warp_used_hint = 513 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #fp4_src = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 #fp4_dst = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
 #fp4_scale_bad = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 16], warpsPerCTA = [1, 1], order = [1, 0]}>
@@ -292,6 +364,27 @@ module attributes {"ttg.target" = "hip:gfx950", "ttg.num-ctas" = 1 : i32, "ttg.n
   tt.func @scaled_upcast_fp4_incompatible_scale_encoding(%src: tensor<16x32xi8, #fp4_src>, %scale: tensor<16x64xbf16, #fp4_scale_bad>) {
     // expected-error @+1 {{scale and output encodings are not compatible}}
     %0 = amdg.scaled_upcast_fp4 %src scale %scale {axis = 1 : i32} : tensor<16x32xi8, #fp4_src>, tensor<16x64xbf16, #fp4_scale_bad> -> tensor<16x64xbf16, #fp4_dst>
+    tt.return
+  }
+}
+
+// -----
+
+// Partitioned encoding requires K to be a multiple of numLogicalPieces
+// (= numPartitions*numGroups = 4) so the hinted copy fits in a single
+// TDM instruction.  Here K=2 < numLogicalPieces=4 is rejected.
+#shared_inner_mi = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#partitioned_mi = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #shared_inner_mi}>
+#smem_mi = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @warp_used_hint_partitioned_insufficient(
+    %tensorDesc: !tt.tensordesc<128x16xf16>,
+    %memDesc: !ttg.memdesc<128x16xf16, #partitioned_mi, #smem_mi, mutable>,
+    %pred: i32
+  ) {
+    %c0 = arith.constant 0 : i32
+    // expected-error @+1 {{warp_used_hint with a partitioned shared encoding must select K active warps}}
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0, %c0] into %memDesc, pred = %pred {warp_used_hint = 3 : i32} : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #partitioned_mi, #smem_mi, mutable>
     tt.return
   }
 }

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -420,6 +420,7 @@ class HIPBackend(BaseBackend):
         passes.common.add_sccp(pm)
         passes.ttir.add_loop_aware_cse(pm)
         passes.gluon.add_canonicalizer(pm)
+        passes.ttir.add_loop_unroll(pm)
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
         amd.passes.ttgpuir.add_warp_pipeline(pm)
         passes.ttgpuir.add_allocate_warp_groups(pm)

--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -115,7 +115,7 @@ static PyTypeObject PyKernelArgType = {
 static bool encodeTDMDescriptor(TDMDescriptor *desc, int elementBitWidth,
                                 uint32_t *blockSize, int numWarps,
                                 int padInterval, int padAmount, uint32_t *shape,
-                                uint32_t *strides, uint64_t globalAddress,
+                                uint64_t *strides, uint64_t globalAddress,
                                 int rank) {
   if (rank < 1 || rank > 5)
     return false;
@@ -184,36 +184,46 @@ static bool encodeTDMDescriptor(TDMDescriptor *desc, int elementBitWidth,
   if (rank >= 3)
     desc->group1_4 |= (adjustedBlockSize[rank - 3] << 16);
 
-  // Strides
-  if (rank >= 2)
-    desc->group1_5 = strides[rank - 2];
+  // TDM strides are 48bit in 2 different groups so we mask against overflows
+  // into other fields.
+  const uint64_t kStrideHi16Mask = (uint64_t)0xFFFFu;
+  if (rank >= 2) {
+    uint64_t s0 = strides[rank - 2];
+    desc->group1_5 = (uint32_t)s0;
+    desc->group1_6 = (uint32_t)((s0 >> 32) & kStrideHi16Mask);
+  }
   if (rank >= 3) {
-    desc->group1_6 = (strides[rank - 3] << 16);
-    desc->group1_7 = (strides[rank - 3] >> 16);
+    uint64_t s1 = strides[rank - 3];
+    desc->group1_6 |= (uint32_t)((s1 & 0xFFFFu) << 16);
+    desc->group1_7 = (uint32_t)((s1 >> 16) & 0xFFFFFFFFu);
   }
 
   // group2 (128 bits / 4 dwords) for 3D-5D tensors:
   // [31:0]:    tensor_dim2 (3rd dimension from end)
   // [63:32]:   tensor_dim3 (4th dimension from end)
-  // [111:64]:  tensor_dim2_stride (48 bits, we use 32 bits)
+  // [111:64]:  tensor_dim2_stride (48 bits)
   // [127:112]: tile_dim3
   if (rank >= 3) {
     desc->group2_0 = shape[rank - 3];
     if (rank >= 4) {
+      uint64_t s2 = strides[rank - 4];
       desc->group2_1 = shape[rank - 4];
-      desc->group2_2 = strides[rank - 4];
-      desc->group2_3 = (adjustedBlockSize[rank - 4] << 16);
+      desc->group2_2 = (uint32_t)s2;
+      desc->group2_3 = (uint32_t)((s2 >> 32) & kStrideHi16Mask);
+      desc->group2_3 |= (adjustedBlockSize[rank - 4] << 16);
     }
   }
 
   // group3 (128 bits / 4 dwords) for 4D-5D tensors:
-  // [47:0]:    tensor_dim3_stride (48 bits, we use 32 bits)
+  // [47:0]:    tensor_dim3_stride (48 bits)
   // [79:48]:   tensor_dim4 (5th dimension from end)
   // [95:80]:   tile_dim4
   // [127:96]:  reserved
   if (rank == 5) {
-    desc->group3_0 = strides[rank - 5];
-    desc->group3_1 = (shape[rank - 5] << 16);
+    uint64_t s3 = strides[rank - 5];
+    desc->group3_0 = (uint32_t)s3;
+    desc->group3_1 = (uint32_t)((s3 >> 32) & kStrideHi16Mask);
+    desc->group3_1 |= (shape[rank - 5] << 16);
     desc->group3_2 = (shape[rank - 5] >> 16);
     desc->group3_2 |= (adjustedBlockSize[rank - 5] << 16);
   }
@@ -534,7 +544,7 @@ static PyObject *createTDMDescriptor(PyObject *self, PyObject *args) {
 
   uint32_t blockSizeInt[5];
   uint32_t shapeInt[5];
-  uint32_t stridesInt[5];
+  uint64_t stridesInt64[5];
   int rank = 0;
 
   blockSizeFast = PySequence_Fast(blockSize, "blockSize must be a sequence");
@@ -583,10 +593,22 @@ static PyObject *createTDMDescriptor(PyObject *self, PyObject *args) {
   for (int i = 0; i < rank; ++i) {
     PyObject *item = PySequence_Fast_GET_ITEM(stridesFast, i);
     if (!PyLong_Check(item)) {
-      PyErr_SetString(PyExc_TypeError, "shape must be an int");
+      PyErr_SetString(PyExc_TypeError, "stride must be an int");
       goto cleanup;
     }
-    stridesInt[i] = PyLong_AsLong(item);
+    unsigned long long s = PyLong_AsUnsignedLongLong(item);
+    if (PyErr_Occurred()) {
+      goto cleanup;
+    }
+    const uint32_t kTdmStrideMaxBits = 48;
+    if (s >= (1ULL << kTdmStrideMaxBits)) {
+      PyErr_Format(PyExc_ValueError,
+                   "TDM tensor descriptor stride[%d] = %llu is too large, must "
+                   "fit into %u bits (max %llu)",
+                   i, s, kTdmStrideMaxBits, (1ULL << kTdmStrideMaxBits) - 1);
+      goto cleanup;
+    }
+    stridesInt64[i] = (uint64_t)s;
   }
 
   Py_DECREF(blockSizeFast);
@@ -599,7 +621,7 @@ static PyObject *createTDMDescriptor(PyObject *self, PyObject *args) {
   {
     bool success = encodeTDMDescriptor(
         &descObj->desc, elementBitWidth, blockSizeInt, numWarps, padInterval,
-        padAmount, shapeInt, stridesInt, globalAddress, rank);
+        padAmount, shapeInt, stridesInt64, globalAddress, rank);
     if (!success) {
       PyErr_SetString(PyExc_RuntimeError, "Failed to encode TDM descriptor");
       goto cleanup;

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -795,6 +795,33 @@ def AsyncTDMCopyGlobalToLocalOp : TT_AMDGPU_Op<"async_tdm_copy_global_to_local",
     swizzling.
     The operation can also take an optional 64bit LDS barrier address, in which case
     it sends an "LDS atomic arrive" to signal its completion.
+
+    `warp_used_hint` is an optional i32 bitmask performance hint for
+    partial TDM copy: bit `n` (LSB = warp 0) means warp `n` issues the
+    instruction; bits above `num_warps - 1` must be zero.  Same data
+    lands in shared memory either way -- only emission changes:
+    `K = popcount(hint)` warps cover the block, the rest are pred-off.
+
+    For "all warps participate", omit the attribute (preferred) or pass
+    a full bitmask `K = num_warps`; an explicit `warp_used_hint = 0` is
+    rejected by the verifier.
+
+    Restriction: the hint must be *axis-aligned*.  Pin some warpId bit
+    positions to fixed values and leave the others free; the active
+    warps are exactly those with the pinned bits set accordingly.
+    K = `popcount(hint)` is therefore a power of two (= 2^(number of
+    free bits)).  Legal: `0x0F` (warps 0..3), `0xF0` (warps 4..7),
+    `0x55` / `0xAA` / `0xCC` (stride-by-`2^j`).  Rejected: non
+    axis-aligned patterns like `0x69` or `0x1B`.
+
+    Why this shape: power-of-two K keeps the per-warp tile recalc
+    (`block / K`) integer-clean, and the bit-pinning shape lets the
+    per-warp offset and active-mask predicate fall out of the same
+    `getFreeVariableMasks` LL machinery the no-hint path uses.
+
+    PartitionedSharedEncoding additionally requires `K = popcount(hint)`
+    to be a multiple of `numLogicalPieces` (the hinted path doesn't
+    support multi-instruction slicing).
   }];
 
   let arguments = (ins
@@ -803,14 +830,28 @@ def AsyncTDMCopyGlobalToLocalOp : TT_AMDGPU_Op<"async_tdm_copy_global_to_local",
     Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$result,
     I32:$pred,
     Arg<Optional<TTG_MemDescType>, "", [MemWrite<SharedMemory>]>:$barrier,
-    DefaultValuedAttr<TT_CacheModifierAttr, "triton::CacheModifier::NONE">:$cache
+    DefaultValuedAttr<TT_CacheModifierAttr, "triton::CacheModifier::NONE">:$cache,
+    OptionalAttr<I32Attr>:$warp_used_hint
   );
 
   let results = (outs TTG_AsyncToken:$token);
 
   let builders = [
     OpBuilder<(ins "Value":$desc, "ValueRange":$indices, "Value":$result, "Value":$pred), [{
-      return build($_builder, $_state, desc, indices, result, pred, /*barrier=*/static_cast<mlir::Value>(nullptr));
+      return build($_builder, $_state, desc, indices, result, pred,
+                   /*barrier=*/static_cast<mlir::Value>(nullptr),
+                   /*cache=*/triton::CacheModifier::NONE,
+                   /*warp_used_hint=*/IntegerAttr());
+    }]>,
+    OpBuilder<(ins "Value":$desc, "ValueRange":$indices, "Value":$result, "Value":$pred, "Value":$barrier), [{
+      return build($_builder, $_state, desc, indices, result, pred, barrier,
+                   /*cache=*/triton::CacheModifier::NONE,
+                   /*warp_used_hint=*/IntegerAttr());
+    }]>,
+    OpBuilder<(ins "Value":$desc, "ValueRange":$indices, "Value":$result, "Value":$pred,
+                   "Value":$barrier, "::mlir::triton::CacheModifier":$cache), [{
+      return build($_builder, $_state, desc, indices, result, pred, barrier, cache,
+                   /*warp_used_hint=*/IntegerAttr());
     }]>
   ];
 

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -32,6 +32,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/FormatVariadic.h"
 #include <limits>
 
 // clang-format off
@@ -608,6 +609,62 @@ verifyBarrierType(Operation *op, mlir::triton::gpu::MemDescType barrierType) {
   return success();
 }
 
+namespace {
+// Validate `warp_used_hint` against the axis-aligned hint rule (see
+// TritonAMDGPUOps.td).  Encoding-specific rules (e.g.
+// PartitionedSharedEncoding) live in verify() since they need the result type.
+LogicalResult validateWarpUsedHint(AsyncTDMCopyGlobalToLocalOp op,
+                                   uint32_t hint, int64_t numWarps) {
+  if (!llvm::isPowerOf2_64(numWarps))
+    return op.emitOpError("num_warps must be a power of two when using "
+                          "warp_used_hint, got ")
+           << numWarps;
+
+  if (numWarps >= 32)
+    return op.emitOpError("num_warps must be less than 32 when using "
+                          "warp_used_hint, got ")
+           << numWarps;
+
+  if (hint == 0)
+    return op.emitOpError("warp_used_hint must have at least one bit set");
+
+  // Bits above num_warps - 1 must be zero (no warp at those positions).
+  uint32_t numWarpsMask = (uint32_t{1} << numWarps) - 1;
+  if ((hint & ~numWarpsMask) != 0)
+    return op.emitOpError("warp_used_hint = ")
+           << llvm::formatv("{0:x}", hint)
+           << " sets bits beyond num_warps = " << numWarps;
+
+  unsigned K = llvm::popcount(hint);
+  if (!llvm::isPowerOf2_32(K))
+    return op.emitOpError("popcount(warp_used_hint) = ")
+           << K << " must be a power of two (got hint "
+           << llvm::formatv("{0:x}", hint) << ")";
+
+  // Axis-aligned check.  Anchor at i0 = lsb(hint) and OR the shifted
+  // warp indices: `support` is the bits that vary across the active
+  // set.  Legal iff popcount(support) == log2(K) -- pigeonhole forces
+  // the K shifted indices to hit every subset of `support`, i.e. the
+  // active set is selectable by a single mask check.
+  unsigned i0 = llvm::countr_zero(hint);
+  uint32_t support = 0;
+  for (uint32_t mask = hint; mask != 0; mask &= mask - 1) {
+    unsigned w = llvm::countr_zero(mask);
+    support |= static_cast<uint32_t>(w ^ i0);
+  }
+  unsigned logK = llvm::Log2_32(K);
+  unsigned spanned = static_cast<unsigned>(llvm::popcount(support));
+  if (spanned != logK)
+    return op.emitOpError("warp_used_hint = ")
+           << llvm::formatv("{0:x}", hint) << " is not axis-aligned: K = " << K
+           << " active warps span " << spanned
+           << " warpId bit positions, but an axis-aligned hint "
+           << "spans exactly log2(K) = " << logK;
+
+  return success();
+}
+} // namespace
+
 LogicalResult AsyncTDMCopyGlobalToLocalOp::verify() {
   auto tensorDescTy = getDesc().getType();
   auto smemTy = getResult().getType();
@@ -674,6 +731,31 @@ LogicalResult AsyncTDMCopyGlobalToLocalOp::verify() {
       auto paddingInDwords = padding * elementBitWidth / dwordSize;
       if (paddingInDwords < 1)
         return emitOpError("TDM padding amount must be at least 1 dword");
+    }
+  }
+
+  if (auto warpUsedHintAttr = getWarpUsedHintAttr()) {
+    int numWarps = gpu::lookupNumWarps(*this);
+    uint32_t hint = static_cast<uint32_t>(warpUsedHintAttr.getInt());
+    if (failed(validateWarpUsedHint(*this, hint, numWarps)))
+      return failure();
+
+    // PartitionedSharedEncoding: hinted path = single instruction, so
+    // numLogicalPieces must divide K (equivalent to K >= numLogicalPieces
+    // since K is a power of two).
+    if (partitionedEnc) {
+      unsigned partitionDim = partitionedEnc.getPartitionDim();
+      unsigned numLogicalPieces = partitionedEnc.getNumLogicalPieces();
+      assert(numLogicalPieces > 0 &&
+             "PartitionedSharedEncoding must have numLogicalPieces >= 1");
+      unsigned K = llvm::popcount(hint);
+      if (K % numLogicalPieces != 0)
+        return emitOpError(
+                   "warp_used_hint with a partitioned shared encoding must "
+                   "select K active warps such that numLogicalPieces divides "
+                   "K so the copy fits in a single TDM instruction (got K = ")
+               << K << ", numLogicalPieces = " << numLogicalPieces
+               << ", partitionDim = " << partitionDim << ")";
     }
   }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
@@ -6,6 +6,8 @@ using namespace mlir;
 
 using ::mlir::triton::gpu::AMDWmmaEncodingAttr;
 using ::mlir::triton::gpu::getShapePerCTA;
+using ::mlir::triton::gpu::isPermutationMatrixLayout;
+using ::mlir::triton::gpu::toLinearLayout;
 
 namespace mlir::triton::AMD {
 LogicalResult convertAMDFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
@@ -39,18 +41,26 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
   matchAndRewrite(triton::DotOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // D = A * B + C
-    Value D = op.getResult();
+    auto dType = op.getD().getType();
+    auto dEncoding = dType.getEncoding();
 
-    auto dEncoding = cast<RankedTensorType>(D.getType()).getEncoding();
+    // WMMA is the only path that has been validated against non-permutation
+    // (e.g. swizzled-warp) encodings, so handle it up front and then enforce
+    // the permutation-matrix invariant for all other paths.
+    if (isa<AMDWmmaEncodingAttr>(dEncoding))
+      return AMD::convertWMMA(op, adaptor, getTypeConverter(), rewriter);
+
+    if (!isPermutationMatrixLayout(toLinearLayout(dType.getShape(), dEncoding)))
+      return rewriter.notifyMatchFailure(op,
+                                         "Non-WMMA DotOp result encoding must "
+                                         "have a permutation-matrix linear "
+                                         "layout");
+
     if (isa<AMDMfmaEncodingAttr>(dEncoding)) {
       return AMD::convertMFMA(op, adaptor, getTypeConverter(), rewriter);
     }
-    if (isa<AMDWmmaEncodingAttr>(dEncoding)) {
-      return AMD::convertWMMA(op, adaptor, getTypeConverter(), rewriter);
-    }
 
-    if (isa<BlockedEncodingAttr>(
-            cast<RankedTensorType>(D.getType()).getEncoding()))
+    if (isa<BlockedEncodingAttr>(dEncoding))
       return AMD::convertAMDFMADot(op, adaptor, getTypeConverter(), rewriter);
 
     llvm::report_fatal_error(
@@ -65,16 +75,19 @@ struct ScaledDotOpConversion
   LogicalResult
   matchAndRewrite(triton::DotScaledOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value D = op.getResult();
+    auto dType = op.getD().getType();
+    auto dEncoding = dType.getEncoding();
 
-    auto dEncoding = cast<RankedTensorType>(D.getType()).getEncoding();
-
-    if (isa<AMDMfmaEncodingAttr>(dEncoding)) {
-      return AMD::convertScaledMFMA(op, adaptor, getTypeConverter(), rewriter);
-    }
-    if (isa<AMDWmmaEncodingAttr>(dEncoding)) {
+    if (isa<AMDWmmaEncodingAttr>(dEncoding))
       return AMD::convertScaledWMMA(op, adaptor, getTypeConverter(), rewriter);
-    }
+
+    if (!isPermutationMatrixLayout(toLinearLayout(dType.getShape(), dEncoding)))
+      return rewriter.notifyMatchFailure(
+          op, "non-WMMA dot encoding must have a permutation-matrix linear "
+              "layout");
+
+    if (isa<AMDMfmaEncodingAttr>(dEncoding))
+      return AMD::convertScaledMFMA(op, adaptor, getTypeConverter(), rewriter);
 
     llvm::report_fatal_error(
         "Unsupported DotScaleOp found when converting TritonGPU to LLVM.");

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1318,6 +1318,10 @@ struct AsyncTDMCopyGlobalToLocalOpConversion
         cast<triton::gpu::SharedEncodingTrait>(encoding), shapePerCTA);
     bool isRowMajor = sharedOrder[0] == (sharedOrder.size() - 1);
 
+    std::optional<uint32_t> warpUsedHint;
+    if (auto hintAttr = op.getWarpUsedHintAttr())
+      warpUsedHint = static_cast<uint32_t>(hintAttr.getInt());
+
     auto cacheMod = op.getCache();
     auto auxBits = mlir::LLVM::AMD::getCtrlBitsForCacheModifierOnTarget(
         cacheMod, /*isLoad*/ true, targetInfo);
@@ -1326,7 +1330,7 @@ struct AsyncTDMCopyGlobalToLocalOpConversion
         rewriter, loc, getTypeConverter(), desc, shapePerCTA, numWarps,
         padInterval, padAmount, offset, dstPtrs, op.getPred(), multicastMask,
         elementType, barrierPtr, /*isLoad=*/true, sharedLayout, encoding, ctaId,
-        isRowMajor, auxBits);
+        isRowMajor, auxBits, warpUsedHint);
 
     rewriter.eraseOp(op);
     return success();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -294,39 +294,47 @@ decodeTDMDescriptorFull(RewriterBase &rewriter, Location loc,
   SmallVector<Value> tensorStride(numDims);
   SmallVector<Value> blockShape(numDims);
 
+  // Helper: combine a 32-bit low part and a 16-bit high part into an i64.
+  auto combine48 = [&](Value lo32, Value hi16InDword) -> Value {
+    Value hi16 = b.and_(hi16InDword, b.i32_val(0xFFFF));
+    return b.or_(b.zext(i64_ty, lo32),
+                 b.shl(b.zext(i64_ty, hi16), b.i64_val(32)));
+  };
+
   // Decode dimensions from the end (inner dimensions first)
   tensorShape[numDims - 1] = decode48BitValue(rewriter, b, group1, 1);
 
   if (numDims >= 2) {
     tensorShape[numDims - 2] = decode48BitValue(rewriter, b, group1, 2);
 
-    // Strides are loaded in opposite order of shapes
-    // tensor_dim0_stride from group1[5]
-    tensorStride[numDims - 2] = group1[5];
+    // tensor_dim0_stride: group1[5][0:32] | group1[6][0:16] (48 bits)
+    tensorStride[numDims - 2] = combine48(group1[5], group1[6]);
 
-    // tensor_dim1_stride is encoded in group1[6] (48-bit value across group1[6]
-    // and group1[7])
+    // tensor_dim1_stride: group1[6][16:32] | group1[7][0:32] (48 bits)
     if (numDims >= 3) {
       Value stride1Low =
           b.and_(b.lshr(group1[6], b.i32_val(16)), b.i32_val(0xFFFF));
-      Value stride1High = b.and_(group1[7], b.i32_val(0xFFFF));
+      Value stride1High = group1[7];
       tensorStride[numDims - 3] =
-          b.or_(stride1Low, b.shl(stride1High, b.i32_val(16)));
+          b.or_(b.zext(i64_ty, stride1Low),
+                b.shl(b.zext(i64_ty, stride1High), b.i64_val(16)));
     }
   }
 
-  // tensor_dim2_stride from group2[2]
+  // tensor_dim2_stride: group2[2][0:32] | group2[3][0:16] (48 bits)
   if (numDims >= 4) {
-    tensorStride[numDims - 4] = group2.value()[2];
+    tensorStride[numDims - 4] =
+        combine48(group2.value()[2], group2.value()[3]);
   }
 
-  // tensor_dim3_stride from group3[0]
+  // tensor_dim3_stride: group3[0][0:32] | group3[1][0:16] (48 bits)
   if (numDims == 5) {
-    tensorStride[numDims - 5] = group3.value()[0];
+    tensorStride[numDims - 5] =
+        combine48(group3.value()[0], group3.value()[1]);
   }
 
   // The innermost dimension always has stride 1
-  tensorStride[numDims - 1] = b.i32_val(1);
+  tensorStride[numDims - 1] = b.i64_val(1);
 
   // Block shapes from group1
   blockShape[numDims - 1] =
@@ -393,9 +401,16 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
   auto elementBitWidth = elementType.getIntOrFloatBitWidth();
   auto elementSizeInBytes = elementBitWidth / 8;
 
-  // Cast strides from i64 to i32
+  // Strides come in as i64; the descriptor's stride slots are 48 bits wide.
+  // Separate the low-32 and high-16 bits of the stride.
+  SmallVector<Value> tensorStrideLo32(numDims);
+  SmallVector<Value> tensorStrideHi16(numDims);
   for (size_t i = 0; i < numDims; ++i) {
-    tensorStride[i] = b.trunc(i32_ty, tensorStride[i]);
+    Value s = tensorStride[i];
+    assert(s.getType() == i64_ty && "Expected TDM stride to be i64.");
+    tensorStrideLo32[i] = b.trunc(i32_ty, s);
+    tensorStrideHi16[i] =
+        b.and_(b.trunc(i32_ty, b.lshr(s, b.i64_val(32))), b.i32_val(0xFFFF));
   }
 
   // Compute per-warp tile dimensions for the TDM descriptor.
@@ -508,13 +523,20 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
     group1[4] = b.or_(group1[4], b.i32_val(blockShape[numDims - 3] << 16));
   }
 
-  // Handle strides
+  // Handle strides (each slot is 48 bits: low-32 + high-16).
   if (numDims >= 2) {
-    group1[5] = tensorStride[numDims - 2];
+    group1[5] = tensorStrideLo32[numDims - 2];
+    Value g1_6 = tensorStrideHi16[numDims - 2];
     if (numDims >= 3) {
-      group1[6] = b.or_(group1[6], b.shl(tensorStride[numDims - 3], v16));
-      group1[7] = b.lshr(tensorStride[numDims - 3], v16);
+      g1_6 = b.or_(
+          g1_6,
+          b.shl(b.and_(tensorStrideLo32[numDims - 3], b.i32_val(0xFFFF)), v16));
+      Value stride1Hi32 =
+          b.or_(b.lshr(tensorStrideLo32[numDims - 3], v16),
+                b.shl(tensorStrideHi16[numDims - 3], b.i32_val(16)));
+      group1[7] = stride1Hi32;
     }
+    group1[6] = g1_6;
   }
 
   if (numDims <= 2) {
@@ -574,15 +596,11 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
     // tensor_dim3 (4th dimension from the end)
     if (numDims >= 4) {
       group2[1] = tensorShape[numDims - 4];
-      // tensor_dim2_stride (48 bits: lower 32 bits in group2[2], upper 16 bits
-      // in group2[3])
-      group2[2] = tensorStride[numDims - 4];
-    }
-
-    // tile_dim3 (upper 16 bits of group2[3])
-    if (numDims >= 4) {
-      group2[3] =
-          b.or_(group2[3], b.shl(b.i32_val(blockShape[numDims - 4]), v16));
+      // tensor_dim2_stride: group2[2][0:32] | group2[3][0:16] (48 bits)
+      group2[2] = tensorStrideLo32[numDims - 4];
+      Value g2_3 = b.or_(tensorStrideHi16[numDims - 4],
+                         b.shl(b.i32_val(blockShape[numDims - 4]), v16));
+      group2[3] = g2_3;
     }
   }
 
@@ -631,8 +649,9 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
     // tensor_dim4 (5th dimension from the end) (32 bits starting at bit 48:
     // upper 16 bits of group3[1] and lower 16 bits of group3[2])
     if (numDims == 5) {
-      // Lower 16 bits go into upper 16 bits of group3[1]
-      group3[1] = b.or_(group3[1], b.shl(tensorShape[numDims - 5], v16));
+      // group3[1] = tensor_dim3_stride high-16 | (tensor_dim4 low-16 << 16)
+      group3[1] = b.or_(tensorStrideHi16[numDims - 5],
+                        b.shl(tensorShape[numDims - 5], v16));
       // Upper 16 bits go into lower 16 bits of group3[2]
       group3[2] = b.or_(group3[2], b.lshr(tensorShape[numDims - 5], v16));
     }
@@ -641,7 +660,7 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
     if (numDims == 5) {
       // tensor_dim3_stride (4th dimension from the end) (48 bits split across
       // group3[0] and lower 16 bits of group3[1])
-      group3[0] = tensorStride[numDims - 5];
+      group3[0] = tensorStrideLo32[numDims - 5];
       group3[2] =
           b.or_(group3[2], b.shl(b.i32_val(blockShape[numDims - 5]), v16));
     }
@@ -766,9 +785,9 @@ void fillTDMDescriptor(
     offset[i] = b.add(offset[i], globalOffset[i]);
   }
 
-  Value baseOffset = b.i32_val(0);
+  Value baseOffset = b.i64_val(0);
   for (size_t i = 0; i < numDims; ++i) {
-    Value dimOffset = b.mul(offset[i], tensorStride[i]);
+    Value dimOffset = b.mul(b.sext(i64_ty, offset[i]), tensorStride[i]);
     baseOffset = b.add(baseOffset, dimOffset);
   }
   srcPtr = b.gep(globalPtrTy, elementType, srcPtr, baseOffset);
@@ -972,12 +991,15 @@ void fillTDMDescriptorForGatherScatter(
   auto kBlock = str_attr("block");
   auto cgaOffsets =
       applyLinearLayout(loc, rewriter, cgaLayout, {{kBlock, ctaId}});
-  Value cgaColOffset = b.mul(cgaOffsets[1].second, tensorStride[1]);
+  // tensorStride is i64 (48-bit slots); zext the i32 offsets before
+  // multiplying so we don't truncate to 32 bits.
+  Value cgaColOffset =
+      b.mul(b.zext(i64_ty, cgaOffsets[1].second), tensorStride[1]);
   globalPtr = b.gep(globalPtrTy, elementType, globalPtr, cgaColOffset);
 
   // For scatter, only apply column offset to global address
   // Row positions are specified by rowIndices
-  Value colOffset = b.mul(globalColOffset, tensorStride[1]);
+  Value colOffset = b.mul(b.zext(i64_ty, globalColOffset), tensorStride[1]);
   globalPtr = b.gep(globalPtrTy, elementType, globalPtr, colOffset);
 
   // Calculate LDS offset based on row offset only (column always starts at 0)
@@ -1510,7 +1532,8 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
   auto dot64 = [&](ArrayRef<Value> indices, ArrayRef<Value> strides) {
     Value ret = b.i64_val(0);
     for (auto [index, stride] : llvm::zip(indices, strides)) {
-      ret = b.add(ret, b.mul(b.zext(i64_ty, index), b.zext(i64_ty, stride)));
+      assert(stride.getType() == i64_ty && "Expected TDM stride to be i64.");
+      ret = b.add(ret, b.mul(b.zext(i64_ty, index), stride));
     }
     return ret;
   };
@@ -1521,7 +1544,7 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
 
   // Calculate the total tensor size for bounds checking.
   Value linearTensorSize =
-      b.mul(b.zext(i64_ty, tensorShape[0]), b.zext(i64_ty, tensorStride[0]));
+      b.mul(b.zext(i64_ty, tensorShape[0]), tensorStride[0]);
 
   // Calculate maximum allowed offset from tilePtr before going out of bounds
   Value maxOffsetFromTile = b.sub(linearTensorSize, tileOffset);
@@ -1548,7 +1571,7 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
 
   // Adjust the inner stride (always 1) to the number of elements per prefetch
   auto scaledStride = tensorStride;
-  scaledStride.back() = b.i32_val(elemPerPrefetch);
+  scaledStride.back() = b.i64_val(elemPerPrefetch);
 
   auto baseIndices = applyLinearLayout(loc, rewriter, ll,
                                        {{kRegister, b.i32_val(0)},

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -684,10 +684,13 @@ void fillTDMDescriptor(
     SmallVector<Value> offset, ArrayRef<Value> dstPtrs, Value pred,
     Value multicastMask, Value barrierPtr,
     const triton::LinearLayout &sharedLayout, Value ctaId, bool isStore,
-    bool isRowMajor, ArrayRef<unsigned> warpsPerCTA) {
+    bool isRowMajor, ArrayRef<unsigned> warpsPerCTA,
+    std::optional<uint32_t> warpUsedHint) {
   size_t numDims = offset.size();
   assert(numDims >= 1 && numDims <= 5 && "TDM supports 1D to 5D tensors.");
   assert(!dstPtrs.empty() && "dstPtrs cannot be empty");
+  assert(warpsPerCTA.size() == numDims &&
+         "warpsPerCTA must have one entry per tensor dim");
 
   auto ctx = rewriter.getContext();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -723,6 +726,12 @@ void fillTDMDescriptor(
               : std::nullopt,
           numDims);
 
+  SmallVector<int64_t> tileShape(numDims);
+  for (size_t i = 0; i < numDims; ++i) {
+    tileShape[i] = shapePerCTA[i] / static_cast<int64_t>(warpsPerCTA[i]);
+    decodedBlockShape[i] = b.i32_val(tileShape[i]);
+  }
+
   auto kMessage = str_attr("message");
   auto kWarp = str_attr("warp");
   auto kBlock = str_attr("block");
@@ -734,14 +743,21 @@ void fillTDMDescriptor(
                        .getCGALayout()
                        .getLinearLayout();
 
-  auto tdmLayout =
-      triton::gpu::getTDMLinearLayout(shapePerCTA, warpsPerCTA, cgaLayout);
+  auto tdmLayout = triton::gpu::getTDMLinearLayout(
+      shapePerCTA, warpsPerCTA, cgaLayout, numWarps, warpUsedHint);
 
   auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
 
+  Value warpIdShifted = warpId;
+  if (warpUsedHint) {
+    uint32_t firstActiveWarp = llvm::countr_zero(*warpUsedHint);
+    if (firstActiveWarp != 0)
+      warpIdShifted = b.xor_(warpId, b.i32_val(firstActiveWarp));
+  }
+
   auto warpOffset = applyLinearLayout(
       loc, rewriter, tdmLayout,
-      {{kMessage, b.i32_val(0)}, {kWarp, warpId}, {kBlock, ctaId}});
+      {{kMessage, b.i32_val(0)}, {kWarp, warpIdShifted}, {kBlock, ctaId}});
 
   // Extract per-dimension offsets and update input offsets
   SmallVector<Value> globalOffset(numDims);
@@ -760,7 +776,7 @@ void fillTDMDescriptor(
   auto tdmToShared = tdmLayout.invertAndCompose(tdmViewSharedLayout);
   auto sharedOffsets = applyLinearLayout(
       loc, rewriter, tdmToShared,
-      {{kMessage, b.i32_val(0)}, {kWarp, warpId}, {kBlock, ctaId}});
+      {{kMessage, b.i32_val(0)}, {kWarp, warpIdShifted}, {kBlock, ctaId}});
 
   // Extract the offset and partition index from the result
   Value dstOffset = b.i32_val(0);
@@ -824,9 +840,7 @@ void fillTDMDescriptor(
   // This leverages HW OOB checking to skip padding elements while
   // preserving the original tensor shape if smaller. Note that the pre
   // conditions are checked in the verifier already
-  bool adjustedBlockShape = false;
   if (isStore && padInterval > 0 && padAmount > 0) {
-    adjustedBlockShape = true;
     Value originalTileDim0 = decodedBlockShape[numDims - 1];
 
     // Adjust block shape (tile dimension) to include padding
@@ -842,6 +856,15 @@ void fillTDMDescriptor(
   // Update group0 with addresses
   Value globalAddr = b.ptrtoint(i64_ty, srcPtr);
   Value ldsAddr = b.ptrtoint(i32_ty, dstPtr);
+
+  int32_t warpFreeMask = tdmLayout.getFreeVariableMasks().lookup(kWarp);
+  if (warpFreeMask != 0) {
+    Value isActive = b.icmp_eq(
+        b.and_(warpIdShifted, b.i32_val(warpFreeMask)), b.i32_val(0));
+    Value layoutPred = b.select(isActive, b.i32_val(1), b.i32_val(0));
+    pred = b.and_(pred, layoutPred);
+  }
+
   group0[0] = pred;
   group0[1] = ldsAddr;
   group0[2] = b.trunc(i32_ty, globalAddr);
@@ -873,12 +896,29 @@ void fillTDMDescriptor(
     group1[0] = b.and_(group1[0], b.i32_val(0xFFFBFFFF));
   }
 
-  if (adjustedBlockShape) {
-    // Re-encode the adjusted tile_dim0 (block shape) into upper 16 bits of
-    // group1[3]. This is the same for 1D-5D tensors.
-    group1[3] = b.and_(group1[3], b.i32_val(0xFFFF));
-    group1[3] =
-        b.or_(group1[3], b.shl(decodedBlockShape[numDims - 1], b.i32_val(16)));
+  // Re-encode tile_dim0..4 against the selected warp distribution.
+  group1[3] = b.and_(group1[3], b.i32_val(0xFFFF));
+  group1[3] =
+      b.or_(group1[3], b.shl(decodedBlockShape[numDims - 1], b.i32_val(16)));
+  if (numDims >= 2) {
+    group1[4] = decodedBlockShape[numDims - 2];
+    if (numDims >= 3)
+      group1[4] =
+          b.or_(group1[4], b.shl(decodedBlockShape[numDims - 3], b.i32_val(16)));
+  }
+  if (numDims >= 4) {
+    group2.value().get()[3] =
+        b.and_(group2.value().get()[3], b.i32_val(0xFFFF));
+    group2.value().get()[3] =
+        b.or_(group2.value().get()[3],
+              b.shl(decodedBlockShape[numDims - 4], b.i32_val(16)));
+  }
+  if (numDims == 5) {
+    group3.value().get()[2] =
+        b.and_(group3.value().get()[2], b.i32_val(0xFFFF));
+    group3.value().get()[2] =
+        b.or_(group3.value().get()[2],
+              b.shl(decodedBlockShape[numDims - 5], b.i32_val(16)));
   }
 
   // Update group2/group3 for higher dimensions
@@ -1117,7 +1157,8 @@ static void emitTDMIntrinsic(
     SmallVector<Value> globalOffset, ArrayRef<Value> instrDstPtrs, Value pred,
     Value multicastMask, Value barrier,
     const triton::LinearLayout &instrSharedLayout, Value ctaId, bool isLoad,
-    bool isRowMajor, ArrayRef<unsigned> warpsPerCTA, int32_t auxBits) {
+    bool isRowMajor, ArrayRef<unsigned> warpsPerCTA, int32_t auxBits,
+    std::optional<uint32_t> warpUsedHint = std::nullopt) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   auto v8i32Ty = VectorType::get(8, rewriter.getI32Type());
   Value group4Zero = LLVM::ZeroOp::create(rewriter, loc, v8i32Ty);
@@ -1133,7 +1174,7 @@ static void emitTDMIntrinsic(
                       group0Vec, group1Vec, std::ref(group2Vec),
                       std::ref(group3Vec), globalOffset, instrDstPtrs, pred,
                       multicastMask, barrier, instrSharedLayout, ctaId, !isLoad,
-                      isRowMajor, warpsPerCTA);
+                      isRowMajor, warpsPerCTA, warpUsedHint);
 
     auto group0 = packLLVector(loc, group0Vec, rewriter);
     auto group1 = packLLVector(loc, group1Vec, rewriter);
@@ -1153,7 +1194,8 @@ static void emitTDMIntrinsic(
         rewriter, loc, typeConverter, elementType, effectiveBlockShape,
         numWarps, padInterval, padAmount, group0Vec, group1Vec, std::nullopt,
         std::nullopt, globalOffset, instrDstPtrs, pred, multicastMask, barrier,
-        instrSharedLayout, ctaId, !isLoad, isRowMajor, warpsPerCTA);
+        instrSharedLayout, ctaId, !isLoad, isRowMajor, warpsPerCTA,
+        warpUsedHint);
 
     auto group0 = packLLVector(loc, group0Vec, rewriter);
     auto group1 = packLLVector(loc, group1Vec, rewriter);
@@ -1186,16 +1228,22 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
                       Value barrierPtr, bool isLoad,
                       const triton::LinearLayout &sharedLayout,
                       Attribute encoding, Value ctaId, bool isRowMajor,
-                      int32_t auxBits) {
+                      int32_t auxBits,
+                      std::optional<uint32_t> warpUsedHint) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   size_t numDims = blockShape.size();
   assert(numDims <= 5);
 
   auto partitionedEnc = dyn_cast<PartitionedSharedEncodingAttr>(encoding);
 
+  int effectiveWarps = warpUsedHint ? llvm::popcount(*warpUsedHint) : numWarps;
+
   // Compute warp distribution -- partition-aligned when needed.
   auto [warpsPerCTA, numTDMInstructions] =
-      distributeTDMWarpsAlignToPartition(blockShape, numWarps, encoding);
+      distributeTDMWarpsAlignToPartition(blockShape, effectiveWarps, encoding);
+  assert((!warpUsedHint || numTDMInstructions == 1) &&
+         "verifier should guarantee single-instruction emission for the "
+         "hinted path");
 
   // Fast path: single instruction covers the entire block.
   if (numTDMInstructions == 1) {
@@ -1203,7 +1251,7 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
                      to_vector(blockShape), numWarps, padInterval, padAmount,
                      to_vector(offset), dstPtrs, pred, multicastMask,
                      barrierPtr, sharedLayout, ctaId, isLoad, isRowMajor,
-                     warpsPerCTA, auxBits);
+                     warpsPerCTA, auxBits, warpUsedHint);
     return;
   }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
@@ -67,6 +67,8 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
 // address and pred in a given TDM descriptor for regular load/store (1D-5D).
 // For partitioned shared memory, dstPtrs contains multiple base pointers and
 // the correct one is selected based on sharedLayout's partition dimension.
+// `warpUsedHint` selects an axis-aligned subset of active warps; see
+// TritonAMDGPUOps.td.
 void fillTDMDescriptor(
     RewriterBase &rewriter, Location loc,
     const LLVMTypeConverter *typeConverter, Type elementType,
@@ -77,7 +79,8 @@ void fillTDMDescriptor(
     SmallVector<Value> offset, ArrayRef<Value> dstPtrs, Value pred,
     Value multicastMask, Value barrierPtr,
     const triton::LinearLayout &sharedLayout, Value ctaId, bool isStore,
-    bool isRowMajor, ArrayRef<unsigned> warpsPerCTA);
+    bool isRowMajor, ArrayRef<unsigned> warpsPerCTA,
+    std::optional<uint32_t> warpUsedHint = std::nullopt);
 
 // Fill TDM descriptor for gather/scatter operations (2D only).
 // Gather reads from non-contiguous rows in global memory to LDS.
@@ -103,7 +106,8 @@ void fillTDMDescriptorForGatherScatter(
 // the warp distribution is adjusted so each wave's tile fits within a single
 // LDS partition.  If the warps cannot cover all logical pieces in one
 // instruction, the operation is automatically split into multiple sequential
-// TDM instructions.
+// TDM instructions. A warp hint guarantees single-instruction emission; see
+// TritonAMDGPUOps.td.
 //
 // - offset: starting position in global memory for each dimension
 // - dstPtrs: base pointers to LDS (multiple for partitioned encoding)
@@ -119,7 +123,8 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
                       Value barrierPtr, bool isLoad,
                       const triton::LinearLayout &sharedLayout,
                       Attribute encoding, Value ctaId, bool isRowMajor,
-                      int32_t auxBits);
+                      int32_t auxBits,
+                      std::optional<uint32_t> warpUsedHint = std::nullopt);
 
 // Returns (warpsPerCTA, numTDMInstructions) for a given shared encoding.
 // For PartitionedSharedEncodingAttr, computes a partition-aligned warp

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -373,29 +373,6 @@ static bool warpReduceSwap16or32(RewriterBase &rewriter, Location loc,
   return true;
 }
 
-static bool warpReduceSwap16(RewriterBase &rewriter, Location loc,
-                             SmallVector<Value> &acc, triton::ReduceOp op,
-                             unsigned numLaneToReduce, unsigned interleave) {
-  Operation *reduxOp = op.getSingleCombiner();
-  if (!reduxOp)
-    return false;
-
-  bool mfma16Case = numLaneToReduce == 2 && interleave == 16;
-  if (!mfma16Case)
-    return false;
-
-  Value val = acc[0];
-  unsigned bits = val.getType().getIntOrFloatBitWidth();
-  if (bits > 32)
-    return false;
-
-  StringRef intrinsic = "llvm.amdgcn.permlane16.swap";
-  for (auto i = 0; i < acc.size(); i++) {
-    acc[i] = permuteAndReduce(rewriter, loc, intrinsic, acc[i], reduxOp);
-  }
-  return true;
-}
-
 bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
                             SmallVector<Value> &acc, triton::ReduceOp op,
                             unsigned numLaneToReduce,
@@ -404,9 +381,6 @@ bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
 
   if (getISAFamily() == ISAFamily::CDNA4 &&
       warpReduceSwap16or32(rewriter, loc, acc, op, numLaneToReduce, interleave))
-    return true;
-  if ((getISAFamily() == ISAFamily::GFX1250) &&
-      warpReduceSwap16(rewriter, loc, acc, op, numLaneToReduce, interleave))
     return true;
   if (numLaneToReduce != getWarpSize())
     return false;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -28,7 +28,7 @@ enum class ShflKind : uint32_t {
 
 Value emitDpp(Location loc, RewriterBase &rewriter, Value old, Value src,
               DppCtrl dppCtrl, uint32_t rowMask = 0xf, uint32_t bankMask = 0xf,
-              bool boundCtrl = false) {
+              bool boundCtrl = true) {
   return ROCDL::DPPUpdateOp::create(
       rewriter, loc, src.getType(), old, src,
       rewriter.getI32IntegerAttr(static_cast<uint32_t>(dppCtrl)),
@@ -53,6 +53,25 @@ Value emitPermlaneX16Xor(Location loc, RewriterBase &rewriter, Value val,
   Value hiSel = b.i32_val(buildSelectorMask(8));
   return ROCDL::PermlaneX16Op::create(rewriter, loc, val.getType(), val, val,
                                       loSel, hiSel, true, false);
+}
+
+Value emitPermlaneSwapXor(Location loc, RewriterBase &rewriter, Value val,
+                          uint32_t laneMask) {
+  assert((laneMask == 16 || laneMask == 32) && "Expected a power of 2 mask");
+  assert(val.getType().isInteger(32) && "permlane_swap operates on i32 values");
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  MLIRContext *ctx = rewriter.getContext();
+  const char *intrinsic = laneMask == 32 ? "llvm.amdgcn.permlane32.swap"
+                                         : "llvm.amdgcn.permlane16.swap";
+  Type retTy = struct_ty({i32_ty, i32_ty});
+  Value f = b.false_val();
+  Value perm = LLVM::createLLVMIntrinsicCallOp(rewriter, loc, intrinsic, retTy,
+                                               ValueRange{val, val, f, f})
+                   ->getResult(0);
+  Value v0 = b.extract_val(i32_ty, perm, 0);
+  Value v1 = b.extract_val(i32_ty, perm, 1);
+  Value isOriginalVal = b.icmp_eq(v0, val);
+  return b.select(isOriginalVal, v1, v0);
 }
 
 Value shuffleCommonImpl(Location loc, RewriterBase &rewriter,
@@ -141,6 +160,7 @@ Value shuffleCommonImpl(Location loc, RewriterBase &rewriter,
         ctrlBits |= (lane ^ quadMask) << (lane * 2);
       return static_cast<DppCtrl>(ctrlBits);
     };
+    bool usePermlaneSwap = isaFamily == ISAFamily::CDNA4 && (mask & 0x30);
 
     if (isRDNA(isaFamily) || isaFamily == ISAFamily::GFX1250) {
       if (mask < 16)
@@ -149,7 +169,7 @@ Value shuffleCommonImpl(Location loc, RewriterBase &rewriter,
       else if (mask < 32)
         return emitPermlaneX16Xor(loc, rewriter, val, mask & 0xf);
     } else if ((isCDNA(isaFamily) || isaFamily == ISAFamily::GCN5_1) &&
-               mask < 16) {
+               (mask < 16 || usePermlaneSwap)) {
       Value result = val;
       uint32_t highBitsDppBasis = 0;
 
@@ -158,7 +178,7 @@ Value shuffleCommonImpl(Location loc, RewriterBase &rewriter,
       if (mask & 8)
         highBitsDppBasis ^= 8;
 
-      uint32_t quadMask = mask ^ highBitsDppBasis;
+      uint32_t quadMask = (mask & 0xf) ^ highBitsDppBasis;
 
       if (highBitsDppBasis) {
         DppCtrl highBitsDppCtrl;
@@ -179,6 +199,13 @@ Value shuffleCommonImpl(Location loc, RewriterBase &rewriter,
       if (quadMask) {
         result =
             emitDpp(loc, rewriter, result, result, makeQuadPermCtrl(quadMask));
+      }
+
+      if (usePermlaneSwap) {
+        if (mask & 16)
+          result = emitPermlaneSwapXor(loc, rewriter, result, 16);
+        if (mask & 32)
+          result = emitPermlaneSwapXor(loc, rewriter, result, 32);
       }
       return result;
     } else {

--- a/third_party/amd/python/examples/gluon/f16_gemm_warp_pipeline_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_gemm_warp_pipeline_gfx1250.py
@@ -12,6 +12,7 @@ try:
         create_shared_layouts,
         create_tensor_descriptors,
         issue_loads,
+        issue_wmma,
         lds_load,
         issue_wmma_compute,
     )
@@ -21,6 +22,7 @@ except ImportError:
         create_shared_layouts,
         create_tensor_descriptors,
         issue_loads,
+        issue_wmma,
         lds_load,
         issue_wmma_compute,
     )
@@ -96,7 +98,97 @@ def gemm_tdm_pipelined_warp_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
     offs_cn = pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, WMMA_LAYOUT))
     offs_c = stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
     mask_c = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    ttgl.store(c_ptr + offs_c, accumulator, mask=mask_c)
+    ttgl.amd.gfx1250.buffer_store(accumulator, c_ptr, offs_c, mask=mask_c)
+
+
+# ---------------------------------------------------------------------------
+# Partial TDM copy variant: only a subset of warps issue TDM copies.
+# Cleared warps get pred=0 (hardware no-op), freeing TDM bandwidth.
+# ---------------------------------------------------------------------------
+
+
+@gluon.jit
+def issue_loads_predicated(producer, a_desc, b_desc, off_am, off_bn, a_buffer, b_buffer, BLOCK_K: ttgl.constexpr,
+                           NUM_BUFFERS: ttgl.constexpr, TRANSPOSE_B: ttgl.constexpr,
+                           TDM_WARP_USED_HINT: ttgl.constexpr):
+    ttgl.amd.gfx1250.tdm.async_load(a_desc, [off_am, producer * BLOCK_K], a_buffer.index(producer % NUM_BUFFERS),
+                                    warp_used_hint=TDM_WARP_USED_HINT)
+    if not TRANSPOSE_B:
+        ttgl.amd.gfx1250.tdm.async_load(b_desc, [producer * BLOCK_K, off_bn], b_buffer.index(producer % NUM_BUFFERS),
+                                        warp_used_hint=TDM_WARP_USED_HINT)
+    else:
+        ttgl.amd.gfx1250.tdm.async_load(b_desc, [off_bn, producer * BLOCK_K], b_buffer.index(producer % NUM_BUFFERS),
+                                        warp_used_hint=TDM_WARP_USED_HINT)
+    producer += 1
+    return producer
+
+
+@gluon.jit
+def gemm_tdm_predicated_pipelined_warp_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
+                                                        M, N, K,  #
+                                                        stride_am, stride_ak,  #
+                                                        stride_bk, stride_bn,  #
+                                                        stride_cm, stride_cn,  #
+                                                        BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr,
+                                                        BLOCK_K: ttgl.constexpr,  #
+                                                        NUM_BUFFERS: ttgl.constexpr,  #
+                                                        TRANSPOSE_B: ttgl.constexpr,  #
+                                                        WARP_BASES: ttgl.constexpr,  #
+                                                        TDM_WARP_USED_HINT: ttgl.constexpr):
+    a_dtype: ttgl.constexpr = a_ptr.type.element_ty
+    b_dtype: ttgl.constexpr = b_ptr.type.element_ty
+    ttgl.static_assert(a_dtype.is_fp16() or a_dtype.is_bf16(), "Only fp16/bf16 supported for A")
+    ttgl.static_assert(b_dtype.is_fp16() or b_dtype.is_bf16(), "Only fp16/bf16 supported for B")
+    ttgl.static_assert(NUM_BUFFERS >= 2, "NUM_BUFFERS must be at least 2")
+
+    WMMA_LAYOUT: ttgl.constexpr = ttgl.amd.AMDWMMALayout(3, True, WARP_BASES, [], [16, 16, 32])
+
+    shared_layouts: ttgl.constexpr = create_shared_layouts(BLOCK_M, BLOCK_N, BLOCK_K, TRANSPOSE_B)
+    SHARED_LAYOUT_A: ttgl.constexpr = shared_layouts[0]
+    SHARED_LAYOUT_B: ttgl.constexpr = shared_layouts[1]
+    OPERAND_LAYOUT_A: ttgl.constexpr = ttgl.DotOperandLayout(0, WMMA_LAYOUT, 8)
+    OPERAND_LAYOUT_B: ttgl.constexpr = ttgl.DotOperandLayout(1, WMMA_LAYOUT, 8)
+
+    pid = ttgl.program_id(axis=0)
+    num_pid_m = ttgl.cdiv(M, BLOCK_M)
+    pid_m = pid % num_pid_m
+    pid_n = pid // num_pid_m
+
+    a_desc, b_desc = create_tensor_descriptors(a_ptr, b_ptr, pid_m * BLOCK_M * stride_am, pid_n * BLOCK_N * stride_bn,
+                                               stride_am, stride_ak, stride_bn, stride_bk, SHARED_LAYOUT_A,
+                                               SHARED_LAYOUT_B, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, TRANSPOSE_B)
+    a_buffer = ttgl.allocate_shared_memory(a_desc.dtype, shape=[NUM_BUFFERS] + a_desc.block_shape, layout=a_desc.layout)
+    b_buffer = ttgl.allocate_shared_memory(b_desc.dtype, shape=[NUM_BUFFERS] + b_desc.block_shape, layout=b_desc.layout)
+
+    producer = 0
+    consumer = 0
+    accumulator = ttgl.zeros((BLOCK_M, BLOCK_N), dtype=c_ptr.type.element_ty, layout=WMMA_LAYOUT)
+
+    for _ in ttgl.static_range(2):
+        producer = issue_loads_predicated(producer, a_desc, b_desc, 0, 0, a_buffer, b_buffer, BLOCK_K, NUM_BUFFERS,
+                                          TRANSPOSE_B, TDM_WARP_USED_HINT)
+
+    ttgl.amd.gfx1250.tdm.async_wait(1 * 2)
+    for _ in range(0, ttgl.cdiv(K, BLOCK_K) - (NUM_BUFFERS - 1)):
+        with ttgl.amd.warp_pipeline_stage("stage0", priority=1):
+            consumer, a, b = lds_load(consumer, a_buffer, OPERAND_LAYOUT_A, b_buffer, OPERAND_LAYOUT_B, NUM_BUFFERS,
+                                      TRANSPOSE_B)
+            producer = issue_loads_predicated(producer, a_desc, b_desc, 0, 0, a_buffer, b_buffer, BLOCK_K, NUM_BUFFERS,
+                                              TRANSPOSE_B, TDM_WARP_USED_HINT)
+        with ttgl.amd.warp_pipeline_stage("stage1", priority=0):
+            accumulator = issue_wmma_compute(a, b, accumulator)
+        ttgl.amd.gfx1250.tdm.async_wait(2)
+
+    for i in ttgl.static_range(NUM_BUFFERS - 1):
+        ttgl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1 - i) * 2)
+        consumer, accumulator = issue_wmma(consumer, a_buffer, OPERAND_LAYOUT_A, b_buffer, OPERAND_LAYOUT_B,
+                                           accumulator, (NUM_BUFFERS - 2 - i) * 2, NUM_BUFFERS, TRANSPOSE_B)
+
+    offs_cm = pid_m * BLOCK_M + ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, WMMA_LAYOUT))
+    offs_cn = pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, WMMA_LAYOUT))
+    offs_c = stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    mask_c = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    ttgl.amd.gfx1250.buffer_store(accumulator, c_ptr, offs_c, mask=mask_c)
 
 
 # ---------------------------------------------------------------------------
@@ -184,7 +276,12 @@ def gemm_tdm_pipelined_warp_pipelined_kernelB(a_ptr, b_ptr, c_ptr,  #
     offs_cn = pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, WMMA_LAYOUT))
     offs_c = stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
     mask_c = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    ttgl.store(c_ptr + offs_c, accumulator, mask=mask_c)
+    ttgl.amd.gfx1250.buffer_store(accumulator, c_ptr, offs_c, mask=mask_c)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K", [(256, 256, 64)])
@@ -242,6 +339,61 @@ def test_runtime_gemm_tdm_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRAN
         print("Done.")
 
 
+@pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K", [(256, 256, 64)])
+@pytest.mark.parametrize("NUM_BUFFERS", [3])
+@pytest.mark.parametrize("TRANSPOSE_B", [True])
+@pytest.mark.parametrize("M,N,K", [(2048, 2048, 2048)])
+@pytest.mark.parametrize("DUMP", [False])
+def test_runtime_gemm_tdm_predicated_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRANSPOSE_B, M, N, K, DUMP):
+    if triton.cdiv(K, BLOCK_K) < NUM_BUFFERS:
+        pytest.skip("Skip tests where K/BLOCK_K < NUM_BUFFERS")
+
+    torch.manual_seed(42)
+
+    a = torch.randn((M, K), dtype=torch.float16)
+    b = torch.randn((K, N), dtype=torch.float16)
+    if TRANSPOSE_B:
+        b = b.T.contiguous()
+    c = torch.zeros((M, N), dtype=torch.float32)
+    stride_am, stride_ak = a.stride(0), a.stride(1)
+    stride_bk, stride_bn = (b.stride(0), b.stride(1)) if not TRANSPOSE_B else (b.stride(1), b.stride(0))
+    stride_cm, stride_cn = c.stride(0), c.stride(1)
+
+    a_device = a.cuda()
+    b_device = b.cuda()
+    c_device = c.cuda()
+
+    # warpsPerCTA = [4, 2]
+    num_warps = 8
+    WARP_BASES = [(0, 1), (1, 0), (2, 0)]
+
+    # 4-warp partial TDM copy: warps 0-3 issue, warps 4-7 are no-ops.
+    tdm_warp_used_hint = 0b00001111
+
+    warp_bases = tuple(WARP_BASES)
+    grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N), 1)
+    kernel = gemm_tdm_predicated_pipelined_warp_pipelined_kernel[grid](
+        a_device, b_device, c_device,  #
+        M, N, K,  #
+        stride_am, stride_ak,  #
+        stride_bk, stride_bn,  #
+        stride_cm, stride_cn,  #
+        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,  #
+        NUM_BUFFERS=NUM_BUFFERS, TRANSPOSE_B=TRANSPOSE_B, WARP_BASES=warp_bases,  #
+        TDM_WARP_USED_HINT=tdm_warp_used_hint, num_warps=num_warps, waves_per_eu=num_warps // 4)
+    static_profile(kernel)
+
+    c_triton = c_device.cpu()
+    c_torch = a.to(torch.float32) @ (b.to(torch.float32) if not TRANSPOSE_B else b.T.to(torch.float32))
+    torch.testing.assert_close(c_triton, c_torch, rtol=1e-4, atol=1e-4)
+    if DUMP:
+        print("triton")
+        print(c_triton)
+        print("torch")
+        print(c_torch)
+        print("Done.")
+
+
 if __name__ == "__main__":
     import argparse
 
@@ -250,6 +402,8 @@ if __name__ == "__main__":
     parser.add_argument("-N", type=int, default=256, help='problem N size')
     parser.add_argument("-K", type=int, default=1024, help='problem K size')
     parser.add_argument("--num-buffers", type=int, choices=[2, 3, 4], default=3, help='num shared memory buffers')
+    parser.add_argument("--4warp-tdm", action="store_true", dest="four_warp_tdm",
+                        help="Use 4-warp partial TDM copy (warps 4-7 skip TDM copies)")
     parser.add_argument("--dump", action="store_true", help="Print out result/golden tensors")
     parser.add_argument("--kernelB", action="store_true", help="Use the kernelB variant")
     args = parser.parse_args()
@@ -265,4 +419,8 @@ if __name__ == "__main__":
         f"({M=}, {N=}, {K=}), ({BLOCK_M=}, {BLOCK_N=}, {BLOCK_K=}), {TRANSPOSE_B=}, {NUM_WARPS=}, {NUM_BUFFERS=}, {USE_KERNEL_B=}"
     )
 
-    test_runtime_gemm_tdm_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRANSPOSE_B, M, N, K, DUMP, USE_KERNEL_B)
+    if args.four_warp_tdm:
+        test_runtime_gemm_tdm_predicated_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRANSPOSE_B, M, N, K, DUMP)
+    else:
+        test_runtime_gemm_tdm_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRANSPOSE_B, M, N, K, DUMP,
+                                        USE_KERNEL_B)

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -393,7 +393,8 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
                                 stride_bk, stride_bn,  #
                                 stride_cm, stride_cn,  #
                                 BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr, BLOCK_K: ttgl.constexpr,  #
-                                NUM_BUFFERS: ttgl.constexpr, USE_TDM: ttgl.constexpr, IS_B_K_CONTIG: ttgl.constexpr):
+                                NUM_BUFFERS: ttgl.constexpr, USE_TDM: ttgl.constexpr, IS_B_K_CONTIG: ttgl.constexpr,
+                                RESOLVE_PARTITION_CONFLICTS: ttgl.constexpr):
     a_dtype: ttgl.constexpr = a_ptr.type.element_ty
     b_dtype: ttgl.constexpr = b_ptr.type.element_ty
     ttgl.static_assert(a_dtype.is_fp16() or a_dtype.is_bf16(), "Only fp16/bf16 supported for A")
@@ -401,19 +402,24 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
     ttgl.static_assert(NUM_BUFFERS >= 2, "NUM_BUFFERS must be at least 2")
 
     BLOCKED_LAYOUT: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [4, 8], [4, 1], [1, 0])
+
+    padded_a: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[BLOCK_K, 8]], [BLOCK_M, BLOCK_K], [1, 0])
     if IS_B_K_CONTIG:
-        BLOCKED_LAYOUT_B: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [4, 8], [4, 1], [1, 0])
+        padded_b: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[BLOCK_K, 8]], [BLOCK_N, BLOCK_K], [1, 0])
     else:
-        BLOCKED_LAYOUT_B: ttgl.constexpr = ttgl.BlockedLayout([8, 1], [8, 4], [1, 4], [0, 1])
-    WMMA_LAYOUT: ttgl.constexpr = ttgl.amd.AMDWMMALayout(3, True, [[0, 1], [1, 0]], [], [16, 16, 32])
-    SHARED_LAYOUT_A: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[BLOCK_K, 8]], [BLOCK_M, BLOCK_K],
-                                                                                [1, 0])
-    if IS_B_K_CONTIG:
-        SHARED_LAYOUT_B: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[BLOCK_N, 8]], [BLOCK_K, BLOCK_N],
-                                                                                    [1, 0])
+        padded_b: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[BLOCK_N, 8]], [BLOCK_K, BLOCK_N], [1, 0])
+
+    if RESOLVE_PARTITION_CONFLICTS:
+        # The padded layouts above are reinterpreted as per-piece sublayouts here.
+        _DOT_LAYOUTS: ttgl.constexpr = ttgl.amd.gfx1250.make_partitioned_dot_layouts(
+            BLOCK_M, BLOCK_N, padded_a, padded_b, 4, [16, 16, 32], a_transposed=False, b_transposed=IS_B_K_CONTIG)
     else:
-        SHARED_LAYOUT_B: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[BLOCK_K, 8]], [BLOCK_K, BLOCK_N],
-                                                                                    [0, 1])
+        _DOT_LAYOUTS: ttgl.constexpr = (padded_a, padded_b,
+                                        ttgl.amd.AMDWMMALayout(3, True, [[0, 1], [1, 0]], [], [16, 16, 32]))
+    SHARED_LAYOUT_A: ttgl.constexpr = _DOT_LAYOUTS[0]
+    SHARED_LAYOUT_B: ttgl.constexpr = _DOT_LAYOUTS[1]
+    WMMA_LAYOUT: ttgl.constexpr = _DOT_LAYOUTS[2]
+
     OPERAND_LAYOUT_A: ttgl.constexpr = ttgl.DotOperandLayout(0, WMMA_LAYOUT, 8)
     OPERAND_LAYOUT_B: ttgl.constexpr = ttgl.DotOperandLayout(1, WMMA_LAYOUT, 8)
 
@@ -429,21 +435,38 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
         strides=(stride_am, stride_ak),  #
         block_shape=(BLOCK_M, BLOCK_K),  #
         layout=SHARED_LAYOUT_A)
-    b_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(  #
-        base=b_ptr + pid_n * BLOCK_N * stride_bn,  #
-        shape=(K, N),  #
-        strides=(stride_bk, stride_bn),  #
-        block_shape=(BLOCK_K, BLOCK_N),  #
-        layout=SHARED_LAYOUT_B)
+    if IS_B_K_CONTIG:
+        # TDM always needs the most-minor dimension to be contiguous, so for K-contiguous B we
+        # describe the tile as (BLOCK_N, BLOCK_K) and permute it before the dot.
+        b_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(  #
+            base=b_ptr + pid_n * BLOCK_N * stride_bn,  #
+            shape=(N, K),  #
+            strides=(stride_bn, stride_bk),  #
+            block_shape=(BLOCK_N, BLOCK_K),  #
+            layout=SHARED_LAYOUT_B)
+    else:
+        b_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(  #
+            base=b_ptr + pid_n * BLOCK_N * stride_bn,  #
+            shape=(K, N),  #
+            strides=(stride_bk, stride_bn),  #
+            block_shape=(BLOCK_K, BLOCK_N),  #
+            layout=SHARED_LAYOUT_B)
 
     # Pointers for AsyncCopy
     offs_ak = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT))
     offs_am = (pid_m * BLOCK_M + ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, BLOCKED_LAYOUT))) % M
     a_ptrs = a_ptr + offs_am[:, None] * stride_am + offs_ak[None, :] * stride_ak
 
-    offs_bk = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(1, BLOCKED_LAYOUT_B))
-    offs_bn = (pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT_B))) % N
-    b_ptrs = b_ptr + offs_bk[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+    if IS_B_K_CONTIG:
+        # Tile is [BLOCK_N, BLOCK_K]: N along rows, K along cols (contiguous).
+        offs_bk = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT))
+        offs_bn = (pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(1, BLOCKED_LAYOUT))) % N
+        b_ptrs = b_ptr + offs_bn[:, None] * stride_bn + offs_bk[None, :] * stride_bk
+    else:
+        # Tile is [BLOCK_K, BLOCK_N]: K along rows, N along cols (contiguous).
+        offs_bk = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(1, BLOCKED_LAYOUT))
+        offs_bn = (pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT))) % N
+        b_ptrs = b_ptr + offs_bk[:, None] * stride_bk + offs_bn[None, :] * stride_bn
 
     a_buffer = ttgl.allocate_shared_memory(a_desc.dtype, shape=[NUM_BUFFERS] + a_desc.block_shape, layout=a_desc.layout)
     b_buffer = ttgl.allocate_shared_memory(b_desc.dtype, shape=[NUM_BUFFERS] + b_desc.block_shape, layout=b_desc.layout)
@@ -456,14 +479,21 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
         if USE_TDM:
             ttgl.amd.gfx1250.tdm.async_load(a_desc, [0, load_idx * BLOCK_K],  #
                                             a_buffer.index(load_idx % NUM_BUFFERS))
-            ttgl.amd.gfx1250.tdm.async_load(b_desc, [load_idx * BLOCK_K, 0],  #
-                                            b_buffer.index(load_idx % NUM_BUFFERS))
+            if IS_B_K_CONTIG:
+                ttgl.amd.gfx1250.tdm.async_load(b_desc, [0, load_idx * BLOCK_K],  #
+                                                b_buffer.index(load_idx % NUM_BUFFERS))
+            else:
+                ttgl.amd.gfx1250.tdm.async_load(b_desc, [load_idx * BLOCK_K, 0],  #
+                                                b_buffer.index(load_idx % NUM_BUFFERS))
         else:
             mask_a = offs_ak[None, :] < K - load_idx * BLOCK_K
             ttgl.amd.gfx1250.async_copy.global_to_shared(a_buffer.index(load_idx % NUM_BUFFERS), a_ptrs, mask_a,
                                                          other=0.0)
 
-            mask_b = offs_bk[:, None] < K - load_idx * BLOCK_K
+            if IS_B_K_CONTIG:
+                mask_b = offs_bk[None, :] < K - load_idx * BLOCK_K
+            else:
+                mask_b = offs_bk[:, None] < K - load_idx * BLOCK_K
             ttgl.amd.gfx1250.async_copy.global_to_shared(b_buffer.index(load_idx % NUM_BUFFERS), b_ptrs, mask_b,
                                                          other=0.0)
             ttgl.amd.gfx1250.async_copy.commit_group()
@@ -476,14 +506,21 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
         if USE_TDM:
             ttgl.amd.gfx1250.tdm.async_load(a_desc, [0, load_idx * BLOCK_K],  #
                                             a_buffer.index(load_idx % NUM_BUFFERS))
-            ttgl.amd.gfx1250.tdm.async_load(b_desc, [load_idx * BLOCK_K, 0],  #
-                                            b_buffer.index(load_idx % NUM_BUFFERS))
+            if IS_B_K_CONTIG:
+                ttgl.amd.gfx1250.tdm.async_load(b_desc, [0, load_idx * BLOCK_K],  #
+                                                b_buffer.index(load_idx % NUM_BUFFERS))
+            else:
+                ttgl.amd.gfx1250.tdm.async_load(b_desc, [load_idx * BLOCK_K, 0],  #
+                                                b_buffer.index(load_idx % NUM_BUFFERS))
         else:
             mask_a = offs_ak[None, :] < K - load_idx * BLOCK_K
             ttgl.amd.gfx1250.async_copy.global_to_shared(a_buffer.index(load_idx % NUM_BUFFERS), a_ptrs, mask_a,
                                                          other=0.0)
 
-            mask_b = offs_bk[:, None] < K - load_idx * BLOCK_K
+            if IS_B_K_CONTIG:
+                mask_b = offs_bk[None, :] < K - load_idx * BLOCK_K
+            else:
+                mask_b = offs_bk[:, None] < K - load_idx * BLOCK_K
             ttgl.amd.gfx1250.async_copy.global_to_shared(b_buffer.index(load_idx % NUM_BUFFERS), b_ptrs, mask_b,
                                                          other=0.0)
             ttgl.amd.gfx1250.async_copy.commit_group()
@@ -498,7 +535,10 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
             ttgl.amd.gfx1250.async_copy.wait_group((NUM_BUFFERS - 1))
 
         a = a_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=OPERAND_LAYOUT_A)
-        b = b_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=OPERAND_LAYOUT_B)
+        if IS_B_K_CONTIG:
+            b = b_buffer.index(wmma_idx % NUM_BUFFERS).permute([1, 0]).load(layout=OPERAND_LAYOUT_B)
+        else:
+            b = b_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=OPERAND_LAYOUT_B)
         accumulator = ttgl.amd.gfx1250.wmma(a, b, accumulator)
         wmma_idx += 1
 
@@ -509,7 +549,10 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
             ttgl.amd.gfx1250.async_copy.wait_group((NUM_BUFFERS - 2 - i))
 
         a = a_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=OPERAND_LAYOUT_A)
-        b = b_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=OPERAND_LAYOUT_B)
+        if IS_B_K_CONTIG:
+            b = b_buffer.index(wmma_idx % NUM_BUFFERS).permute([1, 0]).load(layout=OPERAND_LAYOUT_B)
+        else:
+            b = b_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=OPERAND_LAYOUT_B)
         accumulator = ttgl.amd.gfx1250.wmma(a, b, accumulator)
         wmma_idx += 1
 
@@ -523,26 +566,42 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
 @pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K", [(m, n, k) for (m, n) in [(32, 32), (64, 64)] \
                                                                for k in [32, 64]])
 @pytest.mark.parametrize("NUM_BUFFERS", [2, 4])
-@pytest.mark.parametrize("IS_B_K_CONTIG", [True, False])
 @pytest.mark.parametrize("ASYNC_LOAD_TYPE", ["ASYNC_COPY", "TDM"])
-def test_compile_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, IS_B_K_CONTIG, ASYNC_LOAD_TYPE):
+@pytest.mark.parametrize("B_K_CONTIG", [True, False])
+@pytest.mark.parametrize("RESOLVE_PARTITION_CONFLICTS", [True, False])
+def test_compile_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, ASYNC_LOAD_TYPE, B_K_CONTIG,
+                                      RESOLVE_PARTITION_CONFLICTS):
+    if RESOLVE_PARTITION_CONFLICTS:
+        if ASYNC_LOAD_TYPE == "ASYNC_COPY":
+            pytest.skip("AsyncCopy is not supported with partition shared layouts")
+        # The kernel uses num_warps=4 and instr_shape=[16, 16, 32], which gives
+        # WARP_TILES_M=4 and WARP_TILES_N=2 (see make_partitioned_dot_layouts).
+        # The minimum partitionable tile size is WARP_TILES_{M,N} * instr_shape[{0,1}].
+        min_block_m = 4 * 16
+        min_block_n = 2 * 16
+        if BLOCK_M < min_block_m or BLOCK_N < min_block_n:
+            pytest.skip(
+                f"Minimal block shape for partition conflicts resolution is ({min_block_m}, {min_block_n}) along (M, N)"
+            )
+
     # Inner strides need to be constexpr (1) to get contiguity. Note the compiler frontend does the same for normal dispatches
     signature = {
         "a_ptr": "*fp16", "b_ptr": "*fp16", "c_ptr": "*fp32",  #
         "M": "i32", "N": "i32", "K": "i32",  #
         "stride_am": "i32", "stride_ak": "constexpr",  #
-        "stride_bk": "constexpr", "stride_bn": "constexpr",  #
+        "stride_bk": "constexpr" if B_K_CONTIG else "i32", "stride_bn": "i32" if B_K_CONTIG else "constexpr",  #
         "stride_cm": "i32", "stride_cn": "constexpr",  #
         "BLOCK_M": "constexpr", "BLOCK_N": "constexpr", "BLOCK_K": "constexpr",  #
-        "NUM_BUFFERS": "constexpr", "USE_TDM": "constexpr", "IS_B_K_CONTIG": "constexpr"
+        "NUM_BUFFERS": "constexpr", "USE_TDM": "constexpr", "IS_B_K_CONTIG": "constexpr", "RESOLVE_PARTITION_CONFLICTS":
+        "constexpr"
     }
 
     constexprs = {
-        "stride_ak": 1, "stride_cn": 1, "BLOCK_M": BLOCK_M, "BLOCK_N": BLOCK_N, "BLOCK_K": BLOCK_K, "NUM_BUFFERS":
-        NUM_BUFFERS, "USE_TDM": ASYNC_LOAD_TYPE == "TDM", "IS_B_K_CONTIG": IS_B_K_CONTIG
+        "stride_ak": 1, ("stride_bk" if B_K_CONTIG else "stride_bn"): 1, "stride_cn": 1,  #
+        "BLOCK_M": BLOCK_M, "BLOCK_N": BLOCK_N, "BLOCK_K": BLOCK_K, "NUM_BUFFERS": NUM_BUFFERS,  #
+        "USE_TDM": ASYNC_LOAD_TYPE == "TDM", "IS_B_K_CONTIG": B_K_CONTIG,  #
+        "RESOLVE_PARTITION_CONFLICTS": RESOLVE_PARTITION_CONFLICTS
     }
-    constexprs["stride_bn"] = BLOCK_N if not IS_B_K_CONTIG else 1
-    constexprs["stride_bk"] = BLOCK_K if IS_B_K_CONTIG else 1
 
     fn = gemm_async_pipelined_kernel
 
@@ -563,7 +622,8 @@ def test_compile_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, IS
         assert len(re.findall("tensor_load_to_lds", amdgcn)) == NUM_BUFFERS * 2
     else:
         copy_instr_for_A = BLOCK_M // 4 // 4
-        copy_isntr_for_B = (BLOCK_K if IS_B_K_CONTIG else BLOCK_N) // 4 // 4
+        b_rows = BLOCK_N if B_K_CONTIG else BLOCK_K
+        copy_isntr_for_B = b_rows // 4 // 4
         copy_instr_per_iter = copy_instr_for_A + copy_isntr_for_B
         for cnt in range(NUM_BUFFERS - 1, -1, -1):
             assert re.search(f"s_wait_asynccnt 0x{(cnt * copy_instr_per_iter):x}", amdgcn)
@@ -575,23 +635,42 @@ def test_compile_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, IS
                                                                for k in [32, 64]])
 @pytest.mark.parametrize("NUM_BUFFERS", [2, 4])
 @pytest.mark.parametrize("M,N,K", [(256, 256, 512), (240, 240, 496), (250, 250, 510)])
-@pytest.mark.parametrize("IS_B_K_CONTIG", [True, False])
 @pytest.mark.parametrize("ASYNC_LOAD_TYPE", ["ASYNC_COPY", "TDM"])
-def test_runtime_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, M, N, K, IS_B_K_CONTIG, ASYNC_LOAD_TYPE):
+@pytest.mark.parametrize("B_K_CONTIG", [True, False])
+@pytest.mark.parametrize("RESOLVE_PARTITION_CONFLICTS", [True, False])
+def test_runtime_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, M, N, K, ASYNC_LOAD_TYPE, B_K_CONTIG,
+                                      RESOLVE_PARTITION_CONFLICTS):
     if triton.cdiv(K, BLOCK_K) < NUM_BUFFERS:
         pytest.skip("Skip tests where K/BLOCK_K < NUM_BUFFERS")
 
     if ASYNC_LOAD_TYPE == "ASYNC_COPY" and any([x % 16 != 0 for x in [M, N, K]]):
         pytest.skip("AsyncCopy tests need divisibility==16 to get vectorization information")
 
+    if RESOLVE_PARTITION_CONFLICTS:
+        if ASYNC_LOAD_TYPE == "ASYNC_COPY":
+            pytest.skip("AsyncCopy is not supported with partition shared layouts")
+        # The kernel uses num_warps=4 and instr_shape=[16, 16, 32], which gives
+        # WARP_TILES_M=4 and WARP_TILES_N=2 (see make_partitioned_dot_layouts).
+        # The minimum partitionable tile size is WARP_TILES_{M,N} * instr_shape[{0,1}].
+        min_block_m = 4 * 16
+        min_block_n = 2 * 16
+        if BLOCK_M < min_block_m or BLOCK_N < min_block_n:
+            pytest.skip(
+                f"Minimal block shape for partition conflicts resolution is ({min_block_m}, {min_block_n}) along (M, N)"
+            )
+
     torch.manual_seed(42)
 
     a = torch.randn((M, K), dtype=torch.float16)
-    b = torch.randn((K, N), dtype=torch.float16)
+    if B_K_CONTIG:
+        # Allocate as (N, K) and transpose so that the K dimension is the contiguous one.
+        b = torch.randn((N, K), dtype=torch.float16).t()
+    else:
+        b = torch.randn((K, N), dtype=torch.float16)
     c = torch.zeros((M, N), dtype=torch.float32)
 
     a_device = a.cuda()
-    b_device = b.cuda() if IS_B_K_CONTIG else b.data.T.contiguous().T.cuda()
+    b_device = b.cuda() if B_K_CONTIG else b.data.T.contiguous().T.cuda()
     c_device = c.cuda()
 
     stride_am, stride_ak = a_device.stride(0), a_device.stride(1)
@@ -606,7 +685,8 @@ def test_runtime_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, M,
         stride_bk, stride_bn,  #
         stride_cm, stride_cn,  #
         BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,  #
-        NUM_BUFFERS=NUM_BUFFERS, USE_TDM=ASYNC_LOAD_TYPE == "TDM", IS_B_K_CONTIG=IS_B_K_CONTIG)
+        NUM_BUFFERS=NUM_BUFFERS, USE_TDM=ASYNC_LOAD_TYPE == "TDM", IS_B_K_CONTIG=B_K_CONTIG,
+        RESOLVE_PARTITION_CONFLICTS=RESOLVE_PARTITION_CONFLICTS)
 
     c_triton = c_device.cpu()
     c_torch = a.to(torch.float32) @ b.to(torch.float32)

--- a/third_party/amd/python/test/test_tdm_copy.py
+++ b/third_party/amd/python/test/test_tdm_copy.py
@@ -1,0 +1,273 @@
+"""User-facing manual + test suite for partial TDM copies on gfx1250.
+
+This is the canonical reference for `async_load(..., warp_used_hint=H)`
+on AMD gfx1250.  `H` selects which warps participate in a single TDM
+transfer; cleared warps become hardware no-ops.  The data deposited
+in shared memory is unchanged -- only the work split changes.
+
+Worked example: `vector_add_tdm_kernel` issues two independent partial
+TDM copies into distinct shared buffers and then sums them.
+
+================================================================
+The rule: `H` must be axis-aligned
+================================================================
+
+`H` is legal iff its active warps share fixed values on some warpId
+bit positions and vary freely on the others.  Equivalently: pick
+which warpId bits are free, pin the others to fixed values; the
+active warps are exactly those whose warpId matches the pinned bits.
+K = popcount(H) is therefore a power of two (= 2^(number of free
+bits)) with `1 <= K <= num_warps`.
+
+For full details and rationale, see `AsyncTDMCopyGlobalToLocalOp`
+in `third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td`.
+
+================================================================
+Cookbook: legal 8-warp hints
+================================================================
+
+Bit 7 on the left, bit 0 on the right.
+
+  +-------------+---+--------------------------------------------+
+  | Bitmask     | K | Active warps      (pinned bits)            |
+  +-------------+---+--------------------------------------------+
+  | 0b00001111  | 4 | {0,1,2,3}         (bit 2 = 0)              |
+  | 0b11110000  | 4 | {4,5,6,7}         (bit 2 = 1)              |
+  | 0b01010101  | 4 | {0,2,4,6}         (bit 0 = 0)              |
+  | 0b10101010  | 4 | {1,3,5,7}         (bit 0 = 1)              |
+  | 0b00110011  | 4 | {0,1,4,5}         (bit 1 = 0)              |
+  | 0b00000011  | 2 | {0,1}             (bits 1,2 = 0)           |
+  | 0b00010000  | 1 | {4}               (single warp)            |
+  +-------------+---+--------------------------------------------+
+
+Rejected patterns:
+
+  +-------------+----------------------------------------------------+
+  | 0           | rejected: must select at least one warp; pass None |
+  | 0b00000111  | rejected: K=3 is not a power of two                |
+  | 0b01101001  | rejected: warps {0,3,5,6} are not axis-aligned     |
+  +-------------+----------------------------------------------------+
+
+================================================================
+When to reach for `warp_used_hint`
+================================================================
+
+Default `async_load(desc, idx, buf)` slices the tile across all
+`num_warps` warps.  Reach for `warp_used_hint=H` to:
+
+  * Free warps for unrelated work when the tile is small.
+  * Partition warps by role (producer/consumer pipelines).
+
+Omit or pass `None` for "all warps"; an explicit `warp_used_hint=0`
+is rejected by the verifier.
+
+================================================================
+Constructing a hint generically
+================================================================
+
+If `K` (number of active warps) is parameterised:
+
+  * "first K warps":              `(1 << K) - 1`
+  * "K warps starting at off":    `((1 << K) - 1) << off`
+                                  (off must be a multiple of K)
+  * "K warps spaced by 2**s":     `sum(1 << (i << s) for i in range(K))`
+
+================================================================
+What this file actually tests
+================================================================
+
+  * Compile-only test on the AMDGCN asm: every parametrisation yields
+    two `tensor_load_to_lds` instructions (one per `async_load`).
+  * Runtime test on gfx1250 compares against a torch-on-CPU reference.
+
+Runtime tests are skipped on non-gfx1250 hosts.
+"""
+
+import re
+
+import pytest
+import torch
+
+import triton
+from triton.backends.compiler import GPUTarget
+from triton._internal_testing import is_hip_gfx1250
+from triton.experimental import gluon
+import triton.experimental.gluon.language as ttgl
+
+
+@gluon.jit
+def vector_add_tdm_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    BLOCK_M: ttgl.constexpr,
+    BLOCK_N: ttgl.constexpr,
+    HINT_A: ttgl.constexpr,
+    HINT_B: ttgl.constexpr,
+):
+    """Two-tile vector add via TDM, parametrised on hints A and B.
+
+    `HINT == 0` is mapped to the kwarg-free `async_load` (the verifier
+    rejects an explicit `warp_used_hint = 0`).  Each load issues an
+    independent partial TDM copy into its own shared buffer.
+    """
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    BLOCKED_LAYOUT: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [4, 8], [num_warps, 1], [1, 0])
+    SHARED_LAYOUT: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[32, 4]], [BLOCK_M, BLOCK_N], [1, 0])
+
+    pid_m = ttgl.program_id(axis=0)
+    pid_n = ttgl.program_id(axis=1)
+    off_m = pid_m * BLOCK_M
+    off_n = pid_n * BLOCK_N
+
+    a_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(
+        base=a_ptr,
+        shape=(M, N),
+        strides=(N, 1),
+        block_shape=(BLOCK_M, BLOCK_N),
+        layout=SHARED_LAYOUT,
+    )
+    b_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(
+        base=b_ptr,
+        shape=(M, N),
+        strides=(N, 1),
+        block_shape=(BLOCK_M, BLOCK_N),
+        layout=SHARED_LAYOUT,
+    )
+
+    a_buf = ttgl.allocate_shared_memory(a_desc.dtype, a_desc.block_shape, a_desc.layout)
+    b_buf = ttgl.allocate_shared_memory(b_desc.dtype, b_desc.block_shape, b_desc.layout)
+
+    if HINT_A == 0:
+        ttgl.amd.gfx1250.tdm.async_load(a_desc, [off_m, off_n], a_buf)
+    else:
+        ttgl.amd.gfx1250.tdm.async_load(a_desc, [off_m, off_n], a_buf, warp_used_hint=HINT_A)
+    if HINT_B == 0:
+        ttgl.amd.gfx1250.tdm.async_load(b_desc, [off_m, off_n], b_buf)
+    else:
+        ttgl.amd.gfx1250.tdm.async_load(b_desc, [off_m, off_n], b_buf, warp_used_hint=HINT_B)
+
+    ttgl.amd.gfx1250.tdm.async_wait(0)
+
+    a = a_buf.load(layout=BLOCKED_LAYOUT)
+    b = b_buf.load(layout=BLOCKED_LAYOUT)
+    c = a + b
+
+    offs_m = off_m + ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, BLOCKED_LAYOUT))
+    offs_n = off_n + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT))
+    offs = (offs_m[:, None] * N) + offs_n[None, :]
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    ttgl.store(c_ptr + offs, c, mask=mask)
+
+
+# Hint cookbook for `vector_add_tdm_kernel`.  Layout: (HINT_A, HINT_B,
+# id).  Bit `i` => warp `i`; `0` selects the kwarg-free load (an
+# explicit zero is rejected by the verifier).  All entries below are
+# verifier-legal.
+_HINT_PARAMS = [
+    (0b00000000, 0b00000000, "no_hint"),
+    (0b11111111, 0b00000000, "full_a_unhinted_b"),
+    (0b00001111, 0b11110000, "lo4_hi4"),
+    (0b01010101, 0b10101010, "strided_pair"),
+    (0b00110011, 0b11001100, "lo_hi_pairs"),
+    (0b00000011, 0b00001100, "K2_low_warps"),
+    (0b00000001, 0b00000010, "single_warp_pair"),
+]
+
+
+def _param_args(p):
+    """Strip trailing id from a parametrised entry."""
+    return p[:-1]
+
+
+def _param_id(p):
+    return p[-1]
+
+
+_COMPILE_BLOCK_SHAPES = [(64, 64), (32, 128)]
+
+
+@pytest.mark.parametrize("BLOCK_M,BLOCK_N", _COMPILE_BLOCK_SHAPES)
+@pytest.mark.parametrize(
+    "HINT_A,HINT_B",
+    [_param_args(p) for p in _HINT_PARAMS],
+    ids=[_param_id(p) for p in _HINT_PARAMS],
+)
+def test_compile_vector_add_tdm(BLOCK_M, BLOCK_N, HINT_A, HINT_B):
+    """Compile-only: each `async_load` lowers to one `tensor_load_to_lds`."""
+    NUM_WARPS = 8
+    signature = {
+        "a_ptr": "*i32",
+        "b_ptr": "*i32",
+        "c_ptr": "*i32",
+        "M": "i32",
+        "N": "i32",
+        "BLOCK_M": "constexpr",
+        "BLOCK_N": "constexpr",
+        "HINT_A": "constexpr",
+        "HINT_B": "constexpr",
+    }
+    constexprs = {
+        "BLOCK_M": BLOCK_M,
+        "BLOCK_N": BLOCK_N,
+        "HINT_A": HINT_A,
+        "HINT_B": HINT_B,
+    }
+    k = triton.compile(
+        gluon._runtime.GluonASTSource(
+            fn=vector_add_tdm_kernel,
+            signature=signature,
+            constexprs=constexprs,
+        ),
+        target=GPUTarget("hip", "gfx1250", 32),
+        options={"num_warps": NUM_WARPS},
+    )
+
+    amdgcn = k.asm["amdgcn"]
+    n_tdm = len(re.findall(r"tensor_load_to_lds", amdgcn))
+    assert n_tdm == 2, (f"expected two tensor_load_to_lds for HINT_A=0b{HINT_A:08b}, "
+                        f"HINT_B=0b{HINT_B:08b}, got {n_tdm}\n{amdgcn}")
+
+
+_RUNTIME_BLOCK_SHAPES = [(64, 64), (128, 64)]
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="TDM is only tested on gfx1250.")
+@pytest.mark.parametrize("BLOCK_M,BLOCK_N", _RUNTIME_BLOCK_SHAPES)
+@pytest.mark.parametrize(
+    "HINT_A,HINT_B",
+    [_param_args(p) for p in _HINT_PARAMS],
+    ids=[_param_id(p) for p in _HINT_PARAMS],
+)
+def test_runtime_vector_add_tdm(BLOCK_M, BLOCK_N, HINT_A, HINT_B):
+    """Runtime: integer c = a + b vs torch CPU reference."""
+    M, N = 256, 512
+    NUM_WARPS = 8
+
+    torch.manual_seed(0)
+    # FIXME: Switch to native GPU-side initialization once public PyTorch
+    # supports gfx1250 kernels.
+    a_cpu = torch.randint(0, 128, (M, N), dtype=torch.int32)
+    b_cpu = torch.randint(0, 128, (M, N), dtype=torch.int32)
+    a = a_cpu.cuda()
+    b = b_cpu.cuda()
+    c = torch.empty((M, N), dtype=torch.int32, device="cuda")
+
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    vector_add_tdm_kernel[grid](
+        a,
+        b,
+        c,
+        M,
+        N,
+        BLOCK_M,
+        BLOCK_N,
+        HINT_A,
+        HINT_B,
+        num_warps=NUM_WARPS,
+    )
+
+    expected = a_cpu + b_cpu
+    assert torch.equal(c.cpu(), expected)

--- a/third_party/amd/python/test/test_warp_pipeline_gfx9.py
+++ b/third_party/amd/python/test/test_warp_pipeline_gfx9.py
@@ -17,7 +17,7 @@ def _compile_gluon(fn, signature, constexprs, arch="gfx950"):
 
 @gluon.jit
 def pipeline_simple(A, B, BLOCK: gl.constexpr):
-    """Minimal 2-stage pipeline — baseline for s_setprio check."""
+    """Minimal 2-stage pipeline -- baseline for s_setprio check."""
     blocked: gl.constexpr = gl.BlockedLayout(size_per_thread=[1, 8], threads_per_warp=[16, 4],
                                              warps_per_cta=[gl.num_warps(), 1], order=[1, 0])
     offs_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=blocked)
@@ -31,6 +31,29 @@ def pipeline_simple(A, B, BLOCK: gl.constexpr):
             gl.store(B + offs, a)
 
 
+@gluon.jit
+def pipeline_unrolled(A, B, N, BLOCK: gl.constexpr):
+    """2-stage pipeline with loop unrolling -- IV used inside stages.
+
+    The IV must be referenced inside execute_region bodies so only the
+    scalar IV-remap ops (arith.muli + arith.addi on the index) land
+    between the cloned clusters after unrolling.  Gluon skips make_ttir,
+    so loop_unroll_factor survives until after add_warp_pipeline.
+    """
+    blocked: gl.constexpr = gl.BlockedLayout(size_per_thread=[1, 8], threads_per_warp=[16, 4],
+                                             warps_per_cta=[gl.num_warps(), 1], order=[1, 0])
+    offs_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=blocked)
+    base = gl.arange(0, BLOCK, layout=offs_layout)
+
+    for i in tl.range(0, N, loop_unroll_factor=2):
+        with warp_pipeline_stage("stage1", priority=1):
+            offs = base + i * BLOCK
+            a = gl.load(A + offs)
+
+        with warp_pipeline_stage("stage2", priority=0):
+            gl.store(B + offs, a)
+
+
 def test_simple_pipeline_setprio():
     """Baseline: a simple 2-stage pipeline emits s_setprio."""
     signature = {"A": "*fp16", "B": "*fp16", "BLOCK": "constexpr"}
@@ -38,3 +61,66 @@ def test_simple_pipeline_setprio():
     k = _compile_gluon(pipeline_simple, signature, constexprs)
     amdgcn = k.asm["amdgcn"]
     assert amdgcn.count("s_setprio") > 0, "Simple pipeline must emit s_setprio."
+
+
+def test_pipeline_with_unroll():
+    """Warp pipeline + loop unrolling: IV remap ops between stages must not break conversion.
+
+    Gluon kernels skip make_ttir, so loop_unroll_factor survives until the
+    Gluon pipeline where add_loop_unroll runs AFTER add_warp_pipeline.  The
+    MLIR unroller emits arith.muli+arith.addi for IV remapping between the
+    cloned execute_region clusters -- ConvertWarpPipeline must tolerate these.
+    """
+    signature = {"A": "*fp16", "B": "*fp16", "N": "i32", "BLOCK": "constexpr"}
+    constexprs = {"BLOCK": BLOCK}
+    k = _compile_gluon(pipeline_unrolled, signature, constexprs)
+    amdgcn = k.asm["amdgcn"]
+    # Each successfully converted loop emits s_setprio instructions.
+    # With unroll factor 2 and dynamic bound, we get a main loop + epilogue.
+    # Both must convert: without the fix only the epilogue converts (4 s_setprio),
+    # with the fix both convert (10 s_setprio).
+    assert amdgcn.count("s_setprio") > 4, \
+        f"Expected > 4 s_setprio (both main+epilogue converted), got {amdgcn.count('s_setprio')}"
+
+
+@gluon.jit
+def pipeline_static_range_unrolled(A, B, N, BLOCK: gl.constexpr):
+    """Outer loop_unroll_factor + static_range wrapping both stages.
+
+    The outer tl.range has loop_unroll_factor=2, so MLIR unrolling injects
+    scalar IV remap ops between cloned bodies.  Inside each iteration,
+    static_range(2) duplicates both pipeline stages at the AST level.
+    This is the worst-case combo for ConvertWarpPipeline: the loop body
+    has 4 execute_region clusters with scalar ops between them.
+    """
+    blocked: gl.constexpr = gl.BlockedLayout(size_per_thread=[1, 8], threads_per_warp=[16, 4],
+                                             warps_per_cta=[gl.num_warps(), 1], order=[1, 0])
+    offs_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=blocked)
+    base = gl.arange(0, BLOCK, layout=offs_layout)
+
+    for i in tl.range(0, N, loop_unroll_factor=2):
+        for j in gl.static_range(2):
+            with warp_pipeline_stage("stage1", priority=1):
+                offs = base + (i + j) * BLOCK
+                a = gl.load(A + offs)
+
+            with warp_pipeline_stage("stage2", priority=0):
+                gl.store(B + offs, a)
+
+
+def test_pipeline_static_range_with_unroll():
+    """static_range wrapping both stages + outer loop_unroll_factor must convert."""
+    signature = {"A": "*fp16", "B": "*fp16", "N": "i32", "BLOCK": "constexpr"}
+    constexprs = {"BLOCK": BLOCK}
+    k = _compile_gluon(pipeline_static_range_unrolled, signature, constexprs)
+    amdgcn = k.asm["amdgcn"]
+    setprio_lines = [line.strip() for line in amdgcn.splitlines() if "s_setprio" in line]
+    prios = [int(l.split()[-1]) for l in setprio_lines]
+    # Each converted loop emits: 1 pre-loop + (N-1) in-body + 1 wrap-around + 1 post-loop reset.
+    # Main loop has 8 clusters (static_range(2) * 2 stages * unroll(2)): 1+7+1+1 = 10.
+    # Epilogue has 4 clusters (static_range(2) * 2 stages): 1+3+1+1 = 6.
+    # Total: 16 s_setprio.  Both priority levels must appear.
+    assert len(prios) == 16, \
+        f"Expected 16 s_setprio (main=10 + epilogue=6), got {len(prios)}: {prios}"
+    assert prios.count(0) == 8 and prios.count(1) == 8, \
+        f"Expected 8 prio-0 and 8 prio-1, got {prios}"

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
@@ -9,7 +9,9 @@ using namespace mlir;
 using namespace mlir::triton;
 
 using ::mlir::triton::gpu::getShapePerCTA;
+using ::mlir::triton::gpu::isPermutationMatrixLayout;
 using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
+using ::mlir::triton::gpu::toLinearLayout;
 
 LogicalResult convertMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                          const LLVMTypeConverter *typeConverter,
@@ -43,6 +45,12 @@ struct ScaledDotOpConversion
   LogicalResult
   matchAndRewrite(triton::DotScaledOp op, triton::DotScaledOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto rty = cast<RankedTensorType>(op.getResult().getType());
+    if (!isPermutationMatrixLayout(
+            toLinearLayout(rty.getShape(), rty.getEncoding())))
+      return rewriter.notifyMatchFailure(
+          op, "ScaledDotOp result encoding must have a permutation-matrix "
+              "linear layout");
     return convertMMADotScaled(op, adaptor, getTypeConverter(), rewriter);
   }
 
@@ -63,9 +71,16 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
                   ConversionPatternRewriter &rewriter) const override {
     // D = A * B + C
     Value D = op.getResult();
+    auto dType = op.getResult().getType();
+    auto dEncoding = dType.getEncoding();
 
-    NvidiaMmaEncodingAttr mmaLayout = dyn_cast<NvidiaMmaEncodingAttr>(
-        cast<RankedTensorType>(D.getType()).getEncoding());
+    if (!isPermutationMatrixLayout(toLinearLayout(dType.getShape(), dEncoding)))
+      return rewriter.notifyMatchFailure(
+          op,
+          "DotOp result encoding must have a permutation-matrix linear layout");
+
+    NvidiaMmaEncodingAttr mmaLayout =
+        dyn_cast<NvidiaMmaEncodingAttr>(dEncoding);
     if (mmaLayout) {
       if (mmaLayout.getVersionMajor() == 2) {
         return convertMMA(op, adaptor, getTypeConverter(), rewriter,
@@ -76,8 +91,7 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
           "Unsupported MMA kind found when converting DotOp to LLVM.");
     }
 
-    if (isa<BlockedEncodingAttr>(
-            cast<RankedTensorType>(D.getType()).getEncoding()))
+    if (isa<BlockedEncodingAttr>(dEncoding))
       return convertFMADot(op, adaptor, getTypeConverter(), rewriter);
 
     llvm::report_fatal_error(


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/10414

Upstream commit message:
```
> [AMD] Improve codegen in shuffleXor and warpReduce (#10414)

> While debugging a kernel I noticed that `v_mov_dpp`s weren't being fused
> with the subsequent arithmetic instructions. This was an oversight of
> mine due to not setting the bound control to be True on the intrinsic.

> We also remove the `v_permlane16_swap` fast-path for gfx1250 in
> `targetInfo::warpReduce` as it requires a preceding `v_mov` to duplicate
> a register in order to feed the two operand slots and takes more cycles
> to issue than a `permlanex16`, which is utilized in the `reduceOp`'s
> generic fallback path via shuffleXor.

> For CDNA4 we add `permlane*_swap` for shuffleXor instead of
> `ds_bpermute`.
```

***Do not remove the following line from this commit***
Reactor Backport Revision: 33d2a3f6a6585b6bfd3af119b2c24a73f4ae50b6
 ---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 10414
```

Differential Revision: D114132360
