### PR TITLE
[triton][beta] [Cherry-pick] '[AMD] Enable loop unrolling for Gluon warp-pipelined kernels (#9666)' (#2544)

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3034,6 +3034,36 @@ struct TritonGPUInferLayoutInterface
           applyPermutation(invOrderUnsigned, enc.getOrder()), cgaLayout);
       return success();
     }
+
+    if (auto enc = dyn_cast<PartitionedSharedEncodingAttr>(operandEncoding)) {
+      // Recurse on the inner partition layout using the shape of a single
+      // logical piece (partitionDim is divided by numLogicalPieces, all other
+      // dimensions are unchanged). Rank, divisibility, and partitionDim bounds
+      // are invariants of a valid PartitionedSharedEncodingAttr enforced by
+      // its verifier. The recursive call will checkRank against the inner
+      // partitionLayout.
+      unsigned partitionDim = enc.getPartitionDim();
+      SmallVector<int64_t> partitionShape(shape.begin(), shape.end());
+      partitionShape[partitionDim] /= enc.getNumLogicalPieces();
+
+      Attribute innerResultEncoding;
+      if (failed(inferTransOpEncoding(enc.getPartitionLayout(), partitionShape,
+                                      order, innerResultEncoding, loc)))
+        return failure();
+
+      auto innerShared = dyn_cast<SharedEncodingTrait>(innerResultEncoding);
+      if (!innerShared) {
+        return emitOptionalError(loc, "transposed partition layout is not a "
+                                      "SharedEncodingTrait");
+      }
+
+      // After the permutation, the old partitionDim axis lives at the position
+      // j where order[j] == partitionDim, i.e. invOrder[partitionDim].
+      resultEncoding = PartitionedSharedEncodingAttr::get(
+          ctx, enc.getNumPartitions(), enc.getNumGroups(),
+          invOrder[partitionDim], innerShared);
+      return success();
+    }
     // Generic case
     auto padded = dyn_cast<PaddedSharedEncodingAttr>(operandEncoding);
 

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -23,6 +23,10 @@ from triton.experimental.gluon.language.amd.gfx1250 import (
     async_copy as gfx1250_async_copy, )
 from triton.experimental.gluon.language.amd.gfx1250 import mbarrier as gfx1250_mbarrier
 from triton.experimental.gluon.language.amd.gfx1250 import cluster as gfx1250_cluster
+from triton.experimental.gluon.language.amd.gfx1250 import (
+    PartitionedSharedLayout,
+    make_partitioned_dot_layouts,
+)
 from triton.experimental.gluon.language.extra import libdevice
 
 from triton._filecheck import filecheck_test, run_parser
