### PR TITLE
[TLX][Blackwell] Reduce register spills in softmax partition via lifetime shortening (#2717)

### DIFF
--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -72,7 +72,10 @@ configs = [
         num_warps=4,
         pre_hook=_host_descriptor_pre_hook,
         ctas_per_cga=(2, 1, 1),
-    ) for kv in [3, 5] for grp_n in [1] for (rescale_opt, where) in [(False, False), (True, False), (True, True)]
+    )
+    for kv in [4, 5, 6, 7, 8, 9]
+    for grp_n in [1]
+    for (rescale_opt, where) in [(False, False), (True, False), (True, True)]
 ]
 
 
@@ -89,7 +92,7 @@ def prune_configs_by_hdim(configs, named_args, **kwargs):
         if grp_n != target_group_size_n:
             continue
         if is_2cta:
-            if kv not in (3, 5):
+            if kv not in (4, 5, 6, 7):
                 continue
         else:
             if kv != target_kv_buffers:
@@ -246,12 +249,8 @@ def _softmax_inner_loop(
     lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
 
     for start_n in tl.range(lo, hi, BLOCK_N):
-        if USE_2CTA:
-            qk_buf = accum_cnt_qk & 1
-            qk_buf_phase = (accum_cnt_qk >> 1) & 1
-        else:
-            qk_buf = cid
-            qk_buf_phase = accum_cnt_qk & 1
+        qk_buf = cid
+        qk_buf_phase = accum_cnt_qk & 1
         alpha_phase = accum_cnt_qk & 1
         tlx.barrier_wait(tlx.local_view(qk_fulls, qk_buf), qk_buf_phase)
         qk = tlx.local_load(tlx.local_view(qk_tiles, qk_buf))
@@ -407,99 +406,6 @@ def _fwd_load_1cta(
 
         kv_offset_y += BLOCK_N
         accum_cnt_kv += 2
-
-    return accum_cnt_kv
-
-
-@triton.jit
-def _fwd_load_2cta(
-    tile_count,
-    accum_cnt_kv,
-    lo,
-    hi,
-    qo_offset_y,
-    kv_offset_y,
-    desc_q,
-    desc_k,
-    desc_v,
-    q_tiles,
-    k_tiles,
-    v_tiles,
-    q_fulls,
-    q_empties,
-    k_fulls,
-    k_empties,
-    v_fulls,
-    v_empties,
-    cluster_cta_rank,
-    is_leader,
-    Q_BYTES_PER_ELEM: tl.constexpr,
-    K_BYTES_PER_ELEM: tl.constexpr,
-    V_BYTES_PER_ELEM: tl.constexpr,
-    BLOCK_M_SPLIT: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    HEAD_DIM: tl.constexpr,
-    NUM_CTAS: tl.constexpr,
-    NUM_BUFFERS_Q: tl.constexpr,
-    NUM_BUFFERS_KV: tl.constexpr,
-):
-    """2-CTA M-split forward load for one tile.
-
-    Each CTA loads ONE Q group (128 rows selected by cluster_cta_rank).
-    K/V are collective-MMA B operands loaded with two_ctas (leader-only
-    expect_bytes covers both halves):
-      K split along BLOCK_N rows   -> k_tiles[BLOCK_N // NUM_CTAS, HEAD_DIM]
-      V split along HEAD_DIM cols   -> v_tiles[BLOCK_N, HEAD_DIM // NUM_CTAS]
-    Both CTAs share the same tile → same kv_offset_y → consistent K/V head.
-    """
-    BLOCK_N_KV: tl.constexpr = BLOCK_N // NUM_CTAS
-    HEAD_DIM_KV: tl.constexpr = HEAD_DIM // NUM_CTAS
-
-    # load Q (two_ctas: both CTAs signal the leader's barrier so the MMA
-    # knows BOTH halves of Q are in SMEM before the .2CTA Q@K dot).
-    q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
-    tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
-    if is_leader:
-        tlx.barrier_expect_bytes(q_fulls[q_bufIdx], Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
-    tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx], [qo_offset_y + cluster_cta_rank * BLOCK_M_SPLIT, 0],
-                              q_fulls[q_bufIdx], two_ctas=tl.constexpr(True))
-
-    # load K (two_ctas, split along BLOCK_N rows)
-    k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-    tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
-    if is_leader:
-        tlx.barrier_expect_bytes(k_fulls[k_bufIdx], K_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-    tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx], [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0],
-                              k_fulls[k_bufIdx], two_ctas=tl.constexpr(True))
-
-    # load V (two_ctas, split along HEAD_DIM cols)
-    v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-    tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
-    if is_leader:
-        tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-    tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx], [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV],
-                              v_fulls[v_bufIdx], two_ctas=tl.constexpr(True))
-
-    kv_offset_y += BLOCK_N
-    accum_cnt_kv += 1
-
-    for _ in tl.range(lo + BLOCK_N, hi, BLOCK_N):
-        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-        tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
-        if is_leader:
-            tlx.barrier_expect_bytes(k_fulls[k_bufIdx], K_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-        tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx], [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0],
-                                  k_fulls[k_bufIdx], two_ctas=tl.constexpr(True))
-
-        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-        tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
-        if is_leader:
-            tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-        tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx], [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV],
-                                  v_fulls[v_bufIdx], two_ctas=tl.constexpr(True))
-
-        kv_offset_y += BLOCK_N
-        accum_cnt_kv += 1
 
     return accum_cnt_kv
 
