### PR TITLE
[H100 downstream][Triton][beta] Keep Hopper TMA compatible with PTX < 8.6 (#2586)

### DIFF
--- a/test/Conversion/tma_to_llvm.mlir
+++ b/test/Conversion/tma_to_llvm.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --convert-triton-gpu-to-llvm --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | FileCheck %s
+// RUN: triton-opt %s --convert-triton-gpu-to-llvm=compute-capability=100 --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -284,7 +284,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_global_to_local
   // CHECK: elect.sync
-  // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes [$1], [$2, {$3, $4}], [$5];", "b,r,l,r,r,r" {{.*}} : (i1, !llvm.ptr<3>, !llvm.ptr, i32, i32, !llvm.ptr<3>) -> !llvm.void
+  // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes [$1], [$2, {$3, $4}], [$5];", "b,r,l,r,r,r" {{.*}} : (i1, !llvm.ptr<3>, !llvm.ptr, i32, i32, !llvm.ptr<3>) -> !llvm.void
   // CHECK-NOT: cp.async.bulk.tensor.2d.shared
   // CHECK: return
   tt.func @tma_copy_global_to_local(%tma: !tt.tensordesc<128x128xf32, #shared1>, %alloc: !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
@@ -348,14 +348,14 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
-// TMA copy with barrier mask zero: barrier has no CGALayout -> shared::cta
+// The current pre-PTX-8.6 Hopper path uses shared::cluster even when the
+// barrier has no CGALayout.
 #shared0_cta = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_barrier_mask_zero
-  // CHECK: cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes
-  // CHECK-NOT: cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier
+  // CHECK: cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes
   tt.func @tma_copy_barrier_mask_zero(%tma: !tt.tensordesc<128x128xf32, #shared1>, %alloc: !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0_cta, #smem>, %pred: i1) {
     ttng.async_tma_copy_global_to_local %tma[%x, %x] %alloc, %barrier, %pred : !tt.tensordesc<128x128xf32, #shared1>, !ttg.memdesc<1xi64, #shared0_cta, #smem> -> !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>
     tt.return
@@ -369,7 +369,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true} {
   // CHECK-LABEL: tma_copy_single_cta_barrier_in_two_cta_kernel
-  // CHECK: cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes
   // CHECK-NOT: cp.async.bulk.tensor.2d.cta_group::2
   tt.func @tma_copy_single_cta_barrier_in_two_cta_kernel(%tma: !tt.tensordesc<128x128xf32, #shared1_cga>, %alloc: !ttg.memdesc<128x128xf32, #shared1_cga, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<2xi64, #shared0_cta, #smem>, %pred: i1) {
     ttng.async_tma_copy_global_to_local %tma[%x, %x] %alloc, %barrier, %pred : !tt.tensordesc<128x128xf32, #shared1_cga>, !ttg.memdesc<2xi64, #shared0_cta, #smem> -> !ttg.memdesc<128x128xf32, #shared1_cga, #smem, mutable>
@@ -440,7 +440,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_global_to_local_im2col
   // CHECK: elect.sync
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // CHECK-NOT: cp.async.bulk.tensor.4d.shared
   // CHECK: return
   tt.func @tma_copy_global_to_local_im2col(%tma: !ttng.tensordesc_im2col<16x64xf32, #shared1>, %alloc: !ttg.memdesc<16x64xf32, #shared1, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
@@ -467,16 +467,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // Verify 4 TMA messages are generated with offsets computed via shift-left by 8 (multiply by 256)
   // CHECK-DAG: llvm.mlir.constant(8 : i32)
   // Message 1 (copyIdx=0): offset = 0 << 8 = 0
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // Message 2 (copyIdx=1): offset = 1 << 8 = 256
   // CHECK: llvm.mlir.constant(1 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // Message 3 (copyIdx=2): offset = 2 << 8 = 512
   // CHECK: llvm.mlir.constant(2 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // Message 4 (copyIdx=3): offset = 3 << 8 = 768
   // CHECK: llvm.mlir.constant(3 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // CHECK: return
   tt.func @tma_copy_global_to_local_im2col_multi_msg(%tma: !ttng.tensordesc_im2col<64x1024xf32, #shared2>, %alloc: !ttg.memdesc<64x1024xf32, #shared2, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
     %off_w = arith.constant 1 : i16
@@ -502,16 +502,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // Verify 4 TMA messages are generated with offsets computed via shift-left by 6 (multiply by 64)
   // CHECK-DAG: llvm.mlir.constant(6 : i32)
   // Message 1 (copyIdx=0): offset = 0 << 6 = 0
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // Message 2 (copyIdx=1): offset = 1 << 6 = 64
   // CHECK: llvm.mlir.constant(1 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // Message 3 (copyIdx=2): offset = 2 << 6 = 128
   // CHECK: llvm.mlir.constant(2 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // Message 4 (copyIdx=3): offset = 3 << 6 = 192
   // CHECK: llvm.mlir.constant(3 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // CHECK: return
   tt.func @tma_copy_global_to_local_im2col_multi_msg_swizzle(%tma: !ttng.tensordesc_im2col<64x256xf16, #shared_swz>, %alloc: !ttg.memdesc<64x256xf16, #shared_swz, #smem_swz, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0_swz, #smem_swz>, %pred: i1) {
     %off_w = arith.constant 1 : i16

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1423,8 +1423,12 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       // otherwise it is CTA-local. The barrier component keys on the barrier
       // layout (not the SMEM layout), matching #9510.
       auto multicastMask = op.getMulticastTargets();
-      bool clusterScope = crossCTABarrier || multicast ||
-                          multicastMask != nullptr || op.getTwoCta();
+      // The current Hopper toolchain emits PTX < 8.6, where shared::cta TMA
+      // loads are not accepted. Conservatively use cluster scope on Hopper;
+      // keep CTA scope on Blackwell.
+      bool clusterScope = computeCapability < 100 || crossCTABarrier ||
+                          multicast || multicastMask != nullptr ||
+                          op.getTwoCta();
       std::string tmaInst = "@$0 cp.async.bulk.tensor." + std::to_string(rank) +
                             "d.shared::" + (clusterScope ? "cluster" : "cta") +
                             ".global.mbarrier::complete_tx::bytes";


### PR DESCRIPTION
Summary:

Failed tests:
- MrnTest.test_mrn_numerics_parity_triton
- gdpaTest.test_gdpa_output_offset_calculation
- gdpaTest.test_gdpa_tma_store_functionality
- gdpaTest.test_gdpa_descriptor_initialization (3 parameterizations)
- gdpaTest.test_gdpa_workspace_allocation (3 parameterizations)

Failure:
CUDA 12.4 ptxas rejected the emitted Hopper TMA loads with "State space incorrect for instruction 'cp.async.bulk.tensor'". The current Hopper toolchain emits PTX before 8.6, where the shared::cta form is not accepted, so the tests failed during kernel assembly before their assertions ran.

Fix:
Emit cluster-scoped TMA loads on SM90/Hopper and preserve CTA scope on SM100/Blackwell. This keeps the existing CUDA 12.4 H100 targets working instead of moving them to a newer toolchain.

Reviewed By: njriasan

Differential Revision: D114305038


