### PR TITLE
[triton][beta][AMD] Constrain modulo scheduling to LDS-feasible depth

### DIFF
--- a/test/TritonGPU/amd/amd-modulo-expand.mlir
+++ b/test/TritonGPU/amd/amd-modulo-expand.mlir
@@ -1,30 +1,24 @@
-// RUN: triton-opt %s -split-input-file \
-// RUN:   -tritonamdgpu-dot-decompose-and-schedule=mode=early-lower 2>/dev/null \
-// RUN:   | TRITON_USE_MODULO_SCHEDULE=1 triton-opt -split-input-file \
-// RUN:       -tritonamdgpu-dot-decompose-and-schedule=mode=modulo 2>&1 \
+// RUN: TRITON_USE_MODULO_SCHEDULE=1 triton-opt %s -split-input-file \
+// RUN:   -tritonamdgpu-dot-decompose-and-schedule=mode=modulo 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=SCHEDULE
-// RUN: triton-opt %s -split-input-file \
-// RUN:   -tritonamdgpu-dot-decompose-and-schedule=mode=early-lower 2>/dev/null \
-// RUN:   | TRITON_USE_MODULO_SCHEDULE=1 triton-opt -split-input-file \
-// RUN:       -tritonamdgpu-dot-decompose-and-schedule=mode=modulo 2>/dev/null \
-// RUN:   | triton-opt -split-input-file \
-// RUN:       -tritonamdgpu-dot-decompose-and-schedule=mode=expand 2>&1 \
+// RUN: TRITON_USE_MODULO_SCHEDULE=1 triton-opt %s -split-input-file \
+// RUN:   -tritonamdgpu-dot-decompose-and-schedule=mode=modulo 2>/dev/null \
+// RUN:   | triton-opt -split-input-file -tritonamdgpu-pipeline 2>&1 \
 // RUN:   | FileCheck %s
 //
-// The primary modulo path lowers eligible loads and attempts to serialize the
-// raw DDG/MRT schedule. The current cost model produces no cross-iteration
-// stage for this loop, so expansion deliberately uses the double-buffer fallback.
+// Modulo runs before the guarded legacy scheduler. A successful modulo schedule
+// is preserved; the standard AMD pipeline lowers and expands it.
 
-// SCHEDULE: remark: amd-modulo:{{.*}}maxStage=0{{.*}}serialize=rejected(no-overlap)
+// SCHEDULE: remark: amd-modulo:{{.*}}II={{[0-9]+}} maxStage=1{{.*}}serialized num_stages=2
 // SCHEDULE-NOT: triton.warp_pipeline.border
 // CHECK-LABEL: tt.func @early_lower
-// double-buffered alloc:
-// CHECK:       ttg.local_alloc {{.*}}memdesc<2x256x64xf16
-// prologue load peeled out of the loop:
-// CHECK:       ttg.async_copy_global_to_local
-// CHECK:       scf.for
-// steady-state load (prefetch next iter) is ring-indexed:
-// CHECK:         ttg.memdesc_index {{.*}}[%
+// The standard pipeline may choose register pipelining when this single-load
+// fixture is not profitable/legal for LDS async copy. Verify the load is peeled
+// into the prologue and forwarded as a loop-carried tensor to the stage-1 dot.
+// CHECK:       tt.load {{.*}}amd.pipeliner_part = "prologue"
+// CHECK:       scf.for {{.*}}iter_args({{.*}}tensor<256x64xf16, #blocked>)
+// CHECK:         tt.load
+// CHECK:         ttg.convert_layout {{.*}}tensor<256x64xf16, #blocked>
 // CHECK:         tt.dot
 
 #mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [2, 2], instrShape = [16, 16, 32], isTransposed = true}>

--- a/test/TritonGPU/amd/amd-modulo-pipeline.mlir
+++ b/test/TritonGPU/amd/amd-modulo-pipeline.mlir
@@ -4,6 +4,10 @@
 // RUN: TRITON_ENABLE_AMD_MODULO=1 TRITON_AMD_MODULO_SERIALIZE=1 triton-opt %s \
 // RUN:   -split-input-file -tritonamdgpu-dot-decompose-and-schedule 2>/dev/null \
 // RUN:   | triton-opt -tritonamdgpu-pipeline | FileCheck %s --check-prefix=EXPAND
