### PR TITLE
[Triton][TLX] num_stages=0 -> 1 (triton-lang/triton beta)

### DIFF
--- a/docs/design/amd_global_instruction_scheduling.md
+++ b/docs/design/amd_global_instruction_scheduling.md
@@ -548,7 +548,7 @@ The FA forward kernel in `amd-fa-pipelined_test.py` ships four variants of incre
 
 | Variant | Kernel | LDS depth | Pipelining mechanism |
 |---|---|---|---|
-| `async_simple` | `_attn_fwd_async_simple` | 1 (single-buffer) | plain async-load + `wait_group(0)`, `num_stages=0` |
+| `async_simple` | `_attn_fwd_async_simple` | 1 (single-buffer) | plain async-load + `wait_group(0)`, `num_stages=1` |
 | `async_prefetch` | `_attn_fwd_async_prefetch` | 2 (double-buffer) | hand modulo-scheduled prologue / hot-loop / epilogue |
 | `persistent` | `_attn_fwd_persistent` | 2 | `async_prefetch` tile body + persistent XCD-pinned zig-zag scheduler |
 | **`cluster`** | **`_attn_fwd_cluster_pipeline` → `_attn_inner_pipelined`** | **2 (2-slot), depth-4** | **rotated 4-cluster `warp_pipeline_stage`** |
@@ -646,7 +646,7 @@ The `local_trans` on K is a **metadata-only memdesc transpose**: it makes `local
 ### Pass B/C, Step 5: Emitted IR (steady-state loop, abbreviated; rendered as TLX for readability)
 
 ```python
-for block_n in tl.range(block_start, block_end - 3, num_stages=0):
+for block_n in tl.range(block_start, block_end - 3, num_stages=1):
     cur_slot = (block_n - block_start) % BUF_DEPTH
     nxt_slot = (block_n + 1 - block_start) % BUF_DEPTH
 

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -500,7 +500,7 @@ def _token_in_loop_kernel(
     acc = tl.zeros((BLOCK_SIZE, ), dtype=tl.float32)
 
     # tok is in scope here -- that's what we're testing.
-    for i in tl.range(0, NUM_ITERS, num_stages=0):
+    for i in tl.range(0, NUM_ITERS, num_stages=1):
         tlx.async_load_wait_group(0)
         x = tlx.local_load(buf0)
         acc += x
@@ -555,7 +555,7 @@ def _loop_carried_dot_layout_kernel(
     b_reg = tlx.local_load(b_buf)
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
 
-    for k in tl.range(0, K_ITERS - 1, num_stages=0):
+    for k in tl.range(0, K_ITERS - 1, num_stages=1):
         acc = tl.dot(a_reg, b_reg, acc)
         next_slot = (k + 1) % 2
         next_a = tlx.local_view(a_buffers, next_slot)

--- a/third_party/tlx/tools/microbench/amd_latency.py
+++ b/third_party/tlx/tools/microbench/amd_latency.py
@@ -55,7 +55,7 @@ def _k_baseline(seed_ptr, out_ptr, check_ptr, NITER):
     tid = tlx.thread_id(0)
     x = tl.load(seed_ptr).to(tl.float32)
     t0 = tlx.clock64()
-    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=1):
         x += 1.0
     t1 = tlx.clock64()
     if tid == 0:
@@ -70,7 +70,7 @@ def _k_valu_dependent(seed_ptr, out_ptr, check_ptr, NITER):
     mul = tl.load(seed_ptr + 1).to(tl.float32)
     inc = tl.load(seed_ptr + 2).to(tl.float32)
     t0 = tlx.clock64()
-    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=1):
         x = x * mul + inc
     t1 = tlx.clock64()
     if tid == 0:
@@ -94,7 +94,7 @@ def _k_valu_independent_x4(seed_ptr, out_ptr, check_ptr, NITER):
     inc2 = tl.load(seed_ptr + 10).to(tl.float32)
     inc3 = tl.load(seed_ptr + 11).to(tl.float32)
     t0 = tlx.clock64()
-    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=1):
         x0 = x0 * mul0 + inc0
         x1 = x1 * mul1 + inc1
         x2 = x2 * mul2 + inc2
@@ -115,7 +115,7 @@ def _k_lds_dependent_gather_chase(table_ptr, out_ptr, check_ptr, NITER):
 
     idx = tl.load(table_ptr + 64).to(tl.int32)
     t0 = tlx.clock64()