@@ -2473,6 +2477,54 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 }
 """,
     )
+
+
+@pytest.mark.parametrize("num_warps", [4, 8])
+@pytest.mark.parametrize("block_m,block_n", [(64, 64), (64, 128), (128, 128)])
+@pytest.mark.parametrize("a_transposed", [False, True])
+@pytest.mark.parametrize("b_transposed", [False, True])
+def test_make_partitioned_dot_layouts(num_warps, block_m, block_n, a_transposed, b_transposed):
+    block_k = 32
+    INSTR_M, INSTR_N, INSTR_K = 16, 16, 32
+    # WARP_TILES_M=4 and WARP_TILES_N=2 for both 4- and 8-warp cases (different
+    # warp/reg base layouts but same per-warp tile extents).
+    warp_coverage_m = 4 * INSTR_M
+    warp_coverage_n = 2 * INSTR_N
+
+    a_shape = [block_k, block_m] if a_transposed else [block_m, block_k]
+    b_shape = [block_n, block_k] if b_transposed else [block_k, block_n]
+    pa = ttgl.PaddedSharedLayout.with_identity_for([[a_shape[1], 8]], a_shape, [1, 0])
+    pb = ttgl.PaddedSharedLayout.with_identity_for([[b_shape[1], 8]], b_shape, [1, 0])
+    sla, slb, wmma = make_partitioned_dot_layouts(block_m, block_n, pa, pb, num_warps=num_warps,
+                                                  instr_shape=[INSTR_M, INSTR_N, INSTR_K], a_transposed=a_transposed,
+                                                  b_transposed=b_transposed)
+
+    a_num_groups = block_m // warp_coverage_m
+    b_num_groups = block_n // warp_coverage_n
+    a_partition_dim = 1 if a_transposed else 0
+    b_partition_dim = 0 if b_transposed else 1
+    # The non-partitioned axis of each piece is block_k, the partitioned axis is
+    # divided down to (block / num_partitions / num_groups).
+    a_inner = [block_m / 2 / a_num_groups, block_k]
+    b_inner = [block_n / 2 / b_num_groups, block_k] if b_transposed else [block_k, block_n / 2 / b_num_groups]
+    for layout, num_groups, partition_dim, inner_shape in [
+        (sla, a_num_groups, a_partition_dim, a_inner),
+        (slb, b_num_groups, b_partition_dim, b_inner),
+    ]:
+        assert isinstance(layout, PartitionedSharedLayout)
+        assert layout.num_partitions == 2
+        assert layout.num_groups == num_groups
+        assert layout.partition_dim == partition_dim
+        assert layout.partition_layout.shape == inner_shape
+
+    if num_warps == 4:
+        expected_warp_bases, expected_reg_bases = [[2, 1], [1, 0]], [[2, 0]]
+    else:
+        expected_warp_bases, expected_reg_bases = [[2, 1], [1, 0], [2, 0]], []
+    assert isinstance(wmma, amd_layouts.AMDWMMALayout)
+    assert wmma.warp_bases == expected_warp_bases
+    assert wmma.reg_bases == expected_reg_bases
+    assert wmma.instr_shape == [INSTR_M, INSTR_N, INSTR_K]
 
 
 @gluon.jit

--- a/python/test/unit/tools/test_slice_kernel.py
+++ b/python/test/unit/tools/test_slice_kernel.py
@@ -302,7 +302,7 @@ def test_slice_kernel_public_imports():
     from triton.tools.triton_to_gluon_translator.slice_kernel import slice_kernel as new_slice_kernel
     from triton.tools.triton_to_gluon_translator.translator import translate_paths
     from triton.tools.triton_to_gluon_translator.translator import convert_triton_to_gluon
-    from triton.tools.triton_to_gluon_translator.translator_helpers import convert_host_descriptor
+    from triton.tools.triton_to_gluon_translator.nvidia_helpers import convert_host_descriptor
 
     assert callable(new_slice_kernel)
     assert callable(translate_paths)

--- a/python/test/unit/tools/test_triton_to_gluon.py
+++ b/python/test/unit/tools/test_triton_to_gluon.py
@@ -7,8 +7,17 @@ import pytest
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 from triton.tools.triton_to_gluon_translator.translator import convert_triton_to_gluon
-from triton.tools.triton_to_gluon_translator.translator_helpers import convert_host_descriptor
-from triton._internal_testing import is_blackwell, is_hopper_or_newer, is_cuda, is_hip_rdna
+from triton.tools.triton_to_gluon_translator.target import TranslatorTarget
+from triton._internal_testing import (
+    is_blackwell,
+    is_cuda,
+    is_hip_cdna3_or_newer,
+    is_hip_cdna4,
+    is_hip_gfx1250,
+    is_hip_rdna,
+    is_hopper_or_newer,
+)
+from triton.language.target_info import current_target
 
 pytestmark = pytest.mark.skipif(
     is_hip_rdna(),
@@ -16,8 +25,21 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def convert_kernel(kernel, kernel_name, tmp_path):
-    converted = convert_triton_to_gluon([kernel])
+def _convert_host_descriptor(desc):
+    """Import and call the target-appropriate convert_host_descriptor."""
+    target = current_target()
+    if target is not None and target.backend == "hip":
+        from triton.tools.triton_to_gluon_translator.amd_helpers import convert_host_descriptor
+    else:
+        from triton.tools.triton_to_gluon_translator.nvidia_helpers import convert_host_descriptor
+    return convert_host_descriptor(desc)
+
+
+def convert_kernel(kernel, kernel_name, tmp_path, target=None):
+    if target is None:
+        t = current_target()
+        target = TranslatorTarget("nvidia" if t.backend == "cuda" else t.arch)
+    converted = convert_triton_to_gluon([kernel], target=target)
 
     # Write converted kernel to a file so @gluon.jit can retrieve source
     mod_path = tmp_path / "converted_kernel.py"
@@ -41,7 +63,6 @@ def add_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK: tl.constexpr):
     tl.store(out_ptr + offsets, x + y)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_simple_kernel(tmp_path):
     kernel = convert_kernel(add_kernel, "add_kernel", tmp_path)
 
@@ -75,9 +96,9 @@ def matmul_tile_kernel(a_ptr, b_ptr, c_ptr, BLOCK_M: tl.constexpr, BLOCK_N: tl.c
     impl_matmul_tile_kernel(a_ptr, b_ptr, c_ptr, BLOCK_M, BLOCK_N, BLOCK_K)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_triton_to_gluon_dot_minimal(tmp_path):
-    # Convert directly from the Triton kernel object
+    if not (is_blackwell() or is_hip_cdna3_or_newer() or is_hip_gfx1250()):
+        pytest.skip("Requires Blackwell, CDNA3+, or gfx1250")
     kernel = convert_kernel(matmul_tile_kernel, "matmul_tile_kernel", tmp_path)
     M, N, K = 128, 128, 128
     a = torch.randn((M, K), device="cuda", dtype=torch.float16)
@@ -136,8 +157,9 @@ def matmul_kernel(  #
 @pytest.mark.parametrize("dtype_dst_str", ["float32"])
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES", [(128, 128, 64, 1)])
 @pytest.mark.parametrize("NUM_WARPS", [4])
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_simple_matmul(dtype_src_str, dtype_dst_str, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, NUM_WARPS, tmp_path):
+    if not (is_blackwell() or is_hip_cdna4() or is_hip_gfx1250()):
+        pytest.skip("Requires Blackwell, CDNA4, or gfx1250")
     device = "cuda"
     M, N, K = 1024, 512, 256
     torch.manual_seed(42)
@@ -166,8 +188,15 @@ def descriptor_store_kernel(desc, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, 
     desc.store([0, 0], tile)
 
 
-@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
+def _skip_unless_descriptor_target():
+    if is_cuda() and not is_hopper_or_newer():
+        pytest.skip("Requires Hopper+")
+    elif not is_cuda() and not is_hip_gfx1250():
+        pytest.skip("Requires descriptor support")
+
+
 def test_triton_to_gluon_descriptor_roundtrip(tmp_path):
+    _skip_unless_descriptor_target()
     kernel = convert_kernel(descriptor_store_kernel, "descriptor_store_kernel", tmp_path)
 
     M = N = 64
@@ -175,7 +204,7 @@ def test_triton_to_gluon_descriptor_roundtrip(tmp_path):
     grid = (1, )
     block_shape = [M, N]
     desc = TensorDescriptor(y, y.shape, y.stride(), block_shape)
-    gluon_desc = convert_host_descriptor(desc)
+    gluon_desc = _convert_host_descriptor(desc)
     kernel[grid](gluon_desc, M, N, 1.0)
 
     y_ref = torch.zeros((M, N), device="cuda", dtype=torch.float16)
@@ -190,8 +219,8 @@ def descriptor_copy_kernel(in_desc, out_desc, BLOCK_M: tl.constexpr, BLOCK_N: tl
     out_desc.store([0, 0], tile)
 
 
-@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
 def test_triton_to_gluon_descriptor_load_roundtrip(tmp_path):
+    _skip_unless_descriptor_target()
     kernel = convert_kernel(descriptor_copy_kernel, "descriptor_copy_kernel", tmp_path)
 
     M = N = 64
@@ -201,8 +230,8 @@ def test_triton_to_gluon_descriptor_load_roundtrip(tmp_path):
     block_shape = [M, N]
 
     in_desc = TensorDescriptor(x, x.shape, x.stride(), block_shape)
-    gluon_desc = convert_host_descriptor(in_desc)
-    out_desc = convert_host_descriptor(TensorDescriptor(y, y.shape, y.stride(), block_shape))
+    gluon_desc = _convert_host_descriptor(in_desc)
+    out_desc = _convert_host_descriptor(TensorDescriptor(y, y.shape, y.stride(), block_shape))
     kernel[grid](gluon_desc, out_desc, M, N)
 
     y_ref = torch.zeros((M, N), device="cuda", dtype=torch.float16)
@@ -229,8 +258,8 @@ def make_tensor_descriptor_copy_kernel(x_ptr, y_ptr, M, N, BLOCK_M: tl.constexpr
     out_desc.store([0, 0], tile)
 
 
-@pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer")
 def test_triton_to_gluon_make_tensor_descriptor(tmp_path, with_allocator):
+    _skip_unless_descriptor_target()
     kernel = convert_kernel(make_tensor_descriptor_copy_kernel, "make_tensor_descriptor_copy_kernel", tmp_path)
 
     M = N = 64
@@ -263,7 +292,6 @@ def reshape_trans_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK: tl.constexpr,
 
 
 @pytest.mark.parametrize("TRANS_KIND", ["trans_method", "tl_trans_separate", "tl_trans_tuple", "tl_trans"])
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_triton_reshape_trans(tmp_path, TRANS_KIND):
     kernel = convert_kernel(reshape_trans_kernel, "reshape_trans_kernel", tmp_path)
 
@@ -294,7 +322,6 @@ def split_kernel(x_ptr, out_ptr):
     tl.store(p, a)
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_split(tmp_path):
     kernel = convert_kernel(split_kernel, "split_kernel", tmp_path)
 
@@ -344,7 +371,6 @@ def reduce_to_scalar_kernel(out_ptr):
     tl.store(out_ptr, x)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_reduce_to_scalar(tmp_path):
     kernel = convert_kernel(reduce_to_scalar_kernel, "reduce_to_scalar_kernel", tmp_path)
     grid = (1, )
@@ -408,7 +434,6 @@ def atomic_add_kernel(out_ptr, BLOCK: tl.constexpr):
     tl.atomic_add(out_ptr + idx, idx, mask=scalar_mask, sem="release", scope="cta")
 
 
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_atomic_add(tmp_path):
     kernel = convert_kernel(atomic_add_kernel, "atomic_add_kernel", tmp_path)
 
@@ -419,3 +444,58 @@ def test_atomic_add(tmp_path):
     out = torch.zeros((block, ), device="cuda")
     kernel[(1, )](out, BLOCK=block)
     torch.testing.assert_close(out, ref)
+
+
+# ---- additional op coverage ----
+
+
+@triton.jit
+def cat_kernel(x_ptr, y_ptr, out_ptr, BLOCK: tl.constexpr):
+    offs = tl.arange(0, BLOCK)
+    x = tl.load(x_ptr + offs)
+    y = tl.load(y_ptr + offs)
+    z = tl.cat(x, y, can_reorder=True)
+    tl.store(out_ptr + tl.arange(0, 2 * BLOCK), z)
+
+
+def test_cat(tmp_path):
+    kernel = convert_kernel(cat_kernel, "cat_kernel", tmp_path)
+
+    BLOCK = 256
+    x = torch.randn(BLOCK, device="cuda", dtype=torch.float32)
+    y = torch.randn(BLOCK, device="cuda", dtype=torch.float32)
+    out = torch.empty(2 * BLOCK, device="cuda", dtype=torch.float32)
+    kernel[(1, )](x, y, out, BLOCK)
+
+    ref = torch.empty_like(out)
+    cat_kernel[(1, )](x, y, ref, BLOCK)
+    torch.testing.assert_close(sorted(out.cpu()), sorted(ref.cpu()), atol=0, rtol=0)
+
+
+@triton.jit
+def gather_scatter_roundtrip_kernel(out_ptr, in_ptr, idx_ptr, X: tl.constexpr, Y: tl.constexpr, BLOCK_X: tl.constexpr,
+                                    BLOCK_Y: tl.constexpr):
+    idx = tl.load(idx_ptr + tl.arange(0, BLOCK_X))
+    in_desc = tl.make_tensor_descriptor(in_ptr, [X, Y], [Y, 1], [1, BLOCK_Y])
+    out_desc = tl.make_tensor_descriptor(out_ptr, [X, Y], [Y, 1], [1, BLOCK_Y])
+    data = in_desc.gather(idx, 0)
+    out_desc.scatter(data, idx, 0)
+
+
+# TODO: parametrize over _descriptor_targets once NVIDIA gather/scatter translation is supported.
+# The translator currently routes gather/scatter to AMD-specific helpers for AMD targets only.
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires gfx1250")
+def test_gather_scatter_roundtrip(tmp_path):
+    kernel = convert_kernel(gather_scatter_roundtrip_kernel, "gather_scatter_roundtrip_kernel", tmp_path,
+                            target=TranslatorTarget.GFX1250)
+
+    X, Y, BLOCK_X, BLOCK_Y = 64, 64, 8, 64
+    inp = torch.arange(X * Y, device="cuda", dtype=torch.float16).reshape(X, Y)
+    idx = torch.tensor([0, 2, 4, 6, 1, 3, 5, 7], device="cuda", dtype=torch.int32)
+    out = torch.zeros((X, Y), device="cuda", dtype=torch.float16)
+    kernel[(1, )](out, inp, idx, X, Y, BLOCK_X, BLOCK_Y)
+
+    expected = torch.zeros_like(out)
+    for i, row in enumerate(idx.tolist()):
+        expected[row] = inp[row]
+    torch.testing.assert_close(out, expected, atol=0, rtol=0)

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -110,6 +110,10 @@ def is_hip_gfx1250():
     return target is not None and target.backend == 'hip' and 'gfx1250' in target.arch
 
 
+def is_hip_cdna3_or_newer():
+    return is_hip_cdna3() or is_hip_cdna4()
+
+
 def is_hip_cdna():
     return is_hip_cdna2() or is_hip_cdna3() or is_hip_cdna4()
 

--- a/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/__init__.py
@@ -5,7 +5,7 @@ from ..._core import builtin, int8, uint8, int32, float8e4nv, tensor, _unwrap_if
 from .._ops import _wmma, _verify_wmma, _mma_scaled, _scaled_upcast
 from .._layouts import AMDWMMALayout
 from ..cdna3 import buffer_load, buffer_store
-from ._layouts import PartitionedSharedLayout
+from ._layouts import PartitionedSharedLayout, make_partitioned_dot_layouts
 from . import tdm
 from . import async_copy
 from . import mbarrier
@@ -13,7 +13,7 @@ from . import cluster
 
 __all__ = [
     "async_copy", "tdm", "mbarrier", "cluster", "wmma", "wmma_scaled", "scaled_upcast", "buffer_load", "buffer_store",
-    "get_wmma_scale_layout", "PartitionedSharedLayout"
+    "get_wmma_scale_layout", "PartitionedSharedLayout", "make_partitioned_dot_layouts"
 ]
 
 

--- a/python/triton/experimental/gluon/language/amd/gfx1250/_layouts.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/_layouts.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from triton.language.core import _unwrap_if_constexpr
+from triton.runtime.jit import constexpr_function
 
-from triton.experimental.gluon.language._layouts import SharedLayout
+from triton.experimental.gluon.language._layouts import PaddedSharedLayout, SharedLayout
 
 __all__ = [
     "PartitionedSharedLayout",
+    "make_partitioned_dot_layouts",
 ]
 
 
@@ -67,3 +69,138 @@ class PartitionedSharedLayout(SharedLayout):
             self.partition_dim,
             self.partition_layout,
         ))
+
+
+@constexpr_function
+def _make_partitioned_dot_operand_layout(sublayout, partition_dim, num_partitions, block_mn_size, warp_coverage, order):
+    """Build a ``PartitionedSharedLayout`` for one GEMM operand.
+
+    The operand tile (``sublayout``) is split along ``partition_dim`` into
+    ``num_partitions * num_groups`` logical pieces, where
+    ``num_groups = block_mn_size // warp_coverage``.  Each piece carries an
+    inner ``PaddedSharedLayout`` rebuilt with an identity mapping using the
+    original sublayout's ``interval_padding_pairs`` and ``cga_layout``.
+    """
+    is_power_of_2 = lambda n: n > 0 and n & (n - 1) == 0
+    num_groups = block_mn_size // warp_coverage
+    assert num_groups >= 1, f"block dim ({block_mn_size}) must be >= {warp_coverage}"
+    assert is_power_of_2(num_groups), \
+        f"block_dim / warp_coverage = {num_groups} must be a power of 2"
+
+    num_logical_pieces = num_partitions * num_groups
+    inner_shape = list(sublayout.shape)
+    assert inner_shape[partition_dim] % num_logical_pieces == 0
+    inner_shape[partition_dim] //= num_logical_pieces
+
+    # TODO: when the partitioned dimension is the contiguous (fastest-varying)
+    # dimension, the interval_padding_pairs may need adjustment to preserve
+    # bank-conflict avoidance properties for the smaller piece shape.
+    inner = PaddedSharedLayout.with_identity_for(sublayout.interval_padding_pairs, inner_shape, order,
+                                                 sublayout.cga_layout)
+    return PartitionedSharedLayout(num_partitions, num_groups, partition_dim, inner)
+
+
+@constexpr_function
+def make_partitioned_dot_layouts(block_m, block_n, original_layout_a, original_layout_b, num_warps, instr_shape,
+                                 a_transposed=False, b_transposed=False):
+    """Create partitioned shared memory layouts and WMMA layout for a GFX1250 GEMM
+       in order to avoid LDS partition conflicts.
+
+    Args:
+        block_m: M dimension tile size.  Must be at least
+            ``WARP_TILES_M * instr_shape[0]`` (the per-CTA M extent covered by
+            one partition group), and a power-of-2 multiple thereof.
+        block_n: N dimension tile size.  Must be at least
+            ``WARP_TILES_N * instr_shape[1]``, and a power-of-2 multiple
+            thereof.
+        original_layout_a: ``PaddedSharedLayout`` for operand A.  Shape is
+            ``[block_m, block_k]`` when not transposed (K contiguous) and
+            ``[block_k, block_m]`` when transposed (M contiguous).
+        original_layout_b: ``PaddedSharedLayout`` for operand B.  Shape is
+            ``[block_k, block_n]`` when not transposed (N contiguous) and
+            ``[block_n, block_k]`` when transposed (K contiguous).
+        num_warps: Number of warps per CTA.  Currently must be 4 or 8.
+        instr_shape: WMMA instruction shape as ``[M, N, K]``.
+        a_transposed: Whether A is transposed in shared memory, i.e. M is
+            the contiguous axis instead of K.
+        b_transposed: Whether B is transposed in shared memory, i.e. K is
+            the contiguous axis instead of N.
+
+    Returns:
+        A tuple ``(shared_layout_a, shared_layout_b, wmma_layout)``.
+    """
+    from triton.experimental.gluon.language.amd._layouts import AMDWMMALayout
+
+    INSTR_SHAPE = list(instr_shape)
+
+    assert num_warps in (4, 8), f"Only 4 or 8 warps are currently supported, got {num_warps}"
+
+    NUM_PARTITIONS = 2
+
+    # The caller passes each sublayout with its contiguous axis at dim 1 of the
+    # tile (i.e. the tile's shape is already expressed in memory order):
+    #   A non-transposed: [block_m, block_k] — K contiguous at dim 1
+    #   A transposed:     [block_k, block_m] — M contiguous at dim 1
+    #   B non-transposed: [block_k, block_n] — N contiguous at dim 1
+    #   B transposed:     [block_n, block_k] — K contiguous at dim 1
+    # So the linear component is always built with order [1, 0] regardless of
+    # transposition. TDM additionally requires order [rank-1, ..., 0].
+    order = [1, 0]
+
+    # WMMA CTA layout: Below, M runs vertically (rows) and N
+    # horizontally (cols); each cell is one INSTR_SHAPE-sized instruction tile,
+    # labelled with the warp that computes it.  ``warp_bases`` map warp-id bits
+    # to (M, N) tile offsets, ``reg_bases`` map register-id
+    # (more specifically, instruction repetition registers) bits the same way.
+    #
+    # 4-warp case (warp_bases = [[2, 1], [1, 0]], reg_bases = [[2, 0]]):
+    #
+    #   M=0:  w0 w1   <- second tile computed by w1 (reg=1)
+    #   M=1:  w2 w3
+    #   M=2:  w0 w1   <- first tile computed by w1 (reg=0)
+    #   M=3:  w2 w3
+    #
+    # Such layout allows w0 and w1 as well as w2 and w3 to read different A/B
+    # operand data blocks in a single instruction, which is necessary precondition
+    # for avoiding LDS partition conflicts.
+    if num_warps == 4:
+        warp_bases = [[2, 1], [1, 0]]
+        reg_bases = [[2, 0]]
+    else:  # num_warps == 8
+        # Same idea as the 4-warp case, but the third warp bit replaces the
+        # register bit. This means there's no need to define repetition registers,
+        # single instruction CTA layout is enough to describe the layout we need.
+        # Each warp now owns a single instruction tile and the extra warp dimension
+        # is folded into the M-axis of the warp grid.
+        warp_bases = [[2, 1], [1, 0], [2, 0]]
+        reg_bases = []
+
+    # The tile extent along each dimension is 2^m, where m is the largest
+    # basis component in that dimension across both warp and register bases.
+    def _tile_extent(dim):
+        m = max((b[dim] for b in warp_bases + reg_bases), default=0)
+        return 1 << m
+
+    WARP_TILES_M = _tile_extent(0)
+    WARP_TILES_N = _tile_extent(1)
+
+    wmma_layout = AMDWMMALayout(3, True, warp_bases, reg_bases, INSTR_SHAPE)
+
+    # Per-CTA extent that one warp+register cycle covers in each dimension.
+    warp_coverage_m = WARP_TILES_M * INSTR_SHAPE[0]
+    warp_coverage_n = WARP_TILES_N * INSTR_SHAPE[1]
+
+    # Partition A along its M axis and B along its N axis.  These dims live
+    # at different positions in the tile depending on transposition (the
+    # contiguous axis is always at dim 1, so M / N moves to dim 0 or dim 1).
+    a_partition_dim = 1 if a_transposed else 0
+    b_partition_dim = 0 if b_transposed else 1
+
+    shared_layout_a = _make_partitioned_dot_operand_layout(original_layout_a, partition_dim=a_partition_dim,
+                                                           num_partitions=NUM_PARTITIONS, block_mn_size=block_m,
+                                                           warp_coverage=warp_coverage_m, order=order)
+    shared_layout_b = _make_partitioned_dot_operand_layout(original_layout_b, partition_dim=b_partition_dim,
+                                                           num_partitions=NUM_PARTITIONS, block_mn_size=block_n,
+                                                           warp_coverage=warp_coverage_n, order=order)
+
+    return shared_layout_a, shared_layout_b, wmma_layout

--- a/python/triton/tools/triton_to_gluon_translator/amd_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/amd_helpers.py
@@ -1,0 +1,410 @@
+# type: ignore
+
+import math
+
+import triton.language as tl
+from triton.experimental import gluon
+from triton.experimental.gluon import language as ttgl
+from triton.experimental.gluon.language.amd.gfx1250 import wmma as amd_wmma
+from triton.experimental.gluon.language.amd.gfx1250 import tdm as amd_tdm
+from triton.experimental.gluon.language.amd.cdna3 import mfma as amd_mfma
+from triton.language.target_info import current_target
+
+from triton.tools.triton_to_gluon_translator.common_helpers import *  # noqa: F401,F403
+from triton.tools.triton_to_gluon_translator.common_helpers import (
+    default_blocked_layout,
+    get_num_threads_per_warp,
+    tl_dot_decomposed_scale_arg,
+    tl_trans,
+)
+
+# ---- architecture detection ----
+
+
+@gluon.constexpr_function
+def _is_gfx1250(target=None):
+    return target is not None and target.arch == "gfx1250"
+
+
+@gluon.constexpr_function
+def _is_cdna(target=None):
+    return target is not None and target.arch in ("gfx942", "gfx950")
+
+
+@gluon.constexpr_function
+def _cdna_version(target=None):
+    """Returns 3 for gfx942, 4 for gfx950."""
+    return 4 if target is not None and target.arch == "gfx950" else 3
+
+
+# ---- AMD WMMA layout helpers (gfx1250) ----
+
+
+@gluon.constexpr_function
+def compute_warp_bases(num_warps):
+    """Distribute warps across M/N: first bit to N, rest to M."""
+    n_bits = int(math.log2(num_warps))
+    if n_bits == 0:
+        return []
+    warp_bases = [[0, 1]]
+    for i in range(n_bits - 1):
+        warp_bases.append([1 << i, 0])
+    return warp_bases
+
+
+@gluon.constexpr_function
+def get_wmma_layout(shape, num_warps):
+    warp_bases = compute_warp_bases(num_warps)
+    return ttgl.amd.AMDWMMALayout(3, True, warp_bases, [], [16, 16, 32])
+
+
+@gluon.constexpr_function
+def get_wmma_k_width(a_ty, b_ty):
+    min_bitwidth = min(a_ty.element_ty.primitive_bitwidth, b_ty.element_ty.primitive_bitwidth)
+    return max(128 // min_bitwidth, 1)
+
+
+# ---- AMD MFMA layout helpers (cdna3/cdna4) ----
+
+
+@gluon.constexpr_function
+def get_mfma_instr_k(element_bitwidth, target=None):
+    """K dimension of the MFMA instruction for [32, 32, K]."""
+    k_bits = 128 if _cdna_version(target) == 3 else 256
+    return k_bits // element_bitwidth
+
+
+@gluon.constexpr_function
+def get_mfma_layout(num_warps, element_bitwidth, target=None):
+    instr_k = get_mfma_instr_k(element_bitwidth, target)
+    return ttgl.amd.AMDMFMALayout(
+        version=_cdna_version(target),
+        instr_shape=[32, 32, instr_k],
+        transposed=True,
+        warps_per_cta=[num_warps, 1],
+    )
+
+
+@gluon.constexpr_function
+def get_mfma_k_width(a_ty, b_ty, target=None):
+    min_bitwidth = min(a_ty.element_ty.primitive_bitwidth, b_ty.element_ty.primitive_bitwidth)
+    instr_k = get_mfma_instr_k(min_bitwidth, target)
+    return instr_k // 2
+
+
+# ---- AMD dot paths ----
+
+
+@gluon.jit
+def tl_dot_wmma(a, b, acc, out_dtype):
+    """gfx1250 WMMA path."""
+    M: ttgl.constexpr = a.type.shape[0]
+    N: ttgl.constexpr = b.type.shape[1]
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+
+    wmma_layout: ttgl.constexpr = get_wmma_layout([M, N], num_warps)
+    k_width: ttgl.constexpr = get_wmma_k_width(a.type, b.type)
+    a_layout: ttgl.constexpr = ttgl.DotOperandLayout(operand_index=0, parent=wmma_layout, k_width=k_width)
+    b_layout: ttgl.constexpr = ttgl.DotOperandLayout(operand_index=1, parent=wmma_layout, k_width=k_width)
+
+    a = ttgl.convert_layout(a, a_layout)
+    b = ttgl.convert_layout(b, b_layout)
+
+    if acc is not None:
+        accumulator = ttgl.convert_layout(acc, wmma_layout)
+    else:
+        accumulator = ttgl.zeros([M, N], out_dtype, layout=wmma_layout)
+
+    result = amd_wmma(a, b, accumulator)
+
+    if acc is not None:
+        ret_layout: ttgl.constexpr = acc.type.layout
+    else:
+        ret_layout: ttgl.constexpr = default_blocked_layout(result.type.shape, num_warps)
+    return ttgl.convert_layout(result, ret_layout)
+
+
+@gluon.jit
+def tl_dot_mfma(a, b, acc, out_dtype):
+    """CDNA3/CDNA4 MFMA path."""
+    M: ttgl.constexpr = a.type.shape[0]
+    N: ttgl.constexpr = b.type.shape[1]
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    min_bitwidth: ttgl.constexpr = min(a.type.element_ty.primitive_bitwidth, b.type.element_ty.primitive_bitwidth)
+    target: ttgl.constexpr = current_target()
+
+    mfma_layout: ttgl.constexpr = get_mfma_layout(num_warps, min_bitwidth, target)
+    k_width: ttgl.constexpr = get_mfma_k_width(a.type, b.type, target)
+    a_layout: ttgl.constexpr = ttgl.DotOperandLayout(operand_index=0, parent=mfma_layout, k_width=k_width)
+    b_layout: ttgl.constexpr = ttgl.DotOperandLayout(operand_index=1, parent=mfma_layout, k_width=k_width)
+
+    a = ttgl.convert_layout(a, a_layout)
+    b = ttgl.convert_layout(b, b_layout)
+
+    if acc is not None:
+        accumulator = ttgl.convert_layout(acc, mfma_layout)
+    else:
+        accumulator = ttgl.zeros([M, N], out_dtype, layout=mfma_layout)
+
+    result = amd_mfma(a, b, accumulator)
+
+    if acc is not None:
+        ret_layout: ttgl.constexpr = acc.type.layout
+    else:
+        ret_layout: ttgl.constexpr = default_blocked_layout(result.type.shape, num_warps)
+    return ttgl.convert_layout(result, ret_layout)
+
+
+# ---- AMD dot dispatch ----
+
+
+@gluon.jit
+def tl_dot(
+    a,
+    b,
+    acc=None,
+    input_precision=None,
+    allow_tf32=None,
+    max_num_imprecise_acc=None,
+    out_dtype=ttgl.float32,
+):
+    target: ttgl.constexpr = current_target()
+    if _is_gfx1250(target):
+        return tl_dot_wmma(a, b, acc, out_dtype)
+    elif _is_cdna(target):
+        return tl_dot_mfma(a, b, acc, out_dtype)
+
+
+# Defined here (not imported from common) so __globals__ resolves tl_dot to this module's version.
+@gluon.jit
+def tl_dot_decomposed_block_scales(
+    lhs,
+    lhs_scale,
+    lhs_format,
+    rhs,
+    rhs_scale,
+    rhs_format,
+    acc=None,
+    fast_math=False,
+    lhs_k_pack=True,
+    rhs_k_pack=True,
+    out_dtype=ttgl.float32,
+):
+    if lhs_scale is None and rhs_scale is not None:
+        lhs_trans = tl_trans(lhs)
+        rhs_trans = tl_trans(rhs)
+        if acc is not None:
+            orig_layout: ttgl.constexpr = acc.type.layout
+            acc = tl_trans(acc)
+        result = tl_dot_scaled(
+            rhs_trans,
+            rhs_scale,
+            rhs_format,
+            lhs_trans,
+            lhs_scale,
+            lhs_format,
+            acc,
+            fast_math,
+            lhs_k_pack,
+            rhs_k_pack,
+            out_dtype,
+        )
+        result = tl_trans(result)
+        if acc is not None:
+            result = ttgl.convert_layout(result, orig_layout)
+        return result
+    else:
+        ttgl.static_assert(not (not lhs_k_pack or not rhs_k_pack), "TODO: support m/n packed formats")
+        compute_type: ttgl.constexpr = (ttgl.float16 if
+                                        (lhs_format == "fp16" or rhs_format == "fp16") else ttgl.bfloat16)
+
+        scale_a = tl_dot_decomposed_scale_arg(lhs, lhs_scale, lhs_format, 0, compute_type, fast_math)
+        scale_b = tl_dot_decomposed_scale_arg(rhs, rhs_scale, rhs_format, 1, compute_type, fast_math)
+
+        return tl_dot(scale_a, scale_b, acc, out_dtype=out_dtype)
+
+
+@gluon.jit
+def tl_dot_scaled(
+    lhs,
+    lhs_scale,
+    lhs_format,
+    rhs,
+    rhs_scale,
+    rhs_format,
+    acc=None,
+    fast_math=False,
+    lhs_k_pack=True,
+    rhs_k_pack=True,
+    out_dtype=ttgl.float32,
+):
+    return tl_dot_decomposed_block_scales(
+        lhs,
+        lhs_scale,
+        lhs_format,
+        rhs,
+        rhs_scale,
+        rhs_format,
+        acc,
+        fast_math,
+        lhs_k_pack,
+        rhs_k_pack,
+        out_dtype,
+    )
+
+
+# ---- AMD TDM tensor descriptors (gfx1250 only) ----
+
+
+@gluon.constexpr_function
+def get_default_tdm_layout(*block_shape):
+    block_shape = list(block_shape)
+    return ttgl.PaddedSharedLayout.with_identity_for(
+        [[block_shape[-1], 4]],
+        block_shape,
+        list(range(len(block_shape) - 1, -1, -1)),
+    )
+
+
+@tl.core._aggregate
+class AMDTensorDescriptorArgs:
+    """Wraps a real TDM descriptor alongside the original base pointer.
+
+    The base_ptr is needed by gather/scatter to recreate the descriptor with a different
+    block_shape -- Triton uses block_shape=[1, N] but TDM hardware requires [num_indices, N].
+    Shape, strides, and block_shape are read from desc (type metadata gives plain Python ints
+    for block_shape, tuples for shape/strides)."""
+    desc: amd_tdm.tensor_descriptor
+    base_ptr: tl.core.tensor
+
+
+@gluon.jit
+def tl_make_tensor_descriptor(base, shape, strides, block_shape, padding_option: ttgl.constexpr = "zero"):
+    ttgl.static_assert(_is_gfx1250(current_target()), "tl_make_tensor_descriptor requires gfx1250 target")
+    layout: ttgl.constexpr = get_default_tdm_layout(*block_shape)
+    desc = amd_tdm.make_tensor_descriptor(base, shape, strides, block_shape, layout)
+    return AMDTensorDescriptorArgs(desc, base)
+
+
+# ---- AMD obj dispatch ----
+
+
+@gluon.jit
+def tl_obj_load_amd(desc, offsets):
+    smem = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout)
+    amd_tdm.async_load(desc, offsets, smem)
+    amd_tdm.async_wait(0)
+    ret_layout: ttgl.constexpr = default_blocked_layout(desc.block_shape, ttgl.num_warps())
+    return smem.load(ret_layout)
+
+
+@gluon.jit
+def tl_obj_store_amd(desc, offsets, value):
+    smem = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout, value)
+    amd_tdm.async_store(desc, offsets, smem)
+    amd_tdm.async_wait(0)
+
+
+@gluon.jit
+def tl_obj_store(obj, offsets, value):
+    if isinstance(obj, AMDTensorDescriptorArgs):
+        tl_obj_store_amd(obj.desc, offsets, value)
+    elif isinstance(obj, amd_tdm.tensor_descriptor):
+        tl_obj_store_amd(obj, offsets, value)
+    else:
+        return obj.store(offsets, value)
+
+
+@gluon.jit
+def tl_obj_load(obj, offsets):
+    if isinstance(obj, AMDTensorDescriptorArgs):
+        return tl_obj_load_amd(obj.desc, offsets)
+    elif isinstance(obj, amd_tdm.tensor_descriptor):
+        return tl_obj_load_amd(obj, offsets)
+    else:
+        return obj.load(offsets)
+
+
+@gluon.jit
+def tl_obj_gather_amd(desc_args, x_offsets, y_offset):
+    NUM_IDX: ttgl.constexpr = x_offsets.shape[0]
+    BLOCK_N: ttgl.constexpr = desc_args.desc.block_shape[1]
+    smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [1, 0])
+    gather_block_shape: ttgl.constexpr = [NUM_IDX, BLOCK_N]
+    gather_desc = amd_tdm.make_tensor_descriptor(desc_args.base_ptr, desc_args.desc.shape, desc_args.desc.strides,
+                                                 gather_block_shape, smem_layout)
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    gather_shape: ttgl.constexpr = gather_desc.block_shape
+    idx_base: ttgl.constexpr = ttgl.BlockedLayout([gather_shape[0], 1],
+                                                  [1, get_num_threads_per_warp(current_target())], [1, num_warps],
+                                                  [1, 0])
+    idx_layout: ttgl.constexpr = ttgl.SliceLayout(1, idx_base)
+    x_offsets = ttgl.convert_layout(x_offsets, idx_layout)
+    alloc = ttgl.allocate_shared_memory(desc_args.desc.dtype, list(gather_shape), smem_layout)
+    y_off = ttgl.to_tensor(y_offset)
+    amd_tdm.async_gather(gather_desc, x_offsets, y_off, alloc)
+    amd_tdm.async_wait(0)
+    ret_layout: ttgl.constexpr = default_blocked_layout(list(gather_shape), num_warps, current_target())
+    out = alloc.load(ret_layout)
+    return out
+
+
+@gluon.jit
+def tl_obj_scatter_amd(desc_args, value, x_offsets, y_offset):
+    NUM_IDX: ttgl.constexpr = x_offsets.shape[0]
+    BLOCK_N: ttgl.constexpr = desc_args.desc.block_shape[1]
+    smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [1, 0])
+    scatter_block_shape: ttgl.constexpr = [NUM_IDX, BLOCK_N]
+    scatter_desc = amd_tdm.make_tensor_descriptor(desc_args.base_ptr, desc_args.desc.shape, desc_args.desc.strides,
+                                                  scatter_block_shape, smem_layout)
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    scatter_shape: ttgl.constexpr = scatter_desc.block_shape
+    idx_base: ttgl.constexpr = ttgl.BlockedLayout([scatter_shape[0], 1],
+                                                  [1, get_num_threads_per_warp(current_target())], [1, num_warps],
+                                                  [1, 0])
+    idx_layout: ttgl.constexpr = ttgl.SliceLayout(1, idx_base)
+    x_offsets = ttgl.convert_layout(x_offsets, idx_layout)
+    alloc = ttgl.allocate_shared_memory(desc_args.desc.dtype, list(scatter_shape), smem_layout, value)
+    y_off = ttgl.to_tensor(y_offset)
+    amd_tdm.async_scatter(scatter_desc, x_offsets, y_off, alloc)
+    amd_tdm.async_wait(0)
+
+
+@gluon.jit
+def tl_obj_gather(obj, x_offsets, y_offset):
+    if isinstance(obj, AMDTensorDescriptorArgs):
+        return tl_obj_gather_amd(obj, x_offsets, y_offset)
+    else:
+        return obj.gather(x_offsets, y_offset)
+
+
+@gluon.jit
+def tl_obj_scatter(obj, value, x_offsets, y_offset):
+    if isinstance(obj, AMDTensorDescriptorArgs):
+        tl_obj_scatter_amd(obj, value, x_offsets, y_offset)
+    else:
+        obj.scatter(value, x_offsets, y_offset)
+
+
+# ---- AMD host-side descriptor ----
+
+
+def convert_host_descriptor(desc):
+
+    def torch_dtype_to_triton(dtype):
+        import torch
+
+        if dtype == torch.float8_e5m2:
+            return ttgl.float8e5
+        if dtype == torch.float8_e4m3fn:
+            return ttgl.float8e4nv
+        return getattr(ttgl, str(dtype).split(".")[1])
+
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    assert isinstance(desc, TensorDescriptor)
+    block_shape = desc.block_shape
+    tensor = desc.base
+
+    layout = get_default_tdm_layout(*block_shape)
+    return gluon.amd.gfx1250.TensorDescriptor(tensor, list(desc.shape), list(desc.strides), block_shape, layout)

--- a/python/triton/tools/triton_to_gluon_translator/common_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/common_helpers.py
@@ -1,0 +1,273 @@
+# type: ignore
+
+from triton.experimental import gluon
+from triton.experimental.gluon import language as ttgl
+
+# hack to workaround limited dependencies tracking.
+# TODO: fix this by pulling imports into the generated file.
+from triton.language.target_info import current_target  # noqa: F401
+
+# ---- layout utilities ----
+
+
+@gluon.constexpr_function
+def get_num_threads_per_warp(target=None) -> ttgl.constexpr:
+    if target is None:
+        target = current_target()
+    if target is not None and target.backend == "hip":
+        gfx_major = int(target.arch[3:-2])
+        return ttgl.constexpr(32 if gfx_major >= 10 else 64)
+    return ttgl.constexpr(32)
+
+
+@gluon.jit
+def get_num_threads_per_program():
+    return ttgl.num_warps() * get_num_threads_per_warp(current_target())
+
+
+@gluon.constexpr_function
+def default_blocked_layout(shape: ttgl.constexpr, num_warps: ttgl.constexpr, target=None) -> ttgl.constexpr:
+    rank = len(shape)
+    size_per_thread = [1] * rank
+    threads_per_warp = [1] * rank
+    # TODO: pick a better layout based on shape. Using this allows to not have to convert layout when broadcasting but may blow up register pressure.
+    threads_per_warp[rank - 1] = get_num_threads_per_warp(target)
+    warps_per_cta = [1] * rank
+    warps_per_cta[0] = num_warps
+    order = list(range(rank - 1, -1, -1))
+    return ttgl.BlockedLayout(
+        size_per_thread=size_per_thread,
+        threads_per_warp=threads_per_warp,
+        warps_per_cta=warps_per_cta,
+        order=order,
+    )
+
+
+@gluon.constexpr_function
+def get_swizzle_byte_width(bitwidth):
+    swizzle = min(bitwidth, 128)
+    swizzle = 0 if swizzle < 32 else swizzle
+    return swizzle
+
+
+@gluon.constexpr_function
+def get_int_type(bitwidth):
+    if bitwidth == 64:
+        return ttgl.int64
+    elif bitwidth == 32:
+        return ttgl.int32
+    elif bitwidth == 16:
+        return ttgl.int16
+    elif bitwidth == 8:
+        return ttgl.int8
+    else:
+        assert False, f"Unsupported bitwidth: {bitwidth}"
+
+
+# ---- portable ops ----
+
+
+@gluon.jit
+def tl_arange(start: ttgl.constexpr, stop: ttgl.constexpr = None):
+    layout: ttgl.constexpr = default_blocked_layout([stop - start], ttgl.num_warps())
+    return ttgl.arange(start, stop, layout=layout)
+
+
+@gluon.jit
+def tl_full(shape, value, dtype=None):
+    layout: ttgl.constexpr = default_blocked_layout(shape, ttgl.num_warps())
+    return ttgl.full(shape, value, dtype, layout=layout)
+
+
+@gluon.jit
+def tl_trans(value, *dims):
+    return value.trans(*dims)
+
+
+@gluon.constexpr_function
+def cat_permute_order(rank, dim):
+    order = list(range(rank))
+    order.insert(dim, rank)
+    return order
+
+
+@gluon.constexpr_function
+def cat_result_shape(input_shape, dim):
+    result_shape = list(input_shape)
+    result_shape[dim] *= 2
+    return result_shape
+
+
+@gluon.jit
+def tl_cat(input, other, can_reorder=False, dim=0):
+    c = ttgl.join(input, other)
+    order: ttgl.constexpr = cat_permute_order(len(input.shape), dim)
+    c = ttgl.permute(c, order)
+    shape: ttgl.constexpr = cat_result_shape(input.shape, dim)
+    c = ttgl.reshape(c, shape)
+    return reset_to_default_layout(c)
+
+
+@gluon.jit
+def reset_to_default_layout(value):
+    ty: ttgl.constexpr = value.type
+    if isinstance(ty, ttgl.tuple_type):
+        out = ()
+        for i in ttgl.static_range(len(value)):
+            r = ttgl.convert_layout(value[i], layout=default_blocked_layout(value[i].type.shape, ttgl.num_warps()))
+            out = out + (r, )
+        return out
+    elif isinstance(value, ttgl.tensor) and isinstance(value.type, ttgl.distributed_type):
+        layout: ttgl.constexpr = default_blocked_layout(ty.shape, ttgl.num_warps())
+        return ttgl.convert_layout(value, layout=layout)
+    else:
+        return value
+
+
+@gluon.constexpr_function
+def get_split_src_layout(shape: ttgl.constexpr, num_warps: ttgl.constexpr, target=None) -> ttgl.constexpr:
+    rank = len(shape)
+    size_per_thread = [1 if i != rank - 1 else 2 for i in range(rank)]
+    threads_per_warp = [1 for _ in range(rank)]
+    remaining_threads = get_num_threads_per_warp(target)
+    for dim in range(rank - 2, -1, -1):
+        threads_per_warp[dim] = min(shape[dim], remaining_threads)
+        remaining_threads = remaining_threads // threads_per_warp[dim]
+    warps_per_cta = [1 for _ in range(rank)]
+    warps_per_cta[0] = num_warps
+    order = list(range(rank - 1, -1, -1))
+    return ttgl.BlockedLayout(
+        size_per_thread=size_per_thread,
+        threads_per_warp=threads_per_warp,
+        warps_per_cta=warps_per_cta,
+        order=order,
+    )
+
+
+@gluon.jit
+def set_split_src_layout(value):
+    layout: ttgl.constexpr = get_split_src_layout(value.type.shape, ttgl.num_warps())
+    return ttgl.convert_layout(value, layout=layout)
+
+
+@gluon.constexpr_function
+def build_expand_dims_layout(shape, expand_dims, num_warps):
+    if isinstance(shape, ttgl.tuple):
+        shape = shape.values
+    assert isinstance(shape, list), (f"expected shape to be a list, got {shape} which is {type(shape)}")
+    parent_shape = list(shape)
+    for dim in expand_dims:
+        parent_shape.insert(dim, 1)
+    layout = default_blocked_layout(parent_shape, num_warps)
+    for dim in reversed(expand_dims):
+        layout = ttgl.SliceLayout(dim=dim, parent=layout)
+    return layout
+
+
+@gluon.jit
+def convert_to_expand_dims_layout(value, expand_dims: list[int]):
+    layout: ttgl.constexpr = build_expand_dims_layout(value.shape, expand_dims, ttgl.num_warps())
+    return ttgl.convert_layout(value, layout)
+
+
+# ---- dot-scaled sub-helpers (vendor-neutral) ----
+
+
+@gluon.jit
+def tl_dot_decomposed_scale_to_16(scale, compute_type):
+    large_fp_type: ttgl.constexpr = ttgl.float32 if compute_type == ttgl.float16 else compute_type
+    int_width: ttgl.constexpr = large_fp_type.primitive_bitwidth
+    int_type: ttgl.constexpr = get_int_type(int_width)
+
+    zexted = ttgl.cast(scale, int_type)
+    shift_value: ttgl.constexpr = large_fp_type.fp_mantissa_width
+    shl_res = zexted << shift_value
+    scale_fp = ttgl.cast(shl_res, large_fp_type, bitcast=True)
+    if large_fp_type != compute_type:
+        scale_fp = ttgl.cast(scale_fp, compute_type)
+    return scale_fp
+
+
+@gluon.constexpr_function
+def tl_dot_get_expand_dims_layout(scale_ty, num_warps, rank):
+    shape = scale_ty.shape.values + [1]
+    blocked = default_blocked_layout(shape, num_warps)
+    slice = ttgl.SliceLayout(rank, blocked)
+    return slice
+
+
+@gluon.constexpr_function
+def tl_dot_get_permute_order(rank, dim):
+    order = list(range(rank))
+    order.insert(dim + 1, rank)
+    return order
+
+
+@gluon.constexpr_function
+def tl_dot_get_reshape_shape(scale_ty, dim):
+    shape = list(scale_ty.shape.values)
+    shape.pop()
+    shape[dim] *= 32
+    return shape
+
+
+@gluon.jit
+def tl_dot_decomposed_broadcast_scale(scale, dim):
+    scale_ty: ttgl.constexpr = scale.type
+    rank: ttgl.constexpr = len(scale_ty.shape)
+
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    slice_enc: ttgl.constexpr = tl_dot_get_expand_dims_layout(scale_ty, num_warps, rank)
+    scale = ttgl.convert_layout(scale, slice_enc)
+    expand_scale = scale.expand_dims(rank)
+    broadcast_scale = expand_scale.broadcast_to(scale.type.shape + (32, ))
+    permute_order: ttgl.constexpr = tl_dot_get_permute_order(rank, dim)
+    transposed_scale = broadcast_scale.permute(permute_order)
+    reshape_shape: ttgl.constexpr = tl_dot_get_reshape_shape(broadcast_scale.type, dim)
+    return transposed_scale.reshape(reshape_shape)
+
+
+@gluon.constexpr_function
+def tl_dot_decomposed_get_transposed_order(rank):
+    assert rank >= 2
+    order = list(range(rank - 2))
+    order += [rank - 1, rank - 2]
+    return order
+
+
+@gluon.jit
+def tl_dot_decomposed_extend_and_broadcast_scale(v, scale, compute_type, operand_index):
+    rank: ttgl.constexpr = len(v.type.shape)
+    k_dim: ttgl.constexpr = rank - 1 if operand_index == 0 else rank - 2
+
+    if operand_index == 1:
+        order: ttgl.constexpr = tl_dot_decomposed_get_transposed_order(rank)
+        scale = ttgl.permute(scale, order)
+
+    scale16 = tl_dot_decomposed_scale_to_16(scale, compute_type)
+    reshape_scale = tl_dot_decomposed_broadcast_scale(scale16, k_dim)
+    return ttgl.convert_layout(reshape_scale, v.type.layout), scale
+
+
+@gluon.jit
+def tl_dot_decomposed_mask_nan(mxfp, scale, fast_math):
+    ttgl.static_assert(fast_math, "TODO: support non-fast-math")
+    return mxfp
+
+
+@gluon.jit
+def tl_dot_decomposed_scale_arg(v, scale, arg_format, operand_index, compute_type, fast_math):
+    is_fp4: ttgl.constexpr = arg_format == "e2m1"
+    rank: ttgl.constexpr = len(v.type.shape)
+    k_dim: ttgl.constexpr = rank - 1 if operand_index == 0 else rank - 2
+
+    if is_fp4:
+        v = ttgl.fp4_to_fp(v, compute_type, k_dim)
+    else:
+        v = ttgl.cast(v, compute_type)
+    if scale is None:
+        return v
+    else:
+        reshape_scale, scale = tl_dot_decomposed_extend_and_broadcast_scale(v, scale, compute_type, operand_index)
+        mxfp = ttgl.mul(v, reshape_scale)
+        return tl_dot_decomposed_mask_nan(mxfp, scale, fast_math)

--- a/python/triton/tools/triton_to_gluon_translator/inline_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/inline_helpers.py
@@ -1,25 +1,42 @@
+_torch_dtype_to_triton_def = R"""
+def _torch_dtype_to_triton(dtype):
+    import torch
+
+    if dtype == torch.float8_e5m2:
+        return gl.float8e5
+    if dtype == torch.float8_e4m3fn:
+        return gl.float8e4nv
+    return getattr(gl, str(dtype).split(".")[1])
+"""
+
 defs: dict[str, str] = {
     "convert_host_descriptor":
-    R"""
+    _torch_dtype_to_triton_def + R"""
 def convert_host_descriptor(desc):
-    def torch_dtype_to_triton(dtype):
-        import torch
-
-        if dtype == torch.float8_e5m2:
-            return gl.float8e5
-        if dtype == torch.float8_e4m3fn:
-            return gl.float8e4nv
-        return getattr(gl, str(dtype).split(".")[1])
-
     from triton.tools.tensor_descriptor import TensorDescriptor
 
     assert isinstance(desc, TensorDescriptor)
     block_shape = desc.block_shape
     dtype = desc.base.dtype
     tensor = desc.base
-    layout = gl.NVMMASharedLayout.get_default_for(block_shape, torch_dtype_to_triton(dtype))
+    layout = gl.NVMMASharedLayout.get_default_for(block_shape, _torch_dtype_to_triton(dtype))
     return gluon.nvidia.hopper.TensorDescriptor(
         tensor, desc.shape, desc.strides, block_shape, layout
     )
-"""
+""",
+    "convert_host_descriptor_amd":
+    _torch_dtype_to_triton_def + R"""
+def convert_host_descriptor(desc):
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    assert isinstance(desc, TensorDescriptor)
+    block_shape = desc.block_shape
+    dtype = desc.base.dtype
+    layout = gl.PaddedSharedLayout.with_identity_for(
+        [[block_shape[-1], 4]], list(block_shape), [1, 0]
+    )
+    return gluon.amd.gfx1250.TensorDescriptor(
+        desc.base, list(desc.shape), list(desc.strides), block_shape, layout
+    )
+""",
 }

--- a/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
@@ -14,8 +14,18 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     tcgen05_mma_scaled,
 )
 from triton.experimental.gluon.language.nvidia.blackwell import tma as tma_blackwell
-from triton.experimental.gluon.language.nvidia.hopper import mbarrier, tma
+from triton.experimental.gluon.language.nvidia.hopper import fence_async_shared, mbarrier, tma
 from triton.language.core import _unwrap_if_constexpr
+
+from triton.tools.triton_to_gluon_translator.common_helpers import *  # noqa: F401,F403
+from triton.tools.triton_to_gluon_translator.common_helpers import (
+    default_blocked_layout,
+    get_num_threads_per_warp,
+    tl_dot_decomposed_scale_arg,
+    tl_trans,
+)
+
+# ---- NVIDIA MMA sync (Ampere) ----
 
 
 @gluon.constexpr_function
@@ -57,6 +67,9 @@ def tl_dot_mma_sync(a, b, acc_init=None, input_precision=None, out_dtype=ttgl.fl
         layout: ttgl.constexpr = default_blocked_layout(result.type.shape, ttgl.num_warps())
     result = ttgl.convert_layout(result, layout)
     return result
+
+
+# ---- NVIDIA Blackwell dot ----
 
 
 @gluon.constexpr_function
@@ -145,7 +158,6 @@ def tl_dot_blackwell(
     a_smem = get_shared_memory_mma_operand(a, 0, allow_transpose)
     b_smem = get_shared_memory_mma_operand(b, 1, allow_transpose)
 
-    # MMA instruction shape
     m: ttgl.constexpr = 128 if M >= 128 else 64
     n: ttgl.constexpr = 256 if N >= 256 else N
 
@@ -166,11 +178,13 @@ def tl_dot_blackwell(
     mbarrier.wait(bar, phase=0)
     mbarrier.invalidate(bar)
 
-    # Load back from TMEM using a register layout and convert to acc layout
     out = acc_tmem.load()
     ret_layout: ttgl.constexpr = default_blocked_layout([M, N], ttgl.num_warps())
     out = ttgl.convert_layout(out, ret_layout)
     return out
+
+
+# ---- NVIDIA dot dispatch ----
 
 
 @gluon.jit
@@ -188,6 +202,9 @@ def tl_dot(
         return tl_dot_blackwell(a, b, acc, input_precision, allow_tf32, max_num_imprecise_acc, out_dtype)
     else:
         return tl_dot_mma_sync(a, b, acc, input_precision, out_dtype)
+
+
+# ---- NVIDIA dot-scaled ----
 
 
 @gluon.constexpr_function
@@ -486,7 +503,6 @@ def tl_dot_scaled_blackwell(
     tcgen05_commit(bar)
     mbarrier.wait(bar, phase=0)
     mbarrier.invalidate(bar)
-    # Load back from TMEM using a register layout and convert to acc layout
     out = acc_tmem.load()
     ret_layout: ttgl.constexpr = default_blocked_layout([M, N], ttgl.num_warps())
     out = ttgl.convert_layout(out, ret_layout)
@@ -528,63 +544,7 @@ def default_blocked_layout(shape: ttgl.constexpr, num_warps: ttgl.constexpr) -> 
         order=order,
     )
 
-
-@gluon.jit
-def tl_obj_store(obj, offsets, value):
-    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
-        return tl_store_tensor_descriptor(obj, offsets, value)
-    else:
-        return obj.store(offsets, value)
-
-
-@gluon.jit
-def tl_obj_load(obj, offsets):
-    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
-        return tl_load_tensor_descriptor(obj, offsets)
-    else:
-        return obj.load(offsets)
-
-
-@gluon.jit
-def tl_obj_gather(obj, x_offsets, y_offset):
-    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
-        desc = obj
-        desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
-        alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout)
-        bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
-        mbarrier.init(bar, count=1)
-        x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
-            0,
-            ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
-        )
-        x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
-        mbarrier.expect(bar, x_offsets.shape[0] * obj.block_type.nbytes)
-        tma_blackwell.async_gather(desc, x_offsets, y_offset, bar, alloc)
-        mbarrier.wait(bar, phase=0)
-        mbarrier.invalidate(bar)
-        # Load from shared memory into a register tensor using a reasonable default layout
-        ret_layout: ttgl.constexpr = default_blocked_layout(desc.block_shape, ttgl.num_warps())
-        out = alloc.load(ret_layout)
-        return out
-    else:
-        return obj.gather(x_offsets, y_offset)
-
-
-@gluon.jit
-def tl_obj_scatter(obj, value, x_offsets, y_offset):
-    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
-        desc = obj
-        desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
-        alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout, value)
-        x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
-            0,
-            ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
-        )
-        x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
-        tma_blackwell.async_scatter(desc, x_offsets, y_offset, alloc)
-        tma.store_wait(0, read_only=False)
-    else:
-        obj.scatter(value, x_offsets, y_offset)
+# ---- NVIDIA TMA tensor descriptors ----
 
 
 @ttgl._core.builtin
@@ -606,15 +566,65 @@ def tl_load_tensor_descriptor(desc, offsets):
     smem = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout)
     bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
     mbarrier.init(bar, count=1)
-    # Issue async copy from global (descriptor) to shared memory and wait for completion
     mbarrier.expect(bar, desc.block_type.nbytes)
     tma.async_copy_global_to_shared(desc, offsets, bar, smem)
     mbarrier.wait(bar, phase=0)
     mbarrier.invalidate(bar)
-    # Load from shared memory into a register tensor using a reasonable default layout
     ret_layout: ttgl.constexpr = default_blocked_layout(desc.block_shape, ttgl.num_warps())
     out = smem.load(ret_layout)
     return out
+
+
+# ---- NVIDIA obj dispatch ----
+
+
+@gluon.jit
+def tl_obj_store(obj, offsets, value):
+    tl_store_tensor_descriptor(obj, offsets, value)
+
+
+@gluon.jit
+def tl_obj_load(obj, offsets):
+    return tl_load_tensor_descriptor(obj, offsets)
+
+
+@gluon.jit
+def tl_obj_gather(obj, x_offsets, y_offset):
+    desc = obj
+    desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
+    alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout)
+    bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
+    mbarrier.init(bar, count=1)
+    x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
+        0,
+        ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
+    )
+    x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
+    mbarrier.expect(bar, x_offsets.shape[0] * obj.block_type.nbytes)
+    tma_blackwell.async_gather(desc, x_offsets, y_offset, bar, alloc)
+    mbarrier.wait(bar, phase=0)
+    mbarrier.invalidate(bar)
+    ret_layout: ttgl.constexpr = default_blocked_layout(desc.block_shape, ttgl.num_warps())
+    out = alloc.load(ret_layout)
+    return out
+
+
+@gluon.jit
+def tl_obj_scatter(obj, value, x_offsets, y_offset):
+    desc = obj
+    desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
+    alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout, value)
+    fence_async_shared()
+    x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
+        0,
+        ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
+    )
+    x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
+    tma_blackwell.async_scatter(desc, x_offsets, y_offset, alloc)
+    tma.store_wait(0)
+
+
+# ---- NVIDIA host-side descriptor ----
 
 
 @gluon.jit

--- a/python/triton/tools/triton_to_gluon_translator/slice_kernel.py
+++ b/python/triton/tools/triton_to_gluon_translator/slice_kernel.py
@@ -26,6 +26,7 @@ from triton.tools.triton_to_gluon_translator.inline_helpers import defs as inlin
 from triton.tools.triton_to_gluon_translator.ordered_set import ordered_set
 from triton.tools.triton_to_gluon_translator.scoped_dict import scoped_dict
 from triton.tools.triton_to_gluon_translator.stable_toposort import stable_toposort
+from triton.tools.triton_to_gluon_translator.target import TranslatorTarget
 
 logger = logging.getLogger(__name__)
 
@@ -521,6 +522,7 @@ class SliceRewriter(ReferenceRewriter):
     translate_to_gluon: bool = False
     inline_helpers: ordered_set[str] = field(default_factory=ordered_set[str])
     cvt_context: list[bool] = field(default_factory=lambda: [False])
+    target: TranslatorTarget = TranslatorTarget.NVIDIA
 
     def __post_init__(self) -> None:
         # Special rules for sugaring imports.
@@ -562,7 +564,7 @@ class SliceRewriter(ReferenceRewriter):
             self.imports.add("import triton.experimental.gluon._runtime as gluon_runtime")
             new_node = parse_expr("gluon_runtime.GluonJITFunction")
         elif value is tl.tensor_descriptor:
-            self.imports.add("from triton.experimental.gluon.language.nvidia.hopper.tma import tensor_descriptor")
+            self.imports.add(self.target.tensor_descriptor_import)
             new_node = ast.Name(id="tensor_descriptor", ctx=ast.Load())
         return new_node
 
@@ -709,6 +711,7 @@ def slice_kernel(
     leaf_paths: list[str] | None = None,
     translate_to_gluon: bool = False,
     ignored_decorator_matchers: Sequence[DecoratorMatcher] | None = None,
+    target: TranslatorTarget = TranslatorTarget.NVIDIA,
 ) -> str:
     base_values: list[GlobalValue] = [get_base_value(root_path) for root_path in root_paths]
     base_value_ids: set[int] = set()
@@ -736,7 +739,7 @@ def slice_kernel(
             ignored_decorator_matchers=ignored_decorator_matchers,
         )
         jit_functions = [fn for fn in jit_functions if not fn.original_value.is_gluon()]
-        converted_functions = translate_kernels(jit_functions)
+        converted_functions = translate_kernels(jit_functions, target=target)
         module_file = tempfile.NamedTemporaryFile(delete=False, prefix="translated_", suffix=".py")
         module_path = Path(module_file.name)
         module_path.write_text(converted_functions)
@@ -782,6 +785,7 @@ def slice_kernel(
             ignored_decorator_matchers=tuple(ignored_decorator_matchers or ()),
             translate_to_gluon=translate_to_gluon,
             inline_helpers=inline_helpers,
+            target=target,
         )
         tree = rewriter.visit(tree)
         source = ast.unparse(tree)
@@ -807,6 +811,7 @@ def slice_kernel_from_trace(
     translate_to_gluon: bool,
     extra_modules: dict[str, str],
     ignored_decorator_matchers: Sequence[DecoratorMatcher] | None = None,
+    target: TranslatorTarget = TranslatorTarget.NVIDIA,
 ) -> str:
     module_remap: dict[str, str] = {}
     for name, path in extra_modules.items():
@@ -831,6 +836,7 @@ def slice_kernel_from_trace(
         leaf_paths=sorted(leaf_paths),
         translate_to_gluon=translate_to_gluon,
         ignored_decorator_matchers=ignored_decorator_matchers,
+        target=target,
     )
 
     fn_name = lambda path: path.split(":")[1]
@@ -853,6 +859,7 @@ def main(
     translate_to_gluon: bool = False,
     output_path: str = "/tmp/reference.py",
     ignored_decorator_matchers: Sequence[DecoratorMatcher] | None = None,
+    target: TranslatorTarget = TranslatorTarget.NVIDIA,
 ) -> None:
     output = slice_kernel(
         root_paths,
@@ -861,6 +868,7 @@ def main(
         leaf_paths,
         translate_to_gluon,
         ignored_decorator_matchers,
+        target=target,
     )
     with open(output_path, "w") as f:
         f.write(output)

--- a/python/triton/tools/triton_to_gluon_translator/target.py
+++ b/python/triton/tools/triton_to_gluon_translator/target.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class TranslatorTarget(str, Enum):
+    """Target architecture for the Triton-to-Gluon translator.
+
+    Known targets are listed as explicit members for discoverability.
+    Unknown ``gfx*`` strings are accepted via ``_missing_()`` so that
+    new AMD architectures work without adding an enum member.
+    """
+
+    NVIDIA = "nvidia"
+    # AMD targets currently exercised by the translator test suite:
+    GFX1250 = "gfx1250"
+    GFX942 = "gfx942"
+    GFX950 = "gfx950"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "TranslatorTarget | None":
+        """Allow any ``gfx*`` string as a valid AMD target."""
+        if isinstance(value, str) and value.startswith("gfx"):
+            obj = str.__new__(cls, value)
+            obj._value_ = value
+            return obj
+        return None
+
+    @property
+    def is_amd(self) -> bool:
+        return self != TranslatorTarget.NVIDIA
+
+    @property
+    def tensor_descriptor_import(self) -> str:
+        """Return the import statement for the target's tensor descriptor module."""
+        if self.is_amd:
+            return "from triton.experimental.gluon.language.amd.gfx1250.tdm import tensor_descriptor"
+        return "from triton.experimental.gluon.language.nvidia.hopper.tma import tensor_descriptor"
+
+    @property
+    def helpers_module(self) -> str:
+        """Return the helpers module path for this target."""
+        base = "triton.tools.triton_to_gluon_translator"
+        if self.is_amd:
+            return f"{base}.amd_helpers"
+        return f"{base}.nvidia_helpers"

