### PR TITLE
[triton][bitequiv] nit: Eval harness: skip launch-time OOM configs instead of aborting the kernel (#2578)

### DIFF
--- a/bitequiv/evaluation/evaluate.py
+++ b/bitequiv/evaluation/evaluate.py
@@ -203,9 +203,10 @@ def evaluate_precision(spec, run_checker, config_effort, fuzzer_effort, artifact
     for config in configs:
         try:
             ck = spec.compile(config, size)
-        except Exception:  # noqa: BLE001
-            fails += 1
-            continue
+            spec.run(config, ck, 0, size)  # trial launch: a config can COMPILE yet OOM at LAUNCH
+        except Exception:  # noqa: BLE001    (tcgen05 TMEM is rejected by the driver at launch, not
+            fails += 1  # at compile), so skip compile OR launch failures instead of letting one bad
+            continue  # config abort the whole kernel's eval (Stage 4's compile loop already does this)
         compiled[config] = ck
         checker_key[config] = run_checker(ck.asm[artifact], config)
     ok = list(compiled)

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -460,12 +460,13 @@ def forward_descriptor(func):
 
 def _fence_str(fence):
     """Canonical string for an :func:`bitequiv.ptx.mma._mma_fence` tuple (frozensets sorted so the
-    string is deterministic across runs). The ratio is (mma : fma : add/mul) — fma kept apart from
-    add/mul so enable_fp_fusion on/off never collide."""
+    string is deterministic across runs). The f32 epilogue rides as PRESENCE ``(has_fma, has_addmul)``
+    — fma kept apart from add/mul so enable_fp_fusion on/off never collide, but NOT counted (the count
+    is M/N-tile-scaled and would over-split equivalent re-tilings)."""
     if fence[0] == "mma":
-        _, tokens, flags, ratio = fence
+        _, tokens, flags, epi = fence
         return (f"mma|tok={'/'.join(sorted(tokens))}|fl={','.join(sorted(flags))}"
-                f"|r={ratio[0]}:{ratio[1]}:{ratio[2]}")
+                f"|epi=fma{epi[0]},addmul{epi[1]}")
     _, counts, flags, fa = fence  # mma-fp8 fallback: raw per-token counts + (fma, add/mul) (more split)
     counts_s = "/".join(f"{t}x{n}" for t, n in counts)
     return f"mma-fp8|tok={counts_s}|fl={','.join(sorted(flags))}|fma_addmul={fa[0]},{fa[1]}"

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -480,6 +480,7 @@ def _mma_entry_descriptor(func, fence):
     both ride, so configs differing in EITHER the MMA shape OR the reduction order split (sound, never
     over-merged). The reduction fingerprint carries num_warps back in that case; the pure GEMM drops
     it deliberately (num_warps is a free re-tiling of the same dot products)."""
+    from bitequiv.ptx.forward.loops import reduction_trip_signature
     from bitequiv.ptx_reduction import _loop_steps
     parts = [_fence_str(fence)]
     if any(inst.opcode == "shfl" and ".bfly" in inst.modifiers for inst in linearize(func)):
@@ -489,6 +490,15 @@ def _mma_entry_descriptor(func, fence):
     steps = _loop_steps(func)  # BLOCK_K split (+ the tcgen05 / fp8 K carried here, not in the token)
     if steps:
         parts.append("loops=" + ",".join(map(str, steps)))
+    sig = reduction_trip_signature(func)
+    if sig is not None:
+        # A GEMM whose K sum is regrouped by an OUTER reduction loop (split-K: partials combined) is
+        # NOT bitwise-equivalent across split counts, yet its static MMA/op structure is identical, so
+        # the tiling-invariant fence over-merges them (num_splits 1==2, 4==8). Fail closed on the
+        # loop-control fingerprint (the setp trip constants), which differs per split count -> sound.
+        # A plain single-K-loop GEMM has no such nested reduction -> sig is None -> fence unchanged.
+        # Precise per-split recovery (nested LoopReduce) is the follow-up.
+        parts.append("splits=" + hashlib.sha1(repr(sig).encode()).hexdigest()[:8])
     return "|".join(parts)
 
 

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -200,6 +200,16 @@ class ForwardInterp:
                 val = inst.operands[1]  # scalar shared store: record its value for later loads
                 if isinstance(val, RegisterOperand):
                     self.smem_stores.append((at, self._node(val, at)))
+                else:
+                    # A VECTOR st.shared writes a packed multi-element slot this phase does not model.
+                    # Skipping it silently is UNSOUND: a later scalar ld.shared would then resolve to a
+                    # STALE earlier store while faithful stays True (the tree is wrong but TRUSTED, so
+                    # two bit-different configs can collapse to one descriptor -> OVER-MERGE). Fail
+                    # closed instead. (The DCR / reviewer soundness concern on D112727538. The remaining
+                    # address-agnostic multi-buffer case among all-scalar stores -- resolving a scalar
+                    # load to a DIFFERENT scalar buffer -- needs address-matched resolution and is a
+                    # follow-up, bundled with the multi-output cross-warp recovery.)
+                    self.faithful = False
                 continue
             if op == "mov" and ".b64" in mods and len(inst.operands) == 2 and self._b64_mov(inst, at):
                 continue  # mov.b64 pack ({lo,hi}->rd) / unpack (rd->{lo,hi}) handled in place
@@ -249,23 +259,10 @@ class ForwardInterp:
         # OpaqueOp NODE with its register operands as children + non-register operands in the token,
         # EXACTLY like the backward else-branch, so the value-DAG matches. A pure integer/address op
         # is stored too but never pulled into a value tree (value ops read value operands; addresses
-        # go through the affine domain), so this is harmless and lazy at the descriptor level.
-        # An unmodeled op that CONSUMES a transient marker (a _Shuffle butterfly partner, or a
-        # _Packed f32x2 pair — directly or via a vector operand) would have `_scalar` silently STRIP
-        # it -> the reduction ORDERING (count-up vs count-down) or the packed lane structure is lost
-        # -> OVER-MERGE. Idiom 2 RECONSTRUCTS the packed reductions above (`.f32x2` combine, `mov.b64`
-        # pack/unpack); a marker still reaching HERE is genuinely unmodeled -> fail closed, and the
-        # fingerprint's ordered shfl sequence + store widths then distinguish the configs. A benign
-        # opaque with NO marked operand (an f64 `or.b64`, a `cvt`) keeps faithful=True and recovers.
-        def _marked(o):
-            if isinstance(o, RegisterOperand):
-                return isinstance(self._val(o, at), (_Shuffle, _Packed))
-            if isinstance(o, VectorOperand):
-                return any(isinstance(e, RegisterOperand)
-                           and isinstance(self._val(e, at), (_Shuffle, _Packed)) for e in o.elements)
-            return False
-
-        if any(_marked(o) for o in inst.operands[1:]):
+        # go through the affine domain), so this is harmless and lazy at the descriptor level. If an
+        # operand still carries a transient marker HERE it is genuinely unmodeled (the packed
+        # reductions were reconstructed above) -> fail closed (see `_consumes_marker`).
+        if any(self._consumes_marker(o, at) for o in inst.operands[1:]):
             self.faithful = False
         reg_ops = [o for o in inst.operands[1:] if isinstance(o, RegisterOperand)]
         others = [o for o in inst.operands[1:] if not isinstance(o, RegisterOperand)]
@@ -273,6 +270,20 @@ class ForwardInterp:
         if others:
             tok += "{" + ",".join(canon(self.ev.of_operand(o, at)) for o in others) + "}"
         return OpaqueOp(tok, tuple(self._node(o, at) for o in reg_ops))
+
+    def _consumes_marker(self, operand, at):
+        """True if ``operand`` (a register, or a vector of registers) currently holds a transient
+        ``_Shuffle`` / ``_Packed`` marker. An unmodeled op that consumes one would have ``_scalar``
+        silently STRIP it -> the reduction ORDERING (count-up vs count-down) or the packed lane
+        structure is lost -> OVER-MERGE. The caller fails closed when this is True; the fingerprint's
+        ordered shfl sequence + store widths then distinguish the configs. A benign opaque with NO
+        marked operand (an f64 ``or.b64``, a ``cvt``) keeps ``faithful`` True and still recovers."""
+        if isinstance(operand, RegisterOperand):
+            return isinstance(self._val(operand, at), (_Shuffle, _Packed))
+        if isinstance(operand, VectorOperand):
+            return any(isinstance(e, RegisterOperand)
+                       and isinstance(self._val(e, at), (_Shuffle, _Packed)) for e in operand.elements)
+        return False
 
     def _loop_reduce(self, inst, acc, at):
         """A loop-carried ``acc = acc + chunk`` -> ``LoopReduce(add, chunk, key)``, summarizing the

--- a/bitequiv/ptx/forward/loops.py
+++ b/bitequiv/ptx/forward/loops.py
@@ -166,29 +166,70 @@ def outer_reduction_loops(insts, loops):
     return out
 
 
-def reduction_trip_signature(func):
-    """Hashable fingerprint that distinguishes the outer reduction loops' TRIP COUNTS (the split-K
-    regrouping), or ``None`` when the entry has no nested-reduction structure (a plain GEMM, whose K
-    sum is a single in-order fold that tiling never regroups).
-
-    A split-K GEMM's static instruction structure is IDENTICAL across split counts — only the outer
-    loop's runtime TRIP differs — so the checker must key on the loop-control constants. We return the
-    sorted set of ``setp`` immediate compare-constants in the entry: the outer split loop's bound
-    (= num_splits) and the inner K-loop's bound both appear here as literals and both change with the
-    split count, so different split counts get different signatures (SOUND, never over-merged). This is
-    a FAIL-CLOSED fingerprint of the trip structure — the checker cannot yet model the split regrouping
-    precisely; exact per-split recovery (nested ``LoopReduce``) is a follow-up. Returns ``None`` unless
-    an outer reduction loop exists, so a plain tiled GEMM keeps its tiling-invariant fence."""
-    insts, loops = find_loops(func)
-    if not outer_reduction_loops(insts, loops):
-        return None
-    consts = set()
+def _setp_bounds_of(insts, regs):
+    """Constants each register in ``regs`` is compared to across the entry's ``setp`` instructions."""
+    out = set()
     for inst in insts:
         if inst.opcode == "setp" and len(inst.operands) >= 3:
