### PR TITLE
[triton][bitequiv] Forward checker: share one signature memo across an entry's output roots

### DIFF
--- a/bitequiv/ptx/builder.py
+++ b/bitequiv/ptx/builder.py
@@ -225,11 +225,17 @@ class _Builder:
         return FpOp(tag, aux, tuple(kids))  # tag == fp kind (add/sub/mul/div/min/max)
 
 
-def _postorder(root):
-    """Nodes of a tree in post-order (children before parents), each visited once even in a
-    shared DAG. Iterative, so deep folds never hit Python's recursion limit."""
+def _forest_postorder(roots):
+    """Nodes of a whole FOREST in post-order (children before parents), each visited once even
+    when the roots share subtrees. Iterative, so deep folds never hit Python's recursion limit.
+
+    Walking (and re-materializing) per root costs O(roots x nodes) on a DAG whose roots share a
+    long chain — a prefix scan, where ``root[i]`` contains ``root[i-1]``, is the worst case. One
+    shared walk makes it O(unique nodes). The emission ORDER differs from the concatenated
+    per-root walks; that is immaterial because every consumer computes a node's value from its
+    children's values, so only children-before-parents matters."""
     order, seen = [], set()
-    stack = [(root, False)]
+    stack = [(r, False) for r in reversed(roots)]
     while stack:
         node, done = stack.pop()
         if id(node) in seen:
@@ -245,6 +251,12 @@ def _postorder(root):
     return order
 
 
+def _postorder(root):
+    """Nodes of one tree in post-order (children before parents), each visited once even in a
+    shared DAG."""
+    return _forest_postorder([root])
+
+
 def tree_sig(root):
     """Full canonical signature string of a tree (readable; for small trees / debugging).
     A shared DAG inlines a shared subtree at each reference, so this can be very large for a
@@ -255,15 +267,25 @@ def tree_sig(root):
     return memo[id(root)]
 
 
+def tree_hashes(roots):
+    """:func:`tree_hash` for EVERY root of one shared DAG, hashing each unique node ONCE.
+
+    A per-root call gives each root a fresh memo, so a subtree shared by k roots is re-hashed k
+    times. The hash is a pure bottom-up Merkle fold — a node's hash is a function of its own local
+    string and its children's hashes, never of which root reached it — so one shared memo yields
+    byte-identical hashes for a fraction of the work."""
+    h = {}
+    for node in _forest_postorder(roots):
+        local = node.sig_local([h[id(c)] for c in node.children])
+        h[id(node)] = hashlib.sha1(local.encode()).hexdigest()[:16]
+    return [h[id(r)] for r in roots]
+
+
 def tree_hash(root):
     """Compact canonical signature: a Merkle hash where each node hashes its local string
     over its children's hashes. Equal trees (including shared DAGs) -> equal hash, computed
     once per unique node, so the descriptor stays O(1)-sized regardless of reduction size."""
-    h = {}
-    for node in _postorder(root):
-        local = node.sig_local([h[id(c)] for c in node.children])
-        h[id(node)] = hashlib.sha1(local.encode()).hexdigest()[:16]
-    return h[id(root)]
+    return tree_hashes([root])[0]
 
 
 def build_trees(func):
@@ -297,13 +319,17 @@ def _is_reduce_node(n):
             or (isinstance(n, ShflCombine) and n.kind in _REDUCE_FP) or isinstance(n, SmemExchange))
 
 
-def _balance_pass(root):
+def _balance_pass(order):
     """Per node: (balanced, height, optok). A subtree is a balanced reduction iff every reduce
     node has children that are balanced reductions of one consistent op AND (for the 2-ary fp
     combine) their heights differ by <= 1 — the AVL property that separates inner_tree's balanced
-    tree from unordered's left-fold. Boundary leaves are trivial arity-1 balanced reductions."""
+    tree from unordered's left-fold. Boundary leaves are trivial arity-1 balanced reductions.
+
+    ``order`` is a post-order node list (one tree's or a whole forest's). Every value is a pure
+    function of the node's own subtree, so a forest-wide pass gives each node exactly the values a
+    per-tree pass would."""
     bal, ht, optok = {}, {}, {}
-    for n in _postorder(root):
+    for n in order:
         if _is_reduce_node(n):
             kids = list(n.children)
             ops = {optok[id(c)] for c in kids if optok[id(c)] is not None}
@@ -526,14 +552,34 @@ def output_coordfree_key(node):
     over-split) descriptor. This blanks more than the guarded reduction collapse (in particular it does
     not re-prove the elementwise assumption for a swizzled address), so it is gated on the empirical
     fuzzer (0 over-merge) rather than statically proven."""
-    for n in _postorder(node):
-        if isinstance(n, OpaqueLeaf) and "imm(" not in n.token:
-            return None  # a lost-provenance (non-constant) value -> unsafe to coord-blank
-        if isinstance(n, OpaqueOp) and not _tok_is_pure(n.token):
-            return None  # an unmodeled value op -> unsafe
-        if isinstance(n, Leaf) and n.coord is None:
-            return None  # no coord at all (not even opaque) -> nothing to blank soundly
-    return _coordfree_sig(node)
+    return output_coordfree_keys([node])[0]
+
+
+def _coordfree_blankable(n):
+    """Is THIS node (ignoring its children) safe to coord-blank? See :func:`output_coordfree_key`."""
+    if isinstance(n, OpaqueLeaf) and "imm(" not in n.token:
+        return False  # a lost-provenance (non-constant) value -> unsafe to coord-blank
+    if isinstance(n, OpaqueOp) and not _tok_is_pure(n.token):
+        return False  # an unmodeled value op -> unsafe
+    if isinstance(n, Leaf) and n.coord is None:
+        return False  # no coord at all (not even opaque) -> nothing to blank soundly
+    return True
+
+
+def output_coordfree_keys(nodes):
+    """:func:`output_coordfree_key` for EVERY output tree of one entry, sharing the safety scan and
+    the signature memo across them, so a subtree several outputs share is scanned and serialized
+    once instead of once per output. Both are pure bottom-up folds, so the returned keys are
+    byte-identical to the per-tree calls. Signatures are built only for the trees that passed the
+    scan (an unsafe tree returns ``None`` and its string is never needed)."""
+    order = _forest_postorder(nodes)
+    safe = {}
+    for n in order:
+        safe[id(n)] = _coordfree_blankable(n) and all(safe[id(c)] for c in n.children)
+    sig, wanted = {}, [n for n in nodes if safe[id(n)]]
+    for n in _forest_postorder(wanted):
+        sig[id(n)] = "L[]" if isinstance(n, Leaf) else n.sig_local([sig[id(c)] for c in n.children])
+    return [sig[id(n)] if safe[id(n)] else None for n in nodes]
 
 
 def _rebuild(n, kids):
@@ -569,20 +615,100 @@ def collapse_balanced(root):
       cross-warp reduction resolved to a representative), the set varies -> distinct -> stays
       over-split (sound, no recovery).
 
