### PR TITLE
[triton] Fix pre-commit formatting/lint failures on 11 files

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -277,20 +277,16 @@ class TestTLXTemplates(TestCase):
             return torch.nn.functional.gelu(torch.addmm(bias, a, w.t()))
 
         with config.patch({
-            "triton.tlx_mode": "force",
-            "force_disable_caches": True,
-            "max_autotune": True,
-            "max_autotune_gemm_backends": "TRITON",
-            "enable_caching_generated_triton_templates": False,
-            "cpp_wrapper": False,
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+                "cpp_wrapper": False,
         }):
-            c_actual, code = run_and_get_code(
-                torch.compile(addmm_gelu), bias, a, w
-            )
+            c_actual, code = run_and_get_code(torch.compile(addmm_gelu), bias, a, w)
 
-        c_expected = torch.nn.functional.gelu(
-            a.float() @ w.t().float() + bias.float()
-        ).to(dtype)
+        c_expected = torch.nn.functional.gelu(a.float() @ w.t().float() + bias.float()).to(dtype)
         torch.testing.assert_close(c_actual, c_expected, atol=3e-2, rtol=3e-2)
 
         code_str = "\n".join(code)
@@ -303,9 +299,7 @@ class TestTLXTemplates(TestCase):
     )
     @unittest.skipIf(not has_tlx(), "TLX not available")
     @parametrize("epilogue", ("gelu", "mul"))
-    def test_tlx_addmm_warppipe_split_k_cpp_wrapper_fused_epilogue(
-        self, epilogue: str
-    ):
+    def test_tlx_addmm_warppipe_split_k_cpp_wrapper_fused_epilogue(self, epilogue: str):
         M, K, N = 256, 4096, 256
         dtype = torch.float16
         a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
@@ -326,18 +320,14 @@ class TestTLXTemplates(TestCase):
                 "enable_caching_generated_triton_templates": False,
                 "cpp_wrapper": True,
         }), ):
-            c_actual, code = run_and_get_code(
-                torch.compile(addmm_epilogue), bias, a, w
-            )
+            c_actual, code = run_and_get_code(torch.compile(addmm_epilogue), bias, a, w)
 
         reference = a.float() @ w.t().float() + bias.float()
         if epilogue == "gelu":
             reference = torch.nn.functional.gelu(reference)
         else:
             reference = reference * 0.5
-        torch.testing.assert_close(
-            c_actual, reference.to(dtype), atol=4e-2, rtol=4e-2
-        )
+        torch.testing.assert_close(c_actual, reference.to(dtype), atol=4e-2, rtol=4e-2)
 
         code_str = "\n".join(code)
         self.assertIn("split_k_ws", code_str)
@@ -557,14 +547,14 @@ class TestTLXTemplates(TestCase):
             return templates
 
         with (
-            mock.patch.object(_tlx_mm, "append_tlx", _only_persistent),
-            config.patch({
-                "triton.tlx_mode": "force",
-                "force_disable_caches": True,
-                "max_autotune": True,
-                "max_autotune_gemm_backends": "TRITON",
-                "enable_caching_generated_triton_templates": False,
-            }),
+                mock.patch.object(_tlx_mm, "append_tlx", _only_persistent),
+                config.patch({
+                    "triton.tlx_mode": "force",
+                    "force_disable_caches": True,
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "TRITON",
+                    "enable_caching_generated_triton_templates": False,
+                }),
         ):
             c_actual, code = run_and_get_code(torch.compile(addmm), bias, a, w)
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -1132,7 +1132,6 @@ void emitTDMIntrinsic(RewriterBase &rewriter, Location loc,
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   auto v4i32Ty = VectorType::get(4, rewriter.getI32Type());
   auto v8i32Ty = VectorType::get(8, rewriter.getI32Type());
-
   SmallVector<Value, 4> groups(desc.begin(),
                                desc.begin() + (numDims > 2 ? 4 : 2));
   fillTDMDescriptor(rewriter, loc, typeConverter, elementType,

--- a/third_party/tlx/tutorials/hstu_cross_attn/bench_bwd.py
+++ b/third_party/tlx/tutorials/hstu_cross_attn/bench_bwd.py
@@ -87,7 +87,10 @@ def force(ns=2, bm=BLOCK, bn=BLOCK):
 
 def make(Lq, Lkv, Z, shared=False):
     tq, tk = Z * Lq, Z * Lkv
-    g = lambda n: torch.randn(n, H, D, device="cuda", dtype=torch.bfloat16)
+
+    def g(n):
+        return torch.randn(n, H, D, device="cuda", dtype=torch.bfloat16)
+
     q = g(tq).requires_grad_(True)
     k = g(tk).requires_grad_(True)
     # shared-KV: V aliases K (same tensor), so k.grad accumulates dk + dv.


### PR DESCRIPTION
Summary:
The facebookexperimental/triton mirror pre-commit gate ("pre-commit / code
formatting") is red on `main` and on every PR: `pre-commit run --all-files`
flags 11 files. None are newly introduced here -- this is pre-existing trunk
formatting debt surfaced by the whole-tree check.

This applies the fixes at the repo's pinned hook versions (yapf v0.43.0,
clang-format v19.1.6, ruff v0.9.1):
- yapf + clang-format autofixes (formatting only) across the 11 files.
- Two non-autofixable ruff fixes:
  - `nvidia_helpers.py`: removed the redundant explicit `common_helpers`
    import block. All four names (`default_blocked_layout`,
    `get_num_threads_per_warp`, `tl_dot_decomposed_scale_arg`, `tl_trans`) are
    redefined locally later in the file (ruff F811), and the preceding
    `from ... common_helpers import *` still provides them. Reviewer agrontsai
    added the local redefinitions in D109506928 -- please confirm the intent is
    to keep the local versions (this change assumes so).
  - `bench_bwd.py`: rewrote `g = lambda n: ...` as a nested `def g` (ruff E731).
    From D110625979 (mren).

No functional change: formatting, dead-import removal, and a lambda->def.

Authored with Claude.

Reviewed By: manman-ren

Differential Revision: D114316174


