### PR TITLE
[triton][beta] [Cherry-pick] '[AMD][gfx1250] TDM: add regression test for the uniform tensor_dim clamp (#10605)' (#2647)

### DIFF
--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -117,6 +117,17 @@ private:
     return false;
   }
 
+  /// Return true if \p op broadcasts only along \p axis, false otherwise.
+  static bool isBroadcastAlongAxis(BroadcastOp op, unsigned axis) {
+    auto srcShape = op.getSrc().getType().getShape();
+    auto dstShape = op.getType().getShape();
+    for (unsigned i = 0; i < srcShape.size(); ++i) {
+      if ((srcShape[i] != dstShape[i]) != (i == axis))
+        return false;
+    }
+    return true;
+  }
+
 public:
   CombineBroadcastMulReducePattern(MLIRContext *context)
       : RewritePattern(ReduceOp::getOperationName(), 1, context) {}
@@ -125,6 +136,11 @@ public:
                                 PatternRewriter &rewriter) const override {
     auto reduceOp = llvm::dyn_cast<ReduceOp>(op);
     if (!reduceOp)
+      return failure();
+    if (cast<RankedTensorType>(reduceOp.getOperand(0).getType()).getRank() != 3)
+      return failure();
+    // We must be reducing along the middle dim.
+    if (reduceOp.getAxis() != 1)
       return failure();
     // only support reduce with simple addition
     Region &combineOp = reduceOp.getCombineOp();
@@ -155,6 +171,11 @@ public:
     int expandLhsAxis = expandLhsOp.getAxis();
     int expandRhsAxis = expandRhsOp.getAxis();
     if (expandLhsAxis != 2 || expandRhsAxis != 0)
+      return failure();
+    // The first operand must be broadcasted from (M, K, 1) to (M, K, N), and
+    // the second operand must go from (1, K, N) to (M, K, N).
+    if (!isBroadcastAlongAxis(broadcastLhsOp, 2) ||
+        !isBroadcastAlongAxis(broadcastRhsOp, 0))
       return failure();
     auto broadcastLhsShape =
         cast<ShapedType>(broadcastLhsOp.getType()).getShape();

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -107,8 +107,6 @@ bool isGenericLinearEncoding(Attribute attr) {
 Attribute inferEncodingFromLinearLayout(MLIRContext *ctx, LinearLayout ll,
                                         Attribute srcEnc) {
   if (isGenericLinearEncoding(srcEnc)) {
-    assert(!isPermutationMatrixLayout(ll) &&
-           "Expected non-permutation layout from this source encoding");
     return GenericLinearEncodingAttr::get(ctx, std::move(ll));
   }
   return LinearEncodingAttr::get(ctx, std::move(ll));

--- a/lib/Tools/LayoutUtils.cpp
+++ b/lib/Tools/LayoutUtils.cpp
@@ -86,15 +86,20 @@ ensureLayoutNotLargerThan(const LinearLayout &layout,
     // From the largest basis to the smallest.
     llvm::sort(sortedBases,
                [](auto a, auto b) { return std::get<2>(a) > std::get<2>(b); });
-    for (auto [inDimName, basisIdx, outValue] : sortedBases) {
-      if (span <= shrinkTarget) {
-        break;
-      }
-      if (!broadcastRegisters && inDimName == kRegister) {
-        broadcastedDims.insert(basisIdx);
-      } else {
-        bases[inDimName][basisIdx][outDim.index()] = 0;
-      }
+    for (size_t i = 0; i < sortedBases.size() && span > shrinkTarget;) {
+      int outValue = std::get<2>(sortedBases[i]);
+      do {
+        auto inDimName = std::get<0>(sortedBases[i]);
+        auto basisIdx = std::get<1>(sortedBases[i++]);
+        if (!broadcastRegisters && inDimName == kRegister) {
+          broadcastedDims.insert(basisIdx);
+        } else {
+          bases[inDimName][basisIdx][outDim.index()] = 0;
+        }
+      } while (i < sortedBases.size() &&
+               std::get<2>(sortedBases[i]) == outValue);
+      // Duplicate bases encode the same output bit and shrink the span only
+      // after every copy has been removed.
       span >>= 1;
     }
   }

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1149,8 +1149,7 @@ void init_gluon_ir(py::module &&m) {
                  /*descPtr=*/mlir::Value(), paddingOption);
            })
       .def("create_async_tdm_copy_global_to_local",
-           [](GluonOpBuilder &self, Value descPtr, std::vector<Value> &indices,
-              Value result, Value pred, Value barrier,
+           [](GluonOpBuilder &self, Value descPtr, Value result, Value barrier,
               tt::CacheModifier cacheModifier,
               std::optional<uint32_t> warpUsedHint) {
              IntegerAttr hintAttr;
@@ -1158,14 +1157,13 @@ void init_gluon_ir(py::module &&m) {
                hintAttr = self.getBuilder().getI32IntegerAttr(
                    static_cast<int32_t>(*warpUsedHint));
              self.create<ttag::AsyncTDMCopyGlobalToLocalOp>(
-                 descPtr, indices, result, pred, barrier, cacheModifier,
-                 hintAttr);
+                 descPtr, result, barrier, cacheModifier, hintAttr);
            })
       .def("create_async_tdm_copy_local_to_global",
-           [](GluonOpBuilder &self, Value descPtr, std::vector<Value> &indices,
-              Value src, Value barrier, tt::CacheModifier cacheModifier) {
+           [](GluonOpBuilder &self, Value descPtr, Value src, Value barrier,
+              tt::CacheModifier cacheModifier) {
              self.create<ttag::AsyncTDMCopyLocalToGlobalOp>(
-                 descPtr, indices, src, barrier, cacheModifier);
+                 descPtr, src, barrier, cacheModifier);
            })
       .def("create_update_tensor_descriptor",
            [](GluonOpBuilder &self, Value descPtr,

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -1170,10 +1170,14 @@ void init_gluon_ir(py::module &&m) {
       .def("create_update_tensor_descriptor",
            [](GluonOpBuilder &self, Value descPtr,
               std::vector<Value> &addOffsets, std::vector<Value> &setBounds,
-              Value dest, Value pred, Value barrier) -> Value {
-             return self.create<ttag::UpdateTensorDescriptorOp>(
+              Value pred, bool clampBounds) -> Value {
+             Value res = self.create<ttag::UpdateTensorDescriptorOp>(
                  descPtr.getType(), descPtr, ValueRange(addOffsets),
-                 ValueRange(setBounds), dest, pred, barrier);
+                 ValueRange(setBounds), pred);
+             if (clampBounds)
+               res.getDefiningOp()->setAttr("clamp_bounds",
+                                            self.getBuilder().getUnitAttr());
+             return res;
            })
       .def("create_async_tdm_scatter",
            [](GluonOpBuilder &self, Value descPtr, Value dstRowIndices,

--- a/python/test/gluon/test_frontend.py
+++ b/python/test/gluon/test_frontend.py
@@ -4306,9 +4306,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
     %c2_i32 = arith.constant 2 : i32
     %c1_i32 = arith.constant 1 : i32
-    %2 = amdg.async_tdm_copy_global_to_local %0[%c0_i32, %c2_i32] into %1, pred = %c1_i32 : !tt.tensordesc<16x64xf16, #shared> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
-    %3 = amdg.async_tdm_wait  {num = 0 : i32}
-    %4 = ttg.local_load %1 : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> tensor<16x64xf16, #blocked>
+    %2 = amdg.update_tensor_descriptor %0 add_offsets = [%c0_i32, %c2_i32] pred = %c1_i32 {clamp_bounds} : !tt.tensordesc<16x64xf16, #shared>
+    %3 = amdg.async_tdm_copy_global_to_local %2 into %1 : !tt.tensordesc<16x64xf16, #shared> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    %4 = amdg.async_tdm_wait  {num = 0 : i32}
+    %5 = ttg.local_load %1 : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> tensor<16x64xf16, #blocked>
     tt.return
   }
 }
@@ -4344,9 +4345,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
     %c2_i32 = arith.constant 2 : i32
     %c1_i32 = arith.constant 1 : i32
-    %1 = amdg.async_tdm_copy_global_to_local %arg0[%c0_i32, %c2_i32] into %0, pred = %c1_i32 : !tt.tensordesc<16x64xf16, #shared> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
-    %2 = amdg.async_tdm_wait  {num = 0 : i32}
-    %3 = ttg.local_load %0 : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> tensor<16x64xf16, #blocked>
+    %1 = amdg.update_tensor_descriptor %arg0 add_offsets = [%c0_i32, %c2_i32] pred = %c1_i32 {clamp_bounds} : !tt.tensordesc<16x64xf16, #shared>
+    %2 = amdg.async_tdm_copy_global_to_local %1 into %0 : !tt.tensordesc<16x64xf16, #shared> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    %3 = amdg.async_tdm_wait  {num = 0 : i32}
+    %4 = ttg.local_load %0 : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> tensor<16x64xf16, #blocked>
     tt.return
   }
 }
@@ -4397,8 +4399,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %1 = ttg.local_alloc %cst_0 : (tensor<16x64xf16, #blocked>) -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
     %c0_i32 = arith.constant 0 : i32
     %c2_i32 = arith.constant 2 : i32
-    amdg.async_tdm_copy_local_to_global %0[%c0_i32, %c2_i32] from %1 : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<16x64xf16, #shared>
-    %2 = amdg.async_tdm_wait  {num = 0 : i32}
+    %2 = amdg.update_tensor_descriptor %0 add_offsets = [%c0_i32, %c2_i32] {clamp_bounds} : !tt.tensordesc<16x64xf16, #shared>
+    amdg.async_tdm_copy_local_to_global %2 from %1 : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<16x64xf16, #shared>
+    %3 = amdg.async_tdm_wait  {num = 0 : i32}
     tt.return
   }
 }
@@ -4537,23 +4540,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
     %c2_i32 = arith.constant 2 : i32
     %c0_i32_1 = arith.constant 0 : i32
-    %2 = amdg.async_tdm_copy_global_to_local %0[%c0_i32, %c2_i32] into %1, pred = %c0_i32_1 : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %2 = amdg.update_tensor_descriptor %0 add_offsets = [%c0_i32, %c2_i32] pred = %c0_i32_1 {clamp_bounds} : !tt.tensordesc<64x64xf16, #shared>
+    %3 = amdg.async_tdm_copy_global_to_local %2 into %1 : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     %c0_i32_2 = arith.constant 0 : i32
     %c2_i32_3 = arith.constant 2 : i32
     %c1_i32 = arith.constant 1 : i32
-    %3 = amdg.async_tdm_copy_global_to_local %0[%c0_i32_2, %c2_i32_3] into %1, pred = %c1_i32 : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %4 = amdg.update_tensor_descriptor %0 add_offsets = [%c0_i32_2, %c2_i32_3] pred = %c1_i32 {clamp_bounds} : !tt.tensordesc<64x64xf16, #shared>
+    %5 = amdg.async_tdm_copy_global_to_local %4 into %1 : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     %c64_i32_4 = arith.constant 64 : i32
-    %4 = arith.cmpi slt, %arg1, %c64_i32_4 : i32
+    %6 = arith.cmpi slt, %arg1, %c64_i32_4 : i32
     %c0_i32_5 = arith.constant 0 : i32
     %c2_i32_6 = arith.constant 2 : i32
-    %5 = arith.extui %4 : i1 to i32
-    %6 = amdg.async_tdm_copy_global_to_local %0[%c0_i32_5, %c2_i32_6] into %1, pred = %5 : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %7 = arith.extui %6 : i1 to i32
+    %8 = amdg.update_tensor_descriptor %0 add_offsets = [%c0_i32_5, %c2_i32_6] pred = %7 {clamp_bounds} : !tt.tensordesc<64x64xf16, #shared>
+    %9 = amdg.async_tdm_copy_global_to_local %8 into %1 : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     %c1_i32_7 = arith.constant 1 : i32
     %c1_i32_8 = arith.constant 1 : i32
-    %7 = arith.andi %arg1, %c1_i32_8 : i32
+    %10 = arith.andi %arg1, %c1_i32_8 : i32
     %c0_i32_9 = arith.constant 0 : i32
     %c2_i32_10 = arith.constant 2 : i32
-    %8 = amdg.async_tdm_copy_global_to_local %0[%c0_i32_9, %c2_i32_10] into %1, pred = %7 : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %11 = amdg.update_tensor_descriptor %0 add_offsets = [%c0_i32_9, %c2_i32_10] pred = %10 {clamp_bounds} : !tt.tensordesc<64x64xf16, #shared>
+    %12 = amdg.async_tdm_copy_global_to_local %11 into %1 : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -4703,8 +4710,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
     %c2_i32 = arith.constant 2 : i32
     %c1_i32 = arith.constant 1 : i32
-    %3 = amdg.async_tdm_copy_global_to_local %0[%c0_i32, %c2_i32] into %2, pred = %c1_i32, barrier = %1 : !tt.tensordesc<16x64xf16, #shared>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
-    %4 = ttg.local_load %2 : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> tensor<16x64xf16, #blocked>
+    %3 = amdg.update_tensor_descriptor %0 add_offsets = [%c0_i32, %c2_i32] pred = %c1_i32 {clamp_bounds} : !tt.tensordesc<16x64xf16, #shared>
+    %4 = amdg.async_tdm_copy_global_to_local %3 into %2, barrier = %1 : !tt.tensordesc<16x64xf16, #shared>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<16x64xf16, #shared, #smem, mutable>
+    %5 = ttg.local_load %2 : !ttg.memdesc<16x64xf16, #shared, #smem, mutable> -> tensor<16x64xf16, #blocked>
     tt.return
   }
 }

--- a/python/test/unit/language/test_random.py
+++ b/python/test/unit/language/test_random.py
@@ -247,14 +247,15 @@ def test_randn(size, seed, dtype, device, const_seed):
     assert abs(x.std() - 1) < 1e-2
 
 
-# tl.rand() should never produce >=1.0
+# tl.rand() should never produce >=1.0. With debug=True, this also guards the
+# int32 fold against the INT_MIN overflow that tripped the sanitizer (#10597).
 
 
 @pytest.mark.interpreter
 @pytest.mark.parametrize('dtype', ['int32', 'int64'])
 def test_rand_limits(dtype, device):
 
-    @triton.jit
+    @triton.jit(debug=True)
     def kernel(input, output, n: tl.constexpr):
         idx = tl.arange(0, n)
         x = tl.load(input + idx)

--- a/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
@@ -155,9 +155,8 @@ def _handle_i32_pred(pred, _semantic):
 
 @builtin
 def update_tensor_descriptor(desc: tensor_descriptor, add_offsets: List[ttgl.constexpr | ttgl.tensor] = None,
-                             set_bounds: List[ttgl.constexpr | ttgl.tensor] = None,
-                             dest: shared_memory_descriptor = None, pred=None, barrier: shared_memory_descriptor = None,
-                             _semantic=None) -> tensor_descriptor:
+                             set_bounds: List[ttgl.constexpr | ttgl.tensor] = None, pred=None,
+                             clamp_bounds: bool = False, _semantic=None) -> tensor_descriptor:
     """Update selected fields of a TDM descriptor; return a new descriptor SSA value.
 
     Each parameter is independently optional; only the fields the caller
@@ -167,7 +166,8 @@ def update_tensor_descriptor(desc: tensor_descriptor, add_offsets: List[ttgl.con
     NOTE: Unlike the standard tensor-descriptor mental model, `add_offsets`
     here moves the tile position only.  It does NOT update the descriptor's
     bounds.  If the loop crosses an OOB boundary, you must also pass
-    `set_bounds` explicitly to install the correct OOB extent.
+    `set_bounds` explicitly, or pass `clamp_bounds=True` to derive the OOB
+    extent from `add_offsets`.
 
     Args:
         desc (tensor_descriptor): the input descriptor.
@@ -176,11 +176,11 @@ def update_tensor_descriptor(desc: tensor_descriptor, add_offsets: List[ttgl.con
         set_bounds (List[int], optional): per-dim absolute rewrite of the
             descriptor's bounds.  Use to install OOB extent at a peel
             epilogue.
-        dest (shared_memory_descriptor, optional): set the descriptor's
-            shared-memory slot used by subsequent loads/stores.
         pred (int, optional): set the descriptor's predicate.
-        barrier (shared_memory_descriptor, optional): enable barrier
-            signaling on this descriptor and set the barrier address.
+        clamp_bounds (bool, optional): if True, also shrink the descriptor's
+            bounds by `add_offsets` (tensor_dim[i] = max(0, tensor_dim[i] -
+            add_offsets[i])) to derive the advanced tile's OOB extent.
+            Requires `add_offsets`; mutually exclusive with `set_bounds`.
 
     Returns:
         tensor_descriptor: a new descriptor SSA value with the requested
@@ -193,16 +193,23 @@ def update_tensor_descriptor(desc: tensor_descriptor, add_offsets: List[ttgl.con
         # K-loop interior: bump tile position only
         d = tdm.update_tensor_descriptor(d, add_offsets=[0, BLOCK_K])
 
-        # Prologue: position at first tile + wire LDS and barrier
+        # Prologue: position at first tile + set the predicate
         d = tdm.update_tensor_descriptor(d, add_offsets=[pid_m * BLOCK_M, 0],
-                                         dest=a_shared, barrier=a_bar)
+                                         pred=do_load)
 
         # Peel epilogue: install real OOB extent for the partial last tile
         d = tdm.update_tensor_descriptor(d, set_bounds=[M - pid_m * BLOCK_M, K - k_main])
     """
-    if add_offsets is None and set_bounds is None and dest is None and pred is None and barrier is None:
+    if add_offsets is None and set_bounds is None and pred is None:
         raise ValueError("tdm.update_tensor_descriptor requires at least one of add_offsets, "
-                         "set_bounds, dest, pred, barrier")
+                         "set_bounds, pred")
+
+    clamp_bounds = _unwrap_if_constexpr(clamp_bounds)
+    if clamp_bounds:
+        if add_offsets is None:
+            raise ValueError("tdm.update_tensor_descriptor: clamp_bounds requires add_offsets")
+        if set_bounds is not None:
+            raise ValueError("tdm.update_tensor_descriptor: clamp_bounds and set_bounds are mutually exclusive")
 
     rank = len(desc.block_shape)
 
