### PR TITLE
[AutoWS][HSTU] Align cross-attention bwd with TLX 2-KV

### DIFF
--- a/third_party/tlx/tutorials/hstu_cross_attn/bench_bwd.py
+++ b/third_party/tlx/tutorials/hstu_cross_attn/bench_bwd.py
@@ -34,6 +34,7 @@ import triton_bw_cross_attention as xa
 
 D = 128
 H = 2
+H_KV = 1
 BLOCK = 64  # BLOCK_M == BLOCK_N used by the redq/autows benchmark configs
 
 VARIANTS = [
@@ -44,9 +45,10 @@ VARIANTS = [
     # Manual 2-KV data-partition + compute-fold + shared-KV. WS dispatch ("1");
     # under TRITON_USE_LIST_SCHEDULE=1 its inner loop's schedule is autotuned.
     ("autows_2kv", xa.BwdVariant.TRITON_AUTOWS_2KV, "1"),
+    ("autows_2kv_host_tma", xa.BwdVariant.TRITON_AUTOWS_2KV_HOST_TMA, "1"),
 ]
 # Variants that require shared-KV (V aliases K); only run under --shared-kv.
-SHARED_KV_ONLY = {"tlx_2kv", "autows_2kv"}
+SHARED_KV_ONLY = {"tlx_2kv", "autows_2kv", "autows_2kv_host_tma"}
 
 
 def force(ns=2, bm=BLOCK, bn=BLOCK):
@@ -97,6 +99,40 @@ def make(Lq, Lkv, Z, shared=False):
     return q, k, v, do, so_kv, so_q, asc
 
 
+def make_prod(max_targets, max_kv, batch, seed=1001):
+    """Build the jagged GQA/shared-KV shape used by T281143734's Buck bench."""
+    dev = "cuda"
+    gen = torch.Generator(device=dev).manual_seed(seed)
+    # Port generative_recommenders.common.generate_sparse_seq_len at
+    # --seq-sparsity=0.95: U[int(0.9 * max_kv), max_kv).
+    lengths_kv = torch.randint(
+        int(0.9 * max_kv), max_kv, (batch,), device=dev,
+        dtype=torch.int64, generator=gen,
+    )
+    lengths_q = torch.randint(
+        1 if max_targets < 400 else max_targets // 2,
+        max_targets + 1,
+        (batch,), device=dev, dtype=torch.int64, generator=gen,
+    )
+    so_kv = torch.zeros(batch + 1, device=dev, dtype=torch.int64)
+    so_q = torch.zeros(batch + 1, device=dev, dtype=torch.int64)
+    torch.cumsum(lengths_kv, 0, out=so_kv[1:])
+    torch.cumsum(lengths_q, 0, out=so_q[1:])
+    tq, tkv = int(so_q[-1]), int(so_kv[-1])
+
+    def tensor(n, heads):
+        return torch.empty(n, heads, D, device=dev, dtype=torch.bfloat16).uniform_(
+            -0.1, 0.1, generator=gen
+        )
+
+    q = tensor(tq, H).requires_grad_(True)
+    k = tensor(tkv, H_KV).requires_grad_(True)
+    v = k  # The production benchmark passes --share-kv True.
+    do = tensor(tq, H)
+    asc = torch.tensor(1.0 / (max_kv + max_targets), device=dev)
+    return q, k, v, do, so_kv, so_q, asc
+
+
 def torch_ref(q, k, v, do, so_kv, so_q, asc, softmax=True, shared=False):
     """Float autograd reference on the HSTU cross-attn forward (asymmetric Q/KV).
     When shared, K and V are one leaf so the returned dk = dk + dv (dv is None)."""
@@ -143,7 +179,7 @@ def _fwd(var, ws, q, k, v, so_kv, so_q, Lkv, Lq, asc, shared=False):
         attn_scale=asc,
         max_q_len=Lq,
         seq_offsets_q=so_q,
-        num_softmax_heads=H,
+        num_softmax_heads=q.shape[1],
         shared_kv=shared,
         enable_tma=True,
     )
@@ -184,16 +220,22 @@ def run_accuracy(configs, ns=2, ref_name="redq", variants=None, shared=False):
                 print(f"  {name:<8} ERROR {type(e).__name__}: {str(e)[:50]}")
 
 