--- a/python/triton/tools/triton_to_gluon_translator/translator.py
+++ b/python/triton/tools/triton_to_gluon_translator/translator.py
@@ -21,6 +21,7 @@ from triton.tools.triton_to_gluon_translator.slice_kernel import (
     mangle_reference_names,
     parse_expr,
 )
+from triton.tools.triton_to_gluon_translator.target import TranslatorTarget
 from triton.tools.triton_to_gluon_translator.stable_toposort import stable_toposort
 
 
@@ -108,6 +109,7 @@ def add_expr_rewrites(rewrites: list[RewriteFn]) -> None:
 @dataclass
 class Translator(ReferenceRewriter):
     tensor_member_match_fns: list[str] = field(default_factory=list)
+    target: TranslatorTarget = TranslatorTarget.NVIDIA
 
     def __post_init__(self) -> None:
         import triton
@@ -123,7 +125,7 @@ class Translator(ReferenceRewriter):
 
         self.imports.add("import triton.experimental.gluon as gluon")
         self.imports.add("import triton.experimental.gluon.language as gl")
-        self.imports.add("import triton.tools.triton_to_gluon_translator.translator_helpers as helpers")
+        self.imports.add(f"import {self.target.helpers_module} as helpers")
 
         self.tensor_member_match_fns = ["reshape", "trans", "permute", "split", "reduce", "sum"]
 
