### PR TITLE
[Test-Fix] [triton][beta] Fix interpreter `tl.dot` and empty-grid fast launch

### DIFF
--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -702,7 +702,10 @@ class InterpreterBuilder:
     def create_trans(self, arg, perm):
         return TensorHandle(np.transpose(arg.data, perm), arg.dtype.scalar)
 
-    def create_dot(self, a, b, d, input_precision, max_num_imprecise_acc):
+    def create_dot(self, a, b, d, input_precision, max_num_imprecise_acc, two_ctas=False):
+        # two_ctas only splits the MMA across a CTA pair on the device; the
+        # operand shapes and the mathematical result are unchanged, so the
+        # interpreter ignores it.
         a_data = a.data
         b_data = b.data
         if (a.dtype.primitive_bitwidth == 8 and a.dtype.is_floating()) or \

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -2622,10 +2622,22 @@ static inline int td_convert_args(TritonDispatcher *self,
   return 0;
 }
 
+/* Read one grid dimension from a Python int, normalizing an empty grid to 0.
+ * triton_launch_kernel() treats a non-positive grid as a no-op launch, so the
+ * dispatcher must too: casting a negative dimension straight to unsigned would
+ * wrap it into a huge gridDim that cuLaunchKernelEx rejects with
+ * CUDA_ERROR_INVALID_VALUE. */
+static inline unsigned td_grid_dim(PyObject *obj) {
+  long v = PyLong_AsLong(obj);
+  return v > 0 ? (unsigned)v : 0u;
+}
+
 /* Relaunch with pre-built attrs (cuLaunchKernelEx wrapper) */
 static inline CUresult td_relaunch(TritonDispatcher *d, unsigned gx,
                                    unsigned gy, unsigned gz, CUstream stream) {
-  if (gx * gy * gz == 0)
+  /* Per-dimension, not gx * gy * gz: the product overflows to 0 for legal
+   * grids such as (1 << 26, 64, 1), which would silently skip the launch. */
+  if (gx == 0 || gy == 0 || gz == 0)
     return CUDA_SUCCESS;
   if (d->use_core_launch) {
     /* Converged path: launch through the shared core in launch.h. */
@@ -2964,12 +2976,12 @@ static PyObject *TritonDispatcher_vectorcall(PyObject *callable,
   if (PyErr_Occurred())
     return NULL;
 
+  if (gx_l <= 0 || gy_l <= 0 || gz_l <= 0)
+    Py_RETURN_NONE;
+
   unsigned gx = (unsigned)gx_l;
   unsigned gy = (unsigned)gy_l;
   unsigned gz = (unsigned)gz_l;
-
-  if (gx * gy * gz == 0)
-    Py_RETURN_NONE;
 
   CUstream stream = (CUstream)(uintptr_t)PyLong_AsUnsignedLongLong(args[3]);
 
@@ -3117,12 +3129,9 @@ static PyObject *JITRunner_new(PyTypeObject *type, PyObject *args,
   Py_INCREF(dispatcher_obj);
 
   Py_ssize_t gs = PyTuple_Size(grid_tuple);
-  self->grid[0] =
-      (gs > 0) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 0)) : 1;
-  self->grid[1] =
-      (gs > 1) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 1)) : 1;
-  self->grid[2] =
-      (gs > 2) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 2)) : 1;
+  self->grid[0] = (gs > 0) ? td_grid_dim(PyTuple_GET_ITEM(grid_tuple, 0)) : 1;
+  self->grid[1] = (gs > 1) ? td_grid_dim(PyTuple_GET_ITEM(grid_tuple, 1)) : 1;
+  self->grid[2] = (gs > 2) ? td_grid_dim(PyTuple_GET_ITEM(grid_tuple, 2)) : 1;
 
   self->get_stream_fn = get_stream_fn;
   Py_INCREF(get_stream_fn);
@@ -3385,12 +3394,9 @@ static PyObject *fast_subscript(PyObject *self, PyObject *grid) {
     pr->dispatcher = (TritonDispatcher *)disp;
     Py_INCREF(disp);
     Py_ssize_t gs = PyTuple_Size(grid_tuple);
-    pr->grid[0] =
-        (gs > 0) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 0)) : 1;
-    pr->grid[1] =
-        (gs > 1) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 1)) : 1;
-    pr->grid[2] =
-        (gs > 2) ? (unsigned)PyLong_AsLong(PyTuple_GET_ITEM(grid_tuple, 2)) : 1;
+    pr->grid[0] = (gs > 0) ? td_grid_dim(PyTuple_GET_ITEM(grid_tuple, 0)) : 1;
+    pr->grid[1] = (gs > 1) ? td_grid_dim(PyTuple_GET_ITEM(grid_tuple, 1)) : 1;
+    pr->grid[2] = (gs > 2) ? td_grid_dim(PyTuple_GET_ITEM(grid_tuple, 2)) : 1;
 
     pr->get_stream_fn = gsf;
     Py_INCREF(gsf);


### PR DESCRIPTION
Summary:
Two Triton launch/execution-path bugs, fixed here in `beta` so they are gone at the source before the next promotion. Both were found while triaging the 3.8.0+fb stable promotion CI (D115081437); `beta` carries byte-identical copies of the affected code, so it has the same two bugs. D115211977 has the same fix applied to `beta` and `stable` together and is the stable-side reference; this diff is the beta-only change and is the one intended to land.

`TritonSemantic.dot` passes `two_ctas` as a 6th positional argument to `builder.create_dot`, but `InterpreterBuilder.create_dot` was never widened past 5 parameters. Every `tl.dot` under `TRITON_INTERPRET=1` therefore dies with `TypeError: create_dot() takes 6 positional arguments but 7 were given`. `two_ctas` only splits the MMA across a CTA pair on the device -- operand shapes and the mathematical result are unchanged -- so the interpreter accepts and ignores it.

The `_TritonDispatcher` C fast path is not launch-equivalent to `triton_launch_kernel` for an empty grid. The Python launcher skips the launch entirely when `gridX * gridY * gridZ > 0` fails on signed ints; the dispatcher casts each dimension to `unsigned` first and only skips on `== 0`, so a negative dimension wraps to a huge `gridDim` and `cuLaunchKernelEx` rejects it with `CUDA_ERROR_INVALID_VALUE`. The grid is now read through `td_grid_dim`, which normalizes any non-positive dimension to 0, and the skip check is per-dimension rather than on the product -- the product also overflows to 0 for legal grids such as `(1 << 26, 64, 1)`, which would silently drop the launch.

Note for the callers this unblocks: `aps_models/ads/modules/interformer` reaches `concat_2D_jagged` with grid `(4, -176, 1)`, i.e. a negative `max_seq_len`. That is very likely a bug on their side that the silent no-op on the Python launch path has been masking; this diff only makes the two launch paths agree and does not change their code.

Authored with Claude Code.

Differential Revision: D115224712


