### PR TITLE
[CI] Skip existing LLVM builds

### DIFF
--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -46,28 +46,26 @@ jobs:
       with:
         path: llvm-build
 
-    - name: Install System Prerequisites (AlmaLinux)
-      if: matrix.config.target-os == 'almalinux'
-      run: |
-        rpm --import https://packages.microsoft.com/keys/microsoft.asc
-        dnf install --assumeyes https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
-        dnf install --assumeyes azure-cli llvm-toolset-20.1.8 python38-pip python38-devel git jq tar gzip
-        alternatives --set python3 /usr/bin/python3.8
-        echo "extra_cmake_flags=-DCMAKE_ASM_COMPILER=clang -DCMAKE_CXX_FLAGS=-Wno-everything -DPython3_EXECUTABLE=/usr/bin/python3.8 -DPython_EXECUTABLE=/usr/bin/python3.8" >> "$GITHUB_ENV"
-
     - name: Fetch LLVM Build Metadata
       shell: bash
       run: |
-        LLVM_COMMIT_HASH="$(jq -r '.llvm_hash' llvm-build/cmake/llvm-build-info.json)"
+        LLVM_INFO="llvm-build/cmake/llvm-build-info.json"
+        LLVM_COMMIT_HASH="$(sed -n 's/.*"llvm_hash"[[:space:]]*:[[:space:]]*"\([0-9a-f]*\)".*/\1/p' "${LLVM_INFO}")"
         echo "Found LLVM commit hash: ${LLVM_COMMIT_HASH}"
         echo "llvm_commit_hash=${LLVM_COMMIT_HASH}" >> ${GITHUB_ENV}
 
-        LLVM_REPOSITORY="$(jq -r '.repository // "llvm/llvm-project"' llvm-build/cmake/llvm-build-info.json)"
+        LLVM_REPOSITORY="$(sed -n 's/.*"repository"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${LLVM_INFO}")"
+        LLVM_REPOSITORY="${LLVM_REPOSITORY:-llvm/llvm-project}"
         echo "Found LLVM repository: ${LLVM_REPOSITORY}"
         echo "llvm_repository=${LLVM_REPOSITORY}" >> ${GITHUB_ENV}
 
-        LLVM_BUILD_NUMBER="$(jq -r '.build_number' llvm-build/cmake/llvm-build-info.json)"
+        LLVM_BUILD_NUMBER="$(sed -n 's/.*"build_number"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' "${LLVM_INFO}")"
         echo "Found LLVM build number: ${LLVM_BUILD_NUMBER}"
+
+        if [[ ! "${LLVM_COMMIT_HASH}" =~ ^[0-9a-f]{40}$ || ! "${LLVM_BUILD_NUMBER}" =~ ^[0-9]+$ ]]; then
+          echo "Invalid LLVM build metadata in ${LLVM_INFO}" >&2
+          exit 1
+        fi
 
         SHORT_LLVM_COMMIT_HASH="${LLVM_COMMIT_HASH:0:8}"
         echo "Short LLVM commit hash: ${SHORT_LLVM_COMMIT_HASH}"
@@ -77,18 +75,39 @@ jobs:
         echo "LLVM installation directory name: ${INSTALL_DIR}"
         echo "llvm_install_dir=${INSTALL_DIR}" >> ${GITHUB_ENV}
 
-    - name: Check LLVM Build Does Not Exist
-      if: github.event_name != 'pull_request'
+    - name: Check for Existing LLVM Build
+      id: llvm-build
       shell: bash
       run: |
+        # The public artifact store is shared across PR refs, unlike GitHub Actions caches.
         URL="https://oaitriton.blob.core.windows.net/public/llvm-builds/${{ env.llvm_install_dir }}.tar.gz"
         HTTP_STATUS="$(curl --head --silent --show-error --output /dev/null --write-out "%{http_code}" "${URL}")"
-        if [ "${HTTP_STATUS}" != "404" ]; then
-          echo "LLVM build already exists or could not be checked: ${URL} returned ${HTTP_STATUS}"
-          exit 1
-        fi
+        case "${HTTP_STATUS}" in
+          200)
+            echo "LLVM build already exists: ${URL}"
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+            ;;
+          404)
+            echo "LLVM build does not exist: ${URL}"
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+            ;;
+          *)
+            echo "Could not check LLVM build: ${URL} returned ${HTTP_STATUS}" >&2
+            exit 1
+            ;;
+        esac
+
+    - name: Install System Prerequisites (AlmaLinux)
+      if: ${{ steps.llvm-build.outputs.exists != 'true' && matrix.config.target-os == 'almalinux' }}
+      run: |
+        rpm --import https://packages.microsoft.com/keys/microsoft.asc
+        dnf install --assumeyes https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
+        dnf install --assumeyes azure-cli llvm-toolset-20.1.8 python38-pip python38-devel git tar gzip
+        alternatives --set python3 /usr/bin/python3.8
+        echo "extra_cmake_flags=-DCMAKE_ASM_COMPILER=clang -DCMAKE_CXX_FLAGS=-Wno-everything -DPython3_EXECUTABLE=/usr/bin/python3.8 -DPython_EXECUTABLE=/usr/bin/python3.8" >> "$GITHUB_ENV"
 
     - name: Checkout LLVM
