### PR TITLE
[AMD][gfx950][TLX] a4w4 GEMM repro vs AITER baseline (#2569)

### DIFF
--- a/third_party/tlx/tutorials/amd_bmm.py
+++ b/third_party/tlx/tutorials/amd_bmm.py
@@ -1,0 +1,242 @@
+"""AMD a16w16 batched GEMM (BMM) for gfx950 / CDNA4 — dual load-path, single kernel.
+
+C[b] = A[b] @ B[b], fp16/bf16, batched. A is (B, M, K); B is (B, K, N) COLUMN-major
+(K-contiguous, stride_bk == 1), i.e. built as (B, N, K) then transposed (the layout the
+direct-to-LDS b loads expect); C is (B, M, N) row-major. ``make_bmm_inputs`` always builds
+SHARED-A (one (M, K) reused across the batch, ``a.stride(0) == 0``) — the shared-LHS layout;
+we always benchmark shared-A, since distinct-A flatters TLX (rocBLAS reads shared-A once).
+
+For the standard torch.bmm / inductor layout (ROW-major B, stride_bn == 1) see the
+companion ``amd_bmm_shared_perf.py``, which uses num_warps=8 + matrix_instr_nonkdim=32
+(the row-major winning config; nw=8 does not compile with this column-major kernel's
+swizzle + 4-warp split store) and is the shared-A vs rocBLAS perf reproducer.
+
+ONE kernel, two load paths selected by a ``USE_DIRECT`` constexpr the launcher sets from K's
+alignment (``K % BLOCK_K == 0``):
+
+  * USE_DIRECT=1  (aligned rows): the fast async direct-to-LDS path (``buffer_load_to_local`` —
+    global -> LDS with no register round-trip). Beats rocBLAS on short/medium-K shapes.
+  * USE_DIRECT=0  (odd / unaligned / K%BLOCK_K != 0): a register path (``tl.load`` -> registers ->
+    ``tlx.local_store``, masked K-tail) that lowers for ANY row-stride alignment where direct-to-LDS
+    is illegal on CDNA4 (odd K -> 2-byte-aligned rows). Wins the odd-K shapes.
+
+Shared by both paths — the levers that beat the vendor on this occupancy-saturated BMM family:
+  * num_warps=4  -> 2 workgroups co-resident per CU: the two WGs drift out of phase and the hardware
+    overlaps one WG's MFMA with the other's loads for free (inter-WG "ping-pong").
+  * Swizzled + padded LDS (``padded_shared_layout_encoding``) -> bank-conflict-free ``ds_read_b128``.
+  * L2 XCD-chunk remap (``_chip``) -> a batch's M-tiles stay on one XCD, keeping B hot in L2.
+  * int64 per-batch base advance (batch*M*K can exceed 2**31); within-tile offsets stay int32.
+  * ``% M`` / ``% N`` wrap on load indices -> OOB rows re-read valid data (L2), never HBM garbage.
+  * NB-deep software pipeline (prologue prime / steady overlap / epilogue drain).
+  * 4-warp coalesced split-store ([128, 256] -> two [128, 128] dwordx4 stores).
+
+Exposes ``bmm(a, b)`` for the correctness / perf suites.
+"""
+import os
+
+import torch
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+BLOCK_N = 256
+BLOCK_K = 32
+NUM_XCDS = 8
+NB = 3
+KERNEL_NAME = "amd_bmm"
+
+
+def _swz(shape, cd):
+    """Swizzle-offset bases for a [d0, d1] tile whose contiguous dim is ``cd``."""
+
+    def basis(d, i):
+        return [1 << i, 0] if d == 0 else [0, 1 << i]
+
+    fd = 1 - cd
+    cb = int(shape[cd]).bit_length() - 1
+    fb = int(shape[fd]).bit_length() - 1
+    return ([basis(cd, i) for i in range(cb)] + [basis(fd, i)
+                                                 for i in range(4, fb)] + [basis(fd, i) for i in range(min(4, fb))])
+
+
+_B_BASES = tl.constexpr(_swz([BLOCK_K, BLOCK_N], 0))
+# 4-warp (256-thread) coalesced [128, 128] store layout: 8 contiguous N per thread (dwordx4).
+_C4 = tlx.layout(shape=((16, 16), (8, 8)), stride=((8, 128), (1, 2048)))
+
+
+@triton.jit
+def _chip(pid, nwg, nx: tl.constexpr, cs: tl.constexpr):
+    """L2-aware XCD remap: keep a batch's M-tiles (chunk of size ``cs``) on one XCD."""
+    al = (nwg // (nx * cs)) * (nx * cs)
+    if pid >= al:
+        return pid
+    x = pid % nx
+    lp = pid // nx
+    return (lp // cs) * nx * cs + x * cs + (lp % cs)
+
+
+@triton.jit
+def amd_bmm_kernel(a_ptr, b_ptr, c_ptr, M, N, K, sab, sam, sak, sbb, sbk, sbn, scb, scm, scn, BLOCK_M: tl.constexpr,
+                   BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, A_BASES: tl.constexpr, NUM_XCDS: tl.constexpr,
+                   GRID_MN: tl.constexpr, NUM_TILES: tl.constexpr, NB: tl.constexpr, USE_DIRECT: tl.constexpr):
+    tl.assume(sam > 0)
+    tl.assume(sak > 0)
+    tl.assume(sbn > 0)
+    tl.assume(sbk > 0)
+    npn = tl.cdiv(N, BLOCK_N)
+    pidf = _chip(tl.program_id(0), NUM_TILES, NUM_XCDS, GRID_MN)
+    bid = pidf // GRID_MN
+    pid = pidf % GRID_MN
+    pm = pid // npn
+    pn = pid % npn
+    a_sh: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases([(512, 16)], A_BASES, [BLOCK_M, BLOCK_K])
+    b_sh: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases([(512, 16)], _B_BASES, [BLOCK_K, BLOCK_N])
+    sA = tlx.local_alloc((BLOCK_M, BLOCK_K), tl.float16, NB, layout=a_sh)
+    sB = tlx.local_alloc((BLOCK_K, BLOCK_N), tl.float16, NB, layout=b_sh)
+    om = (pm * BLOCK_M + tl.arange(0, BLOCK_M)) % M
+    on = (pn * BLOCK_N + tl.arange(0, BLOCK_N)) % N
+    ok = tl.arange(0, BLOCK_K)
+    a_ptr = a_ptr + bid.to(tl.int64) * sab
+    b_ptr = b_ptr + bid.to(tl.int64) * sbb
+    ao = om[:, None] * sam
+    bo = on[None, :] * sbn
+    KI = tl.cdiv(K, BLOCK_K)
+
+    # ---- prologue: prime NB LDS buffers ----
+    for i in tl.range(0, NB, loop_unroll_factor=NB):
+        kk = i * BLOCK_K
+        if USE_DIRECT:
+            tlx.buffer_load_to_local(tlx.local_view(sA, i), a_ptr, ao + (kk + ok[None, :]) * sak)
+            tlx.buffer_load_to_local(tlx.local_view(sB, i), b_ptr, (kk + ok[:, None]) * sbk + bo)
+            tlx.async_load_commit_group()
+        else:
+            km = (kk + ok) < K
+            ar = tl.load(a_ptr + ao + (kk + ok[None, :]) * sak, mask=km[None, :], other=0.0)
+            br = tl.load(b_ptr + (kk + ok[:, None]) * sbk + bo, mask=km[:, None], other=0.0)
+            tlx.local_store(tlx.local_view(sA, i), ar)
+            tlx.local_store(tlx.local_view(sB, i), br)
+    if USE_DIRECT:
+        tlx.async_load_wait_group(NB - 2)
+    else:
+        tl.debug_barrier()
+    a = tlx.local_load(tlx.local_view(sA, 0))
+    b = tlx.local_load(tlx.local_view(sB, 0))
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    # ---- steady-state pipeline: compute tile k while prefetching tile k+NB ----
+    for k in tl.range(0, KI - NB):
+        cur = (k + 1) % NB
+        pf = k % NB
+        kp = (k + NB) * BLOCK_K
+        acc = tl.dot(a, b, acc)
+        if USE_DIRECT:
+            tlx.buffer_load_to_local(tlx.local_view(sA, pf), a_ptr, ao + (kp + ok[None, :]) * sak)
+            tlx.buffer_load_to_local(tlx.local_view(sB, pf), b_ptr, (kp + ok[:, None]) * sbk + bo)
+            tlx.async_load_commit_group()
+            tlx.async_load_wait_group(NB - 2)
+        else:
+            km = (kp + ok) < K
+            ar = tl.load(a_ptr + ao + (kp + ok[None, :]) * sak, mask=km[None, :], other=0.0)
+            br = tl.load(b_ptr + (kp + ok[:, None]) * sbk + bo, mask=km[:, None], other=0.0)
+            tlx.local_store(tlx.local_view(sA, pf), ar)
+            tlx.local_store(tlx.local_view(sB, pf), br)
+            tl.debug_barrier()
+        a = tlx.local_load(tlx.local_view(sA, cur))
+        b = tlx.local_load(tlx.local_view(sB, cur))
+
+    # ---- epilogue: drain the last NB tiles ----
+    acc = tl.dot(a, b, acc)
+    if USE_DIRECT:
+        tlx.async_load_wait_group(0)
+    for i in tl.range(0, NB - 1, loop_unroll_factor=NB - 1):
+        bf = (KI - (NB - 1) + i) % NB
+        acc = tl.dot(tlx.local_load(tlx.local_view(sA, bf)), tlx.local_load(tlx.local_view(sB, bf)), acc)
+
+    # ---- 4-warp coalesced split-store ----
+    et = c_ptr.dtype.element_ty
+    cb = c_ptr + bid.to(tl.int64) * scb
+    HN: tl.constexpr = BLOCK_N // 2
+    rm = pm * BLOCK_M + tl.arange(0, BLOCK_M)
+    rnl = pn * BLOCK_N + tl.arange(0, HN)
+    rnr = rnl + HN
+    mm = rm[:, None] < M
+    al, ar2 = tl.split(tl.trans(tl.reshape(acc, BLOCK_M, 2, HN), 0, 2, 1))
+    tl.store(cb + scm * rm[:, None] + scn * rnl[None, :], tlx.require_layout(al.to(et), _C4),
+             mask=mm & (rnl[None, :] < N))
+    tl.store(cb + scm * rm[:, None] + scn * rnr[None, :], tlx.require_layout(ar2.to(et), _C4),
+             mask=mm & (rnr[None, :] < N))
+
+
+def bmm(a, b, block_m=None, nw=4, nb=None):
+    """C = A @ B batched. a (B, M, K) row-major; b (B, K, N) COLUMN-major (stride_bk == 1)."""
+    assert a.ndim == 3 and b.ndim == 3 and a.shape[0] == b.shape[0]
+    Bs, M, K = a.shape
+    _, _, N = b.shape
+    bm = block_m or int(os.environ.get("BM_BMM", "128"))
+    A_BASES = tuple(tuple(x) for x in _swz([bm, BLOCK_K], 1))
+    nb = nb or int(os.environ.get("NB_BMM", NB))
+    nb = min(nb, triton.cdiv(K, BLOCK_K))  # prologue needs KI >= NB
+    use_direct = (K % BLOCK_K == 0)  # aligned, no K-tail -> fast direct-to-LDS
+    GM = triton.cdiv(M, bm) * triton.cdiv(N, BLOCK_N)
+    NT = Bs * GM
+    c = torch.empty((Bs, M, N), device=a.device, dtype=a.dtype)
+    amd_bmm_kernel[(NT, )](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        a.stride(2),
+        b.stride(0),
+        b.stride(1),
+        b.stride(2),
+        c.stride(0),
+        c.stride(1),
+        c.stride(2),
+        BLOCK_M=bm,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        A_BASES=A_BASES,
+        NUM_XCDS=NUM_XCDS,
+        GRID_MN=GM,
+        NUM_TILES=NT,
+        NB=nb,
+        USE_DIRECT=use_direct,
+        num_warps=nw,
+        num_stages=1,
+        matrix_instr_nonkdim=16,
+        llvm_fn_attrs=(("amdgpu-agpr-alloc", "0,0"), ),
+    )
+    return c
+
+
+def make_bmm_inputs(B, M, N, K, device, dtype=torch.float16, seed=0):
+    """SHARED-A (the shared-LHS layout): a single (M, K) matrix reused
+    across the whole batch via ``expand`` -> ``a.stride(0) == 0`` (mat1 batch-stride 0).
+    rocBLAS/hipBLASLt exploits this to read A once from HBM (L2-resident), so it is MUCH
+    faster than distinct-A -> we ALWAYS benchmark shared-A; distinct-A flatters TLX.
+    B is (B, K, N) COLUMN-major (built as (B, N, K) then transposed); C is (B, M, N) row-major.
+    """
+    g = torch.Generator(device=device).manual_seed(seed)
+    a = torch.randn((M, K), device=device, dtype=dtype, generator=g).unsqueeze(0).expand(B, M, K)
+    b = torch.randn((B, N, K), device=device, dtype=dtype, generator=g).transpose(1, 2)  # (B, K, N) col-major
+    return a, b
+
+
+if __name__ == "__main__":
+    dev = triton.runtime.driver.active.get_active_torch_device()
+    # (M, N, K, B): mix of aligned (direct-to-LDS) and odd/unaligned (register) K.
+    shapes = [(1024, 256, 256, 320), (395, 256, 320, 1024), (140, 256, 1888, 1024), (262, 256, 294, 1024),
+              (40, 256, 1956, 1024), (176, 256, 257, 1024), (1195, 256, 2309, 1024), (433, 256, 2352, 1024)]
+    print(f"{'M x N x K (B)':<24}{'path':<9}{'max_err':<10}{'result'}")
+    for M, N, K, B in shapes:
+        a, b = make_bmm_inputs(B, M, N, K, dev)
+        ref = torch.bmm(a.float(), b.float())
+        out = bmm(a, b).float()
+        err = (out - ref).abs().max().item()
+        path = "direct" if K % BLOCK_K == 0 else "register"
+        print(f"{f'{M}x{N}x{K} ({B})':<24}{path:<9}{err:<10.4f}{'OK' if err < 0.15 else 'FAIL'}")

--- a/third_party/tlx/tutorials/amd_bmm_shared_perf.py
+++ b/third_party/tlx/tutorials/amd_bmm_shared_perf.py
@@ -1,0 +1,220 @@
+"""Shared-A batched GEMM (BMM) for gfx950 / CDNA4 — ROW-major B (shared-LHS).
+
+Companion to ``amd_bmm.py`` (which uses COLUMN-major B). This file targets the
+standard torch.bmm / inductor layout and is the reproducer for the shared-A
+perf comparison against rocBLAS.
+
+LAYOUT (shared-LHS batched GEMM):
+  * A: shared-A — one (M, K) matrix reused across the whole batch, ``a.stride(0) == 0``
+    (mat1 batch-stride 0). rocBLAS/hipBLASLt exploits this to read A once from HBM
+    (it stays L2-resident), so it is 1.5-2.4x faster than distinct-A. BENCHMARK
+    AGAINST SHARED-A, not distinct-A, or the comparison flatters TLX.
+  * B: (B, K, N) ROW-major (N-contiguous, ``stride_bn == 1``) — standard torch.bmm.
+  * C: (B, M, N) row-major.
+
+WINNING CONFIG for this row-major layout (differs from amd_bmm.py's column-major):
+  * num_warps = 8, matrix_instr_nonkdim = 32 (32x32 MFMA). These are latency/MFMA
+    levers for this occupancy-bound BMM family; nw=8 beats the column-major kernel's
+    nw=4 here (nw=8 does NOT compile with the column-major swizzle+split-store).
+  * Dual load-path by K alignment (``K % 8 == 0`` -> 16-byte-aligned A rows):
+      - aligned  -> direct-to-LDS (buffer_load_to_local) + swizzled LDS. WINS rocBLAS.
+      - odd K    -> register path (tl.load -> local_store), masked K-tail.
+
+PERF (Triton beta + ROCm 7.0, MI350X, warm device time, shared-A; ratio = rocBLAS/TLX,
+>1 = TLX ahead). EVERY shape is an improvement target -- we do not want to regress the
+ones we are ahead on, and we need to close the rest; more is always better:
+    shape (MxNxK)     B      TLX      rocBLAS   ratio    path   status
+    1024x256x256     320     77us      82us     1.07x    direct  ahead, want more
+    395x256x320     1024    144us     155us     1.08x    direct  ahead, want more
+    40x256x1956     1024    196us     188us     0.96x    reg     NEEDS WORK
+    262x256x294     1024    133us      92us     0.69x    reg     NEEDS WORK
+    1195x256x2309   1024   2739us    1966us     0.72x    reg     NEEDS WORK
+
+ODD-K CEILING: the register-path shapes (40, 262, 1195) trail because A's odd K forces
+16-bit A loads. rocBLAS handles this with ``buffer_load_short_d16``/``_d16_hi`` —
+16-bit loads PACKED 2 fp16 per VGPR (half the registers -> higher occupancy). It
+does NOT use wide unaligned loads (hardware needs 16B alignment for dwordx4; we
+verified forcing it gives wrong results). Triton's AMD backend emits
+``buffer_load_ushort`` (zero-extend, 1 fp16/reg) instead -> the remaining gap is
+this d16-packing codegen difference, not tiling/config.
+"""
+import torch
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+from triton.testing import do_bench
+
+BLOCK_N = 256
+BLOCK_K = 32
+NUM_XCDS = 8
+NB = 3
+
+
+def _swz(shape, cd):
+    def basis(d, i):
+        return [1 << i, 0] if d == 0 else [0, 1 << i]
+
+    fd = 1 - cd
+    cb = int(shape[cd]).bit_length() - 1
+    fb = int(shape[fd]).bit_length() - 1
+    return ([basis(cd, i) for i in range(cb)] + [basis(fd, i)
+                                                 for i in range(4, fb)] + [basis(fd, i) for i in range(min(4, fb))])
+
+
+@triton.jit
+def _chip(pid, nt, nx: tl.constexpr, cs: tl.constexpr):
+    """L2 XCD-chunk remap: keep a batch's MN-tiles on one XCD (B stays hot in L2)."""
+    al = (nt // (nx * cs)) * (nx * cs)
+    if pid >= al:
+        return pid
+    x = pid % nx
+    lp = pid // nx
+    return (lp // cs) * nx * cs + x * cs + (lp % cs)
+
+
+@triton.jit
+def _bmm_direct(a_ptr, b_ptr, c_ptr, M, N, K, sab, sam, sak, sbb, sbk, sbn, scb, scm, scn,
+                BM: tl.constexpr, BN: tl.constexpr, BK: tl.constexpr, AB: tl.constexpr, BB: tl.constexpr,
+                NUM_XCDS: tl.constexpr, GMN: tl.constexpr, NT: tl.constexpr, NB: tl.constexpr):
+    """Aligned rows (K % 8 == 0): direct-to-LDS + swizzled LDS."""
+    npn = tl.cdiv(N, BN)
+    pidf = _chip(tl.program_id(0), NT, NUM_XCDS, GMN)
+    bid = pidf // GMN; pid = pidf % GMN; pm = pid // npn; pn = pid % npn
+    ash: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases([(512, 16)], AB, [BM, BK])
+    bsh: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases([(512, 16)], BB, [BK, BN])
+    sA = tlx.local_alloc((BM, BK), tl.float16, NB, layout=ash)
+    sB = tlx.local_alloc((BK, BN), tl.float16, NB, layout=bsh)
+    om = (pm * BM + tl.arange(0, BM)) % M; on = (pn * BN + tl.arange(0, BN)) % N; ok = tl.arange(0, BK)
+    a_ptr = a_ptr + bid.to(tl.int64) * sab; b_ptr = b_ptr + bid.to(tl.int64) * sbb
+    ao = om[:, None] * sam; bo = on[None, :] * sbn; KI = tl.cdiv(K, BK)
+    for i in tl.range(0, NB, loop_unroll_factor=NB):
+        kk = i * BK
+        tlx.buffer_load_to_local(tlx.local_view(sA, i), a_ptr, ao + (kk + ok[None, :]) * sak)
+        tlx.buffer_load_to_local(tlx.local_view(sB, i), b_ptr, (kk + ok[:, None]) * sbk + bo)
+        tlx.async_load_commit_group()
+    tlx.async_load_wait_group(NB - 2)
+    a = tlx.local_load(tlx.local_view(sA, 0)); b = tlx.local_load(tlx.local_view(sB, 0))
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for k in tl.range(0, KI - NB):
+        cur = (k + 1) % NB; pf = k % NB; kp = (k + NB) * BK
+        acc = tl.dot(a, b, acc)
+        tlx.buffer_load_to_local(tlx.local_view(sA, pf), a_ptr, ao + (kp + ok[None, :]) * sak)
+        tlx.buffer_load_to_local(tlx.local_view(sB, pf), b_ptr, (kp + ok[:, None]) * sbk + bo)
+        tlx.async_load_commit_group(); tlx.async_load_wait_group(NB - 2)
+        a = tlx.local_load(tlx.local_view(sA, cur)); b = tlx.local_load(tlx.local_view(sB, cur))
+    acc = tl.dot(a, b, acc)
+    tlx.async_load_wait_group(0)
+    for i in tl.range(0, NB - 1, loop_unroll_factor=NB - 1):
+        bf = (KI - (NB - 1) + i) % NB
+        acc = tl.dot(tlx.local_load(tlx.local_view(sA, bf)), tlx.local_load(tlx.local_view(sB, bf)), acc)
+    et = c_ptr.dtype.element_ty; cb = c_ptr + bid.to(tl.int64) * scb
+    rm = pm * BM + tl.arange(0, BM); rn = pn * BN + tl.arange(0, BN)
+    tl.store(cb + scm * rm[:, None] + scn * rn[None, :], acc.to(et), mask=(rm[:, None] < M) & (rn[None, :] < N))
+
+
+@triton.jit
+def _bmm_register(a_ptr, b_ptr, c_ptr, M, N, K, sab, sam, sak, sbb, sbk, sbn, scb, scm, scn,
+                  BM: tl.constexpr, BN: tl.constexpr, BK: tl.constexpr,
+                  NUM_XCDS: tl.constexpr, GMN: tl.constexpr, NT: tl.constexpr, NB: tl.constexpr):
+    """Odd / unaligned K: register path (tl.load -> local_store), masked K-tail."""
+    npn = tl.cdiv(N, BN)
+    pidf = _chip(tl.program_id(0), NT, NUM_XCDS, GMN)
+    bid = pidf // GMN; pid = pidf % GMN; pm = pid // npn; pn = pid % npn
+    sA = tlx.local_alloc((BM, BK), tl.float16, NB); sB = tlx.local_alloc((BK, BN), tl.float16, NB)
+    om = (pm * BM + tl.arange(0, BM)) % M; on = (pn * BN + tl.arange(0, BN)) % N; ok = tl.arange(0, BK)
+    a_ptr = a_ptr + bid.to(tl.int64) * sab; b_ptr = b_ptr + bid.to(tl.int64) * sbb
+    ao = om[:, None] * sam; bo = on[None, :] * sbn; KI = tl.cdiv(K, BK)
+    for i in tl.range(0, NB, loop_unroll_factor=NB):
+        kk = i * BK; km = (kk + ok) < K
+        ar = tl.load(a_ptr + ao + (kk + ok[None, :]) * sak, mask=km[None, :], other=0.0)
+        br = tl.load(b_ptr + (kk + ok[:, None]) * sbk + bo, mask=km[:, None], other=0.0)
+        tlx.local_store(tlx.local_view(sA, i), ar); tlx.local_store(tlx.local_view(sB, i), br)
+    tl.debug_barrier()
+    a = tlx.local_load(tlx.local_view(sA, 0)); b = tlx.local_load(tlx.local_view(sB, 0))
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for k in tl.range(0, KI - NB):
+        cur = (k + 1) % NB; pf = k % NB; kp = (k + NB) * BK
+        acc = tl.dot(a, b, acc)
+        km = (kp + ok) < K
+        ar = tl.load(a_ptr + ao + (kp + ok[None, :]) * sak, mask=km[None, :], other=0.0)
+        br = tl.load(b_ptr + (kp + ok[:, None]) * sbk + bo, mask=km[:, None], other=0.0)
+        tlx.local_store(tlx.local_view(sA, pf), ar); tlx.local_store(tlx.local_view(sB, pf), br)
+        tl.debug_barrier()
+        a = tlx.local_load(tlx.local_view(sA, cur)); b = tlx.local_load(tlx.local_view(sB, cur))
+    acc = tl.dot(a, b, acc)
+    for i in tl.range(0, NB - 1, loop_unroll_factor=NB - 1):
+        bf = (KI - (NB - 1) + i) % NB
+        acc = tl.dot(tlx.local_load(tlx.local_view(sA, bf)), tlx.local_load(tlx.local_view(sB, bf)), acc)
+    et = c_ptr.dtype.element_ty; cb = c_ptr + bid.to(tl.int64) * scb
+    rm = pm * BM + tl.arange(0, BM); rn = pn * BN + tl.arange(0, BN)
+    tl.store(cb + scm * rm[:, None] + scn * rn[None, :], acc.to(et), mask=(rm[:, None] < M) & (rn[None, :] < N))
+
+
+def bmm(a, b):
+    """C = A @ B, shared-A, ROW-major B (stride_bn == 1). nw=8, mfma=32."""
+    Bs, M, K = a.shape
+    N = b.shape[-1]
+    bm = 64 if M <= 64 else 128
+    nb = min(NB, triton.cdiv(K, BLOCK_K))
+    GMN = triton.cdiv(M, bm) * triton.cdiv(N, BLOCK_N)
+    NT = Bs * GMN
+    c = torch.empty((Bs, M, N), device=a.device, dtype=a.dtype)
+    attrs = (("amdgpu-agpr-alloc", "0,0"), )
+    common = dict(num_warps=8, num_stages=1, matrix_instr_nonkdim=32, llvm_fn_attrs=attrs)
+    st = (a.stride(0), a.stride(1), a.stride(2), b.stride(0), b.stride(1), b.stride(2), c.stride(0), c.stride(1),
+          c.stride(2))
+    if K % 8 == 0:  # 16-byte-aligned A rows -> direct-to-LDS (wins)
+        AB = tuple(tuple(x) for x in _swz([bm, BLOCK_K], 1))
+        BB = tuple(tuple(x) for x in _swz([BLOCK_K, BLOCK_N], 1))
+        _bmm_direct[(NT, )](a, b, c, M, N, K, *st, BM=bm, BN=BLOCK_N, BK=BLOCK_K, AB=AB, BB=BB, NUM_XCDS=NUM_XCDS,
+                            GMN=GMN, NT=NT, NB=nb, **common)
+    else:  # odd / unaligned K -> register path
+        _bmm_register[(NT, )](a, b, c, M, N, K, *st, BM=bm, BN=BLOCK_N, BK=BLOCK_K, NUM_XCDS=NUM_XCDS, GMN=GMN, NT=NT,
+                              NB=nb, **common)
+    return c
+
+
+def make_bmm_inputs(B, M, N, K, device, dtype=torch.float16, seed=0):
+    """SHARED-A: one (M,K) reused across the batch -> a.stride(0)==0. B row-major.
+
+    We always use shared-A: it is the shared-LHS layout, and distinct-A flatters TLX
+    (rocBLAS reads shared-A once from HBM, so it is much faster on distinct-A).
+    """
+    g = torch.Generator(device=device).manual_seed(seed)
+    a = torch.randn((M, K), device=device, dtype=dtype, generator=g).unsqueeze(0).expand(B, M, K)
+    b = torch.randn((B, K, N), device=device, dtype=dtype, generator=g)  # row-major (stride_bn == 1)
+    return a, b
+
+
+def _warm_ms(fn, iters=60, warmup=20):
+    """Warm device time (L2 hot, back-to-back) — matches rocprofv3 kernel-trace, no launch tax."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    s = torch.cuda.Event(enable_timing=True)
+    e = torch.cuda.Event(enable_timing=True)
+    s.record()
+    for _ in range(iters):
+        fn()
+    e.record()
+    torch.cuda.synchronize()
+    return s.elapsed_time(e) / iters
+
+
+if __name__ == "__main__":
+    dev = triton.runtime.driver.active.get_active_torch_device()
+    # (B, M, N, K): representative shared-LHS shapes.  Always shared-A.
+    shapes = [(320, 1024, 256, 256), (1024, 395, 256, 320), (1024, 40, 256, 1956), (1024, 262, 256, 294),
+              (1024, 1195, 256, 2309)]
+    print("mode: shared-A (shared-LHS)   (B row-major)")
+    print(f"{'M x N x K (B)':<22}{'path':<8}{'TLX':>9}{'rocBLAS':>10}{'ratio':>8}  {'ok'}")
+    for B, M, N, K in shapes:
+        a, b = make_bmm_inputs(B, M, N, K, dev)
+        ref = torch.bmm(a, b)
+        out = bmm(a, b)
+        ok = torch.allclose(out.float(), ref.float(), atol=2e-2, rtol=2e-2)
+        t = _warm_ms(lambda: bmm(a, b)) * 1e3
+        rb = _warm_ms(lambda: torch.bmm(a, b)) * 1e3
+        path = "direct" if K % 8 == 0 else "reg"
+        print(f"{f'{M}x{N}x{K} ({B})':<22}{path:<8}{t:8.0f}u{rb:9.0f}u{rb / t:7.2f}x  {'OK' if ok else 'WRONG'}")

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/aiter_baseline_repro.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/aiter_baseline_repro.py
@@ -1,0 +1,684 @@
+#!/usr/bin/env python3
+"""Benchmark the TLX MXFP4 (A4W4) GEMM against the AITER baseline on gfx950.
+
+The **baseline is AITER** (`aiter.ops.gemm_op_a4w4.gemm_a4w4`, its tuned assembly
+`_ZN...` kernel with pre-shuffled B). This script runs the *unchanged* public TLX
+A4W4 matmul next to that AITER baseline on the same inputs, checks both against a
+FP32-dequantized reference, and reports TLX latency relative to the AITER
+baseline. It is fully self-contained: no external product, serving, or framework
+dependencies.
+
+We are sharing this to ask for help closing the gap to the AITER baseline: on
+large shapes the TLX kernel is materially slower, and we would like guidance on
+what the AITER assembly kernels do that a Triton/TLX kernel can replicate (MFMA
+selection, pipeline depth, B pre-shuffle, scheduling).
+
+Requirements: a single gfx950 (CDNA4) GPU, ROCm PyTorch, Triton with TLX, and an
+AITER build that has tuned A4W4 configs for the benchmarked shapes.
+
+Example:
+
+    HIP_VISIBLE_DEVICES=0 python \
+      third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/aiter_baseline_repro.py \
+      --tlx-inter-wave-source third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py \
+      --tlx-intra-wave-source third_party/tlx/tutorials/gfx9_gemm/intra_wave/a4w4/matmul_kernel.py \
+      --json /tmp/a4w4_vs_aiter.json
+
+Use --tlx-inter-wave-source to load matmul_kernel.py directly from a checkout. The source
+hash is checked by default so the kernel under test cannot silently drift; pass
+--allow-source-mismatch to benchmark a modified kernel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import importlib
+import importlib.metadata
+import importlib.util
+import json
+import math
+import os
+import statistics
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Protocol
+
+import torch
+import triton
+
+# Kernel under test: the in-repo inter_wave matmul_kernel.py shipped in this change
+# (co-located under this tutorials tree, including the skinny-gate dispatch tweak
+# that routes grid_256 <= NUM_CU//4 to the 128-tile split-K path). EXPECTED_TLX_SHA256
+# pins that exact file so the benchmarked kernel cannot silently drift; pass
+# --allow-source-mismatch to benchmark a modified copy. AITER is the baseline.
+EXPECTED_TLX_SHA256 = "5808240cc31ce9c30238678cfbad437eedae56745a2a830342b788e0f93f350d"
+TLX_MODULE = (
+    "triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a4w4.matmul_kernel"
+)
+# Second TLX variant: the 4-wave intra_wave kernel (same public matmul() ABI).
+# Not hash-pinned, so it can track the checked-in intra_wave kernel.
+TLX_INTRA_MODULE = (
+    "triton.language.extra.tlx.tutorials.gfx9_gemm.intra_wave.a4w4.matmul_kernel"
+)
+
+# AITER baseline: the public gemm_a4w4 assembly path with pre-shuffled B.
+AITER_BASE_COMMIT = "3ccc08d20c465c2617b393177d45405245032528"
+AITER_BASE_URL = f"https://github.com/ROCm/aiter/commit/{AITER_BASE_COMMIT}"
+
+SCALE_GROUP_SIZE = 32
+DEFAULT_SHAPES = (
+    # small / occupancy-starved shapes
+    (256, 4096, 4096),
+    (256, 8192, 4096),
+    (512, 4096, 4096),
+    (512, 8192, 4096),
+    # large / well-filled shapes (the gap to the AITER baseline is largest here)
+    (2048, 4096, 8192),
+    (2048, 8192, 4096),
+    (2048, 8192, 8192),
+)
+
+
+@dataclass(frozen=True)
+class Timing:
+    median_us: float
+    mad_us: float
+    p10_us: float
+    p90_us: float
+    mean_us: float
+    stdev_us: float
+    cv_percent: float
+    minimum_us: float
+    maximum_us: float
+    samples: int
+
+
+class Runner(Protocol):
+    name: str
+
+    def __call__(self) -> torch.Tensor: ...
+
+
+class L2Flusher:
+    def __init__(self, mib: int) -> None:
+        self.buffer = torch.zeros(
+            mib * 1024 * 1024 // 4,
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+    def flush(self) -> None:
+        self.buffer.add_(1)
+
+
+class TlxRunner:
+    def __init__(self, name, module, a, b, a_scales, b_scales) -> None:
+        self.name = name
+        self.module = module
+        self.a = a
+        self.b = b
+        self.a_scales = a_scales
+        self.b_scales = b_scales
+
+    def __call__(self) -> torch.Tensor:
+        return self.module.matmul(
+            self.a,
+            self.b,
+            self.a_scales,
+            self.b_scales,
+        )
+
+
+class AiterBaselineRunner:
+    name = "aiter_baseline_gemm_a4w4"
+
+    def __init__(self, a, b, a_scales, b_scales) -> None:
+        from aiter.ops.gemm_op_a4w4 import gemm_a4w4, get_GEMM_config
+        from aiter.ops.shuffle import shuffle_scale, shuffle_weight
+
+        self.gemm = gemm_a4w4
+        self.a = a
+        self.b = shuffle_weight(b)
+        self.a_scales = shuffle_scale(a_scales.contiguous())
+        self.b_scales = shuffle_scale(b_scales.contiguous())
+        self.config = get_GEMM_config(a.shape[0], b.shape[0], a.shape[1] * 2)
+        if self.config is None:
+            raise RuntimeError(
+                "AITER baseline has no tuned configuration for "
+                f"M={a.shape[0]}, N={b.shape[0]}, K={a.shape[1] * 2}"
+            )
+        if "_ZN" not in self.config["kernelName"]:
+            raise RuntimeError(
+                f"Expected a tuned AITER assembly kernel, got {self.config}"
+            )
+
+    def __call__(self) -> torch.Tensor:
+        return self.gemm(
+            self.a,
+            self.b,
+            self.a_scales,
+            self.b_scales,
+            bpreshuffle=True,
+        )
+
+
+def parse_shape(raw: str) -> tuple[int, int, int]:
+    pieces = raw.lower().replace("x", ",").split(",")
+    if len(pieces) != 3:
+        raise argparse.ArgumentTypeError(f"Expected MxNxK, got {raw!r}")
+    shape = tuple(int(piece) for piece in pieces)
+    if any(value <= 0 for value in shape):
+        raise argparse.ArgumentTypeError(f"Shape must be positive, got {shape}")
+    return shape
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Benchmark the TLX A4W4 matmul against the AITER baseline."
+    )
+    parser.add_argument(
+        "--shape",
+        action="append",
+        type=parse_shape,
+        dest="shapes",
+        help="M x N x K shape; repeat for multiple shapes",
+    )
+    parser.add_argument(
+        "--tlx-inter-wave-source",
+        type=Path,
+        help="load the inter_wave matmul_kernel.py directly instead of the installed module",
+    )
+    parser.add_argument(
+        "--tlx-intra-wave-source",
+        type=Path,
+        help="load the intra_wave matmul_kernel.py to also benchmark it (optional)",
+    )
+    parser.add_argument(
+        "--no-intra",
+        action="store_true",
+        help="skip the intra_wave variant even if it is available",
+    )
+    parser.add_argument(
+        "--allow-source-mismatch",
+        action="store_true",
+        help="allow a TLX source hash other than the pinned kernel under test",
+    )
+    parser.add_argument("--warmups", type=int, default=20)
+    parser.add_argument("--samples", type=int, default=100)
+    parser.add_argument("--timing-rounds", type=int, default=3)
+    parser.add_argument("--flush-mib", type=int, default=256)
+    parser.add_argument("--seed", type=int, default=20260730)
+    parser.add_argument("--json", type=Path)
+    args = parser.parse_args()
+    args.shapes = args.shapes or list(DEFAULT_SHAPES)
+    for name in ("warmups", "samples", "timing_rounds", "flush_mib"):
+        if getattr(args, name) <= 0:
+            parser.error(f"--{name.replace('_', '-')} must be positive")
+    return args
+
+
+def package_version(*names: str) -> str:
+    for name in names:
+        try:
+            return importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return "unknown"
+
+
+def runtime_metadata() -> dict:
+    if not torch.cuda.is_available() or torch.version.hip is None:
+        raise RuntimeError("This repro requires ROCm PyTorch")
+    if torch.cuda.device_count() != 1:
+        raise RuntimeError(
+            "Expose exactly one GPU with HIP_VISIBLE_DEVICES; got "
+            f"{torch.cuda.device_count()} visible GPUs"
+        )
+    properties = torch.cuda.get_device_properties(0)
+    if not properties.gcnArchName.startswith("gfx950"):
+        raise RuntimeError(
+            f"The kernel under test requires gfx950, got {properties.gcnArchName}"
+        )
+    metadata = {
+        "hip_visible_devices": os.environ.get("HIP_VISIBLE_DEVICES"),
+        "device_name": properties.name,
+        "arch": properties.gcnArchName,
+        "compute_units": properties.multi_processor_count,
+        "vram_bytes": properties.total_memory,
+        "torch": torch.__version__,
+        "hip": torch.version.hip,
+        "triton": triton.__version__,
+        "aiter": package_version("amd-aiter", "aiter"),
+        "python": sys.version.split()[0],
+        "argv": sys.argv,
+    }
+    print(f"runtime={json.dumps(metadata, sort_keys=True)}", flush=True)
+    return metadata
+
+
+def load_tlx_module(
+    source_arg: Path | None,
+    allow_source_mismatch: bool,
+    module_name: str,
+    expected_sha256: str | None,
+    unique_name: str,
+) -> tuple[ModuleType, Path, str]:
+    if source_arg is None:
+        spec = importlib.util.find_spec(module_name)
+        if spec is None or spec.origin is None:
+            raise RuntimeError(f"Could not find installed TLX module {module_name}")
+        source = Path(spec.origin).resolve()
+    else:
+        source = source_arg.resolve()
+        if not source.is_file():
+            raise FileNotFoundError(source)
+
+    digest = hashlib.sha256(source.read_bytes()).hexdigest()
+    if (
+        expected_sha256 is not None
+        and digest != expected_sha256
+        and not allow_source_mismatch
+    ):
+        raise RuntimeError(
+            f"TLX source SHA256 mismatch: expected {expected_sha256}, "
+            f"got {digest} at {source}. Use --allow-source-mismatch only when "
+            "intentionally testing a modified kernel."
+        )
+
+    if source_arg is None:
+        module = importlib.import_module(module_name)
+    else:
+        spec = importlib.util.spec_from_file_location(unique_name, source)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"Could not load TLX source {source}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+
+    print(f"tlx_source={source} sha256={digest} expected={expected_sha256}", flush=True)
+    return module, source, digest
+
+
+def mxfp4_to_f32(packed: torch.Tensor) -> torch.Tensor:
+    unpacked = packed.repeat_interleave(2, dim=1)
+    unpacked[:, ::2] &= 0xF
+    unpacked[:, 1::2] >>= 4
+    values = torch.tensor(
+        [
+            0.0,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.0,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+        ],
+        dtype=torch.float32,
+        device=packed.device,
+    )
+    return values[unpacked.long()]
+
+
+def e8m0_to_f32(scales: torch.Tensor) -> torch.Tensor:
+    exponent = scales.to(torch.int16).to(torch.float32) - 127.0
+    return torch.pow(2.0, exponent)
+
+
+def make_inputs(m: int, n: int, k: int, seed: int):
+    if k % (2 * SCALE_GROUP_SIZE) != 0:
+        raise ValueError(f"K must be divisible by {2 * SCALE_GROUP_SIZE}, got {k}")
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed + m * 17 + n)
+    a = torch.randint(
+        0,
+        256,
+        (m, k // 2),
+        dtype=torch.uint8,
+        device="cuda",
+        generator=generator,
+    )
+    b = torch.randint(
+        0,
+        256,
+        (n, k // 2),
+        dtype=torch.uint8,
+        device="cuda",
+        generator=generator,
+    )
+
+    # TLX requires row scales to be contiguous in the M/N dimension.
+    padded_m = triton.cdiv(m, 256) * 256
+    a_scales = torch.randint(
+        124,
+        128,
+        (k // SCALE_GROUP_SIZE, padded_m),
+        dtype=torch.uint8,
+        device="cuda",
+        generator=generator,
+    ).T[:m]
+    b_scales = torch.randint(
+        124,
+        128,
+        (k // SCALE_GROUP_SIZE, n),
+        dtype=torch.uint8,
+        device="cuda",
+        generator=generator,
+    ).T
+    if a_scales.stride(0) != 1 or b_scales.stride(0) != 1:
+        raise RuntimeError("TLX scale layout construction failed")
+    return a, b, a_scales, b_scales
+
+
+def reference(a, b, a_scales, b_scales) -> torch.Tensor:
+    a_f32 = mxfp4_to_f32(a)
+    a_f32 *= e8m0_to_f32(a_scales).repeat_interleave(
+        SCALE_GROUP_SIZE,
+        dim=1,
+    )
+    b_f32 = mxfp4_to_f32(b)
+    b_f32 *= e8m0_to_f32(b_scales).repeat_interleave(
+        SCALE_GROUP_SIZE,
+        dim=1,
+    )
+    output = torch.mm(a_f32, b_f32.T).to(torch.bfloat16)
+    del a_f32, b_f32
+    return output
+
+
+def validate_runner(runner: Runner, expected: torch.Tensor) -> dict:
+    first = runner().clone()
+    second = runner().clone()
+    torch.cuda.synchronize()
+    deterministic = torch.equal(first, second)
+    exact = torch.equal(first, expected)
+    difference = first.float() - expected.float()
+    metrics = {
+        "deterministic": deterministic,
+        "exact": exact,
+        "max_abs_error": float(difference.abs().max().item()),
+        "mean_abs_error": float(difference.abs().mean().item()),
+        "nan_count": int(torch.isnan(first).sum().item()),
+        "inf_count": int(torch.isinf(first).sum().item()),
+    }
+    del first, second, difference
+    if not deterministic:
+        raise RuntimeError(f"{runner.name} is not bitwise deterministic")
+    if not exact:
+        raise RuntimeError(
+            f"{runner.name} does not exactly match the BF16 reference: {metrics}"
+        )
+    print(f"correctness name={runner.name} {json.dumps(metrics, sort_keys=True)}")
+    return metrics
+
+
+def percentile(values: list[float], quantile: float) -> float:
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    return ordered[lower] * (upper - position) + ordered[upper] * (position - lower)
+
+
+def summarize(values: list[float]) -> Timing:
+    median = statistics.median(values)
+    mean = statistics.mean(values)
+    stdev = statistics.stdev(values) if len(values) > 1 else 0.0
+    return Timing(
+        median_us=median,
+        mad_us=statistics.median(abs(value - median) for value in values),
+        p10_us=percentile(values, 0.10),
+        p90_us=percentile(values, 0.90),
+        mean_us=mean,
+        stdev_us=stdev,
+        cv_percent=100.0 * stdev / mean,
+        minimum_us=min(values),
+        maximum_us=max(values),
+        samples=len(values),
+    )
+
+
+def benchmark_interleaved(
+    runners: list[Runner],
+    flusher: L2Flusher,
+    warmups: int,
+    samples: int,
+    rounds: int,
+) -> dict[str, dict]:
+    for runner in runners:
+        for _ in range(warmups):
+            output = runner()
+            del output
+    torch.cuda.synchronize()
+
+    all_samples = {runner.name: [] for runner in runners}
+    round_medians = {runner.name: [] for runner in runners}
+    for round_index in range(rounds):
+        round_samples = {runner.name: [] for runner in runners}
+        for sample_index in range(samples):
+            order = runners if (round_index + sample_index) % 2 == 0 else runners[::-1]
+            for runner in order:
+                flusher.flush()
+                start = torch.cuda.Event(enable_timing=True)
+                end = torch.cuda.Event(enable_timing=True)
+                start.record()
+                output = runner()
+                end.record()
+                end.synchronize()
+                elapsed_us = start.elapsed_time(end) * 1000.0
+                del output
+                round_samples[runner.name].append(elapsed_us)
+                all_samples[runner.name].append(elapsed_us)
+        for runner in runners:
+            round_medians[runner.name].append(
+                statistics.median(round_samples[runner.name])
+            )
+
+    return {
+        runner.name: {
+            "timing": asdict(summarize(all_samples[runner.name])),
+            "round_medians_us": round_medians[runner.name],
+        }
+        for runner in runners
+    }
+
+
+def tlx_dispatch(module, m: int, n: int) -> dict:
+    # Best-effort dispatch prediction; intra_wave may not expose these attrs.
+    block_m = getattr(module, "BLOCK_M", 256)
+    block_n = getattr(module, "BLOCK_N", 256)
+    grid_256 = triton.cdiv(m, block_m) * triton.cdiv(n, block_n)
+    info = {"grid_256": grid_256}
+    num_cu = getattr(module, "NUM_CU", None)
+    if num_cu is not None and hasattr(module, "SKINNY_BLOCK_M"):
+        skinny_threshold = num_cu // 4
+        info["skinny_threshold"] = skinny_threshold
+        info["expected_selected_dispatch"] = (
+            "skinny" if grid_256 <= skinny_threshold else "256tile"
+        )
+    else:
+        info["expected_selected_dispatch"] = "256tile"
+    return info
+
+
+def run_shape(tlx_variants, shape, args, flusher) -> dict:
+    m, n, k = shape
+    print(f"\nshape={m}x{n}x{k}", flush=True)
+    a, b, a_scales, b_scales = make_inputs(m, n, k, args.seed)
+    try:
+        aiter_runner = AiterBaselineRunner(a, b, a_scales, b_scales)
+    except RuntimeError as exc:
+        # This AITER build has no tuned A4W4 baseline for this shape; skip it
+        # rather than abort the whole sweep. Try a build with more tuned configs
+        # to benchmark these shapes against AITER.
+        print(f"skip shape={m}x{n}x{k} reason={exc}", flush=True)
+        del a, b, a_scales, b_scales
+        gc.collect()
+        torch.cuda.empty_cache()
+        return {"shape": list(shape), "skipped": str(exc)}
+
+    tlx_runners = [
+        TlxRunner(name, module, a, b, a_scales, b_scales)
+        for name, module in tlx_variants
+    ]
+    dispatch = {name: tlx_dispatch(module, m, n) for name, module in tlx_variants}
+    # AITER first: it is the baseline every TLX number is reported against.
+    runners: list[Runner] = [aiter_runner, *tlx_runners]
+
+    expected = reference(a, b, a_scales, b_scales)
+    torch.cuda.synchronize()
+    correctness = {runner.name: validate_runner(runner, expected) for runner in runners}
+    del expected
+    torch.cuda.empty_cache()
+
+    timings = benchmark_interleaved(
+        runners,
+        flusher,
+        args.warmups,
+        args.samples,
+        args.timing_rounds,
+    )
+    aiter_us = timings[aiter_runner.name]["timing"]["median_us"]
+    # speedup = AITER / TLX  ->  > 1.0 means TLX is FASTER (a win); < 1.0 is a regression.
+    speedup = {
+        r.name: aiter_us / timings[r.name]["timing"]["median_us"] for r in tlx_runners
+    }
+    result = {
+        "shape": list(shape),
+        "aiter_baseline_us": aiter_us,
+        "aiter_baseline_config": aiter_runner.config,
+        "tlx_dispatch": dispatch,
+        "correctness": correctness,
+        "timings": timings,
+        "tlx_speedup_over_aiter_baseline": speedup,
+    }
+    print(f"result={json.dumps(result, sort_keys=True)}", flush=True)
+
+    del runners, tlx_runners, aiter_runner, a, b, a_scales, b_scales
+    gc.collect()
+    torch.cuda.empty_cache()
+    return result
+
+
+def print_table(results: list[dict], variant_names: list[str]) -> None:
+    print("\nTLX vs AITER baseline (cold L2, GPU-event median)")
+    print("Speedup = AITER / TLX:  > 1.0 means TLX is FASTER (win); < 1.0 is a regression.")
+    header = f"{'M x N x K':>18} {'AITER us':>9}"
+    for name in variant_names:
+        header += f" {name + ' us':>{len(name) + 4}} {name + ' x':>{len(name) + 3}}"
+    print(header)
+    for result in results:
+        shape = "x".join(str(value) for value in result["shape"])
+        if "skipped" in result:
+            print(f"{shape:>18} {'skipped (no AITER baseline config)':>44}")
+            continue
+        aiter_us = result["aiter_baseline_us"]
+        row = f"{shape:>18} {aiter_us:9.2f}"
+        for name in variant_names:
+            uw, xw = len(name) + 4, len(name) + 3
+            if name in result["timings"]:
+                tlx_us = result["timings"][name]["timing"]["median_us"]
+                spd = result["tlx_speedup_over_aiter_baseline"][name]
+                row += f" {tlx_us:>{uw}.2f} {spd:>{xw}.3f}"
+            else:
+                row += f" {'--':>{uw}} {'--':>{xw}}"
+        print(row)
+
+
+def main() -> None:
+    args = parse_args()
+    runtime = runtime_metadata()
+
+    # inter_wave: the pinned, hash-checked primary kernel under test.
+    inter_module, inter_source, inter_digest = load_tlx_module(
+        args.tlx_inter_wave_source,
+        args.allow_source_mismatch,
+        TLX_MODULE,
+        EXPECTED_TLX_SHA256,
+        "tlx_a4w4_inter_kernel",
+    )
+    tlx_variants = [("inter_wave_TLX", inter_module)]
+    kernels_under_test = {
+        "inter_wave_TLX": {
+            "path": str(inter_source),
+            "sha256": inter_digest,
+            "expected_sha256": EXPECTED_TLX_SHA256,
+        }
+    }
+    # intra_wave: optional second variant (not hash-pinned).
+    if not args.no_intra:
+        try:
+            intra_module, intra_source, intra_digest = load_tlx_module(
+                args.tlx_intra_wave_source,
+                True,  # no pinned hash for intra_wave
+                TLX_INTRA_MODULE,
+                None,
+                "tlx_a4w4_intra_kernel",
+            )
+            tlx_variants.append(("intra_wave_TLX", intra_module))
+            kernels_under_test["intra_wave_TLX"] = {
+                "path": str(intra_source),
+                "sha256": intra_digest,
+            }
+        except Exception as exc:  # noqa: BLE001 - optional variant
+            print(f"intra_wave variant unavailable: {exc}", flush=True)
+
+    variant_names = [name for name, _ in tlx_variants]
+    protocol = {
+        "baseline": "AITER gemm_a4w4 (tuned assembly, pre-shuffled B)",
+        "warmups": args.warmups,
+        "samples_per_round": args.samples,
+        "timing_rounds": args.timing_rounds,
+        "flush_mib_per_sample": args.flush_mib,
+        "seed": args.seed,
+        "timing": "GPU events around unchanged public API calls",
+        "runner_order": "alternating",
+        "correctness": "exact BF16 equality against FP32-dequantized torch.mm",
+        "layout_conversion_timed": False,
+        "output_allocation_timed": True,
+        "input_layouts": {
+            "tlx": "raw packed A/B; scales contiguous in M/N dimension",
+            "aiter": "raw A; pre-shuffled B and A/B scales",
+        },
+        "scope": (
+            "public-wrapper device elapsed time, not preallocated kernel-only latency"
+        ),
+    }
+    print(f"protocol={json.dumps(protocol, sort_keys=True)}", flush=True)
+    flusher = L2Flusher(args.flush_mib)
+    results = [run_shape(tlx_variants, shape, args, flusher) for shape in args.shapes]
+    payload = {
+        "runtime": runtime,
+        "tlx_kernels_under_test": kernels_under_test,
+        "protocol": protocol,
+        "aiter_baseline": {
+            "api": "aiter.ops.gemm_op_a4w4.gemm_a4w4",
+            "installed_build": runtime["aiter"],
+            "public_base_commit": AITER_BASE_COMMIT,
+            "public_base_url": AITER_BASE_URL,
+            "note": "Absolute latency can differ with another AITER build.",
+        },
+        "results": results,
+    }
+    print_table(results, variant_names)
+    print(f"\nsummary={json.dumps(payload, sort_keys=True)}", flush=True)
+    if args.json is not None:
+        args.json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
@@ -872,11 +872,14 @@ def _matmul_skinny(a, b, a_scales, b_scales, SPLIT_K=None):
 
 def matmul(a, b, a_scales, b_scales):
     """A @ B.T for packed MXFP4 A/B. Dispatches on the 256-tile grid fill:
-    severely occupancy-starved shapes (e.g. skinny-N) take the 128x128 + split-K
-    TLX path; everything else takes the 256x256 inter-wave path."""
+    the 256x256 inter-wave tile only fills the GPU once its grid reaches ~half the
+    CUs; below that it wastes CUs (a 256x256 tile is 1 workgroup/CU), so route those
+    occupancy-starved shapes to the 128x128 + split-K path, which spawns 4x the
+    workgroups and refills with split-K. Measured crossover on gfx950 (256 CUs):
+    skinny wins for grid_256 <= 64, the 256x256 tile wins from grid_256 >= 128."""
     M = a.shape[0]
     N = b.shape[0]
     grid_mn_256 = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
-    if grid_mn_256 <= NUM_CU // 32:
+    if grid_mn_256 <= NUM_CU // 4:
         return _matmul_skinny(a, b, a_scales, b_scales)
     return _matmul_256tile(a, b, a_scales, b_scales)

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -76,6 +76,10 @@ from triton.language.extra.tlx.tutorials.amd_gemm_warp_pipeline import (
     matmul as _amd_gemm_warp_pipeline, )
 from triton.language.extra.tlx.tutorials.amd_gemm_pipelined import (
     matmul as _amd_gemm_pipelined, )
+from triton.language.extra.tlx.tutorials.amd_bmm import (
+    bmm as _amd_bmm,
+    make_bmm_inputs as _amd_bmm_inputs,
+)
 from triton.language.extra.tlx.tutorials.amd_mxfp_gemm_tdm_pipelined import (
     matmul as _amd_mxfp_gemm_tdm_pipelined,
     pack_scale as _amd_mxfp_pack_scale,
@@ -1401,6 +1405,18 @@ def test_amd_gemm_warp_pipeline(dtype):
 def test_amd_gemm_pipelined(dtype):
     # Autotuned kernel: no fixed config (config=None).
     Gemm.run_test(_amd_gemm_pipelined, None, dtype=dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires AMD gfx950 (CDNA4)")
+def test_amd_bmm(dtype):
+    # a16w16 batched GEMM (col-major B). Covers both load paths of the single kernel:
+    # aligned K (K % 32 == 0) -> direct-to-LDS; odd / unaligned K -> register path.
+    for M, N, K, B in [(256, 256, 256, 8), (395, 256, 320, 8), (262, 256, 294, 8), (176, 256, 257, 8)]:
+        a, b = _amd_bmm_inputs(B, M, N, K, DEVICE, dtype=dtype)
+        out = _amd_bmm(a, b)
+        ref = torch.bmm(a, b)
+        torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
 
 
 # =============================================================================


### PR DESCRIPTION
Summary:

REPRO. A self-contained script to benchmark the TLX MXFP4 (a4w4) GEMM kernels
against the AITER baseline on gfx950 (CDNA4).

Baseline = AITER (aiter.ops.gemm_op_a4w4.gemm_a4w4; tuned "_ZN..." assembly with
pre-shuffled B). The script runs the unchanged public TLX matmul() for both
variants -- inter_wave_TLX and intra_wave_TLX -- on identical inputs, validates
each bit-exact against an FP32 reference, and reports speedup = AITER / TLX
(> 1.0 = TLX faster/win, < 1.0 = regression). Cold-L2 flush + GPU-event medians;
pins the inter_wave kernel by SHA; skips shapes with no AITER tuned config.

This diff ships the inter_wave kernel with the skinny-gate dispatch tweak
(route grid_256 <= NUM_CU//4 to the 128-tile split-K path), and the repro pins
that exact kernel by SHA, so the numbers below are what the pinned kernel yields.

Run on a single gfx950 with ROCm PyTorch + AITER:

  HIP_VISIBLE_DEVICES=0 python \
    third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/aiter_baseline_repro.py \
    --tlx-inter-wave-source third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py \
    --tlx-intra-wave-source third_party/tlx/tutorials/gfx9_gemm/intra_wave/a4w4/matmul_kernel.py

Example output (cold L2, GPU-event median; speedup = AITER/TLX):

         M x N x K  AITER us  inter_wave_TLX us  inter_wave_TLX x  intra_wave_TLX us  intra_wave_TLX x
     256x4096x4096     11.64              17.60             0.661              40.96             0.284
     256x8192x4096     14.76              25.60             0.577              41.56             0.355
     512x4096x4096     13.76              20.84             0.660              41.56             0.331
     512x8192x4096     18.36              20.28             0.905              42.40             0.433
    2048x4096x8192     42.48              56.24             0.755              81.56             0.521
    2048x8192x4096     44.28              58.36             0.759              51.00             0.868
    2048x8192x8192     66.24              95.08             0.697              89.20             0.743

All kernels report exact BF16 equality vs the FP32 reference.

Co-authored with Claude Code.

Differential Revision: D114296896


