### PR TITLE
[tlx][amd] v9: keep the K-offset bumps inside a warp_pipeline stage

### DIFF
--- a/third_party/tlx/tutorials/gfx9_gemm/a16w16/v9_beyond_hotloop/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/a16w16/v9_beyond_hotloop/matmul_kernel.py
@@ -143,9 +143,8 @@ def v9_beyond_hotloop(
             b_left = tlx.local_load(smem_b_left[1], relaxed=True)
             tlx.buffer_load_to_local(smem_b_right[0], b_ptr, br_off + b_k)
             tlx.async_load_commit_group()
-
-        a_k += BLOCK_K * stride_ak
-        b_k += BLOCK_K * stride_bk
+            a_k += BLOCK_K * stride_ak
+            b_k += BLOCK_K * stride_bk
 
         # ──── Region 2 ────
         with tlx.warp_pipeline_stage("mfma", priority=0):
@@ -166,9 +165,17 @@ def v9_beyond_hotloop(
             b_left = tlx.local_load(smem_b_left[0], relaxed=True)
             tlx.buffer_load_to_local(smem_b_right[1], b_ptr, br_off + b_k)
             tlx.async_load_commit_group()
-
-        a_k += BLOCK_K * stride_ak
-        b_k += BLOCK_K * stride_bk
+            # Bump the K offsets INSIDE the final stage. Left trailing after it,
+            # these two adds are the only ops following the last
+            # warp_pipeline_stage border, and WarpPipeliner::createPipeline
+            # sweeps whatever is left over into an extra "last_cluster" stage
+            # (priority -1) containing nothing but two arith.addi -- a whole
+            # pipeline turn where one wave group does two scalar adds while the
+            # other waits. sinkPureScalarsIntoNextStage cannot rescue them
+            # because there is no next stage to sink into. The identical pair in
+            # the middle of the body IS rescued, which is why only this one hurt.
+            a_k += BLOCK_K * stride_ak
+            b_k += BLOCK_K * stride_bk
 
     # ── Epilogue: drain the last two K iterations ──
     acc_left = tl.dot(a, b_left, acc_left)


### PR DESCRIPTION
Summary:
The v9 loop body ended with two trailing `a_k/b_k += BLOCK_K * stride`
statements sitting after the final `warp_pipeline_stage` border. Anything left
over after the last border is swept into an extra pipeline stage by
`WarpPipeliner::createPipeline`:

    if (!cluster.empty()) {   // Create the last cluster if needed.
      clusters.push_back(std::move(cluster));
      clusterMarkers.push_back({StringAttr::get(ctx, "last_cluster"), -1});
    }

so the TTGIR grew a `triton.warp_pipeline.stage = "last_cluster"` region whose
entire body is two `arith.addi` -- a whole ping-pong turn in which one wave
group does two scalar adds while the other waits. `sinkPureScalarsIntoNextStage`
cannot rescue them because there is no next stage to sink into; the identical
pair in the middle of the body IS rescued, which is why only the trailing one
cost anything.

Moving both pairs inside their preceding "mem" stage removes the extra stage
(`last_cluster` count 1 -> 0) and is a pure reordering: the loads in that stage
already consumed the pre-bump offsets, so the bump simply happens at the end of
the region instead of after it. Both pairs are moved rather than just the
trailing one, to keep the body consistent -- that also measured marginally
better and with a tighter spread.

This is easy to reintroduce: the failure is silent, costs ~2%, and depends only
on whether the author happens to end the loop body with a stage. inter_wave and
the split-M ping-pong avoid it purely by ending on a stage. Folding trailing
pure scalars into the last real cluster (or warning when `last_cluster` holds
only pure scalars) would make it unhittable; that fix belongs in
WarpPipeliner.cpp and is not part of this change.

 {F1993386843}

Reviewed By: htyu

Differential Revision: D114682538


