### PR TITLE
Virtualize Triton PTX source paths

### DIFF
--- a/python/test/unit/language/test_line_info.py
+++ b/python/test/unit/language/test_line_info.py
@@ -250,13 +250,13 @@ def test_line_info_ir_source(monkeypatch, status, tmp_path, fresh_triton_cache):
     kernel_info = triton.compile(str(temp_file))
     file_lines = extract_file_lines(command, anchor, separator, kernel_info.asm[obj_kind])
     if status == "ttir":
-        assert check_file_lines(file_lines, "/path/test.py", 8, should_contain=False)
-        assert check_file_lines(file_lines, str(temp_file), -1, should_contain=True)
+        assert check_file_lines(file_lines, "<source>/test.py", 8, should_contain=False)
+        assert check_file_lines(file_lines, "<source>/test.ttir", 3)
     else:
         # The scalar load may be folded into the store, dropping line 8 debug
         # info. This already happened on AMD and now also happens on NVIDIA with
         # newer LLVM, so only verify file-level info is present.
-        assert check_file_lines(file_lines, "/path/test.py", -1, should_contain=True)
+        assert check_file_lines(file_lines, "<source>/test.py", -1)
 
 
 def test_use_name_loc_as_prefix(fresh_triton_cache):

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -26,6 +26,35 @@ TRITON_MAX_TMA_DESCS = 8
 TRITON_MAX_TMA_DIMS = 5
 
 
+_PTX_FILE_DIRECTIVE = re.compile(
+    r"""
+    # Match one complete PTX .file directive and preserve its prefix.
+    ^
+    (?P<directive_prefix>
+        [ \t]* \.file [ \t]+
+        \d+ [ \t]+ "
+    )
+    (?P<path>
+        (?: [^"\\] | \\. )*  # Allow escaped characters in the quoted path.
+    )
+    "
+    (?: [ \t]* , [ \t]* \d+ [ \t]* , [ \t]* \d+ )?  # Optional mtime and size.
+    [ \t]*
+    $
+    """,
+    flags=re.MULTILINE | re.X,
+)
+
+
+def normalize_ptx_file_metadata(src: str) -> str:
+    def normalize_file(match: re.Match[str]) -> str:
+        filename = match.group("path").rsplit("/", 1)[-1]
+        virtual_path = f"<source>/{filename}"
+        return f'{match.group("directive_prefix")}{virtual_path}", 0, 0'
+
+    return _PTX_FILE_DIRECTIVE.sub(normalize_file, src)
+
+
 def min_dot_size(target: GPUTarget):
 
     def check_dot_compatibility(lhs_type, rhs_type) -> Tuple[int, int, int]:  # [m, n, k]
@@ -1240,6 +1269,7 @@ class CUDABackend(BaseBackend):
             # Note: if this flag is removed, the source var name and type info will be lost when ptx was compiled into cubin
             #           and we may not be able to see them in cuda-gdb
             ret = re.sub(r",\s*debug|debug,\s*", "", ret)
+        ret = normalize_ptx_file_metadata(ret)
         if knobs.nvidia.dump_nvptx:
             print("// -----// NVPTX Dump //----- //")
             print(ret)


### PR DESCRIPTION
Summary:
## Problem

When ptxas resolves source paths referenced by PTX, generated cubins can include local filesystem metadata. This affects build caching. 

## Fix

Normalize every PTX `.file` source path independently of language, package layout, or build system:

- Preserve the PTX file number and source basename.
- Replace the source directory with `<source_N>/`, where `N` is the existing PTX file number. This keeps duplicate basenames distinct while preventing filesystem resolution.
- Always emit timestamp and size `0`, including when the original directive omits metadata.
- Parse directives with an extracted `re.X` pattern and named groups.

Reviewed By: stashuk-olek

Differential Revision: D115062368


