### PR TITLE
[triton][lint] Suppress missing pybind stub in knobs test (#2726)

### DIFF
--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -2,7 +2,7 @@ import os
 import pytest
 import shutil
 import triton
-from triton._C.libtriton import get_cache_invalidating_env_vars
+from triton._C.libtriton import get_cache_invalidating_env_vars  # type: ignore[attr-defined]
 from triton._internal_testing import is_hip
 
 from pathlib import Path


### PR DESCRIPTION
Summary:

Mark the `get_cache_invalidating_env_vars` import as an untyped pybind attribute because `libtriton` does not provide a top-level stub for dynamically registered bindings.

Reviewed By: njriasan

Differential Revision: D114768607