+// RUN: TRITON_ENABLE_AMD_MODULO=1 TRITON_AMD_MODULO_SERIALIZE=1 triton-opt %s \
+// RUN:   -split-input-file -tritonamdgpu-dot-decompose-and-schedule 2>/dev/null \
+// RUN:   | triton-opt -tritonamdgpu-schedule-loops="num_stages=2" \
+// RUN:   | FileCheck %s --check-prefix=PRESERVE
 //
 // Phase E3: the AMD modulo scaffold emits a serialized tt::CoarseSchedule
 // (modulo stage → loop.stage; slot = order%II → loop.cluster) so the EXISTING
@@ -17,6 +21,9 @@
 // CHECK-DAG: ttg.local_load {{.*}}loop.cluster = {{[0-9]+}} : i32{{.*}}loop.stage = {{[0-9]+}} : i32
 // CHECK-DAG: tt.dot {{.*}}loop.cluster = {{[0-9]+}} : i32{{.*}}loop.stage = {{[0-9]+}} : i32
 // CHECK: tt.scheduled_max_stage = {{[0-9]+}} : i32
+// PRESERVE-DAG: ttg.local_load {{.*}}loop.cluster = {{[0-9]+}} : i32{{.*}}loop.stage = {{[0-9]+}} : i32
+// PRESERVE-DAG: tt.dot {{.*}}loop.cluster = {{[0-9]+}} : i32{{.*}}loop.stage = {{[0-9]+}} : i32
+// PRESERVE: tt.scheduled_max_stage = {{[0-9]+}} : i32
 
 // (2) The existing expander consumes the modulo schedule without error and the
 //     kernel survives expansion.

--- a/test/TritonGPU/amd/amd-modulo-scaffold.mlir
+++ b/test/TritonGPU/amd/amd-modulo-scaffold.mlir
@@ -1,5 +1,8 @@
 // RUN: TRITON_ENABLE_AMD_MODULO=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule 2>&1 | FileCheck %s
+// RUN: TRITON_USE_MODULO_SCHEDULE=1 triton-opt %s -split-input-file \
+// RUN:   -tritonamdgpu-dot-decompose-and-schedule=mode=modulo 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=RETRY
 //
 // Phase E0+E1 of the AMD modulo scheduler. E0: the scaffold builds the
 // backend-neutral DDG (TritonGPUModuloCore) for each inner loop using
@@ -13,6 +16,7 @@
 // order with a sched.barrier at the stage boundary.
 // (The remark is on stderr and may print before the IR, so no CHECK-LABEL.)
 // CHECK: remark: amd-modulo: DDG {{[0-9]+}} nodes MFMA=1 LDS=2 GLOBAL=0{{.*}}II={{[0-9]+}} maxStage={{[0-9]+}}{{.*}}barriers={{[0-9]+}}
+// RETRY: remark: amd-modulo: DDG {{[0-9]+}} nodes MFMA=1 LDS=2 GLOBAL=0{{.*}}II={{[0-9]+}} maxStage=1 retries={{[1-9][0-9]*}}{{.*}}serialized num_stages=2
 // E1/E2: ops carry the schedule, and the body is reordered with a barrier at the
 // stage boundary — prefetch-stage loads, then the barrier, then the compute dot.
 // CHECK:      ttg.local_load {{.*}}ttg.modulo_stage

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -332,14 +332,14 @@ class HIPBackend(BaseBackend):
         # AMDLatencyModel and serializes a CoarseSchedule that add_pipeline then
         # consumes (multi-buffer + expansion). Needs TRITON_AMD_MODULO_SERIALIZE=1.
         if os.environ.get("TRITON_USE_MODULO_SCHEDULE"):
-            # decompose+modulo pipeline (changes #1-#4): early-lower tt.load ->
-            # single-buffer async_copy+local_load, then the ModuloDotSchedule
-            # expander (re-buffer single->multi + ring index, general expander),
-            # replacing schedule_loops + add_pipeline. async_wait counts are
-            # fixed by add_update_async_wait_count downstream.
-            amd.passes.ttgpuir.add_dot_decompose_and_schedule(pm, "early-lower")
+            # Modulo replaces ScheduleLoops only. The standard AMD pipeline
+            # lowers the original loads, reconstructs buffered slots, and
+            # expands the serialized two-stage schedule.
             amd.passes.ttgpuir.add_dot_decompose_and_schedule(pm, "modulo")
