### PR TITLE
[triton][bitequiv] Forward checker: model the cross-warp shared exchange

### DIFF
--- a/bitequiv/ptx/affine.py
+++ b/bitequiv/ptx/affine.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from pyptx.ir.nodes import (
     AddressOperand,
     ImmediateOperand,
+    LabelOperand,
     RegisterOperand,
 )
 
@@ -189,6 +190,12 @@ class AffineEval:
             return self.of_reg(operand.name, before_index)
         if isinstance(operand, AddressOperand):
             return self.of_address(operand, before_index)
+        if isinstance(operand, LabelOperand):
+            # A bare symbol used as a VALUE (`mov.b32 %r, global_smem`) is that symbol's ADDRESS: a
+            # link-time constant, the same for every thread. Same symbol form `of_address` already
+            # gives a non-`%` base, so `[global_smem+8]` and `mov %r, global_smem; [%r+8]` agree.
+            # Without this the shared-memory base poisoned every address built on it to `Opaque`.
+            return _symbol("sym:" + operand.name)
         return Opaque(f"operand({type(operand).__name__})")
 
     def of_address(self, addr, before_index):
@@ -282,7 +289,12 @@ class AffineEval:
         if op in ("or", "xor") and len(srcs) == 2:
             return self._or_xor(ev(srcs[0]), ev(srcs[1]))
         if op == "bfe" and len(srcs) == 3:  # bit-field extract: bits [pos, pos+len) of a
-            return self._bfe(ev(srcs[0]), ev(srcs[1]), ev(srcs[2]))
+            # SIGNED `bfe.s32/.s64` SIGN-EXTENDS the extracted field, so a 1-bit extract yields 0 or
+            # -1, not 0 or 1 — the idiom Triton uses to turn a tid bit into an xor-swizzle mask. Only
+            # the unsigned form is the plain bit slice modeled below; leave the signed one opaque.
+            if any(m in (".u32", ".u64") for m in mods):
+                return self._bfe(ev(srcs[0]), ev(srcs[1]), ev(srcs[2]))
+            return self._opaque_def(d)
 
         return self._opaque_def(d)
 
@@ -436,6 +448,70 @@ class AffineEval:
         parts = [canon(self.of_operand(o, d.index)) for o in inst.operands[1:]]
         slot = "" if d.slot is None else f"#{d.slot}"
         return Opaque(f"{inst.opcode}{''.join(inst.modifiers)}{slot}({','.join(parts)})")
+
+
+# Cap on the number of thread-grid addresses :func:`thread_image` will materialize.
+_MAX_IMAGE = 1 << 16
+
+
+def _bit_basis(ev, aff):
+    """Rewrite ``aff``'s thread-index terms into the ``%tid.<dim>.bit<i>`` basis.
+
+    This basis IS the (warp, lane) decomposition of the thread index: ``%tid.x`` bits [0, 5) are the
+    LANE inside a warp and bits [5, log2(ntid.x)) are the WARP. So a cross-warp shared exchange reads
+    directly off it — a warp leader's store address is a function of the warp bits, the reading
+    warp's load address a function of the lane bits — and enumerating the basis
+    (:func:`thread_image`) composes the two into the real slot <-> warp map.
+
+    Returns ``(uniform_terms, bit_terms, const)`` where ``uniform_terms`` is the frozenset of
+    ``(symbol, coeff)`` that are CONSTANT across a thread block (the shared-array base, ``%ctaid``,
+    kernel params) and ``bit_terms`` maps a bit symbol to its coefficient. ``None`` when a term is
+    not decomposable (a non-power-of-two / unknown ``ntid``, or an unknown varying symbol), in which
+    case the caller must fail closed. Expanding a PLAIN ``%tid.<dim>`` into its bits is exact
+    because ``ntid`` is a power of two, and it keeps the plain and the already-sliced forms of the
+    same thread index on ONE basis so their images cannot be double-counted."""
+    if not isinstance(aff, Affine):
+        return None
+    uniform, bits = [], {}
+    for sym, coeff in aff.terms:
+        parts = sym.split(".")
+        if parts[-1].startswith("bit") and parts[0] in ("%tid", "%laneid"):
+            bits[sym] = bits.get(sym, 0) + coeff  # already on the bit basis
+            continue
+        if parts[0] == "%laneid":
+            stem, n = "%laneid", 32
+        elif parts[0] == "%tid" and len(parts) == 2:
+            stem, n = sym, ev.reqntid.get(parts[1])
+        elif sym.startswith(("sym:", "reg:", "param:", "%ctaid", "%nctaid", "%ntid")):
+            uniform.append((sym, coeff))  # uniform across the block -> not part of the slot index
+            continue
+        else:
+            return None  # an unknown varying symbol -> the image cannot be proven
+        if not _is_pow2(n):
+            return None
+        for i in range(n.bit_length() - 1):
+            b = f"{stem}.bit{i}"
+            bits[b] = bits.get(b, 0) + coeff * (1 << i)
+    return frozenset(uniform), {s: c for s, c in bits.items() if c != 0}, aff.const
+
+
+def thread_image(ev, aff):
+    """``(uniform_key, offsets)`` of an address over the whole thread grid, or ``None``.
+
+    ``uniform_key`` identifies the memory object (the ``global_smem`` base symbol + any block-uniform
+    row offset); ``offsets`` is the frozenset of byte addresses the instruction touches as the thread
+    index ranges over the block. Two accesses can only alias when their ``uniform_key`` matches, and
+    then exactly on the intersection of their ``offsets``."""
+    got = _bit_basis(ev, aff)
+    if got is None:
+        return None
+    uniform, bits, const = got
+    offs = {const}
+    for coeff in bits.values():
+        offs = {o for base in offs for o in (base, base + coeff)}
+        if len(offs) > _MAX_IMAGE:
+            return None
+    return uniform, frozenset(offs)
 
 
 def reqntid_of(func):

--- a/bitequiv/ptx/builder.py
+++ b/bitequiv/ptx/builder.py
@@ -320,15 +320,27 @@ def _is_reduce_node(n):
 
 
 def _balance_pass(order):
-    """Per node: (balanced, height, optok). A subtree is a balanced reduction iff every reduce
+    """Per node: (balanced, height, level, optok). A subtree is a balanced reduction iff every reduce
     node has children that are balanced reductions of one consistent op AND (for the 2-ary fp
     combine) their heights differ by <= 1 — the AVL property that separates inner_tree's balanced
     tree from unordered's left-fold. Boundary leaves are trivial arity-1 balanced reductions.
 
+    ``height`` is the REDUCTION height — log2 of the number of elements folded into the node — so a
+    ``SmemExchange`` is transparent: staging a partial through shared memory does not combine
+    anything, and counting it inflated the height by the number of exchanges, which is exactly a
+    num_warps artifact (num_warps=1 needs no exchange at all, so the same total reduction came out
+    two levels shorter and never matched the multi-warp configs). Dropping the artifact also removes
+    accidental MERGES it caused, where one config's extra exchange made up for a genuinely shorter
+    reduction.
+
+    ``level`` is the raw node depth (every reduce node counts, exchanges included). It is what the
+    butterfly-direction readers (:func:`_is_count_up`, :func:`_shfl_dir`) group shuffle steps by, so
+    that the within-warp run stays separated from the cross-warp run by the exchange between them.
+
     ``order`` is a post-order node list (one tree's or a whole forest's). Every value is a pure
     function of the node's own subtree, so a forest-wide pass gives each node exactly the values a
     per-tree pass would."""
-    bal, ht, optok = {}, {}, {}
+    bal, ht, lvl, optok = {}, {}, {}, {}
     for n in order:
         if _is_reduce_node(n):
             kids = list(n.children)
@@ -344,11 +356,15 @@ def _balance_pass(order):
                 bal[id(n)] = kids_bal and op is not None and abs(ht[id(kids[0])] - ht[id(kids[1])]) <= 1
             else:  # min/max FpOp (shape-invariant), or a 1-ary shfl/smem step: no AVL check needed
                 bal[id(n)] = kids_bal and op is not None
-            ht[id(n)] = max((ht[id(c)] for c in kids), default=0) + 1
+            # A shared exchange RELOCATES a partial between threads; it combines nothing, so it
+            # multiplies the reduced element count by one and adds no reduction height.
+            grow = 0 if isinstance(n, SmemExchange) else 1
+            ht[id(n)] = max((ht[id(c)] for c in kids), default=0) + grow
+            lvl[id(n)] = max((lvl[id(c)] for c in kids), default=0) + 1
             optok[id(n)] = op
         else:
-            bal[id(n)], ht[id(n)], optok[id(n)] = True, 0, None
-    return bal, ht, optok
+            bal[id(n)], ht[id(n)], lvl[id(n)], optok[id(n)] = True, 0, 0, None
+    return bal, ht, lvl, optok
 
 
 def _has_opaque(node):
@@ -368,7 +384,7 @@ def _addr_resolved(node):
     return True
 
 
-def _is_count_up(node, ht):
+def _is_count_up(node, lvl):
     """True iff the butterfly shuffles reduce COUNT-UP — the offset DOUBLES leaf->root (1, 2, 4, 8, ...).
     That is the ``inner_tree`` signature: a count-up balanced tree fixes the reduction to the layout-
     invariant canonical order, so it is bit-identical across ``num_warps``. ``unordered`` is count-DOWN
@@ -377,22 +393,24 @@ def _is_count_up(node, ht):
     num_warps-invariant order from the layout-dependent one, so the single-leaf collapse MUST gate on it
     or it over-merges ``unordered`` across num_warps.
 
-    Examine EVERY maximal run of shuffles at consecutive heights — the within-warp butterfly AND the
+    Examine EVERY maximal run of shuffles at consecutive LEVELS — the within-warp butterfly AND the
     cross-warp run (which sits higher, separated by a shared-memory exchange). Both carry the same
     direction. inner_tree makes every run increasing; unordered makes every run decreasing. Return True
     iff at least one run of >= 2 steps is strictly increasing AND no run is non-increasing. Reading only
     the TOP run (old behavior) missed the direction at low num_warps, where the cross-warp run is a
     single (direction-less) step and only the within-warp butterfly proves count-up — so nw=2 stayed
-    over-split. A count-DOWN run (unordered), a non-monotone run, a dynamic offset, or a height carrying
-    two offsets -> False (cannot prove inner_tree -> do not collapse -> sound over-split)."""
+    over-split. A count-DOWN run (unordered), a non-monotone run, a dynamic offset, or a level carrying
+    two offsets -> False (cannot prove inner_tree -> do not collapse -> sound over-split). Runs are cut
+    at LEVEL (not reduction height) gaps on purpose: the exchange between the within-warp and the
+    cross-warp butterfly is what separates their two runs, and it carries no reduction height."""
     by_ht = {}
-    for n in _postorder(node):
+    for n in _region_nodes(node):
         if isinstance(n, ShflCombine):
             try:
                 off = int(n.offset)
             except (TypeError, ValueError):
                 return False  # dynamic / unresolved offset
-            by_ht.setdefault(ht[id(n)], set()).add(off)
+            by_ht.setdefault(lvl[id(n)], set()).add(off)
     if not by_ht or any(len(offs) != 1 for offs in by_ht.values()):
         return False  # no shuffles, or a height carrying two different offsets -> ambiguous
     flat = {h: next(iter(offs)) for h, offs in by_ht.items()}
@@ -432,17 +450,30 @@ def _tok_is_pure(token):
     return any(token == p or token.startswith(p + ".") for p in _PURE_ELT)
 
 