@@ -218,19 +225,12 @@ def update_tensor_descriptor(desc: tensor_descriptor, add_offsets: List[ttgl.con
             raise ValueError(f"set_bounds must have length {rank} (descriptor rank), got {len(set_bounds)}")
         set_bounds_handles = _semantic._convert_to_ir_values(set_bounds, require_i64=False)
 
-    dest = _unwrap_if_constexpr(dest)
-    dest_handle = dest.handle if dest is not None else ttgl.ir.value()
-
     pred_handle = ttgl.ir.value()
     if pred is not None:
-        pred_t = _semantic.to_tensor(pred)
-        pred_handle = pred_t.handle
-
-    barrier = _unwrap_if_constexpr(barrier)
-    barrier_handle = barrier.handle if barrier is not None else ttgl.ir.value()
+        pred_handle = _handle_i32_pred(pred, _semantic).handle
 
     new_handle = _semantic.builder.create_update_tensor_descriptor(desc.handle, add_offset_handles, set_bounds_handles,
-                                                                   dest_handle, pred_handle, barrier_handle)
+                                                                   pred_handle, bool(clamp_bounds))
     # Rebuild shape/strides tuples so the returned descriptor's tuple objects
     # don't alias the original's (the frontend's SSA tracking assumes distinct
     # tuples per descriptor value).

--- a/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
+++ b/python/triton/experimental/gluon/language/amd/gfx1250/tdm.py
@@ -240,16 +240,24 @@ def update_tensor_descriptor(desc: tensor_descriptor, add_offsets: List[ttgl.con
 
 
 @builtin
-def async_load(src: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tensor], dest: shared_memory_descriptor,
-               pred=True, mbarrier: shared_memory_descriptor = None, warp_used_hint=None, cache_modifier="",
-               _semantic=None) -> None:
+def async_load(src: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tensor] = None,
+               dest: shared_memory_descriptor = None, pred=None, mbarrier: shared_memory_descriptor = None,
+               warp_used_hint=None, cache_modifier="", _semantic=None) -> None:
     """Load a block of tensor specified in tensor descriptor from global memory to shared memory asynchronously.
+
+    This op expects a prior ``update_tensor_descriptor`` to position the
+    descriptor for the load offsets and bounds.  Doing this explicitly lets the
+    developer control when and where the descriptor update happens, which has
+    performance implications for downstream code generation.  For convenience,
+    ``offsets`` (and optionally ``pred``) may be passed here, in which case an
+    ``update_tensor_descriptor`` is emitted right before the load.
 
     Args:
         src (tensor_descriptor): the source tensor descriptor.
-        offsets (List[int]): the offsets from the base pointer in the tensor descriptor.
+        offsets (List[int], optional): if given, the offsets from the base
+            pointer used to position the descriptor before the load.
         dest (shared_memory_descriptor): the shared memory destination to store the loaded data.
-        pred (bool, optional): Predicate to enable or disable the load. Defaults to True.
+        pred (bool, optional): if given, predicate to enable or disable the load.
         mbarrier (shared_memory_descriptor, optional): The barrier object to signal "arrive" on.
         warp_used_hint (int, optional): Bitmask selecting which warps issue
             the TDM copy (bit ``n`` => warp ``n``); cleared warps become HW
@@ -262,8 +270,13 @@ def async_load(src: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tenso
             rejected by the verifier.
         cache_modifier (str, optional): Cache behavior.
     """
-    offset_handles = _semantic._convert_to_ir_values(offsets, require_i64=False)
-    pred = _handle_i32_pred(pred, _semantic)
+    assert dest is not None, "async_load requires a dest shared_memory_descriptor"
+    if offsets:
+        eff_pred = True if pred is None else pred
+        src = update_tensor_descriptor(src, add_offsets=offsets, pred=eff_pred, clamp_bounds=True, _semantic=_semantic)
+    elif pred is not None:
+        src = update_tensor_descriptor(src, pred=pred, _semantic=_semantic)
+
     mbarrier = _unwrap_if_constexpr(mbarrier)
     mbarrier_handle = mbarrier.handle if mbarrier is not None else ttgl.ir.value()
     cache_modifier = _semantic._str_to_load_cache_modifier(cache_modifier)
@@ -272,27 +285,35 @@ def async_load(src: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tenso
     if warp_used_hint is not None:
         warp_used_hint = int(warp_used_hint)
 
-    _semantic.builder.create_async_tdm_copy_global_to_local(src.handle, offset_handles, dest.handle, pred.handle,
-                                                            mbarrier_handle, cache_modifier, warp_used_hint)
+    _semantic.builder.create_async_tdm_copy_global_to_local(src.handle, dest.handle, mbarrier_handle, cache_modifier,
+                                                            warp_used_hint)
 
 
 @builtin
-def async_store(dest: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tensor], src: shared_memory_descriptor,
-                mbarrier: shared_memory_descriptor = None, cache_modifier="", _semantic=None) -> None:
+def async_store(dest: tensor_descriptor, offsets: List[ttgl.constexpr | ttgl.tensor] = None,
+                src: shared_memory_descriptor = None, mbarrier: shared_memory_descriptor = None, cache_modifier="",
+                _semantic=None) -> None:
     """Store a block of tensor specified in tensor descriptor from shared memory to global memory asynchronously.
+
+    See :func:`async_load` for how the descriptor is positioned (a prior
+    ``update_tensor_descriptor`` or the ``offsets`` convenience).  Stores take no
+    ``pred``.
 
     Args:
         dest (tensor_descriptor): the destination tensor descriptor.
-        offsets (List[int]): the offsets from the base pointer in the tensor descriptor.
+        offsets (List[int], optional): if given, the offsets from the base
+            pointer used to position the descriptor before the store.
         src (shared_memory_descriptor): the shared memory source to load the data.
         mbarrier (shared_memory_descriptor, optional): The barrier object to signal "arrive" on.
     """
-    offset_handles = _semantic._convert_to_ir_values(offsets, require_i64=False)
+    assert src is not None, "async_store requires a src shared_memory_descriptor"
+    if offsets:
+        dest = update_tensor_descriptor(dest, add_offsets=offsets, clamp_bounds=True, _semantic=_semantic)
+
     mbarrier = _unwrap_if_constexpr(mbarrier)
     mbarrier_handle = mbarrier.handle if mbarrier is not None else ttgl.ir.value()
     cache_modifier = _semantic._str_to_store_cache_modifier(cache_modifier)
-    _semantic.builder.create_async_tdm_copy_local_to_global(dest.handle, offset_handles, src.handle, mbarrier_handle,
-                                                            cache_modifier)
+    _semantic.builder.create_async_tdm_copy_local_to_global(dest.handle, src.handle, mbarrier_handle, cache_modifier)
 
 
 @builtin

--- a/python/triton/language/random.py
+++ b/python/triton/language/random.py
@@ -139,7 +139,7 @@ def uint_to_uniform_float(x):
         tl.static_assert(tl.constexpr(x.dtype == tl.uint64) or tl.constexpr(x.dtype == tl.int64))
         x = x.to(tl.int64, bitcast=True)
         scale = 1.0842020432385337e-19
-    x = tl.where(x < 0, -x - 1, x)
+    x = tl.where(x < 0, ~x, x)
     return x * scale
 
 

--- a/test/Conversion/amd/async_ops_to_llvm_gfx1250.mlir
+++ b/test/Conversion/amd/async_ops_to_llvm_gfx1250.mlir
@@ -310,9 +310,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK-NEXT: %[[OOB_LDS:.*]] = llvm.inttoptr %[[NEG1]] :
     // CHECK-NEXT: %[[LDS_PTR:.*]] = llvm.select %{{.*}}, %{{.*}}, %[[OOB_LDS]]
     // CHECK-NEXT: rocdl.global.load.async.to.lds{{.*}} %{{.*}}, %[[LDS_PTR]],
-    // CHECK: llvm.cond_br
-    // CHECK: llvm.store
-    // CHECK-NEXT: llvm.br
+
+    // CHECK: %[[INV_MASK:.*]] = llvm.icmp "ne" %{{.*}}, %{{.*}} : i1
+    // CHECK: %[[OTHER_NEG1:.*]] = llvm.mlir.constant(2147483647 : i32)
+    // CHECK-NEXT: %[[OTHER_OOB_LDS:.*]] = llvm.inttoptr %[[OTHER_NEG1]] :
+    // CHECK-NEXT: %[[OTHER_LDS_PTR:.*]] = llvm.select %[[INV_MASK]], %{{.*}}, %[[OTHER_OOB_LDS]]
+    // CHECK: llvm.store %{{.*}}, %[[OTHER_LDS_PTR]]
     %2 = ttg.async_copy_global_to_local %1, %arg2 mask %67 other %cst_0 : tensor<4x32x!tt.ptr<f32>, #blocked> -> <4x32xf32, #shared, #smem, mutable>
     tt.return
   }

--- a/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
@@ -19,7 +19,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: llvm.insertelement{{.*}} : vector<4xi32>
     // CHECK: llvm.insertelement{{.*}} : vector<8xi32>
     // CHECK: "llvm.amdgcn.tensor.load.to.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
-    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %0 into %1 : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.s.wait.tensorcnt"
     %3 = amdg.async_tdm_intrinsic_wait  {count = 0 : i32}
     %4 = ttg.local_load %1 : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> tensor<64x64xf16, #blocked>
@@ -49,7 +49,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: llvm.insertelement{{.*}} : vector<4xi32>
     // CHECK: llvm.insertelement{{.*}} : vector<8xi32>
     // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
-    amdg.async_tdm_copy_local_to_global %0[%c_offset, %c_offset] from %1: !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x64xf16, #shared>
+    amdg.async_tdm_copy_local_to_global %0 from %1: !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x64xf16, #shared>
     // CHECK: llvm.call_intrinsic "llvm.amdgcn.s.wait.tensorcnt"
     %3 = amdg.async_tdm_intrinsic_wait  {count = 0 : i32}
     tt.return
@@ -84,7 +84,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
 
     // CHECK: "llvm.amdgcn.tensor.load.to.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
-    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %0 into %1 : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -115,7 +115,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
-    amdg.async_tdm_copy_local_to_global %0[%c_offset, %c_offset] from %1: !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x64xf16, #shared>
+    amdg.async_tdm_copy_local_to_global %0 from %1: !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x64xf16, #shared>
     tt.return
   }
 }
@@ -139,17 +139,15 @@ module attributes {"ttg.num-ctas" = 16 : i32, "ttg.num-warps" = 4 : i32, "ttg.th
     // CHECK-DAG: %[[CTA_ID:.*]] = rocdl.cluster.workgroup.id.x
     // CHECK: %[[SHIFT_AMOUNT:.*]] = llvm.and %[[CTA_ID]], %[[NON_FREE_BITS]]
     // CHECK: %[[CTA_MASK:.*]] = llvm.shl %[[GROUP_MASK]], %[[SHIFT_AMOUNT]]
-    // Combine with other values
+    // The multicast OR result is stamped directly into the vector<8xi32> group.
     // CHECK: %[[TMP:.*]] = llvm.or %{{.*}}, %[[CTA_MASK]]
-    // CHECK: %[[TMP2:.*]] = llvm.and %[[TMP]]
-    // CHECK-NOT: llvm.insertelement{{.*}} : vector<8xi32>
-    // CHECK: llvm.insertelement %[[TMP2]]
+    // CHECK: llvm.insertelement %[[TMP]]
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
 
 
     // CHECK: "llvm.amdgcn.tensor.load.to.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
-    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %0 into %1 : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -199,7 +197,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %memDesc: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
   ) {
     %c0_i32 = arith.constant 0 : i32
-    amdg.async_tdm_copy_local_to_global %tensorDesc[%c0_i32, %c0_i32] from %memDesc: !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<128x64xf16>
+    amdg.async_tdm_copy_local_to_global %tensorDesc from %memDesc: !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !tt.tensordesc<128x64xf16>
     // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
     tt.return
   }
@@ -216,7 +214,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %memDesc: !ttg.memdesc<8x8x8x16x16xf16, #shared_5d, #smem_5d, mutable>
   ) {
     %c0_i32 = arith.constant 0 : i32
-    amdg.async_tdm_copy_local_to_global %tensorDesc[%c0_i32, %c0_i32, %c0_i32, %c0_i32, %c0_i32] from %memDesc: !ttg.memdesc<8x8x8x16x16xf16, #shared_5d, #smem_5d, mutable> -> !tt.tensordesc<8x8x8x16x16xf16>
+    amdg.async_tdm_copy_local_to_global %tensorDesc from %memDesc: !ttg.memdesc<8x8x8x16x16xf16, #shared_5d, #smem_5d, mutable> -> !tt.tensordesc<8x8x8x16x16xf16>
     // CHECK: "llvm.amdgcn.tensor.store.from.lds"({{.+}}) : (vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32>, vector<8xi32>, i32) -> ()
     tt.return
   }
@@ -270,7 +268,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     // CHECK: %[[LAYOUT_PRED:.*]] = llvm.select %[[IS_ACTIVE]], %{{.*}}, %{{.*}} : i1, i32
     // CHECK: llvm.and %{{.*}}, %[[LAYOUT_PRED]] : i32
     // CHECK: "llvm.amdgcn.tensor.load.to.lds"
-    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred {warp_used_hint = 15 : i32} : !tt.tensordesc<256x64xf16, #shared> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %0 into %1 {warp_used_hint = 15 : i32} : !tt.tensordesc<256x64xf16, #shared> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -299,7 +297,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: %[[MASKED:.*]] = llvm.and %{{.*}}, %[[FREE_MASK]] : i32
     // CHECK: llvm.icmp "eq" %[[MASKED]], %[[ZERO]] : i32
     // CHECK: "llvm.amdgcn.tensor.load.to.lds"
-    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred {warp_used_hint = 3 : i32} : !tt.tensordesc<128x16xf16, #partitioned> -> !ttg.memdesc<128x16xf16, #partitioned, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %0 into %1 {warp_used_hint = 3 : i32} : !tt.tensordesc<128x16xf16, #partitioned> -> !ttg.memdesc<128x16xf16, #partitioned, #smem, mutable>
     tt.return
   }
 }
@@ -323,7 +321,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // CHECK: llvm.insertelement %{{.*}}, %{{.*}} : vector<8xi32>
     %0 = tt.make_tensor_descriptor %arg0, [%shape0, %shape1], [%stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %0 into %1 : !tt.tensordesc<64x64xf16, #shared> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -346,7 +344,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK-DAG: llvm.lshr %[[S1]], %{{.*}} : i64
     %0 = tt.make_tensor_descriptor %arg0, [%shape0, %shape1, %shape2], [%stride0, %stride1, %c_stride2] : !tt.ptr<f16>, !tt.tensordesc<4x16x64xf16, #shared>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<4x16x64xf16, #shared, #smem, mutable>
-    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset, %c_offset] into %1, pred = %c_pred : !tt.tensordesc<4x16x64xf16, #shared> -> !ttg.memdesc<4x16x64xf16, #shared, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %0 into %1 : !tt.tensordesc<4x16x64xf16, #shared> -> !ttg.memdesc<4x16x64xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -369,7 +367,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape0, %c_shape1], [%c_stride0, %c_stride1] : !tt.ptr<i16>, !tt.tensordesc<1x64xi16, #desc>
     %1 = ttg.local_alloc : () -> !ttg.memdesc<64xi16, #alloc, #smem, mutable>
     // CHECK: "llvm.amdgcn.tensor.load.to.lds"
-    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred : !tt.tensordesc<1x64xi16, #desc> -> !ttg.memdesc<64xi16, #alloc, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %0 into %1 : !tt.tensordesc<1x64xi16, #desc> -> !ttg.memdesc<64xi16, #alloc, #smem, mutable>
     tt.return
   }
 }

--- a/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_tdm_to_llvm.mlir
@@ -350,3 +350,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// Rank-reducing padded load: 2D [1, 64] descriptor into a 1D [64] allocation.
+#desc = #ttg.padded_shared<[64:+8] {order = [1, 0], shape = [1, 64]}>
+#alloc = #ttg.padded_shared<[64:+8] {order = [0], shape = [64]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tdm_load_rank_reducing_padded
+  tt.func public @tdm_load_rank_reducing_padded(%arg0: !tt.ptr<i16> {tt.divisibility = 16 : i32}) {
+    %c_shape0 = arith.constant 1 : i32
+    %c_shape1 = arith.constant 64 : i32
+    %c_stride0 = arith.constant 64 : i64
+    %c_stride1 = arith.constant 1 : i64
+    %c_offset = arith.constant 0 : i32
+    %c_pred = arith.constant 1 : i32
+    %0 = tt.make_tensor_descriptor %arg0, [%c_shape0, %c_shape1], [%c_stride0, %c_stride1] : !tt.ptr<i16>, !tt.tensordesc<1x64xi16, #desc>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<64xi16, #alloc, #smem, mutable>
+    // CHECK: "llvm.amdgcn.tensor.load.to.lds"
+    %2 = amdg.async_tdm_copy_global_to_local %0[%c_offset, %c_offset] into %1, pred = %c_pred : !tt.tensordesc<1x64xi16, #desc> -> !ttg.memdesc<64xi16, #alloc, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/Conversion/amd/tritongpu_update_tensor_descriptor.mlir
+++ b/test/Conversion/amd/tritongpu_update_tensor_descriptor.mlir
@@ -51,28 +51,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: update_tensor_descriptor_dest_only
-  // The dest parameter ptrtoints the smem ptr and stamps into group0[1].
-  // CHECK-NOT: amdg.update_tensor_descriptor
-  // CHECK: llvm.ptrtoint
-  // CHECK: llvm.insertelement{{.*}}vector<4xi32>
-  tt.func public @update_tensor_descriptor_dest_only(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32})
-      -> !tt.tensordesc<64x64xf16, #shared> {
-    %c_shape = arith.constant 128 : i32
-    %c_stride0 = arith.constant 128 : i64
-    %c_stride1 = arith.constant 1 : i64
-    %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
-    %lds = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-    %1 = amdg.update_tensor_descriptor %0 dest = %lds : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> : !tt.tensordesc<64x64xf16, #shared>
-    tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
-  }
-}
-
-// -----
-
-#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: update_tensor_descriptor_pred_only
   // The pred kwarg stamps into group0[0].
   // CHECK-NOT: amdg.update_tensor_descriptor
@@ -91,40 +69,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 // -----
 
 #shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
-#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  // CHECK-LABEL: update_tensor_descriptor_barrier_only
-  // The barrier kwarg ptrtoints the barrier ptr, shifts and stamps into
-  // group1[1] lo-16 plus the enable bit (group1[0] bit 18).
-  // CHECK-NOT: amdg.update_tensor_descriptor
-  // CHECK: llvm.ptrtoint
-  // CHECK: llvm.insertelement{{.*}}vector<8xi32>
-  tt.func public @update_tensor_descriptor_barrier_only(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32})
-      -> !tt.tensordesc<64x64xf16, #shared> {
-    %c_shape = arith.constant 128 : i32
-    %c_stride0 = arith.constant 128 : i64
-    %c_stride1 = arith.constant 1 : i64
-    %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
-    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
-    %1 = amdg.update_tensor_descriptor %0 barrier = %bar : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable> : !tt.tensordesc<64x64xf16, #shared>
-    tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
-  }
-}
-
-// -----
-
-#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
-#shared_bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: update_tensor_descriptor_prologue
-  // The K-loop prologue pattern: position at first tile + wire LDS + barrier + pred.
+  // The K-loop prologue pattern: position at first tile + set pred.
+  // (The LDS destination and TDM barrier are op-level operands on the copy,
+  // not descriptor fields.)
   // CHECK-NOT: amdg.update_tensor_descriptor
-  // CHECK: llvm.ptrtoint
   // CHECK: llvm.add{{.*}}: i64
   // CHECK: llvm.insertelement{{.*}}vector<4xi32>
-  // CHECK: llvm.insertelement{{.*}}vector<8xi32>
   tt.func public @update_tensor_descriptor_prologue(
       %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
       %dx: i32, %dy: i32, %p: i32) -> !tt.tensordesc<64x64xf16, #shared> {
@@ -132,14 +85,61 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     %c_stride0 = arith.constant 128 : i64
     %c_stride1 = arith.constant 1 : i64
     %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
-    %lds = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
-    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
     %1 = amdg.update_tensor_descriptor %0
             add_offsets = [%dx, %dy]
-            dest = %lds : !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
             pred = %p
-            barrier = %bar : !ttg.memdesc<1xi64, #shared_bar, #smem, mutable>
             : !tt.tensordesc<64x64xf16, #shared>
     tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
+  }
+}
+
+// -----
+
+#shared = #ttg.padded_shared<[32:+4] {order = [1, 0], shape = [64, 64]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: update_tensor_descriptor_clamp_bounds
+  // clamp_bounds bumps global_addr (add_offsets) AND derives the OOB extent:
+  // tensor_dim[d] = max(0, decoded_tensor_dim[d] - add_offsets[d]).  The clamp
+  // is the shared signed form (max(cur-off, 0), forced to 0 when off<0), one
+  // per descriptor dim (inner + outer).
+  // CHECK-NOT: amdg.update_tensor_descriptor
+  // global_addr bump (add_offsets):
+  // CHECK-DAG: llvm.sext{{.*}}i32 to i64
+  // CHECK-DAG: llvm.mul{{.*}}: i64
+  // tensor_dim clamp, per dim (signed: off<0 check):
+  // CHECK-COUNT-2: llvm.icmp "slt"
+  // CHECK: llvm.select
+  tt.func public @update_tensor_descriptor_clamp_bounds(
+      %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %dx: i32, %dy: i32)
+      -> !tt.tensordesc<64x64xf16, #shared> {
+    %c_shape = arith.constant 128 : i32
+    %c_stride0 = arith.constant 128 : i64
+    %c_stride1 = arith.constant 1 : i64
+    %0 = tt.make_tensor_descriptor %arg0, [%c_shape, %c_shape], [%c_stride0, %c_stride1] : !tt.ptr<f16>, !tt.tensordesc<64x64xf16, #shared>
+    %1 = amdg.update_tensor_descriptor %0 add_offsets = [%dx, %dy] {clamp_bounds} : !tt.tensordesc<64x64xf16, #shared>
+    tt.return %1 : !tt.tensordesc<64x64xf16, #shared>
+  }
+}
+
+// -----
+
+// 3D update lowers (update_tensor_descriptor is no longer 2D-only): add_offsets
+// bumps global_addr across all dims; clamp_bounds derives the OOB extent per dim
+// (signed clamp, one per dim).
+#shared3d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [2, 1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: update_tensor_descriptor_3d_clamp
+  // CHECK-NOT: amdg.update_tensor_descriptor
+  // CHECK-DAG: llvm.sext{{.*}}i32 to i64
+  // Per-dim signed clamp: icmp slt + select, one per descriptor dim (the select
+  // produces the clamped tensor_dim that is stamped back into group1/group2).
+  // CHECK-COUNT-3: llvm.icmp "slt"
+  // CHECK: llvm.select
+  tt.func public @update_tensor_descriptor_3d_clamp(
+      %desc: !tt.tensordesc<8x8x32xf16, #shared3d>, %x: i32, %y: i32, %z: i32)
+      -> !tt.tensordesc<8x8x32xf16, #shared3d> {
+    %0 = amdg.update_tensor_descriptor %desc add_offsets = [%x, %y, %z] {clamp_bounds} : !tt.tensordesc<8x8x32xf16, #shared3d>
+    tt.return %0 : !tt.tensordesc<8x8x32xf16, #shared3d>
   }
 }

