### PR TITLE
[Test-Fix] [AutoWS] Disable Hopper upstream tests

### DIFF
--- a/python/test/unit/language/test_warp_specialization.py
+++ b/python/test/unit/language/test_warp_specialization.py
@@ -9,6 +9,7 @@ from triton.tools.tensor_descriptor import TensorDescriptor
 
 if not is_hip() and torch.cuda.is_available() and torch.cuda.get_device_capability()[0] in [9, 10, 11]:
     from triton._C.libtriton import nvidia
+
     cublas_workspace = torch.empty(32 * 1024 * 1024, device="cuda", dtype=torch.uint8)
     cublas = nvidia.cublas.CublasLt(cublas_workspace)
 else:
@@ -72,7 +73,7 @@ def test_warp_specialize_basic_ir(tmp_path: pathlib.Path):
     temp_file.write_text(ir)
     kernel = triton.compile(str(temp_file))
 
-    input = torch.empty(2, dtype=torch.int32, device='cuda')
+    input = torch.empty(2, dtype=torch.int32, device="cuda")
     kernel[(1, 1, 1)](input)
     assert input[0] == 42
     assert input[1] == 5555
@@ -140,7 +141,7 @@ def test_warp_specialize_tmem_ir(tmp_path: pathlib.Path):
     temp_file = tmp_path / "test_warp_specialize_tmem_ir.ttgir"
     temp_file.write_text(ir)
     kernel = triton.compile(str(temp_file))
-    input = torch.arange(128 * 64, dtype=torch.float32, device='cuda').reshape(128, 64)
+    input = torch.arange(128 * 64, dtype=torch.float32, device="cuda").reshape(128, 64)
     output = torch.empty_like(input)
     kernel[(1, 1, 1)](input, output)
     torch.testing.assert_close(input, output, atol=0, rtol=0)
@@ -152,7 +153,7 @@ def test_warpgroup_reduction(tmp_path: pathlib.Path):
 
     def template(i, num_warps, in_ptr, out_ptr):
         return f"""
-          %range = tt.make_range {{end = {(i+1)*256} : i32, start = {i*256} : i32}} : tensor<256xi32, #blocked{num_warps}>
+          %range = tt.make_range {{end = {(i + 1) * 256} : i32, start = {i * 256} : i32}} : tensor<256xi32, #blocked{num_warps}>
           %splatted = tt.splat {in_ptr} : !tt.ptr<i32> -> tensor<256x!tt.ptr<i32>, #blocked{num_warps}>
           %ptrs = tt.addptr %splatted, %range : tensor<256x!tt.ptr<i32>, #blocked{num_warps}>, tensor<256xi32, #blocked{num_warps}>
           %input = tt.load %ptrs : tensor<256x!tt.ptr<i32>, #blocked{num_warps}>
@@ -166,7 +167,7 @@ def test_warpgroup_reduction(tmp_path: pathlib.Path):
           tt.store %output, %result : !tt.ptr<i32>
         """
 
-    ir = """
+    ir = ("""
     #blocked4 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
     #blocked2 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [2], order = [0]}>
     #blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
@@ -195,14 +196,14 @@ def test_warpgroup_reduction(tmp_path: pathlib.Path):
     }
 
     }
-    """
+    """)
 
     temp_file = tmp_path / "test_warpgroup_reduction.ttgir"
     temp_file.write_text(ir)
     kernel = triton.compile(str(temp_file))
 
-    input = torch.arange(1024, dtype=torch.int32, device='cuda')
-    output = torch.empty(4, dtype=torch.int32, device='cuda')
+    input = torch.arange(1024, dtype=torch.int32, device="cuda")
+    output = torch.empty(4, dtype=torch.int32, device="cuda")
     kernel[(1, 1, 1)](input, output)
     assert output[0] == torch.arange(0, 256).sum()
     assert output[1] == torch.arange(256, 512).sum()
@@ -318,9 +319,26 @@ def test_warp_specialize_tma_matmul(M, N, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_S
     triton.set_allocator(alloc_fn)
 
     grid = (triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N), )