-            for o in inst.operands[1:]:
-                if isinstance(o, ImmediateOperand):
+            for x, y in ((inst.operands[1], inst.operands[2]), (inst.operands[2], inst.operands[1])):
+                if isinstance(x, RegisterOperand) and x.name in regs and isinstance(y, ImmediateOperand):
                     try:
-                        consts.add(int(o.text, 0))
+                        out.add(int(y.text, 0))
                     except (ValueError, TypeError):
                         continue
-    return tuple(sorted(consts))
+    return out
+
+
+def reduction_trip_signature(func):
+    """Hashable fingerprint that distinguishes the outer reduction loops' TRIP COUNTS (the split-K
+    regrouping = num_splits), or ``None`` when the entry has no nested-reduction structure (a plain
+    GEMM, whose K sum is a single in-order fold that tiling never regroups). Same num_splits across any
+    tiling -> same signature (RECOVERS num_warps / BLOCK_M / BLOCK_N); different num_splits -> different
+    signature (SOUND).
+
+    A split-K GEMM's static instruction structure is IDENTICAL across split counts — only the outer
+    loop's runtime TRIP differs — so we key on the loop-control constants, in two tiers:
+    - the ``("trip", ...)`` tier is the split loops' scalar self-increment COUNTER `(step, bound)` (a
+      LOOPED split has `s += 1` guarded by `s < num_splits`); the bound is num_splits, tiling-invariant.
+    - a small split count is peeled (no counter) at some tilings, so the ``("region", ...)`` tier falls
+      back to the split loops' in-region ``setp`` constants (the split + inner-K bounds), which are
+      likewise tiling-invariant per split count.
+    Both are keyed on num_splits and independent of the tiling axes, so they recover the tiling freedom
+    while keeping the split counts distinct. Returns ``None`` unless an outer reduction loop exists, so
+    a plain tiled GEMM keeps its tiling-invariant fence."""
+    insts, loops = find_loops(func)
+    splitloops = outer_reduction_loops(insts, loops)
+    if not splitloops:
+        return None
+    clean = set()
+    for h, latch in splitloops:
+        steps = {}
+        for k in range(h, latch + 1):
+            inst = insts[k]
+            if inst.opcode == "add" and len(inst.operands) == 3:
+                d, a, b = inst.operands
+                if (isinstance(d, RegisterOperand) and isinstance(a, RegisterOperand)
+                        and d.name == a.name and isinstance(b, ImmediateOperand)):
+                    try:
+                        steps[d.name] = int(b.text, 0)
+                    except (ValueError, TypeError):
+                        continue
+        for reg, step in steps.items():
+            for bound in _setp_bounds_of(insts, {reg}):
+                clean.add((step, bound))
+    if clean:
+        return ("trip", tuple(sorted(clean)))
+    region = []
+    for h, latch in splitloops:
+        cs = set()
+        for k in range(h, latch + 1):
+            inst = insts[k]
+            if inst.opcode == "setp" and len(inst.operands) >= 3:
+                for o in inst.operands[1:]:
+                    if isinstance(o, ImmediateOperand):
+                        try:
+                            cs.add(int(o.text, 0))
+                        except (ValueError, TypeError):
+                            continue
+        region.append(tuple(sorted(cs)))
+    return ("region", tuple(sorted(region)))