--- a/test/TLX/insert-require-layout-propagate.mlir
+++ b/test/TLX/insert-require-layout-propagate.mlir
@@ -283,7 +283,8 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     // CHECK: %[[BUF:.*]] = ttg.memdesc_index %[[ALLOC]][%{{.*}}] : !ttg.memdesc<2x32x128xf16, #[[$PADDED_A]], #smem, mutable> -> !ttg.memdesc<32x128xf16, #[[$PADDED_A]], #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x32x128xf16, #shared_6, #smem_6, mutable> -> !ttg.memdesc<32x128xf16, #shared_6, #smem_6, mutable>
     // CHECK: amdg.async_tdm_copy_global_to_local %{{.*}} into %[[BUF]]
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_6, #smem_6, mutable>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] pred = %p : !tt.tensordesc<32x128xf16>
+    %tok = amdg.async_tdm_copy_global_to_local %positioned into %buf : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_6, #smem_6, mutable>
     // CHECK: %[[SUB:.*]] = ttg.memdesc_subslice %[[BUF]][0, 0] : !ttg.memdesc<32x128xf16, #[[$PADDED_A]], #smem, mutable> -> !ttg.memdesc<32x32xf16, #[[$PADDED_A]], #smem, mutable, 32x128>
     %sub = ttg.memdesc_subslice %buf[0, 0] : !ttg.memdesc<32x128xf16, #shared_6, #smem_6, mutable> -> !ttg.memdesc<32x32xf16, #shared_6, #smem_6, mutable, 32x128>
     // CHECK: ttg.local_load %[[SUB]] : !ttg.memdesc<32x32xf16, #[[$PADDED_A]], #smem, mutable, 32x128> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
@@ -318,9 +319,11 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     // CHECK: %[[BUF_B:.*]] = ttg.memdesc_index %[[ALLOC_B]][%{{.*}}] : !ttg.memdesc<2x128x32xf16, #[[$PADDED_B_SUB]], #smem, mutable> -> !ttg.memdesc<128x32xf16, #[[$PADDED_B_SUB]], #smem, mutable>
     %buf_b = ttg.memdesc_index %alloc_b[%c0] : !ttg.memdesc<2x128x32xf16, #shared_7, #smem_7, mutable> -> !ttg.memdesc<128x32xf16, #shared_7, #smem_7, mutable>
     // CHECK: amdg.async_tdm_copy_global_to_local %{{.*}} into %[[BUF_A]]
-    %tok_a = amdg.async_tdm_copy_global_to_local %desc_a[%m, %k] into %buf_a, pred = %p : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_7, #smem_7, mutable>
+    %positioned_a = amdg.update_tensor_descriptor %desc_a add_offsets = [%m, %k] pred = %p : !tt.tensordesc<32x128xf16>
+    %tok_a = amdg.async_tdm_copy_global_to_local %positioned_a into %buf_a : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_7, #smem_7, mutable>
     // CHECK: amdg.async_tdm_copy_global_to_local %{{.*}} into %[[BUF_B]]
-    %tok_b = amdg.async_tdm_copy_global_to_local %desc_b[%k, %n] into %buf_b, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared_7, #smem_7, mutable>
+    %positioned_b = amdg.update_tensor_descriptor %desc_b add_offsets = [%k, %n] pred = %p : !tt.tensordesc<128x32xf16>
+    %tok_b = amdg.async_tdm_copy_global_to_local %positioned_b into %buf_b : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared_7, #smem_7, mutable>
     // CHECK: %[[SUB_A:.*]] = ttg.memdesc_subslice %[[BUF_A]][0, 32] : !ttg.memdesc<32x128xf16, #[[$PADDED_A_SUB]], #smem, mutable> -> !ttg.memdesc<32x32xf16, #[[$PADDED_A_SUB]], #smem, mutable, 32x128>
     %sub_a = ttg.memdesc_subslice %buf_a[0, 32] : !ttg.memdesc<32x128xf16, #shared_7, #smem_7, mutable> -> !ttg.memdesc<32x32xf16, #shared_7, #smem_7, mutable, 32x128>
     // CHECK: %[[SUB_B:.*]] = ttg.memdesc_subslice %[[BUF_B]][32, 0] : !ttg.memdesc<128x32xf16, #[[$PADDED_B_SUB]], #smem, mutable> -> !ttg.memdesc<32x32xf16, #[[$PADDED_B_SUB]], #smem, mutable, 128x32>
@@ -361,9 +364,11 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %buf_a = ttg.memdesc_index %alloc_a[%c0] : !ttg.memdesc<2x32x128xf16, #shared_8, #smem_8, mutable> -> !ttg.memdesc<32x128xf16, #shared_8, #smem_8, mutable>
     // CHECK: %[[BUF_B:.*]] = ttg.memdesc_index %[[ALLOC_B]][%{{.*}}] : !ttg.memdesc<2x32x128xf16, #[[$PADDED_B_TRANS]], #smem, mutable> -> !ttg.memdesc<32x128xf16, #[[$PADDED_B_TRANS]], #smem, mutable>
     %buf_b = ttg.memdesc_index %alloc_b[%c0] : !ttg.memdesc<2x32x128xf16, #shared_8, #smem_8, mutable> -> !ttg.memdesc<32x128xf16, #shared_8, #smem_8, mutable>
-    %tok_a = amdg.async_tdm_copy_global_to_local %desc_a[%m, %k] into %buf_a, pred = %p : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_8, #smem_8, mutable>
+    %positioned_a = amdg.update_tensor_descriptor %desc_a add_offsets = [%m, %k] pred = %p : !tt.tensordesc<32x128xf16>
+    %tok_a = amdg.async_tdm_copy_global_to_local %positioned_a into %buf_a : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_8, #smem_8, mutable>
     // CHECK: amdg.async_tdm_copy_global_to_local %{{.*}} into %[[BUF_B]]
-    %tok_b = amdg.async_tdm_copy_global_to_local %desc_b[%n, %k] into %buf_b, pred = %p : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_8, #smem_8, mutable>
+    %positioned_b = amdg.update_tensor_descriptor %desc_b add_offsets = [%n, %k] pred = %p : !tt.tensordesc<32x128xf16>
+    %tok_b = amdg.async_tdm_copy_global_to_local %positioned_b into %buf_b : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_8, #smem_8, mutable>
     // CHECK: %[[SUB_A:.*]] = ttg.memdesc_subslice %[[BUF_A]][0, 64] : !ttg.memdesc<32x128xf16, #[[$PADDED_A_TRANS]], #smem, mutable> -> !ttg.memdesc<32x32xf16, #[[$PADDED_A_TRANS]], #smem, mutable, 32x128>
     %sub_a = ttg.memdesc_subslice %buf_a[0, 64] : !ttg.memdesc<32x128xf16, #shared_8, #smem_8, mutable> -> !ttg.memdesc<32x32xf16, #shared_8, #smem_8, mutable, 32x128>
     // CHECK: %[[SUB_B:.*]] = ttg.memdesc_subslice %[[BUF_B]][0, 64] : !ttg.memdesc<32x128xf16, #[[$PADDED_B_TRANS]], #smem, mutable> -> !ttg.memdesc<32x32xf16, #[[$PADDED_B_TRANS]], #smem, mutable, 32x128>
@@ -403,7 +408,8 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     // CHECK: %[[BUF:.*]] = ttg.memdesc_index %[[ALLOC]][%{{.*}}] : !ttg.memdesc<2x128x32xf16, #[[$PADDED_RESHAPE]], #smem, mutable> -> !ttg.memdesc<128x32xf16, #[[$PADDED_RESHAPE]], #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf16, #shared_9, #smem_9, mutable> -> !ttg.memdesc<128x32xf16, #shared_9, #smem_9, mutable>
     // CHECK: amdg.async_tdm_copy_global_to_local %{{.*}} into %[[BUF]]
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared_9, #smem_9, mutable>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] pred = %p : !tt.tensordesc<128x32xf16>
+    %tok = amdg.async_tdm_copy_global_to_local %positioned into %buf : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared_9, #smem_9, mutable>
     // CHECK: %[[RESHAPE:.*]] = ttg.memdesc_reshape %[[BUF]] : !ttg.memdesc<128x32xf16, #[[$PADDED_RESHAPE]], #smem, mutable> -> !ttg.memdesc<32x128xf16, #{{.*}}, #smem, mutable>
     %reshape = ttg.memdesc_reshape %buf : !ttg.memdesc<128x32xf16, #shared_9, #smem_9, mutable> -> !ttg.memdesc<32x128xf16, #shared_9, #smem_9, mutable>
     // CHECK: ttg.local_load %[[RESHAPE]] : !ttg.memdesc<32x128xf16, #{{.*}}, #smem, mutable> -> tensor<32x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>

--- a/test/TLX/insert-require-layout-tdm.mlir
+++ b/test/TLX/insert-require-layout-tdm.mlir
@@ -20,11 +20,11 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
   // CHECK-LABEL: @tdm_no_consumer
   // CHECK: tlx.require_layout {{.*}} -> !ttg.memdesc<128x32xf16, #[[$PADDED32]], #smem, mutable>
   // CHECK-NEXT: amdg.async_tdm_copy_global_to_local
-  tt.func public @tdm_no_consumer(%desc: !tt.tensordesc<128x32xf16, #shared>, %m: i32, %k: i32, %p: i32) {
+  tt.func public @tdm_no_consumer(%desc: !tt.tensordesc<128x32xf16>, %m: i32, %k: i32, %p: i32) {
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16, #shared> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -44,11 +44,11 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
   // CHECK-LABEL: @tdm_local_load_no_dot
   // CHECK: tlx.require_layout {{.*}} -> !ttg.memdesc<128x32xf16, #[[$PADDED32]], #smem, mutable>
   // CHECK-NEXT: amdg.async_tdm_copy_global_to_local
-  tt.func public @tdm_local_load_no_dot(%desc: !tt.tensordesc<128x32xf16, #shared>, %m: i32, %k: i32, %p: i32) {
+  tt.func public @tdm_local_load_no_dot(%desc: !tt.tensordesc<128x32xf16>, %m: i32, %k: i32, %p: i32) {
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16, #shared> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
     %val = ttg.local_load %buf : !ttg.memdesc<128x32xf16, #shared, #smem, mutable> -> tensor<128x32xf16, #blocked>
     tt.return
   }
@@ -67,12 +67,12 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
   // CHECK-LABEL: @tdm_already_wrapped
   // CHECK-COUNT-1: tlx.require_layout
   // CHECK-NOT: tlx.require_layout
-  tt.func public @tdm_already_wrapped(%desc: !tt.tensordesc<128x32xf16, #shared>, %m: i32, %k: i32, %p: i32) {
+  tt.func public @tdm_already_wrapped(%desc: !tt.tensordesc<128x32xf16>, %m: i32, %k: i32, %p: i32) {
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #padded, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf16, #padded, #smem, mutable> -> !ttg.memdesc<128x32xf16, #padded, #smem, mutable>
     %req = tlx.require_layout %buf : !ttg.memdesc<128x32xf16, #padded, #smem, mutable> -> !ttg.memdesc<128x32xf16, #padded, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %req, pred = %p : !tt.tensordesc<128x32xf16, #shared> -> !ttg.memdesc<128x32xf16, #padded, #smem, mutable>
+    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %req, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #padded, #smem, mutable>
     tt.return
   }
 }
@@ -93,11 +93,11 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
   // CHECK: tlx.require_layout
   // CHECK-NEXT: amdg.async_tdm_copy_global_to_local
   // CHECK-NOT: tlx.require_layout {{.*}} -> !ttg.memdesc<{{.*}}, #ttg.swizzled_shared
-  tt.func public @tdm_dot_path_skip(%desc: !tt.tensordesc<128x32xf16, #shared>, %m: i32, %k: i32, %p: i32) {
+  tt.func public @tdm_dot_path_skip(%desc: !tt.tensordesc<128x32xf16>, %m: i32, %k: i32, %p: i32) {
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16, #shared> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
     %val = ttg.local_load %buf : !ttg.memdesc<128x32xf16, #shared, #smem, mutable> -> tensor<128x32xf16, #dot0>
     tt.return
   }
@@ -116,11 +116,11 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
 module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tdm_bf16_default
   // CHECK: tlx.require_layout {{.*}} -> !ttg.memdesc<128x32xbf16, #[[$PADDED32BF16]], #smem, mutable>
-  tt.func public @tdm_bf16_default(%desc: !tt.tensordesc<128x32xbf16, #shared>, %m: i32, %k: i32, %p: i32) {
+  tt.func public @tdm_bf16_default(%desc: !tt.tensordesc<128x32xbf16>, %m: i32, %k: i32, %p: i32) {
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xbf16, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xbf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xbf16, #shared, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xbf16, #shared> -> !ttg.memdesc<128x32xbf16, #shared, #smem, mutable>
+    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xbf16> -> !ttg.memdesc<128x32xbf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -138,11 +138,11 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
 module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tdm_fp32_default
   // CHECK: tlx.require_layout {{.*}} -> !ttg.memdesc<128x32xf32, #[[$PADDED32FP32]], #smem, mutable>
-  tt.func public @tdm_fp32_default(%desc: !tt.tensordesc<128x32xf32, #shared>, %m: i32, %k: i32, %p: i32) {
+  tt.func public @tdm_fp32_default(%desc: !tt.tensordesc<128x32xf32>, %m: i32, %k: i32, %p: i32) {
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf32, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf32, #shared, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf32, #shared> -> !ttg.memdesc<128x32xf32, #shared, #smem, mutable>
+    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf32> -> !ttg.memdesc<128x32xf32, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -158,11 +158,11 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
 module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tdm_pred_preserved
   // CHECK: amdg.async_tdm_copy_global_to_local {{.*}}, pred = %arg3
-  tt.func public @tdm_pred_preserved(%desc: !tt.tensordesc<128x32xf16, #shared>, %m: i32, %k: i32, %p: i32) {
+  tt.func public @tdm_pred_preserved(%desc: !tt.tensordesc<128x32xf16>, %m: i32, %k: i32, %p: i32) {
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16, #shared> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/test/TLX/insert-require-layout-tdm.mlir
+++ b/test/TLX/insert-require-layout-tdm.mlir
@@ -24,7 +24,8 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] pred = %p : !tt.tensordesc<128x32xf16>
+    %tok = amdg.async_tdm_copy_global_to_local %positioned into %buf : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -48,7 +49,8 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] pred = %p : !tt.tensordesc<128x32xf16>
+    %tok = amdg.async_tdm_copy_global_to_local %positioned into %buf : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
     %val = ttg.local_load %buf : !ttg.memdesc<128x32xf16, #shared, #smem, mutable> -> tensor<128x32xf16, #blocked>
     tt.return
   }
@@ -72,7 +74,8 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #padded, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf16, #padded, #smem, mutable> -> !ttg.memdesc<128x32xf16, #padded, #smem, mutable>
     %req = tlx.require_layout %buf : !ttg.memdesc<128x32xf16, #padded, #smem, mutable> -> !ttg.memdesc<128x32xf16, #padded, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %req, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #padded, #smem, mutable>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] pred = %p : !tt.tensordesc<128x32xf16>
+    %tok = amdg.async_tdm_copy_global_to_local %positioned into %req : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #padded, #smem, mutable>
     tt.return
   }
 }
@@ -97,7 +100,8 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] pred = %p : !tt.tensordesc<128x32xf16>
+    %tok = amdg.async_tdm_copy_global_to_local %positioned into %buf : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
     %val = ttg.local_load %buf : !ttg.memdesc<128x32xf16, #shared, #smem, mutable> -> tensor<128x32xf16, #dot0>
     tt.return
   }
@@ -120,7 +124,8 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xbf16, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xbf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xbf16, #shared, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xbf16> -> !ttg.memdesc<128x32xbf16, #shared, #smem, mutable>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] pred = %p : !tt.tensordesc<128x32xbf16>
+    %tok = amdg.async_tdm_copy_global_to_local %positioned into %buf : !tt.tensordesc<128x32xbf16> -> !ttg.memdesc<128x32xbf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -142,14 +147,16 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf32, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf32, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf32, #shared, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf32> -> !ttg.memdesc<128x32xf32, #shared, #smem, mutable>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] pred = %p : !tt.tensordesc<128x32xf32>
+    %tok = amdg.async_tdm_copy_global_to_local %positioned into %buf : !tt.tensordesc<128x32xf32> -> !ttg.memdesc<128x32xf32, #shared, #smem, mutable>
     tt.return
   }
 }
 
 // -----
 // =============================================================================
-// 7. Pred operand is preserved when the TDM op is rewrapped.
+// 7. The descriptor update carrying the predicate is preserved when the TDM
+// op is rewrapped.
 // =============================================================================
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
@@ -157,12 +164,14 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
 
 module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @tdm_pred_preserved
-  // CHECK: amdg.async_tdm_copy_global_to_local {{.*}}, pred = %arg3
+  // CHECK: %[[POSITIONED:.*]] = amdg.update_tensor_descriptor %arg0 add_offsets = [%arg1, %arg2] pred = %arg3
+  // CHECK: amdg.async_tdm_copy_global_to_local %[[POSITIONED]] into
   tt.func public @tdm_pred_preserved(%desc: !tt.tensordesc<128x32xf16>, %m: i32, %k: i32, %p: i32) {
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] pred = %p : !tt.tensordesc<128x32xf16>
+    %tok = amdg.async_tdm_copy_global_to_local %positioned into %buf : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -186,7 +195,8 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
-    amdg.async_tdm_copy_local_to_global %desc[%m, %n] from %buf : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<128x128xf16, #shared>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %n] : !tt.tensordesc<128x128xf16, #shared>
+    amdg.async_tdm_copy_local_to_global %positioned from %buf : !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<128x128xf16, #shared>
     tt.return
   }
 }
@@ -212,7 +222,8 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<1x128x32xf16, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<1x128x32xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x32xf16, #shared, #smem, mutable>
     %val = ttg.local_load %buf : !ttg.memdesc<128x32xf16, #shared, #smem, mutable> -> tensor<128x32xf16, #dot0>
-    amdg.async_tdm_copy_local_to_global %desc[%m, %k] from %buf : !ttg.memdesc<128x32xf16, #shared, #smem, mutable> -> !tt.tensordesc<128x32xf16, #shared>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] : !tt.tensordesc<128x32xf16, #shared>
+    amdg.async_tdm_copy_local_to_global %positioned from %buf : !ttg.memdesc<128x32xf16, #shared, #smem, mutable> -> !tt.tensordesc<128x32xf16, #shared>
     tt.return
   }
 }
@@ -244,7 +255,8 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #shared, #smem, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x32x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<32x128xf16, #shared, #smem, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared, #smem, mutable>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] pred = %p : !tt.tensordesc<32x128xf16>
+    %tok = amdg.async_tdm_copy_global_to_local %positioned into %buf : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared, #smem, mutable>
     %sub = ttg.memdesc_subslice %buf[0, 0] : !ttg.memdesc<32x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x128>
     %t = ttg.local_load %sub : !ttg.memdesc<32x32xf16, #shared, #smem, mutable, 32x128> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
     tt.return %t : tensor<32x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
@@ -276,7 +288,8 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x32x128xf16, #shared_t, #smem_t, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x32x128xf16, #shared_t, #smem_t, mutable> -> !ttg.memdesc<32x128xf16, #shared_t, #smem_t, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_t, #smem_t, mutable>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] pred = %p : !tt.tensordesc<32x128xf16>
+    %tok = amdg.async_tdm_copy_global_to_local %positioned into %buf : !tt.tensordesc<32x128xf16> -> !ttg.memdesc<32x128xf16, #shared_t, #smem_t, mutable>
     %sub = ttg.memdesc_subslice %buf[0, 32] : !ttg.memdesc<32x128xf16, #shared_t, #smem_t, mutable> -> !ttg.memdesc<32x32xf16, #shared_t, #smem_t, mutable, 32x128>
     %trans = ttg.memdesc_trans %sub {order = array<i32: 1, 0>} : !ttg.memdesc<32x32xf16, #shared_t, #smem_t, mutable, 32x128> -> !ttg.memdesc<32x32xf16, #shared_t_trans, #smem_t, mutable, 128x32>
     %t = ttg.local_load %trans : !ttg.memdesc<32x32xf16, #shared_t_trans, #smem_t, mutable, 128x32> -> tensor<32x32xf16, #ttg.dot_op<{opIdx = 1, parent = #mma_t, kWidth = 8}>>
@@ -308,7 +321,8 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
     %c0 = arith.constant 0 : i32
     %alloc = ttg.local_alloc : () -> !ttg.memdesc<2x128x32xf16, #shared_r, #smem_r, mutable>
     %buf = ttg.memdesc_index %alloc[%c0] : !ttg.memdesc<2x128x32xf16, #shared_r, #smem_r, mutable> -> !ttg.memdesc<128x32xf16, #shared_r, #smem_r, mutable>
