### PR TITLE
[TLX] Preserve pinned layouts across helper calls

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -165,7 +165,8 @@ struct ConvertLayoutOpConversion
     std::pair<Value, Value> coordinates = distributedCoordinates
                                               ? *distributedCoordinates
                                               : getLaneAndWarpId(rewriter, loc);
-    auto [laneId, warpId] = coordinates;
+    Value laneId = coordinates.first;
+    Value warpId = coordinates.second;
     auto elemPtrTy = ptr_ty(ctx, targetInfo.getSharedAddressSpace());
     smemBase = b.bitcast(smemBase, elemPtrTy);
 

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -1537,6 +1537,45 @@ def test_amd_scheduled_mfma_split_resident_chains_correct_gfx950(
 
 
 # ---------------------------------------------------------------------------
+# Reproducer: restructuring a loaded value must not release its pinned offsets.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _load_then_restructure(base, offsets):
+    value = tlx.buffer_load(base, offsets)
+    value = tl.reshape(value, [4, 4, 16, 2, 2])
+    value = tl.trans(value, (0, 4, 2, 3, 1))
+    return tl.reshape(value, [128, 8])
+
+
+@triton.jit
+def _pinned_load_helper_kernel(src, dst, PHYSICAL: tl.constexpr):
+    row = tl.arange(0, 4)[:, None]
+    col = tl.arange(0, 256)[None, :]
+    offsets = tlx.require_layout(row * 256 + col, PHYSICAL)
+    value = _load_then_restructure(src, offsets)
+    out_row = tl.arange(0, 128)[:, None]
+    out_col = tl.arange(0, 8)[None, :]
+    tl.store(dst + out_row * 8 + out_col, value)
+
+
+def test_load_helper_preserves_pinned_offset_layout_gfx950():
+    physical = tlx.layout(
+        shape=((16, 4, 4), (2, 2, 4)),
+        stride=((4, 64, 0), (1, 2, 256)),
+    )
+    compiled = compile_for_gfx950(
+        _pinned_load_helper_kernel,
+        signature={"src": "*fp8e4nv", "dst": "*fp8e4nv"},
+        constexprs={"PHYSICAL": physical},
+    )
+
+    # The helper keeps the offset pin and derives layouts for the loaded value.
+    assert "tlx.release_layout" not in compiled.asm["ttir"]
+
+
+# ---------------------------------------------------------------------------
 # Test: warp-pipelined batched matmul (bmm) with a partial-K tail on gfx950.
 #
 # Models the production "compression bmm" (batch, M, prime K=2309, N).

--- a/python/test/unit/language/test_tlx_layout.py
+++ b/python/test/unit/language/test_tlx_layout.py
@@ -235,8 +235,8 @@ def test_pinned_scf_loop_carried_const_init():
 def test_pinned_softmax_end_to_end():
     """End-to-end mirror of the HSTU forward softmax island: pinned load -> mask
     (select+add) -> thread-local reduce -> fma helper (tt.call) -> exp2 -> row sum
-    -> restructuring helper (reshape/split, auto-released) -> store. Exercises
-    every propagation/relaxation path together, with no explicit release."""
+    -> restructuring helper (reshape/split, pin preserved) -> store. Exercises
+    every propagation/inference path together, with no explicit release."""
 
     @triton.jit
     def _restructure_tail(p):
@@ -256,7 +256,7 @@ def test_pinned_softmax_end_to_end():
         p = tl.math.exp2(x)
         l = tl.reduce(p, 1, _pinned_add_combine)
         p = p * l[:, None]
-        # Restructuring helper: the fixup auto-releases the pin on the call arg.
+        # The fixup specializes the helper and preserves the pin through it.
         y = _restructure_tail(p)
         tlx.local_store(v, y)
 
@@ -297,12 +297,11 @@ def test_pinned_reduction_through_tl_max_sum_call():
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
-def test_pinned_auto_release_through_restructuring_call():
+def test_pinned_preserved_through_restructuring_call():
     """A pinned tensor fed to a @triton.jit helper that restructures it
-    (reshape/permute/split, like subtile_ops._split_n_2D) compiles with no
-    explicit release: TritonTLXFixup inserts an internal layout release on the
-    placeholder call args (the pin has no meaning across the restructure) and
-    the tail runs in a compiler-chosen layout."""
+    (reshape/permute/split, like subtile_ops._split_n_2D) keeps its layout
+    constraint. TritonTLXFixup specializes the helper signature and re-infers
+    each result layout without inserting an implicit release."""
 
     @triton.jit
     def _restructure_helper(x):
@@ -315,10 +314,11 @@ def test_pinned_auto_release_through_restructuring_call():
         v = tlx.local_view(buf, 0)
         x = tlx.local_load(v, layout=LAYOUT)
         x = tl.math.exp2(x)  # pinned arith
-        y = _restructure_helper(x)  # tt.call, restructuring -> auto-release the arg
+        y = _restructure_helper(x)
         tlx.local_store(v, y)
 
     compiled = kernel.warmup(_row_per_thread_layout(), grid=(1, ), num_warps=4)
+    assert "tlx.release_layout" not in compiled.asm["ttir"]
     assert "no_verify_layout" not in compiled.asm["ttgir"]
 
 

--- a/test/TLX/pinned-helper-offset-layout.mlir
+++ b/test/TLX/pinned-helper-offset-layout.mlir
@@ -1,0 +1,146 @@
+// RUN: triton-opt --verify-each=false %s -pass-pipeline='builtin.module(triton-tlx-fixup{num-warps=4 target=hip:gfx950 num-ctas=1 threads-per-warp=64})' | FileCheck %s
+//
+// Run manually:
+//   build/cmake.linux-x86_64-cpython-3.12/bin/triton-opt \
+//     --verify-each=false test/TLX/pinned-helper-offset-layout.mlir \
+//     -pass-pipeline='builtin.module(triton-tlx-fixup{num-warps=4 target=hip:gfx950 num-ctas=1 threads-per-warp=64})'
+//
+// The Python frontend normally enters this pass with an encoding-stripped
+// helper signature and a temporarily mismatched pinned call operand. Textual
+// MLIR verifies call signatures before running passes, so this reproducer uses
+// the equivalent post-specialization helper signature. Verification between
+// passes is disabled because the current bug makes the call invalid again by
+// releasing only its operand.
+//
+// The helper restructures only the loaded value. The pinned offset flows into
+// amdg.buffer_load, which is an ownership boundary for argument dataflow.
+//
+// CHECK-LABEL: tt.func private @load_then_restructure(
+// CHECK-SAME: %[[BASE:[a-zA-Z0-9_]+]]: !tt.ptr<f8E4M3FN>, %[[OFFSETS:[a-zA-Z0-9_]+]]: tensor<4x256xi32, #[[PIN:tlx.no_verify_layout<#shared[0-9]*>]]>
+// CHECK: %[[LOADED:.*]] = amdg.buffer_load %[[BASE]][%[[OFFSETS]]] : tensor<4x256xf8E4M3FN, #[[PIN]]>
+// CHECK: %[[RESHAPED:.*]] = tt.reshape %[[LOADED]]
+// CHECK-SAME: -> tensor<4x4x16x2x2xf8E4M3FN, #[[RESHAPE_LAYOUT:.*]]>
+// CHECK: %[[TRANSPOSED:.*]] = tt.trans %[[RESHAPED]]
+// CHECK-SAME: -> tensor<4x2x16x2x4xf8E4M3FN, #[[TRANS_LAYOUT:.*]]>
+// CHECK: tt.return {{.*}} : tensor<128x8xf8E4M3FN, #[[RETURN_LAYOUT:.*]]>
+// CHECK-LABEL: tt.func public @kernel
+// CHECK: %[[PINNED:.*]] = tlx.require_layout
+// CHECK-NOT: tlx.release_layout
+// CHECK: tt.call @load_then_restructure(%{{.*}}, %[[PINNED]])
+// CHECK-LABEL: tt.func private @explicit_release
+// CHECK: %[[RELEASED:.*]] = tlx.release_layout
+// CHECK: tt.return %[[RELEASED]] : tensor<4x256xi32>
+// CHECK-LABEL: tt.func public @explicit_release_kernel
+// CHECK: %[[EXPLICIT_PIN:.*]] = tlx.require_layout
+// CHECK: %[[UNPINNED:.*]] = tt.call @explicit_release(%[[EXPLICIT_PIN]])
+// CHECK-SAME: -> tensor<4x256xi32>
+// CHECK: tt.return
+//
+// Full post-fixup snapshots follow. The current module uses generic syntax
+// because releasing only the call operand makes the call temporarily invalid.
+// The desired example uses custom syntax and normalized SSA names for clarity.
+
+// ============================== PRE-FIX GENERATED OUTPUT ==============================
+//
+// #linear = #ttg.linear<{register = [[0, 1], [0, 2], [1, 0], [2, 0]], lane = [[0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128]], warp = [[0, 0], [0, 0]], block = []}>
+// #shared = #tlx.user_layout<#tlx.no_verify_layout<#linear>>
+// "builtin.module"() ({
+//   "tt.func"() <{function_type = (!tt.ptr<f8E4M3FN>, tensor<4x256xi32, #tlx.no_verify_layout<#shared>>) -> tensor<128x8xf8E4M3FN>, sym_name = "load_then_restructure", sym_visibility = "private"}> ({
+//   ^bb0(%arg2: !tt.ptr<f8E4M3FN>, %arg3: tensor<4x256xi32, #tlx.no_verify_layout<#shared>>):
+//     %3 = "amdg.buffer_load"(%arg2, %arg3) <{cache = 1 : i32, contiguity = 1 : i32, operandSegmentSizes = array<i32: 1, 1, 0, 0, 0>}> : (!tt.ptr<f8E4M3FN>, tensor<4x256xi32, #tlx.no_verify_layout<#shared>>) -> tensor<4x256xf8E4M3FN, #tlx.no_verify_layout<#shared>>
+//     %4 = "tt.reshape"(%3) <{allow_reorder}> : (tensor<4x256xf8E4M3FN, #tlx.no_verify_layout<#shared>>) -> tensor<4x4x16x2x2xf8E4M3FN>
+//     %5 = "tt.trans"(%4) <{order = array<i32: 0, 4, 2, 3, 1>}> : (tensor<4x4x16x2x2xf8E4M3FN>) -> tensor<4x2x16x2x4xf8E4M3FN>
+//     %6 = "tt.reshape"(%5) <{allow_reorder}> : (tensor<4x2x16x2x4xf8E4M3FN>) -> tensor<128x8xf8E4M3FN>
+//     "tt.return"(%6) : (tensor<128x8xf8E4M3FN>) -> ()
+//   }) : () -> ()
+//   "tt.func"() <{function_type = (!tt.ptr<f8E4M3FN>, tensor<4x256xi32>) -> (), sym_name = "kernel", sym_visibility = "public"}> ({
+//   ^bb0(%arg0: !tt.ptr<f8E4M3FN>, %arg1: tensor<4x256xi32>):
+//     %0 = "tlx.require_layout"(%arg1) : (tensor<4x256xi32>) -> tensor<4x256xi32, #tlx.no_verify_layout<#shared>>
+//     %1 = "tlx.release_layout"(%0) : (tensor<4x256xi32, #tlx.no_verify_layout<#shared>>) -> tensor<4x256xi32>
+//     %2 = "tt.call"(%arg0, %1) <{callee = @load_then_restructure}> : (!tt.ptr<f8E4M3FN>, tensor<4x256xi32>) -> tensor<128x8xf8E4M3FN>
+//     "tt.return"() : () -> ()
+//   }) : () -> ()
+// }) {tlx.has_tlx_ops = true, triton.skip_generic_pipeline, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} : () -> ()
+//
+// ================================= FIXED OUTPUT =================================
+//
+// #linear = #ttg.linear<{register = [[0, 1], [0, 2], [1, 0], [2, 0]], lane = [[0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128]], warp = [[0, 0], [0, 0]], block = []}>
+// #shared = #tlx.user_layout<#tlx.no_verify_layout<#linear>>
+// module attributes {tlx.has_tlx_ops = true, triton.skip_generic_pipeline, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+//   tt.func private @load_then_restructure(
+//       %base: !tt.ptr<f8E4M3FN>,
+//       %pinned_offsets: tensor<4x256xi32, #tlx.no_verify_layout<#shared>>)
+//       -> tensor<128x8xf8E4M3FN> {
+//     %loaded = amdg.buffer_load %base[%pinned_offsets]
+//         : tensor<4x256xf8E4M3FN, #tlx.no_verify_layout<#shared>>
+//     %reshaped = tt.reshape %loaded allow_reorder
+//         : tensor<4x256xf8E4M3FN, #tlx.no_verify_layout<#shared>>
+//           -> tensor<4x4x16x2x2xf8E4M3FN>
+//     %transposed = tt.trans %reshaped {order = array<i32: 0, 4, 2, 3, 1>}
+//         : tensor<4x4x16x2x2xf8E4M3FN> -> tensor<4x2x16x2x4xf8E4M3FN>
+//     %result = tt.reshape %transposed allow_reorder
+//         : tensor<4x2x16x2x4xf8E4M3FN> -> tensor<128x8xf8E4M3FN>
+//     tt.return %result : tensor<128x8xf8E4M3FN>
+//   }
+//
+//   tt.func public @kernel(
+//       %base: !tt.ptr<f8E4M3FN>,
+//       %offsets: tensor<4x256xi32>) {
+//     %pinned_offsets = tlx.require_layout %offsets
+//         : tensor<4x256xi32>
+//           -> tensor<4x256xi32, #tlx.no_verify_layout<#shared>>
+//     %result = tt.call @load_then_restructure(%base, %pinned_offsets)
+//         : (!tt.ptr<f8E4M3FN>, tensor<4x256xi32, #tlx.no_verify_layout<#shared>>)
+//           -> tensor<128x8xf8E4M3FN>
+//     tt.return
+//   }
+// }
+//
+// The semantic difference is the absent tlx.release_layout in @kernel. The load
+// is the ownership boundary: its result retains the same-shaped pin, while only
+// that loaded result is subsequently reshaped and transposed.
+
+#physical = #ttg.linear<{
+  register = [[0, 1], [0, 2], [1, 0], [2, 0]],
+  lane = [[0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [0, 128]],
+  warp = [[0, 0], [0, 0]],
+  block = []
+}>
+#pin = #tlx.no_verify_layout<#tlx.user_layout<#tlx.no_verify_layout<#physical>>>
+
+module {
+  tt.func private @load_then_restructure(
+      %base: !tt.ptr<f8E4M3FN>,
+      %offsets: tensor<4x256xi32, #pin>) -> tensor<128x8xf8E4M3FN> {
+    %loaded = amdg.buffer_load %base[%offsets] : tensor<4x256xf8E4M3FN, #pin>
+    %reshaped = tt.reshape %loaded allow_reorder : tensor<4x256xf8E4M3FN, #pin> -> tensor<4x4x16x2x2xf8E4M3FN>
+    %transposed = tt.trans %reshaped {order = array<i32: 0, 4, 2, 3, 1>} : tensor<4x4x16x2x2xf8E4M3FN> -> tensor<4x2x16x2x4xf8E4M3FN>
+    %result = tt.reshape %transposed allow_reorder : tensor<4x2x16x2x4xf8E4M3FN> -> tensor<128x8xf8E4M3FN>
+    tt.return %result : tensor<128x8xf8E4M3FN>
+  }
+
+  tt.func public @kernel(
+      %base: !tt.ptr<f8E4M3FN>,
+      %offsets: tensor<4x256xi32>) {
+    %pinned_offsets = tlx.require_layout %offsets
+        : tensor<4x256xi32> -> tensor<4x256xi32, #pin>
+    %result = tt.call @load_then_restructure(%base, %pinned_offsets)
+        : (!tt.ptr<f8E4M3FN>, tensor<4x256xi32, #pin>) -> tensor<128x8xf8E4M3FN>
+    tt.return
+  }
+
+  tt.func private @explicit_release(
+      %value: tensor<4x256xi32, #pin>) -> tensor<4x256xi32> {
+    %released = tlx.release_layout %value
+        : tensor<4x256xi32, #pin> -> tensor<4x256xi32>
+    tt.return %released : tensor<4x256xi32>
+  }
+
+  tt.func public @explicit_release_kernel(%value: tensor<4x256xi32>) {
+    %pinned = tlx.require_layout %value
+        : tensor<4x256xi32> -> tensor<4x256xi32, #pin>
+    %released = tt.call @explicit_release(%pinned)
+        : (tensor<4x256xi32, #pin>) -> tensor<4x256xi32>
+    tt.return
+  }
+}

--- a/test/TLX/placeholder-verifier-defer.mlir
+++ b/test/TLX/placeholder-verifier-defer.mlir
@@ -63,19 +63,20 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32,
 #linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
 #ph = #tlx.no_verify_layout<#tlx.user_layout<#linear>>
 #slice = #ttg.slice<{dim = 1, parent = #ph}>
+#deferred_slice = #tlx.no_verify_layout<#slice>
 module {
-  // The slice must remain the outer encoding so repeated reduction inference
-  // is structurally stable. Its nested placeholder defers layout verification
-  // while frontend IR has no ttg.num-warps context.
+  // The nested placeholder keeps canonical slice-parent inference stable. The
+  // outer placeholder defers verification of the complete slice while frontend
+  // IR has no ttg.num-warps context and keeps later inference in the TLX dialect.
   // CHECK-LABEL: @nested_placeholder_slice
-  tt.func @nested_placeholder_slice(%x: tensor<128x128xf32, #ph>) -> tensor<128xf32, #slice> {
+  tt.func @nested_placeholder_slice(%x: tensor<128x128xf32, #ph>) -> tensor<128xf32, #deferred_slice> {
     // CHECK: "tt.reduce"
     %m = "tt.reduce"(%x) <{axis = 1 : i32}> ({
     ^bb0(%lhs: f32, %rhs: f32):
       %max = arith.maxnumf %lhs, %rhs : f32
       tt.reduce.return %max : f32
-    }) : (tensor<128x128xf32, #ph>) -> tensor<128xf32, #slice>
-    tt.return %m : tensor<128xf32, #slice>
+    }) : (tensor<128x128xf32, #ph>) -> tensor<128xf32, #deferred_slice>
+    tt.return %m : tensor<128xf32, #deferred_slice>
   }
 }
 

--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -134,8 +134,12 @@ struct TLXInferLayoutInterface : public triton::DialectInferLayoutInterface {
     if (auto slice = dyn_cast<triton::gpu::SliceEncodingAttr>(result)) {
       auto parent = cast<triton::gpu::DistributedEncodingTrait>(
           wrapNoVerifyLayout(slice.getParent()));
-      resultEncoding = triton::gpu::SliceEncodingAttr::get(
+      auto deferredSlice = triton::gpu::SliceEncodingAttr::get(
           result.getContext(), slice.getDim(), parent);
+      // Keep the slice parent deferred for canonical slice inference, and also
+      // defer verification of the whole result while frontend TTIR has no
+      // ttg.num-warps context yet.
+      resultEncoding = wrapNoVerifyLayout(deferredSlice);
     } else {
       resultEncoding = wrapNoVerifyLayout(result);
     }

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -6,6 +6,7 @@
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 #include "tlx/dialect/include/IR/Dialect.h"
@@ -82,6 +83,16 @@ static bool isEncodingUniformArithOp(Operation *op) {
     if (!sameShape(ty))
       return false;
   return haveShape;
+}
+
+static bool hasSameOperandsEncodingTrait(Operation *op) {
+  return op->hasTrait<mlir::OpTrait::SameOperandsEncoding>() ||
+         op->hasTrait<mlir::OpTrait::SameLoadStoreOperandsEncoding>();
+}
+
+static bool hasSameOperandsAndResultEncodingTrait(Operation *op) {
+  return op->hasTrait<mlir::OpTrait::SameOperandsAndResultEncoding>() ||
+         op->hasTrait<mlir::OpTrait::SameLoadStoreOperandsAndResultEncoding>();
 }
 
 static bool isPlaceholderEncoding(Attribute enc) {
@@ -434,6 +445,61 @@ static LogicalResult synchronizeConcreteHelperABI(ModuleOp mod) {
   return success();
 }
 
+static void appendForwardedValues(OpOperand &use,
+                                  SmallVectorImpl<Value> &worklist) {
+  Operation *user = use.getOwner();
+  if (auto yield = dyn_cast<scf::YieldOp>(user)) {
+    unsigned index = use.getOperandNumber();
+    Operation *parent = yield->getParentOp();
+    if (auto ifOp = dyn_cast<scf::IfOp>(parent)) {
+      if (index < ifOp.getNumResults())
+        worklist.push_back(ifOp.getResult(index));
+    } else if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+      if (index < forOp.getNumResults()) {
+        worklist.push_back(forOp.getRegionIterArg(index));
+        worklist.push_back(forOp.getResult(index));
+      }
+    }
+    return;
+  }
+  if (auto forOp = dyn_cast<scf::ForOp>(user)) {
+    unsigned index = use.getOperandNumber();
+    if (index >= forOp.getNumControlOperands()) {
+      index -= forOp.getNumControlOperands();
+      if (index < forOp.getNumRegionIterArgs()) {
+        worklist.push_back(forOp.getRegionIterArg(index));
+        worklist.push_back(forOp.getResult(index));
+      }
+    }
+    return;
+  }
+  // An scf.if operand is its condition, not a value forwarded to its results.
+  // An explicit release ends the pinned value's provenance by definition.
+  if (isa<scf::IfOp, ReleaseLayoutOp>(user) || !isMemoryEffectFree(user))
+    return;
+  for (Value result : user->getResults())
+    if (isa<RankedTensorType>(result.getType()))
+      worklist.push_back(result);
+}
+
+static SmallVector<Value> collectForwardedValues(Value root) {
+  SmallVector<Value> worklist{root};
+  SmallVector<Value> visited;
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (llvm::is_contained(visited, value))
+      continue;
+    visited.push_back(value);
+    for (OpOperand &use : value.getUses())
+      appendForwardedValues(use, worklist);
+  }
+  return visited;
+}
+
+static bool flowsToValue(Value root, Value target) {
+  return llvm::is_contained(collectForwardedValues(root), target);
+}
+
 static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
   bool conflict = false;
   // Find a placeholder encoding among a set of linked values (values an op
@@ -518,26 +584,34 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
         }
         return;
       }
-      // tt.store: value / ptr / mask must share one encoding
-      // (SameLoadStoreOperandsEncoding). If the value carries a user pin,
-      // propagate it to ptr/mask so make_ttir's verifier accepts the store
-      // without a per-op tolerance; concrete layouts resolve later in
-      // make_ttgir. Bridge (require_layout convert) the ptr/mask for this use
-      // only, leaving their producers (addptr / mask cmp, with their own
-      // same-encoding verifiers) untouched.
-      if (auto store = dyn_cast<::mlir::triton::StoreOp>(op)) {
-        SmallVector<Value> linked{store.getValue(), store.getPtr()};
-        if (store.getMask())
-          linked.push_back(store.getMask());
+      // Ops declaring a same-encoding trait keep their ranked tensor values in
+      // one layout domain. Use the trait rather than an op name so helper
+      // specialization works for all current and future load/store operations.
+      bool sameOperands = hasSameOperandsEncodingTrait(op);
+      bool sameOperandsAndResults = hasSameOperandsAndResultEncodingTrait(op);
+      if (sameOperands || sameOperandsAndResults) {
+        SmallVector<Value> linked;
+        for (Value operand : op->getOperands())
+          if (isa<RankedTensorType>(operand.getType()))
+            linked.push_back(operand);
+        if (sameOperandsAndResults)
+          for (Value result : op->getResults())
+            if (isa<RankedTensorType>(result.getType()))
+              linked.push_back(result);
         Attribute enc = findPlaceholder(linked, op);
         if (enc) {
-          bridgeOrRetype(store.getPtr(), enc, op, /*operandIdx=*/0,
-                         /*forceBridge=*/true);
-          if (store.getMask())
-            bridgeOrRetype(store.getMask(), enc, op, /*operandIdx=*/2,
-                           /*forceBridge=*/true);
+          if (sameOperandsAndResults)
+            for (Value result : op->getResults())
+              changed |= retypeWithEncoding(result, enc);
+          for (auto indexed : llvm::enumerate(op->getOperands()))
+            if (isa<RankedTensorType>(indexed.value().getType()))
+              bridgeOrRetype(indexed.value(), enc, op, indexed.index(),
+                             /*forceBridge=*/true);
         }
-        return;
+        // Operand-only traits (e.g. tt.reduce) do not describe result layouts;
+        // continue to the op's inference interface below.
+        if (sameOperandsAndResults)
+          return;
       }
       // scf.for: init / region iter-arg / yield operand / result of each
       // loop-carried value must share the encoding.
@@ -587,17 +661,17 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
         }
         return;
       }
-      // tt.expand_dims / tt.broadcast: their result type was fixed at build
-      // time, but the operand may only receive a placeholder via the arith/scf
-      // propagation above. Re-infer the result via the op's
-      // InferTypeOpInterface (broadcast preserves the encoding; expand_dims
-      // maps slice<->parent through the TLX infer interface) so operand and
-      // result stay consistent.
-      if (isa<::mlir::triton::ExpandDimsOp, ::mlir::triton::BroadcastOp,
-              ::mlir::triton::ReduceOp>(op)) {
-        auto ot = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
-        if (!ot || !isPlaceholderEncoding(ot.getEncoding()))
-          return;
+      // Re-infer any op whose operands acquired a placeholder after frontend
+      // construction. This covers trans/split/reduce/expand-dims and future ops
+      // implementing InferTypeOpInterface.
+      Attribute operandEnc;
+      for (Value operand : op->getOperands())
+        if (auto type = dyn_cast<RankedTensorType>(operand.getType()))
+          if (isPlaceholderEncoding(type.getEncoding())) {
+            operandEnc = type.getEncoding();
+            break;
+          }
+      if (operandEnc && !isa<::mlir::triton::CallOp>(op)) {
         if (auto iface = dyn_cast<InferTypeOpInterface>(op)) {
           SmallVector<Type> inferred;
           if (succeeded(iface.inferReturnTypes(
@@ -611,31 +685,48 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
                 changed = true;
               }
           }
+          return;
         }
-        return;
+        if (auto reshape = dyn_cast<::mlir::triton::ReshapeOp>(op)) {
+          auto srcTy = reshape.getSrc().getType();
+          auto dstTy = reshape.getType();
+          Attribute dstEnc = dstTy.getEncoding();
+          auto *layout = cast<::mlir::triton::DialectInferLayoutInterface>(
+              &operandEnc.getDialect());
+          if (succeeded(layout->inferReshapeOpEncoding(
+                  srcTy.getShape(), operandEnc, dstTy.getShape(), dstEnc,
+                  reshape.getAllowReorder(), reshape.getLoc())))
+            changed |= retypeWithEncoding(reshape.getResult(), dstEnc);
+          return;
+        }
+        if (auto join = dyn_cast<::mlir::triton::JoinOp>(op)) {
+          SmallVector<Value> linked{join.getLhs(), join.getRhs()};
+          Attribute srcEnc = findPlaceholder(linked, op);
+          if (!srcEnc)
+            return;
+          bridgeOrRetype(join.getLhs(), srcEnc, op, 0);
+          bridgeOrRetype(join.getRhs(), srcEnc, op, 1);
+          auto srcTy = join.getLhs().getType();
+          Attribute dstEnc;
+          auto *layout = cast<::mlir::triton::DialectInferLayoutInterface>(
+              &srcEnc.getDialect());
+          if (succeeded(layout->inferDefaultJoinOpEncoding(
+                  srcEnc, dstEnc, srcTy.getShape(), join.getLoc())))
+            changed |= retypeWithEncoding(join.getResult(), dstEnc);
+          return;
+        }
       }
-      // tt.call to a @triton.jit helper carrying a pinned (placeholder) arg.
-      // Three cases, keyed on what the (monomorphized, encoding-stripped)
-      // callee does:
-      //   (A) it restructures the tensor (reshape / split / join / trans, e.g.
-      //       subtile_ops._split_n_2D): the row-per-thread pin has no meaning
-      //       across the restructure, so auto-release the placeholder args
-      //       before the call (make_ttgir picks the tail layout) -- the kernel
-      //       does not need an explicit tlx.release_layout.
-      //   (B/C) it is elementwise (fast_fma) or a reduction (standard.max/sum):
-      //       specialize the callee params, then sync the call result to the
-      //       callee return -- forcing the placeholder for an elementwise
-      //       result (shape matches the arg) or mirroring the fixpoint-inferred
-      //       return for a reduction result (shape differs, slice of the pin).
-      //       This keeps the kernel on natural tl.max/tl.sum and fast_fma.
+      // tt.call to a @triton.jit helper carrying a pinned placeholder argument.
+      // Specialize the encoding-stripped callee signature, then let the
+      // fixpoint re-infer its body and synchronize its return/call result
+      // types. The original pin remains authoritative across the function
+      // boundary.
       if (auto callOp = dyn_cast<::mlir::triton::CallOp>(op)) {
         Attribute enc;
-        ArrayRef<int64_t> encShape;
         for (Value a : callOp.getOperands())
           if (auto t = dyn_cast<RankedTensorType>(a.getType()))
             if (isPlaceholderEncoding(t.getEncoding())) {
               enc = t.getEncoding();
-              encShape = t.getShape();
               break;
             }
         auto callee =
@@ -645,30 +736,8 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
         if (!callee)
           return;
 
-        // (A) restructuring callee -> release the placeholder args.
-        bool restructures = false;
-        callee.walk([&](Operation *o) {
-          if (isa<::mlir::triton::ReshapeOp, ::mlir::triton::SplitOp,
-                  ::mlir::triton::JoinOp, ::mlir::triton::TransOp>(o))
-            restructures = true;
-        });
-        if (restructures) {
-          OpBuilder b(callOp);
-          for (unsigned i = 0; i < callOp.getNumOperands(); ++i) {
-            auto t = dyn_cast<RankedTensorType>(callOp.getOperand(i).getType());
-            if (!t || !isPlaceholderEncoding(t.getEncoding()))
-              continue;
-            auto relTy =
-                RankedTensorType::get(t.getShape(), t.getElementType());
-            Value rel = ReleaseLayoutOp::create(b, callOp.getLoc(), relTy,
-                                                callOp.getOperand(i));
-            callOp.setOperand(i, rel);
-            changed = true;
-          }
-          return;
-        }
+        Block &entry = callee.getBody().front();
 
-        // (B/C) elementwise / reduction: specialize the callee.
         // If the monomorphized helper is shared with other call sites (possibly
         // unpinned or pinned to a different layout), defer privatizing it:
         // clone a private copy after the walk and point this call at it, so
@@ -690,7 +759,6 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
         // FunctionType inputs) to the placeholder; nested helper calls and the
         // callee body (e.g. the reduction's tt.reduce) are re-inferred by the
         // fixpoint once their params are set.
-        Block &entry = callee.getBody().front();
         SmallVector<Type> newInputs(
             callee.getFunctionType().getInputs().begin(),
             callee.getFunctionType().getInputs().end());
@@ -728,14 +796,30 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
           if (!rets.empty() && i < rets[0].getNumOperands())
             retT = dyn_cast<RankedTensorType>(rets[0].getOperand(i).getType());
           Type target;
-          if (retT && isPlaceholderEncoding(retT.getEncoding()))
+          if (retT && isPlaceholderEncoding(retT.getEncoding())) {
             target = retT;
-          else if (callRt && callRt.getShape() == encShape)
-            // Elementwise: result shares the arg shape -> force the
-            // placeholder.
-            target = RankedTensorType::get(callRt.getShape(),
-                                           callRt.getElementType(), enc);
-          else
+          } else if (callRt && !rets.empty() && i < rets[0].getNumOperands()) {
+            // Elementwise: specialize only when the return value actually
+            // descends from a surviving pinned argument with the same shape.
+            // This avoids re-pinning a result derived from another argument
+            // whose layout was released before a restructure.
+            Value retV = rets[0].getOperand(i);
+            for (unsigned argIdx = 0; argIdx < callOp.getNumOperands();
+                 ++argIdx) {
+              auto argT = dyn_cast<RankedTensorType>(
+                  callOp.getOperand(argIdx).getType());
+              if (!argT || !isPlaceholderEncoding(argT.getEncoding()) ||
+                  argT.getShape() != callRt.getShape() ||
+                  argIdx >= entry.getNumArguments() ||
+                  !flowsToValue(entry.getArgument(argIdx), retV))
+                continue;
+              target = RankedTensorType::get(callRt.getShape(),
+                                             callRt.getElementType(),
+                                             argT.getEncoding());
+              break;
+            }
+          }
+          if (!target)
             continue;
           if (callOp.getResult(i).getType() != target) {
             callOp.getResult(i).setType(target);


### PR DESCRIPTION
## Summary

Preserve `tlx.require_layout` constraints when pinned tensors pass through `@triton.jit` helper calls.

## Problem

The frontend generates helpers with layout-free tensor signatures. Previously, if a helper contained restructuring operations such as `reshape`, `split`, `join`, or `trans`, `TritonTLXFixup` inserted `tlx.release_layout` before the call.

This made the call types legal but discarded the user-required layout, sometimes for unrelated arguments such as pinned buffer-load offsets.

## Solution

- Specialize helper arguments and return types using the caller's pinned layout.
- Re-infer derived layouts through reshape, transpose, split, join, reduce, and related operations.
- Use generic Triton encoding traits and layout interfaces instead of AMD-specific operation checks.
- Clone shared helpers when call sites require different layout specializations.
- Preserve explicit user-written `tlx.release_layout` boundaries.
- Propagate layout provenance through `scf.if` and `scf.for`.
- Defer verification for pinned reduction slice layouts until the required GPU layout context is available.

The change also includes a small C++17 compatibility fix for capturing lane and warp coordinates in `ConvertLayoutOpToLLVM.cpp`.

## Testing

- AMD TLX suite: **75 passed, 5 skipped**
- Pinned helper AMD regression: **passed**
- `test/TLX/pinned-helper-offset-layout.mlir`: **passed**
- Blackwell helper regression: skipped locally because Blackwell hardware was unavailable
