### PR TITLE
[triton][bitequiv] cuBLAS-equivalent GEMM: one entry point for fp16 and fp8, and bring the operand layout and the fp8 scales into the equivalence claim (#2755)

### DIFF
--- a/bitequiv/cublas_equiv_gemm.py
+++ b/bitequiv/cublas_equiv_gemm.py
@@ -52,9 +52,14 @@ library (always present with a CUDA runtime).  Measured on GB200 / sm_100.
 """
 from __future__ import annotations
 
+import contextlib
 import ctypes
+import dataclasses
 import glob
+import os
 import re
+import threading
+import warnings
 
 import torch
 import triton
@@ -72,10 +77,147 @@ class CublasUnsupportedShape(Exception):
     byte-compare (e.g. fp8 vertical/cluster split-K, fp16 non-aligned s1688 K=8 / odd-K)."""
 
 
+class CublasUnsupportedPlatform(CublasUnsupportedShape):
+    """No measured strategy for this GPU architecture.
+
+    Every reconstruction rule in this file is architecture-specific and was measured, not
+    derived, so it must not be extrapolated: the sm_103 rules did not carry over to sm_100 when
+    that move was tried. Subclasses `CublasUnsupportedShape` on purpose, so a caller that
+    already writes `except CublasUnsupportedShape: <fall back to cuBLAS>` keeps working
+    unchanged on a machine we have not measured."""
+
+
 class CublasNeedRuntimeMatch(Exception):
     """The shape cannot be reconstructed from the heuristic STATICALLY with confidence; a
     runtime byte-compare against cuBLAS is needed to confirm (or reject) it. Raised only in
     static mode (`enable_runtime_match=False`). Re-call with `enable_runtime_match=True`."""
+
+
+# --------------------------------------------------------------------------- #
+# Per-platform strategy
+#
+# PORTING GUIDE. Everything cuBLAS-specific in this file lives in an ArchProfile below, so
+# adding a GPU is filling in one dataclass -- no dispatch code changes. Nothing here may be
+# guessed from another architecture: when the sm_103 rules were carried over to sm_100 they
+# were wrong, and the same is expected in reverse. Each field says how to measure it.
+#
+# The gate is (compute capability, cuBLASLt version). The cuBLASLt library we call through
+# ctypes is what decides the kernels -- its name literally carries the arch, e.g.
+# `nvjet_sm100_...` -- so it, not the CUDA toolkit torch was built against, is what we pin.
+# --------------------------------------------------------------------------- #
+# What a profile that does not name its own versions -- every placeholder, until someone
+# measures it -- is assumed to hold for. The newest version the rules have been measured on.
+_DEFAULT_CUBLASLT = (13, 1)
+
+@dataclasses.dataclass(frozen=True)
+class ArchProfile:
+    """The measured cuBLAS behaviour of one GPU architecture.
+
+    `measured=False` means the entry is a placeholder: the dispatch knows the architecture
+    exists but has no rules for it, and the API raises `CublasUnsupportedPlatform`."""
+
+    name: str                        # human-readable, e.g. "sm_100 (NVIDIA GB200 / B200)"
+    measured: bool = False
+    # (major, minor) cuBLASLt versions these rules were measured against. A patch bump inside a
+    # listed (major, minor) is silent; any other version warns and runs anyway, because a version
+    # change *can* move which kernel a shape lands on but usually does not. A placeholder profile
+    # inherits `_DEFAULT_CUBLASLT` until whoever fills it in measures which versions it holds for.
+    cublaslt_versions: tuple = (_DEFAULT_CUBLASLT, )
+    measured_cublaslt: str = ""      # exact version, for the record
+
+    # -- alignment gate -------------------------------------------------------------------
+    # Which contiguous dims must be aligned for cuBLAS to stay on its own (nvjet) kernels.
+    # Measure: sweep shapes, profile the launched kernel name, find where it flips to CUTLASS.
+    align_elems: tuple = ()          # sm_100: (("fp16", 8), ("fp8", 16)) -- see `_aligned`
+
+    # -- nvjet split-K --------------------------------------------------------------------
+    # k-slice grain of cuBLAS's own split-K, per dtype. Measure: byte-compare
+    # `chunk = ceil(ceil(K/G)/SPLITK_NUM)*G` for candidate G against cuBLAS-direct.
+    nvjet_grain: tuple = ()          # sm_100: (("fp16", 64), ("fp8", 128))
+
+    # -- Triton-side constraint -----------------------------------------------------------
+    # Minimum BM below which Triton stops using the native fp8 tensor-core path. Measure: dump
+    # PTX over a (BM, BN, BK, num_warps) grid and look for the MMA instruction changing.
+    fp8_min_bm: int = 64
+
+    # -- CUTLASS fallback (only reached when the shape is not aligned) ---------------------
+    # Real k-elements per `tl.dot`, i.e. the MMA's K. Measure: read the `s<MMA>gemm` token.
+    k_per_dot_choices: tuple = ()    # sm_100: (16, 8)
+    # Threadblock k-tiles CUTLASS uses here; decides where the partial group sits. Measure:
+    # read the `<tbK>x<stages>` token from the launched name over many shapes.
+    ktile_choices: tuple = ()        # sm_100: (32, 64, 128)
+    # Default k-tile when the name omits that field (two-stage sm_75 instances do).
+    ktile_default: int = 32
+    # Partition grains to try for CUTLASS split-K. Measure: byte-compare, and cross-check
+    # against `kAlignK` in `cutlass/.../params_universal_base.h`.
+    splitk_grains: tuple = ()        # sm_100: (8, 64)
+    # CUBLASLT_REDUCTION_SCHEME -> our merge scheme. Measure: cross-tabulate attr 3 against the
+    # merge scheme that byte-matches. sm_100: NONE -> serial fp16, COMPUTE_TYPE -> fp32 forward
+    # sum, OUTPUT_TYPE -> fp16 partials.
+    reduction_to_cmode: tuple = ()   # sm_100: ((0, 3), (2, 0), (4, 2))
+
+
+_SM100 = ArchProfile(
+    name="sm_100 (NVIDIA GB200 / B200)",
+    measured=True,
+    cublaslt_versions=((13, 1), (12, 8)),
+    measured_cublaslt="13.1.1 and 12.8.5",
+    align_elems=(("fp16", 8), ("bf16", 8), ("fp8", 16)),
+    nvjet_grain=(("fp16", 64), ("bf16", 64), ("fp8", 128)),
+    fp8_min_bm=64,
+    k_per_dot_choices=(16, 8),
+    ktile_choices=(32, 64, 128),
+    ktile_default=32,
+    splitk_grains=(8, 64),
+    reduction_to_cmode=((0, 3), (2, 0), (4, 2)),
+)
+
+# Placeholders. Fill in the fields above on the machine in question and flip `measured=True`;
+# the dispatch, the kernels and the eval need no changes. Re-measure every field -- the values
+# in `_SM100` are not a starting point, they are a different architecture's answer.
+_SM103 = ArchProfile(name="sm_103 (NVIDIA GB300)")
+_SM90 = ArchProfile(name="sm_90 (NVIDIA H100)")
+
+_PROFILES = {(10, 0): _SM100, (10, 3): _SM103, (9, 0): _SM90}
+
+
+def _cublaslt_version():
+    """(major, minor, patch) of the cuBLASLt we actually call."""
+    return _lt_version_of(_load_lt())
+
+
+def _platform():
+    """The ArchProfile for the current device, or raise CublasUnsupportedPlatform."""
+    cap = torch.cuda.get_device_capability()
+    major, minor, patch = _cublaslt_version()
+    if (cap, major, minor) in _PLATFORM_CACHE:
+        return _PLATFORM_CACHE[(cap, major, minor)]
+    prof = _PROFILES.get(cap)
+    dev = torch.cuda.get_device_name()
+    if prof is None or not prof.measured:
+        known = ", ".join(p.name for p in _PROFILES.values() if p.measured)
+        raise CublasUnsupportedPlatform(
+            f"unsupported on sm_{cap[0]}{cap[1]} ({dev}): no cuBLAS-equivalence strategy has been "
+            f"measured for this GPU. Supported: {known}. The reconstruction rules are "
+            f"architecture-specific and must be re-measured, not extrapolated -- see ArchProfile.")
+    if (major, minor) not in prof.cublaslt_versions:
+        want = ", ".join(f"{a}.{b}.x" for a, b in prof.cublaslt_versions)
+        exact = f" (exactly {prof.measured_cublaslt})" if prof.measured_cublaslt else ""
+        # Warn, do not refuse. A cuBLASLt update can move which kernel a shape lands on, but in
+        # practice most shapes are unaffected, and every reconstruction is still either checked
+        # against cuBLAS (runtime tier) or read off the kernel cuBLAS actually launched
+        # (pseudo-static tier). Only the static tier trusts the rules blind. Warn once per
+        # architecture: the cache below is filled exactly once, so a fuzzer loop stays quiet.
+        warnings.warn(
+            f"cuBLASLt {major}.{minor}.{patch} on {prof.name} was not measured: the rules come from "
+            f"{want}{exact}. Results should still be bit-identical to cuBLAS, but a version bump can "
+            f"change which kernel a shape lands on. Re-measure and add {major}.{minor} to "
+            f"ArchProfile.cublaslt_versions to silence this.", RuntimeWarning, stacklevel=2)
+    _PLATFORM_CACHE[(cap, major, minor)] = prof
+    return prof
+
+
+_PLATFORM_CACHE: dict = {}
 
 
 # --------------------------------------------------------------------------- #
@@ -292,7 +434,7 @@ def _tile(M: int, N: int, dtype=None) -> tuple[int, int]:
     BM = 16 if M <= 16 else 32 if M <= 32 else 64 if M <= 64 else 128
     BN = 16 if N <= 16 else 32 if N <= 32 else 64 if N <= 64 else 128
     if dtype == torch.float8_e4m3fn:
-        BM = max(BM, 64)
+        BM = max(BM, _platform().fp8_min_bm)
     return BM, BN
 
 
@@ -335,9 +477,10 @@ def _k_per_dot_candidates(K):
     and parity gets `k_per_dot` wrong for the WMMA kernels -- so try all six. Measured over
     1,806 non-aligned single-pass fp16 shapes at 32 seeds: exactly one of the six byte-matches
     every shape, with no exceptions, taking that family from 33.4% to 100%."""
+    prof = _platform()
     out, seen = [], set()
-    for k_per_dot in (16, 8):
-        for ktile in (32, 64, 128):
+    for k_per_dot in prof.k_per_dot_choices:
+        for ktile in prof.ktile_choices:
             cand = (k_per_dot, K % ktile)
             if cand not in seen:
                 seen.add(cand)
@@ -383,15 +526,16 @@ def _splitk_group_candidates(K, nsplit):
     Using them would cut the list from 36 candidates to 3. The k-tile is the one knob no
     heuristic field pins -- config groups identical in every readable field still differ in it --
     so a byte-compare is still needed, which is why these shapes are `runtime`, not `static`."""
+    prof = _platform()
     chunks = []
-    for g in (8, 64):
+    for g in prof.splitk_grains:
         chunk = _chunk_from_ns(K, nsplit, g)
         if g <= chunk <= K and chunk not in chunks:
             chunks.append(chunk)
     out = []
     for cmode in (3, 2, 0):        # serial-fp16 70%, fp16-partials 17%, fp32-forward 12%
-        for k_per_dot in (8, 16):  # 8 is 80%
-            for ktile in (32, 64, 128):  # 32 is 86%
+        for k_per_dot in reversed(prof.k_per_dot_choices):  # 8 is 80%
+            for ktile in prof.ktile_choices:  # 32 is 86%
                 for chunk in chunks:
                     out.append((chunk, k_per_dot, ktile, cmode))
     return out
@@ -428,10 +572,11 @@ _DESC_A_SCALE_PTR, _DESC_B_SCALE_PTR = 17, 18
 _PREF_MAX_WS = 1
 _LAYOUT_ORDER, _ORDER_ROW = 1, 1
 _CFG_ID, _CFG_SPLITK, _CFG_REDUCTION = 0, 2, 3
-# CUBLASLT_REDUCTION_SCHEME -> which split-K merge scheme the kernel uses. Measured against the
-# scheme that actually byte-matches: 119 non-aligned split-K shapes, no mixing.
-_REDUCTION_TO_CMODE = {0: 3, 2: 0, 4: 2}  # NONE -> serial fp16, COMPUTE_TYPE -> fp32, OUTPUT_TYPE -> fp16 partials
-_LT = None
+_LT_SPEC = None   # process-wide choice from set_cublaslt(); None = newest installed
+_TLS = threading.local()   # per-CALL overrides live here, never in a global -- see _using_cublaslt
+_UNSET = object()
+_LT_LIBS: dict = {}   # resolved path -> loaded library, so switching back and forth is free
+_LT_PATHS: dict = {}  # spec -> resolved path
 _ONES = None  # device fp32 [1.0] for fp8 scale pointers
 _WS = None    # device scratch for the reference execute
 
@@ -441,21 +586,97 @@ class _HeurResult(ctypes.Structure):
                 ("wavesCount", ctypes.c_float), ("reserved", ctypes.c_int * 4)]
 
 
