### PR TITLE
[triton][TLX] Fall back to prepared-tree conftest imports & fixtlx templates formatting (#2652)

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.h
+++ b/include/triton/Tools/Sys/GetEnv.h
@@ -15,6 +15,7 @@ namespace mlir::triton {
 inline const std::set<std::string> CACHE_INVALIDATING_ENV_VARS = {
     // clang-format off
     "AMDGCN_ENABLE_DUMP",
+    "AMDGCN_SCALARIZE_PACKED_FOPS",
     "AMDGCN_USE_BUFFER_ATOMICS",
     "AMDGCN_USE_BUFFER_OPS",
     "DISABLE_LLVM_OPT",

--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -16,7 +16,12 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 from triton.runtime.fbcode_gating import is_fbcode_dependant
 
 if is_fbcode_dependant():
-    from python.test.unit.language.conftest import _generate_test_params, _swizzle_scale_to_5d
+    try:
+        from python.test.unit.language.conftest import _generate_test_params, _swizzle_scale_to_5d
+    except ModuleNotFoundError as error:
+        if error.name != "python.test":
+            raise
+        from conftest import _generate_test_params, _swizzle_scale_to_5d
 else:
     from conftest import _generate_test_params, _swizzle_scale_to_5d
 

--- a/python/test/unit/language/test_tlx_tma.py
+++ b/python/test/unit/language/test_tlx_tma.py
@@ -10,7 +10,12 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 from triton.runtime.fbcode_gating import is_fbcode_dependant
 
 if is_fbcode_dependant():
-    from python.test.unit.language.conftest import _swizzle_scale_to_5d
+    try:
+        from python.test.unit.language.conftest import _swizzle_scale_to_5d
+    except ModuleNotFoundError as error:
+        if error.name != "python.test":
+            raise
+        from conftest import _swizzle_scale_to_5d
 else:
     from conftest import _swizzle_scale_to_5d
 

--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -277,20 +277,16 @@ class TestTLXTemplates(TestCase):
             return torch.nn.functional.gelu(torch.addmm(bias, a, w.t()))
 
         with config.patch({
-            "triton.tlx_mode": "force",
-            "force_disable_caches": True,
-            "max_autotune": True,
-            "max_autotune_gemm_backends": "TRITON",
-            "enable_caching_generated_triton_templates": False,
-            "cpp_wrapper": False,
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "max_autotune": True,
+                "max_autotune_gemm_backends": "TRITON",
+                "enable_caching_generated_triton_templates": False,
+                "cpp_wrapper": False,
         }):
-            c_actual, code = run_and_get_code(
-                torch.compile(addmm_gelu), bias, a, w
-            )
+            c_actual, code = run_and_get_code(torch.compile(addmm_gelu), bias, a, w)
 
-        c_expected = torch.nn.functional.gelu(
-            a.float() @ w.t().float() + bias.float()
-        ).to(dtype)
+        c_expected = torch.nn.functional.gelu(a.float() @ w.t().float() + bias.float()).to(dtype)
         torch.testing.assert_close(c_actual, c_expected, atol=3e-2, rtol=3e-2)
 
         code_str = "\n".join(code)
@@ -303,9 +299,7 @@ class TestTLXTemplates(TestCase):
     )
     @unittest.skipIf(not has_tlx(), "TLX not available")
     @parametrize("epilogue", ("gelu", "mul"))
-    def test_tlx_addmm_warppipe_split_k_cpp_wrapper_fused_epilogue(
-        self, epilogue: str
-    ):
+    def test_tlx_addmm_warppipe_split_k_cpp_wrapper_fused_epilogue(self, epilogue: str):
         M, K, N = 256, 4096, 256
         dtype = torch.float16
         a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
@@ -326,18 +320,14 @@ class TestTLXTemplates(TestCase):
                 "enable_caching_generated_triton_templates": False,
                 "cpp_wrapper": True,
         }), ):
-            c_actual, code = run_and_get_code(
-                torch.compile(addmm_epilogue), bias, a, w
-            )
+            c_actual, code = run_and_get_code(torch.compile(addmm_epilogue), bias, a, w)
 
         reference = a.float() @ w.t().float() + bias.float()
         if epilogue == "gelu":
             reference = torch.nn.functional.gelu(reference)
         else:
             reference = reference * 0.5
-        torch.testing.assert_close(
-            c_actual, reference.to(dtype), atol=4e-2, rtol=4e-2
-        )
+        torch.testing.assert_close(c_actual, reference.to(dtype), atol=4e-2, rtol=4e-2)
 
         code_str = "\n".join(code)
         self.assertIn("split_k_ws", code_str)
@@ -557,14 +547,14 @@ class TestTLXTemplates(TestCase):
             return templates
 
         with (
-            mock.patch.object(_tlx_mm, "append_tlx", _only_persistent),
-            config.patch({
-                "triton.tlx_mode": "force",
-                "force_disable_caches": True,
-                "max_autotune": True,
-                "max_autotune_gemm_backends": "TRITON",
-                "enable_caching_generated_triton_templates": False,
-            }),
+                mock.patch.object(_tlx_mm, "append_tlx", _only_persistent),
+                config.patch({
+                    "triton.tlx_mode": "force",
+                    "force_disable_caches": True,
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "TRITON",
+                    "enable_caching_generated_triton_templates": False,
+                }),
         ):
             c_actual, code = run_and_get_code(torch.compile(addmm), bias, a, w)
 

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import shutil
 import triton
+from triton._C.libtriton import get_cache_invalidating_env_vars
 from triton._internal_testing import is_hip
 
 from pathlib import Path
@@ -109,6 +110,17 @@ def test_env_updated(fresh_knobs, monkeypatch):
     fresh_knobs.cache.home_dir = "/foo/bar"
     assert os.getenv("TRITON_HOME") == "/foo/bar"
     assert os.environ["TRITON_HOME"] == "/foo/bar"
+
+
+def test_scalarize_packed_fops_invalidates_cache(monkeypatch):
+    monkeypatch.setenv("AMDGCN_SCALARIZE_PACKED_FOPS", "0")
+    disabled = get_cache_invalidating_env_vars()
+
+    monkeypatch.setenv("AMDGCN_SCALARIZE_PACKED_FOPS", "1")
+    enabled = get_cache_invalidating_env_vars()
+
+    assert disabled["AMDGCN_SCALARIZE_PACKED_FOPS"] == "false"
+    assert enabled["AMDGCN_SCALARIZE_PACKED_FOPS"] == "true"
 
 
 @pytest.mark.parametrize("truthy, falsey", [("1", "0"), ("true", "false"), ("True", "False"), ("TRUE", "FALSE"),


### PR DESCRIPTION
Summary:

Keep the fbcode `python.test` import path for normal Buck runs, but fall back to pytest-s local `conftest` module when Reactor-s packaged top-level `python` package shadows the prepared Triton namespace. Only handle the exact missing `python.test` module so dependency import errors remain visible.

Reviewed By: njriasan

Differential Revision: D114342563


