### PR TITLE
[TLX][AMD] Add explicit gfx1250 WMMA layout controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1410,6 +1410,18 @@ hand-poking attributes.
 Currently consumed only by the scaled-WMMA pattern (gfx1250). Regular
 `tt.dot` WMMA and the MFMA patterns do not read it.
 
+### Explicit WMMA layout pinning
+
+`tlx.require_amd_wmma_layout(x, version=3, transposed=True, warp_bases=...,
+reg_bases=..., instr_shape=(16, 16, 128))` pins a tensor to an explicit AMD
+WMMA register/warp layout. This is useful for tuned gfx1250 epilogues that must
+retain the accumulator ownership chosen by `tiles_per_warp` across otherwise
+layout-neutral tensor operations. The bases contain one linear-layout basis
+vector per register or warp bit and must match the tensor rank.
+
+The helper lowers to a pinned `tlx.require_layout`; omit it when automatic
+layout propagation is sufficient.
+
 ## Kernels Implemented with TLX
 
 ### GEMM kernels

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -2485,6 +2485,107 @@ def test_local_reshape_correctness_gfx1250(device):
 # ---------------------------------------------------------------------------
 
 
+@triton.jit
+def _dot_scaled_tiles_per_warp_kernel(
+    a_ptr,
+    b_ptr,
+    a_scale_ptr,
+    b_scale_ptr,
+    c_ptr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    SCALE_BLOCK: tl.constexpr,
+    TILES_PER_WARP: tl.constexpr,
+):
+    block_k_scale: tl.constexpr = BLOCK_K // SCALE_BLOCK
+    offs_m = tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    offs_ks = tl.arange(0, block_k_scale)
+
+    a = tl.load(a_ptr + offs_m[:, None] * BLOCK_K + offs_k[None, :])
+    b = tl.load(b_ptr + offs_k[:, None] * BLOCK_N + offs_n[None, :])
+    a_scale = tl.load(a_scale_ptr + offs_m[:, None] * block_k_scale + offs_ks[None, :])
+    b_scale = tl.load(b_scale_ptr + offs_n[:, None] * block_k_scale + offs_ks[None, :])
+
+    acc = tlx.dot_scaled(a, a_scale, "e5m2", b, b_scale, "e5m2", tiles_per_warp=TILES_PER_WARP)
+    tl.store(c_ptr + offs_m[:, None] * BLOCK_N + offs_n[None, :], acc)
+
+
+def _compile_dot_scaled_tiles_per_warp(tiles_per_warp):
+    src = ASTSource(
+        fn=_dot_scaled_tiles_per_warp_kernel,
+        signature={
+            "a_ptr": "*fp8e5",
+            "b_ptr": "*fp8e5",
+            "a_scale_ptr": "*i8",
+            "b_scale_ptr": "*i8",
+            "c_ptr": "*fp32",
+        },
+        constexprs={
+            "BLOCK_M": 256,
+            "BLOCK_N": 256,
+            "BLOCK_K": 128,
+            "SCALE_BLOCK": 32,
+            "TILES_PER_WARP": tiles_per_warp,
+        },
+    )
+    return triton_compile(src, target=GPUTarget("hip", "gfx1250", 32))
+
+
+def test_dot_scaled_tiles_per_warp_attr_gfx1250():
+    compiled = _compile_dot_scaled_tiles_per_warp((2, 2))
+    assert "amdg.wmma_tiles_per_warp = array<i32: 2, 2>" in compiled.asm["ttir"]
+    assert "#ttg.amd_wmma" in compiled.asm["ttgir"]
+
+
+@pytest.mark.parametrize(
+    "tiles_per_warp, error",
+    [
+        ((1, ), "tiles_per_warp requires 2 entries"),
+        ((0, 1), "tiles_per_warp entries must be positive"),
+    ],
+)
+def test_dot_scaled_tiles_per_warp_rejects_invalid_gfx1250(tiles_per_warp, error):
+    with pytest.raises(CompilationError, match=error):
+        _compile_dot_scaled_tiles_per_warp(tiles_per_warp)
+
+
+@triton.jit
+def _require_amd_wmma_layout_kernel(x_ptr, y_ptr, BLOCK: tl.constexpr):
+    offs_m = tl.arange(0, BLOCK)
+    offs_n = tl.arange(0, BLOCK)
+    offsets = offs_m[:, None] * BLOCK + offs_n[None, :]
+    values = tl.load(x_ptr + offsets)
+    values = tlx.require_amd_wmma_layout(
+        values,
+        version=3,
+        transposed=True,
+        warp_bases=((0, 2), (2, 0)),
+        reg_bases=((0, 1), (1, 0)),
+        instr_shape=(16, 16, 128),
+    )
+    offsets = tlx.require_amd_wmma_layout(
+        offsets,
+        version=3,
+        transposed=True,
+        warp_bases=((0, 2), (2, 0)),
+        reg_bases=((0, 1), (1, 0)),
+        instr_shape=(16, 16, 128),
+    )
+    tl.store(y_ptr + offsets, values)
+
+
+def test_require_amd_wmma_layout_compiles_gfx1250():
+    compiled = compile_for_gfx1250(
+        _require_amd_wmma_layout_kernel,
+        signature={"x_ptr": "*fp32", "y_ptr": "*fp32"},
+        constexprs={"BLOCK": 256},
+    )
+    assert "#ttg.amd_wmma" in compiled.asm["ttgir"]
+
+
 def test_mxgemm_tdm_pipelined_compiles_gfx1250(device):
     """The mxfp GEMM tutorial kernel should lower to TDM + dot_scaled + WMMA."""
     compiled = compile_for_gfx1250(

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250-invalid.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250-invalid.mlir
@@ -1,0 +1,62 @@
+// RUN: triton-opt %s --split-input-file --tritonamdgpu-accelerate-matmul="gfx-arch=gfx1250" --verify-diagnostics -o /dev/null
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @wrong_tiles_per_warp_rank(
+      %a: tensor<256x256xf8E4M3FN, #blocked>,
+      %b: tensor<256x256xf8E4M3FN, #blocked1>,
+      %a_scale: tensor<256x8xi8, #blocked2>,
+      %b_scale: tensor<256x8xi8, #blocked2>,
+      %out: tensor<256x256x!tt.ptr<f32>, #blocked3>) {
+    %acc = arith.constant dense<0.000000e+00> : tensor<256x256xf32, #blocked3>
+    // expected-error @+1 {{amdg.wmma_tiles_per_warp must have 2 entries}}
+    %0 = tt.dot_scaled %a scale %a_scale, %b scale %b_scale, %acc lhs = e4m3 rhs = e4m3 {fastMath = false, amdg.wmma_tiles_per_warp = array<i32: 2>} : tensor<256x256xf8E4M3FN, #blocked>, tensor<256x8xi8, #blocked2> * tensor<256x256xf8E4M3FN, #blocked1>, tensor<256x8xi8, #blocked2> -> tensor<256x256xf32, #blocked3>
+    tt.store %out, %0 : tensor<256x256x!tt.ptr<f32>, #blocked3>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @nonpositive_tiles_per_warp(
+      %a: tensor<256x256xf8E4M3FN, #blocked>,
+      %b: tensor<256x256xf8E4M3FN, #blocked1>,
+      %a_scale: tensor<256x8xi8, #blocked2>,
+      %b_scale: tensor<256x8xi8, #blocked2>,
+      %out: tensor<256x256x!tt.ptr<f32>, #blocked3>) {
+    %acc = arith.constant dense<0.000000e+00> : tensor<256x256xf32, #blocked3>
+    // expected-error @+1 {{amdg.wmma_tiles_per_warp entries must be positive}}
+    %0 = tt.dot_scaled %a scale %a_scale, %b scale %b_scale, %acc lhs = e4m3 rhs = e4m3 {fastMath = false, amdg.wmma_tiles_per_warp = array<i32: 0, 2>} : tensor<256x256xf8E4M3FN, #blocked>, tensor<256x8xi8, #blocked2> * tensor<256x256xf8E4M3FN, #blocked1>, tensor<256x8xi8, #blocked2> -> tensor<256x256xf32, #blocked3>
+    tt.store %out, %0 : tensor<256x256x!tt.ptr<f32>, #blocked3>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @overflowing_tiles_per_warp_extent(
+      %a: tensor<256x256xf8E4M3FN, #blocked>,
+      %b: tensor<256x256xf8E4M3FN, #blocked1>,
+      %a_scale: tensor<256x8xi8, #blocked2>,
+      %b_scale: tensor<256x8xi8, #blocked2>,
+      %out: tensor<256x256x!tt.ptr<f32>, #blocked3>) {
+    %acc = arith.constant dense<0.000000e+00> : tensor<256x256xf32, #blocked3>
+    // expected-error @+1 {{amdg.wmma_tiles_per_warp requires extent 4294967296 in dimension 0, which exceeds the result tile shape}}
+    %0 = tt.dot_scaled %a scale %a_scale, %b scale %b_scale, %acc lhs = e4m3 rhs = e4m3 {fastMath = false, amdg.wmma_tiles_per_warp = array<i32: 134217728, 1>} : tensor<256x256xf8E4M3FN, #blocked>, tensor<256x8xi8, #blocked2> * tensor<256x256xf8E4M3FN, #blocked1>, tensor<256x8xi8, #blocked2> -> tensor<256x256xf32, #blocked3>
+    tt.store %out, %0 : tensor<256x256x!tt.ptr<f32>, #blocked3>
+    tt.return
+  }
+}

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
@@ -39,6 +39,30 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK-DAG: #[[$MMA_TPW:.+]] = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {register = {{\[\[0, 1\], \[1, 0\]\]}}, warp = {{\[\[0, 2\], \[2, 0\]\]}}}, instrShape = [16, 16, 128]}>
+// CHECK-LABEL: wmma_dot_scaled_explicit_tiles_per_warp
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @wmma_dot_scaled_explicit_tiles_per_warp(
+      %arg0: tensor<256x256xf8E4M3FN, #blocked>,
+      %arg1: tensor<256x256xf8E4M3FN, #blocked1>,
+      %arg2: tensor<256x8xi8, #blocked2>,
+      %arg3: tensor<256x8xi8, #blocked2>,
+      %arg4: tensor<256x256x!tt.ptr<f32>, #blocked3>
+      ) {
+    // CHECK: tt.dot_scaled {{.*}} -> tensor<256x256xf32, #[[$MMA_TPW]]>
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x256xf32, #blocked3>
+    %1 = tt.dot_scaled %arg0 scale %arg2, %arg1 scale %arg3, %cst lhs = e4m3 rhs = e4m3 {fastMath = false, amdg.wmma_tiles_per_warp = array<i32: 2, 2>} : tensor<256x256xf8E4M3FN, #blocked>, tensor<256x8xi8, #blocked2> * tensor<256x256xf8E4M3FN, #blocked1>, tensor<256x8xi8, #blocked2> -> tensor<256x256xf32, #blocked3>
+    tt.store %arg4, %1 : tensor<256x256x!tt.ptr<f32>, #blocked3>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 // CHECK{LITERAL}: #linear = #ttg.linear<{register = [[0, 1], [0, 2]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 0]], warp = [[0, 0], [16, 0]], block = []}>
 // CHECK{LITERAL}: #linear1 = #ttg.linear<{register = [[0, 1], [0, 2]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 0]], warp = [[16, 0], [0, 0]], block = []}>
 // CHECK{LITERAL}: #mma = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, instrShape = [16, 16, 128]}>

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -32,6 +32,7 @@ using triton::amdgpu::TargetFeatures;
 
 constexpr char AttrDecomposedDotScaledSource[] =
     "amdg.decomposed_dot_scaled_source";
+constexpr char AttrAMDWmmaTilesPerWarp[] = "amdg.wmma_tiles_per_warp";
 
 int getMfmaVersion(ISAFamily isaFamily) {
   switch (isaFamily) {
@@ -164,6 +165,44 @@ SmallVector<unsigned, 3> planWarps(Operation *dotOp, ArrayRef<int64_t> shape,
   }
 
   return ret;
+}
+
+LogicalResult validateWmmaTilesPerWarp(tt::DotScaledOp dotOp) {
+  auto attr = dotOp->getAttrOfType<DenseI32ArrayAttr>(AttrAMDWmmaTilesPerWarp);
+  if (!attr)
+    return success();
+
+  auto resultType = dotOp.getType();
+  unsigned rank = resultType.getRank();
+  ArrayRef<int32_t> requested = attr.asArrayRef();
+  if (requested.size() != rank)
+    return dotOp.emitOpError()
+           << AttrAMDWmmaTilesPerWarp << " must have " << rank << " entries";
+  if (rank != 2)
+    return dotOp.emitOpError()
+           << AttrAMDWmmaTilesPerWarp << " currently requires a rank-2 dot";
+
+  constexpr unsigned mDim = 16;
+  constexpr unsigned nDim = 16;
+  auto cgaLayout = ttg::getCGALayout(resultType.getEncoding());
+  auto shapePerCTA =
+      ttg::getShapePerCTA(cgaLayout.getCTASplitNum(), resultType.getShape());
+  auto warpsPerTile =
+      planWarps(dotOp, shapePerCTA, ttg::lookupNumWarps(dotOp), {mDim, nDim});
+  SmallVector<unsigned> instrPerDim = {mDim, nDim};
+  for (auto [dim, tiles] : llvm::enumerate(requested)) {
+    if (tiles <= 0)
+      return dotOp.emitOpError()
+             << AttrAMDWmmaTilesPerWarp << " entries must be positive";
+    uint64_t requiredExtent = static_cast<uint64_t>(instrPerDim[dim]) *
+                              warpsPerTile[dim] * static_cast<unsigned>(tiles);
+    if (static_cast<uint64_t>(shapePerCTA[dim]) < requiredExtent)
+      return dotOp.emitOpError()
+             << AttrAMDWmmaTilesPerWarp << " requires extent " << requiredExtent
+             << " in dimension " << dim
+             << ", which exceeds the result tile shape";
+  }
+  return success();
 }
 
 // Chooses a proper MFMA instruction that can used to compute the given dot op.
@@ -1188,8 +1227,15 @@ public:
 
     auto warpsPerTile =
         planWarps(dotOp, oldShapePerCTA, numWarps, {mDim, nDim});
-    // TODO: Select tilesPerWarp in Triton
     SmallVector<unsigned> tilesPerWarp(rank, 1u);
+    if (auto attr =
+            dotOp->getAttrOfType<DenseI32ArrayAttr>(AttrAMDWmmaTilesPerWarp)) {
+      ArrayRef<int32_t> requested = attr.asArrayRef();
+      tilesPerWarp.clear();
+      llvm::transform(
+          requested, std::back_inserter(tilesPerWarp),
+          [](int32_t tiles) { return static_cast<unsigned>(tiles); });
+    }
 
     auto ctaLayout =
         ttg::chooseWmmaCTALinearLayout(ctx, rank, warpsPerTile, tilesPerWarp);
@@ -1760,6 +1806,16 @@ struct TritonAMDGPUAccelerateMatmulPass
     TargetFeatures targetFeatures{llvm::StringRef(gfxArch)};
     auto isaFamily = targetFeatures.getISAFamily();
     unsigned wmmaVersion = getWmmaVersion(isaFamily);
+    if (isaFamily == ISAFamily::GFX1250) {
+      WalkResult validation = m.walk([&](tt::DotScaledOp dotOp) {
+        return failed(validateWmmaTilesPerWarp(dotOp)) ? WalkResult::interrupt()
+                                                       : WalkResult::advance();
+      });
+      if (validation.wasInterrupted()) {
+        signalPassFailure();
+        return;
+      }
+    }
     switch (isaFamily) {
     case ISAFamily::GFX1250:
       mfmaPatterns.add<ScaledBlockedToScaledWMMAF8F6F4>(context, wmmaVersion,

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -538,6 +538,26 @@ void init_triton_tlx_ir(py::module &&m) {
                                                  versionMinor, warpsPerCTA,
                                                  CTALayout, instrShape)));
            })