-def run_perf(shapes, ns=2, variants=None, shared=False):
+def run_perf(shapes, ns=2, variants=None, production=False, bm=BLOCK, bn=BLOCK):
     sel = VARIANTS if variants is None else [x for x in VARIANTS if x[0] in variants]
-    mode = "shared-KV" if shared else "separate-KV"
+    mode = "shared-KV, jagged GQA" if production else "dense"
     print(f"\n=== Perf ({mode}): backward latency per variant "
           f"(autograd bwd on prebuilt fwd graph) ===")
     for Lq, Lkv, Z in shapes:
-        force(ns)
+        force(ns, bm=bm, bn=bn)
         torch.manual_seed(0)
-        q, k, v, do, so_kv, so_q, asc = make(Lq, Lkv, Z, shared=shared)
-        print(f"\n  Lq={Lq} Lkv={Lkv}({Lkv // BLOCK}blk) Z={Z} H={H} D={D} ns={ns}")
+        if production:
+            q, k, v, do, so_kv, so_q, asc = make_prod(Lq, Lkv, Z)
+        else:
+            q, k, v, do, so_kv, so_q, asc = make(Lq, Lkv, Z)
+        shared = production
+        q_tokens, kv_tokens = int(so_q[-1]), int(so_kv[-1])
+        print(f"\n  maxLq={Lq} maxLkv={Lkv} Z={Z} Hq={q.shape[1]} "
+              f"Hkv={k.shape[1]} D={D} q_tok={q_tokens} kv_tok={kv_tokens} ns={ns}")
         print(f"  {'variant':<8}{'bwd ms':>10}{'vs redq':>10}")
         base = None
         for name, var, ws in sel:
@@ -206,7 +248,7 @@ def run_perf(shapes, ns=2, variants=None, shared=False):
                     out.backward(do, retain_graph=True)
 
                 fn()  # warm / compile / autotune
-                ms = triton.testing.do_bench(fn, warmup=25, rep=100)
+                ms = triton.testing.do_bench(fn, warmup=25, rep=1000)
                 if name == "redq":
                     base = ms
                 spd = f"{base / ms:.2f}x" if base else "-"
@@ -221,7 +263,17 @@ def main():
     ap.add_argument("--perf", action="store_true", help="perf only")
     ap.add_argument("--ns", type=int, default=2, help="bwd num_stages")
     ap.add_argument("--shared-kv", action="store_true", dest="shared_kv",
-                    help="run shared-KV (V aliases K); required for tlx_2kv")
+                    help="use shared-KV for accuracy cases (perf always matches production)")
+    ap.add_argument("--batch", type=int, default=1024,
+                    help="performance batch size (default: Buck workload 1024)")
+    ap.add_argument("--max-kv", type=int, default=4096, dest="max_kv",
+                    help="performance max KV length (default: task focus 4096)")
+    ap.add_argument("--max-targets", default="32,128,160,256", dest="max_targets",
+                    help="comma-separated performance max query/target lengths")
+    ap.add_argument("--bm", type=int, default=BLOCK,
+                    help="pinned autoWS backward BLOCK_M")
+    ap.add_argument("--bn", type=int, default=128,
+                    help="pinned autoWS backward BLOCK_N (TLX-aligned default: 128)")
     ap.add_argument("--ref", choices=["redq", "tlx"], default="redq",
                     help="byte-reference kernel for the dq bad-Q-block count")
     known = [n for n, _, _ in VARIANTS]
@@ -251,14 +303,19 @@ def main():
         # 2kv uses BLOCK_N=128 (2*BLOCK_N=256 per pair); use Lkv multiples of 128,
         # incl. an odd number of KV blocks (384) to exercise the partial tail pair.
         acc_cfgs = [(256, 256, 2), (256, 384, 2), (256, 512, 2)]
-        perf_shapes = [(256, 256, 4), (256, 512, 4), (256, 1024, 4)]
     else:
         acc_cfgs = [(256, 64, 2), (256, 128, 2), (256, 192, 2)]
-        perf_shapes = [(256, 256, 4), (256, 1024, 4)]
+    try:
+        target_lengths = [int(x) for x in args.max_targets.split(",")]
+    except ValueError:
+        ap.error("--max-targets must be a comma-separated list of integers")
+    perf_shapes = [(max_targets, args.max_kv, args.batch)
+                   for max_targets in target_lengths]
     if do_acc:
         run_accuracy(acc_cfgs, ns=args.ns, ref_name=ref, variants=variants, shared=shared)
     if do_perf:
