### PR TITLE
[H100 core][triton][beta][consan] Backport generalized BufferRegion analysis (#11045)

### DIFF
--- a/include/triton/Analysis/BufferRegion.h
+++ b/include/triton/Analysis/BufferRegion.h
@@ -1,29 +1,100 @@
 #ifndef TRITON_ANALYSIS_BUFFER_REGION_H
 #define TRITON_ANALYSIS_BUFFER_REGION_H
 
-#include <limits>
+#include <cstdint>
 #include <set>
+#include <tuple>
+#include <utility>
 
 #include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include "mlir/IR/Value.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SparseBitVector.h"
 
 namespace mlir::triton {
 
 //===----------------------------------------------------------------------===//
-// BufferRegion: a single logical region derived from an alloc
+// Exact physical address sets
 //===----------------------------------------------------------------------===//
+
+/// An exact set of physical storage units. Shared-memory addresses are bytes.
+/// Tensor-memory addresses are 32-bit words encoded as (row << 16) | column.
+class AddressSet {
+public:
+  AddressSet() = default;
+
+  static AddressSet fromRange(uint32_t begin, uint32_t length);
+
+  void set(uint32_t address);
+  void insert(const AddressSet &other);
+  AddressSet intersection(const AddressSet &other) const;
+  void subtract(const AddressSet &other);
+
+  auto begin() const { return addresses.begin(); }
+  auto end() const { return addresses.end(); }
+  bool empty() const { return addresses.empty(); }
+  bool intersects(const AddressSet &other) const;
+  bool contains(const AddressSet &other) const;
+  AddressSet translated(uint32_t delta) const;
+
+  bool operator==(const AddressSet &other) const {
+    return addresses == other.addresses;
+  }
+  bool operator<(const AddressSet &other) const {
+    auto lhs = begin();
+    auto rhs = other.begin();
+    while (lhs != end() && rhs != other.end()) {
+      if (*lhs != *rhs)
+        return *lhs < *rhs;
+      ++lhs;
+      ++rhs;
+    }
+    return lhs == end() && rhs != other.end();
+  }
+
+private:
+  llvm::SparseBitVector<> addresses;
+};
+
+//===----------------------------------------------------------------------===//
+// BufferRegion: runtime identity plus exact physical geometry
+//===----------------------------------------------------------------------===//
+
 struct BufferRegion {
-  uint32_t baseOffset;
-  uint32_t length;
+  using CTAAddresses = std::pair<uint32_t, AddressSet>;
+
+  /// Runtime descriptor key. It deliberately does not define geometry:
+  /// distinct sparse views may have the same key.
+  uint32_t baseOffset = 0;
+  uint32_t length = 0;
+  llvm::SmallVector<CTAAddresses, 2> ctaAddresses;
+
+  bool intersects(const BufferRegion &other) const {
+    return llvm::any_of(ctaAddresses, [&](const CTAAddresses &lhs) {
+      return llvm::any_of(other.ctaAddresses, [&](const CTAAddresses &rhs) {
+        return lhs.first == rhs.first && lhs.second.intersects(rhs.second);
+      });
+    });
+  }
+  bool contains(const BufferRegion &other) const {
+    return llvm::all_of(other.ctaAddresses, [&](const CTAAddresses &rhs) {
+      return llvm::any_of(ctaAddresses, [&](const CTAAddresses &lhs) {
+        return lhs.first == rhs.first && lhs.second.contains(rhs.second);
+      });
+    });
+  }
 
   bool operator==(const BufferRegion &other) const {
-    return baseOffset == other.baseOffset && length == other.length;
+    return std::tie(baseOffset, length, ctaAddresses) ==
+           std::tie(other.baseOffset, other.length, other.ctaAddresses);
   }
 
   bool operator<(const BufferRegion &other) const {
-    if (baseOffset != other.baseOffset)
-      return baseOffset < other.baseOffset;
-    return length < other.length;
+    return std::tie(baseOffset, length, ctaAddresses) <
+           std::tie(other.baseOffset, other.length, other.ctaAddresses);
   }
 
   template <typename T> void print(T &os) const {
@@ -31,78 +102,98 @@ struct BufferRegion {
   }
 };
 
-} // namespace mlir::triton
+/// A physical region and the provenance required to compose descriptor views.
+struct BufferRegionView {
+  BufferRegion region;
+  uint32_t storageBase = 0;
+  uint32_t affineOffset = 0;
+  llvm::SmallVector<uint32_t, 2> partitionBases;
+  uint32_t affinePartitionOffset = 0;
+  uint32_t affineCTAOffset = 0;
 
-namespace llvm {
+private:
+  auto key() const {
+    return std::tie(region, storageBase, affineOffset, affinePartitionOffset,
+                    affineCTAOffset, partitionBases);
+  }
 
-using namespace mlir::triton;
+public:
+  bool operator==(const BufferRegionView &other) const {
+    return key() == other.key();
+  }
 
-template <> struct DenseMapInfo<BufferRegion> {
-  static BufferRegion getEmptyKey() {
-    constexpr uint32_t empty = std::numeric_limits<uint32_t>::max();
-    return BufferRegion{empty, empty};
-  }
-  static BufferRegion getTombstoneKey() {
-    constexpr uint32_t tombstone = std::numeric_limits<uint32_t>::max() - 1;
-    return BufferRegion{tombstone, tombstone};
-  }
-  static unsigned getHashValue(const BufferRegion &r) {
-    return llvm::hash_combine(r.baseOffset, r.length);
-  }
-  static bool isEqual(const BufferRegion &a, const BufferRegion &b) {
-    return a == b;
+  bool operator<(const BufferRegionView &other) const {
+    return key() < other.key();
   }
 };
 
-} // namespace llvm
+//===----------------------------------------------------------------------===//
+// Buffer state planning
+//===----------------------------------------------------------------------===//
 
-namespace mlir::triton {
+/// A compile-time plan for representing mutable ConSan state. Masks are
+/// indexed by the input region order and all have numLanes bits.
+struct BufferStatePlan {
+  unsigned numLanes = 0;
+  llvm::SmallVector<llvm::SmallBitVector> regionMasks;
+  llvm::SmallBitVector unknownMask;
+};
+
+BufferStatePlan createBufferStatePlan(llvm::ArrayRef<BufferRegion> regions,
+                                      bool includeUnknown = false);
 
 //===----------------------------------------------------------------------===//
 // RegionInfo lattice
 //===----------------------------------------------------------------------===//
 //
-// This wraps a set of BufferRegions and provides lattice semantics
+// This wraps a set of descriptor views and provides lattice semantics.
 //
 struct RegionInfo {
-  using RegionList = llvm::DenseSet<BufferRegion>;
-  RegionList regions;
+  enum class Kind { Uninitialized, Exact, Unknown };
+  using ViewList = std::set<BufferRegionView>;
+
+  Kind kind = Kind::Uninitialized;
+  ViewList views;
 
   RegionInfo() = default;
-  RegionInfo(const RegionList &r) : regions(r) {}
+  RegionInfo(ViewList views) : kind(Kind::Exact), views(std::move(views)) {}
 
-  // Lattice join: union of regions
+  bool isUnknown() const { return kind == Kind::Unknown; }
+
   static RegionInfo join(const RegionInfo &lhs, const RegionInfo &rhs) {
+    if (lhs.isUnknown() || rhs.isUnknown())
+      return getPessimisticValueState();
+    if (lhs.kind == Kind::Uninitialized)
+      return rhs;
+    if (rhs.kind == Kind::Uninitialized)
+      return lhs;
     RegionInfo result = lhs;
-    for (const auto &reg : rhs.regions)
-      if (llvm::find(result.regions, reg) == result.regions.end())
-        result.regions.insert(reg);
+    result.views.insert(rhs.views.begin(), rhs.views.end());
     return result;
   }
 
   bool operator==(const RegionInfo &other) const {
-    if (regions.size() != other.regions.size())
-      return false;
-    for (auto &r : regions)
-      if (llvm::find(other.regions, r) == other.regions.end())
-        return false;
-    return true;
+    return kind == other.kind && views == other.views;
   }
 
   template <typename T> void print(T &os) const {
-    llvm::SmallVector<BufferRegion> sortedRegions(regions.begin(),
-                                                  regions.end());
-    llvm::sort(sortedRegions, [](const BufferRegion &a, const BufferRegion &b) {
-      return a < b;
+    if (isUnknown()) {
+      os << "unknown";
+      return;
+    }
+    llvm::interleaveComma(views, os, [&](const BufferRegionView &view) {
+      view.region.print(os);
     });
-    llvm::interleaveComma(sortedRegions, os,
-                          [&](const BufferRegion &r) { r.print(os); });
   }
 
   static RegionInfo getPessimisticValueState(MLIRContext *context = nullptr) {
-    return RegionInfo(); // means "unknown / empty"
+    RegionInfo result;
+    result.kind = Kind::Unknown;
+    return result;
   }
-  static RegionInfo getPessimisticValueState(Value) { return RegionInfo(); }
+  static RegionInfo getPessimisticValueState(Value) {
+    return getPessimisticValueState();
+  }
 };
 
 //===----------------------------------------------------------------------===//
@@ -123,17 +214,25 @@ public:
 
   enum RegionType { SHARED_MEMORY, TENSOR_MEMORY, BARRIER, NUM_REGION_TYPES };
 
-  static bool isMemoryAccessOperation(Operation *op);
+  struct MemoryAccess {
+    Value value;
+    bool isWrite;
+  };
+
+  static llvm::SmallVector<MemoryAccess> getMemoryAccesses(Operation *op);
 
   // ------------------------------
   // Public API for ConSan
   // ------------------------------
 
-  /// Return the list of all unique (alloc,offset,len) buffer regions
-  /// discovered by the analysis.
+  /// Return all unique exact regions discovered by the analysis.
   llvm::SmallVector<BufferRegion>
   getAllUsedBufferRegions(RegionType type) const {
     return llvm::to_vector(usedBufferRegions[type]);
+  }
+
+  bool hasUnknownUsedBufferRegions(RegionType type) const {
+    return usedUnknownBufferRegions[type];
   }
 
   void calculateUsedBufferRegions(Operation *op);
@@ -157,8 +256,8 @@ public:
 private:
   // Global registry of all regions
   std::set<BufferRegion> usedBufferRegions[NUM_REGION_TYPES];
-
-  static void verifyOpIsSupported(Operation *op);
+  bool usedUnknownBufferRegions[NUM_REGION_TYPES] = {};
+  llvm::DenseMap<std::pair<Type, uint32_t>, AddressSet> footprintCache;
 };
 
 } // namespace mlir::triton

--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -97,10 +97,21 @@ public:
   // reaches its warp-specialize terminator.
   void createRetireActiveThreadCall(ImplicitLocOpBuilder &b, int thread,
                                     Operation *insertPoint);
-  // checkAllActiveWaiting: assert that not all unfinished threads across the
-  // cluster are waiting on matching barrier phases.
-  void createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b, Value pred,
-                                       Operation *insertPoint);
+  // clusterBarrierRendezvous: model a cluster barrier as an arrive-and-wait on
+  // a virtual entry in the ordinary ConSan barrier tables. The completing
+  // arrival publishes cluster visibility for non-relaxed barriers. The call
+  // returns only after the virtual barrier phase changes or a deadlock is
+  // reported.
+  void createClusterBarrierRendezvousCall(ImplicitLocOpBuilder &b,
+                                          int barrierIdx, int thread,
+                                          uint64_t threadPeersMask,
+                                          bool partitionScoped,
+                                          bool publishVisibility,
+                                          Operation *insertPoint);
+  // checkAllActiveWaiting: return whether unfinished threads across the
+  // cluster are not all waiting on matching barrier phases.
+  Value createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b, Value pred,
+                                        Operation *insertPoint);
   // verifyBarrierCanInit: ensure the barrier is currently invalidated before
   // initializing it again.
   void createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b, Value mbar,
@@ -139,30 +150,28 @@ public:
   // as visible to the threads set in threadMask. Clears out any other threads
   // from the visibility bitmask. We know this is safe because there cannot be
   // outstanding writes to this buffer at this point.
-  void createSetWriteVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
-                                    uint32_t length, uint64_t threadMask,
-                                    Value pred, MemType memType,
-                                    Operation *insertPoint, Value effectCTAs);
-  // setReadVisibility: add the threads set in threadMask to the buffer's read
-  // visibility bitmask.
-  void createSetReadVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
-                                   uint32_t length, uint64_t threadMask,
-                                   Value pred, MemType memType,
-                                   Operation *insertPoint, Value effectCTAs);
-  // clearWriteTracking: clear all the information about threads writing to a
-  // buffer.
-  void createClearWriteTrackingCall(ImplicitLocOpBuilder &b, Value buf,
-                                    uint32_t length, Value pred,
+  void createSetWriteVisibilityCall(ImplicitLocOpBuilder &b, Value bufferMask,
+                                    uint64_t threadMask, Value pred,
                                     MemType memType, Operation *insertPoint,
                                     Value effectCTAs);
+  // setReadVisibility: add the threads set in threadMask to the buffer's read
+  // visibility bitmask.
+  void createSetReadVisibilityCall(ImplicitLocOpBuilder &b, Value bufferMask,
+                                   uint64_t threadMask, Value pred,
+                                   MemType memType, Operation *insertPoint,
+                                   Value effectCTAs);
+  // clearWriteTracking: clear all the information about threads writing to a
+  // buffer.
+  void createClearWriteTrackingCall(ImplicitLocOpBuilder &b, Value bufferMask,
+                                    Value pred, MemType memType,
+                                    Operation *insertPoint, Value effectCTAs);
   // clearReadVisibility: clear the read visibility for a buffer.
-  void createClearReadVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
-                                     uint32_t length, Value pred,
-                                     MemType memType, Operation *insertPoint,
-                                     Value effectCTAs);
+  void createClearReadVisibilityCall(ImplicitLocOpBuilder &b, Value bufferMask,
+                                     Value pred, MemType memType,
+                                     Operation *insertPoint, Value effectCTAs);
   // clearReadTracking: clear the read tracking for a buffer.
-  void createClearReadTrackingCall(ImplicitLocOpBuilder &b, Value buf,
-                                   uint32_t length, Value pred, MemType memType,
+  void createClearReadTrackingCall(ImplicitLocOpBuilder &b, Value bufferMask,
+                                   Value pred, MemType memType,
                                    Operation *insertPoint, Value effectCTAs);
   // trackVisibleWrites: snapshot buffers currently visible to the thread into
   // the tracking table for a barrier.
@@ -177,8 +186,8 @@ public:
   // trackBarrierWriteForBuffer: mark a specific buffer as tracked by a
   // barrier in the write-tracking table.
   void createTrackBarrierWriteForBufferCall(ImplicitLocOpBuilder &b, Value mbar,
-                                            Value buf, uint32_t length,
-                                            Value pred, MemType memType,
+                                            Value bufferMask, Value pred,
+                                            MemType memType,
                                             Operation *insertPoint,
                                             Value barrierCTAs,
                                             Value effectCTAs);
@@ -202,20 +211,19 @@ public:
   void createTransferVisibleReadsCall(ImplicitLocOpBuilder &b, Value mbar,
                                       uint64_t threadMask, Value pred,
                                       MemType memType, Operation *insertPoint);
-  // verifyWriteVisibility: ensure the thread sees the latest write. When
-  // allowNoWrite is true, also allow rows that have not been written yet.
-  void createVerifyWriteVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
-                                       uint32_t length, int thread,
+  // verifyWriteVisibility: ensure the thread either sees the latest write or no
+  // other thread is writing the buffer.
+  void createVerifyWriteVisibilityCall(ImplicitLocOpBuilder &b,
+                                       Value bufferMask, int thread,
                                        StringRef operandName, Value pred,
                                        MemType memType, Operation *insertPoint,
-                                       Value effectCTAs, bool allowNoWrite);
+                                       Value effectCTAs);
   // verifyReadVisibility: ensure all reads from the buffer are visible to the
   // thread.
-  void createVerifyReadVisibilityCall(ImplicitLocOpBuilder &b, Value buf,
-                                      uint32_t length, int thread,
-                                      StringRef operandName, Value pred,
-                                      MemType memType, Operation *insertPoint,
-                                      Value effectCTAs);
+  void createVerifyReadVisibilityCall(ImplicitLocOpBuilder &b, Value bufferMask,
+                                      int thread, StringRef operandName,
+                                      Value pred, MemType memType,
+                                      Operation *insertPoint, Value effectCTAs);
   // copyWriteVisibility: replicate the write visibility bit of sourceThread to
   // every destination thread in destMask.
   void createCopyWriteVisibilityCall(ImplicitLocOpBuilder &b, int sourceThread,
@@ -226,16 +234,69 @@ public:
   void createCopyReadVisibilityCall(ImplicitLocOpBuilder &b, int sourceThread,
                                     uint64_t destMask, Value pred,
                                     MemType memType, Operation *insertPoint);
-  // publishClusterVisibility: after a non-relaxed cluster barrier, make
-  // synchronous facts visible to every CTA in the cluster.
+  // publishClusterVisibility: after a non-relaxed cluster barrier, make the
+  // participating threads' synchronous facts visible across the cluster. A
+  // top-level barrier includes every thread; a warp-specialized barrier is
+  // scoped to its partition and peer thread classes.
   void createPublishClusterVisibilityCall(ImplicitLocOpBuilder &b, Value pred,
-                                          MemType memType,
+                                          int thread, uint64_t threadPeersMask,
+                                          bool partitionScoped, MemType memType,
                                           Operation *insertPoint);
+  // setProxyAccess: record a generic-proxy access by the current base thread
+  // and invalidate prior proxy-fence coverage for that source thread.
+  void createSetProxyAccessCall(ImplicitLocOpBuilder &b, Value bufferMask,
+                                int thread, Value pred, Operation *insertPoint,
+                                Value effectCTAs);
+  // fenceProxyAccesses: mark all generic accesses visible to the current base
+  // thread as covered by fence.proxy.async. A CTA fence covers the current
+  // buffer row; a cluster fence covers every cluster buffer row.
+  void createFenceProxyAccessesCall(ImplicitLocOpBuilder &b, int thread,
+                                    bool cluster, Value pred,
+                                    Operation *insertPoint);
+  // trackProxyAccesses: snapshot the current base thread's packed generic
+  // access/fence frontier into a barrier tracking row.
+  void createTrackProxyAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
+                                    int thread, Value pred,
+                                    Operation *insertPoint, Value barrierCTAs);
+  // trackProxyAccessesForBuffer: snapshot the current base thread's packed
+  // generic access/fence frontier for shared-memory regions fully contained
+  // in buffer. This is used by async-proxy writes that complete a barrier:
+  // waiting on that barrier orders only the bytes written by the operation.
+  void createTrackProxyAccessesForBufferCall(
+      ImplicitLocOpBuilder &b, Value mbar, Value bufferMask, int thread,
+      Value pred, Operation *insertPoint, Value barrierCTAs, Value effectCTAs);
+  // transferProxyAccesses: merge a barrier's packed proxy frontier into the
+  // waiting base thread.
+  void createTransferProxyAccessesCall(ImplicitLocOpBuilder &b, Value mbar,
+                                       int thread, Value pred,
+                                       Operation *insertPoint);
+  // clearBarrierProxyAccessTracking: clear packed proxy state associated with
+  // an invalidated barrier.
+  void createClearBarrierProxyAccessTrackingCall(ImplicitLocOpBuilder &b,
+                                                 Value mbar, Value pred,
+                                                 Operation *insertPoint);
+  // verifyProxyAccess: assert that every generic-proxy access visible to the
+  // issuing base thread has crossed fence.proxy.async.
+  void createVerifyProxyAccessCall(ImplicitLocOpBuilder &b, Value bufferMask,
+                                   int thread, StringRef operandName,
+                                   Value pred, Operation *insertPoint,
+                                   Value effectCTAs);
+  // copyProxyAccesses: copy a parent base thread's packed proxy frontier to
+  // warp-specialization partition threads.
+  void createCopyProxyAccessesCall(ImplicitLocOpBuilder &b, int sourceThread,
+                                   uint64_t destMask, Value pred,
+                                   Operation *insertPoint);
+  // publishClusterProxyAccesses: publish packed generic access and fence facts
+  // across the cluster. A warp-specialized barrier only updates the
+  // participating base-thread column.
+  void createPublishClusterProxyAccessesCall(ImplicitLocOpBuilder &b,
+                                             Value pred, int thread,
+                                             bool partitionScoped,
+                                             Operation *insertPoint);
   // stageAccessForCommit: mark the buffer as staged (value -1) in the
   // outstanding commit table for this thread.
-  void createStageAccessForCommitCall(ImplicitLocOpBuilder &b, Value buf,
-                                      uint32_t length, int thread, Value pred,
-                                      MemType memType,
+  void createStageAccessForCommitCall(ImplicitLocOpBuilder &b, Value bufferMask,
+                                      int thread, Value pred, MemType memType,
                                       CommitKind::Kind commitKind,
                                       Operation *insertPoint);
   // commitAccesses: convert staged entries to 1 and increment outstanding
@@ -271,12 +332,24 @@ public:
   // When excludeSelf is true, the calling thread's own column is masked out
   // so that only other partitions' outstanding commits are checked.
   void createCheckOutstandingCommitsCall(
-      ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
+      ImplicitLocOpBuilder &b, Value bufferMask, int thread,
       StringRef pendingAccessType, Value pred, MemType memType,
       CommitKind::Kind commitKind, Operation *insertPoint, Value effectCTAs,
       bool excludeSelf = false);
 
 private:
+  void createClearOutstandingCommitsTransferCall(
+      ImplicitLocOpBuilder &b, int thread, uint64_t transferThreadMask,
+      int outstandingNum, Value pred, CommitKind::Kind commitKind,
+      MemType memType, Operation *insertPoint, bool transferWrites,
+      bool transferReads);
+
+  void createTrackProxyAccessesCallImpl(ImplicitLocOpBuilder &b, Value mbar,
+                                        int thread, Value pred,
+                                        Operation *insertPoint,
+                                        Value barrierCTAs, Value bufferMask,
+                                        Value effectCTAs);
+
   ModuleOp module;
   AuxDataMap &auxData;
 };

--- a/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
+++ b/include/triton/Dialect/TritonInstrument/IR/TritonInstrumentOps.td
@@ -65,6 +65,20 @@ def TTI_ExperimentalMemDescToI32Op
   let assemblyFormat = "$memdesc attr-dict `:` type($memdesc)";
 }
 