+def _is_const_token(token):
+    """True iff an ``OpaqueLeaf``'s token is a compile-time CONSTANT — a literal immediate the
+    affine evaluator could not parse as an integer (``opq(imm(0f3FB8AA3B))``, a float literal) or one
+    it could (a bare decimal). A constant is the same value in every thread and in every config, so
+    unlike a lost-provenance value it cannot hide a layout dependence."""
+    return "imm(" in token or token.lstrip("-").isdigit()
+
+
 def _leaf_layout_invariant(node):
     """A reduction boundary-leaf subtree is layout-invariant (safe to collapse over) iff it has
-    NO cross-thread op (Shfl/Smem), NO lost-provenance OpaqueLeaf, no fused-fma ACC-chain (a
-    layout-dependent accumulation, not a per-element value), and every OpaqueOp is a pure
-    per-element op (cvt/mov/abs/neg) kept verbatim. This admits the bf16 promote (cvt.f32.bf16)
-    and a single product mul(L,L) / fma(L,L;const) while refusing anything whose value could
-    depend on the thread/lane layout."""
+    NO cross-thread op (Shfl/Smem), NO lost-provenance OpaqueLeaf (a literal CONSTANT is fine — see
+    :func:`_is_const_token`), no fused-fma ACC-chain (a layout-dependent accumulation, not a
+    per-element value), and every OpaqueOp is a pure per-element op (cvt/mov/abs/neg) kept verbatim.
+    This admits the bf16 promote (cvt.f32.bf16) and a single product mul(L,L) / fma(L,L;const) while
+    refusing anything whose value could depend on the thread/lane layout.
+
+    An ``ITreeReduce`` is accepted: it is a NESTED reduction this same pass already certified as
+    layout-invariant, and its token rides verbatim into the outer ``leaf_sig``, so an outer reduction
+    over inner reductions (softmax's ``sum(exp(x - max(x)))``) collapses without losing the inner
+    key. Callers pass the already-COLLAPSED leaf, so this is the only place such a node appears."""
     for n in _postorder(node):
         if isinstance(n, (ShflCombine, SmemExchange, Mma, LoopReduce)):
             return False  # cross-thread / opaque-chunk / loop-fold node: not a per-element leaf
-        if isinstance(n, OpaqueLeaf):
+        if isinstance(n, OpaqueLeaf) and not _is_const_token(n.token):
             return False
         if isinstance(n, OpaqueOp) and not _tok_is_pure(n.token):
             return False
@@ -452,27 +483,76 @@ def _leaf_layout_invariant(node):
     return True
 
 
-def _shfl_dir(node, ht):
-    """The butterfly DIRECTION: the distinct offsets of the FIRST (min-height, nearest-leaves)
+def _shfl_dir(node, lvl):
+    """The butterfly DIRECTION: the distinct offsets of the FIRST (min-level, nearest-leaves)
     shuffle step. count-up (inner_tree) starts at offset 1; count-down (unordered) starts at 16.
     They pair lanes differently -> different bits, so this must be in the token. It is
     num_warps-INVARIANT (the within-warp butterfly's first step is offset 1 for inner_tree at any
-    num_warps; cross-warp shuffles sit at higher height), so it distinguishes the orderings
+    num_warps; cross-warp shuffles sit at a higher level), so it distinguishes the orderings
     WITHOUT blocking num_warps recovery (the full offset sequence would, since cross-warp shuffle
-    count scales with num_warps)."""
-    shfls = [(ht[id(n)], str(n.offset)) for n in _postorder(node) if isinstance(n, ShflCombine)]
+    count scales with num_warps). Scoped to THIS region (:func:`_region_nodes`): a butterfly inside a
+    boundary leaf belongs to that nested reduction, and letting it leak in made the direction key
+    depend on which hardware form the nested reduce took (col_max's `redux.sync` at num_warps=32 vs a
+    shuffle butterfly below), splitting an outer sum whose own direction is identical."""
+    shfls = [(lvl[id(n)], str(n.offset)) for n in _region_nodes(node) if isinstance(n, ShflCombine)]
     if not shfls:
         return ()
     lo = min(h for h, _ in shfls)
     return tuple(sorted({off for h, off in shfls if h == lo}))
 
 
-def _collapse_info(node, ht=None):
+def _region_nodes(node):
+    """Every reduce node of the reduction REGION rooted at ``node`` — the walk descends only through
+    reduce nodes, so a nested reduction hiding inside a BOUNDARY leaf is not part of this region."""
+    out, stack, seen = [], [node], set()
+    while stack:
+        n = stack.pop()
+        if id(n) in seen:
+            continue
+        seen.add(id(n))
+        out.append(n)
+        for c in n.children:
+            if _is_reduce_node(c):
+                stack.append(c)
+    return out
+
+
+def _region_walk(node):
+    """``(reduce op token, boundary leaves)`` of the reduction REGION rooted at ``node``, or
+    ``(None, ...)`` when the region mixes two reduce ops.
+
+    The walk descends ONLY through reduce nodes, exactly like the op propagation in
+    :func:`_balance_pass`: a non-reduce child ends the region and is a boundary leaf, and whatever
+    lives INSIDE that leaf is the leaf's business. Scanning the whole post-order instead (the old
+    behaviour) reached back into the leaves and saw their own reduce nodes, so any reduction fed by a
+    DIFFERENT-op or different-width sub-reduction — softmax's ``sum(exp(x - max(x)))``, col_max's
+    within-thread ``max.f16`` fold under a cross-warp ``max.f32`` — looked like a two-op region and
+    never collapsed, which is precisely where the num_warps split lived."""
+    op, leaves = None, []
+    for n in _region_nodes(node):
+        tok = _reduce_op(n)  # FpOp OR ShflCombine (a pure cross-thread butterfly carries its op here)
+        if tok is not None:
+            if op is None:
+                op = tok
+            elif op != tok:
+                return None, leaves
+        for c in n.children:  # a boundary leaf is a non-reduce child of a reduce node
+            if not _is_reduce_node(c):
+                leaves.append(c)
+    return op, leaves
+
+
+def _collapse_info(node, lvl=None, collapsed=None):
     """(reduce_op_token, uniform_coord_free_leaf_sig, reduced_column_SET) for a collapsible reduction,
-    or None if it cannot be SOUNDLY collapsed. The BOUNDARY leaves are the non-reduce CHILDREN of
-    reduce nodes (NOT every non-reduce postorder node — collecting the latter double-counts a
-    boundary's own internal nodes, e.g. it sees both ``cvt(L)`` and its child ``L`` -> two coord-free
-    sigs -> a spurious bail; that is why the baseline never collapsed cvt/exp/mul-fed reductions).
+    or None if it cannot be SOUNDLY collapsed. The BOUNDARY leaves are the non-reduce CHILDREN of the
+    region's reduce nodes (:func:`_region_walk`).
+
+    ``collapsed`` maps a node id to its ALREADY-COLLAPSED form (the post-order output map of
+    :func:`_collapse_regions`). The boundary-leaf signature is taken from there, so a leaf that is
+    itself a nested reduction contributes its layout-invariant ``ITreeReduce`` token instead of its
+    physical fold — which is what makes an outer reduction over it num_warps-invariant too. The
+    column image and the address-resolution gate still read the RAW leaf (more leaves visible ->
+    strictly more conservative).
 
     Guards: a single consistent reduce op (read from FpOp AND ShflCombine, so a pure cross-thread
     butterfly counts); >= 1 boundary leaf; every boundary is layout-invariant (pure-elt); the SAME
@@ -487,21 +567,10 @@ def _collapse_info(node, ht=None):
     image being recoverable is the config-invariance proof. (The old ``_single_element`` guard refused
     this because coord-blanking cannot prove the pairing; but the pairing is a source fact, not a
     layout fact, so it is invariant across the configs actually compared.)"""
-    op, leaves = None, []
-    for n in _postorder(node):
-        if not _is_reduce_node(n):
-            continue
-        tok = _reduce_op(n)  # FpOp OR ShflCombine (a pure cross-thread butterfly carries its op here)
-        if tok is not None:
-            if op is None:
-                op = tok
-            elif op != tok:
-                return None
-        for c in n.children:  # a boundary leaf is a non-reduce child of a reduce node
-            if not _is_reduce_node(c):
-                leaves.append(c)
-    if op is None or not leaves:
+    op, raw = _region_walk(node)
+    if op is None or not raw:
         return None
+    leaves = [collapsed[id(l)] for l in raw] if collapsed is not None else raw
     # Leaf-count guard depends on the op's shape-sensitivity. A SHAPE-INVARIANT op (min/max) keys on
     # the reduced element SET (cols) below, so a lone coord-blanked leaf is fine — a pure cross-thread
     # min/max butterfly (1 leaf/thread) is a real reduction and MAY collapse. A SHAPE-DEPENDENT op
@@ -515,15 +584,15 @@ def _collapse_info(node, ht=None):
     # recovers num_warps. Count-DOWN (unordered) or an UNRESOLVED (opaque/swizzled) address keeps the
     # old >= 2 fail-close (over-split, sound) — count-up vs count-down is the ONLY signal separating the
     # num_warps-invariant order from the layout-dependent one when there is no within-thread fold. This
-    # is the affine linchpin. (ht is None on the pre-collapse `_reduces_without_leaf` scan -> stay strict.)
-    if (op.split(".")[0] not in _ORDER_INVARIANT_OPS and len(leaves) < 2
-            and not (_addr_resolved(leaves[0]) and ht is not None and _is_count_up(node, ht))):
+    # is the affine linchpin. (lvl is None on the pre-collapse `_reduces_without_leaf` scan -> stay strict.)
+    if (op.split(".")[0] not in _ORDER_INVARIANT_OPS and len(raw) < 2
+            and not (_addr_resolved(raw[0]) and lvl is not None and _is_count_up(node, lvl))):
         return None
     if not all(_leaf_layout_invariant(l) for l in leaves):
         return None  # a layout-dependent / lost-provenance leaf -> do not collapse
     if len({_coordfree_sig(l) for l in leaves}) != 1:
         return None  # non-uniform leaf computations -> conservative
-    unions = [_leaf_cols_union(l) for l in leaves]  # config-invariant column image of every leaf
+    unions = [_leaf_cols_union(l) for l in raw]  # config-invariant column image of every leaf
     if any(u is None for u in unions):
         return None  # addressing not understood for some leaf -> cannot prove the extent -> conservative
     return (op, _coordfree_sig(leaves[0]), frozenset().union(*unions))
@@ -557,7 +626,7 @@ def output_coordfree_key(node):
 
 def _coordfree_blankable(n):
     """Is THIS node (ignoring its children) safe to coord-blank? See :func:`output_coordfree_key`."""
-    if isinstance(n, OpaqueLeaf) and "imm(" not in n.token:
+    if isinstance(n, OpaqueLeaf) and not _is_const_token(n.token):
         return False  # a lost-provenance (non-constant) value -> unsafe to coord-blank
     if isinstance(n, OpaqueOp) and not _tok_is_pure(n.token):
         return False  # an unmodeled value op -> unsafe
@@ -618,22 +687,22 @@ def collapse_balanced(root):
     Iterative (no recursion on deep folds). Use :func:`collapse_balanced_forest` for a multi-output
     entry — calling this per output rebuilds every shared subtree once per output."""
     order = _postorder(root)
-    ht, collapsible = _collapse_prep(order)
+    ht, lvl, collapsible = _collapse_prep(order)
     marks = {}
     for n in order:
         if collapsible[id(n)]:
             for c in n.children:
                 marks[id(c)] = True
-    return _collapse_regions(order, [root], ht, collapsible, marks)[0]
+    return _collapse_regions(order, [root], ht, lvl, collapsible, marks)[0]
 
 
 def _collapse_prep(order):
-    """(height, collapsible) per node of a post-order list. Collapse every MAXIMAL balanced
+    """(height, level, collapsible) per node of a post-order list. Collapse every MAXIMAL balanced
     reduction region, including per-chunk reductions nested under a persistent kernel's cross-chunk
     loop. The ITreeReduce token keeps the reduction height (= log2(BLOCK_N)+const,
     num_warps-invariant, BLOCK_N-monotone), so different chunk sizes stay in distinct classes."""
-    bal, ht, optok = _balance_pass(order)
-    return ht, {id(n): (_is_reduce_node(n) and bal[id(n)] and optok[id(n)] is not None) for n in order}
+    bal, ht, lvl, optok = _balance_pass(order)
+    return ht, lvl, {id(n): (_is_reduce_node(n) and bal[id(n)] and optok[id(n)] is not None) for n in order}
 
 
 def collapse_balanced_forest(roots):
@@ -649,11 +718,11 @@ def collapse_balanced_forest(roots):
     resolved by :func:`_shared_region_marks`, which falls back to the exact per-root pass when the
     roots disagree."""
     order = _forest_postorder(roots)
-    ht, collapsible = _collapse_prep(order)
+    ht, lvl, collapsible = _collapse_prep(order)
     marks = _shared_region_marks(order, roots, collapsible)
     if marks is None:
         return [collapse_balanced(r) for r in roots]
-    return _collapse_regions(order, roots, ht, collapsible, marks)
+    return _collapse_regions(order, roots, ht, lvl, collapsible, marks)
 
 
 # Cap on the root x node bitmasks :func:`_shared_region_marks` builds (bits, ~8 MB). Beyond it the
@@ -705,12 +774,12 @@ def _shared_region_marks(order, roots, collapsible):
     return out
 
 
-def _collapse_regions(order, roots, ht, collapsible, has_coll_parent):
+def _collapse_regions(order, roots, ht, lvl, collapsible, has_coll_parent):
     """Collapsed tree of each root, sharing one output map over ``order`` (see the two callers)."""
     new = {}
     for n in order:
         region_root = collapsible[id(n)] and not has_coll_parent.get(id(n), False)
-        info = _collapse_info(n, ht) if region_root else None
+        info = _collapse_info(n, lvl, new) if region_root else None
         if info is not None:
             op, leaf_sig, cols = info
             if op.split(".")[0] in _ORDER_INVARIANT_OPS:
@@ -734,7 +803,7 @@ def _collapse_regions(order, roots, ht, collapsible, has_coll_parent):
                 # add (etc): the SHAPE matters. Keep height (= log2 of the total fan-in, which is
                 # num_warps-invariant for a balanced tree — a 1-leaf pure cross-thread butterfly
                 # included) + the butterfly direction, so unordered stays split and inner_tree merges.
-                new[id(n)] = ITreeReduce(op, leaf_sig, ht[id(n)], _shfl_dir(n, ht))
+                new[id(n)] = ITreeReduce(op, leaf_sig, ht[id(n)], _shfl_dir(n, lvl))
         else:
             new[id(n)] = _rebuild(n, [new[id(c)] for c in n.children])
     return [new[id(r)] for r in roots]

--- a/bitequiv/ptx/builder.py
+++ b/bitequiv/ptx/builder.py
@@ -225,11 +225,17 @@ class _Builder:
         return FpOp(tag, aux, tuple(kids))  # tag == fp kind (add/sub/mul/div/min/max)
 
 
-def _postorder(root):
-    """Nodes of a tree in post-order (children before parents), each visited once even in a
-    shared DAG. Iterative, so deep folds never hit Python's recursion limit."""
+def _forest_postorder(roots):
+    """Nodes of a whole FOREST in post-order (children before parents), each visited once even
+    when the roots share subtrees. Iterative, so deep folds never hit Python's recursion limit.
+
+    Walking (and re-materializing) per root costs O(roots x nodes) on a DAG whose roots share a
+    long chain — a prefix scan, where ``root[i]`` contains ``root[i-1]``, is the worst case. One
+    shared walk makes it O(unique nodes). The emission ORDER differs from the concatenated
+    per-root walks; that is immaterial because every consumer computes a node's value from its
+    children's values, so only children-before-parents matters."""
     order, seen = [], set()
-    stack = [(root, False)]
+    stack = [(r, False) for r in reversed(roots)]
     while stack:
         node, done = stack.pop()
         if id(node) in seen:
@@ -245,6 +251,12 @@ def _postorder(root):
     return order
 
 
+def _postorder(root):
+    """Nodes of one tree in post-order (children before parents), each visited once even in a
+    shared DAG."""
+    return _forest_postorder([root])
+
+
 def tree_sig(root):
     """Full canonical signature string of a tree (readable; for small trees / debugging).
     A shared DAG inlines a shared subtree at each reference, so this can be very large for a
@@ -255,15 +267,25 @@ def tree_sig(root):
     return memo[id(root)]
 
 
+def tree_hashes(roots):
+    """:func:`tree_hash` for EVERY root of one shared DAG, hashing each unique node ONCE.
+
+    A per-root call gives each root a fresh memo, so a subtree shared by k roots is re-hashed k
+    times. The hash is a pure bottom-up Merkle fold — a node's hash is a function of its own local
+    string and its children's hashes, never of which root reached it — so one shared memo yields
+    byte-identical hashes for a fraction of the work."""
+    h = {}
+    for node in _forest_postorder(roots):
+        local = node.sig_local([h[id(c)] for c in node.children])
+        h[id(node)] = hashlib.sha1(local.encode()).hexdigest()[:16]
+    return [h[id(r)] for r in roots]
+
+
 def tree_hash(root):
     """Compact canonical signature: a Merkle hash where each node hashes its local string
     over its children's hashes. Equal trees (including shared DAGs) -> equal hash, computed
     once per unique node, so the descriptor stays O(1)-sized regardless of reduction size."""
-    h = {}
-    for node in _postorder(root):
-        local = node.sig_local([h[id(c)] for c in node.children])
-        h[id(node)] = hashlib.sha1(local.encode()).hexdigest()[:16]
-    return h[id(root)]
+    return tree_hashes([root])[0]
 
 
 def build_trees(func):
@@ -297,13 +319,17 @@ def _is_reduce_node(n):
             or (isinstance(n, ShflCombine) and n.kind in _REDUCE_FP) or isinstance(n, SmemExchange))
 
 
-def _balance_pass(root):
+def _balance_pass(order):
     """Per node: (balanced, height, optok). A subtree is a balanced reduction iff every reduce
     node has children that are balanced reductions of one consistent op AND (for the 2-ary fp
     combine) their heights differ by <= 1 — the AVL property that separates inner_tree's balanced
