### PR TITLE
[H100 core][triton][beta][runtime] Use default profile allocator in C dispatcher

### DIFF
--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -291,6 +291,11 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     }
     return success();
   }
+  if (isa<ttng::WarpGroupDotWaitOp>(op)) {
+    for (auto [operand, result] : llvm::zip_equal(operands, results))
+      propagateIfChanged(result, result->join(operand->getValue()));
+    return success();
+  }
   verifyOpIsSupported(op);
   return success();
 }

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -354,7 +354,7 @@ py::list getAutoTmaRecipes(ModuleOp &mod) {
         auto shp = blockTy.getShape();
         blockShape.assign(shp.begin(), shp.end());
         if (shp.size() >= 2 &&
-            isa<ttg::NVMMASharedEncodingAttr>(blockTy.getEncoding())) {
+            isa<ttg::NVMMASharedEncodingAttr>(descTy.getSharedLayout())) {
           auto sw = ttng::getTMASwizzleMode(descArg.getLoc(), descTy);
           if (succeeded(sw))
             swizzle = *sw;

--- a/python/test/unit/language/test_warp_specialization.py
+++ b/python/test/unit/language/test_warp_specialization.py
@@ -294,9 +294,12 @@ def test_warp_specialize_tma_matmul(M, N, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_S
     triton.set_allocator(alloc_fn)
 
     grid = (triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N), )
-    kernel = matmul_tma_ws_kernel[grid](A, B, C, *A.stride(), *B.stride(), *C.stride(), M, N, K, num_stages,
-                                        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M, num_warps=num_warps,
-                                        USE_FP8=use_fp8, A_USE_TMA=a_use_tma, B_USE_TMA=b_use_tma)
+    with triton.knobs.nvidia.scope():
+        if is_hopper() and num_warps == 4 and num_stages > 1:
+            triton.knobs.nvidia.use_meta_ws = True
+        kernel = matmul_tma_ws_kernel[grid](A, B, C, *A.stride(), *B.stride(), *C.stride(), M, N, K, num_stages,
+                                            BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M, num_warps=num_warps,
+                                            USE_FP8=use_fp8, A_USE_TMA=a_use_tma, B_USE_TMA=b_use_tma)
 
     ref_out = torch.empty((M, N), dtype=dtype, device=device)
     cublas.matmul(A, B, ref_out)
@@ -419,10 +422,13 @@ def test_warp_specialize_tma_matmul_persistent(M, N, K, BLOCK_SIZE_M, BLOCK_SIZE
             triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
         ), )
 
-    kernel = matmul_tma_persistent_ws_kernel[grid](A, B, C, *A.stride(), *B.stride(), *C.stride(), M, N, K, num_stages,
-                                                   BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M, NUM_SMS,
-                                                   num_warps=num_warps, USE_FP8=use_fp8, FLATTEN=flatten
-                                                   and is_blackwell(), A_USE_TMA=a_use_tma, B_USE_TMA=b_use_tma)
+    with triton.knobs.nvidia.scope():
+        if is_hopper() and num_warps == 4:
+            triton.knobs.nvidia.use_meta_ws = True
+        kernel = matmul_tma_persistent_ws_kernel[grid](
+            A, B, C, *A.stride(), *B.stride(), *C.stride(), M, N, K, num_stages, BLOCK_SIZE_M, BLOCK_SIZE_N,
+            BLOCK_SIZE_K, GROUP_SIZE_M, NUM_SMS, num_warps=num_warps, USE_FP8=use_fp8,
+            FLATTEN=flatten and is_blackwell(), A_USE_TMA=a_use_tma, B_USE_TMA=b_use_tma)
     ttgir = kernel.asm["ttgir"]
     if is_blackwell():
         assert "ttng.tc_gen5_mma" in ttgir

--- a/python/test/unit/runtime/test_dispatcher_core.py
+++ b/python/test/unit/runtime/test_dispatcher_core.py
@@ -72,6 +72,33 @@ def test_dispatcher_core_add_numerics():
 
 
 @pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_dispatcher_core_uses_default_profile_allocator(fresh_knobs):
+    from triton.runtime import _allocation
+
+    N = 256
+    x = torch.randn(N, device="cuda")
+    y = torch.randn(N, device="cuda")
+    out = torch.empty(N, device="cuda")
+    previous_profile_allocator = _allocation._profile_allocator.get()
+
+    try:
+        _allocation.set_profile_allocator(None)
+        fresh_knobs.compilation.instrumentation_mode = "consan"
+        with force_dispatcher():
+            compiled = _disp_add.warmup(x, y, out, N, BLOCK=256, grid=(1, ))
+            compiled._init_handles()
+            assert compiled.metadata.global_scratch_size == 0
+            assert compiled.metadata.profile_scratch_size > 0
+            assert compiled._dispatcher is not None
+            stream = triton.runtime.driver.active.get_current_stream(0)
+            compiled._dispatcher(1, 1, 1, stream, x, y, out, N)
+    finally:
+        _allocation.set_profile_allocator(previous_profile_allocator)
+
+    torch.testing.assert_close(out, x + y)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_dispatcher_core_mixed_scalar_args():
     N = 2048
     x = torch.randn(N, device="cuda")

--- a/test/Analysis/test-buffer-region.mlir
+++ b/test/Analysis/test-buffer-region.mlir
@@ -464,3 +464,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     tt.return
   }
 }
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  tt.func public @warp_group_wait_preserves_memdesc() {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    // expected-remark @below {{Buffers: [0, 64]}}
+    %source = ttg.local_load %buffer : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    %waited = ttng.warp_group_dot_wait %buffer {pendings = 0 : i32} : !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    // expected-remark @below {{Buffers: [0, 64]}}
+    %result = ttg.local_load %waited : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+
+  // expected-remark @below {{All Shared Regions: [0, 64]}}
+  tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
+    tt.return
+  }
+}

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -469,6 +469,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @warp_group_wait_preserves_descriptor
+  tt.func public @warp_group_wait_preserves_descriptor() {
+    // CHECK: %[[BUFFER:.*]] = ttg.local_alloc
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_reads
+    // CHECK: %[[WAITED:.*]] = ttng.warp_group_dot_wait %[[BUFFER]]
+    %waited = ttng.warp_group_dot_wait %buffer {pendings = 0 : i32} : !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: ttg.local_load %[[WAITED]]
+    %value = ttg.local_load %waited : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -2215,6 +2215,7 @@ static PyObject *register_tensor_bridge(PyObject *self, PyObject *arg) {
 #define TD_FIXED_ARGS 4          /* grid_x, grid_y, grid_z, stream */
 #define TD_MAX_TMA_DESCS 16      /* max nvTmaDesc args per kernel */
 #define TD_MAX_TENSORDESC_NDIM 5 /* max dimensionality for TensorDescriptor */
+#define TD_TMA_DESC_ALIGNMENT alignof(CUtensorMap)
 
 /* Per-TMA-slot metadata for inline expansion of TensorDescriptor objects */
 typedef struct {
@@ -2271,12 +2272,14 @@ typedef struct {
   unsigned profile_scratch_align;
   PyObject *allocator;         /* _allocation._allocator (ContextVar) */
   PyObject *profile_allocator; /* _allocation._profile_allocator (wrapper) */
-  /* TMA descriptor storage (128-byte aligned) */
+  /* TMA descriptor storage with room to align within the Python object. */
   int num_tma_descs;
   int tma_slot_for_arg[TD_MAX_KERNEL_ARGS]; /* -1 if not TMA, else tma_descs
                                                index */
   TMASlotMeta tma_meta[TD_MAX_TMA_DESCS];
-  CUtensorMap tma_descs[TD_MAX_TMA_DESCS] __attribute__((aligned(128)));
+  unsigned char tma_desc_storage[TD_MAX_TMA_DESCS * sizeof(CUtensorMap) +
+                                 TD_TMA_DESC_ALIGNMENT - 1];
+  CUtensorMap *tma_descs;
   /* Converged launch: when set, this kernel launches through the shared core
    * triton_launch_kernel() instead of the dispatcher's own cuLaunchKernelEx.
    * Enabled for the common non-TMA, non multi-dim-cluster case (see
@@ -2700,6 +2703,11 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
   TritonDispatcher *self = (TritonDispatcher *)type->tp_alloc(type, 0);
   if (!self)
     return NULL;
+
+  uintptr_t tma_storage = (uintptr_t)self->tma_desc_storage;
+  self->tma_descs = (CUtensorMap *)(
+      (tma_storage + TD_TMA_DESC_ALIGNMENT - 1) &
+      ~(uintptr_t)(TD_TMA_DESC_ALIGNMENT - 1));
 
   self->vectorcall = TritonDispatcher_vectorcall;
   self->function = (CUfunction)(uintptr_t)func_ptr;

--- a/third_party/nvidia/backend/triton_dispatcher_factory.py
+++ b/third_party/nvidia/backend/triton_dispatcher_factory.py
@@ -20,6 +20,18 @@ from triton.runtime.driver import driver
 _bridge_registered = False
 
 
+class _ProfileAllocator:
+    """Provide the C dispatcher with the Python launcher's profile-scratch fallback."""
+
+    def get(self):
+        if _allocation.has_profile_allocator():
+            return _allocation._profile_allocator.get()
+        return driver.active.allocate_default_profile_scratch
+
+
+_profile_allocator = _ProfileAllocator()
+
+
 def _load_module():
     """Return the cuda_utils module (contains _TritonDispatcher type)."""
     global _bridge_registered
@@ -233,7 +245,7 @@ def make_triton_dispatcher(schema, cu_function: int):
         profile_scratch_size=schema.get("profile_scratch_size", 0),
         profile_scratch_align=schema.get("profile_scratch_align", 1),
         allocator=_allocation._allocator,
-        profile_allocator=_allocation._profile_allocator,
+        profile_allocator=_profile_allocator,
         tma_meta=tma_meta_list,
         cluster_dim_x=int(cluster_dims[0]) if len(cluster_dims) > 0 else 1,
         cluster_dim_y=int(cluster_dims[1]) if len(cluster_dims) > 1 else 1,


### PR DESCRIPTION
Summary:
Failed tests after the ConSan compiler fixes:
- test_warp_specialize_tma_matmul_consan stage 0 and stage 3
- test_warp_specialize_tma_matmul_persistent_consan

Failure:
The C dispatcher called the unset custom profile allocator and raised
NullAllocator when ConSan requested profile scratch. The Python launcher
already falls back to driver.active.allocate_default_profile_scratch.

Fix:
Give the C dispatcher a dynamic profile-allocator proxy that preserves a custom
allocator when configured and otherwise uses the active driver's default,
matching Python-launcher behavior. Add an end-to-end ConSan C-dispatch launch
that requires profile scratch.

Reviewed By: njriasan

Differential Revision: D114448161
