### PR TITLE
[triton][beta] Gate AMD HSTU benchmark to gfx950

### DIFF
--- a/third_party/tlx/tutorials/testing/test_amd_hstu_perf.py
+++ b/third_party/tlx/tutorials/testing/test_amd_hstu_perf.py
@@ -5,7 +5,7 @@ import torch
 
 import triton
 
-from triton._internal_testing import is_hip
+from triton._internal_testing import is_hip_cdna4
 from triton.language.extra.tlx.tutorials import amd_hstu_attn as _hstu
 
 
@@ -235,8 +235,8 @@ def parse_args():
 
 
 def main():
-    if not is_hip():
-        print("Skipping benchmarks, no AMD GPU found.")
+    if not is_hip_cdna4():
+        print("Skipping benchmarks, requires gfx950 hardware (CDNA4).")
         return
     args = parse_args()
     run_benchmark(args)


### PR DESCRIPTION
Summary: The HSTU tutorial uses CDNA4-only async TLX lowering and has never compiled on gfx942. Match its correctness coverage by skipping the performance benchmark unless `is_hip_cdna4()` is true.

Reviewed By: njriasan

Differential Revision: D114781808


