### PR TITLE
[release/3.8.x] [Test-Fix] [AutoWS] Enable aref in upstream AutoWS" (#2751)

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/AutomaticWarpSpecialization.cpp
@@ -116,16 +116,7 @@ void AutomaticWarpSpecialization::runOnOperation() {
   addPassWithPartitionVerifier(createTritonGPUPartitionScheduling());
   addPassWithPartitionVerifier(createNVWSHoistTmemStore());
   addPassWithPartitionVerifier(createNVWSInsertAref());
-  // META_WS_CHANGE: InsertTmemAref fails with Meta's partition layout
-  // (getInitialSchedule + schedulePostLoopOps). Keep disabled until partition
-  // scheduling is aligned with upstream. LoadMMASpecialization is retained
-  // locally as the fallback.
-#if 0
   addPassWithPartitionVerifier(createNVWSInsertTmemAref());
-#else
-  addPassWithPartitionVerifier(
-      createTritonGPULoadMMASpecialization({numStages}));
-#endif
   // `int-range-optimizations` and SCCP are good at cleaning up loop arithmetic.
   // FIXME: Re-enable integer range analysis once it is fixed.
   // pm.addPass(arith::createIntRangeOptimizationsPass());


### PR DESCRIPTION
Summary:
Enables aref in upstream AutoWS to fix `pytest -s -v -x python/test/unit/language/test_warp_specialization.py` on Blackwell. This was previously disabled because AutoWS wasn't well enough isolated.

Pull Request resolved: https://github.com/facebookexperimental/triton/pull/2751

Reviewed By: warrendeng

Differential Revision: D115060233

Pulled By: njriasan

fbshipit-source-id: 7a8ec209b5a7a5a20ec21d5460c468ce48ec4bb8 (cherry picked from commit cc5f800acc90153a5c9f0d86cccd64ae19ecd166)