### PR TITLE
[Release] Fix issues from the large backport

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
@@ -97,7 +97,7 @@ public:
         continue; // Log2_64(0) is UB; nothing to dedup
       int64_t pow2C = c & (-c);
       for (int i = 0; i < llvm::Log2_64(pow2C); i++) {
-        bases_inv[d][i] = {0};
+        bases_inv[d][i][0] = 0;
       }
     }
     auto invBroadcast = LinearLayout(std::move(bases_inv), invReg.getOutDims(),

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1955,16 +1955,16 @@ LogicalResult TMEMCopyOp::verify() {
     auto tmemLl = toLinearLayout(dstTy);
 
     // The upstream cga-layout equality check uses invertAndCompose, which
-    // requires matching out-dim names AND tmem out-dim sizes >= shmem out-dim
+    // requires matching out-dim names AND shmem out-dim sizes >= tmem out-dim
     // sizes (its internal assertion). Meta Triton's flexible multi-dimensional
-    // scale SMEM sources can be larger than the tmem destination, which would
-    // trip that assertion, so only run the check when the out-dims are
-    // compatible (the rank-equal case upstream assumes).
+    // scale SMEM sources can have incompatible per-dimension shapes, so only
+    // run the check when the out-dims are compatible (the rank-equal case
+    // upstream assumes).
     bool compatibleOutDims =
         llvm::equal(shmemLl.getOutDimNames(), tmemLl.getOutDimNames());
     if (compatibleOutDims) {
       for (auto dim : tmemLl.getOutDimNames()) {
-        if (tmemLl.getOutDimSize(dim) < shmemLl.getOutDimSize(dim)) {
+        if (shmemLl.getOutDimSize(dim) < tmemLl.getOutDimSize(dim)) {
           compatibleOutDims = false;
           break;
         }

--- a/scripts/build-llvm-project.sh
+++ b/scripts/build-llvm-project.sh
@@ -33,7 +33,6 @@ if [ -z "$CMAKE_ARGS" ]; then
               -DCMAKE_BUILD_TYPE="$LLVM_BUILD_TYPE"
               -DLLVM_CCACHE_BUILD=OFF
               -DLLVM_ENABLE_ASSERTIONS=ON
-              -DLLVM_INSTALL_UTILS=ON
               "${CLANG_LLD_ARGS[@]}"
               -DLLVM_OPTIMIZED_TABLEGEN=ON
               -DMLIR_ENABLE_BINDINGS_PYTHON=OFF

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -1125,8 +1125,8 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // RUBIN-LABEL: @cluster_barrier_inside_warp_specialize_rubin
   // RUBIN-COUNT-2: mbarrier.init.shared::cta.b64 [$1], 3;
   // RUBIN: %[[CTA:.*]] = nvvm.read.ptx.sreg.cluster.ctarank
-  // RUBIN: %[[ALL_CTAS:.*]] = llvm.mlir.constant(15 : i32) : i32
-  // RUBIN: %[[SELF_MASK:.*]] = llvm.shl %{{.*}}, %[[CTA]] : i32
+  // RUBIN-DAG: %[[ALL_CTAS:.*]] = llvm.mlir.constant(15 : i32) : i32
+  // RUBIN-DAG: %[[SELF_MASK:.*]] = llvm.shl %{{.*}}, %[[CTA]] : i32
   // RUBIN: %[[PEER_MASK:.*]] = llvm.xor %[[ALL_CTAS]], %[[SELF_MASK]] : i32
   // RUBIN-COUNT-1: mbarrier.arrive.release.cluster.shared::cluster.multicast::cluster::32b.b64 _, [$1], $2;
   // RUBIN-NOT: mbarrier.arrive

--- a/test/TritonGPU/amd/amd-consan.mlir
+++ b/test/TritonGPU/amd/amd-consan.mlir
@@ -1153,16 +1153,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // CHECK-LABEL: @tdm_gather_scatter_track_commits
   tt.func public @tdm_gather_scatter_track_commits(%desc: !tt.tensordesc<64x128xf16>, %rows: tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>) {
     %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
-    %c0_i32 = arith.constant 0 : i32
-    %true_i32 = arith.constant 1 : i32
     // CHECK: tt.call @__triton_consan_stage_access_for_commit
     // CHECK: tt.call @__triton_consan_commit_accesses
     // CHECK: amdg.async_tdm_gather
-    %gather = amdg.async_tdm_gather %desc[%rows, %c0_i32] to %buffer, pred = %true_i32 : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    %gather = amdg.async_tdm_gather %desc[%rows] to %buffer : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
     // CHECK: tt.call @__triton_consan_stage_access_for_commit
     // CHECK: tt.call @__triton_consan_commit_accesses
     // CHECK: amdg.async_tdm_scatter
-    %scatter = amdg.async_tdm_scatter %desc[%rows, %c0_i32] from %buffer : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    %scatter = amdg.async_tdm_scatter %desc[%rows] from %buffer : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
     // CHECK: tt.call @__triton_consan_clear_outstanding_commits_transfer_both
     // CHECK: amdg.async_tdm_wait
     %wait = amdg.async_tdm_wait %scatter {num = 0 : i32}
@@ -1184,19 +1182,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   tt.func public @tdm_gather_scatter_track_barrier(%desc: !tt.tensordesc<64x128xf16>, %rows: tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>) {
     %buffer = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
     %barrier = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
-    %c0_i32 = arith.constant 0 : i32
-    %true_i32 = arith.constant 1 : i32
     amdg.init_barrier %barrier, 8 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_commit_accesses
     // CHECK: amdg.async_tdm_gather
-    %gather = amdg.async_tdm_gather %desc[%rows, %c0_i32] to %buffer, pred = %true_i32, barrier = %barrier : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    %gather = amdg.async_tdm_gather %desc[%rows] to %buffer, barrier = %barrier : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
     // CHECK-NOT: tt.call @__triton_consan_commit_accesses
     // CHECK: amdg.async_tdm_scatter
-    %scatter = amdg.async_tdm_scatter %desc[%rows, %c0_i32] from %buffer, barrier = %barrier : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
+    %scatter = amdg.async_tdm_scatter %desc[%rows] from %buffer, barrier = %barrier : tensor<64xi32, #ttg.slice<{dim = 0, parent = #idx_parent}>>, !ttg.memdesc<256x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable> -> !tt.tensordesc<64x128xf16>
     tt.return
   }
 }


### PR DESCRIPTION
- Duplicate flag in the build script.
- Build failure due to only being compatible with certain gcc/clang versions
- Fix a logic issue in TMEM handling.
- Fix a rubin consistency issue we couldn't fix internally because we don't have cuda 13.4 yet.