### PR TITLE
[triton][tlx] Allow scaled MMA N tiles through 256

### DIFF
--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -1349,8 +1349,9 @@ def test_async_dot_scaled_2cta(device):
 
 @pytest.mark.parametrize("A_DATA_TYPE", ["e5m2", "e4m3"])
 @pytest.mark.parametrize("B_DATA_TYPE", ["e5m2", "e4m3"])
+@pytest.mark.parametrize("N", [128, 256])
 @pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
-def test_async_dot_scaled(A_DATA_TYPE, B_DATA_TYPE, device):
+def test_async_dot_scaled(A_DATA_TYPE, B_DATA_TYPE, N, device):
     """
     Test D = (A * A_scale)  * (B * B_scale) with mxfp8 format for both A and B.
 

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -472,11 +472,9 @@ def async_dot_scaled(
     # Blackwell block-scaled tcgen05.mma (PTX ISA 9.3, Table 42): the per-CTA
     # instruction shape is fixed to M=128 with N a multiple of 8 in [8, 256]. K is
     # only lower-bounded because the lowering splits the K blocks across instructions.
-    # Gap: the ISA allows N up to 256, but the current lowering rejects blockN==256 for
-    # the scaled op (see InsertTmemAref.cpp), so we cap N at 128 until that is fixed.
     assert M == 128, f"M must be 128 for the scaled MMA, but got {M}"
     assert K >= 16, "K must be at least 16"
-    assert 8 <= N <= 128 and N % 8 == 0, f"N must be a multiple of 8 in [8, 128], but got {N}"
+    assert 8 <= N <= 256 and N % 8 == 0, f"N must be a multiple of 8 in [8, 256], but got {N}"
 
     assert isinstance(A, tlx.buffered_tensor), "input must be a buffered tensor"
     assert isinstance(B, tlx.buffered_tensor), "input must be a buffered tensor"


### PR DESCRIPTION
Summary: Align async_dot_scaled validation with the Blackwell PTX tcgen05.mma block-scaled instruction range by accepting N tiles that are multiples of 8 through 256. Remove the stale comment claiming the lowering rejects N=256 and extend the scaled-MMA unit test to cover N=128 and N=256 across the existing FP8 format combinations.

Differential Revision: D115454196


