### PR TITLE
[triton][beta] [Cherry-pick] '[AMD][Gluon][Test] Fix test bug in MXFP GEMM sliceK (#10550)' (#2636)

### DIFF
--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1133,6 +1133,13 @@ void init_gluon_ir(py::module &&m) {
              return self.create<ttag::ScaledUpcastFp8Op>(resultType, input,
                                                          scale);
            })
+      .def("create_extract_slice",
+           [](GluonOpBuilder &self, Type resultType, Value source,
+              std::vector<int64_t> &offsets) -> Value {
+             auto offsetsAttr = self.getBuilder().getDenseI64ArrayAttr(offsets);
+             return self.create<ttag::ExtractSliceOp>(resultType, source,
+                                                      offsetsAttr);
+           })
       .def("create_make_tensor_descriptor",
            [](TritonOpBuilder &self, Type resultTy, Value &base,
               std::vector<Value> &shape, std::vector<Value> &strides,

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -3336,6 +3336,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     )
 
 
+@gluon.jit
+def slice_kernel():
+    layout: ttgl.constexpr = ttgl.BlockedLayout([1, 1], [1, 64], [4, 1], [1, 0])
+    x = ttgl.full([128, 128], 1.0, ttgl.float32, layout=layout)
+    s = ttgl.amd.slice(x, [64, 128], [64, 0])
+    ttgl.static_assert(s.type.shape == [64, 128])
+    ttgl.static_assert(s.type.layout == layout)
+
+
+def test_amd_slice():
+    module = run_parser(slice_kernel, target=HIP_TARGET_CDNA3)
+    expecttest.assert_expected_inline(
+        anonymize_ir(module.str_nodebug()), """\
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "...", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @slice_kernel() attributes {noinline = false} {
+    %cst = arith.constant 1.000000e+00 : f32
+    %cst_0 = arith.constant dense<1.000000e+00> : tensor<128x128xf32, #blocked>
+    %0 = amdg.extract_slice %cst_0 [64, 0] : tensor<128x128xf32, #blocked> to tensor<64x128xf32, #blocked>
+    tt.return
+  }
+}
+""")
+
+
 @pytest.mark.parametrize("target", [HIP_TARGET_CDNA4])
 def test_amd_mfma_scaled(target):
 

--- a/python/triton/experimental/gluon/language/amd/__init__.py
+++ b/python/triton/experimental/gluon/language/amd/__init__.py
@@ -3,6 +3,9 @@ from ._layouts import AMDMFMALayout, AMDWMMALayout
 from . import cdna3, cdna4
 from . import rdna3, rdna4
 from . import gfx1250
+from .slice import slice
 from .warp_pipeline import warp_pipeline_stage
 
-__all__ = ["AMDMFMALayout", "AMDWMMALayout", "cdna3", "cdna4", "rdna3", "rdna4", "gfx1250", "warp_pipeline_stage"]
+__all__ = [
+    "AMDMFMALayout", "AMDWMMALayout", "cdna3", "cdna4", "rdna3", "rdna4", "gfx1250", "warp_pipeline_stage", "slice"
+]

--- a/python/triton/experimental/gluon/language/amd/slice.py
+++ b/python/triton/experimental/gluon/language/amd/slice.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from triton.experimental.gluon.language import _core as ttgl
+from triton.experimental.gluon.language._semantic import _check
+
+from .._core import builtin, _unwrap_if_constexpr
+
+__all__ = ["slice"]
+
+
+@builtin
+def slice(source, shape, offsets, _semantic=None):
+    """Extract a register only slice of a tensor.
+
+    Returns a view of ``source`` of the requested ``shape`` starting at
+    ``offsets``, keeping the source's distributed layout. Because the layout is
+    preserved, the slice introduces no cross-thread data movement; the slice
+    extent and offsets must align to the source layout's CTA tiling.
+
+    Args:
+        source (tensor): The tensor to slice. Must have a distributed layout.
+        shape (List[int]): Shape of the extracted slice (same rank as source).
+        offsets (List[int]): Per-dimension start offsets into ``source``.
+    """
+    _check(isinstance(source.type, ttgl.distributed_type),
+           lambda: f"Expected source to have a distributed_type but got {source.type}")
+
+    shape = [_unwrap_if_constexpr(s) for s in shape]
+    offsets = [_unwrap_if_constexpr(o) for o in offsets]
+
+    rank = len(source.type.shape)
+    _check(len(shape) == rank, lambda: f"slice: shape must have rank {rank}, got {len(shape)}")
+    _check(len(offsets) == rank, lambda: f"slice: offsets must have rank {rank}, got {len(offsets)}")
+
+    src_shape = source.type.shape
+    for i in range(rank):
+        _check(shape[i] <= src_shape[i], lambda: f"slice: result shape {shape} cannot exceed source shape {src_shape}")
+        _check(offsets[i] + shape[i] <= src_shape[i],
+               lambda: f"slice: offset {offsets} + shape {shape} exceeds source shape {src_shape}")
+
+    ret_ty = ttgl.distributed_type(source.dtype, shape, source.type.layout)
+    handle = _semantic.builder.create_extract_slice(ret_ty.to_ir(_semantic.builder), source.handle, offsets)
+    return ttgl.tensor(handle, ret_ty)

--- a/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
@@ -562,20 +562,19 @@ class MXFPGEMMSliceKProgram:
         load_idx = 0
         wmma_idx = 0
 
-        # prologue
-        # iter 0
-        load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer, self.b_scale_buffer)
+        # Prologue: keep NUM_BUFFERS K-tiles in flight, then wait until only the
+        # future tiles remain outstanding before consuming the oldest one.
+        for _ in gl.static_range(cfg.NUM_BUFFERS):
+            load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer,
+                                        self.b_scale_buffer)
 