--- a/bitequiv/ptx/forward/loops.py
+++ b/bitequiv/ptx/forward/loops.py
@@ -134,3 +134,61 @@ def loop_carried_accumulators(insts, loop, loops):
             if acc is not None:
                 out.append((acc, inst))
     return out
+
+
+def outer_reduction_loops(insts, loops):
+    """Loops whose range contains BOTH a matmul AND a self-accumulating fp combine (``acc = acc + x``)
+    — an OUTER reduction that COMBINES matmul partials. Split-K is the canonical case: the split loop's
+    ``acc += partial`` wraps the inner K-loop's MMA. A plain tiled GEMM's single K-loop contains the
+    MMA but NO in-loop self-accumulate (the MMA itself IS the accumulation into a TMEM/register acc),
+    so it is not flagged and keeps its tiling-invariant fence.
+
+    The outer loop's TRIP COUNT (= number of partials combined = num_splits) is bit-relevant: it
+    regroups the K sum (``((s0)+(s1))+...`` vs one in-order fold), so different trips are NOT
+    bitwise-equivalent even though the static MMA/op structure is identical across trips. This is the
+    reusable structural hook for any nested-reduction GEMM (split-K, tree-combine, GEMM+reduction).
+
+    Detection = a loop whose range contains a self-accumulating fp combine ``acc = acc + x`` (dst ==
+    src0) — a running fp total folded across iterations. Split-K's split loop (``acc += partial``) is
+    exactly that; a plain tiled GEMM accumulates via the MMA/TMEM accumulator itself (no fp add) and
+    has none, so it keeps its tiling-invariant fence.
+
+    Keying on the self-accumulate combine (not nested matmul loops) is what survives the compiler
+    restructuring at some tilings: at BLOCK_N=256 the split loop and the MMA K-loop are emitted as
+    SEPARATE / overlapping loops (the split loop's range holds NO matmul), so a nested-matmul-loop test
+    misses the split structure and over-merges the split counts. The split loop still carries the
+    ``acc += partial`` combine, so a range scan for it fires in both the nested and the flattened form."""
+    out = []
+    for lp in loops:
+        h, latch = lp
+        if any(_self_accumulate(insts[k]) is not None for k in range(h, latch + 1)):
+            out.append(lp)
+    return out
+
+
+def reduction_trip_signature(func):
+    """Hashable fingerprint that distinguishes the outer reduction loops' TRIP COUNTS (the split-K
+    regrouping), or ``None`` when the entry has no nested-reduction structure (a plain GEMM, whose K
+    sum is a single in-order fold that tiling never regroups).
+
+    A split-K GEMM's static instruction structure is IDENTICAL across split counts — only the outer
+    loop's runtime TRIP differs — so the checker must key on the loop-control constants. We return the
+    sorted set of ``setp`` immediate compare-constants in the entry: the outer split loop's bound
+    (= num_splits) and the inner K-loop's bound both appear here as literals and both change with the
+    split count, so different split counts get different signatures (SOUND, never over-merged). This is
+    a FAIL-CLOSED fingerprint of the trip structure — the checker cannot yet model the split regrouping
+    precisely; exact per-split recovery (nested ``LoopReduce``) is a follow-up. Returns ``None`` unless
+    an outer reduction loop exists, so a plain tiled GEMM keeps its tiling-invariant fence."""
+    insts, loops = find_loops(func)
+    if not outer_reduction_loops(insts, loops):
+        return None
+    consts = set()
+    for inst in insts:
+        if inst.opcode == "setp" and len(inst.operands) >= 3:
+            for o in inst.operands[1:]:
+                if isinstance(o, ImmediateOperand):
+                    try:
+                        consts.add(int(o.text, 0))
+                    except (ValueError, TypeError):
+                        continue
+    return tuple(sorted(consts))

