### PR TITLE
[AutoWS] Fix a Hopper bug related to shared stores

### DIFF
--- a/.llms/rules/partition-scheduler-bugs.md
+++ b/.llms/rules/partition-scheduler-bugs.md
@@ -132,6 +132,12 @@
 - **Regression**: WarpSpecialization lit suite 119 pass / 10 xfail / 0 unexpected.
 - **Key insight**: a `ttg.partition` attribute is a *set*, not a scalar. `PartitionSchedulingMeta` can legitimately assign an op to more than one partition (documented for the no-MMA scalar offset; also possible via the `TMAStoreTokenWaitOp` copy path). Any consumer of `ttg.partition` must handle size ≥ 1, not size == 1.
 
+### 17. Hopper data-partitioned TMA stores share staging slot 0 (2026-07-30, fixed)
+- **Symptom**: the Hopper tutorial09 data-partitioned GEMM writes incorrect output when two epilogue tasks TMA-store different C tiles through the same descriptor. Both stores use slot 0 of one fused staging allocation.
+- **Root cause** (`WSMemoryPlanner.cpp`, `fuseEpilogueWSBuffers`): Phase 3.5 keyed TMA staging fusion on `(descriptor, originalLoad)`. Hopper register accumulators do not trace to a `ttng.tmem_load`, so both `originalLoad` values were null and the key collapsed to the descriptor alone. `doCodePartition` then merged the two task-local allocations even though each task independently indexed its staging channel at slot 0.
+- **Fix**: when `originalLoad` is unavailable, include the channel's producer task in the staging-fusion key. Same-task subtiles still fuse, but concurrent data partitions targeting the same descriptor receive distinct `buffer.id`s.
+- **Tests**: `ws_memory_planner_tma_store_staging_cap.mlir` checks distinct IDs for two null-origin producer tasks. `test_hopper_matmul_tma_warp_specialize[False-True-2-True-False-4-3-64-128-128-8192-8192-1024]` passes and its final TTGIR contains two one-copy staging allocations instead of one two-copy reuse group.
+
 ## Debugging Workflow
 - `t.dump` captures IR after each WarpSpec pass (doTaskIdPropagate → doBufferAllocation → doMemoryPlanner → doCodePartition → ...)
 - IR after PartitionSchedulingMeta uses `ttg.partition = array<i32: N>` attributes (not `async_task_id`)

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -154,7 +154,9 @@ struct ConvertLayoutOpConversion
       assert(srcLayout.getOutDimSize(dim) == dstLayout.getOutDimSize(dim) &&
              "source and destination logical dimensions must have equal size");
 
-    auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
+    auto laneAndWarpId = getLaneAndWarpId(rewriter, loc);
+    Value laneId = laneAndWarpId.first;
+    Value warpId = laneAndWarpId.second;
     auto elemPtrTy = ptr_ty(ctx, targetInfo.getSharedAddressSpace());
     smemBase = b.bitcast(smemBase, elemPtrTy);
 

--- a/python/test/unit/language/test_autows_addmm.py
+++ b/python/test/unit/language/test_autows_addmm.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 import triton
 import triton.language as tl
-from triton._internal_testing import is_blackwell
+from triton._internal_testing import is_blackwell, is_hopper
 from triton.language.extra.subtile_ops import _split_n_2D
 from triton.tools.tensor_descriptor import TensorDescriptor
 
