### PR TITLE
[triton][beta] Backport (release/3.8.x) 'Gate explicit shared stores using PTX version (#10787)' (#2735)

### DIFF
--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -1,6 +1,7 @@
-// RUN: triton-opt %s -split-input-file --nvgpu-tma-store-token-wait-lowering --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=87' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=87' -reconcile-unrealized-casts | FileCheck %s
+// RUN: triton-opt %s -split-input-file --nvgpu-tma-store-token-wait-lowering --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=84' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=84' -reconcile-unrealized-casts | FileCheck %s
 // RUN: triton-opt %s -split-input-file --nvgpu-tma-store-token-wait-lowering --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=85' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=85' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX85 %s
 // RUN: triton-opt %s -split-input-file --nvgpu-tma-store-token-wait-lowering --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=86' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=86' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX86 %s
+// RUN: triton-opt %s -split-input-file --nvgpu-tma-store-token-wait-lowering --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=88' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=88' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX88 %s
 // RUN: triton-opt %s -split-input-file --nvgpu-tma-store-token-wait-lowering --convert-triton-gpu-to-llvm='compute-capability=107 ptx-version=94' --initialize-ws-cluster-barriers='compute-capability=107 ptx-version=94' -reconcile-unrealized-casts | FileCheck --check-prefix=RUBIN %s
 
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
@@ -932,6 +933,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.tot
 
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // CHECK-LABEL: @local_gather_scatter_same_ownership
+  // PTX88-LABEL: @local_gather_scatter_same_ownership
+  // PTX88: llvm.inline_asm {{.*}} "st.shared.b32
   // CHECK-NOT: nvvm.mapa
   // CHECK: llvm.load {{.*}} : !llvm.ptr<3> -> i32
   // CHECK: nvvm.barrier
@@ -952,6 +955,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   }
 
   // CHECK-LABEL: @local_gather_scatter_broadcast
+  // PTX88-LABEL: @local_gather_scatter_broadcast
+  // PTX88: llvm.inline_asm {{.*}} "st.shared.b32
   // CHECK: nvg.cluster_id
   // CHECK-NOT: nvvm.mapa
   // CHECK: llvm.load {{.*}} : !llvm.ptr<3> -> i32
@@ -973,6 +978,8 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   }
 
   // CHECK-LABEL: @local_gather_scatter_cross_cta
+  // PTX88-LABEL: @local_gather_scatter_cross_cta
+  // PTX88: llvm.inline_asm {{.*}} "st.shared::cluster.b32
   // CHECK: nvvm.mapa
   // CHECK: llvm.load {{.*}} : !llvm.ptr<7> -> i32
   // CHECK: nvvm.barrier

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -321,7 +321,7 @@ void TargetInfo::storeDShared(RewriterBase &rewriter, Location loc, Value ptr,
 
   auto *ptrOpr = builder.newAddrOperand(ptr, "r");
 
-  if (isConstantTruePred(pred) && !barrierPtr) {
+  if (isConstantTruePred(pred) && !barrierPtr && !useExplicitSharedStore()) {
     b.store(val, ptr, /*align=*/vec * elemBitwidth / 8);
   } else {
     PTXBuilder::Operand *valOpr;
@@ -335,15 +335,25 @@ void TargetInfo::storeDShared(RewriterBase &rewriter, Location loc, Value ptr,
     } else {
       valOpr = builder.newOperand(val, constraint);
     }
-    // Build the store instruction with optional barrier operand
+
+    // Build the explicit store, adding barrier and predicate operands when
+    // needed.
     if (barrierPtr.has_value()) {
       auto *barrierOpr = builder.newAddrOperand(mappedBarrier, "r");
       st(ptrOpr, valOpr, barrierOpr).predicate(pred, "b");
-    } else {
+    } else if (!isConstantTruePred(pred)) {
       st(ptrOpr, valOpr).predicate(pred, "b");
+    } else {
+      st(ptrOpr, valOpr);
     }
     builder.launch(rewriter, loc, void_ty(ctx));
   }
+}
+
+bool TargetInfo::useExplicitSharedStore() const {
+  // Use explicit shared stores for PTX 8.5-8.9 to avoid a ptxas
+  // miscompilation; other PTX versions keep the LLVM store path.
+  return ptxVersion >= 85 && ptxVersion < 90;
 }
 
 void TargetInfo::copyBulkSharedToRemoteShared(RewriterBase &rewriter,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -105,6 +105,8 @@ public:
   bool isCuda() const override { return true; }
 
 private:
+  bool useExplicitSharedStore() const;
+
   triton::nvidia_gpu::TargetFeatures targetFeatures;
   int ptxVersion;
 };


### PR DESCRIPTION
Summary:

This is a resolved backport of upstream PR https://github.com/triton-lang/triton/pull/10787 for the Triton 3.8 release branch.

Why this change is needed:
The upstream change fixes silent incorrectness caused by generic shared-memory stores on affected NVIDIA toolchains. In the supported Beta matrix, CUDA 12.4 emits PTX 8.4 and does not reproduce the issue, while CUDA 12.9 emits PTX 8.8 and does. CUDA 13.x emits PTX 9.x and does not reproduce the issue.

How this differs from upstream PR #10787:
- Upstream unconditionally replaces constant-true llvm.store lowering with explicit shared-store PTX.
- Beta uses the PTX version already stored in TargetInfo as a proxy for the supported toolchains. PTX 8.5 through 8.9 use the explicit-store workaround; PTX 8.4 and PTX 9.x retain the existing llvm.store lowering.
- The original if/else structure is preserved. The only change to the optimized branch is the additional workaround condition.
- The Beta-specific predicated async barrierPtr path remains unchanged.
- Beta retains its existing st.shared spelling for CTA-local memory; this is the legacy equivalent of upstream st.shared::cta. Cluster stores continue to use st.shared::cluster.

Implementation and test differences:
- The gate is implemented entirely in TargetInfo through useExplicitSharedStore(). No Python helper, module attribute, pass option, or constructor plumbing is added.
- The existing tritonnvidiagpu_to_llvm.mlir test runs the conversion with PTX 8.4 and PTX 8.8, verifying llvm.store for PTX 8.4 and explicit local and cluster shared stores for PTX 8.8.
- checkout_info.bzl records the release/3.8.x Reactor backport revision.

Reviewed By: njriasan

Differential Revision: D114626878