-    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=1):
         gathered = tlx.local_gather(table[0], tl.full((1,), idx, tl.int32), 0)
         idx = tl.sum(gathered, axis=0).to(tl.int32)
     t1 = tlx.clock64()
@@ -137,7 +137,7 @@ def _k_lds_independent_gather_x4(table_ptr, out_ptr, check_ptr, NITER):
     idx2 = tl.load(table_ptr + 66).to(tl.int32)
     idx3 = tl.load(table_ptr + 67).to(tl.int32)
     t0 = tlx.clock64()
-    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=1):
         idx0 = tl.sum(tlx.local_gather(table[0], tl.full((1,), idx0, tl.int32), 0), axis=0).to(tl.int32)
         idx1 = tl.sum(tlx.local_gather(table[0], tl.full((1,), idx1, tl.int32), 0), axis=0).to(tl.int32)
         idx2 = tl.sum(tlx.local_gather(table[0], tl.full((1,), idx2, tl.int32), 0), axis=0).to(tl.int32)
@@ -154,7 +154,7 @@ def _k_global_tl_load_dependent(src_ptr, out_ptr, check_ptr, NITER):
     idx = tl.load(src_ptr + 1).to(tl.int64)
     acc = tl.full((), 0, tl.int64)
     t0 = tlx.clock64()
-    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=1):
         # src contains a self pointer at 0; this creates a serialized global load
         # dependency without changing the address range.
         idx = tl.load(src_ptr + idx).to(tl.int64)
@@ -172,7 +172,7 @@ def _k_global_direct_to_lds_composite(src_ptr, out_ptr, check_ptr, NITER):
     offs = tl.arange(0, 32)[:, None] * 32 + tl.arange(0, 32)[None, :]
     acc = tl.zeros((32, 32), tl.float32)
     t0 = tlx.clock64()
-    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=1):
         tok = tlx.buffer_load_to_local(smem[0], src_ptr, offs)
         tlx.async_load_commit_group([tok])
         tlx.async_load_wait_group(0)
@@ -195,7 +195,7 @@ def _k_mfma_dependent(a_ptr, b_ptr, out_ptr, check_ptr, NITER):
     b = tl.load(b_ptr + offs_k[:, None] * 32 + offs_n[None, :])
     acc = tl.zeros((32, 32), tl.float32)
     t0 = tlx.clock64()
-    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=1):
         acc = tl.dot(a, b, acc, allow_tf32=False)
     t1 = tlx.clock64()
     s = tl.sum(tl.sum(acc, axis=1), axis=0)
@@ -223,7 +223,7 @@ def _k_mfma_independent_x4(a_ptr, b_ptr, out_ptr, check_ptr, NITER):
     acc2 = tl.zeros((32, 32), tl.float32)
     acc3 = tl.zeros((32, 32), tl.float32)
     t0 = tlx.clock64()
-    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=0):
+    for _ in tl.range(0, NITER, loop_unroll_factor=1, num_stages=1):
         acc0 = tl.dot(a0, b0, acc0, allow_tf32=False)
         acc1 = tl.dot(a1, b1, acc1, allow_tf32=False)
         acc2 = tl.dot(a2, b2, acc2, allow_tf32=False)

--- a/third_party/tlx/tools/microbench/test_amd_latency.py
+++ b/third_party/tlx/tools/microbench/test_amd_latency.py
@@ -70,7 +70,7 @@ def test_niter_is_runtime_loop_not_constexpr_unrolled():
     source = inspect.getsource(amd_latency)
     assert "NITER: tl.constexpr" not in source
     assert "range(NITER)" not in source
-    assert "tl.range(0, NITER, loop_unroll_factor=1, num_stages=0)" in source
+    assert "tl.range(0, NITER, loop_unroll_factor=1, num_stages=1)" in source
 
 
 def test_lds_pointer_chase_expected_matches_cpu_sequence():

--- a/third_party/tlx/tutorials/amd_addmm_glu.py
+++ b/third_party/tlx/tutorials/amd_addmm_glu.py
@@ -958,7 +958,7 @@ def tlx_addmm_glu_kernel_baseline(
 
     bias = tl.load(bias_ptr + offs_n).to(tl.float32)
     acc = bias[None, :] + tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    for k in tl.range(NUM_STAGES - 1, k_iters, num_stages=0):
+    for k in tl.range(NUM_STAGES - 1, k_iters, num_stages=1):
         a_smem = tlx.local_view(buffers_a, k % (NUM_STAGES - 1))
         b_smem = tlx.local_view(buffers_b, k % (NUM_STAGES - 1))
         a_reg = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)