@@ -691,142 +597,6 @@ def _fwd_mma_dots_1cta(
     return accum_cnt_kv, accum_cnt_qk
 
 
-@triton.jit
-def _fwd_mma_dots_2cta(
-    tile_count,
-    accum_cnt_kv,
-    accum_cnt_qk,
-    lo,
-    hi,
-    q_tiles,
-    k_tiles,
-    v_tiles,
-    qk_tiles,
-    p_tiles,
-    acc_tiles,
-    q_empties,
-    q_fulls,
-    k_fulls,
-    k_empties,
-    v_fulls,
-    v_empties,
-    qk_fulls,
-    qk_empties,
-    p_fulls,
-    acc_fulls,
-    acc_empties,
-    alpha_fulls,
-    BLOCK_N: tl.constexpr,
-    HEAD_DIM: tl.constexpr,
-    NUM_CTAS: tl.constexpr,
-    NUM_BUFFERS_Q: tl.constexpr,
-    NUM_BUFFERS_KV: tl.constexpr,
-    NUM_MMA_SLICES: tl.constexpr,
-    NUM_MMA_GROUPS: tl.constexpr,
-):
-    """2-CTA M-split forward MMA with P@V-first pipeline.
-
-    Prolog:  Q@K[0] only (no P@V)
-    Loop:    P@V[i] + Q@K[i+1]  (P@V dispatched first)
-    Epilog:  P@V[last]
-
-    P@V dispatched BEFORE Q@K so TC FIFO guarantees P@V[i] completes
-    before Q@K[i+1]. The correction triggered by Q@K[i+1] is therefore
-    safe to read acc_tiles without an extra pv_done barrier.
-    """
-    HEAD_DIM_KV: tl.constexpr = HEAD_DIM // NUM_CTAS
-
-    q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
-    k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-
-    # --- PROLOG: dispatch Q@K[0] to buf 0, no P@V ---
-    tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
-    tlx.barrier_wait(q_fulls[q_bufIdx], q_phase)
-
-    k_tile = tlx.local_trans(k_tiles[k_bufIdx])
-    tlx.barrier_wait(qk_empties[0], q_phase ^ 1)
-    tlx.async_dot(q_tiles[0], k_tile, qk_tiles[0], use_acc=False, mBarriers=[qk_fulls[0], k_empties[k_bufIdx]],
-                  two_ctas=True)
-
-    # --- INNER LOOP: P@V[i] then Q@K[i+1] (P@V-first) ---
-    pv_started = False
-    v_bufIdx_prev_pv = 0
-
-    for i in tl.range(lo + BLOCK_N, hi, BLOCK_N):
-        qk_buf_prev = accum_cnt_qk & 1
-        qk_phase_prev = (accum_cnt_qk >> 1) & 1
-
-        accum_cnt_qk += 1
-        accum_cnt_kv += 1
-        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-        qk_buf = accum_cnt_qk & 1
-        v_bufIdx_for_pv, v_phase_for_pv = get_bufidx_phase(accum_cnt_kv - 1, NUM_BUFFERS_KV)
-
-        # -- Dispatch P@V FIRST --
-        tlx.barrier_wait(v_fulls[v_bufIdx_for_pv], v_phase_for_pv)
-        tlx.barrier_wait(acc_fulls[qk_buf_prev], qk_phase_prev)
-        last_p_idx = qk_buf_prev * NUM_MMA_SLICES + (NUM_MMA_SLICES - 1)
-        tlx.barrier_wait(p_fulls[last_p_idx], qk_phase_prev)
-        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-            p_idx = qk_buf_prev * NUM_MMA_SLICES + slice_id
-            kv_slice = tlx.local_slice(v_tiles[v_bufIdx_for_pv], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                                       [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
-            if pv_started:
-                if slice_id == NUM_MMA_SLICES - 1:
-                    tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=True,
-                                  mBarriers=[v_empties[v_bufIdx_prev_pv]], two_ctas=True)
-                else:
-                    tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=True, two_ctas=True)
-            else:
-                if slice_id == NUM_MMA_SLICES - 1:
-                    tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=slice_id > 0, two_ctas=True)
-                else:
-                    tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=slice_id > 0, force_async=True,
-                                  two_ctas=True)
-        v_bufIdx_prev_pv = v_bufIdx_for_pv
-        pv_started = True
-
-        # -- Dispatch Q@K SECOND --
-        tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
-        k_tile = tlx.local_trans(k_tiles[k_bufIdx])
-        tlx.async_dot(q_tiles[0], k_tile, qk_tiles[qk_buf], use_acc=False,
-                      mBarriers=[qk_fulls[qk_buf], k_empties[k_bufIdx]], two_ctas=True)
-
-    # --- EPILOG: P@V[last] ---
-    qk_buf_last = accum_cnt_qk & 1
-    qk_phase_last = (accum_cnt_qk >> 1) & 1
-    v_bufIdx_last, v_phase_last = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-
-    tlx.barrier_wait(v_fulls[v_bufIdx_last], v_phase_last)
-    tlx.barrier_wait(acc_fulls[qk_buf_last], qk_phase_last)
-    last_p_idx_ep = qk_buf_last * NUM_MMA_SLICES + (NUM_MMA_SLICES - 1)
-    tlx.barrier_wait(p_fulls[last_p_idx_ep], qk_phase_last)
-    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-        p_idx = qk_buf_last * NUM_MMA_SLICES + slice_id
-        kv_slice = tlx.local_slice(v_tiles[v_bufIdx_last], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                                   [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
-        if pv_started:
-            if slice_id == NUM_MMA_SLICES - 1:
-                tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=True,
-                              mBarriers=[v_empties[v_bufIdx_prev_pv]], two_ctas=True)
-            else:
-                tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=True, two_ctas=True)
-        else:
-            if slice_id == NUM_MMA_SLICES - 1:
-                tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=slice_id > 0, two_ctas=True)
-            else:
-                tlx.async_dot(p_tiles[p_idx], kv_slice, acc_tiles[0], use_acc=slice_id > 0, force_async=True,
-                              two_ctas=True)
-
-    tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=True)
-    tlx.tcgen05_commit(acc_empties[0], two_ctas=True)
-    tlx.tcgen05_commit(v_empties[v_bufIdx_last], two_ctas=True)
-
-    accum_cnt_qk += 1
-    accum_cnt_kv += 1
-    return accum_cnt_kv, accum_cnt_qk
-
-
 @triton.autotune(
     configs=configs,
     key=["N_CTX", "HEAD_DIM", "STAGE"],
@@ -882,11 +652,13 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
     is_leader = (not USE_2CTA) or (cluster_cta_rank % 2 == 0)
 
     BLOCK_M_SPLIT: tl.constexpr = BLOCK_M // 2
-    # In 2-CTA M-split, each CTA handles ONE group; in 1-CTA, both groups.
-    NUM_GROUPS_PER_CTA: tl.constexpr = 1 if USE_2CTA else NUM_MMA_GROUPS
+    tl.static_assert(NUM_MMA_GROUPS == 2)
+    NUM_GROUPS_PER_CTA: tl.constexpr = NUM_MMA_GROUPS
     # Per-CTA head-dim of the multicast K/V (B) operands: the collective 2-CTA
     # MMA reassembles the full HEAD_DIM contraction from both CTAs' halves.
     HEAD_DIM_KV: tl.constexpr = HEAD_DIM // NUM_CTAS
+    # Effective M-block: 2-CTA covers BLOCK_M * NUM_CTAS total Q rows per work tile.
+    EFFECTIVE_BLOCK_M: tl.constexpr = BLOCK_M * NUM_CTAS
 
     # Compute bytes per element for each tensor type
     Q_BYTES_PER_ELEM: tl.constexpr = tlx.size_of(tlx.dtype_of(desc_q))
@@ -898,23 +670,20 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
     #   triton.cdiv(q.shape[2], META["BLOCK_M"]),
     #   q.shape[0] * q.shape[1],
     start_pid = tl.program_id(0)
-    num_pid_m = tl.cdiv(N_CTX, BLOCK_M)
+    num_pid_m = tl.cdiv(N_CTX, EFFECTIVE_BLOCK_M)
     num_pid_n = Z * H
     num_pid_in_group = num_pid_m * GROUP_SIZE_N
 
     # allocate SMEM buffers and barriers
     NUM_Q_BUFS: tl.constexpr = NUM_GROUPS_PER_CTA * NUM_BUFFERS_Q
     q_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_Q_BUFS)