-        run_perf(perf_shapes, ns=args.ns, variants=variants, shared=shared)
+        run_perf(perf_shapes, ns=args.ns, variants=variants, production=True,
+                 bm=args.bm, bn=args.bn)
 
 
 if __name__ == "__main__":

--- a/third_party/tlx/tutorials/hstu_cross_attn/triton_bw_cross_attention.py
+++ b/third_party/tlx/tutorials/hstu_cross_attn/triton_bw_cross_attention.py
@@ -22,6 +22,7 @@ import triton
 
 # @manual=//triton:triton
 import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
 from stubs import switch_to_contiguous_if_needed
 from stubs import (
     is_sm90,
@@ -36,10 +37,14 @@ from stubs import (
 from stubs import get_full_autotune
 from triton_attention_utils import (
     backward_softmax_activation_scaled_alpha,
+    fast_fma,
+    fast_mul,
     fast_silu,
     forward_softmax_activation_scaled_alpha,
     forward_softmax_activation_trans_scaled_alpha,
 )
+
+
 from triton_hstu_cross_attention import (
     _attn_bwd_preprocess,
     backward_common_preprocess,
@@ -57,6 +62,40 @@ from triton_hstu_cross_attention import (
 
 # Check for on-device TMA API availability (requires Triton 3.5+)
 HAS_TENSOR_DESCRIPTOR = hasattr(tl, "make_tensor_descriptor")
+
+
+@triton.jit
+def _backward_softmax_activation_scaled_alpha_f32x2(
+    qk_trans,
+    scaled_alpha,
+    valid_mask_trans,
+    M_off,
+    offs_m,
+    stride_mm,
+    mask_m,
+    k,
+):
+    """B200 packed-FP32 form matching the TLX 2-KV backward kernel."""
+    m = tl.load(M_off + offs_m * stride_mm, mask=mask_m)
+    qk_trans = fast_fma(qk_trans, scaled_alpha, -m[None, :])
+    pT = tl.math.exp2(qk_trans)
+    pT = tl.where(valid_mask_trans, pT, 0.0)
+    act_qk_trans = pT.to(k.dtype)
+    return qk_trans, act_qk_trans, pT
+
+
+@triton.jit
+def _backward_d_softmax_activation_f32x2(
+    dact_qk_trans,
+    Delta_off,
+    offs_m,
+    stride_mm,
+    mask_m,
+    pT,
+):
+    """B200 packed-FP32 multiply matching the TLX 2-KV backward kernel."""
+    Di = tl.load(Delta_off + offs_m * stride_mm, mask=mask_m)
+    return fast_mul(pT, dact_qk_trans - Di[None, :])
 
 
 # Frozen (hashable) wrapper for the autoWS per-dot schedule attrs, usable in a
@@ -253,6 +292,9 @@ class BwdVariant(Enum):
     # parallelism WITHOUT triggering the compiler's automatic DP pass. Shared-KV +
     # compute-fold only. Milestone 1: WS off.
     TRITON_AUTOWS_2KV = "triton_autows_2kv"
+    # Same 2-KV autoWS kernel, but Q/K/V/DO TMA descriptors are constructed on
+    # the host, matching TLX. Dynamic DQ/DK bounds still require device TMA.
+    TRITON_AUTOWS_2KV_HOST_TMA = "triton_autows_2kv_host_tma"
 
 
 # Global variables for variant selection, can be overridden in unit tests
@@ -1546,6 +1588,11 @@ def _bwd_pre_hook_redq_v3(nargs):
         nargs["DK"].zero_()
         if not nargs["SHARED_KV"]:
             nargs["DV"].zero_()
+    if isinstance(nargs.get("desc_q_host"), TensorDescriptor):
+        nargs["desc_q_host"].block_shape = [nargs["BLOCK_M"], nargs["DimQ"]]
+        nargs["desc_k_host"].block_shape = [nargs["BLOCK_N"], nargs["DimQ"]]
+        nargs["desc_v_host"].block_shape = [nargs["BLOCK_N"], nargs["DimV"]]
+        nargs["desc_do_host"].block_shape = [nargs["BLOCK_M"], nargs["DimV"]]
 
 
 def _get_triton_bw_redq_configs() -> List[triton.Config]:
@@ -2036,16 +2083,15 @@ def _get_triton_bw_redq_2kv_configs() -> List[triton.Config]:
             },
             num_stages=ns,
             num_warps=nw,
+            maxRegAutoWS=192,
             pre_hook=_bwd_pre_hook_redq_v3,
         )
-        # BLOCK_M=64, BLOCK_N=64. The compute fold MMA-accumulates BOTH KV blocks'
-        # dk in TMEM (each [BLOCK_N, DimQ]); at BLOCK_N=64 the two dk tiles stack
-        # in TMEM's two 64-row groups at the SAME columns (128 cols for both, not
-        # 256), which -- with dq as a single shared accumulator -- keeps the peak
-        # at ~480 < 512 cols and lets BLOCK_M reach 64. BLOCK_N=128 would need 256
-        # dk cols and overflows at BLOCK_M=64 (608 > 512).
+        # Match the hand-TLX 2-KV tile: each explicit half handles 128 KV rows,
+        # so one outer iteration covers 256 rows.  The merged four-partition
+        # layout plus an elevated maxRegAutoWS avoids the large spill seen when
+        # this tile is compiled with the old five-partition/default-budget setup.
         for M in [64]
-        for N in [64]
+        for N in [128]
         for ns in [1]
         for nw in [4]
         for pick in inner_picks
@@ -2067,6 +2113,10 @@ def _get_triton_bw_redq_2kv_configs() -> List[triton.Config]:
 )
 @triton.jit
 def _hstu_attn_bwd_redq_2kv(  # noqa C901
+    desc_q_host,
+    desc_k_host,
+    desc_v_host,
+    desc_do_host,
     Q,
     K,
     V,
@@ -2121,6 +2171,7 @@ def _hstu_attn_bwd_redq_2kv(  # noqa C901
     # pyrefly: ignore [bad-function-definition]
     AUTOWS: tl.constexpr = False,
     WS_ON: tl.constexpr = False,
+    HOST_TMA: tl.constexpr = False,
     # Inner (start_m) loop list-schedule rank; swept by autotune under
     # TRITON_USE_LIST_SCHEDULE=1. See _get_triton_bw_redq_2kv_configs.
     # pyrefly: ignore [bad-function-definition]
@@ -2159,34 +2210,40 @@ def _hstu_attn_bwd_redq_2kv(  # noqa C901
     if seq_len_kv == 0:
         return
     H_kv = H // G
-    desc_q = tl.make_tensor_descriptor(
-        Q,
-        shape=[total_seq_len_q, H * DimQ],
-        # pyrefly: ignore [bad-argument-type]
-        strides=[H * DimQ, 1],
-        block_shape=[BLOCK_M, DimQ],
-    )
-    desc_k = tl.make_tensor_descriptor(
-        K,
-        shape=[total_seq_len_kv, H_kv * DimQ],
-        # pyrefly: ignore [bad-argument-type]
-        strides=[H_kv * DimQ, 1],
-        block_shape=[BLOCK_N, DimQ],
-    )
-    desc_v = tl.make_tensor_descriptor(
-        V,
-        shape=[total_seq_len_kv, H_kv * DimV],
-        # pyrefly: ignore [bad-argument-type]
-        strides=[H_kv * DimV, 1],
-        block_shape=[BLOCK_N, DimV],
-    )
-    desc_do = tl.make_tensor_descriptor(
-        DO,
-        shape=[total_seq_len_q, H * DimV],
-        # pyrefly: ignore [bad-argument-type]
-        strides=[H * DimV, 1],
-        block_shape=[BLOCK_M, DimV],
-    )
+    if HOST_TMA:
+        desc_q = desc_q_host
+        desc_k = desc_k_host
+        desc_v = desc_v_host
+        desc_do = desc_do_host
+    else:
+        desc_q = tl.make_tensor_descriptor(
+            Q,
+            shape=[total_seq_len_q, H * DimQ],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H * DimQ, 1],
+            block_shape=[BLOCK_M, DimQ],
+        )
+        desc_k = tl.make_tensor_descriptor(
+            K,
+            shape=[total_seq_len_kv, H_kv * DimQ],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H_kv * DimQ, 1],
+            block_shape=[BLOCK_N, DimQ],
+        )
+        desc_v = tl.make_tensor_descriptor(
+            V,
+            shape=[total_seq_len_kv, H_kv * DimV],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H_kv * DimV, 1],
+            block_shape=[BLOCK_N, DimV],
+        )
+        desc_do = tl.make_tensor_descriptor(
+            DO,
+            shape=[total_seq_len_q, H * DimV],
+            # pyrefly: ignore [bad-argument-type]
+            strides=[H * DimV, 1],
+            block_shape=[BLOCK_M, DimV],
+        )
     end_kv = seq_start_kv + seq_len_kv
     desc_dk = tl.make_tensor_descriptor(
         DK,
@@ -3475,8 +3532,11 @@ def _hstu_attn_bwd_inner(  # noqa C901
             v,
             tl.trans(do),
             allow_tf32=ALLOW_TF32,
-            attrs=(_HSTU_ATTRS_DPT_2KV if (SHARED_KV and _HSTU_COMPUTE_FOLD) else _HSTU_ATTRS_DPT) if
-            (WS_ON and not _HSTU_MODULO_TOPK) else None,
+            # This kernel processes one KV block per iteration, even when the
+            # shared-KV compute fold is enabled.  Keep TLX's dP<->dq TMEM reuse
+            # (id 11); the separate id 5 is only needed by the manual 2-KV
+            # kernel where dP and the shared dq accumulator overlap in time.
+            attrs=_HSTU_ATTRS_DPT if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
         if SHARED_KV:
             dk = tl.dot(
@@ -3679,21 +3739,11 @@ def _hstu_attn_bwd_inner_2kv(  # noqa C901
     else:
         low_q = 0
 
-    # warp_specialize is OFF for the 2-KV inner loop. WS produces an incorrect
-    # dq here (rel-L2 ~89): the two-block shared dq accumulator is written in the
-    # gemm partition but loaded/stored (store_reduce="add") in the reduction
-    # partition, and that cross-partition gemm->reduction handoff over-counts dq.
-    # This is independent of MMA placement (all dq dots already co-locate in the
-    # gemm partition) -- see T279388065. Until that handoff is fixed, run the
-    # 2-KV inner loop unspecialized (correct via the non-WS fallback).
-    #
-    # NOTE: previously WS was effectively suppressed here by the warp budget
-    # (18/16); the accumulator-chain dpFactor collapse now fits the budget
-    # (14/16), so WS would fire and expose the dq bug -- hence the explicit OFF.
-    #
-    # merge_epilogue is also OFF (unlike the single-KV inner): folding the dq
-    # epilogue store into the computation partition duplicates/misplaces the
-    # store for the shared dq accumulator, over-counting dq.
+    # The chained-accumulator and reduce-store co-location fixes now make the
+    # two-block shared dq handoff correct under WS (see T279388065).  Merge the
+    # epilogue to match TLX's four roles and keep the computation partition on
+    # the maxRegAutoWS budget; the older five-partition shape spills heavily at
+    # the TLX-aligned BLOCK_N=128 tile.
     #
     # num_stages=1: software pipelining the two-block loop (num_stages>=2) trips
     # the pipeliner ("local_alloc can't predicate") on the doubled operand
@@ -3704,7 +3754,7 @@ def _hstu_attn_bwd_inner_2kv(  # noqa C901
             BLOCK_M,
             num_stages=1,
             warp_specialize=WS_ON,
-            merge_epilogue=False,
+            merge_epilogue=True,
     ):
         offs_m = start_m + tl.arange(0, BLOCK_M)
         mask_m = offs_m < seq_len_q
@@ -3726,7 +3776,7 @@ def _hstu_attn_bwd_inner_2kv(  # noqa C901
         else:
             valid_mask_trans0 = offs_m[None, :] < seq_len_q
         if num_softmax_heads > 0:
-            qk_trans0, act_qk_trans0, pT0 = (backward_softmax_activation_scaled_alpha(
+            qk_trans0, act_qk_trans0, pT0 = (_backward_softmax_activation_scaled_alpha_f32x2(
                 qk_trans0,
                 scaled_alpha,
                 valid_mask_trans0,
@@ -3746,7 +3796,9 @@ def _hstu_attn_bwd_inner_2kv(  # noqa C901
             attrs=_HSTU_ATTRS_DPT_2KV if (WS_ON and not _HSTU_MODULO_TOPK) else None,
         )
         if num_softmax_heads > 0:
-            dqk_trans0 = backward_d_softmax_activation(dact_qk_trans0, Delta_off, offs_m, stride_mm, mask_m, pT0)
+            dqk_trans0 = _backward_d_softmax_activation_f32x2(
+                dact_qk_trans0, Delta_off, offs_m, stride_mm, mask_m, pT0
+            )
         else:
             dqk_trans0 = backward_d_silu_activation(dact_qk_trans0, pT0, qk_trans0, scale, valid_mask_trans0)
         ######### computation/activation for P1
@@ -3764,7 +3816,7 @@ def _hstu_attn_bwd_inner_2kv(  # noqa C901
             valid_mask_trans1 = offs_m[None, :] < seq_len_q
         # calculate pT
         if num_softmax_heads > 0:
-            qk_trans1, act_qk_trans1, pT1 = (backward_softmax_activation_scaled_alpha(
+            qk_trans1, act_qk_trans1, pT1 = (_backward_softmax_activation_scaled_alpha_f32x2(
                 qk_trans1,
                 scaled_alpha,
                 valid_mask_trans1,
@@ -3785,12 +3837,14 @@ def _hstu_attn_bwd_inner_2kv(  # noqa C901
         )
         # calculate dqk_trans
         if num_softmax_heads > 0:
-            dqk_trans1 = backward_d_softmax_activation(dact_qk_trans1, Delta_off, offs_m, stride_mm, mask_m, pT1)
+            dqk_trans1 = _backward_d_softmax_activation_f32x2(
+                dact_qk_trans1, Delta_off, offs_m, stride_mm, mask_m, pT1
+            )
         else:
             dqk_trans1 = backward_d_silu_activation(dact_qk_trans1, pT1, qk_trans1, scale, valid_mask_trans1)
 
         # compute fold: pre-scale alpha into dqk so both dq and dk_attn carry it.
-        dqk_trans0 = (dqk_trans0 * alpha).to(k0.dtype)
+        dqk_trans0 = fast_mul(dqk_trans0, alpha).to(k0.dtype)
         # dq is a SINGLE accumulator over both KV blocks: b0 fresh-writes it, b1
         # accumulates into the same TMEM tile (opndD id 11) below. This avoids a
         # cross-partition register sum (dq0 and dq1 land in different warp
@@ -3819,7 +3873,7 @@ def _hstu_attn_bwd_inner_2kv(  # noqa C901
         # ---- KV block b1 (SHARED_KV + compute fold) ----
         # WS on: b1 uses DISJOINT buffer.ids (_B1) so its concurrently-live
         # tiles never alias b0's (which stays on _2KV).
-        dqk_trans1 = (dqk_trans1 * alpha).to(k1.dtype)
+        dqk_trans1 = fast_mul(dqk_trans1, alpha).to(k1.dtype)
         # Accumulate b1's dq into the SAME dq_trans TMEM tile (opndD id 11 via
         # _B1), reducing both KV blocks' contributions in TMEM.
         dq_trans = tl.dot(
@@ -4210,13 +4264,53 @@ def triton_hstu_cross_attn_v3_bwd(
             # loop STRUCTURE with warp specialization DISABLED (isolation reference).
             WS_ON=((bwd_variant == BwdVariant.TRITON_AUTOWS) and os.environ.get("HSTU_AUTOWS_WS_OFF", "0") != "1"),
         )
-    elif bwd_variant == BwdVariant.TRITON_AUTOWS_2KV:
+    elif bwd_variant in (
+        BwdVariant.TRITON_AUTOWS_2KV,
+        BwdVariant.TRITON_AUTOWS_2KV_HOST_TMA,
+    ):
         # MANUAL 2-KV-block data-partition variant. Shared-KV only; G == 1
         # (self-attn) so no per-kv-head atomic path is needed.
         assert shared_kv, "BwdVariant.TRITON_AUTOWS_2KV requires shared_kv"
         assert G == 1, "BwdVariant.TRITON_AUTOWS_2KV requires G == 1"
+        host_tma = bwd_variant == BwdVariant.TRITON_AUTOWS_2KV_HOST_TMA
+        if host_tma:
+            dummy_block = [1, 1]
+            desc_q_host = TensorDescriptor(
+                q,
+                shape=[total_seq_len_q, H * DimQ],
+                strides=[H * DimQ, 1],
+                block_shape=dummy_block,
+            )
+            desc_k_host = TensorDescriptor(
+                k,
+                shape=[total_seq_len_kv, (H // G) * DimQ],
+                strides=[(H // G) * DimQ, 1],
+                block_shape=dummy_block,
+            )
+            desc_v_host = TensorDescriptor(
+                v,
+                shape=[total_seq_len_kv, (H // G) * DimV],
+                strides=[(H // G) * DimV, 1],
+                block_shape=dummy_block,
+            )
+            desc_do_host = TensorDescriptor(
+                dout,
+                shape=[total_seq_len_q, H * DimV],
+                strides=[H * DimV, 1],
+                block_shape=dummy_block,
+            )
+        else:
+            # These arguments are compile-time dead in the device-TMA variant.
+            # Passing existing tensors avoids host descriptor construction and
+            # preserves its current launch/timing behavior.
+            desc_q_host, desc_k_host = q, k
+            desc_v_host, desc_do_host = v, dout
         grid = lambda meta: (Z * H, 1)  # noqa E731
         _hstu_attn_bwd_redq_2kv[grid](
+            desc_q_host=desc_q_host,
+            desc_k_host=desc_k_host,
+            desc_v_host=desc_v_host,
+            desc_do_host=desc_do_host,
             Q=q,
             K=k,
             V=v,
@@ -4270,6 +4364,7 @@ def triton_hstu_cross_attn_v3_bwd(
             AUTOWS=False,
             # Milestone 2: warp specialization ON.
             WS_ON=True,
+            HOST_TMA=host_tma,
         )
     else:
         grid = lambda meta: (Z * H, 1)  # noqa E731

--- a/third_party/tlx/tutorials/test_cross_attention_bwd_autows.py
+++ b/third_party/tlx/tutorials/test_cross_attention_bwd_autows.py
@@ -148,7 +148,11 @@ _AUTOWS_2KV_SHAPES = [(256, 256, 2), (256, 320, 2), (256, 384, 2), (256, 512, 2)
 
 @pytest.mark.parametrize("ns", [1])
 @pytest.mark.parametrize("Lq,Lkv,Z", _AUTOWS_2KV_SHAPES)
-def test_cross_attention_bwd_autows_2kv(Lq, Lkv, Z, ns, monkeypatch):
+@pytest.mark.parametrize(
+    "variant",
+    [xa.BwdVariant.TRITON_AUTOWS_2KV, xa.BwdVariant.TRITON_AUTOWS_2KV_HOST_TMA],
+)
+def test_cross_attention_bwd_autows_2kv(Lq, Lkv, Z, ns, variant, monkeypatch):
     """MANUAL 2-KV-block data-partition reduce_dq (BwdVariant.TRITON_AUTOWS_2KV),
     shared-KV + compute fold, warp specialization ON (milestone 2). Two KV blocks
     are processed per step explicitly in Triton, with DISJOINT per-block
@@ -179,7 +183,7 @@ def test_cross_attention_bwd_autows_2kv(Lq, Lkv, Z, ns, monkeypatch):
         t.grad = None
     # ws="1" -> TRITON_USE_META_WS=1 (meta warp specialization enabled), required
     # now that the kernel is dispatched with WS_ON=True.
-    bb._fwd(xa.BwdVariant.TRITON_AUTOWS_2KV, "1", q, k, v, so_kv, so_q, Lkv, Lq, asc, shared=True).backward(do)
+    bb._fwd(variant, "1", q, k, v, so_kv, so_q, Lkv, Lq, asc, shared=True).backward(do)
     dq, dk = q.grad.clone(), k.grad.clone()
     for name, got, want in (("dq", dq, rq), ("dk", dk, rk)):
         rl2 = bb.rel_l2(got, want)


### PR DESCRIPTION
Summary: Align the AutoWS backward tile and production-shape benchmark with TLX, add the host-TMA comparison variant, and use packed FP32 math in the 2-KV path.

Reviewed By: njriasan

Differential Revision: D114248208


