### PR TITLE
[TLX][AMD] Fix reduce-k epilogue indentation for AOTI split-K epilogue fusion

### DIFF
--- a/third_party/tlx/language/tlx/inductor/reduce_k.py
+++ b/third_party/tlx/language/tlx/inductor/reduce_k.py
@@ -143,10 +143,13 @@ def _reduce_k_body_source(
         bias_offs = offs_m[:, None] * {stride_bias_m} + offs_n[None, :] * {stride_bias_n}
         acc += tl.load({bias_name} + bias_offs, mask=mask, other=0.0).to(tl.float32)
         """)
-    epilogue_code = textwrap.dedent(epilogue_code)
-    if "fused_result" not in epilogue_code:
+    epilogue_lines = [
+        line.lstrip() for line in textwrap.dedent(epilogue_code).splitlines()
+    ]
+    epilogue_body = "\n".join(line for line in epilogue_lines if line)
+    if "fused_result" not in epilogue_body:
         raise AssertionError("reduce-k epilogue must define fused_result")
-    code += "\n" + epilogue_code
+    code += "\n" + epilogue_body
     code += f"\ntl.store({output_name} + base_offs, fused_result, mask=mask)\n"
     return code
 


### PR DESCRIPTION
Summary:
On top of D113916722. That diff's latest version normalizes the fused split-K
epilogue in `_reduce_k_body_source` (tlx `reduce_k.py`) with
`textwrap.dedent(epilogue_code)`. `textwrap.dedent` strips only the *common*
leading whitespace, but the epilogue arrives as `fused_result = acc` at column 0
followed by the pointwise body at column 4, so the common indent is 0 and nothing
is stripped. The generated reducer then has the epilogue one indent level too
deep, producing `IndentationError: unexpected indent` at codegen ->
`LoweringStageException` -> `MTS_EXIT=1` on the HI OC merge net.

Fix: normalize per line (`textwrap.dedent` then `lstrip` each line, dropping
blanks). Flat pointwise epilogues (gelu/mul/casts) need per-line normalization,
not common-prefix dedent.

Authored with Claude Code.

Reviewed By: htyu

Differential Revision: D114098812