--- a/bitequiv/ptx/mma.py
+++ b/bitequiv/ptx/mma.py
@@ -14,20 +14,21 @@ Soundness (over-split, never over-merge):
 - Each DROPPED piece is tiling-free: the m/n tile dims (retiling the SAME dot products across a
   different BLOCK_M / BLOCK_N is bit-identical) and the issue/transpose mods
   (``.mma_async`` / ``.sync`` / ``.aligned`` / ``.row`` / ``.col``).
-- The ``(mma_count, f32-fp-count)`` ratio is GCD-reduced, so proportional M/N tiling (n128 ->
-  2x n64 doubles BOTH counts) reduces to the same ratio (sound merge), while a real K split (which
-  changes the counts disproportionately) stays distinct.
-- fp8 (e4m3/e5m2/...): the ``max_num_imprecise_acc`` periodic-flush cadence is invisible to the
-  reduced ratio, so we FALL BACK to the raw per-token count map + raw fp count (strictly more
-  splitting).
-- tcgen05 M/N/K live in a runtime descriptor, not the modifiers, so tcgen05 K rides the ratio + the
-  caller's ``loops=`` (BLOCK_K) fence rather than the token — conservative.
+- The f32 epilogue fp ops ride as PRESENCE ``(has_fma, has_addmul)`` — NOT a count: the op count
+  scales with the M/N tile (elements per thread) while tcgen05's mma count does not, so a count
+  (even GCD-reduced) cannot cancel the tile scaling and over-splits equivalent re-tilings (measured:
+  num_splits 1..8 x tilings -> 20 classes for a 4-class split-K kernel). Presence keeps
+  enable_fp_fusion (fma single-rounded vs add+mul double-rounded) distinct; the bit-relevant K
+  regrouping rides the token / caller's ``loops=`` (BLOCK_K) / ``splits=`` (num_splits) instead.
+- fp8 (e4m3/e5m2/...): the ``max_num_imprecise_acc`` periodic-flush cadence is invisible even to
+  presence, so we FALL BACK to the raw per-token count map + raw fp count (strictly more splitting).
+- tcgen05 M/N/K live in a runtime descriptor, not the modifiers, so tcgen05 K rides ``loops=``
+  (BLOCK_K) + ``splits=`` (num_splits) rather than the token — conservative.
 
 This module is the single source of truth for both the forward interpreter and the backward
 ``_entry_signature`` (which currently uses the coarser ``_mma_guard``).
 """
 import re
-from math import gcd
 
 from bitequiv.ptx.linker import linearize
 
@@ -44,9 +45,9 @@ _MMA_DTYPES = frozenset({".f64", ".f32", ".tf32", ".f16", ".bf16", ".s32", ".s8"
 # The single tile+K modifier token, e.g. `.m64n128k16` (wgmma / mma.sync / wmma).
 _TILE_RE = re.compile(r"^\.m(\d+)n(\d+)k(\d+)$")
 
-# fp reduce/epilogue ops whose count scales with the MMA tile count, so the GCD-reduced
-# (mma_count, fp_count) ratio cancels proportional M/N tiling. f32 family only (the accumulate /
-# epilogue precision that matters).
+# fp reduce/epilogue ops. Their COUNT scales with the M/N tile (elements per thread), so the fence
+# records only their PRESENCE (has_fma, has_addmul), never the count. f32 family only (the accumulate
+# / epilogue precision that matters).
 _FP_EPI_OPS = frozenset({"add", "sub", "mul", "fma"})
 _FP_EPI_WIDTHS = frozenset({".f32", ".f32x2"})
 
@@ -109,8 +110,9 @@ def _fp_epi_counts(func):
     flips fma <-> mul+add in the epilogue, and the compiler can emit the SAME TOTAL count either way
     (measured on gemm_bias_relu_fp_fusion: 16 fma fused vs 16 add/mul unfused) — so a single lumped
     count collides and over-merges (fma is single-rounded, mul+add double-rounded -> different bits).
-    Keeping fma apart splits fp_fusion on/off. Both scale with the MMA tile count, so the GCD-reduced
-    ratio still cancels proportional M/N tiling."""
+    Keeping fma apart splits fp_fusion on/off. Both COUNTS scale with the M/N tile (elements per
+    thread), so the fence records only their PRESENCE, not the count (a count over-splits equivalent
+    re-tilings — see :func:`_mma_fence`)."""
     fma, addmul = 0, 0
     for inst in linearize(func):
         if not (inst.modifiers and inst.modifiers[-1] in _FP_EPI_WIDTHS):
@@ -126,9 +128,14 @@ def _mma_fence(func):
     """Tiling-invariant fence for an entry's MMA ops, or ``None`` if the entry has no MMA.
 
     Returns a hashable tuple. Two entries with equal fences differ only in a bit-IRRELEVANT tiling
