### PR TITLE
[triton] HSTU tutorials: use num_stages=1 instead of 0 in autotune configs (#2651)

### DIFF
--- a/third_party/tlx/tutorials/hstu_cross_attn/triton_bw_cross_attention.py
+++ b/third_party/tlx/tutorials/hstu_cross_attn/triton_bw_cross_attention.py
@@ -376,7 +376,7 @@ def get_fwd_triton_configs() -> List[triton.Config]:
                 "TRANS": tma_trans[1],
                 "NUM_STAGES": ns,
             },
-            num_stages=0,
+            num_stages=1,
             num_warps=nw,
         )
         for bm in [32, 64, 128]
@@ -1034,7 +1034,7 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                     "NUM_STAGES1": ns1,
                     "IS_DYNAMIC": is_dynamic,
                 },
-                num_stages=0,
+                num_stages=1,
                 num_warps=nw,
             )
             for bm in [64, 128]
@@ -1061,7 +1061,7 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                     "NUM_STAGES1": 2,
                     "IS_DYNAMIC": True,
                 },
-                num_stages=0,
+                num_stages=1,
                 num_warps=4,
             ),
             triton.Config(
@@ -1076,7 +1076,7 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                     "NUM_STAGES1": 2,
                     "IS_DYNAMIC": True,
                 },
-                num_stages=0,
+                num_stages=1,
                 num_warps=4,
             ),
             triton.Config(
@@ -1091,7 +1091,7 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                     "NUM_STAGES1": 2,
                     "IS_DYNAMIC": True,
                 },
-                num_stages=0,
+                num_stages=1,
                 num_warps=4,
             ),
             triton.Config(
@@ -1106,7 +1106,7 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                     "NUM_STAGES1": 4,
                     "IS_DYNAMIC": True,
                 },
-                num_stages=0,
+                num_stages=1,
                 num_warps=2,
             ),
             triton.Config(
@@ -1121,7 +1121,7 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                     "NUM_STAGES1": 2,
                     "IS_DYNAMIC": True,
                 },
-                num_stages=0,
+                num_stages=1,
                 num_warps=4,
             ),
             triton.Config(
@@ -1136,7 +1136,7 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                     "NUM_STAGES1": 2,
                     "IS_DYNAMIC": True,
                 },
-                num_stages=0,
+                num_stages=1,
                 num_warps=4,
             ),
         ]
@@ -1155,7 +1155,7 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                         "NUM_STAGES1": 4,
                         "IS_DYNAMIC": True,
                     },
-                    num_stages=0,
+                    num_stages=1,
                     num_warps=4,
                 ),
                 triton.Config(
@@ -1170,7 +1170,7 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                         "NUM_STAGES1": 4,
                         "IS_DYNAMIC": False,
                     },
-                    num_stages=0,
+                    num_stages=1,
                     num_warps=4,
                 ),
                 triton.Config(
@@ -1185,7 +1185,7 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                         "NUM_STAGES1": 2,
                         "IS_DYNAMIC": False,
                     },
-                    num_stages=0,
+                    num_stages=1,
                     num_warps=4,
                 ),
                 triton.Config(
@@ -1200,7 +1200,7 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                         "NUM_STAGES1": 4,
                         "IS_DYNAMIC": False,
                     },
-                    num_stages=0,
+                    num_stages=1,
                     num_warps=8,
                 ),
                 triton.Config(
@@ -1215,7 +1215,7 @@ def get_fwd_triton_spec_configs() -> List[triton.Config]:
                         "NUM_STAGES1": 4,
                         "IS_DYNAMIC": False,
                     },
-                    num_stages=0,
+                    num_stages=1,
                     num_warps=4,
                 ),
             ]

--- a/third_party/tlx/tutorials/hstu_self_attn/tlx_bw_hstu_attention.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/tlx_bw_hstu_attention.py
@@ -85,7 +85,7 @@ def get_fwd_persistent_configs() -> List[triton.Config]:
                 "MOVE_QK_WAIT": qk_wait,
                 "SLICE_MASK": slice_mask,
             },
-            num_stages=0,
+            num_stages=1,
             num_warps=4,
             pre_hook=_host_descriptor_pre_hook,
         )


### PR DESCRIPTION
Summary:

`NVGPUWarpSpecializationPass` requires `numStages >= 1` -- a buffer count of 0
is meaningless, since a single buffer already means "unpipelined". These HSTU
tutorial kernels pipeline themselves and expressed that by asking the compiler
for `num_stages=0`, pairing it with their own `NUM_STAGES` / `NUM_BUFFERS_*`
constexpr. `num_stages=1` expresses the same intent without violating the
invariant.

The 14 configs here are the in-repo half of that idiom. They do not cause the
red H100 TritonBench job -- that one comes from an `_hstu_attn_fwd` TLX config
in `fbcode/generative_recommenders`, gated on `device_capability == 9`, which
needs the same one-line change and is not part of this diff.

These 14 are latent rather than visible today. The assert is compiled out under
`NDEBUG`, and `add_hopper_warpspec` is only added on Hopper, or on Blackwell
under `TRITON_USE_META_WS`. `test_cross_attention_bwd_autows.py` does run with
meta-WS on, so its 13 configs abort in an assert-enabled build; they go
unnoticed because no CI job or Buck target covers these tests. The self-attn
config is currently sidestepped by a deliberate process split -- see the
docstring in `test_self_attention_bwd.py`, which notes the TLX self-attn fwd
"uses num_stages=0 and asserts under meta-WS, so it cannot be compiled in the
same (META_WS) process", at the cost of falling back to a torch accuracy
oracle instead of the TLX one.

Landing these unblocks tightening the compiler-side check from a bare assert
into a clear diagnostic without silently breaking tests that CI does not guard.

Reviewed By: htyu

Differential Revision: D114413080


