### PR TITLE
[triton][beta] Align AMD TDM descriptor layouts with allocations

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.h
@@ -47,6 +47,11 @@ private:
                                       unsigned numCTAs);
 
 protected:
+  virtual Attribute getDesiredDescriptorEncoding(
+      TypedValue<triton::TensorDescType> descriptor) {
+    return {};
+  }
+
   virtual Attribute getCompatibleSharedEncoding(Attribute enc,
                                                 ArrayRef<int64_t> shape,
                                                 Type elementType) {

--- a/lib/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.cpp
@@ -397,6 +397,10 @@ void AssignDescriptorMemoryLayouts::runOnFunction(FuncOp &func) {
 
       auto setEncoding = [&](Value v) {
         auto typedVal = cast<TypedValue<TensorDescType>>(v);
+        if (auto desiredEncoding = getDesiredDescriptorEncoding(typedVal)) {
+          updateEncoding({typedVal}, EncodingInfo{desiredEncoding});
+          return;
+        }
         valueToEncodingInfo.try_emplace(typedVal, einfo);
         if (forcedToDefault)
           worklist.insert(typedVal);

--- a/test/TritonGPU/amd/amd-optimize-descriptor-encoding.mlir
+++ b/test/TritonGPU/amd/amd-optimize-descriptor-encoding.mlir
@@ -193,3 +193,38 @@ tt.func public @descriptor_fallback(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: i32,
   tt.return
 }
 }
+
+// -----
+// Test that TDM loads inherit the explicit shared allocation encoding through
+// descriptor updates.
+#padded = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [128, 32]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250"} {
+// CHECK-DAG: #[[$TDM_PADDED:.*]] = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [128, 32]}>
+// CHECK-LABEL: @tdm_load_allocation_encoding
+tt.func public @tdm_load_allocation_encoding(%desc: !tt.tensordesc<128x32xf16>, %m: i32, %k: i32) {
+  // CHECK-SAME: %[[DESC:.*]]: !tt.tensordesc<128x32xf16, #[[$TDM_PADDED]]>
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<128x32xf16, #padded, #smem, mutable>
+  // CHECK: %[[POSITIONED:.*]] = amdg.update_tensor_descriptor %[[DESC]] {{.*}} : !tt.tensordesc<128x32xf16, #[[$TDM_PADDED]]>
+  %positioned = amdg.update_tensor_descriptor %desc add_offsets = [%m, %k] : !tt.tensordesc<128x32xf16>
+  // CHECK: amdg.async_tdm_copy_global_to_local %[[POSITIONED]] into {{.*}} : !tt.tensordesc<128x32xf16, #[[$TDM_PADDED]]> -> !ttg.memdesc<128x32xf16, #[[$TDM_PADDED]], #smem, mutable>
+  %token = amdg.async_tdm_copy_global_to_local %positioned into %alloc : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #padded, #smem, mutable>
+  tt.return
+}
+}
+
+// -----
+// Test that TDM stores inherit a swizzled source allocation encoding.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250"} {
+// CHECK-DAG: #[[$TDM_SHARED:.*]] = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+// CHECK-LABEL: @tdm_store_allocation_encoding
+tt.func public @tdm_store_allocation_encoding(%desc: !tt.tensordesc<32x32xf16>) {
+  // CHECK-SAME: %[[DESC:.*]]: !tt.tensordesc<32x32xf16, #[[$TDM_SHARED]]>
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<32x32xf16, #shared, #smem, mutable>
+  // CHECK: amdg.async_tdm_copy_local_to_global %[[DESC]] from {{.*}} : !ttg.memdesc<32x32xf16, #[[$TDM_SHARED]], #smem, mutable> -> !tt.tensordesc<32x32xf16, #[[$TDM_SHARED]]>
+  amdg.async_tdm_copy_local_to_global %desc from %alloc : !ttg.memdesc<32x32xf16, #shared, #smem, mutable> -> !tt.tensordesc<32x32xf16>
+  tt.return
+}
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeDescriptorEncoding.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeDescriptorEncoding.cpp
@@ -7,6 +7,7 @@
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "llvm/ADT/STLExtras.h"
 
 namespace tt = mlir::triton;
 namespace ttg = mlir::triton::gpu;
@@ -130,6 +131,8 @@ public:
   AMDGPUAssignDescriptorMemoryLayouts() = default;
 
 private:
+  Attribute getDesiredDescriptorEncoding(
+      TypedValue<tt::TensorDescType> descriptor) override;
   Attribute buildFallbackSharedEncoding(mlir::MLIRContext *ctx,
                                         ArrayRef<int64_t> shape,
                                         ArrayRef<unsigned> order,
@@ -137,6 +140,65 @@ private:
                                         Type elementType) override;
   bool isCompatibleSharedEncoding(Attribute enc) override;
 };