+    BLOCK_N_KV: tl.constexpr = BLOCK_N // NUM_CTAS
     if USE_2CTA:
-        # 2-CTA collective-MMA B operands: K split along BLOCK_N rows, V split
-        # along HEAD_DIM cols (each CTA holds half; HW reassembles).
-        k_tiles = tlx.local_alloc((BLOCK_N // NUM_CTAS, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
-        v_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM // NUM_CTAS), tlx.dtype_of(desc_v), NUM_BUFFERS_KV)
-        # o_tiles reuses q_tiles SMEM (sequential lifetime: Q consumed in inner
-        # loop, O produced only in epilogue after inner loop completes).
-        qo_smem_alias = tlx.storage_alias_spec(storage=tlx.storage_kind.smem)
-        o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_GROUPS_PER_CTA,
-                                  reuse=qo_smem_alias)
+        # Separate k_tiles and v_tiles. K loaded as (N/2, D), local_trans to (D, N/2).
+        # V loaded as (N, D/2).
+        k_tiles = tlx.local_alloc((BLOCK_N_KV, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
+        v_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM_KV), tlx.dtype_of(desc_v), NUM_BUFFERS_KV)
+        o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_GROUPS_PER_CTA, reuse=q_tiles)
     else:
         kv_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
         o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_MMA_GROUPS)
