### PR TITLE
[TLX][AMD] Expose positioned tensor descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1277,9 +1277,19 @@ phases. Neither role changes the numerical matrix operation.
 
 ## AMD TDM Descriptor Loads
 
-`tlx.async_amd_descriptor_load(desc, result, offsets, pred=None)` issues an AMD
-TDM descriptor load from global memory to a TLX local buffer. It is available on
-TDM-capable AMD targets (`gfx1250+`) and should be synchronized with
+`tlx.update_tensor_descriptor(desc, add_offsets=None, set_bounds=None,
+pred=None, clamp_bounds=False)` produces a positioned descriptor SSA value.
+`add_offsets` advances the tile position without changing bounds;
+`set_bounds` rewrites absolute bounds; and `pred` replaces the inherited
+predicate. Use `clamp_bounds=True` with `add_offsets` to derive the remaining
+OOB extent of an advanced tile.
+
+`tlx.async_amd_descriptor_load(desc, result, offsets=None, pred=None,
+clamp_bounds=True)` issues an AMD TDM descriptor load from global memory to a
+TLX local buffer. If `offsets` is omitted, `desc` is used as already positioned
+and its predicate is preserved. The analogous store accepts `offsets=None` for
+the same reason. Both operations are available on TDM-capable AMD targets
+(`gfx1250+`) and should be synchronized with
 `tlx.async_amd_descriptor_wait`.
 
 `tlx.async_amd_descriptor_load_group(descs, results, offsets, warp_masks,

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -2130,6 +2130,7 @@ def test_async_amd_desc_load_compiles_gfx1250(device):
     )
     ttgir = compiled.asm["ttgir"]
     assert "async_tdm_copy_global_to_local" in ttgir
+    assert "clamp_bounds" in ttgir
     assert "async_tdm_wait" in ttgir
     assert "local_load" in ttgir
     assert "amdgcn" in compiled.asm
@@ -2239,6 +2240,109 @@ def test_async_amd_desc_store_compiles_gfx1250(device):
     ttgir = compiled.asm["ttgir"]
     assert "async_tdm_copy_global_to_local" in ttgir
     assert "async_tdm_copy_local_to_global" in ttgir
+    assert ttgir.count("clamp_bounds") == 2
+
+
+@triton.jit
+def _update_tensor_descriptor_store_kernel(
+    x_ptr,
+    y_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+):
+    desc_in = tl.make_tensor_descriptor(x_ptr, [M, N], [N, 1], [M, N])
+    desc_out = tl.make_tensor_descriptor(y_ptr, [M, N], [N, 1], [M, N])
+    load_buf = tlx.local_alloc((M, N), tl.float16, 1)
+    store_buf = tlx.local_alloc((M, N), tl.float16, 1)
+    load_view = tlx.local_view(load_buf, 0)
+    store_view = tlx.local_view(store_buf, 0)
+
+    pred = tl.program_id(0) == 0
+    desc_in = tlx.update_tensor_descriptor(desc_in, set_bounds=[M, N], pred=pred)
+    offset_m = desc_in.shape[0] - M
+    offset_n = (desc_in.strides[1] - 1).to(tl.int32)
+    desc_in = tlx.update_tensor_descriptor(desc_in, add_offsets=[offset_m, offset_n])
+    tlx.async_amd_descriptor_load(desc_in, load_view)
+    tlx.async_amd_descriptor_wait(0)
+    tlx.local_store(store_view, tlx.local_load(load_view))
+
+    desc_out = tlx.update_tensor_descriptor(desc_out, add_offsets=[0, 0], clamp_bounds=True)
+    tlx.async_amd_descriptor_store(desc_out, store_view)
+    tlx.async_amd_descriptor_wait(0)
+
+
+@pytest.mark.skipif(not is_hip(), reason="Requires HIP runtime")
+def test_update_tensor_descriptor_store_compiles_gfx1250(device):
+    compiled = compile_for_gfx1250(
+        _update_tensor_descriptor_store_kernel,
+        signature={"x_ptr": "*fp16", "y_ptr": "*fp16"},
+        constexprs={"M": 32, "N": 32},
+    )
+    ttgir = compiled.asm["ttgir"]
+    assert "amdg.update_tensor_descriptor" in ttgir
+    assert "set_bounds =" in ttgir
+    assert "pred =" in ttgir
+    assert "clamp_bounds" in ttgir
+    assert "amdg.async_tdm_copy_local_to_global" in ttgir
+    assert ttgir.count("clamp_bounds") == 1
+    # Two explicit input updates and one output update are the only descriptor
+    # mutations. Neither pre-positioned copy may add a no-op update.
+    assert ttgir.count("amdg.update_tensor_descriptor") == 3
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires gfx1250 hardware")
+def test_update_tensor_descriptor_roundtrip_gfx1250(device):
+    x = torch.randn((32, 32), dtype=torch.float16, device=device)
+    y = torch.empty_like(x)
+    _update_tensor_descriptor_store_kernel[(1, )](x, y, M=32, N=32)
+    torch.testing.assert_close(x, y)
+
+
+@triton.jit
+def _invalid_update_tensor_descriptor_kernel(x_ptr, MODE: tl.constexpr):
+    desc = tl.make_tensor_descriptor(x_ptr, [16, 16], [16, 1], [16, 16])
+    if MODE == 0:
+        desc = tlx.update_tensor_descriptor(desc)
+    elif MODE == 1:
+        desc = tlx.update_tensor_descriptor(desc, pred=True, clamp_bounds=True)
+    elif MODE == 2:
+        desc = tlx.update_tensor_descriptor(
+            desc,
+            add_offsets=[0, 0],
+            set_bounds=[16, 16],
+            clamp_bounds=True,
+        )
+    elif MODE == 3:
+        desc = tlx.update_tensor_descriptor(desc, add_offsets=[0])
+    else:
+        desc = tlx.update_tensor_descriptor(desc, add_offsets=[0, 0])
+
+
+@pytest.mark.parametrize(
+    "mode, error",
+    [
+        (0, "requires at least one"),
+        (1, "clamp_bounds requires add_offsets"),
+        (2, "clamp_bounds and set_bounds are mutually exclusive"),
+        (3, "add_offsets must have length 2"),
+    ],
+)
+def test_update_tensor_descriptor_rejects_invalid_gfx1250(mode, error):
+    with pytest.raises(CompilationError, match=error):
+        compile_for_gfx1250(
+            _invalid_update_tensor_descriptor_kernel,
+            signature={"x_ptr": "*fp16"},
+            constexprs={"MODE": mode},
+        )
+
+
+def test_update_tensor_descriptor_rejects_unsupported_target():
+    with pytest.raises(CompilationError, match="only available on AMD TDM-capable targets"):
+        compile_for_gfx950(
+            _invalid_update_tensor_descriptor_kernel,
+            signature={"x_ptr": "*fp16"},
+            constexprs={"MODE": 4},
+        )
 
 
 @pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires gfx1250 hardware")

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -64,6 +64,7 @@ from .mem_ops import (
     storage_alias_spec,
     subslice,
     tmem_copy,
+    update_tensor_descriptor,
 )
 from .mma_ops import (
     amd_mfma_commit,
@@ -189,6 +190,7 @@ __all__ = [
     "local_reinterpret",
     "local_reshape",
     "allocate_tensor_descriptor",
+    "update_tensor_descriptor",
     "async_amd_descriptor_load",
     "async_amd_descriptor_store",
     "async_amd_descriptor_wait",

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -1442,18 +1442,89 @@ def _handle_i32_pred(pred, _semantic):
     return pred
 
 
+def _updated_tensor_descriptor(desc, handle):
+    if isinstance(desc, tl.tensor_descriptor):
+        return tl.tensor_descriptor(handle, list(desc.shape.values), list(desc.strides.values), desc.block_type)
+    return tl.tensor_descriptor_base(handle, desc.block_type)
+
+
+@tl.builtin
+def update_tensor_descriptor(
+    desc: tl.tensor_descriptor_base,
+    add_offsets: Optional[list[tl.tensor]] = None,
+    set_bounds: Optional[list[tl.tensor]] = None,
+    pred: tl.tensor = None,
+    clamp_bounds: tl.constexpr = False,
+    _semantic=None,
+) -> tl.tensor_descriptor_base:
+    """Return a new AMD TDM descriptor with selected fields updated.
+
+    ``add_offsets`` advances the tile position in element units without
+    changing its bounds. ``set_bounds`` rewrites the absolute per-dimension
+    bounds, while ``pred`` replaces the inherited descriptor predicate.
+    ``clamp_bounds=True`` derives the remaining bounds by subtracting the
+    offsets; it requires ``add_offsets`` and is mutually exclusive with
+    ``set_bounds``.
+    """
+    assert isinstance(desc, tl.tensor_descriptor_base)
+    arch = _semantic.builder.options.arch
+    assert is_amd_tdm_target(arch), (
+        f"update_tensor_descriptor is only available on AMD TDM-capable targets, got arch={arch}")
+    if add_offsets is None and set_bounds is None and pred is None:
+        raise ValueError("tlx.update_tensor_descriptor requires at least one of add_offsets, set_bounds, pred")
+
+    clamp_bounds = bool(tl._unwrap_if_constexpr(clamp_bounds))
+    if clamp_bounds:
+        if add_offsets is None:
+            raise ValueError("tlx.update_tensor_descriptor: clamp_bounds requires add_offsets")
+        if set_bounds is not None:
+            raise ValueError("tlx.update_tensor_descriptor: clamp_bounds and set_bounds are mutually exclusive")
+
+    rank = len(desc.block_shape)
+    add_offset_handles = []
+    if add_offsets is not None:
+        if len(add_offsets) != rank:
+            raise ValueError(f"add_offsets must have length {rank} (descriptor rank), got {len(add_offsets)}")
+        add_offset_handles = _semantic._convert_to_ir_values(add_offsets, require_i64=False)
+
+    set_bounds_handles = []
+    if set_bounds is not None:
+        if len(set_bounds) != rank:
+            raise ValueError(f"set_bounds must have length {rank} (descriptor rank), got {len(set_bounds)}")
+        set_bounds_handles = _semantic._convert_to_ir_values(set_bounds, require_i64=False)
+
+    pred_handle = None
+    if pred is not None:
+        pred_handle = _handle_i32_pred(pred, _semantic).handle
+
+    handle = _semantic.builder.create_update_tensor_descriptor(
+        desc.handle,
+        add_offset_handles,
+        set_bounds_handles,
+        pred_handle,
+        clamp_bounds,
+    )
+    return _updated_tensor_descriptor(desc, handle)
+
+
 @tl.builtin
 def async_amd_descriptor_load(
     desc: tl.tensor_descriptor_base,
     result: tlx.buffered_tensor,
-    offsets: list[tl.tensor],
+    offsets: Optional[list[tl.tensor]] = None,
     pred: tl.tensor = None,
+    clamp_bounds: tl.constexpr = True,
     _semantic=None,
 ) -> tlx.async_token:
     """Asynchronous descriptor load from global to a local buffer (AMD).
 
     Lowers to ``amdgpu.async_tdm_copy_global_to_local``; synchronize with
     :func:`async_amd_descriptor_wait`.
+
+    Pass a descriptor positioned by :func:`update_tensor_descriptor` with
+    ``offsets=None`` to avoid a redundant update. Supplying ``offsets`` is a
+    convenience that advances the descriptor and clamps its remaining bounds
+    by default; set ``clamp_bounds=False`` for position-only advancement.
 
     Available only on AMD TDM-capable targets (gfx1250+).
     """
@@ -1462,7 +1533,8 @@ def async_amd_descriptor_load(
     assert is_amd_tdm_target(arch), (
         f"async_amd_descriptor_load is only available on AMD TDM-capable targets, got arch={arch}")
     ndim = len(desc.block_shape)
-    assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
+    if offsets is not None:
+        assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
 
     layout = result.type.layout
     if not getattr(layout, "_tlx_default", False):
@@ -1476,13 +1548,27 @@ def async_amd_descriptor_load(
                 stacklevel=2,
             )
 
-    offsets_handles = _semantic._convert_to_ir_values(offsets, require_i64=False)
-    # The copy op is now pure: position the descriptor (tile offsets + predicate,
-    # with clamped OOB bounds) first, then issue the copy from it.
-    pred32 = _handle_i32_pred(True if pred is None else pred, _semantic)
-    positioned_desc = _semantic.builder.create_update_tensor_descriptor(desc.handle, offsets_handles, [], pred32.handle,
-                                                                        True,  # clamp_bounds
-                                                                        )
+    positioned_desc = desc.handle
+    if offsets is not None:
+        offsets_handles = _semantic._convert_to_ir_values(offsets, require_i64=False)
+        clamp_bounds = bool(tl._unwrap_if_constexpr(clamp_bounds))
+        pred32 = _handle_i32_pred(True if pred is None else pred, _semantic)
+        positioned_desc = _semantic.builder.create_update_tensor_descriptor(
+            desc.handle,
+            offsets_handles,
+            [],
+            pred32.handle,
+            clamp_bounds,
+        )
+    elif pred is not None:
+        pred32 = _handle_i32_pred(pred, _semantic)
+        positioned_desc = _semantic.builder.create_update_tensor_descriptor(
+            desc.handle,
+            [],
+            [],
+            pred32.handle,
+            False,
+        )
     token_handle = _semantic.builder.create_async_tdm_copy_global_to_local(
         positioned_desc,
         result.handle,
@@ -1495,13 +1581,18 @@ def async_amd_descriptor_load(
 def async_amd_descriptor_store(
     desc: tl.tensor_descriptor_base,
     source: tlx.buffered_tensor,
-    offsets: list[tl.tensor],
+    offsets: Optional[list[tl.tensor]] = None,
+    clamp_bounds: tl.constexpr = True,
     _semantic=None,
 ) -> None:
     """Asynchronous descriptor store from a local buffer to global (AMD).
 
     Lowers to ``amdgpu.async_tdm_copy_local_to_global``; synchronize with
     :func:`async_amd_descriptor_wait`.
+
+    ``offsets=None`` stores through an already positioned descriptor. When
+    offsets are supplied, the convenience update clamps remaining bounds by
+    default; set ``clamp_bounds=False`` for position-only advancement.
 
     Available only on AMD TDM-capable targets (gfx1250+).
     """
@@ -1510,7 +1601,8 @@ def async_amd_descriptor_store(
     assert is_amd_tdm_target(arch), (
         f"async_amd_descriptor_store is only available on AMD TDM-capable targets, got arch={arch}")
     ndim = len(desc.block_shape)
-    assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
+    if offsets is not None:
+        assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
 
     layout = source.type.layout
     if not getattr(layout, "_tlx_default", False):
@@ -1524,12 +1616,17 @@ def async_amd_descriptor_store(
                 stacklevel=2,
             )
 
-    offsets_handles = _semantic._convert_to_ir_values(offsets, require_i64=False)
-    # Position the descriptor (tile offsets + clamped OOB bounds); stores take no
-    # predicate. The copy op is now pure and reads from the positioned descriptor.
-    positioned_desc = _semantic.builder.create_update_tensor_descriptor(desc.handle, offsets_handles, [], None,
-                                                                        True,  # clamp_bounds
-                                                                        )
+    positioned_desc = desc.handle
+    if offsets is not None:
+        clamp_bounds = bool(tl._unwrap_if_constexpr(clamp_bounds))
+        offsets_handles = _semantic._convert_to_ir_values(offsets, require_i64=False)
+        positioned_desc = _semantic.builder.create_update_tensor_descriptor(
+            desc.handle,
+            offsets_handles,
+            [],
+            None,
+            clamp_bounds,
+        )
     _semantic.builder.create_async_tdm_copy_local_to_global(
         positioned_desc,
         source.handle,


### PR DESCRIPTION
Expose update_tensor_descriptor as the TLX frontend for the existing AMD TDM descriptor-update operation. Preserve tensor shape and stride metadata on the returned SSA value and support incremental offsets, absolute bounds, predicate replacement, and optional bounds clamping.

Allow async descriptor loads and stores to consume an already positioned descriptor without inserting a redundant update. Offset-based convenience calls retain their existing bounds-clamping behavior by default, while clamp_bounds=False enables position-only advancement for tuned kernels.

Validate target support and argument combinations in the frontend, document the positioning semantics, and cover chained metadata-preserving updates, predicates and bounds, default clamping, pre-positioned copies, invalid calls, unsupported targets, and a modeled gfx1250 runtime round-trip.

Extracted from https://github.com/facebookexperimental/triton/pull/2773