+      if: steps.llvm-build.outputs.exists != 'true'
       uses: actions/checkout@v6
       with:
         repository: ${{ env.llvm_repository }}
@@ -96,18 +115,19 @@ jobs:
         ref: ${{ env.llvm_commit_hash }}
 
     - name: Set up Python
-      if: matrix.config.target-os != 'almalinux'
+      if: ${{ steps.llvm-build.outputs.exists != 'true' && matrix.config.target-os != 'almalinux' }}
       uses: actions/setup-python@v6
       with:
         python-version: 3.11
 
     - name: Set up MSVC
-      if: matrix.config.arch == 'x64' && (matrix.config.target-os == 'windows')
+      if: ${{ steps.llvm-build.outputs.exists != 'true' && matrix.config.arch == 'x64' && matrix.config.target-os == 'windows' }}
       uses: ilammy/msvc-dev-cmd@v1.13.0
       with:
         arch: amd64
 
     - name: Install Prerequisites
+      if: steps.llvm-build.outputs.exists != 'true'
       shell: bash
       run: |
         python3 -m pip install cmake ninja sccache
@@ -115,6 +135,7 @@ jobs:
         rm -rf ${{ env.SCCACHE_DIR }}/*
 
     - name: Enable Cache
+      if: steps.llvm-build.outputs.exists != 'true'
       uses: actions/cache@v4
       with:
         path: ${{ env.SCCACHE_DIR }}
@@ -122,7 +143,7 @@ jobs:
         restore-keys: ${{ matrix.config.target-os }}-${{ matrix.config.arch }}-
 
     - name: Free disk space on Ubuntu
-      if: matrix.config.arch == 'x64' && matrix.config.target-os == 'ubuntu'
+      if: ${{ steps.llvm-build.outputs.exists != 'true' && matrix.config.arch == 'x64' && matrix.config.target-os == 'ubuntu' }}
       run: |
         df -h
         echo "Removing large packages"
@@ -133,7 +154,7 @@ jobs:
         df -h
 
     - name: Configure, Build, Test, and Install LLVM (Ubuntu, CentOS, and macOS)
-      if: matrix.config.target-os == 'ubuntu' || matrix.config.target-os == 'almalinux' || matrix.config.target-os == 'macos'
+      if: ${{ steps.llvm-build.outputs.exists != 'true' && (matrix.config.target-os == 'ubuntu' || matrix.config.target-os == 'almalinux' || matrix.config.target-os == 'macos') }}
       run: >
         cmake -GNinja -Bllvm-project/build
         -DCMAKE_BUILD_TYPE=Release
@@ -158,7 +179,7 @@ jobs:
         tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
 
     - name: Configure, Build, Test, and Install LLVM (Windows)
-      if: matrix.config.arch == 'x64' && (matrix.config.target-os == 'windows')
+      if: ${{ steps.llvm-build.outputs.exists != 'true' && matrix.config.arch == 'x64' && matrix.config.target-os == 'windows' }}
       run: >
         cmake -GNinja -Bllvm-project/build
         -DCMAKE_BUILD_TYPE=Release
@@ -182,6 +203,7 @@ jobs:
 
 
     - name: Upload Build Artifacts
+      if: steps.llvm-build.outputs.exists != 'true'
       uses: actions/upload-artifact@v7
       with:
         name: llvm-${{ matrix.config.target-os }}-${{ matrix.config.arch }}
@@ -189,7 +211,8 @@ jobs:
           ${{ github.workspace }}/llvm-*-${{ matrix.config.target-os }}-${{ matrix.config.arch }}-*.tar.gz
 
     - name: Azure login
-      if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'main' }}
+      id: azure-login
+      if: ${{ steps.llvm-build.outputs.exists != 'true' && github.repository == 'triton-lang/triton' && github.ref_name == 'main' }}
       uses: azure/login@v2
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID_LLVM }}
@@ -197,7 +220,7 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_LLVM }}
 
     - name: Upload LLVM Artifacts to Azure
-      if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'main' }}
+      if: ${{ steps.llvm-build.outputs.exists != 'true' && github.repository == 'triton-lang/triton' && github.ref_name == 'main' }}
       shell: bash -el {0}
       run: |
         sha256sum "${{ env.llvm_install_dir }}.tar.gz"
@@ -208,11 +231,12 @@ jobs:
         echo "Blob URL: ${URL}"
 
     - name: Azure Logout
-      if: ${{ (github.repository == 'triton-lang/triton') && github.ref_name == 'main' }}
+      if: ${{ always() && steps.azure-login.outcome == 'success' }}
       run: |
         az logout
         az cache purge
         az account clear
 
     - name: Dump Sccache Statistics
+      if: steps.llvm-build.outputs.exists != 'true'
       run: sccache --show-stats


### PR DESCRIPTION
Skip unnecessary LLVM builds from running in github actions when the LLVM hash hasn't changed. This seems to be a major source of CI cost.

Authored with Codex.