### PR TITLE
[triton][beta] [Cherry-pick] '[CONSAN] Fix deadlock detection in WS code (#10192)' (#2614)

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -72,6 +72,10 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
                                        NVMMASharedEncodingAttr shared,
                                        TMAMode mode,
                                        bool disableSwizzle = false);
+FailureOr<LinearLayout>
+nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
+                          NVMMASharedEncodingAttr shared, TMAMode mode,
+                          bool disableSwizzle, bool emitErrors);
 
 // Given a linear layout where the input dimensions contain a "block" dimension,
 // this method sets the "block" dimension to 0 and removes the corresponding

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -14,8 +14,8 @@ include "triton/Dialect/Triton/IR/TritonOpInterfaces.td"
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td" // RegionBranchOpInterface
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
-include "mlir/Interfaces/InferTypeOpInterface.td"  // SameOperandsAndResultType
-include "mlir/Interfaces/SideEffectInterfaces.td"  // Pure
+include "mlir/Interfaces/InferTypeOpInterface.td" // SameOperandsAndResultType
+include "mlir/Interfaces/SideEffectInterfaces.td" // Pure
 include "mlir/Interfaces/ViewLikeInterface.td"
 
 //
@@ -24,15 +24,14 @@ include "mlir/Interfaces/ViewLikeInterface.td"
 def GlobalMemory : Resource<"::mlir::triton::GlobalMemory">;
 def SharedMemory : Resource<"::mlir::triton::gpu::SharedMemory">;
 
-class TTG_Op<string mnemonic, list<Trait> traits = []> :
-    Op<TritonGPU_Dialect, mnemonic,
-       !listconcat(traits, [VerifyTensorLayoutsTrait, VerifyMemDescLayoutsTrait])> {
-}
+class TTG_Op<string mnemonic, list<Trait> traits = []>
+    : Op<TritonGPU_Dialect, mnemonic,
+         !listconcat(
+             traits, [VerifyTensorLayoutsTrait, VerifyMemDescLayoutsTrait])> {}
 
