### PR TITLE
[TLX][MXFP8] Publish attention alpha through SMEM

### DIFF
--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
@@ -390,13 +390,6 @@ def _attn_fwd_mxf8_ws(sm_scale, desc_m,  #
             tlx.storage_kind.tmem,
             reuse=qk_storage_alias,
         )
-        alpha_tiles = tlx.local_alloc(
-            (BLOCK_M_SPLIT, 1),
-            tl.float32,
-            NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-            tlx.storage_kind.tmem,
-            reuse=qk_storage_alias,
-        )
         l_tiles = tlx.local_alloc(
             (BLOCK_M_SPLIT, 1),
             tl.float32,
@@ -450,9 +443,8 @@ def _attn_fwd_mxf8_ws(sm_scale, desc_m,  #
         # QK and P have sequential lifetimes (QK consumed by softmax before P produced),
         # so they share the same TMEM region. P in FP8 (32 cols) fits within QK's FP32 space (128 cols).
         # QK[0] : |                              BLK_M/2 * BLOCK_N * fp32                                       |
-        # Alpha[0]: |BLK_M/2*1*fp32|
-        # L[0]:                    |BLK_M/2*1*fp32|
-        # M[0]:                                   |BLK_M/2*1*fp32|
+        # L[0]: |BLK_M/2*1*fp32|
+        # M[0]:                    |BLK_M/2*1*fp32|
         # Q_SCALES[1]:                                           |512*uint8|
         # K_SCALES[1]:                                                     |512*uint8|
         # V_SCALES[0]:                                                               |512*uint8|
@@ -462,7 +454,6 @@ def _attn_fwd_mxf8_ws(sm_scale, desc_m,  #
             tlx.reuse_group(
                 qk_tiles,
                 tlx.reuse_group(
-                    alpha_tiles,
                     l_tiles,
                     m_tiles,
                     q_scale_tmem,
@@ -478,12 +469,6 @@ def _attn_fwd_mxf8_ws(sm_scale, desc_m,  #
     else:
         # We have enough TMEM space to isolate every buffer.
         qk_tiles = tlx.local_alloc((BLOCK_M_SPLIT, BLOCK_N), qk_dtype, NUM_MMA_GROUPS, tlx.storage_kind.tmem)
-        alpha_tiles = tlx.local_alloc(
-            (BLOCK_M_SPLIT, 1),
-            tl.float32,
-            NUM_MMA_GROUPS * NUM_BUFFERS_QK,
-            tlx.storage_kind.tmem,
-        )
         l_tiles = tlx.local_alloc(
             (BLOCK_M_SPLIT, 1),
             tl.float32,
@@ -527,6 +512,7 @@ def _attn_fwd_mxf8_ws(sm_scale, desc_m,  #
             tlx.storage_kind.tmem,
         )
 
+    alpha_tiles = tlx.local_alloc((BLOCK_M_SPLIT, 1), tl.float32, NUM_MMA_GROUPS)
     acc_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tl.float32, NUM_MMA_GROUPS, tlx.storage_kind.tmem)
 
     qk_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
@@ -536,8 +522,8 @@ def _attn_fwd_mxf8_ws(sm_scale, desc_m,  #
     acc_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
     acc_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
 
-    alpha_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
-    alpha_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+    alpha_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
+    alpha_empties = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
     l_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
     l_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
 


### PR DESCRIPTION
Summary:
Move the per-row alpha correction factors from TMEM into two 128-row SMEM shards and use 4-warp full/empty barriers. This gives each softmax group a direct 128-thread SMEM handoff to the correction task, keeps phase progression and the P/PV accumulator protocol unchanged, and removes alpha from the QK TMEM alias set.

Why SMEM is better for this alpha handoff:
- Alpha is only one FP32 scalar per row and is not an MMA operand or accumulator, so it does not benefit from TMEM placement.
- The old path required TMEM store completion plus an ordinary leader-arrive barrier. In generated SASS, the compiler delayed the alpha publication behind later P exp2/block-scale work.
- The new path is a direct SMEM store followed by a 128-thread warp-barrier arrive, allowing correction to consume alpha while P exp2 and MXFP8 quantization continue.
- It removes alpha from the QK TMEM alias set at a cost of only 1024 bytes of SMEM.
- The measured improvement belongs to the complete SMEM-plus-warp-barrier protocol; it should not be interpreted as SMEM being universally faster than TMEM.

Performance:
B200 kernel-only forward, non-causal (B,H,Hkv,N,Nkv,D)=(1,32,32,8704,8704,128), clocks locked to 1965 MHz and power capped at 750 W. Same process, same quantized inputs, O/M bitwise identical, 300 warmup and 300 measured iterations per interleaved run.

SMEM alpha candidate:
- 1.063289 ms
- 1.062242 ms
- 1.060714 ms
- mean: 1.062082 ms

TMEM alpha control:
- 1.076023 ms
- 1.074702 ms
- 1.078234 ms
- mean: 1.076320 ms

Latency improvement: 1.323%. The candidate won all three paired comparisons.

NCU:
Kernel-only forward on the same shape. Candidate was captured with the focused three-pass NCU metric set; control uses the existing full NCU report. NCU replay duration is distinct from the locked benchmark latency above.

- duration: 1.862528 -> 1.798496 ms (-3.438%)
- SM frequency: 946.710788 -> 941.870904 MHz (-0.511%)
- FP32 FADD execution rate: 32.539880 -> 33.871562 inst/cycle (+4.092%)
- FP32 FFMA execution rate: 55.602125 -> 57.877620 inst/cycle (+4.092%)
- FP32 FMUL execution rate: 65.259207 -> 67.929916 inst/cycle (+4.092%)
- candidate report: /tmp/tritonbench_hoy/bf16_blackwell_attentions_mxfp8_fwd/tlx_blackwell_mxfp8_0/ncu_rep.ncu-rep
- control report: /home/hoy/local/fbsource/fbcode/tlx_mxfp8_attention_B1_H32_N8704_D128.ncu-rep

Reviewed By: hx2224, njriasan

Differential Revision: D114970883


