### PR TITLE
[TLX][Blackwell] 2-CTA Flash Attention forward: unified per-CTA BLOCK_M and CLC persistent fix

### DIFF
--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -72,7 +72,10 @@ configs = [
         num_warps=4,
         pre_hook=_host_descriptor_pre_hook,
         ctas_per_cga=(2, 1, 1),
-    ) for kv in [3, 5] for grp_n in [1] for (rescale_opt, where) in [(False, False), (True, False), (True, True)]
+    )
+    for kv in [4, 5, 6, 7, 8, 9]
+    for grp_n in [1]
+    for (rescale_opt, where) in [(False, False), (True, False), (True, True)]
 ]
 
 
@@ -89,7 +92,7 @@ def prune_configs_by_hdim(configs, named_args, **kwargs):
         if grp_n != target_group_size_n:
             continue
         if is_2cta:
-            if kv not in (3, 5):
+            if kv not in (4, 5, 6, 7):
                 continue
         else:
             if kv != target_kv_buffers:
@@ -246,12 +249,8 @@ def _softmax_inner_loop(
     lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
 
     for start_n in tl.range(lo, hi, BLOCK_N):
-        if USE_2CTA:
-            qk_buf = accum_cnt_qk & 1
-            qk_buf_phase = (accum_cnt_qk >> 1) & 1
-        else:
-            qk_buf = cid
-            qk_buf_phase = accum_cnt_qk & 1
+        qk_buf = cid
+        qk_buf_phase = accum_cnt_qk & 1
         alpha_phase = accum_cnt_qk & 1
         tlx.barrier_wait(tlx.local_view(qk_fulls, qk_buf), qk_buf_phase)
         qk = tlx.local_load(tlx.local_view(qk_tiles, qk_buf))
@@ -407,99 +406,6 @@ def _fwd_load_1cta(
 
         kv_offset_y += BLOCK_N
         accum_cnt_kv += 2
-
-    return accum_cnt_kv
-
-
-@triton.jit
-def _fwd_load_2cta(
-    tile_count,
-    accum_cnt_kv,
-    lo,
-    hi,
-    qo_offset_y,
-    kv_offset_y,
-    desc_q,
-    desc_k,
-    desc_v,
-    q_tiles,
-    k_tiles,
-    v_tiles,
-    q_fulls,
-    q_empties,
-    k_fulls,
-    k_empties,
-    v_fulls,
-    v_empties,
-    cluster_cta_rank,
-    is_leader,
-    Q_BYTES_PER_ELEM: tl.constexpr,
-    K_BYTES_PER_ELEM: tl.constexpr,
-    V_BYTES_PER_ELEM: tl.constexpr,
-    BLOCK_M_SPLIT: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    HEAD_DIM: tl.constexpr,
-    NUM_CTAS: tl.constexpr,
-    NUM_BUFFERS_Q: tl.constexpr,
-    NUM_BUFFERS_KV: tl.constexpr,
-):
-    """2-CTA M-split forward load for one tile.
-
-    Each CTA loads ONE Q group (128 rows selected by cluster_cta_rank).
-    K/V are collective-MMA B operands loaded with two_ctas (leader-only
-    expect_bytes covers both halves):
-      K split along BLOCK_N rows   -> k_tiles[BLOCK_N // NUM_CTAS, HEAD_DIM]
-      V split along HEAD_DIM cols   -> v_tiles[BLOCK_N, HEAD_DIM // NUM_CTAS]
-    Both CTAs share the same tile → same kv_offset_y → consistent K/V head.
-    """
-    BLOCK_N_KV: tl.constexpr = BLOCK_N // NUM_CTAS
-    HEAD_DIM_KV: tl.constexpr = HEAD_DIM // NUM_CTAS
-
-    # load Q (two_ctas: both CTAs signal the leader's barrier so the MMA
-    # knows BOTH halves of Q are in SMEM before the .2CTA Q@K dot).
-    q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
-    tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
-    if is_leader:
-        tlx.barrier_expect_bytes(q_fulls[q_bufIdx], Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
-    tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx], [qo_offset_y + cluster_cta_rank * BLOCK_M_SPLIT, 0],
-                              q_fulls[q_bufIdx], two_ctas=tl.constexpr(True))
-
-    # load K (two_ctas, split along BLOCK_N rows)
-    k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-    tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
-    if is_leader:
-        tlx.barrier_expect_bytes(k_fulls[k_bufIdx], K_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-    tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx], [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0],
-                              k_fulls[k_bufIdx], two_ctas=tl.constexpr(True))
-
-    # load V (two_ctas, split along HEAD_DIM cols)
-    v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-    tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
-    if is_leader:
-        tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-    tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx], [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV],
-                              v_fulls[v_bufIdx], two_ctas=tl.constexpr(True))
-
-    kv_offset_y += BLOCK_N
-    accum_cnt_kv += 1
-
-    for _ in tl.range(lo + BLOCK_N, hi, BLOCK_N):
-        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-        tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
-        if is_leader:
-            tlx.barrier_expect_bytes(k_fulls[k_bufIdx], K_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-        tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx], [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0],
-                                  k_fulls[k_bufIdx], two_ctas=tl.constexpr(True))
-
-        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-        tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
-        if is_leader:
-            tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-        tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx], [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV],
-                                  v_fulls[v_bufIdx], two_ctas=tl.constexpr(True))
-
-        kv_offset_y += BLOCK_N
-        accum_cnt_kv += 1
 
     return accum_cnt_kv
 
