### PR TITLE
[TLX][AMD] Split-K: fuse epilogues in both JIT and AOTI via one generated reducer

### DIFF
--- a/third_party/tlx/language/tlx/inductor/reduce_k.py
+++ b/third_party/tlx/language/tlx/inductor/reduce_k.py
@@ -143,10 +143,13 @@ def _reduce_k_body_source(
         bias_offs = offs_m[:, None] * {stride_bias_m} + offs_n[None, :] * {stride_bias_n}
         acc += tl.load({bias_name} + bias_offs, mask=mask, other=0.0).to(tl.float32)
         """)
-    epilogue_code = textwrap.dedent(epilogue_code)
-    if "fused_result" not in epilogue_code:
+    epilogue_lines = [
+        line.lstrip() for line in textwrap.dedent(epilogue_code).splitlines()
+    ]
+    epilogue_body = "\n".join(line for line in epilogue_lines if line)
+    if "fused_result" not in epilogue_body:
         raise AssertionError("reduce-k epilogue must define fused_result")
-    code += "\n" + epilogue_code
+    code += "\n" + epilogue_body
     code += f"\ntl.store({output_name} + base_offs, fused_result, mask=mask)\n"
     return code
 

--- a/third_party/tlx/language/tlx/inductor/reduce_k.py
+++ b/third_party/tlx/language/tlx/inductor/reduce_k.py
@@ -180,6 +180,12 @@ def emit_aoti_reduce_k_call(
     from torch._inductor.virtualized import V
     from torch.utils._sympy.functions import CeilDiv
 
+    # Single template-side reducer path: with no fused epilogue, use an identity so the
+    # generated reducer still does sum + bias + store. This keeps every split-K reducer
+    # on the code-generated define_kernel path (never define_user_defined_triton_kernel),
+    # so no WorkspaceArg special-casing is needed in the Inductor wrapper.
+    if epilogue_code is None:
+        epilogue_code = "fused_result = acc"
     if epilogue_code is not None:
         if template_kernel is None or main_kernel_name is None or final_output_ptr is None:
             raise AssertionError("fused reduce-k requires template kernel metadata")
@@ -227,62 +233,3 @@ def emit_aoti_reduce_k_call(
             device=output_node.get_device(),
         )
         return
-
-    has_bias = bias_node is not None
-    bias_arg = bias_node if has_bias else output_node
-    workspace_buffer = ir.Buffer(
-        name=workspace_arg.outer_name,
-        layout=workspace_arg.get_layout(),
-    )
-    kwargs = {
-        "workspace_ptr": workspace_buffer,
-        "c_ptr": output_node,
-        "bias_ptr": bias_arg,
-        "M": M,
-        "N": N,
-        "SPLIT_K": split_k,
-        "BLOCK_SIZE_M": 32,
-        "BLOCK_SIZE_N": 32,
-        "OUTPUT_DTYPE": getattr(tl, output_triton_dtype.removeprefix("tl.")),
-        "HAS_BIAS": has_bias,
-        "STRIDE_BIAS_M": stride_bias_m,
-        "STRIDE_BIAS_N": stride_bias_n,
-    }
-    grid = [[CeilDiv(M, 32), CeilDiv(N, 32), sympy.Integer(1)]]
-    name, triton_meta, inductor_meta, grid_args = (
-        wrapper.define_user_defined_triton_kernel(
-            _reduce_k_kernel,
-            [triton.Config({})],
-            kwargs,
-            restore_value_args=(),
-            reset_to_zero_args=(),
-            grids=grid,
-            epilogue_fusion=None,
-            launch_kwargs=(),
-        )
-    )
-    call_args = [
-        workspace_arg.outer_name,
-        output_node.get_name(),
-        bias_arg.get_name(),
-        M,
-        N,
-        *grid_args,
-    ]
-    arg_types = [
-        workspace_arg.dtype,
-        output_node.get_dtype(),
-        bias_arg.get_dtype(),
-        type(M),
-        type(N),
-        *map(type, grid_args),
-    ]
-    wrapper.generate_kernel_call(
-        name,
-        call_args,
-        arg_types=arg_types,
-        triton_meta=triton_meta,
-        inductor_meta=inductor_meta,
-        triton=True,
-        device=output_node.get_device(),
-    )

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1973,7 +1973,7 @@ def _tlx_codegen_template_body(  # type: ignore[no-untyped-def]
         result = orig_render()
 
         reduce_epilogue_hook = None
-        if split_k > 1 and config.cpp_wrapper and epilogue_nodes:
+        if split_k > 1 and epilogue_nodes:
             reduce_epilogue_hook = self.compute_reduce_epilogue()
 
         # After render, codegen epilogue nodes into COMPUTE_EPILOGUE subgraphs,
@@ -2095,7 +2095,12 @@ def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-u
             else:
                 bias_name = None  # unexpected rank; skip (should not happen for addmm)
 
-        if config.cpp_wrapper:
+        # Split-K is handled entirely template-side: when there is a fusible epilogue
+        # the reducer is code-generated to replay it (backend-agnostic, works for the
+        # Python/JIT wrapper and the AOTI C++ wrapper alike); otherwise the generic
+        # sum+bias reducer is used. Nothing about split-K leaks to the Inductor compiler.
+        _reduce_epilogue_code = getattr(self, "_tlx_reduce_epilogue_code", None)
+        if config.cpp_wrapper or _reduce_epilogue_code is not None:
             emit_aoti_reduce_k_call(
                 wrapper,
                 workspace_arg=self.workspace_arg,
@@ -2111,7 +2116,7 @@ def _tlx_emit_post_kernel_code(self, wrapper, kernel_name):  # type: ignore[no-u
                 stride_bias_n=stride_bias_n,
                 template_kernel=self,
                 main_kernel_name=kernel_name,
-                epilogue_code=getattr(self, "_tlx_reduce_epilogue_code", None),
+                epilogue_code=_reduce_epilogue_code,
                 final_output_ptr=self.output_ptr(),
                 bias_kernel_ptr=(
                     self.args.input_buffers.get(bias_name)
@@ -2158,7 +2163,7 @@ def _tlx_compute_fusion_metadata(  # type: ignore[no-untyped-def]
         from collections import defaultdict
 
         self._epilogue_nodes_by_subgraph = defaultdict(list)
-        self._unfused_epilogues = [] if config.cpp_wrapper else list(epilogue_nodes)
+        self._unfused_epilogues = []
         self._prologue_sources = {}
         self._scheduling_ref = scheduling
     elif _orig_compute_fusion_metadata is not None:


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/191859

Per Hongtao's suggestion on D113910767, split-K should be handled entirely on the template side, with no split-K-specific logic in the Inductor compiler. This diff makes that true for the reducer, on top of the landed split-K base (D113851999 / D113916722). D113910767 -- which added the Inductor-core gating (the `allow_epilogue_fusion` gate, the `split_k` caller attribute, and the `WorkspaceArg` branch in `define_user_defined_triton_kernel`) -- is abandoned, so there is nothing left to revert here; this diff is now scoped to two beta-triton files.

Changes:
- `registry.py`: the code-generated reducer replays the fused epilogue in BOTH wrappers. Compute the reduce-epilogue hook whenever `split_k > 1 and epilogue_nodes` (drop the `config.cpp_wrapper` condition), route the epilogue case through the backend-agnostic generated reducer for JIT and AOTI alike, and always mark epilogues fused (`_unfused_epilogues = []`). Previously JIT emitted a separate epilogue pointwise kernel; now it fuses like AOTI.
- `reduce_k.py`: unify the reducer onto a single code-generated `define_kernel` path. When there is no fused epilogue, use an identity epilogue (`fused_result = acc`) so the same generated reducer still does sum + bias + store. The `define_user_defined_triton_kernel` reducer path is deleted -- nothing emits the reducer that way anymore.

Net: split-K epilogue fusion is identical in JIT and AOTI, produced by one generated reducer, and the compiler sees no split-K-specific logic. Perf-neutral (kineto gpu_user_annotation: split-K epilogue fusion 26.5 vs 27.0 ms/iter).

Authored with Claude Code.

Reviewed By: htyu

Differential Revision: D114342717


