### PR TITLE
[H100 core][triton][beta][auto-TMA] Fix recipe shared-layout lookup

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -354,7 +354,7 @@ py::list getAutoTmaRecipes(ModuleOp &mod) {
         auto shp = blockTy.getShape();
         blockShape.assign(shp.begin(), shp.end());
         if (shp.size() >= 2 &&
-            isa<ttg::NVMMASharedEncodingAttr>(blockTy.getEncoding())) {
+            isa<ttg::NVMMASharedEncodingAttr>(descTy.getSharedLayout())) {
           auto sw = ttng::getTMASwizzleMode(descArg.getLoc(), descTy);
           if (succeeded(sw))
             swizzle = *sw;

--- a/python/test/unit/runtime/test_cache_determinism.py
+++ b/python/test/unit/runtime/test_cache_determinism.py
@@ -71,6 +71,9 @@ def stress_parent():
 
 def _subprocess_key(mode, seed, order="forward"):
     env = os.environ.copy()
+    # A Buck par's sys.executable does not reconstruct the parent test
+    # runner's link-tree paths when it launches a script directly.
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
     env["PYTHONHASHSEED"] = str(seed)
     env["TRITON_CACHE_KEY_TEST_ORDER"] = order
     env["TRITON_CACHE_KEY_TEST_SEED"] = str(seed)

--- a/third_party/proton/proton/hooks/instrumentation.py
+++ b/third_party/proton/proton/hooks/instrumentation.py
@@ -305,7 +305,7 @@ class InstrumentationHook(Hook):
             total_unit = data["num_warps"]
             uid_num = total_unit if self.mode.sampling_strategy == triton_proton.SAMPLING_STRATEGY.NONE else len(
                 sampled_warps)
-            block_num = int(alloc_size / scratch_mem_size)
+            block_num = alloc_size // scratch_mem_size if scratch_mem_size else 0
 
             # Binary trace layout:
             # +------------------+
@@ -357,5 +357,6 @@ class InstrumentationHook(Hook):
             InstrumentationHook.host_buffer = torch.empty(header_size + alloc_size, dtype=torch.uint8, device="cpu")
             config_portion = InstrumentationHook.host_buffer[:header_size]
             config_portion.copy_(torch.tensor(list(header_bytes), dtype=torch.uint8))
-            data_portion = InstrumentationHook.host_buffer[header_size:].view_as(self.buffer)
-            data_portion.copy_(self.buffer.cpu())
+            if self.buffer is not None:
+                data_portion = InstrumentationHook.host_buffer[header_size:].view_as(self.buffer)
+                data_portion.copy_(self.buffer.cpu())

--- a/third_party/proton/test/test_instrumentation.py
+++ b/third_party/proton/test/test_instrumentation.py
@@ -296,6 +296,41 @@ def test_select_ids(tmp_path: pathlib.Path):
         assert sorted(warp_indices) == select_ids
 
 
+def test_no_scope_zero_scratch(tmp_path: pathlib.Path):
+    from contextlib import contextmanager
+
+    mode = proton.mode.Default()
+
+    @contextmanager
+    def instrumentation(file_path):
+        proton.hooks.InstrumentationHook.enable_host_buffer = True
+        proton.start(str(file_path.with_suffix("")), backend="instrumentation", mode=mode)
+        try:
+            yield
+        finally:
+            proton.hooks.InstrumentationHook.enable_host_buffer = False
+            proton.finalize()
+
+    @triton.jit
+    def add_kernel(x_ptr, y_ptr, output_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+        pid = tl.program_id(axis=0)
+        offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(x_ptr + offsets, mask=mask)
+        y = tl.load(y_ptr + offsets, mask=mask)
+        tl.store(output_ptr + offsets, x + y, mask=mask)
+
+    size = 256
+    x = torch.rand(size, device="cuda")
+    y = torch.rand(size, device="cuda")
+    output = torch.empty_like(x)
+    temp_file = tmp_path / "test_no_scope_zero_scratch.hatchet"
+
+    with instrumentation(temp_file):
+        add_kernel[(1, 1, 1)](x, y, output, size, BLOCK_SIZE=1024, num_warps=4)
+        assert proton.hooks.InstrumentationHook.host_buffer is not None
+
+
 @pytest.mark.parametrize("hook", ["triton", None])
 def test_tree(tmp_path: pathlib.Path, hook):
 


### PR DESCRIPTION
Summary:
Failed tests:
- test_auto_tma_2d_strided_numerics
- test_auto_tma_gemm_nows
- test_ws_auto_tma_data_partition_numerics
- test_auto_tma_store_block_over_256_promoted
- test_auto_tma_outer_dim_over_256
- test_auto_tma_autows_load_over_256
- test_auto_tma_metaws_store_over_256

Failure:
Compilation crashed while deriving host AutoTMA recipes because
TensorDescInterface::getBlockType() returns an unencoded ranked tensor and
getAutoTmaRecipes dereferenced its null encoding.

Fix:
Read the finalized shared layout directly from TensorDescInterface. This is the
authoritative descriptor layout after descriptor-encoding optimization and
avoids inspecting the unencoded block type.

Reviewed By: njriasan, tissue3

Differential Revision: D114275448


