### PR TITLE
[triton][beta] [Cherry-pick] 'Track each LLVM build separately' (#2550)

### DIFF
--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -1,8 +1,9 @@
 import argparse
 import contextlib
+import hashlib
+import io
 import json
 import os
-import io
 import platform
 import re
 import shutil
@@ -10,6 +11,7 @@ import subprocess
 import sys
 import sysconfig
 import tarfile
+import tempfile
 import time
 import urllib.request
 import zipfile
@@ -59,6 +61,11 @@ def _normalize_optional(value: str) -> Optional[str]:
         return None
     value = value.strip()
     return value if value else None
+
+
+# Taken from https://github.com/pytorch/pytorch/blob/master/tools/setup_helpers/env.py
+def check_env_flag(name: str, default: str = "") -> bool:
+    return os.getenv(name, default).upper() in ["ON", "1", "YES", "TRUE", "Y"]
 
 
 def _normalize_optional_path(value: str) -> Optional[str]:
@@ -170,7 +177,7 @@ def _download_file(url: str, label: str):
     return file_bytes
 
 
-def _download_and_extract(url, download_dir, label):
+def _download_and_extract(url, download_dir, label, expected_sha256=None):
     label = f"downloading {label}"
     os.makedirs(download_dir, exist_ok=True)
     with contextlib.ExitStack() as stack:
@@ -180,10 +187,25 @@ def _download_and_extract(url, download_dir, label):
             file = stack.enter_context(zipfile.ZipFile(file_bytes, "r"))
             file.extractall(path=download_dir)
         else:
-            # tar files can be streamed directly into untar
             response = stack.enter_context(open_url(url))
             progress_reader = DownloadProgressReader(response, label)
-            file = stack.enter_context(tarfile.open(fileobj=progress_reader, mode="r|*"))
+            tar_fileobj = progress_reader
+            if expected_sha256 is not None:
+                tar_fileobj = stack.enter_context(tempfile.TemporaryFile())
+                digest = hashlib.sha256()
+                while chunk := progress_reader.read(io.DEFAULT_BUFFER_SIZE):
+                    tar_fileobj.write(chunk)
+                    digest.update(chunk)
+                actual_sha256 = digest.hexdigest()
+                if actual_sha256 != expected_sha256:
+                    message = (f"LLVM download from {url} failed checksum validation. "
+                               f"Expected SHA256 {expected_sha256}, got {actual_sha256}.")
+                    if check_env_flag("TRITON_UNSAFE_DISABLE_SHA_CHECK"):
+                        print(f"WARNING: {message}", file=sys.stderr)
+                    else:
+                        raise RuntimeError(message)
+                tar_fileobj.seek(0)
+            file = stack.enter_context(tarfile.open(fileobj=tar_fileobj, mode="r|*"))
             # Use extractall without filter for Python version < 3.12 compatibility
             if hasattr(tarfile, "data_filter"):
                 file.extractall(path=download_dir, filter="data")
@@ -217,6 +239,7 @@ class Package:
     lib_flag: str
     syspath_var_name: str
     sym_name: Optional[str] = None
+    sha256sum: Optional[str] = None
 
 
 def get_json_package_info():
@@ -281,7 +304,17 @@ def get_llvm_package_info(helper_args: BuildHelperArgs):
     # Create a stable symlink that doesn't include revision
     sym_name = f"llvm-{system_suffix}"
     url = f"https://oaitriton.blob.core.windows.net/public/llvm-builds/{name}.tar.gz"
-    return Package("llvm", name, url, "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH", sym_name=sym_name)
+    sha256sum = llvm_info["sha256sum"][system_suffix]
+    return Package(
+        "llvm",
+        name,
+        url,
+        "LLVM_INCLUDE_DIRS",
+        "LLVM_LIBRARY_DIR",
+        "LLVM_SYSPATH",
+        sym_name=sym_name,
+        sha256sum=sha256sum,
+    )
 
 
 def _get_syspath_override(package_syspath_var_name: str, helper_args: BuildHelperArgs) -> Optional[str]:
@@ -310,7 +343,12 @@ def _get_thirdparty_package_cmake_vars(package: Package, helper_args: BuildHelpe
     if not helper_args.offline_build and not input_defined and not input_compatible:
         with contextlib.suppress(Exception):
             shutil.rmtree(package_root_dir)
-        _download_and_extract(package.url, package_root_dir, package.name)
+        _download_and_extract(
+            package.url,
+            package_root_dir,
+            package.name,
+            package.sha256sum,
+        )
         # write version url to package_dir
         with open(os.path.join(package_dir, "version.txt"), "w") as file:
             file.write(package.url)

--- a/python/test/unit/test_build_helpers.py
+++ b/python/test/unit/test_build_helpers.py
@@ -1,0 +1,108 @@
+import hashlib
+import io
+import json
+import os
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from python import build_helpers
+
+
+class _Response(io.BytesIO):
+    headers: dict[str, str] = {}
+
+
+class DownloadAndExtractTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        archive = io.BytesIO()
+        payload = b"verified payload"
+        with tarfile.open(fileobj=archive, mode="w:gz") as tar:
+            info = tarfile.TarInfo("payload.txt")
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+        self.archive = archive.getvalue()
+
+    def _open_url(self, _url: str) -> _Response:
+        return _Response(self.archive)
+
+    def test_matching_checksum_extracts_archive(self) -> None:
+        expected_sha256 = hashlib.sha256(self.archive).hexdigest()
+        with tempfile.TemporaryDirectory() as output_dir, patch.object(build_helpers, "open_url",
+                                                                       side_effect=self._open_url):
+            build_helpers._download_and_extract(
+                "https://example.com/llvm.tar.gz",
+                output_dir,
+                "LLVM",
+                expected_sha256,
+            )
+
+            self.assertEqual(
+                b"verified payload",
+                (Path(output_dir) / "payload.txt").read_bytes(),
+            )
+
+    def test_mismatched_checksum_rejects_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as output_dir, patch.object(build_helpers, "open_url",
+                                                                       side_effect=self._open_url), patch.dict(
+                                                                           os.environ,
+                                                                           {"TRITON_UNSAFE_DISABLE_SHA_CHECK": ""}):
+            with self.assertRaisesRegex(RuntimeError, "failed checksum validation"):
+                build_helpers._download_and_extract(
+                    "https://example.com/llvm.tar.gz",
+                    output_dir,
+                    "LLVM",
+                    "0" * 64,
+                )
+
+            self.assertFalse((Path(output_dir) / "payload.txt").exists())
+
+    def test_unsafe_override_extracts_mismatched_archive(self) -> None:
+        stderr = io.StringIO()
+        with tempfile.TemporaryDirectory() as output_dir, patch.object(
+                build_helpers, "open_url", side_effect=self._open_url), patch.dict(
+                    os.environ, {"TRITON_UNSAFE_DISABLE_SHA_CHECK": "1"}), patch("sys.stderr", stderr):
+            build_helpers._download_and_extract(
+                "https://example.com/llvm.tar.gz",
+                output_dir,
+                "LLVM",
+                "0" * 64,
+            )
+
+            self.assertTrue((Path(output_dir) / "payload.txt").exists())
+            self.assertIn("WARNING:", stderr.getvalue())
+
+    def test_llvm_package_uses_platform_checksum(self) -> None:
+        with tempfile.TemporaryDirectory() as base_dir:
+            cmake_dir = Path(base_dir) / "cmake"
+            cmake_dir.mkdir()
+            (cmake_dir / "llvm-info.json").write_text(
+                json.dumps({
+                    "llvm_hash": "abcdef0123456789",
+                    "build_number": 7,
+                    "sha256sum": {"test-platform": "expected-checksum"},
+                }))
+            helper_args = build_helpers.BuildHelperArgs(
+                cache_path=base_dir,
+                offline_build=False,
+                llvm_system_suffix="test-platform",
+                llvm_syspath=None,
+                json_syspath=None,
+                ptxas_path=None,
+                ptxas_blackwell_path=None,
+                cuobjdump_path=None,
+                nvdisasm_path=None,
+                cudacrt_path=None,
+                cudart_path=None,
+                cupti_include_path=None,
+                cupti_lib_path=None,
+                cupti_lib_blackwell_path=None,
+            )
+            with patch.object(build_helpers, "get_base_dir", return_value=base_dir):
+                package = build_helpers.get_llvm_package_info(helper_args)
+
+            self.assertEqual("llvm-abcdef01-test-platform-7", package.name)
+            self.assertEqual("expected-checksum", package.sha256sum)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ except ImportError:
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from python.build_helpers import get_base_dir, get_cmake_dir
+from python.build_helpers import check_env_flag, get_base_dir, get_cmake_dir
 
 
 def is_git_repo() -> bool:
@@ -124,11 +124,6 @@ class BackendInstaller:
             BackendInstaller.prepare(backend_name, backend_src_dir=backend_src_dir, is_external=True)
             for backend_name, backend_src_dir in zip(backend_names, backend_dirs)
         ]
-
-
-# Taken from https://github.com/pytorch/pytorch/blob/master/tools/setup_helpers/env.py
-def check_env_flag(name: str, default: str = "") -> bool:
-    return os.getenv(name, default).upper() in ["ON", "1", "YES", "TRUE", "Y"]
 
 
 def get_build_type():


### PR DESCRIPTION
Summary:

This is a semantic backport of upstream PR: https://github.com/triton-lang/triton/pull/10358

The normal reactor backport cannot be used here because #10358 replaces `cmake/llvm-hash.txt` with historical `cmake/llvm-info.json` contents. Applying that file wholesale would downgrade beta from LLVM `62b7cf9623fc310525f39ed69aaecc318a909731` to `87717bf9f81f7b29466c5d9a30a3453bdfc93941` and regenerate the vendored LLVM tree.

This change ports the remaining artifact-integrity behavior while preserving beta current LLVM revision: per-platform SHA-256 verification, the explicit unsafe override, shared `check_env_flag`, focused tests, and reactor bookkeeping.

***Do not remove the following line from this commit***
Reactor Backport Revision: 7190a1c3c7264651f99d55b002e6657aba4d3a90

Authored with Codex.

Reviewed By: njriasan

Differential Revision: D114142271


