### PR TITLE
Propagate AutoWS task IDs through scf.while control flow

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_task_id_propagation.mlir
+++ b/test/Hopper/WarpSpecialization/ws_task_id_propagation.mlir
@@ -56,6 +56,42 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// A data-partitioned inner loop can introduce a structural task that does not
+// otherwise consume the outer while's tile id. Physical while specialization
+// still preserves the complete loop signature in that task, so the condition
+// and loop-carried atomic claim must be available to the full task union.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @while_with_nested_structural_task
+  // CHECK:       arith.cmpi {{.*}} {async_task_id = array<i32: 0, 1, 2>}
+  // CHECK:       scf.condition{{.*}} {async_task_id = array<i32: 0, 1, 2>}
+  // CHECK:       tt.atomic_rmw {{.*}} {async_task_id = array<i32: 0, 1, 2>}
+  // CHECK:       scf.yield {async_task_id = array<i32: 0, 1, 2>} %{{.*}} : i32
+  tt.func public @while_with_nested_structural_task(
+      %counter: !tt.ptr<i32>, %out0: !tt.ptr<i32>, %out1: !tt.ptr<i32>,
+      %bound: i32) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %result = scf.while (%tile = %c0) : (i32) -> i32 {
+      %valid = arith.cmpi slt, %tile, %bound : i32
+      scf.condition(%valid) %tile : i32
+    } do {
+    ^bb0(%tile: i32):
+      scf.for %i = %c0 to %c1 step %c1 : i32 {
+        scf.yield {"ttg.partition" = array<i32: 2>}
+      }
+      tt.store %out0, %tile {"ttg.partition" = array<i32: 0>} : !tt.ptr<i32>
+      tt.store %out1, %tile {"ttg.partition" = array<i32: 1>} : !tt.ptr<i32>
+      %next = tt.atomic_rmw add, acq_rel, gpu, %counter, %c1, %true : (!tt.ptr<i32>, i32, i1) -> i32
+      scf.yield %next : i32
+    }
+    tt.return
+  }
+}
+
+// -----
+
 // Test that nested for loop constant bounds get allTasks after propagation.
 // The inner loop body only contains ops with tasks 1 and 2, while task 0 ops
 // are in the outer loop epilogue. The solver's backward propagation only sees

--- a/test/Hopper/WarpSpecialization/ws_task_id_propagation_no_tasks.mlir
+++ b/test/Hopper/WarpSpecialization/ws_task_id_propagation_no_tasks.mlir
@@ -1,0 +1,23 @@
+// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta '--nvgpu-warp-specialization=capability=90 num-stages=3 smem-budget=200000' | FileCheck %s
+
+// A while with no partition anchors has no task union. It must pass through
+// task propagation without materializing an unknown task attribute.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @while_without_tasks
+  // CHECK-NOT:   scf.while
+  // CHECK:       tt.return
+  tt.func public @while_without_tasks(%bound: i32) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %result = scf.while (%i = %c0) : (i32) -> i32 {
+      %valid = arith.cmpi slt, %i, %bound : i32
+      scf.condition(%valid) %i : i32
+    } do {
+    ^bb0(%i: i32):
+      %next = arith.addi %i, %c1 : i32
+      scf.yield %next : i32
+    } attributes {tt.warp_specialize}
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TaskIdPropagation.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TaskIdPropagation.cpp
@@ -124,7 +124,7 @@ LogicalResult TaskIdBackwardPropagation::visitOperation(
     ArrayRef<const TaskIdLattice *> results) {
   // TODO(Arda): Replace the following with getAsyncTaskIds when we no longer
   // need to dump the task ids into the IR.
-  auto taskIdAttr = op->getAttrOfType<DenseI32ArrayAttr>("async_task_id");
+  auto taskIdAttr = op->getAttrOfType<DenseI32ArrayAttr>(kAsyncTaskIdAttrName);
 
   // An op is a non-anchor (allows backward propagation to flow through) only
   // if it is a scalar arithmetic/math op. These ops compute shared addresses
@@ -211,17 +211,25 @@ void TaskIdBackwardPropagation::visitBranchOperand(OpOperand &operand) {
   auto defOp = operand.getOwner();
   if (auto condOp = dyn_cast<scf::ConditionOp>(defOp)) {
     auto whileOp = cast<scf::WhileOp>(condOp->getParentOp());
+    auto whileTaskIds = TaskId::getUninitialized();
+    if (auto attr =
+            whileOp->getAttrOfType<DenseI32ArrayAttr>(kAsyncTaskIdAttrName))
+      whileTaskIds = TaskId(attr);
     for (auto [idx, forwarded] : llvm::enumerate(condOp.getArgs())) {
       if (forwarded != operand.get())
         continue;
       auto resultLattice = getLatticeElement(whileOp.getResult(idx));
-      if (resultLattice->getValue().isUninitialized())
-        return;
       auto forwardedLattice = getLatticeElement(forwarded);
-      ChangeResult changed = forwardedLattice->meet(resultLattice->getValue());
+      auto taskIds = TaskId::meet(resultLattice->getValue(), whileTaskIds);
+      if (taskIds.isUninitialized())
+        return;
+      ChangeResult changed = forwardedLattice->meet(taskIds);
       propagateIfChanged(forwardedLattice, changed);
       return;
     }
+    auto conditionLattice = getLatticeElement(operand.get());
+    ChangeResult changed = conditionLattice->meet(whileTaskIds);
+    propagateIfChanged(conditionLattice, changed);
     return;
   }
 


### PR DESCRIPTION
Summary:
A Hopper warp-specialization test fell back to unspecialized code because a task introduced by a nested loop was missing from the outer `scf.while` condition and loop-carried tile ID. This mismatch caused the atomic-broadcast safety check to reject warp specialization.

Merge the full task set from the enclosing while into its condition and forwarded values during task-ID propagation. Add regressions for the nested-loop case and an unannotated while.

Reviewed By: njriasan

Differential Revision: D114466298


