### PR TITLE
[triton][bitequiv] MMA chunk fence: prove the fold, do not guess it

### DIFF
--- a/bitequiv/evaluation/benchmark_kernels.py
+++ b/bitequiv/evaluation/benchmark_kernels.py
@@ -33,6 +33,7 @@ Keep shapes modest but representative so the whole suite runs quickly.
 """
 
 import argparse
+import contextlib
 import sys
 from dataclasses import dataclass
 from typing import Callable, Optional
@@ -41,6 +42,7 @@ import torch
 
 import triton
 import triton.language as tl
+from triton.runtime.jit import JITFunction
 
 # libdevice (erf/tanh/rsqrt/... ) — import robustly across Triton versions; kernels that use
 # it fail gracefully (caught per-kernel by the runner) if it is unavailable.
@@ -58,19 +60,51 @@ DEVICE = "cuda"
 # --------------------------------------------------------------------------- #
 # Input helpers (seeded, reproducible)
 # --------------------------------------------------------------------------- #
+# Per-trial base seed the equivalence sweep varies so a kernel gets fresh inputs on each fuzzer
+# seed WITHOUT every make_inputs needing a seed argument. 0 in the normal perf/correctness run,
+# so those are unchanged. Set only at runtime via ``set_input_seed`` (never at import time).
+_INPUT_SEED = 0
+
+
+def set_input_seed(seed):
+    """Set the additive seed the input helpers fold in (fuzzer input variance; 0 for perf runs)."""
+    global _INPUT_SEED
+    _INPUT_SEED = seed
+
+
 def randn(*shape, dtype=torch.float32, seed=0):
-    g = torch.Generator(device="cpu").manual_seed(seed)
+    g = torch.Generator(device="cpu").manual_seed(seed + _INPUT_SEED)
     return torch.randn(*shape, generator=g, dtype=torch.float32).to(DEVICE, dtype)
 
 
 def rand(*shape, dtype=torch.float32, seed=0):
-    g = torch.Generator(device="cpu").manual_seed(seed)
+    g = torch.Generator(device="cpu").manual_seed(seed + _INPUT_SEED)
     return torch.rand(*shape, generator=g, dtype=torch.float32).to(DEVICE, dtype)
 
 
 def randint(high, shape, seed=0, dtype=torch.int32):
-    g = torch.Generator(device="cpu").manual_seed(seed)
+    g = torch.Generator(device="cpu").manual_seed(seed + _INPUT_SEED)
     return torch.randint(0, high, shape, generator=g, dtype=torch.int64).to(DEVICE, dtype)
+
+
+def adv(*shape, dtype=torch.float32, seed=0, lo=-6.0, hi=6.0):
+    """Order-sensitive input: wide dynamic range (logspace magnitudes) x alternating signs.
+
+    Reduction / softmax / norm / scan / attention kernels are bit-STABLE under plain unit-scale
+    ``randn`` -- every summand has ~the same magnitude, so the association order barely moves the
+    rounding and the sweep can't tell configs apart. Spreading magnitudes across ``[10**lo, 10**hi]``
+    and alternating the sign makes the FP reduction ORDER decide the output bits, which is what the
+    equivalence sweep needs. Narrow ``lo``/``hi`` for exp-based kernels (softmax/attention) so
+    ``exp`` stays finite. A drop-in for ``randn`` (same ``*shape, dtype, seed`` signature).
+    """
+    numel = 1
+    for s in shape:
+        numel *= s
+    g = torch.Generator(device="cpu").manual_seed(seed + _INPUT_SEED)
+    base = torch.randn(numel, generator=g, dtype=torch.float32)
+    scale = torch.logspace(lo, hi, numel, dtype=torch.float32)
+    signs = torch.where(torch.arange(numel) % 2 == 0, torch.tensor(1.0), torch.tensor(-1.0))
+    return (base * scale * signs).reshape(*shape).to(DEVICE, dtype)
 
 
 def ones(*shape, dtype=torch.float32):
@@ -93,6 +127,8 @@ class Bench:
     shape_note: str = ""
     runnable: bool = True  # False => SKIP (e.g. needs Blackwell sm100 / a HW path not in portable Triton)
     note: str = ""  # reason shown when skipped, or any caveat
+    nondeterministic: bool = False  # output not bit-reproducible (e.g. cross-CTA FP atomic_add) -> a bitwise-equivalence checker eval must SKIP it (bit-equivalence is undefined for it); the standalone perf run still uses it
+    configs: Optional[list] = None  # equivalence-sweep config axis: list of launch-override dicts (e.g. [{"num_warps": 4}, {"num_warps": 8}]); None => the sweep's default num_warps list. num_warps/num_stages are forced generically; a block-size constexpr is baked in each run() body so it is not swept here
 
 
 BENCHMARKS: list = []
@@ -116,12 +152,145 @@ def _allclose(out, exp, rtol, atol):
     return torch.allclose(out.float(), exp.float(), rtol=rtol, atol=atol)
 
 
+# --------------------------------------------------------------------------- #
+# Equivalence-checker soundness sweep (opt-in: `python benchmark_kernels.py --sweep`)
+# --------------------------------------------------------------------------- #
+@contextlib.contextmanager
+def _sweep_launch(num_warps=None, num_stages=None):
+    """Force a launch config on every kernel launched in the block AND collect each CompiledKernel.
+
+    The equivalence sweep needs (a) a config axis (num_warps / num_stages) so a kernel has >1
+    config and (b) the PTX of each launched kernel for the static checker. Rather than thread both
+    through all ~90 run() bodies, we intercept JITFunction.run for the duration of one launch and
+    restore it on exit -- SCOPED, so no global state is left patched (unlike a module monkeypatch).
+    A block-size constexpr has a kernel-specific name, so it is baked in each run() and not forced.
+    """
+    captured = []
+    orig = JITFunction.run
+
+    def run(self, *a, **k):
+        if num_warps is not None:
+            k.setdefault("num_warps", num_warps)
+        if num_stages is not None:
+            k.setdefault("num_stages", num_stages)
+        try:
+            ck = orig(self, *a, **k)
+        except TypeError:  # autotuned / fixed-config kernel rejects the override: retry unforced
+            k.pop("num_warps", None)
+            k.pop("num_stages", None)
+            ck = orig(self, *a, **k)
+        captured.append(ck)
+        return ck
+
+    JITFunction.run = run
+    try:
+        yield captured
+    finally:
+        JITFunction.run = orig
+
+
+def _to_bytes(t):
+    """Exact output bits (the fuzzer's equality unit); flattens tuple/list outputs."""
+    if isinstance(t, (tuple, list)):
+        return b"".join(_to_bytes(x) for x in t)
+    return t.detach().cpu().contiguous().view(torch.uint8).numpy().tobytes()
+
+
+def _cfg_axis(bench, warps):
+    """The config axis for a kernel: its own ``Bench.configs``, else one dict per swept num_warps.
+
+    Returns ``[(hashable_key, launch_dict), ...]`` -- a dict is unhashable so the sweep keys configs
+    by ``tuple(sorted(cfg.items()))`` (the fuzzer needs hashable configs) and launches the dict.
+    """
+    cfgs = bench.configs or [{"num_warps": nw} for nw in warps]
+    return [(tuple(sorted(c.items())), c) for c in cfgs]
+
+
+def _eval_bench(bench, warps, repeats, checker, fz):
+    """Compile each config -> checker key, fuzz -> empirical key, classify soundness (see _run_sweep)."""
+    launch = dict(_cfg_axis(bench, warps))
+
+    def launch_bytes(key, seed):
+        set_input_seed(seed)
+        with _sweep_launch(**launch[key]) as captured:
+            out = bench.run(bench.make_inputs())
+        torch.cuda.synchronize()
+        cks = [c for c in captured if getattr(c, "asm", None) and "ptx" in c.asm]
+        return tuple(checker(c.asm["ptx"]) for c in cks), _to_bytes(out)
+
+    ck_key, ok, fails = {}, [], 0
+    for key in launch:
+        try:
+            ck_key[key], _ = launch_bytes(key, 0)  # PTX is seed-independent: one compile per config
+            ok.append(key)
+        except Exception:  # noqa: BLE001 - a broken config is dropped, not fatal to the sweep
+            fails += 1
+    if not ok:
+        return dict(name=bench.name, ok=0, fails=fails, classification="error-all-configs-failed")
+    no_ptx = any(len(ck_key[k]) == 0 for k in ok)
+    nondet = bench.nondeterministic
+    if not (nondet or no_ptx):
+        nondet = any(launch_bytes(k, 0)[1] != launch_bytes(k, 0)[1] for k in ok)
+    skip = nondet or no_ptx
+    emp = fz.empirical_keys(lambda key, seed: launch_bytes(key, seed)[1], ok, repeats)
+    ck_sets, emp_sets = fz.partition(ok, ck_key), fz.partition(ok, emp)
+    over_m = None if skip else fz.over_merges(ok, ck_key, emp)
+    over_s = None if skip else fz.over_merges(ok, emp, ck_key)
+    if nondet:
+        cls = "d-nondeterministic"
+    elif no_ptx:
+        cls = "e-no-ptx (checker n/a)"
+    elif len(emp_sets) == 1:
+        cls = "c-bit-stable"
+    elif over_m > 0:
+        cls = "b-DISCRIMINATING-OVER-MERGE"
+    else:
+        cls = "a-discriminating-sound"
+    return dict(name=bench.name, category=bench.category, ok=len(ok), fails=fails,
+                checker_sets=len(ck_sets), empirical_sets=len(emp_sets), over_merges=over_m,
+                over_splits=over_s, classification=cls)
+
+
+def _run_sweep(benches, warps, repeats):
+    """Measure the FORWARD PTX checker against the empirical fuzzer over every runnable kernel.
+
+    For each kernel: over the num_warps config axis (same input+math, different reduction/layout),
+    compare the checker's partition against the fuzzer's bit-identical-on-every-seed partition and
+    report the over-merge count (checker classes that straddle an empirical boundary -- a soundness
+    violation, must be 0). nondeterministic (cross-CTA FP atomic_add) kernels are out of contract,
+    so their over-merges are NOT counted. Reuses bitequiv.ptx.forward.interp + equivalence_fuzzer.
+    """
+    # Lazy so the zoo stays torch+triton-only (drop-in) for its list / perf use.
+    from bitequiv.evaluation import equivalence_fuzzer as fz
+    from bitequiv.ptx.forward.interp import forward_module_descriptor
+
+    print(f"device: {torch.cuda.get_device_name()}  checker: forward_module_descriptor  "
+          f"kernels: {len(benches)}  warps: {warps}  repeats: {repeats}")
+    print(f"{'category':16s} {'kernel':30s} {'ok':>3s} {'chk':>4s} {'emp':>4s} "
+          f"{'over_m':>7s} {'over_s':>7s} class")
+    for b in benches:
+        if not b.runnable:
+            continue
+        try:
+            res = _eval_bench(b, warps, repeats, forward_module_descriptor, fz)
+        except Exception as e:  # noqa: BLE001 - one bad kernel must not abort the sweep
+            print(f"{b.category:16s} {b.name:30s}  ERROR {type(e).__name__}: {str(e).splitlines()[0][:50]}")
+            continue
+        print(f"{b.category:16s} {b.name:30s} {res.get('ok', 0):>3} {str(res.get('checker_sets')):>4} "
+              f"{str(res.get('empirical_sets')):>4} {str(res.get('over_merges')):>7} "
+              f"{str(res.get('over_splits')):>7} {res.get('classification')}")
+
+
 def main(argv):
     ap = argparse.ArgumentParser(description="Standalone Triton kernel benchmark zoo.")
     ap.add_argument("--filter", default=None, help="substring match on kernel name OR category")
     ap.add_argument("--only", default=None, help="exact kernel name")
     ap.add_argument("--list", action="store_true", help="list kernels and exit")
     ap.add_argument("--no-check", action="store_true", help="skip correctness, time only")
+    ap.add_argument("--sweep", action="store_true",
+                    help="run the checker+fuzzer equivalence sweep instead of timing")
+    ap.add_argument("--warps", default="2,4,8", help="num_warps config axis for --sweep")
+    ap.add_argument("--repeats", type=int, default=12, help="fuzzer seeds per config for --sweep")
     args = ap.parse_args(argv)
 
     benches = BENCHMARKS
@@ -138,6 +307,10 @@ def main(argv):
 
     if not torch.cuda.is_available():
         raise SystemExit("benchmark_kernels needs a CUDA device.")
+
+    if args.sweep:
+        _run_sweep(benches, [int(x) for x in args.warps.split(",")], args.repeats)
+        return
 
     print(f"device: {torch.cuda.get_device_name()}")
     print(f"{'category':20s} {'kernel':34s} {'shape':24s} {'ms':>10s} {'correct':>8s}")
@@ -691,7 +864,7 @@ def _run_softmax(inp):
 
 register(name="softmax_row", category="softmax",
          source="https://github.com/triton-lang/triton/blob/main/python/tutorials/02-fused-softmax.py",
-         make_inputs=lambda: (randn(1024, 4096, seed=24), ),
+         make_inputs=lambda: (adv(1024, 4096, seed=24, lo=-1.0, hi=1.0), ),
          run=_run_softmax, ref=lambda inp: torch.softmax(inp[0], dim=1),
          rtol=2e-3, atol=2e-3, shape_note="1024x4096")
 
@@ -717,7 +890,7 @@ def _run_log_softmax(inp):
 
 register(name="log_softmax_row", category="softmax",
          source="https://github.com/FlagOpen/FlagGems/blob/master/src/flag_gems/ops/log_softmax.py",
-         make_inputs=lambda: (randn(1024, 4096, seed=25), ),
+         make_inputs=lambda: (adv(1024, 4096, seed=25, lo=-1.0, hi=1.0), ),
          run=_run_log_softmax, ref=lambda inp: torch.log_softmax(inp[0], dim=1),
          rtol=2e-3, atol=2e-3, shape_note="1024x4096")
 
@@ -748,7 +921,8 @@ def _ref_softmax_bwd(inp):
 
 register(name="softmax_bwd", category="softmax",
          source="https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/utils/softmax.py",
-         make_inputs=lambda: (torch.softmax(randn(1024, 4096, seed=26), 1), randn(1024, 4096, seed=27)),
+         make_inputs=lambda: (torch.softmax(adv(1024, 4096, seed=26, lo=-1.0, hi=1.0), 1),
+                              adv(1024, 4096, seed=27, lo=-2.0, hi=2.0)),
          run=_run_softmax_bwd, ref=_ref_softmax_bwd, rtol=2e-3, atol=2e-3, shape_note="1024x4096")
 
 
@@ -782,7 +956,7 @@ def _run_layernorm(inp):
 
 register(name="layernorm_fwd", category="norm",
          source="https://github.com/triton-lang/triton/blob/main/python/tutorials/05-layer-norm.py",
-         make_inputs=lambda: (randn(2048, 2048, seed=28), randn(2048, seed=29), randn(2048, seed=30)),
+         make_inputs=lambda: (adv(2048, 2048, seed=28, lo=-2.0, hi=2.0), randn(2048, seed=29), randn(2048, seed=30)),
          run=_run_layernorm,
          ref=lambda inp: torch.nn.functional.layer_norm(inp[0], (inp[0].shape[1], ), inp[1], inp[2], 1e-5),
          rtol=2e-3, atol=2e-3, shape_note="2048x2048")
@@ -814,7 +988,7 @@ def _ref_rmsnorm(inp):
 
 register(name="rmsnorm_fwd", category="norm",
          source="https://github.com/pytorch-labs/tritonbench/blob/main/tritonbench/operators/rms_norm/fused_triton.py",
-         make_inputs=lambda: (randn(2048, 2048, seed=31), randn(2048, seed=32)),
+         make_inputs=lambda: (adv(2048, 2048, seed=31, lo=-2.0, hi=2.0), randn(2048, seed=32)),
          run=_run_rmsnorm, ref=_ref_rmsnorm, rtol=2e-3, atol=2e-3, shape_note="2048x2048")
 
 
@@ -838,7 +1012,7 @@ def _run_l2norm(inp):
 
 register(name="l2norm_row", category="norm",
          source="https://github.com/fla-org/flash-linear-attention/blob/main/fla/modules/l2norm.py",
-         make_inputs=lambda: (randn(2048, 2048, seed=33), ),
+         make_inputs=lambda: (adv(2048, 2048, seed=33, lo=-2.0, hi=2.0), ),
          run=_run_l2norm, ref=lambda inp: torch.nn.functional.normalize(inp[0], dim=1),
          rtol=2e-3, atol=2e-3, shape_note="2048x2048")
 
@@ -873,7 +1047,7 @@ def _run_groupnorm(inp):
 
 register(name="groupnorm_fwd", category="norm",
          source="https://github.com/FlagOpen/FlagGems/blob/master/src/flag_gems/ops/groupnorm.py",
-         make_inputs=lambda: (randn(16, 64, 128, seed=34), randn(64, seed=35), randn(64, seed=36)),
+         make_inputs=lambda: (adv(16, 64, 128, seed=34, lo=-2.0, hi=2.0), randn(64, seed=35), randn(64, seed=36)),
          run=_run_groupnorm,
          ref=lambda inp: torch.nn.functional.group_norm(inp[0], 8, inp[1], inp[2], 1e-5),
          rtol=2e-3, atol=2e-3, shape_note="16x64x128 G=8")
@@ -930,10 +1104,10 @@ def _mk_rowreduce(kind):
 
 _REDUCE_SRC = "https://github.com/FlagOpen/FlagGems/blob/master/src/flag_gems/ops"
 register(name="reduce_sum", category="reduction", source=_REDUCE_SRC + "/sum.py",
-         make_inputs=lambda: (randn(2048, 4096, seed=37), ), run=_mk_rowreduce(0),
+         make_inputs=lambda: (adv(2048, 4096, seed=37, lo=-2.0, hi=2.0), ), run=_mk_rowreduce(0),
          ref=lambda inp: inp[0].sum(1), rtol=2e-3, atol=2e-3, shape_note="2048x4096")
 register(name="reduce_mean", category="reduction", source=_REDUCE_SRC + "/mean.py",
-         make_inputs=lambda: (randn(2048, 4096, seed=38), ), run=_mk_rowreduce(1),
+         make_inputs=lambda: (adv(2048, 4096, seed=38, lo=-2.0, hi=2.0), ), run=_mk_rowreduce(1),
          ref=lambda inp: inp[0].mean(1), rtol=2e-3, atol=2e-3, shape_note="2048x4096")
 register(name="reduce_max", category="reduction", source=_REDUCE_SRC + "/max.py",
          make_inputs=lambda: (randn(2048, 4096, seed=39), ), run=_mk_rowreduce(2),
@@ -942,10 +1116,10 @@ register(name="reduce_min", category="reduction", source=_REDUCE_SRC + "/min.py"
          make_inputs=lambda: (randn(2048, 4096, seed=40), ), run=_mk_rowreduce(3),
          ref=lambda inp: inp[0].min(1).values, shape_note="2048x4096")
 register(name="reduce_var", category="reduction", source=_REDUCE_SRC + "/var_mean.py",
-         make_inputs=lambda: (randn(2048, 4096, seed=41), ), run=_mk_rowreduce(4),
+         make_inputs=lambda: (adv(2048, 4096, seed=41, lo=-2.0, hi=2.0), ), run=_mk_rowreduce(4),
          ref=lambda inp: inp[0].var(1, unbiased=False), rtol=2e-3, atol=2e-3, shape_note="2048x4096")
 register(name="reduce_logsumexp", category="reduction", source=_REDUCE_SRC + "/logsumexp.py",
-         make_inputs=lambda: (randn(2048, 4096, seed=42), ), run=_mk_rowreduce(5),
+         make_inputs=lambda: (adv(2048, 4096, seed=42, lo=-1.0, hi=1.0), ), run=_mk_rowreduce(5),
          ref=lambda inp: torch.logsumexp(inp[0], 1), rtol=2e-3, atol=2e-3, shape_note="2048x4096")
 
 
@@ -1045,7 +1219,7 @@ def _run_welford(inp):
 
 register(name="welford_mean_var", category="reduction",
          source="https://github.com/pytorch-labs/tritonbench/blob/main/tritonbench/operators/welford/triton_welford.py",
-         make_inputs=lambda: (randn(2048, 4096, seed=47), ), run=_run_welford,
+         make_inputs=lambda: (adv(2048, 4096, seed=47, lo=-2.0, hi=2.0), ), run=_run_welford,
          ref=lambda inp: (inp[0].mean(1), inp[0].var(1, unbiased=False)), rtol=2e-3, atol=2e-3,
          shape_note="2048x4096")
 
@@ -1077,7 +1251,7 @@ def _run_cumsum(inp):
 
 
 register(name="cumsum_row", category="scan", source=_REDUCE_SRC + "/cumsum.py",
-         make_inputs=lambda: (randn(4096, 512, seed=48), ),
+         make_inputs=lambda: (adv(4096, 512, seed=48, lo=-2.0, hi=2.0), ),
          run=_run_cumsum, ref=lambda inp: torch.cumsum(inp[0], 1), rtol=2e-3, atol=2e-3, shape_note="4096x512")
 
 
@@ -1350,15 +1524,15 @@ def _mk_attn_ref(causal):
 
 register(name="flash_attention_fwd", category="attention",
          source="https://github.com/triton-lang/triton/blob/main/python/tutorials/06-fused-attention.py",
-         make_inputs=lambda: (randn(4, 8, 1024, 64, dtype=torch.float16, seed=62),
-                              randn(4, 8, 1024, 64, dtype=torch.float16, seed=63),
-                              randn(4, 8, 1024, 64, dtype=torch.float16, seed=64)),
+         make_inputs=lambda: (adv(4, 8, 1024, 64, dtype=torch.float16, seed=62, lo=-1.0, hi=1.0),
+                              adv(4, 8, 1024, 64, dtype=torch.float16, seed=63, lo=-1.0, hi=1.0),
+                              adv(4, 8, 1024, 64, dtype=torch.float16, seed=64, lo=-1.0, hi=1.0)),
          run=_mk_attn(False), ref=_mk_attn_ref(False), rtol=1e-2, atol=2e-2, shape_note="4x8x1024x64")
 register(name="flash_attention_causal", category="attention",
          source="https://github.com/triton-lang/triton/blob/main/python/tutorials/06-fused-attention.py",
-         make_inputs=lambda: (randn(4, 8, 1024, 64, dtype=torch.float16, seed=65),
-                              randn(4, 8, 1024, 64, dtype=torch.float16, seed=66),
-                              randn(4, 8, 1024, 64, dtype=torch.float16, seed=67)),
+         make_inputs=lambda: (adv(4, 8, 1024, 64, dtype=torch.float16, seed=65, lo=-1.0, hi=1.0),
+                              adv(4, 8, 1024, 64, dtype=torch.float16, seed=66, lo=-1.0, hi=1.0),
+                              adv(4, 8, 1024, 64, dtype=torch.float16, seed=67, lo=-1.0, hi=1.0)),
          run=_mk_attn(True), ref=_mk_attn_ref(True), rtol=1e-2, atol=2e-2, shape_note="4x8x1024x64 causal")
 
 
@@ -1390,7 +1564,7 @@ def _run_cross_entropy(inp):
 
 register(name="cross_entropy", category="loss",
          source="https://github.com/pytorch-labs/tritonbench/blob/main/tritonbench/operators/cross_entropy",
-         make_inputs=lambda: (randn(4096, 4096, seed=68), randint(4096, (4096, ), seed=69)),
+         make_inputs=lambda: (adv(4096, 4096, seed=68, lo=-1.0, hi=1.0), randint(4096, (4096, ), seed=69)),
          run=_run_cross_entropy,
          ref=lambda inp: torch.nn.functional.cross_entropy(inp[0], inp[1].long(), reduction="none"),
          rtol=2e-3, atol=2e-3, shape_note="4096x4096")
@@ -1417,8 +1591,8 @@ def _run_kl_div(inp):
 
 register(name="kl_div", category="loss",
          source="https://github.com/pytorch-labs/tritonbench/blob/main/tritonbench/operators/kl_div",
-         make_inputs=lambda: (torch.log_softmax(randn(4096, 2048, seed=70), 1),
-                              torch.softmax(randn(4096, 2048, seed=71), 1)),
+         make_inputs=lambda: (torch.log_softmax(adv(4096, 2048, seed=70, lo=-1.0, hi=1.0), 1),
+                              torch.softmax(adv(4096, 2048, seed=71, lo=-1.0, hi=1.0), 1)),
          run=_run_kl_div,
          ref=lambda inp: torch.nn.functional.kl_div(inp[0], inp[1], reduction="none").sum(1),
          rtol=2e-3, atol=2e-3, shape_note="4096x2048")
@@ -1558,7 +1732,7 @@ def _ref_index_add(inp):
     return torch.zeros(v, device=DEVICE, dtype=torch.float32).index_add_(0, idx.long(), src)
 
 
-register(name="scatter_index_add", category="embedding",
+register(name="scatter_index_add", category="embedding", nondeterministic=True,
          source="https://github.com/FlagOpen/FlagGems/blob/master/src/flag_gems/ops/scatter.py",
          make_inputs=lambda: (randint(4096, (1 << 20, ), seed=81), randn(1 << 20, seed=82), 4096),
          run=_run_index_add, ref=_ref_index_add, rtol=1e-2, atol=1e-2, shape_note="2^20 -> 4096 (atomic)")
@@ -1820,7 +1994,7 @@ def _run_gemm_splitk(inp):
     return c
 
 
-register(name="gemm_splitk", category="gemm-structural",
+register(name="gemm_splitk", category="gemm-structural", nondeterministic=True,
          source="https://github.com/triton-lang/triton/blob/main/python/tutorials/12-split-k-matmul.py",
          make_inputs=lambda: (randn(512, 512, dtype=torch.float16, seed=91),
                               randn(512, 512, dtype=torch.float16, seed=92)),
@@ -2055,7 +2229,7 @@ def _run_coop_global_sum(inp):
     return acc
 
 
-register(name="cooperative_global_sum", category="cooperative",
+register(name="cooperative_global_sum", category="cooperative", nondeterministic=True,
          source="https://github.com/triton-lang/triton/blob/main/python/tutorials/15-multi-cta-layer-norm.py",
          make_inputs=lambda: (randn(1 << 20, seed=102), ),
          run=_run_coop_global_sum, ref=lambda inp: inp[0].sum().reshape(1), rtol=1e-2, atol=1e-1,

--- a/bitequiv/evaluation/eval_kernels.py
+++ b/bitequiv/evaluation/eval_kernels.py
@@ -1514,7 +1514,11 @@ def gemm_splitk_partial_kernel(a_ptr, b_ptr, ws_ptr, M, N, K, stride_am, stride_
                                BLOCK_K: tl.constexpr, NUM_SPLITS: tl.constexpr):
     """Stage 1 of the two-kernel split-K: a 3-D grid (m, n, split) writes each split's
     K-slice partial to workspace[split, m_tile, n_tile] via a plain st.global (no
-    combine yet). The cross-split combine is a SEPARATE kernel (below)."""
+    combine yet). The cross-split combine is a SEPARATE kernel (below).
+
+    This is DETERMINISTIC split-K: traditional split-K accumulates partials across CTAs with
+    atomic adds (a non-reproducible add order); here each split owns its own workspace slot and
+    the separate combine kernel sums them in a fixed order, so the output is bit-reproducible."""
     pid_m = tl.program_id(0)
     pid_n = tl.program_id(1)
     pid_s = tl.program_id(2)

--- a/bitequiv/evaluation/eval_kernels.py
+++ b/bitequiv/evaluation/eval_kernels.py
@@ -16,17 +16,21 @@ checker or the fuzzer:
   * a small precision size for Stages 1-2 and a perf size + ``benchmark`` hook so
     Stage 3 can time every kernel across its config space.
 
-The kernels are organized into three comment-delimited GROUPS:
+The kernels are organized into four comment-delimited GROUPS:
 
-  GROUP 1 — PRIORITY (the shapes we want to support): the M1 reductions and the
-    M3 wgmma GEMM kernels. These are what the checker + optimization pass must
-    handle first.
+  GROUP 1 — PRIORITY REDUCTIONS (M1): the M1 reductions the checker + optimization
+    pass must handle first.
   GROUP 2 — OPTIMIZATION LAYOUTS (M2): reductions whose operand is a genuinely
     multi-dim tile, so the compiler has a real layout choice and the M2
     reduction-layout pass has something to optimize. (Folded in from the former
     ``eval_kernels_layout.py``.)
-  GROUP 3 — DIVERSITY / ROBUSTNESS: a placeholder for a broad, diverse kernel
-    set that stresses both the checker and the pass. Next-step job (see banner).
+  GROUP 3 — ALL GEMM KERNELS (M3 wgmma / tcgen05): every GEMM-shaped kernel --
+    the per-knob GEMMs (each isolates one bit knob) plus the diversity /
+    robustness variants (single-program K-grouping robustness kernels, real
+    cross-CTA split-K, and GEMM->reduction fusions) that stress the checker's
+    must-not-over-merge on GEMM.
+  GROUP 4 — WARP-SPECIALIZATION (WS): reductions inside a warp-specialize region
+    (inlined from the former ``eval_kernels_ws.py``).
 
 Reduction inputs are float32 with a wide dynamic range and alternating signs
 (``_adv_sum_2d`` / ``_adv_dot_2d`` / ``_adv_nd``): that is the regime where the
@@ -42,12 +46,15 @@ GROUP 1 kernels:
   * ``dot``                 — single-tile row dot product (mul-fed reduction).
   * ``cond_reduce``         — column sum behind a DATA-DEPENDENT branch (exercises
                               the checker's control-flow gap in Stage 1).
-  * GEMM (M3: Hopper wgmma bitwise-equivalence) -- DRAFT, not GPU-verified:
-    ``gemm_f16_free_tiling`` (free-var positive: M/N tiling + num_warps stay ONE
-    class), ``gemm_kloop_block_k`` (block_k = fixed bit knob), ``gemm_input_precision``
-    (tf32/ieee/tf32x3 -> 3 classes), ``gemm_bias_relu_fp_fusion`` (enable_fp_fusion
-    on/off -> 2 classes), ``gemm_fp8_imprecise_acc`` (max_num_imprecise_acc flush),
-    ``gemm_tma_store`` (known-limitation: C via TMA, no st.global root).
+
+GROUP 3 per-knob GEMM kernels (M3: Hopper wgmma / Blackwell tcgen05
+bitwise-equivalence) -- DRAFT, not GPU-verified: ``gemm_f16_free_tiling``
+(free-var positive: M/N tiling + num_warps stay ONE class), ``gemm_kloop_block_k``
+(block_k = fixed bit knob), ``gemm_input_precision`` (tf32/ieee/tf32x3 -> 3
+classes), ``gemm_bias_relu_fp_fusion`` (enable_fp_fusion on/off -> 2 classes),
+``gemm_fp8_imprecise_acc`` (max_num_imprecise_acc flush), ``gemm_tma_store``
+(known-limitation: C via TMA, no st.global root), ``gemm_kgroup`` and ``gemm_all``;
+plus the diversity / robustness GEMM variants (see the GROUP 3 banner).
 
 GROUP 2 kernels (large legal-layout space; the GROUP 2 banner explains the M2
 win/control split): ``sum_2d_keepdim``, ``sum_2d_axis0``, ``sum_2d_col``,
@@ -67,6 +74,7 @@ import torch
 
 import triton
 import triton.language as tl
+import triton.language.extra.tlx as tlx
 
 DEVICE = "cuda"
 
@@ -89,58 +97,42 @@ _DOT_LOGSPACE = (0, 6)
 # are None (e.g. welford has no reduction_ordering; single-tile kernels have no
 # block_n). Full names, no abbreviations.
 _AXIS_ORDER = ("reduction_ordering", "num_warps", "num_stages", "enable_fp_fusion", "block_n", "gemm_block_m",
-               "gemm_block_n", "gemm_block_k", "input_precision", "max_num_imprecise_acc", "gemm_num_splits")
+               "gemm_block_n", "gemm_block_k", "input_precision", "max_num_imprecise_acc", "gemm_num_splits",
+               "gemm_num_ctas", "gemm_combine", "dtype")
 Config = namedtuple("Config", _AXIS_ORDER)
 
-# Per-effort value lists. "light" (~10 configs) is the quick smoke / CI grid;
-# "heavy" is the full sweep (the looped kernels reach ~1300 configs via block_n).
+# The single MAX config grid: every knob's FULL valid value set (the kernel's whole
+# feasible config space). The eval SCRIPT subsamples this per effort (light/mid/heavy);
+# the suite only declares the max. gemm_block_m=32 (%64!=0) -> MMAv2 (mma.sync);
+# 64/128 -> MMAv5 (tcgen05). GEMM specs filter num_warps to {4,8} (wgmma needs %4==0).
 _AXIS_VALUES = {
-    "light": {
-        "reduction_ordering": ("unordered", "inner_tree"),
-        "num_warps": (1, 2, 4, 8),
-        "num_stages": (1, ),
-        "enable_fp_fusion": (True, ),
-        "block_n": (4096, ),
-        # GEMM axes (M3). gemm_block_* are the wgmma tile; note they are DISTINCT
-        # from the reduction `block_n` (a chunk size like 4096) to avoid collision.
-        # num_warps is shared, but GEMM specs filter it to {4, 8} (wgmma needs %4==0).
-        "gemm_block_m": (64, 128),
-        "gemm_block_n": (64, 128),
-        "gemm_block_k": (32, ),
-        "input_precision": ("tf32", "ieee", "tf32x3"),
-        "max_num_imprecise_acc": (32, 128),
-        "gemm_num_splits": (1, 2, 4),  # split-K: K split into this many partials then combined (bit-relevant)
-    },
-    "heavy": {
-        "reduction_ordering": ("unordered", "inner_tree"),
-        "num_warps": (1, 2, 4, 8, 16, 32),
-        "num_stages": (1, 2, 3, 4, 5, 6),
-        "enable_fp_fusion": (True, False),
-        "block_n": (64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384),
-        "gemm_block_m": (64, 128),
-        "gemm_block_n": (64, 128, 256),
-        "gemm_block_k": (16, 32, 64),
-        "input_precision": ("tf32", "ieee", "tf32x3"),
-        "max_num_imprecise_acc": (32, 64, 128),
-        "gemm_num_splits": (1, 2, 4, 8),  # split-K: K split into this many partials then combined
-    },
+    "reduction_ordering": ("unordered", "inner_tree"),
+    "num_warps": (1, 2, 4, 8, 16, 32),
+    "num_stages": (1, 2, 3, 4, 5, 6),
+    "enable_fp_fusion": (True, False),
+    "block_n": (64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384),
+    "gemm_block_m": (32, 64, 128),
+    "gemm_block_n": (64, 128, 256),
+    "gemm_block_k": (16, 32, 64),
+    "input_precision": ("tf32", "ieee", "tf32x3"),
+    "max_num_imprecise_acc": (32, 64, 128),
+    "gemm_num_splits": (1, 2, 4, 8),
+    "gemm_num_ctas": (1, 2),
+    "gemm_combine": ("seq", "strided"),
+    "dtype": ("f16", "bf16", "f32", "fp8"),  # GEMM dtype axis; each spec's valid_dtypes restricts it
 }
 
 
-def build_configs(axes, config_effort, overrides=None):
-    """Cartesian product of the kernel's ``axes`` at the given effort.
+def build_configs(axes, overrides=None):
+    """Cartesian product of the kernel's ``axes`` over the MAX config grid.
 
     Axes the kernel does not use are pinned to ``None`` so every kernel yields a
-    uniform :class:`Config`. ``overrides`` (``{axis: values}``) replaces the
-    per-effort value list for specific axes, so a spec's class-splitting knob can
-    vary at every effort without perturbing the shared ``_AXIS_VALUES``.
+    uniform :class:`Config`. ``overrides`` (``{axis: values}``) replaces the max
+    value list for specific axes (a spec's class-splitting knob). The eval SCRIPT
+    is responsible for subsampling the result per effort (light/mid/heavy).
     """
-    try:
-        values = _AXIS_VALUES[config_effort]
-    except KeyError:
-        raise ValueError(f"unknown config effort {config_effort!r}; expected one of {sorted(_AXIS_VALUES)}")
     overrides = overrides or {}
-    per_axis = [(overrides.get(a, values[a]) if a in axes else (None, )) for a in _AXIS_ORDER]
+    per_axis = [(overrides.get(a, _AXIS_VALUES[a]) if a in axes else (None, )) for a in _AXIS_ORDER]
     return [Config(*combo) for combo in itertools.product(*per_axis)]
 
 
@@ -156,7 +148,7 @@ def config_label(config):
     if config.block_n is not None:
         parts.append(f"block_n={config.block_n}")
     for axis in ("gemm_block_m", "gemm_block_n", "gemm_block_k", "input_precision", "max_num_imprecise_acc",
-                 "gemm_num_splits"):
+                 "gemm_num_splits", "gemm_num_ctas", "gemm_combine"):
         value = getattr(config, axis)
         if value is not None:
             parts.append(f"{axis}={value}")
@@ -170,12 +162,29 @@ def _signs(cols):
     return torch.where(torch.arange(cols) % 2 == 0, torch.tensor(1.0), torch.tensor(-1.0)).unsqueeze(0)
 
 
-def _adv_sum_2d(rows, cols, seed):
+# Reduction INPUT dtype (the reductions cast to tl.float32 internally, so the f32 accumulation order --
+# hence the checker's soundness -- is dtype-invariant; only the loaded-leaf precision changes).
+_TORCH_DT = {"f16": torch.float16, "bf16": torch.bfloat16, "f32": torch.float32}
+
+
+def _dt(config):
+    return _TORCH_DT.get(getattr(config, "dtype", None) or "f32", torch.float32)
+
+
+def _clip_logspace(lo, hi, dt):
+    """f16 (max ~65504, min-normal ~6e-5) cannot hold the f32/bf16 ~12-decade dynamic range without
+    overflowing to inf, so narrow it for f16 -- still wide enough that reduction ORDER changes the bits.
+    bf16 shares f32's exponent range, so it is left at the full range."""
+    return (max(lo, -3), min(hi, 3)) if dt is torch.float16 else (lo, hi)
+
+
+def _adv_sum_2d(rows, cols, seed, dt=torch.float32):
     """Wide dynamic range + alternating signs: reduction ORDER strongly affects the bits."""
     g = torch.Generator(device="cpu").manual_seed(seed)
     base = torch.randn(rows, cols, generator=g, dtype=torch.float32)
-    scale = torch.logspace(_SUM_LOGSPACE[0], _SUM_LOGSPACE[1], cols, dtype=torch.float32).unsqueeze(0)
-    return (base * scale * _signs(cols)).to(DEVICE, torch.float32)
+    lo, hi = _clip_logspace(_SUM_LOGSPACE[0], _SUM_LOGSPACE[1], dt)
+    scale = torch.logspace(lo, hi, cols, dtype=torch.float32).unsqueeze(0)
+    return (base * scale * _signs(cols)).to(DEVICE, dt)
 
 
 def _full_mantissa_2d(rows, cols, seed):
@@ -183,13 +192,14 @@ def _full_mantissa_2d(rows, cols, seed):
     return 1.0 + torch.randint(0, 1 << 23, (rows, cols), generator=g).float() / (1 << 23)  # [1, 2)
 
 
-def _adv_dot_2d(rows, cols, seed):
+def _adv_dot_2d(rows, cols, seed, dt=torch.float32):
     """Large near-cancelling products: residual dominated by product-rounding (fma axis)
     and reduction order (num_warps axis). Returns (a, b)."""
     mant = _full_mantissa_2d(rows, cols, seed)
-    mag = torch.logspace(_DOT_LOGSPACE[0], _DOT_LOGSPACE[1], cols, dtype=torch.float32).unsqueeze(0)
-    a = (mant * mag * _signs(cols)).to(DEVICE, torch.float32)
-    b = (mant * mag).to(DEVICE, torch.float32)
+    lo, hi = _clip_logspace(_DOT_LOGSPACE[0], _DOT_LOGSPACE[1], dt)
+    mag = torch.logspace(lo, hi, cols, dtype=torch.float32).unsqueeze(0)
+    a = (mant * mag * _signs(cols)).to(DEVICE, dt)
+    b = (mant * mag).to(DEVICE, dt)
     return a, b
 
 
@@ -199,20 +209,21 @@ def _randn_2d(rows, cols, seed):
     return torch.randn(rows, cols, generator=g, dtype=torch.float32).to(DEVICE)
 
 
-def _adv_nd(numel, seed):
-    """Flat wide-dynamic-range, alternating-sign f32 buffer — reduction ORDER (over any
+def _adv_nd(numel, seed, dt=torch.float32):
+    """Flat wide-dynamic-range, alternating-sign buffer — reduction ORDER (over any
     axis, once viewed multi-dim) strongly affects the result bits. Used by GROUP 2."""
     g = torch.Generator(device="cpu").manual_seed(seed)
     base = torch.randn(numel, generator=g, dtype=torch.float32)
-    scale = torch.logspace(_SUM_LOGSPACE[0], _SUM_LOGSPACE[1], numel, dtype=torch.float32)
+    lo, hi = _clip_logspace(_SUM_LOGSPACE[0], _SUM_LOGSPACE[1], dt)
+    scale = torch.logspace(lo, hi, numel, dtype=torch.float32)
     signs = torch.where(torch.arange(numel) % 2 == 0, torch.tensor(1.0), torch.tensor(-1.0))
-    return (base * scale * signs).to(DEVICE, torch.float32)
+    return (base * scale * signs).to(DEVICE, dt)
 
 
-def _plain_nd(numel, seed):
-    """Plain unit-scale flat f32 — GROUP 2 perf timing (Stage 3) and realistic fusions."""
+def _plain_nd(numel, seed, dt=torch.float32):
+    """Plain unit-scale flat buffer — GROUP 2 perf timing (Stage 3) and realistic fusions."""
     g = torch.Generator(device="cpu").manual_seed(seed)
-    return torch.randn(numel, generator=g, dtype=torch.float32).to(DEVICE)
+    return torch.randn(numel, generator=g, dtype=torch.float32).to(DEVICE, dt)
 
 
 def _to_bytes(t):
@@ -221,9 +232,10 @@ def _to_bytes(t):
 
 
 # =========================================================================== #
-# GROUP 1 — PRIORITY KERNELS TO SUPPORT: M1 reductions + M3 wgmma GEMM.
-# The shapes the checker + optimization pass must handle first. The M1 reductions
-# come first (kernels, then compile/run/bench), then the M3 GEMM kernels.
+# GROUP 1 — PRIORITY REDUCTIONS (M1).
+# The M1 reductions the checker + optimization pass must handle first (kernels,
+# then compile/run/bench). The GEMM kernels now live in GROUP 3 (ALL GEMMs); the
+# GEMM @triton.jit defs stay physically below (defs must precede registration).
 # =========================================================================== #
 @triton.jit
 def sum_dim1_kernel(input_ptr, output_ptr, M, N, input_stride_m, input_stride_n, BLOCK_N: tl.constexpr,
@@ -340,7 +352,7 @@ def cond_reduce_kernel(input_ptr, output_ptr, M, N, input_stride_m, input_stride
 # --------------------------------------------------------------------------- #
 def _simple_compile(config, size, maxnreg=None):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, 0)
+    src = _adv_sum_2d(rows, cols, 0, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     return sum_dim1_kernel.warmup(src, out, rows, cols, src.stride(0), src.stride(1), grid=(rows, ), BLOCK_N=cols,
                                   ROWS_PER_BLOCK=1, REDUCTION_ORDERING=_ORDERING[config.reduction_ordering],
@@ -350,7 +362,7 @@ def _simple_compile(config, size, maxnreg=None):
 
 def _simple_run(config, ck, seed, size):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, seed)
+    src = _adv_sum_2d(rows, cols, seed, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     ck[(rows, 1, 1)](src, out, rows, cols, src.stride(0), src.stride(1))
     torch.cuda.synchronize()
@@ -359,7 +371,7 @@ def _simple_run(config, ck, seed, size):
 
 def _persist_compile(config, size, maxnreg=None):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, 0)
+    src = _adv_sum_2d(rows, cols, 0, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     return sum_dim1_kernel_batched.warmup(src, out, rows, cols, src.stride(0), src.stride(1), grid=(rows, ),
                                           BLOCK_N=config.block_n, ROWS_PER_BLOCK=1,
@@ -370,7 +382,7 @@ def _persist_compile(config, size, maxnreg=None):
 
 def _persist_run(config, ck, seed, size):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, seed)
+    src = _adv_sum_2d(rows, cols, seed, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     ck[(rows, 1, 1)](src, out, rows, cols, src.stride(0), src.stride(1))
     torch.cuda.synchronize()
@@ -379,7 +391,7 @@ def _persist_run(config, ck, seed, size):
 
 def _welford_compile(config, size, maxnreg=None):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, 0)
+    src = _adv_sum_2d(rows, cols, 0, _dt(config))
     mean = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     var = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     return welford_kernel.warmup(src, mean, var, cols, src.stride(0), grid=(rows, ), BLOCK_SIZE=config.block_n,
@@ -389,7 +401,7 @@ def _welford_compile(config, size, maxnreg=None):
 
 def _welford_run(config, ck, seed, size):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, seed)
+    src = _adv_sum_2d(rows, cols, seed, _dt(config))
     mean = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     var = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     ck[(rows, 1, 1)](src, mean, var, cols, src.stride(0))
@@ -399,7 +411,7 @@ def _welford_run(config, ck, seed, size):
 
 def _rowsum_compile(config, size, maxnreg=None):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, 0)
+    src = _adv_sum_2d(rows, cols, 0, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     return rowsum_kernel.warmup(src, out, cols, src.stride(0), grid=(rows, ), BLOCK=cols,
                                 ORD=_ORDERING[config.reduction_ordering], num_warps=config.num_warps,
@@ -408,7 +420,7 @@ def _rowsum_compile(config, size, maxnreg=None):
 
 def _rowsum_run(config, ck, seed, size):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, seed)
+    src = _adv_sum_2d(rows, cols, seed, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     ck[(rows, 1, 1)](src, out, cols, src.stride(0))
     torch.cuda.synchronize()
@@ -417,7 +429,7 @@ def _rowsum_run(config, ck, seed, size):
 
 def _rowdot_compile(config, size, maxnreg=None):
     rows, cols = size
-    a, b = _adv_dot_2d(rows, cols, 0)
+    a, b = _adv_dot_2d(rows, cols, 0, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     return rowdot_kernel.warmup(a, b, out, cols, a.stride(0), grid=(rows, ), BLOCK=cols,
                                 ORD=_ORDERING[config.reduction_ordering], num_warps=config.num_warps,
@@ -426,7 +438,7 @@ def _rowdot_compile(config, size, maxnreg=None):
 
 def _rowdot_run(config, ck, seed, size):
     rows, cols = size
-    a, b = _adv_dot_2d(rows, cols, seed)
+    a, b = _adv_dot_2d(rows, cols, seed, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     ck[(rows, 1, 1)](a, b, out, cols, a.stride(0))
     torch.cuda.synchronize()
@@ -435,7 +447,7 @@ def _rowdot_run(config, ck, seed, size):
 
 def _cond_compile(config, size, maxnreg=None):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, 0)
+    src = _adv_sum_2d(rows, cols, 0, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     return cond_reduce_kernel.warmup(src, out, rows, cols, src.stride(0), src.stride(1), grid=(rows, ), BLOCK_N=cols,
                                      ROWS_PER_BLOCK=1, REDUCTION_ORDERING=_ORDERING[config.reduction_ordering],
@@ -445,7 +457,7 @@ def _cond_compile(config, size, maxnreg=None):
 
 def _cond_run(config, ck, seed, size):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, seed)
+    src = _adv_sum_2d(rows, cols, seed, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     ck[(rows, 1, 1)](src, out, rows, cols, src.stride(0), src.stride(1))
     torch.cuda.synchronize()
@@ -491,7 +503,7 @@ def _bench(ck, thunk, out_bytes):
 
 def _simple_benchmark(config, size):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, 0)
+    src = _adv_sum_2d(rows, cols, 0, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     ck = _simple_compile(config, size)
     return _bench(ck, lambda: ck[(rows, 1, 1)](src, out, rows, cols, src.stride(0), src.stride(1)), _to_bytes(out))
@@ -499,7 +511,7 @@ def _simple_benchmark(config, size):
 
 def _welford_benchmark(config, size):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, 0)
+    src = _adv_sum_2d(rows, cols, 0, _dt(config))
     mean = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     var = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     ck = _welford_compile(config, size)
@@ -508,7 +520,7 @@ def _welford_benchmark(config, size):
 
 def _rowsum_benchmark(config, size):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, 0)
+    src = _adv_sum_2d(rows, cols, 0, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     ck = _rowsum_compile(config, size)
     return _bench(ck, lambda: ck[(rows, 1, 1)](src, out, cols, src.stride(0)), _to_bytes(out))
@@ -516,7 +528,7 @@ def _rowsum_benchmark(config, size):
 
 def _rowdot_benchmark(config, size):
     rows, cols = size
-    a, b = _adv_dot_2d(rows, cols, 0)
+    a, b = _adv_dot_2d(rows, cols, 0, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     ck = _rowdot_compile(config, size)
     return _bench(ck, lambda: ck[(rows, 1, 1)](a, b, out, cols, a.stride(0)), _to_bytes(out))
@@ -524,14 +536,16 @@ def _rowdot_benchmark(config, size):
 
 def _cond_benchmark(config, size):
     rows, cols = size
-    src = _adv_sum_2d(rows, cols, 0)
+    src = _adv_sum_2d(rows, cols, 0, _dt(config))
     out = torch.empty(rows, device=DEVICE, dtype=torch.float32)
     ck = _cond_compile(config, size)
     return _bench(ck, lambda: ck[(rows, 1, 1)](src, out, rows, cols, src.stride(0), src.stride(1)), _to_bytes(out))
 
 
 # --------------------------------------------------------------------------- #
-# GEMM kernels (M3: Hopper wgmma bitwise-equivalence)
+# GROUP 3 GEMM kernels (M3: Hopper wgmma / Blackwell tcgen05 bitwise-equivalence)
+# The @triton.jit defs + compile/run fns live here because they must precede
+# their registration; the GROUP 3 REGISTRY.update is far below (after GROUP 2).
 # --------------------------------------------------------------------------- #
 # DRAFT -- these kernels are NOT yet GPU-verified. Every "lowers to wgmma" and
 # "order-sensitive" claim below rests on a static code audit, not a live H100
@@ -660,22 +674,27 @@ def gemm_tma_store_kernel(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak, st
 
 
 @triton.jit
-def gemm_splitk_kernel(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
+def gemm_kgroup_kernel(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
                        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr, OUT_DTYPE: tl.constexpr,
                        NUM_SPLITS: tl.constexpr):
-    """Split-K GEMM: the K contraction is cut into NUM_SPLITS contiguous slices, each summed into its
-    OWN partial accumulator, and the partials are then combined into the output. Unlike BLOCK_K (which
-    only re-chunks the SAME sequential K order and is therefore bit-free), NUM_SPLITS changes the
-    GROUPING of the K sum -- ((s0)+(s1))+... instead of a single left-fold -- so with order-sensitive
-    operands it DOES change the result bits. This is the one tiling-like GEMM knob that is genuinely
-    bit-relevant, so it exercises the checker's must-not-over-merge on GEMM (soundness), not just
-    recovery. Fused into a single kernel so it emits one st.global root the PTX checker can read."""
+    """K-grouping GEMM -- a ROBUSTNESS-TEST kernel, NOT split-K. Real split-K needs a cross-CTA reduction
+    (several CTAs write partials, a separate step sums them across CTAs -- see gemm_splitk here, or the
+    tutorial 12-split-k-matmul.py); this kernel is deliberately NOT written that way. Instead ONE program
+    (one CTA) computes the whole output tile: the K contraction is cut into NUM_SPLITS contiguous slices
+    (ceil-sized, the K tail masked so K need not divide NUM_SPLITS -- no OOB/undefined reads), each
+    summed into its OWN partial accumulator, then the partials are combined -- a single-program
+    stand-in for that grouping, so the kernel emits one st.global root the PTX checker can read. The whole
+    point is to hand the checker a genuinely BIT-RELEVANT GEMM knob to test: unlike BLOCK_K (which only
+    re-chunks the SAME sequential K order, bit-free), NUM_SPLITS changes the GROUPING of the K sum --
+    ((s0)+(s1))+... instead of a single left-fold -- so with order-sensitive operands it DOES change the
+    result bits. So it exercises the checker's must-not-over-merge on a tiling-like GEMM knob (soundness),
+    not just recovery."""
     pid_m = tl.program_id(0)
     pid_n = tl.program_id(1)
     offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
     offs_k = tl.arange(0, BLOCK_K)
-    split_k = K // NUM_SPLITS
+    split_k = tl.cdiv(K, NUM_SPLITS)  # ceil so the NUM_SPLITS contiguous slices cover all of K
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
     for s in range(NUM_SPLITS):
         partial = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
@@ -683,7 +702,10 @@ def gemm_splitk_kernel(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak, strid
         a_ptrs = a_ptr + offs_m[:, None] * stride_am + (k0 + offs_k)[None, :] * stride_ak
         b_ptrs = b_ptr + (k0 + offs_k)[:, None] * stride_bk + offs_n[None, :] * stride_bn
         for _k in range(0, split_k, BLOCK_K):
-            partial = tl.dot(tl.load(a_ptrs), tl.load(b_ptrs), partial, out_dtype=tl.float32)
+            k_mask = (k0 + _k + offs_k) < K  # mask the K tail -> K need not divide NUM_SPLITS, no OOB read
+            a = tl.load(a_ptrs, mask=k_mask[None, :], other=0.0)
+            b = tl.load(b_ptrs, mask=k_mask[:, None], other=0.0)
+            partial = tl.dot(a, b, partial, out_dtype=tl.float32)
             a_ptrs += BLOCK_K * stride_ak
             b_ptrs += BLOCK_K * stride_bk
         acc += partial  # combine this split's partial (the NUM_SPLITS-dependent grouping)
@@ -732,6 +754,7 @@ def _gemm_launch_kwargs(config):
         "num_warps": config.num_warps,
         "num_stages": config.num_stages if config.num_stages is not None else 1,
         "enable_fp_fusion": config.enable_fp_fusion if config.enable_fp_fusion is not None else True,
+        "num_ctas": config.gemm_num_ctas if config.gemm_num_ctas is not None else 1,
     }
 
 
@@ -758,37 +781,47 @@ def _gemm_run_generic(config, ck, seed, size, in_dtype, out_dtype, default_bk):
     return _to_bytes(c)
 
 
-def _gemm_free_tiling_compile(config, size, maxnreg=None):
-    return _gemm_compile_generic(config, size, maxnreg, torch.float16, tl.float16, 32, None, None)
+# Base GEMM: one dtype-parameterized kernel folding the former per-dtype/per-knob plain GEMM specs.
+# compile/run dispatch by config.dtype to _gemm_compile_generic (same gemm_kernel -> behavior-preserving).
+_GEMM_DTYPES = {
+    "f16": (torch.float16, tl.float16, 32),
+    "bf16": (torch.bfloat16, tl.float32, 32),
+    "f32": (torch.float32, tl.float32, 32),
+    "fp8": (torch.float8_e4m3fn, tl.float32, 256) if hasattr(torch, "float8_e4m3fn") else None,
+}
 
 
-def _gemm_free_tiling_run(config, ck, seed, size):
-    return _gemm_run_generic(config, ck, seed, size, torch.float16, tl.float16, 32)
+def _gemm_compile(config, size, maxnreg=None):
+    in_dt, out_dt, default_bk = _GEMM_DTYPES[config.dtype]
+    ip = config.input_precision if config.dtype == "f32" else None
+    ia = config.max_num_imprecise_acc if config.dtype == "fp8" else None
+    return _gemm_compile_generic(config, size, maxnreg, in_dt, out_dt, default_bk, ip, ia)
 
 
-def _gemm_kloop_compile(config, size, maxnreg=None):
-    return _gemm_compile_generic(config, size, maxnreg, torch.bfloat16, tl.float32, 32, None, None)
+def _gemm_run(config, ck, seed, size):
+    in_dt, out_dt, default_bk = _GEMM_DTYPES[config.dtype]
+    return _gemm_run_generic(config, ck, seed, size, in_dt, out_dt, default_bk)
 
 
-def _gemm_kloop_run(config, ck, seed, size):
-    return _gemm_run_generic(config, ck, seed, size, torch.bfloat16, tl.float32, 32)
-
-
-def _gemm_prec_compile(config, size, maxnreg=None):
-    return _gemm_compile_generic(config, size, maxnreg, torch.float32, tl.float32, 32, config.input_precision, None)
-
-
-def _gemm_prec_run(config, ck, seed, size):
-    return _gemm_run_generic(config, ck, seed, size, torch.float32, tl.float32, 32)
-
-
-def _gemm_fp8_compile(config, size, maxnreg=None):
-    return _gemm_compile_generic(config, size, maxnreg, torch.float8_e4m3fn, tl.float32, 256, None,
-                                 config.max_num_imprecise_acc)
-
-
-def _gemm_fp8_run(config, ck, seed, size):
-    return _gemm_run_generic(config, ck, seed, size, torch.float8_e4m3fn, tl.float32, 256)
+def _gemm_filter(config):
+    """wgmma num_warps%%4, the sm_100 TMEM guards, and dtype-conditional pruning: input_precision
+    only varies for f32 and max_num_imprecise_acc only for fp8 (else pinned to one value to avoid
+    spurious duplicate configs); fp8 dropped entirely if torch has no float8_e4m3fn."""
+    if config.num_warps not in (4, 8):
+        return False
+    if config.gemm_block_k == 64 and (config.num_stages or 1) >= 3:
+        return False
+    if config.gemm_block_n == 256 and (config.num_stages or 1) >= 5:
+        return False
+    if config.dtype == "fp8" and _GEMM_DTYPES["fp8"] is None:
+        return False
+    if config.dtype == "fp8" and (config.gemm_block_k or 32) < 32:
+        return False  # fp8 tensor core needs block_k >= 32; block_k=16 fails to compile
+    if config.dtype != "f32" and config.input_precision not in (None, "ieee"):
+        return False
+    if config.dtype != "fp8" and config.max_num_imprecise_acc not in (None, 32):
+        return False
+    return True
 
 
 def _gemm_bias(N, seed):
@@ -845,18 +878,18 @@ def _gemm_tma_store_run(config, ck, seed, size):
     return _to_bytes(c)
 
 
-def _gemm_splitk_compile(config, size, maxnreg=None):
+def _gemm_kgroup_compile(config, size, maxnreg=None):
     M, N, K = size
     bm, bn, bk = _gemm_blocks(config, 32)
     splits = config.gemm_num_splits if config.gemm_num_splits is not None else 1
     a, b = _gemm_operands(M, N, K, 0, torch.bfloat16)
     c = torch.empty((M, N), device=DEVICE, dtype=torch.float32)
-    return gemm_splitk_kernel.warmup(a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0),
+    return gemm_kgroup_kernel.warmup(a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0),
                                      c.stride(1), grid=(M // bm, N // bn), BLOCK_M=bm, BLOCK_N=bn, BLOCK_K=bk,
                                      OUT_DTYPE=tl.float32, NUM_SPLITS=splits, maxnreg=maxnreg, **_gemm_launch_kwargs(config))
 
 
-def _gemm_splitk_run(config, ck, seed, size):
+def _gemm_kgroup_run(config, ck, seed, size):
     M, N, K = size
     bm, bn, _bk = _gemm_blocks(config, 32)
     a, b = _gemm_operands(M, N, K, seed, torch.bfloat16)
@@ -886,16 +919,25 @@ class KernelSpec:
     perf_fn: object = None  # (config, size) -> (ms, bytes, asm_dict); None => skipped in Stage 3
     config_filter: object = None  # optional (config) -> bool; drop configs that fail it (e.g. GEMM num_warps in {4, 8})
     axis_values: object = None  # optional {axis: values} override so a splitting knob varies at every effort
+    valid_dtypes: tuple = ()  # dtypes this kernel supports; the script materializes one named spec per dtype (kernel_<dtype>)
+    bit_relevant_axes: tuple = ()  # axes whose value CHANGES output bits (the script keeps these when subsampling)
 
     @property
     def supports_perf(self):
         return self.perf_fn is not None
 
-    def config_space(self, config_effort):
-        configs = build_configs(self.axes, config_effort, self.axis_values)
+    def max_config_space(self):
+        """The kernel's FULL valid config space (the max grid). The eval script subsamples per effort."""
+        overrides = dict(self.axis_values or {})
+        if "dtype" in self.axes and self.valid_dtypes:
+            overrides["dtype"] = self.valid_dtypes  # the dtype axis is driven by the spec's valid_dtypes
+        configs = build_configs(self.axes, overrides)
         if self.config_filter is not None:
             configs = [c for c in configs if self.config_filter(c)]
         return configs
+
+    def config_space(self, config_effort=None):  # compat shim until evaluate.py switches to max_config_space
+        return self.max_config_space()
 
     def compile(self, config, size, maxnreg=None):
         return self.compile_fn(config, size, maxnreg=maxnreg)
@@ -907,7 +949,7 @@ class KernelSpec:
         return self.perf_fn(config, size)
 
 
-_REDUCTION_AXES = ("reduction_ordering", "num_warps", "num_stages", "enable_fp_fusion")
+_REDUCTION_AXES = ("reduction_ordering", "num_warps", "num_stages", "enable_fp_fusion", "dtype")
 
 REGISTRY = {
     "sum_dim1_simple":
@@ -989,132 +1031,7 @@ REGISTRY = {
         run_fn=_cond_run,
         perf_fn=_cond_benchmark,
     ),
-    # GEMM (M3) -- DRAFT, not GPU-verified. Stage-3 perf deferred (perf_fn=None).
-    "gemm_f16_free_tiling":
-    KernelSpec(
-        name="gemm_f16_free_tiling",
-        description="f16 wgmma GEMM; free-var positive -- only M/N tiling + num_warps vary, must stay ONE bitwise class",
-        output_arity=1,
-        axes=("num_warps", "gemm_block_m", "gemm_block_n"),
-        precision_size=(256, 256, 256),
-        perf_size=(256, 256, 256),
-        known_limitation="",
-        compile_fn=_gemm_free_tiling_compile,
-        run_fn=_gemm_free_tiling_run,
-        config_filter=_gemm_num_warps_filter,
-    ),
-    "gemm_kloop_block_k":
-    KernelSpec(
-        name="gemm_kloop_block_k",
-        description="bf16 K-looped GEMM; M/N tiling FREE, block_k is a FIXED bit knob (splits classes)",
-        output_arity=1,
-        axes=("num_warps", "num_stages", "gemm_block_m", "gemm_block_n", "gemm_block_k"),
-        precision_size=(256, 256, 256),
-        perf_size=(256, 256, 256),
-        known_limitation="",
-        compile_fn=_gemm_kloop_compile,
-        run_fn=_gemm_kloop_run,
-        config_filter=_gemm_num_warps_filter,
-        axis_values={"gemm_block_k": (16, 32)},  # sweep the splitting knob at every effort (light gemm_block_k is single-valued)
-    ),
-    "gemm_input_precision":
-    KernelSpec(
-        name="gemm_input_precision",
-        description="f32 GEMM; input_precision tf32/ieee/tf32x3 must land in 3 distinct classes",
-        output_arity=1,
-        axes=("num_warps", "gemm_block_m", "gemm_block_n", "input_precision"),
-        precision_size=(256, 256, 256),
-        perf_size=(256, 256, 256),
-        known_limitation="",
-        compile_fn=_gemm_prec_compile,
-        run_fn=_gemm_prec_run,
-        config_filter=_gemm_num_warps_filter,
-    ),
-    "gemm_bias_relu_fp_fusion":
-    KernelSpec(
-        name="gemm_bias_relu_fp_fusion",
-        description="bf16 GEMM + relu(acc*alpha+bias); enable_fp_fusion on/off -> 2 classes (fma vs mul+add)",
-        output_arity=1,
-        axes=("enable_fp_fusion", "num_warps", "gemm_block_m", "gemm_block_n"),
-        precision_size=(256, 256, 256),
-        perf_size=(256, 256, 256),
-        known_limitation="",
-        compile_fn=_gemm_bias_relu_compile,
-        run_fn=_gemm_bias_relu_run,
-        config_filter=_gemm_num_warps_filter,
-        axis_values={"enable_fp_fusion": (True, False)},  # on/off split at every effort (light enable_fp_fusion is single-valued)
-    ),
-    "gemm_fp8_imprecise_acc":
-    KernelSpec(
-        name="gemm_fp8_imprecise_acc",
-        description="fp8 e4m3 GEMM; max_num_imprecise_acc (partial-accumulator flush) is a FIXED bit knob",
-        output_arity=1,
-        axes=("num_warps", "gemm_block_m", "gemm_block_n", "max_num_imprecise_acc"),
-        precision_size=(256, 256, 512),
-        perf_size=(256, 256, 512),
-        known_limitation="",
-        compile_fn=_gemm_fp8_compile,
-        run_fn=_gemm_fp8_run,
-        config_filter=_gemm_num_warps_filter,
-    ),
-    "gemm_tma_store":
-    KernelSpec(
-        name="gemm_tma_store",
-        description="f16 wgmma GEMM with a TMA-descriptor epilogue (no st.global root)",
-        output_arity=1,
-        axes=("num_warps", "gemm_block_m", "gemm_block_n"),
-        precision_size=(256, 256, 256),
-        perf_size=(256, 256, 256),
-        known_limitation=("C is stored via a TMA descriptor (cp.async.bulk.tensor), not st.global; the PTX checker's "
-                          "builder.roots() finds no root -> empty descriptor -> UNSUPPORTED. (TMA API + host "
-                          "allocator wiring is unverified on the target Triton.)"),
-        compile_fn=_gemm_tma_store_compile,
-        run_fn=_gemm_tma_store_run,
-        config_filter=_gemm_num_warps_filter,
-    ),
-    "gemm_splitk":
-    KernelSpec(
-        name="gemm_splitk",
-        description=("bf16 split-K GEMM; gemm_num_splits regroups the K sum into that many partials then combines "
-                     "them -> a genuinely BIT-RELEVANT tiling-like knob (a distinct class per split value), unlike "
-                     "the bit-free block_k. Order-sensitive operands (wide range + alternating sign along K). This is "
-                     "the GEMM kernel that stresses the checker's must-not-over-merge on tiling (soundness)."),
-        output_arity=1,
-        axes=("num_warps", "gemm_block_m", "gemm_block_n", "gemm_num_splits"),
-        precision_size=(256, 256, 2048),
-        perf_size=(256, 256, 2048),
-        known_limitation="",
-        compile_fn=_gemm_splitk_compile,
-        run_fn=_gemm_splitk_run,
-        config_filter=_gemm_num_warps_filter,
-        axis_values={"gemm_num_splits": (1, 2, 4, 8)},  # sweep the splitting knob at every effort
-    ),
-    "gemm_all":
-    KernelSpec(
-        name="gemm_all",
-        description=("f32 GEMM varying ALL co-existing knobs together (M/N/K tiling x input_precision x "
-                     "enable_fp_fusion x num_warps x num_stages) -- the real autotuner cross-product, to "
-                     "stress the MMA fence with cross-knob interactions. The per-knob GEMM specs above "
-                     "isolate one knob each for clean attribution; this crosses them (~1300 configs at heavy). "
-                     "fp8 stays a separate spec (a distinct dtype path that cannot co-vary with input_precision)."),
-        output_arity=1,
-        axes=("enable_fp_fusion", "num_warps", "num_stages", "gemm_block_m", "gemm_block_n", "gemm_block_k",
-              "input_precision"),
-        precision_size=(256, 256, 256),
-        perf_size=(256, 256, 256),
-        known_limitation="",
-        compile_fn=_gemm_prec_compile,
-        run_fn=_gemm_prec_run,
-        config_filter=_gemm_all_filter,
-        axis_values={"gemm_block_k": (16, 32, 64), "enable_fp_fusion": (True, False)},
-    ),
 }
-
-# fp8 e4m3 is absent on older torch builds; drop the fp8 spec if so, to keep the
-# import safe and avoid a missing-dtype AttributeError masquerading as an
-# UNSUPPORTED checker verdict.
-if not hasattr(torch, "float8_e4m3fn"):
-    REGISTRY.pop("gemm_fp8_imprecise_acc", None)
 
 
 # =========================================================================== #
@@ -1352,7 +1269,7 @@ class _LK:
 def _mk_compile(lk):
     def compile_fn(config, size, maxnreg=None):
         grid = size[0]
-        dt = lk.in_dtype or torch.float32
+        dt = lk.in_dtype or _dt(config)
         # warmup does not launch, so the data is irrelevant — use cheap buffers.
         ins = [torch.empty(grid * lk.tile_numel, device=DEVICE, dtype=dt) for _ in range(lk.n_inputs)]
         out = torch.empty(grid * lk.out_numel, device=DEVICE, dtype=torch.float32)
@@ -1366,8 +1283,8 @@ def _mk_compile(lk):
 def _mk_run(lk):
     def run_fn(config, ck, seed, size):
         grid = size[0]
-        dt = lk.in_dtype or torch.float32
-        ins = [lk.input_fn(grid * lk.tile_numel, seed + i).to(dt) for i in range(lk.n_inputs)]
+        dt = lk.in_dtype or _dt(config)
+        ins = [lk.input_fn(grid * lk.tile_numel, seed + i, dt) for i in range(lk.n_inputs)]
         out = torch.empty(grid * lk.out_numel, device=DEVICE, dtype=torch.float32)
         ck[(grid, 1, 1)](*ins, out)
         torch.cuda.synchronize()
@@ -1473,13 +1390,771 @@ REGISTRY.update({
 
 
 # =========================================================================== #
-# GROUP 3 — DIVERSITY / ROBUSTNESS KERNELS (placeholder — next-step job).
+# GROUP 3 — ALL GEMM KERNELS (M3 wgmma / tcgen05).
 # =========================================================================== #
-# Intentionally empty for now. This group will hold a broad, diverse set of
-# reduction kernels (varied purpose / control-flow / dtype / rank / op) chosen so
-# that most have a real base(inner_tree) != ceiling(unordered) gap, to stress both
-# the checker (soundness) and the M2 pass (robustness). A 29-kernel draft of these
-# lives in the history of D111025844; re-adding + curating them here is a follow-up.
+# Every GEMM-shaped kernel lives in this group. The per-knob GEMMs (moved here
+# from GROUP 1: gemm_f16_free_tiling / gemm_kloop_block_k / gemm_input_precision /
+# gemm_bias_relu_fp_fusion / gemm_fp8_imprecise_acc / gemm_tma_store / gemm_kgroup /
+# gemm_all) each isolate one bit knob; the diversity / robustness variants below
+# stress the checker beyond those per-knob GEMMs and split into two families:
+#
+#   BIT-CHANGING (each MUST produce > 1 empirical class): the K-sum grouping and
+#     split-K variants (gemm_kgroup / gemm_kgroup_precision are single-program
+#     K-grouping ROBUSTNESS-TEST kernels, NOT split-K -- real split-K needs a
+#     cross-CTA reduction; gemm_splitk / gemm_splitk_tree are the real cross-CTA
+#     split-K) and the
+#     GEMM-then-order-sensitive-reduction fusions (gemm_reduce_sum / _softmax /
+#     _layernorm). These hunt checker OVER-MERGES (soundness): a knob that changes
+#     the FP grouping/order (num_splits, combine order, the epilogue reduce order)
+#     changes the result bits, so the checker must never merge across it. Operands
+#     use wide magnitude + ALTERNATING SIGN along the summed axis so the sum
+#     catastrophically cancels and its order decides the bits (plain data rounds
+#     every order the same and hides the signal).
+#
+#   BIT-NEUTRAL CONTROLS (must stay ~1 empirical class): gemm_2cta / gemm_grouped
+#     / gemm_bmm. Only genuinely FREE knobs vary (M/N tiling, num_warps, cluster
+#     size, batch/group scheduling), which never change a given C[m, n]'s bits, so
+#     the whole config space is one bitwise class. They confirm GEMM diversity does
+#     not introduce spurious over-merges and measure the checker's recovery.
+#
+# All fit the KernelSpec harness (one st.global-rooted output the PTX checker can
+# read) and the sm_100 TMEM budget (modest block sizes; the split accumulator is a
+# single MMA tile). Reuses _gemm_operands / _gemm_blocks / _gemm_launch_kwargs /
+# _gemm_num_warps_filter / _to_bytes from the GEMM section above.
+
+# Combine-order knob (gemm_splitk_tree): map the string axis to a kernel constexpr.
+# "seq" = sequential left fold; "strided" = even/odd two-accumulator fold (see
+# gemm_splitk_combine_kernel for why a balanced binary tree is not expressible list-free).
+_COMBINE = {"seq": 0, "strided": 1, None: 0}
+
+# Batch / group counts for the bmm / grouped controls (a free, embarrassingly
+# parallel axis — kept small so the eval stays fast). Not an autotuner knob.
+_BMM_BATCH = 4
+_GROUPED_G = 4
+
+
+def _gemm_reduce_operands(M, N, K, seed, dtype):
+    """A[M, K] @ B[K, N] whose product C[m, n] carries wide magnitude + ALTERNATING
+    SIGN along N (the axis the epilogue reduces), so the epilogue sum over N
+    catastrophically cancels and its ORDER decides the result bits. Achieved by
+    scaling/sign-flipping the COLUMNS of B (column n of C inherits B's column n
+    scale). A stays plain — the K-contraction is not the order-sensitive axis here."""
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    a = torch.randn(M, K, generator=g, dtype=torch.float32)
+    b = torch.randn(K, N, generator=g, dtype=torch.float32)
+    n_scale = torch.logspace(-2.0, 2.0, N, dtype=torch.float32)
+    n_sign = torch.where(torch.arange(N) % 2 == 0, torch.tensor(1.0), torch.tensor(-1.0))
+    b = b * (n_scale * n_sign).unsqueeze(0)
+    return a.to(DEVICE, dtype), b.to(DEVICE, dtype)
+
+
+def _gemm_softmax_operands(M, N, K, seed, dtype):
+    """A @ B scaled so C[m, n] ~ N(0, 1) (A divided by sqrt(K)). softmax needs a
+    MODERATE C: with the wide/cancelling reduce operands, exp(C - rowmax) underflows
+    to 0 for all but the top entry, so the denominator sum has one term and is
+    order-INSENSITIVE (1 empirical class). With C ~ O(1) the 256 exp terms are all
+    comparable, so the sum over N is genuinely order-sensitive."""
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    a = torch.randn(M, K, generator=g, dtype=torch.float32) / (K**0.5)
+    b = torch.randn(K, N, generator=g, dtype=torch.float32)
+    return a.to(DEVICE, dtype), b.to(DEVICE, dtype)
+
+
+def _gemm_batched_operands(batch, M, N, K, seed, dtype):
+    """A stack of ``batch`` independent order-sensitive GEMM operand pairs -> tensors
+    A[batch, M, K], B[batch, K, N]. Each slice is a normal _gemm_operands pair, so
+    every batch/group is its own independent GEMM (a free axis: bit-identical bits
+    per slice regardless of tiling)."""
+    a_list, b_list = [], []
+    for i in range(batch):
+        a, b = _gemm_operands(M, N, K, seed * 131 + i, dtype)
+        a_list.append(a)
+        b_list.append(b)
+    return torch.stack(a_list), torch.stack(b_list)
+
+
+# --------------------------------------------------------------------------- #
+# GROUP 3 kernels
+# --------------------------------------------------------------------------- #
+@triton.jit
+def gemm_kgroup_prec_kernel(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_ak, stride_bk, stride_bn, stride_cm,
+                            stride_cn, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+                            OUT_DTYPE: tl.constexpr, NUM_SPLITS: tl.constexpr, INPUT_PRECISION: tl.constexpr):
+    """K-grouping GEMM (a ROBUSTNESS-TEST kernel like gemm_kgroup_kernel: NOT split-K -- a single program
+    mimics the K-partition grouping; real cross-CTA split-K is gemm_splitk / the tutorial, not written
+    this way) with an extra input_precision knob, so a config crosses num_splits (K-sum grouping ->
+    bit-relevant) x input_precision (tf32/ieee/tf32x3 -> distinct MMA rounding) x gemm_block_k (bit-FREE
+    re-chunk). The empirical partition is ~ input_precision x distinct-split-grouping (block_k merges
+    within), a double-digit set that stresses cross-knob attribution."""
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    split_k = K // NUM_SPLITS
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for s in range(NUM_SPLITS):
+        partial = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        k0 = s * split_k
+        a_ptrs = a_ptr + offs_m[:, None] * stride_am + (k0 + offs_k)[None, :] * stride_ak
+        b_ptrs = b_ptr + (k0 + offs_k)[:, None] * stride_bk + offs_n[None, :] * stride_bn
+        for _k in range(0, split_k, BLOCK_K):
+            partial = tl.dot(tl.load(a_ptrs), tl.load(b_ptrs), partial, input_precision=INPUT_PRECISION,
+                             out_dtype=tl.float32)
+            a_ptrs += BLOCK_K * stride_ak
+            b_ptrs += BLOCK_K * stride_bk
+        acc += partial
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, acc.to(OUT_DTYPE))
+
+
+@triton.jit
+def gemm_splitk_partial_kernel(a_ptr, b_ptr, ws_ptr, M, N, K, stride_am, stride_ak, stride_bk, stride_bn, stride_ws_s,
+                               stride_ws_m, stride_ws_n, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+                               BLOCK_K: tl.constexpr, NUM_SPLITS: tl.constexpr):
+    """Stage 1 of the two-kernel split-K: a 3-D grid (m, n, split) writes each split's
+    K-slice partial to workspace[split, m_tile, n_tile] via a plain st.global (no
+    combine yet). The cross-split combine is a SEPARATE kernel (below)."""
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    pid_s = tl.program_id(2)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    split_k = K // NUM_SPLITS
+    k0 = pid_s * split_k
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + (k0 + offs_k)[None, :] * stride_ak
+    b_ptrs = b_ptr + (k0 + offs_k)[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    partial = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for _k in range(0, split_k, BLOCK_K):
+        partial = tl.dot(tl.load(a_ptrs), tl.load(b_ptrs), partial, out_dtype=tl.float32)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+    ws_ptrs = ws_ptr + pid_s * stride_ws_s + offs_m[:, None] * stride_ws_m + offs_n[None, :] * stride_ws_n
+    tl.store(ws_ptrs, partial)
+
+
+@triton.jit
+def gemm_splitk_combine_kernel(ws_ptr, c_ptr, M, N, stride_ws_s, stride_ws_m, stride_ws_n, stride_cm, stride_cn,
+                        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, NUM_SPLITS: tl.constexpr, COMBINE: tl.constexpr,
+                        OUT_DTYPE: tl.constexpr):
+    """Stage 2 of the two-kernel split-K: load the NUM_SPLITS partials for this tile
+    and combine them, then st.global to C. COMBINE selects the FP grouping:
+    0 = sequential left fold ((p0+p1)+p2)+...; 1 = strided fold (sum of even-indexed
+    splits) + (sum of odd-indexed splits) -- a genuinely different associativity than
+    the left fold (Triton's list literals are immutable tuples, so a recursive
+    balanced tree cannot hold its intermediates; the strided two-accumulator fold is
+    the list-free stand-in that plays the same "non-sequential combine" role). For
+    NUM_SPLITS >= 4 the two orders round differently on order-sensitive partials, so
+    gemm_combine is a bit-relevant knob at fixed num_splits (the fold-order signal)."""
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    base = offs_m[:, None] * stride_ws_m + offs_n[None, :] * stride_ws_n
+    if COMBINE == 0:  # sequential left fold ((p0+p1)+p2)+...+p_{S-1}
+        acc = tl.load(ws_ptr + base)
+        for s in range(1, NUM_SPLITS):
+            acc = acc + tl.load(ws_ptr + s * stride_ws_s + base)
+    else:  # strided fold (sum of even splits) + (sum of odd splits) -- a distinct associativity
+        even = tl.load(ws_ptr + base)
+        for s in range(2, NUM_SPLITS, 2):
+            even = even + tl.load(ws_ptr + s * stride_ws_s + base)
+        odd = tl.load(ws_ptr + stride_ws_s + base)
+        for s in range(3, NUM_SPLITS, 2):
+            odd = odd + tl.load(ws_ptr + s * stride_ws_s + base)
+        acc = even + odd
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, acc.to(OUT_DTYPE))
+
+
+@triton.jit
+def gemm_reduce_kernel(a_ptr, b_ptr, out_ptr, M, N, K, stride_am, stride_ak, stride_bk, stride_bn, BLOCK_M: tl.constexpr,
+                       BLOCK_K: tl.constexpr, N_COLS: tl.constexpr, ORD: tl.constexpr, OUT_DTYPE: tl.constexpr):
+    """GEMM then an order-sensitive ROW SUM: compute C[BLOCK_M, N] = A @ B (whole N in
+    one tile), then out[m] = sum_n C[m, n] with reduction_ordering=ORD. The MMA feeds a
+    reduction, so this exercises MMA -> reduce composition; the sum ORDER (ORD, num_warps
+    layout) decides the bits while M/N tiling stays free."""
+    pid_m = tl.program_id(0)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, N_COLS)
+    offs_k = tl.arange(0, BLOCK_K)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    acc = tl.zeros((BLOCK_M, N_COLS), dtype=tl.float32)
+    for _k in range(0, K, BLOCK_K):
+        acc = tl.dot(tl.load(a_ptrs), tl.load(b_ptrs), acc, out_dtype=tl.float32)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+    s = tl.sum(acc, axis=1, reduction_ordering=ORD)
+    tl.store(out_ptr + offs_m, s.to(OUT_DTYPE))
+
+
+@triton.jit
+def gemm_softmax_kernel(a_ptr, b_ptr, out_ptr, M, N, K, stride_am, stride_ak, stride_bk, stride_bn,
+                        BLOCK_M: tl.constexpr, BLOCK_K: tl.constexpr, N_COLS: tl.constexpr, ORD: tl.constexpr,
+                        OUT_DTYPE: tl.constexpr):
+    """GEMM then a row SOFTMAX over N. max is order-invariant; the denominator
+    sum_n exp(C - max) is the order-sensitive reduce (reduction_ordering=ORD)."""
+    pid_m = tl.program_id(0)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, N_COLS)
+    offs_k = tl.arange(0, BLOCK_K)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    acc = tl.zeros((BLOCK_M, N_COLS), dtype=tl.float32)
+    for _k in range(0, K, BLOCK_K):
+        acc = tl.dot(tl.load(a_ptrs), tl.load(b_ptrs), acc, out_dtype=tl.float32)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+    mx = tl.max(acc, axis=1)
+    e = tl.exp(acc - mx[:, None])
+    s = tl.sum(e, axis=1, reduction_ordering=ORD)
+    y = e / s[:, None]
+    out_ptrs = out_ptr + offs_m[:, None] * N_COLS + offs_n[None, :]
+    tl.store(out_ptrs, y.to(OUT_DTYPE))
+
+
+@triton.jit
+def gemm_layernorm_kernel(a_ptr, b_ptr, out_ptr, M, N, K, stride_am, stride_ak, stride_bk, stride_bn,
+                          BLOCK_M: tl.constexpr, BLOCK_K: tl.constexpr, N_COLS: tl.constexpr, ORD: tl.constexpr,
+                          OUT_DTYPE: tl.constexpr):
+    """GEMM then a row LAYERNORM over N: the mean and variance reductions over N are
+    both order-sensitive (reduction_ordering=ORD)."""
+    pid_m = tl.program_id(0)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, N_COLS)
+    offs_k = tl.arange(0, BLOCK_K)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    acc = tl.zeros((BLOCK_M, N_COLS), dtype=tl.float32)
+    for _k in range(0, K, BLOCK_K):
+        acc = tl.dot(tl.load(a_ptrs), tl.load(b_ptrs), acc, out_dtype=tl.float32)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+    mean = tl.sum(acc, axis=1, reduction_ordering=ORD) / N_COLS
+    xc = acc - mean[:, None]
+    var = tl.sum(xc * xc, axis=1, reduction_ordering=ORD) / N_COLS
+    y = xc / tl.sqrt(var[:, None] + 1e-6)
+    out_ptrs = out_ptr + offs_m[:, None] * N_COLS + offs_n[None, :]
+    tl.store(out_ptrs, y.to(OUT_DTYPE))
+
+
+@triton.jit
+def gemm_bmm_kernel(a_ptr, b_ptr, c_ptr, M, N, K, stride_ab, stride_am, stride_ak, stride_bb, stride_bk, stride_bn,
+                    stride_cb, stride_cm, stride_cn, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+                    BLOCK_K: tl.constexpr, OUT_DTYPE: tl.constexpr):
+    """Batched matmul: a 3-D grid (batch, m, n); each batch is an INDEPENDENT GEMM
+    (the batch axis is embarrassingly parallel and free). A bit-neutral control:
+    tiling / num_warps never change a batch's bits, so the whole space is one class."""
+    pid_b = tl.program_id(0)
+    pid_m = tl.program_id(1)
+    pid_n = tl.program_id(2)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    a_ptrs = a_ptr + pid_b * stride_ab + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + pid_b * stride_bb + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for _k in range(0, K, BLOCK_K):
+        acc = tl.dot(tl.load(a_ptrs), tl.load(b_ptrs), acc, out_dtype=tl.float32)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+    c_ptrs = c_ptr + pid_b * stride_cb + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, acc.to(OUT_DTYPE))
+
+
+@triton.jit
+def gemm_grouped_kernel(a_ptr, b_ptr, c_ptr, M, N, K, stride_ag, stride_am, stride_ak, stride_bg, stride_bk, stride_bn,
+                        stride_cg, stride_cm, stride_cn, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+                        BLOCK_K: tl.constexpr, NUM_M_TILES: tl.constexpr, NUM_N_TILES: tl.constexpr,
+                        OUT_DTYPE: tl.constexpr):
+    """Grouped GEMM (equal-size groups): a 1-D LINEARIZED tile schedule (the MoE
+    pattern) maps program_id -> (group, m_tile, n_tile). Every group is an
+    independent GEMM. Bit-neutral control -- differs from bmm only in the grid
+    scheduling (1-D flattened vs 3-D), which is free, so still one bitwise class."""
+    pid = tl.program_id(0)
+    tiles_per_group = NUM_M_TILES * NUM_N_TILES
+    gid = pid // tiles_per_group
+    t = pid % tiles_per_group
+    pid_m = t // NUM_N_TILES
+    pid_n = t % NUM_N_TILES
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    a_ptrs = a_ptr + gid * stride_ag + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + gid * stride_bg + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for _k in range(0, K, BLOCK_K):
+        acc = tl.dot(tl.load(a_ptrs), tl.load(b_ptrs), acc, out_dtype=tl.float32)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+    c_ptrs = c_ptr + gid * stride_cg + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, acc.to(OUT_DTYPE))
+
+
+# --------------------------------------------------------------------------- #
+# GROUP 3 compile / run
+# --------------------------------------------------------------------------- #
+def _gemm_kgroup_prec_compile(config, size, maxnreg=None):
+    M, N, K = size
+    bm, bn, bk = _gemm_blocks(config, 32)
+    splits = config.gemm_num_splits if config.gemm_num_splits is not None else 1
+    a, b = _gemm_operands(M, N, K, 0, torch.float32)
+    c = torch.empty((M, N), device=DEVICE, dtype=torch.float32)
+    return gemm_kgroup_prec_kernel.warmup(a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1),
+                                          c.stride(0), c.stride(1), grid=(M // bm, N // bn), BLOCK_M=bm, BLOCK_N=bn,
+                                          BLOCK_K=bk, OUT_DTYPE=tl.float32, NUM_SPLITS=splits,
+                                          INPUT_PRECISION=config.input_precision, maxnreg=maxnreg,
+                                          **_gemm_launch_kwargs(config))
+
+
+def _gemm_kgroup_prec_run(config, ck, seed, size):
+    M, N, K = size
+    bm, bn, _bk = _gemm_blocks(config, 32)
+    a, b = _gemm_operands(M, N, K, seed, torch.float32)
+    c = torch.empty((M, N), device=DEVICE, dtype=torch.float32)
+    ck[(M // bm, N // bn, 1)](a, b, c, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0),
+                              c.stride(1))
+    torch.cuda.synchronize()
+    return _to_bytes(c)
+
+
+def _gemm_2kernel_compile(config, size, maxnreg=None):
+    # The checker reads the COMBINE kernel (the cross-split fold); the partial kernel
+    # is compiled+launched in run. Combine uses COMBINE=seq for the plain 2-kernel spec.
+    M, N, K = size
+    bm, bn, _bk = _gemm_blocks(config, 32)
+    splits = config.gemm_num_splits if config.gemm_num_splits is not None else 1
+    combine = _COMBINE[config.gemm_combine]
+    ws = torch.empty((splits, M, N), device=DEVICE, dtype=torch.float32)
+    c = torch.empty((M, N), device=DEVICE, dtype=torch.float32)
+    return gemm_splitk_combine_kernel.warmup(ws, c, M, N, ws.stride(0), ws.stride(1), ws.stride(2), c.stride(0), c.stride(1),
+                                      grid=(M // bm, N // bn), BLOCK_M=bm, BLOCK_N=bn, NUM_SPLITS=splits,
+                                      COMBINE=combine, OUT_DTYPE=tl.float32, maxnreg=maxnreg,
+                                      **_gemm_launch_kwargs(config))
+
+
+def _gemm_2kernel_run(config, ck, seed, size):
+    M, N, K = size
+    bm, bn, bk = _gemm_blocks(config, 32)
+    splits = config.gemm_num_splits if config.gemm_num_splits is not None else 1
+    a, b = _gemm_operands(M, N, K, seed, torch.bfloat16)
+    ws = torch.empty((splits, M, N), device=DEVICE, dtype=torch.float32)
+    gemm_splitk_partial_kernel[(M // bm, N // bn, splits)](a, b, ws, M, N, K, a.stride(0), a.stride(1), b.stride(0),
+                                                           b.stride(1), ws.stride(0), ws.stride(1), ws.stride(2),
+                                                           BLOCK_M=bm, BLOCK_N=bn, BLOCK_K=bk, NUM_SPLITS=splits,
+                                                           **_gemm_launch_kwargs(config))
+    c = torch.empty((M, N), device=DEVICE, dtype=torch.float32)
+    ck[(M // bm, N // bn, 1)](ws, c, M, N, ws.stride(0), ws.stride(1), ws.stride(2), c.stride(0), c.stride(1))
+    torch.cuda.synchronize()
+    return _to_bytes(c)
+
+
+def _gemm_reduce_compile_for(kernel, operand_fn):
+    def compile_fn(config, size, maxnreg=None):
+        M, N, K = size
+        bm = config.gemm_block_m if config.gemm_block_m is not None else 128
+        out_shape = (M, ) if kernel is gemm_reduce_kernel else (M, N)
+        a, b = operand_fn(M, N, K, 0, torch.bfloat16)
+        out = torch.empty(out_shape, device=DEVICE, dtype=torch.float32)
+        return kernel.warmup(a, b, out, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1),
+                             grid=(M // bm, ), BLOCK_M=bm, BLOCK_K=32, N_COLS=N,
+                             ORD=_ORDERING[config.reduction_ordering], OUT_DTYPE=tl.float32, maxnreg=maxnreg,
+                             **_gemm_launch_kwargs(config))
+
+    return compile_fn
+
+
+def _gemm_reduce_run_for(kernel, operand_fn):
+    def run_fn(config, ck, seed, size):
+        M, N, K = size
+        bm = config.gemm_block_m if config.gemm_block_m is not None else 128
+        out_shape = (M, ) if kernel is gemm_reduce_kernel else (M, N)
+        a, b = operand_fn(M, N, K, seed, torch.bfloat16)
+        out = torch.empty(out_shape, device=DEVICE, dtype=torch.float32)
+        ck[(M // bm, 1, 1)](a, b, out, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1))
+        torch.cuda.synchronize()
+        return _to_bytes(out)
+
+    return run_fn
+
+
+def _gemm_bmm_compile(config, size, maxnreg=None):
+    M, N, K = size
+    bm, bn, bk = _gemm_blocks(config, 32)
+    a, b = _gemm_batched_operands(_BMM_BATCH, M, N, K, 0, torch.bfloat16)
+    c = torch.empty((_BMM_BATCH, M, N), device=DEVICE, dtype=torch.float32)
+    return gemm_bmm_kernel.warmup(a, b, c, M, N, K, a.stride(0), a.stride(1), a.stride(2), b.stride(0), b.stride(1),
+                                  b.stride(2), c.stride(0), c.stride(1), c.stride(2), grid=(_BMM_BATCH, M // bm, N // bn),
+                                  BLOCK_M=bm, BLOCK_N=bn, BLOCK_K=bk, OUT_DTYPE=tl.float32, maxnreg=maxnreg,
+                                  **_gemm_launch_kwargs(config))
+
+
+def _gemm_bmm_run(config, ck, seed, size):
+    M, N, K = size
+    bm, bn, _bk = _gemm_blocks(config, 32)
+    a, b = _gemm_batched_operands(_BMM_BATCH, M, N, K, seed, torch.bfloat16)
+    c = torch.empty((_BMM_BATCH, M, N), device=DEVICE, dtype=torch.float32)
+    ck[(_BMM_BATCH, M // bm, N // bn)](a, b, c, M, N, K, a.stride(0), a.stride(1), a.stride(2), b.stride(0), b.stride(1),
+                                       b.stride(2), c.stride(0), c.stride(1), c.stride(2))
+    torch.cuda.synchronize()
+    return _to_bytes(c)
+
+
+def _gemm_grouped_compile(config, size, maxnreg=None):
+    M, N, K = size
+    bm, bn, bk = _gemm_blocks(config, 32)
+    num_m, num_n = M // bm, N // bn
+    a, b = _gemm_batched_operands(_GROUPED_G, M, N, K, 0, torch.bfloat16)
+    c = torch.empty((_GROUPED_G, M, N), device=DEVICE, dtype=torch.float32)
+    return gemm_grouped_kernel.warmup(a, b, c, M, N, K, a.stride(0), a.stride(1), a.stride(2), b.stride(0), b.stride(1),
+                                      b.stride(2), c.stride(0), c.stride(1), c.stride(2),
+                                      grid=(_GROUPED_G * num_m * num_n, ), BLOCK_M=bm, BLOCK_N=bn, BLOCK_K=bk,
+                                      NUM_M_TILES=num_m, NUM_N_TILES=num_n, OUT_DTYPE=tl.float32, maxnreg=maxnreg,
+                                      **_gemm_launch_kwargs(config))
+
+
+def _gemm_grouped_run(config, ck, seed, size):
+    M, N, K = size
+    bm, bn, _bk = _gemm_blocks(config, 32)
+    num_m, num_n = M // bm, N // bn
+    a, b = _gemm_batched_operands(_GROUPED_G, M, N, K, seed, torch.bfloat16)
+    c = torch.empty((_GROUPED_G, M, N), device=DEVICE, dtype=torch.float32)
+    ck[(_GROUPED_G * num_m * num_n, 1, 1)](a, b, c, M, N, K, a.stride(0), a.stride(1), a.stride(2), b.stride(0),
+                                           b.stride(1), b.stride(2), c.stride(0), c.stride(1), c.stride(2))
+    torch.cuda.synchronize()
+    return _to_bytes(c)
+
+
+# --------------------------------------------------------------------------- #
+# GROUP 3 registry
+# --------------------------------------------------------------------------- #
+_GEMM_TILE_AXES = ("num_warps", "gemm_block_m", "gemm_block_n")
+
+REGISTRY.update({
+    # --- base GEMM: one dtype-parameterized plain tiled GEMM. Folds the former per-dtype/per-knob
+    #     gemm_f16_free_tiling / kloop_block_k / input_precision / all / fp8_imprecise_acc / 2cta.
+    #     The eval script emits one named spec per selected dtype (gemm_f16 / gemm_bf16 / gemm_f32 / gemm_fp8).
+    #     DRAFT, not GPU-verified. Stage-3 perf deferred (perf_fn=None). ---
+    "gemm":
+    KernelSpec(
+        name="gemm",
+        description=("plain tiled GEMM (C=A@B), dtype-parameterized. Free knobs (M/N/K tiling, num_warps, "
+                     "num_stages, gemm_num_ctas) are BIT-FREE; BIT-RELEVANT knobs are input_precision "
+                     "(f32: tf32/ieee/tf32x3), enable_fp_fusion, and dtype (fp8: MMAv2 vs MMAv5). Folds the "
+                     "former per-knob plain-GEMM specs; the script emits one gemm_<dtype> per selected dtype."),
+        output_arity=1,
+        axes=("num_warps", "num_stages", "enable_fp_fusion", "gemm_block_m", "gemm_block_n", "gemm_block_k",
+              "input_precision", "max_num_imprecise_acc", "gemm_num_ctas", "dtype"),
+        precision_size=(256, 256, 256),
+        perf_size=(256, 256, 256),
+        known_limitation="",
+        compile_fn=_gemm_compile,
+        run_fn=_gemm_run,
+        config_filter=_gemm_filter,
+        valid_dtypes=("f16", "bf16", "f32", "fp8"),
+        bit_relevant_axes=("input_precision", "enable_fp_fusion", "dtype"),
+    ),
+    "gemm_bias_relu_fp_fusion":
+    KernelSpec(
+        name="gemm_bias_relu_fp_fusion",
+        description="bf16 GEMM + relu(acc*alpha+bias); enable_fp_fusion on/off -> 2 classes (fma vs mul+add)",
+        output_arity=1,
+        axes=("enable_fp_fusion", "num_warps", "gemm_block_m", "gemm_block_n"),
+        precision_size=(256, 256, 256),
+        perf_size=(256, 256, 256),
+        known_limitation="",
+        compile_fn=_gemm_bias_relu_compile,
+        run_fn=_gemm_bias_relu_run,
+        config_filter=_gemm_num_warps_filter,
+        axis_values={"enable_fp_fusion": (True, False)},  # on/off split at every effort (light enable_fp_fusion is single-valued)
+    ),
+    "gemm_tma_store":
+    KernelSpec(
+        name="gemm_tma_store",
+        description="f16 wgmma GEMM with a TMA-descriptor epilogue (no st.global root)",
+        output_arity=1,
+        axes=("num_warps", "gemm_block_m", "gemm_block_n"),
+        precision_size=(256, 256, 256),
+        perf_size=(256, 256, 256),
+        known_limitation=("C is stored via a TMA descriptor (cp.async.bulk.tensor), not st.global; the PTX checker's "
+                          "builder.roots() finds no root -> empty descriptor -> UNSUPPORTED. (TMA API + host "
+                          "allocator wiring is unverified on the target Triton.)"),
+        compile_fn=_gemm_tma_store_compile,
+        run_fn=_gemm_tma_store_run,
+        config_filter=_gemm_num_warps_filter,
+    ),
+    "gemm_kgroup":
+    KernelSpec(
+        name="gemm_kgroup",
+        description=("bf16 K-grouping GEMM -- a ROBUSTNESS-TEST kernel, NOT split-K (real split-K needs a cross-CTA "
+                     "reduction: gemm_splitk / the tutorial; this is a single-program stand-in, not written that way). "
+                     "gemm_num_splits regroups the K sum into that many partials then combines them -> a genuinely "
+                     "BIT-RELEVANT tiling-like knob (a distinct class per split value; num_splits swept over a rich set "
+                     "incl. non-powers-of-2: 1,2,3,4,6,8,12), unlike the bit-free block_k. Order-sensitive operands "
+                     "(wide range + alternating sign along K). This is the GEMM kernel that stresses the checker's "
+                     "must-not-over-merge on tiling (soundness)."),
+        output_arity=1,
+        axes=("num_warps", "gemm_block_m", "gemm_block_n", "gemm_num_splits"),
+        precision_size=(256, 256, 3072),
+        perf_size=(256, 256, 3072),
+        known_limitation="",
+        compile_fn=_gemm_kgroup_compile,
+        run_fn=_gemm_kgroup_run,
+        config_filter=_gemm_num_warps_filter,
+        axis_values={"gemm_num_splits": (1, 2, 3, 4, 6, 8, 12)},  # rich set incl. non-powers-of-2 (K=3072 divisible by 3/6/12); swept at every effort
+    ),
+    # --- bit-changing: single-program K-grouping (gemm_kgroup*) + real cross-CTA
+    #     split-K variants (hunt over-merges on the K-sum grouping) ---
+    "gemm_kgroup_precision":
+    KernelSpec(
+        name="gemm_kgroup_precision",
+        description=("f32 K-grouping GEMM -- a ROBUSTNESS-TEST kernel, NOT split-K (single-program stand-in; real "
+                     "cross-CTA split-K is gemm_splitk / the tutorial) crossing gemm_num_splits x input_precision x "
+                     "gemm_block_k -- a double-digit empirical set (split grouping x tf32/ieee/tf32x3 rounding; "
+                     "block_k is bit-free)"),
+        output_arity=1,
+        axes=("num_warps", "gemm_block_m", "gemm_num_splits", "input_precision", "gemm_block_k"),
+        precision_size=(256, 256, 1024),
+        perf_size=(256, 256, 1024),
+        known_limitation="",
+        compile_fn=_gemm_kgroup_prec_compile,
+        run_fn=_gemm_kgroup_prec_run,
+        config_filter=_gemm_num_warps_filter,
+        axis_values={"gemm_num_splits": (1, 2, 4, 8), "input_precision": ("tf32", "ieee", "tf32x3")},
+    ),
+    "gemm_splitk":
+    KernelSpec(
+        name="gemm_splitk",
+        description=("THE canonical REAL cross-CTA split-K: a 3-D-grid partial kernel writes per-split partials to a "
+                     "global workspace, a SEPARATE combine kernel sums them into C. The checker reads the combine "
+                     "kernel (cross-split fold over ld.global partials); num_splits changes the fold -> bit-relevant"),
+        output_arity=1,
+        axes=_GEMM_TILE_AXES + ("gemm_num_splits", ),
+        precision_size=(256, 256, 2048),
+        perf_size=(256, 256, 2048),
+        known_limitation="",
+        compile_fn=_gemm_2kernel_compile,
+        run_fn=_gemm_2kernel_run,
+        config_filter=_gemm_num_warps_filter,
+        axis_values={"gemm_num_splits": (1, 2, 4, 8)},
+    ),
+    "gemm_splitk_tree":
+    KernelSpec(
+        name="gemm_splitk_tree",
+        description=("two-kernel split-K where the combine kernel folds the partials SEQUENTIALLY (left fold) vs "
+                     "STRIDED (even-splits sum + odd-splits sum) via gemm_combine. At fixed num_splits>=4 the two "
+                     "orders round differently -> the combine ORDER is bit-relevant; probes whether the checker "
+                     "distinguishes fold shape"),
+        output_arity=1,
+        axes=_GEMM_TILE_AXES + ("gemm_num_splits", "gemm_combine"),
+        precision_size=(256, 256, 2048),
+        perf_size=(256, 256, 2048),
+        known_limitation="",
+        compile_fn=_gemm_2kernel_compile,
+        run_fn=_gemm_2kernel_run,
+        config_filter=_gemm_num_warps_filter,
+        axis_values={"gemm_num_splits": (4, 8), "gemm_combine": ("seq", "strided")},
+    ),
+    # --- bit-changing: GEMM then an order-sensitive reduction over C = A @ B ---
+    "gemm_reduce_sum":
+    KernelSpec(
+        name="gemm_reduce_sum",
+        description=("GEMM then an order-sensitive ROW SUM over N (out[m]=sum_n (A@B)[m,n]); MMA->reduce "
+                     "composition, the sum order (reduction_ordering, num_warps) decides the bits"),
+        output_arity=1,
+        axes=("reduction_ordering", "num_warps", "gemm_block_m"),
+        precision_size=(256, 256, 512),
+        perf_size=(256, 256, 512),
+        known_limitation="",
+        compile_fn=_gemm_reduce_compile_for(gemm_reduce_kernel, _gemm_reduce_operands),
+        run_fn=_gemm_reduce_run_for(gemm_reduce_kernel, _gemm_reduce_operands),
+        config_filter=_gemm_num_warps_filter,
+    ),
+    "gemm_softmax":
+    KernelSpec(
+        name="gemm_softmax",
+        description=("GEMM then a row SOFTMAX over N; the denominator sum_n exp(C-max) is the order-sensitive "
+                     "reduce (reduction_ordering, num_warps)"),
+        output_arity=1,
+        axes=("reduction_ordering", "num_warps", "gemm_block_m"),
+        precision_size=(256, 256, 512),
+        perf_size=(256, 256, 512),
+        known_limitation="",
+        compile_fn=_gemm_reduce_compile_for(gemm_softmax_kernel, _gemm_softmax_operands),
+        run_fn=_gemm_reduce_run_for(gemm_softmax_kernel, _gemm_softmax_operands),
+        config_filter=_gemm_num_warps_filter,
+    ),
+    "gemm_layernorm":
+    KernelSpec(
+        name="gemm_layernorm",
+        description=("GEMM then a row LAYERNORM over N; the mean and variance reductions over N are order-sensitive "
+                     "(reduction_ordering, num_warps)"),
+        output_arity=1,
+        axes=("reduction_ordering", "num_warps", "gemm_block_m"),
+        precision_size=(256, 256, 512),
+        perf_size=(256, 256, 512),
+        known_limitation="",
+        compile_fn=_gemm_reduce_compile_for(gemm_layernorm_kernel, _gemm_reduce_operands),
+        run_fn=_gemm_reduce_run_for(gemm_layernorm_kernel, _gemm_reduce_operands),
+        config_filter=_gemm_num_warps_filter,
+    ),
+    # --- bit-neutral controls (must stay ~1 empirical class) ---
+    "gemm_bmm":
+    KernelSpec(
+        name="gemm_bmm",
+        description=(f"bf16 BATCHED matmul ({_BMM_BATCH} independent GEMMs, 3-D grid). Batch is a free axis; tiling / "
+                     "num_warps never change a batch's bits -> bit-neutral control (one class)"),
+        output_arity=1,
+        axes=_GEMM_TILE_AXES,
+        precision_size=(256, 256, 512),
+        perf_size=(256, 256, 512),
+        known_limitation="",
+        compile_fn=_gemm_bmm_compile,
+        run_fn=_gemm_bmm_run,
+        config_filter=_gemm_num_warps_filter,
+    ),
+    "gemm_grouped":
+    KernelSpec(
+        name="gemm_grouped",
+        description=(f"bf16 GROUPED GEMM ({_GROUPED_G} equal groups, 1-D linearized MoE-style tile schedule). Group "
+                     "+ tile scheduling is free -> bit-neutral control (one class)"),
+        output_arity=1,
+        axes=_GEMM_TILE_AXES,
+        precision_size=(256, 256, 512),
+        perf_size=(256, 256, 512),
+        known_limitation="",
+        compile_fn=_gemm_grouped_compile,
+        run_fn=_gemm_grouped_run,
+        config_filter=_gemm_num_warps_filter,
+    ),
+})
+
+# (fp8 availability is handled per-config in `_gemm_filter`: fp8 configs of the base `gemm`
+# are dropped when torch lacks float8_e4m3fn, so no post-registration pop is needed.)
+
+
+# =========================================================================== #
+# GROUP 4 — WARP-SPECIALIZATION (WS): reductions inside a warp-specialize region.
+# Inlined from the former eval_kernels_ws.py. Two sub-groups:
+#
+#   GROUP WS-1 -- pure-Triton automatic warp specialization: PLACEHOLDER. Triton's
+#     auto-WS for no-MMA reductions currently crashes upstream (a WSTaskIdPropagate
+#     assertion, "expected exactly 1 partition element"), and that crash happens
+#     BEFORE the M2 reduction-layout pass runs -- so there is no pure-Triton WS
+#     reduction kernel that reaches M2 yet. Re-add kernels here once that upstream
+#     bug is fixed. (MMA-fed reductions are out of scope for M2 anyway: their reduce
+#     operand is a #linear layout, which M2 -- blocked-only -- deliberately skips.)
+#
+#   GROUP WS-2 -- TLX explicit warp specialization: a consumer partition performs a
+#     cross-warp ``inner_tree`` reduction. M2 fires INSIDE the ``ttg.warp_specialize``
+#     partition and sizes the moved layout to the PARTITION warp count (not the
+#     module total). Proven bit-identical (M2 on == M2 off, bytewise).
+# =========================================================================== #
+
+_TLX_M = 64  # reduce-axis extent (rows), split across the consumer partition's warps
+_TLX_C = 32  # kept / output extent (cols)
+_TLX_CONSUMER_WARPS = 4
+
+
+@triton.jit
+def _tlx_ws_colsum(X, Out, M: tl.constexpr, C: tl.constexpr, CW: tl.constexpr, ORD: tl.constexpr):
+    with tlx.async_tasks():
+        with tlx.async_task("default"):
+            pass
+        with tlx.async_task(num_warps=CW):
+            g = tl.program_id(0)
+            m = tl.arange(0, M)[:, None]
+            c = tl.arange(0, C)[None, :]
+            x = tl.load(X + g * (M * C) + m * C + c)  # [M, C]
+            s = tl.sum(x, axis=0, reduction_ordering=ORD)  # [C]; reduce axis 0 (across warps)
+            tl.store(Out + g * C + tl.arange(0, C), s)
+
+
+def _tlx_colsum_compile(config, size, maxnreg=None):
+    grid = size[0]
+    x = torch.empty(grid * _TLX_M * _TLX_C, device=DEVICE, dtype=torch.float32)
+    out = torch.empty(grid * _TLX_C, device=DEVICE, dtype=torch.float32)
+    return _tlx_ws_colsum.warmup(x, out, grid=(grid, ), M=_TLX_M, C=_TLX_C, CW=_TLX_CONSUMER_WARPS,
+                                 ORD=_ORDERING[config.reduction_ordering], num_warps=config.num_warps,
+                                 num_stages=config.num_stages, enable_fp_fusion=config.enable_fp_fusion,
+                                 maxnreg=maxnreg)
+
+
+def _tlx_colsum_run(config, ck, seed, size):
+    grid = size[0]
+    x = _adv_nd(grid * _TLX_M * _TLX_C, seed)
+    out = torch.empty(grid * _TLX_C, device=DEVICE, dtype=torch.float32)
+    ck[(grid, 1, 1)](x, out)
+    torch.cuda.synchronize()
+    return _to_bytes(out)
+
+
+def _tlx_colsum_bench(config, size):
+    grid = size[0]
+    x = _plain_nd(grid * _TLX_M * _TLX_C, 0)
+    out = torch.empty(grid * _TLX_C, device=DEVICE, dtype=torch.float32)
+    ck = _tlx_colsum_compile(config, size)
+
+    def thunk():
+        ck[(grid, 1, 1)](x, out)
+
+    thunk()
+    torch.cuda.synchronize()
+    return _bench_ms(thunk), _to_bytes(out), ck.asm
+
+
+REGISTRY["tlx_ws_colsum"] = KernelSpec(
+    name="tlx_ws_colsum",
+    description=("TLX warp-specialized: consumer partition (4 warps, < module num-warps) does a "
+                 "cross-warp inner_tree column sum; M2 relayouts the operand INSIDE the "
+                 "ttg.warp_specialize partition to the partition warp count. Bit-identical."),
+    output_arity=1,
+    axes=_REDUCTION_AXES,
+    precision_size=(64, _TLX_M),  # (grid, reduce_extent); reduce_extent is display-only
+    perf_size=(2048, _TLX_M),
+    known_limitation="",
+    compile_fn=_tlx_colsum_compile,
+    run_fn=_tlx_colsum_run,
+    perf_fn=_tlx_colsum_bench,
+    # The module num-warps must exceed the consumer partition (4) + default, so keep >= 8.
+    config_filter=lambda c: c.num_warps is None or c.num_warps >= 8,
+)
+
+
+# Per-kernel dtype + bit-relevant-axis metadata, applied ONCE post-registration (single place).
+#   valid_dtypes      -> the eval script names each spec `<name>_<dtype>` and filters it by --dtypes.
+#   bit_relevant_axes -> axes whose value CHANGES the output bits; the script keeps these when it
+#                        subsamples a config space per effort (the rest are free to sample).
+# The base `gemm` sets its own (multi-dtype) inline, so it is skipped below. Everything else is
+# single-dtype (default f32) with the exceptions listed here.
+_KERNEL_DTYPE = {
+    "col_bf16": "bf16", "gemm_bias_relu_fp_fusion": "bf16", "gemm_tma_store": "f16",
+    "gemm_kgroup": "bf16", "gemm_splitk": "bf16", "gemm_splitk_tree": "bf16",
+    "gemm_bmm": "bf16", "gemm_grouped": "bf16",
+}
+_BIT_RELEVANT = {
+    "gemm_bias_relu_fp_fusion": ("enable_fp_fusion", ), "gemm_tma_store": (),
+    "gemm_kgroup": ("gemm_num_splits", ), "gemm_kgroup_precision": ("gemm_num_splits", "input_precision"),
+    "gemm_splitk": ("gemm_num_splits", ), "gemm_splitk_tree": ("gemm_num_splits", "gemm_combine"),
+    "gemm_reduce_sum": ("reduction_ordering", ), "gemm_softmax": ("reduction_ordering", ),
+    "gemm_layernorm": ("reduction_ordering", ), "gemm_bmm": (), "gemm_grouped": (), "col_max": (),
+}
+# Pure reductions cast their inputs to tl.float32 internally, so a low-precision INPUT (f16/bf16) is a
+# meaningful, distinct config (only the loaded-leaf precision changes; the f32 accumulation order does
+# not) -> give them f16/bf16/f32. Kernels with a pinned in_dtype (col_bf16) stay in _KERNEL_DTYPE.
+_REDUCTION_DTYPES = ("f16", "bf16", "f32")
+for _name, _spec in REGISTRY.items():
+    if _spec.valid_dtypes:  # base `gemm` already set its own inline -> leave it
+        continue
+    if _spec.axes is _REDUCTION_AXES and _name not in _KERNEL_DTYPE:
+        _dtypes = _REDUCTION_DTYPES
+    else:
+        _dtypes = (_KERNEL_DTYPE.get(_name, "f32"), )
+    object.__setattr__(_spec, "valid_dtypes", _dtypes)
+    object.__setattr__(_spec, "bit_relevant_axes",
+                       _BIT_RELEVANT.get(_name, ("reduction_ordering", "enable_fp_fusion")))
 
 
 def resolve_kernels(selector):

--- a/bitequiv/evaluation/evaluate.py
+++ b/bitequiv/evaluation/evaluate.py
@@ -2,65 +2,62 @@
 
 WHAT THIS IS
 ------------
-One driver, four stages, run from the command line, that measure how good a
-static bitwise-equivalence checker is at deciding which autotuner configs of a
-reduction kernel produce identical output bits. The checker under test is
-pluggable (``--checker``); by default it is the repo checker
-``bitequiv.ptx_reduction.ptx_reduction_descriptor``. This script changes no
+One driver, a few opt-in stages, run from the command line, that measure how good
+a static bitwise-equivalence checker is at deciding which autotuner configs of a
+kernel produce identical output bits. The checker under test is pluggable
+(``--checker``); by default it is the repo checker
+``bitequiv.ptx_reduction:ptx_reduction_descriptor``. This script changes no
 checker code — it only evaluates one.
 
-WHY SEPARATE STAGES
--------------------
-The question "is this checker good?" splits into independent questions, so
-the framework answers them separately and you can run only the ones you need:
-
-  Stage 1 — SUPPORT.   Does the checker even understand this kind of kernel?
-      For each kernel it probes the checker on a reference config and reports
-      SUPPORTED / LIMITED / UNSUPPORTED. Today this is a thin heuristic on the
-      descriptor (empty / unparseable => UNSUPPORTED, a tensor-core ``mma`` guard
-      => LIMITED, otherwise SUPPORTED) plus any limitation the kernel author
-      declared (the ``cond_reduce`` control-flow kernel is the example). The repo
-      checker accepts essentially every reduction, so this stage is a placeholder;
-      ``kernel_support`` is the documented extension point for when a checker can
-      declare real support itself.
-
-  Stage 2 — PRECISION.   Of the configs it supports, how well does the checker
-      partition them, and is it SOUND? It builds the config space, compiles each
-      config to PTX, asks the checker to group them, and independently fuzzes
-      every config (the empirical ground truth). It then reports, per kernel:
-        * how many equivalence classes the checker found and the largest one
-          (the bit-equivalent search space the checker recovers);
-        * how many classes the fuzzer found and the largest one (the recovery
-          CEILING — the most the checker could ever recover);
+THE STAGES (pick with ``--stages``, comma list of names)
+-------------------------------------------------------
+  precision   — Of the configs it supports, how well does the checker partition
+      them, and is it SOUND? It builds the config space, compiles each config to
+      PTX, asks the checker to group them, and independently fuzzes every config
+      (the empirical ground truth). It reports, per kernel:
+        * checker sets and the largest one (the tuning freedom the checker recovers);
+        * empirical sets and the largest one (the recovery CEILING);
         * OVER-MERGES — pairs the checker called equal but the fuzzer separated.
-          This is the soundness violation count and MUST be 0;
-        * REFINES — whether the checker partition refines the empirical one (the
-          formal statement of soundness).
+          The soundness violation count; MUST be 0;
+        * OVER-SPLITS — pairs the fuzzer merged but the checker separated. Recovery
+          left on the table (safe, not a soundness bug — just conservative);
+        * REFINES — whether the checker partition refines the empirical one.
 
-  Stage 3 — PERFORMANCE (opt-in).   Given a bit-exactness constraint, how much
-      speed is on the table? It benchmarks every kernel across its config space,
-      finds the global-fastest CEILING (a normal autotuner, no equivalence
-      constraint), then looks inside one checker-certified equivalence set:
-      after verifying every member is byte-identical, it reports the fastest vs
-      slowest member (the tuning freedom the checker hands the autotuner) and the
-      best member vs the ceiling (the cost of demanding identical bits).
+  performance — Given a bit-exactness constraint, how much speed is on the table?
+      Benchmarks every config, finds the global-fastest CEILING (a normal
+      autotuner, no equivalence constraint), then looks inside one
+      checker-certified set: after verifying every member is byte-identical it
+      reports fastest vs slowest member (the freedom the checker hands the
+      autotuner) and best member vs the ceiling (the cost of identical bits).
 
-  Stage 4 — EQUIVALENCE UNDER REGISTER PRESSURE (opt-in).   Does the checker's
-      verdict survive ptxas (PTX -> SASS) across a WHOLE diverse equivalence set? It
-      fuzzes each checker-equivalence set (diverse num_warps / num_stages /
-      enable_fp_fusion / block_n) while ALSO capping ``maxnreg`` low enough to make
-      ptxas spill. ``maxnreg`` only adds a ``.maxnreg`` directive (same PTX body =>
-      same checker classes) but changes ptxas allocation, so the set spans diverse
-      configs AND register regimes. One checker class == one bit-class (over-merges 0)
-      means equivalence holds across diverse configs even under spilling; a bit-split
-      would flag any ptxas-induced break. Run at heavy config effort + the large tensor.
+  regpressure — Does the checker's verdict survive ptxas (PTX -> SASS) across a
+      WHOLE diverse set? Fuzzes each checker set while ALSO capping ``maxnreg`` low
+      enough to make ptxas spill. ``.maxnreg`` leaves the PTX body identical (same
+      checker classes) but changes ptxas allocation, so the set spans diverse
+      configs AND register regimes. One checker class == one bit-class => equivalence
+      holds even under spilling.
 
-EFFORT KNOBS
-------------
-  --config-effort  light (~10 configs, quick gate)  |  heavy (full sweep, ~1000-3000)
-  --fuzzer-effort  fast (10 random seeds)            |  convincing (1000 seeds)
+  korder      — K-reduction-order experiment (GEMM v5/v2 bit-invariance, split-K
+      order sensitivity, 2-CTA). Placeholder here; filled by the korder stage.
+
+  cublas      — bit-for-bit match against a cuBLAS reference. Placeholder.
+
+EFFORT (``--effort``, applies to ``precision`` + ``performance`` only)
+--------------------------------------------------------------------
+  light  — a few priority kernels, one representative per bit-relevant bucket,
+           small input, 10 fuzz seeds. A ~15-min smoke / demo run.
+  mid    — the full max config space, larger input, 20 seeds. The per-diff table.
+  heavy  — the full max config space, ML-scale input, 20 seeds. The headline run.
+Input sizes scale with effort: GEMM 256^3 / 2048^3 / 8192^3; reduction 32x2048 /
+512x8192 / 2048x16384. ``regpressure`` / ``korder`` / ``cublas`` always run at mid.
 A fuzzer can only refute equivalence, never prove it, so more seeds = stronger
 evidence of soundness, never certainty.
+
+DATATYPE (``--dtypes``, comma list or ``all``)
+----------------------------------------------
+Each base kernel is materialized into one named spec per selected dtype, named
+``<kernel>_<dtype>`` (e.g. ``gemm_f16``, ``gemm_bf16``, ``sum_f32``). dtype is a
+first-class config axis for GEMMs, never collapsed — every dtype gets its own row.
 
 OUTPUT
 ------
@@ -70,21 +67,25 @@ short summary on stdout whose soundness line the pytest gate parses.
 
 LAYOUT
 ------
-  eval_kernels.py       — every test kernel + its KernelSpec (the registry).
+  eval_kernels.py       — every test kernel + its KernelSpec (the registry / the
+                          MAX config space each kernel declares).
   equivalence_fuzzer.py — standalone empirical oracle + partition/soundness math.
-  evaluate.py (here)    — the staged CLI driver; orchestration only.
+  evaluate.py (here)    — the staged CLI driver; orchestration + effort sampling.
 
 EXAMPLES
 --------
   # quick smoke / what the pytest gate runs:
-  python -m bitequiv.evaluation.evaluate --stages 1,2 --config-effort light --fuzzer-effort fast
-  # full standard run with perf:
-  python -m bitequiv.evaluation.evaluate --stages 1,2,3 --config-effort heavy --fuzzer-effort convincing
+  python -m bitequiv.evaluation.evaluate --stages precision --effort light
+  # the per-diff table (precision + performance) over every kernel and dtype:
+  python -m bitequiv.evaluation.evaluate --stages precision,performance --effort mid
+  # just the GEMMs, bf16 only, headline soundness run:
+  python -m bitequiv.evaluation.evaluate --kernels gemm,gemm_kgroup --dtypes bf16 --effort heavy
   # evaluate a different / experimental checker:
   python -m bitequiv.evaluation.evaluate --checker my.module:my_descriptor
 """
 
 import argparse
+import dataclasses
 import datetime
 import importlib
 import inspect
@@ -100,10 +101,47 @@ if _REPO not in sys.path:
 import torch  # noqa: E402
 
 from bitequiv.evaluation import eval_kernels, equivalence_fuzzer  # noqa: E402
-from bitequiv.evaluation.eval_kernels import _AXIS_ORDER, config_label, resolve_kernels  # noqa: E402
+from bitequiv.evaluation.eval_kernels import _AXIS_ORDER, build_configs, config_label, resolve_kernels  # noqa: E402
 
 _DEFAULT_CHECKER = "bitequiv.ptx_reduction:ptx_reduction_descriptor"
 _DEFAULT_OUT = os.path.join(os.path.dirname(__file__), "result.txt")
+
+# The effort knob. Only ``precision`` and ``performance`` read it; the other stages
+# always run at ``mid``. Each level fixes three things at once: how many fuzz seeds
+# per config, whether to use the full max config space or a small subsample, and the
+# input tensor size (per kernel family, resolved in ``_effort_size``).
+_EFFORT = {
+    "light": dict(repeats=10, gemm_size=(256, 256, 256), reduction_size=(32, 2048),
+                  default_kernels=("sum", "dot", "softmax", "gemm", "gemm_kgroup", "gemm_splitk")),
+    "mid": dict(repeats=20, gemm_size=(2048, 2048, 2048), reduction_size=(512, 8192), default_kernels=None),
+    "heavy": dict(repeats=20, gemm_size=(8192, 8192, 8192), reduction_size=(2048, 16384), default_kernels=None),
+}
+_LIGHT_PER_BUCKET = 4  # light keeps this many configs per bit-relevant bucket (some free-axis spread to merge)
+_MID = "mid"  # stages other than precision/performance always run here
+_STAGES = ("precision", "performance", "regpressure", "korder", "cublas")
+
+# How much of the max config space each effort actually RUNS (input size scales separately in _EFFORT):
+#   light — a few configs per bit-relevant bucket (smoke / demo);
+#   mid   — the PROVEN old-experiment "heavy" curated axis values (the scope prior per-diff tables were
+#           built on): a tractable subset of the full grid. Axes added later (gemm_num_ctas, gemm_combine,
+#           gemm_block_m=32 / MMAv2) are pinned to their old single value so mid stays known-good; the
+#           v5/v2 and 2-CTA stories are covered by the korder stage instead;
+#   heavy — the full max grid (spec.max_config_space()).
+_MID_AXIS_VALUES = {
+    "reduction_ordering": ("unordered", "inner_tree"),
+    "num_warps": (1, 2, 4, 8, 16, 32),
+    "num_stages": (1, 2, 3, 4, 5, 6),
+    "enable_fp_fusion": (True, False),
+    "block_n": (64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384),
+    "gemm_block_m": (64, 128),
+    "gemm_block_n": (64, 128, 256),
+    "gemm_block_k": (16, 32, 64),
+    "input_precision": ("tf32", "ieee", "tf32x3"),
+    "max_num_imprecise_acc": (32, 64, 128),
+    "gemm_num_splits": (1, 2, 4, 8),
+    "gemm_num_ctas": (1, ),
+    "gemm_combine": ("seq", ),
+}
 
 
 # --------------------------------------------------------------------------- #
@@ -139,52 +177,75 @@ def make_run_checker(checker):
     if wants_config:
         return lambda asm_text, config: checker(asm_text, config)
     return lambda asm_text, config: checker(asm_text)
-
-
-def _descriptor_verdict(desc):
-    """Heuristic SUPPORTED/LIMITED/UNSUPPORTED from a checker descriptor alone.
-
-    The repo descriptor is a compact *hash* per entry (e.g. ``ntid=x32|<hash>``),
-    so we cannot read the tree out of it — the only checker-agnostic signals are:
-    a non-empty parseable descriptor (the checker accepted the kernel), the
-    plaintext ``unanalyzed-mma`` guard (a tensor-core op it does not model), or an
-    empty / unparseable result. This is why Stage 1 is a placeholder: today's
-    checker accepts essentially every reduction, so a real LIMITED/UNSUPPORTED
-    signal must come from a declared limitation or a checker that self-declares
-    support (the ``kernel_support`` extension point).
-    """
-    if not desc:
-        return "UNSUPPORTED", "empty descriptor (no entry / no reduction reconstructed)"
-    if not isinstance(desc, (tuple, list)):
-        return "UNSUPPORTED", "checker could not parse the PTX"
-    if any("unanalyzed-mma" in str(s) for s in desc):
-        return "LIMITED", "contains a tensor-core (mma) op the checker does not model"
-    return "SUPPORTED", "checker reconstructed a reduction descriptor"
-
-
-def kernel_support(spec, run_checker, artifact="ptx"):
-    """Stage 1 verdict for one kernel: (verdict, detail).
-
-    A declared ``known_limitation`` (the author knows the checker can't model this
-    kernel soundly, e.g. control flow) downgrades to LIMITED regardless of the
-    descriptor heuristic — Stage 1 is a placeholder until the checker can declare
-    real support itself.
-    """
-    ref = spec.config_space("light")[0]
-    try:
-        ck = spec.compile(ref, spec.precision_size)
-        desc = run_checker(ck.asm[artifact], ref)
-    except Exception as exc:  # noqa: BLE001
-        return "UNSUPPORTED", f"reference config failed to compile or check: {type(exc).__name__}"
-    verdict, detail = _descriptor_verdict(desc)
-    if spec.known_limitation:
-        return "LIMITED", spec.known_limitation
-    return verdict, detail
-
-
 # --------------------------------------------------------------------------- #
-# Stage 2 — precision
+# Effort sampling — the suite declares the MAX config space + a base size; the
+# script picks how much of it to run, and at what input size, per effort.
 # --------------------------------------------------------------------------- #
+def _size_family(spec):
+    """gemm (3-D M/N/K) | reduction (2-D rows/cols) | other (keep the spec's baked size)."""
+    if spec.name.startswith("gemm") and len(spec.precision_size) == 3:
+        return "gemm"
+    if len(spec.precision_size) == 2:
+        return "reduction"
+    return "other"
+
+
+def _effort_size(spec, effort, perf=False):
+    """Input size for this kernel at this effort. GEMM/reduction families scale with effort;
+    every other shape (3-D/4-D reductions, batched GEMM, ...) keeps its baked spec size."""
+    fam = _size_family(spec)
+    if fam == "gemm":
+        return _EFFORT[effort]["gemm_size"]
+    if fam == "reduction":
+        return _EFFORT[effort]["reduction_size"]
+    return spec.perf_size if perf else spec.precision_size
+
+
+def _resolve_configs(spec, effort):
+    """The config set to actually run at this effort (see _MID_AXIS_VALUES for the levels).
+
+    heavy = the full max grid; mid = the proven old-experiment curated axis values (dtype pinned to the
+    spec's, num_ctas/combine to their old single value); light = a few configs per *bit-relevant bucket*
+    (every bit distinction stays present so the over-merge picture is honest, free-axis variation trimmed)."""
+    if effort == "heavy":
+        return spec.max_config_space()
+    if effort == "mid":
+        overrides = dict(_MID_AXIS_VALUES)
+        overrides.update(spec.axis_values or {})  # a spec's own splitting-knob override wins
+        if "dtype" in spec.axes and spec.valid_dtypes:
+            overrides["dtype"] = spec.valid_dtypes
+        configs = build_configs(spec.axes, overrides)
+        if spec.config_filter is not None:
+            configs = [c for c in configs if spec.config_filter(c)]
+        return configs
+    full = spec.max_config_space()  # light
+    buckets = {}
+    for config in full:
+        key = tuple(getattr(config, axis) for axis in spec.bit_relevant_axes)
+        buckets.setdefault(key, []).append(config)
+    out = []
+    for group in buckets.values():
+        out.extend(group[:_LIGHT_PER_BUCKET])
+    return out
+
+
+def _materialize(specs, dtypes_selector):
+    """Expand each base spec into one named spec per selected dtype (``<name>_<dtype>``).
+
+    A GEMM's ``dtype`` config axis is pinned to the one dtype (so ``gemm_f16`` runs only
+    f16 configs); a single-dtype kernel just gets the suffix on its name. ``dtypes_selector``
+    is ``all`` or a comma list; a spec with no selected dtype among its ``valid_dtypes`` is
+    dropped (e.g. ``--dtypes bf16`` drops the f32-only reductions)."""
+    selected = None if dtypes_selector == "all" else {d.strip() for d in dtypes_selector.split(",") if d.strip()}
+    out = []
+    for spec in specs:
+        for dt in (spec.valid_dtypes or ("f32", )):
+            if selected is not None and dt not in selected:
+                continue
+            out.append(dataclasses.replace(spec, name=f"{spec.name}_{dt}", valid_dtypes=(dt, )))
+    return out
+
+
 def _spanned_axes(configs):
     """Which knobs vary within a set (= the tuning freedom that set recovers)."""
     spans = {}
@@ -195,10 +256,14 @@ def _spanned_axes(configs):
     return spans
 
 
-def evaluate_precision(spec, run_checker, config_effort, fuzzer_effort, artifact="ptx"):
+# --------------------------------------------------------------------------- #
+# Stage: precision (soundness + partition quality)
+# --------------------------------------------------------------------------- #
+def evaluate_precision(spec, run_checker, effort, artifact="ptx"):
     """Compile + checker-partition + fuzz one kernel; return a result dict."""
-    size = spec.precision_size
-    configs = spec.config_space(config_effort)
+    size = _effort_size(spec, effort)
+    configs = _resolve_configs(spec, effort)
+    repeats = _EFFORT[effort]["repeats"]
     compiled, checker_key, fails = {}, {}, 0
     for config in configs:
         try:
@@ -206,14 +271,13 @@ def evaluate_precision(spec, run_checker, config_effort, fuzzer_effort, artifact
             spec.run(config, ck, 0, size)  # trial launch: a config can COMPILE yet OOM at LAUNCH
         except Exception:  # noqa: BLE001    (tcgen05 TMEM is rejected by the driver at launch, not
             fails += 1  # at compile), so skip compile OR launch failures instead of letting one bad
-            continue  # config abort the whole kernel's eval (Stage 4's compile loop already does this)
+            continue  # config abort the whole kernel's eval (the regpressure loop already does this)
         compiled[config] = ck
         checker_key[config] = run_checker(ck.asm[artifact], config)
     ok = list(compiled)
     if not ok:
         return dict(name=spec.name, attempted=len(configs), ok=0, fails=fails)
 
-    repeats = equivalence_fuzzer.effort_repeats(fuzzer_effort)
     empirical_key = equivalence_fuzzer.empirical_keys(
         lambda config, seed: spec.run(config, compiled[config], seed, size), ok, repeats)
 
@@ -221,20 +285,24 @@ def evaluate_precision(spec, run_checker, config_effort, fuzzer_effort, artifact
     empirical_sets = equivalence_fuzzer.partition(ok, empirical_key)
     holds, straddle = equivalence_fuzzer.refines(ok, checker_key, empirical_key)
     largest = max(checker_sets, key=len)
-    return dict(name=spec.name, attempted=len(configs), ok=len(ok), fails=fails, checker_n=len(checker_sets),
-                checker_max=equivalence_fuzzer.max_class_size(checker_sets), empirical_n=len(empirical_sets),
-                empirical_max=equivalence_fuzzer.max_class_size(empirical_sets),
-                over_merges=equivalence_fuzzer.over_merges(ok, checker_key, empirical_key), refines=holds,
-                straddle=straddle, largest_set=sorted(largest, key=config_label), largest_spans=_spanned_axes(largest))
+    return dict(
+        name=spec.name, attempted=len(configs), ok=len(ok), fails=fails, checker_n=len(checker_sets),
+        checker_max=equivalence_fuzzer.max_class_size(checker_sets), empirical_n=len(empirical_sets),
+        empirical_max=equivalence_fuzzer.max_class_size(empirical_sets),
+        over_merges=equivalence_fuzzer.over_merges(ok, checker_key, empirical_key),
+        # over-splits = the mirror of over-merges: pairs the fuzzer MERGED but the checker split
+        # (recovery the checker left on the table). Safe direction, so it is a quality number, not a gate.
+        over_splits=equivalence_fuzzer.over_merges(ok, empirical_key, checker_key), refines=holds, straddle=straddle,
+        largest_set=sorted(largest, key=config_label), largest_spans=_spanned_axes(largest))
 
 
 # --------------------------------------------------------------------------- #
-# Stage 3 — performance
+# Stage: performance
 # --------------------------------------------------------------------------- #
-def evaluate_performance(spec, run_checker, artifact="ptx", config_effort="light"):
+def evaluate_performance(spec, run_checker, effort, artifact="ptx"):
     """Benchmark a kernel across its config space; compare within-set spread to the global ceiling."""
-    size = spec.perf_size
-    configs = spec.config_space(config_effort)
+    size = _effort_size(spec, effort, perf=True)
+    configs = _resolve_configs(spec, effort)
     ms, bits, checker_key, fails = {}, {}, {}, 0
     for config in configs:
         try:
@@ -266,27 +334,28 @@ def evaluate_performance(spec, run_checker, artifact="ptx", config_effort="light
 
 
 # --------------------------------------------------------------------------- #
-# Stage 4 — equivalence under register pressure (post-ptxas / the PTX->SASS gap)
+# Stage: regpressure (post-ptxas / the PTX->SASS gap) — always runs at mid
 # --------------------------------------------------------------------------- #
-def evaluate_ptxas_robustness(spec, run_checker, config_effort, fuzzer_effort, artifact, maxnreg_sweep):
+def evaluate_regpressure(spec, run_checker, artifact, maxnreg_sweep):
     """Does the checker's equivalence verdict survive ptxas across a WHOLE diverse set?
 
-    Take the full ``config_effort`` config space (diverse num_warps / num_stages /
-    enable_fp_fusion / block_n) and ALSO cap ``maxnreg`` low enough to make ptxas spill. A
-    ``.maxnreg`` directive leaves the PTX reduction body identical, so it does not change the
-    checker descriptor -- the diverse configs and the register regimes fall into the SAME
-    checker-equivalence classes. We then fuzz every ``(config, maxnreg)`` member and check each
-    checker class is still a single bit-class. So this stresses the cross-config equivalence
-    claim AND the PTX->SASS gap (register spilling) at once: one checker class == one bit-class
-    (over-merges 0) means equivalence holds across diverse configs even under spilling.
+    Take the full mid config space (diverse num_warps / num_stages / enable_fp_fusion /
+    block_n) and ALSO cap ``maxnreg`` low enough to make ptxas spill. A ``.maxnreg``
+    directive leaves the PTX reduction body identical, so it does not change the checker
+    descriptor -- the diverse configs and the register regimes fall into the SAME checker
+    classes. We then fuzz every ``(config, maxnreg)`` member and check each checker class is
+    still a single bit-class. So this stresses the cross-config equivalence claim AND the
+    PTX->SASS gap (register spilling) at once: one checker class == one bit-class (over-merges
+    0) means equivalence holds across diverse configs even under spilling.
 
-    Uses ``precision_size`` (a sizable 8K-16K-column tensor): the larger ``perf_size`` overflows
-    shared memory / trips ptxas at heavy config scale, and register pressure here is driven by the
-    config diversity (num_stages / block_n) plus the ``maxnreg`` cap, not by tensor size.
+    Uses the mid precision-style size: the larger perf size overflows shared memory / trips
+    ptxas at full config scale, and register pressure here is driven by config diversity
+    (num_stages / block_n) plus the ``maxnreg`` cap, not by tensor size.
     """
-    size = spec.precision_size
+    size = _effort_size(spec, _MID)
+    repeats = _EFFORT[_MID]["repeats"]
     caps = [None] + list(maxnreg_sweep)
-    base = spec.config_space(config_effort)
+    base = _resolve_configs(spec, _MID)
     compiled, checker_key, nregs, nspills, items, fails = {}, {}, {}, {}, [], 0
     for cfg in base:
         for cap in caps:
@@ -305,7 +374,6 @@ def evaluate_ptxas_robustness(spec, run_checker, config_effort, fuzzer_effort, a
     if not items:
         return dict(name=spec.name, ok=0, attempted=attempted, fails=fails)
 
-    repeats = equivalence_fuzzer.effort_repeats(fuzzer_effort)
     empirical_key = equivalence_fuzzer.empirical_keys(lambda key, seed: spec.run(key[0], compiled[key], seed, size),
                                                       items, repeats)
     checker_sets = equivalence_fuzzer.partition(items, checker_key)
@@ -338,6 +406,109 @@ def evaluate_ptxas_robustness(spec, run_checker, config_effort, fuzzer_effort, a
 
 
 # --------------------------------------------------------------------------- #
+# Stage: korder — K-reduction-order experiment (placeholder; filled by the korder step)
+# --------------------------------------------------------------------------- #
+def _mma_version(ck):
+    """Which tensor-core path the compiled GEMM took, read from its asm."""
+    ptx = ck.asm.get("ptx", "") or ""
+    ttgir = ck.asm.get("ttgir", "") or ""
+    if "tcgen05.mma" in ptx:
+        return "v5(tcgen05.mma)"
+    if "mma.sync" in ptx:
+        return "v2(mma.sync)"
+    if "wgmma" in ptx:
+        return "wgmma(Hopper)"
+    if "fma.rn.f32" in ptx:
+        return "FMA(no tensor core)"
+    if "tcgen05" in ttgir or "tmem" in ttgir:
+        return "v5(ttgir)"
+    return "?"
+
+
+def _pair_on(spec, axis, va, vb):
+    """Two configs from the spec's space that differ ONLY in ``axis`` (values ``va`` vs ``vb``),
+    matched on every other axis. Returns (None, None) if no matched pair exists."""
+    other = [a for a in spec.axes if a != axis]
+    groups = {}
+    for c in spec.max_config_space():
+        key = tuple(getattr(c, a) for a in other)
+        slot = groups.setdefault(key, {})
+        val = getattr(c, axis)
+        if val == va:
+            slot.setdefault("a", c)
+        elif val == vb:
+            slot.setdefault("b", c)
+    for slot in groups.values():
+        if "a" in slot and "b" in slot:
+            return slot["a"], slot["b"]
+    return None, None
+
+
+def _bit_verdict(bytes_a, bytes_b):
+    return "BIT-IDENTICAL" if bytes_a == bytes_b else "DIFFER"
+
+
+def evaluate_korder(specs, checker, artifact):
+    """GEMM K-reduction-order experiment (always mid size). Two questions, decided by BITS
+    (empirical, not the checker):
+
+      * v5 vs v2 tensor core — for each ``gemm_<dtype>``, compile the same config at
+        ``gemm_block_m=32`` (lowers to MMAv2 ``mma.sync``) and at ``64`` (MMAv5 ``tcgen05``)
+        and compare output bits. Expectation from the GB300 study: f16/bf16/f32 are
+        BIT-IDENTICAL across v5/v2, fp8 DIFFERs (so a checker may merge v5/v2 for the
+        former, must not for fp8).
+      * K-split order — for ``gemm_kgroup`` / ``gemm_splitk``, compile the same config at
+        ``gemm_num_splits`` 1 vs 2 and compare bits. Splitting the K reduction changes the
+        summation order, so this is EXPECTED to DIFFER (num_splits is bit-relevant)."""
+    size = _EFFORT[_MID]["gemm_size"]
+    v5v2, ksplit, notes = [], [], []
+    for spec in specs:
+        if _size_family(spec) != "gemm":
+            continue
+        base = spec.name.rsplit("_", 1)[0]  # strip the _<dtype> suffix
+        if base == "gemm":
+            c2, c5 = _pair_on(spec, "gemm_block_m", 32, 64)
+            if not (c2 and c5):
+                v5v2.append(dict(kernel=spec.name, note="no matched block_m 32-vs-64 pair"))
+                continue
+            try:
+                ck2 = spec.compile(c2, size)
+                b2 = spec.run(c2, ck2, 0, size)
+                ck5 = spec.compile(c5, size)
+                b5 = spec.run(c5, ck5, 0, size)
+            except Exception as exc:  # noqa: BLE001
+                v5v2.append(dict(kernel=spec.name, note=f"compile/run failed: {type(exc).__name__}"))
+                continue
+            v5v2.append(dict(kernel=spec.name, v2=_mma_version(ck2), v5=_mma_version(ck5),
+                             verdict=_bit_verdict(b2, b5)))
+        elif base in ("gemm_kgroup", "gemm_splitk"):
+            c1, cN = _pair_on(spec, "gemm_num_splits", 1, 2)
+            if not (c1 and cN):
+                ksplit.append(dict(kernel=spec.name, note="no matched num_splits 1-vs-2 pair"))
+                continue
+            try:
+                ck1 = spec.compile(c1, size)
+                b1 = spec.run(c1, ck1, 0, size)
+                ckN = spec.compile(cN, size)
+                bN = spec.run(cN, ckN, 0, size)
+            except Exception as exc:  # noqa: BLE001
+                ksplit.append(dict(kernel=spec.name, note=f"compile/run failed: {type(exc).__name__}"))
+                continue
+            ksplit.append(dict(kernel=spec.name, splits="1 vs 2", verdict=_bit_verdict(b1, bN)))
+    notes.append("2-CTA: num_ctas is bit-free on a bare matmul (a real cta_group::2 needs the TLX "
+                 "cluster path, not modeled here) — placeholder.")
+    return dict(v5v2=v5v2, ksplit=ksplit, notes=notes)
+
+
+# --------------------------------------------------------------------------- #
+# Stage: cublas — bit-for-bit match against a cuBLAS reference (placeholder)
+# --------------------------------------------------------------------------- #
+def evaluate_cublas(specs, checker, artifact):
+    """Compare Triton GEMM output bits against a cuBLAS reference. Not yet wired up."""
+    return dict(note="cublas stage not yet implemented (non-split-K GEMM ≡ cuBLAS is the free-tiling class)")
+
+
+# --------------------------------------------------------------------------- #
 # Report rendering
 # --------------------------------------------------------------------------- #
 def _table(headers, rows):
@@ -347,16 +518,8 @@ def _table(headers, rows):
     return [fmt(headers), fmt(["-" * w for w in widths])] + [fmt(r) for r in rows[:]]
 
 
-def render_stage1(results):
-    lines = ["STAGE 1 — kernel support", "-" * 24, ""]
-    rows = [[r["name"], r["verdict"], r["detail"]] for r in results]
-    lines += _table(["kernel", "verdict", "detail"], rows)
-    lines.append("")
-    return lines
-
-
-def render_stage2(results):
-    lines = ["STAGE 2 — checker precision (soundness + partition)", "-" * 51, ""]
+def render_precision(results):
+    lines = ["STAGE precision — checker soundness + partition", "-" * 47, ""]
     rows = []
     for r in results:
         if not r.get("ok"):
@@ -368,12 +531,15 @@ def render_stage2(results):
             f"{r['checker_n']} (max {r['checker_max']})",
             f"{r['empirical_n']} (max {r['empirical_max']})",
             str(r["over_merges"]),
+            str(r["over_splits"]),
             "yes" if r["refines"] else "NO",
         ])
-    lines += _table(["kernel", "configs", "checker sets", "empirical sets (ceiling)", "over-merges", "refines"],
-                    [[row[0], row[1], row[2], row[3], row[4], row[5]] for row in rows])
+    lines += _table(
+        ["kernel", "configs", "checker sets", "empirical sets (ceiling)", "over-merges", "over-splits", "refines"],
+        rows)
     lines.append("")
     lines.append("over-merges = configs the checker merged but the fuzzer separated (MUST be 0 = sound).")
+    lines.append("over-splits = bit-equal configs the checker separated (recovery left on the table; safe, not a bug).")
     lines.append("empirical-sets max = the recovery ceiling (the largest bit-equivalent set that exists).")
     lines.append("")
     lines.append("Largest checker-equivalent set per kernel (the recovered tuning freedom):")
@@ -391,8 +557,8 @@ def render_stage2(results):
     return lines
 
 
-def render_stage3(results):
-    lines = ["STAGE 3 — performance vs ceiling (optional)", "-" * 43, ""]
+def render_performance(results):
+    lines = ["STAGE performance — speed vs the bit-exact ceiling", "-" * 50, ""]
     for r in results:
         if not r.get("ok"):
             lines.append(f"{r['name']}: no configs benchmarked (failed {r.get('fails', 0)}).")
@@ -415,12 +581,12 @@ def render_stage3(results):
     return lines
 
 
-def render_stage4(results):
-    lines = ["STAGE 4 — equivalence under register pressure (post-ptxas / the PTX->SASS gap)", "-" * 78, ""]
+def render_regpressure(results):
+    lines = ["STAGE regpressure — equivalence under register pressure (post-ptxas / the PTX->SASS gap)", "-" * 87, ""]
     lines.append("Fuzz each WHOLE checker-equivalence set (DIVERSE configs) while also capping maxnreg to make")
     lines.append("ptxas spill. maxnreg only adds a .maxnreg directive (same PTX body => same checker classes) but")
     lines.append("changes ptxas allocation. One checker class == one bit-class (over-merges 0) => equivalence holds")
-    lines.append("across diverse configs AND register spilling.")
+    lines.append("across diverse configs AND register spilling. Always run at mid effort.")
     lines.append("")
     total_om = 0
     for r in results:
@@ -454,6 +620,31 @@ def render_stage4(results):
     return lines
 
 
+def render_korder(result):
+    lines = ["STAGE korder — GEMM K-reduction-order (v5/v2 tensor core, K-split order)", "-" * 70, ""]
+    lines.append("Decided by output BITS (empirical), not the checker. mid size. v5/v2: same config at")
+    lines.append("gemm_block_m=32 (MMAv2 mma.sync) vs 64 (MMAv5 tcgen05). K-split: same config, num_splits 1 vs 2.")
+    lines.append("")
+    lines.append("v5 vs v2 tensor core (expect f16/bf16/f32 BIT-IDENTICAL, fp8 DIFFER):")
+    rows = [[r["kernel"], r.get("v5", "-"), r.get("v2", "-"), r.get("verdict", r.get("note", "-"))]
+            for r in result["v5v2"]] or [["(no GEMM specs selected)", "-", "-", "-"]]
+    lines += _table(["kernel", "v5 path", "v2 path", "bit-compare"], rows)
+    lines.append("")
+    lines.append("K-split order (expect DIFFER — splitting K changes the summation order):")
+    rows = [[r["kernel"], r.get("splits", "-"), r.get("verdict", r.get("note", "-"))]
+            for r in result["ksplit"]] or [["(no split-K specs selected)", "-", "-"]]
+    lines += _table(["kernel", "num_splits", "bit-compare"], rows)
+    lines.append("")
+    for note in result["notes"]:
+        lines.append(f"  {note}")
+    lines.append("")
+    return lines
+
+
+def render_note(title, result):
+    return [title, "-" * len(title), "", f"  {result['note']}", ""]
+
+
 def write_report(path, header, sections):
     lines = list(header)
     for section in sections:
@@ -467,10 +658,16 @@ def write_report(path, header, sections):
 # --------------------------------------------------------------------------- #
 def parse_args(argv):
     p = argparse.ArgumentParser(description="bitequiv evaluation framework (see module docstring).")
-    p.add_argument("--kernels", default="all", help="'all' or comma list: " + ",".join(eval_kernels.REGISTRY))
-    p.add_argument("--stages", default="1,2", help="comma list of stages to run (Stage 3 perf is opt-in)")
-    p.add_argument("--config-effort", default="light", choices=("light", "heavy"))
-    p.add_argument("--fuzzer-effort", default="fast", choices=("fast", "convincing"))
+    p.add_argument("--kernels", default="",
+                   help="'all', a comma list of base kernel names, or empty to use the effort default "
+                   "(light = a few priority kernels; mid/heavy = all). Base names: " + ",".join(eval_kernels.REGISTRY))
+    p.add_argument("--dtypes", default="all",
+                   help="'all' or comma list (f16,bf16,f32,fp8); each base kernel is materialized into one "
+                   "named spec per selected dtype (<kernel>_<dtype>)")
+    p.add_argument("--stages", default="precision", help="comma list of stages to run: " + ",".join(_STAGES))
+    p.add_argument("--effort", default="mid", choices=("light", "mid", "heavy"),
+                   help="config-subset x fuzz-seeds x input-size for precision/performance "
+                   "(other stages always run at mid)")
     p.add_argument("--checker", default=_DEFAULT_CHECKER, help="module:function descriptor (default: repo checker)")
     p.add_argument("--artifact", default="ptx", choices=("ptx", "ttgir"),
                    help="which compiled IR artifact to feed the checker (default: ptx)")
@@ -480,11 +677,22 @@ def parse_args(argv):
         "expectedly not sound (e.g. the TTGIR checker, blind to FMA contraction)")
     p.add_argument(
         "--maxnreg-sweep", default="16",
-        help="Stage 4: comma list of maxnreg caps (added on top of the diverse config space to "
+        help="regpressure: comma list of maxnreg caps (added on top of the diverse config space to "
         "force ptxas spilling; a None/uncapped baseline is always included). Each cap multiplies "
-        "the member count, so keep it small at heavy config effort")
+        "the member count, so keep it small")
     p.add_argument("--out", default=_DEFAULT_OUT, help="result table path")
     return p.parse_args(argv)
+
+
+def _select_specs(kernels_arg, effort, dtypes_arg):
+    """Resolve --kernels (effort-default when empty) into base specs, then materialize per dtype."""
+    if kernels_arg:
+        selector = kernels_arg
+    elif _EFFORT[effort]["default_kernels"]:
+        selector = ",".join(_EFFORT[effort]["default_kernels"])
+    else:
+        selector = "all"
+    return _materialize(resolve_kernels(selector), dtypes_arg)
 
 
 def main(argv=None):
@@ -493,24 +701,29 @@ def main(argv=None):
         print("no CUDA GPU available; the framework needs one to compile and run kernels. Skipping.")
         return 0
 
-    stages = {int(s) for s in args.stages.split(",") if s.strip()}
-    specs = resolve_kernels(args.kernels)
+    stages = [s.strip() for s in args.stages.split(",") if s.strip()]
+    bad = [s for s in stages if s not in _STAGES]
+    if bad:
+        print(f"unknown stage(s) {bad}; valid: {', '.join(_STAGES)}")
+        return 2
+    specs = _select_specs(args.kernels, args.effort, args.dtypes)
     checker = load_checker(args.checker)
     run_checker = make_run_checker(checker)
-    repeats = equivalence_fuzzer.effort_repeats(args.fuzzer_effort)
     device = torch.cuda.get_device_name()
 
     header = [
         "bitequiv evaluation result",
         "==========================",
-        f"generated:      {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
-        f"checker:        {args.checker}",
-        f"artifact:       {args.artifact}",
-        f"device:         {device}",
-        f"config effort:  {args.config_effort}",
-        f"fuzzer effort:  {args.fuzzer_effort} ({repeats} seeds/config)",
-        f"kernels:        {', '.join(s.name for s in specs)}",
-        f"stages:         {','.join(str(s) for s in sorted(stages))}",
+        f"generated:   {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+        f"checker:     {args.checker}",
+        f"artifact:    {args.artifact}",
+        f"device:      {device}",
+        f"effort:      {args.effort}  (precision/performance; other stages run at mid; "
+        f"{_EFFORT[args.effort]['repeats']} fuzz seeds; config = "
+        f"{ {'light': 'per-bucket subsample', 'mid': 'old-heavy curated', 'heavy': 'full max grid'}[args.effort] })",
+        f"dtypes:      {args.dtypes}",
+        f"kernels:     {', '.join(s.name for s in specs)}",
+        f"stages:      {', '.join(stages)}",
         "",
     ]
     print("\n".join(header))
@@ -519,22 +732,13 @@ def main(argv=None):
     total_over_merges = 0
     any_unsound = False
 
-    if 1 in stages:
-        print("== Stage 1: support ==", flush=True)
+    if "precision" in stages:
+        print("== precision ==", flush=True)
         results = []
         for spec in specs:
-            verdict, detail = kernel_support(spec, run_checker, args.artifact)
-            results.append(dict(name=spec.name, verdict=verdict, detail=detail))
-            print(f"  {spec.name}: {verdict} — {detail}", flush=True)
-        sections.append(render_stage1(results))
-
-    if 2 in stages:
-        print("== Stage 2: precision ==", flush=True)
-        results = []
-        for spec in specs:
-            n_configs = len(spec.config_space(args.config_effort))
-            print(f"  {spec.name}: {n_configs} configs x {repeats} fuzz seeds ...", flush=True)
-            r = evaluate_precision(spec, run_checker, args.config_effort, args.fuzzer_effort, args.artifact)
+            n_configs = len(_resolve_configs(spec, args.effort))
+            print(f"  {spec.name}: {n_configs} configs x {_EFFORT[args.effort]['repeats']} fuzz seeds ...", flush=True)
+            r = evaluate_precision(spec, run_checker, args.effort, args.artifact)
             results.append(r)
             if r.get("ok"):
                 total_over_merges += r["over_merges"]
@@ -542,34 +746,34 @@ def main(argv=None):
                 print(
                     f"    -> {r['ok']}/{r['attempted']} ok | checker max set {r['checker_max']} "
                     f"| empirical ceiling {r['empirical_max']} | over-merges {r['over_merges']} "
-                    f"| refines {r['refines']}", flush=True)
+                    f"| over-splits {r['over_splits']} | refines {r['refines']}", flush=True)
             else:
                 print(f"    -> 0/{r['attempted']} compiled (build drift?)", flush=True)
-        sections.append(render_stage2(results))
+            write_report(args.out, header, [render_precision(results)])  # checkpoint per kernel (survive a reap)
+        sections.append(render_precision(results))
 
-    if 3 in stages:
-        print("== Stage 3: performance ==", flush=True)
+    if "performance" in stages:
+        print("== performance ==", flush=True)
         results = []
         for spec in specs:
             if not spec.supports_perf:
                 print(f"  {spec.name}: no perf hook; skipping.", flush=True)
                 continue
-            print(f"  {spec.name}: benchmarking {len(spec.config_space(args.config_effort))} configs ...", flush=True)
-            results.append(evaluate_performance(spec, run_checker, args.artifact, args.config_effort))
+            print(f"  {spec.name}: benchmarking {len(_resolve_configs(spec, args.effort))} configs ...", flush=True)
+            results.append(evaluate_performance(spec, run_checker, args.effort, args.artifact))
         if results:
-            sections.append(render_stage3(results))
+            sections.append(render_performance(results))
 
-    if 4 in stages:
-        print("== Stage 4: equivalence under register pressure (post-ptxas) ==", flush=True)
+    if "regpressure" in stages:
+        print("== regpressure (post-ptxas; mid effort) ==", flush=True)
         maxnreg_sweep = [int(x) for x in args.maxnreg_sweep.split(",") if x.strip()]
         results = []
         for spec in specs:
-            members = len(spec.config_space(args.config_effort)) * (1 + len(maxnreg_sweep))
+            members = len(_resolve_configs(spec, _MID)) * (1 + len(maxnreg_sweep))
             print(
                 f"  {spec.name}: ~{members} (config x maxnreg{['none'] + maxnreg_sweep}) members "
-                f"x {repeats} fuzz seeds ...", flush=True)
-            r = evaluate_ptxas_robustness(spec, run_checker, args.config_effort, args.fuzzer_effort, args.artifact,
-                                          maxnreg_sweep)
+                f"x {_EFFORT[_MID]['repeats']} fuzz seeds ...", flush=True)
+            r = evaluate_regpressure(spec, run_checker, args.artifact, maxnreg_sweep)
             results.append(r)
             if r.get("ok"):
                 print(
@@ -577,11 +781,26 @@ def main(argv=None):
                     f"{r['checker_n']} (max {r['checker_max']}) | over-merges {r['over_merges']}", flush=True)
             else:
                 print(f"    -> 0/{r.get('attempted')} compiled (fails: {r.get('fails')})", flush=True)
-        sections.append(render_stage4(results))
+        sections.append(render_regpressure(results))
+
+    if "korder" in stages:
+        print("== korder (mid effort) ==", flush=True)
+        r = evaluate_korder(specs, checker, args.artifact)
+        for row in r["v5v2"]:
+            print(f"  v5/v2 {row['kernel']}: {row.get('verdict', row.get('note'))}", flush=True)
+        for row in r["ksplit"]:
+            print(f"  K-split {row['kernel']}: {row.get('verdict', row.get('note'))}", flush=True)
+        sections.append(render_korder(r))
+
+    if "cublas" in stages:
+        print("== cublas (mid effort) ==", flush=True)
+        r = evaluate_cublas(specs, checker, args.artifact)
+        print(f"  {r['note']}", flush=True)
+        sections.append(render_note("STAGE cublas — bit-for-bit vs a cuBLAS reference", r))
 
     write_report(args.out, header, sections)
     print(f"\nWROTE {args.out}")
-    if 2 in stages:
+    if "precision" in stages:
         gate = "0; --allow-unsound" if args.allow_unsound else "must be 0"
         print(f"SOUNDNESS: total over-merges ({gate}) = {total_over_merges}")
         if any_unsound or total_over_merges:

--- a/bitequiv/evaluation/realistic_inductor_kernels.py
+++ b/bitequiv/evaluation/realistic_inductor_kernels.py
@@ -2076,6 +2076,405 @@ def RED_any_isinf(
     tl.store(out_ptr0 + (tl.full([XBLOCK, 1], 0, tl.int32)), tmp3, None)
 
 
+# #########################################################################################
+# ## GROUP 9 - LOOP-CARRIED REDUCTION DISCRIMINATORS (drove the D113598054 loop-chunk fix).
+# ## Real torch-Inductor looped reductions harvested VERBATIM from
+# ## ~/bitwise-equiv/inductor_loopcarried_kernels/ (each kernel there ships a SPEC + shared
+# ## _harness.py; see that dir's EVAL.md for the full separation table). UNLIKE GROUPS 1-8 (a
+# ## scope/gap-analysis corpus of mostly bit-STABLE kernels), every kernel here spans GENUINE
+# ## bitwise inequivalence: the accumulation is a loop-carried fold (acc = acc (+|*|max) chunk),
+# ## so the reduction CHUNK SIZE (R0_BLOCK; k_split for split-K) is a bit-RELEVANT knob -
+# ## different chunkings regroup the FP fold and produce DIFFERENT output bits. These are the
+# ## discriminators that DROVE the D113598054 loop-chunk soundness fix (the leaf-less / |loops=
+# ## fence over-merge): prod_loop_f32 + splitsum_2kernel_f32 were the two configs the pre-fix
+# ## checker WRONGLY merged (see EVAL.md "SOUNDNESS FINDING"); the fix makes over-merges 0.
+# ## Faithfulness: @triton.jit bodies copied verbatim (only the @triton_heuristics decorator +
+# ## standalone _harness scaffolding stripped, Inductor names given an LC_ group prefix). This is
+# ## step 1 = bring the kernels in; they are NOT wired into evaluate.py (format-unification is a
+# ## later step), matching how GROUPS 2+ stay a reference corpus.
+# #########################################################################################
+
+# ========================================================================================= #
+# LC-1. Long-axis sum, looped ADD-fold (fp32)  (source: sum_loop_f32.py / triton_red_fused_sum_0)
+# -----------------------------------------------------------------------------------------
+# What it computes: x.sum(-1) over (64, 16384) fp32 as a loop-carried add-fold (acc += chunk) then
+# a final tl.sum. Inductor: triton_red_fused_sum_0 (looped reduction, R0_BLOCK-wide chunks).
+# Bit-difference axis: R0_BLOCK (the chunk grouping) -> 22 empirical bit-classes over 36 configs.
+# Checker: SUPPORTED (reconstructed reduction tree); over-merges 0 AFTER the D113598054 fence fix.
+# ========================================================================================= #
+@triton.jit
+def LC_sum_loop_f32(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK : tl.constexpr, R0_BLOCK : tl.constexpr):
+    xnumel = 64
+    r0_numel = 16384
+    rnumel = r0_numel
+    RBLOCK: tl.constexpr = R0_BLOCK
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+    xmask = xindex < xnumel
+    r0_base = tl.arange(0, R0_BLOCK)[None, :]
+    rbase = r0_base
+    x0 = xindex
+    _tmp2 = tl.full([XBLOCK, R0_BLOCK], 0, tl.float32)
+    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
+        r0_index = r0_offset + r0_base
+        r0_mask = r0_index < r0_numel
+        roffset = r0_offset
+        rindex = r0_index
+        r0_1 = r0_index
+        tmp0 = tl.load(in_ptr0 + (r0_1 + 16384*x0), r0_mask & xmask, eviction_policy='evict_first', other=0.0)
+        tmp1 = tl.broadcast_to(tmp0, [XBLOCK, R0_BLOCK])
+        tmp3 = _tmp2 + tmp1
+        _tmp2 = tl.where(r0_mask & xmask, tmp3, _tmp2)
+    tmp2 = tl.sum(_tmp2, 1)[:, None]
+    tl.store(out_ptr0 + (x0), tmp2, xmask)
+
+
+# ========================================================================================= #
+# LC-2. Long-axis sum, looped ADD-fold (fp16)  (source: sum_loop_f16.py / triton_red_fused_sum_0)
+# -----------------------------------------------------------------------------------------
+# What it computes: x.sum(-1) over (64, 16384) fp16 (loaded to fp32 for the fold). Same body as
+# LC-1 with a .to(tl.float32) on the load; the fp16 vs fp32 difference lives in the input/output
+# dtype the (stripped) harness sets, so the @triton.jit body is verbatim-identical to LC-3.
+# Bit-difference axis: R0_BLOCK + num_warps -> 17 bit-classes over 36 configs (fp16 store rounds
+# away some low bits, so fewer classes than fp32). Checker: SUPPORTED; over-merges 0.
+# ========================================================================================= #
+@triton.jit
+def LC_sum_loop_f16(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK : tl.constexpr, R0_BLOCK : tl.constexpr):
+    xnumel = 64
+    r0_numel = 16384
+    rnumel = r0_numel
+    RBLOCK: tl.constexpr = R0_BLOCK
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+    xmask = xindex < xnumel
+    r0_base = tl.arange(0, R0_BLOCK)[None, :]
+    rbase = r0_base
+    x0 = xindex
+    _tmp2 = tl.full([XBLOCK, R0_BLOCK], 0, tl.float32)
+    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
+        r0_index = r0_offset + r0_base
+        r0_mask = r0_index < r0_numel
+        roffset = r0_offset
+        rindex = r0_index
+        r0_1 = r0_index
+        tmp0 = tl.load(in_ptr0 + (r0_1 + 16384*x0), r0_mask & xmask, eviction_policy='evict_first', other=0.0).to(tl.float32)
+        tmp1 = tl.broadcast_to(tmp0, [XBLOCK, R0_BLOCK])
+        tmp3 = _tmp2 + tmp1
+        _tmp2 = tl.where(r0_mask & xmask, tmp3, _tmp2)
+    tmp2 = tl.sum(_tmp2, 1)[:, None]
+    tl.store(out_ptr0 + (x0), tmp2, xmask)
+
+
+# ========================================================================================= #
+# LC-3. Long-axis sum, looped ADD-fold (bf16)  (source: sum_loop_bf16.py / triton_red_fused_sum_0)
+# -----------------------------------------------------------------------------------------
+# What it computes: x.sum(-1) over (64, 16384) bf16 (loaded to fp32 for the fold). Body is
+# verbatim-identical to LC-2 (bf16 vs fp16 is only the harness dtype). Bit-difference axis:
+# R0_BLOCK + num_warps -> 4 bit-classes over 36 configs (bf16 store rounds away the most low bits,
+# so the fewest empirical classes of the three sums). Checker: SUPPORTED; over-merges 0.
+# ========================================================================================= #
+@triton.jit
+def LC_sum_loop_bf16(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK : tl.constexpr, R0_BLOCK : tl.constexpr):
+    xnumel = 64
+    r0_numel = 16384
+    rnumel = r0_numel
+    RBLOCK: tl.constexpr = R0_BLOCK
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+    xmask = xindex < xnumel
+    r0_base = tl.arange(0, R0_BLOCK)[None, :]
+    rbase = r0_base
+    x0 = xindex
+    _tmp2 = tl.full([XBLOCK, R0_BLOCK], 0, tl.float32)
+    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
+        r0_index = r0_offset + r0_base
+        r0_mask = r0_index < r0_numel
+        roffset = r0_offset
+        rindex = r0_index
+        r0_1 = r0_index
+        tmp0 = tl.load(in_ptr0 + (r0_1 + 16384*x0), r0_mask & xmask, eviction_policy='evict_first', other=0.0).to(tl.float32)
+        tmp1 = tl.broadcast_to(tmp0, [XBLOCK, R0_BLOCK])
+        tmp3 = _tmp2 + tmp1
+        _tmp2 = tl.where(r0_mask & xmask, tmp3, _tmp2)
+    tmp2 = tl.sum(_tmp2, 1)[:, None]
+    tl.store(out_ptr0 + (x0), tmp2, xmask)
+
+
+# ========================================================================================= #
+# LC-4. Long-axis product, looped MUL-fold (fp32)  (source: prod_loop_f32.py / triton_red_fused_prod_0)
+# -----------------------------------------------------------------------------------------
+# What it computes: x.prod(-1) over (64, 8192) fp32 (values near 1.0) as a loop-carried mul-fold
+# (acc *= chunk) then triton_helpers.prod. Bit-difference axis: R0_BLOCK -> 18 bit-classes over 36.
+# *** DRIVER of the D113598054 fix: this MUL-fold was 1 of the 2 pre-fix OVER-MERGES *** (r0_block
+# 512 vs 1024 hashed to the SAME descriptor with no |loops= fence, yet the output bytes differ).
+# Checker: SUPPORTED (mul-fold not add-collapsed); over-merges 1 -> 0 AFTER the fence fix.
+# ========================================================================================= #
+@triton.jit
+def LC_prod_loop_f32(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK : tl.constexpr, R0_BLOCK : tl.constexpr):
+    xnumel = 64
+    r0_numel = 8192
+    rnumel = r0_numel
+    RBLOCK: tl.constexpr = R0_BLOCK
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+    xmask = xindex < xnumel
+    r0_base = tl.arange(0, R0_BLOCK)[None, :]
+    rbase = r0_base
+    x0 = xindex
+    _tmp2 = tl.full([XBLOCK, R0_BLOCK], 1, tl.float32)
+    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
+        r0_index = r0_offset + r0_base
+        r0_mask = r0_index < r0_numel
+        roffset = r0_offset
+        rindex = r0_index
+        r0_1 = r0_index
+        tmp0 = tl.load(in_ptr0 + (r0_1 + 8192*x0), r0_mask & xmask, eviction_policy='evict_first', other=0.0)
+        tmp1 = tl.broadcast_to(tmp0, [XBLOCK, R0_BLOCK])
+        tmp3 = _tmp2 * tmp1
+        _tmp2 = tl.where(r0_mask & xmask, tmp3, _tmp2)
+    tmp2 = triton_helpers.prod(_tmp2, 1)[:, None]
+    tl.store(out_ptr0 + (x0), tmp2, xmask)
+
+
+# ========================================================================================= #
+# LC-5. logsumexp: MAX-fold + SUM-of-exp fold (fp32)  (source: logsumexp_loop_f32.py / triton_red_fused_logsumexp_0)
+# -----------------------------------------------------------------------------------------
+# What it computes: x.logsumexp(-1) over (64, 16384) fp32 = a looped running-max fold, then a
+# looped running-sum-of-exp(x - max) fold, then log + add-back. Bit-difference axis: R0_BLOCK
+# (regroups BOTH folds) + num_warps -> 2 bit-classes over 36 configs. Checker: FAIL-CLOSED (falls
+# back to the sound fingerprint that pins ntid + shfl + loops, so it never merges); over-merges 0.
+# ========================================================================================= #
+@triton.jit
+def LC_logsumexp_loop_f32(in_out_ptr0, in_ptr0, xnumel, r0_numel, XBLOCK : tl.constexpr, R0_BLOCK : tl.constexpr):
+    xnumel = 64
+    r0_numel = 16384
+    rnumel = r0_numel
+    RBLOCK: tl.constexpr = R0_BLOCK
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+    xmask = xindex < xnumel
+    r0_base = tl.arange(0, R0_BLOCK)[None, :]
+    rbase = r0_base
+    x0 = xindex
+    _tmp2 = tl.full([XBLOCK, R0_BLOCK], float("-inf"), tl.float32)
+    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
+        r0_index = r0_offset + r0_base
+        r0_mask = r0_index < r0_numel
+        roffset = r0_offset
+        rindex = r0_index
+        r0_1 = r0_index
+        tmp0 = tl.load(in_ptr0 + (r0_1 + 16384*x0), r0_mask & xmask, eviction_policy='evict_last', other=0.0)
+        tmp1 = tl.broadcast_to(tmp0, [XBLOCK, R0_BLOCK])
+        tmp3 = triton_helpers.maximum(_tmp2, tmp1)
+        _tmp2 = tl.where(r0_mask & xmask, tmp3, _tmp2)
+    tmp2 = triton_helpers.max2(_tmp2, 1)[:, None]
+    _tmp13 = tl.full([XBLOCK, R0_BLOCK], 0, tl.float32)
+    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
+        r0_index = r0_offset + r0_base
+        r0_mask = r0_index < r0_numel
+        roffset = r0_offset
+        rindex = r0_index
+        r0_1 = r0_index
+        tmp4 = tl.load(in_ptr0 + (r0_1 + 16384*x0), r0_mask & xmask, eviction_policy='evict_first', other=0.0)
+        tmp5 = tl_math.abs(tmp2)
+        tmp6 = tl.full([1, 1], float("inf"), tl.float32)
+        tmp7 = tmp5 == tmp6
+        tmp8 = tl.full([1, 1], 0.0, tl.float32)
+        tmp9 = tl.where(tmp7, tmp8, tmp2)
+        tmp10 = tmp4 - tmp9
+        tmp11 = libdevice.exp(tmp10)
+        tmp12 = tl.broadcast_to(tmp11, [XBLOCK, R0_BLOCK])
+        tmp14 = _tmp13 + tmp12
+        _tmp13 = tl.where(r0_mask & xmask, tmp14, _tmp13)
+    tmp13 = tl.sum(_tmp13, 1)[:, None]
+    tmp15 = tl_math.log(tmp13)
+    tmp16 = tl_math.abs(tmp2)
+    tmp17 = tl.full([1, 1], float("inf"), tl.float32)
+    tmp18 = tmp16 == tmp17
+    tmp19 = tl.full([1, 1], 0.0, tl.float32)
+    tmp20 = tl.where(tmp18, tmp19, tmp2)
+    tmp21 = tmp15 + tmp20
+    tl.store(in_out_ptr0 + (x0), tmp21, xmask)
+
+
+# ========================================================================================= #
+# LC-6. Variance via WELFORD online fold (fp32)  (source: var_welford_f32.py / triton_red_fused_var_0)
+# -----------------------------------------------------------------------------------------
+# What it computes: x.var(-1) over (64, 16384) fp32 via triton_helpers.welford_reduce online
+# (mean, M2, weight) fold, then a cross-lane welford + divide. Bit-difference axis: R0_BLOCK
+# (regroups the welford fold) -> 18 bit-classes over 36 configs. Checker: FAIL-CLOSED (the welford
+# combine is FMA/contraction-bearing, so it falls back to the sound fingerprint); over-merges 0.
+# ========================================================================================= #
+@triton.jit
+def LC_var_welford_f32(in_out_ptr0, in_ptr0, xnumel, r0_numel, XBLOCK : tl.constexpr, R0_BLOCK : tl.constexpr):
+    xnumel = 64
+    r0_numel = 16384
+    rnumel = r0_numel
+    RBLOCK: tl.constexpr = R0_BLOCK
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+    xmask = xindex < xnumel
+    r0_base = tl.arange(0, R0_BLOCK)[None, :]
+    rbase = r0_base
+    x0 = xindex
+    tmp2_mean = tl.zeros([XBLOCK, R0_BLOCK], tl.float32)
+    tmp2_m2 = tl.zeros([XBLOCK, R0_BLOCK], tl.float32)
+    tmp2_weight = tl.zeros([XBLOCK, R0_BLOCK], tl.float32)
+    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
+        r0_index = r0_offset + r0_base
+        r0_mask = r0_index < r0_numel
+        roffset = r0_offset
+        rindex = r0_index
+        r0_1 = r0_index
+        tmp0 = tl.load(in_ptr0 + (r0_1 + 16384*x0), r0_mask & xmask, eviction_policy='evict_first', other=0.0)
+        tmp1 = tl.broadcast_to(tmp0, [XBLOCK, R0_BLOCK])
+        tmp2_mean_next, tmp2_m2_next, tmp2_weight_next = triton_helpers.welford_reduce(
+            tmp1, tmp2_mean, tmp2_m2, tmp2_weight, roffset == 0
+        )
+        tmp2_mean = tl.where(r0_mask & xmask, tmp2_mean_next, tmp2_mean)
+        tmp2_m2 = tl.where(r0_mask & xmask, tmp2_m2_next, tmp2_m2)
+        tmp2_weight = tl.where(r0_mask & xmask, tmp2_weight_next, tmp2_weight)
+    tmp3, tmp4, tmp5 = triton_helpers.welford(tmp2_mean, tmp2_m2, tmp2_weight, 1)
+    tmp2 = tmp3[:, None]
+    tmp6 = tmp4[:, None]
+    tmp7 = tmp5[:, None]
+    tmp8 = tl.full([1, 1], 16383.0, tl.float32)
+    tmp9 = (tmp6 / tmp8)
+    tl.store(in_out_ptr0 + (x0), tmp9, xmask)
+
+
+# ========================================================================================= #
+# LC-7. Cumulative sum via tl.associative_scan (fp32)  (source: cumsum_scan_f32.py / triton_red_fused_cumsum_0)
+# -----------------------------------------------------------------------------------------
+# What it computes: x.cumsum(-1) over (64, 16384) fp32 = a per-chunk associative_scan + a
+# loop-carried cross-chunk carry. Reuses the module-level _triton_helper_fn_add0 add-combine
+# (defined near the top for F_cumsum_scan / GROUP 5). Bit-difference axis: R0_BLOCK (regroups the
+# scan chunks + carry) -> 12 bit-classes over 36 configs. Checker: SUPPORTED (tt.scan is not
+# modeled, so it falls to the ntid + |loops= fence); the probe = does that fence separate every
+# chunking? over-merges 0 AFTER the fix.
+# ========================================================================================= #
+@triton.jit
+def LC_cumsum_scan_f32(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK : tl.constexpr, R0_BLOCK : tl.constexpr):
+    xnumel = 64
+    r0_numel = 16384
+    rnumel = r0_numel
+    RBLOCK: tl.constexpr = R0_BLOCK
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+    xmask = xindex < xnumel
+    r0_base = tl.arange(0, R0_BLOCK)[None, :]
+    rbase = r0_base
+    x0 = xindex
+    tmp3 = tl.full([XBLOCK, 1], float('nan'), tl.float32)
+    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
+        r0_index = r0_offset + r0_base
+        r0_mask = r0_index < r0_numel
+        roffset = r0_offset
+        rindex = r0_index
+        r0_1 = r0_index
+        tmp0 = tl.load(in_ptr0 + (r0_1 + 16384*x0), r0_mask & xmask, eviction_policy='evict_first', other=0.0)
+        tmp1 = tmp0.to(tl.float32)
+        tmp2 = tl.broadcast_to(tmp1, [XBLOCK, R0_BLOCK])
+        tmp4, = tl.associative_scan((tmp2,), 1, _triton_helper_fn_add0)
+        tmp5 = triton_helpers.select_one((tmp4), rbase == (RBLOCK - 1), dim=-1, keep_dims=True)
+        tmp6 = tmp3 + tmp5
+        tmp7 = tmp3 + tmp4
+        tmp8 = tl.where(roffset > 0, tmp7, tmp4)
+        tmp3 = tl.where(roffset > 0, tmp6, tmp5)
+        tl.store(out_ptr0 + (r0_1 + 16384*x0), tmp8, r0_mask & xmask)
+
+
+# ========================================================================================= #
+# LC-8. 2-kernel split reduction: partials + combine (fp32)  (source: splitsum_2kernel_f32.py)
+# -----------------------------------------------------------------------------------------
+# What it computes: x.sum() over (1048576,) fp32, which Inductor SPLITS into 128 partials (kernel0:
+# triton_red_fused_sum_0, a looped add-fold over 8192 each) + a combine (kernel1:
+# triton_per_fused_sum_1, sums the 128 partials). The non-GEMM analog of split-K. Bit-difference
+# axis: kernel0 R0_BLOCK (per-split fold grouping) -> 21 bit-classes over 36 configs.
+# *** DRIVER of the D113598054 fix: kernel0 was the OTHER pre-fix OVER-MERGE *** (same r0_block
+# 512 vs 1024 mechanism as LC-4). Checker: SUPPORTED; over-merges 1 -> 0 AFTER the fence fix.
+# ========================================================================================= #
+@triton.jit
+def LC_splitsum_partial_f32(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK : tl.constexpr, R0_BLOCK : tl.constexpr):
+    xnumel = 128
+    r0_numel = 8192
+    rnumel = r0_numel
+    RBLOCK: tl.constexpr = R0_BLOCK
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+    xmask = xindex < xnumel
+    r0_base = tl.arange(0, R0_BLOCK)[None, :]
+    rbase = r0_base
+    x0 = xindex
+    _tmp2 = tl.full([XBLOCK, R0_BLOCK], 0, tl.float32)
+    for r0_offset in tl.range(0, r0_numel, R0_BLOCK):
+        r0_index = r0_offset + r0_base
+        r0_mask = r0_index < r0_numel
+        roffset = r0_offset
+        rindex = r0_index
+        r0_1 = r0_index
+        tmp0 = tl.load(in_ptr0 + (r0_1 + 8192*x0), r0_mask & xmask, eviction_policy='evict_first', other=0.0)
+        tmp1 = tl.broadcast_to(tmp0, [XBLOCK, R0_BLOCK])
+        tmp3 = _tmp2 + tmp1
+        _tmp2 = tl.where(r0_mask & xmask, tmp3, _tmp2)
+    tmp2 = tl.sum(_tmp2, 1)[:, None]
+    tl.store(out_ptr0 + (x0), tmp2, xmask)
+
+
+@triton.jit
+def LC_splitsum_combine_f32(in_ptr0, out_ptr0, xnumel, r0_numel, XBLOCK : tl.constexpr):
+    xnumel = 1
+    r0_numel = 128
+    R0_BLOCK: tl.constexpr = 128
+    rnumel = r0_numel
+    RBLOCK: tl.constexpr = R0_BLOCK
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+    xmask = tl.full([XBLOCK], True, tl.int1)[:, None]
+    r0_index = tl.arange(0, R0_BLOCK)[None, :]
+    r0_offset = 0
+    r0_mask = tl.full([R0_BLOCK], True, tl.int1)[None, :]
+    roffset = r0_offset
+    rindex = r0_index
+    r0_0 = r0_index
+    tmp0 = tl.load(in_ptr0 + (r0_0), None, eviction_policy='evict_first')
+    tmp1 = tl.broadcast_to(tmp0, [XBLOCK, R0_BLOCK])
+    tmp3 = tl.sum(tmp1, 1)[:, None].to(tl.float32)
+    tl.store(out_ptr0 + (tl.full([1, 1], 0, tl.int32).broadcast_to(XBLOCK, 1)), tmp3, None)
+
+
+# ========================================================================================= #
+# LC-9. Split-K GEMM via Inductor decompose_k (fp16 out, fp32 partials)  (source: splitk_gemm_f16.py / triton_per_fused_mm_0)
+# -----------------------------------------------------------------------------------------
+# What it computes: a @ b (a:(64,16384) b:(16384,64) fp16) which Inductor decompose_k lowers to an
+# extern bmm (cuBLAS, fp32 partials, DETERMINISTIC - not atomic_add) + this Triton reduction that
+# sums the k_split partials. Only body edit: R0_BLOCK lifted from a body constexpr to a signature
+# constexpr so k_split is sweepable. Bit-difference axis: k_split (# of K-contraction groups) ->
+# 7 bit-classes over 28 configs. Checker: SUPPORTED (only the deterministic partial-sum is checked;
+# the MMA is invisible/extern); over-merges 0.
+# ========================================================================================= #
+@triton.jit
+def LC_splitk_gemm_f16(in_ptr0, out_ptr1, xnumel, r0_numel, XBLOCK : tl.constexpr, R0_BLOCK : tl.constexpr):
+    xnumel = 4096
+    rnumel = r0_numel
+    RBLOCK: tl.constexpr = R0_BLOCK
+    xoffset = tl.program_id(0) * XBLOCK
+    xindex = xoffset + tl.arange(0, XBLOCK)[:, None]
+    xmask = tl.full([XBLOCK], True, tl.int1)[:, None]
+    r0_index = tl.arange(0, R0_BLOCK)[None, :]
+    r0_offset = 0
+    r0_mask = tl.full([R0_BLOCK], True, tl.int1)[None, :]
+    roffset = r0_offset
+    rindex = r0_index
+    r0_1 = r0_index
+    x0 = xindex
+    tmp0 = tl.load(in_ptr0 + (x0 + 4096*r0_1), None, eviction_policy='evict_first')
+    tmp1 = tl.broadcast_to(tmp0, [XBLOCK, R0_BLOCK])
+    tmp3 = tl.sum(tmp1, 1)[:, None].to(tl.float32)
+    tmp4 = tmp3.to(tl.float32)
+    tl.store(out_ptr1 + (x0), tmp4, None)
+
+
 # =========================================================================================
 # Corpus tuples. Values are the raw @triton.jit functions (NOT KernelSpecs) - this module is a
 # reference/gap-analysis corpus, deliberately not wired into evaluate.py. See the module
@@ -2118,6 +2517,22 @@ POINTWISE_KERNELS = (
 
 NONFP_REDUCTION_KERNELS = (RED_any_isinf, )
 
+# GROUP 9 - loop-carried reduction discriminators (D113598054 loop-chunk fix drivers). 9 source
+# discriminators = 10 @triton.jit kernels (splitsum_2kernel is a partial fold + a combine). Every
+# one spans genuine bitwise inequivalence across its reduction chunk-size knob (R0_BLOCK / k_split).
+LOOP_CARRIED_KERNELS = (
+    LC_sum_loop_f32,
+    LC_sum_loop_f16,
+    LC_sum_loop_bf16,
+    LC_prod_loop_f32,
+    LC_logsumexp_loop_f32,
+    LC_var_welford_f32,
+    LC_cumsum_scan_f32,
+    LC_splitsum_partial_f32,
+    LC_splitsum_combine_f32,
+    LC_splitk_gemm_f16,
+)
+
 # Everything, groups in table order.
 REALISTIC_KERNELS = (
     REDUCTION_FUSION_KERNELS
@@ -2128,6 +2543,7 @@ REALISTIC_KERNELS = (
     + COOPERATIVE_REDUCTION_KERNELS
     + POINTWISE_KERNELS
     + NONFP_REDUCTION_KERNELS
+    + LOOP_CARRIED_KERNELS
 )
 
 
@@ -2191,6 +2607,18 @@ def _adv_nd(numel, seed):
     return (base * scale * signs).to(_DEV, torch.float32)
 
 
+def _near_one_nd(numel, seed):
+    """Values near 1.0 (product folds overflow/underflow on wide-range data, so keep them tame)."""
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    return (1.0 + 0.01 * torch.randn(numel, generator=g, dtype=torch.float32)).to(_DEV, torch.float32)
+
+
+def _spread_nd(numel, seed, scale=3.0):
+    """Moderate-spread f32 (for exp-based folds like logsumexp, where wide range would overflow)."""
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    return (scale * torch.randn(numel, generator=g, dtype=torch.float32)).to(_DEV, torch.float32)
+
+
 def _to_bytes(t):
     """Exact output bits as a bytes object (the equality unit)."""
     return t.detach().cpu().contiguous().view(torch.uint8).numpy().tobytes()
@@ -2204,16 +2632,17 @@ def _bench_ms(thunk):
 
 # Per-kernel arg builders: return (jit_fn, args, outs, scalars, constexprs, grid_rows). XBLOCK is
 # set >1 (a real kept dim) where the x-extent allows, so M2 has room to relayout.
-def _spec_A(nw):
+def _spec_A(nw, seed=0):
     X = 1024
-    ins = [_adv_nd(X * 256, 1), _adv_nd(256, 2)]  # in_ptr0 (x), in_ptr1 (weight)
+    ins = [_adv_nd(X * 256, 1 + seed), _adv_nd(256, 2 + seed)]  # in_ptr0 (x), in_ptr1 (weight)
     outs = [torch.empty(X, device=_DEV), torch.empty(X * 256, device=_DEV)]  # in_out_ptr0, out_ptr0
     return A_rms_norm_fwd, [outs[0], ins[0], ins[1], outs[1]], outs, [X, 256], dict(XBLOCK=8), X // 8
 
 
-def _spec_C(nw):
+def _spec_C(nw, seed=0):
     X = 1024
-    ins = [_adv_nd(X * 256, i) for i in range(1, 3)] + [_adv_nd(X, 3), _adv_nd(X, 4), _adv_nd(256, 5), _adv_nd(256, 6)]
+    ins = [_adv_nd(X * 256, i + seed) for i in range(1, 3)] + [
+        _adv_nd(X, 3 + seed), _adv_nd(X, 4 + seed), _adv_nd(256, 5 + seed), _adv_nd(256, 6 + seed)]
     # order: in_ptr0[X*256], in_ptr1[X], in_ptr2[X], in_ptr3[256], in_ptr4[256], in_ptr5[X*256]
     in_ptr0, in_ptr5, in_ptr1, in_ptr2, in_ptr3, in_ptr4 = ins
     outs = [torch.empty(X * 256, device=_DEV) for _ in range(3)]
@@ -2221,47 +2650,47 @@ def _spec_C(nw):
     return C_rms_norm_bwd_2reduce, args, outs, [X, 256], dict(XBLOCK=8), X // 8
 
 
-def _spec_D(nw):
-    ins = [_adv_nd(1024, 1)]
+def _spec_D(nw, seed=0):
+    ins = [_adv_nd(1024, 1 + seed)]
     outs = [torch.empty(1, device=_DEV)]
     return D_masked_global_sum, [ins[0], outs[0]], outs, [1, 608], dict(XBLOCK=1), 1
 
 
-def _spec_E(nw):
+def _spec_E(nw, seed=0):
     X = 592
-    ins = [_adv_nd(X * 235, 1)]
+    ins = [_adv_nd(X * 235, 1 + seed)]
     outs = [torch.empty(X, device=_DEV)]
     return E_triu_masked_rowsum, [ins[0], outs[0]], outs, [X, 235], dict(XBLOCK=8), (X + 7) // 8
 
 
-def _spec_G(nw):
+def _spec_G(nw, seed=0):
     X = 5760
-    ins = [_adv_nd(737280, 1)]
+    ins = [_adv_nd(737280, 1 + seed)]
     outs = [torch.empty(X, device=_DEV)]
     return G_plain_sum_looped, [ins[0], outs[0]], outs, [X, 128], dict(XBLOCK=8, R0_BLOCK=128), (X + 7) // 8
 
 
-def _spec_H(nw):
+def _spec_H(nw, seed=0):
     X = 1024
-    ins = [_adv_nd(X * 256, 1)]
+    ins = [_adv_nd(X * 256, 1 + seed)]
     outs = [torch.empty(X, device=_DEV)]
     return H_mean_permute, [ins[0], outs[0]], outs, [X, 256], dict(XBLOCK=8), X // 8
 
 
 # GROUP 1b — strided-axis reductions (M2 firing). Kept axis (xnumel) is contiguous, reduce axis
 # (r0_numel) is strided by xnumel; XBLOCK is the kept tile so the axis is split across warps.
-def _spec_I(nw):
+def _spec_I(nw, seed=0):
     # dbias = grad.sum(dim=0): grad [r0=512, x=256] -> dbias[256]. Kept tiled 32-wide (like sum_2d_col).
     N, M = 256, 512
-    ins = [_adv_nd(N * M, 1)]
+    ins = [_adv_nd(N * M, 1 + seed)]
     outs = [torch.empty(N, device=_DEV)]
     return RED_colsum_dim0, [ins[0], outs[0]], outs, [N, M], dict(XBLOCK=32, R0_BLOCK=512), (N + 31) // 32
 
 
-def _spec_J(nw):
+def _spec_J(nw, seed=0):
     # matmul-epilogue / per-channel column sum: [r0=512, x=64] -> [64] (narrow kept, single tile).
     N, M = 64, 512
-    ins = [_adv_nd(N * M, 1)]
+    ins = [_adv_nd(N * M, 1 + seed)]
     outs = [torch.empty(N, device=_DEV)]
     return RED_colsum_dim0, [ins[0], outs[0]], outs, [N, M], dict(XBLOCK=64, R0_BLOCK=512), 1
 
@@ -2284,11 +2713,11 @@ def _clear():
                         pass
 
 
-def _compile(spec_fn, ordering, m2, nw):
+def _compile(spec_fn, ordering, m2, nw, seed=0):
     os.environ.setdefault("TRITON_ALWAYS_COMPILE", "1")
     os.environ["TRITON_M2_ENABLE"] = "1" if m2 else "0"
     _clear()
-    fn, args, outs, scalars, cst, grid = spec_fn(nw)
+    fn, args, outs, scalars, cst, grid = spec_fn(nw, seed)
     # Runtime args = pointers (args) + the non-constexpr scalars (xnumel, r0_numel); both warmup
     # and launch must pass them identically.
     runtime = [*args, *scalars]
@@ -2296,8 +2725,8 @@ def _compile(spec_fn, ordering, m2, nw):
     return runtime, outs, grid, ck
 
 
-def _run(spec_fn, ordering, m2, nw):
-    runtime, outs, grid, ck = _compile(spec_fn, ordering, m2, nw)
+def _run(spec_fn, ordering, m2, nw, seed=0):
+    runtime, outs, grid, ck = _compile(spec_fn, ordering, m2, nw, seed)
     ck[(grid, 1, 1)](*runtime)
     torch.cuda.synchronize()
     return b"".join(_to_bytes(o) for o in outs)
@@ -2312,6 +2741,203 @@ def _bench(spec_fn, ordering, m2, nw):
     thunk()
     torch.cuda.synchronize()
     return _bench_ms(thunk)
+
+
+# #########################################################################################
+# ## CHECKER + FUZZER SOUNDNESS SWEEP                                                      ##
+# #########################################################################################
+# A second entry point (next to the M2 perf harness) that measures the FORWARD PTX checker
+# against the empirical fuzzer over a FAIR equivalence axis per kernel (same input data + math,
+# different reduction ORDER / loop chunking / num_warps). For each kernel it reports the checker
+# vs empirical partition + the over-merge count (checker classes that straddle an empirical
+# boundary -- a soundness violation, must be 0) and classifies it:
+#   a-discriminating-sound        empirical_sets>1, over_merges==0  (checker over-splits only = good)
+#   b-DISCRIMINATING-OVER-MERGE   over_merges>0                     (a REAL soundness violation)
+#   c-bit-stable                  empirical_sets==1                 (can't test soundness)
+#   d-nondeterministic            same config+seed differs on rerun (out of contract; OM not counted)
+# Reuses the FORWARD checker (bitequiv.ptx.forward.interp:forward_module_descriptor) + the
+# standalone fuzzer (bitequiv.evaluation.equivalence_fuzzer). Both are imported lazily inside
+# ``_sweep`` so the corpus still imports in a checkerless / torch-less environment.
+_R0_16384 = (512, 1024, 2048, 4096, 8192, 16384)  # r0_numel=16384 loop-chunk sweep
+_R0_8192 = (256, 512, 1024, 2048, 4096, 8192)     # r0_numel=8192; spans the 256/512 unroll/fence boundary
+
+
+def _checker_key(checker, ck):
+    """Static-checker key: the forward descriptor of the kernel's PTX (a tuple for a multi-launch case)."""
+    cks = ck if isinstance(ck, (tuple, list)) else [ck]
+    return tuple(checker(k.asm["ptx"]) for k in cks)
+
+
+def _eval_case(name, cfgs, compile_fn, run_fn, label_fn, repeats, checker, fz, nondet=False, note=""):
+    """Compile each config -> checker key, fuzz -> empirical key, classify soundness (see the banner)."""
+    ck_key, compiled, fails = {}, [], 0
+    for cfg in cfgs:
+        try:
+            ck = compile_fn(cfg)
+            run_fn(cfg, 0)  # trial launch: a config can compile yet fail / OOM at launch
+            ck_key[cfg] = _checker_key(checker, ck)
+            compiled.append(cfg)
+        except Exception:  # noqa: BLE001 - a broken config is dropped, not fatal to the sweep
+            fails += 1
+    if not compiled:
+        return dict(name=name, ok=0, fails=fails, classification="error-all-configs-failed", note=note)
+    if not nondet:
+        nondet = any(run_fn(c, 0) != run_fn(c, 0) for c in compiled)
+    emp_key = fz.empirical_keys(lambda cfg, seed: run_fn(cfg, seed), compiled, repeats)
+    ck_sets, emp_sets = fz.partition(compiled, ck_key), fz.partition(compiled, emp_key)
+    over_m = None if nondet else fz.over_merges(compiled, ck_key, emp_key)
+    over_s = None if nondet else fz.over_merges(compiled, emp_key, ck_key)
+    if nondet:
+        cls = "d-nondeterministic"
+    elif len(emp_sets) == 1:
+        cls = "c-bit-stable"
+    elif over_m > 0:
+        cls = "b-DISCRIMINATING-OVER-MERGE"
+    else:
+        cls = "a-discriminating-sound"
+    res = dict(name=name, ok=len(compiled), attempted=len(cfgs), fails=fails, repeats=repeats,
+               checker_sets=len(ck_sets), empirical_sets=len(emp_sets), over_merges=over_m,
+               over_splits=over_s, nondet=nondet, classification=cls, note=note)
+    if over_m:
+        pairs = fz.over_merge_pairs(compiled, ck_key, emp_key)
+        res["over_merge_pairs"] = [[label_fn(a), label_fn(b)] for a, b in pairs[:12]]
+    return res
+
+
+def _g1_cases():
+    """GROUP 1 ordered add-reductions. Fair axis: reduction_ordering x num_warps on the SAME
+    order-sensitive data (seed-varying via the threaded ``_spec_*``/``_run`` seed)."""
+    cfgs = [(o, nw) for o in ("unordered", "inner_tree") for nw in (1, 2, 4, 8)]
+    cases = []
+    for specname, spec_fn in SPECS.items():
+        def compile_fn(cfg, spec_fn=spec_fn):
+            return _compile(spec_fn, cfg[0], False, cfg[1], 0)[3]
+
+        def run_fn(cfg, seed, spec_fn=spec_fn):
+            return _run(spec_fn, cfg[0], False, cfg[1], seed)
+
+        cases.append((specname, cfgs, compile_fn, run_fn, lambda cfg: f"ord={cfg[0]} nw={cfg[1]}",
+                      False, "GROUP1 ordered add-reduction (ordering x num_warps, order-sensitive data)"))
+    return cases
+
+
+def _lc_launch(jitfn, xnumel, r0_numel, out_numel, in_dtype, builder, rb, nw, seed,
+               two_ptr=False, out_full=False, xblock=1):
+    """Warmup + launch one loop-carried config; data depends ONLY on seed (fixed across R0_BLOCK)."""
+    grid = (xnumel + xblock - 1) // xblock
+    a = builder(xnumel * r0_numel, seed).to(in_dtype)
+    out = torch.empty(xnumel * r0_numel if out_full else out_numel, device=_DEV, dtype=torch.float32)
+    args = [out, a, xnumel, r0_numel] if two_ptr else [a, out, xnumel, r0_numel]
+    ck = jitfn.warmup(*args, grid=(grid, ), XBLOCK=xblock, R0_BLOCK=rb, num_warps=nw)
+    ck[(grid, 1, 1)](*args)
+    torch.cuda.synchronize()
+    return _to_bytes(out), ck
+
+
+def _lc_case(name, jitfn, xnumel, r0_numel, out_numel, in_dtype, r0_blocks, builder, **kw):
+    """GROUP 9 loop-carried case: R0_BLOCK re-chunks the SAME data (fair over-merge axis) x num_warps."""
+    cfgs = [(rb, nw) for rb in r0_blocks for nw in (1, 2, 4, 8)]
+
+    def compile_fn(cfg):
+        return _lc_launch(jitfn, xnumel, r0_numel, out_numel, in_dtype, builder, cfg[0], cfg[1], 0, **kw)[1]
+
+    def run_fn(cfg, seed):
+        return _lc_launch(jitfn, xnumel, r0_numel, out_numel, in_dtype, builder, cfg[0], cfg[1], seed, **kw)[0]
+
+    return (name, cfgs, compile_fn, run_fn, lambda cfg: f"R0_BLOCK={cfg[0]} nw={cfg[1]}", False,
+            "GROUP9 loop-carried; R0_BLOCK re-chunks the SAME data (fair over-merge axis)")
+
+
+def _splitk_case():
+    """Split-K partial-sum (LC-9): k_split is NOT a fair axis (each split reduces independent per-k
+    data, so different k_split = different math, not a reordering) -- so k is fixed, num_warps only."""
+    K = 32
+
+    def launch(nw, seed):
+        a = _adv_nd(K * 4096, seed).to(torch.float16)
+        out = torch.empty(4096, device=_DEV, dtype=torch.float32)
+        ck = LC_splitk_gemm_f16.warmup(a, out, 4096, K, grid=(512, ), XBLOCK=8, R0_BLOCK=K, num_warps=nw)
+        ck[(512, 1, 1)](a, out, 4096, K)
+        torch.cuda.synchronize()
+        return _to_bytes(out), ck
+
+    cfgs = [(K, nw) for nw in (1, 2, 4, 8)]
+    return ("LC_splitk_gemm_f16", cfgs, lambda cfg: launch(cfg[1], 0)[1],
+            lambda cfg, seed: launch(cfg[1], seed)[0], lambda cfg: f"k={cfg[0]} nw={cfg[1]}", False,
+            "split-K partial-sum; num_warps-only fair axis (k fixed: independent per-k data)")
+
+
+def _combine_case():
+    """Split-sum combine (LC-8 kernel 2): a fixed 128-wide fold with no R0_BLOCK knob, so num_warps only."""
+    def launch(nw, seed):
+        a = _adv_nd(128, seed)
+        out = torch.empty(1, device=_DEV, dtype=torch.float32)
+        ck = LC_splitsum_combine_f32.warmup(a, out, 1, 128, grid=(1, ), XBLOCK=1, num_warps=nw)
+        ck[(1, 1, 1)](a, out, 1, 128)
+        torch.cuda.synchronize()
+        return _to_bytes(out), ck
+
+    cfgs = [(128, nw) for nw in (1, 2, 4, 8)]
+    return ("LC_splitsum_combine_f32", cfgs, lambda cfg: launch(cfg[1], 0)[1],
+            lambda cfg, seed: launch(cfg[1], seed)[0], lambda cfg: f"chunk={cfg[0]} nw={cfg[1]}", False,
+            "split-sum combine; num_warps-only fair axis (fixed 128-wide fold)")
+
+
+def _lc_cases():
+    """GROUP 9 loop-carried discriminators. R0_BLOCK spans small->full (incl. the 256/512 boundary)."""
+    return [
+        _lc_case("LC_sum_loop_f32", LC_sum_loop_f32, 64, 16384, 64, torch.float32, _R0_16384, _adv_nd),
+        _lc_case("LC_sum_loop_f16", LC_sum_loop_f16, 64, 16384, 64, torch.float16, _R0_16384, _adv_nd),
+        _lc_case("LC_sum_loop_bf16", LC_sum_loop_bf16, 64, 16384, 64, torch.bfloat16, _R0_16384, _adv_nd),
+        _lc_case("LC_prod_loop_f32", LC_prod_loop_f32, 64, 8192, 64, torch.float32, _R0_8192, _near_one_nd),
+        _lc_case("LC_logsumexp_loop_f32", LC_logsumexp_loop_f32, 64, 16384, 64, torch.float32, _R0_16384,
+                 _spread_nd, two_ptr=True),
+        _lc_case("LC_var_welford_f32", LC_var_welford_f32, 64, 16384, 64, torch.float32, _R0_16384,
+                 _adv_nd, two_ptr=True),
+        _lc_case("LC_cumsum_scan_f32", LC_cumsum_scan_f32, 64, 16384, 64, torch.float32, _R0_16384,
+                 _adv_nd, out_full=True),
+        _lc_case("LC_splitsum_partial_f32", LC_splitsum_partial_f32, 128, 8192, 128, torch.float32,
+                 _R0_8192, _adv_nd),
+        _splitk_case(),
+        _combine_case(),
+    ]
+
+
+def _sweep(argv):
+    """Checker+fuzzer soundness sweep over GROUP 1 reductions + GROUP 9 loop-carried discriminators.
+
+    Run:  PYTHONPATH=. TRITON_ALWAYS_COMPILE=1 \
+              python -m bitequiv.evaluation.realistic_inductor_kernels sweep [--repeats N] [--only SUBSTR]
+    """
+    import argparse
+
+    # Lazy so the corpus imports without the project's PTX checker (kept torch/inductor-optional above).
+    from bitequiv.evaluation import equivalence_fuzzer as fz
+    from bitequiv.ptx.forward.interp import forward_module_descriptor
+
+    ap = argparse.ArgumentParser(prog="realistic_inductor_kernels sweep")
+    ap.add_argument("--repeats", type=int, default=12, help="fuzzer seeds per config")
+    ap.add_argument("--only", default=None, help="substring filter on kernel name")
+    args = ap.parse_args(argv)
+
+    cases = _g1_cases() + _lc_cases()
+    if args.only:
+        cases = [c for c in cases if args.only in c[0]]
+    print(f"device: {torch.cuda.get_device_name()}  checker: forward_module_descriptor  "
+          f"cases: {len(cases)}  repeats: {args.repeats}")
+    print(f"{'kernel':28s} {'ok':>3s} {'chk':>4s} {'emp':>4s} {'over_m':>7s} {'over_s':>7s} class")
+    for name, cfgs, compile_fn, run_fn, label_fn, nondet, note in cases:
+        try:
+            res = _eval_case(name, cfgs, compile_fn, run_fn, label_fn, args.repeats,
+                             forward_module_descriptor, fz, nondet=nondet, note=note)
+        except Exception as e:  # noqa: BLE001 - one bad kernel must not abort the sweep
+            print(f"{name:28s}  ERROR {type(e).__name__}: {str(e).splitlines()[0][:60]}")
+            continue
+        print(f"{name:28s} {res.get('ok', 0):>3} {str(res.get('checker_sets')):>4} "
+              f"{str(res.get('empirical_sets')):>4} {str(res.get('over_merges')):>7} "
+              f"{str(res.get('over_splits')):>7} {res.get('classification')}")
+        if res.get("over_merges"):
+            print(f"    !!! OVER-MERGE sample: {res['over_merge_pairs'][:3]}")
 
 
 def main(argv):
@@ -2339,4 +2965,7 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    if len(sys.argv) > 1 and sys.argv[1] == "sweep":
+        _sweep(sys.argv[2:])
+    else:
+        main(sys.argv[1:])

--- a/bitequiv/ptx/affine.py
+++ b/bitequiv/ptx/affine.py
@@ -68,6 +68,10 @@ def _ctz(n):
     return z
 
 
+def _is_pow2(n):
+    return n is not None and n > 0 and (n & (n - 1)) == 0
+
+
 def _is_special(name):
     return any(name.startswith(p) for p in _SPECIAL_PREFIXES)
 
@@ -277,6 +281,8 @@ class AffineEval:
             return self._and(ev(srcs[0]), ev(srcs[1]))
         if op in ("or", "xor") and len(srcs) == 2:
             return self._or_xor(ev(srcs[0]), ev(srcs[1]))
+        if op == "bfe" and len(srcs) == 3:  # bit-field extract: bits [pos, pos+len) of a
+            return self._bfe(ev(srcs[0]), ev(srcs[1]), ev(srcs[2]))
 
         return self._opaque_def(d)
 
@@ -316,7 +322,62 @@ class AffineEval:
                 terms = frozenset((sym, c >> s) for sym, c in a.terms)
                 return Affine(a.const >> s, terms, rng=_rng_scale(a.rng, 1) if a.rng is None else
                               (a.rng[0] >> s, ((a.rng[1] - 1) >> s) + 1))
+            # tid bit-slice: decompose to the bit basis, drop bits < s, shift the rest down.
+            exp = self._tid_bit_expand(a)
+            pos = self._bit_positions(exp) if exp is not None else None
+            if pos is not None and s >= 0:
+                kept = frozenset((sym, 1 << (p - s)) for p, sym in pos.items() if p >= s)
+                hi = sum(1 << (p - s) for p in pos if p >= s) + 1
+                return Affine(0, kept, rng=(0, hi))
         return self._opaque_pair(a, "shr", b)
+
+    def _tid_bit_expand(self, aff):
+        """Rewrite an integer affine into the ``%tid`` BIT basis: each ``%tid.<dim>`` term is
+        replaced by ``sum_i (coeff * 2**i) * %tid.<dim>.bit<i>`` over ``i`` in ``[0, log2(N))``
+        where ``N = reqntid[dim]`` (a bit symbol has range ``[0, 2)`` — see :func:`leaf_columns`).
+
+        This is the tid->(warp, lane, tile) basis change: because ``N`` is a power of two, bits
+        ``[0, log2 N)`` cover ``[0, N)`` EXACTLY, so the rewrite is bit-for-bit the same integer —
+        the sound precondition for turning ``and`` / ``shr`` / ``bfe`` on ``tid`` (opaque today)
+        into an exact affine. Returns ``None`` (caller stays opaque) when a term is not so
+        decomposable: a non-power-of-two / unknown ``ntid`` (bits would over-cover ``[0, N)``), or a
+        NON-tid varying symbol (``%ctaid`` / ``param:`` / ``%laneid`` / opaque) whose bits are
+        unknown, or a non-zero constant (its bits could carry into the slice — kept out of scope)."""
+        if not isinstance(aff, Affine) or aff.const != 0:
+            return None
+        terms = {}
+        for sym, coeff in aff.terms:
+            parts = sym.split(".")
+            is_bit = len(parts) == 3 and parts[0] == "%tid" and parts[2].startswith("bit")
+            is_plain = len(parts) == 2 and parts[0] == "%tid"
+            if is_bit:  # already a bit symbol — carry through
+                terms[sym] = terms.get(sym, 0) + coeff
+                continue
+            if not is_plain:
+                return None  # a non-tid varying symbol -> not bit-decomposable
+            n = self.reqntid.get(parts[1])
+            if not _is_pow2(n):
+                return None
+            for i in range(n.bit_length() - 1):  # log2(N) bits
+                bit = f"{sym}.bit{i}"
+                terms[bit] = terms.get(bit, 0) + coeff * (1 << i)
+        frozen = frozenset((s, c) for s, c in terms.items() if c != 0)
+        return Affine(0, frozen, rng=aff.rng)
+
+    @staticmethod
+    def _bit_positions(exp):
+        """The bit position of every term of a pure bit-basis affine (const 0, each coeff a single
+        power of two), or ``None`` if any coeff is not a single set bit or two terms collide on one
+        position (so a bitwise mask/shift would not distribute over the sum)."""
+        pos = {}
+        for sym, coeff in exp.terms:
+            if coeff <= 0 or (coeff & (coeff - 1)) != 0:
+                return None  # not a single power of two
+            p = coeff.bit_length() - 1
+            if p in pos:
+                return None  # two bits collide on one position
+            pos[p] = sym
+        return pos
 
     def _and(self, a, b):
         # x & mask == x  when mask covers every bit x can possibly set (no-op mask).
@@ -325,19 +386,37 @@ class AffineEval:
             bits = _set_bits_mask(a)
             if bits is not None and (mask & bits) == bits:
                 return a
-        if isinstance(b, Affine) and not b.terms and isinstance(a, Affine):
-            # symmetric (mask & x)
-            pass
+            # tid bit-slice: decompose to the bit basis and keep only bits fully inside the mask.
+            exp = self._tid_bit_expand(a)
+            pos = self._bit_positions(exp) if exp is not None else None
+            if pos is not None and mask >= 0:
+                kept = frozenset((sym, 1 << p) for p, sym in pos.items() if (mask >> p) & 1)
+                hi = sum(1 << p for p in pos if (mask >> p) & 1) + 1
+                return Affine(0, kept, rng=(0, hi))
         return self._opaque_pair(a, "and", b)
 
     def _or_xor(self, a, b):
-        # x | imm == x ^ imm == x + imm  when imm is disjoint from x's possible set bits.
-        if isinstance(a, Affine) and isinstance(b, Affine) and not b.terms:
-            imm = b.const
-            bits = _set_bits_mask(a)
-            if bits is not None and (imm & bits) == 0 and imm >= 0:
+        # x | imm == x ^ imm == x + imm  when imm is disjoint from x's possible set bits (no carry),
+        # or (a | b) == (a ^ b) == (a + b) when a, b set DISJOINT bits — both add with no carry.
+        if isinstance(a, Affine) and isinstance(b, Affine):
+            ba, bb = _set_bits_mask(a), _set_bits_mask(b)
+            if ba is not None and bb is not None and (ba & bb) == 0 and (a.const & bb) == 0 and (b.const & ba) == 0:
                 return self._binop_add(a, b, 1)
         return self._opaque_pair(a, "orxor", b)
+
+    def _bfe(self, a, pos, length):
+        """``bfe`` (bit-field extract): bits ``[p, p+len)`` of ``a`` shifted down to bit 0. Exact on
+        the tid bit basis (``= shr(and(a, ((1<<len)-1)<<p), p)``); opaque otherwise."""
+        if not (isinstance(pos, Affine) and not pos.terms and isinstance(length, Affine) and not length.terms):
+            return self._opaque_pair(a, "bfe", pos)
+        p, ln = pos.const, length.const
+        exp = self._tid_bit_expand(a)
+        bpos = self._bit_positions(exp) if exp is not None else None
+        if bpos is not None and p >= 0 and ln > 0:
+            kept = frozenset((sym, 1 << (bp - p)) for bp, sym in bpos.items() if p <= bp < p + ln)
+            hi = sum(1 << (bp - p) for bp in bpos if p <= bp < p + ln) + 1
+            return Affine(0, kept, rng=(0, hi))
+        return self._opaque_pair(a, "bfe", pos)
 
     # -- opaque construction (structural, register-name independent) -----------
 

--- a/bitequiv/ptx/builder.py
+++ b/bitequiv/ptx/builder.py
@@ -18,8 +18,8 @@ from pyptx.ir.nodes import RegisterOperand, VectorOperand
 from bitequiv.ptx.affine import AffineEval, canon, reqntid_of
 from bitequiv.ptx.leaves import leaf_coord, leaf_columns
 from bitequiv.ptx.linker import Def, DefUse
-from bitequiv.ptx.treeir import (FpOp, ITreeReduce, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp,
-                                 ShflCombine, SmemExchange)
+from bitequiv.ptx.treeir import (FpOp, ITreeReduce, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp, ShflCombine,
+                                 SmemExchange)
 
 _FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f64", ".bf16", ".bf16x2"})
 _FP_KINDS = frozenset({"add", "sub", "mul", "div", "min", "max"})
@@ -329,13 +329,74 @@ def _has_opaque(node):
     return any(isinstance(n, (OpaqueLeaf, OpaqueOp)) for n in _postorder(node))
 
 
+def _addr_resolved(node):
+    """True iff every ``Leaf`` in ``node`` has a FULLY-affine address (no ``opq(`` token in its
+    coord) — i.e. the affine engine, with its ``%tid`` bit-basis (:func:`bitequiv.ptx.affine`),
+    pinned the exact element each thread loads. This is the "affine linchpin" gate for the
+    single-leaf add collapse below: only when the addressing is fully resolved is the reduced
+    element identity known, so a lone cross-thread add leaf may soundly collapse; an unresolved
+    (opaque / swizzled) address keeps the conservative >= 2 guard (fail-closed, over-split)."""
+    for n in _postorder(node):
+        if isinstance(n, Leaf) and (n.coord is None or "opq(" in n.coord):
+            return False
+    return True
+
+
+def _is_count_up(node, ht):
+    """True iff the butterfly shuffles reduce COUNT-UP — the offset DOUBLES leaf->root (1, 2, 4, 8, ...).
+    That is the ``inner_tree`` signature: a count-up balanced tree fixes the reduction to the layout-
+    invariant canonical order, so it is bit-identical across ``num_warps``. ``unordered`` is count-DOWN
+    (16, 8, ..., 1 leaf->root). For a PURE cross-thread reduction (one boundary leaf, no within-thread
+    fold to reveal the left-fold) the butterfly direction is the ONLY signal that separates the
+    num_warps-invariant order from the layout-dependent one, so the single-leaf collapse MUST gate on it
+    or it over-merges ``unordered`` across num_warps.
+
+    Examine EVERY maximal run of shuffles at consecutive heights — the within-warp butterfly AND the
+    cross-warp run (which sits higher, separated by a shared-memory exchange). Both carry the same
+    direction. inner_tree makes every run increasing; unordered makes every run decreasing. Return True
+    iff at least one run of >= 2 steps is strictly increasing AND no run is non-increasing. Reading only
+    the TOP run (old behavior) missed the direction at low num_warps, where the cross-warp run is a
+    single (direction-less) step and only the within-warp butterfly proves count-up — so nw=2 stayed
+    over-split. A count-DOWN run (unordered), a non-monotone run, a dynamic offset, or a height carrying
+    two offsets -> False (cannot prove inner_tree -> do not collapse -> sound over-split)."""
+    by_ht = {}
+    for n in _postorder(node):
+        if isinstance(n, ShflCombine):
+            try:
+                off = int(n.offset)
+            except (TypeError, ValueError):
+                return False  # dynamic / unresolved offset
+            by_ht.setdefault(ht[id(n)], set()).add(off)
+    if not by_ht or any(len(offs) != 1 for offs in by_ht.values()):
+        return False  # no shuffles, or a height carrying two different offsets -> ambiguous
+    flat = {h: next(iter(offs)) for h, offs in by_ht.items()}
+    heights = sorted(flat)
+    runs, cur = [], [heights[0]]  # maximal runs of CONSECUTIVE heights (ascending height = leaf->root)
+    for h in heights[1:]:
+        if h == cur[-1] + 1:
+            cur.append(h)
+        else:
+            runs.append(cur)
+            cur = [h]
+    runs.append(cur)
+    saw_up = False
+    for run in runs:
+        offs = [flat[h] for h in run]  # leaf->root
+        if len(offs) < 2:
+            continue  # a single (cross-warp) step: direction-less on its own -> no evidence, skip
+        if all(0 < offs[i] < offs[i + 1] for i in range(len(offs) - 1)):
+            saw_up = True
+        else:
+            return False  # count-DOWN (unordered) or non-monotone -> not provably inner_tree
+    return saw_up
+
+
 # Pure per-element ops that are safe to keep VERBATIM inside a collapsed reduction's leaf: each is
 # a deterministic function of ONE element (cast/copy/abs/neg + the transcendentals a softmax /
 # rmsnorm / layernorm applies before the reduce), hence layout-invariant. Its token rides verbatim
 # into leaf_sig (compared, never dropped), so equal leaf_sig => same op; a config WITHOUT the op
 # gets a different leaf_sig and never merges.
-_PURE_ELT = ("cvt", "mov", "abs", "neg", "ex2", "lg2", "exp", "log",
-             "sqrt", "rsqrt", "rcp", "sin", "cos", "tanh")
+_PURE_ELT = ("cvt", "mov", "abs", "neg", "ex2", "lg2", "exp", "log", "sqrt", "rsqrt", "rcp", "sin", "cos", "tanh")
 
 
 def _tok_is_pure(token):
@@ -380,7 +441,7 @@ def _shfl_dir(node, ht):
     return tuple(sorted({off for h, off in shfls if h == lo}))
 
 
-def _collapse_info(node):
+def _collapse_info(node, ht=None):
     """(reduce_op_token, uniform_coord_free_leaf_sig, reduced_column_SET) for a collapsible reduction,
     or None if it cannot be SOUNDLY collapsed. The BOUNDARY leaves are the non-reduce CHILDREN of
     reduce nodes (NOT every non-reduce postorder node — collecting the latter double-counts a
@@ -420,9 +481,17 @@ def _collapse_info(node):
     # min/max butterfly (1 leaf/thread) is a real reduction and MAY collapse. A SHAPE-DEPENDENT op
     # (add) keys on height + shfl_dir, NOT the element set, so a lone coord-blanked leaf would merge
     # reductions over DIFFERENT element sets that share the height/direction (they differ in bits) ->
-    # keep the >= 2 guard for add (a within-thread fold pins the layout enough for the eval's
-    # same-element-set configs; a 1-leaf pure cross-thread add stays over-split, sound).
-    if op.split(".")[0] not in _ORDER_INVARIANT_OPS and len(leaves) < 2:
+    # keep the >= 2 guard for add UNLESS the sole leaf's address is FULLY resolved to affine
+    # (`_addr_resolved`) AND the tree reduces COUNT-UP (`_is_count_up`): with the `%tid` bit-basis the
+    # exact reduced element set is then pinned by the coord, and count-up is the inner_tree canonical
+    # order (bit-identical across num_warps), so a pure cross-thread add for an axis-0 / outer-axis
+    # reduction (sum_2d_axis0 etc., whose whole reduction is cross-thread -> one boundary leaf) soundly
+    # recovers num_warps. Count-DOWN (unordered) or an UNRESOLVED (opaque/swizzled) address keeps the
+    # old >= 2 fail-close (over-split, sound) — count-up vs count-down is the ONLY signal separating the
+    # num_warps-invariant order from the layout-dependent one when there is no within-thread fold. This
+    # is the affine linchpin. (ht is None on the pre-collapse `_reduces_without_leaf` scan -> stay strict.)
+    if (op.split(".")[0] not in _ORDER_INVARIANT_OPS and len(leaves) < 2
+            and not (_addr_resolved(leaves[0]) and ht is not None and _is_count_up(node, ht))):
         return None
     if not all(_leaf_layout_invariant(l) for l in leaves):
         return None  # a layout-dependent / lost-provenance leaf -> do not collapse
@@ -515,7 +584,7 @@ def collapse_balanced(root):
     new = {}
     for n in _postorder(root):
         region_root = collapsible[id(n)] and not has_coll_parent.get(id(n), False)
-        info = _collapse_info(n) if region_root else None
+        info = _collapse_info(n, ht) if region_root else None
         if info is not None:
             op, leaf_sig, cols = info
             if op.split(".")[0] in _ORDER_INVARIANT_OPS:

--- a/bitequiv/ptx/builder.py
+++ b/bitequiv/ptx/builder.py
@@ -63,7 +63,7 @@ def _reduce_op(node):
 
 
 def _is_fp(inst):
-    return bool(inst.modifiers) and inst.modifiers[-1] in _FP_WIDTHS
+    return bool(inst.modifiers) and any(m in _FP_WIDTHS for m in inst.modifiers)
 
 
 def _offset(operand):

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -36,7 +36,7 @@ from bitequiv.ptx.forward.loops import (find_loops, loop_accumulates, loop_carri
 from bitequiv.ptx.forward.predicate import PredicateDecoder
 from bitequiv.ptx.leaves import leaf_coord, leaf_columns
 from bitequiv.ptx.linker import DefUse, _def_regs, linearize
-from bitequiv.ptx.mma import _is_mma, _mma_fence
+from bitequiv.ptx.mma import _fence_all_matmul, _is_mma, _mma_fence
 from bitequiv.ptx.treeir import (FpOp, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp, ShflCombine,
                                  SmemExchange)
 
@@ -709,8 +709,11 @@ def _epilogue_reduces_mma(sinks):
 def _mma_entry_descriptor(func, fence):
     """Descriptor for an entry containing MMA (tensor-core) ops, via the tiling-invariant fence.
 
-    A PURE GEMM (MMA, no reduction over the output) is the fence ALONE -> num_warps + BLOCK_M/BLOCK_N
-    are free (recovered), with ``loops=`` kept (BLOCK_K is a real, bit-relevant K split). An MMA + a
+    A PURE f16/bf16/tf32 GEMM (MMA, no reduction over the output) is the fence ALONE -> num_warps +
+    BLOCK_M/BLOCK_N + BLOCK_K are all free (recovered) and v2 (``mma.sync``) merges with v5
+    (``tcgen05``): the fence token is form- and tiling-invariant and ``loops=`` (BLOCK_K) is dropped
+    because BLOCK_K only re-batches the same in-order k-fold (native-k fixed, exact F=25 accumulate).
+    fp8 keeps ``loops=`` (imprecise-acc cadence). An MMA + a
     reduction OVER the MMA output (FA softmax, or gemm_reduce_sum / softmax / layernorm) is FAIL-CLOSED:
     the fence AND the reduction fingerprint both ride, so configs differing in EITHER the MMA shape OR
     the reduction order split (sound, never over-merged). The reduction is detected structurally
@@ -735,10 +738,16 @@ def _mma_entry_descriptor(func, fence):
     sinks += [v for _, v in interp.smem_stores if hasattr(v, "children")]
     sinks += [v for v in interp.regs.values() if hasattr(v, "children")]
     has_shfl = any(inst.opcode == "shfl" and ".bfly" in inst.modifiers for inst in linearize(func))
-    if has_shfl or _epilogue_reduces_mma(sinks):
+    reduces = has_shfl or _epilogue_reduces_mma(sinks)
+    if reduces:
         parts.append("mma+red|" + interp.fingerprint())
-    steps = _loop_steps(func)  # BLOCK_K split (+ the tcgen05 / fp8 K carried here, not in the token)
-    if steps:
+    steps = _loop_steps(func)
+    # BLOCK_K is bit-neutral for a PURE f16/bf16/tf32 tensor-core GEMM: native-k is fixed and each MMA's
+    # F=25 accumulate is exact, so BLOCK_K only re-batches the same in-order k-fold. Drop loops= there ->
+    # recovers BLOCK_K AND lets v2 (mma.sync, emits loops=) match v5 (tcgen05, emits none). Keep loops=
+    # for fp8 (the max_num_imprecise_acc cadence can shift with BLOCK_K) and when the entry reduces over
+    # the MMA output (a chunked reduction step may be bit-relevant; its order otherwise rides mma+red).
+    if steps and (reduces or not _fence_all_matmul(fence)):
         parts.append("loops=" + ",".join(map(str, steps)))
     sig = reduction_trip_signature(func)
     if sig is not None:

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -42,6 +42,11 @@ from bitequiv.ptx.treeir import (FpOp, Leaf, LoopReduce, Mma, OpaqueLeaf, Opaque
 
 _FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f64", ".bf16", ".bf16x2"})
 _FP_KINDS = frozenset({"add", "sub", "mul", "div", "min", "max"})
+# The f16-in-a-32-bit-reg within-warp butterfly wraps its `shfl.bfly.b32` in a `cvt.u32.u16` (widen the
+# 16-bit fp payload so a `.b32` shuffle can move it) + a `cvt.u16.u32` (narrow it back). Both are pure
+# bit-repacks of the SAME 16-bit payload, so the forward walk carries the register value THROUGH them
+# (see `_transfer`) to keep the `_Shuffle` butterfly marker alive for the downstream `add.f16`.
+_U16_U32_REPACK = frozenset({".u16", ".u32"})
 # A packed op decomposes into independent per-lane SCALAR ops (`.f32x2` = two `.f32`, bit-identical),
 # so a decomposed lane node carries the SCALAR width. Keeping the packed width on a lane node would
 # make its reduce-op token (`add.f32x2`) differ from the surrounding scalar `.f32` combines and break
@@ -317,6 +322,25 @@ class ForwardInterp:
             if acc is not None and op == "add":
                 return self._loop_reduce(inst, acc, at)  # loop-carried add-accumulation -> fold summary
             return self._combine(inst, at)
+        if op == "cvt" and len(inst.operands) == 2 and set(mods) == _U16_U32_REPACK:
+            # f16 within-warp butterfly:  cvt.u32.u16 (widen) -> shfl.bfly.b32 -> cvt.u16.u32 (narrow)
+            # -> add.f16.  The 16-bit fp payload rides in a 32-bit register only so the `.b32` shuffle
+            # can move it; both cvts are pure bit-repacks of that SAME payload (widen zero-extends the
+            # irrelevant high 16 bits, narrow truncates them back off), i.e. identity on the fp value.
+            # So carry the register value THROUGH the cvt (keeping any `_Shuffle` marker) instead of
+            # burying it in an OpaqueOp: the following `add.f16` then still sees `add(p, shfl.bfly(p,
+            # off))` and rebuilds a `ShflCombine` WITH its offset. Without this the marker is stripped
+            # at the narrow cvt (the OpaqueOp branch below), so inner_tree (count-up) and unordered
+            # (count-down) f16 reductions both reconstruct as the SAME offset-free `add.f16` fold and
+            # OVER-MERGE across the order. bf16/f32 reduce in f32 (shuffle the value directly, no u16
+            # repack) so they are unaffected.
+            v = self._val(inst.operands[1], at)
+            if mods[0] == ".u32":
+                return v  # widen (u16->u32, zero-extend): payload-preserving -> pass value/marker through
+            if isinstance(v, _Shuffle):
+                return v  # narrow (u32->u16) of a shuffled payload: pass the butterfly marker through
+            # A narrow cvt whose source is NOT a shuffled payload could drop meaningful high bits (not
+            # provably value-preserving) -> leave it opaque / fail-closed below (sound, never over-merge).
         # Any other unmodeled op (an f64 half-assembly `or.b64`, a `cvt`, ...): keep it as an
         # OpaqueOp NODE with its register operands as children + non-register operands in the token,
         # EXACTLY like the backward else-branch, so the value-DAG matches. A pure integer/address op

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -58,11 +58,11 @@ _PACKED_WIDTH = ".f32x2"
 
 
 def _is_fp(inst):
-    return bool(inst.modifiers) and inst.modifiers[-1] in _FP_WIDTHS
+    return bool(inst.modifiers) and any(m in _FP_WIDTHS for m in inst.modifiers)
 
 
 def _is_packed(inst):
-    return bool(inst.modifiers) and inst.modifiers[-1] == _PACKED_WIDTH
+    return bool(inst.modifiers) and any(m == _PACKED_WIDTH for m in inst.modifiers)
 
 
 def _redux_minmax_kind(mods):
@@ -555,7 +555,7 @@ class ForwardInterp:
         ntid = ",".join(f"{k}{v}" for k, v in sorted(self.ev.reqntid.items())) or "?"
         shfl, stores, fp, fma = [], {}, 0, 0
         for inst in self.flat:
-            is_fp = inst.modifiers and any(t in inst.modifiers[-1] for t in (".f16", ".f32", ".f64", ".bf16"))
+            is_fp = inst.modifiers and any(t in m for m in inst.modifiers for t in (".f16", ".f32", ".f64", ".bf16"))
             if inst.opcode == "shfl" and ".bfly" in inst.modifiers and len(inst.operands) >= 3:
                 shfl.append(str(_offset(inst.operands[2])))
             elif inst.opcode == "st" and ".shared" in inst.modifiers:

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -733,19 +733,23 @@ def _epilogue_reduces_mma(sinks):
 def _mma_entry_descriptor(func, fence):
     """Descriptor for an entry containing MMA (tensor-core) ops, via the tiling-invariant fence.
 
-    A PURE f16/bf16/tf32 GEMM (MMA, no reduction over the output) is the fence ALONE -> num_warps +
-    BLOCK_M/BLOCK_N + BLOCK_K are all free (recovered) and v2 (``mma.sync``) merges with v5
-    (``tcgen05``): the fence token is form- and tiling-invariant and ``loops=`` (BLOCK_K) is dropped
-    because BLOCK_K only re-batches the same in-order k-fold (native-k fixed, exact F=25 accumulate).
-    fp8 keeps ``loops=`` (imprecise-acc cadence). An MMA + a
-    reduction OVER the MMA output (FA softmax, or gemm_reduce_sum / softmax / layernorm) is FAIL-CLOSED:
-    the fence AND the reduction fingerprint both ride, so configs differing in EITHER the MMA shape OR
-    the reduction order split (sound, never over-merged). The reduction is detected structurally
-    (:func:`_epilogue_reduces_mma`) rather than by ``shfl.bfly`` presence, so a within-thread epilogue
-    fold (no shuffle) — which the shfl-only trigger missed, over-merging unordered vs inner_tree — is
-    now caught. The reduction fingerprint carries num_warps back in that case; the pure GEMM drops it
-    deliberately (num_warps is a free re-tiling of the same dot products)."""
-    from bitequiv.ptx.forward.loops import reduction_trip_signature
+    A PROVEN-PURE tensor-core fold (:func:`bitequiv.ptx.forward.loops.is_pure_mma_fold`: the loop's
+    accumulator is written only by MMA and read by nothing else) in an exactly-accumulating MMA family
+    (:func:`_fence_all_matmul`: f16/bf16/tf32), with no reduction over the output, is the fence ALONE
+    -> num_warps + BLOCK_M/BLOCK_N + BLOCK_K are all free (recovered) and v2 (``mma.sync``) merges with
+    v5 (``tcgen05``): the fence token is form- and tiling-invariant and ``loops=`` (BLOCK_K) is dropped
+    because BLOCK_K then only re-batches the same in-order k-fold (native-k fixed, exact F=25
+    accumulate). fp8 keeps ``loops=`` (imprecise-acc cadence).
+
+    Anything the fold recognizer cannot prove is FAIL-CLOSED on the conservative per-config
+    fingerprint: an MMA + a reduction OVER the output (FA softmax, or gemm_reduce_sum / softmax /
+    layernorm, detected structurally by :func:`_epilogue_reduces_mma` rather than by ``shfl.bfly``
+    presence, so a within-thread epilogue fold is caught too), and equally any tensor-core loop that
+    runs extra fp arithmetic inside the fold (``input_precision=tf32x3``, whose compensation sums are
+    grouped per K chunk, so its BLOCK_K IS bit-relevant). The fingerprint — not ``loops=`` alone — is
+    the fallback ON PURPOSE: a tcgen05 fold increments no pointer, so ``_loop_steps`` is empty there
+    and ``loops=`` would leave the descriptor chunk-blind exactly where the proof failed."""
+    from bitequiv.ptx.forward.loops import is_pure_mma_fold, reduction_trip_signature
     from bitequiv.ptx_reduction import _loop_steps
     parts = [_fence_str(fence)]
     interp = ForwardInterp(func)
@@ -763,15 +767,23 @@ def _mma_entry_descriptor(func, fence):
     sinks += [v for v in interp.regs.values() if hasattr(v, "children")]
     has_shfl = any(inst.opcode == "shfl" and ".bfly" in inst.modifiers for inst in linearize(func))
     reduces = has_shfl or _epilogue_reduces_mma(sinks)
-    if reduces:
-        parts.append("mma+red|" + interp.fingerprint())
+    # Positive proof that one loop iteration contributes nothing but MMA products to an accumulator
+    # nothing else touches. Without it we know only that the entry HAS tensor-core ops, which says
+    # nothing about whether re-chunking the fold is bit-free.
+    pure_fold = is_pure_mma_fold(func)
+    if reduces or not pure_fold:
+        # The fence alone does not describe this entry's fp behaviour: something outside the MMAs
+        # (an epilogue / in-fold reduction, or extra in-fold arithmetic) also decides the bits. Fail
+        # closed on the conservative per-config fingerprint, which carries num_warps, the ordered
+        # shuffle sequence and the op counts, so any of those differing splits.
+        parts.append("mma+fp|" + interp.fingerprint())
     steps = _loop_steps(func)
-    # BLOCK_K is bit-neutral for a PURE f16/bf16/tf32 tensor-core GEMM: native-k is fixed and each MMA's
-    # F=25 accumulate is exact, so BLOCK_K only re-batches the same in-order k-fold. Drop loops= there ->
-    # recovers BLOCK_K AND lets v2 (mma.sync, emits loops=) match v5 (tcgen05, emits none). Keep loops=
-    # for fp8 (the max_num_imprecise_acc cadence can shift with BLOCK_K) and when the entry reduces over
-    # the MMA output (a chunked reduction step may be bit-relevant; its order otherwise rides mma+red).
-    if steps and (reduces or not _fence_all_matmul(fence)):
+    # BLOCK_K is bit-neutral only for a PROVEN-pure f16/bf16/tf32 tensor-core fold: native-k is fixed
+    # and each MMA's F=25 accumulate is exact, so BLOCK_K then only re-batches the same in-order
+    # k-fold. Drop loops= there -> recovers BLOCK_K AND lets v2 (mma.sync, emits loops=) match v5
+    # (tcgen05, emits none). Keep loops= for fp8 (the max_num_imprecise_acc cadence can shift with
+    # BLOCK_K), when the entry reduces over the MMA output, and whenever the fold is not proven pure.
+    if steps and (reduces or not pure_fold or not _fence_all_matmul(fence)):
         parts.append("loops=" + ",".join(map(str, steps)))
     sig = reduction_trip_signature(func)
     if sig is not None:

--- a/bitequiv/ptx/forward/loops.py
+++ b/bitequiv/ptx/forward/loops.py
@@ -74,7 +74,7 @@ def own_body(insts, loop, loops):
 
 
 def _is_fp_combine(inst):
-    return inst.opcode in _FP_COMBINE and inst.modifiers and inst.modifiers[-1] in _FP_WIDTHS
+    return inst.opcode in _FP_COMBINE and inst.modifiers and any(m in _FP_WIDTHS for m in inst.modifiers)
 
 
 def _self_accumulate(inst):
@@ -108,6 +108,11 @@ def loop_self_increments(insts, loop, loops):
             d, a, b = inst.operands
             if (isinstance(d, RegisterOperand) and isinstance(a, RegisterOperand) and d.name == a.name
                     and isinstance(b, ImmediateOperand)):
+                # A non-literal increment immediate (symbolic / unparseable) is not a fixed chunk size,
+                # so we skip it rather than guess. Sound: chunk keys are only ever literal constants
+                # (BLOCK_K / BLOCK_N); dropping a symbolic step just keys the loop on its remaining literal
+                # steps (or none -> the conservative empty key), never merges two distinct chunkings, and
+                # the empirical fuzzer backstops. We do NOT fall back to 0 (0 would be dropped anyway).
                 try:
                     v = int(b.text, 0)
                 except (ValueError, TypeError):

--- a/bitequiv/ptx/forward/loops.py
+++ b/bitequiv/ptx/forward/loops.py
@@ -6,15 +6,30 @@ branch (``bra`` to a label at/before it) is a loop back-edge. On top of that we 
 carrying a floating-point ACCUMULATION (a running total across iterations) — the thing that makes its
 chunk size bit-relevant — and expose the loop-carried accumulator register(s) + the accumulating
 instruction, which the forward interpreter uses to emit a ``LoopReduce`` (fold summary) instead of
-unrolling.
+unrolling. :func:`is_pure_mma_fold` is the matching POSITIVE recognizer for the tensor-core case: it
+proves an entry's fp accumulation is carried by MMA instructions alone, which is what lets the MMA
+descriptor drop its chunk (BLOCK_K) fence.
 """
-from pyptx.ir.nodes import Block, ImmediateOperand, Label, RegisterOperand
+from pyptx.ir.nodes import Block, ImmediateOperand, Label, RegisterOperand, VectorOperand
 
 from bitequiv.ptx.mma import _is_mma
 
 # fp combine ops + widths, used to detect a loop-carried floating-point accumulation.
 _FP_WIDTHS = frozenset({".f16", ".f16x2", ".f32", ".f32x2", ".f64", ".bf16", ".bf16x2"})
 _FP_COMBINE = frozenset({"add", "sub", "mul", "div", "min", "max", "fma"})
+
+# fp opcodes that COMPUTE a value — arithmetic, transcendentals, comparisons, selects. Any of these
+# inside a tensor-core fold means the loop does more than sum MMA products, so re-chunking it can
+# regroup that arithmetic (see :func:`is_pure_mma_fold`). Format conversion (``cvt``) and the memory /
+# movement ops are deliberately NOT here: they are per-element and cannot regroup a fold, and an fp8
+# GEMM upcasts its operands with ``cvt`` inside the K loop yet is still a pure fold. A ``cvt`` (or any
+# other op) applied to the ACCUMULATOR is caught by the accumulator-read rule instead.
+_FP_VALUE_OPS = frozenset({"add", "sub", "mul", "div", "fma", "mad", "min", "max", "rcp", "sqrt",
+                           "rsqrt", "sin", "cos", "lg2", "ex2", "tanh", "abs", "neg", "selp", "setp",
+                           "redux", "testp", "copysign", "atom", "red"})
+# `.tf32` is normally an MMA operand dtype rather than a scalar-op width; it is listed so that an
+# arithmetic op carrying only that width still counts as floating point.
+_FP_VALUE_WIDTHS = _FP_WIDTHS | frozenset({".tf32"})
 
 
 def instrs_and_labels(func):
@@ -139,6 +154,84 @@ def loop_carried_accumulators(insts, loop, loops):
             if acc is not None:
                 out.append((acc, inst))
     return out
+
+
+def _operand_regs(operand):
+    """Register name(s) an operand mentions (a scalar register, or every element of a vector)."""
+    if isinstance(operand, RegisterOperand):
+        return {operand.name}
+    if isinstance(operand, VectorOperand):
+        return {e.name for e in operand.elements if isinstance(e, RegisterOperand)}
+    return set()
+
+
+def _mma_accumulator_regs(inst):
+    """Register(s) an MMA writes its accumulator into, or an empty set when it has none in registers.
+    ``tcgen05.mma`` accumulates in TENSOR MEMORY — its first operand is an ADDRESS, not a value — so
+    there is no accumulator register to track; reading that accumulator back needs a ``tcgen05.ld``,
+    which :func:`is_pure_mma_fold` rejects separately."""
+    if inst.opcode == "tcgen05" or not inst.operands:
+        return set()
+    return _operand_regs(inst.operands[0])
+
+
+def _is_fp_value_op(inst):
+    """True iff ``inst`` COMPUTES a floating-point value (see ``_FP_VALUE_OPS``)."""
+    return (inst.opcode in _FP_VALUE_OPS and inst.modifiers
+            and any(m in _FP_VALUE_WIDTHS for m in inst.modifiers))
+
+
+def _is_tmem_load(inst):
+    """True iff ``inst`` reads the tensor-memory MMA accumulator back into registers."""
+    return inst.opcode == "tcgen05" and ".ld" in inst.modifiers
+
+
+def is_pure_mma_fold(func):
+    """True iff every tensor-core fold in ``func`` accumulates by MMA instructions ALONE — the
+    positive recognizer that lets an MMA descriptor drop its chunk (BLOCK_K) fence.
+
+    A tensor-core K-loop is re-chunkable without changing a bit only when one iteration contributes
+    exactly one batch of MMA products to an accumulator that nothing else touches: any chunking then
+    issues the SAME dot products, in the same order, into the same accumulator. The folds are the
+    loops that ISSUE the MMAs (an MMA in their own body); for each, over its whole range:
+
+    1. no non-MMA instruction COMPUTES an fp value (:func:`_is_fp_value_op`) — nothing else joins the
+       fold. This is what rejects ``input_precision=tf32x3``, whose 3-pass f32 emulation sums its
+       compensation products INSIDE the K loop, so its chunking IS bit-relevant;
+    2. no non-MMA instruction reads an MMA accumulator register, and no ``tcgen05.ld`` reads the
+       tensor-memory accumulator — the accumulator is consumed only AFTER the fold. This is what
+       rejects Flash Attention, which rescales the running MMA accumulator every iteration.
+
+    Each fold is scanned over its FULL range, nested loops included, since arithmetic hidden in a
+    nested loop is still part of one iteration's contribution. An OUTER loop that combines whole MMA
+    partials (split-K: ``acc += partial``, no MMA of its own) is deliberately NOT a fold here — its
+    regrouping is num_splits, which :func:`reduction_trip_signature` fences separately.
+
+    Returns False — fail closed — for anything it cannot prove, including an entry with no recovered
+    MMA loop (a fully unrolled or unrecognized fold). Asking for a POSITIVE match is the point: the
+    fence check this backs up (:func:`bitequiv.ptx.mma._fence_all_matmul`) only rules out an inexact
+    MMA dtype, so on its own it lets through every tensor-core kernel that is not a plain GEMM
+    (precision emulation, attention, implicit-GEMM convolution, a tensor-core scan). A positive
+    recognizer puts those on the conservative side without needing a case for each."""
+    insts, loops = find_loops(func)
+    folds = [lp for lp in set(loops) if any(_is_mma(insts[k]) for k in own_body(insts, lp, loops))]
+    if not folds:
+        return False
+    for header, latch in folds:
+        body = range(header, latch + 1)
+        acc_regs = set()
+        for k in body:
+            if _is_mma(insts[k]):
+                acc_regs |= _mma_accumulator_regs(insts[k])
+        for k in body:
+            inst = insts[k]
+            if _is_mma(inst):
+                continue
+            if _is_fp_value_op(inst) or _is_tmem_load(inst):
+                return False
+            if acc_regs and any(acc_regs & _operand_regs(o) for o in inst.operands):
+                return False
+    return True
 
 
 def outer_reduction_loops(insts, loops):

--- a/bitequiv/ptx/forward/predicate.py
+++ b/bitequiv/ptx/forward/predicate.py
@@ -14,6 +14,7 @@ structural kinds (warp-leader, first-N, loop induction variable) that would let 
 RECOVER more freedom are a later extension; the floor needs only the structural-vs-data-dependent
 split so the interpreter can fail closed on data-dependent control flow.
 """
+import logging
 from dataclasses import dataclass
 
 from pyptx.ir.nodes import RegisterOperand, VectorOperand
@@ -22,6 +23,8 @@ from bitequiv.ptx.mma import _is_mma
 
 DATA_DEPENDENT = "DATA_DEPENDENT"
 STRUCTURAL = "STRUCTURAL"
+
+_log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -56,12 +59,17 @@ class PredicateDecoder:
     def decode(self, pred_reg, before_index):
         """``PredInfo`` for the predicate held in ``pred_reg`` at ``before_index`` (a program point in
         the same linearized stream the interpreter walks)."""
-        dd = self._depends_on_data(pred_reg, before_index)
-        return PredInfo(DATA_DEPENDENT if dd else STRUCTURAL)
+        trigger = self._depends_on_data(pred_reg, before_index)
+        if trigger is not None:  # log WHY the sound floor fired, so a fail-closed kernel is debuggable
+            _log.debug("control-flow floor: predicate %s is DATA_DEPENDENT (traces to `%s` at index %s) "
+                       "-> dropping it would be unsound, failing closed", pred_reg,
+                       trigger.inst.opcode + "".join(trigger.inst.modifiers), trigger.index)
+        return PredInfo(DATA_DEPENDENT if trigger is not None else STRUCTURAL)
 
     def _depends_on_data(self, reg, before_index):
-        """True iff the value in ``reg`` traces back (through def-use) to a data source. Iterative
-        with a seen-set so a shared/cyclic def graph terminates."""
+        """The producing ``Def`` of the runtime-data source ``reg`` traces back to (through def-use), or
+        ``None`` if ``reg`` is structural. Iterative with a seen-set so a shared/cyclic def graph
+        terminates. (Returning the Def, not just a bool, lets ``decode`` log which op forced the floor.)"""
         stack, seen = [(reg, before_index)], set()
         while stack:
             r, at = stack.pop()
@@ -72,11 +80,11 @@ class PredicateDecoder:
             if d is None:
                 continue  # kernel param / special register (%tid, %laneid, ...) -> structural leaf
             if _is_data_source(d.inst):
-                return True
+                return d
             for o in (d.inst.operands[1:] if d.inst.operands else []):  # source operands
                 if isinstance(o, RegisterOperand):
                     stack.append((o.name, d.index))
                 elif isinstance(o, VectorOperand):
                     stack.extend((e.name, d.index) for e in o.elements
                                  if isinstance(e, RegisterOperand))
-        return False
+        return None

--- a/bitequiv/ptx/leaves.py
+++ b/bitequiv/ptx/leaves.py
@@ -78,7 +78,11 @@ def leaf_columns(ev, du, load_inst, slot):
     grid = []  # (coeff, n) for each thread-index symbol that selects a column
     for sym, coeff in addr.terms:
         if sym.startswith("%tid"):
-            n = ev.reqntid.get(sym.split(".")[-1])
+            parts = sym.split(".")
+            if len(parts) == 3 and parts[2].startswith("bit"):
+                n = 2  # one tid bit (from affine.py's tid bit-basis), range [0, 2)
+            else:
+                n = ev.reqntid.get(parts[-1])
             if n is None:
                 return None
             grid.append((coeff, n))

--- a/bitequiv/ptx/mma.py
+++ b/bitequiv/ptx/mma.py
@@ -115,7 +115,7 @@ def _fp_epi_counts(func):
     re-tilings — see :func:`_mma_fence`)."""
     fma, addmul = 0, 0
     for inst in linearize(func):
-        if not (inst.modifiers and inst.modifiers[-1] in _FP_EPI_WIDTHS):
+        if not (inst.modifiers and any(m in _FP_EPI_WIDTHS for m in inst.modifiers)):
             continue
         if inst.opcode == "fma":
             fma += 1

--- a/bitequiv/ptx/mma.py
+++ b/bitequiv/ptx/mma.py
@@ -75,19 +75,68 @@ def _k_of(mods):
     return None
 
 
-def _mma_token(opcode, mods):
-    """Tiling-INVARIANT fence token: keep the bit-relevant facts, drop the free ones.
+# Operand dtype -> accumulation FAMILY (narrowest operand wins; the accumulator is the wider f32).
+# f16 and bf16 map to ONE family "f16": on Blackwell both lower through tcgen05 `.kind::f16` and the
+# same F=25-bit fixed-point accumulate, and a native tcgen05 GEMM does not even encode f16-vs-bf16 in
+# the PTX (see `_mma_token`). tf32/f32 -> "tf32" (a tensor-core f32 input is first rounded to tf32).
+# fp8 kinds are handled separately in `_mma_token` (kept conservative — fp8 is the one v2 != v5 case).
+_FAMILY_PRIORITY = (({".f16", ".bf16"}, "f16"), ({".tf32"}, "tf32"), ({".f64"}, "f64"),
+                    ({".s8", ".u8"}, "s8"), ({".s4", ".u4"}, "s4"), ({".b1"}, "b1"), ({".f32"}, "tf32"))
 
-    tcgen05: M/N/K live in a runtime descriptor (not the modifiers), so they ride the ratio +
-    ``loops=`` instead; keep ``.kind::`` (dtype family -> rounding) and ``.cta_group::`` (2-CTA
-    changes the accumulation). wgmma / mma.sync / wmma: keep K and the operand/accumulator dtypes;
-    drop the m/n tile dims and the issue/transpose mods."""
+
+def _dtype_family(dtypes):
+    """The accumulation family for a set of MMA operand dtypes. Narrowest operand wins because the
+    accumulator is always the wider f32; e.g. ``{.f32, .bf16}`` (acc f32, operands bf16) -> "f16"."""
+    for group, fam in _FAMILY_PRIORITY:
+        if any(d in dtypes for d in group):
+            return fam
+    return "?"
+
+
+def _fence_all_matmul(fence):
+    """True iff every token in an :func:`_mma_fence` is the canonical non-fp8 ``matmul|`` form — i.e. a
+    pure f16/bf16/tf32 tensor-core GEMM. The forward descriptor uses this to drop the bit-free
+    ``loops=`` (BLOCK_K) for such GEMMs, while keeping it for fp8 (``max_num_imprecise_acc`` cadence)
+    and the native-form cases."""
+    return fence is not None and fence[0] == "mma" and all(t.startswith("matmul|") for t in fence[1])
+
+
+def _mma_token(opcode, mods):
+    """Form-agnostic, tiling-invariant matmul token. The v2 warp-level MMA (``mma.sync``) and the v5
+    Blackwell MMA (``tcgen05.mma``) that compute the SAME matmul get the SAME token, so the autotuner
+    can move freely between them. Keeps only the bit-relevant facts — the accumulation dtype FAMILY and
+    the CTA group (2-CTA changes the accumulation) — and drops the FORM (mma vs tcgen05), the native
+    m/n/k tile, and the issue/transpose mods (all bit-free re-tilings of the same dot products).
+
+    Why v2 == v5 is sound for f16/bf16/tf32 (INFERRED, not an NVIDIA guarantee): for these types each
+    product ``A*B`` is exact in f32 (f16/tf32 give <=22 product significand bits, bf16 <=16, f32 holds
+    24 -> no rounding on the multiply), and both forms on the same Blackwell chip add the exact products
+    in the same wide fixed-point accumulator (F=25 fractional bits) with a single normalize -> same
+    bits. NVIDIA documents none of this; it is corroborated by two reverse-engineered bit-accurate
+    tensor-core models (arXiv 2511.10909 map both HMMA and UTCHMMA to FDA(F=25); arXiv 2512.07004 find
+    B200 == H100/H200 behavior, tensor cores NOT IEEE-754) and by our GB300 corpus (v2 and v5 land in
+    one bit class for f16/bf16/tf32). fp8 is the EXCEPTION and is kept conservative below: fp8
+    accumulation runs in limited precision with a periodic promote-to-f32 (Triton `max_num_imprecise_acc`
+    + a fp8-specific block ordering) that need not match across the two lowerings, so fp8 v2 != v5.
+
+    Note (dtype-relative): a native tcgen05 GEMM does not encode the specific operand dtype (``.kind::f16``
+    covers f16 AND bf16; the inputs are untyped ``.b16``), so the family cannot tell f16 from bf16 for
+    v5. The token is therefore dtype-RELATIVE: f16 and bf16 share the "f16" family. This is sound for
+    how the checker is used (the autotuner compares configs of ONE kernel = one fixed dtype), but two
+    DIFFERENT-dtype GEMMs would share a token."""
     if opcode == "tcgen05":
-        keep = sorted(m for m in mods if m.startswith(".kind::") or m.startswith(".cta_group::"))
-        return "tcgen05|" + ",".join(keep)
-    k = _k_of(mods)
+        kind = next((m[len(".kind::"):] for m in mods if m.startswith(".kind::")), "?")
+        if kind == "f8f6f4":  # fp8: v2 != v5 -> keep the native tcgen05 form so it never merges into matmul|
+            keep = sorted(m for m in mods if m.startswith(".kind::") or m.startswith(".cta_group::"))
+            return "tcgen05|" + ",".join(keep)
+        cta = next((m[len(".cta_group::"):] for m in mods if m.startswith(".cta_group::")), "1")
+        return f"matmul|{kind}|cta{cta}"
     dtypes = [m for m in mods if m in _MMA_DTYPES]
-    return f"{opcode}|k{k}|{','.join(dtypes)}"
+    if any(d in _FP8_DTYPES for d in dtypes):  # native fp8 (wgmma / mma.sync): keep the conservative form
+        k = _k_of(mods)
+        return f"{opcode}|k{k}|{','.join(dtypes)}"
+    cta = next((m[len(".cta_group::"):] for m in mods if m.startswith(".cta_group::")), "1")
+    return f"matmul|{_dtype_family(dtypes)}|cta{cta}"
 
 
 def _imm(operand):

--- a/bitequiv/ptx/mma.py
+++ b/bitequiv/ptx/mma.py
@@ -94,10 +94,15 @@ def _dtype_family(dtypes):
 
 
 def _fence_all_matmul(fence):
-    """True iff every token in an :func:`_mma_fence` is the canonical non-fp8 ``matmul|`` form — i.e. a
-    pure f16/bf16/tf32 tensor-core GEMM. The forward descriptor uses this to drop the bit-free
-    ``loops=`` (BLOCK_K) for such GEMMs, while keeping it for fp8 (``max_num_imprecise_acc`` cadence)
-    and the native-form cases."""
+    """True iff every token in an :func:`_mma_fence` is the canonical non-fp8 ``matmul|`` form, i.e.
+    every tensor-core op in the entry accumulates its products EXACTLY (the f16/bf16/tf32 families;
+    fp8's ``max_num_imprecise_acc`` cadence does not, and keeps its native form).
+
+    This is a statement about the MMA DTYPE only. It says nothing about what the loop around the MMA
+    does, so it is NOT on its own a licence to drop the chunk (BLOCK_K) fence — the forward descriptor
+    pairs it with :func:`bitequiv.ptx.forward.loops.is_pure_mma_fold`, which proves the fold structure
+    separately. Reading this predicate as "so the entry is a plain GEMM" is an open-world guess: every
+    tensor-core kernel that is not one (``input_precision=tf32x3``, attention, ...) also passes it."""
     return fence is not None and fence[0] == "mma" and all(t.startswith("matmul|") for t in fence[1])
 
 

--- a/bitequiv/ptx_reduction.py
+++ b/bitequiv/ptx_reduction.py
@@ -100,7 +100,14 @@ _MMA_OPCODES = frozenset({"wgmma", "mma", "wmma", "tcgen05"})
 # bare-entry fragments (unit-test snippets) do not, so synthesize a minimal header when
 # absent. The synthetic version/target only label the module; they do not affect the
 # extracted reduction tree.
-_SYNTH_HEADER = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+def ptx_header(target="sm_90a", version="8.5", address_size=64):
+    """A minimal pyptx-parseable module header. Parameterized so a target / PTX-ISA-version upgrade is a
+    one-line change here rather than a hardcoded string duplicated across call sites and the unit tests
+    (reviewer nit, D112765110)."""
+    return f".version {version}\n.target {target}\n.address_size {address_size}\n"
+
+
+_SYNTH_HEADER = ptx_header()
 
 
 class _Unparseable:

--- a/bitequiv/tests/test_ptx_affine.py
+++ b/bitequiv/tests/test_ptx_affine.py
@@ -28,10 +28,14 @@ def test_and_lowbit_mask_is_noop_within_range():
     assert canon(v) == "4*%tid.x"
 
 
-def test_and_partial_mask_is_opaque():
-    # mask 12 (bits 2,3) does NOT cover all bits 4*tid can set -> not provably no-op.
+def test_and_partial_mask_on_tid_is_bit_basis():
+    # A partial mask on tid is EXACT via the %tid bit-basis: reqntid 128 makes tid < 128, so bits
+    # [0,7) cover the value exactly, and 4*tid & 12 keeps bits 2,3 = (tid & 3)*4 = 4*bit0 + 8*bit1.
     v = _eval("mov.u32 %r1, %tid.x;\nshl.b32 %r2, %r1, 2;\nand.b32 %r3, %r2, 12;", "%r3")
-    assert isinstance(v, Opaque)
+    assert isinstance(v, Affine) and canon(v) == "4*%tid.x.bit0+8*%tid.x.bit1"
+    # A partial mask on a NON-tid value (unknown bits) is not bit-decomposable -> stays Opaque.
+    p = _eval("ld.param.b32 %r1, [k_param_1];\nand.b32 %r2, %r1, 12;", "%r2")
+    assert isinstance(p, Opaque)
 
 
 def test_disjoint_or_is_add():
@@ -56,8 +60,12 @@ def test_mad_wide_is_affine_times_const_plus_base():
 def test_shr_exact_when_multiple_else_opaque():
     exact = _eval("mov.u32 %r1, %tid.x;\nshl.b32 %r2, %r1, 2;\nshr.u32 %r3, %r2, 1;", "%r3")
     assert canon(exact) == "2*%tid.x"
-    inexact = _eval("mov.u32 %r1, %tid.x;\nshr.u32 %r2, %r1, 5;", "%r2")  # tid has tz 0
-    assert isinstance(inexact, Opaque)
+    # tid >> 5 (the warp index) is EXACT via the %tid bit-basis when reqntid pins tid < 128 (bits 5,6).
+    warp = _eval("mov.u32 %r1, %tid.x;\nshr.u32 %r2, %r1, 5;", "%r2")
+    assert isinstance(warp, Affine) and canon(warp) == "1*%tid.x.bit5+2*%tid.x.bit6"
+    # ...but Opaque WITHOUT a reqntid bound: cannot prove the shifted-out low bits are all tid has.
+    unbounded = _eval("mov.u32 %r1, %tid.x;\nshr.u32 %r2, %r1, 5;", "%r2", reqntid=False)
+    assert isinstance(unbounded, Opaque)
 
 
 def test_mul_reg_reg_is_opaque_and_structural():

--- a/bitequiv/tests/test_ptx_affine.py
+++ b/bitequiv/tests/test_ptx_affine.py
@@ -3,8 +3,9 @@ from pyptx.parser import parse
 
 from bitequiv.ptx.affine import Affine, AffineEval, Opaque, canon, reqntid_of
 from bitequiv.ptx.linker import DefUse
+from bitequiv.ptx_reduction import ptx_header
 
-_HEADER = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+_HEADER = ptx_header()
 
 
 def _eval(body, reg, reqntid=True):

--- a/bitequiv/tests/test_ptx_forward.py
+++ b/bitequiv/tests/test_ptx_forward.py
@@ -185,12 +185,12 @@ def test_squared_and_distinct_element_products_both_collapse():
 
 
 def test_mma_entry_gets_fence_descriptor():
-    # A wgmma entry -> the tiling-invariant fence (K + dtypes kept, m/n dropped), not a tree hash or
-    # the old coarse unanalyzed-mma guard.
+    # A wgmma entry -> the tiling-invariant, form-invariant fence (dtype FAMILY kept; form / m-n-k tile
+    # dropped), not a tree hash or the old coarse unanalyzed-mma guard.
     ptx = (_HDR + ".visible .entry k()\n{\n.reg .b32 %r<8>;\n"
            "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r1}, %r2, %r3;\nret;\n}\n")
     (desc, ) = forward_module_descriptor(ptx)
-    assert desc.startswith("mma|tok=") and "k16" in desc and "m64" not in desc
+    assert desc.startswith("mma|tok=matmul|f16|") and "m64" not in desc and "k16" not in desc
 
 
 # -- Phase 4b: a reduction OVER the MMA output rides the reduction fingerprint (soundness) ----------

--- a/bitequiv/tests/test_ptx_forward.py
+++ b/bitequiv/tests/test_ptx_forward.py
@@ -211,21 +211,65 @@ def _mma_body(body):
 
 def test_mma_within_thread_reduction_rides_fingerprint():
     # A within-thread add fold over the 4 MMA-output lanes (no shfl.bfly) is a reduction over the MMA
-    # output -> the descriptor carries "mma+red" (the fingerprint), not the fence alone.
+    # output -> the descriptor carries the fingerprint ("mma+fp"), not the fence alone.
     (desc, ) = forward_module_descriptor(
         _mma_body(_WGMMA4 + "add.f32 %f5, %f1, %f2;\nadd.f32 %f6, %f5, %f3;\n"
                   "add.f32 %f7, %f6, %f4;\nst.global.f32 [%rd2], %f7;\n"))
-    assert desc.startswith("mma|") and "mma+red" in desc
+    assert desc.startswith("mma|") and "mma+fp" in desc
+
+
+# -- Phase 4c: the chunk (BLOCK_K) fence is dropped only for a PROVEN-pure MMA fold ----------
+# Dropping ``loops=`` recovers BLOCK_K and merges mma.sync with tcgen05, but it is bit-safe only when
+# one loop iteration contributes nothing but MMA products to an accumulator nothing else touches
+# (``is_pure_mma_fold``). Deciding it from the MMA dtype alone ("all tokens are matmul| => a plain
+# GEMM") admits every tensor-core kernel that is NOT a plain GEMM -- measured on
+# ``input_precision=tf32x3``, whose 3-pass f32 emulation sums its compensation products INSIDE the K
+# loop, so its BLOCK_K IS bit-relevant and the checker merged 4 distinct bit classes into 2.
+
+def _mma_fold(step, in_loop="", epilogue=""):
+    """A K-loop folding one MMA per iteration with chunk step ``step``, plus optional extra
+    arithmetic INSIDE the loop and an ``epilogue`` after it."""
+    return (_HDR + ".visible .entry k(.param .u64 po)\n{\n"
+            ".reg .b64 %rd<8>;\n.reg .f32 %f<16>;\n.reg .b32 %r<8>;\n.reg .pred %p<4>;\n"
+            "ld.param.u64 %rd1, [po];\ncvta.to.global.u64 %rd2, %rd1;\nmov.b32 %r2, 0;\n"
+            "$L__K:\n" + _WGMMA4 + in_loop + f"add.s32 %r2, %r2, {step};\n"
+            "setp.lt.s32 %p1, %r2, 1024;\n@%p1 bra $L__K;\n" + epilogue +
+            "st.global.f32 [%rd2], %f1;\nret;\n}\n")
+
+
+def test_pure_mma_fold_recovers_block_k():
+    # A K-loop whose body is nothing but the MMA: re-chunking it re-batches the SAME in-order k-fold,
+    # so the two chunk steps must land on ONE descriptor (the tiling-invariant fence alone).
+    a = forward_module_descriptor(_mma_fold(32))
+    b = forward_module_descriptor(_mma_fold(64))
+    assert a == b and "loops=" not in a[0] and "fwd-incomplete" not in a[0]
+
+
+def test_extra_arithmetic_in_fold_keeps_chunk_fence():
+    # Extra fp arithmetic INSIDE the fold (the tf32x3 compensation shape) makes the chunking
+    # bit-relevant -> fail closed: the chunk fence rides and the two chunk steps must SPLIT.
+    comp = "sub.f32 %f6, %f7, %f8;\n"
+    a = forward_module_descriptor(_mma_fold(32, in_loop=comp))
+    b = forward_module_descriptor(_mma_fold(64, in_loop=comp))
+    assert a != b and "loops=32" in a[0] and "fwd-incomplete" in a[0]
 
 
 def test_mma_elementwise_epilogue_stays_pure_fence():
     # An elementwise epilogue (acc + bias): the add has a non-Mma child (bias from ld.global), so it is
-    # NOT a reduction over the MMA output -> the clean tiling-invariant fence, no "mma+red" (must not
-    # over-split the pure GEMMs, e.g. gemm_bias_relu).
+    # NOT a reduction over the MMA output, and it sits outside the fold -> the clean tiling-invariant
+    # fence (must not over-split the pure GEMMs, e.g. gemm_bias_relu).
     (desc, ) = forward_module_descriptor(
-        _mma_body(_WGMMA4 + "ld.global.f32 %f5, [%rd2];\nadd.f32 %f6, %f1, %f5;\n"
-                  "st.global.f32 [%rd2], %f6;\n"))
-    assert desc.startswith("mma|") and "mma+red" not in desc
+        _mma_fold(32, epilogue="ld.global.f32 %f5, [%rd2];\nadd.f32 %f1, %f1, %f5;\n"))
+    assert desc.startswith("mma|") and "fwd-incomplete" not in desc
+
+
+def test_epilogue_arithmetic_does_not_trip_the_fold():
+    # The same fp op AFTER the loop (gemm_bias_relu's elementwise epilogue) cannot regroup the k-fold,
+    # so the recognizer must stay LOOP-SCOPED: the chunk steps still merge on the pure fence.
+    epi = "ld.global.f32 %f5, [%rd2];\nfma.rn.f32 %f1, %f1, %f5, %f5;\n"
+    a = forward_module_descriptor(_mma_fold(32, epilogue=epi))
+    b = forward_module_descriptor(_mma_fold(64, epilogue=epi))
+    assert a == b and "loops=" not in a[0] and "fwd-incomplete" not in a[0]
 
 
 def test_mma_reduction_orders_do_not_over_merge():

--- a/bitequiv/tests/test_ptx_forward.py
+++ b/bitequiv/tests/test_ptx_forward.py
@@ -14,8 +14,9 @@ from pyptx.parser import parse
 from bitequiv.ptx.builder import _postorder, collapse_balanced
 from bitequiv.ptx.forward.interp import ForwardInterp, forward_module_descriptor
 from bitequiv.ptx.treeir import FpOp, ITreeReduce, Leaf, OpaqueOp, ShflCombine
+from bitequiv.ptx_reduction import ptx_header
 
-_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+_HDR = ptx_header()
 
 _FIX = os.path.join(os.path.dirname(__file__), "fixtures", "ptx")
 

--- a/bitequiv/tests/test_ptx_forward_cfg.py
+++ b/bitequiv/tests/test_ptx_forward_cfg.py
@@ -5,8 +5,9 @@ from bitequiv.ptx.affine import AffineEval, reqntid_of
 from bitequiv.ptx.forward.cfg import has_unknown_control, predicated_insts
 from bitequiv.ptx.forward.predicate import PredicateDecoder
 from bitequiv.ptx.linker import DefUse, linearize
+from bitequiv.ptx_reduction import ptx_header
 
-_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+_HDR = ptx_header()
 
 
 def _entry(body):

--- a/bitequiv/tests/test_ptx_gemm_splitk.py
+++ b/bitequiv/tests/test_ptx_gemm_splitk.py
@@ -8,9 +8,9 @@ from pyptx.parser import parse
 
 from bitequiv.ptx.forward import loops
 from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
-from bitequiv.ptx_reduction import _ensure_header
+from bitequiv.ptx_reduction import _ensure_header, ptx_header
 
-_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+_HDR = ptx_header()
 _MMA = "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r3}, %r4, %r5;\n"
 
 

--- a/bitequiv/tests/test_ptx_loops.py
+++ b/bitequiv/tests/test_ptx_loops.py
@@ -79,3 +79,94 @@ def test_innermost_and_own_body_pure():
     assert loops.innermost_loop(4, lps) == (3, 6)
     assert loops.innermost_loop(1, lps) == (0, 9)
     assert loops.own_body(dummy, (0, 9), lps) == [0, 1, 2, 7, 8, 9]  # outer's own body = range minus nested
+
+
+# -- is_pure_mma_fold: the POSITIVE recognizer behind the MMA chunk (BLOCK_K) fence ----------
+# A tensor-core K-loop may be re-chunked bit-for-bit only when one iteration contributes nothing but
+# MMA products to an accumulator nothing else touches. Everything else fails closed.
+
+_MMA = "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%f1}, %rd2, %rd3;\n"
+
+
+def _fold(in_loop="", epilogue=""):
+    return """
+.visible .entry k(.param .u64 p) {
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<4>;
+  ld.param.u64 %rd1, [p];
+  mov.b32 %r2, 0;
+$L__K:
+""" + _MMA + in_loop + """  add.s32 %r2, %r2, 32;
+  setp.lt.s32 %p1, %r2, 1024;
+  @%p1 bra $L__K;
+""" + epilogue + """  st.global.f32 [%rd1], %f1;
+  ret;
+}
+"""
+
+
+def test_pure_mma_fold_true():
+    assert loops.is_pure_mma_fold(_entry(_fold())) is True
+
+
+def test_pure_mma_fold_false_on_in_loop_arithmetic():
+    # A compensation product summed INSIDE the fold (the tf32x3 shape) -> the chunking is bit-relevant.
+    assert loops.is_pure_mma_fold(_entry(_fold(in_loop="  sub.f32 %f5, %f6, %f7;\n"))) is False
+
+
+def test_pure_mma_fold_false_when_accumulator_read_in_loop():
+    # Reading the MMA accumulator back inside the fold (Flash Attention's per-iteration rescale) breaks
+    # the "accumulate now, consume later" shape. Uses a NON-fp reader so this pins the accumulator rule
+    # rather than the in-loop-arithmetic rule.
+    assert loops.is_pure_mma_fold(_entry(_fold(in_loop="  mov.b32 %r5, %f1;\n"))) is False
+
+
+def test_pure_mma_fold_true_with_epilogue_arithmetic():
+    # The recognizer is LOOP-SCOPED: an elementwise epilogue after the loop cannot regroup the k-fold.
+    assert loops.is_pure_mma_fold(_entry(_fold(epilogue="  fma.rn.f32 %f1, %f1, %f4, %f5;\n"))) is True
+
+
+def test_pure_mma_fold_true_for_split_k_outer_combine():
+    # split-K: an OUTER loop combines whole MMA partials (`acc += partial`) around the INNER K-loop.
+    # That regrouping is num_splits, which `reduction_trip_signature` fences separately, so the K fold
+    # itself stays proven pure and BLOCK_M / BLOCK_N / BLOCK_K recovery survives.
+    split_k = """
+.visible .entry k(.param .u64 p) {
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<4>;
+  ld.param.u64 %rd1, [p];
+  mov.f32 %f2, 0f00000000;
+  mov.b32 %r1, 0;
+$L__OUTER:
+  mov.b32 %r2, 0;
+$L__INNER:
+""" + _MMA + """  add.s32 %r2, %r2, 32;
+  setp.lt.s32 %p1, %r2, 1024;
+  @%p1 bra $L__INNER;
+  add.f32 %f2, %f2, %f1;
+  add.s32 %r1, %r1, 1;
+  setp.lt.s32 %p2, %r1, 4;
+  @%p2 bra $L__OUTER;
+  st.global.f32 [%rd1], %f2;
+  ret;
+}
+"""
+    assert loops.is_pure_mma_fold(_entry(split_k)) is True
+
+
+def test_pure_mma_fold_false_without_a_recovered_fold():
+    # No back-edge at all (fully unrolled / unrecognized): nothing is proven, so fail closed.
+    unrolled = """
+.visible .entry k(.param .u64 p) {
+  .reg .f32 %f<8>;
+  .reg .b64 %rd<4>;
+  ld.param.u64 %rd1, [p];
+""" + _MMA + """  st.global.f32 [%rd1], %f1;
+  ret;
+}
+"""
+    assert loops.is_pure_mma_fold(_entry(unrolled)) is False

--- a/bitequiv/tests/test_ptx_mma.py
+++ b/bitequiv/tests/test_ptx_mma.py
@@ -26,18 +26,27 @@ _WGMMA = "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r1}, %r2, %r3;\n
 _MMA_SYNC = "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%r1}, {%r2}, {%r3}, {%r4};\n"
 
 
-def test_k_kept_tile_dropped_dtypes_kept():
+def test_native_k_and_tile_dropped_family_kept():
+    # The canonical token keeps only the accumulation dtype FAMILY. The m/n tile AND the native k are
+    # dropped: native k is fixed per family (carries no extra bit-relevant info) and keeping it would
+    # block the v2==v5 merge, since tcgen05 has no k modifier.
     tok = _tok(_WGMMA)
-    assert "k16" in tok and "m64" not in tok and "n128" not in tok and ".f16" in tok
+    assert tok == "matmul|f16|cta1" and "k16" not in tok and "m64" not in tok
 
 
-def test_wgmma_vs_mma_sync_distinct():
-    assert _tok(_WGMMA) != _tok(_MMA_SYNC)
+def test_wgmma_and_mma_sync_and_tcgen05_merge():
+    # Form-invariant: mma.sync (v2), wgmma, and tcgen05 (v5) computing the same matmul get the SAME
+    # token -- bit-identical for f16/bf16/tf32 (exact products + shared F=25 accumulate; see _mma_token).
+    tcg = _tok("tcgen05.mma.cta_group::1.kind::f16 [%r1], %r2, %r3;\n")
+    assert _tok(_WGMMA) == _tok(_MMA_SYNC) == tcg == "matmul|f16|cta1"
 
 
-def test_tcgen05_keeps_kind_and_cta_group():
-    tok = _tok("tcgen05.mma.cta_group::1.kind::f16 [%r1], %r2, %r3;\n")
-    assert "kind::f16" in tok and "cta_group::1" in tok and tok.startswith("tcgen05|")
+def test_tcgen05_canonical_and_fp8_kept_distinct():
+    # Non-fp8 tcgen05 -> the canonical matmul token (merges with v2). fp8 (kind::f8f6f4) is the v2!=v5
+    # exception: it keeps the native tcgen05 form so it never merges into matmul|.
+    assert _tok("tcgen05.mma.cta_group::1.kind::f16 [%r1], %r2, %r3;\n") == "matmul|f16|cta1"
+    fp8 = _tok("tcgen05.mma.cta_group::1.kind::f8f6f4 [%r1], %r2, %r3;\n")
+    assert fp8.startswith("tcgen05|") and "kind::f8f6f4" in fp8
 
 
 def test_wgmma_fence_wait_is_not_a_matmul():
@@ -61,12 +70,15 @@ def test_proportional_tiling_reduces_to_same_fence():
     assert one == two
 
 
-def test_k_split_stays_distinct():
-    k16 = _mma_fence(_entry(_WGMMA + "add.f32 %f1, %f2, %f3;\n"))
-    k32 = _mma_fence(_entry(
-        "wgmma.mma_async.sync.aligned.m64n128k32.f32.f16.f16 {%r1}, %r2, %r3;\n"
+def test_dtype_family_stays_distinct():
+    # Different accumulation families must NOT merge (different rounding). f16 vs tf32. (The native tile
+    # k is dropped -- it is fixed per family -- so it is no longer a splitter; the real K regrouping,
+    # split-K, rides splits= and is covered in test_ptx_gemm_splitk.)
+    f16 = _mma_fence(_entry(_WGMMA + "add.f32 %f1, %f2, %f3;\n"))
+    tf32 = _mma_fence(_entry(
+        "wgmma.mma_async.sync.aligned.m64n128k8.f32.tf32.tf32 {%r1}, %r2, %r3;\n"
         "add.f32 %f1, %f2, %f3;\n"))
-    assert k16 != k32
+    assert f16 != tf32
 
 
 def test_fp8_falls_back_to_conservative():

--- a/bitequiv/tests/test_ptx_mma.py
+++ b/bitequiv/tests/test_ptx_mma.py
@@ -3,8 +3,9 @@ from pyptx.parser import parse
 
 from bitequiv.ptx.linker import linearize
 from bitequiv.ptx.mma import _is_mma, _mma_fence, _mma_token
+from bitequiv.ptx_reduction import ptx_header
 
-_HDR = ".version 8.5\n.target sm_90a\n.address_size 64\n"
+_HDR = ptx_header()
 
 
 def _entry(body):


### PR DESCRIPTION
Summary:
The forward PTX checker drops the `loops=` chunk (BLOCK_K) fence for a tensor-core entry when `_fence_all_matmul(fence)` holds. That predicate only answers "is every tensor-core op in the matmul family?", but the code read it as "so this is a plain GEMM, and re-chunking its K loop cannot change the bits". That is an open-world guess: any tensor-core kernel that is NOT a plain GEMM also passes it and silently loses its chunk fence. `input_precision=tf32x3` is the measured victim - the 3-pass f32 emulation splits each f32 into tf32 parts and sums the compensation products INSIDE the K loop, so its BLOCK_K IS bit-relevant, yet the descriptor carried no chunk term at all. On `gemm/f32` `input_precision=tf32x3` (529 configs) the ground truth is 4 bit classes, exactly the 4 `gemm_block_k` values {16,32,64,128}; the checker returned 28 classes and OVER-MERGED 50472 config pairs.

The fix replaces the negative pattern match with a positive recognizer, `is_pure_mma_fold` in `bitequiv/ptx/forward/loops.py`. For every loop that ISSUES an MMA (an MMA in its own body) it checks, over the loop's whole range, that no non-MMA instruction computes a floating-point value, that no non-MMA instruction reads an MMA accumulator register, and that no `tcgen05.ld` reads the tensor-memory accumulator. That is the structural statement of "one iteration contributes nothing but MMA products to an accumulator nothing else touches", which is what makes any re-chunking issue the same dot products in the same order. The chunk fence is dropped only when the fold is proven pure AND the MMA family accumulates exactly (`_fence_all_matmul` keeps its dtype job, and its docstring now says so) AND nothing reduces over the MMA output. The recognizer is structure-derived only - no kernel names, no tile shapes, no `input_precision` test - so precision emulation, attention, implicit-GEMM convolution and any future non-GEMM tensor-core loop land on the conservative side with no new case. An outer loop that combines whole MMA partials (split-K: `acc += partial`, no MMA of its own) is deliberately not a fold here, because `reduction_trip_signature` already fences its regrouping through `splits=`.

When the proof fails the descriptor falls back to the conservative per-config fingerprint, the same one the MMA-output-reduction branch already uses - NOT to `loops=` alone. `loops=` is the multiset of loop pointer self-increments, and a `tcgen05` fold increments no pointer, so it is empty exactly where the proof failed. This is real, not hypothetical: corpus config `gemm_kgroup/bf16/23e3d212bfe44d3f.ptx` is a v5 `tcgen05` split-K GEMM whose pre-fix descriptor is `mma|tok=matmul|f16|cta1|fl=|epi=fma0,addmul1|splits=0e3c00bf` - no chunk term of any kind, and keeping `loops=` would have added nothing. With the fix the fingerprint rides and carries the chunk-bearing terms.

Support table. All rows are cached-PTX grades of the local corpus at `/home/youngzt/bitwise-equiv/local_evaluation/corpus`, comparing the checker partition against the empirical (run-the-kernel, 20 seeds) partition. Before and after are computed on the SAME configs in the same process, so the populations are identical by construction; the before column was cross-checked against a separate run of the committed code over 20961 shared configs with 0 mismatches. `OM` = over-merged pairs (soundness violations, must be 0).

The bug case and the GEMM recovery rows:

| kernel | dtype | slice | configs | empirical classes | checker before | checker after | OM before | OM after |
|---|---|---|---|---|---|---|---|---|
| `gemm` | f32 | `input_precision=tf32x3` | 529 | 4 | 28 | 497 | 50472 | 0 |
| `gemm` | f32 | `input_precision=tf32` | 807 | 1 | 1 | 1 | 0 | 0 |
| `gemm` | f32 | `input_precision=ieee` | 3465 | 1 | 849 | 849 | 0 | 0 |
| `gemm` | bf16 | all | 4047 | 1 | 1 | 1 | 0 | 0 |
| `gemm` | f16 | all | 4027 | 1 | 1 | 1 | 0 | 0 |
| `gemm` | fp8 | all | 3141 | 2 | 2 | 2 | 0 | 0 |
| `gemm_bias_relu_fp_fusion` | bf16 | all | 192 | 1 | 1 | 1 | 0 | 0 |
| `gemm_tma_store` | f16 | all | 18 | 1 | 1 | 1 | 0 | 0 |
| `gemm_reduce_sum` | f32 | all | 270 | 9 | 60 | 60 | 0 | 0 |
| `gemm_softmax` | f32 | all | 270 | 9 | 60 | 60 | 0 | 0 |
| `gemm_kgroup` | bf16 | all | 1152 | 6 | 17 | 133 | 0 | 0 |

The bug is gone and the recovery it was paying for is intact: `tf32x3` drops from 50472 over-merged pairs to 0 and no checker class spans two `gemm_block_k` values any more (4 did before), while `tf32` keeps its single class over all 4 `gemm_block_k` values and still merges mma v2 with v5 (663 v2 + 144 v5 in one class). `gemm` bf16/f16/fp8, `gemm_bias_relu_fp_fusion` and `gemm_tma_store` are byte-identical, including the block_k merge in `gemm_bias_relu_fp_fusion` whose fma sits in the elementwise epilogue AFTER the K loop - the recognizer is loop-scoped, so an epilogue op does not trip it.

The one recovery cost is `gemm_kgroup/bf16`: 17 to 133 checker classes (6 empirical), still sound at OM 0. Those are Blackwell split-K configs whose persistent outer loop both issues MMAs and reads the tensor-memory accumulator back with `tcgen05.ld` inside the same loop, so the fold is genuinely not "accumulate now, consume later" and fails closed. The other 83% of that kernel's configs (960 of 1152) stay recovered through the split-K carve-out.

The f16 and fp8 whole-corpus sweep (the standing dtype policy) - 27 groups, 16805 configs: `LC_splitk_gemm_f16`, `LC_sum_loop_f16`, `col_dot`, `col_max`, `col_sum_loop`, `cond_reduce`, `dot`, `flash_attention` (f16, fp8, fp8e5m2), `gemm` (f16, fp8), `gemm_tma_store`, `layernorm`, `rmsnorm`, `softmax`, `sum`, `sum_2d_axis0`, `sum_2d_col`, `sum_2d_col_big`, `sum_2d_deep`, `sum_2d_keepdim`, `sum_3d`, `sum_3d_mid`, `sum_3d_outer`, `sum_4d`, `sum_multiaxis`. Every one of them has an IDENTICAL partition before and after - not merely the same class count, the same grouping of configs - so zero regressions and zero new over-merges. Over the whole graded corpus (35 groups, 27825 configs) over-merges go from 50595 to 123, and the 123 are the pre-existing `flash_attention/f16` over-merge described below.

Robustness. The measured population is the local cached-PTX corpus as of this run: 27825 feasible configs over 35 (kernel, dtype) groups, all graded at 20 fuzz seeds except the flash-attention groups, and compared only within a group. The corpus was still growing while the sweep ran (a background `build_gemm_knobs` job), so the `gemm` rows are larger than earlier measurements of the same defect and will keep growing; the before/after columns are always the same population. Nothing outside the tensor-core descriptor moves: entries with no MMA (including `gemm/f32 input_precision=ieee`, which has no tensor-core op at all) never reach this code, and every pure-reduction group in the sweep is unchanged. Known limitations: the recognizer proves a fold pure only when the loop back-edge is recovered, so a fully unrolled K loop fails closed; it reasons per loop, so a loop-carried value that is neither a self-accumulating fp combine nor an MMA accumulator is still invisible to it (that blind spot predates this diff and is shared with `loop_accumulates`); and the fail-closed fingerprint is coarse, which is why `tf32x3` lands at 497 classes for 4 bit classes - recovering it needs a positive model of the 3-pass emulation, not a looser fence, and is left as follow-up. Finally, `flash_attention/f16` carries a PRE-EXISTING over-merge of 123 pairs (2720 configs, 266 empirical classes) that this diff does not touch: those configs already rode the fingerprint through the MMA-output-reduction branch, so their descriptors are unchanged, before and after. This diff makes flash attention conservative BY PROOF rather than by the accident of containing a `shfl.bfly`, but it neither fixes nor worsens that separate defect.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D114312238


