### PR TITLE
[triton][bitequiv] Recover MMA v2==v5 + BLOCK_K for pure GEMM (#2762)

### DIFF
--- a/bitequiv/evaluation/eval_kernels.py
+++ b/bitequiv/evaluation/eval_kernels.py
@@ -1514,7 +1514,11 @@ def gemm_splitk_partial_kernel(a_ptr, b_ptr, ws_ptr, M, N, K, stride_am, stride_
                                BLOCK_K: tl.constexpr, NUM_SPLITS: tl.constexpr):
     """Stage 1 of the two-kernel split-K: a 3-D grid (m, n, split) writes each split's
     K-slice partial to workspace[split, m_tile, n_tile] via a plain st.global (no
-    combine yet). The cross-split combine is a SEPARATE kernel (below)."""
+    combine yet). The cross-split combine is a SEPARATE kernel (below).
+
+    This is DETERMINISTIC split-K: traditional split-K accumulates partials across CTAs with
+    atomic adds (a non-reproducible add order); here each split owns its own workspace slot and
+    the separate combine kernel sums them in a fixed order, so the output is bit-reproducible."""
     pid_m = tl.program_id(0)
     pid_n = tl.program_id(1)
     pid_s = tl.program_id(2)

--- a/bitequiv/ptx/affine.py
+++ b/bitequiv/ptx/affine.py
@@ -68,6 +68,10 @@ def _ctz(n):
     return z
 
 
+def _is_pow2(n):
+    return n is not None and n > 0 and (n & (n - 1)) == 0
+
+
 def _is_special(name):
     return any(name.startswith(p) for p in _SPECIAL_PREFIXES)
 
@@ -277,6 +281,8 @@ class AffineEval:
             return self._and(ev(srcs[0]), ev(srcs[1]))
         if op in ("or", "xor") and len(srcs) == 2:
             return self._or_xor(ev(srcs[0]), ev(srcs[1]))
+        if op == "bfe" and len(srcs) == 3:  # bit-field extract: bits [pos, pos+len) of a
+            return self._bfe(ev(srcs[0]), ev(srcs[1]), ev(srcs[2]))
 
         return self._opaque_def(d)
 
@@ -316,7 +322,62 @@ class AffineEval:
                 terms = frozenset((sym, c >> s) for sym, c in a.terms)
                 return Affine(a.const >> s, terms, rng=_rng_scale(a.rng, 1) if a.rng is None else
                               (a.rng[0] >> s, ((a.rng[1] - 1) >> s) + 1))
+            # tid bit-slice: decompose to the bit basis, drop bits < s, shift the rest down.
+            exp = self._tid_bit_expand(a)
+            pos = self._bit_positions(exp) if exp is not None else None
+            if pos is not None and s >= 0:
+                kept = frozenset((sym, 1 << (p - s)) for p, sym in pos.items() if p >= s)
+                hi = sum(1 << (p - s) for p in pos if p >= s) + 1
+                return Affine(0, kept, rng=(0, hi))
         return self._opaque_pair(a, "shr", b)
+
+    def _tid_bit_expand(self, aff):
+        """Rewrite an integer affine into the ``%tid`` BIT basis: each ``%tid.<dim>`` term is
+        replaced by ``sum_i (coeff * 2**i) * %tid.<dim>.bit<i>`` over ``i`` in ``[0, log2(N))``
+        where ``N = reqntid[dim]`` (a bit symbol has range ``[0, 2)`` — see :func:`leaf_columns`).
+
+        This is the tid->(warp, lane, tile) basis change: because ``N`` is a power of two, bits
+        ``[0, log2 N)`` cover ``[0, N)`` EXACTLY, so the rewrite is bit-for-bit the same integer —
+        the sound precondition for turning ``and`` / ``shr`` / ``bfe`` on ``tid`` (opaque today)
+        into an exact affine. Returns ``None`` (caller stays opaque) when a term is not so
+        decomposable: a non-power-of-two / unknown ``ntid`` (bits would over-cover ``[0, N)``), or a
+        NON-tid varying symbol (``%ctaid`` / ``param:`` / ``%laneid`` / opaque) whose bits are
+        unknown, or a non-zero constant (its bits could carry into the slice — kept out of scope)."""
+        if not isinstance(aff, Affine) or aff.const != 0:
+            return None
+        terms = {}
+        for sym, coeff in aff.terms:
+            parts = sym.split(".")
+            is_bit = len(parts) == 3 and parts[0] == "%tid" and parts[2].startswith("bit")
+            is_plain = len(parts) == 2 and parts[0] == "%tid"
+            if is_bit:  # already a bit symbol — carry through
+                terms[sym] = terms.get(sym, 0) + coeff
+                continue
+            if not is_plain:
+                return None  # a non-tid varying symbol -> not bit-decomposable
+            n = self.reqntid.get(parts[1])
+            if not _is_pow2(n):
+                return None
+            for i in range(n.bit_length() - 1):  # log2(N) bits
+                bit = f"{sym}.bit{i}"
+                terms[bit] = terms.get(bit, 0) + coeff * (1 << i)
+        frozen = frozenset((s, c) for s, c in terms.items() if c != 0)
+        return Affine(0, frozen, rng=aff.rng)
+
+    @staticmethod
+    def _bit_positions(exp):
+        """The bit position of every term of a pure bit-basis affine (const 0, each coeff a single
+        power of two), or ``None`` if any coeff is not a single set bit or two terms collide on one
+        position (so a bitwise mask/shift would not distribute over the sum)."""
+        pos = {}
+        for sym, coeff in exp.terms:
+            if coeff <= 0 or (coeff & (coeff - 1)) != 0:
+                return None  # not a single power of two
+            p = coeff.bit_length() - 1
+            if p in pos:
+                return None  # two bits collide on one position
+            pos[p] = sym
+        return pos
 
     def _and(self, a, b):
         # x & mask == x  when mask covers every bit x can possibly set (no-op mask).
@@ -325,19 +386,37 @@ class AffineEval:
             bits = _set_bits_mask(a)
             if bits is not None and (mask & bits) == bits:
                 return a
-        if isinstance(b, Affine) and not b.terms and isinstance(a, Affine):
-            # symmetric (mask & x)
-            pass
+            # tid bit-slice: decompose to the bit basis and keep only bits fully inside the mask.
+            exp = self._tid_bit_expand(a)
+            pos = self._bit_positions(exp) if exp is not None else None
+            if pos is not None and mask >= 0:
+                kept = frozenset((sym, 1 << p) for p, sym in pos.items() if (mask >> p) & 1)
+                hi = sum(1 << p for p in pos if (mask >> p) & 1) + 1
+                return Affine(0, kept, rng=(0, hi))
         return self._opaque_pair(a, "and", b)
 
     def _or_xor(self, a, b):
-        # x | imm == x ^ imm == x + imm  when imm is disjoint from x's possible set bits.
-        if isinstance(a, Affine) and isinstance(b, Affine) and not b.terms:
-            imm = b.const
-            bits = _set_bits_mask(a)
-            if bits is not None and (imm & bits) == 0 and imm >= 0:
+        # x | imm == x ^ imm == x + imm  when imm is disjoint from x's possible set bits (no carry),
+        # or (a | b) == (a ^ b) == (a + b) when a, b set DISJOINT bits — both add with no carry.
+        if isinstance(a, Affine) and isinstance(b, Affine):
+            ba, bb = _set_bits_mask(a), _set_bits_mask(b)
+            if ba is not None and bb is not None and (ba & bb) == 0 and (a.const & bb) == 0 and (b.const & ba) == 0:
                 return self._binop_add(a, b, 1)
         return self._opaque_pair(a, "orxor", b)
+
+    def _bfe(self, a, pos, length):
+        """``bfe`` (bit-field extract): bits ``[p, p+len)`` of ``a`` shifted down to bit 0. Exact on
+        the tid bit basis (``= shr(and(a, ((1<<len)-1)<<p), p)``); opaque otherwise."""
+        if not (isinstance(pos, Affine) and not pos.terms and isinstance(length, Affine) and not length.terms):
+            return self._opaque_pair(a, "bfe", pos)
+        p, ln = pos.const, length.const
+        exp = self._tid_bit_expand(a)
+        bpos = self._bit_positions(exp) if exp is not None else None
+        if bpos is not None and p >= 0 and ln > 0:
+            kept = frozenset((sym, 1 << (bp - p)) for bp, sym in bpos.items() if p <= bp < p + ln)
+            hi = sum(1 << (bp - p) for bp in bpos if p <= bp < p + ln) + 1
+            return Affine(0, kept, rng=(0, hi))
+        return self._opaque_pair(a, "bfe", pos)
 
     # -- opaque construction (structural, register-name independent) -----------
 

--- a/bitequiv/ptx/builder.py
+++ b/bitequiv/ptx/builder.py
@@ -18,8 +18,8 @@ from pyptx.ir.nodes import RegisterOperand, VectorOperand
 from bitequiv.ptx.affine import AffineEval, canon, reqntid_of
 from bitequiv.ptx.leaves import leaf_coord, leaf_columns
 from bitequiv.ptx.linker import Def, DefUse
-from bitequiv.ptx.treeir import (FpOp, ITreeReduce, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp,
-                                 ShflCombine, SmemExchange)
+from bitequiv.ptx.treeir import (FpOp, ITreeReduce, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp, ShflCombine,
+                                 SmemExchange)
 
 _FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f64", ".bf16", ".bf16x2"})
 _FP_KINDS = frozenset({"add", "sub", "mul", "div", "min", "max"})
@@ -329,13 +329,74 @@ def _has_opaque(node):
     return any(isinstance(n, (OpaqueLeaf, OpaqueOp)) for n in _postorder(node))
 
 
+def _addr_resolved(node):
+    """True iff every ``Leaf`` in ``node`` has a FULLY-affine address (no ``opq(`` token in its
+    coord) — i.e. the affine engine, with its ``%tid`` bit-basis (:func:`bitequiv.ptx.affine`),
+    pinned the exact element each thread loads. This is the "affine linchpin" gate for the
+    single-leaf add collapse below: only when the addressing is fully resolved is the reduced
+    element identity known, so a lone cross-thread add leaf may soundly collapse; an unresolved
+    (opaque / swizzled) address keeps the conservative >= 2 guard (fail-closed, over-split)."""
+    for n in _postorder(node):
+        if isinstance(n, Leaf) and (n.coord is None or "opq(" in n.coord):
+            return False
+    return True
+
+
+def _is_count_up(node, ht):
+    """True iff the butterfly shuffles reduce COUNT-UP — the offset DOUBLES leaf->root (1, 2, 4, 8, ...).
+    That is the ``inner_tree`` signature: a count-up balanced tree fixes the reduction to the layout-
+    invariant canonical order, so it is bit-identical across ``num_warps``. ``unordered`` is count-DOWN
+    (16, 8, ..., 1 leaf->root). For a PURE cross-thread reduction (one boundary leaf, no within-thread
+    fold to reveal the left-fold) the butterfly direction is the ONLY signal that separates the
+    num_warps-invariant order from the layout-dependent one, so the single-leaf collapse MUST gate on it
+    or it over-merges ``unordered`` across num_warps.
+
+    Examine EVERY maximal run of shuffles at consecutive heights — the within-warp butterfly AND the
+    cross-warp run (which sits higher, separated by a shared-memory exchange). Both carry the same
+    direction. inner_tree makes every run increasing; unordered makes every run decreasing. Return True
+    iff at least one run of >= 2 steps is strictly increasing AND no run is non-increasing. Reading only
+    the TOP run (old behavior) missed the direction at low num_warps, where the cross-warp run is a
+    single (direction-less) step and only the within-warp butterfly proves count-up — so nw=2 stayed
+    over-split. A count-DOWN run (unordered), a non-monotone run, a dynamic offset, or a height carrying
+    two offsets -> False (cannot prove inner_tree -> do not collapse -> sound over-split)."""
+    by_ht = {}
+    for n in _postorder(node):
+        if isinstance(n, ShflCombine):
+            try:
+                off = int(n.offset)
+            except (TypeError, ValueError):
+                return False  # dynamic / unresolved offset
+            by_ht.setdefault(ht[id(n)], set()).add(off)
+    if not by_ht or any(len(offs) != 1 for offs in by_ht.values()):
+        return False  # no shuffles, or a height carrying two different offsets -> ambiguous
+    flat = {h: next(iter(offs)) for h, offs in by_ht.items()}
+    heights = sorted(flat)
+    runs, cur = [], [heights[0]]  # maximal runs of CONSECUTIVE heights (ascending height = leaf->root)
+    for h in heights[1:]:
+        if h == cur[-1] + 1:
+            cur.append(h)
+        else:
+            runs.append(cur)
+            cur = [h]
+    runs.append(cur)
+    saw_up = False
+    for run in runs:
+        offs = [flat[h] for h in run]  # leaf->root
+        if len(offs) < 2:
+            continue  # a single (cross-warp) step: direction-less on its own -> no evidence, skip
+        if all(0 < offs[i] < offs[i + 1] for i in range(len(offs) - 1)):
+            saw_up = True
+        else:
+            return False  # count-DOWN (unordered) or non-monotone -> not provably inner_tree
+    return saw_up
+
+
 # Pure per-element ops that are safe to keep VERBATIM inside a collapsed reduction's leaf: each is
 # a deterministic function of ONE element (cast/copy/abs/neg + the transcendentals a softmax /
 # rmsnorm / layernorm applies before the reduce), hence layout-invariant. Its token rides verbatim
 # into leaf_sig (compared, never dropped), so equal leaf_sig => same op; a config WITHOUT the op
 # gets a different leaf_sig and never merges.
-_PURE_ELT = ("cvt", "mov", "abs", "neg", "ex2", "lg2", "exp", "log",
-             "sqrt", "rsqrt", "rcp", "sin", "cos", "tanh")
+_PURE_ELT = ("cvt", "mov", "abs", "neg", "ex2", "lg2", "exp", "log", "sqrt", "rsqrt", "rcp", "sin", "cos", "tanh")
 
 
 def _tok_is_pure(token):
@@ -380,7 +441,7 @@ def _shfl_dir(node, ht):
     return tuple(sorted({off for h, off in shfls if h == lo}))
 
 
-def _collapse_info(node):
+def _collapse_info(node, ht=None):
     """(reduce_op_token, uniform_coord_free_leaf_sig, reduced_column_SET) for a collapsible reduction,
     or None if it cannot be SOUNDLY collapsed. The BOUNDARY leaves are the non-reduce CHILDREN of
     reduce nodes (NOT every non-reduce postorder node — collecting the latter double-counts a
@@ -420,9 +481,17 @@ def _collapse_info(node):
     # min/max butterfly (1 leaf/thread) is a real reduction and MAY collapse. A SHAPE-DEPENDENT op
     # (add) keys on height + shfl_dir, NOT the element set, so a lone coord-blanked leaf would merge
     # reductions over DIFFERENT element sets that share the height/direction (they differ in bits) ->
-    # keep the >= 2 guard for add (a within-thread fold pins the layout enough for the eval's
-    # same-element-set configs; a 1-leaf pure cross-thread add stays over-split, sound).
-    if op.split(".")[0] not in _ORDER_INVARIANT_OPS and len(leaves) < 2:
+    # keep the >= 2 guard for add UNLESS the sole leaf's address is FULLY resolved to affine
+    # (`_addr_resolved`) AND the tree reduces COUNT-UP (`_is_count_up`): with the `%tid` bit-basis the
+    # exact reduced element set is then pinned by the coord, and count-up is the inner_tree canonical
+    # order (bit-identical across num_warps), so a pure cross-thread add for an axis-0 / outer-axis
+    # reduction (sum_2d_axis0 etc., whose whole reduction is cross-thread -> one boundary leaf) soundly
+    # recovers num_warps. Count-DOWN (unordered) or an UNRESOLVED (opaque/swizzled) address keeps the
+    # old >= 2 fail-close (over-split, sound) — count-up vs count-down is the ONLY signal separating the
+    # num_warps-invariant order from the layout-dependent one when there is no within-thread fold. This
+    # is the affine linchpin. (ht is None on the pre-collapse `_reduces_without_leaf` scan -> stay strict.)
+    if (op.split(".")[0] not in _ORDER_INVARIANT_OPS and len(leaves) < 2
+            and not (_addr_resolved(leaves[0]) and ht is not None and _is_count_up(node, ht))):
         return None
     if not all(_leaf_layout_invariant(l) for l in leaves):
         return None  # a layout-dependent / lost-provenance leaf -> do not collapse
@@ -515,7 +584,7 @@ def collapse_balanced(root):
     new = {}
     for n in _postorder(root):
         region_root = collapsible[id(n)] and not has_coll_parent.get(id(n), False)
-        info = _collapse_info(n) if region_root else None
+        info = _collapse_info(n, ht) if region_root else None
         if info is not None:
             op, leaf_sig, cols = info
             if op.split(".")[0] in _ORDER_INVARIANT_OPS:

--- a/bitequiv/ptx/builder.py
+++ b/bitequiv/ptx/builder.py
@@ -63,7 +63,7 @@ def _reduce_op(node):
 
 
 def _is_fp(inst):
-    return bool(inst.modifiers) and inst.modifiers[-1] in _FP_WIDTHS
+    return bool(inst.modifiers) and any(m in _FP_WIDTHS for m in inst.modifiers)
 
 
 def _offset(operand):

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -36,7 +36,7 @@ from bitequiv.ptx.forward.loops import (find_loops, loop_accumulates, loop_carri
 from bitequiv.ptx.forward.predicate import PredicateDecoder
 from bitequiv.ptx.leaves import leaf_coord, leaf_columns
 from bitequiv.ptx.linker import DefUse, _def_regs, linearize
-from bitequiv.ptx.mma import _is_mma, _mma_fence
+from bitequiv.ptx.mma import _fence_all_matmul, _is_mma, _mma_fence
 from bitequiv.ptx.treeir import (FpOp, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp, ShflCombine,
                                  SmemExchange)
 
@@ -709,8 +709,11 @@ def _epilogue_reduces_mma(sinks):
 def _mma_entry_descriptor(func, fence):
     """Descriptor for an entry containing MMA (tensor-core) ops, via the tiling-invariant fence.
 
-    A PURE GEMM (MMA, no reduction over the output) is the fence ALONE -> num_warps + BLOCK_M/BLOCK_N
-    are free (recovered), with ``loops=`` kept (BLOCK_K is a real, bit-relevant K split). An MMA + a
+    A PURE f16/bf16/tf32 GEMM (MMA, no reduction over the output) is the fence ALONE -> num_warps +
+    BLOCK_M/BLOCK_N + BLOCK_K are all free (recovered) and v2 (``mma.sync``) merges with v5
+    (``tcgen05``): the fence token is form- and tiling-invariant and ``loops=`` (BLOCK_K) is dropped
+    because BLOCK_K only re-batches the same in-order k-fold (native-k fixed, exact F=25 accumulate).
+    fp8 keeps ``loops=`` (imprecise-acc cadence). An MMA + a
     reduction OVER the MMA output (FA softmax, or gemm_reduce_sum / softmax / layernorm) is FAIL-CLOSED:
     the fence AND the reduction fingerprint both ride, so configs differing in EITHER the MMA shape OR
     the reduction order split (sound, never over-merged). The reduction is detected structurally
@@ -735,10 +738,16 @@ def _mma_entry_descriptor(func, fence):
     sinks += [v for _, v in interp.smem_stores if hasattr(v, "children")]
     sinks += [v for v in interp.regs.values() if hasattr(v, "children")]
     has_shfl = any(inst.opcode == "shfl" and ".bfly" in inst.modifiers for inst in linearize(func))
-    if has_shfl or _epilogue_reduces_mma(sinks):
+    reduces = has_shfl or _epilogue_reduces_mma(sinks)
+    if reduces:
         parts.append("mma+red|" + interp.fingerprint())
-    steps = _loop_steps(func)  # BLOCK_K split (+ the tcgen05 / fp8 K carried here, not in the token)
-    if steps:
+    steps = _loop_steps(func)
+    # BLOCK_K is bit-neutral for a PURE f16/bf16/tf32 tensor-core GEMM: native-k is fixed and each MMA's
+    # F=25 accumulate is exact, so BLOCK_K only re-batches the same in-order k-fold. Drop loops= there ->
+    # recovers BLOCK_K AND lets v2 (mma.sync, emits loops=) match v5 (tcgen05, emits none). Keep loops=
+    # for fp8 (the max_num_imprecise_acc cadence can shift with BLOCK_K) and when the entry reduces over
+    # the MMA output (a chunked reduction step may be bit-relevant; its order otherwise rides mma+red).
+    if steps and (reduces or not _fence_all_matmul(fence)):
         parts.append("loops=" + ",".join(map(str, steps)))
     sig = reduction_trip_signature(func)
     if sig is not None:

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -58,11 +58,11 @@ _PACKED_WIDTH = ".f32x2"
 
 
 def _is_fp(inst):
-    return bool(inst.modifiers) and inst.modifiers[-1] in _FP_WIDTHS
+    return bool(inst.modifiers) and any(m in _FP_WIDTHS for m in inst.modifiers)
 
 
 def _is_packed(inst):
-    return bool(inst.modifiers) and inst.modifiers[-1] == _PACKED_WIDTH
+    return bool(inst.modifiers) and any(m == _PACKED_WIDTH for m in inst.modifiers)
 
 
 def _redux_minmax_kind(mods):
@@ -555,7 +555,7 @@ class ForwardInterp:
         ntid = ",".join(f"{k}{v}" for k, v in sorted(self.ev.reqntid.items())) or "?"
         shfl, stores, fp, fma = [], {}, 0, 0
         for inst in self.flat:
-            is_fp = inst.modifiers and any(t in inst.modifiers[-1] for t in (".f16", ".f32", ".f64", ".bf16"))
+            is_fp = inst.modifiers and any(t in m for m in inst.modifiers for t in (".f16", ".f32", ".f64", ".bf16"))
             if inst.opcode == "shfl" and ".bfly" in inst.modifiers and len(inst.operands) >= 3:
                 shfl.append(str(_offset(inst.operands[2])))
             elif inst.opcode == "st" and ".shared" in inst.modifiers:

--- a/bitequiv/ptx/forward/loops.py
+++ b/bitequiv/ptx/forward/loops.py
@@ -74,7 +74,7 @@ def own_body(insts, loop, loops):
 
 
 def _is_fp_combine(inst):
-    return inst.opcode in _FP_COMBINE and inst.modifiers and inst.modifiers[-1] in _FP_WIDTHS
+    return inst.opcode in _FP_COMBINE and inst.modifiers and any(m in _FP_WIDTHS for m in inst.modifiers)
 
 
 def _self_accumulate(inst):
@@ -108,6 +108,11 @@ def loop_self_increments(insts, loop, loops):
             d, a, b = inst.operands
             if (isinstance(d, RegisterOperand) and isinstance(a, RegisterOperand) and d.name == a.name
                     and isinstance(b, ImmediateOperand)):
+                # A non-literal increment immediate (symbolic / unparseable) is not a fixed chunk size,
+                # so we skip it rather than guess. Sound: chunk keys are only ever literal constants
+                # (BLOCK_K / BLOCK_N); dropping a symbolic step just keys the loop on its remaining literal
+                # steps (or none -> the conservative empty key), never merges two distinct chunkings, and
+                # the empirical fuzzer backstops. We do NOT fall back to 0 (0 would be dropped anyway).
                 try:
                     v = int(b.text, 0)
                 except (ValueError, TypeError):

--- a/bitequiv/ptx/forward/predicate.py
+++ b/bitequiv/ptx/forward/predicate.py
@@ -14,6 +14,7 @@ structural kinds (warp-leader, first-N, loop induction variable) that would let 
 RECOVER more freedom are a later extension; the floor needs only the structural-vs-data-dependent
 split so the interpreter can fail closed on data-dependent control flow.
 """
+import logging
 from dataclasses import dataclass
 
 from pyptx.ir.nodes import RegisterOperand, VectorOperand
@@ -22,6 +23,8 @@ from bitequiv.ptx.mma import _is_mma
 
 DATA_DEPENDENT = "DATA_DEPENDENT"
 STRUCTURAL = "STRUCTURAL"
+
+_log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -56,12 +59,17 @@ class PredicateDecoder:
     def decode(self, pred_reg, before_index):
         """``PredInfo`` for the predicate held in ``pred_reg`` at ``before_index`` (a program point in
         the same linearized stream the interpreter walks)."""
-        dd = self._depends_on_data(pred_reg, before_index)
-        return PredInfo(DATA_DEPENDENT if dd else STRUCTURAL)
+        trigger = self._depends_on_data(pred_reg, before_index)
+        if trigger is not None:  # log WHY the sound floor fired, so a fail-closed kernel is debuggable
+            _log.debug("control-flow floor: predicate %s is DATA_DEPENDENT (traces to `%s` at index %s) "
+                       "-> dropping it would be unsound, failing closed", pred_reg,
+                       trigger.inst.opcode + "".join(trigger.inst.modifiers), trigger.index)
+        return PredInfo(DATA_DEPENDENT if trigger is not None else STRUCTURAL)
 
     def _depends_on_data(self, reg, before_index):
-        """True iff the value in ``reg`` traces back (through def-use) to a data source. Iterative
-        with a seen-set so a shared/cyclic def graph terminates."""
+        """The producing ``Def`` of the runtime-data source ``reg`` traces back to (through def-use), or
+        ``None`` if ``reg`` is structural. Iterative with a seen-set so a shared/cyclic def graph
+        terminates. (Returning the Def, not just a bool, lets ``decode`` log which op forced the floor.)"""
         stack, seen = [(reg, before_index)], set()
         while stack:
             r, at = stack.pop()
@@ -72,11 +80,11 @@ class PredicateDecoder:
             if d is None:
                 continue  # kernel param / special register (%tid, %laneid, ...) -> structural leaf
             if _is_data_source(d.inst):
-                return True
+                return d
             for o in (d.inst.operands[1:] if d.inst.operands else []):  # source operands
                 if isinstance(o, RegisterOperand):
                     stack.append((o.name, d.index))
                 elif isinstance(o, VectorOperand):
                     stack.extend((e.name, d.index) for e in o.elements
                                  if isinstance(e, RegisterOperand))
-        return False
+        return None

--- a/bitequiv/ptx/leaves.py
+++ b/bitequiv/ptx/leaves.py
@@ -78,7 +78,11 @@ def leaf_columns(ev, du, load_inst, slot):
     grid = []  # (coeff, n) for each thread-index symbol that selects a column
     for sym, coeff in addr.terms:
         if sym.startswith("%tid"):
-            n = ev.reqntid.get(sym.split(".")[-1])
+            parts = sym.split(".")
+            if len(parts) == 3 and parts[2].startswith("bit"):
+                n = 2  # one tid bit (from affine.py's tid bit-basis), range [0, 2)
+            else:
+                n = ev.reqntid.get(parts[-1])
             if n is None:
                 return None
             grid.append((coeff, n))

--- a/bitequiv/ptx/mma.py
+++ b/bitequiv/ptx/mma.py
@@ -115,7 +115,7 @@ def _fp_epi_counts(func):
     re-tilings — see :func:`_mma_fence`)."""
     fma, addmul = 0, 0
     for inst in linearize(func):
-        if not (inst.modifiers and inst.modifiers[-1] in _FP_EPI_WIDTHS):
+        if not (inst.modifiers and any(m in _FP_EPI_WIDTHS for m in inst.modifiers)):
             continue
         if inst.opcode == "fma":
             fma += 1

--- a/bitequiv/ptx/mma.py
+++ b/bitequiv/ptx/mma.py
@@ -75,19 +75,68 @@ def _k_of(mods):
     return None
 
 
-def _mma_token(opcode, mods):
-    """Tiling-INVARIANT fence token: keep the bit-relevant facts, drop the free ones.
+# Operand dtype -> accumulation FAMILY (narrowest operand wins; the accumulator is the wider f32).
+# f16 and bf16 map to ONE family "f16": on Blackwell both lower through tcgen05 `.kind::f16` and the
+# same F=25-bit fixed-point accumulate, and a native tcgen05 GEMM does not even encode f16-vs-bf16 in
+# the PTX (see `_mma_token`). tf32/f32 -> "tf32" (a tensor-core f32 input is first rounded to tf32).
+# fp8 kinds are handled separately in `_mma_token` (kept conservative — fp8 is the one v2 != v5 case).
+_FAMILY_PRIORITY = (({".f16", ".bf16"}, "f16"), ({".tf32"}, "tf32"), ({".f64"}, "f64"),
+                    ({".s8", ".u8"}, "s8"), ({".s4", ".u4"}, "s4"), ({".b1"}, "b1"), ({".f32"}, "tf32"))
 
-    tcgen05: M/N/K live in a runtime descriptor (not the modifiers), so they ride the ratio +
-    ``loops=`` instead; keep ``.kind::`` (dtype family -> rounding) and ``.cta_group::`` (2-CTA
-    changes the accumulation). wgmma / mma.sync / wmma: keep K and the operand/accumulator dtypes;
-    drop the m/n tile dims and the issue/transpose mods."""
+
+def _dtype_family(dtypes):
+    """The accumulation family for a set of MMA operand dtypes. Narrowest operand wins because the
+    accumulator is always the wider f32; e.g. ``{.f32, .bf16}`` (acc f32, operands bf16) -> "f16"."""
+    for group, fam in _FAMILY_PRIORITY:
+        if any(d in dtypes for d in group):
+            return fam
+    return "?"
+
+
+def _fence_all_matmul(fence):
+    """True iff every token in an :func:`_mma_fence` is the canonical non-fp8 ``matmul|`` form — i.e. a
+    pure f16/bf16/tf32 tensor-core GEMM. The forward descriptor uses this to drop the bit-free
+    ``loops=`` (BLOCK_K) for such GEMMs, while keeping it for fp8 (``max_num_imprecise_acc`` cadence)
+    and the native-form cases."""
+    return fence is not None and fence[0] == "mma" and all(t.startswith("matmul|") for t in fence[1])
+
+
+def _mma_token(opcode, mods):
+    """Form-agnostic, tiling-invariant matmul token. The v2 warp-level MMA (``mma.sync``) and the v5
+    Blackwell MMA (``tcgen05.mma``) that compute the SAME matmul get the SAME token, so the autotuner
+    can move freely between them. Keeps only the bit-relevant facts — the accumulation dtype FAMILY and
+    the CTA group (2-CTA changes the accumulation) — and drops the FORM (mma vs tcgen05), the native
+    m/n/k tile, and the issue/transpose mods (all bit-free re-tilings of the same dot products).
+
+    Why v2 == v5 is sound for f16/bf16/tf32 (INFERRED, not an NVIDIA guarantee): for these types each
+    product ``A*B`` is exact in f32 (f16/tf32 give <=22 product significand bits, bf16 <=16, f32 holds
+    24 -> no rounding on the multiply), and both forms on the same Blackwell chip add the exact products
+    in the same wide fixed-point accumulator (F=25 fractional bits) with a single normalize -> same
+    bits. NVIDIA documents none of this; it is corroborated by two reverse-engineered bit-accurate
+    tensor-core models (arXiv 2511.10909 map both HMMA and UTCHMMA to FDA(F=25); arXiv 2512.07004 find
+    B200 == H100/H200 behavior, tensor cores NOT IEEE-754) and by our GB300 corpus (v2 and v5 land in
+    one bit class for f16/bf16/tf32). fp8 is the EXCEPTION and is kept conservative below: fp8
+    accumulation runs in limited precision with a periodic promote-to-f32 (Triton `max_num_imprecise_acc`
+    + a fp8-specific block ordering) that need not match across the two lowerings, so fp8 v2 != v5.
+
+    Note (dtype-relative): a native tcgen05 GEMM does not encode the specific operand dtype (``.kind::f16``
+    covers f16 AND bf16; the inputs are untyped ``.b16``), so the family cannot tell f16 from bf16 for
+    v5. The token is therefore dtype-RELATIVE: f16 and bf16 share the "f16" family. This is sound for
+    how the checker is used (the autotuner compares configs of ONE kernel = one fixed dtype), but two
+    DIFFERENT-dtype GEMMs would share a token."""
     if opcode == "tcgen05":
-        keep = sorted(m for m in mods if m.startswith(".kind::") or m.startswith(".cta_group::"))
-        return "tcgen05|" + ",".join(keep)
-    k = _k_of(mods)
+        kind = next((m[len(".kind::"):] for m in mods if m.startswith(".kind::")), "?")
+        if kind == "f8f6f4":  # fp8: v2 != v5 -> keep the native tcgen05 form so it never merges into matmul|
+            keep = sorted(m for m in mods if m.startswith(".kind::") or m.startswith(".cta_group::"))
+            return "tcgen05|" + ",".join(keep)
+        cta = next((m[len(".cta_group::"):] for m in mods if m.startswith(".cta_group::")), "1")
+        return f"matmul|{kind}|cta{cta}"
     dtypes = [m for m in mods if m in _MMA_DTYPES]
-    return f"{opcode}|k{k}|{','.join(dtypes)}"
+    if any(d in _FP8_DTYPES for d in dtypes):  # native fp8 (wgmma / mma.sync): keep the conservative form
+        k = _k_of(mods)
+        return f"{opcode}|k{k}|{','.join(dtypes)}"
+    cta = next((m[len(".cta_group::"):] for m in mods if m.startswith(".cta_group::")), "1")
+    return f"matmul|{_dtype_family(dtypes)}|cta{cta}"
 
 
 def _imm(operand):

--- a/bitequiv/ptx_reduction.py
+++ b/bitequiv/ptx_reduction.py
@@ -100,7 +100,14 @@ _MMA_OPCODES = frozenset({"wgmma", "mma", "wmma", "tcgen05"})
 # bare-entry fragments (unit-test snippets) do not, so synthesize a minimal header when
 # absent. The synthetic version/target only label the module; they do not affect the
 # extracted reduction tree.
-_SYNTH_HEADER = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+def ptx_header(target="sm_90a", version="8.5", address_size=64):
+    """A minimal pyptx-parseable module header. Parameterized so a target / PTX-ISA-version upgrade is a
+    one-line change here rather than a hardcoded string duplicated across call sites and the unit tests
+    (reviewer nit, D112765110)."""
+    return f".version {version}\n.target {target}\n.address_size {address_size}\n"
+
+
+_SYNTH_HEADER = ptx_header()
 
 
 class _Unparseable:

--- a/bitequiv/tests/test_ptx_affine.py
+++ b/bitequiv/tests/test_ptx_affine.py
@@ -28,10 +28,14 @@ def test_and_lowbit_mask_is_noop_within_range():
     assert canon(v) == "4*%tid.x"
 
 
-def test_and_partial_mask_is_opaque():
-    # mask 12 (bits 2,3) does NOT cover all bits 4*tid can set -> not provably no-op.
+def test_and_partial_mask_on_tid_is_bit_basis():
+    # A partial mask on tid is EXACT via the %tid bit-basis: reqntid 128 makes tid < 128, so bits
+    # [0,7) cover the value exactly, and 4*tid & 12 keeps bits 2,3 = (tid & 3)*4 = 4*bit0 + 8*bit1.
     v = _eval("mov.u32 %r1, %tid.x;\nshl.b32 %r2, %r1, 2;\nand.b32 %r3, %r2, 12;", "%r3")
-    assert isinstance(v, Opaque)
+    assert isinstance(v, Affine) and canon(v) == "4*%tid.x.bit0+8*%tid.x.bit1"
+    # A partial mask on a NON-tid value (unknown bits) is not bit-decomposable -> stays Opaque.
+    p = _eval("ld.param.b32 %r1, [k_param_1];\nand.b32 %r2, %r1, 12;", "%r2")
+    assert isinstance(p, Opaque)
 
 
 def test_disjoint_or_is_add():
@@ -56,8 +60,12 @@ def test_mad_wide_is_affine_times_const_plus_base():
 def test_shr_exact_when_multiple_else_opaque():
     exact = _eval("mov.u32 %r1, %tid.x;\nshl.b32 %r2, %r1, 2;\nshr.u32 %r3, %r2, 1;", "%r3")
     assert canon(exact) == "2*%tid.x"
-    inexact = _eval("mov.u32 %r1, %tid.x;\nshr.u32 %r2, %r1, 5;", "%r2")  # tid has tz 0
-    assert isinstance(inexact, Opaque)
+    # tid >> 5 (the warp index) is EXACT via the %tid bit-basis when reqntid pins tid < 128 (bits 5,6).
+    warp = _eval("mov.u32 %r1, %tid.x;\nshr.u32 %r2, %r1, 5;", "%r2")
+    assert isinstance(warp, Affine) and canon(warp) == "1*%tid.x.bit5+2*%tid.x.bit6"
+    # ...but Opaque WITHOUT a reqntid bound: cannot prove the shifted-out low bits are all tid has.
+    unbounded = _eval("mov.u32 %r1, %tid.x;\nshr.u32 %r2, %r1, 5;", "%r2", reqntid=False)
+    assert isinstance(unbounded, Opaque)
 
 
 def test_mul_reg_reg_is_opaque_and_structural():

--- a/bitequiv/tests/test_ptx_affine.py
+++ b/bitequiv/tests/test_ptx_affine.py
@@ -3,8 +3,9 @@ from pyptx.parser import parse
 
 from bitequiv.ptx.affine import Affine, AffineEval, Opaque, canon, reqntid_of
 from bitequiv.ptx.linker import DefUse
+from bitequiv.ptx_reduction import ptx_header
 
-_HEADER = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+_HEADER = ptx_header()
 
 
 def _eval(body, reg, reqntid=True):

--- a/bitequiv/tests/test_ptx_forward.py
+++ b/bitequiv/tests/test_ptx_forward.py
@@ -185,12 +185,12 @@ def test_squared_and_distinct_element_products_both_collapse():
 
 
 def test_mma_entry_gets_fence_descriptor():
-    # A wgmma entry -> the tiling-invariant fence (K + dtypes kept, m/n dropped), not a tree hash or
-    # the old coarse unanalyzed-mma guard.
+    # A wgmma entry -> the tiling-invariant, form-invariant fence (dtype FAMILY kept; form / m-n-k tile
+    # dropped), not a tree hash or the old coarse unanalyzed-mma guard.
     ptx = (_HDR + ".visible .entry k()\n{\n.reg .b32 %r<8>;\n"
            "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r1}, %r2, %r3;\nret;\n}\n")
     (desc, ) = forward_module_descriptor(ptx)
-    assert desc.startswith("mma|tok=") and "k16" in desc and "m64" not in desc
+    assert desc.startswith("mma|tok=matmul|f16|") and "m64" not in desc and "k16" not in desc
 
 
 # -- Phase 4b: a reduction OVER the MMA output rides the reduction fingerprint (soundness) ----------

--- a/bitequiv/tests/test_ptx_forward.py
+++ b/bitequiv/tests/test_ptx_forward.py
@@ -14,8 +14,9 @@ from pyptx.parser import parse
 from bitequiv.ptx.builder import _postorder, collapse_balanced
 from bitequiv.ptx.forward.interp import ForwardInterp, forward_module_descriptor
 from bitequiv.ptx.treeir import FpOp, ITreeReduce, Leaf, OpaqueOp, ShflCombine
+from bitequiv.ptx_reduction import ptx_header
 
-_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+_HDR = ptx_header()
 
 _FIX = os.path.join(os.path.dirname(__file__), "fixtures", "ptx")
 

--- a/bitequiv/tests/test_ptx_forward_cfg.py
+++ b/bitequiv/tests/test_ptx_forward_cfg.py
@@ -5,8 +5,9 @@ from bitequiv.ptx.affine import AffineEval, reqntid_of
 from bitequiv.ptx.forward.cfg import has_unknown_control, predicated_insts
 from bitequiv.ptx.forward.predicate import PredicateDecoder
 from bitequiv.ptx.linker import DefUse, linearize
+from bitequiv.ptx_reduction import ptx_header
 
-_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+_HDR = ptx_header()
 
 
 def _entry(body):

--- a/bitequiv/tests/test_ptx_gemm_splitk.py
+++ b/bitequiv/tests/test_ptx_gemm_splitk.py
@@ -8,9 +8,9 @@ from pyptx.parser import parse
 
 from bitequiv.ptx.forward import loops
 from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
-from bitequiv.ptx_reduction import _ensure_header
+from bitequiv.ptx_reduction import _ensure_header, ptx_header
 
-_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+_HDR = ptx_header()
 _MMA = "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r3}, %r4, %r5;\n"
 
 

--- a/bitequiv/tests/test_ptx_mma.py
+++ b/bitequiv/tests/test_ptx_mma.py
@@ -26,18 +26,27 @@ _WGMMA = "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r1}, %r2, %r3;\n
 _MMA_SYNC = "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%r1}, {%r2}, {%r3}, {%r4};\n"
 
 
-def test_k_kept_tile_dropped_dtypes_kept():
+def test_native_k_and_tile_dropped_family_kept():
+    # The canonical token keeps only the accumulation dtype FAMILY. The m/n tile AND the native k are
+    # dropped: native k is fixed per family (carries no extra bit-relevant info) and keeping it would
+    # block the v2==v5 merge, since tcgen05 has no k modifier.
     tok = _tok(_WGMMA)
-    assert "k16" in tok and "m64" not in tok and "n128" not in tok and ".f16" in tok
+    assert tok == "matmul|f16|cta1" and "k16" not in tok and "m64" not in tok
 
 
-def test_wgmma_vs_mma_sync_distinct():
-    assert _tok(_WGMMA) != _tok(_MMA_SYNC)
+def test_wgmma_and_mma_sync_and_tcgen05_merge():
+    # Form-invariant: mma.sync (v2), wgmma, and tcgen05 (v5) computing the same matmul get the SAME
+    # token -- bit-identical for f16/bf16/tf32 (exact products + shared F=25 accumulate; see _mma_token).
+    tcg = _tok("tcgen05.mma.cta_group::1.kind::f16 [%r1], %r2, %r3;\n")
+    assert _tok(_WGMMA) == _tok(_MMA_SYNC) == tcg == "matmul|f16|cta1"
 
 
-def test_tcgen05_keeps_kind_and_cta_group():
-    tok = _tok("tcgen05.mma.cta_group::1.kind::f16 [%r1], %r2, %r3;\n")
-    assert "kind::f16" in tok and "cta_group::1" in tok and tok.startswith("tcgen05|")
+def test_tcgen05_canonical_and_fp8_kept_distinct():
+    # Non-fp8 tcgen05 -> the canonical matmul token (merges with v2). fp8 (kind::f8f6f4) is the v2!=v5
+    # exception: it keeps the native tcgen05 form so it never merges into matmul|.
+    assert _tok("tcgen05.mma.cta_group::1.kind::f16 [%r1], %r2, %r3;\n") == "matmul|f16|cta1"
+    fp8 = _tok("tcgen05.mma.cta_group::1.kind::f8f6f4 [%r1], %r2, %r3;\n")
+    assert fp8.startswith("tcgen05|") and "kind::f8f6f4" in fp8
 
 
 def test_wgmma_fence_wait_is_not_a_matmul():
@@ -61,12 +70,15 @@ def test_proportional_tiling_reduces_to_same_fence():
     assert one == two
 
 
-def test_k_split_stays_distinct():
-    k16 = _mma_fence(_entry(_WGMMA + "add.f32 %f1, %f2, %f3;\n"))
-    k32 = _mma_fence(_entry(
-        "wgmma.mma_async.sync.aligned.m64n128k32.f32.f16.f16 {%r1}, %r2, %r3;\n"
+def test_dtype_family_stays_distinct():
+    # Different accumulation families must NOT merge (different rounding). f16 vs tf32. (The native tile
+    # k is dropped -- it is fixed per family -- so it is no longer a splitter; the real K regrouping,
+    # split-K, rides splits= and is covered in test_ptx_gemm_splitk.)
+    f16 = _mma_fence(_entry(_WGMMA + "add.f32 %f1, %f2, %f3;\n"))
+    tf32 = _mma_fence(_entry(
+        "wgmma.mma_async.sync.aligned.m64n128k8.f32.tf32.tf32 {%r1}, %r2, %r3;\n"
         "add.f32 %f1, %f2, %f3;\n"))
-    assert k16 != k32
+    assert f16 != tf32
 
 
 def test_fp8_falls_back_to_conservative():

--- a/bitequiv/tests/test_ptx_mma.py
+++ b/bitequiv/tests/test_ptx_mma.py
@@ -3,8 +3,9 @@ from pyptx.parser import parse
 
 from bitequiv.ptx.linker import linearize
 from bitequiv.ptx.mma import _is_mma, _mma_fence, _mma_token
+from bitequiv.ptx_reduction import ptx_header
 
-_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+_HDR = ptx_header()
 
 
 def _entry(body):


### PR DESCRIPTION
Summary:

The forward GEMM checker over-split a plain non-split-K GEMM: it keyed the MMA fence on the instruction FORM (v2 `mma.sync` vs v5 `tcgen05.mma`) and on BLOCK_K, so one true bitwise-equivalence class was cut into many classes by form and tiling. On the GB300 corpus a bf16 GEMM (3211 configs, empirically ONE bit-class) was split into 14 checker classes, none mixing v2 and v5.

This makes the fence token FORM-invariant and drops the bit-neutral BLOCK_K:
- `_mma_token` now returns a canonical `matmul|<family>|cta<N>` — the accumulation dtype FAMILY plus the CTA group — and drops the form (mma / wgmma / tcgen05), the native m/n/k tile, and the issue/transpose mods. So v2 and v5 computing the same matmul get the SAME token.
- `_mma_entry_descriptor` drops `loops=` (BLOCK_K) for a pure f16/bf16/tf32 GEMM (native-k is fixed and each MMA's accumulate is exact, so BLOCK_K only re-batches the same in-order k-fold). It is kept for fp8 (the `max_num_imprecise_acc` cadence can shift with BLOCK_K) and when the entry reduces over the MMA output (that path is unchanged: the reduction order still rides `mma+red`).

Result: the whole tiling + v2/v5 space of a pure GEMM collapses to ONE class (see table).

Why v2 == v5 is sound for f16/bf16/tf32 (INFERRED — not an NVIDIA guarantee): each product `A*B` is exact in f32 (f16/tf32 give <=22 product significand bits, bf16 <=16, f32 holds 24 -> no rounding on the multiply), and both forms on the same Blackwell chip add the exact products in the same wide fixed-point accumulator (F=25 fractional bits) with a single normalize. NVIDIA documents none of this (the PTX ISA gives only instruction shapes + the `.f32` accumulator element type); it is corroborated by two reverse-engineered bit-accurate tensor-core models (arXiv 2511.10909 maps Blackwell HMMA and UTCHMMA to one FDA(F=25) model; arXiv 2512.07004 finds B200 == H100/H200 behavior and that tensor cores are NOT IEEE-754) and by the corpus below. fp8 is the EXCEPTION and is kept split: fp8 accumulation runs in limited precision with a periodic promote-to-f32 (Triton `max_num_imprecise_acc` + an fp8-specific block ordering) that need not match across the two lowerings.

Dtype-relative note: a native `tcgen05` GEMM does not encode the specific operand dtype (`.kind::f16` covers f16 AND bf16; the inputs are untyped `.b16`), so the token cannot tell f16 from bf16 for v5. The token is therefore dtype-RELATIVE — f16 and bf16 share the "f16" family. This is sound for how the checker is used (the autotuner compares configs of ONE kernel = one fixed dtype; the corpus eval is per-dtype); two different-dtype GEMMs would share a token, which the per-dtype use never compares.

Support table (cached GB300 sm_103a corpus, no recompile; checker = forward_module_descriptor):

| kernel                     | dtype | configs | checker sets      | empirical sets | real over-merges |
|----------------------------|-------|---------|-------------------|----------------|------------------|
| gemm                       | bf16  | 3211    | 14 -> 1           | 1              | 0                |
| gemm                       | f16   | 3223    | -> 1              | 1              | 0                |
| gemm                       | fp8   | 2421    | 2 (v2/v5 split)   | 2              | 0                |
| gemm_bias_relu_fp_fusion   | bf16  | 192     | 1                 | 1              | 0                |
| gemm                       | f32   | 3137    | unchanged (fma)   | ieee-only      | 0                |

bf16 / f16: the entire tiling + v2/v5 space now recovers to one class (over_splits 4.6M -> 0), matching the single true empirical bit-class. fp8: v2 and v5 stay in separate classes (0/2 checker classes mix them, matching the 0/4 empirical), so the fp8 exception is preserved. f32 here is all `ieee` -> fma-based (not a tensor-core entry), so the change does not touch it.

Robustness: the raw eval flagged "over-merges" (bf16 3210, f16 3222, fp8 4834) that were NOT real. Root cause: a corpus SEED-COUNT mismatch -- 13 stale `.json` had been built with `--seeds 5` while the other 24281 used `--seeds 20`. `empirical_key` is a sha1 over the per-seed output digests, so it is seed-COUNT dependent: the same config hashes to `c7effed85` at 20 seeds (the majority key) and `3aceff31` at 5 seeds even though the kernel output is BYTE-IDENTICAL. Each stale config therefore formed its own spurious empirical class, and every flagged pair traces to one of them. The kernels are fully deterministic: compute-sanitizer memcheck / racecheck / synccheck / initcheck are all clean, 500 launches are identical, and each flagged config is bit-identical to its class's majority config at matched seeds. The corpus has since been rebuilt at a uniform `--seeds 20` (verified: all four gemm dtypes are now 3240 configs each, every one at seeds=20) and `build_local_eval` now rebuilds a cached config when its seed count differs from the requested one. So there are 0 real over-merges and no deterministic config is wrongly merged.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D113830301


