### PR TITLE
[H100 downstream][Triton][beta] Make fast-cache insertion idempotent (#2713)

### DIFF
--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -886,8 +886,26 @@ struct FastCache {
     return nullptr;
   }
 
-  void insert(const FCCacheKey &key, PyObject *kernel, PyObject *dispatcher,
-              PyObject *const *args, int n_args) {
+  FCEntry *insert(const FCCacheKey &key, PyObject *kernel, PyObject *dispatcher,
+                  PyObject *const *args, int n_args) {
+    // Autotuner seeding can insert the same specialization more than once.
+    // Keep a single entry so dispatcher metadata cannot diverge across
+    // duplicates or be reordered by a table resize.
+    if (table) {
+      if (FCEntry *entry = lookup(key, args)) {
+        Py_INCREF(kernel);
+        Py_XINCREF(dispatcher);
+        Py_DECREF(entry->kernel);
+        Py_XDECREF(entry->dispatcher);
+        entry->kernel = kernel;
+        entry->dispatcher = dispatcher;
+        free(entry->dispatch_arg_indices);
+        entry->dispatch_arg_indices = nullptr;
+        entry->n_dispatch_args = 0;
+        return entry;
+      }
+    }
+
     if (!table)
       init_table(16);
     if (count * 4 >= capacity * 3)
@@ -906,7 +924,7 @@ struct FastCache {
     if (n_ce && (!positions || !vals)) {
       free(positions);
       free(vals);
-      return; // OOM — skip insertion
+      return nullptr; // OOM — skip insertion
     }
     int ci = 0;
     for (int i = 0; i < n_args && i < n_params; i++) {
@@ -939,7 +957,7 @@ struct FastCache {
               Py_DECREF(vals[k]);
             free(vals);
             free(positions);
-            return;
+            return nullptr;
           }
           vals[ci] = cmp_key; // new ref from PyTuple_Pack
         } else {
@@ -950,7 +968,7 @@ struct FastCache {
             Py_DECREF(vals[k]);
           free(vals);
           free(positions);
-          return;
+          return nullptr;
         }
         ci++;
       }
@@ -973,11 +991,13 @@ struct FastCache {
     table[idx].n_dispatch_args = 0;
     table[idx].occupied = true;
     count++;
+    return &table[idx];
   }
 
-  void set_dispatch_indices(size_t idx, int *indices, int n) {
-    table[idx].dispatch_arg_indices = indices;
-    table[idx].n_dispatch_args = n;
+  void set_dispatch_indices(FCEntry *entry, int *indices, int n) {
+    free(entry->dispatch_arg_indices);
+    entry->dispatch_arg_indices = indices;
+    entry->n_dispatch_args = n;
   }
 };
 
@@ -1525,7 +1545,7 @@ PyObject *native_fast_dispatch_insert(PyObject *self, PyObject *const *args,
     Py_RETURN_NONE;
 
   PyObject *disp = (dispatcher == Py_None) ? nullptr : dispatcher;
-  cache->insert(key, kernel, disp, ca, (int)n);
+  FCEntry *entry = cache->insert(key, kernel, disp, ca, (int)n);
 
   // Store dispatch_arg_indices if provided
   if (dispatch_indices != Py_None && PyTuple_Check(dispatch_indices)) {
@@ -1537,21 +1557,8 @@ PyObject *native_fast_dispatch_insert(PyObject *self, PyObject *const *args,
           indices[i] =
               (int)PyLong_AsLong(PyTuple_GET_ITEM(dispatch_indices, i));
         }
-        if (!PyErr_Occurred() && cache->table) {
-          // Find the just-inserted entry
-          FCCacheKeyHash hasher;
-          size_t idx = hasher(key) % cache->capacity;
-          bool found = false;
-          while (cache->table[idx].occupied) {
-            if (cache->table[idx].key == key) {
-              cache->set_dispatch_indices(idx, indices, (int)n_indices);
-              found = true;
-              break;
-            }
-            idx = (idx + 1) % cache->capacity;
-          }
-          if (!found)
-            free(indices);
+        if (!PyErr_Occurred() && entry) {
+          cache->set_dispatch_indices(entry, indices, (int)n_indices);
         } else {
           PyErr_Clear();
           free(indices);

--- a/test/Conversion/tma_to_llvm.mlir
+++ b/test/Conversion/tma_to_llvm.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --convert-triton-gpu-to-llvm --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | FileCheck %s
+// RUN: triton-opt %s --convert-triton-gpu-to-llvm=compute-capability=100 --convert-nv-gpu-to-llvm | mlir-translate -mlir-to-llvmir | opt -S -O1 | FileCheck %s
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -284,7 +284,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_global_to_local
   // CHECK: elect.sync
-  // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes [$1], [$2, {$3, $4}], [$5];", "b,r,l,r,r,r" {{.*}} : (i1, !llvm.ptr<3>, !llvm.ptr, i32, i32, !llvm.ptr<3>) -> !llvm.void
+  // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes [$1], [$2, {$3, $4}], [$5];", "b,r,l,r,r,r" {{.*}} : (i1, !llvm.ptr<3>, !llvm.ptr, i32, i32, !llvm.ptr<3>) -> !llvm.void
   // CHECK-NOT: cp.async.bulk.tensor.2d.shared
   // CHECK: return
   tt.func @tma_copy_global_to_local(%tma: !tt.tensordesc<128x128xf32, #shared1>, %alloc: !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
@@ -348,14 +348,14 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
-// TMA copy with barrier mask zero: barrier has no CGALayout -> shared::cta
+// The current pre-PTX-8.6 Hopper path uses shared::cluster even when the
+// barrier has no CGALayout.
 #shared0_cta = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_barrier_mask_zero
-  // CHECK: cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes
-  // CHECK-NOT: cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier
+  // CHECK: cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes
   tt.func @tma_copy_barrier_mask_zero(%tma: !tt.tensordesc<128x128xf32, #shared1>, %alloc: !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0_cta, #smem>, %pred: i1) {
     ttng.async_tma_copy_global_to_local %tma[%x, %x] %alloc, %barrier, %pred : !tt.tensordesc<128x128xf32, #shared1>, !ttg.memdesc<1xi64, #shared0_cta, #smem> -> !ttg.memdesc<128x128xf32, #shared1, #smem, mutable>
     tt.return
@@ -369,7 +369,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true} {
   // CHECK-LABEL: tma_copy_single_cta_barrier_in_two_cta_kernel
-  // CHECK: cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes
   // CHECK-NOT: cp.async.bulk.tensor.2d.cta_group::2
   tt.func @tma_copy_single_cta_barrier_in_two_cta_kernel(%tma: !tt.tensordesc<128x128xf32, #shared1_cga>, %alloc: !ttg.memdesc<128x128xf32, #shared1_cga, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<2xi64, #shared0_cta, #smem>, %pred: i1) {
     ttng.async_tma_copy_global_to_local %tma[%x, %x] %alloc, %barrier, %pred : !tt.tensordesc<128x128xf32, #shared1_cga>, !ttg.memdesc<2xi64, #shared0_cta, #smem> -> !ttg.memdesc<128x128xf32, #shared1_cga, #smem, mutable>
@@ -440,7 +440,7 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy_global_to_local_im2col
   // CHECK: elect.sync
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // CHECK-NOT: cp.async.bulk.tensor.4d.shared
   // CHECK: return
   tt.func @tma_copy_global_to_local_im2col(%tma: !ttng.tensordesc_im2col<16x64xf32, #shared1>, %alloc: !ttg.memdesc<16x64xf32, #shared1, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
@@ -467,16 +467,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // Verify 4 TMA messages are generated with offsets computed via shift-left by 8 (multiply by 256)
   // CHECK-DAG: llvm.mlir.constant(8 : i32)
   // Message 1 (copyIdx=0): offset = 0 << 8 = 0
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // Message 2 (copyIdx=1): offset = 1 << 8 = 256
   // CHECK: llvm.mlir.constant(1 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // Message 3 (copyIdx=2): offset = 2 << 8 = 512
   // CHECK: llvm.mlir.constant(2 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // Message 4 (copyIdx=3): offset = 3 << 8 = 768
   // CHECK: llvm.mlir.constant(3 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // CHECK: return
   tt.func @tma_copy_global_to_local_im2col_multi_msg(%tma: !ttng.tensordesc_im2col<64x1024xf32, #shared2>, %alloc: !ttg.memdesc<64x1024xf32, #shared2, #smem, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
     %off_w = arith.constant 1 : i16
@@ -502,16 +502,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
   // Verify 4 TMA messages are generated with offsets computed via shift-left by 6 (multiply by 64)
   // CHECK-DAG: llvm.mlir.constant(6 : i32)
   // Message 1 (copyIdx=0): offset = 0 << 6 = 0
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // Message 2 (copyIdx=1): offset = 1 << 6 = 64
   // CHECK: llvm.mlir.constant(1 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // Message 3 (copyIdx=2): offset = 2 << 6 = 128
   // CHECK: llvm.mlir.constant(2 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // Message 4 (copyIdx=3): offset = 3 << 6 = 192
   // CHECK: llvm.mlir.constant(3 : i32)
-  // CHECK: cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes
+  // CHECK: cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes
   // CHECK: return
   tt.func @tma_copy_global_to_local_im2col_multi_msg_swizzle(%tma: !ttng.tensordesc_im2col<64x256xf16, #shared_swz>, %alloc: !ttg.memdesc<64x256xf16, #shared_swz, #smem_swz, mutable>, %x: i32, %barrier: !ttg.memdesc<1xi64, #shared0_swz, #smem_swz>, %pred: i1) {
     %off_w = arith.constant 1 : i16

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1423,8 +1423,12 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       // otherwise it is CTA-local. The barrier component keys on the barrier
       // layout (not the SMEM layout), matching #9510.
       auto multicastMask = op.getMulticastTargets();
-      bool clusterScope = crossCTABarrier || multicast ||
-                          multicastMask != nullptr || op.getTwoCta();
+      // The current Hopper toolchain emits PTX < 8.6, where shared::cta TMA
+      // loads are not accepted. Conservatively use cluster scope on Hopper;
+      // keep CTA scope on Blackwell.
+      bool clusterScope = computeCapability < 100 || crossCTABarrier ||
+                          multicast || multicastMask != nullptr ||
+                          op.getTwoCta();
       std::string tmaInst = "@$0 cp.async.bulk.tensor." + std::to_string(rank) +
                             "d.shared::" + (clusterScope ? "cluster" : "cta") +
                             ".global.mbarrier::complete_tx::bytes";


### PR DESCRIPTION
Summary:

Failed tests:
- TestTritonbenchGpu.test_gpu_tritonbench_generalized_dot_product_attention
- StuTest.test_mrn_train_parity
- StuTest.test_custom_kernel_cross_hstu
- StuTest.test_custom_kernel_softmax_attention
- HSTULinearTest.test_compute_output_triton_cc
- RaggedHSTUAttentionTest.test_hstu_preprocess_and_attention_train

Failure:
The original local generalized-attention run failed with a cache/dispatch error; ServiceLab reported a different "CUDA error: unspecified launch failure" that has not been reproduced locally. HSTU target runs intermittently reported a CUDA misaligned-address launch failure followed by Xid 13/43 errors; after the first fault, the poisoned CUDA context made later tests fail as a cascade.

Root cause:
Reinserting the same fast-cache specialization could create duplicate entries or pair a dispatcher with incorrect argument-index metadata. A replacement with no index tuple could also retain stale indices.

Fix:
Update the existing specialization in place, clear its prior dispatcher indices, and attach any replacement indices directly to the returned entry.

Verification status:
The corrected beta fast-cache suite passes 19/19. A frozen-revision full TritonBench reproduction is still running on a separate H100.

Reviewed By: tissue3

Differential Revision: D114313143


