### PR TITLE
[Triton][beta][AMD] Align two-dot BlockPingpong scheduling (#2745)

### DIFF
--- a/test/TritonGPU/amd/amd-block-pingpong-chained-dots.mlir
+++ b/test/TritonGPU/amd/amd-block-pingpong-chained-dots.mlir
@@ -66,7 +66,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %16 = ttg.async_copy_global_to_local %arg0, %15 : tensor<64x16x!tt.ptr<f16>, #blocked> -> <64x16xf16, #shared, #smem, mutable>
       %17 = ttg.async_commit_group tokens %16
       scf.yield %12, %6, %14, %arg19, %17, %arg21, %15, %11, %9 : tensor<128x16xf32, #mma>, tensor<128x16xf32, #mma>, tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>, !ttg.async.token, !ttg.async.token, !ttg.memdesc<64x16xf16, #shared, #smem, mutable>, !ttg.memdesc<64x16xf16, #shared, #smem, mutable>, !ttg.async.token, !ttg.memdesc<64x16xf16, #shared, #smem, mutable>
-    }
+    } {amdg.two_dot_schedule}
     ttg.local_dealloc %1 : !ttg.memdesc<2x64x16xf16, #shared, #smem, mutable>
     ttg.local_dealloc %0 : !ttg.memdesc<2x64x16xf16, #shared, #smem, mutable>
     tt.return %5#0 : tensor<128x16xf32, #mma>
@@ -136,7 +136,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %12 = ttg.memdesc_index %1[%arg6] : !ttg.memdesc<2x64x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x16xf16, #shared, #smem, mutable>
       %13 = tt.load %arg1 : tensor<64x16x!tt.ptr<f16>, #blocked>
       scf.yield %10, %6, %11, %arg19, %12, %8, %9, %13 : tensor<128x16xf32, #mma>, tensor<128x16xf32, #mma>, tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>, !ttg.memdesc<64x16xf16, #shared, #smem, mutable>, !ttg.memdesc<64x16xf16, #shared, #smem, mutable>, !ttg.memdesc<64x16xf16, #shared, #smem, mutable>, tensor<64x16xf16, #blocked>, tensor<64x16xf16, #blocked>
-    }
+    } {amdg.two_dot_schedule}
     ttg.local_dealloc %1 : !ttg.memdesc<2x64x16xf16, #shared, #smem, mutable>
     ttg.local_dealloc %0 : !ttg.memdesc<2x64x16xf16, #shared, #smem, mutable>
     tt.return %5#0 : tensor<128x16xf32, #mma>
@@ -172,7 +172,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %12 = ttg.memdesc_index %1[%arg6] : !ttg.memdesc<2x64x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x16xf16, #shared, #smem, mutable>
       %13 = tt.load %arg1 : tensor<64x16x!tt.ptr<f16>, #blocked>
       scf.yield %10, %6, %11, %arg19, %12, %12, %13, %13 : tensor<128x16xf32, #mma>, tensor<128x16xf32, #mma>, tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>, !ttg.memdesc<64x16xf16, #shared, #smem, mutable>, !ttg.memdesc<64x16xf16, #shared, #smem, mutable>, !ttg.memdesc<64x16xf16, #shared, #smem, mutable>, tensor<64x16xf16, #blocked>, tensor<64x16xf16, #blocked>
-    }
+    } {amdg.two_dot_schedule}
     ttg.local_dealloc %1 : !ttg.memdesc<2x64x16xf16, #shared, #smem, mutable>
     ttg.local_dealloc %0 : !ttg.memdesc<2x64x16xf16, #shared, #smem, mutable>
     tt.return %5#0 : tensor<128x16xf32, #mma>
@@ -200,7 +200,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %13 = tt.load %arg1 : tensor<64x16x!tt.ptr<f16>, #blocked>
       %10 = tt.dot %arg10, %arg17, %arg16 : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x16xf32, #mma>
       scf.yield %10, %6, %11, %arg19, %arg20, %arg20, %13, %13 : tensor<128x16xf32, #mma>, tensor<128x16xf32, #mma>, tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>, !ttg.memdesc<64x16xf16, #shared, #smem, mutable, 2x64x16>, !ttg.memdesc<64x16xf16, #shared, #smem, mutable, 2x64x16>, !ttg.memdesc<64x16xf16, #shared, #smem, mutable, 2x64x16>, tensor<64x16xf16, #blocked>, tensor<64x16xf16, #blocked>