@@ -198,7 +200,7 @@ class Translator(ReferenceRewriter):
         return self.generic_visit(node)
 
 
-def translate_kernels(kernels: list[GlobalValue]) -> str:
+def translate_kernels(kernels: list[GlobalValue], target: TranslatorTarget = TranslatorTarget.NVIDIA) -> str:
 
     def filter(value: ModuleType | GlobalValue) -> bool:
         if isinstance(value, ModuleType):
@@ -240,6 +242,7 @@ def translate_kernels(kernels: list[GlobalValue]) -> str:
             imports,
             filter,
             value_remap={},
+            target=target,
         )
         tree = rewriter.visit(tree)
         source = ast.unparse(tree)
@@ -250,12 +253,12 @@ def translate_kernels(kernels: list[GlobalValue]) -> str:
     return output
 
 
-def translate_paths(kernel_paths: list[str]) -> str:
+def translate_paths(kernel_paths: list[str], target: TranslatorTarget = TranslatorTarget.NVIDIA) -> str:
     kernels = [get_base_value(kernel_path) for kernel_path in kernel_paths]
-    return translate_kernels(kernels)
+    return translate_kernels(kernels, target=target)
 
 
-def convert_triton_to_gluon(src: list[JITCallable]) -> str:
+def convert_triton_to_gluon(src: list[JITCallable], target: TranslatorTarget = TranslatorTarget.NVIDIA) -> str:
     kernels = [
         GlobalValue.wrap(
             kernel,
@@ -263,11 +266,11 @@ def convert_triton_to_gluon(src: list[JITCallable]) -> str:
             lambda: builtins,
         ) for kernel in src
     ]