@@ -105,7 +105,7 @@ def addmm_kernel_tma_persistent_ws(
 @pytest.mark.parametrize("B_col_major", [False, True])
 @pytest.mark.parametrize("DATA_PARTITION_FACTOR", [1, 2])
 @pytest.mark.parametrize("generate_subtiled_region", [True, False])
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell")
 def test_autows_addmm_tma_persistent(
     M,
     N,
@@ -125,6 +125,13 @@ def test_autows_addmm_tma_persistent(
     """Test addmm kernel (bias + matmul) with warp_specialize=True."""
     if FLATTEN:
         pytest.skip("FLATTEN will not WarpSpecialize although it will otherwise pass.")
+
+    if is_hopper():
+        if EPILOGUE_SUBTILE != 1:
+            pytest.skip("EPILOGUE_SUBTILE is only supported for Blackwell.")
+
+        if BLOCK_SIZE_M == 256:
+            pytest.skip("BLOCK_SIZE_M == 256 runs out of shared memory for Hopper")
 
     # DATA_PARTITION_FACTOR != 1 requires BLOCK_SIZE_M == 256
     if DATA_PARTITION_FACTOR != 1 and BLOCK_SIZE_M != 256:
@@ -208,8 +215,11 @@ def test_autows_addmm_tma_persistent(
         # Verify IR contains expected ops
         ttgir = kernel.asm["ttgir"]
         assert "ttg.warp_specialize" in ttgir, "Expected warp specialization in IR"
-        assert "ttng.tc_gen5_mma" in ttgir, "Expected Blackwell MMA instruction"
         assert "ttng.async_tma_copy_global_to_local" in ttgir, "Expected TMA copy"
+        if is_blackwell():
+            assert "ttng.tc_gen5_mma" in ttgir, "Expected Blackwell MMA instruction"
+        else:
+            assert "ttng.warp_group_dot" in ttgir, "Expected Hopper MMA instruction"
 
         # Verify correctness: bias + A @ B.T
         ref_out = (torch.matmul(A.to(torch.float32), B.T.to(torch.float32)) + bias.to(torch.float32)).to(dtype)

--- a/scripts/build-llvm-project.sh
+++ b/scripts/build-llvm-project.sh
@@ -33,6 +33,7 @@ if [ -z "$CMAKE_ARGS" ]; then
               -DCMAKE_BUILD_TYPE="$LLVM_BUILD_TYPE"
               -DLLVM_CCACHE_BUILD=OFF
               -DLLVM_ENABLE_ASSERTIONS=ON
+              -DLLVM_INSTALL_UTILS=ON
               "${CLANG_LLD_ARGS[@]}"
               -DLLVM_OPTIMIZED_TABLEGEN=ON
               -DMLIR_ENABLE_BINDINGS_PYTHON=OFF

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_tma_store_staging_cap.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_tma_store_staging_cap.mlir
@@ -21,6 +21,15 @@
 // enforced; see PSM-related design discussion).
 // CHECK: ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 19 : i32, buffer.tmaStaging = 1 : i32} : () -> !ttg.memdesc<128x64xf16
 
+// Hopper register accumulators do not trace back to a tmem_load. When two data
+// partitions stage stores to the same descriptor, the producer task must keep
+// their fallback fusion groups distinct.
+// CHECK-LABEL: tt.func public @hopper_dp_staging
+// CHECK: %[[STAGE0:.*]] = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32, buffer.tmaStaging = 1 : i32}
+// CHECK: ttg.local_store %{{.*}}, %[[STAGE0]] {async_task_id = array<i32: 0>}
+// CHECK: %[[STAGE1:.*]] = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 1 : i32, buffer.tmaStaging = 1 : i32}
+// CHECK: ttg.local_store %{{.*}}, %[[STAGE1]] {async_task_id = array<i32: 1>}
+
 // -----// WarpSpec internal IR Dump After: doBufferAllocation
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -213,6 +222,20 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
     } {async_task_id = array<i32: 0, 1, 2, 3>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 200000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "load", "computation"], ttg.warp_specialize.tag = 0 : i32} loc(#loc118)
     tt.return loc(#loc77)
   } loc(#loc)
+
+  tt.func public @hopper_dp_staging(%desc: !tt.tensordesc<64x128xf16, #shared>, %src0: tensor<64x128xf16, #blocked4>, %src1: tensor<64x128xf16, #blocked4>) attributes {noinline = false} {
+    %c0 = arith.constant 0 : i32
+    %c64 = arith.constant 64 : i32
+    %stage0 = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+    ttg.local_store %src0, %stage0 {async_task_id = array<i32: 0>} : tensor<64x128xf16, #blocked4> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+    %token0 = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %stage0 {async_task_id = array<i32: 0>} : !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %token0 {async_task_id = array<i32: 0>} : !ttg.async.token
+    %stage1 = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+    ttg.local_store %src1, %stage1 {async_task_id = array<i32: 1>} : tensor<64x128xf16, #blocked4> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+    %token1 = ttng.async_tma_copy_local_to_global %desc[%c64, %c0] %stage1 {async_task_id = array<i32: 1>} : !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %token1 {async_task_id = array<i32: 1>} : !ttg.async.token
+    tt.return
+  }
 } loc(#loc)
 #loc1 = loc("/data/users/mren/MetaMain2/triton/python/tutorials/fused-attention-ws-device-tma.py":763:35)
 #loc2 = loc("/data/users/mren/MetaMain2/triton/python/tutorials/fused-attention-ws-device-tma.py":877:16)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -1381,11 +1381,17 @@ static void fuseEpilogueWSBuffers(SmallVector<WSBuffer> &wsBuffers,
   // separate: both store to the SAME descriptor but trace back to different
   // accumulators, so they must NOT share one physical staging buffer (doing so
   // makes the two concurrent partitions alias one slot/barrier -> corrupt
-  // output + deadlock). When the load can't be traced (origLoad == null), the
-  // key degenerates to the descriptor alone, preserving the prior behavior
-  // (e.g. FA backward, where each descriptor already has a single source).
-  DenseMap<std::pair<Value, Operation *>, SmallVector<unsigned>>
-      tmaStagingGroups;
+  // output + deadlock). Hopper register accumulators cannot currently be traced
+  // to a tmem_load, so fall back to the producer task instead of collapsing all
+  // untraceable sources for a descriptor into one group. Same-task epilogue
+  // subtiles still fuse, while different data partitions remain separate.
+  struct TMAStagingGroup {
+    Value desc;
+    Operation *origLoad = nullptr;
+    int producerTask = -1;
+    SmallVector<unsigned> indices;
+  };
+  SmallVector<TMAStagingGroup> tmaStagingGroups;
   for (unsigned i = 0; i < wsBuffers.size(); ++i) {
     auto &buf = wsBuffers[i];
     // TMA staging buffers: group per (descriptor, original load) regardless of
@@ -1403,9 +1409,21 @@ static void fuseEpilogueWSBuffers(SmallVector<WSBuffer> &wsBuffers,
         }
       }
       if (desc) {
-        Operation *origLoad =
-            findOriginalLoadForChannel(findChannelForOp(buf.allocOp, channels));
-        tmaStagingGroups[{desc, origLoad}].push_back(i);
+        Channel *channel = findChannelForOp(buf.allocOp, channels);
+        Operation *origLoad = findOriginalLoadForChannel(channel);
+        int producerTask = origLoad || !channel ? -1 : channel->relation.first;
+        auto it = llvm::find_if(tmaStagingGroups, [&](const auto &group) {
+          return group.desc == desc && group.origLoad == origLoad &&
+                 group.producerTask == producerTask;
+        });
+        if (it == tmaStagingGroups.end()) {
+          tmaStagingGroups.emplace_back();
+          it = std::prev(tmaStagingGroups.end());
+          it->desc = desc;
+          it->origLoad = origLoad;
+          it->producerTask = producerTask;
+        }
+        it->indices.push_back(i);
       }
       continue;
     }
@@ -1439,8 +1457,9 @@ static void fuseEpilogueWSBuffers(SmallVector<WSBuffer> &wsBuffers,
   for (auto &[origLoad, indices] : loadGroups)
     mergeGroup(indices, "epilogue fusion");
 
-  for (auto &[key, indices] : tmaStagingGroups)
-    mergeGroup(indices, "TMA staging per-(descriptor,load) fusion");
+  for (auto &group : tmaStagingGroups)
+    mergeGroup(group.indices,
+               "TMA staging per-(descriptor,load-or-task) fusion");
 }
 
 /// Phase 4.5: Iterative copy increase for fused P2_Other groups.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -876,6 +876,13 @@ struct WSBuffer {
   int reuseTargetBufferId = -1; // bufferId of the reuse target, -1 = no reuse.
 };
 
+struct TMAStagingGroup {
+  Value desc;
+  Operation *origLoad = nullptr;
+  int producerTask = -1;
+  SmallVector<unsigned> indices;
+};
+
 static unsigned
 getWSBufferUsageOrder(const WSBuffer &buf, SmallVector<Channel *> &channels,
                       const DenseMap<Operation *, unsigned> &opOrder) {
@@ -1385,12 +1392,6 @@ static void fuseEpilogueWSBuffers(SmallVector<WSBuffer> &wsBuffers,
   // to a tmem_load, so fall back to the producer task instead of collapsing all
   // untraceable sources for a descriptor into one group. Same-task epilogue
   // subtiles still fuse, while different data partitions remain separate.
-  struct TMAStagingGroup {
-    Value desc;
-    Operation *origLoad = nullptr;
-    int producerTask = -1;
-    SmallVector<unsigned> indices;
-  };
   SmallVector<TMAStagingGroup> tmaStagingGroups;
   for (unsigned i = 0; i < wsBuffers.size(); ++i) {
     auto &buf = wsBuffers[i];

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/ReuseGroups.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/ReuseGroups.md
@@ -163,10 +163,12 @@ For a data-partitioned epilogue (`tt.data_partition_factor > 1`) with
 `early_tma_store_lowering`, every partition's TMA-store staging buffer targets the
 **same** descriptor. `WSMemoryPlanner.cpp` `fuseEpilogueWSBuffers` therefore keys
 the TMA-staging fusion on `(descriptor, originalLoad)` — `originalLoad` traces the
-`local_store` source back to the originating `ttng.tmem_load` / accumulator — so
-the two partitions get **distinct** `buffer.id`s instead of sharing one physical
-buffer + barrier (which aliases concurrent partitions → corruption + deadlock).
-This mirrors the non-staging `loadGroups` discriminator.
+`local_store` source back to the originating `ttng.tmem_load` / accumulator. When
+that trace is unavailable for a Hopper register accumulator, the key uses the
+producer task instead. Thus two data partitions get **distinct** `buffer.id`s
+instead of sharing one physical buffer + barrier (which aliases concurrent
+partitions → corruption + deadlock), while same-task subtiles still fuse. This
+mirrors the non-staging `loadGroups` discriminator.
 
 ## What Reuse Groups Affect
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMAStoreWaitPipeline.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMAStoreWaitPipeline.md
@@ -43,11 +43,13 @@ The flag drives a special path through three phases:
 
 ### Phase 3.5: TMA Staging Fusion
 
-All TMA staging WSBuffers that feed the same TMA descriptor are merged
-into a single `bufferId` (via `fuseEpilogueWSBuffers`). For example, the
-4 subtile stagings of `desc_dq` (under `EPILOGUE_SUBTILE=4`) all share
-one `bufferId`, as do the dk and dv subtile stagings (each per their own
-descriptor).
+TMA staging WSBuffers are merged by descriptor and originating load (via
+`fuseEpilogueWSBuffers`). If the originating load cannot be traced, as with
+Hopper register accumulators, the producer task is used instead. For example,
+the 4 same-task subtile stagings of `desc_dq` (under `EPILOGUE_SUBTILE=4`) all
+share one `bufferId`, as do the dk and dv subtile stagings (each per their own
+descriptor). Different data-partition tasks targeting the same descriptor stay
+in distinct buffers.
 
 The shared `bufferId` is honored by `doCodePartition` downstream: the
 subtile allocs are physically merged into one `local_alloc` of shape


### PR DESCRIPTION
Fixes an issue where stores were incorrectly sharing 1 buffer for both data partitions. This is not safe in Hopper as they will be in separate producer partitions entirely.