@@ -691,142 +597,6 @@ def _fwd_mma_dots_1cta(
     return accum_cnt_kv, accum_cnt_qk
 
 
-@triton.jit
-def _fwd_mma_dots_2cta(
-    tile_count,
-    accum_cnt_kv,
-    accum_cnt_qk,
-    lo,
-    hi,
-    q_tiles,
-    k_tiles,
-    v_tiles,
-    qk_tiles,
-    p_tiles,
-    acc_tiles,
-    q_empties,
-    q_fulls,
-    k_fulls,
-    k_empties,
-    v_fulls,
-    v_empties,
-    qk_fulls,
-    qk_empties,
-    p_fulls,
-    acc_fulls,
-    acc_empties,
-    alpha_fulls,
-    BLOCK_N: tl.constexpr,
-    HEAD_DIM: tl.constexpr,
-    NUM_CTAS: tl.constexpr,
-    NUM_BUFFERS_Q: tl.constexpr,
-    NUM_BUFFERS_KV: tl.constexpr,
-    NUM_MMA_SLICES: tl.constexpr,
-    NUM_MMA_GROUPS: tl.constexpr,
-):
-    """2-CTA M-split forward MMA with P@V-first pipeline.
-
-    Prolog:  Q@K[0] only (no P@V)
-    Loop:    P@V[i] + Q@K[i+1]  (P@V dispatched first)
-    Epilog:  P@V[last]
-
-    P@V dispatched BEFORE Q@K so TC FIFO guarantees P@V[i] completes
-    before Q@K[i+1]. The correction triggered by Q@K[i+1] is therefore
-    safe to read acc_tiles without an extra pv_done barrier.
-    """
-    HEAD_DIM_KV: tl.constexpr = HEAD_DIM // NUM_CTAS
-
-    q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
-    k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-
-    # --- PROLOG: dispatch Q@K[0] to buf 0, no P@V ---
-    tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
-    tlx.barrier_wait(q_fulls[q_bufIdx], q_phase)
-
-    k_tile = tlx.local_trans(k_tiles[k_bufIdx])
-    tlx.barrier_wait(qk_empties[0], q_phase ^ 1)
-    tlx.async_dot(q_tiles[0], k_tile, qk_tiles[0], use_acc=False, mBarriers=[qk_fulls[0], k_empties[k_bufIdx]],
-                  two_ctas=True)
-
-    # --- INNER LOOP: P@V[i] then Q@K[i+1] (P@V-first) ---
-    pv_started = False
-    v_bufIdx_prev_pv = 0
-
-    for i in tl.range(lo + BLOCK_N, hi, BLOCK_N):
-        qk_buf_prev = accum_cnt_qk & 1
-        qk_phase_prev = (accum_cnt_qk >> 1) & 1
-
-        accum_cnt_qk += 1
-        accum_cnt_kv += 1
-        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-        qk_buf = accum_cnt_qk & 1
-        v_bufIdx_for_pv, v_phase_for_pv = get_bufidx_phase(accum_cnt_kv - 1, NUM_BUFFERS_KV)
-
-        # -- Dispatch P@V FIRST --
-        tlx.barrier_wait(v_fulls[v_bufIdx_for_pv], v_phase_for_pv)
-        tlx.barrier_wait(acc_fulls[qk_buf_prev], qk_phase_prev)
-        last_p_idx = qk_buf_prev * NUM_MMA_SLICES + (NUM_MMA_SLICES - 1)
-        tlx.barrier_wait(p_fulls[last_p_idx], qk_phase_prev)
-        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-            p_idx = qk_buf_prev * NUM_MMA_SLICES + slice_id
-            kv_slice = tlx.local_slice(v_tiles[v_bufIdx_for_pv], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                                       [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
-            if pv_started:
-                if slice_id == NUM_MMA_SLICES - 1:
-                    tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=True,
-                                  mBarriers=[v_empties[v_bufIdx_prev_pv]], two_ctas=True)
-                else:
-                    tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=True, two_ctas=True)
-            else:
-                if slice_id == NUM_MMA_SLICES - 1:
-                    tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=slice_id > 0, two_ctas=True)
-                else:
-                    tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=slice_id > 0, force_async=True,
-                                  two_ctas=True)
-        v_bufIdx_prev_pv = v_bufIdx_for_pv
-        pv_started = True
-
-        # -- Dispatch Q@K SECOND --
-        tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
-        k_tile = tlx.local_trans(k_tiles[k_bufIdx])
-        tlx.async_dot(q_tiles[0], k_tile, qk_tiles[qk_buf], use_acc=False,
-                      mBarriers=[qk_fulls[qk_buf], k_empties[k_bufIdx]], two_ctas=True)
-
-    # --- EPILOG: P@V[last] ---
-    qk_buf_last = accum_cnt_qk & 1
-    qk_phase_last = (accum_cnt_qk >> 1) & 1
-    v_bufIdx_last, v_phase_last = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-
-    tlx.barrier_wait(v_fulls[v_bufIdx_last], v_phase_last)
-    tlx.barrier_wait(acc_fulls[qk_buf_last], qk_phase_last)
-    last_p_idx_ep = qk_buf_last * NUM_MMA_SLICES + (NUM_MMA_SLICES - 1)
-    tlx.barrier_wait(p_fulls[last_p_idx_ep], qk_phase_last)
-    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-        p_idx = qk_buf_last * NUM_MMA_SLICES + slice_id
-        kv_slice = tlx.local_slice(v_tiles[v_bufIdx_last], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                                   [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
-        if pv_started:
-            if slice_id == NUM_MMA_SLICES - 1:
-                tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=True,
-                              mBarriers=[v_empties[v_bufIdx_prev_pv]], two_ctas=True)
-            else:
-                tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=True, two_ctas=True)
-        else:
-            if slice_id == NUM_MMA_SLICES - 1:
-                tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=slice_id > 0, two_ctas=True)
-            else:
-                tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=slice_id > 0, force_async=True,
-                              two_ctas=True)
-
-    tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=True)
-    tlx.tcgen05_commit(acc_empties[0], two_ctas=True)
-    tlx.tcgen05_commit(v_empties[v_bufIdx_last], two_ctas=True)
-
-    accum_cnt_qk += 1
-    accum_cnt_kv += 1
-    return accum_cnt_kv, accum_cnt_qk
-
-
 @triton.autotune(
     configs=configs,
     key=["N_CTX", "HEAD_DIM", "STAGE"],
@@ -882,11 +652,13 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
     is_leader = (not USE_2CTA) or (cluster_cta_rank % 2 == 0)
 
     BLOCK_M_SPLIT: tl.constexpr = BLOCK_M // 2
-    # In 2-CTA M-split, each CTA handles ONE group; in 1-CTA, both groups.
-    NUM_GROUPS_PER_CTA: tl.constexpr = 1 if USE_2CTA else NUM_MMA_GROUPS
+    tl.static_assert(NUM_MMA_GROUPS == 2)
+    NUM_GROUPS_PER_CTA: tl.constexpr = NUM_MMA_GROUPS
     # Per-CTA head-dim of the multicast K/V (B) operands: the collective 2-CTA
     # MMA reassembles the full HEAD_DIM contraction from both CTAs' halves.
     HEAD_DIM_KV: tl.constexpr = HEAD_DIM // NUM_CTAS
+    # Effective M-block: 2-CTA covers BLOCK_M * NUM_CTAS total Q rows per work tile.
+    EFFECTIVE_BLOCK_M: tl.constexpr = BLOCK_M * NUM_CTAS
 
     # Compute bytes per element for each tensor type
     Q_BYTES_PER_ELEM: tl.constexpr = tlx.size_of(tlx.dtype_of(desc_q))
@@ -898,23 +670,20 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
     #   triton.cdiv(q.shape[2], META["BLOCK_M"]),
     #   q.shape[0] * q.shape[1],
     start_pid = tl.program_id(0)
-    num_pid_m = tl.cdiv(N_CTX, BLOCK_M)
+    num_pid_m = tl.cdiv(N_CTX, EFFECTIVE_BLOCK_M)
     num_pid_n = Z * H
     num_pid_in_group = num_pid_m * GROUP_SIZE_N
 
     # allocate SMEM buffers and barriers
     NUM_Q_BUFS: tl.constexpr = NUM_GROUPS_PER_CTA * NUM_BUFFERS_Q
     q_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_Q_BUFS)