--- a/third_party/tlx/tutorials/amd_fa_cluster.py
+++ b/third_party/tlx/tutorials/amd_fa_cluster.py
@@ -241,7 +241,7 @@ def _attn_inner_pipelined(
         tok_v1 = tlx.async_load(v_ptrs + n1 * stride_vn, tlx.local_view(v_buf, 1))
     tlx.async_load_commit_group([tok_v1])
 
-    for block_n in tl.range(block_start, block_end - 3, num_stages=0):
+    for block_n in tl.range(block_start, block_end - 3, num_stages=1):
         cur_slot = (block_n - block_start) % BUF_DEPTH
         nxt_slot = (block_n + 1 - block_start) % BUF_DEPTH
         ack_n = (block_n + 3) * BLOCK_N
@@ -388,7 +388,7 @@ def _attn_inner_short(
 
     num_blocks = block_end - block_start
     if USE_DIRECT_LOAD:
-        for block_offset in tl.range(0, num_blocks, num_stages=0):
+        for block_offset in tl.range(0, num_blocks, num_stages=1):
             start_n = (block_start + block_offset) * BLOCK_N
             mask = (start_n + offs_n)[:, None] < N_CTX
             k = tl.load(k_ptrs + start_n * stride_kn, mask=mask, other=0.0)
@@ -409,7 +409,7 @@ def _attn_inner_short(
             acc = tl.dot(p_dot, v, state.acc)
             state = SoftmaxState(acc, state.l_i, state.m_i)
     else:
-        for chunk_start in tl.range(0, num_blocks, BUF_DEPTH, num_stages=0):
+        for chunk_start in tl.range(0, num_blocks, BUF_DEPTH, num_stages=1):
             for slot in tl.static_range(BUF_DEPTH):
                 block_offset = chunk_start + slot
                 if block_offset < num_blocks:
@@ -815,7 +815,7 @@ def _attn_fwd_cluster_persistent_pipeline(
     hz_per_xcd = (Z * H + NUM_XCDS - 1) // NUM_XCDS
     units = hz_per_xcd * units_per_hz
 
-    for unit in tl.range(local, units, NUM_LOCAL, num_stages=0):
+    for unit in tl.range(local, units, NUM_LOCAL, num_stages=1):
         local_hz = unit // units_per_hz
         bundle = unit % units_per_hz
         pid_hz = xcd + local_hz * NUM_XCDS
@@ -831,7 +831,7 @@ def _attn_fwd_cluster_persistent_pipeline(
                     else:
                         pid_m = idx
                     # Safe to reuse the LDS slots across units: the outer loop
-                    # has num_stages=0 and _attn_cluster_tile drains all async
+                    # has num_stages=1 and _attn_cluster_tile drains all async
                     # load groups before it returns.
                     _attn_cluster_tile(
                         pid_m,

--- a/third_party/tlx/tutorials/amd_fa_persistent.py
+++ b/third_party/tlx/tutorials/amd_fa_persistent.py
@@ -123,7 +123,7 @@ def _attn_fwd_async_simple(
     k_base = K + k_off + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kk
     v_base = V + v_off + offs_n[:, None] * stride_vn + offs_d[None, :] * stride_vk
 
-    for start_n in tl.range(0, hi, BLOCK_N, num_stages=0):
+    for start_n in tl.range(0, hi, BLOCK_N, num_stages=1):
         kn = start_n + offs_n
         k_mask = kn[:, None] < N_CTX
         v_mask = kn[:, None] < N_CTX
@@ -270,7 +270,7 @@ def _attn_fwd_async_prefetch(
     [LR_KV]
     [QK, SM0, SM1, PV]  [GLDS_KV],
     """
-    for block_id in tl.range(0, n_main * BLOCK_N, BLOCK_N, num_stages=0):
+    for block_id in tl.range(0, n_main * BLOCK_N, BLOCK_N, num_stages=1):
         next_off = block_id + BLOCK_N
         kn = block_id + offs_n
         next_mask = (next_off + offs_n[:, None]) < N_CTX
@@ -428,7 +428,7 @@ def _async_prefetch_attn_tile(
     """
     Unmasked steady-state loop
     """
-    for block_id in tl.range(0, n_unmasked * BLOCK_N, BLOCK_N, num_stages=0):
+    for block_id in tl.range(0, n_unmasked * BLOCK_N, BLOCK_N, num_stages=1):
         next_off = block_id + BLOCK_N
         i = block_id // BLOCK_N
         slot_cur = i % 2
@@ -456,7 +456,7 @@ def _async_prefetch_attn_tile(
     """
     Masked peeled epilogue
     """
-    for block_id in tl.range(n_unmasked * BLOCK_N, n_blocks * BLOCK_N, BLOCK_N, num_stages=0):
+    for block_id in tl.range(n_unmasked * BLOCK_N, n_blocks * BLOCK_N, BLOCK_N, num_stages=1):
         next_off = block_id + BLOCK_N
         kn = block_id + offs_n
         i = block_id // BLOCK_N
@@ -588,7 +588,7 @@ def _attn_fwd_persistent(
     units_per_hz: tl.constexpr = (NUM_M_BLOCKS + TILES_PER_UNIT - 1) // TILES_PER_UNIT
     hz_per_xcd = (Z * H + NUM_XCDS - 1) // NUM_XCDS
     units = hz_per_xcd * units_per_hz
-    for unit in tl.range(local, units, NUM_LOCAL, num_stages=0):
+    for unit in tl.range(local, units, NUM_LOCAL, num_stages=1):
         local_hz = unit // units_per_hz  # which head-batch id (quotient)
         bundle = unit % units_per_hz  # quer_seq/m tiles within head-batch id (remainder)
         pid_hz = xcd + local_hz * NUM_XCDS  # global head-batch id.

--- a/third_party/tlx/tutorials/amd_fa_pipelined.py
+++ b/third_party/tlx/tutorials/amd_fa_pipelined.py
@@ -111,7 +111,7 @@ def _attn_fwd_async_simple(
     k_base = K + k_off + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kk
     v_base = V + v_off + offs_n[:, None] * stride_vn + offs_d[None, :] * stride_vk
 
-    for start_n in tl.range(0, hi, BLOCK_N, num_stages=0):
+    for start_n in tl.range(0, hi, BLOCK_N, num_stages=1):
         kn = start_n + offs_n
         k_mask = kn[:, None] < N_CTX
         v_mask = kn[:, None] < N_CTX
@@ -253,7 +253,7 @@ def _attn_fwd_async_prefetch(
     [LR_KV]
     [QK, SM0, SM1, PV]  [GLDS_KV],
     """
-    for block_id in tl.range(0, n_main * BLOCK_N, BLOCK_N, num_stages=0):
+    for block_id in tl.range(0, n_main * BLOCK_N, BLOCK_N, num_stages=1):
         next_off = block_id + BLOCK_N
         kn = block_id + offs_n
         next_mask = (next_off + offs_n[:, None]) < N_CTX

--- a/third_party/tlx/tutorials/amd_gemm_pipelined.py
+++ b/third_party/tlx/tutorials/amd_gemm_pipelined.py
@@ -186,8 +186,8 @@ def matmul_kernel_pipelined_mi300(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, strid
     # Pipeline Kernel Main Loop.
     # BLOCK_SIZE_K - (NUM_STAGES - 1) iterations
     acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    # Disable auto-pipelining with num_stages=0
-    for k in tl.range(NUM_STAGES - 1, K_ITERS, num_stages=0):
+    # Disable auto-pipelining with num_stages=1
+    for k in tl.range(NUM_STAGES - 1, K_ITERS, num_stages=1):
         # prefetch data for k into regs, this is NUM_STAGES - 1 ahead of the k in the following tl.dot
         a_k_smem_view = tlx.local_view(buffers_A, k % NUM_BUFFERS)
         b_k_smem_view = tlx.local_view(buffers_B, k % NUM_BUFFERS)

--- a/third_party/tlx/tutorials/amd_hstu_attn.py
+++ b/third_party/tlx/tutorials/amd_hstu_attn.py
@@ -488,7 +488,7 @@ def _hstu_attn_fwd_compute(  # noqa C901
             if uih_end < start_m:
                 low_delta = start_m
                 high_delta = start_m + BLOCK_M
-                for start_delta in tl.range(low_delta, high_delta, BLOCK_N, num_stages=0):
+                for start_delta in tl.range(low_delta, high_delta, BLOCK_N, num_stages=1):
                     acc += _hstu_attn_fwd_one_block(
                         start_n=start_delta,
                         seq_len=seq_len,

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel_split_m.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel_split_m.py
@@ -166,7 +166,7 @@ def matmul_kernel_pingpong(
     at_ptrs += BLOCK_K * stride_ak
 
     tlx.async_load_wait_group(3)
-    for j in tl.range(0, num_k_tiles - 2, num_stages=0):
+    for j in tl.range(0, num_k_tiles - 2, num_stages=1):
         cur = j % 2
         oth = 1 - cur
         with tlx.warp_pipeline_stage("mem", priority=1):

--- a/third_party/tlx/tutorials/hopper_gemm_pipelined.py
+++ b/third_party/tlx/tutorials/hopper_gemm_pipelined.py
@@ -80,8 +80,8 @@ def matmul_kernel_pipelined_hopper(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stri
 
     # main K loop
     acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    # Disable auto-pipelining with num_stages=0
-    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=0):
+    # Disable auto-pipelining with num_stages=1
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=1):
         # Select the buffer for the current iteration.
         buf = k % NUM_STAGES
         a_k = tlx.local_view(buffers_A, buf)

--- a/third_party/tlx/tutorials/hopper_gemm_ws.py
+++ b/third_party/tlx/tutorials/hopper_gemm_ws.py
@@ -141,7 +141,7 @@ def _skinny_matmul_kernel(
         tlx.async_load_commit_group([token_a, token_b])
 
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    for k in tl.range(0, tl.cdiv(K_LEN, BLOCK_K), num_stages=0):
+    for k in tl.range(0, tl.cdiv(K_LEN, BLOCK_K), num_stages=1):
         buf = k % NUM_STAGES
         a_k = tlx.local_view(buffers_A, buf)
         b_k = tlx.local_view(buffers_B, buf)
@@ -319,7 +319,7 @@ def _skinny_tma_kernel(
         tlx.async_descriptor_load(b_desc, buf_b, [offset_k, offset_bn], bar_b)
 
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    for k in tl.range(0, num_k_iters, num_stages=0):
+    for k in tl.range(0, num_k_iters, num_stages=1):
         buf = k % NUM_STAGES
         phase = (k // NUM_STAGES) & 1
 

--- a/third_party/tlx/tutorials/test_self_attention_autows.py
+++ b/third_party/tlx/tutorials/test_self_attention_autows.py
@@ -29,7 +29,7 @@ Notes:
   are set BEFORE importing the kernel so the constexpr/config pick see them.
 - HSTU_SELF_DP=1: data_partition_factor=2 would need BLOCK_M=256 (each slice
   >=128 TMEM rows) which OOMs TMEM on this kernel, so DP is off here.
-- The TLX self-attn *fwd* uses num_stages=0 and asserts under meta-WS, so it
+- The TLX self-attn *fwd* uses num_stages=1 and asserts under meta-WS, so it
   cannot be compiled in the same (META_WS) process; the accuracy oracle here is
   the torch reference (as in test_cross_attention_bwd_autows.py). The dq-reduce
   config's grads match this torch ref to bf16 precision, i.e. the same numerics

--- a/third_party/tlx/tutorials/test_self_attention_bwd.py
+++ b/third_party/tlx/tutorials/test_self_attention_bwd.py
@@ -2,7 +2,7 @@
 hand-written TLX bwd, and both vs a torch-autograd float causal-SiLU reference.
 
 Runs WITHOUT meta-WS (TRITON_USE_META_WS unset): the TLX self-attn fwd uses
-num_stages=0 and asserts under meta-WS, so this is the process where plain-Triton
+num_stages=1 and asserts under meta-WS, so this is the process where plain-Triton
 and TLX can coexist. (The autoWS variant is a separate process /
 test_self_attention_autows.py.) HSTU_SELF_PIN=1 pins the bwd autotune to one
 config so it compiles fast instead of building the ~29-config bwd space.


### PR DESCRIPTION
Summary:
TLX tutorials, AMD microbenches, a TLX AMD unit test and the AMD global instruction scheduling design doc in the vendored `third-party/triton/beta` tree. These need a matching upstream triton-lang/triton change.

Split out of D114751669 so each GitHub export destination lands as its
own diff. `num_stages=0` has been removed from TLX (AMD included), so the
remaining uses move to `num_stages=1` -- covering the
`triton.Config(..., num_stages=0)` autotune param, the
`tl.range(..., num_stages=0)` loop attribute, and autotune sweeps that
generate a 0 (the 0 is dropped rather than duplicated to 1).

See D114751669 for the full sweep and rationale.

Differential Revision: D114753271


