### PR TITLE
[triton][bitequiv] Eval: add gemm_splitk discrimination kernel (split-K, num_splits axis)

### DIFF
--- a/bitequiv/evaluation/eval_kernels.py
+++ b/bitequiv/evaluation/eval_kernels.py
@@ -89,7 +89,7 @@ _DOT_LOGSPACE = (0, 6)
 # are None (e.g. welford has no reduction_ordering; single-tile kernels have no
 # block_n). Full names, no abbreviations.
 _AXIS_ORDER = ("reduction_ordering", "num_warps", "num_stages", "enable_fp_fusion", "block_n", "gemm_block_m",
-               "gemm_block_n", "gemm_block_k", "input_precision", "max_num_imprecise_acc")
+               "gemm_block_n", "gemm_block_k", "input_precision", "max_num_imprecise_acc", "gemm_num_splits")
 Config = namedtuple("Config", _AXIS_ORDER)
 
 # Per-effort value lists. "light" (~10 configs) is the quick smoke / CI grid;
@@ -109,6 +109,7 @@ _AXIS_VALUES = {
         "gemm_block_k": (32, ),
         "input_precision": ("tf32", "ieee", "tf32x3"),
         "max_num_imprecise_acc": (32, 128),
+        "gemm_num_splits": (1, 2, 4),  # split-K: K split into this many partials then combined (bit-relevant)
     },
     "heavy": {
         "reduction_ordering": ("unordered", "inner_tree"),
@@ -121,6 +122,7 @@ _AXIS_VALUES = {
         "gemm_block_k": (16, 32, 64),
         "input_precision": ("tf32", "ieee", "tf32x3"),
         "max_num_imprecise_acc": (32, 64, 128),
+        "gemm_num_splits": (1, 2, 4, 8),  # split-K: K split into this many partials then combined
     },
 }
 
@@ -153,7 +155,8 @@ def config_label(config):
         parts.append(f"enable_fp_fusion={'on' if config.enable_fp_fusion else 'off'}")
     if config.block_n is not None:
         parts.append(f"block_n={config.block_n}")
-    for axis in ("gemm_block_m", "gemm_block_n", "gemm_block_k", "input_precision", "max_num_imprecise_acc"):
+    for axis in ("gemm_block_m", "gemm_block_n", "gemm_block_k", "input_precision", "max_num_imprecise_acc",
+                 "gemm_num_splits"):
         value = getattr(config, axis)
         if value is not None:
             parts.append(f"{axis}={value}")
@@ -656,6 +659,38 @@ def gemm_tma_store_kernel(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak, st
     c_desc.store([pid_m * BLOCK_M, pid_n * BLOCK_N], acc.to(OUT_DTYPE))
 
 
+@triton.jit
+def gemm_splitk_kernel(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
+                       BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, OUT_DTYPE: tl.constexpr,
+                       NUM_SPLITS: tl.constexpr):
+    """Split-K GEMM: the K contraction is cut into NUM_SPLITS contiguous slices, each summed into its
+    OWN partial accumulator, and the partials are then combined into the output. Unlike BLOCK_K (which
+    only re-chunks the SAME sequential K order and is therefore bit-free), NUM_SPLITS changes the
+    GROUPING of the K sum -- ((s0)+(s1))+... instead of a single left-fold -- so with order-sensitive
+    operands it DOES change the result bits. This is the one tiling-like GEMM knob that is genuinely
+    bit-relevant, so it exercises the checker's must-not-over-merge on GEMM (soundness), not just
+    recovery. Fused into a single kernel so it emits one st.global root the PTX checker can read."""
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    split_k = K // NUM_SPLITS
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for s in range(NUM_SPLITS):
+        partial = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        k0 = s * split_k
+        a_ptrs = a_ptr + offs_m[:, None] * stride_am + (k0 + offs_k)[None, :] * stride_ak
+        b_ptrs = b_ptr + (k0 + offs_k)[:, None] * stride_bk + offs_n[None, :] * stride_bn
+        for _k in range(0, split_k, BLOCK_K):
+            partial = tl.dot(tl.load(a_ptrs), tl.load(b_ptrs), partial, out_dtype=tl.float32)
+            a_ptrs += BLOCK_K * stride_ak
+            b_ptrs += BLOCK_K * stride_bk
+        acc += partial  # combine this split's partial (the NUM_SPLITS-dependent grouping)
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, acc.to(OUT_DTYPE))
+
+
 # --------------------------------------------------------------------------- #
 # GEMM compile / run
 # --------------------------------------------------------------------------- #
@@ -804,6 +839,28 @@ def _gemm_tma_store_run(config, ck, seed, size):
     bm, bn, _bk = _gemm_blocks(config, 32)
     a, b = _gemm_operands(M, N, K, seed, torch.float16)
     c = torch.empty((M, N), device=DEVICE, dtype=torch.float16)
