### PR TITLE
[triton][beta] [Cherry-pick][BUNDLE] Cherry-pick 2 upstream(#10287 #10056) (#2548)

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -146,6 +146,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerTritonAMDFoldTrueCmpI();
   mlir::registerTritonAMDGPUFpSanitizer();
   mlir::triton::amdgpu::registerTritonAMDGPUOptimizeDotOperands();
+  mlir::registerConSanAMDHooks();
 
   // NVWS passes
   mlir::triton::registerNVWSTransformsPasses();

--- a/include/triton/Conversion/TritonGPUToLLVM/Passes.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Passes.h
@@ -18,6 +18,8 @@ namespace triton::gpu {
 #define GEN_PASS_REGISTRATION
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h.inc"
 
+void runGlobalScratchMemoryAllocation(ModuleOp module);
+
 } // namespace triton::gpu
 
 } // namespace mlir

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOpInterfaces.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOpInterfaces.td
@@ -42,4 +42,39 @@ def InferMemDescTypeOpWithLayoutEquivalence : InferTypeOpAdaptorBase<[{
   }
 }]>;
 
+def MBarrierOpInterface : OpInterface<"MBarrierOpInterface"> {
+  let description = [{
+    Interface for operations that use mbarrier synchronization primitives.
+    Returns the barrier memdesc operand (or null if absent), allowing
+    backend-agnostic barrier identification without direct dialect dependencies.
+  }];
+
+  let cppNamespace = "::mlir::triton::gpu";
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/"Return the barrier memdesc operand, or null if absent.",
+      /*retType=*/"::mlir::TypedValue<::mlir::triton::gpu::MemDescType>",
+      /*methodName=*/"getBarrier",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return {};
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/"Return all barrier memdesc operands.",
+      /*retType=*/"::llvm::SmallVector<::mlir::Value>",
+      /*methodName=*/"getBarriers",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        if (::mlir::Value barrier = $_op.getBarrier())
+          return {barrier};
+        return {};
+      }]
+    >
+  ];
+}
+
 #endif // TRITONGPU_OP_INTERFACES

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -96,31 +96,37 @@ public:
   // verifyBarrierCanInit: ensure the barrier is currently invalidated before
   // initializing it again.
   void createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b, Value mbar,
-                                      Operation *insertPoint);
+                                      Value pred, Operation *insertPoint,
+                                      Value recipientCTAs);
   // verifyBarrierInitialized: ensure the barrier has been initialized and not
   // invalidated before it is used.
   void createVerifyBarrierInitializedCall(ImplicitLocOpBuilder &b, Value mbar,
-                                          Value pred, Operation *insertPoint);
+                                          Value pred, Operation *insertPoint,
+                                          Value recipientCTAs);
   // initBarrierState: Initialize the tracked barrier state to phase 0 and set
   // both the initial and current arrival counts. A zero state denotes an
   // invalidated/uninitialized barrier.
   void createInitBarrierStateCall(ImplicitLocOpBuilder &b, Value mbar,
-                                  int count, Operation *insertPoint);
+                                  int count, Value pred,
+                                  Operation *insertPoint);
   // invalidateBarrierState: clear the tracked barrier lifecycle state and any
   // waiting bits for the barrier.
   void createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b, Value mbar,
-                                        Operation *insertPoint);
+                                        Value pred, Operation *insertPoint);
   // verifyBarrierArrive: Check that applying the arrive count would not drive
-  // the tracked current count negative. Triggers an assertion on failure.
+  // the tracked current count negative, and that applying the tx-count delta
+  // would keep it in range. Triggers an assertion on failure.
   void createVerifyBarrierArriveCall(ImplicitLocOpBuilder &b, Value mbar,
                                      int count, Value pred,
-                                     Operation *insertPoint);
+                                     Operation *insertPoint,
+                                     Value recipientCTAs, int txCount = 0);
   // updateBarrierState: Apply an arrive count to the tracked barrier state,
-  // toggling the phase when the count reaches zero and reloading the current
-  // count from the initial count.
+  // apply a tx-count delta, toggling the phase when both counts reach zero and
+  // reloading the current count from the initial count.
   void createUpdateBarrierStateCall(ImplicitLocOpBuilder &b, Value mbar,
                                     int count, Value pred,
-                                    Operation *insertPoint);
+                                    Operation *insertPoint, Value recipientCTAs,
+                                    int txCount = 0);
   // setWriteVisibility: Set the write visibility for a buffer. Marks the buffer
   // as visible to the threads set in threadMask. Clears out any other threads
   // from the visibility bitmask. We know this is safe because there cannot be
@@ -128,42 +134,48 @@ public:
   void createSetWriteVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
                                     uint32_t length, uint64_t threadMask,
                                     Value pred, MemType memType,
-                                    Operation *insertPoint);
+                                    Operation *insertPoint,
+                                    Value recipientCTAs);
   // setReadVisibility: add the threads set in threadMask to the buffer's read
   // visibility bitmask.
   void createSetReadVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
                                    uint32_t length, uint64_t threadMask,
                                    Value pred, MemType memType,
-                                   Operation *insertPoint);
+                                   Operation *insertPoint, Value recipientCTAs);
   // clearWriteTracking: clear all the information about threads writing to a
   // buffer.
   void createClearWriteTrackingCall(ImplicitLocOpBuilder &b, Value buf,
                                     uint32_t length, Value pred,
-                                    MemType memType, Operation *insertPoint);
+                                    MemType memType, Operation *insertPoint,
+                                    Value recipientCTAs);
   // clearReadVisibility: clear the read visibility for a buffer.
   void createClearReadVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
                                      uint32_t length, Value pred,
-                                     MemType memType, Operation *insertPoint);
+                                     MemType memType, Operation *insertPoint,
+                                     Value recipientCTAs);
   // clearReadTracking: clear the read tracking for a buffer.
   void createClearReadTrackingCall(ImplicitLocOpBuilder &b, Value buf,
                                    uint32_t length, Value pred, MemType memType,
-                                   Operation *insertPoint);
+                                   Operation *insertPoint, Value recipientCTAs);
   // trackVisibleWrites: snapshot buffers currently visible to the thread into
   // the tracking table for a barrier.
   void createTrackVisibleWritesCall(ImplicitLocOpBuilder &b, Value mbar,
                                     int thread, Value pred, MemType memType,
-                                    Operation *insertPoint);
+                                    Operation *insertPoint,
+                                    Value recipientCTAs);
   // trackVisibleReads: snapshot buffers currently visible to the thread into
   // the read tracking table for a barrier.
   void createTrackVisibleReadsCall(ImplicitLocOpBuilder &b, Value mbar,
                                    int thread, Value pred, MemType memType,
-                                   Operation *insertPoint);
+                                   Operation *insertPoint, Value recipientCTAs);
   // trackBarrierWriteForBuffer: mark a specific buffer as tracked by a
   // barrier in the write-tracking table.
   void createTrackBarrierWriteForBufferCall(ImplicitLocOpBuilder &b, Value mbar,
                                             Value buf, uint32_t length,
                                             Value pred, MemType memType,
-                                            Operation *insertPoint);
+                                            Operation *insertPoint,
+                                            Value barrierRecipientCTAs,
+                                            Value effectRecipientCTAs);
   // clearBarrierWriteTracking: clear all write tracking associated with the
   // given barrier row.
   void createClearBarrierWriteTrackingCall(ImplicitLocOpBuilder &b, Value mbar,
@@ -189,13 +201,15 @@ public:
   void createVerifyWriteVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
                                        uint32_t length, int thread,
                                        StringRef operandName, Value pred,
-                                       MemType memType, Operation *insertPoint);
+                                       MemType memType, Operation *insertPoint,
+                                       Value recipientCTAs);
   // verifyReadVisibility: ensure all reads from the buffer are visible to the
   // thread.
   void createVerifyReadVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
                                       uint32_t length, int thread,
                                       StringRef operandName, Value pred,
-                                      MemType memType, Operation *insertPoint);
+                                      MemType memType, Operation *insertPoint,
+                                      Value recipientCTAs);
   // copyWriteVisibility: replicate the write visibility bit of sourceThread to
   // every destination thread in destMask.
   void createCopyWriteVisibilityCall(ImplicitLocOpBuilder &b, int sourceThread,
@@ -232,14 +246,24 @@ public:
       ImplicitLocOpBuilder &b, int thread, uint64_t transferThreadMask,
       int outstandingNum, Value pred, CommitKind::Kind commitKind,
       MemType memType, Operation *insertPoint);
+  // clearOutstandingCommitsTransferBoth: clear entries farther than
+  // outstandingNum from the thread and set both write and read visibility
+  // for threads in transferThreadMask. Handles the partial case gracefully:
+  // if only one visibility table exists, delegates to the corresponding
+  // single-transfer function.
+  void createClearOutstandingCommitsTransferBothCall(
+      ImplicitLocOpBuilder &b, int thread, uint64_t transferThreadMask,
+      int outstandingNum, Value pred, CommitKind::Kind commitKind,
+      MemType memType, Operation *insertPoint);
   // checkOutstandingCommits: assert that the outstanding commit row for the
   // buffer is zero before the access described by pendingAccessType.
-  void createCheckOutstandingCommitsCall(ImplicitLocOpBuilder &b, Value buf,
-                                         uint32_t length, int thread,
-                                         StringRef pendingAccessType,
-                                         Value pred, MemType memType,
-                                         CommitKind::Kind commitKind,
-                                         Operation *insertPoint);
+  // When excludeSelf is true, the calling thread's own column is masked out
+  // so that only other partitions' outstanding commits are checked.
+  void createCheckOutstandingCommitsCall(
+      ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
+      StringRef pendingAccessType, Value pred, MemType memType,
+      CommitKind::Kind commitKind, Operation *insertPoint, Value recipientCTAs,
+      bool excludeSelf = false);
 
 private:
   ModuleOp module;

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -31,7 +31,7 @@ All types are generated on-demand (per partition) based on:
 - readVisibility (scratch, <B x 64 x i64>): Per-buffer, per-thread lanes. Each lane stores a 64-bit mask of other threads whose reads are visible to that lane’s thread
 - writeTracking (scratch, <B x K x i8>): Map buffers → barriers tracking writes (boolean stored in i8)
 - readTracking (scratch, <B x K x i64>): Map buffers → barriers tracking reads (bitmask of threads)
-- barrierStates (scratch, <K x i32>): Packed barrier metadata. Bit 0 stores the current phase, bits [1..8] the initial arrival count, bits [9..16] the current arrival count. The verifier checks underflow before updating, and flips the phase when the current count reaches zero.
+- barrierStates (scratch, <K x i64>): Packed barrier metadata. Bit 0 stores the current phase, bits [1..20] the initial arrival count, bits [21..40] the current arrival count, and bits [41..61] the signed tx-count. The verifier checks underflow before updating, and flips the phase when both the current count and tx-count reach zero.
 - waiting (scratch, <K x i32>): Per-barrier bitfield describing waiting threads. Each base thread gets two bits: bit (2 * thread + 0) is the waiting flag, bit (2 * thread + 1) stores the phase the thread is waiting on.
 - outstandingCommits (scratch, <B x 16 x i8>): Per-buffer, per-base-thread commit counters for cp.async and wgmma
 
@@ -58,8 +58,8 @@ ConSan separates “tracking” from “visibility transfer”:
 ### Barrier phase/count tracking
 
 - experimental_init_barrier_state(barrier, count, barrierStates) initializes the per-barrier state with phase = 0 and both initial/current arrival counts = `count`.
-- experimental_verify_barrier_arrive(barrier, count, barrierStates) checks that subtracting `count` from the current arrival count would not underflow. The codegen emits an assert if it would.
-- experimental_update_barrier_state(barrier, count, barrierStates) applies the arrive: subtracts `count`, flips the phase when the count reaches zero, and reloads the current count from the initial count.
+- experimental_verify_barrier_arrive(barrier, count, txCount, barrierStates) checks that subtracting `count` from the current arrival count would not underflow and that applying `txCount` keeps the tx-count in range. The codegen emits an assert if it would not.
+- experimental_update_barrier_state(barrier, count, txCount, barrierStates) applies the arrive and tx-count delta, flips the phase when both counts reach zero, and reloads the current count from the initial count.
 
 ### Deadlock detection
 

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -1,6 +1,7 @@
 #ifndef TRITONINSTRUMENT_UTILITY_H
 #define TRITONINSTRUMENT_UTILITY_H
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "triton/Analysis/BufferRegion.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
@@ -28,6 +29,42 @@ namespace CommitKind {
 enum Kind { None = -1, AsyncCp = 0, Wgmma, TmaStore, NumCommitKinds };
 }
 
+// -- ConSan capture-count constants -----------------------------------------
+// Each constant corresponds to specific passToWarpSpecialize() calls in
+// populateAndPassToWarpSpecialize().  Keep in sync with that function and
+// with estimateConSanCaptureCount() below.
+
+// writeVisibility + readVisibility per active memory type.
+constexpr int kCapturesPerMemType = 2;
+
+// barrierStates + waiting + barrierWriteRecipients (only when barriers exist).
+constexpr int kBarrierBaseCaptures = 3;
+
+// writeTracking + readTracking per active memory type (only when barriers
+// exist and the memory type has buffers).
+constexpr int kBarrierTrackingCapturesPerMemType = 2;
+
+// The lock variable (always present).
+constexpr int kFixedCaptures = 1;
+
+// Size in bytes of each capture (a global-scratch pointer).
+constexpr int kCaptureSizeBytes = 8;
+
+/// Estimate the number of WarpSpecialize captures that the
+/// ConcurrencySanitizer pass will add via passToWarpSpecialize().
+/// \p numActiveMemTypes  Number of memory types with buffers.
+/// \p hasBarriers        Whether barriers exist in the module.
+/// \p numCommitKinds     Number of distinct commit kinds required.
+inline int estimateConSanCaptureCount(int numActiveMemTypes, bool hasBarriers,
+                                      int numCommitKinds) {
+  int perMemType = kCapturesPerMemType * numActiveMemTypes;
+  int barrierCaptures =
+      hasBarriers ? kBarrierBaseCaptures +
+                        kBarrierTrackingCapturesPerMemType * numActiveMemTypes
+                  : 0;
+  return perMemType + barrierCaptures + kFixedCaptures + numCommitKinds;
+}
+
 void createAssertInThread(ImplicitLocOpBuilder &b, Value condition,
                           StringRef message);
 Operation *createStoreScratchMemory(OpBuilder &b, Location loc, Value alloc,
@@ -51,6 +88,14 @@ TypedValue<RankedTensorType> createConstIntTensor(OpBuilder &builder,
                                                   bool isSigned = false);
 uint32_t getMemDescLength(Value buf);
 FuncOp getEntryPoint(ModuleOp module);
+
+inline Value maybeAnd(ImplicitLocOpBuilder &b, Value lhs, Value rhs) {
+  if (!lhs)
+    return rhs;
+  if (!rhs)
+    return lhs;
+  return arith::AndIOp::create(b, lhs, rhs);
+}
 
 struct ValueType {
   Value value;
@@ -105,7 +150,6 @@ struct AuxDataMap {
   // Per-memory-type packed buffer descriptors. Each i64 stores the 32-bit base
   // offset and 32-bit length of one shared-memory or tensor-memory region.
   RegionToValueMap buffers[numMemTypes];
-
   // tensor, <C x K x i64>
   // Packed descriptors for tracked mbarrier allocations. Barriers are shared
   // memory descriptors.
@@ -116,6 +160,10 @@ struct AuxDataMap {
   // phase, bits [1..20] are the initial arrival count, bits [21..40] are the
   // current arrival count, and bits [41..61] hold a signed tx-count.
   RegionToValueMap barrierStates;
+
+  // tensor, <C x K x C x i1>
+  // Recipient CTA mask for writes tracked by each barrier.
+  RegionToValueMap barrierWriteRecipients;
 
   // scratch, <C x B x i64>
   // Per-memory-type write frontier. Bit i means logical ConSan thread i can see
@@ -171,7 +219,7 @@ private:
       SmallVector<SmallVector<triton::BufferRegion>, 2> &bufRegions,
       SmallVector<triton::BufferRegion> &barrierRegions);
   void passToWarpSpecialize(triton::FuncOp func, ValueType value,
-                            RegionToValueMap &map);
+                            RegionToValueMap &map, int &captureCounter);
   void createInWarpSpecialize(
       triton::FuncOp func, RegionToValueMap &map,
       std::function<ValueType(ImplicitLocOpBuilder &)> createFn);

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -14,11 +14,9 @@ namespace mlir::triton::instrument {
 struct MemEffectsOpInfo {
   // Frontier: snapshot thread-visible frontier into barrier tracking.
   // EffectWrites: track only buffers written by op effects.
-  // None: perform no visibility tracking for the barrier.
   enum class BarrierTrackingMode {
     Frontier,
     EffectWrites,
-    None,
   };
   struct Effects {
     enum RW { Read, Write } rw;
@@ -35,6 +33,7 @@ struct MemEffectsOpInfo {
     Value pred;
     int count;
     BarrierTrackingMode trackingMode = BarrierTrackingMode::Frontier;
+    int txCount = 0;
   };
   enum class TrackingKind {
     None,
@@ -62,10 +61,20 @@ struct BarrierWaitInfo {
   Value pred;
 };
 
+struct BarrierInvalidateInfo {
+  Value alloc;
+};
+
 struct WaitOpInfo {
   CommitKind::Kind commitKind;
   int pendingCount;
   bool transferWrites;
+  bool transferReads;
+};
+
+struct CommitKindDesc {
+  CommitKind::Kind kind;
+  std::string operationDesc;
 };
 
 class ConSanTargetHooks {
@@ -73,7 +82,6 @@ public:
   virtual ~ConSanTargetHooks() = default;
 
   virtual bool isTMAOp(Operation *op) const = 0;
-  virtual bool isPostInstrumentedOp(Operation *op) const = 0;
 
   virtual std::optional<BarrierInitInfo>
   getBarrierInitInfo(Operation *op) const = 0;
@@ -81,7 +89,13 @@ public:
   virtual std::optional<BarrierWaitInfo>
   getBarrierWaitInfo(Operation *op) const = 0;
 
+  virtual std::optional<BarrierInvalidateInfo>
+  getBarrierInvalidateInfo(Operation *op) const = 0;
+
   virtual std::optional<WaitOpInfo> getWaitOpInfo(Operation *op) const = 0;
+
+  virtual Value getIssuerCTAPred(ImplicitLocOpBuilder &b,
+                                 Operation *op) const = 0;
 
   virtual std::optional<MemEffectsOpInfo>
   getMemEffectsOpInfo(Operation *op) const {
@@ -115,6 +129,29 @@ public:
       }
     }
     return info;
+  }
+
+  // Returns commit kinds used by addWriteChecks to detect outstanding
+  // write accesses to shared memory.
+  virtual SmallVector<CommitKindDesc> getOutstandingWriteCommitKinds() const {
+    return {{CommitKind::AsyncCp, "async_copy_global_to_shared"}};
+  }
+
+  // Returns commit kinds used by addReadChecks to detect outstanding
+  // read accesses to shared memory.
+  virtual SmallVector<CommitKindDesc> getOutstandingReadCommitKinds() const {
+    return {};
+  }
+
+  // Returns true for commit kinds whose ops complete in issue order within a
+  // warp. ConSan's thread model tracks one logical
+  // thread per WS partition, so it cannot distinguish intra-warp ordering from
+  // cross-warp races inside the same partition. For such kinds, the
+  // outstanding-commit check excludes the calling thread's own column, avoiding
+  // intra-partition false positives while still detecting cross-partition
+  // races.
+  virtual bool isOrderedCommitKind(CommitKind::Kind kind) const {
+    return false;
   }
 
   virtual SmallVector<CommitKind::Kind>

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -185,6 +185,20 @@ inline int getMinWarpsForOp(Operation *op) {
   return 1;
 }
 
+SmallVector<uint16_t> getCTABroadcastMasks(bool twoCTAs, ValueRange descs);
+
+// Compact encoding of a CTA multicast group for a given broadcast mask:
+// `fixedBits` selects the CTA-id bits that identify the group leader, and
+// `pattern` is the recipient bitset for leader CTA 0 before shifting to the
+// current group.
+struct TMAMulticastMaskEncoding {
+  uint32_t fixedBits;
+  uint32_t pattern;
+};
+
+TMAMulticastMaskEncoding getTMAMulticastMaskEncoding(int numCTAs,
+                                                     uint16_t broadcastBits);
+
 } // namespace mlir::triton::nvidia_gpu
 
 #endif // TRITON_DIALECT_TRITONNVIDIAGPU_IR_DIALECT_H_

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -151,7 +151,8 @@ def TTNG_ClusterBarrierOp : TTNG_Op<"cluster_barrier", []> {
 //
 // Cluster Launch Control (CLC) Ops - Blackwell SM100+
 //
-def TTNG_CLCTryCancelOp : TTNG_Op<"clc_try_cancel", []> {
+def TTNG_CLCTryCancelOp : TTNG_Op<"clc_try_cancel", [
+    DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier"]>]> {
   let summary = "Issue CLC try_cancel to cancel a pending cluster";
 
   let description = [{
@@ -372,7 +373,8 @@ def TTNG_WarpGroupDotWaitOp : TTNG_Op<"warp_group_dot_wait", [DeclareOpInterface
   let hasVerifier = 1;
 }
 
-def TTNG_InitBarrierOp : TTNG_Op<"init_barrier"> {
+def TTNG_InitBarrierOp : TTNG_Op<"init_barrier", [
+    DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier"]>]> {
   let summary = "Initialize a barrier in the given shared memory allocation.";
 
   let description = [{
@@ -391,7 +393,8 @@ def TTNG_InitBarrierOp : TTNG_Op<"init_barrier"> {
   let hasVerifier = 1;
 }
 
-def TTNG_InvalBarrierOp : TTNG_Op<"inval_barrier"> {
+def TTNG_InvalBarrierOp : TTNG_Op<"inval_barrier", [
+    DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier"]>]> {
   let summary = "Invalidate a barrier allocation.";
 
   let description = [{
@@ -407,7 +410,8 @@ def TTNG_InvalBarrierOp : TTNG_Op<"inval_barrier"> {
 }
 
 def TTNG_BarrierExpectOp : TTNG_Op<"barrier_expect", [
-    DeclareOpInterfaceMethods<PredicatedOpInterface>]> {
+    DeclareOpInterfaceMethods<PredicatedOpInterface>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier"]>]> {
   let summary = "Signal a barrier of an expected number of bytes to be copied.";
 
   let description = [{
@@ -428,7 +432,8 @@ def TTNG_BarrierExpectOp : TTNG_Op<"barrier_expect", [
 }
 
 def TTNG_WaitBarrierOp : TTNG_Op<"wait_barrier", [AttrSizedOperandSegments,
-    DeclareOpInterfaceMethods<PredicatedOpInterface>]> {
+    DeclareOpInterfaceMethods<PredicatedOpInterface>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier"]>]> {
   let summary = "wait until the mbarrier phase completes.";
 
   let description = [{
@@ -480,7 +485,8 @@ def TTNG_WaitBarrierOp : TTNG_Op<"wait_barrier", [AttrSizedOperandSegments,
 }
 
 def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier", [
-    DeclareOpInterfaceMethods<PredicatedOpInterface>]> {
+    DeclareOpInterfaceMethods<PredicatedOpInterface>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier"]>]> {
   let summary = "perform the arrive operation on an mbarrier";
   let description = [{
     The `ttng.arrive_barrier` operation performs the "arrive" operation on an
@@ -550,7 +556,8 @@ def TTNG_ArriveBarrierOp : TTNG_Op<"arrive_barrier", [
   let hasVerifier = 1;
 }
 
-def TTNG_AsyncCopyMbarrierArriveOp : TTNG_Op<"async_copy_mbarrier_arrive"> {
+def TTNG_AsyncCopyMbarrierArriveOp : TTNG_Op<"async_copy_mbarrier_arrive", [
+    DeclareOpInterfaceMethods<MBarrierOpInterface>]> {
   let summary = "arrive on mbarrier once all previously issued copies are completed";
   let arguments = (ins
     Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$barrier,
@@ -657,7 +664,8 @@ def TTNG_VoteBallotSyncOp : TTNG_Op<"vote_ballot_sync", [Pure]> {
 
 def TTNG_AsyncTMACopyGlobalToLocalOp : TTNG_Op<"async_tma_copy_global_to_local", [
     AttrSizedOperandSegments, TMALoadLikeOpInterface,
-    DeclareOpInterfaceMethods<PredicatedOpInterface>]> {
+    DeclareOpInterfaceMethods<PredicatedOpInterface>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface>]> {
   let summary = "copy data based on descriptor from global memory to local memory asynchronously";
 
   let description = [{
@@ -874,7 +882,8 @@ def TTNG_AsyncTMAReduceOp : TTNG_Op<"async_tma_reduce", [
 
 def TTNG_AsyncTMAGatherOp : TTNG_Op<"async_tma_gather", [
     TMALoadLikeOpInterface,
-    DeclareOpInterfaceMethods<PredicatedOpInterface>]> {
+    DeclareOpInterfaceMethods<PredicatedOpInterface>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface>]> {
   let summary = "gather data based on descriptor from global memory to local memory asynchronously";
 
   let description = [{
@@ -971,6 +980,7 @@ def TTNG_TCGen5MMAOp : TTNG_Op<"tc_gen5_mma", [
     DeclareOpInterfaceMethods<DotOpInterface, ["verifyOutputDims"]>,
     DeclareOpInterfaceMethods<MMAv5OpInterface>,
     DeclareOpInterfaceMethods<PredicatedOpInterface>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface>,
     AttrSizedOperandSegments
 ]> {
   let summary = "block level op mapping to tensorcore gen5 mma";
@@ -1032,6 +1042,7 @@ def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [
     DeclareOpInterfaceMethods<DotOpInterface, ["verifyDims", "verifyOutputDims"]>,
     DeclareOpInterfaceMethods<MMAv5OpInterface>,
     DeclareOpInterfaceMethods<PredicatedOpInterface>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface>,
     AttrSizedOperandSegments
 ]> {
   let summary = "block level op mapping to tensorcore gen5 mma";
@@ -1103,7 +1114,8 @@ def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [
 }
 
 def TTNG_TCGen5CommitOp : TTNG_Op<"tc_gen5_commit", [AttrSizedOperandSegments,
-    DeclareOpInterfaceMethods<PredicatedOpInterface>]> {
+    DeclareOpInterfaceMethods<PredicatedOpInterface>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface>]> {
   let summary = "make an mbarrier track completion of all prior async tcgen5 ops";
 
   let description = [{

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -61,31 +61,11 @@ unsigned getNumBuffers(ttg::MemDescIndexOp memdescIndexOp) {
 }
 
 llvm::DenseSet<Value> getBarrierOperands(Operation *op) {
-  if (auto initBarrierOp = dyn_cast<ttng::InitBarrierOp>(op)) {
-    return {initBarrierOp.getOperand()};
+  if (auto barrierOp = dyn_cast<ttg::MBarrierOpInterface>(op)) {
+    auto barriers = barrierOp.getBarriers();
+    return llvm::DenseSet<Value>(barriers.begin(), barriers.end());
   }
-  if (auto waitBarrierOp = dyn_cast<ttng::WaitBarrierOp>(op)) {
-    return {waitBarrierOp.getAlloc()};
-  }
-  if (auto arriveBarrierOp = dyn_cast<ttng::ArriveBarrierOp>(op)) {
-    return {arriveBarrierOp.getAlloc()};
-  }
-  if (auto barrierExpectOp = dyn_cast<ttng::BarrierExpectOp>(op)) {
-    return {barrierExpectOp.getAlloc()};
-  }
-  if (auto invalBarrierOp = dyn_cast<ttng::InvalBarrierOp>(op)) {
-    return {invalBarrierOp.getAlloc()};
-  }
-  if (auto asyncOp = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
-    return {asyncOp.getBarrier()};
-  }
-  if (auto gatherOp = dyn_cast<ttng::AsyncTMAGatherOp>(op)) {
-    return {gatherOp.getBarrier()};
-  }
-  if (auto mmaV5Op = dyn_cast<ttng::MMAv5OpInterface>(op)) {
-    return llvm::DenseSet<Value>(mmaV5Op.getCompletionBarriers().begin(),
-                                 mmaV5Op.getCompletionBarriers().end());
-  }
+
   return llvm::DenseSet<Value>{};
 }
 
@@ -347,6 +327,9 @@ bool BufferRegionAnalysis::isMemoryAccessOperation(Operation *op) {
           ttng::AsyncTMAGatherOp, ttng::AsyncTMAScatterOp, ttng::InitBarrierOp,
           ttng::BarrierExpectOp, ttng::InvalBarrierOp, ttng::WaitBarrierOp,
           ttng::ArriveBarrierOp>(op)) {
+    return true;
+  }
+  if (isa<ttg::MBarrierOpInterface>(op)) {
     return true;
   }
   // Allocations with operands write to the memory.

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -363,8 +363,8 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
           }
         }
       }
-      // If this op may be signalling other threads asynchronously, make sure
-      // all shared memory transactions are complete beforehand.
+      // If this op may signal other threads asynchronously, make sure all
+      // shared-memory transactions in this partition are complete first.
       if (isa<triton::nvidia_gpu::ArriveBarrierOp>(op)) {
         Interval<size_t> allIntervals(0, std::numeric_limits<size_t>::max());
         auto allMemorySlice = AllocationSlice(allIntervals);

--- a/lib/Conversion/TritonGPUToLLVM/GlobalScratchMemoryAllocation.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/GlobalScratchMemoryAllocation.cpp
@@ -110,36 +110,38 @@ class TritonGPUGlobalScratchAllocationPass
           TritonGPUGlobalScratchAllocationPass> {
 public:
   void runOnOperation() override {
-    ModuleOp mod = getOperation();
-
-    bool seenKernel = false;
-
-    SetVector<Operation *> callStack;
-    mod->walk([&](triton::FuncOp func) {
-      allocateGMem(func, callStack);
-
-      if (func.getVisibility() == SymbolTable::Visibility::Public) {
-        assert(!seenKernel);
-        seenKernel = true;
-        auto size =
-            func->getAttrOfType<IntegerAttr>("ttg.global_scratch_memory_size");
-        auto align = func->getAttrOfType<IntegerAttr>(
-            "ttg.global_scratch_memory_alignment");
-        auto profileSize =
-            func->getAttrOfType<IntegerAttr>("ttg.profile_scratch_memory_size");
-        auto profileAlign = func->getAttrOfType<IntegerAttr>(
-            "ttg.profile_scratch_memory_alignment");
-        assert(size);
-        assert(align);
-        assert(profileSize);
-        assert(profileAlign);
-        mod->setAttr("ttg.global_scratch_memory_size", size);
-        mod->setAttr("ttg.global_scratch_memory_alignment", align);
-        mod->setAttr("ttg.profile_scratch_memory_size", profileSize);
-        mod->setAttr("ttg.profile_scratch_memory_alignment", profileAlign);
-      }
-    });
-    assert(seenKernel);
+    runGlobalScratchMemoryAllocation(getOperation());
   }
 };
 } // namespace
+
+void mlir::triton::gpu::runGlobalScratchMemoryAllocation(ModuleOp mod) {
+  bool seenKernel = false;
+
+  SetVector<Operation *> callStack;
+  mod->walk([&](triton::FuncOp func) {
+    allocateGMem(func, callStack);
+
+    if (func.getVisibility() == SymbolTable::Visibility::Public) {
+      assert(!seenKernel);
+      seenKernel = true;
+      auto size =
+          func->getAttrOfType<IntegerAttr>("ttg.global_scratch_memory_size");
+      auto align = func->getAttrOfType<IntegerAttr>(
+          "ttg.global_scratch_memory_alignment");
+      auto profileSize =
+          func->getAttrOfType<IntegerAttr>("ttg.profile_scratch_memory_size");
+      auto profileAlign = func->getAttrOfType<IntegerAttr>(
+          "ttg.profile_scratch_memory_alignment");
+      assert(size);
+      assert(align);
+      assert(profileSize);
+      assert(profileAlign);
+      mod->setAttr("ttg.global_scratch_memory_size", size);
+      mod->setAttr("ttg.global_scratch_memory_alignment", align);
+      mod->setAttr("ttg.profile_scratch_memory_size", profileSize);
+      mod->setAttr("ttg.profile_scratch_memory_alignment", profileAlign);
+    }
+  });
+  assert(seenKernel);
+}

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -1,4 +1,5 @@
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "third_party/nvidia/include/Dialect/NVGPU/IR/Dialect.h"
 #include "third_party/nvidia/include/TritonNVIDIAGPUToLLVM/PTXAsmFormat.h"
@@ -170,10 +171,13 @@ struct BufferDescriptorsOpConversion
     return b.ptrtoint(i64Ty, basePtr);
   }
 };
-
 struct LockAcquireOpConversion
     : public ConvertOpToLLVMPattern<tti::ExperimentalLockAcquireOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  explicit LockAcquireOpConversion(LLVMTypeConverter &typeConverter,
+                                   const TargetInfoBase &targetInfo)
+      : ConvertOpToLLVMPattern<tti::ExperimentalLockAcquireOp>(typeConverter),
+        targetInfo(targetInfo) {}
+
   LogicalResult matchAndRewrite(tti::ExperimentalLockAcquireOp op,
                                 OpAdaptor adaptor,
                                 ConversionPatternRewriter &b) const override {
@@ -190,7 +194,17 @@ struct LockAcquireOpConversion
     Block *whileBlock = b.splitBlock(prevBlock2, b.getInsertionPoint());
     Block *endBlock = b.splitBlock(whileBlock, whileBlock->begin());
     b.setInsertionPointToEnd(prevBlock2);
-    Value elect = mlir::LLVM::NVIDIA::createElectPredicateWarp0(loc, b);
+
+    Value elect;
+    if (targetInfo.isCuda()) {
+      elect = mlir::LLVM::NVIDIA::createElectPredicateWarp0(loc, b);
+    } else {
+      TritonLLVMOpBuilder tb(loc, b);
+      auto [laneId, warpId] = getLaneAndWarpId(b, loc);
+      Value lane0 = tb.icmp_eq(laneId, tb.i32_val(0));
+      Value warp0 = tb.icmp_eq(warpId, tb.i32_val(0));
+      elect = tb.and_(lane0, warp0);
+    }
     if (op.getPred()) {
       elect = arith::AndIOp::create(b, loc, elect, op.getPred());
     }
@@ -204,22 +218,31 @@ struct LockAcquireOpConversion
     Value one =
         arith::ConstantOp::create(b, loc, i32, b.getIntegerAttr(i32, 1));
 
-    // Inline PTX CAS: old = atom.global.acquire.gpu.cas.b32 [lock], 0, 1
-    // Use converted lock pointer from adaptor for addressing
-    PTXBuilder ptx;
-    auto *dstOpr = ptx.newOperand("=r", /*init=*/true);
-    auto *ptrOpr = ptx.newAddrOperand(adaptor.getLock(), "l");
-    auto *cmpOpr = ptx.newOperand(zero, "r");
-    auto *valOpr = ptx.newOperand(one, "r");
-    auto &atom = *ptx.create("atom");
-    atom.global().o("acquire").o("gpu").o("cas").o("b32");
-    atom(dstOpr, ptrOpr, cmpOpr, valOpr);
-    Value old = ptx.launch(b, loc, i32);
-
-    // while (old != 0) loop
-    Value cond =
-        arith::CmpIOp::create(b, loc, arith::CmpIPredicate::ne, old, zero);
-    LLVM::CondBrOp::create(b, loc, cond, whileBlock, endBlock);
+    if (targetInfo.isCuda()) {
+      // Inline PTX CAS: old = atom.global.acquire.gpu.cas.b32 [lock], 0, 1
+      // Use converted lock pointer from adaptor for addressing
+      PTXBuilder ptx;
+      auto *dstOpr = ptx.newOperand("=r", /*init=*/true);
+      auto *ptrOpr = ptx.newAddrOperand(adaptor.getLock(), "l");
+      auto *cmpOpr = ptx.newOperand(zero, "r");
+      auto *valOpr = ptx.newOperand(one, "r");
+      auto &atom = *ptx.create("atom");
+      atom.global().o("acquire").o("gpu").o("cas").o("b32");
+      atom(dstOpr, ptrOpr, cmpOpr, valOpr);
+      Value old = ptx.launch(b, loc, i32);
+      // while (old != 0) loop
+      Value cond =
+          arith::CmpIOp::create(b, loc, arith::CmpIPredicate::ne, old, zero);
+      LLVM::CondBrOp::create(b, loc, cond, whileBlock, endBlock);
+    } else {
+      Value oldVal = LLVM::AtomicRMWOp::create(
+          b, loc, LLVM::AtomicBinOp::xchg, adaptor.getLock(), one,
+          LLVM::AtomicOrdering::acquire,
+          StringAttr::get(b.getContext(), "agent"));
+      Value acquired =
+          arith::CmpIOp::create(b, loc, arith::CmpIPredicate::eq, oldVal, zero);
+      LLVM::CondBrOp::create(b, loc, acquired, endBlock, whileBlock);
+    }
 
     b.setInsertionPointToStart(endBlock);
     triton::gpu::BarrierOp::create(b, loc,
@@ -228,11 +251,18 @@ struct LockAcquireOpConversion
     b.eraseOp(op);
     return success();
   }
+
+private:
+  const TargetInfoBase &targetInfo;
 };
 
 struct LockReleaseOpConversion
     : public ConvertOpToLLVMPattern<tti::ExperimentalLockReleaseOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  explicit LockReleaseOpConversion(LLVMTypeConverter &typeConverter,
+                                   const TargetInfoBase &targetInfo)
+      : ConvertOpToLLVMPattern<tti::ExperimentalLockReleaseOp>(typeConverter),
+        targetInfo(targetInfo) {}
+
   LogicalResult matchAndRewrite(tti::ExperimentalLockReleaseOp op,
                                 OpAdaptor adaptor,
                                 ConversionPatternRewriter &b) const override {
@@ -251,24 +281,35 @@ struct LockReleaseOpConversion
     triton::gpu::BarrierOp::create(b, loc,
                                    triton::gpu::AddrSpace::GlobalRead |
                                        triton::gpu::AddrSpace::GlobalWrite);
-    Value elect = mlir::LLVM::NVIDIA::createElectPredicateWarp0(loc, b);
 
     auto i32 = b.getI32Type();
     Value zero =
         arith::ConstantOp::create(b, loc, i32, b.getIntegerAttr(i32, 0));
 
-    PTXBuilder ptx;
-    auto *dstOpr = ptx.newOperand("=r", /*init=*/true);
-    auto *ptrOpr = ptx.newAddrOperand(adaptor.getLock(), "l");
-    auto *valOpr = ptx.newOperand(zero, "r");
-    auto &atom = *ptx.create("atom");
-    atom.global().o("acq_rel").o("gpu").o("exch").o("b32");
-    atom(dstOpr, ptrOpr, valOpr).predicate(elect);
-    ptx.launch(b, loc, i32);
+    if (targetInfo.isCuda()) {
+      Value elect = mlir::LLVM::NVIDIA::createElectPredicateWarp0(loc, b);
+
+      PTXBuilder ptx;
+      auto *dstOpr = ptx.newOperand("=r", /*init=*/true);
+      auto *ptrOpr = ptx.newAddrOperand(adaptor.getLock(), "l");
+      auto *valOpr = ptx.newOperand(zero, "r");
+      auto &atom = *ptx.create("atom");
+      atom.global().o("acq_rel").o("gpu").o("exch").o("b32");
+      atom(dstOpr, ptrOpr, valOpr).predicate(elect);
+      ptx.launch(b, loc, i32);
+    } else {
+      LLVM::AtomicRMWOp::create(b, loc, LLVM::AtomicBinOp::xchg,
+                                adaptor.getLock(), zero,
+                                LLVM::AtomicOrdering::release,
+                                StringAttr::get(b.getContext(), "agent"));
+    }
 
     b.eraseOp(op);
     return success();
   }
+
+private:
+  const TargetInfoBase &targetInfo;
 };
 
 struct MemDescToI32OpConversion
@@ -318,8 +359,8 @@ void mlir::triton::populateInstrumentationToLLVMPatterns(
     const TargetInfoBase &targetInfo) {
   patterns.add<AssertUniformOpConversion>(typeConverter);
   patterns.add<BufferDescriptorsOpConversion>(typeConverter);
-  patterns.add<LockAcquireOpConversion>(typeConverter);
-  patterns.add<LockReleaseOpConversion>(typeConverter);
+  patterns.add<LockAcquireOpConversion>(typeConverter, targetInfo);
+  patterns.add<LockReleaseOpConversion>(typeConverter, targetInfo);
   patterns.add<MemDescToI32OpConversion>(typeConverter);
   patterns.add<ClusterCTAIdOpConversion>(typeConverter, targetInfo);
 }

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionSchedulingUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionSchedulingUtility.cpp
@@ -60,7 +60,7 @@ Flags getNodeFlags(Node *node) {
 }
 
 size_t computeCost(Operation *op) {
-  if (auto mma = dyn_cast<nvidia_gpu::TCGen5MMAOp>(op)) {
+  if (auto mma = dyn_cast<nvidia_gpu::MMAv5OpInterface>(op)) {
     auto a = mma.getA();
     auto b = mma.getB();
     auto a_shape = a.getType().getShape();

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1,5 +1,7 @@
 #include "triton/Dialect/TritonInstrument/IR/FunctionBuilder.h"
 
+#include <cassert>
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/IR/Builders.h"
@@ -45,9 +47,14 @@ namespace {
 
 namespace BarrierBits {
 constexpr unsigned initCountLsb = 1;
-constexpr unsigned currentCountLsb = 9;
-constexpr unsigned countBitWidth = 8;
-constexpr unsigned countMask = (1u << countBitWidth) - 1;
+constexpr unsigned currentCountLsb = 21;
+constexpr unsigned txCountLsb = 41;
+constexpr unsigned countBitWidth = 20;
+constexpr unsigned txCountBitWidth = 21;
+constexpr uint64_t countMask = (1ull << countBitWidth) - 1;
+constexpr uint64_t txCountMask = (1ull << txCountBitWidth) - 1;
+constexpr int64_t txCountMin = -(int64_t)countMask;
+constexpr int64_t txCountMax = (int64_t)countMask;
 } // namespace BarrierBits
 
 namespace WaitingBits {
@@ -317,6 +324,57 @@ Value createDimMask(ImplicitLocOpBuilder &b, Value index,
 Value createColumnMask(ImplicitLocOpBuilder &b, Value column,
                        RankedTensorType tensorType) {
   return createDimMask(b, column, tensorType, tensorType.getRank() - 1);
+}
+
+Value createCurrentCTAMask(ImplicitLocOpBuilder &b) {
+  Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
+  return arith::ShLIOp::create(b, arith::ConstantIntOp::create(b, 1, 32),
+                               ctaId);
+}
+
+Value createRecipientCTAMask(ImplicitLocOpBuilder &b,
+                             RankedTensorType tensorType, Value recipientCTAs) {
+  int numCTAs = ttg::lookupNumCTAs(b);
+
+  // Turn the scalar recipient bitset into a tensor mask over logical CTA rows:
+  // build a [0, numCTAs) row-index vector on dim 0, broadcast it to the state
+  // tensor shape, and test one bit of `recipientCTAs` per row.
+  auto loc = b.getLoc();
+  // master refactored getSingleDimSliceEncoding() into getSlicedTensorType():
+  // slice `tensorType` down to its dim-0 (CTA) row as an i32 index vector.
+  auto rowType =
+      tti::getSlicedTensorType(tensorType, /*keptDims=*/{0}, b.getI32Type());
+  Value rowIdx = triton::MakeRangeOp::create(b, rowType, /*start=*/0,
+                                             /*end=*/numCTAs);
+  auto indexType = cast<RankedTensorType>(
+      tensorType.cloneWith(std::nullopt, b.getI32Type()));
+  rowIdx = convertAndBroadcast(b, rowIdx, {0}, indexType);
+
+  Value recipientBitsTensor =
+      triton::SplatOp::create(b, indexType, recipientCTAs);
+  Value shifted = arith::ShRUIOp::create(b, recipientBitsTensor, rowIdx);
+  Value one = tti::createConstIntTensor(b, loc, 1, indexType);
+  Value selectedBit = arith::AndIOp::create(b, shifted, one);
+  Value zero = tti::createConstIntTensor(b, loc, 0, indexType);
+  return arith::CmpIOp::create(b, arith::CmpIPredicate::ne, selectedBit, zero);
+}
+
+Operation *createCTAScopedStoreScratchMemory(ImplicitLocOpBuilder &b,
+                                             Location loc, Value alloc,
+                                             Value tensor,
+                                             RankedTensorType tensorType,
+                                             Value recipientCTAs) {
+  int64_t numCTAs = ttg::lookupNumCTAs(b);
+  if (numCTAs > 1) {
+    // This should hopefully be folded with the previous load in the caller
+    // function
+    Value oldTensor = tti::createLoadScratchMemory(b, loc, alloc, tensorType);
+    Value ctaMask = createRecipientCTAMask(b, tensorType, recipientCTAs);
+    // and this with the previous selectOp, if there is any
+    tensor = arith::SelectOp::create(b, loc, ctaMask, tensor, oldTensor);
+  }
+  return tti::createStoreScratchMemory(b, loc, alloc, tensor, tensorType,
+                                       /*currentCTAOnly=*/false);
 }
 
 } // namespace
@@ -611,12 +669,16 @@ void FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
 }
 
 void FunctionBuilder::createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b,
-                                                     Value mbar,
-                                                     Operation *insertPoint) {
+                                                     Value mbar, Value pred,
+                                                     Operation *insertPoint,
+                                                     Value recipientCTAs) {
   assert(!auxData.barriers.empty() &&
          "barrier descriptors must exist when verifying barrier init");
   assert(!auxData.barrierStates.empty() &&
          "barrier states must exist when verifying barrier init");
+  if (!pred) {
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  }
   Value barriersVal = auxData.barriers.at(insertPoint).value;
   auto barriersType =
       cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
@@ -626,8 +688,8 @@ void FunctionBuilder::createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b,
   uint32_t length = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset, lengthVal, barriersVal,
-                             barrierStatesVal};
+  SmallVector<Value> args = {mbarOffset,  lengthVal,        pred,
+                             barriersVal, barrierStatesVal, recipientCTAs};
   AssertInfo assertInfo{
       "Barrier re-initialized without prior invalidation",
       barrierStatesType.cloneWith(std::nullopt, b.getI1Type())};
@@ -638,8 +700,10 @@ void FunctionBuilder::createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b,
                                         Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
-        Value barriers = entryBlock->getArgument(2);
-        Value statesPtr = entryBlock->getArgument(3);
+        Value pred = entryBlock->getArgument(2);
+        Value barriers = entryBlock->getArgument(3);
+        Value statesPtr = entryBlock->getArgument(4);
+        Value recipientCTAs = entryBlock->getArgument(5);
 
         Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
                                                     barrierStatesType);
@@ -653,12 +717,17 @@ void FunctionBuilder::createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b,
         auto condType = cast<RankedTensorType>(canInit.getType());
         Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
         canInit = arith::SelectOp::create(fb, mask, canInit, vTrue);
+        Value ctaMask = createRecipientCTAMask(fb, condType, recipientCTAs);
+        canInit = arith::SelectOp::create(fb, ctaMask, canInit, vTrue);
+        Value predTensor = triton::SplatOp::create(fb, condType, pred);
+        canInit = arith::SelectOp::create(fb, predTensor, canInit, vTrue);
         triton::ReturnOp::create(fb, canInit);
       });
 }
 
 void FunctionBuilder::createVerifyBarrierInitializedCall(
-    ImplicitLocOpBuilder &b, Value mbar, Value pred, Operation *insertPoint) {
+    ImplicitLocOpBuilder &b, Value mbar, Value pred, Operation *insertPoint,
+    Value recipientCTAs) {
   assert(!auxData.barriers.empty() &&
          "barrier descriptors must exist when verifying barrier use");
   assert(!auxData.barrierStates.empty() &&
@@ -675,8 +744,8 @@ void FunctionBuilder::createVerifyBarrierInitializedCall(
   uint32_t length = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset, lengthVal, pred, barriersVal,
-                             barrierStatesVal};
+  SmallVector<Value> args = {mbarOffset,  lengthVal,        pred,
+                             barriersVal, barrierStatesVal, recipientCTAs};
   AssertInfo assertInfo{
       "Barrier used before initialization or after invalidation",
       barrierStatesType.cloneWith(std::nullopt, b.getI1Type())};
@@ -690,6 +759,7 @@ void FunctionBuilder::createVerifyBarrierInitializedCall(
         Value pred = entryBlock->getArgument(2);
         Value barriers = entryBlock->getArgument(3);
         Value statesPtr = entryBlock->getArgument(4);
+        Value recipientCTAs = entryBlock->getArgument(5);
 
         Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
                                                     barrierStatesType);
@@ -703,6 +773,8 @@ void FunctionBuilder::createVerifyBarrierInitializedCall(
         auto condType = cast<RankedTensorType>(initialized.getType());
         Value vTrue = tti::createConstIntTensor(fb, fb.getLoc(), 1, condType);
         initialized = arith::SelectOp::create(fb, mask, initialized, vTrue);
+        Value ctaMask = createRecipientCTAMask(fb, condType, recipientCTAs);
+        initialized = arith::SelectOp::create(fb, ctaMask, initialized, vTrue);
         Value predTensor = triton::SplatOp::create(fb, condType, pred);
         Value predicatedInitialized =
             arith::SelectOp::create(fb, predTensor, initialized, vTrue);
@@ -712,10 +784,16 @@ void FunctionBuilder::createVerifyBarrierInitializedCall(
 
 void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
                                                  Value mbar, int count,
+                                                 Value pred,
                                                  Operation *insertPoint) {
+  assert(count >= 0 && (uint64_t)count <= BarrierBits::countMask &&
+         "barrier init count exceeds barrier state capacity");
 
   if (auxData.barriers.empty() || auxData.barrierStates.empty()) {
     return;
+  }
+  if (!pred) {
+    pred = arith::ConstantIntOp::create(b, 1, 1);
   }
   Value countVal = arith::ConstantIntOp::create(b, count, 32);
   Value barriersVal = auxData.barriers.at(insertPoint).value;
@@ -727,8 +805,8 @@ void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
   uint32_t length = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset, lengthVal, countVal, barriersVal,
-                             barrierStatesVal};
+  SmallVector<Value> args = {mbarOffset, lengthVal,   countVal,
+                             pred,       barriersVal, barrierStatesVal};
   createCallToCachedFunction(
       b, "init_barrier_state", args,
       /*assertInfo=*/std::nullopt, {barriersType, barrierStatesType},
@@ -737,9 +815,10 @@ void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value count = entryBlock->getArgument(2);
+        Value pred = entryBlock->getArgument(3);
 
-        Value barriers = entryBlock->getArgument(3);
-        Value statesPtr = entryBlock->getArgument(4);
+        Value barriers = entryBlock->getArgument(4);
+        Value statesPtr = entryBlock->getArgument(5);
 
         Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
                                                     barrierStatesType);
@@ -747,33 +826,38 @@ void FunctionBuilder::createInitBarrierStateCall(ImplicitLocOpBuilder &b,
         Value mask = createCmpIntTensorScalar(fb, barriers, descriptor);
         mask = convertAndBroadcast(fb, mask, {0, 1}, barrierStatesType);
 
+        Value countWide = adjustIntegerWidth(
+            fb, count, cast<IntegerType>(barrierStatesType.getElementType()));
         Value countMask =
-            arith::ConstantIntOp::create(fb, BarrierBits::countMask, 32);
-        Value maskedCount = arith::AndIOp::create(fb, count, countMask);
+            arith::ConstantIntOp::create(fb, BarrierBits::countMask, 64);
+        Value maskedCount = arith::AndIOp::create(fb, countWide, countMask);
         Value countTensor =
             triton::SplatOp::create(fb, barrierStatesType, maskedCount);
 
-        Value shiftOneTensor = tti::createConstIntTensor(
+        Value shiftInitTensor = tti::createConstIntTensor(
             fb, fb.getLoc(), BarrierBits::initCountLsb, barrierStatesType);
-        Value shiftNineTensor = tti::createConstIntTensor(
+        Value shiftCurrentTensor = tti::createConstIntTensor(
             fb, fb.getLoc(), BarrierBits::currentCountLsb, barrierStatesType);
 
         Value initField =
-            arith::ShLIOp::create(fb, countTensor, shiftOneTensor);
+            arith::ShLIOp::create(fb, countTensor, shiftInitTensor);
         Value currentField =
-            arith::ShLIOp::create(fb, countTensor, shiftNineTensor);
+            arith::ShLIOp::create(fb, countTensor, shiftCurrentTensor);
         Value newState = arith::OrIOp::create(fb, initField, currentField);
 
         Value updated = arith::SelectOp::create(fb, mask, newState, states);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), statesPtr, updated,
-                                      barrierStatesType,
-                                      /*currentCTAOnly=*/true);
+        auto condType = cast<RankedTensorType>(mask.getType());
+        Value predTensor = triton::SplatOp::create(fb, condType, pred);
+        updated = arith::SelectOp::create(fb, predTensor, updated, states);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), statesPtr, updated,
+                                          barrierStatesType,
+                                          createCurrentCTAMask(fb));
         triton::ReturnOp::create(fb);
       });
 }
 
 void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
-                                                       Value mbar,
+                                                       Value mbar, Value pred,
                                                        Operation *insertPoint) {
   assert(!auxData.barriers.empty() &&
          "barrier descriptors must exist when invalidating a barrier");
@@ -781,6 +865,9 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
          "barrier states must exist when invalidating a barrier");
   assert(!auxData.waiting.empty() &&
          "waiting state must exist when invalidating a barrier");
+  if (!pred) {
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  }
   Value barriersVal = auxData.barriers.at(insertPoint).value;
   auto barriersType =
       cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
@@ -793,8 +880,8 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
   uint32_t length = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset, lengthVal, barriersVal,
-                             barrierStatesVal, waitingVal};
+  SmallVector<Value> args = {mbarOffset,  lengthVal,        pred,
+                             barriersVal, barrierStatesVal, waitingVal};
   createCallToCachedFunction(
       b, "invalidate_barrier_state", args,
       /*assertInfo=*/std::nullopt,
@@ -803,9 +890,10 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
                                                      Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
-        Value barriers = entryBlock->getArgument(2);
-        Value statesPtr = entryBlock->getArgument(3);
-        Value waitingPtr = entryBlock->getArgument(4);
+        Value pred = entryBlock->getArgument(2);
+        Value barriers = entryBlock->getArgument(3);
+        Value statesPtr = entryBlock->getArgument(4);
+        Value waitingPtr = entryBlock->getArgument(5);
 
         Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
                                                     barrierStatesType);
@@ -821,24 +909,38 @@ void FunctionBuilder::createInvalidateBarrierStateCall(ImplicitLocOpBuilder &b,
             tti::createConstIntTensor(fb, fb.getLoc(), 0, waitingType);
         Value updatedStates =
             arith::SelectOp::create(fb, mask, zeroState, states);
+        auto stateCondType = cast<RankedTensorType>(mask.getType());
+        Value statePredTensor =
+            triton::SplatOp::create(fb, stateCondType, pred);
+        updatedStates =
+            arith::SelectOp::create(fb, statePredTensor, updatedStates, states);
         Value waitingMask =
             createConvertLayout(fb, mask, waitingType.getEncoding());
         Value updatedWaiting =
             arith::SelectOp::create(fb, waitingMask, zeroWaiting, waiting);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), statesPtr, updatedStates,
-                                      barrierStatesType,
-                                      /*currentCTAOnly=*/true);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), waitingPtr,
-                                      updatedWaiting, waitingType,
-                                      /*currentCTAOnly=*/true);
+        auto waitingCondType = cast<RankedTensorType>(waitingMask.getType());
+        Value waitingPredTensor =
+            triton::SplatOp::create(fb, waitingCondType, pred);
+        updatedWaiting = arith::SelectOp::create(fb, waitingPredTensor,
+                                                 updatedWaiting, waiting);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), statesPtr,
+                                          updatedStates, barrierStatesType,
+                                          createCurrentCTAMask(fb));
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), waitingPtr,
+                                          updatedWaiting, waitingType,
+                                          createCurrentCTAMask(fb));
         triton::ReturnOp::create(fb);
       });
 }
 
-void FunctionBuilder::createVerifyBarrierArriveCall(ImplicitLocOpBuilder &b,
-                                                    Value mbar, int count,
-                                                    Value pred,
-                                                    Operation *insertPoint) {
+void FunctionBuilder::createVerifyBarrierArriveCall(
+    ImplicitLocOpBuilder &b, Value mbar, int count, Value pred,
+    Operation *insertPoint, Value recipientCTAs, int txCount) {
+  assert(count >= 0 && (uint64_t)count <= BarrierBits::countMask &&
+         "barrier arrive count exceeds barrier state capacity");
+  assert(txCount >= BarrierBits::txCountMin &&
+         txCount <= BarrierBits::txCountMax &&
+         "barrier tx-count delta exceeds barrier state capacity");
 
   if (auxData.barriers.empty() || auxData.barrierStates.empty()) {
     return;
@@ -847,6 +949,7 @@ void FunctionBuilder::createVerifyBarrierArriveCall(ImplicitLocOpBuilder &b,
     pred = arith::ConstantIntOp::create(b, 1, 1);
   }
   Value countVal = arith::ConstantIntOp::create(b, count, 32);
+  Value txCountVal = arith::ConstantIntOp::create(b, txCount, 64);
   Value barriersVal = auxData.barriers.at(insertPoint).value;
   auto barriersType =
       cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
@@ -856,10 +959,12 @@ void FunctionBuilder::createVerifyBarrierArriveCall(ImplicitLocOpBuilder &b,
   uint32_t length = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset, lengthVal,   countVal,
-                             pred,       barriersVal, barrierStatesVal};
+  SmallVector<Value> args = {mbarOffset,       lengthVal,    countVal,
+                             txCountVal,       pred,         barriersVal,
+                             barrierStatesVal, recipientCTAs};
   AssertInfo assertInfo{
-      "Barrier arrive underflow: current count would become negative",
+      "Barrier arrive underflow: current count or tx-count would become "
+      "invalid",
       barrierStatesType.cloneWith(std::nullopt, b.getI1Type())};
   createCallToCachedFunction(
       b, "verify_barrier_arrive", args, assertInfo,
@@ -869,10 +974,12 @@ void FunctionBuilder::createVerifyBarrierArriveCall(ImplicitLocOpBuilder &b,
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value count = entryBlock->getArgument(2);
-        Value pred = entryBlock->getArgument(3);
+        Value txCount = entryBlock->getArgument(3);
+        Value pred = entryBlock->getArgument(4);
 
-        Value barriers = entryBlock->getArgument(4);
-        Value statesPtr = entryBlock->getArgument(5);
+        Value barriers = entryBlock->getArgument(5);
+        Value statesPtr = entryBlock->getArgument(6);
+        Value recipientCTAs = entryBlock->getArgument(7);
 
         Value states = tti::createLoadScratchMemory(fb, fb.getLoc(), statesPtr,
                                                     barrierStatesType);
@@ -884,39 +991,78 @@ void FunctionBuilder::createVerifyBarrierArriveCall(ImplicitLocOpBuilder &b,
             tti::createConstIntTensor(fb, fb.getLoc(), 0, barrierStatesType);
         Value maskFF = tti::createConstIntTensor(
             fb, fb.getLoc(), BarrierBits::countMask, barrierStatesType);
-        Value shiftNineTensor = tti::createConstIntTensor(
+        Value shiftCurrentTensor = tti::createConstIntTensor(
             fb, fb.getLoc(), BarrierBits::currentCountLsb, barrierStatesType);
+        Value shiftTxTensor = tti::createConstIntTensor(
+            fb, fb.getLoc(), BarrierBits::txCountLsb, barrierStatesType);
+        Value shiftTxSignTensor = tti::createConstIntTensor(
+            fb, fb.getLoc(), 64 - BarrierBits::txCountBitWidth,
+            barrierStatesType);
 
         Value currentCount =
-            arith::ShRUIOp::create(fb, states, shiftNineTensor);
+            arith::ShRUIOp::create(fb, states, shiftCurrentTensor);
         currentCount = arith::AndIOp::create(fb, currentCount, maskFF);
+        Value currentTxCount =
+            arith::ShRUIOp::create(fb, states, shiftTxTensor);
+        currentTxCount =
+            arith::ShLIOp::create(fb, currentTxCount, shiftTxSignTensor);
+        currentTxCount =
+            arith::ShRSIOp::create(fb, currentTxCount, shiftTxSignTensor);
 
         Value countMask =
-            arith::ConstantIntOp::create(fb, BarrierBits::countMask, 32);
-        Value maskedCount = arith::AndIOp::create(fb, count, countMask);
+            arith::ConstantIntOp::create(fb, BarrierBits::countMask, 64);
+        Value countWide = adjustIntegerWidth(
+            fb, count, cast<IntegerType>(barrierStatesType.getElementType()));
+        Value maskedCount = arith::AndIOp::create(fb, countWide, countMask);
         Value arriveCount =
             triton::SplatOp::create(fb, barrierStatesType, maskedCount);
+        Value txCountTensor =
+            triton::SplatOp::create(fb, barrierStatesType, txCount);
 
         Value newCurrent = arith::SubIOp::create(fb, currentCount, arriveCount);
         Value newCurrentMasked =
             arith::SelectOp::create(fb, mask, newCurrent, zero32);
-        Value nonNegative = arith::CmpIOp::create(fb, arith::CmpIPredicate::sge,
-                                                  newCurrentMasked, zero32);
+        Value newTxCount =
+            arith::AddIOp::create(fb, currentTxCount, txCountTensor);
+        Value newTxCountMasked =
+            arith::SelectOp::create(fb, mask, newTxCount, zero32);
+        Value arrivalsNonNegative = arith::CmpIOp::create(
+            fb, arith::CmpIPredicate::sge, newCurrentMasked, zero32);
+        Value minTxCount = tti::createConstIntTensor(
+            fb, fb.getLoc(), BarrierBits::txCountMin, barrierStatesType,
+            /*isSigned=*/true);
+        Value maxTxCount = tti::createConstIntTensor(
+            fb, fb.getLoc(), BarrierBits::txCountMax, barrierStatesType);
+        Value txCountInRange = arith::AndIOp::create(
+            fb,
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::sge,
+                                  newTxCountMasked, minTxCount),
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::sle,
+                                  newTxCountMasked, maxTxCount));
+        Value valid =
+            arith::AndIOp::create(fb, arrivalsNonNegative, txCountInRange);
         Value vTrue = tti::createConstIntTensor(
-            fb, fb.getLoc(), 1, cast<RankedTensorType>(nonNegative.getType()));
+            fb, fb.getLoc(), 1, cast<RankedTensorType>(valid.getType()));
+        auto condType = cast<RankedTensorType>(valid.getType());
+        Value ctaMask = createRecipientCTAMask(fb, condType, recipientCTAs);
+        valid = arith::SelectOp::create(fb, ctaMask, valid, vTrue);
         Value predTensor = triton::SplatOp::create(
-            fb, cast<RankedTensorType>(nonNegative.getType()), pred);
-        Value predicatedNonNegative =
-            arith::SelectOp::create(fb, predTensor, nonNegative, vTrue);
+            fb, cast<RankedTensorType>(valid.getType()), pred);
+        Value predicatedValid =
+            arith::SelectOp::create(fb, predTensor, valid, vTrue);
 
-        triton::ReturnOp::create(fb, predicatedNonNegative);
+        triton::ReturnOp::create(fb, predicatedValid);
       });
 }
 
-void FunctionBuilder::createUpdateBarrierStateCall(ImplicitLocOpBuilder &b,
-                                                   Value mbar, int count,
-                                                   Value pred,
-                                                   Operation *insertPoint) {
+void FunctionBuilder::createUpdateBarrierStateCall(
+    ImplicitLocOpBuilder &b, Value mbar, int count, Value pred,
+    Operation *insertPoint, Value recipientCTAs, int txCount) {
+  assert(count >= 0 && (uint64_t)count <= BarrierBits::countMask &&
+         "barrier update count exceeds barrier state capacity");
+  assert(txCount >= BarrierBits::txCountMin &&
+         txCount <= BarrierBits::txCountMax &&
+         "barrier tx-count delta exceeds barrier state capacity");
 
   if (auxData.barriers.empty() || auxData.barrierStates.empty()) {
     return;
@@ -925,6 +1071,7 @@ void FunctionBuilder::createUpdateBarrierStateCall(ImplicitLocOpBuilder &b,
     pred = arith::ConstantIntOp::create(b, 1, 1);
   }
   Value countVal = arith::ConstantIntOp::create(b, count, 32);
+  Value txCountVal = arith::ConstantIntOp::create(b, txCount, 64);
   Value barriersVal = auxData.barriers.at(insertPoint).value;
   auto barriersType =
       cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
@@ -934,8 +1081,9 @@ void FunctionBuilder::createUpdateBarrierStateCall(ImplicitLocOpBuilder &b,
   uint32_t length = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset, lengthVal,   countVal,
-                             pred,       barriersVal, barrierStatesVal};
+  SmallVector<Value> args = {mbarOffset,       lengthVal,    countVal,
+                             txCountVal,       pred,         barriersVal,
+                             barrierStatesVal, recipientCTAs};
   createCallToCachedFunction(
       b, "update_barrier_state", args,
       /*assertInfo=*/std::nullopt, {barriersType, barrierStatesType},
@@ -944,10 +1092,12 @@ void FunctionBuilder::createUpdateBarrierStateCall(ImplicitLocOpBuilder &b,
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value count = entryBlock->getArgument(2);
-        Value pred = entryBlock->getArgument(3);
+        Value txCount = entryBlock->getArgument(3);
+        Value pred = entryBlock->getArgument(4);
 
-        Value barriers = entryBlock->getArgument(4);
-        Value statesPtr = entryBlock->getArgument(5);
+        Value barriers = entryBlock->getArgument(5);
+        Value statesPtr = entryBlock->getArgument(6);
+        Value recipientCTAs = entryBlock->getArgument(7);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -964,58 +1114,86 @@ void FunctionBuilder::createUpdateBarrierStateCall(ImplicitLocOpBuilder &b,
             tti::createConstIntTensor(fb, fb.getLoc(), 1, barrierStatesType);
         Value maskFF = tti::createConstIntTensor(
             fb, fb.getLoc(), BarrierBits::countMask, barrierStatesType);
-        Value shiftOneTensor = tti::createConstIntTensor(
+        Value shiftInitTensor = tti::createConstIntTensor(
             fb, fb.getLoc(), BarrierBits::initCountLsb, barrierStatesType);
-        Value shiftNineTensor = tti::createConstIntTensor(
+        Value shiftCurrentTensor = tti::createConstIntTensor(
             fb, fb.getLoc(), BarrierBits::currentCountLsb, barrierStatesType);
+        Value shiftTxTensor = tti::createConstIntTensor(
+            fb, fb.getLoc(), BarrierBits::txCountLsb, barrierStatesType);
+        Value shiftTxSignTensor = tti::createConstIntTensor(
+            fb, fb.getLoc(), 64 - BarrierBits::txCountBitWidth,
+            barrierStatesType);
 
         Value phase = arith::AndIOp::create(fb, states, one32);
-        Value initCount = arith::ShRUIOp::create(fb, states, shiftOneTensor);
+        Value initCount = arith::ShRUIOp::create(fb, states, shiftInitTensor);
         initCount = arith::AndIOp::create(fb, initCount, maskFF);
         Value currentCount =
-            arith::ShRUIOp::create(fb, states, shiftNineTensor);
+            arith::ShRUIOp::create(fb, states, shiftCurrentTensor);
         currentCount = arith::AndIOp::create(fb, currentCount, maskFF);
+        Value currentTxCount =
+            arith::ShRUIOp::create(fb, states, shiftTxTensor);
+        currentTxCount =
+            arith::ShLIOp::create(fb, currentTxCount, shiftTxSignTensor);
+        currentTxCount =
+            arith::ShRSIOp::create(fb, currentTxCount, shiftTxSignTensor);
 
         Value countMask =
-            arith::ConstantIntOp::create(fb, BarrierBits::countMask, 32);
-        Value maskedCount = arith::AndIOp::create(fb, count, countMask);
+            arith::ConstantIntOp::create(fb, BarrierBits::countMask, 64);
+        Value countWide = adjustIntegerWidth(
+            fb, count, cast<IntegerType>(barrierStatesType.getElementType()));
+        Value maskedCount = arith::AndIOp::create(fb, countWide, countMask);
         Value arriveCount =
             triton::SplatOp::create(fb, barrierStatesType, maskedCount);
+        Value txCountTensor =
+            triton::SplatOp::create(fb, barrierStatesType, txCount);
 
         Value newCurrent = arith::SubIOp::create(fb, currentCount, arriveCount);
         Value newCurrentMasked =
             arith::SelectOp::create(fb, mask, newCurrent, currentCount);
+        Value newTxCount =
+            arith::AddIOp::create(fb, currentTxCount, txCountTensor);
+        Value newTxCountMasked =
+            arith::SelectOp::create(fb, mask, newTxCount, currentTxCount);
 
-        Value zeroCond = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
-                                               newCurrentMasked, zero32);
+        Value zeroCond = arith::AndIOp::create(
+            fb,
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
+                                  newCurrentMasked, zero32),
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
+                                  newTxCountMasked, zero32));
         zeroCond = arith::AndIOp::create(fb, zeroCond, mask);
         Value zeroCondI32 =
             arith::ExtUIOp::create(fb, barrierStatesType, zeroCond);
         Value newPhase = arith::XOrIOp::create(fb, phase, zeroCondI32);
         Value newCurrentValue =
             arith::SelectOp::create(fb, zeroCond, initCount, newCurrentMasked);
+        Value newTxCountValue =
+            arith::SelectOp::create(fb, zeroCond, zero32, newTxCountMasked);
 
-        Value initField = arith::ShLIOp::create(fb, initCount, shiftOneTensor);
+        Value initField = arith::ShLIOp::create(fb, initCount, shiftInitTensor);
         Value currentField =
-            arith::ShLIOp::create(fb, newCurrentValue, shiftNineTensor);
+            arith::ShLIOp::create(fb, newCurrentValue, shiftCurrentTensor);
+        Value txCountMask = tti::createConstIntTensor(
+            fb, fb.getLoc(), BarrierBits::txCountMask, barrierStatesType);
+        Value txCountField =
+            arith::AndIOp::create(fb, newTxCountValue, txCountMask);
+        txCountField = arith::ShLIOp::create(fb, txCountField, shiftTxTensor);
         Value newState = arith::OrIOp::create(fb, newPhase, initField);
         newState = arith::OrIOp::create(fb, newState, currentField);
+        newState = arith::OrIOp::create(fb, newState, txCountField);
 
         Value updated = arith::SelectOp::create(fb, mask, newState, states);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), statesPtr, updated,
-                                      barrierStatesType,
-                                      /*currentCTAOnly=*/true);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), statesPtr, updated,
+                                          barrierStatesType, recipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
       });
 }
 
-void FunctionBuilder::createSetWriteVisibilityCall(ImplicitLocOpBuilder &b,
-                                                   Value buf, uint32_t length,
-                                                   uint64_t threadMask,
-                                                   Value pred, MemType memType,
-                                                   Operation *insertPoint) {
+void FunctionBuilder::createSetWriteVisibilityCall(
+    ImplicitLocOpBuilder &b, Value buf, uint32_t length, uint64_t threadMask,
+    Value pred, MemType memType, Operation *insertPoint, Value recipientCTAs) {
 
   if (auxData.buffers[(int)memType].empty() ||
       auxData.writeVisibility[(int)memType].empty()) {
@@ -1034,7 +1212,8 @@ void FunctionBuilder::createSetWriteVisibilityCall(ImplicitLocOpBuilder &b,
   Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
   SmallVector<Value> args = {bufOffset,     lengthVal,  pred,
-                             threadMaskVal, buffersVal, writeVisibilityVal};
+                             threadMaskVal, buffersVal, writeVisibilityVal,
+                             recipientCTAs};
   createCallToCachedFunction(
       b, "set_write_visibility", args,
       /*assertInfo=*/std::nullopt,
@@ -1047,6 +1226,7 @@ void FunctionBuilder::createSetWriteVisibilityCall(ImplicitLocOpBuilder &b,
         Value threadMaskVal = entryBlock->getArgument(3);
         Value buffers = entryBlock->getArgument(4);
         Value writeVisibilityPtr = entryBlock->getArgument(5);
+        Value recipientCTAs = entryBlock->getArgument(6);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -1063,20 +1243,18 @@ void FunctionBuilder::createSetWriteVisibilityCall(ImplicitLocOpBuilder &b,
             triton::SplatOp::create(fb, writeVisibilityType, threadMaskElem);
         Value newVisibility = arith::SelectOp::create(
             fb, buffersEqBuf, threadMaskTensor, writeVisibility);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), writeVisibilityPtr,
-                                      newVisibility, writeVisibilityType,
-                                      /*currentCTAOnly=*/true);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), writeVisibilityPtr,
+                                          newVisibility, writeVisibilityType,
+                                          recipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
       });
 }
 
-void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
-                                                  Value buf, uint32_t length,
-                                                  uint64_t threadMask,
-                                                  Value pred, MemType memType,
-                                                  Operation *insertPoint) {
+void FunctionBuilder::createSetReadVisibilityCall(
+    ImplicitLocOpBuilder &b, Value buf, uint32_t length, uint64_t threadMask,
+    Value pred, MemType memType, Operation *insertPoint, Value recipientCTAs) {
 
   if (auxData.buffers[(int)memType].empty() ||
       auxData.readVisibility[(int)memType].empty()) {
@@ -1095,7 +1273,8 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
   Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
   SmallVector<Value> args = {bufOffset,     lengthVal,  pred,
-                             threadMaskVal, buffersVal, readVisibilityVal};
+                             threadMaskVal, buffersVal, readVisibilityVal,
+                             recipientCTAs};
   createCallToCachedFunction(
       b, "set_read_visibility", args,
       /*assertInfo=*/std::nullopt,
@@ -1108,6 +1287,7 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
         Value threadMaskVal = entryBlock->getArgument(3);
         Value buffers = entryBlock->getArgument(4);
         Value readVisibilityPtr = entryBlock->getArgument(5);
+        Value recipientCTAs = entryBlock->getArgument(6);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -1130,9 +1310,9 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
             arith::AndIOp::create(fb, buffersEqBuf, threadColumnMask);
         Value newVisibility = arith::SelectOp::create(
             fb, bufAndThread, readVisibilityOrThreadBit, readVisibility);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
-                                      newVisibility, readVisibilityType,
-                                      /*currentCTAOnly=*/true);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
+                                          newVisibility, readVisibilityType,
+                                          recipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -1142,7 +1322,8 @@ void FunctionBuilder::createSetReadVisibilityCall(ImplicitLocOpBuilder &b,
 void FunctionBuilder::createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
                                                    Value buf, uint32_t length,
                                                    Value pred, MemType memType,
-                                                   Operation *insertPoint) {
+                                                   Operation *insertPoint,
+                                                   Value recipientCTAs) {
   if (auxData.buffers[(int)memType].empty() ||
       auxData.writeTracking[(int)memType].empty()) {
     return;
@@ -1158,8 +1339,8 @@ void FunctionBuilder::createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
       auxData.writeTracking[(int)memType].at(insertPoint).type);
   Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {bufOffset, lengthVal, pred, buffersVal,
-                             writeTrackingVal};
+  SmallVector<Value> args = {bufOffset,  lengthVal,        pred,
+                             buffersVal, writeTrackingVal, recipientCTAs};
   createCallToCachedFunction(
       b, "clear_write_tracking", args,
       /*assertInfo=*/std::nullopt,
@@ -1171,6 +1352,7 @@ void FunctionBuilder::createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
         Value pred = entryBlock->getArgument(2);
         Value buffers = entryBlock->getArgument(3);
         Value writeTrackingPtr = entryBlock->getArgument(4);
+        Value recipientCTAs = entryBlock->getArgument(5);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -1185,9 +1367,9 @@ void FunctionBuilder::createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
             tti::createConstIntTensor(fb, fb.getLoc(), 0, writeTrackingType);
         Value newTracking =
             arith::SelectOp::create(fb, buffersEqBuf, zero, writeTracking);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
-                                      newTracking, writeTrackingType,
-                                      /*currentCTAOnly=*/true);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
+                                          newTracking, writeTrackingType,
+                                          recipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -1197,7 +1379,8 @@ void FunctionBuilder::createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
 void FunctionBuilder::createClearReadVisibilityCall(ImplicitLocOpBuilder &b,
                                                     Value buf, uint32_t length,
                                                     Value pred, MemType memType,
-                                                    Operation *insertPoint) {
+                                                    Operation *insertPoint,
+                                                    Value recipientCTAs) {
   if (auxData.buffers[(int)memType].empty() ||
       auxData.readVisibility[(int)memType].empty()) {
     return;
@@ -1213,8 +1396,8 @@ void FunctionBuilder::createClearReadVisibilityCall(ImplicitLocOpBuilder &b,
       auxData.readVisibility[(int)memType].at(insertPoint).type);
   Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {bufOffset, lengthVal, pred, buffersVal,
-                             readVisibilityVal};
+  SmallVector<Value> args = {bufOffset,  lengthVal,         pred,
+                             buffersVal, readVisibilityVal, recipientCTAs};
   createCallToCachedFunction(
       b, "clear_read_visibility", args,
       /*assertInfo=*/std::nullopt,
@@ -1226,6 +1409,7 @@ void FunctionBuilder::createClearReadVisibilityCall(ImplicitLocOpBuilder &b,
         Value pred = entryBlock->getArgument(2);
         Value buffers = entryBlock->getArgument(3);
         Value readVisibilityPtr = entryBlock->getArgument(4);
+        Value recipientCTAs = entryBlock->getArgument(5);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -1240,9 +1424,9 @@ void FunctionBuilder::createClearReadVisibilityCall(ImplicitLocOpBuilder &b,
             tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
         Value newVisibility =
             arith::SelectOp::create(fb, buffersEqBuf, zero, readVisibility);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
-                                      newVisibility, readVisibilityType,
-                                      /*currentCTAOnly=*/true);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
+                                          newVisibility, readVisibilityType,
+                                          recipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -1252,7 +1436,8 @@ void FunctionBuilder::createClearReadVisibilityCall(ImplicitLocOpBuilder &b,
 void FunctionBuilder::createClearReadTrackingCall(ImplicitLocOpBuilder &b,
                                                   Value buf, uint32_t length,
                                                   Value pred, MemType memType,
-                                                  Operation *insertPoint) {
+                                                  Operation *insertPoint,
+                                                  Value recipientCTAs) {
 
   if (auxData.buffers[(int)memType].empty() ||
       auxData.readTracking[(int)memType].empty()) {
@@ -1269,8 +1454,8 @@ void FunctionBuilder::createClearReadTrackingCall(ImplicitLocOpBuilder &b,
       auxData.readTracking[(int)memType].at(insertPoint).type);
   Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {bufOffset, lengthVal, pred, buffersVal,
-                             readTrackingVal};
+  SmallVector<Value> args = {bufOffset,  lengthVal,       pred,
+                             buffersVal, readTrackingVal, recipientCTAs};
   createCallToCachedFunction(
       b, "clear_read_tracking", args,
       /*assertInfo=*/std::nullopt,
@@ -1282,6 +1467,7 @@ void FunctionBuilder::createClearReadTrackingCall(ImplicitLocOpBuilder &b,
         Value pred = entryBlock->getArgument(2);
         Value buffers = entryBlock->getArgument(3);
         Value readTrackingPtr = entryBlock->getArgument(4);
+        Value recipientCTAs = entryBlock->getArgument(5);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -1296,9 +1482,9 @@ void FunctionBuilder::createClearReadTrackingCall(ImplicitLocOpBuilder &b,
             tti::createConstIntTensor(fb, fb.getLoc(), 0, readTrackingType);
         Value newTracking =
             arith::SelectOp::create(fb, buffersEqBuf, zero, readTracking);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
-                                      newTracking, readTrackingType,
-                                      /*currentCTAOnly=*/true);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
+                                          newTracking, readTrackingType,
+                                          recipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -1308,7 +1494,8 @@ void FunctionBuilder::createClearReadTrackingCall(ImplicitLocOpBuilder &b,
 void FunctionBuilder::createTrackVisibleWritesCall(ImplicitLocOpBuilder &b,
                                                    Value mbar, int thread,
                                                    Value pred, MemType memType,
-                                                   Operation *insertPoint) {
+                                                   Operation *insertPoint,
+                                                   Value recipientCTAs) {
   if (auxData.barriers.empty() ||
       auxData.writeVisibility[(int)memType].empty() ||
       auxData.writeTracking[(int)memType].empty()) {
@@ -1331,9 +1518,9 @@ void FunctionBuilder::createTrackVisibleWritesCall(ImplicitLocOpBuilder &b,
   uint32_t length = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset,      lengthVal,   pred,
-                             threadVal,       barriersVal, writeVisibilityVal,
-                             writeTrackingVal};
+  SmallVector<Value> args = {mbarOffset,       lengthVal,    pred,
+                             threadVal,        barriersVal,  writeVisibilityVal,
+                             writeTrackingVal, recipientCTAs};
   createCallToCachedFunction(
       b, "track_visible_writes", args,
       /*assertInfo=*/std::nullopt,
@@ -1347,6 +1534,7 @@ void FunctionBuilder::createTrackVisibleWritesCall(ImplicitLocOpBuilder &b,
         Value barriers = entryBlock->getArgument(4);
         Value writeVisibilityPtr = entryBlock->getArgument(5);
         Value writeTrackingPtr = entryBlock->getArgument(6);
+        Value recipientCTAs = entryBlock->getArgument(7);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -1378,9 +1566,9 @@ void FunctionBuilder::createTrackVisibleWritesCall(ImplicitLocOpBuilder &b,
             tti::createConstIntTensor(fb, fb.getLoc(), 1, writeTrackingType);
         Value newTracking = arith::SelectOp::create(
             fb, barAndVisible, writeTrackingOne, writeTracking);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
-                                      newTracking, writeTrackingType,
-                                      /*currentCTAOnly=*/true);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
+                                          newTracking, writeTrackingType,
+                                          recipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -1390,7 +1578,8 @@ void FunctionBuilder::createTrackVisibleWritesCall(ImplicitLocOpBuilder &b,
 void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
                                                   Value mbar, int thread,
                                                   Value pred, MemType memType,
-                                                  Operation *insertPoint) {
+                                                  Operation *insertPoint,
+                                                  Value recipientCTAs) {
 
   if (auxData.barriers.empty() ||
       auxData.readVisibility[(int)memType].empty() ||
@@ -1414,9 +1603,9 @@ void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
   uint32_t length = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset,     lengthVal,   pred,
-                             threadVal,      barriersVal, readVisibilityVal,
-                             readTrackingVal};
+  SmallVector<Value> args = {mbarOffset,      lengthVal,    pred,
+                             threadVal,       barriersVal,  readVisibilityVal,
+                             readTrackingVal, recipientCTAs};
   createCallToCachedFunction(
       b, "track_visible_reads", args,
       /*assertInfo=*/std::nullopt,
@@ -1430,6 +1619,7 @@ void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
         Value barriers = entryBlock->getArgument(4);
         Value readVisibilityPtr = entryBlock->getArgument(5);
         Value readTrackingPtr = entryBlock->getArgument(6);
+        Value recipientCTAs = entryBlock->getArgument(7);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -1456,9 +1646,9 @@ void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
             arith::OrIOp::create(fb, readTracking, visibleReads);
         Value newTracking = arith::SelectOp::create(
             fb, barriersEqBar, readTrackingOrVisible, readTracking);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
-                                      newTracking, readTrackingType,
-                                      /*currentCTAOnly=*/true);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
+                                          newTracking, readTrackingType,
+                                          recipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -1467,11 +1657,14 @@ void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
 
 void FunctionBuilder::createTrackBarrierWriteForBufferCall(
     ImplicitLocOpBuilder &b, Value mbar, Value buf, uint32_t length, Value pred,
-    MemType memType, Operation *insertPoint) {
+    MemType memType, Operation *insertPoint, Value barrierRecipientCTAs,
+    Value effectRecipientCTAs) {
   if (auxData.barriers.empty() || auxData.buffers[(int)memType].empty() ||
       auxData.writeTracking[(int)memType].empty()) {
     return;
   }
+  assert(!auxData.barrierWriteRecipients.empty() &&
+         "barrier write recipients must exist when tracking TMA writes");
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   Value barriersVal = auxData.barriers.at(insertPoint).value;
@@ -1484,20 +1677,34 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
       auxData.writeTracking[(int)memType].at(insertPoint).value;
   auto writeTrackingType = cast<RankedTensorType>(
       auxData.writeTracking[(int)memType].at(insertPoint).type);
+  Value barrierWriteRecipientsVal =
+      auxData.barrierWriteRecipients.at(insertPoint).value;
+  auto barrierWriteRecipientsType = cast<RankedTensorType>(
+      auxData.barrierWriteRecipients.at(insertPoint).type);
   uint32_t mbarLength = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value mbarLengthVal = arith::ConstantIntOp::create(b, mbarLength, 32);
   Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
   Value bufLengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset, mbarLengthVal,   pred,
-                             bufOffset,  bufLengthVal,    barriersVal,
-                             buffersVal, writeTrackingVal};
+  SmallVector<Value> args = {mbarOffset,
+                             mbarLengthVal,
+                             pred,
+                             bufOffset,
+                             bufLengthVal,
+                             barriersVal,
+                             buffersVal,
+                             writeTrackingVal,
+                             barrierWriteRecipientsVal,
+                             barrierRecipientCTAs,
+                             effectRecipientCTAs};
   createCallToCachedFunction(
       b, "track_barrier_write_for_buffer", args,
       /*assertInfo=*/std::nullopt,
-      {barriersType, buffersType, writeTrackingType, (uint64_t)memType},
-      [barriersType, buffersType, writeTrackingType](ImplicitLocOpBuilder &fb,
-                                                     Block *entryBlock) {
+      {barriersType, buffersType, writeTrackingType, barrierWriteRecipientsType,
+       (uint64_t)memType},
+      [barriersType, buffersType, writeTrackingType,
+       barrierWriteRecipientsType](ImplicitLocOpBuilder &fb,
+                                   Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value mbarLengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -1506,16 +1713,33 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
         Value barriers = entryBlock->getArgument(5);
         Value buffers = entryBlock->getArgument(6);
         Value writeTrackingPtr = entryBlock->getArgument(7);
+        Value barrierWriteRecipientsPtr = entryBlock->getArgument(8);
+        Value barrierRecipientCTAs = entryBlock->getArgument(9);
+        Value effectRecipientCTAs = entryBlock->getArgument(10);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
         Value writeTracking = tti::createLoadScratchMemory(
             fb, fb.getLoc(), writeTrackingPtr, writeTrackingType);
+        Value barrierWriteRecipients = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), barrierWriteRecipientsPtr,
+            barrierWriteRecipientsType);
         Value barrierDescriptor =
             createBufferDescriptor(fb, mbarOffset, mbarLengthVal);
         Value barriersEqBar =
             createCmpIntTensorScalar(fb, barriers, barrierDescriptor);
+        Value effectRecipientCTAsTensor = triton::SplatOp::create(
+            fb, barrierWriteRecipientsType, effectRecipientCTAs);
+        Value updatedBarrierWriteRecipients = arith::OrIOp::create(
+            fb, barrierWriteRecipients, effectRecipientCTAsTensor);
+        updatedBarrierWriteRecipients = arith::SelectOp::create(
+            fb, barriersEqBar, updatedBarrierWriteRecipients,
+            barrierWriteRecipients);
+        createCTAScopedStoreScratchMemory(
+            fb, fb.getLoc(), barrierWriteRecipientsPtr,
+            updatedBarrierWriteRecipients, barrierWriteRecipientsType,
+            barrierRecipientCTAs);
         barriersEqBar =
             convertAndBroadcast(fb, barriersEqBar, {0, 2}, writeTrackingType);
         Value bufferDescriptor =
@@ -1530,9 +1754,9 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
             tti::createConstIntTensor(fb, fb.getLoc(), 1, writeTrackingType);
         Value newTracking = arith::SelectOp::create(
             fb, trackMask, writeTrackingOne, writeTracking);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
-                                      newTracking, writeTrackingType,
-                                      /*currentCTAOnly=*/true);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
+                                          newTracking, writeTrackingType,
+                                          effectRecipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -1557,40 +1781,68 @@ void FunctionBuilder::createClearBarrierWriteTrackingCall(
       auxData.writeTracking[(int)memType].at(insertPoint).value;
   auto writeTrackingType = cast<RankedTensorType>(
       auxData.writeTracking[(int)memType].at(insertPoint).type);
+  Value barrierWriteRecipientsVal =
+      auxData.barrierWriteRecipients.at(insertPoint).value;
+  auto barrierWriteRecipientsType = cast<RankedTensorType>(
+      auxData.barrierWriteRecipients.at(insertPoint).type);
   uint32_t length = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset, lengthVal, pred, barriersVal,
-                             writeTrackingVal};
+  SmallVector<Value> args = {
+      mbarOffset,  lengthVal,        pred,
+      barriersVal, writeTrackingVal, barrierWriteRecipientsVal};
   createCallToCachedFunction(
       b, "clear_barrier_write_tracking", args,
       /*assertInfo=*/std::nullopt,
-      {barriersType, writeTrackingType, (uint64_t)memType},
-      [barriersType, writeTrackingType](ImplicitLocOpBuilder &fb,
-                                        Block *entryBlock) {
+      {barriersType, writeTrackingType, barrierWriteRecipientsType,
+       (uint64_t)memType},
+      [barriersType, writeTrackingType, barrierWriteRecipientsType](
+          ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
         Value barriers = entryBlock->getArgument(3);
         Value writeTrackingPtr = entryBlock->getArgument(4);
+        Value barrierWriteRecipientsPtr = entryBlock->getArgument(5);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
         Value writeTracking = tti::createLoadScratchMemory(
             fb, fb.getLoc(), writeTrackingPtr, writeTrackingType);
+        Value barrierWriteRecipients = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), barrierWriteRecipientsPtr,
+            barrierWriteRecipientsType);
         Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
         Value barriersEqBar =
             createCmpIntTensorScalar(fb, barriers, descriptor);
+        Value barrierRecipientCTAs = createCurrentCTAMask(fb);
+        Value barrierCTAMask = createRecipientCTAMask(
+            fb, barrierWriteRecipientsType, barrierRecipientCTAs);
+        Value selectedBarrier =
+            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
+        Value zeroRecipients = tti::createConstIntTensor(
+            fb, fb.getLoc(), 0, barrierWriteRecipientsType);
+        Value selectedRecipients = arith::SelectOp::create(
+            fb, selectedBarrier, barrierWriteRecipients, zeroRecipients);
+        Value effectRecipientCTAs =
+            reduceAll<arith::OrIOp>(fb, selectedRecipients);
+        Value recipientCTAs =
+            arith::OrIOp::create(fb, barrierRecipientCTAs, effectRecipientCTAs);
+        Value updatedRecipients = arith::SelectOp::create(
+            fb, selectedBarrier, zeroRecipients, barrierWriteRecipients);
+        createCTAScopedStoreScratchMemory(
+            fb, fb.getLoc(), barrierWriteRecipientsPtr, updatedRecipients,
+            barrierWriteRecipientsType, barrierRecipientCTAs);
         barriersEqBar =
             convertAndBroadcast(fb, barriersEqBar, {0, 2}, writeTrackingType);
         Value zero =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, writeTrackingType);
         Value updated =
             arith::SelectOp::create(fb, barriersEqBar, zero, writeTracking);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
-                                      updated, writeTrackingType,
-                                      /*currentCTAOnly=*/true);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
+                                          updated, writeTrackingType,
+                                          recipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -1646,9 +1898,9 @@ void FunctionBuilder::createClearBarrierReadTrackingCall(
             tti::createConstIntTensor(fb, fb.getLoc(), 0, readTrackingType);
         Value updated =
             arith::SelectOp::create(fb, barriersEqBar, zero, readTracking);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr, updated,
-                                      readTrackingType,
-                                      /*currentCTAOnly=*/true);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
+                                          updated, readTrackingType,
+                                          createCurrentCTAMask(fb));
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -1678,18 +1930,29 @@ void FunctionBuilder::createTransferVisibleWritesCall(
       auxData.writeTracking[(int)memType].at(insertPoint).value;
   auto writeTrackingType = cast<RankedTensorType>(
       auxData.writeTracking[(int)memType].at(insertPoint).type);
+  Value barrierWriteRecipientsVal =
+      auxData.barrierWriteRecipients.at(insertPoint).value;
+  auto barrierWriteRecipientsType = cast<RankedTensorType>(
+      auxData.barrierWriteRecipients.at(insertPoint).type);
   uint32_t length = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset,      lengthVal,   pred,
-                             threadMaskVal,   barriersVal, writeVisibilityVal,
-                             writeTrackingVal};
+  SmallVector<Value> args = {mbarOffset,
+                             lengthVal,
+                             pred,
+                             threadMaskVal,
+                             barriersVal,
+                             writeVisibilityVal,
+                             writeTrackingVal,
+                             barrierWriteRecipientsVal};
   createCallToCachedFunction(
       b, "transfer_visible_writes", args,
       /*assertInfo=*/std::nullopt,
-      {barriersType, writeVisibilityType, writeTrackingType, (uint64_t)memType},
-      [barriersType, writeVisibilityType,
-       writeTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      {barriersType, writeVisibilityType, writeTrackingType,
+       barrierWriteRecipientsType, (uint64_t)memType},
+      [barriersType, writeVisibilityType, writeTrackingType,
+       barrierWriteRecipientsType](ImplicitLocOpBuilder &fb,
+                                   Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -1697,6 +1960,7 @@ void FunctionBuilder::createTransferVisibleWritesCall(
         Value barriers = entryBlock->getArgument(4);
         Value writeVisibilityPtr = entryBlock->getArgument(5);
         Value writeTrackingPtr = entryBlock->getArgument(6);
+        Value barrierWriteRecipientsPtr = entryBlock->getArgument(7);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -1705,9 +1969,27 @@ void FunctionBuilder::createTransferVisibleWritesCall(
             fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
         Value writeTracking = tti::createLoadScratchMemory(
             fb, fb.getLoc(), writeTrackingPtr, writeTrackingType);
+        Value barrierWriteRecipients = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), barrierWriteRecipientsPtr,
+            barrierWriteRecipientsType);
         Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
         Value barriersEqBar =
             createCmpIntTensorScalar(fb, barriers, descriptor);
+        Value ctaId = tti::ExperimentalClusterCTAIdOp::create(fb, fb.getLoc());
+        Value barrierCTAMask =
+            createDimMask(fb, ctaId, barrierWriteRecipientsType, /*dim=*/0);
+        Value selectedBarrier =
+            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
+        Value zeroRecipients = tti::createConstIntTensor(
+            fb, fb.getLoc(), 0, barrierWriteRecipientsType);
+        Value selectedRecipients = arith::SelectOp::create(
+            fb, selectedBarrier, barrierWriteRecipients, zeroRecipients);
+        Value trackedRecipientCTAs =
+            reduceAll<arith::OrIOp>(fb, selectedRecipients);
+        Value currentCTA = arith::ShLIOp::create(
+            fb, arith::ConstantIntOp::create(fb, 1, 32), ctaId);
+        Value recipientCTAs =
+            arith::OrIOp::create(fb, currentCTA, trackedRecipientCTAs);
         barriersEqBar =
             convertAndBroadcast(fb, barriersEqBar, {0, 2}, writeTrackingType);
         Value zeroTracking =
@@ -1733,9 +2015,9 @@ void FunctionBuilder::createTransferVisibleWritesCall(
             fb, trackingBuffers, threadMaskTensor, zeroVisibility);
         Value newVisibility =
             arith::OrIOp::create(fb, writeVisibility, trackingThreadBit);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), writeVisibilityPtr,
-                                      newVisibility, writeVisibilityType,
-                                      /*currentCTAOnly=*/true);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), writeVisibilityPtr,
+                                          newVisibility, writeVisibilityType,
+                                          recipientCTAs);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -1810,9 +2092,9 @@ void FunctionBuilder::createTransferVisibleReadsCall(
             createThreadColumnMask(fb, threadMaskVal, readVisibilityType);
         Value newVisibility = arith::SelectOp::create(
             fb, threadColumnMask, readVisibilityOrTracking, readVisibility);
-        tti::createStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
-                                      newVisibility, readVisibilityType,
-                                      /*currentCTAOnly=*/true);
+        createCTAScopedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
+                                          newVisibility, readVisibilityType,
+                                          createCurrentCTAMask(fb));
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
@@ -1821,8 +2103,8 @@ void FunctionBuilder::createTransferVisibleReadsCall(
 
 void FunctionBuilder::createVerifyWriteVisibilityCall(
     ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
-    StringRef operandName, Value pred, MemType memType,
-    Operation *insertPoint) {
+    StringRef operandName, Value pred, MemType memType, Operation *insertPoint,
+    Value recipientCTAs) {
   if (auxData.buffers[(int)memType].empty() ||
       auxData.writeVisibility[(int)memType].empty() ||
       (auxData.hasNonTrivialAliasing[(int)memType] &&
@@ -1857,7 +2139,8 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
       Value threadVal = entryBlock->getArgument(3);
       Value buffers = entryBlock->getArgument(4);
       Value writeVisibilityPtr = entryBlock->getArgument(5);
-      Value aliasMatrix = useAlias ? entryBlock->getArgument(6) : Value();
+      Value recipientCTAs = entryBlock->getArgument(6);
+      Value aliasMatrix = useAlias ? entryBlock->getArgument(7) : Value();
 
       Value writeVisibility = tti::createLoadScratchMemory(
           fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
@@ -1870,8 +2153,8 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
       }
       buffersEqBuf =
           convertAndBroadcast(fb, buffersEqBuf, {0, 1}, writeVisibilityType);
-      Value ctaId = tti::ExperimentalClusterCTAIdOp::create(fb, fb.getLoc());
-      Value ctaMask = createDimMask(fb, ctaId, writeVisibilityType, /*dim=*/0);
+      Value ctaMask =
+          createRecipientCTAMask(fb, writeVisibilityType, recipientCTAs);
       buffersEqBuf = arith::AndIOp::create(fb, buffersEqBuf, ctaMask);
       Value writeVisibilityZero =
           tti::createConstIntTensor(fb, fb.getLoc(), 0, writeVisibilityType);
@@ -1909,16 +2192,17 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
     aliasMatrixTypeBase =
         auxData.aliasMatrices[(int)memType].at(insertPoint).type;
     auto aliasMatrixType = cast<RankedTensorType>(aliasMatrixTypeBase);
-    SmallVector<Value> args = {bufOffset,     lengthVal,  pred,
-                               threadVal,     buffersVal, writeVisibilityVal,
-                               aliasMatrixVal};
+    SmallVector<Value> args = {bufOffset,     lengthVal,     pred,
+                               threadVal,     buffersVal,    writeVisibilityVal,
+                               recipientCTAs, aliasMatrixVal};
     createCallToCachedFunction(
         b, "verify_write_visibility", args, assertInfo,
         {buffersType, writeVisibilityType, aliasMatrixType, (uint64_t)memType},
         buildVerifyWriteBody(/*useAlias=*/true));
   } else {
-    SmallVector<Value> args = {bufOffset, lengthVal,  pred,
-                               threadVal, buffersVal, writeVisibilityVal};
+    SmallVector<Value> args = {bufOffset,    lengthVal,  pred,
+                               threadVal,    buffersVal, writeVisibilityVal,
+                               recipientCTAs};
     createCallToCachedFunction(
         b, "verify_write_visibility_noalias", args, assertInfo,
         {buffersType, writeVisibilityType, (uint64_t)memType},
@@ -1928,8 +2212,8 @@ void FunctionBuilder::createVerifyWriteVisibilityCall(
 
 void FunctionBuilder::createVerifyReadVisibilityCall(
     ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
-    StringRef operandName, Value pred, MemType memType,
-    Operation *insertPoint) {
+    StringRef operandName, Value pred, MemType memType, Operation *insertPoint,
+    Value recipientCTAs) {
   if (auxData.buffers[(int)memType].empty() ||
       auxData.readVisibility[(int)memType].empty() ||
       (auxData.hasNonTrivialAliasing[(int)memType] &&
@@ -1964,7 +2248,8 @@ void FunctionBuilder::createVerifyReadVisibilityCall(
       Value threadVal = entryBlock->getArgument(3);
       Value buffers = entryBlock->getArgument(4);
       Value readVisibilityPtr = entryBlock->getArgument(5);
-      Value aliasMatrix = useAlias ? entryBlock->getArgument(6) : Value();
+      Value recipientCTAs = entryBlock->getArgument(6);
+      Value aliasMatrix = useAlias ? entryBlock->getArgument(7) : Value();
 
       Value readVisibility = tti::createLoadScratchMemory(
           fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
@@ -1977,8 +2262,8 @@ void FunctionBuilder::createVerifyReadVisibilityCall(
       }
       buffersEqBuf =
           convertAndBroadcast(fb, buffersEqBuf, {0, 1}, readVisibilityType);
-      Value ctaId = tti::ExperimentalClusterCTAIdOp::create(fb, fb.getLoc());
-      Value ctaMask = createDimMask(fb, ctaId, readVisibilityType, /*dim=*/0);
+      Value ctaMask =
+          createRecipientCTAMask(fb, readVisibilityType, recipientCTAs);
       buffersEqBuf = arith::AndIOp::create(fb, buffersEqBuf, ctaMask);
       Value readVisibilityZero =
           tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
@@ -2011,16 +2296,17 @@ void FunctionBuilder::createVerifyReadVisibilityCall(
     aliasMatrixTypeBase =
         auxData.aliasMatrices[(int)memType].at(insertPoint).type;
     auto aliasMatrixType = cast<RankedTensorType>(aliasMatrixTypeBase);
-    SmallVector<Value> args = {bufOffset,     lengthVal,  pred,
-                               threadVal,     buffersVal, readVisibilityVal,
-                               aliasMatrixVal};
+    SmallVector<Value> args = {bufOffset,     lengthVal,     pred,
+                               threadVal,     buffersVal,    readVisibilityVal,
+                               recipientCTAs, aliasMatrixVal};
     createCallToCachedFunction(
         b, "verify_read_visibility", args, assertInfo,
         {buffersType, readVisibilityType, aliasMatrixType, (uint64_t)memType},
         buildVerifyReadBody(/*useAlias=*/true));
   } else {
-    SmallVector<Value> args = {bufOffset, lengthVal,  pred,
-                               threadVal, buffersVal, readVisibilityVal};
+    SmallVector<Value> args = {bufOffset,    lengthVal,  pred,
+                               threadVal,    buffersVal, readVisibilityVal,
+                               recipientCTAs};
     createCallToCachedFunction(
         b, "verify_read_visibility_noalias", args, assertInfo,
         {buffersType, readVisibilityType, (uint64_t)memType},
@@ -2064,9 +2350,10 @@ void FunctionBuilder::createCopyWriteVisibilityCall(ImplicitLocOpBuilder &b,
             tti::createConstIntTensor(fb, fb.getLoc(), 0, writeVisibilityType);
 
         constexpr uint64_t fullMask =
-            tti::THREADS_BITMASK_SIZE >= 64
+            tti::THREADS_BITMASK_SIZE == 64
                 ? std::numeric_limits<uint64_t>::max()
-                : ((1ull << tti::THREADS_BITMASK_SIZE) - 1);
+                : (std::numeric_limits<uint64_t>::max() >>
+                   (64 - tti::THREADS_BITMASK_SIZE));
         Value fullMaskVal = arith::ConstantIntOp::create(fb, fullMask, 64);
         Value destMaskElem = adjustIntegerWidth(fb, destMaskVal, elemType);
         Value fullMaskElem = adjustIntegerWidth(fb, fullMaskVal, elemType);
@@ -2442,10 +2729,140 @@ void FunctionBuilder::createClearOutstandingCommitsTransferReadsCall(
       });
 }
 
+void FunctionBuilder::createClearOutstandingCommitsTransferBothCall(
+    ImplicitLocOpBuilder &b, int thread, uint64_t transferThreadMask,
+    int outstandingNum, Value pred, CommitKind::Kind commitKind,
+    MemType memType, Operation *insertPoint) {
+  if (auxData.commits[commitKind].empty())
+    return;
+  bool hasWriteVis = !auxData.writeVisibility[(int)memType].empty();
+  bool hasReadVis = !auxData.readVisibility[(int)memType].empty();
+  if (!hasWriteVis && !hasReadVis)
+    return;
+  if (!hasWriteVis) {
+    createClearOutstandingCommitsTransferReadsCall(
+        b, thread, transferThreadMask, outstandingNum, pred, commitKind,
+        memType, insertPoint);
+    return;
+  }
+  if (!hasReadVis) {
+    createClearOutstandingCommitsTransferWritesCall(
+        b, thread, transferThreadMask, outstandingNum, pred, commitKind,
+        memType, insertPoint);
+    return;
+  }
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType outstandingCommits = auxData.commits[commitKind].at(insertPoint);
+  ValueType writeVisibility =
+      auxData.writeVisibility[(int)memType].at(insertPoint);
+  ValueType readVisibility =
+      auxData.readVisibility[(int)memType].at(insertPoint);
+  auto commitsType = cast<RankedTensorType>(outstandingCommits.type);
+  auto writeVisibilityType = cast<RankedTensorType>(writeVisibility.type);
+  auto readVisibilityType = cast<RankedTensorType>(readVisibility.type);
+  Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
+  Value transferMaskVal =
+      arith::ConstantIntOp::create(b, transferThreadMask, 64);
+  Value outstandingNumVal = arith::ConstantIntOp::create(b, outstandingNum, 32);
+  SmallVector<Value> args = {threadVal,
+                             transferMaskVal,
+                             outstandingNumVal,
+                             pred,
+                             outstandingCommits.value,
+                             writeVisibility.value,
+                             readVisibility.value};
+  createCallToCachedFunction(
+      b, "clear_outstanding_commits_transfer_both", args,
+      /*assertInfo=*/std::nullopt,
+      {commitsType, writeVisibilityType, readVisibilityType},
+      [commitsType, writeVisibilityType,
+       readVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value threadVal = entryBlock->getArgument(0);
+        Value transferMaskVal = entryBlock->getArgument(1);
+        Value outstandingNumVal = entryBlock->getArgument(2);
+        Value pred = entryBlock->getArgument(3);
+        Value outstandingCommitsPtr = entryBlock->getArgument(4);
+        Value writeVisibilityPtr = entryBlock->getArgument(5);
+        Value readVisibilityPtr = entryBlock->getArgument(6);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+
+        Value outstandingCommits = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), outstandingCommitsPtr, commitsType);
+        Value writeVisibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
+        Value readVisibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
+
+        auto elemIntType = cast<IntegerType>(commitsType.getElementType());
+        Value outstandingNumElem =
+            adjustIntegerWidth(fb, outstandingNumVal, elemIntType);
+        Value threadColumnMask = createColumnMask(fb, threadVal, commitsType);
+        auto outstandingCommitsGtOutstandingNum =
+            createCmpIntTensorScalar(fb, outstandingCommits, outstandingNumElem,
+                                     arith::CmpIPredicate::sgt);
+        outstandingCommitsGtOutstandingNum = arith::AndIOp::create(
+            fb, outstandingCommitsGtOutstandingNum, threadColumnMask);
+
+        // Update write visibility
+        Value writeRowMask =
+            reduceLastDim<arith::OrIOp>(fb, outstandingCommitsGtOutstandingNum);
+        writeRowMask = createConvertLayout(fb, writeRowMask,
+                                           writeVisibilityType.getEncoding());
+        Value writeTransferMaskElem = adjustIntegerWidth(
+            fb, transferMaskVal,
+            cast<IntegerType>(writeVisibilityType.getElementType()));
+        Value writeTransferMaskTensor = triton::SplatOp::create(
+            fb, writeVisibilityType, writeTransferMaskElem);
+        Value writeVisibilityOrThreadBit =
+            arith::OrIOp::create(fb, writeVisibility, writeTransferMaskTensor);
+        Value writeVisibilityUpdated = arith::SelectOp::create(
+            fb, writeRowMask, writeVisibilityOrThreadBit, writeVisibility);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), writeVisibilityPtr,
+                                      writeVisibilityUpdated,
+                                      writeVisibilityType,
+                                      /*currentCTAOnly=*/true);
+
+        // Update read visibility
+        Value readRowMask =
+            reduceLastDim<arith::OrIOp>(fb, outstandingCommitsGtOutstandingNum);
+        readRowMask =
+            convertAndBroadcast(fb, readRowMask, {0, 1}, readVisibilityType);
+        Value readTransferMaskElem = adjustIntegerWidth(
+            fb, transferMaskVal,
+            cast<IntegerType>(readVisibilityType.getElementType()));
+        Value readTransferMaskTensor = triton::SplatOp::create(
+            fb, readVisibilityType, readTransferMaskElem);
+        Value readVisibilityOrThreadBit =
+            arith::OrIOp::create(fb, readVisibility, readTransferMaskTensor);
+        Value readVisibilityUpdated = arith::SelectOp::create(
+            fb, readRowMask, readVisibilityOrThreadBit, readVisibility);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
+                                      readVisibilityUpdated, readVisibilityType,
+                                      /*currentCTAOnly=*/true);
+
+        // Clear outstanding commits once
+        Value outstandingCommitsZero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, commitsType);
+        outstandingCommits =
+            arith::SelectOp::create(fb, outstandingCommitsGtOutstandingNum,
+                                    outstandingCommitsZero, outstandingCommits);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), outstandingCommitsPtr,
+                                      outstandingCommits, commitsType,
+                                      /*currentCTAOnly=*/true);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
 void FunctionBuilder::createCheckOutstandingCommitsCall(
     ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
     StringRef pendingAccessType, Value pred, MemType memType,
-    CommitKind::Kind commitKind, Operation *insertPoint) {
+    CommitKind::Kind commitKind, Operation *insertPoint, Value recipientCTAs,
+    bool excludeSelf) {
   if (auxData.buffers[(int)memType].empty() ||
       auxData.commits[commitKind].empty() ||
       (auxData.hasNonTrivialAliasing[(int)memType] &&
@@ -2470,9 +2887,10 @@ void FunctionBuilder::createCheckOutstandingCommitsCall(
       commitsType.cloneWith(std::nullopt, b.getI1Type()));
   AssertInfo assertInfo{message, checkCommitsResultType};
   Type aliasMatrixTypeBase;
+
   auto buildCheckOutstandingCommitsBody = [&commitsType, &aliasMatrixTypeBase,
                                            checkCommitsResultType](
-                                              bool useAlias) {
+                                              bool useAlias, bool exclSelf) {
     return [=](ImplicitLocOpBuilder &fb, Block *entryBlock) {
       Value bufOffset = entryBlock->getArgument(0);
       Value lengthVal = entryBlock->getArgument(1);
@@ -2480,7 +2898,8 @@ void FunctionBuilder::createCheckOutstandingCommitsCall(
       Value threadVal = entryBlock->getArgument(3);
       Value buffers = entryBlock->getArgument(4);
       Value outstandingCommitsPtr = entryBlock->getArgument(5);
-      Value aliasMatrix = useAlias ? entryBlock->getArgument(6) : Value();
+      Value recipientCTAs = entryBlock->getArgument(6);
+      Value aliasMatrix = useAlias ? entryBlock->getArgument(7) : Value();
 
       Value outstandingCommits = tti::createLoadScratchMemory(
           fb, fb.getLoc(), outstandingCommitsPtr, commitsType);
@@ -2492,13 +2911,17 @@ void FunctionBuilder::createCheckOutstandingCommitsCall(
                           cast<RankedTensorType>(aliasMatrixTypeBase));
       }
       buffersEqBuf = convertAndBroadcast(fb, buffersEqBuf, {0, 1}, commitsType);
-      Value ctaId = tti::ExperimentalClusterCTAIdOp::create(fb, fb.getLoc());
-      Value ctaMask = createDimMask(fb, ctaId, commitsType, /*dim=*/0);
+      Value ctaMask = createRecipientCTAMask(fb, commitsType, recipientCTAs);
       buffersEqBuf = arith::AndIOp::create(fb, buffersEqBuf, ctaMask);
       Value zeroTensor =
           tti::createConstIntTensor(fb, fb.getLoc(), 0, commitsType);
       Value selectedRows = arith::SelectOp::create(
           fb, buffersEqBuf, outstandingCommits, zeroTensor);
+      if (exclSelf) {
+        Value threadColumnMask = createColumnMask(fb, threadVal, commitsType);
+        selectedRows = arith::SelectOp::create(fb, threadColumnMask, zeroTensor,
+                                               selectedRows);
+      }
       Value selectedEqZero = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
                                                    selectedRows, zeroTensor);
       Value allSelectedEqZero = reduceAll<arith::AndIOp>(fb, selectedEqZero);
@@ -2517,22 +2940,28 @@ void FunctionBuilder::createCheckOutstandingCommitsCall(
     ValueType aliasMatrix = auxData.aliasMatrices[(int)memType].at(insertPoint);
     aliasMatrixTypeBase = aliasMatrix.type;
     auto aliasMatrixType = cast<RankedTensorType>(aliasMatrixTypeBase);
-    SmallVector<Value> args = {
-        bufOffset,        lengthVal,     pred,
-        threadVal,        buffers.value, outstandingCommits.value,
-        aliasMatrix.value};
+    SmallVector<Value> args = {bufOffset,     lengthVal,
+                               pred,          threadVal,
+                               buffers.value, outstandingCommits.value,
+                               recipientCTAs, aliasMatrix.value};
+    std::string funcName = excludeSelf ? "check_outstanding_commits_excl_self"
+                                       : "check_outstanding_commits";
     createCallToCachedFunction(
-        b, "check_outstanding_commits", args, assertInfo,
+        b, funcName, args, assertInfo,
         {buffersType, commitsType, aliasMatrixType, (uint64_t)thread},
-        buildCheckOutstandingCommitsBody(/*useAlias=*/true));
+        buildCheckOutstandingCommitsBody(/*useAlias=*/true, excludeSelf));
   } else {
     SmallVector<Value> args = {bufOffset,     lengthVal,
                                pred,          threadVal,
-                               buffers.value, outstandingCommits.value};
+                               buffers.value, outstandingCommits.value,
+                               recipientCTAs};
+    std::string funcName = excludeSelf
+                               ? "check_outstanding_commits_excl_self_noalias"
+                               : "check_outstanding_commits_noalias";
     createCallToCachedFunction(
-        b, "check_outstanding_commits_noalias", args, assertInfo,
+        b, funcName, args, assertInfo,
         {buffersType, commitsType, (uint64_t)thread},
-        buildCheckOutstandingCommitsBody(/*useAlias=*/false));
+        buildCheckOutstandingCommitsBody(/*useAlias=*/false, excludeSelf));
   }
 }
 

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -1,5 +1,6 @@
 #include "triton/Dialect/TritonInstrument/IR/Utility.h"
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "triton/Analysis/BufferRegion.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -154,7 +155,22 @@ Value createZeroInitStateTensor(ImplicitLocOpBuilder &b,
                                             /*alignment=*/16,
                                             /*sharedClusterState=*/true);
   Value cstZero = arith::ConstantIntOp::create(b, 0, bitWidth);
+  Value ctaId = ExperimentalClusterCTAIdOp::create(b, b.getLoc());
+  Value zero = arith::ConstantIntOp::create(b, 0, 32);
+  Value isCTA0 =
+      arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaId, zero);
+  Block *prevBlock = b.getInsertionBlock();
+  Block::iterator insertPoint = b.getInsertionPoint();
+  Block *ifBlock = prevBlock->splitBlock(insertPoint);
+  Block *thenBlock = ifBlock->splitBlock(ifBlock->begin());
+  b.setInsertionPointToEnd(ifBlock);
+  cf::BranchOp::create(b, thenBlock);
+  b.setInsertionPointToEnd(prevBlock);
+  cf::CondBranchOp::create(b, isCTA0, ifBlock, ValueRange{}, thenBlock,
+                           ValueRange{});
+  b.setInsertionPointToStart(ifBlock);
   funcBuilder.createFillGlobalTensorCall(b, alloc, type, cstZero);
+  b.setInsertionPointToStart(thenBlock);
   return alloc;
 }
 
@@ -460,6 +476,7 @@ void AuxDataMap::populateAndPassToWarpSpecialize(
   SmallVector<BufferRegion> barrierRegions;
   getBuffersAndBarriers(module, bufRegions, barrierRegions);
   int numCTAs = lookupNumCTAs(module);
+  int captureCounter = 0;
 
   FuncOp entryPoint = getEntryPoint(module);
   assert(entryPoint);
@@ -510,7 +527,7 @@ void AuxDataMap::populateAndPassToWarpSpecialize(
         entryRegion, {createZeroInitStateTensor(b, {numCTAs, numBufs}, 64, fb),
                       getIntTensorType(entryRegion, {numCTAs, numBufs}, 64)});
     passToWarpSpecialize(entryPoint, writeVisibility[iMemType].at(entryRegion),
-                         writeVisibility[iMemType]);
+                         writeVisibility[iMemType], captureCounter);
     readVisibility[iMemType].insert(
         entryRegion,
         {createZeroInitStateTensor(b, {numCTAs, numBufs, THREADS_BITMASK_SIZE},
@@ -518,7 +535,7 @@ void AuxDataMap::populateAndPassToWarpSpecialize(
          getIntTensorType(entryRegion, {numCTAs, numBufs, THREADS_BITMASK_SIZE},
                           64)});
     passToWarpSpecialize(entryPoint, readVisibility[iMemType].at(entryRegion),
-                         readVisibility[iMemType]);
+                         readVisibility[iMemType], captureCounter);
   }
 
   if (!barrierRegions.empty()) {
@@ -535,10 +552,10 @@ void AuxDataMap::populateAndPassToWarpSpecialize(
     int numBarriers = barrierRegions.size();
     barrierStates.insert(
         entryRegion,
-        {createZeroInitStateTensor(b, {numCTAs, numBarriers}, 32, fb),
-         getIntTensorType(entryRegion, {numCTAs, numBarriers}, 32)});
+        {createZeroInitStateTensor(b, {numCTAs, numBarriers}, 64, fb),
+         getIntTensorType(entryRegion, {numCTAs, numBarriers}, 64)});
     passToWarpSpecialize(entryPoint, barrierStates.at(entryRegion),
-                         barrierStates);
+                         barrierStates, captureCounter);
 
     // Deadlock detection aux data over [cta, barrier]: waiting
     // stores waiting flag and phase bits per thread (two bits per thread).
@@ -546,7 +563,15 @@ void AuxDataMap::populateAndPassToWarpSpecialize(
         entryRegion,
         {createZeroInitStateTensor(b, {numCTAs, numBarriers}, 32, fb),
          getIntTensorType(entryRegion, {numCTAs, numBarriers}, 32)});
-    passToWarpSpecialize(entryPoint, waiting.at(entryRegion), waiting);
+    passToWarpSpecialize(entryPoint, waiting.at(entryRegion), waiting,
+                         captureCounter);
+
+    barrierWriteRecipients.insert(
+        entryRegion,
+        {createZeroInitStateTensor(b, {numCTAs, numBarriers}, 32, fb),
+         getIntTensorType(entryRegion, {numCTAs, numBarriers}, 32)});
+    passToWarpSpecialize(entryPoint, barrierWriteRecipients.at(entryRegion),
+                         barrierWriteRecipients, captureCounter);
 
     for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
       int iMemType = (int)memType;
@@ -561,7 +586,7 @@ void AuxDataMap::populateAndPassToWarpSpecialize(
                               8)});
         passToWarpSpecialize(entryPoint,
                              writeTracking[iMemType].at(entryRegion),
-                             writeTracking[iMemType]);
+                             writeTracking[iMemType], captureCounter);
         readTracking[iMemType].insert(
             entryRegion,
             {createZeroInitStateTensor(b, {numCTAs, numBufs, numBarriers}, 64,
@@ -569,7 +594,7 @@ void AuxDataMap::populateAndPassToWarpSpecialize(
              getIntTensorType(entryRegion, {numCTAs, numBufs, numBarriers},
                               64)});
         passToWarpSpecialize(entryPoint, readTracking[iMemType].at(entryRegion),
-                             readTracking[iMemType]);
+                             readTracking[iMemType], captureCounter);
       }
     }
   }
@@ -590,7 +615,7 @@ void AuxDataMap::populateAndPassToWarpSpecialize(
                       AddrSpace::GlobalRead | AddrSpace::GlobalWrite);
   }
   lock.insert(entryRegion, {lockVal, lockVal.getType()});
-  passToWarpSpecialize(entryPoint, lock.at(entryRegion), lock);
+  passToWarpSpecialize(entryPoint, lock.at(entryRegion), lock, captureCounter);
 
   auto createCommitTensor = [&](CommitKind::Kind commitKind) {
     int numBufs = bufRegions[(int)MemType::SHARED_MEM].size();
@@ -603,7 +628,7 @@ void AuxDataMap::populateAndPassToWarpSpecialize(
         {createZeroInitStateTensor(b, {numCTAs, numBufs, NUM_THREADS}, 8, fb),
          getIntTensorType(entryRegion, {numCTAs, numBufs, NUM_THREADS}, 8)});
     passToWarpSpecialize(entryPoint, commits[commitKind].at(entryRegion),
-                         commits[commitKind]);
+                         commits[commitKind], captureCounter);
   };
 
   // Create write commits tensor for cp-async
@@ -616,6 +641,21 @@ void AuxDataMap::populateAndPassToWarpSpecialize(
       if (commits[kind].empty())
         createCommitTensor(kind);
     }
+  }
+
+  // Verify the actual capture count matches the expected one.
+  if (captureCounter > 0) {
+    int numActiveMemTypes = 0;
+    for (int i = 0; i < numMemTypes; ++i)
+      numActiveMemTypes += !bufRegions[i].empty();
+    int numCommitKinds = 0;
+    for (int i = 0; i < CommitKind::NumCommitKinds; ++i)
+      numCommitKinds += !commits[i].empty();
+    int expected = estimateConSanCaptureCount(
+        numActiveMemTypes, !barrierRegions.empty(), numCommitKinds);
+    assert(captureCounter == expected &&
+           "capture count changed -- update estimateConSanCaptureCount if this "
+           "is expected!");
   }
 }
 
@@ -654,7 +694,9 @@ void AuxDataMap::getBuffersAndBarriers(
 }
 
 void AuxDataMap::passToWarpSpecialize(FuncOp func, ValueType valueType,
-                                      RegionToValueMap &map) {
+                                      RegionToValueMap &map,
+                                      int &captureCounter) {
+  ++captureCounter;
   func.walk([&](WarpSpecializePartitionsOp op) {
     op->insertOperands(op.getNumOperands(), {valueType.value});
     for (Region &region : op.getPartitionRegions()) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -10,24 +10,28 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/Sys/GetEnv.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/Support/ErrorHandling.h"
 
 // clang-format off
 // Concurrency Sanitizer data structures:
 // ConSan keeps auxilary data requied for tracking memory accesses in tensors.
 // These tensors are stored as a distributed tensor or in global scratch memory.
+// C = CTAs, B = buffers, K = mbarriers, T = logical ConSan thread bit slots,
+// P = max number of warp-specialize partitions tracked by ConSan (16 for now).
 //
-// Name              | Storage | Rank/Type       | Description
-// ------------------|---------|-----------------|------------
-// buffers           | tensor  | <B x i64>       | Base pointers of all (sub)buffers
-// barriers          | tensor  | <K x i64>       | Pointers to all individual mbarriers
-// barrierStates     | scratch | <K x i32>       | Packed barrier phase (bit 0) and arrival counts (bits[1..8] init, [9..16] current); zero means invalid/uninitialized
-// waiting           | scratch | <K x i32>       | Two bits per thread: waiting flag bit (LSB), stored phase bit (bit 1)
-// writeVisibility   | scratch | <B x i64>       | Per-buffer thread-visibility bitmask (bit i => thread i visible)
-// readVisibility    | scratch | <B x T x i64>   | Per-buffer, per-thread visibility lanes (row-updated; values are bitmasks)
-// writeTracking     | scratch | <B x K x i8>    | Map buffers -> barriers that track writes
-// readTracking      | scratch | <B x K x i64>   | Map buffers -> barriers that track reads
+// Name                   | Storage | Rank/Type          | Description
+// -----------------------|---------|--------------------|------------
+// buffers                | tensor  | <C x B x i64>      | Base pointers of all (sub)buffers
+// barriers               | tensor  | <C x K x i64>      | Pointers to all individual mbarriers
+// barrierStates          | scratch | <C x K x i64>      | Packed barrier phase (bit 0), arrival counts (bits[1..20] init, [21..40] current), and signed tx-count (bits[41..61]); zero means invalid/uninitialized
+// barrierWriteRecipients | scratch | <C x K x i32>      | CTA bitsets of write-tracking rows reached by outstanding TMA effects on each barrier
+// waiting                | scratch | <C x K x i32>      | Two bits per thread: waiting flag bit (LSB), stored phase bit (bit 1)
+// writeVisibility        | scratch | <C x B x i64>      | Per-buffer thread-visibility bitmask (bit i => thread i visible)
+// readVisibility         | scratch | <C x B x T x i64>  | Per-buffer, per-thread visibility lanes (row-updated; values are bitmasks)
+// writeTracking          | scratch | <C x B x K x i8>   | Map buffers -> barriers that track writes
+// readTracking           | scratch | <C x B x K x i64>  | Map buffers -> barriers that track reads
 // outstandingCommits
-//   (async/wgmma)   | scratch | <B x T x i8>    | Number of outstanding commits per buffer/thread (2D replaces prior 1D)
+//   (async/wgmma)        | scratch | <C x B x P x i8>   | Number of outstanding commits per buffer/base partition-thread (2D replaces prior 1D)
 // clang-format on
 
 namespace mlir {
@@ -92,7 +96,7 @@ private:
 };
 
 bool isTensorCoreOp(Operation *op) {
-  return isa<ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp, ttng::TCGen5CommitOp>(
+  return isa<ttng::MMAv5OpInterface, ttng::TCGen5CommitOp, ttng::TMEMCopyOp>(
       op);
 }
 
@@ -273,6 +277,144 @@ bool canInitializeAllocation(Value alloc) {
   return numWarps % 4 == 0;
 }
 
+Value currentCTAMask(ImplicitLocOpBuilder &b) {
+  Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
+  return arith::ShLIOp::create(b, arith::ConstantIntOp::create(b, 1, 32),
+                               ctaId);
+}
+
+uint16_t getBlockBroadcastMask(Value alloc) {
+  auto allocTy = cast<ttg::MemDescType>(alloc.getType());
+  auto kBlock = StringAttr::get(alloc.getContext(), "block");
+  return toLinearLayout(allocTy).getFreeVariableMasks().lookup(kBlock);
+}
+
+Value createCTABitset(ImplicitLocOpBuilder &b, uint32_t pattern,
+                      uint32_t baseMask) {
+  // Create a CTA bitset by shifting `pattern` by the non-broadcast CTA bits of
+  // the current CTA.
+  Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
+  Value base = arith::AndIOp::create(
+      b, ctaId, arith::ConstantIntOp::create(b, baseMask, 32));
+  return arith::ShLIOp::create(b, arith::ConstantIntOp::create(b, pattern, 32),
+                               base);
+}
+
+Value getMulticastRecipientCTAs(ImplicitLocOpBuilder &b, Value alloc) {
+  // Return the CTA rows touched by an alloc: current CTA for
+  // non-broadcast allocs, or all CTAs in the current multicast group.
+  uint16_t broadcastMask = getBlockBroadcastMask(alloc);
+  if (!broadcastMask)
+    return currentCTAMask(b);
+  int numCTAs = ttg::lookupNumCTAs(b);
+  auto encoding = ttng::getTMAMulticastMaskEncoding(numCTAs, broadcastMask);
+  return createCTABitset(b, encoding.pattern, encoding.fixedBits);
+}
+
+Value getLeaderCTA(ImplicitLocOpBuilder &b, Value barrier) {
+  uint16_t broadcastMask = getBlockBroadcastMask(barrier);
+  if (!broadcastMask)
+    return currentCTAMask(b);
+  int numCTAs = ttg::lookupNumCTAs(b);
+  auto encoding = ttng::getTMAMulticastMaskEncoding(numCTAs, broadcastMask);
+  return createCTABitset(b, /*pattern=*/1, encoding.fixedBits);
+}
+
+Value getMulticastBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Value result,
+                                       Value barrier) {
+  uint32_t resultBroadcastMask = getBlockBroadcastMask(result);
+  uint32_t barrierBroadcastMask = getBlockBroadcastMask(barrier);
+  int numCTAs = ttg::lookupNumCTAs(b);
+  uint32_t recipientBroadcastMask =
+      resultBroadcastMask & ~barrierBroadcastMask & (numCTAs - 1);
+  auto encoding =
+      ttng::getTMAMulticastMaskEncoding(numCTAs, recipientBroadcastMask);
+  uint32_t baseMask =
+      ~(resultBroadcastMask | barrierBroadcastMask) & (numCTAs - 1);
+  return createCTABitset(b, encoding.pattern, baseMask);
+}
+
+Value getRecipientCTAsForBroadcastMasks(ImplicitLocOpBuilder &b,
+                                        ArrayRef<uint16_t> broadcastMasks) {
+  if (broadcastMasks.empty())
+    return currentCTAMask(b);
+
+  int numCTAs = ttg::lookupNumCTAs(b);
+  Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
+  Value recipientCTAs = arith::ConstantIntOp::create(b, 0, 32);
+  // Match eager tcgen05_commit lowering in
+  // DotOpToLLVM/MMAv5.cpp:createMMACommit: build one concrete recipient bitset
+  // per descriptor, then OR those bitsets.
+  for (uint16_t broadcastBits : broadcastMasks) {
+    // Compute the map that goes from cta_id to lead_cta_id (fixedBits)
+    // and the pattern that goes from cta_0 to its multicast group (pattern).
+    auto encoding = ttng::getTMAMulticastMaskEncoding(numCTAs, broadcastBits);
+    Value fixedBitsVal =
+        arith::ConstantIntOp::create(b, encoding.fixedBits, 32);
+    Value base = arith::AndIOp::create(b, ctaId, fixedBitsVal);
+    Value patternVal = arith::ConstantIntOp::create(b, encoding.pattern, 32);
+    Value descRecipientCTAs = arith::ShLIOp::create(b, patternVal, base);
+    recipientCTAs = arith::OrIOp::create(b, recipientCTAs, descRecipientCTAs);
+  }
+  return recipientCTAs;
+}
+
+SmallVector<uint16_t> getTensorCoreBarrierBroadcastMasks(Operation *op) {
+  assert(isTensorCoreOp(op) && "expected a tensor-core op");
+  bool twoCTAs = ttng::getModuleTwoCTAs(op);
+  SmallVector<Value> commitDescs;
+  if (auto commitOp = dyn_cast<ttng::TCGen5CommitOp>(op)) {
+    llvm::append_range(commitDescs, commitOp.getDescs());
+  } else if (auto mmaOp = dyn_cast<ttng::TCGen5MMAOp>(op)) {
+    if (mmaOp.getMulticast()) {
+      if (isa<ttg::SharedEncodingTrait>(mmaOp.getA().getType().getEncoding()))
+        commitDescs.push_back(mmaOp.getA());
+      commitDescs.push_back(mmaOp.getB());
+    }
+  } else if (isa<ttng::TMEMCopyOp, ttng::TCGen5MMAScaledOp>(op)) {
+    // TODO: we should support descs for tc_gen5_mma_scaled.
+  } else {
+    llvm_unreachable("unknown tensor-core op");
+  }
+  return ttng::getCTABroadcastMasks(twoCTAs, commitDescs);
+}
+
+Value getBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op);
+
+Value getMemEffectRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
+  if (auto copyOp = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+    if (copyOp.getMulticast())
+      return getMulticastRecipientCTAs(b, copyOp.getResult());
+    return currentCTAMask(b);
+  }
+  if (isTensorCoreOp(op))
+    return getRecipientCTAsForBroadcastMasks(
+        b, ttng::getCTABroadcastMasks(ttng::getModuleTwoCTAs(op), {}));
+  return currentCTAMask(b);
+}
+
+Value getBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
+  if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op))
+    return getLeaderCTA(b, expectOp.getAlloc());
+  if (auto arriveOp = dyn_cast<ttng::ArriveBarrierOp>(op))
+    return getLeaderCTA(b, arriveOp.getAlloc());
+  if (auto arriveOp = dyn_cast<ttng::AsyncCopyMbarrierArriveOp>(op))
+    return getLeaderCTA(b, arriveOp.getBarrier());
+  if (auto copyOp = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+    if (copyOp.getMulticast())
+      return getMulticastBarrierRecipientCTAs(b, copyOp.getResult(),
+                                              copyOp.getBarrier());
+    return getLeaderCTA(b, copyOp.getBarrier());
+  }
+  if (auto gatherOp = dyn_cast<ttng::AsyncTMAGatherOp>(op))
+    return getLeaderCTA(b, gatherOp.getBarrier());
+
+  if (isTensorCoreOp(op))
+    return getRecipientCTAsForBroadcastMasks(
+        b, getTensorCoreBarrierBroadcastMasks(op));
+  return currentCTAMask(b);
+}
+
 class ConcurrencySanitizerImpl {
 public:
   ConcurrencySanitizerImpl(ModuleOp module, const ConSanTargetHooks *hooks)
@@ -326,15 +468,22 @@ private:
       int baseThread = getBaseThread(thread);
       b.setLoc(op->getLoc());
       b.setInsertionPoint(op);
-      if (isa<ttg::LocalAllocOp, ttng::TMEMAllocOp>(op) ||
-          hooks->isPostInstrumentedOp(op)) {
+      if (isa<ttg::LocalAllocOp, ttng::TMEMAllocOp>(op)) {
         // Place insert point after specific ops:
         // allocs - we want to
         //   check if it is not overwriting any earlier allocation, but the
         //   memref value can be referenced only after it is created.
-        // wait barriers - we can update aux data only after the wait is
-        //   completed
         b.setInsertionPointAfter(op);
+      }
+
+      if (auto info = hooks->getBarrierWaitInfo(op)) {
+        // For waits we want to instrument it before and after, so we do it
+        // manually inside instrumentBarrierWait (disable the critical section
+        // listener and return early)
+        b.setListener(nullptr);
+        instrumentBarrierWait(op, info->alloc, info->phase, info->pred, thread,
+                              baseThread, funcBuilder);
+        return;
       }
 
       instrumentMemEffects(b, op, thread, funcBuilder);
@@ -356,24 +505,24 @@ private:
         }
       }
       if (auto info = hooks->getBarrierInitInfo(op)) {
-        funcBuilder.createVerifyBarrierCanInitCall(b, info->alloc, op);
-        funcBuilder.createInitBarrierStateCall(b, info->alloc, info->count, op);
+        Value pred = hooks->getIssuerCTAPred(b, op);
+        funcBuilder.createVerifyBarrierCanInitCall(b, info->alloc, pred, op,
+                                                   currentCTAMask(b));
+        funcBuilder.createInitBarrierStateCall(b, info->alloc, info->count,
+                                               pred, op);
       }
-      if (auto invalOp = dyn_cast<ttng::InvalBarrierOp>(op)) {
-        Value barrier = invalOp.getAlloc();
-        funcBuilder.createVerifyBarrierInitializedCall(b, barrier, nullptr,
-                                                       invalOp);
-        funcBuilder.createInvalidateBarrierStateCall(b, barrier, invalOp);
+      if (auto info = hooks->getBarrierInvalidateInfo(op)) {
+        Value barrier = info->alloc;
+        Value pred = hooks->getIssuerCTAPred(b, op);
+        funcBuilder.createVerifyBarrierInitializedCall(b, barrier, pred, op,
+                                                       currentCTAMask(b));
+        funcBuilder.createInvalidateBarrierStateCall(b, barrier, pred, op);
         for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
-          funcBuilder.createClearBarrierWriteTrackingCall(b, barrier, nullptr,
-                                                          memType, invalOp);
-          funcBuilder.createClearBarrierReadTrackingCall(b, barrier, nullptr,
-                                                         memType, invalOp);
+          funcBuilder.createClearBarrierWriteTrackingCall(b, barrier, pred,
+                                                          memType, op);
+          funcBuilder.createClearBarrierReadTrackingCall(b, barrier, pred,
+                                                         memType, op);
         }
-      }
-      if (auto info = hooks->getBarrierWaitInfo(op)) {
-        instrumentBarrierWait(b, listener, op, info->alloc, info->phase,
-                              info->pred, thread, baseThread, funcBuilder);
       }
       if (auto asyncCommitGroupOp = dyn_cast<ttg::AsyncCommitGroupOp>(op)) {
         if (!auxData.commits[CommitKind::AsyncCp].empty())
@@ -392,11 +541,15 @@ private:
             MemType::SHARED_MEM, op);
       }
       if (auto info = hooks->getWaitOpInfo(op)) {
-        if (info->transferWrites) {
+        if (info->transferWrites && info->transferReads) {
+          funcBuilder.createClearOutstandingCommitsTransferBothCall(
+              b, baseThread, getThreadPeersMask(thread), info->pendingCount,
+              nullptr, info->commitKind, MemType::SHARED_MEM, op);
+        } else if (info->transferWrites) {
           funcBuilder.createClearOutstandingCommitsTransferWritesCall(
               b, baseThread, getThreadPeersMask(thread), info->pendingCount,
               nullptr, info->commitKind, MemType::SHARED_MEM, op);
-        } else {
+        } else if (info->transferReads) {
           funcBuilder.createClearOutstandingCommitsTransferReadsCall(
               b, baseThread, getThreadPeersMask(thread), info->pendingCount,
               nullptr, info->commitKind, MemType::SHARED_MEM, op);
@@ -408,35 +561,55 @@ private:
     });
   }
 
-  void instrumentBarrierWait(ImplicitLocOpBuilder &b,
-                             CriticalSectionListener &listener, Operation *op,
-                             Value alloc, Value phase, Value pred, int thread,
-                             int baseThread,
+  void instrumentBarrierWait(Operation *op, Value alloc, Value phase,
+                             Value pred, int thread, int baseThread,
                              tti::FunctionBuilder &funcBuilder) {
+    ImplicitLocOpBuilder wb(op->getLoc(), op);
+    pred = tti::maybeAnd(wb, pred, hooks->getIssuerCTAPred(wb, op));
+    Value lock = auxData.lock.at(op).value;
     // Pre-wait: mark waiting threads and check for deadlock.
-    {
-      CriticalSectionListener preListener;
-      b.setListener(&preListener);
-      b.setInsertionPoint(op);
-      funcBuilder.createVerifyBarrierInitializedCall(b, alloc, pred, op);
-      funcBuilder.createSetWaitingCall(b, alloc, baseThread, phase, pred, op);
-      funcBuilder.createCheckAllActiveWaitingCall(b, getActiveMask(op), pred,
-                                                  op);
-      preListener.maybeWrapWithCriticalSection(b, auxData, pred);
-      b.setListener(&listener);
-      b.setInsertionPointAfter(op);
-    }
+    tti::ExperimentalLockAcquireOp::create(wb, lock, pred);
+    funcBuilder.createVerifyBarrierInitializedCall(wb, alloc, pred, op,
+                                                   currentCTAMask(wb));
+    funcBuilder.createSetWaitingCall(wb, alloc, baseThread, phase, pred, op);
+    funcBuilder.createCheckAllActiveWaitingCall(wb, getActiveMask(op), pred,
+                                                op);
+    tti::ExperimentalLockReleaseOp::create(wb, lock, pred);
     // Post-wait: transfer visible writes and reads to all peer threads,
-    // and clear waiting for this barrier
+    // and clear waiting for this barrier.
     assert(!auxData.barriers.empty() &&
            "barrier descriptors must exist when instrumenting wait");
+    wb.setInsertionPointAfter(op);
+    tti::ExperimentalLockAcquireOp::create(wb, lock, pred);
     for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
       funcBuilder.createTransferVisibleWritesCall(
-          b, alloc, getThreadPeersMask(thread), pred, memType, op);
+          wb, alloc, getThreadPeersMask(thread), pred, memType, op);
       funcBuilder.createTransferVisibleReadsCall(
-          b, alloc, getThreadPeersMask(thread), pred, memType, op);
+          wb, alloc, getThreadPeersMask(thread), pred, memType, op);
     }
-    funcBuilder.createClearWaitingCall(b, alloc, baseThread, pred, op);
+    funcBuilder.createClearWaitingCall(wb, alloc, baseThread, pred, op);
+    tti::ExperimentalLockReleaseOp::create(wb, lock, pred);
+  }
+
+  void instrumentBarrierExpectNonLeaderArrive(
+      ImplicitLocOpBuilder &b, ttng::BarrierExpectOp expectOp,
+      Value nonLeaderPred, int thread, tti::FunctionBuilder &funcBuilder) {
+    Value barrier = expectOp.getAlloc();
+    Value recipientCTAs = getLeaderCTA(b, barrier);
+
+    // Match BarrierOpToLLVM's cross-CTA path: non-leader CTAs contribute a
+    // plain arrive of count 1 to the leader barrier. The generic barrier path
+    // models the leader CTA's expect_tx.
+    for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
+      funcBuilder.createTrackVisibleWritesCall(
+          b, barrier, thread, nonLeaderPred, memType, expectOp, recipientCTAs);
+      funcBuilder.createTrackVisibleReadsCall(b, barrier, thread, nonLeaderPred,
+                                              memType, expectOp, recipientCTAs);
+    }
+    funcBuilder.createVerifyBarrierArriveCall(
+        b, barrier, /*count=*/1, nonLeaderPred, expectOp, recipientCTAs);
+    funcBuilder.createUpdateBarrierStateCall(
+        b, barrier, /*count=*/1, nonLeaderPred, expectOp, recipientCTAs);
   }
 
   void instrumentMemEffects(ImplicitLocOpBuilder &b, Operation *op, int thread,
@@ -447,12 +620,20 @@ private:
       return;
     }
     Value pred = opInfo->pred;
-    auto combinePredicates = [&](Value barrierPred) -> Value {
-      if (barrierPred && pred) {
-        return arith::AndIOp::create(b, b.getLoc(), barrierPred, pred);
+    // Barrier expect performs an arrive on non-leader CTAs, so we need to
+    // instrument it separately before incorporating getIssuerCTAPred.
+    Value issuerCTAPred = hooks->getIssuerCTAPred(b, op);
+    if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op)) {
+      if (issuerCTAPred) {
+        Value nonLeaderPred = arith::XOrIOp::create(
+            b, issuerCTAPred, arith::ConstantIntOp::create(b, 1, 1));
+        nonLeaderPred = tti::maybeAnd(b, pred, nonLeaderPred);
+        instrumentBarrierExpectNonLeaderArrive(b, expectOp, nonLeaderPred,
+                                               thread, funcBuilder);
       }
-      return barrierPred ? barrierPred : pred;
-    };
+    }
+    pred = tti::maybeAnd(b, pred, issuerCTAPred);
+    Value effectRecipientCTAs = getMemEffectRecipientCTAs(b, op);
     for (auto effect : opInfo->operandEffects) {
       Value buf = effect.buf;
       auto bufType = cast<ttg::MemDescType>(buf.getType());
@@ -464,11 +645,12 @@ private:
         // For op that is reading, we only need to check if anything else
         // is writing to the same buffer.
         addWriteChecks(b, funcBuilder, op, buf, effect.length, pred, memType,
-                       thread, effect.operandName);
+                       thread, effect.operandName, effectRecipientCTAs,
+                       opInfo->commitKind);
         if (opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier) {
-          funcBuilder.createSetReadVisibilityCall(b, buf, effect.length,
-                                                  getThreadPeersMask(thread),
-                                                  pred, memType, op);
+          funcBuilder.createSetReadVisibilityCall(
+              b, buf, effect.length, getThreadPeersMask(thread), pred, memType,
+              op, effectRecipientCTAs);
         }
         if (opInfo->trackingKind ==
             MemEffectsOpInfo::TrackingKind::CommitCount) {
@@ -482,19 +664,21 @@ private:
         // Op is writing to the buffer, we need to check if anything else
         // is reading or writing to the same buffer.
         addWriteChecks(b, funcBuilder, op, buf, effect.length, pred, memType,
-                       thread, effect.operandName);
+                       thread, effect.operandName, effectRecipientCTAs,
+                       opInfo->commitKind);
         addReadChecks(b, funcBuilder, op, buf, effect.length, pred, memType,
-                      thread, effect.operandName);
+                      thread, effect.operandName, effectRecipientCTAs,
+                      opInfo->commitKind);
         if (opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier) {
-          funcBuilder.createSetWriteVisibilityCall(b, buf, effect.length,
-                                                   getThreadPeersMask(thread),
-                                                   pred, memType, op);
-          funcBuilder.createClearWriteTrackingCall(b, buf, effect.length, pred,
-                                                   memType, op);
-          funcBuilder.createClearReadVisibilityCall(b, buf, effect.length, pred,
-                                                    memType, op);
-          funcBuilder.createClearReadTrackingCall(b, buf, effect.length, pred,
-                                                  memType, op);
+          funcBuilder.createSetWriteVisibilityCall(
+              b, buf, effect.length, getThreadPeersMask(thread), pred, memType,
+              op, effectRecipientCTAs);
+          funcBuilder.createClearWriteTrackingCall(
+              b, buf, effect.length, pred, memType, op, effectRecipientCTAs);
+          funcBuilder.createClearReadVisibilityCall(
+              b, buf, effect.length, pred, memType, op, effectRecipientCTAs);
+          funcBuilder.createClearReadTrackingCall(
+              b, buf, effect.length, pred, memType, op, effectRecipientCTAs);
         }
         if (opInfo->trackingKind ==
             MemEffectsOpInfo::TrackingKind::CommitCount) {
@@ -507,18 +691,19 @@ private:
     }
     for (const auto &barrierInfo : opInfo->barriers) {
       Value barrier = barrierInfo.barrier;
-      Value combinedPred = combinePredicates(barrierInfo.pred);
+      Value combinedPred = tti::maybeAnd(b, barrierInfo.pred, pred);
+      Value recipientCTAs = getBarrierRecipientCTAs(b, op);
       funcBuilder.createVerifyBarrierInitializedCall(b, barrier, combinedPred,
-                                                     op);
+                                                     op, recipientCTAs);
       if (barrierInfo.trackingMode ==
           MemEffectsOpInfo::BarrierTrackingMode::Frontier) {
         // If the op has barriers, we treat it as a commit emitted for each
         // barrier.
         for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
-          funcBuilder.createTrackVisibleWritesCall(b, barrier, thread,
-                                                   combinedPred, memType, op);
-          funcBuilder.createTrackVisibleReadsCall(b, barrier, thread,
-                                                  combinedPred, memType, op);
+          funcBuilder.createTrackVisibleWritesCall(
+              b, barrier, thread, combinedPred, memType, op, recipientCTAs);
+          funcBuilder.createTrackVisibleReadsCall(
+              b, barrier, thread, combinedPred, memType, op, recipientCTAs);
         }
       } else if (barrierInfo.trackingMode ==
                  MemEffectsOpInfo::BarrierTrackingMode::EffectWrites) {
@@ -530,14 +715,17 @@ private:
           if (isa<ttg::SharedEncodingTrait>(bufType.getEncoding()))
             memType = MemType::SHARED_MEM;
           funcBuilder.createTrackBarrierWriteForBufferCall(
-              b, barrier, effect.buf, effect.length, combinedPred, memType, op);
+              b, barrier, effect.buf, effect.length, combinedPred, memType, op,
+              recipientCTAs, effectRecipientCTAs);
         }
       }
-      if (barrierInfo.count > 0) {
-        funcBuilder.createVerifyBarrierArriveCall(b, barrier, barrierInfo.count,
-                                                  combinedPred, op);
-        funcBuilder.createUpdateBarrierStateCall(b, barrier, barrierInfo.count,
-                                                 combinedPred, op);
+      if (barrierInfo.count > 0 || barrierInfo.txCount != 0) {
+        funcBuilder.createVerifyBarrierArriveCall(
+            b, barrier, barrierInfo.count, combinedPred, op, recipientCTAs,
+            barrierInfo.txCount);
+        funcBuilder.createUpdateBarrierStateCall(
+            b, barrier, barrierInfo.count, combinedPred, op, recipientCTAs,
+            barrierInfo.txCount);
       }
     }
     if (opInfo->implicitCommit) {
@@ -551,31 +739,41 @@ private:
   void addWriteChecks(ImplicitLocOpBuilder &b,
                       tti::FunctionBuilder &funcBuilder, Operation *op,
                       Value buf, uint32_t length, Value pred, MemType memType,
-                      int thread, const std::string &operandName) {
-    funcBuilder.createVerifyWriteVisibilityCall(b, buf, length, thread,
-                                                operandName, pred, memType, op);
+                      int thread, const std::string &operandName,
+                      Value recipientCTAs,
+                      CommitKind::Kind opCommitKind = CommitKind::None) {
+    funcBuilder.createVerifyWriteVisibilityCall(
+        b, buf, length, thread, operandName, pred, memType, op, recipientCTAs);
     // commit-num-based synchronization is only supported for shared memory
     if (memType == MemType::SHARED_MEM) {
-      funcBuilder.createCheckOutstandingCommitsCall(
-          b, buf, length, getBaseThread(thread), "async_copy_global_to_shared",
-          pred, memType, CommitKind::AsyncCp, op);
+      for (const auto &commitKindDesc :
+           hooks->getOutstandingWriteCommitKinds()) {
+        bool excludeSelf = (opCommitKind == commitKindDesc.kind &&
+                            hooks->isOrderedCommitKind(opCommitKind));
+        funcBuilder.createCheckOutstandingCommitsCall(
+            b, buf, length, getBaseThread(thread), commitKindDesc.operationDesc,
+            pred, memType, commitKindDesc.kind, op, recipientCTAs, excludeSelf);
+      }
     }
   }
 
   void addReadChecks(ImplicitLocOpBuilder &b, tti::FunctionBuilder &funcBuilder,
                      Operation *op, Value buf, uint32_t length, Value pred,
                      MemType memType, int thread,
-                     const std::string &operandName) {
-    funcBuilder.createVerifyReadVisibilityCall(b, buf, length, thread,
-                                               operandName, pred, memType, op);
+                     const std::string &operandName, Value recipientCTAs,
+                     CommitKind::Kind opCommitKind = CommitKind::None) {
+    funcBuilder.createVerifyReadVisibilityCall(
+        b, buf, length, thread, operandName, pred, memType, op, recipientCTAs);
     // commit-num-based synchronization is only supported for shared memory
     if (memType == MemType::SHARED_MEM) {
-      funcBuilder.createCheckOutstandingCommitsCall(
-          b, buf, length, getBaseThread(thread), "warpgroup_mma operand read",
-          pred, memType, CommitKind::Wgmma, op);
-      funcBuilder.createCheckOutstandingCommitsCall(
-          b, buf, length, getBaseThread(thread), "async_copy_shared_to_global",
-          pred, memType, CommitKind::TmaStore, op);
+      for (const auto &commitKindDesc :
+           hooks->getOutstandingReadCommitKinds()) {
+        bool excludeSelf = (opCommitKind == commitKindDesc.kind &&
+                            hooks->isOrderedCommitKind(opCommitKind));
+        funcBuilder.createCheckOutstandingCommitsCall(
+            b, buf, length, getBaseThread(thread), commitKindDesc.operationDesc,
+            pred, memType, commitKindDesc.kind, op, recipientCTAs, excludeSelf);
+      }
     }
   }
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -205,6 +205,8 @@ LogicalResult InitBarrierOp::verify() {
   return success();
 }
 
+TypedValue<MemDescType> InitBarrierOp::getBarrier() { return getAlloc(); }
+
 // -- InvalBarrierOp --
 LogicalResult InvalBarrierOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))
@@ -253,6 +255,8 @@ LogicalResult ClusterBarrierOp::verify() {
   return success();
 }
 
+TypedValue<MemDescType> InvalBarrierOp::getBarrier() { return getAlloc(); }
+
 // -- BarrierExpectOp --
 LogicalResult BarrierExpectOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))
@@ -269,6 +273,7 @@ void BarrierExpectOp::setPredicateOperand(Value pred) {
 Type BarrierExpectOp::getPredicateOperandTypeLike() {
   return getPred().getType();
 }
+TypedValue<MemDescType> BarrierExpectOp::getBarrier() { return getAlloc(); }
 
 // -- WaitBarrierOp --
 LogicalResult WaitBarrierOp::verify() {
@@ -294,6 +299,7 @@ void WaitBarrierOp::setPredicateOperand(Value pred) {
 Type WaitBarrierOp::getPredicateOperandTypeLike() {
   return IntegerType::get(getContext(), 1);
 }
+TypedValue<MemDescType> WaitBarrierOp::getBarrier() { return getAlloc(); }
 
 // -- ArriveBarrierOp --
 LogicalResult ArriveBarrierOp::verify() {
@@ -328,6 +334,7 @@ Type ArriveBarrierOp::getPredicateOperandTypeLike() {
   return IntegerType::get(getContext(), 1);
 }
 
+TypedValue<MemDescType> ArriveBarrierOp::getBarrier() { return getAlloc(); }
 // -- VoteBallotSyncOp --
 LogicalResult VoteBallotSyncOp::verify() {
   Type predType = getPred().getType();
@@ -830,15 +837,19 @@ static LogicalResult verifyMMADType(Operation *op, Type a, Type b, Type d) {
 
 static LogicalResult verifyCompletionBarrierLayout(Operation *op,
                                                    Value barrier) {
+  auto ctx = op->getContext();
+  auto numCTAs = gpu::lookupNumCTAs(op);
   auto barrierTy = cast<MemDescType>(barrier.getType());
-  auto expectedCGALayout =
-      CGAEncodingAttr::get1DLayout(op->getContext(), gpu::lookupNumCTAs(op));
   auto actualCGALayout = getCGALayout(barrierTy.getEncoding());
-  if (actualCGALayout != expectedCGALayout)
-    return op->emitOpError("completion barrier cga_layout must be ")
-           << formatCGALayout(expectedCGALayout) << ", got "
-           << formatCGALayout(actualCGALayout);
-  return success();
+  auto kBlock = StringAttr::get(ctx, "block");
+  auto dim = standardOutDimNames(ctx, /*rank=*/1)[0];
+  auto localLayout =
+      CGAEncodingAttr::get(ctx, LinearLayout::zeros1D(numCTAs, kBlock, dim));
+  if (actualCGALayout == localLayout)
+    return success();
+  return verifyBarrierCGALayout(op, barrier,
+                                CGAEncodingAttr::get1DLayout(ctx, numCTAs),
+                                "completion barrier");
 }
 
 LogicalResult TCGen5MMAOp::verify() {
@@ -852,10 +863,11 @@ LogicalResult TCGen5MMAOp::verify() {
     // models only the rank-1 `Nxi64` mbarrier form introduced upstream by
     // #9474) does not understand. Only verify the rank-1 form; leave beta's
     // higher-rank barriers unchecked here as they were before #9474.
-    if (barrierTy.getRank() == 1 && failed(verifyBarrierType(*this, barrierTy)))
-      return failure();
-    if (failed(verifyCompletionBarrierLayout(getOperation(), barrier)))
-      return failure();
+    if (barrierTy.getRank() == 1) {
+      if (failed(verifyBarrierType(*this, barrierTy)) ||
+          failed(verifyCompletionBarrierLayout(getOperation(), barrier)))
+        return failure();
+    }
   }
   Type atype = getA().getType().getElementType();
   Type btype = getB().getType().getElementType();
@@ -1163,10 +1175,11 @@ LogicalResult TCGen5MMAScaledOp::verify() {
   }
   for (auto barrier : getBarriers()) {
     auto barrierTy = cast<MemDescType>(barrier.getType());
-    if (failed(verifyBarrierType(*this, barrierTy)))
-      return failure();
-    if (failed(verifyCompletionBarrierLayout(getOperation(), barrier)))
-      return failure();
+    if (barrierTy.getRank() == 1) {
+      if (failed(verifyBarrierType(*this, barrierTy)) ||
+          failed(verifyCompletionBarrierLayout(getOperation(), barrier)))
+        return failure();
+    }
   }
   Type atype =
       getScaledMMAOperandType(getA().getType().getElementType(), getAType());
@@ -2061,8 +2074,43 @@ LogicalResult CLCTryCancelOp::verify() {
   return verifyCompletionBarrierLayout(getOperation(), getMbarrier());
 }
 
+TypedValue<MemDescType> CLCTryCancelOp::getBarrier() { return getMbarrier(); }
+
 LogicalResult CLCLoadResultOp::verify() {
   return verifyCLCResultMemdesc(getLoc(), getSrc().getType());
+}
+
+SmallVector<uint16_t> getCTABroadcastMasks(bool twoCTAs, ValueRange descs) {
+  SmallVector<uint16_t> broadcastMasks;
+  if (!descs.empty()) {
+    auto kBlock = StringAttr::get(descs.front().getContext(), "block");
+    for (Value desc : descs) {
+      auto descTy = cast<gpu::MemDescType>(desc.getType());
+      uint16_t broadcastBits =
+          toLinearLayout(descTy).getFreeVariableMasks().lookup(kBlock);
+      if (twoCTAs)
+        broadcastBits |= 1;
+      if (broadcastBits)
+        broadcastMasks.push_back(broadcastBits);
+    }
+  } else if (twoCTAs) {
+    broadcastMasks.push_back(1);
+  }
+  return broadcastMasks;
+}
+
+TMAMulticastMaskEncoding getTMAMulticastMaskEncoding(int numCTAs,
+                                                     uint16_t broadcastBits) {
+  // Compute the map that goes from cta_id to lead_cta_id (fixedBits)
+  // and the pattern that goes from cta_id to the multicast group (pattern).
+  int blockBits = llvm::Log2_32(numCTAs);
+  uint32_t fixedBits = (~broadcastBits) & (numCTAs - 1);
+  uint32_t pattern = 1;
+  for (int i = 0; i < blockBits; ++i) {
+    if ((fixedBits & (1u << i)) == 0)
+      pattern |= (pattern << (1u << i));
+  }
+  return {fixedBits, pattern};
 }
 
 } // namespace nvidia_gpu

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -8,13 +8,27 @@ namespace ttng = mlir::triton::nvidia_gpu;
 namespace tti = mlir::triton::instrument;
 
 using tti::BarrierInitInfo;
+using tti::BarrierInvalidateInfo;
 using tti::BarrierWaitInfo;
+using tti::CommitKindDesc;
 using tti::MemEffectsOpInfo;
 using tti::WaitOpInfo;
 
 namespace mlir {
 namespace triton {
 namespace nvidia_gpu {
+
+namespace {
+
+Value getLeaderCTAPredicate(ImplicitLocOpBuilder &b, uint32_t broadcastMask) {
+  Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
+  Value ctaIdInGroup = arith::AndIOp::create(
+      b, ctaId, arith::ConstantIntOp::create(b, broadcastMask, 32));
+  return arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaIdInGroup,
+                               arith::ConstantIntOp::create(b, 0, 32));
+}
+
+} // namespace
 
 class NVIDIAConSanHooks : public tti::ConSanTargetHooks {
 public:
@@ -24,22 +38,31 @@ public:
                ttng::AsyncTMAScatterOp>(op);
   }
 
-  bool isPostInstrumentedOp(Operation *op) const override {
-    return isa<ttng::WaitBarrierOp>(op);
-  }
-
   std::optional<BarrierInitInfo>
   getBarrierInitInfo(Operation *op) const override {
-    if (auto initOp = dyn_cast<ttng::InitBarrierOp>(op))
-      return BarrierInitInfo{initOp.getAlloc(), initOp.getCount()};
+    if (auto initOp = dyn_cast<ttng::InitBarrierOp>(op)) {
+      auto barrierTy = initOp.getAlloc().getType();
+      // Match mbarrier.init lowering: the leader barrier accounts for every CTA
+      // that routes arrivals to it.
+      uint32_t count = initOp.getCount() * ttg::lookupNumCTAs(op) /
+                       barrierTy.getNumElements();
+      return BarrierInitInfo{initOp.getAlloc(), count};
+    }
     return std::nullopt;
   }
 
   std::optional<BarrierWaitInfo>
   getBarrierWaitInfo(Operation *op) const override {
     if (auto waitOp = dyn_cast<ttng::WaitBarrierOp>(op))
-      return BarrierWaitInfo{waitOp.getAlloc(), waitOp.getPhase(),
+      return BarrierWaitInfo{waitOp.getBarrier(), waitOp.getPhase(),
                              waitOp.getPred()};
+    return std::nullopt;
+  }
+
+  std::optional<BarrierInvalidateInfo>
+  getBarrierInvalidateInfo(Operation *op) const override {
+    if (auto invalOp = dyn_cast<ttng::InvalBarrierOp>(op))
+      return BarrierInvalidateInfo{invalOp.getAlloc()};
     return std::nullopt;
   }
 
@@ -47,8 +70,44 @@ public:
     if (auto tmaStoreWaitOp = dyn_cast<ttng::TMAStoreWaitOp>(op))
       return WaitOpInfo{tti::CommitKind::TmaStore,
                         static_cast<int>(tmaStoreWaitOp.getPendings()),
-                        /*transferWrites=*/false};
+                        /*transferWrites=*/false, /*transferReads=*/true};
     return std::nullopt;
+  }
+
+  Value getIssuerCTAPred(ImplicitLocOpBuilder &b,
+                         Operation *op) const override {
+    // mask = 0 means no CTA predication.
+    uint32_t mask = 0;
+    auto getBarrierMask = [&](Value barrier) {
+      auto barrierTy = cast<ttg::MemDescType>(barrier.getType());
+      auto kBlock = StringAttr::get(op->getContext(), "block");
+      return toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock);
+    };
+    if (auto initOp = dyn_cast<ttng::InitBarrierOp>(op))
+      mask = getBarrierMask(initOp.getAlloc());
+    if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op))
+      mask = getBarrierMask(expectOp.getAlloc());
+    if (auto waitOp = dyn_cast<ttng::WaitBarrierOp>(op))
+      mask = getBarrierMask(waitOp.getAlloc());
+    if (auto invalOp = dyn_cast<ttng::InvalBarrierOp>(op))
+      mask = getBarrierMask(invalOp.getAlloc());
+    if (auto copyOp = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+      if (copyOp.getMulticast()) {
+        auto dstTy = cast<ttg::MemDescType>(copyOp.getResult().getType());
+        auto kBlock = StringAttr::get(op->getContext(), "block");
+        mask = toLinearLayout(dstTy).getFreeVariableMasks().lookup(kBlock);
+      }
+    }
+
+    // In 2CTA tcgen05 and tmem_copy, only the even CTA in each (i, i^1) pair
+    // issues the op.
+    if (isa<ttng::TCGen5MMAOp, ttng::TCGen5MMAScaledOp, ttng::TCGen5CommitOp,
+            ttng::TMEMCopyOp>(op) &&
+        ttng::getModuleTwoCTAs(op))
+      mask = 0x1;
+    if (!mask)
+      return nullptr;
+    return getLeaderCTAPredicate(b, mask);
   }
 
   std::optional<MemEffectsOpInfo>
@@ -57,18 +116,16 @@ public:
     if (info)
       return info;
     if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op)) {
-      // TODO: For async TMA barriers, the barrier "arrive" corresponding to the
-      // completion mechanism is modeled by barrier_expect. Individual
-      // async_tma_copy ops should not decrement the barrier state, otherwise
-      // multiple copies using the same barrier would incorrectly advance the
-      // phase multiple times. This should be improved bu tracking the barrier
-      // expected byte count, and "arriving" the barrier when the expected byte
-      // count is reached.
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
       info->pred = expectOp.getPred();
-      info->barriers.push_back({expectOp.getAlloc(), nullptr, /*count=*/1,
-                                MemEffectsOpInfo::BarrierTrackingMode::None});
+      auto barrierTy = expectOp.getAlloc().getType();
+      int txCount = expectOp.getSize() * ttg::lookupNumCTAs(op) /
+                    barrierTy.getNumElements();
+      info->barriers.push_back({expectOp.getBarrier(), nullptr,
+                                /*count=*/1,
+                                MemEffectsOpInfo::BarrierTrackingMode::Frontier,
+                                /*txCount=*/txCount});
     }
     if (auto loadOp = dyn_cast<ttng::TMEMLoadOp>(op)) {
       info.emplace();
@@ -90,6 +147,14 @@ public:
                                           allocOp.getResult());
       }
     }
+    if (auto copyOp = dyn_cast<ttng::TMEMCopyOp>(op)) {
+      info.emplace();
+      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
+                                        copyOp.getSrc(), "Src");
+      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
+                                        copyOp.getDst(), "Dst");
+    }
     if (auto mmav5Op = dyn_cast<ttng::MMAv5OpInterface>(op)) {
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
@@ -105,6 +170,12 @@ public:
                                         mmav5Op.getB(), "B");
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
                                         mmav5Op.getAccumulator(), "Acc");
+      if (auto mmaScaledOp = dyn_cast<ttng::TCGen5MMAScaledOp>(op)) {
+        info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
+                                          mmaScaledOp.getAScale(), "AScale");
+        info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
+                                          mmaScaledOp.getBScale(), "BScale");
+      }
     }
     if (auto commitOp = dyn_cast<ttng::TCGen5CommitOp>(op)) {
       info.emplace();
@@ -135,9 +206,23 @@ public:
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
       info->pred = copyOp.getPred();
+      int txCount = tti::getMemDescLength(copyOp.getResult());
+      if (copyOp.getMulticast()) {
+        auto resultTy = copyOp.getResult().getType();
+        auto barrierTy = copyOp.getBarrier().getType();
+        auto kBlock = StringAttr::get(op->getContext(), "block");
+        uint16_t resultMask =
+            toLinearLayout(resultTy).getFreeVariableMasks().lookup(kBlock);
+        uint16_t barrierMask =
+            toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock);
+        uint16_t collapsedMask = resultMask & barrierMask;
+        for (; collapsedMask; collapsedMask &= collapsedMask - 1)
+          txCount *= 2;
+      }
       info->barriers.push_back(
           {copyOp.getBarrier(), nullptr, /*count=*/0,
-           MemEffectsOpInfo::BarrierTrackingMode::EffectWrites});
+           MemEffectsOpInfo::BarrierTrackingMode::EffectWrites,
+           /*txCount=*/-txCount});
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
                                         copyOp.getResult());
     }
@@ -155,7 +240,8 @@ public:
       info->pred = gatherOp.getPred();
       info->barriers.push_back(
           {gatherOp.getBarrier(), nullptr, /*count=*/0,
-           MemEffectsOpInfo::BarrierTrackingMode::EffectWrites});
+           MemEffectsOpInfo::BarrierTrackingMode::EffectWrites,
+           /*txCount=*/-(int)tti::getMemDescLength(gatherOp.getResult())});
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
                                         gatherOp.getResult());
     }
@@ -170,9 +256,14 @@ public:
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
       info->pred = arriveOp.getPred();
       info->barriers.push_back(
-          {arriveOp.getAlloc(), nullptr, (int)arriveOp.getCount()});
+          {arriveOp.getBarrier(), nullptr, (int)arriveOp.getCount()});
     }
     return info;
+  }
+
+  SmallVector<CommitKindDesc> getOutstandingReadCommitKinds() const override {
+    return {{tti::CommitKind::Wgmma, "warpgroup_mma operand read"},
+            {tti::CommitKind::TmaStore, "async_copy_shared_to_global"}};
   }
 
   SmallVector<tti::CommitKind::Kind>

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MMALowering.cpp
@@ -220,13 +220,14 @@ public:
       if (!pred) {
         pred = arith::ConstantIntOp::create(rewriter, op.getLoc(), true, 1);
       }
-      if (!moveDefiningOpsBefore(commit.getBarrier(), op) ||
+      Value barrier = commit.getBarrier();
+      if (!moveDefiningOpsBefore(barrier, op) ||
           !moveDefiningOpsBefore(pred, op)) {
         // Give up merging a commit if its defining ops cannot be moved above
         // the mma op.
         break;
       }
-      op.addCompletionBarrier(commit.getBarrier(), pred);
+      op.addCompletionBarrier(barrier, pred);
       rewriter.eraseOp(commit);
     }
     return success();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -70,13 +70,8 @@ bool isAsyncProxyReadSource(Operation *op, Value value) {
   if (auto warpGroupDotOp = dyn_cast<triton::nvidia_gpu::WarpGroupDotOp>(op)) {
     return value == warpGroupDotOp.getA() || value == warpGroupDotOp.getB();
   }
-  if (auto tcGen5MMAOp = dyn_cast<triton::nvidia_gpu::TCGen5MMAOp>(op)) {
-    return value == tcGen5MMAOp.getA() || value == tcGen5MMAOp.getB();
-  }
-  if (auto tcGen5MMAScaledOp =
-          dyn_cast<triton::nvidia_gpu::TCGen5MMAScaledOp>(op)) {
-    return value == tcGen5MMAScaledOp.getA() ||
-           value == tcGen5MMAScaledOp.getB();
+  if (auto mma = dyn_cast<triton::nvidia_gpu::MMAv5OpInterface>(op)) {
+    return value == mma.getA() || value == mma.getB();
   }
   if (auto tmemCopyOp = dyn_cast<triton::nvidia_gpu::TMEMCopyOp>(op)) {
     return value == tmemCopyOp.getSrc();

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -30,19 +30,31 @@ def assert_expected_cuda_failure(exc):
 
 
 @gluon.constexpr_function
-def tcgen05_cga_layout(num_ctas, operand):
+def mma_cga_layout(num_ctas, op_idx, two_cta=False):
     num_ctas = getattr(num_ctas, "value", num_ctas)
-    if num_ctas == 1:
-        return []
-    if num_ctas == 2:
-        return [[1, 0]] if operand != 1 else [[0, 0]]
-    if num_ctas == 4:
-        if operand == 0:
-            return [[1, 0], [0, 0]]
-        if operand == 1:
-            return [[0, 0], [1, 0]]
-        return [[1, 0], [0, 1]]
-    raise AssertionError(f"Unsupported num_ctas={num_ctas}")
+    op_idx = getattr(op_idx, "value", op_idx)
+    two_cta = getattr(two_cta, "value", two_cta)
+    assert op_idx in (0, 1, 2)
+    # For now, but the code above is generic really
+    assert num_ctas <= 4
+    log2_num_ctas = num_ctas.bit_length() - 1
+    cga_layout = [[1, 0], [0, 1]][:log2_num_ctas]
+    if op_idx == 2 or not cga_layout:
+        return tuple(tuple(b) for b in cga_layout)
+
+    # 2CTA performs an outer product so bases are [1, 0] and [0, 1].
+    assert cga_layout[0] == [1, 0]
+    first = (1, 0) if op_idx == 0 else ((0, 1) if two_cta else (0, 0))
+    result = [first]
+    # Broadcast along K (the reduction dimension). We multiply by 2 for
+    # op_idx == 1, as we have added the (0, 1) basis.
+    for b in cga_layout[1:]:
+        if op_idx == 0:
+            result.append((b[0], 0))
+        else:
+            mul = 2 if two_cta else 1
+            result.append((0, mul * b[1]))
+    return tuple(result)
 
 
 @gluon.constexpr_function
@@ -64,6 +76,14 @@ def default_cga_layout(num_ctas, rank, dim=0):
         return []
     assert 0 <= dim < rank
     return [[0] * dim + [1 << i] + [0] * (rank - dim - 1) for i in range(num_ctas.bit_length() - 1)]
+
+
+@gluon.constexpr_function
+def multicast_cga_layout(num_ctas, rank):
+    num_ctas = getattr(num_ctas, "value", num_ctas)
+    if num_ctas == 1:
+        return []
+    return [[0] * rank for _ in range(num_ctas.bit_length() - 1)]
 
 
 # Use the same block size for all tests
@@ -169,10 +189,13 @@ def test_consan_initializes_allocations_with_nan(MEMORY_KIND, device, fresh_knob
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
-def test_async_tma_kernel(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
+@pytest.mark.parametrize("TWO_CTA_BARRIER", [False, True])
+def test_async_tma_kernel(FAILURE, TWO_CTA_BARRIER, device, run_wrapper, monkeypatch, num_ctas):
+    if TWO_CTA_BARRIER and num_ctas == 1:
+        pytest.skip("Need at least 2 CTAs for a two-CTA barrier")
     if run_wrapper:
-        result = run_in_process(test_async_tma_kernel, (FAILURE, device, False, monkeypatch, num_ctas))
-        if FAILURE:
+        result = run_in_process(test_async_tma_kernel, (FAILURE, TWO_CTA_BARRIER, device, False, monkeypatch, num_ctas))
+        if FAILURE or TWO_CTA_BARRIER:
             assert_expected_cuda_failure(result.exc)
             assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
         else:
@@ -185,13 +208,13 @@ def test_async_tma_kernel(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
     knobs.refresh_knobs()
 
     @gluon.jit
-    def kernel(input_desc, out, FAILURE: ttgl.constexpr):
+    def kernel(input_desc, out, FAILURE: ttgl.constexpr, TWO_CTA_BARRIER: ttgl.constexpr):
         block_m: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
         cga_layout: ttgl.constexpr = default_cga_layout(ttgl.num_ctas(), 2)
         blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
                                                             warps_per_cta=[4, 1], order=[0, 1], cga_layout=cga_layout)
         smem = ttgl.allocate_shared_memory(ttgl.float16, [block_m, XBLOCK], input_desc.layout)
-        bar = mbarrier.allocate_mbarrier()
+        bar = mbarrier.allocate_mbarrier(two_ctas=TWO_CTA_BARRIER)
         mbarrier.init(bar, count=1)
         mbarrier.expect(bar, input_desc.nbytes_per_cta)
         tma.async_copy_global_to_shared(input_desc, [0, 0], bar, smem)
@@ -211,7 +234,192 @@ def test_async_tma_kernel(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
     shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
                                            cga_layout=default_cga_layout(num_ctas, 2))
     input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [block_m, XBLOCK.value], shared_layout)
-    kernel[(1, )](input_desc, output, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
+    kernel[(1, )](input_desc, output, FAILURE=FAILURE, TWO_CTA_BARRIER=TWO_CTA_BARRIER, num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("FAILURE", [True, False])
+@pytest.mark.parametrize("TWO_CTA_BARRIER", [False, True])
+def test_async_tma_multicast_kernel(FAILURE, TWO_CTA_BARRIER, device, run_wrapper, monkeypatch, num_ctas):
+    if num_ctas == 1:
+        pytest.skip("Need at least 2 CTAs for multicast in this test")
+    if run_wrapper:
+        result = run_in_process(test_async_tma_multicast_kernel,
+                                (FAILURE, TWO_CTA_BARRIER, device, False, monkeypatch, num_ctas))
+        if FAILURE or TWO_CTA_BARRIER:
+            assert_expected_cuda_failure(result.exc)
+            assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(input_desc, out, FAILURE: ttgl.constexpr, TWO_CTA_BARRIER: ttgl.constexpr):
+        cga_layout: ttgl.constexpr = multicast_cga_layout(ttgl.num_ctas(), 2)
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[0, 1], cga_layout=cga_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], input_desc.layout)
+        bar = mbarrier.allocate_mbarrier(two_ctas=TWO_CTA_BARRIER)
+        mbarrier.init(bar, count=1)
+        mbarrier.expect(bar, input_desc.nbytes_per_cta)
+        tma.async_copy_global_to_shared(input_desc, [0, 0], bar, smem, multicast=True)
+        mbarrier.wait(bar, 0, pred=(not FAILURE), deps=[smem])
+        val = smem.load(blocked_layout)
+        mbarrier.wait(bar, 0, pred=FAILURE, deps=[smem])
+        mbarrier.invalidate(bar)
+
+        out_m = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(1, blocked_layout))[:, None]
+        out_n = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(0, blocked_layout))[None, :]
+        out_ptr = out + out_m * XBLOCK + out_n
+        ttgl.store(out_ptr, val)
+
+    input = torch.randn((XBLOCK.value, XBLOCK.value), device=device, dtype=torch.float16)
+    output = torch.empty((XBLOCK.value, XBLOCK.value), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
+                                           cga_layout=multicast_cga_layout(num_ctas, 2))
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK.value, XBLOCK.value], shared_layout)
+    kernel[(1, )](input_desc, output, FAILURE=FAILURE, TWO_CTA_BARRIER=TWO_CTA_BARRIER, num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("TWO_CTA_BARRIER", [False, True])
+def test_async_tma_multicast_kernel_two_cta_barrier(TWO_CTA_BARRIER, device, run_wrapper, monkeypatch, num_ctas):
+    if num_ctas != 2:
+        pytest.skip("This test covers a single 2-CTA multicast group")
+    if run_wrapper:
+        result = run_in_process(test_async_tma_multicast_kernel_two_cta_barrier,
+                                (TWO_CTA_BARRIER, device, False, monkeypatch, num_ctas))
+        if TWO_CTA_BARRIER:
+            assert_expected_cuda_failure(result.exc)
+            assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(input_desc, out, TWO_CTA_BARRIER: ttgl.constexpr):
+        cga_layout: ttgl.constexpr = multicast_cga_layout(ttgl.num_ctas(), 2)
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[0, 1], cga_layout=cga_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], input_desc.layout)
+        bar = mbarrier.allocate_mbarrier(two_ctas=TWO_CTA_BARRIER)
+        mbarrier.init(bar, count=1)
+        mbarrier.expect(bar, input_desc.nbytes_per_cta)
+        tma.async_copy_global_to_shared(input_desc, [0, 0], bar, smem, multicast=True)
+        mbarrier.wait(bar, 0, deps=[smem])
+        val = smem.load(blocked_layout)
+        mbarrier.invalidate(bar)
+
+        out_m = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(1, blocked_layout))[:, None]
+        out_n = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(0, blocked_layout))[None, :]
+        out_ptr = out + out_m * XBLOCK + out_n
+        ttgl.store(out_ptr, val)
+
+    input = torch.randn((XBLOCK.value, XBLOCK.value), device=device, dtype=torch.float16)
+    output = torch.empty((XBLOCK.value, XBLOCK.value), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
+                                           cga_layout=multicast_cga_layout(num_ctas, 2))
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK.value, XBLOCK.value], shared_layout)
+    kernel[(1, )](input_desc, output, TWO_CTA_BARRIER=TWO_CTA_BARRIER, num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+def test_async_tma_multicast_kernel_reuse(device, run_wrapper, monkeypatch, num_ctas):
+    if num_ctas == 1:
+        pytest.skip("Need at least 2 CTAs for multicast in this test")
+    if run_wrapper:
+        result = run_in_process(test_async_tma_multicast_kernel_reuse, (device, False, monkeypatch, num_ctas))
+        assert result.exc is None
+        assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(input_desc, out):
+        cga_layout: ttgl.constexpr = multicast_cga_layout(ttgl.num_ctas(), 2)
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[0, 1], cga_layout=cga_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], input_desc.layout)
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+        for phase in ttgl.static_range(2):
+            mbarrier.expect(bar, input_desc.nbytes_per_cta)
+            ttgl.barrier(cluster=True)
+            tma.async_copy_global_to_shared(input_desc, [0, 0], bar, smem, multicast=True)
+            mbarrier.wait(bar, phase % 2, deps=[smem])
+            ttgl.barrier(cluster=True)
+        val = smem.load(blocked_layout)
+        mbarrier.invalidate(bar)
+
+        out_m = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(1, blocked_layout))[:, None]
+        out_n = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(0, blocked_layout))[None, :]
+        out_ptr = out + out_m * XBLOCK + out_n
+        ttgl.store(out_ptr, val)
+
+    input = torch.randn((XBLOCK.value, XBLOCK.value), device=device, dtype=torch.float16)
+    output = torch.empty((XBLOCK.value, XBLOCK.value), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
+                                           cga_layout=multicast_cga_layout(num_ctas, 2))
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK.value, XBLOCK.value], shared_layout)
+    kernel[(1, )](input_desc, output, num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+def test_async_tma_multicast_kernel_local_store_race(device, run_wrapper, monkeypatch, num_ctas):
+    if num_ctas == 1:
+        pytest.skip("Need at least 2 CTAs for multicast in this test")
+    if run_wrapper:
+        result = run_in_process(test_async_tma_multicast_kernel_local_store_race,
+                                (device, False, monkeypatch, num_ctas))
+        assert_expected_cuda_failure(result.exc)
+        assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(input_desc, out):
+        cga_layout: ttgl.constexpr = multicast_cga_layout(ttgl.num_ctas(), 2)
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[0, 1], cga_layout=cga_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, XBLOCK], input_desc.layout)
+
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+        mbarrier.expect(bar, input_desc.nbytes_per_cta)
+        tma.async_copy_global_to_shared(input_desc, [0, 0], bar, smem, multicast=True)
+        ttgl.barrier(cluster=True)
+        smem.store(ttgl.full([XBLOCK, XBLOCK], 1, ttgl.float16, blocked_layout))
+        mbarrier.wait(bar, 0, deps=[smem])
+        val = smem.load(blocked_layout)
+        mbarrier.invalidate(bar)
+
+        out_m = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(1, blocked_layout))[:, None]
+        out_n = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(0, blocked_layout))[None, :]
+        out_ptr = out + out_m * XBLOCK + out_n
+        ttgl.store(out_ptr, val)
+
+    input = torch.randn((XBLOCK.value, XBLOCK.value), device=device, dtype=torch.float16)
+    output = torch.empty((XBLOCK.value, XBLOCK.value), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
+                                           cga_layout=multicast_cga_layout(num_ctas, 2))
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK.value, XBLOCK.value], shared_layout)
+    kernel[(1, )](input_desc, output, num_warps=4, num_ctas=num_ctas)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
@@ -264,6 +472,49 @@ def test_async_tma_kernel_2bufs_1bar(FAILURE, device, run_wrapper, monkeypatch, 
     a_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(a, [block_m, XBLOCK.value], shared_layout)
     b_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(b, [block_m, XBLOCK.value], shared_layout)
     kernel[(1, )](a_desc, b_desc, output, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("EXPECT_DELTA", [-16, 16], ids=["under", "over"])
+def test_async_tma_expect_bytes_mismatch(EXPECT_DELTA, device, run_wrapper, monkeypatch, num_ctas):
+    if run_wrapper:
+        result = run_in_process(test_async_tma_expect_bytes_mismatch,
+                                (EXPECT_DELTA, device, False, monkeypatch, num_ctas))
+        assert_expected_cuda_failure(result.exc)
+        assert "Deadlock detected" in result.driver_stderr_output
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(input_desc, out, EXPECT_DELTA: ttgl.constexpr):
+        block_m: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
+        cga_layout: ttgl.constexpr = default_cga_layout(ttgl.num_ctas(), 2)
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[0, 1], cga_layout=cga_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [block_m, XBLOCK], input_desc.layout)
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+        mbarrier.expect(bar, input_desc.nbytes_per_cta + EXPECT_DELTA)
+        tma.async_copy_global_to_shared(input_desc, [0, 0], bar, smem)
+        mbarrier.wait(bar, 0, deps=[smem])
+        val = smem.load(blocked_layout)
+        mbarrier.invalidate(bar)
+
+        out_m = ttgl.arange(0, block_m, ttgl.SliceLayout(1, blocked_layout))[:, None]
+        out_n = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(0, blocked_layout))[None, :]
+        out_ptr = out + out_m * XBLOCK + out_n
+        ttgl.store(out_ptr, val)
+
+    block_m = XBLOCK.value * num_ctas
+    input = torch.randn((block_m, XBLOCK.value), device=device, dtype=torch.float16)
+    output = torch.empty((block_m, XBLOCK.value), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
+                                           cga_layout=default_cga_layout(num_ctas, 2))
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [block_m, XBLOCK.value], shared_layout)
+    kernel[(1, )](input_desc, output, EXPECT_DELTA=EXPECT_DELTA, num_warps=4, num_ctas=num_ctas)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
@@ -473,9 +724,13 @@ def test_tma_store(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
 @pytest.mark.parametrize("MEM_ACCESS_KIND", ["tma_cp", "local_store", "tmem_load", "tmem_store"])
-def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, device, run_wrapper, monkeypatch, num_ctas):
+@pytest.mark.parametrize("TWO_CTAS", [False, True])
+def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, TWO_CTAS, device, run_wrapper, monkeypatch, num_ctas):
+    if TWO_CTAS and num_ctas == 1:
+        pytest.skip("Need at least 2 CTAs for 2CTA mode in this test")
     if run_wrapper:
-        result = run_in_process(test_tcgen5_mma, (FAILURE, MEM_ACCESS_KIND, device, False, monkeypatch, num_ctas))
+        result = run_in_process(test_tcgen5_mma,
+                                (FAILURE, MEM_ACCESS_KIND, TWO_CTAS, device, False, monkeypatch, num_ctas))
         if FAILURE:
             assert_expected_cuda_failure(result.exc)
             if MEM_ACCESS_KIND == "tma_cp":
@@ -498,34 +753,35 @@ def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, device, run_wrapper, monkeypatch, 
     knobs.refresh_knobs()
 
     @gluon.jit
-    def kernel(input_desc, output_desc, FAILURE: ttgl.constexpr, MEM_ACCESS_KIND: ttgl.constexpr):
+    def kernel(input_desc, output_desc, FAILURE: ttgl.constexpr, MEM_ACCESS_KIND: ttgl.constexpr,
+               TWO_CTAS: ttgl.constexpr):
         block_m: ttgl.constexpr = mma_block_m(ttgl.num_ctas())
         block_n: ttgl.constexpr = mma_block_n(ttgl.num_ctas())
         acc_layout: ttgl.constexpr = blackwell.TensorMemoryLayout(
             [XBLOCK, XBLOCK],
             col_stride=1,
-            cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 2),
+            cga_layout=mma_cga_layout(ttgl.num_ctas(), 2, TWO_CTAS),
+            two_ctas=TWO_CTAS,
         )
-        smem_a_blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1,
-                                                                                    XBLOCK], threads_per_warp=[32, 1],
-                                                                   warps_per_cta=[4, 1], order=[0, 1],
-                                                                   cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 0))
+        smem_a_blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(
+            size_per_thread=[1, XBLOCK], threads_per_warp=[32, 1], warps_per_cta=[4, 1], order=[0, 1],
+            cga_layout=mma_cga_layout(ttgl.num_ctas(), 0, TWO_CTAS))
         acc_blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, XBLOCK], threads_per_warp=[32, 1],
                                                                 warps_per_cta=[4, 1], order=[0, 1],
                                                                 cga_layout=acc_layout.cga_layout)
         smemA = ttgl.allocate_shared_memory(ttgl.float16, [block_m, XBLOCK], input_desc.layout)
         smemB = ttgl.allocate_shared_memory(
             ttgl.float16,
-            [block_n, XBLOCK],
-            ttgl.NVMMASharedLayout.get_default_for([block_n, XBLOCK], ttgl.float16,
-                                                   cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 1)),
+            [XBLOCK, block_n],
+            ttgl.NVMMASharedLayout.get_default_for([XBLOCK, block_n], ttgl.float16,
+                                                   cga_layout=mma_cga_layout(ttgl.num_ctas(), 1, TWO_CTAS)),
         )
         bar = mbarrier.allocate_mbarrier(batch=2)
         acc = blackwell.allocate_tensor_memory(ttgl.float32, [block_m, block_n], acc_layout)
         mbarrier.init(bar.index(0), count=1)
         mbarrier.init(bar.index(1), count=1)
 
-        blackwell.tcgen05_mma(smemA, smemB.permute([1, 0]), acc)
+        blackwell.tcgen05_mma(smemA, smemB, acc)
         blackwell.tcgen05_commit(bar.index(0))
 
         if not FAILURE:
@@ -555,14 +811,71 @@ def test_tcgen5_mma(FAILURE, MEM_ACCESS_KIND, device, run_wrapper, monkeypatch, 
     block_n = mma_block_n(num_ctas)
     input = torch.randn((block_m, XBLOCK.value), device=device, dtype=torch.float16)
     shared_layout = ttgl.NVMMASharedLayout.get_default_for([block_m, XBLOCK.value], ttgl.float16,
-                                                           cga_layout=tcgen05_cga_layout(num_ctas, 0))
+                                                           cga_layout=mma_cga_layout(num_ctas, 0, TWO_CTAS))
     input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [block_m, XBLOCK.value], shared_layout)
     output = torch.empty((block_m, block_n), device=device, dtype=torch.float16)
     output_layout = ttgl.NVMMASharedLayout.get_default_for([block_m, block_n], ttgl.float16,
-                                                           cga_layout=tcgen05_cga_layout(num_ctas, 2))
+                                                           cga_layout=mma_cga_layout(num_ctas, 2, TWO_CTAS))
     output_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(output, [block_m, block_n], output_layout)
-    kernel[(1, )](input_desc, output_desc, FAILURE=FAILURE, MEM_ACCESS_KIND=MEM_ACCESS_KIND, num_warps=4,
-                  num_ctas=num_ctas)
+    kernel[(1, )](input_desc, output_desc, FAILURE=FAILURE, MEM_ACCESS_KIND=MEM_ACCESS_KIND, TWO_CTAS=TWO_CTAS,
+                  num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
+@pytest.mark.parametrize("FAILURE", [True, False])
+@pytest.mark.parametrize("MEM_ACCESS_KIND", ["local_store", "tmem_load"])
+def test_tcgen5_copy(FAILURE, MEM_ACCESS_KIND, device, run_wrapper, monkeypatch, num_ctas):
+    if run_wrapper:
+        result = run_in_process(test_tcgen5_copy, (FAILURE, MEM_ACCESS_KIND, device, False, monkeypatch, num_ctas))
+        if FAILURE:
+            assert_expected_cuda_failure(result.exc)
+            if MEM_ACCESS_KIND == "local_store":
+                assert "Buffer being accessed has outstanding reads" in result.driver_stderr_output
+            else:
+                assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(input, output, FAILURE: ttgl.constexpr, MEM_ACCESS_KIND: ttgl.constexpr):
+        block_m: ttgl.constexpr = XBLOCK * ttgl.num_ctas()
+        cga_layout: ttgl.constexpr = default_cga_layout(ttgl.num_ctas(), 2)
+        tmem_layout: ttgl.constexpr = blackwell.TensorMemoryLayout((128, XBLOCK), col_stride=1, cga_layout=cga_layout)
+        tmem = blackwell.allocate_tensor_memory(ttgl.int32, [block_m, XBLOCK], tmem_layout)
+        reg_layout: ttgl.constexpr = tmem.get_reg_layout()
+        offs_m = ttgl.arange(0, block_m, ttgl.SliceLayout(1, reg_layout))[:, None]
+        offs_n = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(0, reg_layout))[None, :]
+        offs = offs_m * XBLOCK + offs_n
+        val = ttgl.load(input + offs)
+        smem_layout: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=32, rank=2,
+                                                             cga_layout=cga_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.int32, [block_m, XBLOCK], smem_layout)
+        smem.store(val)
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+        blackwell.tcgen05_copy(smem, tmem)
+        blackwell.tcgen05_commit(bar)
+        if not FAILURE:
+            mbarrier.wait(bar, 0)
+        if MEM_ACCESS_KIND == "local_store":
+            smem.store(ttgl.zeros([block_m, XBLOCK], ttgl.int32, reg_layout))
+        else:
+            val = tmem.load(reg_layout)
+            ttgl.store(output + offs, val)
+        if FAILURE:
+            mbarrier.wait(bar, 0)
+        mbarrier.invalidate(bar)
+
+    input = torch.arange(XBLOCK.value * XBLOCK.value * num_ctas, device=device,
+                         dtype=torch.int32).reshape(XBLOCK.value * num_ctas, XBLOCK.value)
+    output = torch.empty_like(input)
+    kernel[(1, )](input, output, FAILURE=FAILURE, MEM_ACCESS_KIND=MEM_ACCESS_KIND, num_warps=4, num_ctas=num_ctas)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] != 9, reason="Requires hopper")
@@ -586,15 +899,15 @@ def test_warpgroup_mma(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
     def kernel(input, FAILURE: ttgl.constexpr):
         block_m: ttgl.constexpr = mma_block_m(ttgl.num_ctas())
         block_n: ttgl.constexpr = mma_block_n(ttgl.num_ctas())
-        cga_layout_a: ttgl.constexpr = tcgen05_cga_layout(ttgl.num_ctas(), 0)
-        cga_layout_b: ttgl.constexpr = tcgen05_cga_layout(ttgl.num_ctas(), 1)
-        cga_layout_c: ttgl.constexpr = tcgen05_cga_layout(ttgl.num_ctas(), 2)
+        cga_layout_a: ttgl.constexpr = mma_cga_layout(ttgl.num_ctas(), 0)
+        cga_layout_b: ttgl.constexpr = mma_cga_layout(ttgl.num_ctas(), 1)
+        cga_layout_c: ttgl.constexpr = mma_cga_layout(ttgl.num_ctas(), 2)
         smem_layout_a: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
                                                                cga_layout=cga_layout_a)
         smem_layout_b: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
                                                                cga_layout=cga_layout_b)
         smemA = ttgl.allocate_shared_memory(ttgl.float16, [block_m, XBLOCK], smem_layout_a)
-        smemB = ttgl.allocate_shared_memory(ttgl.float16, [block_n, XBLOCK], smem_layout_b)
+        smemB = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, block_n], smem_layout_b)
 
         blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, XBLOCK], threads_per_warp=[32, 1],
                                                             warps_per_cta=[4, 1], order=[0, 1], cga_layout=cga_layout_a)
@@ -602,7 +915,7 @@ def test_warpgroup_mma(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
         acc_layout: ttgl.constexpr = ttgl.NVMMADistributedLayout(version=[3, 0], warps_per_cta=[4, 1],
                                                                  instr_shape=[16, 32, 16], cga_layout=cga_layout_c)
         acc = ttgl.zeros([block_m, block_n], ttgl.float16, acc_layout)
-        acc = hopper.warpgroup_mma(smemA, smemB.permute([1, 0]), acc, is_async=True)
+        acc = hopper.warpgroup_mma(smemA, smemB, acc, is_async=True)
         if FAILURE:
             smemA.store(ttgl.full([block_m, XBLOCK], 42, ttgl.float16, blocked_layout))
         hopper.warpgroup_mma_wait(num_outstanding=0, deps=[acc])
@@ -633,15 +946,15 @@ def test_warpgroup_mma2(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
     def kernel(input, FAILURE: ttgl.constexpr):
         block_m: ttgl.constexpr = mma_block_m(ttgl.num_ctas())
         block_n: ttgl.constexpr = mma_block_n(ttgl.num_ctas())
-        cga_layout_a: ttgl.constexpr = tcgen05_cga_layout(ttgl.num_ctas(), 0)
-        cga_layout_b: ttgl.constexpr = tcgen05_cga_layout(ttgl.num_ctas(), 1)
-        cga_layout_c: ttgl.constexpr = tcgen05_cga_layout(ttgl.num_ctas(), 2)
+        cga_layout_a: ttgl.constexpr = mma_cga_layout(ttgl.num_ctas(), 0)
+        cga_layout_b: ttgl.constexpr = mma_cga_layout(ttgl.num_ctas(), 1)
+        cga_layout_c: ttgl.constexpr = mma_cga_layout(ttgl.num_ctas(), 2)
         smem_layout_a: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
                                                                cga_layout=cga_layout_a)
         smem_layout_b: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
                                                                cga_layout=cga_layout_b)
         smemA = ttgl.allocate_shared_memory(ttgl.float16, [block_m, XBLOCK], smem_layout_a)
-        smemB = ttgl.allocate_shared_memory(ttgl.float16, [block_n, XBLOCK], smem_layout_b)
+        smemB = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK, block_n], smem_layout_b)
 
         blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, XBLOCK], threads_per_warp=[32, 1],
                                                             warps_per_cta=[4, 1], order=[0, 1], cga_layout=cga_layout_a)
@@ -649,8 +962,8 @@ def test_warpgroup_mma2(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
         acc_layout: ttgl.constexpr = ttgl.NVMMADistributedLayout(version=[3, 0], warps_per_cta=[4, 1],
                                                                  instr_shape=[16, 32, 16], cga_layout=cga_layout_c)
         acc = ttgl.zeros([block_m, block_n], ttgl.float16, acc_layout)
-        acc = hopper.warpgroup_mma(smemA, smemB.permute([1, 0]), acc, is_async=True)
-        acc = hopper.warpgroup_mma(smemA, smemB.permute([1, 0]), acc, is_async=True)
+        acc = hopper.warpgroup_mma(smemA, smemB, acc, is_async=True)
+        acc = hopper.warpgroup_mma(smemA, smemB, acc, is_async=True)
         hopper.warpgroup_mma_wait(num_outstanding=1, deps=[acc])
         if FAILURE:
             smemA.store(ttgl.full([block_m, XBLOCK], 42, ttgl.float16, blocked_layout))
@@ -687,7 +1000,7 @@ def test_tcgen5_mma_multibar(BUF_IDX, BAR_IDX, device, run_wrapper, monkeypatch,
         acc_layout: ttgl.constexpr = blackwell.TensorMemoryLayout(
             [XBLOCK, XBLOCK],
             col_stride=1,
-            cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 2),
+            cga_layout=mma_cga_layout(ttgl.num_ctas(), 2),
         )
         acc_blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, XBLOCK], threads_per_warp=[32, 1],
                                                                 warps_per_cta=[4, 1], order=[0, 1],
@@ -695,19 +1008,18 @@ def test_tcgen5_mma_multibar(BUF_IDX, BAR_IDX, device, run_wrapper, monkeypatch,
         smemA = ttgl.allocate_shared_memory(ttgl.float16, [block_m, XBLOCK], input_desc.layout)
         smemB = ttgl.allocate_shared_memory(
             ttgl.float16,
-            [block_n, XBLOCK],
-            ttgl.NVMMASharedLayout.get_default_for([block_n, XBLOCK], ttgl.float16,
-                                                   cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 1)),
+            [XBLOCK, block_n],
+            ttgl.NVMMASharedLayout.get_default_for([XBLOCK, block_n], ttgl.float16,
+                                                   cga_layout=mma_cga_layout(ttgl.num_ctas(), 1)),
         )
         bar = mbarrier.allocate_mbarrier(batch=4)
         acc = blackwell.allocate_tensor_memory(ttgl.float32, [2, block_m, block_n], acc_layout)
         for i in range(4):
             mbarrier.init(bar.index(i), count=1)
 
-        blackwell.tcgen05_mma(smemA, smemB.permute([1, 0]), acc.index(0), mbarriers=[bar.index(0),
-                                                                                     bar.index(1)],
+        blackwell.tcgen05_mma(smemA, smemB, acc.index(0), mbarriers=[bar.index(0), bar.index(1)],
                               mbarrier_preds=[False, True])
-        blackwell.tcgen05_mma(smemA, smemB.permute([1, 0]), acc.index(1), mbarriers=[bar.index(2)])
+        blackwell.tcgen05_mma(smemA, smemB, acc.index(1), mbarriers=[bar.index(2)])
         blackwell.tcgen05_commit(bar.index(3))
 
         mbarrier.wait(bar.index(BAR_IDX), 0)
@@ -721,7 +1033,7 @@ def test_tcgen5_mma_multibar(BUF_IDX, BAR_IDX, device, run_wrapper, monkeypatch,
     block_m = mma_block_m(num_ctas)
     input = torch.randn((block_m, XBLOCK.value), device=device, dtype=torch.float16)
     shared_layout = ttgl.NVMMASharedLayout.get_default_for([block_m, XBLOCK.value], ttgl.float16,
-                                                           cga_layout=tcgen05_cga_layout(num_ctas, 0))
+                                                           cga_layout=mma_cga_layout(num_ctas, 0))
     input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [block_m, XBLOCK.value], shared_layout)
     kernel[(1, )](input_desc, BUF_IDX, BAR_IDX, num_warps=4, num_ctas=num_ctas)
 
@@ -756,17 +1068,17 @@ def test_multibuffered_loop(FAILURE, device, run_wrapper, monkeypatch, num_ctas)
         block_n: ttgl.constexpr = mma_block_n(ttgl.num_ctas())
 
         acc_layout: ttgl.constexpr = blackwell.TensorMemoryLayout([XBLOCK, XBLOCK], col_stride=1,
-                                                                  cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 2))
+                                                                  cga_layout=mma_cga_layout(ttgl.num_ctas(), 2))
         zero_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, XBLOCK], threads_per_warp=[32, 1],
                                                          warps_per_cta=[4, 1], order=[0, 1],
-                                                         cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 2))
+                                                         cga_layout=mma_cga_layout(ttgl.num_ctas(), 2))
         zero = ttgl.zeros([block_m, block_n], ttgl.float32, zero_layout)
-        b_smem_layout: ttgl.constexpr = ttgl.NVMMASharedLayout.get_default_for([block_n, XBLOCK], ttgl.float16,
-                                                                               cga_layout=tcgen05_cga_layout(
+        b_smem_layout: ttgl.constexpr = ttgl.NVMMASharedLayout.get_default_for([XBLOCK, block_n], ttgl.float16,
+                                                                               cga_layout=mma_cga_layout(
                                                                                    ttgl.num_ctas(), 1))
 
         smemA = ttgl.allocate_shared_memory(ttgl.float16, [num_buffers, block_m, XBLOCK], a_desc.layout)
-        smemB = ttgl.allocate_shared_memory(ttgl.float16, [num_buffers, block_n, XBLOCK], b_smem_layout)
+        smemB = ttgl.allocate_shared_memory(ttgl.float16, [num_buffers, XBLOCK, block_n], b_smem_layout)
         barLoadA = mbarrier.allocate_mbarrier(batch=num_buffers)
         barLoadB = mbarrier.allocate_mbarrier(batch=num_buffers)
         barMMA = mbarrier.allocate_mbarrier(batch=num_mma_stages)
@@ -804,8 +1116,7 @@ def test_multibuffered_loop(FAILURE, device, run_wrapper, monkeypatch, num_ctas)
         mbarrier.wait(barLoadA.index(ext_id), phase)
         mbarrier.wait(barLoadB.index(ext_id), phase)
 
-        blackwell.tcgen05_mma(smemA.index(ext_id),
-                              smemB.index(ext_id).permute([1, 0]), acc, mbarriers=[barMMA.index(mma_id)])
+        blackwell.tcgen05_mma(smemA.index(ext_id), smemB.index(ext_id), acc, mbarriers=[barMMA.index(mma_id)])
         ext_id = inc_mod(ext_id, num_buffers)
         mma_id = inc_mod(mma_id, num_mma_stages)
 
@@ -824,8 +1135,7 @@ def test_multibuffered_loop(FAILURE, device, run_wrapper, monkeypatch, num_ctas)
                 mbarrier.wait(barLoadA.index(ext_id), phase)
                 mbarrier.wait(barLoadB.index(ext_id), phase)
 
-                blackwell.tcgen05_mma(smemA.index(ext_id),
-                                      smemB.index(ext_id).permute([1, 0]), acc, mbarriers=[barMMA.index(mma_id)])
+                blackwell.tcgen05_mma(smemA.index(ext_id), smemB.index(ext_id), acc, mbarriers=[barMMA.index(mma_id)])
                 mma_id = inc_mod(mma_id, num_mma_stages)
 
             mbarrier.wait(barMMA.index(wait_id), mma_phase)
@@ -849,11 +1159,88 @@ def test_multibuffered_loop(FAILURE, device, run_wrapper, monkeypatch, num_ctas)
     a_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(
         input, [block_m, XBLOCK.value],
         ttgl.NVMMASharedLayout.get_default_for([block_m, XBLOCK.value], ttgl.float16,
-                                               cga_layout=tcgen05_cga_layout(num_ctas, 0)))
+                                               cga_layout=mma_cga_layout(num_ctas, 0)))
     b_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(
-        input, [block_n, XBLOCK.value],
-        ttgl.NVMMASharedLayout.get_default_for([block_n, XBLOCK.value], ttgl.float16,
-                                               cga_layout=tcgen05_cga_layout(num_ctas, 1)))
+        input, [XBLOCK.value, block_n],
+        ttgl.NVMMASharedLayout.get_default_for([XBLOCK.value, block_n], ttgl.float16,
+                                               cga_layout=mma_cga_layout(num_ctas, 1)))
+    kernel[(1, )](a_desc, b_desc, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell or newer")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_tma_tcgen05_mma_multicast_loop(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
+    if num_ctas == 1:
+        pytest.skip("Need at least 2 CTAs for 2CTA mode in this test")
+    if run_wrapper:
+        result = run_in_process(test_tma_tcgen05_mma_multicast_loop, (FAILURE, device, False, monkeypatch, num_ctas))
+        if FAILURE:
+            assert_expected_cuda_failure(result.exc)
+            assert "Buffer being accessed has outstanding" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(a_desc, b_desc, FAILURE: ttgl.constexpr):
+        num_k_tiles: ttgl.constexpr = 1 if FAILURE else 4
+        block_m: ttgl.constexpr = mma_block_m(ttgl.num_ctas())
+        block_n: ttgl.constexpr = mma_block_n(ttgl.num_ctas())
+        acc_layout: ttgl.constexpr = blackwell.TensorMemoryLayout(
+            [XBLOCK, XBLOCK],
+            col_stride=1,
+            cga_layout=mma_cga_layout(ttgl.num_ctas(), 2, True),
+            two_ctas=True,
+        )
+        smemA = ttgl.allocate_shared_memory(ttgl.float16, [block_m, XBLOCK], a_desc.layout)
+        smemB = ttgl.allocate_shared_memory(
+            ttgl.float16,
+            [XBLOCK, block_n],
+            ttgl.NVMMASharedLayout.get_default_for([XBLOCK, block_n], ttgl.float16,
+                                                   cga_layout=mma_cga_layout(ttgl.num_ctas(), 1, True)),
+        )
+        tma_bar = mbarrier.allocate_mbarrier(two_ctas=True)
+        mbarrier.init(tma_bar, count=1)
+        mma_bar = mbarrier.allocate_mbarrier()
+        mma_bar_count: ttgl.constexpr = blackwell.tcgen05_mma_barrier_count([smemA, smemB], True)
+        mbarrier.init(mma_bar, count=mma_bar_count)
+        acc = blackwell.allocate_tensor_memory(ttgl.float32, [block_m, block_n], acc_layout)
+
+        phase_tma = 0
+        phase_mma = 0
+        for k in range(num_k_tiles):
+            offs_k = k * XBLOCK
+            mbarrier.expect(tma_bar, a_desc.nbytes_per_cta + b_desc.nbytes_per_cta)
+            tma.async_copy_global_to_shared(a_desc, [0, offs_k], tma_bar, smemA, multicast=True)
+            tma.async_copy_global_to_shared(b_desc, [offs_k, 0], tma_bar, smemB, multicast=True)
+            if not FAILURE:
+                mbarrier.wait(tma_bar, phase_tma, deps=[smemA, smemB])
+            blackwell.tcgen05_mma(smemA, smemB, acc, use_acc=k != 0, multicast=True, mbarriers=[mma_bar])
+            mbarrier.wait(mma_bar, phase_mma, deps=[smemA, smemB])
+            phase_tma = (phase_tma + 1) % 2
+            phase_mma = (phase_mma + 1) % 2
+
+        mbarrier.invalidate(tma_bar)
+        mbarrier.invalidate(mma_bar)
+
+    block_m = mma_block_m(num_ctas)
+    block_n = mma_block_n(num_ctas)
+    num_k_tiles = 1 if FAILURE else 4
+    a = torch.randn((block_m, XBLOCK.value * num_k_tiles), device=device, dtype=torch.float16)
+    b = torch.randn((XBLOCK.value * num_k_tiles, block_n), device=device, dtype=torch.float16)
+    a_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(
+        a, [block_m, XBLOCK.value],
+        ttgl.NVMMASharedLayout.get_default_for([block_m, XBLOCK.value], ttgl.float16,
+                                               cga_layout=mma_cga_layout(num_ctas, 0, True)))
+    b_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(
+        b, [XBLOCK.value, block_n],
+        ttgl.NVMMASharedLayout.get_default_for([XBLOCK.value, block_n], ttgl.float16,
+                                               cga_layout=mma_cga_layout(num_ctas, 1, True)))
     kernel[(1, )](a_desc, b_desc, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
 
 
@@ -880,13 +1267,13 @@ def test_multibuffered_wgmma_loop(FAILURE, device, run_wrapper, monkeypatch, num
         block_m: ttgl.constexpr = mma_block_m(ttgl.num_ctas())
         block_n: ttgl.constexpr = mma_block_n(ttgl.num_ctas())
 
-        cga_layout_c: ttgl.constexpr = tcgen05_cga_layout(ttgl.num_ctas(), 2)
+        cga_layout_c: ttgl.constexpr = mma_cga_layout(ttgl.num_ctas(), 2)
         mma_layout: ttgl.constexpr = ttgl.NVMMADistributedLayout(version=[3, 0], warps_per_cta=[4, 1],
                                                                  instr_shape=[16, 32, 16], cga_layout=cga_layout_c)
         acc = hopper.warpgroup_mma_init(ttgl.zeros([block_m, block_n], ttgl.float32, mma_layout))
 
         smemA = ttgl.allocate_shared_memory(ttgl.float16, [num_buffers, block_m, XBLOCK], a_desc.layout)
-        smemB = ttgl.allocate_shared_memory(ttgl.float16, [num_buffers, block_n, XBLOCK], b_desc.layout)
+        smemB = ttgl.allocate_shared_memory(ttgl.float16, [num_buffers, XBLOCK, block_n], b_desc.layout)
         barLoadA = mbarrier.allocate_mbarrier(batch=num_buffers)
         barLoadB = mbarrier.allocate_mbarrier(batch=num_buffers)
         for i in range(num_buffers):
@@ -919,7 +1306,7 @@ def test_multibuffered_wgmma_loop(FAILURE, device, run_wrapper, monkeypatch, num
             mbarrier.wait(barLoadA.index(ext_id), phase)
             mbarrier.wait(barLoadB.index(ext_id), phase)
 
-            acc = hopper.warpgroup_mma(smemA.index(ext_id), smemB.index(ext_id).permute([1, 0]), acc, is_async=True)
+            acc = hopper.warpgroup_mma(smemA.index(ext_id), smemB.index(ext_id), acc, is_async=True)
             hopper.warpgroup_mma_wait(num_outstanding=1, deps=[acc])
             ext_id = inc_mod(ext_id, num_buffers)
             if ext_id == 0:
@@ -933,13 +1320,13 @@ def test_multibuffered_wgmma_loop(FAILURE, device, run_wrapper, monkeypatch, num
     block_m = mma_block_m(num_ctas)
     block_n = mma_block_n(num_ctas)
     input_a = torch.randn((block_m, XBLOCK.value), device=device, dtype=torch.float16)
-    input_b = torch.randn((block_n, XBLOCK.value), device=device, dtype=torch.float16)
+    input_b = torch.randn((XBLOCK.value, block_n), device=device, dtype=torch.float16)
     shared_layout_a = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
-                                             cga_layout=tcgen05_cga_layout(num_ctas, 0))
+                                             cga_layout=mma_cga_layout(num_ctas, 0))
     shared_layout_b = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
-                                             cga_layout=tcgen05_cga_layout(num_ctas, 1))
+                                             cga_layout=mma_cga_layout(num_ctas, 1))
     a_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input_a, [block_m, XBLOCK.value], shared_layout_a)
-    b_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input_b, [block_n, XBLOCK.value], shared_layout_b)
+    b_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input_b, [XBLOCK.value, block_n], shared_layout_b)
     kernel[(1, )](a_desc, b_desc, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
 
 
@@ -1508,6 +1895,7 @@ def test_ws_async_copy_commits(FAILURE, device, run_wrapper, monkeypatch, num_ct
             assert_expected_cuda_failure(result.exc)
             assert any(msg in result.driver_stderr_output for msg in [
                 "Buffer being accessed has outstanding writes",
+                "Buffer being accessed has outstanding reads",
                 "Accessing buffer with pending access. Pending access type: async_copy_global_to_shared",
             ])
         else:
@@ -1645,8 +2033,8 @@ def test_ws_wgmma_wait_visibility(FAILURE, device, run_wrapper, monkeypatch, num
         block_n: ttgl.constexpr = mma_block_n(ttgl.num_ctas())
         acc = ttgl.zeros([block_m, block_n], ttgl.float16, mma_layout)
         # Issue two async MMAs on two different buffers
-        acc = hopper.warpgroup_mma(smemA.index(0), smemB.index(0).permute([1, 0]), acc, is_async=True)
-        acc = hopper.warpgroup_mma(smemA.index(1), smemB.index(1).permute([1, 0]), acc, is_async=True)
+        acc = hopper.warpgroup_mma(smemA.index(0), smemB.index(0), acc, is_async=True)
+        acc = hopper.warpgroup_mma(smemA.index(1), smemB.index(1), acc, is_async=True)
         # Wait until only 1 outstanding remains
         hopper.warpgroup_mma_wait(num_outstanding=1, deps=[acc])
         # Signal to consumer
@@ -1663,9 +2051,9 @@ def test_ws_wgmma_wait_visibility(FAILURE, device, run_wrapper, monkeypatch, num
     def kernel(FAILURE: ttgl.constexpr):
         block_m: ttgl.constexpr = mma_block_m(ttgl.num_ctas())
         block_n: ttgl.constexpr = mma_block_n(ttgl.num_ctas())
-        cga_layout_a: ttgl.constexpr = tcgen05_cga_layout(ttgl.num_ctas(), 0)
-        cga_layout_b: ttgl.constexpr = tcgen05_cga_layout(ttgl.num_ctas(), 1)
-        cga_layout_c: ttgl.constexpr = tcgen05_cga_layout(ttgl.num_ctas(), 2)
+        cga_layout_a: ttgl.constexpr = mma_cga_layout(ttgl.num_ctas(), 0)
+        cga_layout_b: ttgl.constexpr = mma_cga_layout(ttgl.num_ctas(), 1)
+        cga_layout_c: ttgl.constexpr = mma_cga_layout(ttgl.num_ctas(), 2)
         smem_layout_a: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
                                                                cga_layout=cga_layout_a)
         smem_layout_b: ttgl.constexpr = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2,
@@ -1675,7 +2063,7 @@ def test_ws_wgmma_wait_visibility(FAILURE, device, run_wrapper, monkeypatch, num
         mma_layout: ttgl.constexpr = ttgl.NVMMADistributedLayout(version=[3, 0], warps_per_cta=[4, 1],
                                                                  instr_shape=[16, 32, 16], cga_layout=cga_layout_c)
         smemA = ttgl.allocate_shared_memory(ttgl.float16, [2, block_m, XBLOCK], smem_layout_a)
-        smemB = ttgl.allocate_shared_memory(ttgl.float16, [2, block_n, XBLOCK], smem_layout_b)
+        smemB = ttgl.allocate_shared_memory(ttgl.float16, [2, XBLOCK, block_n], smem_layout_b)
         bar = mbarrier.allocate_mbarrier(batch=1)
         mbarrier.init(bar.index(0), count=1)
         ttgl.warp_specialize([
@@ -1857,7 +2245,7 @@ def test_barrier_underflow(device, run_wrapper, monkeypatch, num_ctas):
     if run_wrapper:
         result = run_in_process(test_barrier_underflow, (device, False, monkeypatch, num_ctas))
         assert_expected_cuda_failure(result.exc)
-        assert "Barrier arrive underflow: current count would become negative" in result.driver_stderr_output
+        assert "Barrier arrive underflow" in result.driver_stderr_output
         return
     monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
     monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
@@ -2166,27 +2554,27 @@ def async_copy_mma_write_after_read_kernel(a_ptr, BLOCK_M: ttgl.constexpr, BLOCK
                                            BLOCK_K: ttgl.constexpr):
     blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 4], threads_per_warp=[32, 1],
                                                         warps_per_cta=[ttgl.num_warps(), 1], order=[0, 1],
-                                                        cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 0))
+                                                        cga_layout=mma_cga_layout(ttgl.num_ctas(), 0))
     a_smem = ttgl.allocate_shared_memory(
         ttgl.float16,
         [BLOCK_M, BLOCK_K],
         ttgl.NVMMASharedLayout.get_default_for([BLOCK_M, BLOCK_K], ttgl.float16,
-                                               cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 0)),
+                                               cga_layout=mma_cga_layout(ttgl.num_ctas(), 0)),
     )
     b_smem = ttgl.allocate_shared_memory(
         ttgl.float16,
-        [BLOCK_N, BLOCK_K],
-        ttgl.NVMMASharedLayout.get_default_for([BLOCK_N, BLOCK_K], ttgl.float16,
-                                               cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 1)),
+        [BLOCK_K, BLOCK_N],
+        ttgl.NVMMASharedLayout.get_default_for([BLOCK_K, BLOCK_N], ttgl.float16,
+                                               cga_layout=mma_cga_layout(ttgl.num_ctas(), 1)),
     )
 
     bar = mbarrier.allocate_mbarrier()
     tmem_layout: ttgl.constexpr = blackwell.TensorMemoryLayout([XBLOCK, XBLOCK], col_stride=1,
-                                                               cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 2))
+                                                               cga_layout=mma_cga_layout(ttgl.num_ctas(), 2))
     tmem = allocate_tensor_memory(ttgl.float32, [BLOCK_M, BLOCK_N], tmem_layout)
 
     mbarrier.init(bar, count=1)
-    blackwell.tcgen05_mma(a_smem, b_smem.permute([1, 0]), tmem, use_acc=False)
+    blackwell.tcgen05_mma(a_smem, b_smem, tmem, use_acc=False)
     offs_m = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, blocked_layout))[:, None]
     offs_k = ttgl.arange(0, BLOCK_K, layout=ttgl.SliceLayout(0, blocked_layout))[None, :]
     offs = offs_m * BLOCK_K + offs_k
@@ -2217,20 +2605,20 @@ def load_local_alloc_mma_write_after_read_kernel(a_ptr, K, BLOCK_M: ttgl.constex
                                                  BLOCK_K: ttgl.constexpr):
     blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 4], threads_per_warp=[32, 1],
                                                         warps_per_cta=[ttgl.num_warps(), 1], order=[0, 1],
-                                                        cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 0))
+                                                        cga_layout=mma_cga_layout(ttgl.num_ctas(), 0))
     a_smem_layout: ttgl.constexpr = ttgl.NVMMASharedLayout.get_default_for([BLOCK_M, BLOCK_K], ttgl.float16,
-                                                                           cga_layout=tcgen05_cga_layout(
+                                                                           cga_layout=mma_cga_layout(
                                                                                ttgl.num_ctas(), 0))
     b_smem = ttgl.allocate_shared_memory(
         ttgl.float16,
-        [BLOCK_N, BLOCK_K],
-        ttgl.NVMMASharedLayout.get_default_for([BLOCK_N, BLOCK_K], ttgl.float16,
-                                               cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 1)),
+        [BLOCK_K, BLOCK_N],
+        ttgl.NVMMASharedLayout.get_default_for([BLOCK_K, BLOCK_N], ttgl.float16,
+                                               cga_layout=mma_cga_layout(ttgl.num_ctas(), 1)),
     )
 
     bar = mbarrier.allocate_mbarrier()
     tmem_layout: ttgl.constexpr = blackwell.TensorMemoryLayout([XBLOCK, XBLOCK], col_stride=1,
-                                                               cga_layout=tcgen05_cga_layout(ttgl.num_ctas(), 2))
+                                                               cga_layout=mma_cga_layout(ttgl.num_ctas(), 2))
     tmem = allocate_tensor_memory(ttgl.float32, [BLOCK_M, BLOCK_N], tmem_layout)
 
     mbarrier.init(bar, count=1)
@@ -2243,7 +2631,7 @@ def load_local_alloc_mma_write_after_read_kernel(a_ptr, K, BLOCK_M: ttgl.constex
         a_value = ttgl.load(a_ptr + offs_m * K + offs_k + k)
 
         a_smem = ttgl.allocate_shared_memory(ttgl.float16, [BLOCK_M, BLOCK_K], a_smem_layout, a_value)
-        blackwell.tcgen05_mma(a_smem, b_smem.permute([1, 0]), tmem, use_acc=use_acc)
+        blackwell.tcgen05_mma(a_smem, b_smem, tmem, use_acc=use_acc)
         use_acc = True
     blackwell.tcgen05_commit(bar)
     mbarrier.wait(bar, phase=0)

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -974,12 +974,12 @@ def test_tcgen05_commit_multicast_two_ctas():
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @tcgen05_commit_multicast_two_ctas_kernel() attributes {noinline = false} {
-    %0 = tt.call @"triton.experimental.gluon.language.nvidia.ampere.mbarrier.allocate_mbarrier____(0,)cNone_(1,)cconstexpr_True_"() : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %0 = tt.call @triton.experimental.gluon.language.nvidia.ampere.mbarrier.allocate_mbarrier__cNone_cTrue() : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     %true = arith.constant true
     ttng.barrier_expect %0, 4, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     tt.return
   }
-  tt.func private @"triton.experimental.gluon.language.nvidia.ampere.mbarrier.allocate_mbarrier____(0,)cNone_(1,)cconstexpr_True_"() -> !ttg.memdesc<1xi64, #shared, #smem, mutable> attributes {noinline = false} {
+  tt.func private @triton.experimental.gluon.language.nvidia.ampere.mbarrier.allocate_mbarrier__cNone_cTrue() -> !ttg.memdesc<1xi64, #shared, #smem, mutable> attributes {noinline = false} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     tt.return %0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
   ^bb1:  // no predecessors

--- a/test/Analysis/test-buffer-region.mlir
+++ b/test/Analysis/test-buffer-region.mlir
@@ -188,6 +188,47 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // -----
 
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @tcgen5_commit_barrier_regions() {
+    %bar = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // expected-remark @below {{Buffers: [8192, 8]}}
+    ttng.tc_gen5_commit %bar : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    tt.return
+  }
+
+  // expected-remark @below {{All Barrier Regions: [8192, 8]}}
+  tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @tmem_copy_regions() {
+    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #shared, #smem, mutable>
+    %dst = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // expected-remark @below {{Buffers: [0, 65536]}}
+    ttng.tmem_copy %src, %dst : !ttg.memdesc<128x128xf32, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // expected-remark @below {{All Shared Regions: [0, 65536]}}
+  // expected-remark @below {{All Tensor Regions: [0, 128]}}
+  tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #smem = #ttg.shared_memory
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1]}>

--- a/test/Analysis/test-membar-ttng.mlir
+++ b/test/Analysis/test-membar-ttng.mlir
@@ -19,6 +19,35 @@ tt.func @async_store_wait(%arg: tensor<32x16xf16, #AL>) {
 
 // -----
 
+#barrier_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+// CHECK-LABEL: @wait_then_arrive_barrier
+tt.func @wait_then_arrive_barrier(%phase: i32) {
+  %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  // CHECK: ttng.wait_barrier
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.arrive_barrier
+  ttng.wait_barrier %barrier, %phase : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.arrive_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  tt.return
+}
+
+// CHECK-LABEL: @arrive_then_wait_barrier
+tt.func @arrive_then_wait_barrier(%phase: i32) {
+  %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  // CHECK: ttng.arrive_barrier
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.wait_barrier
+  ttng.arrive_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %barrier, %phase : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  tt.return
+}
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -229,7 +258,7 @@ tt.func @no_barrier_before_perthread_arrive(%arg: tensor<32x16xf16, #blocked_pt>
 // -----
 
 // Verify that a regular (non-perThread) arrive after a shared memory write
-// DOES get a ttg.barrier inserted before it (existing behavior preserved).
+// gets a barrier inserted before it.
 
 #shared_reg = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #blocked_reg = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
@@ -13,11 +13,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %c_pred = arith.constant 1 : i32
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-    // CHECK-COUNT-4: llvm.insertelement{{.*}} : vector<4xi32>
-    // CHECK-COUNT-8: llvm.insertelement{{.*}} : vector<8xi32>
+    // The descriptor is built as two vectors (<4xi32> + <8xi32>) via a
+    // sequence of insertelement / extractelement ops; just check the final
+    // intrinsic call gets the right operand types.
+    // CHECK: llvm.insertelement{{.*}} : vector<4xi32>
+    // CHECK: llvm.insertelement{{.*}} : vector<8xi32>
     // CHECK: "llvm.amdgcn.tensor.load.to.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
     %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-    // CHECK: llvm.amdgcn.s.wait.tensorcnt{{.*}} : (i16) -> ()
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.s.wait.tensorcnt"
     %3 = amdg.async_tdm_intrinsic_wait  {count = 0 : i32}
     %4 = ttg.local_load %1 : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> tensor<64x64xf16, #blocked>
     tt.return
@@ -40,11 +43,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     %2 = arith.constant dense<0.000000e+00> : tensor<64x64xf16, #blocked>
     ttg.local_store %2, %1 : tensor<64x64xf16, #blocked> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-    // CHECK-COUNT-4: llvm.insertelement{{.*}} : vector<4xi32>
-    // CHECK-COUNT-8: llvm.insertelement{{.*}} : vector<8xi32>
+    // The descriptor is built as two vectors (<4xi32> + <8xi32>) via a
+    // sequence of insertelement / extractelement ops; just check the final
+    // intrinsic call gets the right operand types.
+    // CHECK: llvm.insertelement{{.*}} : vector<4xi32>
+    // CHECK: llvm.insertelement{{.*}} : vector<8xi32>
     // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
     amdg.async_tdm_copy_local_to_global %0[%c_offset, %c_offset] from %1: !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x64xf16, #shared>
-    // CHECK: llvm.amdgcn.s.wait.tensorcnt{{.*}} : (i16) -> ()
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.s.wait.tensorcnt"
     %3 = amdg.async_tdm_intrinsic_wait  {count = 0 : i32}
     tt.return
   }
@@ -64,13 +70,16 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %c_offset = arith.constant 0 : i32
     %c_pred = arith.constant 1 : i32
 
-    // CHECK: llvm.sext %{{.*}} : i32 to i64
-    // CHECK: %[[OFFSET_DIM0:.*]] = llvm.mul %{{.*}}, %{{.*}} : i64
-    // CHECK: %[[OFFSET_TMP1:.*]] = llvm.add %[[OFFSET_DIM0]], %{{.*}} : i64
-    // CHECK: llvm.sext %{{.*}} : i32 to i64
-    // CHECK: %[[OFFSET_DIM1:.*]] = llvm.mul %{{.*}}, %{{.*}} : i64
-    // CHECK: %[[TOTAL_OFFSET:.*]] = llvm.add %[[OFFSET_TMP1]], %[[OFFSET_DIM1]] : i64
-    // CHECK: llvm.getelementptr %{{.*}}[%[[TOTAL_OFFSET]]] : (!llvm.ptr<1>, i64)
+    // CHECK-DAG: %[[STRIDE0:.*]] = llvm.mlir.constant(128 : i64) : i64
+    // CHECK-DAG: %[[STRIDE1:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK: %[[STRIDE0_TRUNC:.*]] = llvm.trunc %[[STRIDE0]] : i64 to i32
+    // The stride is inserted into group1 (<8 x i32>), then the CTA-offset
+    // computation re-extracts it to multiply into the per-dim offset.  The
+    // per-dim offsets are summed and the total feeds `getelementptr` for
+    // the load.
+    // CHECK: llvm.insertelement %[[STRIDE0_TRUNC]]{{.*}}: vector<8xi32>
+    // CHECK: llvm.mul
+    // CHECK: llvm.getelementptr
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
 
@@ -94,14 +103,15 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %c_stride1 = arith.constant 1 : i64
     %c_offset = arith.constant 0 : i32
 
+    // CHECK-DAG: %[[STRIDE0:.*]] = llvm.mlir.constant(128 : i64) : i64
+    // CHECK-DAG: %[[STRIDE1:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-DAG: rocdl.cluster.workgroup.id.x
-    // CHECK: llvm.sext %{{.*}} : i32 to i64
-    // CHECK: %[[OFFSET_DIM0:.*]] = llvm.mul %{{.*}}, %{{.*}} : i64
-    // CHECK: %[[OFFSET_TMP1:.*]] = llvm.add %[[OFFSET_DIM0]], %{{.*}} : i64
-    // CHECK: llvm.sext %{{.*}} : i32 to i64
-    // CHECK: %[[OFFSET_DIM1:.*]] = llvm.mul %{{.*}}, %{{.*}} : i64
-    // CHECK: %[[TOTAL_OFFSET:.*]] = llvm.add %[[OFFSET_TMP1]], %[[OFFSET_DIM1]] : i64
-    // CHECK: llvm.getelementptr %{{.*}}[%[[TOTAL_OFFSET]]] : (!llvm.ptr<1>, i64)
+    // CHECK-DAG: %[[STRIDE0_TRUNC:.*]] = llvm.trunc %[[STRIDE0]] : i64 to i32
+    // Same as the load case above: stride is inserted into group1, then
+    // re-extracted for the CTA-offset multiply, which feeds getelementptr.
+    // CHECK-DAG: llvm.insertelement %[[STRIDE0_TRUNC]]{{.*}}: vector<8xi32>
+    // CHECK: llvm.mul
+    // CHECK: llvm.getelementptr
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
@@ -172,7 +182,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tdm_wait_inst
   tt.func public @tdm_wait_inst() {
-    // CHECK: llvm.amdgcn.s.wait.tensorcnt{{.*}} : (i16) -> ()
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.s.wait.tensorcnt"
     %3 = amdg.async_tdm_intrinsic_wait  {count = 0 : i32}
     tt.return
   }
@@ -185,11 +195,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tdm_2d_with_padding
   tt.func public @tdm_2d_with_padding(
-    %tensorDesc: !tt.tensordesc<128x64xf16, #shared>,
+    %tensorDesc: !tt.tensordesc<128x64xf16>,
     %memDesc: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
   ) {
     %c0_i32 = arith.constant 0 : i32
-    amdg.async_tdm_copy_local_to_global %tensorDesc[%c0_i32, %c0_i32] from %memDesc: !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<128x64xf16, #shared>
+    amdg.async_tdm_copy_local_to_global %tensorDesc[%c0_i32, %c0_i32] from %memDesc: !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<128x64xf16>
     // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
     tt.return
   }
@@ -202,11 +212,32 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tdm_5d_with_padding
   tt.func public @tdm_5d_with_padding(
-    %tensorDesc: !tt.tensordesc<8x8x8x16x16xf16, #shared_5d>,
+    %tensorDesc: !tt.tensordesc<8x8x8x16x16xf16>,
     %memDesc: !ttg.memdesc<8x8x8x16x16xf16, #shared_5d, #smem_5d, mutable>
   ) {
     %c0_i32 = arith.constant 0 : i32
-    amdg.async_tdm_copy_local_to_global %tensorDesc[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] from %memDesc: !ttg.memdesc<8x8x8x16x16xf16, #shared_5d, #smem_5d, mutable> -> !tt.tensordesc<8x8x8x16x16xf16, #shared_5d>
+    amdg.async_tdm_copy_local_to_global %tensorDesc[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] from %memDesc: !ttg.memdesc<8x8x8x16x16xf16, #shared_5d, #smem_5d, mutable> -> !tt.tensordesc<8x8x8x16x16xf16>
+    // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Scatter with padded shared layout: padding interval = innermost block dim.
+#idx_parent = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#idx_layout = #ttg.slice<{dim = 1, parent = #idx_parent}>
+#shared_scatter_pad = #ttg.padded_shared<[64:+8] {order = [1, 0], shape = [8, 64]}>
+#smem_scatter_pad = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tdm_scatter_with_padding
+  tt.func public @tdm_scatter_with_padding(
+    %tensorDesc: !tt.tensordesc<8x64xf16>,
+    %memDesc: !ttg.memdesc<8x64xf16, #shared_scatter_pad, #smem_scatter_pad, mutable>,
+    %row_indices: tensor<8xi32, #idx_layout>
+  ) {
+    %c0_i32 = arith.constant 0 : i32
+    amdg.async_tdm_scatter %tensorDesc[%row_indices, %c0_i32] from %memDesc : tensor<8xi32, #idx_layout>, !ttg.memdesc<8x64xf16, #shared_scatter_pad, #smem_scatter_pad, mutable> -> !tt.tensordesc<8x64xf16>
     // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
     tt.return
   }
@@ -269,27 +300,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: llvm.icmp "eq" %[[MASKED]], %[[ZERO]] : i32
     // CHECK: "llvm.amdgcn.tensor.load.to.lds"
     %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred {warp_used_hint = 3 : i32} : !tt.tensordesc<128x16xf16, #partitioned> -> !ttg.memdesc<128x16xf16, #partitioned, #smem, mutable>
-    tt.return
-  }
-}
-
-// -----
-
-// Scatter with padded shared layout: padding interval = innermost block dim.
-#idx_parent = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#idx_layout = #ttg.slice<{dim = 1, parent = #idx_parent}>
-#shared_scatter_pad = #ttg.padded_shared<[64:+8] {order = [1, 0], shape = [8, 64]}>
-#smem_scatter_pad = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: tdm_scatter_with_padding
-  tt.func public @tdm_scatter_with_padding(
-    %tensorDesc: !tt.tensordesc<8x64xf16>,
-    %memDesc: !ttg.memdesc<8x64xf16, #shared_scatter_pad, #smem_scatter_pad, mutable>,
-    %row_indices: tensor<8xi32, #idx_layout>
-  ) {
-    %c0_i32 = arith.constant 0 : i32
-    amdg.async_tdm_scatter %tensorDesc[%row_indices, %c0_i32] from %memDesc : tensor<8xi32, #idx_layout>, !ttg.memdesc<8x64xf16, #shared_scatter_pad, #smem_scatter_pad, mutable> -> !tt.tensordesc<8x64xf16>
-    // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
     tt.return
   }
 }

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -210,6 +210,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: %[[TMEM_SUBSLICE_BASE:.+]] = llvm.ptrtoint %[[TMEM_SUBSLICE_PTR]] : !llvm.ptr<3> to i32
   // CHECK-COUNT-4: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 0 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_SUBSLICE_BASE]]
   // CHECK-COUNT-4: @$5 tcgen05.mma.cta_group::1.kind::f16 [ $0 + 128 ], $1, $2, $3, $4;", "r,l,l,r,b,b" %[[TMEM_SUBSLICE_BASE]]
+  // CHECK-NOT: nvvm.barrier
   tt.func @tc_gen5_mma_subslice_acc(%a: !ttg.memdesc<256x64xf16, #shared, #ttg.shared_memory>,
                                     %b: !ttg.memdesc<64x64xf16, #shared1, #ttg.shared_memory>,
                                     %c: !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>) {

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -1,0 +1,1000 @@
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritoninstrument-concurrency-sanitizer | FileCheck %s
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @single_local_alloc
+  tt.func public @single_local_alloc() {
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1x1xi64
+
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1xI64(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
+
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1x64xI64(%[[READ_VISIBILITY_GLOB]], %c0_i64
+
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i8>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1x1xI8(%[[WRITE_TRACKING_GLOB]], %c0_i8
+
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1x1xI64(%[[READ_TRACKING_GLOB]], %c0_i64
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @two_local_alloc
+  tt.func public @two_local_alloc() {
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0, 4096], [{{.*}}], shared_mem : tensor<1x2xi64
+
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x2xI64(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
+
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1024 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x2x64xI64(%[[READ_VISIBILITY_GLOB]], %c0_i64
+
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i8>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x2x1xI8(%[[WRITE_TRACKING_GLOB]], %c0_i8
+
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x2x1xI64(%[[READ_TRACKING_GLOB]], %c0_i64
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %1 = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    ttg.local_load %1 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @three_local_alloc
+  tt.func public @three_local_alloc() {
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0, 4096, 8192, 0], [{{.*}}], shared_mem : tensor<1x4xi64,
+
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x4xI64(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
+
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2048 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x4x64xI64(%[[READ_VISIBILITY_GLOB]], %c0_i64
+
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i8>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x4x1xI8(%[[WRITE_TRACKING_GLOB]], %c0_i8
+
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x4x1xI64(%[[READ_TRACKING_GLOB]], %c0_i64
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %1 = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %2 = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 12288 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    ttg.local_load %1 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    ttg.local_load %2 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @three_sub_bufs
+  tt.func public @three_sub_bufs() {
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0, 4096, 8192, 0], [{{.*}}], shared_mem : tensor<1x4xi64,
+
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x4xI64(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
+
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 2048 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x4x64xI64(%[[READ_VISIBILITY_GLOB]], %c0_i64
+
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i8>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x4x1xI8(%[[WRITE_TRACKING_GLOB]], %c0_i8
+
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x4x1xI64(%[[READ_TRACKING_GLOB]], %c0_i64
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x32x32xf32, #shared, #smem, mutable>
+    %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<3x32x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttg.local_load %1 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [2, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK: #[[READ_BARS_L:.*]] = #ttg.blocked<{sizePerThread = [2, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1]}>
+  // CHECK: @read_bars_alloc
+  tt.func public @read_bars_alloc() {
+    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i8>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x2x4xI8(%[[READ_BARS_G]], %c0_i8
+    %c0 = arith.constant 0 : i32
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<4x1xi64, #shared1, #smem, mutable>
+    %bar_sub = ttg.memdesc_index %bar[%c0] : !ttg.memdesc<4x1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    amdg.init_barrier %bar_sub, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %buf_sub = ttg.memdesc_index %0[%c0] : !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    ttg.local_load %buf_sub : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @async_copy_global_to_local
+  tt.func public @async_copy_global_to_local(%ptr: tensor<32x32x!tt.ptr<f16>, #blocked>) {
+    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1x1xi64
+    // CHECK: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i8>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1x16xI8(%[[WRT_COMMITS_GLOB]], %c0_i8
+
+    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
+    // CHECK: tt.call @__triton_consan_verify_write_visibility_noalias_nw1{{.*}}(%[[A_I64]]
+    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
+    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility_noalias_nw1
+    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
+    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit_nw1{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
+    // CHECK: ttg.async_copy_global_to_local %{{.*}}, %[[A]]
+
+    %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
+    ttg.async_copy_global_to_local %ptr, %shmem : tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @async_copy_global_to_local_with_barriers
+  tt.func public @async_copy_global_to_local_with_barriers(%ptr: tensor<32x32x!tt.ptr<f16>, #blocked>) {
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1x1xi64
+    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i8>
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+
+    // CHECK-DAG: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 16 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i8>
+
+    // CHECK: tt.call @__triton_consan_init_barrier_state
+
+    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
+    // CHECK: tt.call @__triton_consan_verify_write_visibility_noalias{{.*}}(%[[A_I64]]
+    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
+    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
+    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}(%[[A_I64]]
+    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
+    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
+    // CHECK: ttg.async_copy_global_to_local %{{.*}}, %[[A]]
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
+    ttg.async_copy_global_to_local %ptr, %shmem : tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @async_commit_group
+  tt.func public @async_commit_group() {
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
+    ttg.async_commit_group
+    ttg.local_load %shmem : !ttg.memdesc<32x32xf16, #shared, #smem, mutable> -> tensor<32x32xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @async_wait
+  tt.func public @async_wait() {
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 4295032833 : i64
+    // CHECK: %[[OUTSTANDING_NUM:.*]] = arith.constant 42 : i32
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]], %[[OUTSTANDING_NUM]]
+    %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
+    ttg.async_wait {num = 42 : i32}
+    ttg.local_load %shmem : !ttg.memdesc<32x32xf16, #shared, #smem, mutable> -> tensor<32x32xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @local_alloc_with_src
+  tt.func public @local_alloc_with_src(%data: tensor<32x32xf16, #blocked>) {
+    // CHECK: %[[BUF:.*]] = ttg.local_alloc
+    // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}(%[[BUF_I64]]
+    // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}(%[[BUF_I64]]
+    %buf = ttg.local_alloc %data {allocation.offset = 0 : i32} : (tensor<32x32xf16, #blocked>) -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @alias_matrix_shared
+  tt.func public @alias_matrix_shared() {
+    // CHECK-DAG: tti.experimental_buffer_descriptors [0, 16], [128, 128], shared_mem : tensor<1x2xi64
+    // CHECK-DAG: arith.constant dense<true> : tensor<2x2xi1
+    %buf0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
+    %buf1 = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttg.local_load %buf0 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
+    ttg.local_load %buf1 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @alias_matrix_shared_indexed
+  tt.func public @alias_matrix_shared_indexed() {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    // CHECK-DAG: tti.experimental_buffer_descriptors [0, 128], [128, 128], shared_mem : tensor<1x2xi64
+    // CHECK-NOT: arith.constant dense<{{\[\[true, false\], \[false, true\]\]}}> : tensor<2x2xi1
+    %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x32xf32, #shared, #smem, mutable>
+    %buf0 = ttg.memdesc_index %smem[%c0_i32] : !ttg.memdesc<2x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
+    %buf1 = ttg.memdesc_index %smem[%c1_i32] : !ttg.memdesc<2x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttg.local_load %buf0 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
+    ttg.local_load %buf1 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @alias_matrix_shared_subslice
+  tt.func public @alias_matrix_shared_subslice() {
+    // CHECK-DAG: tti.experimental_buffer_descriptors [0, 128], [256, 128], shared_mem : tensor<1x2xi64
+    // CHECK-DAG: arith.constant dense<true> : tensor<2x2xi1
+    %buf0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64xf32, #shared, #smem, mutable>
+    %buf1 = ttg.memdesc_subslice %buf0 [32] : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttg.local_load %buf0 : !ttg.memdesc<64xf32, #shared, #smem, mutable> -> tensor<64xf32>
+    ttg.local_load %buf1 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @amdg_init_barrier
+  tt.func public @amdg_init_barrier() {
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_init_barrier_state
+    ttg.local_load %buf : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @amdg_wait_barrier
+  tt.func public @amdg_wait_barrier() {
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1x1xi64
+
+    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1xI64(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
+
+    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1x64xI64(%[[READ_VISIBILITY_GLOB]], %c0_i64
+
+    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1x1xi64
+
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i8>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1x1xI8(%[[WRITE_TRACKING_GLOB]], %c0_i8
+
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1x1xI64(%[[READ_TRACKING_GLOB]], %c0_i64
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK-DAG: tt.call @__triton_consan_set_waiting
+    // CHECK-DAG: tt.call @__triton_consan_check_all_active_waiting
+    // CHECK: amdg.wait_barrier
+    amdg.wait_barrier %bar, %c0_i32 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: tt.call @__triton_consan_transfer_visible_writes{{.*}}%[[BARRIERS]], %[[WRITE_VISIBILITY_GLOB]], %[[WRITE_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_transfer_visible_reads{{.*}}%[[BARRIERS]], %[[READ_VISIBILITY_GLOB]], %[[READ_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_clear_waiting
+    // CHECK: tti.experimental_lock_release
+    ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @amdg_arrive_barrier
+  tt.func public @amdg_arrive_barrier() {
+    // CHECK-DAG: %[[BSTATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i32>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1xI32(%[[BSTATE_GLOB]], %c0_i32
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_init_barrier_state
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: tt.call @__triton_consan_track_visible_writes
+    // CHECK: tt.call @__triton_consan_track_visible_reads
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tti.experimental_lock_release
+    %phase = amdg.arrive_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> i32
+    ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @amdg_wait_barrier_without_init
+  tt.func public @amdg_wait_barrier_without_init() {
+    %c0_i32 = arith.constant 0 : i32
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: tt.call @__triton_consan_set_waiting
+    amdg.wait_barrier %bar, %c0_i32 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @amdg_arrive_barrier_without_init
+  tt.func public @amdg_arrive_barrier_without_init() {
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
+    %phase = amdg.arrive_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> i32
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [32, 32]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @async_tdm_copy_global_to_local
+  tt.func public @async_tdm_copy_global_to_local(%desc: !tt.tensordesc<32x32xf32>) {
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1x1xi64
+
+    // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1xI64(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
+
+    // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1x64xI64(%[[READ_VISIBILITY_GLOB]], %c0_i64
+
+    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1x1xi64
+    // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i8>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1x1xI8(%[[WRITE_TRACKING_GLOB]], %c0_i8
+
+    // CHECK-DAG: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1x1xI64(%[[READ_TRACKING_GLOB]], %c0_i64
+    %c0_i32 = arith.constant 0 : i32
+    %pred = arith.constant 1 : i32
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    amdg.init_barrier %bar, 8 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_init_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: tt.call @__triton_consan_set_write_visibility
+    // CHECK: tt.call @__triton_consan_clear_write_tracking
+    // CHECK: tt.call @__triton_consan_clear_read_visibility
+    // CHECK: tt.call @__triton_consan_clear_read_tracking
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: tt.call @__triton_consan_track_visible_writes
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
+    %1 = amdg.async_tdm_copy_global_to_local %desc[%c0_i32, %c0_i32] into %0, pred = %pred, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [32, 32]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @async_tdm_copy_global_to_local_two_bufs_one_barrier
+  tt.func public @async_tdm_copy_global_to_local_two_bufs_one_barrier(
+      %a: !tt.tensordesc<32x32xf32>,
+      %b: !tt.tensordesc<32x32xf32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %pred = arith.constant 1 : i32
+
+    %a_smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %b_smem = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    amdg.init_barrier %bar, 16 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+    // CHECK: tt.call @__triton_consan_init_barrier_state
+    // First TDM copy: full effects + barrier instrumentation
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: tt.call @__triton_consan_set_write_visibility
+    // CHECK: tt.call @__triton_consan_clear_write_tracking
+    // CHECK: tt.call @__triton_consan_clear_read_visibility
+    // CHECK: tt.call @__triton_consan_clear_read_tracking
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: tt.call @__triton_consan_track_visible_writes
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
+    %0 = amdg.async_tdm_copy_global_to_local %a[%c0_i32, %c0_i32] into %a_smem, pred = %pred, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+
+    // Second TDM copy: same full instrumentation
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: tt.call @__triton_consan_set_write_visibility
+    // CHECK: tt.call @__triton_consan_clear_write_tracking
+    // CHECK: tt.call @__triton_consan_clear_read_visibility
+    // CHECK: tt.call @__triton_consan_clear_read_tracking
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: tt.call @__triton_consan_track_visible_writes
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
+    %1 = amdg.async_tdm_copy_global_to_local %b[%c0_i32, %c0_i32] into %b_smem, pred = %pred, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+
+    %c0_phase = arith.constant 0 : i32
+    amdg.wait_barrier %bar, %c0_phase : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+
+    %va = ttg.local_load %a_smem : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    %vb = ttg.local_load %b_smem : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    %_ = arith.addf %va, %vb : tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [32, 32]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @async_tdm_copy_global_to_local_no_barrier
+  tt.func public @async_tdm_copy_global_to_local_no_barrier(%desc: !tt.tensordesc<32x32xf32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %pred = arith.constant 1 : i32
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self_noalias
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self_noalias
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    // CHECK-NOT: tt.call @__triton_consan_verify_barrier_arrive
+    %1 = amdg.async_tdm_copy_global_to_local %desc[%c0_i32, %c0_i32] into %0, pred = %pred : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @async_tdm_copy_local_to_global
+  tt.func public @async_tdm_copy_local_to_global(%desc: !tt.tensordesc<32x32xf32>, %ptr: tensor<128x128x!tt.ptr<f16>, #blocked>) {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %shmem = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    ttg.async_copy_global_to_local %ptr, %shmem : tensor<128x128x!tt.ptr<f16>, #blocked> -> <128x128xf16, #shared, #smem, mutable>
+
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits_noalias
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self_noalias
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    amdg.async_tdm_copy_local_to_global %desc[%c0_i32, %c0_i32] from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [32, 32]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @async_tdm_load_store_no_barrier
+  tt.func public @async_tdm_load_store_no_barrier(%in_desc: !tt.tensordesc<32x32xf32>, %out_desc: !tt.tensordesc<32x32xf32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %pred = arith.constant 1 : i32
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self_noalias
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    %1 = amdg.async_tdm_copy_global_to_local %in_desc[%c0_i32, %c0_i32] into %0, pred = %pred : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self_noalias
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    amdg.async_tdm_copy_local_to_global %out_desc[%c0_i32, %c0_i32] from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @async_tdm_copy_local_to_global_with_barrier
+  tt.func public @async_tdm_copy_local_to_global_with_barrier(%desc: !tt.tensordesc<32x32xf32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_can_init
+    amdg.init_barrier %bar, 8 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_init_barrier_state
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_set_read_visibility
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: tt.call @__triton_consan_track_visible_writes
+    // CHECK: tt.call @__triton_consan_track_visible_reads
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_stage_access_for_commit
+    amdg.async_tdm_copy_local_to_global %desc[%c0_i32, %c0_i32] from %0, barrier = %bar : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !tt.tensordesc<32x32xf32>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @async_tdm_wait
+  tt.func public @async_tdm_wait() {
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
+    amdg.async_tdm_wait {num = 0 : i32}
+
+    ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @async_tdm_intrinsic_wait
+  tt.func public @async_tdm_intrinsic_wait() {
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
+    amdg.async_tdm_intrinsic_wait {"ttg.num_tdm_ops" = 2 : i64, count = 2 : i32}
+
+    ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @amdg_async_wait
+  tt.func public @amdg_async_wait() {
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 4295032833 : i64
+    // CHECK: %[[OUTSTANDING_NUM:.*]] = arith.constant 42 : i32
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]], %[[OUTSTANDING_NUM]]
+    %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
+    amdg.async_wait {"ttg.num_commit_groups" = 42 : i64, num_inst = 42 : i32}
+    ttg.local_load %shmem : !ttg.memdesc<32x32xf16, #shared, #smem, mutable> -> tensor<32x32xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [32, 32]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @tdm_load_no_barrier_wait
+  tt.func public @tdm_load_no_barrier_wait(%desc: !tt.tensordesc<32x32xf32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %pred = arith.constant 1 : i32
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %1 = amdg.async_tdm_copy_global_to_local %desc[%c0_i32, %c0_i32] into %0, pred = %pred : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
+    amdg.async_tdm_wait {num = 0 : i32}
+    ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @tdm_store_no_barrier_wait
+  tt.func public @tdm_store_no_barrier_wait(%desc: !tt.tensordesc<32x32xf32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    amdg.async_tdm_copy_local_to_global %desc[%c0_i32, %c0_i32] from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
+    amdg.async_tdm_wait {num = 0 : i32}
+    ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [32, 32]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @tdm_load_store_no_barrier_wait
+  tt.func public @tdm_load_store_no_barrier_wait(%desc: !tt.tensordesc<32x32xf32>) {
+    %c0_i32 = arith.constant 0 : i32
+    %pred = arith.constant 1 : i32
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %1 = amdg.async_tdm_copy_global_to_local %desc[%c0_i32, %c0_i32] into %0, pred = %pred : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    amdg.async_tdm_copy_local_to_global %desc[%c0_i32, %c0_i32] from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
+    amdg.async_tdm_wait {num = 0 : i32}
+    ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @local_load_barriers
+  tt.func public @local_load_barriers() {
+    // CHECK: tti.experimental_buffer_descriptors
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_set_read_visibility
+    // CHECK: tti.experimental_lock_release
+    ttg.local_load %buf : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @local_load_barriers_cp_async
+  tt.func public @local_load_barriers_cp_async(%ptr: tensor<32x32x!tt.ptr<f16>, #blocked>) {
+    // CHECK: tti.experimental_buffer_descriptors
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %shmem = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 8192 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttg.async_copy_global_to_local %ptr, %shmem : tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
+    // CHECK: ttg.async_copy_global_to_local
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits
+    // CHECK: tt.call @__triton_consan_set_read_visibility
+    // CHECK: tti.experimental_lock_release
+    // CHECK: ttg.local_load
+    ttg.local_load %buf : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @ws_allocation
+  tt.func public @ws_allocation() {
+    // CHECK-DAG: tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1x1xi64,
+    // CHECK-DAG: tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1x1xi64
+    %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
+    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: tt.call @__triton_consan_copy_read_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
+    ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
+    default {
+      // CHECK: tti.experimental_lock_acquire
+      // CHECK: tt.call @__triton_consan_verify_write_visibility
+      // CHECK: tt.call @__triton_consan_set_read_visibility
+      // CHECK: tti.experimental_lock_release
+      ttg.local_load %smem : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16>
+      ttg.warp_yield
+    }
+    partition0(%arg1: !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<1xi64, #shared1, #smem, mutable>) num_warps(4) {
+      // CHECK: partition0
+      // CHECK-DAG: tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1x1xi64,
+      // CHECK-DAG: tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1x1xi64
+      // CHECK: tti.experimental_lock_acquire
+      // CHECK: tt.call @__triton_consan_verify_write_visibility
+      // CHECK: tt.call @__triton_consan_set_read_visibility
+      // CHECK: tti.experimental_lock_release
+      ttg.local_load %arg1 : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16>
+      ttg.warp_return
+    } : (!ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @ws_buf_ptrs_default
+  tt.func public @ws_buf_ptrs_default() {
+    // CHECK-DAG: tti.experimental_buffer_descriptors [0, {{.*}}], [{{.*}}], shared_mem
+    // CHECK-DAG: tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem
+    %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x128x128xf16, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
+    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: tt.call @__triton_consan_copy_read_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
+    ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
+    default {
+      %c0_i32 = arith.constant 0 : i32
+      %1 = ttg.memdesc_index %smem[%c0_i32] : !ttg.memdesc<3x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      ttg.local_load %1 : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16>
+      ttg.warp_yield
+    }
+    partition0(%arg1: !ttg.memdesc<3x128x128xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<1xi64, #shared1, #smem, mutable>) num_warps(4) {
+      ttg.warp_return
+    } : (!ttg.memdesc<3x128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @ws_buf_ptrs_partition0
+  tt.func public @ws_buf_ptrs_partition0() {
+    // CHECK-DAG: tti.experimental_buffer_descriptors [0, {{.*}}], [{{.*}}], shared_mem
+    // CHECK-DAG: tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem
+    %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x128x128xf16, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
+    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: tt.call @__triton_consan_copy_read_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
+    ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
+    default {
+      ttg.warp_yield
+    }
+    partition0(%arg1: !ttg.memdesc<3x128x128xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<1xi64, #shared1, #smem, mutable>) num_warps(4) {
+      %c0_i32 = arith.constant 0 : i32
+      %1 = ttg.memdesc_index %arg1[%c0_i32] : !ttg.memdesc<3x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      ttg.local_load %1 : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16>
+      ttg.warp_return
+    } : (!ttg.memdesc<3x128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 4, perPhase = 4, maxPhase = 4, order = [1, 0]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
+  // CHECK-LABEL: @ws_wait_barrier
+  tt.func public @ws_wait_barrier() {
+    %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
+    default {
+      // CHECK: tti.experimental_lock_acquire
+      // CHECK: tt.call @__triton_consan_set_waiting
+      // CHECK: %[[ACTIVE_MASK:.*]] = arith.constant 5 : i32
+      // CHECK: tt.call @__triton_consan_check_all_active_waiting{{.*}}(%[[ACTIVE_MASK]], {{.*}}, {{.*}}, {{.*}})
+      // CHECK: tti.experimental_lock_release
+      %c0_i32 = arith.constant 0 : i32
+      amdg.wait_barrier %bar, %c0_i32 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+      ttg.warp_yield
+    }
+    partition0(%arg1: !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, %arg2: !ttg.memdesc<1xi64, #shared1, #smem, mutable>) num_warps(4) {
+      // CHECK: partition0
+      // CHECK: tti.experimental_lock_acquire
+      // CHECK: tt.call @__triton_consan_set_waiting
+      // CHECK: %[[ACTIVE_MASK:.*]] = arith.constant 5 : i32
+      // CHECK: tt.call @__triton_consan_check_all_active_waiting{{.*}}(%[[ACTIVE_MASK]], {{.*}}, {{.*}}, {{.*}})
+      // CHECK: tti.experimental_lock_release
+      %c0_i32 = arith.constant 0 : i32
+      amdg.wait_barrier %arg2, %c0_i32 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+      ttg.warp_return
+    } : (!ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @ws_alias_matrix
+  tt.func public @ws_alias_matrix() {
+    // We expect the alias matrix constant to appear once for the default region
+    // and once for partition0 when we lower warp_specialize.
+    // CHECK-DAG: arith.constant dense<true> : tensor<2x2xi1
+    %smem0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
+    %smem1 = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+
+    ttg.warp_specialize(%smem0, %smem1, %bar) attributes {actualRegisters = array<i32: 32, 32>, allocation.offset = 0 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 0>}
+    default {
+      %c0 = arith.constant 0 : i32
+      ttg.local_load %smem0 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
+      ttg.local_load %smem1 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
+      ttg.warp_yield
+    }
+    partition0(%arg0: !ttg.memdesc<32xf32, #shared, #smem, mutable>, %arg1: !ttg.memdesc<32xf32, #shared, #smem, mutable>, %arg2: !ttg.memdesc<1xi64, #shared, #smem, mutable>) num_warps(1) {
+      // CHECK: arith.constant dense<true> : tensor<2x2xi1
+      %c0 = arith.constant 0 : i32
+      ttg.local_load %arg0 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
+      ttg.local_load %arg1 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
+      ttg.warp_return
+    } : (!ttg.memdesc<32xf32, #shared, #smem, mutable>, !ttg.memdesc<32xf32, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>) -> ()
+    tt.return
+  }
+}

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -233,6 +233,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     ttng.barrier_expect %bar, 4096, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tt.call @__triton_consan_init_barrier_state
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK: tt.call @__triton_consan_track_visible_writes
+    // CHECK: tt.call @__triton_consan_track_visible_reads
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
     // CHECK: tt.call @__triton_consan_verify_write_visibility
@@ -241,10 +243,51 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_clear_write_tracking
     // CHECK: tt.call @__triton_consan_clear_read_visibility
     // CHECK: tt.call @__triton_consan_clear_read_tracking
-    // CHECK-NOT: tt.call @__triton_consan_track_visible_writes
-    // CHECK-NOT: tt.call @__triton_consan_track_visible_reads
     // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
     ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %0, %bar, %true : !tt.tensordesc<32x32xf32, #shared>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1], CGALayout = [[0, 0]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: tt.func private @__triton_consan_check_outstanding_commits_noalias{{.*}}T2x1x16xI8
+  // CHECK-SAME: %arg6: i32
+  // CHECK-NOT: tti.experimental_cluster_cta_id
+  // CHECK: tt.splat %arg6 : i32 -> tensor<2x1x16xi32
+  // CHECK: arith.shrui
+  // CHECK-LABEL: @outstanding_commits_multicast_tma_recipients
+  tt.func public @outstanding_commits_multicast_tma_recipients(
+      %desc: !tt.tensordesc<32x32xf32, #shared>,
+      %ptr: tensor<32x32x!tt.ptr<f32>, #blocked>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<2xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<2xi64, #shared1, #smem, mutable>
+    ttng.barrier_expect %bar, 4096, %true : !ttg.memdesc<2xi64, #shared1, #smem, mutable>
+    %cta = tti.experimental_cluster_cta_id : i32
+    %non_issuer_cta = arith.cmpi eq, %cta, %c1_i32 : i32
+    %mask = tt.splat %non_issuer_cta : i1 -> tensor<32x32xi1, #blocked>
+    ttg.async_copy_global_to_local %ptr, %shmem mask %mask : tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
+    ttg.async_commit_group
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: ttg.async_copy_global_to_local
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    // CHECK: ttg.async_commit_group
+    // CHECK: %[[PATTERN:.*]] = arith.constant 3 : i32
+    // CHECK: %[[RECIPIENTS:.*]] = arith.shli %[[PATTERN]],
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}({{.*}}, %[[RECIPIENTS]])
+    // CHECK: ttng.async_tma_copy_global_to_local
+    ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32] %shmem, %bar, %true {multicast} : !tt.tensordesc<32x32xf32, #shared>, !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -298,8 +341,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65552 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @async_tma_copy_global_to_local_two_bufs_two_barriers
-  // CHECK-NOT: tt.call @__triton_consan_track_visible_writes
-  // CHECK-NOT: tt.call @__triton_consan_track_visible_reads
   // CHECK: %[[A_SMEM:.*]] = ttg.local_alloc {allocation.offset = 0 : i32}
   // CHECK: %[[B_SMEM:.*]] = ttg.local_alloc {allocation.offset = 4096 : i32}
   // CHECK: %[[BAR0:.*]] = ttg.local_alloc {allocation.offset = 65536 : i32}
@@ -525,8 +566,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @arrive_barrier
   tt.func public @arrive_barrier(%arg0: !tt.tensordesc<32x32xf32, #shared>) {
-    // CHECK-DAG: %[[BSTATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i32>
-    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1xI32(%[[BSTATE_GLOB]], %c0_i32
+    // CHECK-DAG: %[[BSTATE_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
+    // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1xI64(%[[BSTATE_GLOB]], %c0_i64
     %true = arith.constant true
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
@@ -605,43 +646,43 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %true, %[[TC_BIT]], %[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 4294967296 : i64
     // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
-    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %true, %[[TC_MASK]], %[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[B_I64:.*]] = tti.experimental_memdesc_to_i32 %[[B:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %true, %[[TC_BIT]], %[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 4294967296 : i64
     // CHECK: %[[B_I64:.*]] = tti.experimental_memdesc_to_i32 %[[B]] :
-    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %true, %[[TC_MASK]], %[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %true, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %true, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 4294967296 : i64
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %true, %[[TC_MASK]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_clear_write_tracking{{.*}}%[[ACC_I64]], {{[^,]+}}, %true, %[[TM_BUFS]], %[[TM_WRITE_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_clear_write_tracking{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TM_BUFS]], %[[TM_WRITE_TRACKING_GLOB]]
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %true, %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_clear_read_tracking{{.*}}%[[ACC_I64]], {{[^,]+}}, %true, %[[TM_BUFS]], %[[TM_READ_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_clear_read_tracking{{.*}}%[[ACC_I64]], {{.*}}, %[[TM_BUFS]], %{{[^,]+}}
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR:.*]] :
     // CHECK: tt.call @__triton_consan_track_visible_writes{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[SM_WRITE_VISIBILITY_GLOB]], %[[SM_WRITE_TRACKING_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
-    // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[SM_READ_VISIBILITY_GLOB]], %[[SM_READ_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[SM_READ_VISIBILITY_GLOB]], %{{[^,]+}}
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
     // CHECK: tt.call @__triton_consan_track_visible_writes{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[TM_WRITE_VISIBILITY_GLOB]], %[[TM_WRITE_TRACKING_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
-    // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[TM_READ_VISIBILITY_GLOB]], %[[TM_READ_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[TM_READ_VISIBILITY_GLOB]], %{{[^,]+}}
     // CHECK: ttng.tc_gen5_mma %[[A]], %[[B]], %[[ACC]][], {{.*}}, {{.*}}, %[[BAR]]
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
@@ -680,43 +721,43 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %true, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 4294967296 : i64
     // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
-    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %true, %[[TC_MASK]], %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[B_I64:.*]] = tti.experimental_memdesc_to_i32 %[[B:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %true, %[[TC_BIT]], %[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 4294967296 : i64
     // CHECK: %[[B_I64:.*]] = tti.experimental_memdesc_to_i32 %[[B]] :
-    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %true, %[[TC_MASK]], %[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %true, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %true, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 4294967296 : i64
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %true, %[[TC_MASK]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_clear_write_tracking{{.*}}%[[ACC_I64]], {{[^,]+}}, %true, %[[TM_BUFS]], %[[TM_WRITE_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_clear_write_tracking{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TM_BUFS]], %[[TM_WRITE_TRACKING_GLOB]]
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %true, %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_clear_read_tracking{{.*}}%[[ACC_I64]], {{[^,]+}}, %true, %[[TM_BUFS]], %[[TM_READ_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_clear_read_tracking{{.*}}%[[ACC_I64]], {{.*}}, %[[TM_BUFS]], %{{[^,]+}}
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR:.*]] :
     // CHECK: tt.call @__triton_consan_track_visible_writes{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[SM_WRITE_VISIBILITY_GLOB]], %[[SM_WRITE_TRACKING_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
-    // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[SM_READ_VISIBILITY_GLOB]], %[[SM_READ_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[SM_READ_VISIBILITY_GLOB]], %{{[^,]+}}
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
     // CHECK: tt.call @__triton_consan_track_visible_writes{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[TM_WRITE_VISIBILITY_GLOB]], %[[TM_WRITE_TRACKING_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 32 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
-    // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[TM_READ_VISIBILITY_GLOB]], %[[TM_READ_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[TM_READ_VISIBILITY_GLOB]], %{{[^,]+}}
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
     // CHECK: tti.experimental_lock_release
@@ -760,6 +801,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     ttng.tc_gen5_commit %bar : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttg.local_load %0 : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16, #blocked>
     ttng.tmem_load %result : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf16>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CGALayout = [[0, 0]]>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32, "ttng.two-ctas" = true} {
+  // CHECK-LABEL: @tmem_copy_2cta
+  tt.func public @tmem_copy_2cta() {
+    %src = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #shared, #smem, mutable>
+    %dst = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    // CHECK: arith.constant 3 : i32
+    // CHECK: ttng.tmem_copy
+    ttng.tmem_copy %src, %dst : !ttg.memdesc<128x128xf32, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     tt.return
   }
 }
@@ -828,6 +886,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     ttg.async_copy_global_to_local %ptr, %shmem : tensor<128x128x!tt.ptr<f16>, #blocked> -> <128x128xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @wait_barrier_multi_cta
+  tt.func public @wait_barrier_multi_cta() {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: %[[WAIT_PRED:.*]] = arith.andi %true, %{{.*}} : i1
+    // CHECK-NEXT: tti.experimental_lock_acquire %{{.*}}, %[[WAIT_PRED]]
+    // CHECK: tt.call @__triton_consan_check_all_active_waiting
+    // CHECK-NEXT: tti.experimental_assert_uniform
+    // CHECK-NEXT: tti.experimental_lock_release %{{.*}}, %[[WAIT_PRED]]
+    // CHECK: ttng.wait_barrier
+    // CHECK-NEXT: tti.experimental_lock_acquire %{{.*}}, %[[WAIT_PRED]]
+    // CHECK: tt.call @__triton_consan_clear_waiting
+    // CHECK-NEXT: tti.experimental_lock_release %{{.*}}, %[[WAIT_PRED]]
+    ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -233,44 +233,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16, CGALayout = [[0, 0]]}>
-#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16, CGALayout = [[0, 1]]}>
-#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
-#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, colStride = 1, CGALayout = [[0, 1]]>
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32} {
-  tt.func @tcgen5_completion_barrier_cga_layout(
-      %a: !ttg.memdesc<128x16xf16, #shared, #ttg.shared_memory>,
-      %b: !ttg.memdesc<16x128xf16, #shared1, #ttg.shared_memory>,
-      %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
-      %accUse: i1,
-      %pred: i1,
-      %bar: !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory>,
-      %barPred: i1) {
-    // expected-error @below {{completion barrier cga_layout must be}}
-    ttng.tc_gen5_mma %a, %b, %c, %accUse, %pred, %bar[%barPred] {is_async} :
-       !ttg.memdesc<128x16xf16, #shared, #ttg.shared_memory>,
-       !ttg.memdesc<16x128xf16, #shared1, #ttg.shared_memory>,
-       !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
-       !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory>
-    tt.return
-  }
-}
-
-// -----
-
-#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
-  tt.func @tcgen5_commit_completion_barrier_cga_layout(
-      %bar: !ttg.memdesc<1xi64, #barrier, #smem, mutable>, %pred: i1) {
-    // expected-error @below {{completion barrier cga_layout must be}}
-    ttng.tc_gen5_commit %bar, %pred : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
-    tt.return
-  }
-}
-
-// -----
-
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
 #sharedT = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
@@ -295,22 +257,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
       !ttg.memdesc<128x8xf8E4M3FN, #shared1, #ttg.shared_memory>,
       !ttg.memdesc<64x8xf8E4M3FN, #shared1, #ttg.shared_memory>,
       !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>
-    tt.return
-  }
-}
-
-// -----
-
-#shared_clc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0], [0]]}>
-#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0], [0]]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
-  tt.func @clc_try_cancel_completion_barrier_cga_layout(
-      %result: !ttg.memdesc<2xi64, #shared_clc, #smem>,
-      %mbar: !ttg.memdesc<1xi64, #barrier, #smem>) {
-    // expected-error @below {{completion barrier cga_layout must be}}
-    ttng.clc_try_cancel %result, %mbar {multicast = false} :
-      !ttg.memdesc<2xi64, #shared_clc, #smem>, !ttg.memdesc<1xi64, #barrier, #smem>
     tt.return
   }
 }
@@ -532,6 +478,106 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     %1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared2, #smem, mutable>
     // expected-error @below {{TILED mode does not support offsets}}
     ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] offsets = [%c1_i16] %0, %1, %true : !tt.tensordesc<64x128xf16, #nvmma_128>, !ttg.memdesc<1xi64, #shared2, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma_128, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16, CGALayout = [[0, 0], [0, 0]]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16, CGALayout = [[0, 1], [0, 0]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [0]]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, colStride = 1, CGALayout = [[0, 1], [0, 0]]>
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 8 : i32} {
+  tt.func @tcgen5_completion_barrier_cga_layout(
+      %a: !ttg.memdesc<128x16xf16, #shared, #ttg.shared_memory>,
+      %b: !ttg.memdesc<16x128xf16, #shared1, #ttg.shared_memory>,
+      %c: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %accUse: i1,
+      %pred: i1,
+      %bar: !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory>,
+      %barPred: i1) {
+    // expected-error @below {{completion barrier cga_layout must be}}
+    ttng.tc_gen5_mma %a, %b, %c, %accUse, %pred, %bar[%barPred] {is_async} :
+       !ttg.memdesc<128x16xf16, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<16x128xf16, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory>
+    tt.return
+  }
+}
+
+// -----
+
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @tcgen5_commit_completion_barrier_cga_layout(
+      %bar: !ttg.memdesc<1xi64, #barrier, #smem, mutable>, %pred: i1) {
+    // expected-error @below {{completion barrier cga_layout must be}}
+    ttng.tc_gen5_commit %bar, %pred : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+#sharedT = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @tcgen5_mma_scaled_sync_with_barrier(
+      %a: !ttg.memdesc<128x256xi8, #shared, #ttg.shared_memory>,
+      %b: !ttg.memdesc<256x64xi8, #sharedT, #ttg.shared_memory>,
+      %c: !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %scale_a: !ttg.memdesc<128x8xf8E4M3FN, #shared1, #ttg.shared_memory>,
+      %scale_b: !ttg.memdesc<64x8xf8E4M3FN, #shared1, #ttg.shared_memory>,
+      %useAcc: i1,
+      %pred: i1,
+      %bar: !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>,
+      %barPred: i1) {
+    // expected-error @below {{The op is synchronous but a barrier is present.}}
+    ttng.tc_gen5_mma_scaled %a, %b, %c, %scale_a, %scale_b, %useAcc, %pred lhs = e2m1 rhs = e2m1, %bar[%barPred] :
+      !ttg.memdesc<128x256xi8, #shared, #ttg.shared_memory>,
+      !ttg.memdesc<256x64xi8, #sharedT, #ttg.shared_memory>,
+      !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+      !ttg.memdesc<128x8xf8E4M3FN, #shared1, #ttg.shared_memory>,
+      !ttg.memdesc<64x8xf8E4M3FN, #shared1, #ttg.shared_memory>,
+      !ttg.memdesc<1xi64, #barrier, #ttg.shared_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared_clc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0], [0]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0], [1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @clc_try_cancel_completion_barrier_cga_layout(
+      %result: !ttg.memdesc<2xi64, #shared_clc, #smem>,
+      %mbar: !ttg.memdesc<1xi64, #barrier, #smem>) {
+    // expected-error @below {{completion barrier cga_layout must be}}
+    ttng.clc_try_cancel %result, %mbar {multicast = false} :
+      !ttg.memdesc<2xi64, #shared_clc, #smem>, !ttg.memdesc<1xi64, #barrier, #smem>
+    tt.return
+  }
+}
+
+// -----
+
+#shared_clc_bad = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  tt.func @clc_try_cancel_result_cga_layout_bases_nonzero(
+      %result: !ttg.memdesc<2xi64, #shared_clc_bad, #smem>,
+      %mbar: !ttg.memdesc<1xi64, #barrier, #smem>) {
+    // expected-error @below {{Expected CLC result buffer cga_layout bases to be all zeros. Got [[1]]}}
+    ttng.clc_try_cancel %result, %mbar {multicast = false} :
+      !ttg.memdesc<2xi64, #shared_clc_bad, #smem>, !ttg.memdesc<1xi64, #barrier, #smem>
     tt.return
   }
 }

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -158,6 +158,11 @@ class HIPBackend(BaseBackend):
         return f"hip:{options.arch}"
 
     def parse_options(self, opts) -> Any:
+        # Keep device-side ConSan assertions through LLVM optimization.
+        if "consan" in opts.get("instrumentation_mode", ""):
+            opts["debug"] = True
+            opts["sanitize_overflow"] = False
+
         args = {"arch": knobs.runtime.override_arch or self.target.arch}
 
         if opts.get("num_ctas", 1) > 1 and not amd.supports_multi_cta_launch(self.target.arch):
@@ -444,7 +449,13 @@ class HIPBackend(BaseBackend):
         passes.convert.add_scf_to_cf(pm)
         passes.gluon.add_inliner(pm)
         passes.convert.add_index_to_llvmir(pm)
+        if "consan" in options.instrumentation_mode and is_consan_supported(options.arch):
+            amd.passes.ttgpuir.add_prepare_consan_captures(pm)
         amd.passes.ttgpuir.add_allocate_shared_memory(pm, options.arch)
+        if "consan" in options.instrumentation_mode and is_consan_supported(options.arch):
+            passes.ttgpuir.add_concurrency_sanitizer(pm)
+            passes.gluon.add_canonicalizer(pm)
+            passes.common.add_cse(pm)
         passes.ttgpuir.add_allocate_global_scratch_memory(pm)
         # instrumentation point here so we can override IRs above (e.g., ttir and ttgir)
         if HIPBackend.instrumentation:
@@ -524,20 +535,24 @@ class HIPBackend(BaseBackend):
         amd.set_bool_control_constant(llvm_mod, "__oclc_wavefrontsize64", options.warp_size == 64)
 
         # Set kernel attributes first given this may affect later optimizations.
+        # The kernel is the only non-declaration function with external linkage;
+        # instrumentation helpers (e.g. ConSan) use internal linkage.
         fns = [fn for fn in llvm_mod.get_functions() if not fn.is_declaration()]
-        # The public kernel should be kernel 0.
-        fns[0].set_calling_conv(amd.CALLING_CONV_AMDGPU_KERNEL)
+        kernel_fn = next((fn for fn in fns if fn.is_external_linkage()), None)
+        if not kernel_fn:
+            raise RuntimeError("Could not find kernel function")
+        kernel_fn.set_calling_conv(amd.CALLING_CONV_AMDGPU_KERNEL)
         cluster_dim = metadata["num_ctas"]
-        fns[0].add_fn_attr("amdgpu-cluster-dims", f"{cluster_dim},1,1")
+        kernel_fn.add_fn_attr("amdgpu-cluster-dims", f"{cluster_dim},1,1")
         # warp-specialization mutates num_warps
         total_warps_num = options.num_warps
         total_num_warps = src.get_int_attr("ttg.total-num-warps")
         if total_num_warps is not None:
             total_warps_num = total_num_warps
-        fns[0].add_fn_attr("amdgpu-flat-work-group-size", f"1,{total_warps_num*options.warp_size}")
+        kernel_fn.add_fn_attr("amdgpu-flat-work-group-size", f"1,{total_warps_num*options.warp_size}")
         if "memory-bound-attention" in options.schedule_hint.split(","):
-            fns[0].add_fn_attr("amdgpu-sched-strategy", "iterative-ilp")
-        fns[0].add_fn_attr("uniform-work-group-size", "true")
+            kernel_fn.add_fn_attr("amdgpu-sched-strategy", "iterative-ilp")
+        kernel_fn.add_fn_attr("uniform-work-group-size", "true")
         # LLVM AMDGPU backend supports the attribute "amdgpu-waves-per-eu"="<min>[, <max>]".
         # This attribute may be attached to a kernel function definition and is an optimization hint.
         # <min> parameter specifies the requested minimum number of waves per EU, and optional <max> parameter
@@ -547,17 +562,17 @@ class HIPBackend(BaseBackend):
         # implies the default behavior (no limits).
         # Specifying N, N forces LLVM to focus on a single register count, simplifies some heuristics
         # and may improve scheduling.
-        fns[0].add_fn_attr("amdgpu-waves-per-eu", f"{options.waves_per_eu}, {options.waves_per_eu}")
+        kernel_fn.add_fn_attr("amdgpu-waves-per-eu", f"{options.waves_per_eu}, {options.waves_per_eu}")
         if is_expert_sched_supported(options.arch) and options.num_warps <= 4:
             fns[0].add_fn_attr("amdgpu-sched-strategy", "coexec")
         denormal_mode = "preserve-sign" if options.allow_flush_denorm else "ieee"
-        fns[0].add_fn_attr("denormal-fp-math-f32", denormal_mode)
+        kernel_fn.add_fn_attr("denormal-fp-math-f32", denormal_mode)
         if knobs.compilation.enable_asan:
-            fns[0].add_fn_target_feature("+xnack")
-            fns[0].add_fn_asan_attr()
+            kernel_fn.add_fn_target_feature("+xnack")
+            kernel_fn.add_fn_asan_attr()
         for name, value in options.llvm_fn_attrs:
-            fns[0].remove_fn_attr(name)
-            fns[0].add_fn_attr(name, value)
+            kernel_fn.remove_fn_attr(name)
+            kernel_fn.add_fn_attr(name, value)
 
         # Hint the compiler that we'd like the firmware to set the kernel arguments
         # to user SGPRs so that the kernel does not need to s_load its arguments
@@ -566,7 +581,7 @@ class HIPBackend(BaseBackend):
         # TODO(tyb0807): Disabled when using MIR swap/dump because the value is
         # not serializable to/from MIR YAML
         if not (knobs.amd.swap_mir or knobs.amd.dump_mir):
-            amd.set_all_fn_arg_inreg(fns[0])
+            amd.set_all_fn_arg_inreg(kernel_fn)
 
         if knobs.compilation.enable_asan:
             default_libdir = Path(__file__).parent / "lib"
@@ -590,12 +605,12 @@ class HIPBackend(BaseBackend):
         # optimize_module from calls to @llvm.amdgcn.workgroup.id.x/y/z(). We cannot rely on this because a
         # dispatch dimensions might be used even if there is no program_id() call for it.
         if amd.has_architected_sgprs(options.arch):
-            fns[0].remove_fn_attr("amdgpu-no-workgroup-id-x")
-            fns[0].remove_fn_attr("amdgpu-no-workgroup-id-y")
-            fns[0].remove_fn_attr("amdgpu-no-workgroup-id-z")
+            kernel_fn.remove_fn_attr("amdgpu-no-workgroup-id-x")
+            kernel_fn.remove_fn_attr("amdgpu-no-workgroup-id-y")
+            kernel_fn.remove_fn_attr("amdgpu-no-workgroup-id-z")
 
         if knobs.amd.scalarize_packed_fops:
-            amd.add_scalarize_packed_fops_llvm_pass(fns[0])
+            amd.add_scalarize_packed_fops_llvm_pass(kernel_fn)
 
         # Get some metadata
         metadata["num_warps"] = total_warps_num

--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -545,12 +545,11 @@ static PyObject *createTDMDescriptor(PyObject *self, PyObject *args) {
   uint32_t blockSizeInt[5];
   uint32_t shapeInt[5];
   uint64_t stridesInt64[5];
-  int rank = 0;
 
   blockSizeFast = PySequence_Fast(blockSize, "blockSize must be a sequence");
   if (!blockSizeFast)
     goto cleanup;
-  rank = PySequence_Fast_GET_SIZE(blockSizeFast);
+  int rank = PySequence_Fast_GET_SIZE(blockSizeFast);
   if (rank == 0 || rank > 5) {
     PyErr_SetString(PyExc_RuntimeError, "rank must be between 1 and 5");
     goto cleanup;
@@ -618,17 +617,15 @@ static PyObject *createTDMDescriptor(PyObject *self, PyObject *args) {
   Py_DECREF(stridesFast);
   stridesFast = NULL;
 
-  {
-    bool success = encodeTDMDescriptor(
-        &descObj->desc, elementBitWidth, blockSizeInt, numWarps, padInterval,
-        padAmount, shapeInt, stridesInt64, globalAddress, rank);
-    if (!success) {
-      PyErr_SetString(PyExc_RuntimeError, "Failed to encode TDM descriptor");
-      goto cleanup;
-    }
-
-    return (PyObject *)descObj;
+  bool success = encodeTDMDescriptor(
+      &descObj->desc, elementBitWidth, blockSizeInt, numWarps, padInterval,
+      padAmount, shapeInt, stridesInt64, globalAddress, rank);
+  if (!success) {
+    PyErr_SetString(PyExc_RuntimeError, "Failed to encode TDM descriptor");
+    goto cleanup;
   }
+
+  return (PyObject *)descObj;
 
 cleanup:
   Py_XDECREF(blockSizeFast);
@@ -663,16 +660,11 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps,
     attributes[1].id = hipLaunchAttributeCooperative;
     attributes[1].val.cooperative = launch_cooperative_grid;
 
-    HIP_LAUNCH_CONFIG config = {(unsigned int)(gridX * num_ctas),
-                                (unsigned int)gridY,
-                                (unsigned int)gridZ,
-                                (unsigned int)(warp_size * num_warps),
-                                1,
-                                1,
-                                (unsigned int)shared_memory,
-                                stream,
-                                attributes,
-                                2};
+    HIP_LAUNCH_CONFIG config = {
+        gridX * num_ctas,      gridY,  gridZ,        // Grid size
+        warp_size * num_warps, 1,      1,            // Block size
+        shared_memory,         stream, attributes, 2 // Number of attributes
+    };
     HIP_CHECK(
         hipSymbolTable.hipDrvLaunchKernelEx(&config, function, params, 0));
     return;
@@ -691,7 +683,7 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps,
 static PyObject *data_ptr_str = NULL;
 
 bool extractPointer(void *ptr, PyObject *obj) {
-  hipDeviceptr_t *dev_ptr = (hipDeviceptr_t *)ptr;
+  hipDeviceptr_t *dev_ptr = ptr;
   if (obj == Py_None) {
     *dev_ptr = (hipDeviceptr_t)0; // valid nullptr
     return true;
@@ -854,25 +846,50 @@ typedef enum {
 } ExtractorTypeIndex;
 
 Extractor extraction_map[EXTRACTOR_TYPE_COUNT] = {
-    /* EXTRACTOR_UNKOWN_INDEX   */ {NULL, 0, {NULL}},
-    /* EXTRACTOR_POINTER_INDEX  */
-    {extractPointer, sizeof(hipDeviceptr_t), {NULL}},
-    /* EXTRACTOR_INT8_INDEX     */ {extractI8, sizeof(int8_t), {"i8"}},
-    /* EXTRACTOR_INT16_INDEX    */ {extractI16, sizeof(int16_t), {"i16"}},
-    /* EXTRACTOR_INT32_INDEX    */ {extractI32, sizeof(int32_t), {"i1", "i32"}},
-    /* EXTRACTOR_INT64_INDEX    */ {extractI64, sizeof(int64_t), {"i64"}},
-    /* EXTRACTOR_UINT8_INDEX    */ {extractU8, sizeof(uint8_t), {"u8"}},
-    /* EXTRACTOR_UINT16_INDEX   */ {extractU16, sizeof(uint16_t), {"u16"}},
-    /* EXTRACTOR_UINT32_INDEX   */
-    {extractU32, sizeof(uint32_t), {"u1", "u32"}},
-    /* EXTRACTOR_UINT64_INDEX   */ {extractU64, sizeof(uint64_t), {"u64"}},
-    /* EXTRACTOR_FP16_INDEX     */ {extractFP16, sizeof(uint16_t), {"fp16"}},
-    /* EXTRACTOR_BF16_INDEX     */ {extractBF16, sizeof(uint16_t), {"bf16"}},
-    /* EXTRACTOR_FP32_INDEX     */
-    {extractFP32, sizeof(uint32_t), {"fp32", "f32"}},
-    /* EXTRACTOR_FP64_INDEX     */ {extractFP64, sizeof(uint64_t), {"fp64"}},
-    /* EXTRACTOR_TDMDESC_INDEX  */
-    {extractTDMDescriptor, sizeof(TDMDescriptor), {"tensordesc"}},
+    [EXTRACTOR_UNKOWN_INDEX] =
+        (Extractor){.extract = NULL, .size = 0, .name = NULL},
+    [EXTRACTOR_POINTER_INDEX] = (Extractor){.extract = extractPointer,
+                                            .size = sizeof(hipDeviceptr_t),
+                                            .name = NULL},
+    [EXTRACTOR_INT8_INDEX] = (Extractor){.extract = extractI8,
+                                         .size = sizeof(int8_t),
+                                         .name = {"i8"}},
+    [EXTRACTOR_INT16_INDEX] = (Extractor){.extract = extractI16,
+                                          .size = sizeof(int16_t),
+                                          .name = {"i16"}},
+    [EXTRACTOR_INT32_INDEX] = (Extractor){.extract = extractI32,
+                                          .size = sizeof(int32_t),
+                                          .name = {"i1", "i32"}},
+    [EXTRACTOR_INT64_INDEX] = (Extractor){.extract = extractI64,
+                                          .size = sizeof(int64_t),
+                                          .name = {"i64"}},
+    [EXTRACTOR_UINT8_INDEX] = (Extractor){.extract = extractU8,
+                                          .size = sizeof(uint8_t),
+                                          .name = {"u8"}},
+    [EXTRACTOR_UINT16_INDEX] = (Extractor){.extract = extractU16,
+                                           .size = sizeof(uint16_t),
+                                           .name = {"u16"}},
+    [EXTRACTOR_UINT32_INDEX] = (Extractor){.extract = extractU32,
+                                           .size = sizeof(uint32_t),
+                                           .name = {"u1", "u32"}},
+    [EXTRACTOR_UINT64_INDEX] = (Extractor){.extract = extractU64,
+                                           .size = sizeof(uint64_t),
+                                           .name = {"u64"}},
+    [EXTRACTOR_FP16_INDEX] = (Extractor){.extract = extractFP16,
+                                         .size = sizeof(uint16_t),
+                                         .name = {"fp16"}},
+    [EXTRACTOR_BF16_INDEX] = (Extractor){.extract = extractBF16,
+                                         .size = sizeof(uint16_t),
+                                         .name = {"bf16"}},
+    [EXTRACTOR_FP32_INDEX] = (Extractor){.extract = extractFP32,
+                                         .size = sizeof(uint32_t),
+                                         .name = {"fp32", "f32"}},
+    [EXTRACTOR_FP64_INDEX] = (Extractor){.extract = extractFP64,
+                                         .size = sizeof(uint64_t),
+                                         .name = {"fp64"}},
+    [EXTRACTOR_TDMDESC_INDEX] = (Extractor){.extract = extractTDMDescriptor,
+                                            .size = sizeof(TDMDescriptor),
+                                            .name = {"tensordesc"}},
 };
 
 Extractor getExtractor(uint8_t index) {
@@ -907,9 +924,10 @@ ExtractorTypeIndex getExtractorIndex(PyObject *type) {
   if (type_bytes[0] == '*') {
     return EXTRACTOR_POINTER_INDEX;
   }
-  for (int i = EXTRACTOR_INT8_INDEX; i < EXTRACTOR_TYPE_COUNT; i++) {
-    if (isMatch(type_bytes, (ExtractorTypeIndex)i)) {
-      return (ExtractorTypeIndex)i;
+  for (ExtractorTypeIndex i = EXTRACTOR_INT8_INDEX; i < EXTRACTOR_TYPE_COUNT;
+       i++) {
+    if (isMatch(type_bytes, i)) {
+      return i;
     }
   }
 
@@ -959,28 +977,23 @@ cleanup:
 
 bool extractArgs(PyObject **final_list, int *list_idx, PyObject *kernel_args,
                  PyObject *arg_annotations) {
-  Py_ssize_t num_annotations = 0;
-  PyObject **annotations = NULL;
-  PyObject *fast_args = NULL;
-  PyObject **args = NULL;
-  int arg_idx = 0;
-
   // Extract arg annotations
   PyObject *fast_annotations = PySequence_Fast(
       arg_annotations, "Expected arg_annotations to be a sequence or iterable");
   if (!fast_annotations) {
     goto cleanup;
   }
-  num_annotations = PySequence_Fast_GET_SIZE(fast_annotations);
-  annotations = PySequence_Fast_ITEMS(fast_annotations);
+  Py_ssize_t num_annotations = PySequence_Fast_GET_SIZE(fast_annotations);
+  PyObject **annotations = PySequence_Fast_ITEMS(fast_annotations);
 
-  fast_args = PySequence_Fast(
+  PyObject *fast_args = PySequence_Fast(
       kernel_args, "Expected kernel_args to be a sequence or iterable");
   if (!fast_args) {
     goto cleanup;
   }
-  args = PySequence_Fast_ITEMS(fast_args);
+  PyObject **args = PySequence_Fast_ITEMS(fast_args);
 
+  int arg_idx = 0;
   for (int i = 0; i < num_annotations; ++i) {
     PyKernelArgObject *annotation = (PyKernelArgObject *)annotations[i];
     switch (annotation->type) {
@@ -1034,14 +1047,6 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
   PyObject *arg_annotations = NULL;
   Py_buffer signature;
   PyObject *kernel_args = NULL;
-  uint8_t *extractor_data = NULL;
-  Py_ssize_t num_args = 0;
-  PyObject **args_data = NULL;
-  int list_idx = 0;
-  int num_params = 0;
-  void **params = NULL;
-  int params_idx = 0;
-
   if (!PyArg_ParseTuple(args, "piiiKKOO(iii)OOOiOy*O", &launch_cooperative_grid,
                         &gridX, &gridY, &gridZ, &_stream, &_function,
                         &global_scratch_obj, &profile_scratch_obj, &num_warps,
@@ -1056,21 +1061,23 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
     goto cleanup;
   }
 
-  extractor_data = (uint8_t *)signature.buf;
-  num_args = signature.len;
+  uint8_t *extractor_data = (uint8_t *)signature.buf;
+  Py_ssize_t num_args = signature.len;
 
   // Extract kernel parameters - flatten tuples & remove constexpr.
-  args_data = (PyObject **)alloca(num_args * sizeof(PyObject *));
+  PyObject **args_data = (PyObject **)alloca(num_args * sizeof(PyObject *));
   if (args_data == NULL) {
     goto cleanup;
   }
+  int list_idx = 0;
   if (!extractArgs(args_data, &list_idx, kernel_args, arg_annotations)) {
     goto cleanup;
   }
 
   // Number of parameters passed to kernel. + 2 for global & profile scratch.
-  num_params = num_args + 2;
-  params = (void **)alloca(num_params * sizeof(void *));
+  int num_params = num_args + 2;
+  void **params = (void **)alloca(num_params * sizeof(void *));
+  int params_idx = 0;
   // This loop has to stay in the same function that owns params, since we are
   // using alloca to allocate pointers to it on the stack of the function.
   for (Py_ssize_t i = 0; i < num_args; ++i) {

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -745,7 +745,9 @@ def AsyncCopyLocalToGlobalOp : TT_AMDGPU_Op<"async_copy_local_to_global", [
 //===----------------------------------------------------------------------===//
 // InitBarrierOp
 //===----------------------------------------------------------------------===//
-def InitBarrierOp : TT_AMDGPU_Op<"init_barrier", [MemoryEffects<[MemWrite<SharedMemory>]>]> {
+def InitBarrierOp : TT_AMDGPU_Op<"init_barrier", [
+    MemoryEffects<[MemWrite<SharedMemory>]>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier"]>]> {
   let summary = "Initialize a barrier in the given shared memory allocation.";
   let description = [{
       Initializes a shared memory allocation with mbarrier information.
@@ -783,7 +785,8 @@ def ReadBarrierPhaseOp : TT_AMDGPU_Op<"read_barrier_phase",  [MemoryEffects<[Mem
 
 def AsyncTDMCopyGlobalToLocalOp : TT_AMDGPU_Op<"async_tdm_copy_global_to_local", [AttrSizedOperandSegments,
     DeclareOpInterfaceMethods<TDMOpInterface>,
-    DeclareOpInterfaceMethods<PredicatedOpInterface>]> {
+    DeclareOpInterfaceMethods<PredicatedOpInterface>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface>]> {
   let summary = "Copy data based on descriptor from global memory to local memory asynchronously";
 
   let description = [{
@@ -868,7 +871,8 @@ def AsyncTDMCopyGlobalToLocalOp : TT_AMDGPU_Op<"async_tdm_copy_global_to_local",
 //===----------------------------------------------------------------------===//
 
 def AsyncTDMCopyLocalToGlobalOp : TT_AMDGPU_Op<"async_tdm_copy_local_to_global", [AttrSizedOperandSegments,
-    DeclareOpInterfaceMethods<TDMOpInterface>]> {
+    DeclareOpInterfaceMethods<TDMOpInterface>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface>]> {
   let summary = "Copy data based on descriptor from local memory to global memory asynchronously";
 
   let description = [{
@@ -902,7 +906,8 @@ def AsyncTDMCopyLocalToGlobalOp : TT_AMDGPU_Op<"async_tdm_copy_local_to_global",
 //===----------------------------------------------------------------------===//
 
 def AsyncTDMScatterOp : TT_AMDGPU_Op<"async_tdm_scatter", [
-    DeclareOpInterfaceMethods<TDMOpInterface>]> {
+    DeclareOpInterfaceMethods<TDMOpInterface>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface>]> {
   let summary = "Scatter data from local memory to non-contiguous global memory rows asynchronously";
 
   let description = [{
@@ -944,7 +949,8 @@ def AsyncTDMScatterOp : TT_AMDGPU_Op<"async_tdm_scatter", [
 
 def AsyncTDMGatherOp : TT_AMDGPU_Op<"async_tdm_gather", [
     DeclareOpInterfaceMethods<TDMOpInterface>,
-    DeclareOpInterfaceMethods<PredicatedOpInterface>]> {
+    DeclareOpInterfaceMethods<PredicatedOpInterface>,
+    DeclareOpInterfaceMethods<MBarrierOpInterface>]> {
   let summary = "Gather data from non-contiguous global memory rows to local memory asynchronously";
 
   let description = [{
@@ -1182,7 +1188,8 @@ def MemoryCounterWaitOp : TT_AMDGPU_Op<"memory_counter_wait"> {
 // WaitBarrierOp
 //===----------------------------------------------------------------------===//
 
-def WaitBarrierOp : TT_AMDGPU_Op<"wait_barrier"> {
+def WaitBarrierOp : TT_AMDGPU_Op<"wait_barrier", [
+    DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier"]>]> {
   let summary = "wait until the mbarrier phase completes.";
 
   let description = [{
@@ -1204,7 +1211,8 @@ def WaitBarrierOp : TT_AMDGPU_Op<"wait_barrier"> {
 //===----------------------------------------------------------------------===//
 // ArriveBarrierOp
 //===----------------------------------------------------------------------===//
-def ArriveBarrierOp : TT_AMDGPU_Op<"arrive_barrier"> {
+def ArriveBarrierOp : TT_AMDGPU_Op<"arrive_barrier", [
+    DeclareOpInterfaceMethods<MBarrierOpInterface, ["getBarrier"]>]> {
   let summary = "perform the arrive operation on an mbarrier";
   let description = [{
     Performs the "arrive" operation on an mbarrier object in shared memory. The operation requires a `count` attribute
@@ -1237,7 +1245,8 @@ def ArriveBarrierOp : TT_AMDGPU_Op<"arrive_barrier"> {
 // AsyncCopyMbarrierArriveOp
 //===----------------------------------------------------------------------===//
 
-def AsyncCopyMbarrierArriveOp : TT_AMDGPU_Op<"async_copy_mbarrier_arrive"> {
+def AsyncCopyMbarrierArriveOp : TT_AMDGPU_Op<"async_copy_mbarrier_arrive", [
+    DeclareOpInterfaceMethods<MBarrierOpInterface>]> {
   let summary = "arrive on mbarrier once all previously issued copies are completed";
   let description = [{
     Performs the "async arrive" operation by decrementing pending account by 1 when all previous async load to LDS (particularly, not TDM) have completed.

--- a/third_party/amd/include/TritonAMDGPUToLLVM/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/Passes.td
@@ -117,4 +117,15 @@ def TritonAMDGPUConvertWarpSpecializeToLLVM : Pass<"triton-amdgpu-convert-warp-s
   ];
 }
 
+def PrepareConSanCaptures : Pass<"prepare-consan-captures", "mlir::ModuleOp"> {
+  let summary = "Reserve shared memory for ConSan captures in WarpSpecializeOps";
+  let description = [{
+    Scans the module to estimate how many WarpSpecialize captures the
+    ConcurrencySanitizer pass will add, and sets a
+    `consan.extra_capture_bytes` attribute on each WarpSpecializeOp.
+    The AllocateAMDGPUSharedMemory pass reads this attribute to reserve
+    enough LDS for the expanded capture struct.
+  }];
+}
+
 #endif

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
@@ -11,6 +11,8 @@ namespace mlir {
 #define GEN_PASS_DECL
 #include "TritonAMDGPUTransforms/Passes.h.inc"
 
+void registerConSanAMDHooks();
+
 } // namespace mlir
 
 namespace mlir::triton::amdgpu {

--- a/third_party/amd/lib/Analysis/AMDGPUAllocation.cpp
+++ b/third_party/amd/lib/Analysis/AMDGPUAllocation.cpp
@@ -82,6 +82,11 @@ unsigned AMDAllocationAnalysisScratchSizeFn(Operation *op,
       else
         captureSize += mlir::triton::gpu::getSharedMemorySize(type);
     }
+    // ConSan adds captures after allocation; reserve space pre-computed by
+    // the PrepareConSanCaptures pass.
+    if (auto extra =
+            ws->getAttrOfType<IntegerAttr>("consan.extra_capture_bytes"))
+      captureSize += extra.getInt();
     return captureSize;
   }
 

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -987,12 +987,16 @@ LogicalResult InitBarrierOp::verify() {
   return success();
 }
 
+TypedValue<gpu::MemDescType> InitBarrierOp::getBarrier() { return getAlloc(); }
+
 // -- WaitBarrierOp --
 LogicalResult WaitBarrierOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))
     return failure();
   return success();
 }
+
+TypedValue<gpu::MemDescType> WaitBarrierOp::getBarrier() { return getAlloc(); }
 
 // -- ArriveBarrierOp --
 LogicalResult ArriveBarrierOp::verify() {
@@ -1001,6 +1005,10 @@ LogicalResult ArriveBarrierOp::verify() {
   if (getCount() < 1)
     return emitOpError("count must be greater than or equal to 1");
   return success();
+}
+
+TypedValue<gpu::MemDescType> ArriveBarrierOp::getBarrier() {
+  return getAlloc();
 }
 
 // -- AsyncCopyMbarrierArriveOp --

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(TritonAMDGPUToLLVM
     AtomicRMWOpsEmitter.cpp
     AllocateSharedMemory.cpp
     BarrierOpConversion.cpp
+    PrepareConSanCaptures.cpp
     BufferOpsEmitter.cpp
     OffsetUniformitySplit.cpp
     UniformityAnalysis.cpp
@@ -43,6 +44,7 @@ add_triton_library(TritonAMDGPUToLLVM
     LINK_LIBS PUBLIC
     MLIRReconcileUnrealizedCasts
     TritonGPUToLLVM
+    TritonInstrumentToLLVM
     TritonAMDGPUIR
     TritonAMDAnalysis
     LLVMCore

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/FuncOpToLLVM.cpp
@@ -2,6 +2,7 @@
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 namespace {
 
@@ -29,10 +30,14 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     if (triton::isKernel(funcOp)) {
       newFuncOp.setLinkage(LLVM::Linkage::External);
     } else {
-      // Set attribute `noinline` to prevent inlining.
-      newFuncOp.setPassthroughAttr(
-          ArrayAttr::get(ctx, rewriter.getStringAttr("noinline")));
+      SmallVector<Attribute> passthroughAttrs = {
+          rewriter.getStringAttr("noinline")};
+      if (funcOp->hasAttrOfType<UnitAttr>("always_use_warp_shuffle"))
+        passthroughAttrs.push_back(rewriter.getStringAttr("convergent"));
+      newFuncOp.setPassthroughAttr(ArrayAttr::get(ctx, passthroughAttrs));
       newFuncOp.setLinkage(LLVM::Linkage::Internal);
+      if (Attribute numWarps = funcOp->getAttr(triton::gpu::AttrNumWarpsName))
+        newFuncOp->setAttr("ws_num_warps", numWarps);
     }
 
     rewriter.eraseOp(funcOp);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1284,14 +1284,12 @@ struct AsyncTDMCopyGlobalToLocalOpConversion
     }
 
     SmallVector<Value> desc =
-        unpackLLElements(loc, adaptor.getDesc(), rewriter);
+        mlir::LLVM::AMD::unpackTDMDescriptor(rewriter, loc, adaptor.getDesc());
 
     SmallVector<int64_t> blockShape = llvm::to_vector(tensorDescTy.getShape());
 
-    // 2D tensors: 12 dwords (group0: 4, group1: 8)
-    // 3D-5D tensors: 20 dwords (group0: 4, group1: 8, group2: 4, group3: 4)
-    assert((blockShape.size() <= 2 && desc.size() == 12) ||
-           (blockShape.size() > 2 && desc.size() == 20));
+    assert((blockShape.size() <= 2 && desc.size() == 2) ||
+           (blockShape.size() > 2 && desc.size() == 4));
 
     auto dstMemObj = LLVM::getSharedMemoryObjectFromStruct(
         loc, adaptor.getResult(), elementType, rewriter);
@@ -1314,10 +1312,6 @@ struct AsyncTDMCopyGlobalToLocalOpConversion
 
     auto shapePerCTA =
         triton::gpu::getShapePerCTA(encoding, tensorDescTy.getShape());
-    auto sharedOrder = triton::gpu::getOrder(
-        cast<triton::gpu::SharedEncodingTrait>(encoding), shapePerCTA);
-    bool isRowMajor = sharedOrder[0] == (sharedOrder.size() - 1);
-
     std::optional<uint32_t> warpUsedHint;
     if (auto hintAttr = op.getWarpUsedHintAttr())
       warpUsedHint = static_cast<uint32_t>(hintAttr.getInt());
@@ -1330,7 +1324,7 @@ struct AsyncTDMCopyGlobalToLocalOpConversion
         rewriter, loc, getTypeConverter(), desc, shapePerCTA, numWarps,
         padInterval, padAmount, offset, dstPtrs, op.getPred(), multicastMask,
         elementType, barrierPtr, /*isLoad=*/true, sharedLayout, encoding, ctaId,
-        isRowMajor, auxBits, warpUsedHint);
+        auxBits, warpUsedHint);
 
     rewriter.eraseOp(op);
     return success();
@@ -1362,14 +1356,12 @@ struct AsyncTDMCopyLocalToGlobalOpConversion
     Type elementType = getTypeConverter()->convertType(smemTy.getElementType());
 
     SmallVector<Value> desc =
-        unpackLLElements(loc, adaptor.getDesc(), rewriter);
+        mlir::LLVM::AMD::unpackTDMDescriptor(rewriter, loc, adaptor.getDesc());
 
     SmallVector<int64_t> blockShape = llvm::to_vector(tensorDescTy.getShape());
 
-    // 2D tensors: 12 dwords (group0: 4, group1: 8)
-    // 3D-5D tensors: 20 dwords (group0: 4, group1: 8, group2: 4, group3: 4)
-    assert((blockShape.size() <= 2 && desc.size() == 12) ||
-           (blockShape.size() > 2 && desc.size() == 20));
+    assert((blockShape.size() <= 2 && desc.size() == 2) ||
+           (blockShape.size() > 2 && desc.size() == 4));
 
     auto dstMemObj = LLVM::getSharedMemoryObjectFromStruct(
         loc, adaptor.getSrc(), elementType, rewriter);
@@ -1405,11 +1397,6 @@ struct AsyncTDMCopyLocalToGlobalOpConversion
     auto ctaId = targetInfo.getClusterCTAId(rewriter, loc);
 
     auto shapePerCTA = triton::gpu::getShapePerCTA(smemTy);
-    auto sharedOrder = triton::gpu::getOrder(
-        cast<triton::gpu::SharedEncodingTrait>(smemTy.getEncoding()),
-        shapePerCTA);
-    bool isRowMajor = sharedOrder[0] == (sharedOrder.size() - 1);
-
     auto cacheMod = op.getCache();
     auto auxBits = mlir::LLVM::AMD::getCtrlBitsForCacheModifierOnTarget(
         cacheMod, /*isLoad*/ false, targetInfo);
@@ -1419,7 +1406,7 @@ struct AsyncTDMCopyLocalToGlobalOpConversion
         rewriter, loc, getTypeConverter(), desc, shapePerCTA, numWarps,
         padInterval, padAmount, offset, srcPtrs, pred,
         /*multicastMask=*/{}, elementType, barrierPtr,
-        /*isLoad=*/false, sharedLayout, encoding, ctaId, isRowMajor, auxBits);
+        /*isLoad=*/false, sharedLayout, encoding, ctaId, auxBits);
 
     rewriter.eraseOp(op);
     return success();
@@ -1454,7 +1441,7 @@ struct AsyncTDMScatterOpConversion
     Type elementType = getTypeConverter()->convertType(smemTy.getElementType());
 
     SmallVector<Value> desc =
-        unpackLLElements(loc, adaptor.getDesc(), rewriter);
+        mlir::LLVM::AMD::unpackTDMDescriptor(rewriter, loc, adaptor.getDesc());
 
     SmallVector<int64_t> blockShape = llvm::to_vector(tensorDescTy.getShape());
 
@@ -1556,7 +1543,7 @@ struct AsyncTDMGatherOpConversion
     Type elementType = getTypeConverter()->convertType(smemTy.getElementType());
 
     SmallVector<Value> desc =
-        unpackLLElements(loc, adaptor.getDesc(), rewriter);
+        mlir::LLVM::AMD::unpackTDMDescriptor(rewriter, loc, adaptor.getDesc());
 
     SmallVector<int64_t> blockShape = llvm::to_vector(tensorDescTy.getShape());
 
@@ -2609,7 +2596,7 @@ struct TDMPrefetchConversion
     Type elementType =
         getTypeConverter()->convertType(tdescType.getElementType());
     SmallVector<Value> desc =
-        unpackLLElements(loc, adaptor.getDesc(), rewriter);
+        mlir::LLVM::AMD::unpackTDMDescriptor(rewriter, loc, adaptor.getDesc());
     SmallVector<Value> offset = adaptor.getIndices();
 
     auto mod = op->getParentOfType<ModuleOp>();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/PrepareConSanCaptures.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/PrepareConSanCaptures.cpp
@@ -1,0 +1,60 @@
+#include "Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "TritonAMDGPUToLLVM/Passes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonInstrument/IR/Utility.h"
+
+using namespace mlir;
+
+namespace mlir::triton {
+#define GEN_PASS_DEF_PREPARECONSANCAPTURES
+#include "TritonAMDGPUToLLVM/Passes.h.inc"
+} // namespace mlir::triton
+
+namespace {
+
+namespace ttg = mlir::triton::gpu;
+namespace ttag = mlir::triton::amdgpu;
+namespace tti = mlir::triton::instrument;
+
+// Pre-reserve LDS space for the WarpSpecialize captures that the
+// ConcurrencySanitizer pass will add.
+struct PrepareConSanCaptures
+    : public mlir::triton::impl::PrepareConSanCapturesBase<
+          PrepareConSanCaptures> {
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+
+    bool hasSharedBufs = false;
+    bool hasBarriers = false;
+    bool needsTdm = false;
+    bool needsAsyncCp = false;
+
+    mod.walk([&](Operation *op) {
+      if (isa<ttg::LocalAllocOp>(op))
+        hasSharedBufs = true;
+      if (isa<ttag::InitBarrierOp>(op))
+        hasBarriers = true;
+      if (isa<ttag::AsyncTDMCopyGlobalToLocalOp,
+              ttag::AsyncTDMCopyLocalToGlobalOp, ttag::AsyncTDMWait,
+              ttag::AsyncTDMIntrinsicWait>(op))
+        needsTdm = true;
+      if (isa<ttag::AsyncWaitOp, ttg::AsyncCopyGlobalToLocalOp,
+              ttg::AsyncCommitGroupOp, ttg::AsyncWaitOp>(op))
+        needsAsyncCp = true;
+    });
+
+    int M = hasSharedBufs ? 1 : 0;
+    int K = (needsTdm ? 1 : 0) + (needsAsyncCp ? 1 : 0);
+
+    int totalCaptures = tti::estimateConSanCaptureCount(M, hasBarriers, K);
+    int extraBytes = totalCaptures * tti::kCaptureSizeBytes;
+
+    auto i32Ty = IntegerType::get(mod.getContext(), 32);
+    mod.walk([&](ttg::WarpSpecializeOp ws) {
+      ws->setAttr("consan.extra_capture_bytes",
+                  IntegerAttr::get(i32Ty, extraBytes));
+    });
+  }
+};
+
+} // namespace

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -12,6 +12,7 @@
 #include "../../backend/include/TDMCommon.h"
 
 namespace mlir::LLVM::AMD {
+
 namespace {
 
 Value vecGet(TritonLLVMOpBuilder &b, Value vec, int idx) {
@@ -23,10 +24,10 @@ Value vecSet(TritonLLVMOpBuilder &b, Value vec, int idx, Value val) {
 }
 
 // Helper to decode a value spanning two 32-bit words
-static Value decode48BitValue(RewriterBase &rewriter, TritonLLVMOpBuilder &b,
-                              ArrayRef<Value> group, int startIdx) {
-  Value low = b.lshr(group[startIdx], b.i32_val(16));
-  Value high = b.shl(group[startIdx + 1], b.i32_val(16));
+Value decode48BitValue(RewriterBase &rewriter, TritonLLVMOpBuilder &b,
+                       Value group, int startIdx) {
+  Value low = b.lshr(vecGet(b, group, startIdx), b.i32_val(16));
+  Value high = b.shl(vecGet(b, group, startIdx + 1), b.i32_val(16));
   return b.or_(low, high);
 }
 
@@ -111,6 +112,61 @@ std::pair<SmallVector<unsigned>, unsigned> distributeTDMWarpsAlignToPartition(
   return {warps, numTDMInstructions};
 }
 
+// Shared layout analysis for TDM gather/scatter, used by both
+// getTDMGatherScatterInstrinsicCount (wait-count pass) and
+// emitTDMGatherScatter (lowering) so the instruction-count logic
+// cannot get out of sync.
+//
+// Uses the LinearLayout of the index tensor to determine:
+// 1. Which registers are broadcasted — remove duplicates
+// 2. Which warps are redundant (freeVarMasks)
+// 3. The effective number of indices per warp and max indices per instruction
+// This analysis is direction-agnostic: the index layout determines which warp
+// owns which rows in LDS, regardless of whether data flows to LDS (gather) or
+// from LDS (scatter).
+struct GatherScatterLayoutAnalysis {
+  triton::LinearLayout indexLL; // post-broadcast-removal
+  ColumnAction removeBcastAction;
+  size_t maxIndicesPerInstr;
+  size_t effectiveRegCount;
+  size_t numInstructions;
+  llvm::MapVector<StringAttr, int32_t> freeVarMasks; // from original layout
+};
+
+GatherScatterLayoutAnalysis
+analyzeGatherScatterLayout(RankedTensorType indicesType) {
+  assert(indicesType.getEncoding());
+
+  bool use32BitIndices =
+      indicesType.getElementType().getIntOrFloatBitWidth() == 32;
+  size_t maxIndicesPerInstr = use32BitIndices ? 8 : 16;
+
+  auto indexLL = triton::gpu::toLinearLayout(indicesType);
+  assert(indexLL.getNumOutDims() == 1 &&
+         "Gather/scatter index layout must have exactly one output dimension");
+  auto freeVarMasks = indexLL.getFreeVariableMasks();
+
+  // Remove broadcasted (duplicated) register entries so indexLL has a compact
+  // register dimension containing only unique index values.
+  auto removeBcastAction = actionRemoveBroadcastedRegs(indexLL);
+  if (!removeBcastAction.isIdentity())
+    indexLL = removeBcastAction.apply(indexLL);
+
+  size_t contigIndiceCount = indexLL.getNumConsecutiveInOut();
+  maxIndicesPerInstr = std::min(maxIndicesPerInstr, contigIndiceCount);
+
+  auto kRegister = StringAttr::get(indicesType.getContext(), "register");
+  size_t effectiveRegCount = indexLL.getInDimSize(kRegister);
+  size_t numInstructions =
+      effectiveRegCount == 0
+          ? 0
+          : llvm::divideCeil(effectiveRegCount, maxIndicesPerInstr);
+
+  return {std::move(indexLL), std::move(removeBcastAction),
+          maxIndicesPerInstr, effectiveRegCount,
+          numInstructions,    std::move(freeVarMasks)};
+}
+
 } // namespace
 
 std::pair<SmallVector<unsigned>, unsigned>
@@ -120,19 +176,6 @@ distributeTDMWarpsAlignToPartition(ArrayRef<int64_t> blockShape, int numWarps,
     return distributeTDMWarpsAlignToPartition(blockShape, numWarps,
                                               partitionedEnc);
   return {distributeTDMWarps(blockShape, numWarps), 1};
-}
-
-SmallVector<Value> TDMDescriptor::getAllGroups() const {
-  SmallVector<Value> result;
-  llvm::append_range(result, group0);
-  llvm::append_range(result, group1);
-  if (group2.has_value()) {
-    llvm::append_range(result, group2.value());
-  }
-  if (group3.has_value()) {
-    llvm::append_range(result, group3.value());
-  }
-  return result;
 }
 
 SmallVector<Value> unpackTDMDescriptor(RewriterBase &rewriter, Location loc,
@@ -167,12 +210,6 @@ SmallVector<Value> scalarizeTDMDescriptor(RewriterBase &rewriter, Location loc,
     scalars.append(unpacked.begin(), unpacked.end());
   }
   return scalars;
-}
-
-// Swap the trailing two dimensions of a vector for TDM operations.
-template <typename T> void swapTrailingDims(SmallVector<T> &vec) {
-  assert(vec.size() >= 2 && "need at least 2 dims to swap");
-  std::swap(vec[vec.size() - 2], vec[vec.size() - 1]);
 }
 
 void updateTensorDescriptor(RewriterBase &rewriter, Location loc,
@@ -271,20 +308,21 @@ void updateTensorDescriptor(RewriterBase &rewriter, Location loc,
   }
 }
 
-// Decode a full TDM descriptor from all 4 group vectors for 3D-5D tensors
-// Returns (base, tensorShape[], tensorStride[], blockShape[])
-std::tuple<Value, SmallVector<Value>, SmallVector<Value>, SmallVector<Value>>
+// Decode a full TDM descriptor for 1D-5D tensors.  Returns (base,
+// tensorShape[], tensorStride[]).  `groups` is 2 (1D-2D) or 4 (3D-5D) entries.
+// Block shape is intentionally NOT decoded: every TDM lowering path rewrites
+// tile_dim* against its own warp distribution, so reading them back here
+// would only generate dead IR.
+std::tuple<Value, SmallVector<Value>, SmallVector<Value>>
 decodeTDMDescriptorFull(RewriterBase &rewriter, Location loc,
-                        ArrayRef<Value> group0, ArrayRef<Value> group1,
-                        std::optional<ArrayRef<Value>> group2,
-                        std::optional<ArrayRef<Value>> group3, size_t numDims) {
+                        ArrayRef<Value> groups, size_t numDims) {
   auto ctx = rewriter.getContext();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Type globalPtrTy = ptr_ty(ctx, 1);
 
   // Decode base address from group0
-  Value globalAddrLow = group0[2];
-  Value globalAddrHigh = b.and_(group0[3], b.i32_val(0x7FFFFFFF));
+  Value globalAddrLow = vecGet(b, groups[0], 2);
+  Value globalAddrHigh = b.and_(vecGet(b, groups[0], 3), b.i32_val(0x7FFFFFFF));
   globalAddrLow = b.zext(i64_ty, globalAddrLow);
   globalAddrHigh = b.shl(b.zext(i64_ty, globalAddrHigh), b.i64_val(32));
   Value globalAddr = b.or_(globalAddrLow, globalAddrHigh);
@@ -292,7 +330,6 @@ decodeTDMDescriptorFull(RewriterBase &rewriter, Location loc,
 
   SmallVector<Value> tensorShape(numDims);
   SmallVector<Value> tensorStride(numDims);
-  SmallVector<Value> blockShape(numDims);
 
   // Helper: combine a 32-bit low part and a 16-bit high part into an i64.
   auto combine48 = [&](Value lo32, Value hi16InDword) -> Value {
@@ -302,19 +339,20 @@ decodeTDMDescriptorFull(RewriterBase &rewriter, Location loc,
   };
 
   // Decode dimensions from the end (inner dimensions first)
-  tensorShape[numDims - 1] = decode48BitValue(rewriter, b, group1, 1);
+  tensorShape[numDims - 1] = decode48BitValue(rewriter, b, groups[1], 1);
 
   if (numDims >= 2) {
-    tensorShape[numDims - 2] = decode48BitValue(rewriter, b, group1, 2);
+    tensorShape[numDims - 2] = decode48BitValue(rewriter, b, groups[1], 2);
 
     // tensor_dim0_stride: group1[5][0:32] | group1[6][0:16] (48 bits)
-    tensorStride[numDims - 2] = combine48(group1[5], group1[6]);
+    tensorStride[numDims - 2] =
+        combine48(vecGet(b, groups[1], 5), vecGet(b, groups[1], 6));
 
     // tensor_dim1_stride: group1[6][16:32] | group1[7][0:32] (48 bits)
     if (numDims >= 3) {
-      Value stride1Low =
-          b.and_(b.lshr(group1[6], b.i32_val(16)), b.i32_val(0xFFFF));
-      Value stride1High = group1[7];
+      Value stride1Low = b.and_(b.lshr(vecGet(b, groups[1], 6), b.i32_val(16)),
+                                b.i32_val(0xFFFF));
+      Value stride1High = vecGet(b, groups[1], 7);
       tensorStride[numDims - 3] =
           b.or_(b.zext(i64_ty, stride1Low),
                 b.shl(b.zext(i64_ty, stride1High), b.i64_val(16)));
@@ -324,75 +362,51 @@ decodeTDMDescriptorFull(RewriterBase &rewriter, Location loc,
   // tensor_dim2_stride: group2[2][0:32] | group2[3][0:16] (48 bits)
   if (numDims >= 4) {
     tensorStride[numDims - 4] =
-        combine48(group2.value()[2], group2.value()[3]);
+        combine48(vecGet(b, groups[2], 2), vecGet(b, groups[2], 3));
   }
 
   // tensor_dim3_stride: group3[0][0:32] | group3[1][0:16] (48 bits)
   if (numDims == 5) {
     tensorStride[numDims - 5] =
-        combine48(group3.value()[0], group3.value()[1]);
+        combine48(vecGet(b, groups[3], 0), vecGet(b, groups[3], 1));
   }
 
   // The innermost dimension always has stride 1
   tensorStride[numDims - 1] = b.i64_val(1);
 
-  // Block shapes from group1
-  blockShape[numDims - 1] =
-      b.and_(b.lshr(group1[3], b.i32_val(16)), b.i32_val(0xFFFF));
-  if (numDims >= 2) {
-    blockShape[numDims - 2] = b.and_(group1[4], b.i32_val(0xFFFF));
-  }
-
   // 3rd dimension from group2 if present
   if (numDims >= 3) {
-    tensorShape[numDims - 3] = group2.value()[0];
-    blockShape[numDims - 3] =
-        b.and_(b.lshr(group1[4], b.i32_val(16)), b.i32_val(0xFFFF));
+    tensorShape[numDims - 3] = vecGet(b, groups[2], 0);
   }
 
   // 4th dimension from group2/group3 if present
   if (numDims >= 4) {
-    tensorShape[numDims - 4] = group2.value()[1];
-    blockShape[numDims - 4] =
-        b.and_(b.lshr(group2.value()[3], b.i32_val(16)), b.i32_val(0xFFFF));
+    tensorShape[numDims - 4] = vecGet(b, groups[2], 1);
   }
 
   // 5th dimension from group3 if present
   if (numDims == 5) {
     // tensor_dim4 is encoded across group3[1] and group3[2]
-    Value tensorDim4Low =
-        b.and_(b.lshr(group3.value()[1], b.i32_val(16)), b.i32_val(0xFFFF));
-    Value tensorDim4High = b.and_(group3.value()[2], b.i32_val(0xFFFF));
+    Value tensorDim4Low = b.and_(b.lshr(vecGet(b, groups[3], 1), b.i32_val(16)),
+                                 b.i32_val(0xFFFF));
+    Value tensorDim4High = b.and_(vecGet(b, groups[3], 2), b.i32_val(0xFFFF));
     tensorShape[0] = b.or_(tensorDim4Low, b.shl(tensorDim4High, b.i32_val(16)));
-
-    blockShape[0] =
-        b.and_(b.lshr(group3.value()[2], b.i32_val(16)), b.i32_val(0xFFFF));
   }
 
-  return {srcPtr, tensorShape, tensorStride, blockShape};
+  return {srcPtr, tensorShape, tensorStride};
 }
 
-TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
-                                  const LLVMTypeConverter *typeConverter,
-                                  Type elementType,
-                                  SmallVector<int64_t> blockShape, int numWarps,
-                                  unsigned padInterval, unsigned padAmount,
-                                  SmallVector<Value> tensorShape,
-                                  SmallVector<Value> tensorStride, Value srcPtr,
-                                  bool isRowMajor, Attribute sharedEncoding) {
-  size_t numDims = tensorShape.size();
-  assert(numDims >= 1 && numDims <= 5 && tensorStride.size() == numDims &&
+SmallVector<Value> createTDMDescriptor(RewriterBase &rewriter, Location loc,
+                                       const LLVMTypeConverter *typeConverter,
+                                       Type elementType, size_t numDims,
+                                       unsigned padInterval, unsigned padAmount,
+                                       SmallVector<Value> tensorShape,
+                                       SmallVector<Value> tensorStride,
+                                       Value srcPtr) {
+  assert(numDims >= 1 && numDims <= 5 && tensorShape.size() == numDims &&
+         tensorStride.size() == numDims &&
          "TDM only supported for 1D-5D tensors.");
-  assert(blockShape.size() == tensorStride.size() &&
-         blockShape.size() == numDims &&
-         "Block/tensor/stride dim count must all be equal.");
   auto b = TritonLLVMOpBuilder(loc, rewriter);
-
-  if (!isRowMajor) {
-    swapTrailingDims(blockShape);
-    swapTrailingDims(tensorStride);
-    swapTrailingDims(tensorShape);
-  }
 
   // Define common values for better readability
   Value v16 = b.i32_val(16);
@@ -413,23 +427,10 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
         b.and_(b.trunc(i32_ty, b.lshr(s, b.i64_val(32))), b.i32_val(0xFFFF));
   }
 
-  // Compute per-warp tile dimensions for the TDM descriptor.
-  // With partitioned layouts, the warp distribution is adjusted so each warp's
-  // chunk stays within a single partition piece.  When multi-instr is needed,
-  // the effective extent along partitionDim is the slice extent
-  // (warps * pieceSize), not the full block extent.
-  {
-    auto [warpsPerCTA, numInstr] = distributeTDMWarpsAlignToPartition(
-        blockShape, numWarps, sharedEncoding);
-    if (auto partitionedEnc =
-            dyn_cast<PartitionedSharedEncodingAttr>(sharedEncoding);
-        partitionedEnc && numInstr > 1)
-      blockShape[partitionedEnc.getPartitionDim()] /= numInstr;
-
-    for (size_t i = 0; i < numDims; ++i) {
-      blockShape[i] = llvm::divideCeil(blockShape[i], warpsPerCTA[i]);
-    }
-  }
+  // This base descriptor records only tensor metadata.  Per-op hardware fields
+  // (pred, LDS address, barrier, tile_dim*) are materialized by
+  // fillTDMDescriptor / fillTDMDescriptorForGatherScatter, where the
+  // destination, predicate, and warp distribution are known.
 
   // group0 (128 bits / 4 dwords) effective bit encoding:
   // [1:0]:     pred (to be filled later)
@@ -439,11 +440,14 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
   // [120:64]:  global address
   // [127:126]: type - currently always set to 0x2
   // NOTE: Currently only scatter is implemented; gather (load) is TODO.
-  SmallVector<Value> group0(4, b.i32_val(0));
+  auto v4i32Ty = VectorType::get(4, i32_ty);
+  auto v8i32Ty = VectorType::get(8, i32_ty);
+  Value group0 = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
   Value globalAddr = b.ptrtoint(i64_ty, srcPtr);
-  group0[2] = b.trunc(i32_ty, globalAddr);
-  group0[3] = b.trunc(i32_ty, b.lshr(globalAddr, v32));
-  group0[3] = b.or_(group0[3], b.i32_val(1 << 31));
+  group0 = vecSet(b, group0, 2, b.trunc(i32_ty, globalAddr));
+  Value g0_3 = b.trunc(i32_ty, b.lshr(globalAddr, v32));
+  g0_3 = b.or_(g0_3, b.i32_val(1 << 31));
+  group0 = vecSet(b, group0, 3, g0_3);
 
   /* group1 bit-field definition:
 
@@ -487,7 +491,7 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
      7       0           32        tensor_dim1_stride(high-16-bit)
      ================================================================
   */
-  SmallVector<Value> group1(8, b.i32_val(0));
+  Value group1 = LLVM::ZeroOp::create(rewriter, loc, v8i32Ty);
   int32_t dataSize = log2(elementSizeInBytes);
   unsigned dwordSize = 32;
   auto padIntervalBits = padInterval * elementBitWidth;
@@ -495,37 +499,35 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
          "padInterval must be a multiple of dwordSize(32bit)");
   auto padIntervalInDwords = padIntervalBits / dwordSize;
   auto padAmountInDwords = padAmount * elementBitWidth / dwordSize;
-  group1[0] = b.or_(group1[0], b.i32_val(dataSize << 16));
+  Value g1_0 = b.i32_val(dataSize << 16);
   if (padIntervalInDwords > 0 && padAmountInDwords > 0) {
     assert(llvm::isPowerOf2_32(padIntervalInDwords));
     int32_t log2PadIntervalDwords = log2(padIntervalInDwords);
     assert(log2PadIntervalDwords <= 8 && "padInterval too large");
-    group1[0] = b.or_(group1[0], b.i32_val(1 << 20));
-    group1[0] = b.or_(group1[0], b.i32_val((log2PadIntervalDwords - 1) << 22));
-    group1[0] = b.or_(group1[0], b.i32_val((padAmountInDwords - 1) << 25));
+    g1_0 = b.or_(g1_0, b.i32_val(1 << 20));
+    g1_0 = b.or_(g1_0, b.i32_val((log2PadIntervalDwords - 1) << 22));
+    g1_0 = b.or_(g1_0, b.i32_val((padAmountInDwords - 1) << 25));
   }
+  group1 = vecSet(b, group1, 0, g1_0);
   // Encode 32-bit tensor shapes
-  group1[1] = b.shl(tensorShape[numDims - 1], v16);
-  group1[2] = b.lshr(tensorShape[numDims - 1], v16);
+  group1 = vecSet(b, group1, 1, b.shl(tensorShape[numDims - 1], v16));
+  Value g1_2 = b.lshr(tensorShape[numDims - 1], v16);
 
+  Value g1_3 = b.i32_val(0);
   if (numDims >= 2) {
-    group1[2] = b.or_(group1[2], b.shl(tensorShape[numDims - 2], v16));
-    group1[3] = b.lshr(tensorShape[numDims - 2], v16);
+    g1_2 = b.or_(g1_2, b.shl(tensorShape[numDims - 2], v16));
+    g1_3 = b.lshr(tensorShape[numDims - 2], v16);
   }
+  group1 = vecSet(b, group1, 2, g1_2);
 
-  // Block shapes
-  group1[3] = b.or_(group1[3], b.i32_val(blockShape[numDims - 1] << 16));
-  if (numDims >= 2) {
-    group1[4] = b.i32_val(blockShape[numDims - 2] & 0xFFFF);
-  }
-  // tile_dim2 (upper 16 bits of group1[4])
-  if (numDims >= 3) {
-    group1[4] = b.or_(group1[4], b.i32_val(blockShape[numDims - 3] << 16));
-  }
+  // tile_dim0/1/2 (group1[3]<31:16>, group1[4]) are intentionally left as
+  // zero here and filled in by fillTDMDescriptor / fillTDMDescriptorForGather
+  // Scatter, which know the per-op warp distribution.
+  group1 = vecSet(b, group1, 3, g1_3);
 
   // Handle strides (each slot is 48 bits: low-32 + high-16).
   if (numDims >= 2) {
-    group1[5] = tensorStrideLo32[numDims - 2];
+    group1 = vecSet(b, group1, 5, tensorStrideLo32[numDims - 2]);
     Value g1_6 = tensorStrideHi16[numDims - 2];
     if (numDims >= 3) {
       g1_6 = b.or_(
@@ -534,13 +536,13 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
       Value stride1Hi32 =
           b.or_(b.lshr(tensorStrideLo32[numDims - 3], v16),
                 b.shl(tensorStrideHi16[numDims - 3], b.i32_val(16)));
-      group1[7] = stride1Hi32;
+      group1 = vecSet(b, group1, 7, stride1Hi32);
     }
-    group1[6] = g1_6;
+    group1 = vecSet(b, group1, 6, g1_6);
   }
 
   if (numDims <= 2) {
-    return TDMDescriptor{group0, group1, std::nullopt, std::nullopt};
+    return {group0, group1};
   }
 
   /* For 3D-5D tensors, fill group2 and group3
@@ -588,20 +590,21 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
           3    0         32        row_index_3
     ================================================================
   */
-  SmallVector<Value> group2(4, b.i32_val(0));
+  Value group2 = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
   if (numDims >= 3) {
     // tensor_dim2 (3rd dimension from the end)
-    group2[0] = tensorShape[numDims - 3];
+    group2 = vecSet(b, group2, 0, tensorShape[numDims - 3]);
 
     // tensor_dim3 (4th dimension from the end)
     if (numDims >= 4) {
-      group2[1] = tensorShape[numDims - 4];
+      group2 = vecSet(b, group2, 1, tensorShape[numDims - 4]);
       // tensor_dim2_stride: group2[2][0:32] | group2[3][0:16] (48 bits)
-      group2[2] = tensorStrideLo32[numDims - 4];
-      Value g2_3 = b.or_(tensorStrideHi16[numDims - 4],
-                         b.shl(b.i32_val(blockShape[numDims - 4]), v16));
-      group2[3] = g2_3;
+      group2 = vecSet(b, group2, 2, tensorStrideLo32[numDims - 4]);
+      group2 = vecSet(b, group2, 3, tensorStrideHi16[numDims - 4]);
     }
+
+    // tile_dim3 (upper 16 bits of group2[3]) is filled in later by the
+    // per-op descriptor filler.
   }
 
   /* group3 bit-field definition
@@ -643,73 +646,44 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
           3    0         32        row_index_7
     ================================================================
   */
-  SmallVector<Value> group3(4, b.i32_val(0));
-  if (numDims >= 4) {
-
-    // tensor_dim4 (5th dimension from the end) (32 bits starting at bit 48:
-    // upper 16 bits of group3[1] and lower 16 bits of group3[2])
-    if (numDims == 5) {
-      // group3[1] = tensor_dim3_stride high-16 | (tensor_dim4 low-16 << 16)
-      group3[1] = b.or_(tensorStrideHi16[numDims - 5],
-                        b.shl(tensorShape[numDims - 5], v16));
-      // Upper 16 bits go into lower 16 bits of group3[2]
-      group3[2] = b.or_(group3[2], b.lshr(tensorShape[numDims - 5], v16));
-    }
-
-    // tile_dim4 (16 bits starting at bit 80: upper 16 bits of group3[2])
-    if (numDims == 5) {
-      // tensor_dim3_stride (4th dimension from the end) (48 bits split across
-      // group3[0] and lower 16 bits of group3[1])
-      group3[0] = tensorStrideLo32[numDims - 5];
-      group3[2] =
-          b.or_(group3[2], b.shl(b.i32_val(blockShape[numDims - 5]), v16));
-    }
+  Value group3 = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
+  if (numDims == 5) {
+    // tensor_dim3_stride (4th dimension from the end) — 48 bits split across
+    // group3[0] (low 32) and the lower 16 bits of group3[1] (high 16).
+    group3 = vecSet(b, group3, 0, tensorStrideLo32[numDims - 5]);
+    // group3[1] = stride_hi16 | (tensor_dim4_lo16 << 16)
+    Value g3_1 = b.or_(tensorStrideHi16[numDims - 5],
+                       b.shl(tensorShape[numDims - 5], v16));
+    group3 = vecSet(b, group3, 1, g3_1);
+    // Lower 16 of group3[2] is the high half of tensor_dim4; upper 16
+    // (tile_dim4) is filled later by the per-op descriptor filler.
+    group3 = vecSet(b, group3, 2, b.lshr(tensorShape[numDims - 5], v16));
   }
 
-  return TDMDescriptor{group0, group1, group2, group3};
+  return {group0, group1, group2, group3};
 }
 
-// Returns a copy of `layout` where the semantics of dimA and dimB are
-// exchanged: new.apply(x)[dimA] == old.apply(x)[dimB] and vice versa. The
-// output dimension order is preserved.
-static triton::LinearLayout
-swapOutDimSemantics(const triton::LinearLayout &layout, StringAttr dimA,
-                    StringAttr dimB) {
-  assert(layout.hasOutDim(dimA));
-  assert(layout.hasOutDim(dimB));
-  SmallVector<std::pair<StringAttr, int32_t>> renamedOutDims;
-  for (auto [name, size] : layout.getOutDims()) {
-    if (name == dimA)
-      renamedOutDims.push_back({dimB, size});
-    else if (name == dimB)
-      renamedOutDims.push_back({dimA, size});
-    else
-      renamedOutDims.push_back({name, size});
-  }
-  // Transpose to restore the original output dimension order.
-  return triton::LinearLayout(layout.getBases(), renamedOutDims,
-                              /*requireSurjective=*/false)
-      .transposeOuts(llvm::to_vector(layout.getOutDimNames()));
-}
-
-// Fill TDM descriptor for regular load/store operations (1D-5D tensors)
-void fillTDMDescriptor(
-    RewriterBase &rewriter, Location loc,
-    const LLVMTypeConverter *typeConverter, Type elementType,
-    SmallVector<int64_t> shapePerCTA, int numWarps, unsigned padInterval,
-    unsigned padAmount, SmallVector<Value> &group0, SmallVector<Value> &group1,
-    std::optional<std::reference_wrapper<SmallVector<Value>>> group2,
-    std::optional<std::reference_wrapper<SmallVector<Value>>> group3,
-    SmallVector<Value> offset, ArrayRef<Value> dstPtrs, Value pred,
-    Value multicastMask, Value barrierPtr,
-    const triton::LinearLayout &sharedLayout, Value ctaId, bool isStore,
-    bool isRowMajor, ArrayRef<unsigned> warpsPerCTA,
-    std::optional<uint32_t> warpUsedHint) {
+// Fill a TDM descriptor for regular load/store (1D-5D).  With `warpUsedHint`
+// (axis-aligned, see TritonAMDGPUOps.td), tile_dim* are re-encoded against
+// K-based `warpsPerCTA` and `warpId` is XOR-anchored by `lsb(hint)`; without
+// a hint, basis defaults to {0..log2K-1}.
+void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
+                       const LLVMTypeConverter *typeConverter, Type elementType,
+                       SmallVector<int64_t> shapePerCTA, int numWarps,
+                       unsigned padInterval, unsigned padAmount,
+                       MutableArrayRef<Value> groups, SmallVector<Value> offset,
+                       ArrayRef<Value> dstPtrs, Value pred, Value multicastMask,
+                       Value barrierPtr,
+                       const triton::LinearLayout &sharedLayout, Value ctaId,
+                       bool isStore, ArrayRef<unsigned> warpsPerCTA,
+                       std::optional<uint32_t> warpUsedHint) {
   size_t numDims = offset.size();
   assert(numDims >= 1 && numDims <= 5 && "TDM supports 1D to 5D tensors.");
   assert(!dstPtrs.empty() && "dstPtrs cannot be empty");
   assert(warpsPerCTA.size() == numDims &&
          "warpsPerCTA must have one entry per tensor dim");
+  assert((numDims <= 2 ? groups.size() == 2 : groups.size() == 4) &&
+         "groups must hold 2 (1D-2D) or 4 (3D-5D) vector entries");
 
   auto ctx = rewriter.getContext();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -717,39 +691,15 @@ void fillTDMDescriptor(
   Type globalPtrTy = ptr_ty(ctx, 1);
   Type sharedPtrTy = ptr_ty(ctx, 3);
 
-  // For col-major tensors the TDM descriptor was created with the trailing two
-  // dimensions swapped. Swap shapePerCTA and offset to match that hardware
-  // view, and rename the same two dims in the shared layout to align out dims.
-  std::optional<triton::LinearLayout> adjustedSharedLayout;
-  if (!isRowMajor) {
-    swapTrailingDims(shapePerCTA);
-    swapTrailingDims(offset);
-    if (numDims >= 2) {
-      auto dimN_2 = StringAttr::get(ctx, "dim" + std::to_string(numDims - 2));
-      auto dimN_1 = StringAttr::get(ctx, "dim" + std::to_string(numDims - 1));
-      adjustedSharedLayout = swapOutDimSemantics(sharedLayout, dimN_2, dimN_1);
-    }
-  }
-  const auto &tdmViewSharedLayout =
-      adjustedSharedLayout ? *adjustedSharedLayout : sharedLayout;
+  // Tile dimensions are owned by this filler (computed below from
+  // shapePerCTA / warpsPerCTA), so the decoder skips them.
+  auto [srcPtr, tensorShape, tensorStride] =
+      decodeTDMDescriptorFull(rewriter, loc, groups, numDims);
 
-  // Decode the full TDM descriptor to get all values
-  auto [srcPtr, tensorShape, tensorStride, decodedBlockShape] =
-      decodeTDMDescriptorFull(
-          rewriter, loc, group0, group1,
-          group2.has_value()
-              ? std::optional<ArrayRef<Value>>(group2.value().get())
-              : std::nullopt,
-          group3.has_value()
-              ? std::optional<ArrayRef<Value>>(group3.value().get())
-              : std::nullopt,
-          numDims);
-
+  // Per-warp tile shape; smaller-K hints scale this up so CTA coverage holds.
   SmallVector<int64_t> tileShape(numDims);
-  for (size_t i = 0; i < numDims; ++i) {
+  for (size_t i = 0; i < numDims; ++i)
     tileShape[i] = shapePerCTA[i] / static_cast<int64_t>(warpsPerCTA[i]);
-    decodedBlockShape[i] = b.i32_val(tileShape[i]);
-  }
 
   auto kMessage = str_attr("message");
   auto kWarp = str_attr("warp");
@@ -758,7 +708,7 @@ void fillTDMDescriptor(
   auto kPartition = str_attr("partition");
 
   auto cgaLayout = triton::gpu::SharedLinearEncodingAttr::get(
-                       ctx, tdmViewSharedLayout, /*layoutAlignment=*/16)
+                       ctx, sharedLayout, /*layoutAlignment=*/16)
                        .getCGALayout()
                        .getLinearLayout();
 
@@ -767,11 +717,13 @@ void fillTDMDescriptor(
 
   auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
 
+  // XOR warpId by i0 = lsb(hint) so the smallest active warp gets tile
+  // offset 0; the rest follow via the warp sublayout.
   Value warpIdShifted = warpId;
   if (warpUsedHint) {
-    uint32_t firstActiveWarp = llvm::countr_zero(*warpUsedHint);
-    if (firstActiveWarp != 0)
-      warpIdShifted = b.xor_(warpId, b.i32_val(firstActiveWarp));
+    uint32_t i0 = llvm::countr_zero(*warpUsedHint);
+    if (i0 != 0)
+      warpIdShifted = b.xor_(warpId, b.i32_val(i0));
   }
 
   auto warpOffset = applyLinearLayout(
@@ -787,12 +739,12 @@ void fillTDMDescriptor(
 
   Value baseOffset = b.i64_val(0);
   for (size_t i = 0; i < numDims; ++i) {
-    Value dimOffset = b.mul(b.sext(i64_ty, offset[i]), tensorStride[i]);
+    Value dimOffset = b.mul(b.zext(i64_ty, offset[i]), tensorStride[i]);
     baseOffset = b.add(baseOffset, dimOffset);
   }
   srcPtr = b.gep(globalPtrTy, elementType, srcPtr, baseOffset);
 
-  auto tdmToShared = tdmLayout.invertAndCompose(tdmViewSharedLayout);
+  auto tdmToShared = tdmLayout.invertAndCompose(sharedLayout);
   auto sharedOffsets = applyLinearLayout(
       loc, rewriter, tdmToShared,
       {{kMessage, b.i32_val(0)}, {kWarp, warpIdShifted}, {kBlock, ctaId}});
@@ -835,17 +787,8 @@ void fillTDMDescriptor(
   dstPtr = b.gep(sharedPtrTy, elementType, dstPtr, dstOffset);
 
   // Update tensor shapes based on offset
-  Value zero = b.i32_val(0);
   for (size_t i = 0; i < numDims; ++i) {
-    // Clamp in this specific way to avoid suboptimal codegen by LLVM.
-    // In some cases, LLVM InstCombine match and fold patterns into instructions
-    // that only have VALU target instructions. Thus extra v_readfirstlane_b32
-    // instructions are emitted to copy the value to sgpr after VALU
-    // instructions.
-    Value diff = b.sub(tensorShape[i], offset[i]);
-    Value clamped = b.smax(diff, zero);
-    Value isNeg = b.icmp_slt(offset[i], zero);
-    tensorShape[i] = b.select(isNeg, zero, clamped);
+    tensorShape[i] = b.smax(b.i32_val(0), b.sub(tensorShape[i], offset[i]));
   }
 
   // TDM store does not support padding in general. However, if the padding
@@ -859,105 +802,109 @@ void fillTDMDescriptor(
   // This leverages HW OOB checking to skip padding elements while
   // preserving the original tensor shape if smaller. Note that the pre
   // conditions are checked in the verifier already
+  int64_t encodedTileDim0 = tileShape[numDims - 1];
   if (isStore && padInterval > 0 && padAmount > 0) {
-    Value originalTileDim0 = decodedBlockShape[numDims - 1];
-
-    // Adjust block shape (tile dimension) to include padding
-    decodedBlockShape[numDims - 1] =
-        b.add(originalTileDim0, b.i32_val(padAmount));
+    int64_t originalTileDim0 = tileShape[numDims - 1];
+    encodedTileDim0 = originalTileDim0 + padAmount;
 
     // Adjust tensor dimension to be min(tensor_dim0, original_tile_dim0)
-    Value cmp = b.icmp_ult(tensorShape[numDims - 1], originalTileDim0);
+    Value origTileVal = b.i32_val(originalTileDim0);
+    Value cmp = b.icmp_ult(tensorShape[numDims - 1], origTileVal);
     tensorShape[numDims - 1] =
-        b.select(cmp, tensorShape[numDims - 1], originalTileDim0);
+        b.select(cmp, tensorShape[numDims - 1], origTileVal);
   }
 
   // Update group0 with addresses
   Value globalAddr = b.ptrtoint(i64_ty, srcPtr);
   Value ldsAddr = b.ptrtoint(i32_ty, dstPtr);
 
-  int32_t warpFreeMask = tdmLayout.getFreeVariableMasks().lookup(kWarp);
-  if (warpFreeMask != 0) {
-    Value isActive = b.icmp_eq(
-        b.and_(warpIdShifted, b.i32_val(warpFreeMask)), b.i32_val(0));
-    Value layoutPred = b.select(isActive, b.i32_val(1), b.i32_val(0));
-    pred = b.and_(pred, layoutPred);
+  // Predicate off redundant warps: `((warpId ^ i0) & warpFreeMask) == 0`.
+  // `warpFreeMask` covers positions NOT in basisBits (or, without a hint,
+  // bits above log2(K)).
+  {
+    auto freeMasks = tdmLayout.getFreeVariableMasks();
+    int32_t warpFreeMask = freeMasks.lookup(kWarp);
+    if (warpFreeMask != 0) {
+      Value isActive = b.icmp_eq(b.and_(warpIdShifted, b.i32_val(warpFreeMask)),
+                                 b.i32_val(0));
+      Value layoutPred = b.select(isActive, b.i32_val(1), b.i32_val(0));
+      pred = b.and_(pred, layoutPred);
+    }
   }
-
-  group0[0] = pred;
-  group0[1] = ldsAddr;
-  group0[2] = b.trunc(i32_ty, globalAddr);
-  group0[3] = b.and_(group0[3], b.i32_val(1 << 31));
-  group0[3] =
-      b.or_(group0[3], b.trunc(i32_ty, b.lshr(globalAddr, b.i64_val(32))));
+  Value &group0 = groups[0];
+  Value &group1 = groups[1];
+  group0 = vecSet(b, group0, 0, pred);
+  group0 = vecSet(b, group0, 1, ldsAddr);
+  group0 = vecSet(b, group0, 2, b.trunc(i32_ty, globalAddr));
+  Value g0_3 = b.and_(vecGet(b, group0, 3), b.i32_val(1 << 31));
+  g0_3 = b.or_(g0_3, b.trunc(i32_ty, b.lshr(globalAddr, b.i64_val(32))));
+  group0 = vecSet(b, group0, 3, g0_3);
 
   // Update group1 with tensor shapes
+  Value g1_0 = vecGet(b, group1, 0);
   if (multicastMask)
-    group1[0] = b.or_(group1[0], multicastMask);
-  group1[1] = b.shl(tensorShape[numDims - 1], b.i32_val(16));
-  group1[2] = b.lshr(tensorShape[numDims - 1], b.i32_val(16));
+    g1_0 = b.or_(g1_0, multicastMask);
+  group1 = vecSet(b, group1, 1, b.shl(tensorShape[numDims - 1], b.i32_val(16)));
+  Value g1_2 = b.lshr(tensorShape[numDims - 1], b.i32_val(16));
+  Value g1_3 = vecGet(b, group1, 3);
 
   if (numDims >= 2) {
-    group1[2] =
-        b.or_(group1[2], b.shl(tensorShape[numDims - 2], b.i32_val(16)));
-    group1[3] = b.and_(group1[3], b.i32_val(0xFFFF << 16));
-    group1[3] =
-        b.or_(group1[3], b.lshr(tensorShape[numDims - 2], b.i32_val(16)));
+    g1_2 = b.or_(g1_2, b.shl(tensorShape[numDims - 2], b.i32_val(16)));
+    g1_3 = b.and_(g1_3, b.i32_val(0xFFFF << 16));
+    g1_3 = b.or_(g1_3, b.lshr(tensorShape[numDims - 2], b.i32_val(16)));
   }
+  group1 = vecSet(b, group1, 2, g1_2);
 
   // Configure barrier
+  Value g1_1 = vecGet(b, group1, 1);
   if (barrierPtr) {
-    group1[0] = b.or_(group1[0], b.shl(b.i32_val(1), b.i32_val(18)));
-    group1[1] = b.or_(
-        group1[1], b.and_(b.lshr(b.ptrtoint(i32_ty, barrierPtr), b.i32_val(3)),
-                          b.i32_val(0x00FFFF)));
+    g1_0 = b.or_(g1_0, b.shl(b.i32_val(1), b.i32_val(18)));
+    g1_1 =
+        b.or_(g1_1, b.and_(b.lshr(b.ptrtoint(i32_ty, barrierPtr), b.i32_val(3)),
+                           b.i32_val(0x00FFFF)));
   } else {
-    group1[0] = b.and_(group1[0], b.i32_val(0xFFFBFFFF));
+    g1_0 = b.and_(g1_0, b.i32_val(0xFFFBFFFF));
   }
+  group1 = vecSet(b, group1, 0, g1_0);
+  group1 = vecSet(b, group1, 1, g1_1);
 
-  // Re-encode tile_dim0..4 against the selected warp distribution.
-  group1[3] = b.and_(group1[3], b.i32_val(0xFFFF));
-  group1[3] =
-      b.or_(group1[3], b.shl(decodedBlockShape[numDims - 1], b.i32_val(16)));
+  // Re-encode tile_dim0..4 against the caller's `warpsPerCTA`
+  // (createTDMDescriptor assumed all numWarps).  Bit positions match the
+  // chart in createTDMDescriptor:
+  //   tile_dim0 -> group1[3]<31:16>, tile_dim1/2 -> group1[4]<15:0>/<31:16>,
+  //   tile_dim3 -> group2[3]<31:16>, tile_dim4 -> group3[2]<31:16>
+  g1_3 = b.and_(g1_3, b.i32_val(0xFFFF));
+  g1_3 = b.or_(g1_3, b.i32_val(encodedTileDim0 << 16));
+  group1 = vecSet(b, group1, 3, g1_3);
   if (numDims >= 2) {
-    group1[4] = decodedBlockShape[numDims - 2];
+    Value g1_4 = b.i32_val(tileShape[numDims - 2] & 0xFFFF);
     if (numDims >= 3)
-      group1[4] =
-          b.or_(group1[4], b.shl(decodedBlockShape[numDims - 3], b.i32_val(16)));
+      g1_4 = b.or_(g1_4, b.i32_val(tileShape[numDims - 3] << 16));
+    group1 = vecSet(b, group1, 4, g1_4);
   }
   if (numDims >= 4) {
-    group2.value().get()[3] =
-        b.and_(group2.value().get()[3], b.i32_val(0xFFFF));
-    group2.value().get()[3] =
-        b.or_(group2.value().get()[3],
-              b.shl(decodedBlockShape[numDims - 4], b.i32_val(16)));
+    Value g2_3 = b.and_(vecGet(b, groups[2], 3), b.i32_val(0xFFFF));
+    g2_3 = b.or_(g2_3, b.i32_val(tileShape[numDims - 4] << 16));
+    groups[2] = vecSet(b, groups[2], 3, g2_3);
   }
   if (numDims == 5) {
-    group3.value().get()[2] =
-        b.and_(group3.value().get()[2], b.i32_val(0xFFFF));
-    group3.value().get()[2] =
-        b.or_(group3.value().get()[2],
-              b.shl(decodedBlockShape[numDims - 5], b.i32_val(16)));
+    Value g3_2 = b.and_(vecGet(b, groups[3], 2), b.i32_val(0xFFFF));
+    g3_2 = b.or_(g3_2, b.i32_val(tileShape[numDims - 5] << 16));
+    groups[3] = vecSet(b, groups[3], 2, g3_2);
   }
 
   // Update group2/group3 for higher dimensions
-  if (numDims >= 3) {
-    group2.value().get()[0] = tensorShape[numDims - 3];
-  }
-
-  if (numDims >= 4) {
-    group2.value().get()[1] = tensorShape[numDims - 4];
-  }
-
+  if (numDims >= 3)
+    groups[2] = vecSet(b, groups[2], 0, tensorShape[numDims - 3]);
+  if (numDims >= 4)
+    groups[2] = vecSet(b, groups[2], 1, tensorShape[numDims - 4]);
   if (numDims == 5) {
-    group3.value().get()[1] =
-        b.and_(group3.value().get()[1], b.i32_val(0xFFFF));
-    group3.value().get()[1] =
-        b.or_(group3.value().get()[1], b.shl(tensorShape[0], b.i32_val(16)));
-    group3.value().get()[2] =
-        b.and_(group3.value().get()[2], b.i32_val(0xFFFF << 16));
-    group3.value().get()[2] =
-        b.or_(group3.value().get()[2], b.lshr(tensorShape[0], b.i32_val(16)));
+    Value g3_1 = b.and_(vecGet(b, groups[3], 1), b.i32_val(0xFFFF));
+    g3_1 = b.or_(g3_1, b.shl(tensorShape[0], b.i32_val(16)));
+    groups[3] = vecSet(b, groups[3], 1, g3_1);
+    Value g3_2 = b.and_(vecGet(b, groups[3], 2), b.i32_val(0xFFFF << 16));
+    g3_2 = b.or_(g3_2, b.lshr(tensorShape[0], b.i32_val(16)));
+    groups[3] = vecSet(b, groups[3], 2, g3_2);
   }
 }
 
@@ -968,10 +915,9 @@ void fillTDMDescriptorForGatherScatter(
     RewriterBase &rewriter, Location loc,
     const LLVMTypeConverter *typeConverter, Type elementType,
     SmallVector<int64_t> blockShape, unsigned padInterval, unsigned padAmount,
-    SmallVector<Value> &group0, SmallVector<Value> &group1,
-    SmallVector<Value> &group2, SmallVector<Value> &group3, Value ldsRowOffset,
-    Value globalColOffset, Value ldsPtr, Value pred, Value barrierPtr,
-    const triton::LinearLayout &cgaLayout, Value ctaId,
+    Value &group0, Value &group1, Value &group2, Value &group3,
+    Value ldsRowOffset, Value globalColOffset, Value ldsPtr, Value pred,
+    Value barrierPtr, const triton::LinearLayout &cgaLayout, Value ctaId,
     ArrayRef<Value> rowIndices, bool use32BitIndices, bool isGather) {
   assert(!rowIndices.empty() && "Gather/scatter requires row indices.");
 
@@ -981,10 +927,10 @@ void fillTDMDescriptorForGatherScatter(
   Type globalPtrTy = ptr_ty(ctx, 1);
   Type sharedPtrTy = ptr_ty(ctx, 3);
 
-  // Decode descriptor to get tensor info
-  auto [globalPtr, tensorShape, tensorStride, decodedBlockShape] =
-      decodeTDMDescriptorFull(rewriter, loc, group0, group1, group2, group3,
-                              /*numDims=*/2);
+  // Decode descriptor to get tensor info (only group0/1 used for 2D).
+  Value descGroups[2] = {group0, group1};
+  auto [globalPtr, tensorShape, tensorStride] =
+      decodeTDMDescriptorFull(rewriter, loc, descGroups, /*numDims=*/2);
 
   // Apply CTA column offset to the base pointer.
   // Row positions are specified by rowIndices, so only column offset applies.
@@ -1016,18 +962,7 @@ void fillTDMDescriptorForGatherScatter(
 
   // Adjust column tensor shape for OOB handling - subtract column offset to
   // get remaining elements.
-  {
-    // Clamp in this specific way to avoid suboptimal codegen by LLVM.
-    // In some cases, LLVM InstCombine match and fold patterns into instructions
-    // that only have VALU target instructions. Thus extra v_readfirstlane_b32
-    // instructions are emitted to copy the value to sgpr after VALU
-    // instructions.
-    Value zero = b.i32_val(0);
-    Value diff = b.sub(tensorShape[1], globalColOffset);
-    Value clamped = b.smax(diff, zero);
-    Value isNeg = b.icmp_slt(globalColOffset, zero);
-    tensorShape[1] = b.select(isNeg, zero, clamped);
-  }
+  tensorShape[1] = b.smax(b.i32_val(0), b.sub(tensorShape[1], globalColOffset));
 
   // For scatter with padding (store-from-LDS): clamp tensor_dim0 to the
   // original column width so OOB checking drops padding elements before they
@@ -1050,41 +985,49 @@ void fillTDMDescriptorForGatherScatter(
     predWithGatherScatter = b.or_(predWithGatherScatter, b.i32_val(1 << 30));
   }
 
-  group0[0] = predWithGatherScatter;
-  group0[1] = ldsAddr;
-  group0[2] = b.trunc(i32_ty, globalAddr);
+  group0 = vecSet(b, group0, 0, predWithGatherScatter);
+  group0 = vecSet(b, group0, 1, ldsAddr);
+  group0 = vecSet(b, group0, 2, b.trunc(i32_ty, globalAddr));
 
   // group0[3]: preserve type bits, set global_addr upper 25 bits
   Value globalAddrHigh = b.trunc(i32_ty, b.lshr(globalAddr, b.i64_val(32)));
   globalAddrHigh = b.and_(globalAddrHigh, b.i32_val(0x01FFFFFF));
-  Value typeBits = b.and_(group0[3], b.i32_val(0xC0000000));
-  group0[3] = b.or_(typeBits, globalAddrHigh);
+  Value typeBits = b.and_(vecGet(b, group0, 3), b.i32_val(0xC0000000));
+  group0 = vecSet(b, group0, 3, b.or_(typeBits, globalAddrHigh));
 
   // Update group1 with adjusted tensor shapes for proper OOB handling
-  group1[1] = b.shl(tensorShape[1], b.i32_val(16));
-  group1[2] = b.lshr(tensorShape[1], b.i32_val(16));
-  group1[2] = b.or_(group1[2], b.shl(tensorShape[0], b.i32_val(16)));
-  group1[3] = b.and_(group1[3], b.i32_val(0xFFFF << 16));
-  group1[3] = b.or_(group1[3], b.lshr(tensorShape[0], b.i32_val(16)));
+  group1 = vecSet(b, group1, 1, b.shl(tensorShape[1], b.i32_val(16)));
+  Value g1_2 = b.lshr(tensorShape[1], b.i32_val(16));
+  g1_2 = b.or_(g1_2, b.shl(tensorShape[0], b.i32_val(16)));
+  group1 = vecSet(b, group1, 2, g1_2);
+  Value g1_3 = b.and_(vecGet(b, group1, 3), b.i32_val(0xFFFF << 16));
+  g1_3 = b.or_(g1_3, b.lshr(tensorShape[0], b.i32_val(16)));
+  group1 = vecSet(b, group1, 3, g1_3);
 
   // Configure barrier
+  Value g1_0 = vecGet(b, group1, 0);
+  Value g1_1 = vecGet(b, group1, 1);
   if (barrierPtr) {
-    group1[0] = b.or_(group1[0], b.shl(b.i32_val(1), b.i32_val(18)));
-    group1[1] = b.or_(
-        group1[1], b.and_(b.lshr(b.ptrtoint(i32_ty, barrierPtr), b.i32_val(3)),
-                          b.i32_val(0x00FFFF)));
+    g1_0 = b.or_(g1_0, b.shl(b.i32_val(1), b.i32_val(18)));
+    g1_1 =
+        b.or_(g1_1, b.and_(b.lshr(b.ptrtoint(i32_ty, barrierPtr), b.i32_val(3)),
+                           b.i32_val(0x00FFFF)));
   } else {
-    group1[0] = b.and_(group1[0], b.i32_val(0xFFFBFFFF));
+    g1_0 = b.and_(g1_0, b.i32_val(0xFFFBFFFF));
   }
+  group1 = vecSet(b, group1, 0, g1_0);
+  group1 = vecSet(b, group1, 1, g1_1);
 
   // Set tile_dim1 (number of valid indices) in lower 16 bits of group1[4]
   size_t numIndices = rowIndices.size();
-  group1[4] = b.and_(group1[4], b.i32_val(0xFFFF0000));
-  group1[4] = b.or_(group1[4], b.i32_val(numIndices & 0xFFFF));
+  Value g1_4 = b.and_(vecGet(b, group1, 4), b.i32_val(0xFFFF0000));
+  g1_4 = b.or_(g1_4, b.i32_val(numIndices & 0xFFFF));
+  group1 = vecSet(b, group1, 4, g1_4);
 
-  // Fix tile_dim0 for gather/scatter: createTDMDescriptor divides the column
-  // dimension across warps for regular load/store, but gather and scatter use
-  // row indices and need the full undivided column width.
+  // Encode tile_dim0 for gather/scatter as the full undivided column width:
+  // gather/scatter is row-indexed across all warps, so each TDM instruction
+  // covers the full row.  createTDMDescriptor leaves the upper 16 bits of
+  // group1[3] zero, so a plain OR is sufficient.
   if (blockShape.size() >= 2) {
     int64_t tileDim0 = blockShape.back();
 
@@ -1093,23 +1036,24 @@ void fillTDMDescriptorForGatherScatter(
     if (!isGather && padInterval > 0 && padAmount > 0)
       tileDim0 += padAmount;
 
-    group1[3] = b.and_(group1[3], b.i32_val(0xFFFF));
-    group1[3] = b.or_(group1[3], b.i32_val(tileDim0 << 16));
+    Value g1_3_gs = b.and_(vecGet(b, group1, 3), b.i32_val(0xFFFF));
+    g1_3_gs = b.or_(g1_3_gs, b.i32_val(tileDim0 << 16));
+    group1 = vecSet(b, group1, 3, g1_3_gs);
   }
 
   // Fill group2 and group3 with row indices
   if (use32BitIndices) {
     // 32-bit indices: 4 in group2, 4 in group3
     for (size_t i = 0; i < 4 && i < numIndices; ++i) {
-      group2[i] = rowIndices[i];
+      group2 = vecSet(b, group2, i, rowIndices[i]);
     }
     for (size_t i = 4; i < 8 && i < numIndices; ++i) {
-      group3[i - 4] = rowIndices[i];
+      group3 = vecSet(b, group3, i - 4, rowIndices[i]);
     }
   } else {
     // 16-bit indices: pack 2 per dword
     // Indices are i16, so zero-extend to i32 before packing
-    auto packIndices = [&](MutableArrayRef<Value> group, size_t baseIdx) {
+    auto packIndices = [&](Value &group, size_t baseIdx) {
       for (size_t i = 0; i < 4; ++i) {
         Value dword = b.i32_val(0);
         size_t idx0 = baseIdx + i * 2;
@@ -1125,13 +1069,15 @@ void fillTDMDescriptorForGatherScatter(
           dword = b.or_(
               dword, b.shl(b.and_(idx1_i32, b.i32_val(0xFFFF)), b.i32_val(16)));
         }
-        group[i] = dword;
+        group = vecSet(b, group, i, dword);
       }
     };
     packIndices(group2, 0);
     packIndices(group3, 8);
   }
 }
+
+namespace {
 
 // Compute how many elements each partition buffer advances between consecutive
 // TDM instruction slices, accounting for padding if present.
@@ -1140,7 +1086,7 @@ void fillTDMDescriptorForGatherScatter(
 // instructions, each instruction writes a "slice" of data into each partition
 // buffer.  We need to know the padded size of that slice so the next
 // instruction can offset its LDS pointer correctly.
-static int64_t computePerPartitionSliceStride(
+int64_t computePerPartitionSliceStride(
     ArrayRef<int64_t> blockShape, unsigned partitionDim,
     int64_t sliceExtentPerPartition, unsigned numPartitions,
     triton::gpu::PartitionedSharedEncodingAttr partitionedEnc) {
@@ -1171,67 +1117,41 @@ static int64_t computePerPartitionSliceStride(
 
 // Emit a single TDM intrinsic (load or store) for the given block shape.
 // This handles both the 2D (d2 intrinsic) and >2D (full intrinsic) cases.
-static void emitTDMIntrinsic(
-    RewriterBase &rewriter, Location loc,
-    const LLVMTypeConverter *typeConverter, ArrayRef<Value> desc,
-    size_t numDims, Type elementType, SmallVector<int64_t> effectiveBlockShape,
-    int numWarps, unsigned padInterval, unsigned padAmount,
-    SmallVector<Value> globalOffset, ArrayRef<Value> instrDstPtrs, Value pred,
-    Value multicastMask, Value barrier,
-    const triton::LinearLayout &instrSharedLayout, Value ctaId, bool isLoad,
-    bool isRowMajor, ArrayRef<unsigned> warpsPerCTA, int32_t auxBits,
-    std::optional<uint32_t> warpUsedHint = std::nullopt) {
+void emitTDMIntrinsic(RewriterBase &rewriter, Location loc,
+                      const LLVMTypeConverter *typeConverter,
+                      ArrayRef<Value> desc, size_t numDims, Type elementType,
+                      SmallVector<int64_t> effectiveBlockShape, int numWarps,
+                      unsigned padInterval, unsigned padAmount,
+                      SmallVector<Value> globalOffset,
+                      ArrayRef<Value> instrDstPtrs, Value pred,
+                      Value multicastMask, Value barrier,
+                      const triton::LinearLayout &instrSharedLayout,
+                      Value ctaId, bool isLoad, ArrayRef<unsigned> warpsPerCTA,
+                      int32_t auxBits,
+                      std::optional<uint32_t> warpUsedHint = std::nullopt) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto v4i32Ty = VectorType::get(4, rewriter.getI32Type());
   auto v8i32Ty = VectorType::get(8, rewriter.getI32Type());
-  Value group4Zero = LLVM::ZeroOp::create(rewriter, loc, v8i32Ty);
 
-  if (numDims > 2) {
-    auto group0Vec = SmallVector<Value>(desc.begin(), desc.begin() + 4);
-    auto group1Vec = SmallVector<Value>(desc.begin() + 4, desc.begin() + 12);
-    auto group2Vec = SmallVector<Value>(desc.begin() + 12, desc.begin() + 16);
-    auto group3Vec = SmallVector<Value>(desc.begin() + 16, desc.end());
+  SmallVector<Value, 4> groups(desc.begin(),
+                               desc.begin() + (numDims > 2 ? 4 : 2));
+  fillTDMDescriptor(rewriter, loc, typeConverter, elementType,
+                    effectiveBlockShape, numWarps, padInterval, padAmount,
+                    groups, globalOffset, instrDstPtrs, pred, multicastMask,
+                    barrier, instrSharedLayout, ctaId, !isLoad, warpsPerCTA,
+                    warpUsedHint);
 
-    fillTDMDescriptor(rewriter, loc, typeConverter, elementType,
-                      effectiveBlockShape, numWarps, padInterval, padAmount,
-                      group0Vec, group1Vec, std::ref(group2Vec),
-                      std::ref(group3Vec), globalOffset, instrDstPtrs, pred,
-                      multicastMask, barrier, instrSharedLayout, ctaId, !isLoad,
-                      isRowMajor, warpsPerCTA, warpUsedHint);
-
-    auto group0 = packLLVector(loc, group0Vec, rewriter);
-    auto group1 = packLLVector(loc, group1Vec, rewriter);
-    auto group2 = packLLVector(loc, group2Vec, rewriter);
-    auto group3 = packLLVector(loc, group3Vec, rewriter);
-
-    const char *intrinsicName = isLoad ? "llvm.amdgcn.tensor.load.to.lds"
-                                       : "llvm.amdgcn.tensor.store.from.lds";
-    LLVM::createLLVMIntrinsicCallOp(
-        rewriter, loc, intrinsicName, {},
-        {group0, group1, group2, group3, group4Zero, b.i32_val(auxBits)});
-  } else {
-    auto group0Vec = SmallVector<Value>(desc.begin(), desc.begin() + 4);
-    auto group1Vec = SmallVector<Value>(desc.begin() + 4, desc.end());
-
-    fillTDMDescriptor(
-        rewriter, loc, typeConverter, elementType, effectiveBlockShape,
-        numWarps, padInterval, padAmount, group0Vec, group1Vec, std::nullopt,
-        std::nullopt, globalOffset, instrDstPtrs, pred, multicastMask, barrier,
-        instrSharedLayout, ctaId, !isLoad, isRowMajor, warpsPerCTA,
-        warpUsedHint);
-
-    auto group0 = packLLVector(loc, group0Vec, rewriter);
-    auto group1 = packLLVector(loc, group1Vec, rewriter);
-    auto v4i32Ty = VectorType::get(4, rewriter.getI32Type());
-    Value group2Zero = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
-    Value group3Zero = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
-
-    const char *intrinsicName = isLoad ? "llvm.amdgcn.tensor.load.to.lds"
-                                       : "llvm.amdgcn.tensor.store.from.lds";
-    LLVM::createLLVMIntrinsicCallOp(rewriter, loc, intrinsicName, {},
-                                    {group0, group1, group2Zero, group3Zero,
-                                     group4Zero, b.i32_val(auxBits)});
-  }
+  // Pad to 4 vector groups (intrinsic always takes 4 group operands).
+  while (groups.size() < 4)
+    groups.push_back(LLVM::ZeroOp::create(rewriter, loc, v4i32Ty));
+  groups.push_back(LLVM::ZeroOp::create(rewriter, loc, v8i32Ty)); // group4
+  groups.push_back(b.i32_val(auxBits));
+  const char *intrinsicName = isLoad ? "llvm.amdgcn.tensor.load.to.lds"
+                                     : "llvm.amdgcn.tensor.store.from.lds";
+  LLVM::createLLVMIntrinsicCallOp(rewriter, loc, intrinsicName, {}, groups);
 }
+
+} // namespace
 
 // Emit TDM load/store, potentially split into multiple instructions for
 // partitioned shared memory.
@@ -1249,8 +1169,7 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
                       Value pred, Value multicastMask, Type elementType,
                       Value barrierPtr, bool isLoad,
                       const triton::LinearLayout &sharedLayout,
-                      Attribute encoding, Value ctaId, bool isRowMajor,
-                      int32_t auxBits,
+                      Attribute encoding, Value ctaId, int32_t auxBits,
                       std::optional<uint32_t> warpUsedHint) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   size_t numDims = blockShape.size();
@@ -1258,9 +1177,12 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
 
   auto partitionedEnc = dyn_cast<PartitionedSharedEncodingAttr>(encoding);
 
+  // With a hint, derive the distribution from K = popcount(hint) instead
+  // of numWarps; verifier guarantees single-instruction emission (incl.
+  // partitioned encodings).  Inactive warps become HW no-ops via
+  // fillTDMDescriptor's free-variable-mask predication (XOR-anchored at i0).
   int effectiveWarps = warpUsedHint ? llvm::popcount(*warpUsedHint) : numWarps;
 
-  // Compute warp distribution -- partition-aligned when needed.
   auto [warpsPerCTA, numTDMInstructions] =
       distributeTDMWarpsAlignToPartition(blockShape, effectiveWarps, encoding);
   assert((!warpUsedHint || numTDMInstructions == 1) &&
@@ -1272,8 +1194,8 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
     emitTDMIntrinsic(rewriter, loc, typeConverter, desc, numDims, elementType,
                      to_vector(blockShape), numWarps, padInterval, padAmount,
                      to_vector(offset), dstPtrs, pred, multicastMask,
-                     barrierPtr, sharedLayout, ctaId, isLoad, isRowMajor,
-                     warpsPerCTA, auxBits, warpUsedHint);
+                     barrierPtr, sharedLayout, ctaId, isLoad, warpsPerCTA,
+                     auxBits, warpUsedHint);
     return;
   }
 
@@ -1337,21 +1259,17 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
     emitTDMIntrinsic(rewriter, loc, typeConverter, desc, numDims, elementType,
                      effectiveBlockShape, numWarps, padInterval, padAmount,
                      globalOffset, instrDstPtrs, pred, multicastMask, barrier,
-                     sliceLayout, ctaId, isLoad, isRowMajor, warpsPerCTA,
-                     auxBits);
+                     sliceLayout, ctaId, isLoad, warpsPerCTA, auxBits);
   }
 }
 
-// Emit a TDM gather or scatter operation for non-contiguous row access.
-size_t getTDMGatherScatterInstrinsicCount(size_t numIndices,
-                                          bool use32BitIndices) {
-  if (numIndices == 0)
-    return 0;
-
-  // Determine max indices per instruction based on index size
-  size_t maxIndicesPerInstr = use32BitIndices ? 8 : 16;
-
-  return llvm::divideCeil(numIndices, maxIndicesPerInstr);
+size_t getTDMGatherScatterInstrinsicCount(RankedTensorType indicesType) {
+  if (!indicesType.getEncoding()) {
+    size_t maxIndicesPerInstr =
+        indicesType.getElementType().getIntOrFloatBitWidth() == 32 ? 8 : 16;
+    return llvm::divideCeil(indicesType.getNumElements(), maxIndicesPerInstr);
+  }
+  return analyzeGatherScatterLayout(indicesType).numInstructions;
 }
 
 void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
@@ -1371,32 +1289,19 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
 
   bool use32BitIndices =
       indicesType.getElementType().getIntOrFloatBitWidth() == 32;
-  size_t maxIndicesPerInstr = use32BitIndices ? 8 : 16;
 
-  // Use LinearLayout to determine:
-  // 1. Which registers are broadcasted — remove duplicates
-  // 2. Which warps are redundant — zero the pred to make instruction a no-op
-  // 3. Per-batch LDS row offset — via applyLinearLayout per batch
-  // This analysis is direction-agnostic: the index layout determines which warp
-  // owns which rows in LDS, regardless of whether data flows to LDS (gather) or
-  // from LDS (scatter).
-  auto indexLL = triton::gpu::toLinearLayout(indicesType);
-  assert(indexLL.getNumOutDims() == 1 &&
-         "Gather/scatter index layout must have exactly one output dimension");
-  auto freeVarMasks = indexLL.getFreeVariableMasks();
+  auto analysis = analyzeGatherScatterLayout(indicesType);
+  auto &indexLL = analysis.indexLL;
+  size_t maxIndicesPerInstr = analysis.maxIndicesPerInstr;
 
   auto kRegister = rewriter.getStringAttr("register");
   auto kLane = rewriter.getStringAttr("lane");
   auto kWarp = rewriter.getStringAttr("warp");
 
-  // Remove broadcasted (duplicated) register entries. After this, indexLL
-  // has a compact register dimension and effectiveRowIndices contains only
-  // unique index values.
+  // Apply broadcast removal to the actual row indices.
   SmallVector<Value> effectiveRowIndices(rowIndices.begin(), rowIndices.end());
-  auto removeBcast = actionRemoveBroadcastedRegs(indexLL);
-  if (!removeBcast.isIdentity()) {
-    indexLL = removeBcast.apply(indexLL);
-    effectiveRowIndices = removeBcast.apply(
+  if (!analysis.removeBcastAction.isIdentity()) {
+    effectiveRowIndices = analysis.removeBcastAction.apply(
         SmallVector<Value>(rowIndices.begin(), rowIndices.end()));
   }
 
@@ -1404,7 +1309,7 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
 
   // If any warp bits are free, those warps hold redundant copies.
   // Zero the pred so the instruction becomes a no-op.
-  int32_t warpFreeMask = freeVarMasks.lookup(kWarp);
+  int32_t warpFreeMask = analysis.freeVarMasks.lookup(kWarp);
   if (warpFreeMask != 0) {
     Value isActive =
         b.icmp_eq(b.and_(warpId, b.i32_val(warpFreeMask)), b.i32_val(0));
@@ -1420,9 +1325,6 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
     pred = b.select(inRange, pred, b.i32_val(0));
   }
 
-  size_t contigIndiceCount = indexLL.getNumConsecutiveInOut();
-  maxIndicesPerInstr = std::min(maxIndicesPerInstr, contigIndiceCount);
-
   // Precompute LDS row offset for each instruction batch via
   // applyLinearLayout with the actual register index and warp ID.
   SmallVector<Value> batchLdsOffsets;
@@ -1436,20 +1338,22 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
                                       {kBlock, b.i32_val(0)}});
     batchLdsOffsets.push_back(offsets[0].second);
   }
+  assert(batchLdsOffsets.size() == analysis.numInstructions);
 
   size_t numIndicesPerWarp = effectiveRowIndices.size();
-  size_t numInstructions = batchLdsOffsets.size();
 
-  // Get the descriptor groups (gather/scatter uses 2D format: 12 dwords)
-  auto group0Vec = SmallVector<Value>(desc.begin(), desc.begin() + 4);
-  auto group1Vec = SmallVector<Value>(desc.begin() + 4, desc.end());
+  // Get the descriptor groups (gather/scatter uses 2D format — desc has 2
+  // vector entries: group0 = <4 x i32>, group1 = <8 x i32>)
+  Value group0In = desc[0];
+  Value group1In = desc[1];
 
   // For TDM gather/scatter, we need group2 and group3 for indices
-  SmallVector<Value> group2Vec(4, b.i32_val(0));
-  SmallVector<Value> group3Vec(4, b.i32_val(0));
+  auto v4i32Ty = VectorType::get(4, rewriter.getI32Type());
+  Value group2Zero = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
+  Value group3Zero = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
 
   // Issue multiple TDM instructions if needed
-  for (size_t instrIdx = 0; instrIdx < numInstructions; ++instrIdx) {
+  for (size_t instrIdx = 0; instrIdx < analysis.numInstructions; ++instrIdx) {
     size_t startIdx = instrIdx * maxIndicesPerInstr;
     size_t endIdx = std::min(startIdx + maxIndicesPerInstr, numIndicesPerWarp);
 
@@ -1458,10 +1362,10 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
                                     effectiveRowIndices.begin() + endIdx);
 
     // Make copies of the descriptor groups for this iteration
-    auto g0 = group0Vec;
-    auto g1 = group1Vec;
-    auto g2 = group2Vec;
-    auto g3 = group3Vec;
+    Value g0 = group0In;
+    Value g1 = group1In;
+    Value g2 = group2Zero;
+    Value g3 = group3Zero;
 
     Value ldsRowOffset = batchLdsOffsets[instrIdx];
 
@@ -1471,20 +1375,13 @@ void emitTDMGatherScatter(RewriterBase &rewriter, Location loc,
         pred, barrierPtr, cgaLayout, ctaId, batchIndices, use32BitIndices,
         isGather);
 
-    // Pack and emit the instruction
-    auto group0 = packLLVector(loc, g0, rewriter);
-    auto group1 = packLLVector(loc, g1, rewriter);
-    auto group2 = packLLVector(loc, g2, rewriter);
-    auto group3 = packLLVector(loc, g3, rewriter);
-
     auto v8i32Ty = VectorType::get(8, rewriter.getI32Type());
     Value group4Zero = LLVM::ZeroOp::create(rewriter, loc, v8i32Ty);
 
     const char *intrinsicName = isGather ? "llvm.amdgcn.tensor.load.to.lds"
                                          : "llvm.amdgcn.tensor.store.from.lds";
-    LLVM::createLLVMIntrinsicCallOp(
-        rewriter, loc, intrinsicName, {},
-        {group0, group1, group2, group3, group4Zero, b.i32_val(0)});
+    LLVM::createLLVMIntrinsicCallOp(rewriter, loc, intrinsicName, {},
+                                    {g0, g1, g2, g3, group4Zero, b.i32_val(0)});
   }
 }
 
@@ -1509,25 +1406,10 @@ SmallVector<Value> emitTDMPrefetch(RewriterBase &rewriter, Location loc,
   int numDims = blockShape.size();
   Type globalPtrTy = ptr_ty(loc.getContext(), 1);
 
-  // Decode TDM descriptor to get the base pointer, shape, and strides
-  auto group0Vec = SmallVector<Value>(desc.begin(), desc.begin() + 4);
-  auto group1Vec = SmallVector<Value>(desc.begin() + 4, desc.begin() + 12);
-  std::optional<SmallVector<Value>> group2Vec;
-  std::optional<SmallVector<Value>> group3Vec;
-  if (numDims > 2) {
-    group2Vec = SmallVector<Value>(desc.begin() + 12, desc.begin() + 16);
-    group3Vec = SmallVector<Value>(desc.begin() + 16, desc.end());
-  }
-  auto [basePtr, tensorShape, tensorStride, decodedBlockShape] =
-      mlir::LLVM::AMD::decodeTDMDescriptorFull(
-          rewriter, loc, group0Vec, group1Vec,
-          group2Vec.has_value()
-              ? std::optional<ArrayRef<Value>>(group2Vec.value())
-              : std::nullopt,
-          group3Vec.has_value()
-              ? std::optional<ArrayRef<Value>>(group3Vec.value())
-              : std::nullopt,
-          numDims);
+  // Decode TDM descriptor to get the base pointer, shape, and strides.
+  // desc has 2 (2D) or 4 (3D-5D) vector entries.
+  auto [basePtr, tensorShape, tensorStride] =
+      mlir::LLVM::AMD::decodeTDMDescriptorFull(rewriter, loc, desc, numDims);
 
   auto dot64 = [&](ArrayRef<Value> indices, ArrayRef<Value> strides) {
     Value ret = b.i64_val(0);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
@@ -3,6 +3,7 @@
 
 #include "TargetInfo.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/IR/Operation.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include <optional>
 
@@ -12,19 +13,19 @@ using PartitionedSharedEncodingAttr =
 
 namespace mlir::LLVM::AMD {
 
-// Structure to hold TDM descriptor groups
-struct TDMDescriptor {
-  SmallVector<Value> group0;
-  SmallVector<Value> group1;
-  std::optional<SmallVector<Value>> group2;
-  std::optional<SmallVector<Value>> group3;
+// TDM descriptor groups (lowering-pass-only; the MLIR-visible struct stays
+// flat {i32 x N} to match the host-side TDMDescriptor in driver.c):
+//   groups[0]/[1]: <4 x i32> / <8 x i32> (always)
+//   groups[2]/[3]: <4 x i32> each (3D-5D only)
+// Size is 2 (1D-2D) or 4 (3D-5D); see unpackTDMDescriptor.
 
-  // Get all groups as a flat vector (for compatibility)
-  SmallVector<Value> getAllGroups() const;
-};
-
+// Unpack the flat {i32 x 12/20} descriptor struct (from convertTensorDescType
+// / host-side TDMDescriptor in driver.c) into 2 or 4 vector groups for
+// emitTDMLoadStore / emitTDMGatherScatter / emitTDMPrefetch.
 SmallVector<Value> unpackTDMDescriptor(RewriterBase &rewriter, Location loc,
                                        Value descStruct);
+
+// Inverse of unpackTDMDescriptor: 2/4 vector groups back to 12/20 scalars.
 SmallVector<Value> scalarizeTDMDescriptor(RewriterBase &rewriter, Location loc,
                                           ArrayRef<Value> vectors);
 
@@ -47,40 +48,32 @@ void updateTensorDescriptor(RewriterBase &rewriter, Location loc,
                             ArrayRef<Value> setBounds, Value dest, Value pred,
                             Value barrier);
 
-// Create a TDM descriptor. This creates a partially filled descriptor, with
-// shared memory address and pred set to zero. User of the descriptor is
-// expected to fill these fields later.
-// For 1D-2D tensors: returns TDMDescriptor with only group0 and group1
-// For 3D-5D tensors: returns TDMDescriptor with all groups populated
-// When encoding is a PartitionedSharedEncodingAttr, the warp distribution is
-// adjusted so each wave's chunk fits in one LDS partition.
-TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
-                                  const LLVMTypeConverter *typeConverter,
-                                  Type elementType,
-                                  SmallVector<int64_t> blockShape, int numWarps,
-                                  unsigned padInterval, unsigned padAmount,
-                                  SmallVector<Value> tensorShape,
-                                  SmallVector<Value> tensorStride, Value srcPtr,
-                                  bool isRowMajor, Attribute sharedEncoding);
+// Create the base TDM descriptor from tensor metadata: global base pointer,
+// tensor shape, strides, and padding.  Fields that depend on a particular TDM
+// operation (pred, LDS address, barrier, tile_dim*) are filled later by the
+// per-op descriptor fillers.  Returns 2 vector groups for 1D-2D, 4 for 3D-5D.
+SmallVector<Value> createTDMDescriptor(RewriterBase &rewriter, Location loc,
+                                       const LLVMTypeConverter *typeConverter,
+                                       Type elementType, size_t numDims,
+                                       unsigned padInterval, unsigned padAmount,
+                                       SmallVector<Value> tensorShape,
+                                       SmallVector<Value> tensorStride,
+                                       Value srcPtr);
 
-// Update the global memory address with offset, and fill the shared memory
-// address and pred in a given TDM descriptor for regular load/store (1D-5D).
-// For partitioned shared memory, dstPtrs contains multiple base pointers and
-// the correct one is selected based on sharedLayout's partition dimension.
-// `warpUsedHint` selects an axis-aligned subset of active warps; see
-// TritonAMDGPUOps.td.
-void fillTDMDescriptor(
-    RewriterBase &rewriter, Location loc,
-    const LLVMTypeConverter *typeConverter, Type elementType,
-    SmallVector<int64_t> blockShape, int numWarps, unsigned padInterval,
-    unsigned padAmount, SmallVector<Value> &group0, SmallVector<Value> &group1,
-    std::optional<std::reference_wrapper<SmallVector<Value>>> group2,
-    std::optional<std::reference_wrapper<SmallVector<Value>>> group3,
-    SmallVector<Value> offset, ArrayRef<Value> dstPtrs, Value pred,
-    Value multicastMask, Value barrierPtr,
-    const triton::LinearLayout &sharedLayout, Value ctaId, bool isStore,
-    bool isRowMajor, ArrayRef<unsigned> warpsPerCTA,
-    std::optional<uint32_t> warpUsedHint = std::nullopt);
+// Fill the dst/pred fields of a TDM descriptor for regular load/store (1D-5D).
+// `groups` is 2 (1D-2D) or 4 (3D-5D) vector entries, updated in place.
+// Partitioned dst: `dstPtrs` holds per-partition bases, picked by partitionDim.
+// `warpUsedHint`: see TritonAMDGPUOps.td for the axis-aligned hint rule.
+void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
+                       const LLVMTypeConverter *typeConverter, Type elementType,
+                       SmallVector<int64_t> blockShape, int numWarps,
+                       unsigned padInterval, unsigned padAmount,
+                       MutableArrayRef<Value> groups, SmallVector<Value> offset,
+                       ArrayRef<Value> dstPtrs, Value pred, Value multicastMask,
+                       Value barrierPtr,
+                       const triton::LinearLayout &sharedLayout, Value ctaId,
+                       bool isStore, ArrayRef<unsigned> warpsPerCTA,
+                       std::optional<uint32_t> warpUsedHint = std::nullopt);
 
 // Fill TDM descriptor for gather/scatter operations (2D only).
 // Gather reads from non-contiguous rows in global memory to LDS.
@@ -94,26 +87,16 @@ void fillTDMDescriptorForGatherScatter(
     RewriterBase &rewriter, Location loc,
     const LLVMTypeConverter *typeConverter, Type elementType,
     SmallVector<int64_t> blockShape, unsigned padInterval, unsigned padAmount,
-    SmallVector<Value> &group0, SmallVector<Value> &group1,
-    SmallVector<Value> &group2, SmallVector<Value> &group3, Value ldsRowOffset,
-    Value globalColOffset, Value ldsPtr, Value pred, Value barrierPtr,
-    const triton::LinearLayout &cgaLayout, Value ctaId,
+    Value &group0, Value &group1, Value &group2, Value &group3,
+    Value ldsRowOffset, Value globalColOffset, Value ldsPtr, Value pred,
+    Value barrierPtr, const triton::LinearLayout &cgaLayout, Value ctaId,
     ArrayRef<Value> rowIndices, bool use32BitIndices, bool isGather);
 
-// Emit a TDM load or store for regular (non-scatter) contiguous transfers.
-//
-// Supports 1D-5D tensors.  When the encoding is a PartitionedSharedEncoding,
-// the warp distribution is adjusted so each wave's tile fits within a single
-// LDS partition.  If the warps cannot cover all logical pieces in one
-// instruction, the operation is automatically split into multiple sequential
-// TDM instructions. A warp hint guarantees single-instruction emission; see
-// TritonAMDGPUOps.td.
-//
-// - offset: starting position in global memory for each dimension
-// - dstPtrs: base pointers to LDS (multiple for partitioned encoding)
-// - sharedLayout: linear layout for the full allocation shape (pre-CGA-split)
-// - encoding: shared memory encoding (used for partition constraints when
-//   splitting into multiple TDM instructions)
+// Emit a TDM load/store for regular contiguous transfers (1D-5D).
+// PartitionedSharedEncoding aligns warps to LDS partitions; without a hint
+// the op auto-splits into multiple instructions when warps don't cover all
+// pieces, while a hint guarantees single-instruction emission (verifier).
+// `warpUsedHint`: see TritonAMDGPUOps.td.
 void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
                       const LLVMTypeConverter *typeConverter,
                       ArrayRef<Value> desc, ArrayRef<int64_t> blockShape,
@@ -122,8 +105,7 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
                       Value pred, Value multicastMask, Type elementType,
                       Value barrierPtr, bool isLoad,
                       const triton::LinearLayout &sharedLayout,
-                      Attribute encoding, Value ctaId, bool isRowMajor,
-                      int32_t auxBits,
+                      Attribute encoding, Value ctaId, int32_t auxBits,
                       std::optional<uint32_t> warpUsedHint = std::nullopt);
 
 // Returns (warpsPerCTA, numTDMInstructions) for a given shared encoding.
@@ -134,13 +116,10 @@ std::pair<SmallVector<unsigned>, unsigned>
 distributeTDMWarpsAlignToPartition(ArrayRef<int64_t> blockShape, int numWarps,
                                    Attribute encoding);
 
-// Calculate the number of TDM gather/scatter instructions needed.
-// - numIndices: number of row indices
-// - use32BitIndices: true for 32-bit indices (max 8 rows/instr), false for
-//   16-bit (max 16 rows/instr)
-// Returns: the number of TDM instructions that will be emitted
-size_t getTDMGatherScatterInstrinsicCount(size_t numIndices,
-                                          bool use32BitIndices);
+// Calculate the number of TDM gather/scatter instructions needed using the
+// same LinearLayout analysis as emitTDMGatherScatter: broadcasts are removed
+// and contiguity is considered when batching indices per instruction.
+size_t getTDMGatherScatterInstrinsicCount(RankedTensorType indicesType);
 
 // Emit a TDM gather or scatter operation for non-contiguous row access.
 // Gather: reads from non-contiguous global rows into LDS

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -26,6 +26,63 @@ LLVM::LLVMFuncOp getOrInsertFunction(T &moduleOp, const Location loc,
   return ret;
 }
 
+// Create (or look up) a noinline function that prints an assertion message
+// via ockl hostcall. Isolating the printf code in a separate noinline
+// function keeps VGPR pressure low when using instrumentation.
+LLVM::LLVMFuncOp getOrCreateAssertFailFunc(ModuleOp moduleOp, Location loc,
+                                           RewriterBase &rewriter) {
+  auto *ctx = rewriter.getContext();
+  StringRef funcName = "__triton_assert_fail";
+
+  if (auto existing = moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(funcName))
+    return existing;
+
+  RewriterBase::InsertionGuard guard(rewriter);
+
+  auto ptrTy = LLVM::LLVMPointerType::get(ctx);
+  auto i64Ty = IntegerType::get(ctx, 64);
+  auto i32Ty = IntegerType::get(ctx, 32);
+  auto voidTy = LLVM::LLVMVoidType::get(ctx);
+
+  // Ensure ockl function declarations exist at module scope.
+  auto printBeginFn = getOrInsertFunction(
+      moduleOp, loc, rewriter, "__ockl_fprintf_stderr_begin",
+      LLVM::LLVMFunctionType::get(i64Ty, {}));
+  auto printStrFn = getOrInsertFunction(
+      moduleOp, loc, rewriter, "__ockl_printf_append_string_n",
+      LLVM::LLVMFunctionType::get(i64Ty, {i64Ty, ptrTy, i64Ty, i32Ty}));
+
+  // Create the noinline function: void @__triton_assert_fail(ptr, i64)
+  rewriter.setInsertionPointToStart(moduleOp.getBody());
+  auto funcType = LLVM::LLVMFunctionType::get(voidTy, {ptrTy, i64Ty});
+  auto funcOp = LLVM::LLVMFuncOp::create(rewriter, loc, funcName, funcType,
+                                         LLVM::Linkage::Internal);
+  funcOp.setPassthroughAttr(
+      ArrayAttr::get(ctx, {
+                              StringAttr::get(ctx, "noinline"),
+                              StringAttr::get(ctx, "cold"),
+                              StringAttr::get(ctx, "convergent"),
+                              StringAttr::get(ctx, "nounwind"),
+                          }));
+  if (auto numWarps = moduleOp->getAttrOfType<IntegerAttr>("ttg.num-warps"))
+    funcOp->setAttr("ws_num_warps", numWarps);
+
+  // Build the function body.
+  Block *entry =
+      rewriter.createBlock(&funcOp.getBody(), {}, {ptrTy, i64Ty}, {loc, loc});
+  Value msg = entry->getArgument(0);
+  Value len = entry->getArgument(1);
+
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  Value beginResult = b.call(printBeginFn, ValueRange()).getResult();
+  Value oneI32 = b.i32_val(1);
+  SmallVector<Value> printArgs = {beginResult, msg, len, oneI32};
+  b.call(printStrFn, printArgs);
+  LLVM::ReturnOp::create(rewriter, loc, ValueRange());
+
+  return funcOp;
+}
+
 // Extend all values to 64-bit per printf call requirements.
 Value printfPromoteValue(RewriterBase &rewriter, Value value, bool isSigned) {
   auto *context = rewriter.getContext();
@@ -627,6 +684,9 @@ void TargetInfo::assertFail(RewriterBase &rewriter, Location loc,
                             StringRef message, StringRef file, StringRef func,
                             int line) const {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
+  auto *ctx = rewriter.getContext();
+  auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
+
   // Compose and print an assert message.
   llvm::SmallString<256> msgBuffer;
   llvm::Twine("device assertion failed: '" + message + "', in " + func +
@@ -634,14 +694,30 @@ void TargetInfo::assertFail(RewriterBase &rewriter, Location loc,
       .toStringRef(msgBuffer);
   Value msgValue =
       LLVM::addStringToModule(loc, rewriter, "printfFormat_", msgBuffer);
-  printfImpl(msgValue, msgBuffer.size_in_bytes(), /*args=*/ValueRange(),
-             /*isSigned=*/{}, rewriter, /*useStdError=*/true);
+
+  // Call the noinline assert handler to print the message via hostcall.
+  auto assertFailFunc = getOrCreateAssertFailFunc(moduleOp, loc, rewriter);
+  Value msgLen = LLVM::ConstantOp::create(
+      rewriter, loc, IntegerType::get(ctx, 64), msgBuffer.size_in_bytes());
+  SmallVector<Value> callArgs = {msgValue, msgLen};
+  b.call(assertFailFunc, callArgs);
 
   // Set block barrier before aborting kernel, give a chance for all
   // the threads in a block to check/print the assert failure.
   b.barrier(triton::gpu::AddrSpace::All);
   // Perform the trap to abort the kernel.
-  LLVM::Trap::create(rewriter, loc);
+  // Use inline asm "s_trap 2" instead of LLVM::Trap because llvm.trap is
+  // noreturn, inserting 'unreachable' which causes StructurizeCFG to defer
+  // the block past convergence points, making ConSan lock releases
+  // unreachable and causing deadlocks. The noinline helper above prevents
+  // the printf code from being inlined and bloating the kernel.
+  LLVM::InlineAsmOp::create(
+      rewriter, loc, LLVM::LLVMVoidType::get(ctx), /*operands=*/ValueRange{},
+      "s_trap 2", /*constraints=*/"",
+      /*has_side_effects=*/true, /*is_align_stack=*/false,
+      LLVM::TailCallKind::None,
+      LLVM::AsmDialectAttr::get(ctx, LLVM::AsmDialect::AD_ATT),
+      /*operand_attrs=*/ArrayAttr::get(ctx, {}));
 }
 
 int TargetInfo::getSharedAddressSpace() const { return 3; }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
@@ -16,8 +16,6 @@ namespace {
 // compatible with TDM. Requirements:
 //  - The shared order must be [rank-1, rank-2, ..., 0].
 //  - All stride-1 dimensions must be consecutive trailing dims.
-// Additionally, a single stride-1 dimension may appear at the rank-2
-// position (col-major) if the shared order has rank-2 and rank-1 swapped.
 LogicalResult validateStridesAndSharedOrder(triton::MakeTensorDescOp op,
                                             Attribute sharedEnc,
                                             ArrayRef<int64_t> shape,
@@ -25,7 +23,6 @@ LogicalResult validateStridesAndSharedOrder(triton::MakeTensorDescOp op,
   int rank = shape.size();
   auto sharedOrder = triton::gpu::getOrder(
       cast<triton::gpu::SharedEncodingTrait>(sharedEnc), shape);
-
   SmallVector<unsigned> strideOneDims;
   for (auto [dim, strideVal] : llvm::enumerate(strides)) {
     if (getConstantIntValue(getAsOpFoldResult(strideVal)).value_or(0) == 1)
@@ -35,8 +32,6 @@ LogicalResult validateStridesAndSharedOrder(triton::MakeTensorDescOp op,
   if (strideOneDims.empty())
     return op.emitError() << "requires at least one dimension to have stride 1";
 
-  // If the only stride-1 dim is the second-to-last dimension (col-major) we can
-  // safely reorder the dimensions during lowering.
   bool isColMajor =
       strideOneDims.size() == 1 && strideOneDims.front() == rank - 2;
 
@@ -64,34 +59,6 @@ LogicalResult validateStridesAndSharedOrder(triton::MakeTensorDescOp op,
   return success();
 }
 
-// Collects all users of the value beyond the basic block boundaries
-// defining a given value.
-void collectUsers(Value value, llvm::SetVector<Operation *> &users) {
-  for (OpOperand &use : value.getUses()) {
-    Operation *userOp = use.getOwner();
-    if (users.contains(userOp)) {
-      // stop recursion; avoid loops
-      return;
-    }
-    users.insert(userOp);
-    const unsigned argIdx = use.getOperandNumber();
-
-    if (auto unrealCast = dyn_cast<mlir::UnrealizedConversionCastOp>(userOp)) {
-      collectUsers(unrealCast->getResult(argIdx), users);
-    }
-
-    if (auto branch = dyn_cast<mlir::BranchOpInterface>(userOp)) {
-      auto successors = branch->getSuccessors();
-      for (auto [idx, successor] : llvm::enumerate(successors)) {
-        auto operands = branch.getSuccessorOperands(idx);
-        if (argIdx < operands.size()) {
-          collectUsers(successor->getArgument(argIdx), users);
-        }
-      }
-    }
-  }
-}
-
 struct MakeTensorDescOpConversion
     : public ConvertOpToLLVMPattern<triton::MakeTensorDescOp> {
   using ConvertOpToLLVMPattern<
@@ -102,16 +69,15 @@ struct MakeTensorDescOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto basePtr = adaptor.getBase();
-    auto tensorShape = llvm::to_vector(adaptor.getShape());
-    auto tensorStride = llvm::to_vector(adaptor.getStrides());
+    auto tensorShape = adaptor.getShape();
+    auto tensorStride = adaptor.getStrides();
     auto result = op.getResult();
 
     auto tensorDescTy = result.getType();
     auto sharedEnc = tensorDescTy.getSharedLayout();
     if (!sharedEnc) {
-      if (!sharedEnc)
-        return rewriter.notifyMatchFailure(
-            op, "Descriptor has no shared memory layout assigned.");
+      return rewriter.notifyMatchFailure(
+          op, "Descriptor has no shared memory layout assigned.");
     }
     unsigned padInterval = 0;
     unsigned padAmount = 0;
@@ -126,7 +92,6 @@ struct MakeTensorDescOpConversion
     Type elementType =
         getTypeConverter()->convertType(tensorDescTy.getElementType());
     SmallVector<int64_t> blockShape = to_vector(tensorDescTy.getShape());
-    int numWarps = lookupNumWarps(op);
     auto shapePerCTA = triton::gpu::getShapePerCTA(sharedEnc, blockShape);
 
     if (failed(validateStridesAndSharedOrder(op, sharedEnc, shapePerCTA,
@@ -135,17 +100,20 @@ struct MakeTensorDescOpConversion
     }
     auto sharedOrder = triton::gpu::getOrder(
         cast<triton::gpu::SharedEncodingTrait>(sharedEnc), shapePerCTA);
-    bool isRowMajor = sharedOrder[0] == (sharedOrder.size() - 1);
-    // Create TDM descriptor for 2D-5D tensors
-    auto tdmDesc = LLVM::AMD::createTDMDescriptor(
-        rewriter, loc, getTypeConverter(), elementType, shapePerCTA, numWarps,
-        padInterval, padAmount, tensorShape, tensorStride, basePtr, isRowMajor,
-        sharedEnc);
+    // Lower the tensor descriptor to a base TDM descriptor.  The final hardware
+    // descriptor is completed at each TDM op site because pred, LDS address,
+    // barrier, and tile_dim* are op-local.
+    // Returns 2 (2D) or 4 (3D-5D) vector groups; scalarize into 12 or 20
+    // i32 scalars to match the flat MLIR struct type from
+    // `convertTensorDescType` (matches the host-side TDMDescriptor ABI).
+    SmallVector<Value> groups = LLVM::AMD::createTDMDescriptor(
+        rewriter, loc, getTypeConverter(), elementType, blockShape.size(),
+        padInterval, padAmount, tensorShape, tensorStride, basePtr);
+    SmallVector<Value> scalars =
+        mlir::LLVM::AMD::scalarizeTDMDescriptor(rewriter, loc, groups);
 
-    SmallVector<Value> groups = tdmDesc.getAllGroups();
-
-    auto desc =
-        packLLElements(loc, getTypeConverter(), groups, rewriter, tensorDescTy);
+    auto desc = packLLElements(loc, getTypeConverter(), scalars, rewriter,
+                               tensorDescTy);
 
     rewriter.replaceOp(op, desc);
     return success();
@@ -163,10 +131,9 @@ struct UpdateTensorDescriptorOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto tensorDescTy = op.getDesc().getType();
-    auto blockTy = tensorDescTy.getBlockType();
     Type elementType =
-        getTypeConverter()->convertType(blockTy.getElementType());
-    SmallVector<int64_t> blockShape = to_vector(blockTy.getShape());
+        getTypeConverter()->convertType(tensorDescTy.getElementType());
+    SmallVector<int64_t> blockShape = to_vector(tensorDescTy.getShape());
 
     if (blockShape.size() != 2) {
       return rewriter.notifyMatchFailure(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -31,6 +31,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 namespace mlir::triton {
@@ -63,6 +64,7 @@ public:
     addIllegalDialect<triton::TritonDialect>();
     addIllegalDialect<triton::gpu::TritonGPUDialect>();
     addIllegalDialect<triton::nvidia_gpu::TritonNvidiaGPUDialect>();
+    addIllegalDialect<triton::instrument::TritonInstrumentDialect>();
     addIllegalDialect<mlir::gpu::GPUDialect>();
     addLegalOp<mlir::UnrealizedConversionCastOp>();
     addLegalOp<triton::amdgpu::InstructionSchedHint>();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_triton_library(TritonAMDGPUTransforms
   CanonicalizePointers.cpp
   CoalesceAsyncCopy.cpp
   CoalesceBufferOps.cpp
+  ConSanAMD.cpp
   ConvertToBufferOps.cpp
   ConvertToTensorOps.cpp
   DotDecomposeAndSchedule.cpp
@@ -36,6 +37,8 @@ add_triton_library(TritonAMDGPUTransforms
   TritonGPUModuloCore
   TritonAMDUtils
   TritonAMDAnalysis
+  TritonInstrumentTransforms
+  TritonInstrumentIR
 )
 
 target_include_directories(TritonAMDGPUTransforms PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../include)

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
@@ -1,0 +1,180 @@
+#include "Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h"
+
+namespace ttg = mlir::triton::gpu;
+namespace ttag = mlir::triton::amdgpu;
+namespace tti = mlir::triton::instrument;
+
+using tti::BarrierInitInfo;
+using tti::BarrierInvalidateInfo;
+using tti::BarrierWaitInfo;
+using tti::CommitKindDesc;
+using tti::MemEffectsOpInfo;
+using tti::WaitOpInfo;
+
+namespace mlir {
+
+class AMDConSanHooks : public tti::ConSanTargetHooks {
+public:
+  bool isTMAOp(Operation *op) const override {
+    return isa<ttag::AsyncTDMCopyGlobalToLocalOp,
+               ttag::AsyncTDMCopyLocalToGlobalOp>(op);
+  }
+
+  // TDM ops from the same warp complete in issue order. ConSan's thread model
+  // uses one logical TDM thread per WS partition, so the outstanding-commit
+  // check excludes the calling thread's own column to avoid intra-partition
+  // false positives while still detecting cross-partition races.
+  bool isOrderedCommitKind(tti::CommitKind::Kind kind) const override {
+    return kind == tti::CommitKind::TmaStore;
+  }
+
+  std::optional<BarrierInitInfo>
+  getBarrierInitInfo(Operation *op) const override {
+    if (auto initOp = dyn_cast<ttag::InitBarrierOp>(op))
+      return BarrierInitInfo{initOp.getBarrier(), initOp.getCount()};
+    return std::nullopt;
+  }
+
+  std::optional<BarrierWaitInfo>
+  getBarrierWaitInfo(Operation *op) const override {
+    if (auto waitOp = dyn_cast<ttag::WaitBarrierOp>(op))
+      return BarrierWaitInfo{waitOp.getBarrier(), waitOp.getPhase(),
+                             /*pred=*/Value()};
+    return std::nullopt;
+  }
+
+  std::optional<BarrierInvalidateInfo>
+  getBarrierInvalidateInfo(Operation *op) const override {
+    return std::nullopt;
+  }
+
+  std::optional<WaitOpInfo> getWaitOpInfo(Operation *op) const override {
+    // AMD amdgpu::AsyncWaitOp replaces ttg::AsyncWaitOp after
+    // UpdateAsyncWaitCount. Read the preserved commit-group count.
+    if (auto asyncWaitOp = dyn_cast<ttag::AsyncWaitOp>(op)) {
+      if (auto attr = asyncWaitOp->getAttrOfType<IntegerAttr>(
+              "ttg.num_commit_groups")) {
+        return WaitOpInfo{tti::CommitKind::AsyncCp, (int)attr.getInt(),
+                          /*transferWrites=*/true, /*transferReads=*/false};
+      }
+      return std::nullopt;
+    }
+    if (auto tdmWaitOp = dyn_cast<ttag::AsyncTDMWait>(op)) {
+      return WaitOpInfo{tti::CommitKind::TmaStore,
+                        static_cast<int>(tdmWaitOp.getNum()),
+                        /*transferWrites=*/true, /*transferReads=*/true};
+    }
+    // AMD AsyncTDMIntrinsicWait: replaces AsyncTDMWait after
+    // UpdateAsyncWaitCount. Read the preserved TDM operation count.
+    if (auto tdmWaitOp = dyn_cast<ttag::AsyncTDMIntrinsicWait>(op)) {
+      if (auto attr =
+              tdmWaitOp->getAttrOfType<IntegerAttr>("ttg.num_tdm_ops")) {
+        return WaitOpInfo{tti::CommitKind::TmaStore, (int)attr.getInt(),
+                          /*transferWrites=*/true, /*transferReads=*/true};
+      }
+      return std::nullopt;
+    }
+    return std::nullopt;
+  }
+
+  Value getIssuerCTAPred(ImplicitLocOpBuilder & /*b*/,
+                         Operation * /*op*/) const override {
+    return nullptr;
+  }
+
+  std::optional<MemEffectsOpInfo>
+  getMemEffectsOpInfo(Operation *op) const override {
+    auto info = ConSanTargetHooks::getMemEffectsOpInfo(op);
+    if (info)
+      return info;
+    // AsyncTDMCopyGlobalToLocalOp: Async copy from global to shared memory.
+    // When a barrier is present, TDM signals it once per warp.
+    // The barrier init count must account for this (e.g. count=NUM_WARPS),
+    // so ConSan decrements the shadow counter by numWarps (one per warp).
+    // When no barrier is present, completion is tracked via the TDM wait
+    // counter (AsyncTDMWait), modeled as CommitCount with implicitCommit.
+    if (auto copyOp = dyn_cast<ttag::AsyncTDMCopyGlobalToLocalOp>(op)) {
+      info.emplace();
+      if (Value barrier = copyOp.getBarrier()) {
+        info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+        int numWarps = ttg::lookupNumWarps(copyOp);
+        info->barriers.push_back({barrier, nullptr, numWarps});
+      } else {
+        info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
+        info->commitKind = tti::CommitKind::TmaStore;
+        info->implicitCommit = true;
+      }
+      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
+                                        copyOp.getResult());
+    }
+    // AsyncTDMCopyLocalToGlobalOp: Async copy from shared to global memory
+    // Same principles as AsyncTDMCopyGlobalToLocalOp apply.
+    if (auto storeOp = dyn_cast<ttag::AsyncTDMCopyLocalToGlobalOp>(op)) {
+      info.emplace();
+      if (Value barrier = storeOp.getBarrier()) {
+        info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+        int numWarps = ttg::lookupNumWarps(storeOp);
+        info->barriers.push_back({barrier, nullptr, numWarps});
+      } else {
+        info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
+        info->commitKind = tti::CommitKind::TmaStore;
+        info->implicitCommit = true;
+      }
+      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
+                                        storeOp.getSrc());
+    }
+    // AMD ArriveBarrierOp: Explicit barrier arrival.
+    // Arrive is per-THREAD when called explicitly (unlike TDM which
+    // is per-warp). Scale by total threads in the partition so ConSan's shadow
+    // barrier state matches the hardware arrival count.
+    if (auto arriveOp = dyn_cast<ttag::ArriveBarrierOp>(op)) {
+      info.emplace();
+      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+      int numWarps = ttg::lookupNumWarps(arriveOp);
+      auto mod = arriveOp->getParentOfType<ModuleOp>();
+      int threadsPerWarp = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
+      int totalCount = (int)arriveOp.getCount() * numWarps * threadsPerWarp;
+      info->barriers.push_back({arriveOp.getBarrier(), nullptr, totalCount});
+    }
+    return info;
+  }
+
+  SmallVector<CommitKindDesc> getOutstandingWriteCommitKinds() const override {
+    return {{tti::CommitKind::AsyncCp, "async_copy_global_to_shared"},
+            {tti::CommitKind::TmaStore, "async_tdm_global_to_shared"}};
+  }
+
+  SmallVector<CommitKindDesc> getOutstandingReadCommitKinds() const override {
+    return {{tti::CommitKind::TmaStore, "async_tdm_shared_to_global"}};
+  }
+
+  SmallVector<tti::CommitKind::Kind>
+  getRequiredCommitKinds(ModuleOp module) const override {
+    SmallVector<tti::CommitKind::Kind> kinds;
+    bool needsTdm = false;
+    bool needsAsyncCp = false;
+    module.walk([&](Operation *op) {
+      if (isa<ttag::AsyncTDMCopyGlobalToLocalOp,
+              ttag::AsyncTDMCopyLocalToGlobalOp, ttag::AsyncTDMWait,
+              ttag::AsyncTDMIntrinsicWait>(op))
+        needsTdm = true;
+      if (isa<ttag::AsyncWaitOp>(op))
+        needsAsyncCp = true;
+    });
+    if (needsTdm)
+      kinds.push_back(tti::CommitKind::TmaStore);
+    if (needsAsyncCp)
+      kinds.push_back(tti::CommitKind::AsyncCp);
+    return kinds;
+  }
+};
+
+void registerConSanAMDHooks() {
+  tti::registerConSanHooks("amd",
+                           [] { return std::make_unique<AMDConSanHooks>(); });
+}
+
+} // namespace mlir

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -389,15 +389,26 @@ void updateWaitCount(WaitType waitOp,
     // Replace ttg.async_wait which counts outstanding commit groups with
     // amdg.async_wait which counts the number of outstanding intrinsics
     auto tokens = waitOp.getAsyncToken();
+    auto origNum = waitOp.getNum();
     rewriter.setInsertionPointAfter(waitOp);
-    rewriter.replaceOpWithNewOp<amdgpu::AsyncWaitOp>(waitOp, tokens, waitCnt);
+    auto newOp = rewriter.replaceOpWithNewOp<amdgpu::AsyncWaitOp>(
+        waitOp, tokens, waitCnt);
+    // Preserve the original commit-group count so downstream passes
+    // (e.g. ConcurrencySanitizer) that reason about commit groups can
+    // still access it after this lowering.
+    newOp->setAttr("ttg.num_commit_groups",
+                   rewriter.getI32IntegerAttr(origNum));
   } else if (std::is_same_v<WaitType, triton::amdgpu::AsyncTDMWait>) {
     // Replace amdg.async_tdm_wait (counts TDM operations) with
     // amdg.async_tdm_intrinsic_wait (counts TDM intrinsics)
     auto tokens = waitOp.getAsyncToken();
+    auto origNum = waitOp.getNum();
     rewriter.setInsertionPointAfter(waitOp);
-    rewriter.replaceOpWithNewOp<amdgpu::AsyncTDMIntrinsicWait>(waitOp, tokens,
-                                                               waitCnt);
+    auto newOp = rewriter.replaceOpWithNewOp<amdgpu::AsyncTDMIntrinsicWait>(
+        waitOp, tokens, waitCnt);
+    // Preserve the original TDM operation count so downstream passes
+    // (e.g. ConcurrencySanitizer) can still access it after this lowering.
+    newOp->setAttr("ttg.num_tdm_ops", rewriter.getI32IntegerAttr(origNum));
   } else {
     assert(false && "Unsupported wait type");
   }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -490,15 +490,10 @@ struct TritonAMDGPUUpdateAsyncWaitCountPass
                   smemTy.getShape(), numWarps, smemTy.getEncoding());
           return numInstr;
         } else if (isa<AsyncTDMScatterOp, AsyncTDMGatherOp>(op)) {
-          // For scatter and gather we need to get the count of TDM intrinsics
-          // based on the row indices tensor type
           auto rowIndicesType =
               cast<RankedTensorType>(op->getOperandTypes()[1]);
-          bool use32BitIndices =
-              rowIndicesType.getElementType().getIntOrFloatBitWidth() == 32;
-          size_t numIndices = rowIndicesType.getNumElements();
           return mlir::LLVM::AMD::getTDMGatherScatterInstrinsicCount(
-              numIndices, use32BitIndices);
+              rowIndicesType);
         } else {
           return 0;
         }

--- a/third_party/amd/python/test/gfx1250_consan_helper.py
+++ b/third_party/amd/python/test/gfx1250_consan_helper.py
@@ -1,0 +1,909 @@
+# ruff: noqa: E402
+import hip
+
+hip.hip.hipInit(0)
+
+import sys
+import os
+
+os.environ["TRITON_INSTRUMENTATION_MODE"] = "consan"
+import torch
+from triton import knobs
+from triton.runtime._allocation import set_profile_allocator
+from triton.experimental import gluon
+import triton.experimental.gluon.language as ttgl
+
+knobs.compilation.instrumentation_mode = "consan"
+knobs.refresh_knobs()
+
+
+def alloc_fn(size, alignment, stream):
+    return torch.empty(size, device="cuda", dtype=torch.int8)
+
+
+set_profile_allocator(alloc_fn)
+
+
+def deadlock_two_partitions():
+
+    @gluon.jit
+    def ws_default(bar):
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+
+    @gluon.jit
+    def ws_1(bar):
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(1), phase=0)
+
+    @gluon.jit
+    def kernel():
+        WARP_SIZE: ttgl.constexpr = 32
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(0), count=4 * WARP_SIZE)
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(1), count=4 * WARP_SIZE)
+        ttgl.warp_specialize([
+            (ws_default, (bar, )),
+            (ws_1, (bar, )),
+        ], [4])
+
+    kernel[(1, )](num_warps=4)
+
+
+def deadlock_overarrival():
+
+    @gluon.jit
+    def kernel():
+        WARP_SIZE: ttgl.constexpr = 32
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(0), count=4 * WARP_SIZE)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(0), count=1)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(0), count=1)
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+
+    kernel[(1, )](num_warps=4)
+
+
+def deadlock_underarrival():
+
+    @gluon.jit
+    def ws_default(bar):
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(1), count=1)
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+
+    @gluon.jit
+    def ws_1(bar):
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(0), count=1)
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(1), phase=0)
+
+    @gluon.jit
+    def kernel():
+        WARP_SIZE: ttgl.constexpr = 32
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(0), count=8 * WARP_SIZE)
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(1), count=8 * WARP_SIZE)
+        ttgl.warp_specialize([
+            (ws_default, (bar, )),
+            (ws_1, (bar, )),
+        ], [4])
+
+    kernel[(1, )](num_warps=4)
+
+
+def deadlock_different_phases():
+
+    @gluon.jit
+    def ws_default(bar):
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(0), count=1)
+
+    @gluon.jit
+    def ws_1(bar):
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=1)
+
+    @gluon.jit
+    def kernel():
+        WARP_SIZE: ttgl.constexpr = 32
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(0), count=4 * WARP_SIZE)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(0), count=1)
+        ttgl.warp_specialize([
+            (ws_default, (bar, )),
+            (ws_1, (bar, )),
+        ], [4])
+
+    kernel[(1, )](num_warps=4)
+
+
+def barrier_underflow():
+
+    @gluon.jit
+    def ws_default(bar):
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(1), count=3)
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+
+    @gluon.jit
+    def ws_1(bar):
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(1), phase=0)
+
+    @gluon.jit
+    def kernel():
+        WARP_SIZE: ttgl.constexpr = 32
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(0), count=4 * WARP_SIZE)
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(1), count=4 * WARP_SIZE)
+        ttgl.warp_specialize([
+            (ws_default, (bar, )),
+            (ws_1, (bar, )),
+        ], [4])
+
+    kernel[(1, )](num_warps=4)
+
+
+XBLOCK = 128
+
+
+def aliasing_shared_visibility():
+    MISSING_BAR = sys.argv[2] == "True"
+    OVERLAP = sys.argv[3] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def writer(alias0: ttgl.constexpr, bar: ttgl.constexpr, OVERLAP: ttgl.constexpr, blocked_layout: ttgl.constexpr):
+        SIZE_N: ttgl.constexpr = XBLOCK_C * 2 if OVERLAP else XBLOCK_C
+        vals = ttgl.full([XBLOCK_C, SIZE_N], 42.0, ttgl.float16, blocked_layout)
+        alias0.store(vals)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(0), count=1)
+
+    @gluon.jit
+    def reader(alias1: ttgl.constexpr, dummy: ttgl.constexpr, bar: ttgl.constexpr, MISSING_BAR: ttgl.constexpr,
+               blocked_layout: ttgl.constexpr):
+        if not MISSING_BAR:
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+        val = alias1.load(blocked_layout)
+        dummy.store(val)
+
+    @gluon.jit
+    def kernel(MISSING_BAR: ttgl.constexpr, OVERLAP: ttgl.constexpr):
+        WARP_SIZE: ttgl.constexpr = 32
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0, 1])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, XBLOCK_C], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[0, 1])
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK_C, XBLOCK_C * 2], smem_layout)
+        smem2 = ttgl.allocate_shared_memory(ttgl.float16, [XBLOCK_C, XBLOCK_C], smem_layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(0), count=4 * WARP_SIZE)
+        alias0 = smem if OVERLAP else smem.slice(0, XBLOCK_C, dim=1)
+        alias1 = smem.slice(XBLOCK_C, XBLOCK_C, dim=1)
+        ttgl.warp_specialize([
+            (writer, (alias0, bar, OVERLAP, blocked_layout)),
+            (reader, (alias1, smem2, bar, MISSING_BAR, blocked_layout)),
+        ], [4])
+
+    kernel[(1, )](MISSING_BAR=MISSING_BAR, OVERLAP=OVERLAP, num_warps=4)
+
+
+def ws_two_loads_two_bars():
+    MISSING_BAR = sys.argv[2]
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def ws_default(smem, bar, MISSING_BAR: ttgl.constexpr, layout: ttgl.constexpr):
+        val = smem.index(0).load(layout)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(0), count=1)
+        smem.index(1).store(val)
+
+    @gluon.jit
+    def ws_1(smem, bar, MISSING_BAR: ttgl.constexpr, layout: ttgl.constexpr):
+        val = smem.index(0).load(layout)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(1), count=1)
+        smem.index(2).store(val)
+
+    @gluon.jit
+    def ws_2(smem, bar, MISSING_BAR: ttgl.constexpr, layout: ttgl.constexpr):
+        if MISSING_BAR != "1":
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+        if MISSING_BAR != "2":
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(1), phase=0)
+        smem.index(0).store(ttgl.arange(0, XBLOCK_C, layout).to(ttgl.float16))
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(2), count=1)
+
+    @gluon.jit
+    def kernel(output, MISSING_BAR: ttgl.constexpr):
+        WARP_SIZE: ttgl.constexpr = 32
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1], threads_per_warp=[32],
+                                                            warps_per_cta=[4], order=[0])
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [3, XBLOCK_C], smem_layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [3, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        for i in range(3):
+            ttgl.amd.gfx1250.mbarrier.init(bar.index(i), count=4 * WARP_SIZE)
+        ttgl.warp_specialize([
+            (ws_default, (smem, bar, MISSING_BAR, blocked_layout)),
+            (ws_1, (smem, bar, MISSING_BAR, blocked_layout)),
+            (ws_2, (smem, bar, MISSING_BAR, blocked_layout)),
+        ], [4, 4])
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(2), phase=0)
+        val = smem.index(0).load(blocked_layout)
+        output_ptrs = output + ttgl.arange(0, XBLOCK_C, blocked_layout)
+        ttgl.store(output_ptrs, val)
+
+    output = torch.empty((XBLOCK, ), device="cuda", dtype=torch.float16)
+    kernel[(1, )](output, MISSING_BAR=MISSING_BAR, num_warps=4)
+
+
+def ws_two_loads_one_bar():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def ws_default(smem, bar, layout: ttgl.constexpr):
+        val = smem.index(0).load(layout)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(0), count=1)
+        smem.index(1).store(val)
+
+    @gluon.jit
+    def ws_1(smem, bar, layout: ttgl.constexpr):
+        val = smem.index(0).load(layout)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(0), count=1)
+        smem.index(2).store(val)
+
+    @gluon.jit
+    def ws_2(smem, bar, FAILURE: ttgl.constexpr, layout: ttgl.constexpr):
+        if not FAILURE:
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+        smem.index(0).store(ttgl.arange(0, XBLOCK_C, layout).to(ttgl.float16))
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(1), count=1)
+
+    @gluon.jit
+    def kernel(output, FAILURE: ttgl.constexpr):
+        WARP_SIZE: ttgl.constexpr = 32
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1], threads_per_warp=[32],
+                                                            warps_per_cta=[4], order=[0])
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [3, XBLOCK_C], smem_layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(0), count=2 * 4 * WARP_SIZE)
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(1), count=4 * WARP_SIZE)
+        ttgl.warp_specialize([
+            (ws_default, (smem, bar, blocked_layout)),
+            (ws_1, (smem, bar, blocked_layout)),
+            (ws_2, (smem, bar, FAILURE, blocked_layout)),
+        ], [4, 4])
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(1), phase=0)
+        val = smem.index(0).load(blocked_layout)
+        output_ptrs = output + ttgl.arange(0, XBLOCK_C, blocked_layout)
+        ttgl.store(output_ptrs, val)
+
+    output = torch.empty((XBLOCK, ), device="cuda", dtype=torch.float16)
+    kernel[(1, )](output, FAILURE=FAILURE, num_warps=4)
+
+
+def ws_two_loads_two_bars_loop():
+    MISSING_BAR = sys.argv[2]
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def ws_default(smem, bar, MISSING_BAR: ttgl.constexpr, layout: ttgl.constexpr):
+        acc = ttgl.zeros([XBLOCK_C], ttgl.float16, layout)
+        phase = 0
+        for _ in range(10):
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(2), phase=phase)
+            phase = (phase + 1) % 2
+            val = smem.index(0).load(layout)
+            ttgl.amd.gfx1250.mbarrier.arrive(bar.index(0), count=1)
+            acc = acc + val
+        smem.index(1).store(acc)
+
+    @gluon.jit
+    def ws_1(smem, bar, MISSING_BAR: ttgl.constexpr, layout: ttgl.constexpr):
+        acc = ttgl.zeros([XBLOCK_C], ttgl.float16, layout)
+        phase = 0
+        for _ in range(10):
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(3), phase=phase)
+            phase = (phase + 1) % 2
+            val = smem.index(0).load(layout)
+            ttgl.amd.gfx1250.mbarrier.arrive(bar.index(1), count=1)
+            acc = acc + val
+        smem.index(2).store(acc)
+
+    @gluon.jit
+    def ws_2(smem, bar, MISSING_BAR: ttgl.constexpr, layout: ttgl.constexpr):
+        phase = 0
+        for _ in range(10):
+            if MISSING_BAR != "0":
+                ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=phase)
+            if MISSING_BAR != "1":
+                ttgl.amd.gfx1250.mbarrier.wait(bar.index(1), phase=phase)
+            phase = (phase + 1) % 2
+            smem.index(0).store(ttgl.arange(0, XBLOCK_C, layout).to(ttgl.float16))
+            ttgl.amd.gfx1250.mbarrier.arrive(bar.index(2), count=1)
+            ttgl.amd.gfx1250.mbarrier.arrive(bar.index(3), count=1)
+
+    @gluon.jit
+    def kernel(output, MISSING_BAR: ttgl.constexpr):
+        WARP_SIZE: ttgl.constexpr = 32
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1], threads_per_warp=[32],
+                                                            warps_per_cta=[4], order=[0])
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [3, XBLOCK_C], smem_layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [4, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        for i in range(4):
+            ttgl.amd.gfx1250.mbarrier.init(bar.index(i), count=4 * WARP_SIZE)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(2), count=1)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(3), count=1)
+        ttgl.warp_specialize([
+            (ws_default, (smem, bar, MISSING_BAR, blocked_layout)),
+            (ws_1, (smem, bar, MISSING_BAR, blocked_layout)),
+            (ws_2, (smem, bar, MISSING_BAR, blocked_layout)),
+        ], [4, 4])
+
+    output = torch.empty((XBLOCK, ), device="cuda", dtype=torch.float16)
+    kernel[(1, )](output, MISSING_BAR=MISSING_BAR, num_warps=4)
+
+
+def ws_load_ordering():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def ws_default(smem, bar, FAILURE: ttgl.constexpr, layout: ttgl.constexpr):
+        phase = 0
+        for _ in range(10):
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(2), phase=phase)
+            phase = (phase + 1) % 2
+            smem.index(0).store(ttgl.arange(0, XBLOCK_C, layout).to(ttgl.float16))
+            ttgl.amd.gfx1250.mbarrier.arrive(bar.index(0), count=1)
+            smem.index(1).store(ttgl.arange(0, XBLOCK_C, layout).to(ttgl.float16))
+            ttgl.amd.gfx1250.mbarrier.arrive(bar.index(1), count=1)
+
+    @gluon.jit
+    def ws_1(smem, bar, FAILURE: ttgl.constexpr, layout: ttgl.constexpr):
+        acc = ttgl.zeros([XBLOCK_C], ttgl.float16, layout)
+        phase = 0
+        for _ in range(10):
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=phase)
+            val = smem.index(1 if FAILURE else 0).load(layout)
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(1), phase=phase)
+            phase = (phase + 1) % 2
+            ttgl.amd.gfx1250.mbarrier.arrive(bar.index(2), count=1)
+            acc = acc + val
+        smem.index(2).store(acc)
+
+    @gluon.jit
+    def kernel(output, FAILURE: ttgl.constexpr):
+        WARP_SIZE: ttgl.constexpr = 32
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1], threads_per_warp=[32],
+                                                            warps_per_cta=[4], order=[0])
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [3, XBLOCK_C], smem_layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [3, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        for i in range(3):
+            ttgl.amd.gfx1250.mbarrier.init(bar.index(i), count=4 * WARP_SIZE)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(2), count=1)
+        ttgl.warp_specialize([
+            (ws_default, (smem, bar, FAILURE, blocked_layout)),
+            (ws_1, (smem, bar, FAILURE, blocked_layout)),
+        ], [4])
+
+    output = torch.empty((XBLOCK, ), device="cuda", dtype=torch.float16)
+    kernel[(1, )](output, FAILURE=FAILURE, num_warps=4)
+
+
+def ws_different_warp_sizes():
+    MISSING_BAR = sys.argv[2]
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def ws_default(smem, bar, MISSING_BAR: ttgl.constexpr, layout: ttgl.constexpr):
+        val = smem.index(0).load(layout)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(0), count=1)
+        smem.index(1).store(val)
+
+    @gluon.jit
+    def ws_1(smem, bar, MISSING_BAR: ttgl.constexpr, layout: ttgl.constexpr):
+        val = smem.index(0).load(layout)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(1), count=1)
+        smem.index(2).store(val)
+
+    @gluon.jit
+    def ws_2(smem, bar, MISSING_BAR: ttgl.constexpr, layout: ttgl.constexpr):
+        if MISSING_BAR != "1":
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+        if MISSING_BAR != "2":
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(1), phase=0)
+        smem.index(0).store(ttgl.arange(0, XBLOCK_C, layout).to(ttgl.float16))
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(2), count=1)
+
+    @gluon.jit
+    def kernel(output, MISSING_BAR: ttgl.constexpr):
+        WARP_SIZE: ttgl.constexpr = 32
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0])
+        layout_4: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1], threads_per_warp=[32], warps_per_cta=[4],
+                                                      order=[0])
+        layout_2: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1], threads_per_warp=[32], warps_per_cta=[2],
+                                                      order=[0])
+        layout_8: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1], threads_per_warp=[32], warps_per_cta=[8],
+                                                      order=[0])
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [3, XBLOCK_C], smem_layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [3, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(0), count=4 * WARP_SIZE)
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(1), count=2 * WARP_SIZE)
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(2), count=8 * WARP_SIZE)
+        ttgl.warp_specialize([
+            (ws_default, (smem, bar, MISSING_BAR, layout_4)),
+            (ws_1, (smem, bar, MISSING_BAR, layout_2)),
+            (ws_2, (smem, bar, MISSING_BAR, layout_8)),
+        ], [2, 8])
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(2), phase=0)
+        val = smem.index(0).load(layout_4)
+        output_ptrs = output + ttgl.arange(0, XBLOCK_C, layout_4)
+        ttgl.store(output_ptrs, val)
+
+    output = torch.empty((XBLOCK, ), device="cuda", dtype=torch.float16)
+    kernel[(1, )](output, MISSING_BAR=MISSING_BAR, num_warps=4)
+
+
+def async_tdm_kernel():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def kernel(input_ptr, out, FAILURE: ttgl.constexpr):
+        NUM_WARPS: ttgl.constexpr = 4
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[1, 0])
+
+        desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=input_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                           strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                           layout=smem_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, shape=desc.block_shape, layout=desc.layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(0), count=NUM_WARPS)
+
+        ttgl.amd.gfx1250.tdm.async_load(desc, [0, 0], smem, mbarrier=bar.index(0))
+        if not FAILURE:
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+        val = smem.load(blocked_layout)
+        if FAILURE:
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+
+        out_m = ttgl.arange(0, XBLOCK_C, ttgl.SliceLayout(1, blocked_layout))[:, None]
+        out_n = ttgl.arange(0, XBLOCK_C, ttgl.SliceLayout(0, blocked_layout))[None, :]
+        out_ptr = out + out_m * XBLOCK_C + out_n
+        ttgl.store(out_ptr, val)
+
+    input = torch.randn((XBLOCK, XBLOCK), dtype=torch.float16)
+    input = input.cuda()
+    output = torch.empty((XBLOCK, XBLOCK), dtype=torch.float16)
+    output = output.cuda()
+    kernel[(1, )](input, output, FAILURE=FAILURE, num_warps=4)
+
+
+def async_tdm_kernel_2bufs_1bar():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def kernel(a_ptr, b_ptr, out, FAILURE: ttgl.constexpr):
+        NUM_WARPS: ttgl.constexpr = 4
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[1, 0])
+
+        a_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=a_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                             strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                             layout=smem_layout)
+        b_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=b_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                             strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                             layout=smem_layout)
+        a_smem = ttgl.allocate_shared_memory(ttgl.float16, shape=a_desc.block_shape, layout=a_desc.layout)
+        b_smem = ttgl.allocate_shared_memory(ttgl.float16, shape=b_desc.block_shape, layout=b_desc.layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [1, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        # 2 TDM loads x NUM_WARPS per-warp arrivals = 2*NUM_WARPS total
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(0), count=2 * NUM_WARPS)
+
+        ttgl.amd.gfx1250.tdm.async_load(a_desc, [0, 0], a_smem, mbarrier=bar.index(0))
+        ttgl.amd.gfx1250.tdm.async_load(b_desc, [0, 0], b_smem, mbarrier=bar.index(0))
+        if not FAILURE:
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+        val = a_smem.load(blocked_layout)
+        val = val + b_smem.load(blocked_layout)
+        if FAILURE:
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+
+        out_m = ttgl.arange(0, XBLOCK_C, ttgl.SliceLayout(1, blocked_layout))[:, None]
+        out_n = ttgl.arange(0, XBLOCK_C, ttgl.SliceLayout(0, blocked_layout))[None, :]
+        out_ptr = out + out_m * XBLOCK_C + out_n
+        ttgl.store(out_ptr, val)
+
+    a = torch.randn((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    b = torch.randn((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    output = torch.empty((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    kernel[(1, )](a, b, output, FAILURE=FAILURE, num_warps=4)
+
+
+def tdm_interleave_kernel():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def kernel(input_ptr, out, FAILURE: ttgl.constexpr):
+        NUM_WARPS: ttgl.constexpr = 4
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[1, 0])
+
+        desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=input_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                           strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                           layout=smem_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [2] + list(desc.block_shape), desc.layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(0), count=NUM_WARPS)
+        ttgl.amd.gfx1250.mbarrier.init(bar.index(1), count=NUM_WARPS)
+
+        ttgl.amd.gfx1250.tdm.async_load(desc, [0, 0], smem.index(0), mbarrier=bar.index(0))
+        ttgl.amd.gfx1250.tdm.async_load(desc, [0, 0], smem.index(1), mbarrier=bar.index(1))
+
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+        if not FAILURE:
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(1), phase=0)
+
+        out_m = ttgl.arange(0, XBLOCK_C, ttgl.SliceLayout(1, blocked_layout))[:, None]
+        out_n = ttgl.arange(0, XBLOCK_C, ttgl.SliceLayout(0, blocked_layout))[None, :]
+        out_ptr = out + out_m * XBLOCK_C + out_n
+        ttgl.store(out_ptr, smem.index(0).load(blocked_layout))
+        ttgl.store(out_ptr, smem.index(1).load(blocked_layout))
+
+        out_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=input_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                               strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                               layout=smem_layout)
+        ttgl.amd.gfx1250.tdm.async_store(out_desc, [0, 0], smem.index(0))
+        ttgl.amd.gfx1250.tdm.async_wait(0)
+
+    input_t = torch.randn((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    output = torch.empty((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    kernel[(1, )](input_t, output, FAILURE=FAILURE, num_warps=4)
+
+
+def async_copy_kernel():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def kernel(input_ptr, FAILURE: ttgl.constexpr):
+        num_warps: ttgl.constexpr = ttgl.num_warps()
+        smem_layout: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[32, 4]], [XBLOCK_C, XBLOCK_C], [1, 0])
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [2, XBLOCK_C, XBLOCK_C], smem_layout)
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [4, 8], [num_warps, 1], [1, 0])
+        offs_m = ttgl.arange(0, XBLOCK_C, layout=ttgl.SliceLayout(dim=1, parent=blocked_layout))[:, None]
+        offs_n = ttgl.arange(0, XBLOCK_C, layout=ttgl.SliceLayout(dim=0, parent=blocked_layout))[None, :]
+        offs = offs_m * XBLOCK_C + offs_n
+        ttgl.amd.gfx1250.async_copy.global_to_shared(smem.index(0), input_ptr + offs)
+        ttgl.amd.gfx1250.async_copy.commit_group()
+
+        ttgl.amd.gfx1250.async_copy.global_to_shared(smem.index(1), input_ptr + offs)
+        ttgl.amd.gfx1250.async_copy.commit_group()
+        ttgl.amd.gfx1250.async_copy.wait_group(2 if FAILURE else 1)
+
+        ttgl.amd.gfx1250.async_copy.global_to_shared(smem.index(0), input_ptr + offs)
+        ttgl.amd.gfx1250.async_copy.commit_group()
+        ttgl.amd.gfx1250.async_copy.wait_group(0)
+
+    input_t = torch.randn((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    kernel[(1, )](input_t, FAILURE=FAILURE, num_warps=4)
+
+
+def tdm_store_kernel():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def kernel(output_ptr, FAILURE: ttgl.constexpr):
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[1, 0])
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [2, XBLOCK_C, XBLOCK_C], smem_layout)
+        val = ttgl.full([XBLOCK_C, XBLOCK_C], 42, ttgl.float16, blocked_layout)
+
+        out_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=output_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                               strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                               layout=smem_layout)
+
+        ttgl.amd.gfx1250.tdm.async_store(out_desc, [0, 0], smem.index(0))
+        ttgl.amd.gfx1250.tdm.async_store(out_desc, [0, 0], smem.index(1))
+        ttgl.amd.gfx1250.tdm.async_wait(1)
+        smem.index(0).store(val)
+        if not FAILURE:
+            ttgl.amd.gfx1250.tdm.async_wait(0)
+        smem.index(1).store(val)
+
+    output = torch.empty((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    kernel[(1, )](output, FAILURE=FAILURE, num_warps=4)
+
+
+def tdm_load_no_barrier_kernel():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def kernel(input_ptr, out, FAILURE: ttgl.constexpr):
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[1, 0])
+
+        desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=input_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                           strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                           layout=smem_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, shape=desc.block_shape, layout=desc.layout)
+
+        ttgl.amd.gfx1250.tdm.async_load(desc, [0, 0], smem)
+        if not FAILURE:
+            ttgl.amd.gfx1250.tdm.async_wait(0)
+        val = smem.load(blocked_layout)
+        if FAILURE:
+            ttgl.amd.gfx1250.tdm.async_wait(0)
+
+        out_m = ttgl.arange(0, XBLOCK_C, ttgl.SliceLayout(1, blocked_layout))[:, None]
+        out_n = ttgl.arange(0, XBLOCK_C, ttgl.SliceLayout(0, blocked_layout))[None, :]
+        out_ptr = out + out_m * XBLOCK_C + out_n
+        ttgl.store(out_ptr, val)
+
+    input_t = torch.randn((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    output = torch.empty((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    kernel[(1, )](input_t, output, FAILURE=FAILURE, num_warps=4)
+
+
+def tdm_load_store_combined_kernel():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def kernel(input_ptr, output_ptr, FAILURE: ttgl.constexpr):
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[1, 0])
+
+        in_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=input_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                              strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                              layout=smem_layout)
+        out_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=output_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                               strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                               layout=smem_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, shape=in_desc.block_shape, layout=in_desc.layout)
+
+        ttgl.amd.gfx1250.tdm.async_load(in_desc, [0, 0], smem)
+        ttgl.amd.gfx1250.tdm.async_store(out_desc, [0, 0], smem)
+        if not FAILURE:
+            ttgl.amd.gfx1250.tdm.async_wait(0)
+        val = smem.load(blocked_layout)
+        if FAILURE:
+            ttgl.amd.gfx1250.tdm.async_wait(0)
+
+        out_m = ttgl.arange(0, XBLOCK_C, ttgl.SliceLayout(1, blocked_layout))[:, None]
+        out_n = ttgl.arange(0, XBLOCK_C, ttgl.SliceLayout(0, blocked_layout))[None, :]
+        ptr = output_ptr + out_m * XBLOCK_C + out_n
+        ttgl.store(ptr, val)
+
+    input_t = torch.randn((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    output = torch.empty((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    kernel[(1, )](input_t, output, FAILURE=FAILURE, num_warps=4)
+
+
+def tdm_two_bufs_one_wait_kernel():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def kernel(a_ptr, b_ptr, out, FAILURE: ttgl.constexpr):
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[1, 0])
+
+        a_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=a_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                             strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                             layout=smem_layout)
+        b_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=b_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                             strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                             layout=smem_layout)
+        a_smem = ttgl.allocate_shared_memory(ttgl.float16, shape=a_desc.block_shape, layout=a_desc.layout)
+        b_smem = ttgl.allocate_shared_memory(ttgl.float16, shape=b_desc.block_shape, layout=b_desc.layout)
+
+        ttgl.amd.gfx1250.tdm.async_load(a_desc, [0, 0], a_smem)
+        ttgl.amd.gfx1250.tdm.async_load(b_desc, [0, 0], b_smem)
+        if not FAILURE:
+            ttgl.amd.gfx1250.tdm.async_wait(1)
+        val = a_smem.load(blocked_layout)
+        if FAILURE:
+            ttgl.amd.gfx1250.tdm.async_wait(0)
+
+        out_m = ttgl.arange(0, XBLOCK_C, ttgl.SliceLayout(1, blocked_layout))[:, None]
+        out_n = ttgl.arange(0, XBLOCK_C, ttgl.SliceLayout(0, blocked_layout))[None, :]
+        out_ptr = out + out_m * XBLOCK_C + out_n
+        ttgl.store(out_ptr, val)
+
+    a = torch.randn((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    b = torch.randn((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    output = torch.empty((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    kernel[(1, )](a, b, output, FAILURE=FAILURE, num_warps=4)
+
+
+def ws_store_wait_load_failure():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def ws_consumer(smem, ready_bar, done_bar, FAILURE: ttgl.constexpr, layout: ttgl.constexpr):
+        if not FAILURE:
+            ttgl.amd.gfx1250.mbarrier.wait(ready_bar, phase=0)
+        val = smem.index(0).load(layout)
+        smem.index(1).store(val)
+        ttgl.amd.gfx1250.mbarrier.arrive(done_bar, count=1)
+
+    @gluon.jit
+    def ws_producer(smem, ready_bar, XBLOCK: ttgl.constexpr, layout: ttgl.constexpr):
+        smem.index(0).store(ttgl.arange(0, XBLOCK, layout).to(ttgl.float16))
+        ttgl.amd.gfx1250.mbarrier.arrive(ready_bar, count=1)
+
+    @gluon.jit
+    def kernel(output, FAILURE: ttgl.constexpr):
+        WARP_SIZE: ttgl.constexpr = 32
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1], threads_per_warp=[32],
+                                                            warps_per_cta=[4], order=[0])
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [2, XBLOCK_C], smem_layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        for i in range(2):
+            ttgl.amd.gfx1250.mbarrier.init(bar.index(i), count=4 * WARP_SIZE)
+        ready_bar = bar.index(0)
+        done_bar = bar.index(1)
+        ttgl.warp_specialize([
+            (ws_consumer, (smem, ready_bar, done_bar, FAILURE, blocked_layout)),
+            (ws_producer, (smem, ready_bar, XBLOCK_C, blocked_layout)),
+        ], [4])
+        ttgl.amd.gfx1250.mbarrier.wait(done_bar, phase=0)
+        val = smem.index(1).load(blocked_layout)
+        output_ptrs = output + ttgl.arange(0, XBLOCK_C, blocked_layout)
+        ttgl.store(output_ptrs, val)
+
+    output = torch.empty((XBLOCK, ), dtype=torch.float16).cuda()
+    kernel[(1, )](output, FAILURE=FAILURE, num_warps=4)
+
+
+def ws_load_wait_store_failure():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def ws_default(smem, bar, FAILURE: ttgl.constexpr, layout: ttgl.constexpr):
+        if not FAILURE:
+            ttgl.amd.gfx1250.mbarrier.wait(bar.index(0), phase=0)
+        smem.index(0).store(ttgl.arange(0, XBLOCK_C, layout).to(ttgl.float16))
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(1), count=1)
+
+    @gluon.jit
+    def ws_1(smem, bar, FAILURE: ttgl.constexpr, layout: ttgl.constexpr):
+        val = smem.index(0).load(layout)
+        ttgl.amd.gfx1250.mbarrier.arrive(bar.index(0), count=1)
+        smem.index(1).store(val)
+
+    @gluon.jit
+    def kernel(output, FAILURE: ttgl.constexpr):
+        WARP_SIZE: ttgl.constexpr = 32
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0])
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1], threads_per_warp=[32],
+                                                            warps_per_cta=[4], order=[0])
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [2, XBLOCK_C], smem_layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        for i in range(2):
+            ttgl.amd.gfx1250.mbarrier.init(bar.index(i), count=4 * WARP_SIZE)
+        ttgl.warp_specialize([
+            (ws_default, (smem, bar, FAILURE, blocked_layout)),
+            (ws_1, (smem, bar, FAILURE, blocked_layout)),
+        ], [4])
+        ttgl.amd.gfx1250.mbarrier.wait(bar.index(1), phase=0)
+        val = smem.index(0).load(blocked_layout)
+        output_ptrs = output + ttgl.arange(0, XBLOCK_C, blocked_layout)
+        ttgl.store(output_ptrs, val)
+
+    output = torch.empty((XBLOCK, ), dtype=torch.float16).cuda()
+    kernel[(1, )](output, FAILURE=FAILURE, num_warps=4)
+
+
+def tdm_cross_partition_kernel():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def ws_default(desc, smem, sync_bar, FAILURE: ttgl.constexpr):
+        ttgl.amd.gfx1250.tdm.async_load(desc, [0, 0], smem)
+        if not FAILURE:
+            ttgl.amd.gfx1250.tdm.async_wait(0)
+        ttgl.amd.gfx1250.mbarrier.arrive(sync_bar, count=1)
+
+    @gluon.jit
+    def ws_1(desc, smem, sync_bar, FAILURE: ttgl.constexpr):
+        ttgl.amd.gfx1250.mbarrier.wait(sync_bar, phase=0)
+        ttgl.amd.gfx1250.tdm.async_load(desc, [0, 0], smem)
+        ttgl.amd.gfx1250.tdm.async_wait(0)
+
+    @gluon.jit
+    def kernel(input_ptr, FAILURE: ttgl.constexpr):
+        WARP_SIZE: ttgl.constexpr = 32
+        NUM_WARPS: ttgl.constexpr = 4
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
+
+        desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=input_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                           strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                           layout=smem_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, shape=desc.block_shape, layout=desc.layout)
+        sync_bar = ttgl.allocate_shared_memory(ttgl.int64, [1, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        ttgl.amd.gfx1250.mbarrier.init(sync_bar.index(0), count=NUM_WARPS * WARP_SIZE)
+
+        ttgl.warp_specialize([
+            (ws_default, (desc, smem, sync_bar.index(0), FAILURE)),
+            (ws_1, (desc, smem, sync_bar.index(0), FAILURE)),
+        ], [NUM_WARPS])
+
+    input_t = torch.randn((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    kernel[(1, )](input_t, FAILURE=FAILURE, num_warps=4)
+
+
+def tdm_cross_partition_load_store_kernel():
+    FAILURE = sys.argv[2] == "True"
+    XBLOCK_C: ttgl.constexpr = ttgl.constexpr(XBLOCK)
+
+    @gluon.jit
+    def ws_default(in_desc, smem, sync_bar, FAILURE: ttgl.constexpr):
+        ttgl.amd.gfx1250.tdm.async_load(in_desc, [0, 0], smem)
+        if not FAILURE:
+            ttgl.amd.gfx1250.tdm.async_wait(0)
+        ttgl.amd.gfx1250.mbarrier.arrive(sync_bar, count=1)
+
+    @gluon.jit
+    def ws_1(out_desc, smem, sync_bar, FAILURE: ttgl.constexpr):
+        ttgl.amd.gfx1250.mbarrier.wait(sync_bar, phase=0)
+        ttgl.amd.gfx1250.tdm.async_store(out_desc, [0, 0], smem)
+        ttgl.amd.gfx1250.tdm.async_wait(0)
+
+    @gluon.jit
+    def kernel(input_ptr, output_ptr, FAILURE: ttgl.constexpr):
+        WARP_SIZE: ttgl.constexpr = 32
+        NUM_WARPS: ttgl.constexpr = 4
+        smem_layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[1, 0])
+
+        in_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=input_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                              strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                              layout=smem_layout)
+        out_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=output_ptr, shape=(XBLOCK_C, XBLOCK_C),
+                                                               strides=(XBLOCK_C, 1), block_shape=(XBLOCK_C, XBLOCK_C),
+                                                               layout=smem_layout)
+        smem = ttgl.allocate_shared_memory(ttgl.float16, shape=in_desc.block_shape, layout=in_desc.layout)
+        sync_bar = ttgl.allocate_shared_memory(ttgl.int64, [1, 1], ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+        ttgl.amd.gfx1250.mbarrier.init(sync_bar.index(0), count=NUM_WARPS * WARP_SIZE)
+
+        ttgl.warp_specialize([
+            (ws_default, (in_desc, smem, sync_bar.index(0), FAILURE)),
+            (ws_1, (out_desc, smem, sync_bar.index(0), FAILURE)),
+        ], [NUM_WARPS])
+
+    input_t = torch.randn((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    output = torch.empty((XBLOCK, XBLOCK), dtype=torch.float16).cuda()
+    kernel[(1, )](input_t, output, FAILURE=FAILURE, num_warps=4)
+
+
+if __name__ == "__main__":
+    tests = {
+        "ws_store_wait_load_failure": ws_store_wait_load_failure, "ws_load_wait_store_failure":
+        ws_load_wait_store_failure, "deadlock_two_partitions": deadlock_two_partitions, "deadlock_overarrival":
+        deadlock_overarrival, "deadlock_underarrival": deadlock_underarrival, "deadlock_different_phases":
+        deadlock_different_phases, "barrier_underflow": barrier_underflow, "aliasing_shared_visibility":
+        aliasing_shared_visibility, "ws_two_loads_two_bars": ws_two_loads_two_bars, "ws_two_loads_one_bar":
+        ws_two_loads_one_bar, "ws_two_loads_two_bars_loop": ws_two_loads_two_bars_loop, "ws_load_ordering":
+        ws_load_ordering, "ws_different_warp_sizes": ws_different_warp_sizes, "async_tdm_kernel": async_tdm_kernel,
+        "async_tdm_kernel_2bufs_1bar": async_tdm_kernel_2bufs_1bar, "tdm_interleave_kernel": tdm_interleave_kernel,
+        "async_copy_kernel": async_copy_kernel, "tdm_store_kernel": tdm_store_kernel, "tdm_load_no_barrier_kernel":
+        tdm_load_no_barrier_kernel, "tdm_load_store_combined_kernel": tdm_load_store_combined_kernel,
+        "tdm_two_bufs_one_wait_kernel": tdm_two_bufs_one_wait_kernel, "tdm_cross_partition_kernel":
+        tdm_cross_partition_kernel, "tdm_cross_partition_load_store_kernel": tdm_cross_partition_load_store_kernel
+    }
+    tests[sys.argv[1]]()

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -3021,6 +3021,15 @@ def test_ws_store_wait_load(XBLOCK):
     arange pattern.
     """
 
+    import os
+    if os.environ.get("TRITON_INSTRUMENTATION_MODE") == "consan":
+        from triton.runtime._allocation import set_profile_allocator
+
+        def alloc_fn(size: int, alignment: int, stream):
+            return torch.empty(size, device="cuda", dtype=torch.int8)
+
+        set_profile_allocator(alloc_fn)
+
     @gluon.jit
     def ws_consumer(smem, ready_bar, done_bar, layout: ttgl.constexpr):
         ttgl.amd.gfx1250.mbarrier.wait(ready_bar, phase=0)
@@ -3082,6 +3091,15 @@ def test_ws_store_wait_load_loop(XBLOCK, NUM_ITERS):
     (executed by default warps) waits for done_bar, loads the accumulated result, and stores it to global memory.
     The test verifies that the output equals the expected arange pattern.
     """
+
+    import os
+    if os.environ.get("TRITON_INSTRUMENTATION_MODE") == "consan":
+        from triton.runtime._allocation import set_profile_allocator
+
+        def alloc_fn(size: int, alignment: int, stream):
+            return torch.empty(size, device="cuda", dtype=torch.int8)
+
+        set_profile_allocator(alloc_fn)
 
     @gluon.jit
     def ws_consumer(smem, ready_bar, done_bar, empty_bar, XBLOCK: ttgl.constexpr, NUM_ITERS: ttgl.constexpr,
@@ -3162,6 +3180,15 @@ def test_runtime_ws_tensor_async_load_store_mbarrier(M, N, BLOCK_M, BLOCK_N, NUM
 
     The test verifies that the output matches the input, confirming that async load/store operations are correctly coordinated by mbarriers.
     """
+
+    import os
+    if os.environ.get("TRITON_INSTRUMENTATION_MODE") == "consan":
+        from triton.runtime._allocation import set_profile_allocator
+
+        def alloc_fn(size: int, alignment: int, stream):
+            return torch.empty(size, device="cuda", dtype=torch.int8)
+
+        set_profile_allocator(alloc_fn)
 
     @gluon.jit
     def ws_producer(a_desc, a_buffer, bars, pid_n, idx_m, BLOCK_N: ttgl.constexpr, NUM_BUFFERS: ttgl.constexpr):
@@ -3245,6 +3272,15 @@ def test_runtime_ws_tensor_copy_mbarrier(M, N, BLOCK_M, BLOCK_N, NUM_BUFFERS, NU
 
     The test verifies that the output matches the input, confirming correct synchronization.
     """
+
+    import os
+    if os.environ.get("TRITON_INSTRUMENTATION_MODE") == "consan":
+        from triton.runtime._allocation import set_profile_allocator
+
+        def alloc_fn(size: int, alignment: int, stream):
+            return torch.empty(size, device="cuda", dtype=torch.int8)
+
+        set_profile_allocator(alloc_fn)
 
     @gluon.jit
     def ws_producer(a_desc, a_buffer, bars, pid_n, idx_m, BLOCK_N: ttgl.constexpr, NUM_BUFFERS: ttgl.constexpr):

--- a/third_party/amd/python/test/test_gluon_gfx1250_consan.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250_consan.py
@@ -1,0 +1,434 @@
+# ruff: noqa: E402
+import hip
+
+hip.hip.hipInit(0)
+
+import pytest
+import subprocess
+import sys
+import os
+
+from triton._internal_testing import is_hip_gfx1250
+
+
+def _run_consan_subprocess(test_name, *args, timeout=120):
+    """Run a ConSan test kernel in a subprocess and return captured stderr.
+
+    The subprocess pipe captures all stderr output including messages
+    flushed during process exit.
+    """
+    helper_script = os.path.join(os.path.dirname(__file__), "gfx1250_consan_helper.py")
+    proc = subprocess.Popen(
+        [sys.executable, helper_script, test_name] + [str(a) for a in args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        _, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        _, stderr = proc.communicate()
+    return stderr.decode(errors="replace")
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_ws_store_wait_load(FAILURE):
+    """
+    Producer stores to smem and signals ready_bar. Consumer conditionally waits
+    on ready_bar before reading smem. FAILURE=True skips the wait, triggering
+    an error.
+    """
+    stderr_str = _run_consan_subprocess("ws_store_wait_load_failure", FAILURE)
+
+    if FAILURE:
+        assert "Buffer being accessed has outstanding writes" in stderr_str, \
+            f"Expected 'Buffer being accessed has outstanding writes' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_ws_load_wait_store(FAILURE):
+    """
+    Worker reads from smem and signals bar[0]. Default partition conditionally
+    waits on bar[0] before writing to smem. FAILURE=True skips the wait,
+    triggering an error.
+    """
+    stderr_str = _run_consan_subprocess("ws_load_wait_store_failure", FAILURE)
+
+    if FAILURE:
+        assert "Buffer being accessed has outstanding reads" in stderr_str, \
+            f"Expected 'Buffer being accessed has outstanding reads' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+def test_deadlock_two_partitions():
+    """
+    Verifies that ConSan detects a deadlock when two warp-specialize partitions
+    each wait on separate barriers that nobody ever arrives on.
+    """
+    stderr_str = _run_consan_subprocess("deadlock_two_partitions")
+
+    assert "Deadlock detected" in stderr_str, f"Expected 'Deadlock detected' in stderr, got:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+def test_deadlock_overarrival():
+    """
+    Verifies that ConSan detects a deadlock caused by over-arrival on an mbarrier.
+    Each thread arrives twice but the barrier only expects one arrival per thread.
+    """
+    stderr_str = _run_consan_subprocess("deadlock_overarrival")
+
+    assert "Deadlock detected" in stderr_str, f"Expected 'Deadlock detected' in stderr, got:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+def test_deadlock_underarrival():
+    """
+    Verifies that ConSan detects a deadlock caused by under-arrival on mbarriers.
+    Two partitions each arrive on the other's barrier but the init count requires
+    arrivals from both partitions.
+    """
+    stderr_str = _run_consan_subprocess("deadlock_underarrival")
+
+    assert "Deadlock detected" in stderr_str, f"Expected 'Deadlock detected' in stderr, got:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+def test_deadlock_different_phases():
+    """
+    Positive test: verifies ConSan does NOT report a false deadlock when two
+    partitions wait on different phases of the same barrier.
+    """
+    stderr_str = _run_consan_subprocess("deadlock_different_phases")
+
+    assert "device assertion failed" not in stderr_str, \
+        f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+def test_barrier_underflow():
+    """
+    Verifies that ConSan detects a barrier arrive underflow when each thread
+    arrives with count=3 on a barrier initialized for count=1 per thread
+    (4*WARP_SIZE=128). Since 128 % 3 != 0, the 43rd arrival triggers underflow.
+    """
+    stderr_str = _run_consan_subprocess("barrier_underflow")
+
+    assert "Barrier arrive underflow" in stderr_str, \
+        f"Expected 'Barrier arrive underflow' in stderr, got:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("MISSING_BAR", [True, False])
+@pytest.mark.parametrize("OVERLAP", [True, False])
+def test_aliasing_shared_visibility(MISSING_BAR, OVERLAP):
+    """
+    Verifies that ConSan detects unsynchronized access when aliased shared memory
+    regions overlap and the reader skips the barrier synchronization.
+
+    Only the MISSING_BAR=True, OVERLAP=True combination should trigger a
+    ConSan assertion. All other combinations are clean (no overlap or barrier
+    is present).
+    """
+    stderr_str = _run_consan_subprocess("aliasing_shared_visibility", MISSING_BAR, OVERLAP)
+
+    if MISSING_BAR and OVERLAP:
+        has_violation = ("outstanding writes" in stderr_str or "outstanding reads" in stderr_str)
+        assert has_violation, \
+            f"Expected 'outstanding writes' or 'outstanding reads' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("MISSING_BAR", ["none", "1", "2"])
+def test_ws_two_loads_two_bars(MISSING_BAR):
+    """
+    Verifies that ConSan detects unsynchronized access when two reader
+    partitions load from the same buffer and a writer partition skips
+    one of the barrier waits.
+
+    MISSING_BAR="1" or "2" should trigger a ConSan assertion.
+    "none" should be clean.
+    """
+    stderr_str = _run_consan_subprocess("ws_two_loads_two_bars", MISSING_BAR)
+
+    if MISSING_BAR != "none":
+        has_violation = ("outstanding writes" in stderr_str or "outstanding reads" in stderr_str)
+        assert has_violation, \
+            f"Expected 'outstanding writes' or 'outstanding reads' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_ws_two_loads_one_bar(FAILURE):
+    """
+    Verifies that ConSan detects unsynchronized access when two reader
+    partitions load from the same buffer via a single shared barrier and
+    the writer partition skips the wait.
+
+    FAILURE=True should trigger "Buffer being accessed has outstanding
+    reads". False should be clean.
+    """
+    stderr_str = _run_consan_subprocess("ws_two_loads_one_bar", FAILURE)
+
+    if FAILURE:
+        assert "Buffer being accessed has outstanding reads" in stderr_str, \
+            f"Expected 'Buffer being accessed has outstanding reads' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("MISSING_BAR", ["none", "0", "1"])
+def test_ws_two_loads_two_bars_loop(MISSING_BAR):
+    """
+    Verifies that ConSan detects unsynchronized access in a looped
+    producer-consumer pattern with two reader partitions and one writer
+    partition, using barriers and phase tracking.
+    """
+    stderr_str = _run_consan_subprocess("ws_two_loads_two_bars_loop", MISSING_BAR)
+
+    if MISSING_BAR == "0":
+        assert "Buffer being accessed has outstanding reads" in stderr_str, \
+            f"Expected 'outstanding reads' in stderr, got:\n{stderr_str}"
+    elif MISSING_BAR == "1":
+        assert "Buffer being accessed has outstanding reads" in stderr_str, \
+            f"Expected 'outstanding reads' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_ws_load_ordering(FAILURE):
+    """
+    Verifies that ConSan detects unsynchronized access when ws_1 loads
+    from smem[1] (protected by bar[1]) after only waiting on bar[0].
+
+    FAILURE=True should trigger "Buffer being accessed has outstanding
+    writes". False should be clean.
+    """
+    stderr_str = _run_consan_subprocess("ws_load_ordering", FAILURE)
+
+    if FAILURE:
+        assert "Buffer being accessed has outstanding writes" in stderr_str, \
+            f"Expected 'outstanding writes' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("MISSING_BAR", ["none", "1", "2"])
+def test_ws_different_warp_sizes(MISSING_BAR):
+    """
+    Verifies that ConSan detects unsynchronized access when three partitions
+    with different warp counts (4, 2, 8) share a buffer.  The writer partition
+    (ws_2, 8 warps) skips one of two barrier waits, storing to smem[0] while
+    readers still have outstanding reads.
+    """
+    stderr_str = _run_consan_subprocess("ws_different_warp_sizes", MISSING_BAR)
+
+    if MISSING_BAR != "none":
+        assert "Buffer being accessed has outstanding reads" in stderr_str, \
+            f"Expected 'Buffer being accessed has outstanding reads' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_async_tdm_kernel(FAILURE):
+    """
+    Verifies that ConSan detects outstanding writes when shared memory is
+    read before a TDM async load (global-to-shared copy) completes.
+
+    FAILURE=True skips the mbarrier.wait before the load, triggering
+    an error.
+    """
+    stderr_str = _run_consan_subprocess("async_tdm_kernel", FAILURE)
+
+    if FAILURE:
+        assert "Buffer being accessed has outstanding writes" in stderr_str, \
+            f"Expected 'Buffer being accessed has outstanding writes' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_async_tdm_kernel_2bufs_1bar(FAILURE):
+    """
+    Two TDM async loads sharing one mbarrier. ConSan must detect
+    outstanding writes when the wait is skipped (FAILURE=True).
+    """
+    stderr_str = _run_consan_subprocess("async_tdm_kernel_2bufs_1bar", FAILURE)
+
+    if FAILURE:
+        assert "Buffer being accessed has outstanding writes" in stderr_str, \
+            f"Expected 'Buffer being accessed has outstanding writes' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_tdm_interleave_kernel(FAILURE):
+    """
+    Two TDM loads with separate barriers, interleaved access.
+    FAILURE=True skips wait on bar[1], so reading smem[1] has outstanding writes.
+    """
+    stderr_str = _run_consan_subprocess("tdm_interleave_kernel", FAILURE)
+
+    if FAILURE:
+        assert "Buffer being accessed has outstanding writes" in stderr_str, \
+            f"Expected 'Buffer being accessed has outstanding writes' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_consan_async_copy(FAILURE):
+    """
+    Async copy with commit_group/wait_group. FAILURE=True uses wait_group(2)
+    instead of wait_group(1), so smem[0] is reused before its copy completes.
+    """
+    stderr_str = _run_consan_subprocess("async_copy_kernel", FAILURE)
+
+    if FAILURE:
+        assert "Accessing buffer with pending access" in stderr_str, \
+            f"Expected 'Accessing buffer with pending access' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_consan_tdm_store(FAILURE):
+    """
+    TDM async store with partial wait. FAILURE=True skips the second
+    async_wait(0) so smem[1] is written while its async store is still
+    reading it.
+    """
+    stderr_str = _run_consan_subprocess("tdm_store_kernel", FAILURE)
+
+    if FAILURE:
+        assert "Accessing buffer with pending access" in stderr_str, \
+            f"Expected 'Accessing buffer with pending access' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_consan_tdm_load_no_barrier(FAILURE):
+    """
+    TDM async load without barrier, using async_wait for completion.
+    FAILURE=True reads shared memory before async_wait, triggering
+    a pending access violation.
+    """
+    stderr_str = _run_consan_subprocess("tdm_load_no_barrier_kernel", FAILURE)
+
+    if FAILURE:
+        assert "Accessing buffer with pending access" in stderr_str, \
+            f"Expected 'Accessing buffer with pending access' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_consan_tdm_two_bufs_one_wait(FAILURE):
+    """
+    Two TDM async loads (no barriers) to separate buffers and a single
+    async_wait. Validates that TDM operations from the same wave are completed in issue order.
+    FAILURE=True reads smem before the wait.
+    """
+    stderr_str = _run_consan_subprocess("tdm_two_bufs_one_wait_kernel", FAILURE)
+
+    if FAILURE:
+        assert "Accessing buffer with pending access" in stderr_str, \
+            f"Expected 'Accessing buffer with pending access' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_consan_tdm_load_store_combined(FAILURE):
+    """
+    TDM async load + async store (both without barriers) and a single
+    async_wait. FAILURE=True reads shared memory before async_wait,
+    triggering a pending access violation.
+    """
+    stderr_str = _run_consan_subprocess("tdm_load_store_combined_kernel", FAILURE)
+
+    if FAILURE:
+        assert "Accessing buffer with pending access" in stderr_str, \
+            f"Expected 'Accessing buffer with pending access' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_consan_tdm_cross_partition(FAILURE):
+    """
+    Two WS partitions both do TDM async load to the same shared memory buffer
+    (commit-tracked, no TDM barrier). FAILURE=True skips async_wait in ws_default
+    partition, leaving its commits outstanding; ws_1's check detects the
+    cross-partition race. FAILURE=False clears commits via async_wait first.
+    """
+    stderr_str = _run_consan_subprocess("tdm_cross_partition_kernel", FAILURE)
+
+    if FAILURE:
+        assert "Accessing buffer with pending access" in stderr_str, \
+            f"Expected 'Accessing buffer with pending access' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_consan_tdm_cross_partition_load_store(FAILURE):
+    """
+    ws_default partition does TDM async load (global -> shared), ws_1 does
+    TDM async store (shared -> global) on the same buffer.
+    FAILURE=True skips async_wait in ws_default, so its access is
+    still pending when ws_1 accesses the buffer; ConSan detects
+    the cross-partition race.
+    """
+    stderr_str = _run_consan_subprocess("tdm_cross_partition_load_store_kernel", FAILURE)
+
+    if FAILURE:
+        assert "Accessing buffer with pending access" in stderr_str, \
+            f"Expected 'Accessing buffer with pending access' in stderr, got:\n{stderr_str}"
+    else:
+        assert "device assertion failed" not in stderr_str, \
+            f"Unexpected ConSan violation in stderr:\n{stderr_str}"

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -64,6 +64,8 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
           pm.addPass(createTritonAMDGPULowerInstructionSchedHintsPass(
               arch, numStages));
         });
+  ADD_PASS_WRAPPER_0("add_prepare_consan_captures",
+                     mlir::triton::createPrepareConSanCaptures);
   ADD_PASS_OPTION_WRAPPER_1("add_allocate_shared_memory",
                             mlir::triton::createAllocateAMDGPUSharedMemoryPass,
                             const std::string &);
@@ -133,6 +135,7 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
   ADD_PASS_OPTION_WRAPPER_1("add_dot_decompose_and_schedule",
                             mlir::createTritonAMDGPUDotDecomposeAndSchedule,
                             const std::string &);
+  mlir::registerConSanAMDHooks();
   m.def("add_in_thread_transpose", [](mlir::PassManager &pm) {
     pm.addNestedPass<mlir::triton::FuncOp>(
         mlir::createTritonAMDGPUInThreadTranspose());

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1096,11 +1096,6 @@ class CUDABackend(BaseBackend):
         nvidia.passes.ttnvgpuir.add_allocate_tensor_memory(pm)
         nvidia.passes.ttgpuir.add_allocate_shared_memory_nv(pm, capability, ptx_version)
         nvidia.passes.ttnvgpuir.add_check_matmul_two_cta(pm)
-        if "consan" in options.instrumentation_mode:
-            # Call ConcurrencySanitizerPass here, before allocating global scratch memory but after allocating tensor and shared
-            passes.ttgpuir.add_concurrency_sanitizer(pm)
-            passes.gluon.add_canonicalizer(pm)
-            passes.common.add_cse(pm)
         if "gsan" in options.instrumentation_mode:
             passes.ttgpuir.add_global_sanitizer(pm)
         # Print TTGIR to TLX mapping before final emission (for debugging/analysis)
@@ -1116,11 +1111,10 @@ class CUDABackend(BaseBackend):
         # instrumentation point here so we can override IRs above (e.g., ttir and ttgir)
         if CUDABackend.instrumentation:
             CUDABackend.instrumentation.patch("ttgpuir_to_llvmir", pm, mod.context)
-        passes.ttgpuir.add_allocate_global_scratch_memory(pm)
         nvidia.passes.ttnvgpuir.add_proxy_fence_insertion(pm, capability)
         nvidia.passes.hopper.add_tma_store_token_wait_lowering(pm)
         nvidia.passes.ttnvgpuir.add_tmem_barrier_insertion(pm)
-        nvidia.passes.ttgpuir.add_to_llvmir(pm, capability, ptx_version)
+        nvidia.passes.ttgpuir.add_to_llvmir(pm, capability, ptx_version, "consan" in options.instrumentation_mode)
         passes.ttgpuir.add_canonicalize_llvm_ir(pm)
         passes.common.add_cse(pm)
         # FB/beta divergence: upstream #9535 ("Re-order WS lowering and NVGPU
@@ -1206,10 +1200,10 @@ class CUDABackend(BaseBackend):
             metadata["num_warps"] = total_num_warps
         metadata["shared"] = src.get_int_attr("ttg.shared")
         metadata["tmem_size"] = src.get_int_attr("ttg.tensor_memory_size")
-        metadata["global_scratch_size"] = src.get_int_attr("ttg.global_scratch_memory_size")
-        metadata["global_scratch_align"] = src.get_int_attr("ttg.global_scratch_memory_alignment")
-        metadata["profile_scratch_size"] = (src.get_int_attr("ttg.profile_scratch_memory_size") or 0)
-        metadata["profile_scratch_align"] = (src.get_int_attr("ttg.profile_scratch_memory_alignment") or 1)
+        metadata["global_scratch_size"] = src.get_int_attr("ttg.global_scratch_memory_size") or 0
+        metadata["global_scratch_align"] = src.get_int_attr("ttg.global_scratch_memory_alignment") or 1
+        metadata["profile_scratch_size"] = src.get_int_attr("ttg.profile_scratch_memory_size") or 0
+        metadata["profile_scratch_align"] = src.get_int_attr("ttg.profile_scratch_memory_alignment") or 1
         ret = str(llvm_mod)
         del llvm_mod
         del context

--- a/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Passes.h
+++ b/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Passes.h
@@ -23,6 +23,9 @@ createConvertTritonGPUToLLVMPass(int32_t computeCapability);
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertTritonGPUToLLVMPass(int32_t computeCapability, int32_t ptxVersion);
 std::unique_ptr<OperationPass<ModuleOp>>
+createConvertTritonGPUToLLVMPass(int32_t computeCapability, int32_t ptxVersion,
+                                 bool enableConcurrencySanitizer);
+std::unique_ptr<OperationPass<ModuleOp>>
 createAllocateSharedMemoryNvPass(int32_t computeCapability, int32_t ptxVersion);
 
 #define GEN_PASS_REGISTRATION

--- a/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Passes.td
+++ b/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Passes.td
@@ -16,6 +16,7 @@ def ConvertTritonGPUToLLVM : Pass<"convert-triton-gpu-to-llvm", "mlir::ModuleOp"
                              "mlir::LLVM::LLVMDialect",
                              "mlir::triton::TritonDialect",
                              "mlir::triton::gpu::TritonGPUDialect",
+                             "mlir::triton::instrument::TritonInstrumentDialect",
                              "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
                              "mlir::triton::nvgpu::NVGPUDialect",
                              "mlir::NVVM::NVVMDialect"];
@@ -27,6 +28,9 @@ def ConvertTritonGPUToLLVM : Pass<"convert-triton-gpu-to-llvm", "mlir::ModuleOp"
         Option<"ptxVersion", "ptx-version",
                "int32_t", /*default*/"80",
                "PTX version">,
+        Option<"enableConcurrencySanitizer", "enable-concurrency-sanitizer",
+               "bool", /*default*/"false",
+               "run ConSan after fence and membar preparation">,
     ];
 }
 def AllocateSharedMemoryNv : Pass<"allocate-shared-memory-nv", "mlir::ModuleOp"> {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
@@ -25,6 +25,7 @@ add_triton_library(TritonNVIDIAGPUToLLVM
     NVGPUAttrDefsIncGen
 
     LINK_LIBS PUBLIC
+    GluonTransforms
     TritonAnalysis
     TritonGPUToLLVM
     TritonInstrumentIR

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -415,20 +415,20 @@ static void createMMACommit(ConversionPatternRewriter &rewriter, Location loc,
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value mask;
   if (!descs.empty()) {
-    auto kBlock = StringAttr::get(rewriter.getContext(), "block");
-    for (Value desc : descs) {
-      auto descTy = cast<MemDescType>(desc.getType());
-      uint16_t broadcastBits =
-          toLinearLayout(descTy).getFreeVariableMasks().lookup(kBlock);
-      if (twoCTAs)
-        broadcastBits |= 1;
-      if (broadcastBits) {
-        Value descMask =
-            LLVM::NVIDIA::createTMAMulticastMask(loc, rewriter, broadcastBits);
-        mask = mask ? b.or_(descMask, mask) : descMask;
-      }
+    for (uint16_t broadcastBits : ttng::getCTABroadcastMasks(twoCTAs, descs)) {
+      Value descMask =
+          LLVM::NVIDIA::createTMAMulticastMask(loc, rewriter, broadcastBits);
+      mask = mask ? b.or_(descMask, mask) : descMask;
     }
   } else if (twoCTAs) {
+    // Beta encodes Blackwell 2-CTA paired MMA via the ttng.two-ctas attribute
+    // while the tensors keep a 1-CTA CGA layout, so lookupNumCTAs() == 1 here.
+    // Routing the completion-barrier mask through
+    // createTMAMulticastMask()/getTMAMulticastMaskEncoding() therefore does not
+    // expand the cluster group and collapses the multicast to the issuing CTA
+    // (0b01), leaving the peer CTA's mbarrier unsignalled -> cluster deadlock.
+    // Build the both-CTA mask (0b11, shifted to the CTA pair) directly from the
+    // paired-MMA flag, independent of lookupNumCTAs().
     auto clusterCTARank = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
     Value ctaPairBase = b.and_(clusterCTARank, b.i32_val(~1));
     mask = b.shl(b.i32_val(3), ctaPairBase);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -11,12 +11,17 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
 #include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Analysis/Membar.h"
+#include "triton/Conversion/TritonGPUToLLVM/Passes.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/Gluon/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
 
@@ -90,6 +95,10 @@ struct ConvertTritonGPUToLLVM
       : ConvertTritonGPUToLLVMBase({computeCapability}) {}
   ConvertTritonGPUToLLVM(int32_t computeCapability, int32_t ptxVersion)
       : ConvertTritonGPUToLLVMBase({computeCapability, ptxVersion}) {}
+  ConvertTritonGPUToLLVM(int32_t computeCapability, int32_t ptxVersion,
+                         bool enableConcurrencySanitizer)
+      : ConvertTritonGPUToLLVMBase(
+            {computeCapability, ptxVersion, enableConcurrencySanitizer}) {}
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
@@ -110,6 +119,22 @@ struct ConvertTritonGPUToLLVM
     if (failed(maybeInsertClusterSync(mod))) {
       return signalPassFailure();
     }
+    if (enableConcurrencySanitizer) {
+      auto hooks = mlir::triton::instrument::createConSanHooks("nvidia");
+      assert(hooks && "no ConSan hooks registered for nvidia");
+      mlir::triton::instrument::runConcurrencySanitizer(mod, hooks.get());
+      mlir::PassManager cleanupPm(context);
+      cleanupPm.addPass(mlir::triton::gluon::createGluonCanonicalize());
+      cleanupPm.addPass(mlir::createCSEPass());
+      if (failed(cleanupPm.run(mod)))
+        return signalPassFailure();
+    }
+    bool hasGlobalScratchAlloc = false;
+    mod.walk([&](triton::gpu::GlobalScratchAllocOp) {
+      hasGlobalScratchAlloc = true;
+    });
+    if (hasGlobalScratchAlloc)
+      mlir::triton::gpu::runGlobalScratchMemoryAllocation(mod);
 
     mlir::LowerToLLVMOptions option(context);
     option.overrideIndexBitwidth(32);
@@ -516,6 +541,13 @@ createConvertTritonGPUToLLVMPass(int32_t computeCapability,
                                  int32_t ptxVersion) {
   return std::make_unique<ConvertTritonGPUToLLVM>(computeCapability,
                                                   ptxVersion);
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertTritonGPUToLLVMPass(int32_t computeCapability, int32_t ptxVersion,
+                                 bool enableConcurrencySanitizer) {
+  return std::make_unique<ConvertTritonGPUToLLVM>(computeCapability, ptxVersion,
+                                                  enableConcurrencySanitizer);
 }
 
 bool NVIDIA::canSkipBarSync(Operation *before, Operation *after,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -152,17 +152,12 @@ Value createLeaderCTAPredicate(Location loc, OpBuilder &rewriter) {
 Value createTMAMulticastMask(Location loc, ConversionPatternRewriter &rewriter,
                              uint16_t broadcastBits) {
   int numCTAs = triton::gpu::lookupNumCTAs(rewriter);
-  int blockBits = llvm::Log2_32(numCTAs);
-  uint32_t fixedBits = (~broadcastBits) & (numCTAs - 1);
-  uint32_t pattern = 1;
-  for (int i = 0; i < blockBits; ++i) {
-    if ((fixedBits & (1u << i)) == 0)
-      pattern |= (pattern << (1u << i));
-  }
+  auto encoding =
+      triton::nvidia_gpu::getTMAMulticastMaskEncoding(numCTAs, broadcastBits);
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
-  Value base = b.and_(ctaId, b.i32_val(fixedBits));
-  return b.shl(b.i32_val(pattern), base);
+  Value base = b.and_(ctaId, b.i32_val(encoding.fixedBits));
+  return b.shl(b.i32_val(encoding.pattern), base);
 }
 
 static uint32_t getCGABroadcastMask(mlir::triton::gpu::MemDescType barrierTy) {

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -137,9 +137,10 @@ void init_triton_nvidia_passes_ttgpuir(py::module &&m) {
               capability, ptxVersion));
         });
   m.def("add_to_llvmir",
-        [](mlir::PassManager &pm, int32_t capability, int32_t ptxVersion) {
+        [](mlir::PassManager &pm, int32_t capability, int32_t ptxVersion,
+           bool enableConcurrencySanitizer) {
           pm.addPass(mlir::triton::createConvertTritonGPUToLLVMPass(
-              capability, ptxVersion));
+              capability, ptxVersion, enableConcurrencySanitizer));
         });
 }
 


### PR DESCRIPTION
Summary:

Picked (2)
Backport AMD gfx1250 TDM descriptor updates from upstream PRs #10287 and #10056. The combined change preserves 48-bit stride fields through descriptor packing and adds optional per-operation warp usage hints while retaining beta-specific stride-order validation and unencoded gather/scatter wait-count support.

Deferred (0, backlog)
None. Both previously deferred PRs tracked by T278652360 are now picked.

Wont-port (0)
None.

Two-pin state: 2 backports, 0 deferred, 0 wont-port; frontier advanced and contiguous pin unchanged.

Upstream commits:
- 1d2f438e5cf27b46af2e411055947d396ef9dbd0 (#10287)
- 11459afc32052402381791a9733abffd83c6c376 (#10056)

Reactor Backport Revision: 1d2f438e5cf27b46af2e411055947d396ef9dbd0
Reactor Backport Revision: 11459afc32052402381791a9733abffd83c6c376

Reviewed By: njriasan

Differential Revision: D113613971
