### PR TITLE
[triton][bitequiv] affine %tid bit-basis + count-up recovery for cross-warp reductions (#2760)

### DIFF
--- a/bitequiv/ptx/affine.py
+++ b/bitequiv/ptx/affine.py
@@ -68,6 +68,10 @@ def _ctz(n):
     return z
 
 
+def _is_pow2(n):
+    return n is not None and n > 0 and (n & (n - 1)) == 0
+
+
 def _is_special(name):
     return any(name.startswith(p) for p in _SPECIAL_PREFIXES)
 
@@ -277,6 +281,8 @@ class AffineEval:
             return self._and(ev(srcs[0]), ev(srcs[1]))
         if op in ("or", "xor") and len(srcs) == 2:
             return self._or_xor(ev(srcs[0]), ev(srcs[1]))
+        if op == "bfe" and len(srcs) == 3:  # bit-field extract: bits [pos, pos+len) of a
+            return self._bfe(ev(srcs[0]), ev(srcs[1]), ev(srcs[2]))
 
         return self._opaque_def(d)
 
@@ -316,7 +322,62 @@ class AffineEval:
                 terms = frozenset((sym, c >> s) for sym, c in a.terms)
                 return Affine(a.const >> s, terms, rng=_rng_scale(a.rng, 1) if a.rng is None else
                               (a.rng[0] >> s, ((a.rng[1] - 1) >> s) + 1))
+            # tid bit-slice: decompose to the bit basis, drop bits < s, shift the rest down.
+            exp = self._tid_bit_expand(a)
+            pos = self._bit_positions(exp) if exp is not None else None
+            if pos is not None and s >= 0:
+                kept = frozenset((sym, 1 << (p - s)) for p, sym in pos.items() if p >= s)
+                hi = sum(1 << (p - s) for p in pos if p >= s) + 1
+                return Affine(0, kept, rng=(0, hi))
         return self._opaque_pair(a, "shr", b)
+
+    def _tid_bit_expand(self, aff):
+        """Rewrite an integer affine into the ``%tid`` BIT basis: each ``%tid.<dim>`` term is
+        replaced by ``sum_i (coeff * 2**i) * %tid.<dim>.bit<i>`` over ``i`` in ``[0, log2(N))``
+        where ``N = reqntid[dim]`` (a bit symbol has range ``[0, 2)`` — see :func:`leaf_columns`).
+
+        This is the tid->(warp, lane, tile) basis change: because ``N`` is a power of two, bits
+        ``[0, log2 N)`` cover ``[0, N)`` EXACTLY, so the rewrite is bit-for-bit the same integer —
+        the sound precondition for turning ``and`` / ``shr`` / ``bfe`` on ``tid`` (opaque today)
+        into an exact affine. Returns ``None`` (caller stays opaque) when a term is not so
+        decomposable: a non-power-of-two / unknown ``ntid`` (bits would over-cover ``[0, N)``), or a
+        NON-tid varying symbol (``%ctaid`` / ``param:`` / ``%laneid`` / opaque) whose bits are
+        unknown, or a non-zero constant (its bits could carry into the slice — kept out of scope)."""
+        if not isinstance(aff, Affine) or aff.const != 0:
+            return None
+        terms = {}
+        for sym, coeff in aff.terms:
+            parts = sym.split(".")
+            is_bit = len(parts) == 3 and parts[0] == "%tid" and parts[2].startswith("bit")
+            is_plain = len(parts) == 2 and parts[0] == "%tid"
+            if is_bit:  # already a bit symbol — carry through
+                terms[sym] = terms.get(sym, 0) + coeff
+                continue
+            if not is_plain:
+                return None  # a non-tid varying symbol -> not bit-decomposable
+            n = self.reqntid.get(parts[1])
+            if not _is_pow2(n):
+                return None
+            for i in range(n.bit_length() - 1):  # log2(N) bits
+                bit = f"{sym}.bit{i}"
+                terms[bit] = terms.get(bit, 0) + coeff * (1 << i)
+        frozen = frozenset((s, c) for s, c in terms.items() if c != 0)
+        return Affine(0, frozen, rng=aff.rng)
+
+    @staticmethod
+    def _bit_positions(exp):
+        """The bit position of every term of a pure bit-basis affine (const 0, each coeff a single
+        power of two), or ``None`` if any coeff is not a single set bit or two terms collide on one
+        position (so a bitwise mask/shift would not distribute over the sum)."""
+        pos = {}
+        for sym, coeff in exp.terms:
+            if coeff <= 0 or (coeff & (coeff - 1)) != 0:
+                return None  # not a single power of two
+            p = coeff.bit_length() - 1
+            if p in pos:
+                return None  # two bits collide on one position
+            pos[p] = sym
+        return pos
 
     def _and(self, a, b):
         # x & mask == x  when mask covers every bit x can possibly set (no-op mask).
@@ -325,19 +386,37 @@ class AffineEval:
             bits = _set_bits_mask(a)
             if bits is not None and (mask & bits) == bits:
                 return a
-        if isinstance(b, Affine) and not b.terms and isinstance(a, Affine):
-            # symmetric (mask & x)
-            pass
+            # tid bit-slice: decompose to the bit basis and keep only bits fully inside the mask.
+            exp = self._tid_bit_expand(a)
+            pos = self._bit_positions(exp) if exp is not None else None
+            if pos is not None and mask >= 0:
+                kept = frozenset((sym, 1 << p) for p, sym in pos.items() if (mask >> p) & 1)
+                hi = sum(1 << p for p in pos if (mask >> p) & 1) + 1
+                return Affine(0, kept, rng=(0, hi))
         return self._opaque_pair(a, "and", b)
 
     def _or_xor(self, a, b):
-        # x | imm == x ^ imm == x + imm  when imm is disjoint from x's possible set bits.
-        if isinstance(a, Affine) and isinstance(b, Affine) and not b.terms:
-            imm = b.const
-            bits = _set_bits_mask(a)
-            if bits is not None and (imm & bits) == 0 and imm >= 0:
+        # x | imm == x ^ imm == x + imm  when imm is disjoint from x's possible set bits (no carry),
+        # or (a | b) == (a ^ b) == (a + b) when a, b set DISJOINT bits — both add with no carry.
+        if isinstance(a, Affine) and isinstance(b, Affine):
+            ba, bb = _set_bits_mask(a), _set_bits_mask(b)
+            if ba is not None and bb is not None and (ba & bb) == 0 and (a.const & bb) == 0 and (b.const & ba) == 0:
                 return self._binop_add(a, b, 1)
         return self._opaque_pair(a, "orxor", b)
+
+    def _bfe(self, a, pos, length):
+        """``bfe`` (bit-field extract): bits ``[p, p+len)`` of ``a`` shifted down to bit 0. Exact on
+        the tid bit basis (``= shr(and(a, ((1<<len)-1)<<p), p)``); opaque otherwise."""
+        if not (isinstance(pos, Affine) and not pos.terms and isinstance(length, Affine) and not length.terms):
+            return self._opaque_pair(a, "bfe", pos)
+        p, ln = pos.const, length.const
+        exp = self._tid_bit_expand(a)
+        bpos = self._bit_positions(exp) if exp is not None else None
+        if bpos is not None and p >= 0 and ln > 0:
+            kept = frozenset((sym, 1 << (bp - p)) for bp, sym in bpos.items() if p <= bp < p + ln)
+            hi = sum(1 << (bp - p) for bp in bpos if p <= bp < p + ln) + 1
+            return Affine(0, kept, rng=(0, hi))
+        return self._opaque_pair(a, "bfe", pos)
 
     # -- opaque construction (structural, register-name independent) -----------
 

--- a/bitequiv/ptx/builder.py
+++ b/bitequiv/ptx/builder.py
@@ -18,8 +18,8 @@ from pyptx.ir.nodes import RegisterOperand, VectorOperand
 from bitequiv.ptx.affine import AffineEval, canon, reqntid_of
 from bitequiv.ptx.leaves import leaf_coord, leaf_columns
 from bitequiv.ptx.linker import Def, DefUse
-from bitequiv.ptx.treeir import (FpOp, ITreeReduce, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp,
-                                 ShflCombine, SmemExchange)
+from bitequiv.ptx.treeir import (FpOp, ITreeReduce, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp, ShflCombine,
+                                 SmemExchange)
 
 _FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f64", ".bf16", ".bf16x2"})
 _FP_KINDS = frozenset({"add", "sub", "mul", "div", "min", "max"})
@@ -329,13 +329,74 @@ def _has_opaque(node):
     return any(isinstance(n, (OpaqueLeaf, OpaqueOp)) for n in _postorder(node))
 
 
+def _addr_resolved(node):
+    """True iff every ``Leaf`` in ``node`` has a FULLY-affine address (no ``opq(`` token in its
+    coord) — i.e. the affine engine, with its ``%tid`` bit-basis (:func:`bitequiv.ptx.affine`),
+    pinned the exact element each thread loads. This is the "affine linchpin" gate for the
+    single-leaf add collapse below: only when the addressing is fully resolved is the reduced
+    element identity known, so a lone cross-thread add leaf may soundly collapse; an unresolved
+    (opaque / swizzled) address keeps the conservative >= 2 guard (fail-closed, over-split)."""
+    for n in _postorder(node):
+        if isinstance(n, Leaf) and (n.coord is None or "opq(" in n.coord):
+            return False
+    return True
+
+
+def _is_count_up(node, ht):
+    """True iff the butterfly shuffles reduce COUNT-UP — the offset DOUBLES leaf->root (1, 2, 4, 8, ...).
+    That is the ``inner_tree`` signature: a count-up balanced tree fixes the reduction to the layout-
+    invariant canonical order, so it is bit-identical across ``num_warps``. ``unordered`` is count-DOWN
+    (16, 8, ..., 1 leaf->root). For a PURE cross-thread reduction (one boundary leaf, no within-thread
+    fold to reveal the left-fold) the butterfly direction is the ONLY signal that separates the
+    num_warps-invariant order from the layout-dependent one, so the single-leaf collapse MUST gate on it
+    or it over-merges ``unordered`` across num_warps.
+
+    Examine EVERY maximal run of shuffles at consecutive heights — the within-warp butterfly AND the
+    cross-warp run (which sits higher, separated by a shared-memory exchange). Both carry the same
+    direction. inner_tree makes every run increasing; unordered makes every run decreasing. Return True
+    iff at least one run of >= 2 steps is strictly increasing AND no run is non-increasing. Reading only
+    the TOP run (old behavior) missed the direction at low num_warps, where the cross-warp run is a
+    single (direction-less) step and only the within-warp butterfly proves count-up — so nw=2 stayed
+    over-split. A count-DOWN run (unordered), a non-monotone run, a dynamic offset, or a height carrying
+    two offsets -> False (cannot prove inner_tree -> do not collapse -> sound over-split)."""
+    by_ht = {}
+    for n in _postorder(node):
+        if isinstance(n, ShflCombine):
+            try:
+                off = int(n.offset)
+            except (TypeError, ValueError):
+                return False  # dynamic / unresolved offset
+            by_ht.setdefault(ht[id(n)], set()).add(off)
+    if not by_ht or any(len(offs) != 1 for offs in by_ht.values()):
+        return False  # no shuffles, or a height carrying two different offsets -> ambiguous
+    flat = {h: next(iter(offs)) for h, offs in by_ht.items()}
+    heights = sorted(flat)
+    runs, cur = [], [heights[0]]  # maximal runs of CONSECUTIVE heights (ascending height = leaf->root)
+    for h in heights[1:]:
+        if h == cur[-1] + 1:
+            cur.append(h)
+        else:
+            runs.append(cur)
+            cur = [h]
+    runs.append(cur)
+    saw_up = False
+    for run in runs:
+        offs = [flat[h] for h in run]  # leaf->root
+        if len(offs) < 2:
+            continue  # a single (cross-warp) step: direction-less on its own -> no evidence, skip
+        if all(0 < offs[i] < offs[i + 1] for i in range(len(offs) - 1)):
+            saw_up = True
+        else:
+            return False  # count-DOWN (unordered) or non-monotone -> not provably inner_tree
+    return saw_up
+
+
 # Pure per-element ops that are safe to keep VERBATIM inside a collapsed reduction's leaf: each is
 # a deterministic function of ONE element (cast/copy/abs/neg + the transcendentals a softmax /
 # rmsnorm / layernorm applies before the reduce), hence layout-invariant. Its token rides verbatim
 # into leaf_sig (compared, never dropped), so equal leaf_sig => same op; a config WITHOUT the op
 # gets a different leaf_sig and never merges.
-_PURE_ELT = ("cvt", "mov", "abs", "neg", "ex2", "lg2", "exp", "log",
-             "sqrt", "rsqrt", "rcp", "sin", "cos", "tanh")
+_PURE_ELT = ("cvt", "mov", "abs", "neg", "ex2", "lg2", "exp", "log", "sqrt", "rsqrt", "rcp", "sin", "cos", "tanh")
 
 
 def _tok_is_pure(token):
@@ -380,7 +441,7 @@ def _shfl_dir(node, ht):
     return tuple(sorted({off for h, off in shfls if h == lo}))
 
 
-def _collapse_info(node):
+def _collapse_info(node, ht=None):
     """(reduce_op_token, uniform_coord_free_leaf_sig, reduced_column_SET) for a collapsible reduction,
     or None if it cannot be SOUNDLY collapsed. The BOUNDARY leaves are the non-reduce CHILDREN of
     reduce nodes (NOT every non-reduce postorder node — collecting the latter double-counts a
@@ -420,9 +481,17 @@ def _collapse_info(node):
     # min/max butterfly (1 leaf/thread) is a real reduction and MAY collapse. A SHAPE-DEPENDENT op
     # (add) keys on height + shfl_dir, NOT the element set, so a lone coord-blanked leaf would merge
     # reductions over DIFFERENT element sets that share the height/direction (they differ in bits) ->
-    # keep the >= 2 guard for add (a within-thread fold pins the layout enough for the eval's
-    # same-element-set configs; a 1-leaf pure cross-thread add stays over-split, sound).
-    if op.split(".")[0] not in _ORDER_INVARIANT_OPS and len(leaves) < 2:
+    # keep the >= 2 guard for add UNLESS the sole leaf's address is FULLY resolved to affine
+    # (`_addr_resolved`) AND the tree reduces COUNT-UP (`_is_count_up`): with the `%tid` bit-basis the
+    # exact reduced element set is then pinned by the coord, and count-up is the inner_tree canonical
+    # order (bit-identical across num_warps), so a pure cross-thread add for an axis-0 / outer-axis
+    # reduction (sum_2d_axis0 etc., whose whole reduction is cross-thread -> one boundary leaf) soundly
+    # recovers num_warps. Count-DOWN (unordered) or an UNRESOLVED (opaque/swizzled) address keeps the
+    # old >= 2 fail-close (over-split, sound) — count-up vs count-down is the ONLY signal separating the
+    # num_warps-invariant order from the layout-dependent one when there is no within-thread fold. This
+    # is the affine linchpin. (ht is None on the pre-collapse `_reduces_without_leaf` scan -> stay strict.)
+    if (op.split(".")[0] not in _ORDER_INVARIANT_OPS and len(leaves) < 2
+            and not (_addr_resolved(leaves[0]) and ht is not None and _is_count_up(node, ht))):
         return None
     if not all(_leaf_layout_invariant(l) for l in leaves):
         return None  # a layout-dependent / lost-provenance leaf -> do not collapse
@@ -515,7 +584,7 @@ def collapse_balanced(root):
     new = {}
     for n in _postorder(root):
         region_root = collapsible[id(n)] and not has_coll_parent.get(id(n), False)
-        info = _collapse_info(n) if region_root else None
+        info = _collapse_info(n, ht) if region_root else None
         if info is not None:
             op, leaf_sig, cols = info
             if op.split(".")[0] in _ORDER_INVARIANT_OPS:

--- a/bitequiv/ptx/leaves.py
+++ b/bitequiv/ptx/leaves.py
@@ -78,7 +78,11 @@ def leaf_columns(ev, du, load_inst, slot):
     grid = []  # (coeff, n) for each thread-index symbol that selects a column
     for sym, coeff in addr.terms:
         if sym.startswith("%tid"):
-            n = ev.reqntid.get(sym.split(".")[-1])
+            parts = sym.split(".")
+            if len(parts) == 3 and parts[2].startswith("bit"):
+                n = 2  # one tid bit (from affine.py's tid bit-basis), range [0, 2)
+            else:
+                n = ev.reqntid.get(parts[-1])
             if n is None:
                 return None
             grid.append((coeff, n))

--- a/bitequiv/tests/test_ptx_affine.py
+++ b/bitequiv/tests/test_ptx_affine.py
@@ -28,10 +28,14 @@ def test_and_lowbit_mask_is_noop_within_range():
     assert canon(v) == "4*%tid.x"
 
 
-def test_and_partial_mask_is_opaque():
-    # mask 12 (bits 2,3) does NOT cover all bits 4*tid can set -> not provably no-op.
+def test_and_partial_mask_on_tid_is_bit_basis():
+    # A partial mask on tid is EXACT via the %tid bit-basis: reqntid 128 makes tid < 128, so bits
+    # [0,7) cover the value exactly, and 4*tid & 12 keeps bits 2,3 = (tid & 3)*4 = 4*bit0 + 8*bit1.
     v = _eval("mov.u32 %r1, %tid.x;\nshl.b32 %r2, %r1, 2;\nand.b32 %r3, %r2, 12;", "%r3")
-    assert isinstance(v, Opaque)
+    assert isinstance(v, Affine) and canon(v) == "4*%tid.x.bit0+8*%tid.x.bit1"
+    # A partial mask on a NON-tid value (unknown bits) is not bit-decomposable -> stays Opaque.
+    p = _eval("ld.param.b32 %r1, [k_param_1];\nand.b32 %r2, %r1, 12;", "%r2")
+    assert isinstance(p, Opaque)
 
 
 def test_disjoint_or_is_add():
@@ -56,8 +60,12 @@ def test_mad_wide_is_affine_times_const_plus_base():
 def test_shr_exact_when_multiple_else_opaque():
     exact = _eval("mov.u32 %r1, %tid.x;\nshl.b32 %r2, %r1, 2;\nshr.u32 %r3, %r2, 1;", "%r3")
     assert canon(exact) == "2*%tid.x"
-    inexact = _eval("mov.u32 %r1, %tid.x;\nshr.u32 %r2, %r1, 5;", "%r2")  # tid has tz 0
-    assert isinstance(inexact, Opaque)
+    # tid >> 5 (the warp index) is EXACT via the %tid bit-basis when reqntid pins tid < 128 (bits 5,6).
+    warp = _eval("mov.u32 %r1, %tid.x;\nshr.u32 %r2, %r1, 5;", "%r2")
+    assert isinstance(warp, Affine) and canon(warp) == "1*%tid.x.bit5+2*%tid.x.bit6"
+    # ...but Opaque WITHOUT a reqntid bound: cannot prove the shifted-out low bits are all tid has.
+    unbounded = _eval("mov.u32 %r1, %tid.x;\nshr.u32 %r2, %r1, 5;", "%r2", reqntid=False)
+    assert isinstance(unbounded, Opaque)
 
 
 def test_mul_reg_reg_is_opaque_and_structural():


### PR DESCRIPTION
Summary:

The forward PTX equivalence checker proves two Triton configs reduce in the same bitwise order by reconstructing each output's reduction tree and comparing a canonical signature. Cross-warp reductions — the outer-axis sums such as `sum_2d_axis0`, `sum_2d_col`, `col_sum_loop` — stage their per-warp partials through shared memory, and the checker could not prove that shared-memory layout `num_warps`-invariant, so it split every `num_warps` into its own class even when `inner_tree` makes them bit-identical. This diff recovers that `num_warps` freedom for the ordered case, soundly.

Review in two steps.

`affine.py` first — the `%tid` bit-basis. A cross-warp partial's shared address is `global_smem + f(%tid)`, where `f` uses `%tid & mask` (lane / tile position) and `%tid >> k` (warp); both were opaque to the affine engine. We now rewrite a `%tid` term into its bit basis (`%tid.x = sum_i 2^i * %tid.x.bit_i` over `i < log2(reqntid)`), so `and` / `shr` / `bfe` on `%tid` become exact affine selections of those bits. This is bit-for-bit exact precisely because a power-of-two `reqntid` makes bits `[0, log2 N)` cover `[0, N)` exactly; a non-power-of-two or unknown `ntid`, a non-`%tid` symbol, or a non-zero constant is not decomposable and stays `Opaque` (conservative). The exact element each thread loads is now pinned even through the shared-memory exchange.

`builder.py` next — the collapse. A pure cross-thread add reduction (one boundary leaf, the whole reduction crossing warps) now collapses to a layout-invariant `ITreeReduce` when (a) the leaf address is fully affine-resolved (`_addr_resolved`, i.e. the bit-basis pinned the element set) and (b) the butterfly is count-up (`_is_count_up`, the `inner_tree` canonical order that is bit-identical across `num_warps`). `_is_count_up` now examines every contiguous-height shuffle run — the within-warp butterfly and the cross-warp run — instead of only the top run, so it can prove the direction even at low `num_warps`, where 2 warps give a single cross-warp step whose direction is visible only on the within-warp butterfly. Count-down (`unordered`), a non-monotone run, or any unresolved / swizzled address fails closed.

`leaves.py` carries the new `%tid` bit symbols (each a `[0,2)` column) into the leaf column image, and `test_ptx_affine.py` updates two unit tests to assert the new exact bit-basis behavior and that the conservative boundary — a non-`%tid` partial mask and an unbounded shift — still yields `Opaque`.

Soundness. The change is monotone: it only ADDS merges that are provably the same ordered tree, and every uncertainty (opaque / swizzled address, count-down, a single ambiguous step) falls back to the existing over-split. It never over-merges. Verified on the forward checker (`--checker bitequiv.ptx.forward.interp:forward_module_descriptor`): 0 over-merges on every kernel below — the checker partition strictly refines the empirical (fuzzer) partition. "checker sets" and "empirical sets" are how many bit-classes each side splits the config space into (fewer checker sets = more tuning freedom recovered; the checker count is always >= the empirical count when sound); the parenthesized value is the largest class.

Reductions (mid effort, f32, 20 fuzz seeds):

| kernel | configs | checker sets | empirical sets | over-merges |
| --- | --- | --- | --- | --- |
| sum | 144 | 8 (max 60) | 7 (max 72) | 0 |
| dot | 144 | 20 (max 30) | 14 (max 36) | 0 |
| sum_2d_axis0 | 144 | 8 (max 60) | 7 (max 72) | 0 |
| sum_2d_col | 144 | 8 (max 60) | 7 (max 72) | 0 |
| sum_2d_col_big | 144 | 9 (max 48) | 7 (max 72) | 0 |
| col_sum_loop | 144 | 10 (max 36) | 7 (max 72) | 0 |
| sum_2d_keepdim | 144 | 7 (max 72) | 2 (max 72) | 0 |
| sum_2d_deep | 144 | 8 (max 60) | 4 (max 72) | 0 |
| sum_3d | 144 | 7 (max 72) | 2 (max 72) | 0 |
| sum_3d_mid | 144 | 8 (max 60) | 4 (max 72) | 0 |
| sum_3d_outer | 144 | 12 (max 12) | 7 (max 72) | 0 |
| sum_4d | 144 | 6 (max 72) | 2 (max 72) | 0 |
| sum_multiaxis | 144 | 7 (max 72) | 2 (max 72) | 0 |
| col_exp_sum | 144 | 8 (max 60) | 7 (max 72) | 0 |
| col_dot | 144 | 24 (max 6) | 15 (max 36) | 0 |
| col_max | 144 | 1 (max 144) | 1 (max 144) | 0 |
| col_bf16 | 16 | 2 (max 8) | 2 (max 8) | 0 |
| cond_reduce | 144 | 24 (max 6) | 14 (max 36) | 0 |
| softmax | 144 | 16 (max 18) | 3 (max 72) | 0 |
| layernorm | 144 | 8 (max 30) | 6 (max 36) | 0 |
| rmsnorm | 144 | 11 (max 30) | 7 (max 36) | 0 |
| welford | 8 | 8 (max 1) | 7 (max 2) | 0 |

GEMM (light effort; the affine change does not touch these — pure MMA with no cross-thread reduction epilogue — so they are here to confirm the checker stays sound on them):

| kernel | configs | checker sets | empirical sets | over-merges |
| --- | --- | --- | --- | --- |
| gemm (bf16) | 8 | 4 (max 2) | 1 (max 8) | 0 |
| gemm (f32) | 24 | 9 (max 4) | 4 (max 8) | 0 |
| gemm (fp8) | 8 | 1 (max 4) | 1 (max 4) | 0 |
| gemm_bias_relu_fp_fusion (bf16) | 8 | 4 (max 3) | 2 (max 4) | 0 |
| gemm_tma_store (f16) | 4 | 2 (max 3) | 1 (max 4) | 0 |
| gemm_kgroup (bf16) | 28 | 15 (max 3) | 7 (max 4) | 0 |
| gemm_reduce_sum (f32) | 8 | 8 (max 1) | 5 (max 4) | 0 |
| gemm_softmax (f32) | 8 | 8 (max 1) | 5 (max 4) | 0 |

Flash Attention (local corpus, num_warps x BM x BN x num_stages, S=2048, 50 fuzz seeds):

| kernel | configs | checker sets | empirical sets | over-merges |
| --- | --- | --- | --- | --- |
| flash_attention | 96 | 96 (max 1) | 25 (max 25) | 0 |

Realistic Inductor kernels (torch-Inductor-style single-kernel reductions, 12 fuzz seeds; this sweep reports set counts, no largest-class column). The corpus's other 8 cases are cross-kernel (two-kernel combine) or loop-carried reductions — a different problem class from single-kernel equivalence — so they are out of scope here:

| kernel | configs | checker sets | empirical sets | over-merges |
| --- | --- | --- | --- | --- |
| A_rms_norm_fwd | 8 | 8 | 3 | 0 |
| C_rms_norm_bwd_2reduce | 8 | 8 | 3 | 0 |
| D_masked_global_sum | 8 | 8 | 5 | 0 |
| E_triu_masked_rowsum | 8 | 8 | 5 | 0 |
| G_plain_sum_looped | 8 | 8 | 5 | 0 |
| H_mean_permute | 8 | 8 | 3 | 0 |
| I_bias_grad_dim0 | 8 | 8 | 5 | 0 |
| J_epilogue_colsum_dim0 | 8 | 8 | 5 | 0 |
| LC_sum_loop_f32 | 24 | 24 | 24 | 0 |
| LC_sum_loop_f16 | 24 | 24 | 21 | 0 |

Recovery. The outer-axis sums now merge across `num_warps` 2-32 for `inner_tree` (previously each `num_warps` was its own class): the largest bit-equivalent class the checker recovers for `sum_2d_axis0` and `sum_2d_col` grows from 12 to 60 configs, and for `col_sum_loop` from 12 to 36; `col_max` reaches the full 144 (order-invariant). `unordered` stays split, correctly — its bits do vary with `num_warps`.

Known gaps, all safe over-split (follow-ups). `num_warps=1` for the outer-axis sums stays separate: with one warp the reduction is reconstructed as 32 within-warp leaves at a different tree height, a structurally distinct shape the height key does not reconcile yet. Mul-fed cross-warp reductions (`col_dot`, `cond_reduce`) and Flash Attention stay fully fail-closed (0 over-merge, no recovery) — they need value-carrying-leaf and online-softmax modeling respectively.

Robustness. Every kernel in the four tables above has 0 over-merges — the reduction corpus (~3000 configs at mid effort), the GEMM corpus, the 96-config Flash-Attention corpus, and the 10 realistic-Inductor single-kernel reductions — and the fast unit suite (152 tests, including the affine bit-basis and builder collapse tests) passes.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D113724314