-    }
+    } {amdg.two_dot_schedule}
     tt.return %5#0 : tensor<128x16xf32, #mma>
   }
 }

--- a/test/TritonGPU/amd/amd-pipeline-chained-dots.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-chained-dots.mlir
@@ -1,4 +1,6 @@
-// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=4" -tritonamdgpu-pipeline="use_async_copy=1" -canonicalize | FileCheck %s
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=4" -tritonamdgpu-pipeline="use_async_copy=1 use_pingpong=1" -canonicalize | FileCheck %s
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=4" -tritonamdgpu-pipeline="use_async_copy=1 use_pingpong=1" -canonicalize --tritonamdgpu-block-pingpong="num-stages=4" | FileCheck %s --check-prefix=PINGPONG
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=4" -tritonamdgpu-pipeline="use_async_copy=1 use_pingpong=0" -canonicalize --tritonamdgpu-block-pingpong="num-stages=4" | FileCheck %s --check-prefix=NO-PINGPONG
 
 #blocked = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
 #mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32, 16], isTransposed = true}>
@@ -14,6 +16,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: ttg.async_wait
   // CHECK: ttg.local_load
   // CHECK: scf.yield
+  // CHECK: } {amdg.two_dot_schedule}
   // CHECK: ttg.async_wait
   // CHECK: ttg.local_load
 
@@ -34,6 +37,55 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       scf.yield %10 : tensor<128x16xf32, #mma>
     }
     tt.return %6 : tensor<128x16xf32, #mma>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32, 16], isTransposed = true}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: tt.func @independent_scaled_dots
+  // CHECK: scf.for
+  // CHECK-COUNT-2: tt.dot_scaled
+  // CHECK: } {amdg.two_dot_schedule}
+  // CHECK: tt.return
+
+  // PINGPONG-LABEL: tt.func @independent_scaled_dots
+  // PINGPONG: scf.for
+  // PINGPONG: rocdl.s.barrier
+  // PINGPONG: tt.dot_scaled
+  // PINGPONG: rocdl.s.setprio
+  // PINGPONG: tt.dot_scaled
+  // PINGPONG-NOT: amdg.two_dot_schedule
+  // PINGPONG: tt.return
+
+  // NO-PINGPONG-LABEL: tt.func @independent_scaled_dots
+  // NO-PINGPONG-NOT: rocdl.s.barrier
+  // NO-PINGPONG-NOT: rocdl.s.setprio
+  // NO-PINGPONG-NOT: amdg.two_dot_schedule
+  // NO-PINGPONG: tt.return
+
+  tt.func @independent_scaled_dots(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>, %arg3: i32, %arg4: i32) -> tensor<128x16xf32, #mma> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma>
+    %0 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<1x16x!tt.ptr<f16>, #blocked>
+    %1 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %2 = tt.expand_dims %1 {axis = 1 : i32} : tensor<64xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %3 = tt.broadcast %0 : tensor<1x16x!tt.ptr<f16>, #blocked> -> tensor<64x16x!tt.ptr<f16>, #blocked>
+    %4 = tt.broadcast %2 : tensor<64x1xi32, #blocked> -> tensor<64x16xi32, #blocked>
+    %5 = tt.addptr %3, %4 : tensor<64x16x!tt.ptr<f16>, #blocked>, tensor<64x16xi32, #blocked>
+    %6:2 = scf.for %arg7 = %c0_i32 to %arg3 step %arg4 iter_args(%arg5 = %cst, %arg6 = %cst) -> (tensor<128x16xf32, #mma>, tensor<128x16xf32, #mma>)  : i32 {
+      %7 = tt.load %5 : tensor<64x16x!tt.ptr<f16>, #blocked>
+      %8 = ttg.convert_layout %7 : tensor<64x16xf16, #blocked> -> tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %9 = tt.load %5 : tensor<64x16x!tt.ptr<f16>, #blocked>
+      %10 = ttg.convert_layout %9 : tensor<64x16xf16, #blocked> -> tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %11 = tt.dot_scaled %arg2, %8, %arg5 lhs = fp16 rhs = fp16 {fastMath = false} : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x16xf32, #mma>
+      %12 = tt.dot_scaled %arg2, %10, %arg6 lhs = fp16 rhs = fp16 {fastMath = false} : tensor<128x64xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<64x16xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x16xf32, #mma>
+      scf.yield %11, %12 : tensor<128x16xf32, #mma>, tensor<128x16xf32, #mma>
+    }
+    %13 = arith.addf %6#0, %6#1 : tensor<128x16xf32, #mma>
+    tt.return %13 : tensor<128x16xf32, #mma>
   }
 }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -9,6 +9,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "third_party/amd/lib/TritonAMDGPUTransforms/PipelineUtility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -83,6 +84,7 @@ class Pingponger {
   SmallVector<ttg::AsyncCopyGlobalToLocalOp> asyncCopyOps;
   SmallVector<ttg::AsyncWaitOp> asyncWaitOps;
   SmallVector<ttg::AsyncCommitGroupOp> asyncCommitOps;