+    BLOCK_N_KV: tl.constexpr = BLOCK_N // NUM_CTAS
     if USE_2CTA:
-        # 2-CTA collective-MMA B operands: K split along BLOCK_N rows, V split
-        # along HEAD_DIM cols (each CTA holds half; HW reassembles).
-        k_tiles = tlx.local_alloc((BLOCK_N // NUM_CTAS, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
-        v_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM // NUM_CTAS), tlx.dtype_of(desc_v), NUM_BUFFERS_KV)
-        # o_tiles reuses q_tiles SMEM (sequential lifetime: Q consumed in inner
-        # loop, O produced only in epilogue after inner loop completes).
-        qo_smem_alias = tlx.storage_alias_spec(storage=tlx.storage_kind.smem)
-        o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_GROUPS_PER_CTA,
-                                  reuse=qo_smem_alias)
+        # Separate k_tiles and v_tiles. K loaded as (N/2, D), local_trans to (D, N/2).
+        # V loaded as (N, D/2).
+        k_tiles = tlx.local_alloc((BLOCK_N_KV, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
+        v_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM_KV), tlx.dtype_of(desc_v), NUM_BUFFERS_KV)
+        o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_GROUPS_PER_CTA, reuse=q_tiles)
     else:
         kv_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
         o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_MMA_GROUPS)