-def _load_lt():
-    global _LT, _ONES, _WS
-    if _LT is not None:
-        return _LT
-    cands = (["/usr/local/cuda-13.0/lib64/libcublasLt.so.13"] + glob.glob("/usr/local/cuda*/lib64/libcublasLt.so*") +
-             glob.glob("/usr/local/cuda*/targets/*/lib/libcublasLt.so*") + ["libcublasLt.so.13", "libcublasLt.so"])
-    lib = None
+def set_cublaslt(spec=None):
+    """Choose which cuBLAS to be bit-identical to, for the rest of the process.
+
+    This is process-wide, as the name says. A single call overrides it with `cublaslt=`, and
+    that override is thread-local, so one thread cannot retarget a call in flight on another.
+
+    `spec` is a version prefix ("12.8", "13.1.1") or a full path to a libcublasLt; `None`
+    restores auto-detection, which takes the newest installed. Which cuBLAS is the target is
+    part of the claim and not an implementation detail -- a box can carry several, and torch's
+    bundled one is usually not the newest. A single call can override this with `cublaslt=`."""
+    global _LT_SPEC
+    _LT_SPEC = spec
+
+
+def _lt_spec():
+    """Which cuBLAS the call on THIS thread is targeting: its own override if it set one,
+    otherwise the process-wide choice."""
+    v = getattr(_TLS, "lt_spec", _UNSET)
+    return _LT_SPEC if v is _UNSET else v
+
+
+@contextlib.contextmanager
+def _using_cublaslt(spec):
+    """Select `spec` for one call. Held in thread-local state rather than a global: two threads
+    can be matching two different cuBLAS at the same time, and a global would let one of them
+    retarget the other mid-flight. Libraries are cached per path, so switching is cheap, and the
+    plan cache keys on the version, so a plan made against one is never reused for another."""
+    if spec is None:
+        yield
+        return
+    prev = getattr(_TLS, "lt_spec", _UNSET)
+    _TLS.lt_spec = spec
+    try:
+        yield
+    finally:
+        if prev is _UNSET:
+            del _TLS.lt_spec
+        else:
+            _TLS.lt_spec = prev
+
+
+def _lt_candidates():
+    """Installed libcublasLt paths, newest first. The version comes from the file name, so
+    picking one does not mean loading all of them."""
+    seen, out = set(), []
+    for p in (glob.glob("/usr/local/cuda*/lib64/libcublasLt.so*") +
+              glob.glob("/usr/local/cuda*/targets/*/lib/libcublasLt.so*")):
+        rp = os.path.realpath(p)
+        if rp in seen:
+            continue
+        seen.add(rp)
+        m = re.search(r"\.so\.([\d.]+)$", rp)
+        out.append((tuple(int(x) for x in m.group(1).split(".")) if m else (), rp))
+    out.sort(reverse=True)
+    return [p for _, p in out] + ["libcublasLt.so"]
+
+
+def _lt_version_of(lib):
+    lib.cublasLtGetVersion.restype = ctypes.c_size_t
+    v = int(lib.cublasLtGetVersion())
+    return v // 10000, (v // 100) % 100, v % 100
+
+
+def _resolve_lt(spec):
+    """`spec` (path, version prefix, or None) -> the path to load."""
+    if spec in _LT_PATHS:
+        return _LT_PATHS[spec]
+    if spec and ("/" in spec or spec.endswith(".so")):
+        cands, want = [spec], None
+    else:
+        cands = _lt_candidates()
+        want = tuple(int(x) for x in spec.split(".")) if spec else None
     for c in cands:
         try:
             lib = ctypes.CDLL(c)
-            break
         except OSError:
             continue
-    if lib is None:
-        raise OSError("libcublasLt not found")
+        if want is not None and _lt_version_of(lib)[:len(want)] != want:
+            continue
+        _LT_PATHS[spec] = os.path.realpath(c)
+        return _LT_PATHS[spec]
+    raise OSError(f"no libcublasLt matching {spec!r}; tried {cands[:4]}")
+
+
+def _load_lt():
+    global _ONES, _WS
+    path = _resolve_lt(_lt_spec())
+    lib = _LT_LIBS.get(path)
+    if lib is not None:
+        return lib
+    lib = ctypes.CDLL(path)
     P, PP = ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)
     ci, cu64, ci64, csz = ctypes.c_int, ctypes.c_uint64, ctypes.c_int64, ctypes.c_size_t
     lib.cublasLtCreate.argtypes = [PP]
@@ -473,9 +694,10 @@ def _load_lt():
     lib.cublasLtMatmulAlgoConfigGetAttribute.argtypes = [P, ci, P, csz, ctypes.POINTER(csz)]
     lib.cublasLtMatmul.restype = ci
     lib.cublasLtMatmul.argtypes = [P] * 14 + [csz, P]  # 14 ptrs, workspaceSize, stream
-    _ONES = torch.ones(1, dtype=torch.float32, device=DEVICE)
-    _WS = torch.empty(_WS_BYTES, dtype=torch.uint8, device=DEVICE)
-    _LT = lib
+    if _ONES is None:
+        _ONES = torch.ones(1, dtype=torch.float32, device=DEVICE)
+        _WS = torch.empty(_WS_BYTES, dtype=torch.uint8, device=DEVICE)
+    _LT_LIBS[path] = lib
     return lib
 
 
@@ -583,19 +805,23 @@ def _cublas_direct(a, b, kind, out_dtype, execute=True):
                 pass
 
 
