### PR TITLE
[triton][beta][AMD] Keep LLVM VectorCombine on gfx950

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -580,8 +580,9 @@ class HIPBackend(BaseBackend):
             if len(paths) > 0:
                 llvm.link_extern_libs(llvm_mod, paths)
 
+        # gfx950 requires VectorCombine for stable BF16 and FP8 code generation.
         llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3, options.arch, "", [], options.enable_fp_fusion,
-                             disable_vector_combine=True)
+                             disable_vector_combine=options.arch != "gfx950")
 
         # Architectures with architected SGPRs store the workgroup id in ttmp9 (X) and ttmp7 (Y[15:0], Z[31:16]).
         # These attributes are used to determine if Z should be masked out when loading Y. They are inferred during


### PR DESCRIPTION
Summary: Upstream PR #10541 globally disabled LLVM `VectorCombinePass` for AMD. Preserve that workaround on existing targets, but keep the pass enabled for `gfx950`, where disabling it regresses BF16 TLX attention and FP8 GEMM code generation.

Reviewed By: njriasan

Differential Revision: D114246409