-    return translate_kernels(kernels)
+    return translate_kernels(kernels, target=target)
 
 
-def main(kernels: list[str], output_path: str) -> None:
-    output = translate_paths(kernels)
+def main(kernels: list[str], output_path: str, target: TranslatorTarget = TranslatorTarget.NVIDIA) -> None:
+    output = translate_paths(kernels, target=target)
     with open(output_path, "w") as f:
         f.write(output)
 
@@ -276,8 +279,9 @@ def _main_cli() -> None:
     parser = argparse.ArgumentParser(description="Translate Triton kernels to Gluon source.")
     parser.add_argument("kernels", nargs="+", help="Kernel symbols in module.path:object format.")
     parser.add_argument("--output-path", required=True, help="Path to write the translated source.")
+    parser.add_argument("--target", default="nvidia", help="Target architecture (e.g. nvidia, amd_gfx1250).")
     args = parser.parse_args()
-    main(args.kernels, args.output_path)
+    main(args.kernels, args.output_path, target=TranslatorTarget(args.target))
 
 
 if __name__ == "__main__":

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -420,6 +420,7 @@ class HIPBackend(BaseBackend):
         passes.common.add_sccp(pm)
         passes.ttir.add_loop_aware_cse(pm)
         passes.gluon.add_canonicalizer(pm)