@@ -1040,7 +809,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     num_pid_n,
                     num_pid_in_group,
                     N_CTX,
-                    BLOCK_M,
+                    EFFECTIVE_BLOCK_M,
                     STAGE,
                     GROUP_SIZE_N,
                 )
@@ -1094,14 +863,14 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                                     acc = _mul_f32x2(acc, alpha_1)
                                     tlx.local_store(subslice, acc)
                         if USE_2CTA:
-                            tlx.barrier_arrive(acc_fulls[accum_cnt & 1], 1, remote_cta_rank=0)
+                            tlx.barrier_arrive(acc_fulls[cid], 1, remote_cta_rank=0)
                         else:
                             tlx.barrier_arrive(acc_fulls[cid])
                     accum_cnt += 1
 
                 _, phase = get_bufidx_phase(tile_count, 1)
                 for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                    group_id = cluster_cta_rank + cid
+                    group_id = cid * NUM_CTAS + cluster_cta_rank
                     # epilogue
                     tlx.barrier_wait(l_fulls[cid], phase)
                     l_loaded = tlx.local_load(l_tiles[cid])
@@ -1120,7 +889,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         # so we scale here before storing M.
                         m = m * sm_scale * 1.44269504
                     m += tl.math.log2(l)
-                    offs_m = start_m * BLOCK_M + group_id * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+                    offs_m = start_m * EFFECTIVE_BLOCK_M + group_id * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
                     m_ptrs = M + off_hz * N_CTX + offs_m
                     tl.store(m_ptrs, tl.reshape(m, [BLOCK_M_SPLIT]))
 
@@ -1162,7 +931,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     num_pid_n,
                     num_pid_in_group,
                     N_CTX,
-                    BLOCK_M,
+                    EFFECTIVE_BLOCK_M,
                     STAGE,
                     GROUP_SIZE_N,
                 )
@@ -1177,12 +946,12 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                 p_dtype = tlx.dtype_of(desc_v)
 
                 if USE_2CTA:
-                    cid = 0
-                    group_id = cluster_cta_rank
+                    cid = tlx.async_task_replica_id()
+                    group_id = cid * NUM_CTAS + cluster_cta_rank
                 else:
                     cid = tlx.async_task_replica_id()
                     group_id = cid
