### PR TITLE
[inductor][tlx] AMD TLX attention kernels + passes + e2e AOTInductor lowering fixes (MI350X)

### DIFF
--- a/third_party/tlx/language/tlx/inductor/reduce_k.py
+++ b/third_party/tlx/language/tlx/inductor/reduce_k.py
@@ -119,10 +119,16 @@ def _reduce_k_body_source(
     bias_name: str | None = None,
     stride_bias_m: int = 0,
     stride_bias_n: int = 1,
+    index_dtype: str = "tl.int32",
 ) -> str:
+    # The spliced fused epilogue references INDEX_DTYPE (Inductor's per-kernel index
+    # dtype, used for dynamic-shape bounds like `tl.full([], ks0, dtype=INDEX_DTYPE)`).
+    # The main template kernel defines it, but this generated reducer is a standalone
+    # kernel, so define it here from the template kernel's own index_dtype.
     code = textwrap.dedent(f"""
     BLOCK_SIZE_M: tl.constexpr = 32
     BLOCK_SIZE_N: tl.constexpr = 32
+    INDEX_DTYPE: tl.constexpr = {index_dtype}
     pid_m = tl.program_id(0)
     pid_n = tl.program_id(1)
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
@@ -210,6 +216,7 @@ def emit_aoti_reduce_k_call(
                 bias_kernel_ptr,
                 stride_bias_m,
                 stride_bias_n,
+                index_dtype=getattr(template_kernel, "index_dtype", "tl.int32"),
             ))
         source_code = source.getvalue().replace(
             str(Placeholder.DESCRIPTIVE_NAME), reduce_name

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+import os
 from typing import Any, Generator
 
 log = logging.getLogger(__name__)
@@ -1239,7 +1240,17 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
         # to that case -- unit-scalar addmm and plain mm both qualify. sympy Symbol == 1
         # returns a plain False, so this stays safe for symbolic scalars.
         scalars = getattr(kernel_inputs, "_scalars", None) or {}
-        allow_split_k = scalars.get("alpha", 1) == 1 and scalars.get("beta", 1) == 1
+        # Split-K is opt-in via TORCHINDUCTOR_TLX_SPLIT_K=1 (default off). Autotune scores
+        # each addmm candidate on the GEMM kernel's own time only and excludes the separate
+        # reduce_k kernel's latency, so a split-K TLX addmm can beat rocBLAS on the GEMM yet
+        # be net-slower e2e once the reducer is added (observed on HIM). Flip on to A/B; make
+        # it default once autotune costs the reducer during lowering. Correctness also
+        # requires alpha == beta == 1.
+        allow_split_k = (
+            scalars.get("alpha", 1) == 1
+            and scalars.get("beta", 1) == 1
+            and os.environ.get("TORCHINDUCTOR_TLX_SPLIT_K", "0") == "1"
+        )
         m_hint = sizevars.optimization_hint(m, fallback=NUM_SMS)
         n_hint = sizevars.optimization_hint(n, fallback=NUM_SMS)
         for (


### PR DESCRIPTION
Summary:
Consolidates the AMD TLX attention kernels and experimental TLX lowering passes
originally authored by Bilal Sheikh (msheikh) in D109902712, plus the fixes to
make TLX selection work end-to-end on the AOTInductor (cpp_wrapper) production
lowering path for MI350X (gfx950). Rebased onto current master, so D114342717's
code-generated split-K `reduce_k` reducer is in the base.

This supersedes D109902712 (which can be abandoned): all of its content is
included here so this two-diff stack is self-contained.

Original work (from D109902712, msheikh):
- `ads_mkl/ops/tlx/tlx_bitattn.py`, `tlx_flash_attention.py`,
  `tlx_pma_attention.py` + their `ads_mkl/ops/tlx/BUCK` targets: AMD TLX
  attention kernels.
- `experiments/flash_attn/tlx_passes.py` + `experiments/flash_attn/BUCK`:
  experimental (non-prod) TLX attention DPer injection passes.

Fixes added on top (this diff):
- `registry.py`: split-K addmm candidates are gated behind a new
  `TORCHINDUCTOR_TLX_SPLIT_K` env knob, default OFF. Autotune scores each addmm
  candidate on the GEMM kernel's own time only and excludes the separate
  `reduce_k` latency, so a split-K TLX addmm can beat rocBLAS on the GEMM yet be
  net-slower e2e once the reducer runs (measured on HIM: split-K on 46.4K vs off
  47.6K qps T2). Enable via env for A/B; make it default once autotune costs the
  reducer. (Split-K also independently requires alpha == beta == 1.)
- `reduce_k.py`: fix D114342717's generated split-K reducer, which referenced
  `INDEX_DTYPE` (undefined) for dynamic-shape epilogues and failed to compile
  under AOTI cpp_wrapper (`NameError: INDEX_DTYPE is not defined`). Define
  `INDEX_DTYPE` in the reducer preamble from the template kernel's own
  `index_dtype`, so the reducer compiles on both JIT and AOTI whenever split-K
  is enabled.
- `use_tlx_self_attn`: compute `pick_config` at pass time from the concrete
  `query_meta.shape` and pass `(scale, block_m, block_n, num_warps, prefetch,
  num_buffers)` as constants into `tlx_self_attn` / `tlx_self_attn_4d`. Fixes
  `TraceError: symbolically traced variables cannot be used as inputs to control
  flow` during the acc_tracer re-trace; skip patterns with no config.
- `tlx_pma_attention.py`: fp16 MMA casts for q/kv/p, `async_load` OOB clamps,
  RMSNorm masked over the real head dim; PMA pass gated by
  `validate_inference(atol=3e-2, rtol=2e-2)`.
- New `use_tlx_gdpa` pass (4th attention pass): direct swap of the incumbent
  `ads_mkl::generalized_dot_product_attention` for
  `torch.ops.ads_mkl.tlx_generalized_dot_product_attention`, carrying `activation`.
- Shared `install_tlx_attn_pass_wiring()` wrapping
  `lower_utils.get_mts_chain_passes` to prepend the requested `use_tlx_*` passes
  (idempotent) + `TLX_ATTN_PASS_BY_NAME` covering the 4 attention passes.

Follow-ups: (1) make autotune add the `reduce_k` kernel's latency to each split-K
candidate's score during lowering, then default `TORCHINDUCTOR_TLX_SPLIT_K` on;
(2) some split-K warp-pipe configs emit "barrier or wait op cannot appear inside a
warp_pipeline_stage region" during autotune (dropped as non-fatal).

Developed with Claude Code.

Reviewed By: bilal

Differential Revision: D114632771