+        passes.ttir.add_loop_unroll(pm)
         passes.ttgpuir.add_combine_tensor_select_and_if(pm)
         amd.passes.ttgpuir.add_warp_pipeline(pm)
         passes.ttgpuir.add_allocate_warp_groups(pm)

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
@@ -6,6 +6,8 @@ using namespace mlir;
 
 using ::mlir::triton::gpu::AMDWmmaEncodingAttr;
 using ::mlir::triton::gpu::getShapePerCTA;
+using ::mlir::triton::gpu::isPermutationMatrixLayout;
+using ::mlir::triton::gpu::toLinearLayout;
 
 namespace mlir::triton::AMD {
 LogicalResult convertAMDFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
@@ -39,18 +41,26 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
   matchAndRewrite(triton::DotOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // D = A * B + C
-    Value D = op.getResult();
+    auto dType = op.getD().getType();
+    auto dEncoding = dType.getEncoding();
 
-    auto dEncoding = cast<RankedTensorType>(D.getType()).getEncoding();
+    // WMMA is the only path that has been validated against non-permutation
+    // (e.g. swizzled-warp) encodings, so handle it up front and then enforce
+    // the permutation-matrix invariant for all other paths.
+    if (isa<AMDWmmaEncodingAttr>(dEncoding))
+      return AMD::convertWMMA(op, adaptor, getTypeConverter(), rewriter);
+
+    if (!isPermutationMatrixLayout(toLinearLayout(dType.getShape(), dEncoding)))
+      return rewriter.notifyMatchFailure(op,
+                                         "Non-WMMA DotOp result encoding must "
+                                         "have a permutation-matrix linear "
+                                         "layout");
+
     if (isa<AMDMfmaEncodingAttr>(dEncoding)) {
       return AMD::convertMFMA(op, adaptor, getTypeConverter(), rewriter);
     }
-    if (isa<AMDWmmaEncodingAttr>(dEncoding)) {
-      return AMD::convertWMMA(op, adaptor, getTypeConverter(), rewriter);
-    }
 
-    if (isa<BlockedEncodingAttr>(
-            cast<RankedTensorType>(D.getType()).getEncoding()))
+    if (isa<BlockedEncodingAttr>(dEncoding))
       return AMD::convertAMDFMADot(op, adaptor, getTypeConverter(), rewriter);
 
     llvm::report_fatal_error(
@@ -65,16 +75,19 @@ struct ScaledDotOpConversion
   LogicalResult
   matchAndRewrite(triton::DotScaledOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value D = op.getResult();
+    auto dType = op.getD().getType();
+    auto dEncoding = dType.getEncoding();
 
-    auto dEncoding = cast<RankedTensorType>(D.getType()).getEncoding();
-
-    if (isa<AMDMfmaEncodingAttr>(dEncoding)) {
-      return AMD::convertScaledMFMA(op, adaptor, getTypeConverter(), rewriter);
-    }
-    if (isa<AMDWmmaEncodingAttr>(dEncoding)) {
+    if (isa<AMDWmmaEncodingAttr>(dEncoding))
       return AMD::convertScaledWMMA(op, adaptor, getTypeConverter(), rewriter);
-    }
+
+    if (!isPermutationMatrixLayout(toLinearLayout(dType.getShape(), dEncoding)))
+      return rewriter.notifyMatchFailure(
+          op, "non-WMMA dot encoding must have a permutation-matrix linear "
+              "layout");
+
+    if (isa<AMDMfmaEncodingAttr>(dEncoding))
+      return AMD::convertScaledMFMA(op, adaptor, getTypeConverter(), rewriter);
 
     llvm::report_fatal_error(
         "Unsupported DotScaleOp found when converting TritonGPU to LLVM.");

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -393,7 +393,8 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
                                 stride_bk, stride_bn,  #
                                 stride_cm, stride_cn,  #
                                 BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr, BLOCK_K: ttgl.constexpr,  #
-                                NUM_BUFFERS: ttgl.constexpr, USE_TDM: ttgl.constexpr, IS_B_K_CONTIG: ttgl.constexpr):
+                                NUM_BUFFERS: ttgl.constexpr, USE_TDM: ttgl.constexpr, IS_B_K_CONTIG: ttgl.constexpr,
+                                RESOLVE_PARTITION_CONFLICTS: ttgl.constexpr):
     a_dtype: ttgl.constexpr = a_ptr.type.element_ty
     b_dtype: ttgl.constexpr = b_ptr.type.element_ty
     ttgl.static_assert(a_dtype.is_fp16() or a_dtype.is_bf16(), "Only fp16/bf16 supported for A")
@@ -401,19 +402,24 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
     ttgl.static_assert(NUM_BUFFERS >= 2, "NUM_BUFFERS must be at least 2")
 
     BLOCKED_LAYOUT: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [4, 8], [4, 1], [1, 0])
+
+    padded_a: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[BLOCK_K, 8]], [BLOCK_M, BLOCK_K], [1, 0])
     if IS_B_K_CONTIG:
-        BLOCKED_LAYOUT_B: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [4, 8], [4, 1], [1, 0])
+        padded_b: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[BLOCK_K, 8]], [BLOCK_N, BLOCK_K], [1, 0])
     else:
-        BLOCKED_LAYOUT_B: ttgl.constexpr = ttgl.BlockedLayout([8, 1], [8, 4], [1, 4], [0, 1])
-    WMMA_LAYOUT: ttgl.constexpr = ttgl.amd.AMDWMMALayout(3, True, [[0, 1], [1, 0]], [], [16, 16, 32])
-    SHARED_LAYOUT_A: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[BLOCK_K, 8]], [BLOCK_M, BLOCK_K],
-                                                                                [1, 0])
-    if IS_B_K_CONTIG:
-        SHARED_LAYOUT_B: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[BLOCK_N, 8]], [BLOCK_K, BLOCK_N],
-                                                                                    [1, 0])
+        padded_b: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[BLOCK_N, 8]], [BLOCK_K, BLOCK_N], [1, 0])
+
+    if RESOLVE_PARTITION_CONFLICTS:
+        # The padded layouts above are reinterpreted as per-piece sublayouts here.
+        _DOT_LAYOUTS: ttgl.constexpr = ttgl.amd.gfx1250.make_partitioned_dot_layouts(
+            BLOCK_M, BLOCK_N, padded_a, padded_b, 4, [16, 16, 32], a_transposed=False, b_transposed=IS_B_K_CONTIG)
     else:
-        SHARED_LAYOUT_B: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[BLOCK_K, 8]], [BLOCK_K, BLOCK_N],
-                                                                                    [0, 1])
+        _DOT_LAYOUTS: ttgl.constexpr = (padded_a, padded_b,
+                                        ttgl.amd.AMDWMMALayout(3, True, [[0, 1], [1, 0]], [], [16, 16, 32]))
+    SHARED_LAYOUT_A: ttgl.constexpr = _DOT_LAYOUTS[0]
+    SHARED_LAYOUT_B: ttgl.constexpr = _DOT_LAYOUTS[1]
+    WMMA_LAYOUT: ttgl.constexpr = _DOT_LAYOUTS[2]
+
     OPERAND_LAYOUT_A: ttgl.constexpr = ttgl.DotOperandLayout(0, WMMA_LAYOUT, 8)
     OPERAND_LAYOUT_B: ttgl.constexpr = ttgl.DotOperandLayout(1, WMMA_LAYOUT, 8)
 
@@ -429,21 +435,38 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
         strides=(stride_am, stride_ak),  #
         block_shape=(BLOCK_M, BLOCK_K),  #
         layout=SHARED_LAYOUT_A)
-    b_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(  #
-        base=b_ptr + pid_n * BLOCK_N * stride_bn,  #
-        shape=(K, N),  #
-        strides=(stride_bk, stride_bn),  #
-        block_shape=(BLOCK_K, BLOCK_N),  #
-        layout=SHARED_LAYOUT_B)
+    if IS_B_K_CONTIG:
+        # TDM always needs the most-minor dimension to be contiguous, so for K-contiguous B we
+        # describe the tile as (BLOCK_N, BLOCK_K) and permute it before the dot.
+        b_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(  #
+            base=b_ptr + pid_n * BLOCK_N * stride_bn,  #
+            shape=(N, K),  #
+            strides=(stride_bn, stride_bk),  #
+            block_shape=(BLOCK_N, BLOCK_K),  #
+            layout=SHARED_LAYOUT_B)
+    else:
+        b_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(  #
+            base=b_ptr + pid_n * BLOCK_N * stride_bn,  #
+            shape=(K, N),  #
+            strides=(stride_bk, stride_bn),  #
+            block_shape=(BLOCK_K, BLOCK_N),  #
+            layout=SHARED_LAYOUT_B)
 
     # Pointers for AsyncCopy
     offs_ak = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT))
     offs_am = (pid_m * BLOCK_M + ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, BLOCKED_LAYOUT))) % M
     a_ptrs = a_ptr + offs_am[:, None] * stride_am + offs_ak[None, :] * stride_ak
 
-    offs_bk = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(1, BLOCKED_LAYOUT_B))
-    offs_bn = (pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT_B))) % N
-    b_ptrs = b_ptr + offs_bk[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+    if IS_B_K_CONTIG:
+        # Tile is [BLOCK_N, BLOCK_K]: N along rows, K along cols (contiguous).
+        offs_bk = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT))
+        offs_bn = (pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(1, BLOCKED_LAYOUT))) % N
+        b_ptrs = b_ptr + offs_bn[:, None] * stride_bn + offs_bk[None, :] * stride_bk
+    else:
+        # Tile is [BLOCK_K, BLOCK_N]: K along rows, N along cols (contiguous).
+        offs_bk = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(1, BLOCKED_LAYOUT))
+        offs_bn = (pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT))) % N
+        b_ptrs = b_ptr + offs_bk[:, None] * stride_bk + offs_bn[None, :] * stride_bn
 
     a_buffer = ttgl.allocate_shared_memory(a_desc.dtype, shape=[NUM_BUFFERS] + a_desc.block_shape, layout=a_desc.layout)
     b_buffer = ttgl.allocate_shared_memory(b_desc.dtype, shape=[NUM_BUFFERS] + b_desc.block_shape, layout=b_desc.layout)
@@ -456,14 +479,21 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
         if USE_TDM:
             ttgl.amd.gfx1250.tdm.async_load(a_desc, [0, load_idx * BLOCK_K],  #
                                             a_buffer.index(load_idx % NUM_BUFFERS))
-            ttgl.amd.gfx1250.tdm.async_load(b_desc, [load_idx * BLOCK_K, 0],  #
-                                            b_buffer.index(load_idx % NUM_BUFFERS))
+            if IS_B_K_CONTIG:
+                ttgl.amd.gfx1250.tdm.async_load(b_desc, [0, load_idx * BLOCK_K],  #
+                                                b_buffer.index(load_idx % NUM_BUFFERS))
+            else:
+                ttgl.amd.gfx1250.tdm.async_load(b_desc, [load_idx * BLOCK_K, 0],  #
+                                                b_buffer.index(load_idx % NUM_BUFFERS))
         else:
             mask_a = offs_ak[None, :] < K - load_idx * BLOCK_K
             ttgl.amd.gfx1250.async_copy.global_to_shared(a_buffer.index(load_idx % NUM_BUFFERS), a_ptrs, mask_a,
                                                          other=0.0)
 
-            mask_b = offs_bk[:, None] < K - load_idx * BLOCK_K
+            if IS_B_K_CONTIG:
+                mask_b = offs_bk[None, :] < K - load_idx * BLOCK_K
+            else:
+                mask_b = offs_bk[:, None] < K - load_idx * BLOCK_K
             ttgl.amd.gfx1250.async_copy.global_to_shared(b_buffer.index(load_idx % NUM_BUFFERS), b_ptrs, mask_b,
                                                          other=0.0)
             ttgl.amd.gfx1250.async_copy.commit_group()
@@ -476,14 +506,21 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
         if USE_TDM:
             ttgl.amd.gfx1250.tdm.async_load(a_desc, [0, load_idx * BLOCK_K],  #
                                             a_buffer.index(load_idx % NUM_BUFFERS))
-            ttgl.amd.gfx1250.tdm.async_load(b_desc, [load_idx * BLOCK_K, 0],  #
-                                            b_buffer.index(load_idx % NUM_BUFFERS))
+            if IS_B_K_CONTIG:
+                ttgl.amd.gfx1250.tdm.async_load(b_desc, [0, load_idx * BLOCK_K],  #
+                                                b_buffer.index(load_idx % NUM_BUFFERS))
+            else:
+                ttgl.amd.gfx1250.tdm.async_load(b_desc, [load_idx * BLOCK_K, 0],  #
+                                                b_buffer.index(load_idx % NUM_BUFFERS))
         else:
             mask_a = offs_ak[None, :] < K - load_idx * BLOCK_K
             ttgl.amd.gfx1250.async_copy.global_to_shared(a_buffer.index(load_idx % NUM_BUFFERS), a_ptrs, mask_a,
                                                          other=0.0)
 
-            mask_b = offs_bk[:, None] < K - load_idx * BLOCK_K
+            if IS_B_K_CONTIG:
+                mask_b = offs_bk[None, :] < K - load_idx * BLOCK_K
+            else:
+                mask_b = offs_bk[:, None] < K - load_idx * BLOCK_K
             ttgl.amd.gfx1250.async_copy.global_to_shared(b_buffer.index(load_idx % NUM_BUFFERS), b_ptrs, mask_b,
                                                          other=0.0)
             ttgl.amd.gfx1250.async_copy.commit_group()
@@ -498,7 +535,10 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
             ttgl.amd.gfx1250.async_copy.wait_group((NUM_BUFFERS - 1))
 
         a = a_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=OPERAND_LAYOUT_A)
-        b = b_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=OPERAND_LAYOUT_B)
+        if IS_B_K_CONTIG:
+            b = b_buffer.index(wmma_idx % NUM_BUFFERS).permute([1, 0]).load(layout=OPERAND_LAYOUT_B)
+        else:
+            b = b_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=OPERAND_LAYOUT_B)
         accumulator = ttgl.amd.gfx1250.wmma(a, b, accumulator)
         wmma_idx += 1
 
@@ -509,7 +549,10 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
             ttgl.amd.gfx1250.async_copy.wait_group((NUM_BUFFERS - 2 - i))
 
         a = a_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=OPERAND_LAYOUT_A)
-        b = b_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=OPERAND_LAYOUT_B)
+        if IS_B_K_CONTIG:
+            b = b_buffer.index(wmma_idx % NUM_BUFFERS).permute([1, 0]).load(layout=OPERAND_LAYOUT_B)
+        else:
+            b = b_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=OPERAND_LAYOUT_B)
         accumulator = ttgl.amd.gfx1250.wmma(a, b, accumulator)
         wmma_idx += 1
 
@@ -523,26 +566,42 @@ def gemm_async_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
 @pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K", [(m, n, k) for (m, n) in [(32, 32), (64, 64)] \
                                                                for k in [32, 64]])
 @pytest.mark.parametrize("NUM_BUFFERS", [2, 4])
-@pytest.mark.parametrize("IS_B_K_CONTIG", [True, False])
 @pytest.mark.parametrize("ASYNC_LOAD_TYPE", ["ASYNC_COPY", "TDM"])
-def test_compile_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, IS_B_K_CONTIG, ASYNC_LOAD_TYPE):
+@pytest.mark.parametrize("B_K_CONTIG", [True, False])
+@pytest.mark.parametrize("RESOLVE_PARTITION_CONFLICTS", [True, False])
+def test_compile_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, ASYNC_LOAD_TYPE, B_K_CONTIG,
+                                      RESOLVE_PARTITION_CONFLICTS):
+    if RESOLVE_PARTITION_CONFLICTS:
+        if ASYNC_LOAD_TYPE == "ASYNC_COPY":
+            pytest.skip("AsyncCopy is not supported with partition shared layouts")
+        # The kernel uses num_warps=4 and instr_shape=[16, 16, 32], which gives
+        # WARP_TILES_M=4 and WARP_TILES_N=2 (see make_partitioned_dot_layouts).
+        # The minimum partitionable tile size is WARP_TILES_{M,N} * instr_shape[{0,1}].
+        min_block_m = 4 * 16
+        min_block_n = 2 * 16
+        if BLOCK_M < min_block_m or BLOCK_N < min_block_n:
+            pytest.skip(
+                f"Minimal block shape for partition conflicts resolution is ({min_block_m}, {min_block_n}) along (M, N)"
+            )
+
     # Inner strides need to be constexpr (1) to get contiguity. Note the compiler frontend does the same for normal dispatches
     signature = {
         "a_ptr": "*fp16", "b_ptr": "*fp16", "c_ptr": "*fp32",  #
         "M": "i32", "N": "i32", "K": "i32",  #
         "stride_am": "i32", "stride_ak": "constexpr",  #
-        "stride_bk": "constexpr", "stride_bn": "constexpr",  #
+        "stride_bk": "constexpr" if B_K_CONTIG else "i32", "stride_bn": "i32" if B_K_CONTIG else "constexpr",  #
         "stride_cm": "i32", "stride_cn": "constexpr",  #
         "BLOCK_M": "constexpr", "BLOCK_N": "constexpr", "BLOCK_K": "constexpr",  #
-        "NUM_BUFFERS": "constexpr", "USE_TDM": "constexpr", "IS_B_K_CONTIG": "constexpr"
+        "NUM_BUFFERS": "constexpr", "USE_TDM": "constexpr", "IS_B_K_CONTIG": "constexpr", "RESOLVE_PARTITION_CONFLICTS":
+        "constexpr"
     }
 
     constexprs = {
-        "stride_ak": 1, "stride_cn": 1, "BLOCK_M": BLOCK_M, "BLOCK_N": BLOCK_N, "BLOCK_K": BLOCK_K, "NUM_BUFFERS":
-        NUM_BUFFERS, "USE_TDM": ASYNC_LOAD_TYPE == "TDM", "IS_B_K_CONTIG": IS_B_K_CONTIG
+        "stride_ak": 1, ("stride_bk" if B_K_CONTIG else "stride_bn"): 1, "stride_cn": 1,  #
+        "BLOCK_M": BLOCK_M, "BLOCK_N": BLOCK_N, "BLOCK_K": BLOCK_K, "NUM_BUFFERS": NUM_BUFFERS,  #
+        "USE_TDM": ASYNC_LOAD_TYPE == "TDM", "IS_B_K_CONTIG": B_K_CONTIG,  #
+        "RESOLVE_PARTITION_CONFLICTS": RESOLVE_PARTITION_CONFLICTS
     }
-    constexprs["stride_bn"] = BLOCK_N if not IS_B_K_CONTIG else 1
-    constexprs["stride_bk"] = BLOCK_K if IS_B_K_CONTIG else 1
 
     fn = gemm_async_pipelined_kernel
 
@@ -563,7 +622,8 @@ def test_compile_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, IS
         assert len(re.findall("tensor_load_to_lds", amdgcn)) == NUM_BUFFERS * 2
     else:
         copy_instr_for_A = BLOCK_M // 4 // 4
-        copy_isntr_for_B = (BLOCK_K if IS_B_K_CONTIG else BLOCK_N) // 4 // 4
+        b_rows = BLOCK_N if B_K_CONTIG else BLOCK_K
+        copy_isntr_for_B = b_rows // 4 // 4
         copy_instr_per_iter = copy_instr_for_A + copy_isntr_for_B
         for cnt in range(NUM_BUFFERS - 1, -1, -1):
             assert re.search(f"s_wait_asynccnt 0x{(cnt * copy_instr_per_iter):x}", amdgcn)