@@ -1040,7 +809,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     num_pid_n,
                     num_pid_in_group,
                     N_CTX,
-                    BLOCK_M,
+                    EFFECTIVE_BLOCK_M,
                     STAGE,
                     GROUP_SIZE_N,
                 )
@@ -1094,14 +863,14 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                                     acc = _mul_f32x2(acc, alpha_1)
                                     tlx.local_store(subslice, acc)
                         if USE_2CTA:
-                            tlx.barrier_arrive(acc_fulls[accum_cnt & 1], 1, remote_cta_rank=0)
+                            tlx.barrier_arrive(acc_fulls[cid], 1, remote_cta_rank=0)
                         else:
                             tlx.barrier_arrive(acc_fulls[cid])
                     accum_cnt += 1
 
                 _, phase = get_bufidx_phase(tile_count, 1)
                 for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                    group_id = cluster_cta_rank + cid
+                    group_id = cid * NUM_CTAS + cluster_cta_rank
                     # epilogue
                     tlx.barrier_wait(l_fulls[cid], phase)
                     l_loaded = tlx.local_load(l_tiles[cid])
@@ -1120,7 +889,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         # so we scale here before storing M.
                         m = m * sm_scale * 1.44269504
                     m += tl.math.log2(l)
-                    offs_m = start_m * BLOCK_M + group_id * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+                    offs_m = start_m * EFFECTIVE_BLOCK_M + group_id * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
                     m_ptrs = M + off_hz * N_CTX + offs_m
                     tl.store(m_ptrs, tl.reshape(m, [BLOCK_M_SPLIT]))
 
