### PR TITLE
[triton][bitequiv] cuBLAS-equivalent GEMM: now supports GB300 (sm_103) (#2768)

### DIFF
--- a/bitequiv/cublas_equiv_gemm.py
+++ b/bitequiv/cublas_equiv_gemm.py
@@ -126,20 +126,23 @@ class CublasUnsupportedShape(Exception):
 class CublasUnsupportedPlatform(CublasUnsupportedShape):
     """No measured strategy for this GPU architecture.
 
-    Every reconstruction rule in this file is architecture-specific and was measured, not
-    derived, so it must not be extrapolated: the sm_103 rules did not carry over to sm_100 when
-    that move was tried. Subclasses `CublasUnsupportedShape` on purpose, so a caller that
-    already writes `except CublasUnsupportedShape: <fall back to cuBLAS>` keeps working
-    unchanged on a machine we have not measured."""
+    Every reconstruction rule in this file was measured on a GPU, not derived, so it must not be
+    extrapolated to one we have not run on -- even though sm_100 and sm_103 did turn out to
+    agree. Subclasses `CublasUnsupportedShape` on purpose, so a caller that already writes
+    `except CublasUnsupportedShape: <fall back to cuBLAS>` keeps working unchanged on a machine
+    we have not measured."""
 
 
 # --------------------------------------------------------------------------- #
 # Per-platform strategy
 #
 # PORTING GUIDE. Everything cuBLAS-specific in this file lives in an ArchProfile below, so
-# adding a GPU is filling in one dataclass -- no dispatch code changes. Nothing here may be
-# guessed from another architecture: when the sm_103 rules were carried over to sm_100 they
-# were wrong, and the same is expected in reverse. Each field says how to measure it.
+# adding a GPU is filling in one dataclass -- no dispatch code changes. Each field says how to
+# measure it, and measuring is the point: sm_103 turned out to share every sm_100 table but one
+# gemv row, but that was established by re-reading each kernel family on a GB300, not by
+# assuming it. An earlier attempt to carry rules the other way, from sm_103 to sm_100, was
+# wrong -- though those rules were an earlier and buggier design, so that failure is weak
+# evidence about the architectures and strong evidence about guessing.
 #
 # The gate is (compute capability, cuBLASLt version). The cuBLASLt library we call through
 # ctypes is what decides the kernels -- its name literally carries the arch, e.g.
@@ -317,6 +320,10 @@ _SM100 = ArchProfile(
         # not imply the same order. Customs 45, 62 and 63 share one signature and have three
         # different recipes. The shortcut does hold for gemv2N/gemv2T_kernel_val, where the ints
         # in the signature are the parameters.
+        #
+        # Custom 8 was only ever reached at K under 80 here, and below one chunk length a chunked
+        # recipe and an unbounded one are the same kernel, so this row is not discriminating above
+        # that. sm_103 reads a 256-k chunk for it; see `_SM103`.
         ((13, 0), (1, 1, 0, False)), ((13, 6), (1, 1, 0, False)), ((13, 7), (1, 1, 0, False)),
         ((13, 8), (1, 1, 0, False)), ((13, 84), (1, 1, 0, False)), ((13, 14), (1, 16, 16, False)),
         ((13, 36), (-64, 32, 0, True)), ((13, 37), (1, 32, 0, True)), ((13, 40), (-64, 4, 0, True)),
@@ -363,10 +370,37 @@ _SM100 = ArchProfile(
 )
 
 
-# Placeholders. Fill in the fields above on the machine in question and flip `measured=True`;
-# the dispatch, the kernels and the eval need no changes. Re-measure every field -- the values
-# in `_SM100` are not a starting point, they are a different architecture's answer.
-_SM103 = ArchProfile(name="sm_103 (NVIDIA GB300)")
+def _with_row(table, key, value):
+    """One row of a measured table replaced, for an architecture that shares all the others."""
+    assert any(k == key for k, _ in table), key
+    return tuple((k, value if k == key else v) for k, v in table)
+
+
+# sm_103 shares every sm_100 table but one gemv row. That is a measurement, not an assumption:
+# each family was re-read on a GB300 against cuBLASLt 13.1.1 -- the same version `_SM100` was
+# measured against, so a difference here would be architecture and not library. 449,520 shapes,
+# 0 declined, 2,174,951 of 2,179,476 byte-compares bit-identical, and every mismatch is the
+# known nvjet deep-K tail. The two gemv families were read with the floating-point probe rather
+# than a byte-compare, because a wrong gemv recipe survives most random inputs: a deliberately
+# wrong `ALGO 14` plan still byte-matched on 91.7% of shapes, so a pass rate proves nothing
+# there. `sm_count` and `threads_per_sm` are the same 152 and 2048 as sm_100, and the
+# `CUSTOM_OPTION 10` cap was re-read at exactly the 9728 elements that predicts.
+_SM103 = dataclasses.replace(
+    _SM100,
+    name="sm_103 (NVIDIA GB300)",
+    measured=True,
+    cublaslt_versions=((13, 1), ),
+    measured_cublaslt="13.1.1",
+    # `CUSTOM_OPTION 8` closes an accumulator group every 256 k here, read off an adjacent-L
+    # boundary scan. The sm_100 row says unbounded, which is the same kernel while K <= 256 and
+    # diverges above it -- byte-equal 15/15 with this row against 7/15 with sm_100's.
+    gemv_recipe=_with_row(_SM100.gemv_recipe, (13, 8), (1, 1, 256, False)),
+)
+
+# Placeholder. Fill in the fields above on the machine in question and flip `measured=True`;
+# the dispatch, the kernels and the eval need no changes. Re-measure every field rather than
+# copying `_SM100` -- sm_103 turned out to share its tables, but that was established by
+# re-reading each family on the GPU, not assumed.
 _SM90 = ArchProfile(name="sm_90 (NVIDIA H100)")
 
 _PROFILES = {(10, 0): _SM100, (10, 3): _SM103, (9, 0): _SM90}

--- a/bitequiv/cublas_gemm_bug_reproduce.py
+++ b/bitequiv/cublas_gemm_bug_reproduce.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+r"""Two fp16 cuBLASLt matrix multiplies that each leave the last 8 values of k out of the sum.
+
+A and B are all ones, so every element of C must be exactly K:
+
+    C[m][n] = sum over k = 0 .. K-1 of 1 * 1 = K
+
+                K = 8648            N = 8                N = 8
+            +-------------+      +---------+       +---------------+
+     M = 1  | 1 1 ... 1 1 | x    | 1 ... 1 |  =    | 8648 ... 8648 |  M = 1
+            +-------------+      | 1 ... 1 |       +---------------+
+                   A             |   ...   |               C
+                                 | 1 ... 1 |  K = 8648
+                                 +---------+
+                                      B
+
+Nothing rounds. A product of two ones is exact in fp32, the accumulator is fp32, and the
+output is fp32, which represents every whole number up to 2^24 exactly. So the number that
+comes back *is* the count of k values that were summed. It comes back short by a whole number,
+which is that many missing terms of `1 * 1` rather than a rounding error of any size.
+
+The three parts below are the same code with a different K. Point `CUBLASLT` at one library,
+run once, and every part runs: the ones that match your GPU and library come back short and the
+rest come back right.
+
+    part one   K =  8648  -> 8640    sm_100 or sm_103, cuBLASLt 13.1.1 / 13.2.2
+    part two   K = 57608  -> 57600   sm_103 or sm_90,  cuBLASLt 12.8.5
+    part three K = 11528  -> 11520   sm_90,            cuBLASLt 12.8.5 AND 13.1.1
+
+Measured, `.` meaning correct and `-8` meaning eight values of k left out:
+
+                       sm_100     sm_103     sm_103     sm_90      sm_90
+                       13.1.1     13.1.x     12.8.5     13.1.1     12.8.5
+    part one   8648      -8         -8          .          .          .
+    part two  57608       ?          .         -8          .         -8
+    part three 11528      ?          ?          ?         -8         -8
+
+WHY NO ONE SHAPE COVERS EVERYTHING. It is not that some versions are fixed. The loss happens
+only where cuBLASLt decides to split K across threadblocks, and that decision moves with both
+the architecture and the library. On GB300 the two libraries were nearly disjoint -- over 12,282
+shapes, 13.1.1 met the condition on 193 and 12.8.5 on 309, with **zero** overlap; at K = 8648
+12.8.5 returns SPLITK_NUM = 1 and never splits, and at K = 57608 the roles swap. On H100 they
+almost coincide instead: over 1,542,555 real GEMMs each, 13.1.1 loses k on 2,714 shapes and
+12.8.5 on 2,995, the smallest is K = 11528 for both, and they only diverge past about K = 50000.
+So the shape has to be chosen per architecture and per library, which is what the three parts
+are.
+
+THE CONDITION, the same everywhere. `block_k` is the k step of one threadblock, 64 for this
+fp16 kernel family; `q = K // block_k`; `tail = K % block_k`; `s = SPLITK_NUM`, the number of
+splits cuBLASLt picks. The tail is lost exactly when
+
+    ALGO_ID == 66   and   tail != 0   and   q % s == 0   and   s > tail
+
+    part one   q = 135, tail = 8, s =  9    135 %  9 == 0,  9 > 8
+    part two   q = 900, tail = 8, s = 45    900 % 45 == 0, 45 > 8   (on sm_90; s = 9 on sm_103)
+    part three q = 180, tail = 8, s =  9    180 %  9 == 0,  9 > 8
+
+The `ALGO_ID` part is not decoration. On sm_90, `1 x 2 x 1032` satisfies all three arithmetic
+parts and loses nothing, because it lands on `ALGO_ID 23`, a CUTLASS
+`cutlass_80_wmma_tensorop_s161616gemm_f16_32x32_64x2_nn_align2` kernel rather than on `nvjet`.
+Over 1,542,555 real GEMMs per library on H100 the four-part condition predicted every loss with
+**0 false positives and 0 false negatives**; dropping the `ALGO_ID` part misclassified 3,557
+shapes under each library. Every one of the 5,709 losses was exactly `K % block_k`.
+
+WHERE THE PIECE IS LOST, drawn for part one. K is handed out to the 9 threadblocks in whole
+blocks of 64. 8648 holds 135 whole blocks, and 135 / 9 = 15 exactly, so each takes 15 * 64 = 960:
+
+    k=0       960     1920    2880    3840    4800    5760    6720    7680    8640 8648
+      |-------|-------|-------|-------|-------|-------|-------|-------|-------|xxxx|
+        CTA 0   CTA 1   CTA 2   CTA 3   CTA 4   CTA 5   CTA 6   CTA 7   CTA 8    ^
+                                                                                 |
+                                                        these 8 belong to no CTA
+
+Every threadblock is full. The last one covers [7680, 8640), which is 15 whole blocks of 64 with
+nothing short about the last one:
+
+    CTA 8:      7680   7744           8512   8576   8640   8648
+                |--64--|--64--|  ...  |--64--|--64--|xxxxxx|
+                   t0     t1            t13    t14     ^
+                                                       |
+                                            outside every CTA
+
+And the reduction adds all 9 partial results; not one is skipped:
+
+    partial 0   partial 1   partial 2   ...   partial 8      (9 results, M x N each)
+          \          |           |             /
+           \_________|___________|____________/
+                       |
+              splitKreduce_kernel adds all 9
+                       |
+                    C[m][n]
+
+Nothing computed is thrown away, and nothing is added twice. The 9 ranges simply do not cover K:
+9 * 960 = 8640, and K is 8648. Part two is the same picture with 9 * 6400 = 57600 against 57608.
+
+THE ONE THING YOU MUST NOT DROP is the workspace. Split-K writes its partial results into it,
+so with a zero-size workspace cuBLASLt never splits and both shapes come back right -- measured,
+0 bytes gives 8648 and 57608. The script passes no algorithm at all: `cublasLtMatmul` takes NULL
+for `algo` and cuBLASLt chooses for itself. It picks the same split either way, so the heuristic
+query is no part of the bug and is not in the code; the `SPLITK_NUM` and the kernel names quoted
+here were read with a separate query.
+
+WHICH KERNELS RUN. Two, which is what split-K means: one GEMM that splits K and writes one
+partial result per threadblock, then one reduction that adds those partials. One launch each
+(names from `torch.profiler`):
+
+    13.1.1 / 13.2.2 on sm_103   nvjet_sm103_hsh_64x8_64x16_1x1_h_bz_splitK_NNT
+    13.1.1          on sm_100   nvjet_sm100_hsh_64x8_64x16_1x1_h_bz_splitK_NNT
+    13.1.1          on sm_90    nvjet_sm90_hss_64x8_64x16_1x1_h_bz_splitK_NNT
+    12.8.5          on sm_103   nvjet_hsh_64x8_64x16_1x1_v_bz_splitK_NNT
+    12.8.5          on sm_90    nvjet_hss_64x8_64x16_1x1_v_bz_splitK_NNT
+    all of them                 cublasLt::splitKreduce_kernel<32, 16, int, float, ...>
+
+All of them are the same tile family `64x8_64x16_1x1`, same `bz`, `splitK`, `NNT`. The 13.x
+names differ from each other only in the architecture tag -- the GEMM kernel is a separate
+binary per architecture, since nvjet is built at run time, yet the tile shape, the block of k,
+the cluster and the layouts are the same, so they do the same arithmetic in the same order and
+lose the same values. 12.8.5's name carries **no** architecture tag at all on either GPU, and
+rasters `v` where 13.x rasters `h`. The third letter follows the output type, `hss` for the
+fp32 output used here and `hsh` for fp16.
+
+Reading the `64x16` group as <block of k>x<stages> gives the block of 64. Do not take that from
+the `cublasLtMatmulStages_t` enum -- its `block_k = 16 << ((id-1)//6)` rule covers ids 1..24 and
+`STAGES_ID` here is 35. On sm_90 the 64 was confirmed three independent ways: the kernel name;
+two discriminating measurements (`K = 57664`, a multiple of 64, loses nothing, which rules out
+128; `K = 57632`, a multiple of 32, loses 32, which rules out 32); and every one of the 5,709
+observed losses being exactly `K % 64`.
+
+WHY THE OUTPUT IS fp32. An fp16 output cannot be trusted at part two's depth. Above 16384 the
+fp16 step is 16, so a K of the form `q * 64 + 8` sits exactly halfway between two fp16 values
+and rounds down to `q * 64` on its own. The control is K = 57616, a shape that is **correct**:
+with an fp16 output it reads 57600 and looks 16 short; with an fp32 output it reads 57616.
+Asking for fp32 does not change what the heuristic picks -- checked on 600 random shapes, all
+600 returned a bit-identical nine-field config either way, and at both shapes here.
+
+IT IS ALSO NOT THREE HAND-PICKED SHAPES. Over 496,906 random shapes on a GB300 under 13.1.1,
+1,062 came back not bit-identical to a full-K reference, and 1,059 of those meet the condition
+above. Under 12.8.5 on the same GPU, 179 shapes were flagged and all 179 lose exactly `tail`
+values of k, while 9,525,600 GEMMs at smaller K lose nothing. On H100, 2,714 shapes under 13.1.1
+and 2,995 under 12.8.5 lose k out of 1,542,555 real GEMMs each. It is not confined to skinny
+gemv-like shapes either: on H100, 363 of 885 (M, N) pairs under 13.1.1 and 416 of 885 under
+12.8.5 lose k somewhere, and 32 x 32, 64 x 64 and 128 x 128 all lose 8 at K = 11528.
+
+`torch.matmul` does not show any of this -- its path never picks this algorithm, so the call has
+to go to cuBLASLt directly. Checked on torch 2.9.1 over eight shapes, four operand layouts,
+`matmul` / `addmm` / `linear`, and with `preferred_blas_library("cublaslt")`.
+
+Point `CUBLASLT` at one library and run. Every part runs every time, so the printed lines are
+themselves the table above for your machine: the parts that match your GPU and library come back
+short, the rest come back right.
+
+    export CUBLASLT=/usr/local/cuda-13.0/lib64/libcublasLt.so   # 13.1.1 or 13.2.2
+    export CUBLASLT=/usr/local/cuda-12.8/lib64/libcublasLt.so   # 12.8.5
+    python cublas_gemm_bug_reproduce.py
+
+Needs a CUDA GPU, and PyTorch for device memory and nothing else.
+`cublaslt_splitk_tail_repro.py` next to this file is a longer version with a sweep.
+"""
+
+import ctypes
+import os
+from ctypes import byref, c_float, c_int, c_int64, c_size_t, c_uint64, c_void_p
+
+import torch
+
+# From cublasLt.h.
+CUDA_R_16F, CUDA_R_32F, CUBLAS_COMPUTE_32F = 2, 0, 68
+CUBLASLT_MATRIX_LAYOUT_ORDER, CUBLASLT_ORDER_ROW = 1, 1
+WORKSPACE_BYTES = 32 << 20
+
+# ========================================================================== #
+# PART ONE.  cuBLASLt 13.1.1 or 13.2.2, on sm_100 (GB200) or sm_103 (GB300).
+#            K = 8648: q = 135, tail = 8, SPLITK_NUM = 9.
+# ========================================================================== #
+
+# 1. cuBLASLt setup. Nothing here depends on the matrices.
+lib = ctypes.CDLL(os.environ["CUBLASLT"])
+handle, desc = c_void_p(), c_void_p()
+assert lib.cublasLtCreate(byref(handle)) == 0
+assert lib.cublasLtMatmulDescCreate(byref(desc), c_int(CUBLAS_COMPUTE_32F),
+                                    c_int(CUDA_R_32F)) == 0            # fp32 accumulate
+workspace = torch.empty(WORKSPACE_BYTES, dtype=torch.uint8, device="cuda")
+
+# 2. The input. A and B all ones, so C must be exactly K. The output is fp32 because an fp16
+#    output cannot represent 8648 exactly and would round down on its own.
+M, N, K = 1, 8, 8648
+a = torch.ones(M, K, dtype=torch.float16, device="cuda")
+b = torch.ones(K, N, dtype=torch.float16, device="cuda")
+c = torch.empty(M, N, dtype=torch.float32, device="cuda")
+layouts = []
+for rows, cols, dtype in ((M, K, CUDA_R_16F), (K, N, CUDA_R_16F), (M, N, CUDA_R_32F)):
+    layout = c_void_p()
+    assert lib.cublasLtMatrixLayoutCreate(byref(layout), c_int(dtype), c_uint64(rows),
+                                          c_uint64(cols), c_int64(cols)) == 0
+    order = c_int(CUBLASLT_ORDER_ROW)        # cuBLASLt reads column-major unless told this
+    assert lib.cublasLtMatrixLayoutSetAttribute(
+        layout, c_int(CUBLASLT_MATRIX_LAYOUT_ORDER), byref(order), c_size_t(4)) == 0
+    layouts.append(layout)
+a_layout, b_layout, c_layout = layouts
+
+# 3. One matrix multiply. `algo` is NULL, so cuBLASLt picks for itself.
+alpha, beta = c_float(1.0), c_float(0.0)
+assert lib.cublasLtMatmul(handle, desc, byref(alpha), c_void_p(a.data_ptr()), a_layout,
+                          c_void_p(b.data_ptr()), b_layout, byref(beta),
+                          c_void_p(c.data_ptr()), c_layout, c_void_p(c.data_ptr()), c_layout,
+                          None, c_void_p(workspace.data_ptr()), c_size_t(WORKSPACE_BYTES),
+                          c_void_p(torch.cuda.current_stream().cuda_stream)) == 0
+torch.cuda.synchronize()
+
+# 4. C reads back how many k values were summed. It is short by a whole number.
+part_one = c[0, 0].item()
+print(f"part one  K = {K}  C[0,0] = {part_one:.0f}  short by {K - part_one:.0f}")
+
+# ========================================================================== #
+# PART TWO.  cuBLASLt 12.8.5, on sm_103 (GB300). The same code again, with a different
+#            library and a different K = 57608: q = 900, tail = 8, SPLITK_NUM = 9.
+# ========================================================================== #
+
+# 1. cuBLASLt setup. Nothing here depends on the matrices.
+lib = ctypes.CDLL(os.environ["CUBLASLT"])
+handle, desc = c_void_p(), c_void_p()
+assert lib.cublasLtCreate(byref(handle)) == 0
+assert lib.cublasLtMatmulDescCreate(byref(desc), c_int(CUBLAS_COMPUTE_32F),
+                                    c_int(CUDA_R_32F)) == 0            # fp32 accumulate
+workspace = torch.empty(WORKSPACE_BYTES, dtype=torch.uint8, device="cuda")
+
+# 2. The input. A and B all ones, so C must be exactly K. The output is fp32 because an fp16
+#    output cannot represent 57608 exactly and would round down on its own.
+M, N, K = 1, 8, 57608
+a = torch.ones(M, K, dtype=torch.float16, device="cuda")
+b = torch.ones(K, N, dtype=torch.float16, device="cuda")
+c = torch.empty(M, N, dtype=torch.float32, device="cuda")
+layouts = []
+for rows, cols, dtype in ((M, K, CUDA_R_16F), (K, N, CUDA_R_16F), (M, N, CUDA_R_32F)):
+    layout = c_void_p()
+    assert lib.cublasLtMatrixLayoutCreate(byref(layout), c_int(dtype), c_uint64(rows),
+                                          c_uint64(cols), c_int64(cols)) == 0
+    order = c_int(CUBLASLT_ORDER_ROW)        # cuBLASLt reads column-major unless told this
+    assert lib.cublasLtMatrixLayoutSetAttribute(
+        layout, c_int(CUBLASLT_MATRIX_LAYOUT_ORDER), byref(order), c_size_t(4)) == 0
+    layouts.append(layout)
+a_layout, b_layout, c_layout = layouts
+
+# 3. One matrix multiply. `algo` is NULL, so cuBLASLt picks for itself.
+alpha, beta = c_float(1.0), c_float(0.0)
+assert lib.cublasLtMatmul(handle, desc, byref(alpha), c_void_p(a.data_ptr()), a_layout,
+                          c_void_p(b.data_ptr()), b_layout, byref(beta),
+                          c_void_p(c.data_ptr()), c_layout, c_void_p(c.data_ptr()), c_layout,
+                          None, c_void_p(workspace.data_ptr()), c_size_t(WORKSPACE_BYTES),
+                          c_void_p(torch.cuda.current_stream().cuda_stream)) == 0
+torch.cuda.synchronize()
+
+# 4. C reads back how many k values were summed. It is short by a whole number.
+part_two = c[0, 0].item()
+print(f"part two  K = {K}  C[0,0] = {part_two:.0f}  short by {K - part_two:.0f}")
+
+# ========================================================================== #
+# PART THREE. cuBLASLt 12.8.5 AND 13.1.1, on sm_90 (H100). The same code again with
+#             K = 11528: q = 180, tail = 8, SPLITK_NUM = 9. On H100 the two libraries
+#             agree, so this one shape covers both.
+# ========================================================================== #
+
+# 1. cuBLASLt setup. Nothing here depends on the matrices.
+lib = ctypes.CDLL(os.environ["CUBLASLT"])
+handle, desc = c_void_p(), c_void_p()
+assert lib.cublasLtCreate(byref(handle)) == 0
+assert lib.cublasLtMatmulDescCreate(byref(desc), c_int(CUBLAS_COMPUTE_32F),
+                                    c_int(CUDA_R_32F)) == 0            # fp32 accumulate
+workspace = torch.empty(WORKSPACE_BYTES, dtype=torch.uint8, device="cuda")
+
+# 2. The input. A and B all ones, so C must be exactly K. The output is fp32 because an fp16
+#    output cannot represent 11528 exactly and would round down on its own.
+M, N, K = 1, 8, 11528
+a = torch.ones(M, K, dtype=torch.float16, device="cuda")
+b = torch.ones(K, N, dtype=torch.float16, device="cuda")
+c = torch.empty(M, N, dtype=torch.float32, device="cuda")
+layouts = []
+for rows, cols, dtype in ((M, K, CUDA_R_16F), (K, N, CUDA_R_16F), (M, N, CUDA_R_32F)):
+    layout = c_void_p()
+    assert lib.cublasLtMatrixLayoutCreate(byref(layout), c_int(dtype), c_uint64(rows),
+                                          c_uint64(cols), c_int64(cols)) == 0
+    order = c_int(CUBLASLT_ORDER_ROW)        # cuBLASLt reads column-major unless told this
+    assert lib.cublasLtMatrixLayoutSetAttribute(
+        layout, c_int(CUBLASLT_MATRIX_LAYOUT_ORDER), byref(order), c_size_t(4)) == 0
+    layouts.append(layout)
+a_layout, b_layout, c_layout = layouts
+
+# 3. One matrix multiply. `algo` is NULL, so cuBLASLt picks for itself.
+alpha, beta = c_float(1.0), c_float(0.0)
+assert lib.cublasLtMatmul(handle, desc, byref(alpha), c_void_p(a.data_ptr()), a_layout,
+                          c_void_p(b.data_ptr()), b_layout, byref(beta),
+                          c_void_p(c.data_ptr()), c_layout, c_void_p(c.data_ptr()), c_layout,
+                          None, c_void_p(workspace.data_ptr()), c_size_t(WORKSPACE_BYTES),
+                          c_void_p(torch.cuda.current_stream().cuda_stream)) == 0
+torch.cuda.synchronize()
+
+# 4. C reads back how many k values were summed. It is short by a whole number.
+part_three = c[0, 0].item()
+print(f"part three  K = {K}  C[0,0] = {part_three:.0f}  short by {K - part_three:.0f}")
+
+# ========================================================================== #
+# Every element of C must be exactly K.
+# ========================================================================== #
+assert part_one == 8648, f"part one: cuBLASLt summed {part_one:.0f} of 8648"
+assert part_two == 57608, f"part two: cuBLASLt summed {part_two:.0f} of 57608"
+assert part_three == 11528, f"part three: cuBLASLt summed {part_three:.0f} of 11528"


### PR DESCRIPTION
Summary:

`_SM103` was a placeholder, so on a GB300 the API raised `CublasUnsupportedPlatform` and reconstructed nothing. This fills it in. On GB300 with cuBLASLt 13.1.1 the module now reconstructs **496,906 of 496,906 shapes with 0 declined, and 2,407,271 of 2,412,320 byte-compares are bit-identical (99.791%)**.

The whole profile is one `dataclasses.replace` of `_SM100` with one gemv row changed: sm_103 shares every measured table with sm_100. That is a measurement rather than an assumption, and the diff is small precisely because the measuring was the work. Everything was run against **13.1.1**, the same version `_SM100` was measured against, so any difference would be architecture and not library.

Three things say the sharing is real and not luck. The CUTLASS `STAGES_ID` key space enumerated through the capability API comes back as `{0} ∪ {7..20} ∪ {25}`, byte-identical to the set `_SM100`'s comment records for sm_100. The `CUSTOM_OPTION 10` occupancy cap bisects to exactly 9728 output elements -- 9729 stops matching -- which is `sm_count 152 * threads_per_sm 2048 / W 32`, and both hardware counts are the same as GB200's. And each family was given a deliberately wrong plan, perturbed the way a mis-ported table entry would be wrong, to see whether a random byte-compare could even tell: CUTLASS controls bite 98-100% of pairs, the nvjet split-K grain control 99.5% fp16 and 72.3% fp8, `ALGO 11` 43-100%. A no-op perturbation bit 0 of 85,284, so there are no false catches.

**The two gemv families were not settled that way, because their oracle is nearly blind.** A deliberately wrong `ALGO 14` lane recipe still byte-matched cuBLAS on 91.7% of shapes, so "2,017 shapes matched" would have been close to no evidence. Those were read instead with the floating-point probe -- a large value at one k and its negation at another, so each output element comes back as either a tiny survivor or exact zero, which reads the accumulator boundaries directly -- and settled by elimination over a 1,025-candidate grid rather than by a pass rate. `ALGO 14`'s two warp butterfly folds were confirmed present at `SPLITK_NUM` 37 to 296, above the `SPLITK_NUM <= 32` boundary where both folds add exact zeros and a shallow check sees nothing. 23 of `ALGO 13`'s 24 rows came back as the unique survivor.

The twenty-fourth is the one changed row. `CUSTOM_OPTION 8` closes an accumulator group every 256 k on sm_103, read off an adjacent-L boundary scan and confirmed by an independent byte-compare against a forced run of that algorithm: the corrected row is byte-equal on 15 of 15 (M=1, N=512, five K values x three seeds) against 7 of 15 for the sm_100 row, and every failure is at `K >= 512`. `_SM100`'s row is left alone. It is not wrong there -- sm_100 only ever reached this `CUSTOM_OPTION` at `K < 80`, and below one chunk length the two forms are the same kernel -- it is simply not discriminating above 256, which the comment now says.

Mismatches: all 1,062 are `ALGO_ID 66`, not one gemv, CUTLASS or gemmsn. 1,059 are the known deep-K tail family, where cuBLAS returns the product over `K - (K % block_k)` elements (see the reproducer in the diff below this one). The other 3 are the fp8 `SPLITK_NUM 149` case already open on sm_100, with the same signature, so sm_103 introduces no new residual.

Also corrected here: two comments claimed that carrying rules the other way, sm_103 to sm_100, had failed and that "the same is expected in reverse". The reverse is now measured and the expectation was wrong. That earlier failure was against a much earlier and buggier version of these rules, so it says little about the architectures and a lot about guessing; the no-extrapolation rule stays, now resting on the per-family controls above rather than on an assumed difference.

Authored with Claude Code.

Differential Revision: D115029276
