### PR TITLE
[AMD][gfx950][TLX] a16w16 batched GEMM tutorial (amd_bmm) (#2558)

### DIFF
--- a/third_party/tlx/tutorials/amd_bmm.py
+++ b/third_party/tlx/tutorials/amd_bmm.py
@@ -1,0 +1,256 @@
+"""AMD a16w16 batched GEMM (BMM) for gfx950 / CDNA4 — dual load-path, single kernel.
+
+C[b] = A[b] @ B[b], fp16/bf16, batched. A is (B, M, K); B is (B, K, N) COLUMN-major
+(K-contiguous, ``stride_bk == 1``), i.e. built as (B, N, K) then transposed — the
+layout the direct-to-LDS B loads expect. C is (B, M, N) row-major.
+``make_bmm_inputs`` builds SHARED-A (one (M, K) reused across the batch,
+``a.stride(0) == 0``); benchmark against shared-A, since rocBLAS reads it once and
+a distinct-A comparison flatters TLX.
+
+For the standard torch.bmm / inductor layout (ROW-major B) see the companion
+``amd_bmm_shared_a.py``, which needs num_warps=8 + matrix_instr_nonkdim=32; nw=8
+does not compile with this kernel's swizzle + 4-warp split store.
+
+ONE kernel, two load paths selected by a ``USE_DIRECT`` constexpr the launcher sets
+from K's alignment (``K % BLOCK_K == 0``):
+  * USE_DIRECT=1 (aligned rows): async direct-to-LDS (``buffer_load_to_local`` —
+    global -> LDS with no register round-trip).
+  * USE_DIRECT=0 (K % BLOCK_K != 0): register path (``tl.load`` -> registers ->
+    ``tlx.local_store``, masked K-tail), required wherever direct-to-LDS is illegal
+    on CDNA4 (odd K -> 2-byte-aligned rows).
+
+Design notes shared by both paths:
+  * num_warps=4 -> 2 workgroups co-resident per CU; they drift out of phase so the
+    hardware overlaps one WG's MFMA with the other's loads (inter-WG ping-pong).
+  * Swizzled + padded LDS (``padded_shared_layout_encoding``) -> bank-conflict-free
+    ``ds_read_b128``.
+  * L2 XCD-chunk remap (``_chip``) -> a batch's M-tiles stay on one XCD, keeping B
+    hot in L2.
+  * int64 per-batch base advance (batch*M*K can exceed 2**31); within-tile offsets
+    stay int32.
+  * ``% M`` / ``% N`` wrap on load indices -> OOB rows re-read valid data (L2),
+    never HBM garbage.
+  * NB-deep software pipeline (prologue prime / steady overlap / epilogue drain).
+  * 4-warp coalesced split-store ([128, 256] -> two [128, 128] dwordx4 stores).
+
+Exposes ``bmm(a, b)``.
+"""
+import os
+
+import torch
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+BLOCK_N = 256
+BLOCK_K = 32
+NUM_XCDS = 8
+NB = 3
+KERNEL_NAME = "amd_bmm"
+
+
+def _swz(shape, cd):
+    """Swizzle-offset bases for a [d0, d1] tile whose contiguous dim is ``cd``."""
+
+    def basis(d, i):
+        return [1 << i, 0] if d == 0 else [0, 1 << i]
+
+    fd = 1 - cd
+    cb = int(shape[cd]).bit_length() - 1
+    fb = int(shape[fd]).bit_length() - 1
+    return ([basis(cd, i) for i in range(cb)] + [basis(fd, i)
+                                                 for i in range(4, fb)] + [basis(fd, i) for i in range(min(4, fb))])
+
+
+_B_BASES = tl.constexpr(_swz([BLOCK_K, BLOCK_N], 0))
+# 4-warp (256-thread) coalesced [128, 128] store layout: 8 contiguous N per thread (dwordx4).
+_C4 = tlx.layout(shape=((16, 16), (8, 8)), stride=((8, 128), (1, 2048)))
+
+
+@triton.jit
+def _chip(pid, nwg, nx: tl.constexpr, cs: tl.constexpr):
+    """L2-aware XCD remap: keep a batch's M-tiles (chunk of size ``cs``) on one XCD."""
+    al = (nwg // (nx * cs)) * (nx * cs)
+    if pid >= al:
+        return pid
+    x = pid % nx
+    lp = pid // nx
+    return (lp // cs) * nx * cs + x * cs + (lp % cs)
+
+
+@triton.jit
+def amd_bmm_kernel(a_ptr, b_ptr, c_ptr, M, N, K, sab, sam, sak, sbb, sbk, sbn, scb, scm, scn, BLOCK_M: tl.constexpr,
+                   BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, A_BASES: tl.constexpr, NUM_XCDS: tl.constexpr,
+                   GRID_MN: tl.constexpr, NUM_TILES: tl.constexpr, NB: tl.constexpr, USE_DIRECT: tl.constexpr):
+    tl.assume(sam > 0)
+    tl.assume(sak > 0)
+    tl.assume(sbn > 0)
+    tl.assume(sbk > 0)
+    npn = tl.cdiv(N, BLOCK_N)
+    pidf = _chip(tl.program_id(0), NUM_TILES, NUM_XCDS, GRID_MN)
+    bid = pidf // GRID_MN
+    pid = pidf % GRID_MN
+    pm = pid // npn
+    pn = pid % npn
+    a_sh: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases([(512, 16)], A_BASES, [BLOCK_M, BLOCK_K])
+    b_sh: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases([(512, 16)], _B_BASES, [BLOCK_K, BLOCK_N])
+    sA = tlx.local_alloc((BLOCK_M, BLOCK_K), tl.float16, NB, layout=a_sh)
+    sB = tlx.local_alloc((BLOCK_K, BLOCK_N), tl.float16, NB, layout=b_sh)
+    om = (pm * BLOCK_M + tl.arange(0, BLOCK_M)) % M
+    on = (pn * BLOCK_N + tl.arange(0, BLOCK_N)) % N
+    ok = tl.arange(0, BLOCK_K)
+    a_ptr = a_ptr + bid.to(tl.int64) * sab
+    b_ptr = b_ptr + bid.to(tl.int64) * sbb
+    ao = om[:, None] * sam
+    bo = on[None, :] * sbn
+    KI = tl.cdiv(K, BLOCK_K)
+
+    # Prime NB LDS buffers before the steady state so tile 0 is already resident.
+    for i in tl.range(0, NB, loop_unroll_factor=NB):
+        kk = i * BLOCK_K
+        if USE_DIRECT:
+            tlx.buffer_load_to_local(tlx.local_view(sA, i), a_ptr, ao + (kk + ok[None, :]) * sak)
+            tlx.buffer_load_to_local(tlx.local_view(sB, i), b_ptr, (kk + ok[:, None]) * sbk + bo)
+            tlx.async_load_commit_group()
+        else:
+            km = (kk + ok) < K
+            ar = tl.load(a_ptr + ao + (kk + ok[None, :]) * sak, mask=km[None, :], other=0.0)
+            br = tl.load(b_ptr + (kk + ok[:, None]) * sbk + bo, mask=km[:, None], other=0.0)
+            tlx.local_store(tlx.local_view(sA, i), ar)
+            tlx.local_store(tlx.local_view(sB, i), br)
+    if USE_DIRECT:
+        tlx.async_load_wait_group(NB - 2)
+    else:
+        tl.debug_barrier()
+    a = tlx.local_load(tlx.local_view(sA, 0))
+    b = tlx.local_load(tlx.local_view(sB, 0))
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    # Steady state: tile k computes while tile k+NB is still in flight.
+    for k in tl.range(0, KI - NB):
+        cur = (k + 1) % NB
+        pf = k % NB
+        kp = (k + NB) * BLOCK_K
+        acc = tl.dot(a, b, acc)
+        if USE_DIRECT:
+            tlx.buffer_load_to_local(tlx.local_view(sA, pf), a_ptr, ao + (kp + ok[None, :]) * sak)
+            tlx.buffer_load_to_local(tlx.local_view(sB, pf), b_ptr, (kp + ok[:, None]) * sbk + bo)
+            tlx.async_load_commit_group()
+            tlx.async_load_wait_group(NB - 2)
+        else:
+            km = (kp + ok) < K
+            ar = tl.load(a_ptr + ao + (kp + ok[None, :]) * sak, mask=km[None, :], other=0.0)
+            br = tl.load(b_ptr + (kp + ok[:, None]) * sbk + bo, mask=km[:, None], other=0.0)
+            tlx.local_store(tlx.local_view(sA, pf), ar)
+            tlx.local_store(tlx.local_view(sB, pf), br)
+            tl.debug_barrier()
+        a = tlx.local_load(tlx.local_view(sA, cur))
+        b = tlx.local_load(tlx.local_view(sB, cur))
+
+    # Drain the NB tiles the prologue put in flight but the loop never consumed.
+    acc = tl.dot(a, b, acc)
+    if USE_DIRECT:
+        tlx.async_load_wait_group(0)
+    for i in tl.range(0, NB - 1, loop_unroll_factor=NB - 1):
+        bf = (KI - (NB - 1) + i) % NB
+        acc = tl.dot(tlx.local_load(tlx.local_view(sA, bf)), tlx.local_load(tlx.local_view(sB, bf)), acc)
+
+    # Split the [BLOCK_M, BLOCK_N] accumulator into two N-halves so each of the 4
+    # warps stores 8 contiguous N per thread (dwordx4).
+    et = c_ptr.dtype.element_ty
+    cb = c_ptr + bid.to(tl.int64) * scb
+    HN: tl.constexpr = BLOCK_N // 2
+    rm = pm * BLOCK_M + tl.arange(0, BLOCK_M)
+    rnl = pn * BLOCK_N + tl.arange(0, HN)
+    rnr = rnl + HN
+    mm = rm[:, None] < M
+    al, ar2 = tl.split(tl.trans(tl.reshape(acc, BLOCK_M, 2, HN), 0, 2, 1))
+    tl.store(cb + scm * rm[:, None] + scn * rnl[None, :], tlx.require_layout(al.to(et), _C4),
+             mask=mm & (rnl[None, :] < N))
+    tl.store(cb + scm * rm[:, None] + scn * rnr[None, :], tlx.require_layout(ar2.to(et), _C4),
+             mask=mm & (rnr[None, :] < N))
+
+
+def bmm(a, b, block_m=None, nw=4, nb=None):
+    """C = A @ B batched. a (B, M, K) row-major; b (B, K, N) COLUMN-major (stride_bk == 1)."""
+    assert a.ndim == 3 and b.ndim == 3 and a.shape[0] == b.shape[0]
+    Bs, M, K = a.shape
+    _, _, N = b.shape
+    bm = block_m or int(os.environ.get("BM_BMM", "128"))
+    # _C4 is a pinned [128,128] store layout (see its definition), so the epilogue
+    # require_layout only matches at bm == 128. Fail here rather than deep inside
+    # the compiler if BM_BMM / block_m is overridden.
+    assert bm == 128, f"block_m must be 128 to match the pinned _C4 store layout, got {bm}"
+    A_BASES = tuple(tuple(x) for x in _swz([bm, BLOCK_K], 1))
+    nb = nb or int(os.environ.get("NB_BMM", NB))
+    KI = triton.cdiv(K, BLOCK_K)
+    assert KI >= 2, f"K must span >= 2 BLOCK_K={BLOCK_K} tiles for the pipeline, got K={K}"
+    # The 2-stage pipeline needs 2 <= nb <= KI: the prologue unconditionally issues
+    # nb loads and the drain indexes (KI - (nb - 1) + i) % nb, so nb > KI would
+    # over-read past K and re-accumulate tile 0. Requiring KI >= 2 makes
+    # min(NB, KI) >= 2 on its own -- a max(2, ...) here would defeat the clamp.
+    nb = min(nb, KI)
+    use_direct = (K % BLOCK_K == 0)  # aligned, no K-tail -> fast direct-to-LDS
+    GM = triton.cdiv(M, bm) * triton.cdiv(N, BLOCK_N)
+    NT = Bs * GM
+    c = torch.empty((Bs, M, N), device=a.device, dtype=a.dtype)
+    amd_bmm_kernel[(NT, )](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        a.stride(2),
+        b.stride(0),
+        b.stride(1),
+        b.stride(2),
+        c.stride(0),
+        c.stride(1),
+        c.stride(2),
+        BLOCK_M=bm,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        A_BASES=A_BASES,
+        NUM_XCDS=NUM_XCDS,
+        GRID_MN=GM,
+        NUM_TILES=NT,
+        NB=nb,
+        USE_DIRECT=use_direct,
+        num_warps=nw,
+        num_stages=1,
+        matrix_instr_nonkdim=16,
+        llvm_fn_attrs=(("amdgpu-agpr-alloc", "0,0"), ),
+    )
+    return c
+
+
+def make_bmm_inputs(B, M, N, K, device, dtype=torch.float16, seed=0):
+    """SHARED-A (the shared-LHS layout): a single (M, K) matrix reused
+    across the whole batch via ``expand`` -> ``a.stride(0) == 0`` (mat1 batch-stride 0).
+    rocBLAS/hipBLASLt exploits this to read A once from HBM (L2-resident), so it is MUCH
+    faster than distinct-A -> we ALWAYS benchmark shared-A; distinct-A flatters TLX.
+    B is (B, K, N) COLUMN-major (built as (B, N, K) then transposed); C is (B, M, N) row-major.
+    """
+    g = torch.Generator(device=device).manual_seed(seed)
+    a = torch.randn((M, K), device=device, dtype=dtype, generator=g).unsqueeze(0).expand(B, M, K)
+    b = torch.randn((B, N, K), device=device, dtype=dtype, generator=g).transpose(1, 2)  # (B, K, N) col-major
+    return a, b
+
+
+if __name__ == "__main__":
+    dev = triton.runtime.driver.active.get_active_torch_device()
+    # (M, N, K, B): mix of aligned (direct-to-LDS) and odd/unaligned (register) K.
+    shapes = [(1024, 256, 256, 320), (395, 256, 320, 1024), (140, 256, 1888, 1024), (262, 256, 294, 1024),
+              (40, 256, 1956, 1024), (176, 256, 257, 1024), (1195, 256, 2309, 1024), (433, 256, 2352, 1024)]
+    print(f"{'M x N x K (B)':<24}{'path':<9}{'max_err':<10}{'result'}")
+    for M, N, K, B in shapes:
+        a, b = make_bmm_inputs(B, M, N, K, dev)
+        ref = torch.bmm(a.float(), b.float())
+        out = bmm(a, b).float()
+        err = (out - ref).abs().max().item()
+        path = "direct" if K % BLOCK_K == 0 else "register"
+        print(f"{f'{M}x{N}x{K} ({B})':<24}{path:<9}{err:<10.4f}{'OK' if err < 0.15 else 'FAIL'}")

--- a/third_party/tlx/tutorials/amd_bmm_shared_a.py
+++ b/third_party/tlx/tutorials/amd_bmm_shared_a.py
@@ -1,0 +1,214 @@
+"""Shared-A batched GEMM (BMM) for gfx950 / CDNA4 — ROW-major B (shared-LHS).
+
+Companion to ``amd_bmm.py``. Both files are shared-A; what differs is B's memory
+layout: ``amd_bmm.py`` takes COLUMN-major B (``stride_bk == 1``), this file takes
+ROW-major B (``stride_bn == 1``), the standard torch.bmm / inductor layout.
+
+LAYOUT:
+  * A: shared-A — one (M, K) matrix reused across the whole batch,
+    ``a.stride(0) == 0`` (mat1 batch-stride 0). Benchmark against shared-A, not
+    distinct-A: rocBLAS reads shared-A once and keeps it L2-resident, so a
+    distinct-A comparison flatters TLX.
+  * B: (B, K, N) ROW-major (N-contiguous, ``stride_bn == 1``).
+  * C: (B, M, N) row-major.
+
+CONFIG: num_warps=8, matrix_instr_nonkdim=32 (32x32 MFMA). nw=8 does not compile
+with the column-major kernel's swizzle + 4-warp split store, which is why the two
+layouts are separate files rather than one parameterised kernel.
+
+Two load paths, selected by K alignment (``K % BLOCK_K == 0`` -> aligned A rows,
+no K-tail):
+  * aligned -> direct-to-LDS (``buffer_load_to_local``) + swizzled LDS.
+  * odd K   -> register path (``tl.load`` -> ``tlx.local_store``), masked K-tail.
+    Required because odd K gives 2-byte-aligned rows, where direct-to-LDS is
+    illegal on CDNA4.
+"""
+import torch
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+from triton.testing import do_bench
+
+BLOCK_N = 256
+BLOCK_K = 32
+NUM_XCDS = 8
+NB = 3
+
+
+def _swz(shape, cd):
+    def basis(d, i):
+        return [1 << i, 0] if d == 0 else [0, 1 << i]
+
+    fd = 1 - cd
+    cb = int(shape[cd]).bit_length() - 1
+    fb = int(shape[fd]).bit_length() - 1
+    return ([basis(cd, i) for i in range(cb)] + [basis(fd, i)
+                                                 for i in range(4, fb)] + [basis(fd, i) for i in range(min(4, fb))])
+
+
+@triton.jit
+def _chip(pid, nt, nx: tl.constexpr, cs: tl.constexpr):
+    """L2 XCD-chunk remap: keep a batch's MN-tiles on one XCD (B stays hot in L2)."""
+    al = (nt // (nx * cs)) * (nx * cs)
+    if pid >= al:
+        return pid
+    x = pid % nx
+    lp = pid // nx
+    return (lp // cs) * nx * cs + x * cs + (lp % cs)
+
+
+@triton.jit
+def _bmm_direct(a_ptr, b_ptr, c_ptr, M, N, K, sab, sam, sak, sbb, sbk, sbn, scb, scm, scn,
+                BM: tl.constexpr, BN: tl.constexpr, BK: tl.constexpr, AB: tl.constexpr, BB: tl.constexpr,
+                NUM_XCDS: tl.constexpr, GMN: tl.constexpr, NT: tl.constexpr, NB: tl.constexpr):
+    """Aligned rows, no K-tail (K % BLOCK_K == 0): direct-to-LDS + swizzled LDS."""
+    npn = tl.cdiv(N, BN)
+    pidf = _chip(tl.program_id(0), NT, NUM_XCDS, GMN)
+    bid = pidf // GMN; pid = pidf % GMN; pm = pid // npn; pn = pid % npn
+    ash: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases([(512, 16)], AB, [BM, BK])
+    bsh: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases([(512, 16)], BB, [BK, BN])
+    sA = tlx.local_alloc((BM, BK), tl.float16, NB, layout=ash)
+    sB = tlx.local_alloc((BK, BN), tl.float16, NB, layout=bsh)
+    om = (pm * BM + tl.arange(0, BM)) % M; on = (pn * BN + tl.arange(0, BN)) % N; ok = tl.arange(0, BK)
+    a_ptr = a_ptr + bid.to(tl.int64) * sab; b_ptr = b_ptr + bid.to(tl.int64) * sbb
+    ao = om[:, None] * sam; bo = on[None, :] * sbn; KI = tl.cdiv(K, BK)
+    for i in tl.range(0, NB, loop_unroll_factor=NB):
+        kk = i * BK
+        tlx.buffer_load_to_local(tlx.local_view(sA, i), a_ptr, ao + (kk + ok[None, :]) * sak)
+        tlx.buffer_load_to_local(tlx.local_view(sB, i), b_ptr, (kk + ok[:, None]) * sbk + bo)
+        tlx.async_load_commit_group()
+    tlx.async_load_wait_group(NB - 2)
+    a = tlx.local_load(tlx.local_view(sA, 0)); b = tlx.local_load(tlx.local_view(sB, 0))
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for k in tl.range(0, KI - NB):
+        cur = (k + 1) % NB; pf = k % NB; kp = (k + NB) * BK
+        acc = tl.dot(a, b, acc)
+        tlx.buffer_load_to_local(tlx.local_view(sA, pf), a_ptr, ao + (kp + ok[None, :]) * sak)
+        tlx.buffer_load_to_local(tlx.local_view(sB, pf), b_ptr, (kp + ok[:, None]) * sbk + bo)
+        tlx.async_load_commit_group(); tlx.async_load_wait_group(NB - 2)
+        a = tlx.local_load(tlx.local_view(sA, cur)); b = tlx.local_load(tlx.local_view(sB, cur))
+    acc = tl.dot(a, b, acc)
+    tlx.async_load_wait_group(0)
+    for i in tl.range(0, NB - 1, loop_unroll_factor=NB - 1):
+        bf = (KI - (NB - 1) + i) % NB
+        acc = tl.dot(tlx.local_load(tlx.local_view(sA, bf)), tlx.local_load(tlx.local_view(sB, bf)), acc)
+    et = c_ptr.dtype.element_ty; cb = c_ptr + bid.to(tl.int64) * scb
+    rm = pm * BM + tl.arange(0, BM); rn = pn * BN + tl.arange(0, BN)
+    tl.store(cb + scm * rm[:, None] + scn * rn[None, :], acc.to(et), mask=(rm[:, None] < M) & (rn[None, :] < N))
+
+
+@triton.jit
+def _bmm_register(a_ptr, b_ptr, c_ptr, M, N, K, sab, sam, sak, sbb, sbk, sbn, scb, scm, scn,
+                  BM: tl.constexpr, BN: tl.constexpr, BK: tl.constexpr,
+                  NUM_XCDS: tl.constexpr, GMN: tl.constexpr, NT: tl.constexpr, NB: tl.constexpr):
+    """Odd / unaligned K: register path (tl.load -> local_store), masked K-tail."""
+    npn = tl.cdiv(N, BN)
+    pidf = _chip(tl.program_id(0), NT, NUM_XCDS, GMN)
+    bid = pidf // GMN; pid = pidf % GMN; pm = pid // npn; pn = pid % npn
+    sA = tlx.local_alloc((BM, BK), tl.float16, NB); sB = tlx.local_alloc((BK, BN), tl.float16, NB)
+    om = (pm * BM + tl.arange(0, BM)) % M; on = (pn * BN + tl.arange(0, BN)) % N; ok = tl.arange(0, BK)
+    a_ptr = a_ptr + bid.to(tl.int64) * sab; b_ptr = b_ptr + bid.to(tl.int64) * sbb
+    ao = om[:, None] * sam; bo = on[None, :] * sbn; KI = tl.cdiv(K, BK)
+    for i in tl.range(0, NB, loop_unroll_factor=NB):
+        kk = i * BK; km = (kk + ok) < K
+        ar = tl.load(a_ptr + ao + (kk + ok[None, :]) * sak, mask=km[None, :], other=0.0)
+        br = tl.load(b_ptr + (kk + ok[:, None]) * sbk + bo, mask=km[:, None], other=0.0)
+        tlx.local_store(tlx.local_view(sA, i), ar); tlx.local_store(tlx.local_view(sB, i), br)
+    tl.debug_barrier()
+    a = tlx.local_load(tlx.local_view(sA, 0)); b = tlx.local_load(tlx.local_view(sB, 0))
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for k in tl.range(0, KI - NB):
+        cur = (k + 1) % NB; pf = k % NB; kp = (k + NB) * BK
+        acc = tl.dot(a, b, acc)
+        km = (kp + ok) < K
+        ar = tl.load(a_ptr + ao + (kp + ok[None, :]) * sak, mask=km[None, :], other=0.0)
+        br = tl.load(b_ptr + (kp + ok[:, None]) * sbk + bo, mask=km[:, None], other=0.0)
+        tlx.local_store(tlx.local_view(sA, pf), ar); tlx.local_store(tlx.local_view(sB, pf), br)
+        tl.debug_barrier()
+        a = tlx.local_load(tlx.local_view(sA, cur)); b = tlx.local_load(tlx.local_view(sB, cur))
+    acc = tl.dot(a, b, acc)
+    for i in tl.range(0, NB - 1, loop_unroll_factor=NB - 1):
+        bf = (KI - (NB - 1) + i) % NB
+        acc = tl.dot(tlx.local_load(tlx.local_view(sA, bf)), tlx.local_load(tlx.local_view(sB, bf)), acc)
+    et = c_ptr.dtype.element_ty; cb = c_ptr + bid.to(tl.int64) * scb
+    rm = pm * BM + tl.arange(0, BM); rn = pn * BN + tl.arange(0, BN)
+    tl.store(cb + scm * rm[:, None] + scn * rn[None, :], acc.to(et), mask=(rm[:, None] < M) & (rn[None, :] < N))
+
+
+def bmm(a, b):
+    """C = A @ B, shared-A, ROW-major B (stride_bn == 1). nw=8, mfma=32."""
+    Bs, M, K = a.shape
+    N = b.shape[-1]
+    bm = 64 if M <= 64 else 128
+    KI = triton.cdiv(K, BLOCK_K)
+    assert KI >= 2, f"K must span >= 2 BLOCK_K={BLOCK_K} tiles for the pipeline, got K={K}"
+    # The 2-stage pipeline needs 2 <= nb <= KI: the prologue unconditionally issues
+    # nb loads and the drain indexes (KI - (nb - 1) + i) % nb, so nb > KI would
+    # over-read past K and re-accumulate tile 0. Requiring KI >= 2 makes
+    # min(NB, KI) >= 2 on its own -- a max(2, ...) here would defeat the clamp.
+    nb = min(NB, KI)
+    GMN = triton.cdiv(M, bm) * triton.cdiv(N, BLOCK_N)
+    NT = Bs * GMN
+    c = torch.empty((Bs, M, N), device=a.device, dtype=a.dtype)
+    attrs = (("amdgpu-agpr-alloc", "0,0"), )
+    common = dict(num_warps=8, num_stages=1, matrix_instr_nonkdim=32, llvm_fn_attrs=attrs)
+    st = (a.stride(0), a.stride(1), a.stride(2), b.stride(0), b.stride(1), b.stride(2), c.stride(0), c.stride(1),
+          c.stride(2))
+    # K % BLOCK_K, not K % 8: the direct path does no K-tail masking on
+    # buffer_load_to_local, so a K that is 8-aligned but not BLOCK_K-aligned
+    # (e.g. 264) reads past the K extent. Matches the guard in amd_bmm.py.
+    if K % BLOCK_K == 0:  # 16-byte-aligned A rows, no K-tail -> direct-to-LDS (wins)
+        AB = tuple(tuple(x) for x in _swz([bm, BLOCK_K], 1))
+        BB = tuple(tuple(x) for x in _swz([BLOCK_K, BLOCK_N], 1))
+        _bmm_direct[(NT, )](a, b, c, M, N, K, *st, BM=bm, BN=BLOCK_N, BK=BLOCK_K, AB=AB, BB=BB, NUM_XCDS=NUM_XCDS,
+                            GMN=GMN, NT=NT, NB=nb, **common)
+    else:  # odd / unaligned K -> register path
+        _bmm_register[(NT, )](a, b, c, M, N, K, *st, BM=bm, BN=BLOCK_N, BK=BLOCK_K, NUM_XCDS=NUM_XCDS, GMN=GMN, NT=NT,
+                              NB=nb, **common)
+    return c
+
+
+def make_bmm_inputs(B, M, N, K, device, dtype=torch.float16, seed=0):
+    """SHARED-A: one (M,K) reused across the batch -> a.stride(0)==0. B row-major.
+
+    We always use shared-A: it is the shared-LHS layout, and distinct-A flatters TLX
+    (rocBLAS reads shared-A once from HBM, so it is much faster on distinct-A).
+    """
+    g = torch.Generator(device=device).manual_seed(seed)
+    a = torch.randn((M, K), device=device, dtype=dtype, generator=g).unsqueeze(0).expand(B, M, K)
+    b = torch.randn((B, K, N), device=device, dtype=dtype, generator=g)  # row-major (stride_bn == 1)
+    return a, b
+
+
+def _warm_ms(fn, iters=60, warmup=20):
+    """Warm device time (L2 hot, back-to-back) — matches rocprofv3 kernel-trace, no launch tax."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    s = torch.cuda.Event(enable_timing=True)
+    e = torch.cuda.Event(enable_timing=True)
+    s.record()
+    for _ in range(iters):
+        fn()
+    e.record()
+    torch.cuda.synchronize()
+    return s.elapsed_time(e) / iters
+
+
+if __name__ == "__main__":
+    dev = triton.runtime.driver.active.get_active_torch_device()
+    # (B, M, N, K): representative shared-LHS shapes.  Always shared-A.
+    shapes = [(320, 1024, 256, 256), (1024, 395, 256, 320), (1024, 40, 256, 1956), (1024, 262, 256, 294),
+              (1024, 1195, 256, 2309)]
+    print("mode: shared-A (shared-LHS)   (B row-major)")
+    print(f"{'M x N x K (B)':<22}{'path':<8}{'TLX':>9}{'rocBLAS':>10}{'ratio':>8}  {'ok'}")
+    for B, M, N, K in shapes:
+        a, b = make_bmm_inputs(B, M, N, K, dev)
+        ref = torch.bmm(a, b)
+        out = bmm(a, b)
+        ok = torch.allclose(out.float(), ref.float(), atol=2e-2, rtol=2e-2)
+        t = _warm_ms(lambda: bmm(a, b)) * 1e3
+        rb = _warm_ms(lambda: torch.bmm(a, b)) * 1e3
+        path = "direct" if K % BLOCK_K == 0 else "reg"
+        print(f"{f'{M}x{N}x{K} ({B})':<22}{path:<8}{t:8.0f}u{rb:9.0f}u{rb / t:7.2f}x  {'OK' if ok else 'WRONG'}")

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -78,6 +78,10 @@ from triton.language.extra.tlx.tutorials.amd_gemm_pipelined import (
     matmul as _amd_gemm_pipelined, )
 from triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a16w16.matmul_kernel_split_m import (
     matmul as _amd_gemm_pingpong, )
+from triton.language.extra.tlx.tutorials.amd_bmm import (
+    bmm as _amd_bmm,
+    make_bmm_inputs as _amd_bmm_inputs,
+)
 from triton.language.extra.tlx.tutorials.amd_mxfp_gemm_tdm_pipelined import (
     matmul as _amd_mxfp_gemm_tdm_pipelined,
     pack_scale as _amd_mxfp_pack_scale,
@@ -1517,6 +1521,21 @@ def test_amd_gemm_pingpong(dtype):
 def test_amd_gemm_pipelined(dtype):
     # Autotuned kernel: no fixed config (config=None).
     Gemm.run_test(_amd_gemm_pipelined, None, dtype=dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires AMD gfx950 (CDNA4)")
+def test_amd_bmm(dtype):
+    # a16w16 batched GEMM (col-major B). Covers both load paths of the single kernel:
+    # aligned K (K % 32 == 0) -> direct-to-LDS; odd / unaligned K -> register path.
+    # K=264 is the boundary case: 8-aligned but NOT BLOCK_K-aligned, so it must take
+    # the register path -- the direct path does no K-tail masking and would over-read.
+    for M, N, K, B in [(256, 256, 256, 8), (395, 256, 320, 8), (262, 256, 294, 8), (176, 256, 257, 8),
+                       (256, 256, 264, 8)]:
+        a, b = _amd_bmm_inputs(B, M, N, K, DEVICE, dtype=dtype)
+        out = _amd_bmm(a, b)
+        ref = torch.bmm(a, b)
+        torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
 
 
 # =============================================================================


### PR DESCRIPTION
Summary:

Single-kernel a16w16 BMM for gfx950 / CDNA4, dual load-path selected by K alignment
(a USE_DIRECT constexpr the launcher sets):
  * aligned K (K % 32 == 0): direct-to-LDS (buffer_load_to_local, global -> LDS, no
    register round-trip).
  * odd / unaligned K: register path (tl.load -> tlx.local_store, masked K-tail) that
    lowers for ANY row-stride alignment where direct-to-LDS is illegal on CDNA4
    (odd K -> 2-byte-aligned rows).

Shared levers: swizzled + padded LDS (ds_read_b128, bank-conflict-free), L2 XCD-chunk
remap (keeps a batch's B hot), int64 per-batch base advance, %M/%N wrap, NB-deep
software pipeline. amd_bmm.py = COLUMN-major B (num_warps=4);
amd_bmm_shared_perf.py = ROW-major B (torch.bmm / inductor layout, num_warps=8 +
matrix_instr_nonkdim=32).

*** This diff is a reproducer to ask for perf help. ***
All numbers are SHARED-A (a.stride(0) == 0 -- the real layout: one A reused across the
batch). Benchmark shared-A, not distinct-A: distinct-A flatters us because rocBLAS reads
shared-A once and keeps it in L2.

EVERY shape is an improvement target. We do not want to regress the ones we are currently
ahead on, and we need help closing the rest -- more is always better.

Perf vs rocBLAS (MI350X, warm device time, shared-A, row-major B; ratio = rocBLAS / TLX,
>1 = TLX ahead):
  1024x256x256  (B=320)    1.07x   direct
  395x256x320   (B=1024)   1.08x   direct
  40x256x1956   (B=1024)   0.96x   reg
  262x256x294   (B=1024)   0.69x   reg
  1195x256x2309 (B=1024)   0.72x   reg

Where we trail (40, 262, 1195 -- odd K): the bottleneck is A's odd-K load width.
rocBLAS uses buffer_load_short_d16 / _d16_hi -- 16-bit loads PACKED 2 fp16 per VGPR
(half the registers -> higher occupancy). Triton's AMD backend emits buffer_load_ushort
(zero-extend, 1 fp16 per VGPR): same memory width and instruction count, but 2x the
registers -> lower occupancy. We could not close this from the Python side (swept
num_warps / nb / num_stages / BLOCK_K; forcing wide unaligned loads is WRONG on CDNA4
-- dwordx4 needs 16B alignment; tl.multiple_of / tl.assume divisibility hints do not
propagate to the buffer-coalescing pass). ATT of the rocBLAS kernel confirms the d16
packing. OPEN QUESTION for AMD / Triton: can the backend emit d16-packed loads for
unaligned fp16 (like rocBLAS), or expose a knob for it? And any ideas to push the
already-ahead direct shapes further are very welcome.

Repro (MI350X):
  python third_party/tlx/tutorials/amd_bmm_shared_perf.py   # row-major, shared-A: per-shape TLX vs rocBLAS (warm device time)
  python third_party/tlx/tutorials/amd_bmm.py               # column-major correctness sweep
Correctness: test_amd_bmm in third_party/tlx/tutorials/testing/test_correctness.py (shared-A).

Authored with Claude.

Reviewed By: htyu

Differential Revision: D114152213


