### PR TITLE
[AMD][gfx950] a4w4 MXFP4 GEMM: four new tiles, LLIR scheduler, host pre-shuffles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,8 +427,14 @@ if(TRITON_BUILD_PYTHON_MODULE)
                   ${PYTHON_SRC_PATH}/passes.cc
                   ${PYTHON_SRC_PATH}/interpreter.cc
                   ${PYTHON_SRC_PATH}/llvm.cc
+                  ${PYTHON_SRC_PATH}/LlirSchedule.cpp
                   ${PYTHON_SRC_PATH}/bitequiv.cc
                   ${PYTHON_SRC_PATH}/specialize.cc)
+  # The native LLIR scheduler uses LLVM value handles (CloneFunction/ValueMap);
+  # LLVM is built -fno-rtti, so match it here to avoid an undefined typeinfo
+  # (llvm::CallbackVH) at load time.
+  set_source_files_properties(${PYTHON_SRC_PATH}/LlirSchedule.cpp
+                              PROPERTIES COMPILE_FLAGS "-fno-rtti")
 
   # Link triton with its dependencies
   target_link_libraries(triton PRIVATE ${TRITON_LIBRARIES})

--- a/include/triton/Tools/Sys/GetEnv.h
+++ b/include/triton/Tools/Sys/GetEnv.h
@@ -38,6 +38,39 @@ inline const std::set<std::string> CACHE_INVALIDATING_ENV_VARS = {
     "TRITON_DISABLE_POST_MISCHED",
     "TRITON_DUMP_MIR",
     "TRITON_ENABLE_LLVM_DEBUG",
+    "TRITON_ENABLE_LLIR_SCHED",
+    "TRITON_LLVM_OPTS",
+    // Tuning knobs for the LLIR scheduler (python/src/LlirSchedule.cpp). They
+    // are read there with plain std::getenv, so without listing them here they
+    // do NOT participate in the cache key: sweeping one of them against a warm
+    // cache silently re-measures the first-compiled binary. That produced a
+    // whole sweep of identical numbers that read as "this knob does nothing".
+    // LLIRSCHED_DEBUG is included for the same reason -- on a cache hit there
+    // is no compilation, so the debug log would simply not appear.
+    "LLIRSCHED_ACC_ROTATE_WIDTH",
+    "LLIRSCHED_DEBUG",
+    "LLIRSCHED_DUMP_IR",
+    "LLIRSCHED_GR_ONLY",
+    "LLIRSCHED_GR_STEAL",
+    "LLIRSCHED_LR_FAIR",
+    "LLIRSCHED_LW_BEFORE",
+    "LLIRSCHED_LW_FIRST",
+    "LLIRSCHED_LW_LAST",
+    "LLIRSCHED_LW_TAIL_STEAL",
+    "LLIRSCHED_MFMA_PER_GR",
+    "LLIRSCHED_MFMA_PER_GRV",
+    "LLIRSCHED_MFMA_PER_LDS",
+    "LLIRSCHED_MFMA_PER_LW_BARRIER",
+    "LLIRSCHED_NO_ACC_ROTATE",
+    "LLIRSCHED_NO_HEAD_PIN",
+    "LLIRSCHED_PIN_OUTSIDE",
+    "LLIRSCHED_WP_DEBUG",
+    "LLIRSCHED_WP_MEMNOP",
+    "LLIRSCHED_WP_NOMAX",
+    "LLIRSCHED_WP_NOOVERCAP",
+    "LLIRSCHED_WP_NOSGB",
+    "LLIRSCHED_WP_PIN",
+    "LLIRSCHED_WP_SGB",
     "TRITON_ENABLE_TTGIR_SCHED",
     "TRITON_TTGIR_SCHED_APPLY",
     "TRITON_TTGIR_SCHED_BARRIER_STRIDE",

--- a/python/src/LlirSchedule.cpp
+++ b/python/src/LlirSchedule.cpp
@@ -1,0 +1,2922 @@
+// ############################################################################
+//  MIT License
+//
+//  Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+// ############################################################################
+
+// Out-of-tree LLVM new-PassManager pass plugin: the gfx950 LLIR scheduler
+// (MFMA <-> memory interleave for GEMM hot loops), ported from AMD-Triton
+// triton-mi450 PR #73 (the sched.barrier variant). Self-contained: depends only
+// on LLVM headers. Load into Triton via LLVM_PASS_PLUGIN_PATH; it auto-inserts
+// at the OptimizerLast extension point of make_llir's optimize_module O3 run.
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/iterator_range.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Plugins/PassPlugin.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+
+#include <cstdlib>
+
+#define DEBUG_TYPE "tritonamdgpu-llir-schedule"
+
+// Inlined from PR#73's TritonAMDGPUToLLVM/MfmaUtility.h so the plugin needs no
+// triton headers.
+namespace mlir::triton::AMD {
+inline bool isMFMAorWMMA(const llvm::Instruction &I) {
+  const auto *CI = llvm::dyn_cast<llvm::CallInst>(&I);
+  if (!CI || CI->isInlineAsm())
+    return false;
+  const llvm::Function *Callee = CI->getCalledFunction();
+  if (!Callee || !Callee->isIntrinsic())
+    return false;
+  llvm::StringRef Name = Callee->getName();
+  return Name.contains("mfma") || Name.contains("wmma");
+}
+} // namespace mlir::triton::AMD
+
+namespace {
+
+using namespace llvm;
+
+// Classification of an instruction for scheduling purposes.
+enum class SchedKind { MFMA, GR, LR, LW, Other };
+
+// LDS resides in address space 3 on AMDGPU.
+constexpr unsigned kLDSAddressSpace = 3;
+
+// Structures used for region analysis/scheduling
+struct AnchorInst {
+  Instruction *I = nullptr;
+  SchedKind Kind = SchedKind::Other;
+};
+
+struct MFMARegionInfo {
+  Instruction *RegionStart = nullptr;
+  unsigned TotalMFMA = 0;
+  // Confined (tlx.sched_region) mode only: the region's exclusive end boundary
+  // (the sched_region_end marker). Without it the last region in a block would
+  // extend to the end of the block (see scheduleBB), so the scheduler would
+  // reorder MFMAs *past* the user's end marker across the rest of the loop.
+  Instruction *RegionEnd = nullptr;
+};
+
+using MFMARegionList = SmallVector<MFMARegionInfo, 8>;
+using BBMFMAAnalysisMap = DenseMap<const BasicBlock *, MFMARegionList>;
+
+struct BBRegion {
+  BasicBlock *BB = nullptr;
+  Instruction *Begin = nullptr; // First instruction in region (inclusive)
+  Instruction *End =
+      nullptr; // First instruction of next region or nullptr (exclusive)
+};
+
+struct MFMARegionCollectResult {
+  // MFMA-input prep instructions to hoist to the region start.
+  SmallVector<Instruction *, 16> Hoist;
+  // MFMA-result users to sink toward the region end.
+  SmallVector<Instruction *, 16> Sink;
+  // Last memory anchor seen while collecting (used to place trailing MFMAs).
+  Instruction *LastAnchor = nullptr;
+  // Memory ops (GR/LR/LW) that the region's MFMAs are spaced around.
+  SmallVector<AnchorInst, 32> Anchors;
+  // The region's MFMA instructions, in program order.
+  SmallVector<Instruction *, 32> MFMAInsts;
+};
+
+// Stateless helpers shared by region analysis and scheduling.
+namespace Utils {
+bool isMFMAorWMMA(const Instruction &I) {
+  // Shared matrix-core predicate (also used by the scalarize-packed-fops
+  // pass). gfx950 only exposes MFMA, but the helper is family-agnostic.
+  return mlir::triton::AMD::isMFMAorWMMA(I);
+}
+
+bool isHoistTransparentInst(const Instruction &I) {
+  return isa<ShuffleVectorInst>(I) || isa<InsertElementInst>(I);
+}
+
+bool isSinkTransparentInst(const Instruction &I) {
+  return isa<ExtractElementInst>(I);
+}
+
+// A GR anchor is either a global load into LDS (buffer.load.lds / async.lds) or
+// one into registers (plain buffer.load). They have opposite slack: the LDS-DMA
+// form is fire-and-forget and consumed a whole iteration later, while the
+// register form feeds an MFMA a few instructions on. Scheduling them alike cost
+// the a4w4 scale loads 3.8 -> 12.1 cy avg under LLIRSCHED_GR_ONLY -- the A/B
+// loads got hoisted around them and took their slack.
+bool isGlobalLoadToRegister(const Instruction *I) {
+  const auto *CI = dyn_cast<CallInst>(I);
+  if (!CI)
+    return false;
+  const Function *F = CI->getCalledFunction();
+  if (!F || !F->isIntrinsic())
+    return false;
+  StringRef N = F->getName();
+  return N.contains("buffer.load") && !N.contains("buffer.load.lds") &&
+         !N.contains("async.lds");
+}
+
+SchedKind classifySchedInst(Instruction &I) {
+  if (isMFMAorWMMA(I))
+    return SchedKind::MFMA;
+
+  if (auto *CI = dyn_cast<CallInst>(&I)) {
+    if (Function *F = CI->getCalledFunction()) {
+      if (F->isIntrinsic()) {
+        StringRef Name = F->getName();
+        // GR: buffer.load (into regs), buffer.load.lds / .async.lds,
+        //     raw.ptr.buffer.store (gmem store from regs)
+        if (Name.contains("buffer.load") ||
+            Name.contains("raw.ptr.buffer.store"))
+          return SchedKind::GR;
+        // LR: ds_read (ds.read.*) or ds_load (ds.load.*)
+        if (Name.contains("ds.read") || Name.contains("ds.load"))
+          return SchedKind::LR;
+      }
+    }
+  }
+
+  // LR: load from LDS (addrspace 3)
+  if (auto *LI = dyn_cast<LoadInst>(&I)) {
+    if (LI->getPointerAddressSpace() == kLDSAddressSpace)
+      return SchedKind::LR;
+  }
+
+  // LW: store to LDS (addrspace 3)
+  if (auto *SI = dyn_cast<StoreInst>(&I)) {
+    if (SI->getPointerAddressSpace() == kLDSAddressSpace)
+      return SchedKind::LW;
+  }
+
+  return SchedKind::Other;
+}
+
+iterator_range<BasicBlock::iterator> instructionsInRegion(const BBRegion &R) {
+  BasicBlock *BB = R.BB;
+  // Begin is now inclusive (region starts at this instruction)
+  auto ItBegin = R.Begin ? R.Begin->getIterator() : BB->begin();
+  auto ItEnd = R.End ? R.End->getIterator() : BB->end();
+  return make_range(ItBegin, ItEnd);
+}
+
+unsigned getMFMACycles(const Instruction &I) {
+  if (!isMFMAorWMMA(I))
+    return 0;
+  const auto *CI = cast<CallInst>(&I);
+  const Function *Callee = CI->getCalledFunction();
+  if (!Callee)
+    return 0;
+  StringRef Name = Callee->getName();
+
+  // Scaled f8f6f4 MFMAs: the cost depends on the operand formats encoded in
+  // cbsz (arg 3) and blgp (arg 4).
+  if (Name.contains("mfma.scale.f32.16x16x128.f8f6f4")) {
+    // both operands f4 -> 16 cycles, otherwise (either operand f8) -> 32.
+    if (auto *CbszC = dyn_cast<ConstantInt>(CI->getArgOperand(3)))
+      if (auto *BlgpC = dyn_cast<ConstantInt>(CI->getArgOperand(4)))
+        return (CbszC->getZExtValue() > 1 && BlgpC->getZExtValue() > 1) ? 16
+                                                                        : 32;
+    return 32; // Fallback if cbsz/blgp are not constants
+  }
+  if (Name.contains("mfma.scale.f32.32x32x64.f8f6f4")) {
+    // both operands f4 -> 32 cycles, otherwise (either operand f8) -> 64.
+    if (auto *CbszC = dyn_cast<ConstantInt>(CI->getArgOperand(3)))
+      if (auto *BlgpC = dyn_cast<ConstantInt>(CI->getArgOperand(4)))
+        return (CbszC->getZExtValue() > 1 && BlgpC->getZExtValue() > 1) ? 32
+                                                                        : 64;
+    return 64; // Fallback if cbsz/blgp are not constants
+  }
+
+  // Fixed-cost MFMAs.
+  static constexpr struct {
+    StringRef Name;
+    unsigned Cycles;
+  } kFixedCycles[] = {
+      {"mfma.f32.16x16x32.f16", 16},  {"mfma.f32.16x16x32.bf16", 16},
+      {"mfma.i32.16x16x64.i8", 16},   {"mfma.f32.32x32x16.f16", 32},
+      {"mfma.f32.32x32x16.bf16", 32}, {"mfma.i32.32x32x32.i8", 32},
+  };
+  for (const auto &Entry : kFixedCycles)
+    if (Name.contains(Entry.Name))
+      return Entry.Cycles;
+
+  // Unknown / unmodeled shape: the scheduler bails on this region and leaves
+  // it to the default LLVM schedulers (such kernels are not perf-critical).
+  return 0;
+}
+
+// Width in bits of the value moved by an LDS-access anchor.
+unsigned getLDSAccessBits(const Instruction *I) {
+  if (const auto *LI = dyn_cast<LoadInst>(I))
+    return LI->getType()->getPrimitiveSizeInBits();
+  if (const auto *SI = dyn_cast<StoreInst>(I))
+    return SI->getValueOperand()->getType()->getPrimitiveSizeInBits();
+  if (const auto *CI = dyn_cast<CallInst>(I))
+    return CI->getType()->getPrimitiveSizeInBits();
+  return 0;
+}
+
+// LDS instruction throughput during steady state, which is proportional to
+// the access bits.
+unsigned getLDSCoverCycles(const Instruction *I, unsigned MFMACycles) {
+  unsigned Bits = getLDSAccessBits(I);
+  return Bits ? (Bits / 8) : MFMACycles;
+}
+
+// True if an s_barrier follows I before Stop (the next anchor). An LDS write
+// that is consumed by a barrier is a LATENCY problem, not a throughput one: the
+// barrier has to wait out the lgkmcnt drain of the write, and getLDSCoverCycles
+// only models the write's issue occupancy. Measured on the a4w4 intra kernel
+// (ATT, 2048x8192x8192): 123 of 128 ds_writes are followed by a stalling
+// s_barrier with 0 or 1 MFMAs in between, costing 2,240 cycles per wave.
+// The LAST LDS write between From (inclusive) and Stop (exclusive). The
+// expensive `s_waitcnt lgkmcnt(0)` is emitted after the last write of a store
+// group, so MFMA cover parked after the FIRST write is separated from the drain
+// by a later write and hides nothing. Measured on a4w4: lgkmcnt-only waits are
+// 89% of all waitcnt stall (4,708 of 5,288 cycles, avg 44cy) while vmcnt waits
+// average 4cy -- so this drain is the one worth covering.
+Instruction *lastLDSWriteBefore(Instruction *From, const Instruction *Stop) {
+  Instruction *Last = From;
+  for (Instruction *P = From->getNextNode(); P && P != Stop;
+       P = P->getNextNode())
+    if (classifySchedInst(*P) == SchedKind::LW)
+      Last = P;
+  return Last;
+}
+
+// NOTE the search must NOT stop at the next anchor: a store group is commonly
+// `LW, LR, ..., s_barrier`, so bounding the scan at Anchors[idx+1] misses the
+// barrier entirely and the cover silently never fires. Scan a bounded window of
+// raw instructions instead.
+Instruction *ldsWriteBarrier(Instruction *I, const Instruction *Stop) {
+  unsigned budget = 64;
+  for (Instruction *P = I->getNextNode(); P && P != Stop && budget--;
+       P = P->getNextNode()) {
+    if (auto *CI = dyn_cast<CallInst>(P))
+      if (const Function *F = CI->getCalledFunction())
+        if (F->getName().contains("amdgcn.s.barrier"))
+          return P;
+  }
+  return nullptr;
+}
+
+// MFMAs to emit at this LDS access under a throughput model: reads and writes
+// share the one LDS issue port, so we carry a running cycle balance across
+// the region's accesses and emit floor(balance / MFMACycles) MFMAs here,
+// keeping the remainder for the next access.
+unsigned takeMFMAsForLDS(const Instruction *I, unsigned MFMACycles,
+                         unsigned &AccumCycles) {
+  AccumCycles += getLDSCoverCycles(I, MFMACycles);
+  unsigned N = AccumCycles / MFMACycles; // floor; carry the remainder
+  AccumCycles -= N * MFMACycles;
+  return N;
+}
+
+// --- tlx.sched_region markers
+// ------------------------------------------------- A user-level scheduling
+// region is delimited by two rocdl.sched.barrier calls carrying reserved
+// sentinel masks (emitted by tlx.sched_region_begin/end). They are NOT real
+// machine-scheduler fences: this pass uses them only to bound where it
+// schedules, then deletes them before codegen. High bit set so they never
+// collide with real sched_barrier masks (small bitfields).
+static constexpr uint32_t kSchedRegionBeginMask = 0xc00u;
+static constexpr uint32_t kSchedRegionEndMask = 0xe00u;
+
+// 0 = not a marker, 1 = region begin, 2 = region end.
+int schedRegionMarkerKind(const Instruction &I) {
+  const auto *CI = dyn_cast<CallInst>(&I);
+  if (!CI)
+    return 0;
+  const Function *F = CI->getCalledFunction();
+  if (!F || !F->getName().contains("amdgcn.sched.barrier"))
+    return 0;
+  if (CI->arg_size() < 1)
+    return 0;
+  if (auto *M = dyn_cast<ConstantInt>(CI->getArgOperand(0))) {
+    uint32_t v = static_cast<uint32_t>(M->getZExtValue());
+    if (v == kSchedRegionBeginMask)
+      return 1;
+    if (v == kSchedRegionEndMask)
+      return 2;
+  }
+  return 0;
+}
+
+bool functionHasSchedRegionMarkers(Function &F) {
+  for (BasicBlock &BB : F)
+    for (Instruction &I : BB)
+      if (schedRegionMarkerKind(I))
+        return true;
+  return false;
+}
+
+// Remove all sched_region markers (called after scheduling so codegen never
+// sees them — they carry no semantics beyond bounding this pass).
+void eraseSchedRegionMarkers(Function &F) {
+  SmallVector<Instruction *, 8> Dead;
+  for (BasicBlock &BB : F)
+    for (Instruction &I : BB)
+      if (schedRegionMarkerKind(I))
+        Dead.push_back(&I);
+  for (Instruction *I : Dead)
+    I->eraseFromParent();
+}
+} // namespace Utils
+
+// Region analysis and scheduling logic grouped into a helper class
+class LLIRScheduler {
+public:
+  explicit LLIRScheduler() = default;
+
+  // Roll a block back to a pre-scheduling snapshot: erase the instructions the
+  // scheduler inserted (the region-comment inline-asm calls and the
+  // llvm.amdgcn.sched.barrier intrinsics, all void with no uses) and restore
+  // the recorded instruction order.
+  static void restoreBlock(BasicBlock &BB,
+                           const SmallVectorImpl<Instruction *> &snapshot) {
+    SmallPtrSet<const Instruction *, 32> orig(snapshot.begin(), snapshot.end());
+    SmallVector<Instruction *, 8> inserted;
+    for (Instruction &I : BB)
+      if (!orig.count(&I))
+        inserted.push_back(&I);
+    for (Instruction *I : inserted) {
+      if (!I->use_empty())
+        I->replaceAllUsesWith(PoisonValue::get(I->getType()));
+      I->eraseFromParent();
+    }
+    for (size_t i = 1; i < snapshot.size(); ++i)
+      snapshot[i]->moveAfter(snapshot[i - 1]);
+  }
+
+  // Schedule every block in the function. Region detection + the per-region
+  // structural invariant make this safe: a block with no eligible MFMA region
+  // is simply left untouched (so no loop-finding heuristic is needed, and an
+  // odd prologue / multiple loops / no loop are all handled uniformly).
+  // Each block is scheduled transactionally: if its schedule fails
+  // verification (e.g. an epilogue the main logic can't safely interleave),
+  // only that block is rolled back, so good blocks keep their schedule.
+  // Returns true if any region was scheduled.
+  bool run(Function &F) {
+    LLVM_DEBUG(dbgs() << "LLIR scheduler analyzing function: " << F.getName()
+                      << "\n");
+    BBMFMAAnalysisMap BBMFMAMap;
+    bool scheduled = false;
+    // If the kernel carries tlx.sched_region markers, confine scheduling to the
+    // marked spans instead of the auto-inferred (MFMA-after-mem) boundaries.
+    const bool ConfineToUserRegions = Utils::functionHasSchedRegionMarkers(F);
+    for (BasicBlock &BB : F) {
+      LLVM_DEBUG(dbgs() << "BB: " << BB.getName() << "\n");
+      analyzeBB(BB, BBMFMAMap, ConfineToUserRegions);
+
+      // Snapshot the block so we can revert just this block on failure.
+      SmallVector<Instruction *, 64> snapshot;
+      for (Instruction &I : BB)
+        snapshot.push_back(&I);
+
+      if (!scheduleBB(BB, BBMFMAMap))
+        continue;
+
+      // Confined mode (opt-in): freeze the hand-written order outside the
+      // marked span so the region barriers we just inserted don't let misched
+      // reschedule the rest of the loop. Off by default now that the region is
+      // properly bounded by the end marker (the transform no longer reorders
+      // outside); enable with LLIRSCHED_PIN_OUTSIDE=1 if misched still perturbs
+      // the outside. Part of this block's transaction, so a verify failure
+      // below rolls these pins back too.
+      if (ConfineToUserRegions && std::getenv("LLIRSCHED_PIN_OUTSIDE"))
+        pinOutsideUserRegions(BB);
+
+      if (verifyFunction(F, nullptr)) {
+        // This block's schedule is invalid; bail gracefully on it alone.
+        if (std::getenv("LLIRSCHED_DEBUG")) {
+          errs() << "[llirsched] BB '" << BB.getName()
+                 << "': verify FAILED -> reverting this block's schedule\n";
+          // Re-run with a stream so the actual violation is visible: a silent
+          // revert looks identical to "the pass did nothing", which is exactly
+          // how a dominance violation here masquerades as a perf regression.
+          verifyFunction(F, &errs());
+        }
+        LLVM_DEBUG(dbgs() << "  reverting unschedulable block " << BB.getName()
+                          << "\n");
+        restoreBlock(BB, snapshot);
+      } else {
+        if (std::getenv("LLIRSCHED_DEBUG"))
+          errs() << "[llirsched] BB '" << BB.getName()
+                 << "': verify PASSED -> schedule kept\n";
+        scheduled = true;
+      }
+    }
+    return scheduled;
+  }
+
+private:
+  // Split a basic block into MFMA regions in a single program-order pass,
+  // recording each region's first MFMA (its RegionStart) and its MFMA count.
+  // A new region opens at every MFMA that follows a memory op (GR/LR/LW) seen
+  // since the region began; by construction an MFMA's input loads land in an
+  // earlier region, so intra-region reordering is dependency-safe.
+  static void analyzeBB(BasicBlock &BB, BBMFMAAnalysisMap &Out,
+                        bool ConfineToUserRegions) {
+    MFMARegionList Regions;
+    unsigned CurRegion = 0;
+    bool SeenMemoryOps = false;
+    bool InRegion = false;
+    // With tlx.sched_region markers present, only schedule MFMAs inside a
+    // begin/end span; MFMAs outside are left untouched (no region formed).
+    bool InsideUserRegion = !ConfineToUserRegions;
+
+    for (Instruction &I : BB) {
+      if (ConfineToUserRegions) {
+        int mk = Utils::schedRegionMarkerKind(I);
+        if (mk == 1) { // region begin: open a fresh span
+          InsideUserRegion = true;
+          InRegion = false;
+          SeenMemoryOps = false;
+          continue;
+        }
+        if (mk == 2) { // region end: close the current region
+          if (InRegion) {
+            // Bound this region at the end marker so the scheduler never
+            // reaches past it (otherwise the last region runs to the end of the
+            // block).
+            Regions[CurRegion].RegionEnd = &I;
+            CurRegion++;
+          }
+          InsideUserRegion = false;
+          InRegion = false;
+          continue;
+        }
+      }
+      SchedKind SK = Utils::classifySchedInst(I);
+      if (SK == SchedKind::GR || SK == SchedKind::LR || SK == SchedKind::LW)
+        SeenMemoryOps = true;
+
+      if (!Utils::isMFMAorWMMA(I))
+        continue;
+      if (!InsideUserRegion)
+        continue; // MFMA outside any user region -> leave it alone
+
+      // This MFMA opens a new region when we are not already in one, or when a
+      // memory op has appeared since the current region's MFMAs began (that op
+      // feeds this MFMA, so it belongs to the next region). Otherwise the MFMA
+      // just extends the current region.
+      bool startNewRegion = !InRegion || SeenMemoryOps;
+      if (startNewRegion) {
+        if (InRegion)
+          CurRegion++; // close the region we were in, open the next
+        InRegion = true;
+        // Memory ops seen *before* a region's first MFMA are that region's own
+        // setup (their data feeds these MFMAs), not a boundary; clear the flag
+        // so they don't spuriously split off the next MFMA.
+        SeenMemoryOps = false;
+        if (CurRegion >= Regions.size())
+          Regions.resize(CurRegion + 1);
+        Regions[CurRegion].RegionStart = &I; // first MFMA is the region start
+      }
+      Regions[CurRegion].TotalMFMA++;
+    }
+
+    if (Regions.empty())
+      return;
+
+    LLVM_DEBUG({
+      for (unsigned i = 0; i < Regions.size(); ++i)
+        dbgs() << "Region " << i << ": total MFMA: " << Regions[i].TotalMFMA
+               << "\n";
+    });
+
+    Out[&BB] = std::move(Regions);
+  }
+
+  static bool feedsMFMA(Instruction *I) {
+    SmallVector<Value *, 8> Worklist;
+    SmallPtrSet<Value *, 16> Visited;
+
+    Worklist.push_back(I);
+
+    while (!Worklist.empty()) {
+      Value *V = Worklist.pop_back_val();
+      if (!Visited.insert(V).second)
+        continue;
+
+      for (User *U : V->users()) {
+        if (auto *UI = dyn_cast<Instruction>(U)) {
+          if (Utils::isMFMAorWMMA(*UI))
+            return true;
+          if (Utils::isHoistTransparentInst(*UI))
+            Worklist.push_back(UI);
+        }
+      }
+    }
+    return false;
+  }
+
+  static bool definedByMFMA(Instruction *I) {
+    SmallVector<Value *, 8> Worklist;
+    SmallPtrSet<Value *, 16> Visited;
+
+    Worklist.push_back(I);
+
+    while (!Worklist.empty()) {
+      Value *V = Worklist.pop_back_val();
+      if (!Visited.insert(V).second)
+        continue;
+
+      if (auto *DefI = dyn_cast<Instruction>(V)) {
+        if (Utils::isMFMAorWMMA(*DefI))
+          return true;
+
+        if (Utils::isSinkTransparentInst(*DefI)) {
+          for (Value *Op : DefI->operands())
+            Worklist.push_back(Op);
+        }
+      }
+    }
+    return false;
+  }
+
+  static MFMARegionCollectResult
+  collectMFMAAndTransparentInstsInRegion(const BBRegion &R) {
+    MFMARegionCollectResult Res;
+
+    // All instructions in this region. Hoisting moves a prep to the region
+    // start (right after R.Begin). That is only safe if the prep's operands are
+    // already available there; if an operand is defined later inside the
+    // region, hoisting the prep above it would use a value before its
+    // definition (an SSA dominance violation / invalid IR). This set lets us
+    // detect that case and leave such preps in place.
+    SmallPtrSet<const Instruction *, 32> RegionInsts;
+    for (Instruction &I : Utils::instructionsInRegion(R))
+      RegionInsts.insert(&I);
+
+    // Preps cleared for hoisting so far (collected in program order). An
+    // operand that is a same-region prep we already hoisted stays ahead of its
+    // use.
+    SmallPtrSet<const Instruction *, 16> Hoisted;
+
+    for (Instruction &I : Utils::instructionsInRegion(R)) {
+      SchedKind K = Utils::classifySchedInst(I);
+      if (K == SchedKind::GR || K == SchedKind::LR || K == SchedKind::LW) {
+        Res.LastAnchor = &I;
+        Res.Anchors.push_back({&I, K});
+        continue;
+      }
+
+      if (K == SchedKind::MFMA) {
+        Res.MFMAInsts.push_back(&I);
+        continue;
+      }
+
+      if (Utils::isHoistTransparentInst(I)) {
+        // Hoisting moves I to right after the region start, so it is safe only
+        // if every operand still dominates that position: operands defined
+        // before the region already do, R.Begin does, and a prep we are also
+        // hoisting keeps its relative order ahead of I. An operand defined
+        // inside the region that we are NOT hoisting — an LR/LW/GR anchor, or a
+        // prep we rejected — would end up after its use, so I must stay put.
+        // This covers both shuffle and insertelement, all anchor kinds, and
+        // multi-hop chains.
+        bool safeToHoist = true;
+        for (Value *Op : I.operands()) {
+          auto *OpI = dyn_cast<Instruction>(Op);
+          if (!OpI || OpI == R.Begin)
+            continue;
+          if (RegionInsts.count(OpI) && !Hoisted.count(OpI)) {
+            safeToHoist = false;
+            break;
+          }
+        }
+        if (safeToHoist && feedsMFMA(&I)) {
+          Res.Hoist.push_back(&I);
+          Hoisted.insert(&I);
+        }
+        continue;
+      }
+
+      if (isa<ExtractElementInst>(I)) {
+        if (definedByMFMA(&I))
+          Res.Sink.push_back(&I);
+      }
+    }
+
+    return Res;
+  }
+
+  static MFMARegionCollectResult
+  preprocessMFMAInstsInRegion(const BBRegion &R) {
+    auto Res = collectMFMAAndTransparentInstsInRegion(R);
+
+    if (Res.Hoist.empty() && Res.Sink.empty())
+      return Res;
+
+    Instruction *HoistPos = R.Begin; // Region start (the region's first MFMA)
+    Instruction *SinkPos = Res.LastAnchor; // last anchor in region
+
+    if (HoistPos)
+      for (Instruction *I : llvm::reverse(Res.Hoist)) {
+        // Don't hoist R.Begin after itself
+        if (I != HoistPos)
+          I->moveAfter(HoistPos);
+      }
+
+    // Sinking needs a trailing anchor to move past. A region with MFMAs but no
+    // GR/LR/LW anchor (LastAnchor stays null) has no valid sink point, so leave
+    // the extractelements in place rather than dereferencing a null insert
+    // position. Such a region carries no anchors, so scheduleMFMAWithSpacing
+    // bails on it anyway.
+    // Sink ALL MFMA-result extractelements to just past the region's last
+    // anchor. This is required, not just opportunistic: it clears them out of
+    // the MFMA run so the subsequent interleaving (which only reorders
+    // instructions before LastAnchor) cannot move an MFMA past one of its own
+    // result extracts. A region with MFMAs but no anchor has no sink point, so
+    // the SinkPos null-guard leaves those extracts in place (scheduleMFMAWith-
+    // Spacing bails on such a region anyway). Any genuinely unsafe sink is
+    // caught by the per-block verifyFunction rollback.
+    if (SinkPos)
+      for (Instruction *I : llvm::reverse(Res.Sink))
+        I->moveAfter(SinkPos);
+
+    return Res;
+  }
+
+  static StringRef schedKindName(SchedKind K) {
+    switch (K) {
+    case SchedKind::GR:
+      return "GR";
+    case SchedKind::LR:
+      return "LR";
+    case SchedKind::LW:
+      return "LW";
+    case SchedKind::MFMA:
+      return "mfma";
+    case SchedKind::Other:
+      return "other";
+    }
+    llvm_unreachable("unknown SchedKind");
+  }
+
+  // Helper: move N MFMAs after InsertPt using moveAfter.
+  // moveAfter naturally produces correct order: each new MFMA goes right
+  // after InsertPt, pushing previous ones further away.
+  // Result: InsertPt, MFMA[N-K], ..., MFMA[N-2], MFMA[N-1]
+  static unsigned moveMFMAsAfter(SmallVectorImpl<Instruction *> &MFMAInsts,
+                                 unsigned &MFMAIdx, unsigned Count,
+                                 Instruction *InsertPt) {
+    unsigned moved = 0;
+    for (unsigned j = 0; j < Count && MFMAIdx > 0; ++j) {
+      MFMAInsts[--MFMAIdx]->moveAfter(InsertPt);
+      moved++;
+    }
+    return moved;
+  }
+
+  // Interleave MFMA with anchor instructions using moveAfter.
+  //
+  // Pure throughput model — every count is "how many MFMAs of compute cover
+  // this memory op's issue-port occupancy needs", never a latency-hiding
+  // reorder:
+  //   - GR (global load): ceil(64 / mfma_cycles) MFMAs (1 if immediately
+  //                       followed by an LR).
+  //   - LR / LW (LDS read/write): floor(carried LDS-cycle balance /
+  //   mfma_cycles)
+  //                       MFMAs. Reads and writes share the one LDS issue port,
+  //                       so both use the same width-proportional pairing.
+  //   - 2 MFMAs drain the tail; any leftover compute (more MFMAs than the
+  //   memory
+  //     ops demand cover for) is split evenly between the region's head and
+  //     tail, with an odd MFMA favoring the head.
+  // Reorder MFMAs to maximise the distance between dependent accumulator
+  // updates.
+  //
+  // Triton's dot lowering emits each accumulator chain contiguously
+  // (tile0_k0, tile0_k1, tile1_k0, tile1_k1, ...), so a dependent pair sits at
+  // distance 1: measured 256 back-to-back dependent MFMA pairs per a4w4 loop
+  // body. A gfx950 16x16x128 fp4 MFMA has 16-cycle latency but issues every 4
+  // cycles, so a distance-1 accumulator dependency exposes ~12 cycles. AITER's
+  // hand-written kernel instead rotates through 32 independent chains
+  // (measured min/median reuse distance 32, zero back-to-back pairs).
+  //
+  // Chains are read off the SSA accumulator def-use edge, so this is exact --
+  // no register information needed. Emitting round-robin across chains keeps
+  // program order inside each chain (the only ordering that is actually
+  // required) while spreading dependent updates NumChains apart.
+  static void
+  reorderMFMAsForAccDistance(SmallVectorImpl<Instruction *> &MFMAInsts) {
+    // OPT-IN ONLY. Measured on the a4w4 intra kernel this is a REGRESSION at
+    // every width tried (2/4/8/full): it removes the back-to-back accumulator
+    // dependencies as intended, but spreading the chains widens the live
+    // operand set, v_accvgpr climbs 51 -> 118..199, and the net is 2% slower at
+    // width 2-4 and 2.5-2.9x slower at full width. Kept, gated off, because the
+    // chain analysis is reusable and the negative result is worth preserving.
+    const char *WidthEnv = std::getenv("LLIRSCHED_ACC_ROTATE_WIDTH");
+    if (!WidthEnv || std::getenv("LLIRSCHED_NO_ACC_ROTATE"))
+      return;
+    unsigned N = MFMAInsts.size();
+    if (N < 8)
+      return;
+
+    // Safety: only reorder when the MFMAs form one contiguous run with no
+    // intervening memory or side-effecting instruction. Then every MFMA's
+    // non-MFMA operands are already available at the first MFMA's position, so
+    // any permutation preserving intra-chain order is legal.
+    for (Instruction *I = MFMAInsts.front(); I && I != MFMAInsts.back();
+         I = I->getNextNode()) {
+      if (Utils::classifySchedInst(*I) == SchedKind::MFMA)
+        continue;
+      if (I->mayReadOrWriteMemory() || I->isTerminator())
+        return;
+    }
+
+    DenseMap<const Instruction *, unsigned> Idx;
+    for (unsigned i = 0; i < N; ++i)
+      Idx[MFMAInsts[i]] = i;
+
+    // An MFMA joins the chain of the earliest MFMA in this region that it
+    // consumes (its accumulator operand); otherwise it starts a new chain.
+    SmallVector<int, 256> Chain(N, -1);
+    int NumChains = 0;
+    for (unsigned i = 0; i < N; ++i) {
+      int C = -1;
+      for (const Use &U : MFMAInsts[i]->operands()) {
+        auto *Op = dyn_cast<Instruction>(U.get());
+        if (!Op)
+          continue;
+        auto It = Idx.find(Op);
+        if (It != Idx.end() && It->second < i) {
+          C = Chain[It->second];
+          break;
+        }
+      }
+      Chain[i] = (C >= 0) ? C : NumChains++;
+    }
+    if (NumChains < 2)
+      return;
+
+    SmallVector<SmallVector<Instruction *, 8>, 64> Buckets(NumChains);
+    for (unsigned i = 0; i < N; ++i)
+      Buckets[Chain[i]].push_back(MFMAInsts[i]);
+
+    // Rotate over a BOUNDED group of chains, not all of them. Full rotation
+    // maximises dependency distance but makes consecutive MFMAs use different
+    // operand slices, so every chain's operands go live at once -- measured:
+    // distance 4->36 but the kernel spilled and ran 2.5-2.9x slower. Only
+    // enough distance to cover the MFMA latency is wanted: a 16-cycle MFMA
+    // issuing every 4 cycles is fully covered at distance 4, so a small group
+    // buys the latency back while keeping the operand working set small.
+    unsigned Width = std::max(1, atoi(WidthEnv));
+    Width = std::min<unsigned>(Width, NumChains);
+
+    SmallVector<Instruction *, 256> Out;
+    for (unsigned Base = 0; Base < (unsigned)NumChains; Base += Width) {
+      unsigned Hi = std::min<unsigned>(Base + Width, NumChains);
+      for (unsigned Round = 0;; ++Round) {
+        bool Any = false;
+        for (unsigned C = Base; C < Hi; ++C)
+          if (Round < Buckets[C].size()) {
+            Out.push_back(Buckets[C][Round]);
+            Any = true;
+          }
+        if (!Any)
+          break;
+      }
+    }
+    assert(Out.size() == N && "round-robin must emit every MFMA exactly once");
+
+    // Relocate into the new order, keeping the run where it already is.
+    Instruction *IP = MFMAInsts.front()->getPrevNode();
+    BasicBlock *BB = MFMAInsts.front()->getParent();
+    for (Instruction *I : Out) {
+      if (IP)
+        I->moveAfter(IP);
+      else
+        I->moveBefore(BB->getFirstInsertionPt());
+      IP = I;
+    }
+    MFMAInsts.assign(Out.begin(), Out.end());
+
+    if (std::getenv("LLIRSCHED_DEBUG"))
+      dbgs() << "[llirsched] acc-rotate: " << N << " MFMA over " << NumChains
+             << " chains -> dependent updates now >= " << NumChains
+             << " apart\n";
+  }
+
+  static void
+  scheduleMFMAWithSpacing(SmallVectorImpl<AnchorInst> &Anchors,
+                          SmallVectorImpl<Instruction *> &MFMAInsts) {
+    if (Anchors.empty() || MFMAInsts.empty())
+      return;
+
+    unsigned mfmaCycles = Utils::getMFMACycles(*MFMAInsts.front());
+    if (mfmaCycles == 0)
+      return;
+    // A global load occupies the global-load path for ~64 cycles, so it needs
+    // 64 cycles of MFMA cover — ceil(64 / mfma_cycles) MFMAs (4 for a 16-cycle
+    // MFMA, 2 for 32-cycle). Same throughput basis as the LDS-access pairing.
+    //
+    // The 64 is a *throughput* figure (how long a load occupies the issue
+    // path), not a latency figure. ATT shows our global loads and LDS reads
+    // stalling (buffer_load 3212 cy, ds_read 6428 cy per wave) where AITER's do
+    // not (268 / 196), i.e. our memory ops are packed too densely for the data
+    // to come back in time. LLIRSCHED_MFMA_PER_GR widens the MFMA cover per
+    // global load so each one gets more slack.
+    unsigned mfmaPerGR = llvm::divideCeil(64, mfmaCycles);
+    if (const char *S = std::getenv("LLIRSCHED_MFMA_PER_GR"))
+      mfmaPerGR = std::max(1, atoi(S));
+    // LLIRSCHED_GR_ONLY=1: anchor on global loads ONLY. LDS reads/writes get no
+    // MFMA cover at all and the whole pool is spread evenly over the global
+    // loads, giving 1GR <n>M 1GR <n>M ...
+    //
+    // The default model funds both, which is right when LDS reads are the thing
+    // stalling. On the a4w4 128x128 kernel after the LDS layout was padded and
+    // the scale round-trip removed, they are not: ATT puts buffer_load_dwordx4
+    // at 18.7% of stall (19.6 cy avg) and ds_read_b128 at 8.6 cy, so an MFMA
+    // spent covering an LDS read is worth less than one spent covering a global
+    // load. This mode lets the caller say so.
+    // Cover for global->register loads specifically. -1 keeps them identical to
+    // the LDS-DMA loads (previous behaviour); 0 stops MFMAs being stacked
+    // behind them, which is what the short-slack scale loads want.
+    int mfmaPerGRV = -1;
+    if (const char *S = std::getenv("LLIRSCHED_MFMA_PER_GRV"))
+      mfmaPerGRV = std::max(0, atoi(S));
+    unsigned grOnly = 0;
+    if (const char *S = std::getenv("LLIRSCHED_GR_ONLY"))
+      grOnly = (unsigned)std::max(0, atoi(S));
+    // Fixed MFMA cover per LDS access, overriding the cycle-ratio model.
+    int mfmaPerLDS = -1;
+    if (const char *S = std::getenv("LLIRSCHED_MFMA_PER_LDS"))
+      mfmaPerLDS = std::max(0, atoi(S));
+    // Minimum MFMA cover for an LDS write whose lgkmcnt(0) drain a following
+    // s_barrier waits on. DEFAULT OFF: measured a REGRESSION on a4w4.
+    // Coverage works (lgkmcnt(0) waits with zero preceding MFMAs: 5 -> 1) but
+    // only ~1 MFMA lands per wait -- the pool is exhausted by GR cover -- and
+    // same-build cold-L2 timing is ~1.6% slower (69.25us -> 70.39us), with ATT
+    // and MfmaUtil (47.6% -> 46.6%) agreeing. Kept, gated off, because the
+    // last-write anchoring and the sched.barrier fence are reusable.
+    unsigned lwBarrierCover = 0;
+    if (const char *S = std::getenv("LLIRSCHED_MFMA_PER_LW_BARRIER"))
+      lwBarrierCover = std::max(0, atoi(S));
+    // EXPERIMENT: split the cover across a two-write store group --
+    // LLIRSCHED_LW_FIRST MFMAs after the FIRST ds_write and LLIRSCHED_LW_LAST
+    // after the LAST one. Hypothesis: the first write's lgkm drain retires
+    // during the bulk of MFMAs, so only the (narrower) second write is still
+    // outstanding when SIInsertWaitcnts' lgkmcnt(0) lands. Overrides the
+    // single-anchor cover above when either is non-zero.
+    unsigned lwFirst = 0, lwLast = 0;
+    if (const char *S = std::getenv("LLIRSCHED_LW_FIRST"))
+      lwFirst = std::max(0, atoi(S));
+    if (const char *S = std::getenv("LLIRSCHED_LW_LAST"))
+      lwLast = std::max(0, atoi(S));
+    // LLIRSCHED_LW_BEFORE=N: put N MFMAs immediately BEFORE the LAST LDS write
+    // of a group, so an earlier write's lgkm drain retires while they run and
+    // only the final write is still outstanding at the s_waitcnt lgkmcnt(0).
+    //   one   LW  ->  N*M  LW
+    //   two   LW  ->  LW  N*M  LW
+    unsigned lwBefore = 0;
+    if (const char *S = std::getenv("LLIRSCHED_LW_BEFORE"))
+      lwBefore = std::max(0, atoi(S));
+    // LLIRSCHED_GR_STEAL=N: drop the first N global loads from 1:mfmaPerGR to
+    // 1:(mfmaPerGR-1), freeing N MFMAs, and add them to the LW budget. This is
+    // the only way to fund an LW in an oversubscribed region: region 0 needs
+    // 14GRx4 + 9 lds + 2 = 67 of 64, so leftover==0 and the write gets nothing
+    // even though the reads are fully covered.
+    unsigned grSteal = 0;
+    if (const char *S = std::getenv("LLIRSCHED_GR_STEAL"))
+      grSteal = std::max(0, atoi(S));
+    // LLIRSCHED_LR_FAIR=N: give EVERY LDS read at least N MFMAs (uniform), and
+    // hand whatever is left to the LDS write. Replaces the cycle-ratio model,
+    // whose floor(bytes/mfmaCycles) starves narrow/late anchors: the reverse
+    // walk spends the pool on the last anchors first, so in region 0 the
+    // earliest 3 reads got ZERO and emitted as a `3LR` clump.
+    unsigned lrFair = 0;
+    if (const char *S = std::getenv("LLIRSCHED_LR_FAIR"))
+      lrFair = std::max(0, atoi(S));
+    // LLIRSCHED_LW_TAIL_STEAL=N: when a region has no leftover, borrow up to N
+    // MFMAs from the 2-MFMA tail drain and give them to the LW instead. In an
+    // oversubscribed region (e.g. region 0: 14GRx4 + 9 lds + 2 = 67 > 64) the
+    // tail drain is the only reclaimable slack -- it shows up as the last
+    // anchor getting `1GR 6M` (4 cover + 2 drain) while the write gets nothing.
+    unsigned lwTailSteal = 0;
+    if (const char *S = std::getenv("LLIRSCHED_LW_TAIL_STEAL"))
+      lwTailSteal = std::max(0, atoi(S));
+
+    unsigned MFMAIdx = MFMAInsts.size();
+    unsigned Total = MFMAIdx;
+
+    // Count anchors by kind. ldsBudget is the total MFMA cover the region's LDS
+    // accesses demand, floor(sum(cycles_per_access) / mfma_cycles) — the
+    // throughput ratio over reads *and* writes alike, so cheap accesses share
+    // an MFMA and wide ones draw several.
+    unsigned numGR = 0, numGRBeforeLR = 0, totalLDSCycles = 0;
+    for (size_t j = 0; j < Anchors.size(); ++j) {
+      if (Anchors[j].Kind == SchedKind::GR) {
+        numGR++;
+        if (j + 1 < Anchors.size() && Anchors[j + 1].Kind == SchedKind::LR)
+          numGRBeforeLR++;
+      } else if (Anchors[j].Kind == SchedKind::LR ||
+                 Anchors[j].Kind == SchedKind::LW) {
+        totalLDSCycles += Utils::getLDSCoverCycles(Anchors[j].I, mfmaCycles);
+      }
+    }
+    unsigned ldsBudget = totalLDSCycles / mfmaCycles;
+
+    // gfx950 scheduling:
+    //   GR: mfmaPerGR MFMAs each (except GR→LR gets 1)
+    //   LR/LW: cycle-paired at the true throughput ratio (takeMFMAsForLDS) —
+    //          cheap accesses share an MFMA, wide ones draw several
+    //   2 MFMAs drain the end; leftover compute is split evenly head/tail
+    // In GR-only mode every global load is covered equally and nothing else is
+    // funded, so the pool divides straight across the global loads.
+    unsigned grOnlyPerGR = (grOnly && numGR) ? Total / numGR : 0;
+    unsigned grBudget =
+        grOnly ? grOnlyPerGR * numGR : mfmaPerGR * (numGR - numGRBeforeLR);
+    unsigned needed =
+        grOnly ? grBudget : grBudget + numGRBeforeLR + ldsBudget + 2;
+    unsigned leftover = (Total > needed) ? Total - needed : 0;
+
+    // Surplus compute (more MFMAs than the memory ops need cover for) is split
+    // evenly between the region's head and tail; an odd MFMA favors the head.
+    unsigned tailLeftover = leftover / 2;            // floor → tail
+    unsigned headLeftover = leftover - tailLeftover; // ceil → head
+
+    LLVM_DEBUG(dbgs() << "  MFMA budget: total=" << Total
+                      << ", needed=" << needed << ", leftover=" << leftover
+                      << " (head=" << headLeftover << ", tail=" << tailLeftover
+                      << ")\n");
+
+    // The 2-MFMA tail drain plus the tail's share of the surplus. The head's
+    // share is whatever stays unmoved at the front after the reverse walk.
+    unsigned tailDrain = 2 + tailLeftover;
+    unsigned stolen = 0;
+    if (lwBefore > 0 && lwTailSteal > 0 && leftover == 0) {
+      stolen = std::min<unsigned>(lwTailSteal, tailDrain);
+      tailDrain -= stolen;
+    }
+    unsigned MFMAAtEnd =
+        moveMFMAsAfter(MFMAInsts, MFMAIdx, tailDrain, Anchors.back().I);
+    // Running LDS-cycle balance carried across the region's LDS accesses (LR
+    // and LW, processed in reverse) so the MFMA:access pairing follows the true
+    // throughput ratio.
+    // Only rob the global loads when the region cannot fund the LW from its
+    // own slack (region 0/2: leftover==0). Regions 1/3 have leftover 16 and
+    // must be left alone -- their GR cover is already paid for.
+    unsigned grStolen = (lwBefore > leftover) ? grSteal : 0;
+
+    // Fair-share plan: split the MFMAs that are not owed to the global loads or
+    // the tail drain evenly across the LDS reads, remainder to the write.
+    unsigned numLR = 0;
+    for (const AnchorInst &A : Anchors)
+      if (A.Kind == SchedKind::LR)
+        numLR++;
+    unsigned fairPerLR = 0, fairRemainder = 0;
+    if (lrFair > 0 && numLR > 0) {
+      unsigned grDemand = mfmaPerGR * (numGR - numGRBeforeLR) + numGRBeforeLR;
+      grDemand -= std::min<unsigned>(grStolen, grDemand);
+      unsigned reserved = grDemand + 2 + tailLeftover;
+      unsigned ldsPool = (Total > reserved) ? Total - reserved : 0;
+      fairPerLR = std::min<unsigned>(lrFair, ldsPool / numLR);
+      fairRemainder = ldsPool - fairPerLR * numLR;
+    }
+    // Program-order ordinal of each GR anchor, so "the first N GRs" is
+    // well defined even though the walk below runs in reverse.
+    SmallVector<int, 32> grOrdinal(Anchors.size(), -1);
+    {
+      int n = 0;
+      for (size_t j = 0; j < Anchors.size(); ++j)
+        if (Anchors[j].Kind == SchedKind::GR)
+          grOrdinal[j] = n++;
+    }
+    unsigned ldsAccum = 0;
+    Instruction *PendingLWBarrier = nullptr;
+    DenseMap<SchedKind, unsigned> MFMAPerAnchorKind;
+
+    for (int i = static_cast<int>(Anchors.size()) - 1; i >= 0 && MFMAIdx > 0;
+         --i) {
+      size_t idx = static_cast<size_t>(i);
+      Instruction *InsertPt = Anchors[idx].I;
+      SchedKind Kind = Anchors[idx].Kind;
+
+      unsigned Count = 0;
+      bool grToReg =
+          (Kind == SchedKind::GR) && Utils::isGlobalLoadToRegister(InsertPt);
+      if (grToReg && mfmaPerGRV >= 0) {
+        Count = (unsigned)mfmaPerGRV;
+      } else if (grOnly) {
+        // Global loads only; LDS accesses are deliberately left bare.
+        Count = (Kind == SchedKind::GR) ? grOnlyPerGR : 0;
+      } else if (Kind == SchedKind::LR || Kind == SchedKind::LW) {
+        // Cycle model: emit floor(balance / mfma_cycles) MFMAs, carrying the
+        // remainder — cheap accesses share an MFMA, wide ones draw several.
+        // Reads and writes use the same shared LDS-cycle balance.
+        Count = mfmaPerLDS >= 0 ? (unsigned)mfmaPerLDS
+                                : Utils::takeMFMAsForLDS(Anchors[idx].I,
+                                                         mfmaCycles, ldsAccum);
+        if (lrFair > 0 && Kind == SchedKind::LR)
+          Count = fairPerLR;
+        // Latency top-up: a ds_write consumed by an s_barrier costs the barrier
+        // an lgkmcnt drain, which the byte-throughput model above does not see.
+        // A ds_write_b64 is 8 bytes -> 8 cycles -> floor(8/16) = 0 MFMAs, so
+        // nothing is scheduled to hide the drain at all. Give those writes real
+        // cover.
+        // PATTERN MATCH on a two-write group: `LW LW`. Only then split the
+        // cover 7/1. An ISOLATED write must be left alone -- region 0 has a
+        // single LW and only ~7 MFMAs left in the pool at that point, so
+        // covering it consumed everything and starved the 8 leading ds_reads
+        // that the default schedule was covering 1M:1LR. That starvation, not
+        // the write cover itself, is what regressed the kernel.
+        bool lwPairFirst = Kind == SchedKind::LW && idx + 1 < Anchors.size() &&
+                           Anchors[idx + 1].Kind == SchedKind::LW;
+        bool lwPairSecond = Kind == SchedKind::LW && idx > 0 &&
+                            Anchors[idx - 1].Kind == SchedKind::LW;
+        if (Kind == SchedKind::LW && lwBefore > 0) {
+          // Never steal cover from the LDS reads / global loads: take at most
+          // the region's spare MFMAs. Region 0 is oversubscribed (14GRx4 + 10
+          // LDS > 64) so leftover==0 and this becomes a no-op there, which is
+          // what kept starving the 8 leading ds_reads. Region 1 has ~15 spare.
+          unsigned lwBudget =
+              lrFair > 0 ? fairRemainder
+                         : std::min<unsigned>(lwBefore, leftover + grStolen);
+          if (lwPairFirst) {
+            // two writes: the 10 land after this (first) write == before the
+            // last one.  LW 10M LW
+            Count = std::max(Count, lwBudget);
+          } else if (!lwPairSecond && idx > 0 && lwBudget > 0) {
+            // single write: park them after the PREVIOUS anchor so they land
+            // before this write.  10M LW
+            moveMFMAsAfter(MFMAInsts, MFMAIdx, lwBudget, Anchors[idx - 1].I);
+          }
+          if (std::getenv("LLIRSCHED_DEBUG"))
+            errs() << "[llirsched]   LW idx=" << idx
+                   << (lwPairFirst    ? " PAIR-FIRST(10 after=before last)"
+                       : lwPairSecond ? " PAIR-SECOND(skip)"
+                                      : " SINGLE(10 before)")
+                   << " count=" << Count << " budget=" << lwBudget
+                   << " leftover=" << leftover << " poolLeft=" << MFMAIdx
+                   << "\n";
+        } else if (Kind == SchedKind::LW && (lwFirst > 0 || lwLast > 0)) {
+          // split mode: pair members only, isolated writes untouched
+          if (lwPairFirst)
+            Count = std::max(Count, lwFirst);
+          else if (lwPairSecond)
+            Count = std::max(Count, lwLast);
+          if (std::getenv("LLIRSCHED_DEBUG"))
+            errs() << "[llirsched]   LW idx=" << idx
+                   << (lwPairFirst    ? " PAIR-FIRST"
+                       : lwPairSecond ? " PAIR-SECOND"
+                                      : " isolated(skip)")
+                   << " count=" << Count << " poolLeft=" << MFMAIdx << "\n";
+        } else if (Kind == SchedKind::LW && lwBarrierCover > 0) {
+          // Scan past following anchors (bounded inside ldsWriteBarrier) --
+          // the barrier that drains this write usually sits after the next
+          // LDS read, not before it.
+          const Instruction *Stop = nullptr;
+          PendingLWBarrier = Utils::ldsWriteBarrier(Anchors[idx].I, Stop);
+          if (std::getenv("LLIRSCHED_DEBUG"))
+            errs() << "[llirsched]   LW anchor idx=" << idx
+                   << " barrier=" << (PendingLWBarrier ? "FOUND" : "not found")
+                   << " poolLeft=" << MFMAIdx << " baseCount=" << Count << "\n";
+          if (PendingLWBarrier) {
+            Instruction *LastW =
+                Utils::lastLDSWriteBefore(Anchors[idx].I, PendingLWBarrier);
+            if (lwFirst > 0 || lwLast > 0) {
+              // Split mode: emit the tail group after the LAST write first
+              // (reverse-walk convention), then the bulk after this anchor.
+              if (lwLast > 0 && LastW != Anchors[idx].I)
+                moveMFMAsAfter(MFMAInsts, MFMAIdx, lwLast, LastW);
+              Count = std::max(Count, lwFirst);
+              // InsertPt stays on the FIRST write (this anchor).
+            } else {
+              Count = std::max(Count, lwBarrierCover);
+              InsertPt = LastW;
+            }
+          }
+        }
+      } else if (Kind == SchedKind::GR) {
+        bool followedByLR = (idx + 1 < Anchors.size() &&
+                             Anchors[idx + 1].Kind == SchedKind::LR);
+        Count = followedByLR ? 1 : mfmaPerGR;
+        // first `grSteal` global loads give up one MFMA each, funding the LW
+        if (grStolen > 0 && !followedByLR && grOrdinal[idx] >= 0 &&
+            (unsigned)grOrdinal[idx] < grStolen && Count > 1)
+          Count -= 1;
+      }
+
+      [[maybe_unused]] unsigned moved =
+          moveMFMAsAfter(MFMAInsts, MFMAIdx, Count, InsertPt);
+      LLVM_DEBUG(MFMAPerAnchorKind[Kind] += moved);
+
+      // Fence the MFMAs we just parked between an LDS write and the s_barrier
+      // it feeds. Without this the machine scheduler sinks them PAST the
+      // barrier (measured: 4 requested, only 1 stayed ahead of the
+      // s_waitcnt lgkmcnt(0)), which defeats the whole point -- an s_barrier
+      // is not a scheduling fence for independent MFMA work.
+      if (PendingLWBarrier && moved > 0) {
+        IRBuilder<> B(PendingLWBarrier->getContext());
+        B.SetInsertPoint(PendingLWBarrier);
+        B.CreateIntrinsic(Intrinsic::amdgcn_sched_barrier, {B.getInt32(0)});
+      }
+      PendingLWBarrier = nullptr;
+    }
+
+    LLVM_DEBUG({
+      dbgs() << "  MFMA insertion summary: total=" << Total
+             << ", at_front=" << MFMAIdx << ", at_end=" << MFMAAtEnd;
+      for (auto &KV : MFMAPerAnchorKind) {
+        dbgs() << ", after_" << schedKindName(KV.first) << "=" << KV.second;
+      }
+      dbgs() << "\n";
+    });
+  }
+
+  // Insert an inline asm comment before the given instruction.
+  // Emit a non-side-effecting inline-asm comment (a pure annotation, NOT a
+  // reorder barrier). The sched.barriers we emit at anchors -- not these region
+  // markers -- pin the schedule, so the markers must stay side-effect-free to
+  // avoid adding scheduling constraints of their own.
+  static void insertAsmComment(Instruction *IP, const std::string &Comment) {
+    LLVMContext &Ctx = IP->getContext();
+    IRBuilder<> Builder(Ctx);
+    Builder.SetInsertPoint(IP);
+    FunctionType *FTy = FunctionType::get(Type::getVoidTy(Ctx), false);
+    InlineAsm *IA =
+        InlineAsm::get(FTy, ";; " + Comment, "", /*hasSideEffects=*/false);
+    Builder.CreateCall(IA);
+  }
+
+  // Insert llvm.amdgcn.sched.barrier(Mask) immediately after AfterI so the pre-
+  // and post-RA machine schedulers cannot move instructions across this anchor.
+  // Mask bits name the instruction classes allowed to cross; 0 is a full
+  // barrier.
+  static void insertSchedBarrier(Instruction *AfterI, uint32_t Mask) {
+    Instruction *Next = AfterI->getNextNode();
+    if (!Next)
+      return; // anchors are never terminators, but be defensive
+    IRBuilder<> Builder(AfterI->getContext());
+    Builder.SetInsertPoint(Next);
+    Builder.CreateIntrinsic(Intrinsic::amdgcn_sched_barrier,
+                            {Builder.getInt32(Mask)});
+  }
+
+  // Debug: print a region's MFMA/anchor sequence in program order, run-length
+  // compressed (e.g. "64M 1LR 1LW 4GR"). Gated by LLIRSCHED_DEBUG. Used to see
+  // the interleave before vs after scheduleMFMAWithSpacing.
+  static void debugPrintRegion(const BBRegion &R, unsigned idx,
+                               const char *tag) {
+    if (!std::getenv("LLIRSCHED_DEBUG"))
+      return;
+    errs() << "[llirsched] region " << idx << " " << tag << ":";
+    SchedKind RunKind = SchedKind::Other;
+    unsigned RunCount = 0;
+    auto flush = [&]() {
+      if (RunCount == 0)
+        return;
+      const char *n = RunKind == SchedKind::MFMA ? "M"
+                      : RunKind == SchedKind::GR ? "GR"
+                      : RunKind == SchedKind::LR ? "LR"
+                      : RunKind == SchedKind::LW ? "LW"
+                                                 : "?";
+      errs() << " " << RunCount << n;
+    };
+    for (Instruction &I : Utils::instructionsInRegion(R)) {
+      SchedKind K = Utils::classifySchedInst(I);
+      if (K != SchedKind::MFMA && K != SchedKind::GR && K != SchedKind::LR &&
+          K != SchedKind::LW)
+        continue;
+      if (K == RunKind) {
+        RunCount++;
+      } else {
+        flush();
+        RunKind = K;
+        RunCount = 1;
+      }
+    }
+    flush();
+    errs() << "\n";
+  }
+
+  static bool scheduleBB(BasicBlock &BB, const BBMFMAAnalysisMap &Analysis) {
+    auto It = Analysis.find(&BB);
+    if (It == Analysis.end())
+      return false;
+
+    const MFMARegionList &Regions = It->second;
+
+    unsigned NumRegions = Regions.size();
+    unsigned ScheduledRegionIdx = 0;
+
+    if (std::getenv("LLIRSCHED_DEBUG")) {
+      errs() << "[llirsched] BB '" << BB.getName()
+             << "': NumRegions=" << NumRegions << "\n";
+      for (unsigned i = 0; i < NumRegions; ++i)
+        errs() << "[llirsched]   region " << i
+               << ": TotalMFMA=" << Regions[i].TotalMFMA
+               << " hasRegionStart=" << (Regions[i].RegionStart != nullptr)
+               << " hasRegionEnd(marker)=" << (Regions[i].RegionEnd != nullptr)
+               << "\n";
+    }
+
+    for (unsigned i = 0; i < NumRegions; ++i) {
+      const MFMARegionInfo &R = Regions[i];
+      if (!R.RegionStart)
+        continue;
+
+      if (R.TotalMFMA != 0) {
+        BBRegion bbR;
+        bbR.BB = &BB;
+        bbR.Begin = Regions[i].RegionStart;
+        // Prefer the user's sched_region_end marker (confined mode); otherwise
+        // the next region's start, or the end of the block for the last region.
+        bbR.End =
+            Regions[i].RegionEnd
+                ? Regions[i].RegionEnd
+                : ((i + 1 < NumRegions) ? Regions[i + 1].RegionStart : nullptr);
+
+        // Schedulability check, performed BEFORE any mutation: bail on a region
+        // whose MFMA shape we don't model (getMFMACycles == 0) or that has no
+        // memory anchor to interleave the MFMAs against. Skipping here --
+        // before preprocessMFMAInstsInRegion moves anything -- ensures the pass
+        // only schedules (and sched.barrier-pins) regions it actually models,
+        // and only reports success (which gates the AGPR-form flags) for those;
+        // unmodeled regions are left to the default LLVM schedulers.
+        unsigned MFMACycles = 0;
+        bool SeenMFMA = false, HasAnchor = false;
+        for (Instruction &I : Utils::instructionsInRegion(bbR)) {
+          SchedKind K = Utils::classifySchedInst(I);
+          if (K == SchedKind::GR || K == SchedKind::LR || K == SchedKind::LW)
+            HasAnchor = true;
+          else if (K == SchedKind::MFMA && !SeenMFMA) {
+            SeenMFMA = true;
+            MFMACycles = Utils::getMFMACycles(I);
+          }
+        }
+        if (MFMACycles == 0 || !HasAnchor)
+          continue;
+
+        MFMARegionCollectResult Res = preprocessMFMAInstsInRegion(bbR);
+
+        // --- Build region comment ---
+        std::string Comment;
+        raw_string_ostream OS(Comment);
+
+        // Count anchors by kind
+        unsigned numGR = 0, numLR = 0, numLW = 0;
+        for (auto &A : Res.Anchors) {
+          if (A.Kind == SchedKind::GR)
+            numGR++;
+          else if (A.Kind == SchedKind::LR)
+            numLR++;
+          else if (A.Kind == SchedKind::LW)
+            numLW++;
+        }
+        OS << "Region " << ScheduledRegionIdx << ": " << Res.MFMAInsts.size()
+           << " mfma, " << numGR << " GR, " << numLR << " LR, " << numLW
+           << " LW";
+        ScheduledRegionIdx++;
+
+        insertAsmComment(bbR.Begin, Comment);
+
+        LLVM_DEBUG({
+          dbgs() << "Cluster " << i << " structure:";
+          SchedKind RunKind = SchedKind::Other;
+          unsigned RunCount = 0;
+          for (Instruction &Inst : Utils::instructionsInRegion(bbR)) {
+            SchedKind K = Utils::classifySchedInst(Inst);
+            if (K != SchedKind::MFMA && K != SchedKind::GR &&
+                K != SchedKind::LR && K != SchedKind::LW)
+              continue;
+            if (K == RunKind) {
+              RunCount++;
+            } else {
+              if (RunCount > 0)
+                dbgs() << " " << RunCount << " " << schedKindName(RunKind);
+              RunKind = K;
+              RunCount = 1;
+            }
+          }
+          if (RunCount > 0)
+            dbgs() << " " << RunCount << " " << schedKindName(RunKind);
+          dbgs() << "\n";
+        });
+
+        debugPrintRegion(bbR, ScheduledRegionIdx - 1, "BEFORE");
+        // bbR.Begin points at the region's FIRST MFMA. moveMFMAsAfter consumes
+        // MFMAInsts from the end, so MFMAInsts[0] -- i.e. Begin -- is relocated
+        // whenever the pool is fully drained (true for any oversubscribed
+        // region). Begin then follows it into the middle of the region and the
+        // AFTER dump silently starts mid-region, hiding every anchor above it.
+        // That is why region 0 printed a clean `1M 1LR 1M 1LR ...` while the
+        // asm actually had `4R` clumped at the head, and why its BEFORE/AFTER
+        // ds_read counts disagreed (9 vs 6).
+        //
+        // Anchor to the instruction BEFORE the region instead: nothing in this
+        // region can move above it (moveMFMAsAfter only inserts after anchors,
+        // all of which are inside), so it is a stable landmark.
+        Instruction *PrevOfRegion = bbR.Begin->getPrevNode();
+        reorderMFMAsForAccDistance(Res.MFMAInsts);
+        scheduleMFMAWithSpacing(Res.Anchors, Res.MFMAInsts);
+        bbR.Begin = PrevOfRegion ? PrevOfRegion->getNextNode() : &BB.front();
+        debugPrintRegion(bbR, ScheduledRegionIdx - 1, "AFTER ");
+
+        // Pin this region's schedule with a full sched.barrier (mask 0) after
+        // each memory anchor, so LLVM's pre- and post-RA machine schedulers
+        // preserve the MFMA<->mem interleave. This keeps misched enabled for
+        // the rest of the function -- prologue/epilogue and any region the pass
+        // bailed on still get machine-scheduled -- so no global misched-disable
+        // is needed.
+        for (const AnchorInst &A : Res.Anchors)
+          insertSchedBarrier(A.I, /*Mask=*/0);
+
+        // Pin the region HEAD as well. Anchor pins only fence *after* each
+        // anchor, so everything above the first pin -- including the region's
+        // leading MFMA -- is unfenced, and the machine scheduler hoists
+        // long-latency ds_reads up into it. Measured on a4w4 region 0: the IR
+        // interleave `1M 1LR 1M 1LR ...` came out as `4R 1M 1R 1M 1R ...` in
+        // the asm, i.e. 4 reads clumped at the head. Gated so it can be
+        // A/B'd.
+        if (!std::getenv("LLIRSCHED_NO_HEAD_PIN")) {
+          if (Instruction *Prev = bbR.Begin->getPrevNode())
+            insertSchedBarrier(Prev, /*Mask=*/0);
+        }
+      }
+    }
+    return ScheduledRegionIdx > 0;
+  }
+
+  // Confined (tlx.sched_region) mode only: make the pass a true no-op OUTSIDE
+  // the marked span. The region sched.barriers we insert split LLVM's per-block
+  // misched scheduling region in two; misched then freely reschedules the code
+  // *outside* the markers into a different (usually worse) order -- so a marker
+  // that should only touch its own span ends up perturbing the whole loop. Pin
+  // every memory/MFMA anchor outside the user region with a full sched.barrier,
+  // WITHOUT reordering it, so misched preserves the as-written (hand-tuned)
+  // order there. In-region anchors are skipped (scheduleBB already pinned
+  // them). Returns true if it pinned anything.
+  static bool pinOutsideUserRegions(BasicBlock &BB) {
+    SmallVector<Instruction *, 64> outsideAnchors;
+    bool insideUserRegion = false;
+    for (Instruction &I : BB) {
+      int mk = Utils::schedRegionMarkerKind(I);
+      if (mk == 1) {
+        insideUserRegion = true;
+        continue;
+      }
+      if (mk == 2) {
+        insideUserRegion = false;
+        continue;
+      }
+      if (insideUserRegion)
+        continue;
+      SchedKind K = Utils::classifySchedInst(I);
+      bool isAnchor = (K == SchedKind::GR || K == SchedKind::LR ||
+                       K == SchedKind::LW || Utils::isMFMAorWMMA(I));
+      if (isAnchor)
+        outsideAnchors.push_back(&I);
+    }
+    for (Instruction *A : outsideAnchors)
+      insertSchedBarrier(A, /*Mask=*/0);
+    return !outsideAnchors.empty();
+  }
+};
+
+// ===========================================================================
+// warp_pipeline (Flash-Attention) region analysis.
+//
+// Unlike the GEMM path (regions inferred from "MFMA after a memory op"), a
+// warp-pipeline kernel already carries its cluster boundaries:
+// ConvertWarpPipeline lowers each stage boundary to
+// llvm.amdgcn.sched.barrier(i32 0). So here a region is simply the instruction
+// span between two sched.barriers, and the compute (MFMA) stages are the
+// regions that contain MFMAs.
+//
+// This first cut only DETECTS regions, checks MFMA<->VALU independence, and
+// histograms mfma / valu — no reordering yet. Enable prints with
+// LLIRSCHED_WP_DEBUG=1.
+// ===========================================================================
+// ===========================================================================
+// Which scheduling model a region wants
+// ===========================================================================
+// This plugin carries TWO independent models, and the choice is a property of
+// what a region CONTAINS, not of which kernel it came from:
+//
+//   mfma + memory (ds_read/ds_write/buffer_load), no valu
+//       -> THROUGHPUT model: pair each memory op with as many mfmas as its
+//          bandwidth needs (`Utils::takeMFMAsForLDS`, the `LLIRScheduler`
+//          path). Typical of intra-wave GEMM, where the loop hides LDS latency.
+//
+//   mfma + valu, no memory
+//       -> CO-EXEC model: fill each mfma's 24-cycle shadow with co-issuable
+//       VALU
+//          and declare it with sched_group_barrier (this namespace). Typical of
+//          inter-wave Flash-Attention, whose DOT clusters are register-only --
+//          `TRITON_WP_DEBUG` confirms the FA dot stages have zero LDS effects.
+//
+//   mfma + valu + memory
+//       -> NOT HANDLED. Intra-wave FA would land here. The two models disagree
+//          about what an mfma is for (covering VALU issue vs covering memory
+//          latency), so such a region is skipped rather than fed to a model
+//          whose assumptions it breaks. Revisit when that kernel exists.
+//
+//   no mfma
+//       -> nothing to schedule around. FA's mem stages are this case (they
+//       carry
+//          LDS + global traffic but no mfma), which is why the co-exec model
+//          never sees them; `LLIRSCHED_WP_MEMNOP` paces them separately.
+//
+// Inter-wave GEMM needs no scheduling at all and simply produces no qualifying
+// region.
+namespace WP {
+
+// The sched.barrier(i32 0) intrinsic marking a warp-pipeline cluster boundary.
+static bool isSchedBarrier(const Instruction &I) {
+  // tlx.sched_region sentinels are region markers, not warp-pipeline cluster
+  // boundaries -- don't let them flip a kernel onto the WP (CoExec) path.
+  if (Utils::schedRegionMarkerKind(I))
+    return false;
+  if (const auto *CI = dyn_cast<CallInst>(&I))
+    if (const Function *F = CI->getCalledFunction())
+      return F->getName().contains("amdgcn.sched.barrier");
+  return false;
+}
+
+// A function is a warp-pipeline kernel iff it already contains sched.barriers
+// (the GEMM path has none before this plugin runs). This only decides *where
+// the region boundaries come from* -- which model each region then gets is
+// decided by classifyRegion() below, per region.
+static bool isWarpPipelineFunc(Function &F) {
+  for (BasicBlock &BB : F)
+    for (Instruction &I : BB)
+      if (isSchedBarrier(I))
+        return true;
+  return false;
+}
+
+enum class RegionModel { None, Throughput, CoExec, Mixed };
+
+// Defined below, once the cost model it belongs to is in scope.
+static int valuWeight(const Instruction &I);
+
+// What does this region contain? Counts are returned so the caller can log
+// them.
+static RegionModel classifyRegion(Instruction *Begin, BasicBlock::iterator End,
+                                  int &numMfma, int &numValu, int &numMem) {
+  numMfma = numValu = numMem = 0;
+  for (auto It = Begin->getIterator(); It != End; ++It) {
+    Instruction &I = *It;
+    if (Utils::isMFMAorWMMA(I)) {
+      ++numMfma;
+      continue;
+    }
+    // Reuse the throughput model's own classifier so the two paths cannot
+    // disagree about what counts as memory: GR = buffer/global, LR/LW = LDS
+    // read/write.
+    SchedKind K = Utils::classifySchedInst(I);
+    if (K == SchedKind::GR || K == SchedKind::LR || K == SchedKind::LW) {
+      ++numMem;
+      continue;
+    }
+    if (valuWeight(I) > 0)
+      ++numValu;
+  }
+  if (numMfma == 0)
+    return RegionModel::None;
+  if (numMem > 0)
+    return numValu > 0 ? RegionModel::Mixed : RegionModel::Throughput;
+  return numValu > 0 ? RegionModel::CoExec : RegionModel::None;
+}
+
+static const char *modelName(RegionModel M) {
+  switch (M) {
+  case RegionModel::None:
+    return "no-mfma";
+  case RegionModel::Throughput:
+    return "mfma+mem -> THROUGHPUT model";
+  case RegionModel::CoExec:
+    return "mfma+valu -> CO-EXEC model";
+  case RegionModel::Mixed:
+    return "mfma+valu+mem -> MIXED (not handled)";
+  }
+  return "?";
+}
+
+// Transcendental (v_exp/v_rcp/...): never co-issues with MFMA -- kept separate
+// from plain VALU (matches the hardware isNeverCoissue rule).
+static bool isTransCompute(const Instruction &I) {
+  if (const auto *CI = dyn_cast<CallInst>(&I))
+    if (const Function *F = CI->getCalledFunction())
+      if (F->isIntrinsic()) {
+        StringRef N = F->getName();
+        return N.contains("exp2") || N.contains("exp.") || N.contains("log2") ||
+               N.contains("sin") || N.contains("cos") || N.contains("sqrt") ||
+               N.contains("rcp");
+      }
+  return false;
+}
+
+// Transitive: does I reach any instruction in `targets` through its operands,
+// WITHIN the same iteration? We stop at PHI nodes so loop-carried (backedge)
+// values are not followed -- a VALU consuming the *previous* iteration's MFMA
+// (the warp-pipeline decoupling) is independent for interleaving purposes; only
+// an intra-iteration MFMA->VALU path counts as a real dependency.
+static bool dependsOnAny(Instruction *I,
+                         const SmallPtrSetImpl<const Instruction *> &targets) {
+  SmallVector<const Value *, 32> Work(I->op_begin(), I->op_end());
+  SmallPtrSet<const Value *, 32> Seen;
+  while (!Work.empty()) {
+    const Value *V = Work.pop_back_val();
+    if (!Seen.insert(V).second)
+      continue;
+    if (const auto *DI = dyn_cast<Instruction>(V)) {
+      if (targets.count(DI))
+        return true;
+      if (isa<PHINode>(DI))
+        continue; // don't cross loop-carried / cross-iteration edges
+      Work.append(DI->op_begin(), DI->op_end());
+    }
+  }
+  return false;
+}
+
+// Co-issue weight of a VALU op for the interleave count (0 if not counted):
+//   regular unpacked scalar FP = 1;  packed (vector FP) = 2;
+//   transcendental (exp/...) = 2;  v_permlane = 2.
+// True if I is an fmaximum/fminimum/maxnum/minnum intrinsic call -- the ops the
+// AMD backend folds pairwise (max(max(a,b),c)) into v_maximum3/v_minimum3.
+static bool isMaxMin(const Instruction &I) {
+  if (const auto *CI = dyn_cast<CallInst>(&I))
+    if (const Function *F = CI->getCalledFunction())
+      if (F->isIntrinsic()) {
+        StringRef N = F->getName();
+        return N.contains("maximum") || N.contains("minimum") ||
+               N.contains("maxnum") || N.contains("minnum");
+      }
+  return false;
+}
+
+// Mark the "inner" max/mins that the backend absorbs into a v_maximum3, so they
+// count 0 (they vanish at isel). Replicates isel's greedy bottom-up fold: walk
+// the region's max/mins in program order; each one absorbs at most one single-
+// use, not-yet-committed max/min operand as its inner. Absorbed -> Folded (0);
+// the absorber becomes a v_maximum3 (full weight). Matches the measured count
+// (LLIR llvm.maximum -> ASM v_maximum3) exactly on the FA softmax reduction.
+static void computeMax3Folds(Instruction *Begin, BasicBlock::iterator End,
+                             const SmallPtrSetImpl<const Instruction *> &Region,
+                             SmallPtrSetImpl<const Instruction *> &Folded) {
+  SmallPtrSet<const Instruction *, 32> Committed;
+  for (auto It = Begin->getIterator(); It != End; ++It) {
+    if (!isMaxMin(*It))
+      continue;
+    for (Value *Op : It->operands()) {
+      auto *In = dyn_cast<Instruction>(Op);
+      if (In && isMaxMin(*In) && Region.count(In) && In->hasOneUse() &&
+          !Folded.count(In) && !Committed.count(In)) {
+        Folded.insert(In);
+        Committed.insert(&*It);
+        break;
+      }
+    }
+  }
+}
+
+static int valuWeight(const Instruction &I) {
+  if (Utils::isMFMAorWMMA(I))
+    return 0;
+  if (isTransCompute(I))
+    return 2;
+  if (const auto *CI = dyn_cast<CallInst>(&I))
+    if (const Function *F = CI->getCalledFunction())
+      if (F->isIntrinsic()) {
+        StringRef N = F->getName();
+        if (N.contains("permlane"))
+          return 2;
+        // Count maximum/minimum (the softmax row-max reduction) by DEFAULT.
+        // The 2:1 v_maximum3 fold is handled at collection time by
+        // computeMax3Folds (inner ops -> weight 0), so with fold-aware
+        // weighting the reduction contributes its real issued count (validated:
+        // 89 vs the naive 164).
+        //
+        // Counting them is worth ~1.5%: with weight 0 the reduction is
+        // INVISIBLE to the interleave, so its ~16 v_maximum3 pile up *before*
+        // the stage's first mfma and no window ever covers them (measured on
+        // FAv4: 76 cycles of co-exec-capable VALU stranded at the PV stage head
+        // while that stage's own windows sat 92 cycles under-filled; counting
+        // moves head 76 -> 0 cyc and fill 292 -> 368 / 384).
+        if (N.contains("maxnum") || N.contains("minnum") ||
+            N.contains("maximum") || N.contains("minimum") ||
+            N.contains("fmuladd") || N.contains("fma."))
+          return I.getType()->isVectorTy() ? 2 : 1;
+        // llvm.fabs is NOT counted, for the same reason as fneg below: it
+        // becomes a source modifier, not an instruction. (No current kernel has
+        // one, so this only guards the future.)
+      }
+  // NOTE: an fmul feeding a single fadd/fsub contracts into one v_pk_fma (->
+  // two v_fma), so in principle the pair is 2 issue slots not 4. But zeroing
+  // the fmul weight here creates weight-0 runs that make the error-diffusion
+  // cluster mfmas (measured a 5-long mfma run, 1035 vs 1043). Left
+  // double-counted on purpose -- the denser qk*scale placement it produces is
+  // empirically better. A packed convert (fptrunc/fpext of a <2 x T>) lowers to
+  // ONE co-issuable v_cvt_pk_f16 (4 cyc) and is NOT scalarized like packed
+  // fmul/fadd, so it is a single co-issue unit -> weight 1, not 2. (Counting it
+  // 2 under-filled the cvt windows: 4 cvt = weight 8 "full" but only 16 cyc of
+  // the 24-cyc window, so the interleave placed 4/window instead of the 6 that
+  // fit.) fneg is NOT an instruction on AMDGPU: it folds into its consumer as a
+  // source modifier (`v_fma_f32 v0, v0, s44, -v129`). Counting it inflates a
+  // declared sched_group_barrier group by an instruction that never exists, and
+  // IGroupLP cannot fill that group -- so its pipeline solver gives up and
+  // leaves ISel's order for the WHOLE region. Measured on FAv4 with
+  // SCALE_ON_Q=0, whose QK stage carries one fneg for fma(qk, qk_scale,
+  // -m_new): 7 of 16 groups were placed and the remaining 8 mfma were emitted
+  // back-to-back, stranding 12 exp2 plus ~20 valu with no co-exec window (the
+  // stage's twin, which had no fneg, scheduled fine).
+  if (I.getOpcode() == Instruction::FNeg)
+    return 0;
+  if (isa<FPTruncInst>(I) || isa<FPExtInst>(I))
+    return 1;
+  if (I.getType()->isFPOrFPVectorTy() &&
+      (isa<BinaryOperator>(I) || isa<UnaryOperator>(I) || isa<SelectInst>(I)))
+    return I.getType()->isVectorTy() ? 2 : 1; // packed vector = 2, scalar = 1
+  return 0;
+}
+
+// Transparent glue that builds an input of one of THIS region's mfmas
+// (insertelement/shuffle feeding a region mfma). Region-restricted so we don't
+// hoist a prep that actually feeds the *next* region's mfma (which may legally
+// use this region's valu).
+static bool feedsMFMA(Instruction *I,
+                      const SmallPtrSetImpl<const Instruction *> &RegionMfmas) {
+  SmallVector<Value *, 8> Work;
+  SmallPtrSet<Value *, 16> Seen;
+  Work.push_back(I);
+  while (!Work.empty()) {
+    Value *V = Work.pop_back_val();
+    if (!Seen.insert(V).second)
+      continue;
+    for (User *U : V->users())
+      if (auto *UI = dyn_cast<Instruction>(U)) {
+        if (RegionMfmas.count(UI))
+          return true;
+        if (Utils::isHoistTransparentInst(*UI))
+          Work.push_back(UI);
+      }
+  }
+  return false;
+}
+
+// extractelement of one of THIS region's mfma results.
+static bool
+definedByMFMA(Instruction *I,
+              const SmallPtrSetImpl<const Instruction *> &RegionMfmas) {
+  SmallVector<Value *, 8> Work;
+  SmallPtrSet<Value *, 16> Seen;
+  Work.push_back(I);
+  while (!Work.empty()) {
+    Value *V = Work.pop_back_val();
+    if (!Seen.insert(V).second)
+      continue;
+    if (auto *DI = dyn_cast<Instruction>(V)) {
+      if (RegionMfmas.count(DI))
+        return true;
+      if (Utils::isSinkTransparentInst(*DI))
+        for (Value *Op : DI->operands())
+          Work.push_back(Op);
+    }
+  }
+  return false;
+}
+
+// Pin an instruction's position by emitting llvm.amdgcn.sched.barrier(0)
+// immediately after it, so the machine scheduler cannot reorder across it.
+static void insertSchedBarrierAfter(Instruction *I) {
+  Instruction *Next = I->getNextNode();
+  if (!Next)
+    return;
+  IRBuilder<> B(Next);
+  B.CreateIntrinsic(Intrinsic::amdgcn_sched_barrier, {B.getInt32(0)});
+}
+
+// IGroupLP scheduling-group masks (AMDGPUIGroupLP / SCHED_GROUP_BARRIER).
+// TRANS is a class of its own: canAddMI()'s VALU branch excludes
+// transcendentals, so v_exp matches ONLY the TRANS mask.
+static constexpr uint32_t kSGBMaskVALU = 0x002;
+static constexpr uint32_t kSGBMaskMFMA = 0x008;
+static constexpr uint32_t kSGBMaskTRANS = 0x400;
+// One mfma opens a co-execution window shorter than its matrix occupancy: a
+// 32x32x16 (32-cycle) mfma exposes 24 cycles. Do not hardcode that -- an FA
+// variant built on 16x16x32 mfma has a 16-cycle occupancy, and giving it
+// 24-cycle windows would over-fill every one of them by 3x.
+static constexpr int kWindowCycles = 24;  // the validated 32-cycle-mfma case
+static constexpr int kMFMANonOverlap = 8; // occupancy - window, from that case
+
+// Co-exec window for a region, derived from the mfmas it actually contains.
+// Returns 0 when the shape is unmodelled or mixed in a way we should not guess
+// at, in which case the caller leaves the region to the default schedulers --
+// the same bail-out `Utils::getMFMACycles` already uses.
+static int regionWindowCycles(Instruction *Begin, BasicBlock::iterator End) {
+  unsigned MinCycles = 0;
+  for (auto It = Begin->getIterator(); It != End; ++It) {
+    if (!Utils::isMFMAorWMMA(*It))
+      continue;
+    unsigned C = Utils::getMFMACycles(*It);
+    if (C == 0)
+      return 0; // unmodelled mfma: do not invent a window for it
+    // Mixed shapes: size the window for the SHORTEST mfma, so no window
+    // overfills.
+    MinCycles = MinCycles ? std::min(MinCycles, C) : C;
+  }
+  if (MinCycles == 0)
+    return 0;
+  return std::max<int>(4, (int)MinCycles - kMFMANonOverlap);
+}
+// Mem-stage head pacing: 2 x `s_nop 7` measured best on both FA kernels.
+static constexpr int kDefaultMemNops = 2;
+// v_permlane is a cross-lane shuffle: model it as a fat 20-cycle VALU.
+static constexpr int kPermlaneCycles = 20;
+// One 4-cycle VALU op per co-exec slot: 24 cycles / 4 = 6 slots per mfma.
+static constexpr int kSlotCycles = 4;
+
+// A packed f32 op this pass can split into per-element scalar ops. Deliberately
+// narrow: fmul / fadd / fsub / fma(muladd) on a <N x float>.
+//
+//  * fptrunc/fpext are excluded -- a packed convert IS one v_cvt_pk_f16_f32,
+//  and
+//    splitting it would double the issue count for no gain.
+//  * <N x half> is excluded -- v_pk_*_f16 is the natural form of f16 math, not
+//  a
+//    fusion of two scalar ops.
+static bool isSplittablePackedFP(const Instruction &I) {
+  auto *VT = dyn_cast<FixedVectorType>(I.getType());
+  if (!VT || VT->getNumElements() < 2 || !VT->getElementType()->isFloatTy())
+    return false;
+  if (isa<BinaryOperator>(I))
+    return I.getOpcode() == Instruction::FMul ||
+           I.getOpcode() == Instruction::FAdd ||
+           I.getOpcode() == Instruction::FSub;
+  if (const auto *CI = dyn_cast<CallInst>(&I))
+    if (const Function *F = CI->getCalledFunction())
+      if (F->isIntrinsic()) {
+        Intrinsic::ID Id = F->getIntrinsicID();
+        return Id == Intrinsic::fmuladd || Id == Intrinsic::fma;
+      }
+  return false;
+}
+
+// Replace a packed op with one scalar op per element, appending the new scalar
+// ops to Out. Same rewrite as Triton's ScalarizePackedFOps, applied to ONE op
+// instead of every packed op in the block -- which is the whole point here:
+// only the ops that landed in an mfma co-exec window want to be scalar.
+static bool scalarizePackedFP(Instruction *I,
+                              SmallVectorImpl<Instruction *> &Out) {
+  auto *VT = dyn_cast<FixedVectorType>(I->getType());
+  if (!VT)
+    return false;
+  unsigned N = VT->getNumElements();
+  IRBuilder<> B(I);
+  Value *Vec = UndefValue::get(VT);
+  auto *BO = dyn_cast<BinaryOperator>(I);
+  auto *CI = dyn_cast<CallInst>(I);
+  for (unsigned e = 0; e < N; ++e) {
+    Value *R = nullptr;
+    if (BO) {
+      Value *A = B.CreateExtractElement(BO->getOperand(0), e);
+      Value *C = B.CreateExtractElement(BO->getOperand(1), e);
+      R = B.CreateBinOp(BO->getOpcode(), A, C);
+    } else if (CI) {
+      Value *A = B.CreateExtractElement(CI->getArgOperand(0), e);
+      Value *C = B.CreateExtractElement(CI->getArgOperand(1), e);
+      Value *D = B.CreateExtractElement(CI->getArgOperand(2), e);
+      R = B.CreateIntrinsic(VT->getElementType(),
+                            CI->getCalledFunction()->getIntrinsicID(),
+                            {A, C, D});
+    } else {
+      return false;
+    }
+    if (auto *RI = dyn_cast<Instruction>(R)) {
+      RI->copyFastMathFlags(
+          I); // keep contraction/reassociation rights identical
+      Out.push_back(RI);
+    }
+    Vec = B.CreateInsertElement(Vec, R, e);
+  }
+  I->replaceAllUsesWith(Vec);
+  I->eraseFromParent();
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Over-capacity stages: choose what to hide, and pack what cannot be hidden.
+// ---------------------------------------------------------------------------
+// declareRegionGroups() below assumes the stage's VALU work FITS in the mfma
+// co-exec capacity (24 cyc x M) and spreads it so no group overflows. FAv3
+// breaks that assumption: its QK stage carries ~470 cycles of VALU against 384
+// cycles of capacity and its PV stage ~490 (measured minGroups 20 and 21
+// against 16 mfmas, so the balanced packer's merge loop collapses pairs into
+// 48-cycle groups).
+//
+// When the work does not fit, no schedule hides it and the question changes to
+// which ops get a window and what shape the rest take:
+//
+//   1. WHICH ops get covered. An op that cannot be packed (exp2, the v_maximum3
+//      reduction, v_cvt_pk, permlane) gains nothing from being left alone, so
+//      it gets first claim on the windows. Whatever capacity is left goes to
+//      the packable ops, taken from the END of the stage backwards -- mfmas
+//      inserted in reverse program order -- which keeps the uncovered remainder
+//      contiguous and leaves it where it already sits: at the head in FAv3's QK
+//      (the rescale muls), in the middle in its PV (the qk_scale fmas, between
+//      the max3 reduction and the exp2s).
+//   2. WHAT SHAPE the rest takes. A covered op should be SCALAR, so it
+//   co-issues
+//      one 4-cycle slot at a time inside its window. An UNCOVERED op should
+//      stay PACKED: nothing hides it either way, and one v_pk_mul_f32 retires
+//      two elements in one issue where two v_mul_f32 need two.
+//
+// This is why FAv3 must NOT set AMDGCN_SCALARIZE_PACKED_FOPS: that pass splits
+// every packed op in any block containing an mfma, including the uncovered ones
+// this pass deliberately keeps packed.
+//
+// Weights follow the slot model: 1 mfma = 6 slots, 1 unpacked op = 1 slot, 1
+// packed op = 2 slots; exp2 = 2 slots (8 cyc) and permlane = 5 (20 cyc).
+static bool declareRegionGroupsOverCap(
+    Instruction *Begin, Instruction *End, int syncID, int M, int windowCycles,
+    const SmallPtrSetImpl<const Instruction *> &Max3Folded,
+    const SmallPtrSetImpl<const Instruction *> &transSet) {
+  BasicBlock *BB = Begin->getParent();
+  auto ItEnd = End ? End->getIterator() : BB->end();
+
+  struct Op {
+    Instruction *I;
+    int cyc;
+    bool isTrans;
+    bool splittable;
+    bool covered;
+  };
+  SmallVector<Op, 64> ops;
+  for (auto It = Begin->getIterator(); It != ItEnd; ++It) {
+    Instruction &I = *It;
+    if (Utils::isMFMAorWMMA(I) || Max3Folded.count(&I))
+      continue;
+    int w = valuWeight(I);
+    if (w <= 0)
+      continue;
+    bool isTrans = transSet.count(&I) != 0;
+    bool isPermlane = false;
+    if (auto *CI = dyn_cast<CallInst>(&I))
+      if (Function *F = CI->getCalledFunction())
+        isPermlane = F->getName().contains("permlane");
+    int cyc = isPermlane ? kPermlaneCycles : w * kSlotCycles;
+    ops.push_back({&I, cyc, isTrans, isSplittablePackedFP(I), false});
+  }
+  if (ops.empty() || M < 2)
+    return false;
+
+  const int Cap = windowCycles * M;
+  int Total = 0, Fixed = 0;
+  for (const Op &o : ops) {
+    Total += o.cyc;
+    if (!o.splittable)
+      Fixed += o.cyc;
+  }
+  if (Total <= Cap)
+    return false; // fits -- the balanced packer handles it better
+
+  // A window is one mfma's 24-cycle shadow. It may hold SEVERAL declared
+  // groups, of different IGroupLP classes: [MFMA 1][VALU 1][TRANS 1] asks for
+  // one mfma and then a sub and an exp2 behind it, which is one mfma instead of
+  // two. FAv3's PV stage ends in exactly that pair (a lone sub, then a lone
+  // exp2) and used to spend two windows on 12 cycles of work.
+  struct Chunk {
+    bool isTrans;
+    int cyc, n;
+  };
+  struct Slot {
+    bool hasMfma; // false = uncovered: declared with no mfma in front of it
+    int cyc;
+    SmallVector<Chunk, 4> chunks;
+  };
+
+  // Decide coverage for a given packable-op budget, then lay the result out
+  // into slots. Returns the number of windows the layout needs.
+  auto decideAndLayout = [&](int avail, SmallVectorImpl<Slot> &out,
+                             int &boughtOut, int &nSplitOut) {
+    for (Op &o : ops)
+      o.covered = !o.splittable; // non-splittable ops get first claim
+    int bought = 0, nSplit = 0;
+    for (int i = (int)ops.size() - 1; i >= 0; --i) {
+      Op &o = ops[i];
+      if (o.splittable && bought + o.cyc <= avail) {
+        o.covered = true;
+        bought += o.cyc;
+        ++nSplit;
+      }
+    }
+    boughtOut = bought;
+    nSplitOut = nSplit;
+
+    out.clear();
+    int nWin = 0;
+    for (const Op &o : ops) {
+      // Instruction count as IGroupLP counts it: a covered packed op is about
+      // to be scalarized into one op per element; an uncovered one stays a
+      // single issue.
+      int n = 1;
+      if (o.covered && o.splittable)
+        if (auto *VT = dyn_cast<FixedVectorType>(o.I->getType()))
+          n = VT->getNumElements();
+      bool wantMfma = o.covered;
+      Slot *S = out.empty() ? nullptr : &out.back();
+      // Extend the current slot when it is the same kind of slot and the op
+      // still fits the window. Class may differ from the previous chunk -- that
+      // is the point -- so only the cycle budget and the covered/uncovered
+      // split bound it.
+      bool fits = S && S->hasMfma == wantMfma &&
+                  (!wantMfma || S->cyc + o.cyc <= windowCycles);
+      if (!fits) {
+        out.push_back({wantMfma, 0, {}});
+        S = &out.back();
+        if (wantMfma)
+          ++nWin;
+      }
+      S->cyc += o.cyc;
+      if (!S->chunks.empty() && S->chunks.back().isTrans == o.isTrans) {
+        S->chunks.back().cyc += o.cyc;
+        S->chunks.back().n += n;
+      } else {
+        S->chunks.push_back({o.isTrans, o.cyc, n});
+      }
+    }
+    return nWin;
+  };
+
+  // Iterate: a window freed by tighter packing is capacity the packable ops can
+  // still use, so feed it back into the coverage budget. FAv3's PV frees the
+  // window its trailing sub+exp2 pair used to waste, which buys three more
+  // v_pk_fma.
+  int Avail = Cap - Fixed, Bought = 0, nSplit = 0;
+  SmallVector<Slot, 40> slots;
+  int nWin = decideAndLayout(Avail, slots, Bought, nSplit);
+  for (int iter = 0; iter < 4 && nWin < M; ++iter) {
+    int grown = Avail + (M - nWin) * windowCycles;
+    SmallVector<Slot, 40> trial;
+    int tb = 0, ts = 0;
+    int tw = decideAndLayout(grown, trial, tb, ts);
+    if (tw > M)
+      break; // overshot: keep the layout that still fits
+    Avail = grown;
+    slots = std::move(trial);
+    Bought = tb;
+    nSplit = ts;
+    if (tw == nWin)
+      break; // nothing more to win
+    nWin = tw;
+  }
+  // Re-run the decision so ops[].covered matches the layout we kept.
+  nWin = decideAndLayout(Avail, slots, Bought, nSplit);
+
+  // More windows than mfmas? Merge the cheapest adjacent pair, so the excess
+  // lands in one deliberately over-full window instead of dropping the tail
+  // slots -- which would cost the LAST exp2 groups their windows, the ops least
+  // able to afford it.
+  while (nWin > M) {
+    size_t bi = slots.size();
+    int best = INT_MAX;
+    for (size_t i = 0; i + 1 < slots.size(); ++i)
+      if (slots[i].hasMfma && slots[i + 1].hasMfma) {
+        int cost = slots[i].cyc + slots[i + 1].cyc;
+        if (cost < best) {
+          best = cost;
+          bi = i;
+        }
+      }
+    if (bi == slots.size())
+      break; // every window is separated by an uncovered slot; nothing to merge
+    slots[bi].cyc += slots[bi + 1].cyc;
+    for (const Chunk &c : slots[bi + 1].chunks)
+      if (!slots[bi].chunks.empty() &&
+          slots[bi].chunks.back().isTrans == c.isTrans) {
+        slots[bi].chunks.back().cyc += c.cyc;
+        slots[bi].chunks.back().n += c.n;
+      } else {
+        slots[bi].chunks.push_back(c);
+      }
+    slots.erase(slots.begin() + bi + 1);
+    --nWin;
+  }
+
+  // Scalarize exactly the covered packed ops. The layout above already
+  // accounted for the instruction count each one becomes, so nothing needs
+  // re-walking after this -- which matters because the rewrite erases the
+  // original op.
+  int PackedLeft = 0;
+  SmallVector<Instruction *, 16> ToSplit;
+  for (Op &o : ops) {
+    if (o.covered && o.splittable)
+      ToSplit.push_back(o.I);
+    else if (o.splittable)
+      ++PackedLeft;
+  }
+  for (Instruction *I : ToSplit) {
+    SmallVector<Instruction *, 4> New;
+    scalarizePackedFP(I, New);
+  }
+
+  // Emit. Program order is always satisfiable (it is the order IGroupLP already
+  // sees), so unlike the fitting path this needs no dependency-ordered blocks:
+  // coverage, not reordering, is the decision here.
+  int gBare = M - nWin;
+  if (gBare < 0)
+    gBare = 0;
+  Instruction *IP = End ? End : BB->getTerminator();
+  if (!IP)
+    return false;
+  IRBuilder<> B(IP);
+  auto emit = [&](uint32_t mask, int size) {
+    B.CreateIntrinsic(Intrinsic::amdgcn_sched_group_barrier,
+                      {B.getInt32(mask), B.getInt32(size), B.getInt32(syncID)});
+  };
+  for (size_t i = 0; i < slots.size(); ++i) {
+    const Slot &S = slots[i];
+    // Partnerless mfmas go just before the LAST slot, not at the region head:
+    // an unfilled window is free, but having it first delays every co-issued
+    // op.
+    if (i + 1 == slots.size())
+      for (int k = 0; k < gBare; ++k)
+        emit(kSGBMaskMFMA, 1);
+    if (S.hasMfma)
+      emit(kSGBMaskMFMA, 1);
+    for (const Chunk &c : S.chunks)
+      emit(c.isTrans ? kSGBMaskTRANS : kSGBMaskVALU, c.n);
+  }
+
+  if (std::getenv("LLIRSCHED_WP_DEBUG")) {
+    errs() << "  [sgb-overcap] sync=" << syncID << " M=" << M << " cap=" << Cap
+           << " total=" << Total << "cyc fixed=" << Fixed
+           << "cyc avail=" << Avail << "cyc bought=" << Bought
+           << "cyc  scalarized=" << nSplit << " packed-left=" << PackedLeft
+           << "  windows=" << nWin << "/" << M << "  slots:";
+    for (const Slot &S : slots) {
+      errs() << " " << (S.hasMfma ? "[" : "*[");
+      bool first = true;
+      for (const Chunk &c : S.chunks) {
+        errs() << (first ? "" : "+") << (c.isTrans ? "T" : "V") << c.n;
+        first = false;
+      }
+      errs() << "]" << S.cyc;
+    }
+    errs() << "  (* = no mfma) bare=" << gBare << "\n";
+  }
+  return true;
+}
+
+// LLIRSCHED_WP_SGB: declare the co-exec schedule with sched_group_barrier
+// instead of physically reordering the region and pinning it with
+// sched_barrier(0).
+//
+// Why: sched_barrier(0) is only an advisory "do not cross" marker for the
+// machine scheduler. Measured on FAv4, codegen still consolidates the last two
+// sub-regions of a stage (an mfma migrates toward the region front, so ~5
+// v_cvt_pk or ~3 v_exp end up past the final mfma with no window over them)
+// even though the plugin's own IR had every group inside its 24-cycle window.
+// sched_group_barrier is the stronger form: AMDGPUIGroupLP *builds* the
+// requested pipeline in the machine scheduler rather than merely forbidding
+// motion. This is the mechanism ROCm/FlyDSL uses -- it emits no reordering at
+// all, just
+// {[MFMA 1][VALU 5..6]} and {[MFMA 1][TRANS 3]} group declarations per cluster
+// on stock upstream LLVM.
+//
+// Group sizing follows the validated split from the FAv3 co-issue work: treat
+// one TRANS as two VALU slots (8 vs 4 cycles), so with M mfma, V valu slots and
+// E trans ops -> K1 = ceil((V + 2E)/M) valu per mfma, K2 = ceil(K1/2) trans per
+// mfma, g0 = round(V/K1) mfmas take VALU groups and the remaining g1 take TRANS
+// groups. VALU groups are declared FIRST (valu-first measured 1071 vs exp-first
+// 1047 TFLOPS on FAv3).
+//
+// Placement matters: IGroupLP forms groups scanning UPWARD from the barrier, so
+// the whole declaration must sit AFTER every real op of the region -- emitting
+// it at the top yields empty groups and silently does nothing.
+static bool declareRegionGroups(Instruction *Begin, Instruction *End,
+                                int syncID) {
+  BasicBlock *BB = Begin->getParent();
+  auto ItEnd = End ? End->getIterator() : BB->end();
+  while (Begin && isa<PHINode>(Begin))
+    Begin = Begin->getNextNode();
+  if (!Begin || Begin == End)
+    return false;
+
+  SmallPtrSet<const Instruction *, 32> RegionInsts, Max3Folded;
+  for (auto It = Begin->getIterator(); It != ItEnd; ++It)
+    RegionInsts.insert(&*It);
+  computeMax3Folds(Begin, ItEnd, RegionInsts, Max3Folded);
+
+  // Collect the region's co-issuable ops as maximal RUNS of a single IGroupLP
+  // class, in program order.
+  //
+  // Why runs and not one VALU block + one TRANS block: the declaration must be
+  // satisfiable, and satisfiability is a dataflow property. FAv4's DOT1 stage
+  // after opt7 is `VALU x8 -> TRANS x8 -> VALU x50` (T3's subs, then its exp2s,
+  // then the sum-reduction adds and the p->fp16 converts, which CONSUME those
+  // exps). A two-block "all VALU then all TRANS" declaration asks IGroupLP to
+  // schedule 58 VALU before the first TRANS, which the dependency forbids --
+  // the solver then abandons the pipeline and leaves ISel's order, collapsing 8
+  // exps plus their dependent adds into one 132-cycle group and leaving 6 mfmas
+  // bare (measured). Emitting one group sequence per run, in order, is always
+  // satisfiable because it *is* the program order, and it handles any number of
+  // class transitions.
+  //
+  // Cost model per op (cycles / instruction count as IGroupLP counts them):
+  //   * plain valu   4 cyc, 1 instruction
+  //   * packed valu  8 cyc, 1 instruction -- two slots' worth of window, but
+  //   ONE
+  //                  entry: sched_group_barrier sizes are instruction counts,
+  //                  and SIPreEmitPeephole splits whatever lands in a shadow
+  //                  later
+  //   * v_permlane   20 cyc, 1 instruction (cross-lane shuffle; one window can
+  //   hide
+  //                  a permlane plus a single 4-cycle op and no more)
+  //   * TRANS (exp2) 8 cyc, 1 instruction, its own mask
+  // Blocks are ordered by DEPENDENCY, not by raw program order.
+  //
+  // Raw program order is too fine: FAv4's PV stage emits sub(T0) exp(T0)
+  // sub(T1) exp(T1) ... = 8 alternating runs, and one mandatory group sequence
+  // per run does not fit 16 windows (measured: budget widened to 32, 156 cyc of
+  // overflow). But those runs are freely reorderable -- sub(T1) does not depend
+  // on exp(T0) -- so they belong in ONE VALU block.
+  //
+  // What is *not* reorderable is a VALU op that consumes a TRANS result. FAv4's
+  // DOT1 stage has exactly that: T3's subs (independent) -> its exp2s -> the
+  // sum-reduction adds and p->fp16 converts, which CONSUME those exps. So
+  // classify:
+  //
+  //   block 0: VALU that does NOT depend on any TRANS in this region
+  //   block 1: TRANS
+  //   block 2: VALU that DOES depend on a TRANS in this region
+  //
+  // That is always satisfiable (it is a topological order of the class
+  // dependency), collapses to the old two-block form when block 2 is empty, and
+  // handles any number of program-order transitions.
+  SmallPtrSet<const Instruction *, 32> transSet;
+  for (auto It = Begin->getIterator(); It != ItEnd; ++It)
+    if (!Utils::isMFMAorWMMA(*It) && !Max3Folded.count(&*It) &&
+        isTransCompute(*It))
+      transSet.insert(&*It);
+
+  struct ClassRun {
+    bool isTrans;
+    SmallVector<int, 32> cyc;
+  };
+  SmallVector<ClassRun, 3> runs;
+  runs.push_back({false, {}}); // VALU, TRANS-independent
+  runs.push_back({true, {}});  // TRANS
+  runs.push_back({false, {}}); // VALU, TRANS-dependent
+  int M = 0;
+  for (auto It = Begin->getIterator(); It != ItEnd; ++It) {
+    Instruction &I = *It;
+    if (Utils::isMFMAorWMMA(I)) {
+      ++M;
+      continue;
+    }
+    if (Max3Folded.count(&I))
+      continue; // folds into a v_maximum3, no issue slot of its own
+    if (isTransCompute(I)) {
+      runs[1].cyc.push_back(8);
+      continue;
+    }
+    if (int w = valuWeight(I)) {
+      bool isPermlane = false;
+      if (auto *CI = dyn_cast<CallInst>(&I))
+        if (Function *F = CI->getCalledFunction())
+          isPermlane = F->getName().contains("permlane");
+      int idx = dependsOnAny(&I, transSet) ? 2 : 0;
+      // ONE entry per instruction, priced by its weight -- the same convention
+      // the TRANS branch above uses (one entry of 8) and the same one
+      // declareRegionGroupsOverCap uses for its Chunks. It matters because the
+      // entry count becomes the sched_group_barrier group SIZE, and that size
+      // is a count of INSTRUCTIONS. Pushing one 4-cycle entry per ELEMENT
+      // instead would declare 6 where a window holds 3 packed ops; IGroupLP
+      // cannot fill the group and its solver then abandons the whole region's
+      // pipeline. With instruction counts the declaration is satisfiable as
+      // emitted, and SIPreEmitPeephole splits whatever ends up in a shadow --
+      // so no kernel needs Triton's ScalarizePackedFOps.
+      if (isPermlane)
+        runs[idx].cyc.push_back(kPermlaneCycles);
+      else
+        runs[idx].cyc.push_back(4 * w);
+    }
+  }
+  // Drop empty blocks so they cost no groups.
+  {
+    SmallVector<ClassRun, 3> kept;
+    for (ClassRun &r : runs)
+      if (!r.cyc.empty())
+        kept.push_back(std::move(r));
+    runs = std::move(kept);
+  }
+  if (M < 2 || runs.empty())
+    return false;
+
+  // Size the co-exec window from the mfmas this region actually contains,
+  // rather than assuming the 32x32x16 shape the model was validated on.
+  const int Window = regionWindowCycles(Begin, ItEnd);
+  if (Window <= 0)
+    return false; // unmodelled mfma shape: leave it to the default schedulers
+  if (Window != kWindowCycles && std::getenv("LLIRSCHED_WP_DEBUG"))
+    errs() << "  [sgb] sync=" << syncID << " window=" << Window
+           << "cyc (derived; the validated 32-cycle-mfma case is "
+           << kWindowCycles << ")\n";
+
+  // Over capacity? Then no arrangement hides the work and the balanced packer
+  // below is solving the wrong problem -- it would spread, find it needs more
+  // groups than there are mfmas, and merge cheap pairs into double-width
+  // groups. Hand those stages to the packed-aware path, which decides what to
+  // cover and keeps the uncovered remainder packed. Opt out with
+  // LLIRSCHED_WP_NOOVERCAP.
+  {
+    int totalCyc = 0;
+    for (const ClassRun &r : runs)
+      for (int c : r.cyc)
+        totalCyc += c;
+    if (totalCyc > Window * M &&
+        std::getenv("LLIRSCHED_WP_NOOVERCAP") == nullptr &&
+        declareRegionGroupsOverCap(Begin, End, syncID, M, Window, Max3Folded,
+                                   transSet))
+      return true;
+  }
+
+  // Pack one block into groups. BALANCED, not greedy first-fit.
+  //
+  // First-fit fills each group to the brim and leaves the block's tail in a
+  // stub, which wastes windows: a 20-cycle permlane after a full group opens a
+  // group that can then take only one more 4-cycle op. Worse, when the
+  // resulting group count exceeded the mfma count the old code widened `budget`
+  // for the WHOLE stage, so every group was allowed to run 28 cycles and
+  // overflow -- 40 cycles of exposed VALU in a stage whose 364 cycles of work
+  // fit inside 384 cycles of capacity.
+  //
+  // Instead: take the minimum number of groups the cycle total needs,
+  // g = ceil(total / budget), then aim for total/g per group. That keeps every
+  // group at or under `budget` while spreading the slack evenly, so no group
+  // overflows and the tail stub disappears.
+  auto packGroups = [](ArrayRef<int> cycles, int budget) {
+    SmallVector<int, 32> sizes;
+    if (cycles.empty())
+      return sizes;
+    int total = 0;
+    for (int c : cycles)
+      total += c;
+    // The minimum number of windows this block's cycle total needs. Hitting
+    // exactly this count matters: one group too many trips the widen-the-window
+    // fallback, which then lets EVERY group in the stage overflow. Measured on
+    // FAv4's QK stage: 360 cyc of work, 384 cyc of capacity, 16 windows
+    // available and 16 needed -- yet fragmentation around the 20-cycle permlane
+    // produced 17 groups, the budget widened to 28, and 16 cycles of VALU ended
+    // up exposed in a stage that fits perfectly.
+    int g = (total + budget - 1) / budget;
+    if (g < 1)
+      g = 1;
+    // Adaptive target: aim each group at the average of what is LEFT over the
+    // groups still to come, capped by the window. This self-corrects after a
+    // wide op (a permlane forces a short group; the following groups take a
+    // little more) and lands on exactly `g` groups instead of fragmenting.
+    int remCyc = total, remG = g, cur = 0, n = 0;
+    for (int c : cycles) {
+      int target = (remG > 0) ? (remCyc + remG - 1) / remG : budget;
+      target = std::min(target, budget);
+      if (n > 0 && (cur + c > budget || (cur >= target && remG > 1))) {
+        sizes.push_back(n);
+        remCyc -= cur;
+        if (remG > 1)
+          --remG;
+        cur = 0;
+        n = 0;
+      }
+      cur += c;
+      ++n;
+    }
+    if (n)
+      sizes.push_back(n);
+    return sizes;
+  };
+  SmallVector<SmallVector<int, 32>, 8> groups;
+  int budget = Window, total = 0;
+  groups.clear();
+  for (const ClassRun &r : runs) {
+    groups.push_back(packGroups(r.cyc, budget));
+    total += (int)groups.back().size();
+  }
+  // Too many groups for the available mfmas? Do NOT widen the window for the
+  // whole stage -- that lets every group overflow (measured: 24 cyc exposed in
+  // a stage whose 360 cyc of work fits in 384 cyc of capacity). Instead MERGE
+  // the cheapest adjacent pair, repeatedly, so the excess is confined to one or
+  // two groups.
+  //
+  // Fragmentation is why the count can exceed the cycle-minimum at all: a
+  // 20-cycle permlane cannot share a 24-cycle window with more than one 4-cycle
+  // op, so the group before it closes short. That costs 8 cycles of capacity,
+  // not 24.
+  while (total > M) {
+    size_t bi = 0, gi = 0;
+    int best = INT_MAX;
+    for (size_t b = 0; b < groups.size(); ++b)
+      for (size_t g = 0; g + 1 < groups[b].size(); ++g) {
+        int cost = groups[b][g] + groups[b][g + 1];
+        if (cost < best) {
+          best = cost;
+          bi = b;
+          gi = g;
+        }
+      }
+    if (best == INT_MAX)
+      break; // nothing left to merge (every block is a single group)
+    groups[bi][gi] += groups[bi][gi + 1];
+    groups[bi].erase(groups[bi].begin() + gi + 1);
+    --total;
+  }
+  int gBare = M - total;
+  if (gBare < 0)
+    gBare = 0;
+
+  Instruction *IP = End ? End : BB->getTerminator();
+  if (!IP)
+    return false;
+  IRBuilder<> B(IP);
+  auto emit = [&](uint32_t mask, int size) {
+    B.CreateIntrinsic(Intrinsic::amdgcn_sched_group_barrier,
+                      {B.getInt32(mask), B.getInt32(size), B.getInt32(syncID)});
+  };
+  for (size_t i = 0; i < runs.size(); ++i) {
+    // Partnerless mfmas go just before the LAST run, not at the region head: an
+    // unfilled window is free, but having it first delays every co-issued op
+    // behind it.
+    if (i + 1 == runs.size())
+      for (int k = 0; k < gBare; ++k)
+        emit(kSGBMaskMFMA, 1);
+    for (int n : groups[i]) {
+      emit(kSGBMaskMFMA, 1);
+      emit(runs[i].isTrans ? kSGBMaskTRANS : kSGBMaskVALU, n);
+    }
+  }
+  if (std::getenv("LLIRSCHED_WP_DEBUG")) {
+    errs() << "  [sgb] sync=" << syncID << " M=" << M << " budget=" << budget;
+    {
+      int tc = 0, need = 0;
+      for (const ClassRun &r : runs) {
+        int c = 0;
+        for (int x : r.cyc)
+          c += x;
+        tc += c;
+        need += (c + Window - 1) / Window;
+        errs() << " [" << (r.isTrans ? "T" : "V") << " " << c << "cyc/"
+               << ((c + Window - 1) / Window) << "g]";
+      }
+      errs() << " total=" << tc << "cyc cap=" << 24 * M
+             << " minGroups=" << need;
+    }
+    errs() << " runs:";
+    for (size_t i = 0; i < runs.size(); ++i) {
+      errs() << " " << (runs[i].isTrans ? "TRANS" : "VALU") << "("
+             << runs[i].cyc.size() << " ops){";
+      for (int n : groups[i])
+        errs() << n << " ";
+      errs() << "}";
+    }
+    errs() << " bare=" << gBare << "\n";
+  }
+  return true;
+}
+
+// Interleave MFMA with VALU in one independent region [Begin, End).
+//   X = sum of valu weights, Y = #mfma.
+//   Reserve the last 6 (weighted) valu for the last mfma; distribute the rest
+//   evenly, ceil((X-6)/(Y-1)) per mfma. Traverse valu in reverse and place each
+//   mfma before the start of its group (mfmas kept in program order so their
+//   accumulator chain stays valid).
+static void interleaveRegion(Instruction *Begin, Instruction *End,
+                             bool pin = true) {
+  BasicBlock *BB = Begin->getParent();
+  // PHI nodes must stay grouped at the block top. When this region is the first
+  // span of its block (Begin is a phi -- e.g. FA's QK stage in the loop's merge
+  // block), advance past all leading phis so no repositioned mfma or hoisted
+  // prep is ever placed above/between them (that is invalid IR -> the whole wp
+  // pass rolls back and the region is left un-interleaved).
+  while (Begin && isa<PHINode>(Begin))
+    Begin = Begin->getNextNode();
+  if (!Begin || Begin == End)
+    return;
+  auto ItEnd = End ? End->getIterator() : BB->end();
+
+  // 1. Cleanup: hoist THIS region's mfma-input preps to Begin, sink its
+  //    mfma-result extracts to just before End, so mfmas can move freely among
+  //    the valu. (llirSched's hoist/sink idea, adapted for wp regions.)
+  SmallVector<Instruction *, 32> Mfmas, Valus;
+  SmallVector<int, 32> Weights;
+  SmallPtrSet<const Instruction *, 32> RegionMfmas, RegionInsts;
+  for (auto It = Begin->getIterator(); It != ItEnd; ++It) {
+    RegionInsts.insert(&*It);
+    if (Utils::isMFMAorWMMA(*It))
+      RegionMfmas.insert(&*It);
+  }
+  SmallVector<Instruction *, 16> Hoist, Sink;
+  SmallPtrSet<const Instruction *, 16> Hoisted;
+  for (auto It = Begin->getIterator(); It != ItEnd; ++It) {
+    Instruction &I = *It;
+    if (Utils::isMFMAorWMMA(I)) {
+      Mfmas.push_back(&I);
+    } else if (Utils::isHoistTransparentInst(I) && feedsMFMA(&I, RegionMfmas)) {
+      // safe to hoist only if every operand already dominates Begin (defined
+      // before the region, or a prep we already hoisted).
+      bool Safe = true;
+      for (Value *Op : I.operands())
+        if (auto *OpI = dyn_cast<Instruction>(Op))
+          if (OpI != Begin && RegionInsts.count(OpI) && !Hoisted.count(OpI)) {
+            Safe = false;
+            break;
+          }
+      if (Safe) {
+        Hoist.push_back(&I);
+        Hoisted.insert(&I);
+      }
+    } else if (isa<ExtractElementInst>(I) && definedByMFMA(&I, RegionMfmas)) {
+      Sink.push_back(&I);
+    }
+  }
+  for (Instruction *I : llvm::reverse(Hoist))
+    if (I != Begin)
+      I->moveAfter(Begin);
+  if (End)
+    for (Instruction *I : llvm::reverse(Sink))
+      I->moveBefore(End->getIterator());
+
+  // 2. Collect valu (weight>0) in current program order, with weights. The
+  // max/min
+  //    reduction is counted (see valuWeight), and by DEFAULT it is counted
+  //    fold-aware: the inner max/mins that isel folds pairwise into a
+  //    v_maximum3 count 0, so the reduction contributes its REAL issued
+  //    instruction count rather than 2x. Without the fold the interleave
+  //    over-reserves window space for ops that vanish at isel.
+  //    LLIRSCHED_WP_NOMAX3FOLD restores naive counting.
+  SmallPtrSet<const Instruction *, 32> Max3Folded;
+  computeMax3Folds(Begin, ItEnd, RegionInsts, Max3Folded);
+  for (auto It = Begin->getIterator(); It != ItEnd; ++It) {
+    if (Max3Folded.count(&*It))
+      continue;
+    int W = valuWeight(*It);
+    if (W > 0) {
+      Valus.push_back(&*It);
+      Weights.push_back(W);
+    }
+  }
+  int Y = Mfmas.size();
+  int N = Valus.size();
+  if (Y < 2 || N == 0)
+    return;
+  int X = 0;
+  for (int W : Weights)
+    X += W;
+  if (X <= 6)
+    return;
+  // 3. Place each mfma's group-start valu by scanning the valu in reverse.
+  //    DEFAULT = REVERSE-6: don't spread evenly. Scan valu in reverse and place
+  //    a mfma after each 6-weight group -- up to 7 when a weight-2 packed op
+  //    straddles the 6 boundary (close at acc>=6; max overshoot 5+2=7). Groups
+  //    are [MFMA][6-7 weight]. When X > 6*Y the leftover valu (X - ~6*Y) sit
+  //    BEFORE the first mfma -> a VALU prologue at the stage front. With the
+  //    LOCAL-barrier fix the in-stage lgkmcnt stalls are gone, so the di/dt
+  //    reason for even-spreading no longer applies; front-loading VALU + tight
+  //    mfma groups wins (FAv3: 1073 -> 1076 TFLOPS, 78.1% MFMA-eff/SIMD).
+  //
+  //    GEMM-safe: interleaveRegion only ever runs on the FAv3 warp-pipeline
+  //    steady-state regions -- scheduleRegions calls it solely for INDEPENDENT
+  //    mfma/valu spans, and GEMM has none (its epilogue valu all depend on the
+  //    region's mfmas -> "DEPENDENT -> skip"), so this path never touches GEMM.
+
+  SmallVector<Instruction *, 32> GroupStart; // reverse: last group first
+  int vi = N - 1;
+  {
+    // Group weight per mfma. Default 6 (REVERSE-6, tuned for VALU-heavy stages
+    // like FA's PV: X=105 for 16 mfma -- surplus valu front-load as a
+    // prologue). When the region is VALU-light (X < 6*Y, e.g. FA's QK stage:
+    // X=51 for 16 mfma) a fixed 6 strands (Y - X/6) mfmas in a front cluster,
+    // so shrink the group weight to ~X/Y (>=1) and spread ALL Y mfmas --
+    // interleave the whole region regardless of how little valu it carries
+    // (mfma/valu already verified independent by the caller). Group weight per
+    // mfma. Weight 6 == the full 24-cyc co-exec window (a plain valu is weight
+    // 1 == 4 cyc; exp/permlane weight 2 == 8 cyc). For a VALU-light region (X <
+    // 6*Y) use the smaller X/Y so all Y mfmas get company instead of (Y - X/6)
+    // of them clustering bare at the region front.
+    //
+    // Window-sized groups (G = 6 everywhere) measured WORSE (1162 vs 1174
+    // TFLOPS on FAv4 @16320): bigger groups leave fewer, larger runs, and the
+    // backend's relocation of pure valu then piles a heavier tail into the last
+    // sub-region -- asm window overflow went 16/20 -> 32/32 cyc for QK/PV.
+    int G = 6;
+    if (X < 6 * Y) {
+      G = X / Y;
+      if (G < 1)
+        G = 1;
+    }
+    int acc = 0;
+    for (; vi >= 0 && (int)GroupStart.size() < Y; --vi) {
+      acc += Weights[vi];
+      if (acc >= G) {
+        GroupStart.push_back(Valus[vi]);
+        acc = 0;
+      }
+    }
+    // The reverse walk only closes a group once it reaches G weight, so when
+    // the valu run out mid-group the front-most (unclosed) run is left with no
+    // mfma ahead of it -- exactly the stranded head above. If any mfma is still
+    // unassigned, spend one on that run: `vi + 1` is its first valu (vi == -1
+    // when the walk consumed every valu, giving Valus[0]).
+    if (acc > 0 && (int)GroupStart.size() < Y)
+      GroupStart.push_back(Valus[vi + 1]);
+  }
+
+  // 4. Place mfmas. mfmas[Y-1] before GroupStart[0] (last group), mfmas[Y-2]
+  //    before GroupStart[1], ...  Any mfmas left after the valu run out go at
+  //    the region front, in program order.
+  int P = GroupStart.size();
+  if (std::getenv("LLIRSCHED_WP_DEBUG"))
+    errs() << "  [interleave] Y(mfma)=" << Y << " N(valu)=" << N
+           << " X(weighted)=" << X
+           << " ideal=(X-6)/(Y-1)=" << (double)(X - 6) / (Y - 1)
+           << " groups_formed=" << P << " front_cluster=" << (Y - P) << "\n";
+  int mi = Y - 1;
+  for (int j = 0; j < P; ++j, --mi)
+    Mfmas[mi]->moveBefore(GroupStart[j]->getIterator());
+  // remaining Mfmas[0..mi] -> before the earliest placed mfma (or first valu),
+  // preserving order.
+  Instruction *At = (P > 0) ? Mfmas[mi + 1] : Valus[0];
+  for (; mi >= 0; --mi) {
+    Mfmas[mi]->moveBefore(At->getIterator());
+    At = Mfmas[mi];
+  }
+
+  // 5. Pin the schedule: emit sched.barrier(0) after each mfma so the machine
+  //    scheduler cannot re-cluster the mfmas (which it does otherwise, undoing
+  //    the interleave). One barrier per mfma locks each [mfma][valu-group]
+  //    pair. Env-toggle (LLIRSCHED_WP_PIN=0 disables) to A/B the pinning.
+  if (pin)
+    for (Instruction *M : Mfmas)
+      insertSchedBarrierAfter(M);
+}
+
+// LLIRSCHED_WP_MEMNOP=k: emit k x `s_nop 7` (8 idle scalar cycles each) at the
+// START of every MEM region -- a region between two cluster barriers that
+// carries memory ops but no mfma.
+//
+// Borrowed from ROCm/FlyDSL's gfx950 FA kernel, which opens every one of its
+// mem clusters with `_s_nop(7)` immediately before that cluster's
+// sched_barrier(0). The point is not to waste time: in an inter-wave ping-pong
+// pipeline the two waves alternate dot/mem clusters, and a fixed delay at the
+// head of the mem cluster shifts this wave's ds_read burst slightly later, so
+// it does not collide with the other wave's LDS traffic / issue slots. It is a
+// phase-tuning knob for the two-wave interleave, so the right value is
+// empirical.
+//
+// FlyDSL writes this as raw inline asm (llvm.inline_asm "s_nop 7",
+// side-effecting) because ROCDL has no s.nop op; at the LLVM-IR level we can
+// use the real llvm.amdgcn.s.nop(i16) intrinsic instead.
+static bool insertMemRegionNops(Function &F, int count) {
+  if (count <= 0)
+    return false;
+  auto isRealBarrier = [](const Instruction &I) {
+    if (const auto *CI = dyn_cast<CallInst>(&I))
+      if (const Function *F = CI->getCalledFunction())
+        return F->getName().contains("amdgcn.s.barrier");
+    return false;
+  };
+  // Flatten the function into layout order. A stage is delimited by the REAL
+  // cluster barrier (amdgcn.s.barrier), and a stage can SPAN SEVERAL BASIC
+  // BLOCKS: FAv4's mem2 carries the lazy-rescale warp_predicate, whose branch
+  // splits the stage across 2-4 blocks. Walking per-block therefore never sees
+  // mem2's closing barrier and skipped it entirely (mem1, a single block, was
+  // the only stage that got its nops).
+  SmallVector<Instruction *, 512> flat;
+  for (BasicBlock &BB : F)
+    for (Instruction &I : BB)
+      flat.push_back(&I);
+
+  bool changed = false;
+  for (size_t i = 0; i < flat.size(); ++i) {
+    if (!isRealBarrier(*flat[i]))
+      continue;
+    // Classify the stage that FOLLOWS this barrier, up to the next one.
+    bool hasMfma = false, hasMem = false;
+    size_t j = i + 1;
+    for (; j < flat.size() && !isRealBarrier(*flat[j]); ++j) {
+      if (Utils::isMFMAorWMMA(*flat[j])) {
+        hasMfma = true;
+        break;
+      }
+      SchedKind K = Utils::classifySchedInst(*flat[j]);
+      if (K == SchedKind::GR || K == SchedKind::LR || K == SchedKind::LW)
+        hasMem = true;
+    }
+    if (hasMfma || !hasMem)
+      continue;
+    // Insert at the head of that mem stage, i.e. right after the barrier.
+    Instruction *ip = flat[i]->getNextNode();
+    while (ip && isa<PHINode>(ip))
+      ip = ip->getNextNode();
+    if (!ip)
+      continue;
+    IRBuilder<> B(ip);
+    for (int k = 0; k < count; ++k)
+      B.CreateIntrinsic(Intrinsic::amdgcn_s_nop,
+                        {B.getInt16(7)}); // s_nop 7 == 8 idle cycles
+    changed = true;
+  }
+  return changed;
+}
+
+// Detect sched.barrier-delimited regions; interleave MFMA<->VALU in the ones
+// that are independent (loop steady-state); skip dependent regions (prologue /
+// coarse) and regions missing mfma or valu. Returns true if anything changed.
+static bool scheduleRegions(Function &F) {
+  const bool Dbg = std::getenv("LLIRSCHED_WP_DEBUG") != nullptr;
+  // Declare the schedule via sched_group_barrier (IGroupLP) rather than
+  // physically reordering + sched_barrier(0) pinning. This is the DEFAULT:
+  // pinning is only advisory, and codegen was measured still consolidating a
+  // stage's last groups despite it, so the declaration is the stronger form.
+  // LLIRSCHED_WP_NOSGB falls back to the physical interleave (slower; kept for
+  // A/B).
+  const bool SGB = std::getenv("LLIRSCHED_WP_NOSGB") == nullptr;
+  // Region: mfma-bearing regions seen (the denominator worth reporting).
+  // SyncID: identifies a *declared* region to IGroupLP. Keep it independent of
+  // how many spans were skipped, so adding a skip reason cannot renumber the
+  // declarations of the regions that do get scheduled.
+  int Region = 0, Done = 0, SyncID = 1;
+  bool Changed = false;
+  for (BasicBlock &BB : F) {
+    // Region boundaries = sched.barriers; process each span between them.
+    Instruction *SpanBegin = &BB.front();
+    SmallVector<std::pair<Instruction *, Instruction *>, 16> Spans;
+    for (Instruction &I : BB) {
+      if (isSchedBarrier(I)) {
+        Spans.push_back({SpanBegin, &I});
+        SpanBegin = I.getNextNode();
+      }
+    }
+    if (SpanBegin)
+      Spans.push_back({SpanBegin, nullptr});
+
+    for (auto &S : Spans) {
+      Instruction *B = S.first, *E = S.second;
+      if (!B)
+        continue;
+      auto EIt = E ? E->getIterator() : BB.end();
+
+      // Pick the model from the region's contents, not from the kernel's
+      // identity.
+      int nMfma = 0, nValu = 0, nMem = 0;
+      RegionModel Model = classifyRegion(B, EIt, nMfma, nValu, nMem);
+      if (Model != RegionModel::CoExec) {
+        // Throughput regions belong to the LLIRScheduler path, Mixed ones to
+        // nobody yet; either way this namespace's co-exec model must not touch
+        // them -- it would spread VALU into windows that exist to cover memory
+        // latency.
+        if (Model != RegionModel::None) {
+          if (Dbg)
+            errs() << "[wp-region " << Region << "] mfma=" << nMfma
+                   << " valu=" << nValu << " mem=" << nMem << "  "
+                   << modelName(Model) << " -> skip\n";
+          ++Region; // counts as a candidate: it has mfma, we just do not own it
+        }
+        continue;
+      }
+
+      SmallVector<Instruction *, 32> Mfmas, Valus;
+      SmallPtrSet<const Instruction *, 32> MfmaSet;
+      for (auto It = B->getIterator(); It != EIt; ++It) {
+        if (Utils::isMFMAorWMMA(*It)) {
+          Mfmas.push_back(&*It);
+          MfmaSet.insert(&*It);
+        } else if (valuWeight(*It) > 0) {
+          Valus.push_back(&*It);
+        }
+      }
+      if (Mfmas.empty() || Valus.empty())
+        continue; // classifyRegion already guarantees both, belt and braces
+      // Independence must hold BOTH ways (intra-iteration): no valu uses a
+      // region mfma, AND no mfma uses a region valu (e.g. an mfma input built
+      // from a fptrunc). Only then can mfmas move freely among the valu.
+      SmallPtrSet<const Instruction *, 32> ValuSet(Valus.begin(), Valus.end());
+      int Dep = 0;
+      for (Instruction *V : Valus)
+        if (dependsOnAny(V, MfmaSet))
+          ++Dep;
+      for (Instruction *M : Mfmas)
+        if (dependsOnAny(M, ValuSet))
+          ++Dep;
+      bool Independent = (Dep == 0);
+      if (Dbg)
+        errs() << "[wp-region " << Region << "] mfma=" << Mfmas.size()
+               << " valu=" << Valus.size() << " mem=" << nMem
+               << " valu_dep_on_mfma=" << Dep << "  " << modelName(Model)
+               << (Independent ? ", INDEPENDENT -> interleave"
+                               : ", DEPENDENT -> skip")
+               << "\n";
+      ++Region;
+      if (Independent) {
+        if (SGB) {
+          // Pure declaration: do NOT physically reorder. The plugin only
+          // *computes* the interleave (group sizes) and hands it to IGroupLP as
+          // sched_group_barrier hints, which then builds the schedule itself.
+          // syncID must be unique per region so IGroupLP solves each stage's
+          // pipeline independently (FlyDSL uses one syncID per cluster too).
+          if (declareRegionGroups(B, E, ++SyncID)) {
+            ++Done;
+            Changed = true;
+          }
+        } else {
+          interleaveRegion(B, E);
+          ++Done;
+          Changed = true;
+        }
+      }
+    }
+  }
+  // Mem-stage head pacing, on by default at the measured optimum. k=2 won on
+  // both kernels (SOQ=0: 1234.3 vs 1227.4 at k=0 and 1218.8 at k=3; SOQ=1:
+  // 1244.9 vs 1239.7 at k=3). LLIRSCHED_WP_MEMNOP=k overrides, and k=0 disables
+  // it.
+  {
+    int k = kDefaultMemNops;
+    if (const char *nopEnv = std::getenv("LLIRSCHED_WP_MEMNOP"))
+      k = atoi(nopEnv);
+    if (k > 0 && insertMemRegionNops(F, k)) {
+      Changed = true;
+      if (Dbg)
+        errs() << "[wp] inserted " << k
+               << " x s_nop 7 at each mem-region head\n";
+    }
+  }
+  if (Dbg)
+    errs() << "[wp] " << F.getName().str() << ": interleaved " << Done << "/"
+           << Region << " regions\n";
+  return Changed;
+}
+
+} // namespace WP
+
+// ---- New-PassManager wrapper (out-of-tree port of PR#73's legacy pass) ----
+// Transactional: clone the function, schedule, verifyFunction, and roll back to
+// the pristine body on failure (so a bad schedule never reaches codegen). The
+// schedule is pinned by the sched.barriers the scheduler inserts, so nothing
+// downstream (make_amdgcn) needs to disable LLVM's machine scheduler.
+static bool runLlirScheduleTransactional(Function &F) {
+  if (F.isDeclaration())
+    return false;
+
+  ValueToValueMapTy VMap;
+  Function *Backup = CloneFunction(&F, VMap);
+  Backup->setName(F.getName() + ".llirsched.bak");
+
+  LLIRScheduler Scheduler;
+  bool didSchedule = Scheduler.run(F);
+
+  if (verifyFunction(F, /*OS=*/nullptr)) {
+    if (std::getenv("LLIRSCHED_WP_DEBUG"))
+      errs() << "[wp] ROLLBACK (invalid IR)\n";
+    if (std::getenv("LLIRSCHED_DEBUG"))
+      errs() << "[llirsched] function '" << F.getName()
+             << "': whole-function verify FAILED -> ROLLBACK entire schedule\n";
+    LLVM_DEBUG(dbgs() << "LLIR schedule produced invalid IR; rolling back.\n");
+    auto OrigLinkage = F.getLinkage();
+    F.deleteBody();
+    F.splice(F.end(), Backup);
+    F.setLinkage(OrigLinkage);
+    for (unsigned i = 0, e = F.arg_size(); i != e; ++i)
+      Backup->getArg(i)->replaceAllUsesWith(F.getArg(i));
+    Backup->eraseFromParent();
+    return false;
+  }
+
+  if (std::getenv("LLIRSCHED_DEBUG"))
+    errs()
+        << "[llirsched] function '" << F.getName()
+        << "': whole-function verify PASSED -> schedule committed (didSchedule="
+        << didSchedule << ")\n";
+  Backup->eraseFromParent();
+  return didSchedule;
+}
+
+// Debug: dump a function's IR to <LLIRSCHED_DUMP_IR>/<fname>.<tag>.ll, so the
+// effect of the scheduler can be diffed before/after. No-op unless the env var
+// (a directory) is set.
+static void dumpFuncIR(Function &F, const char *tag) {
+  const char *dir = std::getenv("LLIRSCHED_DUMP_IR");
+  if (!dir)
+    return;
+  std::error_code EC;
+  std::string path =
+      std::string(dir) + "/" + F.getName().str() + "." + tag + ".ll";
+  raw_fd_ostream os(path, EC);
+  if (!EC)
+    F.print(os);
+}
+
+struct LlirSchedPass : PassInfoMixin<LlirSchedPass> {
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &) {
+    // Warp-pipeline (Flash-Attention) kernels: regions are pre-delimited by
+    // sched.barrier. Interleave MFMA<->VALU in the independent (steady-state)
+    // regions. Transactional: clone, interleave, verify, roll back on failure.
+    if (!F.isDeclaration() && WP::isWarpPipelineFunc(F)) {
+      ValueToValueMapTy VMap;
+      Function *Backup = CloneFunction(&F, VMap);
+      Backup->setName(F.getName() + ".wpsched.bak");
+      bool wpChanged = WP::scheduleRegions(F);
+      if (verifyFunction(F, std::getenv("LLIRSCHED_WP_DEBUG") ? &errs()
+                                                              : nullptr)) {
+        if (std::getenv("LLIRSCHED_WP_DEBUG"))
+          errs() << "[wp] ROLLBACK (invalid IR)\n";
+        LLVM_DEBUG(
+            dbgs() << "wp interleave produced invalid IR; rolling back.\n");
+        auto OrigLinkage = F.getLinkage();
+        F.deleteBody();
+        F.splice(F.end(), Backup);
+        F.setLinkage(OrigLinkage);
+        for (unsigned i = 0, e = F.arg_size(); i != e; ++i)
+          Backup->getArg(i)->replaceAllUsesWith(F.getArg(i));
+        Backup->eraseFromParent();
+        return PreservedAnalyses::all();
+      }
+      Backup->eraseFromParent();
+      if (!wpChanged)
+        return PreservedAnalyses::all();
+      PreservedAnalyses PA;
+      PA.preserveSet<CFGAnalyses>();
+      return PA;
+    }
+    bool hadRegionMarkers = Utils::functionHasSchedRegionMarkers(F);
+    dumpFuncIR(F, "before");
+    bool changed = runLlirScheduleTransactional(F);
+    dumpFuncIR(F, "after");
+    // Drop the tlx.sched_region markers so codegen never sees them (they only
+    // bounded this pass). Done after scheduling, and covers the rollback case
+    // too (the restored body still carries the markers).
+    if (hadRegionMarkers) {
+      Utils::eraseSchedRegionMarkers(F);
+      changed = true;
+    }
+    if (!changed)
+      return PreservedAnalyses::all();
+    // Only reorders/insert within blocks; CFG is preserved.
+    PreservedAnalyses PA;
+    PA.preserveSet<CFGAnalyses>();
+    return PA;
+  }
+};
+
+} // end anonymous namespace
+
+// Native in-tree registration (replaces the out-of-tree plugin boilerplate).
+// Called from python/src/llvm.cc's optimize_module when
+// TRITON_ENABLE_LLIR_SCHED is set, mirroring where the external plugin
+// registered itself (OptimizerLast).
+namespace mlir::triton::amdsched {
+void registerLlirSchedAtOptimizerLast(llvm::PassBuilder &PB) {
+  // Run at the very end of the O3 function pipeline so the pass sees near-final
+  // IR (individual mfma / ds_read / buffer_load).
+  PB.registerOptimizerLastEPCallback([](llvm::ModulePassManager &MPM,
+                                        llvm::OptimizationLevel,
+                                        llvm::ThinOrFullLTOPhase) {
+    MPM.addPass(llvm::createModuleToFunctionPassAdaptor(LlirSchedPass()));
+  });
+}
+} // namespace mlir::triton::amdsched

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -52,6 +52,14 @@ struct BreakStructPhiNodesPass : PassInfoMixin<BreakStructPhiNodesPass> {
 
 using namespace llvm;
 
+// Native gfx950 LLIR scheduler (python/src/LlirSchedule.cpp). Registers the
+// LLVM-IR MFMA<->mem/VALU scheduling pass at OptimizerLast on the given
+// builder. Declared outside the anonymous namespace below: the definition lives
+// in another TU, and the call site is past that namespace's close.
+namespace mlir::triton::amdsched {
+void registerLlirSchedAtOptimizerLast(llvm::PassBuilder &PB);
+} // namespace mlir::triton::amdsched
+
 namespace {
 
 // Set an LLVM command-line option using addOccurrence (simulates command-line)
@@ -743,6 +751,38 @@ void init_triton_llvm(py::module &&m) {
         std::string pluginFile =
             mlir::triton::tools::getStrEnv("LLVM_PASS_PLUGIN_PATH");
 
+        // TRITON_LLVM_OPTS="opt1=val1,opt2=val2" sets registered LLVM cl::opt
+        // values by name, so backend knobs that are only exposed as -mllvm
+        // flags can be driven from Python without a custom driver. Needed for
+        // the AMDGPU register-allocation knobs (amdgpu-spill-vgpr-to-agpr,
+        // amdgpu-mfma-vgpr-form, ...) that decide whether MFMA accumulators
+        // stay in one register bank; on a4w4 only 54/256 MFMAs currently
+        // accumulate in place because the accumulator is split AGPR/VGPR.
+        if (auto optStr = mlir::triton::tools::getStrEnv("TRITON_LLVM_OPTS");
+            !optStr.empty()) {
+          auto &registry = llvm::cl::getRegisteredOptions();
+          llvm::SmallVector<llvm::StringRef, 8> parts;
+          llvm::StringRef(optStr).split(parts, ',', -1, /*KeepEmpty=*/false);
+          for (llvm::StringRef p : parts) {
+            auto [name, value] = p.trim().split('=');
+            auto it = registry.find(name.trim());
+            if (it == registry.end()) {
+              llvm::errs() << "[triton] TRITON_LLVM_OPTS: unknown option '"
+                           << name << "'\n";
+              continue;
+            }
+            std::string v = value.trim().str();
+            if (v.empty())
+              v = "true";
+            if (it->second->addOccurrence(0, name.trim(), v))
+              llvm::errs() << "[triton] TRITON_LLVM_OPTS: failed to set '"
+                           << name << "' = '" << v << "'\n";
+            else
+              llvm::errs() << "[triton] TRITON_LLVM_OPTS: " << name << " = "
+                           << v << "\n";
+          }
+        }
+
         // We don't pass the targetMachine to the LLVM-IR pass builder, unless
         // `arch` is specified.
         //
@@ -759,6 +799,14 @@ void init_triton_llvm(py::module &&m) {
               createTargetMachine(mod, arch, enable_fp_fusion, features);
         PassBuilder pb(/*targetMachine=*/targetMachine.get(), tuningOptions,
                        std::nullopt, instrCbPtr);
+
+        // Native in-tree gfx950 LLIR scheduler (ported from the out-of-tree
+        // ROCm plugin). Registers at OptimizerLast, like the external plugin,
+        // but compiled into libtriton so it needs no plugin .so / default
+        // visibility / KEEP_TARGET_MACHINE (arch is non-empty here so the
+        // target machine is already created above).
+        if (mlir::triton::tools::getBoolEnv("TRITON_ENABLE_LLIR_SCHED"))
+          mlir::triton::amdsched::registerLlirSchedAtOptimizerLast(pb);
 
         if (!pluginFile.empty()) {
           // TODO: Add some logging here that we inserted a pass into the LLVM

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -2,6 +2,7 @@
 #include "Transforms/Passes.h"
 #include "amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "ir.h" // TritonOpBuilder
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Pass/PassManager.h"
 #include "nvidia/include/Dialect/NVGPU/IR/Dialect.h"
 #include "passes.h"
@@ -654,6 +655,14 @@ void init_triton_tlx_ir(py::module &&m) {
            [](TritonOpBuilder &self, Value barrier, Value numThreads) -> void {
              self.create<ttng::NamedBarrierArriveOp>(barrier, numThreads);
            })
+      .def("create_sched_barrier",
+           [](TritonOpBuilder &self, int mask) -> void {
+             // AMD scheduling-only fence (no memory/exec barrier). mask selects
+             // which instruction classes may cross (0 = none). Also used to
+             // carry the reserved sentinel masks that mark an LLIR-scheduler
+             // region (see tlx.sched_region_begin/end + LlirSchedule.cpp).
+             self.create<ROCDL::SchedBarrier>(mask);
+           })
       .def("create_barrier_expect",
            [](TritonOpBuilder &self, Value mbarrerLoc, int expectBytes,
               Value pred) -> void {
@@ -1225,15 +1234,23 @@ void init_triton_tlx_ir(py::module &&m) {
       .def("create_buffer_load",
            [](TritonOpBuilder &self, Value ptr, Value offsets,
               std::optional<Value> mask, std::optional<Value> other,
-              tt::CacheModifier cache) -> Value {
+              tt::CacheModifier cache, int32_t contiguity) -> Value {
              auto offsetsType = cast<RankedTensorType>(offsets.getType());
              auto ptrType = cast<tt::PointerType>(ptr.getType());
              auto resultType = RankedTensorType::get(offsetsType.getShape(),
                                                      ptrType.getPointeeType(),
                                                      offsetsType.getEncoding());
+             // `contiguity` is the AMD BufferLoadOp vectorization hint: the
+             // lowering takes max(inferred, hint). AxisInfo can only express
+             // contiguity along a logical tensor axis, so it cannot see a load
+             // whose per-lane addresses are consecutive in (lane, register)
+             // space -- e.g. a pre-shuffled scale tile, where within a row the
+             // offsets read {0,256,512,768,1,257,513,769}. Such a load
+             // scalarizes to one instruction per element unless the caller
+             // asserts the width here.
              return self.create<ttag::BufferLoadOp>(
                  resultType, ptr, offsets, Value() /*stride*/, cache,
-                 mask.value_or(Value()), other.value_or(Value()));
+                 mask.value_or(Value()), other.value_or(Value()), contiguity);
            })
       .def("create_buffer_store",
            [](TritonOpBuilder &self, Value storedValue, Value ptr,

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -10,6 +10,9 @@ from .barrier import (
     fence_mbarrier_init_cluster,
     named_barrier_arrive,
     named_barrier_wait,
+    sched_barrier,
+    sched_region_begin,
+    sched_region_end,
 )
 from .dynamic_launch import (
     _alloc_clc_responses,
@@ -192,6 +195,9 @@ __all__ = [
     "fence_mbarrier_init_cluster",
     "named_barrier_wait",
     "named_barrier_arrive",
+    "sched_barrier",
+    "sched_region_begin",
+    "sched_region_end",
     # mma_ops
     "async_dot",
     "async_dot_scaled",

--- a/third_party/tlx/language/tlx/barrier.py
+++ b/third_party/tlx/language/tlx/barrier.py
@@ -211,3 +211,50 @@ def named_barrier_arrive(
     bar_handle = _semantic._convert_elem_to_ir_value(bar, require_i64=False)
     arrive_count_handle = _semantic._convert_elem_to_ir_value(arrive_count, require_i64=False)
     _semantic.builder.create_named_barrier_arrive(bar_handle, arrive_count_handle)
+
+
+# Reserved sentinel masks that tag an LLIR-scheduler region boundary. They ride
+# on rocdl.sched.barrier (a recognizable, valid op that survives IR opt) but are
+# NOT real machine-scheduler fences: the native LLIR scheduler
+# (python/src/LlirSchedule.cpp, gated by TRITON_ENABLE_LLIR_SCHED) recognizes
+# them, schedules only the enclosed span, leaves everything outside untouched,
+# and deletes the markers before codegen.
+#
+# These must be VALID ROCDL SchedGroupMask bit combinations (<= all = 4095): as of
+# LLVM 850a2b1b the rocdl.sched.barrier mask is a typed SchedGroupMaskAttr, and an
+# out-of-range sentinel (we used to use 0x40000001) fails op verification with
+# "requires attribute 'mask'". transcendental|ldsdma (+ds_write) is never emitted by
+# any other path -- Triton only emits none(0), and BlockPingpong uses 1/4/8. Being
+# in range also means that if the LLIR pass is disabled the markers degrade to a
+# harmless real sched_barrier instead of tripping the backend's bitmask assert.
+_LLIR_SCHED_REGION_BEGIN_MASK: tl.constexpr = 0xc00
+_LLIR_SCHED_REGION_END_MASK: tl.constexpr = 0xe00
+
+
+@tl.builtin
+def sched_barrier(mask: tl.constexpr = 0, _semantic=None) -> None:
+    """AMD instruction-scheduling fence (no memory/exec barrier). mask 0 = hard
+    boundary (no instruction class crosses). Lowers to rocdl.sched.barrier."""
+    if not is_hip():
+        raise NotImplementedError("tlx.sched_barrier is AMD (HIP) only")
+    mask_val = mask.value if isinstance(mask, tl.constexpr) else mask
+    _semantic.builder.create_sched_barrier(mask_val)
+
+
+@tl.builtin
+def sched_region_begin(_semantic=None) -> None:
+    """Mark the START of a region for the native LLIR scheduler
+    (TRITON_ENABLE_LLIR_SCHED). The scheduler reorders/interleaves only the span
+    between a begin/end pair and leaves code outside untouched; the markers are
+    removed before codegen (no residual fence)."""
+    if not is_hip():
+        raise NotImplementedError("tlx.sched_region_begin is AMD (HIP) only")
+    _semantic.builder.create_sched_barrier(_LLIR_SCHED_REGION_BEGIN_MASK)
+
+
+@tl.builtin
+def sched_region_end(_semantic=None) -> None:
+    """Mark the END of a native LLIR-scheduler region (see sched_region_begin)."""
+    if not is_hip():
+        raise NotImplementedError("tlx.sched_region_end is AMD (HIP) only")
+    _semantic.builder.create_sched_barrier(_LLIR_SCHED_REGION_END_MASK)

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -26,7 +26,7 @@ def _verify_buffer_ops(ptr, offsets, mask=None, other=None):
 
 
 @tl.builtin
-def buffer_load(ptr, offsets, mask=None, other=None, cache=None, _semantic=None):
+def buffer_load(ptr, offsets, mask=None, other=None, cache=None, contiguity=1, _semantic=None):
     """
     AMD buffer load from global memory via a scalar base pointer and a tensor
     of i32 element offsets. Loads data directly into registers.
@@ -40,6 +40,19 @@ def buffer_load(ptr, offsets, mask=None, other=None, cache=None, _semantic=None)
         mask: Optional bool tensor for predicated loads.
         other: Optional tensor/scalar providing default values for masked elements.
         cache: Optional cache modifier string.
+        contiguity: Vectorization hint -- assert that each lane's `contiguity`
+            consecutive registers hold consecutive addresses, so the load is
+            emitted as one vector instruction of that width. The lowering takes
+            max(inferred, hint), so the default 1 changes nothing.
+
+            Needed when the addresses are contiguous per lane but NOT along any
+            logical tensor axis, which AxisInfo is the only thing able to infer.
+            A pre-shuffled scale tile is the motivating case: within a row the
+            offsets run {0,256,512,768,1,257,513,769}, so inference yields 1 and
+            the load scalarizes to one instruction per element.
+
+            UNCHECKED. If the addresses are not actually consecutive the load
+            reads the wrong memory.
     """
     _verify_buffer_ops(ptr, offsets, mask, other)
 
@@ -60,7 +73,8 @@ def buffer_load(ptr, offsets, mask=None, other=None, cache=None, _semantic=None)
     cache_modifier = _semantic._str_to_load_cache_modifier(cache) if cache else ir.CACHE_MODIFIER.NONE
 
     ret_ty = tl.block_type(ptr.type.scalar.element_ty, offsets.type.get_block_shapes())
-    handle = _semantic.builder.create_buffer_load(ptr.handle, offsets.handle, mask_handle, other_handle, cache_modifier)
+    handle = _semantic.builder.create_buffer_load(ptr.handle, offsets.handle, mask_handle, other_handle, cache_modifier,
+                                                  tl._unwrap_if_constexpr(contiguity))
     return tl.tensor(handle, ret_ty)
 
 

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
@@ -872,11 +872,14 @@ def _matmul_skinny(a, b, a_scales, b_scales, SPLIT_K=None):
 
 def matmul(a, b, a_scales, b_scales):
     """A @ B.T for packed MXFP4 A/B. Dispatches on the 256-tile grid fill:
-    severely occupancy-starved shapes (e.g. skinny-N) take the 128x128 + split-K
-    TLX path; everything else takes the 256x256 inter-wave path."""
+    the 256x256 inter-wave tile only fills the GPU once its grid reaches ~half the
+    CUs; below that it wastes CUs (a 256x256 tile is 1 workgroup/CU), so route those
+    occupancy-starved shapes to the 128x128 + split-K path, which spawns 4x the
+    workgroups and refills with split-K. Measured crossover on gfx950 (256 CUs):
+    skinny wins for grid_256 <= 64, the 256x256 tile wins from grid_256 >= 128."""
     M = a.shape[0]
     N = b.shape[0]
     grid_mn_256 = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
-    if grid_mn_256 <= NUM_CU // 32:
+    if grid_mn_256 <= NUM_CU // 4:
         return _matmul_skinny(a, b, a_scales, b_scales)
     return _matmul_256tile(a, b, a_scales, b_scales)

--- a/third_party/tlx/tutorials/gfx9_gemm/intra_wave/a4w4/bench_best_tile.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/intra_wave/a4w4/bench_best_tile.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Run the official AITER-comparison harness across all shapes, best tile per shape.
+
+Why this exists: there are four tile kernels and no dispatcher, so "what is our
+status" means running the right kernel per shape and collating by hand. Doing
+that by hand produced two wrong tables in one sitting -- once by running the
+256x256 kernel on a shape the 128x128 tile owns, once by forgetting that the
+256x256 kernel is the one kernel whose best config has the LLIR scheduler ON.
+Both are encoded below instead.
+
+Selection rule, confirmed on every shape measured so far: pick the tile whose
+grid lands on 256 = the CU count of an MI350X. Tiles that overshoot (two
+workgroups per CU with half the arithmetic intensity each) or undershoot (idle
+CUs) both lose, typically by 10-20%.
+
+    grid = ceil(M / BLOCK_M) * ceil(N / BLOCK_N)
+
+This is a BENCHMARK driver, not a dispatcher. A real dispatcher additionally
+needs a tile-independent input format: shuffle_a_scale is parameterised by
+BLOCK_M, and only the 32x128/64x128 kernels accept pre-shuffled B weights, so
+the required input form currently differs by tile -- and no single shuffle
+callback sees both M and N to choose one.
+
+Usage:
+    python bench_best_tile.py [--harness PATH] [--shape MxNxK ...]
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+# The 256x256 kernel REQUIRES both the LLIR scheduler and force-AGPR, together.
+# Without force-AGPR the scheduler spills 48 registers (512 vgpr / 256 agpr) and
+# the kernel is 3-5x slower; with it, 484/256 and zero spills. 0.888 -> 1.088.
+#
+# NOTE the flag has NO leading dash: TRITON_LLVM_OPTS looks the name up in
+# llvm::cl::getRegisteredOptions(). "-amdgpu-mfma-vgpr-form=false" is silently
+# ignored (it warns on stderr, which sweep scripts routinely discard). Confirm
+# with:  [triton] TRITON_LLVM_OPTS: amdgpu-mfma-vgpr-form = false
+SCHED_AGPR = {
+    "TRITON_ENABLE_LLIR_SCHED": "1",
+    "TRITON_LLVM_OPTS": "amdgpu-mfma-vgpr-form=false",
+}
+
+# shape -> (kernel module file, extra env, note)
+# Ratios in the comments are AITER/ours measured 2026-08-02; > 1.0 is a win.
+PLAN = {
+    (256, 4096, 4096): ("matmul_kernel_32.py", {}, "grid 8x32=256"),
+    (256, 8192, 4096): ("matmul_kernel_64.py", {}, "grid 4x64=256"),
+    (512, 4096, 4096): ("matmul_kernel_64.py", {}, "grid 8x32=256"),
+    (512, 8192, 4096): ("matmul_kernel_128.py", {}, "grid 4x64=256"),
+    # 128x256 wants the scheduler but NOT force-AGPR, unlike its 256x256 parent:
+    # 0.984/0.982/0.983 vs 0.981/0.974/0.972 over three harness reps each. Forcing
+    # AGPR here costs 164 agpr vs 105 and buys nothing -- there are no spills to
+    # fix. AITER's own kernel reports .vgpr_count 512 with no .agpr_count at all.
+    (2048, 4096, 8192): ("matmul_kernel_128x256.py", {"TRITON_ENABLE_LLIR_SCHED": "1"}, "grid 16x16=256"),
+    (2048, 8192, 4096): ("matmul_kernel.py", SCHED_AGPR, "grid 8x32=256"),
+    (2048, 8192, 8192): ("matmul_kernel.py", SCHED_AGPR, "grid 8x32=256"),
+}
+
+ROW = re.compile(r"^\s*(\d+)x(\d+)x(\d+)\s+([\d.]+)\s+\S+\s+\S+\s+([\d.]+)\s+([\d.]+)\s*$")
+
+
+def run_one(harness, kernel, shape, env_extra):
+    import os
+
+    env = dict(os.environ)
+    env.update(env_extra)
+    cmd = [
+        sys.executable,
+        str(harness),
+        "--tlx-intra-wave-source",
+        str(HERE / kernel),
+        "--allow-source-mismatch",
+        "--shape",
+        "x".join(str(v) for v in shape),
+    ]
+    out = subprocess.run(cmd, capture_output=True, text=True, env=env).stdout
+    for line in out.splitlines():
+        m = ROW.match(line)
+        if m and tuple(int(m.group(i)) for i in (1, 2, 3)) == shape:
+            return float(m.group(4)), float(m.group(5)), float(m.group(6))
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--harness", type=Path, default=Path("/tmp/aiter_baseline_repro.py"))
+    ap.add_argument("--shape", action="append", dest="shapes")
+    args = ap.parse_args()
+
+    shapes = list(PLAN)
+    if args.shapes:
+        want = {tuple(int(v) for v in s.split("x")) for s in args.shapes}
+        shapes = [s for s in shapes if s in want]
+        for s in sorted(want - set(PLAN)):
+            print(f"!! no tile planned for {s[0]}x{s[1]}x{s[2]}", file=sys.stderr)
+
+    print(f"{'shape':<16}{'tile':<14}{'AITER us':>9}{'ours us':>9}{'ratio':>8}   note")
+    ratios = []
+    for shape in shapes:
+        kernel, env_extra, note = PLAN[shape]
+        got = run_one(args.harness, kernel, shape, env_extra)
+        label = f"{shape[0]}x{shape[1]}x{shape[2]}"
+        tile = kernel.replace("matmul_kernel", "").replace(".py", "").strip("_") or "256"
+        if got is None:
+            print(f"{label:<16}{tile:<14}{'FAILED':>9}")
+            continue
+        aiter_us, ours_us, ratio = got
+        ratios.append(ratio)
+        flag = " <-- win" if ratio >= 1.0 else ""
+        print(f"{label:<16}{tile:<14}{aiter_us:9.2f}{ours_us:9.2f}{ratio:8.3f}   {note}{flag}")
+    if ratios:
+        print(
+            f"\ngeomean ratio: {(lambda v: __import__('math').exp(sum(map(__import__('math').log, v)) / len(v)))(ratios):.3f}"
+            f"   ({sum(r >= 1.0 for r in ratios)}/{len(ratios)} shapes at or above AITER)")
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/tlx/tutorials/gfx9_gemm/intra_wave/a4w4/matmul_kernel_128.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/intra_wave/a4w4/matmul_kernel_128.py
@@ -1,0 +1,385 @@
+"""TLX MXFP4 GEMM for gfx950 -- 128x128 tile, for occupancy-starved shapes.
+
+Companion to the 256x256 kernel in matmul_kernel.py. Same ABI, same intra-wave
+structure; the only reason it exists is grid fill.
+
+A 256x256 tile is one workgroup per CU, so on a 256-CU MI350X it needs
+M*N >= 256*65536 to fill the machine. Below that it strands CUs: 256x4096x4096
+launches 16 workgroups on 256 CUs. Measured against AITER on the four small
+shapes the 256x256 kernel lands at 0.385-0.562 -- the loop body is the same one
+that reaches parity on large shapes, it is simply running on 6-25% of the GPU.
+
+AITER's tuned configs make the rule explicit: it selects 32x128 / 64x128 /
+128x128 / 128x128 on those four shapes, i.e. whichever tile makes the grid come
+out at exactly 256. This kernel supplies the 128x128 point of that curve:
+
+    512x8192x4096   ->  4 x 64 = 256 workgroups   (exact fill)
+    256x8192x4096   ->  2 x 64 = 128
+    512x4096x4096   ->  4 x 32 = 128
+    256x4096x4096   ->  2 x 32 =  64
+
+The narrower tiles (and/or split-K) are what the two smallest shapes still need.
+
+Differences from the 256x256 kernel, all consequences of BLOCK_N:
+  * No left/right N split. BLOCK_N=128 is one MFMA group, so there is a single
+    accumulator and one tl.dot_scaled per k-step instead of two.
+  * No hand-pinned tlx.layout constants. Those in matmul_kernel.py are derived
+    for the 256x256x256 tile specifically and do not carry over; this kernel
+    lets the compiler choose, which is correct but not yet tuned. Use
+    tlx.dump_layout() to read back what it picked before pinning anything.
+  * Scales still take the LDS round-trip. The pre-shuffle + direct-to-VGPR path
+    (shuffle_a_scale in matmul_kernel.py) needs its own derivation per tile.
+
+Inputs use the same ABI as the Gluon a4w4 tutorial:
+  * A: packed e2m1, shape (M, K // 2), K-contiguous
+  * B: packed e2m1, shape (N, K // 2), K-contiguous; computes A @ B.T
+  * scales: e8m0 uint8, shapes (M, K // 32) and (N, K // 32),
+    contiguous along M/N so scale tiles are coalesced
+  * C: bfloat16, shape (M, N)
+"""
+
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+BLOCK_M = 128
+BLOCK_N = 128
+BLOCK_K = 256
+NUM_CU = 256
+# Launch knobs, module-level so a sweep can set them without editing the source.
+NUM_WARPS = 4
+GROUP_SIZE_M = 4
+NUM_XCDS = 8
+
+
+@triton.jit
+def _a4w4_kernel_128(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    a_scales_ptr,
+    b_scales_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bn,
+    stride_bk,
+    stride_cm,
+    stride_cn,
+    stride_asm,
+    stride_ask,
+    stride_bsn,
+    stride_bsk,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    GRID_MN: tl.constexpr,
+):
+    SCALE_GROUP_SIZE: tl.constexpr = 32
+    # Without these the compiler picks sizePerThread=[1,1] for the scale tiles and
+    # the whole scale path scalarizes: 20 ds_write_b8 + 16 ds_read_u8 +
+    # 8 buffer_load_ubyte + 14 v_perm per iteration, ~96 overhead instructions
+    # against 64 MFMAs of real work. The A/B path does not need pinning -- it
+    # already comes out as ds_read_b128 / buffer_load_dwordx4.
+    # Both scale tiles are (128, 8), the same shape as the 256x256 kernel's
+    # B-scale tile, so scale_b_layout carries over unchanged.
+    # Epilogue layouts, read off the TTGIR. NOTE warpsPerCTA here is [2, 2], not
+    # the [1, 4] of the 64x128 kernel -- the wave grid really is 2x2 for this
+    # tile, so the warp dims land in BOTH the row and column halves. Do not carry
+    # the 64x128 versions over.
+    #   #mma     = amd_mfma<{warpsPerCTA=[2,2], instrShape=[16,16,128], isTransposed}>
+    #   #blocked = sizePerThread=[1,8], threadsPerWarp=[4,16], warpsPerCTA=[4,1]
+    store_layout_c: tl.constexpr = tlx.layout(
+        shape=((64, 4), (8, 8)),
+        stride=((8, 512), (1, 2048)),
+    )
+    accumulator_layout: tl.constexpr = tlx.layout(
+        shape=((16, 4, 2, 2), (4, 4, 4)),
+        stride=((128, 4, 16, 2048), (1, 32, 4096)),
+    )
+    scale_mfma_layout: tl.constexpr = tlx.layout(
+        shape=((16, 4, 2, 2), (2, 4)),
+        stride=((8, 1, 128, 0), (4, 256)),
+    )
+    # A and B tiles are both [128, 128] here, which is exactly the shape the
+    # 256x256 kernel derives shared_layout_b for -- so its padded layout carries
+    # over verbatim to both. Left on the compiler default these allocs gave
+    # LDSBankConflict = 18.9% with MfmaUtil at 12%, i.e. the MFMA unit idle 88% of
+    # the time while MemUnitStalled was ~0: LDS-latency bound, not memory bound.
+    # The [[1024, 32]] pad is what breaks the conflicting stride.
+    shared_layout_ab: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [[1024, 32]],
+        [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [0, 64],
+            [16, 0],
+            [32, 0],
+            [64, 0],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+        ],
+        [BLOCK_M, BLOCK_K // 2],
+    )
+    BLOCK_K_PACKED: tl.constexpr = BLOCK_K // 2
+    BLOCK_K_SCALE: tl.constexpr = BLOCK_K // SCALE_GROUP_SIZE
+
+    pid = tl.program_id(0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+
+    # Spread consecutive pids across XCDs so each XCD gets a contiguous stripe
+    # of the (m, n) grid rather than a strided one.
+    if NUM_XCDS != 1:
+        pids_per_xcd = (GRID_MN + NUM_XCDS - 1) // NUM_XCDS
+        tall_xcds = GRID_MN % NUM_XCDS
+        tall_xcds = NUM_XCDS if tall_xcds == 0 else tall_xcds
+        xcd = pid % NUM_XCDS
+        local_pid = pid // NUM_XCDS
+        if xcd < tall_xcds:
+            pid = xcd * pids_per_xcd + local_pid
+        else:
+            pid = tall_xcds * pids_per_xcd + (xcd - tall_xcds) * (pids_per_xcd - 1) + local_pid
+
+    if GROUP_SIZE_M == 1:
+        pid_m = pid // num_pid_n
+        pid_n = pid % num_pid_n
+    else:
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        tl.assume(group_size_m > 0)
+        pid_m = first_pid_m + (pid % num_pid_in_group) % group_size_m
+        pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # 2 x 16 KB for A/B plus 2 x 1 KB of scale scratch = 66 KB, so unlike the
+    # 256x256 kernel (138 KB) this fits two workgroups per CU on the 160 KB
+    # CDNA4 LDS -- which is the point, since these shapes cannot fill the grid.
+    smem_a = tlx.local_alloc((BLOCK_M, BLOCK_K_PACKED), tlx.dtype_of(a_ptr), 2, layout=shared_layout_ab)
+    smem_b = tlx.local_alloc((BLOCK_N, BLOCK_K_PACKED), tlx.dtype_of(b_ptr), 2, layout=shared_layout_ab)
+    # 2-deep, not 1: a 1-deep scratchpad is store->load->(next iter)store on the
+    # same buffer, a cross-iteration WAR across the 4 warps that showed up as a
+    # nondeterministic result (same inputs, different output run to run).
+
+    offs_am = tl.arange(0, BLOCK_M)
+    offs_ak = tl.arange(0, BLOCK_K_PACKED)
+    a_offsets = offs_am[:, None] * stride_am + offs_ak[None, :] * stride_ak
+    a_offsets_next = a_offsets + BLOCK_K_PACKED * stride_ak
+    a_base = a_ptr + pid_m * BLOCK_M * stride_am
+
+    offs_bn = tl.arange(0, BLOCK_N)
+    offs_bk = tl.arange(0, BLOCK_K_PACKED)
+    b_offsets = offs_bn[:, None] * stride_bn + offs_bk[None, :] * stride_bk
+    b_offsets_next = b_offsets + BLOCK_K_PACKED * stride_bk
+    b_base = b_ptr + pid_n * BLOCK_N * stride_bn
+
+    # Pre-shuffled scale addressing. A and B scale tiles are both
+    # (128, BLOCK_K_SCALE), so one offsets tensor serves both. Within a tile the
+    # byte for (row, k) sits at
+    #   (row%16)*8 + (k%4)*128 + ((row//16)%2)*512 + (k//4) + (row//32)*2
+    # which is scale_mfma_layout's (lane, register) -> element map linearised with
+    # the register index innermost -- so each lane's 8 bytes are contiguous and the
+    # load is one buffer_load_dwordx2 straight into MFMA operand layout. No LDS.
+    # shuffle_a_scale / shuffle_b_scale below are the host side of this formula.
+    TILE_S: tl.constexpr = BLOCK_M * BLOCK_K_SCALE
+    offs_srow = tl.arange(0, BLOCK_M)
+    offs_sk = tl.arange(0, BLOCK_K_SCALE)
+    s_row = (offs_srow % 16) * 8 + ((offs_srow // 16) % 2) * 512 + (offs_srow // 32) * 2
+    s_col = (offs_sk % 4) * 128 + (offs_sk // 4)
+    scale_offsets = tl.add(s_row[:, None], s_col[None, :], sanitize_overflow=False)
+    scale_offsets = tlx.require_layout(scale_offsets, scale_mfma_layout)
+    scale_offsets_next = tl.add(scale_offsets, TILE_S, sanitize_overflow=False)
+    a_scales_base = a_scales_ptr + pid_m * (K // 32 // BLOCK_K_SCALE) * TILE_S
+    b_scales_base = b_scales_ptr + pid_n * (K // 32 // BLOCK_K_SCALE) * TILE_S
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    # Runtime trip count so every supported K shares one compiled kernel.
+    iter_max = K // BLOCK_K
+    tl.assume(iter_max > 1)
+
+    # Prime both stages, one async group each.
+    tlx.buffer_load_to_local(smem_a[0], a_base, a_offsets)
+    tlx.buffer_load_to_local(smem_b[0], b_base, b_offsets)
+    a_sc_buf0 = tlx.require_layout(tlx.buffer_load(a_scales_base, scale_offsets, contiguity=8), scale_mfma_layout)
+    b_sc_buf0 = tlx.require_layout(tlx.buffer_load(b_scales_base, scale_offsets, contiguity=8), scale_mfma_layout)
+    tlx.async_load_commit_group()
+
+    tlx.buffer_load_to_local(smem_a[1], a_base, a_offsets_next)
+    tlx.buffer_load_to_local(smem_b[1], b_base, b_offsets_next)
+    a_sc_buf1 = tlx.require_layout(tlx.buffer_load(a_scales_base, scale_offsets_next, contiguity=8), scale_mfma_layout)
+    b_sc_buf1 = tlx.require_layout(tlx.buffer_load(b_scales_base, scale_offsets_next, contiguity=8), scale_mfma_layout)
+    tlx.async_load_commit_group()
+
+    a_base += BLOCK_K_PACKED * stride_ak * 2
+    b_base += BLOCK_K_PACKED * stride_bk * 2
+    a_scales_base += TILE_S * 2
+    b_scales_base += TILE_S * 2
+
+    tlx.async_load_wait_group(1)
+    a = tlx.local_load(smem_a[0])
+    b = tlx.local_load(tlx.local_trans(smem_b[0]))
+    a_sc = a_sc_buf0
+    b_sc = b_sc_buf0
+
+    # Unrolled by 2 so the two LDS stages alternate without an index variable.
+    # Issue the refill for the stage we just consumed BEFORE waiting on the other
+    # stage. With only two stages there is exactly one group per stage, so if the
+    # refill came after the wait there would be a single group outstanding and
+    # async_load_wait_group(1) would be satisfied by 1 <= 1 without waiting for
+    # anything -- the next local_load would then read a buffer whose DMA was still
+    # in flight. That raced: ~20% of the elements of a tile (one warp's share)
+    # differed run to run. Refill-then-wait keeps two groups in flight, so the
+    # wait actually retires the one being read and still overlaps the other.
+    for _ in tl.range(0, iter_max - 2, 2, num_stages=1):
+        acc = tl.dot_scaled(a, a_sc, "e2m1", b, b_sc, "e2m1", acc)
+        tlx.buffer_load_to_local(smem_a[0], a_base, a_offsets)
+        tlx.buffer_load_to_local(smem_b[0], b_base, b_offsets)
+        a_sc_buf0 = tlx.require_layout(tlx.buffer_load(a_scales_base, scale_offsets, contiguity=8), scale_mfma_layout)
+        b_sc_buf0 = tlx.require_layout(tlx.buffer_load(b_scales_base, scale_offsets, contiguity=8), scale_mfma_layout)
+        tlx.async_load_commit_group()
+        tlx.async_load_wait_group(1)
+        a_n = tlx.local_load(smem_a[1])
+        b_n = tlx.local_load(tlx.local_trans(smem_b[1]))
+        a_sc_n = a_sc_buf1
+        b_sc_n = b_sc_buf1
+
+        acc = tl.dot_scaled(a_n, a_sc_n, "e2m1", b_n, b_sc_n, "e2m1", acc)
+        tlx.buffer_load_to_local(smem_a[1], a_base, a_offsets_next)
+        tlx.buffer_load_to_local(smem_b[1], b_base, b_offsets_next)
+        a_sc_buf1 = tlx.require_layout(tlx.buffer_load(a_scales_base, scale_offsets_next, contiguity=8),
+                                       scale_mfma_layout)
+        b_sc_buf1 = tlx.require_layout(tlx.buffer_load(b_scales_base, scale_offsets_next, contiguity=8),
+                                       scale_mfma_layout)
+        tlx.async_load_commit_group()
+        tlx.async_load_wait_group(1)
+        a = tlx.local_load(smem_a[0])
+        b = tlx.local_load(tlx.local_trans(smem_b[0]))
+        a_sc = a_sc_buf0
+        b_sc = b_sc_buf0
+
+        a_base += BLOCK_K_PACKED * stride_ak * 2
+        b_base += BLOCK_K_PACKED * stride_bk * 2
+        a_scales_base += TILE_S * 2
+        b_scales_base += TILE_S * 2
+
+    # Drain the two in-flight stages.
+    acc = tl.dot_scaled(a, a_sc, "e2m1", b, b_sc, "e2m1", acc)
+    tlx.async_load_wait_group(0)
+    a_n = tlx.local_load(smem_a[1])
+    b_n = tlx.local_load(tlx.local_trans(smem_b[1]))
+    a_sc_n = a_sc_buf1
+    b_sc_n = b_sc_buf1
+    acc = tl.dot_scaled(a_n, a_sc_n, "e2m1", b_n, b_sc_n, "e2m1", acc)
+
+    offs_cm = tl.arange(0, BLOCK_M)
+    offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    c_offsets = tl.add(
+        tl.mul(stride_cm, offs_cm, sanitize_overflow=False)[:, None],
+        tl.mul(stride_cn, offs_cn, sanitize_overflow=False)[None, :],
+        sanitize_overflow=False,
+    )
+    c_offsets = tlx.require_layout(c_offsets, store_layout_c)
+    c_tile_base = c_ptr + pid_m * BLOCK_M * stride_cm
+    # Pin the accumulator before narrowing so the store-layout requirement
+    # redistributes bf16 rather than propagating back through the truncf to f32.
+    # Unpinned the TTGIR reads convert_layout(f32, #mma -> #blocked) then truncf,
+    # i.e. 4 bytes per element through LDS instead of 2.
+    acc = tlx.require_layout(acc, accumulator_layout)
+    c = acc.to(c_ptr.dtype.element_ty)
+    c = tlx.require_layout(c, store_layout_c)
+    tlx.buffer_store(c, c_tile_base, c_offsets)
+
+
+def _shuffle_scale_128(scales):
+    """Permute raw (rows, K//32) e8m0 scales into the layout the kernel loads.
+
+    Host-side, done once, mirroring what AITER gets from
+    aiter.ops.shuffle.shuffle_scale. Raw scales are row-contiguous, so the 8 e8m0
+    a lane needs for one MFMA are scattered; reordering into (row_tile, k_tile)
+    tiles of 128*BLOCK_K_SCALE bytes makes each lane's 8 bytes contiguous, so the
+    kernel reads them with one buffer_load and never touches LDS.
+    Pure permutation; shape and dtype preserved.
+    """
+    rows, nk = scales.shape
+    assert rows % 128 == 0 and nk % 8 == 0, "scales must tile by 128 x 8"
+    t = scales.contiguous().reshape(rows // 128, 4, 2, 16, nk // 8, 2, 4)
+    #        (row_tile, row//32, (row//16)%2, row%16, k_tile, k//4, k%4)
+    # ->     (row_tile, k_tile, (row//16)%2, k%4, row%16, row//32, k//4)
+    return t.permute(0, 4, 2, 6, 3, 1, 5).contiguous().reshape(rows, nk)
+
+
+def shuffle_a_scale(a_scales):
+    return _shuffle_scale_128(a_scales)
+
+
+def shuffle_b_scale(b_scales):
+    return _shuffle_scale_128(b_scales)
+
+
+def matmul(a, b, a_scales, b_scales):
+    assert a.dtype is torch.uint8
+    assert b.dtype is torch.uint8
+    assert a_scales.dtype is torch.uint8
+    assert b_scales.dtype is torch.uint8
+    assert a.is_cuda and b.is_cuda and a_scales.is_cuda and b_scales.is_cuda
+
+    M = a.shape[0]
+    K_packed = a.shape[1]
+    K = K_packed * 2
+    N = b.shape[0]
+
+    assert b.shape[1] == K_packed, "B must have shape (N, K // 2)"
+    assert a_scales.shape == (M, K // 32), "A scales must have shape (M, K // 32)"
+    assert b_scales.shape == (N, K // 32), "B scales must have shape (N, K // 32)"
+    assert a_scales.is_contiguous(), "A scales must be pre-shuffled (see shuffle_a_scale)"
+    assert b_scales.is_contiguous(), "B scales must be pre-shuffled (see shuffle_b_scale)"
+
+    assert M % BLOCK_M == 0, "M must be a multiple of 128"
+    assert N % BLOCK_N == 0, "N must be a multiple of 128"
+    assert K >= 2 * BLOCK_K and K % (2 * BLOCK_K) == 0, "K must be at least 512 and a multiple of 512"
+
+    c = torch.empty((M, N), device=a.device, dtype=torch.bfloat16)
+    grid_mn = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
+    _a4w4_kernel_128[(grid_mn, )](
+        a,
+        b,
+        c,
+        a_scales,
+        b_scales,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        a_scales.stride(0),
+        a_scales.stride(1),
+        b_scales.stride(0),
+        b_scales.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        NUM_XCDS=NUM_XCDS,
+        GRID_MN=grid_mn,
+        num_warps=NUM_WARPS,
+        num_stages=1,
+        matrix_instr_nonkdim=16,
+    )
+    return c

--- a/third_party/tlx/tutorials/gfx9_gemm/intra_wave/a4w4/matmul_kernel_128x256.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/intra_wave/a4w4/matmul_kernel_128x256.py
@@ -1,11 +1,23 @@
-"""TLX MXFP4 GEMM for gfx950.
+"""TLX MXFP4 GEMM for gfx950 -- 128x256 tile.
 
-Inputs use the same ABI as the Gluon a4w4 tutorial:
-  * A: packed e2m1, shape (M, K // 2), K-contiguous
-  * B: packed e2m1, shape (N, K // 2), K-contiguous; computes A @ B.T
-  * scales: e8m0 uint8, shapes (M, K // 32) and (N, K // 32),
-    contiguous along M/N so scale tiles are coalesced
-  * C: bfloat16, shape (M, N)
+Exists for 2048x4096x8192, where it is the only tile that fills the machine:
+  128x256 -> (2048/128) x (4096/256) = 16 x 16 = 256 workgroups = the CU count
+  128x128 -> 16 x 32 = 512 (two per CU, half the arithmetic intensity each)
+  256x256 ->  8 x 16 = 128 (half the machine idle)
+AITER selects its own 128x256 kernel here for the same reason.
+
+Derived from matmul_kernel.py (256x256) with BLOCK_M halved. Only the
+M-dependent pieces change -- accumulator M-repeat 8->4, store M-repeat 16->8,
+scale_a_layout M-repeat 8->4 (so 8 e8m0 per lane, not 16, hence contiguity=8
+and halved A-scale offset strides), shared_layout_a drops the [128, 0] base,
+and the host shuffle tiles by 128 rows. Everything on the B/HALF_N side is
+independent of BLOCK_M and carries over verbatim.
+
+Inherit the parent's config: LLIR sched + force-AGPR TOGETHER, i.e.
+  TRITON_ENABLE_LLIR_SCHED=1 TRITON_LLVM_OPTS=amdgpu-mfma-vgpr-form=false
+Note the flag has NO leading dash -- the dash form is silently ignored.
+Verify against plain once measured; this tile may sit below the 510/512 VGPR
+ceiling that makes the pairing mandatory on the 256x256 parent.
 """
 
 import torch
@@ -15,7 +27,7 @@ import triton.language.extra.tlx as tlx
 
 
 @triton.jit
-def _a4w4_kernel(
+def _a4w4_kernel_128x256(
     a_ptr,
     b_ptr,
     c_ptr,
@@ -75,7 +87,6 @@ def _a4w4_kernel(
             [2, 0],
             [4, 0],
             [8, 0],
-            [128, 0],
         ],
         [BLOCK_M, BLOCK_K_PACKED],
     )
@@ -101,7 +112,7 @@ def _a4w4_kernel(
     )
     shared_scales: tl.constexpr = tlx.swizzled_layout(0, 0, 0, order=[0, 1])
     scale_a_layout: tl.constexpr = tlx.layout(
-        shape=((16, 4, 2, 2), (2, 8)),
+        shape=((16, 4, 2, 2), (2, 4)),
         stride=((8, 1, 0, 128), (4, 256)),
     )
     scale_b_layout: tl.constexpr = tlx.layout(
@@ -109,13 +120,13 @@ def _a4w4_kernel(
         stride=((8, 1, 128, 0), (4, 256)),
     )
     store_layout_c: tl.constexpr = tlx.layout(
-        shape=((64, 4), (8, 16)),
+        shape=((64, 4), (8, 8)),
         stride=((8, 512), (1, 2048)),
     )
     # Generalized Shape:Stride form of the gfx950 16x16x128 MFMA
     # accumulator layout for one [BLOCK_M, HALF_N] result tile.
     accumulator_layout: tl.constexpr = tlx.layout(
-        shape=((16, 4, 2, 2), (4, 4, 8)),
+        shape=((16, 4, 2, 2), (4, 4, 4)),
         stride=((128, 4, 16, 2048), (1, 32, 4096)),
     )
 
@@ -149,14 +160,6 @@ def _a4w4_kernel(
     smem_a = tlx.local_alloc((BLOCK_M, BLOCK_K_PACKED), tlx.dtype_of(a_ptr), 2, layout=shared_layout_a)
     smem_b_left = tlx.local_alloc((HALF_N, BLOCK_K_PACKED), tlx.dtype_of(b_ptr), 2, layout=shared_layout_b)
     smem_b_right = tlx.local_alloc((HALF_N, BLOCK_K_PACKED), tlx.dtype_of(b_ptr), 2, layout=shared_layout_b)
-    # A scales never touch LDS: they arrive pre-shuffled (see shuffle_a_scale) so
-    # each lane's 16 e8m0 are contiguous and one buffer_load lands them straight in
-    # the MFMA operand layout. AITER does the same -- its 4 buffer_load_dword ->VGPR
-    # per iteration are exactly this, bought by the host-side shuffle_scale.
-    # B scales reach LDS by direct-to-LDS copy, so they are not a
-    # 1-deep store/load scratchpad: the copy is async, so each (left|right) x
-    # (stage) slot needs its own buffer, exactly like smem_b_left / smem_b_right.
-    # 1024 B per buffer, so this costs 3 KB more LDS than the single scratchpad.
     smem_bs_left = tlx.local_alloc((HALF_N, BLOCK_K_SCALE), tlx.dtype_of(b_scales_ptr), 2, layout=shared_scales)
     smem_bs_right = tlx.local_alloc((HALF_N, BLOCK_K_SCALE), tlx.dtype_of(b_scales_ptr), 2, layout=shared_scales)
 
@@ -190,8 +193,8 @@ def _a4w4_kernel(
     TILE_AS: tl.constexpr = BLOCK_M * BLOCK_K_SCALE
     offs_asm = tl.arange(0, BLOCK_M)
     offs_sk_a = tl.arange(0, BLOCK_K_SCALE)
-    a_scale_m_offsets = (offs_asm % 16) * 16 + ((offs_asm // 16) % 2) * 1024 + (offs_asm // 32) * 2
-    a_scale_k_offsets = (offs_sk_a % 4) * 256 + (offs_sk_a // 4)
+    a_scale_m_offsets = (offs_asm % 16) * 8 + ((offs_asm // 16) % 2) * 512 + (offs_asm // 32) * 2
+    a_scale_k_offsets = (offs_sk_a % 4) * 128 + (offs_sk_a // 4)
     a_scale_offsets = tl.add(a_scale_m_offsets[:, None], a_scale_k_offsets[None, :], sanitize_overflow=False)
     a_scale_offsets = tlx.require_layout(a_scale_offsets, scale_a_layout)
     a_scale_offsets_next = tl.add(a_scale_offsets, TILE_AS, sanitize_overflow=False)
@@ -218,7 +221,7 @@ def _a4w4_kernel(
 
     tlx.buffer_load_to_local(smem_a[0], a_base, a_offsets)
     tlx.buffer_load_to_local(smem_b_left[0], b_base, b_left_offsets)
-    a_sc_buf1 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets, contiguity=16), scale_a_layout)
+    a_sc_buf1 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets, contiguity=8), scale_a_layout)
     tlx.buffer_load_to_local(smem_bs_left[0], b_scales_base, b_scale_left_offsets)
     tlx.async_load_commit_group()
 
@@ -228,7 +231,7 @@ def _a4w4_kernel(
 
     tlx.buffer_load_to_local(smem_a[1], a_base, a_offsets_next)
     tlx.buffer_load_to_local(smem_b_left[1], b_base, b_left_offsets_next)
-    a_sc_buf3 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets_next, contiguity=16), scale_a_layout)
+    a_sc_buf3 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets_next, contiguity=8), scale_a_layout)
     tlx.buffer_load_to_local(smem_bs_left[1], b_scales_base, b_scale_left_offsets_next)
     tlx.async_load_commit_group()
 
@@ -247,14 +250,31 @@ def _a4w4_kernel(
     a_sc_reg_buf0 = a_sc_buf1
     b_sc_left_reg_buf0 = tlx.local_load(smem_bs_left[0], layout=scale_b_layout)
 
-    for _ in tl.range(0, iter_max - 2, 2, num_stages=1):
+    # K = 1024 per loop body, matching AITER's 128x256 kernel (256 MFMA / 8
+    # s_barrier / 48 buffer_load_dwordx4 per body, against our 128 / 4 / 24).
+    #
+    # Done by unrolling the 4-quarter block twice, NOT by doubling BLOCK_K the way
+    # the 64x128 kernel does it. BLOCK_K=512 here would want A 64 KB + B 128 KB +
+    # scales 8 KB = 205 KB against a 160 KB CU, so it does not fit. Unrolling keeps
+    # LDS byte-identical and buys loop-overhead amortisation plus a 2x bigger
+    # scheduling window -- it does NOT halve barrier density the way the 64x128
+    # change did, because the buffer count is unchanged so barriers scale with the
+    # body. AITER sits at that same 8 barriers per 1024 K.
+    #
+    # The loop covers iter_max - 4 iterations in steps of 4 (so K % 1024 == 0) and
+    # one 4-quarter block is peeled AFTER it, not before: the loop's live-in state
+    # has to come from the prologue. Peeling ahead of the loop instead makes layout
+    # inference resolve the accumulators to #blocked and the A scales to a second,
+    # narrower linear layout, and the kernel fails to compile with
+    #   size mismatch when packing elements for LLVM struct expected 4 but got 8
+    for _ in tl.range(0, iter_max - 4, 4, num_stages=1):
         acc_left = tl.dot_scaled(a, a_sc_reg_buf0, "e2m1", b_left, b_sc_left_reg_buf0, "e2m1", acc_left)
         tlx.async_load_wait_group(2)
         b_right = tlx.local_load(tlx.local_trans(smem_b_right[0]), relaxed=True)
         b_sc_right_reg_buf0 = tlx.local_load(smem_bs_right[0], layout=scale_b_layout)
         tlx.buffer_load_to_local(smem_a[0], a_base, a_offsets)
         tlx.buffer_load_to_local(smem_b_left[0], b_base, b_left_offsets)
-        a_sc_buf1 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets, contiguity=16), scale_a_layout)
+        a_sc_buf1 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets, contiguity=8), scale_a_layout)
         tlx.buffer_load_to_local(smem_bs_left[0], b_scales_base, b_scale_left_offsets)
         tlx.async_load_commit_group()
 
@@ -274,7 +294,7 @@ def _a4w4_kernel(
         b_sc_right_reg_buf2 = tlx.local_load(smem_bs_right[1], layout=scale_b_layout)
         tlx.buffer_load_to_local(smem_a[1], a_base, a_offsets_next)
         tlx.buffer_load_to_local(smem_b_left[1], b_base, b_left_offsets_next)
-        a_sc_buf3 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets_next, contiguity=16),
+        a_sc_buf3 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets_next, contiguity=8),
                                        scale_a_layout)
         tlx.buffer_load_to_local(smem_bs_left[1], b_scales_base, b_scale_left_offsets_next)
         tlx.async_load_commit_group()
@@ -293,6 +313,99 @@ def _a4w4_kernel(
         b_base += BLOCK_K_PACKED * stride_bk * 2
         a_scales_base += TILE_AS * 2
         b_scales_base += BLOCK_K_SCALE * stride_bsk * 2
+
+        acc_left = tl.dot_scaled(a, a_sc_reg_buf0, "e2m1", b_left, b_sc_left_reg_buf0, "e2m1", acc_left)
+        tlx.async_load_wait_group(2)
+        b_right = tlx.local_load(tlx.local_trans(smem_b_right[0]), relaxed=True)
+        b_sc_right_reg_buf0 = tlx.local_load(smem_bs_right[0], layout=scale_b_layout)
+        tlx.buffer_load_to_local(smem_a[0], a_base, a_offsets)
+        tlx.buffer_load_to_local(smem_b_left[0], b_base, b_left_offsets)
+        a_sc_buf1 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets, contiguity=8), scale_a_layout)
+        tlx.buffer_load_to_local(smem_bs_left[0], b_scales_base, b_scale_left_offsets)
+        tlx.async_load_commit_group()
+
+        acc_right = tl.dot_scaled(a, a_sc_reg_buf0, "e2m1", b_right, b_sc_right_reg_buf0, "e2m1", acc_right)
+        tlx.async_load_wait_group(2)
+        a_next = tlx.local_load(smem_a[1], relaxed=True)
+        b_left = tlx.local_load(tlx.local_trans(smem_b_left[1]), relaxed=True)
+        a_sc_reg_buf2 = a_sc_buf3
+        b_sc_left_reg_buf2 = tlx.local_load(smem_bs_left[1], layout=scale_b_layout)
+        tlx.buffer_load_to_local(smem_b_right[0], b_base, b_right_offsets)
+        tlx.buffer_load_to_local(smem_bs_right[0], b_scales_base, b_scale_right_offsets)
+        tlx.async_load_commit_group()
+
+        acc_left = tl.dot_scaled(a_next, a_sc_reg_buf2, "e2m1", b_left, b_sc_left_reg_buf2, "e2m1", acc_left)
+        tlx.async_load_wait_group(2)
+        b_right = tlx.local_load(tlx.local_trans(smem_b_right[1]), relaxed=True)
+        b_sc_right_reg_buf2 = tlx.local_load(smem_bs_right[1], layout=scale_b_layout)
+        tlx.buffer_load_to_local(smem_a[1], a_base, a_offsets_next)
+        tlx.buffer_load_to_local(smem_b_left[1], b_base, b_left_offsets_next)
+        a_sc_buf3 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets_next, contiguity=8),
+                                       scale_a_layout)
+        tlx.buffer_load_to_local(smem_bs_left[1], b_scales_base, b_scale_left_offsets_next)
+        tlx.async_load_commit_group()
+
+        acc_right = tl.dot_scaled(a_next, a_sc_reg_buf2, "e2m1", b_right, b_sc_right_reg_buf2, "e2m1", acc_right)
+        tlx.async_load_wait_group(2)
+        a = tlx.local_load(smem_a[0], relaxed=True)
+        b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
+        a_sc_reg_buf0 = a_sc_buf1
+        b_sc_left_reg_buf0 = tlx.local_load(smem_bs_left[0], layout=scale_b_layout)
+        tlx.buffer_load_to_local(smem_b_right[1], b_base, b_right_offsets_next)
+        tlx.buffer_load_to_local(smem_bs_right[1], b_scales_base, b_scale_right_offsets_next)
+        tlx.async_load_commit_group()
+
+        a_base += BLOCK_K_PACKED * stride_ak * 2
+        b_base += BLOCK_K_PACKED * stride_bk * 2
+        a_scales_base += TILE_AS * 2
+        b_scales_base += BLOCK_K_SCALE * stride_bsk * 2
+
+    # Peeled 4-quarter block: the loop leaves 2 iterations beyond the 2 the
+    # epilogue drains.
+    acc_left = tl.dot_scaled(a, a_sc_reg_buf0, "e2m1", b_left, b_sc_left_reg_buf0, "e2m1", acc_left)
+    tlx.async_load_wait_group(2)
+    b_right = tlx.local_load(tlx.local_trans(smem_b_right[0]), relaxed=True)
+    b_sc_right_reg_buf0 = tlx.local_load(smem_bs_right[0], layout=scale_b_layout)
+    tlx.buffer_load_to_local(smem_a[0], a_base, a_offsets)
+    tlx.buffer_load_to_local(smem_b_left[0], b_base, b_left_offsets)
+    a_sc_buf1 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets, contiguity=8), scale_a_layout)
+    tlx.buffer_load_to_local(smem_bs_left[0], b_scales_base, b_scale_left_offsets)
+    tlx.async_load_commit_group()
+
+    acc_right = tl.dot_scaled(a, a_sc_reg_buf0, "e2m1", b_right, b_sc_right_reg_buf0, "e2m1", acc_right)
+    tlx.async_load_wait_group(2)
+    a_next = tlx.local_load(smem_a[1], relaxed=True)
+    b_left = tlx.local_load(tlx.local_trans(smem_b_left[1]), relaxed=True)
+    a_sc_reg_buf2 = a_sc_buf3
+    b_sc_left_reg_buf2 = tlx.local_load(smem_bs_left[1], layout=scale_b_layout)
+    tlx.buffer_load_to_local(smem_b_right[0], b_base, b_right_offsets)
+    tlx.buffer_load_to_local(smem_bs_right[0], b_scales_base, b_scale_right_offsets)
+    tlx.async_load_commit_group()
+
+    acc_left = tl.dot_scaled(a_next, a_sc_reg_buf2, "e2m1", b_left, b_sc_left_reg_buf2, "e2m1", acc_left)
+    tlx.async_load_wait_group(2)
+    b_right = tlx.local_load(tlx.local_trans(smem_b_right[1]), relaxed=True)
+    b_sc_right_reg_buf2 = tlx.local_load(smem_bs_right[1], layout=scale_b_layout)
+    tlx.buffer_load_to_local(smem_a[1], a_base, a_offsets_next)
+    tlx.buffer_load_to_local(smem_b_left[1], b_base, b_left_offsets_next)
+    a_sc_buf3 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets_next, contiguity=8), scale_a_layout)
+    tlx.buffer_load_to_local(smem_bs_left[1], b_scales_base, b_scale_left_offsets_next)
+    tlx.async_load_commit_group()
+
+    acc_right = tl.dot_scaled(a_next, a_sc_reg_buf2, "e2m1", b_right, b_sc_right_reg_buf2, "e2m1", acc_right)
+    tlx.async_load_wait_group(2)
+    a = tlx.local_load(smem_a[0], relaxed=True)
+    b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
+    a_sc_reg_buf0 = a_sc_buf1
+    b_sc_left_reg_buf0 = tlx.local_load(smem_bs_left[0], layout=scale_b_layout)
+    tlx.buffer_load_to_local(smem_b_right[1], b_base, b_right_offsets_next)
+    tlx.buffer_load_to_local(smem_bs_right[1], b_scales_base, b_scale_right_offsets_next)
+    tlx.async_load_commit_group()
+
+    a_base += BLOCK_K_PACKED * stride_ak * 2
+    b_base += BLOCK_K_PACKED * stride_bk * 2
+    a_scales_base += TILE_AS * 2
+    b_scales_base += BLOCK_K_SCALE * stride_bsk * 2
 
     acc_left = tl.dot_scaled(a, a_sc_reg_buf0, "e2m1", b_left, b_sc_left_reg_buf0, "e2m1", acc_left)
     tlx.async_load_wait_group(2)
@@ -346,17 +459,22 @@ def shuffle_a_scale(a_scales):
     scattered (strides of 32 and 4*M) -- the kernel used to pay a
     ``ds_write`` + ``ds_read_b64_tr_b8`` LDS round-trip purely to transpose them.
     Reordering to (m_tile, k_tile) tiles of BLOCK_M*BLOCK_K_SCALE bytes, with
-    (m, k) at ``(m%16)*16 + (k%4)*256 + ((m//16)%2)*1024 + (k//4) + (m//32)*2``,
-    makes each lane's 16 bytes contiguous -> one buffer_load, no LDS.
+    (m, k) at ``(m%16)*8 + (k%4)*128 + ((m//16)%2)*512 + (k//4) + (m//32)*2``,
+    makes each lane's 8 bytes contiguous -> one buffer_load, no LDS. (Halved
+    from the 256x256 parent: BLOCK_M=128 gives 8 e8m0 per lane, not 16.)
 
     Shape and dtype are preserved; this is a pure permutation.
     """
-    M, nk = a_scales.shape
-    assert M % 256 == 0 and nk % 8 == 0, "A scales must tile by 256 x 8"
-    t = a_scales.contiguous().reshape(M // 256, 8, 2, 16, nk // 8, 2, 4)
-    #            (m_tile, m//32, (m//16)%2, m%16, k_tile, k//4, k%4)
-    # ->         (m_tile, k_tile, (m//16)%2, k%4, m%16, m//32, k//4)
-    return t.permute(0, 4, 2, 6, 3, 1, 5).contiguous().reshape(M, nk)
+    return _shuffle_scale_128(a_scales)
+
+
+def _shuffle_scale_128(scales):
+    rows, nk = scales.shape
+    assert rows % 128 == 0 and nk % 8 == 0, "scales must tile by 128 x 8"
+    t = scales.contiguous().reshape(rows // 128, 4, 2, 16, nk // 8, 2, 4)
+    #            (tile, r//32, (r//16)%2, r%16, k_tile, k//4, k%4)
+    # ->         (tile, k_tile, (r//16)%2, k%4, r%16, r//32, k//4)
+    return t.permute(0, 4, 2, 6, 3, 1, 5).contiguous().reshape(rows, nk)
 
 
 def matmul(a, b, a_scales, b_scales):
@@ -374,21 +492,21 @@ def matmul(a, b, a_scales, b_scales):
     assert b.shape[1] == K_packed, "B must have shape (N, K // 2)"
     assert a_scales.shape == (M, K // 32), "A scales must have shape (M, K // 32)"
     assert b_scales.shape == (N, K // 32), "B scales must have shape (N, K // 32)"
-    # A scales must be pre-shuffled by shuffle_a_scale() -- a one-off host-side
-    # permutation, the same deal AITER gets from aiter.ops.shuffle.shuffle_scale.
-    # That is what lets the kernel read them straight into MFMA operand layout
-    # instead of routing them through LDS to transpose.
+    # Both scale operands must be pre-shuffled by shuffle_a_scale() /
+    # shuffle_b_scale() -- one-off host-side permutations, the same deal AITER gets
+    # from aiter.ops.shuffle.shuffle_scale. That is what lets the kernel read them
+    # straight into MFMA operand layout instead of routing them through LDS.
     assert a_scales.is_contiguous(), "A scales must be pre-shuffled (see shuffle_a_scale)"
     assert b_scales.stride(0) == 1, "B scales must be contiguous along N"
 
-    BLOCK_M, BLOCK_N, BLOCK_K = 256, 256, 256
-    assert M % BLOCK_M == 0, "M must be a multiple of 256"
+    BLOCK_M, BLOCK_N, BLOCK_K = 128, 256, 256
+    assert M % BLOCK_M == 0, "M must be a multiple of 128"
     assert N % BLOCK_N == 0, "N must be a multiple of 256"
-    assert K >= 4 * BLOCK_K and K % (2 * BLOCK_K) == 0, "K must be at least 1024 and a multiple of 512"
+    assert K >= 4 * BLOCK_K and K % (4 * BLOCK_K) == 0, "K must be at least 1024 and a multiple of 1024"
 
     c = torch.empty((M, N), device=a.device, dtype=torch.bfloat16)
     grid_mn = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
-    _a4w4_kernel[(grid_mn, )](
+    _a4w4_kernel_128x256[(grid_mn, )](
         a,
         b,
         c,

--- a/third_party/tlx/tutorials/gfx9_gemm/intra_wave/a4w4/matmul_kernel_32.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/intra_wave/a4w4/matmul_kernel_32.py
@@ -1,0 +1,610 @@
+"""TLX MXFP4 GEMM for gfx950 -- 32x128 tile, the narrowest point of the curve.
+
+Exists for exactly one shape: 256x4096x4096, where it is the only tile that fills
+the machine. AITER selects its own 32x128 kernel there for the same reason.
+
+    tile      grid on 256x4096x4096          ratio vs AITER
+    32x128    (256/32) x (4096/128) = 256      **1.010**
+    64x128    (256/64) x (4096/128) = 128       0.889
+    128x128   (256/128) x (4096/128) = 64       ~0.6
+
+Do NOT use it anywhere else -- it is correctly worse when the grid overshoots:
+
+    shape            32x128    better tile
+    256x4096x4096     1.010    (this one)
+    256x8192x4096     0.762    64x128  (~0.95)
+    512x4096x4096     0.780    64x128  (~0.98)
+    512x8192x4096       --     128x128 (0.996)
+
+Both off-target shapes put the grid at 512, i.e. two workgroups per CU with half
+the arithmetic intensity each. The rule across all four tiles is simply: pick the
+one whose grid lands on 256.
+
+Derived from matmul_kernel_64.py; only the M-dependent layouts change
+(shared_layout_a loses a row base, and the A-scale / accumulator / store layouts
+each lose one M repeat). Everything on the B side -- b_operand_layout, the B
+offsets, shuffle_b_weight, scale_mfma_layout_b -- is independent of BLOCK_M and
+carries over verbatim. All four re-derived layouts were right first try and
+compiled exact, using the conventions established in the 64x128 kernel; see its
+"HOW THE LAYOUTS HERE WERE DERIVED" section before changing any of them.
+
+HOW THE LAYOUTS HERE WERE DERIVED
+  Every pinned layout in this file was read off the TTGIR, not guessed. Guessing
+  stride tuples cost several cycles: the first attempt at the scale layouts
+  assumed warpsPerCTA=[2,2] because that is what the accumulator's *blocked*
+  layout shows, but the MFMA is [1,4], which inverts which operand is
+  warp-broadcast (A, 8 e8m0 per lane) and which is warp-split (B, 4). The symptom
+  was an opaque "size mismatch when packing elements for LLVM struct expected 4
+  but got 8" out of make_llir.
+
+  The reliable procedure, for any future tile shape:
+    TRITON_KERNEL_DUMP=1 TRITON_DUMP_DIR=... python <driver>
+    grep '^#mma\|^#blocked\|^#linear' <dump>/*.ttgir
+  then translate the #ttg.linear basis vectors to Shape:Stride. tlx.dump_layout
+  on a loaded value is NOT enough -- it reports the blocked layout the compiler
+  chose for the load, not the operand layout the MFMA requires.
+
+EPILOGUE
+  Pinning the accumulator before the narrowing (see store_layout_c /
+  accumulator_layout) took the C-store round trip from 8 ds_write_b128 to 4 and
+  s_barrier from 15 to 11, worth +0.1/+3.1/+1.2% on the three shapes above.
+
+  The remaining 4 cannot be removed by pre-shuffling. Pre-shuffle works for the
+  scales because they are *inputs*: the host permutes them outside the timed
+  region and AITER's contract does the same. C is an output whose layout the
+  caller dictates, so there is no free permutation to exploit. The round trip
+  buys coalescing and is worth it: the MFMA hands each lane 4 contiguous columns
+  of one row (lane l -> row l&15), which stores as 16 scattered 32-byte
+  transactions per wave, versus 4 x 256 B after redistributing to store_layout_c.
+  Reaching zero here needs an in-register cross-lane transpose (v_permlane),
+  which is what AITER does -- not a host-side shuffle.
+
+Original scaffold notes follow.
+
+Why it exists: the 128x128 kernel is grid-limited on these shapes, launching
+128 workgroups on 256 CUs (50% of the machine) for 256x8192x4096 and
+512x4096x4096. AITER selects 64x128 for both, which puts the grid at exactly
+256. Its 64x128 kernel is the same design point as its 128x128 one -- 4 waves,
+all 160 KB of LDS, 512 VGPR, 16x16x128 MFMA -- just half the MFMAs per wave
+(128 vs 256), i.e. only BLOCK_M changes.
+
+What transfers from matmul_kernel_128.py and what does not:
+  * smem_b is still (128, 128), so the padded shared layout carries over.
+  * smem_a becomes (64, 128) = 2**13 elements and needs a 13-base padded
+    layout, i.e. the same list minus [64, 0] from the m-bases.
+  * A scales become a (64, 8) tile while B scales stay (128, 8), so they can
+    no longer share one layout/offsets tensor, and the (64, 8) MFMA scale
+    layout has no counterpart in the 256x256 kernel to copy. That derivation
+    is the remaining work; until it is done the scale path here will
+    scalarise the way the 128 kernel did before its layouts were pinned
+    (which cost ~20%).
+
+Original 128x128 header follows.
+
+TLX MXFP4 GEMM for gfx950 -- 128x128 tile, for occupancy-starved shapes.
+
+Companion to the 256x256 kernel in matmul_kernel.py. Same ABI, same intra-wave
+structure; the only reason it exists is grid fill.
+
+A 256x256 tile is one workgroup per CU, so on a 256-CU MI350X it needs
+M*N >= 256*65536 to fill the machine. Below that it strands CUs: 256x4096x4096
+launches 16 workgroups on 256 CUs. Measured against AITER on the four small
+shapes the 256x256 kernel lands at 0.385-0.562 -- the loop body is the same one
+that reaches parity on large shapes, it is simply running on 6-25% of the GPU.
+
+AITER's tuned configs make the rule explicit: it selects 32x128 / 64x128 /
+128x128 / 128x128 on those four shapes, i.e. whichever tile makes the grid come
+out at exactly 256. This kernel supplies the 128x128 point of that curve:
+
+    512x8192x4096   ->  4 x 64 = 256 workgroups   (exact fill)
+    256x8192x4096   ->  2 x 64 = 128
+    512x4096x4096   ->  4 x 32 = 128
+    256x4096x4096   ->  2 x 32 =  64
+
+The narrower tiles (and/or split-K) are what the two smallest shapes still need.
+
+Differences from the 256x256 kernel, all consequences of BLOCK_N:
+  * No left/right N split. BLOCK_N=128 is one MFMA group, so there is a single
+    accumulator and one tl.dot_scaled per k-step instead of two.
+  * No hand-pinned tlx.layout constants. Those in matmul_kernel.py are derived
+    for the 256x256x256 tile specifically and do not carry over; this kernel
+    lets the compiler choose, which is correct but not yet tuned. Use
+    tlx.dump_layout() to read back what it picked before pinning anything.
+  * Scales still take the LDS round-trip. The pre-shuffle + direct-to-VGPR path
+    (shuffle_a_scale in matmul_kernel.py) needs its own derivation per tile.
+
+Inputs use the same ABI as the Gluon a4w4 tutorial:
+  * A: packed e2m1, shape (M, K // 2), K-contiguous
+  * B: packed e2m1, shape (N, K // 2), K-contiguous; computes A @ B.T
+  * scales: e8m0 uint8, shapes (M, K // 32) and (N, K // 32),
+    contiguous along M/N so scale tiles are coalesced
+  * C: bfloat16, shape (M, N)
+"""
+
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+BLOCK_M = 32
+BLOCK_N = 128
+# 512, not 256: the loop steps 2 stages per body, so this is K=1024 per loop body
+# against the same 4 s_barrier -- matching AITER's 64x128 kernel, which issues 64
+# MFMAs per body where BLOCK_K=256 gives us 32. Barrier and loop overhead are
+# amortised over twice the math. Costs 2x the LDS (~99 KB of 160 KB, still one
+# workgroup per CU) and more VGPR, both of which were sitting unused: at these
+# shapes the grid is exactly 256 = the CU count, so occupancy above 1 buys nothing.
+#
+# This is NOT the 4-stage K=1024 variant that regressed the 128x128 kernel 33%.
+# That one added buffers (4 stages x BLOCK_K=256), which adds barriers with the
+# K it adds; this doubles the K per buffer and leaves the barrier count alone.
+BLOCK_K = 512
+NUM_CU = 256
+# Launch knobs, module-level so a sweep can set them without editing the source.
+NUM_WARPS = 4
+GROUP_SIZE_M = 4
+NUM_XCDS = 8
+
+
+@triton.jit
+def _a4w4_kernel_32(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    a_scales_ptr,
+    b_scales_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bn,
+    stride_bk,
+    stride_cm,
+    stride_cn,
+    stride_asm,
+    stride_ask,
+    stride_bsn,
+    stride_bsk,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    GRID_MN: tl.constexpr,
+):
+    SCALE_GROUP_SIZE: tl.constexpr = 32
+    # Without these the compiler picks sizePerThread=[1,1] for the scale tiles and
+    # the whole scale path scalarizes: 20 ds_write_b8 + 16 ds_read_u8 +
+    # 8 buffer_load_ubyte + 14 v_perm per iteration, ~96 overhead instructions
+    # against 64 MFMAs of real work. The A/B path does not need pinning -- it
+    # already comes out as ds_read_b128 / buffer_load_dwordx4.
+    # A scales are a (BLOCK_M, BLOCK_K_SCALE) = (64, 8) tile and B scales a
+    # (BLOCK_N, BLOCK_K_SCALE) = (128, 8) one, so unlike the 128x128 kernel they
+    # need separate layouts and separate offsets. Both put
+    #   row = l0 + 16*l2 + 32*r1,  k = l1 + 4*r0
+    # with l3 a broadcast; only the size of r1 differs (2 vs 4) because it is what
+    # covers the row dimension. 4 e8m0 per lane for A, 8 for B.
+    # Read off the TTGIR after tritonamdgpu-accelerate-matmul, not guessed:
+    #   #mma = amd_mfma<{warpsPerCTA = [1, 4], instrShape = [16, 16, 128]}>
+    #   A (64x8) : register=[[0,4],[16,0],[32,0]]  warp=[[0,0],[0,0]]
+    #   B (128x8): register=[[0,4],[64,0]]         warp=[[16,0],[32,0]]
+    # warpsPerCTA is [1, 4], not [2, 2] -- all four waves lie along N. So A is
+    # broadcast across every warp and carries 8 e8m0 per lane while B is split
+    # across them and carries 4, inverted from the 128x128 tile. That inversion is
+    # what the "expected 4 but got 8" struct-packing error was reporting.
+    # BLOCK_K=512 makes these (64, 16) and (128, 16) tiles, so relative to the
+    # BLOCK_K=256 versions every stride scales with the new ncols=16 and the k
+    # register dim doubles 2 -> 4 (BLOCK_K spans 4 MFMAs of K=128, not 2). Per
+    # lane: 16 e8m0 for A, 8 for B.
+    scale_mfma_layout_a: tl.constexpr = tlx.layout(
+        shape=((16, 4, 4), (4, 2)),
+        stride=((16, 1, 0), (4, 256)),
+    )
+    scale_mfma_layout_b: tl.constexpr = tlx.layout(
+        shape=((16, 4, 2, 2), (4, 2)),
+        stride=((16, 1, 256, 512), (4, 1024)),
+    )
+    # Epilogue layouts, both read off the TTGIR rather than guessed.
+    #
+    # store_layout_c is #blocked<sizePerThread=[1,8], threadsPerWarp=[4,16],
+    # warpsPerCTA=[4,1], order=[1,0]> in Shape:Stride form: 16 lanes of 8
+    # contiguous bf16 cover a 128-wide row (one global_store_dwordx4 each), 64
+    # lanes cover 4 rows, the 4 warps cover 16, and the register dim repeats that
+    # 4 times down to 64.
+    store_layout_c: tl.constexpr = tlx.layout(
+        shape=((64, 4), (8, 2)),
+        stride=((8, 512), (1, 2048)),
+    )
+    # accumulator_layout is #mma<warpsPerCTA=[1,4], instrShape=[16,16,128],
+    # isTransposed=true>. One MFMA tile is lane -> row (16, stride 128) x
+    # col (4, stride 4) with 4 contiguous cols per lane; the 4 warps tile N
+    # contiguously (stride 16), so the CTA covers 16x64 per round and the
+    # registers repeat it 2x across N and 4x down M.
+    # The MFMA B dot-operand layout: dot_op<opIdx=1, parent=#mma, kWidth=16> on
+    # the (K_packed=256, N=128) operand. lane(a,b,c) x reg(e,f,g) ->
+    #   n = a + 16c + 64g,   k = 16b + e + 64f
+    # i.e. lane l holds n = l%16 and 16 contiguous K bytes at k = 16*(l/16), c is
+    # the warp (4 warps tiling N by 16), and the registers repeat 16x and 4x
+    # along K and 2x along N.
+    #
+    # Confirmed, not guessed: pinning the LDS-loaded B to this produced a
+    # byte-identical kernel (same op histogram, same 234 VGPR), so require_layout
+    # was a no-op and this IS the layout the MFMA already asks for. That is what
+    # makes it safe to bypass LDS and load B straight into these registers.
+    b_operand_layout: tl.constexpr = tlx.layout(
+        shape=((16, 4, 4), (16, 4, 2)),
+        stride=((1, 2048, 16), (128, 8192, 64)),
+    )
+    accumulator_layout: tl.constexpr = tlx.layout(
+        shape=((16, 4, 4), (4, 2, 2)),
+        stride=((128, 4, 16), (1, 64, 2048)),
+    )
+    # A is now the only tile in LDS -- B goes global -> VGPR (see b_operand_layout
+    # and shuffle_b_weight), so the (BLOCK_N, BLOCK_K/2) companion layout that used
+    # to back smem_b is gone with it. That also drops LDS from ~99 KB to ~33 KB.
+    #
+    # smem_a is (BLOCK_M, BLOCK_K/2) = (32, 256) = 2**13.
+    #
+    # The pad stays 32 and this tile RUNS WITH 2.9% LDS bank conflicts. That is
+    # deliberate and measured. Halving BLOCK_M re-introduced a 2-way conflict
+    # (0.00 -> 2.90) that the 64x128 tile does not have, and pad=64 does remove
+    # it completely -- LDSBankConflict 0.000 -- but the kernel gets ~2% SLOWER:
+    #
+    #   pad  LDSBankConflict   256x4096x4096 ratio (2 reps, alternating)
+    #    32       2.90%              1.021 / 1.000   <- kept
+    #    64       0.000              0.992 / 0.983
+    #    16       5.795              (not benchmarked)
+    #
+    # Do not "fix" the counter here. The conflict is real but cheap, and the
+    # wider pad costs more elsewhere than the conflicts cost. Note also that the
+    # stride/gcd argument that predicts which pads work is wrong for this tile
+    # (it predicts 16, which is the worst of the three) -- sweep and measure.
+    shared_layout_a: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [[1024, 32]],
+        [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [8, 0],
+            [0, 16],
+            [0, 32],
+            [0, 64],
+            [0, 128],
+            [16, 0],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+        ],
+        [BLOCK_M, BLOCK_K // 2],
+    )
+    BLOCK_K_PACKED: tl.constexpr = BLOCK_K // 2
+    BLOCK_K_SCALE: tl.constexpr = BLOCK_K // SCALE_GROUP_SIZE
+
+    pid = tl.program_id(0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+
+    # Spread consecutive pids across XCDs so each XCD gets a contiguous stripe
+    # of the (m, n) grid rather than a strided one.
+    if NUM_XCDS != 1:
+        pids_per_xcd = (GRID_MN + NUM_XCDS - 1) // NUM_XCDS
+        tall_xcds = GRID_MN % NUM_XCDS
+        tall_xcds = NUM_XCDS if tall_xcds == 0 else tall_xcds
+        xcd = pid % NUM_XCDS
+        local_pid = pid // NUM_XCDS
+        if xcd < tall_xcds:
+            pid = xcd * pids_per_xcd + local_pid
+        else:
+            pid = tall_xcds * pids_per_xcd + (xcd - tall_xcds) * (pids_per_xcd - 1) + local_pid
+
+    if GROUP_SIZE_M == 1:
+        pid_m = pid // num_pid_n
+        pid_n = pid % num_pid_n
+    else:
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        tl.assume(group_size_m > 0)
+        pid_m = first_pid_m + (pid % num_pid_in_group) % group_size_m
+        pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # 2 x 16 KB for A/B plus 2 x 1 KB of scale scratch = 66 KB, so unlike the
+    # 256x256 kernel (138 KB) this fits two workgroups per CU on the 160 KB
+    # CDNA4 LDS -- which is the point, since these shapes cannot fill the grid.
+    smem_a = tlx.local_alloc((BLOCK_M, BLOCK_K_PACKED), tlx.dtype_of(a_ptr), 2, layout=shared_layout_a)
+    # 2-deep, not 1: a 1-deep scratchpad is store->load->(next iter)store on the
+    # same buffer, a cross-iteration WAR across the 4 warps that showed up as a
+    # nondeterministic result (same inputs, different output run to run).
+
+    offs_am = tl.arange(0, BLOCK_M)
+    offs_ak = tl.arange(0, BLOCK_K_PACKED)
+    a_offsets = offs_am[:, None] * stride_am + offs_ak[None, :] * stride_ak
+    a_offsets_next = a_offsets + BLOCK_K_PACKED * stride_ak
+    a_base = a_ptr + pid_m * BLOCK_M * stride_am
+
+    # B is pre-shuffled on the host (shuffle_b_weight) so a plain coalesced global
+    # load lands directly in b_operand_layout -- B never enters LDS. This is
+    # AITER's BpreShuffle contract, which its kernel already gets from the
+    # harness; matching it removes the last structural difference in the loop.
+    # Byte for (k, n) within a (BLOCK_K_PACKED, BLOCK_N) tile:
+    #   4096*((k//64) + 4*(n//64))                      <- which dwordx4
+    #     + 16*((n%16) + 16*((k//16)%4) + 64*((n//16)%4))  <- 16 B per lane
+    #     + (k%16)
+    # i.e. b_operand_layout linearised with the LANE index innermost inside each
+    # 16-byte chunk, NOT register-innermost.
+    #
+    # The register-innermost form (each lane's whole 128 bytes contiguous) is the
+    # obvious generalisation of the scale shuffle and it is 32% SLOWER. A lane
+    # needs 8 dwordx4, so with lane base 128*lane the j-th instruction addresses
+    # 128*lane + 16j -- stride 128 across lanes, touching 64 separate 128-byte
+    # lines and using 16 bytes of each. The scales get away with register-
+    # innermost only because 16 B/lane is exactly one instruction wide.
+    # What has to be contiguous is one INSTRUCTION across lanes, so each of the 8
+    # loads is one 4096-byte burst.
+    TILE_B: tl.constexpr = BLOCK_N * BLOCK_K_PACKED
+    offs_bn = tl.arange(0, BLOCK_N)
+    offs_bk = tl.arange(0, BLOCK_K_PACKED)
+    b_koff = (offs_bk % 16) + ((offs_bk // 16) % 4) * 256 + (offs_bk // 64) * 4096
+    b_noff = (offs_bn % 16) * 16 + ((offs_bn // 16) % 4) * 1024 + (offs_bn // 64) * 16384
+    b_offsets = tl.add(b_koff[:, None], b_noff[None, :], sanitize_overflow=False)
+    b_offsets = tlx.require_layout(b_offsets, b_operand_layout)
+    b_offsets_next = tl.add(b_offsets, TILE_B, sanitize_overflow=False)
+    b_base = b_ptr + pid_n * (K // 2 // BLOCK_K_PACKED) * TILE_B
+
+    # Pre-shuffled scale addressing, one tile per (row_tile, k_tile). A is a
+    # (BLOCK_M, BLOCK_K_SCALE) = (64, 16) tile and B a (128, 16) one, so they need
+    # separate offsets. Within a tile the byte for (row, k) is at
+    #   A: (row%16)*16 + ((row//16)%2)*4 + (row//32)*8
+    #                  + (k%4)*256 + (k//4)
+    #   B: (row%16)*8  + ((row//16)%2)*512 + ((row//32)%2)*1024 + (row//64)*4
+    #                  + (k%4)*128 + (k//4)
+    # i.e. each layout's (lane, register) -> element map linearised with the
+    # register index innermost, so a lane's bytes are contiguous and the load is
+    # one buffer_load_dwordx4 (A, 16 B) / dwordx2 (B, 8 B) straight into MFMA
+    # operand layout, with no LDS round trip. _shuffle_scale below is the host
+    # side of exactly these two formulas; both are verified bijections.
+    TILE_AS: tl.constexpr = BLOCK_M * BLOCK_K_SCALE
+    TILE_BS: tl.constexpr = BLOCK_N * BLOCK_K_SCALE
+    offs_sk = tl.arange(0, BLOCK_K_SCALE)
+    offs_asm = tl.arange(0, BLOCK_M)
+    offs_bsn = tl.arange(0, BLOCK_N)
+    a_row = (offs_asm % 16) * 8 + (offs_asm // 16) * 4
+    a_col = (offs_sk % 4) * 128 + (offs_sk // 4)
+    a_scale_offsets = tl.add(a_row[:, None], a_col[None, :], sanitize_overflow=False)
+    a_scale_offsets = tlx.require_layout(a_scale_offsets, scale_mfma_layout_a)
+    a_scale_offsets_next = tl.add(a_scale_offsets, TILE_AS, sanitize_overflow=False)
+    b_row = ((offs_bsn % 16) * 8 + ((offs_bsn // 16) % 2) * 512 + ((offs_bsn // 32) % 2) * 1024 + (offs_bsn // 64) * 4)
+    b_col = (offs_sk % 4) * 128 + (offs_sk // 4)
+    b_scale_offsets = tl.add(b_row[:, None], b_col[None, :], sanitize_overflow=False)
+    b_scale_offsets = tlx.require_layout(b_scale_offsets, scale_mfma_layout_b)
+    b_scale_offsets_next = tl.add(b_scale_offsets, TILE_BS, sanitize_overflow=False)
+    a_scales_base = a_scales_ptr + pid_m * (K // 32 // BLOCK_K_SCALE) * TILE_AS
+    b_scales_base = b_scales_ptr + pid_n * (K // 32 // BLOCK_K_SCALE) * TILE_BS
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    # Runtime trip count so every supported K shares one compiled kernel.
+    iter_max = K // BLOCK_K
+    tl.assume(iter_max > 1)
+
+    # Prime both stages, one async group each.
+    tlx.buffer_load_to_local(smem_a[0], a_base, a_offsets)
+    b_buf0 = tlx.require_layout(tlx.buffer_load(b_base, b_offsets, contiguity=16), b_operand_layout)
+    a_sc_buf0 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets, contiguity=8), scale_mfma_layout_a)
+    b_sc_buf0 = tlx.require_layout(tlx.buffer_load(b_scales_base, b_scale_offsets, contiguity=8), scale_mfma_layout_b)
+    tlx.async_load_commit_group()
+
+    tlx.buffer_load_to_local(smem_a[1], a_base, a_offsets_next)
+    b_buf1 = tlx.require_layout(tlx.buffer_load(b_base, b_offsets_next, contiguity=16), b_operand_layout)
+    a_sc_buf1 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets_next, contiguity=8),
+                                   scale_mfma_layout_a)
+    b_sc_buf1 = tlx.require_layout(tlx.buffer_load(b_scales_base, b_scale_offsets_next, contiguity=8),
+                                   scale_mfma_layout_b)
+    tlx.async_load_commit_group()
+
+    a_base += BLOCK_K_PACKED * stride_ak * 2
+    b_base += TILE_B * 2
+    a_scales_base += TILE_AS * 2
+    b_scales_base += TILE_BS * 2
+
+    tlx.async_load_wait_group(1)
+    a = tlx.local_load(smem_a[0])
+    b = b_buf0
+    a_sc = a_sc_buf0
+    b_sc = b_sc_buf0
+
+    # Unrolled by 2 so the two LDS stages alternate without an index variable.
+    # Issue the refill for the stage we just consumed BEFORE waiting on the other
+    # stage. With only two stages there is exactly one group per stage, so if the
+    # refill came after the wait there would be a single group outstanding and
+    # async_load_wait_group(1) would be satisfied by 1 <= 1 without waiting for
+    # anything -- the next local_load would then read a buffer whose DMA was still
+    # in flight. That raced: ~20% of the elements of a tile (one warp's share)
+    # differed run to run. Refill-then-wait keeps two groups in flight, so the
+    # wait actually retires the one being read and still overlaps the other.
+    for _ in tl.range(0, iter_max - 2, 2, num_stages=1):
+        acc = tl.dot_scaled(a, a_sc, "e2m1", b, b_sc, "e2m1", acc)
+        tlx.buffer_load_to_local(smem_a[0], a_base, a_offsets)
+        b_buf0 = tlx.require_layout(tlx.buffer_load(b_base, b_offsets, contiguity=16), b_operand_layout)
+        a_sc_buf0 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets, contiguity=8),
+                                       scale_mfma_layout_a)
+        b_sc_buf0 = tlx.require_layout(tlx.buffer_load(b_scales_base, b_scale_offsets, contiguity=8),
+                                       scale_mfma_layout_b)
+        tlx.async_load_commit_group()
+        tlx.async_load_wait_group(1)
+        a_n = tlx.local_load(smem_a[1])
+        b_n = b_buf1
+        a_sc_n = a_sc_buf1
+        b_sc_n = b_sc_buf1
+
+        acc = tl.dot_scaled(a_n, a_sc_n, "e2m1", b_n, b_sc_n, "e2m1", acc)
+        tlx.buffer_load_to_local(smem_a[1], a_base, a_offsets_next)
+        b_buf1 = tlx.require_layout(tlx.buffer_load(b_base, b_offsets_next, contiguity=16), b_operand_layout)
+        a_sc_buf1 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets_next, contiguity=8),
+                                       scale_mfma_layout_a)
+        b_sc_buf1 = tlx.require_layout(tlx.buffer_load(b_scales_base, b_scale_offsets_next, contiguity=8),
+                                       scale_mfma_layout_b)
+        tlx.async_load_commit_group()
+        tlx.async_load_wait_group(1)
+        a = tlx.local_load(smem_a[0])
+        b = b_buf0
+        a_sc = a_sc_buf0
+        b_sc = b_sc_buf0
+
+        a_base += BLOCK_K_PACKED * stride_ak * 2
+        b_base += TILE_B * 2
+        a_scales_base += TILE_AS * 2
+        b_scales_base += TILE_BS * 2
+
+    # Drain the two in-flight stages.
+    acc = tl.dot_scaled(a, a_sc, "e2m1", b, b_sc, "e2m1", acc)
+    tlx.async_load_wait_group(0)
+    a_n = tlx.local_load(smem_a[1])
+    b_n = b_buf1
+    a_sc_n = a_sc_buf1
+    b_sc_n = b_sc_buf1
+    acc = tl.dot_scaled(a_n, a_sc_n, "e2m1", b_n, b_sc_n, "e2m1", acc)
+
+    offs_cm = tl.arange(0, BLOCK_M)
+    offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    c_offsets = tl.add(
+        tl.mul(stride_cm, offs_cm, sanitize_overflow=False)[:, None],
+        tl.mul(stride_cn, offs_cn, sanitize_overflow=False)[None, :],
+        sanitize_overflow=False,
+    )
+    c_offsets = tlx.require_layout(c_offsets, store_layout_c)
+    c_tile_base = c_ptr + pid_m * BLOCK_M * stride_cm
+    # Pin the accumulator layout before narrowing so that the store-layout
+    # requirement redistributes bf16 rather than propagating back to f32. Left
+    # unpinned the compiler hoists the conversion above the truncf -- the TTGIR
+    # reads convert_layout(f32, #mma -> #blocked) then truncf -- and the epilogue
+    # round-trips 4 bytes per element through LDS instead of 2.
+    acc = tlx.require_layout(acc, accumulator_layout)
+    c = acc.to(c_ptr.dtype.element_ty)
+    c = tlx.require_layout(c, store_layout_c)
+    tlx.buffer_store(c, c_tile_base, c_offsets)
+
+
+def _shuffle_scale(scales, tile_rows):
+    """Permute raw (rows, K//32) e8m0 scales into the layout the kernel loads.
+
+    Host-side and done once, mirroring aiter.ops.shuffle.shuffle_scale. A and B
+    differ because warpsPerCTA is [1, 4]: A is warp-broadcast with 8 e8m0 per lane,
+    B warp-split with 4. Both make a lane's bytes contiguous so the load is one
+    buffer_load straight into MFMA operand layout, with no LDS round-trip.
+    Pure permutation; shape and dtype preserved.
+    """
+    rows, nk = scales.shape
+    KS = BLOCK_K // 32
+    assert rows % tile_rows == 0 and nk % KS == 0, "scales must tile by tile_rows x KS"
+    src = scales.contiguous()
+    dev = src.device
+    r = torch.arange(tile_rows, device=dev)
+    k = torch.arange(KS, device=dev)
+    if tile_rows == BLOCK_M:
+        pos = ((r % 16)[:, None] * 8 + (r // 16)[:, None] * 4 + (k % 4)[None, :] * 128 + (k // 4)[None, :])
+    else:
+        pos = (((r % 16) * 8 + ((r // 16) % 2) * 512 + ((r // 32) % 2) * 1024 + (r // 64) * 4)[:, None] +
+               (k % 4)[None, :] * 128 + (k // 4)[None, :])
+    nt, nkt, tile = rows // tile_rows, nk // KS, tile_rows * KS
+    blocks = src.reshape(nt, tile_rows, nkt, KS).permute(0, 2, 1, 3).reshape(nt, nkt, tile)
+    out = torch.empty(nt, nkt, tile, dtype=src.dtype, device=dev)
+    out.scatter_(2, pos.reshape(1, 1, -1).expand(nt, nkt, tile).contiguous(), blocks)
+    return out.reshape(rows, nk)
+
+
+def shuffle_a_scale(a_scales):
+    return _shuffle_scale(a_scales, BLOCK_M)
+
+
+def shuffle_b_scale(b_scales):
+    return _shuffle_scale(b_scales, BLOCK_N)
+
+
+def shuffle_b_weight(b):
+    """Permute raw packed-e2m1 B, shape (N, K // 2), into b_operand_layout order.
+
+    Host-side and done once, the same deal AITER's kernel gets from
+    aiter.ops.shuffle.shuffle_weight (its selected kernel is literally named
+    ..._BpreShuffle_64x128). This is what lets B skip LDS entirely: the shuffled
+    buffer is a sequence of (BLOCK_K_PACKED, BLOCK_N) tiles in which each lane's
+    128 bytes are contiguous, so a plain coalesced global load delivers the MFMA
+    B operand with no staging, no ds_read and no barrier.
+
+    Pure permutation; shape and dtype preserved.
+    """
+    n, kp = b.shape
+    assert n % BLOCK_N == 0 and kp % (BLOCK_K // 2) == 0, "B must tile by BLOCK_N x BLOCK_K_PACKED"
+    KP = BLOCK_K // 2
+    src = b.contiguous()
+    dev = src.device
+    kk = torch.arange(KP, device=dev)[:, None]
+    nn = torch.arange(BLOCK_N, device=dev)[None, :]
+    pos = ((nn % 16) * 16 + ((nn // 16) % 4) * 1024 + (nn // 64) * 16384 + (kk % 16) + ((kk // 16) % 4) * 256 +
+           (kk // 64) * 4096)
+    nt, nkt, tile = n // BLOCK_N, kp // KP, BLOCK_N * KP
+    # (n, kp) -> per-tile (k, n) blocks, matching the kernel's operand orientation
+    blocks = (src.reshape(nt, BLOCK_N, nkt, KP).permute(0, 2, 3, 1).reshape(nt, nkt, tile))
+    out = torch.empty(nt, nkt, tile, dtype=src.dtype, device=dev)
+    out.scatter_(2, pos.reshape(1, 1, -1).expand(nt, nkt, tile).contiguous(), blocks)
+    return out.reshape(n, kp)
+
+
+def matmul(a, b, a_scales, b_scales):
+    assert a.dtype is torch.uint8
+    assert b.dtype is torch.uint8
+    assert a_scales.dtype is torch.uint8
+    assert b_scales.dtype is torch.uint8
+    assert a.is_cuda and b.is_cuda and a_scales.is_cuda and b_scales.is_cuda
+
+    M = a.shape[0]
+    K_packed = a.shape[1]
+    K = K_packed * 2
+    N = b.shape[0]
+
+    assert b.shape[1] == K_packed, "B must have shape (N, K // 2)"
+    assert a_scales.shape == (M, K // 32), "A scales must have shape (M, K // 32)"
+    assert b_scales.shape == (N, K // 32), "B scales must have shape (N, K // 32)"
+    assert a_scales.is_contiguous(), "A scales must be pre-shuffled (see shuffle_a_scale)"
+    assert b_scales.is_contiguous(), "B scales must be pre-shuffled (see shuffle_b_scale)"
+    assert b.is_contiguous(), "B must be pre-shuffled (see shuffle_b_weight)"
+
+    assert M % BLOCK_M == 0, "M must be a multiple of 128"
+    assert N % BLOCK_N == 0, "N must be a multiple of 128"
+    assert K >= 2 * BLOCK_K and K % (2 * BLOCK_K) == 0, "K must be at least 512 and a multiple of 512"
+
+    c = torch.empty((M, N), device=a.device, dtype=torch.bfloat16)
+    grid_mn = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
+    _a4w4_kernel_32[(grid_mn, )](
+        a,
+        b,
+        c,
+        a_scales,
+        b_scales,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        a_scales.stride(0),
+        a_scales.stride(1),
+        b_scales.stride(0),
+        b_scales.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        NUM_XCDS=NUM_XCDS,
+        GRID_MN=grid_mn,
+        num_warps=NUM_WARPS,
+        num_stages=1,
+        matrix_instr_nonkdim=16,
+    )
+    return c

--- a/third_party/tlx/tutorials/gfx9_gemm/intra_wave/a4w4/matmul_kernel_64.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/intra_wave/a4w4/matmul_kernel_64.py
@@ -1,0 +1,591 @@
+"""TLX MXFP4 GEMM for gfx950 -- 64x128 tile, for the M=256/512 x N=4096..8192 shapes.
+
+Working and exact on 256x{4096,8192}x4096 and 512x{4096,8192}x4096, validated
+bit-for-bit against the 256x256 kernel. Zero ds_write in the main loop; the
+epilogue keeps 4 (see "Epilogue" below).
+
+Ratio vs AITER on the official harness (higher is better), by change:
+
+    shape            K=512/body   K=1024/body   + B direct-to-VGPR
+    256x4096x4096       0.767        0.854            0.889
+    256x8192x4096       0.874        0.961            0.953
+    512x4096x4096       0.869        0.955            0.988
+    512x8192x4096       0.824        0.726            0.829
+
+Use this tile for M=256 and for 512x4096. At 512x8192 the 128x128 kernel still
+wins (0.996), matching AITER's own choice of a 128x128 kernel there.
+
+The loop body now matches AITER's 64x128 kernel op-for-op: 64 MFMA, 32
+ds_read_b128, 8 buffer_load_dwordx4 to LDS, 16-18 to VGPR, 4 s_barrier,
+8 s_waitcnt -- at 232 VGPR with no spills.
+
+HOW THE LAYOUTS HERE WERE DERIVED
+  Every pinned layout in this file was read off the TTGIR, not guessed. Guessing
+  stride tuples cost several cycles: the first attempt at the scale layouts
+  assumed warpsPerCTA=[2,2] because that is what the accumulator's *blocked*
+  layout shows, but the MFMA is [1,4], which inverts which operand is
+  warp-broadcast (A, 8 e8m0 per lane) and which is warp-split (B, 4). The symptom
+  was an opaque "size mismatch when packing elements for LLVM struct expected 4
+  but got 8" out of make_llir.
+
+  The reliable procedure, for any future tile shape:
+    TRITON_KERNEL_DUMP=1 TRITON_DUMP_DIR=... python <driver>
+    grep '^#mma\|^#blocked\|^#linear' <dump>/*.ttgir
+  then translate the #ttg.linear basis vectors to Shape:Stride. tlx.dump_layout
+  on a loaded value is NOT enough -- it reports the blocked layout the compiler
+  chose for the load, not the operand layout the MFMA requires.
+
+EPILOGUE
+  Pinning the accumulator before the narrowing (see store_layout_c /
+  accumulator_layout) took the C-store round trip from 8 ds_write_b128 to 4 and
+  s_barrier from 15 to 11, worth +0.1/+3.1/+1.2% on the three shapes above.
+
+  The remaining 4 cannot be removed by pre-shuffling. Pre-shuffle works for the
+  scales because they are *inputs*: the host permutes them outside the timed
+  region and AITER's contract does the same. C is an output whose layout the
+  caller dictates, so there is no free permutation to exploit. The round trip
+  buys coalescing and is worth it: the MFMA hands each lane 4 contiguous columns
+  of one row (lane l -> row l&15), which stores as 16 scattered 32-byte
+  transactions per wave, versus 4 x 256 B after redistributing to store_layout_c.
+  Reaching zero here needs an in-register cross-lane transpose (v_permlane),
+  which is what AITER does -- not a host-side shuffle.
+
+Original scaffold notes follow.
+
+Why it exists: the 128x128 kernel is grid-limited on these shapes, launching
+128 workgroups on 256 CUs (50% of the machine) for 256x8192x4096 and
+512x4096x4096. AITER selects 64x128 for both, which puts the grid at exactly
+256. Its 64x128 kernel is the same design point as its 128x128 one -- 4 waves,
+all 160 KB of LDS, 512 VGPR, 16x16x128 MFMA -- just half the MFMAs per wave
+(128 vs 256), i.e. only BLOCK_M changes.
+
+What transfers from matmul_kernel_128.py and what does not:
+  * smem_b is still (128, 128), so the padded shared layout carries over.
+  * smem_a becomes (64, 128) = 2**13 elements and needs a 13-base padded
+    layout, i.e. the same list minus [64, 0] from the m-bases.
+  * A scales become a (64, 8) tile while B scales stay (128, 8), so they can
+    no longer share one layout/offsets tensor, and the (64, 8) MFMA scale
+    layout has no counterpart in the 256x256 kernel to copy. That derivation
+    is the remaining work; until it is done the scale path here will
+    scalarise the way the 128 kernel did before its layouts were pinned
+    (which cost ~20%).
+
+Original 128x128 header follows.
+
+TLX MXFP4 GEMM for gfx950 -- 128x128 tile, for occupancy-starved shapes.
+
+Companion to the 256x256 kernel in matmul_kernel.py. Same ABI, same intra-wave
+structure; the only reason it exists is grid fill.
+
+A 256x256 tile is one workgroup per CU, so on a 256-CU MI350X it needs
+M*N >= 256*65536 to fill the machine. Below that it strands CUs: 256x4096x4096
+launches 16 workgroups on 256 CUs. Measured against AITER on the four small
+shapes the 256x256 kernel lands at 0.385-0.562 -- the loop body is the same one
+that reaches parity on large shapes, it is simply running on 6-25% of the GPU.
+
+AITER's tuned configs make the rule explicit: it selects 32x128 / 64x128 /
+128x128 / 128x128 on those four shapes, i.e. whichever tile makes the grid come
+out at exactly 256. This kernel supplies the 128x128 point of that curve:
+
+    512x8192x4096   ->  4 x 64 = 256 workgroups   (exact fill)
+    256x8192x4096   ->  2 x 64 = 128
+    512x4096x4096   ->  4 x 32 = 128
+    256x4096x4096   ->  2 x 32 =  64
+
+The narrower tiles (and/or split-K) are what the two smallest shapes still need.
+
+Differences from the 256x256 kernel, all consequences of BLOCK_N:
+  * No left/right N split. BLOCK_N=128 is one MFMA group, so there is a single
+    accumulator and one tl.dot_scaled per k-step instead of two.
+  * No hand-pinned tlx.layout constants. Those in matmul_kernel.py are derived
+    for the 256x256x256 tile specifically and do not carry over; this kernel
+    lets the compiler choose, which is correct but not yet tuned. Use
+    tlx.dump_layout() to read back what it picked before pinning anything.
+  * Scales still take the LDS round-trip. The pre-shuffle + direct-to-VGPR path
+    (shuffle_a_scale in matmul_kernel.py) needs its own derivation per tile.
+
+Inputs use the same ABI as the Gluon a4w4 tutorial:
+  * A: packed e2m1, shape (M, K // 2), K-contiguous
+  * B: packed e2m1, shape (N, K // 2), K-contiguous; computes A @ B.T
+  * scales: e8m0 uint8, shapes (M, K // 32) and (N, K // 32),
+    contiguous along M/N so scale tiles are coalesced
+  * C: bfloat16, shape (M, N)
+"""
+
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+BLOCK_M = 64
+BLOCK_N = 128
+# 512, not 256: the loop steps 2 stages per body, so this is K=1024 per loop body
+# against the same 4 s_barrier -- matching AITER's 64x128 kernel, which issues 64
+# MFMAs per body where BLOCK_K=256 gives us 32. Barrier and loop overhead are
+# amortised over twice the math. Costs 2x the LDS (~99 KB of 160 KB, still one
+# workgroup per CU) and more VGPR, both of which were sitting unused: at these
+# shapes the grid is exactly 256 = the CU count, so occupancy above 1 buys nothing.
+#
+# This is NOT the 4-stage K=1024 variant that regressed the 128x128 kernel 33%.
+# That one added buffers (4 stages x BLOCK_K=256), which adds barriers with the
+# K it adds; this doubles the K per buffer and leaves the barrier count alone.
+BLOCK_K = 512
+NUM_CU = 256
+# Launch knobs, module-level so a sweep can set them without editing the source.
+NUM_WARPS = 4
+GROUP_SIZE_M = 4
+NUM_XCDS = 8
+
+
+@triton.jit
+def _a4w4_kernel_64(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    a_scales_ptr,
+    b_scales_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bn,
+    stride_bk,
+    stride_cm,
+    stride_cn,
+    stride_asm,
+    stride_ask,
+    stride_bsn,
+    stride_bsk,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    GRID_MN: tl.constexpr,
+):
+    SCALE_GROUP_SIZE: tl.constexpr = 32
+    # Without these the compiler picks sizePerThread=[1,1] for the scale tiles and
+    # the whole scale path scalarizes: 20 ds_write_b8 + 16 ds_read_u8 +
+    # 8 buffer_load_ubyte + 14 v_perm per iteration, ~96 overhead instructions
+    # against 64 MFMAs of real work. The A/B path does not need pinning -- it
+    # already comes out as ds_read_b128 / buffer_load_dwordx4.
+    # A scales are a (BLOCK_M, BLOCK_K_SCALE) = (64, 8) tile and B scales a
+    # (BLOCK_N, BLOCK_K_SCALE) = (128, 8) one, so unlike the 128x128 kernel they
+    # need separate layouts and separate offsets. Both put
+    #   row = l0 + 16*l2 + 32*r1,  k = l1 + 4*r0
+    # with l3 a broadcast; only the size of r1 differs (2 vs 4) because it is what
+    # covers the row dimension. 4 e8m0 per lane for A, 8 for B.
+    # Read off the TTGIR after tritonamdgpu-accelerate-matmul, not guessed:
+    #   #mma = amd_mfma<{warpsPerCTA = [1, 4], instrShape = [16, 16, 128]}>
+    #   A (64x8) : register=[[0,4],[16,0],[32,0]]  warp=[[0,0],[0,0]]
+    #   B (128x8): register=[[0,4],[64,0]]         warp=[[16,0],[32,0]]
+    # warpsPerCTA is [1, 4], not [2, 2] -- all four waves lie along N. So A is
+    # broadcast across every warp and carries 8 e8m0 per lane while B is split
+    # across them and carries 4, inverted from the 128x128 tile. That inversion is
+    # what the "expected 4 but got 8" struct-packing error was reporting.
+    # BLOCK_K=512 makes these (64, 16) and (128, 16) tiles, so relative to the
+    # BLOCK_K=256 versions every stride scales with the new ncols=16 and the k
+    # register dim doubles 2 -> 4 (BLOCK_K spans 4 MFMAs of K=128, not 2). Per
+    # lane: 16 e8m0 for A, 8 for B.
+    scale_mfma_layout_a: tl.constexpr = tlx.layout(
+        shape=((16, 4, 4), (4, 2, 2)),
+        stride=((16, 1, 0), (4, 256, 512)),
+    )
+    scale_mfma_layout_b: tl.constexpr = tlx.layout(
+        shape=((16, 4, 2, 2), (4, 2)),
+        stride=((16, 1, 256, 512), (4, 1024)),
+    )
+    # Epilogue layouts, both read off the TTGIR rather than guessed.
+    #
+    # store_layout_c is #blocked<sizePerThread=[1,8], threadsPerWarp=[4,16],
+    # warpsPerCTA=[4,1], order=[1,0]> in Shape:Stride form: 16 lanes of 8
+    # contiguous bf16 cover a 128-wide row (one global_store_dwordx4 each), 64
+    # lanes cover 4 rows, the 4 warps cover 16, and the register dim repeats that
+    # 4 times down to 64.
+    store_layout_c: tl.constexpr = tlx.layout(
+        shape=((64, 4), (8, 4)),
+        stride=((8, 512), (1, 2048)),
+    )
+    # accumulator_layout is #mma<warpsPerCTA=[1,4], instrShape=[16,16,128],
+    # isTransposed=true>. One MFMA tile is lane -> row (16, stride 128) x
+    # col (4, stride 4) with 4 contiguous cols per lane; the 4 warps tile N
+    # contiguously (stride 16), so the CTA covers 16x64 per round and the
+    # registers repeat it 2x across N and 4x down M.
+    # The MFMA B dot-operand layout: dot_op<opIdx=1, parent=#mma, kWidth=16> on
+    # the (K_packed=256, N=128) operand. lane(a,b,c) x reg(e,f,g) ->
+    #   n = a + 16c + 64g,   k = 16b + e + 64f
+    # i.e. lane l holds n = l%16 and 16 contiguous K bytes at k = 16*(l/16), c is
+    # the warp (4 warps tiling N by 16), and the registers repeat 16x and 4x
+    # along K and 2x along N.
+    #
+    # Confirmed, not guessed: pinning the LDS-loaded B to this produced a
+    # byte-identical kernel (same op histogram, same 234 VGPR), so require_layout
+    # was a no-op and this IS the layout the MFMA already asks for. That is what
+    # makes it safe to bypass LDS and load B straight into these registers.
+    b_operand_layout: tl.constexpr = tlx.layout(
+        shape=((16, 4, 4), (16, 4, 2)),
+        stride=((1, 2048, 16), (128, 8192, 64)),
+    )
+    accumulator_layout: tl.constexpr = tlx.layout(
+        shape=((16, 4, 4), (4, 2, 4)),
+        stride=((128, 4, 16), (1, 64, 2048)),
+    )
+    # A is now the only tile in LDS -- B goes global -> VGPR (see b_operand_layout
+    # and shuffle_b_weight), so the (BLOCK_N, BLOCK_K/2) companion layout that used
+    # to back smem_b is gone with it. That also drops LDS from ~99 KB to ~33 KB.
+    #
+    # smem_a is (BLOCK_M, BLOCK_K/2) = (64, 256) = 2**14. Left on the compiler
+    # default these allocs gave LDSBankConflict = 18.9% with MfmaUtil at 12%, i.e.
+    # the MFMA unit idle 88% of the time while MemUnitStalled was ~0: LDS-latency
+    # bound, not memory bound. The [[1024, 32]] pad breaks the conflicting stride.
+    shared_layout_a: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [[1024, 32]],
+        [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [8, 0],
+            [0, 16],
+            [0, 32],
+            [0, 64],
+            [0, 128],
+            [16, 0],
+            [32, 0],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+        ],
+        [BLOCK_M, BLOCK_K // 2],
+    )
+    BLOCK_K_PACKED: tl.constexpr = BLOCK_K // 2
+    BLOCK_K_SCALE: tl.constexpr = BLOCK_K // SCALE_GROUP_SIZE
+
+    pid = tl.program_id(0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+
+    # Spread consecutive pids across XCDs so each XCD gets a contiguous stripe
+    # of the (m, n) grid rather than a strided one.
+    if NUM_XCDS != 1:
+        pids_per_xcd = (GRID_MN + NUM_XCDS - 1) // NUM_XCDS
+        tall_xcds = GRID_MN % NUM_XCDS
+        tall_xcds = NUM_XCDS if tall_xcds == 0 else tall_xcds
+        xcd = pid % NUM_XCDS
+        local_pid = pid // NUM_XCDS
+        if xcd < tall_xcds:
+            pid = xcd * pids_per_xcd + local_pid
+        else:
+            pid = tall_xcds * pids_per_xcd + (xcd - tall_xcds) * (pids_per_xcd - 1) + local_pid
+
+    if GROUP_SIZE_M == 1:
+        pid_m = pid // num_pid_n
+        pid_n = pid % num_pid_n
+    else:
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        tl.assume(group_size_m > 0)
+        pid_m = first_pid_m + (pid % num_pid_in_group) % group_size_m
+        pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # 2 x 16 KB for A/B plus 2 x 1 KB of scale scratch = 66 KB, so unlike the
+    # 256x256 kernel (138 KB) this fits two workgroups per CU on the 160 KB
+    # CDNA4 LDS -- which is the point, since these shapes cannot fill the grid.
+    smem_a = tlx.local_alloc((BLOCK_M, BLOCK_K_PACKED), tlx.dtype_of(a_ptr), 2, layout=shared_layout_a)
+    # 2-deep, not 1: a 1-deep scratchpad is store->load->(next iter)store on the
+    # same buffer, a cross-iteration WAR across the 4 warps that showed up as a
+    # nondeterministic result (same inputs, different output run to run).
+
+    offs_am = tl.arange(0, BLOCK_M)
+    offs_ak = tl.arange(0, BLOCK_K_PACKED)
+    a_offsets = offs_am[:, None] * stride_am + offs_ak[None, :] * stride_ak
+    a_offsets_next = a_offsets + BLOCK_K_PACKED * stride_ak
+    a_base = a_ptr + pid_m * BLOCK_M * stride_am
+
+    # B is pre-shuffled on the host (shuffle_b_weight) so a plain coalesced global
+    # load lands directly in b_operand_layout -- B never enters LDS. This is
+    # AITER's BpreShuffle contract, which its kernel already gets from the
+    # harness; matching it removes the last structural difference in the loop.
+    # Byte for (k, n) within a (BLOCK_K_PACKED, BLOCK_N) tile:
+    #   4096*((k//64) + 4*(n//64))                      <- which dwordx4
+    #     + 16*((n%16) + 16*((k//16)%4) + 64*((n//16)%4))  <- 16 B per lane
+    #     + (k%16)
+    # i.e. b_operand_layout linearised with the LANE index innermost inside each
+    # 16-byte chunk, NOT register-innermost.
+    #
+    # The register-innermost form (each lane's whole 128 bytes contiguous) is the
+    # obvious generalisation of the scale shuffle and it is 32% SLOWER. A lane
+    # needs 8 dwordx4, so with lane base 128*lane the j-th instruction addresses
+    # 128*lane + 16j -- stride 128 across lanes, touching 64 separate 128-byte
+    # lines and using 16 bytes of each. The scales get away with register-
+    # innermost only because 16 B/lane is exactly one instruction wide.
+    # What has to be contiguous is one INSTRUCTION across lanes, so each of the 8
+    # loads is one 4096-byte burst.
+    TILE_B: tl.constexpr = BLOCK_N * BLOCK_K_PACKED
+    offs_bn = tl.arange(0, BLOCK_N)
+    offs_bk = tl.arange(0, BLOCK_K_PACKED)
+    b_koff = (offs_bk % 16) + ((offs_bk // 16) % 4) * 256 + (offs_bk // 64) * 4096
+    b_noff = (offs_bn % 16) * 16 + ((offs_bn // 16) % 4) * 1024 + (offs_bn // 64) * 16384
+    b_offsets = tl.add(b_koff[:, None], b_noff[None, :], sanitize_overflow=False)
+    b_offsets = tlx.require_layout(b_offsets, b_operand_layout)
+    b_offsets_next = tl.add(b_offsets, TILE_B, sanitize_overflow=False)
+    b_base = b_ptr + pid_n * (K // 2 // BLOCK_K_PACKED) * TILE_B
+
+    # Pre-shuffled scale addressing, one tile per (row_tile, k_tile). A is a
+    # (BLOCK_M, BLOCK_K_SCALE) = (64, 16) tile and B a (128, 16) one, so they need
+    # separate offsets. Within a tile the byte for (row, k) is at
+    #   A: (row%16)*16 + ((row//16)%2)*4 + (row//32)*8
+    #                  + (k%4)*256 + (k//4)
+    #   B: (row%16)*8  + ((row//16)%2)*512 + ((row//32)%2)*1024 + (row//64)*4
+    #                  + (k%4)*128 + (k//4)
+    # i.e. each layout's (lane, register) -> element map linearised with the
+    # register index innermost, so a lane's bytes are contiguous and the load is
+    # one buffer_load_dwordx4 (A, 16 B) / dwordx2 (B, 8 B) straight into MFMA
+    # operand layout, with no LDS round trip. _shuffle_scale below is the host
+    # side of exactly these two formulas; both are verified bijections.
+    TILE_AS: tl.constexpr = BLOCK_M * BLOCK_K_SCALE
+    TILE_BS: tl.constexpr = BLOCK_N * BLOCK_K_SCALE
+    offs_sk = tl.arange(0, BLOCK_K_SCALE)
+    offs_asm = tl.arange(0, BLOCK_M)
+    offs_bsn = tl.arange(0, BLOCK_N)
+    a_row = (offs_asm % 16) * 16 + ((offs_asm // 16) % 2) * 4 + (offs_asm // 32) * 8
+    a_col = (offs_sk % 4) * 256 + (offs_sk // 4)
+    a_scale_offsets = tl.add(a_row[:, None], a_col[None, :], sanitize_overflow=False)
+    a_scale_offsets = tlx.require_layout(a_scale_offsets, scale_mfma_layout_a)
+    a_scale_offsets_next = tl.add(a_scale_offsets, TILE_AS, sanitize_overflow=False)
+    b_row = ((offs_bsn % 16) * 8 + ((offs_bsn // 16) % 2) * 512 + ((offs_bsn // 32) % 2) * 1024 + (offs_bsn // 64) * 4)
+    b_col = (offs_sk % 4) * 128 + (offs_sk // 4)
+    b_scale_offsets = tl.add(b_row[:, None], b_col[None, :], sanitize_overflow=False)
+    b_scale_offsets = tlx.require_layout(b_scale_offsets, scale_mfma_layout_b)
+    b_scale_offsets_next = tl.add(b_scale_offsets, TILE_BS, sanitize_overflow=False)
+    a_scales_base = a_scales_ptr + pid_m * (K // 32 // BLOCK_K_SCALE) * TILE_AS
+    b_scales_base = b_scales_ptr + pid_n * (K // 32 // BLOCK_K_SCALE) * TILE_BS
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    # Runtime trip count so every supported K shares one compiled kernel.
+    iter_max = K // BLOCK_K
+    tl.assume(iter_max > 1)
+
+    # Prime both stages, one async group each.
+    tlx.buffer_load_to_local(smem_a[0], a_base, a_offsets)
+    b_buf0 = tlx.require_layout(tlx.buffer_load(b_base, b_offsets, contiguity=16), b_operand_layout)
+    a_sc_buf0 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets, contiguity=16), scale_mfma_layout_a)
+    b_sc_buf0 = tlx.require_layout(tlx.buffer_load(b_scales_base, b_scale_offsets, contiguity=8), scale_mfma_layout_b)
+    tlx.async_load_commit_group()
+
+    tlx.buffer_load_to_local(smem_a[1], a_base, a_offsets_next)
+    b_buf1 = tlx.require_layout(tlx.buffer_load(b_base, b_offsets_next, contiguity=16), b_operand_layout)
+    a_sc_buf1 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets_next, contiguity=16),
+                                   scale_mfma_layout_a)
+    b_sc_buf1 = tlx.require_layout(tlx.buffer_load(b_scales_base, b_scale_offsets_next, contiguity=8),
+                                   scale_mfma_layout_b)
+    tlx.async_load_commit_group()
+
+    a_base += BLOCK_K_PACKED * stride_ak * 2
+    b_base += TILE_B * 2
+    a_scales_base += TILE_AS * 2
+    b_scales_base += TILE_BS * 2
+
+    tlx.async_load_wait_group(1)
+    a = tlx.local_load(smem_a[0])
+    b = b_buf0
+    a_sc = a_sc_buf0
+    b_sc = b_sc_buf0
+
+    # Unrolled by 2 so the two LDS stages alternate without an index variable.
+    # Issue the refill for the stage we just consumed BEFORE waiting on the other
+    # stage. With only two stages there is exactly one group per stage, so if the
+    # refill came after the wait there would be a single group outstanding and
+    # async_load_wait_group(1) would be satisfied by 1 <= 1 without waiting for
+    # anything -- the next local_load would then read a buffer whose DMA was still
+    # in flight. That raced: ~20% of the elements of a tile (one warp's share)
+    # differed run to run. Refill-then-wait keeps two groups in flight, so the
+    # wait actually retires the one being read and still overlaps the other.
+    for _ in tl.range(0, iter_max - 2, 2, num_stages=1):
+        acc = tl.dot_scaled(a, a_sc, "e2m1", b, b_sc, "e2m1", acc)
+        tlx.buffer_load_to_local(smem_a[0], a_base, a_offsets)
+        b_buf0 = tlx.require_layout(tlx.buffer_load(b_base, b_offsets, contiguity=16), b_operand_layout)
+        a_sc_buf0 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets, contiguity=16),
+                                       scale_mfma_layout_a)
+        b_sc_buf0 = tlx.require_layout(tlx.buffer_load(b_scales_base, b_scale_offsets, contiguity=8),
+                                       scale_mfma_layout_b)
+        tlx.async_load_commit_group()
+        tlx.async_load_wait_group(1)
+        a_n = tlx.local_load(smem_a[1])
+        b_n = b_buf1
+        a_sc_n = a_sc_buf1
+        b_sc_n = b_sc_buf1
+
+        acc = tl.dot_scaled(a_n, a_sc_n, "e2m1", b_n, b_sc_n, "e2m1", acc)
+        tlx.buffer_load_to_local(smem_a[1], a_base, a_offsets_next)
+        b_buf1 = tlx.require_layout(tlx.buffer_load(b_base, b_offsets_next, contiguity=16), b_operand_layout)
+        a_sc_buf1 = tlx.require_layout(tlx.buffer_load(a_scales_base, a_scale_offsets_next, contiguity=16),
+                                       scale_mfma_layout_a)
+        b_sc_buf1 = tlx.require_layout(tlx.buffer_load(b_scales_base, b_scale_offsets_next, contiguity=8),
+                                       scale_mfma_layout_b)
+        tlx.async_load_commit_group()
+        tlx.async_load_wait_group(1)
+        a = tlx.local_load(smem_a[0])
+        b = b_buf0
+        a_sc = a_sc_buf0
+        b_sc = b_sc_buf0
+
+        a_base += BLOCK_K_PACKED * stride_ak * 2
+        b_base += TILE_B * 2
+        a_scales_base += TILE_AS * 2
+        b_scales_base += TILE_BS * 2
+
+    # Drain the two in-flight stages.
+    acc = tl.dot_scaled(a, a_sc, "e2m1", b, b_sc, "e2m1", acc)
+    tlx.async_load_wait_group(0)
+    a_n = tlx.local_load(smem_a[1])
+    b_n = b_buf1
+    a_sc_n = a_sc_buf1
+    b_sc_n = b_sc_buf1
+    acc = tl.dot_scaled(a_n, a_sc_n, "e2m1", b_n, b_sc_n, "e2m1", acc)
+
+    offs_cm = tl.arange(0, BLOCK_M)
+    offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    c_offsets = tl.add(
+        tl.mul(stride_cm, offs_cm, sanitize_overflow=False)[:, None],
+        tl.mul(stride_cn, offs_cn, sanitize_overflow=False)[None, :],
+        sanitize_overflow=False,
+    )
+    c_offsets = tlx.require_layout(c_offsets, store_layout_c)
+    c_tile_base = c_ptr + pid_m * BLOCK_M * stride_cm
+    # Pin the accumulator layout before narrowing so that the store-layout
+    # requirement redistributes bf16 rather than propagating back to f32. Left
+    # unpinned the compiler hoists the conversion above the truncf -- the TTGIR
+    # reads convert_layout(f32, #mma -> #blocked) then truncf -- and the epilogue
+    # round-trips 4 bytes per element through LDS instead of 2.
+    acc = tlx.require_layout(acc, accumulator_layout)
+    c = acc.to(c_ptr.dtype.element_ty)
+    c = tlx.require_layout(c, store_layout_c)
+    tlx.buffer_store(c, c_tile_base, c_offsets)
+
+
+def _shuffle_scale(scales, tile_rows):
+    """Permute raw (rows, K//32) e8m0 scales into the layout the kernel loads.
+
+    Host-side and done once, mirroring aiter.ops.shuffle.shuffle_scale. A and B
+    differ because warpsPerCTA is [1, 4]: A is warp-broadcast with 8 e8m0 per lane,
+    B warp-split with 4. Both make a lane's bytes contiguous so the load is one
+    buffer_load straight into MFMA operand layout, with no LDS round-trip.
+    Pure permutation; shape and dtype preserved.
+    """
+    rows, nk = scales.shape
+    KS = BLOCK_K // 32
+    assert rows % tile_rows == 0 and nk % KS == 0, "scales must tile by tile_rows x KS"
+    src = scales.contiguous()
+    dev = src.device
+    r = torch.arange(tile_rows, device=dev)
+    k = torch.arange(KS, device=dev)
+    if tile_rows == 64:
+        pos = ((r % 16)[:, None] * 16 + ((r // 16) % 2)[:, None] * 4 + (r // 32)[:, None] * 8 + (k % 4)[None, :] * 256 +
+               (k // 4)[None, :])
+    else:
+        pos = (((r % 16) * 8 + ((r // 16) % 2) * 512 + ((r // 32) % 2) * 1024 + (r // 64) * 4)[:, None] +
+               (k % 4)[None, :] * 128 + (k // 4)[None, :])
+    nt, nkt, tile = rows // tile_rows, nk // KS, tile_rows * KS
+    blocks = src.reshape(nt, tile_rows, nkt, KS).permute(0, 2, 1, 3).reshape(nt, nkt, tile)
+    out = torch.empty(nt, nkt, tile, dtype=src.dtype, device=dev)
+    out.scatter_(2, pos.reshape(1, 1, -1).expand(nt, nkt, tile).contiguous(), blocks)
+    return out.reshape(rows, nk)
+
+
+def shuffle_a_scale(a_scales):
+    return _shuffle_scale(a_scales, BLOCK_M)
+
+
+def shuffle_b_scale(b_scales):
+    return _shuffle_scale(b_scales, BLOCK_N)
+
+
+def shuffle_b_weight(b):
+    """Permute raw packed-e2m1 B, shape (N, K // 2), into b_operand_layout order.
+
+    Host-side and done once, the same deal AITER's kernel gets from
+    aiter.ops.shuffle.shuffle_weight (its selected kernel is literally named
+    ..._BpreShuffle_64x128). This is what lets B skip LDS entirely: the shuffled
+    buffer is a sequence of (BLOCK_K_PACKED, BLOCK_N) tiles in which each lane's
+    128 bytes are contiguous, so a plain coalesced global load delivers the MFMA
+    B operand with no staging, no ds_read and no barrier.
+
+    Pure permutation; shape and dtype preserved.
+    """
+    n, kp = b.shape
+    assert n % BLOCK_N == 0 and kp % (BLOCK_K // 2) == 0, "B must tile by BLOCK_N x BLOCK_K_PACKED"
+    KP = BLOCK_K // 2
+    src = b.contiguous()
+    dev = src.device
+    kk = torch.arange(KP, device=dev)[:, None]
+    nn = torch.arange(BLOCK_N, device=dev)[None, :]
+    pos = ((nn % 16) * 16 + ((nn // 16) % 4) * 1024 + (nn // 64) * 16384 + (kk % 16) + ((kk // 16) % 4) * 256 +
+           (kk // 64) * 4096)
+    nt, nkt, tile = n // BLOCK_N, kp // KP, BLOCK_N * KP
+    # (n, kp) -> per-tile (k, n) blocks, matching the kernel's operand orientation
+    blocks = (src.reshape(nt, BLOCK_N, nkt, KP).permute(0, 2, 3, 1).reshape(nt, nkt, tile))
+    out = torch.empty(nt, nkt, tile, dtype=src.dtype, device=dev)
+    out.scatter_(2, pos.reshape(1, 1, -1).expand(nt, nkt, tile).contiguous(), blocks)
+    return out.reshape(n, kp)
+
+
+def matmul(a, b, a_scales, b_scales):
+    assert a.dtype is torch.uint8
+    assert b.dtype is torch.uint8
+    assert a_scales.dtype is torch.uint8
+    assert b_scales.dtype is torch.uint8
+    assert a.is_cuda and b.is_cuda and a_scales.is_cuda and b_scales.is_cuda
+
+    M = a.shape[0]
+    K_packed = a.shape[1]
+    K = K_packed * 2
+    N = b.shape[0]
+
+    assert b.shape[1] == K_packed, "B must have shape (N, K // 2)"
+    assert a_scales.shape == (M, K // 32), "A scales must have shape (M, K // 32)"
+    assert b_scales.shape == (N, K // 32), "B scales must have shape (N, K // 32)"
+    assert a_scales.is_contiguous(), "A scales must be pre-shuffled (see shuffle_a_scale)"
+    assert b_scales.is_contiguous(), "B scales must be pre-shuffled (see shuffle_b_scale)"
+    assert b.is_contiguous(), "B must be pre-shuffled (see shuffle_b_weight)"
+
+    assert M % BLOCK_M == 0, "M must be a multiple of 128"
+    assert N % BLOCK_N == 0, "N must be a multiple of 128"
+    assert K >= 2 * BLOCK_K and K % (2 * BLOCK_K) == 0, "K must be at least 512 and a multiple of 512"
+
+    c = torch.empty((M, N), device=a.device, dtype=torch.bfloat16)
+    grid_mn = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
+    _a4w4_kernel_64[(grid_mn, )](
+        a,
+        b,
+        c,
+        a_scales,
+        b_scales,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        a_scales.stride(0),
+        a_scales.stride(1),
+        b_scales.stride(0),
+        b_scales.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        NUM_XCDS=NUM_XCDS,
+        GRID_MN=grid_mn,
+        num_warps=NUM_WARPS,
+        num_stages=1,
+        matrix_instr_nonkdim=16,
+    )
+    return c


### PR DESCRIPTION
Summary:
Ports the gfx950 a4w4 (MXFP4) GEMM work from the OSS tlx-triton branch into
fbsource. Net effect against AITER is roughly parity across the seven benchmark
shapes -- one shape is meaningfully ahead, one meaningfully behind, the rest
within noise. Per-shape ratios are in the table; deliberately not summarised as a
single number, because run-to-run spread across a full sweep is +/- 0.02 and the
two ends of the range are not representative of the middle. Measured against the AITER assembly baseline with the D114296896
repro harness (cold L2, 256 MiB read-modify-write flush per sample, 3 rounds x
100 samples, alternating runner order, exact BF16 equality vs an FP32-dequantized
reference). Ratio is AITER/ours, so > 1.0 means we are faster.

    shape             tile      AITER us   ours us   ratio
    256x4096x4096     32x128       12.08     12.00   0.99
    256x8192x4096     64x128       14.48     15.36   0.94
    512x4096x4096     64x128       13.90     14.08   0.99
    512x8192x4096     128x128      18.48     18.56   1.00
    2048x4096x8192    128x256      41.64     42.52   0.98
    2048x8192x4096    256x256      43.74     40.52   1.08
    2048x8192x8192    256x256      65.92     66.16   1.00

Every kernel validates exact-equal against the reference on every shape.

Note on measurement: the per-shape numbers above come from separate harness
invocations. Running all seven sequentially in one pass drifts the clock and
moves individual ratios by up to 7%, so treat the table as +/- 0.02 and re-measure
a single shape 3-4x for any A/B. Repeated same-shape runs are stable to ~1%.

What actually produced the wins, in the order a reviewer should read them:

1. python/src/LlirSchedule.cpp (new, ~2900 lines) is an LLIR-level scheduler that
   interleaves MFMAs with memory anchors, gated off by default behind
   TRITON_ENABLE_LLIR_SCHED. It is worth +25% on the 256x256 tile and is a 9-20%
   REGRESSION on the 64x128 and 128x128 tiles -- the cost model is calibrated for
   256 MFMAs per unrolled loop body and those tiles issue 64. It is enabled
   per-kernel, never globally; bench_best_tile.py encodes which kernel wants it.

2. python/src/llvm.cc adds TRITON_LLVM_OPTS, which forwards comma-separated
   name=value pairs to llvm::cl options. The 256x256 kernel needs
   amdgpu-mfma-vgpr-form=false to keep accumulators in AGPRs; without it the
   scheduler spills 48 registers and the kernel is 3-5x slower. Note the flag
   takes NO leading dash -- the dashed form is silently ignored with only a
   stderr warning.

3. The scale operands are pre-shuffled host-side (shuffle_a_scale /
   shuffle_b_scale), which is the same input contract AITER gets from
   aiter.ops.shuffle.shuffle_scale. This removes the LDS round-trip that existed
   purely to transpose scales into MFMA operand layout, taking ds_write in the
   main loop to zero and s_barrier from 8 to 4. This was the single largest win.

4. The 64x128 kernel additionally pre-shuffles B weights and loads them
   global->VGPR, so B never enters LDS at all. This is AITER's BpreShuffle
   contract. Worth ~10% there; it is a regression on the larger tiles, which have
   no register headroom for it.

5. Four new tiles (32x128, 64x128, 128x128, 128x256) exist because the selection
   rule is grid = ceil(M/BLOCK_M) * ceil(N/BLOCK_N) landing on 256 = the CU count
   of an MI350X. Overshooting (2 workgroups per CU at half arithmetic intensity)
   and undershooting (idle CUs) each cost 10-20%.

6. The 128x256 tile runs K=1024 per unrolled loop body, matching AITER, by
   emitting the 4-quarter block twice. Doubling BLOCK_K instead would need 205 KB
   of LDS against a 160 KB CU. Worth +4.4%. The peeled block must go AFTER the
   loop, not before -- peeling ahead of it makes layout inference resolve the
   accumulator to #blocked and the kernel fails to compile.

Also included: TLX barrier/mem_ops plumbing the kernels depend on, GetEnv.h knob
registration, and the cmake2buck.toml srcs entry for the new translation unit.

Known remaining gap, both compiler-side rather than kernel-side: every wait we
emit is s_waitcnt lgkmcnt(0), a full LDS-pipeline drain, where AITER uses
lgkmcnt(5) and keeps five ds_reads in flight. tlx.local_load yields a
whole-tensor SSA value, so a dot operand must be completely resident before
dot_scaled consumes it, and at occupancy 1 the drain is fully exposed. A
structural replica of AITER's dataflow that beats it on instruction count, bank
conflicts and MFMA utilisation is still 4% slower, which is the evidence that
this, and not the dataflow, is the ceiling.

Authored with Claude Code.

Differential Revision: D114574369