-def TTG_ConvertLayoutOp : TTG_Op<"convert_layout",
-                                 [SameOperandsAndResultShape,
-                                  SameOperandsAndResultElementType,
-                                  Pure]> {
+def TTG_ConvertLayoutOp
+    : TTG_Op<"convert_layout", [SameOperandsAndResultShape,
+                                SameOperandsAndResultElementType, Pure]> {
   let summary = "convert layout";
 
   let arguments = (ins TT_Tensor:$src);
@@ -69,7 +68,8 @@ def TTG_AsyncWaitOp : TTG_Op<"async_wait", [MemWaitOpTrait]> {
 }
 
 def TTG_AsyncCommitGroupOp : TTG_Op<"async_commit_group"> {
-  let summary = "Commit pending async copies into an async group that can be waited on";
+  let summary =
+      "Commit pending async copies into an async group that can be waited on";
   let description = [{
     Closes the current batch of async_copy_* operations
     and allows for them to be waited on with `ttg.async_wait`.
@@ -87,13 +87,14 @@ def TTG_AsyncCommitGroupOp : TTG_Op<"async_commit_group"> {
   }];
 }
 
-def TTG_AsyncCopyGlobalToLocalOp : TTG_Op<"async_copy_global_to_local", [
-  AttrSizedOperandSegments,
-  DeclareOpInterfaceMethods<PredicatedOpInterface>,
-  OptionalTypesMatchWith<"infer mask type from src type",
-                 "src", "mask", "getI1SameShape($_self)">,
-  OptionalTypesMatchWith<"infer other type from src type",
-                 "src", "other", "getPointeeType($_self)">,
+def TTG_AsyncCopyGlobalToLocalOp
+    : TTG_Op<"async_copy_global_to_local",
+             [AttrSizedOperandSegments,
+              DeclareOpInterfaceMethods<PredicatedOpInterface>,
+              OptionalTypesMatchWith<"infer mask type from src type", "src",
+                                     "mask", "getI1SameShape($_self)">,
+              OptionalTypesMatchWith<"infer other type from src type", "src",
+                                     "other", "getPointeeType($_self)">,
 ]> {
   let summary = "Copy data from global memory to local memory asynchronously";
 
@@ -116,42 +117,41 @@ def TTG_AsyncCopyGlobalToLocalOp : TTG_Op<"async_copy_global_to_local", [
     pointers and mask/other type constraints apply.
   }];
 
-  let arguments = (ins
-    Arg<TT_PtrLike, "", [MemRead<GlobalMemory>]>:$src,
-    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$result,
-    Optional<I1Tensor>:$mask,
-    Optional<TT_Type>:$other,
-    Optional<I32>:$bulkSize,
-    Optional<TTG_MemDescType>:$barrier,
-    DefaultValuedAttr<TT_CacheModifierAttr, "triton::CacheModifier::NONE">:$cache,
-    DefaultValuedAttr<TT_EvictionPolicyAttr, "triton::EvictionPolicy::NORMAL">:$evict,
-    DefaultValuedAttr<BoolAttr, "false">:$isVolatile,
-    DefaultValuedAttr<BoolAttr, "false">:$useBulk,
-    DefaultValuedAttr<I32Attr, "1">:$contiguity
-  );
+  let arguments = (ins Arg<TT_PtrLike, "", [MemRead<GlobalMemory>]>:$src,
+      Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$result,
+      Optional<I1Tensor>:$mask, Optional<TT_Type>:$other,
+      Optional<I32>:$bulkSize, Optional<TTG_MemDescType>:$barrier,
+      DefaultValuedAttr<TT_CacheModifierAttr,
+                        "triton::CacheModifier::NONE">:$cache,
+      DefaultValuedAttr<TT_EvictionPolicyAttr,
+                        "triton::EvictionPolicy::NORMAL">:$evict,
+      DefaultValuedAttr<BoolAttr, "false">:$isVolatile,
+      DefaultValuedAttr<BoolAttr, "false">:$useBulk,
+      DefaultValuedAttr<I32Attr, "1">:$contiguity);
 
   let results = (outs TTG_AsyncToken:$token);
 
   let builders = [
-    // Backward-compatible builder without bulkSize/barrier/useBulk/contiguity
-    OpBuilder<(ins "Value":$src, "Value":$result, "Value":$mask, "Value":$other,
-                   "triton::CacheModifier":$cache, "triton::EvictionPolicy":$evict,
-                   "bool":$isVolatile),
-              [{
+      // Backward-compatible builder without bulkSize/barrier/useBulk/contiguity
+      OpBuilder<(ins "Value":$src, "Value":$result, "Value":$mask,
+                    "Value":$other, "triton::CacheModifier":$cache,
+                    "triton::EvictionPolicy":$evict, "bool":$isVolatile),
+                [{
                 build($_builder, $_state, src, result, mask, other,
                       /*bulkSize=*/Value(), /*barrier=*/Value(), cache, evict,
                       isVolatile, /*useBulk=*/false, /*contiguity=*/1);
               }]>,
-    // Backward-compatible builder without bulkSize/barrier/useBulk but with contiguity
-    OpBuilder<(ins "Value":$src, "Value":$result, "Value":$mask, "Value":$other,
-                   "triton::CacheModifier":$cache, "triton::EvictionPolicy":$evict,
-                   "bool":$isVolatile, "int":$contiguity),
-              [{
+      // Backward-compatible builder without bulkSize/barrier/useBulk but with
+      // contiguity
+      OpBuilder<(ins "Value":$src, "Value":$result, "Value":$mask,
+                    "Value":$other, "triton::CacheModifier":$cache,
+                    "triton::EvictionPolicy":$evict, "bool":$isVolatile,
+                    "int":$contiguity),
+                [{
                 build($_builder, $_state, src, result, mask, other,
                       /*bulkSize=*/Value(), /*barrier=*/Value(), cache, evict,
                       isVolatile, /*useBulk=*/false, contiguity);
-              }]>
-  ];
+              }]>];
 
   let extraClassDeclaration = [{
     static DenseSet<unsigned> getEligibleLoadByteWidth(int computeCapability) {
@@ -179,7 +179,8 @@ def TTG_AsyncCopyGlobalToLocalOp : TTG_Op<"async_copy_global_to_local", [
 }
 
 // Allocate shared memory
-def TTG_LocalAllocOp : TTG_Op<"local_alloc", [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TTG_LocalAllocOp : TTG_Op<"local_alloc", [DeclareOpInterfaceMethods<
+                                                 MemoryEffectsOpInterface>]> {
   let summary = "allocate tensor";
   let description = [{
     This operation allocates buffer in shared memory and return a descriptor
@@ -191,20 +192,18 @@ def TTG_LocalAllocOp : TTG_Op<"local_alloc", [DeclareOpInterfaceMethods<MemoryEf
     must have the element type as the buffer. If `src` is not specified, the
     returned buffer must be mutable.
   }];
-  let arguments = (
-    ins
-    Optional<TT_Tensor>:$src,
-    OptionalAttr<I32Attr>:$alignment
-  );
+  let arguments = (ins Optional<TT_Tensor>:$src,
+      OptionalAttr<I32Attr>:$alignment);
 
-  let builders = [
-    OpBuilder<(ins "Type":$result),
-              [{ build($_builder, $_state, result, Value(), IntegerAttr()); }]>,
-    OpBuilder<(ins "Type":$result, "Value":$src),
-              [{ build($_builder, $_state, result, src, IntegerAttr()); }]>,
-    OpBuilder<(ins "Type":$result, "Value":$src, "int32_t":$alignment),
-              [{ build($_builder, $_state, result, src, $_builder.getI32IntegerAttr(alignment)); }]>
-  ];
+  let builders =
+      [OpBuilder<
+           (ins "Type":$result),
+           [{ build($_builder, $_state, result, Value(), IntegerAttr()); }]>,
+       OpBuilder<(ins "Type":$result, "Value":$src),
+                 [{ build($_builder, $_state, result, src, IntegerAttr()); }]>,
+       OpBuilder<
+           (ins "Type":$result, "Value":$src, "int32_t":$alignment),
+           [{ build($_builder, $_state, result, src, $_builder.getI32IntegerAttr(alignment)); }]>];
 
   let extraClassDeclaration = [{
     bool isSharedMemoryAlloc() {
@@ -265,12 +264,14 @@ def TTG_MemDescIndexOp : TTG_Op<"memdesc_index", [Pure, MemDescViewTrait]> {
 
   let results = (outs TTG_MemDescType:$result);
 
-  let assemblyFormat = [{$src `[` $index `]` attr-dict `:` qualified(type($src)) `->` qualified(type($result))}];
+  let assemblyFormat =
+      [{$src `[` $index `]` attr-dict `:` qualified(type($src)) `->` qualified(type($result))}];
 
   let hasVerifier = 1;
 }
 
-def TTG_MemDescSubsliceOp : TTG_Op<"memdesc_subslice", [Pure, MemDescViewTrait]> {
+def TTG_MemDescSubsliceOp
+    : TTG_Op<"memdesc_subslice", [Pure, MemDescViewTrait]> {
   let summary = "take a subview of the descriptor.";
 
   let description = [{
@@ -301,11 +302,10 @@ def TTG_MemDescSubsliceOp : TTG_Op<"memdesc_subslice", [Pure, MemDescViewTrait]>
   let hasVerifier = 1;
 }
 
-def TTG_MemDescTransOp : TTG_Op<"memdesc_trans", [Pure,
-                                                  MemDescViewTrait,
-                                                  TransposeOpInterface,
-                                                  InferMemDescTypeOpWithLayoutEquivalence,
-                                                  SameOperandsAndResultElementType]> {
+def TTG_MemDescTransOp
+    : TTG_Op<"memdesc_trans", [Pure, MemDescViewTrait, TransposeOpInterface,
+                               InferMemDescTypeOpWithLayoutEquivalence,
+                               SameOperandsAndResultElementType]> {
   let summary = "transpose the descriptor";
 
   let description = [{
@@ -313,21 +313,19 @@ def TTG_MemDescTransOp : TTG_Op<"memdesc_trans", [Pure,
     representing a transposed view of the buffer.
   }];
 
-  let arguments = (
-    ins TTG_MemDescType:$src,
-    DenseI32ArrayAttr:$order
-  );
+  let arguments = (ins TTG_MemDescType:$src, DenseI32ArrayAttr:$order);
 
   let results = (outs TTG_MemDescType:$result);
 
-  let assemblyFormat = "$src attr-dict `:` qualified(type($src)) `->` qualified(type($result))";
+  let assemblyFormat =
+      "$src attr-dict `:` qualified(type($src)) `->` qualified(type($result))";
 
   let hasFolder = 1;
 }
 
-def TTG_MemDescReshapeOp : TTG_Op<"memdesc_reshape", [Pure,
-                                                      MemDescViewTrait,
-                                                      SameOperandsAndResultElementType]> {
+def TTG_MemDescReshapeOp
+    : TTG_Op<"memdesc_reshape", [Pure, MemDescViewTrait,
+                                 SameOperandsAndResultElementType]> {
   let summary = "creates a descriptor for the new shape";
 
   let description = [{
@@ -337,9 +335,7 @@ def TTG_MemDescReshapeOp : TTG_Op<"memdesc_reshape", [Pure,
 
   let arguments = (ins TTG_MemDescType:$src);
 
-  let builders = [
-    OpBuilder<(ins "Value":$src, "ArrayRef<int64_t>":$shape),
-              [{
+  let builders = [OpBuilder<(ins "Value":$src, "ArrayRef<int64_t>":$shape), [{
                 MemDescType dstTy;
                 auto srcTy = cast<MemDescType>(src.getType());
                 auto result = inferReturnTypes($_builder.getContext(),
@@ -347,8 +343,7 @@ def TTG_MemDescReshapeOp : TTG_Op<"memdesc_reshape", [Pure,
                                            srcTy, shape, dstTy);
                 assert(succeeded(result) && "failed to infer return types");
                 build($_builder, $_state, dstTy, src);
-              }]>
-  ];
+              }]>];
   let extraClassDeclaration = [{
       static LogicalResult inferReturnTypes(MLIRContext *context,
                                         std::optional<Location> loc,
@@ -359,12 +354,14 @@ def TTG_MemDescReshapeOp : TTG_Op<"memdesc_reshape", [Pure,
 
   let results = (outs TTG_MemDescType:$result);
 
-  let assemblyFormat = "$src attr-dict `:` qualified(type($src)) `->` qualified(type($result))";
+  let assemblyFormat =
+      "$src attr-dict `:` qualified(type($src)) `->` qualified(type($result))";
 
   let hasVerifier = 1;
 }
 
-def TTG_MemDescReinterpretOp : TTG_Op<"memdesc_reinterpret", [Pure, MemDescViewTrait]> {
+def TTG_MemDescReinterpretOp
+    : TTG_Op<"memdesc_reinterpret", [Pure, MemDescViewTrait]> {
   let summary = "reinterpret a memory descriptor as a different type and shape";
 
   let description = [{
@@ -396,20 +393,17 @@ def TTG_LocalLoadOp : TTG_Op<"local_load", [LocalLoadTrait]> {
   let description = [{
     Load a tensor from the local memory descriptor into a distributed tensor.
   }];
-  let arguments = (ins
-    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
-    Optional<TTG_AsyncToken>:$token
-  );
+  let arguments = (ins Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
+      Optional<TTG_AsyncToken>:$token);
   let results = (outs TT_Tensor:$result);
 
-  let builders = [
-      OpBuilder<(ins "Type":$retType, "Value":$src),
-      [{
+  let builders = [OpBuilder<(ins "Type":$retType, "Value":$src), [{
       build($_builder, $_state, retType, src, /*token=*/static_cast<mlir::Value>(nullptr));
       }]>];
 
   // Use qualified() otherwise "!ttg.memdesc<X>" is printed as "<X>".
-  let assemblyFormat = [{$src (`token` $token^)? attr-dict `:` qualified(type($src)) `->` type($result)}];
+  let assemblyFormat =
+      [{$src (`token` $token^)? attr-dict `:` qualified(type($src)) `->` type($result)}];
   let hasVerifier = 1;
 }
 
@@ -419,10 +413,8 @@ def TTG_LocalStoreOp : TTG_Op<"local_store"> {
   let description = [{
     Store a distributed tensor into a buffer in local memory.
   }];
-  let arguments = (ins
-    TT_Tensor:$src,
-    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$dst
-  );
+  let arguments = (ins TT_Tensor:$src,
+      Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$dst);
 
   let hasVerifier = 1;
   // Use qualified() otherwise "!ttg.memdesc<X>" is printed as "<X>".
@@ -432,18 +424,16 @@ def TTG_LocalStoreOp : TTG_Op<"local_store"> {
 }
 
 def TTG_RemoteShmemStoreOp : TTG_Op<"remote_shmem_store"> {
-  let summary = "Store a distributed tensor into a buffer in remote shared memory";
+  let summary =
+      "Store a distributed tensor into a buffer in remote shared memory";
 
   let description = [{
     Store a distributed tensor into a buffer in remote shared memory.
     `$ctaRank` refers to the unique CTA id in a cluster across all dims. e.g. For a 2x4 CTA cluster, a valid CTA rank
     will be 0~7.
   }];
-  let arguments = (ins
-    TT_Tensor:$src,
-    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$dst,
-    I32:$ctaRank
-  );
+  let arguments = (ins TT_Tensor:$src,
+      Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$dst, I32:$ctaRank);
   // TODO Add a verifier
   let hasVerifier = 0;
   // Use qualified() otherwise "!ttg.memdesc<X>" is printed as "<X>".
@@ -453,7 +443,8 @@ def TTG_RemoteShmemStoreOp : TTG_Op<"remote_shmem_store"> {
 }
 
 def TTG_AsyncRemoteShmemStoreOp : TTG_Op<"async_remote_shmem_store"> {
-  let summary = "Store a distributed tensor into remote shared memory with barrier completion";
+  let summary = "Store a distributed tensor into remote shared memory with "
+                "barrier completion";
   let description = [{
     Store a distributed tensor into a buffer in remote shared memory with barrier completion signaling.
     Uses PTX instruction: st.async.shared::cluster.mbarrier::complete_tx::bytes
@@ -462,12 +453,9 @@ def TTG_AsyncRemoteShmemStoreOp : TTG_Op<"async_remote_shmem_store"> {
     will be 0~7.
     `$barrier` is a mandatory mbarrier in local shared memory that will be signaled when the remote store completes.
   }];
-  let arguments = (ins
-    TT_Tensor:$src,
-    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$dst,
-    I32:$ctaRank,
-    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$barrier
-  );
+  let arguments = (ins TT_Tensor:$src,
+      Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$dst, I32:$ctaRank,
+      Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$barrier);
   let hasVerifier = 0;
   let assemblyFormat = [{
     $src `,` `rank` $ctaRank `,` $dst `barrier` $barrier attr-dict `:` type($src) `->` qualified(type($dst)) `barrier_ty` qualified(type($barrier))
@@ -475,7 +463,8 @@ def TTG_AsyncRemoteShmemStoreOp : TTG_Op<"async_remote_shmem_store"> {
 }
 
 def TTG_AsyncRemoteShmemCopyOp : TTG_Op<"async_remote_shmem_copy"> {
-  let summary = "Copy a local shared memory buffer to remote shared memory with barrier completion";
+  let summary = "Copy a local shared memory buffer to remote shared memory "
+                "with barrier completion";
   let description = [{
     Copy a local shared memory buffer to a buffer in the remote shared memory of a cluster CTA,
     and notify an mbarrier in the remote CTA when the copy completes.
@@ -486,12 +475,9 @@ def TTG_AsyncRemoteShmemCopyOp : TTG_Op<"async_remote_shmem_copy"> {
     `$barrier` is an mbarrier in local shared memory whose address will be mapa'd to the remote CTA's shared memory
     to signal completion of the copy.
   }];
-  let arguments = (ins
-    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
-    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$dst,
-    I32:$ctaRank,
-    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$barrier
-  );
+  let arguments = (ins Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
+      Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$dst, I32:$ctaRank,
+      Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$barrier);
   let hasVerifier = 0;
   let assemblyFormat = [{
     $src `,` `rank` $ctaRank `,` $dst `barrier` $barrier attr-dict `:` qualified(type($src)) `->` qualified(type($dst)) `barrier_ty` qualified(type($barrier))
@@ -512,22 +498,19 @@ def TTG_LocalGatherOp : TTG_Op<"local_gather", [LocalLoadTrait]> {
 
     This matches the behavior of tt.gather but operates on shared memory descriptors.
   }];
-  let arguments = (ins
-    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
-    TT_IntTensor:$indices,
-    I32Attr:$axis,
-    Optional<TTG_AsyncToken>:$token
-  );
+  let arguments = (ins Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
+      TT_IntTensor:$indices, I32Attr:$axis, Optional<TTG_AsyncToken>:$token);
   let results = (outs TT_Tensor:$result);
 
-  let builders = [
-      OpBuilder<(ins "Type":$retType, "Value":$src, "Value":$indices, "IntegerAttr":$axis),
-      [{
+  let builders = [OpBuilder<(ins "Type":$retType, "Value":$src,
+                                "Value":$indices, "IntegerAttr":$axis),
+                            [{
       build($_builder, $_state, retType, src, indices, axis, /*token=*/static_cast<mlir::Value>(nullptr));
       }]>];
 
   // Use qualified() otherwise "!ttg.memdesc<X>" is printed as "<X>".
-  let assemblyFormat = [{$src `[` $indices `]` (`token` $token^)? attr-dict `:` qualified(type($src)) `,` type($indices) `->` type($result)}];
+  let assemblyFormat =
+      [{$src `[` $indices `]` (`token` $token^)? attr-dict `:` qualified(type($src)) `,` type($indices) `->` type($result)}];
   let hasVerifier = 1;
 }
 
@@ -545,32 +528,31 @@ def TTG_LocalScatterOp : TTG_Op<"local_scatter"> {
 
     This is the inverse of local_gather and writes to shared memory at runtime-computed indices.
   }];
-  let arguments = (ins
-    Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$dst,
-    TT_Tensor:$values,
-    TT_IntTensor:$indices,
-    I32Attr:$axis,
-    Optional<TTG_AsyncToken>:$token
-  );
+  let arguments = (ins Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$dst,
+      TT_Tensor:$values, TT_IntTensor:$indices, I32Attr:$axis,
+      Optional<TTG_AsyncToken>:$token);
 
-  let builders = [
-      OpBuilder<(ins "Value":$dst, "Value":$values, "Value":$indices, "IntegerAttr":$axis),
-      [{
+  let builders = [OpBuilder<(ins "Value":$dst, "Value":$values,
+                                "Value":$indices, "IntegerAttr":$axis),
+                            [{
       build($_builder, $_state, dst, values, indices, axis, /*token=*/static_cast<mlir::Value>(nullptr));
       }]>];
 
   // Use qualified() otherwise "!ttg.memdesc<X>" is printed as "<X>".
-  let assemblyFormat = [{$dst `[` $indices `]` `,` $values (`token` $token^)? attr-dict `:` qualified(type($dst)) `,` type($indices) `,` type($values)}];
+  let assemblyFormat =
+      [{$dst `[` $indices `]` `,` $values (`token` $token^)? attr-dict `:` qualified(type($dst)) `,` type($indices) `,` type($values)}];
   let hasVerifier = 1;
 }
 
-def TTG_LocalAtomicScatterRMWOp : TTG_Op<"local_atomic_scatter_rmw", [
-  DeclareOpInterfaceMethods<InferTypeOpInterface>,
-  TypesMatchWith<"result type matches values type", "values", "result", "$_self">,
-  OptionalTypesMatchWith<"mask type matches values type",
-                 "values", "mask", "getI1SameShape($_self)">
-]> {
-  let summary = "Atomically scatter RMW elements into shared memory along a specified axis";
+def TTG_LocalAtomicScatterRMWOp
+    : TTG_Op<"local_atomic_scatter_rmw",
+             [DeclareOpInterfaceMethods<InferTypeOpInterface>,
+              TypesMatchWith<"result type matches values type", "values",
+                             "result", "$_self">,
+              OptionalTypesMatchWith<"mask type matches values type", "values",
+                                     "mask", "getI1SameShape($_self)">]> {
+  let summary = "Atomically scatter RMW elements into shared memory along a "
+                "specified axis";
 
   let description = [{
     Atomically updates elements in a shared memory descriptor using an indices tensor
@@ -587,14 +569,11 @@ def TTG_LocalAtomicScatterRMWOp : TTG_Op<"local_atomic_scatter_rmw", [
     mask[I] is true. Masked-off positions do not update shared memory and return
     an undefined old value.
   }];
-  let arguments = (ins
-    TT_AtomicRMWAttr:$atomic_rmw_op,
-    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$dst,
-    TT_Tensor:$values,
-    TT_IntTensor:$indices,
-    Optional<I1Tensor>:$mask,
-    I32Attr:$axis
-  );
+  let arguments = (ins TT_AtomicRMWAttr:$atomic_rmw_op,
+      Arg<TTG_MemDescType,
+          "", [MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$dst,
+      TT_Tensor:$values, TT_IntTensor:$indices, Optional<I1Tensor>:$mask,
+      I32Attr:$axis);
   let results = (outs TT_Tensor:$result);
 
   let assemblyFormat = [{
@@ -604,31 +583,29 @@ def TTG_LocalAtomicScatterRMWOp : TTG_Op<"local_atomic_scatter_rmw", [
   let hasVerifier = 1;
 }
 
-def TTG_PredicateStageOp: TTG_Op<"predicate_stage",
-                                [Pure, AllTypesMatch<["iv", "ub", "step"]>]> {
+def TTG_PredicateStageOp
+    : TTG_Op<"predicate_stage", [Pure, AllTypesMatch<["iv", "ub", "step"]>]> {
   let summary = "pipeliner stage predicate";
   let arguments = (ins AnySignlessIntegerOrIndex:$iv,
-                       AnySignlessIntegerOrIndex:$ub,
-                       AnySignlessIntegerOrIndex:$step,
-                       I32Attr:$maxStage,
-                       I32Attr:$stage);
+      AnySignlessIntegerOrIndex:$ub, AnySignlessIntegerOrIndex:$step,
+      I32Attr:$maxStage, I32Attr:$stage);
   let results = (outs I1:$result);
-  let assemblyFormat = "$iv `,` $ub `,` $step `maxStage` $maxStage `stage` $stage attr-dict `:` type($iv) `->` type($result)";
+  let assemblyFormat = "$iv `,` $ub `,` $step `maxStage` $maxStage `stage` "
+                       "$stage attr-dict `:` type($iv) `->` type($result)";
 }
 
-def TTG_MaskOp: TTG_Op<"mask",
-                       [SingleBlock]> {
-    let summary = "mask op for pipelining";
-    let arguments = (ins I1:$pred);
-    let results = (outs Variadic<AnyType>:$result);
-    let regions = (region SizedRegion<1>:$region);
+def TTG_MaskOp : TTG_Op<"mask", [SingleBlock]> {
+  let summary = "mask op for pipelining";
+  let arguments = (ins I1:$pred);
+  let results = (outs Variadic<AnyType>:$result);
+  let regions = (region SizedRegion<1>:$region);
 }
 
-def TTG_MaskReturnOp: TTG_Op<"mask.return",
-                             [HasParent<"MaskOp">, Pure, Terminator, ReturnLike]> {
-    let summary = "terminator for mask operator";
-    let arguments = (ins Variadic<AnyType>:$result);
-    let assemblyFormat = "$result attr-dict `:` type($result)";
+def TTG_MaskReturnOp : TTG_Op<"mask.return", [HasParent<"MaskOp">, Pure,
+                                              Terminator, ReturnLike]> {
+  let summary = "terminator for mask operator";
+  let arguments = (ins Variadic<AnyType>:$result);
+  let assemblyFormat = "$result attr-dict `:` type($result)";
 }
 
 def TTG_Fp4ToFpOp : TTG_Op<"fp4_to_fp", [Pure]> {
@@ -645,9 +622,8 @@ def TTG_Fp4ToFpOp : TTG_Op<"fp4_to_fp", [Pure]> {
     The `axis` attribute specifies the axis along which the fp4 elements are packed.
   }];
 
-  let builders = [
-      OpBuilder<(ins "TypedValue<RankedTensorType>":$src, "Type":$elemType, "int32_t":$axis)>
-    ];
+  let builders = [OpBuilder<(ins "TypedValue<RankedTensorType>":$src,
+      "Type":$elemType, "int32_t":$axis)>];
 
   let arguments = (ins RankedTensorOf<[I8]>:$src, I32Attr:$axis);
   let results = (outs TT_FloatTensor:$result);
@@ -675,13 +651,9 @@ def TTG_GlobalScratchAllocOp : TTG_Op<"global_scratch_alloc"> {
     Concurrency sanitizer allocations that hold cluster-wide state can be marked
     using the optional `shared_cluster_state` unit attribute.
   }];
-  let arguments = (
-    ins
-    I32Attr:$nbytes,
-    I32Attr:$alignment,
-    OptionalAttr<UnitAttr>:$third_party_allocation,
-    OptionalAttr<UnitAttr>:$shared_cluster_state
-  );
+  let arguments = (ins I32Attr:$nbytes, I32Attr:$alignment,
+      OptionalAttr<UnitAttr>:$third_party_allocation,
+      OptionalAttr<UnitAttr>:$shared_cluster_state);
   let results = (outs Arg<TT_Ptr, "", [MemAlloc<GlobalMemory>]>:$result);
 
   let extraClassDeclaration = [{
@@ -698,10 +670,11 @@ def TTG_GlobalScratchAllocOp : TTG_Op<"global_scratch_alloc"> {
   let assemblyFormat = [{attr-dict `:` qualified(type($result))}];
 }
 
-def TTG_WarpSpecializeOp : TTG_Op<"warp_specialize", [
-  RecursiveMemoryEffects, RecursivelySpeculatable, AsyncRegions,
-  DeclareOpInterfaceMethods<RegionBranchOpInterface, ["getSuccessorInputs"]>
-]> {
+def TTG_WarpSpecializeOp
+    : TTG_Op<"warp_specialize",
+             [RecursiveMemoryEffects, RecursivelySpeculatable, AsyncRegions,
+              DeclareOpInterfaceMethods<
+                  RegionBranchOpInterface, ["getSuccessorInputs"]>]> {
   let summary = "asynchronously execute code on multiple warpgroups";
   let description = [{
     The `ttg.warp_specialize` op represents executing different code
@@ -743,13 +716,12 @@ def TTG_WarpSpecializeOp : TTG_Op<"warp_specialize", [
       OptionalAttr<DenseI32ArrayAttr>:$actualRegisters);
   let results = (outs Variadic<AnyType>:$defaultPassthrough);
 
-  let regions = (region
-    MinSizedRegion<1>:$defaultRegion,
-    SizedRegion<1>:$partitionOpHolder
-  );
+  let regions = (region MinSizedRegion<1>:$defaultRegion,
+      SizedRegion<1>:$partitionOpHolder);
 
   let extraClassDeclaration = [{
     RegionRange getPartitionRegions();
+    SmallVector<Region *> getNonEmptyPartitionRegions();
     WarpSpecializePartitionsOp getPartitionOp();
 
     // Get the size of the capture list.
@@ -793,10 +765,10 @@ def TTG_WarpSpecializePartitionsOp
   let hasCanonicalizeMethod = 1;
 }
 
-def TTG_WarpYieldOp : TTG_Op<"warp_yield", [
-  Pure, Terminator, ReturnLike, HasParent<"WarpSpecializeOp">,
-  DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>
-]> {
+def TTG_WarpYieldOp
+    : TTG_Op<"warp_yield",
+             [Pure, Terminator, ReturnLike, HasParent<"WarpSpecializeOp">,
+              DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface>]> {
   let summary = "yield from the default region of `ttg.warp_specialize`";
   let description = [{
     The `ttg.warp_yield` operation is the terminator for the "default" region of
@@ -816,9 +788,9 @@ def TTG_WarpYieldOp : TTG_Op<"warp_yield", [
   let hasVerifier = 1;
 }
 
-def TTG_WarpReturnOp : TTG_Op<"warp_return", [
-  Pure, Terminator, ReturnLike, HasParent<"WarpSpecializePartitionsOp">
-]> {
+def TTG_WarpReturnOp
+    : TTG_Op<"warp_return", [Pure, Terminator, ReturnLike,
+                             HasParent<"WarpSpecializePartitionsOp">]> {
   let summary = "implicit terminator from partition regions";
   let description = [{
     The `ttg.warp_return` operation is the implicit terminator that ends the
@@ -831,16 +803,17 @@ def TTG_WarpReturnOp : TTG_Op<"warp_return", [
   let assemblyFormat = "attr-dict";
 }
 
-def TTG_Clock64Op : TTG_Op<"clock64", [
-    MemoryEffects<[MemRead<DefaultResource>, MemWrite<DefaultResource>]>
-]> {
+def TTG_Clock64Op
+    : TTG_Op<"clock64", [MemoryEffects<[MemRead<DefaultResource>,
+                                        MemWrite<DefaultResource>]>]> {
   let summary = "read 64-bit GPU clock counter";
   let results = (outs I64:$res);
   let assemblyFormat = "attr-dict";
 }
 
 def TTG_BarrierOp : TTG_Op<"barrier"> {
-  let summary = "Synchronizes execution and reads/writes to the selected address spaces for all threads in the CTA.";
+  let summary = "Synchronizes execution and reads/writes to the selected "
+                "address spaces for all threads in the CTA.";
   let description = [{
     The `barrier` op synchronises the execution and all operations between the selected address spaces for all
     threads in the CTA. It is used to coordinate communication between threads in the CTA.

--- a/include/triton/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.h
@@ -45,6 +45,15 @@ private:
                                       CGAEncodingAttr cgaLayout,
                                       ArrayRef<int64_t> usageShape,
                                       unsigned numCTAs);
+
+protected:
+  virtual Attribute getCompatibleSharedEncoding(Attribute enc,
+                                                ArrayRef<int64_t> shape,
+                                                Type elementType) {
+    return isCompatibleSharedEncoding(enc) ? enc : Attribute();
+  }
+
+private:
   // Override with backend specific implementation
   virtual Attribute buildFallbackSharedEncoding(mlir::MLIRContext *,
                                                 ArrayRef<int64_t>,

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -89,10 +89,18 @@ public:
   // clearWaiting: clear the waiting flag and stored phase for the base thread.
   void createClearWaitingCall(ImplicitLocOpBuilder &b, Value mbar, int thread,
                               Value pred, Operation *insertPoint);
-  // checkAllActiveWaiting: assert that not all active threads are waiting on
-  // matching barrier phases.
-  void createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b, int activeMask,
-                                       Value pred, Operation *insertPoint);
+  // setActiveMask: reset the live base-thread mask for the next
+  // warp-specialize region.
+  void createSetActiveMaskCall(ImplicitLocOpBuilder &b, int activeMask,
+                               Operation *insertPoint);
+  // retireActiveThread: remove a base thread from the live mask after it
+  // reaches its warp-specialize terminator.
+  void createRetireActiveThreadCall(ImplicitLocOpBuilder &b, int thread,
+                                    Operation *insertPoint);
+  // checkAllActiveWaiting: assert that not all unfinished threads across the
+  // cluster are waiting on matching barrier phases.
+  void createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b, Value pred,
+                                       Operation *insertPoint);
   // verifyBarrierCanInit: ensure the barrier is currently invalidated before
   // initializing it again.
   void createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b, Value mbar,

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -41,8 +41,9 @@ enum Kind { None = -1, AsyncCp = 0, Wgmma, TmaStore, NumCommitKinds };
 // writeVisibility + readVisibility per active memory type.
 constexpr int kCapturesPerMemType = 2;
 
-// barrierStates + waiting + barrierWriteRecipients (only when barriers exist).
-constexpr int kBarrierBaseCaptures = 3;
+// barrierStates + waiting + activeMasks + barrierWriteRecipients (only when
+// barriers exist).
+constexpr int kBarrierBaseCaptures = 4;
 
 // writeTracking + readTracking per active memory type (only when barriers
 // exist and the memory type has buffers).
@@ -208,6 +209,12 @@ struct AuxDataMap {
   // Deadlock-detection bitfield. Each base thread uses two bits: waiting flag
   // and stored phase.
   RegionToValueMap waiting;
+
+  // scratch, <C x i32>
+  // Deadlock-detection bitfield. Outside warp specialization this is 1; inside
+  // it, set bits denote base threads that have not yet reached their
+  // terminator.
+  RegionToValueMap activeMasks;
 
   // True when a memory type has cross-buffer aliasing and therefore requires
   // aliasMatrices to make visibility and commit checks conservative.

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -4530,10 +4530,13 @@ getTMABlockShapeIm2Col(ArrayRef<int64_t> shapePerCTA, int elementBitWidth,
   // H, W). Supporting pixelsPerColumn > 1024 would require computing offsets
   // that depend on input tensor shape and padding, which is non-trivial.
   if (blockShape[otherDim] > otherDimMax) {
-    return emitError() << "im2col mode: pixelsPerColumn dimension "
-                       << blockShape[otherDim]
-                       << " exceeds the maximum supported value of "
-                       << otherDimMax;
+    if (emitError) {
+      emitError() << Twine("im2col mode: pixelsPerColumn dimension ") +
+                         Twine(blockShape[otherDim]) +
+                         " exceeds the maximum supported value of " +
+                         Twine(otherDimMax);
+    }
+    return failure();
   }
 
   // Clamp the contiguous dimension (channelsPerPixel) to max 256
@@ -4543,12 +4546,16 @@ getTMABlockShapeIm2Col(ArrayRef<int64_t> shapePerCTA, int elementBitWidth,
   if (swizzleBytes != 0) {
     auto contigDimSize = (8 * swizzleBytes) / elementBitWidth;
     if (blockShape[contigDim] < contigDimSize) {
-      return emitError() << "im2col mode: block shape along the contiguous "
-                            "dimension "
-                         << contigDim
-                         << " is too small for the swizzle byte size "
-                         << swizzleBytes << ", got " << blockShape[contigDim]
-                         << " but expected at least " << contigDimSize;
+      if (emitError) {
+        emitError() << Twine("im2col mode: block shape along the contiguous "
+                             "dimension ") +
+                           Twine(contigDim) +
+                           " is too small for the swizzle byte size " +
+                           Twine(swizzleBytes) + ", got " +
+                           Twine(blockShape[contigDim]) +
+                           " but expected at least " + Twine(contigDimSize);
+      }
+      return failure();
     }
     blockShape[contigDim] = contigDimSize;
   }
@@ -4579,12 +4586,16 @@ getTMABlockShapeTiled(ArrayRef<int64_t> shapePerCTA, int elementBitWidth,
   if (swizzleBytes != 0) {
     auto contigDimSize = (8 * swizzleBytes) / elementBitWidth;
     if (blockShape[contigDim] < contigDimSize) {
-      return emitError() << "block shape along the contiguous dimension "
-                         << contigDim
-                         << " is too small for the swizzle byte size "
-                         << swizzleBytes << " in an NVMMASharedLayout, got "
-                         << blockShape[contigDim] << " but expected at least "
-                         << contigDimSize;
+      if (emitError) {
+        emitError() << Twine("block shape along the contiguous dimension ") +
+                           Twine(contigDim) +
+                           " is too small for the swizzle byte size " +
+                           Twine(swizzleBytes) +
+                           " in an NVMMASharedLayout, got " +
+                           Twine(blockShape[contigDim]) +
+                           " but expected at least " + Twine(contigDimSize);
+      }
+      return failure();
     }
     blockShape[contigDim] = contigDimSize;
   }

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -195,16 +195,15 @@ LinearLayout getCoreMatrixLinearLayout(NVMMASharedEncodingAttr shared,
   return LinearLayout({{S("offset"), bases2D}}, outDimNames);
 }
 
-LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
-                                       NVMMASharedEncodingAttr shared,
-                                       TMAMode mode, bool disableSwizzle) {
+static FailureOr<LinearLayout> buildNvmmaSharedLinearLayout(
+    ArrayRef<int64_t> shape, NVMMASharedEncodingAttr shared,
+    ArrayRef<int64_t> tmaShape, bool disableSwizzle, bool emitErrors) {
+  if (!llvm::all_of(tmaShape, llvm::isPowerOf2_64))
+    return failure();
   MLIRContext *ctx = shared.getContext();
   int rank = shape.size();
   auto shapePerCTA = getShapePerCTA(shared, shape);
   auto kOffset = S("offset");
-  auto tmaShape =
-      triton::nvidia_gpu::getTMABlockShape(shared, shapePerCTA,
-                                           /*packedSize=*/true, mode);
   // The memdesc shape rank may exceed the encoding's CGALayout rank (the
   // verifier allows encoding_rank == shape_rank - 1 for the leading buffer
   // dimension from local_alloc with num_buffers). Extend the CGALayout by
@@ -266,12 +265,14 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
   int packingFactor = shared.getFp4Padded() ? 2 : 1;
   if (collapsedTmaShape[1] * packingFactor < tileCols ||
       collapsedTmaShape[0] < tileRows) {
-    llvm::errs() << "Illegal shared layout; expected collapsed shapePerCTA to "
-                    "be at least ["
-                 << tileRows << ", " << (tileCols / packingFactor)
-                 << "], collapsedTmaShape: [" << collapsedTmaShape[0] << ", "
-                 << collapsedTmaShape[1] << "]\n";
-    llvm::report_fatal_error("Illegal shared layout");
+    if (emitErrors) {
+      llvm::errs() << "Illegal shared layout; expected collapsed shapePerCTA "
+                      "to be at least ["
+                   << tileRows << ", " << (tileCols / packingFactor)
+                   << "], collapsedTmaShape: [" << collapsedTmaShape[0] << ", "
+                   << collapsedTmaShape[1] << "]\n";
+    }
+    return failure();
   }
 
   // Distribute the remaining rows and cols.
@@ -279,7 +280,8 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
       ensureLayoutNotSmallerThan(tileLayout, outDimNames, collapsedTmaShape);
 
   // Reshape the layout to the N-D pre-transposed shape per CTA.
-  SmallVector<int64_t> maybeTransposedTmaShape = tmaShape;
+  SmallVector<int64_t> maybeTransposedTmaShape(tmaShape.begin(),
+                                               tmaShape.end());
   if (shared.getTransposed()) {
     // Move the outer dim to the inner position.
     // TODO: we should move back to using `order` instead of transposed to make
@@ -288,6 +290,10 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
                 maybeTransposedTmaShape.begin() + 1,
                 maybeTransposedTmaShape.end());
   }
+  // This condition can fail if a layout is speculatively constructed for
+  // equivalence checking.
+  if (layout.getTotalOutDimSize() != product(maybeTransposedTmaShape))
+    return failure();
   auto reshapedLayout = reshapeLayout(ctx, layout, maybeTransposedTmaShape);
 
   if (shared.getTransposed()) {
@@ -302,6 +308,42 @@ LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
       reshapedLayout, standardOutDimNames(ctx, shapePerCTA.size()),
       shapePerCTA);
   return combineCtaCgaWithShape(reshapedLayout, cgaLayout, shape);
+}
+
+LinearLayout nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
+                                       NVMMASharedEncodingAttr shared,
+                                       TMAMode mode, bool disableSwizzle) {
+  auto layout = nvmmaSharedToLinearLayout(shape, shared, mode, disableSwizzle,
+                                          /*emitErrors=*/true);
+  if (failed(layout))
+    llvm::report_fatal_error("Illegal shared layout");
+  return *layout;
+}
+
+FailureOr<LinearLayout>
+nvmmaSharedToLinearLayout(ArrayRef<int64_t> shape,
+                          NVMMASharedEncodingAttr shared, TMAMode mode,
+                          bool disableSwizzle, bool emitErrors) {
+  auto shapePerCTA = getShapePerCTA(shared, shape);
+  SmallVector<int64_t> tmaShape;
+  if (emitErrors) {
+    tmaShape =
+        getTMABlockShape(shapePerCTA, shared.getElementBitWidth(),
+                         shared.getSwizzlingByteWidth(), shared.getFp4Padded(),
+                         shared.getTransposed(), /*packedSize=*/true, mode);
+  } else {
+    auto maybeTmaShape =
+        getTMABlockShape(shapePerCTA, shared.getElementBitWidth(),
+                         shared.getSwizzlingByteWidth(), shared.getFp4Padded(),
+                         shared.getTransposed(), /*packedSize=*/true,
+                         /*emitError=*/nullptr, mode);
+    if (failed(maybeTmaShape))
+      return failure();
+    tmaShape = *maybeTmaShape;
+  }
+
+  return buildNvmmaSharedLinearLayout(shape, shared, tmaShape, disableSwizzle,
+                                      emitErrors);
 }
 
 /// Function to generate lane and warp layout for dot operands.

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1308,6 +1308,14 @@ RegionRange WarpSpecializeOp::getPartitionRegions() {
   return getPartitionOp().getPartitionRegions();
 }
 
+SmallVector<Region *> WarpSpecializeOp::getNonEmptyPartitionRegions() {
+  SmallVector<Region *> regions;
+  for (Region *region : getPartitionRegions())
+    if (!region->empty() && !region->front().without_terminator().empty())
+      regions.push_back(region);
+  return regions;
+}
+
 WarpSpecializePartitionsOp WarpSpecializeOp::getPartitionOp() {
   return cast<WarpSpecializePartitionsOp>(
       getPartitionOpHolder().front().front());

--- a/lib/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.cpp
@@ -254,23 +254,36 @@ EncodingInfo AssignDescriptorMemoryLayouts::combineEncodings(
 
 Attribute
 AssignDescriptorMemoryLayouts::findLoadEncodingFromUsers(Operation *op) {
+  auto getCompatibleEncodingForType = [&](Type type) -> Attribute {
+    if (auto memDescTy = dyn_cast<MemDescType>(type)) {
+      return getCompatibleSharedEncoding(memDescTy.getEncoding(),
+                                         memDescTy.getShape(),
+                                         memDescTy.getElementType());
+    }
+    if (auto tensorTy = dyn_cast<RankedTensorType>(type)) {
+      return getCompatibleSharedEncoding(tensorTy.getEncoding(),
+                                         tensorTy.getShape(),
+                                         tensorTy.getElementType());
+    }
+    return {};
+  };
+
   // Check if there are any desired encodings available on the op
   if (auto attr = op->getDiscardableAttr("tt.desired_encoding")) {
-    if (auto enc = dyn_cast<ttg::SharedEncodingTrait>(attr)) {
-      if (isCompatibleSharedEncoding(enc))
-        return enc;
-    }
+    if (auto resultTy = dyn_cast<RankedTensorType>(op->getResult(0).getType()))
+      if (auto compatible = getCompatibleSharedEncoding(
+              attr, resultTy.getShape(), resultTy.getElementType()))
+        return compatible;
   }
   // Ignore multiple users and just pick the first compatible layout
   for (auto use : op->getUsers()) {
     if (auto alloc = dyn_cast<ttg::LocalAllocOp>(use)) {
-      auto enc = alloc.getType().getEncoding();
-      if (isCompatibleSharedEncoding(enc))
-        return enc;
+      if (auto compatible = getCompatibleEncodingForType(alloc.getType()))
+        return compatible;
     } else if (auto store = dyn_cast<ttg::LocalStoreOp>(use)) {
-      auto enc = store.getDst().getType().getEncoding();
-      if (isCompatibleSharedEncoding(enc))
-        return enc;
+      if (auto compatible =
+              getCompatibleEncodingForType(store.getDst().getType()))
+        return compatible;
     }
   }
   return {};
@@ -436,7 +449,9 @@ void AssignDescriptorMemoryLayouts::runOnFunction(FuncOp &func) {
   auto ctx = func.getContext();
   auto numCTAs = triton::gpu::lookupNumCTAs(func);
   for (auto &[desc, einfo] : valueToEncodingInfo) {
-    auto existingTy = desc.getType().getBlockType();
+    auto descTy = desc.getType();
+    auto existingTy =
+        RankedTensorType::get(descTy.getShape(), descTy.getElementType());
     Attribute newEncoding;
     if (einfo->desiredEncoding) {
       newEncoding = einfo->desiredEncoding;
@@ -454,10 +469,11 @@ void AssignDescriptorMemoryLayouts::runOnFunction(FuncOp &func) {
   SmallVector<Type> resultTys(func.getResultTypes());
   for (auto [i, resultTy] : llvm::enumerate(resultTys)) {
     if (auto descTy = dyn_cast<TensorDescType>(resultTy)) {
-      auto encoding =
-          getFallbackSharedEncoding(descTy.getBlockType(), {}, {}, numCTAs);
-      resultTys[i] = getTensorDescTypeWithEncoding(
-          nullptr, descTy.getBlockType(), encoding);
+      auto existingTy =
+          RankedTensorType::get(descTy.getShape(), descTy.getElementType());
+      auto encoding = getFallbackSharedEncoding(existingTy, {}, {}, numCTAs);
+      resultTys[i] =
+          getTensorDescTypeWithEncoding(nullptr, existingTy, encoding);
     }
   }
   func.setFunctionType(FunctionType::get(ctx, argTys, resultTys));

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -3,8 +3,6 @@
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
-#include "triton/Analysis/Utility.h"
-#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
@@ -12,7 +10,8 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "triton/Tools/LinearLayout.h"
-#include <memory>
+#include <algorithm>
+#include <cassert>
 
 namespace mlir::triton::gpu {
 
@@ -126,7 +125,10 @@ public:
       return failure();
 
     MemDescType allocType = allocOp.getType();
-    auto allocEncoding = cast<NVMMASharedEncodingAttr>(allocType.getEncoding());
+    auto allocEncoding =
+        dyn_cast<NVMMASharedEncodingAttr>(allocType.getEncoding());
+    if (!allocEncoding)
+      return failure();
     RankedTensorType srcTy = trans.getSrc().getType();
 
     Dialect &dialect = allocEncoding.getDialect();
@@ -191,6 +193,120 @@ public:
                                          reshapeOp.getSrc());
     rewriter.replaceOpWithNewOp<MemDescReshapeOp>(allocOp, allocOp.getType(),
                                                   newAlloc);
+    return success();
+  }
+};
+
+// Rewrite
+//   tt.reshape / tt.trans -> local_alloc -> [memdesc views] -> mma
+// into
+//   local_alloc -> memdesc reshape / trans -> [memdesc views] -> mma
+//
+// The MMA operand layout is determined by the sink memdesc already feeding the
+// dot-like op. This pattern back-propagates that layout through the tensor
+// reshape/transpose chain, hoists local_alloc to the base tensor feeding that
+// view chain, and replays those tensor views as memdesc reshape/transpose
+// ops so the original local_alloc type is preserved.
+class RewriteMmaOperandViewsToMemDescForDotOp
+    : public OpInterfaceRewritePattern<triton::DotOpInterface> {
+public:
+  using OpInterfaceRewritePattern<
+      triton::DotOpInterface>::OpInterfaceRewritePattern;
+
+  LogicalResult matchAndRewrite(triton::DotOpInterface dotOp,
+                                PatternRewriter &rewriter) const override {
+    if (!isa<triton::nvidia_gpu::TCGen5MMAOp,
+             triton::nvidia_gpu::TCGen5MMAScaledOp,
+             triton::nvidia_gpu::WarpGroupDotOp>(dotOp))
+      return failure();
+
+    bool changed = false;
+
+    if (rewriteOperand(dotOp.getA(), rewriter).succeeded())
+      changed = true;
+
+    if (rewriteOperand(dotOp.getB(), rewriter).succeeded())
+      changed = true;
+
+    return success(changed);
+  }
+
+private:
+  LogicalResult rewriteOperand(Value operand, PatternRewriter &rewriter) const {
+    auto operandTy = dyn_cast<MemDescType>(operand.getType());
+    if (!operandTy)
+      return failure();
+
+    // Restrict this rewrite to an operand which already uses a shared-linear
+    // encoding. Backward propagation through tensor reshape/trans is not
+    // encoding-stable for NVMMAShared.
+    if (!isa<SharedLinearEncodingAttr>(operandTy.getEncoding()))
+      return failure();
+
+    Value beforeTrailing = operand;
+    while (auto view = beforeTrailing.getDefiningOp()) {
+      if (auto reshape = dyn_cast<MemDescReshapeOp>(view)) {
+        beforeTrailing = reshape.getSrc();
+        continue;
+      }
+      if (auto trans = dyn_cast<MemDescTransOp>(view)) {
+        beforeTrailing = trans.getSrc();
+        continue;
+      }
+      break;
+    }
+
+    auto localAlloc = beforeTrailing.getDefiningOp<LocalAllocOp>();
+    if (!localAlloc || !localAlloc.getSrc())
+      return failure();
+
+    Value baseTensor = localAlloc.getSrc();
+    SmallVector<Operation *> tensorReplaySteps;
+    MemDescType baseMemTy = localAlloc.getType();
+    while (auto view = baseTensor.getDefiningOp()) {
+      if (auto reshape = dyn_cast<triton::ReshapeOp>(view)) {
+        MemDescType srcTy;
+        auto inferred = MemDescReshapeOp::inferReturnTypes(
+            getContext(), reshape.getLoc(), baseMemTy,
+            reshape.getSrc().getType().getShape(), srcTy);
+        assert(succeeded(inferred) && "backward memdesc reshape inference "
+                                      "must succeed");
+        (void)inferred;
+        baseMemTy = srcTy;
+      } else if (auto trans = dyn_cast<triton::TransOp>(view)) {
+        Attribute srcEnc = inferSrcEncoding(view, baseMemTy.getEncoding());
+        if (!srcEnc)
+          return failure();
+        baseMemTy = MemDescType::get(
+            trans.getSrc().getType().getShape(), baseMemTy.getElementType(),
+            srcEnc, baseMemTy.getMemorySpace(), baseMemTy.getMutableMemory());
+      } else {
+        break;
+      }
+      tensorReplaySteps.push_back(view);
+      baseTensor = view->getOperand(0);
+    }
+    if (tensorReplaySteps.empty())
+      return failure();
+
+    std::reverse(tensorReplaySteps.begin(), tensorReplaySteps.end());
+
+    PatternRewriter::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(localAlloc);
+
+    Value rewritten = LocalAllocOp::create(rewriter, localAlloc.getLoc(),
+                                           baseMemTy, baseTensor);
+    for (Operation *op : tensorReplaySteps) {
+      if (auto reshape = dyn_cast<triton::ReshapeOp>(op)) {
+        rewritten = MemDescReshapeOp::create(rewriter, op->getLoc(), rewritten,
+                                             reshape.getType().getShape());
+      } else {
+        auto trans = cast<triton::TransOp>(op);
+        rewritten = MemDescTransOp::create(rewriter, op->getLoc(), rewritten,
+                                           trans.getOrder());
+      }
+    }
+    rewriter.replaceOp(localAlloc, rewritten);
     return success();
   }
 };
@@ -356,6 +472,7 @@ public:
     mlir::RewritePatternSet patterns(context);
     patterns.add<SwizzleShmemConvert>(context);
     patterns.add<FuseTransMMAV3Plus, ReshapeMemDesc>(context);
+    patterns.add<RewriteMmaOperandViewsToMemDescForDotOp>(context);
     patterns.add<UseShmemForScales>(context);
     ConvertLayoutOp::getCanonicalizationPatterns(patterns, context);
     if (failed(applyPatternsGreedily(m, std::move(patterns))))

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -577,8 +577,69 @@ void FunctionBuilder::createClearWaitingCall(ImplicitLocOpBuilder &b,
       });
 }
 
+void FunctionBuilder::createSetActiveMaskCall(ImplicitLocOpBuilder &b,
+                                              int activeMask,
+                                              Operation *insertPoint) {
+  if (auxData.activeMasks.empty())
+    return;
+  int64_t expandedActiveMask = expandActiveMask(activeMask);
+  Value expandedActiveMaskVal =
+      arith::ConstantIntOp::create(b, expandedActiveMask, 32);
+  Value activeMasksVal = auxData.activeMasks.at(insertPoint).value;
+  auto activeMasksType =
+      cast<RankedTensorType>(auxData.activeMasks.at(insertPoint).type);
+  SmallVector<Value> args = {expandedActiveMaskVal, activeMasksVal};
+  createCallToCachedFunction(
+      b, "set_active_mask", args,
+      /*assertInfo=*/std::nullopt, {activeMasksType},
+      [activeMasksType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value expandedActiveMaskVal = entryBlock->getArgument(0);
+        Value activeMasksPtr = entryBlock->getArgument(1);
+
+        Value newActiveMasks =
+            triton::SplatOp::create(fb, activeMasksType, expandedActiveMaskVal);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), activeMasksPtr,
+                                      newActiveMasks, activeMasksType,
+                                      /*currentCTAOnly=*/true);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createRetireActiveThreadCall(ImplicitLocOpBuilder &b,
+                                                   int thread,
+                                                   Operation *insertPoint) {
+  if (auxData.activeMasks.empty())
+    return;
+  int64_t threadMask = expandActiveMask(1u << thread);
+  Value clearMaskVal = arith::ConstantIntOp::create(b, ~threadMask, 32);
+  Value activeMasksVal = auxData.activeMasks.at(insertPoint).value;
+  auto activeMasksType =
+      cast<RankedTensorType>(auxData.activeMasks.at(insertPoint).type);
+  SmallVector<Value> args = {clearMaskVal, activeMasksVal};
+  createCallToCachedFunction(
+      b, "retire_active_thread", args,
+      /*assertInfo=*/std::nullopt, {activeMasksType},
+      [activeMasksType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value clearMaskVal = entryBlock->getArgument(0);
+        Value activeMasksPtr = entryBlock->getArgument(1);
+
+        Value activeMasks = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), activeMasksPtr, activeMasksType);
+        Value clearMask =
+            triton::SplatOp::create(fb, activeMasksType, clearMaskVal);
+        Value retiredMasks = arith::AndIOp::create(fb, activeMasks, clearMask);
+        Value oneMask =
+            tti::createConstIntTensor(fb, fb.getLoc(), 1, activeMasksType);
+        Value newActiveMasks =
+            arith::MaxUIOp::create(fb, retiredMasks, oneMask);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), activeMasksPtr,
+                                      newActiveMasks, activeMasksType,
+                                      /*currentCTAOnly=*/true);
+        triton::ReturnOp::create(fb);
+      });
+}
+
 void FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
-                                                      int activeMask,
                                                       Value pred,
                                                       Operation *insertPoint) {
   if (auxData.waiting.empty() || auxData.barrierStates.empty()) {
@@ -587,9 +648,6 @@ void FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
   if (!pred) {
     pred = arith::ConstantIntOp::create(b, 1, 1);
   }
-  int64_t expandedActiveMask = expandActiveMask(activeMask);
-  Value expandedActiveMaskVal =
-      arith::ConstantIntOp::create(b, expandedActiveMask, 32);
   Value waitingVal = auxData.waiting.at(insertPoint).value;
   auto waitingType =
       cast<RankedTensorType>(auxData.waiting.at(insertPoint).type);
@@ -603,21 +661,27 @@ void FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
   auto barrierStatesGlobalType = tti::getIntTensorType(
       region, barrierStatesType.getShape(),
       barrierStatesType.getElementType().getIntOrFloatBitWidth());
-  SmallVector<Value> args = {expandedActiveMaskVal, pred, waitingVal,
-                             barrierStatesVal};
+  Value activeMasksVal = auxData.activeMasks.at(insertPoint).value;
+  auto activeMasksType =
+      cast<RankedTensorType>(auxData.activeMasks.at(insertPoint).type);
+  auto activeMasksGlobalType = tti::getIntTensorType(
+      region, activeMasksType.getShape(),
+      activeMasksType.getElementType().getIntOrFloatBitWidth());
+  SmallVector<Value> args = {pred, waitingVal, barrierStatesVal,
+                             activeMasksVal};
   AssertInfo assertInfo{
-      "Deadlock detected: all active threads are waiting on mbarriers",
+      "Deadlock detected: all unfinished threads are waiting on mbarriers",
       b.getI1Type()};
   createCallToCachedFunction(
       b, "check_all_active_waiting", args, assertInfo,
-      {waitingGlobalType, barrierStatesGlobalType},
-      [waitingGlobalType, barrierStatesGlobalType](ImplicitLocOpBuilder &fb,
-                                                   Block *entryBlock) {
-        Value expandedActiveMaskVal = entryBlock->getArgument(0);
-        Value pred = entryBlock->getArgument(1);
+      {waitingGlobalType, barrierStatesGlobalType, activeMasksGlobalType},
+      [waitingGlobalType, barrierStatesGlobalType,
+       activeMasksGlobalType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value pred = entryBlock->getArgument(0);
 
-        Value waitingPtr = entryBlock->getArgument(2);
-        Value barrierStatesPtr = entryBlock->getArgument(3);
+        Value waitingPtr = entryBlock->getArgument(1);
+        Value barrierStatesPtr = entryBlock->getArgument(2);
+        Value activeMasksPtr = entryBlock->getArgument(3);
 
         Value waiting = tti::createLoadScratchMemory(
             fb, fb.getLoc(), waitingPtr, waitingGlobalType);
@@ -652,17 +716,26 @@ void FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
             fb, phaseIsOne, waitingPhase1, waitingPhase0);
         Value waitingOr = reduce<arith::OrIOp>(fb, effectiveWaiting, 1);
         auto waitingOrType = cast<RankedTensorType>(waitingOr.getType());
+        Value activeMasks = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), activeMasksPtr, activeMasksGlobalType);
         Value activeMaskTensor =
-            triton::SplatOp::create(fb, waitingOrType, expandedActiveMaskVal);
+            createConvertLayout(fb, activeMasks, waitingOrType.getEncoding());
         Value waitingMasked =
             arith::AndIOp::create(fb, waitingOr, activeMaskTensor);
         Value eqPerCTA = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
                                                waitingMasked, activeMaskTensor);
-        Value eq = reduceAll<arith::AndIOp>(fb, eqPerCTA);
+        Value allFinishedOrWaiting = reduceAll<arith::AndIOp>(fb, eqPerCTA);
+        Value zeroMask = tti::createConstIntTensor(fb, fb.getLoc(), 0,
+                                                   activeMasksGlobalType);
+        Value activePerCTA = arith::CmpIOp::create(fb, arith::CmpIPredicate::ne,
+                                                   activeMasks, zeroMask);
+        Value anyUnfinished = reduceAll<arith::OrIOp>(fb, activePerCTA);
+        Value deadlocked =
+            arith::AndIOp::create(fb, allFinishedOrWaiting, anyUnfinished);
 
         Value vTrue = arith::ConstantOp::create(
-            fb, eq.getType(), fb.getIntegerAttr(fb.getI1Type(), 1));
-        Value ok = arith::XOrIOp::create(fb, eq, vTrue);
+            fb, deadlocked.getType(), fb.getIntegerAttr(fb.getI1Type(), 1));
+        Value ok = arith::XOrIOp::create(fb, deadlocked, vTrue);
         Value predicatedOk = arith::SelectOp::create(fb, pred, ok, vTrue);
         triton::ReturnOp::create(fb, predicatedOk);
       });

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -139,9 +139,9 @@ bool hasCrossBufferAliasing(ArrayRef<BufferRegion> regions) {
   return false;
 }
 
-Value createZeroInitStateTensor(ImplicitLocOpBuilder &b,
-                                ArrayRef<int64_t> shape, int bitWidth,
-                                FunctionBuilder &funcBuilder) {
+Value createInitStateTensor(ImplicitLocOpBuilder &b, ArrayRef<int64_t> shape,
+                            int bitWidth, int64_t initialValue,
+                            FunctionBuilder &funcBuilder) {
   auto type =
       getIntTensorType(b.getInsertionBlock()->getParent(), shape, bitWidth);
   Type elType = type.getElementType();
@@ -154,7 +154,7 @@ Value createZeroInitStateTensor(ImplicitLocOpBuilder &b,
   auto alloc = createThirdPartyScratchAlloc(b, b.getLoc(), ptrType, sizeInBytes,
                                             /*alignment=*/16,
                                             /*sharedClusterState=*/true);
-  Value cstZero = arith::ConstantIntOp::create(b, 0, bitWidth);
+  Value cstInit = arith::ConstantIntOp::create(b, initialValue, bitWidth);
   Value ctaId = ExperimentalClusterCTAIdOp::create(b, b.getLoc());
   Value zero = arith::ConstantIntOp::create(b, 0, 32);
   Value isCTA0 =
@@ -169,9 +169,15 @@ Value createZeroInitStateTensor(ImplicitLocOpBuilder &b,
   cf::CondBranchOp::create(b, isCTA0, ifBlock, ValueRange{}, thenBlock,
                            ValueRange{});
   b.setInsertionPointToStart(ifBlock);
-  funcBuilder.createFillGlobalTensorCall(b, alloc, type, cstZero);
+  funcBuilder.createFillGlobalTensorCall(b, alloc, type, cstInit);
   b.setInsertionPointToStart(thenBlock);
   return alloc;
+}
+
+Value createZeroInitStateTensor(ImplicitLocOpBuilder &b,
+                                ArrayRef<int64_t> shape, int bitWidth,
+                                FunctionBuilder &funcBuilder) {
+  return createInitStateTensor(b, shape, bitWidth, 0, funcBuilder);
 }
 
 TypedValue<RankedTensorType>
@@ -411,7 +417,7 @@ Operation *createStoreScratchMemory(OpBuilder &b, Location loc, Value alloc,
                                     Value tensor, RankedTensorType tensorType,
                                     bool currentCTAOnly) {
   if (currentCTAOnly) {
-    assert(tensorType.getRank() >= 2 &&
+    assert(tensorType.getRank() >= 1 &&
            "expected currentCTAOnly tensor to have a leading CTA dimension");
     int64_t numCTAs = lookupNumCTAs(b);
     assert(tensorType.getShape()[0] == numCTAs &&
@@ -564,6 +570,12 @@ void AuxDataMap::populateAndPassToWarpSpecialize(
         {createZeroInitStateTensor(b, {numCTAs, numBarriers}, 32, fb),
          getIntTensorType(entryRegion, {numCTAs, numBarriers}, 32)});
     passToWarpSpecialize(entryPoint, waiting.at(entryRegion), waiting,
+                         captureCounter);
+
+    activeMasks.insert(entryRegion,
+                       {createInitStateTensor(b, {numCTAs}, 32, 1, fb),
+                        getIntTensorType(entryRegion, {numCTAs}, 32)});
+    passToWarpSpecialize(entryPoint, activeMasks.at(entryRegion), activeMasks,
                          captureCounter);
 
     barrierWriteRecipients.insert(
@@ -721,7 +733,7 @@ void AuxDataMap::createInWarpSpecialize(
     FuncOp func, RegionToValueMap &map,
     std::function<ValueType(ImplicitLocOpBuilder &)> createFn) {
   func.walk([&](WarpSpecializeOp op) {
-    for (Region *region : op.getPartitionRegions()) {
+    for (Region *region : op.getNonEmptyPartitionRegions()) {
       ImplicitLocOpBuilder b(region->getLoc(), region);
       b.setInsertionPointToStart(&region->getBlocks().front());
       map.insert(region, createFn(b));

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -144,18 +144,10 @@ uint64_t getThreadPeersMask(int thread) {
   return mask;
 }
 
-int getActiveMask(Operation *op) {
-  int numParts = 1;
-
-  if (auto wsOp = op->getParentOfType<ttg::WarpSpecializeOp>()) {
-    numParts = wsOp.getPartitionRegions().size() + 1;
-  }
-  if (auto wsOp = op->getParentOfType<ttg::WarpSpecializePartitionsOp>()) {
-    numParts = wsOp.getPartitionRegions().size() + 1;
-  }
-  int activeMask = 0;
-  for (int i = 0; i < numParts; ++i)
-    activeMask |= (1 << i);
+int getActiveMask(ttg::WarpSpecializeOp wsOp) {
+  int activeMask = 1;
+  for (Region *region : wsOp.getNonEmptyPartitionRegions())
+    activeMask |= 1 << (region->getRegionNumber() + 1);
   return activeMask;
 }
 
@@ -511,11 +503,12 @@ private:
       instrumentMemEffects(b, op, thread, funcBuilder);
       b.setLoc(op->getLoc());
       if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(op)) {
-        auto partitionRegions = wsOp.getPartitionRegions();
+        funcBuilder.createSetActiveMaskCall(b, getActiveMask(wsOp), op);
+        auto partitionRegions = wsOp.getNonEmptyPartitionRegions();
         if (!partitionRegions.empty()) {
           uint64_t destMask = 0;
-          for (size_t idx = 0, e = partitionRegions.size(); idx < e; ++idx)
-            destMask |= getThreadPeersMask(idx + 1);
+          for (Region *region : partitionRegions)
+            destMask |= getThreadPeersMask(region->getRegionNumber() + 1);
           if (destMask) {
             for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
               funcBuilder.createCopyWriteVisibilityCall(b, thread, destMask,
@@ -578,6 +571,25 @@ private:
         }
       }
 
+      if (isa<ttg::WarpYieldOp, ttg::WarpReturnOp>(op) &&
+          !auxData.activeMasks.empty()) {
+        auto wsOp = op->getParentOfType<ttg::WarpSpecializeOp>();
+        bool shouldRetire =
+            isa<ttg::WarpYieldOp>(op) ||
+            llvm::is_contained(wsOp.getNonEmptyPartitionRegions(),
+                               op->getParentRegion());
+        if (shouldRetire) {
+          b.setLoc(wsOp.getLoc());
+          funcBuilder.createRetireActiveThreadCall(b, baseThread, op);
+          funcBuilder.createCheckAllActiveWaitingCall(b, nullptr, op);
+        }
+      }
+      if (isa<tt::ReturnOp>(op) && !auxData.activeMasks.empty() &&
+          op->getParentOfType<tt::FuncOp>() == tti::getEntryPoint(module)) {
+        funcBuilder.createSetActiveMaskCall(b, 0, op);
+        funcBuilder.createCheckAllActiveWaitingCall(b, nullptr, op);
+      }
+
       listener.maybeWrapWithCriticalSection(b, auxData, nullptr);
       b.setListener(nullptr);
     });
@@ -594,8 +606,7 @@ private:
     funcBuilder.createVerifyBarrierInitializedCall(wb, alloc, pred, op,
                                                    currentCTAMask(wb));
     funcBuilder.createSetWaitingCall(wb, alloc, baseThread, phase, pred, op);
-    funcBuilder.createCheckAllActiveWaitingCall(wb, getActiveMask(op), pred,
-                                                op);
+    funcBuilder.createCheckAllActiveWaitingCall(wb, pred, op);
     tti::ExperimentalLockReleaseOp::create(wb, lock, pred);
     // Post-wait: transfer visible writes and reads to all peer threads,
     // and clear waiting for this barrier.

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/OptimizeDescriptorEncoding.cpp
@@ -6,6 +6,7 @@
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
 #include "triton/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -36,17 +37,91 @@ static bool isTMACompatibleEncoding(Attribute enc) {
   return false;
 }
 
+static Attribute getCompatibleSharedEncoding(Attribute enc,
+                                             ArrayRef<int64_t> shape,
+                                             Type elementType) {
+  if (isTMACompatibleEncoding(enc))
+    return enc;
+
+  auto sharedLinear = dyn_cast<ttg::SharedLinearEncodingAttr>(enc);
+  if (!sharedLinear)
+    return {};
+
+  auto *ctx = enc.getContext();
+  auto cgaLayout = ttg::getCGALayout(sharedLinear);
+  auto order = ttg::getOrder(sharedLinear, shape);
+  auto sharedLinearLayout = ttg::toLinearLayout(shape, sharedLinear);
+  auto isEquivalent = [&](ttg::NVMMASharedEncodingAttr candidate) {
+    auto candidateLayout = ttg::nvmmaSharedToLinearLayout(
+        shape, candidate, ttg::TMAMode::Tiled, /*disableSwizzle=*/false,
+        /*emitErrors=*/false);
+    return succeeded(candidateLayout) && *candidateLayout == sharedLinearLayout;
+  };
+
+  SmallVector<ttg::NVMMASharedEncodingAttr> preferredCandidates;
+  // TMA descriptors only support non-transposed layouts. Preserve Triton's
+  // default shape/order-based choice when it already matches this
+  // shared_linear layout. The full candidate scan below is only a fallback for
+  // equivalent non-transposed layouts not selected by the heuristic builder.
+  for (bool fp4Padded : {false, true}) {
+    auto preferred = ttg::NVMMASharedEncodingAttr::get(
+        ctx, shape, order, cgaLayout, elementType, fp4Padded);
+    preferredCandidates.push_back(preferred);
+    if (isEquivalent(preferred))
+      return preferred;
+  }
+
+  unsigned elementBitWidth = std::max(8u, elementType.getIntOrFloatBitWidth());
+  for (bool fp4Padded : {false, true}) {
+    for (unsigned swizzle : {0u, 32u, 64u, 128u}) {
+      auto candidate = ttg::NVMMASharedEncodingAttr::get(
+          ctx, swizzle, /*transposed=*/false, elementBitWidth, fp4Padded,
+          cgaLayout);
+      if (llvm::is_contained(preferredCandidates, candidate))
+        continue;
+      if (isEquivalent(candidate))
+        return candidate;
+    }
+  }
+
+  return {};
+}
+
 Attribute findLoadEncodingFromUsers(Operation *op) {
+  auto getCompatibleEncodingForType = [&](Type type) -> Attribute {
+    if (auto memDescTy = dyn_cast<ttg::MemDescType>(type)) {
+      return getCompatibleSharedEncoding(memDescTy.getEncoding(),
+                                         memDescTy.getShape(),
+                                         memDescTy.getElementType());
+    }
+    if (auto tensorTy = dyn_cast<RankedTensorType>(type)) {
+      return getCompatibleSharedEncoding(tensorTy.getEncoding(),
+                                         tensorTy.getShape(),
+                                         tensorTy.getElementType());
+    }
+    return {};
+  };
+
+  if (auto attr = op->getDiscardableAttr("tt.desired_encoding")) {
+    if (op->getNumResults() != 0) {
+      if (auto resultTy =
+              dyn_cast<RankedTensorType>(op->getResult(0).getType())) {
+        if (auto compatible = getCompatibleSharedEncoding(
+                attr, resultTy.getShape(), resultTy.getElementType()))
+          return compatible;
+      }
+    }
+  }
+
   // Ignore multiple users and just pick the first compatible layout
   for (auto use : op->getUsers()) {
     if (auto alloc = dyn_cast<ttg::LocalAllocOp>(use)) {
-      auto enc = alloc.getType().getEncoding();
-      if (isTMACompatibleEncoding(enc))
-        return enc;
+      if (auto compatible = getCompatibleEncodingForType(alloc.getType()))
+        return compatible;
     } else if (auto store = dyn_cast<ttg::LocalStoreOp>(use)) {
-      auto enc = store.getDst().getType().getEncoding();
-      if (isTMACompatibleEncoding(enc))
-        return enc;
+      if (auto compatible =
+              getCompatibleEncodingForType(store.getDst().getType()))
+        return compatible;
     }
   }
   return {};

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -2145,6 +2145,81 @@ def test_deadlock_two_partitions(device, run_wrapper, monkeypatch, num_ctas):
 
 
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+def test_deadlock_with_padded_warp_specialize_partition(device, run_wrapper, monkeypatch, num_ctas):
+    if run_wrapper:
+        result = run_in_process(test_deadlock_with_padded_warp_specialize_partition,
+                                (device, False, monkeypatch, num_ctas))
+        assert_expected_cuda_failure(result.exc)
+        assert "Deadlock detected" in result.driver_stderr_output
+        return
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def wait_forever(bar):
+        mbarrier.wait(bar, phase=0)
+
+    @gluon.jit
+    def done(bar):
+        pass
+
+    @gluon.jit
+    def kernel():
+        bar = mbarrier.allocate_mbarrier()
+        mbarrier.init(bar, count=1)
+        ttgl.warp_specialize([
+            (done, (bar, )),
+            (wait_forever, (bar, )),
+            (wait_forever, (bar, )),
+            (wait_forever, (bar, )),
+        ], [1, 1, 1], [32, 32, 32])
+
+    kernel[(1, )](num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
+@pytest.mark.parametrize("TWO_CTAS", [False, True], ids=["single-cta-barrier", "two-cta-barrier"])
+def test_deadlock_after_other_partition_returns(TWO_CTAS, device, run_wrapper, monkeypatch, num_ctas):
+    if TWO_CTAS and num_ctas == 1:
+        pytest.skip("two-CTA barriers require at least two CTAs")
+    if run_wrapper:
+        result = run_in_process(test_deadlock_after_other_partition_returns,
+                                (TWO_CTAS, device, False, monkeypatch, num_ctas))
+        assert_expected_cuda_failure(result.exc)
+        assert "Deadlock detected" in result.driver_stderr_output
+        return
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def done(bar):
+        pass
+
+    @gluon.jit
+    def wait_forever(bar):
+        mbarrier.wait(bar.index(0), phase=0)
+
+    @gluon.jit
+    def complete_and_return(bar):
+        mbarrier.arrive(bar.index(1), count=1)
+
+    @gluon.jit
+    def kernel(TWO_CTAS: ttgl.constexpr):
+        bar = mbarrier.allocate_mbarrier(batch=2, two_ctas=TWO_CTAS)
+        mbarrier.init(bar.index(0), count=1)
+        mbarrier.init(bar.index(1), count=1)
+        ttgl.warp_specialize([
+            (done, (bar, )),
+            (wait_forever, (bar, )),
+            (complete_and_return, (bar, )),
+        ], [4, 4], [32, 32])
+
+    kernel[(1, )](TWO_CTAS, num_warps=4, num_ctas=num_ctas)
+
+
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper")
 def test_deadlock_overarrival(device, run_wrapper, monkeypatch, num_ctas):
     if run_wrapper:
         result = run_in_process(test_deadlock_overarrival, (device, False, monkeypatch, num_ctas))

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -873,12 +873,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
-    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
-    // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
-    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
-    // CHECK: tt.call @__triton_consan_copy_read_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
+    // CHECK: arith.constant 1 : i32
+    // CHECK: tt.call @__triton_consan_set_active_mask
+    // CHECK: tti.experimental_lock_release
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {
       %c0_i32 = arith.constant 0 : i32
@@ -939,12 +936,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: %[[ACTIVE_MASK:.*]] = arith.constant 5 : i32
+    // CHECK: tt.call @__triton_consan_set_active_mask{{.*}}(%[[ACTIVE_MASK]],
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {
       // CHECK: tti.experimental_lock_acquire
       // CHECK: tt.call @__triton_consan_set_waiting
-      // CHECK: %[[ACTIVE_MASK:.*]] = arith.constant 5 : i32
-      // CHECK: tt.call @__triton_consan_check_all_active_waiting{{.*}}(%[[ACTIVE_MASK]], {{.*}}, {{.*}}, {{.*}})
+      // CHECK: tt.call @__triton_consan_check_all_active_waiting
       // CHECK: tti.experimental_lock_release
       %c0_i32 = arith.constant 0 : i32
       amdg.wait_barrier %bar, %c0_i32 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -954,8 +952,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       // CHECK: partition0
       // CHECK: tti.experimental_lock_acquire
       // CHECK: tt.call @__triton_consan_set_waiting
-      // CHECK: %[[ACTIVE_MASK:.*]] = arith.constant 5 : i32
-      // CHECK: tt.call @__triton_consan_check_all_active_waiting{{.*}}(%[[ACTIVE_MASK]], {{.*}}, {{.*}}, {{.*}})
+      // CHECK: tt.call @__triton_consan_check_all_active_waiting
       // CHECK: tti.experimental_lock_release
       %c0_i32 = arith.constant 0 : i32
       amdg.wait_barrier %arg2, %c0_i32 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>

--- a/test/TritonGPU/amd/amd-pipeline-tdm.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-tdm.mlir
@@ -312,3 +312,70 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK: scf.if %{{[0-9]+}} {
 // CHECK-NEXT: tt.descriptor_store
 // CHECK-NEXT: }
+
+// -----
+
+// Test TDM pipeline for gather + dot on gfx1250.
+// Two gathers (A and B) inside a loop feed into a dot. The pipeline pass
+// should convert them to async_tdm_gather ops and software-pipeline the loop.
+
+#blocked_ga = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked_gb = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#mma_g = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[1, 0], [2, 0], [4, 0]]}, instrShape = [16, 16, 32]}>
+#padded_ga = #ttg.padded_shared<[32:+8] {order = [1, 0], shape = [1, 32]}>
+#padded_gb = #ttg.padded_shared<[16:+16] {order = [1, 0], shape = [1, 16]}>
+#padded_gc = #ttg.padded_shared<[16:+8] {order = [1, 0], shape = [16, 16]}>
+#idx_enc = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 8], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @gather_dot_pipeline(
+      %a_ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %b_ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %c_ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %M: i32 {tt.divisibility = 16 : i32},
+      %N: i32 {tt.divisibility = 16 : i32},
+      %K: i32 {tt.divisibility = 16 : i32}) {
+    %c16_i32 = arith.constant 16 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i32 = arith.constant 32 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c31_i32 = arith.constant 31 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #mma_g>
+    %4 = arith.extsi %K : i32 to i64
+    %a_desc = tt.make_tensor_descriptor %a_ptr, [%M, %K], [%4, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<1x32xf16, #padded_ga>
+    %6 = arith.extsi %N : i32 to i64
+    %b_desc = tt.make_tensor_descriptor %b_ptr, [%K, %N], [%6, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<1x16xf16, #padded_gb>
+    %c_desc = tt.make_tensor_descriptor %c_ptr, [%M, %N], [%6, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<16x16xf16, #padded_gc>
+    %a_indices = tt.make_range {start = 0 : i32, end = 16 : i32} : tensor<16xi32, #ttg.slice<{dim = 0, parent = #idx_enc}>>
+    %b_indices = tt.make_range {start = 0 : i32, end = 32 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #idx_enc}>>
+    %9 = arith.addi %K, %c31_i32 : i32
+    %10 = arith.divsi %9, %c32_i32 : i32
+    %accumulator:2 = scf.for %iv = %c0_i32 to %10 step %c1_i32 iter_args(%k_off = %c0_i32, %acc = %cst) -> (i32, tensor<16x16xf32, #mma_g>)  : i32 {
+      %a = tt.descriptor_gather %a_desc[%a_indices, %k_off] : (!tt.tensordesc<1x32xf16, #padded_ga>, tensor<16xi32, #ttg.slice<{dim = 0, parent = #idx_enc}>>, i32) -> tensor<16x32xf16, #blocked_ga>
+      %b = tt.descriptor_gather %b_desc[%b_indices, %c0_i32] : (!tt.tensordesc<1x16xf16, #padded_gb>, tensor<32xi32, #ttg.slice<{dim = 0, parent = #idx_enc}>>, i32) -> tensor<32x16xf16, #blocked_gb>
+      %a_dot = ttg.convert_layout %a : tensor<16x32xf16, #blocked_ga> -> tensor<16x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_g, kWidth = 8}>>
+      %b_dot = ttg.convert_layout %b : tensor<32x16xf16, #blocked_gb> -> tensor<32x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_g, kWidth = 8}>>
+      %d = tt.dot %a_dot, %b_dot, %acc : tensor<16x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_g, kWidth = 8}>> * tensor<32x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_g, kWidth = 8}>> -> tensor<16x16xf32, #mma_g>
+      %next_k = arith.addi %k_off, %c32_i32 : i32
+      scf.yield %next_k, %d : i32, tensor<16x16xf32, #mma_g>
+    }
+    %out = arith.truncf %accumulator#1 : tensor<16x16xf32, #mma_g> to tensor<16x16xf16, #mma_g>
+    %out_blocked = ttg.convert_layout %out : tensor<16x16xf16, #mma_g> -> tensor<16x16xf16, #blocked_gb>
+    tt.descriptor_store %c_desc[%c0_i32, %c0_i32], %out_blocked : !tt.tensordesc<16x16xf16, #padded_gc>, tensor<16x16xf16, #blocked_gb>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func @gather_dot_pipeline
+// Prologue: two async_tdm_gather ops before the loop
+// CHECK: amdg.async_tdm_gather
+// CHECK: ttg.async_commit_group tokens
+// CHECK: amdg.async_tdm_gather
+// CHECK: ttg.async_commit_group tokens
+// Loop body: two more async_tdm_gather ops (pipelined next iteration)
+// CHECK: scf.for
+// CHECK: amdg.async_tdm_gather
+// CHECK: ttg.async_commit_group tokens
+// CHECK: amdg.async_tdm_gather
+// CHECK: ttg.async_commit_group tokens
+// CHECK: }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -611,7 +611,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @wait_barrier
   tt.func public @wait_barrier(%arg0: !tt.tensordesc<32x32xf32, #shared>) {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1x1xi64, #linear>
+    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1x1xi64, #linear{{[0-9]*}}>
 
     // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1xI64(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
@@ -619,7 +619,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 512 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1x64xI64(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1x1xi64, #linear>
+    // CHECK-DAG: %[[BARRIERS:.*]] = tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem : tensor<1x1xi64, #linear{{[0-9]*}}>
 
     // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}T1x1x1xI8(%[[WRITE_TRACKING_GLOB]], %c0_i8
@@ -1326,12 +1326,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     // CHECK: tti.experimental_lock_acquire
-    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
-    // CHECK: tt.call @__triton_consan_copy_write_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
-    // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[THREAD_MASK:.*]] = arith.constant 562958543486978 : i64
-    // CHECK: tt.call @__triton_consan_copy_read_visibility{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]]
+    // CHECK: arith.constant 1 : i32
+    // CHECK: tt.call @__triton_consan_set_active_mask
+    // CHECK: tti.experimental_lock_release
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {
       %c0_i32 = arith.constant 0 : i32
@@ -1395,12 +1392,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: %[[ACTIVE_MASK:.*]] = arith.constant 5 : i32
+    // CHECK: tt.call @__triton_consan_set_active_mask{{.*}}(%[[ACTIVE_MASK]],
     ttg.warp_specialize(%smem, %bar) attributes {actualRegisters = array<i32: 480, 32>, allocation.offset = 512 : i32, requestedRegisters = array<i32: 32>, warpGroupStartIds = array<i32: 4>}
     default {
       // CHECK: tti.experimental_lock_acquire
       // CHECK: tt.call @__triton_consan_set_waiting
-      // CHECK: %[[ACTIVE_MASK:.*]] = arith.constant 5 : i32
-      // CHECK: tt.call @__triton_consan_check_all_active_waiting{{.*}}(%[[ACTIVE_MASK]], {{.*}}, {{.*}}, {{.*}})
+      // CHECK: tt.call @__triton_consan_check_all_active_waiting
       // CHECK: tti.experimental_lock_release
       %c0_i32 = arith.constant 0 : i32
       %true = arith.constant true
@@ -1411,8 +1409,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       // CHECK: partition0
       // CHECK: tti.experimental_lock_acquire
       // CHECK: tt.call @__triton_consan_set_waiting
-      // CHECK: %[[ACTIVE_MASK:.*]] = arith.constant 5 : i32
-      // CHECK: tt.call @__triton_consan_check_all_active_waiting{{.*}}(%[[ACTIVE_MASK]], {{.*}}, {{.*}}, {{.*}})
+      // CHECK: tt.call @__triton_consan_check_all_active_waiting
       // CHECK: tti.experimental_lock_release
       %c0_i32 = arith.constant 0 : i32
       %true = arith.constant true

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -293,3 +293,125 @@ module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num
     tt.return %a: !ttg.memdesc<64x64xf32, #shared, #smem>
   }
 }
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 16], threadsPerWarp = [1, 1, 4, 8, 1], warpsPerCTA = [1, 1, 4, 1, 1], order = [4, 3, 2, 1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1, 1, 16], threadsPerWarp = [1, 4, 8, 1], warpsPerCTA = [1, 4, 1, 1], order = [3, 2, 1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1, 1, 16], threadsPerWarp = [4, 8, 1, 1], warpsPerCTA = [4, 1, 1, 1], order = [3, 1, 0, 2]}>
+#linear0 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [128, 0], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 128], [16, 0], [32, 0], [64, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64]], block = []}>
+#shared0 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+#shared5 = #ttg.shared_linear<{offset = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128], [16, 0], [32, 0], [64, 0]]}, alignment = 128>
+#smem = #ttg.shared_memory
+#tmem0 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
+// CHECK-DAG: #{{.*}} = #ttg.shared_linear<{{.*}}alignment = 128>
+// CHECK-DAG: #{{.*}} = #ttg.shared_linear<{{.*}}alignment = 128>
+module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @swizzle0_operand_views
+  // CHECK-DAG: %[[A_DESC:.*]] = tt.descriptor_load {{.*}} : !tt.tensordesc<128x128xf8E4M3FN> -> tensor<128x128xf8E4M3FN, #{{.*}}>
+  // CHECK-DAG: %[[A_BASE:.*]] = ttg.local_alloc %[[A_DESC]] : (tensor<128x128xf8E4M3FN, #{{.*}}>) -> !ttg.memdesc<128x128xf8E4M3FN, #{{.*}}, #smem{{.*}}>
+  // CHECK-DAG: %[[B_DESC:.*]] = tt.descriptor_load {{.*}} : !tt.tensordesc<1x1x256x8x16xf8E4M3FN> -> tensor<1x1x256x8x16xf8E4M3FN, #{{.*}}>
+  // CHECK-DAG: %[[B_BASE:.*]] = ttg.local_alloc %[[B_DESC]] : (tensor<1x1x256x8x16xf8E4M3FN, #{{.*}}>) -> !ttg.memdesc<1x1x256x8x16xf8E4M3FN, #{{.*}}, #smem{{.*}}>
+  // CHECK-DAG: %[[B_RS0:.*]] = ttg.memdesc_reshape %[[B_BASE]] : !ttg.memdesc<1x1x256x8x16xf8E4M3FN, #{{.*}}, #smem{{.*}}> -> !ttg.memdesc<8x32x8x16xf8E4M3FN, #{{.*}}, #smem{{.*}}>
+  // CHECK-DAG: %[[B_TR0:.*]] = ttg.memdesc_trans %[[B_RS0]] {order = array<i32: 1, 2, 0, 3>} : !ttg.memdesc<8x32x8x16xf8E4M3FN, #{{.*}}, #smem{{.*}}> -> !ttg.memdesc<32x8x8x16xf8E4M3FN, #{{.*}}, #smem{{.*}}>
+  // CHECK-DAG: %[[B_RS1:.*]] = ttg.memdesc_reshape %[[B_TR0]] : !ttg.memdesc<32x8x8x16xf8E4M3FN, #{{.*}}, #smem{{.*}}> -> !ttg.memdesc<256x128xf8E4M3FN, #{{.*}}, #smem{{.*}}>
+  // CHECK-DAG: %[[B_TR1:.*]] = ttg.memdesc_trans %[[B_RS1]] {order = array<i32: 1, 0>} : !ttg.memdesc<256x128xf8E4M3FN, #{{.*}}, #smem{{.*}}> -> !ttg.memdesc<128x256xf8E4M3FN, #{{.*}}, #smem{{.*}}>
+  // CHECK-NOT: tt.reshape
+  // CHECK-NOT: tt.trans
+  // CHECK-NOT: ttg.local_load
+  // CHECK: ttng.tc_gen5_mma %[[A_BASE]], %[[B_TR1]], %arg2, %true, %true
+  tt.func @swizzle0_operand_views(
+      %a_desc: !tt.tensordesc<128x128xf8E4M3FN>,
+      %b_desc: !tt.tensordesc<1x1x256x8x16xf8E4M3FN>,
+      %acc: !ttg.memdesc<128x256xf32, #tmem0, #ttng.tensor_memory>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %a = tt.descriptor_load %a_desc[%c0_i32, %c0_i32] : !tt.tensordesc<128x128xf8E4M3FN> -> tensor<128x128xf8E4M3FN, #blocked0>
+    %b = tt.descriptor_load %b_desc[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<1x1x256x8x16xf8E4M3FN> -> tensor<1x1x256x8x16xf8E4M3FN, #blocked1>
+    %b1 = tt.reshape %b : tensor<1x1x256x8x16xf8E4M3FN, #blocked1> -> tensor<8x32x8x16xf8E4M3FN, #blocked2>
+    %b2 = tt.trans %b1 {order = array<i32: 1, 2, 0, 3>} : tensor<8x32x8x16xf8E4M3FN, #blocked2> -> tensor<32x8x8x16xf8E4M3FN, #blocked3>
+    %b3 = tt.reshape %b2 : tensor<32x8x8x16xf8E4M3FN, #blocked3> -> tensor<256x128xf8E4M3FN, #linear0>
+    %b4 = tt.trans %b3 {order = array<i32: 1, 0>} : tensor<256x128xf8E4M3FN, #linear0> -> tensor<128x256xf8E4M3FN, #linear2>
+    %a_s = ttg.local_alloc %a : (tensor<128x128xf8E4M3FN, #blocked0>) -> !ttg.memdesc<128x128xf8E4M3FN, #shared0, #smem>
+    %b_s = ttg.local_alloc %b4 : (tensor<128x256xf8E4M3FN, #linear2>) -> !ttg.memdesc<128x256xf8E4M3FN, #shared5, #smem>
+    ttng.tc_gen5_mma %a_s, %b_s, %acc, %true, %true : !ttg.memdesc<128x128xf8E4M3FN, #shared0, #smem>, !ttg.memdesc<128x256xf8E4M3FN, #shared5, #smem>, !ttg.memdesc<128x256xf32, #tmem0, #ttng.tensor_memory>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked_a_load = #ttg.blocked<{sizePerThread = [1, 1, 1, 2], threadsPerWarp = [1, 4, 1, 8], warpsPerCTA = [1, 4, 1, 1], order = [3, 2, 1, 0]}>
+#blocked_a_mat = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared_a_nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = true, elementBitWidth = 32}>
+#shared_rhs_linear = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [0, 8], [1, 0], [2, 4], [4, 8], [8, 0], [16, 0], [32, 0]]}, alignment = 512>
+#tmem_dbg = #ttng.tensor_memory_encoding<blockM = 64, blockN = 16, colStride = 1>
+#smem = #ttg.shared_memory
+module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @nvmma_operand_views_not_rewritten
+  // CHECK: %[[DESC:.*]] = tt.descriptor_load %{{.*}}[%{{.*}}] : !tt.tensordesc<1x16x1x16xf32> -> tensor<1x16x1x16xf32, #{{.*}}>
+  // CHECK: %[[RESHAPE:.*]] = tt.reshape %[[DESC]] : tensor<1x16x1x16xf32, #{{.*}}> -> tensor<16x16xf32, #{{.*}}>
+  // CHECK: %[[ALLOC:.*]] = ttg.local_alloc %[[RESHAPE]] : (tensor<16x16xf32, #{{.*}}>) -> !ttg.memdesc<16x16xf32, #{{.*}}, #smem>
+  // CHECK-NOT: ttg.memdesc_reshape
+  // CHECK: ttng.tc_gen5_mma %{{.*}}, %[[ALLOC]], %{{.*}}, %true, %true : !ttg.memdesc<64x16xf32, #{{.*}}, #smem>, !ttg.memdesc<16x16xf32, #{{.*}}, #smem>, !ttg.memdesc<64x16xf32, #{{.*}}, #ttng.tensor_memory>
+  tt.func @nvmma_operand_views_not_rewritten(
+      %lhs: !tt.tensordesc<1x16x1x16xf32>,
+      %rhs: !ttg.memdesc<64x16xf32, #shared_rhs_linear, #smem>,
+      %acc: !ttg.memdesc<64x16xf32, #tmem_dbg, #ttng.tensor_memory>) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %a = tt.descriptor_load %lhs[%c0, %c0, %c0, %c0] : !tt.tensordesc<1x16x1x16xf32> -> tensor<1x16x1x16xf32, #blocked_a_load>
+    %a_rs = tt.reshape %a : tensor<1x16x1x16xf32, #blocked_a_load> -> tensor<16x16xf32, #blocked_a_mat>
+    %a_s = ttg.local_alloc %a_rs : (tensor<16x16xf32, #blocked_a_mat>) -> !ttg.memdesc<16x16xf32, #shared_a_nvmma, #smem>
+    ttng.tc_gen5_mma %rhs, %a_s, %acc, %true, %true : !ttg.memdesc<64x16xf32, #shared_rhs_linear, #smem>, !ttg.memdesc<16x16xf32, #shared_a_nvmma, #smem>, !ttg.memdesc<64x16xf32, #tmem_dbg, #ttng.tensor_memory>
+    tt.return
+  }
+}
+
+// -----
+
+#blockedA_desc = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blockedB_desc = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 16], threadsPerWarp = [1, 1, 4, 8, 1], warpsPerCTA = [1, 1, 4, 1, 1], order = [4, 3, 2, 1, 0]}>
+#blockedB0_desc = #ttg.blocked<{sizePerThread = [1, 1, 1, 16], threadsPerWarp = [1, 4, 8, 1], warpsPerCTA = [1, 4, 1, 1], order = [3, 2, 1, 0]}>
+#blockedB1_desc = #ttg.blocked<{sizePerThread = [1, 1, 1, 16], threadsPerWarp = [4, 8, 1, 1], warpsPerCTA = [4, 1, 1, 1], order = [3, 1, 0, 2]}>
+#linear_desc = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [128, 0], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#mma_desc = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 32]}>
+#sharedA_desc = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8}>
+#sharedB3_desc = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [0, 4], [0, 8], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0], [128, 0], [0, 16], [0, 32], [0, 64]]}, alignment = 128>
+#sharedB4_desc = #ttg.shared_linear<{offset = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128], [16, 0], [32, 0], [64, 0]]}, alignment = 128>
+#smem = #ttg.shared_memory
+// CHECK-DAG: #{{.*}} = #ttg.shared_linear<{{.*}}alignment = 128>
+// CHECK-DAG: #{{.*}} = #ttg.shared_linear<{{.*}}alignment = 128>
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @swizzle0_operand_views_warp_group_dot
+  // CHECK-DAG: %[[B_DESC_LOAD:.*]] = tt.descriptor_load %arg1[%{{.*}}] : !tt.tensordesc<1x1x256x8x16xf8E4M3FN> -> tensor<1x1x256x8x16xf8E4M3FN, #{{.*}}>
+  // CHECK-DAG: %[[B_BASE:.*]] = ttg.local_alloc %[[B_DESC_LOAD]] : (tensor<1x1x256x8x16xf8E4M3FN, {{.*}}>) -> !ttg.memdesc<1x1x256x8x16xf8E4M3FN, #{{.*}}, #smem{{.*}}>
+  // CHECK-DAG: %[[B_RS0:.*]] = ttg.memdesc_reshape %[[B_BASE]] : !ttg.memdesc<1x1x256x8x16xf8E4M3FN, #{{.*}}, #smem{{.*}}> -> !ttg.memdesc<8x32x8x16xf8E4M3FN, {{.*}}, #smem{{.*}}>
+  // CHECK-DAG: %[[B_TR:.*]] = ttg.memdesc_trans %[[B_RS0]] {order = array<i32: 1, 2, 0, 3>} : !ttg.memdesc<8x32x8x16xf8E4M3FN, {{.*}}, #smem{{.*}}> -> !ttg.memdesc<32x8x8x16xf8E4M3FN, {{.*}}, #smem{{.*}}>
+  // CHECK-DAG: %[[B_RS1:.*]] = ttg.memdesc_reshape %[[B_TR]] : !ttg.memdesc<32x8x8x16xf8E4M3FN, {{.*}}, #smem{{.*}}> -> !ttg.memdesc<256x128xf8E4M3FN, {{.*}}, #smem{{.*}}>
+  // CHECK-DAG: %[[B_T:.*]] = ttg.memdesc_trans %[[B_RS1]] {order = array<i32: 1, 0>} : !ttg.memdesc<256x128xf8E4M3FN, {{.*}}, #smem{{.*}}> -> !ttg.memdesc<128x256xf8E4M3FN, #{{.*}}, #smem{{.*}}>
+  // CHECK-NOT: tt.reshape
+  // CHECK-NOT: tt.trans
+  // CHECK: %[[DOT:.*]] = ttng.warp_group_dot %{{.*}}, %[[B_T]], %arg2
+  // CHECK: %[[WAIT:.*]]:3 = ttng.warp_group_dot_wait %[[DOT]], {{.*}}, %[[B_T]] {pendings = 0 : i32}
+  tt.func @swizzle0_operand_views_warp_group_dot(
+      %a_desc: !tt.tensordesc<128x128xf8E4M3FN, #sharedA_desc>,
+      %b_desc: !tt.tensordesc<1x1x256x8x16xf8E4M3FN>,
+      %acc: tensor<128x256xf32, #mma_desc>) -> tensor<128x256xf32, #mma_desc> {
+    %c0 = arith.constant 0 : i32
+    %a = tt.descriptor_load %a_desc[%c0, %c0] : !tt.tensordesc<128x128xf8E4M3FN, #sharedA_desc> -> tensor<128x128xf8E4M3FN, #blockedA_desc>
+    %a_s = ttg.local_alloc %a : (tensor<128x128xf8E4M3FN, #blockedA_desc>) -> !ttg.memdesc<128x128xf8E4M3FN, #sharedA_desc, #smem>
+    %b_cm = tt.descriptor_load %b_desc[%c0, %c0, %c0, %c0, %c0] : !tt.tensordesc<1x1x256x8x16xf8E4M3FN> -> tensor<1x1x256x8x16xf8E4M3FN, #blockedB_desc>
+    %b0 = tt.reshape %b_cm : tensor<1x1x256x8x16xf8E4M3FN, #blockedB_desc> -> tensor<8x32x8x16xf8E4M3FN, #blockedB0_desc>
+    %b1 = tt.trans %b0 {order = array<i32: 1, 2, 0, 3>} : tensor<8x32x8x16xf8E4M3FN, #blockedB0_desc> -> tensor<32x8x8x16xf8E4M3FN, #blockedB1_desc>
+    %b2 = tt.reshape %b1 : tensor<32x8x8x16xf8E4M3FN, #blockedB1_desc> -> tensor<256x128xf8E4M3FN, #linear_desc>
+    %b_s = ttg.local_alloc %b2 : (tensor<256x128xf8E4M3FN, #linear_desc>) -> !ttg.memdesc<256x128xf8E4M3FN, #sharedB3_desc, #smem>
+    %b_t = ttg.memdesc_trans %b_s {order = array<i32: 1, 0>} : !ttg.memdesc<256x128xf8E4M3FN, #sharedB3_desc, #smem> -> !ttg.memdesc<128x256xf8E4M3FN, #sharedB4_desc, #smem>
+    %r = ttng.warp_group_dot %a_s, %b_t, %acc {inputPrecision = 0 : i32, isAsync = true, maxNumImpreciseAcc = 1073741824 : i32}
+      : !ttg.memdesc<128x128xf8E4M3FN, #sharedA_desc, #smem> * !ttg.memdesc<128x256xf8E4M3FN, #sharedB4_desc, #smem> -> tensor<128x256xf32, #mma_desc>
+    %w:3 = ttng.warp_group_dot_wait %r, %a_s, %b_t {pendings = 0 : i32} : tensor<128x256xf32, #mma_desc>, !ttg.memdesc<128x128xf8E4M3FN, #sharedA_desc, #smem>, !ttg.memdesc<128x256xf8E4M3FN, #sharedB4_desc, #smem>
+    tt.return %w#0 : tensor<128x256xf32, #mma_desc>
+  }
+}

--- a/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
+++ b/test/TritonNvidiaGPU/optimize_descriptor_encoding.mlir
@@ -86,6 +86,27 @@ tt.func public @descriptor_kernel_arg(%arg0: !tt.tensordesc<64x64xf16>, %arg1: i
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
+// CHECK-DAG: #[[BLOCKED_16x128:.*]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK-DAG: #[[NVMMA_128:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+// CHECK-DAG: #[[NVMMA_TRANSPOSED_32:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
+tt.func public @descriptor_ignores_transposed_local_alloc(%arg0: !tt.tensordesc<16x128xf16>) {
+  // CHECK: %arg0: !tt.tensordesc<16x128xf16, #[[NVMMA_128]]>
+  // CHECK: %[[LOAD:.*]] = tt.descriptor_load %arg0{{.*}} : !tt.tensordesc<16x128xf16, #[[NVMMA_128]]> -> tensor<16x128xf16, #[[BLOCKED_16x128]]>
+  // CHECK: ttg.local_alloc %[[LOAD]] : (tensor<16x128xf16, #[[BLOCKED_16x128]]>) -> !ttg.memdesc<16x128xf16, #[[NVMMA_TRANSPOSED_32]], #smem>
+  %c0 = arith.constant 0 : i32
+  %0 = tt.descriptor_load %arg0[%c0, %c0] : !tt.tensordesc<16x128xf16> -> tensor<16x128xf16, #blocked>
+  %1 = ttg.local_alloc %0 : (tensor<16x128xf16, #blocked>) -> !ttg.memdesc<16x128xf16, #shared, #smem>
+  tt.return
+}
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 8}>
@@ -218,4 +239,47 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
     } : (!ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, !tt.tensordesc<128x128xf16>, !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable>) -> ()
     tt.return
   }
+}
+
+// -----
+
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 16], threadsPerWarp = [1, 1, 4, 8, 1], warpsPerCTA = [1, 1, 4, 1, 1], order = [4, 3, 2, 1, 0]}>
+#shared_linear_base = #ttg.shared_linear<{offset = [[0, 0, 0, 0, 1], [0, 0, 0, 0, 2], [0, 0, 0, 0, 4], [0, 0, 0, 0, 8], [0, 0, 0, 1, 0], [0, 0, 0, 2, 0], [0, 0, 0, 4, 0], [0, 0, 1, 0, 0], [0, 0, 2, 0, 0], [0, 0, 4, 0, 0], [0, 0, 8, 0, 0], [0, 0, 16, 0, 0], [0, 0, 32, 0, 0], [0, 0, 64, 0, 0], [0, 0, 128, 0, 0]]}, alignment = 128>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[NVMMA_0:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8, rank = 5}>
+// CHECK-DAG: #[[BLOCKED5D:.*]] = #ttg.blocked<{sizePerThread = [1, 1, 1, 1, 16], threadsPerWarp = [1, 1, 4, 8, 1], warpsPerCTA = [1, 1, 4, 1, 1], order = [4, 3, 2, 1, 0]}>
+// CHECK-DAG: #[[SL_BASE:.*]] = #ttg.shared_linear<{{.*}}alignment = 128>
+tt.func public @descriptor_arg_from_shared_linear_use(%b_desc: !tt.tensordesc<1x1x256x8x16xf8E4M3FN>) {
+  // CHECK: %arg0: !tt.tensordesc<1x1x256x8x16xf8E4M3FN, #[[NVMMA_0]]>
+  // CHECK: %[[LOAD:.*]] = tt.descriptor_load %arg0
+  // CHECK-SAME: : !tt.tensordesc<1x1x256x8x16xf8E4M3FN, #[[NVMMA_0]]> -> tensor<1x1x256x8x16xf8E4M3FN, #[[BLOCKED5D]]>
+  // CHECK: ttg.local_alloc %[[LOAD]] : (tensor<1x1x256x8x16xf8E4M3FN, #[[BLOCKED5D]]>) -> !ttg.memdesc<1x1x256x8x16xf8E4M3FN, #[[SL_BASE]], #smem>
+  %c0 = arith.constant 0 : i32
+  %b = tt.descriptor_load %b_desc[%c0, %c0, %c0, %c0, %c0] : !tt.tensordesc<1x1x256x8x16xf8E4M3FN> -> tensor<1x1x256x8x16xf8E4M3FN, #blocked2>
+  %b_s = ttg.local_alloc %b : (tensor<1x1x256x8x16xf8E4M3FN, #blocked2>) -> !ttg.memdesc<1x1x256x8x16xf8E4M3FN, #shared_linear_base, #smem>
+  tt.return
+}
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1, 1, 2], threadsPerWarp = [1, 4, 1, 8], warpsPerCTA = [1, 4, 1, 1], order = [3, 2, 1, 0]}>
+#shared_linear = #ttg.shared_linear<{offset = [[0, 1, 0, 0], [0, 2, 0, 0], [0, 4, 0, 0], [0, 8, 0, 0], [0, 0, 0, 1], [0, 4, 0, 2], [0, 8, 0, 4], [0, 0, 0, 8]]}, alignment = 512>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[BLOCKED4D:.*]] = #ttg.blocked<{sizePerThread = [1, 1, 1, 2], threadsPerWarp = [1, 4, 1, 8], warpsPerCTA = [1, 4, 1, 1], order = [3, 2, 1, 0]}>
+// CHECK-DAG: #[[NVMMA_64_4D:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 32, rank = 4}>
+// CHECK-DAG: #[[SL_4D:.*]] = #ttg.shared_linear<{{.*}}alignment = 512>
+tt.func public @descriptor_arg_from_4d_shared_linear_use(%arg0: !tt.tensordesc<1x16x1x16xf32>) {
+  // CHECK: %arg0: !tt.tensordesc<1x16x1x16xf32, #[[NVMMA_64_4D]]>
+  // CHECK: %[[LOAD:.*]] = tt.descriptor_load %arg0[%{{.*}}] : !tt.tensordesc<1x16x1x16xf32, #[[NVMMA_64_4D]]> -> tensor<1x16x1x16xf32, #[[BLOCKED4D]]>
+  // CHECK: ttg.local_alloc %[[LOAD]] : (tensor<1x16x1x16xf32, #[[BLOCKED4D]]>) -> !ttg.memdesc<1x16x1x16xf32, #[[SL_4D]], #smem>
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tt.descriptor_load %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] : !tt.tensordesc<1x16x1x16xf32> -> tensor<1x16x1x16xf32, #blocked>
+  %1 = ttg.local_alloc %0 : (tensor<1x16x1x16xf32, #blocked>) -> !ttg.memdesc<1x16x1x16xf32, #shared_linear, #smem>
+  tt.return
+}
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -39,43 +39,82 @@ struct AsyncCopyChainOps {
   ttg::LocalLoadOp maybeLocalLoadOp;
 };
 
-struct TDMCopyChainOps {
-  triton::amdgpu::AsyncTDMCopyGlobalToLocalOp copyOp;
+// Common shape for an async TDM chain (copy or gather). The first op (copy or
+// gather) is type-erased because every consumer below only needs Operation *.
+struct TDMChainOps {
+  Operation *tdmOp;
   ttg::AsyncCommitGroupOp commitOp;
   triton::amdgpu::AsyncTDMWait waitOp;
   ttg::LocalLoadOp maybeLocalLoadOp;
 };
 
 using StreamOpVariant =
-    std::variant<StreamCopyChainOps, AsyncCopyChainOps, TDMCopyChainOps>;
+    std::variant<StreamCopyChainOps, AsyncCopyChainOps, TDMChainOps>;
 using LoadToStreamOpMap = llvm::MapVector<Operation *, StreamOpVariant>;
 
-namespace {
-
-TDMCopyChainOps createTDMAsyncCopy(tt::DescriptorLoadOp loadOp, Value alloc,
-                                   Value extractIdx) {
-  OpBuilder builder(loadOp);
-  Location loc = loadOp.getLoc();
+// Shared skeleton for building a TDM chain:
+//   <buffer view> = createSingleBufferView(...)
+//   <tdmOp>       = buildTDMOp(builder, view, pred)   <- caller-supplied
+//   <commitOp>    = ttg::AsyncCommitGroupOp(tdmOp)
+//   <waitOp>      = amdgpu::AsyncTDMWait(commitOp)
+//   replace uses of original load with a local_load after waitOp
+TDMChainOps createTDMAsync(
+    Operation *origLoad, Value alloc, Value extractIdx,
+    function_ref<Operation *(OpBuilder &, Location, Value, Value)> buildTDMOp) {
+  OpBuilder builder(origLoad);
+  Location loc = origLoad->getLoc();
 
   Value pred = arith::ConstantIntOp::create(builder, loc, 1, 32);
 
-  // Extract local subview from shared allocation
   auto viewLoad = triton::createSingleBufferView(builder, alloc, extractIdx)
                       .getDefiningOp<ttg::MemDescIndexOp>();
 
-  auto copyOp = triton::amdgpu::AsyncTDMCopyGlobalToLocalOp::create(
-      builder, loc, loadOp.getDesc(), loadOp.getIndices(), viewLoad, pred);
+  Operation *tdmOp = buildTDMOp(builder, loc, viewLoad, pred);
 
   auto commitOp =
-      ttg::AsyncCommitGroupOp::create(builder, loc, copyOp->getResult(0));
+      ttg::AsyncCommitGroupOp::create(builder, loc, tdmOp->getResult(0));
   auto waitOp = triton::amdgpu::AsyncTDMWait::create(builder, loc,
                                                      commitOp->getResult(0), 0);
 
   auto maybeSharedLoad = tt::replaceUsesWithLocalLoad(
-      builder, loadOp->getResult(0), viewLoad, waitOp);
+      builder, origLoad->getResult(0), viewLoad, waitOp);
 
-  return {copyOp, commitOp, waitOp, maybeSharedLoad};
+  return {tdmOp, commitOp, waitOp, maybeSharedLoad};
 }
+
+TDMChainOps createTDMAsyncCopy(tt::DescriptorLoadOp loadOp, Value alloc,
+                               Value extractIdx) {
+  return createTDMAsync(
+      loadOp, alloc, extractIdx,
+      [&](OpBuilder &builder, Location loc, Value view, Value pred) {
+        return triton::amdgpu::AsyncTDMCopyGlobalToLocalOp::create(
+            builder, loc, loadOp.getDesc(), loadOp.getIndices(), view, pred);
+      });
+}
+
+TDMChainOps createTDMAsyncGather(tt::DescriptorGatherOp gatherOp, Value alloc,
+                                 Value extractIdx) {
+  return createTDMAsync(
+      gatherOp, alloc, extractIdx,
+      [&](OpBuilder &builder, Location loc, Value view, Value pred) {
+        // Convert to the TDM index layout for better gather performance;
+        // insert a layout convert if the indices don't already have it.
+        auto indices = gatherOp.getXOffsets();
+        auto indicesType = cast<RankedTensorType>(indices.getType());
+        auto idxEnc = getTDMGatherScatterIndexEncoding(gatherOp, indicesType);
+        if (indicesType.getEncoding() != idxEnc) {
+          auto newIdxType = RankedTensorType::get(
+              indicesType.getShape(), indicesType.getElementType(), idxEnc);
+          indices =
+              ttg::ConvertLayoutOp::create(builder, loc, newIdxType, indices);
+        }
+        return triton::amdgpu::AsyncTDMGatherOp::create(
+            builder, loc, gatherOp.getDesc(), indices, gatherOp.getYOffset(),
+            view, pred);
+      });
+}
+
+namespace {
 
 bool canBeConvertedToAsyncLoad(unsigned numBuffers, tt::LoadOp loadOp,
                                ttg::SharedEncodingTrait sharedEnc,
@@ -389,17 +428,15 @@ createStreamOps(const LoadToInfoMap &loadToInfo, scf::ForOp &forOp,
   appendToForOpYield(forOp, {extractIdx});
 
   LoadToStreamOpMap loadToStreamOp;
-  for (auto &[l, info] : loadToInfo) {
+  for (auto &[op, info] : loadToInfo) {
     if (!info.sharedEncoding)
       continue;
 
-    auto loadOp = dyn_cast<tt::LoadOp>(l);
-    auto descLoadOp = dyn_cast<tt::DescriptorLoadOp>(l);
-    if (!loadOp && !descLoadOp)
+    auto loadOp = dyn_cast<tt::LoadOp>(op);
+    auto descLoadOp = dyn_cast<tt::DescriptorLoadOp>(op);
+    auto gatherOp = dyn_cast<tt::DescriptorGatherOp>(op);
+    if (!loadOp && !descLoadOp && !gatherOp)
       continue;
-
-    Operation *op =
-        (loadOp ? loadOp.getOperation() : descLoadOp.getOperation());
 
     // Create an allocation that can hold distance number of loadOp shapes.
     auto ty = cast<RankedTensorType>(op->getResultTypes()[0]);
@@ -411,8 +448,11 @@ createStreamOps(const LoadToInfoMap &loadToInfo, scf::ForOp &forOp,
 
     // Replace the old load with multi-buffered loads
     if (descLoadOp) {
-      loadToStreamOp[descLoadOp] =
-          createTDMAsyncCopy(descLoadOp, alloc, extractIdx);
+      loadToStreamOp[op] = createTDMAsyncCopy(descLoadOp, alloc, extractIdx);
+      continue;
+    }
+    if (gatherOp) {
+      loadToStreamOp[op] = createTDMAsyncGather(gatherOp, alloc, extractIdx);
       continue;
     }
 
@@ -583,14 +623,14 @@ LogicalResult initSchedule(int maxDist, Stages &stages, int numStages,
   return success();
 }
 
-void scheduleTDMCopy(const TDMCopyChainOps &asyncOps,
-                     tt::DescriptorLoadOp loadOp, tt::CoarseSchedule &schedule,
-                     const Stages &stages, const Clusters &clusters) {
-  auto [copyOp, commitOp, waitOp, maybeLocalLoadOp] = asyncOps;
-  auto [loadStage, loadCluster] = schedule[loadOp];
-  schedule.insert(copyOp, loadStage, loadCluster);
-  // Place ttg.async_commit_group op following AsyncCopyGlobalToLocal so the
-  // later UpdateAsyncWaitCount pass can deduce better waitcnts
+void scheduleTDMOps(Operation *tdmOp, Operation *commitOp, Operation *waitOp,
+                    ttg::LocalLoadOp maybeLocalLoadOp, Operation *origLoadOp,
+                    tt::CoarseSchedule &schedule, const Stages &stages,
+                    const Clusters &clusters) {
+  auto [loadStage, loadCluster] = schedule[origLoadOp];
+  schedule.insert(tdmOp, loadStage, loadCluster);
+  // Place ttg.async_commit_group op in the same stage/cluster as the TDM op so
+  // the later UpdateAsyncWaitCount pass can deduce better waitcnts.
   schedule.insert(commitOp, loadStage, loadCluster);
   // If the LocalLoads are scheduled to a later stage than AsyncCopy we need to
   // place the AsyncCopy prefetches after the AsyncWaits which create a barrier
@@ -654,16 +694,15 @@ void scheduleStreamOps(const LoadToStreamOpMap &loadToStreamOp,
                        tt::CoarseSchedule &schedule, const Stages &stages,
                        const Clusters &clusters) {
   for (auto [l, streamOps] : loadToStreamOp) {
-    auto loadOp = dyn_cast<tt::LoadOp>(l);
-    auto descLoadOp = dyn_cast<tt::DescriptorLoadOp>(l);
-    if (!loadOp && !descLoadOp)
-      continue;
-
-    if (auto asyncOps = std::get_if<TDMCopyChainOps>(&streamOps)) {
-      scheduleTDMCopy(*asyncOps, descLoadOp, schedule, stages, clusters);
+    if (auto asyncOps = std::get_if<TDMChainOps>(&streamOps)) {
+      auto [tdmOp, commitOp, waitOp, localLoad] = *asyncOps;
+      scheduleTDMOps(tdmOp, commitOp, waitOp, localLoad, l, schedule, stages,
+                     clusters);
     } else if (auto asyncOps = std::get_if<AsyncCopyChainOps>(&streamOps)) {
+      auto loadOp = cast<tt::LoadOp>(l);
       scheduleAsyncCopy(*asyncOps, loadOp, schedule, stages, clusters);
     } else if (auto sOps = std::get_if<StreamCopyChainOps>(&streamOps)) {
+      auto loadOp = cast<tt::LoadOp>(l);
       scheduleStreamCopy(*sOps, loadOp, schedule, stages, clusters);
     }
   }
@@ -696,7 +735,7 @@ void updateSchedule(scf::ForOp &forOp, const LoadToInfoMap &loadToInfo,
   dumpScheduleDebug(schedule, DEBUG_TYPE, "Coarse schedule stream ops:");
 
   for (auto [l, _] : loadToInfo) {
-    if (isa<tt::DescriptorLoadOp>(l)) {
+    if (isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp>(l)) {
       schedule.erase(l);
       l->erase();
     }
@@ -864,10 +903,12 @@ static void lowerLoop(scf::ForOp forOp,
       load->removeAttr(AttrBypassLDS);
       loadToInfo[load] = {nullptr, distance, use};
     } else {
-      if (auto descLoad = dyn_cast<tt::DescriptorLoadOp>(load)) {
+      if (auto descLoadLike =
+              dyn_cast<tt::DescriptorLoadLikeOpInterface>(load)) {
         hasTDMLoad = true;
-        auto paddedEncoding = getEncodingFromDescriptor(
-            descLoad, descLoad.getResult().getType(), descLoad.getDesc());
+        auto resultType = cast<RankedTensorType>(load->getResult(0).getType());
+        auto paddedEncoding =
+            getEncodingFromDescriptor(load, resultType, descLoadLike.getDesc());
         LoadInfo ldInfo;
         ldInfo.sharedEncoding = paddedEncoding;
         ldInfo.distToUse = distance;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
@@ -570,7 +570,7 @@ void pipelineLoop(scf::ForOp forOp, int numStages) {
     loadInfo.distToUse = distance;
     loadInfo.use = use;
 
-    auto useTDM = isa<tt::DescriptorLoadOp>(load);
+    auto useTDM = isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp>(load);
     if (useTDM) {
       loadToInfo[load] = loadInfo;
       continue;


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/10192

Upstream commit message:
```
> [CONSAN] Fix deadlock detection in WS code (#10192)

> Before, we statically looked at the mask within a WS code to figure out
> whether there was a deadlock. This is problematic because perhaps one
> partition finishes early (rather common when using CLC) and it doesn't
> deadlock, but the others deadlock.

> Here we store a mask per CTA globally. The lifetime of this mask is as
> follows:

> - initialized to 1 outside warp specialization
> - set to the live non-empty partition mask on ttg.warp_specialize
> - on warp_yield / warp_return, clear that region’s bit and clamp with
> max(mask, 1)
>    so that the last exit does not think there is a deadlock
> - deadlock checks always read the per-CTA runtime mask
> - On kernel exit, a CTA puts their mask as 0 signalling that they have
> finished the kernel

> We skip the empty partitions (i.e. the padded partitions) as a small
> optimisation, but if we didn't everything would go through the same.
```

***Do not remove the following line from this commit***
Reactor Backport Revision: 19ccc01d23da4fc5245cd1516219d6842071d037
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 10192
```

Reviewed By: warrendeng

Differential Revision: D114407531