-    tree from unordered's left-fold. Boundary leaves are trivial arity-1 balanced reductions."""
+    tree from unordered's left-fold. Boundary leaves are trivial arity-1 balanced reductions.
+
+    ``order`` is a post-order node list (one tree's or a whole forest's). Every value is a pure
+    function of the node's own subtree, so a forest-wide pass gives each node exactly the values a
+    per-tree pass would."""
     bal, ht, optok = {}, {}, {}
-    for n in _postorder(root):
+    for n in order:
         if _is_reduce_node(n):
             kids = list(n.children)
             ops = {optok[id(c)] for c in kids if optok[id(c)] is not None}
@@ -526,14 +552,34 @@ def output_coordfree_key(node):
     over-split) descriptor. This blanks more than the guarded reduction collapse (in particular it does
     not re-prove the elementwise assumption for a swizzled address), so it is gated on the empirical
     fuzzer (0 over-merge) rather than statically proven."""
-    for n in _postorder(node):
-        if isinstance(n, OpaqueLeaf) and "imm(" not in n.token:
-            return None  # a lost-provenance (non-constant) value -> unsafe to coord-blank
-        if isinstance(n, OpaqueOp) and not _tok_is_pure(n.token):
-            return None  # an unmodeled value op -> unsafe
-        if isinstance(n, Leaf) and n.coord is None:
-            return None  # no coord at all (not even opaque) -> nothing to blank soundly
-    return _coordfree_sig(node)
+    return output_coordfree_keys([node])[0]
+
+
+def _coordfree_blankable(n):
+    """Is THIS node (ignoring its children) safe to coord-blank? See :func:`output_coordfree_key`."""
+    if isinstance(n, OpaqueLeaf) and "imm(" not in n.token:
+        return False  # a lost-provenance (non-constant) value -> unsafe to coord-blank
+    if isinstance(n, OpaqueOp) and not _tok_is_pure(n.token):
+        return False  # an unmodeled value op -> unsafe
+    if isinstance(n, Leaf) and n.coord is None:
+        return False  # no coord at all (not even opaque) -> nothing to blank soundly
+    return True
+
+
+def output_coordfree_keys(nodes):
+    """:func:`output_coordfree_key` for EVERY output tree of one entry, sharing the safety scan and
+    the signature memo across them, so a subtree several outputs share is scanned and serialized
+    once instead of once per output. Both are pure bottom-up folds, so the returned keys are
+    byte-identical to the per-tree calls. Signatures are built only for the trees that passed the
+    scan (an unsafe tree returns ``None`` and its string is never needed)."""
+    order = _forest_postorder(nodes)
+    safe = {}
+    for n in order:
+        safe[id(n)] = _coordfree_blankable(n) and all(safe[id(c)] for c in n.children)
+    sig, wanted = {}, [n for n in nodes if safe[id(n)]]
+    for n in _forest_postorder(wanted):
+        sig[id(n)] = "L[]" if isinstance(n, Leaf) else n.sig_local([sig[id(c)] for c in n.children])
+    return [sig[id(n)] if safe[id(n)] else None for n in nodes]
 
 
 def _rebuild(n, kids):
@@ -569,20 +615,100 @@ def collapse_balanced(root):
       cross-warp reduction resolved to a representative), the set varies -> distinct -> stays
       over-split (sound, no recovery).
 
-    Iterative (no recursion on deep folds)."""
-    bal, ht, optok = _balance_pass(root)
-    # Collapse every MAXIMAL balanced reduction region, including per-chunk reductions nested
-    # under a persistent kernel's cross-chunk loop. The ITreeReduce token keeps the reduction
-    # height (= log2(BLOCK_N)+const, num_warps-invariant, BLOCK_N-monotone), so different chunk
-    # sizes stay in distinct classes.
-    collapsible = {id(n): (_is_reduce_node(n) and bal[id(n)] and optok[id(n)] is not None) for n in _postorder(root)}
-    has_coll_parent = {}
-    for n in _postorder(root):
+    Iterative (no recursion on deep folds). Use :func:`collapse_balanced_forest` for a multi-output
+    entry — calling this per output rebuilds every shared subtree once per output."""
+    order = _postorder(root)
+    ht, collapsible = _collapse_prep(order)
+    marks = {}
+    for n in order:
         if collapsible[id(n)]:
             for c in n.children:
-                has_coll_parent[id(c)] = True
+                marks[id(c)] = True
+    return _collapse_regions(order, [root], ht, collapsible, marks)[0]
+
+
+def _collapse_prep(order):
+    """(height, collapsible) per node of a post-order list. Collapse every MAXIMAL balanced
+    reduction region, including per-chunk reductions nested under a persistent kernel's cross-chunk
+    loop. The ITreeReduce token keeps the reduction height (= log2(BLOCK_N)+const,
+    num_warps-invariant, BLOCK_N-monotone), so different chunk sizes stay in distinct classes."""
+    bal, ht, optok = _balance_pass(order)
+    return ht, {id(n): (_is_reduce_node(n) and bal[id(n)] and optok[id(n)] is not None) for n in order}
+
+
+def collapse_balanced_forest(roots):
+    """:func:`collapse_balanced` for EVERY output root of one value-DAG, rebuilding each unique node
+    ONCE.
+
+    A per-root call gives each root a fresh output map, so a subtree shared by k roots is
+    re-materialized k times: O(roots x nodes) new node objects, all live at once (measured: a
+    512-root prefix scan expanded a 3,719-node DAG into 631,169 objects, ~2.5 n^2). Every quantity
+    the collapse computes is a pure bottom-up function of a node's own subtree — ``_balance_pass``,
+    ``collapsible``, ``_collapse_info``, ``_shfl_dir``, ``_rebuild`` — with ONE exception: whether a
+    node is a region ROOT also depends on its PARENTS, which are a per-root fact. That flag is
+    resolved by :func:`_shared_region_marks`, which falls back to the exact per-root pass when the
+    roots disagree."""
+    order = _forest_postorder(roots)
+    ht, collapsible = _collapse_prep(order)
+    marks = _shared_region_marks(order, roots, collapsible)
+    if marks is None:
+        return [collapse_balanced(r) for r in roots]
+    return _collapse_regions(order, roots, ht, collapsible, marks)
+
+
+# Cap on the root x node bitmasks :func:`_shared_region_marks` builds (bits, ~8 MB). Beyond it the
+# per-root pass is used instead — same descriptors, just the old cost.
+_MAX_REGION_MARK_BITS = 1 << 26
+
+
+def _shared_region_marks(order, roots, collapsible):
+    """One ``has_coll_parent`` map valid for EVERY root, or ``None`` when the roots disagree.
+
+    :func:`collapse_balanced` treats a collapsible node as a region ROOT only when no collapsible
+    PARENT of it is reachable from that root, so the same shared node can legitimately be a region
+    root under one output and be swallowed by a larger region under another. With one shared memo a
+    node is rebuilt once, so whichever answer came first would silently win for everyone — that
+    would move a collapse boundary and change a descriptor. Decide it exactly with two bitmasks over
+    the roots: ``reach[n]`` = the roots that reach n; ``mark[n]`` = the roots that reach some
+    collapsible parent of n. Root R sees ``has_coll_parent[n] = bit R of mark[n]``, so the roots
+    agree on n iff ``mark[n] & reach[n]`` is empty or is all of ``reach[n]``.
+
+    Only COLLAPSIBLE nodes are checked: ``region_root = collapsible[n] and not has_coll_parent[n]``
+    short-circuits, so the flag is never read anywhere else. That matters — a prefix scan does have
+    nodes whose parents differ per root, but none of them is collapsible, so the shared path stays
+    live exactly where it pays off."""
+    if len(roots) * len(order) > _MAX_REGION_MARK_BITS:
+        return None
+    reach = {}
+    for i, r in enumerate(roots):
+        reach[id(r)] = reach.get(id(r), 0) | (1 << i)
+    for n in reversed(order):  # reversed post-order visits every parent before its children
+        m = reach.get(id(n), 0)
+        if m:
+            for c in n.children:
+                reach[id(c)] = reach.get(id(c), 0) | m
+    mark = {}
+    for n in order:
+        if collapsible[id(n)]:
+            m = reach.get(id(n), 0)
+            for c in n.children:
+                mark[id(c)] = mark.get(id(c), 0) | m
+    out = {}
+    for n in order:
+        if not collapsible[id(n)]:
+            continue
+        m = mark.get(id(n), 0) & reach[id(n)]
+        if m:
+            if m != reach[id(n)]:
+                return None  # some root reaches n without reaching any collapsible parent of it
+            out[id(n)] = True
+    return out
+
+
+def _collapse_regions(order, roots, ht, collapsible, has_coll_parent):
+    """Collapsed tree of each root, sharing one output map over ``order`` (see the two callers)."""
     new = {}
-    for n in _postorder(root):
+    for n in order:
         region_root = collapsible[id(n)] and not has_coll_parent.get(id(n), False)
         info = _collapse_info(n, ht) if region_root else None
         if info is not None:
@@ -611,7 +737,7 @@ def collapse_balanced(root):
                 new[id(n)] = ITreeReduce(op, leaf_sig, ht[id(n)], _shfl_dir(n, ht))
         else:
             new[id(n)] = _rebuild(n, [new[id(c)] for c in n.children])
-    return new[id(root)]
+    return [new[id(r)] for r in roots]
 
 
 def _cols_key(cols):
@@ -634,4 +760,4 @@ def entry_signatures(func):
     roots = build_trees(func)
     if len(roots) == 1:
         roots = [collapse_balanced(roots[0])]
-    return tuple(sorted(tree_hash(t) for t in roots))
+    return tuple(sorted(tree_hashes(roots)))

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -25,16 +25,16 @@ the affine domain, resolved on demand for leaf coordinates).
 
 import hashlib
 
-from pyptx.ir.nodes import RegisterOperand, VectorOperand
+from pyptx.ir.nodes import AddressOperand, ImmediateOperand, RegisterOperand, VectorOperand
 
-from bitequiv.ptx.affine import AffineEval, canon, reqntid_of
+from bitequiv.ptx.affine import AffineEval, canon, reqntid_of, thread_image
 from bitequiv.ptx.builder import (_forest_postorder, collapse_balanced, collapse_balanced_forest, output_coordfree_keys,
                                   tree_hash, tree_hashes)
 from bitequiv.ptx.forward.cfg import has_unknown_control
 from bitequiv.ptx.forward.loops import (find_loops, loop_accumulates, loop_carried_accumulators,
                                         loop_self_increments)
 from bitequiv.ptx.forward.predicate import PredicateDecoder