+  SmallVector<tt::DotOpInterface> dotLikeOps;
   SmallVector<tt::DotOp> dotOps;
   SmallVector<tt::DotScaledOp> scaledDotOps;
   SmallVector<SmallVector<Operation *>> subViewOps;
@@ -786,7 +788,7 @@ LogicalResult Pingponger::transformTwoClusterWithAsyncAndAll(OpBuilder &builder,
 // between memory and compute phases.
 LogicalResult Pingponger::transformChainedDotSchedule(OpBuilder &builder,
                                                       Location loc) {
-  assert(dotOps.size() == 2);
+  assert(dotLikeOps.size() == 2);
 
   // Memory clusters start with either ttg.async_wait or ttg.local_store
   auto findNextMemoryCluster = [](Operation *op) {
@@ -796,8 +798,9 @@ LogicalResult Pingponger::transformChainedDotSchedule(OpBuilder &builder,
     return op;
   };
 
-  std::array memoryClusterStartOps = {findNextMemoryCluster(dotOps[0]),
-                                      findNextMemoryCluster(dotOps[1])};
+  std::array memoryClusterStartOps = {
+      findNextMemoryCluster(dotLikeOps[0].getOperation()),
+      findNextMemoryCluster(dotLikeOps[1].getOperation())};
 
   if (llvm::is_contained(memoryClusterStartOps, nullptr) ||
       memoryClusterStartOps[0] == memoryClusterStartOps[1]) {
@@ -808,7 +811,7 @@ LogicalResult Pingponger::transformChainedDotSchedule(OpBuilder &builder,
 
   builder.setInsertionPointToStart(forOp.getBody());
   // ComputeCluster 1
-  updateOpInsertion(dotOps[0]);
+  updateOpInsertion(dotLikeOps[0].getOperation());
   prependOp(ROCDL::SBarrierOp::create(builder, loc), false);
   prependOp(ROCDL::SchedBarrier::create(builder, loc, 0), false);
 
@@ -841,7 +844,7 @@ LogicalResult Pingponger::transformChainedDotSchedule(OpBuilder &builder,
   // s_barrier
   //
   // Check note 2 and 3 for details.
-  updateOpInsertion(dotOps[1]);
+  updateOpInsertion(dotLikeOps[1].getOperation());
   prependOp(ROCDL::SchedBarrier::create(builder, loc, 0), false);
   prependOp(ROCDL::SetPrioOp::create(builder, loc, lowPriority), false);
   prependOp(createLocalMMRAFence(builder, loc, LLVM::AtomicOrdering::release),
@@ -985,6 +988,14 @@ void Pingponger::addAsymmetricSyncToLoop(OpBuilder &builder, Location loc) {
 }
 
 void Pingponger::getDotPingponged() {
+  // LowerLoops sets this only when it materializes the two-dot layout for a
+  // pipeline configured to use pingpong. This pass is the marker's sole
+  // consumer and always removes it, even when the transform is later rejected;
+  // dot count alone cannot distinguish that layout from a single-dot schedule.
+  bool hasTwoDotSchedule =
+      forOp->hasAttr(triton::AMD::AttrTwoDotSchedule);
+  forOp->removeAttr(triton::AMD::AttrTwoDotSchedule);
+
   if (numStages <= 1) {
     LDBG("Pingpong pass expect a loop transformed by pipeliner that prefetches "
          "memory and reduces dependencies among the operations in the same "
@@ -1012,10 +1023,6 @@ void Pingponger::getDotPingponged() {
         })
         .Case<ttg::LocalStoreOp>(
             [&](auto lStore) { lStoreOps.push_back(lStore); })
-        .Case<tt::DotOp>(
-            [&](auto pingpongDot) { dotOps.push_back(pingpongDot); })
-        .Case<tt::DotScaledOp>(
-            [&](auto pingpongDot) { scaledDotOps.push_back(pingpongDot); })
         .Case<ttg::AsyncCopyGlobalToLocalOp>(
             [&](auto asyncOp) { asyncCopyOps.push_back(asyncOp); })
         .Case<ttg::AsyncCommitGroupOp>([&](auto asyncCommitGroupOp) {
@@ -1025,13 +1032,26 @@ void Pingponger::getDotPingponged() {
             [&](auto asyncOp) { asyncWaitOps.push_back(asyncOp); });
   });
 
+  // Pingpong moves dot and memory clusters within the loop body, so nested dots
+  // are not supported. Use the scheduler's direct-child collector for both the
+  // single-dot and two-dot paths instead of counting nested dots that cannot be
+  // transformed safely.
+  dotLikeOps = ChainedDotSchedule::collectDotLikeOps(forOp);
+  for (tt::DotOpInterface dotLikeOp : dotLikeOps) {
+    if (auto dotOp = dyn_cast<tt::DotOp>(dotLikeOp.getOperation()))
+      dotOps.push_back(dotOp);
+    else if (auto scaledDotOp =
+                 dyn_cast<tt::DotScaledOp>(dotLikeOp.getOperation()))
+      scaledDotOps.push_back(scaledDotOp);
+  }
+
   // Currently, pingpong scheduling is known as helpful under limited condition.
   // Individual conditions are checked while collecting each operation such as
   // software pipelining and dot rank=2. Also only accept the for-loop with
   // supported combination of operations because this transformation is very
   // tightly scheduling the latencies.
 
-  int64_t numOfDotLikeOps = scaledDotOps.size() + dotOps.size();
+  int64_t numOfDotLikeOps = dotLikeOps.size();
 
   if (numOfDotLikeOps < 1 || numOfDotLikeOps > 2) {
     LDBG("Only handle one or two dotlike ops");
@@ -1039,7 +1059,7 @@ void Pingponger::getDotPingponged() {
   }
 
   if (numOfDotLikeOps == 2) {
-    if (numStages != 4)
+    if (numStages != 4 || !hasTwoDotSchedule)
       return;
 
     if (transformChainedDotSchedule(builder, loc).failed()) {
@@ -1048,6 +1068,8 @@ void Pingponger::getDotPingponged() {
       return;
     }
     addAsymmetricSyncToLoop(builder, loc);
+    // The transforms below handle single-dot schedules only.
+    return;
   }
 
   useAsyncCopy = (asyncCopyOps.size() > 0);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -933,6 +933,12 @@ static void lowerLoop(scf::ForOp forOp,
                                                              loadToInfo))) {
     ChainedDotSchedule::updateSchedule(forOp, loadToInfo, schedule,
                                        axisInfoAnalysis, useAsyncCopy);
+    // Record the schedule that was actually materialized. BlockPingpong cannot
+    // infer it from the number of dot-like operations because the single-dot
+    // and two-dot layouts can contain the same operations.
+    if (usePingpong)
+      forOp->setAttr(triton::AMD::AttrTwoDotSchedule,
+                     UnitAttr::get(forOp.getContext()));
   } else {
     SingleDotSchedule::updateSchedule(forOp, loadToInfo, schedule,
                                       axisInfoAnalysis, useAsyncCopy,

--- a/third_party/amd/lib/TritonAMDGPUTransforms/PipelineUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/PipelineUtility.h
@@ -3,12 +3,14 @@
 
 #include "mlir/IR/Operation.h"
 #include "third_party/amd/include/Analysis/AxisInfoExt.h"
+#include "triton/Dialect/Triton/IR/OpInterfaces.h"
 #include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
 
 namespace mlir {
 
 namespace triton::AMD {
 constexpr char AttrBypassLDS[] = "amdg.bypass_lds_load";
+constexpr char AttrTwoDotSchedule[] = "amdg.two_dot_schedule";
 }
 
 // This function will
@@ -84,6 +86,11 @@ using Stages = std::array<int, SCHED_SIZE>;
 } // namespace SingleDotSchedule
 
 namespace ChainedDotSchedule {
+// The two-dot schedule only supports dot-like operations directly in the loop
+// body. BlockPingpong uses the same collector so both passes agree on which
+// operations the schedule contains.
+SmallVector<triton::DotOpInterface> collectDotLikeOps(scf::ForOp forOp);
+
 // Defines the order of scheduling clusters. The suffix numbers for memory
 // operations define which dot the operations belongs to. So *_LOAD_1 loads a
 // tensor consumed by the first dot. If a memory operation is used by both dots

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
@@ -138,17 +138,8 @@ mlir::ChainedDotSchedule::checkPreconditions(scf::ForOp forOp, int numStages,
   if (numStages != 4)
     return failure();
 
-  auto dotOps = llvm::to_vector(forOp.getBody()->getOps<tt::DotOp>());
-
-  if (dotOps.size() != 2)
+  if (collectDotLikeOps(forOp).size() != 2)
     return failure();
-
-  // Check that the first dot feeds into the second
-  SetVector<Operation *> slice;
-  getForwardSlice(dotOps[0]->getResult(0), &slice);
-  if (!slice.contains(dotOps[1])) {
-    return failure();
-  }
 
   // Reject loops with indirect loads
   // TODO support indirect loads
@@ -158,6 +149,16 @@ mlir::ChainedDotSchedule::checkPreconditions(scf::ForOp forOp, int numStages,
   }
 
   return success();
+}
+
+SmallVector<tt::DotOpInterface>
+mlir::ChainedDotSchedule::collectDotLikeOps(scf::ForOp forOp) {
+  SmallVector<tt::DotOpInterface> dotOps;
+  for (Operation &op : forOp.getBody()->without_terminator()) {
+    if (auto dotOp = dyn_cast<tt::DotOpInterface>(op))
+      dotOps.push_back(dotOp);
+  }
+  return dotOps;
 }
 
 namespace {
@@ -417,27 +418,30 @@ buildSchedule(scf::ForOp &forOp, int numStages, const LoadToInfoMap &loadToInfo,
 
 // Builds a schedule for loops containing chained dots. This schedule aims to
 // better interleave mma with alu ops which can be co-executed on GFX9. It
-// works for loops which have 2 dots where the result of the first is
-// transformed and used by the second dot. The dot ops will be scheduled with a
-// distance of one and the ops in between will be spit into 2 parts. The first
-// part will be scheduled to the same stage as the fist dot so it can interleave
-// with the second dot. Whereas the second part will be scheduled to the stage
-// of the second dot so it can be interleaved with the first dot. Loads will be
-// double buffered and placed in between the dot/compute clusters. This
-// pipeliner is meant to be used in combination with pingpong
+// works for loops which have 2 independent or chained dot-like operations. For
+// chained dots, the result of the first is transformed and used by the second.
+// For independent dots, scheduleOpsBetweenDots has no work; the schedule still
+// places the dots one stage apart and double-buffers their respective loads for
+// pingpong.
+// The dot ops will be scheduled with a distance of one and the ops in between
+// will be split into 2 parts. The first part will be scheduled to the same stage
+// as the first dot so it can interleave with the second dot. The second part
+// will be scheduled to the stage of the second dot so it can be interleaved
+// with the first dot. Loads will be double buffered and placed in between the
+// dot/compute clusters. This pipeliner is meant to be used with pingpong.
 namespace ChainedDotSchedule {
 using namespace mlir::ChainedDotSchedule;
 // We schedule loads one stage in front of their dots
 LogicalResult
-scheduleLoads(std::array<tt::DotOp, 2> dotOps,
+scheduleLoads(std::array<tt::DotOpInterface, 2> dotOps,
               const llvm::MapVector<Operation *, LoadInfo> &loadToInfo,
               const ChainedDotClusters &clusters,
               tt::CoarseSchedule &schedule) {
   for (auto [loadOp, info] : loadToInfo) {
-    if (info.use == dotOps[0]) {
+    if (info.use == dotOps[0].getOperation()) {
       schedule.insert(loadOp, STAGE_GLOBAL_LOAD_1,
                       clusters[CLUSTER_GLOBAL_LOAD_1]);
-    } else if (info.use == dotOps[1]) {
+    } else if (info.use == dotOps[1].getOperation()) {
       schedule.insert(loadOp, STAGE_GLOBAL_LOAD_2,
                       clusters[CLUSTER_GLOBAL_LOAD_2]);
     } else {
@@ -448,11 +452,11 @@ scheduleLoads(std::array<tt::DotOp, 2> dotOps,
 }
 
 LogicalResult scheduleOpsBetweenDots(scf::ForOp forOp,
-                                     std::array<tt::DotOp, 2> dotOps,
+                                     std::array<tt::DotOpInterface, 2> dotOps,
                                      tt::CoarseSchedule &schedule,
                                      const ChainedDotClusters &clusters) {
   SetVector<Operation *> dot0Slice;
-  getForwardSlice(Value(dotOps[0]), &dot0Slice);
+  getForwardSlice(dotOps[0]->getResult(0), &dot0Slice);
 
   // For each operand of the second dot coming from the first dot we want to
   // split the ops in between into 2 parts.
@@ -522,12 +526,14 @@ buildSchedule(scf::ForOp &forOp, int numStages, const LoadToInfoMap &loadToInfo,
                 [&]() { return schedule.clusters.newAtBack(); });
 
   // Schedule dots
-  auto dotOpsVec = llvm::to_vector(forOp.getBody()->getOps<tt::DotOp>());
+  auto dotOpsVec = collectDotLikeOps(forOp);
   assert(dotOpsVec.size() == 2); // Ensure precondition
-  std::array<tt::DotOp, 2> dotOps = {dotOpsVec[0], dotOpsVec[1]};
+  std::array<tt::DotOpInterface, 2> dotOps = {dotOpsVec[0], dotOpsVec[1]};
 
-  schedule.insert(dotOps[0], STAGE_DOT_1, clusters[CLUSTER_DOT_1]);
-  schedule.insert(dotOps[1], STAGE_DOT_2, clusters[CLUSTER_DOT_2]);
+  schedule.insert(dotOps[0].getOperation(), STAGE_DOT_1,
+                  clusters[CLUSTER_DOT_1]);
+  schedule.insert(dotOps[1].getOperation(), STAGE_DOT_2,
+                  clusters[CLUSTER_DOT_2]);
 
   if (failed(scheduleLoads(dotOps, loadToInfo, clusters, schedule)))
     return {};


### PR DESCRIPTION
Summary:

The gfx950 AOT build for the FP8 SwiGLU grouped GEMM crashed in TritonAMDGPUBlockPingpong for a num_warps=8, num_stages=4 specialization containing two independent tt.dot_scaled operations.

ScheduleLoops collected only top-level tt.dot operations while BlockPingpong counted both tt.dot and tt.dot_scaled recursively. ScheduleLoops therefore built the single-dot layout, but BlockPingpong inferred a two-dot layout from the count and indexed an empty regular-dot vector.

Use one top-level DotOpInterface collector for both passes and allow the existing two-dot schedule to handle independent or chained dot-like pairs. This keeps the scaled SwiGLU GEMMs ping-ponged instead of fixing the crash by disabling the optimization.

LowerLoops marks a loop only when it materializes the two-dot layout for a pipeline configured to use pingpong. BlockPingpong consumes that marker instead of inferring the layout from an operation count. Placing the marker at lowering ties it to the actual final schedule decision and avoids emitting it when pingpong is disabled.

Regression coverage preserves the original direct chained-dot case, verifies that independent scaled dots receive the two-dot schedule and BlockPingpong barriers, verifies that the same loop is not transformed when pingpong was not requested, and keeps the empty-memory-cluster rejection paths active.

Reviewed By: njriasan, robieta

Differential Revision: D114664201