@@ -1162,7 +931,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     num_pid_n,
                     num_pid_in_group,
                     N_CTX,
-                    BLOCK_M,
+                    EFFECTIVE_BLOCK_M,
                     STAGE,
                     GROUP_SIZE_N,
                 )
@@ -1177,12 +946,12 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                 p_dtype = tlx.dtype_of(desc_v)
 
                 if USE_2CTA:
-                    cid = 0
-                    group_id = cluster_cta_rank
+                    cid = tlx.async_task_replica_id()
+                    group_id = cid * NUM_CTAS + cluster_cta_rank
                 else:
                     cid = tlx.async_task_replica_id()
                     group_id = cid
-                offs_m = (start_m * BLOCK_M) + ((group_id * BLOCK_M_SPLIT) + tl.arange(0, BLOCK_M_SPLIT))
+                offs_m = (start_m * EFFECTIVE_BLOCK_M) + ((group_id * BLOCK_M_SPLIT) + tl.arange(0, BLOCK_M_SPLIT))
                 if STAGE & 1:
                     m_i, l_i, accum_cnt_qk = _softmax_inner_loop(
                         qk_fulls,
@@ -1255,12 +1024,98 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                 if USE_2CTA:
                     if is_leader:
                         _, _, lo2, hi2, _, _ = _compute_offsets(tile_id // NUM_CTAS, H, num_pid_n, num_pid_in_group,
-                                                                N_CTX, BLOCK_M, STAGE, GROUP_SIZE_N)
-                        accum_cnt_kv, accum_cnt_qk = _fwd_mma_dots_2cta(
-                            tile_count, accum_cnt_kv, accum_cnt_qk, lo2, hi2, q_tiles, k_tiles, v_tiles, qk_tiles,
-                            p_tiles, acc_tiles, q_empties, q_fulls, k_fulls, k_empties, v_fulls, v_empties, qk_fulls,
-                            qk_empties, p_fulls, acc_fulls, acc_empties, alpha_fulls, BLOCK_N, HEAD_DIM, NUM_CTAS,
-                            NUM_BUFFERS_Q, NUM_BUFFERS_KV, NUM_MMA_SLICES, NUM_MMA_GROUPS)
+                                                                N_CTX, EFFECTIVE_BLOCK_M, STAGE, GROUP_SIZE_N)
+                        q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
+                        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+
+                        tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
+                        tlx.barrier_wait(q_fulls[q_bufIdx], q_phase)
+
+                        k_tile = tlx.local_trans(k_tiles[k_bufIdx])
+                        tlx.barrier_wait(qk_empties[0], q_phase ^ 1)
+                        tlx.async_dot(q_tiles[0], k_tile, qk_tiles[0], use_acc=False, mBarriers=[qk_fulls[0]],
+                                      two_ctas=True)
+
+                        tlx.barrier_wait(q_fulls[q_bufIdx + NUM_BUFFERS_Q], q_phase)
+                        tlx.barrier_wait(qk_empties[1], q_phase ^ 1)
+                        tlx.async_dot(q_tiles[1], k_tile, qk_tiles[1], use_acc=False,
+                                      mBarriers=[qk_fulls[1], k_empties[k_bufIdx]], two_ctas=True)
+
+                        _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
+
+                        tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
+                        tlx.barrier_wait(acc_fulls[0], qk_phase)
+                        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                            p_bufIdx = slice_id
+                            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+                            kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                                       [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
+                            tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[0], use_acc=slice_id > 0,
+                                          force_async=True, two_ctas=True)
+
+                        acc1_init = False
+
+                        for i in tl.range(lo2 + BLOCK_N, hi2, BLOCK_N):
+                            v_bufIdx_prev = v_bufIdx
+                            qk_phase_prev = qk_phase
+
+                            accum_cnt_qk += 1
+                            accum_cnt_kv += 1
+                            k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                            v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+
+                            tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
+                            k_tile = tlx.local_trans(k_tiles[k_bufIdx])
+                            _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
+
+                            tlx.async_dot(q_tiles[0], k_tile, qk_tiles[0], use_acc=False, mBarriers=[qk_fulls[0]],
+                                          two_ctas=True)
+
+                            tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
+                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                                p_bufIdx = slice_id + NUM_MMA_SLICES
+                                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase_prev)
+                                kv_slice = tlx.local_slice(v_tiles[v_bufIdx_prev],
+                                                           [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                                           [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
+                                use_acc = acc1_init if slice_id == 0 else True
+                                mBarriers = [v_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
+                                tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[1], use_acc=use_acc,
+                                              mBarriers=mBarriers, two_ctas=True)
+
+                            acc1_init = True
+
+                            tlx.async_dot(q_tiles[1], k_tile, qk_tiles[1], use_acc=False,
+                                          mBarriers=[qk_fulls[1], k_empties[k_bufIdx]], two_ctas=True)
+
+                            tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
+                            tlx.barrier_wait(acc_fulls[0], qk_phase)
+                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                                p_bufIdx = slice_id
+                                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+                                kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                                           [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
+                                tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[0], use_acc=True, force_async=True,
+                                              two_ctas=True)
+
+                        tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=True)
+                        tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q], two_ctas=True)
+                        tlx.tcgen05_commit(acc_empties[0], two_ctas=True)
+
+                        tlx.barrier_wait(acc_fulls[1], qk_phase)
+                        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                            p_bufIdx = slice_id + NUM_MMA_SLICES
+                            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+                            kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                                       [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
+                            use_acc = acc1_init if slice_id == 0 else True
+                            mBarriers = [acc_empties[1], v_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
+                            tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[1], use_acc=use_acc,
+                                          mBarriers=mBarriers, two_ctas=True)
+
+                        accum_cnt_qk += 1
+                        accum_cnt_kv += 1
                 else:
                     _, _, lo, hi, _, _ = _compute_offsets(tile_id, H, num_pid_n, num_pid_in_group, N_CTX, BLOCK_M,
                                                           STAGE, GROUP_SIZE_N)
@@ -1282,13 +1137,74 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
             clc_phase_consumer = 0
             while tile_id != -1:
                 if USE_2CTA:
-                    _, _, lo2, hi2, qo2, kv2 = _compute_offsets(tile_id // NUM_CTAS, H, num_pid_n, num_pid_in_group,
-                                                                N_CTX, BLOCK_M, STAGE, GROUP_SIZE_N)
-                    accum_cnt_kv = _fwd_load_2cta(tile_count, accum_cnt_kv, lo2, hi2, qo2, kv2, desc_q, desc_k, desc_v,
-                                                  q_tiles, k_tiles, v_tiles, q_fulls, q_empties, k_fulls, k_empties,
-                                                  v_fulls, v_empties, cluster_cta_rank, is_leader, Q_BYTES_PER_ELEM,
-                                                  K_BYTES_PER_ELEM, V_BYTES_PER_ELEM, BLOCK_M_SPLIT, BLOCK_N, HEAD_DIM,
-                                                  NUM_CTAS, NUM_BUFFERS_Q, NUM_BUFFERS_KV)
+                    _, off_hz2, lo2, hi2, qo2, kv2 = _compute_offsets(tile_id // NUM_CTAS, H, num_pid_n,
+                                                                      num_pid_in_group, N_CTX, EFFECTIVE_BLOCK_M, STAGE,
+                                                                      GROUP_SIZE_N)
+
+                    q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
+                    # Q and O share SMEM (o_tiles reuses q_tiles). Wait for the
+                    # epilog to finish storing the previous tile's O before
+                    # overwriting the buffer with new Q data.
+                    _, o_phase = get_bufidx_phase(tile_count, 1)
+                    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+                        tlx.barrier_wait(o_empties[cid], o_phase ^ 1)
+                    # load Q0
+                    tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
+                    if is_leader:
+                        tlx.barrier_expect_bytes(q_fulls[q_bufIdx],
+                                                 Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
+                    tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx], [qo2 + cluster_cta_rank * BLOCK_M_SPLIT, 0],
+                                              q_fulls[q_bufIdx], two_ctas=tl.constexpr(True))
+                    # load Q1
+                    q_bufIdx1 = q_bufIdx + NUM_BUFFERS_Q
+                    tlx.barrier_wait(q_empties[q_bufIdx1], q_phase ^ 1)
+                    if is_leader:
+                        tlx.barrier_expect_bytes(q_fulls[q_bufIdx1],
+                                                 Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
+                    tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx1],
+                                              [qo2 + (NUM_CTAS + cluster_cta_rank) * BLOCK_M_SPLIT, 0],
+                                              q_fulls[q_bufIdx1], two_ctas=tl.constexpr(True))
+
+                    kv_offset_y = kv2
+
+                    k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                    tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
+                    if is_leader:
+                        tlx.barrier_expect_bytes(k_fulls[k_bufIdx], K_BYTES_PER_ELEM * BLOCK_N_KV * HEAD_DIM * NUM_CTAS)
+                    tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx],
+                                              [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0], k_fulls[k_bufIdx],
+                                              two_ctas=tl.constexpr(True))
+
+                    v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                    tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
+                    if is_leader:
+                        tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+                    tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx], [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV],
+                                              v_fulls[v_bufIdx], two_ctas=tl.constexpr(True))
+
+                    kv_offset_y += BLOCK_N
+                    accum_cnt_kv += 1
+
+                    for _ in tl.range(lo2 + BLOCK_N, hi2, BLOCK_N):
+                        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                        tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
+                        if is_leader:
+                            tlx.barrier_expect_bytes(k_fulls[k_bufIdx],
+                                                     K_BYTES_PER_ELEM * BLOCK_N_KV * HEAD_DIM * NUM_CTAS)
+                        tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx],
+                                                  [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0], k_fulls[k_bufIdx],
+                                                  two_ctas=tl.constexpr(True))
+
+                        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                        tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
+                        if is_leader:
+                            tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+                        tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx],
+                                                  [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV], v_fulls[v_bufIdx],
+                                                  two_ctas=tl.constexpr(True))
+
+                        kv_offset_y += BLOCK_N
+                        accum_cnt_kv += 1
                 else:
                     _, _, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(tile_id, H, num_pid_n, num_pid_in_group,
                                                                               N_CTX, BLOCK_M, STAGE, GROUP_SIZE_N)
