### PR TITLE
[triton][beta] [Cherry-pick] '[AMD][GLUON] Expose amdg.extract_slice (#10557)' (#2635)

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1133,6 +1133,13 @@ void init_gluon_ir(py::module &&m) {
              return self.create<ttag::ScaledUpcastFp8Op>(resultType, input,
                                                          scale);
            })
+      .def("create_extract_slice",
+           [](GluonOpBuilder &self, Type resultType, Value source,
+              std::vector<int64_t> &offsets) -> Value {
+             auto offsetsAttr = self.getBuilder().getDenseI64ArrayAttr(offsets);
+             return self.create<ttag::ExtractSliceOp>(resultType, source,
+                                                      offsetsAttr);
+           })
       .def("create_make_tensor_descriptor",
            [](TritonOpBuilder &self, Type resultTy, Value &base,
               std::vector<Value> &shape, std::vector<Value> &strides,

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -3336,6 +3336,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     )
 
 
+@gluon.jit
+def slice_kernel():
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 64], [4, 1], [1, 0])
+    x = ttgl.full([128, 128], 1.0, ttgl.float32, layout=layout)
+    s = ttgl.amd.slice(x, [64, 128], [64, 0])
+    ttgl.static_assert(s.type.shape == [64, 128])
+    ttgl.static_assert(s.type.layout == layout)
+
+
+def test_amd_slice():
+    module = run_parser(slice_kernel, target=HIP_TARGET_CDNA3)
+    expecttest.assert_expected_inline(
+        anonymize_ir(module.str_nodebug()), """\
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @slice_kernel() attributes {noinline = false} {
+    %cst = arith.constant 1.000000e+00 : f32
+    %cst_0 = arith.constant dense<1.000000e+00> : tensor<128x128xf32, #blocked>
+    %0 = amdg.extract_slice %cst_0 [64, 0] : tensor<128x128xf32, #blocked> to tensor<64x128xf32, #blocked>
+    tt.return
+  }
+}
+""")
+
+
 @pytest.mark.parametrize("target", [HIP_TARGET_CDNA4])
 def test_amd_mfma_scaled(target):
 

--- a/python/triton/experimental/gluon/language/amd/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/__init__.py
@@ -3,6 +3,9 @@ from ._layouts import AMDMFMALayout, AMDWMMALayout
 from . import cdna3, cdna4
 from . import rdna3, rdna4
 from . import gfx1250
+from .slice import slice
 from .warp_pipeline import warp_pipeline_stage
 
-__all__ = ["AMDMFMALayout", "AMDWMMALayout", "cdna3", "cdna4", "rdna3", "rdna4", "gfx1250", "warp_pipeline_stage"]
+__all__ = [
+    "AMDMFMALayout", "AMDWMMALayout", "cdna3", "cdna4", "rdna3", "rdna4", "gfx1250", "warp_pipeline_stage", "slice"
+]

--- a/python/triton/experimental/gluon/language/amd/slice.py
+++ b/python/triton/experimental/gluon/language/amd/slice.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from triton.experimental.gluon.language import _core as ttgl
+from triton.experimental.gluon.language._semantic import _check
+
+from .._core import builtin, _unwrap_if_constexpr
+
+__all__ = ["slice"]
+
+
+@builtin
+def slice(source, shape, offsets, _semantic=None):
+    """Extract a register only slice of a tensor.
+
+    Returns a view of ``source`` of the requested ``shape`` starting at
+    ``offsets``, keeping the source's distributed layout. Because the layout is
+    preserved, the slice introduces no cross-thread data movement; the slice
+    extent and offsets must align to the source layout's CTA tiling.
+
+    Args:
+        source (tensor): The tensor to slice. Must have a distributed layout.
+        shape (List[int]): Shape of the extracted slice (same rank as source).
+        offsets (List[int]): Per-dimension start offsets into ``source``.
+    """
+    _check(isinstance(source.type, ttgl.distributed_type),
+           lambda: f"Expected source to have a distributed_type but got {source.type}")
+
+    shape = [_unwrap_if_constexpr(s) for s in shape]
+    offsets = [_unwrap_if_constexpr(o) for o in offsets]
+
+    rank = len(source.type.shape)
+    _check(len(shape) == rank, lambda: f"slice: shape must have rank {rank}, got {len(shape)}")
+    _check(len(offsets) == rank, lambda: f"slice: offsets must have rank {rank}, got {len(offsets)}")
+
+    src_shape = source.type.shape
+    for i in range(rank):
+        _check(shape[i] <= src_shape[i], lambda: f"slice: result shape {shape} cannot exceed source shape {src_shape}")
+        _check(offsets[i] + shape[i] <= src_shape[i],
+               lambda: f"slice: offset {offsets} + shape {shape} exceeds source shape {src_shape}")
+
+    ret_ty = ttgl.distributed_type(source.dtype, shape, source.type.layout)
+    handle = _semantic.builder.create_extract_slice(ret_ty.to_ir(_semantic.builder), source.handle, offsets)
+    return ttgl.tensor(handle, ret_ty)


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/10557

Upstream commit message:
```
> [AMD][GLUON] Expose amdg.extract_slice (#10557)

> Support extract slice in Gluon. This can be useful for experimenting
> with different pipelines as it's more flexible than split.
```

***Do not remove the following line from this commit***
Reactor Backport Revision: a94ed3a497d72681e4667b1919d5855aa359cc8f
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 10557
```

Reviewed By: warrendeng

Differential Revision: D114451569


