### PR TITLE
[triton][bitequiv] cuBLAS-equivalent GEMM: now supports H100 (sm_90) (#2769)

### DIFF
--- a/bitequiv/cublas_equiv_gemm.py
+++ b/bitequiv/cublas_equiv_gemm.py
@@ -126,20 +126,23 @@ class CublasUnsupportedShape(Exception):
 class CublasUnsupportedPlatform(CublasUnsupportedShape):
     """No measured strategy for this GPU architecture.
 
-    Every reconstruction rule in this file is architecture-specific and was measured, not
-    derived, so it must not be extrapolated: the sm_103 rules did not carry over to sm_100 when
-    that move was tried. Subclasses `CublasUnsupportedShape` on purpose, so a caller that
-    already writes `except CublasUnsupportedShape: <fall back to cuBLAS>` keeps working
-    unchanged on a machine we have not measured."""
+    Every reconstruction rule in this file was measured on a GPU, not derived, so it must not be
+    extrapolated to one we have not run on -- even though sm_100 and sm_103 did turn out to
+    agree. Subclasses `CublasUnsupportedShape` on purpose, so a caller that already writes
+    `except CublasUnsupportedShape: <fall back to cuBLAS>` keeps working unchanged on a machine
+    we have not measured."""
 
 
 # --------------------------------------------------------------------------- #
 # Per-platform strategy
 #
 # PORTING GUIDE. Everything cuBLAS-specific in this file lives in an ArchProfile below, so
-# adding a GPU is filling in one dataclass -- no dispatch code changes. Nothing here may be
-# guessed from another architecture: when the sm_103 rules were carried over to sm_100 they
-# were wrong, and the same is expected in reverse. Each field says how to measure it.
+# adding a GPU is filling in one dataclass -- no dispatch code changes. Each field says how to
+# measure it, and measuring is the point: sm_103 turned out to share every sm_100 table but one
+# gemv row, but that was established by re-reading each kernel family on a GB300, not by
+# assuming it. An earlier attempt to carry rules the other way, from sm_103 to sm_100, was
+# wrong -- though those rules were an earlier and buggier design, so that failure is weak
+# evidence about the architectures and strong evidence about guessing.
 #
 # The gate is (compute capability, cuBLASLt version). The cuBLASLt library we call through
 # ctypes is what decides the kernels -- its name literally carries the arch, e.g.
@@ -317,6 +320,10 @@ _SM100 = ArchProfile(
         # not imply the same order. Customs 45, 62 and 63 share one signature and have three
         # different recipes. The shortcut does hold for gemv2N/gemv2T_kernel_val, where the ints
         # in the signature are the parameters.
+        #
+        # Custom 8 was only ever reached at K under 80 here, and below one chunk length a chunked
+        # recipe and an unbounded one are the same kernel, so this row is not discriminating above
+        # that. sm_103 reads a 256-k chunk for it; see `_SM103`.
         ((13, 0), (1, 1, 0, False)), ((13, 6), (1, 1, 0, False)), ((13, 7), (1, 1, 0, False)),
         ((13, 8), (1, 1, 0, False)), ((13, 84), (1, 1, 0, False)), ((13, 14), (1, 16, 16, False)),
         ((13, 36), (-64, 32, 0, True)), ((13, 37), (1, 32, 0, True)), ((13, 40), (-64, 4, 0, True)),
@@ -363,10 +370,37 @@ _SM100 = ArchProfile(
 )
 
 
-# Placeholders. Fill in the fields above on the machine in question and flip `measured=True`;
-# the dispatch, the kernels and the eval need no changes. Re-measure every field -- the values
-# in `_SM100` are not a starting point, they are a different architecture's answer.
-_SM103 = ArchProfile(name="sm_103 (NVIDIA GB300)")
+def _with_row(table, key, value):
+    """One row of a measured table replaced, for an architecture that shares all the others."""
+    assert any(k == key for k, _ in table), key
+    return tuple((k, value if k == key else v) for k, v in table)
+
+
+# sm_103 shares every sm_100 table but one gemv row. That is a measurement, not an assumption:
+# each family was re-read on a GB300 against cuBLASLt 13.1.1 -- the same version `_SM100` was
+# measured against, so a difference here would be architecture and not library. 449,520 shapes,
+# 0 declined, 2,174,951 of 2,179,476 byte-compares bit-identical, and every mismatch is the
+# known nvjet deep-K tail. The two gemv families were read with the floating-point probe rather
+# than a byte-compare, because a wrong gemv recipe survives most random inputs: a deliberately
+# wrong `ALGO 14` plan still byte-matched on 91.7% of shapes, so a pass rate proves nothing
+# there. `sm_count` and `threads_per_sm` are the same 152 and 2048 as sm_100, and the
+# `CUSTOM_OPTION 10` cap was re-read at exactly the 9728 elements that predicts.
+_SM103 = dataclasses.replace(
+    _SM100,
+    name="sm_103 (NVIDIA GB300)",
+    measured=True,
+    cublaslt_versions=((13, 1), ),
+    measured_cublaslt="13.1.1",
+    # `CUSTOM_OPTION 8` closes an accumulator group every 256 k here, read off an adjacent-L
+    # boundary scan. The sm_100 row says unbounded, which is the same kernel while K <= 256 and
+    # diverges above it -- byte-equal 15/15 with this row against 7/15 with sm_100's.
+    gemv_recipe=_with_row(_SM100.gemv_recipe, (13, 8), (1, 1, 256, False)),
+)
+
+# Placeholder. Fill in the fields above on the machine in question and flip `measured=True`;
+# the dispatch, the kernels and the eval need no changes. Re-measure every field rather than
+# copying `_SM100` -- sm_103 turned out to share its tables, but that was established by
+# re-reading each family on the GPU, not assumed.
 _SM90 = ArchProfile(name="sm_90 (NVIDIA H100)")
 
 _PROFILES = {(10, 0): _SM100, (10, 3): _SM103, (9, 0): _SM90}

--- a/bitequiv/cublas_equiv_gemm.py
+++ b/bitequiv/cublas_equiv_gemm.py
@@ -179,6 +179,13 @@ class ArchProfile:
     # pair the reconstruction turns on, and the stages id is the only field that pins it.
     # Measure: same sweep, read `<tbK>x<stages>` and the `s<MMA>gemm` token from the name.
     stages_recipe: tuple = ()
+    # (family, CUBLASLT_ALGO_CONFIG_STAGES_ID) keys whose kernel has a SECOND accumulation level
+    # at its own block_k: every block_k-long block is summed on its own and the block totals are
+    # added forward, rather than one flat accumulator running the whole slice. Empty means every
+    # key on this architecture is flat, which is what sm_100 and sm_103 measured. Measure by
+    # byte-comparing the two forms as K grows: they agree exactly while K fits ONE block_k step
+    # and part company at the first K that needs two, including exact multiples of block_k.
+    block_level_keys: tuple = ()
     # Partition grains to try for CUTLASS split-K, largest first; cross-check against `kAlignK`
     # in `cutlass/.../params_universal_base.h`.
     splitk_grains: tuple = ()        # sm_100: (8, 64)
@@ -376,6 +383,15 @@ def _with_row(table, key, value):
     return tuple((k, value if k == key else v) for k, v in table)
 
 
+def _with_new_rows(table, rows):
+    """Rows APPENDED to a measured table, for keys another architecture never reaches. Refuses to
+    overwrite an existing key, so a table that grows can never silently change what it already
+    says."""
+    have = {k for k, _ in table}
+    assert not (have & {k for k, _ in rows}), have & {k for k, _ in rows}
+    return table + tuple(rows)
+
+
 # sm_103 shares every sm_100 table but one gemv row. That is a measurement, not an assumption:
 # each family was re-read on a GB300 against cuBLASLt 13.1.1 -- the same version `_SM100` was
 # measured against, so a difference here would be architecture and not library. 449,520 shapes,
@@ -397,11 +413,82 @@ _SM103 = dataclasses.replace(
     gemv_recipe=_with_row(_SM100.gemv_recipe, (13, 8), (1, 1, 256, False)),
 )
 
-# Placeholder. Fill in the fields above on the machine in question and flip `measured=True`;
-# the dispatch, the kernels and the eval need no changes. Re-measure every field rather than
-# copying `_SM100` -- sm_103 turned out to share its tables, but that was established by
-# re-reading each family on the GPU, not assumed.
-_SM90 = ArchProfile(name="sm_90 (NVIDIA H100)")
+# sm_90 needs four kinds of change from sm_100: 12 EXTRA gemv rows for `CUSTOM_OPTION` values
+# Blackwell never reaches, 3 CHANGED gemv rows, a different `sm_count`, and one nvjet key that
+# grows a second accumulation level. Every family was re-read on an H100 against cuBLASLt
+# 13.1.1 -- the same version `_SM100` was measured against, so a difference here is architecture
+# and not library.
+#
+# This is the first architecture whose tensor core is a different generation (`wgmma`, not
+# `tcgen05`), and most of it still carried over: the reachable `ALGO_ID` set enumerates
+# byte-identical to sm_103 for fp16, bf16 and fp8; ALGO 66's `STAGES_ID` is still 35 for
+# fp16/bf16 and 36 for fp8; the CUTLASS `STAGES_ID` key space is still {0} + {7..20} + {25}; and
+# ALGO 11's two rows re-read exactly, verified up to K = 30,292, which is both sides of the
+# K = 512 boundary where its second accumulation level starts to bite.
+#
+# The gemv rows were read with the floating-point L-probe rather than a byte-compare, because a
+# wrong gemv recipe survives most random inputs. Every one was settled by ELIMINATION over a
+# 1,355-recipe grid -- "only this recipe could have produced these bits" -- with the chunk length
+# then read off an adjacent-L boundary scan at K = 262,144, where the k range holds 128 to 65,536
+# tiles and a chunked recipe could not have hidden. The table is complete for what the TOP
+# heuristic returns: an 8,000,000-shape scan over vector lengths to 1e6 and K to 4e6 produced 42
+# distinct `ALGO_ID 13` `CUSTOM_OPTION` values and every one is keyed below.
+#
+# Two `ALGO_ID`s the top heuristic returns here have NO row and decline: 41 (16 hits in 400,000
+# fp16 draws) and 56 (8 hits). Both are tensor-core kernels whose accumulation order no plan in
+# this file reproduces -- 41 byte-matches a plain accumulator on 28/48 (shape, seed) pairs, and
+# only when `K % 64 < 32`; 56 matches nothing tried, at 0/48. Declining is the honest answer
+# until they are measured.
+_SM90 = dataclasses.replace(
+    _SM100,
+    name="sm_90 (NVIDIA H100)",
+    measured=True,
+    cublaslt_versions=((13, 1), ),
+    measured_cublaslt="13.1.1",
+    # THREE CHANGED ROWS, applied first. The single-lane options close an accumulator on a fixed
+    # k here, where sm_100 records them as unbounded: 0 every 512 k, 7 and 8 every 256 k. Read off
+    # the adjacent-L boundary scan at K 8,192 and 32,768, which prints the boundary positions with
+    # no model in the loop -- 0 lands on 511, 1023, 1535, ... and 7 and 8 on 255, 511, 767, ...,
+    # one gap value each and nothing in between. Byte-checked as well: these rows are 30/30 over
+    # K 128..65536 where sm_100's unbounded row loses 10 to 14 of the same 30. sm_100's rows are
+    # not wrong for sm_100 -- below one chunk length a chunked recipe and an unbounded one are the
+    # same kernel -- and sm_103 already had to change its option 8 the same way.
+    #
+    # THEN THE 12 NEW ROWS, for `CUSTOM_OPTION` values sm_100 never reaches. They are not a new
+    # family: every one lands in a shape sm_100 already has, and they extend its even/odd pairing
+    # -- an even option is the contiguous-slice form at some lane count and the next odd one is
+    # the strided form at the same lane count (100/101 at W 16, 110/111 at W 4, and 92, 74 pairing
+    # with sm_100's 93, 75 at W 32). Every one is `CC` 0: the boundary scan found no accumulator
+    # boundary anywhere in a 262,144-long k range.
+    gemv_recipe=_with_new_rows(_with_row(_with_row(_with_row(
+        _SM100.gemv_recipe, (13, 0), (1, 1, 512, False)),
+        (13, 7), (1, 1, 256, False)),
+        (13, 8), (1, 1, 256, False)), (
+        ((13, 68), (-64, 4, 0, True)), ((13, 72), (-64, 16, 0, True)),
+        ((13, 74), (-64, 32, 0, True)), ((13, 89), (1, 8, 0, True)),
+        ((13, 92), (-64, 32, 0, True)), ((13, 96), (-64, 4, 0, True)),
+        ((13, 100), (-64, 16, 0, True)), ((13, 101), (1, 16, 0, True)),
+        ((13, 102), (-64, 2, 0, True)), ((13, 106), (-64, 8, 0, True)),
+        ((13, 110), (-64, 4, 0, True)), ((13, 111), (1, 4, 0, True)),
+    )),
+    # The one family that genuinely changed shape. H100's fp8 nvjet kernel -- STAGES_ID 36, which
+    # is fp8-only here, so this touches nothing else -- closes an accumulator every 128 k and adds
+    # the block totals afterwards, where the same key on sm_100 and sm_103 runs one flat
+    # accumulator. Read straight off a K walk at 16-k steps: the flat form is byte-identical to
+    # cuBLAS at K 16 through 128, the whole range that fits ONE 128-k step, and misses every K
+    # from 160 up including exact multiples of 128, which rules out a residue-tile explanation.
+    # The block form is byte-identical 7/7 at SPLITK_NUM 1 and 7/7 on split-K shapes where the
+    # current flat plan is 0/7. Triton is on the same hardware path either way -- it emits
+    # `wgmma.mma_async.sync.aligned.m64n128k32.f32.e4m3.e4m3`, the native fp8 MMA -- so this is
+    # cuBLAS's grouping and not a Triton fallback.
+    block_level_keys=(("nvjet", 36), ),
+    # H100 holds 132 * 2048 threads, not GB200's and GB300's 152 * 2048, so the `CUSTOM_OPTION 10`
+    # occupancy cap moves with it. It was bisected here rather than assumed: 8448 output elements
+    # still run 32 lanes and 8449 does not, and 8448 * 32 == 132 * 2048 exactly. That is the first
+    # evidence the formula ports rather than the constant.
+    sm_count=132,
+    threads_per_sm=2048,
+)
 
 _PROFILES = {(10, 0): _SM100, (10, 3): _SM103, (9, 0): _SM90}
 
@@ -548,6 +635,49 @@ def _splitk_partial(A, B, W, M, N, K, am, ak, bk, bn, ws, wm, wn, CHUNK, BM: tl.
         acc = tl.dot(tl.load(ap, mask=km[None, :], other=0.0), tl.load(bp, mask=km[:, None], other=0.0), acc)
         ap += BK * ak
         bp += BK * bk
+    ocm = (pm * BM + tl.arange(0, BM)).to(tl.int64)
+    ocn = (pn * BN + tl.arange(0, BN)).to(tl.int64)
+    tl.store(W + sk.to(tl.int64) * ws + ocm[:, None] * wm + ocn[None, :] * wn, acc,
+             mask=(ocm[:, None] < M) & (ocn[None, :] < N))
+
+
+@triton.jit
+def _splitk_partial_blocks(A, B, W, M, N, K, am, ak, bk, bn, ws, wm, wn, CHUNK, BLOCK_K,
+                           BM: tl.constexpr, BN: tl.constexpr, BK: tl.constexpr):
+    """Pass 1 with a SECOND accumulation level at the kernel's own threadblock k step.
+
+    Slice `sk` covers [sk*CHUNK, min((sk+1)*CHUNK, K)) as in `_splitk_partial`, but inside the
+    slice each BLOCK_K-long block is summed into its OWN fp32 accumulator and the block totals
+    are then added forward, instead of one flat accumulator running the whole slice. Two
+    forward chains, nested.
+
+    That is not a refinement of the flat form, it is a different sum. The two agree exactly
+    while a slice fits one block -- which is why the flat form matched cuBLAS on H100 fp8 up to
+    K = 128 and missed every K above it, even multiples of 128.
+
+    CHUNK and BLOCK_K are runtime args so one compiled kernel serves every combination."""
+    pid = tl.program_id(0)
+    sk = tl.program_id(1)
+    npn = tl.cdiv(N, BN)
+    pm = pid // npn
+    pn = pid % npn
+    om = ((pm * BM + tl.arange(0, BM)) % M).to(tl.int64)
+    on = ((pn * BN + tl.arange(0, BN)) % N).to(tl.int64)
+    k0 = sk * CHUNK
+    kend = tl.minimum(k0 + CHUNK, K)
+    ok = tl.arange(0, BK).to(tl.int64)
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for blk in range(0, tl.cdiv(CHUNK, BLOCK_K)):
+        b0 = k0 + blk * BLOCK_K
+        btop = tl.minimum(b0 + BLOCK_K, kend)
+        sub = tl.zeros((BM, BN), dtype=tl.float32)
+        for ki in range(0, tl.cdiv(BLOCK_K, BK)):
+            kk = b0 + ki * BK + ok
+            real = kk < btop
+            a = tl.load(A + om[:, None] * am + kk[None, :] * ak, mask=real[None, :], other=0.0)
+            b = tl.load(B + kk[:, None] * bk + on[None, :] * bn, mask=real[:, None], other=0.0)
+            sub = tl.dot(a, b, sub)
+        acc = tl.where(blk == 0, sub, acc + sub)
     ocm = (pm * BM + tl.arange(0, BM)).to(tl.int64)
     ocn = (pn * BN + tl.arange(0, BN)).to(tl.int64)
     tl.store(W + sk.to(tl.int64) * ws + ocm[:, None] * wm + ocn[None, :] * wn, acc,
@@ -1004,6 +1134,28 @@ def _triton_splitk(a, b, chunk, out_dtype, scale=1.0, BK=64):
     c = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
     _splitk_combine[(ntile, )](w, c, M, N, w.stride(0), w.stride(1), w.stride(2), c.stride(0), c.stride(1), nsplit,
                                scale, BM=BM, BN=BN, num_warps=4)
+    return c
+
+
+def _triton_splitk_blocks(a, b, chunk, block_k, out_dtype, scale=1.0, BK=32):
+    """Two nested forward chains: `chunk`-long slices, each the forward sum of its `block_k`-long
+    block totals, and the slice partials added forward in fp32. `chunk == K` is the
+    SPLITK_NUM 1 case -- one slice, so only the block level is left."""
+    b = _kcontig(b)
+    M, K = a.shape
+    N = b.shape[1]
+    nsplit = (K + chunk - 1) // chunk
+    if nsplit < 1 or nsplit > 8192:
+        return None
+    BM, BN = _tile(M, N, a.dtype)
+    ntile = triton.cdiv(M, BM) * triton.cdiv(N, BN)
+    w = torch.empty(nsplit, M, N, device=DEVICE, dtype=torch.float32)
+    _splitk_partial_blocks[(ntile, nsplit)](a, b, w, M, N, K, a.stride(0), a.stride(1), b.stride(0),
+                                            b.stride(1), w.stride(0), w.stride(1), w.stride(2),
+                                            chunk, block_k, BM=BM, BN=BN, BK=BK, num_warps=4)
+    c = torch.empty(M, N, device=DEVICE, dtype=out_dtype)
+    _splitk_combine[(ntile, )](w, c, M, N, w.stride(0), w.stride(1), w.stride(2), c.stride(0),
+                               c.stride(1), nsplit, scale, BM=BM, BN=BN, num_warps=4)
     return c
 
 
@@ -1521,11 +1673,17 @@ def _plan_tensor_core(prof, family, M, N, K, kind, config):
         return None, f"unsupported STAGES_ID {stages} for {family}"
     block_k, k_per_dot = recipe
 
-    if family == "nvjet":  # cuBLAS's own kernels: one fp32 accumulator, block_k-grained split-K
+    if family == "nvjet":  # cuBLAS's own kernels: block_k-grained split-K
+        two_level = (family, stages) in prof.block_level_keys
         if nsplit <= 1:
-            return ("plain", None), "ok"
+            # One accumulator over the whole K, unless this key's kernel closes an accumulator
+            # every block_k -- then the whole K is the single slice and only the block level is
+            # left.
+            return ((("split_blocks", (K, block_k)) if two_level else ("plain", None)), "ok")
         chunk = _chunk_from_ns(K, nsplit, block_k)
-        return (("split", chunk), "ok") if block_k <= chunk < K else (None, "chunk out of range")
+        if not block_k <= chunk < K:
+            return None, "chunk out of range"
+        return ((("split_blocks", (chunk, block_k)) if two_level else ("split", chunk)), "ok")
     if kind == "fp8":  # cuBLAS refuses fp8 unless every dim is a multiple of 16, so it never
         return None, "unsupported fp8 on a CUTLASS kernel"  # leaves nvjet; if it did, unmeasured
     if nsplit <= 1:
@@ -1636,6 +1794,8 @@ def _reconstruct(a, b, out_dtype, plan, scale=1.0):
         return _triton_plain_k_per_dot(a, b, out_dtype, arg[0], arg[1], scale=scale)
     if mode == "splitk_groups":
         return _triton_splitk_groups(a, b, arg[0], arg[1], arg[2], arg[3], out_dtype, scale=scale)
+    if mode == "split_blocks":
+        return _triton_splitk_blocks(a, b, arg[0], arg[1], out_dtype, scale=scale)
     # The three CUDA-core modes take no scale: they are fp16/bf16 only, and `scale` is the fp8
     # operand-scale fold, which the API refuses to accept for any other dtype.
     if mode == "gemmsn":

--- a/bitequiv/cublas_gemm_bug_reproduce.py
+++ b/bitequiv/cublas_gemm_bug_reproduce.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+r"""Two fp16 cuBLASLt matrix multiplies that each leave the last 8 values of k out of the sum.
+
+A and B are all ones, so every element of C must be exactly K:
+
+    C[m][n] = sum over k = 0 .. K-1 of 1 * 1 = K
+
+                K = 8648            N = 8                N = 8
+            +-------------+      +---------+       +---------------+
+     M = 1  | 1 1 ... 1 1 | x    | 1 ... 1 |  =    | 8648 ... 8648 |  M = 1
+            +-------------+      | 1 ... 1 |       +---------------+
+                   A             |   ...   |               C
+                                 | 1 ... 1 |  K = 8648
+                                 +---------+
+                                      B
+
+Nothing rounds. A product of two ones is exact in fp32, the accumulator is fp32, and the
+output is fp32, which represents every whole number up to 2^24 exactly. So the number that
+comes back *is* the count of k values that were summed. It comes back short by a whole number,
+which is that many missing terms of `1 * 1` rather than a rounding error of any size.
+
+The three parts below are the same code with a different K. Point `CUBLASLT` at one library,
+run once, and every part runs: the ones that match your GPU and library come back short and the
+rest come back right.
+
+    part one   K =  8648  -> 8640    sm_100 or sm_103, cuBLASLt 13.1.1 / 13.2.2
+    part two   K = 57608  -> 57600   sm_103 or sm_90,  cuBLASLt 12.8.5
+    part three K = 11528  -> 11520   sm_90,            cuBLASLt 12.8.5 AND 13.1.1
+
+Measured, `.` meaning correct and `-8` meaning eight values of k left out:
+
+                       sm_100     sm_103     sm_103     sm_90      sm_90
+                       13.1.1     13.1.x     12.8.5     13.1.1     12.8.5
+    part one   8648      -8         -8          .          .          .
+    part two  57608       ?          .         -8          .         -8
+    part three 11528      ?          ?          ?         -8         -8
+
+WHY NO ONE SHAPE COVERS EVERYTHING. It is not that some versions are fixed. The loss happens
+only where cuBLASLt decides to split K across threadblocks, and that decision moves with both
+the architecture and the library. On GB300 the two libraries were nearly disjoint -- over 12,282
+shapes, 13.1.1 met the condition on 193 and 12.8.5 on 309, with **zero** overlap; at K = 8648
+12.8.5 returns SPLITK_NUM = 1 and never splits, and at K = 57608 the roles swap. On H100 they
+almost coincide instead: over 1,542,555 real GEMMs each, 13.1.1 loses k on 2,714 shapes and
+12.8.5 on 2,995, the smallest is K = 11528 for both, and they only diverge past about K = 50000.
+So the shape has to be chosen per architecture and per library, which is what the three parts
+are.
+
+THE CONDITION, the same everywhere. `block_k` is the k step of one threadblock, 64 for this
+fp16 kernel family; `q = K // block_k`; `tail = K % block_k`; `s = SPLITK_NUM`, the number of
+splits cuBLASLt picks. The tail is lost exactly when
+
+    ALGO_ID == 66   and   tail != 0   and   q % s == 0   and   s > tail
+
+    part one   q = 135, tail = 8, s =  9    135 %  9 == 0,  9 > 8
+    part two   q = 900, tail = 8, s = 45    900 % 45 == 0, 45 > 8   (on sm_90; s = 9 on sm_103)
+    part three q = 180, tail = 8, s =  9    180 %  9 == 0,  9 > 8
+
+The `ALGO_ID` part is not decoration. On sm_90, `1 x 2 x 1032` satisfies all three arithmetic
+parts and loses nothing, because it lands on `ALGO_ID 23`, a CUTLASS
+`cutlass_80_wmma_tensorop_s161616gemm_f16_32x32_64x2_nn_align2` kernel rather than on `nvjet`.
+Over 1,542,555 real GEMMs per library on H100 the four-part condition predicted every loss with
+**0 false positives and 0 false negatives**; dropping the `ALGO_ID` part misclassified 3,557
+shapes under each library. Every one of the 5,709 losses was exactly `K % block_k`.
+
+WHERE THE PIECE IS LOST, drawn for part one. K is handed out to the 9 threadblocks in whole
+blocks of 64. 8648 holds 135 whole blocks, and 135 / 9 = 15 exactly, so each takes 15 * 64 = 960:
+
+    k=0       960     1920    2880    3840    4800    5760    6720    7680    8640 8648
+      |-------|-------|-------|-------|-------|-------|-------|-------|-------|xxxx|
+        CTA 0   CTA 1   CTA 2   CTA 3   CTA 4   CTA 5   CTA 6   CTA 7   CTA 8    ^
+                                                                                 |
+                                                        these 8 belong to no CTA
+
+Every threadblock is full. The last one covers [7680, 8640), which is 15 whole blocks of 64 with
+nothing short about the last one:
+
+    CTA 8:      7680   7744           8512   8576   8640   8648
+                |--64--|--64--|  ...  |--64--|--64--|xxxxxx|
+                   t0     t1            t13    t14     ^
+                                                       |
+                                            outside every CTA
+
+And the reduction adds all 9 partial results; not one is skipped:
+
+    partial 0   partial 1   partial 2   ...   partial 8      (9 results, M x N each)
+          \          |           |             /
+           \_________|___________|____________/
+                       |
+              splitKreduce_kernel adds all 9
+                       |
+                    C[m][n]
+
+Nothing computed is thrown away, and nothing is added twice. The 9 ranges simply do not cover K:
+9 * 960 = 8640, and K is 8648. Part two is the same picture with 9 * 6400 = 57600 against 57608.
+
+THE ONE THING YOU MUST NOT DROP is the workspace. Split-K writes its partial results into it,
+so with a zero-size workspace cuBLASLt never splits and both shapes come back right -- measured,
+0 bytes gives 8648 and 57608. The script passes no algorithm at all: `cublasLtMatmul` takes NULL
+for `algo` and cuBLASLt chooses for itself. It picks the same split either way, so the heuristic
+query is no part of the bug and is not in the code; the `SPLITK_NUM` and the kernel names quoted
+here were read with a separate query.
+
+WHICH KERNELS RUN. Two, which is what split-K means: one GEMM that splits K and writes one
+partial result per threadblock, then one reduction that adds those partials. One launch each
+(names from `torch.profiler`):
+
+    13.1.1 / 13.2.2 on sm_103   nvjet_sm103_hsh_64x8_64x16_1x1_h_bz_splitK_NNT
+    13.1.1          on sm_100   nvjet_sm100_hsh_64x8_64x16_1x1_h_bz_splitK_NNT
+    13.1.1          on sm_90    nvjet_sm90_hss_64x8_64x16_1x1_h_bz_splitK_NNT
+    12.8.5          on sm_103   nvjet_hsh_64x8_64x16_1x1_v_bz_splitK_NNT
+    12.8.5          on sm_90    nvjet_hss_64x8_64x16_1x1_v_bz_splitK_NNT
+    all of them                 cublasLt::splitKreduce_kernel<32, 16, int, float, ...>
+
+All of them are the same tile family `64x8_64x16_1x1`, same `bz`, `splitK`, `NNT`. The 13.x
+names differ from each other only in the architecture tag -- the GEMM kernel is a separate
+binary per architecture, since nvjet is built at run time, yet the tile shape, the block of k,
+the cluster and the layouts are the same, so they do the same arithmetic in the same order and
+lose the same values. 12.8.5's name carries **no** architecture tag at all on either GPU, and
+rasters `v` where 13.x rasters `h`. The third letter follows the output type, `hss` for the
+fp32 output used here and `hsh` for fp16.
+
+Reading the `64x16` group as <block of k>x<stages> gives the block of 64. Do not take that from
+the `cublasLtMatmulStages_t` enum -- its `block_k = 16 << ((id-1)//6)` rule covers ids 1..24 and
+`STAGES_ID` here is 35. On sm_90 the 64 was confirmed three independent ways: the kernel name;
+two discriminating measurements (`K = 57664`, a multiple of 64, loses nothing, which rules out
+128; `K = 57632`, a multiple of 32, loses 32, which rules out 32); and every one of the 5,709
+observed losses being exactly `K % 64`.
+
+WHY THE OUTPUT IS fp32. An fp16 output cannot be trusted at part two's depth. Above 16384 the
+fp16 step is 16, so a K of the form `q * 64 + 8` sits exactly halfway between two fp16 values
+and rounds down to `q * 64` on its own. The control is K = 57616, a shape that is **correct**:
+with an fp16 output it reads 57600 and looks 16 short; with an fp32 output it reads 57616.
+Asking for fp32 does not change what the heuristic picks -- checked on 600 random shapes, all
+600 returned a bit-identical nine-field config either way, and at both shapes here.
+
+IT IS ALSO NOT THREE HAND-PICKED SHAPES. Over 496,906 random shapes on a GB300 under 13.1.1,
+1,062 came back not bit-identical to a full-K reference, and 1,059 of those meet the condition
+above. Under 12.8.5 on the same GPU, 179 shapes were flagged and all 179 lose exactly `tail`
+values of k, while 9,525,600 GEMMs at smaller K lose nothing. On H100, 2,714 shapes under 13.1.1
+and 2,995 under 12.8.5 lose k out of 1,542,555 real GEMMs each. It is not confined to skinny
+gemv-like shapes either: on H100, 363 of 885 (M, N) pairs under 13.1.1 and 416 of 885 under
+12.8.5 lose k somewhere, and 32 x 32, 64 x 64 and 128 x 128 all lose 8 at K = 11528.
+
+`torch.matmul` does not show any of this -- its path never picks this algorithm, so the call has
+to go to cuBLASLt directly. Checked on torch 2.9.1 over eight shapes, four operand layouts,
+`matmul` / `addmm` / `linear`, and with `preferred_blas_library("cublaslt")`.
+
+Point `CUBLASLT` at one library and run. Every part runs every time, so the printed lines are
+themselves the table above for your machine: the parts that match your GPU and library come back
+short, the rest come back right.
+
+    export CUBLASLT=/usr/local/cuda-13.0/lib64/libcublasLt.so   # 13.1.1 or 13.2.2
+    export CUBLASLT=/usr/local/cuda-12.8/lib64/libcublasLt.so   # 12.8.5
+    python cublas_gemm_bug_reproduce.py
+
+Needs a CUDA GPU, and PyTorch for device memory and nothing else.
+`cublaslt_splitk_tail_repro.py` next to this file is a longer version with a sweep.
+"""
+
+import ctypes
+import os
+from ctypes import byref, c_float, c_int, c_int64, c_size_t, c_uint64, c_void_p
+
+import torch
+
+# From cublasLt.h.
+CUDA_R_16F, CUDA_R_32F, CUBLAS_COMPUTE_32F = 2, 0, 68
+CUBLASLT_MATRIX_LAYOUT_ORDER, CUBLASLT_ORDER_ROW = 1, 1
+WORKSPACE_BYTES = 32 << 20
+
+# ========================================================================== #
+# PART ONE.  cuBLASLt 13.1.1 or 13.2.2, on sm_100 (GB200) or sm_103 (GB300).
+#            K = 8648: q = 135, tail = 8, SPLITK_NUM = 9.
+# ========================================================================== #
+
+# 1. cuBLASLt setup. Nothing here depends on the matrices.
+lib = ctypes.CDLL(os.environ["CUBLASLT"])
+handle, desc = c_void_p(), c_void_p()
+assert lib.cublasLtCreate(byref(handle)) == 0
+assert lib.cublasLtMatmulDescCreate(byref(desc), c_int(CUBLAS_COMPUTE_32F),
+                                    c_int(CUDA_R_32F)) == 0            # fp32 accumulate
+workspace = torch.empty(WORKSPACE_BYTES, dtype=torch.uint8, device="cuda")
+
+# 2. The input. A and B all ones, so C must be exactly K. The output is fp32 because an fp16
+#    output cannot represent 8648 exactly and would round down on its own.
+M, N, K = 1, 8, 8648
+a = torch.ones(M, K, dtype=torch.float16, device="cuda")
+b = torch.ones(K, N, dtype=torch.float16, device="cuda")
+c = torch.empty(M, N, dtype=torch.float32, device="cuda")
+layouts = []
+for rows, cols, dtype in ((M, K, CUDA_R_16F), (K, N, CUDA_R_16F), (M, N, CUDA_R_32F)):
+    layout = c_void_p()
+    assert lib.cublasLtMatrixLayoutCreate(byref(layout), c_int(dtype), c_uint64(rows),
+                                          c_uint64(cols), c_int64(cols)) == 0
+    order = c_int(CUBLASLT_ORDER_ROW)        # cuBLASLt reads column-major unless told this
+    assert lib.cublasLtMatrixLayoutSetAttribute(
+        layout, c_int(CUBLASLT_MATRIX_LAYOUT_ORDER), byref(order), c_size_t(4)) == 0
+    layouts.append(layout)
+a_layout, b_layout, c_layout = layouts
+
+# 3. One matrix multiply. `algo` is NULL, so cuBLASLt picks for itself.
+alpha, beta = c_float(1.0), c_float(0.0)
+assert lib.cublasLtMatmul(handle, desc, byref(alpha), c_void_p(a.data_ptr()), a_layout,
+                          c_void_p(b.data_ptr()), b_layout, byref(beta),
+                          c_void_p(c.data_ptr()), c_layout, c_void_p(c.data_ptr()), c_layout,
+                          None, c_void_p(workspace.data_ptr()), c_size_t(WORKSPACE_BYTES),
+                          c_void_p(torch.cuda.current_stream().cuda_stream)) == 0
+torch.cuda.synchronize()
+
+# 4. C reads back how many k values were summed. It is short by a whole number.
+part_one = c[0, 0].item()
+print(f"part one  K = {K}  C[0,0] = {part_one:.0f}  short by {K - part_one:.0f}")
+
+# ========================================================================== #
+# PART TWO.  cuBLASLt 12.8.5, on sm_103 (GB300). The same code again, with a different
+#            library and a different K = 57608: q = 900, tail = 8, SPLITK_NUM = 9.
+# ========================================================================== #
+
+# 1. cuBLASLt setup. Nothing here depends on the matrices.
+lib = ctypes.CDLL(os.environ["CUBLASLT"])
+handle, desc = c_void_p(), c_void_p()
+assert lib.cublasLtCreate(byref(handle)) == 0
+assert lib.cublasLtMatmulDescCreate(byref(desc), c_int(CUBLAS_COMPUTE_32F),
+                                    c_int(CUDA_R_32F)) == 0            # fp32 accumulate
+workspace = torch.empty(WORKSPACE_BYTES, dtype=torch.uint8, device="cuda")
+
+# 2. The input. A and B all ones, so C must be exactly K. The output is fp32 because an fp16
+#    output cannot represent 57608 exactly and would round down on its own.
+M, N, K = 1, 8, 57608
+a = torch.ones(M, K, dtype=torch.float16, device="cuda")
+b = torch.ones(K, N, dtype=torch.float16, device="cuda")
+c = torch.empty(M, N, dtype=torch.float32, device="cuda")
+layouts = []
+for rows, cols, dtype in ((M, K, CUDA_R_16F), (K, N, CUDA_R_16F), (M, N, CUDA_R_32F)):
+    layout = c_void_p()
+    assert lib.cublasLtMatrixLayoutCreate(byref(layout), c_int(dtype), c_uint64(rows),
+                                          c_uint64(cols), c_int64(cols)) == 0
+    order = c_int(CUBLASLT_ORDER_ROW)        # cuBLASLt reads column-major unless told this
+    assert lib.cublasLtMatrixLayoutSetAttribute(
+        layout, c_int(CUBLASLT_MATRIX_LAYOUT_ORDER), byref(order), c_size_t(4)) == 0
+    layouts.append(layout)
+a_layout, b_layout, c_layout = layouts
+
+# 3. One matrix multiply. `algo` is NULL, so cuBLASLt picks for itself.
+alpha, beta = c_float(1.0), c_float(0.0)
+assert lib.cublasLtMatmul(handle, desc, byref(alpha), c_void_p(a.data_ptr()), a_layout,
+                          c_void_p(b.data_ptr()), b_layout, byref(beta),
+                          c_void_p(c.data_ptr()), c_layout, c_void_p(c.data_ptr()), c_layout,
+                          None, c_void_p(workspace.data_ptr()), c_size_t(WORKSPACE_BYTES),
+                          c_void_p(torch.cuda.current_stream().cuda_stream)) == 0
+torch.cuda.synchronize()
+
+# 4. C reads back how many k values were summed. It is short by a whole number.
+part_two = c[0, 0].item()
+print(f"part two  K = {K}  C[0,0] = {part_two:.0f}  short by {K - part_two:.0f}")
+
+# ========================================================================== #
+# PART THREE. cuBLASLt 12.8.5 AND 13.1.1, on sm_90 (H100). The same code again with
+#             K = 11528: q = 180, tail = 8, SPLITK_NUM = 9. On H100 the two libraries
+#             agree, so this one shape covers both.
+# ========================================================================== #
+
+# 1. cuBLASLt setup. Nothing here depends on the matrices.
+lib = ctypes.CDLL(os.environ["CUBLASLT"])
+handle, desc = c_void_p(), c_void_p()
+assert lib.cublasLtCreate(byref(handle)) == 0
+assert lib.cublasLtMatmulDescCreate(byref(desc), c_int(CUBLAS_COMPUTE_32F),
+                                    c_int(CUDA_R_32F)) == 0            # fp32 accumulate
+workspace = torch.empty(WORKSPACE_BYTES, dtype=torch.uint8, device="cuda")
+
+# 2. The input. A and B all ones, so C must be exactly K. The output is fp32 because an fp16
+#    output cannot represent 11528 exactly and would round down on its own.
+M, N, K = 1, 8, 11528
+a = torch.ones(M, K, dtype=torch.float16, device="cuda")
+b = torch.ones(K, N, dtype=torch.float16, device="cuda")
+c = torch.empty(M, N, dtype=torch.float32, device="cuda")
+layouts = []
+for rows, cols, dtype in ((M, K, CUDA_R_16F), (K, N, CUDA_R_16F), (M, N, CUDA_R_32F)):
+    layout = c_void_p()
+    assert lib.cublasLtMatrixLayoutCreate(byref(layout), c_int(dtype), c_uint64(rows),
+                                          c_uint64(cols), c_int64(cols)) == 0
+    order = c_int(CUBLASLT_ORDER_ROW)        # cuBLASLt reads column-major unless told this
+    assert lib.cublasLtMatrixLayoutSetAttribute(
+        layout, c_int(CUBLASLT_MATRIX_LAYOUT_ORDER), byref(order), c_size_t(4)) == 0
+    layouts.append(layout)
+a_layout, b_layout, c_layout = layouts
+
+# 3. One matrix multiply. `algo` is NULL, so cuBLASLt picks for itself.
+alpha, beta = c_float(1.0), c_float(0.0)
+assert lib.cublasLtMatmul(handle, desc, byref(alpha), c_void_p(a.data_ptr()), a_layout,
+                          c_void_p(b.data_ptr()), b_layout, byref(beta),
+                          c_void_p(c.data_ptr()), c_layout, c_void_p(c.data_ptr()), c_layout,
+                          None, c_void_p(workspace.data_ptr()), c_size_t(WORKSPACE_BYTES),
+                          c_void_p(torch.cuda.current_stream().cuda_stream)) == 0
+torch.cuda.synchronize()
+
+# 4. C reads back how many k values were summed. It is short by a whole number.
+part_three = c[0, 0].item()
+print(f"part three  K = {K}  C[0,0] = {part_three:.0f}  short by {K - part_three:.0f}")
+
+# ========================================================================== #
+# Every element of C must be exactly K.
+# ========================================================================== #
+assert part_one == 8648, f"part one: cuBLASLt summed {part_one:.0f} of 8648"
+assert part_two == 57608, f"part two: cuBLASLt summed {part_two:.0f} of 57608"
+assert part_three == 11528, f"part three: cuBLASLt summed {part_three:.0f} of 11528"


### PR DESCRIPTION
Summary:

`_SM90` was a placeholder, so on an H100 the API raised `CublasUnsupportedPlatform` and reconstructed nothing. This fills it in. On H100 with cuBLASLt 13.1.1 the module now reconstructs **648,717 of 648,720 shapes with 3 declined, and 1,886,731 of 1,890,189 byte-compares are bit-identical (99.817%)**.

H100 is the first architecture here whose tensor core is a different generation -- `wgmma`, not Blackwell's `tcgen05` -- so this was expected to be the hard port. Most of it still carried over. The reachable `ALGO_ID` set, enumerated through the capability API, comes back byte-identical to sm_103 for fp16, bf16 and fp8. `ALGO 66`'s `STAGES_ID` is still 35 for fp16/bf16 and 36 for fp8. The CUTLASS `STAGES_ID` key space is still `{0} + {7..20} + {25}`. `ALGO 11`'s two rows re-read exactly, now verified all the way to K = 30,292 -- both sides of the K = 512 boundary where its second accumulation level begins to bite, which sm_100 never reached.

Four things did change, and each was measured rather than guessed.

**Twelve new gemv rows.** sm_90 reaches 12 `ALGO_ID 13` `CUSTOM_OPTION` values Blackwell never does. None is a new family: every one lands in a shape sm_100 already has, and they extend its even/odd pairing, where an even option is the contiguous-slice form at some lane count and the next odd one is the strided form at the same lane count. The table is now complete for what the top heuristic returns -- an 8,000,000-shape scan over vector lengths to 1e6 and K to 4e6 produced 42 distinct `CUSTOM_OPTION` values and every one is keyed.

**Three changed gemv rows.** The single-lane options close an accumulator on a fixed k here where sm_100 records them as unbounded: 0 every 512 k, 7 and 8 every 256 k. sm_100's rows are not wrong there -- below one chunk length a chunked recipe and an unbounded one are the same kernel -- and sm_103 already had to change its option 8 the same way, so this is the third architecture to find that these rows are the ones that move.

**A different occupancy cap, from the same formula.** The `CUSTOM_OPTION 10` cap bisects to exactly 8448 output elements -- 8449 stops matching -- which is `sm_count 132 * threads_per_sm 2048 / W 32`. Both Blackwell parts have 152 SMs and landed on 9728. This is the first evidence that the formula ports and not just the constant.

**fp8 grew a second accumulation level, and this is the one real difference.** H100's fp8 `nvjet` kernel closes an accumulator every 128 k and adds the block totals afterwards, where the same key on sm_100 and sm_103 runs one flat accumulator over the whole slice. That is not a refinement of the flat form, it is a different sum, so it needed a new kernel (`_splitk_partial_blocks`) and a new plan mode rather than a table row. It is keyed by `(family, STAGES_ID)` in the new `ArchProfile.block_level_keys`, which is empty for both Blackwell profiles, so nothing there changes.

The evidence for fp8 is a K walk in 16-k steps: the flat form is byte-identical to cuBLAS at K 16 through 128 -- the whole range that fits ONE 128-k step -- and misses every K from 160 up, including exact multiples of 128, which rules out a residue-tile explanation. The block form is byte-identical 7/7 at `SPLITK_NUM` 1 and 7/7 on split-K shapes where the flat plan is 0/7. Triton is on the same hardware path either way; it emits `wgmma.mma_async.sync.aligned.m64n128k32.f32.e4m3.e4m3`, the native fp8 MMA, so this is cuBLAS's grouping and not a Triton fallback.

Every family also got a deliberately wrong plan, perturbed the way a mis-ported table entry would be wrong, to see whether a random byte-compare could even tell. The fp8 block-level control catches 257,325 of 257,406 pairs (100.0%) and the fp8 `block_k` control 257,367 of 257,406 (100.0%). CUTLASS merge-scheme controls catch 100%, its `k_per_dot` control 98-100%, the nvjet split-K grain control 98-100%. A no-op perturbation was run alongside every one of them and caught 0 pairs on every family whose plan matches, so there are no false catches; the only non-zero no-op counts are exactly the deep-K tail shapes, where the correct plan does not match either.

`ALGO 14` is nearly blind, as on the other two architectures: its lane control catches 2 of 18 and 2 of 15 pairs. The `ALGO 13` rows were therefore read with the floating-point L-probe and settled by elimination over a 1,355-recipe grid -- "only this recipe could have produced these bits" -- with the chunk length then read off an adjacent-L boundary scan at K = 262,144, where the k range holds 128 to 65,536 tiles and a chunked recipe could not have hidden.

Two `ALGO_ID`s decline rather than guess. 41 and 56 are returned by the top heuristic here and by nothing on Blackwell, at 16 and 8 hits in 400,000 fp16 draws. Both are tensor-core kernels whose order no plan in this file reproduces: 41 byte-matches a plain accumulator on 28 of 48 (shape, seed) pairs and only when `K % 64 < 32`; 56 matches nothing tried, at 0 of 48. Together they cost one declined shape in 648,720.

Authored with Claude Code.

Differential Revision: D115037762