@@ -1315,13 +1231,13 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     num_pid_n,
                     num_pid_in_group,
                     N_CTX,
-                    BLOCK_M,
+                    EFFECTIVE_BLOCK_M,
                     STAGE,
                     GROUP_SIZE_N,
                 )
                 _, phase = get_bufidx_phase(tile_count, 1)
                 for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                    group_id = cluster_cta_rank + cid
+                    group_id = cid * NUM_CTAS + cluster_cta_rank
                     tlx.barrier_wait(o_fulls[cid], phase)
                     qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
                     tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
@@ -3416,8 +3332,7 @@ class _attention(torch.autograd.Function):
 
         def grid(META):
             num_ctas = META.get("NUM_CTAS") or 1
-            block_m_per_cta = META["BLOCK_M"] // num_ctas
-            n_ctas = triton.cdiv(q.shape[2], block_m_per_cta) * q.shape[0] * q.shape[1]
+            n_ctas = triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1]
             n_ctas = triton.cdiv(n_ctas, num_ctas) * num_ctas
             return (n_ctas, )
 
@@ -3599,11 +3514,8 @@ def attention(q, k, v, sm_scale, causal, config=None):
     triton.set_allocator(alloc_fn)
 
     num_ctas = config.get("NUM_CTAS", 1)