-                offs_m = (start_m * BLOCK_M) + ((group_id * BLOCK_M_SPLIT) + tl.arange(0, BLOCK_M_SPLIT))
+                offs_m = (start_m * EFFECTIVE_BLOCK_M) + ((group_id * BLOCK_M_SPLIT) + tl.arange(0, BLOCK_M_SPLIT))
                 if STAGE & 1:
                     m_i, l_i, accum_cnt_qk = _softmax_inner_loop(
                         qk_fulls,
@@ -1255,12 +1024,98 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                 if USE_2CTA:
                     if is_leader:
                         _, _, lo2, hi2, _, _ = _compute_offsets(tile_id // NUM_CTAS, H, num_pid_n, num_pid_in_group,
-                                                                N_CTX, BLOCK_M, STAGE, GROUP_SIZE_N)
-                        accum_cnt_kv, accum_cnt_qk = _fwd_mma_dots_2cta(
-                            tile_count, accum_cnt_kv, accum_cnt_qk, lo2, hi2, q_tiles, k_tiles, v_tiles, qk_tiles,
-                            p_tiles, acc_tiles, q_empties, q_fulls, k_fulls, k_empties, v_fulls, v_empties, qk_fulls,
-                            qk_empties, p_fulls, acc_fulls, acc_empties, alpha_fulls, BLOCK_N, HEAD_DIM, NUM_CTAS,
-                            NUM_BUFFERS_Q, NUM_BUFFERS_KV, NUM_MMA_SLICES, NUM_MMA_GROUPS)
+                                                                N_CTX, EFFECTIVE_BLOCK_M, STAGE, GROUP_SIZE_N)
+                        q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
+                        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+
+                        tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
+                        tlx.barrier_wait(q_fulls[q_bufIdx], q_phase)
+
+                        k_tile = tlx.local_trans(k_tiles[k_bufIdx])
+                        tlx.barrier_wait(qk_empties[0], q_phase ^ 1)
+                        tlx.async_dot(q_tiles[0], k_tile, qk_tiles[0], use_acc=False, mBarriers=[qk_fulls[0]],
+                                      two_ctas=True)
+
+                        tlx.barrier_wait(q_fulls[q_bufIdx + NUM_BUFFERS_Q], q_phase)
+                        tlx.barrier_wait(qk_empties[1], q_phase ^ 1)
+                        tlx.async_dot(q_tiles[1], k_tile, qk_tiles[1], use_acc=False,
+                                      mBarriers=[qk_fulls[1], k_empties[k_bufIdx]], two_ctas=True)
+
+                        _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
+
+                        tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
+                        tlx.barrier_wait(acc_fulls[0], qk_phase)
+                        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                            p_bufIdx = slice_id
+                            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+                            kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                                       [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
+                            tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[0], use_acc=slice_id > 0,
+                                          force_async=True, two_ctas=True)
+
+                        acc1_init = False
+
+                        for i in tl.range(lo2 + BLOCK_N, hi2, BLOCK_N):
+                            v_bufIdx_prev = v_bufIdx
+                            qk_phase_prev = qk_phase
+
+                            accum_cnt_qk += 1
+                            accum_cnt_kv += 1
+                            k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                            v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+
+                            tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
+                            k_tile = tlx.local_trans(k_tiles[k_bufIdx])
+                            _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
+
+                            tlx.async_dot(q_tiles[0], k_tile, qk_tiles[0], use_acc=False, mBarriers=[qk_fulls[0]],
+                                          two_ctas=True)
+
+                            tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
+                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                                p_bufIdx = slice_id + NUM_MMA_SLICES
+                                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase_prev)
+                                kv_slice = tlx.local_slice(v_tiles[v_bufIdx_prev],
+                                                           [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                                           [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
+                                use_acc = acc1_init if slice_id == 0 else True
+                                mBarriers = [v_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
+                                tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[1], use_acc=use_acc,
+                                              mBarriers=mBarriers, two_ctas=True)
+
+                            acc1_init = True
+
+                            tlx.async_dot(q_tiles[1], k_tile, qk_tiles[1], use_acc=False,
+                                          mBarriers=[qk_fulls[1], k_empties[k_bufIdx]], two_ctas=True)
+
+                            tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
+                            tlx.barrier_wait(acc_fulls[0], qk_phase)
+                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                                p_bufIdx = slice_id
+                                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+                                kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                                           [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
+                                tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[0], use_acc=True, force_async=True,
+                                              two_ctas=True)
+
+                        tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=True)
+                        tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q], two_ctas=True)
+                        tlx.tcgen05_commit(acc_empties[0], two_ctas=True)
+
+                        tlx.barrier_wait(acc_fulls[1], qk_phase)
+                        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                            p_bufIdx = slice_id + NUM_MMA_SLICES
+                            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+                            kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                                       [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
+                            use_acc = acc1_init if slice_id == 0 else True
+                            mBarriers = [acc_empties[1], v_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
+                            tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[1], use_acc=use_acc,
+                                          mBarriers=mBarriers, two_ctas=True)
+
+                        accum_cnt_qk += 1
+                        accum_cnt_kv += 1
                 else:
                     _, _, lo, hi, _, _ = _compute_offsets(tile_id, H, num_pid_n, num_pid_in_group, N_CTX, BLOCK_M,
                                                           STAGE, GROUP_SIZE_N)
@@ -1282,13 +1137,74 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
             clc_phase_consumer = 0
             while tile_id != -1:
                 if USE_2CTA:
-                    _, _, lo2, hi2, qo2, kv2 = _compute_offsets(tile_id // NUM_CTAS, H, num_pid_n, num_pid_in_group,
-                                                                N_CTX, BLOCK_M, STAGE, GROUP_SIZE_N)
-                    accum_cnt_kv = _fwd_load_2cta(tile_count, accum_cnt_kv, lo2, hi2, qo2, kv2, desc_q, desc_k, desc_v,
-                                                  q_tiles, k_tiles, v_tiles, q_fulls, q_empties, k_fulls, k_empties,
-                                                  v_fulls, v_empties, cluster_cta_rank, is_leader, Q_BYTES_PER_ELEM,
-                                                  K_BYTES_PER_ELEM, V_BYTES_PER_ELEM, BLOCK_M_SPLIT, BLOCK_N, HEAD_DIM,
-                                                  NUM_CTAS, NUM_BUFFERS_Q, NUM_BUFFERS_KV)
+                    _, off_hz2, lo2, hi2, qo2, kv2 = _compute_offsets(tile_id // NUM_CTAS, H, num_pid_n,
+                                                                      num_pid_in_group, N_CTX, EFFECTIVE_BLOCK_M, STAGE,
+                                                                      GROUP_SIZE_N)
+
+                    q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
+                    # Q and O share SMEM (o_tiles reuses q_tiles). Wait for the
+                    # epilog to finish storing the previous tile's O before
+                    # overwriting the buffer with new Q data.
+                    _, o_phase = get_bufidx_phase(tile_count, 1)
+                    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+                        tlx.barrier_wait(o_empties[cid], o_phase ^ 1)
+                    # load Q0
+                    tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
+                    if is_leader:
+                        tlx.barrier_expect_bytes(q_fulls[q_bufIdx],
+                                                 Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
+                    tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx], [qo2 + cluster_cta_rank * BLOCK_M_SPLIT, 0],
+                                              q_fulls[q_bufIdx], two_ctas=tl.constexpr(True))
+                    # load Q1
+                    q_bufIdx1 = q_bufIdx + NUM_BUFFERS_Q
+                    tlx.barrier_wait(q_empties[q_bufIdx1], q_phase ^ 1)
+                    if is_leader:
+                        tlx.barrier_expect_bytes(q_fulls[q_bufIdx1],
+                                                 Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
+                    tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx1],
+                                              [qo2 + (NUM_CTAS + cluster_cta_rank) * BLOCK_M_SPLIT, 0],
+                                              q_fulls[q_bufIdx1], two_ctas=tl.constexpr(True))
+
+                    kv_offset_y = kv2
+
+                    k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                    tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
+                    if is_leader:
+                        tlx.barrier_expect_bytes(k_fulls[k_bufIdx], K_BYTES_PER_ELEM * BLOCK_N_KV * HEAD_DIM * NUM_CTAS)
+                    tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx],
+                                              [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0], k_fulls[k_bufIdx],
+                                              two_ctas=tl.constexpr(True))
+
+                    v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                    tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
+                    if is_leader:
+                        tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+                    tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx], [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV],
+                                              v_fulls[v_bufIdx], two_ctas=tl.constexpr(True))
+
+                    kv_offset_y += BLOCK_N
+                    accum_cnt_kv += 1
+
+                    for _ in tl.range(lo2 + BLOCK_N, hi2, BLOCK_N):
+                        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                        tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
+                        if is_leader:
+                            tlx.barrier_expect_bytes(k_fulls[k_bufIdx],
+                                                     K_BYTES_PER_ELEM * BLOCK_N_KV * HEAD_DIM * NUM_CTAS)
+                        tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx],
+                                                  [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0], k_fulls[k_bufIdx],
+                                                  two_ctas=tl.constexpr(True))
+
+                        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                        tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
+                        if is_leader:
+                            tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+                        tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx],
+                                                  [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV], v_fulls[v_bufIdx],
+                                                  two_ctas=tl.constexpr(True))
+
+                        kv_offset_y += BLOCK_N
+                        accum_cnt_kv += 1
                 else:
                     _, _, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(tile_id, H, num_pid_n, num_pid_in_group,
                                                                               N_CTX, BLOCK_M, STAGE, GROUP_SIZE_N)
