### PR TITLE
[triton][beta] [Cherry-pick] '[TESTS] Run all tests in CI (#10027)' (#2583)

### DIFF
--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,24 +1,7 @@
 import gc
-from collections import defaultdict
-import hashlib
-
 import pytest
 import tempfile
 import torch
-
-
-def _top_level_test_key(item):
-    nodeid = item.nodeid
-    bracket = nodeid.find("[")
-    return nodeid if bracket == -1 else nodeid[:bracket]
-
-
-def _case_key(item):
-    return item.name
-
-
-def _sha256_hex(s: str) -> str:
-    return hashlib.sha256(s.encode("utf-8")).hexdigest()
 
 
 def pytest_configure(config):
@@ -50,35 +33,6 @@ def _gpu_cleanup():
 
 def pytest_addoption(parser):
     parser.addoption("--device", action="store", default="cuda")
-    parser.addoption(
-        "--max-cases-per-test",
-        action="store",
-        type=int,
-        default=100,
-        help="Maximum number of cases per top-level test",
-    )
-
-
-def pytest_collection_modifyitems(config, items):
-    max_cases = config.getoption("--max-cases-per-test")
-    if max_cases <= 0:
-        return
-
-    groups = defaultdict(list)
-    for item in items:
-        groups[_top_level_test_key(item)].append(item)
-
-    kept = []
-    deselected = []
-    for group in groups.values():
-        ordered = sorted(group, key=lambda item: _sha256_hex(_case_key(item)))
-        kept.extend(ordered[:max_cases])
-        deselected.extend(ordered[max_cases:])
-
-    if deselected:
-        config.hook.pytest_deselected(items=deselected)
-
-    items[:] = kept
 
 
 @pytest.fixture

--- a/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout_details/blackwell_value_shuffled.py
@@ -114,11 +114,6 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         Target layout: [E, num_tiles_k, num_tiles_n, tile_n, tile_k_packed]
         This matches the baseline TMA block shape [block_n, packed_block_k] after swapping.
         """
-        if data.ndim == 2:
-            data = data.unsqueeze(0)
-        if data.ndim != 3:
-            raise ValueError(f"Expected 2D or 3D canonical data, got {data.ndim}D")
-
         data = self._canonical_to_physical(data)
         E, num_tiles_k, num_tiles_n, tile_n, tile_k_packed = self.storage_shape
         K_packed, N = data.shape[-2:]
@@ -151,6 +146,7 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         Input layout: [E, num_tiles_k, num_tiles_n, tile_n, tile_k_packed]
         """
         E = data.shape[0]
+        leading_shape = self.shape[:-2]
         # Recover original shape from self.shape (the logical shape passed to convert_layout)
         orig_K_packed = self.shape[-2] // 2 if self.is_fp4 else self.shape[-2]
         orig_N = self.shape[-1]
@@ -171,4 +167,6 @@ class BlackwellMX4ValueShuffledTransformation(LayoutTransformation):
         # Trim padding back to original shape
         data = data[:, :orig_K_packed, :orig_N].contiguous()
         data = self._physical_to_canonical(data)
-        return data if len(self.shape) == 3 else data.squeeze(0)
+        if not leading_shape:
+            return data.squeeze(0)
+        return data.reshape(*leading_shape, data.shape[-2], data.shape[-1])


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/10027

Upstream commit message:
```
> [TESTS] Run all tests in CI (#10027)

> Revert the cap to the number of tests run in CI from
> https://github.com/triton-lang/triton/pull/10016
> CI times are quite reasonable and we want to catch regressions early.
```

***Do not remove the following line from this commit***
Reactor Backport Revision: 035bcb5c4ca661f5345715901a58a3ee5bc65260
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 10027
```

Reviewed By: agron911

Differential Revision: D114381039