-from bitequiv.ptx.leaves import leaf_coord, leaf_columns
+from bitequiv.ptx.leaves import _load_width, leaf_coord, leaf_columns
 from bitequiv.ptx.linker import DefUse, _def_regs, linearize
 from bitequiv.ptx.mma import _fence_all_matmul, _is_mma, _mma_fence, mma_token_counts
 from bitequiv.ptx.treeir import (FpOp, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp, ShflCombine,
@@ -129,21 +129,32 @@ class ForwardInterp:
         self.ev = AffineEval(self.du, ntid)
         self.colev = AffineEval(self.du, ntid, absorb_opaque=True)
         self.regs = {}  # reg name -> value-DAG Node (or a transient _Shuffle marker)
-        # Forward shared-memory model (PHASE + same-structure guard, address-agnostic). Each st.shared
-        # element's value node is recorded into the current write phase; `bar.sync` closes the phase. A
-        # shared load / ldmatrix resolves against the most-recently CLOSED phase: if EVERY write in that
-        # phase has the SAME coord-free value structure, the load returns one (a SmemExchange over the
-        # cross-warp partial), else it FAILS CLOSED. Sound because the reader's element is interchangeable
-        # with any write of the same structure (same reduction sub-tree, config-invariant column set), so
-        # the following combine reduces the real cross-warp fan-in and `collapse_balanced` makes a
-        # BALANCED exchange num_warps-invariant (the recovery); an UNORDERED partial keeps its num_warps-
-        # bearing physical height (split, correct). A mixed-structure phase can't be resolved without the
-        # exact address -> fail closed. This replaces the old most-recent, scalar-only match and
-        # un-fail-closes the VECTOR st.shared path (recorded per element). `smem_stores` keeps every
-        # (index, node) for the MMA-epilogue sink scan in `_mma_entry_descriptor`.
+        # Forward shared-memory model (PHASE + address match). Each st.shared element is recorded into
+        # the current write phase as (slot image, value node); `bar.sync` closes the phase. A shared
+        # load / ldmatrix resolves against the most-recently CLOSED phase in two layers:
+        #
+        #   1. ADDRESS-MATCHED. Both the load and the stores are evaluated to an affine over the
+        #      `%tid` bit basis — which IS the (warp, lane) decomposition: `%tid.x` bits [0,5) index
+        #      the lane, bits [5,..) the warp. A warp-leader store's slot is then a function of the
+        #      WARP bits and the reading warp's load slot a function of the LANE bits, and composing
+        #      the two images gives the real slot <-> warp map. The load takes the value of the
+        #      store(s) whose slot image it actually intersects, and those must share one coord-free
+        #      structure. A load whose slot NO store in the phase wrote is unmodeled -> FAIL CLOSED.
+        #   2. Otherwise (an address that is not provably affine) the old address-agnostic fallback:
+        #      if EVERY write in the phase has the same coord-free structure, return one. If not even
+        #      that holds, FAIL CLOSED.
+        #
+        # Sound because the reader's element is interchangeable with any write of the same structure
+        # (same reduction sub-tree, config-invariant column set), so the following combine reduces the
+        # real cross-warp fan-in and `collapse_balanced` makes a BALANCED exchange num_warps-invariant
+        # (the recovery); an UNORDERED partial keeps its num_warps-bearing physical height (split,
+        # correct). Layer 1 additionally fails closed on a load whose slot NO store in the phase wrote
+        # (a stale / unrelated shared buffer), which layer 2 alone would silently answer with an
+        # unrelated subtree. `smem_stores` keeps every (index, node) for the MMA-epilogue sink scan in
+        # `_mma_entry_descriptor`.
         self.smem_stores = []
-        self._smem_phase = []  # value nodes written since the last bar (the open phase)
-        self._smem_closed = []  # value nodes of the most-recently closed phase (what a load reads)
+        self._smem_phase = []  # (slot image | None, value node) written since the last bar
+        self._smem_closed = []  # the most-recently closed phase (what a load reads)
         self._cf_hash_memo = {}  # id(node) -> coord-free Merkle hash, for the `_resolve_smem` check
         # Sound floor: set False when the walk hits a cross-thread structure this phase does not
         # model faithfully (a cross-warp shared load). The reconstructed tree is then untrustworthy
@@ -277,7 +288,7 @@ class ForwardInterp:
             # Over-identifying an MMA output only ever ADDS a splitting term (sound, monotone).
             return Mma("mma-out")
         if op == "ld" and ".shared" in mods:
-            src = self._resolve_smem()
+            src = self._resolve_smem(self._load_slot_image(inst, at))
             if src is not None:
                 return SmemExchange(src)  # cross-warp exchange: read the stored partial's subtree
             self.faithful = False  # unresolvable shared load -> fail closed (opaque fallback below)
@@ -286,7 +297,7 @@ class ForwardInterp:
             # Model it like ld.shared -> return a phase partial. The transpose only permutes which
             # element each lane receives; the reduction structure (hence the collapsed, num_warps-
             # invariant descriptor) is identical whichever it reads, so returning one is faithful.
-            src = self._resolve_smem()
+            src = self._resolve_smem(self._load_slot_image(inst, at))
             if src is not None:
                 return SmemExchange(src)
             self.faithful = False  # unresolvable ldmatrix -> fail closed
@@ -310,6 +321,15 @@ class ForwardInterp:
                 return ShflCombine("redux", kind, width, self._node(inst.operands[1], at))
         if op == "mov" and len(inst.operands) == 2 and isinstance(inst.operands[1], RegisterOperand):
             return self._val(inst.operands[1], at)  # pass-through (preserves a _Shuffle / _Packed)
+        if op == "mov" and len(inst.operands) == 2 and isinstance(inst.operands[1], ImmediateOperand):
+            # `mov.b32 %r, 0f3FB8AA3B` IS the constant. Whether ptxas materializes a literal in a
+            # register or feeds it straight to the consumer is a register-allocation choice that
+            # varies with num_warps, so keeping the two forms apart (an `OpaqueOp` carrying the `mov`
+            # token vs the consumer's plain immediate `OpaqueLeaf`) split configs whose arithmetic is
+            # identical (softmax's log2(e) factor). `_val` produces exactly the node an inline
+            # immediate produces, so the two spellings now converge. Value-preserving: a `mov` of an
+            # immediate is the identity on that immediate.
+            return self._val(inst.operands[1], at)
         if _is_packed(inst) and op in _FP_KINDS and len(inst.operands) == 3:
             return self._packed_combine(op, mods, inst.operands[1], inst.operands[2], at)
         if _is_packed(inst) and op == "fma" and len(inst.operands) == 4:
@@ -524,17 +544,48 @@ class ForwardInterp:
             return [self._deref(l) for l in v.lanes]
         return [self._scalar(v)]
 
+    def _slot_image(self, operand, at, byte_offsets=(0, )):
+        """``(uniform_key, byte offsets)`` this shared access touches over the thread grid, or
+        ``None`` when the address is not provably affine. ``byte_offsets`` spreads a vector access
+        over its elements (element ``k`` of a ``.vN`` access sits ``k * width`` bytes past the base):
+        a STORE element gets its own slot, a LOAD gets the union of all the slots it reads."""
+        if not isinstance(operand, AddressOperand):
+            return None
+        img = thread_image(self.ev, self.ev.of_address(operand, at))
+        if img is None:
+            return None
+        uniform, offs = img
+        if byte_offsets == (0, ):
+            return uniform, offs
+        return uniform, frozenset(o + b for o in offs for b in byte_offsets)
+
+    def _load_slot_image(self, inst, at):
+        """Slot image of a shared LOAD, covering every element of a ``.vN`` / ``ldmatrix`` read (the
+        forward walk gives all of them one value node, so they must all be matched)."""
+        if len(inst.operands) < 2:
+            return None
+        dst = inst.operands[0]
+        n = len(dst.elements) if isinstance(dst, VectorOperand) else 1
+        width = _load_width(inst.modifiers) or 0
+        return self._slot_image(inst.operands[1], at, tuple(k * width for k in range(n)))
+
     def _record_shared_store(self, inst, at):
         """Record each ``st.shared`` element (scalar or VECTOR, one write per f32 slot) into the
-        current write phase + the flat ``smem_stores`` (used by the MMA-epilogue sink scan)."""
+        current write phase + the flat ``smem_stores`` (used by the MMA-epilogue sink scan). Each
+        element carries the SLOT IMAGE of the address it lands at, so a later load can be matched to
+        the stores that actually wrote the slot it reads. A ``_Packed`` element (two f32 lanes in one
+        64-bit register) expands to two value nodes that share one slot image — imprecise but
+        conservative: a load matching that slot then has to find BOTH lanes structurally equal."""
         val = inst.operands[1]
         elts = val.elements if isinstance(val, VectorOperand) else [val]
-        for e in elts:
+        width = _load_width(inst.modifiers) or 0
+        for k, e in enumerate(elts):
             if not isinstance(e, RegisterOperand):
                 continue  # an immediate element (a constant) carries no reduction structure
+            img = self._slot_image(inst.operands[0], at, (k * width, ))
             for node in self._store_nodes(e, at):
                 self.smem_stores.append((at, node))
-                self._smem_phase.append(node)
+                self._smem_phase.append((img, node))
 
     def _store_nodes(self, operand, at):
         """Value node(s) an ``st.shared`` element contributes to the write phase. A ``_Packed`` (a
@@ -581,20 +632,29 @@ class ForwardInterp:
                 memo[id(n)] = hashlib.sha1(local.encode()).hexdigest()[:16]
         return memo[id(node)]
 
-    def _resolve_smem(self):
-        """Value subtree a shared load / ldmatrix reads: a representative write from the most-recently
-        CLOSED phase, or ``None`` (fail closed) when the phase is empty or its writes are not all the
-        SAME coord-free structure. Address-agnostic but sound: the reader's element is interchangeable
-        with any write of the same structure (same cross-warp partial sub-tree, config-invariant column
-        set), so returning one is faithful and the following combine reduces the real fan-in. A
-        mixed-structure phase cannot be resolved without the exact address -> fail closed (over-split).
-        Falls back to the still-open phase only when nothing has been closed yet (a load before any bar)."""
+    def _resolve_smem(self, load_img=None):
+        """Value subtree a shared load / ldmatrix reads, or ``None`` to fail closed. See the
+        shared-memory model note in :meth:`__init__` for the two layers.
+
+        Layer 1 (address-matched) needs the load address AND every store address in the phase to be
+        provably affine — an unresolved store could have written the very slot we read — and takes the
+        value of the stores whose slot image the load actually intersects. Those stores must share one
+        coord-free structure, which is what makes returning any one of them faithful. Layer 2 is the
+        old address-agnostic whole-phase check, kept for an unresolved address. Falls back to the
+        still-open phase only when nothing has been closed yet (a load before any bar)."""
         cands = self._smem_closed if self._smem_closed else self._smem_phase
         if not cands:
             return None
-        if len({self._cf_hash(c) for c in cands}) != 1:
+        if load_img is not None and all(si is not None for si, _ in cands):
+            uniform, offs = load_img
+            hit = [n for si, n in cands if si[0] == uniform and (si[1] & offs)]
+            if hit and len({self._cf_hash(n) for n in hit}) == 1:
+                return hit[-1]
+            if not hit:
+                return None  # reads a slot this phase never wrote -> unmodeled -> fail closed
+        if len({self._cf_hash(n) for _, n in cands}) != 1:
             return None  # mixed-structure phase -> ambiguous without the address -> fail closed
-        return cands[-1]
+        return cands[-1][1]
 
     def fingerprint(self):
         """Conservative per-config key used when the reconstruction is not faithful. Folds the

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -28,8 +28,8 @@ import hashlib
 from pyptx.ir.nodes import RegisterOperand, VectorOperand
 
 from bitequiv.ptx.affine import AffineEval, canon, reqntid_of
-from bitequiv.ptx.builder import (_coordfree_sig, _postorder, collapse_balanced, output_coordfree_key,
-                                  tree_hash)
+from bitequiv.ptx.builder import (_forest_postorder, collapse_balanced, collapse_balanced_forest, output_coordfree_keys,
+                                  tree_hash, tree_hashes)
 from bitequiv.ptx.forward.cfg import has_unknown_control
 from bitequiv.ptx.forward.loops import (find_loops, loop_accumulates, loop_carried_accumulators,
                                         loop_self_increments)
@@ -144,6 +144,7 @@ class ForwardInterp:
         self.smem_stores = []
         self._smem_phase = []  # value nodes written since the last bar (the open phase)
         self._smem_closed = []  # value nodes of the most-recently closed phase (what a load reads)
+        self._cf_hash_memo = {}  # id(node) -> coord-free Merkle hash, for the `_resolve_smem` check
         # Sound floor: set False when the walk hits a cross-thread structure this phase does not
         # model faithfully (a cross-warp shared load). The reconstructed tree is then untrustworthy
         # for the verbatim hash (it would over-merge across num_warps), so forward_descriptor falls
@@ -554,6 +555,32 @@ class ForwardInterp:
             return [v.child]
         return [v]
 
+    def _cf_hash(self, node):
+        """Coord-free Merkle hash of a subtree (Leaf coordinates blanked) — the same equivalence the
+        string ``_coordfree_sig`` tests, but as a fixed-size hash that composes over CHILD hashes and
+        is memoized by node id across the whole run. ``_resolve_smem`` uses it to decide whether a
+        shared phase's writes all share one structure in O(new nodes) instead of serializing every
+        candidate's full subtree: the string form INLINES a shared subtree at each reference, so on a
+        deeply shared DAG (welford's unrolled two-pass fold) it is quadratic in the chain length and
+        one entry blew past a 20 GB cap. Only an equality test reads this, never a descriptor."""
+        memo = self._cf_hash_memo
+        if id(node) in memo:
+            return memo[id(node)]
+        stack = [(node, False)]
+        while stack:
+            n, done = stack.pop()
+            if id(n) in memo:
+                continue
+            if not done:
+                stack.append((n, True))
+                for c in n.children:
+                    if id(c) not in memo:
+                        stack.append((c, False))
+            else:
+                local = "L[]" if isinstance(n, Leaf) else n.sig_local([memo[id(c)] for c in n.children])
+                memo[id(n)] = hashlib.sha1(local.encode()).hexdigest()[:16]
+        return memo[id(node)]
+
     def _resolve_smem(self):
         """Value subtree a shared load / ldmatrix reads: a representative write from the most-recently
         CLOSED phase, or ``None`` (fail closed) when the phase is empty or its writes are not all the
@@ -565,7 +592,7 @@ class ForwardInterp:
         cands = self._smem_closed if self._smem_closed else self._smem_phase
         if not cands:
             return None
-        if len({_coordfree_sig(c) for c in cands}) != 1:
+        if len({self._cf_hash(c) for c in cands}) != 1:
             return None  # mixed-structure phase -> ambiguous without the address -> fail closed
         return cands[-1]
 
@@ -604,9 +631,10 @@ class ForwardInterp:
 _LDG_TYPE_MODS = frozenset({".b8", ".b16", ".b32", ".b64", ".b128", ".f16", ".f32", ".f64"})
 
 
-def _reduces_without_leaf(roots):
-    """True iff some RAW (uncollapsed) root reduces over a CROSS-THREAD structure (a
+def _reduces_without_leaf(nodes):
+    """True iff the RAW (uncollapsed) output forest reduces over a CROSS-THREAD structure (a
     ``ShflCombine`` butterfly / ``SmemExchange``) yet reaches NO loaded ``Leaf`` anywhere.
+    ``nodes`` is the forest post-order of the raw roots.
 
     Such a tree reduces only over a constant SEED + cross-warp shuffles — the reduced input
     data (the within-thread / chunk fold that feeds the accumulator) was NOT captured by the
@@ -619,12 +647,11 @@ def _reduces_without_leaf(roots):
     NORMAL reduction has no ``Leaf`` either — only the raw tree distinguishes a faithful
     leaf-bearing reduction from this data-losing one."""
     has_leaf = has_cross_thread = False
-    for r in roots:
-        for n in _postorder(r):
-            if isinstance(n, Leaf):
-                has_leaf = True
-            elif isinstance(n, (ShflCombine, SmemExchange)):
-                has_cross_thread = True
+    for n in nodes:
+        if isinstance(n, Leaf):
+            has_leaf = True
+        elif isinstance(n, (ShflCombine, SmemExchange)):
+            has_cross_thread = True
     return has_cross_thread and not has_leaf
 
 
@@ -642,6 +669,17 @@ def _global_load_shape(func):
     return ",".join(f"{k}x{n}" for k, n in sorted(m.items()))
 
 
+# Node budget for the signature stage. Past this many UNIQUE value-DAG nodes the entry takes the
+# conservative fingerprint instead of the collapsed hash. With one memo shared by all the outputs
+# the collapse + hash is linear in this count, so the budget is a backstop against a shape nobody
+# has measured yet, not an active behaviour change: the largest entry that reaches this check
+# across the whole evaluation corpus is 10,793 nodes (18x under), and the largest entry anywhere —
+# a GEMM, which takes the MMA fence path and never gets here — is 72,325 (2.8x under).
+# Fingerprinting is unconditionally sound — it only ever over-splits — so tripping the budget costs
+# recovery, never correctness.
+_MAX_DAG_NODES = 200_000
+
+
 def forward_descriptor(func):
     """Per-entry forward descriptor: the collapsed + Merkle-hashed output trees (reusing the backward
     ``collapse_balanced`` + ``tree_hash`` so it is directly comparable to
@@ -651,7 +689,10 @@ def forward_descriptor(func):
     roots = interp.run()
     if not interp.faithful:
         return (interp.fingerprint(), )
-    if _reduces_without_leaf(roots):
+    nodes = _forest_postorder(roots)  # every unique value-DAG node once, shared by all the outputs
+    if len(nodes) > _MAX_DAG_NODES:
+        return (interp.fingerprint(), )  # see `_MAX_DAG_NODES`
+    if _reduces_without_leaf(nodes):
         # Faithful walk, but the reduction lost its input leaves (a fully-unrolled loop-carried
         # fold reduced only over the seed + cross-warp shuffles). The hash cannot see the chunk
         # grouping -> fail closed with the conservative fingerprint + the global-load shape (a
@@ -668,11 +709,14 @@ def forward_descriptor(func):
     # reduction keeps its ShflCombine offsets in the key -> stays split (correct). If ANY output is not
     # cleanly reconstructed (opaque leaf / unrecovered coord), fall back to the verbatim trees (sound,
     # over-split). Replaces the old blanket multi-output G3 guard; gated on the fuzzer (0 over-merge).
-    collapsed = [collapse_balanced(r) for r in roots]
-    keys = [output_coordfree_key(t) for t in collapsed]
+    # The three stages share ONE memo across the outputs, so a subtree k outputs have in common is
+    # collapsed / scanned / hashed once instead of k times (the outputs of a prefix scan share almost
+    # everything, which is what made this quadratic).
+    collapsed = collapse_balanced_forest(roots)
+    keys = output_coordfree_keys(collapsed)
     if all(k is not None for k in keys):
         return tuple(sorted({hashlib.sha1(k.encode()).hexdigest()[:16] for k in keys}))
-    return tuple(sorted(tree_hash(t) for t in collapsed))
+    return tuple(sorted(tree_hashes(collapsed)))
 
 
 def _fence_str(fence):
@@ -706,27 +750,24 @@ def _epilogue_reduces_mma(sinks):
     layernorm output is the full tile written through ``ldmatrix``, which relocates the reduced values
     across lanes, so the ``st.global`` root alone can miss the ``sum(e)`` reduction buried
     mid-computation. Scanning the recorded shared-store values and the live registers too surfaces its
-    ``FpOp``-both-children-``Mma`` combine. The ``Mma``-bearing walk is memoized across all sinks
-    (shared subtrees walked once)."""
+    ``FpOp``-both-children-``Mma`` combine. ONE forest walk covers every sink, so a subtree many sinks
+    share (the whole accumulator chain, typically) is visited once instead of once per sink."""
     has_mma = {}
-    for root in sinks:
-        for n in _postorder(root):
-            if id(n) in has_mma:
-                continue
-            has_mma[id(n)] = isinstance(n, Mma) or any(has_mma[id(c)] for c in n.children)
-            # A ShflCombine (butterfly) IS a reduce step, so over an Mma subtree it is a genuine
-            # cross-lane reduction. A bare SmemExchange is NOT — it is a cross-warp / relocation READ
-            # (pure data movement). The GEMM epilogue stages the MMA accumulator through
-            # st.shared -> ldmatrix -> st.global, which now reconstructs as SmemExchange(Mma) but
-            # reduces nothing; counting it here over-split every pure GEMM into the per-config
-            # fingerprint (undoing the tiling-invariant fence). A REAL cross-warp reduction over the
-            # MMA output still fires: its combine is the FpOp(add/min/max)-both-children-Mma below, and
-            # it also carries a within-warp ShflCombine / shfl.bfly. So key on an actual reduce node.
-            if isinstance(n, ShflCombine) and has_mma[id(n)]:
-                return True
-            if (isinstance(n, FpOp) and not n.fused and n.kind in ("add", "min", "max")
-                    and len(n.children) == 2 and all(has_mma[id(c)] for c in n.children)):
-                return True
+    for n in _forest_postorder(sinks):
+        has_mma[id(n)] = isinstance(n, Mma) or any(has_mma[id(c)] for c in n.children)
+        # A ShflCombine (butterfly) IS a reduce step, so over an Mma subtree it is a genuine
+        # cross-lane reduction. A bare SmemExchange is NOT — it is a cross-warp / relocation READ
+        # (pure data movement). The GEMM epilogue stages the MMA accumulator through
+        # st.shared -> ldmatrix -> st.global, which now reconstructs as SmemExchange(Mma) but
+        # reduces nothing; counting it here over-split every pure GEMM into the per-config
+        # fingerprint (undoing the tiling-invariant fence). A REAL cross-warp reduction over the
+        # MMA output still fires: its combine is the FpOp(add/min/max)-both-children-Mma below, and
+        # it also carries a within-warp ShflCombine / shfl.bfly. So key on an actual reduce node.
+        if isinstance(n, ShflCombine) and has_mma[id(n)]:
+            return True
+        if (isinstance(n, FpOp) and not n.fused and n.kind in ("add", "min", "max")
+                and len(n.children) == 2 and all(has_mma[id(c)] for c in n.children)):
+            return True
     return False
 
 

--- a/bitequiv/ptx/forward/interp.py
+++ b/bitequiv/ptx/forward/interp.py
@@ -36,7 +36,7 @@ from bitequiv.ptx.forward.loops import (find_loops, loop_accumulates, loop_carri
 from bitequiv.ptx.forward.predicate import PredicateDecoder
 from bitequiv.ptx.leaves import leaf_coord, leaf_columns
 from bitequiv.ptx.linker import DefUse, _def_regs, linearize
-from bitequiv.ptx.mma import _fence_all_matmul, _is_mma, _mma_fence
+from bitequiv.ptx.mma import _fence_all_matmul, _is_mma, _mma_fence, mma_token_counts
 from bitequiv.ptx.treeir import (FpOp, Leaf, LoopReduce, Mma, OpaqueLeaf, OpaqueOp, ShflCombine,
                                  SmemExchange)
 
@@ -748,7 +748,9 @@ def _mma_entry_descriptor(func, fence):
     runs extra fp arithmetic inside the fold (``input_precision=tf32x3``, whose compensation sums are
     grouped per K chunk, so its BLOCK_K IS bit-relevant). The fingerprint — not ``loops=`` alone — is
     the fallback ON PURPOSE: a tcgen05 fold increments no pointer, so ``_loop_steps`` is empty there
-    and ``loops=`` would leave the descriptor chunk-blind exactly where the proof failed."""
+    and ``loops=`` would leave the descriptor chunk-blind exactly where the proof failed. The
+    fail-closed side additionally carries ``mmacnt=`` (:func:`bitequiv.ptx.mma.mma_token_counts`), the
+    matmul reduction extent the fence drops on the strength of a proof that did not hold here."""
     from bitequiv.ptx.forward.loops import is_pure_mma_fold, reduction_trip_signature
     from bitequiv.ptx_reduction import _loop_steps
     parts = [_fence_str(fence)]
@@ -777,6 +779,12 @@ def _mma_entry_descriptor(func, fence):
         # closed on the conservative per-config fingerprint, which carries num_warps, the ordered
         # shuffle sequence and the op counts, so any of those differing splits.
         parts.append("mma+fp|" + interp.fingerprint())
+        # The fingerprint counts every fp op EXCEPT the tensor-core ones, which the fence drops on
+        # purpose (a re-tiling issues a different MMA count over the same dot products). That licence
+        # comes from the pure-fold proof, which just failed here, so put the count back: it is the one
+        # witness of the matmul's REDUCTION EXTENT (attention's head dim, a GEMM's K), which the rest
+        # of the key cannot see. Fail-closed side only -> a proven-pure fold keeps BLOCK_K and v2==v5.
+        parts.append("mmacnt=" + ",".join(f"{t}x{n}" for t, n in mma_token_counts(func)))
     steps = _loop_steps(func)
     # BLOCK_K is bit-neutral only for a PROVEN-pure f16/bf16/tf32 tensor-core fold: native-k is fixed
     # and each MMA's F=25 accumulate is exact, so BLOCK_K then only re-batches the same in-order

--- a/bitequiv/ptx/forward/loops.py
+++ b/bitequiv/ptx/forward/loops.py
@@ -12,6 +12,8 @@ descriptor drop its chunk (BLOCK_K) fence.
 """
 from pyptx.ir.nodes import Block, ImmediateOperand, Label, RegisterOperand, VectorOperand
 
+from bitequiv.ptx.affine import Affine, AffineEval, reqntid_of
+from bitequiv.ptx.linker import DefUse
 from bitequiv.ptx.mma import _is_mma
 
 # fp combine ops + widths, used to detect a loop-carried floating-point accumulation.
@@ -278,6 +280,40 @@ def _setp_bounds_of(insts, regs):
     return out
 
 
+def _symbolic_bounds_of(insts, regs, ev):
+    """Canonical form of the RUNTIME (non-literal) values a counter in ``regs`` is compared against.
+
+    :func:`_setp_bounds_of` sees a bound only when it is an immediate. A reduction loop whose bound is
+    computed at run time — the common tiled / triangular case ``for j in range(0, program_id * TILE)``
+    — is then invisible, and two configs whose folds are split at DIFFERENT points share a signature.
+    Evaluating the bound register as an :class:`~bitequiv.ptx.affine.Affine` over the symbol basis
+    recovers exactly the missing fact: the bound is ``TILE * %ctaid``, so ``TILE`` (how many chunks
+    this CTA's fold covers before the loop hands over to the next region) is in the key.
+
+    A value that is not PROVABLY affine yields one fixed placeholder rather than its structural token:
+    that token inlines unresolved register names, which are allocation noise and would split
+    bit-identical configs. Recording only "a runtime bound of unknown form is present" keeps the term
+    stable while still separating it from a proven affine one."""
+    out = set()
+    for i, inst in enumerate(insts):
+        if inst.opcode != "setp" or len(inst.operands) < 3:
+            continue
+        comparands = inst.operands[1:]
+        if not any(isinstance(o, RegisterOperand) and o.name in regs for o in comparands):
+            continue
+        for o in comparands:
+            if isinstance(o, RegisterOperand) and o.name not in regs:
+                value = ev.of_reg(o.name, i)
+                out.add(value.to_str() if isinstance(value, Affine) else "?")
+    return out
+
+
+def _with_bounds(base, bounds):
+    """``base`` alone when no runtime bound was recovered (byte-identical to the two-tier signature),
+    else ``base`` plus the ``("bound", ...)`` tier."""
+    return base if not bounds else (base, ("bound", tuple(sorted(bounds))))
+
+
 def reduction_trip_signature(func):
     """Hashable fingerprint that distinguishes the outer reduction loops' TRIP COUNTS (the split-K
     regrouping = num_splits), or ``None`` when the entry has no nested-reduction structure (a plain
@@ -294,12 +330,21 @@ def reduction_trip_signature(func):
       likewise tiling-invariant per split count.
     Both are keyed on num_splits and independent of the tiling axes, so they recover the tiling freedom
     while keeping the split counts distinct. Returns ``None`` unless an outer reduction loop exists, so
-    a plain tiled GEMM keeps its tiling-invariant fence."""
+    a plain tiled GEMM keeps its tiling-invariant fence.
+
+    Neither tier can see a bound that is not a compile-time constant, so a third ``("bound", ...)``
+    tier (:func:`_symbolic_bounds_of`) carries the RUNTIME bounds as affine forms. It is appended, not
+    substituted, so a signature that has no runtime bound is byte-identical to before — the tier can
+    only ever SPLIT. This is what fences a fold whose split point moves with the output tile: causal
+    attention runs its unmasked KV blocks in one loop up to ``BLOCK_M * program_id`` and the masked
+    diagonal band in a second loop with DIFFERENT arithmetic, so ``BLOCK_M`` decides which KV blocks
+    are rounded which way even though both loops exist, with the same op mix, at every ``BLOCK_M``."""
     insts, loops = find_loops(func)
     splitloops = outer_reduction_loops(insts, loops)
     if not splitloops:
         return None
-    clean = set()
+    ev = AffineEval(DefUse(func), reqntid_of(func))
+    clean, bounds = set(), set()
     for h, latch in splitloops:
         steps = {}
         for k in range(h, latch + 1):
@@ -312,11 +357,12 @@ def reduction_trip_signature(func):
                         steps[d.name] = int(b.text, 0)
                     except (ValueError, TypeError):
                         continue
+        bounds |= _symbolic_bounds_of(insts, set(steps), ev)
         for reg, step in steps.items():
             for bound in _setp_bounds_of(insts, {reg}):
                 clean.add((step, bound))
     if clean:
-        return ("trip", tuple(sorted(clean)))
+        return _with_bounds(("trip", tuple(sorted(clean))), bounds)
     region = []
     for h, latch in splitloops:
         cs = set()
@@ -330,4 +376,4 @@ def reduction_trip_signature(func):
                         except (ValueError, TypeError):
                             continue
         region.append(tuple(sorted(cs)))
-    return ("region", tuple(sorted(region)))
+    return _with_bounds(("region", tuple(sorted(region))), bounds)

--- a/bitequiv/ptx/mma.py
+++ b/bitequiv/ptx/mma.py
@@ -205,3 +205,21 @@ def _mma_fence(func):
             counts[t] = counts.get(t, 0) + 1
         return ("mma-fp8", tuple(sorted(counts.items())), flags, (fma, addmul))
     return ("mma", frozenset(tokens), flags, (int(fma > 0), int(addmul > 0)))
+
+
+def mma_token_counts(func):
+    """Sorted ``(token, count)`` of the entry's tensor-core matmuls — how many hardware accumulate
+    passes each :func:`_mma_token` contributes.
+
+    :func:`_mma_fence` deliberately DROPS this count for the non-fp8 families, because for a
+    PROVEN-pure tensor-core fold a re-tiling issues a different number of MMA instructions over the
+    same dot products (bit-free). That licence does not exist when the fold is NOT proven pure: there
+    the count is the only PTX witness of how many products reach an accumulator, i.e. of the matmul's
+    REDUCTION EXTENT (attention's head dim, a GEMM's K). Callers on the fail-closed side use this;
+    the fence itself must not, or it would over-split every equivalent re-tiling."""
+    counts = {}
+    for inst in linearize(func):
+        if _is_mma(inst):
+            t = _mma_token(inst.opcode, inst.modifiers)
+            counts[t] = counts.get(t, 0) + 1
+    return tuple(sorted(counts.items()))

--- a/bitequiv/ptx/treeir.py
+++ b/bitequiv/ptx/treeir.py
@@ -141,11 +141,12 @@ class FpOp:
     fused: bool = False  # True for fma: children = (a, b, c) computing a*b + c
 
     def sig_local(self, child_sigs):
-        # .rn is the DEFAULT rounding for add/mul/fma (op.f32 == op.rn.f32 bit-for-bit), so strip an
-        # explicit .rn there to merge enable_fp_fusion's implicit-vs-explicit-.rn difference (e.g.
-        # the persistent kernel's cross-chunk add). Do NOT touch div/sub/min/max (kept verbatim) —
-        # normalizing those broke welford soundness.
-        m = _norm("".join(self.mods)) if self.kind in ("add", "mul", "fma") else "".join(self.mods)
+        # .rn is the DEFAULT rounding for add/sub/mul/fma (op.f32 == op.rn.f32 bit-for-bit), so strip
+        # an explicit .rn there to merge enable_fp_fusion's implicit-vs-explicit-.rn difference (e.g.
+        # the persistent kernel's cross-chunk add, or softmax's `x - max` with fp fusion off). Do NOT
+        # touch div/min/max (kept verbatim) — normalizing those broke welford soundness, and `div`
+        # genuinely carries its rounding/approximation mode in that modifier.
+        m = _norm("".join(self.mods)) if self.kind in ("add", "sub", "mul", "fma") else "".join(self.mods)
         kids = list(child_sigs)
         if self.fused and len(kids) == 3:
             ab = sorted(kids[:2])
@@ -189,7 +190,11 @@ class ShflCombine:
 class SmemExchange:
     """Warp-leader partials crossing through shared memory (a phase boundary in the
     cross-warp reduction). The transpose itself is implied by the surrounding shuffle
-    offsets; this node just marks the exchange so the tree shape is faithful."""
+    offsets; this node just marks the exchange so the tree shape is faithful.
+
+    An exchange RELOCATES one value from one thread to another — an ``ld.shared`` reads a single slot,
+    so its fan-in is exactly one and it combines nothing. That is why it carries no reduction height
+    (see :func:`bitequiv.ptx.builder._balance_pass`)."""
 
     child: object
 

--- a/bitequiv/tests/test_ptx_affine.py
+++ b/bitequiv/tests/test_ptx_affine.py
@@ -91,3 +91,44 @@ def test_affine_value_identity_ignores_range():
     x = Affine(4, frozenset({("%tid.x", 4)}), rng=(0, 512))
     y = Affine(4, frozenset({("%tid.x", 4)}), rng=None)
     assert x == y and hash(x) == hash(y)
+
+
+def test_signed_bfe_is_opaque():
+    # `bfe.s32 d, a, 4, 1` SIGN-EXTENDS the single extracted bit -> 0 or -1, which is how Triton
+    # turns a tid bit into an xor-swizzle mask. Modeling it as the plain 0/1 bit slice would make the
+    # swizzled address provably (and wrongly) affine, so the signed form must stay opaque.
+    assert isinstance(_eval("mov.u32 %r1, %tid.x;\nbfe.s32 %r2, %r1, 4, 1;", "%r2"), Opaque)
+    # The unsigned form IS the plain bit slice and stays exact.
+    u = _eval("mov.u32 %r1, %tid.x;\nbfe.u32 %r2, %r1, 4, 1;", "%r2")
+    assert isinstance(u, Affine) and canon(u) == "1*%tid.x.bit4"
+
+
+def test_symbol_operand_is_a_stable_base():
+    # A bare symbol used as a value (the shared-array base) is a link-time constant, so an address
+    # built on it stays affine instead of poisoning the whole expression to Opaque.
+    v = _eval("mov.b32 %r1, global_smem;\nmov.u32 %r2, %tid.x;\nshl.b32 %r3, %r2, 2;\n"
+              "add.s32 %r4, %r1, %r3;", "%r4")
+    assert isinstance(v, Affine) and canon(v) == "4*%tid.x+1*sym:global_smem"
+
+
+def test_thread_image_enumerates_the_slot_set():
+    from bitequiv.ptx.affine import thread_image
+    src = (f"{_HEADER}.visible .entry k(.param .u64 .ptr .global k_param_0, .param .u32 k_param_1)\n"
+           ".reqntid 128\n{\n.reg .b32 %r<40>;\n.reg .b64 %rd<20>;\n"
+           # a warp-leader store: slot = (tid >> 5) * 4 bytes, i.e. one slot per warp
+           "mov.u32 %r1, %tid.x;\nshr.u32 %r2, %r1, 5;\nshl.b32 %r3, %r2, 2;\n"
+           "mov.b32 %r4, global_smem;\nadd.s32 %r5, %r4, %r3;\n"
+           # the reading warp: slot = lane * 4 bytes
+           "and.b32 %r6, %r1, 31;\nshl.b32 %r7, %r6, 2;\nadd.s32 %r8, %r4, %r7;\n"
+           "ret;\n}\n")
+    m = parse(src)
+    f = [d for d in m.directives if getattr(d, "is_entry", False)][0]
+    du = DefUse(f)
+    ev = AffineEval(du, reqntid_of(f))
+    st = thread_image(ev, ev.of_reg("%r5", len(du.insts)))
+    ld = thread_image(ev, ev.of_reg("%r8", len(du.insts)))
+    base = frozenset({("sym:global_smem", 1)})
+    assert st == (base, frozenset({0, 4, 8, 12}))           # 4 warps at reqntid 128
+    assert ld == (base, frozenset(4 * i for i in range(32)))  # 32 lanes
+    # the store slots are a subset of what the reading warp covers -> the exchange is matched
+    assert st[1] <= ld[1]

--- a/bitequiv/tests/test_ptx_attention.py
+++ b/bitequiv/tests/test_ptx_attention.py
@@ -1,0 +1,147 @@
+"""Two fail-closed MMA residuals that flash attention exposes, in hand-crafted PTX (CPU-only).
+
+1. A fold whose SPLIT POINT moves with the output tile. Causal attention runs its fully-unmasked KV
+   blocks in one loop bounded by ``BLOCK_M * program_id`` and the masked diagonal band in a second
+   loop with DIFFERENT arithmetic. Both loops exist, with the same op mix, at every ``BLOCK_M`` — only
+   the runtime bound moves — so every count-based term of the key is identical while the bits are not.
+   :func:`~bitequiv.ptx.forward.loops.reduction_trip_signature` must carry the bound's affine form.
+2. The matmul REDUCTION EXTENT. The fence drops the MMA count because a re-tiling issues a different
+   count over the same dot products — a licence that comes from the pure-fold proof. Where that proof
+   fails, the count is the only witness of how many products reach the accumulator (attention's head
+   dim), so it must be back in the key; where it holds, it must stay out (BLOCK_K / v2==v5 recovery).
+"""
+from pyptx.parser import parse
+
+from bitequiv.ptx.forward import loops
+from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
+from bitequiv.ptx.mma import mma_token_counts
+from bitequiv.ptx_reduction import _ensure_header, ptx_header
+
+_HDR = ptx_header()
+_MMA = "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 {%r3}, %r4, %r5;\n"
+# A cross-lane butterfly makes the entry reduce over the MMA output -> the fail-closed branch.
+_REDUCE = "shfl.sync.bfly.b32 %r6, %r7, 16, 31, -1;\nadd.f32 %f1, %f1, %f3;\n"
+
+
+def _entry(ptx):
+    return next(d for d in parse(_ensure_header(ptx)).directives if getattr(d, "is_entry", False))
+
+
+def _tiled_fold(tile, nmma=1, first=0):
+    """An accumulating loop whose bound is ``tile * program_id`` — the unmasked region of a
+    tile-diagonal fold. ``first`` shifts every virtual register number (allocation noise)."""
+    r = lambda n: f"%r{n + first}"  # noqa: E731
+    return _HDR + f"""
+.visible .entry k(.param .u64 p) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<{16 + first}>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.f32 %f1, 0f00000000;
+  mov.u32 {r(8)}, %ctaid.x;
+  mul.lo.s32 {r(9)}, {r(8)}, {tile};
+  mov.b32 {r(1)}, 0;
+$L__FOLD:
+  {_MMA * nmma}  {_REDUCE}  add.s32 {r(1)}, {r(1)}, 1;
+  setp.lt.s32 %p1, {r(1)}, {r(9)};
+  @%p1 bra $L__FOLD;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+def _param_fold(first=0):
+    """Same fold, but bounded by a kernel PARAM (no tile scaling) — the non-causal shape."""
+    r = lambda n: f"%r{n + first}"  # noqa: E731
+    return _HDR + f"""
+.visible .entry k(.param .u64 p, .param .u32 n) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<{16 + first}>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  ld.param.u32 {r(9)}, [n];
+  mov.f32 %f1, 0f00000000;
+  mov.b32 {r(1)}, 0;
+$L__FOLD:
+  {_MMA}  {_REDUCE}  add.s32 {r(1)}, {r(1)}, 1;
+  setp.lt.s32 %p1, {r(1)}, {r(9)};
+  @%p1 bra $L__FOLD;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+def _pure_fold(nmma):
+    """A PROVEN-pure tensor-core fold (accumulator touched only by MMA, no reduction over the output):
+    the case whose MMA count MUST stay out of the key so re-tiling / v2==v5 keep merging."""
+    return _HDR + f"""
+.visible .entry k(.param .u64 p) {{
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .pred %p<4>;
+  .reg .b64 %rd<2>;
+  ld.param.u64 %rd1, [p];
+  mov.b32 %r1, 0;
+$L__K:
+  {_MMA * nmma}  add.s32 %r1, %r1, 16;
+  setp.lt.s32 %p1, %r1, 256;
+  @%p1 bra $L__K;
+  st.global.f32 [%rd1], %f1;
+  ret;
+}}
+"""
+
+
+# -- 1. the fold's split point ------------------------------------------------------------------
+
+
+def test_runtime_bound_recovered_as_affine():
+    sig = loops.reduction_trip_signature(_entry(_tiled_fold(64)))
+    assert ("bound", ("64*%ctaid.x", )) in sig
+
+
+def test_tile_scale_of_a_runtime_bound_splits():
+    # POSITIVE: same instructions, same counts -- only the tile the bound scales by differs.
+    assert loops.reduction_trip_signature(_entry(_tiled_fold(64))) \
+        != loops.reduction_trip_signature(_entry(_tiled_fold(128)))
+    assert CHECK(_tiled_fold(64)) != CHECK(_tiled_fold(128))
+
+
+def test_same_bound_does_not_split_on_register_noise():
+    # NEGATIVE: one runtime bound, two register numberings. The tier is the bound's affine FORM, not
+    # its text, so allocation noise must not separate two bit-identical configs.
+    assert loops.reduction_trip_signature(_entry(_param_fold(0))) \
+        == loops.reduction_trip_signature(_entry(_param_fold(32)))
+    assert CHECK(_param_fold(0)) == CHECK(_param_fold(32))
+
+
+def test_no_runtime_bound_leaves_the_signature_untouched():
+    # NEGATIVE: a fold with no reduction loop at all keeps `None` -- a plain tiled GEMM must not
+    # acquire a `splits=` fence (that would undo its tiling recovery).
+    assert loops.reduction_trip_signature(_entry(_pure_fold(1))) is None
+    assert "splits=" not in str(CHECK(_pure_fold(1)))
+
+
+# -- 2. the matmul reduction extent -------------------------------------------------------------
+
+
+def test_token_counts_count_every_matmul():
+    assert mma_token_counts(_entry(_pure_fold(3))) == (("matmul|f16|cta1", 3), )
+
+
+def test_reduction_extent_splits_when_the_fold_is_not_proven_pure():
+    # POSITIVE: an entry that reduces over the MMA output and issues twice the matmuls is summing
+    # twice the products -- a different value -- so it must not share the fail-closed key.
+    a, b = CHECK(_param_fold()), CHECK(_param_fold().replace(_MMA, _MMA * 2, 1))
+    assert "mma+fp|" in str(a) and a != b
+
+
+def test_reduction_extent_stays_out_of_a_proven_pure_fold():
+    # NEGATIVE: re-tiling a proven-pure fold issues a different MMA count over the SAME dot products.
+    # The count must not leak into that key, or BLOCK_K and v2==v5 stop merging.
+    assert "mma+fp|" not in str(CHECK(_pure_fold(1)))
+    assert CHECK(_pure_fold(1)) == CHECK(_pure_fold(2))

--- a/bitequiv/tests/test_ptx_sharing.py
+++ b/bitequiv/tests/test_ptx_sharing.py
@@ -1,0 +1,147 @@
+"""Signature-stage sharing: one memo per value-DAG, not one per output root, plus the node budget.
+
+The interpreter builds ONE value-DAG whose output roots share most of their nodes; the stage after
+it used to re-materialize that DAG once per root with a fresh memo, so a subtree k roots share was
+rebuilt k times (O(n^2) nodes alive at once). These tests pin the two things that fix has to keep
+true: the collapsed / hashed trees are byte-identical to the per-root ones (including where the
+per-root collapse BOUNDARY legitimately differs between roots), and the node budget fails CLOSED to
+the conservative fingerprint instead of merging. CPU-only."""
+import bitequiv.ptx.forward.interp as interp_mod
+from bitequiv.ptx.builder import _forest_postorder, collapse_balanced, collapse_balanced_forest, tree_hash, tree_hashes
+from bitequiv.ptx.forward.interp import forward_module_descriptor
+from bitequiv.ptx.treeir import FpOp, ITreeReduce, Leaf, OpaqueOp
+from bitequiv.ptx_reduction import ptx_header
+
+_HDR = ptx_header()
+
+
+def _leaf(i):
+    return Leaf(f"c{i}", frozenset({i}))
+
+
+def _unique_nodes(trees):
+    """How many DISTINCT node objects the trees are made of (shared nodes counted once)."""
+    seen, stack = set(), list(trees)
+    while stack:
+        n = stack.pop()
+        if id(n) in seen:
+            continue
+        seen.add(id(n))
+        stack.extend(n.children)
+    return len(seen)
+
+
+def _opaque_chain(n):
+    """``n`` outputs over a chain each output extends: ``out[i] = f(out[i-1], leaf_i)``. The scan
+    shape — ``out[i]`` CONTAINS ``out[i-1]``, so the outputs share almost everything. An OpaqueOp is
+    never a reduce node, so nothing collapses and every node goes through the rebuild path."""
+    node, roots = _leaf(0), []
+    for i in range(1, n + 1):
+        node = OpaqueOp("cvt.rn.f32.f32", (node, _leaf(i)))
+        roots.append(node)
+    return roots
+
+
+def _add_chain(n):
+    """The same scan shape built from plain ``add`` combines, so the collapse pass has real
+    decisions to make: the first two links are AVL-balanced (hence collapsible) and the rest are
+    not, which is what makes a node's region membership depend on WHICH root you look from."""
+    node, roots = _leaf(0), []
+    for i in range(1, n + 1):
+        node = FpOp("add", (".f32", ), (node, _leaf(i)))
+        roots.append(node)
+    return roots
+
+
+# -- one memo per DAG, not one per root ---------------------------------------
+
+
+def test_forest_postorder_visits_each_shared_node_once():
+    roots = _opaque_chain(40)
+    order = _forest_postorder(roots)
+    assert len(order) == _unique_nodes(roots)  # every unique node exactly once
+    assert len({id(n) for n in order}) == len(order)  # and no node twice
+    assert [id(n) for n in order[:2]] == [id(_forest_postorder([roots[0]])[i]) for i in range(2)]
+
+
+def test_collapse_forest_rebuilds_a_shared_subtree_once():
+    n = 40
+    roots = _opaque_chain(n)
+    per_root = [collapse_balanced(r) for r in roots]
+    shared = collapse_balanced_forest(roots)
+    assert [t.sig() for t in shared] == [t.sig() for t in per_root]  # byte-identical output
+    # A fresh memo per root copies the shared chain once per root -> quadratic (n(n+1)/2 combines);
+    # one memo shared by all the roots rebuilds each node once -> linear (n combines).
+    assert _unique_nodes(shared) == _unique_nodes(roots) == 2 * n + 1
+    assert _unique_nodes(per_root) == n * (n + 1) // 2 + (n + 1)
+
+
+def test_tree_hashes_match_per_root_hashes():
+    roots = _opaque_chain(40)
+    assert tree_hashes(roots) == [tree_hash(r) for r in roots]
+
+
+# -- the parent-context risk: a shared node's collapse BOUNDARY is per-root ----
+
+
+def test_shared_collapse_keeps_the_per_root_region_boundary():
+    # `add(leaf, leaf)` and `add(that, leaf)` are both AVL-balanced, so both collapse; the third link
+    # is not. So `roots[0]` is a region ROOT on its own (it collapses to an ITreeReduce) but is
+    # SWALLOWED by the larger region under `roots[1]`. One shared memo must not let whichever answer
+    # came first win for everyone -- that would move the collapse boundary and change a descriptor.
+    roots = _add_chain(6)
+    per_root = [collapse_balanced(r) for r in roots]
+    assert isinstance(per_root[0], ITreeReduce)  # alone: its own region
+    assert isinstance(collapse_balanced(roots[2]), FpOp)  # third link: not collapsible
+    assert [t.sig() for t in collapse_balanced_forest(roots)] == [t.sig() for t in per_root]
+
+
+def test_multi_output_descriptor_is_unchanged_by_sharing(monkeypatch):
+    # End to end: the multi-output descriptor must be the same whether the outputs are collapsed and
+    # hashed together or one at a time.
+    ptx = _two_row_sums(4)
+    shared = forward_module_descriptor(ptx)
+    monkeypatch.setattr("bitequiv.ptx.forward.interp.collapse_balanced_forest",
+                        lambda roots: [collapse_balanced(r) for r in roots])
+    monkeypatch.setattr("bitequiv.ptx.forward.interp.tree_hashes", lambda roots: [tree_hash(r) for r in roots])
+    assert forward_module_descriptor(ptx) == shared
+
+
+# -- the node budget fails CLOSED ---------------------------------------------
+
+
+def _balanced_sum4(ntid):
+    """A 4-element balanced within-thread sum at a given ``.reqntid`` (= num_warps). The collapse
+    recovers num_warps, so two of these with different ntid share ONE descriptor."""
+    return (_HDR + f".visible .entry k(.param .u64 pa, .param .u64 po) .reqntid {ntid}, 1, 1\n{{\n"
+            ".reg .b64 %rd<6>;\n.reg .f32 %f<10>;\n"
+            "ld.param.u64 %rd1, [pa];\ncvta.to.global.u64 %rd2, %rd1;\n"
+            "ld.param.u64 %rd3, [po];\ncvta.to.global.u64 %rd4, %rd3;\n"
+            "ld.global.f32 %f1, [%rd2];\nld.global.f32 %f2, [%rd2+4];\n"
+            "ld.global.f32 %f3, [%rd2+8];\nld.global.f32 %f4, [%rd2+12];\n"
+            "add.f32 %f5, %f1, %f2;\nadd.f32 %f6, %f3, %f4;\nadd.f32 %f7, %f5, %f6;\n"
+            "st.global.f32 [%rd4], %f7;\nret;\n}\n")
+
+
+def _two_row_sums(ntid):
+    """Two independent balanced 4-element sums stored as two outputs (a multi-output entry)."""
+    return (_HDR + f".visible .entry k(.param .u64 pa, .param .u64 po) .reqntid {ntid}, 1, 1\n{{\n"
+            ".reg .b64 %rd<6>;\n.reg .f32 %f<20>;\n"
+            "ld.param.u64 %rd1, [pa];\ncvta.to.global.u64 %rd2, %rd1;\n"
+            "ld.param.u64 %rd3, [po];\ncvta.to.global.u64 %rd4, %rd3;\n"
+            "ld.global.f32 %f1, [%rd2];\nld.global.f32 %f2, [%rd2+4];\n"
+            "ld.global.f32 %f3, [%rd2+8];\nld.global.f32 %f4, [%rd2+12];\n"
+            "add.f32 %f5, %f1, %f2;\nadd.f32 %f6, %f3, %f4;\nadd.f32 %f7, %f5, %f6;\n"
+            "add.f32 %f8, %f1, %f3;\nadd.f32 %f9, %f2, %f4;\nadd.f32 %f10, %f8, %f9;\n"
+            "st.global.f32 [%rd4], %f7;\nst.global.f32 [%rd4+4], %f10;\nret;\n}\n")
+
+
+def test_budget_floor_falls_back_to_the_fingerprint(monkeypatch):
+    small, big = _balanced_sum4(32), _balanced_sum4(256)
+    assert forward_module_descriptor(small) == forward_module_descriptor(big)  # merged by the collapse
+    assert "fwd-incomplete" not in forward_module_descriptor(small)[0]
+    monkeypatch.setattr(interp_mod, "_MAX_DAG_NODES", 1)
+    (floored, ) = forward_module_descriptor(small)
+    assert floored.startswith("fwd-incomplete|ntid=x32")
+    # Fail CLOSED: the floor must SPLIT what the collapsed hash merged, never merge more.
+    assert forward_module_descriptor(small) != forward_module_descriptor(big)

--- a/bitequiv/tests/test_ptx_smem.py
+++ b/bitequiv/tests/test_ptx_smem.py
@@ -1,11 +1,11 @@
-"""Forward SmemModel (phase + same-structure guard) soundness + recovery, on hand-crafted PTX.
+"""Forward SmemModel (phase + address match) soundness + recovery, on hand-crafted PTX.
 
-The model records each ``st.shared`` element (scalar OR vector) into the current write phase, closes
-the phase at ``bar.sync``, and resolves a ``ld.shared`` / ``ldmatrix`` against the most-recently closed
-phase: it returns a representative write IFF every write in that phase has the SAME coord-free value
-structure, else it FAILS CLOSED. This replaces the old blanket "vector st.shared -> fail closed" floor
-(D112727538). Sound because the reader's element is interchangeable with any write of the same
-structure; a mixed-structure phase can't be resolved without the exact address -> fail closed.
+The model records each ``st.shared`` element (scalar OR vector) into the current write phase with the
+SLOT IMAGE of its address, closes the phase at ``bar.sync``, and resolves a ``ld.shared`` /
+``ldmatrix`` against the most-recently closed phase in two layers: (1) match the load's slot image
+against the stores' and take the value of the store(s) that actually wrote it — a PROVEN relocation;
+(2) if an address is not provably affine, the older address-blind rule (return a representative iff
+every write in the phase has the same coord-free structure), else FAIL CLOSED.
 
 CPU-only (parses hand-crafted PTX, no GPU)."""
 from bitequiv.ptx.forward.interp import forward_module_descriptor as CHECK
@@ -67,9 +67,10 @@ PTX_VECTOR = _HEAD + """
 }
 """
 
-# MIXED-structure phase: one write is a Leaf (f1), the other a combine add(f1,f2). Their coord-free sigs
-# differ, so a following ld.shared cannot be resolved without the exact address -> FAIL CLOSED (the real
-# soundness guard now that vector stores are modeled).
+# MIXED-structure phase: one write is a Leaf (f1), the other a combine add(f1,f2). Their coord-free
+# sigs differ, so an address-BLIND model cannot tell which the load reads. Both slots are provably
+# affine here, so the address match picks the store that actually wrote the loaded slot (`bufA+0` =
+# the Leaf) and the reconstruction stays faithful.
 PTX_MIXED = _HEAD + """
 .visible .entry k(.param .u64 pin, .param .u64 pout) {
   .reg .f32 %f<8>;
@@ -94,6 +95,66 @@ PTX_MIXED = _HEAD + """
   ld.shared.f32 %f4, [%r2];
   cvta.to.global.u64 %rd7, %rd2;
   st.global.f32 [%rd7], %f4;
+  ret;
+}
+"""
+
+# The same MIXED phase, but the load address is derived from a value LOADED FROM MEMORY, so it is not
+# provably affine: the address match cannot run and the address-blind fallback sees two structures ->
+# FAIL CLOSED (the layered floor).
+PTX_MIXED_OPAQUE_ADDR = _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {
+  .reg .f32 %f<8>;
+  .reg .b32 %r<8>;
+  .reg .b64 %rd<8>;
+  .shared .align 4 .b8 bufA[128];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  add.s64 %rd6, %rd5, 4;
+  ld.global.f32 %f2, [%rd6];
+  add.f32 %f3, %f1, %f2;
+  mov.u32 %r2, bufA;
+  st.shared.f32 [%r2], %f1;
+  add.s32 %r3, %r2, 4;
+  st.shared.f32 [%r3], %f3;
+  bar.sync 0;
+  ld.global.u32 %r6, [%rd5];
+  add.s32 %r7, %r2, %r6;
+  ld.shared.f32 %f4, [%r7];
+  cvta.to.global.u64 %rd7, %rd2;
+  st.global.f32 [%rd7], %f4;
+  ret;
+}
+"""
+
+# A load of a slot NO store in the phase wrote (the store lands at bufA+0, the load reads bufA+64).
+# Address-blind the model happily returns the one write it has; with the address it is provably a
+# DIFFERENT slot, so the value read was never captured -> fail closed.
+PTX_UNWRITTEN_SLOT = _HEAD + """
+.visible .entry k(.param .u64 pin, .param .u64 pout) {
+  .reg .f32 %f<4>;
+  .reg .b32 %r<4>;
+  .reg .b64 %rd<8>;
+  .shared .align 4 .b8 bufA[128];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  mov.u32 %r2, bufA;
+  st.shared.f32 [%r2], %f1;
+  bar.sync 0;
+  add.s32 %r3, %r2, 64;
+  ld.shared.f32 %f2, [%r3];
+  cvta.to.global.u64 %rd6, %rd2;
+  st.global.f32 [%rd6], %f2;
   ret;
 }
 """
@@ -132,10 +193,25 @@ def test_scalar_and_uniform_vector_agree():
     assert CHECK(PTX_SCALAR) == CHECK(PTX_VECTOR)
 
 
-def test_mixed_structure_phase_fails_closed():
-    # A phase holding writes of DIFFERENT structure (Leaf vs add) cannot be resolved address-blind:
-    # the load could read either -> fail closed (conservative fingerprint), the soundness guard.
-    d = CHECK(PTX_MIXED)
+def test_mixed_structure_phase_resolved_by_address():
+    # A phase holding writes of DIFFERENT structure (Leaf vs add) is ambiguous address-blind, but both
+    # slots are provably affine, so the load is matched to the store that wrote ITS slot (bufA+0, the
+    # Leaf) and the reconstruction stays faithful — and equals the single-store scalar kernel, which
+    # computes exactly the same thing.
+    assert _faithful(CHECK(PTX_MIXED))
+    assert CHECK(PTX_MIXED) == CHECK(PTX_SCALAR)
+
+
+def test_mixed_structure_unprovable_address_fails_closed():
+    # Same mixed phase, but the load address comes from a value read out of memory -> not provably
+    # affine -> the address match cannot run and the address-blind fallback fails closed.
+    d = CHECK(PTX_MIXED_OPAQUE_ADDR)
+    assert d and "fwd-incomplete" in str(d[0])
+
+
+def test_load_of_unwritten_slot_fails_closed():
+    # The loaded slot is provably NOT one this phase wrote, so the value is unmodeled -> fail closed.
+    d = CHECK(PTX_UNWRITTEN_SLOT)
     assert d and "fwd-incomplete" in str(d[0])
 
 
@@ -224,3 +300,113 @@ def test_within_thread_minmax_keeps_column_key():
     # reduction, so it keeps its column key: two different column layouts stay DISTINCT (conservative,
     # so the extent-drop can never merge two genuinely different partial maxes).
     assert CHECK(_minmax_kern(1024, "within")) != CHECK(_minmax_kern(4096, "within"))
+
+
+# --------------------------------------------------------------------------- #
+# Cross-warp num_warps recovery. A matched shared exchange is a RELOCATION: it moves one partial
+# from one thread to another and combines nothing, so it adds no reduction height. Two configs that
+# reduce the same element count in the same balanced count-up order therefore agree even though one
+# splits the work over two warps (and needs the exchange) and the other over one (and does not).
+# --------------------------------------------------------------------------- #
+def _bfly(offs, first):
+    """A butterfly chain of ``add.f32(p, shfl.bfly(p, off))`` over ``offs``, leaf -> root."""
+    out, cur = [], first
+    for i, o in enumerate(offs):
+        out.append(f"  shfl.sync.bfly.b32 %f{10 + i}, {cur}, {o}, 31, -1;")
+        out.append(f"  add.f32 %f{30 + i}, {cur}, %f{10 + i};")
+        cur = f"%f{30 + i}"
+    return "\n".join(out), cur
+
+
+def _one_warp(offs):
+    """32 threads x 2 elements: a within-thread add then a 32-lane butterfly. 64 elements, no
+    shared memory at all."""
+    body, cur = _bfly(offs, "%f3")
+    return _HEAD + f"""
+.visible .entry k(.param .u64 pin, .param .u64 pout) .reqntid 32, 1, 1
+{{
+  .reg .pred %p<4>;
+  .reg .f32 %f<64>;
+  .reg .b32 %r<16>;
+  .reg .b64 %rd<16>;
+  .shared .align 4 .b8 buf[512];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+  add.s64 %rd6, %rd5, 128;
+  ld.global.f32 %f2, [%rd6];
+  add.f32 %f3, %f1, %f2;
+{body}
+  cvta.to.global.u64 %rd7, %rd2;
+  st.global.f32 [%rd7], {cur};
+  ret;
+}}
+"""
+
+
+def _two_warps(offs):
+    """64 threads x 1 element: a 32-lane butterfly, then a cross-warp exchange through shared memory
+    (warp leader writes slot = warp id, lane `l < 2` reads slot = l) and one more butterfly step.
+    The SAME 64 elements in the same balanced count-up order as :func:`_one_warp`."""
+    body, cur = _bfly(offs, "%f1")
+    return _HEAD + f"""
+.visible .entry k(.param .u64 pin, .param .u64 pout) .reqntid 64, 1, 1
+{{
+  .reg .pred %p<4>;
+  .reg .f32 %f<64>;
+  .reg .b32 %r<16>;
+  .reg .b64 %rd<16>;
+  .shared .align 4 .b8 buf[512];
+  ld.param.u64 %rd1, [pin];
+  ld.param.u64 %rd2, [pout];
+  cvta.to.global.u64 %rd3, %rd1;
+  mov.u32 %r1, %tid.x;
+  mul.wide.u32 %rd4, %r1, 4;
+  add.s64 %rd5, %rd3, %rd4;
+  ld.global.f32 %f1, [%rd5];
+{body}
+  mov.u32 %r2, buf;
+  shr.u32 %r3, %r1, 5;
+  shl.b32 %r4, %r3, 2;
+  add.s32 %r5, %r2, %r4;
+  and.b32 %r6, %r1, 31;
+  setp.eq.b32 %p1, %r6, 0;
+  @%p1 st.shared.f32 [%r5], {cur};
+  bar.sync 0;
+  shl.b32 %r7, %r1, 2;
+  add.s32 %r8, %r2, %r7;
+  setp.lt.u32 %p2, %r1, 2;
+  @%p2 ld.shared.f32 %f50, [%r8];
+  shfl.sync.bfly.b32 %f51, %f50, 1, 31, -1;
+  add.f32 %f52, %f50, %f51;
+  cvta.to.global.u64 %rd9, %rd2;
+  st.global.f32 [%rd9], %f52;
+  ret;
+}}
+"""
+
+
+_UP = [1, 2, 4, 8, 16]     # count-up (inner_tree): the canonical balanced order
+_DOWN = [16, 8, 4, 2, 1]   # count-down (unordered): pairs lanes differently -> different bits
+
+
+def test_cross_warp_exchange_recovers_num_warps():
+    # The slot <-> warp map is provable (store slot = warp id, load slot = lane), so the exchange is a
+    # matched relocation and carries no height: one warp with a two-element within-thread fold and two
+    # warps with a shared exchange collapse to the SAME `ITREE[add.f32;L[];h6;s('1',)]`.
+    assert _faithful(CHECK(_one_warp(_UP)))
+    assert _faithful(CHECK(_two_warps(_UP)))
+    assert CHECK(_one_warp(_UP)) == CHECK(_two_warps(_UP))
+
+
+def test_cross_warp_exchange_splits_on_reduction_order():
+    # Same element count and the same exchange, but a count-DOWN butterfly pairs the lanes
+    # differently, so the bits differ and the descriptors must stay apart -- in both directions of
+    # the comparison, and against the one-warp count-down form too.
+    assert CHECK(_two_warps(_UP)) != CHECK(_two_warps(_DOWN))
+    assert CHECK(_one_warp(_UP)) != CHECK(_one_warp(_DOWN))
+    assert CHECK(_two_warps(_DOWN)) != CHECK(_one_warp(_DOWN))


### PR DESCRIPTION
Summary:
A block-level reduction has two stages: a `shfl.bfly` butterfly inside a warp, then a shared-memory exchange ACROSS warps (each warp leader writes a slot, `bar.sync`, one warp reads the slots back and reduces them). The forward PTX checker threw the exchange's ADDRESS away: `ForwardInterp._record_shared_store` recorded only the stored VALUE, and `_resolve_smem` answered any shared load with "some write from the most-recently closed phase, provided they all look alike". So the model knew neither which warp wrote which slot nor which slot a lane reads, and the cross-warp stage entered the reduction tree as a bare `SmemExchange` marker. What then distinguished `num_warps` was surrounding SYNTAX rather than the math, and `inner_tree` — whose reduction order is deliberately `num_warps`-invariant, i.e. the bits really are equal — came out in a different class per `num_warps`.

This models the exchange from its address, and fixes the four spellings that were keeping equal reductions apart.

Review in this order.

**Phase A — how much of the address is recoverable.** Evaluating every `st.shared` / `ld.shared` / `ldmatrix` address in the corpus with the existing `AffineEval` says the addressing is almost fully recoverable for reductions and almost fully lost for flash attention: over the 35 reduction groups 70,529 of 72,085 accesses (**97.8%**) resolve to a provable `Affine`, and 24 of 35 groups are at 100%; the worst reduction group is 94%. Flash attention is the opposite: `st.shared` 72.4% and `ld.shared` 73.0% provable, but `ldmatrix` only **0.96%** (3,405 of 354,380) because the matrix loads are xor-swizzled, which drags the FA total to 17.6%. The one thing standing between the reductions and 100% was that a bare symbol operand (`mov.b32 %r, global_smem`, the shared-array base) evaluated to `Opaque` and poisoned every address built on it; `affine.py` now reads it as the link-time constant it is.

**The model.** `thread_image` rewrites an address into the `%tid.<dim>.bit<i>` basis and enumerates the byte offsets it touches over the thread grid. That basis IS the (warp, lane) decomposition — `%tid.x` bits [0,5) are the lane, bits [5,..) the warp — so a warp leader's store slot reads off the warp bits, the reading warp's load slot off the lane bits, and enumerating the basis composes them into the real slot map. Each `st.shared` element is recorded with its slot image; a shared load takes the value of the stores whose slot image it actually intersects. That is strictly sharper than the old whole-phase rule in both directions: a phase holding two different structures now resolves when the address says which one the load reads, and a load whose slot NO store in the phase wrote (a stale or unrelated shared buffer) now fails closed instead of being answered with an unrelated subtree.

**Fail-closed layering.** An address that is not provably affine — every swizzled `ldmatrix`, and any store in the phase whose address is unresolved, since an unresolved store could have written the very slot we read — keeps the old address-blind behaviour exactly. Relatedly, `bfe.s32` is no longer modeled at all: the signed form SIGN-EXTENDS the extracted field, so a 1-bit extract is 0 or -1, which is precisely how Triton builds an xor-swizzle mask out of a tid bit; treating it as the plain 0/1 slice made a swizzled address come out provably (and wrongly) affine.

**Deriving the descriptor from the model.** With the exchange modeled, three things in `builder.py` follow. (1) An exchange RELOCATES one value between threads — an `ld.shared` reads a single slot, fan-in exactly one — so it contributes no reduction HEIGHT. Counting it inflated the height by the number of exchanges, a pure `num_warps` artifact: `num_warps=1` needs no exchange, so the same total reduction came out two levels shorter and never matched the multi-warp configs. The raw node depth is kept as a separate `level` for the butterfly-direction readers, so the within-warp run stays separated from the cross-warp run by the exchange between them. (2) The collapse region is now walked through reduce nodes only, instead of scanning the whole post-order and reaching back inside the boundary leaves; a reduction fed by a different-op sub-reduction (softmax's `sum(exp(x - max(x)))`, col_max's within-thread `max.f16` fold under a cross-warp `max.f32`) looked like a two-op region and never collapsed. Boundary-leaf signatures come from the already-collapsed leaf, so a nested reduction contributes its layout-invariant `ITreeReduce` token rather than its physical fold. (3) Two spellings are canonicalized: a literal CONSTANT is allowed inside a boundary leaf, `mov.b32 %r, <imm>` reconstructs as that immediate (whether ptxas materializes a literal in a register or feeds it inline is a register-allocation choice that moves with `num_warps`), and `sub` joins `add`/`mul`/`fma` in dropping an explicit `.rn` (`.rn` is the PTX default rounding, so `sub.f32` and `sub.rn.f32` are bit-identical and only `enable_fp_fusion` flips which one is emitted).

**Support table.** Graded on the full cached corpus, no sampling: 93 (kernel, dtype) groups, 51,152 configs, checker classes before -> after against the empirical (fuzzer) class count, which is the ideal.

| group | configs | before | after | empirical | over_merges |
|---|--:|--:|--:|--:|--:|
| softmax/f32 | 144 | 16 | 4 | 3 | 0 |
| softmax/f16 | 144 | 16 | 8 | 4 | 0 |
| softmax/bf16 | 144 | 16 | 8 | 4 | 0 |
| col_max/f16 | 144 | 6 | 3 | 1 | 0 |
| col_max/bf16 | 144 | 6 | 3 | 1 | 0 |
| sum/f32 | 144 | 8 | 7 | 7 | 0 |
| sum_2d_axis0/f32 | 144 | 8 | 7 | 7 | 0 |
| sum_2d_col/f32 | 144 | 8 | 7 | 7 | 0 |
| sum_2d_col_big/f32 | 144 | 9 | 8 | 7 | 0 |
| sum_2d_deep/f32 | 144 | 8 | 7 | 4 | 0 |
| sum_2d_deep/bf16 | 144 | 9 | 8 | 4 | 0 |
| sum_3d_mid/f32 | 144 | 8 | 7 | 4 | 0 |
| col_exp_sum/f32 | 144 | 8 | 7 | 7 | 0 |
| col_sum_loop/f32 | 144 | 10 | 9 | 7 | 0 |
| dot/f32 | 144 | 20 | 19 | 14 | 0 |
| layernorm/f16 | 144 | 20 | 19 | 9 | 0 |
| layernorm/f32 | 144 | 8 | 7 | 6 | 0 |
| rmsnorm/f16 | 144 | 18 | 17 | 8 | 0 |
| rmsnorm/f32 | 144 | 11 | 10 | 7 | 0 |
| gemm/f32 | 10293 | 1732 | 1729 | 6 | 0 |
| **reduction total (72 baseline groups)** | **8652** | **855** | **807** | **460** | **0** |
| **reduction total (all 79 groups)** | **9384** | **1057** | **1009** | **614** | **0** |
| **MMA total (14 groups)** | **41768** | **11450** | **11447** | **790** | **0** |
| **everything** | **51152** | **12507** | **12456** | **1404** | **0** |

No-regression rows — every group not listed above is byte-for-byte unchanged, and no group's class count went UP anywhere in the corpus. The MMA side in particular:

| group | configs | before | after | empirical | over_merges |
|---|--:|--:|--:|--:|--:|
| gemm/f16 | 6304 | 1 | 1 | 1 | 0 |
| gemm/bf16 | 6422 | 1 | 1 | 1 | 0 |
| gemm/fp8 | 7263 | 2 | 2 | 2 | 0 |
| gemm_tma_store/f16 | 18 | 1 | 1 | 1 | 0 |
| gemm_bias_relu_fp_fusion/bf16 | 192 | 1 | 1 | 1 | 0 |
| gemm_kgroup/bf16 | 1152 | 138 | 138 | 6 | 0 |
| gemm_reduce_sum/f32 | 270 | 60 | 60 | 9 | 0 |
| gemm_softmax/f32 | 270 | 60 | 60 | 9 | 0 |
| flash_attention/f16 | 2720 | 2655 | 2655 | 266 | 0 |
| flash_attention/bf16 | 2721 | 2656 | 2656 | 260 | 0 |
| flash_attention/fp8 | 2070 | 2070 | 2070 | 112 | 0 |
| flash_attention/fp8e5m2 | 2069 | 2069 | 2069 | 112 | 0 |
| LC_splitk_gemm_f16/f16 | 4 | 4 | 4 | 4 | 0 |
| welford/f32 | 636 | 106 | 106 | 75 | 0 |
| LC_cumsum_scan_f32/f32 | 24 | 24 | 24 | 7 | 0 |
| LC_logsumexp_loop_f32/f32 | 24 | 24 | 24 | 24 | 0 |
| LC_prod_loop_f32/f32 | 24 | 24 | 24 | 24 | 0 |
| LC_var_welford_f32/f32 | 24 | 24 | 24 | 24 | 0 |

Rows whose class count now EQUALS the empirical count (nothing left to recover) go from 15 to 19: `sum/f32`, `sum_2d_axis0/f32`, `sum_2d_col/f32` and `col_exp_sum/f32` join `col_max/f32` and the loop-carried group.

**Robustness.** The population measured is every cached corpus config — 93 (kernel, dtype) groups, 51,152 PTX modules, every reduction group, every GEMM group and all four flash-attention dtypes — with the "before" side reconstructed from the parent commit's checker and confirmed to reproduce the recorded baseline row for row. Over-merges are 0 in every group and no group's class count increased, so the recovery costs no soundness and no existing recovery. What is still NOT modeled: packed `.f16x2` / `.bf16x2` arithmetic, which is what leaves the f16 and bf16 rows of `sum`, `dot`, `col_*` and `sum_*` where they were (the two f16 halves share one 32-bit register and one `.b32` global load, so decomposing them needs the leaf to split too); the control-flow floor, which fingerprints all of `cond_reduce`; and the fma accumulation-chain guard, which refuses `A_rms_norm_fwd`-style leaves. The residual unprovable-address fraction is 2.2% of reduction accesses (xor-swizzled shared layouts, concentrated in `col_dot`, `col_bf16`, `cond_reduce` and one `num_warps=2` shape of the `sum_*` family) and 82.4% of flash-attention accesses, essentially all of it `ldmatrix`; every one of those keeps the previous address-blind behaviour, so they neither gain nor lose. Closing the 855 -> 460 gap the rest of the way is mostly the `.f16x2` work, not more address analysis.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D114470722


