### PR TITLE
[triton][bitequiv] cuBLAS-equivalent Triton GEMM driven by the cuBLASLt heuristic (static + runtime match) (#2752)

### DIFF
--- a/bitequiv/cublas_equiv_gemm.py
+++ b/bitequiv/cublas_equiv_gemm.py
@@ -1,0 +1,612 @@
+"""Bit-for-bit cuBLAS-equivalent Triton GEMM, driven by the cuBLASLt heuristic.
+
+Top-level API (a cuBLAS-like matmul):
+
+    from bitequiv.cublas_equiv_gemm import cublas_equivalent_gemm, cublas_equivalent_scaled_mm
+    c = cublas_equivalent_gemm(a_fp16, b_fp16)               # == cuBLAS fp16/bf16 GEMM, bit-for-bit
+    c = cublas_equivalent_scaled_mm(a_fp8, b_fp8_col, sa, sb) # == cuBLAS fp8 GEMM, bit-for-bit
+
+How it works
+------------
+For a shape (M, N, K, dtype) we ask cuBLAS's OWN heuristic what it would do, then
+rebuild that exact computation in Triton:
+
+  1. Query `cublasLtMatmulAlgoGetHeuristic` (ctypes) -> the top algo's split count
+     `SPLITK_NUM` (config attr 2).  This is faithful to what cuBLAS runs.
+  2. `SPLITK_NUM == 1`  -> plain GEMM (one FP32 accumulator over K).
+     `SPLITK_NUM  > 1`  -> split-K: cut K into k-slices, one FP32 partial each,
+     combine the partials in FORWARD order in FP32, cast to the output dtype.
+  3. The k-slice granularity `G` is fixed per dtype/kernel family (measured on
+     GB300 / sm_100, reference = cuBLAS run directly, no torch):
+       - fp16 / bf16 (nvjet)                     -> G = 64
+       - fp8 (nvjet 2-CTA or horizontal)         -> G = 128
+       - fp8 (nvjet vertical)                    -> G = 64
+     `chunk = ceil(ceil(K/G)/nsplit)*G`; slices are uneven, the LAST is smaller.
+  4. VERIFY-THEN-USE (sound by construction): before trusting any reconstruction
+     we byte-compare it against cuBLAS run directly (`cublasLtMatmul` with the
+     heuristic's own algo) on 3 order-sensitive seeds.  The first candidate recipe
+     that matches all 3 is cached per shape; if none match, the shape is
+     `CublasUnsupportedShape` -- we never silently return a non-matching result.
+     Cached shapes are then PURE Triton (no cuBLAS call).
+
+Known unsupported (raise `CublasUnsupportedShape`): fp16 non-aligned CUTLASS
+`s1688` (K=8 MMA -- Triton's `tl.dot` is K=16) and odd-K tails; fp8 vertical
+split-K where cuBLAS reduces K across the cluster CTAs (a distributed FP32 order a
+tile-level two-pass split-K cannot emit, e.g. some N=192 shapes).
+
+Depends on `torch`, `triton`, `ctypes` (stdlib), and the CUDA `libcublasLt` shared
+library (always present with a CUDA runtime).  GB300 / sm_100.
+"""
+from __future__ import annotations
+
+import ctypes
+import glob
+
+import torch
+import triton
+import triton.language as tl
+
+DEVICE = "cuda"
+_WS_BYTES = 33554432  # 32 MiB scratch for the cuBLAS-direct reference execute
+_SEEDS = tuple(range(32))  # order-sensitive seeds to verify a reconstruction; more seeds reject borderline
+# (near-miss) nsplit that a wide sweep would otherwise accept on too few samples, at the cost of slower calibration.
+
+
+class CublasUnsupportedShape(Exception):
+    """No Triton reconstruction bit-matches cuBLAS for this shape, even with a runtime
+    byte-compare (e.g. fp8 vertical/cluster split-K, fp16 non-aligned s1688 K=8 / odd-K)."""
+
+
+class CublasNeedRuntimeMatch(Exception):
+    """The shape cannot be reconstructed from the heuristic STATICALLY with confidence; a
+    runtime byte-compare against cuBLAS is needed to confirm (or reject) it. Raised only in
+    static mode (`enable_runtime_match=False`). Re-call with `enable_runtime_match=True`."""
+
+
+# --------------------------------------------------------------------------- #
+# Triton kernels (scale-capable, single FP32 accumulator)
+# --------------------------------------------------------------------------- #
+@triton.jit
+def _plain_gemm(A, B, C, M, N, K, am, ak, bk, bn, cm, cn, sa, sb, BM: tl.constexpr, BN: tl.constexpr,
+                BK: tl.constexpr):
+    pid = tl.program_id(0)
+    npn = tl.cdiv(N, BN)
+    pm = pid // npn
+    pn = pid % npn
+    om = (pm * BM + tl.arange(0, BM)) % M
+    on = (pn * BN + tl.arange(0, BN)) % N
+    ok = tl.arange(0, BK)
+    ap = A + om[:, None] * am + ok[None, :] * ak
+    bp = B + ok[:, None] * bk + on[None, :] * bn
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BK)):
+        acc = tl.dot(tl.load(ap, mask=ok[None, :] < K - k * BK, other=0.0),
+                     tl.load(bp, mask=ok[:, None] < K - k * BK, other=0.0), acc)
+        ap += BK * ak
+        bp += BK * bk
+    acc = acc * sa * sb
+    ocm = pm * BM + tl.arange(0, BM)
+    ocn = pn * BN + tl.arange(0, BN)
+    tl.store(C + cm * ocm[:, None] + cn * ocn[None, :], acc.to(C.dtype.element_ty),
+             mask=(ocm[:, None] < M) & (ocn[None, :] < N))
+
+
+@triton.jit
+def _splitk_partial(A, B, W, M, N, K, am, ak, bk, bn, ws, wm, wn, CHUNK, BM: tl.constexpr, BN: tl.constexpr,
+                    BK: tl.constexpr):
+    """Pass 1: slice `sk` covers [sk*CHUNK, min((sk+1)*CHUNK, K)) -> one FP32 partial.
+    CHUNK is a runtime arg, so one compiled kernel serves any num_split / granularity."""
+    pid = tl.program_id(0)
+    sk = tl.program_id(1)
+    npn = tl.cdiv(N, BN)
+    pm = pid // npn
+    pn = pid % npn
+    om = (pm * BM + tl.arange(0, BM)) % M
+    on = (pn * BN + tl.arange(0, BN)) % N
+    k0 = sk * CHUNK
+    klen = tl.minimum(CHUNK, K - k0)
+    ok = tl.arange(0, BK)
+    ap = A + om[:, None] * am + (k0 + ok)[None, :] * ak
+    bp = B + (k0 + ok)[:, None] * bk + on[None, :] * bn
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for ki in range(0, tl.cdiv(CHUNK, BK)):
+        km = (ki * BK + ok) < klen
+        acc = tl.dot(tl.load(ap, mask=km[None, :], other=0.0), tl.load(bp, mask=km[:, None], other=0.0), acc)
+        ap += BK * ak
+        bp += BK * bk
+    ocm = pm * BM + tl.arange(0, BM)
+    ocn = pn * BN + tl.arange(0, BN)
+    tl.store(W + sk * ws + ocm[:, None] * wm + ocn[None, :] * wn, acc, mask=(ocm[:, None] < M) & (ocn[None, :] < N))
+
+
+@triton.jit
+def _splitk_combine(W, C, M, N, ws, wm, wn, cm, cn, S, sa, sb, BM: tl.constexpr, BN: tl.constexpr):
+    """Pass 2: sum the S FP32 partials in FORWARD order (slice 0..S-1), scale, cast."""
+    pid = tl.program_id(0)
+    npn = tl.cdiv(N, BN)
+    pm = pid // npn
+    pn = pid % npn
+    om = pm * BM + tl.arange(0, BM)
+    on = pn * BN + tl.arange(0, BN)
+    m2 = (om[:, None] < M) & (on[None, :] < N)
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for i in range(0, S):
+        acc += tl.load(W + i * ws + om[:, None] * wm + on[None, :] * wn, mask=m2, other=0.0)
+    acc = acc * sa * sb
+    tl.store(C + cm * om[:, None] + cn * on[None, :], acc.to(C.dtype.element_ty), mask=m2)
+
+
+def _tile(M: int, N: int) -> tuple[int, int]:
+    """Partial tile (bit-neutral): small tiles for small M,N, capped at 128."""
+    BM = 16 if M <= 16 else 32 if M <= 32 else 64 if M <= 64 else 128
+    BN = 16 if N <= 16 else 32 if N <= 32 else 64 if N <= 64 else 128
+    return BM, BN
+
+
+def _kcontig(b):
+    return b if b.stride(1) == 1 else b.contiguous()
+
+
+def _triton_plain(a, b, out_dtype, sa=1.0, sb=1.0, BM=128, BN=128, BK=64):
+    b = _kcontig(b)
+    M, K = a.shape
+    N = b.shape[1]
+    c = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
+    grid = (triton.cdiv(M, BM) * triton.cdiv(N, BN), )
+    _plain_gemm[grid](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0), c.stride(1),
+                      sa, sb, BM=BM, BN=BN, BK=BK, num_warps=8)
+    return c
+
+
+def _triton_splitk(a, b, chunk, out_dtype, sa=1.0, sb=1.0, BK=64):
+    """Deterministic two-pass split-K at `chunk`-element early slices (uneven tail),
+    forward FP32 combine. Returns None if the chunk does not yield a real split (nsplit<2)."""
+    b = _kcontig(b)
+    M, K = a.shape
+    N = b.shape[1]
+    nsplit = (K + chunk - 1) // chunk
+    if nsplit < 2 or nsplit > 8192:
+        return None
+    BM, BN = _tile(M, N)
+    ntile = triton.cdiv(M, BM) * triton.cdiv(N, BN)
+    w = torch.empty(nsplit, M, N, device=DEVICE, dtype=torch.float32)
+    _splitk_partial[(ntile, nsplit)](a, b, w, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), w.stride(0),
+                                     w.stride(1), w.stride(2), chunk, BM=BM, BN=BN, BK=BK, num_warps=4)
+    c = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
+    _splitk_combine[(ntile, )](w, c, M, N, w.stride(0), w.stride(1), w.stride(2), c.stride(0), c.stride(1), nsplit, sa,
+                               sb, BM=BM, BN=BN, num_warps=4)
+    return c
+
+
+# --------------------------------------------------------------------------- #
+# cuBLASLt via ctypes: heuristic query + run the chosen algo directly (reference)
+# --------------------------------------------------------------------------- #
+_CUDA_R_16F, _CUDA_R_32F, _CUDA_R_16BF, _CUDA_R_8F_E4M3 = 2, 0, 14, 28
+_CUBLAS_COMPUTE_32F = 68
+_OP_N, _OP_T = 0, 1
+_DESC_TRANSA, _DESC_TRANSB = 3, 4
+_DESC_A_SCALE_PTR, _DESC_B_SCALE_PTR = 17, 18
+_PREF_MAX_WS = 1
+_LAYOUT_ORDER, _ORDER_ROW = 1, 1
+_CFG_ID, _CFG_SPLITK = 0, 2
+_LT = None
+_ONES = None  # device fp32 [1.0] for fp8 scale pointers
+_WS = None    # device scratch for the reference execute
+
+
+class _HeurResult(ctypes.Structure):
+    _fields_ = [("algo", ctypes.c_char * 64), ("workspaceSize", ctypes.c_size_t), ("state", ctypes.c_int),
+                ("wavesCount", ctypes.c_float), ("reserved", ctypes.c_int * 4)]
+
+
+def _load_lt():
+    global _LT, _ONES, _WS
+    if _LT is not None:
+        return _LT
+    cands = (["/usr/local/cuda-13.0/lib64/libcublasLt.so.13"] + glob.glob("/usr/local/cuda*/lib64/libcublasLt.so*") +
+             glob.glob("/usr/local/cuda*/targets/*/lib/libcublasLt.so*") + ["libcublasLt.so.13", "libcublasLt.so"])
+    lib = None
+    for c in cands:
+        try:
+            lib = ctypes.CDLL(c)
+            break
+        except OSError:
+            continue
+    if lib is None:
+        raise OSError("libcublasLt not found")
+    P, PP = ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)
+    ci, cu64, ci64, csz = ctypes.c_int, ctypes.c_uint64, ctypes.c_int64, ctypes.c_size_t
+    lib.cublasLtCreate.argtypes = [PP]
+    lib.cublasLtDestroy.argtypes = [P]
+    lib.cublasLtMatmulDescCreate.argtypes = [PP, ci, ci]
+    lib.cublasLtMatmulDescDestroy.argtypes = [P]
+    lib.cublasLtMatmulDescSetAttribute.argtypes = [P, ci, P, csz]
+    lib.cublasLtMatrixLayoutCreate.argtypes = [PP, ci, cu64, cu64, ci64]
+    lib.cublasLtMatrixLayoutDestroy.argtypes = [P]
+    lib.cublasLtMatrixLayoutSetAttribute.argtypes = [P, ci, P, csz]
+    lib.cublasLtMatmulPreferenceCreate.argtypes = [PP]
+    lib.cublasLtMatmulPreferenceDestroy.argtypes = [P]
+    lib.cublasLtMatmulPreferenceSetAttribute.argtypes = [P, ci, P, csz]
+    lib.cublasLtMatmulAlgoGetHeuristic.argtypes = [P, P, P, P, P, P, P, ci, P, ctypes.POINTER(ci)]
+    lib.cublasLtMatmulAlgoConfigGetAttribute.argtypes = [P, ci, P, csz, ctypes.POINTER(csz)]
+    lib.cublasLtMatmul.restype = ci
+    lib.cublasLtMatmul.argtypes = [P] * 14 + [csz, P]  # 14 ptrs, workspaceSize, stream
+    _ONES = torch.ones(1, dtype=torch.float32, device=DEVICE)
+    _WS = torch.empty(_WS_BYTES, dtype=torch.uint8, device=DEVICE)
+    _LT = lib
+    return lib
+
+
+def _ck(nm, rc):
+    if rc != 0:
+        raise RuntimeError(f"cublasLt {nm} failed (status {rc})")
+
+
+def _cfg(algo_ptr, attr):
+    lib = _load_lt()
+    o = ctypes.c_int(-1)
+    w = ctypes.c_size_t(0)
+    r = lib.cublasLtMatmulAlgoConfigGetAttribute(algo_ptr, attr, ctypes.byref(o), 4, ctypes.byref(w))
+    return o.value if r == 0 else None
+
+
+def _lt_dtypes(kind, out_dtype):
+    """(ab_dt, cd_dt, transa, transb) for the cuBLASLt layouts, per input dtype."""
+    cd = _CUDA_R_16BF if out_dtype == torch.bfloat16 else _CUDA_R_16F
+    if kind == "fp8":
+        return _CUDA_R_8F_E4M3, cd, _OP_T, _OP_N  # e4m3 TN
+    ab = _CUDA_R_16BF if kind == "bf16" else _CUDA_R_16F
+    return ab, cd, _OP_N, _OP_N
+
+
+def _set_row(lib, layout):
+    v = ctypes.c_int(_ORDER_ROW)
+    _ck("layout-order", lib.cublasLtMatrixLayoutSetAttribute(layout, _LAYOUT_ORDER, ctypes.byref(v), 4))
+
+
+def _make_layouts(lib, desc, M, N, K, kind, out_dtype):
+    """Row-major layouts matching a standard torch GEMM dispatch; set transa/transb
+    (+ fp8 scale pointers). Returns (A, B, C, D) layout handles."""
+    ab, cd, transa, transb = _lt_dtypes(kind, out_dtype)
+    ta, tb = ctypes.c_int(transa), ctypes.c_int(transb)
+    _ck("transa", lib.cublasLtMatmulDescSetAttribute(desc, _DESC_TRANSA, ctypes.byref(ta), 4))
+    _ck("transb", lib.cublasLtMatmulDescSetAttribute(desc, _DESC_TRANSB, ctypes.byref(tb), 4))
+    A, B, C, D = (ctypes.c_void_p() for _ in range(4))
+    if kind != "fp8":
+        _ck("LA", lib.cublasLtMatrixLayoutCreate(ctypes.byref(A), ab, M, K, K))
+        _set_row(lib, A)
+        _ck("LB", lib.cublasLtMatrixLayoutCreate(ctypes.byref(B), ab, K, N, N))
+        _set_row(lib, B)
+    else:  # fp8 e4m3 TN: operands K-contiguous (col-major), output row-major
+        _ck("LA", lib.cublasLtMatrixLayoutCreate(ctypes.byref(A), ab, K, M, K))
+        _ck("LB", lib.cublasLtMatrixLayoutCreate(ctypes.byref(B), ab, K, N, K))
+        sp = ctypes.c_void_p(_ONES.data_ptr())
+        _ck("Ascale", lib.cublasLtMatmulDescSetAttribute(desc, _DESC_A_SCALE_PTR, ctypes.byref(sp), 8))
+        _ck("Bscale", lib.cublasLtMatmulDescSetAttribute(desc, _DESC_B_SCALE_PTR, ctypes.byref(sp), 8))
+    _ck("LC", lib.cublasLtMatrixLayoutCreate(ctypes.byref(C), cd, M, N, N))
+    _set_row(lib, C)
+    _ck("LD", lib.cublasLtMatrixLayoutCreate(ctypes.byref(D), cd, M, N, N))
+    _set_row(lib, D)
+    return A, B, C, D
+
+
+def _cublas_direct(a, b, kind, out_dtype, execute=True):
+    """Query cuBLAS's top-heuristic algo and (if execute) run it DIRECTLY via ctypes
+    cublasLtMatmul. Returns (D, nsplit): with execute, D is cuBLAS's exact output; without,
+    D is None and only the heuristic's SPLITK_NUM is read (pure-static, no GEMM run). No torch."""
+    lib = _load_lt()
+    M, K = a.shape
+    N = b.shape[1]
+    handle, desc, pref = ctypes.c_void_p(), ctypes.c_void_p(), ctypes.c_void_p()
+    A = B = C = D = None
+    try:
+        _ck("create", lib.cublasLtCreate(ctypes.byref(handle)))
+        _ck("desc", lib.cublasLtMatmulDescCreate(ctypes.byref(desc), _CUBLAS_COMPUTE_32F, _CUDA_R_32F))
+        A, B, C, D = _make_layouts(lib, desc, M, N, K, kind, out_dtype)
+        _ck("pref", lib.cublasLtMatmulPreferenceCreate(ctypes.byref(pref)))
+        ws = ctypes.c_size_t(_WS_BYTES)
+        _ck("pref-set", lib.cublasLtMatmulPreferenceSetAttribute(pref, _PREF_MAX_WS, ctypes.byref(ws), 8))
+        results = (_HeurResult * 16)()
+        ret = ctypes.c_int(0)
+        rc = lib.cublasLtMatmulAlgoGetHeuristic(handle, desc, A, B, C, D, pref, 16,
+                                                ctypes.cast(results, ctypes.c_void_p), ctypes.byref(ret))
+        if rc != 0 or ret.value == 0:
+            raise CublasUnsupportedShape(f"no cuBLAS algo for {M}x{N}x{K} {kind} (rc={rc}, ret={ret.value})")
+        algo_ptr = ctypes.cast(ctypes.byref(results[0]), ctypes.c_void_p)
+        nsplit = _cfg(algo_ptr, _CFG_SPLITK)
+        nsplit = nsplit if isinstance(nsplit, int) and nsplit >= 1 else 1
+        if not execute:
+            return None, nsplit
+        out = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
+        alpha, beta = ctypes.c_float(1.0), ctypes.c_float(0.0)
+        stream = ctypes.c_void_p(torch.cuda.current_stream().cuda_stream)
+        rc = lib.cublasLtMatmul(handle, desc, ctypes.cast(ctypes.pointer(alpha), ctypes.c_void_p),
+                                ctypes.c_void_p(a.data_ptr()), A, ctypes.c_void_p(b.data_ptr()), B,
+                                ctypes.cast(ctypes.pointer(beta), ctypes.c_void_p), ctypes.c_void_p(out.data_ptr()), C,
+                                ctypes.c_void_p(out.data_ptr()), D, algo_ptr,
+                                ctypes.c_void_p(_WS.data_ptr()), ctypes.c_size_t(_WS_BYTES), stream)
+        _ck("matmul", rc)
+        torch.cuda.synchronize()
+        return out, (nsplit if isinstance(nsplit, int) and nsplit >= 1 else 1)
+    finally:
+        for h, d in [(pref, lib.cublasLtMatmulPreferenceDestroy), (D, lib.cublasLtMatrixLayoutDestroy),
+                     (C, lib.cublasLtMatrixLayoutDestroy), (B, lib.cublasLtMatrixLayoutDestroy),
+                     (A, lib.cublasLtMatrixLayoutDestroy), (desc, lib.cublasLtMatmulDescDestroy),
+                     (handle, lib.cublasLtDestroy)]:
+            try:
+                if h is not None and h.value:
+                    d(h)
+            except Exception:
+                pass
+
+
+def cublas_matmul(a, b, out_dtype=None):
+    """cuBLAS's OWN output (run directly via cublasLtMatmul), the reference our
+    reconstruction must match. fp16/bf16: `b` is [K,N]. fp8: `b` is [K,N] column-major."""
+    kind = _kind_of(a)
+    out_dtype = out_dtype or (torch.float16 if kind == "fp8" else a.dtype)
+    return _cublas_direct(a, b, kind, out_dtype)[0]
+
+
+# --------------------------------------------------------------------------- #
+# Reconstruction planning (verify-then-use) + per-shape cache
+# --------------------------------------------------------------------------- #
+# (M,N,K,kind,out_dtype) -> (origin, plan): origin "static"|"runtime"|"unsupported"; plan
+# ("plain",None) | ("split",chunk) | None. Decided once; a "runtime" plan is withheld in static mode.
+_PLAN: dict[tuple, tuple] = {}
+
+
+def _kind_of(a) -> str:
+    if a.dtype == torch.float8_e4m3fn:
+        return "fp8"
+    if a.dtype == torch.bfloat16:
+        return "bf16"
+    return "fp16"
+
+
+def _chunk_from_ns(K, ns, G):
+    total = (K + G - 1) // G
+    return ((total + ns - 1) // ns) * G
+
+
+def _grain(kind):
+    """k-slice granularity for the split-K partition: fp16/bf16 = 64, fp8 = 128
+    (measured; fp8 G=128 at the heuristic nsplit dominates G=64 for every kernel family,
+    including 2-CTA/horizontal/vertical -- the earlier "vertical->64" was a 3-seed artifact)."""
+    return 128 if kind == "fp8" else 64
+
+
+def _static_chunk(K, nsplit, kind):
+    """The k-slice partition the cuBLAS heuristic implies: G-grain, uneven, remainder last."""
+    return _chunk_from_ns(K, nsplit, _grain(kind))
+
+
+_CALIB_MAX_NS = 256  # bounded split count for the wide runtime sweep
+
+
+def _splitk_candidate_chunks(K, nsplit, kind):
+    """Candidate partitions for the runtime-match path, in try-order: the heuristic nsplit
+    +/-1 first (the common case resolves fast), then a WIDE canonical sweep over nsplit
+    2..cap at the grain(s) -- the heuristic's split count can be off by more than 1, so the
+    narrow window alone falsely rejects reconstructable shapes. Grains: fp16/bf16 = 64; fp8 =
+    128 then 64. Deduped by chunk."""
+    grains = (64, ) if kind != "fp8" else (128, 64)
+    chunks, seen = [], set()
+
+    def add(ns, G):
+        if ns < 2:
+            return
+        chunk = _chunk_from_ns(K, ns, G)
+        if G <= chunk < K and chunk not in seen:
+            seen.add(chunk)
+            chunks.append(chunk)
+
+    for ns in (nsplit, nsplit - 1, nsplit + 1):  # near the heuristic first
+        add(ns, _grain(kind))
+    for G in grains:                             # then the wide sweep
+        cap = min((K + G - 1) // G, _CALIB_MAX_NS)
+        for ns in range(2, cap + 1):
+            add(ns, G)
+    return chunks
+
+
+def _make_inputs(M, N, K, kind, seed):
+    """Order-sensitive inputs (magnitude spread + alternating sign along K) so the K
+    reduction order shows up in the output bits. Magnitudes are kept in range so the
+    output stays finite -- for fp8 the values must fit e4m3 (max 448)."""
+    torch.manual_seed(seed)
+    sign = torch.where(torch.arange(K, device=DEVICE) % 2 == 0, 1.0, -1.0).unsqueeze(0)
+    if kind == "fp8":
+        scale = torch.logspace(-1, 1, K, device=DEVICE, dtype=torch.float32).unsqueeze(0)  # 0.1..10, fp8-safe
+        a = (torch.randn(M, K, device=DEVICE) * scale * sign).to(torch.float8_e4m3fn)
+        b = (torch.randn(N, K, device=DEVICE) * 0.25).to(torch.float8_e4m3fn).t()  # [K,N] col-major
+        return a, b
+    dt = torch.bfloat16 if kind == "bf16" else torch.float16
+    scale = torch.logspace(-3, 3, K, device=DEVICE, dtype=torch.float32).unsqueeze(0)
+    a = (torch.randn(M, K, device=DEVICE) * scale * sign).to(dt)
+    b = (torch.randn(K, N, device=DEVICE) * 0.05).to(dt)
+    return a, b
+
+
+def _bits_eq(x, y):
+    return torch.equal(x.contiguous().view(torch.uint8), y.contiguous().view(torch.uint8))
+
+
+def _aligned(M, N, K, kind):
+    """Contiguous-dim alignment cuBLAS needs to stay on its reconstructable nvjet path.
+    fp16/bf16: K%8==0 and N%8==0 (M free). fp8: all dims %16."""
+    if kind == "fp8":
+        return M % 16 == 0 and N % 16 == 0 and K % 16 == 0
+    return K % 8 == 0 and N % 8 == 0
+
+
+def _is_static_exact(kind, nsplit, aligned, M, N):
+    """Can we reconstruct from the heuristic ALONE (no runtime byte-compare) and be sure it
+    is bit-exact? Measured on GB300/sm_100:
+      - fp16/bf16 aligned: yes (plain and split-K at G=64@heur both match);
+      - fp8 large-output plain (ceil(M/64)*ceil(N/64) >= 64, nsplit==1): yes;
+      - fp8 skinny (small output): NO -- even at SPLITK_NUM==1 cuBLAS may use a cluster kernel
+        that reduces K across CTAs, which a single-accumulator/two-pass Triton kernel cannot
+        bit-match; and fp8 split-K vertical is not reproducible -> defer to a runtime match;
+      - fp16/bf16 non-aligned: NO (CUTLASS; K=16 variants reconstruct, s1688/odd-K do not)."""
+    if not aligned:
+        return False
+    if kind in ("fp16", "bf16"):
+        return True
+    tiles = ((M + 63) // 64) * ((N + 63) // 64)
+    return nsplit <= 1 and tiles >= 64  # fp8: only the large-output plain subset is static-safe
+
+
+def _reconstruct(a, b, out_dtype, plan, sa=1.0, sb=1.0):
+    mode, chunk = plan
+    if mode == "plain":
+        return _triton_plain(a, b, out_dtype, sa=sa, sb=sb)
+    return _triton_splitk(a, b, chunk, out_dtype, sa=sa, sb=sb)
+
+
+def _calibrate(M, N, K, kind, out_dtype):
+    """RUNTIME match: find the reconstruction that bit-matches cuBLAS run directly, verified
+    on _SEEDS order-sensitive seeds. Returns ("plain",None) or ("split",chunk); raises
+    CublasUnsupportedShape if nothing matches. cuBLAS's choice is a function of the shape
+    (not the data), so one calibration serves all future inputs of that shape."""
+    refs, nsplit = [], 1
+    for i, s in enumerate(_SEEDS):
+        a, b = _make_inputs(M, N, K, kind, s)
+        d, ns = _cublas_direct(a, b, kind, out_dtype)
+        refs.append((a, b, d))
+        if i == 0:
+            nsplit = ns
+
+    if nsplit <= 1:  # cuBLAS runs a plain GEMM
+        if all(_bits_eq(_triton_plain(a, b, out_dtype), d) for a, b, d in refs):
+            return ("plain", None)
+        raise CublasUnsupportedShape(f"{M}x{N}x{K} {kind}: plain reconstruction does not match cuBLAS")
+
+    a0, b0, d0 = refs[0]
+    for chunk in _splitk_candidate_chunks(K, nsplit, kind):  # cuBLAS runs split-K
+        c0 = _triton_splitk(a0, b0, chunk, out_dtype)
+        if c0 is None or not _bits_eq(c0, d0):
+            continue  # seed-0 prefilter: keeps the wide nsplit sweep cheap
+        if all(_bits_eq(_triton_splitk(a, b, chunk, out_dtype), d) for a, b, d in refs[1:]):
+            return ("split", chunk)
+    raise CublasUnsupportedShape(f"{M}x{N}x{K} {kind}: no split-K recipe matches cuBLAS (nsplit={nsplit})")
+
+
+def _resolve(a, b, kind, out_dtype, enable_runtime_match):
+    """Reconstruction plan for this shape (cached). Static-exact shapes are planned from the
+    heuristic alone (no GEMM run). Others need a runtime byte-compare: with
+    enable_runtime_match they are calibrated against cuBLAS; without, raise
+    CublasNeedRuntimeMatch."""
+    M, K = a.shape
+    N = b.shape[1]
+    key = (M, N, K, kind, out_dtype)
+    if key in _PLAN:
+        origin, plan = _PLAN[key]  # origin: "static" | "runtime" | "unsupported"
+        if origin == "unsupported":
+            raise CublasUnsupportedShape(f"{M}x{N}x{K} {kind}: unsupported (cached)")
+        if origin == "runtime" and not enable_runtime_match:
+            raise CublasNeedRuntimeMatch(f"{M}x{N}x{K} {kind}: needs a runtime match (cached)")
+        return plan
+
+    nsplit = _cublas_direct(a, b, kind, out_dtype, execute=False)[1]  # static: heuristic only, no GEMM run
+    if _is_static_exact(kind, nsplit, _aligned(M, N, K, kind), M, N):
+        plan = ("plain", None) if nsplit <= 1 else ("split", _static_chunk(K, nsplit, kind))
+        _PLAN[key] = ("static", plan)
+        return plan
+
+    if not enable_runtime_match:
+        raise CublasNeedRuntimeMatch(f"{M}x{N}x{K} {kind}: not statically guaranteed; "
+                                     f"re-call with enable_runtime_match=True")  # not cached: unknown until runtime
+    try:
+        plan = _calibrate(M, N, K, kind, out_dtype)
+    except CublasUnsupportedShape:
+        _PLAN[key] = ("unsupported", None)  # even a runtime match found nothing; cache the negative
+        raise
+    _PLAN[key] = ("runtime", plan)
+    return plan
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+def cublas_equivalent_gemm(a: torch.Tensor, b: torch.Tensor, out_dtype: torch.dtype | None = None,
+                           enable_runtime_match: bool = False) -> torch.Tensor:
+    """fp16/bf16 GEMM, bit-identical to cuBLAS. `a` is [M,K], `b` is [K,N].
+
+    Static by default: the reconstruction is planned from the cuBLAS heuristic alone (no GEMM
+    run). Aligned fp16/bf16 is static-exact. A shape that is not statically guaranteed
+    (non-aligned) raises CublasNeedRuntimeMatch -- unless `enable_runtime_match=True`, which
+    byte-compares candidates against cuBLAS and returns the match or raises
+    CublasUnsupportedShape."""
+    kind = _kind_of(a)
+    if kind == "fp8":
+        raise ValueError("use cublas_equivalent_scaled_mm for fp8")
+    out_dtype = out_dtype or a.dtype
+    plan = _resolve(a, b, kind, out_dtype, enable_runtime_match)
+    return _reconstruct(a, b, out_dtype, plan)
+
+
+def cublas_equivalent_scaled_mm(a: torch.Tensor, b: torch.Tensor, scale_a: float = 1.0, scale_b: float = 1.0,
+                                out_dtype: torch.dtype = torch.float16,
+                                enable_runtime_match: bool = False) -> torch.Tensor:
+    """fp8 (e4m3) GEMM, bit-identical to cuBLAS. `a` is [M,K], `b` is [K,N] column-major
+    (i.e. from `w.t()`); scales are scalars.
+
+    fp8 plain is static-exact. fp8 split-K is NOT statically guaranteed (the vertical/cluster
+    kernel is not bit-reproducible) -> raises CublasNeedRuntimeMatch unless
+    `enable_runtime_match=True`, which byte-compares against cuBLAS and returns the match or
+    raises CublasUnsupportedShape (vertical split-K)."""
+    plan = _resolve(a, b, "fp8", out_dtype, enable_runtime_match)
+    return _reconstruct(a, b, out_dtype, plan, sa=scale_a, sb=scale_b)
+
+
+# --------------------------------------------------------------------------- #
+# Self-check
+# --------------------------------------------------------------------------- #
+def _check_one(kind, M, N, K):
+    """Classify + verify one shape: try static first; if it needs a runtime match, retry with
+    enable_runtime_match=True. Returns (class, bit_ok) where class is static/runtime/unsupported."""
+    a, b = _make_inputs(M, N, K, kind, 7)
+    ref = cublas_matmul(a, b, torch.float16 if kind == "fp8" else None)
+    call = (lambda rt: cublas_equivalent_scaled_mm(a, b, 1.0, 1.0, torch.float16, enable_runtime_match=rt)) \
+        if kind == "fp8" else (lambda rt: cublas_equivalent_gemm(a, b, enable_runtime_match=rt))
+    try:
+        return "static", _bits_eq(call(False), ref)
+    except CublasNeedRuntimeMatch:
+        pass
+    try:
+        return "runtime", _bits_eq(call(True), ref)
+    except CublasUnsupportedShape:
+        return "unsupported", None
+
+
+def verify():
+    if not torch.cuda.is_available():
+        print("no CUDA GPU; verify() needs one.")
+        return
+    print(f"device: {torch.cuda.get_device_name()} | cap {torch.cuda.get_device_capability()} | "
+          f"cuda {torch.version.cuda}")
+    print("class = static (heuristic only) / runtime (byte-compare) / unsupported; then vs cuBLAS-direct\n")
+
+    shapes = [("fp16", 4096, 4096, 4096), ("fp16", 2048, 2048, 512), ("fp16", 16, 16384, 16384),
+              ("fp16", 64, 64, 32768), ("fp16", 128, 128, 16384), ("fp8", 4096, 4096, 4096),
+              ("fp8", 8192, 8192, 8192), ("fp8", 64, 64, 65536), ("fp8", 128, 128, 65536), ("fp8", 16, 64, 131072)]
+    n_ok = n_static = n_runtime = n_unsup = 0
+    for (kind, M, N, K) in shapes:
+        cls, ok = _check_one(kind, M, N, K)
+        n_static += int(cls == "static")
+        n_runtime += int(cls == "runtime")
+        if cls == "unsupported":
+            n_unsup += 1
+            verdict = "UNSUPPORTED"
+        else:
+            n_ok += int(bool(ok))
+            verdict = "BIT-IDENTICAL" if ok else "DIFFER"
+        print(f"  {kind:4s} {M:5d}x{N:5d}x{K:6d}  {cls:11s}  {verdict}")
+
+    print(f"\nbit-identical {n_ok}/{n_static + n_runtime} | static {n_static} | runtime {n_runtime} | "
+          f"unsupported {n_unsup}")
+
+
+if __name__ == "__main__":
+    verify()

--- a/bitequiv/eval_cublas_equiv_gemm.py
+++ b/bitequiv/eval_cublas_equiv_gemm.py
@@ -1,0 +1,233 @@
+"""Fuzz evaluation: is the cuBLAS-equivalent Triton GEMM really bit-identical to cuBLAS?
+
+A timeout-bounded infinite loop. Each round:
+  1. draw a random matmul shape (M, N, K) + dtype;
+  2. draw R random input tensors for it;
+  3. feed each input to BOTH our API and cuBLAS run directly, and check the two
+     outputs are byte-for-byte equal.
+
+Every mismatch (our API returned a result that is NOT bit-identical to cuBLAS -- a
+soundness bug) is written to a temp file for debugging. A shape the API declines
+(`CublasUnsupportedShape`) is counted separately: that is an honest "no
+reconstruction", NOT a mismatch. The bit-consistency rate is reported periodically.
+
+IMPORTANT: the fuzz inputs use seeds disjoint from the ones the API calibrates on,
+so this tests inputs the reconstruction was NOT tuned for.
+
+Run:
+  python -m bitequiv.eval_cublas_equiv_gemm --timeout 300
+  python -m bitequiv.eval_cublas_equiv_gemm --timeout 3600 --dtypes fp16,fp8 --R 5
+"""
+import argparse
+import json
+import os
+import random
+import time
+
+import torch
+
+from bitequiv.cublas_equiv_gemm import (
+    CublasNeedRuntimeMatch,
+    CublasUnsupportedShape,
+    cublas_equivalent_gemm,
+    cublas_equivalent_scaled_mm,
+    cublas_matmul,
+)
+
+DEVICE = "cuda"
+_F8 = torch.float8_e4m3fn
+
+
+def _bits_eq(x, y):
+    return torch.equal(x.contiguous().view(torch.uint8), y.contiguous().view(torch.uint8))
+
+
+def _round_to(x, m):
+    return max(m, (x // m) * m)
+
+
+def random_shape(rng, dtypes):
+    """A random, aligned matmul shape + dtype. Mixes plain (square/rect) and split-K
+    (skinny + deep) regimes, plus an occasional non-aligned fp16 to exercise the decline
+    path. fp16/bf16 need K%8==0 & N%8==0; fp8 needs all dims %16."""
+    dtype = rng.choice(dtypes)
+    regime = rng.choices(["splitk", "plain", "nonaligned"], weights=[0.6, 0.35, 0.05], k=1)[0]
+
+    if regime == "splitk":  # skinny + deep -> cuBLAS tends to split K
+        small = rng.choice([16, 24, 32, 48, 64, 80, 96, 112, 128])
+        other = rng.choice([16, 32, 48, 64, 96, 128, 192, 256])
+        M, N = (small, other) if rng.random() < 0.5 else (other, small)
+        K = rng.choice([8192, 12288, 16384, 24576, 32768, 49152, 65536, 98304, 131072])
+    elif regime == "plain":  # larger output -> cuBLAS runs plain
+        M = rng.choice([256, 512, 768, 1024, 2048, 4096])
+        N = rng.choice([256, 512, 768, 1024, 2048, 4096])
+        K = rng.choice([256, 512, 1024, 2048, 4096, 8192])
+    else:  # deliberately non-aligned fp16 (odd N or K) -> cuBLAS uses CUTLASS; API should decline
+        dtype = "fp16"
+        M = rng.choice([16, 64, 512])
+        N = rng.choice([65, 129, 257, 513])
+        K = rng.choice([4096, 4097, 8192, 8195])
+
+    if dtype == "fp8":
+        M, N, K = _round_to(M, 16), _round_to(N, 16), _round_to(K, 16)
+    elif regime != "nonaligned":
+        N, K = _round_to(N, 8), _round_to(K, 8)
+    return M, N, K, dtype
+
+
+def make_inputs(M, N, K, dtype, seed, mode):
+    """Random inputs. `order` mode = magnitude spread + alternating sign along K (stresses
+    the K reduction order -- the hardest test for a split-K reconstruction); `plain` mode =
+    ordinary small-scale gaussians. Magnitudes stay in range so the output is finite (fp8
+    values must fit e4m3, max 448). fp8 returns b as [K,N] column-major."""
+    torch.manual_seed(seed)
+    sign = torch.where(torch.arange(K, device=DEVICE) % 2 == 0, 1.0, -1.0).unsqueeze(0)
+    if mode == "order":
+        lo, hi = (-1, 1) if dtype == "fp8" else (-3, 3)  # fp8: 0.1..10 (no overflow)
+        scale = torch.logspace(lo, hi, K, device=DEVICE, dtype=torch.float32).unsqueeze(0)
+        af = torch.randn(M, K, device=DEVICE) * scale * sign
+        if dtype == "fp8":
+            bf = torch.randn(N, K, device=DEVICE) * 0.25
+        else:
+            bf = torch.randn(K, N, device=DEVICE) * 0.05
+    else:
+        af = torch.randn(M, K, device=DEVICE) * 0.3
+        bf = (torch.randn(N, K, device=DEVICE) if dtype == "fp8" else torch.randn(K, N, device=DEVICE)) * 0.3
+
+    if dtype == "fp8":
+        return af.to(_F8), bf.to(_F8).t()  # b -> [K,N] column-major
+    dt = torch.bfloat16 if dtype == "bf16" else torch.float16
+    return af.to(dt), bf.to(dt)
+
+
+def our_api(a, b, dtype, out_dtype, enable_rt):
+    if dtype == "fp8":
+        return cublas_equivalent_scaled_mm(a, b, 1.0, 1.0, out_dtype, enable_runtime_match=enable_rt)
+    return cublas_equivalent_gemm(a, b, out_dtype, enable_runtime_match=enable_rt)
+
+
+def run(timeout, report_every, R, dtypes, seed, enable_rt):
+    rng = random.Random(seed)
+    mm_path = f"/tmp/cublas_equiv_mismatches_{os.getpid()}.jsonl"
+    mm_file = open(mm_path, "w")
+
+    st = {"shapes": 0, "cmp": 0, "match": 0, "mismatch": 0, "no_ref": 0, "nonfinite": 0, "error": 0}
+    # distinct shapes by class: static (heuristic only) / runtime (byte-compare) / need-rt (skipped in
+    # static-only mode) / unsupported (no reconstruction even with a runtime match)
+    seen_static, seen_runtime, seen_needrt, seen_unsup = set(), set(), set(), set()
+    t0 = time.time()
+    last = t0
+
+    print(f"device: {torch.cuda.get_device_name()} | dtypes={dtypes} R={R} timeout={timeout}s "
+          f"enable_runtime_match={enable_rt}")
+    print(f"mismatches -> {mm_path}\n", flush=True)
+
+    def report(tag):
+        el = time.time() - t0
+        scmp = st["match"] + st["mismatch"]
+        rate = (100.0 * st["match"] / scmp) if scmp else 100.0
+        classified = len(seen_static) + len(seen_runtime) + len(seen_needrt) + len(seen_unsup)
+        sfrac = (100.0 * len(seen_static) / classified) if classified else 0.0
+        print(f"[{tag} {el:6.0f}s] shapes={st['shapes']} cmp={st['cmp']} "
+              f"bit-consistent={rate:6.2f}% ({st['match']}/{scmp}) mismatch={st['mismatch']} | "
+              f"static={len(seen_static)} runtime={len(seen_runtime)} needRT={len(seen_needrt)} "
+              f"unsup={len(seen_unsup)} static-frac={sfrac:5.1f}% | "
+              f"no_ref={st['no_ref']} nonfinite={st['nonfinite']} err={st['error']}", flush=True)
+
+    while time.time() - t0 < timeout:
+        M, N, K, dtype = random_shape(rng, dtypes)
+        key = (M, N, K, dtype)
+        out_dtype = torch.float16 if dtype == "fp8" else (torch.bfloat16 if dtype == "bf16" else torch.float16)
+        st["shapes"] += 1
+        use_rt = None  # per-shape mode, decided on the first comparable input
+        for r in range(R):
+            s = 100003 + st["shapes"] * 131 + r  # disjoint from the API's calibration seeds
+            imode = "order" if (r % 2 == 0) else "plain"
+            try:
+                a, b = make_inputs(M, N, K, dtype, s, imode)
+            except Exception:
+                st["error"] += 1
+                break
+            try:
+                ref = cublas_matmul(a, b, out_dtype)
+            except (CublasUnsupportedShape, Exception):
+                st["no_ref"] += 1  # cuBLAS itself has no algo (e.g. unrunnable shape)
+                break
+            if not torch.isfinite(ref.float()).all():
+                st["nonfinite"] += 1  # overflow -> byte-compare is meaningless, skip this input
+                continue
+            try:
+                if use_rt is None:  # classify the shape: static, else need-runtime
+                    try:
+                        out = our_api(a, b, dtype, out_dtype, False)
+                        use_rt = False
+                        seen_static.add(key)
+                    except CublasNeedRuntimeMatch:
+                        if not enable_rt:
+                            seen_needrt.add(key)
+                            break  # static-only mode: count it, do not compare
+                        out = our_api(a, b, dtype, out_dtype, True)
+                        use_rt = True
+                        seen_runtime.add(key)
+                else:
+                    out = our_api(a, b, dtype, out_dtype, use_rt)
+            except CublasUnsupportedShape:
+                seen_unsup.add(key)
+                break
+            except Exception as e:
+                st["error"] += 1
+                mm_file.write(json.dumps({"M": M, "N": N, "K": K, "dtype": dtype, "seed": s, "mode": imode,
+                                          "error": f"{type(e).__name__}: {str(e)[:120]}"}) + "\n")
+                mm_file.flush()
+                break
+            st["cmp"] += 1
+            if _bits_eq(out, ref):
+                st["match"] += 1
+            else:
+                st["mismatch"] += 1
+                diff = (out.float() - ref.float()).abs()
+                mm_file.write(json.dumps({
+                    "M": M, "N": N, "K": K, "dtype": dtype, "seed": s, "mode": imode,
+                    "class": "runtime" if use_rt else "static", "max_abs_diff": float(diff.max()),
+                    "n_diff": int((diff > 0).sum()), "out_dtype": str(out_dtype)}) + "\n")
+                mm_file.flush()
+        if time.time() - last >= report_every:
+            report("run")
+            last = time.time()
+
+    mm_file.close()
+    print()
+    report("DONE")
+    classified = len(seen_static) + len(seen_runtime) + len(seen_needrt) + len(seen_unsup)
+    sfrac = (100.0 * len(seen_static) / classified) if classified else 0.0
+    scmp = st["match"] + st["mismatch"]
+    print(f"\nstatic-reconstructable (cuBLAS heuristic alone, no GEMM run): {len(seen_static)}/{classified} = "
+          f"{sfrac:.1f}% of shapes")
+    print(f"  runtime-match: {len(seen_runtime)} | need-runtime(skipped): {len(seen_needrt)} | "
+          f"unsupported: {len(seen_unsup)}")
+    print(f"bit-consistent (static + runtime): {st['match']}/{scmp} = "
+          f"{(100.0 * st['match'] / scmp) if scmp else 100.0:.3f}%")
+    if st["mismatch"]:
+        print(f"{st['mismatch']} mismatches ({{static, runtime}} that were not bit-identical) -> {mm_path}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--timeout", type=float, default=300, help="run this many seconds, then stop")
+    ap.add_argument("--report-every", type=float, default=15, help="print the running rate every N seconds")
+    ap.add_argument("--R", type=int, default=5, help="random input tensors per shape")
+    ap.add_argument("--dtypes", type=str, default="fp16,fp8", help="comma list: fp16,fp8,bf16")
+    ap.add_argument("--seed", type=int, default=0, help="shape RNG seed (reproducible)")
+    ap.add_argument("--enable-runtime-match", action="store_true",
+                    help="also byte-compare the need-runtime shapes (default: static only -> they are "
+                         "counted as need-runtime and skipped)")
+    args = ap.parse_args()
+    if not torch.cuda.is_available():
+        print("no CUDA GPU; this eval needs one.")
+        return
+    dtypes = [d.strip() for d in args.dtypes.split(",") if d.strip()]
+    run(args.timeout, args.report_every, args.R, dtypes, args.seed, args.enable_runtime_match)
+
+
+if __name__ == "__main__":
+    main()

--- a/bitequiv/example_cublas_equiv_gemm.py
+++ b/bitequiv/example_cublas_equiv_gemm.py
@@ -1,0 +1,142 @@
+"""Example: how to use the cuBLAS-equivalent Triton GEMM API.
+
+Run:  python -m bitequiv.example_cublas_equiv_gemm
+
+Shows the fp16 and fp8 entry points, that the result is bit-identical to cuBLAS,
+and how to handle a shape that has no Triton reconstruction.
+
+`enable_runtime_match` is written explicitly at every call below. The default is
+`False` (static: reconstruct from the cuBLAS heuristic alone, no GEMM run); pass
+`True` to allow a one-time runtime byte-compare against cuBLAS for shapes that are
+not statically guaranteed.
+"""
+import torch
+
+from bitequiv.cublas_equiv_gemm import (
+    CublasNeedRuntimeMatch,
+    CublasUnsupportedShape,
+    cublas_equivalent_gemm,
+    cublas_equivalent_scaled_mm,
+    cublas_matmul,
+)
+
+DEVICE = "cuda"
+
+
+def _bit_equal(x, y):
+    return torch.equal(x.contiguous().view(torch.uint8), y.contiguous().view(torch.uint8))
+
+
+def example_fp16_plain():
+    """fp16 GEMM on a large shape -> cuBLAS runs a plain kernel; our Triton GEMM matches."""
+    M, N, K = 4096, 4096, 4096
+    a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
+    b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
+
+    out = cublas_equivalent_gemm(a, b, enable_runtime_match=False)  # static (default): heuristic only, no GEMM run
+    ref = cublas_matmul(a, b)                                       # cuBLAS's own output (the reference)
+    print(f"fp16 plain    {M}x{N}x{K}: bit-identical to cuBLAS = {_bit_equal(out, ref)}")
+
+
+def example_fp16_split_k():
+    """fp16 GEMM on a skinny+deep shape -> cuBLAS runs split-K; our Triton split-K matches.
+    The split count comes from the cuBLAS heuristic; the reconstruction is verified once
+    and cached, so calling it again for the same shape is pure Triton."""
+    M, N, K = 64, 64, 32768
+    a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
+    b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
+
+    out = cublas_equivalent_gemm(a, b, enable_runtime_match=False)  # static (default): aligned fp16 split-K is exact
+    ref = cublas_matmul(a, b)
+    print(f"fp16 split-K  {M}x{N}x{K}: bit-identical to cuBLAS = {_bit_equal(out, ref)}")
+
+
+def example_fp8_plain():
+    """fp8 (e4m3) GEMM, plain shape. `b` is [K,N] column-major (as produced by a weight
+    `w.t()`); scales are scalars, output defaults to fp16. fp8 plain is static-exact."""
+    M, N, K = 8192, 8192, 8192
+    a = (torch.randn(M, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn)
+    b = (torch.randn(N, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn).t()   # [K,N] column-major
+
+    out = cublas_equivalent_scaled_mm(a, b, scale_a=1.0, scale_b=1.0, out_dtype=torch.float16,
+                                      enable_runtime_match=False)  # static (default): large-output fp8 plain is exact
+    ref = cublas_matmul(a, b, out_dtype=torch.float16)
+    print(f"fp8  plain    {M}x{N}x{K}: bit-identical to cuBLAS = {_bit_equal(out, ref)}")
+
+
+def example_fp8_split_k_runtime():
+    """fp8 split-K is NOT statically guaranteed (the vertical/cluster kernel is not
+    bit-reproducible). By default the API returns need-runtime-match; pass
+    enable_runtime_match=True to let it byte-compare against cuBLAS and reconstruct (or raise
+    CublasUnsupportedShape for the vertical family)."""
+    M, N, K = 64, 64, 65536
+    a = (torch.randn(M, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn)
+    b = (torch.randn(N, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn).t()
+
+    try:                                          # static mode (default): heuristic only, no cuBLAS GEMM run
+        cublas_equivalent_scaled_mm(a, b, enable_runtime_match=False)
+        print(f"fp8  split-K  {M}x{N}x{K}: statically reconstructed")
+    except CublasNeedRuntimeMatch:
+        print(f"fp8  split-K  {M}x{N}x{K}: needs a runtime match (static mode declined)")
+
+    try:                                          # runtime mode: allow a one-time byte-compare against cuBLAS
+        out = cublas_equivalent_scaled_mm(a, b, enable_runtime_match=True)
+        print(f"fp8  split-K  {M}x{N}x{K}: with enable_runtime_match=True -> "
+              f"bit-identical = {_bit_equal(out, cublas_matmul(a, b))}")
+    except CublasUnsupportedShape:
+        out = cublas_matmul(a, b)                 # vertical split-K: fall back to cuBLAS
+        print(f"fp8  split-K  {M}x{N}x{K}: UNSUPPORTED -> fell back to cuBLAS")
+
+
+def example_cannot_match():
+    """Shapes where the cuBLAS heuristic's algo has NO bit-identical Triton reconstruction,
+    even with enable_runtime_match=True -> CublasUnsupportedShape (never a wrong result).
+
+    Two families cover essentially all of them:
+      1. fp16 non-aligned (odd N or odd K): cuBLAS switches to a CUTLASS kernel that either
+         uses an MMA with K=8 (`s1688`) or an odd-K reduction tail. Triton's `tl.dot` emits
+         K=16, so the base MMA groups/rounds the products differently -- unreproducible.
+      2. fp8 vertical / cluster split-K: cuBLAS reduces K across the cluster's CTAs in a
+         multi-level fp32 order; a tile-level two-pass split-K in Triton cannot emit that
+         order (differs by ~1 fp16 ulp in a few elements)."""
+    fp16_bad = [(64, 64, 257), (16, 65, 8192), (64, 129, 8192), (512, 513, 4096), (64, 64, 4097),
+                (128, 127, 16384), (33, 33, 15000)]
+    fp8_bad = [(16, 64, 65536), (16, 128, 65536), (32, 256, 65536), (32, 256, 131072), (32, 32, 16384)]
+
+    print("cannot-match (heuristic gives an algo, but no Triton reconstruction is bit-identical):")
+    print("  -- fp16 non-aligned -> CUTLASS s1688 (MMA K=8) / odd-K tail --")
+    for (M, N, K) in fp16_bad:
+        a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
+        b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
+        try:
+            cublas_equivalent_gemm(a, b, enable_runtime_match=True)
+            print(f"  fp16 {M}x{N}x{K}: reconstructed (unexpected)")
+        except CublasUnsupportedShape:
+            print(f"  fp16 {M}x{N}x{K}: UNSUPPORTED -> caller falls back to cuBLAS")
+
+    print("  -- fp8 vertical / cluster split-K -> cross-CTA K reduction --")
+    for (M, N, K) in fp8_bad:
+        a = (torch.randn(M, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn)
+        b = (torch.randn(N, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn).t()
+        try:
+            cublas_equivalent_scaled_mm(a, b, enable_runtime_match=True)
+            print(f"  fp8  {M}x{N}x{K}: reconstructed (unexpected)")
+        except CublasUnsupportedShape:
+            print(f"  fp8  {M}x{N}x{K}: UNSUPPORTED -> caller falls back to cuBLAS")
+
+
+def main():
+    if not torch.cuda.is_available():
+        print("no CUDA GPU; this example needs one.")
+        return
+    print(f"device: {torch.cuda.get_device_name()}\n")
+    example_fp16_plain()
+    example_fp16_split_k()
+    example_fp8_plain()
+    example_fp8_split_k_runtime()
+    print()
+    example_cannot_match()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:

A Triton GEMM whose output is bit-identical to cuBLAS, driven by the cuBLASLt heuristic. Three self-contained files under `bitequiv/` (torch + triton + ctypes only): the method, an example, and a fuzzer eval. GB300 / sm_100, fp16 + fp8 (e4m3). This replaces the earlier calibrate-against-torch approach in this diff: the reference is now cuBLAS run DIRECTLY (`cublasLtMatmul` on the algo the heuristic returns), not torch.

Method: query the cuBLASLt heuristic for (M,N,K) to get the split count s = SPLITK_NUM, then rebuild in Triton. s == 1 gives a plain GEMM (one fp32 accumulator over K; tiling is bit-neutral). s > 1 gives a deterministic two-pass split-K at grain G (64 for fp16, 128 for fp8): slice j covers k in [j*chunk, min((j+1)*chunk, K)) with chunk = ceil(ceil(K/G)/s)*G (uneven, remainder in the last slice); one fp32 partial per slice; combine the partials forward in fp32; cast to the output dtype.

Three outcomes, selected by the `enable_runtime_match` flag (default is static). static (no cuBLAS GEMM run): bit-exact from the heuristic alone for aligned fp16/bf16 and large-output fp8 plain; returned directly. runtime (opt-in): the reconstruction is byte-compared against cuBLAS on 32 order-sensitive seeds and cached; needed for fp8 2cta/horizontal split-K, where the exact chunk is not pinned by s alone; in static mode these raise CublasNeedRuntimeMatch instead of guessing. unsupported: no reconstruction matches even with a runtime byte-compare, so the API raises CublasUnsupportedShape and the caller falls back to cuBLAS. The two unsupported families are fp16 non-aligned s1688 (MMA K=8) / odd-K, and fp8 vertical/cluster split-K (K reduced across the cluster CTAs, which a tile-level two-pass cannot emit). The API never returns a result that is not bit-identical to cuBLAS.

Files: `bitequiv/cublas_equiv_gemm.py` (the method plus the `cublas_matmul` ctypes reference), `bitequiv/example_cublas_equiv_gemm.py` (usage plus a cannot-match section), `bitequiv/eval_cublas_equiv_gemm.py` (a timeout-bounded fuzzer: random shapes, R inputs each, byte-compare vs cuBLAS-direct, reports static/runtime/unsupported and bit-consistency, logs mismatches).

Results (fuzzer sample, runtime match verified on 32 order-sensitive seeds):

| dtype | sampled | static | static+runtime | unsupported | bit-consistent |
| --- | --- | --- | --- | --- | --- |
| fp16 | 1236 | 1188 (96.1%) | 1195 (96.7%) | 41 (3.3%) | 100.00% (63402/63402) |
| fp8 | 1092 | 186 (17.0%) | 970 (88.8%) | 122 (11.2%) | 99.87% (80215/80322) |

Column meanings: sampled = distinct (M,N,K) shapes tried (shapes cuBLAS will not run are excluded). static = reconstructed from the cuBLAS heuristic ALONE, no cuBLAS GEMM run. static+runtime = reconstructed either statically OR via a one-time runtime byte-compare against cuBLAS, then cached. unsupported = NO bit-identical Triton reconstruction even with the runtime byte-compare, so the API declines (raises) rather than return a wrong result. bit-consistent = of the reconstructed (static+runtime) shapes, the fraction byte-identical to cuBLAS over ALL fuzz inputs (counted per shape x input); unsupported shapes are not in this denominator. fp8 static is low because the fuzzer over-draws skinny fp8 (fp8 is static only for large-output plain); static-only mode is 100% bit-consistent by construction.

Authored with Claude Code.

Reviewed By: njriasan

Differential Revision: D114086739


