### PR TITLE
[triton][Modulo Scheduling] Add native Z3 constraint encoder (#2765)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(TRITON_BUILD_WITH_CCACHE "Build with ccache (if available)" ON)
 option(TRITON_BUILD_TLX "Build Triton TLX" ON)
 option(TRITON_OFFLINE_BUILD "Build without downloading dependencies" OFF)
 option(TRITON_EXT_ENABLED "Build with default visibility for Triton+LLVM symbol exposure to plugin extensions" OFF)
+option(TRITON_ENABLE_Z3_JOINT_SOLVER "Enable the native Z3 joint modulo scheduler" OFF)
 set(TRITON_CODEGEN_BACKENDS "" CACHE STRING "Enable different codegen backends")
 set(TRITON_VERSION "" CACHE STRING "Triton version string (passed from setup.py)")
 
@@ -231,6 +232,9 @@ find_package(MLIR REQUIRED CONFIG PATHS ${MLIR_DIR})
 
 list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+if(TRITON_ENABLE_Z3_JOINT_SOLVER)
+  find_package(Z3 REQUIRED)
+endif()
 
 include(TableGen) # required by AddMLIR
 include(AddLLVM)

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_triton_library(TritonGPUModuloCore
   ModuloScheduling/ModuloReservationTable.cpp
   ModuloScheduling/SwingScheduler.cpp
   ModuloScheduling/ExhaustiveScheduler.cpp
+  ModuloScheduling/Z3ConstraintEncoder.cpp
   ModuloScheduling/ModuloScheduleGraph.cpp
 
   LINK_LIBS PUBLIC
@@ -17,6 +18,14 @@ add_triton_library(TritonGPUModuloCore
   TritonGPUIR
   MLIRTransformUtils
 )
+
+if(TRITON_ENABLE_Z3_JOINT_SOLVER)
+  target_compile_definitions(TritonGPUModuloCore
+    PRIVATE TRITON_ENABLE_Z3_JOINT_SOLVER=1
+  )
+  target_include_directories(TritonGPUModuloCore PRIVATE ${Z3_INCLUDE_DIR})
+  target_link_libraries(TritonGPUModuloCore PUBLIC ${Z3_LIBRARIES})
+endif()
 
 add_triton_library(NVHopperTransforms
   MultiCTAReduction.cpp

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/Z3ConstraintEncoder.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/Z3ConstraintEncoder.cpp
@@ -1,0 +1,111 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "Z3ConstraintEncoder.h"
+
+#ifdef TRITON_ENABLE_Z3_JOINT_SOLVER
+
+#include <algorithm>
+#include <string>
+
+namespace mlir::triton::gpu {
+namespace {
+
+static std::string toDecimalString(__int128 value) {
+  bool negative = value < 0;
+  unsigned __int128 magnitude =
+      negative ? static_cast<unsigned __int128>(-(value + 1)) + 1
+               : static_cast<unsigned __int128>(value);
+  std::string result;
+  do {
+    result.push_back(static_cast<char>('0' + magnitude % 10));
+    magnitude /= 10;
+  } while (magnitude != 0);
+  if (negative)
+    result.push_back('-');
+  std::reverse(result.begin(), result.end());
+  return result;
+}
+
+} // namespace
+
+Z3ConstraintEncoder::Z3ConstraintEncoder(Z3_context context, Z3_solver solver)
+    : context(context), solver(solver), intSort(Z3_mk_int_sort(context)) {}
+
+Z3_ast Z3ConstraintEncoder::intValue(int64_t value) const {
+  return Z3_mk_int64(context, value, intSort);
+}
+
+Z3_ast Z3ConstraintEncoder::wideIntValue(__int128 value) const {
+  std::string storage = toDecimalString(value);
+  return Z3_mk_numeral(context, storage.c_str(), intSort);
+}
+
+Z3_ast Z3ConstraintEncoder::variable(llvm::StringRef name) const {
+  std::string storage = name.str();
+  return Z3_mk_const(context, Z3_mk_string_symbol(context, storage.c_str()),
+                     intSort);
+}
+
+Z3_ast Z3ConstraintEncoder::add(Z3_ast lhs, Z3_ast rhs) const {
+  Z3_ast args[] = {lhs, rhs};
+  return Z3_mk_add(context, 2, args);
+}
+
+Z3_ast Z3ConstraintEncoder::sub(Z3_ast lhs, Z3_ast rhs) const {
+  Z3_ast args[] = {lhs, rhs};
+  return Z3_mk_sub(context, 2, args);
+}
+
+Z3_ast Z3ConstraintEncoder::mul(Z3_ast lhs, Z3_ast rhs) const {
+  Z3_ast args[] = {lhs, rhs};
+  return Z3_mk_mul(context, 2, args);
+}
+
+Z3_ast Z3ConstraintEncoder::sum(llvm::ArrayRef<Z3_ast> terms) const {
+  if (terms.empty())
+    return intValue(0);
+  if (terms.size() == 1)
+    return terms.front();
+  return Z3_mk_add(context, static_cast<unsigned>(terms.size()), terms.data());
+}
+
+Z3_ast Z3ConstraintEncoder::conjunction(llvm::ArrayRef<Z3_ast> terms) const {
+  if (terms.empty())
+    return Z3_mk_true(context);
+  if (terms.size() == 1)
+    return terms.front();
+  return Z3_mk_and(context, static_cast<unsigned>(terms.size()), terms.data());
+}
+
+Z3_ast Z3ConstraintEncoder::disjunction(llvm::ArrayRef<Z3_ast> terms) const {
+  if (terms.empty())
+    return Z3_mk_false(context);
+  if (terms.size() == 1)
+    return terms.front();
+  return Z3_mk_or(context, static_cast<unsigned>(terms.size()), terms.data());
+}
+
+Z3_ast Z3ConstraintEncoder::maximum(llvm::ArrayRef<Z3_ast> terms) const {
+  if (terms.empty())
+    return intValue(0);
+  Z3_ast result = terms.front();
+  for (Z3_ast term : terms.drop_front())
+    result = maximum(result, term);
+  return result;
+}
+
+Z3_ast Z3ConstraintEncoder::maximum(Z3_ast lhs, Z3_ast rhs) const {
+  return Z3_mk_ite(context, Z3_mk_ge(context, lhs, rhs), lhs, rhs);
+}
+
+Z3_ast Z3ConstraintEncoder::implies(Z3_ast premise, Z3_ast conclusion) const {
+  return Z3_mk_implies(context, premise, conclusion);
+}
+
+void Z3ConstraintEncoder::assertFormula(Z3_ast formula) const {
+  Z3_solver_assert(context, solver, formula);
+}
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_ENABLE_Z3_JOINT_SOLVER

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/Z3ConstraintEncoder.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/Z3ConstraintEncoder.h
@@ -1,0 +1,59 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#ifndef TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_Z3_CONSTRAINT_ENCODER_H
+#define TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_Z3_CONSTRAINT_ENCODER_H
+
+#ifdef TRITON_ENABLE_Z3_JOINT_SOLVER
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+
+#if __has_include("third-party/z3/4_15_2/src/api/z3.h")
+#include "third-party/z3/4_15_2/src/api/z3.h"
+#elif __has_include(<z3.h>)
+#include <z3.h>
+#elif __has_include(<api/z3.h>)
+#include <api/z3.h>
+#else
+#error "Z3 headers are unavailable"
+#endif
+
+namespace mlir::triton::gpu {
+
+/// Typed facade for constructing integer Z3 constraints used by the native
+/// modulo-scheduling models. Context and solver ownership stays with the
+/// caller; this class only creates expressions and records assertions.
+class Z3ConstraintEncoder {
+public:
+  Z3ConstraintEncoder(Z3_context context, Z3_solver solver);
+
+  Z3_ast intValue(int64_t value) const;
+  Z3_ast wideIntValue(__int128 value) const;
+  Z3_ast variable(llvm::StringRef name) const;
+
+  Z3_ast add(Z3_ast lhs, Z3_ast rhs) const;
+  Z3_ast sub(Z3_ast lhs, Z3_ast rhs) const;
+  Z3_ast mul(Z3_ast lhs, Z3_ast rhs) const;
+  Z3_ast sum(llvm::ArrayRef<Z3_ast> terms) const;
+  Z3_ast conjunction(llvm::ArrayRef<Z3_ast> terms) const;
+  Z3_ast disjunction(llvm::ArrayRef<Z3_ast> terms) const;
+  Z3_ast maximum(llvm::ArrayRef<Z3_ast> terms) const;
+  Z3_ast maximum(Z3_ast lhs, Z3_ast rhs) const;
+  Z3_ast implies(Z3_ast premise, Z3_ast conclusion) const;
+
+  void assertFormula(Z3_ast formula) const;
+  Z3_context getContext() const { return context; }
+
+private:
+  Z3_context context;
+  Z3_solver solver;
+  Z3_sort intSort;
+};
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_ENABLE_Z3_JOINT_SOLVER
+
+#endif // TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_Z3_CONSTRAINT_ENCODER_H

--- a/unittest/Hopper/CMakeLists.txt
+++ b/unittest/Hopper/CMakeLists.txt
@@ -5,3 +5,16 @@ add_triton_ut(
     MLIRIR
     MLIRSupport
 )
+
+add_triton_ut(
+  NAME Z3ConstraintEncoderTest
+  SRCS z3_constraint_encoder_test.cpp
+  LIBS
+    TritonGPUModuloCore
+)
+
+if(TRITON_ENABLE_Z3_JOINT_SOLVER)
+  target_compile_definitions(Z3ConstraintEncoderTest
+    PRIVATE TRITON_ENABLE_Z3_JOINT_SOLVER=1
+  )
+endif()

--- a/unittest/Hopper/z3_constraint_encoder_test.cpp
+++ b/unittest/Hopper/z3_constraint_encoder_test.cpp
@@ -1,0 +1,48 @@
+#include "third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/Z3ConstraintEncoder.h"
+
+#include <gtest/gtest.h>
+
+#ifdef TRITON_ENABLE_Z3_JOINT_SOLVER
+
+namespace mlir::triton::gpu {
+namespace {
+
+TEST(Z3ConstraintEncoderTest, EncodesIntegerConstraints) {
+  Z3_config config = Z3_mk_config();
+  ASSERT_NE(config, nullptr);
+  Z3_context context = Z3_mk_context(config);
+  Z3_del_config(config);
+  ASSERT_NE(context, nullptr);
+
+  Z3_solver solver = Z3_mk_solver(context);
+  ASSERT_NE(solver, nullptr);
+  Z3_solver_inc_ref(context, solver);
+
+  Z3ConstraintEncoder encoder(context, solver);
+  Z3_ast x = encoder.variable("x");
+  Z3_ast y = encoder.variable("y");
+  encoder.assertFormula(Z3_mk_ge(context, x, encoder.intValue(0)));
+  encoder.assertFormula(
+      Z3_mk_eq(context, y, encoder.add(x, encoder.intValue(3))));
+  encoder.assertFormula(
+      Z3_mk_eq(context, encoder.maximum(x, y), encoder.intValue(5)));
+
+  ASSERT_EQ(Z3_solver_check(context, solver), Z3_L_TRUE);
+  Z3_model model = Z3_solver_get_model(context, solver);
+  ASSERT_NE(model, nullptr);
+  Z3_model_inc_ref(context, model);
+  Z3_ast value = nullptr;
+  int64_t integer = 0;
+  ASSERT_TRUE(Z3_model_eval(context, model, x, true, &value));
+  ASSERT_TRUE(Z3_get_numeral_int64(context, value, &integer));
+  EXPECT_EQ(integer, 2);
+
+  Z3_model_dec_ref(context, model);
+  Z3_solver_dec_ref(context, solver);
+  Z3_del_context(context);
+}
+
+} // namespace
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_ENABLE_Z3_JOINT_SOLVER


### PR DESCRIPTION
Summary:

Add a reusable in-process Z3 integer constraint encoder with CMake/Buck integration and focused unit tests. This base layer does not enable a compiler pass or encode a scheduling model. Authored with Codex.

Reviewed By: wlei-llvm

Differential Revision: D114956425


