### PR TITLE
[triton][bitequiv] Fix the last over-merge: causal-attention folds

### DIFF
--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -36,7 +36,7 @@ from bitequiv.ptx.forward.loops import (find_loops, loop_accumulates, loop_carri
 from bitequiv.ptx.forward.predicate import PredicateDecoder
 from bitequiv.ptx.leaves import leaf_coord, leaf_columns
 from bitequiv.ptx.linker import DefUse, _def_regs, linearize
-from bitequiv.ptx.mma import _fence_all_matmul, _is_mma, _mma_fence
+from bitequiv.ptx.mma import _fence_all_matmul, _is_mma, _mma_fence, mma_token_counts
 from bitequiv.ptx.treeir import (FpOp, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp, ShflCombine,
                                  SmemExchange)
 
@@ -748,7 +748,9 @@ def _mma_entry_descriptor(func, fence):
     runs extra fp arithmetic inside the fold (``input_precision=tf32x3``, whose compensation sums are
     grouped per K chunk, so its BLOCK_K IS bit-relevant). The fingerprint — not ``loops=`` alone — is
     the fallback ON PURPOSE: a tcgen05 fold increments no pointer, so ``_loop_steps`` is empty there
-    and ``loops=`` would leave the descriptor chunk-blind exactly where the proof failed."""
+    and ``loops=`` would leave the descriptor chunk-blind exactly where the proof failed. The
+    fail-closed side additionally carries ``mmacnt=`` (:func:`bitequiv.ptx.mma.mma_token_counts`), the
+    matmul reduction extent the fence drops on the strength of a proof that did not hold here."""
     from bitequiv.ptx.forward.loops import is_pure_mma_fold, reduction_trip_signature
     from bitequiv.ptx_reduction import _loop_steps
     parts = [_fence_str(fence)]
@@ -777,6 +779,12 @@ def _mma_entry_descriptor(func, fence):
         # closed on the conservative per-config fingerprint, which carries num_warps, the ordered
         # shuffle sequence and the op counts, so any of those differing splits.
         parts.append("mma+fp|" + interp.fingerprint())
+        # The fingerprint counts every fp op EXCEPT the tensor-core ones, which the fence drops on
+        # purpose (a re-tiling issues a different MMA count over the same dot products). That licence
+        # comes from the pure-fold proof, which just failed here, so put the count back: it is the one
+        # witness of the matmul's REDUCTION EXTENT (attention's head dim, a GEMM's K), which the rest
+        # of the key cannot see. Fail-closed side only -> a proven-pure fold keeps BLOCK_K and v2==v5.
+        parts.append("mmacnt=" + ",".join(f"{t}x{n}" for t, n in mma_token_counts(func)))
     steps = _loop_steps(func)
     # BLOCK_K is bit-neutral only for a PROVEN-pure f16/bf16/tf32 tensor-core fold: native-k is fixed
     # and each MMA's F=25 accumulate is exact, so BLOCK_K then only re-batches the same in-order

--- a/bitequiv/ptx/forward/loops.py
+++ b/bitequiv/ptx/forward/loops.py
@@ -12,6 +12,8 @@ descriptor drop its chunk (BLOCK_K) fence.
 """
 from pyptx.ir.nodes import Block, ImmediateOperand, Label, RegisterOperand, VectorOperand
 
+from bitequiv.ptx.affine import Affine, AffineEval, reqntid_of
+from bitequiv.ptx.linker import DefUse
 from bitequiv.ptx.mma import _is_mma
 
 # fp combine ops + widths, used to detect a loop-carried floating-point accumulation.
@@ -278,6 +280,40 @@ def _setp_bounds_of(insts, regs):
     return out
 
 
+def _symbolic_bounds_of(insts, regs, ev):
+    """Canonical form of the RUNTIME (non-literal) values a counter in ``regs`` is compared against.
+
+    :func:`_setp_bounds_of` sees a bound only when it is an immediate. A reduction loop whose bound is
+    computed at run time — the common tiled / triangular case ``for j in range(0, program_id * TILE)``
+    — is then invisible, and two configs whose folds are split at DIFFERENT points share a signature.
+    Evaluating the bound register as an :class:`~bitequiv.ptx.affine.Affine` over the symbol basis
+    recovers exactly the missing fact: the bound is ``TILE * %ctaid``, so ``TILE`` (how many chunks
+    this CTA's fold covers before the loop hands over to the next region) is in the key.
+
+    A value that is not PROVABLY affine yields one fixed placeholder rather than its structural token:
+    that token inlines unresolved register names, which are allocation noise and would split
+    bit-identical configs. Recording only "a runtime bound of unknown form is present" keeps the term
+    stable while still separating it from a proven affine one."""
+    out = set()
+    for i, inst in enumerate(insts):
+        if inst.opcode != "setp" or len(inst.operands) < 3:
+            continue
+        comparands = inst.operands[1:]
+        if not any(isinstance(o, RegisterOperand) and o.name in regs for o in comparands):
+            continue
+        for o in comparands:
+            if isinstance(o, RegisterOperand) and o.name not in regs:
+                value = ev.of_reg(o.name, i)
+                out.add(value.to_str() if isinstance(value, Affine) else "?")
+    return out
+
+
+def _with_bounds(base, bounds):
+    """``base`` alone when no runtime bound was recovered (byte-identical to the two-tier signature),
+    else ``base`` plus the ``("bound", ...)`` tier."""
+    return base if not bounds else (base, ("bound", tuple(sorted(bounds))))
+
+
 def reduction_trip_signature(func):
     """Hashable fingerprint that distinguishes the outer reduction loops' TRIP COUNTS (the split-K
     regrouping = num_splits), or ``None`` when the entry has no nested-reduction structure (a plain
@@ -294,12 +330,21 @@ def reduction_trip_signature(func):
       likewise tiling-invariant per split count.
     Both are keyed on num_splits and independent of the tiling axes, so they recover the tiling freedom
     while keeping the split counts distinct. Returns ``None`` unless an outer reduction loop exists, so
-    a plain tiled GEMM keeps its tiling-invariant fence."""
+    a plain tiled GEMM keeps its tiling-invariant fence.
+
+    Neither tier can see a bound that is not a compile-time constant, so a third ``("bound", ...)``
+    tier (:func:`_symbolic_bounds_of`) carries the RUNTIME bounds as affine forms. It is appended, not
+    substituted, so a signature that has no runtime bound is byte-identical to before — the tier can
+    only ever SPLIT. This is what fences a fold whose split point moves with the output tile: causal
+    attention runs its unmasked KV blocks in one loop up to ``BLOCK_M * program_id`` and the masked
+    diagonal band in a second loop with DIFFERENT arithmetic, so ``BLOCK_M`` decides which KV blocks
+    are rounded which way even though both loops exist, with the same op mix, at every ``BLOCK_M``."""
     insts, loops = find_loops(func)
     splitloops = outer_reduction_loops(insts, loops)
     if not splitloops:
         return None
-    clean = set()
+    ev = AffineEval(DefUse(func), reqntid_of(func))
+    clean, bounds = set(), set()
     for h, latch in splitloops:
         steps = {}
         for k in range(h, latch + 1):
@@ -312,11 +357,12 @@ def reduction_trip_signature(func):
                         steps[d.name] = int(b.text, 0)
                     except (ValueError, TypeError):
                         continue
+        bounds |= _symbolic_bounds_of(insts, set(steps), ev)
         for reg, step in steps.items():
             for bound in _setp_bounds_of(insts, {reg}):
                 clean.add((step, bound))
     if clean:
-        return ("trip", tuple(sorted(clean)))
+        return _with_bounds(("trip", tuple(sorted(clean))), bounds)
     region = []
     for h, latch in splitloops:
         cs = set()
@@ -330,4 +376,4 @@ def reduction_trip_signature(func):
                         except (ValueError, TypeError):
                             continue
         region.append(tuple(sorted(cs)))
-    return ("region", tuple(sorted(region)))
+    return _with_bounds(("region", tuple(sorted(region))), bounds)

--- a/bitequiv/ptx/mma.py
+++ b/bitequiv/ptx/mma.py
@@ -205,3 +205,21 @@ def _mma_fence(func):
             counts[t] = counts.get(t, 0) + 1
         return ("mma-fp8", tuple(sorted(counts.items())), flags, (fma, addmul))
     return ("mma", frozenset(tokens), flags, (int(fma > 0), int(addmul > 0)))
+
+
+def mma_token_counts(func):
+    """Sorted ``(token, count)`` of the entry's tensor-core matmuls — how many hardware accumulate
+    passes each :func:`_mma_token` contributes.
+
+    :func:`_mma_fence` deliberately DROPS this count for the non-fp8 families, because for a
+    PROVEN-pure tensor-core fold a re-tiling issues a different number of MMA instructions over the
+    same dot products (bit-free). That licence does not exist when the fold is NOT proven pure: there
+    the count is the only PTX witness of how many products reach an accumulator, i.e. of the matmul's
+    REDUCTION EXTENT (attention's head dim, a GEMM's K). Callers on the fail-closed side use this;
+    the fence itself must not, or it would over-split every equivalent re-tiling."""
+    counts = {}
+    for inst in linearize(func):
+        if _is_mma(inst):
+            t = _mma_token(inst.opcode, inst.modifiers)
+            counts[t] = counts.get(t, 0) + 1
+    return tuple(sorted(counts.items()))

--- a/bitequiv/tests/test_ptx_attention.py
+++ b/bitequiv/tests/test_ptx_attention.py
@@ -1,0 +1,147 @@
+"""Two fail-closed MMA residuals that flash attention exposes, in hand-crafted PTX (CPU-only).
+
+1. A fold whose SPLIT POINT moves with the output tile. Causal attention runs its fully-unmasked KV
+   blocks in one loop bounded by ``BLOCK_M * program_id`` and the masked diagonal band in a second
+   loop with DIFFERENT arithmetic. Both loops exist, with the same op mix, at every ``BLOCK_M`` — only
+   the runtime bound moves — so every count-based term of the key is identical while the bits are not.
+   :func:`~bitequiv.ptx.forward.loops.reduction_trip_signature` must carry the bound's affine form.
+2. The matmul REDUCTION EXTENT. The fence drops the MMA count because a re-tiling issues a different
+   count over the same dot products — a licence that comes from the pure-fold proof. Where that proof
+   fails, the count is the only witness of how many products reach the accumulator (attention's head
+   dim), so it must be back in the key; where it holds, it must stay out (BLOCK_K / v2==v5 recovery).
+"""
+from pyptx.parser import parse
+
+from bitequiv.ptx.forward import loops
+from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
+from bitequiv.ptx.mma import mma_token_counts
+from bitequiv.ptx_reduction import _ensure_header, ptx_header
+
+_HDR = ptx_header()
+_MMA = "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r3}, %r4, %r5;\n"
+# A cross-lane butterfly makes the entry reduce over the MMA output -> the fail-closed branch.
+_REDUCE = "shfl.sync.bfly.b32 %r6, %r7, 16, 31, -1;\nadd.f32 %f1, %f1, %f3;\n"
+
+
+def _entry(ptx):
+    return next(d for d in parse(_ensure_header(ptx)).directives if getattr(d, "is_entry", False))
+
+
+def _tiled_fold(tile, nmma=1, first=0):
+    """An accumulating loop whose bound is ``tile * program_id`` — the unmasked region of a
+    tile-diagonal fold. ``first`` shifts every virtual register number (allocation noise)."""
+    r = lambda n: f"%r{n + first}"  # noqa: E731
+    return _HDR + f"""
+.visible .entry k(.param .u64 p) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<{16 + first}>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.f32 %f1, 0f00000000;
+  mov.u32 {r(8)}, %ctaid.x;
+  mul.lo.s32 {r(9)}, {r(8)}, {tile};
+  mov.b32 {r(1)}, 0;
+$L__FOLD:
+  {_MMA * nmma}  {_REDUCE}  add.s32 {r(1)}, {r(1)}, 1;
+  setp.lt.s32 %p1, {r(1)}, {r(9)};
+  @%p1 bra $L__FOLD;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+def _param_fold(first=0):
+    """Same fold, but bounded by a kernel PARAM (no tile scaling) — the non-causal shape."""
+    r = lambda n: f"%r{n + first}"  # noqa: E731
+    return _HDR + f"""
+.visible .entry k(.param .u64 p, .param .u32 n) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<{16 + first}>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  ld.param.u32 {r(9)}, [n];
+  mov.f32 %f1, 0f00000000;
+  mov.b32 {r(1)}, 0;
+$L__FOLD:
+  {_MMA}  {_REDUCE}  add.s32 {r(1)}, {r(1)}, 1;
+  setp.lt.s32 %p1, {r(1)}, {r(9)};
+  @%p1 bra $L__FOLD;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+def _pure_fold(nmma):
+    """A PROVEN-pure tensor-core fold (accumulator touched only by MMA, no reduction over the output):
+    the case whose MMA count MUST stay out of the key so re-tiling / v2==v5 keep merging."""
+    return _HDR + f"""
+.visible .entry k(.param .u64 p) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.b32 %r1, 0;
+$L__K:
+  {_MMA * nmma}  add.s32 %r1, %r1, 16;
+  setp.lt.s32 %p1, %r1, 256;
+  @%p1 bra $L__K;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+# -- 1. the fold's split point ------------------------------------------------------------------
+
+
+def test_runtime_bound_recovered_as_affine():
+    sig = loops.reduction_trip_signature(_entry(_tiled_fold(64)))
+    assert ("bound", ("64*%ctaid.x", )) in sig
+
+
+def test_tile_scale_of_a_runtime_bound_splits():
+    # POSITIVE: same instructions, same counts -- only the tile the bound scales by differs.
+    assert loops.reduction_trip_signature(_entry(_tiled_fold(64))) \
+        != loops.reduction_trip_signature(_entry(_tiled_fold(128)))
+    assert CHECK(_tiled_fold(64)) != CHECK(_tiled_fold(128))
+
+
+def test_same_bound_does_not_split_on_register_noise():
+    # NEGATIVE: one runtime bound, two register numberings. The tier is the bound's affine FORM, not
+    # its text, so allocation noise must not separate two bit-identical configs.
+    assert loops.reduction_trip_signature(_entry(_param_fold(0))) \
+        == loops.reduction_trip_signature(_entry(_param_fold(32)))
+    assert CHECK(_param_fold(0)) == CHECK(_param_fold(32))
+
+
+def test_no_runtime_bound_leaves_the_signature_untouched():
+    # NEGATIVE: a fold with no reduction loop at all keeps `None` -- a plain tiled GEMM must not
+    # acquire a `splits=` fence (that would undo its tiling recovery).
+    assert loops.reduction_trip_signature(_entry(_pure_fold(1))) is None
+    assert "splits=" not in str(CHECK(_pure_fold(1)))
+
+
+# -- 2. the matmul reduction extent -------------------------------------------------------------
+
+
+def test_token_counts_count_every_matmul():
+    assert mma_token_counts(_entry(_pure_fold(3))) == (("matmul|f16|cta1", 3), )
+
+
+def test_reduction_extent_splits_when_the_fold_is_not_proven_pure():
+    # POSITIVE: an entry that reduces over the MMA output and issues twice the matmuls is summing
+    # twice the products -- a different value -- so it must not share the fail-closed key.
+    a, b = CHECK(_param_fold()), CHECK(_param_fold().replace(_MMA, _MMA * 2, 1))
+    assert "mma+fp|" in str(a) and a != b
+
+
+def test_reduction_extent_stays_out_of_a_proven_pure_fold():
+    # NEGATIVE: re-tiling a proven-pure fold issues a different MMA count over the SAME dot products.
+    # The count must not leak into that key, or BLOCK_K and v2==v5 stop merging.
+    assert "mma+fp|" not in str(CHECK(_pure_fold(1)))
+    assert CHECK(_pure_fold(1)) == CHECK(_pure_fold(2))


### PR DESCRIPTION
Summary:
`flash_attention` was the only kernel left in the corpus whose forward PTX checker over-merges: it hands two configs the same descriptor while the hardware produces different bits. Everything else — all the reductions, the whole GEMM family, and fp8/fp8e5m2 FA — was already at `over_merges == 0`. On the full corpus this defect splits in two.

**Defect 1 (the real soundness bug).** Same problem shape, only `BLOCK_M` differs, bits differ, descriptor identical: 69 pairs in f16 and 69 in bf16, and **every one of them is `causal=True`**. `BLOCK_M` is a genuine autotuning knob, so an autotuner really would compare these two configs and could ship the wrong one. The cause is structural: causal attention runs its fully-unmasked KV blocks in one loop bounded by `BLOCK_M * program_id` and the masked diagonal band in a second loop whose arithmetic is different (the mask bias is added before the running-max subtraction). Moving `BLOCK_M` moves the boundary, so a given KV block is rounded one way at `BLOCK_M=64` and the other way at `BLOCK_M=128`. Both loops exist, with the same op mix, at every `BLOCK_M` — only the runtime bound moves — so the per-thread op counts, the shuffle sequence, the shared-store widths, `ntid`, `loops=` and `splits=` are all bit-identical between the two PTX files, and the key was blind to the one thing that changed. Non-causal attention has no such boundary (its KV loop is bounded by the sequence-length parameter, not by the tile), which is exactly why only the causal pairs are affected.

**Defect 2 (the descriptor's contract).** 54 pairs per dtype collide across `HEAD_DIM` 64 vs 128. An autotuner never compares across `HEAD_DIM` — it is a problem-shape parameter, like a GEMM's M/N/K — so this is not an autotuning hazard, but the descriptor claims "same key means same bits" and that claim is false here. The two entries issue a different number of tensor-core matmuls (20 vs 12 in the measured pair) because `HEAD_DIM` is the reduction extent of the QK matmul, yet the count is nowhere in the key.

The fix is two pure splitters, each scoped to the side of the checker where the proof it depends on has already failed.

`reduction_trip_signature` gains a third `("bound", ...)` tier (`_symbolic_bounds_of`). It already fences how many chunks an fp accumulation folds, but only through LITERAL `setp` bounds; a bound computed at run time was invisible. The new tier evaluates the bound register as an `Affine` over the symbol basis, which recovers `64*%ctaid.x` vs `128*%ctaid.x` — literally "how many chunks this CTA's fold covers before the loop hands over to the next region". A value that is not provably affine yields one fixed placeholder instead of its structural token, because that token inlines unresolved register names and would split on allocation noise. The tier is APPENDED, never substituted, so a signature with no runtime bound is byte-identical to before, and the gate stays `outer_reduction_loops` so a plain tiled GEMM still gets `None` and keeps its tiling recovery.

`_mma_entry_descriptor`'s fail-closed branch gains `mmacnt=` (`mma_token_counts`). The fence drops the matmul count on purpose, because for a PROVEN-pure fold a re-tiling issues a different count over the same dot products — but that licence comes from `is_pure_mma_fold`, which by definition did not hold on this branch. The fingerprint next to it already counts every OTHER fp op per thread, so leaving the tensor-core ops uncounted was the inconsistency; the count is the only witness in the PTX of the matmul's reduction extent. The proven-pure path is untouched, so `BLOCK_K` and v2 == v5 keep merging.

Neither term can merge anything, so neither can create a new over-merge.

**Support table.** Full corpus, no sampling. Both keys are computed over the SAME population in one pass (the "before" column is the committed key captured before the edit; a monkeypatch reconstruction of the committed behaviour was verified byte-identical on 558/558 sampled configs across 10 kernel/dtype pairs). FA is `seeds=50`, everything else `seeds=20` or `12`; keys are never compared across kernels.

| kernel / dtype | configs | empirical classes | checker classes before | after | over-merges before | after |
|---|---|---|---|---|---|---|
| `flash_attention` / f16 | 2720 | 266 | 2546 | 2655 | 123 (D1 69, D2 54) | **0** |
| `flash_attention` / bf16 | 2721 | 260 | 2547 | 2656 | 123 (D1 69, D2 54) | **0** |
| `flash_attention` / fp8 | 2070 | 112 | 2070 | 2070 | 0 | 0 |
| `flash_attention` / fp8e5m2 | 2069 | 112 | 2069 | 2069 | 0 | 0 |
| `gemm` / f16 | 5394 | 1 | 1 | 1 | 0 | 0 |
| `gemm` / fp8 | 4758 | 2 | 2 | 2 | 0 | 0 |
| `gemm_tma_store` / f16 | 18 | 1 | 1 | 1 | 0 | 0 |
| `LC_splitk_gemm_f16` / f16 | 4 | 4 | 4 | 4 | 0 | 0 |
| `dot` / f16 | 144 | 1 | 19 | 19 | 0 | 0 |
| `col_dot` / f16 | 144 | 10 | 15 | 15 | 0 | 0 |
| `col_max` / f16 | 144 | 1 | 6 | 6 | 0 | 0 |
| `col_sum_loop` / f16 | 144 | 7 | 12 | 12 | 0 | 0 |
| `cond_reduce` / f16 | 144 | 7 | 24 | 24 | 0 | 0 |
| `layernorm` / f16 | 144 | 9 | 20 | 20 | 0 | 0 |
| `rmsnorm` / f16 | 144 | 8 | 18 | 18 | 0 | 0 |
| `softmax` / f16 | 144 | 4 | 16 | 16 | 0 | 0 |
| `sum` / f16 | 144 | 7 | 12 | 12 | 0 | 0 |
| `sum_2d_axis0` / f16 | 144 | 7 | 12 | 12 | 0 | 0 |
| `sum_2d_col` / f16 | 144 | 7 | 12 | 12 | 0 | 0 |
| `sum_2d_col_big` / f16 | 144 | 7 | 12 | 12 | 0 | 0 |
| `sum_2d_deep` / f16 | 144 | 4 | 12 | 12 | 0 | 0 |
| `sum_2d_keepdim` / f16 | 144 | 3 | 12 | 12 | 0 | 0 |
| `sum_3d` / f16 | 144 | 3 | 12 | 12 | 0 | 0 |
| `sum_3d_mid` / f16 | 144 | 4 | 12 | 12 | 0 | 0 |
| `sum_3d_outer` / f16 | 144 | 7 | 11 | 11 | 0 | 0 |
| `sum_4d` / f16 | 144 | 3 | 12 | 12 | 0 | 0 |
| `sum_multiaxis` / f16 | 144 | 3 | 12 | 12 | 0 | 0 |
| `LC_sum_loop_f16` / f16 | 20 | 20 | 20 | 20 | 0 | 0 |
| **total** | **22510** | 880 | 9521 | 9739 | **246** | **0** |

Legend: "configs" = compiled+fuzzed configs graded (`ok=true` only); "empirical classes" = distinct bit-output classes the fuzzer found; "checker classes" = distinct descriptors; "over-merges" = ordered pairs of configs the checker calls equal that the fuzzer says differ; D1/D2 = the two defects above.

**Robustness.** Measured on the full cached corpus at 22510 configs across 28 kernel/dtype pairs (every f16 and fp8 kernel plus all four FA dtypes); nothing was sampled and no gate was frozen. Over-merges go 246 to 0 and no kernel gains one. The recovery cost is zero in the sense that matters: on FA f16 the CORRECT merged pairs stay at 86 before and after while the wrong ones go 123 to 0 (bf16 the same), and every one of the 86 survivors is a `causal=False` `BLOCK_M` pair — so non-causal attention keeps its full `BLOCK_M` freedom and only the causal configs, which genuinely differ in bits, split. The class-count rise (+109 on FA f16 and bf16, the only two rows that move at all) is entirely the 123 wrong merges being taken apart. Every other row is byte-identical, including the pure-GEMM single class over 5394 f16 and 4758 fp8 configs, so `BLOCK_K`, v2 == v5 and split-K are untouched; a plain GEMM still returns `None` from `reduction_trip_signature`, and the `mmacnt=` term never reaches a proven-pure fold. Both new terms are cheap: peak RSS stays under 0.8 GB on the largest 8.4 MB FA PTX, and the affine evaluation is limited to the comparands of the reduction loops' exit tests, so it cannot walk into the O(n^2) token blow-up that a whole-entry evaluation hits. Known limitations: the `("bound", ...)` tier only fires for loops `outer_reduction_loops` recognises, so a fold whose accumulation the recognizer misses is still bound-blind; a bound that is not provably affine collapses to one placeholder, so two different unprovable bounds do not separate; the tier is a FENCE, not recovery, so two causal configs that really do fold identically now split (over-split, sound); and this is measured on GB300 sm_100 PTX only, with H100 unverified for these two terms.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D114345591