-    # Grid = total CTAs, derived from per-CTA block size (BWD convention).
-    # BLOCK_M is per-cluster; per-CTA block = BLOCK_M // num_ctas.
-    block_m_per_cta = config["BLOCK_M"] // num_ctas
-    grid0 = triton.cdiv(q.shape[2], block_m_per_cta) * q.shape[0] * q.shape[1]
-    grid0 = triton.cdiv(grid0, num_ctas) * num_ctas  # pad for cluster alignment
+    grid0 = triton.cdiv(q.shape[2], config["BLOCK_M"]) * q.shape[0] * q.shape[1]
+    grid0 = triton.cdiv(grid0, num_ctas) * num_ctas
     grid = (grid0, 1, 1)
     launch_kwargs = {}
     if num_ctas > 1:

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -319,7 +319,7 @@ class FlashAttention:
             "BLOCK_M": 256,
             "BLOCK_N": 128,
             "NUM_BUFFERS_Q": 1,
-            "NUM_BUFFERS_KV": 3,
+            "NUM_BUFFERS_KV": 5,
             "NUM_BUFFERS_QK": 1,
             "NUM_MMA_GROUPS": 2,
             "NUM_MMA_SLICES": 2,


### PR DESCRIPTION
Summary:
Enable NUM_MMA_GROUPS=2 for the 2-CTA forward Flash Attention kernel
and unify the BLOCK_M convention to always mean per-CTA rows (matching
BWD/GEMM). This is the key optimization that makes 2-CTA competitive
with CuteDSL FAv4.