-    Iterative (no recursion on deep folds)."""
-    bal, ht, optok = _balance_pass(root)
-    # Collapse every MAXIMAL balanced reduction region, including per-chunk reductions nested
-    # under a persistent kernel's cross-chunk loop. The ITreeReduce token keeps the reduction
-    # height (= log2(BLOCK_N)+const, num_warps-invariant, BLOCK_N-monotone), so different chunk
-    # sizes stay in distinct classes.
-    collapsible = {id(n): (_is_reduce_node(n) and bal[id(n)] and optok[id(n)] is not None) for n in _postorder(root)}
-    has_coll_parent = {}
-    for n in _postorder(root):
+    Iterative (no recursion on deep folds). Use :func:`collapse_balanced_forest` for a multi-output
+    entry — calling this per output rebuilds every shared subtree once per output."""
+    order = _postorder(root)
+    ht, collapsible = _collapse_prep(order)
+    marks = {}
+    for n in order:
         if collapsible[id(n)]:
             for c in n.children:
-                has_coll_parent[id(c)] = True
+                marks[id(c)] = True
+    return _collapse_regions(order, [root], ht, collapsible, marks)[0]
+
+
+def _collapse_prep(order):
+    """(height, collapsible) per node of a post-order list. Collapse every MAXIMAL balanced
+    reduction region, including per-chunk reductions nested under a persistent kernel's cross-chunk
+    loop. The ITreeReduce token keeps the reduction height (= log2(BLOCK_N)+const,
+    num_warps-invariant, BLOCK_N-monotone), so different chunk sizes stay in distinct classes."""
+    bal, ht, optok = _balance_pass(order)
+    return ht, {id(n): (_is_reduce_node(n) and bal[id(n)] and optok[id(n)] is not None) for n in order}
+
+
+def collapse_balanced_forest(roots):
+    """:func:`collapse_balanced` for EVERY output root of one value-DAG, rebuilding each unique node
+    ONCE.
+
+    A per-root call gives each root a fresh output map, so a subtree shared by k roots is
+    re-materialized k times: O(roots x nodes) new node objects, all live at once (measured: a
+    512-root prefix scan expanded a 3,719-node DAG into 631,169 objects, ~2.5 n^2). Every quantity
+    the collapse computes is a pure bottom-up function of a node's own subtree — ``_balance_pass``,
+    ``collapsible``, ``_collapse_info``, ``_shfl_dir``, ``_rebuild`` — with ONE exception: whether a
+    node is a region ROOT also depends on its PARENTS, which are a per-root fact. That flag is
+    resolved by :func:`_shared_region_marks`, which falls back to the exact per-root pass when the
+    roots disagree."""
+    order = _forest_postorder(roots)
+    ht, collapsible = _collapse_prep(order)
+    marks = _shared_region_marks(order, roots, collapsible)
+    if marks is None:
+        return [collapse_balanced(r) for r in roots]
+    return _collapse_regions(order, roots, ht, collapsible, marks)
+
+
+# Cap on the root x node bitmasks :func:`_shared_region_marks` builds (bits, ~8 MB). Beyond it the
+# per-root pass is used instead — same descriptors, just the old cost.
+_MAX_REGION_MARK_BITS = 1 << 26
+
+
+def _shared_region_marks(order, roots, collapsible):
+    """One ``has_coll_parent`` map valid for EVERY root, or ``None`` when the roots disagree.
+
+    :func:`collapse_balanced` treats a collapsible node as a region ROOT only when no collapsible
+    PARENT of it is reachable from that root, so the same shared node can legitimately be a region
+    root under one output and be swallowed by a larger region under another. With one shared memo a
+    node is rebuilt once, so whichever answer came first would silently win for everyone — that
+    would move a collapse boundary and change a descriptor. Decide it exactly with two bitmasks over
+    the roots: ``reach[n]`` = the roots that reach n; ``mark[n]`` = the roots that reach some
+    collapsible parent of n. Root R sees ``has_coll_parent[n] = bit R of mark[n]``, so the roots
+    agree on n iff ``mark[n] & reach[n]`` is empty or is all of ``reach[n]``.
+
+    Only COLLAPSIBLE nodes are checked: ``region_root = collapsible[n] and not has_coll_parent[n]``
+    short-circuits, so the flag is never read anywhere else. That matters — a prefix scan does have
+    nodes whose parents differ per root, but none of them is collapsible, so the shared path stays
+    live exactly where it pays off."""
+    if len(roots) * len(order) > _MAX_REGION_MARK_BITS:
+        return None
+    reach = {}
+    for i, r in enumerate(roots):
+        reach[id(r)] = reach.get(id(r), 0) | (1 << i)
+    for n in reversed(order):  # reversed post-order visits every parent before its children
+        m = reach.get(id(n), 0)
+        if m:
+            for c in n.children:
+                reach[id(c)] = reach.get(id(c), 0) | m
+    mark = {}
+    for n in order:
+        if collapsible[id(n)]:
+            m = reach.get(id(n), 0)
+            for c in n.children:
+                mark[id(c)] = mark.get(id(c), 0) | m
+    out = {}
+    for n in order:
+        if not collapsible[id(n)]:
+            continue
+        m = mark.get(id(n), 0) & reach[id(n)]
+        if m:
+            if m != reach[id(n)]:
+                return None  # some root reaches n without reaching any collapsible parent of it
+            out[id(n)] = True
+    return out
+
+
+def _collapse_regions(order, roots, ht, collapsible, has_coll_parent):
+    """Collapsed tree of each root, sharing one output map over ``order`` (see the two callers)."""
     new = {}
-    for n in _postorder(root):
+    for n in order:
         region_root = collapsible[id(n)] and not has_coll_parent.get(id(n), False)
         info = _collapse_info(n, ht) if region_root else None
         if info is not None:
@@ -611,7 +737,7 @@ def collapse_balanced(root):
                 new[id(n)] = ITreeReduce(op, leaf_sig, ht[id(n)], _shfl_dir(n, ht))
         else:
             new[id(n)] = _rebuild(n, [new[id(c)] for c in n.children])
-    return new[id(root)]
+    return [new[id(r)] for r in roots]
 
 
 def _cols_key(cols):
@@ -634,4 +760,4 @@ def entry_signatures(func):
     roots = build_trees(func)
     if len(roots) == 1:
         roots = [collapse_balanced(roots[0])]
-    return tuple(sorted(tree_hash(t) for t in roots))
+    return tuple(sorted(tree_hashes(roots)))

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -28,8 +28,8 @@ import hashlib
 from pyptx.ir.nodes import RegisterOperand, VectorOperand
 
 from bitequiv.ptx.affine import AffineEval, canon, reqntid_of
-from bitequiv.ptx.builder import (_coordfree_sig, _postorder, collapse_balanced, output_coordfree_key,
-                                  tree_hash)
+from bitequiv.ptx.builder import (_forest_postorder, collapse_balanced, collapse_balanced_forest, output_coordfree_keys,
+                                  tree_hash, tree_hashes)
 from bitequiv.ptx.forward.cfg import has_unknown_control
 from bitequiv.ptx.forward.loops import (find_loops, loop_accumulates, loop_carried_accumulators,
                                         loop_self_increments)
@@ -144,6 +144,7 @@ class ForwardInterp:
         self.smem_stores = []
         self._smem_phase = []  # value nodes written since the last bar (the open phase)
         self._smem_closed = []  # value nodes of the most-recently closed phase (what a load reads)
+        self._cf_hash_memo = {}  # id(node) -> coord-free Merkle hash, for the `_resolve_smem` check
         # Sound floor: set False when the walk hits a cross-thread structure this phase does not
         # model faithfully (a cross-warp shared load). The reconstructed tree is then untrustworthy
         # for the verbatim hash (it would over-merge across num_warps), so forward_descriptor falls
@@ -554,6 +555,32 @@ class ForwardInterp:
             return [v.child]
         return [v]
 
