### PR TITLE
[triton][AMD] Make ASAN helper launch hermetic

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.h
+++ b/include/triton/Tools/Sys/GetEnv.h
@@ -15,6 +15,7 @@ namespace mlir::triton {
 inline const std::set<std::string> CACHE_INVALIDATING_ENV_VARS = {
     // clang-format off
     "AMDGCN_ENABLE_DUMP",
+    "AMDGCN_SCALARIZE_PACKED_FOPS",
     "AMDGCN_USE_BUFFER_ATOMICS",
     "AMDGCN_USE_BUFFER_OPS",
     "DISABLE_LLVM_OPT",

--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -16,7 +16,12 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 from triton.runtime.fbcode_gating import is_fbcode_dependant
 
 if is_fbcode_dependant():
-    from python.test.unit.language.conftest import _generate_test_params, _swizzle_scale_to_5d
+    try:
+        from python.test.unit.language.conftest import _generate_test_params, _swizzle_scale_to_5d
+    except ModuleNotFoundError as error:
+        if error.name != "python.test":
+            raise
+        from conftest import _generate_test_params, _swizzle_scale_to_5d
 else:
     from conftest import _generate_test_params, _swizzle_scale_to_5d
 

--- a/python/test/unit/language/test_tlx_tma.py
+++ b/python/test/unit/language/test_tlx_tma.py
@@ -10,7 +10,12 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 from triton.runtime.fbcode_gating import is_fbcode_dependant
 
 if is_fbcode_dependant():
-    from python.test.unit.language.conftest import _swizzle_scale_to_5d
+    try:
+        from python.test.unit.language.conftest import _swizzle_scale_to_5d
+    except ModuleNotFoundError as error:
+        if error.name != "python.test":
+            raise
+        from conftest import _swizzle_scale_to_5d
 else:
     from conftest import _swizzle_scale_to_5d
 

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import shutil
 import triton
+from triton._C.libtriton import get_cache_invalidating_env_vars
 from triton._internal_testing import is_hip
 
 from pathlib import Path
@@ -109,6 +110,17 @@ def test_env_updated(fresh_knobs, monkeypatch):
     fresh_knobs.cache.home_dir = "/foo/bar"
     assert os.getenv("TRITON_HOME") == "/foo/bar"
     assert os.environ["TRITON_HOME"] == "/foo/bar"
+
+
+def test_scalarize_packed_fops_invalidates_cache(monkeypatch):
+    monkeypatch.setenv("AMDGCN_SCALARIZE_PACKED_FOPS", "0")
+    disabled = get_cache_invalidating_env_vars()
+
+    monkeypatch.setenv("AMDGCN_SCALARIZE_PACKED_FOPS", "1")
+    enabled = get_cache_invalidating_env_vars()
+
+    assert disabled["AMDGCN_SCALARIZE_PACKED_FOPS"] == "false"
+    assert enabled["AMDGCN_SCALARIZE_PACKED_FOPS"] == "true"
 
 
 @pytest.mark.parametrize("truthy, falsey", [("1", "0"), ("true", "false"), ("True", "False"), ("TRUE", "FALSE"),

--- a/third_party/amd/python/test/test_address_sanitizer.py
+++ b/third_party/amd/python/test/test_address_sanitizer.py
@@ -1,5 +1,7 @@
 import os
 import subprocess
+import sys
+from pathlib import Path
 
 import triton
 
@@ -32,6 +34,11 @@ def test_address_sanitizer():
     # Disable buffer ops given it has builtin support for out of bound access.
     os.environ["AMDGCN_USE_BUFFER_OPS"] = "0"
 
-    out = subprocess.Popen(["python", "address_sanitizer_helper.py"], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
-    assert "Begin function __asan_report" in out.stdout.read().decode()
-    assert "heap-buffer-overflow" in out.stderr.read().decode()
+    out = subprocess.run(
+        [sys.executable, str(Path(__file__).with_name("address_sanitizer_helper.py"))],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert "Begin function __asan_report" in out.stdout
+    assert "heap-buffer-overflow" in out.stderr


### PR DESCRIPTION
Summary: Launch the address-sanitizer helper with `sys.executable` and an absolute sibling path instead of relying on a host `python` executable and pytest working directory. Use `subprocess.run` to drain both pipes without deadlock.

Reviewed By: njriasan

Differential Revision: D114342568


