### PR TITLE
[TLX][AMD] Fuse split-K epilogues into the AOTI reducer

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -248,8 +248,101 @@ class TestTLXTemplates(TestCase):
 
         code_str = "\n".join(code)
         self.assertIn("split_k_ws", code_str)
-        self.assertIn("call__reduce_k_kernel_", code_str)
+        # Every split-K reducer is now code-generated via define_kernel, even with no
+        # fused epilogue (identity epilogue), so the define_user_defined_triton_kernel
+        # reducer is gone from the forward.
+        self.assertIn("_reduce_k", code_str)
+        self.assertNotIn("call__reduce_k_kernel_", code_str)
         self.assertNotIn("from triton.language.extra.tlx.inductor.reduce_k import", code_str)
+
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_tlx_addmm_warppipe_split_k_python_epilogue_fused(self):
+        """Split-K + pointwise epilogue under the Python/JIT wrapper.
+
+        The generated reducer replays the fused epilogue in both wrappers, so the
+        epilogue runs after the partials are summed and no separate pointwise kernel
+        is emitted.
+        """
+        M, K, N = 256, 4096, 256
+        dtype = torch.float16
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
+        w = torch.randn(N, K, device=GPU_TYPE, dtype=dtype)
+        bias = torch.randn(N, device=GPU_TYPE, dtype=dtype)
+
+        def addmm_gelu(bias, a, w):
+            return torch.nn.functional.gelu(torch.addmm(bias, a, w.t()))
+
+        with config.patch({
+            "triton.tlx_mode": "force",
+            "force_disable_caches": True,
+            "max_autotune": True,
+            "max_autotune_gemm_backends": "TRITON",
+            "enable_caching_generated_triton_templates": False,
+            "cpp_wrapper": False,
+        }):
+            c_actual, code = run_and_get_code(
+                torch.compile(addmm_gelu), bias, a, w
+            )
+
+        c_expected = torch.nn.functional.gelu(
+            a.float() @ w.t().float() + bias.float()
+        ).to(dtype)
+        torch.testing.assert_close(c_actual, c_expected, atol=3e-2, rtol=3e-2)
+
+        code_str = "\n".join(code)
+        self.assertIn("_reduce_k", code_str)
+        self.assertNotIn("triton_poi_", code_str)
+
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @parametrize("epilogue", ("gelu", "mul"))
+    def test_tlx_addmm_warppipe_split_k_cpp_wrapper_fused_epilogue(
+        self, epilogue: str
+    ):
+        M, K, N = 256, 4096, 256
+        dtype = torch.float16
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
+        w = torch.randn(N, K, device=GPU_TYPE, dtype=dtype)
+        bias = torch.randn(N, device=GPU_TYPE, dtype=dtype)
+
+        def addmm_epilogue(bias, a, w):
+            out = torch.addmm(bias, a, w.t())
+            if epilogue == "gelu":
+                return torch.nn.functional.gelu(out)
+            return out * 0.5
+
+        with (config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+                "cpp_wrapper": True,
+        }), ):
+            c_actual, code = run_and_get_code(
+                torch.compile(addmm_epilogue), bias, a, w
+            )
+
+        reference = a.float() @ w.t().float() + bias.float()
+        if epilogue == "gelu":
+            reference = torch.nn.functional.gelu(reference)
+        else:
+            reference = reference * 0.5
+        torch.testing.assert_close(
+            c_actual, reference.to(dtype), atol=4e-2, rtol=4e-2
+        )
+
+        code_str = "\n".join(code)
+        self.assertIn("split_k_ws", code_str)
+        self.assertIn("_reduce_k", code_str)
+        self.assertNotIn("triton_poi_", code_str)
 
     @unittest.skipIf(
         not is_gfx950(),
@@ -690,47 +783,88 @@ class TestReduceKKernel(TestCase):
     """Direct unit tests for the split-K reduction kernel."""
 
     def test_aoti_reduce_k_emission(self):
+        from torch._inductor.virtualized import V
         from triton.language.extra.tlx.inductor.reduce_k import (
             emit_aoti_reduce_k_call, )
 
         wrapper = mock.MagicMock()
-        wrapper.define_user_defined_triton_kernel.return_value = (
-            "_reduce_k_kernel_0",
-            {"signature": {}},
-            {"grid_type": "FixedGrid"},
-            [],
-        )
+        wrapper.src_to_kernel = {}
+
         workspace = mock.MagicMock()
-        workspace.outer_name = "split_k_ws_0"
-        workspace.dtype = torch.float32
+        workspace.inner_name = "split_k_ws"
         output = mock.MagicMock()
-        output.get_name.return_value = "buf_out"
-        output.get_dtype.return_value = torch.float16
-        output.get_device.return_value = torch.device("cuda")
-        bias = mock.MagicMock()
-        bias.get_name.return_value = "arg_bias"
-        bias.get_dtype.return_value = torch.float16
+        output.get_device.return_value = torch.device(GPU_TYPE)
 
-        emit_aoti_reduce_k_call(
-            wrapper,
-            workspace_arg=workspace,
-            output_node=output,
-            bias_node=bias,
-            M=256,
-            N=256,
-            split_k=4,
-            output_triton_dtype="tl.float16",
+        def _argdef(name):
+            arg = mock.MagicMock()
+            arg.full_name.return_value = name
+            return arg
+
+        template_kernel = mock.MagicMock()
+        template_kernel.args.python_argdefs.return_value = (
+            [_argdef("split_k_ws"), _argdef("out_ptr0")],
+            ["split_k_ws_0", "buf_out"],
+            None,
+            [torch.float32, torch.float16],
         )
+        template_kernel.gen_common_triton_imports.return_value = "import triton"
+        template_kernel.jit_lines.return_value = "@triton.jit"
+        template_kernel.triton_meta = {"signature": {}}
 
-        wrapper.define_user_defined_triton_kernel.assert_called_once()
+        graph = mock.MagicMock()
+        graph.get_current_device_or_throw.return_value = torch.device(GPU_TYPE)
+
+        with V.set_graph_handler(graph):
+            emit_aoti_reduce_k_call(
+                wrapper,
+                workspace_arg=workspace,
+                output_node=output,
+                bias_node=None,
+                M=256,
+                N=256,
+                split_k=4,
+                output_triton_dtype="tl.float16",
+                template_kernel=template_kernel,
+                main_kernel_name="triton_tem_fused_addmm_0",
+                final_output_ptr="out_ptr0",
+            )
+
+        reduce_name = "triton_tem_fused_addmm_0_reduce_k"
+        # The reducer is code-generated through define_kernel; the old
+        # define_user_defined_triton_kernel path no longer exists.
+        wrapper.define_user_defined_triton_kernel.assert_not_called()
+        wrapper.define_kernel.assert_called_once()
+        self.assertEqual(reduce_name, wrapper.define_kernel.call_args.args[0])
+
+        body = wrapper.define_kernel.call_args.args[1]
+        self.assertIn(f"def {reduce_name}(split_k_ws, out_ptr0):", body)
+        # No fused epilogue -> identity epilogue, so the reducer still does sum + store.
+        self.assertIn("acc += partial", body)
+        self.assertIn("fused_result = acc", body)
+        self.assertIn("tl.store(out_ptr0 + base_offs, fused_result", body)
+
         wrapper.generate_kernel_call.assert_called_once()
         call = wrapper.generate_kernel_call.call_args
-        self.assertEqual("_reduce_k_kernel_0", call.args[0])
-        self.assertEqual(
-            ["split_k_ws_0", "buf_out", "arg_bias", 256, 256],
-            call.args[1],
-        )
+        self.assertEqual(reduce_name, call.args[0])
+        # Reuses the main template's runtime args, then the reducer grid.
+        self.assertEqual(["split_k_ws_0", "buf_out"], call.args[1][:2])
+        self.assertEqual(3, len(call.args[1]) - 2)
         self.assertTrue(call.kwargs["triton"])
+
+    def test_fused_reduce_k_source(self):
+        from triton.language.extra.tlx.inductor.reduce_k import _reduce_k_body_source
+
+        source = _reduce_k_body_source(
+            "split_k_ws",
+            "out_ptr",
+            "M",
+            "N",
+            4,
+            "    fused_result = tl.libdevice.tanh(acc)",
+        )
+        self.assertLess(source.index("acc += partial"), source.index("fused_result"))
+        self.assertLess(source.index("fused_result"), source.index("tl.store"))
+        self.assertIn("tl.store(out_ptr + base_offs, fused_result", source)
 
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),

--- a/third_party/tlx/language/tlx/inductor/reduce_k.py
+++ b/third_party/tlx/language/tlx/inductor/reduce_k.py
@@ -14,6 +14,7 @@ Ported from upstream:
 
 from __future__ import annotations
 
+import textwrap
 from typing import Any, TYPE_CHECKING
 
 import sympy
@@ -108,6 +109,48 @@ def emit_reduce_k_call(
     )
 
 
+def _reduce_k_body_source(
+    workspace_name: str,
+    output_name: str,
+    M_expr: str,
+    N_expr: str,
+    split_k: int,
+    epilogue_code: str,
+    bias_name: str | None = None,
+    stride_bias_m: int = 0,
+    stride_bias_n: int = 1,
+) -> str:
+    code = textwrap.dedent(f"""
+    BLOCK_SIZE_M: tl.constexpr = 32
+    BLOCK_SIZE_N: tl.constexpr = 32
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    mask = (offs_m[:, None] < {M_expr}) & (offs_n[None, :] < {N_expr})
+    base_offs = offs_m[:, None] * {N_expr} + offs_n[None, :]
+    xnumel = {M_expr} * {N_expr}
+    xindex = base_offs
+    xmask = mask
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for s in range({split_k}):
+        ws_offs = base_offs + s * {M_expr} * {N_expr}
+        partial = tl.load({workspace_name} + ws_offs, mask=mask, other=0.0)
+        acc += partial.to(tl.float32)
+    """)
+    if bias_name is not None:
+        code += textwrap.dedent(f"""
+        bias_offs = offs_m[:, None] * {stride_bias_m} + offs_n[None, :] * {stride_bias_n}
+        acc += tl.load({bias_name} + bias_offs, mask=mask, other=0.0).to(tl.float32)
+        """)
+    epilogue_code = textwrap.dedent(epilogue_code)
+    if "fused_result" not in epilogue_code:
+        raise AssertionError("reduce-k epilogue must define fused_result")
+    code += "\n" + epilogue_code
+    code += f"\ntl.store({output_name} + base_offs, fused_result, mask=mask)\n"
+    return code
+
+
 def emit_aoti_reduce_k_call(
     wrapper: "WrapperCodeGen",
     workspace_arg: Any,
@@ -117,12 +160,70 @@ def emit_aoti_reduce_k_call(
     N: Any,
     split_k: int,
     output_triton_dtype: str,
+    M_kernel_expr: str | None = None,
+    N_kernel_expr: str | None = None,
     stride_bias_m: int = 0,
     stride_bias_n: int = 1,
+    template_kernel: Any | None = None,
+    main_kernel_name: str | None = None,
+    epilogue_code: str | None = None,
+    final_output_ptr: str | None = None,
+    bias_kernel_ptr: str | None = None,
 ) -> None:
     """Register and launch the split-K reducer through the AOTI C++ wrapper."""
     from torch._inductor import ir
+    from torch._inductor.runtime.triton_heuristics import FixedGrid
+    from torch._inductor.utils import IndentedBuffer
+    from torch._inductor.virtualized import V
     from torch.utils._sympy.functions import CeilDiv
+
+    if epilogue_code is not None:
+        if template_kernel is None or main_kernel_name is None or final_output_ptr is None:
+            raise AssertionError("fused reduce-k requires template kernel metadata")
+        from torch._inductor.select_algorithm import Placeholder
+
+        argdefs, call_args, _, arg_types = template_kernel.args.python_argdefs()
+        reduce_name = f"{main_kernel_name}_reduce_k"
+        source = IndentedBuffer()
+        source.splice(template_kernel.gen_common_triton_imports())
+        source.splice(template_kernel.jit_lines())
+        source.writeline(
+            f"def {reduce_name}({', '.join(arg.full_name() for arg in argdefs)}):"
+        )
+        with source.indent():
+            source.splice(_reduce_k_body_source(
+                workspace_arg.inner_name,
+                final_output_ptr,
+                M_kernel_expr or str(M),
+                N_kernel_expr or str(N),
+                split_k,
+                epilogue_code,
+                bias_kernel_ptr,
+                stride_bias_m,
+                stride_bias_n,
+            ))
+        source_code = source.getvalue().replace(
+            str(Placeholder.DESCRIPTIVE_NAME), reduce_name
+        ).replace(str(Placeholder.KERNEL_NAME), reduce_name)
+        compile_wrapper = IndentedBuffer()
+        compile_wrapper.writeline(f"async_compile.triton({reduce_name!r}, '''")
+        compile_wrapper.splice(source_code, strip=True)
+        device = V.graph.get_current_device_or_throw()
+        compile_wrapper.writeline(f"''', device_str='{device.type}')")
+        kernel_body = compile_wrapper.getvalue()
+        wrapper.src_to_kernel[kernel_body] = reduce_name
+        wrapper.define_kernel(reduce_name, kernel_body, "# TLX split-K fused reducer")
+        grid_args = [CeilDiv(M, 32), CeilDiv(N, 32), sympy.Integer(1)]
+        wrapper.generate_kernel_call(
+            reduce_name,
+            [*call_args, *grid_args],
+            arg_types=[*arg_types, *map(type, grid_args)],
+            triton_meta=template_kernel.triton_meta,
+            inductor_meta=FixedGrid.setup_grid_as_args(),
+            triton=True,
+            device=output_node.get_device(),
+        )
+        return
 
     has_bias = bias_node is not None
     bias_arg = bias_node if has_bias else output_node

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1805,7 +1805,7 @@ def _tlx_compute_epilogue(  # type: ignore[no-untyped-def]
     """
     import sympy
     from torch._inductor.codegen.common import OpOverrides
-    from torch._inductor.utils import sympy_dot, triton_type_to_torch
+    from torch._inductor.utils import triton_type_to_torch
 
     subgraph_name = self._get_compute_epilogue_subgraph_name(
         next(self._compute_epilogue_ctr)
@@ -1823,7 +1823,6 @@ def _tlx_compute_epilogue(  # type: ignore[no-untyped-def]
         lengths = [V.graph.sizevars.simplify(s) for s in self.output_node.get_size()]
         assert len(indices) == len(lengths)
 
-        output_layout = self.output_node.get_layout()
         self.template_out = val
 
         # Use the tma_store index setup path (same as store_output with
@@ -1864,7 +1863,6 @@ def _tlx_compute_epilogue(  # type: ignore[no-untyped-def]
         val_shape = tuple(val_shape_copy)
 
         index_symbols = epilogue_index_symbols
-        contiguous_index = sympy_dot(output_layout.stride, index_symbols)
 
         for line in intermediate_lines:
             self.body.writeline(line)
@@ -1914,6 +1912,30 @@ def _tlx_compute_epilogue(  # type: ignore[no-untyped-def]
 _tlx_compute_epilogue.__name__ = "compute_epilogue"
 TritonTemplateKernel.compute_epilogue = _tlx_compute_epilogue  # type: ignore[method-assign]
 
+
+def _tlx_compute_reduce_epilogue(self):  # type: ignore[no-untyped-def]
+    """Codegen only downstream pointwise ops; reduce-k applies addmm bias itself."""
+    subgraph_name = self._get_compute_epilogue_subgraph_name(
+        next(self._compute_epilogue_ctr)
+    )
+    with self.create_subgraph_body(subgraph_name, clear_cse=True):
+        fused = self.cse.namedvar(
+            "acc", dtype=torch.float32, shape=("BLOCK_SIZE_M", "BLOCK_SIZE_N")
+        )
+        self.template_out = "acc"
+        self.template_out_shape = ("BLOCK_SIZE_M", "BLOCK_SIZE_N")
+        self.cse.store_cache[self.output_node.get_name()] = fused
+        self.body.writeline(f"fused_result = {fused}")
+        self.store_buffer_names.add(self.output_node.get_name())
+        self._tlx_compute_epilogue_result_name = "fused_result"
+        self.codegen_body()
+    return self._register_hook(
+        subgraph_name, self._make_codegen_hook(subgraph_name, 4)
+    )
+
+
+TritonTemplateKernel.compute_reduce_epilogue = _tlx_compute_reduce_epilogue  # type: ignore[attr-defined]
+
 # -- codegen_template_body: wrap to set _final_output_name and handle
 #    COMPUTE_EPILOGUE subgraphs --
 # The epilogue-fusion codegen API below (codegen_template_body,
@@ -1937,6 +1959,7 @@ def _tlx_codegen_template_body(  # type: ignore[no-untyped-def]
     prologue_preserves_zero_mask_fn,
     render,
 ):
+    split_k = getattr(self, "_tlx_split_k", 1)
     # Set _final_output_name so output_ptr() resolves to the fused output.
     if epilogue_nodes:
         last_names = epilogue_nodes[-1].get_buffer_names()
@@ -1948,6 +1971,10 @@ def _tlx_codegen_template_body(  # type: ignore[no-untyped-def]
 
     def _render_with_compute_epilogue():
         result = orig_render()
+
+        reduce_epilogue_hook = None
+        if split_k > 1 and config.cpp_wrapper and epilogue_nodes:
+            reduce_epilogue_hook = self.compute_reduce_epilogue()
 
         # After render, codegen epilogue nodes into COMPUTE_EPILOGUE subgraphs,
         # redirecting their stores to variable assignments.
@@ -1974,6 +2001,12 @@ def _tlx_codegen_template_body(  # type: ignore[no-untyped-def]
                 finally:
                     self.store = orig_store  # type: ignore[method-assign]
                 self.cse.invalidate(OrderedSet())
+
+        if reduce_epilogue_hook is not None:
+            hook = self.render_hooks.pop(reduce_epilogue_hook)
+            if hook is None:
+                raise AssertionError("missing split-K reduce epilogue hook")
+            self._tlx_reduce_epilogue_code = hook()
 
         return result
 
@@ -2070,10 +2103,21 @@ def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-u
                 bias_node=bias_node if bias_name is not None else None,
                 M=self.call_sizes[0],
                 N=self.call_sizes[1],
+                M_kernel_expr=self.size("A", 0),
+                N_kernel_expr=self.size("B", 1),
                 split_k=split_k,
                 output_triton_dtype=output_triton_dtype,
                 stride_bias_m=stride_bias_m,
                 stride_bias_n=stride_bias_n,
+                template_kernel=self,
+                main_kernel_name=kernel_name,
+                epilogue_code=getattr(self, "_tlx_reduce_epilogue_code", None),
+                final_output_ptr=self.output_ptr(),
+                bias_kernel_ptr=(
+                    self.args.input_buffers.get(bias_name)
+                    if bias_name is not None
+                    else None
+                ),
             )
         else:
             emit_reduce_k_call(
@@ -2114,7 +2158,7 @@ def _tlx_compute_fusion_metadata(  # type: ignore[no-untyped-def]
         from collections import defaultdict
 
         self._epilogue_nodes_by_subgraph = defaultdict(list)
-        self._unfused_epilogues = list(epilogue_nodes)
+        self._unfused_epilogues = [] if config.cpp_wrapper else list(epilogue_nodes)
         self._prologue_sources = {}
         self._scheduling_ref = scheduling
     elif _orig_compute_fusion_metadata is not None:


### PR DESCRIPTION
Summary:
Move fused pointwise epilogues from the split-K main GEMM into the AOTInductor reduce-k kernel so nonlinear operations execute after all partial sums are combined. Under the AOTI C++ wrapper a split-K choice now keeps its epilogue fused into the generated reducer; the Python/JIT wrapper still emits the epilogue as a separate kernel at this point in the stack.

The reducer reuses the main template runtime signature, Triton metadata, dynamic shape arguments, workspace, and final output pointer. A dedicated reduce-owned epilogue codegen path seeds the reduced accumulator into Inductor CSE, applies addmm bias with explicit 2D offs_m/offs_n broadcasting, then emits downstream pointwise operations before the final store. Flattened xindex/xmask aliases map pointwise indexing to the reducer tile.

This supports GELU, mul/add, casts, and shape-preserving view/clone chains. LayerNorm and output-domain-changing slices remain separate kernels. The split-K render regression now explicitly exercises the legal USE_ASYNC path.

Rebased onto a master that already carries the split-K AOTI groundwork, so this diff no longer touches `select_algorithm.py` or `codegen/wrapper.py` (nor their xplat mirrors). There is no `MultiTemplateBuffer.allow_epilogue_fusion` gate: routing is entirely template-side in `registry.py`, leaving zero Inductor-core footprint. Everything here is confined to the TLX template, its generated reducer, and the unit tests.

Also refreshes three unit tests onto the end-state reducer behavior: `test_aoti_reduce_k_emission` now drives the code-generated `define_kernel` path instead of mocking the removed `define_user_defined_triton_kernel` path, `test_tlx_addmm_warppipe_split_k_cpp_wrapper` asserts the generated reducer rather than the old `call__reduce_k_kernel_` emission, and `test_tlx_addmm_warppipe_split_k_python_epilogue_not_fused` is renamed to `..._python_epilogue_fused` and inverted to assert the epilogue is fused. Their numeric `assert_close` checks are unchanged.

Reviewed By: rocketerfb

Differential Revision: D113916722