-    kernel = matmul_tma_ws_kernel[grid](A, B, C, *A.stride(), *B.stride(), *C.stride(), M, N, K, num_stages,
-                                        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M, num_warps=num_warps,
-                                        USE_FP8=use_fp8, A_USE_TMA=a_use_tma, B_USE_TMA=b_use_tma)
+    kernel = matmul_tma_ws_kernel[grid](
+        A,
+        B,
+        C,
+        *A.stride(),
+        *B.stride(),
+        *C.stride(),
+        M,
+        N,
+        K,
+        num_stages,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        GROUP_SIZE_M,
+        num_warps=num_warps,
+        USE_FP8=use_fp8,
+        A_USE_TMA=a_use_tma,
+        B_USE_TMA=b_use_tma,
+    )
 
     ref_out = torch.empty((M, N), dtype=dtype, device=device)
     cublas.matmul(A, B, ref_out)
@@ -351,8 +369,19 @@ def test_warp_specialize_tma_matmul_consan(M, N, K, num_stages, a_use_tma, b_use
         # FIXME: Hopper warp specialization generates incorrect debug info.
         triton.knobs.compilation.disable_line_info = True
     triton.knobs.compilation.instrumentation_mode = "consan"
-    test_warp_specialize_tma_matmul(M, N, K, BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, num_stages=num_stages,
-                                    num_warps=4, use_fp8=False, a_use_tma=a_use_tma, b_use_tma=b_use_tma)
+    test_warp_specialize_tma_matmul(
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=128,
+        BLOCK_SIZE_N=128,
+        BLOCK_SIZE_K=64,
+        num_stages=num_stages,
+        num_warps=4,
+        use_fp8=False,
+        a_use_tma=a_use_tma,
+        b_use_tma=b_use_tma,
+    )
 
 
 @triton.jit
@@ -443,10 +472,28 @@ def test_warp_specialize_tma_matmul_persistent(M, N, K, BLOCK_SIZE_M, BLOCK_SIZE
             triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
         ), )
 
-    kernel = matmul_tma_persistent_ws_kernel[grid](A, B, C, *A.stride(), *B.stride(), *C.stride(), M, N, K, num_stages,
-                                                   BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M, NUM_SMS,
-                                                   num_warps=num_warps, USE_FP8=use_fp8, FLATTEN=flatten
-                                                   and is_blackwell(), A_USE_TMA=a_use_tma, B_USE_TMA=b_use_tma)
+    kernel = matmul_tma_persistent_ws_kernel[grid](
+        A,
+        B,
+        C,
+        *A.stride(),
+        *B.stride(),
+        *C.stride(),
+        M,
+        N,
+        K,
+        num_stages,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        GROUP_SIZE_M,
+        NUM_SMS,
+        num_warps=num_warps,
+        USE_FP8=use_fp8,
+        FLATTEN=flatten and is_blackwell(),
+        A_USE_TMA=a_use_tma,
+        B_USE_TMA=b_use_tma,
+    )
     ttgir = kernel.asm["ttgir"]
     if is_blackwell():
         assert "ttng.tc_gen5_mma" in ttgir