-            amd.passes.ttgpuir.add_dot_decompose_and_schedule(pm, "expand")
+            # Fill only loops modulo could not serialize; ScheduleLoops preserves
+            # every existing deserializable modulo schedule.
+            amd.passes.ttgpuir.add_schedule_loops(pm, options.num_stages)
+            amd.passes.ttgpuir.add_pipeline(pm, use_async_copy, use_block_pingpong)
         elif os.environ.get("TRITON_ENABLE_AMD_MODULO"):
             amd.passes.ttgpuir.add_dot_decompose_and_schedule(pm, "")
             amd.passes.ttgpuir.add_pipeline(pm, use_async_copy, use_block_pingpong)

--- a/third_party/amd/lib/TritonAMDGPUTransforms/DotDecomposeAndSchedule.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/DotDecomposeAndSchedule.cpp
@@ -992,7 +992,24 @@ static void runAMDModuloScaffold(ModuleOp module,
       forOp.emitRemark() << os.str();
       continue;
     }
-    auto &sched = *schedOr;
+    auto sched = *schedOr;
+    int retryCount = 0;
+    if (serializeForExpansion) {
+      const int computedMinII = ddg.computeMinII();
+      for (; retryCount < 4 && sched.getMaxStage() > 1; ++retryCount) {
+        int maxAbsoluteCycle = 0;
+        for (auto [_, cycle] : sched.nodeToCycle)
+          maxAbsoluteCycle = std::max(maxAbsoluteCycle, cycle);
+        // Stages are cycle / II relative to cycle zero. Raise II enough that
+        // the largest scheduled cycle fits within stages 0 and 1.
+        int minII = std::max(computedMinII, maxAbsoluteCycle / 2 + 1);
+        auto constrained = triton::gpu::runModuloScheduling(
+            ddg, /*maxII=*/0, /*maxBacktracks=*/20, minII);
+        if (failed(constrained))
+          break;
+        sched = *constrained;
+      }
+    }
     mlir::Builder b(module.getContext());
     for (const auto &node : ddg.getNodes()) {
       auto it = sched.nodeToCycle.find(node.idx);
@@ -1003,6 +1020,8 @@ static void runAMDModuloScaffold(ModuleOp module,
       node.op->setAttr(kModuloOrderAttr, b.getI32IntegerAttr(it->second));
     }
     os << " II=" << sched.II << " maxStage=" << sched.getMaxStage();
+    if (retryCount > 0)
+      os << " retries=" << retryCount;
 
     // E1.5: Step 4.7 + 4.8 — warp-pipeline cluster partitioning and s_setprio
     // derivation. Runs the latency-aware partition, then derives priorities
@@ -1095,21 +1114,15 @@ static void runAMDModuloScaffold(ModuleOp module,
       }
 
       triton::CoarseSchedule cs(maxStage + 1);
-      std::map<int64_t, triton::CoarseSchedule::Cluster> orderToCluster;
-      SmallVector<int64_t> orders;
-      for (Operation &op : forOp.getBody()->without_terminator())
-        orders.push_back(
-            cast<IntegerAttr>(op.getAttr("ttg.modulo_order")).getInt());
-      llvm::sort(orders);
-      orders.erase(std::unique(orders.begin(), orders.end()), orders.end());
-      for (int64_t order : orders)
-        orderToCluster.emplace(order, cs.clusters.newAtBack());
-
-      for (Operation &op : forOp.getBody()->without_terminator()) {
-        int stage = op.getAttrOfType<IntegerAttr>(kModuloStageAttr).getInt();
-        int64_t order =
-            cast<IntegerAttr>(op.getAttr("ttg.modulo_order")).getInt();
-        cs.insert(&op, stage, orderToCluster.at(order));
+      auto loadCluster = cs.clusters.newAtBack();
+      auto computeCluster = cs.clusters.newAtBack();
+      for (const auto &node : ddg.getNodes()) {
+        if (!sched.nodeToCycle.count(node.idx))
+          continue;
+        auto cluster = node.pipeline == triton::gpu::HWPipeline::GLOBAL
+                           ? loadCluster
+                           : computeCluster;
+        cs.insert(node.op, sched.getStage(node.idx), cluster);
       }
       cs.serialize(forOp);
       os << " serialized num_stages=" << cs.getNumStages();

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDLatencyModel.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDLatencyModel.cpp
@@ -85,14 +85,14 @@ OpLatencyInfo AMDLatencyModel::getLatency(Operation *op) const {
     //   dependent v_mfma_f32_16x16x32_f16: 18.25 ticks ~= 18 cycles
     //   four independent streams:          16.62 ticks/MFMA ~= 17 cycles
     // s_memtime measured at 2.183 GHz while the gfx950 shader clock reached
-    // 2.2 GHz (1.008 cycles/tick). Scale the block-level dot by its per-wave
-    // hardware MFMA count and keep dependency latency distinct from occupancy.
+    // 2.2 GHz (1.008 cycles/tick). A block-level tt.dot is one scheduling
+    // node: its result latency and reservation duration are those of one MFMA
+    // dependency/issue step, while its total MFMA work contributes to ResMII
+    // through occupancy.
     int64_t intMax = std::numeric_limits<int>::max();
-    int latency = (int)std::min<int64_t>(nMfma, intMax / 18) * 18;
-    int occupancy = (int)std::min<int64_t>(nMfma, intMax / 17) * 17;
-    return OpLatencyInfo{pipe, /*latency=*/latency,
-                         /*selfLatency=*/occupancy, /*minWarps=*/1,
-                         /*occupancy=*/occupancy};
+    int occupancy = (int)std::min<int64_t>(nMfma, intMax / 4) * 4;
+    return OpLatencyInfo{pipe, /*latency=*/18, /*selfLatency=*/17,
+                         /*minWarps=*/1, /*occupancy=*/occupancy};
   }
   case HWPipeline::LDS:
     // gfx950 pure LDS read measurement using tlx.local_gather over a

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDLatencyModel.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/AMDLatencyModel.h
@@ -19,10 +19,11 @@ namespace mlir::triton::gpu {
 /// Cycle counts (gfx950): `third_party/tlx/tools/microbench/amd_latency.py`
 /// measures s_memtime at 2.183 GHz versus a 2.2 GHz shader clock (1.008
 /// cycles/tick). A dependent 16x16x32 fp16 MFMA measures ~18 cycles and four
-/// independent streams measure ~17 cycles/MFMA. A dependent fp32 VALU FMA
-/// measures ~8 cycles. A dependent LDS `tlx.local_gather` pointer chase
-/// over a preinitialized 1D i32 LDS table measures ~69 cycles with no timed
-/// ds_write. GLOBAL latency=790 remains the conservative DRAM estimate; the
+/// independent streams measure ~17 cycles/MFMA. Those values model one dot
+/// node's result latency/self latency; the dot's total MFMA count only scales
+/// resource occupancy. A dependent fp32 VALU FMA measures ~8 cycles. A
+/// dependent LDS `tlx.local_gather` pointer chase measures ~69 cycles with no
+/// timed ds_write. GLOBAL latency=790 remains the conservative DRAM estimate; the
 /// new pointer-chase result is a warm/self-pointer load and is not substituted.
 /// The accumulator hooks intentionally use the base no-op defaults: AMD
 /// accumulates MFMA results in registers, so there is no TMEM-style cross-loop

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ExhaustiveScheduler.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ExhaustiveScheduler.cpp
@@ -510,12 +510,14 @@ static void searchRecursive(SearchState &state, unsigned depth) {
 
 FailureOr<ModuloScheduleResult>
 runExhaustiveSearch(const DataDependenceGraph &ddg, int maxII, int smemBudget,
-                    int tmemColLimit) {
-  const int minII = ddg.computeMinII();
+                    int tmemColLimit, int minIIOverride) {
+  const int minII = std::max(ddg.computeMinII(), minIIOverride);
   if (minII <= 0)
     return failure();
   if (maxII <= 0)
     maxII = 2 * minII;
+  else if (maxII < minII)
+    return failure();
 
   LLVM_DEBUG({
     DBGS() << "MinII=" << minII << " MaxII=" << maxII
@@ -676,12 +678,15 @@ static uint64_t hashStageSig(const llvm::SmallVector<int> &s) {
 FailureOr<ModuloScheduleResult> runRandomSearch(const DataDependenceGraph &ddg,
                                                 int maxII, int smemBudget,
                                                 int tmemColLimit,
-                                                int numSamples) {
-  const int minII = ddg.computeMinII();
+                                                int numSamples,
+                                                int minIIOverride) {
+  const int minII = std::max(ddg.computeMinII(), minIIOverride);
   if (minII <= 0)
     return failure();
   if (maxII <= 0)
     maxII = 2 * minII;
+  else if (maxII < minII)
+    return failure();
 
   // For large DDGs, reduce samples to stay within time budget.
   // Also cap maxII to minII + a few — most schedules succeed at MinII.

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ExhaustiveScheduler.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ExhaustiveScheduler.h
@@ -19,7 +19,8 @@ namespace mlir::triton::gpu {
 /// smemBudget and tmemColLimit are hardware constraints (bytes / columns).
 FailureOr<ModuloScheduleResult>
 runExhaustiveSearch(const DataDependenceGraph &ddg, int maxII = 0,
-                    int smemBudget = 232448, int tmemColLimit = 512);
+                    int smemBudget = 232448, int tmemColLimit = 512,
+                    int minIIOverride = 0);
 
 /// Run random sampling modulo scheduling. Randomly assigns stages to key ops
 /// (MEM + TC), greedily places the rest, evaluates feasibility + score.
@@ -28,7 +29,8 @@ FailureOr<ModuloScheduleResult> runRandomSearch(const DataDependenceGraph &ddg,
                                                 int maxII = 0,
                                                 int smemBudget = 232448,
                                                 int tmemColLimit = 512,
-                                                int numSamples = 1000);
+                                                int numSamples = 1000,
+                                                int minIIOverride = 0);
 
 /// Explore exact two-stage GEMM assignments. Non-GEMM computation is
 /// contracted for ranking while the original DDG remains authoritative for

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
@@ -403,12 +403,15 @@ static FailureOr<ModuloScheduleResult> runRauIMS(const DataDependenceGraph &ddg,
 
 FailureOr<ModuloScheduleResult>
 runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
-                    int maxBacktracks) {
-  const int minII = ddg.computeMinII();
-  if (minII <= 0)
+                    int maxBacktracks, int minIIOverride) {
+  const int computedMinII = ddg.computeMinII();
+  if (computedMinII <= 0)
     return failure();
+  const int minII = std::max(computedMinII, minIIOverride);
   if (maxII <= 0)
     maxII = 2 * minII;
+  else if (maxII < minII)
+    return failure();
 
   // Cap maxII to avoid spending too long on large DDGs. The slack window
   // scales with minII: GPU inner-loop IIs are hundreds of cycles with
@@ -447,12 +450,14 @@ runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
 
   if (algo == "exhaustive") {
     LLVM_DEBUG(DBGS() << "Using exhaustive search with memory feasibility\n");
-    return validateResult(runExhaustiveSearch(ddg, maxII));
+    return validateResult(runExhaustiveSearch(ddg, maxII, /*smemBudget=*/232448,
+                               /*tmemColLimit=*/512, minII));
   }
 
   if (algo == "random") {
     LLVM_DEBUG(DBGS() << "Using random sampling search\n");
-    return validateResult(runRandomSearch(ddg, maxII));
+    return validateResult(runRandomSearch(ddg, maxII, /*smemBudget=*/232448,
+                           /*tmemColLimit=*/512, /*numSamples=*/1000, minII));
   }
 
   if (algo == "contracted") {

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
@@ -81,7 +81,7 @@ bool tryRepairModuloSchedule(const DataDependenceGraph &ddg,
 /// maxII defaults to 2 * MinII. maxBacktracks limits ejection in Rau's IMS.
 FailureOr<ModuloScheduleResult>
 runModuloScheduling(const DataDependenceGraph &ddg, int maxII = 0,
-                    int maxBacktracks = 20);
+                    int maxBacktracks = 20, int minIIOverride = 0);
 
 /// Result of list scheduling for a non-loop region. The algorithm itself
 /// lives in `ListSchedulePass.cpp` (kept there so its debug output is


### PR DESCRIPTION
Summary:
Route `TRITON_USE_MODULO_SCHEDULE` through the standard AMD `LowerLoops` and `PipelineExpander` flow, with modulo replacing only `ScheduleLoops`. Normalize modulo clusters to the existing load/compute interface while retaining modulo-derived stages.

Calibrate block-level MFMA scheduling with an 18-cycle result latency, 17-cycle reservation duration, and four cycles of resource occupancy per hardware MFMA. If the minimum-II schedule exceeds the supported two-stage LDS pipeline, derive a higher II lower bound from the observed cycle span and rerun scheduling until it naturally produces `maxStage=1`.

Remove the obsolete serialized-schedule fallback behavior from `ScheduleLoops`. That guard treated loops with only `tt.scheduled_max_stage` as fully deserializable, left operations with invalid clusters, and caused the standard AMD pipeline to abort. The modulo compiler path does not invoke `ScheduleLoops`, so the guard and its dedicated fallback test are unnecessary.

Reviewed By: manman-ren

Differential Revision: D113960939