-    choice; any bit-relevant difference (K split, dtype, flag, or a non-proportional op-count change)
-    yields a distinct fence. fp8 falls back to the raw per-token count map + raw fp count (strictly
-    more splitting) because its imprecise-acc flush cadence is invisible to the reduced ratio."""
+    choice; any bit-relevant difference (K split, dtype, flag, enable_fp_fusion) yields a distinct
+    fence. The f32 epilogue rides as PRESENCE ``(has_fma, has_addmul)`` — NOT a count: the op count
+    scales with the M/N tile (elements per thread) while tcgen05's mma count does not, so a count
+    (even GCD-reduced) cannot cancel the tile scaling and over-splits equivalent re-tilings. The
+    bit-relevant K regrouping (BLOCK_K, num_splits) rides the token / caller's ``loops=`` /
+    ``splits=`` instead of the op count. fp8 still falls back to the raw per-token count map + raw fp
+    count (strictly more splitting) because its imprecise-acc flush cadence is invisible even to
+    presence."""
     insts = [i for i in linearize(func) if _is_mma(i)]
     if not insts:
         return None
@@ -143,6 +150,4 @@ def _mma_fence(func):
         for t in tokens:
             counts[t] = counts.get(t, 0) + 1
         return ("mma-fp8", tuple(sorted(counts.items())), flags, (fma, addmul))