+    def _cf_hash(self, node):
+        """Coord-free Merkle hash of a subtree (Leaf coordinates blanked) — the same equivalence the
+        string ``_coordfree_sig`` tests, but as a fixed-size hash that composes over CHILD hashes and
+        is memoized by node id across the whole run. ``_resolve_smem`` uses it to decide whether a
+        shared phase's writes all share one structure in O(new nodes) instead of serializing every
+        candidate's full subtree: the string form INLINES a shared subtree at each reference, so on a
+        deeply shared DAG (welford's unrolled two-pass fold) it is quadratic in the chain length and
+        one entry blew past a 20 GB cap. Only an equality test reads this, never a descriptor."""
+        memo = self._cf_hash_memo
+        if id(node) in memo:
+            return memo[id(node)]
+        stack = [(node, False)]
+        while stack:
+            n, done = stack.pop()
+            if id(n) in memo:
+                continue
+            if not done:
+                stack.append((n, True))
+                for c in n.children:
+                    if id(c) not in memo:
+                        stack.append((c, False))
+            else:
+                local = "L[]" if isinstance(n, Leaf) else n.sig_local([memo[id(c)] for c in n.children])
+                memo[id(n)] = hashlib.sha1(local.encode()).hexdigest()[:16]
+        return memo[id(node)]
+
     def _resolve_smem(self):
         """Value subtree a shared load / ldmatrix reads: a representative write from the most-recently
         CLOSED phase, or ``None`` (fail closed) when the phase is empty or its writes are not all the
@@ -565,7 +592,7 @@ class ForwardInterp:
         cands = self._smem_closed if self._smem_closed else self._smem_phase
         if not cands:
             return None
-        if len({_coordfree_sig(c) for c in cands}) != 1:
+        if len({self._cf_hash(c) for c in cands}) != 1:
             return None  # mixed-structure phase -> ambiguous without the address -> fail closed
         return cands[-1]
 
@@ -604,9 +631,10 @@ class ForwardInterp:
 _LDG_TYPE_MODS = frozenset({".b8", ".b16", ".b32", ".b64", ".b128", ".f16", ".f32", ".f64"})
 
 
-def _reduces_without_leaf(roots):
-    """True iff some RAW (uncollapsed) root reduces over a CROSS-THREAD structure (a
+def _reduces_without_leaf(nodes):
+    """True iff the RAW (uncollapsed) output forest reduces over a CROSS-THREAD structure (a
     ``ShflCombine`` butterfly / ``SmemExchange``) yet reaches NO loaded ``Leaf`` anywhere.
+    ``nodes`` is the forest post-order of the raw roots.
 
     Such a tree reduces only over a constant SEED + cross-warp shuffles — the reduced input
     data (the within-thread / chunk fold that feeds the accumulator) was NOT captured by the
@@ -619,12 +647,11 @@ def _reduces_without_leaf(roots):
     NORMAL reduction has no ``Leaf`` either — only the raw tree distinguishes a faithful
     leaf-bearing reduction from this data-losing one."""
     has_leaf = has_cross_thread = False
-    for r in roots:
-        for n in _postorder(r):
-            if isinstance(n, Leaf):
-                has_leaf = True
-            elif isinstance(n, (ShflCombine, SmemExchange)):
-                has_cross_thread = True
+    for n in nodes:
+        if isinstance(n, Leaf):
+            has_leaf = True
+        elif isinstance(n, (ShflCombine, SmemExchange)):
+            has_cross_thread = True
     return has_cross_thread and not has_leaf
 
 
@@ -642,6 +669,17 @@ def _global_load_shape(func):
     return ",".join(f"{k}x{n}" for k, n in sorted(m.items()))
 
 
+# Node budget for the signature stage. Past this many UNIQUE value-DAG nodes the entry takes the
+# conservative fingerprint instead of the collapsed hash. With one memo shared by all the outputs
+# the collapse + hash is linear in this count, so the budget is a backstop against a shape nobody
+# has measured yet, not an active behaviour change: the largest entry that reaches this check
+# across the whole evaluation corpus is 10,793 nodes (18x under), and the largest entry anywhere —
+# a GEMM, which takes the MMA fence path and never gets here — is 72,325 (2.8x under).
+# Fingerprinting is unconditionally sound — it only ever over-splits — so tripping the budget costs
+# recovery, never correctness.
+_MAX_DAG_NODES = 200_000
+
+
 def forward_descriptor(func):
     """Per-entry forward descriptor: the collapsed + Merkle-hashed output trees (reusing the backward
     ``collapse_balanced`` + ``tree_hash`` so it is directly comparable to
@@ -651,7 +689,10 @@ def forward_descriptor(func):
     roots = interp.run()
     if not interp.faithful:
         return (interp.fingerprint(), )
-    if _reduces_without_leaf(roots):
+    nodes = _forest_postorder(roots)  # every unique value-DAG node once, shared by all the outputs
+    if len(nodes) > _MAX_DAG_NODES:
+        return (interp.fingerprint(), )  # see `_MAX_DAG_NODES`
+    if _reduces_without_leaf(nodes):
         # Faithful walk, but the reduction lost its input leaves (a fully-unrolled loop-carried
         # fold reduced only over the seed + cross-warp shuffles). The hash cannot see the chunk
         # grouping -> fail closed with the conservative fingerprint + the global-load shape (a
@@ -668,11 +709,14 @@ def forward_descriptor(func):
     # reduction keeps its ShflCombine offsets in the key -> stays split (correct). If ANY output is not
     # cleanly reconstructed (opaque leaf / unrecovered coord), fall back to the verbatim trees (sound,
     # over-split). Replaces the old blanket multi-output G3 guard; gated on the fuzzer (0 over-merge).
-    collapsed = [collapse_balanced(r) for r in roots]
-    keys = [output_coordfree_key(t) for t in collapsed]
+    # The three stages share ONE memo across the outputs, so a subtree k outputs have in common is
+    # collapsed / scanned / hashed once instead of k times (the outputs of a prefix scan share almost
+    # everything, which is what made this quadratic).
+    collapsed = collapse_balanced_forest(roots)
+    keys = output_coordfree_keys(collapsed)
     if all(k is not None for k in keys):
         return tuple(sorted({hashlib.sha1(k.encode()).hexdigest()[:16] for k in keys}))
-    return tuple(sorted(tree_hash(t) for t in collapsed))
+    return tuple(sorted(tree_hashes(collapsed)))
 
 
 def _fence_str(fence):
@@ -706,27 +750,24 @@ def _epilogue_reduces_mma(sinks):
     layernorm output is the full tile written through ``ldmatrix``, which relocates the reduced values
     across lanes, so the ``st.global`` root alone can miss the ``sum(e)`` reduction buried
     mid-computation. Scanning the recorded shared-store values and the live registers too surfaces its
-    ``FpOp``-both-children-``Mma`` combine. The ``Mma``-bearing walk is memoized across all sinks
-    (shared subtrees walked once)."""
+    ``FpOp``-both-children-``Mma`` combine. ONE forest walk covers every sink, so a subtree many sinks
+    share (the whole accumulator chain, typically) is visited once instead of once per sink."""
     has_mma = {}
-    for root in sinks:
-        for n in _postorder(root):
-            if id(n) in has_mma:
-                continue
-            has_mma[id(n)] = isinstance(n, Mma) or any(has_mma[id(c)] for c in n.children)
-            # A ShflCombine (butterfly) IS a reduce step, so over an Mma subtree it is a genuine
-            # cross-lane reduction. A bare SmemExchange is NOT — it is a cross-warp / relocation READ
-            # (pure data movement). The GEMM epilogue stages the MMA accumulator through
-            # st.shared -> ldmatrix -> st.global, which now reconstructs as SmemExchange(Mma) but
-            # reduces nothing; counting it here over-split every pure GEMM into the per-config
-            # fingerprint (undoing the tiling-invariant fence). A REAL cross-warp reduction over the
-            # MMA output still fires: its combine is the FpOp(add/min/max)-both-children-Mma below, and
-            # it also carries a within-warp ShflCombine / shfl.bfly. So key on an actual reduce node.
-            if isinstance(n, ShflCombine) and has_mma[id(n)]:
-                return True
-            if (isinstance(n, FpOp) and not n.fused and n.kind in ("add", "min", "max")
-                    and len(n.children) == 2 and all(has_mma[id(c)] for c in n.children)):
-                return True
+    for n in _forest_postorder(sinks):
+        has_mma[id(n)] = isinstance(n, Mma) or any(has_mma[id(c)] for c in n.children)
+        # A ShflCombine (butterfly) IS a reduce step, so over an Mma subtree it is a genuine
+        # cross-lane reduction. A bare SmemExchange is NOT — it is a cross-warp / relocation READ
+        # (pure data movement). The GEMM epilogue stages the MMA accumulator through
+        # st.shared -> ldmatrix -> st.global, which now reconstructs as SmemExchange(Mma) but
+        # reduces nothing; counting it here over-split every pure GEMM into the per-config
+        # fingerprint (undoing the tiling-invariant fence). A REAL cross-warp reduction over the
+        # MMA output still fires: its combine is the FpOp(add/min/max)-both-children-Mma below, and
+        # it also carries a within-warp ShflCombine / shfl.bfly. So key on an actual reduce node.
+        if isinstance(n, ShflCombine) and has_mma[id(n)]:
+            return True
+        if (isinstance(n, FpOp) and not n.fused and n.kind in ("add", "min", "max")
+                and len(n.children) == 2 and all(has_mma[id(c)] for c in n.children)):
+            return True
     return False
 
 

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -36,7 +36,7 @@ from bitequiv.ptx.forward.loops import (find_loops, loop_accumulates, loop_carri
 from bitequiv.ptx.forward.predicate import PredicateDecoder
 from bitequiv.ptx.leaves import leaf_coord, leaf_columns
 from bitequiv.ptx.linker import DefUse, _def_regs, linearize
-from bitequiv.ptx.mma import _fence_all_matmul, _is_mma, _mma_fence
+from bitequiv.ptx.mma import _fence_all_matmul, _is_mma, _mma_fence, mma_token_counts
 from bitequiv.ptx.treeir import (FpOp, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp, ShflCombine,
                                  SmemExchange)
 
@@ -748,7 +748,9 @@ def _mma_entry_descriptor(func, fence):
     runs extra fp arithmetic inside the fold (``input_precision=tf32x3``, whose compensation sums are
     grouped per K chunk, so its BLOCK_K IS bit-relevant). The fingerprint — not ``loops=`` alone — is
     the fallback ON PURPOSE: a tcgen05 fold increments no pointer, so ``_loop_steps`` is empty there
-    and ``loops=`` would leave the descriptor chunk-blind exactly where the proof failed."""
+    and ``loops=`` would leave the descriptor chunk-blind exactly where the proof failed. The
+    fail-closed side additionally carries ``mmacnt=`` (:func:`bitequiv.ptx.mma.mma_token_counts`), the
+    matmul reduction extent the fence drops on the strength of a proof that did not hold here."""
     from bitequiv.ptx.forward.loops import is_pure_mma_fold, reduction_trip_signature
     from bitequiv.ptx_reduction import _loop_steps
     parts = [_fence_str(fence)]
@@ -777,6 +779,12 @@ def _mma_entry_descriptor(func, fence):
         # closed on the conservative per-config fingerprint, which carries num_warps, the ordered
         # shuffle sequence and the op counts, so any of those differing splits.
         parts.append("mma+fp|" + interp.fingerprint())
+        # The fingerprint counts every fp op EXCEPT the tensor-core ones, which the fence drops on
+        # purpose (a re-tiling issues a different MMA count over the same dot products). That licence
+        # comes from the pure-fold proof, which just failed here, so put the count back: it is the one
+        # witness of the matmul's REDUCTION EXTENT (attention's head dim, a GEMM's K), which the rest
+        # of the key cannot see. Fail-closed side only -> a proven-pure fold keeps BLOCK_K and v2==v5.
+        parts.append("mmacnt=" + ",".join(f"{t}x{n}" for t, n in mma_token_counts(func)))
     steps = _loop_steps(func)
     # BLOCK_K is bit-neutral only for a PROVEN-pure f16/bf16/tf32 tensor-core fold: native-k is fixed
     # and each MMA's F=25 accumulate is exact, so BLOCK_K then only re-batches the same in-order

--- a/bitequiv/ptx/forward/loops.py
+++ b/bitequiv/ptx/forward/loops.py
@@ -12,6 +12,8 @@ descriptor drop its chunk (BLOCK_K) fence.
 """
 from pyptx.ir.nodes import Block, ImmediateOperand, Label, RegisterOperand, VectorOperand
 
+from bitequiv.ptx.affine import Affine, AffineEval, reqntid_of
+from bitequiv.ptx.linker import DefUse
 from bitequiv.ptx.mma import _is_mma
 
 # fp combine ops + widths, used to detect a loop-carried floating-point accumulation.
@@ -278,6 +280,40 @@ def _setp_bounds_of(insts, regs):
     return out
 
 
+def _symbolic_bounds_of(insts, regs, ev):
+    """Canonical form of the RUNTIME (non-literal) values a counter in ``regs`` is compared against.
+
+    :func:`_setp_bounds_of` sees a bound only when it is an immediate. A reduction loop whose bound is
+    computed at run time — the common tiled / triangular case ``for j in range(0, program_id * TILE)``
+    — is then invisible, and two configs whose folds are split at DIFFERENT points share a signature.
+    Evaluating the bound register as an :class:`~bitequiv.ptx.affine.Affine` over the symbol basis
+    recovers exactly the missing fact: the bound is ``TILE * %ctaid``, so ``TILE`` (how many chunks
+    this CTA's fold covers before the loop hands over to the next region) is in the key.
+
+    A value that is not PROVABLY affine yields one fixed placeholder rather than its structural token:
+    that token inlines unresolved register names, which are allocation noise and would split
+    bit-identical configs. Recording only "a runtime bound of unknown form is present" keeps the term
+    stable while still separating it from a proven affine one."""
+    out = set()
+    for i, inst in enumerate(insts):
+        if inst.opcode != "setp" or len(inst.operands) < 3:
+            continue
+        comparands = inst.operands[1:]
+        if not any(isinstance(o, RegisterOperand) and o.name in regs for o in comparands):
+            continue
+        for o in comparands:
+            if isinstance(o, RegisterOperand) and o.name not in regs:
+                value = ev.of_reg(o.name, i)
+                out.add(value.to_str() if isinstance(value, Affine) else "?")
+    return out
+
+
+def _with_bounds(base, bounds):
+    """``base`` alone when no runtime bound was recovered (byte-identical to the two-tier signature),
+    else ``base`` plus the ``("bound", ...)`` tier."""
+    return base if not bounds else (base, ("bound", tuple(sorted(bounds))))
+
+
 def reduction_trip_signature(func):
     """Hashable fingerprint that distinguishes the outer reduction loops' TRIP COUNTS (the split-K
     regrouping = num_splits), or ``None`` when the entry has no nested-reduction structure (a plain
@@ -294,12 +330,21 @@ def reduction_trip_signature(func):
       likewise tiling-invariant per split count.
     Both are keyed on num_splits and independent of the tiling axes, so they recover the tiling freedom
     while keeping the split counts distinct. Returns ``None`` unless an outer reduction loop exists, so
-    a plain tiled GEMM keeps its tiling-invariant fence."""
+    a plain tiled GEMM keeps its tiling-invariant fence.
+
+    Neither tier can see a bound that is not a compile-time constant, so a third ``("bound", ...)``
+    tier (:func:`_symbolic_bounds_of`) carries the RUNTIME bounds as affine forms. It is appended, not
+    substituted, so a signature that has no runtime bound is byte-identical to before — the tier can
+    only ever SPLIT. This is what fences a fold whose split point moves with the output tile: causal
+    attention runs its unmasked KV blocks in one loop up to ``BLOCK_M * program_id`` and the masked
+    diagonal band in a second loop with DIFFERENT arithmetic, so ``BLOCK_M`` decides which KV blocks
+    are rounded which way even though both loops exist, with the same op mix, at every ``BLOCK_M``."""
     insts, loops = find_loops(func)
     splitloops = outer_reduction_loops(insts, loops)
     if not splitloops:
         return None
-    clean = set()
+    ev = AffineEval(DefUse(func), reqntid_of(func))
+    clean, bounds = set(), set()
     for h, latch in splitloops:
         steps = {}
         for k in range(h, latch + 1):
@@ -312,11 +357,12 @@ def reduction_trip_signature(func):
                         steps[d.name] = int(b.text, 0)
                     except (ValueError, TypeError):
                         continue
+        bounds |= _symbolic_bounds_of(insts, set(steps), ev)
         for reg, step in steps.items():
             for bound in _setp_bounds_of(insts, {reg}):
                 clean.add((step, bound))
     if clean:
-        return ("trip", tuple(sorted(clean)))
+        return _with_bounds(("trip", tuple(sorted(clean))), bounds)
     region = []
     for h, latch in splitloops:
         cs = set()
@@ -330,4 +376,4 @@ def reduction_trip_signature(func):
                         except (ValueError, TypeError):
                             continue
         region.append(tuple(sorted(cs)))
-    return ("region", tuple(sorted(region)))
+    return _with_bounds(("region", tuple(sorted(region))), bounds)

--- a/bitequiv/ptx/mma.py
+++ b/bitequiv/ptx/mma.py
@@ -205,3 +205,21 @@ def _mma_fence(func):
             counts[t] = counts.get(t, 0) + 1
         return ("mma-fp8", tuple(sorted(counts.items())), flags, (fma, addmul))
     return ("mma", frozenset(tokens), flags, (int(fma > 0), int(addmul > 0)))
+
+
+def mma_token_counts(func):
+    """Sorted ``(token, count)`` of the entry's tensor-core matmuls — how many hardware accumulate
+    passes each :func:`_mma_token` contributes.
+
+    :func:`_mma_fence` deliberately DROPS this count for the non-fp8 families, because for a
+    PROVEN-pure tensor-core fold a re-tiling issues a different number of MMA instructions over the
+    same dot products (bit-free). That licence does not exist when the fold is NOT proven pure: there
+    the count is the only PTX witness of how many products reach an accumulator, i.e. of the matmul's
+    REDUCTION EXTENT (attention's head dim, a GEMM's K). Callers on the fail-closed side use this;
+    the fence itself must not, or it would over-split every equivalent re-tiling."""
+    counts = {}
+    for inst in linearize(func):
+        if _is_mma(inst):
+            t = _mma_token(inst.opcode, inst.modifiers)
+            counts[t] = counts.get(t, 0) + 1
+    return tuple(sorted(counts.items()))

--- a/bitequiv/tests/test_ptx_attention.py
+++ b/bitequiv/tests/test_ptx_attention.py
@@ -1,0 +1,147 @@
+"""Two fail-closed MMA residuals that flash attention exposes, in hand-crafted PTX (CPU-only).
+
+1. A fold whose SPLIT POINT moves with the output tile. Causal attention runs its fully-unmasked KV
+   blocks in one loop bounded by ``BLOCK_M * program_id`` and the masked diagonal band in a second
+   loop with DIFFERENT arithmetic. Both loops exist, with the same op mix, at every ``BLOCK_M`` — only
+   the runtime bound moves — so every count-based term of the key is identical while the bits are not.
+   :func:`~bitequiv.ptx.forward.loops.reduction_trip_signature` must carry the bound's affine form.
+2. The matmul REDUCTION EXTENT. The fence drops the MMA count because a re-tiling issues a different
+   count over the same dot products — a licence that comes from the pure-fold proof. Where that proof
+   fails, the count is the only witness of how many products reach the accumulator (attention's head
+   dim), so it must be back in the key; where it holds, it must stay out (BLOCK_K / v2==v5 recovery).
+"""
+from pyptx.parser import parse
+
+from bitequiv.ptx.forward import loops
+from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
+from bitequiv.ptx.mma import mma_token_counts
+from bitequiv.ptx_reduction import _ensure_header, ptx_header
+
+_HDR = ptx_header()
+_MMA = "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r3}, %r4, %r5;\n"
+# A cross-lane butterfly makes the entry reduce over the MMA output -> the fail-closed branch.
+_REDUCE = "shfl.sync.bfly.b32 %r6, %r7, 16, 31, -1;\nadd.f32 %f1, %f1, %f3;\n"
+
+
+def _entry(ptx):
+    return next(d for d in parse(_ensure_header(ptx)).directives if getattr(d, "is_entry", False))
+
+
+def _tiled_fold(tile, nmma=1, first=0):
+    """An accumulating loop whose bound is ``tile * program_id`` — the unmasked region of a
+    tile-diagonal fold. ``first`` shifts every virtual register number (allocation noise)."""
+    r = lambda n: f"%r{n + first}"  # noqa: E731
+    return _HDR + f"""
+.visible .entry k(.param .u64 p) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<{16 + first}>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.f32 %f1, 0f00000000;
+  mov.u32 {r(8)}, %ctaid.x;
+  mul.lo.s32 {r(9)}, {r(8)}, {tile};
+  mov.b32 {r(1)}, 0;
+$L__FOLD:
+  {_MMA * nmma}  {_REDUCE}  add.s32 {r(1)}, {r(1)}, 1;
+  setp.lt.s32 %p1, {r(1)}, {r(9)};
+  @%p1 bra $L__FOLD;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+def _param_fold(first=0):
+    """Same fold, but bounded by a kernel PARAM (no tile scaling) — the non-causal shape."""
+    r = lambda n: f"%r{n + first}"  # noqa: E731
+    return _HDR + f"""
+.visible .entry k(.param .u64 p, .param .u32 n) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<{16 + first}>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  ld.param.u32 {r(9)}, [n];
+  mov.f32 %f1, 0f00000000;
+  mov.b32 {r(1)}, 0;
+$L__FOLD:
+  {_MMA}  {_REDUCE}  add.s32 {r(1)}, {r(1)}, 1;
+  setp.lt.s32 %p1, {r(1)}, {r(9)};
+  @%p1 bra $L__FOLD;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+def _pure_fold(nmma):
+    """A PROVEN-pure tensor-core fold (accumulator touched only by MMA, no reduction over the output):
+    the case whose MMA count MUST stay out of the key so re-tiling / v2==v5 keep merging."""
+    return _HDR + f"""
+.visible .entry k(.param .u64 p) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.b32 %r1, 0;
+$L__K:
+  {_MMA * nmma}  add.s32 %r1, %r1, 16;
+  setp.lt.s32 %p1, %r1, 256;
+  @%p1 bra $L__K;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+# -- 1. the fold's split point ------------------------------------------------------------------
+
+
+def test_runtime_bound_recovered_as_affine():
+    sig = loops.reduction_trip_signature(_entry(_tiled_fold(64)))
+    assert ("bound", ("64*%ctaid.x", )) in sig
+
+
+def test_tile_scale_of_a_runtime_bound_splits():
+    # POSITIVE: same instructions, same counts -- only the tile the bound scales by differs.
+    assert loops.reduction_trip_signature(_entry(_tiled_fold(64))) \
+        != loops.reduction_trip_signature(_entry(_tiled_fold(128)))
+    assert CHECK(_tiled_fold(64)) != CHECK(_tiled_fold(128))
+
+
+def test_same_bound_does_not_split_on_register_noise():
+    # NEGATIVE: one runtime bound, two register numberings. The tier is the bound's affine FORM, not
+    # its text, so allocation noise must not separate two bit-identical configs.
+    assert loops.reduction_trip_signature(_entry(_param_fold(0))) \
+        == loops.reduction_trip_signature(_entry(_param_fold(32)))
+    assert CHECK(_param_fold(0)) == CHECK(_param_fold(32))
+
+
+def test_no_runtime_bound_leaves_the_signature_untouched():
+    # NEGATIVE: a fold with no reduction loop at all keeps `None` -- a plain tiled GEMM must not
+    # acquire a `splits=` fence (that would undo its tiling recovery).
+    assert loops.reduction_trip_signature(_entry(_pure_fold(1))) is None
+    assert "splits=" not in str(CHECK(_pure_fold(1)))
+
+
+# -- 2. the matmul reduction extent -------------------------------------------------------------
+
+
+def test_token_counts_count_every_matmul():
+    assert mma_token_counts(_entry(_pure_fold(3))) == (("matmul|f16|cta1", 3), )
+
+
+def test_reduction_extent_splits_when_the_fold_is_not_proven_pure():
+    # POSITIVE: an entry that reduces over the MMA output and issues twice the matmuls is summing
+    # twice the products -- a different value -- so it must not share the fail-closed key.
+    a, b = CHECK(_param_fold()), CHECK(_param_fold().replace(_MMA, _MMA * 2, 1))
+    assert "mma+fp|" in str(a) and a != b
+
+
+def test_reduction_extent_stays_out_of_a_proven_pure_fold():
+    # NEGATIVE: re-tiling a proven-pure fold issues a different MMA count over the SAME dot products.
+    # The count must not leak into that key, or BLOCK_K and v2==v5 stop merging.
+    assert "mma+fp|" not in str(CHECK(_pure_fold(1)))
+    assert CHECK(_pure_fold(1)) == CHECK(_pure_fold(2))

--- a/bitequiv/tests/test_ptx_sharing.py
+++ b/bitequiv/tests/test_ptx_sharing.py
@@ -1,0 +1,147 @@
+"""Signature-stage sharing: one memo per value-DAG, not one per output root, plus the node budget.
+
+The interpreter builds ONE value-DAG whose output roots share most of their nodes; the stage after
+it used to re-materialize that DAG once per root with a fresh memo, so a subtree k roots share was
+rebuilt k times (O(n^2) nodes alive at once). These tests pin the two things that fix has to keep
+true: the collapsed / hashed trees are byte-identical to the per-root ones (including where the
+per-root collapse BOUNDARY legitimately differs between roots), and the node budget fails CLOSED to
+the conservative fingerprint instead of merging. CPU-only."""
+import bitequiv.ptx.forward.interp as interp_mod
+from bitequiv.ptx.builder import _forest_postorder, collapse_balanced, collapse_balanced_forest, tree_hash, tree_hashes
+from bitequiv.ptx.forward.interp import forward_module_descriptor
+from bitequiv.ptx.treeir import FpOp, ITreeReduce, Leaf, OpaqueOp
+from bitequiv.ptx_reduction import ptx_header
+
+_HDR = ptx_header()
+
+
+def _leaf(i):
+    return Leaf(f"c{i}", frozenset({i}))
+
+
+def _unique_nodes(trees):
+    """How many DISTINCT node objects the trees are made of (shared nodes counted once)."""
+    seen, stack = set(), list(trees)
+    while stack:
+        n = stack.pop()
+        if id(n) in seen:
+            continue
+        seen.add(id(n))
+        stack.extend(n.children)
+    return len(seen)
+
+
+def _opaque_chain(n):
+    """``n`` outputs over a chain each output extends: ``out[i] = f(out[i-1], leaf_i)``. The scan
+    shape — ``out[i]`` CONTAINS ``out[i-1]``, so the outputs share almost everything. An OpaqueOp is
+    never a reduce node, so nothing collapses and every node goes through the rebuild path."""
+    node, roots = _leaf(0), []
+    for i in range(1, n + 1):
+        node = OpaqueOp("cvt.rn.f32.f32", (node, _leaf(i)))
+        roots.append(node)
+    return roots
+
+
+def _add_chain(n):
+    """The same scan shape built from plain ``add`` combines, so the collapse pass has real
+    decisions to make: the first two links are AVL-balanced (hence collapsible) and the rest are
+    not, which is what makes a node's region membership depend on WHICH root you look from."""
+    node, roots = _leaf(0), []
+    for i in range(1, n + 1):
+        node = FpOp("add", (".f32", ), (node, _leaf(i)))
+        roots.append(node)
+    return roots
+
+
+# -- one memo per DAG, not one per root ---------------------------------------
+
+
+def test_forest_postorder_visits_each_shared_node_once():
+    roots = _opaque_chain(40)
+    order = _forest_postorder(roots)
+    assert len(order) == _unique_nodes(roots)  # every unique node exactly once
+    assert len({id(n) for n in order}) == len(order)  # and no node twice
+    assert [id(n) for n in order[:2]] == [id(_forest_postorder([roots[0]])[i]) for i in range(2)]
+
+
+def test_collapse_forest_rebuilds_a_shared_subtree_once():
+    n = 40
+    roots = _opaque_chain(n)
+    per_root = [collapse_balanced(r) for r in roots]
+    shared = collapse_balanced_forest(roots)
+    assert [t.sig() for t in shared] == [t.sig() for t in per_root]  # byte-identical output
+    # A fresh memo per root copies the shared chain once per root -> quadratic (n(n+1)/2 combines);
+    # one memo shared by all the roots rebuilds each node once -> linear (n combines).
+    assert _unique_nodes(shared) == _unique_nodes(roots) == 2 * n + 1
+    assert _unique_nodes(per_root) == n * (n + 1) // 2 + (n + 1)
+
+
+def test_tree_hashes_match_per_root_hashes():
+    roots = _opaque_chain(40)
+    assert tree_hashes(roots) == [tree_hash(r) for r in roots]
+
+
+# -- the parent-context risk: a shared node's collapse BOUNDARY is per-root ----
+
+
+def test_shared_collapse_keeps_the_per_root_region_boundary():
+    # `add(leaf, leaf)` and `add(that, leaf)` are both AVL-balanced, so both collapse; the third link
+    # is not. So `roots[0]` is a region ROOT on its own (it collapses to an ITreeReduce) but is
+    # SWALLOWED by the larger region under `roots[1]`. One shared memo must not let whichever answer
+    # came first win for everyone -- that would move the collapse boundary and change a descriptor.
+    roots = _add_chain(6)
+    per_root = [collapse_balanced(r) for r in roots]
+    assert isinstance(per_root[0], ITreeReduce)  # alone: its own region
+    assert isinstance(collapse_balanced(roots[2]), FpOp)  # third link: not collapsible
+    assert [t.sig() for t in collapse_balanced_forest(roots)] == [t.sig() for t in per_root]
+
+
+def test_multi_output_descriptor_is_unchanged_by_sharing(monkeypatch):
+    # End to end: the multi-output descriptor must be the same whether the outputs are collapsed and
+    # hashed together or one at a time.
+    ptx = _two_row_sums(4)
+    shared = forward_module_descriptor(ptx)
+    monkeypatch.setattr("bitequiv.ptx.forward.interp.collapse_balanced_forest",
+                        lambda roots: [collapse_balanced(r) for r in roots])
+    monkeypatch.setattr("bitequiv.ptx.forward.interp.tree_hashes", lambda roots: [tree_hash(r) for r in roots])
+    assert forward_module_descriptor(ptx) == shared
+
+
+# -- the node budget fails CLOSED ---------------------------------------------
+
+
+def _balanced_sum4(ntid):
+    """A 4-element balanced within-thread sum at a given ``.reqntid`` (= num_warps). The collapse
+    recovers num_warps, so two of these with different ntid share ONE descriptor."""
+    return (_HDR + f".visible .entry k(.param .u64 pa, .param .u64 po) .reqntid {ntid}, 1, 1\n{{\n"
+            ".reg .b64 %rd<6>;\n.reg .f32 %f<10>;\n"
+            "ld.param.u64 %rd1, [pa];\ncvta.to.global.u64 %rd2, %rd1;\n"
+            "ld.param.u64 %rd3, [po];\ncvta.to.global.u64 %rd4, %rd3;\n"
+            "ld.global.f32 %f1, [%rd2];\nld.global.f32 %f2, [%rd2+4];\n"
+            "ld.global.f32 %f3, [%rd2+8];\nld.global.f32 %f4, [%rd2+12];\n"
+            "add.f32 %f5, %f1, %f2;\nadd.f32 %f6, %f3, %f4;\nadd.f32 %f7, %f5, %f6;\n"
+            "st.global.f32 [%rd4], %f7;\nret;\n}\n")
+
+
+def _two_row_sums(ntid):
+    """Two independent balanced 4-element sums stored as two outputs (a multi-output entry)."""
+    return (_HDR + f".visible .entry k(.param .u64 pa, .param .u64 po) .reqntid {ntid}, 1, 1\n{{\n"
+            ".reg .b64 %rd<6>;\n.reg .f32 %f<20>;\n"
+            "ld.param.u64 %rd1, [pa];\ncvta.to.global.u64 %rd2, %rd1;\n"
+            "ld.param.u64 %rd3, [po];\ncvta.to.global.u64 %rd4, %rd3;\n"
+            "ld.global.f32 %f1, [%rd2];\nld.global.f32 %f2, [%rd2+4];\n"
+            "ld.global.f32 %f3, [%rd2+8];\nld.global.f32 %f4, [%rd2+12];\n"
+            "add.f32 %f5, %f1, %f2;\nadd.f32 %f6, %f3, %f4;\nadd.f32 %f7, %f5, %f6;\n"
+            "add.f32 %f8, %f1, %f3;\nadd.f32 %f9, %f2, %f4;\nadd.f32 %f10, %f8, %f9;\n"
+            "st.global.f32 [%rd4], %f7;\nst.global.f32 [%rd4+4], %f10;\nret;\n}\n")
+
+
+def test_budget_floor_falls_back_to_the_fingerprint(monkeypatch):
+    small, big = _balanced_sum4(32), _balanced_sum4(256)
+    assert forward_module_descriptor(small) == forward_module_descriptor(big)  # merged by the collapse
+    assert "fwd-incomplete" not in forward_module_descriptor(small)[0]
+    monkeypatch.setattr(interp_mod, "_MAX_DAG_NODES", 1)
+    (floored, ) = forward_module_descriptor(small)
+    assert floored.startswith("fwd-incomplete|ntid=x32")
+    # Fail CLOSED: the floor must SPLIT what the collapsed hash merged, never merge more.
+    assert forward_module_descriptor(small) != forward_module_descriptor(big)


### PR DESCRIPTION
Summary:
The forward PTX checker's interpreter builds ONE value-DAG whose output roots share most of their nodes, and it is linear: the largest entry in the whole evaluation corpus is 10,793 unique nodes and reconstructs in 0.7 s / 0.04 GB. The stage AFTER it then re-materialized that DAG once per OUTPUT ROOT with a fresh memo — `collapse_balanced` allocated a new output map per call, `tree_hash` a new hash map per call, `output_coordfree_key` a new signature map per call — so a subtree k roots share was rebuilt k times. On `LC_cumsum_scan_f32`, a 512-output prefix scan where `root[i]` contains `root[i-1]`, a 3,719-node DAG expanded into 631,169 collapsed node objects (~2.5 n^2) and one parse took 38.2 s instead of 0.9 s. It needs BOTH many roots and heavy inter-root sharing: `softmax` and `layernorm` also have 64 roots but nearly independent per-row outputs, so they only expanded ~5x. Be clear about the magnitude — for the collapse this is a TIME problem and a scaling hazard, not a single-parse OOM: the peak RSS of that 38 s parse is 0.074 GB.

Two more places had the same defect and are worth more than the headline case. `_epilogue_reduces_mma` walked each of its sinks separately (roots + every recorded shared store + every live register), and a GEMM epilogue's sinks all hang off one accumulator chain, so the walk was quadratic in the chain: the worst `gemm_softmax` entry took 89.8 s / 0.388 GB, now 0.12 s. And `_resolve_smem` decided "do all this shared phase's writes have the same structure?" by serializing each candidate's full `_coordfree_sig` STRING, which inlines a shared subtree at every reference — that one IS a real single-parse memory blowup: one 533 KB `welford` entry blew past a 64 GB RLIMIT_AS cap in 20 s, and now takes 0.68 s / 0.018 GB.

The fix threads ONE memo through all of an entry's roots at each stage. Review in this order: `_forest_postorder` in `builder.py` (the shared walk everything else is built on), then `tree_hashes` and `output_coordfree_keys` (pure bottom-up folds, so a shared memo is trivially value-preserving), then `collapse_balanced_forest`, then the interpreter's `_cf_hash`, and last the node budget in `forward_descriptor`.

`collapse_balanced` is the one stage where sharing is NOT trivially safe, so it gets a real guard. A node is a collapse REGION ROOT only when no collapsible PARENT of it is reachable from that root, and parents are a per-root fact: the same shared node can legitimately be its own region under one output and be swallowed by a larger region under another. With one memo the node is rebuilt once, so whichever answer came first would silently win for everyone and move a collapse boundary. This is not hypothetical — a plain `add` chain hits it, and with a naive union-of-parents memo `roots[0]` comes out as `add.f32(L[c0],L[c1])` instead of `ITREE[add.f32;L[];h1;s()]`. `_shared_region_marks` decides it exactly with two bitmasks over the roots: `reach[n]` = the roots that reach n, `mark[n]` = the roots that reach some collapsible parent of n; the roots agree on n iff `mark[n] & reach[n]` is empty or is all of `reach[n]`, and only COLLAPSIBLE nodes are checked because `region_root = collapsible[n] and not has_coll_parent[n]` short-circuits and never reads the flag anywhere else. When the roots disagree it returns None and the caller runs the exact per-root pass, i.e. today's code. That distinction is what keeps the shared path live where it pays: the 512-root scan has 128 nodes whose parent context differs per root, but none of them is collapsible. `test_shared_collapse_keeps_the_per_root_region_boundary` pins it and fails against a naive shared memo.

The floor (part C) is a node budget: past 200,000 unique value-DAG nodes `forward_descriptor` returns the conservative `interp.fingerprint()` instead of the collapsed hash. Fingerprinting only ever over-splits, so this is unconditionally sound, and after the shared memo the collapse + hash is linear in that count, so the budget bounds the work. It is a backstop, not a behaviour change: nothing in the corpus comes close.

Descriptors are unchanged. Every PTX in the evaluation corpus was graded twice in one process — once by the committed checker (a verbatim copy of HEAD, validated against the real HEAD package on a 72-file sample across 12 kernels) and once by this change — and the two strings compared:

| population | configs | descriptors differing | notes |
|---|--:|--:|---|
| whole corpus, old vs new descriptor string | 53211 | **0** | 43 `gemm` configs another job created during the sweep are ungraded |
| `flash_attention` (bf16/f16/fp8/fp8e5m2) | 12008 | 0 | over_merges 0 in all four groups |
| `gemm` (bf16/f16/f32/fp8) | 29913 | 0 | f16 = 1 class, fp8 = 2 classes, bf16 = 1, over_merges 0 |
| other GEMM variants (`gemm_softmax`, `gemm_reduce_sum`, `gemm_kgroup`, `gemm_bias_relu_fp_fusion`, `gemm_tma_store`, `LC_splitk_gemm_f16`) | 1906 | 0 | over_merges 0 in every group |
| reductions (the 72 frozen baseline groups) | 8652 | 0 | **72/72 rows identical** to `REDUCTION_BASELINE.md`: same configs, same 855 checker classes, same 460 empirical classes, over_merges 0 |
| previously excluded kernels | 732 | 0 | of the 519 the committed checker could finish; the other 213 OOMed and now complete |

Byte-identical descriptors are a stronger statement than matching class counts: the partition is the same set of sets, not just the same size.

Five kernels were excluded from the corpus-wide table by name because of this blowup. All five now complete; these are their first results (over_merges = 0 everywhere, so unblocking them adds no unsoundness):

| kernel | dtype | configs | checker_cls | empirical_cls | over_merges | over_split_pairs | seeds | wall (all configs) | peak RSS |
|---|---|--:|--:|--:|--:|--:|--|--:|--:|
| `LC_cumsum_scan_f32` | f32 | 24 | 24 | 7 | 0 | 33 | 12 | 9.7 s (was 45.6 s) | 0.055 GB (was 0.496 GB) |
| `LC_logsumexp_loop_f32` | f32 | 24 | 24 | 24 | 0 | 0 | 12 | 5.2 s | 0.04 GB |
| `LC_prod_loop_f32` | f32 | 24 | 24 | 24 | 0 | 0 | 12 | 1.4 s | 0.02 GB |
| `LC_var_welford_f32` | f32 | 24 | 24 | 24 | 0 | 0 | 12 | 6.3 s | 0.02 GB |
| `welford` | f32 | 636 | 106 | 75 | 0 | 3636 | 20 | 67 s | 0.02 GB |

The committed checker could not finish 18/24 `LC_logsumexp_loop_f32`, 15/24 `LC_var_welford_f32` and (at a deliberately small 6 GB cap) 180/636 `welford` configs; `LC_prod_loop_f32` never actually had a problem and was skipped only because the skip list matches by substring.

Measured speedup. Single entry, fresh memory-capped process:

| entry | old | new |
|---|--:|--:|
| `LC_cumsum_scan_f32` largest (512 roots, 3,719 nodes) | 38.2 s / 0.074 GB | 0.90 s / 0.018 GB |
| `gemm_softmax/f32/6aa328da4be041cd` | 89.8 s / 0.388 GB | 0.12 s / <0.02 GB |
| `welford/f32/34c22b8e94817c1a` | MemoryError past a 64 GB cap in 20 s | 0.68 s / 0.018 GB |

Whole-kernel batches, all PTX read into memory first, best of two runs in separate processes:

| kernel | configs | old | new |
|---|--:|--:|--:|
| `LC_cumsum_scan_f32` | 24 | 1898 ms/config | 403 ms/config |
| `layernorm` | 432 | 39.2 ms/config | 29.1 ms/config |
| `softmax` | 432 | 35.0 ms/config | 28.2 ms/config |
| `rmsnorm` | 432 | 26.6 ms/config | 21.7 ms/config |
| `sum_3d_outer` | 432 | 57.8 ms/config | 51.3 ms/config |
| `col_dot` | 432 | 82.9 ms/config | 77.5 ms/config |
| `col_sum_loop` | 432 | 40.6 ms/config | 38.0 ms/config |
| `cond_reduce` | 432 | 58.1 ms/config | 57.8 ms/config |
| `sum` (single output) | 432 | 38.1 ms/config | 38.0 ms/config |

Nothing got slower. Single-output entries are unchanged by construction — `collapse_balanced` still runs the per-root path, and `_forest_postorder([root])` is the old `_postorder(root)` walk.

`local_evaluation/build_checker_table.py` skips `cumsum`/`scan`/`welford`/`logsumexp`/`prod_loop` by name. That skip list can now be deleted; it lives outside this repo, so leaving it to the owner.

Robustness. Population measured: the full evaluation corpus as of this change — 53,211 distinct PTX configs over 47 kernels, which is every reduction, GEMM and Flash Attention config in it, plus the 732 configs of the five kernels that used to be excluded. The `gemm` corpus was being extended by another job while the sweep ran, so 43 `gemm` configs created at the very end are ungraded (0.14% of `gemm`, on a family with 29,913 graded and zero differences). Unchanged: every descriptor string, hence every partition, hence every class count and every over_merge count — the 72 frozen reduction baseline rows come back identical, GEMM f16 stays at 1 class and fp8 at 2, and Flash Attention stays at 0 over_merges in all four dtypes. Budget headroom: the largest entry that reaches the check is 10,793 nodes, 18x under the 200,000 limit; the largest value-DAG anywhere in the corpus is a 72,325-node GEMM, which takes the MMA fence path and never reaches the check, and is still 2.8x under. A second internal cap keeps the region-mark bitmasks under ~8 MB and falls back to the per-root pass rather than changing any descriptor. What is NOT done: part B — fusing collapse and hash into a single memoized bottom-up Merkle pass that never materializes a collapsed node object at all. That is strictly better and would drop the remaining per-node allocation, but it is a bigger change and harder to prove neutral, so it is a follow-up.

Reviewed By: njriasan

Differential Revision: D114373253


