### PR TITLE
[triton][beta] [Cherry-pick] '[AMD] Fix buffer-op offset split for shape ops (#10498)' (#2637)

### DIFF
--- a/test/TritonGPU/amd/amd-annotate-buffer-op-split-safety.mlir
+++ b/test/TritonGPU/amd/amd-annotate-buffer-op-split-safety.mlir
@@ -48,3 +48,80 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
         tt.return
     }
 }
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @no_split_convert_layout_negative_summand
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_convert_layout_negative_summand(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %cn64 = arith.constant -64 : i32
+        %neg = tt.splat %cn64 : i32 -> tensor<128xi32, #blocked1>
+        %range = tt.make_range {end = 192 : i32, start = 64 : i32} : tensor<128xi32, #blocked1>
+        %add = arith.addi %neg, %range : tensor<128xi32, #blocked1>
+        %offset = ttg.convert_layout %add : tensor<128xi32, #blocked1> -> tensor<128xi32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<128xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @split_convert_layout_all_nonneg
+    // CHECK: amdg.buffer_load
+    // CHECK-SAME: amdgpu.split_soffset_safe
+    tt.func @split_convert_layout_all_nonneg(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %c5 = arith.constant 5 : i32
+        %base = tt.splat %c5 : i32 -> tensor<128xi32, #blocked1>
+        %range = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #blocked1>
+        %add = arith.addi %base, %range : tensor<128xi32, #blocked1>
+        %offset = ttg.convert_layout %add : tensor<128xi32, #blocked1> -> tensor<128xi32, #blocked0>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<128xf32, #blocked0>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#blocked2d = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @no_split_reshape_negative_summand
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_reshape_negative_summand(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %cn64 = arith.constant -64 : i32
+        %neg = tt.splat %cn64 : i32 -> tensor<128xi32, #blocked0>
+        %range = tt.make_range {end = 192 : i32, start = 64 : i32} : tensor<128xi32, #blocked0>
+        %add = arith.addi %neg, %range : tensor<128xi32, #blocked0>
+        %offset = tt.reshape %add allow_reorder : tensor<128xi32, #blocked0> -> tensor<1x128xi32, #blocked2d>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<1x128xf32, #blocked2d>
+        tt.return
+    }
+}
+
+// -----
+
+#blocked2d = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0]}>
+#slice2d0 = #ttg.slice<{dim = 0, parent = #blocked2d}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+    // CHECK-LABEL: @no_split_expand_dims_broadcast_negative_summand
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: amdgpu.split_soffset_safe
+    tt.func @no_split_expand_dims_broadcast_negative_summand(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
+        %cn64 = arith.constant -64 : i32
+        %neg = tt.splat %cn64 : i32 -> tensor<128xi32, #slice2d0>
+        %range = tt.make_range {end = 192 : i32, start = 64 : i32} : tensor<128xi32, #slice2d0>
+        %add = arith.addi %neg, %range : tensor<128xi32, #slice2d0>
+        %expanded = tt.expand_dims %add {axis = 0 : i32} : tensor<128xi32, #slice2d0> -> tensor<1x128xi32, #blocked2d>
+        %offset = tt.broadcast %expanded : tensor<1x128xi32, #blocked2d> -> tensor<2x128xi32, #blocked2d>
+        %ret = amdg.buffer_load %arg0[%offset] : tensor<2x128xf32, #blocked2d>
+        tt.return
+    }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AnnotateBufferOpSplitSafety.cpp
@@ -8,6 +8,7 @@
 #include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 namespace mlir {
 
@@ -18,8 +19,30 @@ namespace {
 
 namespace AMD = mlir::triton::AMD;
 namespace tta = mlir::triton::amdgpu;
+namespace ttg = mlir::triton::gpu;
 
 constexpr llvm::StringLiteral kSplitSafeAttrName = "amdgpu.split_soffset_safe";
+
+// Shape/layout ops that forward their operand's values unchanged, and with them
+// the operand's sign and its integer-range lattice state.
+static bool isTransparentWrapper(Operation *op) {
+  bool isWrapper =
+      isa<triton::SplatOp, triton::BroadcastOp, triton::ExpandDimsOp,
+          triton::ReshapeOp, ttg::ConvertLayoutOp>(op);
+  assert((!isWrapper || op->getNumOperands() == 1) &&
+         "transparent wrapper must have a single SSA operand.");
+  return isWrapper;
+}
+
+// Peel transparent wrappers to expose the real defining op underneath.
+static Value peelTransparentWrappers(Value v) {
+  while (Operation *def = v.getDefiningOp()) {
+    if (!isTransparentWrapper(def))
+      break;
+    v = def->getOperand(0);
+  }
+  return v;
+}
 
 // Conservatively accept an offset only when every leaf in its
 // additive/shape expression proves non-negative. This may miss safe splits,
@@ -28,7 +51,7 @@ static bool isLeafNonNegative(Value v, DataFlowSolver &solver) {
   // An `add` is never a leaf to the soffset splitter. It peels the summands
   // apart and lifts the uniform ones into the unsigned soffset. So a sum whose
   // range is non-negative can still hide a negative summand.
-  if (v.getDefiningOp<arith::AddIOp>())
+  if (peelTransparentWrappers(v).getDefiningOp<arith::AddIOp>())
     return false;
 
   const auto *range = solver.lookupState<dataflow::IntegerValueRangeLattice>(v);
@@ -77,8 +100,7 @@ static bool isNonNegative(Value v, DataFlowSolver &solver) {
     return mr.getStartAttr().getInt() >= 0;
   if (isa<triton::GetProgramIdOp, triton::GetNumProgramsOp>(def))
     return true;
-  if (isa<triton::SplatOp, triton::BroadcastOp, triton::ExpandDimsOp,
-          triton::ReshapeOp>(def))
+  if (isTransparentWrapper(def))
     return isNonNegative(def->getOperand(0), solver);
 
   return false;

--- a/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/mxfp_gemm_gfx1250.py
@@ -562,20 +562,19 @@ class MXFPGEMMSliceKProgram:
         load_idx = 0
         wmma_idx = 0
 
-        # prologue
-        # iter 0
-        load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer, self.b_scale_buffer)
+        # Prologue: keep NUM_BUFFERS K-tiles in flight, then wait until only the
+        # future tiles remain outstanding before consuming the oldest one.
+        for _ in gl.static_range(cfg.NUM_BUFFERS):
+            load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer,
+                                        self.b_scale_buffer)
 
-        # iter 1
-        load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer, self.b_scale_buffer)
-        # iter 0
         gl.amd.gfx1250.tdm.async_wait((cfg.NUM_BUFFERS - 1) * cfg.NUM_LOADS_IN_BATCH)
         a0, b0, scale_a0, scale_b0 = self.issue_subtile_local_loads(wmma_idx, 0, self.a_buffer, self.b_buffer,
                                                                     self.a_scale_buffer, self.b_scale_buffer)
 
         accumulator = gl.zeros((cfg.BLOCK_M, cfg.BLOCK_N), dtype=gl.float32, layout=self.cfg.acc_layout)
-        loop_ub = gl.cdiv(K, cfg.BLOCK_K) - 1
-        for _ in range(0, loop_ub - 1):
+        loop_ub = gl.cdiv(K, cfg.BLOCK_K) - cfg.NUM_BUFFERS
+        for _ in range(0, loop_ub):
             # iter i
             accumulator = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b0, scale_b0, cfg.DTYPE_B, accumulator)
 
