### PR TITLE
[triton][sched2tlx] Apply native joint-solver schedules (#2794)

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.h
+++ b/include/triton/Tools/Sys/GetEnv.h
@@ -115,6 +115,7 @@ inline const std::set<std::string> CACHE_NEUTRAL_ENV_VARS = {
     "TRITON_REPRODUCER_PATH",
     "TRITON_ENABLE_PYTHON_STACKTRACE",
     "TRITON_TLX_DUMP_DIR",
+    "TRITON_MODULO_BASELINE_REPORT",
     // clang-format on
 };
 

--- a/test/TritonGPU/modulo-schedule.mlir
+++ b/test/TritonGPU/modulo-schedule.mlir
@@ -1,4 +1,6 @@
 // RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -nvgpu-modulo-schedule | FileCheck %s
+// RUN: env TRITON_USE_MODULO_SCHEDULE=joint_solver triton-opt %s -split-input-file -allow-unregistered-dialect -nvgpu-modulo-schedule | FileCheck %s --check-prefix=JOINT
+// RUN: env TRITON_MODULO_BASELINE_REPORT=1 triton-opt %s -split-input-file -allow-unregistered-dialect -nvgpu-modulo-schedule 2>&1 | FileCheck %s --check-prefix=BASELINE
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #acc_layout = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
@@ -10,16 +12,53 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 
 // Verify that the modulo schedule pass annotates the inner loop with its
 // scheduling decision. For a single-MMA GEMM, all MMAs are in the same stage
-// so tt.autows is skipped. The pass marks the loop with tt.modulo_ii (the
-// initiation interval it picked) and tt.scheduled_max_stage (the deepest
-// stage in the schedule); the actual values depend on the latency model, so
-// we only check that the attrs are present, not their specific values.
+// so tt.autows is skipped. The default run only checks the public attributes;
+// the JOINT run freezes the schedule extracted from this DDG by native Z3.
 //
 // CHECK-LABEL: @gemm_inner_loop
 // CHECK: scf.for
 // CHECK-NOT: tt.autows
 // CHECK: tt.modulo_ii = {{[0-9]+}} : i32
 // CHECK-SAME: tt.scheduled_max_stage = {{[0-9]+}} : i32
+//
+// JOINT-LABEL: tt.func @gemm_inner_loop
+// JOINT: arith.muli {{.*}} {loop.cluster = 0 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : i32
+// The two operand loads are symmetric on the TMA pipeline, so their relative
+// cluster order is a tie-break, not a scheduling decision. This diff wraps
+// every constraint as `assumption_literal -> constraint` and solves via
+// Z3_solver_check_assumptions (see AssumptionTracker, added here for UNSAT
+// core extraction), which changes the formula Z3 searches and therefore which
+// of the two it places first. II, stages and partitions are unchanged, so the
+// schedule is equivalent — only these cluster indices flip relative to the
+// parent revision.
+// JOINT: tt.descriptor_load {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>}
+// JOINT: tt.descriptor_load {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 2>}
+// JOINT: ttg.local_alloc {{.*}} {buffer.id = 0 : i32, buffer.merge_group_id = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.num_buffers = 2 : i32, ttg.partition = array<i32: 1>}
+// JOINT: ttg.local_alloc {{.*}} {buffer.id = 1 : i32, buffer.merge_group_id = 1 : i32, loop.cluster = 3 : i32, loop.stage = 0 : i32, tt.num_buffers = 2 : i32, ttg.partition = array<i32: 2>}
+// JOINT: ttng.tmem_alloc {{.*}} {buffer.id = 2 : i32, buffer.merge_group_id = 2 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.num_buffers = 2 : i32, ttg.partition = array<i32: 3>}
+// JOINT: ttng.tc_gen5_mma {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>}
+// JOINT: ttng.tmem_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 3>}
+// JOINT: } {tt.modulo_ii = 1091 : i32, tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, ttg.partition.stages = [0 : i32, 0 : i32, 0 : i32, 1 : i32], ttg.partition_num_warps = array<i32: 4, 1, 1, 4>, ttg.warp_specialize.tag = 0 : i32}
+//
+// M2 acceptance evidence on this same GEMM DDG. The IIs are solver- and
+// machine-dependent so they are matched as numbers, not pinned: what is
+// pinned is that the table is emitted, that both criteria are evaluated, and
+// that neither reports FAIL. SKIP is accepted because the joint rows drop out
+// in a build without Z3 (TRITON_ENABLE_Z3_JOINT_SOLVER off), where the
+// baselines still run but there is nothing to compare them against.
+//
+// On this fixture every backend lands on MinII, so `strict improvement` is
+// NO — the loop is MinII-bound and cannot separate schedulers. That is
+// checked as-is rather than tolerated: if a future change makes the solver
+// beat Rau here, this line must be updated deliberately, with the new number
+// looked at, instead of silently flipping.
+//
+// BASELINE: modulo-baseline-report: gemm_inner_loop
+// BASELINE: fixture{{ +}}MinII{{ +}}II_full{{ +}}relaxed_LB{{ +}}II_rau{{ +}}II_sms{{ +}}II_exhaustive
+// BASELINE: gemm_inner_loop{{ +}}{{[0-9]+}}{{ +}}{{[0-9-]+}}{{ +}}{{[0-9-]+}}{{ +}}{{[0-9-]+}}
+// BASELINE: soundness (II_full >= relaxed_LB): {{PASS|SKIP}}
+// BASELINE: no-regression (II_full <= II_rau): {{PASS|SKIP}}
+// BASELINE: strict improvement (II_full < II_rau): {{NO|SKIP}}
 tt.func @gemm_inner_loop(
   %a_desc: !tt.tensordesc<128x64xf16>,
   %b_desc: !tt.tensordesc<64x128xf16>

--- a/test/TritonGPU/modulo-schedule.mlir
+++ b/test/TritonGPU/modulo-schedule.mlir
@@ -37,8 +37,11 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // JOINT: ttg.local_alloc {{.*}} {buffer.id = 1 : i32, buffer.merge_group_id = 1 : i32, loop.cluster = 3 : i32, loop.stage = 0 : i32, tt.num_buffers = 2 : i32, ttg.partition = array<i32: 2>}
 // JOINT: ttng.tmem_alloc {{.*}} {buffer.id = 2 : i32, buffer.merge_group_id = 2 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.num_buffers = 2 : i32, ttg.partition = array<i32: 3>}
 // JOINT: ttng.tc_gen5_mma {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>}
-// JOINT: ttng.tmem_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 3>}
-// JOINT: } {tt.modulo_ii = 1091 : i32, tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, ttg.partition.stages = [0 : i32, 0 : i32, 0 : i32, 1 : i32], ttg.partition_num_warps = array<i32: 4, 1, 1, 4>, ttg.warp_specialize.tag = 0 : i32}
+// The epilogue tmem_load gets a warp group of its own (4), separate from the
+// MMA's (3), once the solver's warp-group assignment is applied — hence five
+// partitions, not four.
+// JOINT: ttng.tmem_load {{.*}} {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 4>}
+// JOINT: } {tt.modulo_ii = 1091 : i32, tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32, ttg.partition.stages = [0 : i32, 0 : i32, 0 : i32, 0 : i32, 1 : i32], ttg.partition_num_warps = array<i32: 4, 1, 1, 1, 4>, ttg.warp_specialize.tag = 0 : i32}
 //
 // M2 acceptance evidence on this same GEMM DDG. The IIs are solver- and
 // machine-dependent so they are matched as numbers, not pinned: what is

--- a/third_party/amd/lib/TritonAMDGPUTransforms/DotDecomposeAndSchedule.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/DotDecomposeAndSchedule.cpp
@@ -965,6 +965,9 @@ static void runModuloExpand(ModuleOp module) {
 static void runAMDModuloScaffold(ModuleOp module,
                                  bool serializeForExpansion = false) {
   triton::gpu::AMDLatencyModel model;
+  // No forced backend on the AMD path: TRITON_USE_MODULO_SCHEDULE is the only
+  // input. Resolved once so every loop in this module uses one backend.
+  const std::string scheduleAlgo = triton::gpu::getActiveScheduleAlgo();
   // Collect loops first — E2 mutates loop bodies, so don't mutate during walk.
   SmallVector<scf::ForOp> loops;
   module.walk([&](scf::ForOp f) { loops.push_back(f); });
@@ -986,7 +989,7 @@ static void runAMDModuloScaffold(ModuleOp module,
     // E1: run the core modulo scheduler (rau/SMS, selected by
     // TRITON_USE_MODULO_SCHEDULE; default rau) and annotate each op with its
     // stage/order so a downstream expansion can consume the schedule.
-    auto schedOr = triton::gpu::runModuloScheduling(ddg);
+    auto schedOr = triton::gpu::runModuloScheduling(ddg, scheduleAlgo);
     if (!succeeded(schedOr)) {
       os << " II=FAILED";
       forOp.emitRemark() << os.str();
@@ -1004,7 +1007,7 @@ static void runAMDModuloScaffold(ModuleOp module,
         // the largest scheduled cycle fits within stages 0 and 1.
         int minII = std::max(computedMinII, maxAbsoluteCycle / 2 + 1);
         auto constrained = triton::gpu::runModuloScheduling(
-            ddg, /*maxII=*/0, /*maxBacktracks=*/20, minII);
+            ddg, scheduleAlgo, /*maxII=*/0, /*maxBacktracks=*/20, minII);
         if (failed(constrained))
           break;
         sched = *constrained;

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -7,11 +7,13 @@ add_triton_library(TritonGPUModuloCore
   ModuloScheduling/AMDLatencyModel.cpp
   ModuloScheduling/AMDWarpPipelinePartition.cpp
   ModuloScheduling/DataDependenceGraph.cpp
+  ModuloScheduling/JointSolverScheduler.cpp
   ModuloScheduling/ModuloReservationTable.cpp
   ModuloScheduling/SwingScheduler.cpp
   ModuloScheduling/ExhaustiveScheduler.cpp
   ModuloScheduling/Z3ConstraintEncoder.cpp
   ModuloScheduling/Z3JointSolver.cpp
+  ModuloScheduling/Z3JointSolutionValidator.cpp
   ModuloScheduling/ModuloScheduleGraph.cpp
 
   LINK_LIBS PUBLIC

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.cpp
@@ -48,7 +48,8 @@ void DataDependenceGraph::addEdge(unsigned src, unsigned dst, int latency,
 
 DataDependenceGraph DataDependenceGraph::build(
     scf::ForOp loop, const LatencyModel &model,
-    const llvm::DenseMap<Operation *, DataPartitionInfo> &partition) {
+    const llvm::DenseMap<Operation *, DataPartitionInfo> &partition,
+    llvm::StringRef scheduleAlgo) {
   DataDependenceGraph ddg;
 
   // Phase 1: Create nodes for every op in the loop body (except terminator).
@@ -60,13 +61,14 @@ DataDependenceGraph DataDependenceGraph::build(
     // is the inner loop's total execution time (II × trip_count), and
     // its pipeline is NONE (handles its own internal pipelining).
     if (auto innerLoop = dyn_cast<scf::ForOp>(op)) {
-      auto innerDDG = DataDependenceGraph::build(innerLoop, model, partition);
+      auto innerDDG =
+          DataDependenceGraph::build(innerLoop, model, partition, scheduleAlgo);
       // Pass A.5: the inner MMA may be partitioned; apply the split before
       // scheduling so the super-node's innerII is the partitioned II, not the
       // unpartitioned one (which would dilute the outer loop's cost and could
       // hide a variant that only schedules once the inner MMA is split).
       innerDDG.applyDataPartition(partition);
-      auto innerSched = runModuloScheduling(innerDDG);
+      auto innerSched = runModuloScheduling(innerDDG, scheduleAlgo);
 
       DDGNode node;
       node.op = &op;

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/DataDependenceGraph.h
@@ -7,6 +7,7 @@
 #include "mlir/IR/Operation.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace mlir::triton::gpu {
 
@@ -102,10 +103,16 @@ public:
   /// it is modulo-scheduled, so the super-node's `innerII` reflects the split
   /// (an M-partitioned inner MMA is scheduled at its partitioned ResMII, not
   /// the unpartitioned one). Empty by default = no partitioning.
+  ///
+  /// `scheduleAlgo` is the backend used for those inner super-node schedules;
+  /// a pass that forces a backend must thread it here too, or the nested
+  /// schedules silently fall back to the env-selected one. Empty = resolve
+  /// from TRITON_USE_MODULO_SCHEDULE (see getActiveScheduleAlgo).
   static DataDependenceGraph
   build(scf::ForOp loop, const LatencyModel &model,
         const llvm::DenseMap<Operation *, DataPartitionInfo> &partition =
-            llvm::DenseMap<Operation *, DataPartitionInfo>());
+            llvm::DenseMap<Operation *, DataPartitionInfo>(),
+        llvm::StringRef scheduleAlgo = {});
 
   llvm::ArrayRef<DDGNode> getNodes() const { return nodes; }
   llvm::ArrayRef<DDGEdge> getEdges() const { return edges; }

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/JointSolverScheduler.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/JointSolverScheduler.cpp
@@ -324,6 +324,11 @@ private:
   std::unordered_map<std::string, EntryList::iterator> entries;
 };
 
+// The one process-global on the scheduling path, and deliberately so: it is a
+// memo keyed by the canonicalized problem, not configuration. Two modules
+// compiled concurrently (each pass pipeline runs with the GIL released) can
+// only ever hand each other the answer to an identical problem, and the
+// entries are mutex-guarded.
 static JointSolverCache &jointSolverCache() {
   static JointSolverCache cache;
   return cache;

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/JointSolverScheduler.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/JointSolverScheduler.cpp
@@ -4,13 +4,17 @@
 
 #include "JointSolverScheduler.h"
 
-#include "ExhaustiveScheduler.h"
+#include "Z3JointSolutionValidator.h"
 #include "Z3JointSolver.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Tools/Sys/GetEnv.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/raw_ostream.h"
+#include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <list>
 #include <mutex>
@@ -48,9 +52,51 @@ static int serialUpperBound(const DataDependenceGraph &ddg, int minII) {
   return static_cast<int>(std::max<int64_t>(minII, bound));
 }
 
-static std::string buildProblemJSON(const DataDependenceGraph &ddg, int minII,
-                                    int maxII, int smemBudget,
-                                    int tmemColLimit) {
+struct SolverBuffer {
+  unsigned allocNodeIdx;
+  bool isTmem;
+  int64_t sizeBytes;
+  int64_t tmemCols;
+  llvm::SmallVector<unsigned, 4> consumerNodes;
+};
+
+static llvm::SmallVector<SolverBuffer>
+extractSolverBuffers(const DataDependenceGraph &ddg) {
+  llvm::SmallVector<SolverBuffer> buffers;
+  for (const auto &node : ddg.getNodes()) {
+    Operation *op = node.op;
+    SolverBuffer buffer;
+    buffer.allocNodeIdx = node.idx;
+    if (isa<LocalAllocOp>(op)) {
+      auto memDesc = dyn_cast<MemDescType>(op->getResult(0).getType());
+      if (!memDesc)
+        continue;
+      int64_t elements = 1;
+      for (int64_t dimension : memDesc.getShape())
+        elements *= dimension;
+      buffer.isTmem = false;
+      buffer.sizeBytes =
+          elements * memDesc.getElementType().getIntOrFloatBitWidth() / 8;
+      buffer.tmemCols = 0;
+    } else if (node.tmemAllocCols > 0) {
+      buffer.isTmem = true;
+      buffer.sizeBytes = 0;
+      buffer.tmemCols = node.tmemAllocCols;
+    } else {
+      continue;
+    }
+    for (const DDGEdge *edge : ddg.getOutEdges(node.idx))
+      if (edge->distance == 0)
+        buffer.consumerNodes.push_back(edge->dstIdx);
+    buffers.push_back(std::move(buffer));
+  }
+  return buffers;
+}
+
+static std::string
+buildProblemJSON(const DataDependenceGraph &ddg, int minII, int maxII,
+                 int smemBudget, int tmemColLimit,
+                 llvm::ArrayRef<llvm::StringRef> relaxKeepKinds = {}) {
   // Streaming classification (Twill §5.3): a variable-latency op with no
   // incoming data dependence (TMA input loads) runs ahead of the pipeline
   // behind its ring buffer, so in steady state its consumers do not wait its
@@ -82,7 +128,7 @@ static std::string buildProblemJSON(const DataDependenceGraph &ddg, int minII,
     });
   }
   llvm::json::Array buffers;
-  for (const auto &buf : extractSchedBuffers(ddg)) {
+  for (const auto &buf : extractSolverBuffers(ddg)) {
     llvm::json::Array consumers;
     for (unsigned c : buf.consumerNodes)
       consumers.push_back(static_cast<int64_t>(c));
@@ -128,6 +174,12 @@ static std::string buildProblemJSON(const DataDependenceGraph &ddg, int minII,
   if (auto env = tools::getStrEnv("TRITON_MODULO_JOINT_SOLVER_SEED");
       !env.empty())
     root["random_seed"] = std::max<int64_t>(0, std::atoll(env.c_str()));
+  if (!relaxKeepKinds.empty()) {
+    llvm::json::Array keptKinds;
+    for (llvm::StringRef kind : relaxKeepKinds)
+      keptKinds.push_back(kind.str());
+    root["relax_keep_kinds"] = std::move(keptKinds);
+  }
   std::string out;
   llvm::raw_string_ostream os(out);
   os << llvm::json::Value(std::move(root));
@@ -277,23 +329,86 @@ static JointSolverCache &jointSolverCache() {
   return cache;
 }
 
-static bool isCacheableResponse(llvm::StringRef response) {
+constexpr unsigned kDefaultRetryCount = 1;
+constexpr unsigned kMaxRetryCount = 3;
+constexpr double kMaxRetryTimeoutSeconds = 300.0;
+
+enum class ResponseKind { Ok, ProvenUnsat, Inconclusive, Other };
+
+static ResponseKind classifyResponse(llvm::StringRef response) {
   auto parsed = llvm::json::parse(response);
-  if (parsed) {
-    const auto *object = parsed->getAsObject();
-    if (object == nullptr)
-      return false;
-    auto status = object->getString("status");
-    if (status) {
-      if (*status == "ok")
-        return true;
-      if (*status == "infeasible")
-        return object->getBoolean("proven_unsat").value_or(false);
-    }
+  if (!parsed) {
+    llvm::consumeError(parsed.takeError());
+    return ResponseKind::Other;
+  }
+  const auto *object = parsed->getAsObject();
+  if (!object)
+    return ResponseKind::Other;
+  auto status = object->getString("status");
+  if (!status)
+    return ResponseKind::Other;
+  if (*status == "ok")
+    return ResponseKind::Ok;
+  if (*status == "infeasible" &&
+      object->getBoolean("proven_unsat").value_or(false))
+    return ResponseKind::ProvenUnsat;
+  if (*status == "inconclusive")
+    return ResponseKind::Inconclusive;
+  return ResponseKind::Other;
+}
+
+static bool validateSolution(llvm::StringRef problem,
+                             llvm::StringRef response) {
+  std::string validation = validateZ3JointSolution(problem, response);
+  auto parsed = llvm::json::parse(validation);
+  if (!parsed) {
+    llvm::consumeError(parsed.takeError());
+    LLVM_DEBUG(DBGS() << "validator returned malformed JSON\n");
     return false;
   }
-  llvm::consumeError(parsed.takeError());
-  return false;
+  const auto *object = parsed->getAsObject();
+  bool valid = object && object->getBoolean("valid").value_or(false);
+  if (!valid)
+    LLVM_DEBUG(DBGS() << "solution rejected by validator: " << validation
+                      << "\n");
+  return valid;
+}
+
+static unsigned retryCount() {
+  auto env = tools::getStrEnv("TRITON_MODULO_JOINT_SOLVER_RETRIES");
+  if (env.empty())
+    return kDefaultRetryCount;
+  char *end = nullptr;
+  long parsed = std::strtol(env.c_str(), &end, 10);
+  if (end == env.c_str() || *end != '\0')
+    return kDefaultRetryCount;
+  return static_cast<unsigned>(std::clamp<long>(parsed, 0, kMaxRetryCount));
+}
+
+static FailureOr<std::string>
+problemForAttempt(llvm::StringRef canonicalProblem, unsigned attempt) {
+  if (attempt == 0)
+    return canonicalProblem.str();
+
+  auto parsed = llvm::json::parse(canonicalProblem);
+  if (!parsed) {
+    llvm::consumeError(parsed.takeError());
+    return failure();
+  }
+  auto *object = parsed->getAsObject();
+  if (!object)
+    return failure();
+  auto baseTimeout = object->getNumber("time_limit_s");
+  if (!baseTimeout || !std::isfinite(*baseTimeout) || *baseTimeout <= 0.0)
+    return failure();
+  double multiplier = std::ldexp(1.0, static_cast<int>(attempt));
+  (*object)["time_limit_s"] =
+      std::min(*baseTimeout * multiplier, kMaxRetryTimeoutSeconds);
+
+  std::string retryProblem;
+  llvm::raw_string_ostream os(retryProblem);
+  writeCanonicalJSON(os, *parsed);
+  return retryProblem;
 }
 
 } // namespace
@@ -305,12 +420,32 @@ FailureOr<std::string> runJointSolverBackend(llvm::StringRef problemJson) {
   if (auto cached = jointSolverCache().lookup(*canonicalProblem))
     return std::move(*cached);
 
-  auto response = runZ3JointSolver(*canonicalProblem);
-  if (failed(response))
-    return failure();
-  if (isCacheableResponse(*response))
-    jointSolverCache().insert(*canonicalProblem, *response);
-  return response;
+  unsigned retries = retryCount();
+  for (unsigned attempt = 0; attempt <= retries; ++attempt) {
+    auto attemptProblem = problemForAttempt(*canonicalProblem, attempt);
+    if (failed(attemptProblem))
+      return failure();
+    auto response = runZ3JointSolver(*attemptProblem);
+    if (failed(response))
+      return failure();
+
+    ResponseKind kind = classifyResponse(*response);
+    if (kind == ResponseKind::Ok) {
+      if (!validateSolution(*attemptProblem, *response))
+        return failure();
+      jointSolverCache().insert(*canonicalProblem, *response);
+      return response;
+    }
+    if (kind == ResponseKind::ProvenUnsat) {
+      jointSolverCache().insert(*canonicalProblem, *response);
+      return response;
+    }
+    if (kind != ResponseKind::Inconclusive || attempt == retries)
+      return response;
+    LLVM_DEBUG(DBGS() << "inconclusive response; retry " << attempt + 1 << '/'
+                      << retries << " with a fresh backend\n");
+  }
+  llvm_unreachable("joint-solver retry loop must return");
 }
 
 FailureOr<ModuloScheduleResult>
@@ -387,6 +522,101 @@ runJointSolverSchedule(const DataDependenceGraph &ddg, int minII,
   }
   LLVM_DEBUG(DBGS() << "SUCCESS at II=" << result.II << "\n");
   return result;
+}
+
+/// Exclusive modular reservation only — the half of `verifySolution` that a
+/// resource-relaxed schedule is still required to satisfy. Dependences are
+/// deliberately not checked: dropping them is the point of the relaxation.
+static bool
+verifyResourceExclusivity(const DataDependenceGraph &ddg, int ii,
+                          const llvm::DenseMap<unsigned, int> &cycles) {
+  if (ii <= 0)
+    return false;
+  ModuloReservationTable table(ii);
+  for (const auto &node : ddg.getNodes()) {
+    auto cycleIt = cycles.find(node.idx);
+    if (cycleIt == cycles.end() || cycleIt->second < 0)
+      return false;
+    if (node.pipeline == HWPipeline::NONE)
+      continue;
+    int dur = nodeDuration(node);
+    if (dur > ii || !table.isIntervalFree(cycleIt->second, node.pipeline, dur))
+      return false;
+    table.reserve(cycleIt->second, node.pipeline, node.idx, dur);
+  }
+  return true;
+}
+
+FailureOr<int> runJointSolverRelaxedLowerBound(const DataDependenceGraph &ddg,
+                                               int minII, int smemBudget,
+                                               int tmemColLimit) {
+  if (minII <= 0 || ddg.getNumNodes() == 0)
+    return failure();
+  int maxII = serialUpperBound(ddg, minII);
+
+  // Deliberately NOT routed through runJointSolverBackend: that wrapper
+  // validates every "ok" response against the full model, and a relaxed
+  // schedule violates the very constraints it dropped, so it would always be
+  // rejected. The relaxed run is not trusted either — the kept kind is
+  // re-verified below — but it has to be checked against the relaxed model,
+  // not the full one. Skipping the wrapper also skips its cache; the bound is
+  // only computed under TRITON_MODULO_BASELINE_REPORT, so that is not a hot
+  // path.
+  llvm::StringRef keep[] = {llvm::StringRef("resource")};
+  auto rawOut = runZ3JointSolver(
+      buildProblemJSON(ddg, minII, maxII, smemBudget, tmemColLimit, keep));
+  if (failed(rawOut))
+    return failure();
+  auto parsed = llvm::json::parse(*rawOut);
+  if (!parsed) {
+    llvm::consumeError(parsed.takeError());
+    return failure();
+  }
+  auto *obj = parsed->getAsObject();
+  if (!obj)
+    return failure();
+  auto status = obj->getString("status");
+  if (!status || *status != "ok") {
+    LLVM_DEBUG(DBGS() << "relaxed lower bound unavailable: status "
+                      << (status ? *status : "<none>") << "\n");
+    return failure();
+  }
+  // The backend must confirm it honoured the relaxation. Without this, a build
+  // whose solver silently ignored `relax_keep_kinds` would return the FULL
+  // model's II here, making the soundness invariant compare II_full against
+  // itself and pass vacuously.
+  if (!obj->getObject("relaxation")) {
+    LLVM_DEBUG(DBGS() << "backend did not honour relax_keep_kinds\n");
+    return failure();
+  }
+
+  auto ii = obj->getInteger("ii");
+  auto *cycles = obj->getObject("cycles");
+  if (!ii || !cycles || *ii <= 0)
+    return failure();
+
+  llvm::DenseMap<unsigned, int> nodeToCycle;
+  for (const auto &kv : *cycles) {
+    unsigned idx = 0;
+    if (llvm::StringRef(kv.first).getAsInteger(10, idx))
+      return failure();
+    auto cyc = kv.second.getAsInteger();
+    if (!cyc)
+      return failure();
+    nodeToCycle[idx] = static_cast<int>(*cyc);
+  }
+  if (nodeToCycle.size() != ddg.getNumNodes())
+    return failure();
+
+  // A relaxed bound that is too HIGH turns the soundness invariant into a
+  // false alarm, so the kept kind is re-verified before the number is used.
+  if (!verifyResourceExclusivity(ddg, static_cast<int>(*ii), nodeToCycle)) {
+    LLVM_DEBUG(DBGS() << "relaxed schedule violates the kept resource "
+                         "constraints — discarding the bound\n");
+    return failure();
+  }
+  LLVM_DEBUG(DBGS() << "relaxed lower bound = " << *ii << "\n");
+  return static_cast<int>(*ii);
 }
 
 } // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/JointSolverScheduler.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/JointSolverScheduler.h
@@ -33,7 +33,37 @@ runJointSolverSchedule(const DataDependenceGraph &ddg, int minII,
 /// joint-partition mode (ModuloSchedulePass's partitionJointSolver).
 /// Proven results are cached by canonical request JSON in a bounded,
 /// thread-safe LRU.
+/// Inconclusive responses are retried with a fresh backend and a bounded,
+/// increasing timeout.
 FailureOr<std::string> runJointSolverBackend(llvm::StringRef problemJson);
+
+/// Minimum II feasible under a relaxation of the joint model that keeps only
+/// the resource-exclusivity constraints, i.e. `relaxed_lower_bound`.
+///
+/// A relaxation's feasible set is a superset of the full model's, so its
+/// optimum can never exceed the full model's:
+///
+///     relaxed_lower_bound <= II_full     (always, by construction)
+///
+/// That direction is the useful one. A violation is not a performance
+/// regression, it is a *soundness* failure: the full model found a schedule
+/// the relaxed model calls impossible, which can only happen if a constraint
+/// is mis-encoded or a "relaxation" is not actually a relaxation. Reporting
+/// `II_full - relaxed_lower_bound` as an improvement would be backwards; the
+/// gap is informational only, and a large gap can equally mean the dropped
+/// constraints are necessary.
+///
+/// Named `relaxed_` rather than `resource_` deliberately: not every
+/// constraint is assumption-gated, so this is not a pure resource-only bound.
+/// The cycle-domain bounds and the canonical-root pin remain hard assertions
+/// (the SMEM/TMEM ceilings also survive but go vacuous once their gated
+/// contributors are dropped). The bound is therefore tighter than a textbook
+/// resource-only relaxation — still a valid lower bound, and a stronger
+/// soundness test, but not comparable to a published one.
+FailureOr<int> runJointSolverRelaxedLowerBound(const DataDependenceGraph &ddg,
+                                               int minII,
+                                               int smemBudget = 232448,
+                                               int tmemColLimit = 512);
 
 } // namespace mlir::triton::gpu
 

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
@@ -11,6 +11,7 @@
 #include <climits>
 #include <cstdint>
 #include <numeric>
+#include <string>
 
 #define DEBUG_TYPE "modulo-scheduling-rau"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -402,18 +403,25 @@ FailureOr<ModuloScheduleResult> runRauIMS(const DataDependenceGraph &ddg,
 
 // ── Public entry point ──────────────────────────────────────────────────────
 
+std::string getActiveScheduleAlgo(llvm::StringRef forced) {
+  if (!forced.empty())
+    return forced.str();
+  auto algo = mlir::triton::tools::getStrEnv("TRITON_USE_MODULO_SCHEDULE");
+  return algo.empty() ? "rau" : algo;
+}
+
 FailureOr<ModuloScheduleResult>
-runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
-                    int maxBacktracks, int minIIOverride) {
+runModuloScheduling(const DataDependenceGraph &ddg, llvm::StringRef algo,
+                    int maxII, int maxBacktracks, int minIIOverride) {
   const int computedMinII = ddg.computeMinII();
   if (computedMinII <= 0)
     return failure();
   const int minII = std::max(computedMinII, minIIOverride);
-  auto algo = mlir::triton::tools::getStrEnv("TRITON_USE_MODULO_SCHEDULE");
+  const std::string resolvedAlgo = getActiveScheduleAlgo(algo);
 
   // The complete solver computes its own true feasibility bound. Dispatch it
   // before the heuristic maxII window, which can discard feasible schedules.
-  if (algo == "joint_solver") {
+  if (resolvedAlgo == "joint_solver") {
     LLVM_DEBUG(DBGS() << "Using native Z3 joint solver\n");
     auto result = runJointSolverSchedule(
         ddg, minII, /*smemBudget=*/232448, /*tmemColLimit=*/512);
@@ -436,8 +444,8 @@ runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
   // multi-hundred-cycle op durations, so a fixed +10 window (classic CPU
   // modulo-scheduling folklore) is too narrow to absorb reservation-table
   // fragmentation when one pipeline is saturated (ResMII-bound with zero
-  // slack, e.g. layernorm's CUDA pipe). A complete (ILP-style) search has
-  // no such fragmentation failure mode and needs no window at all.
+  // slack, e.g. layernorm's CUDA pipe). Applies to the heuristic paths
+  // below only — the joint_solver path above needs no window (guard 2).
   maxII = std::min(maxII, minII + std::max(10, minII / 8));
 
   LLVM_DEBUG({
@@ -447,7 +455,7 @@ runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
            << " RecMII=" << ddg.computeRecMII() << "\n";
   });
 
-  // TRITON_USE_MODULO_SCHEDULE selects the scheduling algorithm:
+  // `algo` selects the scheduling algorithm:
   //   "joint_solver" → Native Z3 joint schedule and buffer-depth solver
   //   "sms"        → Swing Modulo Scheduling (Llosa et al., PACT 1996)
   //   "exhaustive" → Exhaustive search with joint memory feasibility
@@ -466,19 +474,19 @@ runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
     return std::move(result);
   };
 
-  if (algo == "exhaustive") {
+  if (resolvedAlgo == "exhaustive") {
     LLVM_DEBUG(DBGS() << "Using exhaustive search with memory feasibility\n");
     return validateResult(runExhaustiveSearch(ddg, maxII, /*smemBudget=*/232448,
                                /*tmemColLimit=*/512, minII));
   }
 
-  if (algo == "random") {
+  if (resolvedAlgo == "random") {
     LLVM_DEBUG(DBGS() << "Using random sampling search\n");
     return validateResult(runRandomSearch(ddg, maxII, /*smemBudget=*/232448,
                            /*tmemColLimit=*/512, /*numSamples=*/1000, minII));
   }
 
-  if (algo == "contracted") {
+  if (resolvedAlgo == "contracted") {
     LLVM_DEBUG(DBGS() << "Using contracted-graph two-stage search\n");
     // Contracted mode assigns cycles with a reduced (contracted) latency model
     // and validates its own dependences (see ContractedGraphScheduler.md). The
@@ -487,7 +495,7 @@ runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
     return runContractedSearch(ddg, maxII);
   }
 
-  if (algo == "sms") {
+  if (resolvedAlgo == "sms") {
     LLVM_DEBUG(DBGS() << "Using Swing Modulo Scheduling (SMS)\n");
     return validateResult(runSMS(ddg, minII, maxII));
   }

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.cpp
@@ -3,6 +3,7 @@
 #include "ModuloReservationTable.h"
 
 #include "ExhaustiveScheduler.h"
+#include "JointSolverScheduler.h"
 #include "SwingScheduler.h"
 #include "triton/Tools/Sys/GetEnv.h"
 #include "llvm/Support/Debug.h"
@@ -251,9 +252,9 @@ static int computeEarliestStart(unsigned nodeIdx,
   return earliest;
 }
 
-static FailureOr<ModuloScheduleResult> runRauIMS(const DataDependenceGraph &ddg,
-                                                 int minII, int maxII,
-                                                 int maxBacktracks) {
+FailureOr<ModuloScheduleResult> runRauIMS(const DataDependenceGraph &ddg,
+                                          int minII, int maxII,
+                                          int maxBacktracks) {
   LLVM_DEBUG(DBGS() << "Computing critical path heights...\n");
   auto heights = ddg.computeCriticalPathHeights();
   LLVM_DEBUG(DBGS() << "Heights computed for " << heights.size() << " nodes\n");
@@ -408,6 +409,23 @@ runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
   if (computedMinII <= 0)
     return failure();
   const int minII = std::max(computedMinII, minIIOverride);
+  auto algo = mlir::triton::tools::getStrEnv("TRITON_USE_MODULO_SCHEDULE");
+
+  // The complete solver computes its own true feasibility bound. Dispatch it
+  // before the heuristic maxII window, which can discard feasible schedules.
+  if (algo == "joint_solver") {
+    LLVM_DEBUG(DBGS() << "Using native Z3 joint solver\n");
+    auto result = runJointSolverSchedule(
+        ddg, minII, /*smemBudget=*/232448, /*tmemColLimit=*/512);
+    if (failed(result))
+      return failure();
+    if (!tryRepairModuloSchedule(ddg, *result)) {
+      LLVM_DEBUG(DBGS() << "Rejecting invalid final schedule\n");
+      return failure();
+    }
+    return result;
+  }
+
   if (maxII <= 0)
     maxII = 2 * minII;
   else if (maxII < minII)
@@ -430,12 +448,12 @@ runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
   });
 
   // TRITON_USE_MODULO_SCHEDULE selects the scheduling algorithm:
+  //   "joint_solver" → Native Z3 joint schedule and buffer-depth solver
   //   "sms"        → Swing Modulo Scheduling (Llosa et al., PACT 1996)
   //   "exhaustive" → Exhaustive search with joint memory feasibility
   //   "random"     → Random sampling with greedy placement
   //   "contracted" → Two-stage GEMM search on a contracted compute graph
   //   "1" or other → Rau's Iterative Modulo Scheduling (Rau, 1994)
-  auto algo = mlir::triton::tools::getStrEnv("TRITON_USE_MODULO_SCHEDULE");
 
   auto validateResult = [&](FailureOr<ModuloScheduleResult> result)
       -> FailureOr<ModuloScheduleResult> {
@@ -476,6 +494,210 @@ runModuloScheduling(const DataDependenceGraph &ddg, int maxII,
 
   LLVM_DEBUG(DBGS() << "Using Rau's Iterative Modulo Scheduling (IMS)\n");
   return validateResult(runRauIMS(ddg, minII, maxII, maxBacktracks));
+}
+
+// ── Baseline comparison (M2 acceptance criteria) ────────────────────────────
+
+bool isLegalModuloSchedule(const DataDependenceGraph &ddg,
+                           const ModuloScheduleResult &schedule) {
+  if (!isValidModuloSchedule(ddg, schedule))
+    return false;
+  ModuloReservationTable table(schedule.II);
+  for (const auto &node : ddg.getNodes()) {
+    auto cycleIt = schedule.nodeToCycle.find(node.idx);
+    if (cycleIt == schedule.nodeToCycle.end() || cycleIt->second < 0)
+      return false;
+    if (node.pipeline == HWPipeline::NONE)
+      continue;
+    int duration = getReservationDuration(node);
+    if (duration > schedule.II ||
+        !table.isIntervalFree(cycleIt->second, node.pipeline, duration))
+      return false;
+    table.reserve(cycleIt->second, node.pipeline, node.idx, duration);
+  }
+  return true;
+}
+
+std::optional<int>
+BaselineComparisonReport::baselineII(llvm::StringRef name) const {
+  for (const BaselineII &entry : baselines)
+    if (entry.name == name)
+      return entry.ii;
+  return std::nullopt;
+}
+
+bool BaselineComparisonReport::improvesOnRau() const {
+  auto rau = baselineII("rau");
+  return jointII && rau && *jointII < *rau;
+}
+
+bool BaselineComparisonReport::regressesOnRau() const {
+  auto rau = baselineII("rau");
+  return jointII && rau && *jointII > *rau;
+}
+
+bool BaselineComparisonReport::isMinIIBound() const {
+  if (minII <= 0 || !jointII || *jointII != minII)
+    return false;
+  for (const BaselineII &entry : baselines)
+    if (entry.ii && *entry.ii != minII)
+      return false;
+  return true;
+}
+
+bool baselineReportRequested() {
+  return !mlir::triton::tools::getStrEnv("TRITON_MODULO_BASELINE_REPORT")
+              .empty();
+}
+
+namespace {
+
+/// Run one backend and keep its II only if the schedule it produced is legal.
+/// Note this uses the in-tree checker rather than Z3JointSolutionValidator:
+/// the two enforce the same two properties for the v1 model (dependences +
+/// exclusive modular reservation), and the in-tree one keeps every baseline
+/// row available in builds without Z3, where only the joint row drops out.
+BaselineII runBaseline(llvm::StringRef name, const DataDependenceGraph &ddg,
+                       FailureOr<ModuloScheduleResult> scheduled) {
+  if (failed(scheduled))
+    return BaselineII{name, std::nullopt, "no schedule found"};
+  if (!isLegalModuloSchedule(ddg, *scheduled))
+    return BaselineII{name, std::nullopt, "schedule failed validation"};
+  return BaselineII{name, scheduled->II, ""};
+}
+
+/// Right-justify `text` in `width` columns, always leaving at least one space
+/// so adjacent cells never run together when a value overflows the column.
+void printCell(llvm::raw_ostream &os, llvm::StringRef text, size_t width) {
+  os.indent(
+      static_cast<unsigned>(width > text.size() ? width - text.size() : 1))
+      << text;
+}
+
+void printCell(llvm::raw_ostream &os, std::optional<int> value, size_t width) {
+  printCell(os, value ? std::to_string(*value) : std::string("-"), width);
+}
+
+constexpr size_t kFixtureWidth = 22;
+constexpr size_t kNumberWidth = 12;
+
+} // namespace
+
+BaselineComparisonReport compareAgainstBaselines(const DataDependenceGraph &ddg,
+                                                 llvm::StringRef fixture) {
+  BaselineComparisonReport report;
+  report.fixture = fixture.str();
+
+  const int minII = ddg.computeMinII();
+  if (minII <= 0 || ddg.getNumNodes() == 0)
+    return report;
+  report.minII = minII;
+  // Exactly the window `runModuloScheduling` gives the heuristic backends
+  // (guard 2). The whole point of the Rau row is that it is what the compiler
+  // would otherwise have done, so it must be run with the production bound —
+  // a roomier window would quietly flatter Rau, a tighter one would rig the
+  // comparison in the solver's favour. The joint solver and the relaxed bound
+  // compute their own true feasibility bounds and take no window.
+  const int heuristicMaxII =
+      std::min(2 * minII, minII + std::max(10, minII / 8));
+
+  if (auto joint = runJointSolverSchedule(ddg, minII);
+      succeeded(joint) && isLegalModuloSchedule(ddg, *joint))
+    report.jointII = joint->II;
+
+  if (auto bound = runJointSolverRelaxedLowerBound(ddg, minII);
+      succeeded(bound))
+    report.relaxedLowerBound = *bound;
+
+  report.baselines.push_back(runBaseline(
+      "rau", ddg, runRauIMS(ddg, minII, heuristicMaxII, /*maxBacktracks=*/20)));
+  report.baselines.push_back(
+      runBaseline("sms", ddg, runSMS(ddg, minII, heuristicMaxII)));
+  // Exhaustive bails out above its node/MMA ceiling, so an absent row here is
+  // expected on anything but a small loop. Reported for free context: where it
+  // does terminate it brackets the optimum from the other side.
+  report.baselines.push_back(runBaseline(
+      "exhaustive", ddg,
+      runExhaustiveSearch(ddg, heuristicMaxII, /*smemBudget=*/232448,
+                          /*tmemColLimit=*/512, minII)));
+  return report;
+}
+
+void printBaselineComparison(llvm::raw_ostream &os,
+                             const BaselineComparisonReport &report) {
+  auto printFixtureCell = [&](llvm::StringRef text) {
+    os << "  " << text.substr(0, kFixtureWidth);
+    os.indent(static_cast<unsigned>(
+        text.size() < kFixtureWidth ? kFixtureWidth - text.size() : 1));
+  };
+
+  os << "modulo-baseline-report: " << report.fixture << "\n";
+  printFixtureCell("fixture");
+  printCell(os, llvm::StringRef("MinII"), kNumberWidth);
+  printCell(os, llvm::StringRef("II_full"), kNumberWidth);
+  printCell(os, llvm::StringRef("relaxed_LB"), kNumberWidth);
+  for (const BaselineII &entry : report.baselines)
+    printCell(os, "II_" + entry.name.str(), kNumberWidth);
+  os << "\n";
+
+  printFixtureCell(report.fixture);
+  printCell(os, report.minII, kNumberWidth);
+  printCell(os, report.jointII, kNumberWidth);
+  printCell(os, report.relaxedLowerBound, kNumberWidth);
+  for (const BaselineII &entry : report.baselines)
+    printCell(os, entry.ii, kNumberWidth);
+  os << "\n";
+
+  for (const BaselineII &entry : report.baselines)
+    if (!entry.ii && !entry.note.empty())
+      os << "  note: " << entry.name << ": " << entry.note << "\n";
+
+  // Criterion 1 — soundness. A relaxation's feasible set is a superset of the
+  // full model's, so its optimum can never exceed the full model's. Violation
+  // means a constraint is mis-encoded, NOT that the solver got slower.
+  os << "  soundness (II_full >= relaxed_LB): ";
+  if (!report.soundnessCheckable())
+    os << "SKIP (joint solver or relaxed bound unavailable)\n";
+  else if (report.soundnessHolds())
+    os << "PASS (gap " << *report.jointII - *report.relaxedLowerBound << ")\n";
+  else
+    os << "FAIL\n";
+
+  // Criterion 2 has two halves, kept separate so a tie can never be read as
+  // the acceptance criterion being met. Rau is Triton's current default
+  // scheduler and the path the joint solver's own fallback takes.
+  auto rau = report.baselineII("rau");
+
+  // 2a — no regression against Rau. Required on EVERY fixture.
+  os << "  no-regression (II_full <= II_rau): ";
+  if (!report.jointII || !rau)
+    os << "SKIP (joint solver or rau unavailable)\n";
+  else if (report.regressesOnRau())
+    os << "FAIL (" << *report.jointII << " > " << *rau << ")\n";
+  else
+    os << "PASS\n";
+
+  // 2b — the acceptance criterion proper: strict improvement on at least one
+  // fixture. A single loop cannot decide "at least one", so this line reports
+  // only what this fixture contributes. Reported, never tuned for: a NO is a
+  // real finding to take to the team, not a reason to adjust the fixture.
+  os << "  strict improvement (II_full < II_rau): ";
+  if (!report.jointII || !rau)
+    os << "SKIP (joint solver or rau unavailable)\n";
+  else if (report.improvesOnRau())
+    os << "YES (-" << *rau - *report.jointII << " vs rau)\n";
+  else if (report.isMinIIBound())
+    os << "NO (every backend is at MinII " << report.minII
+       << " — this fixture is MinII-bound and cannot separate schedulers; it "
+          "is not evidence about the solver)\n";
+  else
+    os << "NO (tied with rau at " << *rau << ")\n";
+
+  // The relaxed bound is NOT a pure resource-only model. Stated at the point
+  // of use so the number is never mistaken for a textbook one.
+  os << "  relaxed_LB keeps resource exclusivity only; still-hard: cycle "
+        "domain bounds, canonical-root pinning, SMEM/TMEM ceilings (vacuous "
+        "once their gated contributors are dropped)\n";
 }
 
 } // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
@@ -77,16 +77,28 @@ bool tryRepairModuloSchedule(int II, llvm::DenseMap<unsigned, int> &nodeToCycle,
 bool tryRepairModuloSchedule(const DataDependenceGraph &ddg,
                              ModuloScheduleResult &schedule);
 
-/// Run modulo scheduling on the DDG.
-/// Algorithm selected by TRITON_USE_MODULO_SCHEDULE env var value:
+/// Run modulo scheduling on the DDG with the backend named by `algo`:
+///   "joint_solver" → native in-process Z3 solver; falls back to Rau on
+///                    failure
 ///   "sms"        → Swing Modulo Scheduling (Llosa et al., PACT 1996)
 ///   "exhaustive" → Exhaustive search with joint memory feasibility
 ///   "random"     → Random sampling with greedy placement
-///   "1" or other → Rau's Iterative Modulo Scheduling (Rau, 1994)
+///   "contracted" → Two-stage GEMM search on a contracted compute graph
+///   "rau", "1" or other → Rau's Iterative Modulo Scheduling (Rau, 1994)
+/// Empty resolves from TRITON_USE_MODULO_SCHEDULE (see getActiveScheduleAlgo).
+/// The backend is an argument rather than process state so two modules
+/// compiled concurrently in one process cannot observe each other's choice.
 /// maxII defaults to 2 * MinII. maxBacktracks limits ejection in Rau's IMS.
 FailureOr<ModuloScheduleResult>
-runModuloScheduling(const DataDependenceGraph &ddg, int maxII = 0,
-                    int maxBacktracks = 20, int minIIOverride = 0);
+runModuloScheduling(const DataDependenceGraph &ddg, llvm::StringRef algo,
+                    int maxII = 0, int maxBacktracks = 20,
+                    int minIIOverride = 0);
+
+/// Resolve the scheduling backend: `forced` if non-empty, else
+/// TRITON_USE_MODULO_SCHEDULE, else "rau". A pure function of its argument and
+/// the environment. A pass resolves it once and threads the result into both
+/// runModuloScheduling and its dump/diagnostic labels.
+std::string getActiveScheduleAlgo(llvm::StringRef forced = {});
 
 /// Rau's Iterative Modulo Scheduling (Rau, 1994) — Triton's default backend,
 /// and the fallback the joint solver drops to. Exposed so the baseline

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloReservationTable.h
@@ -6,6 +6,11 @@
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <optional>
+#include <string>
 
 namespace mlir::triton::gpu {
 
@@ -82,6 +87,74 @@ bool tryRepairModuloSchedule(const DataDependenceGraph &ddg,
 FailureOr<ModuloScheduleResult>
 runModuloScheduling(const DataDependenceGraph &ddg, int maxII = 0,
                     int maxBacktracks = 20, int minIIOverride = 0);
+
+/// Rau's Iterative Modulo Scheduling (Rau, 1994) — Triton's default backend,
+/// and the fallback the joint solver drops to. Exposed so the baseline
+/// comparison can invoke it by name instead of going through the
+/// TRITON_USE_MODULO_SCHEDULE dispatch in `runModuloScheduling`.
+FailureOr<ModuloScheduleResult> runRauIMS(const DataDependenceGraph &ddg,
+                                          int minII, int maxII,
+                                          int maxBacktracks);
+
+/// Dependence legality (`isValidModuloSchedule`) AND exclusive modular
+/// reservation. Both halves are required before a scheduler's II may be
+/// compared against another's: a scheduler that emits an illegal schedule can
+/// report any II it likes, so an unvalidated II is meaningless.
+bool isLegalModuloSchedule(const DataDependenceGraph &ddg,
+                           const ModuloScheduleResult &schedule);
+
+/// One baseline scheduler's row in the comparison report.
+struct BaselineII {
+  llvm::StringRef name;
+  std::optional<int> ii; // nullopt: unavailable, failed, or invalid
+  llvm::StringRef note;  // why it is absent, when it is
+};
+
+/// II-level comparison of the native joint solver against the in-tree
+/// schedulers on one DDG, plus the relaxed lower bound. Backs the M2
+/// acceptance criteria; see docs/Diff8BaselineComparison.md for what each
+/// number does and does not claim.
+struct BaselineComparisonReport {
+  std::string fixture;
+  int minII{};
+  std::optional<int> jointII;
+  std::optional<int> relaxedLowerBound;
+  llvm::SmallVector<BaselineII, 3> baselines;
+
+  /// Every backend landed on MinII, so the fixture is MinII-bound and cannot
+  /// separate them: no scheduler can go lower, so a tie is a property of the
+  /// fixture, not evidence about the solver.
+  bool isMinIIBound() const;
+
+  /// `jointII >= relaxedLowerBound` — a soundness invariant, not an
+  /// improvement. Only meaningful when both numbers exist.
+  bool soundnessCheckable() const {
+    return jointII.has_value() && relaxedLowerBound.has_value();
+  }
+  bool soundnessHolds() const {
+    return !soundnessCheckable() || *jointII >= *relaxedLowerBound;
+  }
+
+  /// The acceptance gate: Rau is Triton's current default and the path the
+  /// joint solver's own fallback takes, so beating it is the claim that
+  /// matters operationally.
+  std::optional<int> baselineII(llvm::StringRef name) const;
+  bool improvesOnRau() const;  // strictly better
+  bool regressesOnRau() const; // strictly worse — a hard failure
+};
+
+/// True when TRITON_MODULO_BASELINE_REPORT is set. The comparison runs every
+/// backend on the DDG, so it is opt-in and never on a compile path.
+bool baselineReportRequested();
+
+BaselineComparisonReport compareAgainstBaselines(const DataDependenceGraph &ddg,
+                                                 llvm::StringRef fixture);
+
+/// Emit the comparison as a fixed-width table plus one verdict line per
+/// criterion. Written to `os` (the pass uses llvm::errs(), so the table does
+/// not interleave with triton-opt's IR on stdout).
+void printBaselineComparison(llvm::raw_ostream &os,
+                             const BaselineComparisonReport &report);
 
 /// Result of list scheduling for a non-loop region. The algorithm itself
 /// lives in `ListSchedulePass.cpp` (kept there so its debug output is

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleDriver.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleDriver.h
@@ -1,0 +1,64 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Shared driver for the modulo-scheduling pass family.
+//
+// ModuloSchedulePass (heuristic backends, env-selected) and
+// JointSolverSchedulePass (joint solver: schedule + warp partition) are thin
+// shells over the same orchestration: collect loops → schedule → global
+// warp-group partition → emit loop.stage/loop.cluster + buffer annotations.
+// ScheduleDriverOptions is the ONLY behavioural difference between them, so
+// both passes stay in lockstep on everything downstream consumes.
+
+#ifndef TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_MODULO_SCHEDULE_DRIVER_H
+#define TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_MODULO_SCHEDULE_DRIVER_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LogicalResult.h"
+
+#include <string>
+
+namespace mlir::triton::gpu {
+
+/// How the global warp-group partition (Pass B) is decided.
+enum class JointSolverMode {
+  /// Heuristic partitioners only (exhaustive scorer / greedy). The modulo
+  /// pass runs here. The driver promotes Off to V1Only whenever the active
+  /// schedule backend is "joint_solver" — heuristic partitioners are shaped by
+  /// Rau-conservative schedules and mis-partition the joint solver's
+  /// MinII-aggressive
+  /// ones (see runScheduleDriver), so Off is honoured only for heuristic
+  /// schedules.
+  Off,
+  /// Joint-solver re-solve: v2 (cycles + warp groups in one model) first,
+  /// v1 (warp groups only, cycles fixed) if v2 fails, exhaustive scorer if
+  /// both fail. The joint-solver pass default.
+  V2ThenV1,
+  /// v1 only (then exhaustive scorer). For A/B measurement.
+  V1Only,
+  /// v2 only (then exhaustive scorer). For A/B measurement.
+  V2Only,
+};
+
+struct ScheduleDriverOptions {
+  JointSolverMode jointMode = JointSolverMode::Off;
+  /// When non-empty, forces the per-loop scheduling algorithm for the whole
+  /// driver run, ignoring TRITON_USE_MODULO_SCHEDULE. The joint-solver pass
+  /// forces "joint_solver". The driver resolves this once and threads the
+  /// result down to every scheduling call, so a run's backend choice is never
+  /// visible to another module compiled concurrently in the same process. Any
+  /// future driver knob belongs here for the same reason — not in a global.
+  std::string forceScheduleAlgo;
+  /// Mirror of the passes' print-schedule-graph test option.
+  bool printScheduleGraph = false;
+  /// Mirror of the passes' data-partition-factor option (Pass A.5).
+  int dataPartitionFactor = 0;
+};
+
+/// Run the full Pass A orchestration on `moduleOp`. Returns failure on a
+/// diagnosed error (already emitted); callers map it to signalPassFailure.
+LogicalResult runScheduleDriver(ModuleOp moduleOp,
+                                const ScheduleDriverOptions &opts);
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_MODULO_SCHEDULE_DRIVER_H

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloScheduleGraph.h
@@ -349,6 +349,10 @@ struct ScheduleLoop {
     unsigned arriveAfterNodeId{UINT_MAX};
     unsigned waitBeforeNodeId{UINT_MAX};
 
+    // Authoritative dependence distance from the ScheduleEdge that caused
+    // this synchronization record.
+    unsigned distance{0};
+
     // For mbarrier: expected bytes the producer writes (for expect_tx).
     int64_t expectBytes{0};
   };

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -14,10 +14,14 @@
 
 #include "mlir/IR/Diagnostics.h"
 
+#include "JointSolverScheduler.h"
+#include "llvm/Support/JSON.h"
+
 #include "DataDependenceGraph.h"
 #include "JointSolverScheduler.h"
 #include "LatencyModel.h"
 #include "ModuloReservationTable.h"
+#include "ModuloScheduleDriver.h"
 #include "ModuloScheduleGraph.h"
 
 #include "mlir/Analysis/TopologicalSortUtils.h"
@@ -729,11 +733,12 @@ static void computeClusterIds(ttg::ScheduleLoop &loop) {
 }
 
 /// Build a ScheduleLoop for a loop. For super-nodes (nested loops), builds
-/// its own DDG and schedule recursively — works at any nesting depth.
+/// its own DDG and schedule recursively — works at any nesting depth, with
+/// `scheduleAlgo` (the driver's resolved backend) carried into every level.
 static unsigned buildScheduleLoop(
     scf::ForOp loop, const ttg::DataDependenceGraph &ddg,
     const ttg::ModuloScheduleResult &sched, ttg::ScheduleGraph &graph,
-    const ttg::LatencyModel &model,
+    const ttg::LatencyModel &model, StringRef scheduleAlgo,
     const llvm::DenseMap<Operation *, ttg::DataPartitionInfo> &partition =
         llvm::DenseMap<Operation *, ttg::DataPartitionInfo>()) {
   unsigned loopId = graph.addLoop(loop);
@@ -777,14 +782,15 @@ static unsigned buildScheduleLoop(
       if (auto innerLoop = dyn_cast<scf::ForOp>(ddgNode.op)) {
         // Pass A.5: build and schedule the child under the same partition so
         // its dumped II / ScheduleNodes match the partitioned inner MMA.
-        auto childDDG =
-            ttg::DataDependenceGraph::build(innerLoop, model, partition);
+        auto childDDG = ttg::DataDependenceGraph::build(
+            innerLoop, model, partition, scheduleAlgo);
         childDDG.applyDataPartition(partition);
         if (childDDG.getNumNodes() > 0) {
-          auto childSched = ttg::runModuloScheduling(childDDG);
+          auto childSched = ttg::runModuloScheduling(childDDG, scheduleAlgo);
           if (succeeded(childSched)) {
-            unsigned childId = buildScheduleLoop(
-                innerLoop, childDDG, *childSched, graph, model, partition);
+            unsigned childId =
+                buildScheduleLoop(innerLoop, childDDG, *childSched, graph,
+                                  model, scheduleAlgo, partition);
             sn.childPipelineId = childId;
             sn.prologueLatency = graph.getLoop(childId).prologueLatency;
           }
@@ -1254,8 +1260,10 @@ static void allocateBuffersForLoop(ttg::ScheduleLoop &loop,
       // lifetime-derived count so we don't over-allocate SMEM.
       llvm::DenseSet<unsigned> seen;
       seen.insert(node.id);
-      if (bufferReachesPartMMA(loop, node.id, plan, seen))
+      if (bufferReachesPartMMA(loop, node.id, plan, seen)) {
+        buf.explicitMinCount = 2;
         buf.count = std::max<unsigned>(buf.count, 2u);
+      }
     }
     // No artificial minimum: trust the lifetime-based count from
     // `computeBufferCount`. Earlier code applied `std::max(count, 3u)`
@@ -1271,8 +1279,10 @@ static void allocateBuffersForLoop(ttg::ScheduleLoop &loop,
     // blackwell_gemm_ws tutorial overlap pattern. extractBufferShape
     // already shrank the shape; bump count here, after computeBufferCount
     // overwrote whatever it had set.
-    if (getEpilogueSubtileForOp(node.op) > 1)
+    if (getEpilogueSubtileForOp(node.op) > 1) {
+      buf.explicitMinCount = 2;
       buf.count = std::max<unsigned>(buf.count, 2u);
+    }
 
     loop.buffers.push_back(buf);
     node.producesBuffer = bufId;
@@ -1351,6 +1361,8 @@ static void allocateBuffersForLoop(ttg::ScheduleLoop &loop,
     bar.id = barId;
     bar.kind = ttg::MemoryKind::BARRIER;
     bar.count = loop.buffers[dataBufId].count;
+    bar.requestedCount = loop.buffers[dataBufId].requestedCount;
+    bar.explicitMinCount = loop.buffers[dataBufId].explicitMinCount;
     bar.defOp = loop.buffers[dataBufId].defOp;
     bar.pairedBufferId = dataBufId;
     loop.buffers[dataBufId].pairedBufferId = barId;
@@ -1412,6 +1424,123 @@ static int64_t computeTotalSmem(const ttg::ScheduleLoop &loop) {
 }
 static int64_t computeTotalTmem(const ttg::ScheduleLoop &loop) {
   return computeTotalMemory(loop, ttg::MemoryKind::TMEM);
+}
+
+static llvm::DenseSet<unsigned>
+getSignalOnlyBufferIds(const ttg::ScheduleLoop &loop) {
+  llvm::DenseSet<unsigned> dataUsed;
+  for (const auto &node : loop.nodes) {
+    if (node.producesBuffer != UINT_MAX)
+      dataUsed.insert(node.producesBuffer);
+    for (unsigned bufferId : node.consumesBuffers)
+      dataUsed.insert(bufferId);
+  }
+  llvm::DenseSet<unsigned> forward, backward;
+  for (const auto &barrier : loop.crossGroupBarriers) {
+    if (barrier.pairedBufferId == UINT_MAX ||
+        barrier.producerNodeId >= loop.nodes.size() ||
+        barrier.consumerNodeId >= loop.nodes.size())
+      continue;
+    if (loop.nodes[barrier.producerNodeId].cycle >
+        loop.nodes[barrier.consumerNodeId].cycle)
+      backward.insert(barrier.pairedBufferId);
+    else
+      forward.insert(barrier.pairedBufferId);
+  }
+  llvm::DenseSet<unsigned> signalOnly;
+  for (unsigned bufferId : backward)
+    if (!forward.contains(bufferId) && !dataUsed.contains(bufferId))
+      signalOnly.insert(bufferId);
+  return signalOnly;
+}
+
+static bool emitterCanReuseSmemGroup(
+    const ttg::ScheduleLoop &loop, const ttg::PhysicalBuffer &physical) {
+  if (physical.memberBufferIds.size() < 2)
+    return true;
+  for (unsigned bufferId : physical.memberBufferIds) {
+    bool hasChannel = false;
+    for (const auto &barrier : loop.crossGroupBarriers) {
+      if (barrier.pairedBufferId != bufferId)
+        continue;
+      hasChannel = true;
+      if (barrier.producerNodeId >= loop.nodes.size() ||
+          barrier.consumerNodeId >= loop.nodes.size())
+        return false;
+      const auto &producer = loop.nodes[barrier.producerNodeId];
+      const auto &consumer = loop.nodes[barrier.consumerNodeId];
+      bool hardwareProducer =
+          producer.pipeline == ttg::HWPipeline::TMA ||
+          producer.pipeline == ttg::HWPipeline::TC ||
+          producer.pipeline == ttg::HWPipeline::MFMA;
+      if (producer.cycle > consumer.cycle || hardwareProducer)
+        return false;
+    }
+    if (!hasChannel)
+      return false;
+  }
+  return true;
+}
+
+static int64_t computeEmitterSmem(const ttg::ScheduleLoop &loop) {
+  int64_t total = computeTotalSmem(loop);
+  auto signalOnly = getSignalOnlyBufferIds(loop);
+  for (const auto &physical : loop.physicalBuffers) {
+    if (physical.kind != ttg::MemoryKind::SMEM)
+      continue;
+    int64_t privateBytes = 0;
+    for (unsigned bufferId : physical.memberBufferIds)
+      if (!signalOnly.contains(bufferId))
+        privateBytes += loop.buffers[bufferId].totalBytes();
+    if (privateBytes == 0)
+      total -= physical.totalBytes();
+    else if (!emitterCanReuseSmemGroup(loop, physical))
+      total += privateBytes - physical.totalBytes();
+  }
+  for (const auto &buffer : loop.buffers)
+    if (buffer.mergeGroupId == UINT_MAX && signalOnly.contains(buffer.id))
+      total -= buffer.totalBytes();
+  llvm::DenseSet<unsigned> seenPairedBuffers;
+  std::set<std::tuple<unsigned, unsigned, unsigned>> seenSignalBarriers;
+  for (const auto &barrier : loop.crossGroupBarriers) {
+    int64_t depth = std::max<unsigned>(barrier.depth, 1u);
+    if (barrier.pairedBufferId == UINT_MAX) {
+      auto key = std::make_tuple(barrier.producerNodeId,
+                                 barrier.consumerNodeId, barrier.distance);
+      if (seenSignalBarriers.insert(key).second)
+        total += depth * 8;
+      continue;
+    }
+    if (!seenPairedBuffers.insert(barrier.pairedBufferId).second)
+      continue;
+    bool fullAlreadyCounted = false;
+    if (barrier.pairedBufferId < loop.buffers.size()) {
+      unsigned barrierBufferId =
+          loop.buffers[barrier.pairedBufferId].pairedBufferId;
+      fullAlreadyCounted =
+          barrierBufferId < loop.buffers.size() &&
+          loop.buffers[barrierBufferId].kind == ttg::MemoryKind::BARRIER;
+    }
+    if (signalOnly.contains(barrier.pairedBufferId)) {
+      if (!fullAlreadyCounted)
+        total += depth * 8;
+      continue;
+    }
+    total += (fullAlreadyCounted ? 1 : 2) * depth * 8;
+  }
+  for (const auto &buffer : loop.buffers) {
+    if ((buffer.kind != ttg::MemoryKind::SMEM &&
+         buffer.kind != ttg::MemoryKind::TMEM) ||
+        buffer.shape.empty() || signalOnly.contains(buffer.id) ||
+        seenPairedBuffers.contains(buffer.id))
+      continue;
+    bool fullAlreadyCounted =
+        buffer.pairedBufferId < loop.buffers.size() &&
+        loop.buffers[buffer.pairedBufferId].kind == ttg::MemoryKind::BARRIER;
+    total += (fullAlreadyCounted ? 1 : 2) *
+             static_cast<int64_t>(buffer.count) * 8;
+  }
+  return total;
 }
 
 /// Compute the buffer lifetime (in cycles) for a given producer node.
@@ -2665,7 +2794,7 @@ constexpr double kInfeasiblePenalty = 1e7;
 // handwritten reference launches num_sms*4) can enable it via
 // TRITON_MODULO_CORES_PENALTY without a rebuild. case1's committed
 // footprint sits 12.9% above the 2-CTA SMEM bound (the nearest real
-// target).
+// target); see docs/SolverMigrationNotes.md.
 constexpr int kCoResidencyTargetCTAs = 2;
 static double coResidencyPenalty() {
   auto env = triton::tools::getStrEnv("TRITON_MODULO_CORES_PENALTY");
@@ -4440,6 +4569,7 @@ static void insertCrossGroupBarriers(ttg::ScheduleLoop &loop) {
     // wait BEFORE the consumer starts reading (= consumer node)
     bar.arriveAfterNodeId = edge.srcId;
     bar.waitBeforeNodeId = edge.dstId;
+    bar.distance = edge.distance;
 
     // For mbarrier: expected bytes from the paired buffer.
     if (kind == ttg::ScheduleLoop::BarrierKind::MBARRIER &&
@@ -4717,9 +4847,9 @@ static ttg::ScheduleGraph
 buildScheduleGraph(scf::ForOp loop, const ttg::DataDependenceGraph &ddg,
                    const ttg::ModuloScheduleResult &sched,
                    const ttg::LatencyModel &model,
-                   const DataPartitionPlan &plan) {
+                   const DataPartitionPlan &plan, StringRef scheduleAlgo) {
   ttg::ScheduleGraph graph;
-  buildScheduleLoop(loop, ddg, sched, graph, model, plan.mmaInfo);
+  buildScheduleLoop(loop, ddg, sched, graph, model, scheduleAlgo, plan.mmaInfo);
 
   // Decide epilogue subtiling from the cost model BEFORE buffer allocation, so
   // extractBufferShape shrinks the staging buffer ahead of the SMEM reducer.
@@ -4775,7 +4905,7 @@ buildScheduleGraph(scf::ForOp loop, const ttg::DataDependenceGraph &ddg,
   // runs them as a single global pass over all scheduled loops
   // (`applyGlobalWarpPartition`) so cross-loop coordination — e.g., an
   // outer-loop super-node consistent with the inner loop's MMA group — is
-  // possible. See `runOnOperation`.
+  // possible. See `runScheduleDriver`.
   return graph;
 }
 
@@ -4796,23 +4926,25 @@ struct ScheduleResult {
 /// info (printed only for `node.isSuperNode`) is naturally a no-op for
 /// inner loops, so no branching is needed.
 ///
-/// `label` is used in diagnostics ("Loop" or "Outer"). `printScheduleGraph`
-/// is the test-only knob from the parent pass (dumps the graph to errs
-/// unconditionally for lit tests in opt builds).
+/// `label` is used in diagnostics ("Loop" or "Outer"). `scheduleAlgo` is the
+/// driver's resolved backend. `printScheduleGraph` is the test-only knob from
+/// the parent pass (dumps the graph to errs unconditionally for lit tests in
+/// opt builds).
 ///
-/// Lowering is intentionally NOT done here — `runOnOperation` runs a single
+/// Lowering is intentionally NOT done here — `runScheduleDriver` runs a single
 /// lower-or-emit phase after the iteration loop converges, so the schedule
 /// build stays cheap and idempotent inside the iteration.
 static std::optional<ScheduleResult>
 scheduleOneLoop(scf::ForOp loop, const ttg::LatencyModel &model,
                 triton::ModuleAxisInfoAnalysis &axisInfo, StringRef label,
-                const DataPartitionPlan &plan,
+                const DataPartitionPlan &plan, StringRef scheduleAlgo,
                 bool printScheduleGraph = false) {
   // Pass A.5: thread the partition into build() so any inner super-node's
   // innerII is computed from the PARTITIONED inner schedule; then tag this
   // loop's own MMA bundle(s) so II/ResMII and the dumped ScheduleNode reflect
   // the N hardware issues. No-op when this loop has no partitioned MMA.
-  auto ddg = ttg::DataDependenceGraph::build(loop, model, plan.mmaInfo);
+  auto ddg =
+      ttg::DataDependenceGraph::build(loop, model, plan.mmaInfo, scheduleAlgo);
   if (ddg.getNumNodes() == 0)
     return std::nullopt;
 
@@ -4881,7 +5013,7 @@ scheduleOneLoop(scf::ForOp loop, const ttg::LatencyModel &model,
                                  ttg::compareAgainstBaselines(ddg, fixture));
   }
 
-  auto schedResult = ttg::runModuloScheduling(ddg);
+  auto schedResult = ttg::runModuloScheduling(ddg, scheduleAlgo);
   if (failed(schedResult)) {
     LDBG(label << " scheduling FAILED");
     return std::nullopt;
@@ -4912,7 +5044,8 @@ scheduleOneLoop(scf::ForOp loop, const ttg::LatencyModel &model,
     }
   });
 
-  auto graph = buildScheduleGraph(loop, ddg, *schedResult, model, plan);
+  auto graph =
+      buildScheduleGraph(loop, ddg, *schedResult, model, plan, scheduleAlgo);
 
   LLVM_DEBUG({
     llvm::dbgs() << "[PASS-A] === " << label << " ScheduleGraph ===\n";
@@ -4955,10 +5088,10 @@ static void scheduleAndRecord(scf::ForOp loop, StringRef label, bool isOuter,
                               const ttg::LatencyModel &model,
                               triton::ModuleAxisInfoAnalysis &axisInfo,
                               const DataPartitionPlan &plan,
-                              bool printScheduleGraph,
+                              StringRef scheduleAlgo, bool printScheduleGraph,
                               SmallVectorImpl<ScheduledLoop> &out) {
-  auto result =
-      scheduleOneLoop(loop, model, axisInfo, label, plan, printScheduleGraph);
+  auto result = scheduleOneLoop(loop, model, axisInfo, label, plan,
+                                scheduleAlgo, printScheduleGraph);
   if (!result)
     return;
   std::optional<ttg::ModuloScheduleResult> outerSched;
@@ -6140,8 +6273,12 @@ static void unifyNestEpilogueWarpGroup(ttg::ScheduleGraph &graph) {
 ///
 /// `TRITON_MODULO_EXHAUSTIVE_PARTITION=0|off|false` opts into the greedy
 /// fallback partitioner. Default is the exhaustive Phase 4 search.
-static void
-applyGlobalWarpPartition(MutableArrayRef<ScheduledLoop> scheduledLoops) {
+/// `jointMode` (set by the joint-solver pass, Off under the modulo pass)
+/// engages the joint-solver partition above; each per-loop solver failure
+/// falls back down the chain to the exhaustive scorer.
+static LogicalResult
+applyGlobalWarpPartition(MutableArrayRef<ScheduledLoop> scheduledLoops,
+                         ttg::JointSolverMode jointMode) {
   auto exhaustiveEnv =
       triton::tools::getStrEnv("TRITON_MODULO_EXHAUSTIVE_PARTITION");
   bool useGreedy = (exhaustiveEnv == "0" || exhaustiveEnv == "false" ||
@@ -6150,10 +6287,30 @@ applyGlobalWarpPartition(MutableArrayRef<ScheduledLoop> scheduledLoops) {
   // alongside every OTHER loop's buffers (nested/sibling loops coexist in
   // the CTA — the budget reducers already enforce the limit jointly, see
   // reduceBuffersForGlobalBudget; the channel-capacity gate must too).
-  int64_t allLoopsSmem = 0;
-  for (auto &sl : scheduledLoops)
-    for (auto &schedLoop : sl.graph.loops)
-      allLoopsSmem += computeTotalSmem(schedLoop);
+  auto computeReservedSmem = [&](ttg::ScheduleLoop &current) {
+    int64_t total = 0;
+    Operation *currentOp =
+        current.forOp ? current.forOp.getOperation() : nullptr;
+    llvm::DenseMap<Operation *, int64_t> bytesByLoop;
+    for (auto &sl : scheduledLoops) {
+      for (auto &candidate : sl.graph.loops) {
+        Operation *candidateOp =
+            candidate.forOp ? candidate.forOp.getOperation() : nullptr;
+        if (&candidate == &current ||
+            (currentOp && candidateOp == currentOp))
+          continue;
+        int64_t bytes = computeTotalSmem(candidate);
+        if (candidateOp)
+          bytesByLoop[candidateOp] =
+              std::max(bytesByLoop.lookup(candidateOp), bytes);
+        else
+          total += bytes;
+      }
+    }
+    for (const auto &[_, bytes] : bytesByLoop)
+      total += bytes;
+    return total;
+  };
   for (auto &sl : scheduledLoops) {
     for (auto &schedLoop : sl.graph.loops) {
       if (schedLoop.II <= 0)
@@ -6171,11 +6328,34 @@ applyGlobalWarpPartition(MutableArrayRef<ScheduledLoop> scheduledLoops) {
       // on separate warp groups frees the compute warps and removes the
       // in-stream store drain (measured ~1.2x over 1-WG software
       // pipelining).
-      if (useGreedy) {
+      // TRITON_MODULO_EXHAUSTIVE_PARTITION=0 selects the greedy heuristic,
+      // but only WITHIN heuristic partitioning: when a joint mode is active
+      // (the joint pass, or the joint_solver-schedule promotion in
+      // runScheduleDriver) the env var must not silently disable the
+      // joint-solver partition — heuristics on a joint-solver schedule
+      // re-create the softmax-cut failure class. It instead picks which
+      // heuristic the joint chain falls back to.
+      if (useGreedy && jointMode == ttg::JointSolverMode::Off) {
         partitionIntoWarpGroups(schedLoop);
       } else {
-        partitionExhaustive(schedLoop,
-                            allLoopsSmem - computeTotalSmem(schedLoop));
+        int64_t reserved = computeReservedSmem(schedLoop);
+        // Joint-solver modes: v2 solves cycles + warp groups in one model,
+        // v1 solves warp groups with cycles fixed. The default chain tries
+        // v2 then v1; both fall back to the heuristics (greedy when
+        // requested, exhaustive scorer otherwise).
+        bool jointDone = false;
+        if (jointMode == ttg::JointSolverMode::V2ThenV1 ||
+            jointMode == ttg::JointSolverMode::V2Only)
+          jointDone = partitionJointSolver(schedLoop, reserved, /*v2=*/true);
+        if (!jointDone && (jointMode == ttg::JointSolverMode::V2ThenV1 ||
+                           jointMode == ttg::JointSolverMode::V1Only))
+          jointDone = partitionJointSolver(schedLoop, reserved, /*v2=*/false);
+        if (!jointDone) {
+          if (useGreedy)
+            partitionIntoWarpGroups(schedLoop);
+          else
+            partitionExhaustive(schedLoop, reserved);
+        }
       }
       demoteScalarArithToInfra(schedLoop);
       propagateWarpGroupToInfraOps(schedLoop);
@@ -6213,7 +6393,57 @@ applyGlobalWarpPartition(MutableArrayRef<ScheduledLoop> scheduledLoops) {
         buf.mergeGroupId = UINT_MAX;
       schedLoop.physicalBuffers.clear();
       mergeNonOverlappingBuffers(schedLoop);
+      finalizeLoweringPlanStatus(schedLoop);
     }
+  int64_t finalSmem = 0;
+  ttg::ScheduleLoop *diagnosticLoop = nullptr;
+  llvm::DenseMap<Operation *, int64_t> smemByLoop;
+  llvm::DenseMap<Operation *, int64_t> tmemByLoop;
+  for (auto &sl : scheduledLoops) {
+    for (auto &schedLoop : sl.graph.loops) {
+      Operation *loopOp =
+          schedLoop.forOp ? schedLoop.forOp.getOperation() : nullptr;
+      if (!diagnosticLoop)
+        diagnosticLoop = &schedLoop;
+      int64_t loopSmem = computeEmitterSmem(schedLoop);
+      int64_t finalTmem = computeTotalTmem(schedLoop);
+      if (loopOp) {
+        smemByLoop[loopOp] = std::max(smemByLoop.lookup(loopOp), loopSmem);
+        tmemByLoop[loopOp] = std::max(tmemByLoop.lookup(loopOp), finalTmem);
+      } else {
+        finalSmem += loopSmem;
+      }
+      if (!loopOp && finalTmem > kTmemBudgetBytes) {
+        if (schedLoop.forOp)
+          schedLoop.forOp.emitError()
+              << "final lowering requires " << finalTmem
+              << " bytes of TMEM, exceeding the " << kTmemBudgetBytes
+              << "-byte budget";
+        return failure();
+      }
+    }
+  }
+  for (const auto &[_, bytes] : smemByLoop)
+    finalSmem += bytes;
+  for (const auto &[_, bytes] : tmemByLoop) {
+    if (bytes <= kTmemBudgetBytes)
+      continue;
+    if (diagnosticLoop && diagnosticLoop->forOp)
+      diagnosticLoop->forOp.emitError()
+          << "final lowering requires " << bytes
+          << " bytes of TMEM, exceeding the " << kTmemBudgetBytes
+          << "-byte budget";
+    return failure();
+  }
+  if (finalSmem > kSmemBudgetBytes()) {
+    if (diagnosticLoop && diagnosticLoop->forOp)
+      diagnosticLoop->forOp.emitError()
+          << "final lowering requires " << finalSmem
+          << " bytes of SMEM, exceeding the " << kSmemBudgetBytes()
+          << "-byte budget";
+    return failure();
+  }
+  return success();
 }
 
 /// Re-run the partition-dependent finalization on ONE loop for the top-N
@@ -6391,7 +6621,8 @@ static bool dataPartitionAutoSearch(ModuleOp moduleOp, int optionFactor) {
 
 static DataPartitionPlan
 searchDataPartitionPlan(ModuleOp moduleOp, const ttg::LatencyModel &model,
-                        triton::ModuleAxisInfoAnalysis &axisInfo) {
+                        triton::ModuleAxisInfoAnalysis &axisInfo,
+                        StringRef scheduleAlgo) {
   // Baseline respects explicit pins: an MMA with tt.data_partition_factor keeps
   // that factor even before the search (the user asked for it); every other MMA
   // is N=1. Variants (computeDataPartitionPlanForN) layer the searched N onto
@@ -6465,10 +6696,12 @@ searchDataPartitionPlan(ModuleOp moduleOp, const ttg::LatencyModel &model,
         continue;
       if (c.hasInnerLoop)
         scheduleAndRecord(c.op, "Outer", /*isOuter=*/true, model, axisInfo,
-                          plan, /*printScheduleGraph=*/false, sls);
+                          plan, scheduleAlgo, /*printScheduleGraph=*/false,
+                          sls);
       else if (c.hasMMA || c.hasTMA)
         scheduleAndRecord(c.op, "Inner", /*isOuter=*/false, model, axisInfo,
-                          plan, /*printScheduleGraph=*/false, sls);
+                          plan, scheduleAlgo, /*printScheduleGraph=*/false,
+                          sls);
     }
     sc.scheduled = sls.size();
     for (const auto &sl : sls) {
@@ -6867,6 +7100,75 @@ void jsonDumpScheduleLoop(llvm::raw_ostream &os, const ttg::ScheduleLoop &sl,
   }
   os << "      ],\n";
 
+  // Symbolic lowering contract and its fixed-II shadow placement. The emitter
+  // still derives executable synchronization from cross_wg_barriers.
+  os << "      \"lowering_templates\": [";
+  for (size_t i = 0; i < sl.loweringTemplates.size(); ++i) {
+    const auto &loweringTemplate = sl.loweringTemplates[i];
+    if (i)
+      os << ", ";
+    os << "{\"id\": " << loweringTemplate.id << ", \"relation\": \""
+       << loweringRelationName(loweringTemplate.relation)
+       << "\", \"src_node\": " << loweringTemplate.srcNodeId
+       << ", \"dst_node\": " << loweringTemplate.dstNodeId
+       << ", \"src_cluster\": " << loweringTemplate.srcCluster
+       << ", \"dst_cluster\": " << loweringTemplate.dstCluster
+       << ", \"events\": [";
+    for (size_t j = 0; j < loweringTemplate.events.size(); ++j) {
+      const auto &event = loweringTemplate.events[j];
+      if (j)
+        os << ", ";
+      os << "{\"id\": " << event.id << ", \"kind\": \""
+         << loweringEventKindName(event.kind) << "\", \"owner\": \""
+         << loweringOwnerName(event.owner)
+         << "\", \"anchor_node\": " << event.anchorNodeId
+         << ", \"placement\": \"" << loweringPlacementName(event.placement)
+         << "\", \"pipeline\": \"" << ttg::getPipelineName(event.pipeline)
+         << "\", \"issue_duration\": " << event.issueDuration
+         << ", \"completion_latency\": " << event.completionLatency
+         << ", \"blocking\": " << (event.blocking ? "true" : "false")
+         << ", \"async\": " << (event.isAsync ? "true" : "false")
+         << ", \"distance\": " << event.distance
+         << ", \"frequency\": " << event.frequency << ", \"buffer_id\": "
+         << (event.bufferId == UINT_MAX ? std::string("null")
+                                        : std::to_string(event.bufferId))
+         << ", \"bytes\": " << event.bytes << ", \"depth\": " << event.depth
+         << ", \"semaphore\": \"" << loweringSemaphoreName(event.semaphore)
+         << "\", \"fusion_group\": "
+         << (event.fusionGroup == UINT_MAX ? std::string("null")
+                                           : std::to_string(event.fusionGroup))
+         << ", \"dedup_group\": "
+         << (event.dedupGroup == UINT_MAX ? std::string("null")
+                                          : std::to_string(event.dedupGroup))
+         << "}";
+    }
+    os << "]}";
+  }
+  os << "],\n";
+
+  os << "      \"lowering_plan\": {\"version\": \""
+     << jsonEscape(sl.loweringPlan.version) << "\", \"status\": \""
+     << loweringPlanStatusName(sl.loweringPlan.status)
+     << "\", \"templates\": [";
+  for (size_t i = 0; i < sl.loweringPlan.templates.size(); ++i) {
+    const auto &loweringTemplate = sl.loweringPlan.templates[i];
+    if (i)
+      os << ", ";
+    os << "{\"id\": " << loweringTemplate.id
+       << ", \"active\": " << (loweringTemplate.active ? "true" : "false")
+       << ", \"events\": [";
+    for (size_t j = 0; j < loweringTemplate.events.size(); ++j) {
+      const auto &event = loweringTemplate.events[j];
+      if (j)
+        os << ", ";
+      os << "{\"id\": " << event.id << ", \"cycle\": " << event.cycle
+         << ", \"wg\": " << event.warpGroup
+         << ", \"stream_order\": " << event.streamOrder << "}";
+    }
+    os << "]}";
+  }
+  os << "]},\n";
+
   // Graph: nodes + edges (first-class, from ScheduleGraph).
   os << "      \"graph\": {\n";
 
@@ -6944,7 +7246,15 @@ void jsonDumpScheduleLoop(llvm::raw_ostream &os, const ttg::ScheduleLoop &sl,
        << ", \"depth\": " << b.depth << ", \"paired_buffer_id\": "
        << (b.pairedBufferId == UINT_MAX ? std::string("null")
                                         : std::to_string(b.pairedBufferId))
-       << ", \"expect_bytes\": " << b.expectBytes << "}";
+       << ", \"expect_bytes\": " << b.expectBytes
+       << ", \"distance\": " << b.distance << ", \"arrive_after_node\": "
+       << (b.arriveAfterNodeId == UINT_MAX
+               ? std::string("null")
+               : std::to_string(b.arriveAfterNodeId))
+       << ", \"wait_before_node\": "
+       << (b.waitBeforeNodeId == UINT_MAX ? std::string("null")
+                                          : std::to_string(b.waitBeforeNodeId))
+       << "}";
   }
   os << (sl.crossGroupBarriers.empty() ? "" : "\n        ") << "]\n";
   os << "      }\n";
@@ -7314,7 +7624,8 @@ void jsonDumpDDGLoop(llvm::raw_ostream &os, const ttg::DataDependenceGraph &ddg,
 }
 
 void dumpDDGAsJSON(ModuleOp moduleOp, StringRef path,
-                   ArrayRef<ScheduledLoop> scheduledLoops) {
+                   ArrayRef<ScheduledLoop> scheduledLoops,
+                   StringRef scheduleAlgo) {
   tt::FuncOp kernelFn = findKernelFn(moduleOp);
   JsonDumpContext dc = buildJsonDumpContext(kernelFn, scheduledLoops);
 
@@ -7333,10 +7644,9 @@ void dumpDDGAsJSON(ModuleOp moduleOp, StringRef path,
   // config — global knobs that shape how the solver turns this DDG into a
   // ScheduleGraph (algorithm choice + memory budgets driving buffer sizing).
   {
-    std::string algo = triton::tools::getStrEnv("TRITON_USE_MODULO_SCHEDULE");
-    if (algo.empty())
-      algo = "rau";
-    os << "  \"config\": {\"schedule_algo\": \"" << jsonEscape(algo)
+    // The backend this run actually scheduled with — "joint_solver" under the
+    // joint-solver pass, whatever the env var says.
+    os << "  \"config\": {\"schedule_algo\": \"" << jsonEscape(scheduleAlgo)
        << "\", \"smem_budget_bytes\": " << kSmemBudgetBytes()
        << ", \"tmem_budget_bytes\": " << kTmemBudgetBytes << "},\n";
   }
@@ -7397,7 +7707,326 @@ void dumpScheduleGraphsJSON(ModuleOp moduleOp, StringRef path,
 // Pass A: Modulo Scheduling
 // ============================================================================
 
-/// The main pass.
+/// DDG transformation hooks for iterative refinement (shared driver).
+/// Return true if any DDG was modified (triggers re-scheduling).
+
+/// Pass A.5: Data partitioning — split MMA + companion loads into N
+/// parallel sub-chains so the MMA queue can issue concurrent partials
+/// (NUM_MMA_GROUPS-style on Blackwell). M1: detect candidates only.
+///
+/// A.5 partition helpers (annotatePartition, partitionDecisions_) deferred
+/// along with this stub — they reference ScheduleNode / ScheduleBuffer
+/// partition fields that are part of the A.5 follow-up.
+static bool
+applyDataPartitioning(ModuleOp moduleOp, const ttg::LatencyModel &model,
+                      MutableArrayRef<ScheduledLoop> scheduledLoops) {
+  // A.5 (TRITON_DATA_PARTITION_N) deferred to follow-up diff.
+  return false;
+}
+
+/// Pass A.7: Epilogue subtiling — split monolithic TMA stores into
+/// independent sub-chains for better pipeline interleaving.
+///
+/// M1: detect chain. M2: pick S. M3: annotate ScheduleGraph + shrink store
+/// buffer.
+///
+/// SINGLE-ITERATION MODE (see plan §"KNOWN LIMITATION"): this function
+/// always returns false. The Pass A iterative loop rebuilds DDG +
+/// ScheduleGraph from source TTGIR each iteration, and the global SMEM
+/// reducer runs BEFORE A.7's mutation — so re-running the loop with a
+/// memoized decision doesn't recover K-loop depth. The buffer-recovery
+/// feedback path is deferred to M4.
+static bool
+applyEpilogueSubtiling(ModuleOp moduleOp, const ttg::LatencyModel &model,
+                       MutableArrayRef<ScheduledLoop> scheduledLoops) {
+  // A.7 (TRITON_MODULO_EPILOGUE_SUBTILE) deferred to follow-up diff.
+  return false;
+}
+
+} // namespace
+
+/// Shared Pass A orchestration — the entire behavioural difference between
+/// ModuloSchedulePass and JointSolverSchedulePass is `opts` (see
+/// ModuloScheduleDriver.h). Defined outside the anonymous namespace (whose
+/// helpers stay visible for the rest of the TU) so the qualified name is
+/// legal.
+LogicalResult ttg::runScheduleDriver(ModuleOp moduleOp,
+                                     const ScheduleDriverOptions &opts) {
+  // Resolve the schedule backend once and pass it explicitly to everything
+  // below — including super-node child re-schedules deep in
+  // buildScheduleGraph. The joint-solver pass forces "joint_solver"; the
+  // modulo pass leaves selection to TRITON_USE_MODULO_SCHEDULE. Threading it
+  // (rather than parking it in a process-global) is what keeps two modules
+  // compiled concurrently in one process from stealing each other's backend.
+  const std::string scheduleAlgo =
+      ttg::getActiveScheduleAlgo(opts.forceScheduleAlgo);
+
+  // Schedule/partition capability coupling (2026-07-10): a joint-solver
+  // schedule presses II to the proven minimum, and the heuristic partitioners
+  // were shaped by Rau-conservative schedules — on FA the combination
+  // re-creates the softmax-cut failure class guard 1 used to fence (case3 at
+  // MinII with the heuristic partitioner: 292.9 TF vs 662 with the joint-solver
+  // partition, 2.23x). Joint-solver schedules therefore always get the
+  // joint-solver v1 partition: TRITON_USE_MODULO_SCHEDULE=joint_solver becomes
+  // "joint pass minus v2" instead of a trap, and Off keeps meaning "heuristic
+  // partition for heuristic schedules". See docs/SolverMigrationNotes.md
+  // (2026-07-10 second entry).
+  JointSolverMode jointMode = opts.jointMode;
+  if (jointMode == JointSolverMode::Off && scheduleAlgo == "joint_solver") {
+    LDBG("Joint-solver schedule backend active — promoting warp partition "
+         "from heuristic to joint-solver v1");
+    jointMode = JointSolverMode::V1Only;
+  }
+
+  ttg::NVLatencyModel model;
+  triton::ModuleAxisInfoAnalysis axisInfoAnalysis(moduleOp);
+
+  // Pass A.5: compute the data-partition plan once (module-stable). Threaded
+  // into per-loop scheduling so the inner-loop MMA bundle and the outer-loop
+  // TMEM accumulator buffer are both tagged for the emitter.
+  // TRITON_DATA_PARTITION_N=auto searches the candidate factors with the
+  // scheduler itself; otherwise the factor is user-resolved (option > attr
+  // > env), 1 = off.
+  DataPartitionPlan partitionPlan =
+      dataPartitionAutoSearch(moduleOp, opts.dataPartitionFactor)
+          ? searchDataPartitionPlan(moduleOp, model, axisInfoAnalysis,
+                                    scheduleAlgo)
+          : computeDataPartitionPlan(moduleOp, opts.dataPartitionFactor);
+
+  // ================================================================
+  // Iterative scheduling loop (design doc Pass A orchestrator)
+  //
+  // Each iteration: schedule → derive depths → check budget →
+  // apply DDG transformations → re-run if any DDG changed.
+  // Converges in 1-2 iterations.
+  // ================================================================
+  // Collect scheduling results across iterations. Only the LAST
+  // iteration's results are emitted — earlier iterations are discarded
+  // when DDG transformations trigger re-scheduling.
+  SmallVector<ScheduledLoop, 2> scheduledLoops;
+
+  constexpr int kMaxIterations = 3;
+  for (int iteration = 0; iteration < kMaxIterations; ++iteration) {
+    LDBG("=== Iterative scheduling: iteration " << iteration << " ===");
+    scheduledLoops.clear();
+
+    // Single walk: collect every scf::ForOp with its nesting context and
+    // direct-body flags. Sorted deepest-first so we schedule inner loops
+    // before their outer wrappers — the outer schedule consumes the inner
+    // II as a super-node latency.
+    auto candidates = collectCandidates(moduleOp);
+
+    // We currently support at most a 2-level loop nest (an inner compute
+    // loop optionally wrapped by an outer tile/persistent loop). Refuse
+    // anything deeper rather than silently mis-scheduling — the prologue
+    // expansion, super-node DDG, and outer-loop pipelining all assume
+    // depth <= 1 today.
+    for (const auto &c : candidates) {
+      if (c.depth >= 2) {
+        c.op->emitError("modulo scheduling: loop nesting depth ")
+            << c.depth << " not supported (max 2 levels)";
+        return failure();
+      }
+    }
+
+    // Single bottom-up pass over candidates. `collectCandidates`'s
+    // contract is that the result is sorted by depth non-increasing so an
+    // inner K-loop (depth=1) is visited before its outer tile loop
+    // (depth=0). The outer DDG promotes the inner loop to a super-node
+    // whose `innerII` is the inner schedule's II, so this order is
+    // required for correctness — not just a stylistic preference. The
+    // assert below makes that invariant verifiable at runtime in case
+    // the sort in `collectCandidates` ever drifts.
+    //
+    // hasInnerLoop is the inner-vs-outer signal:
+    //   * true  → wraps a nested scf.for → outer
+    //   * false → leaf → inner (only worth scheduling if it has compute)
+    // Inner-vs-outer differences (super-node print, retaining the raw
+    // ModuloScheduleResult for lowerOuterLoopPipeline) live inside
+    // scheduleAndRecord / ScheduledLoop — not the call site.
+    unsigned numInner = 0, numOuter = 0;
+    [[maybe_unused]] unsigned prevDepth = std::numeric_limits<unsigned>::max();
+    for (const auto &c : candidates) {
+      assert(c.depth <= prevDepth && "candidates must be sorted deepest-first");
+      prevDepth = c.depth;
+      if (c.hasExistingAnnotation) {
+        LDBG("Skipping loop with existing tt.autows annotations");
+        continue;
+      }
+      if (c.hasInnerLoop) {
+        scheduleAndRecord(c.op, "Outer", /*isOuter=*/true, model,
+                          axisInfoAnalysis, partitionPlan, scheduleAlgo,
+                          opts.printScheduleGraph, scheduledLoops);
+        ++numOuter;
+      } else if (c.hasMMA || c.hasTMA) {
+        scheduleAndRecord(c.op, "Inner", /*isOuter=*/false, model,
+                          axisInfoAnalysis, partitionPlan, scheduleAlgo,
+                          opts.printScheduleGraph, scheduledLoops);
+        ++numInner;
+      }
+    }
+    LDBG("Scheduled " << numInner << " inner loop(s), " << numOuter
+                      << " outer loop(s)");
+
+    // ================================================================
+    // Pass B: Global warp-group partition + cross-group barriers across
+    // all scheduled loops. Replaces the per-loop call that used to live
+    // inside `buildScheduleGraph` — moving it out of scheduling makes
+    // cross-loop coordination possible (e.g., outer-loop super-node
+    // matched to inner-loop MMA's warp group).
+    // ================================================================
+    // For top-N autotuning: snapshot each loop's pristine pre-partition
+    // graph (no warp-group assignment, no synthesized barriers/channels)
+    // before the winner is committed. Overwritten each iteration so it
+    // reflects the final converged schedule. Cheap value copy; only when
+    // multi-graph dump is requested.
+    if (getDumpTopN() > 1)
+      for (auto &sl : scheduledLoops)
+        sl.prePartitionGraph = sl.graph;
+    if (failed(applyGlobalWarpPartition(scheduledLoops, jointMode)))
+      return failure();
+
+    // ================================================================
+    // Iterative refinement: apply DDG transformations and check if
+    // we need to re-schedule.
+    // ================================================================
+    bool ddgChanged = false;
+    ddgChanged |= applyDataPartitioning(moduleOp, model, scheduledLoops);
+    ddgChanged |= applyEpilogueSubtiling(moduleOp, model, scheduledLoops);
+
+    if (!ddgChanged) {
+      LDBG("Converged after " << iteration + 1 << " iteration(s)");
+      break;
+    }
+
+    if (iteration + 1 >= kMaxIterations) {
+      LDBG("Hit iteration limit (" << kMaxIterations
+                                   << ") — keeping last valid schedule");
+      break;
+    }
+
+    LDBG("DDG changed by transformation — re-scheduling");
+  } // end iterative loop
+
+  // ================================================================
+  // Lower-or-emit phase. Runs ONCE after convergence so the iteration
+  // loop above stays a pure schedule-refinement loop (no IR rewrites
+  // beyond attribute clamping). For each scheduled loop, either:
+  //   * `useScheduleGraphLowering` (TRITON_MODULO_LOWER_SCHEDULE_GRAPH=1)
+  //     → directly lower to multi-buffered allocs / async TMA / barriers
+  //     / WS regions. compiler.py skips downstream WS+pipeliner.
+  //   * otherwise → emit `loop.stage`/`loop.cluster` annotations and let
+  //     the downstream WS+pipeliner consume them.
+  // For outer loops, lowering is additionally gated by
+  // TRITON_MODULO_OUTER_LOWERING and requires getMaxStage() >= 1.
+  // ================================================================
+  for (auto &sl : scheduledLoops) {
+    if (sl.isOuter) {
+      // Stage clamping + cluster renumbering applies to BOTH paths
+      // (annotation and lowered) — it sits between the schedule and the
+      // attrs that downstream consumers read, so do it here once.
+      clampOuterStagesAndClusters(sl.loop);
+    }
+    emitScheduleFromGraph(sl.loop, sl.graph, sl.ddg);
+    if (sl.isOuter) {
+      // tt.modulo_cycle is a scratch attr the outer DDG builder leaves
+      // behind; clean it up regardless of the lowering path.
+      for (auto &op : sl.loop.getBody()->without_terminator())
+        op.removeAttr("tt.modulo_cycle");
+    }
+  }
+
+  // Inner scf.for ops that are super-nodes in an outer schedule
+  // carry loop.stage/loop.cluster from the OUTER schedule — keep
+  // them so the outer pipeliner knows where the K-loop sits.
+
+  // Optional: dump the ScheduleGraph as JSON for the TLX emitter.
+  if (const char *path = std::getenv("TRITON_MODULO_DUMP_SCHEDULE")) {
+    int topN = getDumpTopN();
+    if (topN <= 1) {
+      // Legacy single-graph dump (the cost-model winner committed to IR).
+      dumpScheduleGraphAsJSON(moduleOp, path, scheduledLoops);
+    } else {
+      // Top-N autotuning: emit ALL variants into ONE file, pluralized
+      // (schedule_graph.json -> schedule_graphs.json), ordered best-predicted
+      // first (variant 0 == committed winner). An external harness reads the
+      // `variants` array, emits + runs each, and picks the empirical winner.
+      //
+      // How many variants we can actually produce: the min over schedulable
+      // loops of available candidate partitions. Loops that fell back to
+      // greedy or had < 2 clusters contribute no alternatives.
+      // Variant count = MAX over schedulable loops of available candidate
+      // partitions (capped at topN). A loop with a single fixed partition
+      // (e.g. <2 clusters) is held fixed across variants via index clamping
+      // below, so it no longer caps the dump. If a loop went to greedy and
+      // recorded no partition, we can't safely build alternatives → fall back
+      // to a single (committed-winner) variant.
+      size_t maxAvail = 0;
+      bool sawSchedulable = false, anyEmpty = false;
+      for (auto &sl : scheduledLoops)
+        for (auto &schedLoop : sl.graph.loops)
+          if (schedLoop.II > 0) {
+            sawSchedulable = true;
+            if (schedLoop.topPartitions.empty())
+              anyEmpty = true;
+            maxAvail = std::max(maxAvail, schedLoop.topPartitions.size());
+          }
+      size_t numVariants =
+          (!sawSchedulable || anyEmpty)
+              ? 1
+              : std::min<size_t>(topN, std::max<size_t>(1, maxAvail));
+
+      SmallVector<SmallVector<ScheduledLoop, 2>, 3> variants;
+      for (size_t k = 0; k < numVariants; ++k) {
+        // Variant 0 reuses the committed winner graph as-is; k >= 1 is built
+        // off the pristine pre-partition snapshot, re-finalized with
+        // candidate-k's partition. Only the fields the dumper reads (loop,
+        // isOuter, graph) are populated.
+        SmallVector<ScheduledLoop, 2> variant;
+        for (auto &sl : scheduledLoops) {
+          ScheduledLoop v;
+          v.loop = sl.loop;
+          v.isOuter = sl.isOuter;
+          if (k == 0) {
+            v.graph = sl.graph; // committed winner
+          } else {
+            v.graph = sl.prePartitionGraph; // pristine copy
+            for (size_t li = 0; li < v.graph.loops.size(); ++li) {
+              auto &dstLoop = v.graph.loops[li];
+              auto &liveLoop = sl.graph.loops[li];
+              if (dstLoop.II > 0 && !liveLoop.topPartitions.empty()) {
+                // Loops with their own candidate-k vary; loops with fewer
+                // candidates (a single fixed partition) clamp to their last
+                // one so they stay constant across variants.
+                size_t idx = std::min(k, liveLoop.topPartitions.size() - 1);
+                finalizeLoopPartitionForDump(dstLoop,
+                                             liveLoop.topPartitions[idx]);
+                if (idx < liveLoop.topPartitionCosts.size())
+                  dstLoop.partitionCost = liveLoop.topPartitionCosts[idx];
+              }
+            }
+          }
+          variant.push_back(std::move(v));
+        }
+        variants.push_back(std::move(variant));
+      }
+      dumpScheduleGraphsJSON(moduleOp, pluralDumpPath(path), variants);
+    }
+  }
+  // Optional: dump the pre-schedule DDG layer (the solver's input + the
+  // MinII analysis it derives) as JSON. This is everything needed to
+  // regenerate the ScheduleGraph from the DDG.
+  if (const char *path = std::getenv("TRITON_MODULO_DUMP_DDG")) {
+    dumpDDGAsJSON(moduleOp, path, scheduledLoops, scheduleAlgo);
+  }
+  return success();
+}
+
+namespace {
+
+/// The main pass — a thin shell over the shared driver with the joint
+/// solver Off and algorithm selection left to TRITON_USE_MODULO_SCHEDULE.
+/// Its joint-solver sibling lives in JointSolverSchedulePass.cpp.
 struct ModuloSchedulePass
     : public PassWrapper<ModuloSchedulePass, OperationPass<ModuleOp>> {
 
@@ -7430,283 +8059,12 @@ struct ModuloSchedulePass
           "MMAs."),
       llvm::cl::init(0)};
 
-  /// DDG transformation hooks for iterative refinement.
-  /// Return true if any DDG was modified (triggers re-scheduling).
-
-  /// Pass A.5: Data partitioning — split MMA + companion loads into N
-  /// parallel sub-chains so the MMA queue can issue concurrent partials
-  /// (NUM_MMA_GROUPS-style on Blackwell). M1: detect candidates only.
-  bool applyDataPartitioning(ModuleOp moduleOp, const ttg::LatencyModel &model,
-                             MutableArrayRef<ScheduledLoop> scheduledLoops) {
-    // A.5 (TRITON_DATA_PARTITION_N) deferred to follow-up diff.
-    return false;
-  }
-
-  // A.5 partition helpers (annotatePartition, partitionDecisions_) deferred
-  // along with applyDataPartitioning above — they reference ScheduleNode /
-  // ScheduleBuffer partition fields that are part of the A.5 follow-up.
-
-  /// Pass A.7: Epilogue subtiling — split monolithic TMA stores into
-  /// independent sub-chains for better pipeline interleaving.
-  ///
-  /// M1: detect chain. M2: pick S. M3: annotate ScheduleGraph + shrink store
-  /// buffer.
-  ///
-  /// SINGLE-ITERATION MODE (see plan §"KNOWN LIMITATION"): this function
-  /// always returns false. The Pass A iterative loop rebuilds DDG +
-  /// ScheduleGraph from source TTGIR each iteration, and the global SMEM
-  /// reducer runs BEFORE A.7's mutation — so re-running the loop with a
-  /// memoized decision doesn't recover K-loop depth. The buffer-recovery
-  /// feedback path is deferred to M4.
-  bool applyEpilogueSubtiling(ModuleOp moduleOp, const ttg::LatencyModel &model,
-                              MutableArrayRef<ScheduledLoop> scheduledLoops) {
-    // A.7 (TRITON_MODULO_EPILOGUE_SUBTILE) deferred to follow-up diff.
-    return false;
-  }
-
   void runOnOperation() override {
-    auto moduleOp = getOperation();
-    ttg::NVLatencyModel model;
-    triton::ModuleAxisInfoAnalysis axisInfoAnalysis(moduleOp);
-
-    // Pass A.5: compute the data-partition plan once (module-stable). Threaded
-    // into per-loop scheduling so the inner-loop MMA bundle and the outer-loop
-    // TMEM accumulator buffer are both tagged for the emitter.
-    // TRITON_DATA_PARTITION_N=auto searches the candidate factors with the
-    // scheduler itself; otherwise the factor is user-resolved (option > attr
-    // > env), 1 = off.
-    DataPartitionPlan partitionPlan =
-        dataPartitionAutoSearch(moduleOp, dataPartitionFactor)
-            ? searchDataPartitionPlan(moduleOp, model, axisInfoAnalysis)
-            : computeDataPartitionPlan(moduleOp, dataPartitionFactor);
-
-    // ================================================================
-    // Iterative scheduling loop (design doc Pass A orchestrator)
-    //
-    // Each iteration: schedule → derive depths → check budget →
-    // apply DDG transformations → re-run if any DDG changed.
-    // Converges in 1-2 iterations.
-    // ================================================================
-    // Collect scheduling results across iterations. Only the LAST
-    // iteration's results are emitted — earlier iterations are discarded
-    // when DDG transformations trigger re-scheduling.
-    SmallVector<ScheduledLoop, 2> scheduledLoops;
-
-    constexpr int kMaxIterations = 3;
-    for (int iteration = 0; iteration < kMaxIterations; ++iteration) {
-      LDBG("=== Iterative scheduling: iteration " << iteration << " ===");
-      scheduledLoops.clear();
-
-      // Single walk: collect every scf::ForOp with its nesting context and
-      // direct-body flags. Sorted deepest-first so we schedule inner loops
-      // before their outer wrappers — the outer schedule consumes the inner
-      // II as a super-node latency.
-      auto candidates = collectCandidates(moduleOp);
-
-      // We currently support at most a 2-level loop nest (an inner compute
-      // loop optionally wrapped by an outer tile/persistent loop). Refuse
-      // anything deeper rather than silently mis-scheduling — the prologue
-      // expansion, super-node DDG, and outer-loop pipelining all assume
-      // depth <= 1 today.
-      for (const auto &c : candidates) {
-        if (c.depth >= 2) {
-          c.op->emitError("modulo scheduling: loop nesting depth ")
-              << c.depth << " not supported (max 2 levels)";
-          return signalPassFailure();
-        }
-      }
-
-      // Single bottom-up pass over candidates. `collectCandidates`'s
-      // contract is that the result is sorted by depth non-increasing so an
-      // inner K-loop (depth=1) is visited before its outer tile loop
-      // (depth=0). The outer DDG promotes the inner loop to a super-node
-      // whose `innerII` is the inner schedule's II, so this order is
-      // required for correctness — not just a stylistic preference. The
-      // assert below makes that invariant verifiable at runtime in case
-      // the sort in `collectCandidates` ever drifts.
-      //
-      // hasInnerLoop is the inner-vs-outer signal:
-      //   * true  → wraps a nested scf.for → outer
-      //   * false → leaf → inner (only worth scheduling if it has compute)
-      // Inner-vs-outer differences (super-node print, retaining the raw
-      // ModuloScheduleResult for lowerOuterLoopPipeline) live inside
-      // scheduleAndRecord / ScheduledLoop — not the call site.
-      unsigned numInner = 0, numOuter = 0;
-      [[maybe_unused]] unsigned prevDepth =
-          std::numeric_limits<unsigned>::max();
-      for (const auto &c : candidates) {
-        assert(c.depth <= prevDepth &&
-               "candidates must be sorted deepest-first");
-        prevDepth = c.depth;
-        if (c.hasExistingAnnotation) {
-          LDBG("Skipping loop with existing tt.autows annotations");
-          continue;
-        }
-        if (c.hasInnerLoop) {
-          scheduleAndRecord(c.op, "Outer", /*isOuter=*/true, model,
-                            axisInfoAnalysis, partitionPlan, printScheduleGraph,
-                            scheduledLoops);
-          ++numOuter;
-        } else if (c.hasMMA || c.hasTMA) {
-          scheduleAndRecord(c.op, "Inner", /*isOuter=*/false, model,
-                            axisInfoAnalysis, partitionPlan, printScheduleGraph,
-                            scheduledLoops);
-          ++numInner;
-        }
-      }
-      LDBG("Scheduled " << numInner << " inner loop(s), " << numOuter
-                        << " outer loop(s)");
-
-      // ================================================================
-      // Pass B: Global warp-group partition + cross-group barriers across
-      // all scheduled loops. Replaces the per-loop call that used to live
-      // inside `buildScheduleGraph` — moving it out of scheduling makes
-      // cross-loop coordination possible (e.g., outer-loop super-node
-      // matched to inner-loop MMA's warp group).
-      // ================================================================
-      // For top-N autotuning: snapshot each loop's pristine pre-partition
-      // graph (no warp-group assignment, no synthesized barriers/channels)
-      // before the winner is committed. Overwritten each iteration so it
-      // reflects the final converged schedule. Cheap value copy; only when
-      // multi-graph dump is requested.
-      if (getDumpTopN() > 1)
-        for (auto &sl : scheduledLoops)
-          sl.prePartitionGraph = sl.graph;
-      applyGlobalWarpPartition(scheduledLoops);
-
-      // ================================================================
-      // Iterative refinement: apply DDG transformations and check if
-      // we need to re-schedule.
-      // ================================================================
-      bool ddgChanged = false;
-      ddgChanged |= applyDataPartitioning(moduleOp, model, scheduledLoops);
-      ddgChanged |= applyEpilogueSubtiling(moduleOp, model, scheduledLoops);
-
-      if (!ddgChanged) {
-        LDBG("Converged after " << iteration + 1 << " iteration(s)");
-        break;
-      }
-
-      if (iteration + 1 >= kMaxIterations) {
-        LDBG("Hit iteration limit (" << kMaxIterations
-                                     << ") — keeping last valid schedule");
-        break;
-      }
-
-      LDBG("DDG changed by transformation — re-scheduling");
-    } // end iterative loop
-
-    // ================================================================
-    // Lower-or-emit phase. Runs ONCE after convergence so the iteration
-    // loop above stays a pure schedule-refinement loop (no IR rewrites
-    // beyond attribute clamping). For each scheduled loop, either:
-    //   * `useScheduleGraphLowering` (TRITON_MODULO_LOWER_SCHEDULE_GRAPH=1)
-    //     → directly lower to multi-buffered allocs / async TMA / barriers
-    //     / WS regions. compiler.py skips downstream WS+pipeliner.
-    //   * otherwise → emit `loop.stage`/`loop.cluster` annotations and let
-    //     the downstream WS+pipeliner consume them.
-    // For outer loops, lowering is additionally gated by
-    // TRITON_MODULO_OUTER_LOWERING and requires getMaxStage() >= 1.
-    // ================================================================
-    for (auto &sl : scheduledLoops) {
-      if (sl.isOuter) {
-        // Stage clamping + cluster renumbering applies to BOTH paths
-        // (annotation and lowered) — it sits between the schedule and the
-        // attrs that downstream consumers read, so do it here once.
-        clampOuterStagesAndClusters(sl.loop);
-      }
-      emitScheduleFromGraph(sl.loop, sl.graph, sl.ddg);
-      if (sl.isOuter) {
-        // tt.modulo_cycle is a scratch attr the outer DDG builder leaves
-        // behind; clean it up regardless of the lowering path.
-        for (auto &op : sl.loop.getBody()->without_terminator())
-          op.removeAttr("tt.modulo_cycle");
-      }
-    }
-
-    // Inner scf.for ops that are super-nodes in an outer schedule
-    // carry loop.stage/loop.cluster from the OUTER schedule — keep
-    // them so the outer pipeliner knows where the K-loop sits.
-
-    // Optional: dump the ScheduleGraph as JSON for the TLX emitter.
-    if (const char *path = std::getenv("TRITON_MODULO_DUMP_SCHEDULE")) {
-      int topN = getDumpTopN();
-      if (topN <= 1) {
-        // Legacy single-graph dump (the cost-model winner committed to IR).
-        dumpScheduleGraphAsJSON(moduleOp, path, scheduledLoops);
-      } else {
-        // Top-N autotuning: emit ALL variants into ONE file, pluralized
-        // (schedule_graph.json -> schedule_graphs.json), ordered best-predicted
-        // first (variant 0 == committed winner). An external harness reads the
-        // `variants` array, emits + runs each, and picks the empirical winner.
-        //
-        // How many variants we can actually produce: the min over schedulable
-        // loops of available candidate partitions. Loops that fell back to
-        // greedy or had < 2 clusters contribute no alternatives.
-        // Variant count = MAX over schedulable loops of available candidate
-        // partitions (capped at topN). A loop with a single fixed partition
-        // (e.g. <2 clusters) is held fixed across variants via index clamping
-        // below, so it no longer caps the dump. If a loop went to greedy and
-        // recorded no partition, we can't safely build alternatives → fall back
-        // to a single (committed-winner) variant.
-        size_t maxAvail = 0;
-        bool sawSchedulable = false, anyEmpty = false;
-        for (auto &sl : scheduledLoops)
-          for (auto &schedLoop : sl.graph.loops)
-            if (schedLoop.II > 0) {
-              sawSchedulable = true;
-              if (schedLoop.topPartitions.empty())
-                anyEmpty = true;
-              maxAvail = std::max(maxAvail, schedLoop.topPartitions.size());
-            }
-        size_t numVariants =
-            (!sawSchedulable || anyEmpty)
-                ? 1
-                : std::min<size_t>(topN, std::max<size_t>(1, maxAvail));
-
-        SmallVector<SmallVector<ScheduledLoop, 2>, 3> variants;
-        for (size_t k = 0; k < numVariants; ++k) {
-          // Variant 0 reuses the committed winner graph as-is; k >= 1 is built
-          // off the pristine pre-partition snapshot, re-finalized with
-          // candidate-k's partition. Only the fields the dumper reads (loop,
-          // isOuter, graph) are populated.
-          SmallVector<ScheduledLoop, 2> variant;
-          for (auto &sl : scheduledLoops) {
-            ScheduledLoop v;
-            v.loop = sl.loop;
-            v.isOuter = sl.isOuter;
-            if (k == 0) {
-              v.graph = sl.graph; // committed winner
-            } else {
-              v.graph = sl.prePartitionGraph; // pristine copy
-              for (size_t li = 0; li < v.graph.loops.size(); ++li) {
-                auto &dstLoop = v.graph.loops[li];
-                auto &liveLoop = sl.graph.loops[li];
-                if (dstLoop.II > 0 && !liveLoop.topPartitions.empty()) {
-                  // Loops with their own candidate-k vary; loops with fewer
-                  // candidates (a single fixed partition) clamp to their last
-                  // one so they stay constant across variants.
-                  size_t idx = std::min(k, liveLoop.topPartitions.size() - 1);
-                  finalizeLoopPartitionForDump(dstLoop,
-                                               liveLoop.topPartitions[idx]);
-                  if (idx < liveLoop.topPartitionCosts.size())
-                    dstLoop.partitionCost = liveLoop.topPartitionCosts[idx];
-                }
-              }
-            }
-            variant.push_back(std::move(v));
-          }
-          variants.push_back(std::move(variant));
-        }
-        dumpScheduleGraphsJSON(moduleOp, pluralDumpPath(path), variants);
-      }
-    }
-    // Optional: dump the pre-schedule DDG layer (the solver's input + the
-    // MinII analysis it derives) as JSON. This is everything needed to
-    // regenerate the ScheduleGraph from the DDG.
-    if (const char *path = std::getenv("TRITON_MODULO_DUMP_DDG")) {
-      dumpDDGAsJSON(moduleOp, path, scheduledLoops);
-    }
+    ttg::ScheduleDriverOptions opts;
+    opts.printScheduleGraph = printScheduleGraph;
+    opts.dataPartitionFactor = dataPartitionFactor;
+    if (failed(ttg::runScheduleDriver(getOperation(), opts)))
+      signalPassFailure();
   }
 };
 

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloSchedulePass.cpp
@@ -4869,6 +4869,18 @@ scheduleOneLoop(scf::ForOp loop, const ttg::LatencyModel &model,
     }
   });
 
+  // Opt-in M2 evidence: compare the joint solver against the in-tree
+  // schedulers on this DDG. Runs every backend, so it is gated behind
+  // TRITON_MODULO_BASELINE_REPORT and never fires on a compile path. Emitted
+  // on stderr so it does not interleave with triton-opt's IR on stdout.
+  if (ttg::baselineReportRequested()) {
+    llvm::StringRef fixture = label;
+    if (auto func = loop->getParentOfType<tt::FuncOp>())
+      fixture = func.getName();
+    ttg::printBaselineComparison(llvm::errs(),
+                                 ttg::compareAgainstBaselines(ddg, fixture));
+  }
+
   auto schedResult = ttg::runModuloScheduling(ddg);
   if (failed(schedResult)) {
     LDBG(label << " scheduling FAILED");
@@ -5539,9 +5551,17 @@ static bool partitionJointSolver(ttg::ScheduleLoop &loop,
   auto status = obj->getString("status");
   auto *wgMap = obj->getObject("wg");
   auto *loweringPlanObj = obj->getObject("lowering_plan");
-  if (!responseVersion || *responseVersion != "joint-solver-0.2" || !status ||
-      *status != "ok" || !wgMap || !loweringPlanObj)
+  if (!status || *status != "ok") {
+    LLVM_DEBUG(DBGS() << "[Phase4-JOINT] solver non-ok response: " << *rawOut
+                      << "\n");
     return false;
+  }
+  if (!responseVersion || *responseVersion != "joint-solver-0.2" || !wgMap ||
+      !loweringPlanObj) {
+    LLVM_DEBUG(DBGS() << "[Phase4-JOINT] malformed ok response: " << *rawOut
+                      << "\n");
+    return false;
+  }
 
   auto checkedInt = [](std::optional<int64_t> value, int &result) {
     if (!value || *value < std::numeric_limits<int>::min() ||

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloWSPartitionPass.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/ModuloWSPartitionPass.cpp
@@ -57,7 +57,10 @@ static int partitionLoopByUtilization(scf::ForOp loop,
 
   auto ddg = ttg::DataDependenceGraph::build(loop, model);
   if (II <= 0) {
-    auto schedResult = ttg::runModuloScheduling(ddg);
+    // No forced backend here: this pass has no schedule-algo option of its
+    // own, so the env var is the only input.
+    auto schedResult =
+        ttg::runModuloScheduling(ddg, ttg::getActiveScheduleAlgo());
     if (failed(schedResult))
       return 0;
     II = schedResult->II;

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/Z3JointSolutionValidator.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/Z3JointSolutionValidator.cpp
@@ -1,0 +1,1599 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "Z3JointSolutionValidator.h"
+
+#include "llvm/Support/Error.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace mlir::triton::gpu {
+namespace {
+
+constexpr llvm::StringLiteral kProblemSchema = "joint-solver-0.2";
+constexpr llvm::StringLiteral kPlanSchema = "lowering-plan-0.1";
+constexpr llvm::StringLiteral kValidationSchema = "joint-solver-validation-0.1";
+
+enum class Relation { Always, SameWG, DifferentWG };
+enum class Placement { Before, After };
+
+struct ValidationResult {
+  bool isValid() const { return violations.empty(); }
+  std::vector<std::string> violations;
+};
+
+struct Node {
+  int64_t id;
+  int64_t fixedCycle;
+  int64_t duration;
+  std::string pipeline;
+  std::optional<size_t> cluster;
+};
+
+struct Cluster {
+  int64_t id;
+  int64_t minWarps;
+  std::vector<size_t> nodes;
+};
+
+struct Edge {
+  size_t src;
+  size_t dst;
+  int64_t result;
+  int64_t latency;
+  int64_t distance;
+  int64_t roundTrip;
+  int64_t channelBytes;
+  std::optional<size_t> srcCluster;
+  std::optional<size_t> dstCluster;
+};
+
+struct Consumer {
+  size_t node;
+  int64_t latency;
+  int64_t distance;
+};
+
+struct Buffer {
+  int64_t id;
+  size_t producer;
+  int64_t sizeBytes;
+  int64_t minCount;
+  std::string kind;
+  std::vector<Consumer> consumers;
+};
+
+struct LoweringEvent {
+  int64_t id;
+  size_t anchor;
+  Placement placement;
+  std::string pipeline;
+  int64_t duration;
+  size_t ownerCluster;
+};
+
+struct LoweringTemplate {
+  int64_t id;
+  Relation relation;
+  size_t srcCluster;
+  size_t dstCluster;
+  std::vector<LoweringEvent> events;
+};
+
+struct Problem {
+  bool jointMode;
+  int64_t ii;
+  int64_t maxWGs;
+  int64_t committedSmem;
+  int64_t fixedSmem;
+  int64_t smemBudget;
+  int64_t tmemBudget;
+  int64_t defaultWGFootprint;
+  std::optional<int64_t> regBudget;
+  std::optional<size_t> canonicalRoot;
+  std::vector<int64_t> warpFootprint;
+  std::vector<Node> nodes;
+  std::vector<Cluster> clusters;
+  std::vector<Edge> edges;
+  std::vector<Buffer> buffers;
+  std::vector<LoweringTemplate> loweringTemplates;
+  std::vector<std::pair<size_t, size_t>> warpGroupConflicts;
+};
+
+struct EventPlan {
+  int64_t cycle;
+  int64_t warpGroup;
+  int64_t streamOrder;
+};
+
+struct TemplatePlan {
+  bool present = false;
+  bool active = false;
+  std::map<int64_t, EventPlan> events;
+};
+
+struct Solution {
+  std::vector<int64_t> cycles;
+  std::vector<int64_t> warpGroups;
+  int64_t usedWGs = 0;
+  std::map<int64_t, int64_t> bufferDepths;
+  std::vector<TemplatePlan> loweringPlans;
+};
+
+struct ExpectedEvent {
+  size_t templateIndex = 0;
+  size_t eventIndex = 0;
+  int64_t cycle = 0;
+  int64_t warpGroup = 0;
+  int64_t streamOrder = 0;
+  bool valid = true;
+};
+
+struct Issue {
+  int64_t cycle;
+  int64_t duration;
+  std::string pipeline;
+  std::optional<size_t> cluster;
+  std::string label;
+};
+
+static bool getInteger(const llvm::json::Object &object, llvm::StringRef key,
+                       int64_t &value) {
+  auto parsed = object.getInteger(key);
+  if (!parsed)
+    return false;
+  value = *parsed;
+  return true;
+}
+
+static bool getString(const llvm::json::Object &object, llvm::StringRef key,
+                      std::string &value) {
+  auto parsed = object.getString(key);
+  if (!parsed)
+    return false;
+  value = parsed->str();
+  return true;
+}
+
+static bool getBoolean(const llvm::json::Object &object, llvm::StringRef key,
+                       bool &value) {
+  auto parsed = object.getBoolean(key);
+  if (!parsed)
+    return false;
+  value = *parsed;
+  return true;
+}
+
+static bool fail(std::string &error, std::string message) {
+  error = std::move(message);
+  return false;
+}
+
+static bool parseProblem(llvm::StringRef json, Problem &problem,
+                         std::string &error) {
+  auto parsed = llvm::json::parse(json);
+  if (!parsed)
+    return fail(error, "problem JSON parse failed: " +
+                           llvm::toString(parsed.takeError()));
+  auto *root = parsed->getAsObject();
+  if (!root)
+    return fail(error, "problem must be a JSON object");
+  auto version = root->getString("version");
+  auto mode = root->getString("mode");
+  if (!version || *version != kProblemSchema || !mode ||
+      (*mode != "joint" && *mode != "partition"))
+    return fail(error, "validator requires a joint-solver-0.2 problem");
+  problem.jointMode = *mode == "joint";
+
+  int64_t emitterCaps = 0;
+  int64_t smRegs = 0;
+  int64_t defaultSlack = 0;
+  if (!getInteger(*root, "emitter_caps_version", emitterCaps) ||
+      emitterCaps != 2 || !getInteger(*root, "ii", problem.ii) ||
+      problem.ii <= 0 || !getInteger(*root, "max_wgs", problem.maxWGs) ||
+      problem.maxWGs <= 0 ||
+      !getInteger(*root, "committed_smem", problem.committedSmem) ||
+      !getInteger(*root, "fixed_smem", problem.fixedSmem) ||
+      !getInteger(*root, "smem_budget", problem.smemBudget) ||
+      !getInteger(*root, "tmem_budget_bytes", problem.tmemBudget) ||
+      !getInteger(*root, "default_wg_footprint", problem.defaultWGFootprint) ||
+      !getInteger(*root, "sm_regs", smRegs) ||
+      !getInteger(*root, "default_slack", defaultSlack) ||
+      problem.committedSmem < 0 || problem.fixedSmem < 0 ||
+      problem.smemBudget < 0 || problem.tmemBudget < 0 ||
+      problem.defaultWGFootprint < 0 || smRegs < 0 || defaultSlack < 0)
+    return fail(error, "invalid joint problem budgets or limits");
+
+  if (root->get("time_limit_s")) {
+    auto value = root->getNumber("time_limit_s");
+    if (!value || !std::isfinite(*value) || *value <= 0.0)
+      return fail(error, "invalid time_limit_s");
+  }
+
+  if (root->get("reg_budget")) {
+    int64_t value = 0;
+    if (!getInteger(*root, "reg_budget", value) || value < 0)
+      return fail(error, "invalid reg_budget");
+    if (value > 0)
+      problem.regBudget = value;
+  }
+
+  auto *nodeValues = root->getArray("nodes");
+  auto *clusterValues = root->getArray("clusters");
+  auto *edgeValues = root->getArray("edges");
+  auto *bufferValues = root->getArray("buffers");
+  auto *templateValues = root->getArray("lowering_templates");
+  auto *footprintValues = root->getArray("warp_footprint");
+  if (!nodeValues || !clusterValues || clusterValues->empty() || !edgeValues ||
+      !bufferValues || !templateValues || !footprintValues)
+    return fail(error, "joint problem is missing a required array");
+
+  problem.warpFootprint.reserve(footprintValues->size());
+  for (const llvm::json::Value &value : *footprintValues) {
+    auto footprint = value.getAsInteger();
+    if (!footprint || *footprint < 0)
+      return fail(error, "warp_footprint entries must be nonnegative integers");
+    problem.warpFootprint.push_back(*footprint);
+  }
+  if (problem.warpFootprint.size() <= 8)
+    return fail(error, "warp_footprint must define indices through eight");
+
+  std::map<int64_t, size_t> nodeIndices;
+  problem.nodes.reserve(nodeValues->size());
+  for (const llvm::json::Value &value : *nodeValues) {
+    auto *object = value.getAsObject();
+    int64_t id = 0;
+    int64_t cycle = 0;
+    int64_t duration = 0;
+    int64_t latency = 0;
+    int64_t frequency = 0;
+    std::string pipeline;
+    if (!object || !getInteger(*object, "id", id) ||
+        !getInteger(*object, "cycle", cycle) ||
+        !getInteger(*object, "duration", duration) ||
+        !getInteger(*object, "latency", latency) ||
+        !getInteger(*object, "freq", frequency) ||
+        !getString(*object, "pipeline", pipeline) || cycle < 0 ||
+        duration < 0 || latency < 0 || frequency <= 0 || nodeIndices.count(id))
+      return fail(error, "invalid node in joint problem");
+    nodeIndices.emplace(id, problem.nodes.size());
+    problem.nodes.push_back(
+        Node{id, cycle, duration, std::move(pipeline), std::nullopt});
+  }
+
+  std::map<int64_t, size_t> clusterIndices;
+  problem.clusters.reserve(clusterValues->size());
+  for (const llvm::json::Value &value : *clusterValues) {
+    auto *object = value.getAsObject();
+    int64_t id = 0;
+    int64_t minWarps = 0;
+    auto *nodes = object ? object->getArray("nodes") : nullptr;
+    if (!object || !getInteger(*object, "id", id) ||
+        !getInteger(*object, "min_warps", minWarps) || !nodes ||
+        nodes->empty() || minWarps <= 0 || minWarps > 8 ||
+        clusterIndices.count(id))
+      return fail(error, "invalid cluster in joint problem");
+    size_t clusterIndex = problem.clusters.size();
+    clusterIndices.emplace(id, clusterIndex);
+    Cluster cluster{id, minWarps, {}};
+    cluster.nodes.reserve(nodes->size());
+    for (const llvm::json::Value &nodeValue : *nodes) {
+      auto nodeId = nodeValue.getAsInteger();
+      if (!nodeId)
+        return fail(error, "cluster node IDs must be integers");
+      auto node = nodeIndices.find(*nodeId);
+      if (node == nodeIndices.end() || problem.nodes[node->second].cluster)
+        return fail(error, "cluster contains an unknown or repeated node");
+      problem.nodes[node->second].cluster = clusterIndex;
+      cluster.nodes.push_back(node->second);
+    }
+    problem.clusters.push_back(std::move(cluster));
+  }
+  problem.maxWGs = std::min<int64_t>(
+      problem.maxWGs, static_cast<int64_t>(problem.clusters.size()));
+
+  if (root->get("canonical_root")) {
+    int64_t rootId = 0;
+    if (!getInteger(*root, "canonical_root", rootId))
+      return fail(error, "canonical_root must be an integer");
+    auto node = nodeIndices.find(rootId);
+    if (node == nodeIndices.end())
+      return fail(error, "canonical_root names an unknown node");
+    problem.canonicalRoot = node->second;
+  }
+
+  problem.edges.reserve(edgeValues->size());
+  for (const llvm::json::Value &value : *edgeValues) {
+    auto *object = value.getAsObject();
+    int64_t srcId = 0;
+    int64_t dstId = 0;
+    int64_t result = 0;
+    int64_t latency = 0;
+    int64_t distance = 0;
+    int64_t frequency = 0;
+    int64_t roundTrip = 0;
+    int64_t crossIssue = 0;
+    int64_t channelBytes = 0;
+    if (!object || !getInteger(*object, "src", srcId) ||
+        !getInteger(*object, "dst", dstId) ||
+        !getInteger(*object, "src_result_idx", result) ||
+        !getInteger(*object, "latency", latency) ||
+        !getInteger(*object, "distance", distance) ||
+        !getInteger(*object, "freq", frequency) ||
+        !getInteger(*object, "rt", roundTrip) ||
+        !getInteger(*object, "xissue", crossIssue) ||
+        !getInteger(*object, "chan_bytes", channelBytes) || result < 0 ||
+        latency < 0 || distance < 0 || frequency <= 0 || roundTrip < 0 ||
+        crossIssue < 0 || channelBytes < 0)
+      return fail(error, "invalid edge in joint problem");
+    auto src = nodeIndices.find(srcId);
+    auto dst = nodeIndices.find(dstId);
+    if (src == nodeIndices.end() || dst == nodeIndices.end())
+      return fail(error, "edge names an unknown node");
+
+    std::optional<size_t> srcCluster;
+    std::optional<size_t> dstCluster;
+    bool hasSrcCluster = object->get("src_cluster") != nullptr;
+    bool hasDstCluster = object->get("dst_cluster") != nullptr;
+    if (hasSrcCluster != hasDstCluster)
+      return fail(error, "edge cluster metadata must be paired");
+    if (hasSrcCluster) {
+      int64_t srcClusterId = 0;
+      int64_t dstClusterId = 0;
+      if (!getInteger(*object, "src_cluster", srcClusterId) ||
+          !getInteger(*object, "dst_cluster", dstClusterId))
+        return fail(error, "edge cluster IDs must be integers");
+      auto srcIt = clusterIndices.find(srcClusterId);
+      auto dstIt = clusterIndices.find(dstClusterId);
+      if (srcIt == clusterIndices.end() || dstIt == clusterIndices.end() ||
+          problem.nodes[src->second].cluster != srcIt->second ||
+          problem.nodes[dst->second].cluster != dstIt->second)
+        return fail(error, "edge cluster metadata disagrees with its nodes");
+      srcCluster = srcIt->second;
+      dstCluster = dstIt->second;
+    } else if (roundTrip != 0 || crossIssue != 0 || channelBytes != 0) {
+      return fail(error, "edge communication metadata requires clusters");
+    }
+    problem.edges.push_back(Edge{src->second, dst->second, result, latency,
+                                 distance, roundTrip, channelBytes, srcCluster,
+                                 dstCluster});
+  }
+
+  std::set<int64_t> bufferIds;
+  problem.buffers.reserve(bufferValues->size());
+  for (const llvm::json::Value &value : *bufferValues) {
+    auto *object = value.getAsObject();
+    int64_t id = 0;
+    int64_t producerId = 0;
+    int64_t sizeBytes = 0;
+    int64_t count = 0;
+    int64_t minCount = 0;
+    std::string kind;
+    auto *consumers = object ? object->getArray("consumers") : nullptr;
+    if (!object || !getInteger(*object, "id", id) ||
+        !getInteger(*object, "producer", producerId) ||
+        !getInteger(*object, "size_bytes", sizeBytes) ||
+        !getInteger(*object, "count", count) ||
+        !getInteger(*object, "min_count", minCount) ||
+        !getString(*object, "kind", kind) || !consumers || sizeBytes < 0 ||
+        count <= 0 || minCount <= 0 || (kind != "smem" && kind != "tmem") ||
+        !bufferIds.insert(id).second)
+      return fail(error, "invalid buffer in joint problem");
+    auto producer = nodeIndices.find(producerId);
+    if (producer == nodeIndices.end())
+      return fail(error, "buffer producer is unknown");
+    Buffer buffer{id,       producer->second, sizeBytes,
+                  minCount, std::move(kind),  {}};
+    for (const llvm::json::Value &consumerValue : *consumers) {
+      auto *consumer = consumerValue.getAsObject();
+      int64_t nodeId = 0;
+      int64_t consumerLatency = 0;
+      int64_t consumerDistance = 0;
+      if (!consumer || !getInteger(*consumer, "node", nodeId) ||
+          !getInteger(*consumer, "latency", consumerLatency) ||
+          !getInteger(*consumer, "distance", consumerDistance) ||
+          consumerLatency < 0 || consumerDistance < 0)
+        return fail(error, "invalid buffer consumer");
+      auto node = nodeIndices.find(nodeId);
+      if (node == nodeIndices.end())
+        return fail(error, "buffer consumer is unknown");
+      buffer.consumers.push_back(
+          Consumer{node->second, consumerLatency, consumerDistance});
+    }
+    problem.buffers.push_back(std::move(buffer));
+  }
+
+  problem.loweringTemplates.reserve(templateValues->size());
+  for (size_t templateIndex = 0; templateIndex < templateValues->size();
+       ++templateIndex) {
+    auto *object = (*templateValues)[templateIndex].getAsObject();
+    int64_t id = 0;
+    int64_t srcNodeId = 0;
+    int64_t dstNodeId = 0;
+    int64_t srcClusterId = 0;
+    int64_t dstClusterId = 0;
+    std::string relationName;
+    auto *events = object ? object->getArray("events") : nullptr;
+    if (!object || !getInteger(*object, "id", id) ||
+        id != static_cast<int64_t>(templateIndex) ||
+        !getString(*object, "relation", relationName) ||
+        !getInteger(*object, "src_node", srcNodeId) ||
+        !getInteger(*object, "dst_node", dstNodeId) ||
+        !getInteger(*object, "src_cluster", srcClusterId) ||
+        !getInteger(*object, "dst_cluster", dstClusterId) || !events)
+      return fail(error, "invalid lowering template");
+    Relation relation;
+    if (relationName == "always")
+      relation = Relation::Always;
+    else if (relationName == "same_wg")
+      relation = Relation::SameWG;
+    else if (relationName == "different_wg")
+      relation = Relation::DifferentWG;
+    else
+      return fail(error, "unknown lowering relation");
+    auto srcNode = nodeIndices.find(srcNodeId);
+    auto dstNode = nodeIndices.find(dstNodeId);
+    auto srcCluster = clusterIndices.find(srcClusterId);
+    auto dstCluster = clusterIndices.find(dstClusterId);
+    if (srcNode == nodeIndices.end() || dstNode == nodeIndices.end() ||
+        srcCluster == clusterIndices.end() ||
+        dstCluster == clusterIndices.end() ||
+        problem.nodes[srcNode->second].cluster != srcCluster->second ||
+        problem.nodes[dstNode->second].cluster != dstCluster->second)
+      return fail(error, "lowering template metadata is inconsistent");
+
+    LoweringTemplate loweringTemplate{
+        id, relation, srcCluster->second, dstCluster->second, {}};
+    std::set<int64_t> eventIds;
+    for (const llvm::json::Value &eventValue : *events) {
+      auto *event = eventValue.getAsObject();
+      int64_t eventId = 0;
+      int64_t anchorId = 0;
+      int64_t issueDuration = 0;
+      int64_t completionLatency = 0;
+      int64_t distance = 0;
+      int64_t frequency = 0;
+      int64_t bytes = 0;
+      int64_t depth = 0;
+      bool blocking = false;
+      bool isAsync = false;
+      std::string kind;
+      std::string owner;
+      std::string placementName;
+      std::string pipeline;
+      std::string semaphore;
+      if (!event || !getInteger(*event, "id", eventId) ||
+          !getString(*event, "kind", kind) ||
+          (kind != "wait" && kind != "arrive" && kind != "expect" &&
+           kind != "local_store" && kind != "local_load" && kind != "fence" &&
+           kind != "tc_commit") ||
+          !getString(*event, "owner", owner) ||
+          !getInteger(*event, "anchor_node", anchorId) ||
+          !getString(*event, "placement", placementName) ||
+          !getString(*event, "pipeline", pipeline) ||
+          !getInteger(*event, "issue_duration", issueDuration) ||
+          !getInteger(*event, "completion_latency", completionLatency) ||
+          !getBoolean(*event, "blocking", blocking) ||
+          !getBoolean(*event, "async", isAsync) ||
+          !getInteger(*event, "distance", distance) ||
+          !getInteger(*event, "frequency", frequency) ||
+          !getInteger(*event, "bytes", bytes) ||
+          !getInteger(*event, "depth", depth) ||
+          !getString(*event, "semaphore", semaphore) || eventId < 0 ||
+          issueDuration < 0 || completionLatency < 0 || distance < 0 ||
+          frequency <= 0 || bytes < 0 || depth < 0 ||
+          !eventIds.insert(eventId).second)
+        return fail(error, "invalid lowering event");
+      (void)blocking;
+      (void)isAsync;
+      auto anchor = nodeIndices.find(anchorId);
+      if (anchor == nodeIndices.end())
+        return fail(error, "lowering event anchor is unknown");
+      size_t ownerCluster;
+      if (owner == "src")
+        ownerCluster = srcCluster->second;
+      else if (owner == "dst")
+        ownerCluster = dstCluster->second;
+      else
+        return fail(error, "unknown lowering event owner");
+      if (problem.nodes[anchor->second].cluster != ownerCluster)
+        return fail(error, "lowering event anchor has the wrong owner cluster");
+      Placement placement;
+      if (placementName == "before")
+        placement = Placement::Before;
+      else if (placementName == "after")
+        placement = Placement::After;
+      else
+        return fail(error, "unknown lowering event placement");
+      __int128 duration = static_cast<__int128>(issueDuration) * frequency;
+      if (duration > std::numeric_limits<int64_t>::max())
+        return fail(error, "lowering event duration overflows int64");
+      loweringTemplate.events.push_back(
+          LoweringEvent{eventId, anchor->second, placement, std::move(pipeline),
+                        static_cast<int64_t>(duration), ownerCluster});
+    }
+    problem.loweringTemplates.push_back(std::move(loweringTemplate));
+  }
+
+  if (auto *conflicts = root->getArray("warp_group_conflicts")) {
+    for (const llvm::json::Value &value : *conflicts) {
+      auto *pair = value.getAsArray();
+      if (!pair || pair->size() != 2)
+        return fail(error, "warp_group_conflicts entries must be pairs");
+      auto leftId = (*pair)[0].getAsInteger();
+      auto rightId = (*pair)[1].getAsInteger();
+      if (!leftId || !rightId)
+        return fail(error, "warp-group conflict IDs must be integers");
+      auto left = clusterIndices.find(*leftId);
+      auto right = clusterIndices.find(*rightId);
+      if (left == clusterIndices.end() || right == clusterIndices.end())
+        return fail(error, "warp-group conflict names an unknown cluster");
+      problem.warpGroupConflicts.push_back({left->second, right->second});
+    }
+  } else if (root->get("warp_group_conflicts")) {
+    return fail(error, "warp_group_conflicts must be an array");
+  }
+  return true;
+}
+
+static bool parseAssignments(const llvm::json::Object &root,
+                             llvm::StringRef field,
+                             const std::map<int64_t, size_t> &indices,
+                             std::vector<int64_t> &values,
+                             bool requireNonnegative, std::string &error) {
+  auto *object = root.getObject(field);
+  if (!object)
+    return fail(error, field.str() + " must be an object");
+  values.assign(indices.size(), 0);
+  std::vector<bool> seen(indices.size(), false);
+  for (const auto &entry : *object) {
+    int64_t id = 0;
+    llvm::StringRef key(entry.first);
+    auto value = entry.second.getAsInteger();
+    if (key.getAsInteger(10, id) || !value)
+      return fail(error, field.str() + " contains a non-integer entry");
+    auto index = indices.find(id);
+    if (index == indices.end() || seen[index->second])
+      return fail(error, field.str() + " contains an unknown or repeated ID");
+    if (requireNonnegative && *value < 0)
+      return fail(error, field.str() + " contains a negative value");
+    seen[index->second] = true;
+    values[index->second] = *value;
+  }
+  if (std::find(seen.begin(), seen.end(), false) != seen.end())
+    return fail(error, field.str() + " is incomplete");
+  return true;
+}
+
+static bool parseSolution(llvm::StringRef json, const Problem &problem,
+                          Solution &solution, std::string &error) {
+  auto parsed = llvm::json::parse(json);
+  if (!parsed)
+    return fail(error, "solution JSON parse failed: " +
+                           llvm::toString(parsed.takeError()));
+  auto *root = parsed->getAsObject();
+  if (!root)
+    return fail(error, "solution must be a JSON object");
+  auto version = root->getString("version");
+  auto status = root->getString("status");
+  if (!version || *version != kProblemSchema || !status || *status != "ok")
+    return fail(error, "solution must be a successful joint-solver-0.2 result");
+  if (!root->getInteger("objective"))
+    return fail(error, "solution objective must be an integer");
+  if (root->get("lowering_objective") &&
+      !root->getInteger("lowering_objective"))
+    return fail(error, "lowering_objective must be an integer");
+
+  std::map<int64_t, size_t> nodeIndices;
+  for (size_t index = 0; index < problem.nodes.size(); ++index)
+    nodeIndices.emplace(problem.nodes[index].id, index);
+  std::map<int64_t, size_t> clusterIndices;
+  for (size_t index = 0; index < problem.clusters.size(); ++index)
+    clusterIndices.emplace(problem.clusters[index].id, index);
+  if (!parseAssignments(*root, "cycles", nodeIndices, solution.cycles, true,
+                        error) ||
+      !parseAssignments(*root, "wg", clusterIndices, solution.warpGroups, true,
+                        error))
+    return false;
+  if (!getInteger(*root, "used_wgs", solution.usedWGs) || solution.usedWGs <= 0)
+    return fail(error, "invalid used_wgs");
+
+  auto *depths = root->getObject("buffer_depths");
+  if (!depths)
+    return fail(error, "buffer_depths must be an object");
+  std::set<int64_t> expectedDepths;
+  for (const Buffer &buffer : problem.buffers)
+    if (buffer.kind == "smem")
+      expectedDepths.insert(buffer.id);
+  for (const auto &entry : *depths) {
+    int64_t id = 0;
+    llvm::StringRef key(entry.first);
+    auto depth = entry.second.getAsInteger();
+    if (key.getAsInteger(10, id) || !depth || *depth <= 0 ||
+        !expectedDepths.erase(id))
+      return fail(error, "buffer_depths contains an invalid entry");
+    solution.bufferDepths.emplace(id, *depth);
+  }
+  if (!expectedDepths.empty())
+    return fail(error, "buffer_depths is incomplete");
+
+  auto *loweringPlan = root->getObject("lowering_plan");
+  if (!loweringPlan)
+    return fail(error, "lowering_plan must be an object");
+  auto planVersion = loweringPlan->getString("version");
+  auto *plans = loweringPlan->getArray("templates");
+  if (!planVersion || *planVersion != kPlanSchema || !plans)
+    return fail(error, "invalid lowering_plan");
+  solution.loweringPlans.resize(problem.loweringTemplates.size());
+  std::map<int64_t, size_t> templateIndices;
+  for (size_t index = 0; index < problem.loweringTemplates.size(); ++index)
+    templateIndices.emplace(problem.loweringTemplates[index].id, index);
+  for (const llvm::json::Value &value : *plans) {
+    auto *object = value.getAsObject();
+    int64_t id = 0;
+    bool active = false;
+    auto *events = object ? object->getArray("events") : nullptr;
+    if (!object || !getInteger(*object, "id", id) ||
+        !getBoolean(*object, "active", active) || !events)
+      return fail(error, "invalid lowering template plan");
+    auto templateIt = templateIndices.find(id);
+    if (templateIt == templateIndices.end() ||
+        solution.loweringPlans[templateIt->second].present)
+      return fail(error, "lowering_plan has an unknown or repeated template");
+    TemplatePlan &plan = solution.loweringPlans[templateIt->second];
+    plan.present = true;
+    plan.active = active;
+    std::set<int64_t> eventIds;
+    for (const LoweringEvent &event :
+         problem.loweringTemplates[templateIt->second].events)
+      eventIds.insert(event.id);
+    for (const llvm::json::Value &eventValue : *events) {
+      auto *event = eventValue.getAsObject();
+      int64_t eventId = 0;
+      int64_t cycle = 0;
+      int64_t warpGroup = 0;
+      int64_t streamOrder = 0;
+      if (!event || !getInteger(*event, "id", eventId) ||
+          !getInteger(*event, "cycle", cycle) ||
+          !getInteger(*event, "wg", warpGroup) ||
+          !getInteger(*event, "stream_order", streamOrder) || warpGroup < 0 ||
+          streamOrder < 0 || !eventIds.count(eventId) ||
+          plan.events.count(eventId))
+        return fail(error, "invalid lowering event plan");
+      plan.events.emplace(eventId, EventPlan{cycle, warpGroup, streamOrder});
+    }
+  }
+  for (const TemplatePlan &plan : solution.loweringPlans)
+    if (!plan.present)
+      return fail(error, "lowering_plan is incomplete");
+  return true;
+}
+
+static void addViolation(ValidationResult &result, std::string message) {
+  result.violations.push_back(std::move(message));
+}
+
+static std::string wideToString(__int128 value) {
+  bool negative = value < 0;
+  unsigned __int128 magnitude =
+      negative ? static_cast<unsigned __int128>(-(value + 1)) + 1
+               : static_cast<unsigned __int128>(value);
+  std::string result;
+  do {
+    result.push_back(static_cast<char>('0' + magnitude % 10));
+    magnitude /= 10;
+  } while (magnitude != 0);
+  if (negative)
+    result.push_back('-');
+  std::reverse(result.begin(), result.end());
+  return result;
+}
+
+static bool templateIsActive(const LoweringTemplate &loweringTemplate,
+                             const Solution &solution) {
+  if (loweringTemplate.relation == Relation::Always)
+    return true;
+  bool same = solution.warpGroups[loweringTemplate.srcCluster] ==
+              solution.warpGroups[loweringTemplate.dstCluster];
+  return loweringTemplate.relation == Relation::SameWG ? same : !same;
+}
+
+static std::vector<std::vector<ExpectedEvent>>
+buildExpectedEvents(const Problem &problem, const Solution &solution,
+                    ValidationResult &result) {
+  std::vector<std::vector<ExpectedEvent>> expected(
+      problem.loweringTemplates.size());
+  using EventRef = std::pair<size_t, size_t>;
+  std::map<std::pair<size_t, int>, std::vector<EventRef>> groups;
+  for (size_t templateIndex = 0;
+       templateIndex < problem.loweringTemplates.size(); ++templateIndex) {
+    const LoweringTemplate &loweringTemplate =
+        problem.loweringTemplates[templateIndex];
+    expected[templateIndex].resize(loweringTemplate.events.size());
+    if (!templateIsActive(loweringTemplate, solution))
+      continue;
+    for (size_t eventIndex = 0; eventIndex < loweringTemplate.events.size();
+         ++eventIndex) {
+      const LoweringEvent &event = loweringTemplate.events[eventIndex];
+      groups[{event.anchor, static_cast<int>(event.placement)}].push_back(
+          {templateIndex, eventIndex});
+    }
+  }
+
+  std::vector<ExpectedEvent *> stream;
+  for (auto &entry : groups) {
+    auto &members = entry.second;
+    std::sort(members.begin(), members.end(),
+              [&](EventRef left, EventRef right) {
+                const LoweringTemplate &leftTemplate =
+                    problem.loweringTemplates[left.first];
+                const LoweringTemplate &rightTemplate =
+                    problem.loweringTemplates[right.first];
+                return std::tie(leftTemplate.id,
+                                leftTemplate.events[left.second].id) <
+                       std::tie(rightTemplate.id,
+                                rightTemplate.events[right.second].id);
+              });
+    size_t anchor = entry.first.first;
+    Placement placement = static_cast<Placement>(entry.first.second);
+    __int128 cursor = solution.cycles[anchor];
+    if (placement == Placement::Before) {
+      for (EventRef member : members)
+        cursor -= problem.loweringTemplates[member.first]
+                      .events[member.second]
+                      .duration;
+    } else {
+      cursor += std::max<int64_t>(problem.nodes[anchor].duration, 1);
+    }
+    for (EventRef member : members) {
+      const LoweringTemplate &loweringTemplate =
+          problem.loweringTemplates[member.first];
+      const LoweringEvent &event = loweringTemplate.events[member.second];
+      ExpectedEvent &out = expected[member.first][member.second];
+      out.templateIndex = member.first;
+      out.eventIndex = member.second;
+      out.warpGroup = solution.warpGroups[event.ownerCluster];
+      if (cursor < std::numeric_limits<int>::min() ||
+          cursor > std::numeric_limits<int>::max()) {
+        out.valid = false;
+        addViolation(result, "lowering event cycle is outside int range");
+      } else {
+        out.cycle = static_cast<int64_t>(cursor);
+        stream.push_back(&out);
+      }
+      cursor += event.duration;
+    }
+  }
+
+  std::sort(
+      stream.begin(), stream.end(),
+      [&](const ExpectedEvent *left, const ExpectedEvent *right) {
+        const LoweringTemplate &leftTemplate =
+            problem.loweringTemplates[left->templateIndex];
+        const LoweringTemplate &rightTemplate =
+            problem.loweringTemplates[right->templateIndex];
+        const LoweringEvent &leftEvent = leftTemplate.events[left->eventIndex];
+        const LoweringEvent &rightEvent =
+            rightTemplate.events[right->eventIndex];
+        int leftPlacement = leftEvent.placement == Placement::Before ? 0 : 2;
+        int rightPlacement = rightEvent.placement == Placement::Before ? 0 : 2;
+        return std::tie(left->warpGroup, left->cycle, leftPlacement,
+                        leftTemplate.id, leftEvent.id) <
+               std::tie(right->warpGroup, right->cycle, rightPlacement,
+                        rightTemplate.id, rightEvent.id);
+      });
+  std::map<int64_t, int64_t> nextOrder;
+  for (ExpectedEvent *event : stream)
+    event->streamOrder = nextOrder[event->warpGroup]++;
+  return expected;
+}
+
+static void
+validateLoweringPlan(const Problem &problem, const Solution &solution,
+                     const std::vector<std::vector<ExpectedEvent>> &expected,
+                     ValidationResult &result) {
+  for (size_t templateIndex = 0;
+       templateIndex < problem.loweringTemplates.size(); ++templateIndex) {
+    const LoweringTemplate &loweringTemplate =
+        problem.loweringTemplates[templateIndex];
+    const TemplatePlan &plan = solution.loweringPlans[templateIndex];
+    bool active = templateIsActive(loweringTemplate, solution);
+    if (plan.active != active)
+      addViolation(result, "lowering template " +
+                               std::to_string(loweringTemplate.id) +
+                               " has the wrong active state");
+    if (!active) {
+      if (!plan.events.empty())
+        addViolation(result, "inactive lowering template " +
+                                 std::to_string(loweringTemplate.id) +
+                                 " contains events");
+      continue;
+    }
+    if (plan.events.size() != loweringTemplate.events.size())
+      addViolation(result, "active lowering template " +
+                               std::to_string(loweringTemplate.id) +
+                               " has an incomplete event plan");
+    for (size_t eventIndex = 0; eventIndex < loweringTemplate.events.size();
+         ++eventIndex) {
+      const LoweringEvent &event = loweringTemplate.events[eventIndex];
+      auto actual = plan.events.find(event.id);
+      if (actual == plan.events.end())
+        continue;
+      const ExpectedEvent &wanted = expected[templateIndex][eventIndex];
+      if (wanted.valid && (actual->second.cycle != wanted.cycle ||
+                           actual->second.warpGroup != wanted.warpGroup ||
+                           actual->second.streamOrder != wanted.streamOrder))
+        addViolation(result, "lowering event " +
+                                 std::to_string(loweringTemplate.id) + ":" +
+                                 std::to_string(event.id) +
+                                 " disagrees with deterministic placement");
+    }
+  }
+}
+
+static std::vector<std::pair<__int128, __int128>>
+cyclicSegments(int64_t cycle, int64_t duration, int64_t ii) {
+  std::vector<std::pair<__int128, __int128>> result;
+  if (duration <= 0)
+    return result;
+  int64_t phase = cycle % ii;
+  if (phase < 0)
+    phase += ii;
+  __int128 end = static_cast<__int128>(phase) + duration;
+  if (end <= ii) {
+    result.push_back({phase, end});
+  } else {
+    result.push_back({phase, ii});
+    result.push_back({0, end - ii});
+  }
+  return result;
+}
+
+static bool cyclicOverlap(const Issue &left, const Issue &right, int64_t ii) {
+  if (left.duration > ii || right.duration > ii)
+    return true;
+  for (const auto &leftSegment : cyclicSegments(left.cycle, left.duration, ii))
+    for (const auto &rightSegment :
+         cyclicSegments(right.cycle, right.duration, ii))
+      if (std::max(leftSegment.first, rightSegment.first) <
+          std::min(leftSegment.second, rightSegment.second))
+        return true;
+  return false;
+}
+
+static void
+validateIssueOccupancy(const Problem &problem, const Solution &solution,
+                       const std::vector<std::vector<ExpectedEvent>> &expected,
+                       ValidationResult &result) {
+  std::vector<Issue> items;
+  for (size_t index = 0; index < problem.nodes.size(); ++index) {
+    const Node &node = problem.nodes[index];
+    items.push_back(Issue{solution.cycles[index],
+                          std::max<int64_t>(node.duration, 1), node.pipeline,
+                          node.cluster, "node " + std::to_string(node.id)});
+  }
+  for (size_t templateIndex = 0;
+       templateIndex < problem.loweringTemplates.size(); ++templateIndex) {
+    const LoweringTemplate &loweringTemplate =
+        problem.loweringTemplates[templateIndex];
+    if (!templateIsActive(loweringTemplate, solution))
+      continue;
+    for (size_t eventIndex = 0; eventIndex < loweringTemplate.events.size();
+         ++eventIndex) {
+      const LoweringEvent &event = loweringTemplate.events[eventIndex];
+      const ExpectedEvent &placed = expected[templateIndex][eventIndex];
+      if (event.duration <= 0 || !placed.valid)
+        continue;
+      items.push_back(Issue{
+          placed.cycle, event.duration, event.pipeline, event.ownerCluster,
+          "lowering event " + std::to_string(loweringTemplate.id) + ":" +
+              std::to_string(event.id)});
+    }
+  }
+
+  for (const Issue &item : items)
+    if (item.duration > problem.ii)
+      addViolation(result, item.label + " occupies more than one II");
+  for (size_t leftIndex = 0; leftIndex < items.size(); ++leftIndex) {
+    const Issue &left = items[leftIndex];
+    for (size_t rightIndex = leftIndex + 1; rightIndex < items.size();
+         ++rightIndex) {
+      const Issue &right = items[rightIndex];
+      if (!cyclicOverlap(left, right, problem.ii))
+        continue;
+      if (left.pipeline != "NONE" && left.pipeline == right.pipeline)
+        addViolation(result, left.label + " overlaps " + right.label +
+                                 " on pipeline " + left.pipeline);
+      if (problem.jointMode && left.cluster && right.cluster &&
+          solution.warpGroups[*left.cluster] ==
+              solution.warpGroups[*right.cluster])
+        addViolation(result, left.label + " overlaps " + right.label +
+                                 " in the same warp group");
+    }
+  }
+}
+
+static __int128 bufferDepth(const Problem &problem, const Solution &solution,
+                            const Buffer &buffer) {
+  __int128 producerCycle = solution.cycles[buffer.producer];
+  __int128 lastEnd = producerCycle;
+  for (const Consumer &consumer : buffer.consumers) {
+    __int128 end = static_cast<__int128>(solution.cycles[consumer.node]) +
+                   consumer.latency +
+                   static_cast<__int128>(consumer.distance) * problem.ii;
+    lastEnd = std::max(lastEnd, end);
+  }
+  __int128 depth = (lastEnd - producerCycle) / problem.ii + 1;
+  return std::max(depth, static_cast<__int128>(buffer.minCount));
+}
+
+static void validateMemory(const Problem &problem, const Solution &solution,
+                           ValidationResult &result) {
+  __int128 smem = problem.jointMode ? problem.fixedSmem : problem.committedSmem;
+  __int128 tmem = 0;
+  for (const Buffer &buffer : problem.buffers) {
+    __int128 depth = bufferDepth(problem, solution, buffer);
+    __int128 charge = static_cast<__int128>(buffer.sizeBytes) * depth;
+    if (buffer.kind == "smem") {
+      if (problem.jointMode)
+        smem += charge;
+      auto actual = solution.bufferDepths.find(buffer.id);
+      if (actual == solution.bufferDepths.end() || actual->second != depth)
+        addViolation(result, "SMEM buffer " + std::to_string(buffer.id) +
+                                 " reports the wrong depth");
+    } else {
+      tmem += charge;
+    }
+  }
+
+  std::set<std::tuple<size_t, size_t, int64_t>> seenChannels;
+  for (const Edge &edge : problem.edges) {
+    if (edge.channelBytes <= 0 || !edge.srcCluster || !edge.dstCluster ||
+        *edge.srcCluster == *edge.dstCluster)
+      continue;
+    auto channel = std::make_tuple(edge.src, edge.dst, edge.result);
+    if (!seenChannels.insert(channel).second)
+      continue;
+    if (solution.warpGroups[*edge.srcCluster] !=
+        solution.warpGroups[*edge.dstCluster])
+      smem += edge.channelBytes;
+  }
+  if (smem > problem.smemBudget)
+    addViolation(result, "SMEM requirement " + wideToString(smem) +
+                             " exceeds budget " +
+                             std::to_string(problem.smemBudget));
+  if (tmem > problem.tmemBudget)
+    addViolation(result, "TMEM requirement " + wideToString(tmem) +
+                             " exceeds budget " +
+                             std::to_string(problem.tmemBudget));
+}
+
+static void validateRegisters(const Problem &problem, const Solution &solution,
+                              ValidationResult &result) {
+  if (!problem.regBudget)
+    return;
+  __int128 total = problem.defaultWGFootprint;
+  for (size_t group = 0; group < problem.clusters.size(); ++group) {
+    int64_t requiredWarps = 0;
+    for (size_t cluster = 0; cluster < problem.clusters.size(); ++cluster)
+      if (solution.warpGroups[cluster] == static_cast<int64_t>(group))
+        requiredWarps =
+            std::max(requiredWarps, problem.clusters[cluster].minWarps);
+    int roundedWarps = requiredWarps <= 0   ? 0
+                       : requiredWarps <= 1 ? 1
+                       : requiredWarps <= 2 ? 2
+                       : requiredWarps <= 4 ? 4
+                                            : 8;
+    total += problem.warpFootprint[roundedWarps];
+  }
+  if (total > *problem.regBudget)
+    addViolation(result, "register requirement " + wideToString(total) +
+                             " exceeds hard cap " +
+                             std::to_string(*problem.regBudget));
+}
+
+static void validateSchedule(const Problem &problem, const Solution &solution,
+                             ValidationResult &result) {
+  for (size_t index = 0; index < problem.nodes.size(); ++index) {
+    const Node &node = problem.nodes[index];
+    bool fixed = problem.jointMode ? solution.cycles[index] / problem.ii ==
+                                         node.fixedCycle / problem.ii
+                                   : solution.cycles[index] == node.fixedCycle;
+    if (!fixed)
+      addViolation(result,
+                   "node " + std::to_string(node.id) +
+                       (problem.jointMode ? " moved out of its committed stage"
+                                          : " moved from its fixed cycle"));
+  }
+  if (problem.canonicalRoot && solution.cycles[*problem.canonicalRoot] != 0)
+    addViolation(result, "canonical root is not scheduled at cycle zero");
+
+  int64_t prefixMaximum = -1;
+  std::set<int64_t> distinctGroups;
+  for (size_t index = 0; index < problem.clusters.size(); ++index) {
+    int64_t group = solution.warpGroups[index];
+    if (group < 0 || group >= static_cast<int64_t>(problem.clusters.size())) {
+      addViolation(result, "cluster " +
+                               std::to_string(problem.clusters[index].id) +
+                               " has an invalid warp-group label");
+      continue;
+    }
+    if ((index == 0 && group != 0) || (index > 0 && group > prefixMaximum + 1))
+      addViolation(result, "warp-group labels violate canonical ordering");
+    prefixMaximum = std::max(prefixMaximum, group);
+    distinctGroups.insert(group);
+  }
+  int64_t usedWGs = prefixMaximum + 1;
+  if (usedWGs != solution.usedWGs ||
+      static_cast<int64_t>(distinctGroups.size()) != solution.usedWGs)
+    addViolation(result, "used_wgs disagrees with the warp-group assignment");
+  if (usedWGs > problem.maxWGs)
+    addViolation(result, "warp-group assignment exceeds max_wgs");
+
+  for (const auto &[left, right] : problem.warpGroupConflicts)
+    if (solution.warpGroups[left] == solution.warpGroups[right])
+      addViolation(result, "conflicting clusters " +
+                               std::to_string(problem.clusters[left].id) +
+                               " and " +
+                               std::to_string(problem.clusters[right].id) +
+                               " share a warp group");
+
+  for (const Edge &edge : problem.edges) {
+    const Node &src = problem.nodes[edge.src];
+    const Node &dst = problem.nodes[edge.dst];
+    int64_t latency =
+        edge.distance == 0 ? std::max<int64_t>(edge.latency, 1) : edge.latency;
+    __int128 required = static_cast<__int128>(solution.cycles[edge.src]) +
+                        latency -
+                        static_cast<__int128>(edge.distance) * problem.ii;
+    if (problem.jointMode && solution.cycles[edge.dst] < required)
+      addViolation(result, "dependence N" + std::to_string(src.id) + " -> N" +
+                               std::to_string(dst.id) + " is violated");
+
+    if (!edge.srcCluster || !edge.dstCluster ||
+        *edge.srcCluster == *edge.dstCluster)
+      continue;
+    bool sameWG = solution.warpGroups[*edge.srcCluster] ==
+                  solution.warpGroups[*edge.dstCluster];
+    if ((src.pipeline == "TC" || src.pipeline == "MFMA") &&
+        (dst.pipeline == "CUDA" || dst.pipeline == "SFU") && sameWG)
+      addViolation(result, "tensor-core result N" + std::to_string(src.id) +
+                               " shares a warp group with software reader N" +
+                               std::to_string(dst.id));
+    if (edge.distance > 0 && edge.roundTrip > 0 && !sameWG)
+      addViolation(result, "loop-carried value N" + std::to_string(src.id) +
+                               " -> N" + std::to_string(dst.id) +
+                               " crosses warp groups");
+    if (problem.jointMode && edge.roundTrip > 0 &&
+        !(edge.distance > 0 && edge.roundTrip > 0) && !sameWG &&
+        solution.cycles[edge.dst] < required + edge.roundTrip)
+      addViolation(result, "cross-WG round trip N" + std::to_string(src.id) +
+                               " -> N" + std::to_string(dst.id) +
+                               " is violated");
+  }
+}
+
+namespace v01 {
+
+constexpr llvm::StringLiteral kProblemSchema = "joint-solver-0.1";
+
+struct Node {
+  int64_t id;
+  std::string pipeline;
+  int64_t duration;
+  bool streaming;
+};
+
+struct Edge {
+  size_t src;
+  size_t dst;
+  int64_t latency;
+  int64_t distance;
+};
+
+enum class BufferKind { Smem, Tmem };
+
+struct Buffer {
+  int64_t id;
+  size_t alloc;
+  BufferKind kind;
+  int64_t sizeBytes;
+  int64_t tmemCols;
+  std::vector<size_t> consumers;
+};
+
+struct Problem {
+  int64_t minII;
+  int64_t maxII;
+  int64_t smemBudget;
+  int64_t tmemColLimit;
+  bool streamingVL;
+  std::optional<size_t> canonicalRoot;
+  std::vector<Node> nodes;
+  std::vector<Edge> edges;
+  std::vector<Buffer> buffers;
+};
+
+struct Solution {
+  int64_t ii;
+  std::vector<int64_t> cycles;
+  std::map<int64_t, int64_t> bufferDepths;
+};
+
+static bool parseProblem(llvm::StringRef json, Problem &problem,
+                         std::string &error) {
+  auto parsed = llvm::json::parse(json);
+  if (!parsed)
+    return fail(error, "problem JSON parse failed: " +
+                           llvm::toString(parsed.takeError()));
+  auto *root = parsed->getAsObject();
+  if (!root || root->get("mode"))
+    return fail(error, "invalid joint-solver-0.1 problem object");
+  auto version = root->getString("version");
+  if (!version || *version != kProblemSchema)
+    return fail(error, "validator requires a joint-solver-0.1 problem");
+  if (!getInteger(*root, "min_ii", problem.minII) ||
+      !getInteger(*root, "max_ii", problem.maxII) ||
+      !getInteger(*root, "smem_budget", problem.smemBudget) ||
+      !getInteger(*root, "tmem_col_limit", problem.tmemColLimit) ||
+      problem.minII <= 0 || problem.maxII < problem.minII ||
+      problem.smemBudget < 0 || problem.tmemColLimit < 0)
+    return fail(error, "invalid joint-solver-0.1 budgets or II range");
+
+  if (root->get("time_limit_s")) {
+    auto value = root->getNumber("time_limit_s");
+    if (!value || !std::isfinite(*value) || *value <= 0.0)
+      return fail(error, "invalid time_limit_s");
+  }
+  problem.streamingVL = false;
+  if (root->get("streaming_vl")) {
+    auto value = root->getBoolean("streaming_vl");
+    if (!value)
+      return fail(error, "streaming_vl must be Boolean");
+    problem.streamingVL = *value;
+  }
+
+  auto *nodeValues = root->getArray("nodes");
+  auto *edgeValues = root->getArray("edges");
+  auto *bufferValues = root->getArray("buffers");
+  if (!nodeValues || !edgeValues || !bufferValues)
+    return fail(error, "joint-solver-0.1 problem is missing a required array");
+
+  std::map<int64_t, size_t> nodeIndices;
+  problem.nodes.reserve(nodeValues->size());
+  for (const llvm::json::Value &value : *nodeValues) {
+    auto *object = value.getAsObject();
+    int64_t id = 0;
+    int64_t duration = 0;
+    std::string pipeline;
+    if (!object || !getInteger(*object, "id", id) ||
+        !getInteger(*object, "duration", duration) || duration < 0 ||
+        !getString(*object, "pipeline", pipeline) || nodeIndices.count(id))
+      return fail(error, "invalid node in joint-solver-0.1 problem");
+    bool streaming = false;
+    if (object->get("streaming")) {
+      auto parsedStreaming = object->getBoolean("streaming");
+      if (!parsedStreaming)
+        return fail(error, "node streaming flag must be Boolean");
+      streaming = *parsedStreaming;
+    }
+    nodeIndices.emplace(id, problem.nodes.size());
+    problem.nodes.push_back(Node{id, std::move(pipeline), duration, streaming});
+  }
+
+  if (root->get("canonical_root")) {
+    int64_t rootId = 0;
+    if (!getInteger(*root, "canonical_root", rootId))
+      return fail(error, "canonical_root must be an integer");
+    auto rootNode = nodeIndices.find(rootId);
+    if (rootNode == nodeIndices.end())
+      return fail(error, "canonical_root names an unknown node");
+    problem.canonicalRoot = rootNode->second;
+  }
+
+  problem.edges.reserve(edgeValues->size());
+  for (const llvm::json::Value &value : *edgeValues) {
+    auto *object = value.getAsObject();
+    int64_t srcId = 0;
+    int64_t dstId = 0;
+    int64_t latency = 0;
+    int64_t distance = 0;
+    if (!object || !getInteger(*object, "src", srcId) ||
+        !getInteger(*object, "dst", dstId) ||
+        !getInteger(*object, "latency", latency) ||
+        !getInteger(*object, "distance", distance) || latency < 0 ||
+        distance < 0)
+      return fail(error, "invalid edge in joint-solver-0.1 problem");
+    auto src = nodeIndices.find(srcId);
+    auto dst = nodeIndices.find(dstId);
+    if (src == nodeIndices.end() || dst == nodeIndices.end())
+      return fail(error, "edge names an unknown node");
+    problem.edges.push_back(Edge{src->second, dst->second, latency, distance});
+  }
+
+  problem.buffers.reserve(bufferValues->size());
+  for (const llvm::json::Value &value : *bufferValues) {
+    auto *object = value.getAsObject();
+    int64_t allocId = 0;
+    int64_t sizeBytes = 0;
+    int64_t tmemCols = 0;
+    std::string kindName;
+    auto *consumers = object ? object->getArray("consumers") : nullptr;
+    if (!object || !getInteger(*object, "alloc_node", allocId) ||
+        !getString(*object, "kind", kindName) || !consumers ||
+        !getInteger(*object, "size_bytes", sizeBytes) ||
+        !getInteger(*object, "tmem_cols", tmemCols) || sizeBytes < 0 ||
+        tmemCols < 0)
+      return fail(error, "invalid buffer in joint-solver-0.1 problem");
+    auto alloc = nodeIndices.find(allocId);
+    if (alloc == nodeIndices.end())
+      return fail(error, "buffer allocation names an unknown node");
+    BufferKind kind;
+    if (kindName == "smem")
+      kind = BufferKind::Smem;
+    else if (kindName == "tmem")
+      kind = BufferKind::Tmem;
+    else
+      return fail(error, "unknown joint-solver-0.1 buffer kind");
+    int64_t id = allocId;
+    if (object->get("id") && !getInteger(*object, "id", id))
+      return fail(error, "buffer id must be an integer");
+    Buffer buffer{id, alloc->second, kind, sizeBytes, tmemCols, {}};
+    buffer.consumers.reserve(consumers->size());
+    for (const llvm::json::Value &consumerValue : *consumers) {
+      auto consumerId = consumerValue.getAsInteger();
+      if (!consumerId)
+        return fail(error, "buffer consumer ID must be an integer");
+      auto consumer = nodeIndices.find(*consumerId);
+      if (consumer == nodeIndices.end())
+        return fail(error, "buffer consumer names an unknown node");
+      buffer.consumers.push_back(consumer->second);
+    }
+    problem.buffers.push_back(std::move(buffer));
+  }
+  return true;
+}
+
+static bool parseSolution(llvm::StringRef json, const Problem &problem,
+                          Solution &solution, std::string &error) {
+  auto parsed = llvm::json::parse(json);
+  if (!parsed)
+    return fail(error, "solution JSON parse failed: " +
+                           llvm::toString(parsed.takeError()));
+  auto *root = parsed->getAsObject();
+  if (!root)
+    return fail(error, "solution must be a JSON object");
+  auto version = root->getString("version");
+  auto status = root->getString("status");
+  if (!version || *version != kProblemSchema || !status || *status != "ok")
+    return fail(error, "solution must be a successful joint-solver-0.1 result");
+  if (!getInteger(*root, "ii", solution.ii) || solution.ii <= 0)
+    return fail(error, "invalid solution II");
+  auto objective = root->getNumber("objective");
+  if (!objective || !std::isfinite(*objective))
+    return fail(error, "solution objective must be a finite number");
+  auto *stats = root->getObject("stats");
+  if (!stats)
+    return fail(error, "solution stats must be an object");
+
+  auto parseIIStats = [&](llvm::StringRef key,
+                          std::set<int64_t> &values) -> bool {
+    auto *array = stats->getArray(key);
+    if (!array)
+      return false;
+    std::optional<int64_t> previous;
+    for (const llvm::json::Value &value : *array) {
+      auto ii = value.getAsInteger();
+      if (!ii || *ii < problem.minII || *ii > problem.maxII ||
+          !values.insert(*ii).second || (previous && *ii <= *previous))
+        return false;
+      previous = *ii;
+    }
+    return true;
+  };
+  std::set<int64_t> tried;
+  std::set<int64_t> unsat;
+  std::set<int64_t> unknown;
+  if (!parseIIStats("iis_tried", tried) || !parseIIStats("unsat_iis", unsat) ||
+      !parseIIStats("unknown_iis", unknown))
+    return fail(error, "solution stats contains an invalid II list");
+  if (!tried.count(solution.ii))
+    return fail(error, "solution stats omits the selected II");
+  for (int64_t ii : unsat)
+    if (!tried.count(ii))
+      return fail(error, "solution stats reports an untried UNSAT II");
+  if (!unknown.empty())
+    return fail(error, "successful solution stats contains an unknown II");
+
+  std::map<int64_t, size_t> nodeIndices;
+  for (size_t index = 0; index < problem.nodes.size(); ++index)
+    nodeIndices.emplace(problem.nodes[index].id, index);
+  if (!parseAssignments(*root, "cycles", nodeIndices, solution.cycles, true,
+                        error))
+    return false;
+
+  auto *depths = root->getObject("buffer_depths");
+  if (!depths)
+    return fail(error, "buffer_depths must be an object");
+  std::set<int64_t> expectedDepths;
+  for (const Buffer &buffer : problem.buffers)
+    if (buffer.kind == BufferKind::Smem)
+      expectedDepths.insert(buffer.id);
+  for (const auto &entry : *depths) {
+    int64_t id = 0;
+    llvm::StringRef key(entry.first);
+    auto depth = entry.second.getAsInteger();
+    if (key.getAsInteger(10, id) || !depth || *depth <= 0 ||
+        !expectedDepths.erase(id))
+      return fail(error, "buffer_depths contains an invalid entry");
+    solution.bufferDepths.emplace(id, *depth);
+  }
+  if (!expectedDepths.empty())
+    return fail(error, "buffer_depths is incomplete");
+  return true;
+}
+
+static int64_t effectiveLatency(const Problem &problem, const Edge &edge) {
+  if (problem.streamingVL && problem.nodes[edge.src].streaming)
+    return 0;
+  return edge.latency;
+}
+
+static std::optional<int64_t> computeHorizon(const Problem &problem,
+                                             int64_t ii) {
+  if (problem.nodes.empty())
+    return ii;
+  __int128 maxAdvance = 1;
+  for (const Edge &edge : problem.edges) {
+    __int128 residual = static_cast<__int128>(effectiveLatency(problem, edge)) -
+                        static_cast<__int128>(edge.distance) * ii;
+    __int128 advance = (residual + static_cast<__int128>(2) * ii - 2) / ii;
+    maxAdvance = std::max(maxAdvance, advance);
+  }
+  __int128 maxStages =
+      1 + static_cast<__int128>(problem.nodes.size() - 1) * maxAdvance;
+  maxStages = std::max<__int128>(maxStages, 4);
+  __int128 horizon = maxStages * ii;
+  if (horizon <= 0 || horizon > std::numeric_limits<int64_t>::max())
+    return std::nullopt;
+  return static_cast<int64_t>(horizon);
+}
+
+static void validateSchedule(const Problem &problem, const Solution &solution,
+                             ValidationResult &result) {
+  if (solution.ii < problem.minII || solution.ii > problem.maxII)
+    addViolation(result, "solution II is outside the requested range");
+  auto horizon = computeHorizon(problem, solution.ii);
+  if (!horizon) {
+    addViolation(result, "joint-solver-0.1 horizon overflows int64");
+  } else {
+    for (size_t index = 0; index < problem.nodes.size(); ++index)
+      if (solution.cycles[index] >= *horizon)
+        addViolation(result, "node " + std::to_string(problem.nodes[index].id) +
+                                 " is outside the solver horizon");
+  }
+
+  if (problem.canonicalRoot) {
+    if (solution.cycles[*problem.canonicalRoot] != 0)
+      addViolation(result, "canonical root is not scheduled at cycle zero");
+  } else if (!solution.cycles.empty() &&
+             std::find(solution.cycles.begin(), solution.cycles.end(), 0) ==
+                 solution.cycles.end()) {
+    addViolation(result, "schedule has no node at cycle zero");
+  }
+
+  for (const Edge &edge : problem.edges) {
+    const Node &src = problem.nodes[edge.src];
+    const Node &dst = problem.nodes[edge.dst];
+    __int128 required = static_cast<__int128>(solution.cycles[edge.src]) +
+                        effectiveLatency(problem, edge) -
+                        static_cast<__int128>(edge.distance) * solution.ii;
+    if (solution.cycles[edge.dst] < required)
+      addViolation(result, "dependence N" + std::to_string(src.id) + " -> N" +
+                               std::to_string(dst.id) + " is violated");
+    if (edge.distance == 0 && solution.cycles[edge.src] / solution.ii >
+                                  solution.cycles[edge.dst] / solution.ii)
+      addViolation(result, "dependence N" + std::to_string(src.id) + " -> N" +
+                               std::to_string(dst.id) +
+                               " reverses stage order");
+  }
+
+  std::map<std::string, std::vector<size_t>> nodesByPipeline;
+  for (size_t index = 0; index < problem.nodes.size(); ++index) {
+    const Node &node = problem.nodes[index];
+    if (node.pipeline == "NONE")
+      continue;
+    int64_t duration = std::max<int64_t>(node.duration, 1);
+    if (duration > solution.ii)
+      addViolation(result, "node " + std::to_string(node.id) +
+                               " occupies more than one II");
+    nodesByPipeline[node.pipeline].push_back(index);
+  }
+  for (const auto &entry : nodesByPipeline) {
+    const std::vector<size_t> &members = entry.second;
+    for (size_t leftIndex = 0; leftIndex < members.size(); ++leftIndex) {
+      size_t left = members[leftIndex];
+      Issue leftIssue{solution.cycles[left],
+                      std::max<int64_t>(problem.nodes[left].duration, 1),
+                      entry.first,
+                      std::nullopt,
+                      {}};
+      for (size_t rightIndex = leftIndex + 1; rightIndex < members.size();
+           ++rightIndex) {
+        size_t right = members[rightIndex];
+        Issue rightIssue{solution.cycles[right],
+                         std::max<int64_t>(problem.nodes[right].duration, 1),
+                         entry.first,
+                         std::nullopt,
+                         {}};
+        if (cyclicOverlap(leftIssue, rightIssue, solution.ii))
+          addViolation(result,
+                       "nodes " + std::to_string(problem.nodes[left].id) +
+                           " and " + std::to_string(problem.nodes[right].id) +
+                           " overlap on pipeline " + entry.first);
+      }
+    }
+  }
+}
+
+static void validateMemory(const Problem &problem, const Solution &solution,
+                           ValidationResult &result) {
+  struct TmemLifetime {
+    __int128 start;
+    __int128 end;
+    int64_t columns;
+  };
+  __int128 smem = 0;
+  std::vector<TmemLifetime> tmemLifetimes;
+  for (const Buffer &buffer : problem.buffers) {
+    if (buffer.kind == BufferKind::Smem) {
+      int64_t allocStage = solution.cycles[buffer.alloc] / solution.ii;
+      int64_t lastStage = allocStage;
+      for (size_t consumer : buffer.consumers)
+        lastStage =
+            std::max(lastStage, solution.cycles[consumer] / solution.ii);
+      int64_t depth = lastStage - allocStage + 1;
+      auto actual = solution.bufferDepths.find(buffer.id);
+      if (actual == solution.bufferDepths.end() || actual->second != depth)
+        addViolation(result, "SMEM buffer " + std::to_string(buffer.id) +
+                                 " reports the wrong depth");
+      smem += static_cast<__int128>(buffer.sizeBytes) * depth;
+      continue;
+    }
+
+    int64_t lastCycle = solution.cycles[buffer.alloc];
+    for (size_t consumer : buffer.consumers)
+      lastCycle = std::max(lastCycle, solution.cycles[consumer]);
+    tmemLifetimes.push_back(TmemLifetime{solution.cycles[buffer.alloc],
+                                         static_cast<__int128>(lastCycle) + 1,
+                                         buffer.tmemCols});
+  }
+  if (smem > problem.smemBudget)
+    addViolation(result, "SMEM requirement " + wideToString(smem) +
+                             " exceeds budget " +
+                             std::to_string(problem.smemBudget));
+
+  __int128 peakTmem = 0;
+  for (const TmemLifetime &checkpoint : tmemLifetimes) {
+    __int128 active = 0;
+    for (const TmemLifetime &lifetime : tmemLifetimes)
+      if (lifetime.start <= checkpoint.start && checkpoint.start < lifetime.end)
+        active += lifetime.columns;
+    peakTmem = std::max(peakTmem, active);
+  }
+  if (peakTmem > problem.tmemColLimit)
+    addViolation(result, "TMEM requirement " + wideToString(peakTmem) +
+                             " exceeds column limit " +
+                             std::to_string(problem.tmemColLimit));
+}
+
+static void validate(const Problem &problem, const Solution &solution,
+                     ValidationResult &result) {
+  validateSchedule(problem, solution, result);
+  validateMemory(problem, solution, result);
+}
+
+} // namespace v01
+
+static bool readProblemSchema(llvm::StringRef json, std::string &schema,
+                              std::string &error) {
+  auto parsed = llvm::json::parse(json);
+  if (!parsed)
+    return fail(error, "problem JSON parse failed: " +
+                           llvm::toString(parsed.takeError()));
+  auto *root = parsed->getAsObject();
+  if (!root)
+    return fail(error, "problem must be a JSON object");
+  auto version = root->getString("version");
+  if (!version)
+    return fail(error, "problem version must be a string");
+  schema = version->str();
+  return true;
+}
+
+static std::string serializeResult(ValidationResult result) {
+  std::vector<std::string> normalized;
+  std::set<std::string> seen;
+  for (std::string &violation : result.violations)
+    if (seen.insert(violation).second)
+      normalized.push_back(std::move(violation));
+  bool valid = normalized.empty();
+  llvm::json::Array violations;
+  for (std::string &violation : normalized)
+    violations.push_back(std::move(violation));
+  llvm::json::Object output{
+      {"schema", kValidationSchema},
+      {"valid", valid},
+      {"message", valid ? "solution satisfies solver constraints"
+                        : "solution violates solver constraints"},
+      {"violations", std::move(violations)},
+  };
+  std::string json;
+  llvm::raw_string_ostream stream(json);
+  stream << llvm::json::Value(std::move(output));
+  stream.flush();
+  return json;
+}
+
+} // namespace
+
+std::string validateZ3JointSolution(llvm::StringRef problemJson,
+                                    llvm::StringRef solutionJson) {
+  ValidationResult result;
+  std::string schema;
+  std::string error;
+  if (!readProblemSchema(problemJson, schema, error)) {
+    addViolation(result, std::move(error));
+    return serializeResult(std::move(result));
+  }
+  if (schema == v01::kProblemSchema) {
+    v01::Problem problem;
+    v01::Solution solution;
+    if (!v01::parseProblem(problemJson, problem, error)) {
+      addViolation(result, std::move(error));
+      return serializeResult(std::move(result));
+    }
+    if (!v01::parseSolution(solutionJson, problem, solution, error)) {
+      addViolation(result, std::move(error));
+      return serializeResult(std::move(result));
+    }
+    v01::validate(problem, solution, result);
+    return serializeResult(std::move(result));
+  }
+  if (schema != kProblemSchema) {
+    addViolation(result, "validator requires a joint-solver-0.1 or "
+                         "joint-solver-0.2 problem");
+    return serializeResult(std::move(result));
+  }
+  Problem problem;
+  Solution solution;
+  if (!parseProblem(problemJson, problem, error)) {
+    addViolation(result, std::move(error));
+    return serializeResult(std::move(result));
+  }
+  if (!parseSolution(solutionJson, problem, solution, error)) {
+    addViolation(result, std::move(error));
+    return serializeResult(std::move(result));
+  }
+
+  validateSchedule(problem, solution, result);
+  auto expectedEvents = buildExpectedEvents(problem, solution, result);
+  validateLoweringPlan(problem, solution, expectedEvents, result);
+  validateIssueOccupancy(problem, solution, expectedEvents, result);
+  validateMemory(problem, solution, result);
+  validateRegisters(problem, solution, result);
+  return serializeResult(std::move(result));
+}
+
+} // namespace mlir::triton::gpu

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/Z3JointSolutionValidator.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/Z3JointSolutionValidator.h
@@ -1,0 +1,20 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#ifndef TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_Z3_JOINT_SOLUTION_VALIDATOR_H
+#define TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_Z3_JOINT_SOLUTION_VALIDATOR_H
+
+#include "llvm/ADT/StringRef.h"
+
+#include <string>
+
+namespace mlir::triton::gpu {
+
+/// Independently validate a joint-solver-0.1 or joint-solver-0.2 result.
+/// The joint-solver-validation-0.1 JSON contains `valid`, `message`, and
+/// `violations` fields.
+std::string validateZ3JointSolution(llvm::StringRef problemJson,
+                                    llvm::StringRef solutionJson);
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_Z3_JOINT_SOLUTION_VALIDATOR_H

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/Z3JointSolver.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/Z3JointSolver.cpp
@@ -159,6 +159,665 @@ private:
 
 enum class CandidateStatus { Sat, Unsat, Unknown, Error };
 
+constexpr llvm::StringLiteral kUnsatCoreSchema = "joint-solver-core-0.1";
+constexpr llvm::StringLiteral kDiagnosticSchema = "joint-solver-diagnostic-0.1";
+constexpr size_t kCoreMinimizeMaxGroups = 32;
+constexpr std::chrono::milliseconds kCoreMinimizeBudget(250);
+
+struct UnsatEvidence {
+  std::vector<std::string> groupIds;
+  std::string normalization = "normalized";
+};
+
+struct ConstraintProvenance {
+  std::string id;
+  std::string kind;
+  std::vector<int64_t> nodes;
+  std::optional<std::string> pipeline;
+  std::optional<std::string> relation;
+  std::optional<std::string> reason;
+  std::optional<std::string> capability;
+  std::optional<std::string> conditionalOn;
+  std::optional<int64_t> latency;
+  std::optional<int64_t> baseLatency;
+  std::optional<int64_t> roundTripLatency;
+  std::optional<int64_t> requiredLatency;
+  std::optional<int64_t> distance;
+  std::optional<int64_t> result;
+  std::optional<int64_t> buffer;
+  std::optional<int64_t> sizeBytes;
+  std::optional<int64_t> columns;
+  std::optional<int64_t> required;
+  bool emitRequired = false;
+  std::optional<int64_t> requiredLowerBound;
+  std::optional<int64_t> requiredWhenActive;
+  std::optional<bool> requiredIsDynamic;
+  std::optional<int64_t> available;
+  std::optional<int64_t> cluster;
+  std::optional<int64_t> minWarps;
+  std::optional<int64_t> group;
+  std::optional<int64_t> fixedStage;
+  std::optional<int64_t> loweringTemplate;
+  std::optional<int64_t> event;
+  std::vector<int64_t> channel;
+};
+
+using ProvenanceMap = std::map<std::string, ConstraintProvenance>;
+
+static int constraintKindRank(llvm::StringRef groupId) {
+  llvm::StringRef prefix = groupId.split(':').first;
+  if (prefix == "dep" || prefix == "dependence")
+    return 0;
+  if (prefix == "resource")
+    return 1;
+  if (prefix == "smem")
+    return 2;
+  if (prefix == "tmem")
+    return 3;
+  if (prefix == "warp-group")
+    return 4;
+  if (prefix == "register")
+    return 5;
+  if (prefix == "lowering")
+    return 6;
+  return 7;
+}
+
+static llvm::StringRef constraintKind(llvm::StringRef groupId) {
+  llvm::StringRef prefix = groupId.split(':').first;
+  return prefix == "dep" ? llvm::StringRef("dependence") : prefix;
+}
+
+static void normalizeCore(std::vector<std::string> &groupIds) {
+  llvm::sort(groupIds, [](const std::string &left, const std::string &right) {
+    int leftRank = constraintKindRank(left);
+    int rightRank = constraintKindRank(right);
+    return std::tie(leftRank, left) < std::tie(rightRank, right);
+  });
+  groupIds.erase(std::unique(groupIds.begin(), groupIds.end()), groupIds.end());
+}
+
+static void addProvenance(ProvenanceMap &provenance,
+                          ConstraintProvenance record) {
+  llvm::sort(record.nodes);
+  record.nodes.erase(std::unique(record.nodes.begin(), record.nodes.end()),
+                     record.nodes.end());
+  auto found = provenance.find(record.id);
+  if (found == provenance.end()) {
+    provenance.emplace(record.id, std::move(record));
+    return;
+  }
+  ConstraintProvenance &existing = found->second;
+  auto takeMaximum = [](std::optional<int64_t> &target,
+                        std::optional<int64_t> value) {
+    if (value)
+      target = target ? std::max(*target, *value) : value;
+  };
+  takeMaximum(existing.latency, record.latency);
+  takeMaximum(existing.baseLatency, record.baseLatency);
+  takeMaximum(existing.roundTripLatency, record.roundTripLatency);
+  takeMaximum(existing.requiredLatency, record.requiredLatency);
+  takeMaximum(existing.required, record.required);
+  takeMaximum(existing.requiredLowerBound, record.requiredLowerBound);
+  takeMaximum(existing.requiredWhenActive, record.requiredWhenActive);
+}
+
+static int64_t saturatedAdd(int64_t left, int64_t right) {
+  __int128 value = static_cast<__int128>(left) + right;
+  return static_cast<int64_t>(
+      std::min<__int128>(value, std::numeric_limits<int64_t>::max()));
+}
+
+static int64_t saturatedMultiply(int64_t left, int64_t right) {
+  __int128 value = static_cast<__int128>(left) * right;
+  return static_cast<int64_t>(
+      std::min<__int128>(value, std::numeric_limits<int64_t>::max()));
+}
+
+static llvm::json::Array integerArray(llvm::ArrayRef<int64_t> values) {
+  llvm::json::Array result;
+  result.reserve(values.size());
+  for (int64_t value : values)
+    result.push_back(value);
+  return result;
+}
+
+static llvm::json::Object provenanceToJson(const ConstraintProvenance &record) {
+  llvm::json::Object result{
+      {"id", record.id},
+      {"kind", record.kind},
+      {"nodes", integerArray(record.nodes)},
+  };
+  auto addString = [&](llvm::StringRef key,
+                       const std::optional<std::string> &value) {
+    if (value)
+      result[key] = *value;
+  };
+  auto addInteger = [&](llvm::StringRef key, std::optional<int64_t> value) {
+    if (value)
+      result[key] = *value;
+  };
+  addString("pipeline", record.pipeline);
+  addString("relation", record.relation);
+  addString("reason", record.reason);
+  addString("capability", record.capability);
+  addString("conditional_on", record.conditionalOn);
+  addInteger("latency", record.latency);
+  addInteger("base_latency", record.baseLatency);
+  addInteger("round_trip_latency", record.roundTripLatency);
+  addInteger("required_latency", record.requiredLatency);
+  addInteger("distance", record.distance);
+  addInteger("result", record.result);
+  addInteger("buffer", record.buffer);
+  addInteger("size_bytes", record.sizeBytes);
+  addInteger("columns", record.columns);
+  if (record.emitRequired)
+    result["required"] = record.required ? llvm::json::Value(*record.required)
+                                         : llvm::json::Value(nullptr);
+  addInteger("required_lower_bound", record.requiredLowerBound);
+  addInteger("required_when_active", record.requiredWhenActive);
+  if (record.requiredIsDynamic)
+    result["required_is_dynamic"] = *record.requiredIsDynamic;
+  addInteger("available", record.available);
+  addInteger("cluster", record.cluster);
+  addInteger("min_warps", record.minWarps);
+  addInteger("group", record.group);
+  addInteger("fixed_stage", record.fixedStage);
+  addInteger("template", record.loweringTemplate);
+  addInteger("event", record.event);
+  if (!record.channel.empty())
+    result["channel"] = integerArray(record.channel);
+  return result;
+}
+
+class AssumptionTracker {
+public:
+  AssumptionTracker(Z3_context context, const Z3ConstraintEncoder &encoder)
+      : context(context), encoder(encoder) {}
+
+  Z3_ast get(llvm::StringRef groupId) {
+    std::string key = groupId.str();
+    auto found = assumptions.find(key);
+    if (found != assumptions.end())
+      return found->second;
+    std::string name =
+        "constraint_assumption_" +
+        std::to_string(static_cast<unsigned>(assumptions.size()));
+    Z3_ast literal =
+        Z3_mk_const(context, Z3_mk_string_symbol(context, name.c_str()),
+                    Z3_mk_bool_sort(context));
+    assumptions.emplace(std::move(key), literal);
+    labelsByAst.emplace(Z3_get_ast_id(context, literal), groupId.str());
+    return literal;
+  }
+
+  void assertFormula(llvm::StringRef groupId, Z3_ast formula) {
+    encoder.assertFormula(encoder.implies(get(groupId), formula));
+  }
+
+  std::vector<Z3_ast> literals() const {
+    std::vector<Z3_ast> result;
+    result.reserve(assumptions.size());
+    for (const auto &[_, literal] : assumptions)
+      result.push_back(literal);
+    return result;
+  }
+
+  /// Literals for the named constraint kinds only (kinds as reported by
+  /// `constraintKind`, e.g. "resource", "dependence", "smem", "tmem").
+  /// Omitting a group's literal from the assumption vector leaves it a free
+  /// boolean, so Z3 may satisfy `literal -> constraint` by setting the literal
+  /// false — i.e. the group is relaxed away. The result is the corresponding
+  /// relaxed model, whose feasible set is a superset of the full model's.
+  std::vector<Z3_ast>
+  literalsForKinds(const std::set<std::string> &kinds) const {
+    std::vector<Z3_ast> result;
+    for (const auto &[groupId, literal] : assumptions)
+      if (kinds.count(constraintKind(groupId).str()))
+        result.push_back(literal);
+    return result;
+  }
+
+  std::optional<std::vector<Z3_ast>>
+  literalsFor(llvm::ArrayRef<std::string> groupIds) const {
+    std::vector<Z3_ast> result;
+    result.reserve(groupIds.size());
+    for (const std::string &groupId : groupIds) {
+      auto found = assumptions.find(groupId);
+      if (found == assumptions.end())
+        return std::nullopt;
+      result.push_back(found->second);
+    }
+    return result;
+  }
+
+  std::optional<std::vector<std::string>>
+  resolveCore(Z3_ast_vector rawCore) const {
+    if (!rawCore)
+      return std::nullopt;
+    std::vector<std::string> result;
+    unsigned size = Z3_ast_vector_size(context, rawCore);
+    result.reserve(size);
+    for (unsigned index = 0; index < size; ++index) {
+      Z3_ast literal = Z3_ast_vector_get(context, rawCore, index);
+      if (!literal)
+        return std::nullopt;
+      auto found = labelsByAst.find(Z3_get_ast_id(context, literal));
+      if (found == labelsByAst.end())
+        return std::nullopt;
+      result.push_back(found->second);
+    }
+    normalizeCore(result);
+    return result;
+  }
+
+private:
+  Z3_context context;
+  const Z3ConstraintEncoder &encoder;
+  std::map<std::string, Z3_ast> assumptions;
+  std::unordered_map<unsigned, std::string> labelsByAst;
+};
+
+static Z3_lbool checkWithAssumptions(Z3_context context, Z3_solver solver,
+                                     llvm::ArrayRef<Z3_ast> assumptions) {
+  return Z3_solver_check_assumptions(
+      context, solver, static_cast<unsigned>(assumptions.size()),
+      assumptions.empty() ? nullptr : assumptions.data());
+}
+
+static Z3_lbool checkWithAssumptions(Z3_context context, Z3_optimize optimize,
+                                     llvm::ArrayRef<Z3_ast> assumptions) {
+  return Z3_optimize_check(context, optimize,
+                           static_cast<unsigned>(assumptions.size()),
+                           assumptions.empty() ? nullptr : assumptions.data());
+}
+
+static UnsatEvidence extractUnsatEvidence(Z3_context context, Z3_solver solver,
+                                          const AssumptionTracker &tracker) {
+  UnsatEvidence evidence;
+  auto groupIds =
+      tracker.resolveCore(Z3_solver_get_unsat_core(context, solver));
+  if (groupIds)
+    evidence.groupIds = std::move(*groupIds);
+  return evidence;
+}
+
+static UnsatEvidence extractUnsatEvidence(Z3_context context,
+                                          Z3_optimize optimize,
+                                          const AssumptionTracker &tracker) {
+  UnsatEvidence evidence;
+  auto groupIds =
+      tracker.resolveCore(Z3_optimize_get_unsat_core(context, optimize));
+  if (groupIds)
+    evidence.groupIds = std::move(*groupIds);
+  return evidence;
+}
+
+static bool
+configureCoreCheckTimeout(Z3_context context, Z3_solver solver,
+                          std::chrono::steady_clock::time_point deadline) {
+  auto now = std::chrono::steady_clock::now();
+  if (now >= deadline)
+    return false;
+  auto remaining =
+      std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now)
+          .count();
+  unsigned timeout = static_cast<unsigned>(std::max<int64_t>(
+      1, std::min<int64_t>(remaining, std::numeric_limits<unsigned>::max())));
+  Z3_params params = Z3_mk_params(context);
+  if (!params)
+    return false;
+  Z3_params_inc_ref(context, params);
+  Z3_params_set_uint(context, params, Z3_mk_string_symbol(context, "timeout"),
+                     timeout);
+  Z3_solver_set_params(context, solver, params);
+  Z3_params_dec_ref(context, params);
+  return !z3ErrorSeen;
+}
+
+static void
+minimizeUnsatEvidence(Z3_context context, Z3_solver solver,
+                      const AssumptionTracker &tracker,
+                      std::chrono::steady_clock::time_point solverDeadline,
+                      UnsatEvidence &evidence) {
+  if (evidence.groupIds.empty() ||
+      evidence.groupIds.size() > kCoreMinimizeMaxGroups || z3ErrorSeen)
+    return;
+  auto deadline = std::min(solverDeadline, std::chrono::steady_clock::now() +
+                                               kCoreMinimizeBudget);
+  bool completed = true;
+  for (size_t index = 0; index < evidence.groupIds.size();) {
+    if (!configureCoreCheckTimeout(context, solver, deadline)) {
+      completed = false;
+      break;
+    }
+    std::vector<std::string> trial = evidence.groupIds;
+    trial.erase(trial.begin() + index);
+    auto trialLiterals = tracker.literalsFor(trial);
+    if (!trialLiterals) {
+      completed = false;
+      break;
+    }
+    Z3_lbool status = checkWithAssumptions(context, solver, *trialLiterals);
+    if (z3ErrorSeen) {
+      completed = false;
+      break;
+    }
+    if (status == Z3_L_FALSE) {
+      evidence.groupIds = std::move(trial);
+      continue;
+    }
+    if (status != Z3_L_TRUE) {
+      completed = false;
+      break;
+    }
+    ++index;
+  }
+  if (completed)
+    evidence.normalization = "locally_minimized";
+}
+
+static std::string dependenceGroupId(int64_t src, int64_t dst,
+                                     int64_t distance) {
+  return "dep:N" + std::to_string(src) + "->N" + std::to_string(dst) + ":d" +
+         std::to_string(distance);
+}
+
+static std::string resourceGroupId(llvm::StringRef pipeline, int64_t node) {
+  return "resource:" + pipeline.str() + ":N" + std::to_string(node);
+}
+
+static std::string bufferGroupId(llvm::StringRef kind, int64_t buffer) {
+  return kind.str() + ":buffer" + std::to_string(buffer);
+}
+
+static std::string clusterGroupId(int64_t cluster) {
+  return "warp-group:cluster" + std::to_string(cluster);
+}
+
+static std::string crossWGGroupId(int64_t src, int64_t dst, int64_t distance,
+                                  int64_t result) {
+  return "dep:cross-wg-rt:N" + std::to_string(src) + "->N" +
+         std::to_string(dst) + ":d" + std::to_string(distance) + ":r" +
+         std::to_string(result);
+}
+
+static std::string channelGroupId(int64_t src, int64_t dst, int64_t result) {
+  return "smem:channel:N" + std::to_string(src) + "->N" + std::to_string(dst) +
+         ":r" + std::to_string(result);
+}
+
+static std::string loopCarriedGroupId(int64_t src, int64_t dst,
+                                      int64_t distance, int64_t result) {
+  return "warp-group:loop-carried:N" + std::to_string(src) + "->N" +
+         std::to_string(dst) + ":d" + std::to_string(distance) + ":r" +
+         std::to_string(result);
+}
+
+static std::string fixedStageGroupId(int64_t node) {
+  return "lowering:fixed-stage:N" + std::to_string(node);
+}
+
+static std::string loweringEventGroupId(int64_t loweringTemplate,
+                                        int64_t event) {
+  return "lowering:template" + std::to_string(loweringTemplate) + ":event" +
+         std::to_string(event);
+}
+
+static llvm::json::Array coreGroupIds(const UnsatEvidence &evidence) {
+  llvm::json::Array result;
+  result.reserve(evidence.groupIds.size());
+  for (const std::string &groupId : evidence.groupIds)
+    result.push_back(groupId);
+  return result;
+}
+
+static llvm::json::Object makeUnsatCore(int64_t ii,
+                                        const UnsatEvidence &evidence) {
+  return llvm::json::Object{
+      {"schema", kUnsatCoreSchema},
+      {"candidateII", ii},
+      {"groupIds", coreGroupIds(evidence)},
+      {"backendStatus", "INFEASIBLE"},
+      {"provenUnsat", true},
+      {"normalization", evidence.normalization},
+  };
+}
+
+static std::vector<std::string>
+missingProvenance(const UnsatEvidence &evidence,
+                  const ProvenanceMap &provenance) {
+  std::vector<std::string> result;
+  for (const std::string &groupId : evidence.groupIds)
+    if (provenance.count(groupId) == 0)
+      result.push_back(groupId);
+  return result;
+}
+
+static llvm::json::Array
+makeAggregates(llvm::ArrayRef<const ConstraintProvenance *> records,
+               int64_t ii) {
+  llvm::json::Array aggregates;
+  std::map<std::string, std::vector<const ConstraintProvenance *>>
+      resourcesByPipeline;
+  std::map<std::string, std::vector<const ConstraintProvenance *>> byKind;
+  for (const ConstraintProvenance *record : records) {
+    byKind[record->kind].push_back(record);
+    if (record->kind == "resource")
+      resourcesByPipeline[record->pipeline.value_or("unknown")].push_back(
+          record);
+  }
+  for (const auto &[pipeline, resources] : resourcesByPipeline) {
+    int64_t required = 0;
+    for (const ConstraintProvenance *record : resources)
+      required = saturatedAdd(required, record->required.value_or(0));
+    aggregates.push_back(llvm::json::Object{
+        {"kind", "resource"},
+        {"resource", pipeline},
+        {"required", required},
+        {"available", resources.front()->available.value_or(ii)},
+    });
+  }
+  for (llvm::StringRef kind :
+       {"dependence", "smem", "tmem", "warp-group", "register", "lowering"}) {
+    auto found = byKind.find(kind.str());
+    if (found == byKind.end())
+      continue;
+    const auto &kindRecords = found->second;
+    bool exact = true;
+    int64_t exactRequired = 0;
+    int64_t lowerBound = 0;
+    for (const ConstraintProvenance *record : kindRecords) {
+      if (!record->emitRequired || !record->required)
+        exact = false;
+      if (kind == "tmem") {
+        exactRequired = std::max(exactRequired, record->required.value_or(0));
+        lowerBound = std::max(lowerBound, record->requiredLowerBound.value_or(
+                                              record->required.value_or(0)));
+      } else {
+        exactRequired =
+            saturatedAdd(exactRequired, record->required.value_or(0));
+        lowerBound = saturatedAdd(
+            lowerBound,
+            record->requiredLowerBound.value_or(record->required.value_or(0)));
+      }
+    }
+    if (kind == "dependence" || kind == "warp-group" || kind == "lowering")
+      exact = false;
+    if (kind == "warp-group")
+      lowerBound = 1;
+    llvm::json::Object aggregate{
+        {"kind", kind},
+        {"required",
+         exact ? llvm::json::Value(exactRequired) : llvm::json::Value(nullptr)},
+        {"available", kindRecords.front()->available.value_or(ii)},
+    };
+    if (!exact) {
+      aggregate["required_lower_bound"] = lowerBound;
+      aggregate["required_is_dynamic"] = true;
+    }
+    aggregates.push_back(std::move(aggregate));
+  }
+  llvm::sort(aggregates,
+             [](const llvm::json::Value &left, const llvm::json::Value &right) {
+               auto *leftObject = left.getAsObject();
+               auto *rightObject = right.getAsObject();
+               llvm::StringRef leftKind = *leftObject->getString("kind");
+               llvm::StringRef rightKind = *rightObject->getString("kind");
+               int leftRank = constraintKindRank(leftKind);
+               int rightRank = constraintKindRank(rightKind);
+               llvm::StringRef leftResource =
+                   leftObject->getString("resource").value_or("");
+               llvm::StringRef rightResource =
+                   rightObject->getString("resource").value_or("");
+               return std::tie(leftRank, leftResource) <
+                      std::tie(rightRank, rightResource);
+             });
+  return aggregates;
+}
+
+static llvm::json::Object makeUnsatDiagnostic(int64_t ii,
+                                              const UnsatEvidence &evidence,
+                                              const ProvenanceMap &provenance) {
+  std::vector<std::string> missing = missingProvenance(evidence, provenance);
+  if (evidence.groupIds.empty() || !missing.empty()) {
+    llvm::json::Object diagnostic{
+        {"schema", kDiagnosticSchema},
+        {"status", "coverage_error"},
+        {"ii", ii},
+        {"backendStatus", "INFEASIBLE"},
+        {"provenUnsat", true},
+        {"message", evidence.groupIds.empty()
+                        ? "backend returned no attributable assumption core"
+                        : "UNSAT core contains constraint groups without "
+                          "provenance"},
+    };
+    if (!missing.empty()) {
+      llvm::json::Array missingIds;
+      for (const std::string &groupId : missing)
+        missingIds.push_back(groupId);
+      diagnostic["missingGroupIds"] = std::move(missingIds);
+    }
+    return diagnostic;
+  }
+
+  llvm::json::Array constraints;
+  std::vector<const ConstraintProvenance *> records;
+  records.reserve(evidence.groupIds.size());
+  std::vector<std::string> kinds;
+  for (const std::string &groupId : evidence.groupIds) {
+    const ConstraintProvenance &record = provenance.at(groupId);
+    constraints.push_back(provenanceToJson(record));
+    records.push_back(&record);
+    if (llvm::find(kinds, record.kind) == kinds.end())
+      kinds.push_back(record.kind);
+  }
+  llvm::sort(kinds, [](const std::string &left, const std::string &right) {
+    return constraintKindRank(left) < constraintKindRank(right);
+  });
+  const std::map<std::string, std::string> names{
+      {"dependence", "dependence or recurrence bound"},
+      {"resource", "pipeline resource capacity"},
+      {"smem", "SMEM capacity"},
+      {"tmem", "TMEM capacity"},
+      {"warp-group", "warp-group legality"},
+      {"register", "register limit"},
+      {"lowering", "lowering or emitter capability"},
+  };
+  std::string summary =
+      "Candidate II " + std::to_string(ii) + " conflicts with ";
+  for (size_t index = 0; index < kinds.size(); ++index) {
+    if (index)
+      summary += ", ";
+    auto name = names.find(kinds[index]);
+    summary += name == names.end() ? kinds[index] : name->second;
+  }
+
+  llvm::json::Array suggestions;
+  for (const std::string &kind : kinds) {
+    bool crossWG = false;
+    bool channel = false;
+    bool loopCarried = false;
+    bool fixedStage = false;
+    for (const ConstraintProvenance *record : records) {
+      if (record->kind != kind)
+        continue;
+      crossWG |= record->roundTripLatency.has_value();
+      channel |= llvm::StringRef(record->id).starts_with("smem:channel:");
+      loopCarried |= record->reason == "loop_carried_register";
+      fixedStage |=
+          llvm::StringRef(record->id).starts_with("lowering:fixed-stage:");
+    }
+    if (kind == "dependence" && crossWG)
+      suggestions.push_back(
+          "consider reducing cross-WG handoff latency or revising the "
+          "warp-group split");
+    else if (kind == "smem" && channel)
+      suggestions.push_back(
+          "consider reducing cross-WG channel storage or revising the "
+          "warp-group split");
+    else if (kind == "warp-group" && loopCarried)
+      suggestions.push_back(
+          "consider revising the warp-group split to keep the loop-carried "
+          "value in one group");
+    else if (kind == "lowering" && fixedStage)
+      suggestions.push_back(
+          "consider allowing stage movement in the emitter or revising the "
+          "fixed-stage schedule");
+    else if (kind == "dependence")
+      suggestions.push_back(
+          "consider increasing II or reducing the reported recurrence "
+          "latency");
+    else if (kind == "resource")
+      suggestions.push_back(
+          "consider increasing II or reducing the reported pipeline "
+          "reservation");
+    else if (kind == "smem")
+      suggestions.push_back("consider reducing buffer depth or tile size");
+    else if (kind == "tmem")
+      suggestions.push_back(
+          "consider reducing overlapping TMEM columns or lifetimes");
+    else if (kind == "warp-group")
+      suggestions.push_back(
+          "consider allowing another warp group or revising the reported "
+          "incompatibility");
+    else if (kind == "register")
+      suggestions.push_back(
+          "consider reducing per-group warp or register requirements");
+    else if (kind == "lowering")
+      suggestions.push_back(
+          "consider a lowering template supported at the candidate II");
+  }
+
+  return llvm::json::Object{
+      {"schema", kDiagnosticSchema},
+      {"status", "unsat"},
+      {"ii", ii},
+      {"summary", std::move(summary)},
+      {"core", makeUnsatCore(ii, evidence)},
+      {"constraints", std::move(constraints)},
+      {"aggregates", makeAggregates(records, ii)},
+      {"suggestions", std::move(suggestions)},
+  };
+}
+
+static llvm::json::Object makeInconclusiveDiagnostic(int64_t ii,
+                                                     llvm::StringRef message) {
+  return llvm::json::Object{
+      {"schema", kDiagnosticSchema}, {"status", "inconclusive"}, {"ii", ii},
+      {"backendStatus", "UNKNOWN"},  {"message", message},
+  };
+}
+
+static void addUnsatDiagnostic(llvm::json::Object &result, int64_t ii,
+                               const UnsatEvidence &evidence,
+                               const ProvenanceMap &provenance) {
+  result["diagnostic"] = makeUnsatDiagnostic(ii, evidence, provenance);
+  if (!evidence.groupIds.empty() &&
+      missingProvenance(evidence, provenance).empty())
+    result["unsat_core"] = makeUnsatCore(ii, evidence);
+}
+
 static std::string serialize(llvm::json::Object object) {
   std::string output;
   llvm::raw_string_ostream stream(output);
@@ -398,7 +1057,28 @@ struct Problem {
   std::vector<Node> nodes;
   std::vector<Edge> edges;
   std::vector<Buffer> buffers;
+  // Assumption-gated constraint kinds to KEEP. Empty = the full model.
+  // Non-empty selects a relaxation, whose minimum feasible II is a lower
+  // bound on the full model's. Not every constraint is assumption-gated, so
+  // the relaxation is never a *pure* single-kind model — see
+  // `kUntrackedHardAssertions`.
+  std::set<std::string> relaxKeepKinds;
 };
+
+/// Constraints that stay hard assertions regardless of `relaxKeepKinds`,
+/// because they are asserted directly on the encoder rather than through
+/// `AssumptionTracker`. A relaxed bound is therefore tighter than a textbook
+/// relaxation of the same kinds — which keeps it a valid lower bound (a
+/// tighter bound is a stronger soundness test), but means it must not be
+/// reported as one. Mirrored in the report emitted by the baseline
+/// comparison; keep the two in sync.
+///
+/// Note that dropping the `smem`/`tmem` literals zeroes their charges, so the
+/// two budget ceilings survive but go vacuous; only the domain bounds and the
+/// canonical-root pin actually bind in a resource-only relaxation.
+constexpr llvm::StringLiteral kUntrackedHardAssertions =
+    "cycle domain bounds (0 <= cycle < horizon), canonical-root pinning, "
+    "smemTotal <= smem_budget, per-checkpoint TMEM columns <= tmem_col_limit";
 
 static std::optional<Problem> parseProblem(llvm::StringRef problemJson) {
   auto parsed = llvm::json::parse(problemJson);
@@ -430,6 +1110,18 @@ static std::optional<Problem> parseProblem(llvm::StringRef problemJson) {
     if (!value)
       return std::nullopt;
     problem.streamingVL = *value;
+  }
+
+  if (root->get("relax_keep_kinds")) {
+    auto *kinds = root->getArray("relax_keep_kinds");
+    if (!kinds || kinds->empty())
+      return std::nullopt;
+    for (const llvm::json::Value &value : *kinds) {
+      auto kind = value.getAsString();
+      if (!kind || kind->empty())
+        return std::nullopt;
+      problem.relaxKeepKinds.insert(kind->str());
+    }
   }
 
   auto *nodeValues = root->getArray("nodes");
@@ -551,6 +1243,58 @@ static int64_t effectiveLatency(const Problem &problem, const Edge &edge) {
   return edge.latency;
 }
 
+static ProvenanceMap constraintProvenance(const Problem &problem, int64_t ii) {
+  ProvenanceMap provenance;
+  for (const Edge &edge : problem.edges) {
+    const Node &src = problem.nodes[edge.src];
+    const Node &dst = problem.nodes[edge.dst];
+    ConstraintProvenance record;
+    record.id = dependenceGroupId(src.id, dst.id, edge.distance);
+    record.kind = "dependence";
+    record.nodes = {src.id, dst.id};
+    record.latency = effectiveLatency(problem, edge);
+    record.distance = edge.distance;
+    record.available = ii;
+    addProvenance(provenance, std::move(record));
+  }
+  for (const Node &node : problem.nodes) {
+    if (node.pipeline == "NONE")
+      continue;
+    ConstraintProvenance record;
+    record.id = resourceGroupId(node.pipeline, node.id);
+    record.kind = "resource";
+    record.nodes = {node.id};
+    record.pipeline = node.pipeline;
+    record.required = std::max<int64_t>(node.duration, 1);
+    record.emitRequired = true;
+    record.available = ii;
+    addProvenance(provenance, std::move(record));
+  }
+  for (const Buffer &buffer : problem.buffers) {
+    ConstraintProvenance record;
+    record.id = bufferGroupId(buffer.kind == BufferKind::Smem ? "smem" : "tmem",
+                              buffer.id);
+    record.kind = buffer.kind == BufferKind::Smem ? "smem" : "tmem";
+    record.nodes.push_back(problem.nodes[buffer.alloc].id);
+    for (size_t consumer : buffer.consumers)
+      record.nodes.push_back(problem.nodes[consumer].id);
+    record.buffer = buffer.id;
+    record.emitRequired = true;
+    record.requiredIsDynamic = true;
+    if (buffer.kind == BufferKind::Smem) {
+      record.sizeBytes = buffer.sizeBytes;
+      record.requiredLowerBound = buffer.sizeBytes;
+      record.available = problem.smemBudget;
+    } else {
+      record.columns = buffer.tmemCols;
+      record.requiredLowerBound = buffer.tmemCols;
+      record.available = problem.tmemColLimit;
+    }
+    addProvenance(provenance, std::move(record));
+  }
+  return provenance;
+}
+
 static std::optional<int64_t> computeHorizon(const Problem &problem,
                                              int64_t ii) {
   if (problem.nodes.empty())
@@ -632,11 +1376,13 @@ struct CandidateResult {
   __int128 objective = 0;
   BudgetExhausted budgetExhausted = BudgetExhausted::None;
   std::optional<uint64_t> rlimitUsed;
+  UnsatEvidence unsatEvidence;
 };
 
 static CandidateResult
 solveCandidate(const Problem &problem, int64_t ii,
-               std::chrono::steady_clock::time_point deadline) {
+               std::chrono::steady_clock::time_point deadline,
+               bool minimizeCore) {
   CandidateResult result;
   auto horizon = computeHorizon(problem, ii);
   if (!horizon)
@@ -646,6 +1392,8 @@ solveCandidate(const Problem &problem, int64_t ii,
   for (const Node &node : problem.nodes) {
     if (node.pipeline != "NONE" && std::max<int64_t>(node.duration, 1) > ii) {
       result.status = CandidateStatus::Unsat;
+      result.unsatEvidence.groupIds = {resourceGroupId(node.pipeline, node.id)};
+      result.unsatEvidence.normalization = "precheck";
       return result;
     }
   }
@@ -666,6 +1414,7 @@ solveCandidate(const Problem &problem, int64_t ii,
   if (!solver)
     return result;
   Z3ConstraintEncoder encoder(context, solver);
+  AssumptionTracker assumptions(context, encoder);
 
   Z3_ast iiValue = encoder.intValue(ii);
   Z3_ast horizonValue = encoder.intValue(*horizon);
@@ -696,15 +1445,18 @@ solveCandidate(const Problem &problem, int64_t ii,
   }
 
   for (const Edge &edge : problem.edges) {
+    std::string groupId = dependenceGroupId(
+        problem.nodes[edge.src].id, problem.nodes[edge.dst].id, edge.distance);
     Z3_ast distance = encoder.mul(encoder.intValue(edge.distance), iiValue);
     Z3_ast rhs = encoder.sub(
         encoder.add(cycles[edge.src],
                     encoder.intValue(effectiveLatency(problem, edge))),
         distance);
-    encoder.assertFormula(Z3_mk_ge(context, cycles[edge.dst], rhs));
+    assumptions.assertFormula(groupId,
+                              Z3_mk_ge(context, cycles[edge.dst], rhs));
     if (edge.distance == 0)
-      encoder.assertFormula(
-          Z3_mk_le(context, stages[edge.src], stages[edge.dst]));
+      assumptions.assertFormula(
+          groupId, Z3_mk_le(context, stages[edge.src], stages[edge.dst]));
   }
 
   // Ordered by pipeline name: this map is iterated to emit the mutual-exclusion
@@ -731,7 +1483,13 @@ solveCandidate(const Problem &problem, int64_t ii,
         std::vector<Z3_ast> separated{
             Z3_mk_ge(context, delta, encoder.intValue(leftDuration)),
             Z3_mk_le(context, delta, encoder.intValue(ii - rightDuration))};
-        encoder.assertFormula(encoder.conjunction(separated));
+        Z3_ast present = encoder.conjunction(
+            {assumptions.get(resourceGroupId(problem.nodes[left].pipeline,
+                                             problem.nodes[left].id)),
+             assumptions.get(resourceGroupId(problem.nodes[right].pipeline,
+                                             problem.nodes[right].id))});
+        encoder.assertFormula(
+            encoder.implies(present, encoder.conjunction(separated)));
       }
     }
   }
@@ -741,6 +1499,7 @@ solveCandidate(const Problem &problem, int64_t ii,
   struct TmemLifetime {
     Z3_ast start;
     Z3_ast end;
+    Z3_ast assumption;
     int64_t columns;
   };
   std::vector<TmemLifetime> tmemLifetimes;
@@ -753,8 +1512,10 @@ solveCandidate(const Problem &problem, int64_t ii,
           encoder.sub(encoder.maximum(lifetimeStages), stages[buffer.alloc]),
           encoder.intValue(1));
       smemDepths.push_back(depth);
+      Z3_ast charge = encoder.mul(encoder.intValue(buffer.sizeBytes), depth);
       smemCharges.push_back(
-          encoder.mul(encoder.intValue(buffer.sizeBytes), depth));
+          Z3_mk_ite(context, assumptions.get(bufferGroupId("smem", buffer.id)),
+                    charge, encoder.intValue(0)));
       continue;
     }
 
@@ -763,8 +1524,9 @@ solveCandidate(const Problem &problem, int64_t ii,
       lifetimeCycles.push_back(cycles[consumer]);
     Z3_ast end =
         encoder.add(encoder.maximum(lifetimeCycles), encoder.intValue(1));
-    tmemLifetimes.push_back(
-        TmemLifetime{cycles[buffer.alloc], end, buffer.tmemCols});
+    tmemLifetimes.push_back(TmemLifetime{
+        cycles[buffer.alloc], end,
+        assumptions.get(bufferGroupId("tmem", buffer.id)), buffer.tmemCols});
   }
   Z3_ast smemTotal = encoder.sum(smemCharges);
   encoder.assertFormula(
@@ -775,6 +1537,7 @@ solveCandidate(const Problem &problem, int64_t ii,
     activeColumns.reserve(tmemLifetimes.size());
     for (const TmemLifetime &lifetime : tmemLifetimes) {
       std::vector<Z3_ast> isActive{
+          lifetime.assumption,
           Z3_mk_le(context, lifetime.start, checkpoint.start),
           Z3_mk_lt(context, checkpoint.start, lifetime.end)};
       activeColumns.push_back(Z3_mk_ite(context, encoder.conjunction(isActive),
@@ -862,12 +1625,20 @@ solveCandidate(const Problem &problem, int64_t ii,
       !configureSolver(context, solver, *timeoutMs, problem.budget))
     return CandidateResult{};
 
-  Z3_lbool status = Z3_solver_check(context, solver);
+  const bool relaxed = !problem.relaxKeepKinds.empty();
+  std::vector<Z3_ast> assumptionLiterals =
+      relaxed ? assumptions.literalsForKinds(problem.relaxKeepKinds)
+              : assumptions.literals();
+  Z3_lbool status = checkWithAssumptions(context, solver, assumptionLiterals);
   if (z3ErrorSeen)
     return CandidateResult{};
   if (status == Z3_L_FALSE) {
     result.status = CandidateStatus::Unsat;
     result.rlimitUsed = readRLimitCount(context, solver);
+    result.unsatEvidence = extractUnsatEvidence(context, solver, assumptions);
+    if (minimizeCore)
+      minimizeUnsatEvidence(context, solver, assumptions, deadline,
+                            result.unsatEvidence);
     return result;
   }
   if (status == Z3_L_UNDEF)
@@ -879,6 +1650,14 @@ solveCandidate(const Problem &problem, int64_t ii,
   if (!baseCandidate)
     return CandidateResult{};
   result = std::move(*baseCandidate);
+
+  // A relaxed solve exists only to bound the minimum feasible II, and its
+  // objective is not comparable to the full model's (the dropped groups also
+  // drop their objective contributions). Stop at feasibility rather than
+  // paying for the composite-objective binary search.
+  if (relaxed)
+    return result;
+
   __int128 low = objectiveLowerBound(problem, ii, *horizon);
   __int128 high = result.objective;
   if (high < low)
@@ -901,7 +1680,7 @@ solveCandidate(const Problem &problem, int64_t ii,
       return CandidateResult{};
     }
 
-    status = Z3_solver_check(context, solver);
+    status = checkWithAssumptions(context, solver, assumptionLiterals);
     if (z3ErrorSeen) {
       Z3_solver_pop(context, solver, 1);
       return CandidateResult{};
@@ -943,6 +1722,12 @@ static llvm::json::Array toJsonArray(const std::vector<int64_t> &values) {
   for (int64_t value : values)
     result.push_back(value);
   return result;
+}
+
+static void insertSortedUnique(std::vector<int64_t> &values, int64_t value) {
+  auto position = std::lower_bound(values.begin(), values.end(), value);
+  if (position == values.end() || *position != value)
+    values.insert(position, value);
 }
 
 /// `rlimit_used` is the deterministic cost of the whole II sweep, summed over
@@ -988,7 +1773,7 @@ static llvm::json::Object makeSuccess(const Problem &problem, int64_t ii,
 
   double objective = static_cast<double>(candidate.objective);
 
-  return llvm::json::Object{
+  llvm::json::Object result{
       {"version", kSchemaVersion},
       {"status", "ok"},
       {"ii", ii},
@@ -997,6 +1782,19 @@ static llvm::json::Object makeSuccess(const Problem &problem, int64_t ii,
       {"objective", static_cast<double>(objective)},
       {"stats", makeStats(tried, unsat, unknown, problem.budget, rlimitUsed)},
   };
+  if (!problem.relaxKeepKinds.empty()) {
+    // Mark the result so a consumer cannot mistake a relaxed schedule for a
+    // full-model one: `ii` is a lower bound, `cycles` satisfy only the kept
+    // kinds, and `objective` is not comparable to a full-model objective.
+    llvm::json::Array keptKinds;
+    for (const std::string &kind : problem.relaxKeepKinds)
+      keptKinds.push_back(kind);
+    result["relaxation"] = llvm::json::Object{
+        {"keep_kinds", std::move(keptKinds)},
+        {"untracked_hard_assertions", kUntrackedHardAssertions.str()},
+    };
+  }
+  return result;
 }
 
 static FailureOr<std::string> run(llvm::StringRef problemJson) {
@@ -1014,62 +1812,103 @@ static FailureOr<std::string> run(llvm::StringRef problemJson) {
   std::vector<int64_t> unsat;
   std::vector<int64_t> unknown;
   uint64_t rlimitUsed = 0;
-  for (int64_t ii = problem->minII;; ++ii) {
-    tried.push_back(ii);
-    CandidateResult candidate = solveCandidate(*problem, ii, deadline);
+  std::optional<std::pair<int64_t, UnsatEvidence>> lastUnsat;
+  std::optional<std::pair<int64_t, CandidateResult>> best;
+
+  auto makeUnknown = [&](int64_t ii, const CandidateResult &candidate) {
+    insertSortedUnique(unknown, ii);
+    std::string message =
+        "joint solve inconclusive at II " + std::to_string(ii);
+    llvm::StringRef diagnosticMessage = candidate.reason.empty()
+                                            ? llvm::StringRef(message)
+                                            : llvm::StringRef(candidate.reason);
+    llvm::json::Object diagnostic =
+        makeInconclusiveDiagnostic(ii, diagnosticMessage);
+    return serialize(llvm::json::Object{
+        {"version", kSchemaVersion},
+        {"status", "inconclusive"},
+        {"proven_unsat", false},
+        {"backend_status", "UNKNOWN"},
+        // Which budget ran out. `rlimit` is deterministic and reproducible — a
+        // property of the problem, answered by raising the budget or
+        // simplifying the model. `walltime` is an environment signal and, with
+        // rlimit binding, should essentially never appear.
+        {"budget_exhausted",
+         budgetExhaustedName(candidate.budgetExhausted).str()},
+        {"message", std::move(message)},
+        {"diagnostic", std::move(diagnostic)},
+        {"stats",
+         makeStats(tried, unsat, unknown, problem->budget, rlimitUsed)},
+    });
+  };
+
+  // Feasibility is monotone in II. Map a schedule at II to a larger II' by
+  // keeping each cycle's stage and remainder: s * II + r -> s * II' + r.
+  // Resource phases stay identical; SMEM depths and TMEM endpoint ordering are
+  // preserved. For a dependence, (stageDelta + distance) is nonnegative, so
+  // increasing II can only preserve or relax its inequality.
+  int64_t low = problem->minII;
+  int64_t high = problem->maxII;
+  while (low < high) {
+    int64_t ii = low + (high - low) / 2;
+    insertSortedUnique(tried, ii);
+    CandidateResult candidate =
+        solveCandidate(*problem, ii, deadline, ii == problem->maxII);
     // Each II is solved in its own context, so the per-II counters sum to the
     // deterministic cost of the sweep.
     rlimitUsed += candidate.rlimitUsed.value_or(0);
     if (candidate.status == CandidateStatus::Sat) {
-      return serialize(makeSuccess(*problem, ii, candidate, tried, unsat,
-                                   unknown, rlimitUsed));
+      best = std::make_pair(ii, std::move(candidate));
+      high = ii;
+      continue;
     }
     if (candidate.status == CandidateStatus::Unsat) {
-      unsat.push_back(ii);
+      insertSortedUnique(unsat, ii);
+      lastUnsat = std::make_pair(ii, std::move(candidate.unsatEvidence));
+      low = ii + 1;
     } else if (candidate.status == CandidateStatus::Unknown) {
-      unknown.push_back(ii);
-      std::string message =
-          "joint solve inconclusive at II " + std::to_string(ii);
-      llvm::json::Object diagnostic{
-          {"schema", "joint-solver-diagnostic-0.1"},
-          {"status", "inconclusive"},
-          {"ii", ii},
-          {"backendStatus", "UNKNOWN"},
-          {"message", candidate.reason.empty() ? message : candidate.reason},
-      };
-      return serialize(llvm::json::Object{
-          {"version", kSchemaVersion},
-          {"status", "inconclusive"},
-          {"proven_unsat", false},
-          {"backend_status", "UNKNOWN"},
-          // Which budget ran out. `rlimit` is deterministic and reproducible —
-          // a property of the problem, answered by raising the budget or
-          // simplifying the model. `walltime` is an environment signal and,
-          // with rlimit binding, should essentially never appear.
-          {"budget_exhausted",
-           budgetExhaustedName(candidate.budgetExhausted).str()},
-          {"message", std::move(message)},
-          {"diagnostic", std::move(diagnostic)},
-          {"stats",
-           makeStats(tried, unsat, unknown, problem->budget, rlimitUsed)},
-      });
+      return makeUnknown(ii, candidate);
     } else {
       return failure();
     }
-    if (ii == problem->maxII)
-      break;
+  }
+
+  if (!best || best->first != low) {
+    insertSortedUnique(tried, low);
+    CandidateResult candidate =
+        solveCandidate(*problem, low, deadline, low == problem->maxII);
+    rlimitUsed += candidate.rlimitUsed.value_or(0);
+    if (candidate.status == CandidateStatus::Sat) {
+      best = std::make_pair(low, std::move(candidate));
+    } else if (candidate.status == CandidateStatus::Unsat) {
+      insertSortedUnique(unsat, low);
+      lastUnsat = std::make_pair(low, std::move(candidate.unsatEvidence));
+    } else if (candidate.status == CandidateStatus::Unknown) {
+      return makeUnknown(low, candidate);
+    } else {
+      return failure();
+    }
+  }
+  if (best) {
+    return serialize(makeSuccess(*problem, best->first, best->second, tried,
+                                 unsat, unknown, rlimitUsed));
   }
 
   std::string message = "no feasible II in [" + std::to_string(problem->minII) +
                         ", " + std::to_string(problem->maxII) + "]";
-  return serialize(llvm::json::Object{
+  llvm::json::Object result{
       {"version", kSchemaVersion},
       {"status", "infeasible"},
       {"proven_unsat", true},
       {"backend_status", "INFEASIBLE"},
       {"message", std::move(message)},
       {"stats", makeStats(tried, unsat, unknown, problem->budget, rlimitUsed)},
-  });
+  };
+  if (lastUnsat) {
+    ProvenanceMap provenance = constraintProvenance(*problem, lastUnsat->first);
+    addUnsatDiagnostic(result, lastUnsat->first, lastUnsat->second, provenance);
+  }
+  return serialize(std::move(result));
 }
 
 } // namespace v01
@@ -1607,6 +2446,203 @@ static std::optional<Problem> parseProblem(llvm::StringRef problemJson) {
   return problem;
 }
 
+static llvm::StringRef relationName(Relation relation) {
+  switch (relation) {
+  case Relation::Always:
+    return "always";
+  case Relation::SameWG:
+    return "same_wg";
+  case Relation::DifferentWG:
+    return "different_wg";
+  }
+  llvm_unreachable("unknown lowering relation");
+}
+
+static ProvenanceMap constraintProvenance(const Problem &problem) {
+  ProvenanceMap provenance;
+  auto addCluster = [&](size_t clusterIndex) {
+    const Cluster &cluster = problem.clusters[clusterIndex];
+    ConstraintProvenance record;
+    record.id = clusterGroupId(cluster.id);
+    record.kind = "warp-group";
+    record.cluster = cluster.id;
+    record.minWarps = cluster.minWarps;
+    record.available = problem.maxWGs;
+    for (size_t node : cluster.nodes)
+      record.nodes.push_back(problem.nodes[node].id);
+    addProvenance(provenance, std::move(record));
+  };
+  for (size_t cluster = 0; cluster < problem.clusters.size(); ++cluster)
+    addCluster(cluster);
+
+  for (const Node &node : problem.nodes) {
+    if (node.pipeline != "NONE" ||
+        std::max<int64_t>(node.duration, 1) > problem.ii) {
+      ConstraintProvenance resource;
+      resource.id = resourceGroupId(node.pipeline, node.id);
+      resource.kind = "resource";
+      resource.nodes = {node.id};
+      resource.pipeline = node.pipeline;
+      resource.required = std::max<int64_t>(node.duration, 1);
+      resource.emitRequired = true;
+      resource.available = problem.ii;
+      addProvenance(provenance, std::move(resource));
+    }
+    if (problem.mode == SolveMode::Joint) {
+      ConstraintProvenance fixedStage;
+      fixedStage.id = fixedStageGroupId(node.id);
+      fixedStage.kind = "lowering";
+      fixedStage.nodes = {node.id};
+      fixedStage.capability = "fixed-stage emitter";
+      fixedStage.fixedStage = node.fixedCycle / problem.ii;
+      fixedStage.available = problem.ii;
+      addProvenance(provenance, std::move(fixedStage));
+    }
+  }
+
+  for (const Edge &edge : problem.edges) {
+    const Node &src = problem.nodes[edge.src];
+    const Node &dst = problem.nodes[edge.dst];
+    int64_t baseLatency = problem.mode == SolveMode::Joint && edge.distance == 0
+                              ? std::max<int64_t>(edge.latency, 1)
+                              : edge.latency;
+    if (problem.mode == SolveMode::Joint) {
+      ConstraintProvenance dependence;
+      dependence.id = dependenceGroupId(src.id, dst.id, edge.distance);
+      dependence.kind = "dependence";
+      dependence.nodes = {src.id, dst.id};
+      dependence.latency = baseLatency;
+      dependence.distance = edge.distance;
+      dependence.available = problem.ii;
+      addProvenance(provenance, std::move(dependence));
+    }
+    bool crossCluster = edge.srcCluster && edge.dstCluster &&
+                        *edge.srcCluster != *edge.dstCluster;
+    if (!crossCluster)
+      continue;
+    if (edge.distance > 0 && edge.roundTrip > 0) {
+      ConstraintProvenance loopCarried;
+      loopCarried.id = loopCarriedGroupId(src.id, dst.id, edge.distance,
+                                          edge.srcResultIndex);
+      loopCarried.kind = "warp-group";
+      loopCarried.nodes = {src.id, dst.id};
+      loopCarried.relation = "same_wg";
+      loopCarried.reason = "loop_carried_register";
+      loopCarried.distance = edge.distance;
+      loopCarried.result = edge.srcResultIndex;
+      loopCarried.roundTripLatency = edge.roundTrip;
+      loopCarried.available = problem.maxWGs;
+      addProvenance(provenance, std::move(loopCarried));
+    } else if (problem.mode == SolveMode::Joint && edge.roundTrip > 0) {
+      ConstraintProvenance handoff;
+      handoff.id =
+          crossWGGroupId(src.id, dst.id, edge.distance, edge.srcResultIndex);
+      handoff.kind = "dependence";
+      handoff.nodes = {src.id, dst.id};
+      handoff.baseLatency = baseLatency;
+      handoff.roundTripLatency = edge.roundTrip;
+      handoff.requiredLatency = saturatedAdd(baseLatency, edge.roundTrip);
+      handoff.distance = edge.distance;
+      handoff.result = edge.srcResultIndex;
+      handoff.conditionalOn = "different_wg";
+      handoff.available = problem.ii;
+      addProvenance(provenance, std::move(handoff));
+    }
+    if (edge.channelBytes > 0) {
+      ConstraintProvenance channel;
+      channel.id = channelGroupId(src.id, dst.id, edge.srcResultIndex);
+      channel.kind = "smem";
+      channel.nodes = {src.id, dst.id};
+      channel.channel = {src.id, dst.id, edge.srcResultIndex};
+      channel.sizeBytes = edge.channelBytes;
+      channel.emitRequired = true;
+      channel.requiredLowerBound = 0;
+      channel.requiredWhenActive = edge.channelBytes;
+      channel.requiredIsDynamic = true;
+      channel.available = problem.smemBudget;
+      channel.conditionalOn = "different_wg";
+      addProvenance(provenance, std::move(channel));
+    }
+  }
+
+  for (const Buffer &buffer : problem.buffers) {
+    bool modelSmem = problem.mode == SolveMode::Joint && buffer.kind == "smem";
+    if (!modelSmem && buffer.kind != "tmem")
+      continue;
+    ConstraintProvenance record;
+    record.id = bufferGroupId(buffer.kind, buffer.id);
+    record.kind = buffer.kind;
+    record.nodes.push_back(problem.nodes[buffer.producer].id);
+    for (const BufferConsumer &consumer : buffer.consumers)
+      record.nodes.push_back(problem.nodes[consumer.node].id);
+    record.buffer = buffer.id;
+    record.sizeBytes = buffer.sizeBytes;
+    record.emitRequired = true;
+    record.requiredLowerBound =
+        saturatedMultiply(buffer.sizeBytes, buffer.minCount);
+    record.requiredIsDynamic = true;
+    record.available = modelSmem ? problem.smemBudget : problem.tmemBudgetBytes;
+    addProvenance(provenance, std::move(record));
+  }
+
+  int64_t fixedSmem = problem.mode == SolveMode::Joint ? problem.fixedSmem
+                                                       : problem.committedSmem;
+  if (fixedSmem > 0) {
+    ConstraintProvenance record;
+    record.id =
+        problem.mode == SolveMode::Joint ? "smem:fixed" : "smem:committed";
+    record.kind = "smem";
+    record.required = fixedSmem;
+    record.emitRequired = true;
+    record.requiredLowerBound = fixedSmem;
+    record.requiredIsDynamic = false;
+    record.available = problem.smemBudget;
+    addProvenance(provenance, std::move(record));
+  }
+
+  int64_t registerLimit = problem.regBudget.value_or(problem.smRegs);
+  for (size_t group = 0; group < problem.clusters.size(); ++group) {
+    ConstraintProvenance record;
+    record.id = "register:wg" + std::to_string(group);
+    record.kind = "register";
+    record.emitRequired = true;
+    record.requiredLowerBound = 0;
+    record.requiredIsDynamic = true;
+    record.available = registerLimit;
+    record.group = group;
+    addProvenance(provenance, std::move(record));
+  }
+  if (problem.defaultWGFootprint > 0) {
+    ConstraintProvenance record;
+    record.id = "register:default";
+    record.kind = "register";
+    record.required = problem.defaultWGFootprint;
+    record.emitRequired = true;
+    record.available = registerLimit;
+    addProvenance(provenance, std::move(record));
+  }
+
+  for (const LoweringTemplate &loweringTemplate : problem.loweringTemplates) {
+    for (const LoweringEvent &event : loweringTemplate.events) {
+      if (event.duration <= 0)
+        continue;
+      ConstraintProvenance record;
+      record.id = loweringEventGroupId(loweringTemplate.id, event.id);
+      record.kind = "lowering";
+      record.nodes = {problem.nodes[event.anchor].id};
+      record.loweringTemplate = loweringTemplate.id;
+      record.event = event.id;
+      record.relation = relationName(loweringTemplate.relation).str();
+      record.capability = event.kind;
+      record.required = event.duration;
+      record.emitRequired = true;
+      record.available = problem.ii;
+      addProvenance(provenance, std::move(record));
+    }
+  }
+  return provenance;
+}
+
 struct Candidate {
   CandidateStatus status = CandidateStatus::Error;
   std::vector<int64_t> cycles;
@@ -1617,6 +2653,7 @@ struct Candidate {
   std::string reason;
   BudgetExhausted budgetExhausted = BudgetExhausted::None;
   std::optional<uint64_t> rlimitUsed;
+  UnsatEvidence unsatEvidence;
 };
 
 struct IssueItem {
@@ -1666,6 +2703,14 @@ static Candidate solveProblem(const Problem &problem,
     result.budgetExhausted = BudgetExhausted::WallTime;
     return result;
   }
+  for (const Node &node : problem.nodes) {
+    if (std::max<int64_t>(node.duration, 1) > problem.ii) {
+      result.status = CandidateStatus::Unsat;
+      result.unsatEvidence.groupIds = {resourceGroupId(node.pipeline, node.id)};
+      result.unsatEvidence.normalization = "precheck";
+      return result;
+    }
+  }
 
   z3ErrorSeen = false;
   Context ownedContext;
@@ -1677,6 +2722,7 @@ static Candidate solveProblem(const Problem &problem,
   if (!solver)
     return result;
   Z3ConstraintEncoder encoder(context, solver);
+  AssumptionTracker assumptions(context, encoder);
 
   Z3_ast zero = encoder.intValue(0);
   Z3_ast iiValue = encoder.intValue(problem.ii);
@@ -1695,19 +2741,14 @@ static Candidate solveProblem(const Problem &problem,
     stages.push_back(stage);
     phases.push_back(phase);
     int64_t fixedStage = node.fixedCycle / problem.ii;
-    __int128 lower = static_cast<__int128>(fixedStage) * problem.ii;
-    __int128 upper = lower + problem.ii - 1;
-    if (upper > std::numeric_limits<int64_t>::max())
-      return result;
-    encoder.assertFormula(Z3_mk_ge(
-        context, cycle, encoder.intValue(static_cast<int64_t>(lower))));
-    encoder.assertFormula(Z3_mk_le(
-        context, cycle, encoder.intValue(static_cast<int64_t>(upper))));
-    encoder.assertFormula(
-        Z3_mk_eq(context, stage, encoder.intValue(fixedStage)));
-    if (problem.mode == SolveMode::Partition)
+    if (problem.mode == SolveMode::Joint) {
+      assumptions.assertFormula(
+          fixedStageGroupId(node.id),
+          Z3_mk_eq(context, stage, encoder.intValue(fixedStage)));
+    } else {
       encoder.assertFormula(
           Z3_mk_eq(context, cycle, encoder.intValue(node.fixedCycle)));
+    }
   }
   if (problem.canonicalRoot)
     encoder.assertFormula(
@@ -1715,10 +2756,14 @@ static Candidate solveProblem(const Problem &problem,
 
   const size_t clusterCount = problem.clusters.size();
   std::vector<Z3_ast> warpGroups;
+  std::vector<Z3_ast> clusterAssumptions;
   warpGroups.reserve(clusterCount);
+  clusterAssumptions.reserve(clusterCount);
   for (size_t index = 0; index < clusterCount; ++index) {
     Z3_ast wg = encoder.variable("v2_wg_" + std::to_string(index));
     warpGroups.push_back(wg);
+    clusterAssumptions.push_back(
+        assumptions.get(clusterGroupId(problem.clusters[index].id)));
     encoder.assertFormula(Z3_mk_ge(context, wg, zero));
     encoder.assertFormula(Z3_mk_lt(
         context, wg, encoder.intValue(static_cast<int64_t>(clusterCount))));
@@ -1743,8 +2788,12 @@ static Candidate solveProblem(const Problem &problem,
   auto sameWG = [&](size_t left, size_t right) {
     return Z3_mk_eq(context, warpGroups[left], warpGroups[right]);
   };
-  for (const auto &[left, right] : problem.warpGroupConflicts)
-    encoder.assertFormula(Z3_mk_not(context, sameWG(left, right)));
+  for (const auto &[left, right] : problem.warpGroupConflicts) {
+    Z3_ast present = encoder.conjunction(
+        {clusterAssumptions[left], clusterAssumptions[right]});
+    encoder.assertFormula(
+        encoder.implies(present, Z3_mk_not(context, sameWG(left, right))));
+  }
 
   for (const Edge &edge : problem.edges) {
     const Node &srcNode = problem.nodes[edge.src];
@@ -1755,11 +2804,18 @@ static Candidate solveProblem(const Problem &problem,
       // Tensor-core results consumed by CUDA/SFU must cross warp groups so
       // software readers cannot miss an mbarrier parity phase.
       if ((srcNode.pipeline == "TC" || srcNode.pipeline == "MFMA") &&
-          (dstNode.pipeline == "CUDA" || dstNode.pipeline == "SFU"))
-        encoder.assertFormula(
-            Z3_mk_not(context, sameWG(*srcCluster, *dstCluster)));
-      if (edge.distance > 0 && edge.roundTrip > 0)
-        encoder.assertFormula(sameWG(*srcCluster, *dstCluster));
+          (dstNode.pipeline == "CUDA" || dstNode.pipeline == "SFU")) {
+        Z3_ast present = encoder.conjunction(
+            {clusterAssumptions[*srcCluster], clusterAssumptions[*dstCluster]});
+        encoder.assertFormula(encoder.implies(
+            present, Z3_mk_not(context, sameWG(*srcCluster, *dstCluster))));
+      }
+      if (edge.distance > 0 && edge.roundTrip > 0) {
+        assumptions.assertFormula(loopCarriedGroupId(srcNode.id, dstNode.id,
+                                                     edge.distance,
+                                                     edge.srcResultIndex),
+                                  sameWG(*srcCluster, *dstCluster));
+      }
     }
 
     if (problem.mode != SolveMode::Joint)
@@ -1769,17 +2825,23 @@ static Candidate solveProblem(const Problem &problem,
     Z3_ast distance = encoder.mul(encoder.intValue(edge.distance), iiValue);
     Z3_ast base = encoder.sub(
         encoder.add(cycles[edge.src], encoder.intValue(latency)), distance);
-    encoder.assertFormula(Z3_mk_ge(context, cycles[edge.dst], base));
+    std::string dependenceId =
+        dependenceGroupId(srcNode.id, dstNode.id, edge.distance);
+    assumptions.assertFormula(dependenceId,
+                              Z3_mk_ge(context, cycles[edge.dst], base));
     if (edge.distance == 0)
-      encoder.assertFormula(
-          Z3_mk_le(context, stages[edge.src], stages[edge.dst]));
+      assumptions.assertFormula(
+          dependenceId, Z3_mk_le(context, stages[edge.src], stages[edge.dst]));
     if (srcCluster && dstCluster && *srcCluster != *dstCluster &&
         edge.roundTrip > 0 && !(edge.distance > 0 && edge.roundTrip > 0)) {
       Z3_ast cross = Z3_mk_not(context, sameWG(*srcCluster, *dstCluster));
       Z3_ast withRoundTrip =
           encoder.add(base, encoder.intValue(edge.roundTrip));
-      encoder.assertFormula(encoder.implies(
-          cross, Z3_mk_ge(context, cycles[edge.dst], withRoundTrip)));
+      assumptions.assertFormula(
+          crossWGGroupId(srcNode.id, dstNode.id, edge.distance,
+                         edge.srcResultIndex),
+          encoder.implies(cross,
+                          Z3_mk_ge(context, cycles[edge.dst], withRoundTrip)));
     }
   }
 
@@ -1794,6 +2856,24 @@ static Candidate solveProblem(const Problem &problem,
       templatePresence.push_back(same);
     else
       templatePresence.push_back(Z3_mk_not(context, same));
+  }
+  std::vector<std::vector<Z3_ast>> eventPresence;
+  eventPresence.reserve(problem.loweringTemplates.size());
+  for (size_t templateIndex = 0;
+       templateIndex < problem.loweringTemplates.size(); ++templateIndex) {
+    const LoweringTemplate &loweringTemplate =
+        problem.loweringTemplates[templateIndex];
+    std::vector<Z3_ast> presences;
+    presences.reserve(loweringTemplate.events.size());
+    for (const LoweringEvent &event : loweringTemplate.events) {
+      Z3_ast presence = templatePresence[templateIndex];
+      if (event.duration > 0)
+        presence = encoder.conjunction(
+            {presence, assumptions.get(loweringEventGroupId(loweringTemplate.id,
+                                                            event.id))});
+      presences.push_back(presence);
+    }
+    eventPresence.push_back(std::move(presences));
   }
 
   using EventKey = std::pair<size_t, int>;
@@ -1816,9 +2896,10 @@ static Candidate solveProblem(const Problem &problem,
   for (size_t nodeIndex = 0; nodeIndex < problem.nodes.size(); ++nodeIndex) {
     const Node &node = problem.nodes[nodeIndex];
     int64_t duration = std::max<int64_t>(node.duration, 1);
-    Z3_ast present = Z3_mk_true(context);
-    if (duration > problem.ii)
-      encoder.assertFormula(Z3_mk_false(context));
+    Z3_ast present =
+        node.pipeline == "NONE"
+            ? Z3_mk_true(context)
+            : assumptions.get(resourceGroupId(node.pipeline, node.id));
     issueItems.push_back(IssueItem{phases[nodeIndex], present, duration,
                                    node.pipeline, node.cluster});
   }
@@ -1845,9 +2926,9 @@ static Candidate solveProblem(const Problem &problem,
           const LoweringEvent &otherEvent =
               problem.loweringTemplates[otherTemplateIndex]
                   .events[otherEventIndex];
-          activeDurations.push_back(
-              Z3_mk_ite(context, templatePresence[otherTemplateIndex],
-                        encoder.intValue(otherEvent.duration), zero));
+          activeDurations.push_back(Z3_mk_ite(
+              context, eventPresence[otherTemplateIndex][otherEventIndex],
+              encoder.intValue(otherEvent.duration), zero));
         }
       } else {
         for (size_t index = 0; index < memberIndex; ++index) {
@@ -1855,9 +2936,9 @@ static Candidate solveProblem(const Problem &problem,
           const LoweringEvent &otherEvent =
               problem.loweringTemplates[otherTemplateIndex]
                   .events[otherEventIndex];
-          activeDurations.push_back(
-              Z3_mk_ite(context, templatePresence[otherTemplateIndex],
-                        encoder.intValue(otherEvent.duration), zero));
+          activeDurations.push_back(Z3_mk_ite(
+              context, eventPresence[otherTemplateIndex][otherEventIndex],
+              encoder.intValue(otherEvent.duration), zero));
         }
       }
       Z3_ast offset = encoder.sum(activeDurations);
@@ -1872,7 +2953,7 @@ static Candidate solveProblem(const Problem &problem,
             offset);
       }
       Z3_ast eventPhase = Z3_mk_mod(context, eventCycle, iiValue);
-      Z3_ast presence = templatePresence[templateIndex];
+      Z3_ast presence = eventPresence[templateIndex][eventIndex];
       size_t ownerCluster = event.owner == Owner::Src
                                 ? loweringTemplate.srcCluster
                                 : loweringTemplate.dstCluster;
@@ -1919,7 +3000,9 @@ static Candidate solveProblem(const Problem &problem,
           continue;
         Z3_ast same = sameWG(*left.cluster, *right.cluster);
         Z3_ast active =
-            encoder.conjunction({left.presence, right.presence, same});
+            encoder.conjunction({left.presence, right.presence, same,
+                                 clusterAssumptions[*left.cluster],
+                                 clusterAssumptions[*right.cluster]});
         encoder.assertFormula(encoder.implies(
             active,
             circularSeparation(encoder, left.phase, left.duration, right.phase,
@@ -1939,8 +3022,12 @@ static Candidate solveProblem(const Problem &problem,
       continue;
     Z3_ast cross =
         Z3_mk_not(context, sameWG(*edge.srcCluster, *edge.dstCluster));
+    Z3_ast present = encoder.conjunction(
+        {cross, assumptions.get(channelGroupId(problem.nodes[edge.src].id,
+                                               problem.nodes[edge.dst].id,
+                                               edge.srcResultIndex))});
     channelCharges.push_back(
-        Z3_mk_ite(context, cross, encoder.intValue(edge.channelBytes), zero));
+        Z3_mk_ite(context, present, encoder.intValue(edge.channelBytes), zero));
   }
 
   std::vector<Z3_ast> smemCharges;
@@ -1966,6 +3053,9 @@ static Candidate solveProblem(const Problem &problem,
     Z3_ast depth =
         encoder.maximum(computedDepth, encoder.intValue(buffer.minCount));
     Z3_ast charge = encoder.mul(encoder.intValue(buffer.sizeBytes), depth);
+    charge = Z3_mk_ite(context,
+                       assumptions.get(bufferGroupId(buffer.kind, buffer.id)),
+                       charge, zero);
     if (modelSmem) {
       smemCharges.push_back(charge);
       smemDepths.push_back(depth);
@@ -1975,12 +3065,19 @@ static Candidate solveProblem(const Problem &problem,
   }
   int64_t fixedSmem = problem.mode == SolveMode::Joint ? problem.fixedSmem
                                                        : problem.committedSmem;
+  Z3_ast fixedSmemCharge = encoder.intValue(fixedSmem);
+  if (fixedSmem > 0) {
+    llvm::StringRef groupId = problem.mode == SolveMode::Joint
+                                  ? llvm::StringRef("smem:fixed")
+                                  : llvm::StringRef("smem:committed");
+    fixedSmemCharge =
+        Z3_mk_ite(context, assumptions.get(groupId), fixedSmemCharge, zero);
+  }
   std::vector<Z3_ast> allSmemCharges = smemCharges;
   allSmemCharges.insert(allSmemCharges.end(), channelCharges.begin(),
                         channelCharges.end());
   encoder.assertFormula(Z3_mk_le(
-      context,
-      encoder.add(encoder.intValue(fixedSmem), encoder.sum(allSmemCharges)),
+      context, encoder.add(fixedSmemCharge, encoder.sum(allSmemCharges)),
       encoder.intValue(problem.smemBudget)));
   encoder.assertFormula(Z3_mk_le(context, encoder.sum(tmemCharges),
                                  encoder.intValue(problem.tmemBudgetBytes)));
@@ -2014,11 +3111,18 @@ static Candidate solveProblem(const Problem &problem,
       footprint = Z3_mk_ite(
           context, Z3_mk_eq(context, roundedWarps, encoder.intValue(warpCount)),
           encoder.intValue(problem.warpFootprint[warpCount]), footprint);
-    registerFootprints.push_back(footprint);
+    registerFootprints.push_back(
+        Z3_mk_ite(context,
+                  assumptions.get("register:wg" +
+                                  std::to_string(static_cast<int64_t>(group))),
+                  footprint, zero));
   }
+  Z3_ast defaultFootprint = encoder.intValue(problem.defaultWGFootprint);
+  if (problem.defaultWGFootprint > 0)
+    defaultFootprint = Z3_mk_ite(context, assumptions.get("register:default"),
+                                 defaultFootprint, zero);
   Z3_ast totalRegisters =
-      encoder.add(encoder.intValue(problem.defaultWGFootprint),
-                  encoder.sum(registerFootprints));
+      encoder.add(defaultFootprint, encoder.sum(registerFootprints));
   if (problem.regBudget)
     encoder.assertFormula(Z3_mk_le(context, totalRegisters,
                                    encoder.intValue(*problem.regBudget)));
@@ -2252,7 +3356,8 @@ static Candidate solveProblem(const Problem &problem,
       !configureOptimize(context, optimize, *timeoutMs, problem.budget))
     return result;
 
-  Z3_lbool status = Z3_optimize_check(context, optimize, 0, nullptr);
+  std::vector<Z3_ast> assumptionLiterals = assumptions.literals();
+  Z3_lbool status = checkWithAssumptions(context, optimize, assumptionLiterals);
   if (z3ErrorSeen)
     return result;
   // The counter lives on the context, so the assertion-accumulating solver
@@ -2260,6 +3365,9 @@ static Candidate solveProblem(const Problem &problem,
   result.rlimitUsed = readRLimitCount(context, solver);
   if (status == Z3_L_FALSE) {
     result.status = CandidateStatus::Unsat;
+    result.unsatEvidence = extractUnsatEvidence(context, optimize, assumptions);
+    minimizeUnsatEvidence(context, solver, assumptions, deadline,
+                          result.unsatEvidence);
     return result;
   }
   if (status == Z3_L_UNDEF) {
@@ -2546,18 +3654,24 @@ static FailureOr<std::string> run(llvm::StringRef problemJson) {
   }
   llvm::json::Object stats = makeStats(*problem, candidate);
   if (candidate.status == CandidateStatus::Unsat) {
-    return serialize(llvm::json::Object{
-        {"version", kSchemaVersion},
-        {"status", "infeasible"},
-        {"proven_unsat", true},
-        {"backend_status", "INFEASIBLE"},
-        {"message", "no feasible joint partition"},
-        {"stats", std::move(stats)},
-    });
+    llvm::StringRef message = problem->mode == SolveMode::Joint
+                                  ? "no feasible joint partition"
+                                  : "no feasible partition";
+    llvm::json::Object result{
+        {"version", kSchemaVersion}, {"status", "infeasible"},
+        {"proven_unsat", true},      {"backend_status", "INFEASIBLE"},
+        {"message", message},        {"stats", std::move(stats)},
+    };
+    ProvenanceMap provenance = constraintProvenance(*problem);
+    addUnsatDiagnostic(result, problem->ii, candidate.unsatEvidence,
+                       provenance);
+    return serialize(std::move(result));
   }
   if (candidate.status == CandidateStatus::Unknown) {
     std::string reason = candidate.reason.empty() ? "joint solve inconclusive"
                                                   : candidate.reason;
+    llvm::json::Object diagnostic =
+        makeInconclusiveDiagnostic(problem->ii, reason);
     return serialize(llvm::json::Object{
         {"version", kSchemaVersion},
         {"status", "inconclusive"},
@@ -2570,6 +3684,7 @@ static FailureOr<std::string> run(llvm::StringRef problemJson) {
          budgetExhaustedName(candidate.budgetExhausted).str()},
         {"message", std::move(reason)},
         {"stats", std::move(stats)},
+        {"diagnostic", std::move(diagnostic)},
     });
   }
   return failure();

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/Z3JointSolver.h
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/Z3JointSolver.h
@@ -15,6 +15,11 @@ namespace mlir::triton::gpu {
 /// support is disabled or the problem schema is unsupported.
 FailureOr<std::string> runZ3JointSolver(llvm::StringRef problemJson);
 
+/// Validate a successful joint-solver-0.1 or joint-solver-0.2 result against
+/// its input problem. Returns a joint-solver-validation-0.1 JSON object.
+std::string validateZ3JointSolution(llvm::StringRef problemJson,
+                                    llvm::StringRef solutionJson);
+
 } // namespace mlir::triton::gpu
 
 #endif // TRITON_NVIDIA_HOPPER_MODULO_SCHEDULING_Z3_JOINT_SOLVER_H

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/docs/Diff8BaselineComparison.md
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/docs/Diff8BaselineComparison.md
@@ -1,0 +1,244 @@
+# Diff 8: Baseline Comparison for the M2 Acceptance Criteria
+
+## Why the original criterion was replaced
+
+The M2 acceptance criterion read:
+
+> Solver-produced II is valid and satisfies all resource/dependency
+> constraints; **improvement over naive encoding (resource-exclusivity-only)
+> demonstrated.**
+
+The second clause cannot be satisfied. A resource-exclusivity-only model is the
+full model with constraints *removed*, so its feasible set is a superset of the
+full model's, and its optimal II can never exceed the full model's:
+
+```
+II*_resource-only  <=  II*_full        (always, by construction)
+```
+
+Demonstrating that the full encoding achieves a *better* II than the
+resource-only encoding is therefore impossible for every input. A test written
+to that wording could only pass through a bug.
+
+The criterion is split into two well-posed ones, implemented here.
+
+## Metric 1 — `relaxed_lower_bound` (soundness, not improvement)
+
+`runJointSolverRelaxedLowerBound` (`JointSolverScheduler.h`) solves the same
+joint model with only the `resource:` constraint groups asserted. The assertion
+is the direction that is actually true:
+
+```
+II_full  >=  relaxed_lower_bound
+```
+
+A violation is **not** a performance regression. It means the full model found
+a schedule the relaxed model calls impossible, which can only happen if a
+constraint is mis-encoded or a "relaxation" is not actually a relaxation. That
+makes it a genuinely valuable regression test, and it should be described as a
+soundness check rather than dressed up as a performance claim.
+
+The gap `II_full - relaxed_lower_bound` is reported as information only. It
+says how much II the non-resource constraints cost, which is real engineering
+signal, but it is not an acceptance threshold — a large gap can equally mean
+those constraints are necessary.
+
+### How the relaxation is obtained
+
+`AssumptionTracker` already gates each constraint group behind an assumption
+literal, so every group's constraints only bind when its literal is asserted
+true:
+
+```cpp
+void AssumptionTracker::assertFormula(llvm::StringRef groupId, Z3_ast formula) {
+  encoder.assertFormula(encoder.implies(get(groupId), formula));
+}
+```
+
+Passing a *subset* of the literals to `checkWithAssumptions` therefore yields
+the corresponding relaxed model with no changes to the encoder. The problem
+JSON carries an optional `relax_keep_kinds` array; `solveCandidate` filters the
+assumption vector through `AssumptionTracker::literalsForKinds`. This reuses
+infrastructure that already has to be correct for UNSAT-core extraction to
+work.
+
+A relaxed solve stops at the first feasible II rather than running the
+composite-objective binary search: only the bound is wanted, and the relaxed
+objective is not comparable to the full model's anyway (the dropped groups also
+drop their objective contributions).
+
+### What the bound is NOT
+
+The metric is named `relaxed_lower_bound`, not `resource_lower_bound`, because
+not every constraint is assumption-gated. These stay hard assertions:
+
+- cycle domain bounds (`0 <= cycle < horizon`)
+- canonical-root pinning
+- `smemTotal <= smem_budget`
+- per-checkpoint TMEM columns `<= tmem_col_limit`
+
+The last two survive but go **vacuous** in a resource-only relaxation: dropping
+the `smem:`/`tmem:` literals zeroes their charges. Only the domain bounds and
+the root pin actually bind.
+
+The bound is consequently *tighter* than a textbook resource-only relaxation.
+That is accepted deliberately: the soundness invariant holds for any
+relaxation, so a tighter bound is a **stronger** test, and the alternative — a
+switch that also drops the untracked assertions — would add a code path
+existing solely for one test, which could itself be wrong. A reader comparing
+this number against a published resource-only bound needs to know it is not
+one, so the caveat is printed with the number and repeated in
+`kUntrackedHardAssertions`.
+
+The relaxed run is deliberately **not** routed through
+`runJointSolverBackend`: that wrapper validates every response against the full
+model, which a relaxed schedule violates by construction. It is not trusted
+either — the kept kind (resource exclusivity) is re-verified in-tree before the
+bound is used, because a bound that is too *high* would turn the soundness
+invariant into a false alarm. The backend must also echo a `relaxation` object,
+so a build whose solver ignored `relax_keep_kinds` cannot silently return the
+full model's II and make the invariant compare `II_full` against itself.
+
+## Metric 2 — improvement over Rau
+
+```
+II_full  <=  II_rau     on every fixture      (hard failure if violated)
+II_full  <   II_rau     on at least one       (the acceptance criterion)
+```
+
+This is well-posed: a heuristic scheduler can and routinely does land above the
+optimum.
+
+**Rau's Iterative Modulo Scheduling is the baseline**, for four reasons:
+
+1. It already exists and is tested — the default backend
+   (`TRITON_USE_MODULO_SCHEDULE` = `1` or unset). No new scheduler to write, no
+   new tie-breaking to specify and defend.
+2. It is the actual production alternative: the joint solver's own fallback
+   path drops through to precisely this scheduler, so beating it is the claim
+   that matters operationally.
+3. It unifies M2 with M3. The M3 criterion reads *"performance improvement over
+   Triton's current default scheduling"*, and Triton's current default **is**
+   Rau. M2 and M3 become schedule-level and wall-clock-level measurements of
+   one claim rather than two unrelated exercises.
+4. A purpose-built "naive greedy" would be a strawman — any scheduler written
+   solely to be beaten invites "did you tune it to lose?". Rau is a published
+   algorithm the team already relies on.
+
+`SwingScheduler` (`sms`) and `ExhaustiveScheduler` (`exhaustive`) are reported
+alongside at no extra cost. **Rau is the acceptance gate**; the others are free
+context. `exhaustive` is especially useful where it terminates, since it
+brackets the optimum from the other side — it bails out above its node/MMA
+ceiling, so an absent row is expected on anything but a small loop.
+
+A purpose-built resource-exclusivity-only greedy is deliberately **not**
+written. If the literal original wording is ever required, it would be added
+*in addition to* Rau, never instead of it: it is the weaker claim and should
+not be the headline number.
+
+### Every baseline is validated before its II is used
+
+An unvalidated II is meaningless — a scheduler that produces an illegal
+schedule can report any II it likes. `isLegalModuloSchedule` checks dependence
+legality *and* exclusive modular reservation; a backend whose schedule fails is
+reported as absent with a note rather than contributing a number.
+
+This uses the in-tree checker rather than `Z3JointSolutionValidator`. The two
+enforce the same two properties for the v1 model, and the in-tree one keeps
+every baseline row available in builds without Z3, where only the joint rows
+drop out.
+
+## Running it
+
+```bash
+TRITON_MODULO_BASELINE_REPORT=1 triton-opt input.mlir -nvgpu-modulo-schedule
+```
+
+The comparison runs every backend on the DDG, so it is opt-in and never fires
+on a compile path. Output goes to stderr so it does not interleave with
+`triton-opt`'s IR on stdout:
+
+Measured output on the checked-in fixture:
+
+```
+modulo-baseline-report: gemm_inner_loop
+  fixture                      MinII     II_full  relaxed_LB      II_rau      II_sms II_exhaustive
+  gemm_inner_loop               1091        1091        1091        1091        1091        1091
+  soundness (II_full >= relaxed_LB): PASS (gap 0)
+  no-regression (II_full <= II_rau): PASS
+  strict improvement (II_full < II_rau): NO (every backend is at MinII 1091 — this
+    fixture is MinII-bound and cannot separate schedulers; it is not evidence about
+    the solver)
+  relaxed_LB keeps resource exclusivity only; still-hard: cycle domain bounds,
+    canonical-root pinning, SMEM/TMEM ceilings (vacuous once their gated
+    contributors are dropped)
+```
+
+The two halves of criterion 2 are reported separately on purpose. `II_full ==
+II_rau` satisfies the no-regression half, and printing one combined `PASS`
+would let a tie read as the acceptance criterion being met. It is not.
+
+## Fixture
+
+The lit fixture `test/TritonGPU/modulo-schedule.mlir` (`@gemm_inner_loop`) —
+real GEMM, and already the DDG the JOINT goldens pin, so the baseline numbers
+are directly comparable to existing golden output.
+
+The 2–3 node oracle fixtures are deliberately not used: they are below the size
+where scheduling quality is meaningful, and Rau trivially matches the optimum
+on them, producing a vacuous "no improvement" result that is evidence of
+nothing.
+
+Note this is currently the only GEMM shape checked in **as a DDG**. The
+two-architecture `gemm-hopper` / `gemm-blackwell` models in
+`unittest/Hopper/modulo_schedule_test.cpp` are joint-solver-0.2 **JSON**
+problems, which the in-tree schedulers cannot consume — `DataDependenceGraph`
+has no public constructor and is only produced by
+`DataDependenceGraph::build(scf::ForOp, LatencyModel)`. Adding a second shape
+means adding a second MLIR loop to the lit fixture, not a second JSON model.
+
+## Current result: the acceptance criterion is NOT met
+
+**As of this change, `strict improvement` is NO on the only fixture available.**
+Every backend — joint solver, Rau, SMS and exhaustive — lands on II = 1091,
+which is exactly `MinII`.
+
+Root cause, and why it is not a solver result: **the fixture is MinII-bound.**
+MinII = max(ResMII, RecMII) is a floor no correct scheduler can go below, so
+when every backend attains it there is nothing left to optimise and no
+scheduler can be separated from any other. The relaxed lower bound confirms
+this from the other side: `relaxed_LB == II_full`, a gap of **0**, meaning the
+resource-exclusivity constraints alone already force II = 1091. Dependences and
+buffer depths cost this loop no II at all. A single-MMA GEMM inner loop
+saturates one pipeline, and the schedule is decided by that pipeline's
+occupancy.
+
+So this fixture cannot produce evidence for or against the M2 improvement
+claim in either direction. It is a valid soundness fixture and a valid
+no-regression fixture; it is not a discriminating improvement fixture.
+
+Per the plan, the fixture is **not** being tuned until the solver wins. Two
+honest ways forward, both of which are follow-up work:
+
+1. Add a fixture that is *not* MinII-bound — a loop with a recurrence or
+   buffer pressure that forces a scheduler to leave the floor, where a
+   heuristic can measurably land above the optimum. This means adding a second
+   MLIR loop, since the in-tree schedulers consume a DDG, not the v0.2 JSON
+   models.
+2. Accept that the joint solver's value on GEMM is not II, and move the M2
+   improvement claim to the dimension where it does show up — warp-group
+   assignment, buffer depth, or M3's wall-clock — rather than schedule-level
+   II.
+
+This is exactly the outcome the plan flagged as plausible ("Rau is a good
+heuristic and GEMM inner loops are small"). It should go to the IM alongside
+the Decision 1 sign-off request, because it bears on whether the reformulated
+criterion is satisfiable on the fixtures that exist today.
+
+## Sequencing
+
+Rau's II is machine-independent, but the joint solver's may not be until the
+Diff 7 determinism work lands (`docs/Diff7DeterminismPlan.md`). Baseline IIs
+must be stable for this to be a regression test rather than a flake. The lit
+test therefore matches IIs as numbers rather than pinning them, and asserts
+only that neither criterion reports `FAIL`.

--- a/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/docs/LoweringPlan.md
+++ b/third_party/nvidia/hopper/lib/Transforms/ModuloScheduling/docs/LoweringPlan.md
@@ -1,0 +1,111 @@
+# Lowering Plan
+
+**Files**: `ModuloScheduleGraph.h`, `ModuloSchedulePass.cpp`,
+`Z3JointSolver.cpp`, and
+`third_party/tlx/tools/sched2tlx/sched2tlx/schedule_graph.py`
+
+The lowering plan is the versioned contract for making synchronization and
+data-movement work visible to the joint scheduler. It is currently a
+**fixed-II shadow model**: it participates in the joint cycle/warp-group solve
+and is dumped for comparison with the emitter, but `sched2tlx` still emits from
+`cross_wg_barriers` and its own semaphore derivation.
+
+This distinction is intentional. A shadow plan can expose model/emitter drift
+without making an incomplete event model part of the correctness path.
+
+## Data Model
+
+`LoweringTemplate` describes conditional work before warp groups are chosen.
+Its relation is `always`, `same_wg`, or `different_wg`. Each event records:
+
+- kind (`wait`, `arrive`, `expect`, `local_store`, `local_load`, `fence`, or
+  `tc_commit`), owner, anchor node, and before/after placement;
+- issue pipeline, duration, completion latency, blocking/async properties,
+  frequency, and loop distance;
+- optional buffer, fusion, and dedup identities plus bytes, depth, and
+  semaphore role.
+
+`LoweringPlan` instantiates active templates after solving. Each concrete event
+has an absolute cycle, owner warp group, and per-warp-group stream order.
+Schema `lowering-plan-0.1` has four states:
+
+| Status | Meaning |
+| --- | --- |
+| `absent` | No joint lowering model was produced. |
+| `shadow_unmodeled` | A v1 partition solve, including a v2-to-v1 arbitration result, materialized coordinates without event-resource constraints. |
+| `shadow_verified` | A v2 fixed-II solve modeled event issue slots and the plan still matches final node ownership after compiler post-processing. |
+| `shadow_stale` | Later ownership changes or a structural mismatch invalidated the solver result. The emitter must not consume it. |
+
+The schedule-graph dump contains both `lowering_templates` and
+`lowering_plan`. A plan without its templates is not self-describing and is
+rejected by the `sched2tlx` parser.
+
+`issue_duration` is per dynamic occurrence; its modeled stream occupancy is
+`issue_duration * frequency`. Synchronization instructions use pipeline
+`NONE`: they occupy the owner's warp-group issue stream, not the chip-wide
+pipeline of the anchor operation.
+
+## Current Coverage
+
+The first shadow model covers two protocols derived from DDG edges:
+
+1. Tensor-core completion consumed by CUDA/SFU work: `tc_commit` plus a
+   blocking `wait`.
+2. Loop-carried CUDA/SFU-to-tensor-core signals crossing warp groups: `arrive`
+   plus `wait`.
+
+Event issue intervals occupy the owner warp group's issue stream. A
+lexicographic second solve minimizes independent CUDA/SFU work left behind
+blocking waits while preserving a proven-optimal primary objective. The
+in-process native Z3 backend evaluates these objectives under a fixed time
+budget, and the compiler revalidates every response before committing it. The
+joint solve also fixes every node to its
+committed stage because stage moves are not representable by the current
+emitter.
+
+This is not yet lowering-aware II search. The request fixes `ii` to the
+existing schedule's II, and the independent `JointSolverScheduler` II sweep
+does not yet receive these templates. TMA handoffs, local store/load bridges,
+full/empty recycle, fan-in/out, fences, and final synthesized buffer identities
+remain emitter-derived.
+
+## Validation Boundary
+
+The solver response is validated into temporaries before any schedule state is
+committed. For v2, the compiler first recomputes buffer counts and synthesized
+channel depth from the solved cycles, re-merges buffers, deduplicates channels
+by producer result, preserves explicit ring-depth floors, and checks that
+loop's SMEM/TMEM hard caps. After scalar demotion, infrastructure propagation,
+cross-loop warp group reconciliation, barrier synthesis, and buffer merging,
+it performs a fail-closed whole-kernel SMEM and per-loop TMEM audit. The SMEM
+audit mirrors sched2tlx's signal-only elimination and unsafe-alias fallback to
+private allocations. Until SemIR itself is shared, the audit conservatively
+reserves a full/empty barrier pair for every non-signal SMEM/TMEM data buffer,
+with existing and cross-WG barrier objects deducted. It then checks template
+presence and event ownership again. Only a matching v2 plan is marked
+`shadow_verified`.
+
+The sched2tlx parser accepts old graphs with no plan, parses all template/event
+semantics, and rejects an unknown version, unknown state, duplicate IDs,
+invalid resources, non-contiguous stream order, or ownership mismatch in a
+verified plan. Parsing is observability only; code emission is unchanged.
+
+## Promotion To Authoritative Lowering
+
+The plan can replace emitter re-derivation only after all of the following hold:
+
+1. A shared planner represents every emitted protocol event and final channel
+   identity, including fusion and deduplication.
+2. Fixed-assignment evaluation matches emitter traces for the case corpus.
+3. The plan generates `cross_wg_barriers` and synthesized buffers instead of
+   being computed before them.
+4. sched2tlx consumes supported plan versions fail-closed and cannot add,
+   remove, reorder, or deepen protocol work.
+5. The same event model participates in the proven-feasible fixed-II sweep;
+   an `UNKNOWN` lower II may not be skipped.
+
+The generic II sweep already stops fail-closed at an `UNKNOWN` candidate. Its
+remaining gap is that it does not yet receive the lowering event model.
+
+Until these gates pass, `shadow_verified` means structural agreement with the
+modeled subset, not exact effective-II ownership.

--- a/third_party/tlx/tools/sched2tlx/SCHEMA.md
+++ b/third_party/tlx/tools/sched2tlx/SCHEMA.md
@@ -200,6 +200,67 @@ The emitter groups sibling sub-ops by `subtile_count` and emits a single
 }
 ```
 
+### `lowering_templates` and `lowering_plan`
+
+These optional loop fields expose the joint solver's fixed-II lowering shadow
+model. Older graphs omit them and parse as an `absent` plan.
+
+`lowering_templates` contains the complete conditional event semantics:
+
+```json
+{
+  "id": 0,
+  "relation": "always",
+  "src_node": 9,
+  "dst_node": 10,
+  "src_cluster": 3,
+  "dst_cluster": 4,
+  "events": [{
+    "id": 0,
+    "kind": "tc_commit",
+    "owner": "src",
+    "anchor_node": 9,
+    "placement": "after",
+    "pipeline": "NONE",
+    "issue_duration": 1,
+    "completion_latency": 559,
+    "blocking": false,
+    "async": true,
+    "distance": 0,
+    "frequency": 1,
+    "buffer_id": null,
+    "bytes": 0,
+    "depth": 1,
+    "semaphore": "full",
+    "fusion_group": null,
+    "dedup_group": null
+  }]
+}
+```
+
+`relation` is `always`, `same_wg`, or `different_wg`. `lowering_plan`
+instantiates the active templates. `issue_duration` is per occurrence, so an
+event occupies `issue_duration * frequency` issue slots. Pipeline `NONE` means
+the event uses only its owner's warp-group issue stream; synchronization events
+do not reserve the anchor operation's chip-wide pipeline.
+
+```json
+{
+  "version": "lowering-plan-0.1",
+  "status": "shadow_verified",
+  "templates": [{
+    "id": 0,
+    "active": true,
+    "events": [{"id": 0, "cycle": 318, "wg": 2, "stream_order": 7}]
+  }]
+}
+```
+
+The statuses are `absent`, `shadow_unmodeled`, `shadow_verified`, and
+`shadow_stale`. None is authoritative for emission yet: sched2tlx parses and
+validates this contract, then continues to lower from `cross_wg_barriers`.
+See `ModuloScheduling/docs/LoweringPlan.md` for coverage and promotion gates.
+
 ## What the emitter does with this
 
 1. **Preamble** = walk all `scope == "function"` ops in source order, emit each

--- a/third_party/tlx/tools/sched2tlx/sched2tlx/emitter.py
+++ b/third_party/tlx/tools/sched2tlx/sched2tlx/emitter.py
@@ -964,6 +964,177 @@ def _bar_empty(buffer_var: str) -> str:
     return f"{buffer_var}_empty"
 
 
+def _skw(buffer_var: str) -> str:
+    """Barrier-name namespace for intra-WG stage-skew rings. The ring's DATA
+    var is the accumulator/alloc var itself, but its barriers must not share
+    names with that var's other barrier pairs: the FA-bwd epilogue handoff
+    allocates `{var}_full/_empty` for the same accumulator, and in merged
+    (all-MMA-in-one-WG) layouts both pairs coexist — the later skew-ring
+    binding silently shadowed the handoff pair (case4 merged draw,
+    2026-07-11), mistargeting the epilogue wait and post-loop commit."""
+    return f"{buffer_var}_skw"
+
+
+def _ring_exprs(count: int, rctx: "RenderCtx") -> tuple[str, str]:
+    """(index, phase) for subscripting a SPECIFIC ring buffer in the current
+    WG body.
+
+    The WG-shared `buf`/`phase` counters advance modulo the WG's
+    REPRESENTATIVE (max) ring depth — correct only for buffers whose own
+    count equals it. A shallower ring in the same WG must use its OWN
+    modulus, or its subscript drifts off the slots its producer and
+    barriers use (case4 v2 draw, 2026-07-10: a count-2 dS ring in a
+    rep_depth-3 WG was read at [_it % 3] but written at [_it % 2] — dQ/dK
+    one tile off and index 2 out of bounds, dV clean).
+    """
+    if count == 1:
+        return "0", "(_it & 1)"
+    rep = getattr(rctx, "_wg_rep_depth", None)
+    if rep is not None and count != rep:
+        return f"(_it % {count})", f"((_it // {count}) & 1)"
+    return "buf", "phase"
+
+
+# ── Merge-group alias safety (Step 4.5 storage reuse) ──────────────────────
+# HW-issued producer kinds: the write happens asynchronously (TMA/MMA engine)
+# and its wait-empty lives in op-specific renderers where alias waits are not
+# injected (yet) — a merge group containing one cannot be guarded by the SW
+# producer path below, so its storage reuse is dropped instead.
+_HW_PRODUCER_KINDS = (
+    "tt.descriptor_load",
+    "tt.descriptor_gather",
+    "ttng.tc_gen5_mma",
+    "ttng.tc_gen5_mma_scaled",
+    "ttng.warp_group_dot",
+    "ttng.tmem_copy",
+    "ttg.async_copy_global_to_local",
+)
+
+
+def _alias_group_safety(loop: Loop) -> dict[int, bool]:
+    """merge_group_id → can the SW producer path synchronize the alias?
+
+    Step 4.5's lifetime check proves merged buffers occupy disjoint cycle
+    windows, but cycles are a MODEL — on hardware only barriers order the
+    aliased writes against the other members' readers. A group is guardable
+    iff every member is a synthesized cross-WG channel (has a paired
+    cross_wg_barrier) whose producer is SW-issued and whose channel is
+    forward (a backward/loop-carry channel is signal-only: its empty never
+    arrives, so waiting on it deadlocks). Guardable groups get alias waits
+    at their producers (_alias_wait_stmts); every other multi-member SMEM
+    group has its reuse DROPPED at alloc time — separate bytes are always
+    correct, merely less thrifty. Single-member groups are trivially safe.
+    """
+    cycle_of = {n.id: n.schedule_cycle for n in loop.schedule.nodes}
+    kind_of = {n.id: n.op_kind for n in loop.schedule.nodes}
+    cbs_by_buf: dict[int, list] = {}
+    for cb in loop.schedule.cross_wg_barriers:
+        if cb.paired_buffer_id is not None:
+            cbs_by_buf.setdefault(cb.paired_buffer_id, []).append(cb)
+    groups: dict[int, list] = {}
+    for b in loop.schedule.buffers:
+        if b.merge_group_id is not None and b.kind == "smem":
+            groups.setdefault(b.merge_group_id, []).append(b)
+    safety: dict[int, bool] = {}
+    for mgid, members in groups.items():
+        if len(members) < 2:
+            safety[mgid] = True
+            continue
+        ok = True
+        for m in members:
+            cbs = cbs_by_buf.get(m.id, [])
+            if not cbs:
+                ok = False
+                break
+            for cb in cbs:
+                pc = cycle_of.get(cb.producer_node)
+                cc = cycle_of.get(cb.consumer_node)
+                if (
+                    pc is None
+                    or cc is None
+                    or pc > cc
+                    or kind_of.get(cb.producer_node) in _HW_PRODUCER_KINDS
+                ):
+                    ok = False
+                    break
+            if not ok:
+                break
+        safety[mgid] = ok
+    return safety
+
+
+def _alias_wait_stmts(loop: Loop, rctx: "RenderCtx", buf_id: int) -> list[str]:
+    """Alias-safety waits for a channel producer whose buffer shares bytes
+    with other merge-group members (Step 4.5 storage reuse).
+
+    The group is one physical slot with k producer/consumer pairs per
+    iteration in lifetime order: p1→c1→…→pk→ck→p1(next iter). Enforcement:
+      * a LATER member's producer waits each EARLIER member's empty at the
+        CONSUMER phase (that member's reader of THIS iteration has drained);
+      * the EARLIEST member's producer waits every other member's empty at
+        the PRODUCER phase (their readers of the PREVIOUS iteration — passes
+        immediately on iteration 0), closing the ring.
+    Where a same-WG data dependence already orders the aliased accesses the
+    wait is redundant but cheap; it exists for WG topologies with no such
+    chain (case4 FA-bwd flake, 2026-07-10: two D-load channels merged, the
+    second WG's local_store raced the first channel's reader — dQ/dK/dV
+    corrupt by 1e3 while every cycle-model check passed).
+    """
+    if rctx.sem_set is None:
+        return []
+    safety = getattr(rctx, "_alias_group_safety", {}).get(loop.loop_id, {})
+    own = next((b for b in loop.schedule.buffers if b.id == buf_id), None)
+    if own is None or own.merge_group_id is None or own.kind != "smem":
+        return []
+    mgid = own.merge_group_id
+    if not safety.get(mgid, False):
+        return []  # reuse was dropped at alloc time — bytes are private
+    members = sorted(
+        (
+            b
+            for b in loop.schedule.buffers
+            if b.merge_group_id == mgid and b.kind == "smem"
+        ),
+        key=lambda b: (b.live_start, b.id),
+    )
+    if len(members) < 2:
+        return []
+    idx = getattr(rctx, "_ls_by_buffer", None)
+    if idx is None:
+        idx = {}
+        for ls in rctx.sem_set.lowered:
+            if ls.sem.buffer is not None:
+                idx.setdefault(
+                    (ls.sem.buffer.loop_id, ls.sem.buffer.buffer_id), []
+                ).append(ls)
+        rctx._ls_by_buffer = idx
+    own_key = (own.live_start, own.id)
+    is_earliest = own_key == (members[0].live_start, members[0].id)
+    targets = (
+        [m for m in members if m.id != own.id]
+        if is_earliest
+        else [m for m in members if (m.live_start, m.id) < own_key]
+    )
+    out: list[str] = []
+    for m in targets:
+        seen: set[str] = set()
+        for ls in idx.get((loop.loop_id, m.id), []):
+            if ls.alloc_empty_stmt is None or ls.empty_name in seen:
+                continue
+            seen.add(ls.empty_name)
+            if is_earliest:
+                phase = f"({ls.phase_expr} ^ 1)"
+                note = "alias wrap"
+            else:
+                phase = ls.phase_expr
+                note = "alias predecessor"
+            out.append(
+                f"tlx.barrier_wait({ls.empty_name}[{ls.slot_expr}], {phase})"
+                f"  # {note} (merge group {mgid})"
+            )
+    return out
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # SemIR barrier-emission helpers (used by in-loop emitters when the flag is on)
 # ──────────────────────────────────────────────────────────────────────────
@@ -1254,8 +1425,7 @@ def _semir_mma_operand_waits_and_mbarriers(
         buf_var = rctx.buffer_var.get((loop.loop_id, buf.id))
         if buf_var is None:
             continue
-        idx = "0" if buf.count == 1 else "buf"
-        ph = "(_it & 1)" if buf.count == 1 else "phase"
+        idx, ph = _ring_exprs(buf.count, rctx)
         # Multi-consumer dedup: when several MMAs in this WG read the same
         # single-buffered operand (e.g. FA-bwd dO feeds both dpT and dV), its
         # `_full` completes ONCE per load — wait it only on the FIRST consumer
@@ -1327,6 +1497,14 @@ def _semir_emit_producer_block(
         # SW producer: wait empty (unless is_released), store, arrive full.
         if w := ls.producer_wait_at.get(n.id):
             _put(w, is_data)
+            # Alias safety: when this buffer shares bytes with other
+            # merge-group members (Step 4.5 reuse), also wait until the
+            # aliased members' readers have drained — cycle-disjoint
+            # lifetimes are a model property, only barriers order the
+            # hardware (case4 FA-bwd flake, 2026-07-10).
+            if sem.buffer is not None:
+                for aw in _alias_wait_stmts(loop, rctx, sem.buffer.buffer_id):
+                    _put(aw, is_data)
         if sem.buffer is not None:
             buf_var = rctx.buffer_var.get((sem.buffer.loop_id, sem.buffer.buffer_id))
             if buf_var is not None:
@@ -1532,6 +1710,14 @@ def _emit_buffers(loop: Loop, g: ScheduleGraph, rctx: RenderCtx, lines: _Lines) 
     # buffers in the same group emit `reuse=<first_var>` (Step 4.5 says they
     # have disjoint lifetimes — same physical bytes, different time slots).
     merge_group_owner: dict[int, str] = {}
+    # Alias-safety verdict per SMEM merge group: guardable groups get alias
+    # waits at their producers (_alias_wait_stmts); unguardable multi-member
+    # groups have their reuse dropped right here. Stashed on rctx for the
+    # producer-side emitters.
+    alias_safety = _alias_group_safety(loop)
+    if not hasattr(rctx, "_alias_group_safety"):
+        rctx._alias_group_safety = {}
+    rctx._alias_group_safety[loop.loop_id] = alias_safety
     for b in loop.schedule.buffers:
         # Signal-only loop-carry-release buffer: no data, so no alloc (the
         # handshake uses its own named barrier, not this buffer). Skips the 64 KB
@@ -1587,6 +1773,12 @@ def _emit_buffers(loop: Loop, g: ScheduleGraph, rctx: RenderCtx, lines: _Lines) 
                 f"II={loop.schedule.II}"
             )
             mgid = b.merge_group_id
+            if mgid is not None and not alias_safety.get(mgid, True):
+                # Unguardable alias (HW producer / signal-only / non-channel
+                # member): allocate private bytes instead of racing on shared
+                # ones. Costs SMEM, never correctness.
+                origin += f"; merge group {mgid} reuse DROPPED (unsynchronizable alias)"
+                mgid = None
             reuse = ""
             if mgid is not None and mgid in merge_group_owner:
                 reuse = f", reuse={merge_group_owner[mgid]}"
@@ -1623,6 +1815,17 @@ def _emit_buffers(loop: Loop, g: ScheduleGraph, rctx: RenderCtx, lines: _Lines) 
             if mgid is not None and mgid not in merge_group_owner:
                 merge_group_owner[mgid] = var
         elif b.kind == "tmem":
+            # Emitter capability (EmitterCaps.kMaxTMEMBlockM in
+            # ModuloSchedulePass.cpp): TMEM accumulators support
+            # blockM <= 128 — no MMA splitting for larger tiles yet.
+            # Fail clearly instead of emitting a kernel that traps
+            # (case2's 256-blockM pre_modulo is the known instance).
+            if len(b.shape) >= 1 and b.shape[0] > 128:
+                raise NotImplementedError(
+                    f"TMEM buffer {b.id} has blockM={b.shape[0]} > 128; "
+                    "the emitter cannot split MMAs for tiles beyond the "
+                    "TMEM row limit (EmitterCaps.kMaxTMEMBlockM). "
+                    "Regenerate the schedule with blockM <= 128.")
             shape = (
                 str(b.shape[0]) + ","
                 if len(b.shape) == 1
@@ -1739,6 +1942,16 @@ def _emit_buffers(loop: Loop, g: ScheduleGraph, rctx: RenderCtx, lines: _Lines) 
             )
             shape = shape_dt[0] if shape_dt else [128, 128]
             dtype = _dtype_str_to_tl(shape_dt[1]) if shape_dt else "tl.float32"
+            # Emitter capability (EmitterCaps.kMaxTMEMBlockM): TMEM
+            # accumulators support blockM <= 128 — fail clearly instead of
+            # emitting a kernel that traps (case2's 256-blockM pre_modulo
+            # is the known instance).
+            if shape and shape[0] > 128:
+                raise NotImplementedError(
+                    f"function-scope TMEM alloc has blockM={shape[0]} > 128; "
+                    "the emitter cannot split MMAs for tiles beyond the TMEM "
+                    "row limit (EmitterCaps.kMaxTMEMBlockM). Regenerate the "
+                    "schedule with blockM <= 128.")
             shape_str = ", ".join(str(d) for d in shape)
             # Reserve `acc_tmem` for the LARGEST function-scope tmem_alloc
             # (the running output accumulator); secondary ones (e.g., QK
@@ -2355,10 +2568,23 @@ def _derive_smem_bridge_channels(g: ScheduleGraph, inner: Loop) -> list[Channel]
                 continue  # cross-WG (cross_wg_barriers cover it) or no MMA consumer
             if any(cb.paired_buffer_id == b.id for cb in L.schedule.cross_wg_barriers):
                 continue  # already staged by a synthesized cross-WG channel
+            # The bridge store/handshake protocol is DEPTH-1 by construction:
+            # the producer store, its full/empty waits, and the operand-side
+            # full wait are all emitted at slot [0] with (_it & 1) parity.
+            # A buffer arriving here with count > 1 (schedule lifetime/II+1
+            # depth) would be written at [0] but read at the WG ring counter
+            # by the consuming MMAs — 2 of every `count` iterations read a
+            # never-written slot (case4 merged-partition draw, 2026-07-11:
+            # dsT depth-3 bridge fed dK/dQ garbage, errors growing with N;
+            # dV clean). Clamp the buffer to the protocol's depth so the
+            # data alloc, the barrier ring, and _ring_exprs all agree; the
+            # depth-1 handshake already serialized the pipeline, so no
+            # overlap is lost.
+            b.count = 1
             out.append(
                 Channel(
                     name=b.def_op,  # resolved to the buffer var by the caller
-                    depth=b.count,
+                    depth=1,
                     producer_wg=val_wg,
                     consumer_wg=val_wg,
                     kind="tmem",  # reuse bridge store+handshake emission
@@ -3172,8 +3398,9 @@ def _emit_skew_ring_consumer_wait(
         var = entry.get("var")
         if var is None or n.id in entry.get("mma_consumers", []):
             continue  # MMA consumers handshake inside the MMA emit branch
+        bv = entry.get("bar_var") or _skw(var)
         w = (
-            f"tlx.barrier_wait({_bar_full(var)}[{entry['slot']}], "
+            f"tlx.barrier_wait({_bar_full(bv)}[{entry['slot']}], "
             f"{entry['phase']})  # intra-WG skew ring (async result ready)"
         )
         seen = getattr(rctx, "_emitted_full_waits", None)
@@ -3195,8 +3422,9 @@ def _emit_skew_ring_consumer_arrive(
             continue
         sw = entry.get("sw_consumers", [])
         if sw and sw[-1] == n.id:
+            bv = entry.get("bar_var") or _skw(var)
             lines += (
-                f"tlx.barrier_arrive({_bar_empty(var)}[{entry['slot']}], 1)"
+                f"tlx.barrier_arrive({_bar_empty(bv)}[{entry['slot']}], 1)"
                 f"  # intra-WG skew ring recycle"
             )
 
@@ -3310,6 +3538,10 @@ def _emit_warp_group(
         if b.id in touched_buf_ids and b.kind in ("smem", "tmem") and b.count > 1
     ]
     rep_depth = max(depths) if depths else 1
+    # Buffers whose count differs from rep_depth must NOT be subscripted
+    # with the shared `buf`/`phase` — _ring_exprs consults this to emit
+    # per-buffer moduli for them.
+    rctx._wg_rep_depth = rep_depth
     iv = loop.schedule.induction_var_name
     # Preserve the IV's MLIR semantic value (= byte offset into K), so the
     # in-loop offsets that reference iv don't need a `* step` multiplier.
@@ -3505,7 +3737,7 @@ def _emit_warp_group(
     # enclosing (function) scope. Re-materialize any function-scope register
     # tensors this WG consumes (e.g. case6 v2's W/B loads) with task-local
     # names; restore the global bindings after the body. No-op if none.
-    _reg_loc_saved = _localize_captured_reg_tensors(g, emit_nodes, rctx, lines)
+    _reg_loc_saved = _localize_captured_reg_tensors(g, [loop], emit_nodes, rctx, lines)
 
     if True:
         lo = _render_operand(loop.schedule.lower_bound, rctx)
@@ -3837,15 +4069,14 @@ def _emit_in_loop_node(
             for e in _semir_producer_expect_bytes(loop.loop_id, n.id, rctx):
                 lines += e
             bar_arg = _semir_producer_barrier_for_tma(loop.loop_id, n.id, rctx)
-            data_slot = "buf" if buf is not None and buf.count > 1 else "0"
+            data_slot = _ring_exprs(buf.count, rctx)[0] if buf is not None else "0"
             lines += f"# load → {buf_var}"
             if bar_arg is None:
                 # No cross-WG semaphore for this TMA (producer + consumer in
                 # the same WG). The intra-WG `<buf>_full` barrier was
                 # allocated in the `extra` carve-out — use it: wait empty,
                 # expect bytes, load with full as the mbarrier arg.
-                ph = "(_it & 1)" if buf.count == 1 else "phase"
-                idx = "0" if buf.count == 1 else "buf"
+                idx, ph = _ring_exprs(buf.count, rctx)
                 nbytes = (
                     (
                         buf.shape[0]
@@ -3877,12 +4108,7 @@ def _emit_in_loop_node(
         # Without this, the consumer-signaled empty barrier appears never to
         # release on subsequent iters → producer wait blocks → kernel hang
         # OR illegal barrier op if the state goes inconsistent.
-        if buf.count == 1:
-            idx = "0"
-            ph = "(_it & 1)"
-        else:
-            idx = "buf"
-            ph = "phase"
+        idx, ph = _ring_exprs(buf.count, rctx)
         nbytes = (
             (buf.shape[0] * buf.shape[1] * _bytes_per_elem_bits(buf.element_bits))
             if len(buf.shape) >= 2
@@ -3929,9 +4155,9 @@ def _emit_in_loop_node(
         def _ring_idx_phase(buf, lp):
             if lp is not loop:
                 return "0", "0"
-            if buf is not None and buf.count == 1:
-                return "0", "(_it & 1)"
-            return "buf", "phase"
+            if buf is None:
+                return "buf", "phase"
+            return _ring_exprs(buf.count, rctx)
 
         a_idx, a_ph = _ring_idx_phase(a_buf, a_loop)
         b_idx, b_ph = _ring_idx_phase(b_buf, b_loop)
@@ -4046,8 +4272,9 @@ def _emit_in_loop_node(
             for side, opnd_var in (("a", a_var), ("b", b_var)):
                 rc = rctx.skew_ring.get(opnd_var)
                 if rc is not None and n.id in rc["consumer_nodes"]:
+                    rc_bv = rc.get("bar_var") or _skw(opnd_var)
                     w = (
-                        f"tlx.barrier_wait({_bar_full(opnd_var)}[{rc['slot']}], "
+                        f"tlx.barrier_wait({_bar_full(rc_bv)}[{rc['slot']}], "
                         f"{rc['phase']})  # intra-WG skew ring operand"
                     )
                     if _seen_fw is None or w not in _seen_fw:
@@ -4055,7 +4282,7 @@ def _emit_in_loop_node(
                         if _seen_fw is not None:
                             _seen_fw.add(w)
                     ring_consumer_empties.append(
-                        f"{_bar_empty(opnd_var)}[{rc['slot']}]"
+                        f"{_bar_empty(rc_bv)}[{rc['slot']}]"
                     )
                     # Re-slot the operand expression onto the ring index.
                     if side == "a":
@@ -4073,8 +4300,9 @@ def _emit_in_loop_node(
             ring_prod = rctx.skew_ring.get(dest_var)
             if ring_prod is not None and n.id == ring_prod["producer_node"]:
                 acc_idx = ring_prod["slot"]
+                rp_bv = ring_prod.get("bar_var") or _skw(dest_var)
                 lines += (
-                    f"tlx.barrier_wait({_bar_empty(dest_var)}[{ring_prod['slot']}], "
+                    f"tlx.barrier_wait({_bar_empty(rp_bv)}[{ring_prod['slot']}], "
                     f"{ring_prod['phase']} ^ 1)  # intra-WG skew ring slot free"
                 )
             lines += f"use_acc = {_use_acc_expr(op, loop, rctx)}"
@@ -4085,7 +4313,8 @@ def _emit_in_loop_node(
             mbar_list.extend(_semir_consumer_mbarriers(loop.loop_id, n.id, rctx))
             mbar_list.extend(_semir_producer_mbarriers(loop.loop_id, n.id, rctx))
             if ring_prod is not None and n.id == ring_prod["producer_node"]:
-                mbar_list.append(f"{_bar_full(dest_var)}[{ring_prod['slot']}]")
+                rp_bv = ring_prod.get("bar_var") or _skw(dest_var)
+                mbar_list.append(f"{_bar_full(rp_bv)}[{ring_prod['slot']}]")
 
             # Pass A.5: when the MMA is partitioned, fan out to N async_dot
             # calls. Each call takes a `tlx.local_slice` view of the shared
@@ -4310,7 +4539,7 @@ def _emit_in_loop_node(
             buf_var = rctx.buffer_var.get(
                 (loop.loop_id, buf.id), f"L{loop.loop_id}_{_buffer_var_name(buf)}"
             )
-            slot = "buf" if buf.count > 1 else "0"
+            slot = _ring_exprs(buf.count, rctx)[0]
         else:
             buf_var, slot = "c_smem", "0"
         if getattr(rctx, "defer_inloop_store", False):
@@ -4355,7 +4584,7 @@ def _emit_in_loop_node(
             buf_var = rctx.buffer_var.get(
                 (loop.loop_id, buf.id), f"L{loop.loop_id}_{_buffer_var_name(buf)}"
             )
-            slot = "buf" if buf.count > 1 else "0"
+            slot = _ring_exprs(buf.count, rctx)[0]
         else:
             buf_var, slot = "dq_smem", "0"
         lines += f"tlx.local_store({buf_var}[{slot}], {value_expr})"
@@ -5045,6 +5274,7 @@ def _result_is_register_tensor(op: Op) -> bool:
 
 def _localize_captured_reg_tensors(
     g: ScheduleGraph,
+    loops: list[Loop],
     target_nodes: list[Node],
     rctx: RenderCtx,
     lines: _Lines,
@@ -5061,10 +5291,28 @@ def _localize_captured_reg_tensors(
     order: list[Op] = []
     seen: set[str] = set()
 
+    # Values produced by scheduled (non-infra) nodes are bound to task-local
+    # names or channel payloads during node emission — the renderer uses the
+    # binding and never inline-expands past them. Only un-scheduled
+    # (inline-rendered) expression trees can smuggle a function-scope register
+    # tensor into this task's rendered code, so the walk mirrors rendering:
+    # stop at scheduled nodes, recurse through everything else — including
+    # IV/iter-arg-dependent inline ops, whose subtrees can still reference
+    # IV-INVARIANT preamble tensors (case4 v2:
+    # `tl.load(D + (tile_id + range_12))` capturing the preamble `tl.arange`).
+    bound_ids = {
+        n.op_ref
+        for lp in loops
+        for n in lp.schedule.nodes
+        if n.op_ref and n.warp_group >= 0
+    }
+
     def walk(op_id: str) -> None:
         if op_id in seen:
             return
         seen.add(op_id)
+        if op_id in bound_ids:
+            return
         op = g.ops.get(op_id)
         if op is None:
             return
@@ -5079,6 +5327,11 @@ def _localize_captured_reg_tensors(
         for o in op.operands:
             if isinstance(o, OpRef):
                 walk(o.op_id)
+        # An IV/iter-arg-dependent value can't be hoisted as a task-local
+        # copy (it isn't loop-invariant) — but its operands, walked above,
+        # still can.
+        if _depends_on_iv_or_iter_arg(g, op_id):
+            return
         # Candidate: a register-tensor value already named at function scope
         # (preamble). Re-emit it here so the task doesn't capture it.
         if (
@@ -5111,6 +5364,82 @@ def _localize_captured_reg_tensors(
         rctx.op_var[op.op_id] = name
         lines += f"{name} = {rhs}"
     return saved
+
+
+def _localize_rendered_captures(
+    g: ScheduleGraph, rctx: RenderCtx, lines: _Lines, body_start: int
+) -> None:
+    """Safety net behind _localize_captured_reg_tensors. The pre-walk predicts
+    which function-scope register tensors a WG body will reference by walking
+    the graph, but a few render paths expand expressions the walk cannot see
+    (e.g. the prologue/skew re-materialization of a channel producer's address
+    chain — case4 v2's `tl.load(D + (tile_id + range_12))` inlines past a
+    channel-bound node). This pass checks the property the TTIR verifier
+    actually enforces ("WarpSpecializeOp should not capture RankedTensorType"):
+    scan the RENDERED body for function-scope register-tensor names, and
+    re-materialize + substitute any found at the top of the task body. No-op
+    when the pre-walk got everything — which keeps committed-kernel parity
+    byte-exact — and correct by construction when it didn't."""
+    # Every function-scope register tensor currently bound to a preamble name.
+    fn_names: dict[str, Op] = {}
+    for op_id, name in rctx.op_var.items():
+        if not name:
+            continue
+        op = g.ops.get(op_id)
+        if op is not None and op.scope == "function" and _result_is_register_tensor(op):
+            fn_names[name] = op
+    if not fn_names:
+        return
+
+    def names_in(text: str) -> set[str]:
+        return {n for n in fn_names if re.search(rf"\b{re.escape(n)}\b", text)}
+
+    body_text = "\n".join(lines.buf[body_start:])
+    needed = names_in(body_text)
+    if not needed:
+        return
+    # A re-materialized expression can itself reference other function-scope
+    # tensors (case6's arange → W/B-load chain) — chase to a fixpoint.
+    exprs: dict[str, str] = {}
+    work = list(needed)
+    while work:
+        name = work.pop()
+        if name in exprs:
+            continue
+        exprs[name] = _render_op_expr(fn_names[name], rctx)
+        work.extend(n for n in names_in(exprs[name]) if n not in exprs)
+
+    # Topological order by textual dependency (SSA — no cycles).
+    ordered: list[str] = []
+    emitted: set[str] = set()
+
+    def visit(name: str) -> None:
+        if name in emitted:
+            return
+        emitted.add(name)
+        for dep in names_in(exprs[name]):
+            if dep != name:
+                visit(dep)
+        ordered.append(name)
+
+    for name in sorted(exprs):
+        visit(name)
+
+    rebound = {name: f"_wgcap{700 + i}" for i, name in enumerate(ordered)}
+    pattern = re.compile("|".join(rf"\b{re.escape(n)}\b" for n in rebound))
+
+    def sub(text: str) -> str:
+        return pattern.sub(lambda m: rebound[m.group(0)], text)
+
+    indent = "    " * lines.indent
+    remat = [
+        f"{indent}# Re-materialize captured function-scope register tensors",
+        f"{indent}# (render-level safety net; see _localize_rendered_captures).",
+    ]
+    remat += [f"{indent}{rebound[name]} = {sub(exprs[name])}" for name in ordered]
+    for i in range(body_start, len(lines.buf)):
+        lines.buf[i] = sub(lines.buf[i])
+    lines.buf[body_start:body_start] = remat
 
 
 # ---------------------------------------------------------------------------
@@ -6011,7 +6340,12 @@ def _emit_uwg_body_impl(
     _loc_nodes = list(_outer_nodes_for_uwg(outer, uwg))
     if inner is not None and uwg.inner_wg is not None:
         _loc_nodes += _inner_nodes_for_uwg(inner, uwg)
-    _localize_captured_reg_tensors(g, _loc_nodes, rctx, lines, descend_iv=True)
+    # No scheduled-node stop-set on this walk (loops=[]): the per-UWG
+    # localization descends the full operand tree like the walk that emitted
+    # the committed fixtures; the stop-set is scoped to the per-loop WG
+    # emission site, and anything missed there is caught by the render-level
+    # capture safety net.
+    _localize_captured_reg_tensors(g, [], _loc_nodes, rctx, lines, descend_iv=True)
 
     # Loop-carry pre-arrives (is_released semaphores, e.g. case9 sem4 acc_tmem
     # release): PRIME ONCE here, before the persistent loop. The inner-loop carry
@@ -6256,6 +6590,14 @@ def emit(graph: ScheduleGraph) -> str:
     outer_loop = _find_outer_loop(graph)
     inner_loop = _find_inner_loop(graph, outer_loop) if outer_loop else None
 
+    # Pre-pass: clamp intra-WG SMEM→MMA bridge buffers to the bridge
+    # protocol's depth-1 BEFORE buffer allocs render — the same derivation
+    # runs again later for channel construction and its clamp side effect
+    # is idempotent, but by then the alloc lines (count=N) are already out.
+    _bridge_detect_loop = inner_loop if inner_loop is not None else outer_loop
+    if _bridge_detect_loop is not None:
+        _derive_smem_bridge_channels(graph, _bridge_detect_loop)
+
     # Fold pipeline=NONE sink ops (warp_group=-1) into their producer's group.
     for L in graph.loops:
         _reassign_orphan_nodes(graph, L)
@@ -6453,6 +6795,18 @@ def emit(graph: ScheduleGraph) -> str:
                 # references it without partition awareness still resolves.
                 lines += f"{name} = {names[0]}"
             else:
+                # Emitter capability (EmitterCaps.kMaxTMEMBlockM): TMEM
+                # accumulators support blockM <= 128 — fail clearly instead
+                # of emitting a kernel that traps (case2's 256-blockM
+                # pre_modulo is the known instance; the unpartitioned
+                # carve-out path is where it lands).
+                if buf.shape and buf.shape[0] > 128:
+                    raise NotImplementedError(
+                        f"TMEM accumulator buf {buf.id} has "
+                        f"blockM={buf.shape[0]} > 128; the emitter cannot "
+                        "split MMAs for tiles beyond the TMEM row limit "
+                        "(EmitterCaps.kMaxTMEMBlockM). Regenerate the "
+                        "schedule with blockM <= 128.")
                 lines += (
                     f"# {name}: outer-loop buf {buf.id}, count={buf.count} "
                     f"(TC writes / default reads across {buf.count} tiles)"
@@ -6899,7 +7253,11 @@ def emit(graph: ScheduleGraph) -> str:
         skew_alloc_names = {c.name for c in channels} | {nm for nm, _ in extra or []}
         for var, entry in rctx.skew_ring.items():
             if var in skew_alloc_names or _bar_full(var) in seen_alloc:
+                # Delegated: an existing channel/extra pair already owns
+                # `{var}_full/_empty`; the ring's waits reuse those names.
+                entry["bar_var"] = var
                 continue
+            entry["bar_var"] = _skw(var)
             skew_alloc_names.add(var)
             eac = len(entry.get("mma_consumers", [])) + (
                 1 if entry.get("sw_consumers") else 0
@@ -6910,11 +7268,11 @@ def emit(graph: ScheduleGraph) -> str:
                 f"{entry['depth'] - 1} iter(s) ahead of its consumers)"
             )
             lines += (
-                f"{_bar_full(var)} = tlx.alloc_barriers"
+                f"{_bar_full(entry['bar_var'])} = tlx.alloc_barriers"
                 f"(num_barriers={entry['depth']}, arrive_count=1)"
             )
             lines += (
-                f"{_bar_empty(var)} = tlx.alloc_barriers"
+                f"{_bar_empty(entry['bar_var'])} = tlx.alloc_barriers"
                 f"(num_barriers={entry['depth']}, arrive_count={max(eac, 1)})"
             )
     else:
@@ -6953,8 +7311,11 @@ def emit(graph: ScheduleGraph) -> str:
             )
             lines += f"# Async task: role={uwg.role} ← {origin} (Phase 4 plan)"
             with lines.block(_task_header(uwg)):
+                body_start = len(lines.buf)
                 _emit_uwg_body(
                     graph, outer_loop, inner_loop, uwg, channels, rctx, lines
                 )
+                if not uwg.is_default:
+                    _localize_rendered_captures(graph, rctx, lines, body_start)
 
     return lines.render()

--- a/third_party/tlx/tools/sched2tlx/sched2tlx/schedule_graph.py
+++ b/third_party/tlx/tools/sched2tlx/sched2tlx/schedule_graph.py
@@ -177,6 +177,64 @@ class CrossWGBarrier:
     depth: int
     paired_buffer_id: int | None
     expect_bytes: int
+    distance: int = 0
+    arrive_after_node: int | None = None
+    wait_before_node: int | None = None
+
+
+@dataclass(frozen=True)
+class LoweringEventTemplate:
+    id: int
+    kind: str
+    owner: str
+    anchor_node: int
+    placement: str
+    pipeline: str
+    issue_duration: int
+    completion_latency: int
+    blocking: bool
+    is_async: bool
+    distance: int
+    frequency: int
+    buffer_id: int | None
+    bytes: int
+    depth: int
+    semaphore: str
+    fusion_group: int | None
+    dedup_group: int | None
+
+
+@dataclass(frozen=True)
+class LoweringTemplate:
+    id: int
+    relation: str
+    src_node: int
+    dst_node: int
+    src_cluster: int
+    dst_cluster: int
+    events: tuple[LoweringEventTemplate, ...]
+
+
+@dataclass(frozen=True)
+class LoweringEvent:
+    id: int
+    cycle: int
+    warp_group: int
+    stream_order: int
+
+
+@dataclass(frozen=True)
+class LoweringTemplatePlan:
+    id: int
+    active: bool
+    events: tuple[LoweringEvent, ...]
+
+
+@dataclass(frozen=True)
+class LoweringPlan:
+    version: str = "lowering-plan-0.1"
+    status: str = "absent"
+    templates: tuple[LoweringTemplatePlan, ...] = ()
 
 
 @dataclass
@@ -208,6 +266,8 @@ class ScheduleLoop:
     nodes: list[Node]
     edges: list[Edge]
     cross_wg_barriers: list[CrossWGBarrier] = field(default_factory=list)
+    lowering_templates: tuple[LoweringTemplate, ...] = ()
+    lowering_plan: LoweringPlan = field(default_factory=LoweringPlan)
 
 
 @dataclass
@@ -306,10 +366,157 @@ def _to_node(d: dict[str, Any]) -> Node:
     )
 
 
+def _to_lowering_event_template(d: dict[str, Any]) -> LoweringEventTemplate:
+    return LoweringEventTemplate(
+        id=d["id"],
+        kind=d["kind"],
+        owner=d["owner"],
+        anchor_node=d["anchor_node"],
+        placement=d["placement"],
+        pipeline=d["pipeline"],
+        issue_duration=d["issue_duration"],
+        completion_latency=d["completion_latency"],
+        blocking=d["blocking"],
+        is_async=d["async"],
+        distance=d["distance"],
+        frequency=d["frequency"],
+        buffer_id=d.get("buffer_id"),
+        bytes=d["bytes"],
+        depth=d["depth"],
+        semaphore=d["semaphore"],
+        fusion_group=d.get("fusion_group"),
+        dedup_group=d.get("dedup_group"),
+    )
+
+
+def _to_lowering_template(d: dict[str, Any]) -> LoweringTemplate:
+    return LoweringTemplate(
+        id=d["id"],
+        relation=d["relation"],
+        src_node=d["src_node"],
+        dst_node=d["dst_node"],
+        src_cluster=d["src_cluster"],
+        dst_cluster=d["dst_cluster"],
+        events=tuple(_to_lowering_event_template(e) for e in d.get("events", [])),
+    )
+
+
+def _to_lowering_plan(d: dict[str, Any] | None) -> LoweringPlan:
+    if d is None:
+        return LoweringPlan()
+    return LoweringPlan(
+        version=d["version"],
+        status=d.get("status", "absent"),
+        templates=tuple(
+            LoweringTemplatePlan(
+                id=template["id"],
+                active=template["active"],
+                events=tuple(
+                    LoweringEvent(
+                        id=event["id"],
+                        cycle=event["cycle"],
+                        warp_group=event["wg"],
+                        stream_order=event["stream_order"],
+                    )
+                    for event in template.get("events", [])
+                ),
+            )
+            for template in d.get("templates", [])
+        ),
+    )
+
+
+def _validate_lowering_contract(loop: ScheduleLoop) -> None:
+    plan = loop.lowering_plan
+    if plan.version != "lowering-plan-0.1":
+        raise ValueError(f"unsupported lowering plan version: {plan.version}")
+    if plan.status not in {
+        "absent",
+        "shadow_unmodeled",
+        "shadow_verified",
+        "shadow_stale",
+    }:
+        raise ValueError(f"unsupported lowering plan status: {plan.status}")
+
+    templates = {template.id: template for template in loop.lowering_templates}
+    plans = {template.id: template for template in plan.templates}
+    if len(templates) != len(loop.lowering_templates):
+        raise ValueError("duplicate lowering template id")
+    if len(plans) != len(plan.templates):
+        raise ValueError("duplicate lowering plan template id")
+    if plan.status == "absent":
+        if templates or plans:
+            raise ValueError("absent lowering plan contains templates")
+        return
+    if templates.keys() != plans.keys():
+        raise ValueError("lowering template/plan ids differ")
+
+    nodes = {node.id: node for node in loop.nodes}
+    stream_orders: dict[int, list[int]] = {}
+    for template_id, template in templates.items():
+        if template.relation not in {"always", "same_wg", "different_wg"}:
+            raise ValueError(f"invalid lowering relation in template {template_id}")
+        if template.src_node not in nodes or template.dst_node not in nodes:
+            raise ValueError(f"unknown lowering endpoint in template {template_id}")
+        event_templates = {event.id: event for event in template.events}
+        if len(event_templates) != len(template.events):
+            raise ValueError(f"duplicate lowering event in template {template_id}")
+        for event in template.events:
+            if event.anchor_node not in nodes:
+                raise ValueError(f"unknown lowering anchor in template {template_id}")
+            if event.owner not in {"src", "dst"}:
+                raise ValueError(f"invalid lowering owner in template {template_id}")
+            if event.placement not in {"before", "after"}:
+                raise ValueError(
+                    f"invalid lowering placement in template {template_id}"
+                )
+            if event.issue_duration < 0 or event.completion_latency < 0:
+                raise ValueError(f"negative lowering timing in template {template_id}")
+            if event.frequency <= 0 or event.depth <= 0 or event.bytes < 0:
+                raise ValueError(f"invalid lowering resource in template {template_id}")
+
+        template_plan = plans[template_id]
+        planned_events = {event.id: event for event in template_plan.events}
+        if len(planned_events) != len(template_plan.events):
+            raise ValueError(f"duplicate planned event in template {template_id}")
+        if plan.status == "shadow_stale":
+            continue
+
+        src_wg = nodes[template.src_node].warp_group
+        dst_wg = nodes[template.dst_node].warp_group
+        expected_active = (
+            template.relation == "always"
+            or (template.relation == "same_wg" and src_wg == dst_wg)
+            or (template.relation == "different_wg" and src_wg != dst_wg)
+        )
+        if template_plan.active != expected_active:
+            raise ValueError(f"lowering presence mismatch in template {template_id}")
+        expected_event_ids = event_templates.keys() if expected_active else set()
+        if planned_events.keys() != expected_event_ids:
+            raise ValueError(f"lowering event ids differ in template {template_id}")
+        for event_id, event in planned_events.items():
+            event_template = event_templates[event_id]
+            owner_node = (
+                template.src_node
+                if event_template.owner == "src"
+                else template.dst_node
+            )
+            owner_wg = nodes[owner_node].warp_group
+            if event.warp_group != owner_wg:
+                raise ValueError(f"lowering owner mismatch in template {template_id}")
+            if nodes[event_template.anchor_node].warp_group != owner_wg:
+                raise ValueError(f"lowering anchor mismatch in template {template_id}")
+            stream_orders.setdefault(event.warp_group, []).append(event.stream_order)
+
+    for warp_group, orders in stream_orders.items():
+        if sorted(orders) != list(range(len(orders))):
+            raise ValueError(f"non-contiguous lowering stream for WG {warp_group}")
+
+
 def _to_schedule_loop(d: dict[str, Any]) -> ScheduleLoop:
     iv = d.get("induction_var", {})
     g = d.get("graph", {})
-    return ScheduleLoop(
+    loop = ScheduleLoop(
         id=d["id"],
         II=d["II"],
         max_stage=d["max_stage"],
@@ -330,7 +537,8 @@ def _to_schedule_loop(d: dict[str, Any]) -> ScheduleLoop:
                 kind=e["kind"],
                 distance=e["distance"],
                 latency=e["latency"],
-            ) for e in g.get("edges", [])
+            )
+            for e in g.get("edges", [])
         ],
         cross_wg_barriers=[
             CrossWGBarrier(
@@ -342,9 +550,20 @@ def _to_schedule_loop(d: dict[str, Any]) -> ScheduleLoop:
                 depth=b["depth"],
                 paired_buffer_id=b.get("paired_buffer_id"),
                 expect_bytes=b["expect_bytes"],
-            ) for b in g.get("cross_wg_barriers", [])
+                distance=b.get("distance", 0),
+                arrive_after_node=b.get("arrive_after_node"),
+                wait_before_node=b.get("wait_before_node"),
+            )
+            for b in g.get("cross_wg_barriers", [])
         ],
+        lowering_templates=tuple(
+            _to_lowering_template(template)
+            for template in d.get("lowering_templates", [])
+        ),
+        lowering_plan=_to_lowering_plan(d.get("lowering_plan")),
     )
+    _validate_lowering_contract(loop)
+    return loop
 
 
 def load_graph(path: str | Path) -> ScheduleGraph:
@@ -356,14 +575,17 @@ def load_graph(path: str | Path) -> ScheduleGraph:
             name=data["kernel"]["name"],
             args=[KernelArg(**a) for a in data["kernel"]["args"]],
         ),
-        ops={op_id: _to_op(op_id, op_data)
-             for op_id, op_data in data.get("ops", {}).items()},
+        ops={
+            op_id: _to_op(op_id, op_data)
+            for op_id, op_data in data.get("ops", {}).items()
+        },
         loops=[
             Loop(
                 loop_id=L["loop_id"],
                 is_outer=L.get("is_outer", False),
                 warp_groups=[WarpGroup(**w) for w in L.get("warp_groups", [])],
                 schedule=_to_schedule_loop(L["schedule_loop"]),
-            ) for L in data.get("loops", [])
+            )
+            for L in data.get("loops", [])
         ],
     )

--- a/third_party/tlx/tools/sched2tlx/sched2tlx/semaphore_ir.py
+++ b/third_party/tlx/tools/sched2tlx/sched2tlx/semaphore_ir.py
@@ -474,6 +474,36 @@ def _derive_intrawg_async_result_consumers(
             # here would serialize the async producer against its own WG.
             if skip_pairs and (loop.loop_id, prod.id, n.id) in skip_pairs:
                 continue
+            # LEGALITY: this handshake is a depth-1 mbarrier parity wait that
+            # EVERY warp of the consumer's group executes. PTX defines parity
+            # tests only for the current and immediately preceding phase, so
+            # in a multi-warp group a straggler warp that falls a full
+            # generation behind aliases the parity and the kernel WEDGES
+            # (case9b fully-merged joint partition, 2026-07-16: ~1/300
+            # launches at 4096 after a small-shape bench). Single-warp groups
+            # execute waits warp-uniformly and are safe. Refuse to emit the
+            # hazard instead of producing a kernel that hangs under load —
+            # the native joint-solver-0.2 legality constraint in
+            # Z3JointSolver.cpp keeps TC/MFMA-to-CUDA/SFU readers in a
+            # different warp group.
+            wg_warps = next(
+                (
+                    w.num_warps
+                    for w in getattr(loop, "warp_groups", [])
+                    if w.id == n.warp_group
+                ),
+                None,
+            )
+            if wg_warps is not None and wg_warps > 1:
+                raise RuntimeError(
+                    f"sched2tlx intra-WG async-result hazard: N{prod.id} "
+                    f"({prod.op_kind}) result is read by N{n.id} ({n.op_kind}) "
+                    f"inside its own multi-warp group wg{n.warp_group} "
+                    f"({wg_warps} warps). The depth-1 parity-wait handshake "
+                    f"tolerates at most one phase of intra-group warp skew and "
+                    f"wedges under load. Put the reader in a different warp "
+                    f"group, or make the producer's group single-warp."
+                )
             seen_pairs.add(pair)
             extra.append(
                 Semaphore(

--- a/third_party/tlx/tools/sched2tlx/test_resident_load_barriers.py
+++ b/third_party/tlx/tools/sched2tlx/test_resident_load_barriers.py
@@ -1,0 +1,220 @@
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from sched2tlx import emitter, schedule_graph
+
+FIXTURE = Path(__file__).parent / "examples/case11_wait_order/schedule_graph.json"
+_WAIT_S1 = "tlx.barrier_wait(sem2_full[0], (_it & 1))"
+_WAIT_S2 = "tlx.barrier_wait(sem3_full[0], (_it & 1))"
+_RECYCLE_S1 = "tlx.barrier_arrive(sem4_full[0], 1)"
+_RECYCLE_S2 = "tlx.barrier_arrive(sem5_full[0], 1)"
+_TMEM_BRIDGE_TAIL = "\n".join(
+    f"                {line}"
+    for line in (
+        "trunc_21 = subf_20.to(tl.float16)",
+        "tlx.barrier_wait(L0_acc_tmem_2_empty[0], (_it & 1) ^ 1)  # TMEM bridge",
+        "tlx.local_store(L0_acc_tmem_2[0], trunc_21)",
+        "tlx.barrier_arrive(L0_acc_tmem_2_full[0], 1)",
+    )
+)
+
+
+def _merge_softmax_warp_groups(
+    graph: schedule_graph.ScheduleGraph, first_stage_order: tuple[int, ...]
+) -> None:
+    loop = graph.loops[0]
+    nodes = {node.id: node for node in loop.schedule.nodes}
+    merged_wg = nodes[8].warp_group
+    absorbed_wg = nodes[11].warp_group
+    for node_id in (11, 12, 13):
+        nodes[node_id].warp_group = merged_wg
+    loop.warp_groups = [wg for wg in loop.warp_groups if wg.id != absorbed_wg]
+
+    loop.schedule.cross_wg_barriers = [
+        barrier
+        for barrier in loop.schedule.cross_wg_barriers
+        if (barrier.producer_node, barrier.consumer_node) != (10, 12)
+    ]
+    for barrier in loop.schedule.cross_wg_barriers:
+        barrier.producer_wg = nodes[barrier.producer_node].warp_group
+        barrier.consumer_wg = nodes[barrier.consumer_node].warp_group
+
+    for cluster, node_id in enumerate(first_stage_order):
+        nodes[node_id].schedule_cluster = cluster
+
+
+def _assert_substrings_in_order(source: str, substrings: tuple[str, ...]) -> None:
+    cursor = 0
+    for substring in substrings:
+        cursor = source.index(substring, cursor) + len(substring)
+
+
+def _assert_shared_resident_load_protocol(sources: tuple[str, str]) -> None:
+    for source in sources:
+        _assert_substrings_in_order(
+            source,
+            (_WAIT_S1, "tlx.local_load(acc_tmem_4[0])", _RECYCLE_S1),
+        )
+        assert source.count(_WAIT_S1) == 1
+        assert source.count(_WAIT_S2) == 1
+        for recycle in (_RECYCLE_S1, _RECYCLE_S2):
+            assert source.splitlines().count(f"                {recycle}") == 1
+
+
+def _add_lowering_contract(data: dict) -> None:
+    schedule = data["loops"][0]["schedule_loop"]
+    nodes = [node for node in schedule["graph"]["nodes"] if node["warp_group"] >= 0]
+    src, dst = nodes[:2]
+    src_wg, dst_wg = src["warp_group"], dst["warp_group"]
+    dst_order = 1 if src_wg == dst_wg else 0
+    common = {
+        "frequency": 1,
+        "buffer_id": None,
+        "bytes": 0,
+        "depth": 1,
+        "semaphore": "full",
+        "fusion_group": None,
+        "dedup_group": None,
+    }
+    schedule["lowering_templates"] = [
+        {
+            "id": 0,
+            "relation": "always",
+            "src_node": src["id"],
+            "dst_node": dst["id"],
+            "src_cluster": 0,
+            "dst_cluster": 1,
+            "events": [
+                {
+                    "id": 0,
+                    "kind": "arrive",
+                    "owner": "src",
+                    "anchor_node": src["id"],
+                    "placement": "after",
+                    "pipeline": src["pipeline"],
+                    "issue_duration": 1,
+                    "completion_latency": 0,
+                    "blocking": False,
+                    "async": False,
+                    "distance": 0,
+                    **common,
+                },
+                {
+                    "id": 1,
+                    "kind": "wait",
+                    "owner": "dst",
+                    "anchor_node": dst["id"],
+                    "placement": "before",
+                    "pipeline": dst["pipeline"],
+                    "issue_duration": 1,
+                    "completion_latency": 0,
+                    "blocking": True,
+                    "async": False,
+                    "distance": 0,
+                    **common,
+                },
+            ],
+        }
+    ]
+    schedule["lowering_plan"] = {
+        "version": "lowering-plan-0.1",
+        "status": "shadow_verified",
+        "templates": [
+            {
+                "id": 0,
+                "active": True,
+                "events": [
+                    {
+                        "id": 0,
+                        "cycle": src["schedule"]["cycle"] + 1,
+                        "wg": src_wg,
+                        "stream_order": 0,
+                    },
+                    {
+                        "id": 1,
+                        "cycle": dst["schedule"]["cycle"] - 1,
+                        "wg": dst_wg,
+                        "stream_order": dst_order,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def test_load_graph_parses_shadow_lowering_contract(tmp_path):
+    data = json.loads(FIXTURE.read_text())
+    _add_lowering_contract(data)
+    graph_path = tmp_path / "schedule_graph.json"
+    graph_path.write_text(json.dumps(data))
+
+    graph = schedule_graph.load_graph(graph_path)
+
+    lowering_template = graph.loops[0].schedule.lowering_templates[0]
+    lowering_plan = graph.loops[0].schedule.lowering_plan
+    assert lowering_template.events[1].kind == "wait"
+    assert lowering_plan.status == "shadow_verified"
+    assert lowering_plan.templates[0].events[1].warp_group >= 0
+
+
+def test_load_graph_rejects_verified_plan_with_wrong_owner(tmp_path):
+    data = json.loads(FIXTURE.read_text())
+    _add_lowering_contract(data)
+    data["loops"][0]["schedule_loop"]["lowering_plan"]["templates"][0]["events"][0][
+        "wg"
+    ] = 999
+    graph_path = tmp_path / "schedule_graph.json"
+    graph_path.write_text(json.dumps(data))
+
+    with pytest.raises(ValueError, match="lowering owner mismatch"):
+        schedule_graph.load_graph(graph_path)
+
+
+def test_transposed_resident_mma_operands_wait_for_tma():
+    src = emitter.emit(schedule_graph.load_graph(FIXTURE))
+
+    consumers = {
+        "q_smem_6": "tlx.async_dot(L0_acc_tmem_2[0], q_smem_6[0]",
+        "q_smem_7": "tlx.local_trans(q_smem_7[0])",
+        "q_smem_8": "tlx.local_trans(q_smem_8[0])",
+    }
+    for alloc_var, consumer in consumers.items():
+        wait = f"tlx.barrier_wait({alloc_var}_full[0], 0)"
+        assert src.count(wait) == 1
+        assert src.index(wait) < src.index(consumer)
+
+
+def test_merged_softmax_resident_load_can_be_early_or_deferred():
+    base = schedule_graph.load_graph(FIXTURE)
+    early, deferred = deepcopy(base), deepcopy(base)
+    _merge_softmax_warp_groups(early, (8, 11, 9, 10))
+    _merge_softmax_warp_groups(deferred, (8, 9, 10, 11))
+
+    early_src, deferred_src = emitter.emit(early), emitter.emit(deferred)
+    _assert_shared_resident_load_protocol((early_src, deferred_src))
+
+    _assert_substrings_in_order(
+        early_src,
+        (
+            _WAIT_S2,
+            "tlx.local_load(acc_tmem_5[0])",
+            _RECYCLE_S2,
+            "* scale)",
+            "tl.math.exp2(",
+        ),
+    )
+    _assert_substrings_in_order(
+        deferred_src,
+        (
+            "* scale)",
+            "tl.math.exp2(",
+            _WAIT_S2,
+            "tlx.local_load(acc_tmem_5[0])",
+            _RECYCLE_S2,
+        ),
+    )
+    assert _TMEM_BRIDGE_TAIL in early_src
+    assert _TMEM_BRIDGE_TAIL in deferred_src

--- a/unittest/Hopper/modulo_schedule_test.cpp
+++ b/unittest/Hopper/modulo_schedule_test.cpp
@@ -14,12 +14,15 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
+#include <cstdlib>
 #include <functional>
 #include <initializer_list>
 #include <map>
 #include <optional>
 #include <set>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <vector>
 
@@ -90,6 +93,98 @@ TEST(ModuloScheduleTest, RejectsRepairWhenLatestCycleIsOccupied) {
 
   EXPECT_FALSE(
       tryRepairModuloSchedule(schedule.II, schedule.nodeToCycle, nodes, edges));
+}
+
+// ── Schedule-backend selection ──────────────────────────────────────────────
+//
+// getActiveScheduleAlgo is a pure function of (forced argument, env var). It
+// used to consult a process-global slot written by an RAII override, which two
+// modules compiled concurrently in one process (triton.AsyncCompileMode with a
+// ThreadPoolExecutor; pass_manager.run releases the GIL) could corrupt for each
+// other. These tests pin the property that replaced it.
+
+constexpr const char *kScheduleAlgoEnvVar = "TRITON_USE_MODULO_SCHEDULE";
+
+/// Pins TRITON_USE_MODULO_SCHEDULE for one test and restores it on scope exit,
+/// so a test can't leak its value into the rest of the binary. `value ==
+/// nullptr` unsets the variable.
+class ScopedScheduleAlgoEnv {
+public:
+  explicit ScopedScheduleAlgoEnv(const char *value) {
+    if (const char *previous = std::getenv(kScheduleAlgoEnvVar))
+      saved = std::string(previous);
+    apply(value);
+  }
+  ~ScopedScheduleAlgoEnv() { apply(saved ? saved->c_str() : nullptr); }
+  ScopedScheduleAlgoEnv(const ScopedScheduleAlgoEnv &) = delete;
+  ScopedScheduleAlgoEnv &operator=(const ScopedScheduleAlgoEnv &) = delete;
+
+private:
+  static void apply(const char *value) {
+    if (value)
+      setenv(kScheduleAlgoEnvVar, value, /*overwrite=*/1);
+    else
+      unsetenv(kScheduleAlgoEnvVar);
+  }
+
+  std::optional<std::string> saved;
+};
+
+TEST(ScheduleAlgoSelectionTest, DefaultsToRauWithoutEnvOrForcedAlgo) {
+  ScopedScheduleAlgoEnv env(nullptr);
+
+  EXPECT_EQ(getActiveScheduleAlgo(), "rau");
+}
+
+TEST(ScheduleAlgoSelectionTest, EmptyForcedAlgoReadsTheEnvVar) {
+  ScopedScheduleAlgoEnv env("sms");
+
+  EXPECT_EQ(getActiveScheduleAlgo(), "sms");
+  EXPECT_EQ(getActiveScheduleAlgo(""), "sms");
+}
+
+TEST(ScheduleAlgoSelectionTest, ForcedAlgoWinsAndLeavesNoResidue) {
+  ScopedScheduleAlgoEnv env("sms");
+
+  EXPECT_EQ(getActiveScheduleAlgo("joint_solver"), "joint_solver");
+  // The forced choice is an argument, not state: the next caller without one
+  // still sees the env var. (Old failure mode: a leaked override made an
+  // unrelated compile run the joint solver it never asked for.)
+  EXPECT_EQ(getActiveScheduleAlgo(), "sms");
+}
+
+// The plan's two-compile scenario, at the selection function: one run forces
+// joint_solver, a concurrent one forces nothing. Each must keep its own
+// backend for its whole run — a shared slot would either be reset under the
+// forcing run ("lost restore") or read by the other one ("leaked override").
+TEST(ScheduleAlgoSelectionTest, ConcurrentSelectionsAreIndependent) {
+  ScopedScheduleAlgoEnv env("rau");
+  constexpr int kIterations = 2000;
+
+  std::atomic<bool> start{false};
+  std::string forcedSaw, unforcedSaw; // first wrong observation, if any
+
+  auto resolveRepeatedly = [&](llvm::StringRef forced, llvm::StringRef expected,
+                               std::string &firstWrong) {
+    while (!start.load(std::memory_order_acquire)) {
+    }
+    for (int i = 0; i < kIterations; ++i) {
+      std::string algo = getActiveScheduleAlgo(forced);
+      if (algo != expected && firstWrong.empty())
+        firstWrong = algo;
+    }
+  };
+
+  std::thread forcedRun(resolveRepeatedly, "joint_solver", "joint_solver",
+                        std::ref(forcedSaw));
+  std::thread unforcedRun(resolveRepeatedly, "", "rau", std::ref(unforcedSaw));
+  start.store(true, std::memory_order_release);
+  forcedRun.join();
+  unforcedRun.join();
+
+  EXPECT_EQ(forcedSaw, "") << "forced run lost its backend to a concurrent one";
+  EXPECT_EQ(unforcedSaw, "")
+      << "unforced run picked up a concurrent run's backend";
 }
 
 #ifdef TRITON_ENABLE_Z3_JOINT_SOLVER

--- a/unittest/Hopper/modulo_schedule_test.cpp
+++ b/unittest/Hopper/modulo_schedule_test.cpp
@@ -12,6 +12,17 @@
 #include <utility>
 #include <vector>
 
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <initializer_list>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
+
 namespace mlir::triton::gpu {
 namespace {
 
@@ -132,6 +143,1004 @@ withFirstLoweringEventKind(llvm::StringRef problemJson, llvm::StringRef kind) {
   (*event)["kind"] = kind.str();
   return serializeJsonObject(std::move(*root));
 }
+
+constexpr size_t kGemmNodeCount = 10;
+
+struct GemmMachineModel {
+  const char *name;
+  const char *architecture;
+  int64_t ii;
+  int64_t loadALatency;
+  int64_t loadBLatency;
+  int64_t barrierLatency;
+  int64_t mmaLatency;
+  int64_t storeLatency;
+  int64_t loopDistance;
+  int64_t smemBudget;
+  int64_t tmemBudget;
+  bool accumulatorInTmem;
+  std::array<int64_t, kGemmNodeCount> committedStages;
+  std::array<int64_t, kGemmNodeCount> expectedCycles;
+};
+
+constexpr GemmMachineModel kHopperGemmModel{
+    "sm90-hopper-gemm-0.1",
+    "sm90",
+    8,
+    4,
+    3,
+    3,
+    3,
+    1,
+    2,
+    128,
+    0,
+    false,
+    {0, 0, 0, 0, 0, 0, 1, 1, 1, 1},
+    {0, 1, 2, 3, 4, 7, 10, 12, 13, 14},
+};
+
+constexpr GemmMachineModel kBlackwellGemmModel{
+    "sm100-blackwell-gemm-0.1",
+    "sm100",
+    8,
+    5,
+    4,
+    4,
+    4,
+    2,
+    3,
+    96,
+    64,
+    true,
+    {0, 0, 0, 0, 0, 1, 1, 1, 1, 2},
+    {0, 1, 2, 3, 4, 8, 12, 14, 15, 17},
+};
+
+static llvm::json::Object makeGemmProblem(const GemmMachineModel &model) {
+  constexpr std::array<const char *, kGemmNodeCount> labels{
+      "ptr_a",       "ptr_b",     "tma_a", "tma_b", "barrier_expect",
+      "mma",         "acc_update", "sfu",   "cast",  "store",
+  };
+  constexpr std::array<const char *, kGemmNodeCount> pipelines{
+      "NONE", "NONE", "TMA", "TMA", "NONE",
+      "TC",   "CUDA", "SFU", "CUDA", "TMA",
+  };
+  constexpr std::array<int64_t, kGemmNodeCount> clusters{
+      0, 0, 0, 0, 0, 1, 2, 2, 2, 3,
+  };
+
+  llvm::json::Array nodes;
+  for (size_t index = 0; index < kGemmNodeCount; ++index) {
+    int64_t latency = 1;
+    if (index == 2)
+      latency = model.loadALatency;
+    else if (index == 3)
+      latency = model.loadBLatency;
+    else if (index == 5)
+      latency = model.mmaLatency;
+    nodes.push_back(llvm::json::Object{
+        {"id", static_cast<int64_t>(index)},
+        {"label", labels[index]},
+        {"cycle", model.committedStages[index] * model.ii},
+        {"duration", llvm::StringRef(pipelines[index]) == "NONE" ? 0 : 1},
+        {"latency", latency},
+        {"pipeline", pipelines[index]},
+        {"freq", 1},
+    });
+  }
+
+  llvm::json::Array edges;
+  auto addEdge = [&](int64_t src, int64_t dst, int64_t latency,
+                     int64_t distance = 0, int64_t roundTrip = 0,
+                     int64_t channelBytes = 0) {
+    edges.push_back(llvm::json::Object{
+        {"src", src},
+        {"dst", dst},
+        {"src_result_idx", 0},
+        {"latency", latency},
+        {"distance", distance},
+        {"freq", 1},
+        {"rt", roundTrip},
+        {"xissue", 0},
+        {"chan_bytes", channelBytes},
+        {"src_cluster", clusters[src]},
+        {"dst_cluster", clusters[dst]},
+    });
+  };
+  addEdge(0, 1, 1);
+  addEdge(1, 2, 1);
+  addEdge(2, 3, 1);
+  addEdge(3, 4, 1);
+  addEdge(2, 5, model.loadALatency, 0, 1, 8);
+  addEdge(3, 5, model.loadBLatency, 0, 1, 8);
+  addEdge(4, 5, model.barrierLatency);
+  addEdge(5, 6, model.mmaLatency);
+  addEdge(6, 7, 2);
+  addEdge(7, 8, 1);
+  addEdge(8, 9, model.storeLatency);
+  addEdge(9, 0, 1, model.loopDistance);
+
+  llvm::json::Array buffers;
+  auto addBuffer = [&](int64_t id, int64_t producer, llvm::StringRef kind,
+                       int64_t sizeBytes, int64_t minCount,
+                       int64_t consumer) {
+    buffers.push_back(llvm::json::Object{
+        {"id", id},
+        {"producer", producer},
+        {"size_bytes", sizeBytes},
+        {"count", minCount},
+        {"min_count", minCount},
+        {"kind", kind},
+        {"consumers",
+         llvm::json::Array{llvm::json::Object{
+             {"node", consumer}, {"latency", 0}, {"distance", 0}}}},
+    });
+  };
+  addBuffer(0, 2, "smem", 16, 2, 5);
+  addBuffer(1, 3, "smem", 16, 2, 5);
+  addBuffer(2, 5, model.accumulatorInTmem ? "tmem" : "smem", 32,
+            model.accumulatorInTmem ? 2 : 1, 8);
+
+  llvm::json::Array conflicts;
+  for (int64_t left = 0; left < 4; ++left)
+    for (int64_t right = left + 1; right < 4; ++right)
+      conflicts.push_back(llvm::json::Array{left, right});
+
+  llvm::json::Array loweringTemplates;
+  loweringTemplates.push_back(llvm::json::Object{
+      {"id", 0},
+      {"relation", "different_wg"},
+      {"src_node", 2},
+      {"dst_node", 5},
+      {"src_cluster", 0},
+      {"dst_cluster", 1},
+      {"events",
+       llvm::json::Array{
+           llvm::json::Object{
+               {"id", 0},
+               {"kind", "arrive"},
+               {"owner", "src"},
+               {"anchor_node", 4},
+               {"placement", "after"},
+               {"pipeline", "NONE"},
+               {"issue_duration", 1},
+               {"completion_latency", 0},
+               {"blocking", false},
+               {"async", false},
+               {"distance", 0},
+               {"frequency", 1},
+               {"bytes", 0},
+               {"depth", 0},
+               {"semaphore", ""},
+           },
+           llvm::json::Object{
+               {"id", 1},
+               {"kind", "wait"},
+               {"owner", "dst"},
+               {"anchor_node", 5},
+               {"placement", "before"},
+               {"pipeline", "NONE"},
+               {"issue_duration", 1},
+               {"completion_latency", 0},
+               {"blocking", true},
+               {"async", false},
+               {"distance", 0},
+               {"frequency", 1},
+               {"bytes", 0},
+               {"depth", 0},
+               {"semaphore", ""},
+           },
+       }},
+  });
+
+  llvm::json::Array warpFootprint;
+  for (int64_t value : {0, 8, 16, 0, 32, 0, 0, 0, 64})
+    warpFootprint.push_back(value);
+
+  return llvm::json::Object{
+      {"version", "joint-solver-0.2"},
+      {"mode", "joint"},
+      {"name", std::string("gemm-") + model.architecture},
+      {"machine_model",
+       llvm::json::Object{{"version", model.name},
+                          {"architecture", model.architecture}}},
+      {"emitter_caps_version", 2},
+      {"ii", model.ii},
+      {"max_wgs", 4},
+      {"committed_smem", 0},
+      {"fixed_smem", 16},
+      {"smem_budget", model.smemBudget},
+      {"tmem_budget_bytes", model.tmemBudget},
+      {"default_wg_footprint", 0},
+      {"sm_regs", 56},
+      {"reg_budget", 56},
+      {"default_slack", 0},
+      {"time_limit_s", 5},
+      {"canonical_root", 0},
+      {"warp_footprint", std::move(warpFootprint)},
+      {"nodes", std::move(nodes)},
+      {"clusters",
+       llvm::json::Array{
+           llvm::json::Object{
+               {"id", 0},
+               {"min_warps", 1},
+               {"nodes", llvm::json::Array{0, 1, 2, 3, 4}}},
+           llvm::json::Object{
+               {"id", 1}, {"min_warps", 1}, {"nodes", llvm::json::Array{5}}},
+           llvm::json::Object{
+               {"id", 2},
+               {"min_warps", 4},
+               {"nodes", llvm::json::Array{6, 7, 8}}},
+           llvm::json::Object{
+               {"id", 3}, {"min_warps", 1}, {"nodes", llvm::json::Array{9}}},
+       }},
+      {"edges", std::move(edges)},
+      {"buffers", std::move(buffers)},
+      {"lowering_templates", std::move(loweringTemplates)},
+      {"warp_group_conflicts", std::move(conflicts)},
+  };
+}
+
+using GoldenAssignment = std::tuple<int64_t, int64_t, int64_t, int64_t>;
+using GoldenBuffer = std::tuple<int64_t, int64_t, std::string>;
+using GoldenEvent =
+    std::tuple<int64_t, int64_t, int64_t, int64_t, int64_t>;
+
+struct CanonicalGolden {
+  std::string machineModel;
+  int64_t ii;
+  int64_t usedWGs;
+  std::vector<GoldenAssignment> assignments;
+  std::vector<GoldenBuffer> buffers;
+  std::vector<GoldenEvent> loweringEvents;
+};
+
+static FailureOr<llvm::json::Object>
+runProductionValidation(llvm::StringRef problemJson,
+                        llvm::StringRef solutionJson) {
+  auto object =
+      parseJsonObject(validateZ3JointSolution(problemJson, solutionJson));
+  if (failed(object))
+    return failure();
+  auto schema = object->getString("schema");
+  if (!schema || *schema != "joint-solver-validation-0.1")
+    return failure();
+  return object;
+}
+
+static FailureOr<CanonicalGolden>
+canonicalizeGolden(llvm::StringRef problemJson, llvm::StringRef solutionJson) {
+  auto problem = parseJsonObject(problemJson);
+  auto solution = parseJsonObject(solutionJson);
+  if (failed(problem) || failed(solution))
+    return failure();
+  auto status = solution->getString("status");
+  auto ii = problem->getInteger("ii");
+  auto usedWGs = solution->getInteger("used_wgs");
+  auto *machineModel = problem->getObject("machine_model");
+  auto modelVersion =
+      machineModel ? machineModel->getString("version") : std::nullopt;
+  auto *nodes = problem->getArray("nodes");
+  auto *clusters = problem->getArray("clusters");
+  auto *problemBuffers = problem->getArray("buffers");
+  auto *problemTemplates = problem->getArray("lowering_templates");
+  auto *cycles = solution->getObject("cycles");
+  auto *warpGroups = solution->getObject("wg");
+  auto *depths = solution->getObject("buffer_depths");
+  auto *loweringPlan = solution->getObject("lowering_plan");
+  auto *planTemplates =
+      loweringPlan ? loweringPlan->getArray("templates") : nullptr;
+  auto planVersion =
+      loweringPlan ? loweringPlan->getString("version") : std::nullopt;
+  if (!status || *status != "ok" || !ii || *ii <= 0 || !usedWGs ||
+      !modelVersion || !nodes || !clusters || !problemBuffers ||
+      !problemTemplates || !cycles || !warpGroups || !depths ||
+      !loweringPlan || !planVersion || *planVersion != "lowering-plan-0.1" ||
+      !planTemplates || cycles->size() != nodes->size() ||
+      warpGroups->size() != clusters->size() ||
+      planTemplates->size() != problemTemplates->size())
+    return failure();
+
+  std::vector<int64_t> nodeIds;
+  std::set<int64_t> uniqueNodeIds;
+  for (const llvm::json::Value &value : *nodes) {
+    auto *node = value.getAsObject();
+    auto id = node ? node->getInteger("id") : std::nullopt;
+    if (!id || !uniqueNodeIds.insert(*id).second)
+      return failure();
+    nodeIds.push_back(*id);
+  }
+  std::sort(nodeIds.begin(), nodeIds.end());
+
+  std::map<int64_t, int64_t> clusterToRawGroup;
+  std::map<int64_t, int64_t> nodeToCluster;
+  for (const llvm::json::Value &value : *clusters) {
+    auto *cluster = value.getAsObject();
+    auto clusterId = cluster ? cluster->getInteger("id") : std::nullopt;
+    auto *clusterNodes = cluster ? cluster->getArray("nodes") : nullptr;
+    if (!clusterId || !clusterNodes ||
+        clusterToRawGroup.count(*clusterId) != 0)
+      return failure();
+    auto group = warpGroups->getInteger(std::to_string(*clusterId));
+    if (!group || *group < 0)
+      return failure();
+    clusterToRawGroup.emplace(*clusterId, *group);
+    for (const llvm::json::Value &nodeValue : *clusterNodes) {
+      auto nodeId = nodeValue.getAsInteger();
+      if (!nodeId || !uniqueNodeIds.count(*nodeId) ||
+          !nodeToCluster.emplace(*nodeId, *clusterId).second)
+        return failure();
+    }
+  }
+
+  CanonicalGolden golden{modelVersion->str(), *ii, *usedWGs, {}, {}, {}};
+  std::map<int64_t, int64_t> rawToNormalizedGroup;
+  std::map<int64_t, int64_t> cycleByNode;
+  for (int64_t nodeId : nodeIds) {
+    auto cycle = cycles->getInteger(std::to_string(nodeId));
+    auto cluster = nodeToCluster.find(nodeId);
+    if (!cycle || *cycle < 0 || cluster == nodeToCluster.end())
+      return failure();
+    int64_t rawGroup = clusterToRawGroup.at(cluster->second);
+    auto [normalized, inserted] = rawToNormalizedGroup.emplace(
+        rawGroup, static_cast<int64_t>(rawToNormalizedGroup.size()));
+    (void)inserted;
+    cycleByNode.emplace(nodeId, *cycle);
+    golden.assignments.emplace_back(nodeId, *cycle, *cycle / *ii,
+                                    normalized->second);
+  }
+  if (static_cast<int64_t>(rawToNormalizedGroup.size()) != *usedWGs)
+    return failure();
+
+  size_t smemBufferCount = 0;
+  std::set<int64_t> uniqueBufferIds;
+  for (const llvm::json::Value &value : *problemBuffers) {
+    auto *buffer = value.getAsObject();
+    auto id = buffer ? buffer->getInteger("id") : std::nullopt;
+    auto producer = buffer ? buffer->getInteger("producer") : std::nullopt;
+    auto sizeBytes = buffer ? buffer->getInteger("size_bytes") : std::nullopt;
+    auto minCount = buffer ? buffer->getInteger("min_count") : std::nullopt;
+    auto kind = buffer ? buffer->getString("kind") : std::nullopt;
+    auto *consumers = buffer ? buffer->getArray("consumers") : nullptr;
+    if (!id || !producer || !sizeBytes || !minCount || !kind || !consumers ||
+        !uniqueBufferIds.insert(*id).second ||
+        cycleByNode.count(*producer) == 0)
+      return failure();
+    int64_t producerCycle = cycleByNode.at(*producer);
+    int64_t lastEnd = producerCycle;
+    for (const llvm::json::Value &consumerValue : *consumers) {
+      auto *consumer = consumerValue.getAsObject();
+      auto node = consumer ? consumer->getInteger("node") : std::nullopt;
+      auto latency =
+          consumer ? consumer->getInteger("latency") : std::nullopt;
+      auto distance =
+          consumer ? consumer->getInteger("distance") : std::nullopt;
+      if (!node || !latency || !distance || cycleByNode.count(*node) == 0)
+        return failure();
+      lastEnd =
+          std::max(lastEnd, cycleByNode.at(*node) + *latency + *distance * *ii);
+    }
+    if (lastEnd < producerCycle)
+      return failure();
+    int64_t depth =
+        std::max((lastEnd - producerCycle) / *ii + 1, *minCount);
+    if (*kind == "smem") {
+      ++smemBufferCount;
+      auto serializedDepth = depths->getInteger(std::to_string(*id));
+      if (!serializedDepth || *serializedDepth != depth)
+        return failure();
+    }
+    golden.buffers.emplace_back(*id, depth, kind->str());
+  }
+  if (depths->size() != smemBufferCount)
+    return failure();
+  std::sort(golden.buffers.begin(), golden.buffers.end());
+
+  std::map<int64_t, const llvm::json::Object *> problemTemplateById;
+  for (const llvm::json::Value &value : *problemTemplates) {
+    auto *loweringTemplate = value.getAsObject();
+    auto id =
+        loweringTemplate ? loweringTemplate->getInteger("id") : std::nullopt;
+    if (!id || !problemTemplateById.emplace(*id, loweringTemplate).second)
+      return failure();
+  }
+  std::set<int64_t> seenTemplateIds;
+  for (const llvm::json::Value &value : *planTemplates) {
+    auto *planTemplate = value.getAsObject();
+    auto id = planTemplate ? planTemplate->getInteger("id") : std::nullopt;
+    auto active =
+        planTemplate ? planTemplate->getBoolean("active") : std::nullopt;
+    auto *events = planTemplate ? planTemplate->getArray("events") : nullptr;
+    if (!id || !active || !events || !seenTemplateIds.insert(*id).second ||
+        problemTemplateById.count(*id) == 0)
+      return failure();
+    const llvm::json::Object *problemTemplate = problemTemplateById.at(*id);
+    auto relation = problemTemplate->getString("relation");
+    auto srcCluster = problemTemplate->getInteger("src_cluster");
+    auto dstCluster = problemTemplate->getInteger("dst_cluster");
+    auto *expectedEvents = problemTemplate->getArray("events");
+    if (!relation || !srcCluster || !dstCluster || !expectedEvents ||
+        clusterToRawGroup.count(*srcCluster) == 0 ||
+        clusterToRawGroup.count(*dstCluster) == 0)
+      return failure();
+    bool sameGroup = clusterToRawGroup.at(*srcCluster) ==
+                     clusterToRawGroup.at(*dstCluster);
+    bool expectedActive = *relation == "always" ||
+                          (*relation == "same_wg" && sameGroup) ||
+                          (*relation == "different_wg" && !sameGroup);
+    if (*active != expectedActive ||
+        events->size() != (expectedActive ? expectedEvents->size() : 0))
+      return failure();
+
+    std::set<int64_t> expectedEventIds;
+    for (const llvm::json::Value &eventValue : *expectedEvents) {
+      auto *event = eventValue.getAsObject();
+      auto eventId = event ? event->getInteger("id") : std::nullopt;
+      if (!eventId || !expectedEventIds.insert(*eventId).second)
+        return failure();
+    }
+    for (const llvm::json::Value &eventValue : *events) {
+      auto *event = eventValue.getAsObject();
+      auto eventId = event ? event->getInteger("id") : std::nullopt;
+      auto cycle = event ? event->getInteger("cycle") : std::nullopt;
+      auto rawGroup = event ? event->getInteger("wg") : std::nullopt;
+      auto streamOrder =
+          event ? event->getInteger("stream_order") : std::nullopt;
+      if (!eventId || !cycle || !rawGroup || !streamOrder ||
+          expectedEventIds.erase(*eventId) != 1 ||
+          rawToNormalizedGroup.count(*rawGroup) == 0)
+        return failure();
+      golden.loweringEvents.emplace_back(
+          *id, *eventId, *cycle, rawToNormalizedGroup.at(*rawGroup),
+          *streamOrder);
+    }
+    if (expectedActive && !expectedEventIds.empty())
+      return failure();
+  }
+  if (seenTemplateIds.size() != problemTemplateById.size())
+    return failure();
+  std::sort(golden.loweringEvents.begin(), golden.loweringEvents.end());
+  return golden;
+}
+
+static CanonicalGolden expectedGemmGolden(const GemmMachineModel &model) {
+  constexpr std::array<int64_t, kGemmNodeCount> groups{
+      0, 0, 0, 0, 0, 1, 2, 2, 2, 3,
+  };
+  CanonicalGolden golden{model.name, model.ii, 4, {}, {}, {}};
+  for (size_t index = 0; index < kGemmNodeCount; ++index)
+    golden.assignments.emplace_back(
+        index, model.expectedCycles[index],
+        model.expectedCycles[index] / model.ii, groups[index]);
+  golden.buffers = model.accumulatorInTmem
+                       ? std::vector<GoldenBuffer>{{0, 2, "smem"},
+                                                   {1, 2, "smem"},
+                                                   {2, 2, "tmem"}}
+                       : std::vector<GoldenBuffer>{{0, 2, "smem"},
+                                                   {1, 2, "smem"},
+                                                   {2, 1, "smem"}};
+  golden.loweringEvents = {
+      {0, 0, 5, 0, 0},
+      {0, 1, model.expectedCycles[5] - 1, 1, 0},
+  };
+  return golden;
+}
+
+static void expectProductionValidity(llvm::StringRef problemJson,
+                                     llvm::StringRef solutionJson,
+                                     bool expectedValid) {
+  auto validation = runProductionValidation(problemJson, solutionJson);
+  ASSERT_TRUE(succeeded(validation));
+  auto valid = validation->getBoolean("valid");
+  auto message = validation->getString("message");
+  ASSERT_TRUE(valid);
+  ASSERT_TRUE(message);
+  EXPECT_EQ(*valid, expectedValid) << message->str();
+  if (!expectedValid)
+    EXPECT_FALSE(message->empty());
+}
+
+static void expectGemmGolden(const GemmMachineModel &model) {
+  std::string problemJson = serializeJsonObject(makeGemmProblem(model));
+  CanonicalGolden expected = expectedGemmGolden(model);
+  std::vector<CanonicalGolden> actual;
+  for (int run = 0; run < 2; ++run) {
+    auto output = runZ3JointSolver(problemJson);
+    ASSERT_TRUE(succeeded(output));
+    expectProductionValidity(problemJson, *output, true);
+    auto canonical = canonicalizeGolden(problemJson, *output);
+    ASSERT_TRUE(succeeded(canonical));
+    actual.push_back(std::move(*canonical));
+  }
+
+  ASSERT_EQ(actual.size(), 2);
+  for (const CanonicalGolden &golden : actual) {
+    EXPECT_EQ(golden.machineModel, expected.machineModel);
+    EXPECT_EQ(golden.ii, expected.ii);
+    EXPECT_EQ(golden.usedWGs, expected.usedWGs);
+    EXPECT_EQ(golden.assignments, expected.assignments);
+    EXPECT_EQ(golden.buffers, expected.buffers);
+    EXPECT_EQ(golden.loweringEvents, expected.loweringEvents);
+  }
+  EXPECT_EQ(actual[0].assignments, actual[1].assignments);
+  EXPECT_EQ(actual[0].buffers, actual[1].buffers);
+  EXPECT_EQ(actual[0].loweringEvents, actual[1].loweringEvents);
+}
+
+static llvm::json::Object *findEdge(llvm::json::Object &problem, int64_t src,
+                                    int64_t dst) {
+  auto *edges = problem.getArray("edges");
+  if (!edges)
+    return nullptr;
+  for (llvm::json::Value &value : *edges) {
+    auto *edge = value.getAsObject();
+    if (edge && edge->getInteger("src") == src &&
+        edge->getInteger("dst") == dst)
+      return edge;
+  }
+  return nullptr;
+}
+
+static int diagnosticKindRank(llvm::StringRef kind) {
+  constexpr llvm::StringLiteral kinds[] = {
+      "dependence", "resource", "smem",     "tmem",
+      "warp-group", "register", "lowering",
+  };
+  auto found = llvm::find(kinds, kind);
+  return found == std::end(kinds) ? static_cast<int>(std::size(kinds))
+                                  : static_cast<int>(found - std::begin(kinds));
+}
+
+static FailureOr<std::vector<std::string>>
+readStringArray(const llvm::json::Object &object, llvm::StringRef key) {
+  auto *values = object.getArray(key);
+  if (!values)
+    return failure();
+  std::vector<std::string> result;
+  result.reserve(values->size());
+  for (const llvm::json::Value &value : *values) {
+    auto string = value.getAsString();
+    if (!string)
+      return failure();
+    result.push_back(string->str());
+  }
+  return result;
+}
+
+static void expectUnsatDiagnostic(
+    llvm::StringRef problemJson,
+    std::initializer_list<llvm::StringRef> requiredKinds,
+    std::initializer_list<llvm::StringRef> requiredGroupIds,
+    llvm::StringRef expectedNormalization = "locally_minimized") {
+  auto output = runZ3JointSolver(problemJson);
+  ASSERT_TRUE(succeeded(output));
+  auto response = parseJsonObject(*output);
+  ASSERT_TRUE(succeeded(response));
+
+  auto status = response->getString("status");
+  auto provenUnsat = response->getBoolean("proven_unsat");
+  auto backendStatus = response->getString("backend_status");
+  auto *core = response->getObject("unsat_core");
+  auto *diagnostic = response->getObject("diagnostic");
+  ASSERT_TRUE(status);
+  ASSERT_TRUE(provenUnsat);
+  ASSERT_TRUE(backendStatus);
+  ASSERT_NE(core, nullptr);
+  ASSERT_NE(diagnostic, nullptr);
+  EXPECT_EQ(*status, "infeasible");
+  EXPECT_TRUE(*provenUnsat);
+  EXPECT_EQ(*backendStatus, "INFEASIBLE");
+
+  auto coreSchema = core->getString("schema");
+  auto coreII = core->getInteger("candidateII");
+  auto coreBackendStatus = core->getString("backendStatus");
+  auto coreProvenUnsat = core->getBoolean("provenUnsat");
+  auto normalization = core->getString("normalization");
+  auto groupIds = readStringArray(*core, "groupIds");
+  ASSERT_TRUE(coreSchema);
+  ASSERT_TRUE(coreII);
+  ASSERT_TRUE(coreBackendStatus);
+  ASSERT_TRUE(coreProvenUnsat);
+  ASSERT_TRUE(normalization);
+  ASSERT_TRUE(succeeded(groupIds));
+  EXPECT_EQ(*coreSchema, "joint-solver-core-0.1");
+  EXPECT_EQ(*coreBackendStatus, "INFEASIBLE");
+  EXPECT_TRUE(*coreProvenUnsat);
+  EXPECT_EQ(*normalization, expectedNormalization);
+  ASSERT_FALSE(groupIds->empty());
+  EXPECT_EQ(std::set<std::string>(groupIds->begin(), groupIds->end()).size(),
+            groupIds->size());
+  for (llvm::StringRef requiredGroupId : requiredGroupIds)
+    EXPECT_TRUE(llvm::is_contained(*groupIds, requiredGroupId.str()));
+
+  auto diagnosticSchema = diagnostic->getString("schema");
+  auto diagnosticStatus = diagnostic->getString("status");
+  auto diagnosticII = diagnostic->getInteger("ii");
+  auto summary = diagnostic->getString("summary");
+  auto *diagnosticCore = diagnostic->getObject("core");
+  auto *constraints = diagnostic->getArray("constraints");
+  auto *aggregates = diagnostic->getArray("aggregates");
+  auto *suggestions = diagnostic->getArray("suggestions");
+  ASSERT_TRUE(diagnosticSchema);
+  ASSERT_TRUE(diagnosticStatus);
+  ASSERT_TRUE(diagnosticII);
+  ASSERT_TRUE(summary);
+  ASSERT_NE(diagnosticCore, nullptr);
+  ASSERT_NE(constraints, nullptr);
+  ASSERT_NE(aggregates, nullptr);
+  ASSERT_NE(suggestions, nullptr);
+  EXPECT_EQ(*diagnosticSchema, "joint-solver-diagnostic-0.1");
+  EXPECT_EQ(*diagnosticStatus, "unsat");
+  EXPECT_EQ(*diagnosticII, *coreII);
+  EXPECT_FALSE(summary->empty());
+  EXPECT_FALSE(suggestions->empty());
+
+  auto diagnosticGroupIds = readStringArray(*diagnosticCore, "groupIds");
+  auto diagnosticCoreSchema = diagnosticCore->getString("schema");
+  auto diagnosticCoreII = diagnosticCore->getInteger("candidateII");
+  auto diagnosticCoreBackendStatus =
+      diagnosticCore->getString("backendStatus");
+  auto diagnosticCoreProvenUnsat =
+      diagnosticCore->getBoolean("provenUnsat");
+  auto diagnosticNormalization = diagnosticCore->getString("normalization");
+  ASSERT_TRUE(succeeded(diagnosticGroupIds));
+  ASSERT_TRUE(diagnosticCoreSchema);
+  ASSERT_TRUE(diagnosticCoreII);
+  ASSERT_TRUE(diagnosticCoreBackendStatus);
+  ASSERT_TRUE(diagnosticCoreProvenUnsat);
+  ASSERT_TRUE(diagnosticNormalization);
+  EXPECT_EQ(*diagnosticGroupIds, *groupIds);
+  EXPECT_EQ(*diagnosticCoreSchema, *coreSchema);
+  EXPECT_EQ(*diagnosticCoreII, *coreII);
+  EXPECT_EQ(*diagnosticCoreBackendStatus, *coreBackendStatus);
+  EXPECT_EQ(*diagnosticCoreProvenUnsat, *coreProvenUnsat);
+  EXPECT_EQ(*diagnosticNormalization, expectedNormalization);
+
+  ASSERT_EQ(constraints->size(), groupIds->size());
+  std::set<std::string> kinds;
+  int previousRank = -1;
+  std::string previousId;
+  for (size_t index = 0; index < constraints->size(); ++index) {
+    auto *constraint = (*constraints)[index].getAsObject();
+    ASSERT_NE(constraint, nullptr);
+    auto id = constraint->getString("id");
+    auto kind = constraint->getString("kind");
+    auto *nodes = constraint->getArray("nodes");
+    ASSERT_TRUE(id);
+    ASSERT_TRUE(kind);
+    ASSERT_NE(nodes, nullptr);
+    EXPECT_NE(constraint->get("available"), nullptr);
+    EXPECT_EQ(*id, (*groupIds)[index]);
+    kinds.insert(kind->str());
+
+    int rank = diagnosticKindRank(*kind);
+    EXPECT_GE(rank, previousRank);
+    if (rank == previousRank)
+      EXPECT_LT(previousId, id->str());
+    previousRank = rank;
+    previousId = id->str();
+
+    std::vector<int64_t> nodeIds;
+    for (const llvm::json::Value &nodeValue : *nodes) {
+      auto node = nodeValue.getAsInteger();
+      ASSERT_TRUE(node);
+      nodeIds.push_back(*node);
+    }
+    EXPECT_TRUE(std::is_sorted(nodeIds.begin(), nodeIds.end()));
+  }
+  for (llvm::StringRef requiredKind : requiredKinds)
+    EXPECT_TRUE(kinds.count(requiredKind.str()));
+
+  previousRank = -1;
+  std::string previousResource;
+  for (const llvm::json::Value &value : *aggregates) {
+    auto *aggregate = value.getAsObject();
+    auto kind = aggregate ? aggregate->getString("kind") : std::nullopt;
+    ASSERT_TRUE(kind);
+    int rank = diagnosticKindRank(*kind);
+    EXPECT_GE(rank, previousRank);
+    std::string resource =
+        aggregate->getString("resource").value_or("").str();
+    if (rank == previousRank)
+      EXPECT_LE(previousResource, resource);
+    previousRank = rank;
+    previousResource = std::move(resource);
+  }
+}
+
+struct OracleNode {
+  int64_t id;
+  std::string pipeline;
+  int64_t duration;
+  bool streaming;
+};
+
+struct OracleEdge {
+  int64_t src;
+  int64_t dst;
+  int64_t latency;
+  int64_t distance;
+};
+
+struct OracleBuffer {
+  int64_t id;
+  int64_t alloc;
+  std::string kind;
+  int64_t sizeBytes;
+  int64_t tmemCols;
+  std::vector<int64_t> consumers;
+};
+
+struct OracleSchedule {
+  int64_t ii;
+  std::map<int64_t, int64_t> cycles;
+};
+
+static bool isOracleScheduleValid(
+    int64_t ii, const std::vector<OracleNode> &nodes,
+    const std::vector<OracleEdge> &edges,
+    const std::vector<OracleBuffer> &buffers, int64_t smemBudget,
+    int64_t tmemColLimit, bool streamingVL,
+    const std::map<int64_t, int64_t> &cycles,
+    std::optional<int64_t> canonicalRoot) {
+  if (ii <= 0 || cycles.size() != nodes.size())
+    return false;
+  if (canonicalRoot) {
+    auto rootCycle = cycles.find(*canonicalRoot);
+    if (rootCycle == cycles.end() || rootCycle->second != 0)
+      return false;
+  } else if (!cycles.empty()) {
+    auto minimum = std::min_element(
+        cycles.begin(), cycles.end(),
+        [](const auto &left, const auto &right) {
+          return left.second < right.second;
+        });
+    if (minimum->second != 0)
+      return false;
+  }
+
+  std::map<int64_t, const OracleNode *> nodeById;
+  for (const OracleNode &node : nodes)
+    nodeById.emplace(node.id, &node);
+
+  for (const OracleEdge &edge : edges) {
+    auto src = cycles.find(edge.src);
+    auto dst = cycles.find(edge.dst);
+    int64_t latency = streamingVL && nodeById.at(edge.src)->streaming
+                          ? 0
+                          : edge.latency;
+    if (src == cycles.end() || dst == cycles.end() ||
+        dst->second + edge.distance * ii < src->second + latency ||
+        (edge.distance == 0 && src->second / ii > dst->second / ii))
+      return false;
+  }
+
+  for (size_t leftIndex = 0; leftIndex < nodes.size(); ++leftIndex) {
+    const OracleNode &left = nodes[leftIndex];
+    if (left.pipeline == "NONE")
+      continue;
+    if (left.duration <= 0 || left.duration > ii)
+      return false;
+    for (size_t rightIndex = leftIndex + 1; rightIndex < nodes.size();
+         ++rightIndex) {
+      const OracleNode &right = nodes[rightIndex];
+      if (left.pipeline != right.pipeline)
+        continue;
+      if (right.duration <= 0 || right.duration > ii)
+        return false;
+      for (int64_t leftOffset = 0; leftOffset < left.duration; ++leftOffset) {
+        for (int64_t rightOffset = 0; rightOffset < right.duration;
+             ++rightOffset) {
+          int64_t leftSlot =
+              (cycles.at(left.id) + leftOffset) % static_cast<int64_t>(ii);
+          int64_t rightSlot =
+              (cycles.at(right.id) + rightOffset) % static_cast<int64_t>(ii);
+          if (leftSlot == rightSlot)
+            return false;
+        }
+      }
+    }
+  }
+
+  int64_t smemUsage = 0;
+  struct TmemLifetime {
+    int64_t start;
+    int64_t end;
+    int64_t columns;
+  };
+  std::vector<TmemLifetime> tmemLifetimes;
+  for (const OracleBuffer &buffer : buffers) {
+    int64_t allocCycle = cycles.at(buffer.alloc);
+    if (buffer.kind == "smem") {
+      int64_t lastStage = allocCycle / ii;
+      for (int64_t consumer : buffer.consumers)
+        lastStage = std::max(lastStage, cycles.at(consumer) / ii);
+      smemUsage += buffer.sizeBytes * (lastStage - allocCycle / ii + 1);
+      continue;
+    }
+    int64_t end = allocCycle + 1;
+    for (int64_t consumer : buffer.consumers)
+      end = std::max(end, cycles.at(consumer) + 1);
+    tmemLifetimes.push_back({allocCycle, end, buffer.tmemCols});
+  }
+  if (smemUsage > smemBudget)
+    return false;
+  for (const TmemLifetime &checkpoint : tmemLifetimes) {
+    int64_t activeColumns = 0;
+    for (const TmemLifetime &lifetime : tmemLifetimes)
+      if (lifetime.start <= checkpoint.start &&
+          checkpoint.start < lifetime.end)
+        activeColumns += lifetime.columns;
+    if (activeColumns > tmemColLimit)
+      return false;
+  }
+  return true;
+}
+
+static FailureOr<OracleSchedule>
+enumerateStageAwareSchedule(llvm::StringRef problemJson) {
+  auto problem = parseJsonObject(problemJson);
+  if (failed(problem))
+    return failure();
+  auto minII = problem->getInteger("min_ii");
+  auto maxII = problem->getInteger("max_ii");
+  auto smemBudget = problem->getInteger("smem_budget");
+  auto tmemColLimit = problem->getInteger("tmem_col_limit");
+  auto streamingVL = problem->getBoolean("streaming_vl");
+  auto *nodeValues = problem->getArray("nodes");
+  auto *edgeValues = problem->getArray("edges");
+  auto *bufferValues = problem->getArray("buffers");
+  if (!minII || !maxII || *minII <= 0 || *maxII < *minII || !nodeValues ||
+      !edgeValues || !bufferValues || !smemBudget || !tmemColLimit ||
+      !streamingVL || *smemBudget < 0 || *tmemColLimit < 0 ||
+      nodeValues->size() > 6)
+    return failure();
+
+  std::vector<OracleNode> nodes;
+  std::set<int64_t> nodeIds;
+  for (const llvm::json::Value &value : *nodeValues) {
+    auto *node = value.getAsObject();
+    auto id = node ? node->getInteger("id") : std::nullopt;
+    auto pipeline = node ? node->getString("pipeline") : std::nullopt;
+    auto duration = node ? node->getInteger("duration") : std::nullopt;
+    auto streaming = node ? node->getBoolean("streaming") : std::nullopt;
+    if (!id || !pipeline || !duration || !streaming ||
+        !nodeIds.insert(*id).second)
+      return failure();
+    nodes.push_back(OracleNode{*id, pipeline->str(), *duration, *streaming});
+  }
+  std::sort(nodes.begin(), nodes.end(),
+            [](const OracleNode &left, const OracleNode &right) {
+              return left.id < right.id;
+            });
+
+  std::vector<OracleEdge> edges;
+  int64_t latencySum = 0;
+  for (const llvm::json::Value &value : *edgeValues) {
+    auto *edge = value.getAsObject();
+    auto src = edge ? edge->getInteger("src") : std::nullopt;
+    auto dst = edge ? edge->getInteger("dst") : std::nullopt;
+    auto latency = edge ? edge->getInteger("latency") : std::nullopt;
+    auto distance = edge ? edge->getInteger("distance") : std::nullopt;
+    if (!src || !dst || !latency || !distance || !nodeIds.count(*src) ||
+        !nodeIds.count(*dst) || *latency < 0 || *distance < 0)
+      return failure();
+    edges.push_back(OracleEdge{*src, *dst, *latency, *distance});
+    latencySum += *latency;
+  }
+
+  std::vector<OracleBuffer> buffers;
+  std::set<int64_t> bufferIds;
+  for (const llvm::json::Value &value : *bufferValues) {
+    auto *buffer = value.getAsObject();
+    auto id = buffer ? buffer->getInteger("id") : std::nullopt;
+    auto alloc = buffer ? buffer->getInteger("alloc_node") : std::nullopt;
+    auto kind = buffer ? buffer->getString("kind") : std::nullopt;
+    auto sizeBytes = buffer ? buffer->getInteger("size_bytes") : std::nullopt;
+    auto tmemCols = buffer ? buffer->getInteger("tmem_cols") : std::nullopt;
+    auto *consumers = buffer ? buffer->getArray("consumers") : nullptr;
+    if (!id || !alloc || !kind || !sizeBytes || !tmemCols || !consumers ||
+        !bufferIds.insert(*id).second || !nodeIds.count(*alloc) ||
+        (*kind != "smem" && *kind != "tmem") || *sizeBytes < 0 ||
+        *tmemCols < 0)
+      return failure();
+    OracleBuffer oracleBuffer{*id, *alloc, kind->str(), *sizeBytes,
+                              *tmemCols, {}};
+    for (const llvm::json::Value &consumerValue : *consumers) {
+      auto consumer = consumerValue.getAsInteger();
+      if (!consumer || !nodeIds.count(*consumer))
+        return failure();
+      oracleBuffer.consumers.push_back(*consumer);
+    }
+    buffers.push_back(std::move(oracleBuffer));
+  }
+
+  std::optional<int64_t> canonicalRoot;
+  if (problem->get("canonical_root")) {
+    canonicalRoot = problem->getInteger("canonical_root");
+    if (!canonicalRoot || !nodeIds.count(*canonicalRoot))
+      return failure();
+  }
+
+  for (int64_t ii = *minII; ii <= *maxII; ++ii) {
+    int64_t horizon =
+        latencySum + ii * (static_cast<int64_t>(nodes.size()) + 1);
+    std::map<int64_t, int64_t> cycles;
+    std::optional<OracleSchedule> result;
+    std::function<void(size_t)> enumerate = [&](size_t index) {
+      if (result)
+        return;
+      if (index == nodes.size()) {
+        if (isOracleScheduleValid(ii, nodes, edges, buffers, *smemBudget,
+                                  *tmemColLimit, *streamingVL, cycles,
+                                  canonicalRoot))
+          result = OracleSchedule{ii, cycles};
+        return;
+      }
+      const OracleNode &node = nodes[index];
+      int64_t last = canonicalRoot && node.id == *canonicalRoot ? 0 : horizon;
+      for (int64_t cycle = 0; cycle <= last; ++cycle) {
+        cycles[node.id] = cycle;
+        enumerate(index + 1);
+        if (result)
+          return;
+      }
+      cycles.erase(node.id);
+    };
+    enumerate(0);
+    if (result)
+      return *result;
+  }
+  return failure();
+}
+
+constexpr llvm::StringLiteral kStageAwareOracleProblem = R"json(
+{
+  "version": "joint-solver-0.1",
+  "min_ii": 1,
+  "max_ii": 1,
+  "smem_budget": 0,
+  "tmem_col_limit": 0,
+  "time_limit_s": 5,
+  "streaming_vl": false,
+  "canonical_root": 0,
+  "nodes": [
+    {"id": 0, "pipeline": "TMA", "duration": 1, "streaming": false},
+    {"id": 1, "pipeline": "CUDA", "duration": 1, "streaming": false}
+  ],
+  "edges": [{"src": 0, "dst": 1, "latency": 2, "distance": 0}],
+  "buffers": []
+}
+)json";
+
+constexpr llvm::StringLiteral kBinaryOracleProblem = R"json(
+{
+  "version": "joint-solver-0.1",
+  "min_ii": 1,
+  "max_ii": 3,
+  "smem_budget": 2,
+  "tmem_col_limit": 1,
+  "time_limit_s": 5,
+  "streaming_vl": true,
+  "canonical_root": 0,
+  "nodes": [
+    {"id": 0, "pipeline": "TMA", "duration": 1, "streaming": true},
+    {"id": 1, "pipeline": "TC", "duration": 1, "streaming": false},
+    {"id": 2, "pipeline": "TC", "duration": 1, "streaming": false}
+  ],
+  "edges": [
+    {"src": 0, "dst": 1, "latency": 5, "distance": 0},
+    {"src": 1, "dst": 2, "latency": 2, "distance": 0}
+  ],
+  "buffers": [
+    {"id": 7, "alloc_node": 0, "kind": "smem", "size_bytes": 1,
+     "tmem_cols": 0, "consumers": [2]},
+    {"id": 9, "alloc_node": 1, "kind": "tmem", "size_bytes": 0,
+     "tmem_cols": 1, "consumers": [2]}
+  ]
+}
+)json";
 
 constexpr llvm::StringLiteral kFeasibleJointSolverProblem = R"json(
 {
@@ -385,6 +1394,34 @@ constexpr llvm::StringLiteral kJointSolverV2Problem = R"json(
 }
 )json";
 
+static llvm::json::Object makeV1DiagnosticProblem() {
+  return llvm::json::Object{
+      {"version", "joint-solver-0.1"},
+      {"min_ii", 1},
+      {"max_ii", 1},
+      {"smem_budget", 0},
+      {"tmem_col_limit", 0},
+      {"time_limit_s", 5},
+      {"streaming_vl", false},
+      {"canonical_root", 0},
+      {"nodes",
+       llvm::json::Array{llvm::json::Object{
+           {"id", 0},
+           {"pipeline", "NONE"},
+           {"duration", 0},
+           {"streaming", false},
+       }}},
+      {"edges", llvm::json::Array{}},
+      {"buffers", llvm::json::Array{}},
+  };
+}
+
+static void forceDifferentWarpGroups(llvm::json::Object &problem) {
+  llvm::json::Array conflicts;
+  conflicts.push_back(llvm::json::Array{10, 30});
+  problem["warp_group_conflicts"] = std::move(conflicts);
+}
+
 constexpr llvm::StringLiteral kJointCrossIssueObjectiveProblem = R"json(
 {
   "version": "joint-solver-0.2",
@@ -506,6 +1543,153 @@ TEST(Z3JointSolverTest, InfeasibleRangeReturnsProofStatus) {
   EXPECT_EQ(*backendStatus, "INFEASIBLE");
 }
 
+TEST(Z3JointSolverTest, V1UnsatDiagnosticsCoverNativeConstraintKinds) {
+  {
+    llvm::json::Object problem = makeV1DiagnosticProblem();
+    problem.getArray("edges")->push_back(llvm::json::Object{
+        {"src", 0}, {"dst", 0}, {"latency", 2}, {"distance", 1}});
+    expectUnsatDiagnostic(serializeJsonObject(std::move(problem)),
+                          {"dependence"}, {"dep:N0->N0:d1"});
+  }
+  {
+    llvm::json::Object problem = makeV1DiagnosticProblem();
+    auto *node = problem.getArray("nodes")->front().getAsObject();
+    ASSERT_NE(node, nullptr);
+    (*node)["pipeline"] = "TC";
+    (*node)["duration"] = 2;
+    expectUnsatDiagnostic(serializeJsonObject(std::move(problem)),
+                          {"resource"}, {"resource:TC:N0"}, "precheck");
+  }
+  {
+    llvm::json::Object problem = makeV1DiagnosticProblem();
+    problem["smem_budget"] = 1;
+    problem.getArray("buffers")->push_back(llvm::json::Object{
+        {"id", 7},
+        {"alloc_node", 0},
+        {"kind", "smem"},
+        {"size_bytes", 2},
+        {"tmem_cols", 0},
+        {"consumers", llvm::json::Array{0}},
+    });
+    expectUnsatDiagnostic(serializeJsonObject(std::move(problem)), {"smem"},
+                          {"smem:buffer7"});
+  }
+  {
+    llvm::json::Object problem = makeV1DiagnosticProblem();
+    problem["tmem_col_limit"] = 1;
+    problem.getArray("buffers")->push_back(llvm::json::Object{
+        {"id", 9},
+        {"alloc_node", 0},
+        {"kind", "tmem"},
+        {"size_bytes", 0},
+        {"tmem_cols", 2},
+        {"consumers", llvm::json::Array{0}},
+    });
+    expectUnsatDiagnostic(serializeJsonObject(std::move(problem)), {"tmem"},
+                          {"tmem:buffer9"});
+  }
+}
+
+TEST(Z3JointSolverV2Test, UnsatDiagnosticsCoverNativeConstraintKinds) {
+  for (llvm::StringRef mode : {llvm::StringRef("partition"),
+                               llvm::StringRef("joint")}) {
+    SCOPED_TRACE(mode.str());
+    auto problem = parseJsonObject(mode == "partition"
+                                       ? kPartitionObjectiveProblem
+                                       : kJointSolverV2Problem);
+    ASSERT_TRUE(succeeded(problem));
+    (*problem)["max_wgs"] = 1;
+    forceDifferentWarpGroups(*problem);
+    expectUnsatDiagnostic(serializeJsonObject(std::move(*problem)),
+                          {"warp-group"},
+                          {"warp-group:cluster10",
+                           "warp-group:cluster30"});
+  }
+  {
+    auto problem = parseJsonObject(kJointSolverV2Problem);
+    ASSERT_TRUE(succeeded(problem));
+    forceDifferentWarpGroups(*problem);
+    (*problem)["reg_budget"] = 1;
+    (*problem)["warp_footprint"] =
+        llvm::json::Array{0, 1, 1, 1, 1, 1, 1, 1, 1};
+    expectUnsatDiagnostic(serializeJsonObject(std::move(*problem)),
+                          {"register"},
+                          {"register:wg0", "register:wg1"});
+  }
+  {
+    auto problem = parseJsonObject(kJointSolverV2Problem);
+    ASSERT_TRUE(succeeded(problem));
+    auto *loweringTemplate =
+        problem->getArray("lowering_templates")->front().getAsObject();
+    ASSERT_NE(loweringTemplate, nullptr);
+    (*loweringTemplate)["relation"] = "always";
+    auto *event = loweringTemplate->getArray("events")->front().getAsObject();
+    ASSERT_NE(event, nullptr);
+    (*event)["issue_duration"] = 5;
+    expectUnsatDiagnostic(serializeJsonObject(std::move(*problem)),
+                          {"lowering"},
+                          {"lowering:template0:event7"});
+  }
+  {
+    auto problem = parseJsonObject(kPartitionObjectiveProblem);
+    ASSERT_TRUE(succeeded(problem));
+    (*problem)["mode"] = "joint";
+    (*problem)["smem_budget"] = 1;
+    forceDifferentWarpGroups(*problem);
+    auto *edge = problem->getArray("edges")->front().getAsObject();
+    ASSERT_NE(edge, nullptr);
+    (*edge)["chan_bytes"] = 2;
+    expectUnsatDiagnostic(serializeJsonObject(std::move(*problem)), {"smem"},
+                          {"smem:channel:N0->N1:r0"});
+  }
+  {
+    auto problem = parseJsonObject(kJointSolverV2Problem);
+    ASSERT_TRUE(succeeded(problem));
+    (*problem)["fixed_smem"] = 1;
+    expectUnsatDiagnostic(serializeJsonObject(std::move(*problem)), {"smem"},
+                          {"smem:fixed"});
+  }
+}
+
+TEST(Z3JointSolverTest, UnknownDiagnosticHasNoUnsatCore) {
+  llvm::json::Array nodes;
+  for (int64_t id = 0; id < 200; ++id) {
+    nodes.push_back(llvm::json::Object{
+        {"id", id},
+        {"pipeline", "TC"},
+        {"duration", 1},
+        {"streaming", false},
+    });
+  }
+  llvm::json::Object problem{
+      {"version", "joint-solver-0.1"},
+      {"min_ii", 200},
+      {"max_ii", 200},
+      {"smem_budget", 0},
+      {"tmem_col_limit", 0},
+      {"time_limit_s", 0.000001},
+      {"streaming_vl", false},
+      {"nodes", std::move(nodes)},
+      {"edges", llvm::json::Array{}},
+      {"buffers", llvm::json::Array{}},
+  };
+  auto output = runZ3JointSolver(serializeJsonObject(std::move(problem)));
+  ASSERT_TRUE(succeeded(output));
+  auto response = parseJsonObject(*output);
+  ASSERT_TRUE(succeeded(response));
+  EXPECT_EQ(response->getString("status"), "inconclusive");
+  EXPECT_EQ(response->getBoolean("proven_unsat"), false);
+  EXPECT_EQ(response->getString("backend_status"), "UNKNOWN");
+  EXPECT_EQ(response->get("unsat_core"), nullptr);
+  auto *diagnostic = response->getObject("diagnostic");
+  ASSERT_NE(diagnostic, nullptr);
+  EXPECT_EQ(diagnostic->getString("schema"),
+            "joint-solver-diagnostic-0.1");
+  EXPECT_EQ(diagnostic->getString("status"), "inconclusive");
+  EXPECT_EQ(diagnostic->getString("backendStatus"), "UNKNOWN");
+  EXPECT_EQ(diagnostic->get("core"), nullptr);
+}
+
 TEST(Z3JointSolverTest, InvalidSchemaReturnsFailure) {
   EXPECT_TRUE(
       failed(runZ3JointSolver(R"json({"version": "unsupported"})json")));
@@ -619,6 +1803,133 @@ TEST(Z3JointSolverV2Test, JointProblemReturnsPublicContract) {
   EXPECT_EQ(*eventCycle, -1);
   EXPECT_EQ(*eventWarpGroup, *firstWarpGroup);
   EXPECT_EQ(*streamOrder, 0);
+}
+
+TEST(Z3JointSolverV2Test, HopperGemmMatchesStableGolden) {
+  expectGemmGolden(kHopperGemmModel);
+}
+
+TEST(Z3JointSolverV2Test, BlackwellGemmMatchesStableGolden) {
+  expectGemmGolden(kBlackwellGemmModel);
+}
+
+TEST(Z3JointSolverV2Test, GemmValidationRejectsIllegalMutations) {
+  for (const GemmMachineModel *model :
+       {&kHopperGemmModel, &kBlackwellGemmModel}) {
+    SCOPED_TRACE(model->name);
+    std::string problemJson = serializeJsonObject(makeGemmProblem(*model));
+    auto output = runZ3JointSolver(problemJson);
+    ASSERT_TRUE(succeeded(output));
+    expectProductionValidity(problemJson, *output, true);
+
+    auto expectProblemMutationInvalid =
+        [&](llvm::StringRef name,
+            const std::function<void(llvm::json::Object &)> &mutate) {
+          SCOPED_TRACE(name.str());
+          llvm::json::Object problem = makeGemmProblem(*model);
+          mutate(problem);
+          expectProductionValidity(serializeJsonObject(std::move(problem)),
+                                   *output, false);
+        };
+
+    expectProblemMutationInvalid("cross-WG round trip", [](auto &problem) {
+      auto *edge = findEdge(problem, 2, 5);
+      ASSERT_NE(edge, nullptr);
+      (*edge)["rt"] = 100;
+    });
+    expectProblemMutationInvalid("fixed SMEM", [&](auto &problem) {
+      problem["fixed_smem"] = model->smemBudget + 1;
+    });
+    expectProblemMutationInvalid("channel SMEM", [](auto &problem) {
+      auto *edge = findEdge(problem, 2, 5);
+      ASSERT_NE(edge, nullptr);
+      (*edge)["chan_bytes"] = 9;
+    });
+    expectProblemMutationInvalid("register budget", [](auto &problem) {
+      problem["reg_budget"] = 55;
+    });
+    expectProblemMutationInvalid("dependency", [&](auto &problem) {
+      auto *edge = findEdge(problem, 5, 6);
+      ASSERT_NE(edge, nullptr);
+      (*edge)["latency"] = model->mmaLatency + 100;
+    });
+    if (model->accumulatorInTmem) {
+      expectProblemMutationInvalid("TMEM budget", [&](auto &problem) {
+        problem["tmem_budget_bytes"] = model->tmemBudget - 1;
+      });
+    }
+
+    auto expectSolutionMutationInvalid =
+        [&](llvm::StringRef name,
+            const std::function<void(llvm::json::Object &)> &mutate) {
+          SCOPED_TRACE(name.str());
+          auto solution = parseJsonObject(*output);
+          ASSERT_TRUE(succeeded(solution));
+          mutate(*solution);
+          expectProductionValidity(
+              problemJson, serializeJsonObject(std::move(*solution)), false);
+        };
+
+    expectSolutionMutationInvalid("fixed stage", [&](auto &solution) {
+      auto *cycles = solution.getObject("cycles");
+      ASSERT_NE(cycles, nullptr);
+      auto cycle = cycles->getInteger("6");
+      ASSERT_TRUE(cycle);
+      (*cycles)["6"] = *cycle + model->ii;
+    });
+    expectSolutionMutationInvalid("lowering placement", [](auto &solution) {
+      auto *plan = solution.getObject("lowering_plan");
+      auto *templates = plan ? plan->getArray("templates") : nullptr;
+      auto *loweringTemplate =
+          templates && !templates->empty()
+              ? templates->front().getAsObject()
+              : nullptr;
+      auto *events =
+          loweringTemplate ? loweringTemplate->getArray("events") : nullptr;
+      auto *event =
+          events && !events->empty() ? events->front().getAsObject() : nullptr;
+      ASSERT_NE(event, nullptr);
+      auto cycle = event->getInteger("cycle");
+      ASSERT_TRUE(cycle);
+      (*event)["cycle"] = *cycle + 1;
+    });
+  }
+}
+
+TEST(Z3JointSolverTest, StageAwareOracleFindsCycleBeyondModuloInterval) {
+  auto oracle = enumerateStageAwareSchedule(kStageAwareOracleProblem);
+  ASSERT_TRUE(succeeded(oracle));
+  EXPECT_EQ(oracle->ii, 1);
+  EXPECT_EQ(oracle->cycles, (std::map<int64_t, int64_t>{{0, 0}, {1, 2}}));
+  EXPECT_GT(oracle->cycles.at(1), oracle->ii - 1);
+
+  auto output = runZ3JointSolver(kStageAwareOracleProblem);
+  ASSERT_TRUE(succeeded(output));
+  expectProductionValidity(kStageAwareOracleProblem, *output, true);
+  auto response = parseJsonObject(*output);
+  ASSERT_TRUE(succeeded(response));
+  auto *cycles = response->getObject("cycles");
+  ASSERT_NE(cycles, nullptr);
+  EXPECT_EQ(cycles->getInteger("0"), 0);
+  EXPECT_EQ(cycles->getInteger("1"), 2);
+}
+
+TEST(Z3JointSolverTest, BinarySearchMatchesBufferAndStreamingOracle) {
+  auto oracle = enumerateStageAwareSchedule(kBinaryOracleProblem);
+  ASSERT_TRUE(succeeded(oracle));
+  EXPECT_EQ(oracle->ii, 2);
+  EXPECT_EQ(oracle->cycles,
+            (std::map<int64_t, int64_t>{{0, 0}, {1, 0}, {2, 3}}));
+
+  auto output = runZ3JointSolver(kBinaryOracleProblem);
+  ASSERT_TRUE(succeeded(output));
+  expectProductionValidity(kBinaryOracleProblem, *output, true);
+  auto response = parseJsonObject(*output);
+  ASSERT_TRUE(succeeded(response));
+  EXPECT_EQ(response->getInteger("ii"), oracle->ii);
+  auto *depths = response->getObject("buffer_depths");
+  ASSERT_NE(depths, nullptr);
+  EXPECT_EQ(depths->getInteger("7"), 2);
 }
 
 TEST(Z3JointSolverV2Test, LoweringEventKindsMatchSchema) {


### PR DESCRIPTION
Summary:

Apply verified native joint-solver cycle and warp-group assignments to the schedule graph, recompute buffer depths and cross-group synchronization, and validate final memory use. Extend the sched2tlx schema and lowering for solver-produced schedules while retaining the lowering plan as diagnostic shadow metadata.

The schedule backend is an argument now, not process state. `runModuloScheduling` takes the backend name, `runScheduleDriver` resolves `ScheduleDriverOptions::forceScheduleAlgo` once and threads it down through `DataDependenceGraph::build` into nested super-node schedules, and `ScopedScheduleAlgoOverride` and its function-local static slot are deleted. `getActiveScheduleAlgo(forced)` stays as a pure function of its argument and `TRITON_USE_MODULO_SCHEDULE`, so dump and diagnostic labels still report what actually ran.

That slot was reachable from two concurrent compiles in one process: `triton.AsyncCompileMode` accepts any `Executor`, and the `pass_manager.run` binding releases the GIL for the whole pipeline, so two `triton.compile()` calls can sit in two pass pipelines at once. One run could then clear another's backend mid-run, or read a backend it never asked for. Both present as scheduling that varies run to run. The no-nesting guard was an `assert`, so it was also absent under `NDEBUG`. With the parameter, nesting is no longer expressible. A namespace-scope audit of the ModuloScheduling directory leaves `JointSolverCache` as the only remaining process-global on this path -- a mutex-guarded memo keyed by the canonicalized problem, now commented as such.

The `modulo-schedule.mlir` JOINT golden is also refreshed. It passes on the parent D114808812 and failed here: once the solver's warp-group assignment is applied the epilogue `tmem_load` gets a group of its own, so the loop has five partitions rather than four.

Review order: `ModuloReservationTable.h` for the API, then `runScheduleDriver` in `ModuloSchedulePass.cpp` for where the backend is resolved, then the mechanical threading through the rest of that file and `DataDependenceGraph`, then the tests and the golden.

Authored with Codex and Claude.

Reviewed By: wlei-llvm

Differential Revision: D114779397
