### PR TITLE
[triton][bitequiv] SmemModel soundness: fail closed on vector st.shared (fix D112727538 over-merge) (#2576)

### DIFF
--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -200,6 +200,16 @@ class ForwardInterp:
                 val = inst.operands[1]  # scalar shared store: record its value for later loads
                 if isinstance(val, RegisterOperand):
                     self.smem_stores.append((at, self._node(val, at)))
+                else:
+                    # A VECTOR st.shared writes a packed multi-element slot this phase does not model.
+                    # Skipping it silently is UNSOUND: a later scalar ld.shared would then resolve to a
+                    # STALE earlier store while faithful stays True (the tree is wrong but TRUSTED, so
+                    # two bit-different configs can collapse to one descriptor -> OVER-MERGE). Fail
+                    # closed instead. (The DCR / reviewer soundness concern on D112727538. The remaining
+                    # address-agnostic multi-buffer case among all-scalar stores -- resolving a scalar
+                    # load to a DIFFERENT scalar buffer -- needs address-matched resolution and is a
+                    # follow-up, bundled with the multi-output cross-warp recovery.)
+                    self.faithful = False
                 continue
             if op == "mov" and ".b64" in mods and len(inst.operands) == 2 and self._b64_mov(inst, at):
                 continue  # mov.b64 pack ({lo,hi}->rd) / unpack (rd->{lo,hi}) handled in place
@@ -249,23 +259,10 @@ class ForwardInterp:
         # OpaqueOp NODE with its register operands as children + non-register operands in the token,
         # EXACTLY like the backward else-branch, so the value-DAG matches. A pure integer/address op
         # is stored too but never pulled into a value tree (value ops read value operands; addresses
-        # go through the affine domain), so this is harmless and lazy at the descriptor level.
-        # An unmodeled op that CONSUMES a transient marker (a _Shuffle butterfly partner, or a
-        # _Packed f32x2 pair — directly or via a vector operand) would have `_scalar` silently STRIP
-        # it -> the reduction ORDERING (count-up vs count-down) or the packed lane structure is lost
-        # -> OVER-MERGE. Idiom 2 RECONSTRUCTS the packed reductions above (`.f32x2` combine, `mov.b64`
-        # pack/unpack); a marker still reaching HERE is genuinely unmodeled -> fail closed, and the
-        # fingerprint's ordered shfl sequence + store widths then distinguish the configs. A benign
-        # opaque with NO marked operand (an f64 `or.b64`, a `cvt`) keeps faithful=True and recovers.
-        def _marked(o):
-            if isinstance(o, RegisterOperand):
-                return isinstance(self._val(o, at), (_Shuffle, _Packed))
-            if isinstance(o, VectorOperand):
-                return any(isinstance(e, RegisterOperand)
-                           and isinstance(self._val(e, at), (_Shuffle, _Packed)) for e in o.elements)
-            return False
-
-        if any(_marked(o) for o in inst.operands[1:]):
+        # go through the affine domain), so this is harmless and lazy at the descriptor level. If an
+        # operand still carries a transient marker HERE it is genuinely unmodeled (the packed
+        # reductions were reconstructed above) -> fail closed (see `_consumes_marker`).
+        if any(self._consumes_marker(o, at) for o in inst.operands[1:]):
             self.faithful = False
         reg_ops = [o for o in inst.operands[1:] if isinstance(o, RegisterOperand)]
         others = [o for o in inst.operands[1:] if not isinstance(o, RegisterOperand)]
@@ -273,6 +270,20 @@ class ForwardInterp:
         if others:
             tok += "{" + ",".join(canon(self.ev.of_operand(o, at)) for o in others) + "}"
         return OpaqueOp(tok, tuple(self._node(o, at) for o in reg_ops))
+
+    def _consumes_marker(self, operand, at):
+        """True if ``operand`` (a register, or a vector of registers) currently holds a transient
+        ``_Shuffle`` / ``_Packed`` marker. An unmodeled op that consumes one would have ``_scalar``
+        silently STRIP it -> the reduction ORDERING (count-up vs count-down) or the packed lane
+        structure is lost -> OVER-MERGE. The caller fails closed when this is True; the fingerprint's
+        ordered shfl sequence + store widths then distinguish the configs. A benign opaque with NO
+        marked operand (an f64 ``or.b64``, a ``cvt``) keeps ``faithful`` True and still recovers."""
+        if isinstance(operand, RegisterOperand):
+            return isinstance(self._val(operand, at), (_Shuffle, _Packed))
+        if isinstance(operand, VectorOperand):
+            return any(isinstance(e, RegisterOperand)
+                       and isinstance(self._val(e, at), (_Shuffle, _Packed)) for e in operand.elements)
+        return False
 
     def _loop_reduce(self, inst, acc, at):
         """A loop-carried ``acc = acc + chunk`` -> ``LoopReduce(add, chunk, key)``, summarizing the

--- a/bitequiv/tests/test_ptx_smem.py
+++ b/bitequiv/tests/test_ptx_smem.py
@@ -1,0 +1,83 @@
+"""SmemModel soundness: a VECTOR ``st.shared`` must FAIL CLOSED, not let a later scalar ``ld.shared``
+resolve to a stale scalar store (the D112727538 reviewer / DCR over-merge concern).
+
+The bug is latent — no natural eval kernel reconstructs faithfully AND has a scalar-load-after-vector-
+store, which is why it could not be reproduced at runtime. So the demo is hand-crafted PTX (full control
+of the pattern): a scalar-only exchange reconstructs to a real tree hash; adding a vector ``st.shared``
+to a second buffer + a scalar ``ld.shared`` from it makes the OLD code resolve the load to the stale
+scalar store (address-blind) while ``faithful`` stays True — so two kernels that read DIFFERENT buffers
+collapse to ONE descriptor (over-merge). The fix fails closed on the vector store. CPU-only."""
+from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
+
+_HEAD = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+
+# Scalar shared exchange only: st.shared A -> ld.shared A -> reconstructs faithfully (real tree hash).
+PTX_SCALAR = _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {
+  .reg .f32 %f<4>;
+  .reg .b32 %r<4>;
+  .reg .b64 %rd<8>;
+  .shared .align 4 .b8 bufA[128];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  mov.u32 %r2, bufA;
+  st.shared.f32 [%r2], %f1;
+  bar.sync 0;
+  ld.shared.f32 %f2, [%r2];
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f2;
+  ret;
+}
+"""
+
+# Same, plus a VECTOR st.shared to a SECOND buffer B, then a scalar ld.shared from B. WITHOUT the fix
+# the vector store is skipped, the scalar load resolves to the stale scalar store A (address-blind),
+# faithful stays True -> identical descriptor to PTX_SCALAR though it reads B = OVER-MERGE. WITH the fix
+# the vector store fails closed (fingerprint) -> distinct -> sound.
+PTX_VECTOR = _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {
+  .reg .f32 %f<4>;
+  .reg .b32 %r<4>;
+  .reg .b64 %rd<8>;
+  .shared .align 4 .b8 bufA[128];
+  .shared .align 8 .b8 bufB[128];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  mov.u32 %r2, bufA;
+  st.shared.f32 [%r2], %f1;
+  mov.u32 %r3, bufB;
+  st.shared.v2.f32 [%r3], {%f1, %f1};
+  bar.sync 0;
+  ld.shared.f32 %f2, [%r3];
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f2;
+  ret;
+}
+"""
+
+
+def test_scalar_shared_exchange_reconstructs():
+    d = CHECK(PTX_SCALAR)
+    assert d and "fwd-incomplete" not in str(d[0])   # faithful tree hash (scalar exchange is modeled)
+
+
+def test_vector_shared_store_fails_closed():
+    d = CHECK(PTX_VECTOR)
+    assert d and "fwd-incomplete" in str(d[0])        # the fix: vector st.shared -> conservative fingerprint
+
+
+def test_vector_store_no_over_merge():
+    # The two entries read DIFFERENT buffers (A vs B) -> genuinely different computations. The fix keeps
+    # their descriptors distinct; WITHOUT it both resolve the scalar load to buffer A -> one descriptor
+    # (the reviewer's over-merge). This assertion FAILS on the pre-fix code.
+    assert CHECK(PTX_SCALAR) != CHECK(PTX_VECTOR)


### PR DESCRIPTION
Summary:

Closes the over-merge risk njriasan / the DCR flagged on D112727538: the forward SmemModel's `run()` records only SCALAR `st.shared` values and silently SKIPS a VECTOR `st.shared` WITHOUT setting `faithful = False`. Combined with the address-agnostic `_match_smem` (most-recent recorded store), a scalar `ld.shared` from a vector-written buffer then resolves to a STALE earlier scalar store from a DIFFERENT buffer, while `faithful` stays True. The reconstructed tree is wrong but TRUSTED, so two kernels that read DIFFERENT buffers can collapse to ONE descriptor -> OVER-MERGE (the exact unsound outcome the sound-floor is meant to prevent).

Fix: a vector `st.shared` now sets `faithful = False` (fail closed) — a packed multi-element shared store is not modeled, so the entry falls back to the conservative fingerprint instead of trusting a stale scalar resolution.

Why the demo is hand-crafted PTX (not a GPU eval kernel): the bug is LATENT — no natural eval kernel both reconstructs faithfully AND does a scalar-load-after-a-vector-store (the ones that use vector shared stores already fail closed for other reasons), which is why the reviewer could not reproduce it at runtime. `bitequiv/tests/test_ptx_smem.py` therefore drives it with two hand-crafted PTX modules where the pattern is fully controlled, and verifies: BEFORE this fix both collapse to one descriptor (over-merge), AFTER it the vector case fails closed and the two stay distinct.

Also addresses Nick's D112727538 code-quality nit (make the flagged inner function a proper method with a real docstring, and stop hanging a long comment on it): the `_transfer` fallback's nested `_marked(o)` helper is promoted to a `_consumes_marker(operand, at)` method whose docstring carries the fail-close rationale, and the call site keeps a one-line pointer. Pure extraction, behavior-preserving. It lands here in the descendant rather than as an amend to D112727538 so the ~9 diffs stacked on top of D112727538 do not have to be restacked.

Remaining gap (follow-up): the address-agnostic `_match_smem` can also mismatch two independent ALL-scalar buffers. A clean fix needs address-matched load<->store resolution, which is subtle (a legit cross-warp exchange's store address carries `%tid` terms while its load address carries a loop-variable term, so naive base-matching would fail-close the working single-buffer `sum` exchange). That is bundled with the multi-output cross-warp recovery (address-matched SmemModel) — tracked separately; this diff only closes the concrete vector-store over-merge.

## Mid-effort evaluation (forward checker)

What THIS fix changes vs before it (the delta this diff owns; compile-only checker sets, measured by temporarily reverting the `faithful=False` hunk — the fix is checker-only, so the PTX is byte-identical either way): of the 14 kernels that emit a vector `st.shared`, 3 IMPROVE (fewer checker sets = more recovery) and 0 regress —

| kernel | checker sets before -> after |
|---|---|
| sum_3d_outer | 14 -> 12 |
| sum_2d_deep | 14 -> 13 |
| sum_3d_mid | 13 -> 12 |

the other 11 vector-store kernels (and every non-vector kernel) are unchanged. Pre-fix, a skipped vector store left `faithful=True` and the reconstruction over-split on config-dependent garbage; fail-closing routes those configs to the clean num_warps-invariant fingerprint. So this soundness fix has ZERO over-split cost and even removes some spurious over-split.

Full suite below — every reduction kernel the forward checker supports, at the env-max config grid, confirming SOUND (0 over-merges everywhere). Config space = reduction_ordering x num_warps{1..32} x num_stages{1..6} x enable_fp_fusion = 144 configs (the max these axes allow). Fuzzer R=50 (MID effort — a headline recovery claim still needs the convincing ~1000-seed pass; this table is the soundness + no-regression floor).

| kernel | config space | checker sets / empirical sets | largest checker / largest empirical | over-merges |
|---|---|---|---|---|
| sum | 144 | 14 / 7 | 60 / 72 | 0 |
| sum_dim1_simple | 144 | 14 / 7 | 60 / 72 | 0 |
| dot | 144 | 24 / 14 | 6 / 36 | 0 |
| cond_reduce | 144 | 24 / 14 | 6 / 36 | 0 |
| sum_2d_keepdim | 144 | 13 / 2 | 12 / 72 | 0 |
| sum_2d_axis0 | 144 | 12 / 7 | 12 / 72 | 0 |
| sum_2d_col | 144 | 12 / 7 | 12 / 72 | 0 |
| sum_2d_col_big | 144 | 12 / 7 | 12 / 72 | 0 |
| sum_3d_outer | 144 | 12 / 7 | 12 / 72 | 0 |
| col_dot | 144 | 24 / 15 | 6 / 36 | 0 |
| col_exp_sum | 144 | 12 / 7 | 12 / 72 | 0 |
| col_bf16 | 144 | 12 / 7 | 12 / 72 | 0 |
| col_max | 144 | 6 / 1 | 24 / 144 | 0 |
| sum_2d_deep | 144 | 13 / 4 | 12 / 72 | 0 |
| sum_3d | 144 | 13 / 2 | 24 / 72 | 0 |
| sum_3d_mid | 144 | 12 / 4 | 12 / 72 | 0 |
| sum_4d | 144 | 14 / 2 | 24 / 72 | 0 |
| sum_multiaxis | 144 | 13 / 2 | 12 / 72 | 0 |
| layernorm | 144 | 8 / 6 | 30 / 36 | 0 |
| softmax | 144 | 24 / 3 | 6 / 72 | 0 |
| rmsnorm | 144 | 12 / 7 | 18 / 36 | 0 |

(welford / sum_dim1_persistent / col_sum_loop excluded: loop-carried kernels whose per-seed fuzzer run hangs — a harness limit, not a checker issue.)

Terms:
- fuzzer = the empirical oracle: runs each config on GPU with R random-seed INPUTS and compares raw output BYTES; two configs are empirically equivalent iff bit-identical on EVERY seed. It only REFUTES equivalence, so larger R = stronger (R=50 = mid).
- empirical sets = the ground-truth partition by that bit-comparison; largest empirical = the biggest bit-identical class = the recovery ceiling.
- checker sets = the static checker's partition; fewer (closer to the empirical count) = less over-split. largest checker / largest empirical = the biggest single class the checker recovered vs the target.
- over-merges = pairs the checker merged but the fuzzer separated = soundness violations (MUST be 0).

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D113308769