-        # iter 1
-        load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer, self.b_scale_buffer)
-        # iter 0
         gl.amd.gfx1250.tdm.async_wait((cfg.NUM_BUFFERS - 1) * cfg.NUM_LOADS_IN_BATCH)
         a0, b0, scale_a0, scale_b0 = self.issue_subtile_local_loads(wmma_idx, 0, self.a_buffer, self.b_buffer,
                                                                     self.a_scale_buffer, self.b_scale_buffer)
 
         accumulator = gl.zeros((cfg.BLOCK_M, cfg.BLOCK_N), dtype=gl.float32, layout=self.cfg.acc_layout)
-        loop_ub = gl.cdiv(K, cfg.BLOCK_K) - 1
-        for _ in range(0, loop_ub - 1):
+        loop_ub = gl.cdiv(K, cfg.BLOCK_K) - cfg.NUM_BUFFERS
+        for _ in range(0, loop_ub):
             # iter i
             accumulator = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b0, scale_b0, cfg.DTYPE_B, accumulator)
 
@@ -584,9 +583,9 @@ class MXFPGEMMSliceKProgram:
                                                                         self.a_scale_buffer, self.b_scale_buffer)
             wmma_idx += 1
 
-            # iter i + 2
+            # iter i + NUM_BUFFERS
             load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer,
-                                        self.b_scale_buffer, phase=wmma_idx + cfg.NUM_BUFFERS - 2)
+                                        self.b_scale_buffer, phase=wmma_idx + cfg.NUM_BUFFERS - 1)
 
             # iter i
             accumulator = gl.amd.gfx1250.wmma_scaled(a1, scale_a1, cfg.DTYPE_A, b1, scale_b1, cfg.DTYPE_B, accumulator)
@@ -597,29 +596,18 @@ class MXFPGEMMSliceKProgram:
                                                                         self.a_scale_buffer, self.b_scale_buffer)
 
         # epilogue
-        # iter end - 2
-        accumulator = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b0, scale_b0, cfg.DTYPE_B, accumulator)
+        for i in gl.static_range(cfg.NUM_BUFFERS):
+            if i > 0:
+                gl.amd.gfx1250.tdm.async_wait((cfg.NUM_BUFFERS - 1 - i) * cfg.NUM_LOADS_IN_BATCH)
+                a0, b0, scale_a0, scale_b0 = self.issue_subtile_local_loads(wmma_idx, 0, self.a_buffer, self.b_buffer,
+                                                                            self.a_scale_buffer, self.b_scale_buffer)
 
