### PR TITLE
[triton][beta] [Cherry-pick][RESOLVED] '[BACKEND] Improve cluster_barrier codegen within WS (#10992)' (#2540)

### DIFF
--- a/docs/gluon/api/nvidia.rst
+++ b/docs/gluon/api/nvidia.rst
@@ -9,3 +9,4 @@ Target-specific Gluon APIs for NVIDIA GPU generations.
    Ampere <nvidia.ampere>
    Hopper <nvidia.hopper>
    Blackwell <nvidia.blackwell>
+   Rubin <nvidia.rubin>

--- a/docs/gluon/api/nvidia.rubin.rst
+++ b/docs/gluon/api/nvidia.rubin.rst
@@ -1,0 +1,32 @@
+NVIDIA Rubin
+============
+
+.. currentmodule:: triton.experimental.gluon.language.nvidia.rubin
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: autosummary/gluon-module.rst
+
+    async_copy
+    clc
+    mbarrier
+    tma
+
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    allocate_tensor_memory
+    fence_async_shared
+    mma_v2
+    tensor_memory_descriptor
+    tensor_memory_descriptor_type
+    tcgen05_commit
+    tcgen05_copy
+    tcgen05_mma
+    tcgen05_mma_barrier_count
+    tcgen05_mma_scaled
+    TensorMemoryLayout
+    TensorMemoryScalesLayout

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TargetFeatures.h
@@ -70,6 +70,7 @@ public:
   bool supports4xFp4Tcgen05MMA() const { return computeCapability == 107; }
   bool supports2xFp8Tcgen05MMA() const { return computeCapability == 107; }
   bool supportsReuseB() const { return computeCapability == 107; }
+  bool supportsMbarMulticast() const { return computeCapability == 107; }
 
 private:
   static constexpr char kTargetPrefix[] = "cuda:";

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1191,26 +1191,28 @@ LogicalResult TCGen5MMAScaledOp::verify() {
     int64_t scalesPerCTA = shapePerCTA.back();
     return rowsPerCTA > 128 && scalesPerCTA > 4;
   };
-  if (isa<TensorMemorySpaceAttr>(aScaleType.getMemorySpace()) &&
-      isScaleBlockRepOrderRelevant(aScaleType)) {
+  auto verifyScaleEncoding = [&](MemDescType scaleType,
+                                 bool isA) -> LogicalResult {
+    if (!isa<TensorMemorySpaceAttr>(scaleType.getMemorySpace()))
+      return success();
+    bool isOrderRelevant = isScaleBlockRepOrderRelevant(scaleType);
     auto encoding =
-        dyn_cast<TensorMemoryScalesEncodingAttr>(aScaleType.getEncoding());
-    if (!encoding)
-      return emitOpError("A scales in tensor memory must use "
-                         "#ttng.tensor_memory_scales_encoding");
-    if (failed(verifyScaleBlockRepOrder(*this, encoding, /*isA=*/true)))
-      return failure();
-  }
-  if (isa<TensorMemorySpaceAttr>(bScaleType.getMemorySpace()) &&
-      isScaleBlockRepOrderRelevant(bScaleType)) {
-    auto encoding =
-        dyn_cast<TensorMemoryScalesEncodingAttr>(bScaleType.getEncoding());
-    if (!encoding)
-      return emitOpError("B scales in tensor memory must use "
-                         "#ttng.tensor_memory_scales_encoding");
-    if (failed(verifyScaleBlockRepOrder(*this, encoding, /*isA=*/false)))
-      return failure();
-  }
+        dyn_cast<TensorMemoryScalesEncodingAttr>(scaleType.getEncoding());
+    if (!encoding) {
+      if (!isOrderRelevant)
+        return success();
+      return emitOpError() << (isA ? "A" : "B")
+                           << " scales in tensor memory must use "
+                              "#ttng.tensor_memory_scales_encoding";
+    }
+    if (!isOrderRelevant && encoding.getBlockRepOrder() ==
+                                TensorMemoryScalesBlockRepOrder::MN_THEN_K)
+      return success();
+    return verifyScaleBlockRepOrder(*this, encoding, isA);
+  };
+  if (failed(verifyScaleEncoding(aScaleType, /*isA=*/true)) ||
+      failed(verifyScaleEncoding(bScaleType, /*isA=*/false)))
+    return failure();
   return success();
 }
 

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -78,7 +78,11 @@ static void printDiagStr(llvm::raw_ostream &os, const Diagnostic &diag) {
 }
 
 struct GluonOpBuilder : public TritonOpBuilder {
-  using TritonOpBuilder::TritonOpBuilder;
+  GluonOpBuilder(MLIRContext *context, std::string arch = "")
+      : TritonOpBuilder(context), arch(arch) {}
+
+  bool isRubin() const { return arch == "sm107"; }
+
   // Construct an attribute or type while calling its verifier. Error messages
   // are intercepted and sent back to Python via a C++ exception.
   template <typename AttrOrType, typename... ArgTs>
@@ -122,6 +126,9 @@ struct GluonOpBuilder : public TritonOpBuilder {
   getChecked(ArgTs &&...args) {
     return AttrOrType::get(std::forward<ArgTs>(args)...);
   }
+
+private:
+  std::string arch;
 };
 
 struct GluonLayouts {
@@ -132,6 +139,7 @@ struct GluonLayouts {
   py::handle DistributedLinearLayout;
   py::handle DotOperandLayout;
   py::handle NVMMADistributedLayout;
+  py::handle RubinTensorMemoryScalesLayout;
   py::handle TensorMemoryScalesLayout;
   py::handle TensorMemoryLayout;
   py::handle NVMMASharedLayout;
@@ -149,6 +157,8 @@ struct GluonLayouts {
         py::module::import("triton.experimental.gluon.language.amd._layouts");
     auto blackwellLayouts = py::module::import(
         "triton.experimental.gluon.language.nvidia.blackwell");
+    auto rubinLayouts = py::module::import(
+        "triton.experimental.gluon.language.nvidia.rubin");
     AutoLayout = py::object(layouts.attr("AutoLayout")).release();
     CoalescedLayout = py::object(layouts.attr("CoalescedLayout")).release();
     BlockedLayout = py::object(layouts.attr("BlockedLayout")).release();
@@ -160,6 +170,8 @@ struct GluonLayouts {
         py::object(layouts.attr("NVMMADistributedLayout")).release();
     TensorMemoryScalesLayout =
         py::object(blackwellLayouts.attr("TensorMemoryScalesLayout")).release();
+    RubinTensorMemoryScalesLayout =
+        py::object(rubinLayouts.attr("TensorMemoryScalesLayout")).release();
     TensorMemoryLayout =
         py::object(blackwellLayouts.attr("TensorMemoryLayout")).release();
     NVMMASharedLayout = py::object(layouts.attr("NVMMASharedLayout")).release();
@@ -201,7 +213,7 @@ std::vector<llvm::ValueTypeFromRangeType<R>> toStdVector(R &&range) {
   return {range.begin(), range.end()};
 }
 
-py::object layoutToGluon(Attribute layout) {
+py::object layoutToGluon(Attribute layout, bool isRubin = false) {
   static GluonLayouts layouts;
   if (auto blocked = dyn_cast<ttg::BlockedEncodingAttr>(layout)) {
     auto cgaBases = getCgaLayoutBases(blocked.getCGALayout());
@@ -211,7 +223,7 @@ py::object layoutToGluon(Attribute layout) {
                                  toStdVector(blocked.getOrder()), cgaBases);
   } else if (auto sliced = dyn_cast<ttg::SliceEncodingAttr>(layout)) {
     return layouts.SliceLayout(sliced.getDim(),
-                               layoutToGluon(sliced.getParent()));
+                               layoutToGluon(sliced.getParent(), isRubin));
   } else if (auto linear = dyn_cast<ttg::LinearEncodingAttr>(layout)) {
     const auto &ll = linear.getLinearLayout();
     auto ctx = layout.getContext();
@@ -224,8 +236,9 @@ py::object layoutToGluon(Attribute layout) {
         ll.getBases().lookup(kWarp), ll.getBases().lookup(kBlock),
         toStdVector(ll.getOutDimSizes()));
   } else if (auto dotOp = dyn_cast<ttg::DotOperandEncodingAttr>(layout)) {
-    return layouts.DotOperandLayout(
-        dotOp.getOpIdx(), layoutToGluon(dotOp.getParent()), dotOp.getKWidth());
+    return layouts.DotOperandLayout(dotOp.getOpIdx(),
+                                    layoutToGluon(dotOp.getParent(), isRubin),
+                                    dotOp.getKWidth());
   } else if (auto mma = dyn_cast<ttg::NvidiaMmaEncodingAttr>(layout)) {
     auto cgaBases = getCgaLayoutBases(mma.getCGALayout());
     return layouts.NVMMADistributedLayout(
@@ -298,19 +311,22 @@ py::object layoutToGluon(Attribute layout) {
   } else if (auto partitioned =
                  dyn_cast<ttg::PartitionedSharedEncodingAttr>(layout)) {
     py::object partitionLayout =
-        layoutToGluon(partitioned.getPartitionLayout());
+        layoutToGluon(partitioned.getPartitionLayout(), isRubin);
     return layouts.PartitionedSharedLayout(
         partitioned.getNumPartitions(), partitioned.getNumGroups(),
         partitioned.getPartitionDim(), partitionLayout);
   } else if (auto tmemScales =
                  dyn_cast<ttng::TensorMemoryScalesEncodingAttr>(layout)) {
-    StringRef blockRepOrder =
-        tmemScales.getBlockRepOrder() ==
-                ttng::TensorMemoryScalesBlockRepOrder::K_THEN_MN
-            ? "kThenMn"
-            : "mnThenK";
-    return layouts.TensorMemoryScalesLayout(
-        getCgaLayoutBases(tmemScales.getCGALayout()), blockRepOrder);
+    auto cgaLayout = getCgaLayoutBases(tmemScales.getCGALayout());
+    if (isRubin) {
+      const char *blockRepOrder =
+          tmemScales.getBlockRepOrder() ==
+                  ttng::TensorMemoryScalesBlockRepOrder::K_THEN_MN
+              ? "kThenMn"
+              : "mnThenK";
+      return layouts.RubinTensorMemoryScalesLayout(cgaLayout, blockRepOrder);
+    }
+    return layouts.TensorMemoryScalesLayout(cgaLayout);
   } else if (auto tmem = dyn_cast<ttng::TensorMemoryEncodingAttr>(layout)) {
     return layouts.TensorMemoryLayout(
         std::vector<unsigned>{tmem.getBlockM(), tmem.getBlockN()},
@@ -337,7 +353,8 @@ void init_gluon_ir(py::module &&m) {
 
   py::class_<GluonOpBuilder, TritonOpBuilder>(
       m, "GluonOpBuilder", py::module_local(), py::dynamic_attr())
-      .def(py::init<MLIRContext *>())
+      .def(py::init<MLIRContext *, std::string>(), py::arg("context"),
+           py::arg("arch") = "")
       .def("get_op_builder", &GluonOpBuilder::getBuilder, ret::reference)
       .def("get_distributed_ty",
            [](GluonOpBuilder &self, Type &elementType,
@@ -415,14 +432,14 @@ void init_gluon_ir(py::module &&m) {
              if (isa<ttg::DistributedEncodingTrait>(layout)) {
                auto attr =
                    ttg::LinearEncodingAttr::get(ctx, std::move(linearLayout));
-               return layoutToGluon(attr);
+               return layoutToGluon(attr, self.isRubin());
              }
              if (isa<ttg::SharedEncodingTrait>(layout)) {
                auto alignment =
                    cast<ttg::SharedEncodingTrait>(layout).getAlignment();
                auto attr = ttg::SharedLinearEncodingAttr::get(
                    ctx, std::move(linearLayout), alignment);
-               return layoutToGluon(attr);
+               return layoutToGluon(attr, self.isRubin());
              }
 
              // TensorMemory encodings: keep the LinearLayout but wrap as
@@ -609,13 +626,13 @@ void init_gluon_ir(py::module &&m) {
            [](GluonOpBuilder &self, Value tensor) -> py::object {
              auto ty = dyn_cast<RankedTensorType>(tensor.getType());
              check(ty.getEncoding(), "expected a tensor with an encoding");
-             return layoutToGluon(ty.getEncoding());
+             return layoutToGluon(ty.getEncoding(), self.isRubin());
            })
       .def("get_gluon_layout_from_memdesc",
            [](GluonOpBuilder &self, Value memdesc) -> py::object {
              auto ty = dyn_cast<ttg::MemDescType>(memdesc.getType());
              check(ty.getEncoding(), "expected a memdesc with an encoding");
-             return layoutToGluon(ty.getEncoding());
+             return layoutToGluon(ty.getEncoding(), self.isRubin());
            })
       .def("get_tensor_descriptor_layout_type",
            [](GluonOpBuilder &self, Type blockType, bool isSigned,
@@ -891,7 +908,8 @@ void init_gluon_ir(py::module &&m) {
               Value result = op.getResult();
               Value red = op.getRed();
               auto redTy = cast<RankedTensorType>(red.getType());
-              py::object redLayout = layoutToGluon(redTy.getEncoding());
+              py::object redLayout =
+                  layoutToGluon(redTy.getEncoding(), self.isRubin());
               return py::make_tuple(result, red, redLayout);
             }
             Value result = op.getResult();

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -28,6 +28,7 @@ from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia.ampere import async_copy, mma_v2
 from triton.experimental.gluon.language.nvidia.hopper import tma, mbarrier, fence_async_shared
 from triton.experimental.gluon.language.nvidia import hopper
+from triton.experimental.gluon.language.nvidia import rubin
 from triton.experimental.gluon.language.amd.cdna4 import async_copy as cdna4_async_copy
 from triton.experimental.gluon.language.extra import libdevice
 from triton.experimental.gluon.language.nvidia.blackwell import (
@@ -617,11 +618,11 @@ def test_mbarrier_arrive_multicast(num_ctas, cta_mask):
 
     @gluon.jit
     def kernel(out_ptr, cta_mask: ttgl.constexpr, init_count: ttgl.constexpr):
-        bar = mbarrier.allocate_mbarrier()
-        mbarrier.init(bar, count=init_count)
-        mbarrier.arrive(bar, cta_mask=cta_mask)
-        mbarrier.wait(bar, 0)
-        mbarrier.invalidate(bar)
+        bar = rubin.mbarrier.allocate_mbarrier()
+        rubin.mbarrier.init(bar, count=init_count)
+        rubin.mbarrier.arrive(bar, cta_mask=cta_mask)
+        rubin.mbarrier.wait(bar, 0)
+        rubin.mbarrier.invalidate(bar)
         ttgl.store(out_ptr + ttgl.program_id(0), ttgl.program_id(0))
 
     out = torch.zeros(num_ctas, device="cuda", dtype=torch.int32)
@@ -651,12 +652,12 @@ def test_mbarrier_arrive_broadcast_one_cta(num_ctas):
             is_pure=True,
             pack=1,
         )
-        bar = mbarrier.allocate_mbarrier()
-        mbarrier.init(bar, count=1)
+        bar = rubin.mbarrier.allocate_mbarrier()
+        rubin.mbarrier.init(bar, count=1)
         # CTA 0 does a multicast arrive, all CTAs wait.
-        mbarrier.arrive(bar, cta_mask=cta_mask, pred=cta_rank == 0)
-        mbarrier.wait(bar, 0)
-        mbarrier.invalidate(bar)
+        rubin.mbarrier.arrive(bar, cta_mask=cta_mask, pred=cta_rank == 0)
+        rubin.mbarrier.wait(bar, 0)
+        rubin.mbarrier.invalidate(bar)
         ttgl.store(out_ptr + pid, pid)
 
     out = torch.zeros(num_ctas, device="cuda", dtype=torch.int32)

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -5,8 +5,10 @@ import re
 from triton.backends.compiler import GPUTarget
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
+from triton.experimental.gluon.language._core import _unwrap_if_constexpr, builtin
 from triton.experimental.gluon.language.nvidia import blackwell
 from triton.experimental.gluon.language.nvidia import hopper
+from triton.experimental.gluon.language.nvidia import rubin
 from triton.experimental.gluon.language.nvidia.ampere import mbarrier as ampere_mbarrier
 from triton.experimental.gluon.language.nvidia.hopper import cluster
 from triton.experimental.gluon.language.nvidia.blackwell import (
@@ -40,6 +42,7 @@ PTRRANGE_PAT = re.compile("(, )?tt.pointer_range = 32 : i32")
 LIBDEVICE_PAT = re.compile('{libname = "", libpath = "", pure = true, symbol = "__.*"}')
 
 BLACKWELL_TARGET = GPUTarget("cuda", 100, 32)
+RUBIN_TARGET = GPUTarget("cuda", 107, 32)
 HOPPER_TARGET = GPUTarget("cuda", 90, 32)
 AMPERE_TARGET = GPUTarget("cuda", 80, 32)
 HIP_TARGET_RDNA3 = GPUTarget("hip", "gfx1100", 32)
@@ -706,6 +709,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 """,
     )
 
+def test_rubin_namespace_extends_blackwell():
+    assert ttgl.nvidia.rubin is rubin
+    assert rubin.TensorMemoryLayout is blackwell.TensorMemoryLayout
+    assert rubin.allocate_tensor_memory is blackwell.allocate_tensor_memory
+    assert rubin.tcgen05_mma_scaled is blackwell.tcgen05_mma_scaled
+    assert rubin.tma is blackwell.tma
+    assert rubin.mbarrier is not blackwell.mbarrier
+    assert rubin.mbarrier.allocate_mbarrier is blackwell.mbarrier.allocate_mbarrier
+
+    with pytest.raises(TypeError, match="block_rep_order"):
+        blackwell.TensorMemoryScalesLayout(block_rep_order="kThenMn")
+
+
 @gluon.jit
 def ampere_mbarrier_arrive_kernel():
     bar = ttgl.allocate_shared_memory(ttgl.int64, [1], ampere_mbarrier.MBarrierLayout())
@@ -723,28 +739,26 @@ def test_ampere_mbarrier_arrive(target):
     run_parser(ampere_mbarrier_arrive_kernel, target=target)
 
 
-def test_mbarrier_arrive_multicast_unsupported_target():
+def test_mbarrier_arrive_multicast_not_exposed_on_blackwell():
 
     @gluon.jit
     def kernel():
         bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
         mbarrier.arrive(bar, count=1, cta_mask=0x1)
 
-    with pytest.raises(CompilationError) as e:
+    with pytest.raises(CompilationError, match="cta_mask"):
         run_parser(kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
-
-    assert "multicast arrive requires Rubin" in str(e.value)
 
 
 def test_mbarrier_arrive_multicast_negative_mask():
 
     @gluon.jit
     def kernel():
-        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
-        mbarrier.arrive(bar, count=1, cta_mask=-1)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], rubin.mbarrier.MBarrierLayout())
+        rubin.mbarrier.arrive(bar, count=1, cta_mask=-1)
 
     with pytest.raises(CompilationError) as e:
-        run_parser(kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
+        run_parser(kernel, *make_args(num_ctas=2), target=RUBIN_TARGET)
 
     assert "cta_mask must be positive" in str(e.value)
 
@@ -753,11 +767,11 @@ def test_mbarrier_arrive_multicast_mask_too_large():
 
     @gluon.jit
     def kernel():
-        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
-        mbarrier.arrive(bar, count=1, cta_mask=2)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], rubin.mbarrier.MBarrierLayout())
+        rubin.mbarrier.arrive(bar, count=1, cta_mask=2)
 
     with pytest.raises(CompilationError) as e:
-        run_parser(kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
+        run_parser(kernel, *make_args(num_ctas=2), target=RUBIN_TARGET)
 
     assert "cta_mask must be <= num_ctas - 1" in str(e.value)
 
@@ -766,11 +780,11 @@ def test_mbarrier_arrive_multicast_non_int_mask():
 
     @gluon.jit
     def kernel():
-        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
-        mbarrier.arrive(bar, count=1, cta_mask=1.5)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], rubin.mbarrier.MBarrierLayout())
+        rubin.mbarrier.arrive(bar, count=1, cta_mask=1.5)
 
     with pytest.raises(CompilationError) as e:
-        run_parser(kernel, *make_args(num_ctas=2), target=BLACKWELL_TARGET)
+        run_parser(kernel, *make_args(num_ctas=2), target=RUBIN_TARGET)
 
     assert "cta_mask must be an int" in str(e.value)
 
@@ -825,6 +839,35 @@ def tcgen05_mma_scaled_kernel(
     scale_b = blackwell.allocate_tensor_memory(ttgl.int8, [128, 32], scale_layout)
     acc = blackwell.allocate_tensor_memory(ttgl.float16, [128, 128], acc_layout)
     blackwell.tcgen05_mma_scaled(a, b, acc, scale_a, scale_b, "e5m2", "e5m2")
+
+
+@builtin
+def assert_tmem_scales_layout_roundtrip(memdesc, expected_layout, _semantic=None):
+    expected_layout = _unwrap_if_constexpr(expected_layout)
+    actual_layout = _semantic.builder.get_gluon_layout_from_memdesc(memdesc.handle)
+    assert actual_layout == expected_layout, f"expected {expected_layout}, got {actual_layout}"
+
+
+@gluon.jit
+def tmem_scales_layout_roundtrip_kernel(scale_layout: ttgl.constexpr):
+    scale = blackwell.allocate_tensor_memory(ttgl.int8, [128, 8], scale_layout)
+    assert_tmem_scales_layout_roundtrip(scale, scale_layout)
+
+
+@pytest.mark.parametrize(
+    "target,scale_layout",
+    [
+        pytest.param(BLACKWELL_TARGET, blackwell.TensorMemoryScalesLayout(), id="blackwell-mn-then-k"),
+        pytest.param(RUBIN_TARGET, rubin.TensorMemoryScalesLayout(), id="rubin-mn-then-k"),
+        pytest.param(
+            RUBIN_TARGET,
+            rubin.TensorMemoryScalesLayout(block_rep_order="kThenMn"),
+            id="rubin-k-then-mn",
+        ),
+    ],
+)
+def test_tmem_scales_layout_roundtrip(target, scale_layout):
+    run_parser(tmem_scales_layout_roundtrip_kernel, *make_args(scale_layout), target=target)
 
 
 def test_tcgen05_mma_scaled():

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -372,7 +372,7 @@ class CodeGenerator(ast.NodeVisitor):
         if is_gluon:
             from triton.experimental.gluon.language._semantic import GluonSemantic
 
-            self.builder = gluon_ir.GluonOpBuilder(context)
+            self.builder = gluon_ir.GluonOpBuilder(context, options.arch)
             self.semantic = GluonSemantic(self.builder)
         else:
             from triton.language.semantic import TritonSemantic

--- a/python/triton/experimental/gluon/language/nvidia/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/__init__.py
@@ -1,4 +1,5 @@
 from . import blackwell
 from . import hopper
+from . import rubin
 
-__all__ = ["blackwell", "hopper"]
+__all__ = ["blackwell", "hopper", "rubin"]

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -88,27 +88,22 @@ class TensorMemoryScalesLayout:
 
     Args:
         cga_layout (Optional[List[List[int]]]): CGA layout bases. Defaults to [].
-        block_rep_order (str): Order of repeated scale blocks. Must be either
-            ``"mnThenK"`` or ``"kThenMn"``. Defaults to ``"mnThenK"``.
     """
     cga_layout: List[List[int]] = field(default_factory=list)
-    block_rep_order: str = "mnThenK"
 
     def __post_init__(self):
         super().__setattr__("cga_layout", _unwrap_if_constexpr(self.cga_layout))
-        super().__setattr__("block_rep_order", _unwrap_if_constexpr(self.block_rep_order))
         assert all(len(basis) == 2 for basis in self.cga_layout)
-        assert self.block_rep_order in ("mnThenK", "kThenMn")
 
     def _to_ir(self, builder):
-        return builder.get_tensor_memory_scales_layout([list(basis) for basis in self.cga_layout], self.block_rep_order)
+        return builder.get_tensor_memory_scales_layout([list(basis) for basis in self.cga_layout])
 
     def mangle(self) -> str:
         cga_layout_str = "_".join("~".join(map(str, basis)) for basis in self.cga_layout)
-        return f"TLS{self.block_rep_order}_{cga_layout_str}TLS"
+        return f"TLS{cga_layout_str}TLS"
 
     def __hash__(self):
-        return hash((tuple(tuple(b) for b in self.cga_layout), self.block_rep_order))
+        return hash(tuple(tuple(b) for b in self.cga_layout))
 
 
 @dataclass(frozen=True)

--- a/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/mbarrier.py
@@ -30,39 +30,17 @@ def expect(mbarrier, bytes_per_cta=None, pred=True, _semantic=None):
 
 
 @builtin
-def arrive(mbarrier, *, count=1, cta_mask=0, pred=True, _semantic=None):
+def arrive(mbarrier, *, count=1, pred=True, _semantic=None):
     """
     Arrive at an mbarrier with a specified count.
-
-    When ``cta_mask`` is non-zero, the arrive is multicast across the cluster.
-    Each bit set in the mask identifies a CTA ID dimension to multicast
-    along. CTA IDs ``a`` and ``b`` belong to the same equivalence class iff
-    ``a & ~cta_mask == b & ~cta_mask``; all CTAs in a class multicast to each
-    other. Multicast requires ``num_ctas > 1``, ``0 < cta_mask <= num_ctas - 1``,
-    and the barrier must have the identity CGA layout ``[[1], [2], ...]``. The
-    default value of ``cta_mask`` is 0 (no multicast).
 
     Args:
         mbarrier (shared_memory_descriptor): Barrier to be signalled.
         count (int): Count to arrive with. Defaults to 1.
-        cta_mask (int): CTA broadcast dimension bits (see above). Defaults
-            to 0 (no multicast). Must satisfy ``0 < cta_mask <= num_ctas - 1``
-            when non-zero.
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
     """
     count = _unwrap_if_constexpr(count)
-    cta_mask = _unwrap_if_constexpr(cta_mask)
-    if not isinstance(cta_mask, int) or isinstance(cta_mask, bool):
-        raise TypeError(f"cta_mask must be an int, got {type(cta_mask).__name__}")
-    if cta_mask:
-        num_ctas = _semantic.builder.options.num_ctas
-        if cta_mask < 0:
-            raise ValueError(f"cta_mask must be positive, got {cta_mask}")
-        if cta_mask > num_ctas - 1:
-            raise ValueError(f"cta_mask must be <= num_ctas - 1 ({num_ctas - 1}), got {cta_mask}")
-        sm = int(_semantic.builder.options.arch.removeprefix("sm"))
-        if sm < 107:
-            raise ValueError(f"multicast arrive requires Rubin (sm_107+), got sm_{sm}")
+    cta_mask = 0
     pred = _semantic.to_tensor(pred)
     _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle)
 

--- a/python/triton/experimental/gluon/language/nvidia/rubin/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/rubin/__init__.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from triton.experimental.gluon.language._core import _unwrap_if_constexpr
+
+from ..blackwell import (
+    TensorMemoryLayout,
+    _TensorMemoryLinearLayout,
+    allocate_tensor_memory,
+    async_copy,
+    clc,
+    fence_async_shared,
+    mma_v2,
+    tensor_memory_descriptor,
+    tensor_memory_descriptor_type,
+    tcgen05_commit,
+    tcgen05_copy,
+    tcgen05_mma,
+    tcgen05_mma_barrier_count,
+    tcgen05_mma_scaled,
+    tma,
+)
+from ..blackwell import TensorMemoryScalesLayout as _BlackwellTensorMemoryScalesLayout
+from . import mbarrier
+
+__all__ = [
+    "allocate_tensor_memory",
+    "async_copy",
+    "clc",
+    "fence_async_shared",
+    "mbarrier",
+    "mma_v2",
+    "tensor_memory_descriptor",
+    "tensor_memory_descriptor_type",
+    "tcgen05_commit",
+    "tcgen05_copy",
+    "tcgen05_mma",
+    "tcgen05_mma_barrier_count",
+    "tcgen05_mma_scaled",
+    "TensorMemoryLayout",
+    "TensorMemoryScalesLayout",
+    "tma",
+    "_TensorMemoryLinearLayout",
+]
+
+
+@dataclass(frozen=True, eq=True)
+class TensorMemoryScalesLayout(_BlackwellTensorMemoryScalesLayout):
+    """
+    Describes the layout for tensor memory scales in Rubin architecture.
+
+    Args:
+        cga_layout (Optional[List[List[int]]]): CGA layout bases. Defaults to [].
+        block_rep_order (str): Order of repeated scale blocks. Must be either
+            ``"mnThenK"`` or ``"kThenMn"``. Defaults to ``"mnThenK"``.
+    """
+    block_rep_order: str = "mnThenK"
+
+    def __post_init__(self):
+        super().__post_init__()
+        super().__setattr__("block_rep_order", _unwrap_if_constexpr(self.block_rep_order))
+        assert self.block_rep_order in ("mnThenK", "kThenMn")
+
+    def _to_ir(self, builder):
+        return builder.get_tensor_memory_scales_layout([list(basis) for basis in self.cga_layout], self.block_rep_order)
+
+    def mangle(self) -> str:
+        cga_layout_str = "_".join("~".join(map(str, basis)) for basis in self.cga_layout)
+        return f"TLS{self.block_rep_order}_{cga_layout_str}TLS"
+
+    def __hash__(self):
+        return hash((tuple(tuple(b) for b in self.cga_layout), self.block_rep_order))

--- a/python/triton/experimental/gluon/language/nvidia/rubin/mbarrier.py
+++ b/python/triton/experimental/gluon/language/nvidia/rubin/mbarrier.py
@@ -1,0 +1,56 @@
+from ..._core import _unwrap_if_constexpr, builtin
+from ..hopper.mbarrier import (
+    MBarrierLayout,
+    allocate_mbarrier,
+    expect,
+    fence_init_release_cluster,
+    init,
+    invalidate,
+    wait,
+)
+
+__all__ = [
+    "allocate_mbarrier",
+    "arrive",
+    "expect",
+    "fence_init_release_cluster",
+    "init",
+    "invalidate",
+    "MBarrierLayout",
+    "wait",
+]
+
+
+@builtin
+def arrive(mbarrier, *, count=1, cta_mask=0, pred=True, _semantic=None):
+    """
+    Arrive at an mbarrier with a specified count.
+
+    When ``cta_mask`` is non-zero, the arrive is multicast across the cluster.
+    Each bit set in the mask identifies a CTA ID dimension to multicast
+    along. CTA IDs ``a`` and ``b`` belong to the same equivalence class iff
+    ``a & ~cta_mask == b & ~cta_mask``; all CTAs in a class multicast to each
+    other. Multicast requires ``num_ctas > 1``, ``0 < cta_mask <= num_ctas - 1``,
+    and the barrier must have the identity CGA layout ``[[1], [2], ...]``. The
+    default value of ``cta_mask`` is 0 (no multicast).
+
+    Args:
+        mbarrier (shared_memory_descriptor): Barrier to be signalled.
+        count (int): Count to arrive with. Defaults to 1.
+        cta_mask (int): CTA broadcast dimension bits (see above). Defaults
+            to 0 (no multicast). Must satisfy ``0 < cta_mask <= num_ctas - 1``
+            when non-zero.
+        pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
+    """
+    count = _unwrap_if_constexpr(count)
+    cta_mask = _unwrap_if_constexpr(cta_mask)
+    if not isinstance(cta_mask, int) or isinstance(cta_mask, bool):
+        raise TypeError(f"cta_mask must be an int, got {type(cta_mask).__name__}")
+    if cta_mask:
+        num_ctas = _semantic.builder.options.num_ctas
+        if cta_mask < 0:
+            raise ValueError(f"cta_mask must be positive, got {cta_mask}")
+        if cta_mask > num_ctas - 1:
+            raise ValueError(f"cta_mask must be <= num_ctas - 1 ({num_ctas - 1}), got {cta_mask}")
+    pred = _semantic.to_tensor(pred)
+    _semantic.builder.create_mbarrier_arrive(mbarrier.handle, count, cta_mask, pred.handle)

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -178,6 +178,33 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
 #sharedT = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+#tmem_scales_k_then_mn = #ttng.tensor_memory_scales_encoding<blockRepOrder = kThenMn>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tcgen5_mma_scaled_blackwell_k_then_mn(
+      %a: !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
+      %b: !ttg.memdesc<64x128xi8, #sharedT, #ttg.shared_memory>,
+      %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %scale_a: !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales_k_then_mn, #ttng.tensor_memory>,
+      %scale_b: !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales, #ttng.tensor_memory>,
+      %useAcc: i1,
+      %pred: i1) {
+    // expected-error @below {{A scales in tensor memory must use #ttng.tensor_memory_scales_encoding<blockRepOrder = mnThenK>}}
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e2m1 rhs = e2m1 :
+      !ttg.memdesc<128x64xi8, #shared, #ttg.shared_memory>,
+      !ttg.memdesc<64x128xi8, #sharedT, #ttg.shared_memory>,
+      !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales_k_then_mn, #ttng.tensor_memory>,
+      !ttg.memdesc<128x8xf8E4M3FN, #tmem_scales, #ttng.tensor_memory>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+#sharedT = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 8}>
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
 #tmem_scales_k_then_mn = #ttng.tensor_memory_scales_encoding<blockRepOrder = kThenMn>

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -153,13 +153,21 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
   int sm_clock_rate;
   int mem_clock_rate;
   int mem_bus_width;
+  int major;
+  int minor;
+
+  CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
+      &major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device));
+  CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
+      &minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device));
 
   // XXX: remove attribute enum def once latest cuda.h is in use
   int CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK = 150;
-  if (CUDA_SUCCESS !=
-      cuDeviceGetAttribute(
-          &max_shared_mem,
-          CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, device)) {
+  if (major == 10 && minor == 7) {
+    CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
+        &max_shared_mem,
+        CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, device));
+  } else {
     CUDA_CHECK_AND_RETURN_NULL(cuDeviceGetAttribute(
         &max_shared_mem, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
         device));


### PR DESCRIPTION
Summary:

This is a backport of upstream PR https://github.com/triton-lang/triton/pull/10992.

Conflict Resolution:
- `test_consan.py`: kept beta's valid kernel invocation; the incoming call references undefined `CLUSTER_PARTITION`.
- `test_lowerings.py`: kept the existing histogram test; the incoming test requires deferred PR #10440.
- `tritonnvidiagpu_to_llvm.mlir`: kept beta's RUN pipeline and coverage; `--initialize-ws-cluster-barriers` is unavailable.
- `ClusterOpsToLLVM.cpp`: kept beta's all-warps lowering; the incoming fragments depend on missing allocator and initialization state from PRs #10440 and #10669.

Raw Conflicts: https://www.internalfb.com/intern/paste/P2441064381/

Diff Versions: Compare V1 (conflict markers) to V2 (resolved) in Phabricator.

Differential Revision: D114157583