== Problem: NUM_MMA_GROUPS=1 arithmetic intensity ==

With NUM_MMA_GROUPS=1, each CTA processes 1 Q group (128 rows). Each KV
load drives only 2 MMA ops (Q@K^T + P@V), while the 1-CTA kernel
drives 4 (two Q groups sharing each KV tile). The Tensor Core is idle
~50% of the time waiting for new KV data.

== Solution: NUM_MMA_GROUPS=2 doubles Q groups per CTA ==

Each CTA now loads 2 Q tiles (Q0 and Q1, 128 rows each, 256 total per
CTA, 512 rows per work tile across 2 CTAs). Each KV load drives 4 MMA
ops in FA4-style interleaving:

  1. Q0 @ K^T[i]   → qk_tiles[0]  (notify softmax0)
  2. P1 @ V[i-1]   → acc_tiles[1]  (PREVIOUS V, cross-iteration reuse)
  3. Q1 @ K^T[i]   → qk_tiles[1]  (notify softmax1, release K[i])
  4. P0 @ V[i]     → acc_tiles[0]  (CURRENT V)

Key properties:
  - K is reused across Q0 and Q1 (loaded once, used twice)
  - V is reused across iterations (V[i] used by P0 in iter i, P1 in i+1)
  - Q0/Q1 write to different accumulators, so no race condition
  - NUM_BUFFERS_KV >= 5 required (vs 3 for single-group) due to V lifetime

== Unified BLOCK_M convention ==

Aligns 2-CTA BLOCK_M with BWD/GEMM: BLOCK_M always means what a single
CTA processes, not the total for the cluster.

  Before: BLOCK_M=256 → 128 rows/CTA (NUM_MMA_GROUPS=1)
  After:  BLOCK_M=256 → always 256 rows/CTA, 512 total for the cluster

This removes the NUM_MMA_GROUPS=1 path entirely:
  - NUM_GROUPS_PER_CTA = NUM_MMA_GROUPS (always 2)
  - EFFECTIVE_BLOCK_M = BLOCK_M × NUM_CTAS (unified formula)
  - Deleted _fwd_mma_dots_2cta and _fwd_load_2cta (single-group functions)
  - Removed single-group conditionals from softmax, correction, MMA, load
  - Grid uses EFFECTIVE_BLOCK_M for tile count

== Q/O SMEM reuse fix for CLC persistent ==

o_tiles reuses q_tiles SMEM (sequential lifetime). When CLC reuses a
cluster for a second tile, the Load task could overwrite q_tiles with
new Q data before the Epilog stored the previous tile's O to global
memory. Fixed by adding o_empties barrier waits in the Load task before
Q loads — ensures the Epilog has finished the TMA store before the
shared buffer is overwritten.

== Key code changes ==

  - Softmax uses replicate=NUM_GROUPS_PER_CTA (2 replicas)
  - Inline MMA loop with FA4 interleaving (not using old 2CTA helpers)
  - group_id = cid × NUM_CTAS + cluster_cta_rank (4 groups: 0,1,2,3)
  - Load task waits o_empties before Q loads (Q/O SMEM reuse protection)
  - ~250 lines removed vs single-group codebase

== Performance ==

see D114619646

Differential Revision: D114187554


