### PR TITLE
[triton][bitequiv] GEMM+reduction soundness: fingerprint a reduction over the MMA output, not just shfl.bfly (#2579)

### DIFF
--- a/bitequiv/evaluation/evaluate.py
+++ b/bitequiv/evaluation/evaluate.py
@@ -203,9 +203,10 @@ def evaluate_precision(spec, run_checker, config_effort, fuzzer_effort, artifact
     for config in configs:
         try:
             ck = spec.compile(config, size)
-        except Exception:  # noqa: BLE001
-            fails += 1
-            continue
+            spec.run(config, ck, 0, size)  # trial launch: a config can COMPILE yet OOM at LAUNCH
+        except Exception:  # noqa: BLE001    (tcgen05 TMEM is rejected by the driver at launch, not
+            fails += 1  # at compile), so skip compile OR launch failures instead of letting one bad
+            continue  # config abort the whole kernel's eval (Stage 4's compile loop already does this)
         compiled[config] = ck
         checker_key[config] = run_checker(ck.asm[artifact], config)
     ok = list(compiled)

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -27,15 +27,15 @@ import hashlib
 from pyptx.ir.nodes import RegisterOperand, VectorOperand
 
 from bitequiv.ptx.affine import AffineEval, canon, reqntid_of
-from bitequiv.ptx.builder import collapse_balanced, output_coordfree_key, tree_hash
+from bitequiv.ptx.builder import _postorder, collapse_balanced, output_coordfree_key, tree_hash
 from bitequiv.ptx.forward.cfg import has_unknown_control
 from bitequiv.ptx.forward.loops import (find_loops, loop_accumulates, loop_carried_accumulators,
                                         loop_self_increments)
 from bitequiv.ptx.forward.predicate import PredicateDecoder
 from bitequiv.ptx.leaves import leaf_coord, leaf_columns
 from bitequiv.ptx.linker import DefUse, _def_regs, linearize
-from bitequiv.ptx.mma import _mma_fence
-from bitequiv.ptx.treeir import (FpOp, Leaf, LoopReduce, OpaqueLeaf, OpaqueOp, ShflCombine,
+from bitequiv.ptx.mma import _is_mma, _mma_fence
+from bitequiv.ptx.treeir import (FpOp, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp, ShflCombine,
                                  SmemExchange)
 
 _FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f64", ".bf16", ".bf16x2"})
@@ -232,6 +232,17 @@ class ForwardInterp:
         """Value produced by a non-load, non-store instruction, or ``None`` when it writes no
         value-domain register (an integer/address op)."""
         op, mods = inst.opcode, inst.modifiers
+        if _is_mma(inst) or (op == "tcgen05" and ".ld" in mods):
+            # The tensor-core output is a hardware-opaque accumulator boundary leaf: an Mma node,
+            # NOT a reconstructable per-element tree (its internal K-fold is not FP-order-recoverable).
+            # On Hopper the wgmma matmul writes its accumulator regs directly; on Blackwell the
+            # tcgen05.mma writes tensor memory (no reg def) and tcgen05.ld reads it back into regs, so
+            # BOTH are the MMA-output boundary. Modeling it lets an epilogue reduction OVER the MMA
+            # output (gemm_reduce_sum / softmax / layernorm) reconstruct with Mma leaves, which
+            # `_epilogue_reduces_mma` detects so `_mma_entry_descriptor` rides the reduction fingerprint
+            # (else those within-thread-fold reductions are invisible and over-merge across the order).
+            # Over-identifying an MMA output only ever ADDS a splitting term (sound, monotone).
+            return Mma("mma-out")
         if op == "ld" and ".shared" in mods:
             src = self._match_smem(at)
             if src is not None:
@@ -472,21 +483,67 @@ def _fence_str(fence):
     return f"mma-fp8|tok={counts_s}|fl={','.join(sorted(flags))}|fma_addmul={fa[0]},{fa[1]}"
 
 
+def _epilogue_reduces_mma(sinks):
+    """True iff any sink value-DAG REDUCES over the MMA output — a reduce node (a 2-ary add/min/max
+    ``FpOp`` whose BOTH children carry an ``Mma`` leaf, or a ``ShflCombine`` / ``SmemExchange`` over an
+    Mma-bearing subtree). This is the ``tl.sum`` / ``tl.max`` epilogue over ``C = A @ B``
+    (gemm_reduce_sum / softmax / layernorm), whether it lowers to a within-thread fold (no shfl), a
+    cross-lane butterfly, or a cross-warp shared exchange. It EXCLUDES an elementwise epilogue
+    (``relu(acc*alpha + bias)``: the bias add has one non-Mma child, relu's max pairs with a constant)
+    and the split-K accumulation (a 1-ary ``LoopReduce`` over an Mma chunk), so the pure GEMMs keep
+    their clean tiling-invariant fence. When it fires, :func:`_mma_entry_descriptor` rides the reduction
+    fingerprint so configs differing only in the reduction ORDER split (they otherwise share one fence
+    and the within-thread fold is invisible -> over-merge across unordered / inner_tree).
+
+    ``sinks`` is EVERY reachable value-DAG root, not just the ``st.global`` stores: a softmax /
+    layernorm output is the full tile written through ``ldmatrix`` (a transposed read the walk fails
+    closed on, so the ``st.global`` root is an opaque relocation), which buries the ``sum(e)`` reduction
+    mid-computation. Scanning the recorded shared-store values and the live registers too surfaces it.
+    The ``Mma``-bearing walk is memoized across all sinks (shared subtrees walked once)."""
+    has_mma = {}
+    for root in sinks:
+        for n in _postorder(root):
+            if id(n) in has_mma:
+                continue
+            has_mma[id(n)] = isinstance(n, Mma) or any(has_mma[id(c)] for c in n.children)
+            if isinstance(n, (ShflCombine, SmemExchange)) and has_mma[id(n)]:
+                return True
+            if (isinstance(n, FpOp) and not n.fused and n.kind in ("add", "min", "max")
+                    and len(n.children) == 2 and all(has_mma[id(c)] for c in n.children)):
+                return True
+    return False
+
+
 def _mma_entry_descriptor(func, fence):
     """Descriptor for an entry containing MMA (tensor-core) ops, via the tiling-invariant fence.
 
-    A PURE GEMM (MMA, no reduction butterfly) is the fence ALONE -> num_warps + BLOCK_M/BLOCK_N are
-    free (recovered), with ``loops=`` kept (BLOCK_K is a real, bit-relevant K split). An MMA + a
-    ``shfl.bfly`` reduction (e.g. FA softmax) is FAIL-CLOSED: the fence AND the reduction fingerprint
-    both ride, so configs differing in EITHER the MMA shape OR the reduction order split (sound, never
-    over-merged). The reduction fingerprint carries num_warps back in that case; the pure GEMM drops
-    it deliberately (num_warps is a free re-tiling of the same dot products)."""
+    A PURE GEMM (MMA, no reduction over the output) is the fence ALONE -> num_warps + BLOCK_M/BLOCK_N
+    are free (recovered), with ``loops=`` kept (BLOCK_K is a real, bit-relevant K split). An MMA + a
+    reduction OVER the MMA output (FA softmax, or gemm_reduce_sum / softmax / layernorm) is FAIL-CLOSED:
+    the fence AND the reduction fingerprint both ride, so configs differing in EITHER the MMA shape OR
+    the reduction order split (sound, never over-merged). The reduction is detected structurally
+    (:func:`_epilogue_reduces_mma`) rather than by ``shfl.bfly`` presence, so a within-thread epilogue
+    fold (no shuffle) — which the shfl-only trigger missed, over-merging unordered vs inner_tree — is
+    now caught. The reduction fingerprint carries num_warps back in that case; the pure GEMM drops it
+    deliberately (num_warps is a free re-tiling of the same dot products)."""
     from bitequiv.ptx.forward.loops import reduction_trip_signature
     from bitequiv.ptx_reduction import _loop_steps
     parts = [_fence_str(fence)]
-    if any(inst.opcode == "shfl" and ".bfly" in inst.modifiers for inst in linearize(func)):
-        interp = ForwardInterp(func)
-        interp.run()
+    interp = ForwardInterp(func)
+    roots = interp.run()
+    # Ride the reduction fingerprint when the entry reduces over the MMA output. Detected two ways,
+    # OR'd so the trigger is a strict SUPERSET of the old ``shfl.bfly`` one (can only ADD splitting):
+    # (1) any ``shfl.bfly`` — a cross-lane / cross-warp reduction (the reconstructed tree may fail
+    #     closed on an unmatched shared load, hiding the Mma leaves, so the structural detector alone
+    #     under-fires here); (2) ``_epilogue_reduces_mma`` — a within-thread fold (no shuffle) over the
+    #     MMA output, which (1) misses and which otherwise over-merges across the reduction order. The
+    #     detector scans every reachable value-DAG (roots + recorded shared stores + live registers),
+    #     since a softmax / layernorm reduction is buried behind the ldmatrix output relocation.
+    sinks = list(roots)
+    sinks += [v for _, v in interp.smem_stores if hasattr(v, "children")]
+    sinks += [v for v in interp.regs.values() if hasattr(v, "children")]
+    has_shfl = any(inst.opcode == "shfl" and ".bfly" in inst.modifiers for inst in linearize(func))
+    if has_shfl or _epilogue_reduces_mma(sinks):
         parts.append("mma+red|" + interp.fingerprint())
     steps = _loop_steps(func)  # BLOCK_K split (+ the tcgen05 / fp8 K carried here, not in the token)
     if steps:

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -460,12 +460,13 @@ def forward_descriptor(func):
 
 def _fence_str(fence):
     """Canonical string for an :func:`bitequiv.ptx.mma._mma_fence` tuple (frozensets sorted so the
-    string is deterministic across runs). The ratio is (mma : fma : add/mul) — fma kept apart from
-    add/mul so enable_fp_fusion on/off never collide."""
+    string is deterministic across runs). The f32 epilogue rides as PRESENCE ``(has_fma, has_addmul)``
+    — fma kept apart from add/mul so enable_fp_fusion on/off never collide, but NOT counted (the count
+    is M/N-tile-scaled and would over-split equivalent re-tilings)."""
     if fence[0] == "mma":
-        _, tokens, flags, ratio = fence
+        _, tokens, flags, epi = fence
         return (f"mma|tok={'/'.join(sorted(tokens))}|fl={','.join(sorted(flags))}"
-                f"|r={ratio[0]}:{ratio[1]}:{ratio[2]}")
+                f"|epi=fma{epi[0]},addmul{epi[1]}")
     _, counts, flags, fa = fence  # mma-fp8 fallback: raw per-token counts + (fma, add/mul) (more split)
     counts_s = "/".join(f"{t}x{n}" for t, n in counts)
     return f"mma-fp8|tok={counts_s}|fl={','.join(sorted(flags))}|fma_addmul={fa[0]},{fa[1]}"

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -480,6 +480,7 @@ def _mma_entry_descriptor(func, fence):
     both ride, so configs differing in EITHER the MMA shape OR the reduction order split (sound, never
     over-merged). The reduction fingerprint carries num_warps back in that case; the pure GEMM drops
     it deliberately (num_warps is a free re-tiling of the same dot products)."""
+    from bitequiv.ptx.forward.loops import reduction_trip_signature
     from bitequiv.ptx_reduction import _loop_steps
     parts = [_fence_str(fence)]
     if any(inst.opcode == "shfl" and ".bfly" in inst.modifiers for inst in linearize(func)):
@@ -489,6 +490,15 @@ def _mma_entry_descriptor(func, fence):
     steps = _loop_steps(func)  # BLOCK_K split (+ the tcgen05 / fp8 K carried here, not in the token)
     if steps:
         parts.append("loops=" + ",".join(map(str, steps)))
+    sig = reduction_trip_signature(func)
+    if sig is not None:
+        # A GEMM whose K sum is regrouped by an OUTER reduction loop (split-K: partials combined) is
+        # NOT bitwise-equivalent across split counts, yet its static MMA/op structure is identical, so
+        # the tiling-invariant fence over-merges them (num_splits 1==2, 4==8). Fail closed on the
+        # loop-control fingerprint (the setp trip constants), which differs per split count -> sound.
+        # A plain single-K-loop GEMM has no such nested reduction -> sig is None -> fence unchanged.
+        # Precise per-split recovery (nested LoopReduce) is the follow-up.
+        parts.append("splits=" + hashlib.sha1(repr(sig).encode()).hexdigest()[:8])
     return "|".join(parts)
 
 

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -200,6 +200,16 @@ class ForwardInterp:
                 val = inst.operands[1]  # scalar shared store: record its value for later loads
                 if isinstance(val, RegisterOperand):
                     self.smem_stores.append((at, self._node(val, at)))
+                else:
+                    # A VECTOR st.shared writes a packed multi-element slot this phase does not model.
+                    # Skipping it silently is UNSOUND: a later scalar ld.shared would then resolve to a
+                    # STALE earlier store while faithful stays True (the tree is wrong but TRUSTED, so
+                    # two bit-different configs can collapse to one descriptor -> OVER-MERGE). Fail
+                    # closed instead. (The DCR / reviewer soundness concern on D112727538. The remaining
+                    # address-agnostic multi-buffer case among all-scalar stores -- resolving a scalar
+                    # load to a DIFFERENT scalar buffer -- needs address-matched resolution and is a
+                    # follow-up, bundled with the multi-output cross-warp recovery.)
+                    self.faithful = False
                 continue
             if op == "mov" and ".b64" in mods and len(inst.operands) == 2 and self._b64_mov(inst, at):
                 continue  # mov.b64 pack ({lo,hi}->rd) / unpack (rd->{lo,hi}) handled in place
@@ -249,23 +259,10 @@ class ForwardInterp:
         # OpaqueOp NODE with its register operands as children + non-register operands in the token,
         # EXACTLY like the backward else-branch, so the value-DAG matches. A pure integer/address op
         # is stored too but never pulled into a value tree (value ops read value operands; addresses
-        # go through the affine domain), so this is harmless and lazy at the descriptor level.
-        # An unmodeled op that CONSUMES a transient marker (a _Shuffle butterfly partner, or a
-        # _Packed f32x2 pair — directly or via a vector operand) would have `_scalar` silently STRIP
-        # it -> the reduction ORDERING (count-up vs count-down) or the packed lane structure is lost
-        # -> OVER-MERGE. Idiom 2 RECONSTRUCTS the packed reductions above (`.f32x2` combine, `mov.b64`
-        # pack/unpack); a marker still reaching HERE is genuinely unmodeled -> fail closed, and the
-        # fingerprint's ordered shfl sequence + store widths then distinguish the configs. A benign
-        # opaque with NO marked operand (an f64 `or.b64`, a `cvt`) keeps faithful=True and recovers.
-        def _marked(o):
-            if isinstance(o, RegisterOperand):
-                return isinstance(self._val(o, at), (_Shuffle, _Packed))
-            if isinstance(o, VectorOperand):
-                return any(isinstance(e, RegisterOperand)
-                           and isinstance(self._val(e, at), (_Shuffle, _Packed)) for e in o.elements)
-            return False
-
-        if any(_marked(o) for o in inst.operands[1:]):
+        # go through the affine domain), so this is harmless and lazy at the descriptor level. If an
+        # operand still carries a transient marker HERE it is genuinely unmodeled (the packed
+        # reductions were reconstructed above) -> fail closed (see `_consumes_marker`).
+        if any(self._consumes_marker(o, at) for o in inst.operands[1:]):
             self.faithful = False
         reg_ops = [o for o in inst.operands[1:] if isinstance(o, RegisterOperand)]
         others = [o for o in inst.operands[1:] if not isinstance(o, RegisterOperand)]
@@ -273,6 +270,20 @@ class ForwardInterp:
         if others:
             tok += "{" + ",".join(canon(self.ev.of_operand(o, at)) for o in others) + "}"
         return OpaqueOp(tok, tuple(self._node(o, at) for o in reg_ops))
+
+    def _consumes_marker(self, operand, at):
+        """True if ``operand`` (a register, or a vector of registers) currently holds a transient
+        ``_Shuffle`` / ``_Packed`` marker. An unmodeled op that consumes one would have ``_scalar``
+        silently STRIP it -> the reduction ORDERING (count-up vs count-down) or the packed lane
+        structure is lost -> OVER-MERGE. The caller fails closed when this is True; the fingerprint's
+        ordered shfl sequence + store widths then distinguish the configs. A benign opaque with NO
+        marked operand (an f64 ``or.b64``, a ``cvt``) keeps ``faithful`` True and still recovers."""
+        if isinstance(operand, RegisterOperand):
+            return isinstance(self._val(operand, at), (_Shuffle, _Packed))
+        if isinstance(operand, VectorOperand):
+            return any(isinstance(e, RegisterOperand)
+                       and isinstance(self._val(e, at), (_Shuffle, _Packed)) for e in operand.elements)
+        return False
 
     def _loop_reduce(self, inst, acc, at):
         """A loop-carried ``acc = acc + chunk`` -> ``LoopReduce(add, chunk, key)``, summarizing the

--- a/bitequiv/ptx/forward/loops.py
+++ b/bitequiv/ptx/forward/loops.py
@@ -166,29 +166,70 @@ def outer_reduction_loops(insts, loops):
     return out
 
 
-def reduction_trip_signature(func):
-    """Hashable fingerprint that distinguishes the outer reduction loops' TRIP COUNTS (the split-K
-    regrouping), or ``None`` when the entry has no nested-reduction structure (a plain GEMM, whose K
-    sum is a single in-order fold that tiling never regroups).
-
-    A split-K GEMM's static instruction structure is IDENTICAL across split counts — only the outer
-    loop's runtime TRIP differs — so the checker must key on the loop-control constants. We return the
-    sorted set of ``setp`` immediate compare-constants in the entry: the outer split loop's bound
-    (= num_splits) and the inner K-loop's bound both appear here as literals and both change with the
-    split count, so different split counts get different signatures (SOUND, never over-merged). This is
-    a FAIL-CLOSED fingerprint of the trip structure — the checker cannot yet model the split regrouping
-    precisely; exact per-split recovery (nested ``LoopReduce``) is a follow-up. Returns ``None`` unless
-    an outer reduction loop exists, so a plain tiled GEMM keeps its tiling-invariant fence."""
-    insts, loops = find_loops(func)
-    if not outer_reduction_loops(insts, loops):
-        return None
-    consts = set()
+def _setp_bounds_of(insts, regs):
+    """Constants each register in ``regs`` is compared to across the entry's ``setp`` instructions."""
+    out = set()
     for inst in insts:
         if inst.opcode == "setp" and len(inst.operands) >= 3:
-            for o in inst.operands[1:]:
-                if isinstance(o, ImmediateOperand):
+            for x, y in ((inst.operands[1], inst.operands[2]), (inst.operands[2], inst.operands[1])):
+                if isinstance(x, RegisterOperand) and x.name in regs and isinstance(y, ImmediateOperand):
                     try:
-                        consts.add(int(o.text, 0))
+                        out.add(int(y.text, 0))
                     except (ValueError, TypeError):
                         continue
-    return tuple(sorted(consts))
+    return out
+
+
+def reduction_trip_signature(func):
+    """Hashable fingerprint that distinguishes the outer reduction loops' TRIP COUNTS (the split-K
+    regrouping = num_splits), or ``None`` when the entry has no nested-reduction structure (a plain
+    GEMM, whose K sum is a single in-order fold that tiling never regroups). Same num_splits across any
+    tiling -> same signature (RECOVERS num_warps / BLOCK_M / BLOCK_N); different num_splits -> different
+    signature (SOUND).
+
+    A split-K GEMM's static instruction structure is IDENTICAL across split counts — only the outer
+    loop's runtime TRIP differs — so we key on the loop-control constants, in two tiers:
+    - the ``("trip", ...)`` tier is the split loops' scalar self-increment COUNTER `(step, bound)` (a
+      LOOPED split has `s += 1` guarded by `s < num_splits`); the bound is num_splits, tiling-invariant.
+    - a small split count is peeled (no counter) at some tilings, so the ``("region", ...)`` tier falls
+      back to the split loops' in-region ``setp`` constants (the split + inner-K bounds), which are
+      likewise tiling-invariant per split count.
+    Both are keyed on num_splits and independent of the tiling axes, so they recover the tiling freedom
+    while keeping the split counts distinct. Returns ``None`` unless an outer reduction loop exists, so
+    a plain tiled GEMM keeps its tiling-invariant fence."""
+    insts, loops = find_loops(func)
+    splitloops = outer_reduction_loops(insts, loops)
+    if not splitloops:
+        return None
+    clean = set()
+    for h, latch in splitloops:
+        steps = {}
+        for k in range(h, latch + 1):
+            inst = insts[k]
+            if inst.opcode == "add" and len(inst.operands) == 3:
+                d, a, b = inst.operands
+                if (isinstance(d, RegisterOperand) and isinstance(a, RegisterOperand)
+                        and d.name == a.name and isinstance(b, ImmediateOperand)):
+                    try:
+                        steps[d.name] = int(b.text, 0)
+                    except (ValueError, TypeError):
+                        continue
+        for reg, step in steps.items():
+            for bound in _setp_bounds_of(insts, {reg}):
+                clean.add((step, bound))
+    if clean:
+        return ("trip", tuple(sorted(clean)))
+    region = []
+    for h, latch in splitloops:
+        cs = set()
+        for k in range(h, latch + 1):
+            inst = insts[k]
+            if inst.opcode == "setp" and len(inst.operands) >= 3:
+                for o in inst.operands[1:]:
+                    if isinstance(o, ImmediateOperand):
+                        try:
+                            cs.add(int(o.text, 0))
+                        except (ValueError, TypeError):
+                            continue
+        region.append(tuple(sorted(cs)))
+    return ("region", tuple(sorted(region)))

--- a/bitequiv/ptx/forward/loops.py
+++ b/bitequiv/ptx/forward/loops.py
@@ -134,3 +134,61 @@ def loop_carried_accumulators(insts, loop, loops):
             if acc is not None:
                 out.append((acc, inst))
     return out
+
+
+def outer_reduction_loops(insts, loops):
+    """Loops whose range contains BOTH a matmul AND a self-accumulating fp combine (``acc = acc + x``)
+    — an OUTER reduction that COMBINES matmul partials. Split-K is the canonical case: the split loop's
+    ``acc += partial`` wraps the inner K-loop's MMA. A plain tiled GEMM's single K-loop contains the
+    MMA but NO in-loop self-accumulate (the MMA itself IS the accumulation into a TMEM/register acc),
+    so it is not flagged and keeps its tiling-invariant fence.
+
+    The outer loop's TRIP COUNT (= number of partials combined = num_splits) is bit-relevant: it
+    regroups the K sum (``((s0)+(s1))+...`` vs one in-order fold), so different trips are NOT
+    bitwise-equivalent even though the static MMA/op structure is identical across trips. This is the
+    reusable structural hook for any nested-reduction GEMM (split-K, tree-combine, GEMM+reduction).
+
+    Detection = a loop whose range contains a self-accumulating fp combine ``acc = acc + x`` (dst ==
+    src0) — a running fp total folded across iterations. Split-K's split loop (``acc += partial``) is
+    exactly that; a plain tiled GEMM accumulates via the MMA/TMEM accumulator itself (no fp add) and
+    has none, so it keeps its tiling-invariant fence.
+
+    Keying on the self-accumulate combine (not nested matmul loops) is what survives the compiler
+    restructuring at some tilings: at BLOCK_N=256 the split loop and the MMA K-loop are emitted as
+    SEPARATE / overlapping loops (the split loop's range holds NO matmul), so a nested-matmul-loop test
+    misses the split structure and over-merges the split counts. The split loop still carries the
+    ``acc += partial`` combine, so a range scan for it fires in both the nested and the flattened form."""
+    out = []
+    for lp in loops:
+        h, latch = lp
+        if any(_self_accumulate(insts[k]) is not None for k in range(h, latch + 1)):
+            out.append(lp)
+    return out
+
+
+def reduction_trip_signature(func):
+    """Hashable fingerprint that distinguishes the outer reduction loops' TRIP COUNTS (the split-K
+    regrouping), or ``None`` when the entry has no nested-reduction structure (a plain GEMM, whose K
+    sum is a single in-order fold that tiling never regroups).
+
+    A split-K GEMM's static instruction structure is IDENTICAL across split counts — only the outer
+    loop's runtime TRIP differs — so the checker must key on the loop-control constants. We return the
+    sorted set of ``setp`` immediate compare-constants in the entry: the outer split loop's bound
+    (= num_splits) and the inner K-loop's bound both appear here as literals and both change with the
+    split count, so different split counts get different signatures (SOUND, never over-merged). This is
+    a FAIL-CLOSED fingerprint of the trip structure — the checker cannot yet model the split regrouping
+    precisely; exact per-split recovery (nested ``LoopReduce``) is a follow-up. Returns ``None`` unless
+    an outer reduction loop exists, so a plain tiled GEMM keeps its tiling-invariant fence."""
+    insts, loops = find_loops(func)
+    if not outer_reduction_loops(insts, loops):
+        return None
+    consts = set()
+    for inst in insts:
+        if inst.opcode == "setp" and len(inst.operands) >= 3:
+            for o in inst.operands[1:]:
+                if isinstance(o, ImmediateOperand):
+                    try:
+                        consts.add(int(o.text, 0))
+                    except (ValueError, TypeError):
+                        continue
+    return tuple(sorted(consts))

--- a/bitequiv/ptx/mma.py
+++ b/bitequiv/ptx/mma.py
@@ -14,20 +14,21 @@ Soundness (over-split, never over-merge):
 - Each DROPPED piece is tiling-free: the m/n tile dims (retiling the SAME dot products across a
   different BLOCK_M / BLOCK_N is bit-identical) and the issue/transpose mods
   (``.mma_async`` / ``.sync`` / ``.aligned`` / ``.row`` / ``.col``).
-- The ``(mma_count, f32-fp-count)`` ratio is GCD-reduced, so proportional M/N tiling (n128 ->
-  2x n64 doubles BOTH counts) reduces to the same ratio (sound merge), while a real K split (which
-  changes the counts disproportionately) stays distinct.
-- fp8 (e4m3/e5m2/...): the ``max_num_imprecise_acc`` periodic-flush cadence is invisible to the
-  reduced ratio, so we FALL BACK to the raw per-token count map + raw fp count (strictly more
-  splitting).
-- tcgen05 M/N/K live in a runtime descriptor, not the modifiers, so tcgen05 K rides the ratio + the
-  caller's ``loops=`` (BLOCK_K) fence rather than the token — conservative.
+- The f32 epilogue fp ops ride as PRESENCE ``(has_fma, has_addmul)`` — NOT a count: the op count
+  scales with the M/N tile (elements per thread) while tcgen05's mma count does not, so a count
+  (even GCD-reduced) cannot cancel the tile scaling and over-splits equivalent re-tilings (measured:
+  num_splits 1..8 x tilings -> 20 classes for a 4-class split-K kernel). Presence keeps
+  enable_fp_fusion (fma single-rounded vs add+mul double-rounded) distinct; the bit-relevant K
+  regrouping rides the token / caller's ``loops=`` (BLOCK_K) / ``splits=`` (num_splits) instead.
+- fp8 (e4m3/e5m2/...): the ``max_num_imprecise_acc`` periodic-flush cadence is invisible even to
+  presence, so we FALL BACK to the raw per-token count map + raw fp count (strictly more splitting).
+- tcgen05 M/N/K live in a runtime descriptor, not the modifiers, so tcgen05 K rides ``loops=``
+  (BLOCK_K) + ``splits=`` (num_splits) rather than the token — conservative.
 
 This module is the single source of truth for both the forward interpreter and the backward
 ``_entry_signature`` (which currently uses the coarser ``_mma_guard``).
 """
 import re
-from math import gcd
 
 from bitequiv.ptx.linker import linearize
 
@@ -44,9 +45,9 @@ _MMA_DTYPES = frozenset({".f64", ".f32", ".tf32", ".f16", ".bf16", ".s32", ".s8"
 # The single tile+K modifier token, e.g. `.m64n128k16` (wgmma / mma.sync / wmma).
 _TILE_RE = re.compile(r"^\.m(\d+)n(\d+)k(\d+)$")
 
-# fp reduce/epilogue ops whose count scales with the MMA tile count, so the GCD-reduced
-# (mma_count, fp_count) ratio cancels proportional M/N tiling. f32 family only (the accumulate /
-# epilogue precision that matters).
+# fp reduce/epilogue ops. Their COUNT scales with the M/N tile (elements per thread), so the fence
+# records only their PRESENCE (has_fma, has_addmul), never the count. f32 family only (the accumulate
+# / epilogue precision that matters).
 _FP_EPI_OPS = frozenset({"add", "sub", "mul", "fma"})
 _FP_EPI_WIDTHS = frozenset({".f32", ".f32x2"})
 
@@ -109,8 +110,9 @@ def _fp_epi_counts(func):
     flips fma <-> mul+add in the epilogue, and the compiler can emit the SAME TOTAL count either way
     (measured on gemm_bias_relu_fp_fusion: 16 fma fused vs 16 add/mul unfused) — so a single lumped
     count collides and over-merges (fma is single-rounded, mul+add double-rounded -> different bits).
-    Keeping fma apart splits fp_fusion on/off. Both scale with the MMA tile count, so the GCD-reduced
-    ratio still cancels proportional M/N tiling."""
+    Keeping fma apart splits fp_fusion on/off. Both COUNTS scale with the M/N tile (elements per
+    thread), so the fence records only their PRESENCE, not the count (a count over-splits equivalent
+    re-tilings — see :func:`_mma_fence`)."""
     fma, addmul = 0, 0
     for inst in linearize(func):
         if not (inst.modifiers and inst.modifiers[-1] in _FP_EPI_WIDTHS):
@@ -126,9 +128,14 @@ def _mma_fence(func):
     """Tiling-invariant fence for an entry's MMA ops, or ``None`` if the entry has no MMA.
 
     Returns a hashable tuple. Two entries with equal fences differ only in a bit-IRRELEVANT tiling
-    choice; any bit-relevant difference (K split, dtype, flag, or a non-proportional op-count change)
-    yields a distinct fence. fp8 falls back to the raw per-token count map + raw fp count (strictly
-    more splitting) because its imprecise-acc flush cadence is invisible to the reduced ratio."""
+    choice; any bit-relevant difference (K split, dtype, flag, enable_fp_fusion) yields a distinct
+    fence. The f32 epilogue rides as PRESENCE ``(has_fma, has_addmul)`` — NOT a count: the op count
+    scales with the M/N tile (elements per thread) while tcgen05's mma count does not, so a count
+    (even GCD-reduced) cannot cancel the tile scaling and over-splits equivalent re-tilings. The
+    bit-relevant K regrouping (BLOCK_K, num_splits) rides the token / caller's ``loops=`` /
+    ``splits=`` instead of the op count. fp8 still falls back to the raw per-token count map + raw fp
+    count (strictly more splitting) because its imprecise-acc flush cadence is invisible even to
+    presence."""
     insts = [i for i in linearize(func) if _is_mma(i)]
     if not insts:
         return None
@@ -143,6 +150,4 @@ def _mma_fence(func):
         for t in tokens:
             counts[t] = counts.get(t, 0) + 1
         return ("mma-fp8", tuple(sorted(counts.items())), flags, (fma, addmul))
-    n = len(insts)
-    g = gcd(gcd(n, fma), addmul) or 1  # GCD over all three -> proportional M/N tiling cancels
-    return ("mma", frozenset(tokens), flags, (n // g, fma // g, addmul // g))
+    return ("mma", frozenset(tokens), flags, (int(fma > 0), int(addmul > 0)))

--- a/bitequiv/ptx/treeir.py
+++ b/bitequiv/ptx/treeir.py
@@ -164,7 +164,13 @@ class ShflCombine:
         return (self.child, )
 
     def sig_local(self, child_sigs):
-        return f"shfl{self.offset}.{self.kind}{''.join(self.mods)}({child_sigs[0]})"
+        # .rn is the DEFAULT rounding for add (add.f32 == add.rn.f32 bit-for-bit), so strip it here
+        # the same way FpOp / ITreeReduce do: enable_fp_fusion on/off flips implicit-vs-explicit .rn
+        # on the butterfly combine, and keeping mods verbatim spuriously split a pure-add reduction
+        # (unordered / partially-collapsed) across fp_fusion on num_warps-invariant bits. min/max
+        # carry no .rn so they are unaffected; sub/div are not reduce butterflies.
+        m = _norm("".join(self.mods)) if self.kind in ("add", "mul", "fma") else "".join(self.mods)
+        return f"shfl{self.offset}.{self.kind}{m}({child_sigs[0]})"
 
     def sig(self):
         return self.sig_local([self.child.sig()])

--- a/bitequiv/tests/test_ptx_forward.py
+++ b/bitequiv/tests/test_ptx_forward.py
@@ -131,6 +131,54 @@ def test_mma_entry_gets_fence_descriptor():
     assert desc.startswith("mma|tok=") and "k16" in desc and "m64" not in desc
 
 
+# -- Phase 4b: a reduction OVER the MMA output rides the reduction fingerprint (soundness) ----------
+# The tiling-invariant fence over-merges a GEMM whose epilogue REDUCES C = A @ B across configs that
+# differ only in the reduction ORDER (gemm_reduce_sum / softmax / layernorm): the reduction can lower
+# to a within-thread add fold with NO shfl.bfly, which the old shfl-only trigger missed -> the fence
+# alone -> unordered and inner_tree collapse to one descriptor -> OVER-MERGE (measured 1/kernel).
+# The MMA output is now an ``Mma`` leaf and ``_epilogue_reduces_mma`` detects the fold, so the
+# reduction fingerprint rides the descriptor and the orders split.
+
+_WGMMA4 = "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%f1, %f2, %f3, %f4}, %rd3, %rd4;\n"
+
+
+def _mma_body(body):
+    return (_HDR + ".visible .entry k(.param .u64 po)\n{\n.reg .b64 %rd<6>;\n.reg .f32 %f<16>;\n"
+            "ld.param.u64 %rd1, [po];\ncvta.to.global.u64 %rd2, %rd1;\n" + body + "ret;\n}\n")
+
+
+def test_mma_within_thread_reduction_rides_fingerprint():
+    # A within-thread add fold over the 4 MMA-output lanes (no shfl.bfly) is a reduction over the MMA
+    # output -> the descriptor carries "mma+red" (the fingerprint), not the fence alone.
+    (desc, ) = forward_module_descriptor(
+        _mma_body(_WGMMA4 + "add.f32 %f5, %f1, %f2;\nadd.f32 %f6, %f5, %f3;\n"
+                  "add.f32 %f7, %f6, %f4;\nst.global.f32 [%rd2], %f7;\n"))
+    assert desc.startswith("mma|") and "mma+red" in desc
+
+
+def test_mma_elementwise_epilogue_stays_pure_fence():
+    # An elementwise epilogue (acc + bias): the add has a non-Mma child (bias from ld.global), so it is
+    # NOT a reduction over the MMA output -> the clean tiling-invariant fence, no "mma+red" (must not
+    # over-split the pure GEMMs, e.g. gemm_bias_relu).
+    (desc, ) = forward_module_descriptor(
+        _mma_body(_WGMMA4 + "ld.global.f32 %f5, [%rd2];\nadd.f32 %f6, %f1, %f5;\n"
+                  "st.global.f32 [%rd2], %f6;\n"))
+    assert desc.startswith("mma|") and "mma+red" not in desc
+
+
+def test_mma_reduction_orders_do_not_over_merge():
+    # Two entries with the IDENTICAL MMA fence but within-thread reductions of different op count (the
+    # unordered-255 vs inner_tree-209 shape difference) must NOT share a descriptor. The old shfl-only
+    # trigger left both as the bare fence -> one class -> over-merge; riding the fingerprint splits them.
+    three = forward_module_descriptor(
+        _mma_body(_WGMMA4 + "add.f32 %f5, %f1, %f2;\nadd.f32 %f6, %f5, %f3;\n"
+                  "add.f32 %f7, %f6, %f4;\nst.global.f32 [%rd2], %f7;\n"))
+    two = forward_module_descriptor(
+        _mma_body(_WGMMA4 + "add.f32 %f6, %f1, %f2;\nadd.f32 %f7, %f6, %f3;\n"
+                  "st.global.f32 [%rd2], %f7;\n"))
+    assert three != two
+
+
 # -- Phase 5: data-dependent control flow fails closed (sound floor) -----------
 
 

--- a/bitequiv/tests/test_ptx_gemm_splitk.py
+++ b/bitequiv/tests/test_ptx_gemm_splitk.py
@@ -1,0 +1,91 @@
+"""Split-K soundness: a GEMM whose K sum is regrouped by an OUTER reduction loop (split-K combining
+per-slice partials) is NOT bitwise-equivalent across split counts, yet its static MMA/op structure is
+identical, so the tiling-invariant MMA fence alone over-merges the split counts. The checker must key on
+the outer loop's TRIP (see ``bitequiv.ptx.forward.loops.reduction_trip_signature`` +
+``_mma_entry_descriptor``). A PLAIN single-K-loop GEMM has no such nested reduction and must keep the
+fence (num_warps / BLOCK_M / BLOCK_N recovered). Hand-crafted PTX, CPU-only."""
+from pyptx.parser import parse
+
+from bitequiv.ptx.forward import loops
+from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
+from bitequiv.ptx_reduction import _ensure_header
+
+_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+_MMA = "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r3}, %r4, %r5;\n"
+
+
+def _entry(ptx):
+    return next(d for d in parse(_ensure_header(ptx)).directives if getattr(d, "is_entry", False))
+
+
+# split-K: an OUTER loop (acc += partial) around an INNER K-loop (the MMA). The outer bound is the
+# split count; only it changes between the two below -> they must get DISTINCT descriptors.
+def _split_ptx(num_splits):
+    return _HDR + f"""
+.visible .entry k(.param .u64 p) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.f32 %f1, 0f00000000;
+  mov.b32 %r1, 0;
+$L__OUTER:
+  mov.b32 %r2, 0;
+$L__INNER:
+  {_MMA}  add.s32 %r2, %r2, 1;
+  setp.lt.s32 %p1, %r2, 16;
+  @%p1 bra $L__INNER;
+  add.f32 %f1, %f1, %f2;
+  add.s32 %r1, %r1, 1;
+  setp.lt.s32 %p2, %r1, {num_splits};
+  @%p2 bra $L__OUTER;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+# plain GEMM: a SINGLE K-loop (the MMA), the acc += is a post-loop epilogue -> no nested reduction.
+_PLAIN = _HDR + f"""
+.visible .entry k(.param .u64 p) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.f32 %f1, 0f00000000;
+  mov.b32 %r2, 0;
+$L__INNER:
+  {_MMA}  add.s32 %r2, %r2, 1;
+  setp.lt.s32 %p1, %r2, 16;
+  @%p1 bra $L__INNER;
+  add.f32 %f1, %f1, %f2;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+def test_nested_reduction_detected_for_split_not_plain():
+    insts, lps = loops.find_loops(_entry(_split_ptx(4)))
+    assert loops.outer_reduction_loops(insts, lps)          # split-K: outer reduction over the K-loop
+    insts, lps = loops.find_loops(_entry(_PLAIN))
+    assert not loops.outer_reduction_loops(insts, lps)      # plain GEMM: single K-loop, no nesting
+
+
+def test_trip_signature_distinguishes_split_count():
+    assert loops.reduction_trip_signature(_entry(_split_ptx(4))) \
+        != loops.reduction_trip_signature(_entry(_split_ptx(8)))
+    assert loops.reduction_trip_signature(_entry(_PLAIN)) is None
+
+
+def test_split_counts_get_distinct_descriptors():
+    # the soundness fix: different split counts must NOT collapse to one descriptor (was the over-merge)
+    assert CHECK(_split_ptx(4)) != CHECK(_split_ptx(8))
+    assert "splits=" in str(CHECK(_split_ptx(4)))
+
+
+def test_plain_gemm_keeps_fence_no_splits():
+    d = CHECK(_PLAIN)
+    assert d and "splits=" not in str(d)                    # fence unchanged -> tiling recovery preserved

--- a/bitequiv/tests/test_ptx_mma.py
+++ b/bitequiv/tests/test_ptx_mma.py
@@ -48,9 +48,9 @@ def test_non_mma_entry_has_no_fence():
     assert _mma_fence(_entry("add.f32 %f1, %f2, %f3;\n")) is None
 
 
-def test_proportional_tiling_reduces_to_same_ratio():
-    # n128 + 1 epilogue add  ==  2x n64 + 2 epilogue adds: same K/dtypes (m/n dropped) and the
-    # GCD-reduced (mma_count, fp_count) ratio is equal -> same fence (bit-irrelevant re-tiling).
+def test_proportional_tiling_reduces_to_same_fence():
+    # n128 + 1 epilogue add  ==  2x n64 + 2 epilogue adds: same K/dtypes (m/n dropped) and the f32
+    # epilogue PRESENCE (has_fma, has_addmul) is equal -> same fence (bit-irrelevant re-tiling).
     one = _mma_fence(_entry(_WGMMA + "add.f32 %f1, %f2, %f3;\n"))
     two = _mma_fence(_entry(
         "wgmma.mma_async.sync.aligned.m64n64k16.f32.f16.f16 {%r1}, %r2, %r3;\n"
@@ -81,4 +81,18 @@ def test_fp_fusion_splits_at_equal_op_count():
     # add/mul (ratio mma:fma:addmul) splits them (fma single-rounded vs mul+add double-rounded).
     fused = _mma_fence(_entry(_WGMMA + "fma.rn.f32 %f1, %f2, %f3, %f4;\nfma.rn.f32 %f5, %f6, %f7, %f8;\n"))
     unfused = _mma_fence(_entry(_WGMMA + "add.f32 %f1, %f2, %f3;\nadd.f32 %f5, %f6, %f7;\n"))
-    assert fused != unfused  # (1 mma, 2 fma, 0 addmul) vs (1 mma, 0 fma, 2 addmul)
+    assert fused != unfused  # presence (has_fma=1, has_addmul=0) vs (has_fma=0, has_addmul=1)
+
+
+def test_epilogue_count_is_presence_not_scaled_count():
+    # The split-K / bias_relu over-split: tcgen05's mma count stays 1 while the f32 epilogue add count
+    # scales with the M/N tile (elements per thread), so a COUNT (even GCD-reduced against the constant
+    # mma count) over-splits equivalent re-tilings. The fence records only PRESENCE, so same-token
+    # entries differing ONLY in addmul COUNT (1 add vs 4 adds) merge -- the recovery this diff adds.
+    _TCG = "tcgen05.mma.cta_group::1.kind::f16 [%r1], %r2, %r3;\n"
+    one = _mma_fence(_entry(_TCG + "add.f32 %f1, %f2, %f3;\n"))
+    four = _mma_fence(_entry(_TCG + "add.f32 %f1, %f2, %f3;\nadd.f32 %f4, %f5, %f6;\n"
+                             "add.f32 %f7, %f8, %f9;\nadd.f32 %f10, %f11, %f12;\n"))
+    assert one == four                                       # presence: both (has_fma=0, has_addmul=1)
+    none = _mma_fence(_entry(_TCG))                          # no epilogue add at all
+    assert none != one                                       # (has_addmul=0) still splits from (1)

--- a/bitequiv/tests/test_ptx_reduction.py
+++ b/bitequiv/tests/test_ptx_reduction.py
@@ -117,7 +117,7 @@ _GOLDEN = {
     "sum_nw4": "c6fda1d478b8",
     "sum_nw8": "dca122a2b82e",
     "dot_fuse_on": "80acbd23018a",
-    "dot_fuse_off": "32aa7e471b9a",
+    "dot_fuse_off": "1cae08676ab8",  # butterfly add.rn.f32 -> add.f32 (ShflCombine .rn normalized; still != fuse_on)
 }
 
 

--- a/bitequiv/tests/test_ptx_smem.py
+++ b/bitequiv/tests/test_ptx_smem.py
@@ -1,0 +1,83 @@
+"""SmemModel soundness: a VECTOR ``st.shared`` must FAIL CLOSED, not let a later scalar ``ld.shared``
+resolve to a stale scalar store (the D112727538 reviewer / DCR over-merge concern).
+
+The bug is latent — no natural eval kernel reconstructs faithfully AND has a scalar-load-after-vector-
+store, which is why it could not be reproduced at runtime. So the demo is hand-crafted PTX (full control
+of the pattern): a scalar-only exchange reconstructs to a real tree hash; adding a vector ``st.shared``
+to a second buffer + a scalar ``ld.shared`` from it makes the OLD code resolve the load to the stale
+scalar store (address-blind) while ``faithful`` stays True — so two kernels that read DIFFERENT buffers
+collapse to ONE descriptor (over-merge). The fix fails closed on the vector store. CPU-only."""
+from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
+
+_HEAD = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+
+# Scalar shared exchange only: st.shared A -> ld.shared A -> reconstructs faithfully (real tree hash).
+PTX_SCALAR = _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {
+  .reg .f32 %f<4>;
+  .reg .b32 %r<4>;
+  .reg .b64 %rd<8>;
+  .shared .align 4 .b8 bufA[128];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  mov.u32 %r2, bufA;
+  st.shared.f32 [%r2], %f1;
+  bar.sync 0;
+  ld.shared.f32 %f2, [%r2];
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f2;
+  ret;
+}
+"""
+
+# Same, plus a VECTOR st.shared to a SECOND buffer B, then a scalar ld.shared from B. WITHOUT the fix
+# the vector store is skipped, the scalar load resolves to the stale scalar store A (address-blind),
+# faithful stays True -> identical descriptor to PTX_SCALAR though it reads B = OVER-MERGE. WITH the fix
+# the vector store fails closed (fingerprint) -> distinct -> sound.
+PTX_VECTOR = _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {
+  .reg .f32 %f<4>;
+  .reg .b32 %r<4>;
+  .reg .b64 %rd<8>;
+  .shared .align 4 .b8 bufA[128];
+  .shared .align 8 .b8 bufB[128];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  mov.u32 %r2, bufA;
+  st.shared.f32 [%r2], %f1;
+  mov.u32 %r3, bufB;
+  st.shared.v2.f32 [%r3], {%f1, %f1};
+  bar.sync 0;
+  ld.shared.f32 %f2, [%r3];
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f2;
+  ret;
+}
+"""
+
+
+def test_scalar_shared_exchange_reconstructs():
+    d = CHECK(PTX_SCALAR)
+    assert d and "fwd-incomplete" not in str(d[0])   # faithful tree hash (scalar exchange is modeled)
+
+
+def test_vector_shared_store_fails_closed():
+    d = CHECK(PTX_VECTOR)
+    assert d and "fwd-incomplete" in str(d[0])        # the fix: vector st.shared -> conservative fingerprint
+
+
+def test_vector_store_no_over_merge():
+    # The two entries read DIFFERENT buffers (A vs B) -> genuinely different computations. The fix keeps
+    # their descriptors distinct; WITHOUT it both resolve the scalar load to buffer A -> one descriptor
+    # (the reviewer's over-merge). This assertion FAILS on the pre-fix code.
+    assert CHECK(PTX_SCALAR) != CHECK(PTX_VECTOR)


### PR DESCRIPTION
Summary:

The tiling-invariant MMA fence over-merged a GEMM whose epilogue REDUCES `C = A@B` (a row-sum / softmax-denominator / layernorm mean+var) across configs that differ only in reduction order. `_mma_entry_descriptor` rode the reduction fingerprint only when it saw a `shfl.bfly`, but at some tilings (e.g. num_warps=4, block_m=128) the N-reduction lowers to a within-thread `add.f32` LEFT-FOLD with no shuffle (255 adds unordered vs 209 inner_tree, all fed by `tcgen05.ld`), so unordered and inner_tree shared one fence and merged despite being bit-different.

Fix (checker-only, `interp.py`): model the MMA output — `wgmma`/`mma.sync`/`wmma` matmul results and the Blackwell `tcgen05.ld` tmem-accumulator read — as an `Mma` boundary leaf; detect a reduction OVER it structurally in `_epilogue_reduces_mma` (a 2-ary `add`/`min`/`max` whose BOTH children carry an `Mma` leaf, or a `ShflCombine`/`SmemExchange` over an Mma-bearing subtree, scanning every reachable value-DAG — roots, recorded shared stores, live registers — because softmax/layernorm bury the `sum(e)` behind the `ldmatrix` output relocation). Trigger = `has_shfl OR _epilogue_reduces_mma`. It EXCLUDES the elementwise epilogue (a bias add has a non-Mma child; relu's max pairs with a constant) and the split-K accumulation (a 1-ary `LoopReduce`), so pure GEMM / bias_relu / split-K keep their clean fence.

Sound by construction: the new trigger is a strict SUPERSET of the old `shfl.bfly` one, so appending the reduction fingerprint can only ADD splitting — it cannot introduce an over-merge.

## What this diff fixes (mid-effort, heavy config, fuzzer R=50)

| kernel | checker / empirical | over-merges |
|---|---|---|
| gemm_reduce_sum | 8 / 4 | 0 (was OM=1) |
| gemm_softmax | 8 / 4 | 0 (was OM=1) |
| gemm_layernorm | 8 / 5 | 0 (was OM=1) |

These three are the Diff-3 GEMM+reduction "hunting" kernels (currently WIP, not yet committed) — shown as the fix's target evidence. They now over-split (8 vs 4-5) rather than over-merge; num_warps is not recovered (the fingerprint is num_warps-bearing), the expected trade-off. Recovering it needs the cross-warp SmemModel (affine smem-address decomposition), a follow-up.

## Full support table — every checker-supported kernel (mid-effort: heavy config space, fuzzer R=50). 0 over-merges everywhere; no regression from this diff.

Reductions (config space = reduction_ordering x num_warps{1..32} x num_stages{1..6} x enable_fp_fusion = 144):

| kernel | config space | checker sets / empirical sets | largest checker / largest empirical | over-merges |
|---|---|---|---|---|
| sum | 144 | 8 / 7 | 60 / 72 | 0 |
| sum_dim1_simple | 144 | 8 / 7 | 60 / 72 | 0 |
| dot | 144 | 24 / 14 | 6 / 36 | 0 |
| cond_reduce | 144 | 24 / 14 | 6 / 36 | 0 |
| sum_2d_keepdim | 144 | 12 / 2 | 12 / 72 | 0 |
| sum_2d_axis0 | 144 | 12 / 7 | 12 / 72 | 0 |
| sum_2d_col | 144 | 12 / 7 | 12 / 72 | 0 |
| sum_2d_col_big | 144 | 12 / 7 | 12 / 72 | 0 |
| sum_3d_outer | 144 | 12 / 7 | 12 / 72 | 0 |
| col_dot | 144 | 24 / 15 | 6 / 36 | 0 |
| col_exp_sum | 144 | 12 / 7 | 12 / 72 | 0 |
| col_bf16 | 144 | 12 / 7 | 12 / 72 | 0 |
| col_max | 144 | 6 / 1 | 24 / 144 | 0 |
| sum_2d_deep | 144 | 12 / 4 | 12 / 72 | 0 |
| sum_3d | 144 | 11 / 2 | 24 / 72 | 0 |
| sum_3d_mid | 144 | 12 / 4 | 12 / 72 | 0 |
| sum_4d | 144 | 11 / 2 | 24 / 72 | 0 |
| sum_multiaxis | 144 | 12 / 2 | 12 / 72 | 0 |
| layernorm | 144 | 8 / 6 | 30 / 36 | 0 |
| softmax | 144 | 24 / 3 | 6 / 72 | 0 |
| rmsnorm | 144 | 12 / 7 | 18 / 36 | 0 |

GEMMs:

| kernel | config space | checker sets / empirical sets | largest checker / largest empirical | over-merges |
|---|---|---|---|---|
| gemm_f16_free_tiling | 12 | 1 / 1 | 12 / 12 | 0 |
| gemm_kloop_block_k | 144 | 1 / 1 | 144 / 144 | 0 |
| gemm_input_precision | 36 | 14 / 3 | 12 / 12 | 0 |
| gemm_fp8_imprecise_acc | 36 | 1 / 1 | 36 / 36 | 0 |
| gemm_bias_relu_fp_fusion | 24 | 2 / 2 | 12 / 12 | 0 |
| gemm_tma_store | 12 | 1 / 1 | 12 / 12 | 0 |
| gemm_splitk | 48 | 4 / 4 | 12 / 12 | 0 |
| gemm_all | 4608 | timed out (per-kernel 480s) — heavy re-measure separately | — | — |

(gemm_input_precision is now measurable — 14/3 — because item-2 D113384117 skips its launch-time-OOM configs instead of aborting the kernel.)

Terms: config space = the tested config selection (axes + heavy grid). checker sets = distinct descriptors the checker assigns (fewer = more tuning freedom recovered). empirical sets = distinct bit-patterns the fuzzer observes (the ground-truth partition). largest checker / largest empirical = biggest single class recovered vs the ceiling. over-merges = configs the checker calls equal that the fuzzer proves differ (MUST be 0 = sound). Mid-effort R=50; a headline RECOVERY claim still needs the convincing (~1000-seed) fuzzer.

## Robustness / soundness sweep (secondary — not a main-line support target)

Beyond the kernels this checker deliberately supports, a standing soundness stress-test runs over two rich, structurally-diverse corpora that are NOT support targets — the torch/Inductor-style kernels (`realistic_inductor_kernels.py`) and the standalone benchmark kernel zoo (`benchmark_kernels.py`): 102 kernels / 4536 configs at ENV-MAX grid (num_warps{1,2,4,8,16,32} x num_stages{1..6}, plus reduction_ordering{unordered,inner_tree} x enable_fp_fusion{on,off} for the Inductor specs; fuzzer R=10-30 per config). Many use semantics the checker does not model, so they over-split (checker partition finer than the empirical ground truth) — expected and harmless; recovery on them is not a goal. The point is soundness, and it holds: 0 genuine over-merges and 0 checker crashes across all 102 kernels — the fail-closed floor held even at ~4x the config space of the first pass, i.e. unmodeled structure only ever over-splits, never over-merges. 27 kernels the checker does not deliberately target still reached perfect precision (checker partition == empirical) for free — real softmax / log_softmax / layernorm / rmsnorm / groupnorm / batchnorm / reduce_* / welford / cross_entropy / swiglu / rope / attention_decode variants — so the existing reduction modeling generalizes to them with no special-casing. The only over-merges in the sweep (312 raw, all on 3 `tl.atomic_add` kernels: scatter_index_add, gemm_splitk, cooperative_global_sum) are not floor holes: those kernels are hardware-non-deterministic — the same config yields different bits across reruns — so bitwise-equivalence is undefined for them (out of contract; already a documented `known_limitation`).

This PR was authored with Claude.

Reviewed By: njriasan

Differential Revision: D113402156