+def TTI_ExperimentalMemoryOffsetToI32Op
+    : TTI_Op<"experimental_memory_offset_to_i32", [Pure]> {
+  let summary = "Materialize a memory-space offset as an i32 address";
+  let description = [{
+    Add a static byte or encoded tensor-memory offset to the current
+    function's memory-space base and return the 32-bit address used by ConSan.
+    This provides the runtime identity corresponding to a compile-time
+    BufferRegion key without materializing a descriptor table.
+  }];
+  let arguments = (ins I32Attr:$offset, TT_MemTypeAttr:$memType);
+  let results = (outs I32:$result);
+  let assemblyFormat = "$offset `,` $memType attr-dict";
+}
+
 def TTI_ExperimentalClusterCTAIdOp
     : TTI_Op<"experimental_cluster_cta_id", [Pure]> {
   let summary = "Get the CTA id within the current cluster";

--- a/include/triton/Dialect/TritonInstrument/IR/Utility.h
+++ b/include/triton/Dialect/TritonInstrument/IR/Utility.h
@@ -35,7 +35,11 @@ enum Kind { None = -1, AsyncCp = 0, Wgmma, TmaStore, NumCommitKinds };
 // writeVisibility + readVisibility per active memory type.
 constexpr int kCapturesPerMemType = 2;
 
-// barrierStates + waiting + activeMasks (only when barriers exist).
+// proxyAccessVisibility, plus proxyAccessTracking when mbarriers are present.
+constexpr int kProxyFenceBaseCaptures = 1;
+constexpr int kProxyFenceBarrierCaptures = 1;
+
+// barrierStates + waiting + activeMasks (only when tracked rendezvous exist).
 constexpr int kBarrierBaseCaptures = 3;
 
 // writeTracking + readTracking per active memory type (only when barriers
@@ -51,16 +55,25 @@ constexpr int kCaptureSizeBytes = 8;
 /// Estimate the number of WarpSpecialize captures that the
 /// ConcurrencySanitizer pass will add via passToWarpSpecialize().
 /// \p numActiveMemTypes  Number of memory types with buffers.
-/// \p hasBarriers        Whether barriers exist in the module.
+/// \p hasMBarriers       Whether mbarriers exist in the module.
+/// \p hasClusterBarriers Whether cluster barriers exist in the module.
 /// \p numCommitKinds     Number of distinct commit kinds required.
-inline int estimateConSanCaptureCount(int numActiveMemTypes, bool hasBarriers,
-                                      int numCommitKinds) {
+inline int estimateConSanCaptureCount(int numActiveMemTypes, bool hasMBarriers,
+                                      bool hasClusterBarriers,
+                                      int numCommitKinds,
+                                      bool hasAsyncProxyFenceTracking) {
   int perMemType = kCapturesPerMemType * numActiveMemTypes;
   int barrierCaptures =
-      hasBarriers ? kBarrierBaseCaptures +
-                        kBarrierTrackingCapturesPerMemType * numActiveMemTypes
-                  : 0;
-  return perMemType + barrierCaptures + kFixedCaptures + numCommitKinds;
+      hasMBarriers || hasClusterBarriers ? kBarrierBaseCaptures : 0;
+  if (hasMBarriers)
+    barrierCaptures += kBarrierTrackingCapturesPerMemType * numActiveMemTypes;
+  int proxyFenceCaptures =
+      hasAsyncProxyFenceTracking
+          ? kProxyFenceBaseCaptures +
+                (hasMBarriers ? kProxyFenceBarrierCaptures : 0)
+          : 0;
+  return perMemType + barrierCaptures + proxyFenceCaptures + kFixedCaptures +
+         numCommitKinds;
 }
 
 void createAssertInThread(ImplicitLocOpBuilder &b, Value condition,
@@ -103,6 +116,17 @@ struct ValueType {
   ValueType(Value value, Type type) : value(value), type(type) {}
   ValueType(std::pair<Value, Type> value)
       : value(value.first), type(value.second) {}
+};
+
+struct BufferStateCandidate {
+  uint32_t baseOffset = 0;
+  llvm::SmallBitVector mask;
+  uint32_t ctaMask = 0;
+};
+
+struct BufferStateCandidates {
+  SmallVector<BufferStateCandidate, 2> cases;
+  bool unknown = false;
 };
 
 // Map from IR region to ConSan auxiliary data.
@@ -152,10 +176,12 @@ struct AuxDataMap {
   //   Cbar, Cbuf, Cthr, Cmask = CTA dimensions qualifying barriers, buffers,
   //       threads, and thread masks respectively. Each has extent C.
   //   B = tracked buffers for one memory type, power-of-two padded.
-  //   K = tracked mbarriers, power-of-two padded.
+  //   K = tracked mbarriers and virtual cluster rendezvous slots,
+  //       power-of-two padded.
   //   T = logical ConSan thread bit slots used by this module, power-of-two
   //       padded for the distributed layout.
-  //   P = base-thread commit columns used by this module, power-of-two padded.
+  //   P = base-thread columns used by commit and proxy state, power-of-two
+  //       padded.
   //
   // Storage notation:
   //   tensor  = distributed tensor value.
@@ -195,6 +221,17 @@ struct AuxDataMap {
   // tracks.
   RegionToValueMap readTracking[numMemTypes];
 
+  // scratch, <Cbuf x B x Cthr x P x Cmask x i64>
+  // Generic-proxy shared-memory accesses visible to each base thread. The low
+  // 16 bits contain source base-thread ids that have accessed the buffer; bits
+  // [16..31] contain the subset covered by fence.proxy.async on the path to
+  // that consumer. CTA dimensions distinguish source and consumer CTAs.
+  RegionToValueMap proxyAccessVisibility;
+
+  // scratch, <Cbuf x B x Cbar x K x Cmask x i64>
+  // Barrier publication table for packed proxyAccessVisibility state.
+  RegionToValueMap proxyAccessTracking;
+
   // scratch, <C x B x P x i8>
   // Per-commit-kind outstanding commit counters for shared-memory buffers.
   // Entries are 0 for none, -1 for staged but uncommitted, and positive for a
@@ -203,21 +240,28 @@ struct AuxDataMap {
   // intra-CTA.
   RegionToValueMap commits[CommitKind::NumCommitKinds];
 
+  // State-lane plans and analysis-derived runtime-base, state-mask, and CTA
+  // cases for each memdesc.
+  triton::BufferStatePlan bufferStatePlans[numMemTypes];
+  DenseMap<Value, BufferStateCandidates> bufferCandidates[numMemTypes];
+
+  // Beta compatibility: legacy FunctionBuilder entry points still consume
+  // packed descriptors and an optional alias expansion matrix.
   // tensor, <B x B x i1>
-  // Optional per-memory-type alias matrix. Created only when BufferRegion
-  // analysis finds cross-buffer aliasing; checks expand selected buffer rows
-  // through this matrix.
   RegionToValueMap aliasMatrices[numMemTypes];
 
   // scratch pointer, i32
   // Shared-cluster lock used to serialize ConSan instrumentation updates.
   RegionToValueMap lock;
 
-  // Consan inserts internal cluster barriers for its own protocols. They must
-  // keep their synchronization semantics, but they are not user-visible
-  // publication points.
-  SmallVector<Operation *> nonPublishingClusterBarriers;
+  // ConSan inserts a cluster barrier to publish lock initialization. It runs
+  // before the lock and rendezvous state are ready, so do not instrument it.
+  SmallVector<Operation *> internalClusterBarriers;
 
+  // Virtual barrier slot for each cluster-barrier lowering resource. Cluster
+  // barriers outside warp specialization share the entry-region slot; each
+  // warp-specialize region has its own slot.
+  DenseMap<Region *, int> clusterBarrierSlots;
   // scratch, <Cbar x K x Cthr x i32>
   // Deadlock-detection bitfield. Each base thread uses two bits: waiting flag
   // and stored phase.
@@ -237,15 +281,21 @@ struct AuxDataMap {
   // present; TMA/TC/CLC peer ranges are added only when the module uses them.
   ThreadLayout threadLayout;
 
+  bool hasAsyncCopyReads = false;
+  bool hasAsyncProxyFenceTracking = false;
+
   LogicalResult populateAndPassToWarpSpecialize(ModuleOp module,
                                                 FunctionBuilder &funcBuilder,
-                                                const ConSanTargetHooks *hooks);
+                                                const ConSanTargetHooks &hooks);
+
+  int getClusterBarrierSlot(Operation *op) const;
 
 private:
-  void getBuffersAndBarriers(
+  LogicalResult getBuffersAndBarriers(
       ModuleOp module,
       SmallVector<SmallVector<triton::BufferRegion>, 2> &bufRegions,
-      SmallVector<triton::BufferRegion> &barrierRegions);
+      SmallVector<triton::BufferRegion> &barrierRegions,
+      const ConSanTargetHooks &hooks);
   void passToWarpSpecialize(triton::FuncOp func, ValueType value,
                             RegionToValueMap &map, int &captureCounter,
                             int64_t &captureBytes);

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -31,12 +31,14 @@ struct MemEffectsOpInfo {
   };
   struct Effects {
     enum RW { Read, Write } rw;
+    enum class Proxy { Generic, Async } proxy;
     Value buf;
     std::string operandName = "";
     uint32_t length = 0;
 
-    Effects(RW rw, Value buf, std::string operandName = "")
-        : rw(rw), buf(buf), operandName(operandName),
+    Effects(RW rw, Value buf, std::string operandName = "",
+            Proxy proxy = Proxy::Generic)
+        : rw(rw), proxy(proxy), buf(buf), operandName(operandName),
           length(getMemDescLength(buf)) {}
   };
   struct BarrierInfo {
@@ -83,6 +85,10 @@ struct WaitOpInfo {
   bool transferReads;
 };
 
+struct AsyncProxyFenceInfo {
+  bool cluster;
+};
+
 struct CommitKindDesc {
   CommitKind::Kind kind;
   std::string operationDesc;
@@ -105,7 +111,17 @@ public:
   virtual std::optional<BarrierInvalidateInfo>
   getBarrierInvalidateInfo(Operation *op) const = 0;
 
-  virtual std::optional<WaitOpInfo> getWaitOpInfo(Operation *op) const = 0;
+  virtual std::optional<WaitOpInfo>
+  getWaitOpInfo(Operation *op, const AuxDataMap &auxData) const = 0;
+
+  virtual std::optional<AsyncProxyFenceInfo>
+  getAsyncProxyFenceInfo(Operation *op) const {
+    return std::nullopt;
+  }
+
+  virtual bool needsAsyncProxyFenceTracking(ModuleOp module) const {
+    return false;
+  }
 
   virtual Value getIssuerCTAPred(ImplicitLocOpBuilder &b,
                                  Operation *op) const = 0;
@@ -113,34 +129,29 @@ public:
   virtual std::optional<MemEffectsOpInfo>
   getMemEffectsOpInfo(Operation *op) const {
     namespace ttg = triton::gpu;
-    std::optional<MemEffectsOpInfo> info;
     if (auto copyOp = dyn_cast<ttg::AsyncCopyGlobalToLocalOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
-      info->commitKind = CommitKind::AsyncCp;
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                        copyOp.getResult());
+      MemEffectsOpInfo info;
+      info.trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
+      info.commitKind = CommitKind::AsyncCp;
+      info.operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
+                                       copyOp.getResult());
+      return info;
     }
-    if (auto loadOp = dyn_cast<ttg::LocalLoadOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                        loadOp.getSrc());
+
+    MemEffectsOpInfo info;
+    info.trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+    auto barrierOp = dyn_cast<ttg::MBarrierOpInterface>(op);
+    for (const auto &access : BufferRegionAnalysis::getMemoryAccesses(op)) {
+      if (barrierOp &&
+          llvm::is_contained(barrierOp.getBarriers(), access.value))
+        continue;
+      info.operandEffects.emplace_back(access.isWrite
+                                           ? MemEffectsOpInfo::Effects::Write
+                                           : MemEffectsOpInfo::Effects::Read,
+                                       access.value);
     }
-    if (auto storeOp = dyn_cast<ttg::LocalStoreOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                        storeOp.getDst());
-    }
-    if (auto allocOp = dyn_cast<ttg::LocalAllocOp>(op)) {
-      if (allocOp.getSrc()) {
-        info.emplace();
-        info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-        info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                          allocOp.getResult());
-      }
-    }
+    if (info.operandEffects.empty())
+      return std::nullopt;
     return info;
   }
 
@@ -152,7 +163,8 @@ public:
 
   // Returns commit kinds used by addReadChecks to detect outstanding
   // read accesses to shared memory.
-  virtual SmallVector<CommitKindDesc> getOutstandingReadCommitKinds() const {
+  virtual SmallVector<CommitKindDesc>
+  getOutstandingReadCommitKinds(const AuxDataMap &auxData) const {
     return {};
   }
 
@@ -172,7 +184,7 @@ public:
 };
 
 LogicalResult runConcurrencySanitizer(ModuleOp module,
-                                      const ConSanTargetHooks *hooks);
+                                      const ConSanTargetHooks &hooks);
 
 using ConSanHooksFactory = std::function<std::unique_ptr<ConSanTargetHooks>()>;
 void registerConSanHooks(llvm::StringRef key, ConSanHooksFactory factory);

--- a/lib/Analysis/BufferRegion.cpp
+++ b/lib/Analysis/BufferRegion.cpp
@@ -1,11 +1,18 @@
 #include "triton/Analysis/BufferRegion.h"
+
+#include <limits>
+#include <optional>
+
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "llvm/Support/MathExtras.h"
 
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
@@ -14,13 +21,26 @@ using namespace mlir;
 
 namespace {
 // TODO: move to Utility.cpp/unify with TritonInstrument/Utility.cpp
-uint64_t getAllocationOffset(ttg::LocalAllocOp op) {
+FailureOr<SmallVector<uint32_t, 2>> getAllocationOffsets(ttg::LocalAllocOp op) {
   auto offsetAttr = op->getAttr("allocation.offset");
   if (!offsetAttr) {
-    llvm::report_fatal_error(
-        "ConcurrencySanitizer should run after AllocateSharedMemory pass.");
+    op.emitError("ConcurrencySanitizer should run after "
+                 "AllocateSharedMemory pass");
+    return failure();
   }
-  return cast<IntegerAttr>(offsetAttr).getInt();
+  SmallVector<uint32_t, 2> offsets;
+  if (auto array = dyn_cast<ArrayAttr>(offsetAttr))
+    for (Attribute offset : array)
+      offsets.push_back(cast<IntegerAttr>(offset).getInt());
+  else
+    offsets.push_back(cast<IntegerAttr>(offsetAttr).getInt());
+  return offsets;
+}
+
+SmallVector<uint32_t, 2> advancePartitionBases(ArrayRef<uint32_t> bases,
+                                               uint32_t offset) {
+  return llvm::to_vector<2>(
+      llvm::map_range(bases, [=](uint32_t base) { return base + offset; }));
 }
 
 uint64_t getAllocationOffset(ttng::TMEMAllocOp op) {
@@ -46,63 +66,219 @@ unsigned getMemDescSize(ttg::MemDescType ty) {
   return product(ttg::getShapePerCTA(ty)) * elSize;
 }
 
-unsigned getAllocSize(ttg::LocalAllocOp op) {
-  return getMemDescSize(op.getType());
+uint32_t applySharedPadding(uint32_t byteOffset, ttg::MemDescType ty) {
+  auto padded = ttg::getPaddedEncoding(ty.getEncoding());
+  if (!padded)
+    return byteOffset;
+  uint64_t elementSize = ty.getElementTypeBitWidth() / 8;
+  uint64_t elementOffset = byteOffset / elementSize;
+  uint64_t paddedOffset =
+      (padded.getPaddedSize({static_cast<int64_t>(elementOffset + 1)}) - 1) *
+          elementSize +
+      byteOffset % elementSize;
+  assert(paddedOffset <= std::numeric_limits<uint32_t>::max());
+  return static_cast<uint32_t>(paddedOffset);
 }
 
-unsigned getAllocSize(ttng::TMEMAllocOp op) {
-  return getMemDescSize(op.getType());
+uint32_t getMemDescStorageOffset(ttg::MemDescType ty, unsigned index);
+
+using MemDescFootprint = SmallVector<triton::BufferRegion::CTAAddresses, 2>;
+
+triton::AddressSet &getAddressesForCTA(MemDescFootprint &footprint,
+                                       uint32_t cta) {
+  auto it = llvm::partition_point(
+      footprint, [cta](const auto &entry) { return entry.first < cta; });
+  if (it == footprint.end() || it->first != cta)
+    it = footprint.insert(it, triton::BufferRegion::CTAAddresses{cta, {}});
+  return it->second;
 }
 
-unsigned getNumBuffers(ttg::MemDescIndexOp memdescIndexOp) {
-  ttg::MemDescType ty =
-      cast<ttg::MemDescType>(memdescIndexOp.getSrc().getType());
-  return ty.getShape()[0];
-}
+MemDescFootprint getMemDescAddresses(
+    uint32_t storageBase, uint32_t affineOffset, ttg::MemDescType ty,
+    llvm::DenseMap<std::pair<Type, uint32_t>, triton::AddressSet> *cache =
+        nullptr,
+    ArrayRef<uint32_t> partitionBases = {}, uint32_t affinePartitionOffset = 0,
+    uint32_t affineCTAOffset = 0) {
+  bool isTmem = isa<ttng::TensorMemorySpaceAttr>(ty.getMemorySpace());
+  auto collectPages = [&]() {
+    ttg::MemDescType pageTy =
+        ty.cloneWith(ty.getShape().drop_front(), ty.getElementType());
+    MemDescFootprint footprint;
+    for (int64_t page = 0; page < ty.getDimSize(0); ++page) {
+      uint32_t pageOffset = getMemDescStorageOffset(pageTy, page);
+      MemDescFootprint pageFootprint = getMemDescAddresses(
+          storageBase + pageOffset, affineOffset, pageTy, /*cache=*/nullptr,
+          advancePartitionBases(partitionBases, pageOffset),
+          affinePartitionOffset, affineCTAOffset);
+      for (const auto &[cta, addresses] : pageFootprint)
+        getAddressesForCTA(footprint, cta).insert(addresses);
+    }
+    return footprint;
+  };
+  if (cast<ttg::LayoutEncodingTrait>(ty.getEncoding()).getRank() !=
+      ty.getRank())
+    return collectPages();
+  triton::LinearLayout layout = ttg::isPaddedEncoding(ty.getEncoding())
+                                    ? ttg::paddedLinearLayout(ty)
+                                    : ttg::toLinearLayout(ty);
+  if (llvm::size(layout.getOutDimNames()) != ty.getRank())
+    return collectPages();
+  triton::LinearLayout inverse = layout.pseudoinvert();
+  MLIRContext *ctx = ty.getContext();
+  SmallVector<StringAttr> dims = triton::standardOutDimNames(ctx, ty.getRank());
+  ArrayRef<int64_t> shape = ty.getShape();
+  uint64_t numPoints = product(shape);
+  uint32_t bitWidth = ty.getElementTypeBitWidth();
 
-llvm::DenseSet<Value> getBarrierOperands(Operation *op) {
-  if (auto barrierOp = dyn_cast<ttg::MBarrierOpInterface>(op)) {
-    auto barriers = barrierOp.getBarriers();
-    return llvm::DenseSet<Value>(barriers.begin(), barriers.end());
+  StringAttr offsetName = StringAttr::get(ctx, "offset");
+  StringAttr blockName = StringAttr::get(ctx, "block");
+  StringAttr partitionName = StringAttr::get(ctx, "partition");
+  StringAttr rowName = StringAttr::get(ctx, "row");
+  StringAttr colName = StringAttr::get(ctx, "col");
+
+  MemDescFootprint footprint;
+  auto addPhysicalAddress = [&](uint32_t offset, uint32_t row, uint32_t col,
+                                uint32_t partition, uint32_t block) {
+    uint32_t cta = block ^ affineCTAOffset;
+    auto &addresses = getAddressesForCTA(footprint, cta);
+    if (isTmem) {
+      uint64_t bitBegin = static_cast<uint64_t>(col) * bitWidth;
+      uint32_t firstWord = bitBegin / 32;
+      uint32_t lastWord = llvm::divideCeil(bitBegin + bitWidth, uint64_t{32});
+      uint32_t relative = (row << 16) | firstWord;
+      uint64_t begin =
+          static_cast<uint64_t>(storageBase) + affineOffset + relative;
+      for (uint32_t word = firstWord; word < lastWord; ++word) {
+        uint64_t address = begin + (word - firstWord);
+        assert(address <= std::numeric_limits<uint32_t>::max());
+        addresses.set(address);
+      }
+    } else {
+      uint32_t base = storageBase;
+      if (!partitionBases.empty())
+        base = partitionBases[partition ^ affinePartitionOffset];
+      uint32_t relative = offset * (bitWidth / 8);
+      uint32_t combined = affineOffset ^ relative;
+      uint64_t begin =
+          static_cast<uint64_t>(base) + applySharedPadding(combined, ty);
+      for (uint32_t byte = 0; byte < bitWidth / 8; ++byte) {
+        assert(begin + byte <= std::numeric_limits<uint32_t>::max());
+        addresses.set(begin + byte);
+      }
+    }
+  };
+
+  struct PhysicalBasis {
+    uint32_t offset = 0;
+    uint32_t row = 0;
+    uint32_t col = 0;
+    uint32_t partition = 0;
+    uint32_t block = 0;
+  };
+  SmallVector<PhysicalBasis> bases;
+  bool hasCTAAddressVariation = false;
+  for (auto dimAndSize : llvm::zip_equal(dims, shape)) {
+    auto dim = std::get<0>(dimAndSize);
+    auto dimSize = std::get<1>(dimAndSize);
+    unsigned numBits = llvm::Log2_64(dimSize);
+    for (unsigned bit = 0; bit < numBits; ++bit) {
+      auto basis = [&](StringAttr name) {
+        return inverse.hasOutDim(name)
+                   ? static_cast<uint32_t>(inverse.getBasis(dim, bit, name))
+                   : 0;
+      };
+      uint32_t block = basis(blockName);
+      hasCTAAddressVariation |= block != 0;
+      bases.push_back({basis(offsetName), basis(rowName), basis(colName),
+                       basis(partitionName), block});
+    }
   }
 
-  return llvm::DenseSet<Value>{};
+  if (cache && partitionBases.empty() && !hasCTAAddressVariation) {
+    auto [found, inserted] =
+        cache->try_emplace(std::make_pair(Type(ty), affineOffset));
+    if (inserted)
+      found->second =
+          std::move(getMemDescAddresses(0, affineOffset, ty).front().second);
+    footprint.emplace_back(affineCTAOffset,
+                           found->second.translated(storageBase));
+    return footprint;
+  }
+
+  PhysicalBasis physical;
+  for (uint64_t index = 0; index < numPoints; ++index) {
+    if (index != 0) {
+      const PhysicalBasis &basis = bases[llvm::countr_zero(index)];
+      physical.offset ^= basis.offset;
+      physical.row ^= basis.row;
+      physical.col ^= basis.col;
+      physical.partition ^= basis.partition;
+      physical.block ^= basis.block;
+    }
+    addPhysicalAddress(physical.offset, physical.row, physical.col,
+                       physical.partition, physical.block);
+  }
+  return footprint;
+}
+
+triton::BufferRegionView getMemDescView(
+    uint32_t storageBase, uint32_t affineOffset, ttg::MemDescType ty,
+    llvm::DenseMap<std::pair<Type, uint32_t>, triton::AddressSet> *cache,
+    ArrayRef<uint32_t> partitionBases = {}, uint32_t affinePartitionOffset = 0,
+    uint32_t affineCTAOffset = 0) {
+  MemDescFootprint footprint =
+      getMemDescAddresses(storageBase, affineOffset, ty, cache, partitionBases,
+                          affinePartitionOffset, affineCTAOffset);
+  uint32_t runtimeStorageBase = partitionBases.empty()
+                                    ? storageBase
+                                    : partitionBases[affinePartitionOffset];
+  uint32_t baseOffset = runtimeStorageBase +
+                        (isa<ttng::TensorMemorySpaceAttr>(ty.getMemorySpace())
+                             ? affineOffset
+                             : applySharedPadding(affineOffset, ty));
+  return {{baseOffset, getMemDescSize(ty), std::move(footprint)},
+          storageBase,
+          affineOffset,
+          llvm::to_vector<2>(partitionBases),
+          affinePartitionOffset,
+          affineCTAOffset};
+}
+
+uint32_t getMemDescStorageOffset(ttg::MemDescType ty, unsigned index) {
+  if (isa<ttng::TensorMemorySpaceAttr>(ty.getMemorySpace()))
+    return index * ttng::getTmemAllocSizes(ty).numCols;
+  uint64_t offset = static_cast<uint64_t>(index) * getMemDescSize(ty);
+  assert(offset <= std::numeric_limits<uint32_t>::max());
+  return static_cast<uint32_t>(offset);
 }
 
 bool isUsedAsBarrier(Value v) {
-  for (auto user : v.getUsers()) {
-    if (getBarrierOperands(user).contains(v)) {
-      return true;
-    }
-  }
-  return false;
+  return llvm::any_of(v.getUsers(), [&](Operation *user) {
+    auto barrierOp = dyn_cast<ttg::MBarrierOpInterface>(user);
+    return barrierOp && llvm::is_contained(barrierOp.getBarriers(), v);
+  });
 }
 
-bool isUsedAsSharedMemory(Value v) {
-  auto type = dyn_cast<ttg::MemDescType>(v.getType());
-  return type &&
-         isa_and_nonnull<ttg::SharedMemorySpaceAttr>(type.getMemorySpace());
-}
+struct MemDescSubsliceOffsets {
+  uint32_t byteOffset = 0;
+  uint32_t partitionOffset = 0;
+  uint32_t ctaOffset = 0;
+};
 
-bool isUsedAsTensorMemory(Value v) {
-  auto type = dyn_cast<ttg::MemDescType>(v.getType());
-  return type &&
-         isa_and_nonnull<ttng::TensorMemorySpaceAttr>(type.getMemorySpace());
-}
-
-uint32_t getMemDescSubsliceByteOffset(ttg::MemDescSubsliceOp op) {
+MemDescSubsliceOffsets
+getMemDescSubsliceUnpaddedOffsets(ttg::MemDescSubsliceOp op) {
   auto srcTy = op.getSrc().getType();
   auto offsets = op.getOffsets();
   if (offsets.empty())
-    return 0;
+    return MemDescSubsliceOffsets{};
 
   Attribute encoding = srcTy.getEncoding();
-  mlir::triton::LinearLayout layout;
-  if (auto padded = dyn_cast<ttg::PaddedSharedEncodingAttr>(encoding)) {
-    layout = padded.getLinearComponent();
-  } else {
-    layout = ttg::toLinearLayout(srcTy);
-  }
+  // Beta's MemDescSubsliceOp offsets and layouts retain the pipelining
+  // dimension; the upstream dropPipeliningDim helper is not present here.
+  auto layoutRank = offsets.size();
+  mlir::triton::LinearLayout layout = ttg::isPaddedEncoding(encoding)
+                                          ? ttg::paddedLinearLayout(srcTy)
+                                          : ttg::toLinearLayout(srcTy);
 
   MLIRContext *ctx = op->getContext();
   SmallVector<StringAttr> dimNames =
@@ -115,13 +291,20 @@ uint32_t getMemDescSubsliceByteOffset(ttg::MemDescSubsliceOp op) {
 
   StringAttr offsetDim = StringAttr::get(ctx, "offset");
   StringAttr blockDim = StringAttr::get(ctx, "block");
-  mlir::triton::LinearLayout inverse = layout.invert();
+  StringAttr partitionDim = StringAttr::get(ctx, "partition");
+  mlir::triton::LinearLayout inverse = layout.pseudoinvert();
   auto mapped = inverse.apply(logicalOffsets);
-  assert(mapped.size() == 2 && mapped[0].first == offsetDim &&
-         mapped[1].first == blockDim && mapped[1].second == 0 &&
-         "expected offset and zero block dimensions after inversion");
-  uint64_t elementOffset = static_cast<uint32_t>(mapped[0].second);
-
+  uint64_t elementOffset = 0;
+  uint32_t blockOffset = 0;
+  uint32_t partitionOffset = 0;
+  for (auto [dim, offset] : mapped) {
+    if (dim == offsetDim)
+      elementOffset = static_cast<uint32_t>(offset);
+    else if (dim == blockDim)
+      blockOffset = static_cast<uint32_t>(offset);
+    else if (dim == partitionDim)
+      partitionOffset = static_cast<uint32_t>(offset);
+  }
   uint64_t elementSizeBytes =
       srcTy.getElementType().getIntOrFloatBitWidth() / 8;
   assert(elementSizeBytes > 0 && "element size must be non-zero");
@@ -149,25 +332,177 @@ uint32_t getMemDescSubsliceByteOffset(ttg::MemDescSubsliceOp op) {
 
   assert(byteOffset <= std::numeric_limits<uint32_t>::max() &&
          "memdesc_subslice offset exceeds 32-bit range");
-  return static_cast<uint32_t>(byteOffset);
+  return MemDescSubsliceOffsets{static_cast<uint32_t>(byteOffset),
+                                partitionOffset, blockOffset};
 }
 
 std::optional<triton::BufferRegionAnalysis::RegionType> getRegionType(Value v) {
-  if (isUsedAsBarrier(v)) {
+  if (isUsedAsBarrier(v))
     return triton::BufferRegionAnalysis::RegionType::BARRIER;
-  }
-  if (isUsedAsSharedMemory(v)) {
+  auto type = dyn_cast<ttg::MemDescType>(v.getType());
+  if (!type)
+    return std::nullopt;
+  if (isa<ttg::SharedMemorySpaceAttr>(type.getMemorySpace()))
     return triton::BufferRegionAnalysis::RegionType::SHARED_MEMORY;
-  }
-  if (isUsedAsTensorMemory(v)) {
+  if (isa<ttng::TensorMemorySpaceAttr>(type.getMemorySpace()))
     return triton::BufferRegionAnalysis::RegionType::TENSOR_MEMORY;
-  }
   return std::nullopt;
 }
 
 } // namespace
 
 namespace mlir::triton {
+
+AddressSet AddressSet::fromRange(uint32_t begin, uint32_t length) {
+  uint64_t end = static_cast<uint64_t>(begin) + length;
+  assert(end <= std::numeric_limits<uint32_t>::max() &&
+         "address range exceeds 32-bit address space");
+  AddressSet result;
+  for (uint64_t address = begin; address < end; ++address)
+    result.set(address);
+  return result;
+}
+
+void AddressSet::set(uint32_t address) { addresses.set(address); }
+
+void AddressSet::insert(const AddressSet &other) {
+  addresses |= other.addresses;
+}
+
+AddressSet AddressSet::intersection(const AddressSet &other) const {
+  AddressSet result = *this;
+  result.addresses &= other.addresses;
+  return result;
+}
+
+void AddressSet::subtract(const AddressSet &other) {
+  addresses.intersectWithComplement(other.addresses);
+}
+
+bool AddressSet::intersects(const AddressSet &other) const {
+  return addresses.intersects(other.addresses);
+}
+
+bool AddressSet::contains(const AddressSet &other) const {
+  return addresses.contains(other.addresses);
+}
+
+AddressSet AddressSet::translated(uint32_t delta) const {
+  AddressSet result;
+  for (uint32_t address : addresses) {
+    uint64_t translated = static_cast<uint64_t>(address) + delta;
+    assert(translated <= std::numeric_limits<uint32_t>::max() &&
+           "translated address set exceeds 32-bit address space");
+    result.set(translated);
+  }
+  return result;
+}
+
+BufferStatePlan createBufferStatePlan(ArrayRef<BufferRegion> regions,
+                                      bool includeUnknown) {
+  BufferStatePlan plan;
+  plan.regionMasks.resize(regions.size());
+
+  SmallVector<AddressSet> projectedAddresses(regions.size());
+  for (auto [region, projected] : llvm::zip(regions, projectedAddresses))
+    for (const auto &[cta, addresses] : region.ctaAddresses)
+      projected.insert(addresses);
+
+  llvm::SmallBitVector assigned(regions.size());
+  SmallVector<SmallVector<unsigned>> components;
+  for (unsigned first = 0; first < regions.size(); ++first) {
+    if (assigned.test(first) || projectedAddresses[first].empty())
+      continue;
+    SmallVector<unsigned> component;
+    SmallVector<unsigned> worklist = {first};
+    assigned.set(first);
+    while (!worklist.empty()) {
+      unsigned current = worklist.pop_back_val();
+      component.push_back(current);
+      for (unsigned candidate = 0; candidate < regions.size(); ++candidate) {
+        if (assigned.test(candidate) || !projectedAddresses[current].intersects(
+                                            projectedAddresses[candidate]))
+          continue;
+        assigned.set(candidate);
+        worklist.push_back(candidate);
+      }
+    }
+    llvm::sort(component);
+    components.push_back(std::move(component));
+  }
+
+  struct ComponentPlan {
+    SmallVector<unsigned> regionIds;
+    SmallVector<llvm::SmallBitVector> atomMemberships;
+  };
+  using Atom = std::pair<AddressSet, llvm::SmallBitVector>;
+  SmallVector<ComponentPlan> componentPlans;
+  for (const SmallVector<unsigned> &component : components) {
+    SmallVector<Atom> atoms;
+    for (auto [localId, regionId] : llvm::enumerate(component)) {
+      AddressSet uncovered = projectedAddresses[regionId];
+      for (size_t atomId = 0, atomCount = atoms.size();
+           atomId < atomCount && !uncovered.empty(); ++atomId) {
+        auto &[addresses, atomMembership] = atoms[atomId];
+        AddressSet overlap = addresses.intersection(uncovered);
+        if (overlap.empty())
+          continue;
+
+        uncovered.subtract(overlap);
+        if (addresses == overlap) {
+          atomMembership.set(localId);
+          continue;
+        }
+
+        llvm::SmallBitVector membership = atomMembership;
+        membership.set(localId);
+        addresses.subtract(overlap);
+        atoms.push_back({std::move(overlap), std::move(membership)});
+      }
+
+      if (!uncovered.empty()) {
+        llvm::SmallBitVector membership(component.size());
+        membership.set(localId);
+        atoms.push_back({std::move(uncovered), std::move(membership)});
+      }
+    }
+
+    // Preserve the original lane order by each atom's first address.
+    llvm::sort(atoms, llvm::less_first());
+
+    SmallVector<llvm::SmallBitVector> atomMemberships;
+    atomMemberships.reserve(atoms.size());
+    for (Atom &atom : atoms)
+      atomMemberships.push_back(std::move(atom.second));
+
+    plan.numLanes += atomMemberships.size();
+    componentPlans.push_back({component, std::move(atomMemberships)});
+  }
+
+  if (includeUnknown)
+    plan.unknownMask = llvm::SmallBitVector(++plan.numLanes, true);
+
+  for (llvm::SmallBitVector &mask : plan.regionMasks)
+    mask.resize(plan.numLanes);
+
+  unsigned laneBegin = 0;
+  for (const ComponentPlan &componentPlan : componentPlans) {
+    for (auto [atomId, membership] :
+         llvm::enumerate(componentPlan.atomMemberships)) {
+      unsigned lane = laneBegin + atomId;
+      for (auto [localId, regionId] :
+           llvm::enumerate(componentPlan.regionIds)) {
+        if (!membership.test(localId))
+          continue;
+        plan.regionMasks[regionId].set(lane);
+      }
+    }
+
+    laneBegin += componentPlan.atomMemberships.size();
+  }
+  assert(laneBegin + includeUnknown == plan.numLanes);
+  return plan;
+}
 
 LogicalResult BufferRegionAnalysis::initialize(Operation *top) {
   // Mark all warp-specialize partitions as live.
@@ -192,7 +527,12 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     Operation *op,
     llvm::ArrayRef<const dataflow::Lattice<RegionInfo> *> operands,
     llvm::ArrayRef<dataflow::Lattice<RegionInfo> *> results) {
-  RegionInfo regionInfo;
+  RegionInfo regionInfo(RegionInfo::ViewList{});
+  auto propagateRegions = [&](const RegionInfo &info) {
+    for (auto *result : results)
+      propagateIfChanged(result, result->join(info));
+    return success();
+  };
   if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(op)) {
     for (Region *region : wsOp.getPartitionRegions()) {
       if (region->empty())
@@ -206,154 +546,157 @@ LogicalResult BufferRegionAnalysis::visitOperation(
     return success();
   }
   if (auto localAllocOp = dyn_cast<ttg::LocalAllocOp>(op)) {
-    uint32_t offset = getAllocationOffset(localAllocOp);
-    uint32_t size = getAllocSize(localAllocOp);
-    regionInfo.regions.insert({offset, size});
-
-    for (auto *r : results) {
-      propagateIfChanged(r, r->join(regionInfo));
-    }
-    return success();
+    FailureOr<SmallVector<uint32_t, 2>> offsets =
+        getAllocationOffsets(localAllocOp);
+    if (failed(offsets))
+      return failure();
+    ArrayRef<uint32_t> partitionBases = offsets->size() > 1
+                                            ? ArrayRef<uint32_t>(*offsets)
+                                            : ArrayRef<uint32_t>();
+    regionInfo.views.insert(getMemDescView(offsets->front(), /*affineOffset=*/0,
+                                           localAllocOp.getType(),
+                                           &footprintCache, partitionBases));
+    return propagateRegions(regionInfo);
   }
   if (auto tmemAllocOp = dyn_cast<ttng::TMEMAllocOp>(op)) {
-    uint32_t offset = getAllocationOffset(tmemAllocOp);
-    uint32_t size = getAllocSize(tmemAllocOp);
-    regionInfo.regions.insert({offset, size});
-
-    for (auto *r : results) {
-      propagateIfChanged(r, r->join(regionInfo));
-    }
-    return success();
+    regionInfo.views.insert(
+        getMemDescView(getAllocationOffset(tmemAllocOp), /*affineOffset=*/0,
+                       tmemAllocOp.getType(), &footprintCache));
+    return propagateRegions(regionInfo);
   }
   if (auto memdescIndexOp = dyn_cast<ttg::MemDescIndexOp>(op)) {
-    RegionInfo in = operands[0]->getValue();
-    int numSubBuffers = getNumBuffers(memdescIndexOp);
-    for (auto &region : in.regions) {
-      for (int i = 0; i < numSubBuffers; i++) {
-        uint32_t subBufferSize = getMemDescSize(memdescIndexOp.getType());
-        regionInfo.regions.insert(
-            {region.baseOffset + i * subBufferSize, subBufferSize});
+    const RegionInfo &in = operands[0]->getValue();
+    if (in.isUnknown())
+      return propagateRegions(in);
+    int numSubBuffers =
+        cast<ttg::MemDescType>(memdescIndexOp.getSrc().getType()).getShape()[0];
+    int firstSubBuffer = 0;
+    int endSubBuffer = numSubBuffers;
+    APInt constantIndex;
+    if (matchPattern(memdescIndexOp.getIndex(),
+                     m_ConstantInt(&constantIndex))) {
+      int64_t index = constantIndex.getSExtValue();
+      firstSubBuffer = index;
+      endSubBuffer = index + 1;
+    }
+    for (const BufferRegionView &view : in.views) {
+      for (int i = firstSubBuffer; i < endSubBuffer; ++i) {
+        uint32_t stageOffset =
+            getMemDescStorageOffset(memdescIndexOp.getType(), i);
+        regionInfo.views.insert(getMemDescView(
+            view.storageBase + stageOffset, view.affineOffset,
+            memdescIndexOp.getType(), &footprintCache,
+            advancePartitionBases(view.partitionBases, stageOffset),
+            view.affinePartitionOffset, view.affineCTAOffset));
       }
     }
 
-    for (auto *r : results) {
-      propagateIfChanged(r, r->join(regionInfo));
-    }
-    return success();
+    return propagateRegions(regionInfo);
   }
   if (auto memdescSubsliceOp = dyn_cast<ttg::MemDescSubsliceOp>(op)) {
-    RegionInfo in = operands[0]->getValue();
-    uint32_t subBufferSize = getMemDescSize(memdescSubsliceOp.getType());
-    uint32_t relativeOffset = getMemDescSubsliceByteOffset(memdescSubsliceOp);
-    for (auto &region : in.regions) {
-      regionInfo.regions.insert(
-          {region.baseOffset + relativeOffset, subBufferSize});
-    }
-    for (auto *r : results) {
-      propagateIfChanged(r, r->join(regionInfo));
-    }
-    return success();
+    const RegionInfo &in = operands[0]->getValue();
+    if (in.isUnknown())
+      return propagateRegions(in);
+    MemDescSubsliceOffsets relativeOffset =
+        getMemDescSubsliceUnpaddedOffsets(memdescSubsliceOp);
+    for (const BufferRegionView &view : in.views)
+      regionInfo.views.insert(getMemDescView(
+          view.storageBase, view.affineOffset ^ relativeOffset.byteOffset,
+          memdescSubsliceOp.getType(), &footprintCache, view.partitionBases,
+          view.affinePartitionOffset ^ relativeOffset.partitionOffset,
+          view.affineCTAOffset ^ relativeOffset.ctaOffset));
+    return propagateRegions(regionInfo);
   }
   if (auto tmemSubsliceOp = dyn_cast<ttng::TMEMSubSliceOp>(op)) {
-    RegionInfo in = operands[0]->getValue();
-    uint32_t subBufferSize = getMemDescSize(tmemSubsliceOp.getType());
+    const RegionInfo &in = operands[0]->getValue();
+    if (in.isUnknown())
+      return propagateRegions(in);
     uint32_t relativeOffset = ttng::getTMemSubSliceOffset(
         tmemSubsliceOp.getType(), tmemSubsliceOp.getN());
-    for (auto &region : in.regions) {
-      regionInfo.regions.insert(
-          {region.baseOffset + relativeOffset, subBufferSize});
-    }
-    for (auto *r : results) {
-      propagateIfChanged(r, r->join(regionInfo));
-    }
-    return success();
+    for (const BufferRegionView &view : in.views)
+      regionInfo.views.insert(getMemDescView(
+          view.storageBase, view.affineOffset + relativeOffset,
+          tmemSubsliceOp.getType(), &footprintCache, view.partitionBases,
+          view.affinePartitionOffset, view.affineCTAOffset));
+    return propagateRegions(regionInfo);
   }
   if (auto selectOp = dyn_cast<arith::SelectOp>(op)) {
     if (isa<ttg::MemDescType>(selectOp.getType())) {
       regionInfo =
           RegionInfo::join(operands[1]->getValue(), operands[2]->getValue());
-      for (auto *r : results) {
-        propagateIfChanged(r, r->join(regionInfo));
-      }
-      return success();
+      return propagateRegions(regionInfo);
     }
   }
-  // "Passthrough" ops that don't modify the buffer regions.
-  if (isa<ttg::MemDescTransOp, ttg::MemDescReshapeOp,
-          ttg::MemDescReinterpretOp>(op)) {
-    // Just propagate the regions from the operand.
-    RegionInfo in = operands[0]->getValue();
-    for (auto &region : in.regions) {
-      regionInfo.regions.insert(region);
-    }
-    for (auto *r : results) {
-      propagateIfChanged(r, r->join(regionInfo));
-    }
+  if (auto reinterpretOp = dyn_cast<ttg::MemDescReinterpretOp>(op)) {
+    const RegionInfo &in = operands[0]->getValue();
+    if (in.isUnknown())
+      return propagateRegions(in);
+    for (const BufferRegionView &view : in.views)
+      regionInfo.views.insert(getMemDescView(
+          view.storageBase, view.affineOffset, reinterpretOp.getType(),
+          &footprintCache, view.partitionBases, view.affinePartitionOffset,
+          view.affineCTAOffset));
+    return propagateRegions(regionInfo);
+  }
+  if (isa<ttg::MemDescTransOp, ttg::MemDescReshapeOp>(op))
+    return propagateRegions(operands[0]->getValue());
+  if (isa<ttng::WarpGroupDotWaitOp>(op)) {
+    for (auto [operand, result] : llvm::zip_equal(operands, results))
+      propagateIfChanged(result, result->join(operand->getValue()));
     return success();
   }
-  verifyOpIsSupported(op);
+  for (auto [result, lattice] : llvm::zip_equal(op->getResults(), results)) {
+    if (isa<ttg::MemDescType>(result.getType()))
+      propagateIfChanged(
+          lattice, lattice->join(RegionInfo::getPessimisticValueState(result)));
+  }
   return success();
 }
 
 void BufferRegionAnalysis::calculateUsedBufferRegions(Operation *op) {
   op->walk([&](Operation *op) {
-    auto insertRegionForValue = [&](Value v) {
-      RegionInfo regionInfo = getLatticeElement(v)->getValue();
-      std::optional<RegionType> regionType = getRegionType(v);
-      if (!regionType) {
-        return;
-      }
-      for (auto &region : regionInfo.regions) {
-        usedBufferRegions[*regionType].insert(region);
-      }
-    };
-    if (BufferRegionAnalysis::isMemoryAccessOperation(op)) {
-      // Allocas define their buffers with return value.
-      if (isa<ttg::LocalAllocOp, ttng::TMEMAllocOp>(op)) {
-        insertRegionForValue(op->getResult(0));
-      }
-      // All other operations access their operands.
-      for (auto operand : op->getOperands()) {
-        insertRegionForValue(operand);
-      }
+    for (const MemoryAccess &access : getMemoryAccesses(op)) {
+      std::optional<RegionType> regionType = getRegionType(access.value);
+      if (!regionType)
+        continue;
+      const RegionInfo &regionInfo =
+          getLatticeElement(access.value)->getValue();
+      if (regionInfo.isUnknown())
+        usedUnknownBufferRegions[*regionType] = true;
+      for (const BufferRegionView &view : regionInfo.views)
+        usedBufferRegions[*regionType].insert(view.region);
     }
   });
 }
 
-bool BufferRegionAnalysis::isMemoryAccessOperation(Operation *op) {
-  if (isa<ttg::LocalLoadOp, ttg::LocalStoreOp, ttng::TMEMLoadOp,
-          ttng::TMEMStoreOp, ttng::TMEMCopyOp, ttg::AsyncCopyGlobalToLocalOp,
-          ttng::TMAOpInterface, ttng::CLCLoadResultOp>(op)) {
-    return true;
-  }
-  if (isa<ttg::MBarrierOpInterface>(op)) {
-    return true;
-  }
-  // Allocations with operands write to the memory.
-  if (isa<ttg::LocalAllocOp, ttng::TMEMAllocOp>(op) &&
-      op->getNumOperands() > 0) {
-    return true;
-  }
-  if (isa<DotOpInterface>(op)) {
-    return true;
-  }
-  return false;
-}
+SmallVector<BufferRegionAnalysis::MemoryAccess>
+BufferRegionAnalysis::getMemoryAccesses(Operation *op) {
+  SmallVector<MemoryAccess> accesses;
+  auto memoryEffects = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!memoryEffects)
+    return accesses;
 
-void BufferRegionAnalysis::verifyOpIsSupported(Operation *op) {
-  bool hasMemoryOperands = llvm::any_of(op->getOperands(), [](Value v) {
-    return isUsedAsSharedMemory(v) || isUsedAsTensorMemory(v);
-  });
-  if (!hasMemoryOperands) {
-    return;
+  SmallVector<MemoryEffects::EffectInstance> effects;
+  memoryEffects.getEffects(effects);
+  for (const MemoryEffects::EffectInstance &effect : effects) {
+    bool isWrite = isa<MemoryEffects::Write>(effect.getEffect());
+    if (!isWrite && !isa<MemoryEffects::Read>(effect.getEffect()))
+      continue;
+    if (effect.getResource() != ttg::SharedMemory::get() &&
+        effect.getResource() != ttng::TensorMemory::get())
+      continue;
+    Value value = effect.getValue();
+    if (!value || !isa<ttg::MemDescType>(value.getType()))
+      continue;
+    auto existing = llvm::find_if(accesses, [&](const MemoryAccess &access) {
+      return access.value == value;
+    });
+    if (existing == accesses.end())
+      accesses.push_back({value, isWrite});
+    else
+      existing->isWrite |= isWrite;
   }
-  if (isMemoryAccessOperation(op)) {
-    return;
-  }
-  op->emitError(
-      "Operation accessing memory unaccounted for in buffer region analysis");
-  llvm::report_fatal_error(
-      "Operation accessing memory unaccounted for in buffer region analysis");
+  return accesses;
 }
 
 } // namespace mlir::triton

--- a/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/InstrumentationToLLVM.cpp
@@ -325,6 +325,38 @@ public:
   }
 };
 
+struct MemoryOffsetToI32OpConversion
+    : public ConvertOpToLLVMPattern<tti::ExperimentalMemoryOffsetToI32Op> {
+public:
+  using ConvertOpToLLVMPattern<
+      tti::ExperimentalMemoryOffsetToI32Op>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(tti::ExperimentalMemoryOffsetToI32Op op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    TritonLLVMOpBuilder b(op.getLoc(), rewriter);
+    auto i32Ty = rewriter.getI32Type();
+    Value base;
+    if (op.getMemType() == tti::MemType::SHARED_MEM) {
+      auto func = op->getParentOfType<FunctionOpInterface>();
+      assert(func && "memory offset must be inside a function");
+      base = b.ptrtoint(i32Ty, LLVM::getStackPointer(rewriter, func));
+    } else {
+      assert(op.getMemType() == tti::MemType::TENSOR_MEM &&
+             "unsupported memory type");
+      Value basePtr =
+          nvgpu::TensorMemoryBaseAddress::create(rewriter, op.getLoc());
+      base = b.ptrtoint(i32Ty, basePtr);
+    }
+
+    Value address = b.add(base, b.i32_val(op.getOffset()));
+    if (op.getMemType() == tti::MemType::SHARED_MEM)
+      address = b.and_(address, b.i32_val(kSharedMemoryObjectMask));
+    rewriter.replaceOp(op, address);
+    return success();
+  }
+};
+
 struct ClusterCTAIdOpConversion
     : public ConvertOpToLLVMPattern<tti::ExperimentalClusterCTAIdOp> {
   ClusterCTAIdOpConversion(const LLVMTypeConverter &converter,
@@ -402,6 +434,7 @@ void mlir::triton::populateInstrumentationToLLVMPatterns(
   patterns.add<LockAcquireOpConversion>(typeConverter, targetInfo);
   patterns.add<LockReleaseOpConversion>(typeConverter, targetInfo);
   patterns.add<MemDescToI32OpConversion>(typeConverter);
+  patterns.add<MemoryOffsetToI32OpConversion>(typeConverter);
   patterns.add<ClusterCTAIdOpConversion>(typeConverter, targetInfo);
   patterns.add<LocalGatherOpConversion>(typeConverter, targetInfo);
 }

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1,6 +1,7 @@
 #include "triton/Dialect/TritonInstrument/IR/FunctionBuilder.h"
 
 #include <cassert>
+#include <optional>
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
@@ -69,6 +70,11 @@ uint32_t makeInterleavedMask(unsigned bit, unsigned numBaseThreads) {
   return mask;
 }
 } // namespace WaitingBits
+
+namespace ProxyAccessBits {
+constexpr unsigned fencedOffset = MAX_NUM_BASE_THREADS;
+constexpr uint64_t seenMask = (1ull << MAX_NUM_BASE_THREADS) - 1;
+} // namespace ProxyAccessBits
 
 // Information about the optional assert message and tensor type to check.
 struct AssertInfo {
@@ -142,11 +148,8 @@ Value reduceAll(ImplicitLocOpBuilder &b, Value tensor) {
   auto tensorType = dyn_cast<RankedTensorType>(tensor.getType());
   if (!tensorType || tensorType.getRank() == 0)
     return tensor;
-  if (tensorType.getRank() != 1) {
-    tensor = triton::ReshapeOp::create(b, {tensorType.getNumElements()}, tensor,
-                                       /*allowReorder=*/true);
-  }
-  return reduceLastDim<OpTy>(b, tensor);
+  SmallVector<int> axes = llvm::to_vector(llvm::seq<int>(tensorType.getRank()));
+  return reduce<OpTy>(b, tensor, axes);
 }
 
 FuncOp getOrCreateFunction(
@@ -193,14 +196,16 @@ FuncOp getOrCreateFunction(
 // Create a call to a function with body given by `buildBody`.
 // If the function does not exist, it will be created, otherwise the
 // existing function will be used.
-// If `assertInfo` is provided, the function should return a tensor of
-// the given type and the result of the function will be asserted.
-void createCallToCachedFunction(
+// If `assertInfo` is provided, the function should return a tensor of the
+// given type. The result is asserted unless `emitAssert` is false.
+Value createCallToCachedFunction(
     ImplicitLocOpBuilder &b, const std::string &name, ArrayRef<Value> args,
     std::optional<AssertInfo> assertInfo, ManglingArgs specializationArgs,
-    std::function<void(ImplicitLocOpBuilder &b, Block *entryBlock)> buildBody) {
-  ModuleOp module = b.getInsertionPoint()->getParentOfType<ModuleOp>();
-  int numWarps = ttg::lookupNumWarps(b.getInsertionPoint()->getParentRegion());
+    std::function<void(ImplicitLocOpBuilder &b, Block *entryBlock)> buildBody,
+    bool emitAssert = true) {
+  Region *region = b.getInsertionBlock()->getParent();
+  ModuleOp module = region->getParentOp()->getParentOfType<ModuleOp>();
+  int numWarps = ttg::lookupNumWarps(region);
   SmallVector<Type> argTypes = llvm::to_vector(
       llvm::map_range(args, [](Value v) { return v.getType(); }));
   Type assertType = assertInfo ? assertInfo->type : nullptr;
@@ -214,9 +219,13 @@ void createCallToCachedFunction(
   auto callOp = triton::CallOp::create(b, func.getName(), resultTypes, args);
   if (assertInfo) {
     Value result = callOp->getResult(0);
-    StringRef message = b.getStringAttr(assertInfo->message);
-    createAssertInThread(b, result, message);
+    if (emitAssert) {
+      StringRef message = b.getStringAttr(assertInfo->message);
+      createAssertInThread(b, result, message);
+    }
+    return result;
   }
+  return {};
 }
 
 Value createBufferDescriptor(ImplicitLocOpBuilder &b, Value offsetI32,
@@ -271,18 +280,6 @@ Value convertAndBroadcast(ImplicitLocOpBuilder &b, Value tensor,
   if (tensorType != sliceType)
     tensor = ttg::ConvertLayoutOp::create(b, sliceType, tensor);
   return tti::reshapeAndBroadcast(b, b.getLoc(), tensor, keptDims, resultType);
-}
-
-Value expandAliases(ImplicitLocOpBuilder &b, Value bufferMask,
-                    Value aliasMatrix, RankedTensorType aliasMatrixType) {
-  assert(aliasMatrixType.getRank() == 2 &&
-         "Alias matrix expected to be rank-2");
-  auto bufferMaskType = cast<RankedTensorType>(bufferMask.getType());
-  Value bufMaskMatrix =
-      convertAndBroadcast(b, bufferMask, {0}, aliasMatrixType);
-  Value aliasingMask = arith::AndIOp::create(b, aliasMatrix, bufMaskMatrix);
-  Value aliasVector = reduce<arith::OrIOp>(b, aliasingMask, {0});
-  return createConvertLayout(b, aliasVector, bufferMaskType.getEncoding());
 }
 
 Value adjustIntegerWidth(ImplicitLocOpBuilder &b, Value value,
@@ -361,8 +358,7 @@ Value createCTASetMask(ImplicitLocOpBuilder &b, RankedTensorType tensorType,
   // build a [0, numCTAs) row-index vector on `dim`, broadcast it to the state
   // tensor shape, and test one bit of `recipientCTAs` per row.
   auto loc = b.getLoc();
-  auto rowType =
-      tti::getSlicedTensorType(tensorType, /*keptDims=*/{dim}, b.getI32Type());
+  auto rowType = tti::getSlicedTensorType(tensorType, {dim}, b.getI32Type());
   Value rowIdx = triton::MakeRangeOp::create(b, rowType, /*start=*/0,
                                              /*end=*/numCTAs);
   auto indexType = cast<RankedTensorType>(
@@ -409,6 +405,71 @@ Operation *createCTAScopedStoreScratchMemory(ImplicitLocOpBuilder &b,
   return createMaskedStoreScratchMemory(
       b, loc, alloc, tensor, tensorType,
       createCTASetMask(b, tensorType, /*dim=*/0, recipientCTAs));
+}
+
+Value createVirtualBarrierMask(ImplicitLocOpBuilder &b, Value barrierIdx,
+                               RankedTensorType tensorType) {
+  Value barrierMask = createDimMask(b, barrierIdx, tensorType, /*dim=*/1);
+  Value leadCTAMask = createCTASetMask(b, tensorType, /*dim=*/0,
+                                       arith::ConstantIntOp::create(b, 1, 32));
+  return arith::AndIOp::create(b, barrierMask, leadCTAMask);
+}
+
+Value arriveVirtualBarrier(ImplicitLocOpBuilder &b, Value statesPtr,
+                           RankedTensorType statesType, Value barrierIdx,
+                           int count) {
+  Value states =
+      tti::createLoadScratchMemory(b, b.getLoc(), statesPtr, statesType);
+  Value mask = createVirtualBarrierMask(b, barrierIdx, statesType);
+  Value one = tti::createConstIntTensor(b, b.getLoc(), 1, statesType);
+  Value two = tti::createConstIntTensor(b, b.getLoc(), 2, statesType);
+  Value phase = arith::AndIOp::create(b, states, one);
+  // Virtual slots encode 2 * arrivals + phase. Completing an epoch resets the
+  // arrival count and toggles the low phase bit used by deadlock detection.
+  Value nextState = arith::AddIOp::create(b, states, two);
+  Value completionState = arith::AddIOp::create(
+      b, phase,
+      tti::createConstIntTensor(b, b.getLoc(), 2 * count, statesType));
+  Value completed =
+      arith::AndIOp::create(b, mask,
+                            arith::CmpIOp::create(b, arith::CmpIPredicate::eq,
+                                                  nextState, completionState));
+  Value completedInt = arith::ExtUIOp::create(b, statesType, completed);
+  Value nextPhase = arith::XOrIOp::create(b, phase, completedInt);
+  nextState = arith::SelectOp::create(b, completed, nextPhase, nextState);
+  Value updated = arith::SelectOp::create(b, mask, nextState, states);
+  tti::createStoreScratchMemory(b, b.getLoc(), statesPtr, updated, statesType);
+  return reduceAll<arith::OrIOp>(b, completed);
+}
+
+Value updateWaitingBits(ImplicitLocOpBuilder &b, Value waiting,
+                        RankedTensorType waitingType, Value thread, Value phase,
+                        Value mask, bool markWaiting) {
+  Value bitsPerThread =
+      arith::ConstantIntOp::create(b, WaitingBits::bitsPerThread, 32);
+  Value flagBit = arith::ConstantIntOp::create(b, WaitingBits::flagBit, 32);
+  Value phaseBit = arith::ConstantIntOp::create(b, WaitingBits::phaseBit, 32);
+  Value one = arith::ConstantIntOp::create(b, 1, 32);
+  Value minusOne = arith::ConstantIntOp::create(b, -1, 32);
+  Value baseTimesBits = arith::MulIOp::create(b, thread, bitsPerThread);
+  Value flagShift = arith::AddIOp::create(b, baseTimesBits, flagBit);
+  Value phaseShift = arith::AddIOp::create(b, baseTimesBits, phaseBit);
+  Value flagMask = arith::ShLIOp::create(b, one, flagShift);
+  Value phaseMask = arith::ShLIOp::create(b, one, phaseShift);
+  Value combinedMask = arith::OrIOp::create(b, flagMask, phaseMask);
+  Value clearMask = arith::XOrIOp::create(b, combinedMask, minusOne);
+  Value clearMaskTensor = triton::SplatOp::create(b, waitingType, clearMask);
+  Value cleared = arith::AndIOp::create(b, waiting, clearMaskTensor);
+
+  if (!markWaiting)
+    return arith::SelectOp::create(b, mask, cleared, waiting);
+
+  Value phaseI32 = arith::ExtUIOp::create(b, b.getI32Type(), phase);
+  Value phaseShifted = arith::ShLIOp::create(b, phaseI32, phaseShift);
+  Value setBits = arith::OrIOp::create(b, flagMask, phaseShifted);
+  Value setBitsTensor = triton::SplatOp::create(b, waitingType, setBits);
+  Value withWaiting = arith::OrIOp::create(b, cleared, setBitsTensor);
+  return arith::SelectOp::create(b, mask, withWaiting, waiting);
 }
 
 } // namespace
@@ -681,11 +742,11 @@ void FunctionBuilder::createRetireActiveThreadCall(ImplicitLocOpBuilder &b,
       });
 }
 
-void FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
-                                                      Value pred,
-                                                      Operation *insertPoint) {
+Value FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
+                                                       Value pred,
+                                                       Operation *insertPoint) {
   if (auxData.waiting.empty() || auxData.barrierStates.empty()) {
-    return;
+    return arith::ConstantIntOp::create(b, 1, 1);
   }
   if (!pred) {
     pred = arith::ConstantIntOp::create(b, 1, 1);
@@ -700,7 +761,7 @@ void FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
   Value barrierStatesVal = auxData.barrierStates.at(insertPoint).value;
   auto barrierStatesType =
       cast<RankedTensorType>(auxData.barrierStates.at(insertPoint).type);
-  Region *region = b.getInsertionPoint()->getParentRegion();
+  Region *region = b.getInsertionBlock()->getParent();
   auto waitingGlobalType = tti::getIntTensorType(
       region, waitingType.getShape(),
       waitingType.getElementType().getIntOrFloatBitWidth());
@@ -715,11 +776,9 @@ void FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
       activeMasksType.getElementType().getIntOrFloatBitWidth());
   SmallVector<Value> args = {pred, waitingVal, barrierStatesVal,
                              activeMasksVal};
-  AssertInfo assertInfo{
-      "Deadlock detected: all unfinished threads are waiting on mbarriers",
-      b.getI1Type()};
-  createCallToCachedFunction(
-      b, "check_all_active_waiting", args, assertInfo,
+  AssertInfo resultInfo{"", b.getI1Type()};
+  return createCallToCachedFunction(
+      b, "check_all_active_waiting", args, resultInfo,
       {waitingGlobalType, barrierStatesGlobalType, activeMasksGlobalType},
       [waitingGlobalType, barrierStatesGlobalType, activeMasksGlobalType,
        flagMask, phaseMask](ImplicitLocOpBuilder &fb, Block *entryBlock) {
@@ -786,7 +845,97 @@ void FunctionBuilder::createCheckAllActiveWaitingCall(ImplicitLocOpBuilder &b,
         Value ok = arith::XOrIOp::create(fb, deadlocked, vTrue);
         Value predicatedOk = arith::SelectOp::create(fb, pred, ok, vTrue);
         triton::ReturnOp::create(fb, predicatedOk);
-      });
+      },
+      /*emitAssert=*/false);
+}
+
+void FunctionBuilder::createClusterBarrierRendezvousCall(
+    ImplicitLocOpBuilder &b, int barrierIdx, int thread,
+    uint64_t threadPeersMask, bool partitionScoped, bool publishVisibility,
+    Operation *insertPoint) {
+  assert(!auxData.waiting.empty() && !auxData.barrierStates.empty() &&
+         !auxData.activeMasks.empty() &&
+         "cluster rendezvous requires barrier deadlock state");
+  Value barrierIdxVal = arith::ConstantIntOp::create(b, barrierIdx, 32);
+  Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
+  Value statesPtr = auxData.barrierStates.at(insertPoint).value;
+  auto statesType =
+      cast<RankedTensorType>(auxData.barrierStates.at(insertPoint).type);
+  Value waitingPtr = auxData.waiting.at(insertPoint).value;
+  auto waitingType =
+      cast<RankedTensorType>(auxData.waiting.at(insertPoint).type);
+  Value lock = auxData.lock.at(insertPoint).value;
+  Value vTrue = arith::ConstantIntOp::create(b, 1, 1);
+  int numCTAs = ttg::lookupNumCTAs(insertPoint);
+
+  auto getPhase = [&]() {
+    Value states =
+        tti::createLoadScratchMemory(b, b.getLoc(), statesPtr, statesType);
+    Value mask = createVirtualBarrierMask(b, barrierIdxVal, statesType);
+    Value phase = arith::AndIOp::create(
+        b, states, tti::createConstIntTensor(b, b.getLoc(), 1, statesType));
+    phase = arith::SelectOp::create(
+        b, mask, phase,
+        tti::createConstIntTensor(b, b.getLoc(), 0, statesType));
+    Value result = arith::TruncIOp::create(b, b.getI1Type(),
+                                           reduceAll<arith::OrIOp>(b, phase));
+    // Every warp must sample this phase before the elected warp can advance
+    // it; otherwise sibling warps can wait for opposite rendezvous epochs.
+    ttg::BarrierOp::create(b, b.getLoc(), ttg::AddrSpace::GlobalRead);
+    return result;
+  };
+  auto updateWaiting = [&](Value phase, Value pred, bool markWaiting) {
+    Value waiting =
+        tti::createLoadScratchMemory(b, b.getLoc(), waitingPtr, waitingType);
+    Value mask = arith::AndIOp::create(
+        b, createDimMask(b, barrierIdxVal, waitingType, /*dim=*/1),
+        createLeadCTAEffectMask(b, waitingType,
+                                arith::ConstantIntOp::create(b, 1, 32)));
+    Value predTensor = triton::SplatOp::create(
+        b, cast<RankedTensorType>(mask.getType()), pred);
+    mask = arith::AndIOp::create(b, mask, predTensor);
+    Value updated = updateWaitingBits(b, waiting, waitingType, threadVal, phase,
+                                      mask, markWaiting);
+    tti::createStoreScratchMemory(b, b.getLoc(), waitingPtr, updated,
+                                  waitingType);
+  };
+
+  tti::ExperimentalLockAcquireOp::create(b, lock, vTrue);
+  Value savedPhase = getPhase();
+  updateWaiting(savedPhase, vTrue, /*markWaiting=*/true);
+  Value completed =
+      arriveVirtualBarrier(b, statesPtr, statesType, barrierIdxVal, numCTAs);
+  if (publishVisibility) {
+    for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM})
+      createPublishClusterVisibilityCall(b, completed, thread, threadPeersMask,
+                                         partitionScoped, memType, insertPoint);
+    createPublishClusterProxyAccessesCall(b, completed, thread, partitionScoped,
+                                          insertPoint);
+  }
+  Value ok = createCheckAllActiveWaitingCall(b, vTrue, insertPoint);
+  tti::ExperimentalLockReleaseOp::create(b, lock, vTrue);
+  tti::createAssertInThread(b, ok, "Deadlock detected at a cluster barrier");
+
+  Block *entryBlock = b.getInsertionBlock();
+  Block *continueBlock = entryBlock->splitBlock(b.getInsertionPoint());
+  Block *phasePollBlock = new Block();
+  entryBlock->getParent()->getBlocks().insert(continueBlock->getIterator(),
+                                              phasePollBlock);
+  b.setInsertionPointToEnd(entryBlock);
+  cf::BranchOp::create(b, phasePollBlock);
+
+  b.setInsertionPointToStart(phasePollBlock);
+  tti::ExperimentalLockAcquireOp::create(b, lock, vTrue);
+  Value currentPhase = getPhase();
+  Value phaseChanged = arith::CmpIOp::create(b, arith::CmpIPredicate::ne,
+                                             currentPhase, savedPhase);
+  updateWaiting(savedPhase, phaseChanged, /*markWaiting=*/false);
+  ok = createCheckAllActiveWaitingCall(b, vTrue, insertPoint);
+  tti::ExperimentalLockReleaseOp::create(b, lock, vTrue);
+  tti::createAssertInThread(b, ok, "Deadlock detected at a cluster barrier");
+  cf::CondBranchOp::create(b, phaseChanged, continueBlock, ValueRange{},
+                           phasePollBlock, ValueRange{});
+  b.setInsertionPointToStart(continueBlock);
 }
 
 void FunctionBuilder::createVerifyBarrierCanInitCall(ImplicitLocOpBuilder &b,
@@ -1314,59 +1463,47 @@ void FunctionBuilder::createUpdateBarrierStateCall(
 }
 
 void FunctionBuilder::createSetWriteVisibilityCall(
-    ImplicitLocOpBuilder &b, Value buf, uint32_t length, uint64_t threadMask,
-    Value pred, MemType memType, Operation *insertPoint, Value effectCTAs) {
+    ImplicitLocOpBuilder &b, Value bufferMask, uint64_t threadMask, Value pred,
+    MemType memType, Operation *insertPoint, Value effectCTAs) {
 
-  if (auxData.buffers[(int)memType].empty() ||
-      auxData.writeVisibility[(int)memType].empty()) {
+  if (auxData.writeVisibility[(int)memType].empty()) {
     return;
   }
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   Value threadMaskVal = arith::ConstantIntOp::create(b, threadMask, 64);
-  Value buffersVal = auxData.buffers[(int)memType].at(insertPoint).value;
-  auto buffersType = cast<RankedTensorType>(
-      auxData.buffers[(int)memType].at(insertPoint).type);
   Value writeVisibilityVal =
       auxData.writeVisibility[(int)memType].at(insertPoint).value;
   auto writeVisibilityType = cast<RankedTensorType>(
       auxData.writeVisibility[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {bufOffset,     lengthVal,  pred,
-                             threadMaskVal, buffersVal, writeVisibilityVal,
-                             effectCTAs};
+  SmallVector<Value> args = {bufferMask, pred, threadMaskVal,
+                             writeVisibilityVal, effectCTAs};
   createCallToCachedFunction(
       b, "set_write_visibility", args,
-      /*assertInfo=*/std::nullopt,
-      {buffersType, writeVisibilityType, (uint64_t)memType},
+      /*assertInfo=*/std::nullopt, {writeVisibilityType, (uint64_t)memType},
       [writeVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value bufOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value threadMaskVal = entryBlock->getArgument(3);
-        Value buffers = entryBlock->getArgument(4);
-        Value writeVisibilityPtr = entryBlock->getArgument(5);
-        Value effectCTAs = entryBlock->getArgument(6);
+        Value bufferMask = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value threadMaskVal = entryBlock->getArgument(2);
+        Value writeVisibilityPtr = entryBlock->getArgument(3);
+        Value effectCTAs = entryBlock->getArgument(4);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
         Value writeVisibility = tti::createLoadScratchMemory(
             fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
-        Value descriptor = createBufferDescriptor(fb, bufOffset, lengthVal);
-        Value buffersEqBuf = createCmpIntTensorScalar(fb, buffers, descriptor);
-        buffersEqBuf =
-            convertAndBroadcast(fb, buffersEqBuf, {1}, writeVisibilityType);
+        bufferMask =
+            convertAndBroadcast(fb, bufferMask, {1}, writeVisibilityType);
         Value relationMask =
             createLeadCTAEffectMask(fb, writeVisibilityType, effectCTAs);
-        buffersEqBuf = arith::AndIOp::create(fb, buffersEqBuf, relationMask);
+        bufferMask = arith::AndIOp::create(fb, bufferMask, relationMask);
         auto elemType = cast<IntegerType>(writeVisibilityType.getElementType());
         Value threadMaskElem = adjustIntegerWidth(fb, threadMaskVal, elemType);
         Value threadMaskTensor =
             triton::SplatOp::create(fb, writeVisibilityType, threadMaskElem);
         Value newVisibility = arith::SelectOp::create(
-            fb, buffersEqBuf, threadMaskTensor, writeVisibility);
+            fb, bufferMask, threadMaskTensor, writeVisibility);
         createMaskedStoreScratchMemory(fb, fb.getLoc(), writeVisibilityPtr,
                                        newVisibility, writeVisibilityType,
                                        relationMask);
@@ -1377,50 +1514,38 @@ void FunctionBuilder::createSetWriteVisibilityCall(
 }
 
 void FunctionBuilder::createSetReadVisibilityCall(
-    ImplicitLocOpBuilder &b, Value buf, uint32_t length, uint64_t threadMask,
-    Value pred, MemType memType, Operation *insertPoint, Value effectCTAs) {
+    ImplicitLocOpBuilder &b, Value bufferMask, uint64_t threadMask, Value pred,
+    MemType memType, Operation *insertPoint, Value effectCTAs) {
 
-  if (auxData.buffers[(int)memType].empty() ||
-      auxData.readVisibility[(int)memType].empty()) {
+  if (auxData.readVisibility[(int)memType].empty()) {
     return;
   }
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   Value threadMaskVal = arith::ConstantIntOp::create(b, threadMask, 64);
-  Value buffersVal = auxData.buffers[(int)memType].at(insertPoint).value;
-  auto buffersType = cast<RankedTensorType>(
-      auxData.buffers[(int)memType].at(insertPoint).type);
   Value readVisibilityVal =
       auxData.readVisibility[(int)memType].at(insertPoint).value;
   auto readVisibilityType = cast<RankedTensorType>(
       auxData.readVisibility[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {bufOffset,     lengthVal,  pred,
-                             threadMaskVal, buffersVal, readVisibilityVal,
+  SmallVector<Value> args = {bufferMask, pred, threadMaskVal, readVisibilityVal,
                              effectCTAs};
   createCallToCachedFunction(
       b, "set_read_visibility", args,
-      /*assertInfo=*/std::nullopt,
-      {buffersType, readVisibilityType, (uint64_t)memType},
+      /*assertInfo=*/std::nullopt, {readVisibilityType, (uint64_t)memType},
       [readVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value bufOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value threadMaskVal = entryBlock->getArgument(3);
-        Value buffers = entryBlock->getArgument(4);
-        Value readVisibilityPtr = entryBlock->getArgument(5);
-        Value effectCTAs = entryBlock->getArgument(6);
+        Value bufferMask = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value threadMaskVal = entryBlock->getArgument(2);
+        Value readVisibilityPtr = entryBlock->getArgument(3);
+        Value effectCTAs = entryBlock->getArgument(4);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
         Value readVisibility = tti::createLoadScratchMemory(
             fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
-        Value descriptor = createBufferDescriptor(fb, bufOffset, lengthVal);
-        Value buffersEqBuf = createCmpIntTensorScalar(fb, buffers, descriptor);
-        buffersEqBuf =
-            convertAndBroadcast(fb, buffersEqBuf, {1}, readVisibilityType);
+        bufferMask =
+            convertAndBroadcast(fb, bufferMask, {1}, readVisibilityType);
         Value relationMask =
             createLeadCTAEffectMask(fb, readVisibilityType, effectCTAs);
         Value threadCTAMask =
@@ -1434,7 +1559,7 @@ void FunctionBuilder::createSetReadVisibilityCall(
             createDimIndices(fb, readVisibilityType, /*dim=*/4));
         threadCTAMask = arith::AndIOp::create(fb, threadCTAMask, sameCTA);
         relationMask = arith::AndIOp::create(fb, relationMask, threadCTAMask);
-        buffersEqBuf = arith::AndIOp::create(fb, buffersEqBuf, relationMask);
+        bufferMask = arith::AndIOp::create(fb, bufferMask, relationMask);
         auto elemType = cast<IntegerType>(readVisibilityType.getElementType());
         Value threadMaskElem = adjustIntegerWidth(fb, threadMaskVal, elemType);
         Value threadBit =
@@ -1445,7 +1570,7 @@ void FunctionBuilder::createSetReadVisibilityCall(
         Value readVisibilityOrThreadBit =
             arith::OrIOp::create(fb, readVisibility, threadBit);
         Value bufAndThread =
-            arith::AndIOp::create(fb, buffersEqBuf, threadColumnMask);
+            arith::AndIOp::create(fb, bufferMask, threadColumnMask);
         Value newVisibility = arith::SelectOp::create(
             fb, bufAndThread, readVisibilityOrThreadBit, readVisibility);
         createMaskedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
@@ -1457,180 +1582,76 @@ void FunctionBuilder::createSetReadVisibilityCall(
       });
 }
 
-void FunctionBuilder::createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
-                                                   Value buf, uint32_t length,
-                                                   Value pred, MemType memType,
-                                                   Operation *insertPoint,
-                                                   Value effectCTAs) {
-  if (auxData.buffers[(int)memType].empty() ||
-      auxData.writeTracking[(int)memType].empty()) {
-    return;
-  }
+static void createClearBufferStateCall(ImplicitLocOpBuilder &b,
+                                       StringRef functionName, Value bufferMask,
+                                       Value pred, ValueType state,
+                                       MemType memType, Value effectCTAs) {
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
-  Value buffersVal = auxData.buffers[(int)memType].at(insertPoint).value;
-  auto buffersType = cast<RankedTensorType>(
-      auxData.buffers[(int)memType].at(insertPoint).type);
-  Value writeTrackingVal =
-      auxData.writeTracking[(int)memType].at(insertPoint).value;
-  auto writeTrackingType = cast<RankedTensorType>(
-      auxData.writeTracking[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {bufOffset,  lengthVal,        pred,
-                             buffersVal, writeTrackingVal, effectCTAs};
+  auto stateType = cast<RankedTensorType>(state.type);
+  SmallVector<Value> args = {bufferMask, pred, state.value, effectCTAs};
   createCallToCachedFunction(
-      b, "clear_write_tracking", args,
-      /*assertInfo=*/std::nullopt,
-      {buffersType, writeTrackingType, (uint64_t)memType},
-      [writeTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value bufOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value buffers = entryBlock->getArgument(3);
-        Value writeTrackingPtr = entryBlock->getArgument(4);
-        Value effectCTAs = entryBlock->getArgument(5);
+      b, functionName.str(), args, /*assertInfo=*/std::nullopt,
+      {stateType, (uint64_t)memType},
+      [stateType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value bufferMask = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value statePtr = entryBlock->getArgument(2);
+        Value effectCTAs = entryBlock->getArgument(3);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
-        Value writeTracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), writeTrackingPtr, writeTrackingType);
-        Value descriptor = createBufferDescriptor(fb, bufOffset, lengthVal);
-        Value buffersEqBuf = createCmpIntTensorScalar(fb, buffers, descriptor);
-        buffersEqBuf =
-            convertAndBroadcast(fb, buffersEqBuf, {1}, writeTrackingType);
-        Value ctaMask =
-            createCTASetMask(fb, writeTrackingType, /*dim=*/0, effectCTAs);
-        buffersEqBuf = arith::AndIOp::create(fb, buffersEqBuf, ctaMask);
-        Value zero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, writeTrackingType);
-        Value newTracking =
-            arith::SelectOp::create(fb, buffersEqBuf, zero, writeTracking);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
-                                       newTracking, writeTrackingType, ctaMask);
+        Value state =
+            tti::createLoadScratchMemory(fb, fb.getLoc(), statePtr, stateType);
+        bufferMask = convertAndBroadcast(fb, bufferMask, {1}, stateType);
+        Value ctaMask = createCTASetMask(fb, stateType, /*dim=*/0, effectCTAs);
+        bufferMask = arith::AndIOp::create(fb, bufferMask, ctaMask);
+        Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, stateType);
+        Value updated = arith::SelectOp::create(fb, bufferMask, zero, state);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), statePtr, updated,
+                                       stateType, ctaMask);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
       });
+}
+
+void FunctionBuilder::createClearWriteTrackingCall(ImplicitLocOpBuilder &b,
+                                                   Value bufferMask, Value pred,
+                                                   MemType memType,
+                                                   Operation *insertPoint,
+                                                   Value effectCTAs) {
+  if (auxData.writeTracking[(int)memType].empty())
+    return;
+  createClearBufferStateCall(
+      b, "clear_write_tracking", bufferMask, pred,
+      auxData.writeTracking[(int)memType].at(insertPoint), memType, effectCTAs);
 }
 
 void FunctionBuilder::createClearReadVisibilityCall(ImplicitLocOpBuilder &b,
-                                                    Value buf, uint32_t length,
+                                                    Value bufferMask,
                                                     Value pred, MemType memType,
                                                     Operation *insertPoint,
                                                     Value effectCTAs) {
-  if (auxData.buffers[(int)memType].empty() ||
-      auxData.readVisibility[(int)memType].empty()) {
+  if (auxData.readVisibility[(int)memType].empty())
     return;
-  }
-  if (!pred)
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-  Value buffersVal = auxData.buffers[(int)memType].at(insertPoint).value;
-  auto buffersType = cast<RankedTensorType>(
-      auxData.buffers[(int)memType].at(insertPoint).type);
-  Value readVisibilityVal =
-      auxData.readVisibility[(int)memType].at(insertPoint).value;
-  auto readVisibilityType = cast<RankedTensorType>(
-      auxData.readVisibility[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {bufOffset,  lengthVal,         pred,
-                             buffersVal, readVisibilityVal, effectCTAs};
-  createCallToCachedFunction(
-      b, "clear_read_visibility", args,
-      /*assertInfo=*/std::nullopt,
-      {buffersType, readVisibilityType, (uint64_t)memType},
-      [readVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value bufOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value buffers = entryBlock->getArgument(3);
-        Value readVisibilityPtr = entryBlock->getArgument(4);
-        Value effectCTAs = entryBlock->getArgument(5);
-
-        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
-        fb.setInsertionPointToStart(ifBlock);
-
-        Value readVisibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
-        Value descriptor = createBufferDescriptor(fb, bufOffset, lengthVal);
-        Value buffersEqBuf = createCmpIntTensorScalar(fb, buffers, descriptor);
-        buffersEqBuf =
-            convertAndBroadcast(fb, buffersEqBuf, {1}, readVisibilityType);
-        Value ctaMask =
-            createCTASetMask(fb, readVisibilityType, /*dim=*/0, effectCTAs);
-        buffersEqBuf = arith::AndIOp::create(fb, buffersEqBuf, ctaMask);
-        Value zero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
-        Value newVisibility =
-            arith::SelectOp::create(fb, buffersEqBuf, zero, readVisibility);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
-                                       newVisibility, readVisibilityType,
-                                       ctaMask);
-
-        fb.setInsertionPointToEnd(thenBlock);
-        triton::ReturnOp::create(fb);
-      });
+  createClearBufferStateCall(
+      b, "clear_read_visibility", bufferMask, pred,
+      auxData.readVisibility[(int)memType].at(insertPoint), memType,
+      effectCTAs);
 }
 
 void FunctionBuilder::createClearReadTrackingCall(ImplicitLocOpBuilder &b,
-                                                  Value buf, uint32_t length,
-                                                  Value pred, MemType memType,
+                                                  Value bufferMask, Value pred,
+                                                  MemType memType,
                                                   Operation *insertPoint,
                                                   Value effectCTAs) {
-
-  if (auxData.buffers[(int)memType].empty() ||
-      auxData.readTracking[(int)memType].empty()) {
+  if (auxData.readTracking[(int)memType].empty())
     return;
-  }
-  if (!pred)
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-  Value buffersVal = auxData.buffers[(int)memType].at(insertPoint).value;
-  auto buffersType = cast<RankedTensorType>(
-      auxData.buffers[(int)memType].at(insertPoint).type);
-  Value readTrackingVal =
-      auxData.readTracking[(int)memType].at(insertPoint).value;
-  auto readTrackingType = cast<RankedTensorType>(
-      auxData.readTracking[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {bufOffset,  lengthVal,       pred,
-                             buffersVal, readTrackingVal, effectCTAs};
-  createCallToCachedFunction(
-      b, "clear_read_tracking", args,
-      /*assertInfo=*/std::nullopt,
-      {buffersType, readTrackingType, (uint64_t)memType},
-      [readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value bufOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value buffers = entryBlock->getArgument(3);
-        Value readTrackingPtr = entryBlock->getArgument(4);
-        Value effectCTAs = entryBlock->getArgument(5);
-
-        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
-        fb.setInsertionPointToStart(ifBlock);
-
-        Value readTracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), readTrackingPtr, readTrackingType);
-        Value descriptor = createBufferDescriptor(fb, bufOffset, lengthVal);
-        Value buffersEqBuf = createCmpIntTensorScalar(fb, buffers, descriptor);
-        buffersEqBuf =
-            convertAndBroadcast(fb, buffersEqBuf, {1}, readTrackingType);
-        Value ctaMask =
-            createCTASetMask(fb, readTrackingType, /*dim=*/0, effectCTAs);
-        buffersEqBuf = arith::AndIOp::create(fb, buffersEqBuf, ctaMask);
-        Value zero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, readTrackingType);
-        Value newTracking =
-            arith::SelectOp::create(fb, buffersEqBuf, zero, readTracking);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
-                                       newTracking, readTrackingType, ctaMask);
-
-        fb.setInsertionPointToEnd(thenBlock);
-        triton::ReturnOp::create(fb);
-      });
+  createClearBufferStateCall(b, "clear_read_tracking", bufferMask, pred,
+                             auxData.readTracking[(int)memType].at(insertPoint),
+                             memType, effectCTAs);
 }
 
 void FunctionBuilder::createTrackVisibleWritesCall(ImplicitLocOpBuilder &b,
@@ -1814,11 +1835,10 @@ void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
 }
 
 void FunctionBuilder::createTrackBarrierWriteForBufferCall(
-    ImplicitLocOpBuilder &b, Value mbar, Value buf, uint32_t length, Value pred,
+    ImplicitLocOpBuilder &b, Value mbar, Value bufferMask, Value pred,
     MemType memType, Operation *insertPoint, Value barrierCTAs,
     Value effectCTAs) {
-  if (auxData.barriers.empty() || auxData.buffers[(int)memType].empty() ||
-      auxData.writeTracking[(int)memType].empty()) {
+  if (auxData.barriers.empty() || auxData.writeTracking[(int)memType].empty()) {
     return;
   }
   if (!pred)
@@ -1826,9 +1846,6 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
   Value barriersVal = auxData.barriers.at(insertPoint).value;
   auto barriersType =
       cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
-  Value buffersVal = auxData.buffers[(int)memType].at(insertPoint).value;
-  auto buffersType = cast<RankedTensorType>(
-      auxData.buffers[(int)memType].at(insertPoint).type);
   Value writeTrackingVal =
       auxData.writeTracking[(int)memType].at(insertPoint).value;
   auto writeTrackingType = cast<RankedTensorType>(
@@ -1836,27 +1853,22 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
   uint32_t mbarLength = getMemDescLength(mbar);
   Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
   Value mbarLengthVal = arith::ConstantIntOp::create(b, mbarLength, 32);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value bufLengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset, mbarLengthVal,    pred,
-                             bufOffset,  bufLengthVal,     barriersVal,
-                             buffersVal, writeTrackingVal, barrierCTAs,
-                             effectCTAs};
+  SmallVector<Value> args = {mbarOffset,  mbarLengthVal, pred,
+                             bufferMask,  barriersVal,   writeTrackingVal,
+                             barrierCTAs, effectCTAs};
   createCallToCachedFunction(
       b, "track_barrier_write_for_buffer", args,
       /*assertInfo=*/std::nullopt,
-      {barriersType, buffersType, writeTrackingType, (uint64_t)memType},
+      {barriersType, writeTrackingType, (uint64_t)memType},
       [writeTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value mbarLengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
-        Value bufOffset = entryBlock->getArgument(3);
-        Value bufLengthVal = entryBlock->getArgument(4);
-        Value barriers = entryBlock->getArgument(5);
-        Value buffers = entryBlock->getArgument(6);
-        Value writeTrackingPtr = entryBlock->getArgument(7);
-        Value barrierCTAs = entryBlock->getArgument(8);
-        Value effectCTAs = entryBlock->getArgument(9);
+        Value bufferMask = entryBlock->getArgument(3);
+        Value barriers = entryBlock->getArgument(4);
+        Value writeTrackingPtr = entryBlock->getArgument(5);
+        Value barrierCTAs = entryBlock->getArgument(6);
+        Value effectCTAs = entryBlock->getArgument(7);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -1869,18 +1881,13 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
             createCmpIntTensorScalar(fb, barriers, barrierDescriptor);
         barriersEqBar =
             convertAndBroadcast(fb, barriersEqBar, {3}, writeTrackingType);
-        Value bufferDescriptor =
-            createBufferDescriptor(fb, bufOffset, bufLengthVal);
-        Value buffersEqBuf =
-            createCmpIntTensorScalar(fb, buffers, bufferDescriptor);
-        buffersEqBuf =
-            convertAndBroadcast(fb, buffersEqBuf, {1}, writeTrackingType);
+        bufferMask =
+            convertAndBroadcast(fb, bufferMask, {1}, writeTrackingType);
         Value bufferCTAMask =
             createCTASetMask(fb, writeTrackingType, /*dim=*/0, effectCTAs);
         Value barrierCTAMask =
             createCTASetMask(fb, writeTrackingType, /*dim=*/2, barrierCTAs);
-        Value trackMask =
-            arith::AndIOp::create(fb, barriersEqBar, buffersEqBuf);
+        Value trackMask = arith::AndIOp::create(fb, barriersEqBar, bufferMask);
         trackMask = arith::AndIOp::create(fb, trackMask, bufferCTAMask);
         trackMask = arith::AndIOp::create(fb, trackMask, barrierCTAMask);
         Value writeTrackingOne =
@@ -1896,126 +1903,82 @@ void FunctionBuilder::createTrackBarrierWriteForBufferCall(
       });
 }
 
-void FunctionBuilder::createClearBarrierWriteTrackingCall(
-    ImplicitLocOpBuilder &b, Value mbar, Value pred, MemType memType,
-    Operation *insertPoint) {
-  if (auxData.writeTracking[(int)memType].empty()) {
-    return;
-  }
-  assert(!auxData.barriers.empty() &&
-         "barrier descriptors must exist when clearing barrier write tracking");
-  if (!pred) {
+static void createClearBarrierTrackingCall(ImplicitLocOpBuilder &b,
+                                           StringRef functionName, Value mbar,
+                                           Value pred, ValueType barriers,
+                                           ValueType tracking,
+                                           std::optional<MemType> memType) {
+  if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
-  }
-  Value barriersVal = auxData.barriers.at(insertPoint).value;
-  auto barriersType =
-      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
-  Value writeTrackingVal =
-      auxData.writeTracking[(int)memType].at(insertPoint).value;
-  auto writeTrackingType = cast<RankedTensorType>(
-      auxData.writeTracking[(int)memType].at(insertPoint).type);
-  uint32_t length = getMemDescLength(mbar);
-  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset, lengthVal, pred, barriersVal,
-                             writeTrackingVal};
+  auto barriersType = cast<RankedTensorType>(barriers.type);
+  auto trackingType = cast<RankedTensorType>(tracking.type);
+  SmallVector<Value> args = {
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32), pred,
+      barriers.value, tracking.value};
+  ManglingArgs specializationArgs{barriersType, trackingType};
+  if (memType)
+    specializationArgs.append(static_cast<uint64_t>(*memType));
   createCallToCachedFunction(
-      b, "clear_barrier_write_tracking", args,
-      /*assertInfo=*/std::nullopt,
-      {barriersType, writeTrackingType, (uint64_t)memType},
-      [writeTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      b, functionName.str(), args, /*assertInfo=*/std::nullopt,
+      specializationArgs,
+      [trackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value mbarOffset = entryBlock->getArgument(0);
         Value lengthVal = entryBlock->getArgument(1);
         Value pred = entryBlock->getArgument(2);
         Value barriers = entryBlock->getArgument(3);
-        Value writeTrackingPtr = entryBlock->getArgument(4);
+        Value trackingPtr = entryBlock->getArgument(4);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
-        Value writeTracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), writeTrackingPtr, writeTrackingType);
+        Value tracking = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), trackingPtr, trackingType);
         Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
         Value barriersEqBar =
             createCmpIntTensorScalar(fb, barriers, descriptor);
         barriersEqBar =
-            convertAndBroadcast(fb, barriersEqBar, {3}, writeTrackingType);
-        Value barrierCTAMask = createCTASetMask(
-            fb, writeTrackingType, /*dim=*/2, createCurrentCTAMask(fb));
+            convertAndBroadcast(fb, barriersEqBar, {3}, trackingType);
+        Value barrierCTAMask = createCTASetMask(fb, trackingType, /*dim=*/2,
+                                                createCurrentCTAMask(fb));
         barriersEqBar =
             arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
         Value zero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, writeTrackingType);
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, trackingType);
         Value updated =
-            arith::SelectOp::create(fb, barriersEqBar, zero, writeTracking);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
-                                       updated, writeTrackingType,
-                                       barrierCTAMask);
+            arith::SelectOp::create(fb, barriersEqBar, zero, tracking);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
+                                       trackingType, barrierCTAMask);
 
         fb.setInsertionPointToEnd(thenBlock);
         triton::ReturnOp::create(fb);
       });
 }
 
+void FunctionBuilder::createClearBarrierWriteTrackingCall(
+    ImplicitLocOpBuilder &b, Value mbar, Value pred, MemType memType,
+    Operation *insertPoint) {
+  if (auxData.writeTracking[(int)memType].empty())
+    return;
+  assert(!auxData.barriers.empty() &&
+         "barrier descriptors must exist when clearing barrier write tracking");
+  createClearBarrierTrackingCall(
+      b, "clear_barrier_write_tracking", mbar, pred,
+      auxData.barriers.at(insertPoint),
+      auxData.writeTracking[(int)memType].at(insertPoint), memType);
+}
+
 void FunctionBuilder::createClearBarrierReadTrackingCall(
     ImplicitLocOpBuilder &b, Value mbar, Value pred, MemType memType,
     Operation *insertPoint) {
-  if (auxData.readTracking[(int)memType].empty()) {
+  if (auxData.readTracking[(int)memType].empty())
     return;
-  }
   assert(!auxData.barriers.empty() &&
          "barrier descriptors must exist when clearing barrier read tracking");
-  if (!pred) {
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-  }
-  Value barriersVal = auxData.barriers.at(insertPoint).value;
-  auto barriersType =
-      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
-  Value readTrackingVal =
-      auxData.readTracking[(int)memType].at(insertPoint).value;
-  auto readTrackingType = cast<RankedTensorType>(
-      auxData.readTracking[(int)memType].at(insertPoint).type);
-  uint32_t length = getMemDescLength(mbar);
-  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {mbarOffset, lengthVal, pred, barriersVal,
-                             readTrackingVal};
-  createCallToCachedFunction(
-      b, "clear_barrier_read_tracking", args,
-      /*assertInfo=*/std::nullopt,
-      {barriersType, readTrackingType, (uint64_t)memType},
-      [readTrackingType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value mbarOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value barriers = entryBlock->getArgument(3);
-        Value readTrackingPtr = entryBlock->getArgument(4);
-
-        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
-        fb.setInsertionPointToStart(ifBlock);
-
-        Value readTracking = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), readTrackingPtr, readTrackingType);
-        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
-        Value barriersEqBar =
-            createCmpIntTensorScalar(fb, barriers, descriptor);
-        barriersEqBar =
-            convertAndBroadcast(fb, barriersEqBar, {3}, readTrackingType);
-        Value barrierCTAMask = createCTASetMask(fb, readTrackingType, /*dim=*/2,
-                                                createCurrentCTAMask(fb));
-        barriersEqBar =
-            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
-        Value zero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, readTrackingType);
-        Value updated =
-            arith::SelectOp::create(fb, barriersEqBar, zero, readTracking);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), readTrackingPtr,
-                                       updated, readTrackingType,
-                                       barrierCTAMask);
-
-        fb.setInsertionPointToEnd(thenBlock);
-        triton::ReturnOp::create(fb);
-      });
+  createClearBarrierTrackingCall(
+      b, "clear_barrier_read_tracking", mbar, pred,
+      auxData.barriers.at(insertPoint),
+      auxData.readTracking[(int)memType].at(insertPoint), memType);
 }
 
 void FunctionBuilder::createTransferVisibleWritesCall(
@@ -2200,267 +2163,152 @@ void FunctionBuilder::createTransferVisibleReadsCall(
 }
 
 void FunctionBuilder::createVerifyWriteVisibilityCall(
-    ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
+    ImplicitLocOpBuilder &b, Value bufferMask, int thread,
     StringRef operandName, Value pred, MemType memType, Operation *insertPoint,
-    Value effectCTAs, bool allowNoWrite) {
-  if (auxData.buffers[(int)memType].empty() ||
-      auxData.writeVisibility[(int)memType].empty() ||
-      (auxData.hasNonTrivialAliasing[(int)memType] &&
-       auxData.aliasMatrices[(int)memType].empty())) {
+    Value effectCTAs) {
+  if (auxData.writeVisibility[(int)memType].empty()) {
     return;
   }
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
-  Value buffersVal = auxData.buffers[(int)memType].at(insertPoint).value;
-  auto buffersType = cast<RankedTensorType>(
-      auxData.buffers[(int)memType].at(insertPoint).type);
   Value writeVisibilityVal =
       auxData.writeVisibility[(int)memType].at(insertPoint).value;
   auto writeVisibilityType = cast<RankedTensorType>(
       auxData.writeVisibility[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
   std::string message = "Buffer being accessed has outstanding writes.";
   if (!operandName.empty())
     message += " Operand: " + operandName.str();
-  std::string uninitializedMessage = "Buffer being read before any write.";
-  if (!operandName.empty())
-    uninitializedMessage += " Operand: " + operandName.str();
   AssertInfo assertInfo{message, b.getI1Type()};
-  Type aliasMatrixTypeBase;
-  auto buildVerifyWriteBody = [&writeVisibilityType, &aliasMatrixTypeBase](
-                                  bool useAlias, bool allowNoWrite) {
-    return [=](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-      Value bufOffset = entryBlock->getArgument(0);
-      Value lengthVal = entryBlock->getArgument(1);
-      Value pred = entryBlock->getArgument(2);
-      Value threadVal = entryBlock->getArgument(3);
-      Value buffers = entryBlock->getArgument(4);
-      Value writeVisibilityPtr = entryBlock->getArgument(5);
-      Value effectCTAs = entryBlock->getArgument(6);
-      Value aliasMatrix = useAlias ? entryBlock->getArgument(7) : Value();
+  SmallVector<Value> args = {bufferMask, pred, threadVal, writeVisibilityVal,
+                             effectCTAs};
+  createCallToCachedFunction(
+      b, "verify_write_visibility", args, assertInfo,
+      {writeVisibilityType, (uint64_t)memType},
+      [writeVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value bufferMask = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value threadVal = entryBlock->getArgument(2);
+        Value writeVisibilityPtr = entryBlock->getArgument(3);
+        Value effectCTAs = entryBlock->getArgument(4);
 
-      Value writeVisibility = tti::createLoadScratchMemory(
-          fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
-      Value descriptor = createBufferDescriptor(fb, bufOffset, lengthVal);
-      Value buffersEqBuf = createCmpIntTensorScalar(fb, buffers, descriptor);
-      if (useAlias) {
-        buffersEqBuf =
-            expandAliases(fb, buffersEqBuf, aliasMatrix,
-                          cast<RankedTensorType>(aliasMatrixTypeBase));
-      }
-      buffersEqBuf =
-          convertAndBroadcast(fb, buffersEqBuf, {1}, writeVisibilityType);
-      Value relationMask =
-          createLeadCTAEffectMask(fb, writeVisibilityType, effectCTAs);
-      buffersEqBuf = arith::AndIOp::create(fb, buffersEqBuf, relationMask);
-      Value writeVisibilityZero =
-          tti::createConstIntTensor(fb, fb.getLoc(), 0, writeVisibilityType);
-      Value bufVisibility = arith::SelectOp::create(
-          fb, buffersEqBuf, writeVisibility, writeVisibilityZero);
-      Value noOneIsWriting = arith::CmpIOp::create(
-          fb, arith::CmpIPredicate::eq, bufVisibility, writeVisibilityZero);
-      Value threadI64 = arith::ExtUIOp::create(fb, fb.getI64Type(), threadVal);
-      Value threadMask =
-          triton::SplatOp::create(fb, writeVisibilityType, threadI64);
-      Value buffersEqBufExt =
-          arith::ExtUIOp::create(fb, writeVisibilityType, buffersEqBuf);
-      Value bufferThreadBit =
-          arith::ShLIOp::create(fb, buffersEqBufExt, threadMask);
-      Value bufferHasVisibility =
-          arith::AndIOp::create(fb, bufVisibility, bufferThreadBit);
-      bufferHasVisibility = arith::CmpIOp::create(
-          fb, arith::CmpIPredicate::eq, bufferHasVisibility, bufferThreadBit);
-      Value result;
-      if (!allowNoWrite) {
-        Value rowOne = tti::createConstIntTensor(
-            fb, fb.getLoc(), 1, cast<RankedTensorType>(buffersEqBuf.getType()));
-        Value rowInitialized =
-            arith::XOrIOp::create(fb, noOneIsWriting, rowOne);
-        Value initializedRows =
-            arith::AndIOp::create(fb, rowInitialized, buffersEqBuf);
-        // Alias rows are alternatives within a CTA, but every selected CTA must
-        // have at least one initialized row.
-        Value initializedCTAs =
-            reduce<arith::OrIOp>(fb, initializedRows, /*axis=*/1);
-        Value selectedCTAs = reduce<arith::OrIOp>(fb, buffersEqBuf, /*axis=*/1);
-        Value ctaOne = tti::createConstIntTensor(
-            fb, fb.getLoc(), 1, cast<RankedTensorType>(selectedCTAs.getType()));
-        Value unmatchedCTAs = arith::XOrIOp::create(fb, selectedCTAs, ctaOne);
-        Value initializedOrUnmatched =
-            arith::OrIOp::create(fb, initializedCTAs, unmatchedCTAs);
-        result = reduceAll<arith::AndIOp>(fb, initializedOrUnmatched);
-      } else {
+        Value writeVisibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
+        bufferMask =
+            convertAndBroadcast(fb, bufferMask, {1}, writeVisibilityType);
+        Value relationMask =
+            createLeadCTAEffectMask(fb, writeVisibilityType, effectCTAs);
+        bufferMask = arith::AndIOp::create(fb, bufferMask, relationMask);
+        Value writeVisibilityZero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, writeVisibilityType);
+        Value bufVisibility = arith::SelectOp::create(
+            fb, bufferMask, writeVisibility, writeVisibilityZero);
+        Value noOneIsWriting = arith::CmpIOp::create(
+            fb, arith::CmpIPredicate::eq, bufVisibility, writeVisibilityZero);
+        Value threadI64 =
+            arith::ExtUIOp::create(fb, fb.getI64Type(), threadVal);
+        Value threadMask =
+            triton::SplatOp::create(fb, writeVisibilityType, threadI64);
+        Value bufferMaskExt =
+            arith::ExtUIOp::create(fb, writeVisibilityType, bufferMask);
+        Value bufferThreadBit =
+            arith::ShLIOp::create(fb, bufferMaskExt, threadMask);
+        Value bufferHasVisibility =
+            arith::AndIOp::create(fb, bufVisibility, bufferThreadBit);
+        bufferHasVisibility = arith::CmpIOp::create(
+            fb, arith::CmpIPredicate::eq, bufferHasVisibility, bufferThreadBit);
         Value writeVisible =
             arith::OrIOp::create(fb, noOneIsWriting, bufferHasVisibility);
-        result = reduceAll<arith::AndIOp>(fb, writeVisible);
-      }
+        Value allWritesVisible = reduceAll<arith::AndIOp>(fb, writeVisible);
 
-      Value vTrue = arith::ConstantOp::create(
-          fb, result.getType(), fb.getIntegerAttr(fb.getI1Type(), 1));
-      Value predicatedWriteVisible =
-          arith::SelectOp::create(fb, pred, result, vTrue);
-      triton::ReturnOp::create(fb, predicatedWriteVisible);
-    };
-  };
-  if (auxData.hasNonTrivialAliasing[(int)memType]) {
-    Value aliasMatrixVal =
-        auxData.aliasMatrices[(int)memType].at(insertPoint).value;
-    aliasMatrixTypeBase =
-        auxData.aliasMatrices[(int)memType].at(insertPoint).type;
-    auto aliasMatrixType = cast<RankedTensorType>(aliasMatrixTypeBase);
-    SmallVector<Value> args = {bufOffset,  lengthVal,     pred,
-                               threadVal,  buffersVal,    writeVisibilityVal,
-                               effectCTAs, aliasMatrixVal};
-    if (!allowNoWrite) {
-      AssertInfo initializedAssertInfo{uninitializedMessage, b.getI1Type()};
-      createCallToCachedFunction(
-          b, "verify_write_initialized", args, initializedAssertInfo,
-          {buffersType, writeVisibilityType, aliasMatrixType,
-           (uint64_t)memType},
-          buildVerifyWriteBody(/*useAlias=*/true, /*allowNoWrite=*/false));
-    }
-    createCallToCachedFunction(
-        b, "verify_write_visibility", args, assertInfo,
-        {buffersType, writeVisibilityType, aliasMatrixType, (uint64_t)memType},
-        buildVerifyWriteBody(/*useAlias=*/true, /*allowNoWrite=*/true));
-  } else {
-    SmallVector<Value> args = {bufOffset, lengthVal,  pred,
-                               threadVal, buffersVal, writeVisibilityVal,
-                               effectCTAs};
-    if (!allowNoWrite) {
-      AssertInfo initializedAssertInfo{uninitializedMessage, b.getI1Type()};
-      createCallToCachedFunction(
-          b, "verify_write_initialized_noalias", args, initializedAssertInfo,
-          {buffersType, writeVisibilityType, (uint64_t)memType},
-          buildVerifyWriteBody(/*useAlias=*/false, /*allowNoWrite=*/false));
-    }
-    createCallToCachedFunction(
-        b, "verify_write_visibility_noalias", args, assertInfo,
-        {buffersType, writeVisibilityType, (uint64_t)memType},
-        buildVerifyWriteBody(/*useAlias=*/false, /*allowNoWrite=*/true));
-  }
+        Value vTrue =
+            arith::ConstantOp::create(fb, allWritesVisible.getType(),
+                                      fb.getIntegerAttr(fb.getI1Type(), 1));
+        Value predicatedWriteVisible =
+            arith::SelectOp::create(fb, pred, allWritesVisible, vTrue);
+        triton::ReturnOp::create(fb, predicatedWriteVisible);
+      });
 }
 
 void FunctionBuilder::createVerifyReadVisibilityCall(
-    ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
+    ImplicitLocOpBuilder &b, Value bufferMask, int thread,
     StringRef operandName, Value pred, MemType memType, Operation *insertPoint,
     Value effectCTAs) {
-  if (auxData.buffers[(int)memType].empty() ||
-      auxData.readVisibility[(int)memType].empty() ||
-      (auxData.hasNonTrivialAliasing[(int)memType] &&
-       auxData.aliasMatrices[(int)memType].empty())) {
+  if (auxData.readVisibility[(int)memType].empty()) {
     return;
   }
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
   Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
-  Value buffersVal = auxData.buffers[(int)memType].at(insertPoint).value;
-  auto buffersType = cast<RankedTensorType>(
-      auxData.buffers[(int)memType].at(insertPoint).type);
   Value readVisibilityVal =
       auxData.readVisibility[(int)memType].at(insertPoint).value;
   auto readVisibilityType = cast<RankedTensorType>(
       auxData.readVisibility[(int)memType].at(insertPoint).type);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
   std::string message = "Buffer being accessed has outstanding reads";
   if (!operandName.empty())
     message += ". Operand: " + operandName.str();
   AssertInfo assertInfo{message, b.getI1Type()};
-  Type aliasMatrixTypeBase;
-  auto buildVerifyReadBody = [&readVisibilityType,
-                              &aliasMatrixTypeBase](bool useAlias) {
-    return [=](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-      Value bufOffset = entryBlock->getArgument(0);
-      Value lengthVal = entryBlock->getArgument(1);
-      Value pred = entryBlock->getArgument(2);
-      Value threadVal = entryBlock->getArgument(3);
-      Value buffers = entryBlock->getArgument(4);
-      Value readVisibilityPtr = entryBlock->getArgument(5);
-      Value effectCTAs = entryBlock->getArgument(6);
-      Value aliasMatrix = useAlias ? entryBlock->getArgument(7) : Value();
+  SmallVector<Value> args = {bufferMask, pred, threadVal, readVisibilityVal,
+                             effectCTAs};
+  createCallToCachedFunction(
+      b, "verify_read_visibility", args, assertInfo,
+      {readVisibilityType, (uint64_t)memType},
+      [readVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value bufferMask = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value threadVal = entryBlock->getArgument(2);
+        Value readVisibilityPtr = entryBlock->getArgument(3);
+        Value effectCTAs = entryBlock->getArgument(4);
 
-      Value readVisibility = tti::createLoadScratchMemory(
-          fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
-      Value descriptor = createBufferDescriptor(fb, bufOffset, lengthVal);
-      Value buffersEqBuf = createCmpIntTensorScalar(fb, buffers, descriptor);
-      if (useAlias) {
-        buffersEqBuf =
-            expandAliases(fb, buffersEqBuf, aliasMatrix,
-                          cast<RankedTensorType>(aliasMatrixTypeBase));
-      }
-      buffersEqBuf =
-          convertAndBroadcast(fb, buffersEqBuf, {1}, readVisibilityType);
-      Value bufferCTAMask =
-          createCTASetMask(fb, readVisibilityType, /*dim=*/0, effectCTAs);
-      Value relationMask =
-          createLeadCTAEffectMask(fb, readVisibilityType, effectCTAs);
-      buffersEqBuf = arith::AndIOp::create(fb, buffersEqBuf, bufferCTAMask);
-      Value readVisibilityZero =
-          tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
-      Value bufVisibility = arith::SelectOp::create(
-          fb, buffersEqBuf, readVisibility, readVisibilityZero);
-      Value totalVisibility = reduce<arith::OrIOp>(fb, bufVisibility, {2, 3});
-      Value threadColumnMask =
-          createDimMask(fb, threadVal, readVisibilityType, /*dim=*/3);
-      Value accessorVisibility = arith::SelectOp::create(
-          fb, relationMask, bufVisibility, readVisibilityZero);
-      accessorVisibility = arith::SelectOp::create(
-          fb, threadColumnMask, accessorVisibility, readVisibilityZero);
-      accessorVisibility = reduce<arith::OrIOp>(fb, accessorVisibility, {3});
-      auto accessorVisibilityType =
-          cast<RankedTensorType>(accessorVisibility.getType());
-      totalVisibility = convertAndBroadcast(fb, totalVisibility, {0, 1, 3},
-                                            accessorVisibilityType);
-      Value threadAndTotalVisibility =
-          arith::AndIOp::create(fb, accessorVisibility, totalVisibility);
-      Value hasVisibility =
-          arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
-                                threadAndTotalVisibility, totalVisibility);
-      Value selectedAccessors =
-          arith::AndIOp::create(fb, buffersEqBuf, relationMask);
-      selectedAccessors = reduce<arith::OrIOp>(fb, selectedAccessors, {3, 4});
-      selectedAccessors = convertAndBroadcast(fb, selectedAccessors, {0, 1, 2},
+        Value readVisibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
+        bufferMask =
+            convertAndBroadcast(fb, bufferMask, {1}, readVisibilityType);
+        Value bufferCTAMask =
+            createCTASetMask(fb, readVisibilityType, /*dim=*/0, effectCTAs);
+        Value relationMask =
+            createLeadCTAEffectMask(fb, readVisibilityType, effectCTAs);
+        bufferMask = arith::AndIOp::create(fb, bufferMask, bufferCTAMask);
+        Value readVisibilityZero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
+        Value bufVisibility = arith::SelectOp::create(
+            fb, bufferMask, readVisibility, readVisibilityZero);
+        Value totalVisibility = reduce<arith::OrIOp>(fb, bufVisibility, {2, 3});
+        Value threadColumnMask =
+            createDimMask(fb, threadVal, readVisibilityType, /*dim=*/3);
+        Value accessorVisibility = arith::SelectOp::create(
+            fb, relationMask, bufVisibility, readVisibilityZero);
+        accessorVisibility = arith::SelectOp::create(
+            fb, threadColumnMask, accessorVisibility, readVisibilityZero);
+        accessorVisibility = reduce<arith::OrIOp>(fb, accessorVisibility, {3});
+        auto accessorVisibilityType =
+            cast<RankedTensorType>(accessorVisibility.getType());
+        totalVisibility = convertAndBroadcast(fb, totalVisibility, {0, 1, 3},
                                               accessorVisibilityType);
-      Value one = tti::createConstIntTensor(
-          fb, fb.getLoc(), 1,
-          cast<RankedTensorType>(selectedAccessors.getType()));
-      Value unmatchedAccessors =
-          arith::XOrIOp::create(fb, selectedAccessors, one);
-      hasVisibility =
-          arith::OrIOp::create(fb, hasVisibility, unmatchedAccessors);
-      hasVisibility = reduceAll<arith::AndIOp>(fb, hasVisibility);
-      Value vTrue = arith::ConstantOp::create(
-          fb, hasVisibility.getType(), fb.getIntegerAttr(fb.getI1Type(), 1));
-      Value predicatedHasVisibility =
-          arith::SelectOp::create(fb, pred, hasVisibility, vTrue);
-      triton::ReturnOp::create(fb, predicatedHasVisibility);
-    };
-  };
-  if (auxData.hasNonTrivialAliasing[(int)memType]) {
-    Value aliasMatrixVal =
-        auxData.aliasMatrices[(int)memType].at(insertPoint).value;
-    aliasMatrixTypeBase =
-        auxData.aliasMatrices[(int)memType].at(insertPoint).type;
-    auto aliasMatrixType = cast<RankedTensorType>(aliasMatrixTypeBase);
-    SmallVector<Value> args = {bufOffset,  lengthVal,     pred,
-                               threadVal,  buffersVal,    readVisibilityVal,
-                               effectCTAs, aliasMatrixVal};
-    createCallToCachedFunction(
-        b, "verify_read_visibility", args, assertInfo,
-        {buffersType, readVisibilityType, aliasMatrixType, (uint64_t)memType},
-        buildVerifyReadBody(/*useAlias=*/true));
-  } else {
-    SmallVector<Value> args = {bufOffset, lengthVal,  pred,
-                               threadVal, buffersVal, readVisibilityVal,
-                               effectCTAs};
-    createCallToCachedFunction(
-        b, "verify_read_visibility_noalias", args, assertInfo,
-        {buffersType, readVisibilityType, (uint64_t)memType},
-        buildVerifyReadBody(/*useAlias=*/false));
-  }
+        Value threadAndTotalVisibility =
+            arith::AndIOp::create(fb, accessorVisibility, totalVisibility);
+        Value hasVisibility =
+            arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
+                                  threadAndTotalVisibility, totalVisibility);
+        Value selectedAccessors =
+            arith::AndIOp::create(fb, bufferMask, relationMask);
+        selectedAccessors = reduce<arith::OrIOp>(fb, selectedAccessors, {3, 4});
+        selectedAccessors = convertAndBroadcast(
+            fb, selectedAccessors, {0, 1, 2}, accessorVisibilityType);
+        Value one = tti::createConstIntTensor(
+            fb, fb.getLoc(), 1,
+            cast<RankedTensorType>(selectedAccessors.getType()));
+        Value unmatchedAccessors =
+            arith::XOrIOp::create(fb, selectedAccessors, one);
+        hasVisibility =
+            arith::OrIOp::create(fb, hasVisibility, unmatchedAccessors);
+        hasVisibility = reduceAll<arith::AndIOp>(fb, hasVisibility);
+        Value vTrue = arith::ConstantOp::create(
+            fb, hasVisibility.getType(), fb.getIntegerAttr(fb.getI1Type(), 1));
+        Value predicatedHasVisibility =
+            arith::SelectOp::create(fb, pred, hasVisibility, vTrue);
+        triton::ReturnOp::create(fb, predicatedHasVisibility);
+      });
 }
 
 void FunctionBuilder::createCopyWriteVisibilityCall(ImplicitLocOpBuilder &b,
@@ -2603,8 +2451,8 @@ void FunctionBuilder::createCopyReadVisibilityCall(ImplicitLocOpBuilder &b,
 }
 
 void FunctionBuilder::createPublishClusterVisibilityCall(
-    ImplicitLocOpBuilder &b, Value pred, MemType memType,
-    Operation *insertPoint) {
+    ImplicitLocOpBuilder &b, Value pred, int thread, uint64_t threadPeersMask,
+    bool partitionScoped, MemType memType, Operation *insertPoint) {
   if (auxData.writeVisibility[(int)memType].empty() ||
       auxData.readVisibility[(int)memType].empty()) {
     return;
@@ -2615,17 +2463,24 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
   auto readVis = auxData.readVisibility[(int)memType].at(insertPoint);
   auto writeVisibilityType = cast<RankedTensorType>(writeVis.type);
   auto readVisibilityType = cast<RankedTensorType>(readVis.type);
-  SmallVector<Value> args = {pred, writeVis.value, readVis.value};
+  Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
+  Value threadPeersMaskVal =
+      arith::ConstantIntOp::create(b, threadPeersMask, 64);
+  SmallVector<Value> args = {pred, threadVal, threadPeersMaskVal,
+                             writeVis.value, readVis.value};
   createCallToCachedFunction(
       b, "publish_cluster_visibility", args,
       /*assertInfo=*/std::nullopt,
-      {writeVisibilityType, readVisibilityType, (uint64_t)memType},
+      {writeVisibilityType, readVisibilityType, (uint64_t)memType,
+       (uint64_t)partitionScoped},
       [writeVisibilityType, readVisibilityType,
-       numBaseThreads = auxData.threadLayout.numBaseThreads](
-          ImplicitLocOpBuilder &fb, Block *entryBlock) {
+       numBaseThreads = auxData.threadLayout.numBaseThreads,
+       partitionScoped](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value pred = entryBlock->getArgument(0);
-        Value writeVisibilityPtr = entryBlock->getArgument(1);
-        Value readVisibilityPtr = entryBlock->getArgument(2);
+        Value threadVal = entryBlock->getArgument(1);
+        Value threadPeersMaskVal = entryBlock->getArgument(2);
+        Value writeVisibilityPtr = entryBlock->getArgument(3);
+        Value readVisibilityPtr = entryBlock->getArgument(4);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
@@ -2635,19 +2490,41 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
         Value readVisibility = tti::createLoadScratchMemory(
             fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
 
-        // Cluster barriers publish generic-proxy synchronous work. Base-thread
-        // visibility distinguishes those facts from async-only TMA/TC/CLC
-        // effects, which are published by their own completion path.
-        uint64_t baseThreadMask = (1ULL << numBaseThreads) - 1;
-        Value baseMask = tti::createConstIntTensor(
-            fb, fb.getLoc(), baseThreadMask, writeVisibilityType);
         Value zeroWrites =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, writeVisibilityType);
-        Value hasBaseWrite = arith::CmpIOp::create(
-            fb, arith::CmpIPredicate::ne,
-            arith::AndIOp::create(fb, writeVisibility, baseMask), zeroWrites);
-        Value syncWrites = arith::SelectOp::create(fb, hasBaseWrite,
-                                                   writeVisibility, zeroWrites);
+        Value syncWrites;
+        if (partitionScoped) {
+          auto elemType =
+              cast<IntegerType>(writeVisibilityType.getElementType());
+          Value threadI64 =
+              arith::ExtUIOp::create(fb, fb.getI64Type(), threadVal);
+          Value threadBitScalar = arith::ShLIOp::create(
+              fb, arith::ConstantIntOp::create(fb, 1, 64), threadI64);
+          Value threadBit = triton::SplatOp::create(
+              fb, writeVisibilityType,
+              adjustIntegerWidth(fb, threadBitScalar, elemType));
+          Value peersMask = triton::SplatOp::create(
+              fb, writeVisibilityType,
+              adjustIntegerWidth(fb, threadPeersMaskVal, elemType));
+          Value hasThreadWrite = arith::CmpIOp::create(
+              fb, arith::CmpIPredicate::ne,
+              arith::AndIOp::create(fb, writeVisibility, threadBit),
+              zeroWrites);
+          syncWrites = arith::SelectOp::create(fb, hasThreadWrite, peersMask,
+                                               zeroWrites);
+        } else {
+          // Top-level cluster barriers represent all synchronous threads. A
+          // base-thread bit distinguishes synchronous work from async-only
+          // TMA/TC/CLC effects, which use their own completion path.
+          uint64_t baseThreadMask = (1ULL << numBaseThreads) - 1;
+          Value baseMask = tti::createConstIntTensor(
+              fb, fb.getLoc(), baseThreadMask, writeVisibilityType);
+          Value hasBaseWrite = arith::CmpIOp::create(
+              fb, arith::CmpIPredicate::ne,
+              arith::AndIOp::create(fb, writeVisibility, baseMask), zeroWrites);
+          syncWrites = arith::SelectOp::create(fb, hasBaseWrite,
+                                               writeVisibility, zeroWrites);
+        }
         Value writesForCluster = reduce<arith::OrIOp>(fb, syncWrites, {2});
         writesForCluster = convertAndBroadcast(fb, writesForCluster, {0, 1},
                                                writeVisibilityType);
@@ -2657,18 +2534,35 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
                                       newWriteVisibility, writeVisibilityType,
                                       /*currentCTAOnly=*/false);
 
-        Value readBaseMask = tti::createConstIntTensor(
-            fb, fb.getLoc(), baseThreadMask, readVisibilityType);
         Value zeroReads =
             tti::createConstIntTensor(fb, fb.getLoc(), 0, readVisibilityType);
-        Value hasBaseRead = arith::CmpIOp::create(
-            fb, arith::CmpIPredicate::ne,
-            arith::AndIOp::create(fb, readVisibility, readBaseMask), zeroReads);
-        Value syncReads =
-            arith::SelectOp::create(fb, hasBaseRead, readVisibility, zeroReads);
-        Value readsForCluster = reduce<arith::OrIOp>(fb, syncReads, {2, 3, 4});
-        readsForCluster = convertAndBroadcast(fb, readsForCluster, {0, 1},
-                                              readVisibilityType);
+        Value readsForCluster;
+        if (partitionScoped) {
+          Value sourceColumn = arith::SelectOp::create(
+              fb, createDimMask(fb, threadVal, readVisibilityType, /*dim=*/3),
+              readVisibility, zeroReads);
+          Value readsForThread =
+              reduce<arith::OrIOp>(fb, sourceColumn, {2, 3, 4});
+          readsForThread = convertAndBroadcast(fb, readsForThread, {0, 1},
+                                               readVisibilityType);
+          Value peerColumns = createThreadColumnMask(
+              fb, threadPeersMaskVal, readVisibilityType, /*columnDim=*/3);
+          readsForCluster = arith::SelectOp::create(fb, peerColumns,
+                                                    readsForThread, zeroReads);
+        } else {
+          uint64_t baseThreadMask = (1ULL << numBaseThreads) - 1;
+          Value readBaseMask = tti::createConstIntTensor(
+              fb, fb.getLoc(), baseThreadMask, readVisibilityType);
+          Value hasBaseRead = arith::CmpIOp::create(
+              fb, arith::CmpIPredicate::ne,
+              arith::AndIOp::create(fb, readVisibility, readBaseMask),
+              zeroReads);
+          Value syncReads = arith::SelectOp::create(fb, hasBaseRead,
+                                                    readVisibility, zeroReads);
+          readsForCluster = reduce<arith::OrIOp>(fb, syncReads, {2, 3, 4});
+          readsForCluster = convertAndBroadcast(fb, readsForCluster, {0, 1},
+                                                readVisibilityType);
+        }
         Value newReadVisibility =
             arith::OrIOp::create(fb, readVisibility, readsForCluster);
         tti::createStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
@@ -2680,51 +2574,588 @@ void FunctionBuilder::createPublishClusterVisibilityCall(
       });
 }
 
+void FunctionBuilder::createSetProxyAccessCall(ImplicitLocOpBuilder &b,
+                                               Value bufferMask, int thread,
+                                               Value pred,
+                                               Operation *insertPoint,
+                                               Value effectCTAs) {
+  if (auxData.proxyAccessVisibility.empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  bool hasTracking = !auxData.proxyAccessTracking.empty();
+  RankedTensorType trackingType;
+  SmallVector<Value> args = {bufferMask, pred,
+                             arith::ConstantIntOp::create(b, thread, 32),
+                             visibility.value, effectCTAs};
+  ManglingArgs specializationArgs{visibilityType, (uint64_t)hasTracking};
+  if (hasTracking) {
+    ValueType tracking = auxData.proxyAccessTracking.at(insertPoint);
+    trackingType = cast<RankedTensorType>(tracking.type);
+    args.push_back(tracking.value);
+    specializationArgs.append(trackingType);
+  }
+
+  createCallToCachedFunction(
+      b, "set_proxy_access", args, /*assertInfo=*/std::nullopt,
+      specializationArgs,
+      [visibilityType, trackingType, hasTracking](ImplicitLocOpBuilder &fb,
+                                                  Block *entryBlock) {
+        Value bufferMask = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value threadVal = entryBlock->getArgument(2);
+        Value visibilityPtr = entryBlock->getArgument(3);
+        Value effectCTAs = entryBlock->getArgument(4);
+        Value trackingPtr = hasTracking ? entryBlock->getArgument(5) : Value();
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        Value bufferVector = bufferMask;
+        bufferMask = convertAndBroadcast(fb, bufferMask, {1}, visibilityType);
+        Value bufferCTAMask =
+            createCTASetMask(fb, visibilityType, /*dim=*/0, effectCTAs);
+        Value currentCTA = createCurrentCTAMask(fb);
+        Value originCTAMask =
+            createCTASetMask(fb, visibilityType, /*dim=*/4, currentCTA);
+        Value selectedBuffers =
+            arith::AndIOp::create(fb, bufferMask, bufferCTAMask);
+        selectedBuffers =
+            arith::AndIOp::create(fb, selectedBuffers, originCTAMask);
+
+        Value threadI64 =
+            arith::ExtUIOp::create(fb, fb.getI64Type(), threadVal);
+        Value one64 = arith::ConstantIntOp::create(fb, 1, 64);
+        Value seenBitScalar = arith::ShLIOp::create(fb, one64, threadI64);
+        Value fencedShift =
+            arith::AddIOp::create(fb, threadI64,
+                                  arith::ConstantIntOp::create(
+                                      fb, ProxyAccessBits::fencedOffset, 64));
+        Value fencedBitScalar = arith::ShLIOp::create(fb, one64, fencedShift);
+        Value allOnes = arith::ConstantIntOp::create(fb, -1, 64);
+        Value clearFencedScalar =
+            arith::XOrIOp::create(fb, fencedBitScalar, allOnes);
+        Value clearFenced =
+            triton::SplatOp::create(fb, visibilityType, clearFencedScalar);
+        Value clearedVisibility =
+            arith::AndIOp::create(fb, visibility, clearFenced);
+        clearedVisibility = arith::SelectOp::create(
+            fb, selectedBuffers, clearedVisibility, visibility);
+
+        Value consumerCTAMask =
+            createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA);
+        Value threadColumnMask =
+            createDimMask(fb, threadVal, visibilityType, /*dim=*/3);
+        Value ownerMask =
+            arith::AndIOp::create(fb, selectedBuffers, consumerCTAMask);
+        ownerMask = arith::AndIOp::create(fb, ownerMask, threadColumnMask);
+        Value seenBit =
+            triton::SplatOp::create(fb, visibilityType, seenBitScalar);
+        Value withSeen = arith::OrIOp::create(fb, clearedVisibility, seenBit);
+        Value updatedVisibility =
+            arith::SelectOp::create(fb, ownerMask, withSeen, clearedVisibility);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr,
+                                       updatedVisibility, visibilityType,
+                                       selectedBuffers);
+
+        // A new generic access supersedes fence coverage for an older access
+        // from the same source. Clear that source's fence bit in outstanding
+        // barrier snapshots as well, so an old publication cannot mask it.
+        if (hasTracking) {
+          Value tracking = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), trackingPtr, trackingType);
+          Value trackingBuffers =
+              convertAndBroadcast(fb, bufferVector, {1}, trackingType);
+          Value trackingBufferCTAMask =
+              createCTASetMask(fb, trackingType, /*dim=*/0, effectCTAs);
+          Value trackingOriginCTAMask =
+              createCTASetMask(fb, trackingType, /*dim=*/4, currentCTA);
+          Value trackingMask =
+              arith::AndIOp::create(fb, trackingBuffers, trackingBufferCTAMask);
+          trackingMask =
+              arith::AndIOp::create(fb, trackingMask, trackingOriginCTAMask);
+          Value trackingClear =
+              triton::SplatOp::create(fb, trackingType, clearFencedScalar);
+          Value clearedTracking =
+              arith::AndIOp::create(fb, tracking, trackingClear);
+          Value updatedTracking = arith::SelectOp::create(
+              fb, trackingMask, clearedTracking, tracking);
+          createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr,
+                                         updatedTracking, trackingType,
+                                         trackingMask);
+        }
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createFenceProxyAccessesCall(ImplicitLocOpBuilder &b,
+                                                   int thread, bool cluster,
+                                                   Value pred,
+                                                   Operation *insertPoint) {
+  if (auxData.proxyAccessVisibility.empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  SmallVector<Value> args = {arith::ConstantIntOp::create(b, thread, 32), pred,
+                             visibility.value};
+  createCallToCachedFunction(
+      b, "fence_proxy_accesses", args, /*assertInfo=*/std::nullopt,
+      {visibilityType, (uint64_t)cluster},
+      [visibilityType, cluster](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value threadVal = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value visibilityPtr = entryBlock->getArgument(2);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        Value currentCTA = createCurrentCTAMask(fb);
+        Value mask =
+            createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA);
+        mask = arith::AndIOp::create(
+            fb, mask, createDimMask(fb, threadVal, visibilityType, /*dim=*/3));
+        if (!cluster) {
+          mask = arith::AndIOp::create(
+              fb, mask,
+              createCTASetMask(fb, visibilityType, /*dim=*/0, currentCTA));
+        }
+        Value seenMask = tti::createConstIntTensor(
+            fb, fb.getLoc(), ProxyAccessBits::seenMask, visibilityType);
+        Value seen = arith::AndIOp::create(fb, visibility, seenMask);
+        Value shift = tti::createConstIntTensor(
+            fb, fb.getLoc(), ProxyAccessBits::fencedOffset, visibilityType);
+        Value fenced = arith::ShLIOp::create(fb, seen, shift);
+        Value covered = arith::OrIOp::create(fb, visibility, fenced);
+        Value updated = arith::SelectOp::create(fb, mask, covered, visibility);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr, updated,
+                                       visibilityType, mask);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createTrackProxyAccessesCall(ImplicitLocOpBuilder &b,
+                                                   Value mbar, int thread,
+                                                   Value pred,
+                                                   Operation *insertPoint,
+                                                   Value barrierCTAs) {
+  createTrackProxyAccessesCallImpl(b, mbar, thread, pred, insertPoint,
+                                   barrierCTAs, Value(), Value());
+}
+
+void FunctionBuilder::createTrackProxyAccessesForBufferCall(
+    ImplicitLocOpBuilder &b, Value mbar, Value bufferMask, int thread,
+    Value pred, Operation *insertPoint, Value barrierCTAs, Value effectCTAs) {
+  createTrackProxyAccessesCallImpl(b, mbar, thread, pred, insertPoint,
+                                   barrierCTAs, bufferMask, effectCTAs);
+}
+
+void FunctionBuilder::createTrackProxyAccessesCallImpl(
+    ImplicitLocOpBuilder &b, Value mbar, int thread, Value pred,
+    Operation *insertPoint, Value barrierCTAs, Value bufferMask,
+    Value effectCTAs) {
+  bool filterByBuffer = static_cast<bool>(bufferMask);
+  if (auxData.barriers.empty() || auxData.proxyAccessVisibility.empty() ||
+      auxData.proxyAccessTracking.empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType barriers = auxData.barriers.at(insertPoint);
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  ValueType tracking = auxData.proxyAccessTracking.at(insertPoint);
+  auto barriersType = cast<RankedTensorType>(barriers.type);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  auto trackingType = cast<RankedTensorType>(tracking.type);
+  SmallVector<Value> args = {
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
+      pred,
+      arith::ConstantIntOp::create(b, thread, 32),
+      barriers.value,
+      visibility.value,
+      tracking.value,
+      barrierCTAs};
+  ManglingArgs specializationArgs{barriersType, visibilityType, trackingType};
+  if (filterByBuffer) {
+    args.append({bufferMask, effectCTAs});
+  }
+  createCallToCachedFunction(
+      b,
+      filterByBuffer ? "track_proxy_accesses_for_buffer"
+                     : "track_proxy_accesses",
+      args, /*assertInfo=*/std::nullopt, specializationArgs,
+      [visibilityType, trackingType, filterByBuffer](ImplicitLocOpBuilder &fb,
+                                                     Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value lengthVal = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value threadVal = entryBlock->getArgument(3);
+        Value barriers = entryBlock->getArgument(4);
+        Value visibilityPtr = entryBlock->getArgument(5);
+        Value trackingPtr = entryBlock->getArgument(6);
+        Value barrierCTAs = entryBlock->getArgument(7);
+        Value completeMask =
+            filterByBuffer ? entryBlock->getArgument(8) : Value();
+        Value effectCTAs =
+            filterByBuffer ? entryBlock->getArgument(9) : Value();
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        Value tracking = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), trackingPtr, trackingType);
+        Value currentCTA = createCurrentCTAMask(fb);
+        Value sourceMask =
+            createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA);
+        sourceMask = arith::AndIOp::create(
+            fb, sourceMask,
+            createDimMask(fb, threadVal, visibilityType, /*dim=*/3));
+        Value containedBuffers;
+        if (filterByBuffer) {
+          containedBuffers = completeMask;
+          Value visibilityBuffers =
+              convertAndBroadcast(fb, containedBuffers, {1}, visibilityType);
+          sourceMask = arith::AndIOp::create(fb, sourceMask, visibilityBuffers);
+          sourceMask = arith::AndIOp::create(
+              fb, sourceMask,
+              createCTASetMask(fb, visibilityType, /*dim=*/0, effectCTAs));
+        }
+        Value zeroVisibility =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
+        Value source =
+            arith::SelectOp::create(fb, sourceMask, visibility, zeroVisibility);
+        source = reduce<arith::OrIOp>(fb, source, {2, 3});
+        source = convertAndBroadcast(fb, source, {0, 1, 4}, trackingType);
+
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
+        Value barriersEqBar =
+            createCmpIntTensorScalar(fb, barriers, descriptor);
+        barriersEqBar =
+            convertAndBroadcast(fb, barriersEqBar, {3}, trackingType);
+        Value barrierCTAMask =
+            createCTASetMask(fb, trackingType, /*dim=*/2, barrierCTAs);
+        Value trackMask =
+            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
+        if (filterByBuffer) {
+          Value trackingBuffers =
+              convertAndBroadcast(fb, containedBuffers, {1}, trackingType);
+          trackMask = arith::AndIOp::create(fb, trackMask, trackingBuffers);
+          trackMask = arith::AndIOp::create(
+              fb, trackMask,
+              createCTASetMask(fb, trackingType, /*dim=*/0, effectCTAs));
+        }
+        Value withSource = arith::OrIOp::create(fb, tracking, source);
+        Value updated =
+            arith::SelectOp::create(fb, trackMask, withSource, tracking);
+        Value storeMask = filterByBuffer ? trackMask : barrierCTAMask;
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), trackingPtr, updated,
+                                       trackingType, storeMask);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createTransferProxyAccessesCall(ImplicitLocOpBuilder &b,
+                                                      Value mbar, int thread,
+                                                      Value pred,
+                                                      Operation *insertPoint) {
+  if (auxData.barriers.empty() || auxData.proxyAccessVisibility.empty() ||
+      auxData.proxyAccessTracking.empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType barriers = auxData.barriers.at(insertPoint);
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  ValueType tracking = auxData.proxyAccessTracking.at(insertPoint);
+  auto barriersType = cast<RankedTensorType>(barriers.type);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  auto trackingType = cast<RankedTensorType>(tracking.type);
+  SmallVector<Value> args = {
+      tti::ExperimentalMemDescToI32Op::create(b, mbar),
+      arith::ConstantIntOp::create(b, getMemDescLength(mbar), 32),
+      pred,
+      arith::ConstantIntOp::create(b, thread, 32),
+      barriers.value,
+      visibility.value,
+      tracking.value};
+  createCallToCachedFunction(
+      b, "transfer_proxy_accesses", args, /*assertInfo=*/std::nullopt,
+      {barriersType, visibilityType, trackingType},
+      [visibilityType, trackingType](ImplicitLocOpBuilder &fb,
+                                     Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value lengthVal = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value threadVal = entryBlock->getArgument(3);
+        Value barriers = entryBlock->getArgument(4);
+        Value visibilityPtr = entryBlock->getArgument(5);
+        Value trackingPtr = entryBlock->getArgument(6);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        Value tracking = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), trackingPtr, trackingType);
+        Value descriptor = createBufferDescriptor(fb, mbarOffset, lengthVal);
+        Value barriersEqBar =
+            createCmpIntTensorScalar(fb, barriers, descriptor);
+        barriersEqBar =
+            convertAndBroadcast(fb, barriersEqBar, {3}, trackingType);
+        Value currentCTA = createCurrentCTAMask(fb);
+        Value barrierCTAMask =
+            createCTASetMask(fb, trackingType, /*dim=*/2, currentCTA);
+        Value selected =
+            arith::AndIOp::create(fb, barriersEqBar, barrierCTAMask);
+        Value zeroTracking =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, trackingType);
+        Value frontier =
+            arith::SelectOp::create(fb, selected, tracking, zeroTracking);
+        frontier = reduce<arith::OrIOp>(fb, frontier, {2, 3});
+        frontier = convertAndBroadcast(fb, frontier, {0, 1, 4}, visibilityType);
+
+        Value targetMask =
+            createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA);
+        targetMask = arith::AndIOp::create(
+            fb, targetMask,
+            createDimMask(fb, threadVal, visibilityType, /*dim=*/3));
+        Value withFrontier = arith::OrIOp::create(fb, visibility, frontier);
+        Value updated =
+            arith::SelectOp::create(fb, targetMask, withFrontier, visibility);
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr, updated,
+                                       visibilityType, targetMask);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createClearBarrierProxyAccessTrackingCall(
+    ImplicitLocOpBuilder &b, Value mbar, Value pred, Operation *insertPoint) {
+  if (auxData.proxyAccessTracking.empty())
+    return;
+  assert(!auxData.barriers.empty() &&
+         "barrier descriptors must exist when clearing proxy tracking");
+  createClearBarrierTrackingCall(b, "clear_barrier_proxy_tracking", mbar, pred,
+                                 auxData.barriers.at(insertPoint),
+                                 auxData.proxyAccessTracking.at(insertPoint),
+                                 std::nullopt);
+}
+
+void FunctionBuilder::createVerifyProxyAccessCall(ImplicitLocOpBuilder &b,
+                                                  Value bufferMask, int thread,
+                                                  StringRef operandName,
+                                                  Value pred,
+                                                  Operation *insertPoint,
+                                                  Value effectCTAs) {
+  if (auxData.proxyAccessVisibility.empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
+  std::string message =
+      "Async shared-memory access is missing fence_async_shared";
+  if (!operandName.empty())
+    message += ". Operand: " + operandName.str();
+  AssertInfo assertInfo{message, b.getI1Type()};
+  SmallVector<Value> args = {bufferMask, pred, threadVal, visibility.value,
+                             effectCTAs};
+  createCallToCachedFunction(
+      b, "verify_proxy_access", args, assertInfo, {visibilityType},
+      [visibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value checkMask = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value threadVal = entryBlock->getArgument(2);
+        Value visibilityPtr = entryBlock->getArgument(3);
+        Value effectCTAs = entryBlock->getArgument(4);
+
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        checkMask = convertAndBroadcast(fb, checkMask, {1}, visibilityType);
+        Value mask = arith::AndIOp::create(
+            fb, checkMask,
+            createCTASetMask(fb, visibilityType, /*dim=*/0, effectCTAs));
+        Value currentCTA = createCurrentCTAMask(fb);
+        mask = arith::AndIOp::create(
+            fb, mask,
+            createCTASetMask(fb, visibilityType, /*dim=*/2, currentCTA));
+        mask = arith::AndIOp::create(
+            fb, mask, createDimMask(fb, threadVal, visibilityType, /*dim=*/3));
+        Value zero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
+        Value selected = arith::SelectOp::create(fb, mask, visibility, zero);
+        Value seenMask = tti::createConstIntTensor(
+            fb, fb.getLoc(), ProxyAccessBits::seenMask, visibilityType);
+        Value seen = arith::AndIOp::create(fb, selected, seenMask);
+        Value shift = tti::createConstIntTensor(
+            fb, fb.getLoc(), ProxyAccessBits::fencedOffset, visibilityType);
+        Value fenced = arith::ShRUIOp::create(fb, selected, shift);
+        fenced = arith::AndIOp::create(fb, fenced, seenMask);
+        Value notFenced = arith::XOrIOp::create(fb, fenced, seenMask);
+        Value missing = arith::AndIOp::create(fb, seen, notFenced);
+        Value missingAny = reduceAll<arith::OrIOp>(fb, missing);
+        Value zeroScalar = arith::ConstantOp::create(
+            fb, missingAny.getType(),
+            fb.getIntegerAttr(missingAny.getType(), 0));
+        Value ok = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
+                                         missingAny, zeroScalar);
+        Value vTrue = arith::ConstantOp::create(
+            fb, ok.getType(), fb.getIntegerAttr(fb.getI1Type(), 1));
+        Value predicatedOk = arith::SelectOp::create(fb, pred, ok, vTrue);
+        triton::ReturnOp::create(fb, predicatedOk);
+      });
+}
+
+void FunctionBuilder::createCopyProxyAccessesCall(ImplicitLocOpBuilder &b,
+                                                  int sourceThread,
+                                                  uint64_t destMask, Value pred,
+                                                  Operation *insertPoint) {
+  if (auxData.proxyAccessVisibility.empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  SmallVector<Value> args = {arith::ConstantIntOp::create(b, sourceThread, 32),
+                             pred, visibility.value};
+  createCallToCachedFunction(
+      b, "copy_proxy_accesses", args, /*assertInfo=*/std::nullopt,
+      {visibilityType, destMask},
+      [visibilityType, destMask](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value sourceThread = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value visibilityPtr = entryBlock->getArgument(2);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        Value zero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
+        Value destColumns = createThreadColumnMask(
+            fb, arith::ConstantIntOp::create(fb, destMask, 64), visibilityType,
+            /*columnDim=*/3);
+        Value cleared =
+            arith::SelectOp::create(fb, destColumns, zero, visibility);
+        Value sourceColumn = arith::SelectOp::create(
+            fb, createDimMask(fb, sourceThread, visibilityType, /*dim=*/3),
+            visibility, zero);
+        sourceColumn = reduce<arith::OrIOp>(fb, sourceColumn, {3});
+        sourceColumn =
+            convertAndBroadcast(fb, sourceColumn, {0, 1, 2, 4}, visibilityType);
+        Value replicated =
+            arith::SelectOp::create(fb, destColumns, sourceColumn, zero);
+        Value updated = arith::OrIOp::create(fb, cleared, replicated);
+        Value currentCTAMask = createCTASetMask(fb, visibilityType, /*dim=*/2,
+                                                createCurrentCTAMask(fb));
+        createMaskedStoreScratchMemory(fb, fb.getLoc(), visibilityPtr, updated,
+                                       visibilityType, currentCTAMask);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
+void FunctionBuilder::createPublishClusterProxyAccessesCall(
+    ImplicitLocOpBuilder &b, Value pred, int thread, bool partitionScoped,
+    Operation *insertPoint) {
+  if (auxData.proxyAccessVisibility.empty())
+    return;
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  ValueType visibility = auxData.proxyAccessVisibility.at(insertPoint);
+  auto visibilityType = cast<RankedTensorType>(visibility.type);
+  SmallVector<Value> args = {pred, arith::ConstantIntOp::create(b, thread, 32),
+                             visibility.value};
+  createCallToCachedFunction(
+      b, "publish_cluster_proxy_accesses", args,
+      /*assertInfo=*/std::nullopt, {visibilityType, (uint64_t)partitionScoped},
+      [visibilityType, partitionScoped](ImplicitLocOpBuilder &fb,
+                                        Block *entryBlock) {
+        Value pred = entryBlock->getArgument(0);
+        Value threadVal = entryBlock->getArgument(1);
+        Value visibilityPtr = entryBlock->getArgument(2);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+        Value visibility = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), visibilityPtr, visibilityType);
+        Value source = visibility;
+        Value zero =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, visibilityType);
+        if (partitionScoped) {
+          Value sourceColumn =
+              createDimMask(fb, threadVal, visibilityType, /*dim=*/3);
+          source = arith::SelectOp::create(fb, sourceColumn, visibility, zero);
+        }
+        Value frontier = reduce<arith::OrIOp>(fb, source, {2, 3});
+        frontier = convertAndBroadcast(fb, frontier, {0, 1, 4}, visibilityType);
+        if (partitionScoped) {
+          Value destinationColumn =
+              createDimMask(fb, threadVal, visibilityType, /*dim=*/3);
+          frontier =
+              arith::SelectOp::create(fb, destinationColumn, frontier, zero);
+        }
+        Value updated = arith::OrIOp::create(fb, visibility, frontier);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), visibilityPtr, updated,
+                                      visibilityType,
+                                      /*currentCTAOnly=*/false);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
 void FunctionBuilder::createStageAccessForCommitCall(
-    ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread, Value pred,
-    MemType memType, CommitKind::Kind commitKind, Operation *insertPoint) {
-  if (auxData.buffers[(int)memType].empty() ||
-      auxData.commits[commitKind].empty()) {
+    ImplicitLocOpBuilder &b, Value bufferMask, int thread, Value pred,
+    MemType /*memType*/, CommitKind::Kind commitKind, Operation *insertPoint) {
+  if (auxData.commits[commitKind].empty()) {
     return;
   }
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
-  ValueType buffers = auxData.buffers[(int)memType].at(insertPoint);
   ValueType outstandingCommits = auxData.commits[commitKind].at(insertPoint);
-  auto buffersType = cast<RankedTensorType>(buffers.type);
   auto commitsType = cast<RankedTensorType>(outstandingCommits.type);
   Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
-  SmallVector<Value> args = {bufOffset,     lengthVal,
-                             pred,          threadVal,
-                             buffers.value, outstandingCommits.value};
+  SmallVector<Value> args = {bufferMask, pred, threadVal,
+                             outstandingCommits.value};
   createCallToCachedFunction(
       b, "stage_access_for_commit", args,
-      /*assertInfo=*/std::nullopt, {buffersType, commitsType},
+      /*assertInfo=*/std::nullopt, {commitsType},
       [commitsType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-        Value bufOffset = entryBlock->getArgument(0);
-        Value lengthVal = entryBlock->getArgument(1);
-        Value pred = entryBlock->getArgument(2);
-        Value threadVal = entryBlock->getArgument(3);
-        Value buffers = entryBlock->getArgument(4);
-        Value outstandingCommitsPtr = entryBlock->getArgument(5);
+        Value bufferMask = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value threadVal = entryBlock->getArgument(2);
+        Value outstandingCommitsPtr = entryBlock->getArgument(3);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
         Value commits = tti::createLoadScratchMemory(
             fb, fb.getLoc(), outstandingCommitsPtr, commitsType);
-        Value descriptor = createBufferDescriptor(fb, bufOffset, lengthVal);
-        Value buffersEqBuf = createCmpIntTensorScalar(fb, buffers, descriptor);
-        buffersEqBuf = convertAndBroadcast(fb, buffersEqBuf, {1}, commitsType);
+        bufferMask = convertAndBroadcast(fb, bufferMask, {1}, commitsType);
         Value ctaMask = createCTASetMask(fb, commitsType, /*dim=*/0,
                                          createCurrentCTAMask(fb));
-        buffersEqBuf = arith::AndIOp::create(fb, buffersEqBuf, ctaMask);
+        bufferMask = arith::AndIOp::create(fb, bufferMask, ctaMask);
         Value threadColumnMask =
             createDimMask(fb, threadVal, commitsType, /*dim=*/2);
         Value bufAndThread =
-            arith::AndIOp::create(fb, buffersEqBuf, threadColumnMask);
+            arith::AndIOp::create(fb, bufferMask, threadColumnMask);
         Value minusOne =
             tti::createConstIntTensor(fb, fb.getLoc(), -1, commitsType, true);
         Value updated =
@@ -2799,250 +3230,99 @@ void FunctionBuilder::createClearOutstandingCommitsTransferWritesCall(
     ImplicitLocOpBuilder &b, int thread, uint64_t transferThreadMask,
     int outstandingNum, Value pred, CommitKind::Kind commitKind,
     MemType memType, Operation *insertPoint) {
-  if (auxData.commits[commitKind].empty() ||
-      auxData.writeVisibility[(int)memType].empty()) {
-    return;
-  }
-  if (!pred)
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-  ValueType outstandingCommits = auxData.commits[commitKind].at(insertPoint);
-  ValueType writeVisibility =
-      auxData.writeVisibility[(int)memType].at(insertPoint);
-  auto commitsType = cast<RankedTensorType>(outstandingCommits.type);
-  auto writeVisibilityType = cast<RankedTensorType>(writeVisibility.type);
-  Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
-  Value transferMaskVal =
-      arith::ConstantIntOp::create(b, transferThreadMask, 64);
-  Value outstandingNumVal = arith::ConstantIntOp::create(b, outstandingNum, 32);
-  SmallVector<Value> args = {
-      threadVal, transferMaskVal,          outstandingNumVal,
-      pred,      outstandingCommits.value, writeVisibility.value};
-  createCallToCachedFunction(
-      b, "clear_outstanding_commits_transfer_writes", args,
-      /*assertInfo=*/std::nullopt, {commitsType, writeVisibilityType},
-      [commitsType, writeVisibilityType](ImplicitLocOpBuilder &fb,
-                                         Block *entryBlock) {
-        Value threadVal = entryBlock->getArgument(0);
-        Value transferMaskVal = entryBlock->getArgument(1);
-        Value outstandingNumVal = entryBlock->getArgument(2);
-        Value pred = entryBlock->getArgument(3);
-        Value outstandingCommitsPtr = entryBlock->getArgument(4);
-        Value writeVisibilityPtr = entryBlock->getArgument(5);
-
-        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
-        fb.setInsertionPointToStart(ifBlock);
-
-        Value outstandingCommits = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), outstandingCommitsPtr, commitsType);
-        Value writeVisibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
-
-        auto elemIntType = cast<IntegerType>(commitsType.getElementType());
-        Value outstandingNumElem =
-            adjustIntegerWidth(fb, outstandingNumVal, elemIntType);
-        Value threadColumnMask =
-            createDimMask(fb, threadVal, commitsType, /*dim=*/2);
-        Value commitCTAMask = createCTASetMask(fb, commitsType, /*dim=*/0,
-                                               createCurrentCTAMask(fb));
-        threadColumnMask =
-            arith::AndIOp::create(fb, threadColumnMask, commitCTAMask);
-        auto outstandingCommitsGtOutstandingNum =
-            createCmpIntTensorScalar(fb, outstandingCommits, outstandingNumElem,
-                                     arith::CmpIPredicate::sgt);
-        outstandingCommitsGtOutstandingNum = arith::AndIOp::create(
-            fb, outstandingCommitsGtOutstandingNum, threadColumnMask);
-
-        Value rowMask =
-            reduceLastDim<arith::OrIOp>(fb, outstandingCommitsGtOutstandingNum);
-        rowMask = convertAndBroadcast(fb, rowMask, {0, 1}, writeVisibilityType);
-        Value transferMaskElem = adjustIntegerWidth(
-            fb, transferMaskVal,
-            cast<IntegerType>(writeVisibilityType.getElementType()));
-        Value transferMaskTensor =
-            triton::SplatOp::create(fb, writeVisibilityType, transferMaskElem);
-        Value writeVisibilityOrThreadBit =
-            arith::OrIOp::create(fb, writeVisibility, transferMaskTensor);
-        Value writeVisibilityUpdated = arith::SelectOp::create(
-            fb, rowMask, writeVisibilityOrThreadBit, writeVisibility);
-        Value writeMask = createCTASetMask(fb, writeVisibilityType, /*dim=*/2,
-                                           createCurrentCTAMask(fb));
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), writeVisibilityPtr,
-                                       writeVisibilityUpdated,
-                                       writeVisibilityType, writeMask);
-
-        Value outstandingCommitsZero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, commitsType);
-        outstandingCommits =
-            arith::SelectOp::create(fb, outstandingCommitsGtOutstandingNum,
-                                    outstandingCommitsZero, outstandingCommits);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), outstandingCommitsPtr,
-                                       outstandingCommits, commitsType,
-                                       commitCTAMask);
-
-        fb.setInsertionPointToEnd(thenBlock);
-        triton::ReturnOp::create(fb);
-      });
+  createClearOutstandingCommitsTransferCall(
+      b, thread, transferThreadMask, outstandingNum, pred, commitKind, memType,
+      insertPoint, /*transferWrites=*/true, /*transferReads=*/false);
 }
 
 void FunctionBuilder::createClearOutstandingCommitsTransferReadsCall(
     ImplicitLocOpBuilder &b, int thread, uint64_t transferThreadMask,
     int outstandingNum, Value pred, CommitKind::Kind commitKind,
     MemType memType, Operation *insertPoint) {
-  if (auxData.commits[commitKind].empty() ||
-      auxData.readVisibility[(int)memType].empty()) {
-    return;
-  }
-  ValueType outstandingCommits = auxData.commits[commitKind].at(insertPoint);
-  ValueType readVisibility =
-      auxData.readVisibility[(int)memType].at(insertPoint);
-  if (!pred)
-    pred = arith::ConstantIntOp::create(b, 1, 1);
-  auto commitsType = cast<RankedTensorType>(outstandingCommits.type);
-  auto readVisibilityType = cast<RankedTensorType>(readVisibility.type);
-  Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
-  Value transferMaskVal =
-      arith::ConstantIntOp::create(b, transferThreadMask, 64);
-  Value outstandingNumVal = arith::ConstantIntOp::create(b, outstandingNum, 32);
-  SmallVector<Value> args = {
-      threadVal, transferMaskVal,          outstandingNumVal,
-      pred,      outstandingCommits.value, readVisibility.value};
-  createCallToCachedFunction(
-      b, "clear_outstanding_commits_transfer_reads", args,
-      /*assertInfo=*/std::nullopt, {commitsType, readVisibilityType},
-      [commitsType, readVisibilityType](ImplicitLocOpBuilder &fb,
-                                        Block *entryBlock) {
-        Value threadVal = entryBlock->getArgument(0);
-        Value transferMaskVal = entryBlock->getArgument(1);
-        Value outstandingNumVal = entryBlock->getArgument(2);
-        Value pred = entryBlock->getArgument(3);
-        Value outstandingCommitsPtr = entryBlock->getArgument(4);
-        Value readVisibilityPtr = entryBlock->getArgument(5);
-
-        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
-        fb.setInsertionPointToStart(ifBlock);
-
-        Value outstandingCommits = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), outstandingCommitsPtr, commitsType);
-        Value readVisibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
-
-        auto elemIntType = cast<IntegerType>(commitsType.getElementType());
-        Value outstandingNumElem =
-            adjustIntegerWidth(fb, outstandingNumVal, elemIntType);
-        Value threadColumnMask =
-            createDimMask(fb, threadVal, commitsType, /*dim=*/2);
-        Value commitCTAMask = createCTASetMask(fb, commitsType, /*dim=*/0,
-                                               createCurrentCTAMask(fb));
-        threadColumnMask =
-            arith::AndIOp::create(fb, threadColumnMask, commitCTAMask);
-        auto outstandingCommitsGtOutstandingNum =
-            createCmpIntTensorScalar(fb, outstandingCommits, outstandingNumElem,
-                                     arith::CmpIPredicate::sgt);
-        outstandingCommitsGtOutstandingNum = arith::AndIOp::create(
-            fb, outstandingCommitsGtOutstandingNum, threadColumnMask);
-
-        Value rowMask =
-            reduceLastDim<arith::OrIOp>(fb, outstandingCommitsGtOutstandingNum);
-        rowMask = convertAndBroadcast(fb, rowMask, {0, 1}, readVisibilityType);
-        Value cMask = createCTASetMask(fb, readVisibilityType, /*dim=*/4,
-                                       createCurrentCTAMask(fb));
-        rowMask = arith::AndIOp::create(fb, rowMask, cMask);
-        Value transferMaskElem = adjustIntegerWidth(
-            fb, transferMaskVal,
-            cast<IntegerType>(readVisibilityType.getElementType()));
-        Value transferMaskTensor =
-            triton::SplatOp::create(fb, readVisibilityType, transferMaskElem);
-        Value readVisibilityOrThreadBit =
-            arith::OrIOp::create(fb, readVisibility, transferMaskTensor);
-        Value readVisibilityUpdated = arith::SelectOp::create(
-            fb, rowMask, readVisibilityOrThreadBit, readVisibility);
-        Value readMask = createCTASetMask(fb, readVisibilityType, /*dim=*/2,
-                                          createCurrentCTAMask(fb));
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
-                                       readVisibilityUpdated,
-                                       readVisibilityType, readMask);
-
-        Value outstandingCommitsZero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, commitsType);
-        outstandingCommits =
-            arith::SelectOp::create(fb, outstandingCommitsGtOutstandingNum,
-                                    outstandingCommitsZero, outstandingCommits);
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), outstandingCommitsPtr,
-                                       outstandingCommits, commitsType,
-                                       commitCTAMask);
-
-        fb.setInsertionPointToEnd(thenBlock);
-        triton::ReturnOp::create(fb);
-      });
+  createClearOutstandingCommitsTransferCall(
+      b, thread, transferThreadMask, outstandingNum, pred, commitKind, memType,
+      insertPoint, /*transferWrites=*/false, /*transferReads=*/true);
 }
 
 void FunctionBuilder::createClearOutstandingCommitsTransferBothCall(
     ImplicitLocOpBuilder &b, int thread, uint64_t transferThreadMask,
     int outstandingNum, Value pred, CommitKind::Kind commitKind,
     MemType memType, Operation *insertPoint) {
+  createClearOutstandingCommitsTransferCall(
+      b, thread, transferThreadMask, outstandingNum, pred, commitKind, memType,
+      insertPoint, /*transferWrites=*/true, /*transferReads=*/true);
+}
+
+void FunctionBuilder::createClearOutstandingCommitsTransferCall(
+    ImplicitLocOpBuilder &b, int thread, uint64_t transferThreadMask,
+    int outstandingNum, Value pred, CommitKind::Kind commitKind,
+    MemType memType, Operation *insertPoint, bool transferWrites,
+    bool transferReads) {
   if (auxData.commits[commitKind].empty())
     return;
-  bool hasWriteVis = !auxData.writeVisibility[(int)memType].empty();
-  bool hasReadVis = !auxData.readVisibility[(int)memType].empty();
-  if (!hasWriteVis && !hasReadVis)
+  bool hasWriteVisibility =
+      transferWrites && !auxData.writeVisibility[(int)memType].empty();
+  bool hasReadVisibility =
+      transferReads && !auxData.readVisibility[(int)memType].empty();
+  if (!hasWriteVisibility && !hasReadVisibility)
     return;
-  if (!hasWriteVis) {
-    createClearOutstandingCommitsTransferReadsCall(
-        b, thread, transferThreadMask, outstandingNum, pred, commitKind,
-        memType, insertPoint);
-    return;
-  }
-  if (!hasReadVis) {
-    createClearOutstandingCommitsTransferWritesCall(
-        b, thread, transferThreadMask, outstandingNum, pred, commitKind,
-        memType, insertPoint);
-    return;
-  }
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
+
   ValueType outstandingCommits = auxData.commits[commitKind].at(insertPoint);
-  ValueType writeVisibility =
-      auxData.writeVisibility[(int)memType].at(insertPoint);
-  ValueType readVisibility =
-      auxData.readVisibility[(int)memType].at(insertPoint);
   auto commitsType = cast<RankedTensorType>(outstandingCommits.type);
-  auto writeVisibilityType = cast<RankedTensorType>(writeVisibility.type);
-  auto readVisibilityType = cast<RankedTensorType>(readVisibility.type);
   Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
   Value transferMaskVal =
       arith::ConstantIntOp::create(b, transferThreadMask, 64);
   Value outstandingNumVal = arith::ConstantIntOp::create(b, outstandingNum, 32);
-  SmallVector<Value> args = {threadVal,
-                             transferMaskVal,
-                             outstandingNumVal,
-                             pred,
-                             outstandingCommits.value,
-                             writeVisibility.value,
-                             readVisibility.value};
+  SmallVector<Value> args = {threadVal, transferMaskVal, outstandingNumVal,
+                             pred, outstandingCommits.value};
+  ManglingArgs specializationArgs{commitsType};
+
+  RankedTensorType writeVisibilityType;
+  if (hasWriteVisibility) {
+    ValueType writeVisibility =
+        auxData.writeVisibility[(int)memType].at(insertPoint);
+    writeVisibilityType = cast<RankedTensorType>(writeVisibility.type);
+    args.push_back(writeVisibility.value);
+    specializationArgs.append(Type(writeVisibilityType));
+  }
+  RankedTensorType readVisibilityType;
+  if (hasReadVisibility) {
+    ValueType readVisibility =
+        auxData.readVisibility[(int)memType].at(insertPoint);
+    readVisibilityType = cast<RankedTensorType>(readVisibility.type);
+    args.push_back(readVisibility.value);
+    specializationArgs.append(Type(readVisibilityType));
+  }
+
+  std::string functionName = hasWriteVisibility && hasReadVisibility
+                                 ? "clear_outstanding_commits_transfer_both"
+                             : hasWriteVisibility
+                                 ? "clear_outstanding_commits_transfer_writes"
+                                 : "clear_outstanding_commits_transfer_reads";
   createCallToCachedFunction(
-      b, "clear_outstanding_commits_transfer_both", args,
-      /*assertInfo=*/std::nullopt,
-      {commitsType, writeVisibilityType, readVisibilityType},
-      [commitsType, writeVisibilityType,
-       readVisibilityType](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+      b, functionName, args, /*assertInfo=*/std::nullopt, specializationArgs,
+      [commitsType, writeVisibilityType, readVisibilityType, hasWriteVisibility,
+       hasReadVisibility](ImplicitLocOpBuilder &fb, Block *entryBlock) {
         Value threadVal = entryBlock->getArgument(0);
         Value transferMaskVal = entryBlock->getArgument(1);
         Value outstandingNumVal = entryBlock->getArgument(2);
         Value pred = entryBlock->getArgument(3);
         Value outstandingCommitsPtr = entryBlock->getArgument(4);
-        Value writeVisibilityPtr = entryBlock->getArgument(5);
-        Value readVisibilityPtr = entryBlock->getArgument(6);
+        unsigned nextArg = 5;
+        Value writeVisibilityPtr;
+        if (hasWriteVisibility)
+          writeVisibilityPtr = entryBlock->getArgument(nextArg++);
+        Value readVisibilityPtr;
+        if (hasReadVisibility)
+          readVisibilityPtr = entryBlock->getArgument(nextArg++);
 
         auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
         fb.setInsertionPointToStart(ifBlock);
 
         Value outstandingCommits = tti::createLoadScratchMemory(
             fb, fb.getLoc(), outstandingCommitsPtr, commitsType);
-        Value writeVisibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
-        Value readVisibility = tti::createLoadScratchMemory(
-            fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
-
         auto elemIntType = cast<IntegerType>(commitsType.getElementType());
         Value outstandingNumElem =
             adjustIntegerWidth(fb, outstandingNumVal, elemIntType);
@@ -3052,61 +3332,62 @@ void FunctionBuilder::createClearOutstandingCommitsTransferBothCall(
                                                createCurrentCTAMask(fb));
         threadColumnMask =
             arith::AndIOp::create(fb, threadColumnMask, commitCTAMask);
-        auto outstandingCommitsGtOutstandingNum =
+        Value outstandingCommitsGtOutstandingNum =
             createCmpIntTensorScalar(fb, outstandingCommits, outstandingNumElem,
                                      arith::CmpIPredicate::sgt);
         outstandingCommitsGtOutstandingNum = arith::AndIOp::create(
             fb, outstandingCommitsGtOutstandingNum, threadColumnMask);
-
-        // Update write visibility
-        Value writeRowMask =
+        Value rowMask =
             reduceLastDim<arith::OrIOp>(fb, outstandingCommitsGtOutstandingNum);
-        writeRowMask =
-            convertAndBroadcast(fb, writeRowMask, {0, 1}, writeVisibilityType);
-        Value writeTransferMaskElem = adjustIntegerWidth(
-            fb, transferMaskVal,
-            cast<IntegerType>(writeVisibilityType.getElementType()));
-        Value writeTransferMaskTensor = triton::SplatOp::create(
-            fb, writeVisibilityType, writeTransferMaskElem);
-        Value writeVisibilityOrThreadBit =
-            arith::OrIOp::create(fb, writeVisibility, writeTransferMaskTensor);
-        Value writeVisibilityUpdated = arith::SelectOp::create(
-            fb, writeRowMask, writeVisibilityOrThreadBit, writeVisibility);
-        Value writeMask = createCTASetMask(fb, writeVisibilityType, /*dim=*/2,
-                                           createCurrentCTAMask(fb));
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), writeVisibilityPtr,
-                                       writeVisibilityUpdated,
-                                       writeVisibilityType, writeMask);
 
-        // Update read visibility
-        Value readRowMask =
-            reduceLastDim<arith::OrIOp>(fb, outstandingCommitsGtOutstandingNum);
-        readRowMask =
-            convertAndBroadcast(fb, readRowMask, {0, 1}, readVisibilityType);
-        Value cMask = createCTASetMask(fb, readVisibilityType, /*dim=*/4,
-                                       createCurrentCTAMask(fb));
-        readRowMask = arith::AndIOp::create(fb, readRowMask, cMask);
-        Value readTransferMaskElem = adjustIntegerWidth(
-            fb, transferMaskVal,
-            cast<IntegerType>(readVisibilityType.getElementType()));
-        Value readTransferMaskTensor = triton::SplatOp::create(
-            fb, readVisibilityType, readTransferMaskElem);
-        Value readVisibilityOrThreadBit =
-            arith::OrIOp::create(fb, readVisibility, readTransferMaskTensor);
-        Value readVisibilityUpdated = arith::SelectOp::create(
-            fb, readRowMask, readVisibilityOrThreadBit, readVisibility);
-        Value readMask = createCTASetMask(fb, readVisibilityType, /*dim=*/2,
-                                          createCurrentCTAMask(fb));
-        createMaskedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
-                                       readVisibilityUpdated,
-                                       readVisibilityType, readMask);
+        if (hasWriteVisibility) {
+          Value writeVisibility = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), writeVisibilityPtr, writeVisibilityType);
+          Value writeRowMask =
+              convertAndBroadcast(fb, rowMask, {0, 1}, writeVisibilityType);
+          Value transferMaskElem = adjustIntegerWidth(
+              fb, transferMaskVal,
+              cast<IntegerType>(writeVisibilityType.getElementType()));
+          Value transferMaskTensor = triton::SplatOp::create(
+              fb, writeVisibilityType, transferMaskElem);
+          Value withTransfer =
+              arith::OrIOp::create(fb, writeVisibility, transferMaskTensor);
+          Value updated = arith::SelectOp::create(
+              fb, writeRowMask, withTransfer, writeVisibility);
+          Value writeMask = createCTASetMask(fb, writeVisibilityType, /*dim=*/2,
+                                             createCurrentCTAMask(fb));
+          createMaskedStoreScratchMemory(fb, fb.getLoc(), writeVisibilityPtr,
+                                         updated, writeVisibilityType,
+                                         writeMask);
+        }
 
-        // Clear outstanding commits once
-        Value outstandingCommitsZero =
-            tti::createConstIntTensor(fb, fb.getLoc(), 0, commitsType);
-        outstandingCommits =
-            arith::SelectOp::create(fb, outstandingCommitsGtOutstandingNum,
-                                    outstandingCommitsZero, outstandingCommits);
+        if (hasReadVisibility) {
+          Value readVisibility = tti::createLoadScratchMemory(
+              fb, fb.getLoc(), readVisibilityPtr, readVisibilityType);
+          Value readRowMask =
+              convertAndBroadcast(fb, rowMask, {0, 1}, readVisibilityType);
+          Value currentCTAMask =
+              createCTASetMask(fb, readVisibilityType,
+                               /*dim=*/4, createCurrentCTAMask(fb));
+          readRowMask = arith::AndIOp::create(fb, readRowMask, currentCTAMask);
+          Value transferMaskElem = adjustIntegerWidth(
+              fb, transferMaskVal,
+              cast<IntegerType>(readVisibilityType.getElementType()));
+          Value transferMaskTensor =
+              triton::SplatOp::create(fb, readVisibilityType, transferMaskElem);
+          Value withTransfer =
+              arith::OrIOp::create(fb, readVisibility, transferMaskTensor);
+          Value updated = arith::SelectOp::create(fb, readRowMask, withTransfer,
+                                                  readVisibility);
+          Value readMask = createCTASetMask(fb, readVisibilityType, /*dim=*/2,
+                                            createCurrentCTAMask(fb));
+          createMaskedStoreScratchMemory(fb, fb.getLoc(), readVisibilityPtr,
+                                         updated, readVisibilityType, readMask);
+        }
+
+        Value zero = tti::createConstIntTensor(fb, fb.getLoc(), 0, commitsType);
+        outstandingCommits = arith::SelectOp::create(
+            fb, outstandingCommitsGtOutstandingNum, zero, outstandingCommits);
         createMaskedStoreScratchMemory(fb, fb.getLoc(), outstandingCommitsPtr,
                                        outstandingCommits, commitsType,
                                        commitCTAMask);
@@ -3117,106 +3398,64 @@ void FunctionBuilder::createClearOutstandingCommitsTransferBothCall(
 }
 
 void FunctionBuilder::createCheckOutstandingCommitsCall(
-    ImplicitLocOpBuilder &b, Value buf, uint32_t length, int thread,
-    StringRef pendingAccessType, Value pred, MemType memType,
+    ImplicitLocOpBuilder &b, Value bufferMask, int thread,
+    StringRef pendingAccessType, Value pred, MemType /*memType*/,
     CommitKind::Kind commitKind, Operation *insertPoint, Value effectCTAs,
     bool excludeSelf) {
-  if (auxData.buffers[(int)memType].empty() ||
-      auxData.commits[commitKind].empty() ||
-      (auxData.hasNonTrivialAliasing[(int)memType] &&
-       auxData.aliasMatrices[(int)memType].empty())) {
+  if (auxData.commits[commitKind].empty()) {
     return;
   }
-  ValueType buffers = auxData.buffers[(int)memType].at(insertPoint);
   ValueType outstandingCommits = auxData.commits[commitKind].at(insertPoint);
   assert(thread < auxData.threadLayout.numBaseThreads &&
          "Commit-count tracking must operate on base threads");
-  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
   if (!pred)
     pred = arith::ConstantIntOp::create(b, 1, 1);
-  auto buffersType = cast<RankedTensorType>(buffers.type);
   auto commitsType = cast<RankedTensorType>(outstandingCommits.type);
   Value threadVal = arith::ConstantIntOp::create(b, thread, 32);
-  Value lengthVal = arith::ConstantIntOp::create(b, length, 32);
   std::string message =
       "Accessing buffer with pending access. Pending access type: " +
       pendingAccessType.str();
   AssertInfo assertInfo{message, b.getI1Type()};
-  Type aliasMatrixTypeBase;
+  SmallVector<Value> args = {bufferMask, pred, threadVal,
+                             outstandingCommits.value, effectCTAs};
+  std::string funcName = excludeSelf ? "check_outstanding_commits_excl_self"
+                                     : "check_outstanding_commits";
+  createCallToCachedFunction(
+      b, funcName, args, assertInfo, {commitsType, (uint64_t)thread},
+      [commitsType, excludeSelf](ImplicitLocOpBuilder &fb, Block *entryBlock) {
+        Value checkMask = entryBlock->getArgument(0);
+        Value pred = entryBlock->getArgument(1);
+        Value threadVal = entryBlock->getArgument(2);
+        Value outstandingCommitsPtr = entryBlock->getArgument(3);
+        Value effectCTAs = entryBlock->getArgument(4);
 
-  auto buildCheckOutstandingCommitsBody = [&commitsType, &aliasMatrixTypeBase](
-                                              bool useAlias, bool exclSelf) {
-    return [=](ImplicitLocOpBuilder &fb, Block *entryBlock) {
-      Value bufOffset = entryBlock->getArgument(0);
-      Value lengthVal = entryBlock->getArgument(1);
-      Value pred = entryBlock->getArgument(2);
-      Value threadVal = entryBlock->getArgument(3);
-      Value buffers = entryBlock->getArgument(4);
-      Value outstandingCommitsPtr = entryBlock->getArgument(5);
-      Value effectCTAs = entryBlock->getArgument(6);
-      Value aliasMatrix = useAlias ? entryBlock->getArgument(7) : Value();
+        Value outstandingCommits = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), outstandingCommitsPtr, commitsType);
+        checkMask = convertAndBroadcast(fb, checkMask, {1}, commitsType);
+        Value ctaMask =
+            createCTASetMask(fb, commitsType, /*dim=*/0, effectCTAs);
+        checkMask = arith::AndIOp::create(fb, checkMask, ctaMask);
+        Value zeroTensor =
+            tti::createConstIntTensor(fb, fb.getLoc(), 0, commitsType);
+        Value selectedRows = arith::SelectOp::create(
+            fb, checkMask, outstandingCommits, zeroTensor);
+        if (excludeSelf) {
+          Value threadColumnMask =
+              createDimMask(fb, threadVal, commitsType, /*dim=*/2);
+          selectedRows = arith::SelectOp::create(fb, threadColumnMask,
+                                                 zeroTensor, selectedRows);
+        }
+        Value selectedEqZero = arith::CmpIOp::create(
+            fb, arith::CmpIPredicate::eq, selectedRows, zeroTensor);
+        Value allSelectedEqZero = reduceAll<arith::AndIOp>(fb, selectedEqZero);
+        Value vTrue =
+            arith::ConstantOp::create(fb, allSelectedEqZero.getType(),
+                                      fb.getIntegerAttr(fb.getI1Type(), 1));
+        Value predicatedSelectedEqZero =
+            arith::SelectOp::create(fb, pred, allSelectedEqZero, vTrue);
 
-      Value outstandingCommits = tti::createLoadScratchMemory(
-          fb, fb.getLoc(), outstandingCommitsPtr, commitsType);
-      Value descriptor = createBufferDescriptor(fb, bufOffset, lengthVal);
-      Value buffersEqBuf = createCmpIntTensorScalar(fb, buffers, descriptor);
-      if (useAlias) {
-        buffersEqBuf =
-            expandAliases(fb, buffersEqBuf, aliasMatrix,
-                          cast<RankedTensorType>(aliasMatrixTypeBase));
-      }
-      buffersEqBuf = convertAndBroadcast(fb, buffersEqBuf, {1}, commitsType);
-      Value ctaMask = createCTASetMask(fb, commitsType, /*dim=*/0, effectCTAs);
-      buffersEqBuf = arith::AndIOp::create(fb, buffersEqBuf, ctaMask);
-      Value zeroTensor =
-          tti::createConstIntTensor(fb, fb.getLoc(), 0, commitsType);
-      Value selectedRows = arith::SelectOp::create(
-          fb, buffersEqBuf, outstandingCommits, zeroTensor);
-      if (exclSelf) {
-        Value threadColumnMask =
-            createDimMask(fb, threadVal, commitsType, /*dim=*/2);
-        selectedRows = arith::SelectOp::create(fb, threadColumnMask, zeroTensor,
-                                               selectedRows);
-      }
-      Value selectedEqZero = arith::CmpIOp::create(fb, arith::CmpIPredicate::eq,
-                                                   selectedRows, zeroTensor);
-      Value allSelectedEqZero = reduceAll<arith::AndIOp>(fb, selectedEqZero);
-      Value vTrue =
-          arith::ConstantOp::create(fb, allSelectedEqZero.getType(),
-                                    fb.getIntegerAttr(fb.getI1Type(), 1));
-      Value predicatedSelectedEqZero =
-          arith::SelectOp::create(fb, pred, allSelectedEqZero, vTrue);
-
-      triton::ReturnOp::create(fb, predicatedSelectedEqZero);
-    };
-  };
-  if (auxData.hasNonTrivialAliasing[(int)memType]) {
-    ValueType aliasMatrix = auxData.aliasMatrices[(int)memType].at(insertPoint);
-    aliasMatrixTypeBase = aliasMatrix.type;
-    auto aliasMatrixType = cast<RankedTensorType>(aliasMatrixTypeBase);
-    SmallVector<Value> args = {bufOffset,     lengthVal,
-                               pred,          threadVal,
-                               buffers.value, outstandingCommits.value,
-                               effectCTAs,    aliasMatrix.value};
-    std::string funcName = excludeSelf ? "check_outstanding_commits_excl_self"
-                                       : "check_outstanding_commits";
-    createCallToCachedFunction(
-        b, funcName, args, assertInfo,
-        {buffersType, commitsType, aliasMatrixType, (uint64_t)thread},
-        buildCheckOutstandingCommitsBody(/*useAlias=*/true, excludeSelf));
-  } else {
-    SmallVector<Value> args = {bufOffset,     lengthVal,
-                               pred,          threadVal,
-                               buffers.value, outstandingCommits.value,
-                               effectCTAs};
-    std::string funcName = excludeSelf
-                               ? "check_outstanding_commits_excl_self_noalias"
-                               : "check_outstanding_commits_noalias";
-    createCallToCachedFunction(
-        b, funcName, args, assertInfo,
-        {buffersType, commitsType, (uint64_t)thread},
-        buildCheckOutstandingCommitsBody(/*useAlias=*/false, excludeSelf));
-  }
+        triton::ReturnOp::create(fb, predicatedSelectedEqZero);
+      });
 }
 
 } // namespace mlir::triton::instrument

--- a/lib/Dialect/TritonInstrument/IR/Utility.cpp
+++ b/lib/Dialect/TritonInstrument/IR/Utility.cpp
@@ -13,6 +13,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 
 using namespace mlir;
@@ -26,6 +27,7 @@ namespace {
 
 DistributedEncodingTrait getWarpLocalEncoding(MLIRContext *ctx,
                                               ArrayRef<int64_t> shape,
+                                              unsigned threadsPerWarp,
                                               unsigned warps, unsigned numCTAs,
                                               unsigned bitwidth) {
   assert(!shape.empty() && "Expected non-empty shape");
@@ -40,13 +42,13 @@ DistributedEncodingTrait getWarpLocalEncoding(MLIRContext *ctx,
   // We pick a layout that vectorises global loads and stores.
   auto dim = StringAttr::get(ctx, "dim0");
   int numel = product(shape);
-  auto nlanes = std::min(numel, 32);
+  auto nlanes = std::min(numel, static_cast<int>(threadsPerWarp));
   auto nregs = numel / nlanes;
   auto vec = std::min<int>(kMaxVectorLengthBits / bitwidth, nregs);
   nregs /= vec;
   auto ll = LinearLayout::identity1D(vec, kRegister, dim) *
             LinearLayout::identity1D(nlanes, kLane, dim) *
-            LinearLayout::zeros1D(32 / nlanes, kLane, dim) *
+            LinearLayout::zeros1D(threadsPerWarp / nlanes, kLane, dim) *
             LinearLayout::zeros1D(warps, kWarp, dim) *
             LinearLayout::zeros1D(numCTAs, kBlock, dim) *
             LinearLayout::identity1D(nregs, kRegister, dim);
@@ -286,10 +288,12 @@ void createAssertInThread(ImplicitLocOpBuilder &b, Value condition,
 RankedTensorType getIntTensorType(Region *region, ArrayRef<int64_t> shape,
                                   unsigned bitWidth) {
   MLIRContext *ctx = region->getContext();
+  unsigned int threadsPerWarp = TritonGPUDialect::getThreadsPerWarp(
+      region->getParentOp()->getParentOfType<ModuleOp>());
   unsigned int warps = lookupNumWarps(region);
   unsigned int numCTAs = lookupNumCTAs(region->getParentOp());
-  DistributedEncodingTrait encoding =
-      getWarpLocalEncoding(ctx, shape, warps, numCTAs, bitWidth);
+  DistributedEncodingTrait encoding = getWarpLocalEncoding(
+      ctx, shape, threadsPerWarp, warps, numCTAs, bitWidth);
   Type elType = IntegerType::get(ctx, bitWidth);
   return RankedTensorType::get(shape, elType, encoding);
 }
@@ -460,7 +464,7 @@ FuncOp getEntryPoint(ModuleOp module) {
 }
 
 AuxDataMap::ThreadLayout getThreadLayout(ModuleOp module,
-                                         const ConSanTargetHooks *hooks) {
+                                         const ConSanTargetHooks &hooks) {
   AuxDataMap::ThreadLayout layout;
   bool hasTMA = false;
   bool hasTC = false;
@@ -473,9 +477,9 @@ AuxDataMap::ThreadLayout getThreadLayout(ModuleOp module,
     if (auto wsOp = dyn_cast<WarpSpecializePartitionsOp>(op))
       layout.numBaseThreads = std::max<int>(
           layout.numBaseThreads, wsOp.getPartitionRegions().size() + 1);
-    hasTMA |= hooks->isTMAOp(op);
+    hasTMA |= hooks.isTMAOp(op);
     hasTC |= isa<MMAv5OpInterface, TCGen5CommitOp, TMEMCopyOp>(op);
-    hasCLC |= hooks->isCLCOp(op);
+    hasCLC |= hooks.isCLCOp(op);
   });
 
   assert(layout.numBaseThreads <= MAX_NUM_BASE_THREADS &&
@@ -499,6 +503,17 @@ AuxDataMap::ThreadLayout getThreadLayout(ModuleOp module,
   assert(layout.totalNumThreads <= 64 &&
          "ConSan thread bitsets are stored in i64 masks");
   return layout;
+}
+
+Region *getClusterBarrierGroupRegion(Operation *op) {
+  Region *region = op->getParentRegion();
+  while (region) {
+    Operation *parent = region->getParentOp();
+    if (isa<WarpSpecializeOp, WarpSpecializePartitionsOp, FuncOp>(parent))
+      return region;
+    region = parent->getParentRegion();
+  }
+  llvm_unreachable("cluster barrier must be nested in a Triton function");
 }
 
 Region *AuxDataMap::RegionToValueMap::getEnclosingParitionOrFunctionRegion(
@@ -529,18 +544,32 @@ Region *AuxDataMap::RegionToValueMap::getEnclosingParitionOrFunctionRegion(
 }
 
 LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
-    ModuleOp module, FunctionBuilder &fb, const ConSanTargetHooks *hooks) {
+    ModuleOp module, FunctionBuilder &fb, const ConSanTargetHooks &hooks) {
   SmallVector<SmallVector<BufferRegion>, numMemTypes> bufRegions(numMemTypes);
   SmallVector<BufferRegion> barrierRegions;
-  getBuffersAndBarriers(module, bufRegions, barrierRegions);
+  if (failed(getBuffersAndBarriers(module, bufRegions, barrierRegions, hooks)))
+    return failure();
   int numCTAs = lookupNumCTAs(module);
   threadLayout = getThreadLayout(module, hooks);
+  hasAsyncProxyFenceTracking =
+      hooks.needsAsyncProxyFenceTracking(module) &&
+      bufferStatePlans[(int)MemType::SHARED_MEM].numLanes != 0;
   int captureCounter = 0;
   int64_t captureBytes = 0;
 
   FuncOp entryPoint = getEntryPoint(module);
   assert(entryPoint);
   Region *entryRegion = &entryPoint.getBody();
+
+  int numMBarriers = barrierRegions.size();
+  entryPoint.walk([&](ClusterBarrierOp op) {
+    Region *group = getClusterBarrierGroupRegion(op);
+    clusterBarrierSlots.try_emplace(group,
+                                    numMBarriers + clusterBarrierSlots.size());
+  });
+  int numTrackedBarriers = numMBarriers + clusterBarrierSlots.size();
+  if (numTrackedBarriers > 0)
+    barrierRegions.resize(llvm::NextPowerOf2(numTrackedBarriers - 1));
 
   ImplicitLocOpBuilder b(entryPoint.getLoc(), entryPoint);
   b.setInsertionPointToStart(&entryPoint.getBody().front());
@@ -551,39 +580,43 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
 
   for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
     int iMemType = (int)memType;
-    if (bufRegions[iMemType].empty()) {
+    if (bufferStatePlans[iMemType].numLanes == 0) {
       continue;
     }
 
-    buffers[iMemType].insert(
-        entryRegion,
-        createBufferDescriptorsTensor(b, memType, bufRegions[iMemType]));
-    // Buffer descriptors are rematerialized in the warp specialize region,
-    // not passed as an argument.
-    createInWarpSpecialize(entryPoint, buffers[iMemType],
-                           [&](ImplicitLocOpBuilder &b) {
-                             return createBufferDescriptorsTensor(
-                                 b, memType, bufRegions[iMemType]);
-                           });
-    int numBufs = bufRegions[iMemType].size();
+    int numBufs = llvm::NextPowerOf2(bufferStatePlans[iMemType].numLanes - 1);
 
-    hasNonTrivialAliasing[iMemType] =
-        hasCrossBufferAliasing(bufRegions[iMemType]);
-    if (hasNonTrivialAliasing[iMemType]) {
-      auto aliasMatrixData = createAliasingMatrix(bufRegions[iMemType]);
-      if (!aliasMatrixData.empty()) {
-        auto aliasTensor =
-            createAliasMatrixTensor(b, aliasMatrixData, entryRegion);
-        aliasMatrices[iMemType].insert(entryRegion,
-                                       {aliasTensor, aliasTensor.getType()});
-        createInWarpSpecialize(
-            entryPoint, aliasMatrices[iMemType],
-            [aliasMatrixData](ImplicitLocOpBuilder &nestedBuilder) {
-              Region *region = nestedBuilder.getInsertionBlock()->getParent();
-              auto tensor = createAliasMatrixTensor(nestedBuilder,
-                                                    aliasMatrixData, region);
-              return ValueType{tensor, tensor.getType()};
-            });
+    // Preserve beta's descriptor-based FunctionBuilder API while Reactor uses
+    // the state-lane plan below for sanitizer instrumentation.
+    if (!bufRegions[iMemType].empty()) {
+      buffers[iMemType].insert(
+          entryRegion,
+          createBufferDescriptorsTensor(b, memType, bufRegions[iMemType]));
+      createInWarpSpecialize(entryPoint, buffers[iMemType],
+                             [&](ImplicitLocOpBuilder &nestedBuilder) {
+                               return createBufferDescriptorsTensor(
+                                   nestedBuilder, memType,
+                                   bufRegions[iMemType]);
+                             });
+
+      hasNonTrivialAliasing[iMemType] =
+          hasCrossBufferAliasing(bufRegions[iMemType]);
+      if (hasNonTrivialAliasing[iMemType]) {
+        auto aliasMatrixData = createAliasingMatrix(bufRegions[iMemType]);
+        if (!aliasMatrixData.empty()) {
+          auto aliasTensor =
+              createAliasMatrixTensor(b, aliasMatrixData, entryRegion);
+          aliasMatrices[iMemType].insert(entryRegion,
+                                         {aliasTensor, aliasTensor.getType()});
+          createInWarpSpecialize(
+              entryPoint, aliasMatrices[iMemType],
+              [aliasMatrixData](ImplicitLocOpBuilder &nestedBuilder) {
+                Region *region = nestedBuilder.getInsertionBlock()->getParent();
+                auto tensor = createAliasMatrixTensor(nestedBuilder,
+                                                      aliasMatrixData, region);
+                return ValueType{tensor, tensor.getType()};
+              });
+        }
       }
     }
 
@@ -600,9 +633,20 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
             64, fb));
     passValueToWarpSpecialize(readVisibility[iMemType].at(entryRegion),
                               readVisibility[iMemType]);
+
+    if (memType == MemType::SHARED_MEM && hasAsyncProxyFenceTracking) {
+      proxyAccessVisibility.insert(
+          entryRegion,
+          createZeroInitStateTensor(b,
+                                    {numCTAs, numBufs, numCTAs,
+                                     threadLayout.numBaseThreadSlots, numCTAs},
+                                    64, fb));
+      passValueToWarpSpecialize(proxyAccessVisibility.at(entryRegion),
+                                proxyAccessVisibility);
+    }
   }
 
-  if (!barrierRegions.empty()) {
+  if (numTrackedBarriers > 0) {
     // Barriers allocations are in shared memory
     barriers.insert(entryRegion, createBufferDescriptorsTensor(
                                      b, MemType::SHARED_MEM, barrierRegions));
@@ -631,8 +675,11 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
     for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
       int iMemType = (int)memType;
       // Create state tensors:
-      int numBufs = bufRegions[iMemType].size();
-      if (numBufs > 0) {
+      int numBufs =
+          bufferStatePlans[iMemType].numLanes == 0
+              ? 0
+              : llvm::NextPowerOf2(bufferStatePlans[iMemType].numLanes - 1);
+      if (numMBarriers > 0 && numBufs > 0) {
         writeTracking[iMemType].insert(
             entryRegion,
             createZeroInitStateTensor(
@@ -647,6 +694,17 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
                                   readTracking[iMemType]);
       }
     }
+    if (numMBarriers > 0 && hasAsyncProxyFenceTracking &&
+        bufferStatePlans[(int)MemType::SHARED_MEM].numLanes != 0) {
+      int numBufs = llvm::NextPowerOf2(
+          bufferStatePlans[(int)MemType::SHARED_MEM].numLanes - 1);
+      proxyAccessTracking.insert(
+          entryRegion,
+          createZeroInitStateTensor(
+              b, {numCTAs, numBufs, numCTAs, numBarriers, numCTAs}, 64, fb));
+      passValueToWarpSpecialize(proxyAccessTracking.at(entryRegion),
+                                proxyAccessTracking);
+    }
   }
 
   // Create lock variable allocation
@@ -660,7 +718,7 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
   ExperimentalLockReleaseOp::create(b, lockVal, isCTA0);
   if (numCTAs > 1) {
     auto clusterBarrier = ClusterBarrierOp::create(b, b.getLoc());
-    nonPublishingClusterBarriers.push_back(clusterBarrier.getOperation());
+    internalClusterBarriers.push_back(clusterBarrier.getOperation());
   } else {
     BarrierOp::create(b, b.getLoc(), AddrSpace::Local);
   }
@@ -668,7 +726,8 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
   passValueToWarpSpecialize(lock.at(entryRegion), lock);
 
   auto createCommitTensor = [&](CommitKind::Kind commitKind) {
-    int numBufs = bufRegions[(int)MemType::SHARED_MEM].size();
+    unsigned numLanes = bufferStatePlans[(int)MemType::SHARED_MEM].numLanes;
+    int numBufs = numLanes == 0 ? 0 : llvm::NextPowerOf2(numLanes - 1);
     if (numBufs == 0)
       return;
     // Commit-count tracking operates on base threads.
@@ -685,23 +744,21 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
     createCommitTensor(CommitKind::AsyncCp);
   }
 
-  if (hooks) {
-    for (auto kind : hooks->getRequiredCommitKinds(module)) {
-      if (commits[kind].empty())
-        createCommitTensor(kind);
-    }
-  }
+  for (auto kind : hooks.getRequiredCommitKinds(module))
+    if (commits[kind].empty())
+      createCommitTensor(kind);
 
   // Verify the actual capture count matches the expected one.
   if (captureCounter > 0) {
     int numActiveMemTypes = 0;
     for (int i = 0; i < numMemTypes; ++i)
-      numActiveMemTypes += !bufRegions[i].empty();
+      numActiveMemTypes += bufferStatePlans[i].numLanes != 0;
     int numCommitKinds = 0;
     for (int i = 0; i < CommitKind::NumCommitKinds; ++i)
       numCommitKinds += !commits[i].empty();
     int expected = estimateConSanCaptureCount(
-        numActiveMemTypes, !barrierRegions.empty(), numCommitKinds);
+        numActiveMemTypes, numMBarriers > 0, !clusterBarrierSlots.empty(),
+        numCommitKinds, hasAsyncProxyFenceTracking);
     assert(captureCounter == expected &&
            "capture count changed -- update estimateConSanCaptureCount if this "
            "is expected!");
@@ -712,38 +769,114 @@ LogicalResult AuxDataMap::populateAndPassToWarpSpecialize(
   return success();
 }
 
-void AuxDataMap::getBuffersAndBarriers(
+LogicalResult AuxDataMap::getBuffersAndBarriers(
     ModuleOp module, SmallVector<SmallVector<BufferRegion>, 2> &bufRegions,
-    SmallVector<BufferRegion> &barrierRegions) {
+    SmallVector<BufferRegion> &barrierRegions, const ConSanTargetHooks &hooks) {
   // Collect shared memory buffers allocated in the module
   std::unique_ptr<DataFlowSolver> solver = createDataFlowSolver();
   triton::BufferRegionAnalysis *analysis =
       solver->load<triton::BufferRegionAnalysis>();
   if (failed(solver->initializeAndRun(module)))
-    return;
+    return failure();
+
+  SmallVector<std::pair<Value, RegionInfo>> candidates[numMemTypes];
+  DenseSet<Value> seenValues;
+  auto collectCandidates = [&](Value value) {
+    if (!seenValues.insert(value).second)
+      return;
+    auto type = dyn_cast<MemDescType>(value.getType());
+    if (!type)
+      return;
+    std::optional<MemType> memType;
+    if (isa<SharedMemorySpaceAttr>(type.getMemorySpace()))
+      memType = MemType::SHARED_MEM;
+    else if (isa<TensorMemorySpaceAttr>(type.getMemorySpace()))
+      memType = MemType::TENSOR_MEM;
+    if (!memType)
+      return;
+    candidates[static_cast<int>(*memType)].push_back(
+        {value, analysis->getLatticeElement(value)->getValue()});
+  };
+  module.walk([&](Operation *op) {
+    auto info = hooks.getMemEffectsOpInfo(op);
+    if (!info)
+      return;
+    if (info->trackingKind == MemEffectsOpInfo::TrackingKind::CommitCount &&
+        info->commitKind == CommitKind::AsyncCp)
+      hasAsyncCopyReads |= llvm::any_of(
+          info->operandEffects, [](const MemEffectsOpInfo::Effects &e) {
+            return e.rw == MemEffectsOpInfo::Effects::Read;
+          });
+    for (const auto &effect : info->operandEffects)
+      collectCandidates(effect.buf);
+  });
 
   analysis->calculateUsedBufferRegions(module);
-  bufRegions[(int)MemType::SHARED_MEM] = analysis->getAllUsedBufferRegions(
-      BufferRegionAnalysis::RegionType::SHARED_MEMORY);
-  bufRegions[(int)MemType::TENSOR_MEM] = analysis->getAllUsedBufferRegions(
-      BufferRegionAnalysis::RegionType::TENSOR_MEMORY);
   barrierRegions = analysis->getAllUsedBufferRegions(
       BufferRegionAnalysis::RegionType::BARRIER);
 
-  if (!barrierRegions.empty()) {
-    barrierRegions.resize(llvm::NextPowerOf2(barrierRegions.size() - 1),
-                          BufferRegion{0, 0});
-  }
-
   for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
     int iMemType = (int)memType;
-    if (bufRegions[iMemType].empty()) {
+    auto regionType = memType == MemType::SHARED_MEM
+                          ? BufferRegionAnalysis::SHARED_MEMORY
+                          : BufferRegionAnalysis::TENSOR_MEMORY;
+    SmallVector<BufferRegion> regions =
+        analysis->getAllUsedBufferRegions(regionType);
+    bufRegions[iMemType] = regions;
+    bool hasUnknown = analysis->hasUnknownUsedBufferRegions(regionType);
+    if (regions.empty() && !hasUnknown)
       continue;
+
+    bufferStatePlans[iMemType] =
+        triton::createBufferStatePlan(regions, hasUnknown);
+
+    for (const auto &[value, regionInfo] : candidates[iMemType]) {
+      BufferStateCandidates stateCandidates;
+      stateCandidates.unknown = regionInfo.isUnknown();
+      for (const BufferRegionView &view : regionInfo.views) {
+        const BufferRegion &candidate = view.region;
+        auto it = llvm::lower_bound(regions, candidate);
+        if (it == regions.end() || !(*it == candidate)) {
+          InFlightDiagnostic diag = emitError(
+              value.getLoc(),
+              "accessed exact buffer-region candidate is absent from the "
+              "ConSan registry: ");
+          candidate.print(diag);
+          return failure();
+        }
+        uint32_t id = std::distance(regions.begin(), it);
+        uint32_t ctaMask = 1u << view.affineCTAOffset;
+
+        auto existing = llvm::find_if(
+            stateCandidates.cases, [&](const BufferStateCandidate &state) {
+              return state.baseOffset == candidate.baseOffset;
+            });
+        if (existing == stateCandidates.cases.end()) {
+          stateCandidates.cases.push_back(
+              {candidate.baseOffset, bufferStatePlans[iMemType].regionMasks[id],
+               ctaMask});
+        } else {
+          existing->mask |= bufferStatePlans[iMemType].regionMasks[id];
+          existing->ctaMask |= ctaMask;
+        }
+      }
+      bufferCandidates[iMemType].try_emplace(value, std::move(stateCandidates));
     }
-    bufRegions[iMemType].resize(
-        llvm::NextPowerOf2(bufRegions[iMemType].size() - 1),
-        BufferRegion{0, 0});
+
+    if (!bufRegions[iMemType].empty())
+      bufRegions[iMemType].resize(
+          llvm::NextPowerOf2(bufRegions[iMemType].size() - 1),
+          BufferRegion{0, 0});
   }
+  return success();
+}
+
+int AuxDataMap::getClusterBarrierSlot(Operation *op) const {
+  Region *group = getClusterBarrierGroupRegion(op);
+  auto it = clusterBarrierSlots.find(group);
+  assert(it != clusterBarrierSlots.end() &&
+         "cluster barrier group must have a virtual barrier slot");
+  return it->second;
 }
 
 void AuxDataMap::passToWarpSpecialize(FuncOp func, ValueType valueType,

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -1,5 +1,6 @@
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -101,11 +102,11 @@ std::optional<int> maybeGetPartitionIdx(Operation *op) {
   return std::nullopt;
 }
 
-int getCurrentThread(Operation *op, const ConSanTargetHooks *hooks,
+int getCurrentThread(Operation *op, const ConSanTargetHooks &hooks,
                      const AuxDataMap::ThreadLayout &threadLayout) {
   // Default partition is 0, other partitions are idx + 1
   int thread = maybeGetPartitionIdx(op).value_or(-1) + 1;
-  if (hooks->isTMAOp(op)) {
+  if (hooks.isTMAOp(op)) {
     assert(threadLayout.hasTMAThreads() &&
            "TMA thread class must exist when instrumenting a TMA op");
     thread += threadLayout.tmaThreadOffset;
@@ -117,7 +118,7 @@ int getCurrentThread(Operation *op, const ConSanTargetHooks *hooks,
     thread += threadLayout.tcThreadOffset;
     return thread;
   }
-  if (hooks->isCLCOp(op)) {
+  if (hooks.isCLCOp(op)) {
     assert(threadLayout.hasCLCThreads() &&
            "CLC thread class must exist when instrumenting a CLC op");
     thread += threadLayout.clcThreadOffset;
@@ -153,6 +154,76 @@ int getActiveMask(ttg::WarpSpecializeOp wsOp) {
   for (Region *region : wsOp.getNonEmptyPartitionRegions())
     activeMask |= 1 << (region->getRegionNumber() + 1);
   return activeMask;
+}
+
+Value createStateMaskConstant(ImplicitLocOpBuilder &b,
+                              RankedTensorType maskType,
+                              const llvm::SmallBitVector &mask) {
+  assert(mask.size() <= static_cast<size_t>(maskType.getNumElements()));
+  SmallVector<APInt> bits(maskType.getNumElements(), APInt(1, 0));
+  for (unsigned bit = 0; bit < mask.size(); ++bit)
+    if (mask.test(bit))
+      bits[bit] = APInt(1, 1);
+  return arith::ConstantOp::create(b, maskType,
+                                   DenseElementsAttr::get(maskType, bits));
+}
+
+FailureOr<Value> createBufferStateMask(ImplicitLocOpBuilder &b,
+                                       AuxDataMap &auxData, MemType memType,
+                                       Value runtimeBase,
+                                       const BufferStateCandidates &candidates,
+                                       Operation *op) {
+  int index = static_cast<int>(memType);
+  const BufferStatePlan &plan = auxData.bufferStatePlans[index];
+  if (plan.numLanes == 0 || auxData.writeVisibility[index].empty()) {
+    op->emitError("active memdesc has no ConSan state plan");
+    return failure();
+  }
+  if (!candidates.unknown && candidates.cases.empty()) {
+    op->emitError("active memdesc has no buffer-state candidates");
+    return failure();
+  }
+
+  auto writeVisibilityType =
+      cast<RankedTensorType>(auxData.writeVisibility[index].at(op).type);
+  RankedTensorType maskType =
+      tti::getSlicedTensorType(writeVisibilityType, {1}, b.getI1Type());
+
+  if (candidates.unknown)
+    return createStateMaskConstant(b, maskType, plan.unknownMask);
+
+  SmallVector<Value> predicates;
+  if (candidates.cases.size() > 1) {
+    if (!runtimeBase) {
+      op->emitError("dynamic buffer-state cases require a runtime base");
+      return failure();
+    }
+    Value resolved = arith::ConstantIntOp::create(b, 0, 1);
+    for (const BufferStateCandidate &candidate : candidates.cases) {
+      Value base = tti::ExperimentalMemoryOffsetToI32Op::create(
+          b, candidate.baseOffset, memType);
+      Value predicate =
+          arith::CmpIOp::create(b, arith::CmpIPredicate::eq, runtimeBase, base);
+      predicates.push_back(predicate);
+      resolved = arith::OrIOp::create(b, resolved, predicate);
+    }
+    tti::createAssertInThread(
+        b, resolved,
+        "internal ConSan error: active memdesc resolved to no buffer state");
+  }
+
+  if (candidates.cases.size() == 1)
+    return createStateMaskConstant(b, maskType, candidates.cases.front().mask);
+
+  Value result =
+      createStateMaskConstant(b, maskType, llvm::SmallBitVector(plan.numLanes));
+  for (auto [state, predicate] : llvm::zip(candidates.cases, predicates)) {
+    Value candidate = createStateMaskConstant(b, maskType, state.mask);
+    Value predicateTensor = tt::SplatOp::create(b, maskType, predicate);
+    candidate = arith::AndIOp::create(b, candidate, predicateTensor);
+    result = arith::OrIOp::create(b, result, candidate);
+  }
+  return result;
 }
 
 bool shouldInitializeAllocations() {
@@ -407,6 +478,51 @@ Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
   return currentCTAMask(b);
 }
 
+Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Value recipients,
+                       const BufferStateCandidates &candidates) {
+  if (candidates.unknown)
+    return allCTAsMask(b);
+
+  uint32_t ownerMask = 0;
+  for (const BufferStateCandidate &candidate : candidates.cases)
+    ownerMask |= candidate.ctaMask;
+
+  if (ownerMask == 1)
+    return recipients;
+
+  int numCTAs = ttg::lookupNumCTAs(b);
+  APInt constant;
+  if (matchPattern(recipients, m_ConstantInt(&constant))) {
+    uint32_t result = 0;
+    for (int source = 0; source < numCTAs; ++source) {
+      if (!(constant.getZExtValue() & (1u << source)))
+        continue;
+      for (int offset = 0; offset < numCTAs; ++offset)
+        if (ownerMask & (1u << offset))
+          result |= 1u << (source ^ offset);
+    }
+    return arith::ConstantIntOp::create(b, result, 32);
+  }
+
+  Value result = arith::ConstantIntOp::create(b, 0, 32);
+  for (int source = 0; source < numCTAs; ++source) {
+    uint32_t targets = 0;
+    for (int offset = 0; offset < numCTAs; ++offset)
+      if (ownerMask & (1u << offset))
+        targets |= 1u << (source ^ offset);
+    Value sourceBit = arith::ConstantIntOp::create(b, 1u << source, 32);
+    Value present =
+        arith::CmpIOp::create(b, arith::CmpIPredicate::ne,
+                              arith::AndIOp::create(b, recipients, sourceBit),
+                              arith::ConstantIntOp::create(b, 0, 32));
+    Value targetMask = arith::SelectOp::create(
+        b, present, arith::ConstantIntOp::create(b, targets, 32),
+        arith::ConstantIntOp::create(b, 0, 32));
+    result = arith::OrIOp::create(b, result, targetMask);
+  }
+  return result;
+}
+
 Value getBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
   if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op))
     return getLeaderCTA(b, expectOp.getAlloc());
@@ -437,7 +553,7 @@ Value getBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
 
 class ConcurrencySanitizerImpl {
 public:
-  ConcurrencySanitizerImpl(ModuleOp module, const ConSanTargetHooks *hooks)
+  ConcurrencySanitizerImpl(ModuleOp module, const ConSanTargetHooks &hooks)
       : module(module), hooks(hooks) {}
 
   LogicalResult run() {
@@ -450,7 +566,8 @@ public:
 
     ImplicitLocOpBuilder b(entryPoint.getLoc(), entryPoint);
     b.setInsertionPointToStart(&entryPoint.getBody().front());
-    instrumentMemoryOperations(b, funcBuilder);
+    if (failed(instrumentMemoryOperations(b, funcBuilder)))
+      return failure();
     initializeAllocations();
     return success();
   }
@@ -481,9 +598,10 @@ private:
     }
   }
 
-  void instrumentMemoryOperations(ImplicitLocOpBuilder &b,
-                                  tti::FunctionBuilder &funcBuilder) {
-    module.walk([&](Operation *op) {
+  LogicalResult instrumentMemoryOperations(ImplicitLocOpBuilder &b,
+                                           tti::FunctionBuilder &funcBuilder) {
+    SmallVector<ttng::ClusterBarrierOp> clusterBarriers;
+    WalkResult result = module.walk([&](Operation *op) -> WalkResult {
       CriticalSectionListener listener;
       b.setListener(&listener);
 
@@ -499,17 +617,20 @@ private:
         b.setInsertionPointAfter(op);
       }
 
-      if (auto info = hooks->getBarrierWaitInfo(op)) {
+      if (auto info = hooks.getBarrierWaitInfo(op)) {
         // For waits we want to instrument it before and after, so we do it
         // manually inside instrumentBarrierWait (disable the critical section
         // listener and return early)
         b.setListener(nullptr);
         instrumentBarrierWait(op, info->alloc, info->phase, info->pred, thread,
                               baseThread, funcBuilder);
-        return;
+        return WalkResult::advance();
       }
 
-      instrumentMemEffects(b, op, thread, funcBuilder);
+      if (failed(instrumentMemEffects(b, op, thread, funcBuilder))) {
+        b.setListener(nullptr);
+        return WalkResult::interrupt();
+      }
       b.setLoc(op->getLoc());
       if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(op)) {
         funcBuilder.createSetActiveMaskCall(b, getActiveMask(wsOp), op);
@@ -529,16 +650,16 @@ private:
           }
         }
       }
-      if (auto info = hooks->getBarrierInitInfo(op)) {
-        Value pred = hooks->getIssuerCTAPred(b, op);
+      if (auto info = hooks.getBarrierInitInfo(op)) {
+        Value pred = hooks.getIssuerCTAPred(b, op);
         funcBuilder.createVerifyBarrierCanInitCall(b, info->alloc, pred, op,
                                                    currentCTAMask(b));
         funcBuilder.createInitBarrierStateCall(b, info->alloc, info->count,
                                                pred, op);
       }
-      if (auto info = hooks->getBarrierInvalidateInfo(op)) {
+      if (auto info = hooks.getBarrierInvalidateInfo(op)) {
         Value barrier = info->alloc;
-        Value pred = hooks->getIssuerCTAPred(b, op);
+        Value pred = hooks.getIssuerCTAPred(b, op);
         funcBuilder.createVerifyBarrierInitializedCall(b, barrier, pred, op,
                                                        currentCTAMask(b));
         funcBuilder.createInvalidateBarrierStateCall(b, barrier, pred, op);
@@ -554,19 +675,13 @@ private:
           funcBuilder.createCommitAccessesCall(b, thread, nullptr,
                                                CommitKind::AsyncCp, op);
       }
-      if (auto asyncWaitOp = dyn_cast<ttg::AsyncWaitOp>(op)) {
-        funcBuilder.createClearOutstandingCommitsTransferWritesCall(
-            b, baseThread, getThreadPeersMask(thread, auxData.threadLayout),
-            asyncWaitOp.getNum(), nullptr, CommitKind::AsyncCp,
-            MemType::SHARED_MEM, op);
-      }
       if (auto wgmmaWaitOp = dyn_cast<ttng::WarpGroupDotWaitOp>(op)) {
         funcBuilder.createClearOutstandingCommitsTransferReadsCall(
             b, baseThread, getThreadPeersMask(thread, auxData.threadLayout),
             wgmmaWaitOp.getPendings(), nullptr, CommitKind::Wgmma,
             MemType::SHARED_MEM, op);
       }
-      if (auto info = hooks->getWaitOpInfo(op)) {
+      if (auto info = hooks.getWaitOpInfo(op, auxData)) {
         if (info->transferWrites && info->transferReads) {
           funcBuilder.createClearOutstandingCommitsTransferBothCall(
               b, baseThread, getThreadPeersMask(thread, auxData.threadLayout),
@@ -583,29 +698,15 @@ private:
               info->pendingCount, nullptr, info->commitKind,
               MemType::SHARED_MEM, op);
         }
+      } else if (auto asyncWaitOp = dyn_cast<ttg::AsyncWaitOp>(op)) {
+        funcBuilder.createClearOutstandingCommitsTransferWritesCall(
+            b, baseThread, getThreadPeersMask(thread, auxData.threadLayout),
+            asyncWaitOp.getNum(), nullptr, CommitKind::AsyncCp,
+            MemType::SHARED_MEM, op);
       }
       if (auto clusterBarrier = dyn_cast<ttng::ClusterBarrierOp>(op)) {
-        if (!clusterBarrier.getRelaxed() &&
-            !llvm::is_contained(auxData.nonPublishingClusterBarriers, op)) {
-          b.setInsertionPointAfter(op);
-          // Publish the cluster-wide frontier once, then keep every CTA at
-          // this synchronization point until the publication completes.
-          b.setListener(nullptr);
-          Value ctaId = tti::ExperimentalClusterCTAIdOp::create(b, b.getLoc());
-          Value zero = arith::ConstantIntOp::create(b, 0, 32);
-          Value isCTA0 =
-              arith::CmpIOp::create(b, arith::CmpIPredicate::eq, ctaId, zero);
-          Value lock = auxData.lock.at(op).value;
-          tti::ExperimentalLockAcquireOp::create(b, lock, isCTA0);
-          for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM})
-            funcBuilder.createPublishClusterVisibilityCall(b, isCTA0, memType,
-                                                           op);
-          tti::ExperimentalLockReleaseOp::create(b, lock, isCTA0);
-          auto publishBarrier = ttng::ClusterBarrierOp::create(b, b.getLoc());
-          auxData.nonPublishingClusterBarriers.push_back(
-              publishBarrier.getOperation());
-          b.setListener(&listener);
-        }
+        if (!llvm::is_contained(auxData.internalClusterBarriers, op))
+          clusterBarriers.push_back(clusterBarrier);
       }
 
       if (isa<ttg::WarpYieldOp, ttg::WarpReturnOp>(op) &&
@@ -616,35 +717,75 @@ private:
             llvm::is_contained(wsOp.getNonEmptyPartitionRegions(),
                                op->getParentRegion());
         if (shouldRetire) {
+          b.setListener(nullptr);
           b.setLoc(wsOp.getLoc());
+          Value lock = auxData.lock.at(op).value;
+          Value trueVal = arith::ConstantIntOp::create(b, 1, 1);
+          tti::ExperimentalLockAcquireOp::create(b, lock, trueVal);
           funcBuilder.createRetireActiveThreadCall(b, baseThread, op);
-          funcBuilder.createCheckAllActiveWaitingCall(b, nullptr, op);
+          Value ok =
+              funcBuilder.createCheckAllActiveWaitingCall(b, nullptr, op);
+          tti::ExperimentalLockReleaseOp::create(b, lock, trueVal);
+          tti::createAssertInThread(
+              b, ok,
+              "Deadlock detected after a warp-specialized thread exited");
+          b.setListener(&listener);
         }
       }
       if (isa<tt::ReturnOp>(op) && !auxData.activeMasks.empty() &&
           op->getParentOfType<tt::FuncOp>() == tti::getEntryPoint(module)) {
+        b.setListener(nullptr);
+        Value lock = auxData.lock.at(op).value;
+        Value trueVal = arith::ConstantIntOp::create(b, 1, 1);
+        tti::ExperimentalLockAcquireOp::create(b, lock, trueVal);
         funcBuilder.createSetActiveMaskCall(b, 0, op);
-        funcBuilder.createCheckAllActiveWaitingCall(b, nullptr, op);
+        Value ok = funcBuilder.createCheckAllActiveWaitingCall(b, nullptr, op);
+        tti::ExperimentalLockReleaseOp::create(b, lock, trueVal);
+        tti::createAssertInThread(b, ok,
+                                  "Deadlock detected when the kernel returned");
+        b.setListener(&listener);
       }
 
       listener.maybeWrapWithCriticalSection(b, auxData, nullptr);
       b.setListener(nullptr);
+      return WalkResult::advance();
     });
+    if (result.wasInterrupted())
+      return failure();
+
+    // Cluster rendezvous polling introduces control-flow blocks, so add it
+    // after the operation walk rather than invalidating the walk iterators.
+    for (ttng::ClusterBarrierOp clusterBarrier : clusterBarriers) {
+      Operation *op = clusterBarrier.getOperation();
+      int thread = getCurrentThread(op, hooks, auxData.threadLayout);
+      int baseThread = getBaseThread(thread, auxData.threadLayout);
+      bool partitionScoped =
+          static_cast<bool>(op->getParentOfType<ttg::WarpSpecializeOp>());
+      b.setLoc(op->getLoc());
+      b.setInsertionPoint(op);
+      funcBuilder.createClusterBarrierRendezvousCall(
+          b, auxData.getClusterBarrierSlot(op), baseThread,
+          getThreadPeersMask(baseThread, auxData.threadLayout), partitionScoped,
+          /*publishVisibility=*/!clusterBarrier.getRelaxed(), op);
+    }
+    return success();
   }
 
   void instrumentBarrierWait(Operation *op, Value alloc, Value phase,
                              Value pred, int thread, int baseThread,
                              tti::FunctionBuilder &funcBuilder) {
     ImplicitLocOpBuilder wb(op->getLoc(), op);
-    pred = tti::maybeAnd(wb, pred, hooks->getIssuerCTAPred(wb, op));
+    pred = tti::maybeAnd(wb, pred, hooks.getIssuerCTAPred(wb, op));
     Value lock = auxData.lock.at(op).value;
     // Pre-wait: mark waiting threads and check for deadlock.
     tti::ExperimentalLockAcquireOp::create(wb, lock, pred);
     funcBuilder.createVerifyBarrierInitializedCall(wb, alloc, pred, op,
                                                    currentCTAMask(wb));
     funcBuilder.createSetWaitingCall(wb, alloc, baseThread, phase, pred, op);
-    funcBuilder.createCheckAllActiveWaitingCall(wb, pred, op);
+    Value ok = funcBuilder.createCheckAllActiveWaitingCall(wb, pred, op);
     tti::ExperimentalLockReleaseOp::create(wb, lock, pred);
+    tti::createAssertInThread(wb, ok,
+                              "Deadlock detected while waiting on an mbarrier");
     // Post-wait: transfer visible writes and reads to all peer threads,
     // and clear waiting for this barrier.
     assert(!auxData.barriers.empty() &&
@@ -663,71 +804,95 @@ private:
     tti::ExperimentalLockReleaseOp::create(wb, lock, pred);
   }
 
-  void instrumentMemEffects(ImplicitLocOpBuilder &b, Operation *op, int thread,
-                            tti::FunctionBuilder &funcBuilder) {
+  LogicalResult instrumentMemEffects(ImplicitLocOpBuilder &b, Operation *op,
+                                     int thread,
+                                     tti::FunctionBuilder &funcBuilder) {
     int baseThread = getBaseThread(thread, auxData.threadLayout);
-    std::optional<MemEffectsOpInfo> opInfo = hooks->getMemEffectsOpInfo(op);
-    if (!opInfo) {
-      return;
-    }
+    std::optional<MemEffectsOpInfo> opInfo = hooks.getMemEffectsOpInfo(op);
+    if (!opInfo)
+      return success();
     Value pred = opInfo->pred;
-    Value issuerCTAPred = hooks->getIssuerCTAPred(b, op);
+    Value issuerCTAPred = hooks.getIssuerCTAPred(b, op);
     pred = tti::maybeAnd(b, pred, issuerCTAPred);
-    Value effectCTAs = getMemEffectCTAs(b, op);
-    for (auto effect : opInfo->operandEffects) {
+    Value defaultEffectCTAs = getMemEffectCTAs(b, op);
+    struct MaterializedEffect {
+      Value bufferMask;
+      Value effectCTAs;
+      MemType memType;
+    };
+    SmallVector<MaterializedEffect> materializedEffects;
+    materializedEffects.reserve(opInfo->operandEffects.size());
+
+    for (const auto &effect : opInfo->operandEffects) {
+      MaterializedEffect materialized;
       Value buf = effect.buf;
       auto bufType = cast<ttg::MemDescType>(buf.getType());
-      MemType memType = MemType::TENSOR_MEM;
-      if (isa<ttg::SharedEncodingTrait>(bufType.getEncoding())) {
-        memType = MemType::SHARED_MEM;
+      materialized.memType = MemType::TENSOR_MEM;
+      if (isa<ttg::SharedMemorySpaceAttr>(bufType.getMemorySpace()))
+        materialized.memType = MemType::SHARED_MEM;
+      auto &candidateMap =
+          auxData.bufferCandidates[static_cast<int>(materialized.memType)];
+      auto candidateIt = candidateMap.find(buf);
+      if (candidateIt == candidateMap.end()) {
+        op->emitError("missing buffer-region candidates for memdesc");
+        return failure();
       }
+      Value runtimeBase;
+      if (!candidateIt->second.unknown && candidateIt->second.cases.size() > 1)
+        runtimeBase = tti::ExperimentalMemDescToI32Op::create(b, buf);
+      FailureOr<Value> stateMask =
+          createBufferStateMask(b, auxData, materialized.memType, runtimeBase,
+                                candidateIt->second, op);
+      if (failed(stateMask))
+        return failure();
+      materialized.bufferMask = *stateMask;
+      materialized.effectCTAs =
+          getMemEffectCTAs(b, defaultEffectCTAs, candidateIt->second);
+      materializedEffects.push_back(materialized);
+
+      Value bufferMask = materialized.bufferMask;
+      Value effectCTAs = materialized.effectCTAs;
+      MemType memType = materialized.memType;
       if (effect.rw == MemEffectsOpInfo::Effects::Read) {
         // For op that is reading, we only need to check if anything else
         // is writing to the same buffer.
-        addWriteChecks(b, funcBuilder, op, buf, effect.length, pred, memType,
-                       thread, effect.operandName, effectCTAs,
-                       /*allowNoWrite=*/false, opInfo->commitKind);
+        addWriteChecks(b, funcBuilder, op, bufferMask, pred, memType, thread,
+                       effect.operandName, effectCTAs, opInfo->commitKind);
         if (opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier) {
           funcBuilder.createSetReadVisibilityCall(
-              b, buf, effect.length,
-              getThreadPeersMask(thread, auxData.threadLayout), pred, memType,
-              op, effectCTAs);
+              b, bufferMask, getThreadPeersMask(thread, auxData.threadLayout),
+              pred, memType, op, effectCTAs);
         }
         if (opInfo->trackingKind ==
             MemEffectsOpInfo::TrackingKind::CommitCount) {
           assert(memType == MemType::SHARED_MEM);
-          funcBuilder.createStageAccessForCommitCall(b, buf, effect.length,
-                                                     baseThread, pred, memType,
-                                                     opInfo->commitKind, op);
+          funcBuilder.createStageAccessForCommitCall(
+              b, bufferMask, baseThread, pred, memType, opInfo->commitKind, op);
         }
       }
       if (effect.rw == MemEffectsOpInfo::Effects::Write) {
         // Op is writing to the buffer, we need to check if anything else
         // is reading or writing to the same buffer.
-        addWriteChecks(b, funcBuilder, op, buf, effect.length, pred, memType,
-                       thread, effect.operandName, effectCTAs,
-                       /*allowNoWrite=*/true, opInfo->commitKind);
-        addReadChecks(b, funcBuilder, op, buf, effect.length, pred, memType,
-                      thread, effect.operandName, effectCTAs,
-                      opInfo->commitKind);
+        addWriteChecks(b, funcBuilder, op, bufferMask, pred, memType, thread,
+                       effect.operandName, effectCTAs, opInfo->commitKind);
+        addReadChecks(b, funcBuilder, op, bufferMask, pred, memType, thread,
+                      effect.operandName, effectCTAs, opInfo->commitKind);
         if (opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier) {
           funcBuilder.createSetWriteVisibilityCall(
-              b, buf, effect.length,
-              getThreadPeersMask(thread, auxData.threadLayout), pred, memType,
-              op, effectCTAs);
-          funcBuilder.createClearWriteTrackingCall(b, buf, effect.length, pred,
-                                                   memType, op, effectCTAs);
-          funcBuilder.createClearReadVisibilityCall(b, buf, effect.length, pred,
+              b, bufferMask, getThreadPeersMask(thread, auxData.threadLayout),
+              pred, memType, op, effectCTAs);
+          funcBuilder.createClearWriteTrackingCall(b, bufferMask, pred, memType,
+                                                   op, effectCTAs);
+          funcBuilder.createClearReadVisibilityCall(b, bufferMask, pred,
                                                     memType, op, effectCTAs);
-          funcBuilder.createClearReadTrackingCall(b, buf, effect.length, pred,
-                                                  memType, op, effectCTAs);
+          funcBuilder.createClearReadTrackingCall(b, bufferMask, pred, memType,
+                                                  op, effectCTAs);
         }
         if (opInfo->trackingKind ==
             MemEffectsOpInfo::TrackingKind::CommitCount) {
           assert(memType == MemType::SHARED_MEM);
-          funcBuilder.createStageAccessForCommitCall(b, buf, effect.length,
-                                                     baseThread, pred, memType,
-                                                     opInfo->commitKind, op);
+          funcBuilder.createStageAccessForCommitCall(
+              b, bufferMask, baseThread, pred, memType, opInfo->commitKind, op);
         }
       }
     }
@@ -749,16 +914,13 @@ private:
         }
       } else if (barrierInfo.trackingMode ==
                  MemEffectsOpInfo::BarrierTrackingMode::EffectWrites) {
-        for (const auto &effect : opInfo->operandEffects) {
+        for (auto [effect, materialized] :
+             llvm::zip(opInfo->operandEffects, materializedEffects)) {
           if (effect.rw != MemEffectsOpInfo::Effects::Write)
             continue;
-          auto bufType = cast<ttg::MemDescType>(effect.buf.getType());
-          MemType memType = MemType::TENSOR_MEM;
-          if (isa<ttg::SharedEncodingTrait>(bufType.getEncoding()))
-            memType = MemType::SHARED_MEM;
           funcBuilder.createTrackBarrierWriteForBufferCall(
-              b, barrier, effect.buf, effect.length, combinedPred, memType, op,
-              recipientCTAs, effectCTAs);
+              b, barrier, materialized.bufferMask, combinedPred,
+              materialized.memType, op, recipientCTAs, materialized.effectCTAs);
         }
       }
       if (barrierInfo.count > 0 || barrierInfo.txCount != 0) {
@@ -776,25 +938,24 @@ private:
       funcBuilder.createCommitAccessesCall(b, baseThread, pred,
                                            opInfo->commitKind, op);
     }
+    return success();
   }
 
   void addWriteChecks(ImplicitLocOpBuilder &b,
                       tti::FunctionBuilder &funcBuilder, Operation *op,
-                      Value buf, uint32_t length, Value pred, MemType memType,
-                      int thread, const std::string &operandName,
-                      Value effectCTAs, bool allowNoWrite,
+                      Value bufferMask, Value pred, MemType memType, int thread,
+                      const std::string &operandName, Value effectCTAs,
                       CommitKind::Kind opCommitKind = CommitKind::None) {
-    funcBuilder.createVerifyWriteVisibilityCall(b, buf, length, thread,
-                                                operandName, pred, memType, op,
-                                                effectCTAs, allowNoWrite);
+    funcBuilder.createVerifyWriteVisibilityCall(
+        b, bufferMask, thread, operandName, pred, memType, op, effectCTAs);
     // commit-num-based synchronization is only supported for shared memory
     if (memType == MemType::SHARED_MEM) {
       for (const auto &commitKindDesc :
-           hooks->getOutstandingWriteCommitKinds()) {
+           hooks.getOutstandingWriteCommitKinds()) {
         bool excludeSelf = (opCommitKind == commitKindDesc.kind &&
-                            hooks->isOrderedCommitKind(opCommitKind));
+                            hooks.isOrderedCommitKind(opCommitKind));
         funcBuilder.createCheckOutstandingCommitsCall(
-            b, buf, length, getBaseThread(thread, auxData.threadLayout),
+            b, bufferMask, getBaseThread(thread, auxData.threadLayout),
             commitKindDesc.operationDesc, pred, memType, commitKindDesc.kind,
             op, effectCTAs, excludeSelf);
       }
@@ -802,20 +963,20 @@ private:
   }
 
   void addReadChecks(ImplicitLocOpBuilder &b, tti::FunctionBuilder &funcBuilder,
-                     Operation *op, Value buf, uint32_t length, Value pred,
+                     Operation *op, Value bufferMask, Value pred,
                      MemType memType, int thread,
                      const std::string &operandName, Value effectCTAs,
                      CommitKind::Kind opCommitKind = CommitKind::None) {
     funcBuilder.createVerifyReadVisibilityCall(
-        b, buf, length, thread, operandName, pred, memType, op, effectCTAs);
+        b, bufferMask, thread, operandName, pred, memType, op, effectCTAs);
     // commit-num-based synchronization is only supported for shared memory
     if (memType == MemType::SHARED_MEM) {
       for (const auto &commitKindDesc :
-           hooks->getOutstandingReadCommitKinds()) {
+           hooks.getOutstandingReadCommitKinds(auxData)) {
         bool excludeSelf = (opCommitKind == commitKindDesc.kind &&
-                            hooks->isOrderedCommitKind(opCommitKind));
+                            hooks.isOrderedCommitKind(opCommitKind));
         funcBuilder.createCheckOutstandingCommitsCall(
-            b, buf, length, getBaseThread(thread, auxData.threadLayout),
+            b, bufferMask, getBaseThread(thread, auxData.threadLayout),
             commitKindDesc.operationDesc, pred, memType, commitKindDesc.kind,
             op, effectCTAs, excludeSelf);
       }
@@ -824,14 +985,13 @@ private:
 
   ModuleOp module;
   AuxDataMap auxData;
-  const ConSanTargetHooks *hooks;
+  const ConSanTargetHooks &hooks;
 };
 
 } // namespace
 
 LogicalResult runConcurrencySanitizer(ModuleOp module,
-                                      const ConSanTargetHooks *hooks) {
-  assert(hooks && "hooks must not be null");
+                                      const ConSanTargetHooks &hooks) {
   ConcurrencySanitizerImpl impl(module, hooks);
   return impl.run();
 }
@@ -850,7 +1010,7 @@ public:
                                                  : "";
     auto hooks = createConSanHooks(key);
     assert(hooks && "no ConSan hooks registered for target");
-    if (failed(runConcurrencySanitizer(module, hooks.get())))
+    if (failed(runConcurrencySanitizer(module, *hooks)))
       return signalPassFailure();
   }
 };

--- a/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/PrepareConSanCaptures.cpp
@@ -59,11 +59,11 @@ bool hasCpAsync(ModuleOp mod) {
   return result;
 }
 
-int getNumCommitKinds(ModuleOp mod, const ConSanTargetHooks *hooks) {
+int getNumCommitKinds(ModuleOp mod, const ConSanTargetHooks &hooks) {
   std::array<bool, tti::CommitKind::NumCommitKinds> commitKinds{};
   if (hasCpAsync(mod))
     commitKinds[tti::CommitKind::AsyncCp] = true;
-  for (auto kind : hooks->getRequiredCommitKinds(mod)) {
+  for (auto kind : hooks.getRequiredCommitKinds(mod)) {
     if (kind >= 0 && kind < tti::CommitKind::NumCommitKinds)
       commitKinds[kind] = true;
   }
@@ -96,9 +96,12 @@ public:
 
     int numActiveMemTypes = (hasSharedMemoryBuffers(mod) ? 1 : 0) +
                             (hasTensorMemoryBuffers(mod) ? 1 : 0);
-    int totalCaptures =
-        tti::estimateConSanCaptureCount(numActiveMemTypes, hasBarriers(mod),
-                                        getNumCommitKinds(mod, hooks.get()));
+    bool hasClusterBarriers = target == "nvidia" && ttg::lookupNumCTAs(mod) > 1;
+    int totalCaptures = tti::estimateConSanCaptureCount(
+        numActiveMemTypes, hasBarriers(mod), hasClusterBarriers,
+        getNumCommitKinds(mod, *hooks),
+        hasSharedMemoryBuffers(mod) &&
+            hooks->needsAsyncProxyFenceTracking(mod));
     int extraBytes = totalCaptures * tti::kCaptureSizeBytes;
 
     auto i32Ty = IntegerType::get(mod.getContext(), 32);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -70,7 +70,8 @@ public:
     return std::nullopt;
   }
 
-  std::optional<WaitOpInfo> getWaitOpInfo(Operation *op) const override {
+  std::optional<WaitOpInfo>
+  getWaitOpInfo(Operation *op, const tti::AuxDataMap &) const override {
     if (auto tmaStoreWaitOp = dyn_cast<ttng::TMAStoreWaitOp>(op))
       return WaitOpInfo{tti::CommitKind::TmaStore,
                         static_cast<int>(tmaStoreWaitOp.getPendings()),
@@ -121,9 +122,7 @@ public:
 
   std::optional<MemEffectsOpInfo>
   getMemEffectsOpInfo(Operation *op) const override {
-    auto info = ConSanTargetHooks::getMemEffectsOpInfo(op);
-    if (info)
-      return info;
+    std::optional<MemEffectsOpInfo> info;
     if (auto expectOp = dyn_cast<ttng::BarrierExpectOp>(op)) {
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
@@ -299,10 +298,11 @@ public:
       info->barriers.push_back(
           {arriveOp.getBarrier(), nullptr, (int)arriveOp.getCount()});
     }
-    return info;
+    return info ? info : ConSanTargetHooks::getMemEffectsOpInfo(op);
   }
 
-  SmallVector<CommitKindDesc> getOutstandingReadCommitKinds() const override {
+  SmallVector<CommitKindDesc>
+  getOutstandingReadCommitKinds(const tti::AuxDataMap &) const override {
     return {{tti::CommitKind::Wgmma, "warpgroup_mma operand read"},
             {tti::CommitKind::TmaStore, "async_copy_shared_to_global"}};
   }

--- a/test/Analysis/test-buffer-region.mlir
+++ b/test/Analysis/test-buffer-region.mlir
@@ -298,14 +298,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   ^use_simple(%arg_simple: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>):
     cf.br ^merge(%arg_simple : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>)
   ^merge(%phi: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>):
-    // expected-remark @below {{Buffers: [4096, 4096], [28672, 4096], [32768, 4096]}}
+    // expected-remark @below {{Buffers: [4096, 4096], [28672, 4096]}}
     ttg.local_load %phi : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
     cf.br ^exit
   ^exit:
     tt.return
   }
 
-  // expected-remark @below {{All Shared Regions: [4096, 4096], [28672, 4096], [32768, 4096]}}
+  // expected-remark @below {{All Shared Regions: [4096, 4096], [28672, 4096]}}
   tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
     tt.return
   }
@@ -355,12 +355,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   ^no_alloc(%arg_in: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>):
     cf.br ^merge(%arg_in : !ttg.memdesc<32x32xf32, #shared, #smem, mutable>)
   ^merge(%phi: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>):
-    // expected-remark @below {{Buffers: [36864, 4096]}}
+    // expected-remark @below {{Buffers: unknown}}
     ttg.local_load %phi : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
     tt.return
   }
 
-  // expected-remark @below {{All Shared Regions: [36864, 4096]}}
   tt.func private @print_all_regions() attributes {test.print_all_used_regions} {
     tt.return
   }

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -103,18 +103,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @three_sub_bufs
   tt.func public @three_sub_bufs() {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0, 4096, 8192, 0], [{{.*}}], shared_mem : tensor<4xi64,
-
-    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x32x32xf32, #shared, #smem, mutable>
@@ -136,7 +134,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: #[[READ_BARS_L:.*]] = #ttg.blocked<{sizePerThread = [2, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1]}>
   // CHECK: @read_bars_alloc
   tt.func public @read_bars_alloc() {
-    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_BARS_G]], %c0_i8
     %c0 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
@@ -157,20 +155,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @async_copy_global_to_local
   tt.func public @async_copy_global_to_local(%ptr: tensor<32x32x!tt.ptr<f16>, #blocked>) {
-    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1xi64
     // CHECK: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRT_COMMITS_GLOB]], %c0_i8
 
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility_noalias_nw1{{.*}}(%[[A_I64]]
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
+    // CHECK: tt.call @__triton_consan_verify_write_visibility_nw1
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
-    // CHECK: tt.call @__triton_consan_verify_read_visibility_noalias_nw1
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}%[[THREAD_BIT]], %[[WRT_COMMITS_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility_nw1
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
-    // CHECK: tt.call @__triton_consan_stage_access_for_commit_nw1{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
-    // CHECK: ttg.async_copy_global_to_local %{{.*}}, %[[A]]
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit_nw1{{.*}}%[[THREAD_BIT]], %[[WRT_COMMITS_GLOB]]
+    // CHECK: ttg.async_copy_global_to_local
 
     %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
     ttg.async_copy_global_to_local %ptr, %shmem : tensor<32x32x!tt.ptr<f16>, #blocked> -> <32x32xf16, #shared, #smem, mutable>
@@ -187,7 +181,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @async_copy_global_to_local_with_barriers
   tt.func public @async_copy_global_to_local_with_barriers(%ptr: tensor<32x32x!tt.ptr<f16>, #blocked>) {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1xi64
     // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
@@ -197,17 +190,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK: tt.call @__triton_consan_init_barrier_state
 
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility_noalias{{.*}}(%[[A_I64]]
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}(%[[A_I64]]
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}%[[THREAD_BIT]], %[[WRT_COMMITS_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{[^,]+}}
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
-    // CHECK: tt.call @__triton_consan_stage_access_for_commit{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
-    // CHECK: ttg.async_copy_global_to_local %{{.*}}, %[[A]]
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit{{.*}}%[[THREAD_BIT]], %[[WRT_COMMITS_GLOB]]
+    // CHECK: ttg.async_copy_global_to_local
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
@@ -245,6 +234,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[THREAD_MASK:.*]] = arith.constant 1 : i64
     // CHECK: %[[OUTSTANDING_NUM:.*]] = arith.constant 42 : i32
     // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes{{.*}}(%[[THREAD_BIT]], %[[THREAD_MASK]], %[[OUTSTANDING_NUM]]
+    // CHECK-NOT: tt.call @__triton_consan_clear_outstanding_commits_transfer_
+    // CHECK: ttg.async_wait
     %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
     ttg.async_wait {num = 42 : i32}
     ttg.local_load %shmem : !ttg.memdesc<32x32xf16, #shared, #smem, mutable> -> tensor<32x32xf16, #blocked>
@@ -262,10 +253,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK-LABEL: @local_alloc_with_src
   tt.func public @local_alloc_with_src(%data: tensor<32x32xf16, #blocked>) {
     // CHECK: %[[BUF:.*]] = ttg.local_alloc
-    // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}(%[[BUF_I64]]
-    // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}(%[[BUF_I64]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{[^,]+}}
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{[^,]+}}
     %buf = ttg.local_alloc %data {allocation.offset = 0 : i32} : (tensor<32x32xf16, #blocked>) -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     amdg.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -569,9 +558,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     %pred = arith.constant 1 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     // CHECK: tt.call @__triton_consan_verify_write_visibility
-    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self_noalias
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self
     // CHECK: tt.call @__triton_consan_verify_read_visibility
-    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self_noalias
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self
     // CHECK: tt.call @__triton_consan_stage_access_for_commit
     // CHECK: tt.call @__triton_consan_commit_accesses
     // CHECK-NOT: tt.call @__triton_consan_verify_barrier_arrive
@@ -594,8 +583,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     ttg.async_copy_global_to_local %ptr, %shmem : tensor<128x128x!tt.ptr<f16>, #blocked> -> <128x128xf16, #shared, #smem, mutable>
 
     // CHECK: tt.call @__triton_consan_verify_write_visibility
-    // CHECK: tt.call @__triton_consan_check_outstanding_commits_noalias
-    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self_noalias
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self
     // CHECK: tt.call @__triton_consan_stage_access_for_commit
     // CHECK: tt.call @__triton_consan_commit_accesses
     amdg.async_tdm_copy_local_to_global %desc[%c0_i32, %c0_i32] from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
@@ -614,11 +603,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.shar
     %pred = arith.constant 1 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     // CHECK: tt.call @__triton_consan_verify_write_visibility
-    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self_noalias
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self
     // CHECK: tt.call @__triton_consan_stage_access_for_commit
     // CHECK: tt.call @__triton_consan_commit_accesses
     %1 = amdg.async_tdm_copy_global_to_local %in_desc[%c0_i32, %c0_i32] into %0, pred = %pred : !tt.tensordesc<32x32xf32> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
-    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self_noalias
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits_excl_self
     // CHECK: tt.call @__triton_consan_stage_access_for_commit
     // CHECK: tt.call @__triton_consan_commit_accesses
     amdg.async_tdm_copy_local_to_global %out_desc[%c0_i32, %c0_i32] from %0 : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf32>
@@ -866,7 +855,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
   // CHECK-LABEL: @ws_buf_ptrs_default
   tt.func public @ws_buf_ptrs_default() {
-    // CHECK-DAG: tti.experimental_buffer_descriptors [0, {{.*}}], [{{.*}}], shared_mem
     // CHECK-DAG: tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x128x128xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -897,7 +885,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
   // CHECK-LABEL: @ws_buf_ptrs_partition0
   tt.func public @ws_buf_ptrs_partition0() {
-    // CHECK-DAG: tti.experimental_buffer_descriptors [0, {{.*}}], [{{.*}}], shared_mem
     // CHECK-DAG: tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x128x128xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -990,6 +977,226 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       ttg.local_load %arg1 : !ttg.memdesc<32xf32, #shared, #smem, mutable> -> tensor<32xf32>
       ttg.warp_return
     } : (!ttg.memdesc<32xf32, #shared, #smem, mutable>, !ttg.memdesc<32xf32, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>) -> ()
+    tt.return
+  }
+}
+
+// -----
+
+// Partitioned padded allocations have several simultaneous physical bases.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [2, 1], order = [1, 0]}>
+#inner_padded = #ttg.padded_shared<[128:+4] {order = [1, 0], shape = [16, 16]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner_padded}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shared = 66592 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 2 : i32} {
+  // CHECK-LABEL: @partitioned_padded_local_load_store
+  // CHECK: ttg.local_alloc {allocation.offset = [0 : i32, 65536 : i32]}
+  // CHECK: tt.call @__triton_consan_verify_write_visibility
+  // CHECK: tt.call @__triton_consan_verify_read_visibility
+  // CHECK: ttg.local_store
+  // CHECK: tt.call @__triton_consan_verify_write_visibility
+  // CHECK: ttg.local_load
+  tt.func public @partitioned_padded_local_load_store(%value: tensor<16x16xf16, #blocked>) {
+    %buffer = ttg.local_alloc {allocation.offset = [0 : i32, 65536 : i32]} : () -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    ttg.local_store %value, %buffer : tensor<16x16xf16, #blocked> -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %loaded = ttg.local_load %buffer : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> tensor<16x16xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Each partitioned subview has its own sanitizer lane; runtime descriptor
+// selection must retain the physical base and state mask of either piece.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [2, 1], order = [1, 0]}>
+#inner = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #inner}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.shared = 66592 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 2 : i32} {
+  // CHECK-LABEL: @partitioned_shared_subslice_masks
+  // CHECK: arith.constant dense<[true, false]> : tensor<2xi1
+  // CHECK: tt.call @__triton_consan_verify_write_visibility
+  // CHECK: tt.call @__triton_consan_verify_read_visibility
+  // CHECK: ttg.local_store
+  // CHECK: arith.constant dense<[false, true]> : tensor<2xi1
+  // CHECK: tt.call @__triton_consan_verify_write_visibility
+  // CHECK: ttg.local_load
+  // CHECK: tti.experimental_memdesc_to_i32
+  // CHECK: tti.experimental_memory_offset_to_i32 0, shared_mem
+  // CHECK: tti.experimental_memory_offset_to_i32 65536, shared_mem
+  // CHECK: ttg.local_load
+  tt.func public @partitioned_shared_subslice_masks(%value: tensor<4x16xf16, #blocked>, %choose: i1) {
+    %buffer = ttg.local_alloc {allocation.offset = [0 : i32, 65536 : i32]} : () -> !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable>
+    %first = ttg.memdesc_subslice %buffer [0, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %second = ttg.memdesc_subslice %buffer [4, 0] : !ttg.memdesc<16x16xf16, #partitioned, #smem, mutable> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    ttg.local_store %value, %first : tensor<4x16xf16, #blocked> -> !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %loaded = ttg.local_load %second : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16, #blocked>
+    %selected = arith.select %choose, %first, %second : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16>
+    %dynamic = ttg.local_load %selected : !ttg.memdesc<4x16xf16, #partitioned, #smem, mutable, 16x16> -> tensor<4x16xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Direct-to-LDS buffer loads participate in ordinary asynchronous-copy
+// commit groups instead of being treated as synchronous shared-memory writes.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @buffer_load_to_local_tracks_async_commit
+  tt.func public @buffer_load_to_local_tracks_async_commit(%ptr: !tt.ptr<f32>, %offsets: tensor<32x64xi32, #blocked>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x64xf32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_verify_read_visibility
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: amdg.buffer_load_to_local
+    %token = amdg.buffer_load_to_local %ptr[%offsets] into %buffer : <f32>[tensor<32x64xi32, #blocked>] -> <32x64xf32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    // CHECK: ttg.async_commit_group
+    %group = ttg.async_commit_group tokens %token
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes
+    // CHECK-NOT: tt.call @__triton_consan_clear_outstanding_commits_transfer_
+    // CHECK: ttg.async_wait
+    %wait = ttg.async_wait %group {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Packed transposed LDS loads receive the synchronous read instrumentation
+// described by their declared memory effects.
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [2, 2], instrShape = [32, 32, 16], isTransposed = true}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 1024 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @packed_transposed_load_tracks_read
+  tt.func public @packed_transposed_load_tracks_read() {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16x64xi8, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_set_read_visibility
+    // CHECK: amdg.local_load_packed_tranposed
+    %value = amdg.local_load_packed_tranposed %buffer : !ttg.memdesc<16x64xi8, #shared, #smem, mutable> -> tensor<32x32xi8, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 16}>>
+    tt.return
+  }
+}
+
+// -----
+
+// An asynchronous LDS-to-global store is an outstanding shared-memory read;
+// a following write must check it and the native wait must publish both sides.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 4096 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @async_copy_local_to_global_tracks_reads
+  tt.func public @async_copy_local_to_global_tracks_reads(%dst: tensor<32x32x!tt.ptr<f32>, #blocked>, %value: tensor<32x32xf32, #blocked>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: amdg.async_copy_local_to_global
+    %token = amdg.async_copy_local_to_global %buffer, %dst : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    // CHECK: ttg.async_commit_group
+    %group = ttg.async_commit_group tokens %token
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits
+    // CHECK: "Accessing buffer with pending access. Pending access type: async_copy_shared_to_global"
+    // CHECK: ttg.local_store
+    ttg.local_store %value, %buffer : tensor<32x32xf32, #blocked> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    // CHECK-NOT: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
+    // CHECK-NOT: tt.call @__triton_consan_clear_outstanding_commits_transfer_
+    // CHECK: ttg.async_wait
+    %wait = ttg.async_wait %group {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Lowered AMD waits retain the same read-and-write completion behavior.
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 4096 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @lowered_async_wait_transfers_reads
+  tt.func public @lowered_async_wait_transfers_reads(%dst: tensor<32x32x!tt.ptr<f32>, #blocked>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %token = amdg.async_copy_local_to_global %buffer, %dst : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32x!tt.ptr<f32>, #blocked>
+    %group = ttg.async_commit_group tokens %token
+    // CHECK-NOT: tt.call @__triton_consan_clear_outstanding_commits_transfer_writes
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
+    // CHECK-NOT: tt.call @__triton_consan_clear_outstanding_commits_transfer_
+    // CHECK: amdg.async_wait
+    amdg.async_wait {"ttg.num_commit_groups" = 0 : i64, num_inst = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// TDM gather and scatter use the TDM commit class and transfer both their
+// outstanding writes and reads when the TDM wait completes.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+#idx_parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tdm_gather_scatter_track_commits
+  tt.func public @tdm_gather_scatter_track_commits(%desc: !tt.tensordesc<64x128xf16>, %rows: tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    %c0_i32 = arith.constant 0 : i32
+    %true_i32 = arith.constant 1 : i32
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    // CHECK: amdg.async_tdm_gather
+    %gather = amdg.async_tdm_gather %desc[%rows, %c0_i32] to %buffer, pred = %true_i32 : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit
+    // CHECK: tt.call @__triton_consan_commit_accesses
+    // CHECK: amdg.async_tdm_scatter
+    %scatter = amdg.async_tdm_scatter %desc[%rows, %c0_i32] from %buffer : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
+    // CHECK: amdg.async_tdm_wait
+    %wait = amdg.async_tdm_wait %scatter {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+// Barrier-completing TDM gather and scatter publish their own accesses through
+// the real barrier instead of creating implicit TDM commit groups.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#barrier_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#idx_parent = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // CHECK-LABEL: @tdm_gather_scatter_track_barrier
+  tt.func public @tdm_gather_scatter_track_barrier(%desc: !tt.tensordesc<64x128xf16>, %rows: tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>) {
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+    %c0_i32 = arith.constant 0 : i32
+    %true_i32 = arith.constant 1 : i32
+    amdg.init_barrier %barrier, 8 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_commit_accesses
+    // CHECK: amdg.async_tdm_gather
+    %gather = amdg.async_tdm_gather %desc[%rows, %c0_i32] to %buffer, pred = %true_i32, barrier = %barrier : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK-NOT: tt.call @__triton_consan_commit_accesses
+    // CHECK: amdg.async_tdm_scatter
+    %scatter = amdg.async_tdm_scatter %desc[%rows, %c0_i32] from %buffer, barrier = %barrier : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -136,18 +136,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @three_sub_bufs
   tt.func public @three_sub_bufs() {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0, 4096, 8192, 0], [{{.*}}], shared_mem : tensor<4xi64,
-
-    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_VISIBILITY_GLOB]], %c0_i64
 
-    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 4 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRITE_TRACKING_GLOB]], %c0_i8
 
-    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 32 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
+    // CHECK: %[[READ_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_TRACKING_GLOB]], %c0_i64
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x32x32xf32, #shared, #smem, mutable>
@@ -169,7 +167,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   // CHECK: #[[READ_BARS_L:.*]] = #ttg.blocked<{sizePerThread = [2, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [0, 1]}>
   // CHECK: @read_bars_alloc
   tt.func public @read_bars_alloc() {
-    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
+    // CHECK: %[[READ_BARS_G:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[READ_BARS_G]], %c0_i8
     %c0 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<2x32x32xf32, #shared, #smem, mutable>
@@ -290,10 +288,10 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #smem = #ttg.shared_memory
 #blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1], CGALayout = [[0, 0]]}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
-  // CHECK-LABEL: tt.func private @__triton_consan_check_outstanding_commits_noalias{{.*}}T2x1x1xI8
-  // CHECK-SAME: %arg6: i32
+  // CHECK-LABEL: tt.func private @__triton_consan_check_outstanding_commits{{.*}}T2x1x1xI8
+  // CHECK-SAME: %arg4: i32
   // CHECK-NOT: tti.experimental_cluster_cta_id
-  // CHECK: tt.splat %arg6 : i32 -> tensor<2x1x1xi32
+  // CHECK: tt.splat %arg4 : i32 -> tensor<2x1x1xi32
   // CHECK: arith.shrui
   // CHECK-LABEL: @outstanding_commits_multicast_tma_recipients
   tt.func public @outstanding_commits_multicast_tma_recipients(
@@ -739,32 +737,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: ttng.init_barrier
     // CHECK: arith.shli
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
-    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[SM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[B_I64:.*]] = tti.experimental_memdesc_to_i32 %[[B:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: %[[B_I64:.*]] = tti.experimental_memdesc_to_i32 %[[B]] :
-    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[SM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_clear_write_tracking{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TM_BUFS]], %[[TM_WRITE_TRACKING_GLOB]]
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_clear_read_tracking{{.*}}%[[ACC_I64]], {{.*}}, %[[TM_BUFS]], %{{[^,]+}}
+    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[TC_MASK]], %[[TM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_clear_write_tracking{{.*}}%[[TM_WRITE_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[TM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_clear_read_tracking
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR:.*]] :
@@ -778,7 +766,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR]] :
     // CHECK: tt.call @__triton_consan_track_visible_reads{{.*}}%[[BAR_I64]], {{.*}}, %[[TC_BIT]], %[[BARRIERS]], %[[TM_READ_VISIBILITY_GLOB]], %{{[^,]+}}
-    // CHECK: ttng.tc_gen5_mma %[[A]], %[[B]], %[[ACC]][], {{.*}}, {{.*}}, %[[BAR]]
+    // CHECK: ttng.tc_gen5_mma
     %c0_i32 = arith.constant 0 : i32
     %0 = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     %1 = ttg.local_alloc {allocation.offset = 32768 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
@@ -817,32 +805,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: ttng.init_barrier
     // CHECK: arith.shli
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
-    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[A_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[B_I64:.*]] = tti.experimental_memdesc_to_i32 %[[B:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[SM_BUFS]], %[[SM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[SM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: %[[B_I64:.*]] = tti.experimental_memdesc_to_i32 %[[B]] :
-    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[B_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[SM_BUFS]], %[[SM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_set_read_visibility{{.*}}%[[TC_MASK]], %[[SM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[TM_WRITE_VISIBILITY_GLOB]]
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_BIT]], %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}%[[TM_READ_VISIBILITY_GLOB]]
     // CHECK: %[[TC_MASK:.*]] = arith.constant 2 : i64
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TC_MASK]], %[[TM_BUFS]], %[[TM_WRITE_VISIBILITY_GLOB]]
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_clear_write_tracking{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TM_BUFS]], %[[TM_WRITE_TRACKING_GLOB]]
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[ACC_I64]], {{[^,]+}}, %{{[^,]+}}, %[[TM_BUFS]], %[[TM_READ_VISIBILITY_GLOB]]
-    // CHECK: %[[ACC_I64:.*]] = tti.experimental_memdesc_to_i32 %[[ACC]] :
-    // CHECK: tt.call @__triton_consan_clear_read_tracking{{.*}}%[[ACC_I64]], {{.*}}, %[[TM_BUFS]], %{{[^,]+}}
+    // CHECK: tt.call @__triton_consan_set_write_visibility{{.*}}%[[TC_MASK]], %[[TM_WRITE_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_clear_write_tracking{{.*}}%[[TM_WRITE_TRACKING_GLOB]]
+    // CHECK: tt.call @__triton_consan_clear_read_visibility{{.*}}%[[TM_READ_VISIBILITY_GLOB]]
+    // CHECK: tt.call @__triton_consan_clear_read_tracking
     // CHECK: tt.call @__triton_consan_verify_barrier_initialized
     // CHECK: %[[TC_BIT:.*]] = arith.constant 1 : i32
     // CHECK: %[[BAR_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BAR:.*]] :
@@ -859,7 +837,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
     // CHECK: tti.experimental_lock_release
-    // CHECK: ttng.tc_gen5_mma %[[A]], %[[B]], %[[ACC]][], {{.*}}, {{.*}}, %[[BAR]]
+    // CHECK: ttng.tc_gen5_mma
     %c0_i32 = arith.constant 0 : i32
     %0 = ttng.tmem_alloc  {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #tmem1, #ttng.tensor_memory, mutable>
     %1 = ttg.local_alloc {allocation.offset = 32768 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
@@ -928,20 +906,16 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @async_copy_global_to_local
   tt.func public @async_copy_global_to_local(%ptr: tensor<128x128x!tt.ptr<f16>, #blocked>) {
-    // CHECK: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1xi64
     // CHECK: %[[WRT_COMMITS_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
     // CHECK: call {{.*}}fill_global_tensor{{.*}}(%[[WRT_COMMITS_GLOB]], %c0_i8
 
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility_noalias_nw1{{.*}}(%[[A_I64]]
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
+    // CHECK: tt.call @__triton_consan_verify_write_visibility_nw1
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
-    // CHECK: tt.call @__triton_consan_verify_read_visibility_noalias_nw1
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}%[[THREAD_BIT]], %[[WRT_COMMITS_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility_nw1
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
-    // CHECK: tt.call @__triton_consan_stage_access_for_commit_nw1{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
-    // CHECK: ttg.async_copy_global_to_local %{{.*}}, %[[A]]
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit_nw1{{.*}}%[[THREAD_BIT]], %[[WRT_COMMITS_GLOB]]
+    // CHECK: ttg.async_copy_global_to_local
 
     %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     ttg.async_copy_global_to_local %ptr, %shmem : tensor<128x128x!tt.ptr<f16>, #blocked> -> <128x128xf16, #shared, #smem, mutable>
@@ -959,7 +933,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
   // CHECK-LABEL: @async_copy_global_to_local_with_barriers
   tt.func public @async_copy_global_to_local_with_barriers(%ptr: tensor<128x128x!tt.ptr<f16>, #blocked>) {
-    // CHECK-DAG: %[[BUFFERS:.*]] = tti.experimental_buffer_descriptors [0], [{{.*}}], shared_mem : tensor<1xi64
     // CHECK-DAG: %[[WRITE_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[READ_VISIBILITY_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 8 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i64>
     // CHECK-DAG: %[[WRITE_TRACKING_GLOB:.*]] = ttg.global_scratch_alloc {alignment = 16 : i32, nbytes = 1 : i32, shared_cluster_state, third_party_allocation, tt.divisibility = 16 : i64} : !tt.ptr<i8>
@@ -969,17 +942,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 
     // CHECK: tt.call @__triton_consan_init_barrier_state
 
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility_noalias{{.*}}(%[[A_I64]]
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}(%[[A_I64]]
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}%[[THREAD_BIT]], %[[WRT_COMMITS_GLOB]]
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{[^,]+}}
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: %[[A_I64:.*]] = tti.experimental_memdesc_to_i32 %[[A]] :
-    // CHECK: tt.call @__triton_consan_stage_access_for_commit{{.*}}(%[[A_I64]], {{.*}}, %[[THREAD_BIT]], %[[BUFFERS]], %[[WRT_COMMITS_GLOB]]
-    // CHECK: ttg.async_copy_global_to_local %{{.*}}, %[[A]]
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit{{.*}}%[[THREAD_BIT]], %[[WRT_COMMITS_GLOB]]
+    // CHECK: ttg.async_copy_global_to_local
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
@@ -1002,8 +971,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: %[[WAIT_PRED:.*]] = arith.andi %true, %{{.*}} : i1
     // CHECK-NEXT: tti.experimental_lock_acquire %{{.*}}, %[[WAIT_PRED]]
     // CHECK: tt.call @__triton_consan_check_all_active_waiting
-    // CHECK-NEXT: tti.experimental_assert_uniform
     // CHECK-NEXT: tti.experimental_lock_release %{{.*}}, %[[WAIT_PRED]]
+    // CHECK-NEXT: tti.experimental_assert_uniform
     // CHECK: ttng.wait_barrier
     // CHECK-NEXT: tti.experimental_lock_acquire %{{.*}}, %[[WAIT_PRED]]
     // CHECK: tt.call @__triton_consan_clear_waiting
@@ -1083,10 +1052,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: tt.call @__triton_consan_stage_access_for_commit{{.*}}(%[[A:.*]], {{.*}}, %[[THREAD_BIT]], %[[SM_BUFS]], %[[SM_WGMMA_WRITES_GLOB]]
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit{{.*}}%[[THREAD_BIT]], %[[SM_WGMMA_WRITES_GLOB]]
     // CHECK: tt.call @__triton_consan_verify_write_visibility
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
-    // CHECK: tt.call @__triton_consan_stage_access_for_commit{{.*}}(%[[B:.*]], {{.*}}, %[[THREAD_BIT]], %[[SM_BUFS]], %[[SM_WGMMA_WRITES_GLOB]]
+    // CHECK: tt.call @__triton_consan_stage_access_for_commit{{.*}}%[[THREAD_BIT]], %[[SM_WGMMA_WRITES_GLOB]]
     // CHECK: %[[THREAD_BIT:.*]] = arith.constant 0 : i32
     // CHECK: tt.call @__triton_consan_commit_accesses{{.*}}(%[[THREAD_BIT]], {{.*}}, %[[SM_WGMMA_WRITES_GLOB]]
     %c0_i32 = arith.constant 0 : i32
@@ -1154,10 +1123,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // CHECK-LABEL: @local_alloc_with_src
   tt.func public @local_alloc_with_src(%acc: tensor<128x128xf16, #mma>) {
     // CHECK: %[[BUF:.*]] = ttg.local_alloc
-    // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}(%[[BUF_I64]]
-    // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}(%[[BUF_I64]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{[^,]+}}
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{[^,]+}}
     %buf = ttg.local_alloc %acc {allocation.offset = 0 : i32} : (tensor<128x128xf16, #mma>) -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -1177,10 +1144,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // CHECK-LABEL: @tmem_alloc_with_src
   tt.func public @tmem_alloc_with_src(%acc: tensor<128x128xf16, #blocked>) {
     // CHECK: %[[BUF:.*]] = ttng.tmem_alloc
-    // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}(%[[BUF_I64]]
-    // CHECK: %[[BUF_I64:.*]] = tti.experimental_memdesc_to_i32 %[[BUF:.*]] :
-    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}(%[[BUF_I64]]
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}({{[^,]+}}
+    // CHECK: tt.call @__triton_consan_verify_read_visibility{{.*}}({{[^,]+}}
     %buf = ttng.tmem_alloc %acc { tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32 } : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
     %bar = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -1327,7 +1292,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
   // CHECK-LABEL: @ws_buf_ptrs_default
   tt.func public @ws_buf_ptrs_default(%arg0: !tt.tensordesc<32x32xf32, #shared>) {
-    // CHECK-DAG: tti.experimental_buffer_descriptors [0, 32768, 65536, 0], [{{.*}}], shared_mem
     // CHECK-DAG: tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x128x128xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -1360,7 +1324,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 8 : i32} {
   // CHECK-LABEL: @ws_buf_ptrs_partition0
   tt.func public @ws_buf_ptrs_partition0(%arg0: !tt.tensordesc<32x32xf32, #shared>) {
-    // CHECK-DAG: tti.experimental_buffer_descriptors [0, 32768, 65536, 0], [{{.*}}], shared_mem
     // CHECK-DAG: tti.experimental_buffer_descriptors [65536], [{{.*}}], shared_mem
     %smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<3x128x128xf16, #shared, #smem, mutable>
     %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
@@ -1648,7 +1611,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     tt.return
   }
 }
-
 // -----
 
 #shared_cluster_publish = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
@@ -1659,16 +1621,77 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
   tt.func public @cluster_barrier_publish_protocol() {
     %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared_cluster_publish, #smem_cluster_publish, mutable>
     // CHECK: ttg.local_load
-    // CHECK-NEXT: ttng.cluster_barrier
-    // CHECK: %[[PUB_CTA:.*]] = tti.experimental_cluster_cta_id : i32
-    // CHECK: %[[PUB_ZERO:.*]] = arith.constant 0 : i32
-    // CHECK: %[[PUB_PRED:.*]] = arith.cmpi eq, %[[PUB_CTA]], %[[PUB_ZERO]] : i32
-    // CHECK: tti.experimental_lock_acquire %{{.*}}, %[[PUB_PRED]]
-    // CHECK: tt.call @__triton_consan_publish_cluster_visibility{{.*}}(%[[PUB_PRED]],
-    // CHECK: tti.experimental_lock_release %{{.*}}, %[[PUB_PRED]]
-    // CHECK-NEXT: ttng.cluster_barrier
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: tt.call @__triton_consan_publish_cluster_visibility
+    // CHECK: cf.cond_br
+    // CHECK: ttng.cluster_barrier
     ttg.local_load %buf : !ttg.memdesc<32x32xf32, #shared_cluster_publish, #smem_cluster_publish, mutable> -> tensor<32x32xf32, #blocked_cluster_publish>
     ttng.cluster_barrier
+    tt.return
+  }
+}
+
+// -----
+
+// A known allocation and an external descriptor share the known state lane;
+// the unknown descriptor additionally covers its dedicated wildcard lane.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @known_and_unknown_descriptor_state
+  tt.func public @known_and_unknown_descriptor_state(%incoming: !ttg.memdesc<16xi32, #shared, #smem, mutable>) {
+    // CHECK: %[[KNOWN:.*]] = ttg.local_alloc
+    %known = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    // CHECK: arith.constant dense<[true, false]> : tensor<2xi1
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: ttg.local_load %[[KNOWN]]
+    %0 = ttg.local_load %known : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    // CHECK: arith.constant dense<true> : tensor<2xi1
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: ttg.local_load %arg0
+    %1 = ttg.local_load %incoming : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+}
+
+// -----
+
+// An unknown-only module still allocates sanitizer state without fabricating
+// or dynamically comparing a physical allocation base.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @unknown_only_descriptor_state
+  tt.func public @unknown_only_descriptor_state(%incoming: !ttg.memdesc<16xi32, #shared, #smem, mutable>) {
+    // CHECK: arith.constant dense<true> : tensor<1xi1
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK-NOT: tti.experimental_memdesc_to_i32
+    // CHECK: ttg.local_load %arg0
+    %0 = ttg.local_load %incoming : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
+    tt.return
+  }
+}
+
+// -----
+
+// A warp-group wait forwards descriptor provenance to its result while
+// separately preserving its asynchronous read-completion semantics.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 64 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @warp_group_wait_preserves_descriptor
+  tt.func public @warp_group_wait_preserves_descriptor() {
+    // CHECK: %[[BUFFER:.*]] = ttg.local_alloc
+    %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_reads
+    // CHECK: %[[WAITED:.*]] = ttng.warp_group_dot_wait %[[BUFFER]]
+    %waited = ttng.warp_group_dot_wait %buffer {pendings = 0 : i32} : !ttg.memdesc<16xi32, #shared, #smem, mutable>
+    // CHECK: tt.call @__triton_consan_verify_write_visibility
+    // CHECK: ttg.local_load %[[WAITED]]
+    %value = ttg.local_load %waited : !ttg.memdesc<16xi32, #shared, #smem, mutable> -> tensor<16xi32>
     tt.return
   }
 }

--- a/test/lib/Analysis/TestBufferRegion.cpp
+++ b/test/lib/Analysis/TestBufferRegion.cpp
@@ -7,6 +7,8 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include <algorithm>
+
 using namespace mlir;
 
 namespace tt = mlir::triton;
@@ -54,18 +56,14 @@ struct TestBufferRegionPass
     analysis->calculateUsedBufferRegions(moduleOp);
 
     moduleOp.walk([&](Operation *op) {
-      if (!triton::BufferRegionAnalysis::isMemoryAccessOperation(op))
-        return;
-
-      auto maybeMemDesc = llvm::find_if(op->getOperands(), [](Value operand) {
-        return isa<ttg::MemDescType>(operand.getType());
-      });
-
-      if (maybeMemDesc == op->operand_end())
-        return;
-
-      emitRegionInfo(op->getLoc(), "Buffers",
-                     analysis->getLatticeElement(*maybeMemDesc)->getValue());
+      for (const auto &access :
+           triton::BufferRegionAnalysis::getMemoryAccesses(op)) {
+        if (!llvm::is_contained(op->getOperands(), access.value))
+          continue;
+        emitRegionInfo(op->getLoc(), "Buffers",
+                       analysis->getLatticeElement(access.value)->getValue());
+        break;
+      }
     });
 
     llvm::SmallVector<Operation *> anchors;
@@ -90,12 +88,196 @@ struct TestBufferRegionPass
   }
 };
 
+struct TestBufferRegionAliasPass
+    : public PassWrapper<TestBufferRegionAliasPass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestBufferRegionAliasPass);
+
+  StringRef getArgument() const final { return "test-buffer-region-alias"; }
+  StringRef getDescription() const final {
+    return "test exact buffer-region alias and containment analysis";
+  }
+
+  static std::optional<Value> getTaggedMemDesc(Operation *op) {
+    for (Value operand : op->getOperands())
+      if (isa<ttg::MemDescType>(operand.getType()))
+        return operand;
+    for (Value result : op->getResults())
+      if (isa<ttg::MemDescType>(result.getType()))
+        return result;
+    return std::nullopt;
+  }
+
+  static FailureOr<tt::RegionInfo>
+  getTaggedRegionInfo(Operation *op, tt::BufferRegionAnalysis *analysis) {
+    if (auto addressesAttr =
+            op->getAttrOfType<DenseI32ArrayAttr>("test.region_addresses")) {
+      SmallVector<uint32_t> addresses;
+      for (int32_t address : addressesAttr.asArrayRef()) {
+        if (address < 0) {
+          op->emitError("test.region_addresses must be non-negative");
+          return failure();
+        }
+        addresses.push_back(static_cast<uint32_t>(address));
+      }
+      uint32_t base = 0;
+      uint32_t length = 0;
+      if (!addresses.empty()) {
+        auto [min, max] =
+            std::minmax_element(addresses.begin(), addresses.end());
+        base = *min;
+        length = *max - *min + 1;
+      }
+      tt::BufferRegion region{base, length};
+      if (!addresses.empty()) {
+        tt::AddressSet addressSet;
+        for (uint32_t address : addresses)
+          addressSet.set(address);
+        region.ctaAddresses.emplace_back(0, std::move(addressSet));
+      }
+      tt::RegionInfo info(tt::RegionInfo::ViewList{});
+      info.views.insert(
+          {std::move(region), /*storageBase=*/base, /*affineOffset=*/0});
+      return info;
+    }
+
+    std::optional<Value> memdesc = getTaggedMemDesc(op);
+    if (!memdesc) {
+      op->emitError("test.region_name requires test.region_addresses or a "
+                    "memdesc operand/result");
+      return failure();
+    }
+    return analysis->getLatticeElement(*memdesc)->getValue();
+  }
+
+  static bool mayAlias(const tt::RegionInfo &lhs, const tt::RegionInfo &rhs) {
+    if (lhs.isUnknown() || rhs.isUnknown())
+      return true;
+    return llvm::any_of(lhs.views, [&](const tt::BufferRegionView &a) {
+      return llvm::any_of(rhs.views, [&](const tt::BufferRegionView &b) {
+        return a.region.intersects(b.region);
+      });
+    });
+  }
+
+  static bool contains(const tt::RegionInfo &container,
+                       const tt::RegionInfo &contained) {
+    if (container.isUnknown() || contained.isUnknown())
+      return false;
+    return llvm::all_of(contained.views, [&](const tt::BufferRegionView &b) {
+      return llvm::any_of(container.views, [&](const tt::BufferRegionView &a) {
+        return a.region.contains(b.region);
+      });
+    });
+  }
+
+  static void printMask(InFlightDiagnostic &diag,
+                        const llvm::SmallBitVector &mask) {
+    diag << "{";
+    bool first = true;
+    for (unsigned bit = 0; bit < mask.size(); ++bit) {
+      if (!mask.test(bit))
+        continue;
+      if (!first)
+        diag << ",";
+      diag << bit;
+      first = false;
+    }
+    diag << "}";
+  }
+
+  static void
+  emitStatePlan(ModuleOp module,
+                ArrayRef<std::pair<std::string, tt::RegionInfo>> namedRegions) {
+    SmallVector<tt::BufferRegion> regions;
+    for (const auto &[name, info] : namedRegions)
+      for (const tt::BufferRegionView &view : info.views)
+        regions.push_back(view.region);
+    llvm::sort(regions);
+    regions.erase(std::unique(regions.begin(), regions.end()), regions.end());
+
+    bool hasUnknown = llvm::any_of(namedRegions, [](const auto &named) {
+      return named.second.isUnknown();
+    });
+    tt::BufferStatePlan plan = tt::createBufferStatePlan(regions, hasUnknown);
+    InFlightDiagnostic summary = module.emitRemark();
+    summary << "state-plan: lanes=" << plan.numLanes;
+
+    for (const auto &[name, info] : namedRegions) {
+      if (info.isUnknown()) {
+        InFlightDiagnostic diag = module.emitRemark();
+        diag << name << " case unknown: mask=";
+        printMask(diag, plan.unknownMask);
+        continue;
+      }
+      SmallVector<tt::BufferRegion> candidates;
+      for (const tt::BufferRegionView &view : info.views)
+        candidates.push_back(view.region);
+      llvm::sort(candidates);
+      for (const tt::BufferRegion &candidate : candidates) {
+        auto it = llvm::lower_bound(regions, candidate);
+        assert(it != regions.end() && *it == candidate);
+        const llvm::SmallBitVector &mask =
+            plan.regionMasks[std::distance(regions.begin(), it)];
+        InFlightDiagnostic diag = module.emitRemark();
+        diag << name << " case ";
+        candidate.print(diag);
+        diag << ": mask=";
+        printMask(diag, mask);
+      }
+    }
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    std::unique_ptr<DataFlowSolver> solver = createDataFlowSolver();
+    tt::BufferRegionAnalysis *analysis =
+        solver->load<tt::BufferRegionAnalysis>();
+    if (failed(solver->initializeAndRun(module)))
+      return signalPassFailure();
+
+    SmallVector<std::pair<std::string, tt::RegionInfo>> namedRegions;
+    module.walk([&](Operation *op) {
+      auto name = op->getAttrOfType<StringAttr>("test.region_name");
+      if (!name)
+        return;
+      FailureOr<tt::RegionInfo> regionInfo = getTaggedRegionInfo(op, analysis);
+      if (failed(regionInfo)) {
+        return signalPassFailure();
+      }
+      namedRegions.push_back({name.str(), std::move(*regionInfo)});
+    });
+    llvm::sort(namedRegions, [](const auto &lhs, const auto &rhs) {
+      return lhs.first < rhs.first;
+    });
+
+    if (!module->hasAttr("test.state_plan_only")) {
+      for (size_t i = 0; i < namedRegions.size(); ++i) {
+        for (size_t j = i; j < namedRegions.size(); ++j) {
+          const auto &[lhsName, lhs] = namedRegions[i];
+          const auto &[rhsName, rhs] = namedRegions[j];
+          module.emitRemark()
+              << lhsName << " vs " << rhsName
+              << ": alias=" << (mayAlias(lhs, rhs) ? "true" : "false")
+              << ", lhs_contains_rhs="
+              << (contains(lhs, rhs) ? "true" : "false")
+              << ", rhs_contains_lhs="
+              << (contains(rhs, lhs) ? "true" : "false");
+        }
+      }
+    }
+
+    if (module->hasAttr("test.print_state_plan"))
+      emitStatePlan(module, namedRegions);
+  }
+};
+
 } // namespace
 
 namespace mlir {
 namespace test {
 void registerTestBufferRegionPass() {
   PassRegistration<TestBufferRegionPass>();
+  PassRegistration<TestBufferRegionAliasPass>();
 }
 } // namespace test
 } // namespace mlir

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConSanAMD.cpp
@@ -19,8 +19,7 @@ namespace mlir {
 class AMDConSanHooks : public tti::ConSanTargetHooks {
 public:
   bool isTMAOp(Operation *op) const override {
-    return isa<ttag::AsyncTDMCopyGlobalToLocalOp,
-               ttag::AsyncTDMCopyLocalToGlobalOp>(op);
+    return isa<ttag::TDMOpInterface>(op);
   }
 
   // TDM ops from the same warp complete in issue order. ConSan's thread model
@@ -51,14 +50,21 @@ public:
     return std::nullopt;
   }
 
-  std::optional<WaitOpInfo> getWaitOpInfo(Operation *op) const override {
-    // AMD amdgpu::AsyncWaitOp replaces ttg::AsyncWaitOp after
-    // UpdateAsyncWaitCount. Read the preserved commit-group count.
+  std::optional<WaitOpInfo>
+  getWaitOpInfo(Operation *op, const tti::AuxDataMap &auxData) const override {
+    // On asyncmark targets (CDNA3/CDNA4), ttg::AsyncWaitOp is kept as-is
+    // by UpdateAsyncWaitCount. Read the commit group count directly.
+    if (auto asyncWaitOp = dyn_cast<ttg::AsyncWaitOp>(op)) {
+      return WaitOpInfo{tti::CommitKind::AsyncCp, (int)asyncWaitOp.getNum(),
+                        /*transferWrites=*/true, auxData.hasAsyncCopyReads};
+    }
+    // On non-asyncmark targets, amdgpu::AsyncWaitOp replaces ttg::AsyncWaitOp
+    // after UpdateAsyncWaitCount. Read the preserved commit-group count.
     if (auto asyncWaitOp = dyn_cast<ttag::AsyncWaitOp>(op)) {
       if (auto attr = asyncWaitOp->getAttrOfType<IntegerAttr>(
               "ttg.num_commit_groups")) {
         return WaitOpInfo{tti::CommitKind::AsyncCp, (int)attr.getInt(),
-                          /*transferWrites=*/true, /*transferReads=*/false};
+                          /*transferWrites=*/true, auxData.hasAsyncCopyReads};
       }
       return std::nullopt;
     }
@@ -87,59 +93,43 @@ public:
 
   std::optional<MemEffectsOpInfo>
   getMemEffectsOpInfo(Operation *op) const override {
-    auto info = ConSanTargetHooks::getMemEffectsOpInfo(op);
-    if (info)
+    bool isAsyncCopy =
+        isa<ttag::BufferLoadToLocalOp, ttag::AsyncCopyLocalToGlobalOp>(op);
+    if (isAsyncCopy || isTMAOp(op)) {
+      auto baseInfo = ConSanTargetHooks::getMemEffectsOpInfo(op);
+      if (!baseInfo)
+        return std::nullopt;
+      MemEffectsOpInfo info = std::move(*baseInfo);
+      Value barrier;
+      if (auto barrierOp = dyn_cast<ttg::MBarrierOpInterface>(op))
+        barrier = barrierOp.getBarrier();
+      if (barrier) {
+        info.trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+        info.barriers.push_back({barrier, nullptr, ttg::lookupNumWarps(op)});
+      } else {
+        info.trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
+        info.commitKind =
+            isAsyncCopy ? tti::CommitKind::AsyncCp : tti::CommitKind::TmaStore;
+        info.implicitCommit = !isAsyncCopy;
+      }
       return info;
-    // AsyncTDMCopyGlobalToLocalOp: Async copy from global to shared memory.
-    // When a barrier is present, TDM signals it once per warp.
-    // The barrier init count must account for this (e.g. count=NUM_WARPS),
-    // so ConSan decrements the shadow counter by numWarps (one per warp).
-    // When no barrier is present, completion is tracked via the TDM wait
-    // counter (AsyncTDMWait), modeled as CommitCount with implicitCommit.
-    if (auto copyOp = dyn_cast<ttag::AsyncTDMCopyGlobalToLocalOp>(op)) {
-      info.emplace();
-      if (Value barrier = copyOp.getBarrier()) {
-        info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-        int numWarps = ttg::lookupNumWarps(copyOp);
-        info->barriers.push_back({barrier, nullptr, numWarps});
-      } else {
-        info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
-        info->commitKind = tti::CommitKind::TmaStore;
-        info->implicitCommit = true;
-      }
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
-                                        copyOp.getResult());
-    }
-    // AsyncTDMCopyLocalToGlobalOp: Async copy from shared to global memory
-    // Same principles as AsyncTDMCopyGlobalToLocalOp apply.
-    if (auto storeOp = dyn_cast<ttag::AsyncTDMCopyLocalToGlobalOp>(op)) {
-      info.emplace();
-      if (Value barrier = storeOp.getBarrier()) {
-        info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
-        int numWarps = ttg::lookupNumWarps(storeOp);
-        info->barriers.push_back({barrier, nullptr, numWarps});
-      } else {
-        info->trackingKind = MemEffectsOpInfo::TrackingKind::CommitCount;
-        info->commitKind = tti::CommitKind::TmaStore;
-        info->implicitCommit = true;
-      }
-      info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Read,
-                                        storeOp.getSrc());
     }
     // AMD ArriveBarrierOp: Explicit barrier arrival.
     // Arrive is per-THREAD when called explicitly (unlike TDM which
     // is per-warp). Scale by total threads in the partition so ConSan's shadow
     // barrier state matches the hardware arrival count.
     if (auto arriveOp = dyn_cast<ttag::ArriveBarrierOp>(op)) {
-      info.emplace();
-      info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
+      MemEffectsOpInfo info;
+      info.trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
       int numWarps = ttg::lookupNumWarps(arriveOp);
       auto mod = arriveOp->getParentOfType<ModuleOp>();
       int threadsPerWarp = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
       int totalCount = (int)arriveOp.getCount() * numWarps * threadsPerWarp;
-      info->barriers.push_back({arriveOp.getBarrier(), nullptr, totalCount});
+      info.barriers.push_back({arriveOp.getBarrier(), nullptr, totalCount});
+      return info;
     }
-    return info;
+
+    return ConSanTargetHooks::getMemEffectsOpInfo(op);
   }
 
   SmallVector<CommitKindDesc> getOutstandingWriteCommitKinds() const override {
@@ -147,8 +137,12 @@ public:
             {tti::CommitKind::TmaStore, "async_tdm_global_to_shared"}};
   }
 
-  SmallVector<CommitKindDesc> getOutstandingReadCommitKinds() const override {
-    return {{tti::CommitKind::TmaStore, "async_tdm_shared_to_global"}};
+  SmallVector<CommitKindDesc>
+  getOutstandingReadCommitKinds(const tti::AuxDataMap &auxData) const override {
+    if (!auxData.hasAsyncCopyReads)
+      return {{tti::CommitKind::TmaStore, "async_tdm_shared_to_global"}};
+    return {{tti::CommitKind::AsyncCp, "async_copy_shared_to_global"},
+            {tti::CommitKind::TmaStore, "async_tdm_shared_to_global"}};
   }
 
   SmallVector<tti::CommitKind::Kind>
@@ -157,12 +151,12 @@ public:
     bool needsTdm = false;
     bool needsAsyncCp = false;
     module.walk([&](Operation *op) {
-      if (isa<ttag::AsyncTDMCopyGlobalToLocalOp,
-              ttag::AsyncTDMCopyLocalToGlobalOp, ttag::AsyncTDMWait,
-              ttag::AsyncTDMIntrinsicWait>(op))
-        needsTdm = true;
-      if (isa<ttag::AsyncWaitOp>(op))
-        needsAsyncCp = true;
+      needsTdm |= isTMAOp(op) ||
+                  isa<ttag::AsyncTDMWait, ttag::AsyncTDMIntrinsicWait>(op);
+      needsAsyncCp |=
+          isa<ttg::AsyncCopyGlobalToLocalOp, ttg::AsyncCommitGroupOp,
+              ttg::AsyncWaitOp, ttag::BufferLoadToLocalOp,
+              ttag::AsyncCopyLocalToGlobalOp, ttag::AsyncWaitOp>(op);
     });
     if (needsTdm)
       kinds.push_back(tti::CommitKind::TmaStore);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -123,8 +123,8 @@ struct ConvertTritonGPUToLLVM
     if (enableConcurrencySanitizer) {
       auto hooks = mlir::triton::instrument::createConSanHooks("nvidia");
       assert(hooks && "no ConSan hooks registered for nvidia");
-      if (failed(mlir::triton::instrument::runConcurrencySanitizer(
-              mod, hooks.get())))
+      if (failed(
+              mlir::triton::instrument::runConcurrencySanitizer(mod, *hooks)))
         return signalPassFailure();
       mlir::PassManager cleanupPm(context);
       cleanupPm.addPass(mlir::triton::gluon::createGluonCanonicalize());

--- a/unittest/Analysis/UtilityTest.cpp
+++ b/unittest/Analysis/UtilityTest.cpp
@@ -1,7 +1,11 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Analysis/BufferRegion.h"
 
 #include "llvm/Support/Signals.h"
 #include <gtest/gtest.h>
+
+#include <deque>
+#include <set>
 
 namespace mlir {
 
@@ -21,6 +25,244 @@ TEST(Analysis, reorder) {
     EXPECT_EQ(reordered[1], 10);
     EXPECT_EQ(reordered[2], 30);
   }
+}
+
+TEST(Analysis, AddressSetExhaustiveEightUnitUniverse) {
+  constexpr unsigned universe = 8;
+  auto fromMask = [](unsigned mask) {
+    triton::AddressSet result;
+    for (unsigned bit = 0; bit < universe; ++bit)
+      if (mask & (1u << bit))
+        result.set(bit);
+    return result;
+  };
+
+  for (unsigned lhsMask = 0; lhsMask < (1u << universe); ++lhsMask) {
+    triton::AddressSet lhs = fromMask(lhsMask);
+
+    for (unsigned rhsMask = 0; rhsMask < (1u << universe); ++rhsMask) {
+      triton::AddressSet rhs = fromMask(rhsMask);
+      EXPECT_EQ(lhs.intersects(rhs), (lhsMask & rhsMask) != 0);
+      EXPECT_EQ(lhs.contains(rhs), (rhsMask & ~lhsMask) == 0);
+      EXPECT_EQ(lhs.intersection(rhs), fromMask(lhsMask & rhsMask));
+
+      triton::AddressSet difference = lhs;
+      difference.subtract(rhs);
+      EXPECT_EQ(difference, fromMask(lhsMask & ~rhsMask));
+    }
+  }
+}
+
+TEST(Analysis, BufferRegionViewPreservesSubviewProvenance) {
+  triton::BufferRegion region{
+      /*baseOffset=*/16,
+      /*length=*/8,
+      {{0, triton::AddressSet::fromRange(/*begin=*/16, /*length=*/8)}}};
+  triton::BufferRegionView fromSubview{region, /*storageBase=*/0,
+                                       /*affineOffset=*/16};
+  triton::BufferRegionView fromAllocation{region, /*storageBase=*/16,
+                                          /*affineOffset=*/0};
+
+  EXPECT_EQ(fromSubview.region, fromAllocation.region);
+  EXPECT_FALSE(fromSubview == fromAllocation);
+  triton::RegionInfo joined = triton::RegionInfo::join(
+      triton::RegionInfo({fromSubview}), triton::RegionInfo({fromAllocation}));
+  EXPECT_EQ(joined.views.size(), 2);
+
+  std::set<triton::BufferRegion> physicalRegions;
+  for (const triton::BufferRegionView &view : joined.views)
+    physicalRegions.insert(view.region);
+  EXPECT_EQ(physicalRegions.size(), 1);
+}
+
+namespace {
+
+uint64_t toBits(const llvm::SmallBitVector &mask) {
+  assert(mask.size() <= 64);
+  uint64_t result = 0;
+  for (unsigned bit = 0; bit < mask.size(); ++bit)
+    if (mask.test(bit))
+      result |= uint64_t{1} << bit;
+  return result;
+}
+
+void expectFullCoveragePartition(ArrayRef<triton::BufferRegion> regions) {
+  ASSERT_EQ(regions.size(), 64u);
+  triton::BufferStatePlan plan = triton::createBufferStatePlan(regions);
+  ASSERT_EQ(plan.numLanes, 64u);
+  ASSERT_EQ(plan.regionMasks.size(), regions.size());
+  EXPECT_EQ(toBits(plan.regionMasks.front()), ~uint64_t{0});
+  for (unsigned tile = 0; tile < 63; ++tile)
+    EXPECT_EQ(toBits(plan.regionMasks[tile + 1]), uint64_t{1} << tile)
+        << "tile " << tile;
+}
+
+triton::BufferRegion makeRegion(unsigned id, unsigned addressMask,
+                                unsigned universe) {
+  triton::AddressSet addresses;
+  for (unsigned bit = 0; bit < universe; ++bit)
+    if (addressMask & (1u << bit))
+      addresses.set(bit);
+  triton::BufferRegion region{/*baseOffset=*/id * 16, /*length=*/universe};
+  if (!addresses.empty())
+    region.ctaAddresses.emplace_back(0, std::move(addresses));
+  return region;
+}
+
+bool planNeverMissesHazard(ArrayRef<unsigned> addressMasks, unsigned universe) {
+  SmallVector<triton::BufferRegion> regions;
+  for (auto [id, mask] : llvm::enumerate(addressMasks))
+    regions.push_back(makeRegion(id, mask, universe));
+  triton::BufferStatePlan plan = triton::createBufferStatePlan(regions);
+  if (plan.numLanes > 64)
+    return false;
+
+  using State = std::pair<unsigned, uint64_t>;
+  std::deque<State> worklist;
+  std::set<State> seen;
+  worklist.push_back({0, 0});
+  seen.insert({0, 0});
+  while (!worklist.empty()) {
+    auto [exactState, planState] = worklist.front();
+    worklist.pop_front();
+    for (unsigned region = 0; region < regions.size(); ++region) {
+      uint64_t check = toBits(plan.regionMasks[region]);
+      bool exactHazard = (exactState & addressMasks[region]) != 0;
+      bool planHazard = (planState & check) != 0;
+      if (exactHazard && !planHazard)
+        return false;
+
+      State updated = {exactState | addressMasks[region],
+                       planState | toBits(plan.regionMasks[region])};
+      if (seen.insert(updated).second)
+        worklist.push_back(updated);
+
+      State completed = {exactState & ~addressMasks[region],
+                         planState & ~toBits(plan.regionMasks[region])};
+      if (seen.insert(completed).second)
+        worklist.push_back(completed);
+    }
+  }
+  return true;
+}
+
+bool planPublishesEveryAliasingAtom(ArrayRef<unsigned> addressMasks,
+                                    unsigned universe) {
+  SmallVector<triton::BufferRegion> regions;
+  for (auto [id, mask] : llvm::enumerate(addressMasks))
+    regions.push_back(makeRegion(id, mask, universe));
+  triton::BufferStatePlan plan = triton::createBufferStatePlan(regions);
+  if (plan.numLanes > 64)
+    return false;
+
+  for (unsigned generic = 0; generic < regions.size(); ++generic) {
+    for (unsigned async = 0; async < regions.size(); ++async) {
+      bool exactOverlap = (addressMasks[generic] & addressMasks[async]) != 0;
+      bool published = (toBits(plan.regionMasks[generic]) &
+                        toBits(plan.regionMasks[async])) != 0;
+      if (exactOverlap != published)
+        return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+TEST(Analysis, BufferStatePlanExhaustiveThreeViewsFourAddresses) {
+  constexpr unsigned universe = 4;
+  constexpr unsigned setCount = 1u << universe;
+  for (unsigned a = 0; a < setCount; ++a)
+    for (unsigned b = 0; b < setCount; ++b)
+      for (unsigned c = 0; c < setCount; ++c) {
+        ASSERT_TRUE(planNeverMissesHazard({a, b, c}, universe))
+            << "address masks: " << a << ", " << b << ", " << c;
+        ASSERT_TRUE(planPublishesEveryAliasingAtom({a, b, c}, universe))
+            << "proxy publication masks: " << a << ", " << b << ", " << c;
+      }
+}
+
+TEST(Analysis, BufferStatePlanUsesAtomsForSparsePartition) {
+  constexpr unsigned universe = 8;
+  SmallVector<unsigned> addressMasks = {
+      0xff, // full
+      0x55, // even
+      0xaa, // odd
+  };
+  SmallVector<triton::BufferRegion> regions;
+  for (auto [id, mask] : llvm::enumerate(addressMasks))
+    regions.push_back(makeRegion(id, mask, universe));
+
+  triton::BufferStatePlan plan = triton::createBufferStatePlan(regions);
+  EXPECT_EQ(plan.numLanes, 2);
+
+  for (unsigned exactState = 0; exactState < (1u << universe); ++exactState) {
+    uint64_t planState = 0;
+    if (exactState & 0x55)
+      planState |= toBits(plan.regionMasks[1]);
+    if (exactState & 0xaa)
+      planState |= toBits(plan.regionMasks[2]);
+    for (unsigned region = 0; region < regions.size(); ++region) {
+      EXPECT_EQ((exactState & addressMasks[region]) != 0,
+                (planState & toBits(plan.regionMasks[region])) != 0);
+    }
+  }
+}
+
+TEST(Analysis, BufferStatePlanKeepsPartialOverlapExact) {
+  SmallVector<triton::BufferRegion> regions = {
+      makeRegion(0, 0b0011, 4),
+      makeRegion(1, 0b0110, 4),
+  };
+  triton::BufferStatePlan plan = triton::createBufferStatePlan(regions);
+  EXPECT_EQ(plan.numLanes, 3);
+  EXPECT_EQ(toBits(plan.regionMasks[0]), 0b011);
+  EXPECT_EQ(toBits(plan.regionMasks[1]), 0b110);
+  EXPECT_TRUE(planNeverMissesHazard({0b0011, 0b0110}, 4));
+  EXPECT_TRUE(planPublishesEveryAliasingAtom({0b0011, 0b0110}, 4));
+}
+
+TEST(Analysis, BufferStatePlanKeepsLargePaddedIntervalsExact) {
+  constexpr uint32_t tileCount = 64;
+  constexpr uint32_t tileLength = 3648;
+  SmallVector<triton::BufferRegion> regions;
+  regions.reserve(tileCount);
+  regions.push_back(
+      {0,
+       tileCount * tileLength,
+       {{0, triton::AddressSet::fromRange(0, tileCount * tileLength)}}});
+  for (uint32_t tile = 0; tile < tileCount - 1; ++tile) {
+    uint32_t base = tile * tileLength;
+    regions.push_back({base,
+                       tileLength,
+                       {{0, triton::AddressSet::fromRange(base, tileLength)}}});
+  }
+
+  expectFullCoveragePartition(regions);
+}
+
+TEST(Analysis, BufferStatePlanKeepsLargeSparsePartitionsExact) {
+  constexpr uint32_t tileCount = 64;
+  constexpr uint32_t stripeCount = 4;
+  constexpr uint32_t stripeLength = 912;
+  constexpr uint32_t tileLength = stripeCount * stripeLength;
+  SmallVector<triton::BufferRegion> regions;
+  regions.reserve(tileCount);
+  regions.push_back(
+      {0,
+       tileCount * tileLength,
+       {{0, triton::AddressSet::fromRange(0, tileCount * tileLength)}}});
+
+  for (uint32_t tile = 0; tile < tileCount - 1; ++tile) {
+    triton::AddressSet addresses;
+    for (uint32_t stripe = 0; stripe < stripeCount; ++stripe)
+      addresses.insert(triton::AddressSet::fromRange(
+          (stripe * tileCount + tile) * stripeLength, stripeLength));
+    regions.push_back(
+        {tile * stripeLength, tileLength, {{0, std::move(addresses)}}});
+  }
+
+  expectFullCoveragePartition(regions);
 }
 
 } // namespace mlir


### PR DESCRIPTION
Summary:
Backport upstream Triton PR #11045:
https://github.com/triton-lang/triton/pull/11045

Failed test:
- test_warp_specialize_tma_matmul_consan[True-True-3-512-512-512]

Failure:
ConSan aborted while analyzing warp-specialized Hopper TMA kernels because
BufferRegion could not model WarpGroupDotWaitOp descriptor forwarding. The
narrow previous revision fixed only that transfer rule.

Fix:
Replace the narrow rule with the complete #11045 BufferRegion/ConSan redesign:
exact per-CTA physical footprints, explicit unknown regions, state-mask based
instrumentation, generic memory-effect discovery, and target hook updates. This
includes the minimal FunctionBuilder mask API and memory-offset lowering from
upstream #10948 that #11045 assumes but the beta pin predates.

Preserve beta-specific CTA, barrier, NVIDIA, and AMD TDM APIs. Use beta
arbitrary-axis reductions instead of the newer transpose/reshape reduction
sequence. The upstream cross-CTA subslice fixture is omitted because beta
rejects CTA-dimension subslices in dialect verification before BufferRegion;
the same fixture fails identically on the D114415246 parent.

Reviewed By: njriasan

Differential Revision: D114448163


