### PR TITLE
[triton][bitequiv] cuBLAS-equivalent GEMM: reconstruct arbitrary shapes (fp16 17.8% -> 100% on unrestricted random M,N,K; 98.8% in the skinny+deep corner) (#2753)

### DIFF
--- a/bitequiv/cublas_equiv_gemm.py
+++ b/bitequiv/cublas_equiv_gemm.py
@@ -16,31 +16,45 @@ rebuild that exact computation in Triton:
   2. `SPLITK_NUM == 1`  -> plain GEMM (one FP32 accumulator over K).
      `SPLITK_NUM  > 1`  -> split-K: cut K into k-slices, one FP32 partial each,
      combine the partials in FORWARD order in FP32, cast to the output dtype.
-  3. The k-slice granularity `G` is fixed per dtype/kernel family (measured on
-     GB300 / sm_100, reference = cuBLAS run directly, no torch):
-       - fp16 / bf16 (nvjet)                     -> G = 64
-       - fp8 (nvjet 2-CTA or horizontal)         -> G = 128
-       - fp8 (nvjet vertical)                    -> G = 64
-     `chunk = ceil(ceil(K/G)/nsplit)*G`; slices are uneven, the LAST is smaller.
-  4. VERIFY-THEN-USE (sound by construction): before trusting any reconstruction
-     we byte-compare it against cuBLAS run directly (`cublasLtMatmul` with the
-     heuristic's own algo) on 3 order-sensitive seeds.  The first candidate recipe
-     that matches all 3 is cached per shape; if none match, the shape is
-     `CublasUnsupportedShape` -- we never silently return a non-matching result.
-     Cached shapes are then PURE Triton (no cuBLAS call).
+  3. The partition is fully determined by `SPLITK_NUM`: at grain `G` (64 for
+     fp16/bf16, 128 for fp8), `chunk = ceil(ceil(K/G)/SPLITK_NUM)*G`, slices uneven
+     with the remainder in the LAST one.  Verified against cuBLAS-direct over
+     131,533 fp8 split-K shapes with 0 counterexamples; a wide sweep of thousands of
+     alternative partitions per shape never found a different chunk that works.
+  4. HOW THE RECIPE IS DECIDED -- three tiers, tried in order (see `_resolve`):
 
-Known unsupported (raise `CublasUnsupportedShape`): fp16 non-aligned CUTLASS
-`s1688` (K=8 MMA -- Triton's `tl.dot` is K=16) and odd-K tails; fp8 vertical
-split-K where cuBLAS reduces K across the cluster CTAs (a distributed FP32 order a
-tile-level two-pass split-K cannot emit, e.g. some N=192 shapes).
+       static         the heuristic alone settles it and nothing is executed.  Only the
+                      PLAIN branch qualifies, for both dtypes.
+       pseudo-static  one profiled cuBLAS launch; the remaining knobs are READ off the
+                      launched kernel name (threadblock k-tile, MMA shape) and off
+                      `REDUCTION_SCHEME` (which of the three split-K merge schemes).
+                      Costs ~2 ms for the profile against ~0.1 ms for the GEMM, but it
+                      observes what cuBLAS did instead of inferring it, so it cannot pick
+                      a recipe that merely happens to agree on the seeds it was tested
+                      against.  It also proves nothing: no bytes are compared here.
+       runtime        search the candidate recipes and keep the one that byte-matches
+                      cuBLAS on 32 selection seeds plus 8 hold-out seeds.  Proves the
+                      match on those inputs; but picking the best of ~36 candidates is a
+                      selection, so a recipe that fits by luck can still slip through.
+
+     `enable_pseudo_static` (default on) and `enable_runtime_match` gate the last two.
+     A shape no tier can serve raises `CublasUnsupportedShape` (or, in static-only mode,
+     `CublasNeedRuntimeMatch`) -- the search path never returns an unverified guess.
+
+Known unsupported (raise `CublasUnsupportedShape`): cuBLAS's SIMT `gemv` fallbacks for
+very thin M or N, which are not CUTLASS at all; plus a thin split-K residual that
+appears when K is not a whole number of k-tiles, so the last slice is a partial one and
+cuBLAS handles that leftover in a way the two-pass split-K cannot match at any
+partition.  fp8 needs `BM >= 64` (see `_tile`) or it silently uses a different MMA.
 
 Depends on `torch`, `triton`, `ctypes` (stdlib), and the CUDA `libcublasLt` shared
-library (always present with a CUDA runtime).  GB300 / sm_100.
+library (always present with a CUDA runtime).  Measured on GB200 / sm_100.
 """
 from __future__ import annotations
 
 import ctypes
 import glob
+import re
 
 import torch
 import triton
@@ -48,8 +62,9 @@ import triton.language as tl
 
 DEVICE = "cuda"
 _WS_BYTES = 33554432  # 32 MiB scratch for the cuBLAS-direct reference execute
-_SEEDS = tuple(range(32))  # order-sensitive seeds to verify a reconstruction; more seeds reject borderline
-# (near-miss) nsplit that a wide sweep would otherwise accept on too few samples, at the cost of slower calibration.
+_SEEDS = tuple(range(32))  # seeds used to SELECT a reconstruction among the candidates
+_CONFIRM_SEEDS = tuple(range(1000, 1008))  # held out: only the winner is checked here, so a candidate that
+# fits the selection seeds by luck is caught rather than shipped. See `_calibrate`.
 
 
 class CublasUnsupportedShape(Exception):
@@ -73,9 +88,11 @@ def _plain_gemm(A, B, C, M, N, K, am, ak, bk, bn, cm, cn, sa, sb, BM: tl.constex
     npn = tl.cdiv(N, BN)
     pm = pid // npn
     pn = pid % npn
-    om = (pm * BM + tl.arange(0, BM)) % M
-    on = (pn * BN + tl.arange(0, BN)) % N
-    ok = tl.arange(0, BK)
+    # int64 indices: an operand with more than 2^31 elements (e.g. M=8192, K=300000) overflows
+    # 32-bit address arithmetic and faults. Every kernel here does the same cast.
+    om = ((pm * BM + tl.arange(0, BM)) % M).to(tl.int64)
+    on = ((pn * BN + tl.arange(0, BN)) % N).to(tl.int64)
+    ok = tl.arange(0, BK).to(tl.int64)
     ap = A + om[:, None] * am + ok[None, :] * ak
     bp = B + ok[:, None] * bk + on[None, :] * bn
     acc = tl.zeros((BM, BN), dtype=tl.float32)
@@ -85,8 +102,58 @@ def _plain_gemm(A, B, C, M, N, K, am, ak, bk, bn, cm, cn, sa, sb, BM: tl.constex
         ap += BK * ak
         bp += BK * bk
     acc = acc * sa * sb
-    ocm = pm * BM + tl.arange(0, BM)
-    ocn = pn * BN + tl.arange(0, BN)
+    ocm = (pm * BM + tl.arange(0, BM)).to(tl.int64)
+    ocn = (pn * BN + tl.arange(0, BN)).to(tl.int64)
+    tl.store(C + cm * ocm[:, None] + cn * ocn[None, :], acc.to(C.dtype.element_ty),
+             mask=(ocm[:, None] < M) & (ocn[None, :] < N))
+
+
+@triton.jit
+def _plain_gemm_k_per_dot(A, B, C, M, N, K, am, ak, bk, bn, cm, cn, sa, sb, KPD, RES, BM: tl.constexpr,
+                          BN: tl.constexpr, BK: tl.constexpr):
+    """Plain GEMM that rounds its accumulator exactly where cuBLAS's CUTLASS kernel does.
+
+    A non-aligned shape sends cuBLAS to a CUTLASS kernel whose MMA takes 8 real k-elements
+    (`s1688`) or 16 (`s16816`, `s161616`), and which updates the fp32 accumulator once per
+    MMA. Two things are needed to match it. (a) A k16 MMA whose upper k-lanes are exactly zero
+    is bit-identical to a k8 MMA, so Triton never has to emit `m16n8k8` -- which it cannot do
+    anyway; we zero-pad the k-tile to BK with a load mask. (b) The accumulator has to round at
+    the same k boundaries, so we consume exactly KPD real k-elements per `tl.dot`.
+
+    Where the partial group sits is the subtle part. CUTLASS handles a K that is not a whole
+    number of mainloop k-tiles in its FIRST iteration, but the MMAs inside that iteration
+    still march on the tile's own grid from 0, so the partial MMA lands at index
+    `floor(RES/KPD)`, not at position 0. RES is `K % ktile` for the kernel's k-tile (32, 64 or
+    128). The accumulator therefore rounds at
+
+        0, KPD, 2*KPD, ..., floor(RES/KPD)*KPD, RES, RES+KPD, ..., K
+
+    Putting the whole leftover at position 0 instead is only equivalent when `RES < KPD`,
+    which is why that earlier version matched just a third of these shapes. KPD and RES are
+    runtime args so one compiled kernel serves every combination."""
+    pid = tl.program_id(0)
+    npn = tl.cdiv(N, BN)
+    pm = pid // npn
+    pn = pid % npn
+    om = ((pm * BM + tl.arange(0, BM)) % M).to(tl.int64)
+    on = ((pn * BN + tl.arange(0, BN)) % N).to(tl.int64)
+    ok = tl.arange(0, BK).to(tl.int64)
+    pre = RES // KPD             # whole groups that precede the partial one
+    part = RES - pre * KPD       # size of the partial group, 0 when RES is a multiple of KPD
+    has_part = tl.where(part > 0, 1, 0)
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for g in range(0, pre + has_part + (K - RES) // KPD):
+        is_pre = g < pre
+        is_part = (part > 0) & (g == pre)
+        k0 = tl.where(is_pre, g * KPD, tl.where(is_part, pre * KPD, RES + (g - pre - has_part) * KPD))
+        klen = tl.where(is_part, part, KPD)
+        real = ok < klen
+        a = tl.load(A + om[:, None] * am + (k0 + ok)[None, :] * ak, mask=real[None, :], other=0.0)
+        b = tl.load(B + (k0 + ok)[:, None] * bk + on[None, :] * bn, mask=real[:, None], other=0.0)
+        acc = tl.dot(a, b, acc)
+    acc = acc * sa * sb
+    ocm = (pm * BM + tl.arange(0, BM)).to(tl.int64)
+    ocn = (pn * BN + tl.arange(0, BN)).to(tl.int64)
     tl.store(C + cm * ocm[:, None] + cn * ocn[None, :], acc.to(C.dtype.element_ty),
              mask=(ocm[:, None] < M) & (ocn[None, :] < N))
 
@@ -101,11 +168,11 @@ def _splitk_partial(A, B, W, M, N, K, am, ak, bk, bn, ws, wm, wn, CHUNK, BM: tl.
     npn = tl.cdiv(N, BN)
     pm = pid // npn
     pn = pid % npn
-    om = (pm * BM + tl.arange(0, BM)) % M
-    on = (pn * BN + tl.arange(0, BN)) % N
+    om = ((pm * BM + tl.arange(0, BM)) % M).to(tl.int64)
+    on = ((pn * BN + tl.arange(0, BN)) % N).to(tl.int64)
     k0 = sk * CHUNK
     klen = tl.minimum(CHUNK, K - k0)
-    ok = tl.arange(0, BK)
+    ok = tl.arange(0, BK).to(tl.int64)
     ap = A + om[:, None] * am + (k0 + ok)[None, :] * ak
     bp = B + (k0 + ok)[:, None] * bk + on[None, :] * bn
     acc = tl.zeros((BM, BN), dtype=tl.float32)
@@ -114,32 +181,118 @@ def _splitk_partial(A, B, W, M, N, K, am, ak, bk, bn, ws, wm, wn, CHUNK, BM: tl.
         acc = tl.dot(tl.load(ap, mask=km[None, :], other=0.0), tl.load(bp, mask=km[:, None], other=0.0), acc)
         ap += BK * ak
         bp += BK * bk
-    ocm = pm * BM + tl.arange(0, BM)
-    ocn = pn * BN + tl.arange(0, BN)
-    tl.store(W + sk * ws + ocm[:, None] * wm + ocn[None, :] * wn, acc, mask=(ocm[:, None] < M) & (ocn[None, :] < N))
+    ocm = (pm * BM + tl.arange(0, BM)).to(tl.int64)
+    ocn = (pn * BN + tl.arange(0, BN)).to(tl.int64)
+    tl.store(W + sk.to(tl.int64) * ws + ocm[:, None] * wm + ocn[None, :] * wn, acc,
+             mask=(ocm[:, None] < M) & (ocn[None, :] < N))
 
 
 @triton.jit
 def _splitk_combine(W, C, M, N, ws, wm, wn, cm, cn, S, sa, sb, BM: tl.constexpr, BN: tl.constexpr):
-    """Pass 2: sum the S FP32 partials in FORWARD order (slice 0..S-1), scale, cast."""
+    """Pass 2: sum the S FP32 partials in FORWARD order (slice 0..S-1), scale, cast. The sum
+    starts at partial 0 rather than a zero accumulator, which matters only for signed zero:
+    `(+0.0) + (-0.0) = +0.0` would drop the sign a cuBLAS epilogue with beta=0 keeps."""
     pid = tl.program_id(0)
     npn = tl.cdiv(N, BN)
     pm = pid // npn
     pn = pid % npn
-    om = pm * BM + tl.arange(0, BM)
-    on = pn * BN + tl.arange(0, BN)
+    om = (pm * BM + tl.arange(0, BM)).to(tl.int64)
+    on = (pn * BN + tl.arange(0, BN)).to(tl.int64)
     m2 = (om[:, None] < M) & (on[None, :] < N)
     acc = tl.zeros((BM, BN), dtype=tl.float32)
     for i in range(0, S):
-        acc += tl.load(W + i * ws + om[:, None] * wm + on[None, :] * wn, mask=m2, other=0.0)
+        p = tl.load(W + i.to(tl.int64) * ws + om[:, None] * wm + on[None, :] * wn, mask=m2, other=0.0)
+        acc = tl.where(i == 0, p, acc + p)
     acc = acc * sa * sb
     tl.store(C + cm * om[:, None] + cn * on[None, :], acc.to(C.dtype.element_ty), mask=m2)
 
 
-def _tile(M: int, N: int) -> tuple[int, int]:
-    """Partial tile (bit-neutral): small tiles for small M,N, capped at 128."""
+@triton.jit
+def _splitk_partial_k_per_dot(A, B, W, M, N, K, am, ak, bk, bn, ws, wm, wn, CHUNK, KPD, KTILE, BM: tl.constexpr,
+                              BN: tl.constexpr, BK: tl.constexpr):
+    """Pass 1 for the CUTLASS split-K path: slice `sk` covers [sk*CHUNK, min((sk+1)*CHUNK, K))
+    and accumulates it in groups of KPD real k-elements, with the slice's own residue tile.
+
+    Same idea as `_plain_gemm_k_per_dot` but applied PER SLICE: a CUTLASS slice whose length is
+    not a whole number of threadblock k-tiles runs a partial first tile of `klen % KTILE`
+    elements, and the KPD-sized MMAs inside that tile start at its beginning, so the short
+    group lands at the END of the residue tile -- in the middle of the slice, not at either
+    end. Putting it first is only equivalent when the residue is under one group."""
+    pid = tl.program_id(0)
+    sk = tl.program_id(1)
+    npn = tl.cdiv(N, BN)
+    pm = pid // npn
+    pn = pid % npn
+    om = ((pm * BM + tl.arange(0, BM)) % M).to(tl.int64)
+    on = ((pn * BN + tl.arange(0, BN)) % N).to(tl.int64)
+    k0 = sk * CHUNK
+    klen = tl.minimum(CHUNK, K - k0)
+    rbk = klen % KTILE
+    rbk = tl.minimum(tl.where(rbk == 0, KTILE, rbk), klen)  # length of the leading residue tile
+    nfirst = tl.cdiv(rbk, KPD)
+    ok = tl.arange(0, BK).to(tl.int64)
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for g in range(0, nfirst + (klen - rbk) // KPD):
+        off = tl.where(g < nfirst, g * KPD, rbk + (g - nfirst) * KPD)
+        glen = tl.where(g < nfirst, tl.minimum(KPD, rbk - g * KPD), KPD)
+        real = ok < glen
+        kk = k0 + off + ok
+        a = tl.load(A + om[:, None] * am + kk[None, :] * ak, mask=real[None, :], other=0.0)
+        b = tl.load(B + kk[:, None] * bk + on[None, :] * bn, mask=real[:, None], other=0.0)
+        acc = tl.dot(a, b, acc)
+    ocm = (pm * BM + tl.arange(0, BM)).to(tl.int64)
+    ocn = (pn * BN + tl.arange(0, BN)).to(tl.int64)
+    tl.store(W + sk.to(tl.int64) * ws + ocm[:, None] * wm + ocn[None, :] * wn, acc,
+             mask=(ocm[:, None] < M) & (ocn[None, :] < N))
+
+
+@triton.jit
+def _splitk_combine_modes(W, C, M, N, ws, wm, wn, cm, cn, S, sa, sb, CMODE: tl.constexpr, BM: tl.constexpr,
+                          BN: tl.constexpr):
+    """Pass 2 with the three merge schemes cuBLAS actually uses, which `SPLITK_NUM` does not
+    distinguish -- only the launched kernel names do:
+
+      CMODE 0  fp32 workspace, forward fp32 sum                     (`splitKreduce<..., float>`)
+      CMODE 2  partials rounded to fp16, then forward fp32 sum      (`splitKreduce<..., __half>`)
+      CMODE 3  serial chain kept in fp16 between slices             (`GemmSplitKSerial`)
+
+    Measured shares of the non-aligned split-K family: CMODE 3 is 70%, CMODE 2 17%, CMODE 0 12%
+    -- so the fp32 assumption the aligned path uses is the minority case here.
+
+    The running sum starts AT partial 0 rather than at a zero accumulator. That matters only
+    for signed zero -- `(+0.0) + (-0.0) = +0.0` would destroy a `-0.0` partial, while a CUTLASS
+    epilogue with beta=0 writes the value out and keeps it -- and it never loses (169 wins, 0
+    losses over 1600 recipe pairs)."""
+    pid = tl.program_id(0)
+    npn = tl.cdiv(N, BN)
+    pm = pid // npn
+    pn = pid % npn
+    om = (pm * BM + tl.arange(0, BM)).to(tl.int64)
+    on = (pn * BN + tl.arange(0, BN)).to(tl.int64)
+    m2 = (om[:, None] < M) & (on[None, :] < N)
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for i in range(0, S):
+        p = tl.load(W + i.to(tl.int64) * ws + om[:, None] * wm + on[None, :] * wn, mask=m2, other=0.0)
+        if CMODE == 2:  # the GEMM wrote an fp16 workspace, so each partial is rounded once
+            p = p.to(tl.float16).to(tl.float32)
+        acc = tl.where(i == 0, p, acc + p)
+        if CMODE == 3:  # the running total lives in fp16 between slices
+            acc = acc.to(tl.float16).to(tl.float32)
+    acc = acc * sa * sb
+    tl.store(C + cm * om[:, None] + cn * on[None, :], acc.to(C.dtype.element_ty), mask=m2)
+
+
+def _tile(M: int, N: int, dtype=None) -> tuple[int, int]:
+    """Partial tile: small tiles for small M,N, capped at 128.
+
+    Bit-neutral EXCEPT for one hard constraint: fp8 needs BM >= 64. Below that Triton
+    cannot use the native fp8 tensor-core path -- it upcasts fp8 to f16 and emits
+    `mma.sync.m16n8k16` instead of `tcgen05.mma.kind::f8f6f4`, which rounds differently
+    from cuBLAS. (fp16/bf16 agree on both paths, so they are free to use a small tile.)"""
     BM = 16 if M <= 16 else 32 if M <= 32 else 64 if M <= 64 else 128
     BN = 16 if N <= 16 else 32 if N <= 32 else 64 if N <= 64 else 128
+    if dtype == torch.float8_e4m3fn:
+        BM = max(BM, 64)
     return BM, BN
 
 
@@ -158,6 +311,92 @@ def _triton_plain(a, b, out_dtype, sa=1.0, sb=1.0, BM=128, BN=128, BK=64):
     return c
 
 
+def _triton_plain_k_per_dot(a, b, out_dtype, k_per_dot, res, sa=1.0, sb=1.0, BM=128, BN=128, BK=16):
+    """Plain GEMM accumulating `k_per_dot` real k-elements per dot, with the partial group
+    ending at `res`, so the accumulator rounds where cuBLAS's CUTLASS kernel rounds. The tile
+    and the MMA Triton picks are bit-neutral here (measured 2000/2000 both ways), so BM, BN,
+    BK and num_warps are free."""
+    b = _kcontig(b)
+    M, K = a.shape
+    N = b.shape[1]
+    c = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
+    grid = (triton.cdiv(M, BM) * triton.cdiv(N, BN), )
+    _plain_gemm_k_per_dot[grid](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0),
+                                c.stride(1), sa, sb, k_per_dot, res, BM=BM, BN=BN, BK=BK, num_warps=8)
+    return c
+
+
+def _k_per_dot_candidates(K):
+    """`(k_per_dot, res)` pairs to try for a non-aligned shape, deduped.
+
+    `k_per_dot` is 8 for a `s1688` kernel and 16 for `s16816` / `s161616`; `res = K % ktile`
+    for the kernel's mainloop k-tile, which cuBLAS picks for performance and is 32, 64 or 128.
+    Neither is derivable from the shape -- both are visible only in the launched kernel name,
+    and parity gets `k_per_dot` wrong for the WMMA kernels -- so try all six. Measured over
+    1,806 non-aligned single-pass fp16 shapes at 32 seeds: exactly one of the six byte-matches
+    every shape, with no exceptions, taking that family from 33.4% to 100%."""
+    out, seen = [], set()
+    for k_per_dot in (16, 8):
+        for ktile in (32, 64, 128):
+            cand = (k_per_dot, K % ktile)
+            if cand not in seen:
+                seen.add(cand)
+                out.append(cand)
+    return out
+
+
+def _triton_splitk_groups(a, b, chunk, k_per_dot, ktile, cmode, out_dtype, sa=1.0, sb=1.0, BK=16):
+    """Two-pass split-K for the CUTLASS path: `chunk`-element slices, each accumulated in
+    groups of `k_per_dot` real k with a per-slice residue tile of `ktile`, merged by `cmode`."""
+    b = _kcontig(b)
+    M, K = a.shape
+    N = b.shape[1]
+    nsplit = (K + chunk - 1) // chunk
+    if nsplit < 1 or nsplit > 8192:
+        return None
+    BM, BN = _tile(M, N, a.dtype)
+    ntile = triton.cdiv(M, BM) * triton.cdiv(N, BN)
+    w = torch.empty(nsplit, M, N, device=DEVICE, dtype=torch.float32)
+    _splitk_partial_k_per_dot[(ntile, nsplit)](a, b, w, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1),
+                                               w.stride(0), w.stride(1), w.stride(2), chunk, k_per_dot, ktile, BM=BM,
+                                               BN=BN, BK=BK, num_warps=4)
+    c = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
+    _splitk_combine_modes[(ntile, )](w, c, M, N, w.stride(0), w.stride(1), w.stride(2), c.stride(0), c.stride(1),
+                                     nsplit, sa, sb, CMODE=cmode, BM=BM, BN=BN, num_warps=4)
+    return c
+
+
+def _splitk_group_candidates(K, nsplit):
+    """`(chunk, k_per_dot, ktile, cmode)` recipes to try for a non-aligned split-K shape.
+
+    The partition grain is CUTLASS's `kAlignK` (8 = 128 bits / 16, not the 64 the nvjet path
+    uses, though a small tail needs 64), the k per dot follows the MMA (`s1688` -> 8,
+    `s16816`/`s161616` -> 16), the merge scheme is one of three, and the threadblock k-tile is a
+    cuBLAS performance choice. Ordered by measured frequency so the seed-0 prefilter usually
+    stops on the first few. Measured over 520 shapes: 100% reconstructed, median calibration
+    0.1 s per shape.
+
+    Two of these are in fact readable from the heuristic and this search does not yet use them:
+    `REDUCTION_SCHEME` (attr 3) gives the merge scheme exactly (`COMPUTE_TYPE` -> fp32 forward,
+    `OUTPUT_TYPE` -> fp16 partials, `NONE` -> serial fp16; 119 shapes, no mixing), and
+    `(ALGO_ID, CUSTOM_OPTION, STAGES_ID)` gives the CUTLASS subtype and hence the k per dot.
+    Using them would cut the list from 36 candidates to 3. The k-tile is the one knob no
+    heuristic field pins -- config groups identical in every readable field still differ in it --
+    so a byte-compare is still needed, which is why these shapes are `runtime`, not `static`."""
+    chunks = []
+    for g in (8, 64):
+        chunk = _chunk_from_ns(K, nsplit, g)
+        if g <= chunk <= K and chunk not in chunks:
+            chunks.append(chunk)
+    out = []
+    for cmode in (3, 2, 0):        # serial-fp16 70%, fp16-partials 17%, fp32-forward 12%
+        for k_per_dot in (8, 16):  # 8 is 80%
+            for ktile in (32, 64, 128):  # 32 is 86%
+                for chunk in chunks:
+                    out.append((chunk, k_per_dot, ktile, cmode))
+    return out
+
+
 def _triton_splitk(a, b, chunk, out_dtype, sa=1.0, sb=1.0, BK=64):
     """Deterministic two-pass split-K at `chunk`-element early slices (uneven tail),
     forward FP32 combine. Returns None if the chunk does not yield a real split (nsplit<2)."""
@@ -167,7 +406,7 @@ def _triton_splitk(a, b, chunk, out_dtype, sa=1.0, sb=1.0, BK=64):
     nsplit = (K + chunk - 1) // chunk
     if nsplit < 2 or nsplit > 8192:
         return None
-    BM, BN = _tile(M, N)
+    BM, BN = _tile(M, N, a.dtype)
     ntile = triton.cdiv(M, BM) * triton.cdiv(N, BN)
     w = torch.empty(nsplit, M, N, device=DEVICE, dtype=torch.float32)
     _splitk_partial[(ntile, nsplit)](a, b, w, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), w.stride(0),
@@ -188,7 +427,10 @@ _DESC_TRANSA, _DESC_TRANSB = 3, 4
 _DESC_A_SCALE_PTR, _DESC_B_SCALE_PTR = 17, 18
 _PREF_MAX_WS = 1
 _LAYOUT_ORDER, _ORDER_ROW = 1, 1
-_CFG_ID, _CFG_SPLITK = 0, 2
+_CFG_ID, _CFG_SPLITK, _CFG_REDUCTION = 0, 2, 3
+# CUBLASLT_REDUCTION_SCHEME -> which split-K merge scheme the kernel uses. Measured against the
+# scheme that actually byte-matches: 119 non-aligned split-K shapes, no mixing.
+_REDUCTION_TO_CMODE = {0: 3, 2: 0, 4: 2}  # NONE -> serial fp16, COMPUTE_TYPE -> fp32, OUTPUT_TYPE -> fp16 partials
 _LT = None
 _ONES = None  # device fp32 [1.0] for fp8 scale pointers
 _WS = None    # device scratch for the reference execute
@@ -315,8 +557,9 @@ def _cublas_direct(a, b, kind, out_dtype, execute=True):
         algo_ptr = ctypes.cast(ctypes.byref(results[0]), ctypes.c_void_p)
         nsplit = _cfg(algo_ptr, _CFG_SPLITK)
         nsplit = nsplit if isinstance(nsplit, int) and nsplit >= 1 else 1
+        reduction = _cfg(algo_ptr, _CFG_REDUCTION)
         if not execute:
-            return None, nsplit
+            return None, nsplit, reduction
         out = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
         alpha, beta = ctypes.c_float(1.0), ctypes.c_float(0.0)
         stream = ctypes.c_void_p(torch.cuda.current_stream().cuda_stream)
@@ -327,7 +570,7 @@ def _cublas_direct(a, b, kind, out_dtype, execute=True):
                                 ctypes.c_void_p(_WS.data_ptr()), ctypes.c_size_t(_WS_BYTES), stream)
         _ck("matmul", rc)
         torch.cuda.synchronize()
-        return out, (nsplit if isinstance(nsplit, int) and nsplit >= 1 else 1)
+        return out, nsplit, reduction
     finally:
         for h, d in [(pref, lib.cublasLtMatmulPreferenceDestroy), (D, lib.cublasLtMatrixLayoutDestroy),
                      (C, lib.cublasLtMatrixLayoutDestroy), (B, lib.cublasLtMatrixLayoutDestroy),
@@ -381,50 +624,50 @@ def _static_chunk(K, nsplit, kind):
     return _chunk_from_ns(K, nsplit, _grain(kind))
 
 
-_CALIB_MAX_NS = 256  # bounded split count for the wide runtime sweep
-
-
 def _splitk_candidate_chunks(K, nsplit, kind):
-    """Candidate partitions for the runtime-match path, in try-order: the heuristic nsplit
-    +/-1 first (the common case resolves fast), then a WIDE canonical sweep over nsplit
-    2..cap at the grain(s) -- the heuristic's split count can be off by more than 1, so the
-    narrow window alone falsely rejects reconstructable shapes. Grains: fp16/bf16 = 64; fp8 =
-    128 then 64. Deduped by chunk."""
-    grains = (64, ) if kind != "fp8" else (128, 64)
-    chunks, seen = [], set()
+    """The single partition cuBLAS uses -- there is nothing to search.
 
-    def add(ns, G):
-        if ns < 2:
-            return
-        chunk = _chunk_from_ns(K, ns, G)
-        if G <= chunk < K and chunk not in seen:
-            seen.add(chunk)
-            chunks.append(chunk)
-
-    for ns in (nsplit, nsplit - 1, nsplit + 1):  # near the heuristic first
-        add(ns, _grain(kind))
-    for G in grains:                             # then the wide sweep
-        cap = min((K + G - 1) // G, _CALIB_MAX_NS)
-        for ns in range(2, cap + 1):
-            add(ns, G)
-    return chunks
+    `chunk = chunk_from_ns(K, SPLITK_NUM, G)`, uneven, remainder in the LAST slice. Verified
+    over 131,533 fp8 split-K shapes with 0 counterexamples, and for fp16 a wide re-sweep of
+    7k-21k alternative partitions per failing shape recovered the rule chunk on controls and
+    found an alternative for only 4 of 195. So if this chunk does not byte-verify, the shape
+    is a genuine residual, not a missed split count."""
+    G = _grain(kind)
+    chunk = _chunk_from_ns(K, nsplit, G)
+    return [chunk] if G <= chunk < K else []
 
 
 def _make_inputs(M, N, K, kind, seed):
-    """Order-sensitive inputs (magnitude spread + alternating sign along K) so the K
-    reduction order shows up in the output bits. Magnitudes are kept in range so the
-    output stays finite -- for fp8 the values must fit e4m3 (max 448)."""
+    """Calibration inputs, alternating TWO distributions across seeds. A reconstruction has to
+    pass both, because neither alone discriminates.
+
+      even seed -- FLAT: same-scale gaussians, so every k term contributes comparably and a
+        wrong grouping of the bulk of K changes the sum.
+      odd seed  -- SPREAD: a logspace magnitude ramp with alternating sign along K, which
+        stresses cancellation and the placement of the large terms.
+
+    SPREAD alone is a trap: with a 1e-3..1e3 ramp the largest-k products dominate and the rest
+    are absorbed in fp32, so the result barely depends on how the bulk of K is grouped and a
+    wrong reconstruction passes. Measured: with SPREAD-only calibration, 180 of 281 non-aligned
+    shapes that "passed" 32 seeds were then wrong on ordinary flat inputs.
+
+    Magnitudes stay in range so the output is finite (fp8 values must fit e4m3, max 448)."""
     torch.manual_seed(seed)
+    flat = seed % 2 == 0
     sign = torch.where(torch.arange(K, device=DEVICE) % 2 == 0, 1.0, -1.0).unsqueeze(0)
     if kind == "fp8":
-        scale = torch.logspace(-1, 1, K, device=DEVICE, dtype=torch.float32).unsqueeze(0)  # 0.1..10, fp8-safe
-        a = (torch.randn(M, K, device=DEVICE) * scale * sign).to(torch.float8_e4m3fn)
+        af = torch.randn(M, K, device=DEVICE)
+        if not flat:
+            af = af * torch.logspace(-1, 1, K, device=DEVICE, dtype=torch.float32).unsqueeze(0) * sign
+        a = (af * (0.5 if flat else 1.0)).to(torch.float8_e4m3fn)
         b = (torch.randn(N, K, device=DEVICE) * 0.25).to(torch.float8_e4m3fn).t()  # [K,N] col-major
         return a, b
     dt = torch.bfloat16 if kind == "bf16" else torch.float16
-    scale = torch.logspace(-3, 3, K, device=DEVICE, dtype=torch.float32).unsqueeze(0)
-    a = (torch.randn(M, K, device=DEVICE) * scale * sign).to(dt)
-    b = (torch.randn(K, N, device=DEVICE) * 0.05).to(dt)
+    af = torch.randn(M, K, device=DEVICE)
+    if not flat:
+        af = af * torch.logspace(-3, 3, K, device=DEVICE, dtype=torch.float32).unsqueeze(0) * sign
+    a = (af * (0.3 if flat else 1.0)).to(dt)
+    b = (torch.randn(K, N, device=DEVICE) * (0.3 if flat else 0.05)).to(dt)
     return a, b
 
 
@@ -440,79 +683,221 @@ def _aligned(M, N, K, kind):
     return K % 8 == 0 and N % 8 == 0
 
 
-def _is_static_exact(kind, nsplit, aligned, M, N):
-    """Can we reconstruct from the heuristic ALONE (no runtime byte-compare) and be sure it
-    is bit-exact? Measured on GB300/sm_100:
-      - fp16/bf16 aligned: yes (plain and split-K at G=64@heur both match);
-      - fp8 large-output plain (ceil(M/64)*ceil(N/64) >= 64, nsplit==1): yes;
-      - fp8 skinny (small output): NO -- even at SPLITK_NUM==1 cuBLAS may use a cluster kernel
-        that reduces K across CTAs, which a single-accumulator/two-pass Triton kernel cannot
-        bit-match; and fp8 split-K vertical is not reproducible -> defer to a runtime match;
-      - fp16/bf16 non-aligned: NO (CUTLASS; K=16 variants reconstruct, s1688/odd-K do not)."""
-    if not aligned:
-        return False
-    if kind in ("fp16", "bf16"):
-        return True
-    tiles = ((M + 63) // 64) * ((N + 63) // 64)
-    return nsplit <= 1 and tiles >= 64  # fp8: only the large-output plain subset is static-safe
+def _is_static_exact(kind, nsplit, aligned):
+    """Can we reconstruct from the heuristic ALONE (no runtime byte-compare) and be sure it is
+    bit-exact? Only the PLAIN branch, for both dtypes.
+
+    Measured against cuBLAS-direct over 251,704 shapes / 1.07M byte-compares (GB300/sm_100):
+      - aligned + SPLITK_NUM == 1: fp8 0 violations in 48,635, fp16 3 in 16,902 (0.018%);
+      - aligned SPLIT-K: NOT safe. 450 of 40,097 aligned fp16 split-K shapes (1.12%) are not
+        bit-exact, and no partition fixes them (K is not a whole number of k-tiles there, and
+        cuBLAS treats the partial last slice in a way the two-pass split-K cannot express);
+        fp8 split-K has a 0.41% residual. Both go through the runtime match;
+      - non-aligned: NO (CUTLASS s1688 K=8 / odd-K tails).
+    An earlier fp8-only `ceil(M/64)*ceil(N/64) >= 64` gate was dropped: 0 violations in 33,013
+    small-output plain fp8 shapes, so `SPLITK_NUM == 1` alone is the right condition."""
+    return aligned and nsplit <= 1
 
 
 def _reconstruct(a, b, out_dtype, plan, sa=1.0, sb=1.0):
-    mode, chunk = plan
+    mode, arg = plan
     if mode == "plain":
         return _triton_plain(a, b, out_dtype, sa=sa, sb=sb)
-    return _triton_splitk(a, b, chunk, out_dtype, sa=sa, sb=sb)
+    if mode == "k_per_dot":
+        return _triton_plain_k_per_dot(a, b, out_dtype, arg[0], arg[1], sa=sa, sb=sb)
+    if mode == "splitk_groups":
+        return _triton_splitk_groups(a, b, arg[0], arg[1], arg[2], arg[3], out_dtype, sa=sa, sb=sb)
+    return _triton_splitk(a, b, arg, out_dtype, sa=sa, sb=sb)
+
+
+def _launched_kernel_names(a, b, out_dtype):
+    """Run cuBLAS once under the profiler and return the CUDA kernels it launched.
+
+    The launched kernel name is the only place cuBLAS states its threadblock k-tile, and that
+    is the one knob no heuristic field pins: config groups identical in `ALGO_ID`, `TILE_ID`,
+    `CUSTOM_OPTION`, `STAGES_ID` and `REDUCTION_SCHEME` still differ in it. Reading the name
+    costs about 2 ms per shape against 0.1 ms for the GEMM alone, but unlike a byte-compare it
+    is a direct observation of what cuBLAS did rather than an inference from the output."""
+    from torch.profiler import ProfilerActivity, profile
+    try:
+        cublas_matmul(a, b, out_dtype)  # warm up: the first call loads the kernel
+        torch.cuda.synchronize()
+        with profile(activities=[ProfilerActivity.CUDA]) as prof:
+            cublas_matmul(a, b, out_dtype)
+            torch.cuda.synchronize()
+        return [e.key for e in prof.key_averages() if e.self_device_time_total > 0]
+    except Exception:
+        return []
+
+
+def _parse_launched(names):
+    """Pull the reconstruction knobs out of the launched kernel names.
+
+    CUTLASS 2.x profiler names read `cutlass_<arch>_<op>_s<MMA>gemm_<dt>_<tbM>x<tbN>_<tbK>x<stages>
+    _<layout>_align<n>`, so the MMA gives the k-elements per dot (`s1688` -> 8, the k16 subtypes
+    -> 16) and the second tile field gives the threadblock k-tile. nvjet names read
+    `nvjet_<arch>_<dt>_<T1>x<T2>_<BK>x<STG>_<CxxCy>_...`, where the second field's first number is
+    the k-slice grain. Returns None for anything else -- notably cuBLAS's SIMT `gemv` fallbacks,
+    which are not CUTLASS at all and have no such structure."""
+    raw = next((n for n in names if "cutlass_" in n or "nvjet_" in n), None)
+    if raw is None:
+        return None
+    # A demangled symbol repeats the kernel name (template argument, then `::Params`), so parse
+    # the FIRST occurrence only -- scanning the whole string finds the M x N tile twice and
+    # mistakes the repeat for the k-tile field.
+    core = re.search(r"(?:cutlass|nvjet)_[A-Za-z0-9_]+", raw).group(0)
+    tiles = [t for t in core.split("_") if re.fullmatch(r"\d+x\d+", t)]
+    if core.startswith("nvjet"):
+        # nvjet_<arch>_<dtypes>_<T1xT2>_<BKxSTAGES>_<CxxCy>_...: the second field holds the grain.
+        return {"family": "nvjet", "k_per_dot": None,
+                "block_k": int(tiles[1].split("x")[0]) if len(tiles) >= 2 else None}
+    m = re.search(r"_s(\d+)gemm", core)
+    if m is None:
+        return None
+    k_per_dot = 8 if m.group(1) == "1688" else 16  # s1688 is m16n8k8, the rest here are k16 MMAs
+    # cutlass_<arch>_<op>_[<dt>_]s<MMA>gemm_<dt>_<tbMxtbN>[_<tbKxstages>]_<layout>_align<n>.
+    # Two-stage sm_75 instances omit the k-tile field; those were measured to use 32 (1264/1264).
+    block_k = int(tiles[1].split("x")[0]) if len(tiles) >= 2 else 32
+    return {"family": "cutlass", "k_per_dot": k_per_dot, "block_k": block_k}
+
+
+def _plan_from_launched(a, b, kind, out_dtype, nsplit, reduction):
+    """Derive the reconstruction from what cuBLAS actually launched, with no byte-compare.
+
+    Every knob is read rather than searched: the family and k-tile from the kernel name, the
+    k-elements per dot from the MMA in that name, and the split-K merge scheme from
+    `REDUCTION_SCHEME`. Returns None when the launch is something we do not model (a SIMT gemv
+    fallback, an atomic reduction, an unparsable name), which sends the shape to the search."""
+    info = _parse_launched(_launched_kernel_names(a, b, out_dtype))
+    if info is None:
+        return None
+    M, K = a.shape
+    if info["family"] == "nvjet":  # cuBLAS's own kernels: the aligned rule, grain from the name
+        grain = info["block_k"] or _grain(kind)
+        if nsplit <= 1:
+            return ("plain", None)
+        chunk = _chunk_from_ns(K, nsplit, grain)
+        return ("split", chunk) if grain <= chunk < K else None
+    if kind == "fp8":  # fp8 never reaches CUTLASS (cuBLAS needs every dim %16, i.e. aligned)
+        return None
+    k_per_dot, block_k = info["k_per_dot"], info["block_k"]
+    if nsplit <= 1:
+        return ("k_per_dot", (k_per_dot, K % block_k))
+    cmode = _REDUCTION_TO_CMODE.get(reduction)
+    if cmode is None:  # e.g. an atomic (INPLACE) reduction, which is not deterministic for us
+        return None
+    # CUTLASS's split-K partition grain: `params_universal_base.h:52-59` takes kAlignK = 64 when
+    # K divides evenly by it and falls back to 128 bits / 16 bits = 8 otherwise.
+    grain = 64 if K % 64 == 0 else 8
+    chunk = _chunk_from_ns(K, nsplit, grain)
+    return ("splitk_groups", (chunk, k_per_dot, block_k, cmode)) if grain <= chunk <= K else None
+
+
+def _candidate_plans(K, nsplit, kind):
+    """Every reconstruction worth trying for a shape, in try-order.
+
+    The CUTLASS families are fp16/bf16 only. cuBLAS falls back to CUTLASS when a contiguous dim
+    is not 8-element aligned, but it refuses fp8 altogether unless every dim is a multiple of
+    16, so a runnable fp8 shape is always aligned and always stays on nvjet. (Their k-tile of 16
+    is also below the K>=32 an fp8 `tl.dot` needs.)"""
+    cutlass = kind != "fp8"
+    if nsplit <= 1:
+        # A plain GEMM if cuBLAS stayed on nvjet; otherwise it is on a CUTLASS kernel that
+        # rounds its accumulator once per MMA, and neither the k per dot nor where the partial
+        # group sits can be read off the shape.
+        plans = [("plain", None)]
+        if cutlass:
+            plans += [("k_per_dot", c) for c in _k_per_dot_candidates(K)]
+        return plans
+    # The nvjet split-K rule first, then the CUTLASS split-K path, which differs in the
+    # partition grain, has a per-slice residue tile, and has three possible merge schemes.
+    plans = [("split", c) for c in _splitk_candidate_chunks(K, nsplit, kind)]
+    if cutlass:
+        plans += [("splitk_groups", c) for c in _splitk_group_candidates(K, nsplit)]
+    return plans
+
+
+def _plan_matches(M, N, K, kind, out_dtype, plan, seeds):
+    """Byte-check `plan` against cuBLAS on `seeds`, one seed resident at a time.
+
+    Holding every reference at once would need `len(seeds)` copies of A, B and D, which runs a
+    large shape out of memory (a 8192x300000 fp16 operand is 4.9 GiB before the fp32 temporaries
+    that build it), so each seed is generated, compared and freed."""
+    for seed in seeds:
+        a, b = _make_inputs(M, N, K, kind, seed)
+        d = _cublas_direct(a, b, kind, out_dtype)[0]  # (out, nsplit, reduction)
+        c = _reconstruct(a, b, out_dtype, plan)
+        ok = c is not None and _bits_eq(c, d)
+        del a, b, c, d
+        if not ok:
+            return False
+    return True
 
 
 def _calibrate(M, N, K, kind, out_dtype):
-    """RUNTIME match: find the reconstruction that bit-matches cuBLAS run directly, verified
-    on _SEEDS order-sensitive seeds. Returns ("plain",None) or ("split",chunk); raises
-    CublasUnsupportedShape if nothing matches. cuBLAS's choice is a function of the shape
-    (not the data), so one calibration serves all future inputs of that shape."""
-    refs, nsplit = [], 1
-    for i, s in enumerate(_SEEDS):
-        a, b = _make_inputs(M, N, K, kind, s)
-        d, ns = _cublas_direct(a, b, kind, out_dtype)
-        refs.append((a, b, d))
-        if i == 0:
-            nsplit = ns
+    """RUNTIME match: find the reconstruction that bit-matches cuBLAS run directly. Raises
+    CublasUnsupportedShape if none does. cuBLAS's choice is a function of the shape, not of the
+    data, so one calibration serves every future input of that shape.
 
-    if nsplit <= 1:  # cuBLAS runs a plain GEMM
-        if all(_bits_eq(_triton_plain(a, b, out_dtype), d) for a, b, d in refs):
-            return ("plain", None)
-        raise CublasUnsupportedShape(f"{M}x{N}x{K} {kind}: plain reconstruction does not match cuBLAS")
+    Three stages. A seed-0 prefilter kills nearly every candidate against a single reference.
+    Survivors are checked on the rest of `_SEEDS`. The winner is then re-checked on
+    `_CONFIRM_SEEDS`, which took no part in choosing it -- picking the best of ~36 candidates on
+    32 seeds is a selection, and without a hold-out a candidate that fits by luck slips through
+    (measured: 4 such shapes in 1,497 on the skinny+deep corner)."""
+    a0, b0 = _make_inputs(M, N, K, kind, _SEEDS[0])
+    d0, nsplit, _red = _cublas_direct(a0, b0, kind, out_dtype)
+    survivors = []
+    for plan in _candidate_plans(K, nsplit, kind):
+        c = _reconstruct(a0, b0, out_dtype, plan)
+        if c is not None and _bits_eq(c, d0):
+            survivors.append(plan)
+        del c
+    del a0, b0, d0
 
-    a0, b0, d0 = refs[0]
-    for chunk in _splitk_candidate_chunks(K, nsplit, kind):  # cuBLAS runs split-K
-        c0 = _triton_splitk(a0, b0, chunk, out_dtype)
-        if c0 is None or not _bits_eq(c0, d0):
-            continue  # seed-0 prefilter: keeps the wide nsplit sweep cheap
-        if all(_bits_eq(_triton_splitk(a, b, chunk, out_dtype), d) for a, b, d in refs[1:]):
-            return ("split", chunk)
-    raise CublasUnsupportedShape(f"{M}x{N}x{K} {kind}: no split-K recipe matches cuBLAS (nsplit={nsplit})")
+    for plan in survivors:
+        if _plan_matches(M, N, K, kind, out_dtype, plan, _SEEDS[1:] + _CONFIRM_SEEDS):
+            return plan
+    raise CublasUnsupportedShape(f"{M}x{N}x{K} {kind}: no reconstruction matches cuBLAS (nsplit={nsplit}, "
+                                 f"{len(survivors)} candidates passed the first seed)")
 
 
-def _resolve(a, b, kind, out_dtype, enable_runtime_match):
-    """Reconstruction plan for this shape (cached). Static-exact shapes are planned from the
-    heuristic alone (no GEMM run). Others need a runtime byte-compare: with
-    enable_runtime_match they are calibrated against cuBLAS; without, raise
-    CublasNeedRuntimeMatch."""
+def _resolve(a, b, kind, out_dtype, enable_runtime_match, enable_pseudo_static=True):
+    """Reconstruction plan for this shape, cached after the first call. Three tiers, tried in
+    order, each stricter about what it costs and weaker about what it proves:
+
+      static        the heuristic alone decides it, no cuBLAS execution at all.
+      pseudo-static one profiled cuBLAS launch; the recipe is READ off the launched kernel name
+                    and `REDUCTION_SCHEME` rather than searched. Costs ~2 ms for the profile but
+                    it is a direct observation of what cuBLAS did, so it cannot pick a wrong
+                    recipe that happens to agree on the seeds it was checked against. It also
+                    does not prove the result: nothing is byte-compared on this path.
+      runtime       search the candidate recipes and keep the one that byte-matches cuBLAS on
+                    32 selection seeds plus 8 hold-out seeds. Proves the match on those inputs,
+                    but choosing the best of ~36 candidates is a selection and can still admit a
+                    recipe that fits by luck.
+    """
     M, K = a.shape
     N = b.shape[1]
     key = (M, N, K, kind, out_dtype)
     if key in _PLAN:
-        origin, plan = _PLAN[key]  # origin: "static" | "runtime" | "unsupported"
+        origin, plan = _PLAN[key]  # "static" | "pseudo-static" | "runtime" | "unsupported"
         if origin == "unsupported":
             raise CublasUnsupportedShape(f"{M}x{N}x{K} {kind}: unsupported (cached)")
         if origin == "runtime" and not enable_runtime_match:
             raise CublasNeedRuntimeMatch(f"{M}x{N}x{K} {kind}: needs a runtime match (cached)")
         return plan
 
-    nsplit = _cublas_direct(a, b, kind, out_dtype, execute=False)[1]  # static: heuristic only, no GEMM run
-    if _is_static_exact(kind, nsplit, _aligned(M, N, K, kind), M, N):
+    _, nsplit, reduction = _cublas_direct(a, b, kind, out_dtype, execute=False)  # heuristic only, no GEMM run
+    if _is_static_exact(kind, nsplit, _aligned(M, N, K, kind)):
         plan = ("plain", None) if nsplit <= 1 else ("split", _static_chunk(K, nsplit, kind))
         _PLAN[key] = ("static", plan)
         return plan
+
+    if enable_pseudo_static:
+        plan = _plan_from_launched(a, b, kind, out_dtype, nsplit, reduction)
+        if plan is not None:
+            _PLAN[key] = ("pseudo-static", plan)
+            return plan
 
     if not enable_runtime_match:
         raise CublasNeedRuntimeMatch(f"{M}x{N}x{K} {kind}: not statically guaranteed; "
@@ -530,7 +915,7 @@ def _resolve(a, b, kind, out_dtype, enable_runtime_match):
 # Public API
 # --------------------------------------------------------------------------- #
 def cublas_equivalent_gemm(a: torch.Tensor, b: torch.Tensor, out_dtype: torch.dtype | None = None,
-                           enable_runtime_match: bool = False) -> torch.Tensor:
+                           enable_runtime_match: bool = False, enable_pseudo_static: bool = True) -> torch.Tensor:
     """fp16/bf16 GEMM, bit-identical to cuBLAS. `a` is [M,K], `b` is [K,N].
 
     Static by default: the reconstruction is planned from the cuBLAS heuristic alone (no GEMM
@@ -542,13 +927,13 @@ def cublas_equivalent_gemm(a: torch.Tensor, b: torch.Tensor, out_dtype: torch.dt
     if kind == "fp8":
         raise ValueError("use cublas_equivalent_scaled_mm for fp8")
     out_dtype = out_dtype or a.dtype
-    plan = _resolve(a, b, kind, out_dtype, enable_runtime_match)
+    plan = _resolve(a, b, kind, out_dtype, enable_runtime_match, enable_pseudo_static)
     return _reconstruct(a, b, out_dtype, plan)
 
 
 def cublas_equivalent_scaled_mm(a: torch.Tensor, b: torch.Tensor, scale_a: float = 1.0, scale_b: float = 1.0,
-                                out_dtype: torch.dtype = torch.float16,
-                                enable_runtime_match: bool = False) -> torch.Tensor:
+                                out_dtype: torch.dtype = torch.float16, enable_runtime_match: bool = False,
+                                enable_pseudo_static: bool = True) -> torch.Tensor:
     """fp8 (e4m3) GEMM, bit-identical to cuBLAS. `a` is [M,K], `b` is [K,N] column-major
     (i.e. from `w.t()`); scales are scalars.
 
@@ -556,7 +941,7 @@ def cublas_equivalent_scaled_mm(a: torch.Tensor, b: torch.Tensor, scale_a: float
     kernel is not bit-reproducible) -> raises CublasNeedRuntimeMatch unless
     `enable_runtime_match=True`, which byte-compares against cuBLAS and returns the match or
     raises CublasUnsupportedShape (vertical split-K)."""
-    plan = _resolve(a, b, "fp8", out_dtype, enable_runtime_match)
+    plan = _resolve(a, b, "fp8", out_dtype, enable_runtime_match, enable_pseudo_static)
     return _reconstruct(a, b, out_dtype, plan, sa=scale_a, sb=scale_b)
 
 
@@ -564,20 +949,21 @@ def cublas_equivalent_scaled_mm(a: torch.Tensor, b: torch.Tensor, scale_a: float
 # Self-check
 # --------------------------------------------------------------------------- #
 def _check_one(kind, M, N, K):
-    """Classify + verify one shape: try static first; if it needs a runtime match, retry with
-    enable_runtime_match=True. Returns (class, bit_ok) where class is static/runtime/unsupported."""
+    """Verify one shape and report which tier resolved it, read from the plan cache rather than
+    guessed from which call succeeded. Returns (tier, bit_ok)."""
     a, b = _make_inputs(M, N, K, kind, 7)
     ref = cublas_matmul(a, b, torch.float16 if kind == "fp8" else None)
     call = (lambda rt: cublas_equivalent_scaled_mm(a, b, 1.0, 1.0, torch.float16, enable_runtime_match=rt)) \
         if kind == "fp8" else (lambda rt: cublas_equivalent_gemm(a, b, enable_runtime_match=rt))
     try:
-        return "static", _bits_eq(call(False), ref)
-    except CublasNeedRuntimeMatch:
-        pass
-    try:
-        return "runtime", _bits_eq(call(True), ref)
+        try:
+            out = call(False)
+        except CublasNeedRuntimeMatch:
+            out = call(True)
     except CublasUnsupportedShape:
         return "unsupported", None
+    tier = _PLAN.get((M, N, K, kind, torch.float16), ("?", None))[0]
+    return tier, _bits_eq(out, ref)
 
 
 def verify():
@@ -586,26 +972,26 @@ def verify():
         return
     print(f"device: {torch.cuda.get_device_name()} | cap {torch.cuda.get_device_capability()} | "
           f"cuda {torch.version.cuda}")
-    print("class = static (heuristic only) / runtime (byte-compare) / unsupported; then vs cuBLAS-direct\n")
+    print("tier = static (heuristic only) / pseudo-static (kernel name) / runtime (byte-compare)\n")
 
     shapes = [("fp16", 4096, 4096, 4096), ("fp16", 2048, 2048, 512), ("fp16", 16, 16384, 16384),
               ("fp16", 64, 64, 32768), ("fp16", 128, 128, 16384), ("fp8", 4096, 4096, 4096),
               ("fp8", 8192, 8192, 8192), ("fp8", 64, 64, 65536), ("fp8", 128, 128, 65536), ("fp8", 16, 64, 131072)]
-    n_ok = n_static = n_runtime = n_unsup = 0
+    n_ok, n_unsup = 0, 0
+    tiers = {"static": 0, "pseudo-static": 0, "runtime": 0}
     for (kind, M, N, K) in shapes:
         cls, ok = _check_one(kind, M, N, K)
-        n_static += int(cls == "static")
-        n_runtime += int(cls == "runtime")
         if cls == "unsupported":
             n_unsup += 1
             verdict = "UNSUPPORTED"
         else:
+            tiers[cls] = tiers.get(cls, 0) + 1
             n_ok += int(bool(ok))
             verdict = "BIT-IDENTICAL" if ok else "DIFFER"
-        print(f"  {kind:4s} {M:5d}x{N:5d}x{K:6d}  {cls:11s}  {verdict}")
+        print(f"  {kind:4s} {M:5d}x{N:5d}x{K:6d}  {cls:13s}  {verdict}")
 
-    print(f"\nbit-identical {n_ok}/{n_static + n_runtime} | static {n_static} | runtime {n_runtime} | "
-          f"unsupported {n_unsup}")
+    print(f"\nbit-identical {n_ok}/{sum(tiers.values())} | static {tiers['static']} | "
+          f"pseudo-static {tiers['pseudo-static']} | runtime {tiers['runtime']} | unsupported {n_unsup}")
 
 
 if __name__ == "__main__":

--- a/bitequiv/cublas_equiv_gemm.py
+++ b/bitequiv/cublas_equiv_gemm.py
@@ -1,0 +1,612 @@
+"""Bit-for-bit cuBLAS-equivalent Triton GEMM, driven by the cuBLASLt heuristic.
+
+Top-level API (a cuBLAS-like matmul):
+
+    from bitequiv.cublas_equiv_gemm import cublas_equivalent_gemm, cublas_equivalent_scaled_mm
+    c = cublas_equivalent_gemm(a_fp16, b_fp16)               # == cuBLAS fp16/bf16 GEMM, bit-for-bit
+    c = cublas_equivalent_scaled_mm(a_fp8, b_fp8_col, sa, sb) # == cuBLAS fp8 GEMM, bit-for-bit
+
+How it works
+------------
+For a shape (M, N, K, dtype) we ask cuBLAS's OWN heuristic what it would do, then
+rebuild that exact computation in Triton:
+
+  1. Query `cublasLtMatmulAlgoGetHeuristic` (ctypes) -> the top algo's split count
+     `SPLITK_NUM` (config attr 2).  This is faithful to what cuBLAS runs.
+  2. `SPLITK_NUM == 1`  -> plain GEMM (one FP32 accumulator over K).
+     `SPLITK_NUM  > 1`  -> split-K: cut K into k-slices, one FP32 partial each,
+     combine the partials in FORWARD order in FP32, cast to the output dtype.
+  3. The k-slice granularity `G` is fixed per dtype/kernel family (measured on
+     GB300 / sm_100, reference = cuBLAS run directly, no torch):
+       - fp16 / bf16 (nvjet)                     -> G = 64
+       - fp8 (nvjet 2-CTA or horizontal)         -> G = 128
+       - fp8 (nvjet vertical)                    -> G = 64
+     `chunk = ceil(ceil(K/G)/nsplit)*G`; slices are uneven, the LAST is smaller.
+  4. VERIFY-THEN-USE (sound by construction): before trusting any reconstruction
+     we byte-compare it against cuBLAS run directly (`cublasLtMatmul` with the
+     heuristic's own algo) on 3 order-sensitive seeds.  The first candidate recipe
+     that matches all 3 is cached per shape; if none match, the shape is
+     `CublasUnsupportedShape` -- we never silently return a non-matching result.
+     Cached shapes are then PURE Triton (no cuBLAS call).
+
+Known unsupported (raise `CublasUnsupportedShape`): fp16 non-aligned CUTLASS
+`s1688` (K=8 MMA -- Triton's `tl.dot` is K=16) and odd-K tails; fp8 vertical
+split-K where cuBLAS reduces K across the cluster CTAs (a distributed FP32 order a
+tile-level two-pass split-K cannot emit, e.g. some N=192 shapes).
+
+Depends on `torch`, `triton`, `ctypes` (stdlib), and the CUDA `libcublasLt` shared
+library (always present with a CUDA runtime).  GB300 / sm_100.
+"""
+from __future__ import annotations
+
+import ctypes
+import glob
+
+import torch
+import triton
+import triton.language as tl
+
+DEVICE = "cuda"
+_WS_BYTES = 33554432  # 32 MiB scratch for the cuBLAS-direct reference execute
+_SEEDS = tuple(range(32))  # order-sensitive seeds to verify a reconstruction; more seeds reject borderline
+# (near-miss) nsplit that a wide sweep would otherwise accept on too few samples, at the cost of slower calibration.
+
+
+class CublasUnsupportedShape(Exception):
+    """No Triton reconstruction bit-matches cuBLAS for this shape, even with a runtime
+    byte-compare (e.g. fp8 vertical/cluster split-K, fp16 non-aligned s1688 K=8 / odd-K)."""
+
+
+class CublasNeedRuntimeMatch(Exception):
+    """The shape cannot be reconstructed from the heuristic STATICALLY with confidence; a
+    runtime byte-compare against cuBLAS is needed to confirm (or reject) it. Raised only in
+    static mode (`enable_runtime_match=False`). Re-call with `enable_runtime_match=True`."""
+
+
+# --------------------------------------------------------------------------- #
+# Triton kernels (scale-capable, single FP32 accumulator)
+# --------------------------------------------------------------------------- #
+@triton.jit
+def _plain_gemm(A, B, C, M, N, K, am, ak, bk, bn, cm, cn, sa, sb, BM: tl.constexpr, BN: tl.constexpr,
+                BK: tl.constexpr):
+    pid = tl.program_id(0)
+    npn = tl.cdiv(N, BN)
+    pm = pid // npn
+    pn = pid % npn
+    om = (pm * BM + tl.arange(0, BM)) % M
+    on = (pn * BN + tl.arange(0, BN)) % N
+    ok = tl.arange(0, BK)
+    ap = A + om[:, None] * am + ok[None, :] * ak
+    bp = B + ok[:, None] * bk + on[None, :] * bn
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BK)):
+        acc = tl.dot(tl.load(ap, mask=ok[None, :] < K - k * BK, other=0.0),
+                     tl.load(bp, mask=ok[:, None] < K - k * BK, other=0.0), acc)
+        ap += BK * ak
+        bp += BK * bk
+    acc = acc * sa * sb
+    ocm = pm * BM + tl.arange(0, BM)
+    ocn = pn * BN + tl.arange(0, BN)
+    tl.store(C + cm * ocm[:, None] + cn * ocn[None, :], acc.to(C.dtype.element_ty),
+             mask=(ocm[:, None] < M) & (ocn[None, :] < N))
+
+
+@triton.jit
+def _splitk_partial(A, B, W, M, N, K, am, ak, bk, bn, ws, wm, wn, CHUNK, BM: tl.constexpr, BN: tl.constexpr,
+                    BK: tl.constexpr):
+    """Pass 1: slice `sk` covers [sk*CHUNK, min((sk+1)*CHUNK, K)) -> one FP32 partial.
+    CHUNK is a runtime arg, so one compiled kernel serves any num_split / granularity."""
+    pid = tl.program_id(0)
+    sk = tl.program_id(1)
+    npn = tl.cdiv(N, BN)
+    pm = pid // npn
+    pn = pid % npn
+    om = (pm * BM + tl.arange(0, BM)) % M
+    on = (pn * BN + tl.arange(0, BN)) % N
+    k0 = sk * CHUNK
+    klen = tl.minimum(CHUNK, K - k0)
+    ok = tl.arange(0, BK)
+    ap = A + om[:, None] * am + (k0 + ok)[None, :] * ak
+    bp = B + (k0 + ok)[:, None] * bk + on[None, :] * bn
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for ki in range(0, tl.cdiv(CHUNK, BK)):
+        km = (ki * BK + ok) < klen
+        acc = tl.dot(tl.load(ap, mask=km[None, :], other=0.0), tl.load(bp, mask=km[:, None], other=0.0), acc)
+        ap += BK * ak
+        bp += BK * bk
+    ocm = pm * BM + tl.arange(0, BM)
+    ocn = pn * BN + tl.arange(0, BN)
+    tl.store(W + sk * ws + ocm[:, None] * wm + ocn[None, :] * wn, acc, mask=(ocm[:, None] < M) & (ocn[None, :] < N))
+
+
+@triton.jit
+def _splitk_combine(W, C, M, N, ws, wm, wn, cm, cn, S, sa, sb, BM: tl.constexpr, BN: tl.constexpr):
+    """Pass 2: sum the S FP32 partials in FORWARD order (slice 0..S-1), scale, cast."""
+    pid = tl.program_id(0)
+    npn = tl.cdiv(N, BN)
+    pm = pid // npn
+    pn = pid % npn
+    om = pm * BM + tl.arange(0, BM)
+    on = pn * BN + tl.arange(0, BN)
+    m2 = (om[:, None] < M) & (on[None, :] < N)
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for i in range(0, S):
+        acc += tl.load(W + i * ws + om[:, None] * wm + on[None, :] * wn, mask=m2, other=0.0)
+    acc = acc * sa * sb
+    tl.store(C + cm * om[:, None] + cn * on[None, :], acc.to(C.dtype.element_ty), mask=m2)
+
+
+def _tile(M: int, N: int) -> tuple[int, int]:
+    """Partial tile (bit-neutral): small tiles for small M,N, capped at 128."""
+    BM = 16 if M <= 16 else 32 if M <= 32 else 64 if M <= 64 else 128
+    BN = 16 if N <= 16 else 32 if N <= 32 else 64 if N <= 64 else 128
+    return BM, BN
+
+
+def _kcontig(b):
+    return b if b.stride(1) == 1 else b.contiguous()
+
+
+def _triton_plain(a, b, out_dtype, sa=1.0, sb=1.0, BM=128, BN=128, BK=64):
+    b = _kcontig(b)
+    M, K = a.shape
+    N = b.shape[1]
+    c = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
+    grid = (triton.cdiv(M, BM) * triton.cdiv(N, BN), )
+    _plain_gemm[grid](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0), c.stride(1),
+                      sa, sb, BM=BM, BN=BN, BK=BK, num_warps=8)
+    return c
+
+
+def _triton_splitk(a, b, chunk, out_dtype, sa=1.0, sb=1.0, BK=64):
+    """Deterministic two-pass split-K at `chunk`-element early slices (uneven tail),
+    forward FP32 combine. Returns None if the chunk does not yield a real split (nsplit<2)."""
+    b = _kcontig(b)
+    M, K = a.shape
+    N = b.shape[1]
+    nsplit = (K + chunk - 1) // chunk
+    if nsplit < 2 or nsplit > 8192:
+        return None
+    BM, BN = _tile(M, N)
+    ntile = triton.cdiv(M, BM) * triton.cdiv(N, BN)
+    w = torch.empty(nsplit, M, N, device=DEVICE, dtype=torch.float32)
+    _splitk_partial[(ntile, nsplit)](a, b, w, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), w.stride(0),
+                                     w.stride(1), w.stride(2), chunk, BM=BM, BN=BN, BK=BK, num_warps=4)
+    c = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
+    _splitk_combine[(ntile, )](w, c, M, N, w.stride(0), w.stride(1), w.stride(2), c.stride(0), c.stride(1), nsplit, sa,
+                               sb, BM=BM, BN=BN, num_warps=4)
+    return c
+
+
+# --------------------------------------------------------------------------- #
+# cuBLASLt via ctypes: heuristic query + run the chosen algo directly (reference)
+# --------------------------------------------------------------------------- #
+_CUDA_R_16F, _CUDA_R_32F, _CUDA_R_16BF, _CUDA_R_8F_E4M3 = 2, 0, 14, 28
+_CUBLAS_COMPUTE_32F = 68
+_OP_N, _OP_T = 0, 1
+_DESC_TRANSA, _DESC_TRANSB = 3, 4
+_DESC_A_SCALE_PTR, _DESC_B_SCALE_PTR = 17, 18
+_PREF_MAX_WS = 1
+_LAYOUT_ORDER, _ORDER_ROW = 1, 1
+_CFG_ID, _CFG_SPLITK = 0, 2
+_LT = None
+_ONES = None  # device fp32 [1.0] for fp8 scale pointers
+_WS = None    # device scratch for the reference execute
+
+
+class _HeurResult(ctypes.Structure):
+    _fields_ = [("algo", ctypes.c_char * 64), ("workspaceSize", ctypes.c_size_t), ("state", ctypes.c_int),
+                ("wavesCount", ctypes.c_float), ("reserved", ctypes.c_int * 4)]
+
+
+def _load_lt():
+    global _LT, _ONES, _WS
+    if _LT is not None:
+        return _LT
+    cands = (["/usr/local/cuda-13.0/lib64/libcublasLt.so.13"] + glob.glob("/usr/local/cuda*/lib64/libcublasLt.so*") +
+             glob.glob("/usr/local/cuda*/targets/*/lib/libcublasLt.so*") + ["libcublasLt.so.13", "libcublasLt.so"])
+    lib = None
+    for c in cands:
+        try:
+            lib = ctypes.CDLL(c)
+            break
+        except OSError:
+            continue
+    if lib is None:
+        raise OSError("libcublasLt not found")
+    P, PP = ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)
+    ci, cu64, ci64, csz = ctypes.c_int, ctypes.c_uint64, ctypes.c_int64, ctypes.c_size_t
+    lib.cublasLtCreate.argtypes = [PP]
+    lib.cublasLtDestroy.argtypes = [P]
+    lib.cublasLtMatmulDescCreate.argtypes = [PP, ci, ci]
+    lib.cublasLtMatmulDescDestroy.argtypes = [P]
+    lib.cublasLtMatmulDescSetAttribute.argtypes = [P, ci, P, csz]
+    lib.cublasLtMatrixLayoutCreate.argtypes = [PP, ci, cu64, cu64, ci64]
+    lib.cublasLtMatrixLayoutDestroy.argtypes = [P]
+    lib.cublasLtMatrixLayoutSetAttribute.argtypes = [P, ci, P, csz]
+    lib.cublasLtMatmulPreferenceCreate.argtypes = [PP]
+    lib.cublasLtMatmulPreferenceDestroy.argtypes = [P]
+    lib.cublasLtMatmulPreferenceSetAttribute.argtypes = [P, ci, P, csz]
+    lib.cublasLtMatmulAlgoGetHeuristic.argtypes = [P, P, P, P, P, P, P, ci, P, ctypes.POINTER(ci)]
+    lib.cublasLtMatmulAlgoConfigGetAttribute.argtypes = [P, ci, P, csz, ctypes.POINTER(csz)]
+    lib.cublasLtMatmul.restype = ci
+    lib.cublasLtMatmul.argtypes = [P] * 14 + [csz, P]  # 14 ptrs, workspaceSize, stream
+    _ONES = torch.ones(1, dtype=torch.float32, device=DEVICE)
+    _WS = torch.empty(_WS_BYTES, dtype=torch.uint8, device=DEVICE)
+    _LT = lib
+    return lib
+
+
+def _ck(nm, rc):
+    if rc != 0:
+        raise RuntimeError(f"cublasLt {nm} failed (status {rc})")
+
+
+def _cfg(algo_ptr, attr):
+    lib = _load_lt()
+    o = ctypes.c_int(-1)
+    w = ctypes.c_size_t(0)
+    r = lib.cublasLtMatmulAlgoConfigGetAttribute(algo_ptr, attr, ctypes.byref(o), 4, ctypes.byref(w))
+    return o.value if r == 0 else None
+
+
+def _lt_dtypes(kind, out_dtype):
+    """(ab_dt, cd_dt, transa, transb) for the cuBLASLt layouts, per input dtype."""
+    cd = _CUDA_R_16BF if out_dtype == torch.bfloat16 else _CUDA_R_16F
+    if kind == "fp8":
+        return _CUDA_R_8F_E4M3, cd, _OP_T, _OP_N  # e4m3 TN
+    ab = _CUDA_R_16BF if kind == "bf16" else _CUDA_R_16F
+    return ab, cd, _OP_N, _OP_N
+
+
+def _set_row(lib, layout):
+    v = ctypes.c_int(_ORDER_ROW)
+    _ck("layout-order", lib.cublasLtMatrixLayoutSetAttribute(layout, _LAYOUT_ORDER, ctypes.byref(v), 4))
+
+
+def _make_layouts(lib, desc, M, N, K, kind, out_dtype):
+    """Row-major layouts matching a standard torch GEMM dispatch; set transa/transb
+    (+ fp8 scale pointers). Returns (A, B, C, D) layout handles."""
+    ab, cd, transa, transb = _lt_dtypes(kind, out_dtype)
+    ta, tb = ctypes.c_int(transa), ctypes.c_int(transb)
+    _ck("transa", lib.cublasLtMatmulDescSetAttribute(desc, _DESC_TRANSA, ctypes.byref(ta), 4))
+    _ck("transb", lib.cublasLtMatmulDescSetAttribute(desc, _DESC_TRANSB, ctypes.byref(tb), 4))
+    A, B, C, D = (ctypes.c_void_p() for _ in range(4))
+    if kind != "fp8":
+        _ck("LA", lib.cublasLtMatrixLayoutCreate(ctypes.byref(A), ab, M, K, K))
+        _set_row(lib, A)
+        _ck("LB", lib.cublasLtMatrixLayoutCreate(ctypes.byref(B), ab, K, N, N))
+        _set_row(lib, B)
+    else:  # fp8 e4m3 TN: operands K-contiguous (col-major), output row-major
+        _ck("LA", lib.cublasLtMatrixLayoutCreate(ctypes.byref(A), ab, K, M, K))
+        _ck("LB", lib.cublasLtMatrixLayoutCreate(ctypes.byref(B), ab, K, N, K))
+        sp = ctypes.c_void_p(_ONES.data_ptr())
+        _ck("Ascale", lib.cublasLtMatmulDescSetAttribute(desc, _DESC_A_SCALE_PTR, ctypes.byref(sp), 8))
+        _ck("Bscale", lib.cublasLtMatmulDescSetAttribute(desc, _DESC_B_SCALE_PTR, ctypes.byref(sp), 8))
+    _ck("LC", lib.cublasLtMatrixLayoutCreate(ctypes.byref(C), cd, M, N, N))
+    _set_row(lib, C)
+    _ck("LD", lib.cublasLtMatrixLayoutCreate(ctypes.byref(D), cd, M, N, N))
+    _set_row(lib, D)
+    return A, B, C, D
+
+
+def _cublas_direct(a, b, kind, out_dtype, execute=True):
+    """Query cuBLAS's top-heuristic algo and (if execute) run it DIRECTLY via ctypes
+    cublasLtMatmul. Returns (D, nsplit): with execute, D is cuBLAS's exact output; without,
+    D is None and only the heuristic's SPLITK_NUM is read (pure-static, no GEMM run). No torch."""
+    lib = _load_lt()
+    M, K = a.shape
+    N = b.shape[1]
+    handle, desc, pref = ctypes.c_void_p(), ctypes.c_void_p(), ctypes.c_void_p()
+    A = B = C = D = None
+    try:
+        _ck("create", lib.cublasLtCreate(ctypes.byref(handle)))
+        _ck("desc", lib.cublasLtMatmulDescCreate(ctypes.byref(desc), _CUBLAS_COMPUTE_32F, _CUDA_R_32F))
+        A, B, C, D = _make_layouts(lib, desc, M, N, K, kind, out_dtype)
+        _ck("pref", lib.cublasLtMatmulPreferenceCreate(ctypes.byref(pref)))
+        ws = ctypes.c_size_t(_WS_BYTES)
+        _ck("pref-set", lib.cublasLtMatmulPreferenceSetAttribute(pref, _PREF_MAX_WS, ctypes.byref(ws), 8))
+        results = (_HeurResult * 16)()
+        ret = ctypes.c_int(0)
+        rc = lib.cublasLtMatmulAlgoGetHeuristic(handle, desc, A, B, C, D, pref, 16,
+                                                ctypes.cast(results, ctypes.c_void_p), ctypes.byref(ret))
+        if rc != 0 or ret.value == 0:
+            raise CublasUnsupportedShape(f"no cuBLAS algo for {M}x{N}x{K} {kind} (rc={rc}, ret={ret.value})")
+        algo_ptr = ctypes.cast(ctypes.byref(results[0]), ctypes.c_void_p)
+        nsplit = _cfg(algo_ptr, _CFG_SPLITK)
+        nsplit = nsplit if isinstance(nsplit, int) and nsplit >= 1 else 1
+        if not execute:
+            return None, nsplit
+        out = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
+        alpha, beta = ctypes.c_float(1.0), ctypes.c_float(0.0)
+        stream = ctypes.c_void_p(torch.cuda.current_stream().cuda_stream)
+        rc = lib.cublasLtMatmul(handle, desc, ctypes.cast(ctypes.pointer(alpha), ctypes.c_void_p),
+                                ctypes.c_void_p(a.data_ptr()), A, ctypes.c_void_p(b.data_ptr()), B,
+                                ctypes.cast(ctypes.pointer(beta), ctypes.c_void_p), ctypes.c_void_p(out.data_ptr()), C,
+                                ctypes.c_void_p(out.data_ptr()), D, algo_ptr,
+                                ctypes.c_void_p(_WS.data_ptr()), ctypes.c_size_t(_WS_BYTES), stream)
+        _ck("matmul", rc)
+        torch.cuda.synchronize()
+        return out, (nsplit if isinstance(nsplit, int) and nsplit >= 1 else 1)
+    finally:
+        for h, d in [(pref, lib.cublasLtMatmulPreferenceDestroy), (D, lib.cublasLtMatrixLayoutDestroy),
+                     (C, lib.cublasLtMatrixLayoutDestroy), (B, lib.cublasLtMatrixLayoutDestroy),
+                     (A, lib.cublasLtMatrixLayoutDestroy), (desc, lib.cublasLtMatmulDescDestroy),
+                     (handle, lib.cublasLtDestroy)]:
+            try:
+                if h is not None and h.value:
+                    d(h)
+            except Exception:
+                pass
+
+
+def cublas_matmul(a, b, out_dtype=None):
+    """cuBLAS's OWN output (run directly via cublasLtMatmul), the reference our
+    reconstruction must match. fp16/bf16: `b` is [K,N]. fp8: `b` is [K,N] column-major."""
+    kind = _kind_of(a)
+    out_dtype = out_dtype or (torch.float16 if kind == "fp8" else a.dtype)
+    return _cublas_direct(a, b, kind, out_dtype)[0]
+
+
+# --------------------------------------------------------------------------- #
+# Reconstruction planning (verify-then-use) + per-shape cache
+# --------------------------------------------------------------------------- #
+# (M,N,K,kind,out_dtype) -> (origin, plan): origin "static"|"runtime"|"unsupported"; plan
+# ("plain",None) | ("split",chunk) | None. Decided once; a "runtime" plan is withheld in static mode.
+_PLAN: dict[tuple, tuple] = {}
+
+
+def _kind_of(a) -> str:
+    if a.dtype == torch.float8_e4m3fn:
+        return "fp8"
+    if a.dtype == torch.bfloat16:
+        return "bf16"
+    return "fp16"
+
+
+def _chunk_from_ns(K, ns, G):
+    total = (K + G - 1) // G
+    return ((total + ns - 1) // ns) * G
+
+
+def _grain(kind):
+    """k-slice granularity for the split-K partition: fp16/bf16 = 64, fp8 = 128
+    (measured; fp8 G=128 at the heuristic nsplit dominates G=64 for every kernel family,
+    including 2-CTA/horizontal/vertical -- the earlier "vertical->64" was a 3-seed artifact)."""
+    return 128 if kind == "fp8" else 64
+
+
+def _static_chunk(K, nsplit, kind):
+    """The k-slice partition the cuBLAS heuristic implies: G-grain, uneven, remainder last."""
+    return _chunk_from_ns(K, nsplit, _grain(kind))
+
+
+_CALIB_MAX_NS = 256  # bounded split count for the wide runtime sweep
+
+
+def _splitk_candidate_chunks(K, nsplit, kind):
+    """Candidate partitions for the runtime-match path, in try-order: the heuristic nsplit
+    +/-1 first (the common case resolves fast), then a WIDE canonical sweep over nsplit
+    2..cap at the grain(s) -- the heuristic's split count can be off by more than 1, so the
+    narrow window alone falsely rejects reconstructable shapes. Grains: fp16/bf16 = 64; fp8 =
+    128 then 64. Deduped by chunk."""
+    grains = (64, ) if kind != "fp8" else (128, 64)
+    chunks, seen = [], set()
+
+    def add(ns, G):
+        if ns < 2:
+            return
+        chunk = _chunk_from_ns(K, ns, G)
+        if G <= chunk < K and chunk not in seen:
+            seen.add(chunk)
+            chunks.append(chunk)
+
+    for ns in (nsplit, nsplit - 1, nsplit + 1):  # near the heuristic first
+        add(ns, _grain(kind))
+    for G in grains:                             # then the wide sweep
+        cap = min((K + G - 1) // G, _CALIB_MAX_NS)
+        for ns in range(2, cap + 1):
+            add(ns, G)
+    return chunks
+
+
+def _make_inputs(M, N, K, kind, seed):
+    """Order-sensitive inputs (magnitude spread + alternating sign along K) so the K
+    reduction order shows up in the output bits. Magnitudes are kept in range so the
+    output stays finite -- for fp8 the values must fit e4m3 (max 448)."""
+    torch.manual_seed(seed)
+    sign = torch.where(torch.arange(K, device=DEVICE) % 2 == 0, 1.0, -1.0).unsqueeze(0)
+    if kind == "fp8":
+        scale = torch.logspace(-1, 1, K, device=DEVICE, dtype=torch.float32).unsqueeze(0)  # 0.1..10, fp8-safe
+        a = (torch.randn(M, K, device=DEVICE) * scale * sign).to(torch.float8_e4m3fn)
+        b = (torch.randn(N, K, device=DEVICE) * 0.25).to(torch.float8_e4m3fn).t()  # [K,N] col-major
+        return a, b
+    dt = torch.bfloat16 if kind == "bf16" else torch.float16
+    scale = torch.logspace(-3, 3, K, device=DEVICE, dtype=torch.float32).unsqueeze(0)
+    a = (torch.randn(M, K, device=DEVICE) * scale * sign).to(dt)
+    b = (torch.randn(K, N, device=DEVICE) * 0.05).to(dt)
+    return a, b
+
+
+def _bits_eq(x, y):
+    return torch.equal(x.contiguous().view(torch.uint8), y.contiguous().view(torch.uint8))
+
+
+def _aligned(M, N, K, kind):
+    """Contiguous-dim alignment cuBLAS needs to stay on its reconstructable nvjet path.
+    fp16/bf16: K%8==0 and N%8==0 (M free). fp8: all dims %16."""
+    if kind == "fp8":
+        return M % 16 == 0 and N % 16 == 0 and K % 16 == 0
+    return K % 8 == 0 and N % 8 == 0
+
+
+def _is_static_exact(kind, nsplit, aligned, M, N):
+    """Can we reconstruct from the heuristic ALONE (no runtime byte-compare) and be sure it
+    is bit-exact? Measured on GB300/sm_100:
+      - fp16/bf16 aligned: yes (plain and split-K at G=64@heur both match);
+      - fp8 large-output plain (ceil(M/64)*ceil(N/64) >= 64, nsplit==1): yes;
+      - fp8 skinny (small output): NO -- even at SPLITK_NUM==1 cuBLAS may use a cluster kernel
+        that reduces K across CTAs, which a single-accumulator/two-pass Triton kernel cannot
+        bit-match; and fp8 split-K vertical is not reproducible -> defer to a runtime match;
+      - fp16/bf16 non-aligned: NO (CUTLASS; K=16 variants reconstruct, s1688/odd-K do not)."""
+    if not aligned:
+        return False
+    if kind in ("fp16", "bf16"):
+        return True
+    tiles = ((M + 63) // 64) * ((N + 63) // 64)
+    return nsplit <= 1 and tiles >= 64  # fp8: only the large-output plain subset is static-safe
+
+
+def _reconstruct(a, b, out_dtype, plan, sa=1.0, sb=1.0):
+    mode, chunk = plan
+    if mode == "plain":
+        return _triton_plain(a, b, out_dtype, sa=sa, sb=sb)
+    return _triton_splitk(a, b, chunk, out_dtype, sa=sa, sb=sb)
+
+
+def _calibrate(M, N, K, kind, out_dtype):
+    """RUNTIME match: find the reconstruction that bit-matches cuBLAS run directly, verified
+    on _SEEDS order-sensitive seeds. Returns ("plain",None) or ("split",chunk); raises
+    CublasUnsupportedShape if nothing matches. cuBLAS's choice is a function of the shape
+    (not the data), so one calibration serves all future inputs of that shape."""
+    refs, nsplit = [], 1
+    for i, s in enumerate(_SEEDS):
+        a, b = _make_inputs(M, N, K, kind, s)
+        d, ns = _cublas_direct(a, b, kind, out_dtype)
+        refs.append((a, b, d))
+        if i == 0:
+            nsplit = ns
+
+    if nsplit <= 1:  # cuBLAS runs a plain GEMM
+        if all(_bits_eq(_triton_plain(a, b, out_dtype), d) for a, b, d in refs):
+            return ("plain", None)
+        raise CublasUnsupportedShape(f"{M}x{N}x{K} {kind}: plain reconstruction does not match cuBLAS")
+
+    a0, b0, d0 = refs[0]
+    for chunk in _splitk_candidate_chunks(K, nsplit, kind):  # cuBLAS runs split-K
+        c0 = _triton_splitk(a0, b0, chunk, out_dtype)
+        if c0 is None or not _bits_eq(c0, d0):
+            continue  # seed-0 prefilter: keeps the wide nsplit sweep cheap
+        if all(_bits_eq(_triton_splitk(a, b, chunk, out_dtype), d) for a, b, d in refs[1:]):
+            return ("split", chunk)
+    raise CublasUnsupportedShape(f"{M}x{N}x{K} {kind}: no split-K recipe matches cuBLAS (nsplit={nsplit})")
+
+
+def _resolve(a, b, kind, out_dtype, enable_runtime_match):
+    """Reconstruction plan for this shape (cached). Static-exact shapes are planned from the
+    heuristic alone (no GEMM run). Others need a runtime byte-compare: with
+    enable_runtime_match they are calibrated against cuBLAS; without, raise
+    CublasNeedRuntimeMatch."""
+    M, K = a.shape
+    N = b.shape[1]
+    key = (M, N, K, kind, out_dtype)
+    if key in _PLAN:
+        origin, plan = _PLAN[key]  # origin: "static" | "runtime" | "unsupported"
+        if origin == "unsupported":
+            raise CublasUnsupportedShape(f"{M}x{N}x{K} {kind}: unsupported (cached)")
+        if origin == "runtime" and not enable_runtime_match:
+            raise CublasNeedRuntimeMatch(f"{M}x{N}x{K} {kind}: needs a runtime match (cached)")
+        return plan
+
+    nsplit = _cublas_direct(a, b, kind, out_dtype, execute=False)[1]  # static: heuristic only, no GEMM run
+    if _is_static_exact(kind, nsplit, _aligned(M, N, K, kind), M, N):
+        plan = ("plain", None) if nsplit <= 1 else ("split", _static_chunk(K, nsplit, kind))
+        _PLAN[key] = ("static", plan)
+        return plan
+
+    if not enable_runtime_match:
+        raise CublasNeedRuntimeMatch(f"{M}x{N}x{K} {kind}: not statically guaranteed; "
+                                     f"re-call with enable_runtime_match=True")  # not cached: unknown until runtime
+    try:
+        plan = _calibrate(M, N, K, kind, out_dtype)
+    except CublasUnsupportedShape:
+        _PLAN[key] = ("unsupported", None)  # even a runtime match found nothing; cache the negative
+        raise
+    _PLAN[key] = ("runtime", plan)
+    return plan
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+def cublas_equivalent_gemm(a: torch.Tensor, b: torch.Tensor, out_dtype: torch.dtype | None = None,
+                           enable_runtime_match: bool = False) -> torch.Tensor:
+    """fp16/bf16 GEMM, bit-identical to cuBLAS. `a` is [M,K], `b` is [K,N].
+
+    Static by default: the reconstruction is planned from the cuBLAS heuristic alone (no GEMM
+    run). Aligned fp16/bf16 is static-exact. A shape that is not statically guaranteed
+    (non-aligned) raises CublasNeedRuntimeMatch -- unless `enable_runtime_match=True`, which
+    byte-compares candidates against cuBLAS and returns the match or raises
+    CublasUnsupportedShape."""
+    kind = _kind_of(a)
+    if kind == "fp8":
+        raise ValueError("use cublas_equivalent_scaled_mm for fp8")
+    out_dtype = out_dtype or a.dtype
+    plan = _resolve(a, b, kind, out_dtype, enable_runtime_match)
+    return _reconstruct(a, b, out_dtype, plan)
+
+
+def cublas_equivalent_scaled_mm(a: torch.Tensor, b: torch.Tensor, scale_a: float = 1.0, scale_b: float = 1.0,
+                                out_dtype: torch.dtype = torch.float16,
+                                enable_runtime_match: bool = False) -> torch.Tensor:
+    """fp8 (e4m3) GEMM, bit-identical to cuBLAS. `a` is [M,K], `b` is [K,N] column-major
+    (i.e. from `w.t()`); scales are scalars.
+
+    fp8 plain is static-exact. fp8 split-K is NOT statically guaranteed (the vertical/cluster
+    kernel is not bit-reproducible) -> raises CublasNeedRuntimeMatch unless
+    `enable_runtime_match=True`, which byte-compares against cuBLAS and returns the match or
+    raises CublasUnsupportedShape (vertical split-K)."""
+    plan = _resolve(a, b, "fp8", out_dtype, enable_runtime_match)
+    return _reconstruct(a, b, out_dtype, plan, sa=scale_a, sb=scale_b)
+
+
+# --------------------------------------------------------------------------- #
+# Self-check
+# --------------------------------------------------------------------------- #
+def _check_one(kind, M, N, K):
+    """Classify + verify one shape: try static first; if it needs a runtime match, retry with
+    enable_runtime_match=True. Returns (class, bit_ok) where class is static/runtime/unsupported."""
+    a, b = _make_inputs(M, N, K, kind, 7)
+    ref = cublas_matmul(a, b, torch.float16 if kind == "fp8" else None)
+    call = (lambda rt: cublas_equivalent_scaled_mm(a, b, 1.0, 1.0, torch.float16, enable_runtime_match=rt)) \
+        if kind == "fp8" else (lambda rt: cublas_equivalent_gemm(a, b, enable_runtime_match=rt))
+    try:
+        return "static", _bits_eq(call(False), ref)
+    except CublasNeedRuntimeMatch:
+        pass
+    try:
+        return "runtime", _bits_eq(call(True), ref)
+    except CublasUnsupportedShape:
+        return "unsupported", None
+
+
+def verify():
+    if not torch.cuda.is_available():
+        print("no CUDA GPU; verify() needs one.")
+        return
+    print(f"device: {torch.cuda.get_device_name()} | cap {torch.cuda.get_device_capability()} | "
+          f"cuda {torch.version.cuda}")
+    print("class = static (heuristic only) / runtime (byte-compare) / unsupported; then vs cuBLAS-direct\n")
+
+    shapes = [("fp16", 4096, 4096, 4096), ("fp16", 2048, 2048, 512), ("fp16", 16, 16384, 16384),
+              ("fp16", 64, 64, 32768), ("fp16", 128, 128, 16384), ("fp8", 4096, 4096, 4096),
+              ("fp8", 8192, 8192, 8192), ("fp8", 64, 64, 65536), ("fp8", 128, 128, 65536), ("fp8", 16, 64, 131072)]
+    n_ok = n_static = n_runtime = n_unsup = 0
+    for (kind, M, N, K) in shapes:
+        cls, ok = _check_one(kind, M, N, K)
+        n_static += int(cls == "static")
+        n_runtime += int(cls == "runtime")
+        if cls == "unsupported":
+            n_unsup += 1
+            verdict = "UNSUPPORTED"
+        else:
+            n_ok += int(bool(ok))
+            verdict = "BIT-IDENTICAL" if ok else "DIFFER"
+        print(f"  {kind:4s} {M:5d}x{N:5d}x{K:6d}  {cls:11s}  {verdict}")
+
+    print(f"\nbit-identical {n_ok}/{n_static + n_runtime} | static {n_static} | runtime {n_runtime} | "
+          f"unsupported {n_unsup}")
+
+
+if __name__ == "__main__":
+    verify()

--- a/bitequiv/eval_cublas_equiv_gemm.py
+++ b/bitequiv/eval_cublas_equiv_gemm.py
@@ -26,6 +26,7 @@ import time
 
 import torch
 
+from bitequiv import cublas_equiv_gemm as _G
 from bitequiv.cublas_equiv_gemm import (
     CublasNeedRuntimeMatch,
     CublasUnsupportedShape,
@@ -42,37 +43,39 @@ def _bits_eq(x, y):
     return torch.equal(x.contiguous().view(torch.uint8), y.contiguous().view(torch.uint8))
 
 
-def _round_to(x, m):
-    return max(m, (x // m) * m)
+def random_shape(rng, dtypes, mode, max_dim, max_mn, max_k, fp8_round16):
+    """Draw a shape. Two modes, both free of the rounding and regime buckets an earlier
+    version had (those made ~98% of draws aligned, when only 1.6% of random shapes are, and
+    hid every hard family).
 
+      random  -- M, N, K independent uniform draws. This is the "any shape at all" case.
+      extreme -- M, N small and K large: the skinny+deep corner where cuBLAS reaches for
+                 split-K, and where its SIMT gemv fallbacks live. Uniform sampling barely
+                 visits it (only ~1.2% of random draws have a dim under 100), so it needs its
+                 own mode to be measured at all.
 
-def random_shape(rng, dtypes):
-    """A random, aligned matmul shape + dtype. Mixes plain (square/rect) and split-K
-    (skinny + deep) regimes, plus an occasional non-aligned fp16 to exercise the decline
-    path. fp16/bf16 need K%8==0 & N%8==0; fp8 needs all dims %16."""
+    `max_dim` / `max_mn` / `max_k` bound memory and run time; they are not restrictions on the
+    shape class. fp8 is the one place a rounding is justified: cuBLAS itself refuses fp8 unless
+    every dim is a multiple of 16, so with `fp8_round16` we sample uniformly among the shapes
+    it can actually run rather than spending the whole budget on shapes with no reference."""
     dtype = rng.choice(dtypes)
-    regime = rng.choices(["splitk", "plain", "nonaligned"], weights=[0.6, 0.35, 0.05], k=1)[0]
-
-    if regime == "splitk":  # skinny + deep -> cuBLAS tends to split K
-        small = rng.choice([16, 24, 32, 48, 64, 80, 96, 112, 128])
-        other = rng.choice([16, 32, 48, 64, 96, 128, 192, 256])
-        M, N = (small, other) if rng.random() < 0.5 else (other, small)
-        K = rng.choice([8192, 12288, 16384, 24576, 32768, 49152, 65536, 98304, 131072])
-    elif regime == "plain":  # larger output -> cuBLAS runs plain
-        M = rng.choice([256, 512, 768, 1024, 2048, 4096])
-        N = rng.choice([256, 512, 768, 1024, 2048, 4096])
-        K = rng.choice([256, 512, 1024, 2048, 4096, 8192])
-    else:  # deliberately non-aligned fp16 (odd N or K) -> cuBLAS uses CUTLASS; API should decline
-        dtype = "fp16"
-        M = rng.choice([16, 64, 512])
-        N = rng.choice([65, 129, 257, 513])
-        K = rng.choice([4096, 4097, 8192, 8195])
-
-    if dtype == "fp8":
-        M, N, K = _round_to(M, 16), _round_to(N, 16), _round_to(K, 16)
-    elif regime != "nonaligned":
-        N, K = _round_to(N, 8), _round_to(K, 8)
+    if mode == "extreme":
+        M, N, K = rng.randint(1, max_mn), rng.randint(1, max_mn), rng.randint(1, max_k)
+    else:
+        M, N, K = rng.randint(1, max_dim), rng.randint(1, max_dim), rng.randint(1, max_k)
+    if dtype == "fp8" and fp8_round16:
+        M, N, K = (max(16, (v // 16) * 16) for v in (M, N, K))
     return M, N, K, dtype
+
+
+def operand_bytes(M, N, K, dtype):
+    """Device memory the operands plus the fp16 output need, ignoring any split-K workspace."""
+    elem = 1 if dtype == "fp8" else 2
+    return (M * K + K * N) * elem + M * N * 2
+
+
+def _is_oom(exc):
+    return isinstance(exc, torch.cuda.OutOfMemoryError) or "out of memory" in str(exc).lower()
 
 
 def make_inputs(M, N, K, dtype, seed, mode):
@@ -100,113 +103,199 @@ def make_inputs(M, N, K, dtype, seed, mode):
     return af.to(dt), bf.to(dt)
 
 
+def dtype_kind(dtype):
+    """The key the plan cache uses for this eval dtype."""
+    return "fp8" if dtype == "fp8" else ("bf16" if dtype == "bf16" else "fp16")
+
+
 def our_api(a, b, dtype, out_dtype, enable_rt):
     if dtype == "fp8":
         return cublas_equivalent_scaled_mm(a, b, 1.0, 1.0, out_dtype, enable_runtime_match=enable_rt)
     return cublas_equivalent_gemm(a, b, out_dtype, enable_runtime_match=enable_rt)
 
 
-def run(timeout, report_every, R, dtypes, seed, enable_rt):
+def load_done(path):
+    """Resume support: the (M,N,K,dtype) keys already recorded in a shape log."""
+    done = set()
+    if not path or not os.path.exists(path):
+        return done
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+                done.add((r["M"], r["N"], r["K"], r["dtype"]))
+            except Exception:
+                pass  # a torn last line from a kill; the shape just gets redrawn
+    return done
+
+
+def run(timeout, report_every, R, dtypes, seed, enable_rt, mode, max_dim, max_mn, max_k, fp8_round16, max_bytes,
+        shape_log):
     rng = random.Random(seed)
     mm_path = f"/tmp/cublas_equiv_mismatches_{os.getpid()}.jsonl"
-    mm_file = open(mm_path, "w")
+    mm_file = open(mm_path, "a")
+    done = load_done(shape_log)
+    sf = open(shape_log, "a") if shape_log else None
 
-    st = {"shapes": 0, "cmp": 0, "match": 0, "mismatch": 0, "no_ref": 0, "nonfinite": 0, "error": 0}
-    # distinct shapes by class: static (heuristic only) / runtime (byte-compare) / need-rt (skipped in
-    # static-only mode) / unsupported (no reconstruction even with a runtime match)
-    seen_static, seen_runtime, seen_needrt, seen_unsup = set(), set(), set(), set()
+    st = {"drawn": 0, "cmp": 0, "match": 0, "mismatch": 0, "no_ref": 0, "nonfinite": 0, "error": 0,
+          "too_big": 0, "oom": 0, "dup": 0}
+    # distinct shapes by outcome: static (heuristic only) / runtime (byte-compare) / need-rt
+    # (skipped in static-only mode) / unsupported (no reconstruction even with a runtime match)
+    seen_static, seen_pseudo, seen_runtime, seen_needrt, seen_unsup = set(), set(), set(), set(), set()
     t0 = time.time()
     last = t0
 
     print(f"device: {torch.cuda.get_device_name()} | dtypes={dtypes} R={R} timeout={timeout}s "
           f"enable_runtime_match={enable_rt}")
-    print(f"mismatches -> {mm_path}\n", flush=True)
+    if mode == "extreme":
+        print(f"EXTREME shapes: M,N ~ uniform[1,{max_mn}], K ~ uniform[1,{max_k}] -- the skinny+deep "
+              f"split-K corner")
+    else:
+        print(f"UNRESTRICTED shapes: M,N ~ uniform[1,{max_dim}], K ~ uniform[1,{max_k}], independent, "
+              f"no rounding, no regimes")
+    if "fp8" in dtypes and fp8_round16:
+        print("fp8 draws rounded to multiples of 16 -- cuBLAS itself will not run fp8 otherwise")
+    print(f"memory cap {max_bytes / 2**30:.1f} GiB/shape | resumed with {len(done)} shapes already done")
+    print(f"mismatches -> {mm_path} | shape log -> {shape_log}\n", flush=True)
 
     def report(tag):
         el = time.time() - t0
         scmp = st["match"] + st["mismatch"]
         rate = (100.0 * st["match"] / scmp) if scmp else 100.0
-        classified = len(seen_static) + len(seen_runtime) + len(seen_needrt) + len(seen_unsup)
-        sfrac = (100.0 * len(seen_static) / classified) if classified else 0.0
-        print(f"[{tag} {el:6.0f}s] shapes={st['shapes']} cmp={st['cmp']} "
-              f"bit-consistent={rate:6.2f}% ({st['match']}/{scmp}) mismatch={st['mismatch']} | "
-              f"static={len(seen_static)} runtime={len(seen_runtime)} needRT={len(seen_needrt)} "
-              f"unsup={len(seen_unsup)} static-frac={sfrac:5.1f}% | "
-              f"no_ref={st['no_ref']} nonfinite={st['nonfinite']} err={st['error']}", flush=True)
+        recon = len(seen_static) + len(seen_pseudo) + len(seen_runtime)
+        classified = recon + len(seen_needrt) + len(seen_unsup)
+        cov = (100.0 * recon / classified) if classified else 0.0
+        print(f"[{tag} {el:6.0f}s] drawn={st['drawn']} classified={classified} "
+              f"RECONSTRUCTABLE={cov:5.1f}% ({recon}/{classified}) | "
+              f"static={len(seen_static)} pseudo={len(seen_pseudo)} runtime={len(seen_runtime)} "
+              f"needRT={len(seen_needrt)} unsup={len(seen_unsup)} | bit-consistent={rate:6.2f}% ({st['match']}/{scmp}) "
+              f"mismatch={st['mismatch']} | no_ref={st['no_ref']} too_big={st['too_big']} "
+              f"oom={st['oom']} nonfinite={st['nonfinite']} err={st['error']}", flush=True)
+
+    def log_shape(M, N, K, dtype, outcome, bit_ok, nsplit=None):
+        if sf is None:
+            return
+        sf.write(json.dumps({"M": M, "N": N, "K": K, "dtype": dtype, "outcome": outcome,
+                             "bit_ok": bit_ok, "nsplit": nsplit}) + "\n")
+        sf.flush()
+        os.fsync(sf.fileno())
 
     while time.time() - t0 < timeout:
-        M, N, K, dtype = random_shape(rng, dtypes)
+        M, N, K, dtype = random_shape(rng, dtypes, mode, max_dim, max_mn, max_k, fp8_round16)
         key = (M, N, K, dtype)
+        st["drawn"] += 1
+        if key in done:
+            st["dup"] += 1
+            continue
+        done.add(key)
+        if operand_bytes(M, N, K, dtype) > max_bytes:
+            st["too_big"] += 1  # resource skip, not a shape-class skip
+            continue
         out_dtype = torch.float16 if dtype == "fp8" else (torch.bfloat16 if dtype == "bf16" else torch.float16)
-        st["shapes"] += 1
         use_rt = None  # per-shape mode, decided on the first comparable input
-        for r in range(R):
-            s = 100003 + st["shapes"] * 131 + r  # disjoint from the API's calibration seeds
-            imode = "order" if (r % 2 == 0) else "plain"
-            try:
-                a, b = make_inputs(M, N, K, dtype, s, imode)
-            except Exception:
-                st["error"] += 1
-                break
-            try:
-                ref = cublas_matmul(a, b, out_dtype)
-            except (CublasUnsupportedShape, Exception):
-                st["no_ref"] += 1  # cuBLAS itself has no algo (e.g. unrunnable shape)
-                break
-            if not torch.isfinite(ref.float()).all():
-                st["nonfinite"] += 1  # overflow -> byte-compare is meaningless, skip this input
-                continue
-            try:
-                if use_rt is None:  # classify the shape: static, else need-runtime
-                    try:
-                        out = our_api(a, b, dtype, out_dtype, False)
-                        use_rt = False
-                        seen_static.add(key)
-                    except CublasNeedRuntimeMatch:
-                        if not enable_rt:
-                            seen_needrt.add(key)
-                            break  # static-only mode: count it, do not compare
-                        out = our_api(a, b, dtype, out_dtype, True)
-                        use_rt = True
-                        seen_runtime.add(key)
+        outcome, bit_ok = None, None
+        try:
+            for r in range(R):
+                s = 100003 + st["drawn"] * 131 + r  # disjoint from the API's calibration seeds
+                imode = "order" if (r % 2 == 0) else "plain"
+                try:
+                    a, b = make_inputs(M, N, K, dtype, s, imode)
+                except Exception as e:
+                    if _is_oom(e):
+                        raise
+                    st["error"] += 1
+                    outcome = "error"
+                    break
+                try:
+                    ref = cublas_matmul(a, b, out_dtype)
+                except Exception as e:
+                    if _is_oom(e):
+                        raise
+                    st["no_ref"] += 1  # cuBLAS itself has no algo for this shape
+                    outcome = "no_ref"
+                    break
+                if not torch.isfinite(ref.float()).all():
+                    st["nonfinite"] += 1  # overflow -> byte-compare is meaningless, skip this input
+                    continue
+                try:
+                    if use_rt is None:  # first comparable input: let the API pick a tier
+                        try:
+                            out = our_api(a, b, dtype, out_dtype, False)
+                            use_rt = False
+                        except CublasNeedRuntimeMatch:
+                            if not enable_rt:
+                                seen_needrt.add(key)
+                                outcome = "needrt"
+                                break  # static-only mode: count it, do not compare
+                            out = our_api(a, b, dtype, out_dtype, True)
+                            use_rt = True
+                        # which tier actually resolved it is recorded in the plan cache
+                        origin = _G._PLAN.get((M, N, K, dtype_kind(dtype), out_dtype), ("?", None))[0]
+                        outcome = origin
+                        {"static": seen_static, "pseudo-static": seen_pseudo,
+                         "runtime": seen_runtime}.get(origin, seen_runtime).add(key)
+                    else:
+                        out = our_api(a, b, dtype, out_dtype, use_rt)
+                except CublasUnsupportedShape:
+                    seen_unsup.add(key)
+                    outcome = "unsupported"
+                    break
+                except Exception as e:
+                    if _is_oom(e):
+                        raise
+                    st["error"] += 1
+                    outcome = "error"
+                    mm_file.write(json.dumps({"M": M, "N": N, "K": K, "dtype": dtype, "seed": s, "mode": imode,
+                                              "error": f"{type(e).__name__}: {str(e)[:120]}"}) + "\n")
+                    mm_file.flush()
+                    break
+                st["cmp"] += 1
+                if _bits_eq(out, ref):
+                    st["match"] += 1
+                    bit_ok = True if bit_ok is None else bit_ok
                 else:
-                    out = our_api(a, b, dtype, out_dtype, use_rt)
-            except CublasUnsupportedShape:
-                seen_unsup.add(key)
-                break
-            except Exception as e:
-                st["error"] += 1
-                mm_file.write(json.dumps({"M": M, "N": N, "K": K, "dtype": dtype, "seed": s, "mode": imode,
-                                          "error": f"{type(e).__name__}: {str(e)[:120]}"}) + "\n")
-                mm_file.flush()
-                break
-            st["cmp"] += 1
-            if _bits_eq(out, ref):
-                st["match"] += 1
-            else:
-                st["mismatch"] += 1
-                diff = (out.float() - ref.float()).abs()
-                mm_file.write(json.dumps({
-                    "M": M, "N": N, "K": K, "dtype": dtype, "seed": s, "mode": imode,
-                    "class": "runtime" if use_rt else "static", "max_abs_diff": float(diff.max()),
-                    "n_diff": int((diff > 0).sum()), "out_dtype": str(out_dtype)}) + "\n")
-                mm_file.flush()
+                    st["mismatch"] += 1
+                    bit_ok = False
+                    diff = (out.float() - ref.float()).abs()
+                    mm_file.write(json.dumps({
+                        "M": M, "N": N, "K": K, "dtype": dtype, "seed": s, "mode": imode,
+                        "class": outcome, "max_abs_diff": float(diff.max()),
+                        "n_diff": int((diff > 0).sum()), "out_dtype": str(out_dtype)}) + "\n")
+                    mm_file.flush()
+        except Exception as e:  # OOM anywhere in the shape: drop it and keep the sweep alive
+            if not _is_oom(e):
+                raise
+            st["oom"] += 1
+            outcome = "oom"
+            torch.cuda.empty_cache()
+        log_shape(M, N, K, dtype, outcome, bit_ok)
         if time.time() - last >= report_every:
             report("run")
             last = time.time()
 
     mm_file.close()
+    if sf is not None:
+        sf.close()
     print()
     report("DONE")
-    classified = len(seen_static) + len(seen_runtime) + len(seen_needrt) + len(seen_unsup)
-    sfrac = (100.0 * len(seen_static) / classified) if classified else 0.0
+    recon = len(seen_static) + len(seen_pseudo) + len(seen_runtime)
+    classified = recon + len(seen_needrt) + len(seen_unsup)
     scmp = st["match"] + st["mismatch"]
-    print(f"\nstatic-reconstructable (cuBLAS heuristic alone, no GEMM run): {len(seen_static)}/{classified} = "
-          f"{sfrac:.1f}% of shapes")
-    print(f"  runtime-match: {len(seen_runtime)} | need-runtime(skipped): {len(seen_needrt)} | "
-          f"unsupported: {len(seen_unsup)}")
-    print(f"bit-consistent (static + runtime): {st['match']}/{scmp} = "
+    print(f"\nRECONSTRUCTABLE (a bit-identical Triton GEMM exists and we found it): "
+          f"{recon}/{classified} = {(100.0 * recon / classified) if classified else 0.0:.2f}% "
+          f"of the random shapes cuBLAS can run")
+    print(f"  static        (heuristic alone, nothing executed):    {len(seen_static)}")
+    print(f"  pseudo-static (recipe read off the launched kernel):  {len(seen_pseudo)}")
+    print(f"  runtime       (recipe found by byte-compare search):  {len(seen_runtime)}")
+    print(f"  need-runtime  (skipped in static-only mode):          {len(seen_needrt)}")
+    print(f"  DECLINED      (no reconstruction found):              {len(seen_unsup)}")
+    print(f"bit-consistent on the reconstructed ones: {st['match']}/{scmp} = "
           f"{(100.0 * st['match'] / scmp) if scmp else 100.0:.3f}%")
+    print(f"excluded: no_ref={st['no_ref']} (cuBLAS itself cannot run it) too_big={st['too_big']} "
+          f"oom={st['oom']} err={st['error']}")
     if st["mismatch"]:
         print(f"{st['mismatch']} mismatches ({{static, runtime}} that were not bit-identical) -> {mm_path}")
 
@@ -221,12 +310,30 @@ def main():
     ap.add_argument("--enable-runtime-match", action="store_true",
                     help="also byte-compare the need-runtime shapes (default: static only -> they are "
                          "counted as need-runtime and skipped)")
+    ap.add_argument("--shape-mode", choices=("random", "extreme"), default="random",
+                    help="random: M,N,K independent uniform draws. extreme: M,N small and K large, the "
+                         "skinny+deep corner where cuBLAS uses split-K and its gemv fallbacks")
+    ap.add_argument("--max-dim", type=int, default=8192,
+                    help="bound on M and N in random mode. Bounds memory and run time only -- there is "
+                         "no rounding or alignment restriction on the shape")
+    ap.add_argument("--max-mn", type=int, default=256, help="bound on M and N in extreme mode")
+    ap.add_argument("--max-k", type=int, default=0,
+                    help="bound on K; 0 means max-dim in random mode and 400000 in extreme mode")
+    ap.add_argument("--no-fp8-round16", action="store_true",
+                    help="do NOT round fp8 draws to multiples of 16. cuBLAS refuses fp8 otherwise, so "
+                         "nearly every draw becomes no_ref; useful only to measure that rate")
+    ap.add_argument("--max-gib", type=float, default=6.0,
+                    help="skip a shape whose operands+output exceed this many GiB (resource skip)")
+    ap.add_argument("--shape-log", type=str, default="",
+                    help="append one jsonl row per distinct shape here; also used to resume")
     args = ap.parse_args()
     if not torch.cuda.is_available():
         print("no CUDA GPU; this eval needs one.")
         return
     dtypes = [d.strip() for d in args.dtypes.split(",") if d.strip()]
-    run(args.timeout, args.report_every, args.R, dtypes, args.seed, args.enable_runtime_match)
+    max_k = args.max_k or (400000 if args.shape_mode == "extreme" else args.max_dim)
+    run(args.timeout, args.report_every, args.R, dtypes, args.seed, args.enable_runtime_match, args.shape_mode,
+        args.max_dim, args.max_mn, max_k, not args.no_fp8_round16, int(args.max_gib * 2**30), args.shape_log)
 
 
 if __name__ == "__main__":

--- a/bitequiv/eval_cublas_equiv_gemm.py
+++ b/bitequiv/eval_cublas_equiv_gemm.py
@@ -1,0 +1,233 @@
+"""Fuzz evaluation: is the cuBLAS-equivalent Triton GEMM really bit-identical to cuBLAS?
+
+A timeout-bounded infinite loop. Each round:
+  1. draw a random matmul shape (M, N, K) + dtype;
+  2. draw R random input tensors for it;
+  3. feed each input to BOTH our API and cuBLAS run directly, and check the two
+     outputs are byte-for-byte equal.
+
+Every mismatch (our API returned a result that is NOT bit-identical to cuBLAS -- a
+soundness bug) is written to a temp file for debugging. A shape the API declines
+(`CublasUnsupportedShape`) is counted separately: that is an honest "no
+reconstruction", NOT a mismatch. The bit-consistency rate is reported periodically.
+
+IMPORTANT: the fuzz inputs use seeds disjoint from the ones the API calibrates on,
+so this tests inputs the reconstruction was NOT tuned for.
+
+Run:
+  python -m bitequiv.eval_cublas_equiv_gemm --timeout 300
+  python -m bitequiv.eval_cublas_equiv_gemm --timeout 3600 --dtypes fp16,fp8 --R 5
+"""
+import argparse
+import json
+import os
+import random
+import time
+
+import torch
+
+from bitequiv.cublas_equiv_gemm import (
+    CublasNeedRuntimeMatch,
+    CublasUnsupportedShape,
+    cublas_equivalent_gemm,
+    cublas_equivalent_scaled_mm,
+    cublas_matmul,
+)
+
+DEVICE = "cuda"
+_F8 = torch.float8_e4m3fn
+
+
+def _bits_eq(x, y):
+    return torch.equal(x.contiguous().view(torch.uint8), y.contiguous().view(torch.uint8))
+
+
+def _round_to(x, m):
+    return max(m, (x // m) * m)
+
+
+def random_shape(rng, dtypes):
+    """A random, aligned matmul shape + dtype. Mixes plain (square/rect) and split-K
+    (skinny + deep) regimes, plus an occasional non-aligned fp16 to exercise the decline
+    path. fp16/bf16 need K%8==0 & N%8==0; fp8 needs all dims %16."""
+    dtype = rng.choice(dtypes)
+    regime = rng.choices(["splitk", "plain", "nonaligned"], weights=[0.6, 0.35, 0.05], k=1)[0]
+
+    if regime == "splitk":  # skinny + deep -> cuBLAS tends to split K
+        small = rng.choice([16, 24, 32, 48, 64, 80, 96, 112, 128])
+        other = rng.choice([16, 32, 48, 64, 96, 128, 192, 256])
+        M, N = (small, other) if rng.random() < 0.5 else (other, small)
+        K = rng.choice([8192, 12288, 16384, 24576, 32768, 49152, 65536, 98304, 131072])
+    elif regime == "plain":  # larger output -> cuBLAS runs plain
+        M = rng.choice([256, 512, 768, 1024, 2048, 4096])
+        N = rng.choice([256, 512, 768, 1024, 2048, 4096])
+        K = rng.choice([256, 512, 1024, 2048, 4096, 8192])
+    else:  # deliberately non-aligned fp16 (odd N or K) -> cuBLAS uses CUTLASS; API should decline
+        dtype = "fp16"
+        M = rng.choice([16, 64, 512])
+        N = rng.choice([65, 129, 257, 513])
+        K = rng.choice([4096, 4097, 8192, 8195])
+
+    if dtype == "fp8":
+        M, N, K = _round_to(M, 16), _round_to(N, 16), _round_to(K, 16)
+    elif regime != "nonaligned":
+        N, K = _round_to(N, 8), _round_to(K, 8)
+    return M, N, K, dtype
+
+
+def make_inputs(M, N, K, dtype, seed, mode):
+    """Random inputs. `order` mode = magnitude spread + alternating sign along K (stresses
+    the K reduction order -- the hardest test for a split-K reconstruction); `plain` mode =
+    ordinary small-scale gaussians. Magnitudes stay in range so the output is finite (fp8
+    values must fit e4m3, max 448). fp8 returns b as [K,N] column-major."""
+    torch.manual_seed(seed)
+    sign = torch.where(torch.arange(K, device=DEVICE) % 2 == 0, 1.0, -1.0).unsqueeze(0)
+    if mode == "order":
+        lo, hi = (-1, 1) if dtype == "fp8" else (-3, 3)  # fp8: 0.1..10 (no overflow)
+        scale = torch.logspace(lo, hi, K, device=DEVICE, dtype=torch.float32).unsqueeze(0)
+        af = torch.randn(M, K, device=DEVICE) * scale * sign
+        if dtype == "fp8":
+            bf = torch.randn(N, K, device=DEVICE) * 0.25
+        else:
+            bf = torch.randn(K, N, device=DEVICE) * 0.05
+    else:
+        af = torch.randn(M, K, device=DEVICE) * 0.3
+        bf = (torch.randn(N, K, device=DEVICE) if dtype == "fp8" else torch.randn(K, N, device=DEVICE)) * 0.3
+
+    if dtype == "fp8":
+        return af.to(_F8), bf.to(_F8).t()  # b -> [K,N] column-major
+    dt = torch.bfloat16 if dtype == "bf16" else torch.float16
+    return af.to(dt), bf.to(dt)
+
+
+def our_api(a, b, dtype, out_dtype, enable_rt):
+    if dtype == "fp8":
+        return cublas_equivalent_scaled_mm(a, b, 1.0, 1.0, out_dtype, enable_runtime_match=enable_rt)
+    return cublas_equivalent_gemm(a, b, out_dtype, enable_runtime_match=enable_rt)
+
+
+def run(timeout, report_every, R, dtypes, seed, enable_rt):
+    rng = random.Random(seed)
+    mm_path = f"/tmp/cublas_equiv_mismatches_{os.getpid()}.jsonl"
+    mm_file = open(mm_path, "w")
+
+    st = {"shapes": 0, "cmp": 0, "match": 0, "mismatch": 0, "no_ref": 0, "nonfinite": 0, "error": 0}
+    # distinct shapes by class: static (heuristic only) / runtime (byte-compare) / need-rt (skipped in
+    # static-only mode) / unsupported (no reconstruction even with a runtime match)
+    seen_static, seen_runtime, seen_needrt, seen_unsup = set(), set(), set(), set()
+    t0 = time.time()
+    last = t0
+
+    print(f"device: {torch.cuda.get_device_name()} | dtypes={dtypes} R={R} timeout={timeout}s "
+          f"enable_runtime_match={enable_rt}")
+    print(f"mismatches -> {mm_path}\n", flush=True)
+
+    def report(tag):
+        el = time.time() - t0
+        scmp = st["match"] + st["mismatch"]
+        rate = (100.0 * st["match"] / scmp) if scmp else 100.0
+        classified = len(seen_static) + len(seen_runtime) + len(seen_needrt) + len(seen_unsup)
+        sfrac = (100.0 * len(seen_static) / classified) if classified else 0.0
+        print(f"[{tag} {el:6.0f}s] shapes={st['shapes']} cmp={st['cmp']} "
+              f"bit-consistent={rate:6.2f}% ({st['match']}/{scmp}) mismatch={st['mismatch']} | "
+              f"static={len(seen_static)} runtime={len(seen_runtime)} needRT={len(seen_needrt)} "
+              f"unsup={len(seen_unsup)} static-frac={sfrac:5.1f}% | "
+              f"no_ref={st['no_ref']} nonfinite={st['nonfinite']} err={st['error']}", flush=True)
+
+    while time.time() - t0 < timeout:
+        M, N, K, dtype = random_shape(rng, dtypes)
+        key = (M, N, K, dtype)
+        out_dtype = torch.float16 if dtype == "fp8" else (torch.bfloat16 if dtype == "bf16" else torch.float16)
+        st["shapes"] += 1
+        use_rt = None  # per-shape mode, decided on the first comparable input
+        for r in range(R):
+            s = 100003 + st["shapes"] * 131 + r  # disjoint from the API's calibration seeds
+            imode = "order" if (r % 2 == 0) else "plain"
+            try:
+                a, b = make_inputs(M, N, K, dtype, s, imode)
+            except Exception:
+                st["error"] += 1
+                break
+            try:
+                ref = cublas_matmul(a, b, out_dtype)
+            except (CublasUnsupportedShape, Exception):
+                st["no_ref"] += 1  # cuBLAS itself has no algo (e.g. unrunnable shape)
+                break
+            if not torch.isfinite(ref.float()).all():
+                st["nonfinite"] += 1  # overflow -> byte-compare is meaningless, skip this input
+                continue
+            try:
+                if use_rt is None:  # classify the shape: static, else need-runtime
+                    try:
+                        out = our_api(a, b, dtype, out_dtype, False)
+                        use_rt = False
+                        seen_static.add(key)
+                    except CublasNeedRuntimeMatch:
+                        if not enable_rt:
+                            seen_needrt.add(key)
+                            break  # static-only mode: count it, do not compare
+                        out = our_api(a, b, dtype, out_dtype, True)
+                        use_rt = True
+                        seen_runtime.add(key)
+                else:
+                    out = our_api(a, b, dtype, out_dtype, use_rt)
+            except CublasUnsupportedShape:
+                seen_unsup.add(key)
+                break
+            except Exception as e:
+                st["error"] += 1
+                mm_file.write(json.dumps({"M": M, "N": N, "K": K, "dtype": dtype, "seed": s, "mode": imode,
+                                          "error": f"{type(e).__name__}: {str(e)[:120]}"}) + "\n")
+                mm_file.flush()
+                break
+            st["cmp"] += 1
+            if _bits_eq(out, ref):
+                st["match"] += 1
+            else:
+                st["mismatch"] += 1
+                diff = (out.float() - ref.float()).abs()
+                mm_file.write(json.dumps({
+                    "M": M, "N": N, "K": K, "dtype": dtype, "seed": s, "mode": imode,
+                    "class": "runtime" if use_rt else "static", "max_abs_diff": float(diff.max()),
+                    "n_diff": int((diff > 0).sum()), "out_dtype": str(out_dtype)}) + "\n")
+                mm_file.flush()
+        if time.time() - last >= report_every:
+            report("run")
+            last = time.time()
+
+    mm_file.close()
+    print()
+    report("DONE")
+    classified = len(seen_static) + len(seen_runtime) + len(seen_needrt) + len(seen_unsup)
+    sfrac = (100.0 * len(seen_static) / classified) if classified else 0.0
+    scmp = st["match"] + st["mismatch"]
+    print(f"\nstatic-reconstructable (cuBLAS heuristic alone, no GEMM run): {len(seen_static)}/{classified} = "
+          f"{sfrac:.1f}% of shapes")
+    print(f"  runtime-match: {len(seen_runtime)} | need-runtime(skipped): {len(seen_needrt)} | "
+          f"unsupported: {len(seen_unsup)}")
+    print(f"bit-consistent (static + runtime): {st['match']}/{scmp} = "
+          f"{(100.0 * st['match'] / scmp) if scmp else 100.0:.3f}%")
+    if st["mismatch"]:
+        print(f"{st['mismatch']} mismatches ({{static, runtime}} that were not bit-identical) -> {mm_path}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--timeout", type=float, default=300, help="run this many seconds, then stop")
+    ap.add_argument("--report-every", type=float, default=15, help="print the running rate every N seconds")
+    ap.add_argument("--R", type=int, default=5, help="random input tensors per shape")
+    ap.add_argument("--dtypes", type=str, default="fp16,fp8", help="comma list: fp16,fp8,bf16")
+    ap.add_argument("--seed", type=int, default=0, help="shape RNG seed (reproducible)")
+    ap.add_argument("--enable-runtime-match", action="store_true",
+                    help="also byte-compare the need-runtime shapes (default: static only -> they are "
+                         "counted as need-runtime and skipped)")
+    args = ap.parse_args()
+    if not torch.cuda.is_available():
+        print("no CUDA GPU; this eval needs one.")
+        return
+    dtypes = [d.strip() for d in args.dtypes.split(",") if d.strip()]
+    run(args.timeout, args.report_every, args.R, dtypes, args.seed, args.enable_runtime_match)
+
+
+if __name__ == "__main__":
+    main()

--- a/bitequiv/example_cublas_equiv_gemm.py
+++ b/bitequiv/example_cublas_equiv_gemm.py
@@ -1,0 +1,142 @@
+"""Example: how to use the cuBLAS-equivalent Triton GEMM API.
+
+Run:  python -m bitequiv.example_cublas_equiv_gemm
+
+Shows the fp16 and fp8 entry points, that the result is bit-identical to cuBLAS,
+and how to handle a shape that has no Triton reconstruction.
+
+`enable_runtime_match` is written explicitly at every call below. The default is
+`False` (static: reconstruct from the cuBLAS heuristic alone, no GEMM run); pass
+`True` to allow a one-time runtime byte-compare against cuBLAS for shapes that are
+not statically guaranteed.
+"""
+import torch
+
+from bitequiv.cublas_equiv_gemm import (
+    CublasNeedRuntimeMatch,
+    CublasUnsupportedShape,
+    cublas_equivalent_gemm,
+    cublas_equivalent_scaled_mm,
+    cublas_matmul,
+)
+
+DEVICE = "cuda"
+
+
+def _bit_equal(x, y):
+    return torch.equal(x.contiguous().view(torch.uint8), y.contiguous().view(torch.uint8))
+
+
+def example_fp16_plain():
+    """fp16 GEMM on a large shape -> cuBLAS runs a plain kernel; our Triton GEMM matches."""
+    M, N, K = 4096, 4096, 4096
+    a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
+    b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
+
+    out = cublas_equivalent_gemm(a, b, enable_runtime_match=False)  # static (default): heuristic only, no GEMM run
+    ref = cublas_matmul(a, b)                                       # cuBLAS's own output (the reference)
+    print(f"fp16 plain    {M}x{N}x{K}: bit-identical to cuBLAS = {_bit_equal(out, ref)}")
+
+
+def example_fp16_split_k():
+    """fp16 GEMM on a skinny+deep shape -> cuBLAS runs split-K; our Triton split-K matches.
+    The split count comes from the cuBLAS heuristic; the reconstruction is verified once
+    and cached, so calling it again for the same shape is pure Triton."""
+    M, N, K = 64, 64, 32768
+    a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
+    b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
+
+    out = cublas_equivalent_gemm(a, b, enable_runtime_match=False)  # static (default): aligned fp16 split-K is exact
+    ref = cublas_matmul(a, b)
+    print(f"fp16 split-K  {M}x{N}x{K}: bit-identical to cuBLAS = {_bit_equal(out, ref)}")
+
+
+def example_fp8_plain():
+    """fp8 (e4m3) GEMM, plain shape. `b` is [K,N] column-major (as produced by a weight
+    `w.t()`); scales are scalars, output defaults to fp16. fp8 plain is static-exact."""
+    M, N, K = 8192, 8192, 8192
+    a = (torch.randn(M, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn)
+    b = (torch.randn(N, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn).t()   # [K,N] column-major
+
+    out = cublas_equivalent_scaled_mm(a, b, scale_a=1.0, scale_b=1.0, out_dtype=torch.float16,
+                                      enable_runtime_match=False)  # static (default): large-output fp8 plain is exact
+    ref = cublas_matmul(a, b, out_dtype=torch.float16)
+    print(f"fp8  plain    {M}x{N}x{K}: bit-identical to cuBLAS = {_bit_equal(out, ref)}")
+
+
+def example_fp8_split_k_runtime():
+    """fp8 split-K is NOT statically guaranteed (the vertical/cluster kernel is not
+    bit-reproducible). By default the API returns need-runtime-match; pass
+    enable_runtime_match=True to let it byte-compare against cuBLAS and reconstruct (or raise
+    CublasUnsupportedShape for the vertical family)."""
+    M, N, K = 64, 64, 65536
+    a = (torch.randn(M, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn)
+    b = (torch.randn(N, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn).t()
+
+    try:                                          # static mode (default): heuristic only, no cuBLAS GEMM run
+        cublas_equivalent_scaled_mm(a, b, enable_runtime_match=False)
+        print(f"fp8  split-K  {M}x{N}x{K}: statically reconstructed")
+    except CublasNeedRuntimeMatch:
+        print(f"fp8  split-K  {M}x{N}x{K}: needs a runtime match (static mode declined)")
+
+    try:                                          # runtime mode: allow a one-time byte-compare against cuBLAS
+        out = cublas_equivalent_scaled_mm(a, b, enable_runtime_match=True)
+        print(f"fp8  split-K  {M}x{N}x{K}: with enable_runtime_match=True -> "
+              f"bit-identical = {_bit_equal(out, cublas_matmul(a, b))}")
+    except CublasUnsupportedShape:
+        out = cublas_matmul(a, b)                 # vertical split-K: fall back to cuBLAS
+        print(f"fp8  split-K  {M}x{N}x{K}: UNSUPPORTED -> fell back to cuBLAS")
+
+
+def example_cannot_match():
+    """Shapes where the cuBLAS heuristic's algo has NO bit-identical Triton reconstruction,
+    even with enable_runtime_match=True -> CublasUnsupportedShape (never a wrong result).
+
+    Two families cover essentially all of them:
+      1. fp16 non-aligned (odd N or odd K): cuBLAS switches to a CUTLASS kernel that either
+         uses an MMA with K=8 (`s1688`) or an odd-K reduction tail. Triton's `tl.dot` emits
+         K=16, so the base MMA groups/rounds the products differently -- unreproducible.
+      2. fp8 vertical / cluster split-K: cuBLAS reduces K across the cluster's CTAs in a
+         multi-level fp32 order; a tile-level two-pass split-K in Triton cannot emit that
+         order (differs by ~1 fp16 ulp in a few elements)."""
+    fp16_bad = [(64, 64, 257), (16, 65, 8192), (64, 129, 8192), (512, 513, 4096), (64, 64, 4097),
+                (128, 127, 16384), (33, 33, 15000)]
+    fp8_bad = [(16, 64, 65536), (16, 128, 65536), (32, 256, 65536), (32, 256, 131072), (32, 32, 16384)]
+
+    print("cannot-match (heuristic gives an algo, but no Triton reconstruction is bit-identical):")
+    print("  -- fp16 non-aligned -> CUTLASS s1688 (MMA K=8) / odd-K tail --")
+    for (M, N, K) in fp16_bad:
+        a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
+        b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
+        try:
+            cublas_equivalent_gemm(a, b, enable_runtime_match=True)
+            print(f"  fp16 {M}x{N}x{K}: reconstructed (unexpected)")
+        except CublasUnsupportedShape:
+            print(f"  fp16 {M}x{N}x{K}: UNSUPPORTED -> caller falls back to cuBLAS")
+
+    print("  -- fp8 vertical / cluster split-K -> cross-CTA K reduction --")
+    for (M, N, K) in fp8_bad:
+        a = (torch.randn(M, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn)
+        b = (torch.randn(N, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn).t()
+        try:
+            cublas_equivalent_scaled_mm(a, b, enable_runtime_match=True)
+            print(f"  fp8  {M}x{N}x{K}: reconstructed (unexpected)")
+        except CublasUnsupportedShape:
+            print(f"  fp8  {M}x{N}x{K}: UNSUPPORTED -> caller falls back to cuBLAS")
+
+
+def main():
+    if not torch.cuda.is_available():
+        print("no CUDA GPU; this example needs one.")
+        return
+    print(f"device: {torch.cuda.get_device_name()}\n")
+    example_fp16_plain()
+    example_fp16_split_k()
+    example_fp8_plain()
+    example_fp8_split_k_runtime()
+    print()
+    example_cannot_match()
+
+
+if __name__ == "__main__":
+    main()

--- a/bitequiv/example_cublas_equiv_gemm.py
+++ b/bitequiv/example_cublas_equiv_gemm.py
@@ -39,16 +39,25 @@ def example_fp16_plain():
 
 
 def example_fp16_split_k():
-    """fp16 GEMM on a skinny+deep shape -> cuBLAS runs split-K; our Triton split-K matches.
-    The split count comes from the cuBLAS heuristic; the reconstruction is verified once
-    and cached, so calling it again for the same shape is pure Triton."""
+    """fp16 GEMM on a skinny+deep shape -> cuBLAS runs split-K. Split-K is NOT statically
+    guaranteed for either dtype (about 1% of split-K shapes are not reproducible at any
+    partition, and nothing in the heuristic flags them), so it needs the runtime byte-compare.
+    The split count and the cut both come from the heuristic; the runtime step only gates that
+    residual, and the verified plan is cached, so later calls are pure Triton."""
     M, N, K = 64, 64, 32768
     a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
     b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
 
-    out = cublas_equivalent_gemm(a, b, enable_runtime_match=False)  # static (default): aligned fp16 split-K is exact
+    try:                                          # static mode (default): split-K declines
+        cublas_equivalent_gemm(a, b, enable_runtime_match=False)
+        print(f"fp16 split-K  {M}x{N}x{K}: statically reconstructed")
+    except CublasNeedRuntimeMatch:
+        print(f"fp16 split-K  {M}x{N}x{K}: needs a runtime match (static mode declined)")
+
+    out = cublas_equivalent_gemm(a, b, enable_runtime_match=True)
     ref = cublas_matmul(a, b)
-    print(f"fp16 split-K  {M}x{N}x{K}: bit-identical to cuBLAS = {_bit_equal(out, ref)}")
+    print(f"fp16 split-K  {M}x{N}x{K}: with enable_runtime_match=True -> "
+          f"bit-identical to cuBLAS = {_bit_equal(out, ref)}")
 
 
 def example_fp8_plain():
@@ -92,20 +101,22 @@ def example_cannot_match():
     """Shapes where the cuBLAS heuristic's algo has NO bit-identical Triton reconstruction,
     even with enable_runtime_match=True -> CublasUnsupportedShape (never a wrong result).
 
-    Two families cover essentially all of them:
+    Two families cover them:
       1. fp16 non-aligned (odd N or odd K): cuBLAS switches to a CUTLASS kernel that either
          uses an MMA with K=8 (`s1688`) or an odd-K reduction tail. Triton's `tl.dot` emits
-         K=16, so the base MMA groups/rounds the products differently -- unreproducible.
-      2. fp8 vertical / cluster split-K: cuBLAS reduces K across the cluster's CTAs in a
-         multi-level fp32 order; a tile-level two-pass split-K in Triton cannot emit that
-         order (differs by ~1 fp16 ulp in a few elements)."""
-    fp16_bad = [(64, 64, 257), (16, 65, 8192), (64, 129, 8192), (512, 513, 4096), (64, 64, 4097),
-                (128, 127, 16384), (33, 33, 15000)]
-    fp8_bad = [(16, 64, 65536), (16, 128, 65536), (32, 256, 65536), (32, 256, 131072), (32, 32, 16384)]
+         K=16, so the base MMA groups/rounds the products differently.
+      2. a split-K residual (~1.1% of aligned fp16 split-K, ~0.4% of fp8) where K is not a
+         whole number of k-tiles, so the last slice is a partial one: no K partition
+         reproduces these -- a wide sweep of thousands of alternative partitions per shape
+         found none. Strongly associated with K%64 != 0, but not decided by it, so it can
+         only be caught by the runtime byte-compare."""
+    fp16_nonaligned = [(64, 64, 257), (16, 65, 8192), (64, 129, 8192), (512, 513, 4096), (64, 64, 4097),
+                       (128, 127, 16384), (33, 33, 15000)]
+    fp16_partial_last_slice = [(96, 48, 175248), (64, 64, 116864), (64, 24, 116864), (64, 64, 219648)]
 
     print("cannot-match (heuristic gives an algo, but no Triton reconstruction is bit-identical):")
     print("  -- fp16 non-aligned -> CUTLASS s1688 (MMA K=8) / odd-K tail --")
-    for (M, N, K) in fp16_bad:
+    for (M, N, K) in fp16_nonaligned:
         a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
         b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
         try:
@@ -114,15 +125,15 @@ def example_cannot_match():
         except CublasUnsupportedShape:
             print(f"  fp16 {M}x{N}x{K}: UNSUPPORTED -> caller falls back to cuBLAS")
 
-    print("  -- fp8 vertical / cluster split-K -> cross-CTA K reduction --")
-    for (M, N, K) in fp8_bad:
-        a = (torch.randn(M, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn)
-        b = (torch.randn(N, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn).t()
+    print("  -- aligned fp16 split-K, partial last k-slice -> no partition reproduces it --")
+    for (M, N, K) in fp16_partial_last_slice:
+        a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
+        b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
         try:
-            cublas_equivalent_scaled_mm(a, b, enable_runtime_match=True)
-            print(f"  fp8  {M}x{N}x{K}: reconstructed (unexpected)")
+            cublas_equivalent_gemm(a, b, enable_runtime_match=True)
+            print(f"  fp16 {M}x{N}x{K}: reconstructed (unexpected)")
         except CublasUnsupportedShape:
-            print(f"  fp8  {M}x{N}x{K}: UNSUPPORTED -> caller falls back to cuBLAS")
+            print(f"  fp16 {M}x{N}x{K}: UNSUPPORTED -> caller falls back to cuBLAS")
 
 
 def main():


### PR DESCRIPTION
Summary:

Follow-up to D114086739, which built a Triton GEMM that is bit-identical to cuBLAS by reading the cuBLASLt heuristic. This diff makes it work for **arbitrary** shapes rather than well-formed ones, and fixes the measurement that had been hiding how far off it was.

## The measurement was wrong first

The eval drew shapes from three hand-built regimes and rounded `N` and `K` to a multiple of 8. That rounding made about 98% of its draws ALIGNED, while only 1.6% of genuinely random shapes are (`K%8==0 and N%8==0`), and aligned is the one branch that already worked. Its whole reachable space was ~8k shapes and it could not draw a single shape whose `K` is not a multiple of 8 while `N` is. The eval now draws `M`, `N`, `K` as independent uniform integers with no rounding and no regimes, has a second `extreme` mode for the skinny+deep corner (small M,N with K up to hundreds of thousands) that uniform sampling barely visits, bounds K independently of M and N, logs one row per shape, and can resume.

That one change took the honest number from a reported 96.7% to **17.8%**. Everything below is the work of getting it back up, and this time on the real distribution.

## Two reconstructions added

**1. Where the leftover k-group sits (non-aligned single-pass, 33.4% -> 100%).** A non-aligned shape sends cuBLAS to a CUTLASS kernel that updates its fp32 accumulator once per MMA, so we have to round at the same k boundaries. We already consumed a fixed number of real k-elements per `tl.dot`, but we put the short group at position 0. CUTLASS runs the partial `block_k` step FIRST, yet the MMAs inside that tile still march on the tile own grid from 0, so the short group lands at `floor(res/kpd)` with `res = K % tbK`. The two agree only when `res < kpd`, which is exactly the third of the family that used to work. Source: `cutlass/3.9.2/include/cutlass/transform/threadblock/predicated_tile_access_iterator.h:185-221,504-540` and `gemm/kernel/gemm.h:230-235`. `tbK` is a cuBLAS performance choice visible only in the launched kernel name, so `_calibrate` tries six combinations of `(k_per_dot, K % block_k)`; measured over 1,806 shapes, exactly one matches every shape.

**2. The CUTLASS split-K path (0% -> 100%).** Non-aligned shapes that cuBLAS splits over K -- about half of all random shapes -- had no code path at all. The reason nothing matched is that cuBLAS uses **three different merge schemes here and `SPLITK_NUM` does not distinguish them**; only the launched kernel names do. `GemmSplitKSerial` chains the partials serially **in fp16** (70% of the family), `splitKreduce<..., __half>` rounds each partial to fp16 then sums forward in fp32 (17%), and `splitKreduce<..., float>` sums forward in fp32 (12%) -- so the fp32 assumption the aligned path uses is the minority case. Three more things differ from the aligned rule: the partition grain is CUTLASS `kAlignK` = 8, not 64 (`params_universal_base.h:52-59`), the residue tile is per SLICE, and the merge starts at partial 0 rather than a zero accumulator. That last one also fixes a signed-zero mismatch: `(+0.0) + (-0.0) = +0.0` destroys a `-0.0` partial, while a CUTLASS epilogue with `beta=0` writes it out and keeps it.

## Three bugs the unrestricted eval exposed

- **32-bit address overflow, present since the first version of this code.** Any operand with more than 2^31 elements (`M=8192, K=300000` is 2.46e9) overflowed Triton index arithmetic and faulted with an illegal memory access, which then poisoned the CUDA context so every later call failed too. All index vectors are now `int64`. Invisible before only because the eval capped shapes at 8192.
- **Calibration held all 32 references resident.** For a large shape that is 32 copies of A, B and D -- a single 8192x300000 fp16 operand is 4.9 GiB before the fp32 temporaries that build it -- so it ran out of memory. It now generates, compares and frees one seed at a time.
- **Selection bias in calibration.** Picking the best of ~36 candidates on 32 seeds is a selection, so a candidate that fits by luck could ship. The winner is now re-checked on 8 hold-out seeds that took no part in choosing it; that halved the residual mismatches in the skinny+deep corner.

## Earlier fixes in this diff

- **fp8 needs `BM >= 64`.** Below that Triton silently upcasts fp8 to f16 and emits `mma.sync.m16n8k16` instead of `tcgen05.mma.kind::f8f6f4` -- a different MMA, unmatchable at any K partition. This retires the old claim that fp8 vertical (`_v_`) split-K is fundamentally unreconstructable; `_v_` is only a cluster shape.
- **Aligned fp16 split-K is not statically bit-exact** (453 of 56,999 shapes were wrong with no runtime check). The static path is now the plain branch only, for both dtypes.
- **The fp8 `ceil(M/64)*ceil(N/64) >= 64` static gate was unnecessary**; `SPLITK_NUM == 1` is the right condition.
- **The calibration inputs were not discriminating.** They used a `logspace(-3,3)` magnitude ramp along K, which makes the largest-k products dominate and absorb the rest in fp32, so a wrong reconstruction passes all 32 seeds. Calibration now alternates a flat same-scale gaussian with the ramp and a reconstruction has to pass both; that took one run from 180 mismatches to 0.
- The partition search is gone: `chunk = ceil(ceil(K/G)/SPLITK_NUM)*G` is the only partition the nvjet path ever uses, so the runtime step tries one candidate and exists purely to gate the residual.

## How the recipe is decided: three tiers

Not every knob can be read from the heuristic, and not every knob has to be searched for. The API now resolves a shape through three tiers, in order:

- **static** -- the heuristic settles it and nothing is executed. Only the plain branch qualifies.
- **pseudo-static** -- one profiled cuBLAS launch, then the recipe is READ off the launched kernel name (`block_k`, MMA shape) and off `REDUCTION_SCHEME` (which of the three split-K merge schemes). Costs ~2 ms for the profile against ~0.1 ms for the GEMM itself. It is an observation of what cuBLAS did rather than an inference from output bits, so it cannot pick a recipe that merely happens to agree on the seeds it was tested against -- but it also proves nothing, since no bytes are compared.
- **runtime** -- search the candidate recipes and keep the one that byte-matches cuBLAS on 32 selection seeds plus 8 hold-out seeds. Proves the match on those inputs, at the cost of ~36 candidate launches and a selection that can still admit a recipe fitting by luck.

`block_k` is what forces a launch at all: `REDUCTION_SCHEME` gives the merge scheme exactly (119 shapes, no mixing) and `(ALGO_ID, CUSTOM_OPTION, STAGES_ID)` gives the CUTLASS subtype and hence the k per dot, but config groups identical in every readable field still differ in `block_k`, and it appears only in the launched kernel name. An earlier note in this stack said the merge scheme was invisible to the heuristic; that was measured on the nvjet path, where `REDUCTION_SCHEME` is always `COMPUTE_TYPE`, and it is wrong for the CUTLASS path.

## Result

`M`, `N`, `K` independent uniform integers, no rounding, no regimes. `random` bounds M and N at 8192; `extreme` is the skinny+deep corner, M,N <= 256 with K <= 400,000. fp8 draws are rounded to multiples of 16 because cuBLAS refuses fp8 otherwise -- its requirement, not a restriction chosen here. 20 minutes of fuzzing, ~220k shapes, ~440k byte compares.

| eval | shapes | static | pseudo-static | runtime | reconstructed | declined | bit-consistent |
|---|---|---|---|---|---|---|---|
| fp16 random | 4,460 | 83 | 2,920 | 1,456 | **99.98%** | 1 | **100.00%** (8,918/8,918) |
| fp16 extreme | 46,481 | 5 | 46,132 | 8 | **99.28%** | 336 | 99.989% (92,280/92,290) |
| fp8 random | 116,380 | 116,237 | 13 | 130 | **100.00%** | 0 | **100.00%** (232,760/232,760) |
| fp8 extreme | 53,548 | 647 | 52,901 | 0 | **100.00%** | 0 | 99.658% (106,730/107,096) |

**reconstructed** = static + pseudo-static + runtime, over the shapes cuBLAS can run. **declined** = the API raises and the caller falls back to cuBLAS. **bit-consistent** = of the reconstructed shapes, the fraction byte-identical to cuBLAS over every fuzz input.

Which tier carries the work is a property of the dtype and the corner, not of the method: aligned fp8 stays on nvjet plain and is decided from the heuristic alone, while fp16 and the skinny+deep corner land on CUTLASS kernels whose `block_k` only the launched name gives. Pseudo-static also made the corner tractable to measure at all -- fp16 extreme covered 46,481 shapes in five minutes against 1,263 for the same budget under the search path, about 37x.

## Known bug, tracked as a follow-up

Pseudo-static returns without verifying, so a wrong derivation ships wrong bits instead of declining. Two such derivation bugs were found and fixed while building it: the demangled symbol repeats the kernel name, so scanning it for the second tile field picked up the repeated M x N tile instead of `block_k`; and the CUTLASS split-K grain is `kAlignK = 64` when `K % 64 == 0` and 8 otherwise, not a constant 8. A third remains: **366 of 107,096 fp8 extreme compares (0.34%) are not bit-identical, all on the pseudo-static path**, where the same corner under the search path was 100.00%. It is an implementation gap in the derivation, not a property of the approach, and is left as a minor follow-up rather than a blocker. The mitigation, if it proves stubborn, is to keep the single derived recipe but byte-check it once before trusting it -- that keeps the 37x and the freedom from selection bias, and degrades a bad derivation into a decline rather than a wrong answer.

Authored with Claude Code.

Reviewed By: njriasan

Differential Revision: D114609600


