### PR TITLE
[triton][beta] [Cherry-pick] '[AMD][gfx1250] Support Triton-level descriptor gather/scatter (#10157)' (#2610)

### DIFF
--- a/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/include/triton/Dialect/Triton/IR/Dialect.h
@@ -117,6 +117,9 @@ public:
 };
 
 // Descriptor gather and scatter have restrictions on the tile sizes.
+LogicalResult verifyGatherScatterResultType(Operation *op,
+                                            ShapedType resultType,
+                                            ShapedType indicesType);
 LogicalResult verifyGatherScatterOp(Operation *op, ShapedType blockType,
                                     ShapedType resultType,
                                     ShapedType indicesType);

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -6,15 +6,14 @@ include "triton/Dialect/Triton/IR/TritonTypes.td"
 include "triton/Dialect/Triton/IR/TritonAttrDefs.td"
 include "triton/Dialect/Triton/IR/TritonInterfaces.td"
 include "mlir/IR/OpBase.td"
-include "mlir/IR/SymbolInterfaces.td" // SymbolUserOpInterface
-include "mlir/IR/OpAsmInterface.td" // OpAsmOpInterface
-include "mlir/Interfaces/FunctionInterfaces.td" // FunctionOpInterface
-include "mlir/Interfaces/SideEffectInterfaces.td" // Pure
+include "mlir/IR/SymbolInterfaces.td"              // SymbolUserOpInterface
+include "mlir/IR/OpAsmInterface.td"                // OpAsmOpInterface
+include "mlir/Interfaces/FunctionInterfaces.td"    // FunctionOpInterface
+include "mlir/Interfaces/SideEffectInterfaces.td"  // Pure
 include "mlir/Interfaces/ControlFlowInterfaces.td" // BranchOpInterface
-include "mlir/Interfaces/InferTypeOpInterface.td" // SameOperandsAndResultType
-include "mlir/Interfaces/CallInterfaces.td" // CallOpInterface
+include "mlir/Interfaces/InferTypeOpInterface.td"  // SameOperandsAndResultType
+include "mlir/Interfaces/CallInterfaces.td"        // CallOpInterface
 include "triton/Dialect/Triton/IR/TritonOpInterfaces.td"
-
 
 //
 // Interfaces
@@ -24,10 +23,9 @@ def GlobalMemory : Resource<"::mlir::triton::GlobalMemory">;
 //
 // Op Base
 //
-class TT_Op<string mnemonic, list<Trait> traits = []> :
-    Op<Triton_Dialect, mnemonic,
-       !listconcat(traits, [TensorSizeTrait, VerifyTensorLayoutsTrait])> {
-}
+class TT_Op<string mnemonic, list<Trait> traits = []>
+    : Op<Triton_Dialect, mnemonic,
+         !listconcat(traits, [TensorSizeTrait, VerifyTensorLayoutsTrait])> {}
 
 //
 // Cast Ops
@@ -37,243 +35,223 @@ class TT_Op<string mnemonic, list<Trait> traits = []> :
 //   fptoui, fptosi, uitofp, sitofp,
 //   extf, tructf,
 //   extui, extsi, tructi
-def TT_IntToPtrOp : TT_Op<"int_to_ptr", [Elementwise,
-                                         SameOperandsAndResultShape,
-                                         SameOperandsAndResultEncoding,
-                                         Pure]> {
-    let summary = "Cast int64 to pointer";
+def TT_IntToPtrOp
+    : TT_Op<"int_to_ptr", [Elementwise, SameOperandsAndResultShape,
+                           SameOperandsAndResultEncoding, Pure]> {
+  let summary = "Cast int64 to pointer";
 
-    let arguments = (ins TT_I64Like:$src);
+  let arguments = (ins TT_I64Like:$src);
 
-    let results = (outs TT_PtrLike:$result);
+  let results = (outs TT_PtrLike:$result);
 
-    let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
 
-    let hasCanonicalizer = 1;
+  let hasCanonicalizer = 1;
 }
 
-def TT_PtrToIntOp : TT_Op<"ptr_to_int", [Elementwise,
-                                         SameOperandsAndResultShape,
-                                         SameOperandsAndResultEncoding,
-                                         Pure]> {
-    let summary = "Cast pointer to int64";
+def TT_PtrToIntOp
+    : TT_Op<"ptr_to_int", [Elementwise, SameOperandsAndResultShape,
+                           SameOperandsAndResultEncoding, Pure]> {
+  let summary = "Cast pointer to int64";
 
-    let arguments = (ins TT_PtrLike:$src);
+  let arguments = (ins TT_PtrLike:$src);
 
-    let results = (outs TT_I64Like:$result);
+  let results = (outs TT_I64Like:$result);
 
-    let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
 }
 
 // arith.bitcast doesn't support pointers
-def TT_BitcastOp : TT_Op<"bitcast", [Elementwise,
-                                     SameOperandsAndResultShape,
-                                     SameOperandsAndResultEncoding,
-                                     Pure]> {
-    let summary = "Cast between types of the same bitwidth";
+def TT_BitcastOp : TT_Op<"bitcast", [Elementwise, SameOperandsAndResultShape,
+                                     SameOperandsAndResultEncoding, Pure]> {
+  let summary = "Cast between types of the same bitwidth";
 
-    let arguments = (ins TT_Type:$src);
+  let arguments = (ins TT_Type:$src);
 
-    let results = (outs TT_Type:$result);
+  let results = (outs TT_Type:$result);
 
-    let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
-    let hasFolder = 1;
-    let hasVerifier = 1;
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+  let hasFolder = 1;
+  let hasVerifier = 1;
 }
 
-def TT_FpToFpOp : TT_Op<"fp_to_fp", [Elementwise,
-                                     SameOperandsAndResultShape,
-                                     SameOperandsAndResultEncoding,
-                                     Pure]> {
-    let summary = "Floating point casting for custom types";
+def TT_FpToFpOp : TT_Op<"fp_to_fp", [Elementwise, SameOperandsAndResultShape,
+                                     SameOperandsAndResultEncoding, Pure]> {
+  let summary = "Floating point casting for custom types";
 
-    let description = [{
+  let description = [{
         Floating point casting for custom types (F8), and non-default rounding modes.
 
         F8 <-> FP16, BF16, FP32, FP64
     }];
 
-    let arguments = (
-      ins TT_FloatLike:$src,
-      Optional<TT_I32Like>:$rbits,
-      OptionalAttr<TT_RoundingModeAttr>:$rounding
-    );
+  let arguments = (ins TT_FloatLike:$src, Optional<TT_I32Like>:$rbits,
+      OptionalAttr<TT_RoundingModeAttr>:$rounding);
 
-    let results = (outs TT_FloatLike:$result);
+  let results = (outs TT_FloatLike:$result);
 
-    let builders = [
-      OpBuilder<(ins "Type":$resultType,
-                    "Value":$src,
-                    CArg<"Attribute", "Attribute()">:$rounding)>,
+  let builders = [OpBuilder<(ins "Type":$resultType, "Value":$src,
+                      CArg<"Attribute", "Attribute()">:$rounding)>,
 
-      OpBuilder<(ins "Type":$resultType,
-                    "Value":$src,
-                    "Value":$rbits,
-                    CArg<"Attribute", "Attribute()">:$rounding)>,
-    ];
+                  OpBuilder<(ins "Type":$resultType, "Value":$src,
+                      "Value":$rbits,
+                      CArg<"Attribute", "Attribute()">:$rounding)>,
+  ];
 
+  let hasCustomAssemblyFormat = 1;
 
-    let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
 
-    let hasVerifier = 1;
-
-    let hasFolder = 1;
+  let hasFolder = 1;
 }
 
 //
 // Arithmetic Ops
 //
 
-def TT_ClampFOp : TT_Op<"clampf", [Elementwise,
-                                   SameOperandsAndResultType,
-                                   Pure]> {
-    let summary = "Clamp operation for floating point types";
+def TT_ClampFOp
+    : TT_Op<"clampf", [Elementwise, SameOperandsAndResultType, Pure]> {
+  let summary = "Clamp operation for floating point types";
 
-    let description = [{
+  let description = [{
         Clamp operation for floating point types.
 
         The operation takes three arguments: x, min, and max. It returns a tensor of the same shape as x with its values clamped to the range [min, max].
     }];
 
-    let arguments = (
-      ins
-      TT_FloatLike:$x,
-      TT_FloatLike:$min,
-      TT_FloatLike:$max,
-      TT_PropagateNanAttr:$propagateNan
-    );
+  let arguments = (ins TT_FloatLike:$x, TT_FloatLike:$min, TT_FloatLike:$max,
+      TT_PropagateNanAttr:$propagateNan);
 
-    let results = (outs TT_FloatLike:$result);
+  let results = (outs TT_FloatLike:$result);
 
-    // List $propagateNan explicitly rather than relying on attr-dict to pick it
-    // up, because if it's inside attr-dict, its value will be printed as a
-    // number rather than as a meaningful string.
-    let assemblyFormat = "$x `,` $min `,` $max `,` `propagateNan` `=` $propagateNan attr-dict `:` type($result)";
+  // List $propagateNan explicitly rather than relying on attr-dict to pick it
+  // up, because if it's inside attr-dict, its value will be printed as a
+  // number rather than as a meaningful string.
+  let assemblyFormat = "$x `,` $min `,` $max `,` `propagateNan` `=` "
+                       "$propagateNan attr-dict `:` type($result)";
 }
 
 //
 // Math Ops
 //
 
-def TT_PreciseSqrtOp : TT_Op<"precise_sqrt", [Elementwise,
-                                              SameOperandsAndResultType,
-                                              Pure]> {
-    let summary = "Precise sqrt for floating point types";
+def TT_PreciseSqrtOp
+    : TT_Op<"precise_sqrt", [Elementwise, SameOperandsAndResultType, Pure]> {
+  let summary = "Precise sqrt for floating point types";
 
-    let description = [{
+  let description = [{
         Precise sqrt for floating point types.
     }];
 
-    let arguments = (ins TT_FloatLike:$x);
+  let arguments = (ins TT_FloatLike:$x);
 
-    let results = (outs TT_FloatLike:$result);
+  let results = (outs TT_FloatLike:$result);
 
-    let assemblyFormat = "$x attr-dict `:` type($x)";
+  let assemblyFormat = "$x attr-dict `:` type($x)";
 }
 
-def TT_PreciseDivFOp : TT_Op<"precise_divf", [Elementwise,
-                                              SameOperandsAndResultType,
-                                              Pure]> {
-    let summary = "Precise div for floating point types";
+def TT_PreciseDivFOp
+    : TT_Op<"precise_divf", [Elementwise, SameOperandsAndResultType, Pure]> {
+  let summary = "Precise div for floating point types";
 
-    let description = [{
+  let description = [{
         Precise div for floating point types.
     }];
 
-    let arguments = (ins TT_FloatLike:$x, TT_FloatLike:$y);
+  let arguments = (ins TT_FloatLike:$x, TT_FloatLike:$y);
 
-    let results = (outs TT_FloatLike:$result);
+  let results = (outs TT_FloatLike:$result);
 
-    let assemblyFormat = "$x `,` $y attr-dict `:` type($x)";
+  let assemblyFormat = "$x `,` $y attr-dict `:` type($x)";
 }
 
-def TT_MulhiUIOp : TT_Op<"mulhiui", [Elementwise,
-                                     SameOperandsAndResultType,
-                                     Pure]> {
-    let summary = "Most significant N bits of the 2N-bit product of two integers";
+def TT_MulhiUIOp
+    : TT_Op<"mulhiui", [Elementwise, SameOperandsAndResultType, Pure]> {
+  let summary = "Most significant N bits of the 2N-bit product of two integers";
 
-    let description = [{
+  let description = [{
         Most significant N bits of the 2N-bit product of two integers.
     }];
 
-    let arguments = (ins TT_IntLike:$x, TT_IntLike:$y);
+  let arguments = (ins TT_IntLike:$x, TT_IntLike:$y);
 
-    let results = (outs TT_IntLike:$result);
+  let results = (outs TT_IntLike:$result);
 
-    let assemblyFormat = "$x `,` $y attr-dict `:` type($x)";
+  let assemblyFormat = "$x `,` $y attr-dict `:` type($x)";
 }
 
 //
 // Pointer Arith Ops
 //
-def TT_AddPtrOp : TT_Op<"addptr",
-                        [Pure,
-                         Elementwise,
-                         SameOperandsAndResultShape,
-                         SameOperandsAndResultEncoding,
-                         TypesMatchWith<"result type matches ptr type",
-                                        "result", "ptr", "$_self">]> {
-    let arguments = (ins TT_PtrLike:$ptr, TT_IntLike:$offset);
+def TT_AddPtrOp
+    : TT_Op<"addptr", [Pure, Elementwise, SameOperandsAndResultShape,
+                       SameOperandsAndResultEncoding,
+                       TypesMatchWith<"result type matches ptr type", "result",
+                                      "ptr", "$_self">]> {
+  let arguments = (ins TT_PtrLike:$ptr, TT_IntLike:$offset);
 
-    let results = (outs TT_PtrLike:$result);
+  let results = (outs TT_PtrLike:$result);
 
-    let assemblyFormat = "$ptr `,` $offset attr-dict `:` type($result) `,` type($offset)";
-    let hasFolder = 1;
+  let assemblyFormat =
+      "$ptr `,` $offset attr-dict `:` type($result) `,` type($offset)";
+  let hasFolder = 1;
 }
 
 //
 // Load/Store Ops
 //
-def TT_LoadOp : TT_Op<"load", [
-  SameLoadStoreOperandsAndResultShape,
-  SameLoadStoreOperandsAndResultEncoding,
-  AttrSizedOperandSegments,
-  DeclareOpInterfaceMethods<PredicatedOpInterface>,
-  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-  DeclareOpInterfaceMethods<InferTypeOpInterface>,
-  TypesMatchWith<"result matches ptr type", "ptr", "result", "getPointeeType($_self)">,
-  TypesMatchWith<"mask type matches ptr type", "ptr", "mask", "getI1SameShape(getPointeeType($_self))",
+def TT_LoadOp
+    : TT_Op<"load",
+            [SameLoadStoreOperandsAndResultShape,
+             SameLoadStoreOperandsAndResultEncoding, AttrSizedOperandSegments,
+             DeclareOpInterfaceMethods<PredicatedOpInterface>,
+             DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+             DeclareOpInterfaceMethods<InferTypeOpInterface>,
+             TypesMatchWith<"result matches ptr type", "ptr", "result",
+                            "getPointeeType($_self)">,
+             TypesMatchWith<
+                 "mask type matches ptr type", "ptr", "mask",
+                 "getI1SameShape(getPointeeType($_self))",
                  "($_op.getOperands().size() <= 1) || std::equal_to<>()">,
-  TypesMatchWith<"other matches ptr type", "ptr", "other", "getPointeeType($_self)",
-                 "($_op.getOperands().size() <= 2) || std::equal_to<>()">
-]> {
-    let summary = "Load from a pointer or tensor of pointers";
+             TypesMatchWith<
+                 "other matches ptr type", "ptr", "other",
+                 "getPointeeType($_self)",
+                 "($_op.getOperands().size() <= 2) || std::equal_to<>()">]> {
+  let summary = "Load from a pointer or tensor of pointers";
 
-    let arguments = (
-      ins
-      TT_PtrLike:$ptr,
-      Optional<TT_BoolLike>:$mask,
+  let arguments = (ins TT_PtrLike:$ptr, Optional<TT_BoolLike>:$mask,
       Optional<TT_Type>:$other,
-      DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
-      DefaultValuedAttr<TT_EvictionPolicyAttr, "::mlir::triton::EvictionPolicy::NORMAL">:$evict,
-      DefaultValuedAttr<BoolAttr, "false">:$isVolatile
-    );
+      DefaultValuedAttr<TT_CacheModifierAttr,
+                        "::mlir::triton::CacheModifier::NONE">:$cache,
+      DefaultValuedAttr<TT_EvictionPolicyAttr,
+                        "::mlir::triton::EvictionPolicy::NORMAL">:$evict,
+      DefaultValuedAttr<BoolAttr, "false">:$isVolatile);
 
-    let results = (outs TT_Type:$result);
+  let results = (outs TT_Type:$result);
 
-    let builders = [
-        // A tensor of pointers or a pointer to a scalar
-        OpBuilder<(ins "Value":$ptr, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>,
-        // A tensor of pointers or a pointer to a scalar with mask
-        OpBuilder<(ins "Value":$ptr, "Value":$mask, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>
-    ];
+  let builders = [
+      // A tensor of pointers or a pointer to a scalar
+      OpBuilder<(ins "Value":$ptr, "triton::CacheModifier":$cache,
+          "triton::EvictionPolicy":$evict, "bool":$isVolatile)>,
+      // A tensor of pointers or a pointer to a scalar with mask
+      OpBuilder<(ins "Value":$ptr, "Value":$mask,
+          "triton::CacheModifier":$cache, "triton::EvictionPolicy":$evict,
+          "bool":$isVolatile)>];
 
-    // Specify `cacheModifier` and `evictionPolicy` explicitly in the
-    // assemblyFormat instead of as part of attr-dict so that they get printed
-    // as strings rather than opaque integers.
-    //
-    // Note there's no comma between `other` and `cacheModifier` and between
-    // `cacheModifier` and `evictionPolicy`.  This is due to an apparent
-    // limitation in the MLIR custom-format parser.  In oilist, the initial
-    // keywords of each clause have to be unique, so they can't be `,`.
-    //
-    // Even if we gave up on order-independence and used vanilla optional
-    // clauses, the format (`,` `foo` `=` $foo^)? (`,` `bar` `=` $bar^)?  will
-    // not match the string ", bar = 0" because after the initial comma (first
-    // token of the first optional clause) we expect to see "foo".
-    let assemblyFormat = [{
+  // Specify `cacheModifier` and `evictionPolicy` explicitly in the
+  // assemblyFormat instead of as part of attr-dict so that they get printed
+  // as strings rather than opaque integers.
+  //
+  // Note there's no comma between `other` and `cacheModifier` and between
+  // `cacheModifier` and `evictionPolicy`.  This is due to an apparent
+  // limitation in the MLIR custom-format parser.  In oilist, the initial
+  // keywords of each clause have to be unique, so they can't be `,`.
+  //
+  // Even if we gave up on order-independence and used vanilla optional
+  // clauses, the format (`,` `foo` `=` $foo^)? (`,` `bar` `=` $bar^)?  will
+  // not match the string ", bar = 0" because after the initial comma (first
+  // token of the first optional clause) we expect to see "foo".
+  let assemblyFormat = [{
       $ptr (`,` $mask^)? (`,` $other^)?
       oilist(
         `cacheModifier` `=` $cache |
@@ -282,102 +260,95 @@ def TT_LoadOp : TT_Op<"load", [
       attr-dict `:` type($ptr)
     }];
 
-    let hasCanonicalizer = 1;
+  let hasCanonicalizer = 1;
 }
 
-def TT_StoreOp : TT_Op<"store", [
-  SameLoadStoreOperandsShape,
-  SameLoadStoreOperandsEncoding,
-  DeclareOpInterfaceMethods<PredicatedOpInterface>,
-  TypesMatchWith<"value type matches ptr type", "ptr", "value",
-                 "getPointeeType($_self)">,
-  TypesMatchWith<"mask type matches ptr type", "ptr", "mask",
-                 "getI1SameShape(getPointeeType($_self))",
-                 "($_op.getOperands().size() <= 2) || std::equal_to<>()">
-]> {
-    let summary = "Store through a pointer or tensor of pointers";
+def TT_StoreOp
+    : TT_Op<
+          "store", [SameLoadStoreOperandsShape, SameLoadStoreOperandsEncoding,
+                    DeclareOpInterfaceMethods<PredicatedOpInterface>,
+                    TypesMatchWith<"value type matches ptr type", "ptr",
+                                   "value", "getPointeeType($_self)">,
+                    TypesMatchWith<"mask type matches ptr type", "ptr", "mask",
+                                   "getI1SameShape(getPointeeType($_self))",
+                                   "($_op.getOperands().size() <= 2) || "
+                                   "std::equal_to<>()">]> {
+  let summary = "Store through a pointer or tensor of pointers";
 
-    let arguments = (ins
-      Arg<TT_PtrLike, "", [MemWrite<GlobalMemory>]>:$ptr,
-      TT_Type:$value,
-      Optional<TT_BoolLike>:$mask,
-      DefaultValuedAttr<TT_CacheModifierAttr, "triton::CacheModifier::NONE">:$cache,
-      DefaultValuedAttr<TT_EvictionPolicyAttr, "triton::EvictionPolicy::NORMAL">:$evict,
-      UnitAttr:$ignore_cta
-    );
+  let arguments = (ins Arg<TT_PtrLike, "", [MemWrite<GlobalMemory>]>:$ptr,
+      TT_Type:$value, Optional<TT_BoolLike>:$mask,
+      DefaultValuedAttr<TT_CacheModifierAttr,
+                        "triton::CacheModifier::NONE">:$cache,
+      DefaultValuedAttr<TT_EvictionPolicyAttr,
+                        "triton::EvictionPolicy::NORMAL">:$evict,
+      UnitAttr:$ignore_cta);
 
-    let builders = [
-        // A tensor of pointers or a pointer to a scalar
-        OpBuilder<(ins "Value":$ptr, "Value":$value, "triton::CacheModifier":$cache, "triton::EvictionPolicy":$evict)>
-    ];
+  let builders = [
+      // A tensor of pointers or a pointer to a scalar
+      OpBuilder<(ins "Value":$ptr, "Value":$value,
+          "triton::CacheModifier":$cache, "triton::EvictionPolicy":$evict)>];
 
-    // Specify cacheModifier and evictionPolicy explicitly, instead of leaving
-    // them in attr-dict, because this way their values get printed as strings,
-    // rather than as opaque integers.
-    //
-    // Note there are no commas between mask, cacheModifier, and evictionPolicy,
-    // due to limitations in MLIR's asm parser.
-    let assemblyFormat = [{
+  // Specify cacheModifier and evictionPolicy explicitly, instead of leaving
+  // them in attr-dict, because this way their values get printed as strings,
+  // rather than as opaque integers.
+  //
+  // Note there are no commas between mask, cacheModifier, and evictionPolicy,
+  // due to limitations in MLIR's asm parser.
+  let assemblyFormat = [{
       $ptr `,` $value (`,` $mask^)?
       oilist(`cacheModifier` `=` $cache | `evictionPolicy` `=` $evict)
       attr-dict `:` type($ptr)
     }];
 
-    let hasCanonicalizer = 1;
+  let hasCanonicalizer = 1;
 }
 
 //
 // Atomic Ops
 //
-def TT_AtomicRMWOp : TT_Op<"atomic_rmw", [
-  SameOperandsAndResultShape,
-  SameOperandsAndResultEncoding,
-  DeclareOpInterfaceMethods<PredicatedOpInterface>,
-  TypesMatchWith<"ptr type matches value type", "val", "ptr",
-                 "getPointerTypeSameShape($_self)">,
-  TypesMatchWith<"mask type matches value type",
-                 "val", "mask", "getI1SameShape($_self)",
-                 "($_op.getOperands().size() <= 2) || std::equal_to<>()">
-]> {
-    let summary = "atomic rmw";
+def TT_AtomicRMWOp
+    : TT_Op<"atomic_rmw",
+            [SameOperandsAndResultShape, SameOperandsAndResultEncoding,
+             DeclareOpInterfaceMethods<PredicatedOpInterface>,
+             TypesMatchWith<"ptr type matches value type", "val", "ptr",
+                            "getPointerTypeSameShape($_self)">,
+             TypesMatchWith<
+                 "mask type matches value type", "val", "mask",
+                 "getI1SameShape($_self)",
+                 "($_op.getOperands().size() <= 2) || std::equal_to<>()">]> {
+  let summary = "atomic rmw";
 
-    let description = [{
+  let description = [{
         load data at $ptr, do $rmw_op with $val, and store result to $ptr.
 
         return old value at $ptr
     }];
 
-    let arguments = (ins
-      TT_AtomicRMWAttr:$atomic_rmw_op,
+  let arguments = (ins TT_AtomicRMWAttr:$atomic_rmw_op,
       Arg<TT_PtrLike, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$ptr,
-      TT_Type:$val,
-      Optional<TT_BoolLike>:$mask,
-      TT_MemSemanticAttr:$sem,
-      TT_MemSyncScopeAttr:$scope
-    );
+      TT_Type:$val, Optional<TT_BoolLike>:$mask, TT_MemSemanticAttr:$sem,
+      TT_MemSyncScopeAttr:$scope);
 
-    let results = (outs TT_Type:$result);
+  let results = (outs TT_Type:$result);
 
-    // Explicitly list $atomic_rmw_op, $sem, and $scope rather than relying on
-    // attr-dict so they're printed as strings rather than opaque integers.
-    let assemblyFormat = [{
+  // Explicitly list $atomic_rmw_op, $sem, and $scope rather than relying on
+  // attr-dict so they're printed as strings rather than opaque integers.
+  let assemblyFormat = [{
       $atomic_rmw_op `,` $sem `,` $scope `,` $ptr `,` $val (`,` $mask^)?  attr-dict `:`
       functional-type(operands, $result)
     }];
-
 }
 
-def TT_AtomicCASOp : TT_Op<"atomic_cas", [
-  SameOperandsAndResultShape,
-  SameOperandsAndResultEncoding,
-  TypesMatchWith<"ptr type matches cmp type", "cmp", "ptr",
-                  "getPointerTypeSameShape($_self)">,
-  TypesMatchWith<"ptr type matches value type", "val", "ptr",
-                  "getPointerTypeSameShape($_self)">
-]> {
-    let summary = "atomic cas";
+def TT_AtomicCASOp
+    : TT_Op<"atomic_cas",
+            [SameOperandsAndResultShape, SameOperandsAndResultEncoding,
+             TypesMatchWith<"ptr type matches cmp type", "cmp", "ptr",
+                            "getPointerTypeSameShape($_self)">,
+             TypesMatchWith<"ptr type matches value type", "val", "ptr",
+                            "getPointerTypeSameShape($_self)">]> {
+  let summary = "atomic cas";
 
-    let description = [{
+  let description = [{
         compare $cmp with data $old at location $ptr,
 
         if $old == $cmp, store $val to $ptr,
@@ -387,19 +358,17 @@ def TT_AtomicCASOp : TT_Op<"atomic_cas", [
         return $old
     }];
 
-    let arguments = (ins
-      Arg<TT_PtrLike, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$ptr,
-      TT_Type:$cmp,
-      TT_Type:$val,
-      TT_MemSemanticAttr:$sem,
-      TT_MemSyncScopeAttr:$scope
-    );
+  let arguments =
+      (ins Arg<TT_PtrLike,
+               "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$ptr,
+          TT_Type:$cmp, TT_Type:$val, TT_MemSemanticAttr:$sem,
+          TT_MemSyncScopeAttr:$scope);
 
-    let results = (outs TT_Type:$result);
+  let results = (outs TT_Type:$result);
 
-    // Explicitly list $sem and $scope rather than relying on attr-dict so
-    // they're printed as strings rather than opaque integers.
-    let assemblyFormat = [{
+  // Explicitly list $sem and $scope rather than relying on attr-dict so
+  // they're printed as strings rather than opaque integers.
+  let assemblyFormat = [{
       $sem `,` $scope `,` $ptr `,` $cmp `,` $val attr-dict `:`
       functional-type(operands, $result)
      }];
@@ -408,49 +377,50 @@ def TT_AtomicCASOp : TT_Op<"atomic_cas", [
 //
 // Shape Manipulation Ops
 //
-def TT_SplatOp : TT_Op<"splat", [Pure,
-                                 SameOperandsAndResultElementType,
+def TT_SplatOp : TT_Op<"splat", [Pure, SameOperandsAndResultElementType,
                                  SameOperandsAndResultEncoding]> {
-    let summary = "splat";
+  let summary = "splat";
 
-    let arguments = (ins TT_Type:$src);
+  let arguments = (ins TT_Type:$src);
 
-    let results = (outs TT_Tensor:$result);
+  let results = (outs TT_Tensor:$result);
 
-    let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
 
-    let hasFolder = 1;
+  let hasFolder = 1;
 }
 
-def TT_UnsplatOp : TT_Op<"unsplat", [Pure,
-                                     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-    let summary = "convert a tensor with a single element to a scalar";
-    let arguments = (ins TT_Tensor:$src);
-    let results = (outs TT_Type:$result);
+def TT_UnsplatOp
+    : TT_Op<"unsplat", [Pure,
+                        DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+  let summary = "convert a tensor with a single element to a scalar";
+  let arguments = (ins TT_Tensor:$src);
+  let results = (outs TT_Type:$result);
 
-    let assemblyFormat = "$src attr-dict `:` type($src)";
-    let hasVerifier = 1;
+  let assemblyFormat = "$src attr-dict `:` type($src)";
+  let hasVerifier = 1;
 }
 
-def TT_ExpandDimsOp : TT_Op<"expand_dims", [Pure,
-                                            DeclareOpInterfaceMethods<InferTypeOpInterface>,
-                                            SameOperandsAndResultElementType]> {
-    let summary = "expand_dims";
+def TT_ExpandDimsOp
+    : TT_Op<"expand_dims", [Pure,
+                            DeclareOpInterfaceMethods<InferTypeOpInterface>,
+                            SameOperandsAndResultElementType]> {
+  let summary = "expand_dims";
 
-    let arguments = (ins TT_Tensor:$src, I32Attr:$axis);
+  let arguments = (ins TT_Tensor:$src, I32Attr:$axis);
 
-    let results = (outs TT_Tensor:$result);
+  let results = (outs TT_Tensor:$result);
 
-    let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
 
-    let hasCanonicalizeMethod = 1;
-    let hasFolder = 1;
+  let hasCanonicalizeMethod = 1;
+  let hasFolder = 1;
 }
 
-def TT_ReshapeOp : TT_Op<"reshape", [Pure,
-                                     SameOperandsAndResultElementType]> {
-    let summary = "reinterpret a tensor to a different shape. It may change elements order if the attribute is set.";
-    let description = [{
+def TT_ReshapeOp : TT_Op<"reshape", [Pure, SameOperandsAndResultElementType]> {
+  let summary = "reinterpret a tensor to a different shape. It may change "
+                "elements order if the attribute is set.";
+  let description = [{
         reinterpret a tensor to a different shape.
 
         If allow_reorder is set the compiler is free to change the order of
@@ -459,60 +429,59 @@ def TT_ReshapeOp : TT_Op<"reshape", [Pure,
         If efficient_layout is set, this is a hint that the destination layout should be kept for performance reason.
         The compiler is still free to change it for better performance.
     }];
-    let builders = [
-      OpBuilder<(ins "ArrayRef<int64_t>":$shape, "Value":$src,
-                     CArg<"bool", "false">:$allowReorder)>
-    ];
+  let builders = [OpBuilder<(ins "ArrayRef<int64_t>":$shape, "Value":$src,
+      CArg<"bool", "false">:$allowReorder)>];
 
-    let arguments = (ins TT_Tensor:$src, UnitAttr:$allow_reorder, UnitAttr:$efficient_layout);
-    let results = (outs TT_Tensor:$result);
-    let assemblyFormat = "$src (`allow_reorder` $allow_reorder^)? (`efficient_layout` $efficient_layout^)? attr-dict `:` type($src) `->` type($result)";
-    let hasCanonicalizeMethod = 1;
-    let hasFolder = 1;
-    let hasVerifier = 1;
+  let arguments = (ins TT_Tensor:$src, UnitAttr:$allow_reorder,
+      UnitAttr:$efficient_layout);
+  let results = (outs TT_Tensor:$result);
+  let assemblyFormat =
+      "$src (`allow_reorder` $allow_reorder^)? (`efficient_layout` "
+      "$efficient_layout^)? attr-dict `:` type($src) `->` type($result)";
+  let hasCanonicalizeMethod = 1;
+  let hasFolder = 1;
+  let hasVerifier = 1;
 }
 
-def TT_BroadcastOp : TT_Op<"broadcast", [Pure,
-                                         SameOperandsAndResultElementType,
+def TT_BroadcastOp : TT_Op<"broadcast", [Pure, SameOperandsAndResultElementType,
                                          SameOperandsAndResultEncoding]> {
-    let summary = "broadcast a tensor";
+  let summary = "broadcast a tensor";
 
-    let description = [{
+  let description = [{
       For a given tensor, broadcast changes one or more dimensions with size 1
       to a new size, e.g. tensor<1x32x1xf32> -> tensor<2x32x4xf32>.  You cannot
       change the size of a non-1 dimension.
     }];
 
-    let arguments = (ins TT_Tensor:$src);
+  let arguments = (ins TT_Tensor:$src);
 
-    let results = (outs TT_Tensor:$result);
+  let results = (outs TT_Tensor:$result);
 
-    let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
 
-    let hasCanonicalizer = 1;
-    let hasFolder = 1;
-    let hasVerifier = 1;
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+  let hasVerifier = 1;
 }
 
 // Cat is not pure because it may reorder elements.
-def TT_CatOp : TT_Op<"cat", [NoMemoryEffect,
-                             SameTypeOperands,
+def TT_CatOp : TT_Op<"cat", [NoMemoryEffect, SameTypeOperands,
                              SameOperandsAndResultElementType]> {
-    let summary = "concatenate 2 tensors";
+  let summary = "concatenate 2 tensors";
 
-    let arguments = (ins TT_Tensor:$lhs, TT_Tensor:$rhs);
+  let arguments = (ins TT_Tensor:$lhs, TT_Tensor:$rhs);
 
-    let results = (outs TT_Tensor:$result);
+  let results = (outs TT_Tensor:$result);
 
-    let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs) `->` type($result)";
+  let assemblyFormat =
+      "$lhs `,` $rhs attr-dict `:` type($lhs) `->` type($result)";
 
-    let hasVerifier = 1;
+  let hasVerifier = 1;
 }
 
-def TT_JoinOp : TT_Op<"join", [
-    Pure, SameTypeOperands]> {
-    let summary = "join two tensors along a new, minor dimension";
-    let description = [{
+def TT_JoinOp : TT_Op<"join", [Pure, SameTypeOperands]> {
+  let summary = "join two tensors along a new, minor dimension";
+  let description = [{
         For example, if the two input tensors are 4x8xf32, returns a tensor of
         shape 4x8x2xf32.
 
@@ -520,23 +489,20 @@ def TT_JoinOp : TT_Op<"join", [
         the two input tensors must have the same shape.
     }];
 
-    let builders = [
-      OpBuilder<(ins "Value":$lhs, "Value":$rhs)>
-    ];
-    let arguments = (ins TT_Tensor:$lhs, TT_Tensor:$rhs);
-    let results = (outs TT_Tensor:$result);
-    let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs) `->` type($result)";
-    let hasVerifier = 1;
+  let builders = [OpBuilder<(ins "Value":$lhs, "Value":$rhs)>];
+  let arguments = (ins TT_Tensor:$lhs, TT_Tensor:$rhs);
+  let results = (outs TT_Tensor:$result);
+  let assemblyFormat =
+      "$lhs `,` $rhs attr-dict `:` type($lhs) `->` type($result)";
+  let hasVerifier = 1;
 }
 
-def TT_SplitOp : TT_Op<"split", [
-  Pure,
-  InferTensorTypeOpWithLayoutEquivalence,
-  TypesMatchWith<"outLHS and outRHS types match",
-                  "outLHS", "outRHS", "$_self">,
+def TT_SplitOp : TT_Op<"split", [Pure, InferTensorTypeOpWithLayoutEquivalence,
+                                 TypesMatchWith<"outLHS and outRHS types match",
+                                                "outLHS", "outRHS", "$_self">,
 ]> {
-    let summary = "splits a tensor into two, along its last dimension";
-    let description = [{
+  let summary = "splits a tensor into two, along its last dimension";
+  let description = [{
         The input must be a tensor whose last dimension has size 2.  Returns two
         tensors, src[..., 0] and src[..., 1].
 
@@ -544,18 +510,17 @@ def TT_SplitOp : TT_Op<"split", [
         shape 4x8xf32.
     }];
 
-    let arguments = (ins TT_Tensor:$src);
-    let results = (outs TT_Tensor:$outLHS, TT_Tensor:$outRHS);
-    let assemblyFormat = "$src attr-dict `:` type($src) `->` type($outLHS)";
+  let arguments = (ins TT_Tensor:$src);
+  let results = (outs TT_Tensor:$outLHS, TT_Tensor:$outRHS);
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($outLHS)";
 }
 
-def TT_TransOp : TT_Op<"trans", [Pure,
-                                 TransposeOpInterface,
+def TT_TransOp : TT_Op<"trans", [Pure, TransposeOpInterface,
                                  InferTensorTypeOpWithLayoutEquivalence,
                                  SameOperandsAndResultElementType]> {
 
-    let summary = "rearrange the dimensions of a tensor";
-    let description = [{
+  let summary = "rearrange the dimensions of a tensor";
+  let description = [{
       For example, given a tensor x with shape [1,2,4], transpose(x) with
       order=[2,0,1] rearranges the tensor to have shape [4,1,2].
 
@@ -583,36 +548,31 @@ def TT_TransOp : TT_Op<"trans", [Pure,
       transpose+reshape+concat) without going to shared memory after each one.
     }];
 
-    let arguments = (
-      ins TT_Tensor:$src,
-      DenseI32ArrayAttr:$order
-    );
+  let arguments = (ins TT_Tensor:$src, DenseI32ArrayAttr:$order);
 
-    let results = (outs TT_Tensor:$result);
+  let results = (outs TT_Tensor:$result);
 
-    let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
 
-    let hasFolder = 1;
-    let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasVerifier = 1;
 }
 
 //
 // SPMD Ops
 //
 def TT_GetProgramIdOp : TT_Op<"get_program_id", [Pure]> {
-    let arguments = (ins TT_ProgramDim:$axis);
+  let arguments = (ins TT_ProgramDim:$axis);
 
-    let results = (outs I32:$result);
+  let results = (outs I32:$result);
 
-    let assemblyFormat = "$axis attr-dict `:` type($result)";
+  let assemblyFormat = "$axis attr-dict `:` type($result)";
 
-    let builders = [
-      OpBuilder<(ins "int":$axis), [{
+  let builders = [OpBuilder<(ins "int":$axis), [{
         build($_builder, $_state, $_builder.getI32Type(), ProgramIDDimAttr::get($_builder.getContext(), ProgramIDDim(axis)));
-      }]>
-    ];
+      }]>];
 
-    let extraClassDeclaration = [{
+  let extraClassDeclaration = [{
       int32_t getAxisAsInt() {
         return static_cast<int32_t>(getAxis());
       }
@@ -620,18 +580,16 @@ def TT_GetProgramIdOp : TT_Op<"get_program_id", [Pure]> {
 }
 
 def TT_GetNumProgramsOp : TT_Op<"get_num_programs", [Pure]> {
-    let arguments = (ins TT_ProgramDim:$axis);
+  let arguments = (ins TT_ProgramDim:$axis);
 
-    let results = (outs I32:$result);
+  let results = (outs I32:$result);
 
-    let assemblyFormat = "$axis attr-dict `:` type($result)";
-    let builders = [
-      OpBuilder<(ins "int":$axis), [{
+  let assemblyFormat = "$axis attr-dict `:` type($result)";
+  let builders = [OpBuilder<(ins "int":$axis), [{
         build($_builder, $_state, $_builder.getI32Type(), ProgramIDDimAttr::get($_builder.getContext(), ProgramIDDim(axis)));
-      }]>
-    ];
+      }]>];
 
-    let extraClassDeclaration = [{
+  let extraClassDeclaration = [{
       int32_t getAxisAsInt() {
         return static_cast<int32_t>(getAxis());
       }
@@ -641,14 +599,14 @@ def TT_GetNumProgramsOp : TT_Op<"get_num_programs", [Pure]> {
 //
 // Dot Op
 //
-def TT_DotOp : TT_Op<"dot", [Pure,
-                             DeclareOpInterfaceMethods<InferTypeOpInterface>,
-                             DeclareOpInterfaceMethods<DotOpInterface>,
-                             TypesMatchWith<"result's type matches accumulator's type",
-                                            "d", "c", "$_self">]> {
-    let summary = "dot";
+def TT_DotOp
+    : TT_Op<"dot", [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>,
+                    DeclareOpInterfaceMethods<DotOpInterface>,
+                    TypesMatchWith<"result's type matches accumulator's type",
+                                   "d", "c", "$_self">]> {
+  let summary = "dot";
 
-    let description = [{
+  let description = [{
         $d = matrix_multiply($a, $b) + $c. $inputPrecision describes how to exercise the TC
         when the inputs are f32. It can be one of: tf32, tf32x3, ieee, bf16x3, bf16x6.
         tf32: use TC with tf32 ops.
@@ -659,67 +617,59 @@ def TT_DotOp : TT_Op<"dot", [Pure,
         If the GPU does not have Tensor cores or the inputs are not f32, this flag is ignored.
     }];
 
-    let arguments = (
-      ins
-      TT_FpIntTensor:$a,
-      TT_FpIntTensor:$b,
-      TT_FpIntTensor:$c,
-      DefaultValuedAttr<TT_InputPrecisionAttr, "::mlir::triton::InputPrecision::IEEE">:$inputPrecision,
-      DefaultValuedAttr<I32Attr, "0">:$maxNumImpreciseAcc,
-      UnitAttr:$two_ctas
-    );
+  let arguments = (ins TT_FpIntTensor:$a, TT_FpIntTensor:$b, TT_FpIntTensor:$c,
+      DefaultValuedAttr<TT_InputPrecisionAttr,
+                        "::mlir::triton::InputPrecision::IEEE">:$inputPrecision,
+      DefaultValuedAttr<I32Attr, "0">:$maxNumImpreciseAcc, UnitAttr:$two_ctas);
 
-    let results = (outs TT_FpIntTensor:$d);
+  let results = (outs TT_FpIntTensor:$d);
 
-    // attr-dict prints enums as integers.  To get inputPrecision printed as a
-    // string, we need to specify it explicitly.
-    let assemblyFormat = [{
+  // attr-dict prints enums as integers.  To get inputPrecision printed as a
+  // string, we need to specify it explicitly.
+  let assemblyFormat = [{
       $a`,` $b`,` $c (`,` `inputPrecision` `=` $inputPrecision^)? attr-dict `:`
       type($a) `*` type($b) `->` type($d)
     }];
-    let hasVerifier = 1;
+  let hasVerifier = 1;
 }
-
 
 //
 // DotScaled Op
 //
-def TT_DotScaledOp : TT_Op<"dot_scaled", [Pure,
-                             AttrSizedOperandSegments,
-                             DeclareOpInterfaceMethods<DotOpInterface, ["verifyDims", "verifyOutputDims"]>,
-                             TypesMatchWith<"result's type matches accumulator's type",
-                                            "d", "c", "$_self">]> {
-    let summary = "dot_scaled";
+def TT_DotScaledOp
+    : TT_Op<"dot_scaled",
+            [Pure, AttrSizedOperandSegments,
+             DeclareOpInterfaceMethods<DotOpInterface, ["verifyDims",
+                                                        "verifyOutputDims"]>,
+             TypesMatchWith<"result's type matches accumulator's type", "d",
+                            "c", "$_self">]> {
+  let summary = "dot_scaled";
 
-    let description = [{
+  let description = [{
         $d = matrix_multiply(scale($a, $a_scale), scale($b, $b_scale)) + $c.
         Where scale(x, s) is a function that applies the scale per block following microscaling spec.
     }];
 
-    let arguments = (
-      ins
+  let arguments = (ins
       // inputs are floats if we have a type for them, otherwise (fp4),
       // they are packed in pairs in an I8Tensor
-      RankedTensorOf<[TT_Float,I8]>:$a,
-      RankedTensorOf<[TT_Float,I8]>:$b,
-      TT_FloatTensor:$c,
+      RankedTensorOf<[TT_Float, I8]>:$a,
+      RankedTensorOf<[TT_Float, I8]>:$b, TT_FloatTensor:$c,
       Optional<RankedTensorOf<[TT_Float, I8]>>:$a_scale,
       Optional<RankedTensorOf<[TT_Float, I8]>>:$b_scale,
       TT_ScaleDotElemTypeAttr:$a_elem_type,
-      TT_ScaleDotElemTypeAttr:$b_elem_type,
-      BoolAttr:$fastMath,
+      TT_ScaleDotElemTypeAttr:$b_elem_type, BoolAttr:$fastMath,
       DefaultValuedAttr<BoolAttr, "true">:$lhs_k_pack,
-      DefaultValuedAttr<BoolAttr, "true">:$rhs_k_pack
-    );
+      DefaultValuedAttr<BoolAttr, "true">:$rhs_k_pack);
 
-    let results = (outs TT_FloatTensor:$d);
+  let results = (outs TT_FloatTensor:$d);
 
-    let assemblyFormat = [{
+  let assemblyFormat = [{
       $a (`scale` $a_scale^)? `,` $b (`scale` $b_scale^)? `,` $c
       `lhs` `=` $a_elem_type `rhs` `=` $b_elem_type attr-dict
       `:` type($a) (`,` type($a_scale)^)? `*` type($b) (`,` type($b_scale)^)? `->` type($d)
     }];
-    let extraClassDeclaration = [{
+  let extraClassDeclaration = [{
       static LogicalResult deduceScaleFactor(Value lhs, Value lhsScale,
                                              ScaleDotElemType lhsFormat,
                                              bool lhsKPack, Value rhs,
@@ -731,29 +681,24 @@ def TT_DotScaledOp : TT_Op<"dot_scaled", [Pure,
       int32_t deduceScaleFactor();
     }];
 
-    let hasVerifier = 1;
+  let hasVerifier = 1;
 }
 
 //
 // Reduce Op
 //
-def TT_ReduceOp: TT_Op<"reduce",
-                       [Pure,
-                        SameOperandsShape,
-                        SameOperandsEncoding,
-                        SingleBlock,
-                        DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-    let summary = "Reduction using generic combination algorithm";
-    let arguments = (ins
-      Variadic<TT_Tensor>:$srcs,
-      I32Attr:$axis,
-      OptionalAttr<StrAttr>:$reduction_ordering
-    );
-    let results = (outs Variadic<TT_Type>:$result);
-    let regions = (region SizedRegion<1>:$combineOp);
-    let hasVerifier = 1;
-    let hasRegionVerifier = 1;
-    let extraClassDeclaration = [{
+def TT_ReduceOp
+    : TT_Op<"reduce", [Pure, SameOperandsShape, SameOperandsEncoding,
+                       SingleBlock,
+                       DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+  let summary = "Reduction using generic combination algorithm";
+  let arguments = (ins Variadic<TT_Tensor>:$srcs, I32Attr:$axis,
+      OptionalAttr<StrAttr>:$reduction_ordering);
+  let results = (outs Variadic<TT_Type>:$result);
+  let regions = (region SizedRegion<1>:$combineOp);
+  let hasVerifier = 1;
+  let hasRegionVerifier = 1;
+  let extraClassDeclaration = [{
       llvm::SmallVector<RankedTensorType> getInputTypes();
       llvm::SmallVector<Type> getElementTypes();
 
@@ -768,128 +713,131 @@ def TT_ReduceOp: TT_Op<"reduce",
     }];
 }
 
-def TT_ReduceReturnOp: TT_Op<"reduce.return",
-                             [HasParent<"ReduceOp">, Pure, Terminator, ReturnLike]> {
-    let summary = "terminator for reduce operator";
-    let arguments = (ins Variadic<AnyType>:$result);
-    let assemblyFormat = "$result attr-dict `:` type($result)";
+def TT_ReduceReturnOp : TT_Op<"reduce.return", [HasParent<"ReduceOp">, Pure,
+                                                Terminator, ReturnLike]> {
+  let summary = "terminator for reduce operator";
+  let arguments = (ins Variadic<AnyType>:$result);
+  let assemblyFormat = "$result attr-dict `:` type($result)";
 }
 
 //
 // Scan Op
 //
-def TT_ScanOp: TT_Op<"scan",
-                       [Pure,
-                        SameOperandsAndResultEncoding,
-                        SameOperandsAndResultShape,
-                        SingleBlock,
-                        DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-    let summary = "Associative scan using generic combination algorithm";
-    let arguments = (ins Variadic<TT_Tensor>:$srcs, I32Attr:$axis, BoolAttr:$reverse);
-    let results = (outs Variadic<TT_Tensor>:$result);
-    let regions = (region SizedRegion<1>:$combineOp);
-    let builders = [
-        OpBuilder<(ins "ValueRange":$srcs, "int":$axis, "bool":$reverse)>,
-    ];
-    let hasVerifier = 1;
-    let hasRegionVerifier = 1;
-    let extraClassDeclaration = [{
+def TT_ScanOp
+    : TT_Op<"scan", [Pure, SameOperandsAndResultEncoding,
+                     SameOperandsAndResultShape, SingleBlock,
+                     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+  let summary = "Associative scan using generic combination algorithm";
+  let arguments = (ins Variadic<TT_Tensor>:$srcs, I32Attr:$axis,
+      BoolAttr:$reverse);
+  let results = (outs Variadic<TT_Tensor>:$result);
+  let regions = (region SizedRegion<1>:$combineOp);
+  let builders = [OpBuilder<(ins "ValueRange":$srcs, "int":$axis,
+                      "bool":$reverse)>,
+  ];
+  let hasVerifier = 1;
+  let hasRegionVerifier = 1;
+  let extraClassDeclaration = [{
       llvm::SmallVector<RankedTensorType> getInputTypes();
       llvm::SmallVector<Type> getElementTypes();
     }];
 }
 
-def TT_ScanReturnOp: TT_Op<"scan.return",
-                             [HasParent<"ScanOp">, Pure, Terminator, ReturnLike]> {
-    let summary = "terminator for scan operator";
-    let arguments = (ins Variadic<AnyType>:$result);
-    let assemblyFormat = "$result attr-dict `:` type($result)";
+def TT_ScanReturnOp : TT_Op<"scan.return", [HasParent<"ScanOp">, Pure,
+                                            Terminator, ReturnLike]> {
+  let summary = "terminator for scan operator";
+  let arguments = (ins Variadic<AnyType>:$result);
+  let assemblyFormat = "$result attr-dict `:` type($result)";
 }
 
 //
 // Map Elementwise op
 //
-def TT_MapElementwiseOp: TT_Op<"map_elementwise", [SameOperandsAndResultEncoding,
-                                                   SameOperandsAndResultShape,
-                                                   RecursiveMemoryEffects]> {
-    let summary = "Map a scalar subregion over a tensor";
-    let arguments = (ins Variadic<TT_Tensor>:$srcs, I32Attr:$pack);
-    let results = (outs Variadic<TT_Tensor>:$result);
-    let regions = (region AnyRegion:$scalarOp);
-    let hasVerifier = 1;
-    let hasRegionVerifier = 1;
+def TT_MapElementwiseOp
+    : TT_Op<"map_elementwise", [SameOperandsAndResultEncoding,
+                                SameOperandsAndResultShape,
+                                RecursiveMemoryEffects]> {
+  let summary = "Map a scalar subregion over a tensor";
+  let arguments = (ins Variadic<TT_Tensor>:$srcs, I32Attr:$pack);
+  let results = (outs Variadic<TT_Tensor>:$result);
+  let regions = (region AnyRegion:$scalarOp);
+  let hasVerifier = 1;
+  let hasRegionVerifier = 1;
 }
 
-def TT_MapElementwiseReturnOp: TT_Op<"map_elementwise.return",
-                               [HasParent<"MapElementwiseOp">, Pure, Terminator, ReturnLike]> {
-    let summary = "terminator for map elementwise operator";
-    let arguments = (ins Variadic<AnyType>:$result);
-    let assemblyFormat = "attr-dict ($result^ `:` type($result))?";
+def TT_MapElementwiseReturnOp
+    : TT_Op<"map_elementwise.return", [HasParent<"MapElementwiseOp">, Pure,
+                                       Terminator, ReturnLike]> {
+  let summary = "terminator for map elementwise operator";
+  let arguments = (ins Variadic<AnyType>:$result);
+  let assemblyFormat = "attr-dict ($result^ `:` type($result))?";
 }
 
 //
 // External Elementwise op
 //
-def TT_ExternElementwiseOp : TT_Op<"extern_elementwise", [Elementwise,
-                                                          SameOperandsAndResultEncoding,
-                                                          SameVariadicOperandSize,
-                                                          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-                                                          ConditionallySpeculatable]> {
+def TT_ExternElementwiseOp
+    : TT_Op<"extern_elementwise", [Elementwise, SameOperandsAndResultEncoding,
+                                   SameVariadicOperandSize,
+                                   DeclareOpInterfaceMethods<
+                                       MemoryEffectsOpInterface>,
+                                   ConditionallySpeculatable]> {
 
-    let description = [{
+  let description = [{
         call an external function $symbol implemented in $libpath/$libname with $args
         return $libpath/$libname:$symbol($args...)
     }];
 
-    let arguments = (ins Variadic<TT_Type>:$srcs, StrAttr:$libname, StrAttr:$libpath, StrAttr:$symbol, BoolAttr:$pure);
+  let arguments = (ins Variadic<TT_Type>:$srcs, StrAttr:$libname,
+      StrAttr:$libpath, StrAttr:$symbol, BoolAttr:$pure);
 
-    let results = (outs TT_Type:$result);
+  let results = (outs TT_Type:$result);
 
-    let assemblyFormat = "operands attr-dict `:` functional-type(operands, $result)";
+  let assemblyFormat =
+      "operands attr-dict `:` functional-type(operands, $result)";
 
-    let extraClassDeclaration = [{
+  let extraClassDeclaration = [{
       // Interface method for ConditionallySpeculatable.
       Speculation::Speculatability getSpeculatability();
     }];
-
 }
 
 //
 // Make Range Op
 //
 def TT_MakeRangeOp : TT_Op<"make_range", [Pure]> {
-    let summary = "make range";
+  let summary = "make range";
 
-    let description = [{
+  let description = [{
         Returns an 1D int32 tensor.
 
         Values span from $start to $end (exclusive), with step = 1
     }];
 
-    // WARNING: MLIR generates getStart()/getEnd() functions which return
-    // uint32_t, even though these arguments are to be interpreted as *signed*
-    // int32 values.  If this matters, use get{Start,End}Attr().getInt(), which
-    // return int64_t.
-    let arguments = (ins I32Attr:$start, I32Attr:$end);
+  // WARNING: MLIR generates getStart()/getEnd() functions which return
+  // uint32_t, even though these arguments are to be interpreted as *signed*
+  // int32 values.  If this matters, use get{Start,End}Attr().getInt(), which
+  // return int64_t.
+  let arguments = (ins I32Attr:$start, I32Attr:$end);
 
-    let results = (outs TT_IntTensor:$result);
+  let results = (outs TT_IntTensor:$result);
 
-    let assemblyFormat = "attr-dict `:` type($result)";
+  let assemblyFormat = "attr-dict `:` type($result)";
 
-    let hasFolder = 1;
-    let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasVerifier = 1;
 }
 
 //
 // ElementwiseInlineAsm Op
 //
-def TT_ElementwiseInlineAsmOp : TT_Op<"elementwise_inline_asm", [
-  Elementwise,
-  SameOperandsAndResultEncoding,
-  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-  DeclareOpInterfaceMethods<ConditionallySpeculatable>
-]> {
-  let summary = "inline assembly applying an elementwise operation to a group of packed elements.";
+def TT_ElementwiseInlineAsmOp
+    : TT_Op<"elementwise_inline_asm",
+            [Elementwise, SameOperandsAndResultEncoding,
+             DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+             DeclareOpInterfaceMethods<ConditionallySpeculatable>]> {
+  let summary = "inline assembly applying an elementwise operation to a group "
+                "of packed elements.";
   let description = [{
     Runs an inline asm block to generate one or more tensors.
 
@@ -897,7 +845,9 @@ def TT_ElementwiseInlineAsmOp : TT_Op<"elementwise_inline_asm", [
     elems it receives is unspecified.
   }];
 
-  let arguments = (ins StrAttr:$asm_string, StrAttr:$constraints, BoolAttr:$pure, I32Attr:$packed_element, Variadic<AnyTypeOf<[TT_Type]>>:$args);
+  let arguments = (ins StrAttr:$asm_string, StrAttr:$constraints,
+      BoolAttr:$pure, I32Attr:$packed_element,
+      Variadic<AnyTypeOf<[TT_Type]>>:$args);
   let results = (outs Variadic<TT_Type>:$result);
 
   let assemblyFormat = [{
@@ -910,10 +860,12 @@ def TT_ElementwiseInlineAsmOp : TT_Op<"elementwise_inline_asm", [
 //
 // Histogram Op
 //
-def TT_HistogramOp : TT_Op<"histogram", [Pure,
-    TypesMatchWith<"mask type matches src type",
-                 "src", "mask", "getI1SameShape($_self)",
-                 "($_op.getOperands().size() <= 1) || std::equal_to<>()">]> {
+def TT_HistogramOp
+    : TT_Op<"histogram", [Pure,
+                          TypesMatchWith<"mask type matches src type", "src",
+                                         "mask", "getI1SameShape($_self)",
+                                         "($_op.getOperands().size() <= 1) || "
+                                         "std::equal_to<>()">]> {
   let summary = "return a histogram of the inputs.";
   let description = [{
     Return the histogram of the input tensor. The number of bins is equal to
@@ -921,8 +873,7 @@ def TT_HistogramOp : TT_Op<"histogram", [Pure,
     start at 0.
   }];
 
-  let arguments = (ins TT_IntTensor:$src,
-    Optional<TT_BoolLike>:$mask);
+  let arguments = (ins TT_IntTensor:$src, Optional<TT_BoolLike>:$mask);
 
   let results = (outs TT_IntTensor:$result);
 
@@ -934,8 +885,8 @@ def TT_HistogramOp : TT_Op<"histogram", [Pure,
 //
 // Gather Op
 //
-def TT_GatherOp : TT_Op<"gather", [Pure,
-    DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+def TT_GatherOp
+    : TT_Op<"gather", [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "local gather operation";
   let description = [{
     Gather elements from the input tensor using the indices tensor along a
@@ -950,12 +901,8 @@ def TT_GatherOp : TT_Op<"gather", [Pure,
     changed.
   }];
 
-  let arguments = (ins
-    TT_Tensor:$src,
-    TT_IntTensor:$indices,
-    I32Attr:$axis,
-    UnitAttr:$efficient_layout
-  );
+  let arguments = (ins TT_Tensor:$src, TT_IntTensor:$indices, I32Attr:$axis,
+      UnitAttr:$efficient_layout);
   let results = (outs TT_Tensor:$result);
 
   let assemblyFormat = [{
@@ -969,14 +916,10 @@ def TT_GatherOp : TT_Op<"gather", [Pure,
 //
 // Print Op
 //
-def TT_PrintOp : TT_Op<"print", [SameVariadicOperandSize, MemoryEffects<[MemWrite<GlobalMemory>]>]> {
-  let arguments = (
-    ins
-    StrAttr:$prefix,
-    BoolAttr:$hex,
-    Variadic<AnyTypeOf<[TT_Type]>>:$args,
-    DenseI32ArrayAttr:$isSigned
-  );
+def TT_PrintOp : TT_Op<"print", [SameVariadicOperandSize,
+                                 MemoryEffects<[MemWrite<GlobalMemory>]>]> {
+  let arguments = (ins StrAttr:$prefix, BoolAttr:$hex,
+      Variadic<AnyTypeOf<[TT_Type]>>:$args, DenseI32ArrayAttr:$isSigned);
   let summary = "Device-side print, as in CUDA for debugging";
   let description = [{
     `tt.print` takes a literal string prefix and an arbitrary number of scalar or tensor arguments that should be printed.
@@ -1003,45 +946,47 @@ def TT_AssertOp : TT_Op<"assert", [MemoryEffects<[MemWrite<GlobalMemory>]>]> {
 //
 // Make Tensor Descriptor Op
 //
-def TT_MakeTensorDescOp : TT_Op<"make_tensor_descriptor", [
-    AttrSizedOperandSegments,
-    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+def TT_MakeTensorDescOp
+    : TT_Op<"make_tensor_descriptor", [AttrSizedOperandSegments,
+                                       DeclareOpInterfaceMethods<
+                                           MemoryEffectsOpInterface>,
 ]> {
-  let summary = "Make a tensor descriptor type with meta information of the parent tensor and block size";
+  let summary = "Make a tensor descriptor type with meta information of the "
+                "parent tensor and block size";
 
   let description = [{
       `tt.make_tensor_descriptor` takes both meta information of the parent tensor and the block size,
       and returns a descriptor object which can be used to load/store from the tensor in global memory.
   }];
 
-  let arguments = (ins
-    TT_Ptr:$base,
-    Variadic<I32>:$shape,
-    Variadic<I64>:$strides,
-    Optional<TT_Ptr>:$descPtr,
-    DefaultValuedAttr<TT_PaddingOptionAttr, "::mlir::triton::PaddingOption::PAD_ZERO">:$padding
-  );
+  let arguments = (ins TT_Ptr:$base, Variadic<I32>:$shape,
+      Variadic<I64>:$strides, Optional<TT_Ptr>:$descPtr,
+      DefaultValuedAttr<TT_PaddingOptionAttr,
+                        "::mlir::triton::PaddingOption::PAD_ZERO">:$padding);
 
   let results = (outs TT_TensorDescType:$result);
 
   let hasCustomAssemblyFormat = 1;
 
-  let builders = [
-    OpBuilder<(ins "Value":$base, "ValueRange":$shape, "ValueRange":$strides, "ArrayRef<int32_t>":$blockShape, "bool":$isSignedInteger,
-    "triton::PaddingOption":$padding)>,
-    OpBuilder<(ins "Value":$base, "ValueRange":$shape, "ValueRange":$strides, "Value":$descPtr, "ArrayRef<int32_t>":$blockShape, "bool":$isSignedInteger,
-    "triton::PaddingOption":$padding)>
-  ];
-
+  let builders =
+      [OpBuilder<(ins "Value":$base, "ValueRange":$shape, "ValueRange":$strides,
+           "ArrayRef<int32_t>":$blockShape, "bool":$isSignedInteger,
+           "triton::PaddingOption":$padding)>,
+       OpBuilder<(ins "Value":$base, "ValueRange":$shape, "ValueRange":$strides,
+           "Value":$descPtr, "ArrayRef<int32_t>":$blockShape,
+           "bool":$isSignedInteger, "triton::PaddingOption":$padding)>];
 }
 
-// The following ops, including `call`, `func`, and `return` are copied and modified from
+// The following ops, including `call`, `func`, and `return` are copied and
+// modified from
 // https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Dialect/Func/IR/FuncOps.td
 // We could revert it back once MLIR has a better inliner interface.
 //
 // Function Ops
 //
-def CallOp : TT_Op<"call", [CallOpInterface, /*MemRefsNormalizable, */DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+def CallOp : TT_Op<"call", [CallOpInterface,
+                            /*MemRefsNormalizable, */ DeclareOpInterfaceMethods<
+                                SymbolUserOpInterface>]> {
   let summary = "call operation";
   let description = [{
     The `tt.call` operation represents a direct call to a function that is
@@ -1056,30 +1001,32 @@ def CallOp : TT_Op<"call", [CallOpInterface, /*MemRefsNormalizable, */DeclareOpI
     ```
   }];
 
-  let arguments = (ins FlatSymbolRefAttr:$callee,
-                   Variadic<AnyType>:$operands,
-                   OptionalAttr<DictArrayAttr>:$arg_attrs,
-                   OptionalAttr<DictArrayAttr>:$res_attrs);
+  let arguments = (ins FlatSymbolRefAttr:$callee, Variadic<AnyType>:$operands,
+      OptionalAttr<DictArrayAttr>:$arg_attrs,
+      OptionalAttr<DictArrayAttr>:$res_attrs);
   let results = (outs Variadic<AnyType>);
 
-  let builders = [
-    OpBuilder<(ins "FuncOp":$callee, CArg<"ValueRange", "{}">:$operands), [{
+  let builders =
+      [OpBuilder<(ins "FuncOp":$callee, CArg<"ValueRange", "{}">:$operands), [{
       $_state.addOperands(operands);
       $_state.addAttribute("callee", SymbolRefAttr::get(callee));
       $_state.addTypes(callee.getFunctionType().getResults());
     }]>,
-    OpBuilder<(ins "SymbolRefAttr":$callee, "TypeRange":$results,
-      CArg<"ValueRange", "{}">:$operands), [{
+       OpBuilder<(ins "SymbolRefAttr":$callee, "TypeRange":$results,
+                     CArg<"ValueRange", "{}">:$operands),
+                 [{
       $_state.addOperands(operands);
       $_state.addAttribute("callee", callee);
       $_state.addTypes(results);
     }]>,
-    OpBuilder<(ins "StringAttr":$callee, "TypeRange":$results,
-      CArg<"ValueRange", "{}">:$operands), [{
+       OpBuilder<(ins "StringAttr":$callee, "TypeRange":$results,
+                     CArg<"ValueRange", "{}">:$operands),
+                 [{
       build($_builder, $_state, SymbolRefAttr::get(callee), results, operands);
     }]>,
-    OpBuilder<(ins "StringRef":$callee, "TypeRange":$results,
-      CArg<"ValueRange", "{}">:$operands), [{
+       OpBuilder<(ins "StringRef":$callee, "TypeRange":$results,
+                     CArg<"ValueRange", "{}">:$operands),
+                 [{
       build($_builder, $_state, StringAttr::get($_builder.getContext(), callee),
             results, operands);
     }]>];
@@ -1119,11 +1066,10 @@ def CallOp : TT_Op<"call", [CallOpInterface, /*MemRefsNormalizable, */DeclareOpI
   }];
 }
 
-def FuncOp : TT_Op<"func", [
-    AffineScope, AutomaticAllocationScope, CallableOpInterface,
-    FunctionOpInterface, IsolatedFromAbove, OpAsmOpInterface,
-    HasParent<"ModuleOp">
-]> {
+def FuncOp
+    : TT_Op<"func", [AffineScope, AutomaticAllocationScope, CallableOpInterface,
+                     FunctionOpInterface, IsolatedFromAbove, OpAsmOpInterface,
+                     HasParent<"ModuleOp">]> {
   let summary = "An operation with a name containing a single `SSACFG` region";
   let description = [{
     Operations within the function cannot implicitly capture values defined
@@ -1164,17 +1110,15 @@ def FuncOp : TT_Op<"func", [
   }];
 
   let arguments = (ins SymbolNameAttr:$sym_name,
-                       TypeAttrOf<FunctionType>:$function_type,
-                       OptionalAttr<StrAttr>:$sym_visibility,
-                       OptionalAttr<DictArrayAttr>:$arg_attrs,
-                       OptionalAttr<DictArrayAttr>:$res_attrs);
+      TypeAttrOf<FunctionType>:$function_type,
+      OptionalAttr<StrAttr>:$sym_visibility,
+      OptionalAttr<DictArrayAttr>:$arg_attrs,
+      OptionalAttr<DictArrayAttr>:$res_attrs);
   let regions = (region AnyRegion:$body);
 
-  let builders = [OpBuilder<(ins
-    "StringRef":$name, "FunctionType":$type,
-    CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs,
-    CArg<"ArrayRef<DictionaryAttr>", "{}">:$argAttrs)
-  >];
+  let builders = [OpBuilder<(ins "StringRef":$name, "FunctionType":$type,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs,
+      CArg<"ArrayRef<DictionaryAttr>", "{}">:$argAttrs)>];
   let extraClassDeclaration = [{
     //===------------------------------------------------------------------===//
     // CallableOpInterface
@@ -1220,7 +1164,9 @@ def FuncOp : TT_Op<"func", [
   let hasCustomAssemblyFormat = 1;
 }
 
-def ReturnOp : TT_Op<"return", [Pure, HasParent<"FuncOp">, /*MemRefsNormalizable, */ReturnLike, Terminator]> {
+def ReturnOp
+    : TT_Op<"return", [Pure, HasParent<"FuncOp">,
+                       /*MemRefsNormalizable, */ ReturnLike, Terminator]> {
   let summary = "Function return operation";
   let description = [{
     The `tt.return` operation represents a return operation within a function.
@@ -1248,20 +1194,21 @@ def ReturnOp : TT_Op<"return", [Pure, HasParent<"FuncOp">, /*MemRefsNormalizable
   let hasVerifier = 1;
 }
 
-
-def TT_DescriptorLoadOp : TT_Op<"descriptor_load", [TT_DescriptorLoadLikeOpInterface]> {
+def TT_DescriptorLoadOp
+    : TT_Op<"descriptor_load", [TT_DescriptorLoadLikeOpInterface]> {
   let summary = "Load from descriptor";
   let description = [{
     This operation will be lowered to Nvidia TMA load operation on targets supporting it.
     `desc` is a tensor descriptor object.
     The destination tensor type and shape must match the descriptor otherwise the result is undefined.
   }];
-  let arguments = (ins
-    Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc,
-    Variadic<I32>:$indices,
-    DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
-    DefaultValuedAttr<TT_EvictionPolicyAttr, "::mlir::triton::EvictionPolicy::NORMAL">:$evict
-  );
+  let arguments =
+      (ins Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc,
+          Variadic<I32>:$indices,
+          DefaultValuedAttr<TT_CacheModifierAttr,
+                            "::mlir::triton::CacheModifier::NONE">:$cache,
+          DefaultValuedAttr<TT_EvictionPolicyAttr,
+                            "::mlir::triton::EvictionPolicy::NORMAL">:$evict);
 
   let results = (outs TT_Tensor:$result);
 
@@ -1277,19 +1224,21 @@ def TT_DescriptorLoadOp : TT_Op<"descriptor_load", [TT_DescriptorLoadLikeOpInter
   let hasVerifier = 1;
 }
 
-def TT_DescriptorStoreOp : TT_Op<"descriptor_store", [TT_DescriptorStoreLikeOpInterface]> {
+def TT_DescriptorStoreOp
+    : TT_Op<"descriptor_store", [TT_DescriptorStoreLikeOpInterface]> {
   let summary = "store value based on descriptor";
   let description = [{
     This operation will be lowered to Nvidia TMA store operation on targets supporting it.
     `desc` is a tensor descriptor object.
     The shape and types of `src` must match the descriptor otherwise the result is undefined.
   }];
-  let arguments = (ins
-    Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$desc,
-    TT_Tensor:$src,
-    Variadic<I32>:$indices,
-    DefaultValuedAttr<TT_DescriptorReduceKindAttr, "::mlir::triton::DescriptorReduceKind::NONE">:$reduce_kind
-  );
+  let arguments =
+      (ins Arg<TT_TensorDescType,
+               "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$desc,
+          TT_Tensor:$src, Variadic<I32>:$indices,
+          DefaultValuedAttr<
+              TT_DescriptorReduceKindAttr,
+              "::mlir::triton::DescriptorReduceKind::NONE">:$reduce_kind);
 
   let assemblyFormat = [{
     $desc `[` $indices `]` `,` $src
@@ -1299,19 +1248,18 @@ def TT_DescriptorStoreOp : TT_Op<"descriptor_store", [TT_DescriptorStoreLikeOpIn
   let hasVerifier = 1;
 }
 
-def TT_DescriptorReduceOp : TT_Op<"descriptor_reduce", [TT_DescriptorStoreLikeOpInterface]> {
+def TT_DescriptorReduceOp
+    : TT_Op<"descriptor_reduce", [TT_DescriptorStoreLikeOpInterface]> {
   let summary = "performs a reducing store operation based on a descriptor";
   let description = [{
     This operation will be lowered to Nvidia TMA store operation on targets supporting it.
     `desc` is a tensor descriptor object.
     The shape and types of `src` must match the descriptor otherwise the result is undefined.
   }];
-  let arguments = (ins
-    TT_DescriptorReduceKindAttr:$kind,
-    Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$desc,
-    TT_Tensor:$src,
-    Variadic<I32>:$indices
-  );
+  let arguments = (ins TT_DescriptorReduceKindAttr:$kind,
+      Arg<TT_TensorDescType,
+          "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$desc,
+      TT_Tensor:$src, Variadic<I32>:$indices);
 
   let assemblyFormat = [{
     $kind `,` $desc `[` $indices `]` `,` $src
@@ -1320,7 +1268,8 @@ def TT_DescriptorReduceOp : TT_Op<"descriptor_reduce", [TT_DescriptorStoreLikeOp
   let hasVerifier = 1;
 }
 
-def TT_DescriptorGatherOp : TT_Op<"descriptor_gather", [TT_DescriptorLoadLikeOpInterface]> {
+def TT_DescriptorGatherOp
+    : TT_Op<"descriptor_gather", [TT_DescriptorLoadLikeOpInterface]> {
   let summary = "gather multiple rows from a descriptor into a single tensor";
   let description = [{
     The `tt.descriptor_gather` op will be lowered to NVIDIA TMA
@@ -1331,11 +1280,9 @@ def TT_DescriptorGatherOp : TT_Op<"descriptor_gather", [TT_DescriptorLoadLikeOpI
     Accordingly, the result is a 2D tensor multiple rows.
   }];
 
-  let arguments = (ins
-    Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc,
-    RankedTensorOf<[I32]>:$x_offsets,
-    I32:$y_offset
-  );
+  let arguments =
+      (ins Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc,
+          RankedTensorOf<[I16, I32]>:$x_offsets, I32:$y_offset);
   let results = (outs TT_Tensor:$result);
 
   let assemblyFormat = [{
@@ -1346,7 +1293,8 @@ def TT_DescriptorGatherOp : TT_Op<"descriptor_gather", [TT_DescriptorLoadLikeOpI
   let hasVerifier = 1;
 }
 
-def TT_DescriptorScatterOp : TT_Op<"descriptor_scatter", [TT_DescriptorStoreLikeOpInterface]> {
+def TT_DescriptorScatterOp
+    : TT_Op<"descriptor_scatter", [TT_DescriptorStoreLikeOpInterface]> {
   let summary = "scatter multiple rows to a descriptor from a single tensor";
   let description = [{
     The `tt.descriptor_scatter` op will be lowered to NVIDIA TMA
@@ -1357,12 +1305,10 @@ def TT_DescriptorScatterOp : TT_Op<"descriptor_scatter", [TT_DescriptorStoreLike
     Accordingly, the result is a 2D tensor multiple rows.
   }];
 
-  let arguments = (ins
-    Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$desc,
-    RankedTensorOf<[I32]>:$x_offsets,
-    I32:$y_offset,
-    TT_Tensor:$src
-  );
+  let arguments =
+      (ins Arg<TT_TensorDescType,
+               "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$desc,
+          RankedTensorOf<[I16, I32]>:$x_offsets, I32:$y_offset, TT_Tensor:$src);
 
   let assemblyFormat = [{
     $desc `[` $x_offsets `,` $y_offset `]` `,` $src
@@ -1371,6 +1317,5 @@ def TT_DescriptorScatterOp : TT_Op<"descriptor_scatter", [TT_DescriptorStoreLike
 
   let hasVerifier = 1;
 }
-
 
 #endif // Triton_OPS

--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -119,13 +119,34 @@ struct SharedMemory : public SideEffects::Resource::Base<SharedMemory> {
   SideEffects::Resource *getParent() const override { return nullptr; }
 };
 
+// Returns true iff every non-broadcast basis of `ll`, after flattening in and
+// out dimensions, maps to a single power-of-2 in the flattened output.
 bool hasPowerOfTwoBases(const LinearLayout &ll);
+
+// Check whether after removing broadcast bases the flattened layout is a
+// permutation matrix (each non-broadcast basis maps to a distinct power-of-2
+// and the remaining layout is bijective).
 bool isPermutationMatrixLayout(const LinearLayout &ll);
+
+// Returns whether the attribute is a GenericLinearEncoding, a WMMA with warp
+// swizzling or a slice or DotOp of one of these.
+bool isGenericLinearEncoding(Attribute attr);
+
+// Create a GenericLinearEncoding if the source isGenericLinearEncoding, and a
+// LinearEncoding otherwise.
+Attribute inferEncodingFromLinearLayout(MLIRContext *ctx, LinearLayout ll,
+                                        Attribute srcEnc);
 
 // Convert a distributed layout to a linear encoding
 LinearEncodingAttr toLinearEncoding(RankedTensorType type);
 LinearEncodingAttr toLinearEncoding(DistributedEncodingTrait layout,
                                     ArrayRef<int64_t> shape);
+
+// Convert a distributed layout to a generic linear encoding
+GenericLinearEncodingAttr toGenericLinearEncoding(RankedTensorType type);
+GenericLinearEncodingAttr
+toGenericLinearEncoding(DistributedEncodingTrait layout,
+                        ArrayRef<int64_t> shape);
 
 unsigned getTotalElemsPerThread(Type type);
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -90,34 +90,28 @@ When vec=2, elements are swizzled in pairs of 2.  In other words, the element at
 
   // swizzle info: vec, perPhase, maxPhase
   // order: the fastest-changing axis first
-  let parameters = (
-    ins
-    "unsigned":$vec,
-    "unsigned":$perPhase,
-    "unsigned":$maxPhase,
-    ArrayRefParameter<"unsigned">:$order,
-    "CGAEncodingAttr":$CGALayout
-  );
+  let parameters = (ins "unsigned":$vec, "unsigned":$perPhase,
+      "unsigned":$maxPhase, ArrayRefParameter<"unsigned">:$order,
+      "CGAEncodingAttr":$CGALayout);
 
-  let builders = [
-    AttrBuilder<(ins "DotOperandEncodingAttr":$dotOpEnc,
-                     "ArrayRef<int64_t>":$shape,
-                     "ArrayRef<unsigned>":$order,
-                     "CGAEncodingAttr":$CGALayout,
-                     "unsigned":$typeWidthInBit), [{
+  let builders =
+      [AttrBuilder<(ins "DotOperandEncodingAttr":$dotOpEnc,
+                       "ArrayRef<int64_t>":$shape, "ArrayRef<unsigned>":$order,
+                       "CGAEncodingAttr":$CGALayout,
+                       "unsigned":$typeWidthInBit),
+                   [{
         bool needTrans = false; // default value
         return get(context, dotOpEnc, shape, order, CGALayout, typeWidthInBit, needTrans);
     }]>,
 
-    // TODO(jlebar): This should not be an overload of
-    // SwizzledSharedEncodingAttr::get().  It's misleading, because it does a bunch of
-    // nontrivial work based on the given dotOpEnc.
-    AttrBuilder<(ins "DotOperandEncodingAttr":$dotOpEnc,
-                     "ArrayRef<int64_t>":$shape,
-                     "ArrayRef<unsigned>":$order,
-                     "CGAEncodingAttr":$CGALayout,
-                     "unsigned":$typeWidthInBit,
-                     "bool":$needTrans), [{
+       // TODO(jlebar): This should not be an overload of
+       // SwizzledSharedEncodingAttr::get().  It's misleading, because it does a
+       // bunch of nontrivial work based on the given dotOpEnc.
+       AttrBuilder<(ins "DotOperandEncodingAttr":$dotOpEnc,
+                       "ArrayRef<int64_t>":$shape, "ArrayRef<unsigned>":$order,
+                       "CGAEncodingAttr":$CGALayout, "unsigned":$typeWidthInBit,
+                       "bool":$needTrans),
+                   [{
 
         // ---- begin MFMA ----
         if (auto mfmaEnc = mlir::dyn_cast<AMDMfmaEncodingAttr>(dotOpEnc.getParent())) {
@@ -148,15 +142,13 @@ When vec=2, elements are swizzled in pairs of 2.  In other words, the element at
         llvm_unreachable("unsupported swizzling for provided MMA version");
     }]>,
 
-    // NVIDIA constructor!
-    // TODO(lezcano): We should totally get rid of all these constructors...
-    AttrBuilder<(ins "int":$opIdx,
-                     "unsigned":$kWidth,
-                     "ArrayRef<int64_t>":$shape,
-                     "ArrayRef<unsigned>":$order,
-                     "CGAEncodingAttr":$CGALayout,
-                     "unsigned":$bitwidth,
-                     "bool":$needTrans), [{
+       // NVIDIA constructor!
+       // TODO(lezcano): We should totally get rid of all these constructors...
+       AttrBuilder<(ins "int":$opIdx, "unsigned":$kWidth,
+                       "ArrayRef<int64_t>":$shape, "ArrayRef<unsigned>":$order,
+                       "CGAEncodingAttr":$CGALayout, "unsigned":$bitwidth,
+                       "bool":$needTrans),
+                   [{
         int K =  getShapePerCTA(CGALayout.getCTASplitNum(), shape)[order[0]];
         // Elems necessary to cover all the banks divided by the inner dimension
         // This packs a few rows together for small K
@@ -181,21 +173,19 @@ When vec=2, elements are swizzled in pairs of 2.  In other words, the element at
         return get(context, vec, perPhase, maxPhase, order, CGALayout);
     }]>,
 
-    AttrBuilder<(ins "DotOperandEncodingAttr":$dotOpEnc,
-                     "ArrayRef<int64_t>":$shape,
-                     "ArrayRef<unsigned>":$order,
-                     "CGAEncodingAttr":$CGALayout,
-                     "Type":$eltTy), [{
+       AttrBuilder<(ins "DotOperandEncodingAttr":$dotOpEnc,
+                       "ArrayRef<int64_t>":$shape, "ArrayRef<unsigned>":$order,
+                       "CGAEncodingAttr":$CGALayout, "Type":$eltTy),
+                   [{
       unsigned bitwidth = eltTy.getIntOrFloatBitWidth();
       return get(context, dotOpEnc, shape, order, CGALayout, bitwidth);
     }]>,
 
-    AttrBuilder<(ins "DotOperandEncodingAttr":$dotOpEnc,
-                     "ArrayRef<int64_t>":$shape,
-                     "ArrayRef<unsigned>":$order,
-                     "CGAEncodingAttr":$CGALayout,
-                     "Type":$eltTy,
-                     "bool":$needTrans), [{
+       AttrBuilder<(ins "DotOperandEncodingAttr":$dotOpEnc,
+                       "ArrayRef<int64_t>":$shape, "ArrayRef<unsigned>":$order,
+                       "CGAEncodingAttr":$CGALayout, "Type":$eltTy,
+                       "bool":$needTrans),
+                   [{
       unsigned bitwidth = eltTy.getIntOrFloatBitWidth();
       return get(context, dotOpEnc, shape, order, CGALayout, bitwidth, needTrans);
     }]>,
@@ -285,25 +275,23 @@ For identity mappings a short form based on order and shape is used to increase 
 
   }];
 
-  let parameters = (ins
-      ArrayRefParameter<"unsigned">:$intervals,
+  let parameters = (ins ArrayRefParameter<"unsigned">:$intervals,
       ArrayRefParameter<"unsigned">:$paddings,
-      LinearLayoutParam:$linearComponent
-  );
+      LinearLayoutParam:$linearComponent);
 
-  let builders = [
-      AttrBuilder<(ins "ArrayRef<std::pair<unsigned, unsigned>>":$intervalPads,
-                       "LinearLayout":$linearComponent)>,
+  let builders =
+      [AttrBuilder<(ins "ArrayRef<std::pair<unsigned, unsigned>>":$intervalPads,
+           "LinearLayout":$linearComponent)>,
 
-      // Builder to create an identity mapping as the linear component
-      AttrBuilder<(ins "ArrayRef<std::pair<unsigned, unsigned>>":$intervalPads,
-                       "ArrayRef<unsigned>":$order, "ArrayRef<int64_t>":$shape,
-                       "CGAEncodingAttr":$cgaLayout)>,
+       // Builder to create an identity mapping as the linear component
+       AttrBuilder<(ins "ArrayRef<std::pair<unsigned, unsigned>>":$intervalPads,
+           "ArrayRef<unsigned>":$order, "ArrayRef<int64_t>":$shape,
+           "CGAEncodingAttr":$cgaLayout)>,
   ];
 
-  let extraClassDeclaration = extraBaseClassDeclaration # [{
+  let extraClassDeclaration = extraBaseClassDeclaration#[{
     // Returns the order of the dimensions `dimName` of the layout.
-    // If more than dimension is of size one, it uses defaultOrder to determine
+    // If more than one dimension is of size one, it uses defaultOrder to determine
     // the order of the dimensions of size one.
     SmallVector<unsigned> orderPerDim(StringAttr dimName,
                                       ArrayRef<unsigned> defaultOrder) const;
@@ -326,10 +314,10 @@ For identity mappings a short form based on order and shape is used to increase 
   let genVerifyDecl = 1;
 }
 
-
 def PartitionedSharedEncodingAttr
     : TritonGPU_Attr<"PartitionedSharedEncoding", "partitioned_shared_encoding",
-                     [SharedEncodingTrait, DeclareLayoutEncodingMethods,  LayoutEncodingTrait]> {
+                     [SharedEncodingTrait, DeclareLayoutEncodingMethods,
+                      LayoutEncodingTrait]> {
   let mnemonic = "partitioned_shared";
 
   let description = [{
@@ -374,12 +362,8 @@ def PartitionedSharedEncodingAttr
     in distinct physical shared memory partitions.
   }];
 
-  let parameters = (ins
-      "unsigned":$numPartitions,
-      "unsigned":$numGroups,
-      "unsigned":$partitionDim,
-      "SharedEncodingTrait":$partitionLayout
-  );
+  let parameters = (ins "unsigned":$numPartitions, "unsigned":$numGroups,
+      "unsigned":$partitionDim, "SharedEncodingTrait":$partitionLayout);
 
   let extraClassDeclaration = [{
     /// Returns the total number of logical pieces.
@@ -404,7 +388,8 @@ def SharedLinearEncodingAttr
     offsets (and optionally blocks) map to logical tensor indices.
   }];
 
-  let parameters = (ins LinearLayoutParam:$linearLayout, "unsigned":$layoutAlignment);
+  let parameters = (ins LinearLayoutParam:$linearLayout,
+      "unsigned":$layoutAlignment);
 
   let extraClassDeclaration = [{
     SmallVector<unsigned> basesPerDim(StringAttr dimName,
@@ -425,7 +410,8 @@ def SharedLinearEncodingAttr
   let hasCustomAssemblyFormat = 1;
 }
 
-def NVMMASharedEncodingAttr : TritonGPU_Attr<"NVMMASharedEncoding", "nvmma_shared_encoding",
+def NVMMASharedEncodingAttr
+    : TritonGPU_Attr<"NVMMASharedEncoding", "nvmma_shared_encoding",
                      [DeclareSharedEncodingMethods, LayoutEncodingTrait,
                       DeclareLayoutEncodingMethods]> {
   let mnemonic = "nvmma_shared";
@@ -444,24 +430,18 @@ def NVMMASharedEncodingAttr : TritonGPU_Attr<"NVMMASharedEncoding", "nvmma_share
     in the MMA instruction descriptors. https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-shared-memory-layout-swizzling
   }];
 
+  // fp4Padded: Indicates that this encoding represents a mixed-precision fp4
+  // operand in MMAv5 scaled dot, which needs to be in the special padded layout
+  // as described in
+  // https://docs.nvidia.com/cuda/parallel-thread-execution/#packing-format-used-for-matrix-a-and-b-by-kind-mxf8f6f4-in-shared-memory
+  let parameters = (ins "unsigned":$swizzlingByteWidth, "bool":$transposed,
+      "unsigned":$elementBitWidth, "bool":$fp4Padded,
+      "CGAEncodingAttr":$CGALayout);
 
-  // fp4Padded: Indicates that this encoding represents a mixed-precision fp4 operand in MMAv5 scaled dot, which needs
-  // to be in the special padded layout as described in https://docs.nvidia.com/cuda/parallel-thread-execution/#packing-format-used-for-matrix-a-and-b-by-kind-mxf8f6f4-in-shared-memory
-  let parameters = (
-    ins
-    "unsigned":$swizzlingByteWidth,
-    "bool":$transposed,
-    "unsigned":$elementBitWidth,
-    "bool":$fp4Padded,
-    "CGAEncodingAttr":$CGALayout
-  );
-
-  let builders = [
-    AttrBuilder<(ins "ArrayRef<int64_t>":$shape,
-                     "ArrayRef<unsigned>":$order,
-                     "CGAEncodingAttr":$CGALayout,
-                     "Type":$eltTy,
-                     "bool": $fp4Padded), [{
+  let builders = [AttrBuilder<
+      (ins "ArrayRef<int64_t>":$shape, "ArrayRef<unsigned>":$order,
+          "CGAEncodingAttr":$CGALayout, "Type":$eltTy, "bool":$fp4Padded),
+      [{
         auto shapePerCTA = getShapePerCTA(CGALayout.getCTASplitNum(), shape);
         int32_t swizzlingByteWidth = 0;
         unsigned eleBitWidth = eltTy.getIntOrFloatBitWidth();
@@ -488,10 +468,9 @@ def NVMMASharedEncodingAttr : TritonGPU_Attr<"NVMMASharedEncoding", "nvmma_share
         }
         bool transposed = order.size() > 1 && order[0] == 0;
         return $_get(context, swizzlingByteWidth, transposed, eleBitWidth, fp4Padded, CGALayout);
-    }]>
-  ];
+    }]>];
 
-  let extraClassDeclaration = extraBaseClassDeclaration # [{
+  let extraClassDeclaration = extraBaseClassDeclaration#[{
     int getPerPhase() const;
     int getMaxPhase() const;
     int getVec() const;
@@ -500,10 +479,11 @@ def NVMMASharedEncodingAttr : TritonGPU_Attr<"NVMMASharedEncoding", "nvmma_share
   let genVerifyDecl = 1;
 }
 
-def AMDRotatingSharedEncodingAttr :
-  TritonGPU_Attr<"AMDRotatingSharedEncoding", "amd_rotating_shared_encoding",
-                 [SharedEncodingTrait, LayoutEncodingTrait,
-                  DeclareLayoutEncodingMethods]> {
+def AMDRotatingSharedEncodingAttr
+    : TritonGPU_Attr<"AMDRotatingSharedEncoding",
+                     "amd_rotating_shared_encoding",
+                     [SharedEncodingTrait, LayoutEncodingTrait,
+                      DeclareLayoutEncodingMethods]> {
   let mnemonic = "amd_rotating_shared";
 
   let description = [{
@@ -586,24 +566,19 @@ Swizzling examples (matrix is filled with numbers 0, 1, 2, .. columns*rows-1):
     7  [30, 31, 28, 29]   // phase = 3 blockNo = 1 (xor with 2)
   }];
 
-  let parameters = (
-    ins
-    "unsigned":$vec,
-    "unsigned":$perPhase,
-    "unsigned":$maxPhase,
-    ArrayRefParameter<"unsigned">:$order,
-    "CGAEncodingAttr":$CGALayout
-  );
+  let parameters = (ins "unsigned":$vec, "unsigned":$perPhase,
+      "unsigned":$maxPhase, ArrayRefParameter<"unsigned">:$order,
+      "CGAEncodingAttr":$CGALayout);
 
   let hasCustomAssemblyFormat = 1;
 }
 
-
-class DistributedEncoding<string name, string attrMnemonic, list<Trait> traits = []>
-  : TritonGPU_Attr<name, attrMnemonic,
-                   !listconcat([DistributedEncodingTrait, LayoutEncodingTrait,
-                                DeclareLayoutEncodingMethods],
-                               traits)> {
+class DistributedEncoding<string name, string attrMnemonic,
+                          list<Trait> traits = []>
+    : TritonGPU_Attr<name, attrMnemonic,
+                     !listconcat([DistributedEncodingTrait, LayoutEncodingTrait,
+                                  DeclareLayoutEncodingMethods],
+                                 traits)> {
 
   let description = [{
 Distributed encodings have a layout function L that is entirely characterized
@@ -638,7 +613,7 @@ L(T) = [ {0,8} , {1,9} , {2,10}, {3,11}, {0,8} , {1, 9} , {2, 10}, {3, 11},
          {4,12}, {5,13}, {6,14}, {7,15}, {4,12}, {5, 13}, {6, 14}, {7, 15} ]
   }];
 
-  code extraDistributedDeclaration  = extraBaseClassDeclaration # [{
+  code extraDistributedDeclaration = extraBaseClassDeclaration#[{
     // Implemented in subclasses
     SmallVector<unsigned> getRepOrder() const;
 
@@ -647,50 +622,55 @@ L(T) = [ {0,8} , {1,9} , {2,10}, {3,11}, {0,8} , {1, 9} , {2, 10}, {3, 11},
 }
 
 //===----------------------------------------------------------------------===//
-// Linear Layout Encoding
+// Linear Layout Encodings (common base class)
 //===----------------------------------------------------------------------===//
 
-def LinearEncodingAttr : DistributedEncoding<"LinearEncoding", "linear_encoding"> {
-  let mnemonic = "linear";
-
-  let description = [{
-    See the docs in LinearLayout.h for the definition of linear layouts.
-  }];
+class LinearDistributedEncoding<string name, string attrMnemonic,
+                                list<Trait> traits = []>
+    : DistributedEncoding<name, attrMnemonic,
+                          !listconcat([LinearEncodingTrait,
+                                       DeclareLinearEncodingMethods],
+                                      traits)> {
 
   let parameters = (ins LinearLayoutParam:$linearLayout);
 
-  let extraClassDeclaration = extraDistributedDeclaration # [{
-    // Generic distributed encoding methods
-    unsigned getTotalElemsPerThread(ArrayRef<int64_t> shape) const;
-    SmallVector<unsigned> getElemsPerThread(ArrayRef<int64_t> shape) const;
-
-    SmallVector<unsigned int> getContig(const char *, SmallVector<unsigned int>) const;
-    SmallVector<unsigned> getContigPerThread() const;
-    SmallVector<unsigned> getContigPerWarp() const;
-    SmallVector<unsigned> getOrder() const;
-    SmallVector<unsigned> getWarpOrder() const;
-    SmallVector<unsigned> getThreadOrder() const;
-
-
-    // Generalizes get{Warp,Thread,CTA}Order to linear layouts.
-    // Returns the order of the dimensions `dimName` of the layout.
-    // If more than dimension is of size one, it uses defaultOrder to determine
-    // the order of the dimensions of size one.
-    SmallVector<unsigned> orderPerDim(StringAttr dimName,
-                                      ArrayRef<unsigned> defaultOrder) const;
-
-    // Generalizes getThreadsPerWarp, getWarpsPerCTA, getCTAsPerCGA to linear layouts.
-    // Returns the bases of the dimensions `dimName` of the layout.
-    // If skipBroadcast is false, we count a base zero
-    SmallVector<unsigned> basesPerDim(StringAttr dimName,
-                                      bool skipBroadcast = true) const;
-    SmallVector<unsigned> getThreadsPerWarp() const;
-    SmallVector<unsigned> getWarpsPerCTA() const;
-
+  code extraLinearDistributedDeclaration = [{
     unsigned getRank() const { return getLinearLayout().getNumOutDims(); }
+  }];
+}
 
-    // [FIXME LL] Supports legacy behaviour. We should remove these functions
-    SmallVector<unsigned> getSizePerThread() const;
+//===----------------------------------------------------------------------===//
+// Linear Layout Encoding
+//===----------------------------------------------------------------------===//
+
+def LinearEncodingAttr
+    : LinearDistributedEncoding<"LinearEncoding", "linear_encoding"> {
+  let mnemonic = "linear";
+
+  let description = [{
+    An encoding backed by a LinearLayout with input dims
+    {register, lane, warp, block} and output dims {dim0, dim1, ...}. See the
+    docs in LinearLayout.h for the general definition of linear layouts;
+    this attribute is a strictly more restricted form of that abstraction.
+
+    Compared to GenericLinearEncodingAttr, this is more constrained
+    LinearLayout-based encoding:
+    - Every basis vector (register, lane, warp, and block) must be
+      non-swizzled, i.e. have at most one non-zero output component (the
+      basis either moves along a single output dim, or is a broadcast/zero
+      basis).
+    - After removing broadcast bases the layout must be bijective.
+
+    GenericLinearEncodingAttr relaxes the above in two ways:
+    - Warp bases MAY be swizzled (non-zero in multiple output dims).
+      Register, lane, and block bases must still be non-swizzled.
+    - The layout is only required to be surjective (not bijective) after
+      removing broadcast bases.
+  }];
+
+  let extraClassDeclaration = extraLinearDistributedDeclaration#[{
+    SmallVector<unsigned> getWarpsPerCTA() const;
+    SmallVector<unsigned> getWarpOrder() const;
   }];
 
   let genVerifyDecl = 1;
@@ -702,12 +682,42 @@ def LinearEncodingAttr : DistributedEncoding<"LinearEncoding", "linear_encoding"
   let hasCustomAssemblyFormat = 1;
 }
 
+//===----------------------------------------------------------------------===//
+// Generic Linear Layout Encoding
+//===----------------------------------------------------------------------===//
+
+def GenericLinearEncodingAttr
+    : LinearDistributedEncoding<"GenericLinearEncoding",
+                                "generic_linear_encoding"> {
+  let mnemonic = "generic_linear";
+
+  let description = [{
+    A linear layout encoding with relaxed constraints compared to LinearEncoding.
+    Like LinearEncoding, it wraps a LinearLayout with input dims
+    {register, lane, warp, block} and output dims {dim0, dim1, ...}.
+
+    Unlike LinearEncoding:
+    - Warp bases MAY be swizzled (non-zero in multiple output dims).
+    - The layout is NOT required to be bijective after removing broadcast bases,
+      but it's still required to be surjective.
+
+    Register, lane, and block bases must still be non-swizzled (at most one
+    non-zero output component per basis vector), which preserves existing
+    within-thread, within-warp, and CGA lowering paths.
+  }];
+
+  let extraClassDeclaration = extraLinearDistributedDeclaration;
+
+  let genVerifyDecl = 1;
+  let hasCustomAssemblyFormat = 1;
+}
 
 //===----------------------------------------------------------------------===//
 // Blocked Layout Encoding
 //===----------------------------------------------------------------------===//
 
-def BlockedEncodingAttr : DistributedEncoding<"BlockedEncoding", "blocked_encoding"> {
+def BlockedEncodingAttr
+    : DistributedEncoding<"BlockedEncoding", "blocked_encoding"> {
   let mnemonic = "blocked";
 
   let description = [{
@@ -787,26 +797,22 @@ for
 }>
 }];
 
-  let parameters = (
-    ins
-    ArrayRefParameter<"unsigned">:$sizePerThread,
-    ArrayRefParameter<"unsigned">:$threadsPerWarp,
-    ArrayRefParameter<"unsigned">:$warpsPerCTA,
-    ArrayRefParameter<"unsigned">:$order, // the fastest-changing axis first
+  let parameters = (ins ArrayRefParameter<"unsigned">:$sizePerThread,
+      ArrayRefParameter<"unsigned">:$threadsPerWarp,
+      ArrayRefParameter<"unsigned">:$warpsPerCTA,
+      ArrayRefParameter<"unsigned">:$order, // the fastest-changing axis first
 
-    // CGALayout is optional in the textual IR.  If omitted, we infer it to be a
-    // CGA with a single CTA (i.e. the trivial map onto dim0..dimn-1)
-    "CGAEncodingAttr":$CGALayout
-  );
+      // CGALayout is optional in the textual IR.  If omitted, we infer it to be
+      // a CGA with a single CTA (i.e. the trivial map onto dim0..dimn-1)
+      "CGAEncodingAttr":$CGALayout);
   let genVerifyDecl = 1;
 
-  let builders = [
-    AttrBuilder<(ins "ArrayRef<int64_t>":$shape,
-                     "ArrayRef<unsigned>":$sizePerThread,
-                     "ArrayRef<unsigned>":$order,
-                     "unsigned":$numWarps,
-                     "unsigned":$numThreadsPerWarp,
-                     "CGAEncodingAttr":$CGALayout), [{
+  let builders =
+      [AttrBuilder<
+           (ins "ArrayRef<int64_t>":$shape, "ArrayRef<unsigned>":$sizePerThread,
+               "ArrayRef<unsigned>":$order, "unsigned":$numWarps,
+               "unsigned":$numThreadsPerWarp, "CGAEncodingAttr":$CGALayout),
+           [{
       unsigned rank = sizePerThread.size();
       SmallVector<unsigned, 4> threadsPerWarp(rank);
       SmallVector<unsigned, 4> warpsPerCTA(rank);
@@ -850,12 +856,11 @@ for
       return $_get(context, sizePerThread, threadsPerWarp, warpsPerCTA, order, CGALayout);
     }]>,
 
-    AttrBuilder<(ins "ArrayRef<int64_t>":$shape,
-                     "ArrayRef<unsigned>":$sizePerThread,
-                     "ArrayRef<unsigned>":$order,
-                     "unsigned":$numWarps,
-                     "unsigned":$numThreadsPerWarp,
-                     "unsigned":$numCTAs), [{
+       AttrBuilder<(ins "ArrayRef<int64_t>":$shape,
+                       "ArrayRef<unsigned>":$sizePerThread,
+                       "ArrayRef<unsigned>":$order, "unsigned":$numWarps,
+                       "unsigned":$numThreadsPerWarp, "unsigned":$numCTAs),
+                   [{
       unsigned rank = sizePerThread.size();
       SmallVector<unsigned, 4> CTAsPerCGA(rank);
       SmallVector<unsigned, 4> CTASplitNum(rank);
@@ -875,15 +880,16 @@ for
 
       CGAEncodingAttr CGALayout = CGAEncodingAttr::fromSplitParams(context, CTAsPerCGA, CTASplitNum, CTAOrder);
       return get(context, shape, sizePerThread, order, numWarps, numThreadsPerWarp, CGALayout);
-    }]>
-  ];
+    }]>];
 
   let extraClassDeclaration = extraDistributedDeclaration;
 
   let hasCustomAssemblyFormat = 1;
 }
 
-def AMDMfmaEncodingAttr : DistributedEncoding<"AMDMfmaEncoding", "amd_mfma_encoding", [MmaEncodingTrait]> {
+def AMDMfmaEncodingAttr
+    : DistributedEncoding<"AMDMfmaEncoding",
+                          "amd_mfma_encoding", [MmaEncodingTrait]> {
   let mnemonic = "amd_mfma";
 
   let description = [{
@@ -1007,35 +1013,27 @@ w2 w2 w3 w3
 w2 w2 w3 w3
 }];
 
-  let parameters = (
-    ins
-    "unsigned": $version,
-    ArrayRefParameter<"unsigned">:$warpsPerCTA,
-    ArrayRefParameter<"unsigned">:$instrShape,
-    "bool":$isTransposed,
-    "CGAEncodingAttr":$CGALayout,
-    ArrayRefParameter<"unsigned">:$tilesPerWarp,
-    "unsigned":$elementBitWidth
-  );
+  let parameters = (ins "unsigned":$version,
+      ArrayRefParameter<"unsigned">:$warpsPerCTA,
+      ArrayRefParameter<"unsigned">:$instrShape, "bool":$isTransposed,
+      "CGAEncodingAttr":$CGALayout, ArrayRefParameter<"unsigned">:$tilesPerWarp,
+      "unsigned":$elementBitWidth);
 
-  let builders = [
-    AttrBuilder<(ins "unsigned":$version,
-                     "ArrayRef<unsigned>":$warpsPerCTA,
-                     "ArrayRef<unsigned>":$instrShape,
-                     "bool":$isTransposed,
-                     "CGAEncodingAttr":$CGALayout,
-                     CArg<"ArrayRef<unsigned>", "{}">:$tpw,
-                     CArg<"unsigned", "0">:$elementBitWidth), [{
+  let builders = [AttrBuilder<
+      (ins "unsigned":$version, "ArrayRef<unsigned>":$warpsPerCTA,
+          "ArrayRef<unsigned>":$instrShape, "bool":$isTransposed,
+          "CGAEncodingAttr":$CGALayout, CArg<"ArrayRef<unsigned>", "{}">:$tpw,
+          CArg<"unsigned", "0">:$elementBitWidth),
+      [{
       SmallVector<unsigned> tilesPerWarp(tpw);
       if (tilesPerWarp.empty())
         tilesPerWarp = SmallVector<unsigned>(warpsPerCTA.size(), 1);
       if (elementBitWidth == 0)
         elementBitWidth = 32;
       return $_get($_ctxt, version, warpsPerCTA, instrShape, isTransposed, CGALayout, tilesPerWarp, elementBitWidth);
-    }]>
-  ];
+    }]>];
 
-  let extraClassDeclaration = extraDistributedDeclaration # [{
+  let extraClassDeclaration = extraDistributedDeclaration#[{
     SmallVector<int64_t> getInstrShapeForOperand(int kWidth, int opIdx) const;
     SmallVector<int64_t> getRepForOperand(ArrayRef<int64_t> operandShape, int kWidth, int opIdx) const;
     SmallVector<unsigned> getRepOrderForOperand(int opIdx) const;
@@ -1056,7 +1054,9 @@ w2 w2 w3 w3
   let skipDefaultBuilders = 1;
 }
 
-def AMDWmmaEncodingAttr : DistributedEncoding<"AMDWmmaEncoding", "amd_wmma_encoding", [MmaEncodingTrait]> {
+def AMDWmmaEncodingAttr
+    : DistributedEncoding<"AMDWmmaEncoding",
+                          "amd_wmma_encoding", [MmaEncodingTrait]> {
   let mnemonic = "amd_wmma";
 
   let description = [{
@@ -1217,19 +1217,14 @@ wmmaLayout = tileLayout * ctaLayout
 This simplifies both WMMA and dotOperand layouts lowering to linear layout.
   }];
 
-  let parameters = (
-    ins
-    "unsigned": $version,
-    LinearLayoutParam:$ctaLayout,
-    "bool":$isTransposed,
-    "CGAEncodingAttr":$CGALayout,
-    ArrayRefParameter<"unsigned">:$instrShape
-  );
+  let parameters = (ins "unsigned":$version, LinearLayoutParam:$ctaLayout,
+      "bool":$isTransposed, "CGAEncodingAttr":$CGALayout,
+      ArrayRefParameter<"unsigned">:$instrShape);
 
   let genVerifyDecl = 1;
   let hasCustomAssemblyFormat = 1;
 
-  let extraClassDeclaration = extraDistributedDeclaration # [{
+  let extraClassDeclaration = extraDistributedDeclaration#[{
     SmallVector<unsigned> getRepOrderForOperand(int opIdx) const;
     LinearLayout getTileLayout(unsigned rank) const;
     static SmallVector<unsigned, 3> getDefaultInstrShape() {
@@ -1253,7 +1248,9 @@ This simplifies both WMMA and dotOperand layouts lowering to linear layout.
   }];
 }
 
-def NvidiaMmaEncodingAttr : DistributedEncoding<"NvidiaMmaEncoding", "nvidia_mma_encoding", [MmaEncodingTrait]> {
+def NvidiaMmaEncodingAttr
+    : DistributedEncoding<"NvidiaMmaEncoding",
+                          "nvidia_mma_encoding", [MmaEncodingTrait]> {
   let mnemonic = "nvidia_mma";
 
   let description = [{
@@ -1337,17 +1334,11 @@ For example, the matrix L corresponding to blockTileSize=[32,16] is:
 
 }];
 
-  let parameters = (
-    ins
-    "unsigned":$versionMajor,
-    "unsigned":$versionMinor,
-    ArrayRefParameter<"unsigned">:$warpsPerCTA,
-    "CGAEncodingAttr":$CGALayout,
-    ArrayRefParameter<"unsigned">:$instrShape
-  );
+  let parameters = (ins "unsigned":$versionMajor, "unsigned":$versionMinor,
+      ArrayRefParameter<"unsigned">:$warpsPerCTA, "CGAEncodingAttr":$CGALayout,
+      ArrayRefParameter<"unsigned">:$instrShape);
 
-
-  let extraClassDeclaration = extraDistributedDeclaration # [{
+  let extraClassDeclaration = extraDistributedDeclaration#[{
     bool isVolta() const;
     bool isTuring() const;
     bool isAmpere() const;
@@ -1393,13 +1384,9 @@ def SliceEncodingAttr : DistributedEncoding<"SliceEncoding", "slice_encoding"> {
     during some optimization passes.
   }];
 
-  let parameters = (
-    ins
-    "unsigned":$dim,
-    "DistributedEncodingTrait":$parent
-  );
+  let parameters = (ins "unsigned":$dim, "DistributedEncodingTrait":$parent);
 
-  let extraClassDeclaration = extraDistributedDeclaration # [{
+  let extraClassDeclaration = extraDistributedDeclaration#[{
     template<class T>
     SmallVector<T> paddedShape(ArrayRef<T> shape) const;
 
@@ -1412,7 +1399,8 @@ def SliceEncodingAttr : DistributedEncoding<"SliceEncoding", "slice_encoding"> {
   let genVerifyDecl = 1;
 }
 
-def DotOperandEncodingAttr : DistributedEncoding<"DotOperandEncoding", "dot_operand_encoding"> {
+def DotOperandEncodingAttr
+    : DistributedEncoding<"DotOperandEncoding", "dot_operand_encoding"> {
   let mnemonic = "dot_op";
 
   let description = [{
@@ -1451,17 +1439,11 @@ quadM (m-index of the "quad" in the core matrix)
 vecIdx (index of the element in the quad; this is always along the k-dim)
   }];
 
-  let parameters = (
-    ins
-    "unsigned":$opIdx,
-    "Attribute":$parent,
-    DefaultValuedParameter<"unsigned", "0">:$kWidth
-  );
+  let parameters = (ins "unsigned":$opIdx, "Attribute":$parent,
+      DefaultValuedParameter<"unsigned", "0">:$kWidth);
 
-  let builders = [
-    AttrBuilder<(ins "unsigned":$opIdx,
-                     "Attribute":$parent,
-                     "Type":$eltTy), [{
+  let builders = [AttrBuilder<
+      (ins "unsigned":$opIdx, "Attribute":$parent, "Type":$eltTy), [{
       NvidiaMmaEncodingAttr parentAttr = mlir::dyn_cast<NvidiaMmaEncodingAttr>(parent);
       if (!parentAttr || (!parentAttr.isAmpere() && !parentAttr.isHopper()))
         return $_get(context, opIdx, parent, 0);
@@ -1469,8 +1451,7 @@ vecIdx (index of the element in the quad; this is always along the k-dim)
       unsigned bitwidth = eltTy.getIntOrFloatBitWidth();
       unsigned kWidth = std::max(32 / bitwidth, 1u);
       return $_get(context, opIdx, parent, kWidth);
-    }]>
-  ];
+    }]>];
 
   let assemblyFormat = "`<` `{` struct(params) `}` `>`";
   let genVerifyDecl = 1;

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrInterfaces.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrInterfaces.td
@@ -12,17 +12,15 @@ def LayoutEncodingTrait : AttrInterface<"LayoutEncodingTrait"> {
   let description = [{
     Common trait for all TTGIR layouts.
   }];
-  let methods = [
-    InterfaceMethod<"Get the CGA layout backing this encoding.",
-                    "CGAEncodingAttr", "getCGALayout">,
-    InterfaceMethod<"Get the rank of the layout.", "unsigned", "getRank",
-                    (ins), [{}], [{
+  let methods = [InterfaceMethod<"Get the CGA layout backing this encoding.",
+                                 "CGAEncodingAttr", "getCGALayout">,
+                 InterfaceMethod<"Get the rank of the layout.", "unsigned",
+                                 "getRank", (ins), [{}], [{
       return $_attr.getCGALayout().getRank();
-    }]>
-  ];
+    }]>];
 }
-def DeclareLayoutEncodingMethods : DeclareAttrInterfaceMethods<
-  LayoutEncodingTrait, ["getCGALayout"]>;
+def DeclareLayoutEncodingMethods
+    : DeclareAttrInterfaceMethods<LayoutEncodingTrait, ["getCGALayout"]>;
 
 def SharedEncodingTrait : AttrInterface<"SharedEncodingTrait"> {
   let cppNamespace = "::mlir::triton::gpu";
@@ -30,27 +28,28 @@ def SharedEncodingTrait : AttrInterface<"SharedEncodingTrait"> {
   let description = [{
     Common trait describing shared memory.
   }];
-  let methods = [
-    InterfaceMethod<"Return the default alignment for the layout.",
-                    "int32_t", "getAlignment", (ins), [{}], [{ return 16; }]>,
+  let methods = [InterfaceMethod<"Return the default alignment for the layout.",
+                                 "int32_t", "getAlignment", (ins), [{}],
+                                 [{ return 16; }]>,
   ];
 }
-def DeclareSharedEncodingMethods : DeclareAttrInterfaceMethods<
-  SharedEncodingTrait, ["getAlignment"]>;
+def DeclareSharedEncodingMethods
+    : DeclareAttrInterfaceMethods<SharedEncodingTrait, ["getAlignment"]>;
 
-// Marker interface for encodings that the user pinned explicitly and that layout
-// passes must treat as fixed (e.g. an anchor in remove-layout-conversions). It
-// carries no methods; a layout attribute (such as TLX's UserLayoutAttr) advertises
-// itself as user-pinned by implementing this interface, so core TritonGPU passes
-// can recognize it without depending on the dialect that defines the wrapper.
+// Marker interface for encodings that the user pinned explicitly and that
+// layout passes must treat as fixed (e.g. an anchor in
+// remove-layout-conversions). It carries no methods; a layout attribute (such
+// as TLX's UserLayoutAttr) advertises itself as user-pinned by implementing
+// this interface, so core TritonGPU passes can recognize it without depending
+// on the dialect that defines the wrapper.
 def PinnedEncodingTrait : AttrInterface<"PinnedEncodingTrait"> {
   let cppNamespace = "::mlir::triton::gpu";
   let description = [{
     Marks an encoding as user-pinned: layout optimization must not rewrite it.
   }];
-  let methods = [
-    InterfaceMethod<"Return the concrete layout this wrapper pins.",
-                    "::mlir::Attribute", "getPinnedLayout">,
+  let methods = [InterfaceMethod<
+                     "Return the concrete layout this wrapper pins.",
+                     "::mlir::Attribute", "getPinnedLayout">,
   ];
 }
 
@@ -77,38 +76,180 @@ If the layout does not completely cover the tensor, we tile it until we cover th
 We call each individual tile "rep".
   }];
 
-  let methods = [
-    InterfaceMethod<"Get the order of reps (tiles of this layout that tile the whole tensor). The fastest-changing axis first",
-                    "SmallVector<unsigned>",
-                    "getRepOrder">,
-    InterfaceMethod<"Return total element size per thread.",
-                    "unsigned",
-                    "getTotalElemsPerThread",
-                     (ins "ArrayRef<int64_t>":$shape),
-                     /*defaultImplementation=*/[{
+  let methods =
+      [InterfaceMethod<"Get the order of reps (tiles of this layout that tile "
+                       "the whole tensor). The fastest-changing axis first",
+                       "SmallVector<unsigned>", "getRepOrder">,
+       InterfaceMethod<"Return total element size per thread.", "unsigned",
+                       "getTotalElemsPerThread",
+                       (ins "ArrayRef<int64_t>":$shape),
+                       /*defaultImplementation=*/[{
                          return toLinearEncoding($_self, shape).getTotalElemsPerThread(shape);
                      }]>,
-    InterfaceMethod<"Return element size per thread in each dimension.",
-                    "SmallVector<unsigned>",
-                    "getElemsPerThread",
-                     (ins "ArrayRef<int64_t>":$shape),
-                     /*defaultImplementation=*/[{
+       InterfaceMethod<"Return element size per thread in each dimension.",
+                       "SmallVector<unsigned>", "getElemsPerThread",
+                       (ins "ArrayRef<int64_t>":$shape),
+                       /*defaultImplementation=*/[{
                          return toLinearEncoding($_self, shape).getElemsPerThread(shape);
                      }]>,
-    InterfaceMethod<"Convert to LinearLayout.",
-                    "LinearLayout",
-                    "toLinearLayout",
-                    (ins "ArrayRef<int64_t>":$shape)>,
+       InterfaceMethod<"Convert to LinearLayout.", "LinearLayout",
+                       "toLinearLayout", (ins "ArrayRef<int64_t>":$shape)>,
   ];
 }
 
+def LinearEncodingTrait : AttrInterface<"LinearEncodingTrait"> {
+  let cppNamespace = "::mlir::triton::gpu";
+  let description = [{
+    Common trait for distributed encodings backed by a LinearLayout
+    (LinearEncodingAttr and GenericLinearEncodingAttr).
+  }];
+  let methods =
+      [InterfaceMethod<"Get the underlying linear layout.",
+                       "const LinearLayout &", "getLinearLayout">,
+
+       InterfaceMethod<[{
+      Generalizes getThreadsPerWarp, getWarpsPerCTA, getCTAsPerCGA to linear layouts.
+      Returns the bases of the dimensions `dimName` of the layout.
+      If skipBroadcast is false, we count a base zero.
+    }],
+                       "SmallVector<unsigned>", "basesPerDim",
+                       (ins "StringAttr":$dimName, "bool":$skipBroadcast), [{}],
+                       [{
+      return LinearEncodingTrait::basesPerDim(
+          $_attr.getLinearLayout(), dimName, skipBroadcast);
+    }]>,
+       InterfaceMethod<[{
+      Generalizes get{Warp,Thread,CTA}Order to linear layouts.
+      Returns the order of the dimensions `dimName` of the layout.
+      If more than one dimension is of size one, it uses defaultOrder to determine the order
+      of the dimensions of size one.
+    }],
+                       "SmallVector<unsigned>", "orderPerDim",
+                       (ins "StringAttr":$dimName,
+                           "ArrayRef<unsigned>":$defaultOrder),
+                       [{}], [{
+      return LinearEncodingTrait::orderPerDim(
+          $_attr.getLinearLayout(), dimName, defaultOrder);
+    }]>,
+       InterfaceMethod<"Get the layout order.", "SmallVector<unsigned>",
+                       "getOrder", (ins), [{}], [{
+      const auto &ll = $_attr.getLinearLayout();
+      auto rank = ll.getNumOutDims();
+      SmallVector<unsigned> order(rank);
+      // Choose [rank-1, rank-2, ... 0] as the default order in case
+      // there are dims that do not move in the register.
+      // This order is as good as any.
+      std::iota(order.rbegin(), order.rend(), 0);
+      return $_attr.orderPerDim(
+          StringAttr::get($_attr.getContext(), "register"), order);
+    }]>,
+       InterfaceMethod<"Get contiguity for a given input dimension.",
+                       "SmallVector<unsigned>", "getContig",
+                       (ins "const char *":$inDim,
+                           "SmallVector<unsigned>":$lowerContig),
+                       [{}], [{
+      return LinearEncodingTrait::getContig(
+          $_attr.getLinearLayout(), inDim, lowerContig, $_attr.getOrder());
+    }]>,
+       // [FIXME LL] Supports legacy behaviour. We should remove these
+       // functions.
+       InterfaceMethod<"Get size per thread.", "SmallVector<unsigned>",
+                       "getSizePerThread", (ins), [{}], [{
+      auto cgaSplitNum = $_attr.getCGALayout().getCTASplitNum();
+      return LinearEncodingTrait::getSizePerThread(
+          $_attr.getLinearLayout(), cgaSplitNum);
+    }]>,
+       InterfaceMethod<"Get the CGA layout.", "CGAEncodingAttr", "getCGALayout",
+                       (ins), [{}], [{
+      return LinearEncodingTrait::getCGALayout($_attr.getLinearLayout());
+    }]>,
+       InterfaceMethod<"Convert to LinearLayout.", "LinearLayout",
+                       "toLinearLayout", (ins "ArrayRef<int64_t>":$shape), [{}],
+                       [{
+      auto repOrder = $_attr.getRepOrder();
+      return LinearEncodingTrait::toLinearLayout(
+          $_attr.getLinearLayout(), repOrder, shape);
+    }]>,
+
+       InterfaceMethod<"Get threads per warp in each dimension.",
+                       "SmallVector<unsigned>", "getThreadsPerWarp", (ins),
+                       [{}], [{
+      return $_attr.basesPerDim(
+          StringAttr::get($_attr.getContext(), "lane"), /*skipBroadcast=*/true);
+    }]>,
+       InterfaceMethod<"Get the thread order.", "SmallVector<unsigned>",
+                       "getThreadOrder", (ins), [{}], [{
+      return $_attr.orderPerDim(
+          StringAttr::get($_attr.getContext(), "lane"), $_attr.getOrder());
+    }]>,
+       InterfaceMethod<"Get contiguity per thread.", "SmallVector<unsigned>",
+                       "getContigPerThread", (ins), [{}], [{
+      SmallVector<unsigned> c($_attr.getOrder().size(), 1);
+      return $_attr.getContig("register", c);
+    }]>,
+       InterfaceMethod<"Get contiguity per warp.", "SmallVector<unsigned>",
+                       "getContigPerWarp", (ins), [{}], [{
+      return $_attr.getContig("lane", $_attr.getContigPerThread());
+    }]>,
+       InterfaceMethod<
+           "Get the rep order (also satisfies DistributedEncodingTrait).",
+           "SmallVector<unsigned>", "getRepOrder", (ins), [{}], [{
+      // This is not correct, but:
+      // - It happens to agree in most places with the legacy layout
+      // - getRepOrder does not make sense for LinearEncodingAttr as it already has
+      //   the same shape as the tensor that uses it
+      return $_attr.getOrder();
+    }]>,
+       InterfaceMethod<"Get elements per thread (overrides "
+                       "DistributedEncodingTrait default).",
+                       "SmallVector<unsigned>", "getElemsPerThread",
+                       (ins "ArrayRef<int64_t>":$shape), [{}], [{
+      return LinearEncodingTrait::getElemsPerThread(
+          $_attr.getLinearLayout(), $_attr.getOrder(), shape);
+    }]>,
+       InterfaceMethod<"Get total elements per thread (overrides "
+                       "DistributedEncodingTrait default).",
+                       "unsigned", "getTotalElemsPerThread",
+                       (ins "ArrayRef<int64_t>":$shape), [{}], [{
+      return LinearEncodingTrait::getTotalElemsPerThread(
+          $_attr.getLinearLayout(), $_attr.getOrder(), shape);
+    }]>,
+  ];
+  let extraClassDeclaration = [{
+    static SmallVector<unsigned> basesPerDim(const LinearLayout &ll,
+                                             StringAttr dimName,
+                                             bool skipBroadcast);
+    static SmallVector<unsigned> orderPerDim(const LinearLayout &ll,
+                                             StringAttr dimName,
+                                             ArrayRef<unsigned> defaultOrder);
+    static SmallVector<unsigned> getContig(const LinearLayout &ll,
+                                           const char *inDim,
+                                           SmallVector<unsigned> lowerContig,
+                                           ArrayRef<unsigned> order);
+    static SmallVector<unsigned> getSizePerThread(
+        const LinearLayout &ll, ArrayRef<unsigned> cgaSplitNum);
+    static CGAEncodingAttr getCGALayout(const LinearLayout &ll);
+    static LinearLayout toLinearLayout(const LinearLayout &ll,
+                                       ArrayRef<unsigned> repOrder,
+                                       ArrayRef<int64_t> shape);
+    static SmallVector<unsigned> getElemsPerThread(
+        const LinearLayout &ll, ArrayRef<unsigned> repOrder,
+        ArrayRef<int64_t> shape);
+    static unsigned getTotalElemsPerThread(
+        const LinearLayout &ll, ArrayRef<unsigned> repOrder,
+        ArrayRef<int64_t> shape);
+  }];
+}
+def DeclareLinearEncodingMethods
+    : DeclareAttrInterfaceMethods<LinearEncodingTrait, ["getLinearLayout"]>;
+
 def MmaEncodingTrait : AttrInterface<"MmaEncodingTrait"> {
   let cppNamespace = "::mlir::triton::gpu";
-  let methods = [
-    InterfaceMethod<"Get the order of reps (tiles of this layout that tile the whole tensor). The fastest-changing axis first",
-                    "SmallVector<unsigned>",
-                    "getRepOrderForOperand",
-                    (ins "int":$opIdx)>,
+  let methods = [InterfaceMethod<
+                     "Get the order of reps (tiles of this layout that tile "
+                     "the whole tensor). The fastest-changing axis first",
+                     "SmallVector<unsigned>", "getRepOrderForOperand",
+                     (ins "int":$opIdx)>,
   ];
 }
 

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -169,13 +169,16 @@ public:
                                    int thread, Value pred, MemType memType,
                                    Operation *insertPoint, Value recipientCTAs);
   // trackBarrierWriteForBuffer: mark a specific buffer as tracked by a
-  // barrier in the write-tracking table.
+  // barrier in the write-tracking table. When diagonalEffectRecipientCTAs is
+  // false, every signaled barrier row publishes the full effectRecipientCTAs
+  // mask. When it is true, barrier row i publishes only bit i of that mask.
   void createTrackBarrierWriteForBufferCall(ImplicitLocOpBuilder &b, Value mbar,
                                             Value buf, uint32_t length,
                                             Value pred, MemType memType,
                                             Operation *insertPoint,
                                             Value barrierRecipientCTAs,
-                                            Value effectRecipientCTAs);
+                                            Value effectRecipientCTAs,
+                                            bool diagonalEffectRecipientCTAs);
   // clearBarrierWriteTracking: clear all write tracking associated with the
   // given barrier row.
   void createClearBarrierWriteTrackingCall(ImplicitLocOpBuilder &b, Value mbar,

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrument.md
@@ -9,10 +9,10 @@ Auxiliary state is kept in distributed tensors and global scratch memory, with t
 ### Thread model
 
 - Base threads: 16 warp-specialization (WS) threads (allowing for up to 16 partitions).
-- Peer classes: +16 Tensor Core (TC) threads and +16 TMA threads to model lack of ordering with base threads.
-- Total logical threads: 48. Bitmasks are sized to the next power of two: 64.
+- Peer classes: +16 TMA threads, +16 Tensor Core (TC) threads, and +16 CLC threads to model lack of ordering with base threads.
+- Total logical threads: 64.
 
-Indexing uses a logical thread id in [0, 48), with column vectors sized to 64 for layout convenience.
+Indexing uses a logical thread id in [0, 64), with column vectors sized to 64 for layout convenience.
 
 ## Auxiliary data structures
 
@@ -21,7 +21,7 @@ All types are generated on-demand (per partition) based on:
 - B: number of tracked buffers (power-of-two padded)
 - K: number of mbarriers (power-of-two padded)
 - T_bits: 64 (bitmask width)
-- T_commits: 16 (base threads; commit counters do not apply to TC/TMA helpers)
+- T_commits: 16 (base threads; commit counters do not apply to TC/TMA/CLC helpers)
 
 “tensor” means a distributed Triton tensor; “scratch” means a pointer into global scratch memory. Shapes below are logical; actual encodings are partition-local blocked layouts.
 
@@ -53,7 +53,7 @@ ConSan separates “tracking” from “visibility transfer”:
   - experimental_set_read_visibility / experimental_set_write_visibility updates the appropriate visibility table for the current thread and buffer.
   - experimental_track_visible_reads / experimental_track_visible_writes snapshots current per-buffer visibility into readTracking/writeTracking for the given barrier.
 - At arrive/commit sites (e.g., tc commit, arrive on mbarrier): ConSan emits the track ops for both reads and writes.
-- At waits: experimental_transfer_visible_reads / experimental_transfer_visible_writes propagates tracked visibility from the barrier back into the waiting thread’s visibility, and this transfer is repeated to peer threads (base, TMA, TC) to keep the three classes consistent.
+- At waits: experimental_transfer_visible_reads / experimental_transfer_visible_writes propagates tracked visibility from the barrier back into the waiting thread’s visibility, and this transfer is repeated to peer threads (base, TMA, TC, CLC) to keep the classes consistent.
 
 ### Barrier phase/count tracking
 

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -6,6 +6,7 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h"
+#include "llvm/Support/MathExtras.h"
 
 #include <array>
 
@@ -22,8 +23,11 @@ constexpr int numMemTypes = getMaxEnumValForMemType() + 1;
 constexpr int NUM_THREADS = 16;
 constexpr int TMA_THREAD_OFFSET = NUM_THREADS;
 constexpr int TC_THREAD_OFFSET = TMA_THREAD_OFFSET + NUM_THREADS;
-constexpr int TOTAL_NUM_THREADS = TC_THREAD_OFFSET + NUM_THREADS;
-constexpr int THREADS_BITMASK_SIZE = llvm::NextPowerOf2(TOTAL_NUM_THREADS);
+constexpr int CLC_THREAD_OFFSET = TC_THREAD_OFFSET + NUM_THREADS;
+constexpr int TOTAL_NUM_THREADS = CLC_THREAD_OFFSET + NUM_THREADS;
+static_assert(TOTAL_NUM_THREADS <= 64,
+              "ConSan thread bitsets are stored in i64 masks");
+const int THREADS_BITMASK_SIZE = llvm::PowerOf2Ceil(TOTAL_NUM_THREADS);
 
 namespace CommitKind {
 enum Kind { None = -1, AsyncCp = 0, Wgmma, TmaStore, NumCommitKinds };

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -12,8 +12,19 @@
 namespace mlir::triton::instrument {
 
 struct MemEffectsOpInfo {
-  // Frontier: snapshot thread-visible frontier into barrier tracking.
-  // EffectWrites: track only buffers written by op effects.
+  // Controls which memory effects become visible to a CTA after it waits on
+  // this barrier.
+  //
+  // Frontier snapshots the issuing thread's current visibility frontier into
+  // the barrier. A later wait publishes whatever shared/tensor memory writes
+  // and reads were visible to that logical thread before the arrive/commit. Use
+  // this for ordering operations whose semantics are a release of prior work.
+  //
+  // EffectWrites does not snapshot the whole thread frontier. Instead, it
+  // attaches only the explicit write effects of this op to the barrier. A later
+  // wait publishes those op-local writes and nothing else. Use this for PTX ops
+  // that perform the write and also signal the barrier via
+  // `mbarrier::complete_tx`.
   enum class BarrierTrackingMode {
     Frontier,
     EffectWrites,
@@ -34,6 +45,18 @@ struct MemEffectsOpInfo {
     int count;
     BarrierTrackingMode trackingMode = BarrierTrackingMode::Frontier;
     int txCount = 0;
+    // For EffectWrites, effectRecipientCTAs identifies the CTA rows where the
+    // op wrote its explicit result. By default, for
+    // diagonalEffectRecipientCTAs=false, waiting on a barrier publishes the CTA
+    // rows in effectRecipientCTAs, which is the full mask. This is the
+    // behaviour of TMA multicast. If diagonalEffectRecipientCTAs is true,
+    // waiting on a barrier publishes only the CTA rows in effectRecipientCTAs,
+    // which is the diagonal mask. e.g. effectRecipientCTAs = 0b1101 If
+    // DiagonalEffectRecipientCTAs is false, waiting on the barrier publishes
+    // the following CTA rows: CTA0 0b1101 CTA1 0b1101 CTA2 0b1101 CTA3 0b1101
+    // If diagonalEffectRecipientCTAs is true, waiting on the barrier publishes
+    // the following CTA rows: CTA0 0b1000 CTA1 0b0100 CTA2 0b0000 CTA3 0b0001
+    bool diagonalEffectRecipientCTAs = false;
   };
   enum class TrackingKind {
     None,
@@ -82,6 +105,8 @@ public:
   virtual ~ConSanTargetHooks() = default;
 
   virtual bool isTMAOp(Operation *op) const = 0;
+
+  virtual bool isCLCOp(Operation *op) const { return false; }
 
   virtual std::optional<BarrierInitInfo>
   getBarrierInitInfo(Operation *op) const = 0;

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOpInterfaces.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOpInterfaces.td
@@ -42,6 +42,11 @@ def TMALoadLikeOpInterface : OpInterface<"TMALoadLikeOpInterface", [TMAOpInterfa
       /*retType=*/"::mlir::Value",
       /*methodName=*/"getPred",
       /*args=*/(ins)>,
+    InterfaceMethod<
+      /*desc=*/"Return true if this load uses multicast",
+      /*retType=*/"bool",
+      /*methodName=*/"getMulticast",
+      /*args=*/(ins)>,
   ];
 }
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -898,7 +898,8 @@ def TTNG_AsyncTMAGatherOp : TTNG_Op<"async_tma_gather", [
     I32:$y_offset,
     Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$barrier,
     Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$result,
-    I1:$pred
+    I1:$pred,
+    UnitAttr:$multicast
   );
 
   let assemblyFormat = [{

--- a/include/triton/Tools/LayoutUtils.h
+++ b/include/triton/Tools/LayoutUtils.h
@@ -123,7 +123,7 @@ ColumnAction actionRemoveBroadcastedRegs(const LinearLayout &layout);
 
 std::pair<int64_t, ColumnAction>
 actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
-                      uint64_t maskSpanOffsets);
+                      uint64_t maskSpanOffsets, int64_t regsPerInst);
 
 // For a layout A with A.hasInDim(kReg), repeat the values so that they have
 // the same broadcasting as layout

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -323,10 +323,7 @@ void BufferRegionAnalysis::calculateUsedBufferRegions(Operation *op) {
 bool BufferRegionAnalysis::isMemoryAccessOperation(Operation *op) {
   if (isa<ttg::LocalLoadOp, ttg::LocalStoreOp, ttng::TMEMLoadOp,
           ttng::TMEMStoreOp, ttng::TMEMCopyOp, ttg::AsyncCopyGlobalToLocalOp,
-          ttng::AsyncTMACopyGlobalToLocalOp, ttng::AsyncTMACopyLocalToGlobalOp,
-          ttng::AsyncTMAGatherOp, ttng::AsyncTMAScatterOp, ttng::InitBarrierOp,
-          ttng::BarrierExpectOp, ttng::InvalBarrierOp, ttng::WaitBarrierOp,
-          ttng::ArriveBarrierOp>(op)) {
+          ttng::TMAOpInterface, ttng::CLCLoadResultOp>(op)) {
     return true;
   }
   if (isa<ttg::MBarrierOpInterface>(op)) {

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -54,6 +54,13 @@ struct ConvertLayoutOpConversion
     auto kRegister = str_attr("register");
 
     auto dims = conversion.getInDimNames();
+    auto srcEnc = cast<RankedTensorType>(srcTy).getEncoding();
+    auto dstEnc = cast<RankedTensorType>(dstTy).getEncoding();
+    if ((isGenericLinearEncoding(srcEnc) || isGenericLinearEncoding(dstEnc)) &&
+        llvm::range_size(dims) > 1)
+      return op.emitError("ConvertLayoutOp  supports GenericLinearEncoding "
+                          " only when the conversion is transfer between "
+                          "values in the same thread.");
     bool alwaysUseWarpShuffle = cvtAlwaysUseWarpShuffle(op);
     assert(to_vector(conversion.getInDimNames()) ==
            to_vector(conversion.getOutDimNames()));

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -23,9 +23,6 @@ int getNumElementsPerThreads(Type type,
   return numElemsPerThread;
 }
 
-} // namespace
-
-namespace {
 struct AddPtrOpConversion : public ConvertOpToLLVMPattern<AddPtrOp> {
   using ConvertOpToLLVMPattern<AddPtrOp>::ConvertOpToLLVMPattern;
 

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -585,7 +585,7 @@ Value getLaneId(OpBuilder &rewriter, Location loc) {
 }
 
 // Helper function: applies linear layout vectorized over register indices
-SmallVector<SmallVector<std::pair<StringAttr, Value>>>
+static SmallVector<SmallVector<std::pair<StringAttr, Value>>>
 applyLinearLayoutVec(Location loc, RewriterBase &rewriter,
                      const LinearLayout &layout,
                      ArrayRef<std::pair<StringAttr, Value>> indices,
@@ -1828,6 +1828,8 @@ SmallVector<Value> getSharedMemoryBases(Location loc, RewriterBase &rewriter,
   return bases;
 }
 
+namespace {
+
 // Extract the bits of `a` that are set in `mask`
 Value pext_i32(RewriterBase &rewriter, Location loc, Value a, uint32_t mask) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -1895,6 +1897,8 @@ Value pdep_i32(RewriterBase &rewriter, Location loc, Value a, uint32_t mask) {
 
   return result;
 }
+
+} // namespace
 
 std::tuple<SmallVector<Value>, Value>
 delinearize(RewriterBase &rewriter, Location loc,

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1017,8 +1017,8 @@ lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
     addrBases.push_back({kBlock, reps.getBases().lookup(kBlock)});
   }
   LinearLayout addrLayout(addrBases, reps.getOutDims(), false);
-  auto [nAdditive, permStrides] =
-      actionAdditiveStrides(reps, addrLayout, maskSpanAffineOffset);
+  auto [nAdditive, permStrides] = actionAdditiveStrides(
+      reps, addrLayout, maskSpanAffineOffset, elemsPerVec);
   reps = permStrides.apply(reps);
 
   if (isPartitioned) {

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1920,7 +1920,7 @@ delinearize(RewriterBase &rewriter, Location loc,
   auto linearLayout = triton::gpu::LinearEncodingAttr::get(
       rewriter.getContext(), std::move(ll));
   auto orderDim = linearLayout.orderPerDim(dimName, linearLayout.getOrder());
-  auto shapeDim = linearLayout.basesPerDim(dimName);
+  auto shapeDim = linearLayout.basesPerDim(dimName, /*skipBroadcast=*/true);
   auto multiDim = delinearize(rewriter, loc, linear, shapeDim, orderDim);
 
   return std::make_tuple(std::move(multiDim), isRepresentative);
@@ -2018,7 +2018,7 @@ Value linearize(RewriterBase &rewriter, Location loc, ArrayRef<Value> multiDim,
 Value linearize(RewriterBase &rewriter, Location loc, ArrayRef<Value> multiDim,
                 triton::gpu::LinearEncodingAttr encoding, StringAttr dimName) {
   auto orderDim = encoding.orderPerDim(dimName, encoding.getOrder());
-  auto shapeDim = encoding.basesPerDim(dimName);
+  auto shapeDim = encoding.basesPerDim(dimName, /*skipBroadcast=*/true);
   auto linear = linearize(rewriter, loc, multiDim, shapeDim, orderDim);
   auto ll = encoding.getLinearLayout();
   int32_t freeVarMask = ll.getFreeVariableMasks().lookup(dimName);

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -535,6 +535,8 @@ ReduceOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
 }
 
 // Helpers for Reductions and Scans
+namespace {
+
 template <class Op> LogicalResult verifyReduceScan(Op &op) {
   if (op.getOperands().empty()) {
     return op.emitOpError() << "must have at least 1 operand";
@@ -564,8 +566,7 @@ template <class Op> LogicalResult verifyReduceScan(Op &op) {
   return success();
 }
 
-template <class ReturnOp, class Op>
-static LogicalResult verifyRegionsImpl(Op &op) {
+template <class ReturnOp, class Op> LogicalResult verifyRegionsImpl(Op &op) {
   auto argElementTypes = op.getElementTypes();
   const auto &operands = op.getOperands();
   const auto numArgs = 2 * operands.size();
@@ -610,7 +611,7 @@ static LogicalResult verifyRegionsImpl(Op &op) {
   return success();
 }
 
-static llvm::SmallVector<RankedTensorType>
+llvm::SmallVector<RankedTensorType>
 getInputTypesImpl(const Operation::operand_range &operands) {
   llvm::SmallVector<RankedTensorType> srcTys;
   srcTys.reserve(operands.size());
@@ -621,7 +622,7 @@ getInputTypesImpl(const Operation::operand_range &operands) {
 }
 
 template <typename ValueRange>
-static llvm::SmallVector<Type> getElementTypesImpl(const ValueRange &operands) {
+llvm::SmallVector<Type> getElementTypesImpl(const ValueRange &operands) {
   llvm::SmallVector<Type> srcElemTys;
   srcElemTys.reserve(operands.size());
   for (const auto &op : operands) {
@@ -629,6 +630,8 @@ static llvm::SmallVector<Type> getElementTypesImpl(const ValueRange &operands) {
   }
   return srcElemTys;
 }
+
+} // namespace
 
 LogicalResult ReduceOp::verify() { return verifyReduceScan(*this); }
 
@@ -710,7 +713,8 @@ LogicalResult MapElementwiseOp::verify() {
 }
 
 template <typename T>
-SmallVector<T> repeatInterleave(const SmallVectorImpl<T> &vs, int nRepeat) {
+static SmallVector<T> repeatInterleave(const SmallVectorImpl<T> &vs,
+                                       int nRepeat) {
   SmallVector<T> result;
   result.reserve(vs.size() * nRepeat);
   for (auto v : vs)

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -1802,9 +1802,9 @@ LogicalResult GatherOp::inferReturnTypes(
 }
 
 // -- DescriptorGatherOp
-static LogicalResult verifyGatherScatterResultType(Operation *op,
-                                                   ShapedType resultType,
-                                                   ShapedType indicesType) {
+LogicalResult verifyGatherScatterResultType(Operation *op,
+                                            ShapedType resultType,
+                                            ShapedType indicesType) {
   if (indicesType.getRank() != 1)
     return op->emitOpError("x offsets must be a 1D tensor, but got ")
            << indicesType;

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3855,7 +3855,8 @@ struct TritonGPUVerifyTensorLayoutInterface
       return true;
     return isa<triton::MakeRangeOp, triton::SplatOp, triton::BroadcastOp,
                triton::LoadOp, triton::StoreOp, triton::JoinOp, triton::SplitOp,
-               triton::gpu::ConvertLayoutOp, triton::gpu::Fp4ToFpOp>(op);
+               triton::gpu::ConvertLayoutOp, triton::gpu::Fp4ToFpOp,
+               triton::gpu::LocalLoadOp, triton::gpu::LocalStoreOp>(op);
   }
 
   LogicalResult verifyTensorLayout(

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -89,8 +89,45 @@ LinearEncodingAttr toLinearEncoding(RankedTensorType type) {
       type.getShape(), type.getEncoding());
 }
 
+bool isGenericLinearEncoding(Attribute attr) {
+  if (isa<GenericLinearEncodingAttr>(attr))
+    return true;
+
+  // Unwrap wrapper encodings to find the root layout.
+  if (auto dotOp = dyn_cast<DotOperandEncodingAttr>(attr))
+    return isGenericLinearEncoding(dotOp.getParent());
+  if (auto slice = dyn_cast<SliceEncodingAttr>(attr))
+    return isGenericLinearEncoding(slice.getParent());
+  if (auto wmma = dyn_cast<AMDWmmaEncodingAttr>(attr))
+    return !isPermutationMatrixLayout(wmma.getCtaLayout());
+
+  return false;
+}
+
+Attribute inferEncodingFromLinearLayout(MLIRContext *ctx, LinearLayout ll,
+                                        Attribute srcEnc) {
+  if (isGenericLinearEncoding(srcEnc)) {
+    assert(!isPermutationMatrixLayout(ll) &&
+           "Expected non-permutation layout from this source encoding");
+    return GenericLinearEncodingAttr::get(ctx, std::move(ll));
+  }
+  return LinearEncodingAttr::get(ctx, std::move(ll));
+}
+
+GenericLinearEncodingAttr
+toGenericLinearEncoding(DistributedEncodingTrait layout,
+                        ArrayRef<int64_t> shape) {
+  auto ll = toLinearLayout(shape, layout);
+  return GenericLinearEncodingAttr::get(layout.getContext(), std::move(ll));
+}
+
+GenericLinearEncodingAttr toGenericLinearEncoding(RankedTensorType type) {
+  return toGenericLinearEncoding(
+      cast<DistributedEncodingTrait>(type.getEncoding()), type.getShape());
+}
+
 unsigned getTotalElemsPerThread(Attribute layout, ArrayRef<int64_t> shape) {
-  return toLinearEncoding(cast<DistributedEncodingTrait>(layout), shape)
+  return toGenericLinearEncoding(cast<DistributedEncodingTrait>(layout), shape)
       .getTotalElemsPerThread(shape);
 }
 
@@ -103,7 +140,7 @@ unsigned getUniqueElemsPerThread(Attribute layout, ArrayRef<int64_t> shape) {
 
 SmallVector<unsigned> getElemsPerThread(Attribute layout,
                                         ArrayRef<int64_t> shape) {
-  return toLinearEncoding(cast<DistributedEncodingTrait>(layout), shape)
+  return toGenericLinearEncoding(cast<DistributedEncodingTrait>(layout), shape)
       .getElemsPerThread(shape);
 }
 
@@ -155,7 +192,7 @@ inferFp4ToFpResultType(RankedTensorType srcType, Type elemType, int32_t axis,
 
 SmallVector<unsigned> getThreadsPerWarp(Attribute layout,
                                         ArrayRef<int64_t> shape) {
-  return toLinearEncoding(cast<DistributedEncodingTrait>(layout), shape)
+  return toGenericLinearEncoding(cast<DistributedEncodingTrait>(layout), shape)
       .getThreadsPerWarp();
 }
 
@@ -166,7 +203,7 @@ SmallVector<unsigned> getWarpsPerCTA(Attribute layout,
 }
 
 SmallVector<unsigned> getContigPerThread(RankedTensorType type) {
-  return toLinearEncoding(type).getContigPerThread();
+  return toGenericLinearEncoding(type).getContigPerThread();
 }
 
 bool isExpensiveView(ArrayRef<int64_t> srcShape, Attribute srcEncoding,
@@ -296,12 +333,12 @@ SmallVector<unsigned> getOrder(SharedEncodingTrait layout,
 
 SmallVector<unsigned> getOrder(DistributedEncodingTrait layout,
                                ArrayRef<int64_t> shape) {
-  return toLinearEncoding(layout, shape).getOrder();
+  return toGenericLinearEncoding(layout, shape).getOrder();
 }
 
 SmallVector<unsigned> getOrderForMemory(DistributedEncodingTrait layout,
                                         ArrayRef<int64_t> shape) {
-  auto linear = toLinearEncoding(layout, shape);
+  auto linear = toGenericLinearEncoding(layout, shape);
   auto order = linear.getOrder();
   auto threadOrder = linear.getThreadOrder();
   if (order == threadOrder) {
@@ -321,7 +358,7 @@ SmallVector<unsigned> getOrderForMemory(DistributedEncodingTrait layout,
 
 SmallVector<unsigned> getThreadOrder(DistributedEncodingTrait layout,
                                      ArrayRef<int64_t> shape) {
-  return toLinearEncoding(layout, shape).getThreadOrder();
+  return toGenericLinearEncoding(layout, shape).getThreadOrder();
 }
 
 SmallVector<unsigned> getWarpOrder(DistributedEncodingTrait layout,
@@ -362,8 +399,8 @@ SmallVector<unsigned> getCTAsPerCGA(Attribute layout) {
   // A generic linear encoding may not have a CGA layout
   // as having a CGA layout implies being of the form cta_layout * cga_layout
   auto kBlock = StringAttr::get(layout.getContext(), "block");
-  if (auto linearLayout = dyn_cast<LinearEncodingAttr>(layout)) {
-    return linearLayout.basesPerDim(kBlock, /*skipBroadcast=*/false);
+  if (auto linearEnc = dyn_cast<LinearEncodingTrait>(layout)) {
+    return linearEnc.basesPerDim(kBlock, /*skipBroadcast=*/false);
   } else if (auto sharedLinearLayout =
                  dyn_cast<SharedLinearEncodingAttr>(layout)) {
     return sharedLinearLayout.basesPerDim(kBlock, /*skipBroadcast=*/false);
@@ -383,14 +420,14 @@ SmallVector<unsigned> getCTASplitNum(Attribute layout) {
   // A generic linear encoding may not have a CGA layout
   // as having a CGA layout implies being of the form cta_layout * cga_layout
   auto kBlock = StringAttr::get(layout.getContext(), "block");
-  if (auto linearLayout = dyn_cast<LinearEncodingAttr>(layout)) {
-    return linearLayout.basesPerDim(kBlock);
+  if (auto linearEnc = dyn_cast<LinearEncodingTrait>(layout)) {
+    return linearEnc.basesPerDim(kBlock, /*skipBroadcast=*/true);
   } else if (auto sharedLinearLayout =
                  dyn_cast<SharedLinearEncodingAttr>(layout)) {
     return sharedLinearLayout.basesPerDim(kBlock);
   } else if (auto sliceLayout = dyn_cast<SliceEncodingAttr>(layout)) {
     if (auto slicedLinear = getSlicedLinearEncoding(sliceLayout))
-      return slicedLinear.basesPerDim(kBlock);
+      return slicedLinear.basesPerDim(kBlock, /*skipBroadcast=*/true);
     return cast<LayoutEncodingTrait>(sliceLayout)
         .getCGALayout()
         .getCTASplitNum();
@@ -402,8 +439,8 @@ SmallVector<unsigned> getCTASplitNum(Attribute layout) {
 
 SmallVector<unsigned> getCTAOrder(Attribute layout) {
   auto kBlock = StringAttr::get(layout.getContext(), "block");
-  if (auto linearLayout = dyn_cast<LinearEncodingAttr>(layout)) {
-    return linearLayout.orderPerDim(kBlock, linearLayout.getOrder());
+  if (auto linearEnc = dyn_cast<LinearEncodingTrait>(layout)) {
+    return linearEnc.orderPerDim(kBlock, linearEnc.getOrder());
   } else if (auto sharedLinearLayout =
                  dyn_cast<SharedLinearEncodingAttr>(layout)) {
     return sharedLinearLayout.orderPerDim(kBlock,
@@ -543,27 +580,6 @@ verifyLayoutOrder(function_ref<InFlightDiagnostic()> emitError,
   return success();
 }
 
-static LogicalResult
-verifyDistributedLinearLayout(function_ref<InFlightDiagnostic()> emitError,
-                              const LinearLayout &linearLayout,
-                              StringRef subject) {
-  LinearLayout flattened = linearLayout.flattenIns().flattenOuts();
-  auto inDim = *flattened.getInDimNames().begin();
-  LinearLayout withoutBroadcast = flattened.removeZeroBasesAlongDim(inDim);
-  if (!llvm::all_of(withoutBroadcast.getBases().lookup(inDim),
-                    [](const auto &basis) {
-                      return llvm::isPowerOf2_32(basis.front());
-                    })) {
-    return emitError() << "After removing the zero bases " << subject
-                       << " must be a permutation matrix";
-  }
-  if (!withoutBroadcast.isInvertible()) {
-    return emitError() << "After removing the zero bases " << subject
-                       << " must be a permutation matrix";
-  }
-  return success();
-}
-
 LogicalResult
 CGAEncodingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                         LinearLayout linearLayout) {
@@ -586,8 +602,11 @@ CGAEncodingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                        << outDimNames << "].";
   }
 
-  return verifyDistributedLinearLayout(emitError, linearLayout,
-                                       "the CGA encoding");
+  if (!isPermutationMatrixLayout(linearLayout)) {
+    return emitError() << "After removing broadcast bases the CGA encoding "
+                          "must be a permutation matrix";
+  }
+  return success();
 }
 
 CGAEncodingAttr CGAEncodingAttr::get1CTALayout(MLIRContext *ctx, int rank) {
@@ -1093,10 +1112,9 @@ void BlockedEncodingAttr::print(mlir::AsmPrinter &printer) const {
   printer << "}>";
 }
 
-// FIXME Can we take the LinearLayout by const&?
-LogicalResult
-LinearEncodingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
-                           LinearLayout linearLayout) {
+static LogicalResult
+verifyDistributedLinearLayoutDims(function_ref<InFlightDiagnostic()> emitError,
+                                  const LinearLayout &linearLayout) {
   // Example of LinearEncodingAttr
   // <{register = [[0, 1], [8, 0], [0, 8], [64, 0]],
   //   lane = [[0, 2], [0, 4], [1, 0], [2, 0], [4, 0]],
@@ -1125,31 +1143,20 @@ LinearEncodingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
     }
   }
 
-  const auto &bases = linearLayout.getBases();
-  auto nonZero = [](auto val) { return val != 0; };
-  for (const auto &dimBases : llvm::make_second_range(bases)) {
-    if (!llvm::all_of(dimBases, [&](const auto &basis) {
-          return std::count_if(basis.begin(), basis.end(), nonZero) <= 1;
-        })) {
-      return emitError()
-             << "In a distributed layout, each base must move in at most one "
-                "dimension.";
-    }
-  }
+  return success();
+}
 
-  LinearLayout withoutBroadcast = linearLayout;
-  for (auto inDim : linearLayout.getInDimNames()) {
-    withoutBroadcast = withoutBroadcast.removeZeroBasesAlongDim(inDim);
-  }
-  if (withoutBroadcast.isModular()) {
-    if (!withoutBroadcast.isSurjective()) {
-      return emitError() << "NPOT distributed layout not yet supported: after "
-                            "removing the zero bases the modular layout must "
-                            "be surjective";
-    }
-  } else if (!withoutBroadcast.isInvertible()) {
+// FIXME Can we take the LinearLayout by const&?
+LogicalResult
+LinearEncodingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                           LinearLayout linearLayout) {
+  if (failed(verifyDistributedLinearLayoutDims(emitError, linearLayout)))
+    return failure();
+
+  if (!isPermutationMatrixLayout(linearLayout)) {
     return emitError()
-           << "After removing the zero bases the layout must be bijective";
+           << "LinearEncodingAttr requires a permutation matrix layout "
+              "after removing broadcast bases";
   }
 
   return success();
@@ -1193,6 +1200,15 @@ Attribute LinearEncodingAttr::parse(AsmParser &parser, Type type) {
                                                std::move(*maybeLL));
 }
 
+SmallVector<unsigned> LinearEncodingAttr::getWarpsPerCTA() const {
+  return basesPerDim(StringAttr::get(getContext(), "warp"),
+                     /*skipBroadcast=*/true);
+}
+
+SmallVector<unsigned> LinearEncodingAttr::getWarpOrder() const {
+  return orderPerDim(StringAttr::get(getContext(), "warp"), getOrder());
+}
+
 static SmallVector<unsigned>
 basesPerDimImpl(const LinearLayout::BasesT &namedBases, StringAttr dimName,
                 size_t rank, bool skipBroadcast) {
@@ -1222,13 +1238,6 @@ basesPerDimImpl(const LinearLayout::BasesT &namedBases, StringAttr dimName,
   return ret;
 }
 
-SmallVector<unsigned>
-LinearEncodingAttr::basesPerDim(StringAttr dimName, bool skipBroadcast) const {
-  const auto &ll = getLinearLayout();
-  auto rank = ll.getNumOutDims();
-  return basesPerDimImpl(ll.getBases(), dimName, rank, skipBroadcast);
-}
-
 static CGAEncodingAttr
 linearToCGAEncodingAttr(const LinearLayout &ll,
                         ArrayRef<unsigned> cgaLogicalShape) {
@@ -1256,56 +1265,76 @@ linearToCGAEncodingAttr(const LinearLayout &ll,
   return CGAEncodingAttr::get(ctx, std::move(cgaLayout));
 }
 
+//===----------------------------------------------------------------------===//
+// LinearEncodingTrait shared implementations
+//===----------------------------------------------------------------------===//
+
+SmallVector<unsigned> LinearEncodingTrait::basesPerDim(const LinearLayout &ll,
+                                                       StringAttr dimName,
+                                                       bool skipBroadcast) {
+  auto dimLayout =
+      ll.sublayout({dimName}, llvm::to_vector(ll.getOutDimNames()));
+  if (!hasPowerOfTwoBases(dimLayout))
+    llvm_unreachable("basesPerDim cannot decompose swizzled bases into "
+                     "per-dimension counts.");
+  auto rank = ll.getNumOutDims();
+  return basesPerDimImpl(ll.getBases(), dimName, rank, skipBroadcast);
+}
+
 SmallVector<unsigned>
-LinearEncodingAttr::orderPerDim(StringAttr dimName,
-                                ArrayRef<unsigned> defaultOrder) const {
-  return orderPerDimImpl(getLinearLayout(), dimName, defaultOrder);
+LinearEncodingTrait::orderPerDim(const LinearLayout &ll, StringAttr dimName,
+                                 ArrayRef<unsigned> defaultOrder) {
+  auto dimLayout =
+      ll.sublayout({dimName}, llvm::to_vector(ll.getOutDimNames()));
+  if (!hasPowerOfTwoBases(dimLayout))
+    llvm_unreachable(
+        "orderPerDim cannot determine dimension order for swizzled bases.");
+  return orderPerDimImpl(ll, dimName, defaultOrder);
 }
 
-// [Note. Divergence of methods wrt. legacy layouts]
-// For smaller shapes where the CTATile is larger than the output
-// tensor, some methods return different values than the legacy layouts. I think
-// this is benign tho. An example: what is the vector of `warpsPerCTA` if
-// all the warps hold the same data? I think it should be [1, 1], even if we
-// have 4 warps. But perhaps for this we have to add some masking in some
-// places... We'll see
-SmallVector<unsigned> LinearEncodingAttr::getRepOrder() const {
-  // This is not correct, but:
-  // - It happens to agree in most places with the legacy layout
-  // - getRepOrder does not make sense for LinearEncodingAttr as it already has
-  //   the same shape as the tensor that uses it
-  return getOrder();
+// Extracts the MLIRContext from a LinearLayout by peeking at one of its
+// (StringAttr) input-dimension names. LinearLayouts constructed for distributed
+// encodings always have at least one input dimension.
+static MLIRContext *getContextFromLL(const LinearLayout &ll) {
+  assert(!ll.getBases().empty() &&
+         "LinearLayout must have at least one input dim to extract context");
+  return (*ll.getInDimNames().begin()).getContext();
 }
 
-CGAEncodingAttr LinearEncodingAttr::getCGALayout() const {
-  auto splitNum = basesPerDim(StringAttr::get(getContext(), "block"));
-  return linearToCGAEncodingAttr(getLinearLayout(), splitNum);
-}
-SmallVector<unsigned> LinearEncodingAttr::getWarpsPerCTA() const {
-  return basesPerDim(StringAttr::get(getContext(), "warp"));
-}
-SmallVector<unsigned> LinearEncodingAttr::getWarpOrder() const {
-  return orderPerDim(StringAttr::get(getContext(), "warp"), getOrder());
-}
-SmallVector<unsigned> LinearEncodingAttr::getThreadsPerWarp() const {
-  return basesPerDim(StringAttr::get(getContext(), "lane"));
-}
-SmallVector<unsigned> LinearEncodingAttr::getThreadOrder() const {
-  return orderPerDim(StringAttr::get(getContext(), "lane"), getOrder());
+SmallVector<unsigned>
+LinearEncodingTrait::getContig(const LinearLayout &ll, const char *inDim,
+                               SmallVector<unsigned> lowerContig,
+                               ArrayRef<unsigned> order) {
+  auto *ctx = getContextFromLL(ll);
+  const auto &bases = ll.getBases().find(StringAttr::get(ctx, inDim))->second;
+  auto rank = order.size();
+
+  SmallVector<unsigned> contig(lowerContig);
+  auto basisIt = bases.begin();
+  for (unsigned dim : order) {
+    std::vector<int32_t> basis(rank, 0);
+    basis[dim] = contig[dim];
+
+    while (basisIt != bases.end() && *basisIt == basis) {
+      contig[dim] *= 2;
+      basis[dim] *= 2;
+      ++basisIt;
+    }
+  }
+  return contig;
 }
 
-SmallVector<unsigned> LinearEncodingAttr::getSizePerThread() const {
-  auto rank = getOrder().size();
-  const auto &ll = getLinearLayout();
-  auto ctx = getContext();
-  auto kRegister = StringAttr::get(ctx, "register");
-  auto splitNum = getCGALayout().getCTASplitNum();
+SmallVector<unsigned>
+LinearEncodingTrait::getSizePerThread(const LinearLayout &ll,
+                                      ArrayRef<unsigned> cgaSplitNum) {
+  auto rank = ll.getNumOutDims();
+  auto kRegister = StringAttr::get(getContextFromLL(ll), "register");
 
   // We canonicalize on the spot, as if we use CGAs the regs are not in
   // canonical form The order is [reg, lane, warp, rep, block], so we first
   // remove the blocks
   llvm::SmallVector<unsigned> ctaShape;
-  for (auto [shape, cgaNum] : llvm::zip(ll.getOutDimSizes(), splitNum)) {
+  for (auto [shape, cgaNum] : llvm::zip(ll.getOutDimSizes(), cgaSplitNum)) {
     ctaShape.push_back(shape / cgaNum);
   }
   LinearLayout::BasesT bases = ll.getBases();
@@ -1332,81 +1361,120 @@ SmallVector<unsigned> LinearEncodingAttr::getSizePerThread() const {
   return basesPerDimImpl(bases, kRegister, rank);
 }
 
-SmallVector<unsigned> LinearEncodingAttr::getOrder() const {
-  auto rank = getLinearLayout().getNumOutDims();
-  SmallVector<unsigned> order(rank);
-  // Choose [rank-1, rank-2, ... 0] as the default order in case
-  // there are dims that do not move in the register
-  // This order is as good as any really
-  std::iota(order.rbegin(), order.rend(), 0);
-
-  return orderPerDim(StringAttr::get(getContext(), "register"), order);
+CGAEncodingAttr LinearEncodingTrait::getCGALayout(const LinearLayout &ll) {
+  auto splitNum =
+      basesPerDim(ll, StringAttr::get(getContextFromLL(ll), "block"),
+                  /*skipBroadcast=*/true);
+  return linearToCGAEncodingAttr(ll, splitNum);
 }
 
-LinearLayout LinearEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
-  auto ll = getLinearLayout();
+LinearLayout LinearEncodingTrait::toLinearLayout(const LinearLayout &ll,
+                                                 ArrayRef<unsigned> repOrder,
+                                                 ArrayRef<int64_t> shape) {
+  auto result = ll;
   auto canonicalDims = llvm::to_vector(ll.getOutDimNames());
   llvm::SmallDenseMap<StringAttr, int64_t> namedShape;
   llvm::SmallVector<StringAttr> permutedDims;
-  for (auto dim : getRepOrder()) {
+  for (auto dim : repOrder) {
     permutedDims.push_back(canonicalDims[dim]);
     namedShape[canonicalDims[dim]] = shape[dim];
   }
-  ll = ll.transposeOuts(permutedDims);
-  ll = ensureLayoutNotSmallerThan(ll, namedShape);
-  ll = ensureLayoutNotLargerThan(ll, namedShape, /*broadcastRegisters=*/false);
-  ll = ll.transposeOuts(canonicalDims);
-  return ll;
+  result = result.transposeOuts(permutedDims);
+  result = ensureLayoutNotSmallerThan(result, namedShape);
+  result = ensureLayoutNotLargerThan(result, namedShape,
+                                     /*broadcastRegisters=*/false);
+  result = result.transposeOuts(canonicalDims);
+  return result;
 }
 
 SmallVector<unsigned>
-LinearEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape) const {
+LinearEncodingTrait::getElemsPerThread(const LinearLayout &ll,
+                                       ArrayRef<unsigned> repOrder,
+                                       ArrayRef<int64_t> shape) {
   // When broadcasting the layout the shape changes, otherwise the shape is
   // the same as the shape of the tensor
   // We can either have BroadcastOp with SameOperandsAndResultEncoding, or keep
   // the invariant that the shape of the LL is that of the tensor
   // We choose the former for BC
-  auto scaledLayout = get(getContext(), toLinearLayout(shape));
-  auto kRegister = StringAttr::get(getContext(), "register");
-  return scaledLayout.basesPerDim(kRegister, /*skipBroadcast=*/false);
-}
-
-SmallVector<unsigned>
-LinearEncodingAttr::getContig(const char *inDim,
-                              SmallVector<unsigned int> lowerContig) const {
-  const auto &ll = getLinearLayout();
-  const auto &bases =
-      ll.getBases().find(StringAttr::get(getContext(), inDim))->second;
-  auto order = getOrder();
-  auto rank = order.size();
-
-  SmallVector<unsigned> contig(lowerContig);
-  auto basisIt = bases.begin();
-  for (unsigned dim : order) {
-    std::vector<int32_t> basis(rank, 0);
-    basis[dim] = contig[dim];
-
-    while (basisIt != bases.end() && *basisIt == basis) {
-      contig[dim] *= 2;
-      basis[dim] *= 2;
-      ++basisIt;
-    }
-  }
-  return contig;
-}
-
-SmallVector<unsigned> LinearEncodingAttr::getContigPerThread() const {
-  SmallVector<unsigned> contig(getOrder().size(), 1);
-  return getContig("register", contig);
-}
-
-SmallVector<unsigned> LinearEncodingAttr::getContigPerWarp() const {
-  return getContig("lane", getContigPerThread());
+  auto scaledLL = toLinearLayout(ll, repOrder, shape);
+  auto kRegister = StringAttr::get(getContextFromLL(ll), "register");
+  return basesPerDimImpl(scaledLL.getBases(), kRegister,
+                         scaledLL.getNumOutDims(), /*skipBroadcast=*/false);
 }
 
 unsigned
-LinearEncodingAttr::getTotalElemsPerThread(ArrayRef<int64_t> shape) const {
-  return product(getElemsPerThread(shape));
+LinearEncodingTrait::getTotalElemsPerThread(const LinearLayout &ll,
+                                            ArrayRef<unsigned> repOrder,
+                                            ArrayRef<int64_t> shape) {
+  return product(getElemsPerThread(ll, repOrder, shape));
+}
+
+CGAEncodingAttr LinearEncodingAttr::getCGALayout() const {
+  return LinearEncodingTrait::getCGALayout(getLinearLayout());
+}
+
+//===----------------------------------------------------------------------===//
+// Generic Linear Encoding
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+GenericLinearEncodingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                                  LinearLayout linearLayout) {
+  if (failed(verifyDistributedLinearLayoutDims(emitError, linearLayout)))
+    return failure();
+
+  // Register, lane, and block bases must be non-swizzled (at most one non-zero
+  // per basis). Only warp bases may be swizzled.
+  auto nonZero = [](auto val) { return val != 0; };
+  auto ctx = (*linearLayout.getInDimNames().begin()).getContext();
+  for (StringRef dimName : {"register", "lane", "block"}) {
+    auto key = StringAttr::get(ctx, dimName);
+    const auto &dimBases = linearLayout.getBases().find(key)->second;
+    if (!llvm::all_of(dimBases, [&](const auto &basis) {
+          return std::count_if(basis.begin(), basis.end(), nonZero) <= 1;
+        })) {
+      return emitError() << "In a generic linear layout, register, lane, and "
+                            "block bases must move in at most one dimension. "
+                            "Swizzled bases found in '"
+                         << dimName << "'.";
+    }
+  }
+
+  if (!linearLayout.isSurjective())
+    return emitError() << "Generic linear layout must be surjective, i.e. "
+                          "all output values must be covered by some input.";
+
+  return success();
+}
+
+void GenericLinearEncodingAttr::print(mlir::AsmPrinter &printer) const {
+  printer << "<{";
+  printLinearLayout(printer, getLinearLayout());
+  printer << "}>";
+}
+
+Attribute GenericLinearEncodingAttr::parse(AsmParser &parser, Type type) {
+  if (parser.parseLess().failed())
+    return {};
+
+  DictionaryAttr dict;
+  if (parser.parseAttribute(dict).failed())
+    return {};
+
+  if (parser.parseGreater().failed())
+    return {};
+
+  std::vector<std::string> inDimNames = {"register", "lane", "warp", "block"};
+  auto maybeLL = parseLinearLayout(dict, parser, inDimNames);
+  if (!maybeLL.has_value())
+    return {};
+
+  return parser.getChecked<GenericLinearEncodingAttr>(parser.getContext(),
+                                                      std::move(*maybeLL));
+}
+
+CGAEncodingAttr GenericLinearEncodingAttr::getCGALayout() const {
+  return LinearEncodingTrait::getCGALayout(getLinearLayout());
 }
 
 //===----------------------------------------------------------------------===//
@@ -2907,6 +2975,10 @@ public:
     } else if (auto linearAttr = mlir::dyn_cast<LinearEncodingAttr>(attr)) {
       os << "linear";
       return AliasResult::FinalAlias;
+    } else if (auto genericLinearAttr =
+                   mlir::dyn_cast<GenericLinearEncodingAttr>(attr)) {
+      os << "generic_linear";
+      return AliasResult::FinalAlias;
     } /* else if (auto sliceAttr = dyn_cast<SliceEncodingAttr>(attr)) {
       os << "slice";
       return AliasResult::FinalAlias;
@@ -3076,7 +3148,8 @@ struct TritonGPUInferLayoutInterface
       return failure();
     auto transposedLl = transposeLinearLayout(ll, order);
     if (isa<DistributedEncodingTrait>(operandEncoding)) {
-      resultEncoding = LinearEncodingAttr::get(ctx, std::move(transposedLl));
+      resultEncoding = inferEncodingFromLinearLayout(
+          ctx, std::move(transposedLl), operandEncoding);
     } else if (padded) {
       resultEncoding = PaddedSharedEncodingAttr::get(ctx, padded.getIntervals(),
                                                      padded.getPaddings(),
@@ -3527,7 +3600,8 @@ struct TritonGPUInferLayoutInterface
     LinearLayout ll =
         inferReshapeLinearLayout(cast<TensorOrMemDesc>(srcTy), dstShape);
 
-    dstEnc = LinearEncodingAttr::get(srcEnc.getContext(), std::move(ll));
+    dstEnc = inferEncodingFromLinearLayout(srcEnc.getContext(), std::move(ll),
+                                           srcEnc);
     return success();
   }
 
@@ -3592,7 +3666,7 @@ struct TritonGPUInferLayoutInterface
         tryJoinOnAxis(ctx, ll, newLl, /*fwdInference=*/true, axis, loc);
 
     assert(result.succeeded());
-    dstEnc = LinearEncodingAttr::get(ctx, std::move(newLl));
+    dstEnc = inferEncodingFromLinearLayout(ctx, std::move(newLl), srcEnc);
     return success();
   }
 
@@ -3647,7 +3721,7 @@ struct TritonGPUInferLayoutInterface
     SmallVector<int64_t> dstShape(shape.begin(), shape.end());
     dstShape.pop_back();
     newLl = newLl.reshapeOuts(standardOutDimPairs(ctx, dstShape));
-    dstEnc = LinearEncodingAttr::get(ctx, std::move(newLl));
+    dstEnc = inferEncodingFromLinearLayout(ctx, std::move(newLl), srcEnc);
     return success();
   }
 
@@ -3710,7 +3784,7 @@ struct TritonGPUInferLayoutInterface
     auto result = tryJoinOnAxis(ctx, ll, newLl, fwdInference, axis, loc);
     if (!result.succeeded())
       return result;
-    outEnc = LinearEncodingAttr::get(ctx, std::move(newLl));
+    outEnc = inferEncodingFromLinearLayout(ctx, std::move(newLl), inEnc);
     return success();
   }
 };
@@ -3769,6 +3843,21 @@ struct TritonGPUVerifyTensorLayoutInterface
     return success();
   }
 
+  // Ops that have been explicitly vetted to handle encodings with swizzled
+  // warp bases or non-injective layouts (GenericLinearEncodingAttr,
+  // AMDWmmaEncoding with swizzled warps, etc.).  All other ops reject them so
+  // that unvetted code paths fail early rather than silently producing wrong
+  // results.
+  static bool isOpVettedForGenericEncoding(Operation *op) {
+    if (op->hasTrait<OpTrait::Elementwise>())
+      return true;
+    if (isView(op))
+      return true;
+    return isa<triton::MakeRangeOp, triton::SplatOp, triton::BroadcastOp,
+               triton::LoadOp, triton::StoreOp, triton::JoinOp, triton::SplitOp,
+               triton::gpu::ConvertLayoutOp, triton::gpu::Fp4ToFpOp>(op);
+  }
+
   LogicalResult verifyTensorLayout(
       Attribute layout, RankedTensorType rankedTy, Operation *op,
       function_ref<InFlightDiagnostic()> makeErr) const override {
@@ -3780,6 +3869,12 @@ struct TritonGPUVerifyTensorLayoutInterface
     if (!distr)
       return makeErr()
              << "Non-distributed layout is not allowed in tensor type.";
+
+    if (isGenericLinearEncoding(layout) && !isOpVettedForGenericEncoding(op)) {
+      return makeErr() << "Encoding not compatible with LinearEncodingAttr "
+                       << "(e.g., swizzled warp bases or non-injective layout) "
+                       << "is not supported on " << op->getName() << ".";
+    }
     if (llvm::any_of(rankedTy.getShape(),
                      [](int64_t i) { return !llvm::isPowerOf2_64(i); })) {
       static const bool allowNpot =

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -498,9 +498,9 @@ unsigned getNumCTAs(Attribute layout) {
   return product<unsigned>(getCTAsPerCGA(layout));
 }
 
-SmallVector<unsigned> orderPerDimImpl(const LinearLayout &ll,
-                                      StringAttr dimName,
-                                      ArrayRef<unsigned> defaultOrder) {
+static SmallVector<unsigned> orderPerDimImpl(const LinearLayout &ll,
+                                             StringAttr dimName,
+                                             ArrayRef<unsigned> defaultOrder) {
   assert(ll.getBases().contains(dimName));
   const auto &bases = ll.getBases().find(dimName)->second;
   llvm::SetVector<unsigned> order;
@@ -704,9 +704,9 @@ getDefaultBlockedEncoding(MLIRContext *context, ArrayRef<int64_t> shape,
   return encoding;
 }
 
-LogicalResult tryJoinOnAxis(MLIRContext *ctx, const LinearLayout &inLl,
-                            LinearLayout &outLl, bool fwdInference, int axis,
-                            std::optional<Location> loc) {
+static LogicalResult tryJoinOnAxis(MLIRContext *ctx, const LinearLayout &inLl,
+                                   LinearLayout &outLl, bool fwdInference,
+                                   int axis, std::optional<Location> loc) {
   auto kRegister = StringAttr::get(ctx, "register");
   auto outDims = llvm::to_vector(inLl.getOutDimNames());
   if (fwdInference) {
@@ -747,8 +747,10 @@ LogicalResult tryJoinOnAxis(MLIRContext *ctx, const LinearLayout &inLl,
 } // namespace triton
 } // namespace mlir
 
-static LogicalResult parseIntAttrValue(AsmParser &parser, Attribute attr,
-                                       unsigned &value, StringRef desc) {
+namespace {
+
+LogicalResult parseIntAttrValue(AsmParser &parser, Attribute attr,
+                                unsigned &value, StringRef desc) {
   auto intAttr = mlir::dyn_cast<IntegerAttr>(attr);
   if (!intAttr) {
     parser.emitError(parser.getNameLoc(), "expected an integer type in ")
@@ -779,8 +781,8 @@ static LogicalResult parseIntAttrValue(AsmParser &parser, Attribute attr,
   return success();
 }
 
-static LogicalResult parseBoolAttrValue(AsmParser &parser, Attribute attr,
-                                        bool &value, StringRef desc) {
+LogicalResult parseBoolAttrValue(AsmParser &parser, Attribute attr, bool &value,
+                                 StringRef desc) {
   auto boolAttr = mlir::dyn_cast<BoolAttr>(attr);
   if (!boolAttr) {
     parser.emitError(parser.getNameLoc(), "expected a bool type in ") << desc;
@@ -791,10 +793,8 @@ static LogicalResult parseBoolAttrValue(AsmParser &parser, Attribute attr,
 }
 
 // parse an array of integers
-static LogicalResult parseIntArrayAttr(AsmParser &parser,
-                                       const NamedAttribute &attr,
-                                       SmallVector<unsigned> &res,
-                                       StringRef desc) {
+LogicalResult parseIntArrayAttr(AsmParser &parser, const NamedAttribute &attr,
+                                SmallVector<unsigned> &res, StringRef desc) {
   auto arrayAttr = mlir::dyn_cast<ArrayAttr>(attr.getValue());
   if (!arrayAttr) {
     parser.emitError(parser.getNameLoc(), "expected an array for ") << desc;
@@ -809,13 +809,13 @@ static LogicalResult parseIntArrayAttr(AsmParser &parser,
   return success();
 };
 
-static LogicalResult parseUInt(AsmParser &parser, const NamedAttribute &attr,
-                               unsigned &value, StringRef desc) {
+LogicalResult parseUInt(AsmParser &parser, const NamedAttribute &attr,
+                        unsigned &value, StringRef desc) {
   return parseIntAttrValue(parser, attr.getValue(), value, desc);
 };
 
-static LogicalResult parseBool(AsmParser &parser, const NamedAttribute &attr,
-                               bool &value, StringRef desc) {
+LogicalResult parseBool(AsmParser &parser, const NamedAttribute &attr,
+                        bool &value, StringRef desc) {
   return parseBoolAttrValue(parser, attr.getValue(), value, desc);
 };
 
@@ -898,6 +898,8 @@ std::optional<LinearLayout> parseLinearLayout(const DictionaryAttr &dict,
   // Create LinearLayout
   return LinearLayout(std::move(bases), std::move(outDimNames));
 }
+
+} // namespace
 
 // We don't use the default implementation as it's a bit too verbose
 // This prints in the following format that is shape agnostic, in the sense
@@ -1227,8 +1229,9 @@ LinearEncodingAttr::basesPerDim(StringAttr dimName, bool skipBroadcast) const {
   return basesPerDimImpl(ll.getBases(), dimName, rank, skipBroadcast);
 }
 
-CGAEncodingAttr linearToCGAEncodingAttr(const LinearLayout &ll,
-                                        ArrayRef<unsigned> cgaLogicalShape) {
+static CGAEncodingAttr
+linearToCGAEncodingAttr(const LinearLayout &ll,
+                        ArrayRef<unsigned> cgaLogicalShape) {
   // Compute the shapePerCTA
   auto shape = ll.getOutDims();
   for (int i = 0; i < shape.size(); ++i) {
@@ -1785,7 +1788,7 @@ template SmallVector<int64_t>
 SliceEncodingAttr::paddedShape<int64_t>(ArrayRef<int64_t> shape) const;
 
 template <typename SpecificEncoding>
-Attribute parseSwizzledEncoding(AsmParser &parser, Type type) {
+static Attribute parseSwizzledEncoding(AsmParser &parser, Type type) {
   if (parser.parseLess().failed())
     return {};
   // Parse the data as a dictionary

--- a/lib/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.cpp
@@ -13,13 +13,17 @@ namespace ttng = mlir::triton::nvidia_gpu;
 
 namespace mlir::triton::gpu {
 
-static SmallVector<int64_t> expandToRank(ArrayRef<int64_t> shape, int rank) {
+namespace {
+
+SmallVector<int64_t> expandToRank(ArrayRef<int64_t> shape, int rank) {
   SmallVector<int64_t> result(rank, 1);
   assert(shape.size() <= rank);
   auto rankDiff = rank - shape.size();
   std::copy(shape.begin(), shape.end(), result.begin() + rankDiff);
   return result;
 }
+
+} // namespace
 
 CGAEncodingAttr updateCGALayoutForShape(CGAEncodingAttr cgaLayout,
                                         ArrayRef<int64_t> shape) {
@@ -121,9 +125,9 @@ SharedEncodingTrait updateEncodingForShape(Operation *op,
 
 // Build shared encoding for a tensor descriptor by applying callback to adjust
 // for block shape of the descriptor
-TensorDescType getTensorDescTypeWithEncoding(Operation *op,
-                                             RankedTensorType existingTy,
-                                             Attribute encoding) {
+static TensorDescType getTensorDescTypeWithEncoding(Operation *op,
+                                                    RankedTensorType existingTy,
+                                                    Attribute encoding) {
   auto sharedEnc = cast<SharedEncodingTrait>(encoding);
   encoding = updateEncodingForShape(op, sharedEnc, existingTy);
   return TensorDescType::get(existingTy.getShape(), existingTy.getElementType(),

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -25,7 +25,7 @@ namespace mlir::triton::gpu {
 // scheduleLoops
 //===----------------------------------------------------------------------===//
 
-template <typename... OpTypes> bool containsAny(scf::ForOp forOp) {
+template <typename... OpTypes> static bool containsAny(scf::ForOp forOp) {
   WalkResult result = forOp.walk([&](Operation *op) {
     if (isa<OpTypes...>(op))
       return WalkResult::interrupt();

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
@@ -246,6 +246,8 @@ static void threadValuesThroughWait(ttng::WarpGroupDotWaitOp wait,
   wait->erase();
 }
 
+namespace {
+
 // Split the LHS of a RSWGMMADot operation into multiple
 // tensors of size MxnewK via SplitOps
 SmallVector<Value> splitLhs(OpBuilder &builder,
@@ -389,6 +391,8 @@ splitRSDots(const llvm::MapVector<Operation *, int> &dots) {
   }
   return ret;
 }
+
+} // namespace
 
 // Determines whether a given MMAv3 dot op, represented as ttng.warp_group_dot,
 // needs a wait immediately after it.

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1281,7 +1281,7 @@ std::optional<StringRef> getAMDArch(Operation *module) {
   return ref.drop_front(4); // drop the "hip:"
 }
 
-inline ttg::SwizzledSharedEncodingAttr
+static inline ttg::SwizzledSharedEncodingAttr
 swizzleDotOperandLike(RankedTensorType type, ttg::CGAEncodingAttr cgaLayout) {
   // We want to see if the linear layout has the same order as an mma microtile
   // of shape (8, 4*kWidth) or (4*kWidth, 8). If so, we return a

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1290,8 +1290,7 @@ swizzleDotOperandLike(RankedTensorType type, ttg::CGAEncodingAttr cgaLayout) {
   // the swizzling
 
   auto *ctx = type.getContext();
-  auto layout = ttg::toLinearEncoding(type);
-  auto order = layout.getThreadOrder();
+  auto order = ttg::getThreadOrder(type);
   auto rank = order.size();
   if (rank < 2) {
     return {};
@@ -1304,7 +1303,7 @@ swizzleDotOperandLike(RankedTensorType type, ttg::CGAEncodingAttr cgaLayout) {
   } else {
     return {};
   }
-  auto kWidth = layout.getContigPerThread()[order[0]];
+  auto kWidth = ttg::getContigPerThread(type)[order[0]];
   SmallVector<unsigned> microtileShape(rank, 1);
   microtileShape[order[0]] = 4 * kWidth;
   microtileShape[order[1]] = 8;
@@ -1312,7 +1311,7 @@ swizzleDotOperandLike(RankedTensorType type, ttg::CGAEncodingAttr cgaLayout) {
   // 2, ...]
   auto repOrder = to_vector(llvm::seq<unsigned>(rank));
   auto tile = ttg::nvidiaMmaTile(ctx, microtileShape, kWidth, order, repOrder);
-  if (!divideLeft(layout.getLinearLayout(), tile).has_value()) {
+  if (!divideLeft(ttg::toLinearLayout(type), tile).has_value()) {
     return {};
   }
   return ttg::SwizzledSharedEncodingAttr::get(

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1658,13 +1658,13 @@ void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
 void FunctionBuilder::createTrackBarrierWriteForBufferCall(
     ImplicitLocOpBuilder &b, Value mbar, Value buf, uint32_t length, Value pred,
     MemType memType, Operation *insertPoint, Value barrierRecipientCTAs,
-    Value effectRecipientCTAs) {
+    Value effectRecipientCTAs, bool diagonalEffectRecipientCTAs) {
   if (auxData.barriers.empty() || auxData.buffers[(int)memType].empty() ||
       auxData.writeTracking[(int)memType].empty()) {
     return;
   }
   assert(!auxData.barrierWriteRecipients.empty() &&
-         "barrier write recipients must exist when tracking TMA writes");
+         "barrier write recipients must exist when tracking EffectWrites");
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   Value barriersVal = auxData.barriers.at(insertPoint).value;
@@ -1701,10 +1701,10 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
       b, "track_barrier_write_for_buffer", args,
       /*assertInfo=*/std::nullopt,
       {barriersType, buffersType, writeTrackingType, barrierWriteRecipientsType,
-       (uint64_t)memType},
-      [barriersType, buffersType, writeTrackingType,
-       barrierWriteRecipientsType](ImplicitLocOpBuilder &fb,
-                                   Block *entryBlock) {
+       (uint64_t)memType, (uint64_t)diagonalEffectRecipientCTAs},
+      [barriersType, buffersType, writeTrackingType, barrierWriteRecipientsType,
+       diagonalEffectRecipientCTAs](ImplicitLocOpBuilder &fb,
+                                    Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value mbarLengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
@@ -1731,6 +1731,26 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
             createCmpIntTensorScalar(fb, barriers, barrierDescriptor);
         Value effectRecipientCTAsTensor = triton::SplatOp::create(
             fb, barrierWriteRecipientsType, effectRecipientCTAs);
+        if (diagonalEffectRecipientCTAs) {
+          // Expand the effect CTA mask diagonally: barrier row i publishes only
+          // bit i. This models per-CTA results, while the default replicated
+          // mask models TMA multicast where a barrier publishes all result
+          // rows.
+          int numCTAs = barrierWriteRecipientsType.getShape()[0];
+          auto rowType = tti::getSlicedTensorType(
+              barrierWriteRecipientsType, /*keptDims=*/{0}, fb.getI32Type());
+          Value rowIdx = triton::MakeRangeOp::create(fb, rowType,
+                                                     /*start=*/0,
+                                                     /*end=*/numCTAs);
+          auto indexType =
+              cast<RankedTensorType>(barrierWriteRecipientsType.cloneWith(
+                  std::nullopt, fb.getI32Type()));
+          rowIdx = convertAndBroadcast(fb, rowIdx, {0}, indexType);
+          Value one = tti::createConstIntTensor(fb, fb.getLoc(), 1, indexType);
+          Value rowBit = arith::ShLIOp::create(fb, one, rowIdx);
+          effectRecipientCTAsTensor =
+              arith::AndIOp::create(fb, effectRecipientCTAsTensor, rowBit);
+        }
         Value updatedBarrierWriteRecipients = arith::OrIOp::create(
             fb, barrierWriteRecipients, effectRecipientCTAsTensor);
         updatedBarrierWriteRecipients = arith::SelectOp::create(
@@ -2349,11 +2369,10 @@ void FunctionBuilder::createCopyWriteVisibilityCall(ImplicitLocOpBuilder &b,
         Value zeroTensor =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, writeVisibilityType);
 
-        constexpr uint64_t fullMask =
-            tti::THREADS_BITMASK_SIZE == 64
-                ? std::numeric_limits<uint64_t>::max()
-                : (std::numeric_limits<uint64_t>::max() >>
-                   (64 - tti::THREADS_BITMASK_SIZE));
+        uint64_t fullMask = tti::THREADS_BITMASK_SIZE == 64
+                                ? std::numeric_limits<uint64_t>::max()
+                                : (std::numeric_limits<uint64_t>::max() >>
+                                   (64 - tti::THREADS_BITMASK_SIZE));
         Value fullMaskVal = arith::ConstantIntOp::create(fb, fullMask, 64);
         Value destMaskElem = adjustIntegerWidth(fb, destMaskVal, elemType);
         Value fullMaskElem = adjustIntegerWidth(fb, fullMaskVal, elemType);

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -611,8 +611,7 @@ void AuxDataMap::populateAndPassToWarpSpecialize(
   if (numCTAs > 1) {
     ClusterBarrierOp::create(b, b.getLoc());
   } else {
-    BarrierOp::create(b, b.getLoc(),
-                      AddrSpace::GlobalRead | AddrSpace::GlobalWrite);
+    BarrierOp::create(b, b.getLoc(), AddrSpace::Local);
   }
   lock.insert(entryRegion, {lockVal, lockVal.getType()});
   passToWarpSpecialize(entryPoint, lock.at(entryRegion), lock, captureCounter);

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -387,6 +387,9 @@ Value getMemEffectRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
       return getMulticastRecipientCTAs(b, copyOp.getResult());
     return currentCTAMask(b);
   }
+  if (auto gatherOp = dyn_cast<ttng::AsyncTMAGatherOp>(op);
+      gatherOp && gatherOp.getMulticast())
+    return getMulticastRecipientCTAs(b, gatherOp.getResult());
   if (isTensorCoreOp(op))
     return getRecipientCTAsForBroadcastMasks(
         b, ttng::getCTABroadcastMasks(ttng::getModuleTwoCTAs(op), {}));
@@ -406,8 +409,12 @@ Value getBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
                                               copyOp.getBarrier());
     return getLeaderCTA(b, copyOp.getBarrier());
   }
-  if (auto gatherOp = dyn_cast<ttng::AsyncTMAGatherOp>(op))
+  if (auto gatherOp = dyn_cast<ttng::AsyncTMAGatherOp>(op)) {
+    if (gatherOp.getMulticast())
+      return getMulticastBarrierRecipientCTAs(b, gatherOp.getResult(),
+                                              gatherOp.getBarrier());
     return getLeaderCTA(b, gatherOp.getBarrier());
+  }
 
   if (isTensorCoreOp(op))
     return getRecipientCTAsForBroadcastMasks(

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -24,7 +24,7 @@
 // buffers                | tensor  | <C x B x i64>      | Base pointers of all (sub)buffers
 // barriers               | tensor  | <C x K x i64>      | Pointers to all individual mbarriers
 // barrierStates          | scratch | <C x K x i64>      | Packed barrier phase (bit 0), arrival counts (bits[1..20] init, [21..40] current), and signed tx-count (bits[41..61]); zero means invalid/uninitialized
-// barrierWriteRecipients | scratch | <C x K x i32>      | CTA bitsets of write-tracking rows reached by outstanding TMA effects on each barrier
+// barrierWriteRecipients | scratch | <C x K x i32>      | CTA bitsets of EffectWrites rows published by each barrier
 // waiting                | scratch | <C x K x i32>      | Two bits per thread: waiting flag bit (LSB), stored phase bit (bit 1)
 // writeVisibility        | scratch | <C x B x i64>      | Per-buffer thread-visibility bitmask (bit i => thread i visible)
 // readVisibility         | scratch | <C x B x T x i64>  | Per-buffer, per-thread visibility lanes (row-updated; values are bitmasks)
@@ -121,12 +121,16 @@ int getCurrentThread(Operation *op, const ConSanTargetHooks *hooks) {
     thread += TC_THREAD_OFFSET;
     return thread;
   }
+  if (hooks->isCLCOp(op)) {
+    thread += CLC_THREAD_OFFSET;
+    return thread;
+  }
   return thread;
 }
 
 int getBaseThread(int thread) { return thread % NUM_THREADS; }
 
-// Peer threads are the equivalent threads in the TMA, TC and normal
+// Peer threads are the equivalent threads in the TMA, TC, CLC and normal
 // thread classes.
 // If a thread is a base thread, return the mask with the peers, otherwise
 // return the mask with the thread itself.
@@ -135,6 +139,7 @@ uint64_t getThreadPeersMask(int thread) {
   if (thread < NUM_THREADS) {
     mask |= 1ULL << (thread + TMA_THREAD_OFFSET);
     mask |= 1ULL << (thread + TC_THREAD_OFFSET);
+    mask |= 1ULL << (thread + CLC_THREAD_OFFSET);
   }
   return mask;
 }
@@ -283,6 +288,12 @@ Value currentCTAMask(ImplicitLocOpBuilder &b) {
                                ctaId);
 }
 
+Value allCTAsMask(ImplicitLocOpBuilder &b) {
+  int numCTAs = ttg::lookupNumCTAs(b);
+  assert(numCTAs <= 16 && "ConSan CTA bitsets assume at most 16 CTAs");
+  return arith::ConstantIntOp::create(b, (1u << numCTAs) - 1, 32);
+}
+
 uint16_t getBlockBroadcastMask(Value alloc) {
   auto allocTy = cast<ttg::MemDescType>(alloc.getType());
   auto kBlock = StringAttr::get(alloc.getContext(), "block");
@@ -390,6 +401,8 @@ Value getMemEffectRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
   if (auto gatherOp = dyn_cast<ttng::AsyncTMAGatherOp>(op);
       gatherOp && gatherOp.getMulticast())
     return getMulticastRecipientCTAs(b, gatherOp.getResult());
+  if (isa<ttng::CLCTryCancelOp>(op))
+    return allCTAsMask(b);
   if (isTensorCoreOp(op))
     return getRecipientCTAsForBroadcastMasks(
         b, ttng::getCTABroadcastMasks(ttng::getModuleTwoCTAs(op), {}));
@@ -415,6 +428,8 @@ Value getBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
                                               gatherOp.getBarrier());
     return getLeaderCTA(b, gatherOp.getBarrier());
   }
+  if (isa<ttng::CLCTryCancelOp>(op))
+    return allCTAsMask(b);
 
   if (isTensorCoreOp(op))
     return getRecipientCTAsForBroadcastMasks(
@@ -723,7 +738,8 @@ private:
             memType = MemType::SHARED_MEM;
           funcBuilder.createTrackBarrierWriteForBufferCall(
               b, barrier, effect.buf, effect.length, combinedPred, memType, op,
-              recipientCTAs, effectRecipientCTAs);
+              recipientCTAs, effectRecipientCTAs,
+              barrierInfo.diagonalEffectRecipientCTAs);
         }
       }
       if (barrierInfo.count > 0 || barrierInfo.txCount != 0) {

--- a/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Dialect.cpp
@@ -49,6 +49,8 @@ namespace mlir {
 namespace triton {
 namespace nvidia_gpu {
 
+namespace {
+
 FailureOr<gpu::CGAEncodingAttr> parseCGALayoutRankTwo(AsmParser &parser) {
   Attribute attr;
   if (parser.parseAttribute(attr).failed())
@@ -61,6 +63,8 @@ FailureOr<gpu::CGAEncodingAttr> parseCGALayoutRankTwo(AsmParser &parser) {
 void printCGALayoutRankTwo(AsmPrinter &printer, gpu::CGAEncodingAttr cgaAttr) {
   gpu::printCGAAttr(printer, cgaAttr);
 }
+
+} // namespace
 
 TensorMemoryScalesBlockRepOrder getTensorMemoryScalesBlockRepOrder(
     Operation *op, bool isA, ScaleDotElemType aType, ScaleDotElemType bType,

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -512,6 +512,55 @@ static LogicalResult verifyAsyncTMAStoreOp(Operation *op,
   return verifyTMAEncoding(op, desc.getType(), srcEnc);
 }
 
+static LogicalResult verifyAsyncTMAGatherScatterOp(Operation *op,
+                                                   ShapedType blockType,
+                                                   MemDescType memDescType,
+                                                   ShapedType indicesType) {
+  if (blockType.getRank() != 2)
+    return op->emitOpError("descriptor block must be a 2D tensor, but got ")
+           << blockType;
+  if (blockType.getShape()[0] != 1)
+    return op->emitOpError("descriptor block must have exactly 1 row, but got ")
+           << blockType;
+  if (failed(verifyGatherScatterResultType(op, memDescType, indicesType)))
+    return failure();
+
+  if (memDescType.getShape()[1] != blockType.getShape()[1])
+    return op->emitOpError("result tensor number of columns must match block (")
+           << blockType.getShape()[1] << "), but got " << memDescType;
+  if (memDescType.getElementType() != blockType.getElementType())
+    return op->emitOpError("result tensor element type must match block (")
+           << blockType.getElementType() << "), but got " << memDescType;
+
+  ArrayRef<int64_t> allocShape = memDescType.getAllocShape();
+  if (allocShape.size() < 2 ||
+      memDescType.getShape() != allocShape.take_back(2))
+    return op->emitOpError("memdesc shape must match alloc shape");
+
+  auto xOffsetsType = cast<RankedTensorType>(indicesType);
+  if (xOffsetsType.getEncoding()) {
+    auto xCoordsLayout = triton::gpu::toLinearLayout(xOffsetsType);
+    auto kLane = StringAttr::get(op->getContext(), "lane");
+    if (getContigPerThread(xOffsetsType).front() < 4)
+      return op->emitOpError(
+          "x offsets must have at least 4 contiguous elements per thread");
+    unsigned threadsPerWarp = xCoordsLayout.getInDimSize(kLane);
+    if (xCoordsLayout.getFreeVariableMasks()[kLane] != (threadsPerWarp - 1))
+      return op->emitOpError("x offsets must be broadcasted across each warp");
+    auto kBlock = StringAttr::get(op->getContext(), "block");
+    auto kDim0 = StringAttr::get(op->getContext(), "dim0");
+    auto rowsCGA = getCGALayout(memDescType.getEncoding())
+                       .getLinearLayout()
+                       .sublayout({kBlock}, {kDim0});
+    auto xOffsetsCGA =
+        getCGALayout(xOffsetsType.getEncoding()).getLinearLayout();
+    if (rowsCGA != xOffsetsCGA)
+      return op->emitOpError(
+          "x offsets must have the same row CGA layout as the memdesc");
+  }
+  return success();
+}
+
 // Helper to determine if the descriptor type is for im2col mode
 static bool isIm2ColDescriptor(Type descType) {
   return isa<TensorDescIm2ColType>(descType);
@@ -693,9 +742,12 @@ LogicalResult AsyncTMAGatherOp::verify() {
   // `tile::gather4` does not support fp4_padded operands.
   if (isFp4Padded(getResult().getType().getEncoding()))
     return emitOpError("does not support fp4_padded operands");
-  return verifyGatherScatterOp(*this,
-                               getDesc().getType().getSignlessBlockType(),
-                               resultType, getXOffsets().getType());
+  if (getMulticast() && !hasCGABroadcast(resultType))
+    return emitOpError(
+        "multicast requires the shared layout to broadcast across CTAs");
+  return verifyAsyncTMAGatherScatterOp(
+      *this, getDesc().getType().getSignlessBlockType(), resultType,
+      getXOffsets().getType());
 }
 
 Value AsyncTMAGatherOp::getPredicateOperand() { return getPred(); }
@@ -713,9 +765,9 @@ LogicalResult AsyncTMAScatterOp::verify() {
   auto srcType = getSrc().getType();
   if (failed(verifyAsyncTMAStoreOp(*this, getDesc(), srcType)))
     return failure();
-  return verifyGatherScatterOp(*this,
-                               getDesc().getType().getSignlessBlockType(),
-                               srcType, getXOffsets().getType());
+  return verifyAsyncTMAGatherScatterOp(
+      *this, getDesc().getType().getSignlessBlockType(), srcType,
+      getXOffsets().getType());
 }
 
 // -- TCGen5MMAOp --

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -49,6 +49,8 @@ static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
     return false;
   } else if (auto tma = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
     return tma.getMulticast();
+  } else if (auto tma = dyn_cast<ttng::AsyncTMAGatherOp>(op)) {
+    return tma.getMulticast();
   }
   return false;
 }
@@ -99,6 +101,9 @@ usesTrackedBarrierInCrossCTAConsumerOp(Operation *op,
   if (auto tma = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
     return tma.getMulticast() && !tma.getMulticastTargets() &&
            aliasesTracked(tma.getBarrier());
+  }
+  if (auto tma = dyn_cast<ttng::AsyncTMAGatherOp>(op)) {
+    return tma.getMulticast() && aliasesTracked(tma.getBarrier());
   }
   return false;
 }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -105,6 +105,9 @@ usesTrackedBarrierInCrossCTAConsumerOp(Operation *op,
   if (auto tma = dyn_cast<ttng::AsyncTMAGatherOp>(op)) {
     return tma.getMulticast() && aliasesTracked(tma.getBarrier());
   }
+  if (auto clc = dyn_cast<ttng::CLCTryCancelOp>(op)) {
+    return aliasesTracked(clc.getMbarrier());
+  }
   return false;
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -38,6 +38,10 @@ public:
                ttng::AsyncTMAReduceOp, ttng::AsyncTMAScatterOp>(op);
   }
 
+  bool isCLCOp(Operation *op) const override {
+    return isa<ttng::CLCTryCancelOp>(op);
+  }
+
   std::optional<BarrierInitInfo>
   getBarrierInitInfo(Operation *op) const override {
     if (auto initOp = dyn_cast<ttng::InitBarrierOp>(op)) {
@@ -100,6 +104,11 @@ public:
         mask = getBarrierMask(gatherOp.getResult());
     if (auto storeOp = dyn_cast<ttng::TMAStoreLikeOpInterface>(op))
       mask = getBarrierMask(storeOp.getSrc());
+    if (isa<ttng::CLCTryCancelOp>(op) && ttg::lookupNumCTAs(op) > 1) {
+      Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
+      return arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaId,
+                                   arith::ConstantIntOp::create(b, 0, 32));
+    }
 
     // In 2CTA tcgen05 and tmem_copy, only the even CTA in each (i, i^1) pair
     // issues the op.
@@ -228,7 +237,25 @@ public:
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
                                         copyOp.getResult());
     }
-    if (auto storeOp = dyn_cast<ttng::AsyncTMACopyLocalToGlobalOp>(op)) {
+    if (auto tryCancelOp = dyn_cast<ttng::CLCTryCancelOp>(op)) {
+      info.emplace();
+      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+      info->barriers.push_back(
+          {tryCancelOp.getMbarrier(), nullptr, /*count=*/0,
+           MemEffectsOpInfo::BarrierTrackingMode::EffectWrites,
+           /*txCount=*/
+           -static_cast<int>(tti::getMemDescLength(tryCancelOp.getResult())),
+           /*diagonalEffectRecipientCTAs=*/true});
+      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
+                                        tryCancelOp.getResult());
+    }
+    if (auto loadResultOp = dyn_cast<ttng::CLCLoadResultOp>(op)) {
+      info.emplace();
+      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
+                                        loadResultOp.getSrc());
+    }
+    if (auto storeOp = dyn_cast<ttng::TMAStoreLikeOpInterface>(op)) {
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
       info->commitKind = tti::CommitKind::TmaStore;
@@ -259,22 +286,6 @@ public:
            /*txCount=*/-txCount});
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
                                         gatherOp.getResult());
-    }
-    if (auto reduceOp = dyn_cast<ttng::AsyncTMAReduceOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
-      info->commitKind = tti::CommitKind::TmaStore;
-      info->implicitCommit = true;
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                        reduceOp.getSrc());
-    }
-    if (auto scatterOp = dyn_cast<ttng::AsyncTMAScatterOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
-      info->commitKind = tti::CommitKind::TmaStore;
-      info->implicitCommit = true;
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                        scatterOp.getSrc());
     }
     if (auto arriveOp = dyn_cast<ttng::ArriveBarrierOp>(op)) {
       info.emplace();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -35,7 +35,7 @@ public:
   bool isTMAOp(Operation *op) const override {
     return isa<ttng::AsyncTMACopyGlobalToLocalOp,
                ttng::AsyncTMACopyLocalToGlobalOp, ttng::AsyncTMAGatherOp,
-               ttng::AsyncTMAScatterOp>(op);
+               ttng::AsyncTMAReduceOp, ttng::AsyncTMAScatterOp>(op);
   }
 
   std::optional<BarrierInitInfo>
@@ -92,12 +92,14 @@ public:
     if (auto invalOp = dyn_cast<ttng::InvalBarrierOp>(op))
       mask = getBarrierMask(invalOp.getAlloc());
     if (auto copyOp = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
-      if (copyOp.getMulticast()) {
-        auto dstTy = cast<ttg::MemDescType>(copyOp.getResult().getType());
-        auto kBlock = StringAttr::get(op->getContext(), "block");
-        mask = toLinearLayout(dstTy).getFreeVariableMasks().lookup(kBlock);
-      }
+      if (copyOp.getMulticast())
+        mask = getBarrierMask(copyOp.getResult());
     }
+    if (auto gatherOp = dyn_cast<ttng::AsyncTMAGatherOp>(op))
+      if (gatherOp.getMulticast())
+        mask = getBarrierMask(gatherOp.getResult());
+    if (auto storeOp = dyn_cast<ttng::TMAStoreLikeOpInterface>(op))
+      mask = getBarrierMask(storeOp.getSrc());
 
     // In 2CTA tcgen05 and tmem_copy, only the even CTA in each (i, i^1) pair
     // issues the op.
@@ -238,16 +240,39 @@ public:
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
       info->pred = gatherOp.getPred();
+      int txCount = tti::getMemDescLength(gatherOp.getResult());
+      if (gatherOp.getMulticast()) {
+        auto resultTy = gatherOp.getResult().getType();
+        auto barrierTy = gatherOp.getBarrier().getType();
+        auto kBlock = StringAttr::get(op->getContext(), "block");
+        uint32_t resultMask =
+            toLinearLayout(resultTy).getFreeVariableMasks().lookup(kBlock);
+        uint32_t barrierMask =
+            toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock);
+        uint32_t collapsedMask = resultMask & barrierMask;
+        for (; collapsedMask; collapsedMask &= collapsedMask - 1)
+          txCount *= 2;
+      }
       info->barriers.push_back(
           {gatherOp.getBarrier(), nullptr, /*count=*/0,
            MemEffectsOpInfo::BarrierTrackingMode::EffectWrites,
-           /*txCount=*/-(int)tti::getMemDescLength(gatherOp.getResult())});
+           /*txCount=*/-txCount});
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
                                         gatherOp.getResult());
     }
+    if (auto reduceOp = dyn_cast<ttng::AsyncTMAReduceOp>(op)) {
+      info.emplace();
+      info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
+      info->commitKind = tti::CommitKind::TmaStore;
+      info->implicitCommit = true;
+      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
+                                        reduceOp.getSrc());
+    }
     if (auto scatterOp = dyn_cast<ttng::AsyncTMAScatterOp>(op)) {
       info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::None;
+      info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
+      info->commitKind = tti::CommitKind::TmaStore;
+      info->implicitCommit = true;
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
                                         scatterOp.getSrc());
     }
@@ -272,7 +297,8 @@ public:
     bool needsTmaStore = false;
     bool needsWgmma = false;
     module.walk([&](Operation *op) {
-      if (isa<ttng::AsyncTMACopyLocalToGlobalOp, ttng::TMAStoreWaitOp>(op))
+      if (isa<ttng::AsyncTMACopyLocalToGlobalOp, ttng::AsyncTMAReduceOp,
+              ttng::AsyncTMAScatterOp, ttng::TMAStoreWaitOp>(op))
         needsTmaStore = true;
       if (isa<ttng::WarpGroupDotOp, ttng::WarpGroupDotWaitOp>(op))
         needsWgmma = true;

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -24,6 +24,11 @@ static int __builtin_ctzll(unsigned long long x) {
 
 #endif
 
+using namespace mlir;
+using namespace mlir::triton;
+
+namespace {
+
 void printBasis(const llvm::SmallVector<int32_t> &basis,
                 const std::string &name) {
   llvm::errs() << name << ": ";
@@ -31,11 +36,6 @@ void printBasis(const llvm::SmallVector<int32_t> &basis,
     llvm::errs() << b << " ";
   llvm::errs() << "\n";
 }
-
-using namespace mlir;
-using namespace mlir::triton;
-
-namespace {
 
 // Goes from bases of the form [[1], [2], [4], [8]] to [1, 2, 4, 8]
 SmallVector<int32_t> flatten(const LinearLayout &ll, StringAttr dim) {
@@ -216,9 +216,6 @@ SmallVector<int32_t> complementBasis(ArrayRef<int32_t> basis, int32_t dim) {
 
   return comp;
 }
-} // namespace
-
-namespace mlir::triton::gpu {
 
 SmallVector<int32_t> intersectionBasis(ArrayRef<int32_t> b1,
                                        ArrayRef<int32_t> b2, int32_t dim) {
@@ -244,6 +241,10 @@ SmallVector<int32_t> intersectionBasis(ArrayRef<int32_t> b1,
     return nullspaceBasis(joint, dim);
   }
 }
+
+} // namespace
+
+namespace mlir::triton::gpu {
 
 std::pair<int, int> bankConflicts(ArrayRef<int32_t> tileSrc,
                                   ArrayRef<int32_t> tileDst,
@@ -342,7 +343,7 @@ int bankConflictsMemDesc(const LinearLayout &reg, const LinearLayout &smem,
       .first;
 }
 
-std::optional<SmallVector<int32_t>> optimalSwizzlingTile(
+static std::optional<SmallVector<int32_t>> optimalSwizzlingTile(
     const LinearLayout &a, const LinearLayout &b, int32_t nRegA, int32_t nRegB,
     ArrayRef<int32_t> laneIdTileA, ArrayRef<int32_t> laneIdTileB) {
   // For now se just implement the .v4 variants for all the instructions

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -317,31 +317,40 @@ ColumnAction actionRemoveBroadcastedRegs(const LinearLayout &layout) {
 }
 std::pair<int64_t, ColumnAction>
 actionAdditiveStrides(const LinearLayout &layout, const LinearLayout addrLayout,
-                      uint64_t maskSpanOffsets) {
+                      uint64_t maskSpanOffsets, int64_t regsPerInst) {
   // General idea:
-  // We wan to swap an xor into an addition when computing the register offsets.
-  // We can do this if the output bits of this register are disjoint from those
-  // from lanes/warps/blocks or any affine offset (i.e., markSpanOffsets).
-
-  // Note this function assumes that if any registers are used in the addrLayout
-  // of the layout (as in ldmatrix/stmatrix) they will be the first non-zero
-  // registers within `layout`
+  // We want to swap an xor into an addition when computing the register
+  // offsets. We can do this if the output bits of this register are disjoint
+  // from those from lanes/warps/blocks or any affine offset (i.e.,
+  // maskSpanOffsets).
+  //
+  // Additionally, the lowering only ever evaluates register offsets at indices
+  // that are multiples of `regsPerInst` (the inner-loop stride, matching one
+  // vectorised instruction). The first `log2(regsPerInst)` register bases are
+  // therefore never selected by any computed index and are trivially additive,
+  // independent of their basis value. We force them into the "additive" group
+  // unconditionally so that the returned `nAdditive` is always at least
+  // `regsPerInst`. In particular, callers do not need to pre-zero those bases
+  // for the invariant to hold.
   assert(layout.getNumInDims() != 0);
+  assert(llvm::isPowerOf2_64(regsPerInst) &&
+         "regsPerInst must be a power of two");
   auto kReg = *layout.getInDimNames().begin();
   assert(kReg.str() == "register");
+  const size_t regBasisPerVec = llvm::Log2_64(regsPerInst);
   uint32_t bits = maskSpanOffsets;
-  llvm::SetVector<uint32_t> tileBases;
   auto addrNamedBases = addrLayout.flattenOuts().getBases();
   for (auto bases : llvm::make_second_range(addrNamedBases)) {
     for (auto basis : bases) {
       bits |= basis[0];
-      tileBases.insert(basis[0]);
     }
   }
   SmallVector<size_t> front, back;
   auto layoutNamedBases = layout.flattenOuts().getBases();
+  assert(layoutNamedBases.lookup(kReg).size() >= regBasisPerVec &&
+         "layout must have at least log2(regsPerInst) register bases");
   for (auto [idx, basis] : llvm::enumerate(layoutNamedBases.lookup(kReg))) {
-    if ((basis[0] & bits) == 0 || tileBases.contains(basis[0])) {
+    if (idx < regBasisPerVec || (basis[0] & bits) == 0) {
       front.push_back(idx);
     } else {
       back.push_back(idx);

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -36,7 +36,9 @@ namespace ttng = triton::nvidia_gpu;
 namespace gluon = mlir::triton::gluon;
 namespace ttag = mlir::triton::amdgpu;
 
-static ttg::CGAEncodingAttr
+namespace {
+
+ttg::CGAEncodingAttr
 buildCgaLayoutAttr(MLIRContext *ctx,
                    const std::vector<std::vector<int32_t>> &layout,
                    unsigned rank) {
@@ -48,7 +50,7 @@ buildCgaLayoutAttr(MLIRContext *ctx,
   return ttg::CGAEncodingAttr::get(ctx, std::move(ll));
 }
 
-static std::vector<std::vector<int32_t>>
+std::vector<std::vector<int32_t>>
 getCgaLayoutBases(ttg::CGAEncodingAttr layout) {
   std::vector<std::vector<int32_t>> result;
   auto ctx = layout.getContext();
@@ -61,15 +63,14 @@ getCgaLayoutBases(ttg::CGAEncodingAttr layout) {
 
 // Helper to check if an MLIR type or attribute has a verifier method.
 template <typename AttrOrType>
-static constexpr auto hasVerifier(AttrOrType t)
-    -> decltype(t.verifyInvariants, true) {
+constexpr auto hasVerifier(AttrOrType t) -> decltype(t.verifyInvariants, true) {
   return true;
 }
-static constexpr auto hasVerifier(...) { return false; }
+constexpr auto hasVerifier(...) { return false; }
 
 // Print a diagnostic without its location. The frontend will attach the AST
 // location to the error message.
-static void printDiagStr(llvm::raw_ostream &os, const Diagnostic &diag) {
+void printDiagStr(llvm::raw_ostream &os, const Diagnostic &diag) {
   for (const DiagnosticArgument &arg : diag.getArguments())
     arg.print(os);
   os << "\n";
@@ -192,7 +193,7 @@ struct GluonLayouts {
   }
 };
 
-static bool isConvertLayoutTrivial(RankedTensorType dstTy, Value value) {
+bool isConvertLayoutTrivial(RankedTensorType dstTy, Value value) {
   auto srcTy = cast<RankedTensorType>(value.getType());
   if (srcTy.getEncoding() == dstTy.getEncoding())
     return true;
@@ -337,10 +338,12 @@ py::object layoutToGluon(Attribute layout, bool isRubin = false) {
   throw py::value_error("Unhandled encoding encountered");
 }
 
-template <typename CondT> static void check(CondT &&cond, const char *msg) {
+template <typename CondT> void check(CondT &&cond, const char *msg) {
   if (!std::forward<CondT>(cond))
     throw py::value_error(msg);
 }
+
+} // namespace
 
 void init_gluon_ir(py::module &&m) {
   using ret = py::return_value_policy;

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -225,8 +225,8 @@ py::object layoutToGluon(Attribute layout, bool isRubin = false) {
   } else if (auto sliced = dyn_cast<ttg::SliceEncodingAttr>(layout)) {
     return layouts.SliceLayout(sliced.getDim(),
                                layoutToGluon(sliced.getParent(), isRubin));
-  } else if (auto linear = dyn_cast<ttg::LinearEncodingAttr>(layout)) {
-    const auto &ll = linear.getLinearLayout();
+  } else if (auto linearEnc = dyn_cast<ttg::LinearEncodingTrait>(layout)) {
+    const auto &ll = linearEnc.getLinearLayout();
     auto ctx = layout.getContext();
     auto kReg = mlir::StringAttr::get(ctx, "register");
     auto kLane = mlir::StringAttr::get(ctx, "lane");
@@ -424,7 +424,9 @@ void init_gluon_ir(py::module &&m) {
                                          {kBlock, blockBases}},
                                         outDims,
                                         /*requiresSurjective=*/true);
-             return ttg::LinearEncodingAttr::get(ctx, std::move(ll));
+             if (ttg::isPermutationMatrixLayout(ll))
+               return ttg::LinearEncodingAttr::get(ctx, std::move(ll));
+             return ttg::GenericLinearEncodingAttr::get(ctx, std::move(ll));
            })
       .def("to_linear_layout",
            [](GluonOpBuilder &self, Attribute layout,

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1039,12 +1039,15 @@ void init_gluon_ir(py::module &&m) {
            [](GluonOpBuilder &self, int pendings, bool readOnly) {
              self.create<ttng::TMAStoreWaitOp>(pendings, readOnly);
            })
-      .def("create_async_tma_gather",
-           [](GluonOpBuilder &self, Value descPtr, Value xOffsets,
-              Value yOffset, Value barrier, Value result, Value pred) {
-             self.create<ttng::AsyncTMAGatherOp>(descPtr, xOffsets, yOffset,
-                                                 barrier, result, pred);
-           })
+      .def(
+          "create_async_tma_gather",
+          [](GluonOpBuilder &self, Value descPtr, Value xOffsets, Value yOffset,
+             Value barrier, Value result, Value pred, bool multicast) {
+            multicast &=
+                ttng::hasCGABroadcast(cast<ttg::MemDescType>(result.getType()));
+            self.create<ttng::AsyncTMAGatherOp>(
+                descPtr, xOffsets, yOffset, barrier, result, pred, multicast);
+          })
       .def("create_async_tma_scatter",
            [](GluonOpBuilder &self, Value descPtr, Value xOffsets,
               Value yOffset, Value src) {

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1,6 +1,7 @@
 #include "ir.h"
 
 #include <algorithm>
+#include <cstring>
 #include <optional>
 #include <pybind11/cast.h>
 #include <pybind11/functional.h>
@@ -2257,6 +2258,8 @@ void init_triton_ir(py::module &&m) {
           py::call_guard<py::gil_scoped_release>());
 }
 
+namespace {
+
 bool str_eq_ignore_case(const char *s1, const char *s2, int n) {
   for (int i = 0; i < n; ++i) {
     if (tolower(s1[i]) != s2[i])
@@ -2265,17 +2268,10 @@ bool str_eq_ignore_case(const char *s1, const char *s2, int n) {
   return true;
 }
 
-int strlen_max(const char *str, int max) {
-  for (int i = 0; i <= max; ++i) {
-    if (str[i] == '\0') {
-      return i;
-    }
-  }
-  return 0;
-}
-
 bool is_truthy(char *str) {
-  int len = strlen_max(str, 4);
+  int len = strnlen(str, 5);
+  if (len > 4)
+    return false;
   switch (len) {
   case 1:
     return str[0] == '1' || tolower(str[0]) == 'y';
@@ -2330,11 +2326,13 @@ PyObject *py_getenv_bool(PyObject *self, PyObject *const *args,
   return res;
 }
 
-static PyMethodDef ModuleMethods[] = {
+PyMethodDef ModuleMethods[] = {
     {"getenv", (PyCFunction)py_getenv, METH_FASTCALL, NULL},
     {"getenv_bool", (PyCFunction)py_getenv_bool, METH_FASTCALL, NULL},
     {NULL, NULL, 0, NULL} // sentinel
 };
+
+} // namespace
 
 void init_triton_env_vars(py::module &m) {
   m.def("get_cache_invalidating_env_vars",

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -52,6 +52,8 @@ struct BreakStructPhiNodesPass : PassInfoMixin<BreakStructPhiNodesPass> {
 
 using namespace llvm;
 
+namespace {
+
 // Set an LLVM command-line option using addOccurrence (simulates command-line)
 // and return its original value. Using addOccurrence instead of setValue is
 // necessary because some LLVM passes (like schedulers) check whether the option
@@ -524,6 +526,8 @@ translateMIRToASM(const std::string &mirPath, const std::string &triple,
 
 using ret = py::return_value_policy;
 
+} // namespace
+
 void init_triton_llvm(py::module &&m) {
 
   py::class_<llvm::LLVMContext>(m, "context", py::module_local())
@@ -964,7 +968,7 @@ void init_triton_llvm(py::module &&m) {
   });
 }
 
-void triton_stacktrace_signal_handler(void *) {
+static void triton_stacktrace_signal_handler(void *) {
   llvm::sys::PrintStackTrace(llvm::errs());
   raise(SIGABRT);
 }

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -20,6 +20,8 @@
 
 namespace py = pybind11;
 
+namespace {
+
 void init_triton_analysis(py::module &&m) {
   py::class_<mlir::ModuleAllocation>(m, "allocation", py::module_local())
       .def(py::init<mlir::ModuleOp>());
@@ -152,6 +154,8 @@ void init_gluon_passes(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_infer_coalesced_encodings",
                      gluon::createGluonInferCoalescedEncodingsPass);
 }
+
+} // namespace
 
 void init_triton_passes(py::module &&m) {
   init_triton_analysis(m.def_submodule("analysis"));

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -8,7 +8,7 @@ from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia import blackwell
 from triton.experimental.gluon.language.nvidia import hopper
 from triton.experimental.gluon.language.nvidia import ampere
-from triton.experimental.gluon.language.nvidia.blackwell import allocate_tensor_memory, mbarrier, tma
+from triton.experimental.gluon.language.nvidia.blackwell import allocate_tensor_memory, clc, mbarrier, tma
 from triton._internal_testing import is_cuda, run_in_process
 
 
@@ -331,6 +331,44 @@ def test_async_tma_multicast_kernel_two_cta_barrier(TWO_CTA_BARRIER, device, run
                                            cga_layout=multicast_cga_layout(num_ctas, 2))
     input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK.value, XBLOCK.value], shared_layout)
     kernel[(1, )](input_desc, output, TWO_CTA_BARRIER=TWO_CTA_BARRIER, num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 10, reason="Requires blackwell")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_clc_result_visibility(FAILURE, device, run_wrapper, monkeypatch, num_ctas):
+    if run_wrapper:
+        result = run_in_process(test_clc_result_visibility, (FAILURE, device, False, monkeypatch, num_ctas))
+        if FAILURE:
+            assert_expected_cuda_failure(result.exc)
+            assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(out, FAILURE: ttgl.constexpr):
+        cga_layout: ttgl.constexpr = multicast_cga_layout(ttgl.num_ctas(), 1)
+        layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0], cga_layout=cga_layout)
+        clc_result = ttgl.allocate_shared_memory(ttgl.int64, [2], layout)
+        clc_bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(clc_bar, count=1)
+
+        clc.try_cancel(clc_result, clc_bar)
+        mbarrier.expect(clc_bar, 16)
+        mbarrier.wait(clc_bar, 0, pred=(not FAILURE))
+        response = clc.load_result(clc_result)
+        mbarrier.wait(clc_bar, 0, pred=FAILURE)
+        mbarrier.invalidate(clc_bar)
+
+        ttgl.store(out + ttgl.program_id(0), response.is_canceled())
+
+    output = torch.empty((1, ), device=device, dtype=torch.bool)
+    kernel[(1, )](output, FAILURE=FAILURE, num_warps=4, num_ctas=num_ctas)
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -29,6 +29,7 @@ from triton.experimental.gluon.language.nvidia.ampere import async_copy, mma_v2
 from triton.experimental.gluon.language.nvidia.hopper import tma, mbarrier, fence_async_shared
 from triton.experimental.gluon.language.nvidia import hopper
 from triton.experimental.gluon.language.nvidia import rubin
+from triton.experimental.gluon.language.nvidia.blackwell import tma as blackwell_tma
 from triton.experimental.gluon.language.amd.cdna4 import async_copy as cdna4_async_copy
 from triton.experimental.gluon.language.extra import libdevice
 from triton.experimental.gluon.language.nvidia.blackwell import (
@@ -317,6 +318,87 @@ def test_tma_multicast_copy(ctas_per_cga):
     expect_multicast = any(ctas_per_cga[i] > cga_split_num[i] for i in range(len(ctas_per_cga)))
     assert (".multicast::cluster" in compiled.asm["ptx"]) == expect_multicast
     torch.testing.assert_close(out, inp, atol=0, rtol=0)
+
+
+@gluon.jit
+def tma_gather_scatter_kernel(in_desc, gather_out_desc, scatter_out_desc, gather_idx_ptr, scatter_idx_ptr,
+                              BLOCK_M: ttgl.constexpr, x_offsets_layout: ttgl.constexpr):
+    smem = ttgl.allocate_shared_memory(in_desc.dtype, [BLOCK_M, gather_out_desc.block_shape[1]], gather_out_desc.layout)
+
+    bar = mbarrier.allocate_mbarrier()
+    mbarrier.init(bar, count=1)
+
+    gather_offsets = ttgl.load(gather_idx_ptr + ttgl.arange(0, BLOCK_M, layout=x_offsets_layout))
+    mbarrier.expect(bar, smem.nbytes_per_cta)
+    blackwell_tma.async_gather(in_desc, gather_offsets, 0, bar, smem, multicast=True)
+    mbarrier.wait(bar, phase=0, deps=[smem])
+
+    mbarrier.invalidate(bar)
+
+    scatter_offsets = ttgl.load(scatter_idx_ptr + ttgl.arange(0, BLOCK_M, layout=x_offsets_layout))
+    tma.async_copy_shared_to_global(gather_out_desc, [0, 0], smem)
+    blackwell_tma.async_scatter(scatter_out_desc, scatter_offsets, 0, smem)
+    tma.store_wait(0)
+
+    smem._keep_alive()
+
+
+def get_split_dim(cga_layout, dim):
+    return 1 << sum(basis[dim] != 0 for basis in cga_layout)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("cga_layout", [
+    [[1, 0]],
+    [[0, 0], [1, 0]],
+    [[1, 0], [0, 0]],
+    [[1, 0], [2, 0]],
+])
+def test_tma_gather_scatter_multi_cta(cga_layout):
+    cga_split_num = [get_split_dim(cga_layout, dim) for dim in range(2)]
+
+    BLOCK_M = 32 * cga_split_num[0]
+    BLOCK_N = 128 * cga_split_num[1]
+
+    inp = torch.arange(BLOCK_M * BLOCK_N, dtype=torch.float16, device="cuda").reshape(BLOCK_M, BLOCK_N)
+    gather_idx = torch.arange(BLOCK_M - 1, -1, -1, dtype=torch.int32, device="cuda")
+    scatter_idx = (torch.arange(0, BLOCK_M, dtype=torch.int32, device="cuda") + 1) % BLOCK_M
+    gather_out = torch.empty_like(inp)
+    scatter_out = torch.zeros_like(inp)
+
+    layout = ttgl.NVMMASharedLayout.get_default_for(
+        [BLOCK_M, BLOCK_N],
+        ttgl.float16,
+        cga_layout=cga_layout,
+    )
+    in_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(inp, [1, BLOCK_N // cga_split_num[1]], layout)
+    gather_out_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(gather_out, [BLOCK_M, BLOCK_N], layout)
+    scatter_out_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(scatter_out, [1, BLOCK_N // cga_split_num[1]],
+                                                                        layout)
+
+    offset_layout = ttgl.BlockedLayout([4, 1], [1, 32], [4, 1], [0, 1], cga_layout=cga_layout)
+    x_offsets_layout = ttgl.SliceLayout(1, offset_layout)
+
+    num_ctas = 1 << len(cga_layout)
+    compiled = tma_gather_scatter_kernel[(1, )](
+        in_desc,
+        gather_out_desc,
+        scatter_out_desc,
+        gather_idx,
+        scatter_idx,
+        BLOCK_M,
+        x_offsets_layout,
+        num_warps=4,
+        num_ctas=num_ctas,
+    )
+
+    expected_gather = inp[gather_idx.to(torch.int64)]
+    expected_scatter = torch.zeros_like(inp)
+    expected_scatter[scatter_idx.to(torch.int64)] = expected_gather
+    expect_multicast = any(all(coord == 0 for coord in basis) for basis in cga_layout)
+    assert (".multicast::cluster" in compiled.asm["ptx"]) == expect_multicast
+    torch.testing.assert_close(gather_out, expected_gather, atol=0, rtol=0)
+    torch.testing.assert_close(scatter_out, expected_scatter, atol=0, rtol=0)
 
 
 @gluon.jit
@@ -894,11 +976,13 @@ def test_tcgen05_mma_two_ctas_transposed_lhs_shared_layout():
 
 
 @gluon.jit
-def tma_mma_shared_inputs_kernel(a_desc, b_desc, out_ptr, BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr,
-                                 BLOCK_K: ttgl.constexpr, NUM_K_TILES: ttgl.constexpr, block_layout_c: ttgl.constexpr,
+def tma_mma_shared_inputs_kernel(a_desc, b_desc, out_ptr, out_desc, gather_idx_ptr, scatter_idx_ptr,
+                                 BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr, BLOCK_K: ttgl.constexpr,
+                                 NUM_K_TILES: ttgl.constexpr, block_layout_c: ttgl.constexpr,
                                  acc_layout: ttgl.constexpr, acc_tmem_layout: ttgl.constexpr,
-                                 use_tcgen05: ttgl.constexpr, multicast: ttgl.constexpr):
-    smem_a = ttgl.allocate_shared_memory(a_desc.dtype, a_desc.block_shape, a_desc.layout)
+                                 use_tcgen05: ttgl.constexpr, multicast: ttgl.constexpr,
+                                 use_gather_scatter: ttgl.constexpr):
+    smem_a = ttgl.allocate_shared_memory(a_desc.dtype, [BLOCK_M, BLOCK_K], a_desc.layout)
     smem_b = ttgl.allocate_shared_memory(b_desc.dtype, b_desc.block_shape, b_desc.layout)
 
     two_ctas: ttgl.constexpr = isinstance(acc_tmem_layout, TensorMemoryLayout) and acc_tmem_layout.two_ctas
@@ -919,9 +1003,17 @@ def tma_mma_shared_inputs_kernel(a_desc, b_desc, out_ptr, BLOCK_M: ttgl.constexp
     else:
         acc = ttgl.zeros([BLOCK_M, BLOCK_N], dtype=ttgl.float32, layout=acc_layout)
 
+    if use_gather_scatter:
+        gather_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
+            1, ttgl.BlockedLayout([4, 1], [1, 32], [ttgl.num_warps(), 1], [0, 1], cga_layout=a_desc.layout.cga_layout))
+        gather_offsets = ttgl.load(gather_idx_ptr + ttgl.arange(0, BLOCK_M, layout=gather_offsets_layout))
+
     for k in range(NUM_K_TILES):
-        mbarrier.expect(tma_bar, a_desc.nbytes_per_cta + b_desc.nbytes_per_cta)
-        tma.async_copy_global_to_shared(a_desc, [0, k * BLOCK_K], tma_bar, smem_a, multicast=multicast)
+        mbarrier.expect(tma_bar, smem_a.nbytes_per_cta + smem_b.nbytes_per_cta)
+        if use_gather_scatter:
+            blackwell_tma.async_gather(a_desc, gather_offsets, k * BLOCK_K, tma_bar, smem_a, multicast=multicast)
+        else:
+            tma.async_copy_global_to_shared(a_desc, [0, k * BLOCK_K], tma_bar, smem_a, multicast=multicast)
         tma.async_copy_global_to_shared(b_desc, [k * BLOCK_K, 0], tma_bar, smem_b, multicast=multicast)
         mbarrier.wait(tma_bar, phase=phase_tma, deps=[smem_a, smem_b])
         phase_tma ^= 1
@@ -944,9 +1036,19 @@ def tma_mma_shared_inputs_kernel(a_desc, b_desc, out_ptr, BLOCK_M: ttgl.constexp
         acc = acc_tmem.load()
 
     acc = ttgl.convert_layout(acc, block_layout_c)
-    offs_m = ttgl.arange(0, BLOCK_M)[:, None]
-    offs_n = ttgl.arange(0, BLOCK_N)[None, :]
-    ttgl.store(out_ptr + offs_m * BLOCK_N + offs_n, acc)
+    if use_gather_scatter:
+        scatter_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
+            1, ttgl.BlockedLayout([4, 1], [1, 32], [ttgl.num_warps(), 1], [0, 1],
+                                  cga_layout=out_desc.layout.cga_layout))
+        scatter_offsets = ttgl.load(scatter_idx_ptr + ttgl.arange(0, BLOCK_M, layout=scatter_offsets_layout))
+        acc_smem = ttgl.allocate_shared_memory(out_desc.dtype, [BLOCK_M, BLOCK_N], out_desc.layout, acc)
+        blackwell_tma.async_scatter(out_desc, scatter_offsets, 0, acc_smem)
+        tma.store_wait(0)
+        acc_smem._keep_alive()
+    else:
+        offs_m = ttgl.arange(0, BLOCK_M)[:, None]
+        offs_n = ttgl.arange(0, BLOCK_N)[None, :]
+        ttgl.store(out_ptr + offs_m * BLOCK_N + offs_n, acc)
 
 
 @pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell")
@@ -955,7 +1057,8 @@ def tma_mma_shared_inputs_kernel(a_desc, b_desc, out_ptr, BLOCK_M: ttgl.constexp
 @pytest.mark.parametrize("ctas_per_cga", [[1, 1], [2, 1], [4, 4]])
 @pytest.mark.parametrize("two_ctas", [False, True] if is_blackwell() else [False])
 @pytest.mark.parametrize("multicast", [False, True])
-def test_tma_mma_shared_inputs(warps, reps, ctas_per_cga, two_ctas, multicast):
+@pytest.mark.parametrize("use_gather_scatter", [False, True] if is_blackwell() else [False])
+def test_tma_mma_shared_inputs(warps, reps, ctas_per_cga, two_ctas, multicast, use_gather_scatter):
     bitwidth = 16
     acc_dtype = torch.float32
 
@@ -1027,19 +1130,26 @@ def test_tma_mma_shared_inputs(warps, reps, ctas_per_cga, two_ctas, multicast):
     gluon_dtype = ttgl.float16
     shared_layout_a = ttgl.NVMMASharedLayout.get_default_for([BLOCK_M, BLOCK_K], gluon_dtype, cga_layout=cga_layout_a)
     shared_layout_b = ttgl.NVMMASharedLayout.get_default_for([BLOCK_K, BLOCK_N], gluon_dtype, cga_layout=cga_layout_b)
+    shared_layout_c = ttgl.NVMMASharedLayout.get_default_for([BLOCK_M, BLOCK_N], ttgl.float32, cga_layout=cga_layout_c)
     assert shared_layout_a.swizzle_byte_width != 0
     assert shared_layout_b.swizzle_byte_width != 0
-    a_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(a, [BLOCK_M, BLOCK_K], shared_layout_a)
+    a_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(a, [1 if use_gather_scatter else BLOCK_M, BLOCK_K],
+                                                              shared_layout_a)
     b_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(b, [BLOCK_K, BLOCK_N], shared_layout_b)
-
     num_warps = warps[0] * warps[1]
     num_ctas = ctas_per_cga[0] * ctas_per_cga[1]
+    out_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(out, [1, BLOCK_N], shared_layout_c)
+    gather_idx = torch.arange(BLOCK_M - 1, -1, -1, dtype=torch.int32, device=device)
+    scatter_idx = (torch.arange(0, BLOCK_M, dtype=torch.int32, device=device) + 1) % BLOCK_M
 
     try:
         tma_mma_shared_inputs_kernel[(1, )](
             a_desc,
             b_desc,
             out,
+            out_desc,
+            gather_idx,
+            scatter_idx,
             BLOCK_M,
             BLOCK_N,
             BLOCK_K,
@@ -1049,6 +1159,7 @@ def test_tma_mma_shared_inputs(warps, reps, ctas_per_cga, two_ctas, multicast):
             acc_tmem_layout,
             is_blackwell(),
             multicast=multicast,
+            use_gather_scatter=use_gather_scatter,
             num_warps=num_warps,
             num_ctas=num_ctas,
         )
@@ -1058,7 +1169,13 @@ def test_tma_mma_shared_inputs(warps, reps, ctas_per_cga, two_ctas, multicast):
     try:
         allow_tf32 = torch.backends.cuda.matmul.allow_tf32
         torch.backends.cuda.matmul.allow_tf32 = True
-        ref = torch.matmul(a.to(torch.float32), b.to(torch.float32))
+        if use_gather_scatter:
+            matmul = torch.matmul(a[gather_idx.to(torch.int64)].to(torch.float32), b.to(torch.float32))
+            ref = torch.empty_like(matmul)
+            # Correct as scatter_idx is a permutation!
+            ref[scatter_idx.to(torch.int64)] = matmul
+        else:
+            ref = torch.matmul(a.to(torch.float32), b.to(torch.float32))
     finally:
         torch.backends.cuda.matmul.allow_tf32 = allow_tf32
 

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -2266,6 +2266,44 @@ def test_atomic_rmw():
 
 @filecheck_test
 @gluon.jit
+def test_atomic_rmw_scalar_masks():
+    # CHECK-LABEL: test_atomic_rmw_scalar_masks
+    BLOCK: ttgl.constexpr = 128
+    x = ttgl.full([BLOCK], 0, ttgl.int64)
+    ptr = x.cast(ttgl.pointer_type(ttgl.int32), bitcast=True)
+    offs = ttgl.arange(0, BLOCK)
+    ptrs = ptr + offs
+    val = ttgl.full([BLOCK], 1, ttgl.int32)
+    mask = offs >= 0
+    scalar_mask = True
+    constexpr_value: ttgl.constexpr = 1
+    constexpr_mask: ttgl.constexpr = True
+
+    # CHECK: {{.*}} = tt.atomic_rmw add, acq_rel, gpu
+    ttgl.atomic_add(ptrs, val, mask=mask)
+    # CHECK: {{.*}} = tt.atomic_rmw add, acq_rel, gpu
+    ttgl.atomic_add(ptrs, 1, mask=True)
+    # CHECK: {{.*}} = tt.atomic_rmw add, acq_rel, gpu
+    ttgl.atomic_add(ptrs, constexpr_value, mask=constexpr_mask)
+    # CHECK: {{.*}} = tt.atomic_rmw add, acq_rel, gpu
+    ttgl.atomic_add(ptrs, val, mask=scalar_mask)
+
+    # CHECK: {{.*}} = tt.atomic_rmw exch, acq_rel, gpu
+    ttgl.atomic_xchg(ptrs, 1, mask=True)
+    # CHECK: {{.*}} = tt.atomic_rmw max, acq_rel, gpu
+    ttgl.atomic_max(ptrs, 1, mask=True)
+    # CHECK: {{.*}} = tt.atomic_rmw min, acq_rel, gpu
+    ttgl.atomic_min(ptrs, 1, mask=True)
+    # CHECK: {{.*}} = tt.atomic_rmw and, acq_rel, gpu
+    ttgl.atomic_and(ptrs, 1, mask=True)
+    # CHECK: {{.*}} = tt.atomic_rmw or, acq_rel, gpu
+    ttgl.atomic_or(ptrs, 1, mask=True)
+    # CHECK: {{.*}} = tt.atomic_rmw xor, acq_rel, gpu
+    ttgl.atomic_xor(ptrs, 1, mask=True)
+
+
+@filecheck_test
+@gluon.jit
 def test_atomic_cas():
     # CHECK: {{.*}} = arith.constant dense<1> : tensor<1xi64, #gluon.auto_encoding>
     x0 = ttgl.full([1], 1, ttgl.int64, layout=ttgl.AutoLayout())

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -60,6 +60,7 @@ def anonymize_ir(ir):
     ir = TARGET_PAT.sub('ttg.target = "..."', ir)
     ir = PTRRANGE_PAT.sub("", ir)
     ir = LIBDEVICE_PAT.sub('{libname = "", libpath = "", pure = true, symbol = "..."}', ir)
+    ir = ir.replace("python.test.gluon.", "")
     return ir
 
 
@@ -974,12 +975,12 @@ def test_tcgen05_commit_multicast_two_ctas():
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @tcgen05_commit_multicast_two_ctas_kernel() attributes {noinline = false} {
-    %0 = tt.call @"triton.experimental.gluon.language.nvidia.ampere.mbarrier.allocate_mbarrier____(0,)cNone_(1,)cconstexpr_True_"() : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %0 = tt.call @"triton.experimental.gluon.language.nvidia.ampere.mbarrier.allocate_mbarrier____(0,)cconstexpr_None__(1,)cconstexpr_True_"() : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     %true = arith.constant true
     ttng.barrier_expect %0, 4, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     tt.return
   }
-  tt.func private @"triton.experimental.gluon.language.nvidia.ampere.mbarrier.allocate_mbarrier____(0,)cNone_(1,)cconstexpr_True_"() -> !ttg.memdesc<1xi64, #shared, #smem, mutable> attributes {noinline = false} {
+  tt.func private @"triton.experimental.gluon.language.nvidia.ampere.mbarrier.allocate_mbarrier____(0,)cconstexpr_None__(1,)cconstexpr_True_"() -> !ttg.memdesc<1xi64, #shared, #smem, mutable> attributes {noinline = false} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     tt.return %0 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
   ^bb1:  // no predecessors
@@ -1558,10 +1559,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %cst_0 = arith.constant dense<1.000000e+00> : tensor<16x16xf32, #blocked>
     %cst_1 = arith.constant 2.000000e+00 : f32
     %cst_2 = arith.constant dense<2.000000e+00> : tensor<16x16xf32, #blocked>
-    %0 = tt.call @"triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL__(1,)cconstexpr_0__(2,)cconstexpr_False__(3,)cNone_(4,)cNone"(%cst_0) : (tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
-    %1 = tt.call @"triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL__(1,)cconstexpr_1__(2,)cconstexpr_False__(3,)cNone_(4,)cNone"(%cst_0) : (tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    %2 = tt.call @"triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL__(1,)cNone_(2,)cconstexpr_False__(3,)cNone_(4,)cNone"(%cst_0) : (tensor<16x16xf32, #blocked>) -> f32
-    %3 = tt.call @"triton.language.standard.max__fp32S16SLSL0_B1_1_1_32_4_1_1_0_BSLL__(1,)cconstexpr_0__(2,)cconstexpr_False__(3,)cconstexpr_True__(4,)cconstexpr_False__(5,)cNone"(%0) : (tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> f32
+    %0 = tt.call @"triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL__(1,)cconstexpr_0__(2,)cconstexpr_False__(3,)cconstexpr_None__(4,)cconstexpr_None_"(%cst_0) : (tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %1 = tt.call @"triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL__(1,)cconstexpr_1__(2,)cconstexpr_False__(3,)cconstexpr_None__(4,)cconstexpr_None_"(%cst_0) : (tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %2 = tt.call @"triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL__(1,)cconstexpr_None__(2,)cconstexpr_False__(3,)cconstexpr_None__(4,)cconstexpr_None_"(%cst_0) : (tensor<16x16xf32, #blocked>) -> f32
+    %3 = tt.call @"triton.language.standard.max__fp32S16SLSL0_B1_1_1_32_4_1_1_0_BSLL__(1,)cconstexpr_0__(2,)cconstexpr_False__(3,)cconstexpr_True__(4,)cconstexpr_False__(5,)cconstexpr_None_"(%0) : (tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> f32
     %4 = ttg.convert_layout %1 : tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
     %5:2 = "tt.reduce"(%cst_0, %cst_2) <{axis = 0 : i32}> ({
     ^bb0(%arg1: f32, %arg2: f32, %arg3: f32, %arg4: f32):
@@ -1578,7 +1579,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.store %12, %9 : tensor<16x!tt.ptr<f32>, #ttg.slice<{dim = 0, parent = #blocked}>>
     tt.return
   }
-  tt.func private @"triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL__(1,)cconstexpr_0__(2,)cconstexpr_False__(3,)cNone_(4,)cNone"(%arg0: tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>> attributes {noinline = false} {
+  tt.func private @"triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL__(1,)cconstexpr_0__(2,)cconstexpr_False__(3,)cconstexpr_None__(4,)cconstexpr_None_"(%arg0: tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>> attributes {noinline = false} {
     %0 = "tt.reduce"(%arg0) <{axis = 0 : i32}> ({
     ^bb0(%arg1: f32, %arg2: f32):
       %2 = tt.call @triton.language.standard._sum_combine__fp32_fp32__(%arg1, %arg2) : (f32, f32) -> f32
@@ -1596,7 +1597,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %1 = ub.poison : f32
     tt.return %1 : f32
   }
-  tt.func private @"triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL__(1,)cconstexpr_1__(2,)cconstexpr_False__(3,)cNone_(4,)cNone"(%arg0: tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>> attributes {noinline = false} {
+  tt.func private @"triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL__(1,)cconstexpr_1__(2,)cconstexpr_False__(3,)cconstexpr_None__(4,)cconstexpr_None_"(%arg0: tensor<16x16xf32, #blocked>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>> attributes {noinline = false} {
     %0 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
     ^bb0(%arg1: f32, %arg2: f32):
       %2 = tt.call @triton.language.standard._sum_combine__fp32_fp32__(%arg1, %arg2) : (f32, f32) -> f32
@@ -1607,7 +1608,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %1 = ub.poison : tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
     tt.return %1 : tensor<16xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
   }
-  tt.func private @"triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL__(1,)cNone_(2,)cconstexpr_False__(3,)cNone_(4,)cNone"(%arg0: tensor<16x16xf32, #blocked>) -> f32 attributes {noinline = false} {
+  tt.func private @"triton.language.standard.sum__fp32S16_16SLB1_1_1_32_4_1_1_0_BL__(1,)cconstexpr_None__(2,)cconstexpr_False__(3,)cconstexpr_None__(4,)cconstexpr_None_"(%arg0: tensor<16x16xf32, #blocked>) -> f32 attributes {noinline = false} {
     %0 = tt.reshape %arg0 : tensor<16x16xf32, #blocked> -> tensor<256xf32, #linear>
     %1 = "tt.reduce"(%0) <{axis = 0 : i32}> ({
     ^bb0(%arg1: f32, %arg2: f32):
@@ -1619,7 +1620,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %2 = ub.poison : f32
     tt.return %2 : f32
   }
-  tt.func private @"triton.language.standard.max__fp32S16SLSL0_B1_1_1_32_4_1_1_0_BSLL__(1,)cconstexpr_0__(2,)cconstexpr_False__(3,)cconstexpr_True__(4,)cconstexpr_False__(5,)cNone"(%arg0: tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> f32 attributes {noinline = false} {
+  tt.func private @"triton.language.standard.max__fp32S16SLSL0_B1_1_1_32_4_1_1_0_BSLL__(1,)cconstexpr_0__(2,)cconstexpr_False__(3,)cconstexpr_True__(4,)cconstexpr_False__(5,)cconstexpr_None_"(%arg0: tensor<16xf32, #ttg.slice<{dim = 0, parent = #blocked}>>) -> f32 attributes {noinline = false} {
     %0 = "tt.reduce"(%arg0) <{axis = 0 : i32}> ({
     ^bb0(%arg1: f32, %arg2: f32):
       %2 = tt.call @triton.language.standard._elementwise_max__fp32_fp32__(%arg1, %arg2) : (f32, f32) -> f32
@@ -3292,7 +3293,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %cst_3 = arith.constant 0.000000e+00 : f32
     %cst_4 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma>
     %cst_5 = arith.constant 0.000000e+00 : f32
-    %0 = tt.dot %cst_0, %cst_2, %cst_4, inputPrecision = tf32 : tensor<64x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<32x64xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<64x64xf32, #mma>
+    %0 = tt.dot %cst_0, %cst_2, %cst_4 : tensor<64x32xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<32x64xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<64x64xf32, #mma>
     tt.return
   }
 }
@@ -3715,14 +3716,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     %cst_4 = arith.constant dense<1> : tensor<16x4xi8, #linear>
     %cst_5 = arith.constant 0.000000e+00 : f32
     %0 = tt.dot_scaled %cst scale %cst_3, %cst_0 scale %cst_4, %cst_2 lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<16x64xi8, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 16}>>, tensor<16x4xi8, #linear> * tensor<64x16xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 16}>>, tensor<16x4xi8, #linear> -> tensor<16x16xf32, #mma1>
-    %c3_i32 = arith.constant 3 : i32
-    %1 = arith.trunci %c3_i32 : i32 to i8
-    %c4_i32 = arith.constant 4 : i32
-    %2 = arith.trunci %c4_i32 : i32 to i8
-    %3 = tt.splat %1 : i8 -> tensor<16x4xi8, #linear>
-    %4 = tt.splat %2 : i8 -> tensor<16x4xi8, #linear>
-    %cst_6 = arith.constant 0.000000e+00 : f32
-    %5 = tt.dot_scaled %cst scale %3, %cst_0 scale %4, %cst_2 lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<16x64xi8, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 16}>>, tensor<16x4xi8, #linear> * tensor<64x16xi8, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 16}>>, tensor<16x4xi8, #linear> -> tensor<16x16xf32, #mma1>
     tt.return
   }
 }

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -162,6 +162,290 @@ def test_scan_blocked_broadcast_layout_multiblock(device):
     scan_kernel[(1, )](x, y, M, 1, src_layout, 0, num_warps=2)
 
 
+def _swizzled_warp_layouts_1d():
+    """1D DistributedLinearLayout test layouts (non-injective, lowered as GenericLinearEncoding)."""
+
+    def ilog2(x):
+        return x.bit_length() - 1
+
+    return [
+        # Non-injective 1D: warp bases overlap with lane coverage
+        ttgl.DistributedLinearLayout(
+            reg_bases=[[1], [2]],
+            lane_bases=[[4], [8], [16], [32], [64]] + ([[0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[64], [128]],
+            block_bases=[],
+            shape=[256],
+        ),
+        # Non-injective 1D: warp bases overlap with register coverage
+        ttgl.DistributedLinearLayout(
+            reg_bases=[[1], [2], [4]],
+            lane_bases=[[8], [16], [32], [64], [128]] + ([[0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[4], [256]],
+            block_bases=[],
+            shape=[512],
+        ),
+        # Non-power-of-two basis (96 = 64 + 32) in the warp bases
+        ttgl.DistributedLinearLayout(
+            reg_bases=[[1], [2]],
+            lane_bases=[[4], [8], [16], [32], [64]] + ([[0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[96], [128]],
+            block_bases=[],
+            shape=[256],
+        ),
+    ]
+
+
+def _swizzled_warp_layouts_2d():
+    """2D DistributedLinearLayout test layouts (swizzled warp bases and/or non-injective)."""
+
+    def ilog2(x):
+        return x.bit_length() - 1
+
+    return [
+        # Mildly swizzled: one warp base touches both dims
+        ttgl.DistributedLinearLayout(
+            reg_bases=[[1, 0], [0, 1]],
+            lane_bases=[[2, 0], [4, 0], [8, 0], [0, 2], [0, 4]] + ([[0, 0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[16, 8], [0, 8]],
+            block_bases=[],
+            shape=[32, 16],
+        ),
+        # Aggressively swizzled: both warp bases touch both dims
+        ttgl.DistributedLinearLayout(
+            reg_bases=[[1, 0], [0, 1]],
+            lane_bases=[[2, 0], [4, 0], [8, 0], [0, 2], [0, 4]] + ([[0, 0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[4, 2], [8, 4]],
+            block_bases=[],
+            shape=[16, 8],
+        ),
+        # Swizzled warp + broadcasting in registers
+        ttgl.DistributedLinearLayout(
+            reg_bases=[[1, 0], [0, 0], [0, 1]],
+            lane_bases=[[2, 0], [4, 0], [8, 0], [0, 2], [0, 4]] + ([[0, 0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[16, 8], [0, 8]],
+            block_bases=[],
+            shape=[32, 16],
+        ),
+        # non-injective
+        ttgl.DistributedLinearLayout(
+            reg_bases=[[0, 1], [0, 2], [0, 4], [0, 16], [32, 0]],
+            lane_bases=[[1, 0], [2, 0], [4, 0], [8, 0], [0, 8]] + ([[0, 0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[32, 0], [16, 0]],
+            block_bases=[],
+            shape=[64, 32],
+        ),
+        # non-power-of-two basis (24 = 16 + 8) in the warp bases
+        ttgl.DistributedLinearLayout(
+            reg_bases=[[1, 0], [0, 1]],
+            lane_bases=[[2, 0], [4, 0], [8, 0], [0, 2], [0, 4]] + ([[0, 0]] * (ilog2(THREADS_PER_WARP) - 5)),
+            warp_bases=[[24, 0], [0, 8]],
+            block_bases=[],
+            shape=[32, 16],
+        ),
+    ]
+
+
+def _swizzled_warp_layouts():
+    """All swizzled/non-injective DistributedLinearLayout test layouts (1D and 2D)."""
+    return _swizzled_warp_layouts_1d() + _swizzled_warp_layouts_2d()
+
+
+# ===--- Tests with swizzled/non-injective DistributedLinearLayout ---===
+
+
+@pytest.mark.parametrize("src_layout", _filter_layouts(_swizzled_warp_layouts()))
+def test_elementwise_generic_linear(src_layout, device):
+    shape = src_layout.shape
+    num_warps = 2**len(src_layout.warp_bases)
+
+    if len(shape) == 1:
+        N, = shape
+
+        @gluon.jit
+        def kernel(x_ptr, y_ptr, N: ttgl.constexpr, layout: ttgl.constexpr):
+            offs = ttgl.arange(0, N, layout=layout)
+            x = ttgl.load(x_ptr + offs)
+            y = x * x + x
+            ttgl.store(y_ptr + offs, y)
+
+        x = torch.randn(N, dtype=torch.float32, device=device)
+        y = torch.empty_like(x)
+        kernel[(1, )](x, y, N, src_layout, num_warps=num_warps)
+    else:
+        M, N = shape
+
+        @gluon.jit
+        def kernel(x_ptr, y_ptr, M: ttgl.constexpr, N: ttgl.constexpr, layout: ttgl.constexpr):
+            offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, layout))[:, None]
+            offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, layout))[None, :]
+            x = ttgl.load(x_ptr + offs_m * N + offs_n)
+            y = x * x + x
+            ttgl.store(y_ptr + offs_m * N + offs_n, y)
+
+        x = torch.randn((M, N), dtype=torch.float32, device=device)
+        y = torch.empty_like(x)
+        kernel[(1, )](x, y, M, N, src_layout, num_warps=num_warps)
+
+    torch.testing.assert_close(y, x * x + x)
+
+
+@pytest.mark.parametrize("src_layout", _filter_layouts(_swizzled_warp_layouts_2d()))
+def test_expand_dims_generic_linear(src_layout, device):
+    M, N = src_layout.shape
+    num_warps = 2**len(src_layout.warp_bases)
+
+    @gluon.jit
+    def kernel(x_ptr, y_ptr, M: ttgl.constexpr, layout: ttgl.constexpr):
+        offs = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, layout))
+        x = ttgl.load(x_ptr + offs)
+        x_2d = ttgl.expand_dims(x, axis=1)
+        offs_2d = ttgl.expand_dims(offs, axis=1)
+        ttgl.store(y_ptr + offs_2d, x_2d)
+
+    torch.manual_seed(17)
+    x = torch.randint(0, 4, (M, 1), dtype=torch.float32, device=device)
+    y = torch.zeros((M, 1), dtype=torch.float32, device=device)
+    kernel[(1, )](x, y, M, src_layout, num_warps=num_warps)
+    torch.testing.assert_close(y, x)
+
+
+@pytest.mark.parametrize("src_layout", _filter_layouts(_swizzled_warp_layouts()))
+def test_reshape_generic_linear(src_layout, device):
+    shape = src_layout.shape
+    num_warps = 2**len(src_layout.warp_bases)
+    total = 1
+    for s in shape:
+        total *= s
+
+    if len(shape) == 1:
+        N, = shape
+
+        @gluon.jit
+        def kernel(x_ptr, y_ptr, N: ttgl.constexpr, layout: ttgl.constexpr):
+            offs = ttgl.arange(0, N, layout=layout)
+            x = ttgl.load(x_ptr + offs)
+            reshaped = x.reshape([N // 2, 2])
+            flat = reshaped.reshape([N])
+            ttgl.store(y_ptr + offs, flat)
+
+        torch.manual_seed(0)
+        x = torch.randn(N, dtype=torch.float32, device=device)
+        y = torch.zeros_like(x)
+        kernel[(1, )](x, y, N, src_layout, num_warps=num_warps)
+    else:
+        M, N = shape
+
+        @gluon.jit
+        def kernel(x_ptr, y_ptr, M: ttgl.constexpr, N: ttgl.constexpr, layout: ttgl.constexpr):
+            offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, layout))[:, None]
+            offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, layout))[None, :]
+            x = ttgl.load(x_ptr + offs_m * N + offs_n)
+            flat = x.reshape([M * N])
+            y = flat.reshape([M, N])
+            ttgl.store(y_ptr + offs_m * N + offs_n, y)
+
+        torch.manual_seed(0)
+        x = torch.randn((M, N), dtype=torch.float32, device=device)
+        y = torch.zeros_like(x)
+        kernel[(1, )](x, y, M, N, src_layout, num_warps=num_warps)
+
+    torch.testing.assert_close(y, x)
+
+
+@pytest.mark.parametrize("src_layout", _filter_layouts(_swizzled_warp_layouts_2d()))
+def test_permute_generic_linear(src_layout, device):
+    M, N = src_layout.shape
+    num_warps = 2**len(src_layout.warp_bases)
+
+    @gluon.jit
+    def kernel(x_ptr, y_ptr, M: ttgl.constexpr, N: ttgl.constexpr, layout: ttgl.constexpr):
+        offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, layout))[:, None]
+        offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, layout))[None, :]
+        x = ttgl.load(x_ptr + offs_m * N + offs_n)
+        xt = ttgl.permute(x, [1, 0])
+        y = ttgl.permute(xt, [1, 0])
+        ttgl.store(y_ptr + offs_m * N + offs_n, y)
+
+    torch.manual_seed(0)
+    x = torch.randn((M, N), dtype=torch.float32, device=device)
+    y = torch.zeros_like(x)
+    kernel[(1, )](x, y, M, N, src_layout, num_warps=num_warps)
+    torch.testing.assert_close(y, x)
+
+
+@pytest.mark.parametrize("src_layout", _filter_layouts(_swizzled_warp_layouts()))
+def test_split_join_generic_linear(src_layout, device):
+    if any(all(v == 0 for v in b) for b in src_layout.reg_bases):
+        pytest.skip(
+            "Broadcast register bases cause join/split types mismatch. This is not related to GenericLinearEncodingAttr."
+        )
+    shape = src_layout.shape
+    num_warps = 2**len(src_layout.warp_bases)
+
+    if len(shape) == 1:
+        N, = shape
+
+        @gluon.jit
+        def kernel(x_ptr, y_ptr, N: ttgl.constexpr, layout: ttgl.constexpr):
+            offs = ttgl.arange(0, N, layout=layout)
+            x = ttgl.load(x_ptr + offs)
+            joined = ttgl.join(x, x * 2)
+            a, b = ttgl.split(joined)
+            result = a + b
+            result_layout: ttgl.constexpr = result.type.layout
+            ttgl.store(y_ptr + ttgl.arange(0, N, layout=result_layout), result)
+
+        torch.manual_seed(0)
+        x = torch.randn(N, dtype=torch.float32, device=device)
+        y = torch.zeros_like(x)
+        kernel[(1, )](x, y, N, src_layout, num_warps=num_warps)
+    else:
+        M, N = shape
+
+        @gluon.jit
+        def kernel(x_ptr, y_ptr, M: ttgl.constexpr, N: ttgl.constexpr, layout: ttgl.constexpr):
+            offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, layout))[:, None]
+            offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, layout))[None, :]
+            x = ttgl.load(x_ptr + offs_m * N + offs_n)
+            joined = ttgl.join(x, x * 2)
+            a, b = ttgl.split(joined)
+            result = a + b
+            result_layout: ttgl.constexpr = result.type.layout
+            out_offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, result_layout))[:, None]
+            out_offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, result_layout))[None, :]
+            ttgl.store(y_ptr + out_offs_m * N + out_offs_n, result)
+
+        torch.manual_seed(0)
+        x = torch.randn((M, N), dtype=torch.float32, device=device)
+        y = torch.zeros_like(x)
+        kernel[(1, )](x, y, M, N, src_layout, num_warps=num_warps)
+
+    torch.testing.assert_close(y, x + x * 2)
+
+
+@pytest.mark.parametrize("src_layout", _filter_layouts(_swizzled_warp_layouts_2d()))
+def test_broadcast_generic_linear(src_layout, device):
+    M, N = src_layout.shape
+    num_warps = 2**len(src_layout.warp_bases)
+
+    @gluon.jit
+    def kernel(x_ptr, y_ptr, z_ptr, M: ttgl.constexpr, N: ttgl.constexpr, layout: ttgl.constexpr):
+        offs_m = ttgl.arange(0, M, layout=ttgl.SliceLayout(1, layout))[:, None]
+        offs_n = ttgl.arange(0, N, layout=ttgl.SliceLayout(0, layout))[None, :]
+        col = ttgl.load(x_ptr + offs_m)
+        row = ttgl.load(y_ptr + offs_n)
+        result = col + row
+        ttgl.store(z_ptr + offs_m * N + offs_n, result)
+
+    torch.manual_seed(0)
+    x = torch.randn(M, dtype=torch.float32, device=device)
+    y = torch.randn(N, dtype=torch.float32, device=device)
+    z = torch.zeros((M, N), dtype=torch.float32, device=device)
+    kernel[(1, )](x, y, z, M, N, src_layout, num_warps=num_warps)
+    torch.testing.assert_close(z, x[:, None] + y[None, :])
+
+
 def _funky_reduce_layouts():
 
     def ilog2(x):

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -446,6 +446,66 @@ def test_broadcast_generic_linear(src_layout, device):
     torch.testing.assert_close(z, x[:, None] + y[None, :])
 
 
+def _shared_layout_kinds():
+    kinds = ["swizzled_trivial", "swizzled", "padded"]
+    if is_hip():
+        kinds += ["partitioned_swizzled", "partitioned_padded"]
+    return kinds
+
+
+def _make_shared_layout(kind, shape):
+    order = list(reversed(range(len(shape))))
+    if kind == "swizzled_trivial":
+        return ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=order)
+    if kind == "swizzled":
+        return ttgl.SwizzledSharedLayout(vec=4, per_phase=2, max_phase=4, order=order)
+    if kind == "padded":
+        return ttgl.PaddedSharedLayout.with_identity_for(interval_padding_pairs=[[16, 4]], shape=list(shape),
+                                                         order=order)
+    if kind == "partitioned_swizzled":
+        inner = ttgl.SwizzledSharedLayout(vec=4, per_phase=2, max_phase=4, order=order)
+        return PartitionedSharedLayout(num_partitions=2, num_groups=1, partition_dim=0, partition_layout=inner)
+    if kind == "partitioned_padded":
+        inner = ttgl.PaddedSharedLayout.with_identity_for(interval_padding_pairs=[[16, 4]], shape=list(shape),
+                                                          order=order)
+        return PartitionedSharedLayout(num_partitions=2, num_groups=1, partition_dim=0, partition_layout=inner)
+    raise ValueError(f"Unknown shared layout kind: {kind}")
+
+
+@pytest.mark.parametrize("src_layout", _filter_layouts(_swizzled_warp_layouts()))
+@pytest.mark.parametrize("shared_kind", _shared_layout_kinds())
+def test_local_load_store_generic_linear(src_layout, shared_kind, device):
+    """Round-trip through shared memory using a swizzled/non-injective DistributedLinearLayout.
+
+    Exercises local_store (smem.store) and local_load (smem.load) lowerings for
+    GenericLinearEncoding sources across various shared-memory layouts.
+    """
+    shape = tuple(src_layout.shape)
+    shared_layout = _make_shared_layout(shared_kind, shape)
+    num_warps = 2**len(src_layout.warp_bases)
+
+    @gluon.jit
+    def kernel(x_ptr, y_ptr, shape: ttgl.constexpr, layout: ttgl.constexpr, shared_layout: ttgl.constexpr):
+        if len(shape) == 1:
+            offs = ttgl.arange(0, shape[0], layout=layout)
+        else:
+            offs_m = ttgl.arange(0, shape[0], layout=ttgl.SliceLayout(1, layout))[:, None]
+            offs_n = ttgl.arange(0, shape[1], layout=ttgl.SliceLayout(0, layout))[None, :]
+            offs = offs_m * shape[1] + offs_n
+        x = ttgl.load(x_ptr + offs)
+        smem = ttgl.allocate_shared_memory(x.dtype, shape, shared_layout)
+        smem.store(x)
+        y = smem.load(layout)
+        ttgl.store(y_ptr + offs, y)
+
+    torch.manual_seed(0)
+    x = torch.randn(shape, dtype=torch.float32, device=device)
+    y = torch.empty_like(x)
+    kernel[(1, )](x, y, shape, src_layout, shared_layout, num_warps=num_warps)
+
+    torch.testing.assert_close(y, x)
+
+
 def _funky_reduce_layouts():
 
     def ilog2(x):

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -599,6 +599,22 @@ def test_tuple_constexpr():
     run_parser(foo, args=(test, ))
 
 
+@triton.jit
+def tuple_arg_identity(xs):
+    return xs
+
+
+def test_jit_call_tuple_of_tensors_plus_tuple_of_int():
+
+    @triton.jit
+    def kernel():
+        x0 = tl.program_id(0)
+        x1 = tl.program_id(1)
+        tuple_arg_identity((x0, x1)[:-1] + (1, ))
+
+    run_parser(kernel)
+
+
 @triton.aggregate
 class AggregateWithConstexprFunction:
     val: tl.constexpr

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -719,6 +719,43 @@ def test_constexpr_return():
     run_parser(test)
 
 
+@filecheck_test
+@triton.jit
+def test_atomic_scalar_masks():
+    # CHECK-LABEL: test_atomic_scalar_masks
+    BLOCK: tl.constexpr = 128
+    ptr = tl.full((BLOCK, ), 0, tl.int64).to(tl.pointer_type(tl.int32), bitcast=True)
+    offs = tl.arange(0, BLOCK)
+    ptrs = ptr + offs
+    val = tl.full((BLOCK, ), 1, tl.int32)
+    mask = offs >= 0
+    scalar_mask = True
+    constexpr_value: tl.constexpr = 1
+    constexpr_mask: tl.constexpr = True
+
+    # CHECK: {{.*}} = tt.atomic_rmw add, acq_rel, gpu
+    tl.atomic_add(ptrs, val, mask=mask)
+    # CHECK: {{.*}} = tt.atomic_rmw add, acq_rel, gpu
+    tl.atomic_add(ptrs, 1, mask=True)
+    # CHECK: {{.*}} = tt.atomic_rmw add, acq_rel, gpu
+    tl.atomic_add(ptrs, constexpr_value, mask=constexpr_mask)
+    # CHECK: {{.*}} = tt.atomic_rmw add, acq_rel, gpu
+    tl.atomic_add(ptrs, val, mask=scalar_mask)
+
+    # CHECK: {{.*}} = tt.atomic_rmw exch, acq_rel, gpu
+    tl.atomic_xchg(ptrs, 1, mask=True)
+    # CHECK: {{.*}} = tt.atomic_rmw max, acq_rel, gpu
+    tl.atomic_max(ptrs, 1, mask=True)
+    # CHECK: {{.*}} = tt.atomic_rmw min, acq_rel, gpu
+    tl.atomic_min(ptrs, 1, mask=True)
+    # CHECK: {{.*}} = tt.atomic_rmw and, acq_rel, gpu
+    tl.atomic_and(ptrs, 1, mask=True)
+    # CHECK: {{.*}} = tt.atomic_rmw or, acq_rel, gpu
+    tl.atomic_or(ptrs, 1, mask=True)
+    # CHECK: {{.*}} = tt.atomic_rmw xor, acq_rel, gpu
+    tl.atomic_xor(ptrs, 1, mask=True)
+
+
 @pytest.mark.interpreter
 def test_return_promotion():
 

--- a/python/test/unit/language/test_tensor_descriptor.py
+++ b/python/test/unit/language/test_tensor_descriptor.py
@@ -1394,10 +1394,13 @@ def torch_gather_rows(input, idx, y, block_y):
 @pytest.mark.parametrize("BLOCK_X, BLOCK_Y", [(32, 32), (64, 128), (16, 128), (512, 16)])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.int8])
 @pytest.mark.parametrize("y", [0, 32, 48])
+@pytest.mark.parametrize("idx_dtype", [torch.int32, torch.int16])
 @pytest.mark.skipif(is_hopper(), reason="TMA Scatter is not supported on hopper")
-def test_tma_gather(X, Y, BLOCK_X, BLOCK_Y, dtype, y, device):
+def test_tma_gather(X, Y, BLOCK_X, BLOCK_Y, dtype, y, idx_dtype, device):
     if BLOCK_X > X or y + BLOCK_Y > Y:
         pytest.skip()
+    if idx_dtype == torch.int16 and not is_hip():
+        pytest.skip("I16 gather indices only supported on AMD")
 
     torch.manual_seed(42)
     if dtype != torch.int8:
@@ -1406,7 +1409,7 @@ def test_tma_gather(X, Y, BLOCK_X, BLOCK_Y, dtype, y, device):
         input = torch.arange(X * Y, dtype=dtype, device=device).reshape(X, Y)
     output = torch.empty((BLOCK_X, BLOCK_Y), dtype=dtype, device=device)
 
-    idx = torch.randint(BLOCK_X, (BLOCK_X, ), dtype=torch.int32, device=device)
+    idx = torch.randint(BLOCK_X, (BLOCK_X, ), dtype=idx_dtype, device=device)
 
     def alloc_fn(size: int, align: int, steam):
         return torch.empty(size, dtype=torch.int8, device=device)
@@ -1493,17 +1496,20 @@ def tma_scatter_rows_kernel(out_ptr, in_ptr, idx_ptr, y, X: tl.constexpr, Y: tl.
 @pytest.mark.parametrize("BLOCK_X, BLOCK_Y", [(32, 32), (64, 128), (16, 128), (512, 16)])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.int8])
 @pytest.mark.parametrize("y", [0, 32, 48])
+@pytest.mark.parametrize("idx_dtype", [torch.int32, torch.int16])
 @pytest.mark.skipif(is_hopper(), reason="TMA Scatter is not supported on hopper")
 @pytest.mark.skipif(is_sm12x(), reason="TMA Scatter is not supported on sm120")
-def test_tma_scatter(X, Y, BLOCK_X, BLOCK_Y, dtype, y, device):
+def test_tma_scatter(X, Y, BLOCK_X, BLOCK_Y, dtype, y, idx_dtype, device):
     if BLOCK_X > X or y + BLOCK_Y > Y:
         pytest.skip()
+    if idx_dtype == torch.int16 and not is_hip():
+        pytest.skip("I16 scatter indices only supported on AMD")
 
     torch.manual_seed(42)
     input = torch.arange(BLOCK_X * BLOCK_Y, dtype=dtype, device=device).reshape(BLOCK_X, BLOCK_Y)
     output = torch.zeros((X, Y), dtype=dtype, device=device)
 
-    idx = torch.randperm(BLOCK_X, dtype=torch.int32, device=device)
+    idx = torch.randperm(BLOCK_X, dtype=idx_dtype, device=device)
 
     def alloc_fn(size: int, align: int, steam):
         return torch.empty(size, dtype=torch.int8, device=device)

--- a/python/test/unit/tools/test_slice_kernel.py
+++ b/python/test/unit/tools/test_slice_kernel.py
@@ -1,6 +1,7 @@
 import ast
 import importlib
 import sys
+import sysconfig
 import textwrap
 import uuid
 from pathlib import Path
@@ -8,9 +9,8 @@ from typing import Callable
 
 import pytest
 
-from triton.tools.triton_to_gluon_translator.ordered_set import ordered_set
 from triton.tools.triton_to_gluon_translator.slice_kernel import RewriteSpec, get_reference, slice_kernel
-from triton.tools.triton_to_gluon_translator.stable_toposort import stable_toposort
+from triton.tools.triton_to_gluon_translator.target import TranslatorTarget
 
 
 @pytest.fixture(autouse=True)
@@ -30,25 +30,16 @@ def _make_package(tmp_path: Path, files: dict[str, str]) -> tuple[str, Callable[
     pkg_dir.mkdir()
     (pkg_dir / "__init__.py").write_text("")
     for name, source in files.items():
-        (pkg_dir / name).write_text(textwrap.dedent(source).strip() + "\n")
+        (pkg_dir / name).write_text(textwrap.dedent(source).strip().replace("{pkg}", pkg) + "\n")
     sys.path.insert(0, str(tmp_path))
     importlib.invalidate_caches()
     return pkg, lambda mod: f"{pkg}.{mod}"
 
 
-def _normalize(source: str) -> list[str]:
-    return [line.strip() for line in source.strip().splitlines() if line.strip()]
-
-
-def test_stable_toposort_preserves_component_order():
-    graph = {
-        0: ordered_set([1]),
-        1: ordered_set([2]),
-        2: ordered_set([0, 3]),
-        3: ordered_set([4]),
-        4: ordered_set(),
-    }
-    assert stable_toposort(graph) == [0, 1, 2, 3, 4]
+def assert_code_equal(actual: str, expected: str) -> None:
+    lhs = ast.dump(ast.parse(actual))
+    rhs = ast.dump(ast.parse(expected))
+    assert lhs == rhs
 
 
 def test_slice_kernel_basic_module_slicing(tmp_path):
@@ -93,14 +84,84 @@ def test_slice_kernel_basic_module_slicing(tmp_path):
         },
     )
 
-    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"])
-    assert "import math" in output
-    assert "def lib_foo_some_util() -> int:" in output
-    assert "def some_util() -> int:" in output
-    assert "def lib_bar_prod(values) -> None:" in output
-    assert "def common_util() -> int:" in output
-    assert "lib_bar_prod([42, 22])" in output
-    assert "lib_foo_some_util()" in output
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+import math
+
+def lib_foo_some_util() -> int:
+    return 42
+
+
+def some_util() -> int:
+    return 55
+
+
+def lib_bar_prod(values) -> None:
+    return
+
+
+def common_util() -> int:
+    return math.prod([11, 33])
+
+
+def prod() -> None:
+    return
+
+
+def kernel() -> None:
+    prod()
+    common_util()
+    lib_bar_prod([42, 22])
+    some_util()
+    lib_foo_some_util()
+    """
+    assert_code_equal(output, expected)
+
+
+def test_slice_kernel_does_not_treat_site_packages_as_stdlib(tmp_path, monkeypatch):
+    fake_stdlib = tmp_path / "venv" / "lib" / "python3.12"
+    fake_site_packages = fake_stdlib / "site-packages"
+    fake_site_packages.mkdir(parents=True)
+    pkg, mod = _make_package(
+        fake_site_packages,
+        {
+            "helpers.py":
+            """
+                def helper() -> int:
+                    return 7
+            """,
+            "kernel_mod.py":
+            """
+                from .helpers import helper
+
+                def kernel() -> int:
+                    return helper()
+            """,
+        },
+    )
+
+    original_get_paths = sysconfig.get_paths
+
+    def fake_get_paths():
+        paths = original_get_paths().copy()
+        paths["stdlib"] = str(fake_stdlib)
+        paths["platstdlib"] = str(fake_stdlib)
+        paths["purelib"] = str(fake_site_packages)
+        paths["platlib"] = str(fake_site_packages)
+        return paths
+
+    monkeypatch.setattr(sysconfig, "get_paths", fake_get_paths)
+
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+def helper() -> int:
+    return 7
+
+
+def kernel() -> int:
+    return helper()
+    """
+    assert_code_equal(output, expected)
 
 
 def test_slice_kernel_supports_injected_decorator_matchers(tmp_path):
@@ -155,19 +216,48 @@ def test_slice_kernel_supports_injected_decorator_matchers(tmp_path):
         [f"{mod('kernel_mod')}:kernel_top"],
         ["triton", "torch"],
         rewrite_spec=RewriteSpec(ignored_decorator_matchers=[matcher]),
+        target=TranslatorTarget.GENERIC,
     )
-    assert "@keep()" in top
-    assert "@mock_kernel" not in top
+    expected_top = R"""
+def keep():
+
+    def deco(inner):
+        return inner
+    return deco
+
+
+def foo() -> None:
+    pass
+
+
+@keep()
+def kernel_top() -> None:
+    foo()
+    """
+    assert_code_equal(top, expected_top)
 
     bottom = slice_kernel(
         [f"{mod('kernel_mod')}:kernel_bottom"],
         ["triton", "torch"],
         rewrite_spec=RewriteSpec(ignored_decorator_matchers=[matcher]),
+        target=TranslatorTarget.GENERIC,
     )
-    assert "@keep()" not in bottom
-    assert "@mock_kernel" not in bottom
-    assert "def get_idle_sms" not in bottom
-    assert "def nested_dep" not in bottom
+    expected_bottom = R"""
+def keep():
+
+    def deco(inner):
+        return inner
+    return deco
+
+
+def foo() -> None:
+    pass
+
+
+def kernel_bottom() -> None:
+    foo()
+    """
+    assert_code_equal(bottom, expected_bottom)
 
 
 def test_slice_kernel_translate_to_gluon_keeps_tensor_method_rewrites(tmp_path):
@@ -186,11 +276,24 @@ def test_slice_kernel_translate_to_gluon_keeps_tensor_method_rewrites(tmp_path):
         },
     )
 
-    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], translate_to_gluon=True)
-    assert "import triton.experimental.gluon as gluon" in output
-    assert "@gluon.jit(repr=lambda _: 'custom_kernel_name')" in output
-    assert "reset_to_default_layout" in output
-    assert "squeeze(x, 0)" in output
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], translate_to_gluon=True,
+                          target=TranslatorTarget.GENERIC)
+    expected = R"""
+import triton.experimental.gluon.language as gl
+import triton.tools.triton_to_gluon_translator.common_helpers
+import triton.experimental.gluon as gluon
+
+@gluon.jit
+def squeeze(x, dim: gl.constexpr):
+    gl.static_assert(x.shape[dim] == 1)
+    return triton.tools.triton_to_gluon_translator.common_helpers.reset_to_default_layout(x.reshape(x.shape[:dim] + x.shape[dim + 1:]))
+
+
+@gluon.jit(repr=lambda _: 'custom_kernel_name')
+def kernel(x):
+    squeeze(x, 0)
+    """
+    assert_code_equal(output, expected)
 
 
 def test_slice_kernel_translate_to_gluon_inlines_descriptor_adapter(tmp_path):
@@ -207,9 +310,37 @@ def test_slice_kernel_translate_to_gluon_inlines_descriptor_adapter(tmp_path):
         },
     )
 
-    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], translate_to_gluon=True)
-    assert "convert_host_descriptor(" in output
-    assert "def convert_host_descriptor" in output
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], translate_to_gluon=True,
+                          target=TranslatorTarget.GENERIC)
+    expected = R"""
+import triton.tools.ragged_tma
+
+def kernel(t):
+    return convert_host_descriptor(triton.tools.ragged_tma.create_ragged_descriptor(t, [16, 16]))
+
+
+def _torch_dtype_to_triton(dtype):
+    import torch
+
+    if dtype == torch.float8_e5m2:
+        return gl.float8e5
+    if dtype == torch.float8_e4m3fn:
+        return gl.float8e4nv
+    return getattr(gl, str(dtype).split(".")[1])
+
+def convert_host_descriptor(desc):
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    assert isinstance(desc, TensorDescriptor)
+    block_shape = desc.block_shape
+    dtype = desc.base.dtype
+    tensor = desc.base
+    layout = gl.NVMMASharedLayout.get_default_for(block_shape, _torch_dtype_to_triton(dtype))
+    return gluon.nvidia.hopper.TensorDescriptor(
+        tensor, desc.shape, desc.strides, block_shape, layout
+    )
+    """
+    assert_code_equal(output, expected)
 
 
 def test_slice_kernel_binds_local_imports(tmp_path):
@@ -230,10 +361,286 @@ def test_slice_kernel_binds_local_imports(tmp_path):
         },
     )
 
-    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"])
-    assert "from .helpers import local_helper" not in output
-    assert "def local_helper() -> int:" in output
-    assert "return local_helper()" in output
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+def local_helper() -> int:
+    return 3
+
+
+def kernel() -> int:
+    return local_helper()
+    """
+    assert_code_equal(output, expected)
+
+
+def test_slice_kernel_function_import(tmp_path):
+    pkg, mod = _make_package(
+        tmp_path,
+        {
+            "kernel_mod.py":
+            """
+                def helper() -> None:
+                    import math
+
+                    math.prod([11, 33])
+
+                def kernel() -> None:
+                    helper()
+            """,
+        },
+    )
+
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+import math
+
+def helper() -> None:
+    math.prod([11, 33])
+
+
+def kernel() -> None:
+    helper()
+    """
+    assert_code_equal(output, expected)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="TODO: handle local import aliases that are used as module values",
+)
+def test_slice_kernel_function_import_module_value(tmp_path):
+    pkg, mod = _make_package(
+        tmp_path,
+        {
+            "kernel_mod.py":
+            """
+                def helper():
+                    import math
+
+                    return math
+
+                def kernel():
+                    return helper()
+            """,
+        },
+    )
+
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+import math
+
+def helper():
+    return math
+
+
+def kernel():
+    return helper()
+    """
+    assert_code_equal(output, expected)
+
+
+def test_slice_kernel_function_relative_import(tmp_path):
+    pkg, mod = _make_package(
+        tmp_path,
+        {
+            "lib_foo.py":
+            """
+                import math
+
+                def common_util() -> int:
+                    return math.prod([11, 33])
+            """,
+            "kernel_mod.py":
+            """
+                def helper() -> None:
+                    from .lib_foo import common_util as util_foo
+
+                    util_foo()
+
+                def kernel() -> None:
+                    helper()
+            """,
+        },
+    )
+
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+import math
+
+def common_util() -> int:
+    return math.prod([11, 33])
+
+
+def helper() -> None:
+    common_util()
+
+
+def kernel() -> None:
+    helper()
+    """
+    assert_code_equal(output, expected)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="TODO: preserve origin metadata for local from-import values",
+)
+def test_slice_kernel_function_from_import_value(tmp_path):
+    pkg, mod = _make_package(
+        tmp_path,
+        {
+            "kernel_mod.py":
+            """
+                def helper():
+                    from math import pi
+
+                    return pi
+
+                def kernel():
+                    return helper()
+            """,
+        },
+    )
+
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+import math
+
+def helper():
+    return math.pi
+
+
+def kernel():
+    return helper()
+    """
+    assert_code_equal(output, expected)
+
+
+def test_slice_kernel_function_absolute_import(tmp_path):
+    pkg, mod = _make_package(
+        tmp_path,
+        {
+            "lib_foo.py":
+            """
+                import math
+
+                def common_util() -> int:
+                    return math.prod([11, 33])
+            """,
+            "kernel_mod.py":
+            """
+                import {pkg}.lib_foo
+
+                _PRELOADED_LIB_FOO = {pkg}.lib_foo
+
+                def helper() -> None:
+                    from {pkg}.lib_foo import common_util as util_foo
+
+                    util_foo()
+
+                def kernel() -> None:
+                    helper()
+            """,
+        },
+    )
+
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+import math
+
+def common_util() -> int:
+    return math.prod([11, 33])
+
+
+def helper() -> None:
+    common_util()
+
+
+def kernel() -> None:
+    helper()
+    """
+    assert_code_equal(output, expected)
+
+
+def test_slice_kernel_function_module_relative_import(tmp_path):
+    pkg, mod = _make_package(
+        tmp_path,
+        {
+            "lib_foo.py":
+            """
+                import math
+
+                def common_util() -> int:
+                    return math.prod([11, 33])
+            """,
+            "kernel_mod.py":
+            """
+                def helper() -> None:
+                    from . import lib_foo
+
+                    lib_foo.common_util()
+
+                def kernel() -> None:
+                    helper()
+            """,
+        },
+    )
+
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+import math
+
+def common_util() -> int:
+    return math.prod([11, 33])
+
+
+def helper() -> None:
+    common_util()
+
+
+def kernel() -> None:
+    helper()
+    """
+    assert_code_equal(output, expected)
+
+
+def test_slice_kernel_function_module_relative_import_leaf(tmp_path):
+    pkg, mod = _make_package(
+        tmp_path,
+        {
+            "lib_foo.py":
+            """
+                import math
+
+                def common_util() -> int:
+                    return math.prod([11, 33])
+            """,
+            "kernel_mod.py":
+            """
+                def helper() -> None:
+                    from . import lib_foo
+
+                    lib_foo.common_util()
+
+                def kernel() -> None:
+                    helper()
+            """,
+        },
+    )
+
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch", mod("lib_foo")],
+                          target=TranslatorTarget.GENERIC)
+    expected = f"""
+import {pkg}.lib_foo
+
+def helper() -> None:
+    {pkg}.lib_foo.common_util()
+
+
+def kernel() -> None:
+    helper()
+    """
+    assert_code_equal(output, expected)
 
 
 def test_slice_kernel_treats_assign_targets_as_locals(tmp_path):
@@ -252,9 +659,13 @@ def test_slice_kernel_treats_assign_targets_as_locals(tmp_path):
         },
     )
 
-    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"])
-    assert "def helper() -> int:" not in output
-    assert any(line.replace("lambda :", "lambda:") == "helper = lambda: 2" for line in _normalize(output))
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+def kernel() -> int:
+    helper = lambda: 2
+    return helper()
+    """
+    assert_code_equal(output, expected)
 
 
 def test_slice_kernel_treats_annassign_targets_as_locals(tmp_path):
@@ -272,9 +683,51 @@ def test_slice_kernel_treats_annassign_targets_as_locals(tmp_path):
         },
     )
 
-    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"])
-    assert "value = 7" not in output
-    assert "value: int = 3" in output
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+def kernel() -> int:
+    value: int = 3
+    return value
+    """
+    assert_code_equal(output, expected)
+
+
+def test_slice_kernel_treats_assign_and_annassign_targets_as_locals(tmp_path):
+    pkg, mod = _make_package(
+        tmp_path,
+        {
+            "kernel_mod.py":
+            """
+                import triton
+
+                def global_assign() -> int:
+                    return 1
+
+                def global_annassign() -> int:
+                    return 2
+
+                @triton.jit
+                def kernel() -> tuple[int, int]:
+                    global_assign = 3
+                    copied = global_assign
+                    global_annassign: int = copied + 1
+                    return copied, global_annassign
+            """,
+        },
+    )
+
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], target=TranslatorTarget.GENERIC)
+    expected = R"""
+import triton
+
+@triton.jit
+def kernel() -> tuple[int, int]:
+    global_assign = 3
+    copied = global_assign
+    global_annassign: int = copied + 1
+    return (copied, global_annassign)
+    """
+    assert_code_equal(output, expected)
 
 
 def test_slice_kernel_translate_to_gluon_avoids_double_descriptor_wrap(tmp_path):
@@ -294,8 +747,87 @@ def test_slice_kernel_translate_to_gluon_avoids_double_descriptor_wrap(tmp_path)
         },
     )
 
-    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], translate_to_gluon=True)
-    assert "convert_host_descriptor(convert_host_descriptor(" not in output
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton", "torch"], translate_to_gluon=True,
+                          target=TranslatorTarget.GENERIC)
+    expected = R"""
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+def convert_host_descriptor(desc):
+    return desc
+
+
+def kernel(t):
+    return convert_host_descriptor(TensorDescriptor.from_tensor(t, [16, 16]))
+    """
+    assert_code_equal(output, expected)
+
+
+def test_translate_to_gluon_explicit_expand_dims_rewrites_layout(tmp_path):
+    pkg, mod = _make_package(
+        tmp_path,
+        {
+            "kernel_mod.py":
+            """
+                import triton
+                import triton.language as tl
+
+                @triton.jit
+                def kernel(out_ptr, BLOCK: tl.constexpr):
+                    offsets = tl.arange(0, BLOCK)
+                    expanded = tl.expand_dims(offsets, 0)
+                    tl.store(out_ptr + expanded, expanded)
+            """,
+        },
+    )
+
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton"], translate_to_gluon=True,
+                          target=TranslatorTarget.GENERIC)
+    expected = R"""
+import triton.experimental.gluon.language as gl
+import triton.tools.triton_to_gluon_translator.common_helpers
+import triton.experimental.gluon as gluon
+
+@gluon.jit
+def kernel(out_ptr, BLOCK: gl.constexpr):
+    offsets = triton.tools.triton_to_gluon_translator.common_helpers.tl_arange(0, BLOCK)
+    expanded = gl.expand_dims(triton.tools.triton_to_gluon_translator.common_helpers.convert_to_expand_dims_layout(offsets, [0]), 0)
+    gl.store(out_ptr + expanded, expanded)
+    """
+    assert_code_equal(output, expected)
+
+
+def test_translate_to_gluon_member_fn_expand_dims_rewrites_layout(tmp_path):
+    pkg, mod = _make_package(
+        tmp_path,
+        {
+            "kernel_mod.py":
+            """
+                import triton
+                import triton.language as tl
+
+                @triton.jit
+                def kernel(out_ptr, BLOCK: tl.constexpr):
+                    offsets = tl.arange(0, BLOCK)
+                    expanded = offsets.expand_dims(0)
+                    tl.store(out_ptr + expanded, expanded)
+            """,
+        },
+    )
+
+    output = slice_kernel([f"{mod('kernel_mod')}:kernel"], ["triton"], translate_to_gluon=True,
+                          target=TranslatorTarget.GENERIC)
+    expected = R"""
+import triton.experimental.gluon.language as gl
+import triton.tools.triton_to_gluon_translator.common_helpers
+import triton.experimental.gluon as gluon
+
+@gluon.jit
+def kernel(out_ptr, BLOCK: gl.constexpr):
+    offsets = triton.tools.triton_to_gluon_translator.common_helpers.tl_arange(0, BLOCK)
+    expanded = triton.tools.triton_to_gluon_translator.common_helpers.convert_to_expand_dims_layout(offsets, [0]).expand_dims(0)
+    gl.store(out_ptr + expanded, expanded)
+    """
+    assert_code_equal(output, expected)
 
 
 def test_slice_kernel_public_imports():

--- a/python/test/unit/tools/test_slice_kernel.py
+++ b/python/test/unit/tools/test_slice_kernel.py
@@ -9,7 +9,7 @@ from typing import Callable
 import pytest
 
 from triton.tools.triton_to_gluon_translator.ordered_set import ordered_set
-from triton.tools.triton_to_gluon_translator.slice_kernel import get_reference, slice_kernel
+from triton.tools.triton_to_gluon_translator.slice_kernel import RewriteSpec, get_reference, slice_kernel
 from triton.tools.triton_to_gluon_translator.stable_toposort import stable_toposort
 
 
@@ -154,7 +154,7 @@ def test_slice_kernel_supports_injected_decorator_matchers(tmp_path):
     top = slice_kernel(
         [f"{mod('kernel_mod')}:kernel_top"],
         ["triton", "torch"],
-        ignored_decorator_matchers=[matcher],
+        rewrite_spec=RewriteSpec(ignored_decorator_matchers=[matcher]),
     )
     assert "@keep()" in top
     assert "@mock_kernel" not in top
@@ -162,7 +162,7 @@ def test_slice_kernel_supports_injected_decorator_matchers(tmp_path):
     bottom = slice_kernel(
         [f"{mod('kernel_mod')}:kernel_bottom"],
         ["triton", "torch"],
-        ignored_decorator_matchers=[matcher],
+        rewrite_spec=RewriteSpec(ignored_decorator_matchers=[matcher]),
     )
     assert "@keep()" not in bottom
     assert "@mock_kernel" not in bottom

--- a/python/test/unit/tools/test_stable_toposort.py
+++ b/python/test/unit/tools/test_stable_toposort.py
@@ -334,3 +334,14 @@ def test_input_not_mutated() -> None:
     snapshot = {k: ordered_set(v) for k, v in graph.items()}
     stable_toposort(graph)
     assert graph == snapshot
+
+
+def test_stable_toposort_preserves_component_order():
+    graph = {
+        0: ordered_set([1]),
+        1: ordered_set([2]),
+        2: ordered_set([0, 3]),
+        3: ordered_set([4]),
+        4: ordered_set(),
+    }
+    assert stable_toposort(graph) == [0, 1, 2, 3, 4]

--- a/python/test/unit/tools/test_triton_to_gluon.py
+++ b/python/test/unit/tools/test_triton_to_gluon.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 import pytest
 from triton.tools.tensor_descriptor import TensorDescriptor
+from triton.tools.mxfp import MXFP4Tensor, MXScaleTensor
 
 from triton.tools.triton_to_gluon_translator.translator import convert_triton_to_gluon
 from triton.tools.triton_to_gluon_translator.target import TranslatorTarget
@@ -35,10 +36,10 @@ def _convert_host_descriptor(desc):
     return convert_host_descriptor(desc)
 
 
-def convert_kernel(kernel, kernel_name, tmp_path, target=None):
-    if target is None:
-        t = current_target()
-        target = TranslatorTarget("nvidia" if t.backend == "cuda" else t.arch)
+def convert_kernel(kernel, kernel_name, tmp_path):
+    t = current_target()
+    target = TranslatorTarget(f"sm{t.arch}" if t.backend == "cuda" else t.arch)
+
     converted = convert_triton_to_gluon([kernel], target=target)
 
     # Write converted kernel to a file so @gluon.jit can retrieve source
@@ -97,8 +98,8 @@ def matmul_tile_kernel(a_ptr, b_ptr, c_ptr, BLOCK_M: tl.constexpr, BLOCK_N: tl.c
 
 
 def test_triton_to_gluon_dot_minimal(tmp_path):
-    if not (is_blackwell() or is_hip_cdna3_or_newer() or is_hip_gfx1250()):
-        pytest.skip("Requires Blackwell, CDNA3+, or gfx1250")
+    if not (is_hopper_or_newer() or is_hip_cdna3_or_newer() or is_hip_gfx1250()):
+        pytest.skip("Requires Hopper, Blackwell, CDNA3+, or gfx1250")
     kernel = convert_kernel(matmul_tile_kernel, "matmul_tile_kernel", tmp_path)
     M, N, K = 128, 128, 128
     a = torch.randn((M, K), device="cuda", dtype=torch.float16)
@@ -110,6 +111,219 @@ def test_triton_to_gluon_dot_minimal(tmp_path):
 
     ref = torch.empty_like(c)
     matmul_tile_kernel[grid](a, b, ref, M, N, K, num_warps=8)
+    torch.testing.assert_close(c, ref, atol=0, rtol=0)
+
+
+@triton.jit
+def dot_scaled_tile_kernel(
+    a_ptr,
+    b_ptr,
+    a_scale_ptr,
+    b_scale_ptr,
+    c_ptr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    HAS_A_SCALE: tl.constexpr,
+    HAS_B_SCALE: tl.constexpr,
+    A_FORMAT: tl.constexpr,
+    B_FORMAT: tl.constexpr,
+    LHS_K_PACK: tl.constexpr,
+    RHS_K_PACK: tl.constexpr,
+    FAST_MATH: tl.constexpr,
+):
+    offs_m = tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    offs_scale_k = tl.arange(0, BLOCK_K // 32)
+
+    if A_FORMAT == "e2m1":
+        if LHS_K_PACK:
+            offs_ak = tl.arange(0, BLOCK_K // 2)
+            a = tl.load(a_ptr + offs_m[:, None] * (BLOCK_K // 2) + offs_ak[None, :])
+        else:
+            offs_mp = tl.arange(0, BLOCK_M // 2)
+            a = tl.load(a_ptr + offs_mp[:, None] * BLOCK_K + offs_k[None, :])
+    else:
+        a = tl.load(a_ptr + offs_m[:, None] * BLOCK_K + offs_k[None, :])
+
+    if B_FORMAT == "e2m1":
+        if RHS_K_PACK:
+            offs_bk = tl.arange(0, BLOCK_K // 2)
+            b = tl.load(b_ptr + offs_bk[:, None] * BLOCK_N + offs_n[None, :])
+        else:
+            offs_np = tl.arange(0, BLOCK_N // 2)
+            b = tl.load(b_ptr + offs_k[:, None] * (BLOCK_N // 2) + offs_np[None, :])
+    else:
+        b = tl.load(b_ptr + offs_k[:, None] * BLOCK_N + offs_n[None, :])
+
+    if HAS_A_SCALE:
+        a_scale = tl.load(a_scale_ptr + offs_m[:, None] * (BLOCK_K // 32) + offs_scale_k[None, :])
+    else:
+        a_scale = None
+
+    if HAS_B_SCALE:
+        b_scale = tl.load(b_scale_ptr + offs_n[:, None] * (BLOCK_K // 32) + offs_scale_k[None, :])
+    else:
+        b_scale = None
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    acc = tl.dot_scaled(
+        a,
+        a_scale,
+        A_FORMAT,
+        b,
+        b_scale,
+        B_FORMAT,
+        acc,
+        lhs_k_pack=LHS_K_PACK,
+        rhs_k_pack=RHS_K_PACK,
+        fast_math=FAST_MATH,
+    )
+    tl.store(c_ptr + offs_m[:, None] * BLOCK_N + offs_n[None, :], acc)
+
+
+def _make_dot_scaled_operand(fmt, rows, cols, *, device, is_rhs=False, k_pack=True):
+    if fmt == "e2m1":
+        if is_rhs:
+            operand = MXFP4Tensor(size=(cols, rows), device=device).random()
+            return operand.to_packed_tensor(dim=1 if k_pack else 0).T.contiguous()
+        operand = MXFP4Tensor(size=(rows, cols), device=device).random()
+        return operand.to_packed_tensor(dim=1 if k_pack else 0).contiguous()
+    if fmt == "e5m2":
+        return torch.randint(20, 40, (rows, cols), dtype=torch.uint8, device=device).view(torch.float8_e5m2)
+    if fmt == "e4m3":
+        return torch.randint(20, 40, (rows, cols), dtype=torch.uint8, device=device).view(torch.float8_e4m3fn)
+    if fmt == "fp16":
+        return torch.randn((rows, cols), dtype=torch.float16, device=device)
+    if fmt == "bf16":
+        return torch.randn((rows, cols), dtype=torch.bfloat16, device=device)
+    raise ValueError(f"unsupported dot_scaled format: {fmt}")
+
+
+def _make_dot_scaled_scale(rows, k, *, device, scale_factor=32):
+    return MXScaleTensor(size=(rows, k // scale_factor), device=device).random(high=32.0).data
+
+
+@pytest.mark.parametrize(
+    "BLOCK_M,BLOCK_N,BLOCK_K,A_FORMAT,B_FORMAT,HAS_A_SCALE,HAS_B_SCALE,LHS_K_PACK,RHS_K_PACK,FAST_MATH,NUM_WARPS,SCALE_FACTOR",
+    [
+        pytest.param(128, 16, 32, "e5m2", "e5m2", True, True, True, True, True, 4, 32, id="fp8-both-scales"),
+        pytest.param(64, 16, 32, "e5m2", "e5m2", True, True, True, True, True, 4, 16, id="fp8-both-scales-sf16"),
+        pytest.param(128, 128, 64, "e2m1", "e2m1", True, True, True, True, True, 4, 32, id="fp4-both-scales"),
+        pytest.param(128, 128, 64, "e2m1", "e2m1", True, True, True, True, True, 4, 16, id="fp4-both-scales-sf16"),
+        pytest.param(128, 128, 128, "e2m1", "e5m2", True, True, True, True, True, 4, 32, id="mixed-lhs-fp4"),
+        pytest.param(128, 128, 128, "e5m2", "e2m1", True, True, True, True, True, 4, 32, id="mixed-rhs-fp4"),
+        pytest.param(64, 16, 32, "e5m2", "bf16", True, False, True, True, True, 4, 16, id="lhs-scale-only-sf16"),
+        pytest.param(64, 16, 32, "fp16", "e5m2", False, True, True, True, True, 4, 32, id="rhs-scale-only-fallback"),
+        pytest.param(64, 16, 32, "fp16", "e5m2", False, True, True, True, True, 4, 16, id="rhs-scale-only-sf16"),
+    ],
+)
+def test_triton_to_gluon_dot_scaled(
+    BLOCK_M,
+    BLOCK_N,
+    BLOCK_K,
+    A_FORMAT,
+    B_FORMAT,
+    HAS_A_SCALE,
+    HAS_B_SCALE,
+    LHS_K_PACK,
+    RHS_K_PACK,
+    FAST_MATH,
+    NUM_WARPS,
+    SCALE_FACTOR,
+    tmp_path,
+):
+    if not (is_hopper_or_newer() or is_hip_cdna4() or is_hip_gfx1250()):
+        pytest.skip("Requires Hopper, Blackwell, CDNA4, or gfx1250")
+    torch.manual_seed(0)
+
+    kernel = convert_kernel(dot_scaled_tile_kernel, "dot_scaled_tile_kernel", tmp_path)
+    device = "cuda"
+    a = _make_dot_scaled_operand(A_FORMAT, BLOCK_M, BLOCK_K, device=device, k_pack=LHS_K_PACK)
+    b = _make_dot_scaled_operand(B_FORMAT, BLOCK_K, BLOCK_N, device=device, is_rhs=True, k_pack=RHS_K_PACK)
+    a_scale = _make_dot_scaled_scale(BLOCK_M, BLOCK_K, device=device,
+                                     scale_factor=SCALE_FACTOR) if HAS_A_SCALE else None
+    b_scale = _make_dot_scaled_scale(BLOCK_N, BLOCK_K, device=device,
+                                     scale_factor=SCALE_FACTOR) if HAS_B_SCALE else None
+
+    c = torch.empty((BLOCK_M, BLOCK_N), device=device, dtype=torch.float32)
+    ref = torch.empty_like(c)
+    grid = (1, )
+    kernel_args = (
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_K,
+        HAS_A_SCALE,
+        HAS_B_SCALE,
+        A_FORMAT,
+        B_FORMAT,
+        LHS_K_PACK,
+        RHS_K_PACK,
+        FAST_MATH,
+    )
+
+    kernel[grid](a, b, a_scale, b_scale, c, *kernel_args, num_warps=NUM_WARPS)
+    dot_scaled_tile_kernel[grid](a, b, a_scale, b_scale, ref, *kernel_args, num_warps=NUM_WARPS)
+    torch.testing.assert_close(c, ref, atol=1e-2, rtol=1e-2)
+
+
+@triton.jit
+def dot_transposed_operand_tile_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    LHS_TRANSPOSED: tl.constexpr,
+    RHS_TRANSPOSED: tl.constexpr,
+):
+    offs_m = tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    if LHS_TRANSPOSED:
+        a = tl.load(a_ptr + offs_k[:, None] * BLOCK_M + offs_m[None, :]).trans(1, 0)
+    else:
+        a = tl.load(a_ptr + offs_m[:, None] * BLOCK_K + offs_k[None, :])
+
+    if RHS_TRANSPOSED:
+        b = tl.load(b_ptr + offs_n[:, None] * BLOCK_K + offs_k[None, :]).trans(1, 0)
+    else:
+        b = tl.load(b_ptr + offs_k[:, None] * BLOCK_N + offs_n[None, :])
+
+    c = tl.dot(a, b)
+    tl.store(c_ptr + offs_m[:, None] * BLOCK_N + offs_n[None, :], c)
+
+
+@pytest.mark.parametrize(
+    "lhs_transposed,rhs_transposed",
+    [
+        pytest.param(True, False, id="lhs-transposed"),
+        pytest.param(False, True, id="rhs-transposed"),
+        pytest.param(True, True, id="both-transposed"),
+    ],
+)
+def test_triton_to_gluon_dot_transposed_operands(lhs_transposed, rhs_transposed, tmp_path):
+    if not is_hopper_or_newer():
+        pytest.skip("Requires Hopper or newer")
+
+    kernel = convert_kernel(dot_transposed_operand_tile_kernel, "dot_transposed_operand_tile_kernel", tmp_path)
+    block_m = block_n = block_k = 128
+    device = "cuda"
+
+    a_shape = (block_k, block_m) if lhs_transposed else (block_m, block_k)
+    b_shape = (block_n, block_k) if rhs_transposed else (block_k, block_n)
+    a = torch.randn(a_shape, device=device, dtype=torch.float16)
+    b = torch.randn(b_shape, device=device, dtype=torch.float16)
+    c = torch.empty((block_m, block_n), device=device, dtype=torch.float32)
+    ref = torch.empty_like(c)
+
+    grid = (1, )
+    args = (block_m, block_n, block_k, lhs_transposed, rhs_transposed)
+    kernel[grid](a, b, c, *args, num_warps=8)
+    dot_transposed_operand_tile_kernel[grid](a, b, ref, *args, num_warps=8)
     torch.testing.assert_close(c, ref, atol=0, rtol=0)
 
 
@@ -158,8 +372,8 @@ def matmul_kernel(  #
 @pytest.mark.parametrize("BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES", [(128, 128, 64, 1)])
 @pytest.mark.parametrize("NUM_WARPS", [4])
 def test_simple_matmul(dtype_src_str, dtype_dst_str, BLOCK_M, BLOCK_N, BLOCK_K, NUM_STAGES, NUM_WARPS, tmp_path):
-    if not (is_blackwell() or is_hip_cdna4() or is_hip_gfx1250()):
-        pytest.skip("Requires Blackwell, CDNA4, or gfx1250")
+    if not (is_hopper_or_newer() or is_hip_cdna4() or is_hip_gfx1250()):
+        pytest.skip("Requires Hopper, Blackwell, CDNA4, or gfx1250")
     device = "cuda"
     M, N, K = 1024, 512, 256
     torch.manual_seed(42)
@@ -173,12 +387,42 @@ def test_simple_matmul(dtype_src_str, dtype_dst_str, BLOCK_M, BLOCK_N, BLOCK_K, 
     dtype_dst = getattr(torch, dtype_dst_str)
     output = torch.empty((M, N), dtype=dtype_dst, device=device)
     grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N), 1)
-    kernel[grid](a, b, output, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), output.stride(0),
-                 output.stride(1), BLOCK_M, BLOCK_N, BLOCK_K)
+    kernel[grid](
+        a,
+        b,
+        output,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        output.stride(0),
+        output.stride(1),
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_K,
+    )
 
     ref = torch.empty_like(output)
-    matmul_kernel[grid](a, b, ref, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), output.stride(0),
-                        output.stride(1), BLOCK_M, BLOCK_N, BLOCK_K)
+    matmul_kernel[grid](
+        a,
+        b,
+        ref,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        output.stride(0),
+        output.stride(1),
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_K,
+    )
     torch.testing.assert_close(output, ref, atol=0, rtol=0)
 
 
@@ -482,12 +726,14 @@ def gather_scatter_roundtrip_kernel(out_ptr, in_ptr, idx_ptr, X: tl.constexpr, Y
     out_desc.scatter(data, idx, 0)
 
 
-# TODO: parametrize over _descriptor_targets once NVIDIA gather/scatter translation is supported.
-# The translator currently routes gather/scatter to AMD-specific helpers for AMD targets only.
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires gfx1250")
+@pytest.mark.skipif(not is_hip_gfx1250() and not is_blackwell(), reason="Requires descriptor gather/scatter support")
 def test_gather_scatter_roundtrip(tmp_path):
-    kernel = convert_kernel(gather_scatter_roundtrip_kernel, "gather_scatter_roundtrip_kernel", tmp_path,
-                            target=TranslatorTarget.GFX1250)
+    kernel = convert_kernel(gather_scatter_roundtrip_kernel, "gather_scatter_roundtrip_kernel", tmp_path)
+
+    def allocator(size: int, align: int, stream):
+        return torch.empty(size, dtype=torch.uint8, device="cuda")
+
+    triton.set_allocator(allocator)
 
     X, Y, BLOCK_X, BLOCK_Y = 64, 64, 8, 64
     inp = torch.arange(X * Y, device="cuda", dtype=torch.float16).reshape(X, Y)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1520,9 +1520,17 @@ class CodeGenerator(ast.NodeVisitor):
         bound_args.apply_defaults()
         args = bound_args.arguments
         args = [args[name] for name in fn.arg_names]
+
+        def normalize_arg(arg):
+            if isinstance(arg, language.tuple):
+                return _apply_to_tuple_values(arg, normalize_arg)
+            if not isinstance(arg, base_value) or isinstance(arg, JITCallable):
+                return language.core.constexpr(arg)
+            return arg
+
         for i, arg in enumerate(args):
-            if isinstance(arg, (language.dtype, float, int, bool, JITFunction)):
-                args[i] = language.core.constexpr(arg)
+            args[i] = normalize_arg(arg)
+
         args_cst = find_paths_if(args, lambda _, x: _is_constexpr(x))
         args_cst = {path: get_iterable_path(args, path) for path in args_cst}
         args_path = find_paths_if(args, lambda _, x: not _is_constexpr(x))

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -9,7 +9,8 @@ if TYPE_CHECKING:
     from triton._C.libtriton.gluon_ir import GluonOpBuilder
     from ._semantic import GluonSemantic
 
-from ._layouts import SharedLayout, DistributedLayout, BlockedLayout, DotOperandLayout, AutoLayout, CoalescedLayout
+from ._layouts import (SharedLayout, DistributedLayout, BlockedLayout, DotOperandLayout, AutoLayout, CoalescedLayout,
+                       SharedLinearLayout, _get_shape_per_cta)
 from triton._C.libtriton import ir
 import triton.language.core as tl_core
 from triton.language.core import (
@@ -211,6 +212,23 @@ class shared_memory_descriptor_type(base_type):
     def __str__(self) -> str:
         return f"shared_memory_descriptor<{self.element_ty}, {self.shape}, {self.layout}, {self.alloc_shape}>"
 
+    @property
+    def nbytes_per_cta(self) -> int:
+        if isinstance(self.layout, SharedLinearLayout):
+            cga_layout = []
+            dim_bases = [0] * len(self.shape)
+            for basis in self.layout.block_bases:
+                cga_basis = [0] * len(self.shape)
+                for dim, value in enumerate(basis):
+                    if value != 0:
+                        cga_basis[dim] = 1 << dim_bases[dim]
+                        dim_bases[dim] += 1
+                cga_layout.append(cga_basis)
+        else:
+            cga_layout = self.layout.cga_layout
+        shape_per_cta = _get_shape_per_cta(self.shape, cga_layout)
+        return math.prod(shape_per_cta) * self.element_ty.primitive_bitwidth // 8
+
     def __eq__(self, other) -> bool:
         return (type(self) is type(other) and self.shape == other.shape and self.layout == other.layout
                 and self.alloc_shape == other.alloc_shape)
@@ -299,6 +317,10 @@ class shared_memory_descriptor(base_value):
     @property
     def numel(self) -> int:
         return math.prod(self.shape)
+
+    @property
+    def nbytes_per_cta(self) -> int:
+        return self.type.nbytes_per_cta
 
     @property
     def layout(self):

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/tma.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/tma.py
@@ -41,7 +41,7 @@ __all__ = [
 
 
 @builtin
-def async_gather(tensor_desc, x_offsets, y_offset, barrier, result, pred=True, _semantic=None):
+def async_gather(tensor_desc, x_offsets, y_offset, barrier, result, pred=True, multicast=False, _semantic=None):
     """
     Asynchronously gather elements from global memory to shared memory using TMA.
 
@@ -52,14 +52,16 @@ def async_gather(tensor_desc, x_offsets, y_offset, barrier, result, pred=True, _
         barrier (shared_memory_descriptor): Barrier that will be signaled when the operation is complete.
         result (tensor_memory_descriptor): Result shared memory, must have NVMMASharedLayout.
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.
+        multicast (bool): Enable multicast.
     """
     if _semantic.builder.options.enable_iisan:
         _emit_alignment_check(tensor_desc, (y_offset, ), "async_gather", "y_offset", _semantic=_semantic)
 
     pred = _semantic.to_tensor(pred)
     y_offset = _semantic.to_tensor(y_offset)
+    multicast = ttgl._unwrap_if_constexpr(multicast)
     _semantic.builder.create_async_tma_gather(tensor_desc.handle, x_offsets.handle, y_offset.handle, barrier.handle,
-                                              result.handle, pred.handle)
+                                              result.handle, pred.handle, multicast)
 
 
 def _emit_scatter_nonnegative_check(x_offsets, y_offset, _semantic=None):

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1298,6 +1298,7 @@ class TritonSemantic(Generic[TensorTy]):
         if mask is None:
             ptr, val = self.broadcast_tensors(ptr, val)
         else:
+            mask = self.to_tensor(mask)
             ptr, val, mask = self.broadcast_tensors(ptr, val, mask)
         if ptr_shape != ptr.shape:
             raise ValueError(f"Expected pointer argument to have shape {ptr.shape} but got {ptr_shape}")
@@ -1386,6 +1387,8 @@ class TritonSemantic(Generic[TensorTy]):
                 mask_ty = ptr.type.with_element_ty(tl.int1)
                 mask_ir = self.builder.create_splat(mask_ty.to_ir(self.builder), mask_ir)
             mask = self.tensor(mask_ir, mask_ty)
+        elif not mask.type.scalar.is_bool():
+            raise ValueError("Mask must have boolean scalar type")
         return ptr, val, mask
 
     def _signbit(self, x: TensorTy) -> TensorTy:

--- a/python/triton/tools/triton_to_gluon_translator/amd_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/amd_helpers.py
@@ -14,8 +14,7 @@ from triton.tools.triton_to_gluon_translator.common_helpers import *  # noqa: F4
 from triton.tools.triton_to_gluon_translator.common_helpers import (
     default_blocked_layout,
     get_num_threads_per_warp,
-    tl_dot_decomposed_scale_arg,
-    tl_trans,
+    tl_dot_decomposed_block_scales_impl,
 )
 
 # ---- architecture detection ----
@@ -175,55 +174,6 @@ def tl_dot(
         return tl_dot_mfma(a, b, acc, out_dtype)
 
 
-# Defined here (not imported from common) so __globals__ resolves tl_dot to this module's version.
-@gluon.jit
-def tl_dot_decomposed_block_scales(
-    lhs,
-    lhs_scale,
-    lhs_format,
-    rhs,
-    rhs_scale,
-    rhs_format,
-    acc=None,
-    fast_math=False,
-    lhs_k_pack=True,
-    rhs_k_pack=True,
-    out_dtype=ttgl.float32,
-):
-    if lhs_scale is None and rhs_scale is not None:
-        lhs_trans = tl_trans(lhs)
-        rhs_trans = tl_trans(rhs)
-        if acc is not None:
-            orig_layout: ttgl.constexpr = acc.type.layout
-            acc = tl_trans(acc)
-        result = tl_dot_scaled(
-            rhs_trans,
-            rhs_scale,
-            rhs_format,
-            lhs_trans,
-            lhs_scale,
-            lhs_format,
-            acc,
-            fast_math,
-            lhs_k_pack,
-            rhs_k_pack,
-            out_dtype,
-        )
-        result = tl_trans(result)
-        if acc is not None:
-            result = ttgl.convert_layout(result, orig_layout)
-        return result
-    else:
-        ttgl.static_assert(not (not lhs_k_pack or not rhs_k_pack), "TODO: support m/n packed formats")
-        compute_type: ttgl.constexpr = (ttgl.float16 if
-                                        (lhs_format == "fp16" or rhs_format == "fp16") else ttgl.bfloat16)
-
-        scale_a = tl_dot_decomposed_scale_arg(lhs, lhs_scale, lhs_format, 0, compute_type, fast_math)
-        scale_b = tl_dot_decomposed_scale_arg(rhs, rhs_scale, rhs_format, 1, compute_type, fast_math)
-
-        return tl_dot(scale_a, scale_b, acc, out_dtype=out_dtype)
-
-
 @gluon.jit
 def tl_dot_scaled(
     lhs,
@@ -238,7 +188,9 @@ def tl_dot_scaled(
     rhs_k_pack=True,
     out_dtype=ttgl.float32,
 ):
-    return tl_dot_decomposed_block_scales(
+    return tl_dot_decomposed_block_scales_impl(
+        tl_dot_scaled,
+        tl_dot,
         lhs,
         lhs_scale,
         lhs_format,

--- a/python/triton/tools/triton_to_gluon_translator/blackwell_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/blackwell_helpers.py
@@ -1,0 +1,337 @@
+# type: ignore
+
+from triton.experimental import gluon
+from triton.experimental.gluon import language as ttgl
+from triton.experimental.gluon.language.nvidia.hopper import fence_async_shared, mbarrier, tma
+from triton.experimental.gluon.language.nvidia.blackwell import (
+    TensorMemoryLayout,
+    TensorMemoryScalesLayout,
+    allocate_tensor_memory,
+    tcgen05_commit,
+    tcgen05_mma,
+    tcgen05_mma_scaled,
+)
+from triton.experimental.gluon.language.nvidia.blackwell import tma as tma_blackwell
+
+from triton.tools.triton_to_gluon_translator.common_helpers import *  # noqa: F401,F403
+from triton.tools.triton_to_gluon_translator.common_helpers import (
+    default_blocked_layout,
+    get_num_threads_per_warp,
+    tl_dot_decomposed_block_scales_impl,
+)
+from triton.tools.triton_to_gluon_translator.nvidia_helpers import *  # noqa: F401,F403
+from triton.tools.triton_to_gluon_translator.nvidia_helpers import (
+    tl_dot_mma_sync,
+    get_shared_memory_mma_operand,
+)
+
+# ---- NVIDIA Blackwell dot ----
+
+
+@gluon.constexpr_function
+def tl_dot_mmav5_supported(a_ty, b_ty, num_warps, input_precision, allow_tf32, max_num_imprecise_acc):
+    assert max_num_imprecise_acc in [0, None], ("max_num_imprecise_acc only applies to Hopper warp_group_dot")
+    assert input_precision is None or allow_tf32 is None, (
+        "Only one of input_precision and allow_tf32 can be specified")
+    if input_precision is None and (allow_tf32 or allow_tf32 is None):
+        input_precision = "tf32"
+
+    M = a_ty.shape[0]
+    N = b_ty.shape[1]
+    K = a_ty.shape[1]
+    min_K = 256 // a_ty.element_ty.primitive_bitwidth
+    if a_ty.element_ty.is_int() or b_ty.element_ty.is_int():
+        return False
+    if (min(a_ty.element_ty.primitive_bitwidth, b_ty.element_ty.primitive_bitwidth) >= 32
+            and input_precision != "tf32"):
+        return False
+    return (num_warps in [4, 8] and len(a_ty.shape) == 2 and len(b_ty.shape) == 2 and K >= min_K and M >= 64
+            and N >= 16)
+
+
+@gluon.jit
+def tl_dot_blackwell(
+    a,
+    b,
+    acc=None,
+    input_precision=None,
+    allow_tf32=None,
+    max_num_imprecise_acc=None,
+    out_dtype=ttgl.float32,
+):
+    M: ttgl.constexpr = a.type.shape[0]
+    N: ttgl.constexpr = b.type.shape[1]
+
+    allow_transpose = not a.type.element_ty.is_fp32()
+    a_smem = get_shared_memory_mma_operand(a, 0, allow_transpose)
+    b_smem = get_shared_memory_mma_operand(b, 1, allow_transpose)
+
+    m: ttgl.constexpr = 128 if M >= 128 else 64
+    n: ttgl.constexpr = 256 if N >= 256 else N
+
+    acc_dtype: ttgl.constexpr = acc.dtype if acc is not None else out_dtype
+    col_stride: ttgl.constexpr = 32 // acc_dtype.primitive_bitwidth
+    acc_tmem_layout: ttgl.constexpr = TensorMemoryLayout([m, n], col_stride=col_stride)
+    acc_tmem = allocate_tensor_memory(acc_dtype, [M, N], acc_tmem_layout)
+    tmem_reg_layout: ttgl.constexpr = acc_tmem.get_reg_layout()
+    if acc is not None:
+        acc_temp = ttgl.convert_layout(acc, tmem_reg_layout)
+    else:
+        acc_temp = ttgl.zeros([M, N], out_dtype, layout=tmem_reg_layout)
+    acc_tmem.store(acc_temp)
+    fence_async_shared()
+    bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
+    mbarrier.init(bar, count=1)
+    tcgen05_mma(a_smem, b_smem, acc_tmem, use_acc=True)
+    tcgen05_commit(bar)
+    mbarrier.wait(bar, phase=0)
+    mbarrier.invalidate(bar)
+
+    out = acc_tmem.load()
+    ret_layout: ttgl.constexpr = default_blocked_layout([M, N], ttgl.num_warps())
+    out = ttgl.convert_layout(out, ret_layout)
+    return out
+
+
+# ---- NVIDIA dot dispatch ----
+
+
+@gluon.jit
+def tl_dot(
+    a,
+    b,
+    acc=None,
+    input_precision=None,
+    allow_tf32=None,
+    max_num_imprecise_acc=None,
+    out_dtype=ttgl.float32,
+):
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    if tl_dot_mmav5_supported(a.type, b.type, num_warps, input_precision, allow_tf32, max_num_imprecise_acc):
+        return tl_dot_blackwell(a, b, acc, input_precision, allow_tf32, max_num_imprecise_acc, out_dtype)
+    else:
+        return tl_dot_mma_sync(a, b, acc, input_precision, out_dtype)
+
+
+# ---- NVIDIA dot-scaled ----
+
+
+@gluon.constexpr_function
+def tl_dot_scaled_mmav5_supported(a_ty, b_ty, num_warps):
+    M = a_ty.shape[0]
+    N = b_ty.shape[1]
+    K = a_ty.shape[1]
+    min_K = 256 // a_ty.element_ty.primitive_bitwidth
+    return (num_warps in [4, 8] and len(a_ty.shape) == 2 and len(b_ty.shape) == 2 and K >= min_K and M >= 128
+            and N >= 16)
+
+
+@gluon.jit
+def tl_dot_scaled_blackwell(
+    lhs,
+    lhs_scale,
+    lhs_format,
+    rhs,
+    rhs_scale,
+    rhs_format,
+    acc=None,
+    fast_math=False,
+    lhs_k_pack=True,
+    rhs_k_pack=True,
+    out_dtype=ttgl.float32,
+):
+    is_a_fp4: ttgl.constexpr = lhs_format == "e2m1"
+    is_b_fp4: ttgl.constexpr = rhs_format == "e2m1"
+
+    mixed_prec: ttgl.constexpr = lhs_format != rhs_format
+    is_a_mixed_prec_fp4: ttgl.constexpr = mixed_prec and is_a_fp4
+    is_b_mixed_prec_fp4: ttgl.constexpr = mixed_prec and not is_a_fp4 and is_b_fp4
+
+    is_mmav5_fp4_padded_a: ttgl.constexpr = is_a_mixed_prec_fp4 or not lhs_k_pack
+    is_mmav5_fp4_padded_b: ttgl.constexpr = is_b_mixed_prec_fp4 or not rhs_k_pack
+
+    a_smem = get_shared_memory_mma_operand(
+        lhs,
+        0,
+        allow_transpose=not is_a_fp4,
+        is_fp4_padded=is_mmav5_fp4_padded_a,
+        force_transpose=not lhs_k_pack,
+    )
+    b_smem = get_shared_memory_mma_operand(
+        rhs,
+        1,
+        allow_transpose=not is_b_fp4,
+        is_fp4_padded=is_mmav5_fp4_padded_b,
+        force_transpose=not rhs_k_pack,
+    )
+
+    M: ttgl.constexpr = lhs.type.shape[0]
+    N: ttgl.constexpr = rhs.type.shape[1]
+
+    m: ttgl.constexpr = 128
+    n: ttgl.constexpr = 256 if N >= 256 else N
+
+    acc_dtype: ttgl.constexpr = acc.dtype if acc is not None else out_dtype
+    col_stride: ttgl.constexpr = 32 // acc_dtype.primitive_bitwidth
+    acc_tmem_layout: ttgl.constexpr = TensorMemoryLayout([m, n], col_stride=col_stride)
+    acc_tmem = allocate_tensor_memory(acc_dtype, [M, N], acc_tmem_layout)
+    tmem_reg_layout: ttgl.constexpr = acc_tmem.get_reg_layout()
+    if acc is not None:
+        acc_temp = ttgl.convert_layout(acc, tmem_reg_layout)
+    else:
+        acc_temp = ttgl.zeros([M, N], out_dtype, layout=tmem_reg_layout)
+    acc_tmem.store(acc_temp)
+    fence_async_shared()
+
+    bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
+    mbarrier.init(bar, count=1)
+    scale_layout: ttgl.constexpr = TensorMemoryScalesLayout()
+    a_scale_tmem = allocate_tensor_memory(lhs_scale.dtype, lhs_scale.shape, scale_layout)
+    b_scale_tmem = allocate_tensor_memory(rhs_scale.dtype, rhs_scale.shape, scale_layout)
+    scale_layout_reg_lhs: ttgl.constexpr = a_scale_tmem.get_reg_layout()
+    scale_layout_reg_rhs: ttgl.constexpr = b_scale_tmem.get_reg_layout()
+    lhs_scale = ttgl.convert_layout(lhs_scale, scale_layout_reg_lhs)
+    rhs_scale = ttgl.convert_layout(rhs_scale, scale_layout_reg_rhs)
+    a_scale_tmem.store(lhs_scale)
+    b_scale_tmem.store(rhs_scale)
+
+    tcgen05_mma_scaled(a_smem, b_smem, acc_tmem, a_scale_tmem, b_scale_tmem, lhs_format, rhs_format, use_acc=True)
+    tcgen05_commit(bar)
+    mbarrier.wait(bar, phase=0)
+    mbarrier.invalidate(bar)
+    out = acc_tmem.load()
+    ret_layout: ttgl.constexpr = default_blocked_layout([M, N], ttgl.num_warps())
+    out = ttgl.convert_layout(out, ret_layout)
+    return out
+
+
+@gluon.jit
+def tl_dot_decomposed_block_scales(
+    lhs,
+    lhs_scale,
+    lhs_format,
+    rhs,
+    rhs_scale,
+    rhs_format,
+    acc=None,
+    fast_math=False,
+    lhs_k_pack=True,
+    rhs_k_pack=True,
+    out_dtype=ttgl.float32,
+):
+    return tl_dot_decomposed_block_scales_impl(
+        tl_dot_scaled,
+        tl_dot,
+        lhs,
+        lhs_scale,
+        lhs_format,
+        rhs,
+        rhs_scale,
+        rhs_format,
+        acc=acc,
+        fast_math=fast_math,
+        lhs_k_pack=lhs_k_pack,
+        rhs_k_pack=rhs_k_pack,
+        out_dtype=out_dtype,
+    )
+
+
+@gluon.jit
+def tl_dot_scaled(
+    lhs,
+    lhs_scale,
+    lhs_format,
+    rhs,
+    rhs_scale,
+    rhs_format,
+    acc=None,
+    fast_math=False,
+    lhs_k_pack=True,
+    rhs_k_pack=True,
+    out_dtype=ttgl.float32,
+):
+    if (tl_dot_scaled_mmav5_supported(lhs.type, rhs.type, ttgl.num_warps()) and lhs_scale is not None
+            and rhs_scale is not None):
+        return tl_dot_scaled_blackwell(
+            lhs,
+            lhs_scale,
+            lhs_format,
+            rhs,
+            rhs_scale,
+            rhs_format,
+            acc,
+            fast_math,
+            lhs_k_pack,
+            rhs_k_pack,
+            out_dtype,
+        )
+    else:
+        return tl_dot_decomposed_block_scales(
+            lhs,
+            lhs_scale,
+            lhs_format,
+            rhs,
+            rhs_scale,
+            rhs_format,
+            acc,
+            fast_math,
+            lhs_k_pack,
+            rhs_k_pack,
+            out_dtype,
+        )
+
+
+# ---- NVIDIA TMA tensor descriptors ----
+
+
+@gluon.jit
+def tl_gather_tensor_descriptor(desc, x_offsets, y_offset):
+    desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
+    alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout)
+    bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
+    mbarrier.init(bar, count=1)
+    x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
+        0,
+        ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
+    )
+    x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
+    mbarrier.expect(bar, x_offsets.shape[0] * desc.block_type.nbytes)
+    tma_blackwell.async_gather(desc, x_offsets, y_offset, bar, alloc)
+    mbarrier.wait(bar, phase=0)
+    mbarrier.invalidate(bar)
+    ret_layout: ttgl.constexpr = default_blocked_layout(desc.block_shape, ttgl.num_warps())
+    out = alloc.load(ret_layout)
+    return out
+
+
+@gluon.jit
+def tl_scatter_tensor_descriptor(desc, value, x_offsets, y_offset):
+    desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
+    alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout, value)
+    fence_async_shared()
+    x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
+        0,
+        ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
+    )
+    x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
+    tma_blackwell.async_scatter(desc, x_offsets, y_offset, alloc)
+    tma.store_wait(0)
+
+
+# ---- NVIDIA obj dispatch ----
+
+
+@gluon.jit
+def tl_obj_gather(obj, x_offsets, y_offset):
+    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
+        return tl_gather_tensor_descriptor(obj, x_offsets, y_offset)
+    else:
+        return obj.gather(x_offsets, y_offset)
+
+
+@gluon.jit
+def tl_obj_scatter(obj, value, x_offsets, y_offset):
+    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
+        return tl_scatter_tensor_descriptor(obj, value, x_offsets, y_offset)
+    else:
+        return obj.scatter(value, x_offsets, y_offset)

--- a/python/triton/tools/triton_to_gluon_translator/common_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/common_helpers.py
@@ -174,7 +174,7 @@ def convert_to_expand_dims_layout(value, expand_dims: list[int]):
 
 
 @gluon.jit
-def tl_dot_decomposed_scale_to_16(scale, compute_type):
+def tl_dot_decomposed_scale_to_16(scale, compute_type: ttgl.constexpr):
     large_fp_type: ttgl.constexpr = ttgl.float32 if compute_type == ttgl.float16 else compute_type
     int_width: ttgl.constexpr = large_fp_type.primitive_bitwidth
     int_type: ttgl.constexpr = get_int_type(int_width)
@@ -204,15 +204,15 @@ def tl_dot_get_permute_order(rank, dim):
 
 
 @gluon.constexpr_function
-def tl_dot_get_reshape_shape(scale_ty, dim):
+def tl_dot_get_reshape_shape(scale_ty, dim, scale_factor):
     shape = list(scale_ty.shape.values)
     shape.pop()
-    shape[dim] *= 32
+    shape[dim] *= scale_factor
     return shape
 
 
 @gluon.jit
-def tl_dot_decomposed_broadcast_scale(scale, dim):
+def tl_dot_decomposed_broadcast_scale(scale, dim, scale_factor: ttgl.constexpr):
     scale_ty: ttgl.constexpr = scale.type
     rank: ttgl.constexpr = len(scale_ty.shape)
 
@@ -220,10 +220,10 @@ def tl_dot_decomposed_broadcast_scale(scale, dim):
     slice_enc: ttgl.constexpr = tl_dot_get_expand_dims_layout(scale_ty, num_warps, rank)
     scale = ttgl.convert_layout(scale, slice_enc)
     expand_scale = scale.expand_dims(rank)
-    broadcast_scale = expand_scale.broadcast_to(scale.type.shape + (32, ))
+    broadcast_scale = expand_scale.broadcast_to(scale.type.shape + (scale_factor, ))
     permute_order: ttgl.constexpr = tl_dot_get_permute_order(rank, dim)
     transposed_scale = broadcast_scale.permute(permute_order)
-    reshape_shape: ttgl.constexpr = tl_dot_get_reshape_shape(broadcast_scale.type, dim)
+    reshape_shape: ttgl.constexpr = tl_dot_get_reshape_shape(broadcast_scale.type, dim, scale_factor)
     return transposed_scale.reshape(reshape_shape)
 
 
@@ -236,7 +236,8 @@ def tl_dot_decomposed_get_transposed_order(rank):
 
 
 @gluon.jit
-def tl_dot_decomposed_extend_and_broadcast_scale(v, scale, compute_type, operand_index):
+def tl_dot_decomposed_extend_and_broadcast_scale(v, scale, compute_type: ttgl.constexpr, operand_index: ttgl.constexpr,
+                                                 scale_factor: ttgl.constexpr):
     rank: ttgl.constexpr = len(v.type.shape)
     k_dim: ttgl.constexpr = rank - 1 if operand_index == 0 else rank - 2
 
@@ -245,7 +246,7 @@ def tl_dot_decomposed_extend_and_broadcast_scale(v, scale, compute_type, operand
         scale = ttgl.permute(scale, order)
 
     scale16 = tl_dot_decomposed_scale_to_16(scale, compute_type)
-    reshape_scale = tl_dot_decomposed_broadcast_scale(scale16, k_dim)
+    reshape_scale = tl_dot_decomposed_broadcast_scale(scale16, k_dim, scale_factor)
     return ttgl.convert_layout(reshape_scale, v.type.layout), scale
 
 
@@ -256,7 +257,8 @@ def tl_dot_decomposed_mask_nan(mxfp, scale, fast_math):
 
 
 @gluon.jit
-def tl_dot_decomposed_scale_arg(v, scale, arg_format, operand_index, compute_type, fast_math):
+def tl_dot_decomposed_scale_arg(v, scale, arg_format: ttgl.constexpr, operand_index: ttgl.constexpr,
+                                compute_type: ttgl.constexpr, fast_math: ttgl.constexpr, scale_factor: ttgl.constexpr):
     is_fp4: ttgl.constexpr = arg_format == "e2m1"
     rank: ttgl.constexpr = len(v.type.shape)
     k_dim: ttgl.constexpr = rank - 1 if operand_index == 0 else rank - 2
@@ -268,6 +270,81 @@ def tl_dot_decomposed_scale_arg(v, scale, arg_format, operand_index, compute_typ
     if scale is None:
         return v
     else:
-        reshape_scale, scale = tl_dot_decomposed_extend_and_broadcast_scale(v, scale, compute_type, operand_index)
+        reshape_scale, scale = tl_dot_decomposed_extend_and_broadcast_scale(v, scale, compute_type, operand_index,
+                                                                            scale_factor)
         mxfp = ttgl.mul(v, reshape_scale)
         return tl_dot_decomposed_mask_nan(mxfp, scale, fast_math)
+
+
+@gluon.constexpr_function
+def tl_dot_decomposed_deduce_scale_factor(v, scale, arg_format, operand_index, k_pack):
+    if scale is None:
+        return 0
+    if scale.numel == 1:
+        return 0
+
+    k_dim = len(v.shape) - 1 if operand_index == 0 else len(v.shape) - 2
+    unpack_factor = 2 if arg_format == "e2m1" and k_pack else 1
+    k_size = v.shape[k_dim] * unpack_factor
+    scale_factor = k_size // scale.shape[-1]
+    assert scale_factor in (16, 32), f"scale factor must be 16 or 32. Got {scale_factor}"
+    return scale_factor
+
+
+@gluon.jit
+def tl_dot_decomposed_block_scales_impl(
+    tl_dot_scaled_fn: ttgl.constexpr,
+    tl_dot_fn: ttgl.constexpr,
+    lhs,
+    lhs_scale,
+    lhs_format,
+    rhs,
+    rhs_scale,
+    rhs_format,
+    acc=None,
+    fast_math=False,
+    lhs_k_pack=True,
+    rhs_k_pack=True,
+    out_dtype=ttgl.float32,
+):
+    if lhs_scale is None and rhs_scale is not None:
+        lhs_trans = tl_trans(lhs)
+        rhs_trans = tl_trans(rhs)
+        if acc is not None:
+            orig_layout: ttgl.constexpr = acc.type.layout
+            acc = tl_trans(acc)
+        result = tl_dot_scaled_fn(
+            rhs_trans,
+            rhs_scale,
+            rhs_format,
+            lhs_trans,
+            lhs_scale,
+            lhs_format,
+            acc,
+            fast_math,
+            lhs_k_pack,
+            rhs_k_pack,
+            out_dtype,
+        )
+        result = tl_trans(result)
+        if acc is not None:
+            result = ttgl.convert_layout(result, orig_layout)
+        return result
+    else:
+        ttgl.static_assert(not (not lhs_k_pack or not rhs_k_pack), "TODO: support m/n packed formats")
+        compute_type: ttgl.constexpr = (ttgl.float16 if
+                                        (lhs_format == "fp16" or rhs_format == "fp16") else ttgl.bfloat16)
+        lhs_scale_factor: ttgl.constexpr = tl_dot_decomposed_deduce_scale_factor(lhs, lhs_scale, lhs_format, 0,
+                                                                                 lhs_k_pack)
+        rhs_scale_factor: ttgl.constexpr = tl_dot_decomposed_deduce_scale_factor(rhs, rhs_scale, rhs_format, 1,
+                                                                                 rhs_k_pack)
+        scale_factor: ttgl.constexpr = lhs_scale_factor or rhs_scale_factor or 32
+        ttgl.static_assert(
+            lhs_scale_factor == 0 or rhs_scale_factor == 0 or lhs_scale_factor == rhs_scale_factor,
+            "Operands must have the same scale factor",
+        )
+
+        scale_a = tl_dot_decomposed_scale_arg(lhs, lhs_scale, lhs_format, 0, compute_type, fast_math, scale_factor)
+        scale_b = tl_dot_decomposed_scale_arg(rhs, rhs_scale, rhs_format, 1, compute_type, fast_math, scale_factor)
+
+        return tl_dot_fn(scale_a, scale_b, acc, out_dtype=out_dtype)

--- a/python/triton/tools/triton_to_gluon_translator/hopper_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/hopper_helpers.py
@@ -1,0 +1,287 @@
+# type: ignore
+
+import builtins
+
+from triton.experimental import gluon
+from triton.experimental.gluon import language as ttgl
+from triton.experimental.gluon.language.nvidia.hopper import (
+    fence_async_shared,
+    warpgroup_mma,
+    warpgroup_mma_wait,
+    warpgroup_mma_init,
+)
+
+from triton.tools.triton_to_gluon_translator.common_helpers import *  # noqa: F401,F403
+from triton.tools.triton_to_gluon_translator.common_helpers import (
+    tl_dot_decomposed_block_scales_impl,
+    default_blocked_layout,
+)
+from triton.tools.triton_to_gluon_translator.nvidia_helpers import *  # noqa: F401,F403
+from triton.tools.triton_to_gluon_translator.nvidia_helpers import (
+    tl_dot_mma_sync,
+    get_shared_memory_mma_operand,
+)
+
+# ---- NVIDIA Hopper dot ----
+
+
+@gluon.constexpr_function
+def _get_default_max_num_imprecise_acc(
+    a_ty: ttgl.block_type,
+    b_ty: ttgl.block_type,
+    max_num_imprecise_acc: int | None,
+) -> int:
+    # FIXME: Get this from builder options. Default is 2**30 for Hopper.
+    max_num_imprecise_acc_default = 2**30
+    if max_num_imprecise_acc is not None:
+        return max_num_imprecise_acc
+    if a_ty.element_ty.is_fp8() and b_ty.element_ty.is_fp8():
+        return max_num_imprecise_acc_default
+    return 0
+
+
+@gluon.constexpr_function
+def _get_default_input_precision(
+    allow_tf32: bool | None,
+    input_precision: str | None,
+) -> str:
+    assert input_precision is None or allow_tf32 is None, "Only one of input_precision and allow_tf32 can be specified"
+    if input_precision is not None:
+        return input_precision
+
+    allow_tf32 = allow_tf32 or True
+    return "tf32" if allow_tf32 else "ieee"
+
+
+@gluon.constexpr_function
+def _operand_supports_mmav3(dtype: ttgl.dtype) -> bool:
+    return (dtype.is_fp8() or dtype.is_fp16() or dtype.is_bf16() or dtype.is_fp32() or dtype.is_fp64()
+            or dtype.is_int8() or dtype.is_uint8())
+
+
+@gluon.constexpr_function
+def tl_dot_mmav3_supported(
+    a_ty: ttgl.block_type,
+    b_ty: ttgl.block_type,
+    num_warps: int,
+    input_precision: str,
+    max_num_imprecise_acc: int,
+    out_dtype: ttgl.dtype,
+) -> bool:
+
+    M = a_ty.shape[0]
+    N = b_ty.shape[1]
+    K = a_ty.shape[1]
+
+    a_dtype = a_ty.element_ty
+    b_dtype = b_ty.element_ty
+
+    # Minimum MMA instruction K shape.
+    mma_min_K = 256 // a_dtype.primitive_bitwidth
+    if K < mma_min_K:
+        return False
+
+    # Only rank 2 supported.
+    if len(a_ty.shape) != 2 or len(b_ty.shape) != 2:
+        return False
+
+    # Minimum 4 warps.
+    if num_warps % 4 != 0:
+        return False
+
+    # Minimum MMA instruction shape along M and N.
+    if M % 64 != 0 or N % 8 != 0:
+        return False
+
+    # Accepted LHS dtypes: float8e5m2, float8e4m3fn, u/int8, float16, bfloat16, float32.
+    if a_dtype not in [
+            ttgl.float8e5,
+            ttgl.float8e4nv,
+            ttgl.int8,
+            ttgl.uint8,
+            ttgl.float16,
+            ttgl.bfloat16,
+            ttgl.float32,
+    ]:
+        return False
+
+    # Check float8 -> float32 accumulation with imprecise acc.
+    if max_num_imprecise_acc < 32 and a_dtype in [ttgl.float8e5, ttgl.float8e4nv] and out_dtype.is_fp32():
+        return False
+
+    # fp32 operands require tf32.
+    if a_dtype.is_fp32() and b_dtype.is_fp32():
+        return input_precision == "tf32"
+
+    # Check supported operand dtypes.
+    return _operand_supports_mmav3(a_dtype) and _operand_supports_mmav3(b_dtype)
+
+
+@gluon.constexpr_function
+def _mmav3_acc_layout(
+    num_warps: int,
+    c_shape: list[int],
+    a_dtype: ttgl.dtype,
+    b_dtype: ttgl.dtype,
+    out_dtype: ttgl.dtype,
+):
+    k = 256 // a_dtype.primitive_bitwidth
+    assert c_shape[0] % 64 == 0 and c_shape[1] % 8 == 0, "c_shape must be divisible [64, 8]"
+
+    # fmt: off
+    if a_dtype.is_floating():
+        valid_n = [256, 248, 240, 232, 224, 216, 208, 200, 192, 184, 176,
+                   168, 160, 152, 144, 136, 128, 120, 112, 104, 96,  88,  # noqa: E241
+                    80,  72,  64,  56,  48,  40,  32,  24,  16,  8]       # noqa: E241, E127
+    else:
+        assert a_dtype.is_int()
+        valid_n = [224, 208, 192, 176, 160, 144, 128, 112, 96, 80, 64, 48, 32, 24, 16, 8]
+    # fmt: on
+
+    m = 16
+    m_warps = max(c_shape[0] // m, 1)
+    n_warps = max(num_warps // m_warps, 1)
+    max_n = max(c_shape[1] // n_warps, 8)
+    instr_shape = None
+    for n in valid_n:
+        if c_shape[1] % n == 0 and n <= max_n:
+            instr_shape = [m, n, k]
+            break
+
+    assert instr_shape is not None, "Failed to find valid instruction shape"
+
+    warps_per_tile = [4, 1]
+    shape_per_warp = [16, instr_shape[1]]
+    while True:
+        if warps_per_tile[0] * warps_per_tile[1] >= num_warps:
+            break
+        if c_shape[0] > shape_per_warp[0] * warps_per_tile[0]:
+            warps_per_tile[0] *= 2
+        else:
+            warps_per_tile[1] *= 2
+
+    return ttgl.NVMMADistributedLayout(
+        version=[3, 0],
+        warps_per_cta=warps_per_tile,
+        instr_shape=instr_shape,
+    )
+
+
+@gluon.jit
+def tl_dot_mmav3(
+    a: ttgl.tensor,
+    b: ttgl.tensor,
+    acc: ttgl.tensor | None,
+    input_precision: builtins.str,
+    max_num_imprecise_acc: int,
+    out_dtype: ttgl.dtype,
+):
+    el_ty: ttgl.constexpr = a.type.element_ty
+    allow_transpose: ttgl.constexpr = el_ty.is_fp16() or el_ty.is_bf16()
+    a_smem = get_shared_memory_mma_operand(a, 0, allow_transpose, is_fp4_padded=False, force_transpose=False)
+    b_smem = get_shared_memory_mma_operand(b, 1, allow_transpose, is_fp4_padded=False, force_transpose=False)
+
+    c_shape: ttgl.constexpr = a.shape[:-1] + [b.shape[-1]]
+    if acc is not None:
+        ttgl.static_assert(acc.shape == c_shape, "accumulator shape is incompatible")
+        ttgl.static_assert(acc.type.element_ty == out_dtype, "accumulator dtype is incompatible")
+
+    mma_layout: ttgl.constexpr = _mmav3_acc_layout(
+        ttgl.num_warps(),
+        c_shape,
+        a.type.element_ty,
+        b.type.element_ty,
+        out_dtype,
+    )
+
+    if acc is None:
+        ret_layout: ttgl.constexpr = default_blocked_layout(c_shape, ttgl.num_warps())
+        acc = ttgl.zeros(c_shape, out_dtype, layout=mma_layout)
+    else:
+        ret_layout: ttgl.constexpr = acc.type.layout
+        acc = ttgl.convert_layout(acc, mma_layout)
+
+    fence_async_shared()
+    wgmma_acc = warpgroup_mma_init(acc)
+    wgmma_acc = warpgroup_mma(a_smem, b_smem, wgmma_acc, is_async=True)
+    acc = warpgroup_mma_wait(num_outstanding=0, deps=(wgmma_acc, ))
+
+    return ttgl.convert_layout(acc, ret_layout)
+
+
+@gluon.jit
+def tl_dot(
+    a: ttgl.tensor,
+    b: ttgl.tensor,
+    acc: ttgl.tensor | None = None,
+    input_precision: builtins.str | None = None,
+    allow_tf32: builtins.bool | None = None,
+    max_num_imprecise_acc: int | None = None,
+    out_dtype: ttgl.dtype = ttgl.float32,
+):
+    input_prec: ttgl.constexpr = _get_default_input_precision(
+        allow_tf32,
+        input_precision,
+    )
+    max_num_imprecise: ttgl.constexpr = _get_default_max_num_imprecise_acc(
+        a.type,
+        b.type,
+        max_num_imprecise_acc,
+    )
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+
+    if tl_dot_mmav3_supported(a.type, b.type, num_warps, input_prec, max_num_imprecise, out_dtype):
+        return tl_dot_mmav3(a, b, acc, input_prec, max_num_imprecise, out_dtype)
+    else:
+        return tl_dot_mma_sync(a, b, acc, input_precision, out_dtype)
+
+
+# ---- NVIDIA Hopper dot-scaled ----
+
+
+@gluon.jit
+def tl_dot_scaled(
+    lhs,
+    lhs_scale,
+    lhs_format,
+    rhs,
+    rhs_scale,
+    rhs_format,
+    acc=None,
+    fast_math=False,
+    lhs_k_pack=True,
+    rhs_k_pack=True,
+    out_dtype=ttgl.float32,
+):
+    return tl_dot_decomposed_block_scales_impl(
+        tl_dot_scaled,
+        tl_dot,
+        lhs,
+        lhs_scale,
+        lhs_format,
+        rhs,
+        rhs_scale,
+        rhs_format,
+        acc=acc,
+        fast_math=fast_math,
+        lhs_k_pack=lhs_k_pack,
+        rhs_k_pack=rhs_k_pack,
+        out_dtype=out_dtype,
+    )
+
+
+# ---- NVIDIA obj dispatch ----
+
+
+@gluon.jit
+def tl_obj_gather(obj, x_offsets, y_offset):
+    ttgl.static_assert(not isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor),
+                       "descriptor gather is not supported on Hopper")
+    return obj.gather(x_offsets, y_offset)
+
+
+@gluon.jit
+def tl_obj_scatter(obj, value, x_offsets, y_offset):
+    ttgl.static_assert(not isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor),
+                       "descriptor scatter is not supported on Hopper")
+    return obj.scatter(value, x_offsets, y_offset)

--- a/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
@@ -5,19 +5,12 @@ from typing import Any
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia.ampere import mma_v2
-from triton.experimental.gluon.language.nvidia.blackwell import (
-    TensorMemoryLayout,
-    TensorMemoryScalesLayout,
-    allocate_tensor_memory,
-    tcgen05_commit,
-    tcgen05_mma,
-    tcgen05_mma_scaled,
-)
-from triton.experimental.gluon.language.nvidia.blackwell import tma as tma_blackwell
-from triton.experimental.gluon.language.nvidia.hopper import fence_async_shared, mbarrier, tma
+from triton.experimental.gluon.language.nvidia.hopper import mbarrier, tma
 from triton.language.core import _unwrap_if_constexpr
 
 from triton.tools.triton_to_gluon_translator.common_helpers import *  # noqa: F401,F403
+from triton.tools.triton_to_gluon_translator.common_helpers import (
+    tl_dot_decomposed_block_scales_impl, )
 
 # ---- NVIDIA MMA sync (Ampere) ----
 
@@ -61,30 +54,6 @@ def tl_dot_mma_sync(a, b, acc_init=None, input_precision=None, out_dtype=ttgl.fl
         layout: ttgl.constexpr = default_blocked_layout(result.type.shape, ttgl.num_warps())
     result = ttgl.convert_layout(result, layout)
     return result
-
-
-# ---- NVIDIA Blackwell dot ----
-
-
-@gluon.constexpr_function
-def tl_dot_mmav5_supported(a_ty, b_ty, num_warps, input_precision, allow_tf32, max_num_imprecise_acc):
-    assert max_num_imprecise_acc is None, ("max_num_imprecise_acc only applies to Hopper warp_group_dot")
-    assert input_precision is None or allow_tf32 is None, (
-        "Only one of input_precision and allow_tf32 can be specified")
-    if input_precision is None and (allow_tf32 or allow_tf32 is None):
-        input_precision = "tf32"
-
-    M = a_ty.shape[0]
-    N = b_ty.shape[1]
-    K = a_ty.shape[1]
-    min_K = 256 // a_ty.element_ty.primitive_bitwidth
-    if a_ty.element_ty.is_int() or b_ty.element_ty.is_int():
-        return False
-    if (min(a_ty.element_ty.primitive_bitwidth, b_ty.element_ty.primitive_bitwidth) >= 32
-            and input_precision != "tf32"):
-        return False
-    return (num_warps in [4, 8] and len(a_ty.shape) == 2 and len(b_ty.shape) == 2 and K >= min_K and M >= 64
-            and N >= 16)
 
 
 @gluon.constexpr_function
@@ -135,49 +104,6 @@ def get_shared_memory_mma_operand(value, operand_index, allow_transpose, is_fp4_
     return ttgl.allocate_shared_memory(value.dtype, value.shape, layout, value)
 
 
-@gluon.jit
-def tl_dot_blackwell(
-    a,
-    b,
-    acc=None,
-    input_precision=None,
-    allow_tf32=None,
-    max_num_imprecise_acc=None,
-    out_dtype=ttgl.float32,
-):
-    M: ttgl.constexpr = a.type.shape[0]
-    N: ttgl.constexpr = b.type.shape[1]
-
-    allow_transpose = not a.type.element_ty.is_fp32()
-    a_smem = get_shared_memory_mma_operand(a, 0, allow_transpose)
-    b_smem = get_shared_memory_mma_operand(b, 1, allow_transpose)
-
-    m: ttgl.constexpr = 128 if M >= 128 else 64
-    n: ttgl.constexpr = 256 if N >= 256 else N
-
-    acc_dtype: ttgl.constexpr = acc.dtype if acc is not None else out_dtype
-    col_stride: ttgl.constexpr = 32 // acc_dtype.primitive_bitwidth
-    acc_tmem_layout: ttgl.constexpr = TensorMemoryLayout([m, n], col_stride=col_stride)
-    acc_tmem = allocate_tensor_memory(acc_dtype, [M, N], acc_tmem_layout)
-    tmem_reg_layout: ttgl.constexpr = acc_tmem.get_reg_layout()
-    if acc is not None:
-        acc_temp = ttgl.convert_layout(acc, tmem_reg_layout)
-    else:
-        acc_temp = ttgl.zeros([M, N], out_dtype, layout=tmem_reg_layout)
-    acc_tmem.store(acc_temp)
-    bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
-    mbarrier.init(bar, count=1)
-    tcgen05_mma(a_smem, b_smem, acc_tmem, use_acc=True)
-    tcgen05_commit(bar)
-    mbarrier.wait(bar, phase=0)
-    mbarrier.invalidate(bar)
-
-    out = acc_tmem.load()
-    ret_layout: ttgl.constexpr = default_blocked_layout([M, N], ttgl.num_warps())
-    out = ttgl.convert_layout(out, ret_layout)
-    return out
-
-
 # ---- NVIDIA dot dispatch ----
 
 
@@ -191,11 +117,7 @@ def tl_dot(
     max_num_imprecise_acc=None,
     out_dtype=ttgl.float32,
 ):
-    num_warps: ttgl.constexpr = ttgl.num_warps()
-    if tl_dot_mmav5_supported(a.type, b.type, num_warps, input_precision, allow_tf32, max_num_imprecise_acc):
-        return tl_dot_blackwell(a, b, acc, input_precision, allow_tf32, max_num_imprecise_acc, out_dtype)
-    else:
-        return tl_dot_mma_sync(a, b, acc, input_precision, out_dtype)
+    return tl_dot_mma_sync(a, b, acc, input_precision, out_dtype)
 
 
 # ---- NVIDIA dot-scaled ----
@@ -346,35 +268,21 @@ def tl_dot_scaled(
     rhs_k_pack=True,
     out_dtype=ttgl.float32,
 ):
-    if (tl_dot_scaled_mmav5_supported(lhs.type, rhs.type, ttgl.num_warps()) and lhs_scale is not None
-            and rhs_scale is not None):
-        return tl_dot_scaled_blackwell(
-            lhs,
-            lhs_scale,
-            lhs_format,
-            rhs,
-            rhs_scale,
-            rhs_format,
-            acc,
-            fast_math,
-            lhs_k_pack,
-            rhs_k_pack,
-            out_dtype,
-        )
-    else:
-        return tl_dot_decomposed_block_scales(
-            lhs,
-            lhs_scale,
-            lhs_format,
-            rhs,
-            rhs_scale,
-            rhs_format,
-            acc,
-            fast_math,
-            lhs_k_pack,
-            rhs_k_pack,
-            out_dtype,
-        )
+    return tl_dot_decomposed_block_scales_impl(
+        tl_dot_scaled,
+        tl_dot,
+        lhs,
+        lhs_scale,
+        lhs_format,
+        rhs,
+        rhs_scale,
+        rhs_format,
+        acc,
+        fast_math,
+        lhs_k_pack,
+        rhs_k_pack,
+        out_dtype,
+    )
 
 
 @gluon.jit
@@ -423,84 +331,6 @@ def tl_dot_decomposed_block_scales(
         scale_b = tl_dot_decomposed_scale_arg(rhs, rhs_scale, rhs_format, 1, compute_type, fast_math)
 
         return tl_dot(scale_a, scale_b, acc, out_dtype=out_dtype)
-
-
-@gluon.jit
-def tl_dot_scaled_blackwell(
-    lhs,
-    lhs_scale,
-    lhs_format,
-    rhs,
-    rhs_scale,
-    rhs_format,
-    acc=None,
-    fast_math=False,
-    lhs_k_pack=True,
-    rhs_k_pack=True,
-    out_dtype=ttgl.float32,
-):
-    is_a_fp4: ttgl.constexpr = lhs_format == "e2m1"
-    is_b_fp4: ttgl.constexpr = rhs_format == "e2m1"
-
-    mixed_prec: ttgl.constexpr = lhs_format != rhs_format
-    is_a_mixed_prec_fp4: ttgl.constexpr = mixed_prec and is_a_fp4
-    is_b_mixed_prec_fp4: ttgl.constexpr = mixed_prec and not is_a_fp4 and is_b_fp4
-
-    is_mmav5_fp4_padded_a: ttgl.constexpr = is_a_mixed_prec_fp4 or not lhs_k_pack
-    is_mmav5_fp4_padded_b: ttgl.constexpr = is_b_mixed_prec_fp4 or not rhs_k_pack
-
-    a_smem = get_shared_memory_mma_operand(
-        lhs,
-        0,
-        allow_transpose=not is_a_fp4,
-        is_fp4_padded=is_mmav5_fp4_padded_a,
-        force_transpose=not lhs_k_pack,
-    )
-    b_smem = get_shared_memory_mma_operand(
-        rhs,
-        1,
-        allow_transpose=not is_b_fp4,
-        is_fp4_padded=is_mmav5_fp4_padded_b,
-        force_transpose=not rhs_k_pack,
-    )
-
-    M: ttgl.constexpr = lhs.type.shape[0]
-    N: ttgl.constexpr = rhs.type.shape[1]
-
-    m: ttgl.constexpr = 128
-    n: ttgl.constexpr = 256 if N >= 256 else N
-
-    acc_dtype: ttgl.constexpr = acc.dtype if acc is not None else out_dtype
-    col_stride: ttgl.constexpr = 32 // acc_dtype.primitive_bitwidth
-    acc_tmem_layout: ttgl.constexpr = TensorMemoryLayout([m, n], col_stride=col_stride)
-    acc_tmem = allocate_tensor_memory(acc_dtype, [M, N], acc_tmem_layout)
-    tmem_reg_layout: ttgl.constexpr = acc_tmem.get_reg_layout()
-    if acc is not None:
-        acc_temp = ttgl.convert_layout(acc, tmem_reg_layout)
-    else:
-        acc_temp = ttgl.zeros([M, N], out_dtype, layout=tmem_reg_layout)
-    acc_tmem.store(acc_temp)
-
-    bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
-    mbarrier.init(bar, count=1)
-    scale_layout: ttgl.constexpr = TensorMemoryScalesLayout()
-    a_scale_tmem = allocate_tensor_memory(lhs_scale.dtype, lhs_scale.shape, scale_layout)
-    b_scale_tmem = allocate_tensor_memory(rhs_scale.dtype, rhs_scale.shape, scale_layout)
-    scale_layout_reg_lhs: ttgl.constexpr = a_scale_tmem.get_reg_layout()
-    scale_layout_reg_rhs: ttgl.constexpr = b_scale_tmem.get_reg_layout()
-    lhs_scale = ttgl.convert_layout(lhs_scale, scale_layout_reg_lhs)
-    rhs_scale = ttgl.convert_layout(rhs_scale, scale_layout_reg_rhs)
-    a_scale_tmem.store(lhs_scale)
-    b_scale_tmem.store(rhs_scale)
-
-    tcgen05_mma_scaled(a_smem, b_smem, acc_tmem, a_scale_tmem, b_scale_tmem, lhs_format, rhs_format, use_acc=True)
-    tcgen05_commit(bar)
-    mbarrier.wait(bar, phase=0)
-    mbarrier.invalidate(bar)
-    out = acc_tmem.load()
-    ret_layout: ttgl.constexpr = default_blocked_layout([M, N], ttgl.num_warps())
-    out = ttgl.convert_layout(out, ret_layout)
-    return out
 
 
 @gluon.constexpr_function
@@ -570,40 +400,6 @@ def tl_load_tensor_descriptor(desc, offsets):
     return out
 
 
-@gluon.jit
-def tl_gather_tensor_descriptor(desc, x_offsets, y_offset):
-    desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
-    alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout)
-    bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
-    mbarrier.init(bar, count=1)
-    x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
-        0,
-        ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
-    )
-    x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
-    mbarrier.expect(bar, x_offsets.shape[0] * desc.block_type.nbytes)
-    tma_blackwell.async_gather(desc, x_offsets, y_offset, bar, alloc)
-    mbarrier.wait(bar, phase=0)
-    mbarrier.invalidate(bar)
-    ret_layout: ttgl.constexpr = default_blocked_layout(desc.block_shape, ttgl.num_warps())
-    out = alloc.load(ret_layout)
-    return out
-
-
-@gluon.jit
-def tl_scatter_tensor_descriptor(desc, value, x_offsets, y_offset):
-    desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
-    alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout, value)
-    fence_async_shared()
-    x_offsets_layout: ttgl.constexpr = ttgl.SliceLayout(
-        0,
-        ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
-    )
-    x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
-    tma_blackwell.async_scatter(desc, x_offsets, y_offset, alloc)
-    tma.store_wait(0)
-
-
 # ---- NVIDIA obj dispatch ----
 
 
@@ -625,18 +421,12 @@ def tl_obj_load(obj, offsets):
 
 @gluon.jit
 def tl_obj_gather(obj, x_offsets, y_offset):
-    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
-        return tl_gather_tensor_descriptor(obj, x_offsets, y_offset)
-    else:
-        return obj.gather(x_offsets, y_offset)
+    return obj.gather(x_offsets, y_offset)
 
 
 @gluon.jit
 def tl_obj_scatter(obj, value, x_offsets, y_offset):
-    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
-        return tl_scatter_tensor_descriptor(obj, value, x_offsets, y_offset)
-    else:
-        return obj.scatter(value, x_offsets, y_offset)
+    return obj.scatter(value, x_offsets, y_offset)
 
 
 # ---- NVIDIA host-side descriptor ----

--- a/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
+++ b/python/triton/tools/triton_to_gluon_translator/nvidia_helpers.py
@@ -570,22 +570,8 @@ def tl_load_tensor_descriptor(desc, offsets):
     return out
 
 
-# ---- NVIDIA obj dispatch ----
-
-
 @gluon.jit
-def tl_obj_store(obj, offsets, value):
-    tl_store_tensor_descriptor(obj, offsets, value)
-
-
-@gluon.jit
-def tl_obj_load(obj, offsets):
-    return tl_load_tensor_descriptor(obj, offsets)
-
-
-@gluon.jit
-def tl_obj_gather(obj, x_offsets, y_offset):
-    desc = obj
+def tl_gather_tensor_descriptor(desc, x_offsets, y_offset):
     desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
     alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout)
     bar = ttgl.allocate_shared_memory(ttgl.int64, [1], mbarrier.MBarrierLayout())
@@ -595,7 +581,7 @@ def tl_obj_gather(obj, x_offsets, y_offset):
         ttgl.BlockedLayout([1, 4], [get_num_threads_per_warp(), 1], [1, ttgl.num_warps()], [1, 0]),
     )
     x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
-    mbarrier.expect(bar, x_offsets.shape[0] * obj.block_type.nbytes)
+    mbarrier.expect(bar, x_offsets.shape[0] * desc.block_type.nbytes)
     tma_blackwell.async_gather(desc, x_offsets, y_offset, bar, alloc)
     mbarrier.wait(bar, phase=0)
     mbarrier.invalidate(bar)
@@ -605,8 +591,7 @@ def tl_obj_gather(obj, x_offsets, y_offset):
 
 
 @gluon.jit
-def tl_obj_scatter(obj, value, x_offsets, y_offset):
-    desc = obj
+def tl_scatter_tensor_descriptor(desc, value, x_offsets, y_offset):
     desc_shape: ttgl.constexpr = [x_offsets.shape[0], desc.block_shape[1]]
     alloc = ttgl.allocate_shared_memory(desc.dtype, desc_shape, desc.layout, value)
     fence_async_shared()
@@ -617,6 +602,41 @@ def tl_obj_scatter(obj, value, x_offsets, y_offset):
     x_offsets = ttgl.convert_layout(x_offsets, x_offsets_layout)
     tma_blackwell.async_scatter(desc, x_offsets, y_offset, alloc)
     tma.store_wait(0)
+
+
+# ---- NVIDIA obj dispatch ----
+
+
+@gluon.jit
+def tl_obj_store(obj, offsets, value):
+    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
+        return tl_store_tensor_descriptor(obj, offsets, value)
+    else:
+        return obj.store(offsets, value)
+
+
+@gluon.jit
+def tl_obj_load(obj, offsets):
+    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
+        return tl_load_tensor_descriptor(obj, offsets)
+    else:
+        return obj.load(offsets)
+
+
+@gluon.jit
+def tl_obj_gather(obj, x_offsets, y_offset):
+    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
+        return tl_gather_tensor_descriptor(obj, x_offsets, y_offset)
+    else:
+        return obj.gather(x_offsets, y_offset)
+
+
+@gluon.jit
+def tl_obj_scatter(obj, value, x_offsets, y_offset):
+    if isinstance(obj, ttgl.nvidia.hopper.tma.tensor_descriptor):
+        return tl_scatter_tensor_descriptor(obj, value, x_offsets, y_offset)
+    else:
+        return obj.scatter(value, x_offsets, y_offset)
 
 
 # ---- NVIDIA host-side descriptor ----

--- a/python/triton/tools/triton_to_gluon_translator/slice_kernel.py
+++ b/python/triton/tools/triton_to_gluon_translator/slice_kernel.py
@@ -533,10 +533,10 @@ class ReferenceRewriter(ast.NodeTransformer):
 
 @dataclass
 class SliceRewriter(ReferenceRewriter):
+    target: TranslatorTarget = field(kw_only=True)
     translate_to_gluon: bool = False
     inline_helpers: ordered_set[str] = field(default_factory=ordered_set[str])
     cvt_context: list[bool] = field(default_factory=lambda: [False])
-    target: TranslatorTarget = TranslatorTarget.NVIDIA
 
     def __post_init__(self) -> None:
         # Special rules for sugaring imports.
@@ -627,8 +627,14 @@ def is_stdlib_module(module: ModuleType) -> bool:
     if origin in ["built-in", "frozen"]:
         return True
 
-    stdlib_path = Path(sysconfig.get_paths()["stdlib"])
-    return Path(origin).is_relative_to(stdlib_path)
+    origin_path = Path(origin)
+    sys_paths = sysconfig.get_paths()
+    site_package_paths = [Path(sys_paths[key]) for key in ("purelib", "platlib") if key in sys_paths]
+    if any(origin_path.is_relative_to(site_path) for site_path in site_package_paths):
+        return False
+
+    stdlib_paths = [Path(sys_paths[key]) for key in ("stdlib", "platstdlib") if key in sys_paths]
+    return any(origin_path.is_relative_to(stdlib_path) for stdlib_path in stdlib_paths)
 
 
 def find_references(
@@ -725,7 +731,8 @@ def slice_kernel(
     leaf_paths: list[str] | None = None,
     translate_to_gluon: bool = False,
     rewrite_spec: RewriteSpec | None = None,
-    target: TranslatorTarget = TranslatorTarget.NVIDIA,
+    *,
+    target: TranslatorTarget,
 ) -> str:
     rewrite_spec = rewrite_spec or RewriteSpec()
     base_values: list[GlobalValue] = [get_base_value(root_path) for root_path in root_paths]
@@ -826,7 +833,8 @@ def slice_kernel_from_trace(
     translate_to_gluon: bool,
     extra_modules: dict[str, str],
     rewrite_spec: RewriteSpec | None = None,
-    target: TranslatorTarget = TranslatorTarget.NVIDIA,
+    *,
+    target: TranslatorTarget,
 ) -> str:
     module_remap: dict[str, str] = {}
     for name, path in extra_modules.items():
@@ -873,7 +881,8 @@ def main(
     leaf_paths: list[str] | None = None,
     translate_to_gluon: bool = False,
     output_path: str = "/tmp/reference.py",
-    target: TranslatorTarget = TranslatorTarget.NVIDIA,
+    *,
+    target: TranslatorTarget,
 ) -> None:
     output = slice_kernel(
         root_paths=root_paths,
@@ -899,6 +908,7 @@ def _main_cli() -> None:
     parser.add_argument("--translate-to-gluon", action="store_true",
                         help="Translate Triton JIT callables to Gluon while slicing.")
     parser.add_argument("--output-path", default="/tmp/reference.py", help="Path to write the sliced output.")
+    parser.add_argument("--target", required=True, help="Target architecture (e.g. nvidia, gfx1250).")
     args = parser.parse_args()
     main(
         root_paths=args.root_paths,
@@ -907,6 +917,7 @@ def _main_cli() -> None:
         leaf_paths=args.leaf_paths or None,
         translate_to_gluon=args.translate_to_gluon,
         output_path=args.output_path,
+        target=TranslatorTarget(args.target),
     )
 
 

--- a/python/triton/tools/triton_to_gluon_translator/slice_kernel.py
+++ b/python/triton/tools/triton_to_gluon_translator/slice_kernel.py
@@ -121,6 +121,13 @@ class GlobalValue:
 
 FilterFn = Callable[[ModuleType | GlobalValue], bool]
 DecoratorMatcher: TypeAlias = Callable[[scoped_dict[str, Any], ModuleType, ast.expr], bool]
+AnnotationRewriter: TypeAlias = Callable[[scoped_dict[str, Any], ModuleType, ast.Subscript], ast.expr | None]
+
+
+@dataclass
+class RewriteSpec:
+    ignored_decorator_matchers: Sequence[DecoratorMatcher] = field(default_factory=tuple)
+    annotation_rewriters: Sequence[AnnotationRewriter] = field(default_factory=tuple)
 
 
 def get_assign_target(stmt: ast.Assign | ast.AnnAssign) -> ast.Name | None:
@@ -240,9 +247,9 @@ def is_ignored_decorator(
     context: scoped_dict[str, Any],
     cur_module: ModuleType,
     decorator: ast.expr,
-    ignored_decorator_matchers: Sequence[DecoratorMatcher],
+    rewrite_spec: RewriteSpec,
 ) -> bool:
-    return any(matcher(context, cur_module, decorator) for matcher in ignored_decorator_matchers)
+    return any(matcher(context, cur_module, decorator) for matcher in rewrite_spec.ignored_decorator_matchers)
 
 
 @dataclass
@@ -266,7 +273,7 @@ class ReferenceScanner(ast.NodeVisitor):
     queue: list[GlobalValue]
     value_remap: dict[int, GlobalValue]
     filter: FilterFn
-    ignored_decorator_matchers: Sequence[DecoratorMatcher] = field(default_factory=tuple)
+    rewrite_spec: RewriteSpec = field(default_factory=RewriteSpec)
 
     edges: ordered_set[int] = field(default_factory=ordered_set[int])
 
@@ -311,7 +318,7 @@ class ReferenceScanner(ast.NodeVisitor):
                 self.context,
                 self.cur_module,
                 decorator,
-                self.ignored_decorator_matchers,
+                self.rewrite_spec,
             )
         ]
         args = node.args
@@ -430,7 +437,7 @@ class ReferenceRewriter(ast.NodeTransformer):
     imports: ordered_set[str]
     filter: FilterFn
     value_remap: dict[int, GlobalValue]
-    ignored_decorator_matchers: Sequence[DecoratorMatcher] = field(default_factory=tuple)
+    rewrite_spec: RewriteSpec = field(default_factory=RewriteSpec)
 
     rewrites: list[RewriteFn] = field(default_factory=list)
 
@@ -485,6 +492,13 @@ class ReferenceRewriter(ast.NodeTransformer):
             return self.generic_visit(node)
         value, rel_module, name = ref
         return self.process_reference(node, name, value, rel_module)
+
+    def visit_Subscript(self, node: ast.Subscript) -> ast.AST:
+        for rewriter in self.rewrite_spec.annotation_rewriters:
+            replacement = rewriter(self.context, self.cur_module, node)
+            if replacement is not None:
+                return ast.copy_location(self.visit(replacement), node)
+        return self.generic_visit(node)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
         args = node.args
@@ -593,7 +607,7 @@ class SliceRewriter(ReferenceRewriter):
                     self.context,
                     self.cur_module,
                     decorator,
-                    self.ignored_decorator_matchers,
+                    self.rewrite_spec,
             ):
                 new_decorators = []
                 continue
@@ -621,12 +635,12 @@ def find_references(
     base_values: list[GlobalValue],
     filter: FilterFn,
     value_remap: dict[int, GlobalValue],
-    ignored_decorator_matchers: Sequence[DecoratorMatcher] | None = None,
+    rewrite_spec: RewriteSpec | None = None,
 ) -> tuple[OrderedDict[int, Reference], dict[int, ordered_set[int]]]:
     references: OrderedDict[int, Reference] = OrderedDict()
     queue: list[GlobalValue] = []
     graph: dict[int, ordered_set[int]] = {}
-    ignored_decorator_matchers = tuple(ignored_decorator_matchers or ())
+    rewrite_spec = rewrite_spec or RewriteSpec()
 
     for base_value in base_values:
         base_value = value_remap.get(base_value.id, base_value)
@@ -647,7 +661,7 @@ def find_references(
             queue,
             value_remap,
             filter,
-            ignored_decorator_matchers=ignored_decorator_matchers,
+            rewrite_spec=rewrite_spec,
         )
         tree = value.parse_ast()
         scanner.visit(tree)
@@ -675,7 +689,7 @@ def mangle_reference_names(references: OrderedDict[int, Reference], filter: Filt
 def find_jit_functions(
     base_values: list[GlobalValue],
     filter: FilterFn,
-    ignored_decorator_matchers: Sequence[DecoratorMatcher] | None = None,
+    rewrite_spec: RewriteSpec | None = None,
 ) -> list[GlobalValue]:
 
     def new_filter(value: ModuleType | GlobalValue) -> bool:
@@ -687,7 +701,7 @@ def find_jit_functions(
         base_values,
         new_filter,
         value_remap={},
-        ignored_decorator_matchers=ignored_decorator_matchers,
+        rewrite_spec=rewrite_spec,
     )
     return [
         reference.value for reference in references.values() if isinstance(reference.value.original_value, JITFunction)
@@ -710,9 +724,10 @@ def slice_kernel(
     include_below: list[str] | None = None,
     leaf_paths: list[str] | None = None,
     translate_to_gluon: bool = False,
-    ignored_decorator_matchers: Sequence[DecoratorMatcher] | None = None,
+    rewrite_spec: RewriteSpec | None = None,
     target: TranslatorTarget = TranslatorTarget.NVIDIA,
 ) -> str:
+    rewrite_spec = rewrite_spec or RewriteSpec()
     base_values: list[GlobalValue] = [get_base_value(root_path) for root_path in root_paths]
     base_value_ids: set[int] = set()
     for leaf_path in leaf_paths or []:
@@ -736,7 +751,7 @@ def slice_kernel(
         jit_functions = find_jit_functions(
             base_values,
             filter,
-            ignored_decorator_matchers=ignored_decorator_matchers,
+            rewrite_spec=rewrite_spec,
         )
         jit_functions = [fn for fn in jit_functions if not fn.original_value.is_gluon()]
         converted_functions = translate_kernels(jit_functions, target=target)
@@ -753,7 +768,7 @@ def slice_kernel(
         base_values,
         filter,
         value_remap,
-        ignored_decorator_matchers=ignored_decorator_matchers,
+        rewrite_spec=rewrite_spec,
     )
     mangle_reference_names(references, filter)
 
@@ -782,7 +797,7 @@ def slice_kernel(
             imports,
             filter,
             value_remap,
-            ignored_decorator_matchers=tuple(ignored_decorator_matchers or ()),
+            rewrite_spec=rewrite_spec,
             translate_to_gluon=translate_to_gluon,
             inline_helpers=inline_helpers,
             target=target,
@@ -810,7 +825,7 @@ def slice_kernel_from_trace(
     trace: list[dict[str, list[str]]],
     translate_to_gluon: bool,
     extra_modules: dict[str, str],
-    ignored_decorator_matchers: Sequence[DecoratorMatcher] | None = None,
+    rewrite_spec: RewriteSpec | None = None,
     target: TranslatorTarget = TranslatorTarget.NVIDIA,
 ) -> str:
     module_remap: dict[str, str] = {}
@@ -835,7 +850,7 @@ def slice_kernel_from_trace(
         leaf_modules=["triton", "torch", "ki.spo"],
         leaf_paths=sorted(leaf_paths),
         translate_to_gluon=translate_to_gluon,
-        ignored_decorator_matchers=ignored_decorator_matchers,
+        rewrite_spec=rewrite_spec,
         target=target,
     )
 
@@ -858,16 +873,14 @@ def main(
     leaf_paths: list[str] | None = None,
     translate_to_gluon: bool = False,
     output_path: str = "/tmp/reference.py",
-    ignored_decorator_matchers: Sequence[DecoratorMatcher] | None = None,
     target: TranslatorTarget = TranslatorTarget.NVIDIA,
 ) -> None:
     output = slice_kernel(
-        root_paths,
-        leaf_modules,
-        include_below,
-        leaf_paths,
-        translate_to_gluon,
-        ignored_decorator_matchers,
+        root_paths=root_paths,
+        leaf_modules=leaf_modules,
+        include_below=include_below,
+        leaf_paths=leaf_paths,
+        translate_to_gluon=translate_to_gluon,
         target=target,
     )
     with open(output_path, "w") as f:

--- a/python/triton/tools/triton_to_gluon_translator/target.py
+++ b/python/triton/tools/triton_to_gluon_translator/target.py
@@ -11,15 +11,19 @@ class TranslatorTarget(str, Enum):
     new AMD architectures work without adding an enum member.
     """
 
-    NVIDIA = "nvidia"
+    GENERIC = "generic"
+    SM80 = "sm80"
+    SM90 = "sm90"
+    SM100 = "sm100"
+    SM103 = "sm103"
     # AMD targets currently exercised by the translator test suite:
+    GFX90A = "gfx90a"
     GFX1250 = "gfx1250"
     GFX942 = "gfx942"
     GFX950 = "gfx950"
 
     @classmethod
     def _missing_(cls, value: object) -> "TranslatorTarget | None":
-        """Allow any ``gfx*`` string as a valid AMD target."""
         if isinstance(value, str) and value.startswith("gfx"):
             obj = str.__new__(cls, value)
             obj._value_ = value
@@ -28,19 +32,35 @@ class TranslatorTarget(str, Enum):
 
     @property
     def is_amd(self) -> bool:
-        return self != TranslatorTarget.NVIDIA
+        return self.value.startswith("gfx")
+
+    @property
+    def is_nvidia(self) -> bool:
+        return self in (
+            TranslatorTarget.SM80,
+            TranslatorTarget.SM90,
+            TranslatorTarget.SM100,
+            TranslatorTarget.SM103,
+        )
 
     @property
     def tensor_descriptor_import(self) -> str:
-        """Return the import statement for the target's tensor descriptor module."""
-        if self.is_amd:
-            return "from triton.experimental.gluon.language.amd.gfx1250.tdm import tensor_descriptor"
-        return "from triton.experimental.gluon.language.nvidia.hopper.tma import tensor_descriptor"
+        module = "amd.gfx1250.tdm" if self.is_amd else "nvidia.hopper.tma"
+        return f"from triton.experimental.gluon.language.{module} import tensor_descriptor"
 
     @property
     def helpers_module(self) -> str:
-        """Return the helpers module path for this target."""
         base = "triton.tools.triton_to_gluon_translator"
+
         if self.is_amd:
             return f"{base}.amd_helpers"
-        return f"{base}.nvidia_helpers"
+
+        if self.is_nvidia:
+            if self in (TranslatorTarget.SM100, TranslatorTarget.SM103):
+                return f"{base}.blackwell_helpers"
+            if self in (TranslatorTarget.SM90):
+                return f"{base}.hopper_helpers"
+            if self in (TranslatorTarget.SM80):
+                return f"{base}.nvidia_helpers"
+
+        return f"{base}.common_helpers"

--- a/python/triton/tools/triton_to_gluon_translator/translator.py
+++ b/python/triton/tools/triton_to_gluon_translator/translator.py
@@ -108,8 +108,8 @@ def add_expr_rewrites(rewrites: list[RewriteFn]) -> None:
 
 @dataclass
 class Translator(ReferenceRewriter):
+    target: TranslatorTarget = field(kw_only=True)
     tensor_member_match_fns: list[str] = field(default_factory=list)
-    target: TranslatorTarget = TranslatorTarget.NVIDIA
 
     def __post_init__(self) -> None:
         import triton
@@ -127,7 +127,7 @@ class Translator(ReferenceRewriter):
         self.imports.add("import triton.experimental.gluon.language as gl")
         self.imports.add(f"import {self.target.helpers_module} as helpers")
 
-        self.tensor_member_match_fns = ["reshape", "trans", "permute", "split", "reduce", "sum"]
+        self.tensor_member_match_fns = ["reshape", "trans", "permute", "split", "reduce", "sum", "expand_dims"]
 
     def visit_Attribute(self, node: ast.Attribute) -> ast.AST:
         new_node = super().visit_Attribute(node)
@@ -170,6 +170,9 @@ class Translator(ReferenceRewriter):
             node.keywords = [kw for kw in node.keywords if kw.arg != "can_reorder"]
         elif value is tl.split:
             node.args[0] = parse_expr(f"helpers.set_split_src_layout({ast.unparse(node.args[0])})")
+        elif value is tl.expand_dims:
+            node.args[0] = parse_expr(
+                f"helpers.convert_to_expand_dims_layout({ast.unparse(node.args[0])}, [{ast.unparse(node.args[1])}])")
         elif value is tl.range:
             return ast.Call(
                 func=ast.Name("range", ast.Load()),
@@ -200,7 +203,7 @@ class Translator(ReferenceRewriter):
         return self.generic_visit(node)
 
 
-def translate_kernels(kernels: list[GlobalValue], target: TranslatorTarget = TranslatorTarget.NVIDIA) -> str:
+def translate_kernels(kernels: list[GlobalValue], target: TranslatorTarget) -> str:
 
     def filter(value: ModuleType | GlobalValue) -> bool:
         if isinstance(value, ModuleType):
@@ -253,12 +256,12 @@ def translate_kernels(kernels: list[GlobalValue], target: TranslatorTarget = Tra
     return output
 
 
-def translate_paths(kernel_paths: list[str], target: TranslatorTarget = TranslatorTarget.NVIDIA) -> str:
+def translate_paths(kernel_paths: list[str], target: TranslatorTarget) -> str:
     kernels = [get_base_value(kernel_path) for kernel_path in kernel_paths]
     return translate_kernels(kernels, target=target)
 
 
-def convert_triton_to_gluon(src: list[JITCallable], target: TranslatorTarget = TranslatorTarget.NVIDIA) -> str:
+def convert_triton_to_gluon(src: list[JITCallable], target: TranslatorTarget) -> str:
     kernels = [
         GlobalValue.wrap(
             kernel,
@@ -269,7 +272,7 @@ def convert_triton_to_gluon(src: list[JITCallable], target: TranslatorTarget = T
     return translate_kernels(kernels, target=target)
 
 
-def main(kernels: list[str], output_path: str, target: TranslatorTarget = TranslatorTarget.NVIDIA) -> None:
+def main(kernels: list[str], output_path: str, target: TranslatorTarget) -> None:
     output = translate_paths(kernels, target=target)
     with open(output_path, "w") as f:
         f.write(output)
@@ -279,7 +282,7 @@ def _main_cli() -> None:
     parser = argparse.ArgumentParser(description="Translate Triton kernels to Gluon source.")
     parser.add_argument("kernels", nargs="+", help="Kernel symbols in module.path:object format.")
     parser.add_argument("--output-path", required=True, help="Path to write the translated source.")
-    parser.add_argument("--target", default="nvidia", help="Target architecture (e.g. nvidia, amd_gfx1250).")
+    parser.add_argument("--target", required=True, help="Target architecture (e.g. nvidia, gfx1250).")
     args = parser.parse_args()
     main(args.kernels, args.output_path, target=TranslatorTarget(args.target))
 

--- a/test/Conversion/amd/tritongpu_tdm_stride_order.mlir
+++ b/test/Conversion/amd/tritongpu_tdm_stride_order.mlir
@@ -4,9 +4,7 @@
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @tdm_load_runtime_strides(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %stride0: i64, %stride1: i64) {
     %c_shape = arith.constant 128 : i32
-    %c_stride0 = arith.constant 128 : i64
-    %c_stride1 = arith.constant 1 : i64
-    // expected-error @+2 {{requires at least one dimension to have stride 1}}
+    // expected-error @+2 {{last dimension must have stride 1}}
     // expected-error @+1 {{failed to legalize operation}}
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%stride0, %stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
     tt.return
@@ -17,12 +15,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 #shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @tdm_1x1_tensor(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %stride0: i64, %stride1: i64) {
+  // CHECK-LABEL: tdm_1x1_tensor
+  tt.func public @tdm_1x1_tensor(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %stride1: i64) {
     %c_shape = arith.constant 1 : i32
     %c_stride1 = arith.constant 1 : i64
-    // expected-error @+2 {{requires at least one dimension to have stride 1}}
-    // expected-error @+1 {{failed to legalize operation}}
-    %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%stride1, %stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
+    %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride1, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
     tt.return
   }
 }
@@ -34,7 +31,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   tt.func public @tdm_wrong_stride_order(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %runtime_stride: i64) {
     %c_shape = arith.constant 128 : i32
     %c_stride1 = arith.constant 1 : i64
-    // expected-error @+2 {{requires shared order [rank-2, rank-1, rank-3, rank-4, ..., 0] because dim[rank-2] has stride 1}}
+    // expected-error @+2 {{last dimension must have stride 1}}
     // expected-error @+1 {{failed to legalize operation}}
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride1, %runtime_stride] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
     tt.return
@@ -107,7 +104,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %c_stride1 = arith.constant 1 : i64
     %c_shape = arith.constant 1 : i32
     %c_shape2 = arith.constant 128 : i32
-    // expected-error @+2 {{requires all stride 1 dimensions to be consecutive starting from the last dimension}}
+    // expected-error @+2 {{last dimension must have stride 1}}
     // expected-error @+1 {{failed to legalize operation}}
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape, %c_shape2], [%c_stride1, %c_stride1, %runtime_stride] : !tt.ptr<f16>, !tt.tensordesc<1x1x1xf16, #shared>
     tt.return

--- a/test/Conversion/tma_multicast_to_llvm.mlir
+++ b/test/Conversion/tma_multicast_to_llvm.mlir
@@ -1,0 +1,27 @@
+// RUN: triton-opt %s --convert-triton-gpu-to-llvm --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | FileCheck %s
+
+#blocked_bcast = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 0]]}>
+#shared_bar_bcast = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#shared_gather_bcast = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+
+// CHECK-LABEL: @tma_gather_multicast
+tt.func public @tma_gather_multicast(%arg0: !tt.tensordesc<1x128xbf16, #shared_gather_bcast>, %arg1: !ttg.memdesc<1xi64, #shared_bar_bcast, #smem, mutable>, %arg2: tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked_bcast}>>, %arg3: i32, %arg4: !ttg.memdesc<32x128xbf16, #shared_gather_bcast, #smem, mutable>, %arg5: i1) {
+  // CHECK: [[BAR:%.*]] = extractvalue {{.*}} %1, 0
+  // CHECK: [[BAR_INT:%.*]] = ptrtoint ptr addrspace(3) [[BAR]] to i64
+  // CHECK: [[LEADER_BAR_INT:%.*]] = and i64 [[BAR_INT]],
+  // CHECK: [[LEADER_BAR:%.*]] = inttoptr i64 [[LEADER_BAR_INT]] to ptr addrspace(3)
+  // CHECK: [[ELECT:%.*]] = tail call { i32, i1 } @llvm.nvvm.elect.sync
+  // CHECK: [[ELECT_PRED:%.*]] = extractvalue { i32, i1 } [[ELECT]], 1
+  // CHECK: [[PRED:%.*]] = and i1 {{.*}}, [[ELECT_PRED]]
+  // CHECK: "@$0 cp.async.bulk.tensor.2d.tile::gather4.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster [$1], [$2, {$3, $4, $5, $6, $7}], [$8], $9;", "b,r,l,r,r,r,r,r,r,h"
+  // CHECK-SAME: (i1 [[PRED]], ptr addrspace(3) {{.*}}, ptr nonnull %0, i32 %3, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, ptr addrspace(3) [[LEADER_BAR]], i32 {{(%[0-9]+|3)}})
+  ttng.async_tma_gather %arg0[%arg2, %arg3] %arg4, %arg1, %arg5 {multicast} : !tt.tensordesc<1x128xbf16, #shared_gather_bcast>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked_bcast}>>, i32, !ttg.memdesc<1xi64, #shared_bar_bcast, #smem, mutable>, !ttg.memdesc<32x128xbf16, #shared_gather_bcast, #smem, mutable>, i1
+
+  // CHECK: ret void
+  tt.return
+}
+
+}

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -555,8 +555,30 @@ tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<1x1x8x2x256xi8, #shared, #t
   // CHECK-NOT: tcgen05.commit
   ttng.tmem_copy %src, %dst : !ttg.memdesc<1x1x8x2x256xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>
   tt.return
+  }
 }
 
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 0]]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true} {
+  // CHECK-LABEL: @tma_scatter_broadcast_two_ctas
+  // CHECK: %[[CTA:.+]] = nvg.cluster_id
+  // CHECK: %[[MASK:.+]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK: %[[CTA_IN_GROUP:.+]] = llvm.and %[[CTA]], %[[MASK]] : i32
+  // CHECK: %[[ZERO:.+]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK: %[[IS_LEADER:.+]] = llvm.icmp "eq" %[[CTA_IN_GROUP]], %[[ZERO]] : i32
+  // CHECK: %[[WARP_PRED:.+]] = llvm.icmp "eq" {{.*}} : i32
+  // CHECK: %[[LEADER_WARP_PRED:.+]] = llvm.and %[[IS_LEADER]], %[[WARP_PRED]] : i1
+  // CHECK: %[[ELECT:.+]] = nvvm.elect.sync -> i1
+  // CHECK: %[[PRED:.+]] = llvm.and %[[LEADER_WARP_PRED]], %[[ELECT]] : i1
+  // CHECK: @$0 cp.async.bulk.tensor.2d.tile::scatter4.global.shared::cta.bulk_group
+  // CHECK-SAME: "b,l,r,r,r,r,r,r" %[[PRED]],
+  tt.func @tma_scatter_broadcast_two_ctas(%desc: !tt.tensordesc<1x128xbf16, #shared>, %x_offsets: tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>, %y_offset: i32, %src: !ttg.memdesc<32x128xbf16, #shared, #ttg.shared_memory, mutable>) {
+    ttng.async_tma_scatter %desc[%x_offsets, %y_offset] %src : !tt.tensordesc<1x128xbf16, #shared>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>, i32, !ttg.memdesc<32x128xbf16, #shared, #ttg.shared_memory, mutable>
+    tt.return
+  }
 }
 
 // -----

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -362,6 +362,23 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#blocked_offsets = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+#shared0_cluster = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#shared1_split = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: tma_gather_barrier_mask_nonzero
+  // Gather uses shared::cluster when barrier mask is non-zero
+  // CHECK: cp.async.bulk.tensor.2d.tile::gather4.shared::cluster.global.mbarrier::complete_tx::bytes
+  // CHECK-NOT: cp.async.bulk.tensor.2d.tile::gather4.shared::cta.global.mbarrier
+  tt.func @tma_gather_barrier_mask_nonzero(%tma: !tt.tensordesc<1x128xbf16, #shared1_split>, %alloc: !ttg.memdesc<32x128xbf16, #shared1_split, #smem, mutable>, %x_offsets: tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked_offsets}>>, %y: i32, %barrier: !ttg.memdesc<1xi64, #shared0_cluster, #smem>, %pred: i1) {
+    ttng.async_tma_gather %tma[%x_offsets, %y] %alloc, %barrier, %pred : !tt.tensordesc<1x128xbf16, #shared1_split>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked_offsets}>>, i32, !ttg.memdesc<1xi64, #shared0_cluster, #smem>, !ttg.memdesc<32x128xbf16, #shared1_split, #smem, mutable>, i1
+    tt.return
+  }
+}
+
+// -----
+
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32}>
 #smem = #ttg.shared_memory
@@ -557,6 +574,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK: nvvm.cp.async.bulk.commit.group
   tt.func @tma_reduce(%tma: !tt.tensordesc<128x128xf32, #shared1>, %alloc: !ttg.memdesc<128x128xf32, #shared1, #smem>, %x: i32) {
     ttng.async_tma_reduce add, %tma[%x, %x] %alloc : !tt.tensordesc<128x128xf32, #shared1>, !ttg.memdesc<128x128xf32, #shared1, #smem>
+    tt.return
+  }
+}
+
+// -----
+
+#shared1_broadcast = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, CGALayout = [[0, 0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: tma_copy_local_to_global_broadcast
+  // CHECK: elect.sync
+  // CHECK: nvg.cluster_id
+  // CHECK: llvm.and
+  // CHECK: llvm.icmp "eq"
+  // CHECK: "@$0 cp.async.bulk.tensor.2d.global.shared::cta.bulk_group [$1, {$2, $3}], [$4];", "b,l,r,r,r" {{.*}} : (i1, !llvm.ptr, i32, i32, !llvm.ptr<3>) -> !llvm.void
+  // CHECK-NOT: shared::cluster
+  // CHECK: nvvm.cp.async.bulk.commit.group
+  tt.func @tma_copy_local_to_global_broadcast(%tma: !tt.tensordesc<128x128xf32, #shared1_broadcast>, %alloc: !ttg.memdesc<128x128xf32, #shared1_broadcast, #smem>, %x: i32) {
+    ttng.async_tma_copy_local_to_global %tma[%x, %x] %alloc : !tt.tensordesc<128x128xf32, #shared1_broadcast>, !ttg.memdesc<128x128xf32, #shared1_broadcast, #smem>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -242,7 +242,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @async_wait() {
     // CHECK: tti.experimental_lock_acquire
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 4295032833 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 281479271743489 : i64
     // CHECK: %[[OUTSTANDING_NUM:.*]] = arith.constant 42 : i32
     // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]], %[[OUTSTANDING_NUM]]
     %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
@@ -699,7 +699,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @amdg_async_wait() {
     // CHECK: tti.experimental_lock_acquire
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 4295032833 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 281479271743489 : i64
     // CHECK: %[[OUTSTANDING_NUM:.*]] = arith.constant 42 : i32
     // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]], %[[OUTSTANDING_NUM]]
     %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
@@ -830,10 +830,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
     // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
     // CHECK: tt.call @__triton_consan_copy_read_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {
@@ -874,10 +874,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
     // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
     // CHECK: tt.call @__triton_consan_copy_read_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {
@@ -908,10 +908,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
     // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
     // CHECK: tt.call @__triton_consan_copy_read_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {

--- a/test/TritonGPU/amd/amd-convert-tensor-ops.mlir
+++ b/test/TritonGPU/amd/amd-convert-tensor-ops.mlir
@@ -1,5 +1,109 @@
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-tensor-ops | FileCheck %s
 
+// Gather i32: indices arrive with the NVIDIA-oriented slice encoding (#nv_slice)
+// from the shared TritonToTritonGPU pass. The pass re-layouts them to AMD's TDM
+// encoding and lowers to amdg.async_tdm_gather.
+
+#nv_slice = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_res = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#padded_desc = #ttg.padded_shared<[32:+16] {order = [1, 0], shape = [1, 32]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[$AMD_IDX_I32:.*]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+// CHECK-LABEL: @test_gather_i32
+// CHECK: ttg.convert_layout %{{.*}} -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I32]]}>>
+// CHECK: ttg.local_alloc
+// CHECK: amdg.async_tdm_gather {{.*}} pred = %{{.*}} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I32]]
+// CHECK: amdg.async_tdm_wait {num = 0 : i32}
+// CHECK: ttg.local_load
+tt.func public @test_gather_i32(%desc: !tt.tensordesc<1x32xi8, #padded_desc>,
+                                %indices: tensor<32xi32, #ttg.slice<{dim = 0, parent = #nv_slice}>>,
+                                %y_off: i32) -> tensor<32x32xi8, #blocked_res> {
+  %0 = tt.descriptor_gather %desc[%indices, %y_off] : (!tt.tensordesc<1x32xi8, #padded_desc>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #nv_slice}>>, i32) -> tensor<32x32xi8, #blocked_res>
+  tt.return %0 : tensor<32x32xi8, #blocked_res>
+}
+}
+
+// -----
+
+// Gather i16: same NVIDIA-oriented slice encoding on the indices (the shared
+// pass doesn't special-case index element type). i16 indices are AMD-only.
+
+#nv_slice16 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_res16 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#padded_desc16 = #ttg.padded_shared<[32:+16] {order = [1, 0], shape = [1, 32]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[$AMD_IDX_I16:.*]] = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+// CHECK-LABEL: @test_gather_i16
+// CHECK: ttg.convert_layout %{{.*}} -> tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I16]]}>>
+// CHECK: ttg.local_alloc
+// CHECK: amdg.async_tdm_gather {{.*}} pred = %{{.*}} : tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_I16]]
+// CHECK: amdg.async_tdm_wait {num = 0 : i32}
+// CHECK: ttg.local_load
+tt.func public @test_gather_i16(%desc: !tt.tensordesc<1x32xi8, #padded_desc16>,
+                                %indices: tensor<32xi16, #ttg.slice<{dim = 0, parent = #nv_slice16}>>,
+                                %y_off: i32) -> tensor<32x32xi8, #blocked_res16> {
+  %0 = tt.descriptor_gather %desc[%indices, %y_off] : (!tt.tensordesc<1x32xi8, #padded_desc16>, tensor<32xi16, #ttg.slice<{dim = 0, parent = #nv_slice16}>>, i32) -> tensor<32x32xi8, #blocked_res16>
+  tt.return %0 : tensor<32x32xi8, #blocked_res16>
+}
+}
+
+// -----
+
+// Scatter i32: indices arrive with the NVIDIA-oriented slice encoding (#nv_slice)
+// from the shared TritonToTritonGPU pass. The pass re-layouts them to AMD's TDM
+// encoding and lowers to amdg.async_tdm_scatter.
+
+#nv_slice_s = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#padded_desc_s = #ttg.padded_shared<[32:+16] {order = [1, 0], shape = [1, 32]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[$AMD_IDX_S_I32:.*]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+// CHECK-LABEL: @test_scatter_i32
+// CHECK: ttg.convert_layout %{{.*}} -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I32]]}>>
+// CHECK: ttg.local_alloc {{.*}} : (tensor<32x32xi8
+// CHECK: amdg.async_tdm_scatter {{.*}} from {{.*}} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I32]]
+// CHECK: amdg.async_tdm_wait {num = 0 : i32}
+// CHECK-NOT: ttg.local_load
+tt.func public @test_scatter_i32(%desc: !tt.tensordesc<1x32xi8, #padded_desc_s>,
+                                 %indices: tensor<32xi32, #ttg.slice<{dim = 0, parent = #nv_slice_s}>>,
+                                 %y_off: i32,
+                                 %src: tensor<32x32xi8, #blocked_src>) {
+  tt.descriptor_scatter %desc[%indices, %y_off], %src : !tt.tensordesc<1x32xi8, #padded_desc_s>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #nv_slice_s}>>, i32, tensor<32x32xi8, #blocked_src>
+  tt.return
+}
+}
+
+// -----
+
+// Scatter i16: same NVIDIA-oriented slice encoding on the indices (the shared
+// pass doesn't special-case index element type). i16 indices are AMD-only.
+
+#nv_slice_s16 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_src16 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#padded_desc_s16 = #ttg.padded_shared<[32:+16] {order = [1, 0], shape = [1, 32]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[$AMD_IDX_S_I16:.*]] = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+// CHECK-LABEL: @test_scatter_i16
+// CHECK: ttg.convert_layout %{{.*}} -> tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I16]]}>>
+// CHECK: ttg.local_alloc {{.*}} : (tensor<32x32xi8
+// CHECK: amdg.async_tdm_scatter {{.*}} from {{.*}} : tensor<32xi16, #ttg.slice<{dim = 0, parent = #[[$AMD_IDX_S_I16]]
+// CHECK: amdg.async_tdm_wait {num = 0 : i32}
+// CHECK-NOT: ttg.local_load
+tt.func public @test_scatter_i16(%desc: !tt.tensordesc<1x32xi8, #padded_desc_s16>,
+                                 %indices: tensor<32xi16, #ttg.slice<{dim = 0, parent = #nv_slice_s16}>>,
+                                 %y_off: i32,
+                                 %src: tensor<32x32xi8, #blocked_src16>) {
+  tt.descriptor_scatter %desc[%indices, %y_off], %src : !tt.tensordesc<1x32xi8, #padded_desc_s16>, tensor<32xi16, #ttg.slice<{dim = 0, parent = #nv_slice_s16}>>, i32, tensor<32x32xi8, #blocked_src16>
+  tt.return
+}
+}
+
+// -----
+
 // CHECK-LABEL: test_cvt1
 // CHECK: amdg.async_tdm_copy_global_to_local {{.*}}: !tt.tensordesc<128x16xf16, #shared> -> !ttg.memdesc<128x16xf16, #shared{{[0-9]*}}, #smem, mutable>
 // CHECK: amdg.async_tdm_wait  {num = 0 : i32}

--- a/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
@@ -606,6 +606,48 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#idx_i32_parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#idx_i16_parent = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tdm_gather_scatter_encoded_multiple_instructions
+  tt.func public @tdm_gather_scatter_encoded_multiple_instructions(
+    %memDesc: !ttg.memdesc<256x128xf16, #shared, #smem, mutable>,
+    %tensorDesc: !tt.tensordesc<64x128xf16>,
+    %row_indices_i32: tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>,
+    %row_indices_i16: tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>,
+    %pred: i32
+  ) {
+    %c0_i32 = arith.constant 0 : i32
+
+    // Gather with i32 indices: sizePerThread=16, 4 warps, maxPerInstr=8 => 2 instructions
+    amdg.async_tdm_gather %tensorDesc[%row_indices_i32, %c0_i32] to %memDesc, pred = %pred : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Scatter with i32 indices: 2 instructions
+    amdg.async_tdm_scatter %tensorDesc[%row_indices_i32, %c0_i32] from %memDesc : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Gather with i16 indices: sizePerThread=64, 4 warps, maxPerInstr=16 => 4 instructions
+    amdg.async_tdm_gather %tensorDesc[%row_indices_i16, %c0_i32] to %memDesc, pred = %pred : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Scatter with i16 indices: 4 instructions
+    amdg.async_tdm_scatter %tensorDesc[%row_indices_i16, %c0_i32] from %memDesc : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+
+    // i32 ops emit 2 instructions each, i16 ops emit 4 each => total 12 instructions
+    // CHECK: amdg.async_tdm_intrinsic_wait {count = 0
+    amdg.async_tdm_wait {num = 0 : i32}
+    // CHECK: amdg.async_tdm_intrinsic_wait {count = 4
+    amdg.async_tdm_wait {num = 1 : i32}
+    // CHECK: amdg.async_tdm_intrinsic_wait {count = 8
+    amdg.async_tdm_wait {num = 2 : i32}
+    // CHECK: amdg.async_tdm_intrinsic_wait {count = 10
+    amdg.async_tdm_wait {num = 3 : i32}
+    // CHECK: amdg.async_tdm_intrinsic_wait {count = 12
+    amdg.async_tdm_wait {num = 4 : i32}
+
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -639,6 +639,45 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#idx_i32_parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#idx_i16_parent = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tdm_gather_scatter_encoded_multiple_instructions
+  tt.func public @tdm_gather_scatter_encoded_multiple_instructions(
+    %memDesc: !ttg.memdesc<256x128xf16, #shared, #smem, mutable>,
+    %tensorDesc: !tt.tensordesc<64x128xf16>,
+    %row_indices_i32: tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>,
+    %row_indices_i16: tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>,
+    %pred: i32
+  ) {
+    %c0_i32 = arith.constant 0 : i32
+
+    // Gather with i32 indices: sizePerThread=16, 4 warps, maxPerInstr=8 => 2 instructions
+    %token1 = amdg.async_tdm_gather %tensorDesc[%row_indices_i32, %c0_i32] to %memDesc, pred = %pred : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Scatter with i32 indices: 2 instructions
+    %token2 = amdg.async_tdm_scatter %tensorDesc[%row_indices_i32, %c0_i32] from %memDesc : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_i32_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Gather with i16 indices: sizePerThread=64, 4 warps, maxPerInstr=16 => 4 instructions
+    %token3 = amdg.async_tdm_gather %tensorDesc[%row_indices_i16, %c0_i32] to %memDesc, pred = %pred : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // Scatter with i16 indices: 4 instructions
+    %token4 = amdg.async_tdm_scatter %tensorDesc[%row_indices_i16, %c0_i32] from %memDesc : tensor<256xi16, #ttg.slice<{dim = 0, parent = #idx_i16_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+
+    // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 0
+    %w1 = amdg.async_tdm_wait %token4 {num = 0 : i32}
+    // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 4
+    %w2 = amdg.async_tdm_wait %token3 {num = 0 : i32}
+    // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 8
+    %w3 = amdg.async_tdm_wait %token2 {num = 0 : i32}
+    // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 10
+    %w4 = amdg.async_tdm_wait %token1 {num = 0 : i32}
+
+    tt.return
+  }
+}
+
+// -----
+
 // Test bug fix: With warp = [[0], [0]] the warp dimension has free variables,
 // so the load should contribute 0 instructions — non-canonical warps skip the
 // load entirely.

--- a/test/TritonGPU/automatic-warp-specialization.mlir
+++ b/test/TritonGPU/automatic-warp-specialization.mlir
@@ -7,7 +7,8 @@
 // CLEAN-NOT: ttg.partition
 // CLEAN-NOT: ttg.warp_specialize.tag
 
-#indices_layout = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#indices_layout_parent = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#indices_layout = #ttg.slice<{dim = 0, parent = #indices_layout_parent}>
 #acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #oper_layout = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #b_layout = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -294,6 +294,40 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // -----
 
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+#offset_parent = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0], CGALayout = [[0, 0]]}>
+#offsets = #ttg.slice<{dim = 0, parent = #offset_parent}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttng.two-ctas" = true, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @multicast_gather_two_cta_tx_count
+  tt.func public @multicast_gather_two_cta_tx_count(%desc: !tt.tensordesc<1x32xf32, #shared>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %x_offsets = arith.constant dense<0> : tensor<32xi32, #offsets>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %result = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: scf.for
+    scf.for %i = %c0 to %c2 step %c1 {
+      // CHECK: arith.constant 8192 : i64
+      // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+      // CHECK: ttng.barrier_expect
+      ttng.barrier_expect %bar, 4096, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+      // CHECK: arith.constant -8192 : i64
+      // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+      // CHECK: ttng.async_tma_gather
+      ttng.async_tma_gather %desc[%x_offsets, %c0_i32] %result, %bar, %true {multicast} : !tt.tensordesc<1x32xf32, #shared>, tensor<32xi32, #offsets>, i32, !ttg.memdesc<1xi64, #shared1, #smem, mutable>, !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, i1
+    }
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
@@ -480,9 +514,35 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     ttng.warp_group_dot %shmem, %shmem, %acc : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> * !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> tensor<128x128xf16, #mma>
     // CHECK: ttng.warp_group_dot
 
+	    // CHECK: tt.call @__triton_consan_verify_write_visibility
+	    // CHECK: tt.call @__triton_consan_check_outstanding_commits
+	    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+	    // CHECK: tt.call @__triton_consan_commit_accesses
+	    ttng.async_tma_scatter %arg0[%x_offsets, %c0_i32] %0 : !tt.tensordesc<1x32xf32, #shared>, tensor<32xi32>, i32, !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+	    tt.return
+	  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 32, 16]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @async_tma_reduce
+  tt.func public @async_tma_reduce(%arg0: !tt.tensordesc<32x32xf32, #shared>, %ptr: tensor<128x128x!tt.ptr<f16>, #blocked>, %acc: tensor<128x128xf16, #mma>) {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %shmem = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+    ttg.async_copy_global_to_local %ptr, %shmem : tensor<128x128x!tt.ptr<f16>, #blocked> -> <128x128xf16, #shared, #smem, mutable>
+
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: tt.call @__triton_consan_check_outstanding_commits
-    ttng.async_tma_scatter %arg0[%x_offsets, %c0_i32] %0 : !tt.tensordesc<1x32xf32, #shared>, tensor<32xi32>, i32, !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    ttng.async_tma_reduce add, %arg0[%c0_i32, %c0_i32] %0 : !tt.tensordesc<32x32xf32, #shared>, !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -253,6 +253,36 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
 // -----
 
+#shared_clc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @clc_try_cancel_diagonal_effect_recipients
+  tt.func public @clc_try_cancel_diagonal_effect_recipients() {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %result = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 16 : i32} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    // CHECK: tti.experimental_cluster_cta_id
+    // CHECK: arith.cmpi eq
+    // CHECK: %[[CLC_THREAD:.*]] = arith.constant 48 : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[CLC_THREAD]]
+    // CHECK: %[[CLC_MASK:.*]] = arith.constant 281474976710656 : i64
+    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[CLC_MASK]]
+    // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer{{.*}}_I1
+    ttng.clc_try_cancel %result, %bar : !ttg.memdesc<2xi64, #shared_clc, #smem, mutable>, !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %bar, 16, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: ttng.clc_load_result
+    %clc_res = ttng.clc_load_result %result : !ttg.memdesc<2xi64, #shared_clc, #smem, mutable> -> i128
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #smem = #ttg.shared_memory
@@ -1001,7 +1031,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @async_commit_group() {
     // CHECK: tti.experimental_lock_acquire
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 4295032833 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 281479271743489 : i64
     // CHECK: %[[OUTSTANDING_NUM:.*]] = arith.constant 42 : i32
     // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]], %[[OUTSTANDING_NUM]]
     %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
@@ -1252,10 +1282,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
     // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
     // CHECK: tt.call @__triton_consan_copy_read_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {
@@ -1297,10 +1327,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
     // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
     // CHECK: tt.call @__triton_consan_copy_read_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {
@@ -1333,10 +1363,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
     // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 8590065666 : i64
+    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
     // CHECK: tt.call @__triton_consan_copy_read_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {

--- a/test/TritonGPU/gsan.mlir
+++ b/test/TritonGPU/gsan.mlir
@@ -63,7 +63,8 @@ module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32}
 
 // -----
 
-#blocked_rows = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#blocked_rows_parent = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0]}>
+#blocked_rows = #ttg.slice<{dim = 0, parent = #blocked_rows_parent}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -10,7 +10,17 @@ tt.func public @local_alloc_i1() {
 
 // -----
 
-// expected-error @+1 {{After removing the zero bases the CGA encoding must be a permutation matrix}}
+// expected-error @+1 {{LinearEncodingAttr requires a permutation matrix layout after removing broadcast bases}}
+#linear_bad_perm = #ttg.linear<{register = [[1], [3]], lane = [], warp = [], block = []}>
+module {
+  tt.func public @invalid_linear_layout(%arg0: tensor<4xi32, #linear_bad_perm>) {
+    tt.return
+  }
+}
+
+// -----
+
+// expected-error @+1 {{After removing broadcast bases the CGA encoding must be a permutation matrix}}
 #blocked_bad_cga = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1], CGALayout = [[1, 0], [1, 0]]}>
 module {
   tt.func public @invalid_cga_layout(%arg0: tensor<1x1xf32, #blocked_bad_cga>) {
@@ -20,12 +30,7 @@ module {
 
 // -----
 
-// beta divergence (NPOT reland, T276910804): beta's LinearEncodingAttr::verify
-// accepts modular/NPOT distributed layouts (e.g. register = [[1], [3]]) that
-// upstream rejects, so upstream's "must be a permutation matrix" case for such a
-// layout is not invalid here and was dropped. The remaining case checks beta's
-// own "each base must move in at most one dimension" rejection.
-// expected-error @+1 {{In a distributed layout, each base must move in at most one dimension.}}
+// expected-error @+1 {{LinearEncodingAttr requires a permutation matrix layout after removing broadcast bases}}
 #linear_bad_after_flatten = #ttg.linear<{register = [[1, 1], [1, 0]], lane = [], warp = [], block = []}>
 module {
   tt.func public @invalid_linear_layout_after_flatten(%arg0: tensor<2x2xi32, #linear_bad_after_flatten>) {

--- a/test/TritonGPU/loop-pipeline-blackwell.mlir
+++ b/test/TritonGPU/loop-pipeline-blackwell.mlir
@@ -168,7 +168,8 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, ttg.targ
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1_parent = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked1 = #ttg.slice<{dim = 0, parent = #blocked1_parent}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [16, 8]}>

--- a/test/TritonGPU/loop-pipeline-hopper.mlir
+++ b/test/TritonGPU/loop-pipeline-hopper.mlir
@@ -472,7 +472,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked1_parent = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked1 = #ttg.slice<{dim = 0, parent = #blocked1_parent}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: tma_scatter_pipeline

--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -779,7 +779,8 @@ tt.func @tma_load_lowering(%lb : index, %ub : index, %step : index,
 // -----
 
 #A = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#offsets = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#offsets_parent = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#offsets = #ttg.slice<{dim = 0, parent = #offsets_parent}>
 #nvmma_128 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -871,6 +871,66 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // -----
 
+#blocked_broadcast = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
+#nvmma_no_broadcast = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @async_tma_gather_multicast_requires_broadcast(%arg0: !tt.tensordesc<1x128xf16, #nvmma_no_broadcast>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %x_offsets = arith.constant dense<0> : tensor<32xi32, #blocked_broadcast>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    %result = ttg.local_alloc : () -> !ttg.memdesc<32x128xf16, #nvmma_no_broadcast, #smem, mutable>
+    // expected-error @below {{multicast requires the shared layout to broadcast across CTAs}}
+    ttng.async_tma_gather %arg0[%x_offsets, %c0_i32] %result, %bar, %true {multicast} : !tt.tensordesc<1x128xf16, #nvmma_no_broadcast>, tensor<32xi32, #blocked_broadcast>, i32, !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>, !ttg.memdesc<32x128xf16, #nvmma_no_broadcast, #smem, mutable>, i1
+    tt.return
+  }
+}
+
+// -----
+
+#blocked_broadcast_parent = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 0], [0, 0]]}>
+#blocked_broadcast = #ttg.slice<{dim = 0, parent = #blocked_broadcast_parent}>
+#nvmma_partial_broadcast = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0], [0, 0]]}>
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0], [0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @async_tma_gather_multicast_requires_matching_x_offset_cga(%arg0: !tt.tensordesc<1x128xf16, #nvmma_partial_broadcast>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %x_offsets = arith.constant dense<0> : tensor<32xi32, #blocked_broadcast>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    %result = ttg.local_alloc : () -> !ttg.memdesc<32x128xf16, #nvmma_partial_broadcast, #smem, mutable>
+    // expected-error @below {{x offsets must have the same row CGA layout as the memdesc}}
+    ttng.async_tma_gather %arg0[%x_offsets, %c0_i32] %result, %bar, %true {multicast} : !tt.tensordesc<1x128xf16, #nvmma_partial_broadcast>, tensor<32xi32, #blocked_broadcast>, i32, !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>, !ttg.memdesc<32x128xf16, #nvmma_partial_broadcast, #smem, mutable>, i1
+    tt.return
+  }
+}
+
+// -----
+
+#blocked_split_parent = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+#blocked_split = #ttg.slice<{dim = 0, parent = #blocked_split_parent}>
+#nvmma_broadcast = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @async_tma_gather_multicast_requires_uniform_x_offsets(%arg0: !tt.tensordesc<1x128xf16, #nvmma_broadcast>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %x_offsets = arith.constant dense<0> : tensor<32xi32, #blocked_split>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    %result = ttg.local_alloc : () -> !ttg.memdesc<32x128xf16, #nvmma_broadcast, #smem, mutable>
+    // expected-error @below {{x offsets must have the same row CGA layout as the memdesc}}
+    ttng.async_tma_gather %arg0[%x_offsets, %c0_i32] %result, %bar, %true {multicast} : !tt.tensordesc<1x128xf16, #nvmma_broadcast>, tensor<32xi32, #blocked_split>, i32, !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>, !ttg.memdesc<32x128xf16, #nvmma_broadcast, #smem, mutable>, i1
+    tt.return
+  }
+
+}
+
+// -----
+
 // Test invalid TensorDescIm2ColType: rank-3 blockType (must be rank-2)
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
   // expected-error @below {{TensorDescIm2ColType requires rank-2 shape, got rank 3}}
@@ -986,6 +1046,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %src = ttg.local_alloc : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     // expected-error @below {{unsupported reduce kind inc for element type 'f32'}}
     ttng.async_tma_reduce inc, %arg0[%x, %x] %src : !tt.tensordesc<32x32xf32, #shared>, !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @async_tma_gather_requires_legal_x_offsets(%arg0: !tt.tensordesc<1x128xf16, #shared>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %x_offsets = arith.constant dense<0> : tensor<32xi32, #blocked>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
+    %result = ttg.local_alloc : () -> !ttg.memdesc<32x128xf16, #shared, #smem, mutable>
+    // expected-error @below {{x offsets must have at least 4 contiguous elements per thread}}
+    ttng.async_tma_gather %arg0[%x_offsets, %c0_i32] %result, %bar, %true : !tt.tensordesc<1x128xf16, #shared>, tensor<32xi32, #blocked>, i32, !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>, !ttg.memdesc<32x128xf16, #shared, #smem, mutable>, i1
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -732,7 +732,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-// expected-error @+1 {{After removing the zero bases the layout must be bijective}}
+// expected-error @+1 {{LinearEncodingAttr requires a permutation matrix layout after removing broadcast bases}}
 #linear = #ttg.linear<{register = [[0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 1]], warp = [[16, 0], [8, 0]], block = []}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func @invalid_linear_layout(%arg0: tensor<32x64xi32, #linear>) {

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -498,6 +498,35 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#sharedCLC = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#barrierCLC = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CLC multicasts completion through the cluster, so it needs init sync even
+  // if the barrier allocation shape looks per-CTA.
+  // CHECK-LABEL: @cluster_clc_with_per_cta_barrier
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_barrier {relaxed = true}
+  // CHECK-NEXT: ttng.clc_try_cancel
+  // CHECK: tt.return
+  tt.func @cluster_clc_with_per_cta_barrier() {
+    %true = arith.constant true
+    %result = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #sharedCLC, #smem, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierCLC, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierCLC, #smem, mutable>
+    ttng.clc_try_cancel %result, %barrier :
+      !ttg.memdesc<2xi64, #sharedCLC, #smem, mutable>,
+      !ttg.memdesc<2xi64, #barrierCLC, #smem, mutable>
+    ttng.barrier_expect %barrier, 16, %true :
+      !ttg.memdesc<2xi64, #barrierCLC, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[0, 0]]}>
 #barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>

--- a/test/TritonNvidiaGPU/ops.mlir
+++ b/test/TritonNvidiaGPU/ops.mlir
@@ -10,7 +10,8 @@
 #tmem_int32 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#offsets = #ttg.slice<{dim = 0, parent = #blocked}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [1, 4], order = [0, 1]}>
 #scales = #ttg.linear<{register = [[0, 1], [0, 2], [32, 0], [64, 0], [0, 4]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[0, 0], [0, 0]], block = []}>
 
@@ -85,12 +86,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-SAME: [[BAR:%arg[0-9]+]]:
   // CHECK-SAME: [[RESULT:%arg[0-9]+]]:
   // CHECK-SAME: [[PRED:%arg[0-9]+]]:
-  tt.func @async_tma_gather(%desc: !tt.tensordesc<1x128xbf16, #shared>, %x_offsets: tensor<32xi32, #blocked>, %y_offset: i32,
+  tt.func @async_tma_gather(%desc: !tt.tensordesc<1x128xbf16, #shared>, %x_offsets: tensor<32xi32, #offsets>, %y_offset: i32,
                             %bar: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>,
                             %result: !ttg.memdesc<32x128xbf16, #shared, #ttg.shared_memory, mutable>,
                             %pred: i1) {
-    // CHECK-NEXT: ttng.async_tma_gather [[DESC]][[[X_OFFSETS]], [[Y_OFFSET]]] [[RESULT]], [[BAR]], [[PRED]] : !tt.tensordesc<1x128xbf16, #shared>, tensor<32xi32, #blocked>, i32, !ttg.memdesc<1xi64, #shared2, #smem, mutable>, !ttg.memdesc<32x128xbf16, #shared, #smem, mutable>, i1
-    ttng.async_tma_gather %desc[%x_offsets, %y_offset] %result, %bar, %pred : !tt.tensordesc<1x128xbf16, #shared>, tensor<32xi32, #blocked>, i32, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>, !ttg.memdesc<32x128xbf16, #shared, #ttg.shared_memory, mutable>, i1
+    // CHECK-NEXT: ttng.async_tma_gather [[DESC]][[[X_OFFSETS]], [[Y_OFFSET]]] [[RESULT]], [[BAR]], [[PRED]] : !tt.tensordesc<1x128xbf16, #shared>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>, i32, !ttg.memdesc<1xi64, #shared2, #smem, mutable>, !ttg.memdesc<32x128xbf16, #shared, #smem, mutable>, i1
+    ttng.async_tma_gather %desc[%x_offsets, %y_offset] %result, %bar, %pred : !tt.tensordesc<1x128xbf16, #shared>, tensor<32xi32, #offsets>, i32, !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory, mutable>, !ttg.memdesc<32x128xbf16, #shared, #ttg.shared_memory, mutable>, i1
     tt.return
   }
 
@@ -99,10 +100,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-SAME: [[X_OFFSETS:%arg[0-9]+]]:
   // CHECK-SAME: [[Y_OFFSET:%arg[0-9]+]]:
   // CHECK-SAME: [[SRC:%arg[0-9]+]]:
-  tt.func @async_tma_scatter(%desc: !tt.tensordesc<1x128xbf16, #shared>, %x_offsets: tensor<32xi32, #blocked>, %y_offset: i32,
+  tt.func @async_tma_scatter(%desc: !tt.tensordesc<1x128xbf16, #shared>, %x_offsets: tensor<32xi32, #offsets>, %y_offset: i32,
                              %src: !ttg.memdesc<32x128xbf16, #shared, #ttg.shared_memory, mutable>) {
-    // CHECK-NEXT: ttng.async_tma_scatter [[DESC]][[[X_OFFSETS]], [[Y_OFFSET]]] [[SRC]] : !tt.tensordesc<1x128xbf16, #shared>, tensor<32xi32, #blocked>, i32, !ttg.memdesc<32x128xbf16, #shared, #smem, mutable>
-    ttng.async_tma_scatter %desc[%x_offsets, %y_offset] %src : !tt.tensordesc<1x128xbf16, #shared>, tensor<32xi32, #blocked>, i32, !ttg.memdesc<32x128xbf16, #shared, #ttg.shared_memory, mutable>
+    // CHECK-NEXT: ttng.async_tma_scatter [[DESC]][[[X_OFFSETS]], [[Y_OFFSET]]] [[SRC]] : !tt.tensordesc<1x128xbf16, #shared>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>, i32, !ttg.memdesc<32x128xbf16, #shared, #smem, mutable>
+    ttng.async_tma_scatter %desc[%x_offsets, %y_offset] %src : !tt.tensordesc<1x128xbf16, #shared>, tensor<32xi32, #offsets>, i32, !ttg.memdesc<32x128xbf16, #shared, #ttg.shared_memory, mutable>
     tt.return
   }
 

--- a/test/TritonNvidiaGPU/tma_lowering.mlir
+++ b/test/TritonNvidiaGPU/tma_lowering.mlir
@@ -90,14 +90,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#offsets = #ttg.slice<{dim = 0, parent = #blocked}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #nvmma_128 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // CHECK-LABEL: @tma_gather
-tt.func @tma_gather(%arg0: !tt.tensordesc<1x128xbf16, #nvmma_128>, %arg1: tensor<32xi32, #blocked>, %arg2: i32) -> tensor<32x128xbf16, #blocked1> {
+tt.func @tma_gather(%arg0: !tt.tensordesc<1x128xbf16, #nvmma_128>, %arg1: tensor<32xi32, #offsets>, %arg2: i32) -> tensor<32x128xbf16, #blocked1> {
   // CHECK: [[RESULT:%.*]] = ttg.local_alloc
   // CHECK: [[BARRIER:%.*]] = ttg.local_alloc
   // CHECK: ttng.init_barrier [[BARRIER]]
@@ -105,18 +106,18 @@ tt.func @tma_gather(%arg0: !tt.tensordesc<1x128xbf16, #nvmma_128>, %arg1: tensor
   // CHECK: ttng.wait_barrier [[BARRIER]]
   // CHECK: ttng.inval_barrier [[BARRIER]]
   // CHECK: [[OUT:%.*]] = ttg.local_load [[RESULT]]
-  %0 = tt.descriptor_gather %arg0[%arg1, %arg2] : (!tt.tensordesc<1x128xbf16, #nvmma_128>, tensor<32xi32, #blocked>, i32) -> tensor<32x128xbf16, #blocked1>
+  %0 = tt.descriptor_gather %arg0[%arg1, %arg2] : (!tt.tensordesc<1x128xbf16, #nvmma_128>, tensor<32xi32, #offsets>, i32) -> tensor<32x128xbf16, #blocked1>
   // CHECK: return [[OUT]]
   tt.return %0 : tensor<32x128xbf16, #blocked1>
 }
 
 // CHECK-LABEL: @tma_scatter
-tt.func @tma_scatter(%arg0: !tt.tensordesc<1x128xbf16, #nvmma_128>, %arg1: tensor<32xi32, #blocked>, %arg2: i32, %arg3: tensor<32x128xbf16, #blocked1>) {
+tt.func @tma_scatter(%arg0: !tt.tensordesc<1x128xbf16, #nvmma_128>, %arg1: tensor<32xi32, #offsets>, %arg2: i32, %arg3: tensor<32x128xbf16, #blocked1>) {
   // CHECK-NEXT: [[SRC:%.*]] = ttg.local_alloc %arg3
   // CHECK-NEXT: ttng.fence_async_shared {bCluster = false}
   // CHECK-NEXT: ttng.async_tma_scatter %arg0[%arg1, %arg2] [[SRC]]
   // CHECK-NEXT: ttng.async_tma_store_wait {pendings = 0 : i32}
-  tt.descriptor_scatter %arg0[%arg1, %arg2], %arg3 : !tt.tensordesc<1x128xbf16, #nvmma_128>, tensor<32xi32, #blocked>, i32, tensor<32x128xbf16, #blocked1>
+  tt.descriptor_scatter %arg0[%arg1, %arg2], %arg3 : !tt.tensordesc<1x128xbf16, #nvmma_128>, tensor<32xi32, #offsets>, i32, tensor<32x128xbf16, #blocked1>
   tt.return
   }
 

--- a/third_party/amd/include/TritonAMDGPUToLLVM/TypeConverter.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/TypeConverter.h
@@ -29,6 +29,11 @@ public:
     auto ctx = type.getContext();
     int numDwords = amdgpu::getTensorDescNumDwords(type);
 
+    // Keep the MLIR-visible descriptor type as a flat `{i32 × N}` struct so
+    // that its in-memory ABI matches the host-side `TDMDescriptor` layout in
+    // third_party/amd/backend/driver.c (N consecutive uint32_t).  Inside the
+    // lowering we pack these scalars into vector groups (<4 × i32>,
+    // <8 × i32>) for cleaner intra-function code.
     auto types = SmallVector<Type>(numDwords, IntegerType::get(ctx, 32));
     return LLVM::LLVMStructType::getLiteral(ctx, types);
   }

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -809,7 +809,7 @@ LogicalResult AsyncTDMCopyLocalToGlobalOp::verify() {
       return emitOpError("TDM store only supports single interval paddings.");
 
     auto shapePerCTA = triton::gpu::getShapePerCTA(paddedEnc, blockShape);
-    if (intervals[0] != shapePerCTA[paddedEnc.getOrder().front()])
+    if (intervals[0] != shapePerCTA.back())
       return emitOpError("TDM store padding is only supported when padding "
                          "interval equals the innermost block dimension (got "
                          "padInterval=")
@@ -874,13 +874,6 @@ LogicalResult AsyncTDMScatterOp::verify() {
 
   if (!paddedEnc && !swizzledEnc)
     return emitOpError("Invalid shared memory layout for TDM");
-
-  auto shapePerCTA = triton::gpu::getShapePerCTA(smemTy);
-  auto sharedOrder = triton::gpu::getOrder(
-      cast<triton::gpu::SharedEncodingTrait>(smemTy.getEncoding()),
-      shapePerCTA);
-  if (sharedOrder[0] != (sharedOrder.size() - 1))
-    return emitOpError("TDM scatter only supports row-major shared order");
 
   return success();
 }

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -83,6 +83,8 @@ void mlir::triton::amdgpu::TritonAMDGPUDialect::initialize() {
 
 namespace mlir::triton::amdgpu {
 
+namespace {
+
 std::string getStringFromCoords(mlir::triton::AMD::ElemLocationKey coords) {
   std::string result;
   llvm::raw_string_ostream os(result);
@@ -94,8 +96,7 @@ std::string getStringFromCoords(mlir::triton::AMD::ElemLocationKey coords) {
 }
 
 // Helper function to verify TDM block dimensions
-static LogicalResult verifyTDMBlockSize(Operation *op,
-                                        ArrayRef<int64_t> blockShape) {
+LogicalResult verifyTDMBlockSize(Operation *op, ArrayRef<int64_t> blockShape) {
   constexpr int64_t maxBlockSize = std::numeric_limits<uint16_t>::max();
   for (size_t i = 0; i < blockShape.size(); ++i) {
     if (blockShape[i] > maxBlockSize) {
@@ -106,6 +107,8 @@ static LogicalResult verifyTDMBlockSize(Operation *op,
   }
   return success();
 }
+
+} // namespace
 
 LogicalResult ExtractSliceOp::verify() {
   // Basic type/rank checks.
@@ -583,8 +586,8 @@ LogicalResult LocalLoadPackedTransposedOp::verify() {
 
 // This pattern removes a concatOp if it has a single input operand.
 // This scenario can potentially happen as a result of ops refinement.
-mlir::LogicalResult foldConcatOpFromSingleSource(amdgpu::ConcatOp op,
-                                                 PatternRewriter &rewriter) {
+static mlir::LogicalResult
+foldConcatOpFromSingleSource(amdgpu::ConcatOp op, PatternRewriter &rewriter) {
   auto sources = op.getSources();
   if (sources.size() == 1) {
     auto source = sources.front();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -253,8 +253,8 @@ private:
 
     // Compute the bits that are moved by one instruction
     // Compute elements for which we can swap the xor by an add
-    auto [nAdditive, permStrides] =
-        actionAdditiveStrides(reps, addrLayout, maskSpanAffineOffset);
+    auto [nAdditive, permStrides] = actionAdditiveStrides(
+        reps, addrLayout, maskSpanAffineOffset, fullTile.getInDimSize(kReg));
     reps = permStrides.apply(reps);
     if (isPartitioned) {
       partitionLayout = permStrides.apply(partitionLayout);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
@@ -23,38 +23,22 @@ LogicalResult validateStridesAndSharedOrder(triton::MakeTensorDescOp op,
   int rank = shape.size();
   auto sharedOrder = triton::gpu::getOrder(
       cast<triton::gpu::SharedEncodingTrait>(sharedEnc), shape);
-  SmallVector<unsigned> strideOneDims;
-  for (auto [dim, strideVal] : llvm::enumerate(strides)) {
-    if (getConstantIntValue(getAsOpFoldResult(strideVal)).value_or(0) == 1)
-      strideOneDims.push_back(dim);
-  }
-
-  if (strideOneDims.empty())
-    return op.emitError() << "requires at least one dimension to have stride 1";
-
-  bool isColMajor =
-      strideOneDims.size() == 1 && strideOneDims.front() == rank - 2;
-
   SmallVector<unsigned> expectedOrder(llvm::reverse(llvm::seq<unsigned>(rank)));
-  if (isColMajor)
-    std::swap(expectedOrder[0], expectedOrder[1]);
-
   if (sharedOrder != ArrayRef(expectedOrder)) {
-    if (isColMajor)
-      return op.emitError()
-             << "requires shared order [rank-2, rank-1, rank-3, "
-                "rank-4, ..., 0] because dim[rank-2] has stride 1";
     return op.emitError() << "requires shared order [rank-1, rank-2, ..., 0]";
   }
 
-  if (strideOneDims.size() > 1) {
-    unsigned numStride1Dims = strideOneDims.size();
-    for (unsigned i = 0; i < numStride1Dims; ++i) {
-      if (strideOneDims[i] != rank - numStride1Dims + i)
-        return op.emitError() << "requires all stride 1 dimensions to be "
-                                 "consecutive starting from the last dimension";
-    }
-  }
+  auto isStride1 = [](Value v) {
+    return getConstantIntValue(getAsOpFoldResult(v)).value_or(0) == 1;
+  };
+  auto reversedStrides = llvm::reverse(strides);
+  auto firstNonStride1 = llvm::find_if_not(reversedStrides, isStride1);
+  if (firstNonStride1 == reversedStrides.begin())
+    return op.emitError() << "last dimension must have stride 1";
+  if (llvm::any_of(llvm::make_range(firstNonStride1, reversedStrides.end()),
+                   isStride1))
+    return op.emitError() << "requires all stride 1 dimensions to be "
+                             "consecutive starting from the last dimension";
 
   return success();
 }
@@ -98,8 +82,6 @@ struct MakeTensorDescOpConversion
                                              tensorStride))) {
       return failure();
     }
-    auto sharedOrder = triton::gpu::getOrder(
-        cast<triton::gpu::SharedEncodingTrait>(sharedEnc), shapePerCTA);
     // Lower the tensor descriptor to a base TDM descriptor.  The final hardware
     // descriptor is completed at each TDM op site because pred, LDS address,
     // barrier, and tile_dim* are op-local.

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToTensorOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToTensorOps.cpp
@@ -54,6 +54,51 @@ public:
   }
 };
 
+struct TensorGatherLowering : public OpRewritePattern<DescriptorGatherOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(DescriptorGatherOp op,
+                                PatternRewriter &rewriter) const override {
+    MLIRContext *ctx = op.getContext();
+    Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
+    auto loc = op.getLoc();
+    auto tensorType = op.getResult().getType();
+
+    auto encoding = getEncodingFromDescriptor(op, tensorType, op.getDesc());
+    if (!encoding) {
+      op.emitError() << "Could not create encoding for descriptor gather";
+      return failure();
+    }
+
+    auto indices = op.getXOffsets();
+    auto indicesType = cast<RankedTensorType>(indices.getType());
+    auto idxEnc = getTDMGatherScatterIndexEncoding(op, indicesType);
+
+    // NOTE: The shared TritonToTritonGPU conversion (GatherScatterOpPattern)
+    // unconditionally applies an NVIDIA-oriented index layout. Because of
+    // this, the indices arriving here already carry that layout, making default
+    // index encoding never matches most desirable AMD index encoding, and
+    // therefore an additional ConvertLayoutOp emitted.
+    if (indicesType.getEncoding() != idxEnc) {
+      auto newIdxType = RankedTensorType::get(
+          indicesType.getShape(), indicesType.getElementType(), idxEnc);
+      indices = ConvertLayoutOp::create(rewriter, loc, newIdxType, indices);
+    }
+
+    MemDescType memDescType =
+        MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
+                         encoding, sharedMemorySpace, /*mutableMemory=*/true);
+    Value alloc = LocalAllocOp::create(rewriter, loc, memDescType);
+    Value pred = arith::ConstantIntOp::create(rewriter, loc, 1, 32);
+
+    amdgpu::AsyncTDMGatherOp::create(rewriter, loc, op.getDesc(), indices,
+                                     op.getYOffset(), alloc, pred);
+    amdgpu::AsyncTDMWait::create(rewriter, loc, ArrayRef<Value>{}, 0);
+    rewriter.replaceOpWithNewOp<LocalLoadOp>(op, op.getType(), alloc);
+    return success();
+  }
+};
+
 class TensorStoreLowering : public OpRewritePattern<DescriptorStoreOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
@@ -85,6 +130,51 @@ public:
   }
 };
 
+struct TensorScatterLowering : public OpRewritePattern<DescriptorScatterOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(DescriptorScatterOp op,
+                                PatternRewriter &rewriter) const override {
+    MLIRContext *ctx = op.getContext();
+    Attribute sharedMemorySpace = triton::gpu::SharedMemorySpaceAttr::get(ctx);
+    auto loc = op.getLoc();
+    Value desc = op.getDesc();
+    mlir::TypedValue<RankedTensorType> src = op.getSrc();
+    auto tensorType = src.getType();
+
+    auto encoding = getEncodingFromDescriptor(op, tensorType, desc);
+    if (!encoding) {
+      op.emitError() << "Could not create encoding for descriptor scatter";
+      return failure();
+    }
+
+    auto indices = op.getXOffsets();
+    auto indicesType = cast<RankedTensorType>(indices.getType());
+    auto idxEnc = getTDMGatherScatterIndexEncoding(op, indicesType);
+
+    // NOTE: The shared TritonToTritonGPU conversion (GatherScatterOpPattern)
+    // unconditionally applies an NVIDIA-oriented index layout. Re-layout the
+    // indices into the AMD TDM-friendly encoding so the LLVM lowering can use
+    // a single TDM instruction per row group.
+    if (indicesType.getEncoding() != idxEnc) {
+      auto newIdxType = RankedTensorType::get(
+          indicesType.getShape(), indicesType.getElementType(), idxEnc);
+      indices = ConvertLayoutOp::create(rewriter, loc, newIdxType, indices);
+    }
+
+    MemDescType memDescType =
+        MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
+                         encoding, sharedMemorySpace, /*mutableMemory=*/true);
+    Value alloc = LocalAllocOp::create(rewriter, loc, memDescType, src);
+    amdgpu::AsyncTDMScatterOp::create(rewriter, loc, op.getDesc(), indices,
+                                      op.getYOffset(), alloc,
+                                      /*barrier=*/Value{});
+    amdgpu::AsyncTDMWait::create(rewriter, loc, ArrayRef<Value>{}, 0);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct TritonAMDGPUConvertToTensorOps
     : impl::TritonAMDGPUConvertToTensorOpsBase<TritonAMDGPUConvertToTensorOps> {
 
@@ -93,7 +183,8 @@ struct TritonAMDGPUConvertToTensorOps
     ModuleOp m = getOperation();
 
     mlir::RewritePatternSet patterns(context);
-    patterns.add<TensorLoadLowering, TensorStoreLowering>(context);
+    patterns.add<TensorLoadLowering, TensorGatherLowering, TensorStoreLowering,
+                 TensorScatterLowering>(context);
     if (applyPatternsGreedily(m, std::move(patterns)).failed())
       signalPassFailure();
   }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -50,6 +50,8 @@ using StreamOpVariant =
     std::variant<StreamCopyChainOps, AsyncCopyChainOps, TDMCopyChainOps>;
 using LoadToStreamOpMap = llvm::MapVector<Operation *, StreamOpVariant>;
 
+namespace {
+
 TDMCopyChainOps createTDMAsyncCopy(tt::DescriptorLoadOp loadOp, Value alloc,
                                    Value extractIdx) {
   OpBuilder builder(loadOp);
@@ -429,7 +431,10 @@ createStreamOps(const LoadToInfoMap &loadToInfo, scf::ForOp &forOp,
   return loadToStreamOp;
 }
 
+} // namespace
+
 namespace SingleDotSchedule {
+namespace {
 using namespace mlir::SingleDotSchedule;
 using ClusterMap = DenseMap<tt::CoarseSchedule::ClusterHash, int>;
 
@@ -704,9 +709,11 @@ void updateSchedule(scf::ForOp &forOp, const LoadToInfoMap &loadToInfo,
   ttg::scheduleRemainingToLastStage(forOp, schedule, computeCluster);
   dumpScheduleDebug(schedule, DEBUG_TYPE, "Final coarse schedule:");
 }
+} // namespace
 } // namespace SingleDotSchedule
 
 namespace ChainedDotSchedule {
+namespace {
 using namespace mlir::ChainedDotSchedule;
 
 void scheduleAsyncCopy(const AsyncCopyChainOps &asyncOps, tt::LoadOp loadOp,
@@ -823,11 +830,12 @@ void updateSchedule(scf::ForOp &forOp, const LoadToInfoMap &loadToInfo,
   triton::gpu::scheduleRemainingToLastStage(forOp, schedule, lastCluster);
   dumpScheduleDebug(schedule, DEBUG_TYPE, "Final coarse schedule:");
 }
+} // namespace
 } // namespace ChainedDotSchedule
 
-void lowerLoop(scf::ForOp forOp,
-               triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis,
-               bool useAsyncCopy, bool usePingpong) {
+static void lowerLoop(scf::ForOp forOp,
+                      triton::AMD::ModuleAxisInfoAnalysis &axisInfoAnalysis,
+                      bool useAsyncCopy, bool usePingpong) {
   tt::CoarseSchedule schedule;
   if (failed(schedule.deSerialize(forOp, /*normalizeClusterId=*/false))) {
     return;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -187,13 +187,14 @@ std::optional<ttg::SharedEncodingTrait> getSharedEncIfAllUsersAreDotEnc(
         // the shared memory order to follow the thread order, while preserving
         // the fastest dimension from the memory order if it's contiguous > 1 to
         // keep vectorization.
-        auto llEnc =
-            triton::gpu::toLinearEncoding(cast<RankedTensorType>(srcTy));
-        auto threadOrder = llEnc.getThreadOrder();
+        auto srcTensorTy = cast<RankedTensorType>(srcTy);
+        auto regOrder = triton::gpu::getOrder(srcTensorTy);
+        auto threadOrder = triton::gpu::getThreadOrder(srcTensorTy);
 
         SetVector<unsigned> orderSet;
 
-        auto regContig = llEnc.getContigPerThread()[order[0]];
+        auto regContig =
+            triton::gpu::getContigPerThread(srcTensorTy)[regOrder[0]];
         unsigned elemBitWidth = srcTy.getElementType().getIntOrFloatBitWidth();
         unsigned finalRegContig =
             fitToValidDirectToLdsVecSize(regContig, elemBitWidth, targetInfo);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -12,7 +12,8 @@
 namespace tt = triton;
 namespace ttg = triton::gpu;
 
-namespace deduceMin {
+namespace {
+
 int deduceMinCountInBlock(Block &block,
                           const std::function<int(Operation *)> &countFunc);
 
@@ -59,17 +60,15 @@ int deduceMinCountInBlock(Block &block,
     return 0;
   return deduceMinCountBetweeOps(&block.front(), &block.back(), countFunc);
 }
-} // namespace deduceMin
 
 int deduceMinCountOnDefChain(Value defValue, Operation *consumerOp,
                              const std::function<int(Operation *)> &countFunc,
                              int pathSum, int foundMin) {
-  using namespace deduceMin;
   // If the value is not defined in the same region as the consumer we need to
   // peel the parent region of consumer until we arrive at value's region
   while (consumerOp->getParentRegion() != defValue.getParentRegion()) {
-    pathSum += deduceMin::deduceMinCountBetweeOps(
-        &consumerOp->getBlock()->front(), consumerOp, countFunc);
+    pathSum += deduceMinCountBetweeOps(&consumerOp->getBlock()->front(),
+                                       consumerOp, countFunc);
     consumerOp = consumerOp->getParentOp();
   }
 
@@ -114,6 +113,8 @@ int deduceMinCountOnDefChain(Value defValue, Operation *consumerOp,
   // Unsupported value, return 0 conservatively.
   return 0;
 }
+
+} // namespace
 
 int deduceMinCountOnDefChain(Value defValue, Operation *consumerOp,
                              llvm::function_ref<int(Operation *)> countFunc) {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -493,6 +493,28 @@ composePaddedLayout(const tt::AMD::TargetInfo &targetInfo, int opIdx,
   return {};
 }
 
+ttg::SliceEncodingAttr
+getTDMGatherScatterIndexEncoding(Operation *op, RankedTensorType indicesType) {
+  MLIRContext *ctx = op->getContext();
+  unsigned idxBitWidth = indicesType.getElementType().getIntOrFloatBitWidth();
+  assert((idxBitWidth == 16 || idxBitWidth == 32) &&
+         "TDM gather/scatter indices must be i16 or i32");
+  unsigned maxIndicesPerInstr = 256 / idxBitWidth;
+
+  unsigned numWarps = ttg::lookupNumWarps(op);
+  unsigned threadsPerWarp =
+      ttg::TritonGPUDialect::getThreadsPerWarp(op->getParentOfType<ModuleOp>());
+  auto cgaLayout = ttg::CGAEncodingAttr::get1CTALayout(ctx, /*rank=*/2);
+
+  std::array<unsigned, 2> sizePerThread = {1, maxIndicesPerInstr};
+  std::array<unsigned, 2> tPerWarp = {threadsPerWarp, 1};
+  std::array<unsigned, 2> warpsPerCTA = {1, numWarps};
+  std::array<unsigned, 2> order = {0, 1};
+  auto parentEnc = ttg::BlockedEncodingAttr::get(ctx, sizePerThread, tPerWarp,
+                                                 warpsPerCTA, order, cgaLayout);
+  return ttg::SliceEncodingAttr::get(ctx, /*dim=*/0, parentEnc);
+}
+
 ttg::SharedEncodingTrait getEncodingFromDescriptor(Operation *op,
                                                    RankedTensorType tensorType,
                                                    Value desc) {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
@@ -57,6 +57,16 @@ triton::gpu::SharedEncodingTrait
 getEncodingFromDescriptor(Operation *op, RankedTensorType tensorType,
                           Value desc);
 
+// Build the index encoding for TDM gather/scatter.
+//
+// Layout: BlockedLayout([1, M], [threadsPerWarp, 1], [1, numWarps], [0, 1])
+// sliced along dim 0 to produce a 1D encoding. M is the max number of row
+// indices per TDM instruction (256 bits / index element bitwidth). The
+// freeVarMasks mechanism in the LLVM lowering adapts the number of active
+// warps and gathers per warp to the actual problem size.
+triton::gpu::SliceEncodingAttr
+getTDMGatherScatterIndexEncoding(Operation *op, RankedTensorType indicesType);
+
 // Returns the given |inputValue|'s dot user result encoding and updates |opIdx|
 // and |vecSize| with which dot operand |inputValue| is fed into if possible.
 template <class T>

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -1912,9 +1912,7 @@ def tensor_descriptor_load_store_nd_kernel_host_tdm(out_desc, inp_desc):
     ttgl.amd.gfx1250.tdm.async_wait(0)
 
 
-def _run_tensor_descriptor_load_store_test(dtype_str, ndim, INNER_BLOCK, TDM_TYPE, SHARED_LAYOUT, ROW_MAJOR):
-    if not ROW_MAJOR and TDM_TYPE == "HOST_TDM":
-        pytest.skip("NYI: Host TDM does not support non-row major layouts")
+def _run_tensor_descriptor_load_store_test(dtype_str, ndim, INNER_BLOCK, TDM_TYPE, SHARED_LAYOUT):
     """Utility function to run TDM load/store tests with a given shared layout."""
     alloc_shape = [1, 1, 3, 7, INNER_BLOCK][-ndim:]
 
@@ -1922,10 +1920,6 @@ def _run_tensor_descriptor_load_store_test(dtype_str, ndim, INNER_BLOCK, TDM_TYP
     inp = to_triton(numpy_random(alloc_shape, dtype_str), device="cpu", dst_type=dtype_str)
     inp.data = inp.data[..., :INNER_BLOCK - 3]
     out = inp.new_empty(BLOCK_SHAPE)
-
-    if ndim > 1 and not ROW_MAJOR:
-        out = out.data.transpose(-2, -1).contiguous().transpose(-2, -1)
-        inp = inp.data.transpose(-2, -1).contiguous().transpose(-2, -1)
 
     inp = inp.cuda()
     out = out.cuda()
@@ -1961,23 +1955,19 @@ def _run_tensor_descriptor_load_store_test(dtype_str, ndim, INNER_BLOCK, TDM_TYP
 @pytest.mark.parametrize("INNER_BLOCK", [4, 8, 16, 32, 64, 128])
 @pytest.mark.parametrize("dtype_str", sorted(set(float_dtypes + int_dtypes)))
 @pytest.mark.parametrize("TDM_TYPE", ["DEVICE_TDM", "HOST_TDM"])
-@pytest.mark.parametrize("ROW_MAJOR", [False, True])
-def test_tensor_descriptor_load_store_nd(dtype_str, ndim, INNER_BLOCK, TDM_TYPE, ROW_MAJOR):
+def test_tensor_descriptor_load_store_nd(dtype_str, ndim, INNER_BLOCK, TDM_TYPE):
     """Test TDM load/store with swizzled shared layout."""
 
     order = [ndim - 1 - i for i in range(ndim)]
-    if ndim > 1 and not ROW_MAJOR:
-        order[0], order[1] = order[1], order[0]
     SHARED_LAYOUT: ttgl.constexpr = ttgl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=order)
 
-    _run_tensor_descriptor_load_store_test(dtype_str, ndim, INNER_BLOCK, TDM_TYPE, SHARED_LAYOUT, ROW_MAJOR)
+    _run_tensor_descriptor_load_store_test(dtype_str, ndim, INNER_BLOCK, TDM_TYPE, SHARED_LAYOUT)
 
 
 @pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
 @pytest.mark.parametrize("INNER_BLOCK", [16, 64])
 @pytest.mark.parametrize("dtype_str", ["float16", "int32"])
-@pytest.mark.parametrize("ROW_MAJOR", [False, True])
-def test_tensor_descriptor_load_store_nd_with_padding(dtype_str, ndim, INNER_BLOCK, ROW_MAJOR):
+def test_tensor_descriptor_load_store_nd_with_padding(dtype_str, ndim, INNER_BLOCK):
     """Test TDM load/store with padded shared memory layout.
     TDM store only supports padding when:
     1. There is a single padding interval
@@ -1987,12 +1977,9 @@ def test_tensor_descriptor_load_store_nd_with_padding(dtype_str, ndim, INNER_BLO
     BLOCK_SHAPE = (2, 2, 4, 8, INNER_BLOCK)[-ndim:]
     order = [ndim - 1 - i for i in range(ndim)]
     padding = [INNER_BLOCK, 8]
-    if ndim > 1 and not ROW_MAJOR:
-        order[0], order[1] = order[1], order[0]
-        padding = [8, INNER_BLOCK]
     PADDED_LAYOUT: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([padding], BLOCK_SHAPE, order)
 
-    _run_tensor_descriptor_load_store_test(dtype_str, ndim, INNER_BLOCK, "DEVICE_TDM", PADDED_LAYOUT, ROW_MAJOR)
+    _run_tensor_descriptor_load_store_test(dtype_str, ndim, INNER_BLOCK, "DEVICE_TDM", PADDED_LAYOUT)
 
 
 def test_tensor_descriptor_load_store_invalid_blocksize():

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -388,14 +388,6 @@ unsigned ttng::TmemAllocChannel::getNumBuffers() {
   return 1;
 }
 
-// Check to see if there is no outer loop that is enclosed under ifOp.
-bool immediateEnclosing(scf::IfOp ifOp, Operation *subOp) {
-  auto pOp = subOp->getParentOfType<scf::ForOp>();
-  if (!pOp)
-    return true;
-  return !enclosing(ifOp, pOp.getOperation());
-}
-
 // Control Ops can be replaced during the pass, but channel srcOp/dstOp should
 // be valid.
 static bool needAccumCntForReuse(Operation *ctrlOp, ReuseGroup *group) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
@@ -40,9 +40,10 @@ namespace mlir {
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
-static bool
-enclosingAChannel(Operation *ctrlOp,
-                  const DenseSet<Operation *> &regionsWithChannels) {
+namespace {
+
+bool enclosingAChannel(Operation *ctrlOp,
+                       const DenseSet<Operation *> &regionsWithChannels) {
   for (auto *op : regionsWithChannels) {
     if (ctrlOp == op)
       return true;
@@ -54,16 +55,6 @@ enclosingAChannel(Operation *ctrlOp,
         return true;
   }
   return false;
-}
-
-unsigned getLoopDepth(Operation *op) {
-  unsigned depth = 0;
-  auto pOp = op->getParentOfType<scf::ForOp>();
-  while (pOp) {
-    ++depth;
-    pOp = pOp->getParentOfType<scf::ForOp>();
-  }
-  return depth;
 }
 
 // Update preOrderOps with a list of region Ops nested under ctrlOp that will
@@ -670,6 +661,10 @@ scf::ForOp createNewLoop(scf::ForOp forOp, scf::ForOp &parentForOp,
   return newForOp;
 }
 
+} // namespace
+
+// Here we assume the source and destination ops are in the same region op.
+// Go through channels, and get a set of region ops containing channels.
 void collectRegionsWithChannels(const SmallVector<Channel *> &channels,
                                 DenseSet<Operation *> &regionsWithChannels) {
   for (auto *channel : channels) {
@@ -735,6 +730,8 @@ void collectRegionsWithChannels(const SmallVector<Channel *> &channels,
     }
   }
 }
+
+namespace {
 
 // Go through a list of operations in opList, recursively call into
 // createNewLoopWrapper or rewriteIfOp.
@@ -1251,6 +1248,8 @@ scf::WhileOp createNewWhileWrapper(scf::WhileOp origWhileOp,
   });
   return newWhileOp;
 }
+
+} // namespace
 
 void appendAccumCntsForOps(SmallVector<Operation *> &taskTopOps,
                            const SmallVector<Channel *> &channels,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -99,7 +99,9 @@ static ttng::SubtiledRegionOp getEnclosingSubtiledRegionTile(Operation *op) {
   return nullptr;
 }
 
-static unsigned getNumBuffersOrDefault(scf::ForOp forOp, unsigned numBuffers) {
+namespace {
+
+unsigned getNumBuffersOrDefault(scf::ForOp forOp, unsigned numBuffers) {
   // Use the attribute attached to the loop if it exists otherwise use the
   // global control.
   if (!forOp->hasAttr(mlir::triton::kNumStagesAttrName))
@@ -195,9 +197,9 @@ void getTransitiveUsers(Value root,
 
 // When traversing MMAv5, producerOp can be either the defining op of operand
 // A or the accumulator.
-static void createChannel(Operation *producerOp, mlir::DominanceInfo &dom,
-                          SmallVector<std::unique_ptr<Channel>> &channels,
-                          bool opndAOfGen5, unsigned producerNumBuffers) {
+void createChannel(Operation *producerOp, mlir::DominanceInfo &dom,
+                   SmallVector<std::unique_ptr<Channel>> &channels,
+                   bool opndAOfGen5, unsigned producerNumBuffers) {
   // For TMEM channels, op is MMAv5 op, producerOp can be either A operand
   // or accumulator.
   auto producerTaskIds = getAsyncTaskIds(producerOp);
@@ -335,13 +337,12 @@ void collectAsyncChannels(SmallVector<std::unique_ptr<Channel>> &channels,
   });
 }
 
-static Operation *getUniqueActualConsumer(Operation *consumerOp) {
+Operation *getUniqueActualConsumer(Operation *consumerOp) {
   auto consumers = getActualConsumers(consumerOp);
   return consumers.size() == 1 ? consumers[0] : consumerOp;
 }
 
-static Operation *getUniqueActualConsumer(Operation *consumerOp,
-                                          AsyncTaskId taskId) {
+Operation *getUniqueActualConsumer(Operation *consumerOp, AsyncTaskId taskId) {
   auto consumers = getActualConsumers(consumerOp);
   if (consumers.size() == 1)
     return consumers[0];
@@ -655,6 +656,8 @@ void reorderEpilogOps(const SmallVector<Channel *> &channels,
   });
 }
 
+} // namespace
+
 // Find top-level ops which contain at least one channel. If a channel's
 // getSrcOp() and getDstOp() belong to the inner loop, the outer loop will be
 // part of asyncTaskOps.
@@ -701,9 +704,10 @@ getTaskTopRegion(triton::FuncOp funcOp,
 }
 
 // Create an allocation to hold the mbarriers.
-static Value createBarrierAlloc(triton::FuncOp funcOp, unsigned distance,
-                                StringRef srcName = "",
-                                unsigned arriveCount = 1) {
+namespace {
+
+Value createBarrierAlloc(triton::FuncOp funcOp, unsigned distance,
+                         StringRef srcName = "", unsigned arriveCount = 1) {
   OpBuilder builder(funcOp);
   builder.setInsertionPointToStart(&(funcOp.getBody().front()));
   Attribute sharedMemorySpace =
@@ -1495,10 +1499,9 @@ static ttg::LocalAllocOp hoistLocalAllocMultiBuffer(OpBuilder &builder,
   return ttg::LocalAllocOp::create(builder, oldAlloc.getLoc(), memdescType);
 }
 
-static ttng::TMEMAllocOp
-createTMemAllocMultiBuffer(OpBuilder &builder, ttng::TMEMAllocOp oldTMemAllocOp,
-                           int numBuffers) {
-  Location loc = oldTMemAllocOp.getLoc();
+ttng::TMEMAllocOp createTMemAllocMultiBuffer(OpBuilder &builder,
+                                             ttng::TMEMAllocOp oldTMemAllocOp,
+                                             int numBuffers) {
   auto oldRetType = oldTMemAllocOp.getType();
   SmallVector<int64_t> shape = {oldRetType.getShape().begin(),
                                 oldRetType.getShape().end()};
@@ -4747,6 +4750,8 @@ static void mergeDuplicateLocalAllocs(triton::FuncOp &funcOp) {
   }
 }
 
+} // namespace
+
 // Remove redundant TMEM zeroing stores.
 // When a TMEMAllocOp is used as operand D of an MMAv5 op with
 // useAccumulator=false (on the first iteration), any preceding
@@ -4902,6 +4907,8 @@ void doBufferAllocation(triton::FuncOp funcOp) {
   // local_alloc + local_store for downstream channel detection.
   separateLocalAllocWithSrc(funcOp);
 }
+
+namespace {
 
 // ── mergeStagingReuseIntoHost ───────────────────────────────────────────
 // Realize the planner's `allocation.reuseTarget` annotation by replacing
@@ -5180,6 +5187,8 @@ static void lowerMultiTaskSubtiledRegions(triton::FuncOp funcOp) {
   for (auto op : multiTaskOps)
     ttng::lowerSubtiledRegion(op);
 }
+
+} // namespace
 
 void doCodePartition(triton::FuncOp funcOp, unsigned numBuffers) {
   // Step 1: collect all communications between producers and consumers.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -51,7 +51,9 @@ Value createBufferView(OpBuilderWithAsyncTaskIds &builder, Value alloc,
                                              viewDescType, alloc, idx);
 }
 
-static int getTMALoadSize(tt::DescriptorLoadOp &tmaLoad) {
+namespace {
+
+int getTMALoadSize(tt::DescriptorLoadOp &tmaLoad) {
   auto tensorTy = cast<RankedTensorType>(tmaLoad->getResult(0).getType());
   int loadSize = product(tensorTy.getShape());
   return loadSize * tensorTy.getElementType().getIntOrFloatBitWidth() / 8;
@@ -85,6 +87,8 @@ Value getBufferForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
       buffer.getLoc(), subviewTy, buffer, bufferIdx);
   return desc;
 }
+
+} // namespace
 
 Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                             SmallVector<tt::DescriptorLoadOp> &tmaLoads,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
@@ -26,9 +26,11 @@ namespace mlir {
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
+namespace {
+
 // Lower to use GetCanonicalWarpIdOp.
 // In Hopper, each task is a warpgroup consisting of 4 warps.
-static const int THREADS_PER_WARP = 32;
+const int THREADS_PER_WARP = 32;
 
 Value getMBarrierPhaseBit(OpBuilder &builder, Operation *op,
                           bool emptyBarrier) {
@@ -371,6 +373,8 @@ void lowerTokenOperations(Operation *parentOp, int numCTAs,
     parentOp->dump();
   });
 }
+
+} // namespace
 
 void doTokenLowering(triton::FuncOp funcOp, unsigned numConsumerGroups) {
   ModuleOp mod = funcOp.getOperation()->getParentOfType<ModuleOp>();

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -38,12 +38,14 @@ namespace mlir {
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
-static bool isWarpSpecializeBarrierAlloc(Value value) {
+namespace {
+
+bool isWarpSpecializeBarrierAlloc(Value value) {
   auto alloc = dyn_cast_or_null<ttg::LocalAllocOp>(value.getDefiningOp());
   return alloc && alloc->hasAttr(kWarpSpecializeGeneratedBarrierAttrName);
 }
 
-static void invalidateBarrierAlloc(OpBuilder &builder, Value barrierAlloc) {
+void invalidateBarrierAlloc(OpBuilder &builder, Value barrierAlloc) {
   auto barrierType = cast<ttg::MemDescType>(barrierAlloc.getType());
   int64_t numBarriers = barrierType.getShape().front();
   assert(numBarriers > 0 && "expected at least one barrier");
@@ -146,8 +148,8 @@ unsigned scanRegUsage(Block *block, AsyncTaskId asyncTaskId,
 }
 
 // Collect argument indices that are used by the specific taskId.
-static SmallVector<unsigned> collectBlockArgsForTask(scf::ForOp forOp,
-                                                     int asyncTaskId) {
+SmallVector<unsigned> collectBlockArgsForTask(scf::ForOp forOp,
+                                              int asyncTaskId) {
 
   // Collect argument indices that can be reached along the definition chain.
   SetVector<unsigned> argIndices;
@@ -669,6 +671,8 @@ static SmallVector<Operation *> topologicalSort(ArrayRef<Operation *> opList) {
 
   return sortedOpList;
 }
+
+} // namespace
 
 void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -313,30 +313,6 @@ private:
   }
 };
 
-// Helper class to load tensor memory following MMAv5 layout.
-class DotOpMmaV5TmemLoader : public DotOpMmaMemLoader {
-public:
-  DotOpMmaV5TmemLoader() {}
-  static DotOpMmaV5TmemLoader build(Location loc, RewriterBase &rewriter,
-                                    gpu::MemDescType memTy, Value tmemBase);
-
-  MemDescOperand tmemLoad(int a, int b, ConversionPatternRewriter &rewriter,
-                          Location loc) const;
-
-  MemDescOperand memLoad(int a, int b, ConversionPatternRewriter &rewriter,
-                         Location loc) const override {
-    return tmemLoad(a, b, rewriter, loc);
-  }
-
-private:
-  DotOpMmaV5TmemLoader(LinearLayout ll, Value address, int bitwidth)
-      : ll(std::move(ll)), address(address), bitwidth(bitwidth) {}
-
-  LinearLayout ll;
-  Value address;
-  int bitwidth;
-};
-
 static Value getOffsetedBase(Value v, gpu::MemDescType memDescTy,
                              const TypeConverter *typeConverter,
                              ConversionPatternRewriter &rewriter,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -16,42 +16,55 @@ namespace ttng = mlir::triton::nvidia_gpu;
 using ::mlir::triton::gpu::NVMMASharedEncodingAttr;
 using ::mlir::triton::gpu::SharedLinearEncodingAttr;
 
-//===----------------------------------------------------------------------===//
-// DotOpMmaV5TmemLoader
-//===----------------------------------------------------------------------===//
+namespace {
 
-DotOpMmaV5TmemLoader mlir::triton::NVIDIA::DotOpMmaV5TmemLoader::build(
-    Location loc, RewriterBase &rewriter, gpu::MemDescType memTy,
-    Value tmemBase) {
-  // We take the full layout even when it is a subview
-  // We'll just iterate the real shape when calling tmemLoad tho
-  auto ll = toLinearLayout(memTy);
-  auto bitwidth = memTy.getElementTypeBitWidth();
-  auto tb = TritonLLVMOpBuilder(loc, rewriter);
-  Value address = tb.ptrtoint(i32_ty, tmemBase);
-  return DotOpMmaV5TmemLoader(ll.pseudoinvert(), address, bitwidth);
-}
+// Helper class to load tensor memory following MMAv5 layout.
+class DotOpMmaV5TmemLoader : public DotOpMmaMemLoader {
+public:
+  static DotOpMmaV5TmemLoader build(Location loc, RewriterBase &rewriter,
+                                    mlir::triton::gpu::MemDescType memTy,
+                                    Value tmemBase) {
+    // We take the full layout even when it is a subview
+    // We'll just iterate the real shape when calling tmemLoad tho
+    auto ll = toLinearLayout(memTy);
+    auto bitwidth = memTy.getElementTypeBitWidth();
+    auto tb = TritonLLVMOpBuilder(loc, rewriter);
+    Value address = tb.ptrtoint(i32_ty, tmemBase);
+    return DotOpMmaV5TmemLoader(ll.pseudoinvert(), address, bitwidth);
+  }
 
-MemDescOperand mlir::triton::NVIDIA::DotOpMmaV5TmemLoader::tmemLoad(
-    int a, int b, ConversionPatternRewriter &rewriter, Location loc) const {
-  auto dims = to_vector(ll.getInDimNames());
-  auto rowCol = ll.apply({{dims[0], a}, {dims[1], b}});
-  int row = rowCol[0].second;
-  int col = rowCol[1].second * bitwidth / 32;
-  int offset = col | (row << 16);
-  return {address, offset};
-}
+  MemDescOperand tmemLoad(int a, int b, ConversionPatternRewriter &rewriter,
+                          Location loc) const {
+    auto dims = to_vector(ll.getInDimNames());
+    auto rowCol = ll.apply({{dims[0], a}, {dims[1], b}});
+    int row = rowCol[0].second;
+    int col = rowCol[1].second * bitwidth / 32;
+    int offset = col | (row << 16);
+    return {address, offset};
+  }
+
+  MemDescOperand memLoad(int a, int b, ConversionPatternRewriter &rewriter,
+                         Location loc) const override {
+    return tmemLoad(a, b, rewriter, loc);
+  }
+
+private:
+  DotOpMmaV5TmemLoader(LinearLayout ll, Value address, int bitwidth)
+      : ll(std::move(ll)), address(address), bitwidth(bitwidth) {}
+
+  LinearLayout ll;
+  Value address;
+  int bitwidth;
+};
 
 //===----------------------------------------------------------------------===//
 // InstDescriptor
 //===----------------------------------------------------------------------===//
 
-namespace {
-
 enum class mxfpKind { mxf8f6f4 = 0, mxf4 = 1, mxf4nvf4 = 2 };
 enum class scaleKind : uint32_t { ue4m3 = 0, e8m0 = 1, ue5m3 = 2 };
 
-static bool isTransposed(Value operand) {
+bool isTransposed(Value operand) {
   auto tensorTy = cast<MemDescType>(operand.getType());
   if (isa<ttng::TensorMemoryEncodingAttr>(tensorTy.getEncoding()))
     return false;
@@ -61,18 +74,18 @@ static bool isTransposed(Value operand) {
   return attrs->transposed;
 }
 
-static int getScaleFactor(Type scaleType, int blockK) {
+int getScaleFactor(Type scaleType, int blockK) {
   auto shapedType = cast<ShapedType>(scaleType);
   int64_t scaleCols = shapedType.getShape().back();
   assert(blockK % scaleCols == 0);
   return blockK / scaleCols;
 }
 
-static int getScaleVecSize(ttng::TCGen5MMAScaledOp op) {
+int getScaleVecSize(ttng::TCGen5MMAScaledOp op) {
   return getScaleFactor(op.getAScale().getType(), op.getBlockK());
 }
 
-static bool isBlock16Scale(Type scaleType, int blockK) {
+bool isBlock16Scale(Type scaleType, int blockK) {
   auto shapedType = dyn_cast<ShapedType>(scaleType);
   if (!shapedType || !shapedType.hasRank())
     return false;
@@ -101,7 +114,7 @@ inline mxfpKind getMXFPKind(ScaleDotElemType typeA, ScaleDotElemType typeB,
   return mxfpKind::mxf8f6f4;
 };
 
-static scaleKind getScaleKind(ttng::TCGen5MMAScaledOp op, int blockK) {
+scaleKind getScaleKind(ttng::TCGen5MMAScaledOp op, int blockK) {
   Type scaleType = op.getAScale().getType();
   Type elemType = cast<ShapedType>(scaleType).getElementType();
   if (llvm::isa<Float8E4M3FNType>(elemType))
@@ -111,9 +124,9 @@ static scaleKind getScaleKind(ttng::TCGen5MMAScaledOp op, int blockK) {
   return scaleKind::e8m0;
 }
 
-static Value createInstDescriptor(ConversionPatternRewriter &rewriter,
-                                  ttng::TCGen5MMAOp op, int M, int N,
-                                  bool transposeA, bool transposeB, int kSize) {
+Value createInstDescriptor(ConversionPatternRewriter &rewriter,
+                           ttng::TCGen5MMAOp op, int M, int N, bool transposeA,
+                           bool transposeB, int kSize) {
   Location loc = op.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   union TCGen5InstructionDescriptor {
@@ -177,12 +190,11 @@ static Value createInstDescriptor(ConversionPatternRewriter &rewriter,
   return b.int_val(32, desc.descriptor);
 }
 
-static Value createScaleInstDescriptorFp8(ConversionPatternRewriter &rewriter,
-                                          ttng::TCGen5MMAScaledOp op, int M,
-                                          int N, bool transposeA,
-                                          bool transposeB,
-                                          int scaleFactorsubIdxA,
-                                          int scaleFactorsubIdxB, int kSize) {
+Value createScaleInstDescriptorFp8(ConversionPatternRewriter &rewriter,
+                                   ttng::TCGen5MMAScaledOp op, int M, int N,
+                                   bool transposeA, bool transposeB,
+                                   int scaleFactorsubIdxA,
+                                   int scaleFactorsubIdxB, int kSize) {
   Location loc = op.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   union TCGen5InstructionDescriptor {
@@ -247,7 +259,7 @@ static Value createScaleInstDescriptorFp8(ConversionPatternRewriter &rewriter,
   return b.int_val(32, desc.descriptor);
 }
 
-static Value createScaleInstDescriptorFp4(
+Value createScaleInstDescriptorFp4(
     ConversionPatternRewriter &rewriter, ttng::TCGen5MMAScaledOp op, int M,
     int N, bool transposeA, bool transposeB, int scaleFactorsubIdxA,
     int scaleFactorsubIdxB, mxfpKind mxfpInstKind, int blockK, int kSize) {
@@ -327,11 +339,11 @@ static Value createScaleInstDescriptorFp4(
 // tcgen05 instructions
 //===----------------------------------------------------------------------===//
 
-static void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
-                          ttng::TCGen5MMAOp op, MemDescOperand a, Value b,
-                          MemDescOperand d, Value pred, Value instDescriptor,
-                          Value useInitAcc, bool aInTMem, bool twoCTAs,
-                          std::string collectorB) {
+void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
+                   ttng::TCGen5MMAOp op, MemDescOperand a, Value b,
+                   MemDescOperand d, Value pred, Value instDescriptor,
+                   Value useInitAcc, bool aInTMem, bool twoCTAs,
+                   std::string collectorB) {
   PTXBuilder ptxBuilder;
   std::string opcode =
       "tcgen05.mma.cta_group::" + std::to_string(twoCTAs ? 2 : 1) + ".kind::";
@@ -362,14 +374,12 @@ static void createGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
   ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
 }
 
-static void createScaledGen5MMA(ConversionPatternRewriter &rewriter,
-                                Location loc, ttng::TCGen5MMAScaledOp op,
-                                MemDescOperand a, Value b, MemDescOperand d,
-                                Value scaleA, Value scaleB, Value pred,
-                                Value instDescriptor, Value useInitAcc,
-                                bool aInTmem, mxfpKind mxfpInstKind,
-                                bool twoCTAs, std::string collectorB,
-                                int ptxVersion) {
+void createScaledGen5MMA(ConversionPatternRewriter &rewriter, Location loc,
+                         ttng::TCGen5MMAScaledOp op, MemDescOperand a, Value b,
+                         MemDescOperand d, Value scaleA, Value scaleB,
+                         Value pred, Value instDescriptor, Value useInitAcc,
+                         bool aInTmem, mxfpKind mxfpInstKind, bool twoCTAs,
+                         std::string collectorB, int ptxVersion) {
   PTXBuilder ptxBuilder;
   std::string opcode =
       "tcgen05.mma.cta_group::" + std::to_string(twoCTAs ? 2 : 1) + ".kind::";
@@ -408,9 +418,9 @@ static void createScaledGen5MMA(ConversionPatternRewriter &rewriter,
   ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
 }
 
-static void createMMACommit(ConversionPatternRewriter &rewriter, Location loc,
-                            Value barrier, Value pred, bool twoCTAs,
-                            ValueRange descs) {
+void createMMACommit(ConversionPatternRewriter &rewriter, Location loc,
+                     Value barrier, Value pred, bool twoCTAs,
+                     ValueRange descs) {
   PTXBuilder ptxBuilder;
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value mask;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -35,6 +35,8 @@ using ::mlir::triton::gpu::MemDescType;
 using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
 using ::mlir::triton::gpu::SharedEncodingTrait;
 
+namespace {
+
 triton::nvgpu::WGMMAEltType getMmaRetType(Value d) {
   auto dTy = cast<RankedTensorType>(d.getType()).getElementType();
   if (dTy.isF32()) {
@@ -147,8 +149,8 @@ SmallVector<Value> unpackAccumulator(ConversionPatternRewriter &rewriter,
   return results;
 }
 
-static Value faddAccumulate(ConversionPatternRewriter &rewriter, Location loc,
-                            Value a, Value b) {
+Value faddAccumulate(ConversionPatternRewriter &rewriter, Location loc, Value a,
+                     Value b) {
   int numEl = cast<LLVM::LLVMStructType>(a.getType()).getBody().size();
   Value newStruct = LLVM::UndefOp::create(rewriter, loc, a.getType());
   for (int i = 0; i < numEl; ++i) {
@@ -160,9 +162,8 @@ static Value faddAccumulate(ConversionPatternRewriter &rewriter, Location loc,
   return newStruct;
 }
 
-static SmallVector<Value> emitWait(ConversionPatternRewriter &rewriter,
-                                   Location loc, SmallVector<Value> acc,
-                                   int pendings) {
+SmallVector<Value> emitWait(ConversionPatternRewriter &rewriter, Location loc,
+                            SmallVector<Value> acc, int pendings) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   SmallVector<Type> types(acc.size(), acc[0].getType());
   auto structTy =
@@ -372,6 +373,8 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
   rewriter.replaceOp(op, res);
   return success();
 }
+
+} // namespace
 
 LogicalResult convertWGMMA(triton::nvidia_gpu::WarpGroupDotOp op,
                            triton::nvidia_gpu::WarpGroupDotOp::Adaptor adaptor,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1363,9 +1363,9 @@ struct AsyncTMACopyGlobalToLocalOpConversion
 
     uint32_t barrierMask =
         toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock);
-    // We emit a cluster-level barrier when the barrier mask is set.
-    bool clusterBarrier = barrierMask != 0;
-    if (clusterBarrier) {
+    // Use a cross-CTA mbarrier pointer when the barrier mask is set.
+    bool crossCTABarrier = barrierMask != 0;
+    if (crossCTABarrier) {
       barrierPtr =
           LLVM::NVIDIA::getLeaderAddress(loc, rewriter, barrierPtr, barrierTy);
     }
@@ -1396,7 +1396,7 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       Value copyIdxVal = b.add(warpID, b.i32_val(copyIdx));
       Value shMemOffset =
           applyLinearLayout(loc, rewriter, msgToShared,
-                            {{kMsg, copyIdxVal}, {kBlock, zero}})[0]
+                            {{kMsg, copyIdxVal}, {kBlock, ctaId}})[0]
               .second;
       Value shMemPtr = b.gep(elemPtrTy, llvmElemTy, dstBase, shMemOffset);
       SmallVector<PTXBuilder::Operand *> operands = {
@@ -1408,7 +1408,7 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       // otherwise it is CTA-local. The barrier component keys on the barrier
       // layout (not the SMEM layout), matching #9510.
       auto multicastMask = op.getMulticastTargets();
-      bool clusterScope = clusterBarrier || multicast ||
+      bool clusterScope = crossCTABarrier || multicast ||
                           multicastMask != nullptr || op.getTwoCta();
       std::string tmaInst = "@$0 cp.async.bulk.tensor." + std::to_string(rank) +
                             "d.shared::" + (clusterScope ? "cluster" : "cta") +
@@ -1629,6 +1629,14 @@ convertTMAStoreLikeOp(Operation *op, const TypeConverter *typeConverter,
   auto numCopies = msgToOffset.getInDimSize(kMsg);
   auto zero = b.i32_val(0);
   auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+  uint32_t maskCGABroadcast = smemLayout.getFreeVariableMasks().lookup(kBlock);
+  if (maskCGABroadcast != 0) {
+    // Stores and reductions operate from CTA-local shared memory, so if the
+    // source tile is broadcast across CTAs only the lead CTA should issue the
+    // TMA message.
+    Value ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
+    pred = b.and_(pred, b.icmp_eq(ctaIdInGroup, zero));
+  }
 
   for (int copyIdx = 0; copyIdx < numCopies; copyIdx += numWarps) {
     int numWarpsToCopy = std::min(numCopies - copyIdx, numWarps);
@@ -1641,7 +1649,7 @@ convertTMAStoreLikeOp(Operation *op, const TypeConverter *typeConverter,
     Value copyIdxVal = b.add(warpID, b.i32_val(copyIdx));
     Value shMemOffset =
         applyLinearLayout(loc, rewriter, msgToShared,
-                          {{kMsg, copyIdxVal}, {kBlock, zero}})[0]
+                          {{kMsg, copyIdxVal}, {kBlock, ctaId}})[0]
             .second;
     Value shMemPtr = b.gep(elemPtrTy, llvmElemTy, dstBase, shMemOffset);
     SmallVector<PTXBuilder::Operand *> operands = {
@@ -1864,6 +1872,8 @@ static LogicalResult iterateGatherScatterIndices(
   LinearLayout msgToCol =
       LinearLayout::strided1D(numMessagesPerRow, msgSize, kMsg, kDim1);
   LinearLayout msgLayout = xCoordsLayout * msgToCol;
+  LinearLayout msgToOffset =
+      getMsgToPackedOffsetLayout(smemType, ttg::TMAMode::Tiled);
 
   // `gather4` will put the segments of the 4 rows consecutively in
   // shared memory. However, if the 4 rows are smaller than the shared memory
@@ -1882,6 +1892,10 @@ static LogicalResult iterateGatherScatterIndices(
 
   Value warpId = mlir::triton::gpu::WarpIdOp::create(rewriter, loc);
   Value blockId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+  auto ctaOffsets = applyLinearLayout(
+      loc, rewriter, msgToOffset, {{kMsg, b.i32_val(0)}, {kBlock, blockId}});
+  assert(ctaOffsets.size() == 2 && ctaOffsets.back().first == kDim1);
+  yOffsetValue = b.add(yOffsetValue, ctaOffsets.back().second);
 
   // Mask out warps with redundant x offsets.
   pred = b.and_(pred,
@@ -1935,12 +1949,36 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
     triton::nvidia_gpu::AsyncTMAGatherOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   Location loc = op.getLoc();
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
 
   LLVM::LLVMVoidType voidTy = void_ty(op->getContext());
   auto barrierTy = op.getBarrier().getType();
   auto barrierMemObj = LLVM::getSharedMemoryObjectFromStruct(
       loc, adaptor.getBarrier(),
       typeConverter->convertType(barrierTy.getElementType()), rewriter);
+
+  auto kBlock = StringAttr::get(op.getContext(), "block");
+  bool multicast = op.getMulticast();
+  Value pred = adaptor.getPred();
+  Value multicastMask;
+  if (multicast) {
+    uint32_t maskCGABroadcast = ttg::toLinearLayout(op.getResult().getType())
+                                    .getFreeVariableMasks()
+                                    .lookup(kBlock);
+    multicastMask =
+        LLVM::NVIDIA::createTMAMulticastMask(loc, rewriter, maskCGABroadcast);
+    Value ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+    Value ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
+    pred = b.and_(pred, b.icmp_eq(ctaIdInGroup, b.i32_val(0)));
+  }
+
+  Value barrierPtr = barrierMemObj.getBase();
+  bool crossCTABarrier =
+      toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock) != 0;
+  if (crossCTABarrier) {
+    barrierPtr =
+        LLVM::NVIDIA::getLeaderAddress(loc, rewriter, barrierPtr, barrierTy);
+  }
 
   std::string ctaGroup;
   if (getModuleTwoCTAs(op)) {
@@ -1956,8 +1994,16 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
                       ArrayRef<Value> xOffsets) {
     std::string tmaInst = "@$0 cp.async.bulk.tensor.2d.tile::gather4";
     tmaInst += ctaGroup;
-    tmaInst += ".shared::cta.global.mbarrier::complete_tx::bytes "
-               "[$1], [$2, {$3, $4, $5, $6, $7}], [$8];";
+    tmaInst += ".shared::";
+    bool clusterScope = multicast || (crossCTABarrier && !getModuleTwoCTAs(op));
+    tmaInst += clusterScope ? "cluster" : "cta";
+    tmaInst += ".global.mbarrier::complete_tx::bytes";
+    if (multicast)
+      tmaInst += ".multicast::cluster";
+    tmaInst += " [$1], [$2, {$3, $4, $5, $6, $7}], [$8]";
+    if (multicast)
+      tmaInst += ", $9";
+    tmaInst += ";";
 
     PTXBuilder ptxBuilder;
     SmallVector<PTXBuilder::Operand *, 9> operands{
@@ -1970,7 +2016,9 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
     };
     for (Value xOffset : xOffsets)
       operands.push_back(ptxBuilder.newOperand(xOffset, "r"));
-    operands.push_back(ptxBuilder.newOperand(barrierMemObj.getBase(), "r"));
+    operands.push_back(ptxBuilder.newOperand(barrierPtr, "r"));
+    if (multicast)
+      operands.push_back(ptxBuilder.newOperand(multicastMask, "h"));
 
     auto &tma = *ptxBuilder.create(tmaInst);
     tma(operands, /*attachOnlyMLIRArgs=*/true);
@@ -1980,7 +2028,7 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
   if (failed(iterateGatherScatterIndices(
           op, rewriter, *getTypeConverter(), op.getXOffsets(), op.getResult(),
           adaptor.getResult(), adaptor.getXOffsets(), adaptor.getYOffset(),
-          adaptor.getPred(), callback)))
+          pred, callback)))
     return failure();
 
   rewriter.eraseOp(op);
@@ -2002,6 +2050,18 @@ LogicalResult AsyncTMAScatterOpConversion::matchAndRewrite(
   Location loc = op.getLoc();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   LLVM::LLVMVoidType voidTy = void_ty(op->getContext());
+  auto kBlock = StringAttr::get(op.getContext(), "block");
+  Value pred = b.true_val();
+  uint32_t maskCGABroadcast = ttg::toLinearLayout(op.getSrc().getType())
+                                  .getFreeVariableMasks()
+                                  .lookup(kBlock);
+  if (maskCGABroadcast != 0) {
+    // `scatter4` only reads from the current CTA's shared memory, so if the
+    // source is broadcast across CTAs only the lead CTA should issue it.
+    Value ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+    Value ctaIdInGroup = b.and_(ctaId, b.i32_val(maskCGABroadcast));
+    pred = b.icmp_eq(ctaIdInGroup, b.i32_val(0));
+  }
 
   // Callback to generate the scatter4 instruction.
   auto callback = [&](Value pred, Value shMemPtr, Value yOffset,
@@ -2029,8 +2089,8 @@ LogicalResult AsyncTMAScatterOpConversion::matchAndRewrite(
 
   if (failed(iterateGatherScatterIndices(
           op, rewriter, *getTypeConverter(), op.getXOffsets(), op.getSrc(),
-          adaptor.getSrc(), adaptor.getXOffsets(), adaptor.getYOffset(),
-          /*pred=*/b.true_val(), callback)))
+          adaptor.getSrc(), adaptor.getXOffsets(), adaptor.getYOffset(), pred,
+          callback)))
     return failure();
 
   // TODO: Separate the syncronizations operations into separate TTGIR ops to

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -370,8 +370,8 @@ LogicalResult lowerLdStMatrix(
                    {{kOffset, reps.getOutDimSize(kOffset)}}, false);
   // Compute the bits that are moved by one instruction
   // Compute elements for which we can swap the xor by an add
-  auto [nAdditive, permStrides] =
-      actionAdditiveStrides(reps, addrLayout, maskSpanAffineOffset);
+  auto [nAdditive, permStrides] = actionAdditiveStrides(
+      reps, addrLayout, maskSpanAffineOffset, fullTileVec.getInDimSize(kReg));
   reps = permStrides.apply(reps);
   if (isStore) {
     vals = permStrides.apply(vals);

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -125,8 +125,6 @@ public:
   void synchronize() { check(cuCtxSynchronize(), "cuCtxSynchronize"); }
 };
 
-} // namespace
-
 void init_triton_nvidia_passes_ttgpuir(py::module &&m) {
   using namespace mlir::triton;
   // TODO: it is weird to pass mlir::triton::NVVM here since the conversion is
@@ -144,14 +142,14 @@ void init_triton_nvidia_passes_ttgpuir(py::module &&m) {
         });
 }
 
-static std::unique_ptr<mlir::Pass>
+std::unique_ptr<mlir::Pass>
 createTritonGPUFenceInsertionWrapper(int32_t capability) {
   ttng::TritonGPUFenceInsertionOptions options;
   options.computeCapability = capability;
   return ttng::createTritonGPUFenceInsertion(options);
 }
 
-static std::unique_ptr<mlir::Pass>
+std::unique_ptr<mlir::Pass>
 createTritonGPUProxyFenceInsertionWrapper(int32_t capability) {
   ttng::TritonGPUProxyFenceInsertionOptions options;
   options.computeCapability = capability;
@@ -246,12 +244,12 @@ void init_triton_hopper_passes(py::module &&m) {
                      mlir::createNVGPU2CTATransformLoads);
 }
 
-static void checkMatmulConstraints(const std::string &A_dtype,
-                                   const std::string &B_dtype,
-                                   const std::string &C_dtype,
-                                   const std::vector<int> &A_shape,
-                                   const std::vector<int> &B_shape,
-                                   const std::vector<int> &C_shape) {
+void checkMatmulConstraints(const std::string &A_dtype,
+                            const std::string &B_dtype,
+                            const std::string &C_dtype,
+                            const std::vector<int> &A_shape,
+                            const std::vector<int> &B_shape,
+                            const std::vector<int> &C_shape) {
   if (A_dtype != B_dtype || A_dtype != C_dtype) {
     throw std::runtime_error("Data types do not match.");
   }
@@ -293,6 +291,8 @@ static void checkMatmulConstraints(const std::string &A_dtype,
         "that B needs to be transposed.");
   }
 }
+
+} // namespace
 
 void init_triton_nvidia(py::module &&m) {
   auto passes = m.def_submodule("passes");

--- a/third_party/proton/csrc/lib/Data/TraceData.cpp
+++ b/third_party/proton/csrc/lib/Data/TraceData.cpp
@@ -21,7 +21,18 @@ namespace proton {
 
 namespace {
 inline constexpr size_t kMaxActiveEventStackCacheObjects = 10;
+
+thread_local std::unordered_map<const TraceData *, std::vector<size_t>>
+    traceDataToActiveEventStack;
+
+uint64_t getCurrentCpuTimestampNs() {
+  using Clock = std::chrono::system_clock;
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             Clock::now().time_since_epoch())
+      .count();
 }
+
+} // namespace
 
 class TraceData::Trace {
 public:
@@ -163,16 +174,6 @@ private:
   // tree node id -> trace context
   std::map<size_t, TraceContext> traceContextMap;
 };
-
-thread_local std::unordered_map<const TraceData *, std::vector<size_t>>
-    traceDataToActiveEventStack;
-
-uint64_t getCurrentCpuTimestampNs() {
-  using Clock = std::chrono::system_clock;
-  return std::chrono::duration_cast<std::chrono::nanoseconds>(
-             Clock::now().time_since_epoch())
-      .count();
-}
 
 void TraceData::enterScope(const Scope &scope) {
   // enterOp and addMetric maybe called from different threads

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -8,20 +8,17 @@
 #include "triton/Tools/StrUtil.h"
 #include "llvm/Support/Signals.h"
 
-namespace {
-
-template <typename T> std::string stringifyLLVMType(const T &t) {
+template <typename T> static std::string stringifyLLVMType(const T &t) {
   std::string str;
   llvm::raw_string_ostream ros(str);
   ros << t;
   return str;
 }
-} // namespace
 
 namespace mlir {
 // gtest printer for mlir::Attribute.  This must live in namespace mlir in order
 // for it to be found via ADL.
-void PrintTo(const Attribute &attr, std::ostream *os) {
+static void PrintTo(const Attribute &attr, std::ostream *os) {
   *os << stringifyLLVMType(attr);
 }
 } // namespace mlir


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/10157

Upstream commit message:
```
> [AMD][gfx1250] Support Triton-level descriptor gather/scatter (#10157)

> This patch adds AMD TDM (Tensor Data Mover) lowering for the Triton
> `tt.descriptor_gather` and `tt.descriptor_scatter` operations on
> gfx1250.

> Key changes:
> - Widen `x_offsets` type in `tt.descriptor_gather` and
> `tt.descriptor_scatter` from i32-only to {i16, i32} to support AMD TDM's
> native 16-bit index mode.
> - Add NVIDIA TMA guard to reject i16 indices (NVIDIA TMA only supports
> i32).
> - Add `TensorGatherLowering` and `TensorScatterLowering` patterns in the
> AMD `ConvertToTensorOps` pass, lowering to `amdgpu.async_tdm_gather` /
> `amdgpu.async_tdm_scatter` with proper index layout conversion.
> - Extract `getTDMGatherScatterIndexEncoding` into shared Utility to
> build the TDM-friendly blocked+sliced index encoding for both gather and
> scatter.
> - Add MLIR lit tests for gather/scatter with both i32 and i16 indices.
> - Add Python test parametrization for i16 index dtype on AMD.

> Pipelined gather/scatter support in LowerLoops is deferred to a
> follow-up PR.
```

***Do not remove the following line from this commit***
Reactor Backport Revision: 2e82bd6297933abc3f52557465be05d666f38a81
 ---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 10157
```

Reviewed By: agron911

Differential Revision: D114403240