@@ -1315,13 +1231,13 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     num_pid_n,
                     num_pid_in_group,
                     N_CTX,
-                    BLOCK_M,
+                    EFFECTIVE_BLOCK_M,
                     STAGE,
                     GROUP_SIZE_N,
                 )
                 _, phase = get_bufidx_phase(tile_count, 1)
                 for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                    group_id = cluster_cta_rank + cid
+                    group_id = cid * NUM_CTAS + cluster_cta_rank
                     tlx.barrier_wait(o_fulls[cid], phase)
                     qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
                     tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
@@ -3416,8 +3332,7 @@ class _attention(torch.autograd.Function):
 
         def grid(META):
             num_ctas = META.get("NUM_CTAS") or 1
-            block_m_per_cta = META["BLOCK_M"] // num_ctas
-            n_ctas = triton.cdiv(q.shape[2], block_m_per_cta) * q.shape[0] * q.shape[1]
+            n_ctas = triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1]
             n_ctas = triton.cdiv(n_ctas, num_ctas) * num_ctas
             return (n_ctas, )
 
@@ -3599,11 +3514,8 @@ def attention(q, k, v, sm_scale, causal, config=None):
     triton.set_allocator(alloc_fn)
 
     num_ctas = config.get("NUM_CTAS", 1)