-    %tok = amdg.async_tdm_copy_global_to_local %desc[%m, %k] into %buf, pred = %p : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared_r, #smem_r, mutable>
+    %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] pred = %p : !tt.tensordesc<128x32xf16>
+    %tok = amdg.async_tdm_copy_global_to_local %positioned into %buf : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #shared_r, #smem_r, mutable>
     %reshape = ttg.memdesc_reshape %buf : !ttg.memdesc<128x32xf16, #shared_r, #smem_r, mutable> -> !ttg.memdesc<32x128xf16, #shared_r, #smem_r, mutable>
     %t = ttg.local_load %reshape : !ttg.memdesc<32x128xf16, #shared_r, #smem_r, mutable> -> tensor<32x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_r, kWidth = 8}>>
     tt.return %t : tensor<32x128xf16, #ttg.dot_op<{opIdx = 0, parent = #mma_r, kWidth = 8}>>

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -491,3 +491,54 @@ tt.func @test_combine_broadcast_mul_reduce(%arg0: tensor<32x16xf32>, %arg1: tens
     }) : (tensor<32x16x32xf32>) -> tensor<32x32xf32>
     tt.return %5 : tensor<32x32xf32>
 }
+
+// CHECK-LABEL: @test_combine_broadcast_mul_reduce_extra_broadcast
+tt.func @test_combine_broadcast_mul_reduce_extra_broadcast(%arg0: tensor<32x1xf32>, %arg1: tensor<1x32xf32>) -> tensor<32x32xf32> {
+    // CHECK-NOT: tt.dot
+    // CHECK: tt.reduce
+    %0 = tt.expand_dims %arg0 {axis = 2 : i32} : tensor<32x1xf32> -> tensor<32x1x1xf32>
+    %1 = tt.broadcast %0 : tensor<32x1x1xf32> -> tensor<32x16x32xf32>
+    %2 = tt.expand_dims %arg1 {axis = 0 : i32} : tensor<1x32xf32> -> tensor<1x1x32xf32>
+    %3 = tt.broadcast %2 : tensor<1x1x32xf32> -> tensor<32x16x32xf32>
+    %4 = arith.mulf %1, %3 : tensor<32x16x32xf32>
+    %5 = "tt.reduce"(%4) <{axis = 1 : i32}> ({
+    ^bb0(%arg2: f32, %arg3: f32):
+        %6 = arith.addf %arg2, %arg3 : f32
+        tt.reduce.return %6 : f32
+    }) : (tensor<32x16x32xf32>) -> tensor<32x32xf32>
+    tt.return %5 : tensor<32x32xf32>
+}
+
+// CHECK-LABEL: @test_combine_broadcast_mul_reduce_wrong_axis
+tt.func @test_combine_broadcast_mul_reduce_wrong_axis(%arg0: tensor<32x32xf32>, %arg1: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    // CHECK-NOT: tt.dot
+    // CHECK: tt.reduce
+    %0 = tt.expand_dims %arg0 {axis = 2 : i32} : tensor<32x32xf32> -> tensor<32x32x1xf32>
+    %1 = tt.broadcast %0 : tensor<32x32x1xf32> -> tensor<32x32x32xf32>
+    %2 = tt.expand_dims %arg1 {axis = 0 : i32} : tensor<32x32xf32> -> tensor<1x32x32xf32>
+    %3 = tt.broadcast %2 : tensor<1x32x32xf32> -> tensor<32x32x32xf32>
+    %4 = arith.mulf %1, %3 : tensor<32x32x32xf32>
+    %5 = "tt.reduce"(%4) <{axis = 0 : i32}> ({
+    ^bb0(%arg2: f32, %arg3: f32):
+        %6 = arith.addf %arg2, %arg3 : f32
+        tt.reduce.return %6 : f32
+    }) : (tensor<32x32x32xf32>) -> tensor<32x32xf32>
+    tt.return %5 : tensor<32x32xf32>
+}
+
+// CHECK-LABEL: @test_combine_broadcast_mul_reduce_higher_rank
+tt.func @test_combine_broadcast_mul_reduce_higher_rank(%arg0: tensor<32x16x4xf32>, %arg1: tensor<16x32x4xf32>) -> tensor<32x32x4xf32> {
+    // CHECK-NOT: tt.dot
+    // CHECK: tt.reduce
+    %0 = tt.expand_dims %arg0 {axis = 2 : i32} : tensor<32x16x4xf32> -> tensor<32x16x1x4xf32>
+    %1 = tt.broadcast %0 : tensor<32x16x1x4xf32> -> tensor<32x16x32x4xf32>
+    %2 = tt.expand_dims %arg1 {axis = 0 : i32} : tensor<16x32x4xf32> -> tensor<1x16x32x4xf32>
+    %3 = tt.broadcast %2 : tensor<1x16x32x4xf32> -> tensor<32x16x32x4xf32>
+    %4 = arith.mulf %1, %3 : tensor<32x16x32x4xf32>
+    %5 = "tt.reduce"(%4) <{axis = 1 : i32}> ({
+    ^bb0(%arg2: f32, %arg3: f32):
+        %6 = arith.addf %arg2, %arg3 : f32
+        tt.reduce.return %6 : f32
+    }) : (tensor<32x16x32x4xf32>) -> tensor<32x32x4xf32>
+    tt.return %5 : tensor<32x32x4xf32>
+}

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -496,7 +496,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_track_visible_writes
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
-    %1 = amdg.async_tdm_copy_global_to_local %desc[%c0_i32, %c0_i32] into %0, pred = %pred, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %1 = amdg.async_tdm_copy_global_to_local %desc into %0, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -533,7 +533,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_track_visible_writes
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
-    %0 = amdg.async_tdm_copy_global_to_local %a[%c0_i32, %c0_i32] into %a_smem, pred = %pred, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %0 = amdg.async_tdm_copy_global_to_local %a into %a_smem, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
 
     // Second TDM copy: same full instrumentation
     // CHECK: tt.call @__triton_consan_verify_write_visibility
@@ -546,7 +546,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_track_visible_writes
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
-    %1 = amdg.async_tdm_copy_global_to_local %b[%c0_i32, %c0_i32] into %b_smem, pred = %pred, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %1 = amdg.async_tdm_copy_global_to_local %b into %b_smem, barrier = %bar : !tt.tensordesc<32x32xf32>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
 
     %c0_phase = arith.constant 0 : i32
     amdg.wait_barrier %bar, %c0_phase : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -575,7 +575,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_stage_access_for_commit
     // CHECK: tt.call @__triton_consan_commit_accesses
     // CHECK-NOT: tt.call @__triton_consan_verify_barrier_arrive
-    %1 = amdg.async_tdm_copy_global_to_local %desc[%c0_i32, %c0_i32] into %0, pred = %pred : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %1 = amdg.async_tdm_copy_global_to_local %desc into %0 : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -598,7 +598,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self_noalias
     // CHECK: tt.call @__triton_consan_stage_access_for_commit
     // CHECK: tt.call @__triton_consan_commit_accesses
-    amdg.async_tdm_copy_local_to_global %desc[%c0_i32, %c0_i32] from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
+    amdg.async_tdm_copy_local_to_global %desc from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
     tt.return
   }
 }
@@ -617,11 +617,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self_noalias
     // CHECK: tt.call @__triton_consan_stage_access_for_commit
     // CHECK: tt.call @__triton_consan_commit_accesses
-    %1 = amdg.async_tdm_copy_global_to_local %in_desc[%c0_i32, %c0_i32] into %0, pred = %pred : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %1 = amdg.async_tdm_copy_global_to_local %in_desc into %0 : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self_noalias
     // CHECK: tt.call @__triton_consan_stage_access_for_commit
     // CHECK: tt.call @__triton_consan_commit_accesses
-    amdg.async_tdm_copy_local_to_global %out_desc[%c0_i32, %c0_i32] from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
+    amdg.async_tdm_copy_local_to_global %out_desc from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
     tt.return
   }
 }
@@ -648,7 +648,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_stage_access_for_commit
-    amdg.async_tdm_copy_local_to_global %desc[%c0_i32, %c0_i32] from %0, barrier = %bar : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !tt.tensordesc<32x32xf32>
+    amdg.async_tdm_copy_local_to_global %desc from %0, barrier = %bar : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !tt.tensordesc<32x32xf32>
     tt.return
   }
 }
@@ -720,7 +720,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     %c0_i32 = arith.constant 0 : i32
     %pred = arith.constant 1 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
-    %1 = amdg.async_tdm_copy_global_to_local %desc[%c0_i32, %c0_i32] into %0, pred = %pred : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %1 = amdg.async_tdm_copy_global_to_local %desc into %0 : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
     amdg.async_tdm_wait {num = 0 : i32}
     ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
@@ -738,7 +738,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
   tt.func public @tdm_store_no_barrier_wait(%desc: !tt.tensordesc<32x32xf32>) {
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
-    amdg.async_tdm_copy_local_to_global %desc[%c0_i32, %c0_i32] from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
+    amdg.async_tdm_copy_local_to_global %desc from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
     // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
     amdg.async_tdm_wait {num = 0 : i32}
     ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
@@ -757,8 +757,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     %c0_i32 = arith.constant 0 : i32
     %pred = arith.constant 1 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
-    %1 = amdg.async_tdm_copy_global_to_local %desc[%c0_i32, %c0_i32] into %0, pred = %pred : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
-    amdg.async_tdm_copy_local_to_global %desc[%c0_i32, %c0_i32] from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
+    %1 = amdg.async_tdm_copy_global_to_local %desc into %0 : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    amdg.async_tdm_copy_local_to_global %desc from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
     // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
     amdg.async_tdm_wait {num = 0 : i32}
     ttg.local_load %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>

--- a/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count-without-token.mlir
@@ -660,10 +660,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   ) {
     %c0_i32 = arith.constant 0 : i32
 
-    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0_i32, %c0_i32] into %memDesc, pred = %pred : !tt.tensordesc<64x128xf16> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
-    amdg.async_tdm_copy_local_to_global %tensorDesc[%c0_i32, %c0_i32] from %memDesc : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
-    %1 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0_i32, %c0_i32] into %memDesc, pred = %pred : !tt.tensordesc<64x128xf16> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
-    amdg.async_tdm_copy_local_to_global %tensorDesc[%c0_i32, %c0_i32] from %memDesc : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc : !tt.tensordesc<64x128xf16> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+    amdg.async_tdm_copy_local_to_global %tensorDesc from %memDesc : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    %1 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc : !tt.tensordesc<64x128xf16> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+    amdg.async_tdm_copy_local_to_global %tensorDesc from %memDesc : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
 
     // CHECK: amdg.async_tdm_intrinsic_wait {count = 0
     amdg.async_tdm_wait {num = 0 : i32}

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -411,8 +411,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
 
     // Each async_tdm_copy only emits a single instruction (-> counts 1)
-    %1 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0_i32, %c0_i32] into %memDesc, pred = %mask : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #shared, #smem, mutable>
-    %2 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0_i32, %c0_i32] into %memDesc, pred = %mask : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #shared, #smem, mutable>
+    %1 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #shared, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #shared, #smem, mutable>
 
     // Do not wait on the second tdm => waitcnt 1
     // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 1
@@ -543,12 +543,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %c0_i32 = arith.constant 0 : i32
 
     // Each async_tdm_copy only emits a single instruction (-> counts 1)
-    %1 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0_i32, %c0_i32] into %memDesc, pred = %mask : !tt.tensordesc<128x8xf16> -> !ttg.memdesc<128x8xf16, #shared, #smem, mutable>
+    %1 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc : !tt.tensordesc<128x8xf16> -> !ttg.memdesc<128x8xf16, #shared, #smem, mutable>
 
     %2 = ttg.async_copy_global_to_local %ptr, %memDesc : tensor<128x8x!tt.ptr<f16>, #blocked> -> <128x8xf16, #shared, #smem, mutable>
     %21 = ttg.async_commit_group tokens %2
 
-    %3 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0_i32, %c0_i32] into %memDesc, pred = %mask : !tt.tensordesc<128x8xf16> -> !ttg.memdesc<128x8xf16, #shared, #smem, mutable>
+    %3 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc : !tt.tensordesc<128x8xf16> -> !ttg.memdesc<128x8xf16, #shared, #smem, mutable>
 
     %4 = ttg.async_copy_global_to_local %ptr, %memDesc : tensor<128x8x!tt.ptr<f16>, #blocked> -> <128x8xf16, #shared, #smem, mutable>
     %5 = ttg.async_copy_global_to_local %ptr, %memDesc : tensor<128x8x!tt.ptr<f16>, #blocked> -> <128x8xf16, #shared, #smem, mutable>
@@ -744,8 +744,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // numLogicalPieces = numPartitions * numGroups = 2 * 4 = 8
     // warpsAlongPartition = gcd(numWarps=4, numLogicalPieces=8) = 4
     // Each async_tdm_copy emits divideCeil(8, 4) = 2 instructions
-    %1 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0_i32, %c0_i32] into %memDesc, pred = %mask : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #partitioned, #smem, mutable>
-    %2 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0_i32, %c0_i32] into %memDesc, pred = %mask : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #partitioned, #smem, mutable>
+    %1 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #partitioned, #smem, mutable>
+    %2 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #partitioned, #smem, mutable>
 
     // Skip second copy (2 instructions) => count = 2
     // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 2

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -214,7 +214,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   ) {
     %c0_i32 = arith.constant 0 : i32
     // expected-error @+1 {{TDM store padding is only supported when padding interval equals the innermost block dimension}}
-    amdg.async_tdm_copy_local_to_global %tensorDesc[%c0_i32, %c0_i32] from %memDesc: !ttg.memdesc<128x64xf16, #shared_32, #smem, mutable> -> !tt.tensordesc<128x64xf16>
+    amdg.async_tdm_copy_local_to_global %tensorDesc from %memDesc: !ttg.memdesc<128x64xf16, #shared_32, #smem, mutable> -> !tt.tensordesc<128x64xf16>
     tt.return
   }
 
@@ -224,7 +224,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   ) {
     %c0_i32 = arith.constant 0 : i32
     // expected-error @+1 {{TDM store only supports single interval paddings}}
-    amdg.async_tdm_copy_local_to_global %tensorDesc[%c0_i32, %c0_i32] from %memDesc: !ttg.memdesc<128x64xf16, #shared_2_intervals, #smem, mutable> -> !tt.tensordesc<128x64xf16>
+    amdg.async_tdm_copy_local_to_global %tensorDesc from %memDesc: !ttg.memdesc<128x64xf16, #shared_2_intervals, #smem, mutable> -> !tt.tensordesc<128x64xf16>
     tt.return
   }
 }
@@ -297,7 +297,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
   ) {
     %c0 = arith.constant 0 : i32
     // expected-error @+1 {{warp_used_hint must have at least one bit set}}
-    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0, %c0] into %memDesc, pred = %pred {warp_used_hint = 0 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc {warp_used_hint = 0 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
     tt.return
   }
 
@@ -311,7 +311,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
   ) {
     %c0 = arith.constant 0 : i32
     // expected-error @+1 {{is not axis-aligned}}
-    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0, %c0] into %memDesc, pred = %pred {warp_used_hint = 105 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc {warp_used_hint = 105 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
     tt.return
   }
 
@@ -324,7 +324,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
   ) {
     %c0 = arith.constant 0 : i32
     // expected-error @+1 {{popcount(warp_used_hint) = 3 must be a power of two}}
-    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0, %c0] into %memDesc, pred = %pred {warp_used_hint = 7 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc {warp_used_hint = 7 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
     tt.return
   }
 
@@ -337,7 +337,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
   ) {
     %c0 = arith.constant 0 : i32
     // expected-error @+1 {{warp_used_hint = 0xffff sets bits beyond num_warps = 8}}
-    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0, %c0] into %memDesc, pred = %pred {warp_used_hint = 65535 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc {warp_used_hint = 65535 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
     tt.return
   }
 
@@ -350,7 +350,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
   ) {
     %c0 = arith.constant 0 : i32
     // expected-error @+1 {{sets bits beyond num_warps = 8}}
-    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0, %c0] into %memDesc, pred = %pred {warp_used_hint = 513 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc {warp_used_hint = 513 : i32} : !tt.tensordesc<256x64xf16> -> !ttg.memdesc<256x64xf16, #shared_wb, #smem_wb, mutable>
     tt.return
   }
 }
@@ -384,7 +384,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   ) {
     %c0 = arith.constant 0 : i32
     // expected-error @+1 {{warp_used_hint with a partitioned shared encoding must select K active warps}}
-    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0, %c0] into %memDesc, pred = %pred {warp_used_hint = 3 : i32} : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #partitioned_mi, #smem_mi, mutable>
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc {warp_used_hint = 3 : i32} : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #partitioned_mi, #smem_mi, mutable>
     tt.return
   }
 }
@@ -541,12 +541,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @tdm_load_inconsistent_descriptor_layout(
     %tensorDesc: !tt.tensordesc<64x64xf16, #load_desc>,
-    %memDesc: !ttg.memdesc<64x64xf16, #load_alloc, #smem, mutable>,
-    %pred: i32
+    %memDesc: !ttg.memdesc<64x64xf16, #load_alloc, #smem, mutable>
   ) {
-    %c0_i32 = arith.constant 0 : i32
     // expected-error @+1 {{is inconsistent with the shared memory allocation layout}}
-    %token = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0_i32, %c0_i32] into %memDesc, pred = %pred : !tt.tensordesc<64x64xf16, #load_desc> -> !ttg.memdesc<64x64xf16, #load_alloc, #smem, mutable>
+    %token = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc : !tt.tensordesc<64x64xf16, #load_desc> -> !ttg.memdesc<64x64xf16, #load_alloc, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -463,3 +463,62 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return %result : !tt.tensordesc<64x64xf16, #shared>
   }
 }
+
+// -----
+
+// scatter: two padded layouts whose padding amount differs.
+#scatter_desc = #ttg.padded_shared<[64:+8] {order = [1, 0], shape = [8, 64]}>
+#scatter_alloc = #ttg.padded_shared<[64:+4] {order = [1, 0], shape = [8, 64]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @scatter_inconsistent_descriptor_layout(
+    %tensorDesc: !tt.tensordesc<8x64xf16, #scatter_desc>,
+    %memDesc: !ttg.memdesc<8x64xf16, #scatter_alloc, #smem, mutable>,
+    %row_indices: tensor<8xi32>
+  ) {
+    %c0_i32 = arith.constant 0 : i32
+    // expected-error @+1 {{is inconsistent with the shared memory allocation layout}}
+    amdg.async_tdm_scatter %tensorDesc[%row_indices, %c0_i32] from %memDesc : tensor<8xi32>, !ttg.memdesc<8x64xf16, #scatter_alloc, #smem, mutable> -> !tt.tensordesc<8x64xf16, #scatter_desc>
+    tt.return
+  }
+}
+
+// -----
+
+// gather: descriptor and allocation use different encoding kinds (padded vs
+// swizzled).
+#gather_desc = #ttg.padded_shared<[64:+8] {order = [1, 0], shape = [8, 64]}>
+#gather_alloc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @gather_inconsistent_descriptor_layout(
+    %tensorDesc: !tt.tensordesc<8x64xf16, #gather_desc>,
+    %memDesc: !ttg.memdesc<8x64xf16, #gather_alloc, #smem, mutable>,
+    %row_indices: tensor<8xi32>,
+    %pred: i32
+  ) {
+    %c0_i32 = arith.constant 0 : i32
+    // expected-error @+1 {{is inconsistent with the shared memory allocation layout}}
+    %token = amdg.async_tdm_gather %tensorDesc[%row_indices, %c0_i32] to %memDesc, pred = %pred : tensor<8xi32>, !ttg.memdesc<8x64xf16, #gather_alloc, #smem, mutable> -> !tt.tensordesc<8x64xf16, #gather_desc>
+    tt.return
+  }
+}
+
+// -----
+
+// load (global-to-local copy): two swizzled layouts whose order differs.
+#load_desc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#load_alloc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @tdm_load_inconsistent_descriptor_layout(
+    %tensorDesc: !tt.tensordesc<64x64xf16, #load_desc>,
+    %memDesc: !ttg.memdesc<64x64xf16, #load_alloc, #smem, mutable>,
+    %pred: i32
+  ) {
+    %c0_i32 = arith.constant 0 : i32
+    // expected-error @+1 {{is inconsistent with the shared memory allocation layout}}
+    %token = amdg.async_tdm_copy_global_to_local %tensorDesc[%c0_i32, %c0_i32] into %memDesc, pred = %pred : !tt.tensordesc<64x64xf16, #load_desc> -> !ttg.memdesc<64x64xf16, #load_alloc, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -458,8 +458,36 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   tt.func public @update_tensor_descriptor_no_kwargs(
     %desc: !tt.tensordesc<64x64xf16, #shared>
   ) -> !tt.tensordesc<64x64xf16, #shared> {
-    // expected-error @+1 {{must provide at least one of add_offsets, set_bounds, dest, pred, or barrier}}
+    // expected-error @+1 {{must provide at least one of add_offsets, set_bounds, or pred}}
     %result = amdg.update_tensor_descriptor %desc : !tt.tensordesc<64x64xf16, #shared>