-def cublas_matmul(a, b, out_dtype=None):
+def cublas_matmul(a, b, out_dtype=None, cublaslt=None):
     """cuBLAS's OWN output (run directly via cublasLtMatmul), the reference our
-    reconstruction must match. fp16/bf16: `b` is [K,N]. fp8: `b` is [K,N] column-major."""
+    reconstruction must match. fp16/bf16: `b` is [K,N]. fp8: `b` is [K,N] column-major.
+    `cublaslt` picks which cuBLAS, as in `cublas_equivalent_gemm`."""
     kind = _kind_of(a)
     out_dtype = out_dtype or (torch.float16 if kind == "fp8" else a.dtype)
-    return _cublas_direct(a, b, kind, out_dtype)[0]
+    with _using_cublaslt(cublaslt):
+        return _cublas_direct(a, b, kind, out_dtype)[0]
 
 
 # --------------------------------------------------------------------------- #
 # Reconstruction planning (verify-then-use) + per-shape cache
 # --------------------------------------------------------------------------- #
-# (M,N,K,kind,out_dtype) -> (origin, plan): origin "static"|"runtime"|"unsupported"; plan
-# ("plain",None) | ("split",chunk) | None. Decided once; a "runtime" plan is withheld in static mode.
+# (capability,cublaslt,M,N,K,kind,out_dtype) -> (origin, plan). The capability and the cuBLASLt
+# version keep a process that switched either one from reusing the old recipe. origin is
+# "static" | "pseudo-static" | "runtime" | "unsupported"; a "runtime" plan is withheld in
+# static mode.
 _PLAN: dict[tuple, tuple] = {}
 
 
@@ -613,10 +839,8 @@ def _chunk_from_ns(K, ns, G):
 
 
 def _grain(kind):
-    """k-slice granularity for the split-K partition: fp16/bf16 = 64, fp8 = 128
-    (measured; fp8 G=128 at the heuristic nsplit dominates G=64 for every kernel family,
-    including 2-CTA/horizontal/vertical -- the earlier "vertical->64" was a 3-seed artifact)."""
-    return 128 if kind == "fp8" else 64
+    """k-slice granularity of cuBLAS's own (nvjet) split-K, from the platform profile."""
+    return dict(_platform().nvjet_grain)[kind]
 
 
 def _static_chunk(K, nsplit, kind):
@@ -678,9 +902,8 @@ def _bits_eq(x, y):
 def _aligned(M, N, K, kind):
     """Contiguous-dim alignment cuBLAS needs to stay on its reconstructable nvjet path.
     fp16/bf16: K%8==0 and N%8==0 (M free). fp8: all dims %16."""
-    if kind == "fp8":
-        return M % 16 == 0 and N % 16 == 0 and K % 16 == 0
-    return K % 8 == 0 and N % 8 == 0
+    n = dict(_platform().align_elems)[kind]
+    return (M % n == 0 and N % n == 0 and K % n == 0) if kind == "fp8" else (K % n == 0 and N % n == 0)
 
 
 def _is_static_exact(kind, nsplit, aligned):
@@ -757,7 +980,7 @@ def _parse_launched(names):
     k_per_dot = 8 if m.group(1) == "1688" else 16  # s1688 is m16n8k8, the rest here are k16 MMAs
     # cutlass_<arch>_<op>_[<dt>_]s<MMA>gemm_<dt>_<tbMxtbN>[_<tbKxstages>]_<layout>_align<n>.
     # Two-stage sm_75 instances omit the k-tile field; those were measured to use 32 (1264/1264).
-    block_k = int(tiles[1].split("x")[0]) if len(tiles) >= 2 else 32
+    block_k = int(tiles[1].split("x")[0]) if len(tiles) >= 2 else _platform().ktile_default
     return {"family": "cutlass", "k_per_dot": k_per_dot, "block_k": block_k}
 
 
@@ -783,12 +1006,13 @@ def _plan_from_launched(a, b, kind, out_dtype, nsplit, reduction):
     k_per_dot, block_k = info["k_per_dot"], info["block_k"]
     if nsplit <= 1:
         return ("k_per_dot", (k_per_dot, K % block_k))
-    cmode = _REDUCTION_TO_CMODE.get(reduction)
+    cmode = dict(_platform().reduction_to_cmode).get(reduction)
     if cmode is None:  # e.g. an atomic (INPLACE) reduction, which is not deterministic for us
         return None
     # CUTLASS's split-K partition grain: `params_universal_base.h:52-59` takes kAlignK = 64 when
     # K divides evenly by it and falls back to 128 bits / 16 bits = 8 otherwise.
-    grain = 64 if K % 64 == 0 else 8
+    big, small = max(_platform().splitk_grains), min(_platform().splitk_grains)
+    grain = big if K % big == 0 else small
     chunk = _chunk_from_ns(K, nsplit, grain)
     return ("splitk_groups", (chunk, k_per_dot, block_k, cmode)) if grain <= chunk <= K else None
 
@@ -861,6 +1085,13 @@ def _calibrate(M, N, K, kind, out_dtype):
                                  f"{len(survivors)} candidates passed the first seed)")
 
 
+def plan_origin(M, N, K, kind, out_dtype=torch.float16):
+    """Which tier settled this shape: "static" | "pseudo-static" | "runtime" | "unsupported",
+    or "?" if it has not been resolved yet."""
+    return _PLAN.get((torch.cuda.get_device_capability(), _cublaslt_version(), M, N, K, kind, out_dtype),
+                     ("?", None))[0]
+
+
 def _resolve(a, b, kind, out_dtype, enable_runtime_match, enable_pseudo_static=True):
     """Reconstruction plan for this shape, cached after the first call. Three tiers, tried in
     order, each stricter about what it costs and weaker about what it proves:
@@ -878,7 +1109,7 @@ def _resolve(a, b, kind, out_dtype, enable_runtime_match, enable_pseudo_static=T
     """
     M, K = a.shape
     N = b.shape[1]
-    key = (M, N, K, kind, out_dtype)
+    key = (torch.cuda.get_device_capability(), _cublaslt_version(), M, N, K, kind, out_dtype)
     if key in _PLAN:
         origin, plan = _PLAN[key]  # "static" | "pseudo-static" | "runtime" | "unsupported"
         if origin == "unsupported":
@@ -915,34 +1146,46 @@ def _resolve(a, b, kind, out_dtype, enable_runtime_match, enable_pseudo_static=T
 # Public API
 # --------------------------------------------------------------------------- #
 def cublas_equivalent_gemm(a: torch.Tensor, b: torch.Tensor, out_dtype: torch.dtype | None = None,
-                           enable_runtime_match: bool = False, enable_pseudo_static: bool = True) -> torch.Tensor:
+                           enable_runtime_match: bool = False, enable_pseudo_static: bool = True,
+                           cublaslt: str | None = None) -> torch.Tensor:
     """fp16/bf16 GEMM, bit-identical to cuBLAS. `a` is [M,K], `b` is [K,N].
 
     Static by default: the reconstruction is planned from the cuBLAS heuristic alone (no GEMM
     run). Aligned fp16/bf16 is static-exact. A shape that is not statically guaranteed
     (non-aligned) raises CublasNeedRuntimeMatch -- unless `enable_runtime_match=True`, which
     byte-compares candidates against cuBLAS and returns the match or raises
-    CublasUnsupportedShape."""
+    CublasUnsupportedShape.
+
+    `cublaslt` picks which cuBLAS to match for this call -- a version prefix ("12.8") or a
+    path -- overriding `set_cublaslt`. Default is the process-wide choice.
+    """
     kind = _kind_of(a)
     if kind == "fp8":
         raise ValueError("use cublas_equivalent_scaled_mm for fp8")
     out_dtype = out_dtype or a.dtype
-    plan = _resolve(a, b, kind, out_dtype, enable_runtime_match, enable_pseudo_static)
-    return _reconstruct(a, b, out_dtype, plan)
+    with _using_cublaslt(cublaslt):
+        plan = _resolve(a, b, kind, out_dtype, enable_runtime_match, enable_pseudo_static)
+        return _reconstruct(a, b, out_dtype, plan)
 
 
 def cublas_equivalent_scaled_mm(a: torch.Tensor, b: torch.Tensor, scale_a: float = 1.0, scale_b: float = 1.0,
                                 out_dtype: torch.dtype = torch.float16, enable_runtime_match: bool = False,
-                                enable_pseudo_static: bool = True) -> torch.Tensor:
+                                enable_pseudo_static: bool = True,
+                                cublaslt: str | None = None) -> torch.Tensor:
     """fp8 (e4m3) GEMM, bit-identical to cuBLAS. `a` is [M,K], `b` is [K,N] column-major
     (i.e. from `w.t()`); scales are scalars.
 
     fp8 plain is static-exact. fp8 split-K is NOT statically guaranteed (the vertical/cluster
     kernel is not bit-reproducible) -> raises CublasNeedRuntimeMatch unless
     `enable_runtime_match=True`, which byte-compares against cuBLAS and returns the match or
-    raises CublasUnsupportedShape (vertical split-K)."""
-    plan = _resolve(a, b, "fp8", out_dtype, enable_runtime_match, enable_pseudo_static)
-    return _reconstruct(a, b, out_dtype, plan, sa=scale_a, sb=scale_b)
+    raises CublasUnsupportedShape (vertical split-K).
+
+    `cublaslt` picks which cuBLAS to match for this call -- a version prefix ("12.8") or a
+    path -- overriding `set_cublaslt`. Default is the process-wide choice.
+    """
+    with _using_cublaslt(cublaslt):
+        plan = _resolve(a, b, "fp8", out_dtype, enable_runtime_match, enable_pseudo_static)
+        return _reconstruct(a, b, out_dtype, plan, sa=scale_a, sb=scale_b)
 
 
 # --------------------------------------------------------------------------- #
@@ -962,7 +1205,7 @@ def _check_one(kind, M, N, K):
             out = call(True)
     except CublasUnsupportedShape:
         return "unsupported", None
-    tier = _PLAN.get((M, N, K, kind, torch.float16), ("?", None))[0]
+    tier = plan_origin(M, N, K, kind)
     return tier, _bits_eq(out, ref)
 
 

--- a/bitequiv/cublas_equiv_gemm.py
+++ b/bitequiv/cublas_equiv_gemm.py
@@ -2,9 +2,9 @@
 
 Top-level API (a cuBLAS-like matmul):
 