-    # Grid = total CTAs, derived from per-CTA block size (BWD convention).
-    # BLOCK_M is per-cluster; per-CTA block = BLOCK_M // num_ctas.
-    block_m_per_cta = config["BLOCK_M"] // num_ctas
-    grid0 = triton.cdiv(q.shape[2], block_m_per_cta) * q.shape[0] * q.shape[1]
-    grid0 = triton.cdiv(grid0, num_ctas) * num_ctas  # pad for cluster alignment
+    grid0 = triton.cdiv(q.shape[2], config["BLOCK_M"]) * q.shape[0] * q.shape[1]
+    grid0 = triton.cdiv(grid0, num_ctas) * num_ctas
     grid = (grid0, 1, 1)
     launch_kwargs = {}
     if num_ctas > 1:

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -4,7 +4,7 @@ import triton.language as tl
 import triton.language.extra.tlx as tlx
 from triton.language.extra.tlx.warp_spec import get_bufidx_phase
 from triton.language.extra.cuda.inline_ptx_lib import _mul_f32x2, _fma_f32x2, _sub_f32x2
-from triton.language.extra.subtile_ops import _join_n_2D, _split_n_2D
+from triton.language.extra.subtile_ops import _split_n_2D
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
@@ -286,6 +286,8 @@ def _softmax_inner_loop(
         tlx.barrier_wait(tlx.local_view(alpha_empties, cid), alpha_phase ^ 1)
         tlx.local_store(tlx.local_view(alpha_tiles, cid), tl.join(alpha, alpha) if SCALAR_N == 2 else alpha[:, None])
         tlx.barrier_arrive(tlx.local_view(alpha_fulls, cid))
+        # Shorten alpha's lifetime: consume immediately, add l_ij later
+        l_i *= alpha
 
         # scale_subtract_rowmax:
         # -> row_max_scaled = row_max_new * scale
@@ -301,7 +303,7 @@ def _softmax_inner_loop(
         # elements 12 to 15 use emulation, elements 16 to 27 use SFU, elements 28 to 31 use emulation
         # the loop is unrolled twice likely for vectorization
         qks = _split_n_2D(qk, NUM_MMA_SLICES)
-        ps = ()
+        l_ij = tl.zeros_like(l_i)
         for slice_id in tl.static_range(0, NUM_MMA_SLICES):
             # prepare p for the v dot
             p_bufIdx = qk_buf * NUM_MMA_SLICES + slice_id
@@ -311,11 +313,9 @@ def _softmax_inner_loop(
                 tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx), 1, remote_cta_rank=0)
             else:
                 tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
-            ps = ps + (p_i, )
+            l_ij += tl.sum(p_i, 1)
 
-        p = _join_n_2D(ps)
-        l_ij = tl.sum(p, 1)
-        l_i = l_i * alpha + l_ij
+        l_i += l_ij
         m_i = m_ij
         accum_cnt_qk += 1
 

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -319,7 +319,7 @@ class FlashAttention:
             "BLOCK_M": 256,
             "BLOCK_N": 128,
             "NUM_BUFFERS_Q": 1,
-            "NUM_BUFFERS_KV": 3,
+            "NUM_BUFFERS_KV": 5,
             "NUM_BUFFERS_QK": 1,
             "NUM_MMA_GROUPS": 2,
             "NUM_MMA_SLICES": 2,


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/tritonbench/pull/1213


## Motivation

NCU profiling of the 2-CTA Flash Attention kernel revealed heavy register
spills in the softmax partition:
- 50.63M Local memory instructions (vs 98.3K Global memory instructions)
- 25.26M Local memory requests (read + write)
- L1/TEX cache hit rate 99.72% (spills stay in L1 but still add latency)

SASS showed two hot spill slots:
```
STL    [R1],      R2        ; spill alpha
LDL.LU R163,      [R1]      ; reload alpha

LDL.LU R80,       [R1+0x4]  ; reload l_i
STL    [R1+0x4],  R80       ; spill l_i
```

These correspond to `alpha` and `l_i` in `_softmax_inner_loop`, where:
1. `alpha` is computed then stored to TMEM, but not consumed until ~30 lines
   later. This long live range forces alpha to spill.
2. All `p_i` values are accumulated in a Python tuple `ps`, then joined and
   summed at the end. This keeps NUM_MMA_SLICES p_i tensors live
   simultaneously, adding register pressure.

## Changes

**Fix 1: Shorten alpha's lifetime**

Move `l_i *= alpha` right after `tlx.local_store(alpha_tiles, alpha)` so
alpha is consumed immediately and its register is freed. The final
`l_i += l_ij` replaces the original `l_i = l_i * alpha + l_ij`.
Mathematically equivalent.

**Fix 2: Incremental l_ij accumulation (eliminate ps tuple)**

Replace the `ps = ps + (p_i,)` tuple accumulation + `_join_n_2D(ps)` +
`tl.sum(p, 1)` with incremental `l_ij += tl.sum(p_i, 1)` inside the loop.
Each `p_i` dies at end of iteration instead of all staying live.

**Fix 3: Enable conditional rescale (IfOp) for 2-CTA mode**

The RESCALE_OPT conditional path uses `scf.if` to skip `acc *= alpha` when
alpha==1.0 (no rescale needed). This was previously disabled for 2-CTA mode
(`if RESCALE_OPT and not USE_2CTA`) due to a suspected compiler miscompile.

Investigation showed the original compiler bug has since been fixed in TLX
TMEM token chain handling. Removed the `not USE_2CTA` guard, enabling the
optimization for 2-CTA.

This skips a full TMEM round trip (tcgen05.ld.sync.aligned + multiply +
tcgen05.st.sync.aligned + waits) on the accumulator tile (128x128xf32 =
64KB) when alpha==1.0. Since the running row-max stabilizes after a few
KV tiles, ~90% of iterations have alpha==1.0 and the rescale is a no-op.

**Fix 4: Autotuner grid lambda None-safety**

Changed `META.get("Q_STAGE", 1)` to `(META.get("Q_STAGE") or 1)` to handle
configs where Q_STAGE key exists with value None.

**Benchmark: locked 1CTA / 2CTA-Q2 configs**
Added `tlx_blackwell_1cta` and `tlx_blackwell_2cta_q2` benchmarks with
locked configs for isolated performance comparison.

## Results (GB300, denoise.sh, tritonbench --input-id 3)

### Fix 1 + Fix 2 impact (A/B on parent commit, before Fix 3):

| SeqLen | cuDNN before | 1CTA before | 2CTA-Q2 before | cuDNN after | 1CTA after | 2CTA-Q2 after |
|--------|-------------|-------------|----------------|------------|------------|---------------|
| 1024   | 1213        | 880         | 1199           | 1066       | 1099       | 1192          |
| 2048   | 1502        | 1353        | 1461           | 1575       | 1390       | 1505          |
| 4096   | 1639        | 1457        | 1527           | 1630       | 1540       | 1624          |
| 8192   | 1635        | 1569        | 1562           | 1713       | 1673       | 1716          |
| 16384  | 1670        | 1671        | 1692           | 1697       | 1689       | 1711          |
| **avg**| **1532**    | **1386**    | **1488**       | **1536**   | **1478**   | **1550**      |

**1CTA +6.6% (1386->1478), 2CTA-Q2 +4.2% (1488->1550)**

### Full stack with all fixes: TLX 1CTA vs 2CTA-Q2 vs FAv4 vs CUTLASS (cudagraph mode, pure kernel time)

| SeqLen | TLX 1CTA | TLX 2CTA-Q2 | FAv4 (CuTeDSL) | CUTLASS |
|--------|----------|-------------|----------------|---------|
| 1024   | 1148     | 1285        | **1482**       | -       |
| 2048   | 1410     | 1579        | **1679**       | -       |
| 4096   | 1548     | 1690        | **1763**       | -       |
| 8192   | 1659     | 1749        | **1777**       | -       |
| 16384  | 1694     | 1770        | **1798**       | -       |
| **avg**| **1492** | **1614**    | **1700**       | -       |

2CTA-Q2 is +8.2% over 1CTA. Pure kernel perf (cudagraph) is -5.1% vs FAv4;
gap narrows at longer sequences (-1.6% at 16K).

Without cudagraph (includes launch overhead):

| SeqLen | TLX 1CTA | TLX 2CTA-Q2 | FAv4 (CuTeDSL) | CUTLASS |
|--------|----------|-------------|----------------|---------|
| 1024   | 1094     | **1220**    | 717            | 968     |
| 2048   | 1396     | 1576        | **1664**       | 1227    |
| 4096   | 1562     | **1617**    | 1650           | 1306    |
| 8192   | 1649     | 1747        | **1763**       | 1381    |
| 16384  | 1704     | 1773        | **1804**       | 1407    |
| **avg**| **1481** | **1587**    | **1520**       | **1258**|

With launch overhead, TLX 2CTA-Q2 avg +4.4% over FAv4 (CLC persistent
scheduling amortizes launch cost).

### Register tuning experiment (reverted -- not included):

Attempted increasing softmax partition registers from 168 to 184/200.
200 caused -18% regression (occupancy crash). 184 was mixed (+-1%).
168 regs is already the optimal spill-vs-occupancy tradeoff.

Reviewed By: htyu

Differential Revision: D114619646


