### PR TITLE
[H100 core][triton][beta][runtime] Preserve Buck paths in cache-key subprocesses

### DIFF
--- a/python/test/unit/runtime/test_cache_determinism.py
+++ b/python/test/unit/runtime/test_cache_determinism.py
@@ -71,6 +71,9 @@ def stress_parent():
 
 def _subprocess_key(mode, seed, order="forward"):
     env = os.environ.copy()
+    # A Buck par's sys.executable does not reconstruct the parent test
+    # runner's link-tree paths when it launches a script directly.
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
     env["PYTHONHASHSEED"] = str(seed)
     env["TRITON_CACHE_KEY_TEST_ORDER"] = order
     env["TRITON_CACHE_KEY_TEST_SEED"] = str(seed)


### PR DESCRIPTION
Summary:
Failed tests:
- test_cache_key_deterministic_across_process_global_identities
- test_cache_key_deterministic_under_concurrent_dependency_hashing

Failure:
Both child interpreters exited before comparing cache keys with
ModuleNotFoundError: No module named 'triton'. Under Buck, invoking the helper
script through sys.executable does not reconstruct the parent test runner's
link-tree import paths.

Fix:
Pass the parent runner's resolved sys.path to child interpreters through
PYTHONPATH. This test-only change lets the intended fresh-process cache-key
checks execute without changing runtime cache behavior.

Differential Revision: D114286751