+      .def("make_amd_wmma_encoding_attr",
+           [](TritonOpBuilder &self, unsigned version, bool transposed,
+              std::vector<std::vector<int32_t>> &warpBases,
+              std::vector<std::vector<int32_t>> &regBases,
+              std::vector<unsigned> &instrShape, unsigned rank) -> Attribute {
+             auto ctx = self.getBuilder().getContext();
+             auto kReg = mlir::StringAttr::get(ctx, "register");
+             auto kWarp = mlir::StringAttr::get(ctx, "warp");
+             auto ctaLayout =
+                 tt::LinearLayout({{kReg, regBases}, {kWarp, warpBases}},
+                                  tt::standardOutDimNames(ctx, rank));
+             auto cgaLayout = ttg::CGAEncodingAttr::get1CTALayout(ctx, rank);
+             return mlir::cast<Attribute>(ttg::AMDWmmaEncodingAttr::get(
+                 ctx, version, ctaLayout, transposed, cgaLayout, instrShape));
+           })
+      .def(
+          "make_i32_array_attr",
+          [](TritonOpBuilder &self, std::vector<int32_t> &values) -> Attribute {
+            return self.getBuilder().getDenseI32ArrayAttr(values);
+          })
       .def("make_dot_operand_encoding_attr",
            [](TritonOpBuilder &self, Value opnd, unsigned opIdx,
               Attribute parentEnc) -> Attribute {

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -71,8 +71,10 @@ from .mma_ops import (
     async_dot,
     async_dot_scaled,
     async_dot_wait,
+    dot_scaled,
     extract_slice,
     rematerialized_range,
+    require_amd_wmma_layout,
     require_layout,
     tcgen05_commit,
 )
@@ -213,6 +215,8 @@ __all__ = [
     "named_barrier_arrive",
     "amd_sched_barrier",
     # mma_ops
+    "dot_scaled",
+    "require_amd_wmma_layout",
     "async_dot",
     "async_dot_scaled",
     "async_dot_wait",

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -269,6 +269,81 @@ def require_tmem_scales_layout(src: tlx.buffered_tensor, _builder=None):
     return _builder.create_require_layout(src.handle, layout_handle)
 
 
+@tl.builtin
+def require_amd_wmma_layout(
+        src,
+        version: tl.constexpr = 3,
+        transposed: tl.constexpr = True,
+        warp_bases: tl.constexpr = ((0, 2), (2, 0)),
+        reg_bases: tl.constexpr = ((0, 1), (1, 0)),
+        instr_shape: tl.constexpr = (16, 16, 128),
+        _semantic=None,
+):
+    """Pin a tensor to an explicit AMD WMMA register layout."""
+    version = int(tl._unwrap_if_constexpr(version))
+    transposed = bool(tl._unwrap_if_constexpr(transposed))
+    warp_bases = [list(row) for row in tl._unwrap_if_constexpr(warp_bases)]
+    reg_bases = [list(row) for row in tl._unwrap_if_constexpr(reg_bases)]
+    instr_shape = list(tl._unwrap_if_constexpr(instr_shape))
+    rank = len(src.shape)
+    layout_handle = _semantic.builder.make_amd_wmma_encoding_attr(
+        version,
+        transposed,
+        warp_bases,
+        reg_bases,
+        instr_shape,
+        rank,
+    )
+    handle = _semantic.builder.create_require_layout(src.handle, layout_handle, pin=True)
+    return tl.tensor(handle, src.type)
+
+
+@tl.builtin
+def dot_scaled(
+    lhs,
+    lhs_scale,
+    lhs_format,
+    rhs,
+    rhs_scale,
+    rhs_format,
+    acc=None,
+    fast_math=False,
+    lhs_k_pack=True,
+    rhs_k_pack=True,
+    out_dtype=tl.float32,
+    tiles_per_warp: tl.constexpr = None,
+    _semantic=None,
+):
+    """Call ``tl.dot_scaled`` with an optional AMD WMMA tile schedule."""
+    result = tl.dot_scaled(
+        lhs,
+        lhs_scale,
+        lhs_format,
+        rhs,
+        rhs_scale,
+        rhs_format,
+        acc,
+        fast_math,
+        lhs_k_pack,
+        rhs_k_pack,
+        out_dtype,
+        _semantic=_semantic,
+    )
+    tiles_per_warp = tl._unwrap_if_constexpr(tiles_per_warp)
+    if tiles_per_warp is not None:
+        tiles_per_warp = [int(tile) for tile in tiles_per_warp]
+        rank = len(result.shape)
+        if len(tiles_per_warp) != rank:
+            raise ValueError(f"tiles_per_warp requires {rank} entries, got {len(tiles_per_warp)}")
+        if any(tile <= 0 for tile in tiles_per_warp):
+            raise ValueError("tiles_per_warp entries must be positive")
+        result.handle.set_attr(
+            "amdg.wmma_tiles_per_warp",
+            _semantic.builder.make_i32_array_attr(tiles_per_warp),
+        )
+    return result
+
+
 def _get_use_acc_handle(use_acc: tl.constexpr | tl.tensor | None, _builder):
     if use_acc is None:
         return None


### PR DESCRIPTION
Preshuffled gfx1250 MXFP kernels require stable accumulator ownership and epilogue layouts. Teach scaled WMMA lowering to consume an optional amdg.wmma_tiles_per_warp hint and use it when constructing the CTA linear layout.

Expose the hint through tlx.dot_scaled while preserving default tl.dot_scaled behavior when it is omitted. Also add tlx.require_amd_wmma_layout so kernels can pin explicit register and warp bases for epilogue tensors.

Validate hint rank, positivity, and tile extent in both the frontend and backend, using overflow-safe extent arithmetic. This commit provides compiler and frontend infrastructure only; kernel adoption follows separately.

Tests cover exact WMMA layout lowering, invalid and overflowing hints, Python-to-TTIR attribute propagation, and compilation of explicitly pinned layouts.

Extracted from https://github.com/facebookexperimental/triton/pull/2773