-        # iter end - 2
-        a1, b1, scale_a1, scale_b1 = self.issue_subtile_local_loads(wmma_idx, 1, self.a_buffer, self.b_buffer,
-                                                                    self.a_scale_buffer, self.b_scale_buffer)
-        wmma_idx += 1
+            accumulator = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b0, scale_b0, cfg.DTYPE_B, accumulator)
 
-        # iter end - 2
-        accumulator = gl.amd.gfx1250.wmma_scaled(a1, scale_a1, cfg.DTYPE_A, b1, scale_b1, cfg.DTYPE_B, accumulator)
-        # iter end - 1
-        gl.amd.gfx1250.tdm.async_wait(0)
-        a0, b0, scale_a0, scale_b0 = self.issue_subtile_local_loads(wmma_idx, 0, self.a_buffer, self.b_buffer,
-                                                                    self.a_scale_buffer, self.b_scale_buffer)
-        # iter end - 1
-        accumulator = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b0, scale_b0, cfg.DTYPE_B, accumulator)
-
-        # iter end - 1
-        a1, b1, scale_a1, scale_b1 = self.issue_subtile_local_loads(wmma_idx, 1, self.a_buffer, self.b_buffer,
-                                                                    self.a_scale_buffer, self.b_scale_buffer)
-        wmma_idx += 1
-
-        accumulator = gl.amd.gfx1250.wmma_scaled(a1, scale_a1, cfg.DTYPE_A, b1, scale_b1, cfg.DTYPE_B, accumulator)
+            a1, b1, scale_a1, scale_b1 = self.issue_subtile_local_loads(wmma_idx, 1, self.a_buffer, self.b_buffer,
+                                                                        self.a_scale_buffer, self.b_scale_buffer)
+            wmma_idx += 1
+            accumulator = gl.amd.gfx1250.wmma_scaled(a1, scale_a1, cfg.DTYPE_A, b1, scale_b1, cfg.DTYPE_B, accumulator)
 
         apply_activation_and_store(self.cfg, accumulator, self.c_ptr, self.c_offs, self.c_mask)
 
@@ -1247,8 +1235,10 @@ def test_runtime_mxgemm_tdm_pipelined(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_
         if ASYNC_COPY_SCALE:
             pytest.skip('Only use ASYNC_COPY_SCALE in sliceNK schedule')
 
-    if SCHEDULE != 'baseline' and NUM_BUFFERS != 2:
-        pytest.skip('Only test 2 buffers in sliceK and sliceNK schedules')
+    if SCHEDULE == 'sliceNK' and NUM_BUFFERS != 2:
+        pytest.skip('Only test 2 buffers in sliceNK schedule')
+    if SCHEDULE == 'sliceK' and NUM_BUFFERS not in (2, 3):
+        pytest.skip('Only test 2 or 3 buffers in sliceK schedule')
 
     if ASYNC_COPY_SCALE and (M < BLOCK_M or N < BLOCK_N or K < BLOCK_K):
         pytest.skip('NYI: Skipping small problem sizes for async copy scale')
@@ -1340,6 +1330,12 @@ def test_runtime_mxgemm_tdm_pipelined(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_
     else:
         torch.testing.assert_close(c_d.cpu(), c_ref.cpu(), rtol=1e-5, atol=1e-8)
     print('✅Pass')
+
+
+@pytest.mark.parametrize("NUM_BUFFERS", [2, 3])
+def test_runtime_mxgemm_tdm_slicek_three_k_tiles(NUM_BUFFERS):
+    test_runtime_mxgemm_tdm_pipelined('float8_e4m3', 'float8_e5m2', 256, 256, 768, 128, 128, 256, True, NUM_BUFFERS,
+                                      True, True, 'sliceK', False, 8, '')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/10550

Upstream commit message:
```
> [AMD][Gluon][Test] Fix test bug in MXFP GEMM sliceK (#10550)

> - Fix a bug in slot indexing.
> - Support 3-buffer sliceK by matching the prefetch/drain depth to
> NUM_BUFFERS
```

***Do not remove the following line from this commit***
Reactor Backport Revision: ddfaa7c9c624d2f8de34f77da4871e55799d942e
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 10550
```

Reviewed By: warrendeng

Differential Revision: D114451735