+
+Attribute AMDGPUAssignDescriptorMemoryLayouts::getDesiredDescriptorEncoding(
+    TypedValue<tt::TensorDescType> descriptor) {
+  SmallVector<Value> worklist{descriptor};
+  SmallVector<Value> visited;
+  Attribute desiredEncoding;
+
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (llvm::is_contained(visited, value))
+      continue;
+    visited.push_back(value);
+
+    for (Operation *user : value.getUsers()) {
+      if (auto update = dyn_cast<triton::amdgpu::UpdateTensorDescriptorOp>(user)) {
+        if (update.getDesc() == value)
+          worklist.push_back(update.getResult());
+        continue;
+      }
+
+      ttg::MemDescType memoryType;
+      if (auto load =
+              dyn_cast<triton::amdgpu::AsyncTDMCopyGlobalToLocalOp>(user)) {
+        if (load.getDesc() == value)
+          memoryType = load.getResult().getType();
+      } else if (auto store =
+                     dyn_cast<triton::amdgpu::AsyncTDMCopyLocalToGlobalOp>(
+                         user)) {
+        if (store.getDesc() == value)
+          memoryType = store.getSrc().getType();
+      } else if (auto gather =
+                     dyn_cast<triton::amdgpu::AsyncTDMGatherOp>(user)) {
+        if (gather.getDesc() == value)
+          memoryType = gather.getDst().getType();
+      } else if (auto scatter =
+                     dyn_cast<triton::amdgpu::AsyncTDMScatterOp>(user)) {
+        if (scatter.getDesc() == value)
+          memoryType = scatter.getSrc().getType();
+      }
+
+      if (!memoryType)
+        continue;
+
+      Attribute encoding = memoryType.getEncoding();
+      if (auto partitioned =
+              dyn_cast<ttg::PartitionedSharedEncodingAttr>(encoding))
+        encoding = partitioned.getPartitionLayout();
+      encoding = getCompatibleSharedEncoding(
+          encoding, memoryType.getShape(), memoryType.getElementType());
+      if (!encoding)
+        continue;
+      if (desiredEncoding && desiredEncoding != encoding)
+        return {};
+      desiredEncoding = encoding;
+    }
+  }
+
+  return desiredEncoding;
+}
 
 Attribute AMDGPUAssignDescriptorMemoryLayouts::buildFallbackSharedEncoding(
     mlir::MLIRContext *ctx, ArrayRef<int64_t> shape, ArrayRef<unsigned> order,


### PR DESCRIPTION
Summary:
Seed tensor descriptor encodings from the explicit shared-memory allocation used by AMD TDM load, store, gather, and scatter operations. Follow `update_tensor_descriptor` uses and preserve the effective inner layout for partitioned allocations so the descriptor and hardware allocation remain consistent.

Keep the descriptor consistency verifier intact and add focused coverage for padded loads and swizzled stores.

Reviewed By: njriasan

Differential Revision: D114781807