@@ -575,23 +635,42 @@ def test_compile_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, IS
                                                                for k in [32, 64]])
 @pytest.mark.parametrize("NUM_BUFFERS", [2, 4])
 @pytest.mark.parametrize("M,N,K", [(256, 256, 512), (240, 240, 496), (250, 250, 510)])
-@pytest.mark.parametrize("IS_B_K_CONTIG", [True, False])
 @pytest.mark.parametrize("ASYNC_LOAD_TYPE", ["ASYNC_COPY", "TDM"])
-def test_runtime_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, M, N, K, IS_B_K_CONTIG, ASYNC_LOAD_TYPE):
+@pytest.mark.parametrize("B_K_CONTIG", [True, False])
+@pytest.mark.parametrize("RESOLVE_PARTITION_CONFLICTS", [True, False])
+def test_runtime_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, M, N, K, ASYNC_LOAD_TYPE, B_K_CONTIG,
+                                      RESOLVE_PARTITION_CONFLICTS):
     if triton.cdiv(K, BLOCK_K) < NUM_BUFFERS:
         pytest.skip("Skip tests where K/BLOCK_K < NUM_BUFFERS")
 
     if ASYNC_LOAD_TYPE == "ASYNC_COPY" and any([x % 16 != 0 for x in [M, N, K]]):
         pytest.skip("AsyncCopy tests need divisibility==16 to get vectorization information")
 
+    if RESOLVE_PARTITION_CONFLICTS:
+        if ASYNC_LOAD_TYPE == "ASYNC_COPY":
+            pytest.skip("AsyncCopy is not supported with partition shared layouts")
+        # The kernel uses num_warps=4 and instr_shape=[16, 16, 32], which gives
+        # WARP_TILES_M=4 and WARP_TILES_N=2 (see make_partitioned_dot_layouts).
+        # The minimum partitionable tile size is WARP_TILES_{M,N} * instr_shape[{0,1}].
+        min_block_m = 4 * 16
+        min_block_n = 2 * 16
+        if BLOCK_M < min_block_m or BLOCK_N < min_block_n:
+            pytest.skip(
+                f"Minimal block shape for partition conflicts resolution is ({min_block_m}, {min_block_n}) along (M, N)"
+            )
+
     torch.manual_seed(42)
 
     a = torch.randn((M, K), dtype=torch.float16)
-    b = torch.randn((K, N), dtype=torch.float16)
+    if B_K_CONTIG:
+        # Allocate as (N, K) and transpose so that the K dimension is the contiguous one.
+        b = torch.randn((N, K), dtype=torch.float16).t()
+    else:
+        b = torch.randn((K, N), dtype=torch.float16)
     c = torch.zeros((M, N), dtype=torch.float32)
 
     a_device = a.cuda()
-    b_device = b.cuda() if IS_B_K_CONTIG else b.data.T.contiguous().T.cuda()
+    b_device = b.cuda() if B_K_CONTIG else b.data.T.contiguous().T.cuda()
     c_device = c.cuda()
 
     stride_am, stride_ak = a_device.stride(0), a_device.stride(1)
@@ -606,7 +685,8 @@ def test_runtime_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, M,
         stride_bk, stride_bn,  #
         stride_cm, stride_cn,  #
         BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,  #
-        NUM_BUFFERS=NUM_BUFFERS, USE_TDM=ASYNC_LOAD_TYPE == "TDM", IS_B_K_CONTIG=IS_B_K_CONTIG)
+        NUM_BUFFERS=NUM_BUFFERS, USE_TDM=ASYNC_LOAD_TYPE == "TDM", IS_B_K_CONTIG=B_K_CONTIG,
+        RESOLVE_PARTITION_CONFLICTS=RESOLVE_PARTITION_CONFLICTS)
 
     c_triton = c_device.cpu()
     c_torch = a.to(torch.float32) @ b.to(torch.float32)

--- a/third_party/amd/python/test/test_warp_pipeline_gfx9.py
+++ b/third_party/amd/python/test/test_warp_pipeline_gfx9.py
@@ -17,7 +17,7 @@ def _compile_gluon(fn, signature, constexprs, arch="gfx950"):
 
 @gluon.jit
 def pipeline_simple(A, B, BLOCK: gl.constexpr):
-    """Minimal 2-stage pipeline — baseline for s_setprio check."""
+    """Minimal 2-stage pipeline -- baseline for s_setprio check."""
     blocked: gl.constexpr = gl.BlockedLayout(size_per_thread=[1, 8], threads_per_warp=[16, 4],
                                              warps_per_cta=[gl.num_warps(), 1], order=[1, 0])
     offs_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=blocked)
@@ -31,6 +31,29 @@ def pipeline_simple(A, B, BLOCK: gl.constexpr):
             gl.store(B + offs, a)
 
 
+@gluon.jit
+def pipeline_unrolled(A, B, N, BLOCK: gl.constexpr):
+    """2-stage pipeline with loop unrolling -- IV used inside stages.
+
+    The IV must be referenced inside execute_region bodies so only the
+    scalar IV-remap ops (arith.muli + arith.addi on the index) land
+    between the cloned clusters after unrolling.  Gluon skips make_ttir,
+    so loop_unroll_factor survives until after add_warp_pipeline.
+    """
+    blocked: gl.constexpr = gl.BlockedLayout(size_per_thread=[1, 8], threads_per_warp=[16, 4],
+                                             warps_per_cta=[gl.num_warps(), 1], order=[1, 0])
+    offs_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=blocked)
+    base = gl.arange(0, BLOCK, layout=offs_layout)
+
+    for i in tl.range(0, N, loop_unroll_factor=2):
+        with warp_pipeline_stage("stage1", priority=1):
+            offs = base + i * BLOCK
+            a = gl.load(A + offs)
+
+        with warp_pipeline_stage("stage2", priority=0):
+            gl.store(B + offs, a)
+
+
 def test_simple_pipeline_setprio():
     """Baseline: a simple 2-stage pipeline emits s_setprio."""
     signature = {"A": "*fp16", "B": "*fp16", "BLOCK": "constexpr"}
@@ -38,3 +61,66 @@ def test_simple_pipeline_setprio():
     k = _compile_gluon(pipeline_simple, signature, constexprs)
     amdgcn = k.asm["amdgcn"]
     assert amdgcn.count("s_setprio") > 0, "Simple pipeline must emit s_setprio."
+
+
+def test_pipeline_with_unroll():
+    """Warp pipeline + loop unrolling: IV remap ops between stages must not break conversion.
+
+    Gluon kernels skip make_ttir, so loop_unroll_factor survives until the
+    Gluon pipeline where add_loop_unroll runs AFTER add_warp_pipeline.  The
+    MLIR unroller emits arith.muli+arith.addi for IV remapping between the
+    cloned execute_region clusters -- ConvertWarpPipeline must tolerate these.
+    """
+    signature = {"A": "*fp16", "B": "*fp16", "N": "i32", "BLOCK": "constexpr"}
+    constexprs = {"BLOCK": BLOCK}
+    k = _compile_gluon(pipeline_unrolled, signature, constexprs)
+    amdgcn = k.asm["amdgcn"]
+    # Each successfully converted loop emits s_setprio instructions.
+    # With unroll factor 2 and dynamic bound, we get a main loop + epilogue.
+    # Both must convert: without the fix only the epilogue converts (4 s_setprio),
+    # with the fix both convert (10 s_setprio).
+    assert amdgcn.count("s_setprio") > 4, \
+        f"Expected > 4 s_setprio (both main+epilogue converted), got {amdgcn.count('s_setprio')}"
+
+
+@gluon.jit
+def pipeline_static_range_unrolled(A, B, N, BLOCK: gl.constexpr):
+    """Outer loop_unroll_factor + static_range wrapping both stages.
+
+    The outer tl.range has loop_unroll_factor=2, so MLIR unrolling injects
+    scalar IV remap ops between cloned bodies.  Inside each iteration,
+    static_range(2) duplicates both pipeline stages at the AST level.
+    This is the worst-case combo for ConvertWarpPipeline: the loop body
+    has 4 execute_region clusters with scalar ops between them.
+    """
+    blocked: gl.constexpr = gl.BlockedLayout(size_per_thread=[1, 8], threads_per_warp=[16, 4],
+                                             warps_per_cta=[gl.num_warps(), 1], order=[1, 0])
+    offs_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=blocked)
+    base = gl.arange(0, BLOCK, layout=offs_layout)
+
+    for i in tl.range(0, N, loop_unroll_factor=2):
+        for j in gl.static_range(2):
+            with warp_pipeline_stage("stage1", priority=1):
+                offs = base + (i + j) * BLOCK
+                a = gl.load(A + offs)
+
+            with warp_pipeline_stage("stage2", priority=0):
+                gl.store(B + offs, a)
+
+
+def test_pipeline_static_range_with_unroll():
+    """static_range wrapping both stages + outer loop_unroll_factor must convert."""
+    signature = {"A": "*fp16", "B": "*fp16", "N": "i32", "BLOCK": "constexpr"}
+    constexprs = {"BLOCK": BLOCK}
+    k = _compile_gluon(pipeline_static_range_unrolled, signature, constexprs)
+    amdgcn = k.asm["amdgcn"]
+    setprio_lines = [line.strip() for line in amdgcn.splitlines() if "s_setprio" in line]
+    prios = [int(l.split()[-1]) for l in setprio_lines]
+    # Each converted loop emits: 1 pre-loop + (N-1) in-body + 1 wrap-around + 1 post-loop reset.
+    # Main loop has 8 clusters (static_range(2) * 2 stages * unroll(2)): 1+7+1+1 = 10.
+    # Epilogue has 4 clusters (static_range(2) * 2 stages): 1+3+1+1 = 6.
+    # Total: 16 s_setprio.  Both priority levels must appear.
+    assert len(prios) == 16, \
+        f"Expected 16 s_setprio (main=10 + epilogue=6), got {len(prios)}: {prios}"
+    assert prios.count(0) == 8 and prios.count(1) == 8, \
+        f"Expected 8 prio-0 and 8 prio-1, got {prios}"

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
@@ -9,7 +9,9 @@ using namespace mlir;
 using namespace mlir::triton;
 
 using ::mlir::triton::gpu::getShapePerCTA;
+using ::mlir::triton::gpu::isPermutationMatrixLayout;
 using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
+using ::mlir::triton::gpu::toLinearLayout;
 
 LogicalResult convertMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                          const LLVMTypeConverter *typeConverter,
@@ -43,6 +45,12 @@ struct ScaledDotOpConversion
   LogicalResult
   matchAndRewrite(triton::DotScaledOp op, triton::DotScaledOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto rty = cast<RankedTensorType>(op.getResult().getType());
+    if (!isPermutationMatrixLayout(
+            toLinearLayout(rty.getShape(), rty.getEncoding())))
+      return rewriter.notifyMatchFailure(
+          op, "ScaledDotOp result encoding must have a permutation-matrix "
+              "linear layout");
     return convertMMADotScaled(op, adaptor, getTypeConverter(), rewriter);
   }
 
@@ -63,9 +71,16 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
                   ConversionPatternRewriter &rewriter) const override {
     // D = A * B + C
     Value D = op.getResult();
+    auto dType = op.getResult().getType();
+    auto dEncoding = dType.getEncoding();
 
-    NvidiaMmaEncodingAttr mmaLayout = dyn_cast<NvidiaMmaEncodingAttr>(
-        cast<RankedTensorType>(D.getType()).getEncoding());
+    if (!isPermutationMatrixLayout(toLinearLayout(dType.getShape(), dEncoding)))
+      return rewriter.notifyMatchFailure(
+          op,
+          "DotOp result encoding must have a permutation-matrix linear layout");
+
+    NvidiaMmaEncodingAttr mmaLayout =
+        dyn_cast<NvidiaMmaEncodingAttr>(dEncoding);
     if (mmaLayout) {
       if (mmaLayout.getVersionMajor() == 2) {
         return convertMMA(op, adaptor, getTypeConverter(), rewriter,
@@ -76,8 +91,7 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
           "Unsupported MMA kind found when converting DotOp to LLVM.");
     }
 
-    if (isa<BlockedEncodingAttr>(
-            cast<RankedTensorType>(D.getType()).getEncoding()))
+    if (isa<BlockedEncodingAttr>(dEncoding))
       return convertFMADot(op, adaptor, getTypeConverter(), rewriter);
 
     llvm::report_fatal_error(


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/9666

Upstream commit message:
```
> [AMD] Enable loop unrolling for Gluon warp-pipelined kernels (#9666)

> Two changes to support loop_unroll_factor on AMD Gluon kernels with
> warp pipeline stages (e.g. the gfx950 FA example):

> 1. Gluon skips make_ttir, so add add_loop_unroll to the Gluon pipeline
>    before add_warp_pipeline.

> 2. The MLIR loop unroller injects scalar arith.addi/muli IV-remap ops
>    at iteration boundaries. In kernels whose iteration begins with an
>    ignorable op (async_wait/barrier), those scalars land between a
>    border and the next ignorable, which poisons WarpPipeliner's cluster
>    building. Add a local pre-pass inside createPipeline that sinks pure
>    scalar ops past adjacent ignorable ops so they join the next cluster
>    naturally. No changes to ConvertWarpPipeline required.

> ---------

> Signed-off-by: Ivan Butygin <ivan.butygin@gmail.com>
> Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
```

***Do not remove the following line from this commit***
Reactor Backport Revision: 2ad055bd17f1f8dcae39226214117720aca47352
 ---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 9666
```

Reviewed By: htyu

Differential Revision: D114118208