@@ -476,9 +523,20 @@ def test_warp_specialize_tma_matmul_persistent_consan(M, N, K, a_use_tma, b_use_
         # FIXME: Hopper warp specialization generates incorrect debug info.
         triton.knobs.compilation.disable_line_info = True
     triton.knobs.compilation.instrumentation_mode = "consan"
-    test_warp_specialize_tma_matmul_persistent(M, N, K, BLOCK_SIZE_M=128, BLOCK_SIZE_N=128, BLOCK_SIZE_K=64,
-                                               num_stages=3, num_warps=4, use_fp8=False, flatten=flatten,
-                                               a_use_tma=a_use_tma, b_use_tma=b_use_tma)
+    test_warp_specialize_tma_matmul_persistent(
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=128,
+        BLOCK_SIZE_N=128,
+        BLOCK_SIZE_K=64,
+        num_stages=3,
+        num_warps=4,
+        use_fp8=False,
+        flatten=flatten,
+        a_use_tma=a_use_tma,
+        b_use_tma=b_use_tma,
+    )
 
 
 @triton.jit
@@ -488,7 +546,7 @@ def attention_inner_loop_kernel(  #
         M, N, qk_scale,  #
         BLOCK_M: tl.constexpr,  #
         HEAD_DIM: tl.constexpr,  #
-        warp_specialize: tl.constexpr  #
+        warp_specialize: tl.constexpr,  #
 ):
     m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
     l_i = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
@@ -559,10 +617,38 @@ def test_warp_specialize_attention_forward(M, N, BLOCK_M, HEAD_DIM, num_stages, 
                                     block_shape=[BLOCK_M, HEAD_DIM])
     desc_acc = TensorDescriptor(acc, shape=[M, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
 
-    attention_inner_loop_kernel[(M // BLOCK_M, )](desc_q, desc_k, desc_v, desc_acc_ref, l_i_ref, m_i_ref, M, N, 0.5,
-                                                  BLOCK_M, HEAD_DIM, False, num_stages=num_stages, num_warps=num_warps)
-    attention_inner_loop_kernel[(M // BLOCK_M, )](desc_q, desc_k, desc_v, desc_acc, l_i, m_i, M, N, 0.5, BLOCK_M,
-                                                  HEAD_DIM, True, num_stages=num_stages, num_warps=num_warps)
+    attention_inner_loop_kernel[(M // BLOCK_M, )](
+        desc_q,
+        desc_k,
+        desc_v,
+        desc_acc_ref,
+        l_i_ref,
+        m_i_ref,
+        M,
+        N,
+        0.5,
+        BLOCK_M,
+        HEAD_DIM,
+        False,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    attention_inner_loop_kernel[(M // BLOCK_M, )](
+        desc_q,
+        desc_k,
+        desc_v,
+        desc_acc,
+        l_i,
+        m_i,
+        M,
+        N,
+        0.5,
+        BLOCK_M,
+        HEAD_DIM,
+        True,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
 
     torch.testing.assert_close(acc.to(torch.float32), acc_ref.to(torch.float32), atol=0, rtol=0)
     torch.testing.assert_close(l_i.to(torch.float32), l_i_ref.to(torch.float32), atol=0, rtol=0)
@@ -571,13 +657,20 @@ def test_warp_specialize_attention_forward(M, N, BLOCK_M, HEAD_DIM, num_stages, 
 
 @triton.jit
 def attention_persistent_inner_loop_kernel(  #
-        desc_q, desc_k, desc_v,  #
-        desc_acc, l_i_ptr, m_i_ptr,  #
-        M, N, qk_scale,  #
-        BLOCK_M: tl.constexpr,  #
-        HEAD_DIM: tl.constexpr,  #
-        warp_specialize: tl.constexpr,  #
-        num_stages: tl.constexpr):
+    desc_q,
+    desc_k,
+    desc_v,  #
+    desc_acc,
+    l_i_ptr,
+    m_i_ptr,  #
+    M,
+    N,
+    qk_scale,  #
+    BLOCK_M: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,  #
+    warp_specialize: tl.constexpr,  #
+    num_stages: tl.constexpr,
+):
     prog_id = tl.program_id(0)
     num_sm = tl.num_programs(0)
     num_tiles = tl.cdiv(M, BLOCK_M)
@@ -660,10 +753,38 @@ def test_warp_specialize_attention_persistent_forward(M, N, BLOCK_M, HEAD_DIM, n
     desc_acc = TensorDescriptor(acc, shape=[M, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=[BLOCK_M, HEAD_DIM])
 
     NUM_SM = 4
-    attention_persistent_inner_loop_kernel[(NUM_SM, )](desc_q, desc_k, desc_v, desc_acc, l_i, m_i, M, N, 0.5, BLOCK_M,
-                                                       HEAD_DIM, True, num_stages=num_stages, num_warps=num_warps)
-    attention_inner_loop_kernel[(M // BLOCK_M, )](desc_q, desc_k, desc_v, desc_acc_ref, l_i_ref, m_i_ref, M, N, 0.5,
-                                                  BLOCK_M, HEAD_DIM, False, num_stages=num_stages, num_warps=num_warps)
+    attention_persistent_inner_loop_kernel[(NUM_SM, )](
+        desc_q,
+        desc_k,
+        desc_v,
+        desc_acc,
+        l_i,
+        m_i,
+        M,
+        N,
+        0.5,
+        BLOCK_M,
+        HEAD_DIM,
+        True,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+    attention_inner_loop_kernel[(M // BLOCK_M, )](
+        desc_q,
+        desc_k,
+        desc_v,
+        desc_acc_ref,
+        l_i_ref,
+        m_i_ref,
+        M,
+        N,
+        0.5,
+        BLOCK_M,
+        HEAD_DIM,
+        False,
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
 
     torch.testing.assert_close(acc.to(torch.float32), acc_ref.to(torch.float32), atol=0, rtol=0)
     torch.testing.assert_close(l_i.to(torch.float32), l_i_ref.to(torch.float32), atol=0, rtol=0)
@@ -771,9 +892,22 @@ def group_gemm_tma_fn(group_A, group_B):
 
     triton.set_allocator(alloc_fn)
 
-    grid = lambda META: (META['NUM_SM'], )
-    out = grouped_matmul_tma_kernel[grid](d_a_ptrs, d_b_ptrs, d_c_ptrs, M, N, K, d_g_lds, group_size, BLOCK_SIZE_M=128,
-                                          BLOCK_SIZE_N=128, BLOCK_SIZE_K=64, NUM_SM=4, num_stages=3)
+    grid = lambda META: (META["NUM_SM"], )
+    out = grouped_matmul_tma_kernel[grid](
+        d_a_ptrs,
+        d_b_ptrs,
+        d_c_ptrs,
+        M,
+        N,
+        K,
+        d_g_lds,
+        group_size,
+        BLOCK_SIZE_M=128,
+        BLOCK_SIZE_N=128,
+        BLOCK_SIZE_K=64,
+        NUM_SM=4,
+        num_stages=3,
+    )
     assert "ttg.warp_specialize" in out.asm["ttgir"]
     return group_C
 

--- a/python/test/unit/language/test_warp_specialization.py
+++ b/python/test/unit/language/test_warp_specialization.py
@@ -19,6 +19,30 @@ def is_hopper_or_blackwell():
     return is_hopper() or is_blackwell()
 
 
+# Upstream's Hopper automatic warp specialization is not reachable in this fork,
+# so every test here that expects `ttg.warp_specialize` fails on sm_90.
+#
+# Upstream drives sm_90 autoWS through `nvidia.passes.hopper.add_hopper_warpspec`
+# (upstream PR #7136), which consumes the `ttg.partition` attributes written by a
+# preceding partition-scheduling pass. Our refactor split that annotation step out
+# into `add_partition_scheduling_meta` and gated it behind `TRITON_USE_META_WS`
+# (see third_party/nvidia/backend/compiler.py). On the default OSS path nothing
+# annotates the loop, so the WS pass runs over unannotated IR and no-ops -- no
+# `ttg.warp_specialize` is ever emitted on Hopper.
+#
+# Neither obvious repair is a drop-in:
+#   - Enabling TRITON_USE_META_WS makes Hopper specialize, but Meta WS also
+#     specializes at num_warps=8 / num_stages<=1, where this file asserts the
+#     opposite (see the is_hopper() carve-outs below).
+#   - Feeding the Meta WS engine from upstream's partition scheduler collapses
+#     every op into one partition, because `getNodeFlags` only classifies MMAv5
+#     ops as MMA and so does not recognize `ttng.warp_group_dot`.
+#
+# Skip the whole file on Hopper until Hopper autoWS is realigned with upstream.
+pytestmark = pytest.mark.skipif(
+    is_hopper(), reason="upstream Hopper warp specialization was lost in this fork's WS refactor; see comment above")
+
+
 @pytest.mark.skipif(is_hip(), reason="warp specialization is not supported on hip devices")
 @pytest.mark.skipif(not is_hopper_or_blackwell(), reason="Requires Hopper or Blackwell")
 def test_warp_specialize_basic_ir(tmp_path: pathlib.Path):


### PR DESCRIPTION
Hopper upstream depends on the Meta passes we upstreamed. As a result its not 100% compatible with our fork. For now I disable it, but in the future we may want to revise for MetaWS.

A followup to explore would be to port a duplicate of this file for MetaWS (I will have an agent do this over the weekend).