### PR TITLE
[triton][PR] [AutoWS] Enable 2-CTA for tl.dot_scaled (MXFP8)

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -694,6 +694,8 @@ def TT_DotScaledOp : TT_Op<"dot_scaled", [Pure,
     let description = [{
         $d = matrix_multiply(scale($a, $a_scale), scale($b, $b_scale)) + $c.
         Where scale(x, s) is a function that applies the scale per block following microscaling spec.
+        If $two_ctas is set the op lowers to a 2-CTA (cta_group::2) scaled MMA on
+        Blackwell (SM100+), reading operands distributed across two contiguous CTAs.
     }];
 
     let arguments = (
@@ -709,7 +711,8 @@ def TT_DotScaledOp : TT_Op<"dot_scaled", [Pure,
       TT_ScaleDotElemTypeAttr:$b_elem_type,
       BoolAttr:$fastMath,
       DefaultValuedAttr<BoolAttr, "true">:$lhs_k_pack,
-      DefaultValuedAttr<BoolAttr, "true">:$rhs_k_pack
+      DefaultValuedAttr<BoolAttr, "true">:$rhs_k_pack,
+      UnitAttr:$two_ctas
     );
 
     let results = (outs TT_FloatTensor:$d);

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -859,10 +859,32 @@ public:
     unsigned m = 128;
     unsigned n = retShapePerCTA[1] >= 256 ? 256 : retShapePerCTA[1];
 
+    // 2-CTA (cta_group::2) scaled MMA: honor tt.dot_scaled's two_ctas flag,
+    // mirroring the plain-dot BlockedToMMAv5 path. Requires a >=2 CTA cluster
+    // (ctas_per_cga=(2,1,1)) and BLOCK_M >= 128; otherwise warn and fall back
+    // to 1-CTA so the kernel still compiles.
+    bool useTwoCTAs = false;
+    if (dotOp.getTwoCtas()) {
+      auto mod = dotOp->getParentOfType<ModuleOp>();
+      auto clusterDims = triton::gpu::TritonGPUDialect::getClusterDims(mod);
+      if (clusterDims[0] < 2) {
+        dotOp.emitWarning()
+            << "two_ctas=True requires ctas_per_cga=(2,1,1) or larger; "
+               "cluster-dim-x is "
+            << clusterDims[0] << ". Falling back to 1-CTA scaled MMA.";
+      } else if (oldRetType.getShape()[0] < 128) {
+        dotOp.emitWarning()
+            << "two_ctas=True with BLOCK_M < 128 is not yet supported for "
+               "scaled MMA. Falling back to 1-CTA scaled MMA.";
+      } else {
+        useTwoCTAs = true;
+      }
+    }
+
     auto bitwidth = oldRetType.getElementType().getIntOrFloatBitWidth();
     unsigned colStride = 32 / bitwidth;
     Attribute accEncoding = triton::nvidia_gpu::TensorMemoryEncodingAttr::get(
-        context, m, n, colStride, CGALayout, false,
+        context, m, n, colStride, CGALayout, useTwoCTAs,
         triton::nvidia_gpu::TensorMemoryCTAMode::DEFAULT);
     Attribute tensorMemorySpace =
         triton::nvidia_gpu::TensorMemorySpaceAttr::get(context);
@@ -933,7 +955,7 @@ public:
         rewriter, loc, tokType, a, b, acc.getResult(), acc.getToken(),
         scaleA.getResult(), scaleB.getResult(), dotOp.getAElemType(),
         dotOp.getBElemType(),
-        /*useD=*/vTrue, /*pred=*/vTrue);
+        /*useD=*/vTrue, /*pred=*/vTrue, /*two_ctas=*/useTwoCTAs);
     // Propagate discardable attributes (e.g. tt.autows) from the original dot.
     for (auto attr : dotOp->getDiscardableAttrs())
       mmaOp->setDiscardableAttr(attr.getName(), attr.getValue());

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CheckMatmulTwoCTAs.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CheckMatmulTwoCTAs.cpp
@@ -94,6 +94,12 @@ public:
     WalkResult result = mod.walk([&](Operation *op) {
       if (auto dotOp = dyn_cast<tt::DotOp>(op))
         return checkTwoCTA(op, dotOp.getTwoCtas());
+      // This pass runs before tt.dot_scaled is lowered to tc_gen5_mma_scaled,
+      // so match the scaled op here too. Otherwise the module `ttng.two-ctas`
+      // attr stays false for the scaled 2-CTA path, breaking every downstream
+      // tcgen05 lowering that reads getModuleTwoCTAs.
+      if (auto dotScaledOp = dyn_cast<tt::DotScaledOp>(op))
+        return checkTwoCTA(op, dotScaledOp.getTwoCtas());
       if (auto mmaOp = dyn_cast<ttng::TCGen5MMAOp>(op))
         return checkTwoCTA(op, mmaOp.getTwoCtas());
       if (auto scaledOp = dyn_cast<ttng::TCGen5MMAScaledOp>(op))

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1921,11 +1921,11 @@ void init_triton_ir(py::module &&m) {
               ScaleDotElemType lhs_format, mlir::Value &rhs,
               std::optional<mlir::Value> &rhs_scale,
               ScaleDotElemType rhs_format, bool fast_math, bool lhs_k_pack,
-              bool rhs_k_pack, mlir::Value &c) -> mlir::Value {
+              bool rhs_k_pack, mlir::Value &c, bool two_ctas) -> mlir::Value {
              return self.create<DotScaledOp>(
                  c.getType(), lhs, rhs, c, lhs_scale.value_or(Value()),
                  rhs_scale.value_or(Value()), lhs_format, rhs_format, fast_math,
-                 lhs_k_pack, rhs_k_pack);
+                 lhs_k_pack, rhs_k_pack, two_ctas);
            })
       .def("create_floor",
            [](TritonOpBuilder &self, Value &val) -> Value {

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2590,6 +2590,7 @@ def dot_scaled(
     lhs_k_pack=True,
     rhs_k_pack=True,
     out_dtype=float32,
+    two_ctas=False,
     _semantic=None,
 ):
     """
@@ -2623,6 +2624,10 @@ def dot_scaled(
     :type lhs_k_pack: bool, optional
     :param rhs_k_pack: If false, the rhs tensor is packed into uint8 along N dimension.
     :type rhs_k_pack: bool, optional
+    :param two_ctas: If True, enables 2-CTA collective scaled matmul on Blackwell (SM100+).
+      Launch with ``ctas_per_cga=(2, 1, 1)`` and BLOCK_M >= 128; the compiler splits the
+      B operand across the CTA pair. Generates ``tcgen05.mma.cta_group::2`` for the scaled MMA.
+    :type two_ctas: bool
     """
     lhs_format = _unwrap_if_constexpr(lhs_format)
     rhs_format = _unwrap_if_constexpr(rhs_format)
@@ -2631,6 +2636,7 @@ def dot_scaled(
     out_dtype = _unwrap_if_constexpr(out_dtype)
     lhs_k_pack = _unwrap_if_constexpr(lhs_k_pack)
     rhs_k_pack = _unwrap_if_constexpr(rhs_k_pack)
+    two_ctas = _unwrap_if_constexpr(two_ctas)
     assert out_dtype == float32, "Only float32 is supported for out_dtype at the moment"
     return _semantic.dot_scaled(
         lhs,
@@ -2644,6 +2650,7 @@ def dot_scaled(
         lhs_k_pack,
         rhs_k_pack,
         out_dtype,
+        two_ctas,
     )
 
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1771,10 +1771,11 @@ class TritonSemantic(Generic[TensorTy]):
 
     def dot_scaled(self, lhs: TensorTy, lhs_scale: TensorTy, lhs_format: str, rhs: TensorTy,
                    rhs_scale: Optional[TensorTy], rhs_format: str, acc: TensorTy | None, fast_math: bool,
-                   lhs_k_pack: bool, rhs_k_pack: bool, out_dtype: tl.dtype) -> TensorTy:
+                   lhs_k_pack: bool, rhs_k_pack: bool, out_dtype: tl.dtype, two_ctas: bool = False) -> TensorTy:
         fast_math = tl._unwrap_if_constexpr(fast_math)
         lhs_k_pack = tl._unwrap_if_constexpr(lhs_k_pack)
         rhs_k_pack = tl._unwrap_if_constexpr(rhs_k_pack)
+        two_ctas = tl._unwrap_if_constexpr(two_ctas)
         assert lhs.type.is_block() and rhs.type.is_block(), "dot_scaled operands must be block tensors (not scalars)"
         # TODO: validate types.
         lhs_rank = len(lhs.shape)
@@ -1839,6 +1840,7 @@ class TritonSemantic(Generic[TensorTy]):
                 lhs_k_pack,
                 rhs_k_pack,
                 acc_handle,
+                two_ctas,
             ),
             ret_ty,
         )

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -967,7 +967,7 @@ class CUDABackend(BaseBackend):
             # Only for Meta WS path — non-WS 2-CTA sync is handled by
             # MMAv5.cpp's inline ClusterArriveOp.
             if (opt.cluster_dims is not None and max(opt.cluster_dims) >= 2 and knobs.nvidia.use_meta_ws):
-                nvidia.passes.hopper.add_insert_2cta_sync(pm)
+                nvidia.passes.hopper.add_insert_2cta_sync(pm, False)
         else:
             passes.ttir.add_triton_licm(pm)
         passes.common.add_canonicalizer(pm)
@@ -998,6 +998,10 @@ class CUDABackend(BaseBackend):
             passes.ttgpuir.add_optimize_partition_warps(pm)
         nvidia.passes.ttnvgpuir.add_fence_insertion(pm, capability)
         nvidia.passes.ttnvgpuir.add_lower_mma(pm)
+        # lower_mma created the 2-CTA block-scale tmem_copy (a leader-issued
+        # cross-CTA write); sync its completion before the MMA reads the scales.
+        if (opt.cluster_dims is not None and max(opt.cluster_dims) >= 2 and knobs.nvidia.use_meta_ws):
+            nvidia.passes.hopper.add_insert_2cta_sync(pm, True)
         passes.common.add_sccp(pm)
         passes.common.add_cse(pm)
         passes.common.add_canonicalizer(pm)

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -363,7 +363,20 @@ def NVGPUInsert2CTASync : Pass<"nvgpu-insert-2cta-sync", "mlir::ModuleOp"> {
     This pattern is compatible with warp specialization because the sync
     ops are inserted after the pipeline pass, and the MMA hardware handles
     the actual cross-CTA execution synchronization.
+
+    When `sync-scale-copy` is set, the pass instead synchronizes the 2-CTA
+    block-scale copy (`tcgen05.cp.cta_group::2`) for scaled MMAs. That copy is
+    leader-issued and writes both CTAs' scale TMEM, so the follower's MMA could
+    read scale TMEM before the copy completes. The pass emits a `tc_gen5_commit`
+    on a hoisted, phase-tracked barrier and a wait before each MMA. Must run
+    AFTER lower-mma, which creates the scale copy.
   }];