+    tt.return %result : !tt.tensordesc<64x64xf16, #shared>
+  }
+}
+
+// -----
+
+// clamp_bounds requires add_offsets (it derives bounds from the advance).
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @clamp_bounds_requires_add_offsets(
+    %desc: !tt.tensordesc<64x64xf16, #shared>, %p: i32
+  ) -> !tt.tensordesc<64x64xf16, #shared> {
+    // expected-error @+1 {{clamp_bounds requires add_offsets}}
+    %result = amdg.update_tensor_descriptor %desc pred = %p {clamp_bounds} : !tt.tensordesc<64x64xf16, #shared>
+    tt.return %result : !tt.tensordesc<64x64xf16, #shared>
+  }
+}
+
+// -----
+
+// clamp_bounds and set_bounds are mutually exclusive (both write tensor_dim).
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @clamp_bounds_excludes_set_bounds(
+    %desc: !tt.tensordesc<64x64xf16, #shared>, %i: i32, %j: i32, %m: i32, %k: i32
+  ) -> !tt.tensordesc<64x64xf16, #shared> {
+    // expected-error @+1 {{clamp_bounds and set_bounds are mutually exclusive}}
+    %result = amdg.update_tensor_descriptor %desc add_offsets = [%i, %j] set_bounds = [%m, %k] {clamp_bounds} : !tt.tensordesc<64x64xf16, #shared>
     tt.return %result : !tt.tensordesc<64x64xf16, #shared>
   }
 }

--- a/test/TritonGPU/ops.mlir
+++ b/test/TritonGPU/ops.mlir
@@ -167,6 +167,20 @@ module attributes {"ttg.target" = "cuda:0", "ttg.num-ctas" = 1 : i32, "ttg.num-w
 
 // -----
 
+#src = #ttg.generic_linear<{register = [[1, 0], [0, 1]], lane = [[2, 0], [4, 0], [8, 0], [0, 2], [0, 4]], warp = [[16, 8], [0, 8]], block = []}>
+#dst = #ttg.generic_linear<{register = [[1]], lane = [[2], [4], [8], [0], [0]], warp = [[16], [0]], block = []}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @reshape_generic_linear_to_permutation
+  // CHECK: tt.reshape
+  tt.func @reshape_generic_linear_to_permutation(%arg: tensor<32x1xi32, #src>) {
+    %0 = tt.reshape %arg : tensor<32x1xi32, #src> -> tensor<32xi32, #dst>
+    tt.return
+  }
+}
+
+// -----
+
 #shared1d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #shared2d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory

--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -134,10 +134,13 @@ static bool encodeTDMDescriptor(TDMDescriptor *desc, int elementBitWidth,
     adjustedBlockSize[i] = (uint32_t)adjustedBlockSize64[i];
 
   // group0 (128 bits / 4 dwords) effective bit encoding:
-  // [1:0]:     pred (to be filled later)
+  // [1:0]:     pred (defaulted to 1)
   // [63:32]:   lds address (to be filled later)
   // [120:64]:  global address
   // [127:126]: type - currently always set to 0x2
+  // Default pred = 1 (matches device createTDMDescriptor) so a host descriptor
+  // used by a copy without an explicit pred update doesn't silently no-op.
+  desc->group0_0 = 1;
   desc->group0_2 = (uint32_t)(globalAddress & 0xFFFFFFFF);
   desc->group0_3 = (uint32_t)((globalAddress >> 32) & 0x7FFFFFFF) | (0x1 << 31);
 

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -784,10 +784,8 @@ def ReadBarrierPhaseOp
 
 def AsyncTDMCopyGlobalToLocalOp
     : TT_AMDGPU_Op<"async_tdm_copy_global_to_local",
-                   [AttrSizedOperandSegments,
-                    DeclareOpInterfaceMethods<TDMOpInterface>,
-                    DeclareOpInterfaceMethods<PredicatedOpInterface>,
-                    DeclareOpInterfaceMethods<MBarrierOpInterface>]> {
+                   [DeclareOpInterfaceMethods<MBarrierOpInterface>,
+                    DeclareOpInterfaceMethods<TDMOpInterface>]> {
   let summary = "Copy data based on descriptor from global memory to local "
                 "memory asynchronously";
 
@@ -795,9 +793,12 @@ def AsyncTDMCopyGlobalToLocalOp
     This operation copies data from global memory to local memory
     asynchronously. This is analogue to tt.load except the data are copied to
     local memory pointed by `result` instead of a distributed tensor. The data
-    copied depends on the global memory pointed to by `desc`. Set `pred` to
-    false will disable the copy. This operation does not support shared memory
-    swizzling.
+    copied depends on the global memory pointed to by `desc`. This operation
+    does not support shared memory swizzling.
+
+    The descriptor must be positioned beforehand by amdg.update_tensor_descriptor
+    (global offset, bounds, pred); this op applies only the per-warp distribution
+    and inherits `pred` from the descriptor.
     The operation can also take an optional 64bit LDS barrier address, in which case
     it sends an "LDS atomic arrive" to signal its completion.
 
@@ -831,8 +832,7 @@ def AsyncTDMCopyGlobalToLocalOp
 
   let arguments =
       (ins Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc,
-          Variadic<I32>:$indices,
-          Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$result, I32:$pred,
+          Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$result,
           Arg<Optional<TTG_MemDescType>, "", [MemWrite<SharedMemory>]>:$barrier,
           DefaultValuedAttr<TT_CacheModifierAttr,
                             "triton::CacheModifier::NONE">:$cache,
@@ -841,31 +841,20 @@ def AsyncTDMCopyGlobalToLocalOp
   let results = (outs TTG_AsyncToken:$token);
 
   let builders =
-      [OpBuilder<(ins "Value":$desc, "ValueRange":$indices, "Value":$result,
-                     "Value":$pred),
-                 [{
-      return build($_builder, $_state, desc, indices, result, pred,
+      [OpBuilder<(ins "Value":$desc, "Value":$result), [{
+      return build($_builder, $_state, desc, result,
                    /*barrier=*/static_cast<mlir::Value>(nullptr),
                    /*cache=*/triton::CacheModifier::NONE,
                    /*warp_used_hint=*/IntegerAttr());
     }]>,
-       OpBuilder<(ins "Value":$desc, "ValueRange":$indices, "Value":$result,
-                     "Value":$pred, "Value":$barrier),
-                 [{
-      return build($_builder, $_state, desc, indices, result, pred, barrier,
+       OpBuilder<(ins "Value":$desc, "Value":$result, "Value":$barrier), [{
+      return build($_builder, $_state, desc, result, barrier,
                    /*cache=*/triton::CacheModifier::NONE,
-                   /*warp_used_hint=*/IntegerAttr());
-    }]>,
-       OpBuilder<(ins "Value":$desc, "ValueRange":$indices, "Value":$result,
-                     "Value":$pred, "Value":$barrier,
-                     "::mlir::triton::CacheModifier":$cache),
-                 [{
-      return build($_builder, $_state, desc, indices, result, pred, barrier, cache,
                    /*warp_used_hint=*/IntegerAttr());
     }]>];
 
   let assemblyFormat = [{
-    $desc `[` $indices `]` `into` $result `,` `pred` `=` $pred (`,` `barrier` `=` $barrier^)?
+    $desc `into` $result (`,` `barrier` `=` $barrier^)?
     attr-dict `:` qualified(type($desc)) (`,` qualified(type($barrier))^)? `->` qualified(type($result))
   }];
 
@@ -878,9 +867,8 @@ def AsyncTDMCopyGlobalToLocalOp
 
 def AsyncTDMCopyLocalToGlobalOp
     : TT_AMDGPU_Op<"async_tdm_copy_local_to_global",
-                   [AttrSizedOperandSegments,
-                    DeclareOpInterfaceMethods<TDMOpInterface>,
-                    DeclareOpInterfaceMethods<MBarrierOpInterface>]> {
+                   [DeclareOpInterfaceMethods<MBarrierOpInterface>,
+                    DeclareOpInterfaceMethods<TDMOpInterface>]> {
   let summary = "Copy data based on descriptor from local memory to global "
                 "memory asynchronously";
 
@@ -890,20 +878,22 @@ def AsyncTDMCopyLocalToGlobalOp
     local memory pointed by `src` instead of a distributed tensor. The copy
     destination depends on the global memory pointed to by `desc`. This
     operation does not support shared memory padding or swizzling.
+
+    The descriptor must be positioned beforehand by
+    amdg.update_tensor_descriptor; this op applies only the per-warp distribution.
     The operation can also take an optional 64bit LDS barrier address, in which case
     it sends an "LDS atomic arrive" to signal its completion.
   }];
 
   let arguments =
       (ins Arg<TT_TensorDescType, "", [MemWrite<GlobalMemory>]>:$desc,
-          Variadic<I32>:$indices,
           Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
           Arg<Optional<TTG_MemDescType>, "", [MemWrite<SharedMemory>]>:$barrier,
           DefaultValuedAttr<TT_CacheModifierAttr,
                             "triton::CacheModifier::NONE">:$cache);
 
   let assemblyFormat = [{
-    $desc `[` $indices `]` `from` $src (`,` `barrier` `=` $barrier^)?
+    $desc `from` $src (`,` `barrier` `=` $barrier^)?
     attr-dict `:` qualified(type($src)) (`,` qualified(type($barrier))^)? `->` qualified(type($desc))
   }];
 

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -1104,14 +1104,24 @@ def UpdateTensorDescriptorOp
     |----------------|-------------|-----------------------------------------------------------------|
     | `add_offsets`  | incremental | `global_addr += sum(add_offsets[i] * stride[i] * elem_size)`    |
     | `set_bounds`   | rewrite     | `tensor_dim[i] = set_bounds[i]` (absolute)                      |
-    | `dest`         | rewrite     | `lds_addr = dest`                                               |
     | `pred`         | rewrite     | `pred = pred`                                                   |
-    | `barrier`      | rewrite     | `barrier_addr = barrier`                                        |
+    | `clamp_bounds` | derive      | `tensor_dim[i] = max(0, tensor_dim[i] - add_offsets[i])`        |
+
+    The LDS destination and the TDM barrier (mbarrier) are op-level operands
+    on the async_tdm_copy ops, not descriptor fields, so they are not settable
+    here.
 
     `add_offsets` is incremental (deltas in element units) and does not
     touch `tensor_dim` — for OOB-correct loops, set `set_bounds` once
     outside the loop (interior tiles see a loop-invariant tensor_dim
     that hoists), or set `set_bounds` per iteration when OOB must fire.
+
+    `clamp_bounds` is a unit attribute that, when present, additionally
+    shrinks `tensor_dim` by `add_offsets` so the descriptor carries the
+    OOB extent of the advanced tile. It requires `add_offsets` and is
+    mutually exclusive with `set_bounds`. It lets a descriptor derive its
+    OOB bounds from the advance without a separate `set_bounds`, and works
+    for host-built descriptors whose shape is only known at runtime.
 
     Examples:
     ```
@@ -1119,10 +1129,10 @@ def UpdateTensorDescriptorOp
     %d1 = amdg.update_tensor_descriptor %d, add_offsets=[%c0, %BLOCK_K]
             : !tt.tensordesc<64x64xf16, #shared>
 
-    // Prologue: position at first tile + wire LDS and barrier
+    // Prologue: position at first tile + set the predicate
     %d1 = amdg.update_tensor_descriptor %d,
             add_offsets=[%pid_m_off, %c0],
-            dest=%a_shared, barrier=%a_bar
+            pred=%p
             : !tt.tensordesc<64x64xf16, #shared>
 
     // Peel epilogue: install real OOB extent for the partial last tile
@@ -1132,10 +1142,7 @@ def UpdateTensorDescriptorOp
   }];
 
   let arguments = (ins TT_TensorDescType:$desc, Variadic<I32>:$add_offsets,
-      Variadic<I32>:$set_bounds,
-      Arg<Optional<TTG_MemDescType>, "", [MemWrite<SharedMemory>]>:$dest,
-      Optional<I32>:$pred,
-      Arg<Optional<TTG_MemDescType>, "", [MemWrite<SharedMemory>]>:$barrier);
+      Variadic<I32>:$set_bounds, Optional<I32>:$pred, UnitAttr:$clamp_bounds);
 
   let results = (outs TT_TensorDescType:$result);
 
@@ -1144,9 +1151,7 @@ def UpdateTensorDescriptorOp
     oilist(
         `add_offsets` `=` `[` $add_offsets `]`
       | `set_bounds` `=` `[` $set_bounds `]`
-      | `dest` `=` $dest `:` qualified(type($dest))
       | `pred` `=` $pred
-      | `barrier` `=` $barrier `:` qualified(type($barrier))
     )
     attr-dict `:` qualified(type($desc))
   }];

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -1138,14 +1138,6 @@ Type AsyncCopyLocalToGlobalOp::getPredicateOperandTypeLike() {
   return getDst().getType();
 }
 
-Value AsyncTDMCopyGlobalToLocalOp::getPredicateOperand() { return getPred(); }
-void AsyncTDMCopyGlobalToLocalOp::setPredicateOperand(Value pred) {
-  getPredMutable().assign(pred);
-}
-Type AsyncTDMCopyGlobalToLocalOp::getPredicateOperandTypeLike() {
-  return getPred().getType();
-}
-
 Value AsyncTDMGatherOp::getPredicateOperand() { return getPred(); }
 void AsyncTDMGatherOp::setPredicateOperand(Value pred) {
   getPredMutable().assign(pred);

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -960,10 +960,16 @@ LogicalResult UpdateTensorDescriptorOp::verify() {
 
   // At least one mutation parameter must be provided -- a no-op update is
   // either a user mistake or should be folded by canonicalizer.
-  if (getAddOffsets().empty() && getSetBounds().empty() && !getDest() &&
-      !getPred() && !getBarrier())
+  if (getAddOffsets().empty() && getSetBounds().empty() && !getPred())
     return emitOpError("must provide at least one of add_offsets, set_bounds, "
-                       "dest, pred, or barrier");
+                       "or pred");
+
+  if (getClampBounds()) {
+    if (getAddOffsets().empty())
+      return emitOpError("clamp_bounds requires add_offsets");
+    if (!getSetBounds().empty())
+      return emitOpError("clamp_bounds and set_bounds are mutually exclusive");
+  }
 
   return success();
 }

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -29,6 +29,7 @@
 #include "triton/Dialect/Triton/IR/Interfaces.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/LayoutUtils.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -106,6 +107,67 @@ LogicalResult verifyTDMBlockSize(Operation *op, ArrayRef<int64_t> blockShape) {
              << maxBlockSize;
     }
   }
+  return success();
+}
+
+// Verify the descriptor and allocation carry a consistent TDM shared layout
+LogicalResult verifyTDMLayoutConsistency(Operation *op,
+                                         triton::TensorDescType descTy,
+                                         gpu::MemDescType smemTy) {
+  Attribute descLayout = descTy.getSharedLayout();
+  if (!descLayout)
+    return success();
+  Attribute allocLayout = smemTy.getEncoding();
+  auto descPartitioned =
+      llvm::dyn_cast<gpu::PartitionedSharedEncodingAttr>(descLayout);
+  auto allocPartitioned =
+      llvm::dyn_cast<gpu::PartitionedSharedEncodingAttr>(allocLayout);
+  Attribute effectiveAllocLayout = allocLayout;
+  if (!descPartitioned && allocPartitioned)
+    effectiveAllocLayout = allocPartitioned.getPartitionLayout();
+
+  bool compatible =
+      descLayout == allocLayout || (!descPartitioned && allocPartitioned &&
+                                    descLayout == effectiveAllocLayout);
+  // Padded layouts bake in the tile shape, so compare the physical padding
+  // only.
+  auto descPad = llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(descLayout);
+  auto allocPad =
+      llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(effectiveAllocLayout);
+  if (descPad && allocPad)
+    compatible = descPad.getIntervals() == allocPad.getIntervals() &&
+                 descPad.getPaddings() == allocPad.getPaddings();
+
+  if (!compatible && descTy.getShape() != smemTy.getShape() &&
+      llvm::isa<gpu::SwizzledSharedEncodingAttr>(descLayout)) {
+    auto descEncoding = llvm::cast<gpu::SharedEncodingTrait>(descLayout);
+    auto smemTensorTy = RankedTensorType::get(
+        smemTy.getShape(), smemTy.getElementType(), effectiveAllocLayout);
+    compatible = gpu::updateEncodingForShape(op, descEncoding, smemTensorTy) ==
+                 effectiveAllocLayout;
+  }
+
+  if (!compatible)
+    return op->emitOpError("shared layout of the tensor descriptor (")
+           << descLayout
+           << ") is inconsistent with the shared memory allocation layout ("
+           << allocLayout
+           << "); TDM uses a single shared layout so they must match";
+  return success();
+}
+
+// Verify the TDM layout constraints common to all TDM ops
+LogicalResult verifyTDMCommonLayout(Operation *op,
+                                    triton::TensorDescType descTy,
+                                    gpu::MemDescType smemTy) {
+  if (failed(verifyTDMBlockSize(op, descTy.getShape())))
+    return failure();
+
+  auto swizzledEnc =
+      llvm::dyn_cast<gpu::SwizzledSharedEncodingAttr>(smemTy.getEncoding());
+  if (swizzledEnc && swizzledEnc.getMaxPhase() != 1)
+    return op->emitOpError("TDM does not support swizzling");
+
   return success();
 }
 
@@ -658,29 +720,15 @@ LogicalResult AsyncTDMCopyGlobalToLocalOp::verify() {
   auto tensorDescTy = getDesc().getType();
   auto smemTy = getResult().getType();
 
-  // Check that every dimension of the block shape is <= 2^16
-  auto blockShape = tensorDescTy.getShape();
-  auto verifyResult = verifyTDMBlockSize(getOperation(), blockShape);
-  if (failed(verifyResult))
-    return verifyResult;
+  if (failed(verifyTDMCommonLayout(getOperation(), tensorDescTy, smemTy)))
+    return failure();
 
-  // NOTE: no strict `descriptor sharedLayout == smem encoding` check here.
-  // beta derives the destination encoding from the descriptor via
-  // updateEncodingForShape (order/shape/CGA are rebuilt for the result tensor),
-  // so the two are compatible-by-construction but not attribute-equal. Upstream
-  // reconciles them with alignTDMDescriptorEncodings, which is not yet ported;
-  // the interval/padding check below is the guard until it is.
-  auto swizzledEnc =
-      llvm::dyn_cast<gpu::SwizzledSharedEncodingAttr>(smemTy.getEncoding());
-  if (swizzledEnc && swizzledEnc.getMaxPhase() != 1)
-    return emitOpError("TDM does not support swizzling");
-
-  auto paddedEnc =
-      llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(smemTy.getEncoding());
+  auto enc = smemTy.getEncoding();
+  auto paddedEnc = llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(enc);
+  auto swizzledEnc = llvm::dyn_cast<gpu::SwizzledSharedEncodingAttr>(enc);
 
   // Check for PartitionedSharedEncodingAttr and validate its inner layout
-  auto partitionedEnc =
-      llvm::dyn_cast<gpu::PartitionedSharedEncodingAttr>(smemTy.getEncoding());
+  auto partitionedEnc = llvm::dyn_cast<gpu::PartitionedSharedEncodingAttr>(enc);
   if (partitionedEnc) {
     auto partitionLayout = partitionedEnc.getPartitionLayout();
     auto innerSwizzled =
@@ -702,14 +750,6 @@ LogicalResult AsyncTDMCopyGlobalToLocalOp::verify() {
   Type elementType = smemTy.getElementType();
   auto elementBitWidth = elementType.getIntOrFloatBitWidth();
   if (paddedEnc) {
-    auto descPaddedEnc = llvm::dyn_cast_or_null<gpu::PaddedSharedEncodingAttr>(
-        tensorDescTy.getSharedLayout());
-    if (descPaddedEnc &&
-        descPaddedEnc.getIntervals() != paddedEnc.getIntervals() &&
-        descPaddedEnc.getPaddings() != paddedEnc.getPaddings()) {
-      return emitOpError(
-          "Interval/Padding mismatch between descriptor and allocation");
-    }
     unsigned dwordSize = 32;
     for (auto [interval, padding] :
          llvm::zip(paddedEnc.getIntervals(), paddedEnc.getPaddings())) {
@@ -748,7 +788,7 @@ LogicalResult AsyncTDMCopyGlobalToLocalOp::verify() {
     }
   }
 
-  return success();
+  return verifyTDMLayoutConsistency(getOperation(), tensorDescTy, smemTy);
 }
 
 // -- AsyncCopyLocalToGlobalOp --
@@ -765,22 +805,15 @@ LogicalResult AsyncTDMCopyLocalToGlobalOp::verify() {
   auto tensorDescTy = getDesc().getType();
   auto smemTy = getSrc().getType();
 
-  // Check that every dimension of the block shape is <= 2^16
+  if (failed(verifyTDMCommonLayout(getOperation(), tensorDescTy, smemTy)))
+    return failure();
+
+  auto enc = smemTy.getEncoding();
+  auto paddedEnc = llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(enc);
+  if (!paddedEnc && !llvm::isa<gpu::SwizzledSharedEncodingAttr>(enc))
+    return emitOpError("Invalid shared memory layout for TDM");
+
   auto blockShape = tensorDescTy.getShape();
-  auto verifyResult = verifyTDMBlockSize(getOperation(), blockShape);
-  if (failed(verifyResult))
-    return verifyResult;
-
-  // NOTE: no strict `descriptor sharedLayout == smem encoding` check here — see
-  // AsyncTDMCopyGlobalToLocalOp::verify (alignTDMDescriptorEncodings not
-  // ported).
-  auto swizzledEnc =
-      llvm::dyn_cast<gpu::SwizzledSharedEncodingAttr>(smemTy.getEncoding());
-  if (swizzledEnc && swizzledEnc.getMaxPhase() != 1)
-    return emitOpError("TDM does not support swizzling");
-
-  auto paddedEnc =
-      llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(smemTy.getEncoding());
   if (paddedEnc) {
     // Check if we can apply the padding workaround, see the lowering to LLVM
     // for more details.
@@ -797,10 +830,7 @@ LogicalResult AsyncTDMCopyLocalToGlobalOp::verify() {
              << ")";
   }
 
-  if (!paddedEnc && !swizzledEnc)
-    return emitOpError("Invalid shared memory layout for TDM");
-
-  return success();
+  return verifyTDMLayoutConsistency(getOperation(), tensorDescTy, smemTy);
 }
 
 LogicalResult AsyncTDMScatterOp::verify() {
@@ -813,10 +843,13 @@ LogicalResult AsyncTDMScatterOp::verify() {
     return emitOpError("TDM scatter only supports 2D tensors, got ")
            << blockShape.size() << "D";
 
-  // Check that every dimension of the block shape is <= 2^16
-  auto verifyResult = verifyTDMBlockSize(getOperation(), blockShape);
-  if (failed(verifyResult))
-    return verifyResult;
+  if (failed(verifyTDMCommonLayout(getOperation(), tensorDescTy, smemTy)))
+    return failure();
+
+  auto enc = smemTy.getEncoding();
+  if (!llvm::isa<gpu::PaddedSharedEncodingAttr>(enc) &&
+      !llvm::isa<gpu::SwizzledSharedEncodingAttr>(enc))
+    return emitOpError("Invalid shared memory layout for TDM");
 
   auto dstRowIndicesType = cast<RankedTensorType>(getDstRowIndices().getType());
   if (dstRowIndicesType.getRank() != 1)
@@ -830,14 +863,7 @@ LogicalResult AsyncTDMScatterOp::verify() {
     return emitOpError("dst_row_indices size must be a power of 2, got ")
            << numIndices;
 
-  auto swizzledEnc =
-      llvm::dyn_cast<gpu::SwizzledSharedEncodingAttr>(smemTy.getEncoding());
-  if (swizzledEnc && swizzledEnc.getMaxPhase() != 1)
-    return emitOpError("TDM does not support swizzling");
-
-  auto paddedEnc =
-      llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(smemTy.getEncoding());
-  if (paddedEnc) {
+  if (auto paddedEnc = llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(enc)) {
     // Check if we can apply the padding workaround, see the lowering to LLVM
     // for more details.
     auto intervals = paddedEnc.getIntervals();
@@ -852,10 +878,7 @@ LogicalResult AsyncTDMScatterOp::verify() {
              << ")";
   }
 
-  if (!paddedEnc && !swizzledEnc)
-    return emitOpError("Invalid shared memory layout for TDM");
-
-  return success();
+  return verifyTDMLayoutConsistency(getOperation(), tensorDescTy, smemTy);
 }
 
 LogicalResult AsyncTDMGatherOp::verify() {
@@ -868,10 +891,13 @@ LogicalResult AsyncTDMGatherOp::verify() {
     return emitOpError("TDM gather only supports 2D tensors, got ")
            << blockShape.size() << "D";
 
-  // Check that every dimension of the block shape is <= 2^16
-  auto verifyResult = verifyTDMBlockSize(getOperation(), blockShape);
-  if (failed(verifyResult))
-    return verifyResult;
+  if (failed(verifyTDMCommonLayout(getOperation(), tensorDescTy, smemTy)))
+    return failure();
+
+  auto enc = smemTy.getEncoding();
+  if (!llvm::isa<gpu::PaddedSharedEncodingAttr>(enc) &&
+      !llvm::isa<gpu::SwizzledSharedEncodingAttr>(enc))
+    return emitOpError("Invalid shared memory layout for TDM");
 
   auto srcRowIndicesType = cast<RankedTensorType>(getSrcRowIndices().getType());
   if (srcRowIndicesType.getRank() != 1)
@@ -885,20 +911,11 @@ LogicalResult AsyncTDMGatherOp::verify() {
     return emitOpError("src_row_indices size must be a power of 2, got ")
            << numIndices;
 
-  auto swizzledEnc =
-      llvm::dyn_cast<gpu::SwizzledSharedEncodingAttr>(smemTy.getEncoding());
-  if (swizzledEnc && swizzledEnc.getMaxPhase() != 1)
-    return emitOpError("TDM does not support swizzling");
-
-  auto paddedEnc =
-      llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(smemTy.getEncoding());
-  if (paddedEnc && !(paddedEnc.getIntervals().size() == 1 &&
+  if (auto paddedEnc = llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(enc);
+      paddedEnc && !(paddedEnc.getIntervals().size() == 1 &&
                      paddedEnc.getPaddings().size() == 1))
     return emitOpError(
         "TDM gather does not support multiple interval-padding pairs");
-
-  if (!paddedEnc && !swizzledEnc)
-    return emitOpError("Invalid shared memory layout for TDM");
 
   auto shapePerCTA = triton::gpu::getShapePerCTA(smemTy);
   auto sharedOrder = triton::gpu::getOrder(
@@ -923,7 +940,7 @@ LogicalResult AsyncTDMGatherOp::verify() {
           "to broadcast the same indices to all lanes in a warp.");
   }
 
-  return success();
+  return verifyTDMLayoutConsistency(getOperation(), tensorDescTy, smemTy);
 }
 
 // -- UpdateTensorDescriptorOp --

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -528,6 +528,18 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
       if (requiresSrcPtrSwizzling)
         ldsAddr = b.gep(ptrTy, vecTy, ldsAddr, swizzleLaneOffset);
     }
+
+    // For architectures supporting scattering to LDS we mask without a branch
+    // so we also mask the local writes by selecting OOB LDS address to avoid
+    // adding a branch just for other writes
+    if (targetInfo.supportsDirectToLdsScatter()) {
+      auto invMask = b.icmp_ne(mask, b.true_val());
+      ldsAddr = selectLdsAddressForPredicate(b, invMask, shmemAddr);
+      // Set the mask to false since we mask via the LDS address. False mask
+      // means that others values are written to LDS, see icmp_ne below
+      mask = b.false_val();
+    }
+
     llStore(rewriter, loc, ldsAddr, storeVal, b.icmp_ne(mask, b.true_val()),
             CacheModifier::NONE, targetInfo.requiresAliasInfoForAsyncOps());
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1306,7 +1306,9 @@ struct AsyncTDMCopyGlobalToLocalOpConversion
         loc, adaptor.getResult(), elementType, rewriter);
     // Get all base pointers (multiple for partitioned encoding)
     SmallVector<Value> dstPtrs = llvm::to_vector(dstMemObj.getBases());
-    SmallVector<Value> offset = adaptor.getIndices();
+    // Positioning lives in the descriptor; the copy only does per-warp
+    // distribution, so the user offset is zero.
+    SmallVector<Value> offset(blockShape.size(), b.i32_val(0));
     int numWarps = triton::gpu::lookupNumWarps(op);
 
     Value barrierPtr = nullptr;
@@ -1331,11 +1333,13 @@ struct AsyncTDMCopyGlobalToLocalOpConversion
     auto auxBits = mlir::LLVM::AMD::getCtrlBitsForCacheModifierOnTarget(
         cacheMod, /*isLoad*/ true, targetInfo);
 
+    // Placeholder: the copy inherits pred from the descriptor.
+    Value pred = b.i32_val(1);
     mlir::LLVM::AMD::emitTDMLoadStore(
         rewriter, loc, getTypeConverter(), desc, shapePerCTA, numWarps,
-        padInterval, padAmount, offset, dstPtrs, op.getPred(), multicastMask,
+        padInterval, padAmount, offset, dstPtrs, pred, multicastMask,
         elementType, barrierPtr, /*isLoad=*/true, sharedLayout, encoding, ctaId,
-        auxBits, warpUsedHint);
+        auxBits, warpUsedHint, /*isPureForm=*/true);
 
     rewriter.eraseOp(op);
     return success();
@@ -1378,7 +1382,9 @@ struct AsyncTDMCopyLocalToGlobalOpConversion
         loc, adaptor.getSrc(), elementType, rewriter);
     // Get all base pointers (multiple for partitioned encoding)
     SmallVector<Value> srcPtrs = llvm::to_vector(dstMemObj.getBases());
-    SmallVector<Value> offset = adaptor.getIndices();
+    // Positioning lives in the descriptor; the copy only does per-warp
+    // distribution, so the user offset is zero.
+    SmallVector<Value> offset(blockShape.size(), b.i32_val(0));
     int numWarps = triton::gpu::lookupNumWarps(op);
 
     Value barrierPtr = nullptr;
@@ -1412,12 +1418,14 @@ struct AsyncTDMCopyLocalToGlobalOpConversion
     auto auxBits = mlir::LLVM::AMD::getCtrlBitsForCacheModifierOnTarget(
         cacheMod, /*isLoad*/ false, targetInfo);
 
+    // Placeholder: the copy inherits pred from the descriptor.
     Value pred = arith::ConstantIntOp::create(rewriter, loc, 1, 32);
     mlir::LLVM::AMD::emitTDMLoadStore(
         rewriter, loc, getTypeConverter(), desc, shapePerCTA, numWarps,
         padInterval, padAmount, offset, srcPtrs, pred,
         /*multicastMask=*/{}, elementType, barrierPtr,
-        /*isLoad=*/false, sharedLayout, encoding, ctaId, auxBits);
+        /*isLoad=*/false, sharedLayout, encoding, ctaId, auxBits,
+        /*warpUsedHint=*/std::nullopt, /*isPureForm=*/true);
 
     rewriter.eraseOp(op);
     return success();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -517,6 +517,9 @@ SmallVector<Value> createTDMDescriptor(RewriterBase &rewriter, Location loc,
   auto v4i32Ty = VectorType::get(4, i32_ty);
   auto v8i32Ty = VectorType::get(8, i32_ty);
   Value group0 = LLVM::ZeroOp::create(rewriter, loc, v4i32Ty);
+  // Default pred = 1 so a descriptor that is never given an explicit pred still
+  // loads/stores instead of silently no-op'ing (copies inherit group0[0]).
+  group0 = vecSet(b, group0, 0, b.i32_val(1));
   Value globalAddr = b.ptrtoint(i64_ty, srcPtr);
   group0 = vecSet(b, group0, 2, b.trunc(i32_ty, globalAddr));
   Value g0_3 = b.trunc(i32_ty, b.lshr(globalAddr, v32));
@@ -750,7 +753,7 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
                        Value barrierPtr,
                        const triton::LinearLayout &sharedLayout, Value ctaId,
                        bool isStore, ArrayRef<unsigned> warpsPerCTA,
-                       std::optional<uint32_t> warpUsedHint) {
+                       std::optional<uint32_t> warpUsedHint, bool isPureForm) {
   size_t numDims = offset.size();
   assert(numDims >= 1 && numDims <= 5 && "TDM supports 1D to 5D tensors.");
   assert(!dstPtrs.empty() && "dstPtrs cannot be empty");
@@ -892,6 +895,11 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
   Value globalAddr = b.ptrtoint(i64_ty, srcPtr);
   Value ldsAddr = b.ptrtoint(i32_ty, dstPtr);
 
+  // Pure form inherits pred from the descriptor (group0[0]); the per-warp
+  // active mask below still applies.
+  if (isPureForm)
+    pred = vecGet(b, groups[0], 0);
+
   // Predicate off redundant warps: `((warpId ^ i0) & warpFreeMask) == 0`.
   // `warpFreeMask` covers positions NOT in basisBits (or, without a hint,
   // bits above log2(K)).
@@ -936,7 +944,9 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
     g1_1 =
         b.or_(g1_1, b.and_(b.lshr(b.ptrtoint(i32_ty, barrierPtr), b.i32_val(3)),
                            b.i32_val(0x00FFFF)));
-  } else {
+  } else if (!isPureForm) {
+    // Clear the barrier-enable bit when no barrier is supplied; pure form
+    // inherits the descriptor's barrier state.
     g1_0 = b.and_(g1_0, b.i32_val(0xFFFBFFFF));
   }
   group1 = vecSet(b, group1, 0, g1_0);
@@ -1202,7 +1212,8 @@ void emitTDMIntrinsic(RewriterBase &rewriter, Location loc,
                       const triton::LinearLayout &instrSharedLayout,
                       Value ctaId, bool isLoad, ArrayRef<unsigned> warpsPerCTA,
                       int32_t auxBits,
-                      std::optional<uint32_t> warpUsedHint = std::nullopt) {
+                      std::optional<uint32_t> warpUsedHint = std::nullopt,
+                      bool isPureForm = false) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   auto v4i32Ty = VectorType::get(4, rewriter.getI32Type());
   auto v8i32Ty = VectorType::get(8, rewriter.getI32Type());
@@ -1212,7 +1223,7 @@ void emitTDMIntrinsic(RewriterBase &rewriter, Location loc,
                     effectiveBlockShape, numWarps, padInterval, padAmount,
                     groups, globalOffset, instrDstPtrs, pred, multicastMask,
                     barrier, instrSharedLayout, ctaId, !isLoad, warpsPerCTA,
-                    warpUsedHint);
+                    warpUsedHint, isPureForm);
 
   // Pad to 4 vector groups (intrinsic always takes 4 group operands).
   while (groups.size() < 4)
@@ -1243,7 +1254,7 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
                       Value barrierPtr, bool isLoad,
                       const triton::LinearLayout &sharedLayout,
                       Attribute encoding, Value ctaId, int32_t auxBits,
-                      std::optional<uint32_t> warpUsedHint) {
+                      std::optional<uint32_t> warpUsedHint, bool isPureForm) {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   size_t numDims = blockShape.size();
   assert(numDims <= 5);
@@ -1268,7 +1279,7 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
                      to_vector(blockShape), numWarps, padInterval, padAmount,
                      to_vector(offset), dstPtrs, pred, multicastMask,
                      barrierPtr, sharedLayout, ctaId, isLoad, warpsPerCTA,
-                     auxBits, warpUsedHint);
+                     auxBits, warpUsedHint, isPureForm);
     return;
   }
 
@@ -1332,7 +1343,8 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
     emitTDMIntrinsic(rewriter, loc, typeConverter, desc, numDims, elementType,
                      effectiveBlockShape, numWarps, padInterval, padAmount,
                      globalOffset, instrDstPtrs, pred, multicastMask, barrier,
-                     sliceLayout, ctaId, isLoad, warpsPerCTA, auxBits);
+                     sliceLayout, ctaId, isLoad, warpsPerCTA, auxBits,
+                     warpUsedHint, isPureForm);
   }
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -212,19 +212,147 @@ SmallVector<Value> scalarizeTDMDescriptor(RewriterBase &rewriter, Location loc,
   return scalars;
 }
 
+// Shrink a tensor_dim by a signed offset, clamping a backward/over-advance to
+// 0:  result = (off < 0) ? 0 : max(0, cur - off).  A negative offset yields a
+// zero extent.  Shared by fillTDMDescriptor / fillTDMDescriptorForGatherScatter
+// (implicit per-tile bounds) and updateTensorDescriptor's clamp_bounds so all
+// paths derive the OOB extent identically.
+//
+// Written in this specific shape (smax + sign select) to avoid suboptimal
+// codegen: LLVM InstCombine can otherwise fold the clamp into VALU-only
+// patterns, forcing extra v_readfirstlane_b32 copies back to SGPR.
+static Value clampTensorDimByOffset(TritonLLVMOpBuilder &b, Value cur,
+                                    Value off) {
+  Value zero = b.i32_val(0);
+  Value clamped = b.smax(b.sub(cur, off), zero);
+  return b.select(b.icmp_slt(off, zero), zero, clamped);
+}
+
+// Decode just the per-dim strides (i64; innermost == 1) from a TDM descriptor.
+// Split out of decodeTDMDescriptorFull so the add_offsets path can advance
+// global_addr without also decoding the base pointer and tensor shapes it would
+// discard.  `groups` is 2 (1D-2D) or 4 (3D-5D) entries.
+static SmallVector<Value> decodeTDMStrides(RewriterBase &rewriter, Location loc,
+                                           ArrayRef<Value> groups,
+                                           size_t numDims) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  SmallVector<Value> tensorStride(numDims);
+  // Combine a 32-bit low part and a 16-bit high part into a 48-bit i64.
+  auto combine48 = [&](Value lo32, Value hi16InDword) -> Value {
+    Value hi16 = b.and_(hi16InDword, b.i32_val(0xFFFF));
+    return b.or_(b.zext(i64_ty, lo32),
+                 b.shl(b.zext(i64_ty, hi16), b.i64_val(32)));
+  };
+  if (numDims >= 2) {
+    // tensor_dim0_stride: group1[5][0:32] | group1[6][0:16]
+    tensorStride[numDims - 2] =
+        combine48(vecGet(b, groups[1], 5), vecGet(b, groups[1], 6));
+  }
+  if (numDims >= 3) {
+    // tensor_dim1_stride: group1[6][16:32] | group1[7][0:32]
+    Value stride1Low = b.and_(b.lshr(vecGet(b, groups[1], 6), b.i32_val(16)),
+                              b.i32_val(0xFFFF));
+    Value stride1High = vecGet(b, groups[1], 7);
+    tensorStride[numDims - 3] =
+        b.or_(b.zext(i64_ty, stride1Low),
+              b.shl(b.zext(i64_ty, stride1High), b.i64_val(16)));
+  }
+  if (numDims >= 4) {
+    // tensor_dim2_stride: group2[2][0:32] | group2[3][0:16]
+    tensorStride[numDims - 4] =
+        combine48(vecGet(b, groups[2], 2), vecGet(b, groups[2], 3));
+  }
+  if (numDims == 5) {
+    // tensor_dim3_stride: group3[0][0:32] | group3[1][0:16]
+    tensorStride[numDims - 5] =
+        combine48(vecGet(b, groups[3], 0), vecGet(b, groups[3], 1));
+  }
+  // The innermost dimension always has stride 1.
+  tensorStride[numDims - 1] = b.i64_val(1);
+  return tensorStride;
+}
+
 void updateTensorDescriptor(RewriterBase &rewriter, Location loc,
                             Type elementType, ArrayRef<int64_t> blockShape,
-                            Value &group0, Value &group1,
+                            MutableArrayRef<Value> groups,
                             ArrayRef<Value> addOffsets,
-                            ArrayRef<Value> setBounds, Value dest, Value pred,
-                            Value barrier) {
+                            ArrayRef<Value> setBounds, Value pred,
+                            bool clampBounds) {
   size_t numDims = blockShape.size();
-  assert(numDims == 2 && "updateTensorDescriptor currently supports 2D");
+  assert(numDims >= 1 && numDims <= 5 && "TDM supports 1D to 5D tensors.");
+  assert((numDims <= 2 ? groups.size() == 2 : groups.size() == 4) &&
+         "groups must hold 2 (1D-2D) or 4 (3D-5D) vector entries");
 
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value v16 = b.i32_val(16);
+  Value &group0 = groups[0];
+  Value &group1 = groups[1];
 
-  // ---- add_offsets: bump global_addr ----
+  // Write a 32-bit value split across two adjacent dwords of `group`:
+  //   value<15:0>  -> group[loDword]<31:16>
+  //   value<31:16> -> group[hiDword]<15:0>   (other halves preserved)
+  auto stampSplit = [&](Value &group, int loDword, int hiDword, Value value) {
+    Value loHi = b.shl(b.and_(value, b.i32_val(0xFFFF)), v16);
+    Value gLo =
+        b.or_(b.and_(vecGet(b, group, loDword), b.i32_val(0x0000FFFF)), loHi);
+    group = vecSet(b, group, loDword, gLo);
+    Value hiLo = b.and_(b.lshr(value, v16), b.i32_val(0xFFFF));
+    Value gHi =
+        b.or_(b.and_(vecGet(b, group, hiDword), b.i32_val(0xFFFF0000)), hiLo);
+    group = vecSet(b, group, hiDword, gHi);
+  };
+  auto decodeSplit = [&](Value &group, int loDword, int hiDword) -> Value {
+    Value lo =
+        b.and_(b.lshr(vecGet(b, group, loDword), v16), b.i32_val(0xFFFF));
+    Value hi = b.shl(b.and_(vecGet(b, group, hiDword), b.i32_val(0xFFFF)), v16);
+    return b.or_(lo, hi);
+  };
+
+  // tensor_dim for *descriptor* dim j (0 = innermost .. 4 = outermost):
+  //   j=0: group1[1]<31:16> | group1[2]<15:0>
+  //   j=1: group1[2]<31:16> | group1[3]<15:0>
+  //   j=2: group2[0] (full 32 bits)
+  //   j=3: group2[1] (full 32 bits)
+  //   j=4: group3[1]<31:16> | group3[2]<15:0>
+  auto stampTensorDim = [&](unsigned j, Value value) {
+    switch (j) {
+    case 0:
+      stampSplit(group1, 1, 2, value);
+      break;
+    case 1:
+      stampSplit(group1, 2, 3, value);
+      break;
+    case 2:
+      groups[2] = vecSet(b, groups[2], 0, value);
+      break;
+    case 3:
+      groups[2] = vecSet(b, groups[2], 1, value);
+      break;
+    case 4:
+      stampSplit(groups[3], 1, 2, value);
+      break;
+    default:
+      llvm_unreachable("TDM tensor_dim has at most 5 dimensions");
+    }
+  };
+  auto decodeTensorDim = [&](unsigned j) -> Value {
+    switch (j) {
+    case 0:
+      return decodeSplit(group1, 1, 2);
+    case 1:
+      return decodeSplit(group1, 2, 3);
+    case 2:
+      return vecGet(b, groups[2], 0);
+    case 3:
+      return vecGet(b, groups[2], 1);
+    case 4:
+      return decodeSplit(groups[3], 1, 2);
+    default:
+      llvm_unreachable("TDM tensor_dim has at most 5 dimensions");
+    }
+  };
+
+  // ---- add_offsets: bump global_addr by sum(offset[i]*stride[i])*elem ----
   if (!addOffsets.empty()) {
     auto elementBitWidth = elementType.getIntOrFloatBitWidth();
     Value elemSize = b.i64_val(elementBitWidth / 8);
@@ -235,20 +363,16 @@ void updateTensorDescriptor(RewriterBase &rewriter, Location loc,
     Value addr = b.or_(b.zext(i64_ty, addrLo),
                        b.shl(b.zext(i64_ty, addrHi), b.i64_val(32)));
 
-    // Byte delta:
-    //   addOffsets[1] (innermost, stride 1) +
-    //   addOffsets[0] * tensor_dim0_stride (from group1[5]),
-    // all scaled by element size.  Promote to i64 before the multiply so
-    // addOffsets[0] * stride0 doesn't overflow i32 for large tensors.
-    // Offsets are signed (advancing backward is allowed) so sext; stride is
-    // unsigned so zext.
-    Value stride0 = vecGet(b, group1, 5);
-    Value off0_64 = b.sext(i64_ty, addOffsets[0]);
-    Value off1_64 = b.sext(i64_ty, addOffsets[1]);
-    Value stride0_64 = b.zext(i64_ty, stride0);
-    Value deltaElem = b.add(off1_64, b.mul(off0_64, stride0_64));
-    Value byteDelta = b.mul(deltaElem, elemSize);
-    addr = b.add(addr, byteDelta);
+    // Per-dim strides (i64; innermost == 1) come from the descriptor.  Offsets
+    // are sign-extended; accumulate in i64 so offset*stride doesn't overflow
+    // i32 for large tensors.
+    SmallVector<Value> tensorStride =
+        decodeTDMStrides(rewriter, loc, groups, numDims);
+    Value deltaElem = b.i64_val(0);
+    for (size_t i = 0; i < numDims; ++i)
+      deltaElem = b.add(deltaElem,
+                        b.mul(b.sext(i64_ty, addOffsets[i]), tensorStride[i]));
+    addr = b.add(addr, b.mul(deltaElem, elemSize));
 
     // Re-pack, restoring the valid bit in group0[3] bit 31.
     Value newLo = b.trunc(i32_ty, addr);
@@ -258,32 +382,27 @@ void updateTensorDescriptor(RewriterBase &rewriter, Location loc,
     group0 = vecSet(b, group0, 3, newHi);
   }
 
-  // ---- set_bounds: absolute rewrite of tensor_dim ----
-  // tensor_dim_inner (setBounds[1] for 2D) spans
-  //   group1[1] hi-16 | group1[2] lo-16
-  // tensor_dim_outer (setBounds[0]) spans
-  //   group1[2] hi-16 | group1[3] lo-16
+  // Map a Triton dim index i (0 = outermost) to the descriptor dim index
+  // (0 = innermost): descriptorDim = numDims - 1 - i.
+  auto descDim = [&](size_t i) { return numDims - 1 - i; };
+
+  // ---- set_bounds: absolute rewrite of tensor_dim, per dim ----
   if (!setBounds.empty()) {
-    auto stampDim = [&](int loDword, int hiDword, Value newDim) {
-      // loDword: keep lo-16, replace hi-16 with (newDim & 0xFFFF) << 16
-      Value loHi = b.shl(b.and_(newDim, b.i32_val(0xFFFF)), v16);
-      Value g_lo = b.or_(
-          b.and_(vecGet(b, group1, loDword), b.i32_val(0x0000FFFF)), loHi);
-      group1 = vecSet(b, group1, loDword, g_lo);
-      // hiDword: keep hi-16, replace lo-16 with (newDim >> 16) & 0xFFFF
-      Value hiLo = b.and_(b.lshr(newDim, v16), b.i32_val(0xFFFF));
-      Value g_hi = b.or_(
-          b.and_(vecGet(b, group1, hiDword), b.i32_val(0xFFFF0000)), hiLo);
-      group1 = vecSet(b, group1, hiDword, g_hi);
-    };
-    stampDim(/*loDword=*/1, /*hiDword=*/2, setBounds[1]); // inner
-    stampDim(/*loDword=*/2, /*hiDword=*/3, setBounds[0]); // outer
+    for (size_t i = 0; i < numDims; ++i)
+      stampTensorDim(descDim(i), setBounds[i]);
   }
 
-  // ---- dest: rewrite lds_addr in group0[1] ----
-  if (dest) {
-    Value ldsAddr = b.ptrtoint(i32_ty, dest);
-    group0 = vecSet(b, group0, 1, ldsAddr);
+  // ---- clamp_bounds: tensor_dim[i] = max(0, tensor_dim[i] - add_offsets[i])
+  // -- Used by the descriptor_load path: after add_offsets advances global_addr
+  // to the tile, the remaining valid extent along each dim is tensor_dim -
+  // offset.  Uses the same signed clamp as fillTDMDescriptor (a negative offset
+  // -> zero extent).  Mutually exclusive with set_bounds (verifier-enforced).
+  if (clampBounds) {
+    assert(!addOffsets.empty() && "clamp_bounds requires add_offsets");
+    for (size_t i = 0; i < numDims; ++i) {
+      Value cur = decodeTensorDim(descDim(i));
+      stampTensorDim(descDim(i), clampTensorDimByOffset(b, cur, addOffsets[i]));
+    }
   }
 
   // ---- pred: rewrite group0[0] ----
@@ -294,18 +413,10 @@ void updateTensorDescriptor(RewriterBase &rewriter, Location loc,
     // them.
     group0 = vecSet(b, group0, 0, pred);
   }
-
-  // ---- barrier: enable bit (group1[0] bit 18) + addr (group1[1] lo-16) ----
-  if (barrier) {
-    Value g1_0 = vecGet(b, group1, 0);
-    Value g1_1 = vecGet(b, group1, 1);
-    g1_0 = b.or_(g1_0, b.shl(b.i32_val(1), b.i32_val(18)));
-    g1_1 = b.or_(b.and_(g1_1, b.i32_val(0xFFFF0000)),
-                 b.and_(b.lshr(b.ptrtoint(i32_ty, barrier), b.i32_val(3)),
-                        b.i32_val(0x0000FFFF)));
-    group1 = vecSet(b, group1, 0, g1_0);
-    group1 = vecSet(b, group1, 1, g1_1);
-  }
+  // NOTE: the TDM barrier (mbarrier) is an op-level operand on the
+  // async_tdm_copy ops, not a descriptor field — it is paired with the
+  // mbarrier_wait via SSA and (for multi-instruction transfers) only the last
+  // slice signals.  It is therefore intentionally NOT settable here.
 }
 
 // Decode a full TDM descriptor for 1D-5D tensors.  Returns (base,
@@ -329,50 +440,13 @@ decodeTDMDescriptorFull(RewriterBase &rewriter, Location loc,
   Value srcPtr = b.inttoptr(globalPtrTy, globalAddr);
 
   SmallVector<Value> tensorShape(numDims);
-  SmallVector<Value> tensorStride(numDims);
+  SmallVector<Value> tensorStride =
+      decodeTDMStrides(rewriter, loc, groups, numDims);
 
-  // Helper: combine a 32-bit low part and a 16-bit high part into an i64.
-  auto combine48 = [&](Value lo32, Value hi16InDword) -> Value {
-    Value hi16 = b.and_(hi16InDword, b.i32_val(0xFFFF));
-    return b.or_(b.zext(i64_ty, lo32),
-                 b.shl(b.zext(i64_ty, hi16), b.i64_val(32)));
-  };
-
-  // Decode dimensions from the end (inner dimensions first)
+  // Decode tensor_dim (shape) from the end (inner dimensions first).
   tensorShape[numDims - 1] = decode48BitValue(rewriter, b, groups[1], 1);
-
-  if (numDims >= 2) {
+  if (numDims >= 2)
     tensorShape[numDims - 2] = decode48BitValue(rewriter, b, groups[1], 2);
-
-    // tensor_dim0_stride: group1[5][0:32] | group1[6][0:16] (48 bits)
-    tensorStride[numDims - 2] =
-        combine48(vecGet(b, groups[1], 5), vecGet(b, groups[1], 6));
-
-    // tensor_dim1_stride: group1[6][16:32] | group1[7][0:32] (48 bits)
-    if (numDims >= 3) {
-      Value stride1Low = b.and_(b.lshr(vecGet(b, groups[1], 6), b.i32_val(16)),
-                                b.i32_val(0xFFFF));
-      Value stride1High = vecGet(b, groups[1], 7);
-      tensorStride[numDims - 3] =
-          b.or_(b.zext(i64_ty, stride1Low),
-                b.shl(b.zext(i64_ty, stride1High), b.i64_val(16)));
-    }
-  }
-
-  // tensor_dim2_stride: group2[2][0:32] | group2[3][0:16] (48 bits)
-  if (numDims >= 4) {
-    tensorStride[numDims - 4] =
-        combine48(vecGet(b, groups[2], 2), vecGet(b, groups[2], 3));
-  }
-
-  // tensor_dim3_stride: group3[0][0:32] | group3[1][0:16] (48 bits)
-  if (numDims == 5) {
-    tensorStride[numDims - 5] =
-        combine48(vecGet(b, groups[3], 0), vecGet(b, groups[3], 1));
-  }
-
-  // The innermost dimension always has stride 1
-  tensorStride[numDims - 1] = b.i64_val(1);
 
   // 3rd dimension from group2 if present
   if (numDims >= 3) {
@@ -786,10 +860,10 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
   }
   dstPtr = b.gep(sharedPtrTy, elementType, dstPtr, dstOffset);
 
-  // Update tensor shapes based on offset
-  for (size_t i = 0; i < numDims; ++i) {
-    tensorShape[i] = b.smax(b.i32_val(0), b.sub(tensorShape[i], offset[i]));
-  }
+  // Update tensor shapes based on offset (shared signed clamp; see
+  // clampTensorDimByOffset).
+  for (size_t i = 0; i < numDims; ++i)
+    tensorShape[i] = clampTensorDimByOffset(b, tensorShape[i], offset[i]);
 
   // TDM store does not support padding in general. However, if the padding
   // interval equals the innermost dimension, we can support it by:
@@ -961,8 +1035,8 @@ void fillTDMDescriptorForGatherScatter(
   ldsPtr = b.gep(sharedPtrTy, elementType, ldsPtr, ldsOffset);
 
   // Adjust column tensor shape for OOB handling - subtract column offset to
-  // get remaining elements.
-  tensorShape[1] = b.smax(b.i32_val(0), b.sub(tensorShape[1], globalColOffset));
+  // get remaining elements (shared signed clamp; see clampTensorDimByOffset).
+  tensorShape[1] = clampTensorDimByOffset(b, tensorShape[1], globalColOffset);
 
   // For scatter with padding (store-from-LDS): clamp tensor_dim0 to the
   // original column width so OOB checking drops padding elements before they

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
@@ -35,18 +35,26 @@ SmallVector<Value> scalarizeTDMDescriptor(RewriterBase &rewriter, Location loc,
 // - addOffsets (incremental): bumps global_addr by
 //   sum(addOffsets[i]*stride[i]) scaled by element size.  Empty = skip.
 // - setBounds  (rewrite):     overwrites tensor_dim absolutely.  Empty = skip.
-// - dest       (rewrite):     overwrites lds_addr.  Null = skip.
 // - pred       (rewrite):     overwrites pred.  Null = skip.
-// - barrier    (rewrite):     enables barrier signaling and writes barrier
-//                             addr.  Null = skip.
+// - clampBounds: when true, also shrink tensor_dim by addOffsets
+//                (tensor_dim[d] = max(0, tensor_dim[d] - addOffsets[d]); a
+//                negative offset yields a zero extent) to derive the OOB extent
+//                of the advanced tile.  Requires addOffsets; mutually exclusive
+//                with setBounds.
 //
-// Currently 2D-only; 3D-5D support TBD.
+// The LDS address and the TDM barrier are intentionally NOT descriptor fields:
+// they are op-level operands on the async_tdm_copy ops (the LDS address is
+// re-stamped per warp from the copy's destination; the barrier is paired with
+// mbarrier_wait via SSA).
+//
+// `groups` is 2 (1D-2D) or 4 (3D-5D) vector entries, updated in place.
+// addOffsets/setBounds are in Triton dim order (index 0 = outermost).
 void updateTensorDescriptor(RewriterBase &rewriter, Location loc,
                             Type elementType, ArrayRef<int64_t> blockShape,
-                            Value &group0, Value &group1,
+                            MutableArrayRef<Value> groups,
                             ArrayRef<Value> addOffsets,
-                            ArrayRef<Value> setBounds, Value dest, Value pred,
-                            Value barrier);
+                            ArrayRef<Value> setBounds, Value pred,
+                            bool clampBounds = false);
 
 // Create the base TDM descriptor from tensor metadata: global base pointer,
 // tensor shape, strides, and padding.  Fields that depend on a particular TDM

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
@@ -72,6 +72,8 @@ SmallVector<Value> createTDMDescriptor(RewriterBase &rewriter, Location loc,
 // `groups` is 2 (1D-2D) or 4 (3D-5D) vector entries, updated in place.
 // Partitioned dst: `dstPtrs` holds per-partition bases, picked by partitionDim.
 // `warpUsedHint`: see TritonAMDGPUOps.td for the axis-aligned hint rule.
+// `isPureForm`: inherit `pred` from the descriptor (group0[0]) instead of the
+// `pred` arg, and leave the barrier-enable bit untouched.
 void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
                        const LLVMTypeConverter *typeConverter, Type elementType,
                        SmallVector<int64_t> blockShape, int numWarps,
@@ -81,7 +83,8 @@ void fillTDMDescriptor(RewriterBase &rewriter, Location loc,
                        Value barrierPtr,
                        const triton::LinearLayout &sharedLayout, Value ctaId,
                        bool isStore, ArrayRef<unsigned> warpsPerCTA,
-                       std::optional<uint32_t> warpUsedHint = std::nullopt);
+                       std::optional<uint32_t> warpUsedHint = std::nullopt,
+                       bool isPureForm = false);
 
 // Fill TDM descriptor for gather/scatter operations (2D only).
 // Gather reads from non-contiguous rows in global memory to LDS.
@@ -114,7 +117,8 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
                       Value barrierPtr, bool isLoad,
                       const triton::LinearLayout &sharedLayout,
                       Attribute encoding, Value ctaId, int32_t auxBits,
-                      std::optional<uint32_t> warpUsedHint = std::nullopt);
+                      std::optional<uint32_t> warpUsedHint = std::nullopt,
+                      bool isPureForm = false);
 
 // Returns (warpsPerCTA, numTDMInstructions) for a given shared encoding.
 // For PartitionedSharedEncodingAttr, computes a partition-aligned warp

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TensorPtrOpsToLLVM.cpp
@@ -117,47 +117,22 @@ struct UpdateTensorDescriptorOpConversion
         getTypeConverter()->convertType(tensorDescTy.getElementType());
     SmallVector<int64_t> blockShape = to_vector(tensorDescTy.getShape());
 
-    if (blockShape.size() != 2) {
-      return rewriter.notifyMatchFailure(
-          op, "UpdateTensorDescriptorOp lowering currently supports 2D only");
-    }
-    // Unpack the input descriptor into vector groups (group0: <4 x i32>,
-    // group1: <8 x i32> for 2D).
+    // Unpack the input descriptor into vector groups: 2 (1D-2D) or 4 (3D-5D).
     SmallVector<Value> groups =
         mlir::LLVM::AMD::unpackTDMDescriptor(rewriter, loc, adaptor.getDesc());
-    assert(groups.size() == 2 && "2D descriptor expects 2 vector groups");
-    Value group0 = groups[0];
-    Value group1 = groups[1];
 
     SmallVector<Value> addOffsets = llvm::to_vector(adaptor.getAddOffsets());
     SmallVector<Value> setBounds = llvm::to_vector(adaptor.getSetBounds());
-
-    Value destPtr;
-    if (op.getDest()) {
-      auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
-          loc, adaptor.getDest(), elementType, rewriter);
-      destPtr = smemObj.getBase();
-    }
-    Value barrierPtr;
-    if (op.getBarrier()) {
-      auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
-          loc, adaptor.getBarrier(),
-          getTypeConverter()->convertType(
-              op.getBarrier().getType().getElementType()),
-          rewriter);
-      barrierPtr = smemObj.getBase();
-    }
     Value pred = adaptor.getPred();
 
     mlir::LLVM::AMD::updateTensorDescriptor(
-        rewriter, loc, elementType, blockShape, group0, group1, addOffsets,
-        setBounds, destPtr, pred, barrierPtr);
+        rewriter, loc, elementType, blockShape, groups, addOffsets, setBounds,
+        pred, op.getClampBounds());
 
     // Re-pack the mutated groups back into the flat MLIR struct that
     // matches convertTensorDescType / the host-side TDMDescriptor ABI.
-    SmallVector<Value> mutated = {group0, group1};
     SmallVector<Value> scalars =
-        mlir::LLVM::AMD::scalarizeTDMDescriptor(rewriter, loc, mutated);
+        mlir::LLVM::AMD::scalarizeTDMDescriptor(rewriter, loc, groups);
     Value newDesc = packLLElements(loc, getTypeConverter(), scalars, rewriter,
                                    tensorDescTy);
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToTensorOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToTensorOps.cpp
@@ -46,8 +46,9 @@ public:
     Value alloc = LocalAllocOp::create(rewriter, loc, memDescType);
     Value pred = arith::ConstantIntOp::create(rewriter, loc, 1, 32);
 
-    amdgpu::AsyncTDMCopyGlobalToLocalOp::create(rewriter, loc, op.getDesc(),
-                                                op.getIndices(), alloc, pred);
+    Value desc = createUpdateTDMDescriptorOp(rewriter, loc, op.getDesc(),
+                                             op.getIndices(), /*pred=*/pred);
+    amdgpu::AsyncTDMCopyGlobalToLocalOp::create(rewriter, loc, desc, alloc);
     amdgpu::AsyncTDMWait::create(rewriter, loc, ArrayRef<Value>{}, 0);
     rewriter.replaceOpWithNewOp<LocalLoadOp>(op, op.getType(), alloc);
     return success();
@@ -121,8 +122,9 @@ public:
         MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
                          encoding, sharedMemorySpace, /*mutableMemory=*/true);
     Value alloc = LocalAllocOp::create(rewriter, loc, memDescType, op.getSrc());
-    amdgpu::AsyncTDMCopyLocalToGlobalOp::create(rewriter, loc, op.getDesc(),
-                                                op.getIndices(), alloc,
+    Value copyDesc = createUpdateTDMDescriptorOp(
+        rewriter, loc, op.getDesc(), op.getIndices(), /*pred=*/Value{});
+    amdgpu::AsyncTDMCopyLocalToGlobalOp::create(rewriter, loc, copyDesc, alloc,
                                                 /*barrier=*/Value{});
     amdgpu::AsyncTDMWait::create(rewriter, loc, ArrayRef<Value>{}, 0);
     rewriter.eraseOp(op);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -85,8 +85,11 @@ TDMChainOps createTDMAsyncCopy(tt::DescriptorLoadOp loadOp, Value alloc,
   return createTDMAsync(
       loadOp, alloc, extractIdx,
       [&](OpBuilder &builder, Location loc, Value view, Value pred) {
-        return triton::amdgpu::AsyncTDMCopyGlobalToLocalOp::create(
-            builder, loc, loadOp.getDesc(), loadOp.getIndices(), view, pred);
+        Value desc = createUpdateTDMDescriptorOp(builder, loc, loadOp.getDesc(),
+                                                 loadOp.getIndices(),
+                                                 /*pred=*/pred);
+        return triton::amdgpu::AsyncTDMCopyGlobalToLocalOp::create(builder, loc,
+                                                                   desc, view);
       });
 }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
@@ -51,10 +51,21 @@ Operation *streamPredication(RewriterBase &rewriter, Operation *op,
     scf::YieldOp::create(elseB, loc, zeroValues);
     return ifOp;
   }
-  // TDM ops with I32 predicates need explicit type conversion since the
-  // generic PredicatedOpInterface path produces I1 masks.
-  if (isa<triton::amdgpu::AsyncTDMCopyGlobalToLocalOp,
-          triton::amdgpu::AsyncTDMGatherOp>(op)) {
+  // Gate the copy by chaining a pred-only update_tensor_descriptor onto its
+  // descriptor: the chained update inherits the positioning and narrows pred to
+  // the loop predicate.
+  if (auto copyOp = dyn_cast<triton::amdgpu::AsyncTDMCopyGlobalToLocalOp>(op)) {
+    rewriter.setInsertionPoint(op);
+    auto predI32 = arith::ExtUIOp::create(rewriter, op->getLoc(),
+                                          rewriter.getI32Type(), pred);
+    auto updated = triton::amdgpu::UpdateTensorDescriptorOp::create(
+        rewriter, op->getLoc(), copyOp.getDesc().getType(), copyOp.getDesc(),
+        /*add_offsets=*/ValueRange{}, /*set_bounds=*/ValueRange{},
+        /*pred=*/predI32);
+    copyOp.getDescMutable().assign(updated.getResult());
+    return op;
+  }
+  if (auto gatherOp = dyn_cast<triton::amdgpu::AsyncTDMGatherOp>(op)) {
     auto predicatedOp = cast<tt::PredicatedOpInterface>(op);
     rewriter.setInsertionPoint(op);
     auto predI32 = arith::ExtUIOp::create(

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -2,6 +2,7 @@
 
 #include "amd/lib/TritonAMDGPUTransforms/Utility.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.h"
@@ -546,4 +547,13 @@ Attribute buildDefaultTDMDescriptorEncoding(MLIRContext *ctx,
   }
   return ttg::PaddedSharedEncodingAttr::get(ctx, {{padInterval, padAmount}},
                                             order, shape, cgaLayout);
+}
+
+Value createUpdateTDMDescriptorOp(OpBuilder &builder, Location loc, Value desc,
+                                  ValueRange addOffsets, Value pred) {
+  auto updateOp = mlir::triton::amdgpu::UpdateTensorDescriptorOp::create(
+      builder, loc, desc.getType(), desc, addOffsets,
+      /*set_bounds=*/ValueRange{}, pred);
+  updateOp.setClampBounds(true);
+  return updateOp.getResult();
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
@@ -2,6 +2,7 @@
 #define TRITON_THIRD_PARTY_AMD_LIB_TRITONAMDGPUTRANSFORMS_UTILITY_H_
 
 #include "Dialect/TritonAMDGPU/IR/TargetFeatures.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
@@ -67,6 +68,12 @@ getEncodingFromDescriptor(Operation *op, RankedTensorType tensorType,
 // warps and gathers per warp to the actual problem size.
 triton::gpu::SliceEncodingAttr
 getTDMGatherScatterIndexEncoding(Operation *op, RankedTensorType indicesType);
+
+// Emit an amdg.update_tensor_descriptor that advances `desc` by `addOffsets`
+// (with clamp_bounds) and sets `pred` when non-null.  Returns the new
+// descriptor.
+Value createUpdateTDMDescriptorOp(OpBuilder &builder, Location loc, Value desc,
+                                  ValueRange addOffsets, Value pred);
 
 // Returns the given |inputValue|'s dot user result encoding and updates |opIdx|
 // and |vecSize| with which dot operand |inputValue| is fed into if possible.

--- a/third_party/amd/python/examples/gluon/f16_gemm_streamk_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_gemm_streamk_gfx1250.py
@@ -154,7 +154,7 @@ def process_streamk_tiles(
     if STREAMK_TILES == 0:
         return
 
-    # Initialize P buffer and locks
+    # Initialize P buffer
     rm = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, WMMA_LAYOUT))
     rn = ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, WMMA_LAYOUT))
     p_offset = pid * BLOCK_M * BLOCK_N + rm[:, None] * BLOCK_N + rn[None, :]
@@ -162,8 +162,6 @@ def process_streamk_tiles(
         p_ptr + p_offset,
         ttgl.zeros((BLOCK_M, BLOCK_N), dtype=p_ptr.type.element_ty, layout=WMMA_LAYOUT),
     )
-    ttgl.barrier()
-    ttgl.store(locks_ptr + pid, 0)
 
     # Compute StreamK params inline
     iters_per_tile = ttgl.cdiv(K, BLOCK_K)
@@ -375,7 +373,7 @@ def process_streamk_tiles_8warps(
     if STREAMK_TILES == 0:
         return
 
-    # Initialize P buffer and locks
+    # Initialize P buffer
     rm = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, WMMA_LAYOUT))
     rn = ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, WMMA_LAYOUT))
     p_offset = pid * BLOCK_M * BLOCK_N + rm[:, None] * BLOCK_N + rn[None, :]
@@ -383,8 +381,6 @@ def process_streamk_tiles_8warps(
         p_ptr + p_offset,
         ttgl.zeros((BLOCK_M, BLOCK_N), dtype=p_ptr.type.element_ty, layout=WMMA_LAYOUT),
     )
-    ttgl.barrier()
-    ttgl.store(locks_ptr + pid, 0)
 
     # Compute StreamK params inline
     iters_per_tile = ttgl.cdiv(K, BLOCK_K)
@@ -1167,13 +1163,12 @@ def run_streamk_gemm_tdm_pipelined(
 
     # Allocate StreamK buffers
     p = torch.empty(num_sms * BLOCK_M * BLOCK_N, dtype=torch.float32)
-    locks = torch.empty(num_sms, dtype=torch.int32)
 
     a_device = a.cuda()
     b_device = b.cuda()
     c_device = c.cuda()
     p_device = p.cuda()
-    locks_device = locks.cuda()
+    locks_device = torch.zeros(num_sms, dtype=torch.int32, device=a_device.device)
 
     if num_warps == 8:
         kernel_name = "pipelined-8warps"

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -612,6 +612,7 @@ def test_compile_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, AS
 
     k = triton.compile(src=gluon._runtime.GluonASTSource(fn, signature, constexprs, attrs=attrs),
                        target=GPUTarget("hip", 'gfx1250', 32))
+    ttgir = k.asm["ttgir"]
     amdgcn = k.asm["amdgcn"]
 
     assert re.search("v_wmma_f32_16x16x32_f16", amdgcn)
@@ -625,9 +626,11 @@ def test_compile_gemm_async_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, AS
         b_rows = BLOCK_N if B_K_CONTIG else BLOCK_K
         copy_isntr_for_B = b_rows // 4 // 4
         copy_instr_per_iter = copy_instr_for_A + copy_isntr_for_B
+        assert len(re.findall("ttg.async_copy_global_to_local", ttgir)) == NUM_BUFFERS * 2
         for cnt in range(NUM_BUFFERS - 1, -1, -1):
             assert re.search(f"s_wait_asynccnt 0x{(cnt * copy_instr_per_iter):x}", amdgcn)
         # Each instruction loads 4 rows per warp and we have 4 warps (see BlockedLayout in test)
+        # Only treat this as a lower bound because LLVM might unroll the loop
         assert len(re.findall("global_load_async_to_lds", amdgcn)) >= NUM_BUFFERS * copy_instr_per_iter
 
 

--- a/third_party/amd/python/test/test_tdm_copy.py
+++ b/third_party/amd/python/test/test_tdm_copy.py
@@ -231,6 +231,44 @@ def test_compile_vector_add_tdm(BLOCK_M, BLOCK_N, HINT_A, HINT_B):
                         f"HINT_B=0b{HINT_B:08b}, got {n_tdm}\n{amdgcn}")
 
 
+@gluon.jit
+def tdm_clamp_kernel(a_ptr, M, N, BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr):
+    """Single TDM load whose offsets exercise the tensor_dim OOB clamp."""
+    SHARED_LAYOUT: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[32, 4]], [BLOCK_M, BLOCK_N], [1, 0])
+    BLOCKED_LAYOUT: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [4, 8], [4, 1], [1, 0])
+
+    off_m = ttgl.program_id(axis=0) * BLOCK_M
+    off_n = ttgl.program_id(axis=1) * BLOCK_N
+    desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=a_ptr, shape=(M, N), strides=(N, 1),
+                                                       block_shape=(BLOCK_M, BLOCK_N), layout=SHARED_LAYOUT)
+    buf = ttgl.allocate_shared_memory(desc.dtype, desc.block_shape, desc.layout)
+    ttgl.amd.gfx1250.tdm.async_load(desc, [off_m, off_n], buf)
+    ttgl.amd.gfx1250.tdm.async_wait(0)
+    buf.load(layout=BLOCKED_LAYOUT)
+
+
+def test_compile_tdm_clamp_no_readfirstlane():
+    """The TDM tensor_dim clamp must stay uniform (SGPR).
+
+    A non-uniform clamp is demoted to VALU and has to be read back into an SGPR
+    with ``v_readfirstlane`` next to each ``tensor_load_to_lds``, adding latency
+    to every TDM load.  A TDM load whose offsets exercise the clamp must lower
+    with none.
+    """
+    signature = {"a_ptr": "*fp16", "M": "i32", "N": "i32", "BLOCK_M": "constexpr", "BLOCK_N": "constexpr"}
+    k = triton.compile(
+        gluon._runtime.GluonASTSource(
+            fn=tdm_clamp_kernel,
+            signature=signature,
+            constexprs={"BLOCK_M": 64, "BLOCK_N": 64},
+        ),
+        target=GPUTarget("hip", "gfx1250", 32),
+        options={"num_warps": 4},
+    )
+    amdgcn = k.asm["amdgcn"]
+    assert "v_readfirstlane" not in amdgcn, f"TDM tensor_dim clamp regressed to VALU (v_readfirstlane emitted)\n{amdgcn}"
+
+
 _RUNTIME_BLOCK_SHAPES = [(64, 64), (128, 64)]
 
 

--- a/third_party/amd/python/test/test_tdm_copy.py
+++ b/third_party/amd/python/test/test_tdm_copy.py
@@ -271,3 +271,67 @@ def test_runtime_vector_add_tdm(BLOCK_M, BLOCK_N, HINT_A, HINT_B):
 
     expected = a_cpu + b_cpu
     assert torch.equal(c.cpu(), expected)
+
+
+@gluon.jit
+def update_clamp_bounds_kernel(a_ptr, c_ptr, LOG_M, N, OFF_M, BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr):
+    """Advance a descriptor by OFF_M rows with clamp_bounds=True, then load a full
+    BLOCK_M x BLOCK_N tile and store it unmasked.
+
+    clamp_bounds shrinks tensor_dim to the advanced tile's valid extent
+    (LOG_M - OFF_M rows), so the hardware loads only the in-bounds rows and
+    zero-fills the rest.  The store is intentionally unmasked so the out-of-bounds
+    tile region is observable: without the clamp those rows would over-read the
+    (physically present) memory past the logical tensor instead of reading zero.
+    """
+    num_warps: ttgl.constexpr = ttgl.num_warps()
+    BLOCKED_LAYOUT: ttgl.constexpr = ttgl.BlockedLayout([1, 8], [4, 8], [num_warps, 1], [1, 0])
+    SHARED_LAYOUT: ttgl.constexpr = ttgl.PaddedSharedLayout.with_identity_for([[32, 4]], [BLOCK_M, BLOCK_N], [1, 0])
+
+    a_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=a_ptr, shape=(LOG_M, N), strides=(N, 1),
+                                                         block_shape=(BLOCK_M, BLOCK_N), layout=SHARED_LAYOUT)
+    a_buf = ttgl.allocate_shared_memory(a_desc.dtype, a_desc.block_shape, a_desc.layout)
+
+    a_desc = ttgl.amd.gfx1250.tdm.update_tensor_descriptor(a_desc, add_offsets=[OFF_M, 0], pred=1, clamp_bounds=True)
+    ttgl.amd.gfx1250.tdm.async_load(a_desc, [0, 0], a_buf)
+    ttgl.amd.gfx1250.tdm.async_wait(0)
+
+    a = a_buf.load(layout=BLOCKED_LAYOUT)
+    rm = ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, BLOCKED_LAYOUT))
+    rn = ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, BLOCKED_LAYOUT))
+    offs = (rm[:, None] * BLOCK_N) + rn[None, :]
+    ttgl.store(c_ptr + offs, a)
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="TDM is only tested on gfx1250.")
+@pytest.mark.parametrize("BLOCK_M,BLOCK_N", _RUNTIME_BLOCK_SHAPES)
+def test_runtime_update_clamp_bounds(BLOCK_M, BLOCK_N):
+    """Runtime: update_tensor_descriptor(clamp_bounds=True) shrinks tensor_dim to
+    the advanced tile's valid extent, so an edge tile loads only the in-bounds
+    rows and the hardware zero-fills the rest.
+
+    The physical source buffer is taller than the logical tensor and filled with
+    non-zero data, so a missing/broken clamp is observable end-to-end: the
+    out-of-bounds tile rows would come back as the (non-zero) memory past the
+    logical tensor instead of zero.  Compared against a torch CPU reference.
+    """
+    N = BLOCK_N
+    LOG_M = BLOCK_M  # logical tensor height
+    OFF_M = BLOCK_M // 4  # advance into the tile: valid remaining = 3/4 of a block
+    PHYS_M = 2 * BLOCK_M  # physical buffer is taller and entirely non-zero
+    NUM_WARPS = 4
+
+    torch.manual_seed(0)
+    # FIXME: Switch to native GPU-side initialization once public PyTorch
+    # supports gfx1250 kernels.  randint(1, ...) keeps every value non-zero so an
+    # over-read is distinguishable from the hardware's OOB zero-fill.
+    src_cpu = torch.randint(1, 128, (PHYS_M, N), dtype=torch.int32)
+    src = src_cpu.cuda()
+    c = torch.empty((BLOCK_M, BLOCK_N), dtype=torch.int32, device="cuda")
+
+    update_clamp_bounds_kernel[(1, )](src, c, LOG_M, N, OFF_M, BLOCK_M, BLOCK_N, num_warps=NUM_WARPS)
+
+    valid = LOG_M - OFF_M
+    expected = torch.zeros((BLOCK_M, BLOCK_N), dtype=torch.int32)
+    expected[:valid, :] = src_cpu[OFF_M:LOG_M, :]
+    assert torch.equal(c.cpu(), expected)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1284,7 +1284,7 @@ class CUDABackend(BaseBackend):
             # -Ofc mid miscompiles some large ConSan kernels into invalid global
             # accesses; -O1 keeps compile time reasonable without that ptxas bug.
             if (not knobs.nvidia.disable_ptxas_opt
-                    and any(mode in knobs.compilation.instrumentation_mode for mode in ["consan", "fpsan"])):
+                    and any(mode in opt.instrumentation_mode for mode in ["consan", "fpsan"])):
                 ptx_extra_options += ["--opt-level", "1"]
 
             # Add --regAllocOptLevel=2 to work around ptxas 13.x bug

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -789,24 +789,30 @@ void init_triton_tlx_ir(py::module &&m) {
              return self.create<ttg::AsyncWaitOp>(asyncTokens, pendings);
            })
       .def("create_async_tdm_copy_global_to_local",
-           [](TritonOpBuilder &self, Value desc, std::vector<Value> indices,
-              Value result, Value pred,
+           [](TritonOpBuilder &self, Value desc, Value result,
               std::optional<Value> barrier) -> mlir::Value {
-             Value pred32 = pred;
-             if (auto intTy = dyn_cast<IntegerType>(pred.getType())) {
-               if (intTy.getWidth() == 1) {
-                 pred32 = self.create<arith::ExtUIOp>(
-                     self.getBuilder().getI32Type(), pred);
-               }
-             }
+             // The op is now pure: tile offsets and predicate are applied to
+             // the descriptor beforehand via create_update_tensor_descriptor.
              return self.create<amdgpu::AsyncTDMCopyGlobalToLocalOp>(
-                 desc, indices, result, pred32, barrier.value_or(Value()));
+                 desc, result, barrier.value_or(Value()));
            })
       .def("create_async_tdm_copy_local_to_global",
-           [](TritonOpBuilder &self, Value desc, std::vector<Value> indices,
-              Value src, std::optional<Value> barrier) {
+           [](TritonOpBuilder &self, Value desc, Value src,
+              std::optional<Value> barrier) {
              self.create<amdgpu::AsyncTDMCopyLocalToGlobalOp>(
-                 desc, indices, src, barrier.value_or(Value()));
+                 desc, src, barrier.value_or(Value()));
+           })
+      .def("create_update_tensor_descriptor",
+           [](TritonOpBuilder &self, Value desc, std::vector<Value> addOffsets,
+              std::vector<Value> setBounds, std::optional<Value> pred,
+              bool clampBounds) -> Value {
+             Value res = self.create<amdgpu::UpdateTensorDescriptorOp>(
+                 desc.getType(), desc, ValueRange(addOffsets),
+                 ValueRange(setBounds), pred.value_or(Value()));
+             if (clampBounds)
+               res.getDefiningOp()->setAttr("clamp_bounds",
+                                            self.getBuilder().getUnitAttr());
+             return res;
            })
       .def("create_tdm_prefetch",
            [](TritonOpBuilder &self, Value desc, std::vector<Value> indices,

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -1279,6 +1279,17 @@ def _layouts_match(actual, expected):
     return False
 
 
+def _handle_i32_pred(pred, _semantic):
+    pred = tl._unwrap_if_constexpr(pred)
+    if isinstance(pred, bool):
+        pred = int(pred)
+    pred = _semantic.to_tensor(pred)
+    if pred.type.is_int1():
+        pred = _semantic.cast(pred, tl.int32)
+    assert pred.type.is_int32(), f"Expected pred to be an int32 or int1 value, but got {pred.type}"
+    return pred
+
+
 @tl.builtin
 def async_amd_descriptor_load(
     desc: tl.tensor_descriptor_base,
@@ -1314,15 +1325,15 @@ def async_amd_descriptor_load(
             )
 
     offsets_handles = _semantic._convert_to_ir_values(offsets, require_i64=False)
-    if pred is None:
-        pred_handle = _semantic.builder.get_int1(True)
-    else:
-        pred_handle = pred.handle
+    # The copy op is now pure: position the descriptor (tile offsets + predicate,
+    # with clamped OOB bounds) first, then issue the copy from it.
+    pred32 = _handle_i32_pred(True if pred is None else pred, _semantic)
+    positioned_desc = _semantic.builder.create_update_tensor_descriptor(desc.handle, offsets_handles, [], pred32.handle,
+                                                                        True,  # clamp_bounds
+                                                                        )
     token_handle = _semantic.builder.create_async_tdm_copy_global_to_local(
-        desc.handle,
-        offsets_handles,
+        positioned_desc,
         result.handle,
-        pred_handle,
         None,
     )
     return tlx.async_token(token_handle)
@@ -1362,9 +1373,13 @@ def async_amd_descriptor_store(
             )
 
     offsets_handles = _semantic._convert_to_ir_values(offsets, require_i64=False)
+    # Position the descriptor (tile offsets + clamped OOB bounds); stores take no
+    # predicate. The copy op is now pure and reads from the positioned descriptor.
+    positioned_desc = _semantic.builder.create_update_tensor_descriptor(desc.handle, offsets_handles, [], None,
+                                                                        True,  # clamp_bounds
+                                                                        )
     _semantic.builder.create_async_tdm_copy_local_to_global(
-        desc.handle,
-        offsets_handles,
+        positioned_desc,
         source.handle,
         None,
     )


### PR DESCRIPTION
Summary:

This is a backport of an upstream PR: https://github.com/triton-lang/triton/pull/10605

Upstream commit message:
```
> [AMD][gfx1250] TDM: add regression test for the uniform tensor_dim clamp (#10605)

> #10517 rephrased the TDM tensor_dim clamp so it stays uniform (SGPR),
> avoiding a VALU demotion that forced a v_readfirstlane_b32 next to each
> tensor_load_to_lds inside the loop (mismatched VGPR MSB -> wrong
> descriptor offset -> NaNs), but it did not add a test. Add a
> compile-only guard: a TDM load whose offsets exercise the tensor_dim
> clamp must lower with zero v_readfirstlane_b32.

> Verified sensitive: reverting the clamp to the pre-#10517 icmp_ule shape
> makes this kernel emit 5 v_readfirstlane_b32.
```

***Do not remove the following line from this commit***
Reactor Backport Revision: 007ef1530aa1c9d1a78d206417fb7721fbd53211
 ---

This diff was generated by running:
```
buck run fbcode//triton/tools/reactor:reactor -- backport --pr 10605
```

Reviewed By: warrendeng

Differential Revision: D114483887