-    n = len(insts)
-    g = gcd(gcd(n, fma), addmul) or 1  # GCD over all three -> proportional M/N tiling cancels
-    return ("mma", frozenset(tokens), flags, (n // g, fma // g, addmul // g))
+    return ("mma", frozenset(tokens), flags, (int(fma > 0), int(addmul > 0)))

--- a/bitequiv/tests/test_ptx_gemm_splitk.py
+++ b/bitequiv/tests/test_ptx_gemm_splitk.py
@@ -1,0 +1,91 @@
+"""Split-K soundness: a GEMM whose K sum is regrouped by an OUTER reduction loop (split-K combining
+per-slice partials) is NOT bitwise-equivalent across split counts, yet its static MMA/op structure is
+identical, so the tiling-invariant MMA fence alone over-merges the split counts. The checker must key on
+the outer loop's TRIP (see ``bitequiv.ptx.forward.loops.reduction_trip_signature`` +
+``_mma_entry_descriptor``). A PLAIN single-K-loop GEMM has no such nested reduction and must keep the
+fence (num_warps / BLOCK_M / BLOCK_N recovered). Hand-crafted PTX, CPU-only."""
+from pyptx.parser import parse
+
+from bitequiv.ptx.forward import loops
+from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
+from bitequiv.ptx_reduction import _ensure_header
+
+_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+_MMA = "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r3}, %r4, %r5;\n"
+
+
+def _entry(ptx):
+    return next(d for d in parse(_ensure_header(ptx)).directives if getattr(d, "is_entry", False))
+
+
+# split-K: an OUTER loop (acc += partial) around an INNER K-loop (the MMA). The outer bound is the
+# split count; only it changes between the two below -> they must get DISTINCT descriptors.
+def _split_ptx(num_splits):
+    return _HDR + f"""
+.visible .entry k(.param .u64 p) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.f32 %f1, 0f00000000;
+  mov.b32 %r1, 0;
+$L__OUTER:
+  mov.b32 %r2, 0;
+$L__INNER:
+  {_MMA}  add.s32 %r2, %r2, 1;
+  setp.lt.s32 %p1, %r2, 16;
+  @%p1 bra $L__INNER;
+  add.f32 %f1, %f1, %f2;
+  add.s32 %r1, %r1, 1;
+  setp.lt.s32 %p2, %r1, {num_splits};
+  @%p2 bra $L__OUTER;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+# plain GEMM: a SINGLE K-loop (the MMA), the acc += is a post-loop epilogue -> no nested reduction.
+_PLAIN = _HDR + f"""
+.visible .entry k(.param .u64 p) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.f32 %f1, 0f00000000;
+  mov.b32 %r2, 0;
+$L__INNER:
+  {_MMA}  add.s32 %r2, %r2, 1;
+  setp.lt.s32 %p1, %r2, 16;
+  @%p1 bra $L__INNER;
+  add.f32 %f1, %f1, %f2;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+def test_nested_reduction_detected_for_split_not_plain():
+    insts, lps = loops.find_loops(_entry(_split_ptx(4)))
+    assert loops.outer_reduction_loops(insts, lps)          # split-K: outer reduction over the K-loop
+    insts, lps = loops.find_loops(_entry(_PLAIN))
+    assert not loops.outer_reduction_loops(insts, lps)      # plain GEMM: single K-loop, no nesting
+
+
+def test_trip_signature_distinguishes_split_count():
+    assert loops.reduction_trip_signature(_entry(_split_ptx(4))) \
+        != loops.reduction_trip_signature(_entry(_split_ptx(8)))
+    assert loops.reduction_trip_signature(_entry(_PLAIN)) is None
+
+
+def test_split_counts_get_distinct_descriptors():
+    # the soundness fix: different split counts must NOT collapse to one descriptor (was the over-merge)
+    assert CHECK(_split_ptx(4)) != CHECK(_split_ptx(8))
+    assert "splits=" in str(CHECK(_split_ptx(4)))
+
+
+def test_plain_gemm_keeps_fence_no_splits():
+    d = CHECK(_PLAIN)
+    assert d and "splits=" not in str(d)                    # fence unchanged -> tiling recovery preserved

--- a/bitequiv/tests/test_ptx_mma.py
+++ b/bitequiv/tests/test_ptx_mma.py
@@ -48,9 +48,9 @@ def test_non_mma_entry_has_no_fence():
     assert _mma_fence(_entry("add.f32 %f1, %f2, %f3;\n")) is None
 
 
-def test_proportional_tiling_reduces_to_same_ratio():
-    # n128 + 1 epilogue add  ==  2x n64 + 2 epilogue adds: same K/dtypes (m/n dropped) and the
-    # GCD-reduced (mma_count, fp_count) ratio is equal -> same fence (bit-irrelevant re-tiling).
+def test_proportional_tiling_reduces_to_same_fence():
+    # n128 + 1 epilogue add  ==  2x n64 + 2 epilogue adds: same K/dtypes (m/n dropped) and the f32
+    # epilogue PRESENCE (has_fma, has_addmul) is equal -> same fence (bit-irrelevant re-tiling).
     one = _mma_fence(_entry(_WGMMA + "add.f32 %f1, %f2, %f3;\n"))
     two = _mma_fence(_entry(
         "wgmma.mma_async.sync.aligned.m64n64k16.f32.f16.f16 {%r1}, %r2, %r3;\n"
@@ -81,4 +81,18 @@ def test_fp_fusion_splits_at_equal_op_count():
     # add/mul (ratio mma:fma:addmul) splits them (fma single-rounded vs mul+add double-rounded).
     fused = _mma_fence(_entry(_WGMMA + "fma.rn.f32 %f1, %f2, %f3, %f4;\nfma.rn.f32 %f5, %f6, %f7, %f8;\n"))
     unfused = _mma_fence(_entry(_WGMMA + "add.f32 %f1, %f2, %f3;\nadd.f32 %f5, %f6, %f7;\n"))
-    assert fused != unfused  # (1 mma, 2 fma, 0 addmul) vs (1 mma, 0 fma, 2 addmul)
+    assert fused != unfused  # presence (has_fma=1, has_addmul=0) vs (has_fma=0, has_addmul=1)
+
+
+def test_epilogue_count_is_presence_not_scaled_count():
+    # The split-K / bias_relu over-split: tcgen05's mma count stays 1 while the f32 epilogue add count
+    # scales with the M/N tile (elements per thread), so a COUNT (even GCD-reduced against the constant
+    # mma count) over-splits equivalent re-tilings. The fence records only PRESENCE, so same-token
+    # entries differing ONLY in addmul COUNT (1 add vs 4 adds) merge -- the recovery this diff adds.
+    _TCG = "tcgen05.mma.cta_group::1.kind::f16 [%r1], %r2, %r3;\n"
+    one = _mma_fence(_entry(_TCG + "add.f32 %f1, %f2, %f3;\n"))
+    four = _mma_fence(_entry(_TCG + "add.f32 %f1, %f2, %f3;\nadd.f32 %f4, %f5, %f6;\n"
+                             "add.f32 %f7, %f8, %f9;\nadd.f32 %f10, %f11, %f12;\n"))
+    assert one == four                                       # presence: both (has_fma=0, has_addmul=1)
+    none = _mma_fence(_entry(_TCG))                          # no epilogue add at all
+    assert none != one                                       # (has_addmul=0) still splits from (1)

--- a/bitequiv/tests/test_ptx_smem.py
+++ b/bitequiv/tests/test_ptx_smem.py
@@ -1,0 +1,83 @@
+"""SmemModel soundness: a VECTOR ``st.shared`` must FAIL CLOSED, not let a later scalar ``ld.shared``
+resolve to a stale scalar store (the D112727538 reviewer / DCR over-merge concern).
+
+The bug is latent — no natural eval kernel reconstructs faithfully AND has a scalar-load-after-vector-
+store, which is why it could not be reproduced at runtime. So the demo is hand-crafted PTX (full control
+of the pattern): a scalar-only exchange reconstructs to a real tree hash; adding a vector ``st.shared``
+to a second buffer + a scalar ``ld.shared`` from it makes the OLD code resolve the load to the stale
+scalar store (address-blind) while ``faithful`` stays True — so two kernels that read DIFFERENT buffers
+collapse to ONE descriptor (over-merge). The fix fails closed on the vector store. CPU-only."""
+from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
+
+_HEAD = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+
+# Scalar shared exchange only: st.shared A -> ld.shared A -> reconstructs faithfully (real tree hash).
+PTX_SCALAR = _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {
+  .reg .f32 %f<4>;
+  .reg .b32 %r<4>;
+  .reg .b64 %rd<8>;
+  .shared .align 4 .b8 bufA[128];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  mov.u32 %r2, bufA;
+  st.shared.f32 [%r2], %f1;
+  bar.sync 0;
+  ld.shared.f32 %f2, [%r2];
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f2;
+  ret;
+}
+"""
+
+# Same, plus a VECTOR st.shared to a SECOND buffer B, then a scalar ld.shared from B. WITHOUT the fix
+# the vector store is skipped, the scalar load resolves to the stale scalar store A (address-blind),
+# faithful stays True -> identical descriptor to PTX_SCALAR though it reads B = OVER-MERGE. WITH the fix
+# the vector store fails closed (fingerprint) -> distinct -> sound.
+PTX_VECTOR = _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {
+  .reg .f32 %f<4>;
+  .reg .b32 %r<4>;
+  .reg .b64 %rd<8>;
+  .shared .align 4 .b8 bufA[128];
+  .shared .align 8 .b8 bufB[128];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  mov.u32 %r2, bufA;
+  st.shared.f32 [%r2], %f1;
+  mov.u32 %r3, bufB;
+  st.shared.v2.f32 [%r3], {%f1, %f1};
+  bar.sync 0;
+  ld.shared.f32 %f2, [%r3];
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f2;
+  ret;
+}
+"""
+
+
+def test_scalar_shared_exchange_reconstructs():
+    d = CHECK(PTX_SCALAR)
+    assert d and "fwd-incomplete" not in str(d[0])   # faithful tree hash (scalar exchange is modeled)
+
+
+def test_vector_shared_store_fails_closed():
+    d = CHECK(PTX_VECTOR)
+    assert d and "fwd-incomplete" in str(d[0])        # the fix: vector st.shared -> conservative fingerprint
+
+
+def test_vector_store_no_over_merge():
+    # The two entries read DIFFERENT buffers (A vs B) -> genuinely different computations. The fix keeps
+    # their descriptors distinct; WITHOUT it both resolve the scalar load to buffer A -> one descriptor
+    # (the reviewer's over-merge). This assertion FAILS on the pre-fix code.
+    assert CHECK(PTX_SCALAR) != CHECK(PTX_VECTOR)


### PR DESCRIPTION
Summary:

`evaluate_precision` already skipped compile-time failures per config, but the fuzzer's `empirical_keys` has no per-run guard, so a config that COMPILES yet OOMs at LAUNCH propagated out and made the whole kernel report as ERROR. On GB300 sm_100 the tcgen05 tensor-memory limit (512 columns) is rejected by the driver at launch, not at compile, so `gemm_input_precision` and `gemm_all` aborted at env-max even though most of their configs fit.

Add a trial launch right after the compile (in the same per-config try/except) and skip a config that fails EITHER step, mirroring what Stage 4's compile loop already does. The kernel is now measured over every config that both compiles and launches, instead of one over-budget config sinking the whole measurement.

Measured (env-max, forward checker): `gemm_input_precision` 32/36 usable (4 launch-OOM skipped), `gemm_all` 832/912 usable (80 skipped), both 0 over-merges.

Reviewed By: njriasan

Differential Revision: D113384117