+
+  let options = [
+    Option<"syncScaleCopy", "sync-scale-copy", "bool", /*default*/"false",
+           "Synchronize the 2-CTA scale tmem_copy (tcgen05.cp) cross-CTA "
+           "completion instead of the MMA cross-CTA rendezvous.">
+  ];
 
   let dependentDialects = [
     "mlir::triton::gpu::TritonGPUDialect",

--- a/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
@@ -112,10 +112,10 @@ static Value computeLinearizedLoopPhase(OpBuilder &builder, Location loc,
 // Insert the "arrive remote, wait local" cross-CTA sync ops before a 2-CTA
 // MMA. The barrier must be allocated externally (before the containing loop
 // if the MMA is in a loop).
-static void insertSyncBeforeMMA(ttng::TCGen5MMAOp mma, Value barrierAlloc,
+static void insertSyncBeforeMMA(Operation *mma, Value barrierAlloc,
                                 unsigned barrierIdx = 0) {
-  MLIRContext *ctx = mma.getContext();
-  Location loc = mma.getLoc();
+  MLIRContext *ctx = mma->getContext();
+  Location loc = mma->getLoc();
   OpBuilder builder(mma);
   auto i32Ty = builder.getI32Type();
 
@@ -171,7 +171,95 @@ static void insertSyncBeforeMMA(ttng::TCGen5MMAOp mma, Value barrierAlloc,
   LDBG("Inserted cross-CTA sync before MMA at " << loc);
 }
 
+// Synchronize the 2-CTA block-scale copy feeding a scaled MMA. lower-mma stages
+// the scales into TMEM via a leader-issued tcgen05.cp.cta_group::2 that writes
+// both CTAs' scale TMEM; nothing orders that cross-CTA write before the
+// follower CTA's MMA reads its scale TMEM (single-CTA is ordered by the
+// in-order tcgen05 pipeline, 2-CTA is not). Commit the copy and wait on both
+// CTAs before the MMA.
+static void insertScaleCpSyncBeforeMMA(Operation *mma, Value barrierAlloc,
+                                       unsigned barrierIdx = 0) {
+  Location loc = mma->getLoc();
+  OpBuilder builder(mma);
+  Value barrierView =
+      triton::createSingleBufferView(builder, barrierAlloc, barrierIdx);
+
+  // Commit the scale cp(s). Under 2-CTA this lowers to a leader-issued
+  // multicast::cluster commit that arrives on both CTAs' barrier.
+  ttng::TCGen5CommitOp::create(builder, loc, barrierView, /*pred=*/Value(),
+                               /*descs=*/ValueRange{});
+
+  // Both CTAs wait for the copy to complete before issuing the MMA.
+  Value phase;
+  if (auto forOp = mma->getParentOfType<scf::ForOp>())
+    phase = computeLinearizedLoopPhase(builder, loc, forOp);
+  else
+    phase = arith::ConstantIntOp::create(builder, loc, 0, 32);
+  Value truePred = arith::ConstantIntOp::create(builder, loc, 1, 1);
+  ttng::WaitBarrierOp::create(builder, loc, barrierView, phase, truePred);
+
+  LDBG("Inserted cross-CTA scale-cp sync before scaled MMA at " << loc);
+}
+
+// Allocate a cross-CTA barrier with `numBarriers` slots and the given
+// `arriveCount`. It is hoisted and init'd before the loop / WarpSpecializeOp so
+// the one-time cluster mbarrier-init fence covers it. Handles the three
+// placement cases (pre-WS, post-WS default region, post-WS partition capture);
+// `anchorOp` locates the partition region to capture into. Returns the barrier
+// usable at that site.
+static Value allocateLoopCrossCTABarrier(scf::ForOp forOp, Operation *anchorOp,
+                                         unsigned numBarriers,
+                                         unsigned arriveCount) {
+  auto isInDefaultRegion = [](Operation *op,
+                              ttg::WarpSpecializeOp wsOp) -> bool {
+    Region *defaultRegion = &wsOp.getDefaultRegion();
+    return defaultRegion->isAncestor(op->getParentRegion());
+  };
+
+  auto wsOp = forOp->getParentOfType<ttg::WarpSpecializeOp>();
+  if (!wsOp) {
+    // Pre-WS path: standard alloc before the for loop.
+    return triton::createBarrierAlloc(forOp, numBarriers, arriveCount);
+  }
+
+  // Post-WS path: alloc+init BEFORE the WarpSpecializeOp (so thread 0 of the
+  // producer warp group initializes it, covered by the one-time cluster fence),
+  // inval+dealloc AFTER.
+  Location loc = wsOp->getLoc();
+  ImplicitLocOpBuilder rewriter(loc, wsOp);
+  Value barrierAlloc =
+      triton::createScalarAlloc(rewriter, rewriter.getI64Type(), numBarriers);
+  for (unsigned i = 0; i < numBarriers; ++i) {
+    Value initView = triton::createSingleBufferView(rewriter, barrierAlloc, i);
+    rewriter.create<ttng::InitBarrierOp>(initView, arriveCount);
+  }
+  rewriter.setInsertionPointAfter(wsOp);
+  for (unsigned i = 0; i < numBarriers; ++i) {
+    Value invalView = triton::createSingleBufferView(rewriter, barrierAlloc, i);
+    rewriter.create<ttng::InvalBarrierOp>(invalView);
+  }
+  rewriter.create<ttg::LocalDeallocOp>(barrierAlloc);
+
+  if (isInDefaultRegion(anchorOp, wsOp)) {
+    // The default region implicitly captures values defined before wsOp.
+    return barrierAlloc;
+  }
+
+  // Partition region (IsolatedFromAbove): capture the barrier explicitly.
+  auto partOp = wsOp.getPartitionOp();
+  partOp->insertOperands(partOp->getNumOperands(), barrierAlloc);
+  Value capturedBarrier;
+  for (Region *region : wsOp.getPartitionRegions()) {
+    BlockArgument arg = region->addArgument(barrierAlloc.getType(), loc);
+    if (region->isAncestor(anchorOp->getParentRegion()))
+      capturedBarrier = arg;
+  }
+  assert(capturedBarrier && "anchor op not found in any partition region");
+  return capturedBarrier;
+}
+
 struct Insert2CTASync : public impl::NVGPUInsert2CTASyncBase<Insert2CTASync> {
+  using impl::NVGPUInsert2CTASyncBase<Insert2CTASync>::NVGPUInsert2CTASyncBase;
 
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
@@ -184,22 +272,31 @@ struct Insert2CTASync : public impl::NVGPUInsert2CTASyncBase<Insert2CTASync> {
     if (moduleOp->hasAttr("tlx.has_tlx_ops"))
       return;
 
-    // Collect 2-CTA MMA ops that need cross-CTA sync insertion.
-    SmallVector<ttng::TCGen5MMAOp> twoCTAMMAOps;
-    moduleOp->walk([&](ttng::TCGen5MMAOp mma) {
-      if (mma.getTwoCtas())
-        twoCTAMMAOps.push_back(mma);
+    // Two modes (see the pass doc): the default MMA rendezvous, and the
+    // scale-copy completion sync for scaled MMAs (run after lower-mma).
+    bool scaleMode = syncScaleCopy;
+
+    // Collect 2-CTA MMA ops that need sync. In scale-copy mode only scaled MMAs
+    // carry a block-scale tmem_copy, so restrict to those.
+    SmallVector<ttng::MMAv5OpInterface> twoCTAMMAOps;
+    moduleOp->walk([&](ttng::MMAv5OpInterface mma) {
+      if (!mma.getTwoCtas())
+        return;
+      if (scaleMode && !isa<ttng::TCGen5MMAScaledOp>(mma.getOperation()))
+        return;
+      twoCTAMMAOps.push_back(mma);
     });
 
     if (twoCTAMMAOps.empty())
       return;
 
-    LDBG("Found " << twoCTAMMAOps.size() << " 2-CTA MMA ops");
+    LDBG("Found " << twoCTAMMAOps.size() << " 2-CTA "
+                  << (scaleMode ? "scaled " : "") << "MMA ops");
 
     // Group MMAs by their containing scf.for loop. Allocate one cross-CTA
     // barrier slot per MMA in each loop.
-    DenseMap<Operation *, SmallVector<ttng::TCGen5MMAOp>> loopToMMAs;
-    SmallVector<ttng::TCGen5MMAOp> nonLoopMMAs;
+    DenseMap<Operation *, SmallVector<ttng::MMAv5OpInterface>> loopToMMAs;
+    SmallVector<ttng::MMAv5OpInterface> nonLoopMMAs;
 
     for (auto mma : twoCTAMMAOps) {
       auto forOp = mma->getParentOfType<scf::ForOp>();
@@ -209,96 +306,32 @@ struct Insert2CTASync : public impl::NVGPUInsert2CTASyncBase<Insert2CTASync> {
         nonLoopMMAs.push_back(mma);
     }
 
-    // Helper: check if an op is inside the default region of a
-    // WarpSpecializeOp (as opposed to a partition region).
-    auto isInDefaultRegion = [](Operation *op,
-                                ttg::WarpSpecializeOp wsOp) -> bool {
-      Region *defaultRegion = &wsOp.getDefaultRegion();
-      return defaultRegion->isAncestor(op->getParentRegion());
+    // MMA rendezvous barrier: both CTAs thread-arrive (count=2), leader waits.
+    // Scale-cp barrier: one leader-issued multicast commit arrives on both
+    // CTAs (count=1), both CTAs wait.
+    unsigned arriveCount = scaleMode ? 1 : 2;
+    auto insertSync = [&](Operation *mma, Value bar, unsigned idx) {
+      if (scaleMode)
+        insertScaleCpSyncBeforeMMA(mma, bar, idx);
+      else
+        insertSyncBeforeMMA(mma, bar, idx);
     };
 
     // Process MMAs inside loops.
     for (auto &[loopOp, mmas] : loopToMMAs) {
       auto forOp = cast<scf::ForOp>(loopOp);
-
-      // Allocate cross-CTA barrier. In the post-WS path (Meta WS),
-      // the loop is nested inside a WarpSpecializeOp. The barrier
-      // alloc+init must be placed BEFORE the WarpSpecializeOp (so thread 0
-      // from the producer warp group initializes it).
-      Value barrierAlloc;
       unsigned numBarriers = mmas.size();
-      auto wsOp = forOp->getParentOfType<ttg::WarpSpecializeOp>();
-      if (!wsOp) {
-        // Pre-WS path: standard alloc before the for loop.
-        barrierAlloc =
-            triton::createBarrierAlloc(forOp, numBarriers, /*arriveCount=*/2);
-      } else if (isInDefaultRegion(mmas[0], wsOp)) {
-        // Post-WS path, MMA in default region: The default region can
-        // implicitly capture values defined before the WarpSpecializeOp,
-        // so no explicit capture is needed. Just allocate+init before wsOp
-        // and inval+dealloc after.
-        Location loc = wsOp->getLoc();
-        ImplicitLocOpBuilder rewriter(loc, wsOp);
-        barrierAlloc = triton::createScalarAlloc(
-            rewriter, rewriter.getI64Type(), numBarriers);
-        for (unsigned i = 0; i < numBarriers; ++i) {
-          Value initView =
-              triton::createSingleBufferView(rewriter, barrierAlloc, i);
-          rewriter.create<ttng::InitBarrierOp>(initView, /*arriveCount=*/2);
-        }
-
-        // Inval and dealloc AFTER the WarpSpecializeOp.
-        rewriter.setInsertionPointAfter(wsOp);
-        for (unsigned i = 0; i < numBarriers; ++i) {
-          Value invalView =
-              triton::createSingleBufferView(rewriter, barrierAlloc, i);
-          rewriter.create<ttng::InvalBarrierOp>(invalView);
-        }
-        rewriter.create<ttg::LocalDeallocOp>(barrierAlloc);
-      } else {
-        // Post-WS path, MMA in a partition region (IsolatedFromAbove):
-        // Must capture the barrier explicitly into the partition.
-        Location loc = wsOp->getLoc();
-        ImplicitLocOpBuilder rewriter(loc, wsOp);
-        barrierAlloc = triton::createScalarAlloc(
-            rewriter, rewriter.getI64Type(), numBarriers);
-        for (unsigned i = 0; i < numBarriers; ++i) {
-          Value initView =
-              triton::createSingleBufferView(rewriter, barrierAlloc, i);
-          rewriter.create<ttng::InitBarrierOp>(initView, /*arriveCount=*/2);
-        }
-
-        // Inval and dealloc AFTER the WarpSpecializeOp.
-        rewriter.setInsertionPointAfter(wsOp);
-        for (unsigned i = 0; i < numBarriers; ++i) {
-          Value invalView =
-              triton::createSingleBufferView(rewriter, barrierAlloc, i);
-          rewriter.create<ttng::InvalBarrierOp>(invalView);
-        }
-        rewriter.create<ttg::LocalDeallocOp>(barrierAlloc);
-
-        // Capture barrier into WarpSpecializeOp partition regions.
-        auto partOp = wsOp.getPartitionOp();
-        partOp->insertOperands(partOp->getNumOperands(), barrierAlloc);
-        Value capturedBarrier;
-        for (Region *region : wsOp.getPartitionRegions()) {
-          BlockArgument arg = region->addArgument(barrierAlloc.getType(), loc);
-          if (region->isAncestor(mmas[0]->getParentRegion()))
-            capturedBarrier = arg;
-        }
-        assert(capturedBarrier && "MMA not found in any partition region");
-        barrierAlloc = capturedBarrier;
-      }
-
+      Value barrierAlloc = allocateLoopCrossCTABarrier(
+          forOp, mmas[0].getOperation(), numBarriers, arriveCount);
       for (unsigned i = 0; i < numBarriers; ++i)
-        insertSyncBeforeMMA(mmas[i], barrierAlloc, i);
+        insertSync(mmas[i].getOperation(), barrierAlloc, i);
     }
 
     // Process standalone MMAs (rare: single-iteration epilogue).
     for (auto mma : nonLoopMMAs) {
-      Value barrierAlloc =
-          triton::createBarrierAlloc(mma, /*numBarriers=*/1, /*arriveCount=*/2);
-      insertSyncBeforeMMA(mma, barrierAlloc);
+      Value barrierAlloc = triton::createBarrierAlloc(
+          mma.getOperation(), /*numBarriers=*/1, arriveCount);
+      insertSync(mma.getOperation(), barrierAlloc, 0);
     }
   }
 };

--- a/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
@@ -143,6 +143,17 @@ static FailureOr<BLoadTrace> traceToDescriptorLoad(Value bMemDesc) {
   return BLoadTrace{descLoad, localAlloc, memDescTrans, trans, splitDim};
 }
 
+// Return the B (RHS) operand of a tcgen05 MMAv5 op. MMAv5OpInterface does not
+// expose getB() (operand accessors are op-specific), so switch on the concrete
+// op. Both the plain and scaled MMA carry a B operand; returns null otherwise.
+static Value getBfromMMA(Operation *op) {
+  if (auto mma = dyn_cast<ttng::TCGen5MMAOp>(op))
+    return mma.getB();
+  if (auto mma = dyn_cast<ttng::TCGen5MMAScaledOp>(op))
+    return mma.getB();
+  return nullptr;
+}
+
 struct Transform2CTALoads
     : public impl::NVGPU2CTATransformLoadsBase<Transform2CTALoads> {
   DenseMap<Value, tt::TensorDescType> originalDescTypes;
@@ -163,9 +174,11 @@ struct Transform2CTALoads
       originalDescTypes.try_emplace(descLoad.getDesc(), descType);
     });
 
-    // Collect 2-CTA MMA ops.
-    SmallVector<ttng::TCGen5MMAOp> twoCTAMMAOps;
-    moduleOp->walk([&](ttng::TCGen5MMAOp mma) {
+    // Collect 2-CTA MMA ops. Walk the shared MMAv5 interface so both the plain
+    // (tc_gen5_mma) and scaled (tc_gen5_mma_scaled) ops are handled by one
+    // path.
+    SmallVector<ttng::MMAv5OpInterface> twoCTAMMAOps;
+    moduleOp->walk([&](ttng::MMAv5OpInterface mma) {
       if (mma.getTwoCtas())
         twoCTAMMAOps.push_back(mma);
     });
@@ -176,15 +189,24 @@ struct Transform2CTALoads
     LDBG("Found " << twoCTAMMAOps.size() << " 2-CTA MMA ops to transform");
 
     for (auto mma : twoCTAMMAOps) {
-      if (failed(transformBLoad(mma)))
-        LDBG("Skipped MMA at " << mma.getLoc()
+      Operation *op = mma.getOperation();
+      if (failed(transformBLoad(getBfromMMA(op), op)))
+        LDBG("Skipped MMA at " << op->getLoc()
                                << " (B not from descriptor load)");
+      // NOTE: the B-scale is intentionally NOT split for a scaled 2-CTA MMA.
+      // tcgen05.mma.cta_group::2.block_scale expects each CTA to hold the FULL
+      // B-scale in TMEM (the per-CTA scale addressing reads the right columns
+      // for its N-half); splitting it to N/2 produces wrong results. Only the B
+      // *operand* is split (above), for the global-load memory win. Verified
+      // exact (max_abs=0) on the simple 2-CTA MXFP8 kernel.
     }
   }
 
-  LogicalResult transformBLoad(ttng::TCGen5MMAOp mma) {
+  LogicalResult transformBLoad(Value b, Operation *mma) {
+    if (!b)
+      return failure();
     // Trace B operand back to DescriptorLoadOp.
-    FailureOr<BLoadTrace> trace = traceToDescriptorLoad(mma.getB());
+    FailureOr<BLoadTrace> trace = traceToDescriptorLoad(b);
     if (failed(trace))
       return failure();
     auto descLoad = trace->descLoad;
@@ -212,7 +234,7 @@ struct Transform2CTALoads
       return failure();
     }
 
-    MLIRContext *ctx = mma.getContext();
+    MLIRContext *ctx = mma->getContext();
     auto elemType = descType.getElementType();
     auto sharedLayout = descType.getSharedLayout();
     auto newDescType =
@@ -328,7 +350,7 @@ struct Transform2CTALoads
     if (makeDesc && makeDesc.getResult().use_empty())
       makeDesc.erase();
 
-    LDBG("Transformed B load for 2-CTA MMA at " << mma.getLoc());
+    LDBG("Transformed B load for 2-CTA MMA at " << mma->getLoc());
     return success();
   }
 };

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -240,7 +240,8 @@ void init_triton_hopper_passes(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_llm_schedule", mlir::createNVGPULLMSchedule);
   ADD_PASS_WRAPPER_0("add_modulo_ws_partition",
                      mlir::createNVGPUModuloWSPartition);
-  ADD_PASS_WRAPPER_0("add_insert_2cta_sync", mlir::createNVGPUInsert2CTASync);
+  ADD_PASS_OPTION_WRAPPER_1("add_insert_2cta_sync",
+                            mlir::createNVGPUInsert2CTASync, bool);
   ADD_PASS_WRAPPER_0("add_2cta_transform_loads",
                      mlir::createNVGPU2CTATransformLoads);
 }


### PR DESCRIPTION
Summary:
Add a two_ctas path for tl.dot_scaled mirroring the plain-tl.dot 2-CTA support,
so MXFP8 block-scaled matmul can use tcgen05.mma.cta_group::2 on Blackwell.

Suggested review order:

1. DSL surface: two_ctas UnitAttr on tt.dot_scaled (TritonOps.td), threaded
   through python/src/ir.cc (create_dot_scaled gains the parameter), core.py,
   semantic.py, and interpreter.py.

2. Lowering (AccelerateMatmul): propagate two_ctas to the accumulator TMEM
   encoding and to tc_gen5_mma_scaled, with cluster-dim / BLOCK_M validation and
   a 1-CTA fallback so the kernel still compiles on misuse.

3. CheckMatmulTwoCTAs: match tt.dot_scaled in the module-uniformity walk. This
   pass runs before lower-mma, and it is load-bearing rather than cosmetic:
   without it the module ttng.two-ctas attribute stays false for the scaled
   path, and every downstream consumer of getModuleTwoCTAs sees the wrong value,
   including the cluster mbarrier-init fence and ClusterBarrierInsertion's
   classification of ttng.tmem_copy as a cross-CTA access.

4. Transform2CTALoads: generalize the walk to MMAv5OpInterface so the B operand
   is split for scaled MMAs too. A scaled MMA has a single B consumer and takes
   the transformBLoad path rather than the tt.split-shaped transformSplitBLoad
   path. The B *scale* is intentionally kept full width per CTA (see the in-code
   NOTE): the block-scale MMA addresses each CTA's N-half out of the full scale,
   so splitting it is wrong.

No explicit scale-copy synchronization is added, and none is needed. Scale
operands become ttng.tmem_copy in lower-mma, i.e. after Insert2CTASync runs, but
the resulting cp -> MMA dependency is already covered: TMemBarrierInsertion
records the TMEMCopyOp write to its destination and the scaled MMA's
getAScale()/getBScale() reads and barriers on intersection, and
ClusterBarrierInsertion treats TMEMCopyOp as cross-CTA whenever getModuleTwoCTAs
is set, which item 3 is what sets. The PTX ISA additionally orders
tcgen05.cp.cta_group::2 before a subsequent tcgen05.mma.cta_group::2 issued by
the same (leader) CTA.

Two pieces live in the child diff D118745928 rather than here. The cross-CTA
rendezvous barrier is generalized to MMAv5OpInterface and multi-buffered so a
follower CTA cannot lap its phase bit, which is required for num_stages >= 3 on
both the scaled and the plain 2-CTA path. That diff also closes the
dependent-chain gap: CheckMatmulTwoCTAs walks DotOpInterface there, so a chain
with a scaled dot at either end is rejected under allowDependentChains=false.

Reviewed By: njriasan

Differential Revision: D114270737


