### PR TITLE
[inductor][tlx] Persistent warp-pipe addmm template (AMD/MI350X) (#2568)

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -427,6 +427,64 @@ class TestTLXTemplates(TestCase):
         self.assertIn("tlx.async_load", src)  # aligned-K async path
         self.assertIn("a_reg = tl.load", src)  # register-path fallback load
 
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX persistent warp-pipe addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    def test_tlx_addmm_persistent_warppipe(self, dtype: torch.dtype):
+        """Persistent TLX warp-pipe addmm template (AMD MI350X / gfx950), col-major B.
+
+        De-risks the persistent tile-loop + tlx.warp_pipeline_stage nesting (the exact
+        pattern that failed to lower on beta triton 3.6). ``append_tlx`` is patched to
+        offer ONLY the persistent template, so force mode is guaranteed to select and
+        compile it (not the per-tile warp-pipe) -- proving it lowers and is numerically
+        correct. The shape has many more MN tiles than SMs, so each program's persistent
+        loop iterates over several output tiles.
+        """
+        from triton.language.extra.tlx.inductor import mm_templates as _tlx_mm
+
+        M, K, N = 4096, 2048, 512  # many MN tiles -> persistent loop iterates per program
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
+        # w.t() => B is [K, N] col-major (stride_bk == 1) -- the nn.Linear weight layout.
+        w = torch.randn(N, K, device=GPU_TYPE, dtype=dtype)
+        bias = torch.randn(N, device=GPU_TYPE, dtype=dtype)
+
+        def addmm(bias, a, w):
+            return torch.addmm(bias, a, w.t())
+
+        def _only_persistent(templates, op_name="mm"):
+            # Offer only the persistent template (drop the per-tile warp-pipe) so force
+            # mode is guaranteed to select and compile the persistent kernel.
+            from torch._inductor.kernel.mm import mm_template
+
+            uids = {getattr(t, "uid", None) for t in templates}
+            if op_name == "addmm" and mm_template.uid in uids:
+                if _tlx_mm.amd_addmm_persistent_warppipe_template.uid not in uids:
+                    templates.append(_tlx_mm.amd_addmm_persistent_warppipe_template)
+            return templates
+
+        with (
+            mock.patch.object(_tlx_mm, "append_tlx", _only_persistent),
+            config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+            }),
+        ):
+            c_actual, code = run_and_get_code(torch.compile(addmm), bias, a, w)
+
+        c_expected = (a.float() @ w.t().float() + bias.float()).to(dtype)
+        torch.testing.assert_close(c_actual, c_expected, atol=2e-2, rtol=2e-2)
+
+        # Only the persistent template is offered, so force mode must lower addmm
+        # through it (triton_tem), never an extern/aten kernel.
+        code_str = "\n".join(code)
+        self.assertIn("triton_tem", code_str)
+
 
 class TestWarpPipeSplitKCodegen(TestCase):
     """Deterministic codegen check for the AMD warp-pipe split-K template.

--- a/third_party/tlx/language/tlx/inductor/amd_addmm_persistent_warppipe.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/amd_addmm_persistent_warppipe.py.jinja
@@ -1,0 +1,130 @@
+{{def_kernel("A", "B")}}
+    # PERSISTENT TLX warp-pipelined addmm for AMD (MI350X / gfx950), COL-MAJOR B (stride_bk == 1).
+    # Persistent variant of amd_addmm_warppipe: the grid is capped at NUM_SMS (see
+    # _persistent_mm_grid_split_k) and each program strides over output tiles by NUM_SMS.
+    # The per-tile body (col-major B loaded as (BLOCK_N, BLOCK_K) + tlx.local_trans, XCD chiplet
+    # swizzle, "mfma"/"mem" warp-pipeline stages, single combined A+B commit, loop-tail wait) is
+    # copied verbatim from the proven per-tile template -- the ONLY change is wrapping it in the
+    # `for tile_iter in tl.range(start_pid, num_tiles, NUM_SMS)` loop and allocating the SMEM
+    # buffers once outside that loop. Bias is applied by store_output via epilogue_fn / prefix_args.
+    #
+    # NOTE: this nesting (warp_pipeline_stage inside a K-loop inside the persistent tile-loop) is
+    # exactly what failed to lower on fbcode beta triton 3.6 ("barrier or wait op cannot appear
+    # inside a warp_pipeline_stage region"); it must be re-verified on 3.7.0+fb.beta.
+    #
+    # async_load int32 offset restriction is inherited from the per-tile template (heuristic only
+    # emits this when M*K and N*K statically fit int32).
+    M = {{size("A", 0)}}
+    N = {{size("B", 1)}}
+    K = {{size("A", 1)}}
+    if M * N == 0:
+        # early exit due to zero-size input(s)
+        return
+    stride_am = {{stride("A", 0)}}
+    stride_ak = {{stride("A", 1)}}
+    stride_bk = {{stride("B", 0)}}
+    stride_bn = {{stride("B", 1)}}
+    tl.assume(stride_am > 0)
+    tl.assume(stride_ak > 0)
+    tl.assume(stride_bk > 0)
+    tl.assume(stride_bn > 0)
+
+    grid_m = (M + BLOCK_M - 1) // BLOCK_M
+    grid_n = (N + BLOCK_N - 1) // BLOCK_N
+    num_tiles = grid_m * grid_n
+    width = GROUP_M * grid_n
+
+    K_ITERS = tl.cdiv(K, BLOCK_K)
+    offs_k = tl.arange(0, BLOCK_K).to(INDEX_DTYPE)
+
+    # Persistent: allocate the multi-buffered LDS staging ONCE and reuse it across tiles.
+    # Each tile's epilogue drains all in-flight loads (async_load_wait_group(0)) before the next
+    # tile's prologue reuses the buffers.
+    smemA = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(A), NUM_BUFFERS)
+    smemB = tlx.local_alloc((BLOCK_N, BLOCK_K), tlx.dtype_of(B), NUM_BUFFERS)   # holds Bᵀ tile
+
+    start_pid = tl.program_id(0).to(INDEX_DTYPE)
+    # L2 chiplet swizzle chunk (see per-tile template / P2410594601).
+    XCD_CHUNK: tl.constexpr = 4
+    aligned = (num_tiles // (NUM_XCDS * XCD_CHUNK)) * (NUM_XCDS * XCD_CHUNK)
+
+    for tile_iter in tl.range(start_pid, num_tiles, NUM_SMS):
+        # XCD chiplet swizzle: group adjacent tiles onto the same XCD in chunks for warm L2.
+        # NUM_XCDS is 8 for gfx942/gfx950 (else 1 -> identity). Trailing remainder passes through.
+        pid = tile_iter
+        if pid < aligned:
+            xcd = pid % NUM_XCDS
+            local_pid = pid // NUM_XCDS
+            pid = (local_pid // XCD_CHUNK) * (NUM_XCDS * XCD_CHUNK) + xcd * XCD_CHUNK + (local_pid % XCD_CHUNK)
+
+        group_id = pid // width
+        group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+        pid_m = group_id * GROUP_M + (pid % group_size)
+        pid_n = (pid % width) // group_size
+        tl.assume(pid_m >= 0)
+        tl.assume(pid_n >= 0)
+
+        offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)) % M
+        offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N).to(INDEX_DTYPE)) % N
+        a_base = offs_m[:, None] * stride_am
+        b_base = offs_n[:, None] * stride_bn          # B as (BLOCK_N, BLOCK_K)
+
+        # prologue: prefetch the first NUM_BUFFERS K-tiles (heuristic guarantees K_ITERS > NUM_BUFFERS).
+        # A and B share a SINGLE async_load_commit_group per K-tile (wait counts tiles directly).
+        for i in tl.range(0, NUM_BUFFERS, loop_unroll_factor=NUM_BUFFERS):
+            k_start = i * BLOCK_K
+            a_offs = a_base + (k_start + offs_k[None, :]) * stride_ak
+            b_offs = b_base + (k_start + offs_k[None, :]) * stride_bk
+            tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, i), mask=offs_k[None, :] < K - k_start)
+            tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, i), mask=offs_k[None, :] < K - k_start)
+            tlx.async_load_commit_group([tok_a, tok_b])
+
+        tlx.async_load_wait_group(NUM_BUFFERS - 2)
+        a_tile = tlx.local_load(tlx.local_view(smemA, 0))
+        b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, 0)))
+
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+
+        for k_id in tl.range(0, K_ITERS - NUM_BUFFERS):
+            # buffer indices MUST be int32 (local_view feeds them to the block-ptr index check).
+            prefetch_buf = (k_id % NUM_BUFFERS).to(tl.int32)
+            next_buf = ((k_id + 1) % NUM_BUFFERS).to(tl.int32)
+            k_prefetch = (k_id + NUM_BUFFERS) * BLOCK_K
+
+            with tlx.warp_pipeline_stage("mfma", priority=0):
+                acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+
+            with tlx.warp_pipeline_stage("mem", priority=1):
+                a_offs = a_base + (k_prefetch + offs_k[None, :]) * stride_ak
+                b_offs = b_base + (k_prefetch + offs_k[None, :]) * stride_bk
+                tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, prefetch_buf),
+                                       mask=offs_k[None, :] < K - k_prefetch)
+                tok_b = tlx.async_load(B + b_offs.to(tl.int32), tlx.local_view(smemB, prefetch_buf),
+                                       mask=offs_k[None, :] < K - k_prefetch)
+                tlx.async_load_commit_group([tok_a, tok_b])
+                a_tile = tlx.local_load(tlx.local_view(smemA, next_buf))
+                b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, next_buf)))
+
+            # loop-tail wait: keep NUM_BUFFERS-2 commit groups in flight (race-free, incl. NUM_BUFFERS=2).
+            tlx.async_load_wait_group(NUM_BUFFERS - 2)
+
+        acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+        tlx.async_load_wait_group(0)
+        for i in tl.range(0, NUM_BUFFERS - 1, loop_unroll_factor=NUM_BUFFERS - 1):
+            buf = ((K_ITERS - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS).to(tl.int32)   # int32 buffer index
+            a_tile = tlx.local_load(tlx.local_view(smemA, buf))
+            b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, buf)))
+            acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
+
+        # rematerialize rm and rn to save registers
+        rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M).to(INDEX_DTYPE)
+        rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N).to(INDEX_DTYPE)
+        idx_m = rm[:, None]
+        idx_n = rn[None, :]
+        mask = (idx_m < M) & (idx_n < N)
+
+        # inductor generates a suffix (bias add via epilogue_fn + prefix_args, cast, store).
+        # store_output inside a persistent tile-loop is supported (see blackwell_gemm_ws.py.jinja);
+        # indent_width=8 is REQUIRED so the generated epilogue body lands at the loop-body indent
+        # (default 4 would emit it outside the loop -> idx_m/idx_n/mask NameError).
+        {{store_output(("idx_m", "idx_n"), "acc", "mask", val_shape=("BLOCK_M", "BLOCK_N"), indent_width=8)}}

--- a/third_party/tlx/language/tlx/inductor/mm_templates.py
+++ b/third_party/tlx/language/tlx/inductor/mm_templates.py
@@ -85,6 +85,17 @@ amd_bmm_warppipe_template = TritonTemplate(
     source=load_tlx_template("amd_bmm_warppipe"),
 )
 
+# Persistent variant of the AMD warp-pipe addmm: same warp-pipe body, but the grid
+# is capped at NUM_SMS (_persistent_mm_grid_split_k) and the kernel loops over output
+# tiles. Competes as an additional addmm candidate so per-template selection can be
+# attributed in the merge_net gemm sweep. Requires NUM_SMS in the template kwargs
+# (supplied by ROCmAddMMPersistentWarpPipeTemplateConfigHeuristic in registry.py).
+amd_addmm_persistent_warppipe_template = TritonTemplate(
+    name="tlx_amd_addmm_persistent_warppipe",
+    grid=_persistent_mm_grid_split_k,
+    source=load_tlx_template("amd_addmm_persistent_warppipe"),
+)
+
 
 def append_tlx(templates, op_name="mm"):
     # Import registry to trigger heuristic registration via decorators
@@ -98,8 +109,15 @@ def append_tlx(templates, op_name="mm"):
         from torch._inductor.kernel.mm import mm_template
 
         uids = {getattr(t, "uid", None) for t in templates}
-        if mm_template.uid in uids and amd_addmm_warppipe_template.uid not in uids:
-            templates.append(amd_addmm_warppipe_template)
+        if mm_template.uid in uids:
+            # per-tile warp-pipe (existing candidate)
+            if amd_addmm_warppipe_template.uid not in uids:
+                templates.append(amd_addmm_warppipe_template)
+            # persistent warp-pipe (new): competes as an ADDITIONAL addmm candidate,
+            # kept a distinct template so the sweep attributes its selection count
+            # separately from the per-tile warp-pipe.
+            if amd_addmm_persistent_warppipe_template.uid not in uids:
+                templates.append(amd_addmm_persistent_warppipe_template)
     elif op_name == "bmm":
         # Compete as an additional candidate alongside the stock bmm_template + aten. Inject once,
         # gated on bmm_template already being present (the unified choice call).

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -51,6 +51,7 @@ def _sizevar_hint(sizevars, expr, fallback):
 
 from . import tlx_config
 from .mm_templates import (
+    amd_addmm_persistent_warppipe_template,
     amd_addmm_warppipe_template,
     amd_bmm_warppipe_template,
     blackwell_gemm_ws_template,
@@ -1419,6 +1420,33 @@ class ROCmBMMWarpPipeTemplateConfigHeuristic(ROCmMMTemplateConfigHeuristic):
             yield self._convert_config_to_template_kwargs(
                 triton_config, m, n, k, out_dtype
             )
+
+
+@register_template_heuristic(
+    amd_addmm_persistent_warppipe_template.uid,
+    "cuda",
+    register=IS_ROCM,
+    op_name="addmm",
+)
+class ROCmAddMMPersistentWarpPipeTemplateConfigHeuristic(
+    ROCmAddMMWarpPipeTemplateConfigHeuristic
+):
+    """Persistent variant of the AMD warp-pipe addmm heuristic (MI350X / gfx950).
+
+    Reuses the per-tile heuristic's col-major-B ``adjust_kernel_inputs``, the
+    fp16/bf16 + int32-offset gating, the ``K_ITERS > NUM_BUFFERS`` correctness guard,
+    and the tuned ``WARPPIPE_CONFIGS`` pool. The only delta is that the persistent
+    template's grid (``_persistent_mm_grid_split_k``) is capped at NUM_SMS, so NUM_SMS
+    must be threaded into the template kwargs (it becomes a constexpr; the kernel
+    strides over output tiles by it).
+    """
+
+    def _get_template_configs_impl(self, kernel_inputs, op_name):
+        num_sms = get_num_sms()
+        for template_kwargs in super()._get_template_configs_impl(
+            kernel_inputs, op_name
+        ):
+            yield {**template_kwargs, "NUM_SMS": num_sms}
 
 
 @register_template_heuristic(


### PR DESCRIPTION
Summary:

Adds a persistent variant of the TLX warp-pipelined addmm template for AMD
MI350X (gfx950), alongside the existing per-tile tlx_amd_addmm_warppipe. Same
warp-pipe body (col-major B loaded as (BLOCK_N, BLOCK_K) + tlx.local_trans,
async_load prefetch into multi-buffered LDS + tlx.warp_pipeline_stage
"mfma"/"mem", XCD L2 swizzle), wrapped in a persistent tile-loop: the grid is
capped at NUM_SMS (_persistent_mm_grid_split_k) and each program strides over
output tiles by NUM_SMS. SMEM is allocated once outside the loop.

- Template amd_addmm_persistent_warppipe.py.jinja (name
  tlx_amd_addmm_persistent_warppipe), defined in mm_templates.py. append_tlx
  now offers BOTH the per-tile and persistent warp-pipe as additional addmm
  candidates (distinct names so autotune / per-template attribution can tell
  them apart). It is an additional candidate only, so it never regresses --
  autotuning keeps the fastest of aten / mm_template / warp-pipe / persistent.
- Heuristic ROCmAddMMPersistentWarpPipeTemplateConfigHeuristic (registry.py):
  subclasses the per-tile heuristic, inheriting the col-major-B
  adjust_kernel_inputs, fp16/bf16 + int32-offset gating, the
  K_ITERS > NUM_BUFFERS correctness guard and the tuned configs; it only adds
  NUM_SMS to the template kwargs for the persistent grid.
- store_output is emitted inside the persistent loop with indent_width=8 (the
  default 4 would place the fused epilogue outside the loop).

This change was authored with Claude.

Reviewed By: bilal, htyu

Differential Revision: D113970230