+    ck[(M // bm, N // bn, 1)](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0),
+                              c.stride(1))
+    torch.cuda.synchronize()
+    return _to_bytes(c)
+
+
+def _gemm_splitk_compile(config, size, maxnreg=None):
+    M, N, K = size
+    bm, bn, bk = _gemm_blocks(config, 32)
+    splits = config.gemm_num_splits if config.gemm_num_splits is not None else 1
+    a, b = _gemm_operands(M, N, K, 0, torch.bfloat16)
+    c = torch.empty((M, N), device=DEVICE, dtype=torch.float32)
+    return gemm_splitk_kernel.warmup(a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0),
+                                     c.stride(1), grid=(M // bm, N // bn), BLOCK_M=bm, BLOCK_N=bn, BLOCK_K=bk,
+                                     OUT_DTYPE=tl.float32, NUM_SPLITS=splits, maxnreg=maxnreg, **_gemm_launch_kwargs(config))
+
+
+def _gemm_splitk_run(config, ck, seed, size):
+    M, N, K = size
+    bm, bn, _bk = _gemm_blocks(config, 32)
+    a, b = _gemm_operands(M, N, K, seed, torch.bfloat16)
+    c = torch.empty((M, N), device=DEVICE, dtype=torch.float32)
     ck[(M // bm, N // bn, 1)](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0),
                               c.stride(1))
     torch.cuda.synchronize()
@@ -1014,6 +1071,23 @@ REGISTRY = {
         compile_fn=_gemm_tma_store_compile,
         run_fn=_gemm_tma_store_run,
         config_filter=_gemm_num_warps_filter,
+    ),
+    "gemm_splitk":
+    KernelSpec(
+        name="gemm_splitk",
+        description=("bf16 split-K GEMM; gemm_num_splits regroups the K sum into that many partials then combines "
+                     "them -> a genuinely BIT-RELEVANT tiling-like knob (a distinct class per split value), unlike "
+                     "the bit-free block_k. Order-sensitive operands (wide range + alternating sign along K). This is "
+                     "the GEMM kernel that stresses the checker's must-not-over-merge on tiling (soundness)."),
+        output_arity=1,
+        axes=("num_warps", "gemm_block_m", "gemm_block_n", "gemm_num_splits"),
+        precision_size=(256, 256, 2048),
+        perf_size=(256, 256, 2048),
+        known_limitation="",
+        compile_fn=_gemm_splitk_compile,
+        run_fn=_gemm_splitk_run,
+        config_filter=_gemm_num_warps_filter,
+        axis_values={"gemm_num_splits": (1, 2, 4, 8)},  # sweep the splitting knob at every effort
     ),
     "gemm_all":
     KernelSpec(

--- a/bitequiv/evaluation/eval_kernels.py
+++ b/bitequiv/evaluation/eval_kernels.py
@@ -665,6 +665,24 @@ def _gemm_num_warps_filter(config):
     return config.num_warps in (4, 8)
 
 
+def _gemm_all_filter(config):
+    """num_warps filter PLUS a Blackwell TMEM (512-column) guard for the combined gemm_all
+    cross-product: the accumulator (block_m x block_n) plus the K-pipeline (block_k x num_stages)
+    can overflow tensor memory, and unlike a compile error a run/launch OOM is NOT caught by
+    evaluate_precision. The dropped boundary (block_k=64 with num_stages>=3; the 256-wide accumulator
+    with num_stages>=5) is calibrated for this spec's default precision_size (256^3), where it leaves
+    0 launch-OOM. NOTE: TMEM use is TENSOR-dependent -- a large K runs the full num_stages pipeline
+    (short K-loops collapse it), so at a much bigger tensor some surviving configs still OOM; a driver
+    that overrides the tensor size must skip run-OOM configs itself (this filter cannot see the size)."""
+    if not _gemm_num_warps_filter(config):
+        return False
+    if config.gemm_block_k == 64 and (config.num_stages or 1) >= 3:
+        return False
+    if config.gemm_block_n == 256 and (config.num_stages or 1) >= 5:
+        return False
+    return True
+
+
 def _gemm_blocks(config, default_bk):
     """Resolve the tile from the config, defaulting axes the spec does not sweep."""
     bm = config.gemm_block_m if config.gemm_block_m is not None else 128
@@ -996,6 +1014,25 @@ REGISTRY = {
         compile_fn=_gemm_tma_store_compile,
         run_fn=_gemm_tma_store_run,
         config_filter=_gemm_num_warps_filter,
+    ),
+    "gemm_all":
+    KernelSpec(
+        name="gemm_all",
+        description=("f32 GEMM varying ALL co-existing knobs together (M/N/K tiling x input_precision x "
+                     "enable_fp_fusion x num_warps x num_stages) -- the real autotuner cross-product, to "
+                     "stress the MMA fence with cross-knob interactions. The per-knob GEMM specs above "
+                     "isolate one knob each for clean attribution; this crosses them (~1300 configs at heavy). "
+                     "fp8 stays a separate spec (a distinct dtype path that cannot co-vary with input_precision)."),
+        output_arity=1,
+        axes=("enable_fp_fusion", "num_warps", "num_stages", "gemm_block_m", "gemm_block_n", "gemm_block_k",
+              "input_precision"),
+        precision_size=(256, 256, 256),
+        perf_size=(256, 256, 256),
+        known_limitation="",
+        compile_fn=_gemm_prec_compile,
+        run_fn=_gemm_prec_run,
+        config_filter=_gemm_all_filter,
+        axis_values={"gemm_block_k": (16, 32, 64), "enable_fp_fusion": (True, False)},
     ),
 }
 

--- a/bitequiv/ptx/builder.py
+++ b/bitequiv/ptx/builder.py
@@ -395,6 +395,39 @@ def _collapse_info(node):
     return (op, _coordfree_sig(leaves[0]))
 
 
+def output_coordfree_key(node):
+    """Coord-free dedup key for one output of a MULTI-output entry (a COLLAPSED tree), or None if the
+    tree is not safe to coord-blank.
+
+    A multi-output entry (softmax / layernorm / rmsnorm: one output per row, many rows per block) is
+    kept VERBATIM by the descriptor today, so num_warps (which redistributes rows across threads)
+    never merges. But when EVERY output is a clean per-element function of its own element over
+    num_warps-invariant reductions — ``out[i] = f(x_i, ITreeReduce(row_i))`` — blanking the leaf coord
+    makes all outputs share ONE key, and deduping that key across the entry gives a num_warps-invariant
+    descriptor (the per-thread output COUNT varies with num_warps, but the SET of distinct output
+    computations does not). An unordered per-row reduction keeps its ShflCombine offsets in the
+    coord-free string (num_warps-bearing) so it still splits — inner_tree recovers, unordered does not.
+
+    SAFE only when the output's VALUE structure is fully modeled: no lost-provenance ``OpaqueLeaf``
+    (except a CONSTANT immediate, which is num_warps-invariant), and every ``OpaqueOp`` is a pure
+    per-element op (cvt / exp / mov / ...). A Leaf's COORD may be opaque (a swizzle / multi-dim address
+    the affine pass could not pin) — that is only ADDRESSING (which element), and blanking it is the
+    whole point; faithful reconstruction already guarantees the value DEPENDENCY is captured, so what
+    remains is an elementwise map over num_warps-invariant reductions. A tree with an unmodeled value
+    op / lost non-constant leaf returns None and the caller falls back to the verbatim (sound,
+    over-split) descriptor. This blanks more than the guarded reduction collapse (in particular it does
+    not re-prove the elementwise assumption for a swizzled address), so it is gated on the empirical
+    fuzzer (0 over-merge) rather than statically proven."""
+    for n in _postorder(node):
+        if isinstance(n, OpaqueLeaf) and "imm(" not in n.token:
+            return None  # a lost-provenance (non-constant) value -> unsafe to coord-blank
+        if isinstance(n, OpaqueOp) and not _tok_is_pure(n.token):
+            return None  # an unmodeled value op -> unsafe
+        if isinstance(n, Leaf) and n.coord is None:
+            return None  # no coord at all (not even opaque) -> nothing to blank soundly
+    return _coordfree_sig(node)
+
+
 def _rebuild(n, kids):
     """Reconstruct node n with already-processed children kids."""
     if isinstance(n, (Leaf, OpaqueLeaf, ITreeReduce)):

--- a/bitequiv/ptx/builder.py
+++ b/bitequiv/ptx/builder.py
@@ -18,7 +18,8 @@ from pyptx.ir.nodes import RegisterOperand, VectorOperand
 from bitequiv.ptx.affine import AffineEval, canon, reqntid_of
 from bitequiv.ptx.leaves import leaf_coord, leaf_columns
 from bitequiv.ptx.linker import Def, DefUse
-from bitequiv.ptx.treeir import FpOp, ITreeReduce, Leaf, OpaqueLeaf, OpaqueOp, ShflCombine, SmemExchange
+from bitequiv.ptx.treeir import (FpOp, ITreeReduce, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp,
+                                 ShflCombine, SmemExchange)
 
 _FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f64", ".bf16", ".bf16x2"})
 _FP_KINDS = frozenset({"add", "sub", "mul", "div", "min", "max"})
@@ -320,8 +321,8 @@ def _leaf_layout_invariant(node):
     and a single product mul(L,L) / fma(L,L;const) while refusing anything whose value could
     depend on the thread/lane layout."""
     for n in _postorder(node):
-        if isinstance(n, (ShflCombine, SmemExchange)):
-            return False
+        if isinstance(n, (ShflCombine, SmemExchange, Mma, LoopReduce)):
+            return False  # cross-thread / opaque-chunk / loop-fold node: not a per-element leaf
         if isinstance(n, OpaqueLeaf):
             return False
         if isinstance(n, OpaqueOp) and not _tok_is_pure(n.token):
@@ -406,6 +407,10 @@ def _rebuild(n, kids):
         return ShflCombine(n.offset, n.kind, n.mods, kids[0])
     if isinstance(n, SmemExchange):
         return SmemExchange(kids[0])
+    if isinstance(n, Mma):
+        return Mma(n.token, n.flags, tuple(kids))
+    if isinstance(n, LoopReduce):
+        return LoopReduce(n.op, kids[0], n.key)
     return n
 
 

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -22,10 +22,12 @@ the conservative fingerprint. Integer/address ops do not touch the value state (
 the affine domain, resolved on demand for leaf coordinates).
 """
 
+import hashlib
+
 from pyptx.ir.nodes import RegisterOperand, VectorOperand
 
 from bitequiv.ptx.affine import AffineEval, canon, reqntid_of
-from bitequiv.ptx.builder import collapse_balanced, tree_hash
+from bitequiv.ptx.builder import collapse_balanced, output_coordfree_key, tree_hash
 from bitequiv.ptx.forward.cfg import has_unknown_control
 from bitequiv.ptx.forward.loops import (find_loops, loop_accumulates, loop_carried_accumulators,
                                         loop_self_increments)
@@ -428,14 +430,20 @@ def forward_descriptor(func):
     roots = interp.run()
     if not interp.faithful:
         return (interp.fingerprint(), )
-    # G3 guard (mirrors the backward `entry_signatures`): the layout-drop collapse is num_warps-
-    # INVARIANT only when ALL of the entry's threads reduce into ONE output. With MULTIPLE outputs
-    # (a 2-D / multi-axis tile reduced per row), num_warps RE-PARTITIONS the threads among the outputs
-    # and re-associates each output's reduction, so collapsing there OVER-MERGES — measured: sum_4d /
-    # softmax / rmsnorm inner_tree vs unordered collapsed to the same descriptor at the heavy grid.
-    # So collapse only a single-output entry; keep a multi-output entry's trees VERBATIM (sound,
-    # over-split — num_warps recovery for multi-output is later, layout-aware work).
-    collapsed = [collapse_balanced(roots[0])] if len(roots) == 1 else roots
+    if len(roots) == 1:
+        return (tree_hash(collapse_balanced(roots[0])), )
+    # MULTI-output: num_warps redistributes the entry's rows across threads, so the forward per-thread
+    # trees (and their COUNT) are num_warps-bearing -> a verbatim descriptor over-splits. When every
+    # output is a CLEAN per-element function of its own element over num_warps-invariant reductions
+    # (softmax / layernorm / rmsnorm), coord-blank each output + dedup: the SET of distinct output
+    # computations is num_warps-invariant even though the per-thread count is not. An unordered per-row
+    # reduction keeps its ShflCombine offsets in the key -> stays split (correct). If ANY output is not
+    # cleanly reconstructed (opaque leaf / unrecovered coord), fall back to the verbatim trees (sound,
+    # over-split). Replaces the old blanket multi-output G3 guard; gated on the fuzzer (0 over-merge).
+    collapsed = [collapse_balanced(r) for r in roots]
+    keys = [output_coordfree_key(t) for t in collapsed]
+    if all(k is not None for k in keys):
+        return tuple(sorted({hashlib.sha1(k.encode()).hexdigest()[:16] for k in keys}))
     return tuple(sorted(tree_hash(t) for t in collapsed))
 
 

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -12,11 +12,14 @@ Modeled so far: ``ld.global`` (scalar + vector slots) -> leaves; the fp combines
 ``ShflCombine`` for any reduce op; ``mov`` pass-through; the cross-warp shared exchange
 (``st.shared`` -> ``ld.shared`` -> ``SmemExchange``, the forward SmemModel); and packed ``.f32x2``
 reductions (``mov.b64`` pack/unpack + ``.f32x2`` combine/fma decomposed per lane). ``st.global``
-values are the roots (a packed store expands to one root per f32 lane). MMA, data-dependent branches,
-and loop back-edges are later phases; anything unmodeled becomes an ``Opaque`` and, if it would strip
-a transient marker (losing a reduction ordering / packed structure), trips ``faithful=False`` — the
-sound floor that falls back to the conservative fingerprint. Integer/address ops do not touch the
-value state (their values live in the affine domain, resolved on demand for leaf coordinates).
+values are the roots (a packed store expands to one root per f32 lane). A loop-carried
+``acc = acc + chunk`` (a chunked / persistent reduction) is summarized as a ``LoopReduce`` fold over
+one iteration's chunk (via :mod:`bitequiv.ptx.forward.loops`), recovering num_warps for looped
+reductions. MMA-accumulation loops (GEMM K-fold) and data-dependent branches are later phases;
+anything unmodeled becomes an ``Opaque`` and, if it would strip a transient marker (losing a
+reduction ordering / packed structure), trips ``faithful=False`` — the sound floor that falls back to
+the conservative fingerprint. Integer/address ops do not touch the value state (their values live in
+the affine domain, resolved on demand for leaf coordinates).
 """
 
 from pyptx.ir.nodes import RegisterOperand, VectorOperand
@@ -24,11 +27,14 @@ from pyptx.ir.nodes import RegisterOperand, VectorOperand
 from bitequiv.ptx.affine import AffineEval, canon, reqntid_of
 from bitequiv.ptx.builder import collapse_balanced, tree_hash
 from bitequiv.ptx.forward.cfg import has_unknown_control
+from bitequiv.ptx.forward.loops import (find_loops, loop_accumulates, loop_carried_accumulators,
+                                        loop_self_increments)
 from bitequiv.ptx.forward.predicate import PredicateDecoder
 from bitequiv.ptx.leaves import leaf_coord, leaf_columns
 from bitequiv.ptx.linker import DefUse, _def_regs, linearize
 from bitequiv.ptx.mma import _mma_fence
-from bitequiv.ptx.treeir import FpOp, Leaf, OpaqueLeaf, OpaqueOp, ShflCombine, SmemExchange
+from bitequiv.ptx.treeir import (FpOp, Leaf, LoopReduce, OpaqueLeaf, OpaqueOp, ShflCombine,
+                                 SmemExchange)
 
 _FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f64", ".bf16", ".bf16x2"})
 _FP_KINDS = frozenset({"add", "sub", "mul", "div", "min", "max"})
@@ -110,6 +116,19 @@ class ForwardInterp:
         self._unknown_ctrl = has_unknown_control(func)
         self.pred = PredicateDecoder(self.ev, self.du)
         self._ddb = None  # cached _has_data_dependent_branch() result
+        # Phase 5 (loops): a loop-carried `acc = acc + chunk` is summarized as a LoopReduce fold
+        # instead of the one-iteration DAG the straight-line walk would leave. Map the accumulating
+        # instruction -> (acc register, LoopReduce key = the loop's chunk step). Only ACCUMULATING
+        # loops (a running fp total), so an output-tiling loop is untouched. `linearize` and
+        # `find_loops` walk `func.body` identically, so the accumulating `inst` objects are shared.
+        self._acc = {}
+        insts, loops = find_loops(func)
+        for lp in set(loops):
+            if not loop_accumulates(insts, lp, loops):
+                continue
+            key = (loop_self_increments(insts, lp, loops), )
+            for acc_name, inst in loop_carried_accumulators(insts, lp, loops):
+                self._acc[id(inst)] = (acc_name, key)
 
     # -- operand lookup -------------------------------------------------------
 
@@ -220,6 +239,9 @@ class ForwardInterp:
         if op == "fma" and _is_fp(inst) and len(inst.operands) == 4:
             return FpOp("fma", mods, tuple(self._node(o, at) for o in inst.operands[1:]), fused=True)
         if op in _FP_KINDS and _is_fp(inst) and len(inst.operands) == 3:
+            acc = self._acc.get(id(inst))
+            if acc is not None and op == "add":
+                return self._loop_reduce(inst, acc, at)  # loop-carried add-accumulation -> fold summary
             return self._combine(inst, at)
         # Any other unmodeled op (an f64 half-assembly `or.b64`, a `cvt`, ...): keep it as an
         # OpaqueOp NODE with its register operands as children + non-register operands in the token,
@@ -249,6 +271,22 @@ class ForwardInterp:
         if others:
             tok += "{" + ",".join(canon(self.ev.of_operand(o, at)) for o in others) + "}"
         return OpaqueOp(tok, tuple(self._node(o, at) for o in reg_ops))
+
+    def _loop_reduce(self, inst, acc, at):
+        """A loop-carried ``acc = acc + chunk`` -> ``LoopReduce(add, chunk, key)``, summarizing the
+        whole fold instead of leaving the one-iteration ``add(seed, chunk)`` the straight-line walk
+        produces. The pre-loop SEED is dropped: when autotuning a single kernel every config shares
+        it, so it can never separate two configs (the module docstring's identical-outside-the-
+        computation assumption). This RECOVERS num_warps for a chunked / persistent reduction — the
+        chunk's within-block reduction collapses to a num_warps-invariant ITreeReduce and the key
+        (chunk step) is num_warps-invariant, so configs differing only in num_warps get one LoopReduce.
+        The key is chunk-BEARING (the step multiset), so a different BLOCK_N still splits (sound)."""
+        acc_name, key = acc
+        chunk = next((o for o in inst.operands[1:]
+                      if not (isinstance(o, RegisterOperand) and o.name == acc_name)), None)
+        if chunk is None:  # `acc = acc + acc` (not a chunk fold) -> fall back to a plain combine
+            return self._combine(inst, at)
+        return LoopReduce(inst.opcode + "".join(inst.modifiers), self._node(chunk, at), key)
 
     def _combine(self, inst, at):
         """Scalar fp binary combine — see :meth:`_combine_nodes`."""

--- a/bitequiv/ptx/forward/loops.py
+++ b/bitequiv/ptx/forward/loops.py
@@ -1,0 +1,116 @@
+"""Loop-structure recovery, shared by the backward ``_loop_steps`` fence and the forward
+``LoopReduce`` reconstruction.
+
+``linearize`` drops labels, so we re-walk ``func.body`` to recover label positions, then a backward
+branch (``bra`` to a label at/before it) is a loop back-edge. On top of that we classify a loop as
+carrying a floating-point ACCUMULATION (a running total across iterations) — the thing that makes its
+chunk size bit-relevant — and expose the loop-carried accumulator register(s) + the accumulating
+instruction, which the forward interpreter uses to emit a ``LoopReduce`` (fold summary) instead of
+unrolling.
+"""
+from pyptx.ir.nodes import Block, Label
+
+from bitequiv.ptx.mma import _is_mma
+
+# fp combine ops + widths, used to detect a loop-carried floating-point accumulation.
+_FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f32x2", ".f64", ".bf16", ".bf16x2"})
+_FP_COMBINE = frozenset({"add", "sub", "mul", "div", "min", "max", "fma"})
+
+
+def instrs_and_labels(func):
+    """Linearized instructions (recursing ``Block`` scopes, like :func:`bitequiv.ptx.linker.linearize`)
+    PLUS a map ``label name -> index of the instruction at/after that label``."""
+    insts, label_at, pending = [], {}, []
+
+    def walk(stmts):
+        for s in stmts:
+            if isinstance(s, Block):
+                walk(s.body)
+            elif isinstance(s, Label):
+                pending.append(s.name)
+            elif type(s).__name__ == "Instruction":
+                while pending:
+                    label_at[pending.pop()] = len(insts)
+                insts.append(s)
+
+    walk(func.body)
+    for name in pending:  # a trailing label points just past the last instruction
+        label_at[name] = len(insts)
+    return insts, label_at
+
+
+def back_edges(insts, label_at):
+    """(header_idx, latch_idx) for each backward branch — a ``bra`` to a label at/before it = a loop."""
+    loops = []
+    for i, inst in enumerate(insts):
+        if inst.opcode == "bra":
+            for o in inst.operands:
+                name = getattr(o, "name", None) or getattr(o, "text", None)
+                j = label_at.get(name)
+                if j is not None and j <= i:
+                    loops.append((j, i))
+    return loops
+
+
+def find_loops(func):
+    """Convenience: ``(insts, loops)`` for ``func`` (loops = list of ``(header, latch)`` back-edges)."""
+    insts, label_at = instrs_and_labels(func)
+    return insts, back_edges(insts, label_at)
+
+
+def innermost_loop(idx, loops):
+    """The smallest loop range ``(header, latch)`` containing ``idx``, or None."""
+    best = None
+    for lp in loops:
+        if lp[0] <= idx <= lp[1] and (best is None or (lp[1] - lp[0]) < (best[1] - best[0])):
+            best = lp
+    return best
+
+
+def own_body(insts, loop, loops):
+    """Indices in ``loop``'s OWN body — its range minus any nested loop's range."""
+    h, latch = loop
+    return [k for k in range(h, latch + 1) if innermost_loop(k, loops) == loop]
+
+
+def _is_fp_combine(inst):
+    return inst.opcode in _FP_COMBINE and inst.modifiers and inst.modifiers[-1] in _FP_WIDTHS
+
+
+def _self_accumulate(inst):
+    """True if ``inst`` is an fp combine whose destination is also one of its sources (dst = dst + x
+    running total). Returns the accumulator register name, or None."""
+    if not (_is_fp_combine(inst) and inst.operands):
+        return None
+    dname = getattr(inst.operands[0], "name", None)
+    if dname and any(getattr(s, "name", None) == dname for s in inst.operands[1:]):
+        return dname
+    return None
+
+
+def loop_accumulates(insts, loop, loops):
+    """True iff the loop's own body carries an FP accumulation: an MMA, or a self-accumulating fp
+    combine. This is what makes the loop's chunk size (BLOCK_K / BLOCK_N) bit-relevant."""
+    for k in own_body(insts, loop, loops):
+        if _is_mma(insts[k]) or _self_accumulate(insts[k]) is not None:
+            return True
+    return False
+
+
+def loop_carried_accumulators(insts, loop, loops):
+    """The loop-carried FP accumulations in ``loop``'s own body, as ``(acc_name, inst)``:
+    a self-accumulating fp combine (``acc = acc + chunk``), or an MMA (accumulator = its dst operand,
+    a register or a TMEM address). The forward interpreter uses these to locate ``acc`` and extract
+    the chunk (the non-acc input) for a ``LoopReduce``."""
+    out = []
+    for k in own_body(insts, loop, loops):
+        inst = insts[k]
+        if _is_mma(inst):
+            name = getattr(inst.operands[0], "name", None) if inst.operands else None
+            if name:
+                out.append((name, inst))
+        else:
+            acc = _self_accumulate(inst)
+            if acc is not None:
+                out.append((acc, inst))
+    return out

--- a/bitequiv/ptx/forward/loops.py
+++ b/bitequiv/ptx/forward/loops.py
@@ -8,7 +8,7 @@ chunk size bit-relevant — and expose the loop-carried accumulator register(s) 
 instruction, which the forward interpreter uses to emit a ``LoopReduce`` (fold summary) instead of
 unrolling.
 """
-from pyptx.ir.nodes import Block, Label
+from pyptx.ir.nodes import Block, ImmediateOperand, Label, RegisterOperand
 
 from bitequiv.ptx.mma import _is_mma
 
@@ -95,6 +95,26 @@ def loop_accumulates(insts, loop, loops):
         if _is_mma(insts[k]) or _self_accumulate(insts[k]) is not None:
             return True
     return False
+
+
+def loop_self_increments(insts, loop, loops):
+    """Sorted immediates of self-increment ``add R, R, IMM`` (dst==src0, IMM != 0) in ``loop``'s own
+    body — the chunk step(s): BLOCK_K for a GEMM K-loop, BLOCK_N for a chunked reduction. Used as the
+    forward ``LoopReduce`` key so different chunk sizes get different keys (split, sound)."""
+    out = []
+    for k in own_body(insts, loop, loops):
+        inst = insts[k]
+        if inst.opcode == "add" and len(inst.operands) == 3:
+            d, a, b = inst.operands
+            if (isinstance(d, RegisterOperand) and isinstance(a, RegisterOperand) and d.name == a.name
+                    and isinstance(b, ImmediateOperand)):
+                try:
+                    v = int(b.text, 0)
+                except (ValueError, TypeError):
+                    continue
+                if v != 0:
+                    out.append(v)
+    return tuple(sorted(out))
 
 
 def loop_carried_accumulators(insts, loop, loops):

--- a/bitequiv/ptx/treeir.py
+++ b/bitequiv/ptx/treeir.py
@@ -187,3 +187,53 @@ class SmemExchange:
 
     def sig(self):
         return self.sig_local([self.child.sig()])
+
+
+@dataclass(frozen=True)
+class Mma:
+    """A tensor-core matmul chunk (wgmma / mma.sync / wmma / tcgen05). Its internal accumulation is
+    hardware-opaque, so it is NOT a reconstructable per-element tree — it is a tiling-invariant fence
+    ``token`` (K + operand/acc dtypes + kind, from :mod:`bitequiv.ptx.mma`) + ``flags`` (scale /
+    accumulate immediates) + its register-operand ``children`` (so a reduction OVER mma outputs
+    composes in the same DAG). NOT a layout-invariant per-element value: a reduction covering an Mma
+    must not collapse it as a uniform leaf (see :func:`bitequiv.ptx.builder._leaf_layout_invariant`)."""
+
+    token: str
+    flags: tuple = ()
+    children: tuple = ()
+
+    def sig_local(self, child_sigs):
+        f = ";fl=" + ",".join(self.flags) if self.flags else ""
+        body = "(" + ",".join(child_sigs) + ")" if child_sigs else ""
+        return f"MMA[{self.token}{f}]{body}"
+
+    def sig(self):
+        return self.sig_local([c.sig() for c in self.children])
+
+
+@dataclass(frozen=True)
+class LoopReduce:
+    """A loop-carried floating-point accumulation (a fold over chunks), summarized WITHOUT unrolling:
+    a GEMM's K-reduction, or a chunked / persistent reduction. ``chunk`` is the value-DAG of ONE
+    iteration's contribution (the accumulator input removed); ``op`` is the fold op (+ modifiers).
+    ``key`` sets the chunk sensitivity:
+
+    * chunk-BEARING ``(step, trip)`` — a different chunk size (BLOCK_K / BLOCK_N) gives a different
+      key -> split. Default; sound whenever re-chunking could change the accumulation order.
+    * chunk-INVARIANT ``()`` — chunk size dropped -> different chunk sizes MERGE. Only when the
+      accumulation is provably order-invariant (e.g. a tensor-core f32 accumulator), gated hard by
+      the empirical fuzzer."""
+
+    op: str
+    chunk: object
+    key: tuple = ()
+
+    @property
+    def children(self):
+        return (self.chunk, )
+
+    def sig_local(self, child_sigs):
+        return f"LOOP[{self.op};{child_sigs[0]};{self.key}]"
+
+    def sig(self):
+        return self.sig_local([self.chunk.sig()])

--- a/bitequiv/ptx_reduction.py
+++ b/bitequiv/ptx_reduction.py
@@ -48,25 +48,101 @@ different launch geometries or un-modeled accumulations never collapse to an emp
 contract/reorder. PTX is the practical check, not absolute ground truth (SASS via
 ``cuobjdump`` would be); ``--fmad=false`` pins the fusion decision. See ``design-doc.md``.
 """
-from pyptx.ir.nodes import Function, ImmediateOperand, RegisterOperand
+from pyptx.ir.nodes import Block, Function, ImmediateOperand, Label, RegisterOperand
 from pyptx.parser import parse
 from pyptx.parser.parser import ParseError
 
 from bitequiv.ptx.affine import reqntid_of
 from bitequiv.ptx.builder import entry_signatures
 from bitequiv.ptx.linker import linearize
+from bitequiv.ptx.mma import _is_mma
+
+# fp combine ops + widths, used to detect a loop-carried floating-point accumulation.
+_FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f32x2", ".f64", ".bf16", ".bf16x2"})
+_FP_COMBINE = frozenset({"add", "sub", "mul", "div", "min", "max", "fma"})
+
+
+def _instrs_and_labels(func):
+    """Linearized instructions (recursing into ``Block`` scopes, like :func:`linearize`) PLUS a map
+    ``label name -> index of the instruction at/after that label``. ``linearize`` drops labels; we
+    need their positions to find loop back-edges."""
+    insts, label_at, pending = [], {}, []
+
+    def walk(stmts):
+        for s in stmts:
+            if isinstance(s, Block):
+                walk(s.body)
+            elif isinstance(s, Label):
+                pending.append(s.name)
+            elif type(s).__name__ == "Instruction":
+                while pending:
+                    label_at[pending.pop()] = len(insts)
+                insts.append(s)
+
+    walk(func.body)
+    for name in pending:  # a trailing label points just past the last instruction
+        label_at[name] = len(insts)
+    return insts, label_at
+
+
+def _back_edges(insts, label_at):
+    """(header_idx, latch_idx) for each backward branch — a ``bra`` to a label at/before it = a loop."""
+    loops = []
+    for i, inst in enumerate(insts):
+        if inst.opcode == "bra":
+            for o in inst.operands:
+                name = getattr(o, "name", None) or getattr(o, "text", None)
+                j = label_at.get(name)
+                if j is not None and j <= i:
+                    loops.append((j, i))
+    return loops
+
+
+def _innermost_loop(idx, loops):
+    """The smallest loop range (header, latch) containing ``idx``, or None."""
+    best = None
+    for lp in loops:
+        if lp[0] <= idx <= lp[1] and (best is None or (lp[1] - lp[0]) < (best[1] - best[0])):
+            best = lp
+    return best
+
+
+def _loop_accumulates(insts, loop, loops):
+    """True iff the loop's OWN body (its range MINUS nested loops) carries a floating-point
+    accumulation: an MMA, or an fp combine whose destination is also one of its sources (a
+    loop-carried running total). This is what separates a K-reduction loop (its chunk size is
+    bit-relevant) from an output-tiling / parallelization loop (each iteration is an independent
+    output; its step is bit-free). Conservative direction is 'accumulates' -> keep."""
+    h, latch = loop
+    for k in range(h, latch + 1):
+        if _innermost_loop(k, loops) != loop:  # this instruction belongs to a NESTED loop
+            continue
+        inst = insts[k]
+        if _is_mma(inst):
+            return True
+        if inst.opcode in _FP_COMBINE and inst.modifiers and inst.modifiers[-1] in _FP_WIDTHS and inst.operands:
+            dname = getattr(inst.operands[0], "name", None)
+            if dname and any(getattr(s, "name", None) == dname for s in inst.operands[1:]):
+                return True
+    return False
 
 
 def _loop_steps(func):
-    """Sorted multiset of loop-induction SELF-INCREMENT constants: every ``add R, R, IMM``
-    where dst==src0 is a loop counter stepped by a compile-time constant (for a chunked
-    reduction this is exactly BLOCK_N — the cross-chunk column stride). This is a LAYOUT-/
-    num_warps-INVARIANT, BLOCK_N-FAITHFUL fence: the reconstruction cannot follow the loop
-    back-edge, so a collapsed per-chunk reduction loses the chunk SIZE; folding the loop step
-    into the entry signature restores it. Adding it can only SPLIT classes further (it is extra
-    distinguishing info), so it is monotonically sound — it never causes an over-merge."""
+    """Sorted multiset of loop-induction SELF-INCREMENT constants (``add R, R, IMM``, dst==src0),
+    but ONLY for loops that carry a floating-point ACCUMULATION. A self-increment inside an
+    output-tiling / parallelization loop (no loop-carried fp total in its own body) is bit-free and
+    dropped — so the fence stops over-splitting on BLOCK_M / num_warps — while the reduction chunk
+    step (BLOCK_N for a chunked reduction, BLOCK_K for a GEMM K-loop) is kept.
+
+    Sound / monotone: a step is DROPPED only when its self-increment sits inside a DETECTED loop
+    that provably does not accumulate. If no loop is recovered around a self-increment (loops
+    unrolled, or structure not recovered), the step is KEPT — so this can only reduce over-split,
+    never introduce an over-merge (dropping a bit-relevant chunk step)."""
+    insts, label_at = _instrs_and_labels(func)
+    loops = _back_edges(insts, label_at)
+    accumulates = {lp: _loop_accumulates(insts, lp, loops) for lp in set(loops)}
     steps = []
-    for inst in linearize(func):
+    for i, inst in enumerate(insts):
         if inst.opcode == "add" and len(inst.operands) == 3:
             d, a, b = inst.operands
             if (isinstance(d, RegisterOperand) and isinstance(a, RegisterOperand) and d.name == a.name
@@ -75,8 +151,12 @@ def _loop_steps(func):
                     v = int(b.text, 0)
                 except (ValueError, TypeError):
                     continue
-                if v != 0:
-                    steps.append(v)
+                if v == 0:
+                    continue
+                lp = _innermost_loop(i, loops)
+                if lp is not None and not accumulates[lp]:
+                    continue  # self-increment in a non-accumulating (tiling / parallel) loop -> drop
+                steps.append(v)
     return tuple(sorted(steps))
 
 

--- a/bitequiv/ptx_reduction.py
+++ b/bitequiv/ptx_reduction.py
@@ -48,83 +48,14 @@ different launch geometries or un-modeled accumulations never collapse to an emp
 contract/reorder. PTX is the practical check, not absolute ground truth (SASS via
 ``cuobjdump`` would be); ``--fmad=false`` pins the fusion decision. See ``design-doc.md``.
 """
-from pyptx.ir.nodes import Block, Function, ImmediateOperand, Label, RegisterOperand
+from pyptx.ir.nodes import Function, ImmediateOperand, RegisterOperand
 from pyptx.parser import parse
 from pyptx.parser.parser import ParseError
 
 from bitequiv.ptx.affine import reqntid_of
 from bitequiv.ptx.builder import entry_signatures
+from bitequiv.ptx.forward.loops import back_edges, innermost_loop, instrs_and_labels, loop_accumulates
 from bitequiv.ptx.linker import linearize
-from bitequiv.ptx.mma import _is_mma
-
-# fp combine ops + widths, used to detect a loop-carried floating-point accumulation.
-_FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f32x2", ".f64", ".bf16", ".bf16x2"})
-_FP_COMBINE = frozenset({"add", "sub", "mul", "div", "min", "max", "fma"})
-
-
-def _instrs_and_labels(func):
-    """Linearized instructions (recursing into ``Block`` scopes, like :func:`linearize`) PLUS a map
-    ``label name -> index of the instruction at/after that label``. ``linearize`` drops labels; we
-    need their positions to find loop back-edges."""
-    insts, label_at, pending = [], {}, []
-
-    def walk(stmts):
-        for s in stmts:
-            if isinstance(s, Block):
-                walk(s.body)
-            elif isinstance(s, Label):
-                pending.append(s.name)
-            elif type(s).__name__ == "Instruction":
-                while pending:
-                    label_at[pending.pop()] = len(insts)
-                insts.append(s)
-
-    walk(func.body)
-    for name in pending:  # a trailing label points just past the last instruction
-        label_at[name] = len(insts)
-    return insts, label_at
-
-
-def _back_edges(insts, label_at):
-    """(header_idx, latch_idx) for each backward branch — a ``bra`` to a label at/before it = a loop."""
-    loops = []
-    for i, inst in enumerate(insts):
-        if inst.opcode == "bra":
-            for o in inst.operands:
-                name = getattr(o, "name", None) or getattr(o, "text", None)
-                j = label_at.get(name)
-                if j is not None and j <= i:
-                    loops.append((j, i))
-    return loops
-
-
-def _innermost_loop(idx, loops):
-    """The smallest loop range (header, latch) containing ``idx``, or None."""
-    best = None
-    for lp in loops:
-        if lp[0] <= idx <= lp[1] and (best is None or (lp[1] - lp[0]) < (best[1] - best[0])):
-            best = lp
-    return best
-
-
-def _loop_accumulates(insts, loop, loops):
-    """True iff the loop's OWN body (its range MINUS nested loops) carries a floating-point
-    accumulation: an MMA, or an fp combine whose destination is also one of its sources (a
-    loop-carried running total). This is what separates a K-reduction loop (its chunk size is
-    bit-relevant) from an output-tiling / parallelization loop (each iteration is an independent
-    output; its step is bit-free). Conservative direction is 'accumulates' -> keep."""
-    h, latch = loop
-    for k in range(h, latch + 1):
-        if _innermost_loop(k, loops) != loop:  # this instruction belongs to a NESTED loop
-            continue
-        inst = insts[k]
-        if _is_mma(inst):
-            return True
-        if inst.opcode in _FP_COMBINE and inst.modifiers and inst.modifiers[-1] in _FP_WIDTHS and inst.operands:
-            dname = getattr(inst.operands[0], "name", None)
-            if dname and any(getattr(s, "name", None) == dname for s in inst.operands[1:]):
-                return True
-    return False
 
 
 def _loop_steps(func):
@@ -138,9 +69,9 @@ def _loop_steps(func):
     that provably does not accumulate. If no loop is recovered around a self-increment (loops
     unrolled, or structure not recovered), the step is KEPT — so this can only reduce over-split,
     never introduce an over-merge (dropping a bit-relevant chunk step)."""
-    insts, label_at = _instrs_and_labels(func)
-    loops = _back_edges(insts, label_at)
-    accumulates = {lp: _loop_accumulates(insts, lp, loops) for lp in set(loops)}
+    insts, label_at = instrs_and_labels(func)
+    loops = back_edges(insts, label_at)
+    accumulates = {lp: loop_accumulates(insts, lp, loops) for lp in set(loops)}
     steps = []
     for i, inst in enumerate(insts):
         if inst.opcode == "add" and len(inst.operands) == 3:
@@ -153,7 +84,7 @@ def _loop_steps(func):
                     continue
                 if v == 0:
                     continue
-                lp = _innermost_loop(i, loops)
+                lp = innermost_loop(i, loops)
                 if lp is not None and not accumulates[lp]:
                     continue  # self-increment in a non-accumulating (tiling / parallel) loop -> drop
                 steps.append(v)

--- a/bitequiv/tests/test_ptx_loops.py
+++ b/bitequiv/tests/test_ptx_loops.py
@@ -1,0 +1,81 @@
+"""loops.py — loop-structure recovery (back-edges, nesting, accumulator detection). CPU-only."""
+from pyptx.parser import parse
+
+from bitequiv.ptx.forward import loops
+from bitequiv.ptx_reduction import _ensure_header
+
+
+def _entry(ptx):
+    m = parse(_ensure_header(ptx))
+    return next(d for d in m.directives if getattr(d, "is_entry", False))
+
+
+# A loop that ACCUMULATES: `%f1 = %f1 + %f2` each iteration (a running total). Its step (32) is
+# bit-relevant.
+_ACC = """
+.visible .entry k(.param .u64 p) {
+  .reg .f32 %f<4>;
+  .reg .b32 %r<4>;
+  .reg .pred %p<2>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.b32 %r1, 0;
+  mov.f32 %f1, 0f00000000;
+$L__BB0_1:
+  add.f32 %f1, %f1, %f2;
+  add.s32 %r1, %r1, 32;
+  setp.lt.s32 %p1, %r1, 256;
+  @%p1 bra $L__BB0_1;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}
+"""
+
+# A TILING loop: each iteration writes an independent output (no loop-carried fp total). Its step
+# (64) is bit-free.
+_TILE = """
+.visible .entry k(.param .u64 p) {
+  .reg .f32 %f<6>;
+  .reg .b32 %r<4>;
+  .reg .pred %p<2>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.b32 %r2, 0;
+$L__BB0_2:
+  mul.f32 %f3, %f4, %f5;
+  st.global.f32 [%rd1], %f3;
+  add.s32 %r2, %r2, 64;
+  setp.lt.s32 %p2, %r2, 512;
+  @%p2 bra $L__BB0_2;
+  ret;
+}
+"""
+
+
+def test_back_edge_detected():
+    insts, label_at = loops.instrs_and_labels(_entry(_ACC))
+    assert len(loops.back_edges(insts, label_at)) == 1
+
+
+def test_accumulating_loop_true():
+    insts, lps = loops.find_loops(_entry(_ACC))
+    assert loops.loop_accumulates(insts, lps[0], lps) is True
+
+
+def test_tiling_loop_false():
+    insts, lps = loops.find_loops(_entry(_TILE))
+    assert loops.loop_accumulates(insts, lps[0], lps) is False
+
+
+def test_loop_carried_accumulator_reg():
+    insts, lps = loops.find_loops(_entry(_ACC))
+    accs = loops.loop_carried_accumulators(insts, lps[0], lps)
+    assert len(accs) == 1 and accs[0][1].opcode == "add"    # the self-accumulating add.f32
+
+
+def test_innermost_and_own_body_pure():
+    dummy = [None] * 10
+    lps = [(0, 9), (3, 6)]                                  # outer loop + a nested loop
+    assert loops.innermost_loop(4, lps) == (3, 6)
+    assert loops.innermost_loop(1, lps) == (0, 9)
+    assert loops.own_body(dummy, (0, 9), lps) == [0, 1, 2, 7, 8, 9]  # outer's own body = range minus nested

--- a/bitequiv/tests/test_ptx_unified.py
+++ b/bitequiv/tests/test_ptx_unified.py
@@ -1,6 +1,11 @@
-"""Unified per-element model — Step 1: Mma + LoopReduce nodes + builder guards. CPU-only."""
+"""Unified per-element model — Step 1: Mma + LoopReduce nodes + builder guards; Step 3: forward
+interpreter loop-carried add-accumulation -> LoopReduce. CPU-only."""
+from pyptx.parser import parse
+
 from bitequiv.ptx.builder import collapse_balanced, tree_hash
+from bitequiv.ptx.forward.interp import ForwardInterp, forward_module_descriptor
 from bitequiv.ptx.treeir import FpOp, ITreeReduce, Leaf, LoopReduce, Mma
+from bitequiv.ptx_reduction import _ensure_header
 
 
 def _leaf(i):
@@ -62,3 +67,55 @@ def test_loopreduce_root_survives_collapse():
     lr = LoopReduce("add.f32", Mma("tcgen05|.kind::f16", (), (_leaf(0), )), ())
     c = collapse_balanced(lr)
     assert isinstance(c, LoopReduce) and c.sig() == lr.sig()
+
+
+# -- Step 3: forward interpreter loop-carried add-accumulation -> LoopReduce ---
+
+# A chunked sum: each iteration loads one element and adds it to the running total `%f1`; the
+# induction var steps by {step} (BLOCK_N). The forward walk should summarize this as one LoopReduce.
+_LOOP_SUM = """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {{
+  .reg .f32 %f<4>;
+  .reg .b32 %r<4>;
+  .reg .pred %p<2>;
+  .reg .b64 %rd<8>;
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  mov.b32 %r1, 0;
+  mov.f32 %f1, 0f00000000;
+  cvta.to.global.u64 %rd3, %rd1;
+$L__BB0_1:
+  mul.wide.s32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f2, [%rd5];
+  add.f32 %f1, %f1, %f2;
+  add.s32 %r1, %r1, {step};
+  setp.lt.s32 %p1, %r1, 4096;
+  @%p1 bra $L__BB0_1;
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f1;
+  ret;
+}}
+"""
+
+
+def _interp(ptx):
+    m = parse(_ensure_header(ptx))
+    f = next(d for d in m.directives if getattr(d, "is_entry", False))
+    interp = ForwardInterp(f)
+    interp.run()
+    return interp
+
+
+def test_loop_add_emits_loopreduce():
+    interp = _interp(_LOOP_SUM.format(step=256))
+    lrs = [v for v in interp.regs.values() if isinstance(v, LoopReduce)]
+    assert len(lrs) == 1                                       # the accumulator became a fold summary
+    lr = lrs[0]
+    assert lr.op == "add.f32" and isinstance(lr.chunk, Leaf) and lr.key == ((256, ), )  # chunk step key
+
+
+def test_loop_step_splits_and_is_deterministic():
+    d256 = forward_module_descriptor(_LOOP_SUM.format(step=256))
+    assert d256 == forward_module_descriptor(_LOOP_SUM.format(step=256))    # deterministic
+    assert d256 != forward_module_descriptor(_LOOP_SUM.format(step=128))    # different BLOCK_N -> split

--- a/bitequiv/tests/test_ptx_unified.py
+++ b/bitequiv/tests/test_ptx_unified.py
@@ -1,0 +1,64 @@
+"""Unified per-element model — Step 1: Mma + LoopReduce nodes + builder guards. CPU-only."""
+from bitequiv.ptx.builder import collapse_balanced, tree_hash
+from bitequiv.ptx.treeir import FpOp, ITreeReduce, Leaf, LoopReduce, Mma
+
+
+def _leaf(i):
+    return Leaf(f"c{i}", frozenset({i}))
+
+
+# -- Mma node -----------------------------------------------------------------
+
+
+def test_mma_sig_and_hash():
+    a = Mma("wgmma|k16|.f32,.f16,.f16", (), (_leaf(0), _leaf(1)))
+    b = Mma("wgmma|k16|.f32,.f16,.f16", (), (_leaf(0), _leaf(1)))
+    assert a.sig().startswith("MMA[wgmma|k16")
+    assert tree_hash(a) == tree_hash(b)                       # same token + children -> same hash
+    assert tree_hash(a) != tree_hash(Mma("wgmma|k32|.f32,.f16,.f16", (), (_leaf(0), _leaf(1))))  # K split
+
+
+def test_mma_flags_split():
+    assert tree_hash(Mma("t", ("1",), (_leaf(0),))) != tree_hash(Mma("t", ("-1",), (_leaf(0),)))
+
+
+# -- LoopReduce node ----------------------------------------------------------
+
+
+def _chunk():
+    return FpOp("mul", (".f32", ), (_leaf(0), _leaf(1)))
+
+
+def test_loopreduce_chunk_bearing_splits_step():
+    a = LoopReduce("add.f32", _chunk(), (16, 64))
+    b = LoopReduce("add.f32", _chunk(), (32, 32))
+    assert tree_hash(a) != tree_hash(b)                       # chunk-bearing: different step -> split
+
+
+def test_loopreduce_chunk_invariant_merges_step():
+    a = LoopReduce("add.f32", _chunk(), ())                   # chunk-invariant (key dropped)
+    b = LoopReduce("add.f32", _chunk(), ())
+    assert tree_hash(a) == tree_hash(b)
+    assert tree_hash(a) != tree_hash(LoopReduce("add.f32", _chunk(), (16, 64)))  # invariant != bearing
+
+
+# -- builder guards: a reduction over Mma / LoopReduce must NOT collapse -------
+
+
+def test_reduction_over_mma_does_not_collapse():
+    t = FpOp("add", (".f32", ), (Mma("wgmma|k16|.f32", (), (_leaf(0), )),
+                                 Mma("wgmma|k16|.f32", (), (_leaf(1), ))))
+    assert not isinstance(collapse_balanced(t), ITreeReduce)  # Mma not layout-invariant -> no collapse
+
+
+def test_reduction_over_loopreduce_does_not_collapse():
+    lr0 = LoopReduce("add.f32", FpOp("mul", (".f32", ), (_leaf(0), _leaf(0))), (16, 64))
+    lr1 = LoopReduce("add.f32", FpOp("mul", (".f32", ), (_leaf(1), _leaf(1))), (16, 64))
+    assert not isinstance(collapse_balanced(FpOp("add", (".f32", ), (lr0, lr1))), ITreeReduce)
+
+
+def test_loopreduce_root_survives_collapse():
+    # single output = one LoopReduce -> collapse_balanced returns it unchanged (it IS the per-element sig)
+    lr = LoopReduce("add.f32", Mma("tcgen05|.kind::f16", (), (_leaf(0), )), ())
+    c = collapse_balanced(lr)
+    assert isinstance(c, LoopReduce) and c.sig() == lr.sig()

--- a/bitequiv/tests/test_ptx_unified.py
+++ b/bitequiv/tests/test_ptx_unified.py
@@ -2,9 +2,9 @@
 interpreter loop-carried add-accumulation -> LoopReduce. CPU-only."""
 from pyptx.parser import parse
 
-from bitequiv.ptx.builder import collapse_balanced, tree_hash
+from bitequiv.ptx.builder import collapse_balanced, output_coordfree_key, tree_hash
 from bitequiv.ptx.forward.interp import ForwardInterp, forward_module_descriptor
-from bitequiv.ptx.treeir import FpOp, ITreeReduce, Leaf, LoopReduce, Mma
+from bitequiv.ptx.treeir import FpOp, ITreeReduce, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp
 from bitequiv.ptx_reduction import _ensure_header
 
 
@@ -119,3 +119,36 @@ def test_loop_step_splits_and_is_deterministic():
     d256 = forward_module_descriptor(_LOOP_SUM.format(step=256))
     assert d256 == forward_module_descriptor(_LOOP_SUM.format(step=256))    # deterministic
     assert d256 != forward_module_descriptor(_LOOP_SUM.format(step=128))    # different BLOCK_N -> split
+
+
+# -- multi-output coord-free dedup key (num_warps recovery for softmax/layernorm/rmsnorm) ------------
+
+
+def test_coordfree_key_blanks_leaf_coord():
+    # same per-element structure, different leaf coords (a different thread owns the element) -> one key
+    a = FpOp("add", (".f32", ), (Leaf("row3col5", frozenset({5})), ITreeReduce("add.f32", "L[]", 4)))
+    b = FpOp("add", (".f32", ), (Leaf("row9col2", frozenset({2})), ITreeReduce("add.f32", "L[]", 4)))
+    assert output_coordfree_key(a) is not None
+    assert output_coordfree_key(a) == output_coordfree_key(b)   # coord blanked -> num_warps-invariant
+
+
+def test_coordfree_key_allows_pure_opaque_and_const_leaf():
+    # softmax shape: div(ex2(...), sum) with a pure OpaqueOp + a CONSTANT OpaqueLeaf (log2e) -> allowed
+    t = OpaqueOp("ex2.approx.f32", (OpaqueLeaf("mov.b32{opq(imm(0f3FB8AA3B))}"), Leaf("c0", frozenset({0}))))
+    assert output_coordfree_key(t) is not None
+
+
+def test_coordfree_key_rejects_unmodeled():
+    assert output_coordfree_key(OpaqueOp("weird.op", (Leaf("c0", frozenset({0})), ))) is None  # unmodeled op
+    assert output_coordfree_key(OpaqueLeaf("%r5")) is None                # lost-provenance (non-const) value
+
+
+def test_coordfree_key_rejects_shfl_bearing():
+    # an UNORDERED per-row reduction keeps its cross-thread ShflCombine -> its coord-free string carries
+    # the num_warps-bearing offset, so two num_warps still differ (correctly NOT recovered). Here we just
+    # confirm the key exists (it is the verbatim-ish coordfree, not None) so the SET still splits by offset.
+    from bitequiv.ptx.treeir import ShflCombine
+    t = ShflCombine(16, "add", (".f32", ), Leaf("c0", frozenset({0})))
+    k16 = output_coordfree_key(t)
+    k8 = output_coordfree_key(ShflCombine(8, "add", (".f32", ), Leaf("c1", frozenset({1}))))
+    assert k16 is not None and k16 != k8   # different butterfly offset -> different key -> stays split


### PR DESCRIPTION
Summary:
Adds a split-K GEMM eval kernel whose configs genuinely differ in bits, so the GEMM suite can finally test the checker's SOUNDNESS (must-not-over-merge), not just recovery.

Why this kernel is needed: a standard tiled GEMM folds all K products into ONE accumulator in k-order, so block_k / num_warps / num_stages / block_m/n / tensor-size never regroup the K sum -- the entire tiling config space is a single bit-class (confirmed at R=200 with wide-dynamic-range cancellation operands; fp8 imprecise-acc at K=32768 is also one class). There is NO reduction-ORDER inequivalence in a normal GEMM: its K-reduction is a sequential per-output fold, not a layout-dependent cross-thread tree like a reduction kernel. So the existing tiling GEMMs (gemm_f16_free_tiling / gemm_kloop_block_k / gemm_fp8_imprecise_acc) all collapse to 1 empirical class -- they test only RECOVERY (merge-all) and cannot test soundness (nothing to wrongly split).

Split-K is the one tiling-like GEMM knob that IS bit-relevant: `gemm_num_splits` cuts K into that many contiguous slices, sums each into its OWN partial accumulator, then combines the partials -- a different grouping `(acc+Sa)+Sb` != a single in-order fold, so with order-sensitive operands each split value is a distinct bit-class. (Deterministic combine, not atomic, so the result is reproducible.) This is a real, common autotuner pattern (occupancy for tall-skinny / large-K GEMMs), and the only realistic GEMM structure that creates reduction-order inequivalence.

Adds: a `gemm_num_splits` config axis (light {1,2,4}, heavy {1,2,4,8}); the fused single-kernel `gemm_splitk_kernel` (outer loop over splits, inner K-loop into a per-split partial, `acc += partial` combine -> one st.global root the PTX checker can read); its compile/run; and the `gemm_splitk` KernelSpec.

NOTE -- this kernel currently EXPOSES a checker soundness gap: the forward PTX checker OVER-MERGES split-K (num_splits 1<->2 and 4<->8 collapse; 72 over-merges, stable at R=200), because the MMA fence op-count ratio is num_splits-invariant and the `loops=` fence captures the split-loop STEP but not its grouping (num_splits). That is exactly what this kernel exists to catch. The checker fix (model the split-K regrouping) will be AMENDED into this diff.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D113138954