@@ -584,9 +583,9 @@ class MXFPGEMMSliceKProgram:
                                                                         self.a_scale_buffer, self.b_scale_buffer)
             wmma_idx += 1
 
-            # iter i + 2
+            # iter i + NUM_BUFFERS
             load_idx = self.issue_loads(load_idx, self.a_buffer, self.b_buffer, self.a_scale_buffer,
-                                        self.b_scale_buffer, phase=wmma_idx + cfg.NUM_BUFFERS - 2)
+                                        self.b_scale_buffer, phase=wmma_idx + cfg.NUM_BUFFERS - 1)
 
             # iter i
             accumulator = gl.amd.gfx1250.wmma_scaled(a1, scale_a1, cfg.DTYPE_A, b1, scale_b1, cfg.DTYPE_B, accumulator)
@@ -597,29 +596,18 @@ class MXFPGEMMSliceKProgram:
                                                                         self.a_scale_buffer, self.b_scale_buffer)
 
         # epilogue
-        # iter end - 2
-        accumulator = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b0, scale_b0, cfg.DTYPE_B, accumulator)
+        for i in gl.static_range(cfg.NUM_BUFFERS):
+            if i > 0:
+                gl.amd.gfx1250.tdm.async_wait((cfg.NUM_BUFFERS - 1 - i) * cfg.NUM_LOADS_IN_BATCH)
+                a0, b0, scale_a0, scale_b0 = self.issue_subtile_local_loads(wmma_idx, 0, self.a_buffer, self.b_buffer,
+                                                                            self.a_scale_buffer, self.b_scale_buffer)
 
-        # iter end - 2
-        a1, b1, scale_a1, scale_b1 = self.issue_subtile_local_loads(wmma_idx, 1, self.a_buffer, self.b_buffer,
-                                                                    self.a_scale_buffer, self.b_scale_buffer)
-        wmma_idx += 1
+            accumulator = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b0, scale_b0, cfg.DTYPE_B, accumulator)
 
