### PR TITLE
[cuda] Migrate docs and agent skills off the `fbcode.platform010_cuda_version` buckconfig

### DIFF
--- a/.claude/skills/running-with-buck/SKILL.md
+++ b/.claude/skills/running-with-buck/SKILL.md
@@ -31,12 +31,12 @@ under Buck in fbcode. It is target-agnostic: substitute your own
    default/stable Triton — without it, changes made here are not exercised.
 4. **Select the GPU architecture** with `-c fbcode.nvcc_arch=<arch>` and,
    where required, the **CUDA version** with
-   `-c fbcode.platform010_cuda_version=<ver>` (see *Hardware
+   `-m ovr_config//third-party/cuda/constraints:<ver>` (see *Hardware
    requirements*).
 5. **Environment variables prefix the `buck2 run`** and are forwarded to
    the launched process:
    ```bash
-   <ENV VARS> buck2 run @mode/opt -m ovr_config//triton:beta -c fbcode.nvcc_arch=<arch> [-c fbcode.platform010_cuda_version=<ver>] \
+   <ENV VARS> buck2 run @mode/opt -m ovr_config//triton:beta -c fbcode.nvcc_arch=<arch> [-m ovr_config//third-party/cuda/constraints:<ver>] \
      <buck target> -- <program args>
    ```
 6. **`buck2 build` vs `buck2 run`.** Use `buck2 build <target>` to compile
@@ -48,7 +48,7 @@ under Buck in fbcode. It is target-agnostic: substitute your own
 
 Pick the arch (and CUDA version) for the single GPU you are targeting:
 
-| Hardware | `fbcode.nvcc_arch` | `fbcode.platform010_cuda_version` |
+| Hardware | `fbcode.nvcc_arch` | `ovr_config//third-party/cuda/constraints:<version>` |
 | --- | --- | --- |
 | Hopper (H100) | `h100a` | (default) |
 | Blackwell B200 / GB200 | `b200a` | `>= 12.8` |
@@ -67,7 +67,7 @@ Notes:
 ```bash
 buck2 run @mode/opt -m ovr_config//triton:beta \
   -c fbcode.nvcc_arch=b300a \
-  -c fbcode.platform010_cuda_version=13.0 \
+  -m ovr_config//third-party/cuda/constraints:13.0 \
   <buck target> -- <program args>
 ```
 
@@ -75,7 +75,7 @@ buck2 run @mode/opt -m ovr_config//triton:beta \
 ```bash
 buck2 run @mode/opt -m ovr_config//triton:beta \
   -c fbcode.nvcc_arch=b200a \
-  -c fbcode.platform010_cuda_version=12.8 \
+  -m ovr_config//third-party/cuda/constraints:12.8 \
   <buck target> -- <program args>
 ```
 
@@ -89,13 +89,13 @@ buck2 run @mode/opt -m ovr_config//triton:beta \
 **With env vars forwarded** (e.g. enabling a feature for the run):
 ```bash
 SOME_ENV=1 buck2 run @mode/opt -m ovr_config//triton:beta -c fbcode.nvcc_arch=b300a \
-  -c fbcode.platform010_cuda_version=13.0 \
+  -m ovr_config//third-party/cuda/constraints:13.0 \
   <buck target> -- <program args>
 ```
 
 **Compile only** (surface a build/compile failure without running):
 ```bash
 buck2 build @mode/opt -m ovr_config//triton:beta -c fbcode.nvcc_arch=b300a \
-  -c fbcode.platform010_cuda_version=13.0 \
+  -m ovr_config//third-party/cuda/constraints:13.0 \
   <buck target>
 ```


### PR DESCRIPTION
Summary:
Last of the three follow-ups to D114549185 (build files) and D114549808 (scripts and configs), completing the `fbcode.platform010_cuda_version` retirement (T282903149) outside `fbsource/users/`.

Docs only: READMEs, runbooks, plan docs, `.claude`/`.llms` SKILL files and reference pages that tell a reader (or an agent) to pass `-c fbcode.platform010_cuda_version=<v>`. Every one becomes `-m ovr_config//third-party/cuda/constraints:<v>`. This matters more than usual for the skill files — they are instructions an agent copies verbatim into a build command, so leaving them stale would keep regenerating uses of the retired buckconfig after the lint rule from D114406837 lands.

Shapes covered beyond the plain flag: line-wrapped commands where `-c` ends one line and the key starts the next, backticked bare key names in tables (`` `-c fbcode.platform010_cuda_version` `` → `` `-m ovr_config//third-party/cuda/constraints:<version>` ``), and prose mentions of the key with no flag at all.

Two spots are deliberately left on the old buckconfig, because no matching constraint target exists for their value (the D114406837 lint rule skips these values for the same reason):

- `claude-templates/.../amd-gemm-benchmark-get-hipblaslt-log/SKILL.md` — suggests `-c fbcode.platform010_cuda_version=rocm` as an AMD fallback.
- Nothing else; all other doc sites migrated cleanly.

While here, `comms/ncclx/docs/ncclx_readme.md` had two build commands that passed *both* the buckconfig and the equivalent `-m` modifier. The now-duplicate modifier is dropped rather than repeated.

Excluded from this diff on purpose: the four `genai/msl/prod_inference/github_mirror/**` docs. Touching that tree links the `mslsrc/prod_inference` export project to the diff and pulls in its ServiceLab workloads, which is unrelated CI for a documentation-only change. They can be migrated separately by their owners.

Reviewed By: sabrina-lo

Differential Revision: D114549880