-    from bitequiv.cublas_equiv_gemm import cublas_equivalent_gemm, cublas_equivalent_scaled_mm
-    c = cublas_equivalent_gemm(a_fp16, b_fp16)               # == cuBLAS fp16/bf16 GEMM, bit-for-bit
-    c = cublas_equivalent_scaled_mm(a_fp8, b_fp8_col, sa, sb) # == cuBLAS fp8 GEMM, bit-for-bit
+    from bitequiv.cublas_equiv_gemm import cublas_equivalent_gemm
+    c = cublas_equivalent_gemm(a_fp16, b_fp16)                            # == cuBLAS fp16/bf16, bit-for-bit
+    c = cublas_equivalent_gemm(a_fp8, b_fp8_col, scale_a=sa, scale_b=sb)  # == cuBLAS fp8, bit-for-bit
 
 How it works
 ------------
@@ -58,6 +58,7 @@ import dataclasses
 import glob
 import os
 import re
+import struct
 import threading
 import warnings
 
@@ -224,7 +225,7 @@ _PLATFORM_CACHE: dict = {}
 # Triton kernels (scale-capable, single FP32 accumulator)
 # --------------------------------------------------------------------------- #
 @triton.jit
-def _plain_gemm(A, B, C, M, N, K, am, ak, bk, bn, cm, cn, sa, sb, BM: tl.constexpr, BN: tl.constexpr,
+def _plain_gemm(A, B, C, M, N, K, am, ak, bk, bn, cm, cn, s, BM: tl.constexpr, BN: tl.constexpr,
                 BK: tl.constexpr):
     pid = tl.program_id(0)
     npn = tl.cdiv(N, BN)
@@ -243,7 +244,7 @@ def _plain_gemm(A, B, C, M, N, K, am, ak, bk, bn, cm, cn, sa, sb, BM: tl.constex
                      tl.load(bp, mask=ok[:, None] < K - k * BK, other=0.0), acc)
         ap += BK * ak
         bp += BK * bk
-    acc = acc * sa * sb
+    acc = acc * s
     ocm = (pm * BM + tl.arange(0, BM)).to(tl.int64)
     ocn = (pn * BN + tl.arange(0, BN)).to(tl.int64)
     tl.store(C + cm * ocm[:, None] + cn * ocn[None, :], acc.to(C.dtype.element_ty),
@@ -251,7 +252,7 @@ def _plain_gemm(A, B, C, M, N, K, am, ak, bk, bn, cm, cn, sa, sb, BM: tl.constex
 
 
 @triton.jit
-def _plain_gemm_k_per_dot(A, B, C, M, N, K, am, ak, bk, bn, cm, cn, sa, sb, KPD, RES, BM: tl.constexpr,
+def _plain_gemm_k_per_dot(A, B, C, M, N, K, am, ak, bk, bn, cm, cn, s, KPD, RES, BM: tl.constexpr,
                           BN: tl.constexpr, BK: tl.constexpr):
     """Plain GEMM that rounds its accumulator exactly where cuBLAS's CUTLASS kernel does.
 
@@ -293,7 +294,7 @@ def _plain_gemm_k_per_dot(A, B, C, M, N, K, am, ak, bk, bn, cm, cn, sa, sb, KPD,
         a = tl.load(A + om[:, None] * am + (k0 + ok)[None, :] * ak, mask=real[None, :], other=0.0)
         b = tl.load(B + (k0 + ok)[:, None] * bk + on[None, :] * bn, mask=real[:, None], other=0.0)
         acc = tl.dot(a, b, acc)
-    acc = acc * sa * sb
+    acc = acc * s
     ocm = (pm * BM + tl.arange(0, BM)).to(tl.int64)
     ocn = (pn * BN + tl.arange(0, BN)).to(tl.int64)
     tl.store(C + cm * ocm[:, None] + cn * ocn[None, :], acc.to(C.dtype.element_ty),
@@ -330,7 +331,7 @@ def _splitk_partial(A, B, W, M, N, K, am, ak, bk, bn, ws, wm, wn, CHUNK, BM: tl.
 
 
 @triton.jit
-def _splitk_combine(W, C, M, N, ws, wm, wn, cm, cn, S, sa, sb, BM: tl.constexpr, BN: tl.constexpr):
+def _splitk_combine(W, C, M, N, ws, wm, wn, cm, cn, S, s, BM: tl.constexpr, BN: tl.constexpr):
     """Pass 2: sum the S FP32 partials in FORWARD order (slice 0..S-1), scale, cast. The sum
     starts at partial 0 rather than a zero accumulator, which matters only for signed zero:
     `(+0.0) + (-0.0) = +0.0` would drop the sign a cuBLAS epilogue with beta=0 keeps."""
@@ -345,7 +346,7 @@ def _splitk_combine(W, C, M, N, ws, wm, wn, cm, cn, S, sa, sb, BM: tl.constexpr,
     for i in range(0, S):
         p = tl.load(W + i.to(tl.int64) * ws + om[:, None] * wm + on[None, :] * wn, mask=m2, other=0.0)
         acc = tl.where(i == 0, p, acc + p)
-    acc = acc * sa * sb
+    acc = acc * s
     tl.store(C + cm * om[:, None] + cn * on[None, :], acc.to(C.dtype.element_ty), mask=m2)
 
 
@@ -389,7 +390,7 @@ def _splitk_partial_k_per_dot(A, B, W, M, N, K, am, ak, bk, bn, ws, wm, wn, CHUN
 
 
 @triton.jit
-def _splitk_combine_modes(W, C, M, N, ws, wm, wn, cm, cn, S, sa, sb, CMODE: tl.constexpr, BM: tl.constexpr,
+def _splitk_combine_modes(W, C, M, N, ws, wm, wn, cm, cn, S, s, CMODE: tl.constexpr, BM: tl.constexpr,
                           BN: tl.constexpr):
     """Pass 2 with the three merge schemes cuBLAS actually uses, which `SPLITK_NUM` does not
     distinguish -- only the launched kernel names do:
@@ -420,7 +421,7 @@ def _splitk_combine_modes(W, C, M, N, ws, wm, wn, cm, cn, S, sa, sb, CMODE: tl.c
         acc = tl.where(i == 0, p, acc + p)
         if CMODE == 3:  # the running total lives in fp16 between slices
             acc = acc.to(tl.float16).to(tl.float32)
-    acc = acc * sa * sb
+    acc = acc * s
     tl.store(C + cm * om[:, None] + cn * on[None, :], acc.to(C.dtype.element_ty), mask=m2)
 
 
@@ -442,18 +443,18 @@ def _kcontig(b):
     return b if b.stride(1) == 1 else b.contiguous()
 
 
-def _triton_plain(a, b, out_dtype, sa=1.0, sb=1.0, BM=128, BN=128, BK=64):
+def _triton_plain(a, b, out_dtype, scale=1.0, BM=128, BN=128, BK=64):
     b = _kcontig(b)
     M, K = a.shape
     N = b.shape[1]
     c = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
     grid = (triton.cdiv(M, BM) * triton.cdiv(N, BN), )
     _plain_gemm[grid](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0), c.stride(1),
-                      sa, sb, BM=BM, BN=BN, BK=BK, num_warps=8)
+                      scale, BM=BM, BN=BN, BK=BK, num_warps=8)
     return c
 
 
-def _triton_plain_k_per_dot(a, b, out_dtype, k_per_dot, res, sa=1.0, sb=1.0, BM=128, BN=128, BK=16):
+def _triton_plain_k_per_dot(a, b, out_dtype, k_per_dot, res, scale=1.0, BM=128, BN=128, BK=16):
     """Plain GEMM accumulating `k_per_dot` real k-elements per dot, with the partial group
     ending at `res`, so the accumulator rounds where cuBLAS's CUTLASS kernel rounds. The tile
     and the MMA Triton picks are bit-neutral here (measured 2000/2000 both ways), so BM, BN,
@@ -464,7 +465,7 @@ def _triton_plain_k_per_dot(a, b, out_dtype, k_per_dot, res, sa=1.0, sb=1.0, BM=
     c = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
     grid = (triton.cdiv(M, BM) * triton.cdiv(N, BN), )
     _plain_gemm_k_per_dot[grid](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0),
-                                c.stride(1), sa, sb, k_per_dot, res, BM=BM, BN=BN, BK=BK, num_warps=8)
+                                c.stride(1), scale, k_per_dot, res, BM=BM, BN=BN, BK=BK, num_warps=8)
     return c
 
 
@@ -488,7 +489,7 @@ def _k_per_dot_candidates(K):
     return out
 
 
-def _triton_splitk_groups(a, b, chunk, k_per_dot, ktile, cmode, out_dtype, sa=1.0, sb=1.0, BK=16):
+def _triton_splitk_groups(a, b, chunk, k_per_dot, ktile, cmode, out_dtype, scale=1.0, BK=16):
     """Two-pass split-K for the CUTLASS path: `chunk`-element slices, each accumulated in
     groups of `k_per_dot` real k with a per-slice residue tile of `ktile`, merged by `cmode`."""
     b = _kcontig(b)
@@ -505,7 +506,7 @@ def _triton_splitk_groups(a, b, chunk, k_per_dot, ktile, cmode, out_dtype, sa=1.
                                                BN=BN, BK=BK, num_warps=4)
     c = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
     _splitk_combine_modes[(ntile, )](w, c, M, N, w.stride(0), w.stride(1), w.stride(2), c.stride(0), c.stride(1),
-                                     nsplit, sa, sb, CMODE=cmode, BM=BM, BN=BN, num_warps=4)
+                                     nsplit, scale, CMODE=cmode, BM=BM, BN=BN, num_warps=4)
     return c
 
 
@@ -541,7 +542,7 @@ def _splitk_group_candidates(K, nsplit):
     return out
 
 
-def _triton_splitk(a, b, chunk, out_dtype, sa=1.0, sb=1.0, BK=64):
+def _triton_splitk(a, b, chunk, out_dtype, scale=1.0, BK=64):
     """Deterministic two-pass split-K at `chunk`-element early slices (uneven tail),
     forward FP32 combine. Returns None if the chunk does not yield a real split (nsplit<2)."""
     b = _kcontig(b)
@@ -556,8 +557,8 @@ def _triton_splitk(a, b, chunk, out_dtype, sa=1.0, sb=1.0, BK=64):
     _splitk_partial[(ntile, nsplit)](a, b, w, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), w.stride(0),
                                      w.stride(1), w.stride(2), chunk, BM=BM, BN=BN, BK=BK, num_warps=4)
     c = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
-    _splitk_combine[(ntile, )](w, c, M, N, w.stride(0), w.stride(1), w.stride(2), c.stride(0), c.stride(1), nsplit, sa,
-                               sb, BM=BM, BN=BN, num_warps=4)
+    _splitk_combine[(ntile, )](w, c, M, N, w.stride(0), w.stride(1), w.stride(2), c.stride(0), c.stride(1), nsplit,
+                               scale, BM=BM, BN=BN, num_warps=4)
     return c
 
 
@@ -577,7 +578,8 @@ _TLS = threading.local()   # per-CALL overrides live here, never in a global -- 
 _UNSET = object()
 _LT_LIBS: dict = {}   # resolved path -> loaded library, so switching back and forth is free
 _LT_PATHS: dict = {}  # spec -> resolved path
-_ONES = None  # device fp32 [1.0] for fp8 scale pointers
+_SCALE_A = None  # device fp32 [1] holding the A scale cuBLAS is given (fp8 only)
+_SCALE_B = None  # same for B
 _WS = None    # device scratch for the reference execute
 
 
@@ -671,7 +673,7 @@ def _resolve_lt(spec):
 
 
 def _load_lt():
-    global _ONES, _WS
+    global _SCALE_A, _SCALE_B, _WS
     path = _resolve_lt(_lt_spec())
     lib = _LT_LIBS.get(path)
     if lib is not None:
@@ -694,8 +696,9 @@ def _load_lt():
     lib.cublasLtMatmulAlgoConfigGetAttribute.argtypes = [P, ci, P, csz, ctypes.POINTER(csz)]
     lib.cublasLtMatmul.restype = ci
     lib.cublasLtMatmul.argtypes = [P] * 14 + [csz, P]  # 14 ptrs, workspaceSize, stream
-    if _ONES is None:
-        _ONES = torch.ones(1, dtype=torch.float32, device=DEVICE)
+    if _SCALE_A is None:
+        _SCALE_A = torch.ones(1, dtype=torch.float32, device=DEVICE)
+        _SCALE_B = torch.ones(1, dtype=torch.float32, device=DEVICE)
         _WS = torch.empty(_WS_BYTES, dtype=torch.uint8, device=DEVICE)
     _LT_LIBS[path] = lib
     return lib
@@ -728,7 +731,7 @@ def _set_row(lib, layout):
     _ck("layout-order", lib.cublasLtMatrixLayoutSetAttribute(layout, _LAYOUT_ORDER, ctypes.byref(v), 4))
 
 
-def _make_layouts(lib, desc, M, N, K, kind, out_dtype):
+def _make_layouts(lib, desc, M, N, K, kind, out_dtype, sa=1.0, sb=1.0):
     """Row-major layouts matching a standard torch GEMM dispatch; set transa/transb
     (+ fp8 scale pointers). Returns (A, B, C, D) layout handles."""
     ab, cd, transa, transb = _lt_dtypes(kind, out_dtype)
@@ -744,9 +747,11 @@ def _make_layouts(lib, desc, M, N, K, kind, out_dtype):
     else:  # fp8 e4m3 TN: operands K-contiguous (col-major), output row-major
         _ck("LA", lib.cublasLtMatrixLayoutCreate(ctypes.byref(A), ab, K, M, K))
         _ck("LB", lib.cublasLtMatrixLayoutCreate(ctypes.byref(B), ab, K, N, K))
-        sp = ctypes.c_void_p(_ONES.data_ptr())
-        _ck("Ascale", lib.cublasLtMatmulDescSetAttribute(desc, _DESC_A_SCALE_PTR, ctypes.byref(sp), 8))
-        _ck("Bscale", lib.cublasLtMatmulDescSetAttribute(desc, _DESC_B_SCALE_PTR, ctypes.byref(sp), 8))
+        _SCALE_A.fill_(sa)
+        _SCALE_B.fill_(sb)
+        for attr, t in ((_DESC_A_SCALE_PTR, _SCALE_A), (_DESC_B_SCALE_PTR, _SCALE_B)):
+            sp = ctypes.c_void_p(t.data_ptr())
+            _ck("scale", lib.cublasLtMatmulDescSetAttribute(desc, attr, ctypes.byref(sp), 8))
     _ck("LC", lib.cublasLtMatrixLayoutCreate(ctypes.byref(C), cd, M, N, N))
     _set_row(lib, C)
     _ck("LD", lib.cublasLtMatrixLayoutCreate(ctypes.byref(D), cd, M, N, N))
@@ -754,7 +759,7 @@ def _make_layouts(lib, desc, M, N, K, kind, out_dtype):
     return A, B, C, D
 
 
-def _cublas_direct(a, b, kind, out_dtype, execute=True):
+def _cublas_direct(a, b, kind, out_dtype, execute=True, sa=1.0, sb=1.0):
     """Query cuBLAS's top-heuristic algo and (if execute) run it DIRECTLY via ctypes
     cublasLtMatmul. Returns (D, nsplit): with execute, D is cuBLAS's exact output; without,
     D is None and only the heuristic's SPLITK_NUM is read (pure-static, no GEMM run). No torch."""
@@ -766,7 +771,7 @@ def _cublas_direct(a, b, kind, out_dtype, execute=True):
     try:
         _ck("create", lib.cublasLtCreate(ctypes.byref(handle)))
         _ck("desc", lib.cublasLtMatmulDescCreate(ctypes.byref(desc), _CUBLAS_COMPUTE_32F, _CUDA_R_32F))
-        A, B, C, D = _make_layouts(lib, desc, M, N, K, kind, out_dtype)
+        A, B, C, D = _make_layouts(lib, desc, M, N, K, kind, out_dtype, sa, sb)
         _ck("pref", lib.cublasLtMatmulPreferenceCreate(ctypes.byref(pref)))
         ws = ctypes.c_size_t(_WS_BYTES)
         _ck("pref-set", lib.cublasLtMatmulPreferenceSetAttribute(pref, _PREF_MAX_WS, ctypes.byref(ws), 8))
@@ -805,14 +810,15 @@ def _cublas_direct(a, b, kind, out_dtype, execute=True):
                 pass
 
 
-def cublas_matmul(a, b, out_dtype=None, cublaslt=None):
+def cublas_matmul(a, b, out_dtype=None, scale_a=None, scale_b=None, cublaslt=None):
     """cuBLAS's OWN output (run directly via cublasLtMatmul), the reference our
     reconstruction must match. fp16/bf16: `b` is [K,N]. fp8: `b` is [K,N] column-major.
     `cublaslt` picks which cuBLAS, as in `cublas_equivalent_gemm`."""
     kind = _kind_of(a)
     out_dtype = out_dtype or (torch.float16 if kind == "fp8" else a.dtype)
     with _using_cublaslt(cublaslt):
-        return _cublas_direct(a, b, kind, out_dtype)[0]
+        return _cublas_direct(a, b, kind, out_dtype, sa=scale_a if scale_a is not None else 1.0,
+                              sb=scale_b if scale_b is not None else 1.0)[0]
 
 
 # --------------------------------------------------------------------------- #
@@ -922,15 +928,30 @@ def _is_static_exact(kind, nsplit, aligned):
     return aligned and nsplit <= 1
 
 
-def _reconstruct(a, b, out_dtype, plan, sa=1.0, sb=1.0):
+def _f32(x):
+    """Round a Python float to fp32, the width cuBLAS keeps its scales in."""
+    return struct.unpack("f", struct.pack("f", x))[0]
+
+
+def _fold_scales(scale_a, scale_b):
+    """The single fp32 factor cuBLAS applies to the accumulator for an fp8 GEMM.
+
+    cuBLAS multiplies the two operand scales together in fp32 and does ONE multiply on the fp32
+    accumulator, before the cast to the output dtype. Applying them as two multiplies rounds
+    twice and differs in the last bits whenever neither is a power of two: measured over 10
+    scale pairs on 3 shapes, two multiplies matched cuBLAS 15/30 and this folding 30/30."""
+    return _f32(_f32(1.0 if scale_a is None else scale_a) * _f32(1.0 if scale_b is None else scale_b))
+
+
+def _reconstruct(a, b, out_dtype, plan, scale=1.0):
     mode, arg = plan
     if mode == "plain":
-        return _triton_plain(a, b, out_dtype, sa=sa, sb=sb)
+        return _triton_plain(a, b, out_dtype, scale=scale)
     if mode == "k_per_dot":
-        return _triton_plain_k_per_dot(a, b, out_dtype, arg[0], arg[1], sa=sa, sb=sb)
+        return _triton_plain_k_per_dot(a, b, out_dtype, arg[0], arg[1], scale=scale)
     if mode == "splitk_groups":
-        return _triton_splitk_groups(a, b, arg[0], arg[1], arg[2], arg[3], out_dtype, sa=sa, sb=sb)
-    return _triton_splitk(a, b, arg, out_dtype, sa=sa, sb=sb)
+        return _triton_splitk_groups(a, b, arg[0], arg[1], arg[2], arg[3], out_dtype, scale=scale)
+    return _triton_splitk(a, b, arg, out_dtype, scale=scale)
 
 
 def _launched_kernel_names(a, b, out_dtype):
@@ -1145,14 +1166,53 @@ def _resolve(a, b, kind, out_dtype, enable_runtime_match, enable_pseudo_static=T
 # --------------------------------------------------------------------------- #
 # Public API
 # --------------------------------------------------------------------------- #
+def _canonical_layout(t, want):
+    """Is `t` laid out the way `_make_layouts` tells cuBLAS it is? A size-1 dim has no say."""
+    r, c = t.shape
+    s0, s1 = t.stride()
+    e0, e1 = (c, 1) if want == "row-major" else (1, r)
+    return (r == 1 or s0 == e0) and (c == 1 or s1 == e1)
+
+
+def _check_operands(a, b, kind):
+    """cuBLAS is told one fixed layout per dtype (see `_make_layouts`), not the tensor's actual
+    strides. An operand laid out any other way therefore makes the reference read the same bytes
+    as a different matrix -- and cuBLAS does not complain, it returns a different product, while
+    the Triton side reads the real strides and returns the right one. That looks like "Triton
+    does not match cuBLAS" when it is really a wrong call. Refuse it up front instead."""
+    if a.dim() != 2 or b.dim() != 2:
+        raise ValueError(f"expected 2-D operands, got {tuple(a.shape)} and {tuple(b.shape)}")
+    if a.shape[1] != b.shape[0]:
+        raise ValueError(f"shapes do not match: a is {tuple(a.shape)}, b is {tuple(b.shape)}")
+    if a.dtype != b.dtype:
+        raise ValueError(f"operands must share a dtype, got {a.dtype} and {b.dtype}")
+    want_b = "column-major" if kind == "fp8" else "row-major"
+    for name, t, want in (("a", a, "row-major"), ("b", b, want_b)):
+        if _canonical_layout(t, want):
+            continue
+        hint = " -- pass `w.t()` for a [N,K] weight" if (name == "b" and kind == "fp8") else ""
+        raise ValueError(f"{kind} needs {name} {list(t.shape)} {want}, got strides {t.stride()}{hint}. "
+                         f"cuBLAS is told this layout, so any other one makes the reference compute a "
+                         f"different product and the comparison meaningless.")
+
+
 def cublas_equivalent_gemm(a: torch.Tensor, b: torch.Tensor, out_dtype: torch.dtype | None = None,
+                           scale_a: float | None = None, scale_b: float | None = None,
                            enable_runtime_match: bool = False, enable_pseudo_static: bool = True,
                            cublaslt: str | None = None) -> torch.Tensor:
-    """fp16/bf16 GEMM, bit-identical to cuBLAS. `a` is [M,K], `b` is [K,N].
+    """A GEMM bit-identical to cuBLAS, for fp16, bf16 and fp8 (e4m3). `a` is [M,K] row-major.
 
-    Static by default: the reconstruction is planned from the cuBLAS heuristic alone (no GEMM
-    run). Aligned fp16/bf16 is static-exact. A shape that is not statically guaranteed
-    (non-aligned) raises CublasNeedRuntimeMatch -- unless `enable_runtime_match=True`, which
+    `b` is [K,N], row-major for fp16/bf16 and column-major for fp8 (i.e. `w.t()` of an [N,K]
+    weight) -- that is cuBLAS's own requirement for e4m3, not a choice here, and passing the
+    other layout raises rather than silently returning something that does not match.
+
+    `scale_a` and `scale_b` are the fp8 operand scales and may only be given for fp8. They are
+    folded into one fp32 factor before the accumulator is scaled, which is what cuBLAS does --
+    see `_fold_scales`. `out_dtype` defaults to the input dtype, or fp16 for fp8 input.
+
+    Static by default: the reconstruction is planned from the cuBLAS heuristic alone, with no
+    GEMM run. Aligned fp16/bf16 and plain fp8 are static-exact. A shape that is not statically
+    guaranteed raises CublasNeedRuntimeMatch -- unless `enable_runtime_match=True`, which
     byte-compares candidates against cuBLAS and returns the match or raises
     CublasUnsupportedShape.
 
@@ -1160,32 +1220,22 @@ def cublas_equivalent_gemm(a: torch.Tensor, b: torch.Tensor, out_dtype: torch.dt
     path -- overriding `set_cublaslt`. Default is the process-wide choice.
     """
     kind = _kind_of(a)
-    if kind == "fp8":
-        raise ValueError("use cublas_equivalent_scaled_mm for fp8")
-    out_dtype = out_dtype or a.dtype
+    if kind != "fp8" and (scale_a is not None or scale_b is not None):
+        raise ValueError(f"scale_a/scale_b are fp8-only, but the input is {a.dtype}")
+    _check_operands(a, b, kind)
+    out_dtype = out_dtype or (torch.float16 if kind == "fp8" else a.dtype)
     with _using_cublaslt(cublaslt):
         plan = _resolve(a, b, kind, out_dtype, enable_runtime_match, enable_pseudo_static)
-        return _reconstruct(a, b, out_dtype, plan)
+        return _reconstruct(a, b, out_dtype, plan, scale=_fold_scales(scale_a, scale_b))
 
 
 def cublas_equivalent_scaled_mm(a: torch.Tensor, b: torch.Tensor, scale_a: float = 1.0, scale_b: float = 1.0,
                                 out_dtype: torch.dtype = torch.float16, enable_runtime_match: bool = False,
                                 enable_pseudo_static: bool = True,
                                 cublaslt: str | None = None) -> torch.Tensor:
-    """fp8 (e4m3) GEMM, bit-identical to cuBLAS. `a` is [M,K], `b` is [K,N] column-major
-    (i.e. from `w.t()`); scales are scalars.
-
-    fp8 plain is static-exact. fp8 split-K is NOT statically guaranteed (the vertical/cluster
-    kernel is not bit-reproducible) -> raises CublasNeedRuntimeMatch unless
-    `enable_runtime_match=True`, which byte-compares against cuBLAS and returns the match or
-    raises CublasUnsupportedShape (vertical split-K).
-
-    `cublaslt` picks which cuBLAS to match for this call -- a version prefix ("12.8") or a
-    path -- overriding `set_cublaslt`. Default is the process-wide choice.
-    """
-    with _using_cublaslt(cublaslt):
-        plan = _resolve(a, b, "fp8", out_dtype, enable_runtime_match, enable_pseudo_static)
-        return _reconstruct(a, b, out_dtype, plan, sa=scale_a, sb=scale_b)
+    """`cublas_equivalent_gemm` under the name torch uses for the scaled fp8 path."""
+    return cublas_equivalent_gemm(a, b, out_dtype, scale_a, scale_b, enable_runtime_match,
+                                  enable_pseudo_static, cublaslt)
 
 
 # --------------------------------------------------------------------------- #
@@ -1196,8 +1246,7 @@ def _check_one(kind, M, N, K):
     guessed from which call succeeded. Returns (tier, bit_ok)."""
     a, b = _make_inputs(M, N, K, kind, 7)
     ref = cublas_matmul(a, b, torch.float16 if kind == "fp8" else None)
-    call = (lambda rt: cublas_equivalent_scaled_mm(a, b, 1.0, 1.0, torch.float16, enable_runtime_match=rt)) \
-        if kind == "fp8" else (lambda rt: cublas_equivalent_gemm(a, b, enable_runtime_match=rt))
+    call = lambda rt: cublas_equivalent_gemm(a, b, enable_runtime_match=rt)  # noqa: E731
     try:
         try:
             out = call(False)

--- a/bitequiv/eval_cublas_equiv_gemm.py
+++ b/bitequiv/eval_cublas_equiv_gemm.py
@@ -29,6 +29,7 @@ import torch
 from bitequiv import cublas_equiv_gemm as _G
 from bitequiv.cublas_equiv_gemm import (
     CublasNeedRuntimeMatch,
+    CublasUnsupportedPlatform,
     CublasUnsupportedShape,
     cublas_equivalent_gemm,
     cublas_equivalent_scaled_mm,
@@ -148,8 +149,14 @@ def run(timeout, report_every, R, dtypes, seed, enable_rt, mode, max_dim, max_mn
     t0 = time.time()
     last = t0
 
-    print(f"device: {torch.cuda.get_device_name()} | dtypes={dtypes} R={R} timeout={timeout}s "
-          f"enable_runtime_match={enable_rt}")
+    try:
+        prof = _G._platform()
+    except CublasUnsupportedPlatform as e:
+        print(f"cannot run here: {e}")
+        return
+    print(f"device: {torch.cuda.get_device_name()} | platform: {prof.name} | cuBLASLt "
+          f"{'.'.join(map(str, _G._cublaslt_version()))} from {_G._load_lt()._name} | dtypes={dtypes} R={R} "
+          f"timeout={timeout}s enable_runtime_match={enable_rt}")
     if mode == "extreme":
         print(f"EXTREME shapes: M,N ~ uniform[1,{max_mn}], K ~ uniform[1,{max_k}] -- the skinny+deep "
               f"split-K corner")
@@ -233,7 +240,7 @@ def run(timeout, report_every, R, dtypes, seed, enable_rt, mode, max_dim, max_mn
                             out = our_api(a, b, dtype, out_dtype, True)
                             use_rt = True
                         # which tier actually resolved it is recorded in the plan cache
-                        origin = _G._PLAN.get((M, N, K, dtype_kind(dtype), out_dtype), ("?", None))[0]
+                        origin = _G.plan_origin(M, N, K, dtype_kind(dtype), out_dtype)
                         outcome = origin
                         {"static": seen_static, "pseudo-static": seen_pseudo,
                          "runtime": seen_runtime}.get(origin, seen_runtime).add(key)
@@ -324,6 +331,8 @@ def main():
                          "nearly every draw becomes no_ref; useful only to measure that rate")
     ap.add_argument("--max-gib", type=float, default=6.0,
                     help="skip a shape whose operands+output exceed this many GiB (resource skip)")
+    ap.add_argument("--cublaslt", type=str, default="",
+                    help="path to the libcublasLt to match (default: auto-detect the newest installed)")
     ap.add_argument("--shape-log", type=str, default="",
                     help="append one jsonl row per distinct shape here; also used to resume")
     args = ap.parse_args()
@@ -332,6 +341,8 @@ def main():
         return
     dtypes = [d.strip() for d in args.dtypes.split(",") if d.strip()]
     max_k = args.max_k or (400000 if args.shape_mode == "extreme" else args.max_dim)
+    if args.cublaslt:
+        _G.set_cublaslt(args.cublaslt)
     run(args.timeout, args.report_every, args.R, dtypes, args.seed, args.enable_runtime_match, args.shape_mode,
         args.max_dim, args.max_mn, max_k, not args.no_fp8_round16, int(args.max_gib * 2**30), args.shape_log)
 

--- a/bitequiv/eval_cublas_equiv_gemm.py
+++ b/bitequiv/eval_cublas_equiv_gemm.py
@@ -32,7 +32,6 @@ from bitequiv.cublas_equiv_gemm import (
     CublasUnsupportedPlatform,
     CublasUnsupportedShape,
     cublas_equivalent_gemm,
-    cublas_equivalent_scaled_mm,
     cublas_matmul,
 )
 
@@ -109,9 +108,17 @@ def dtype_kind(dtype):
     return "fp8" if dtype == "fp8" else ("bf16" if dtype == "bf16" else "fp16")
 
 
-def our_api(a, b, dtype, out_dtype, enable_rt):
+def fp8_scales(rng):
+    """A random (scale_a, scale_b) for fp8. Mostly awkward values on purpose: a power of two
+    is exact on both sides and so proves nothing about where the multiply happens."""
+    if rng.random() < 0.2:
+        return 1.0, 1.0
+    return 10**rng.uniform(-4, 2) * rng.choice([1.0, 1.3, 7.77]), 10**rng.uniform(-4, 2) * rng.choice([1.0, 0.3, 1.1])
+
+
+def our_api(a, b, dtype, out_dtype, enable_rt, scales=(1.0, 1.0)):
     if dtype == "fp8":
-        return cublas_equivalent_scaled_mm(a, b, 1.0, 1.0, out_dtype, enable_runtime_match=enable_rt)
+        return cublas_equivalent_gemm(a, b, out_dtype, scales[0], scales[1], enable_runtime_match=enable_rt)
     return cublas_equivalent_gemm(a, b, out_dtype, enable_runtime_match=enable_rt)
 
 
@@ -208,6 +215,7 @@ def run(timeout, report_every, R, dtypes, seed, enable_rt, mode, max_dim, max_mn
             for r in range(R):
                 s = 100003 + st["drawn"] * 131 + r  # disjoint from the API's calibration seeds
                 imode = "order" if (r % 2 == 0) else "plain"
+                scales = fp8_scales(rng) if dtype == "fp8" else (1.0, 1.0)
                 try:
                     a, b = make_inputs(M, N, K, dtype, s, imode)
                 except Exception as e:
@@ -217,7 +225,7 @@ def run(timeout, report_every, R, dtypes, seed, enable_rt, mode, max_dim, max_mn
                     outcome = "error"
                     break
                 try:
-                    ref = cublas_matmul(a, b, out_dtype)
+                    ref = cublas_matmul(a, b, out_dtype, scales[0], scales[1])
                 except Exception as e:
                     if _is_oom(e):
                         raise
@@ -230,14 +238,14 @@ def run(timeout, report_every, R, dtypes, seed, enable_rt, mode, max_dim, max_mn
                 try:
                     if use_rt is None:  # first comparable input: let the API pick a tier
                         try:
-                            out = our_api(a, b, dtype, out_dtype, False)
+                            out = our_api(a, b, dtype, out_dtype, False, scales)
                             use_rt = False
                         except CublasNeedRuntimeMatch:
                             if not enable_rt:
                                 seen_needrt.add(key)
                                 outcome = "needrt"
                                 break  # static-only mode: count it, do not compare
-                            out = our_api(a, b, dtype, out_dtype, True)
+                            out = our_api(a, b, dtype, out_dtype, True, scales)
                             use_rt = True
                         # which tier actually resolved it is recorded in the plan cache
                         origin = _G.plan_origin(M, N, K, dtype_kind(dtype), out_dtype)
@@ -245,7 +253,7 @@ def run(timeout, report_every, R, dtypes, seed, enable_rt, mode, max_dim, max_mn
                         {"static": seen_static, "pseudo-static": seen_pseudo,
                          "runtime": seen_runtime}.get(origin, seen_runtime).add(key)
                     else:
-                        out = our_api(a, b, dtype, out_dtype, use_rt)
+                        out = our_api(a, b, dtype, out_dtype, use_rt, scales)
                 except CublasUnsupportedShape:
                     seen_unsup.add(key)
                     outcome = "unsupported"
@@ -255,7 +263,7 @@ def run(timeout, report_every, R, dtypes, seed, enable_rt, mode, max_dim, max_mn
                         raise
                     st["error"] += 1
                     outcome = "error"
-                    mm_file.write(json.dumps({"M": M, "N": N, "K": K, "dtype": dtype, "seed": s, "mode": imode,
+                    mm_file.write(json.dumps({"M": M, "N": N, "K": K, "dtype": dtype, "seed": s, "mode": imode, "scales": scales,
                                               "error": f"{type(e).__name__}: {str(e)[:120]}"}) + "\n")
                     mm_file.flush()
                     break
@@ -268,7 +276,7 @@ def run(timeout, report_every, R, dtypes, seed, enable_rt, mode, max_dim, max_mn
                     bit_ok = False
                     diff = (out.float() - ref.float()).abs()
                     mm_file.write(json.dumps({
-                        "M": M, "N": N, "K": K, "dtype": dtype, "seed": s, "mode": imode,
+                        "M": M, "N": N, "K": K, "dtype": dtype, "seed": s, "mode": imode, "scales": scales,
                         "class": outcome, "max_abs_diff": float(diff.max()),
                         "n_diff": int((diff > 0).sum()), "out_dtype": str(out_dtype)}) + "\n")
                     mm_file.flush()

--- a/bitequiv/example_cublas_equiv_gemm.py
+++ b/bitequiv/example_cublas_equiv_gemm.py
@@ -16,7 +16,6 @@ from bitequiv.cublas_equiv_gemm import (
     CublasNeedRuntimeMatch,
     CublasUnsupportedShape,
     cublas_equivalent_gemm,
-    cublas_equivalent_scaled_mm,
     cublas_matmul,
     set_cublaslt,
 )
@@ -68,7 +67,7 @@ def example_fp8_plain():
     a = (torch.randn(M, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn)
     b = (torch.randn(N, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn).t()   # [K,N] column-major
 
-    out = cublas_equivalent_scaled_mm(a, b, scale_a=1.0, scale_b=1.0, out_dtype=torch.float16,
+    out = cublas_equivalent_gemm(a, b, scale_a=1.0, scale_b=1.0, out_dtype=torch.float16,
                                       enable_runtime_match=False)  # static (default): large-output fp8 plain is exact
     ref = cublas_matmul(a, b, out_dtype=torch.float16)
     print(f"fp8  plain    {M}x{N}x{K}: bit-identical to cuBLAS = {_bit_equal(out, ref)}")
@@ -84,18 +83,45 @@ def example_fp8_split_k_runtime():
     b = (torch.randn(N, K, device=DEVICE) * 0.2).to(torch.float8_e4m3fn).t()
 
     try:                                          # static mode (default): heuristic only, no cuBLAS GEMM run
-        cublas_equivalent_scaled_mm(a, b, enable_runtime_match=False)
+        cublas_equivalent_gemm(a, b, enable_runtime_match=False)
         print(f"fp8  split-K  {M}x{N}x{K}: statically reconstructed")
     except CublasNeedRuntimeMatch:
         print(f"fp8  split-K  {M}x{N}x{K}: needs a runtime match (static mode declined)")
 
     try:                                          # runtime mode: allow a one-time byte-compare against cuBLAS
-        out = cublas_equivalent_scaled_mm(a, b, enable_runtime_match=True)
+        out = cublas_equivalent_gemm(a, b, enable_runtime_match=True)
         print(f"fp8  split-K  {M}x{N}x{K}: with enable_runtime_match=True -> "
               f"bit-identical = {_bit_equal(out, cublas_matmul(a, b))}")
     except CublasUnsupportedShape:
         out = cublas_matmul(a, b)                 # vertical split-K: fall back to cuBLAS
         print(f"fp8  split-K  {M}x{N}x{K}: UNSUPPORTED -> fell back to cuBLAS")
+
+
+def example_one_api_two_dtypes():
+    """One entry point for both dtypes; `b`'s required layout is the only thing that differs."""
+    print("-- one API, fp16 and fp8 --")
+    M, N, K = 1024, 1024, 2048
+
+    a16 = torch.randn(M, K, device=DEVICE, dtype=torch.float16)     # [M,K] row-major
+    b16 = torch.randn(K, N, device=DEVICE, dtype=torch.float16)     # [K,N] row-major
+    out = cublas_equivalent_gemm(a16, b16)
+    print(f"  fp16 {M}x{N}x{K}: {'BIT-IDENTICAL' if _bit_equal(out, cublas_matmul(a16, b16)) else 'MISMATCH'}")
+
+    a8 = (torch.randn(M, K, device=DEVICE) / 4).to(torch.float8_e4m3fn)              # [M,K] row-major
+    b8 = (torch.randn(N, K, device=DEVICE) / 4).to(torch.float8_e4m3fn).t()          # [K,N] column-major
+    # Awkward scales on purpose: a power of two is exact either way and proves nothing.
+    for sa, sb in ((1.0, 1.0), (1.3, 0.017)):
+        out = cublas_equivalent_gemm(a8, b8, scale_a=sa, scale_b=sb)
+        ref = cublas_matmul(a8, b8, torch.float16, scale_a=sa, scale_b=sb)
+        print(f"  fp8  {M}x{N}x{K} scales {sa}, {sb}: "
+              f"{'BIT-IDENTICAL' if _bit_equal(out, ref) else 'MISMATCH'}")
+
+    # cuBLAS is told one layout per dtype, so the wrong one used to return a quietly
+    # non-matching result. It now raises.
+    try:
+        cublas_equivalent_gemm(a8, (torch.randn(K, N, device=DEVICE) / 4).to(torch.float8_e4m3fn))
+    except ValueError as e:
+        print(f"  fp8 with a row-major b: refused -- {str(e).split('.')[0]}")
 
 
 def example_choose_cublas_version():
@@ -121,43 +147,25 @@ def example_choose_cublas_version():
 
 
 def example_cannot_match():
-    """Shapes where the cuBLAS heuristic's algo has NO bit-identical Triton reconstruction,
-    even with enable_runtime_match=True -> CublasUnsupportedShape (never a wrong result).
+    """Shapes the heuristic answers but no Triton reconstruction matches, so the API declines.
 
-    Two families cover them:
-      1. fp16 non-aligned (odd N or odd K): cuBLAS switches to a CUTLASS kernel that either
-         uses an MMA with K=8 (`s1688`) or an odd-K reduction tail. Triton's `tl.dot` emits
-         K=16, so the base MMA groups/rounds the products differently.
-      2. a split-K residual (~1.1% of aligned fp16 split-K, ~0.4% of fp8) where K is not a
-         whole number of k-tiles, so the last slice is a partial one: no K partition
-         reproduces these -- a wide sweep of thousands of alternative partitions per shape
-         found none. Strongly associated with K%64 != 0, but not decided by it, so it can
-         only be caught by the runtime byte-compare."""
-    fp16_nonaligned = [(64, 64, 257), (16, 65, 8192), (64, 129, 8192), (512, 513, 4096), (64, 64, 4097),
-                       (128, 127, 16384), (33, 33, 15000)]
-    fp16_partial_last_slice = [(96, 48, 175248), (64, 64, 116864), (64, 24, 116864), (64, 64, 219648)]
-
-    print("cannot-match (heuristic gives an algo, but no Triton reconstruction is bit-identical):")
-    print("  -- fp16 non-aligned -> CUTLASS s1688 (MMA K=8) / odd-K tail --")
-    for (M, N, K) in fp16_nonaligned:
+    All of them are matrix-times-vector: M == 1 or N == 1. cuBLAS then leaves its tensor-core
+    kernels entirely and runs a SIMT fallback -- `gemv2T_kernel`, `dot_kernel`,
+    `reduce_1Block_kernel` -- which is CUDA-core FFMA with a shuffle reduction, an accumulation
+    order none of the reconstructions here has. The caller gets an exception, not wrong bits."""
+    print("cannot-match (cuBLAS runs a SIMT gemv, not a tensor-core kernel):")
+    for M, N, K in [(1, 246, 342349), (94, 1, 175811), (170, 1, 170157), (251, 1, 38346),
+                    (21, 1, 65878), (1, 23, 32259), (1, 104, 151171), (161, 1, 391706)]:
         a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
         b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
         try:
             cublas_equivalent_gemm(a, b, enable_runtime_match=True)
             print(f"  fp16 {M}x{N}x{K}: reconstructed (unexpected)")
         except CublasUnsupportedShape:
-            print(f"  fp16 {M}x{N}x{K}: UNSUPPORTED -> caller falls back to cuBLAS")
-
-    print("  -- aligned fp16 split-K, partial last k-slice -> no partition reproduces it --")
-    for (M, N, K) in fp16_partial_last_slice:
-        a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
-        b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
-        try:
-            cublas_equivalent_gemm(a, b, enable_runtime_match=True)
-            print(f"  fp16 {M}x{N}x{K}: reconstructed (unexpected)")
-        except CublasUnsupportedShape:
-            print(f"  fp16 {M}x{N}x{K}: UNSUPPORTED -> caller falls back to cuBLAS")
-
+            print(f"  fp16 {M}x{N}x{K}: declined -> fall back to cublas_matmul")
+        except CublasNeedRuntimeMatch:
+            print(f"  fp16 {M}x{N}x{K}: needs a runtime match")
+        del a, b
 
 def main():
     if not torch.cuda.is_available():
@@ -168,6 +176,8 @@ def main():
     example_fp16_split_k()
     example_fp8_plain()
     example_fp8_split_k_runtime()
+    print()
+    example_one_api_two_dtypes()
     print()
     example_choose_cublas_version()
     print()

--- a/bitequiv/example_cublas_equiv_gemm.py
+++ b/bitequiv/example_cublas_equiv_gemm.py
@@ -18,6 +18,7 @@ from bitequiv.cublas_equiv_gemm import (
     cublas_equivalent_gemm,
     cublas_equivalent_scaled_mm,
     cublas_matmul,
+    set_cublaslt,
 )
 
 DEVICE = "cuda"
@@ -97,6 +98,28 @@ def example_fp8_split_k_runtime():
         print(f"fp8  split-K  {M}x{N}x{K}: UNSUPPORTED -> fell back to cuBLAS")
 
 
+def example_choose_cublas_version():
+    """Which cuBLAS we are bit-identical to is a choice, not whatever loaded first.
+
+    A box usually carries several: here CUDA 13.0 (13.1.1) and CUDA 12.8 (12.8.5, the one torch
+    is built against). Pass a version prefix or a full path; libraries are cached, so switching
+    back and forth costs nothing after the first use of each."""
+    print("-- choosing which cuBLAS to match --")
+    M, N, K = 2048, 2048, 4096
+    a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
+    b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
+
+    for spec in ("12.8", "13.1"):
+        out = cublas_equivalent_gemm(a, b, cublaslt=spec)          # per call
+        ref = cublas_matmul(a, b, cublaslt=spec)
+        print(f"  cuBLAS {spec}: {'BIT-IDENTICAL' if _bit_equal(out, ref) else 'MISMATCH'}")
+
+    set_cublaslt("12.8")                                           # or for the whole process
+    out = cublas_equivalent_gemm(a, b)
+    print(f"  set_cublaslt(\"12.8\"): {'BIT-IDENTICAL' if _bit_equal(out, cublas_matmul(a, b)) else 'MISMATCH'}")
+    set_cublaslt()                                                 # back to the newest installed
+
+
 def example_cannot_match():
     """Shapes where the cuBLAS heuristic's algo has NO bit-identical Triton reconstruction,
     even with enable_runtime_match=True -> CublasUnsupportedShape (never a wrong result).
@@ -145,6 +168,8 @@ def main():
     example_fp16_split_k()
     example_fp8_plain()
     example_fp8_split_k_runtime()
+    print()
+    example_choose_cublas_version()
     print()
     example_cannot_match()
 


### PR DESCRIPTION
Summary:

There were two entry points, `cublas_equivalent_gemm` for fp16/bf16 and `cublas_equivalent_scaled_mm` for fp8, mirroring `torch.matmul` and `torch._scaled_mm`. Internally they were already one path -- `_kind_of` picks the dtype, `_resolve` takes it as an argument, and the Triton kernels read explicit strides -- so the split only ever lived in the signature. It is now one function that dispatches on the input dtype, with `scale_a` / `scale_b` optional and fp8-only. `cublas_equivalent_scaled_mm` stays as a one-line alias so the torch-familiar name and existing call sites keep working.

Merging turned up two things the claim did not actually cover.

**Operand layout.** `_make_layouts` tells cuBLAS one fixed layout per dtype -- row-major for fp16/bf16, the K-contiguous TN pair cuBLAS requires for e4m3 -- and never looks at the tensor's actual strides, while the Triton side does. Hand either entry point an operand laid out any other way and nothing failed: cuBLAS read the same bytes as a different matrix and returned a different product, the Triton kernel read the real strides and returned the right one, and the caller saw "Triton does not match cuBLAS". On 256x256x512 fp16 with a column-major `b` the reference is off by a relative 1.77 against the true product while the reconstruction is at 3.4e-4, the same as `torch.matmul` -- so the side that was wrong was the reference. Both dtypes are now checked and refused with a message naming the layout and how to fix it.

**fp8 scales.** The reference always handed cuBLAS a device 1.0 for both scale pointers, so the caller's scales reached only the Triton side and had never been compared against anything; every eval and self-check ran at 1.0. Giving cuBLAS the real scales shows it multiplies the two together in fp32 and applies **one** multiply to the fp32 accumulator, before the cast. We were applying two, which rounds twice and differs in the last bits whenever neither scale is a power of two. Over 10 scale pairs on 3 shapes, two multiplies matched 15/30 and folding to one matched 30/30. So the reference now takes the caller's scales, the reconstruction folds them (`_fold_scales`), the kernels carry one factor instead of two, and the fuzzer draws random scales -- deliberately awkward ones, since a power of two is exact either way and proves nothing. The scale does not change which kernel cuBLAS picks, so nothing else in the reconstruction moves.

Review the two guards `_canonical_layout` and `_check_operands`, then `_fold_scales` and the scale threading through `_make_layouts` / `_cublas_direct` / `cublas_matmul`, then the merged signature, then the example.

While in the example file: its cannot-match list had gone stale -- every shape on it now reconstructs through the pseudo-static tier, so it printed "(unexpected)" eleven times. Replaced with shapes that genuinely decline, all matrix-times-vector (M or N equal to 1), where cuBLAS leaves its tensor-core kernels for a SIMT fallback (`gemv2T_kernel`, `dot_kernel`, `reduce_1Block_kernel`) whose accumulation order none of the reconstructions has.

Authored with Claude Code.

Reviewed By: njriasan

Differential Revision: D114741284