-        # iter end - 2
-        accumulator = gl.amd.gfx1250.wmma_scaled(a1, scale_a1, cfg.DTYPE_A, b1, scale_b1, cfg.DTYPE_B, accumulator)
-        # iter end - 1
-        gl.amd.gfx1250.tdm.async_wait(0)
-        a0, b0, scale_a0, scale_b0 = self.issue_subtile_local_loads(wmma_idx, 0, self.a_buffer, self.b_buffer,
-                                                                    self.a_scale_buffer, self.b_scale_buffer)
-        # iter end - 1
-        accumulator = gl.amd.gfx1250.wmma_scaled(a0, scale_a0, cfg.DTYPE_A, b0, scale_b0, cfg.DTYPE_B, accumulator)
-
-        # iter end - 1
-        a1, b1, scale_a1, scale_b1 = self.issue_subtile_local_loads(wmma_idx, 1, self.a_buffer, self.b_buffer,
-                                                                    self.a_scale_buffer, self.b_scale_buffer)
-        wmma_idx += 1
-
-        accumulator = gl.amd.gfx1250.wmma_scaled(a1, scale_a1, cfg.DTYPE_A, b1, scale_b1, cfg.DTYPE_B, accumulator)
+            a1, b1, scale_a1, scale_b1 = self.issue_subtile_local_loads(wmma_idx, 1, self.a_buffer, self.b_buffer,
+                                                                        self.a_scale_buffer, self.b_scale_buffer)
+            wmma_idx += 1
+            accumulator = gl.amd.gfx1250.wmma_scaled(a1, scale_a1, cfg.DTYPE_A, b1, scale_b1, cfg.DTYPE_B, accumulator)
 
         apply_activation_and_store(self.cfg, accumulator, self.c_ptr, self.c_offs, self.c_mask)
 
@@ -1247,8 +1235,10 @@ def test_runtime_mxgemm_tdm_pipelined(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_
         if ASYNC_COPY_SCALE:
             pytest.skip('Only use ASYNC_COPY_SCALE in sliceNK schedule')
 
-    if SCHEDULE != 'baseline' and NUM_BUFFERS != 2:
-        pytest.skip('Only test 2 buffers in sliceK and sliceNK schedules')
+    if SCHEDULE == 'sliceNK' and NUM_BUFFERS != 2:
+        pytest.skip('Only test 2 buffers in sliceNK schedule')
+    if SCHEDULE == 'sliceK' and NUM_BUFFERS not in (2, 3):
+        pytest.skip('Only test 2 or 3 buffers in sliceK schedule')
 
     if ASYNC_COPY_SCALE and (M < BLOCK_M or N < BLOCK_N or K < BLOCK_K):
         pytest.skip('NYI: Skipping small problem sizes for async copy scale')
@@ -1340,6 +1330,12 @@ def test_runtime_mxgemm_tdm_pipelined(DTYPE_A, DTYPE_B, M, N, K, BLOCK_M, BLOCK_
     else:
         torch.testing.assert_close(c_d.cpu(), c_ref.cpu(), rtol=1e-5, atol=1e-8)
     print('✅Pass')
+
+
+@pytest.mark.parametrize("NUM_BUFFERS", [2, 3])
+def test_runtime_mxgemm_tdm_slicek_three_k_tiles(NUM_BUFFERS):
+    test_runtime_mxgemm_tdm_pipelined('float8_e4m3', 'float8_e5m2', 256, 256, 768, 128, 128, 256, True, NUM_BUFFERS,
+                                      True, True, 'sliceK', False, 8, '')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/10498

Upstream commit message:
```
> [AMD] Fix buffer-op offset split for shape ops (#10498)

> An offset is only marked split-safe when it can never feed a negative
> value into the unsigned scalar soffset. The pass was honoring that
> contract for a bare arith.addi (a sum can have a non-negative range
> while still containing a negative term), but the safety check only
> reasoned about the offset's outermost op. In some kernels the relevant
> add is routinely wrapped in shape/layout plumbing (`tt.reshape`,
> `tt.broadcast`, `ttg.convert_layout`, etc.). When that happened, the
> check no longer saw the add, fell back to the aggregate range, and
> concluded "non-negative, safe." That is exactly the case the pass is
> meant to reject, so it was silently producing incorrect addresses.

> Note: This is an extension of the bug fix here:
> https://github.com/triton-lang/triton/pull/10450
```

***Do not remove the following line from this commit***
Reactor Backport Revision: 0cf3eebd047d3d76a40a26f42cf29c50371ac922
---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 10498
```

Reviewed By: warrendeng

Differential Revision: D114451798


