### PR TITLE
[Triton][NPOT] Add exact partitioned mixed-radix maps

### DIFF
--- a/include/triton/Tools/RadixLayout.h
+++ b/include/triton/Tools/RadixLayout.h
@@ -1,0 +1,66 @@
+#ifndef TRITON_TOOLS_RADIXLAYOUT_H
+#define TRITON_TOOLS_RADIXLAYOUT_H
+
+#include <cstdint>
+#include <optional>
+
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::triton {
+
+// A mixed-radix coordinate map whose image is selected by a partition index.
+class PartitionedRadixMap {
+public:
+  enum class Mode { Distribute, Replicate };
+
+  struct Partition {
+    int32_t span;
+    unsigned bitOffset;
+    unsigned bitCount;
+
+    int32_t getStride() const;
+  };
+
+  struct Dimension {
+    int32_t extent;
+    std::optional<Partition> partition;
+  };
+
+  static FailureOr<PartitionedRadixMap>
+  create(llvm::ArrayRef<Dimension> dimensions,
+         llvm::ArrayRef<unsigned> dimensionOrder, unsigned partitionCount,
+         Mode mode);
+
+  llvm::ArrayRef<Dimension> getDimensions() const { return dimensions; }
+  llvm::ArrayRef<unsigned> getDimensionOrder() const { return dimensionOrder; }
+  unsigned getPartitionCount() const { return partitionCount; }
+  Mode getMode() const { return mode; }
+  uint32_t getConstrainedPartitionMask() const {
+    return constrainedPartitionMask;
+  }
+  uint32_t getFreePartitionMask() const { return freePartitionMask; }
+  unsigned getFreePartitionCount() const { return freePartitionCount; }
+
+  FailureOr<uint64_t> getLocalOrdinalCount(unsigned partition) const;
+  // These are mutual inverses on a partition's image.
+  FailureOr<llvm::SmallVector<int32_t>> delinearize(unsigned partition,
+                                                    uint64_t ordinal) const;
+  FailureOr<uint64_t> linearize(unsigned partition,
+                                llvm::ArrayRef<int32_t> coordinates) const;
+  FailureOr<PartitionedRadixMap> removeUnitDimension(unsigned dimension) const;
+
+private:
+  llvm::SmallVector<Dimension> dimensions;
+  llvm::SmallVector<unsigned> dimensionOrder;
+  unsigned partitionCount = 1;
+  Mode mode = Mode::Replicate;
+  uint32_t constrainedPartitionMask = 0;
+  uint32_t freePartitionMask = 0;
+  unsigned freePartitionCount = 1;
+};
+
+} // namespace mlir::triton
+
+#endif // TRITON_TOOLS_RADIXLAYOUT_H

--- a/lib/Tools/CMakeLists.txt
+++ b/lib/Tools/CMakeLists.txt
@@ -4,6 +4,7 @@ add_triton_library(TritonTools
   LinearLayout.cpp
   ModularArithmetic.cpp
   PluginUtils.cpp
+  RadixLayout.cpp
 
   DEPENDS
 

--- a/lib/Tools/RadixLayout.cpp
+++ b/lib/Tools/RadixLayout.cpp
@@ -1,0 +1,264 @@
+#include "triton/Tools/RadixLayout.h"
+
+#include <limits>
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/MathExtras.h"
+
+namespace mlir::triton {
+namespace {
+
+static FailureOr<uint64_t> checkedProduct(llvm::ArrayRef<uint64_t> values) {
+  uint64_t product = 1;
+  for (uint64_t value : values) {
+    if (value != 0 && product > std::numeric_limits<uint64_t>::max() / value)
+      return failure();
+    product *= value;
+  }
+  return product;
+}
+
+static unsigned compressBits(unsigned value, uint32_t mask) {
+  unsigned compressed = 0;
+  unsigned outputBit = 0;
+  for (unsigned inputBit = 0; mask != 0; ++inputBit) {
+    if (!(mask & (uint32_t{1} << inputBit)))
+      continue;
+    compressed |= ((value >> inputBit) & 1u) << outputBit++;
+    mask &= ~(uint32_t{1} << inputBit);
+  }
+  return compressed;
+}
+
+static unsigned getPartitionDigit(const PartitionedRadixMap::Partition &part,
+                                  unsigned partition) {
+  uint32_t mask = (uint32_t{1} << part.bitCount) - 1;
+  return (partition >> part.bitOffset) & mask;
+}
+
+static FailureOr<uint64_t>
+getDimensionOrdinalCount(const PartitionedRadixMap::Dimension &dim,
+                         unsigned partition) {
+  if (!dim.partition)
+    return static_cast<uint64_t>(dim.extent);
+  const auto &part = *dim.partition;
+  uint64_t base = uint64_t(getPartitionDigit(part, partition)) * part.span;
+  if (base >= static_cast<uint64_t>(dim.extent))
+    return uint64_t{0};
+  uint64_t remaining = dim.extent - base;
+  uint64_t stride = part.getStride();
+  return (remaining / stride) * part.span +
+         std::min<uint64_t>(remaining % stride, part.span);
+}
+
+static FailureOr<llvm::SmallVector<uint64_t>> getDimensionOrdinalCounts(
+    llvm::ArrayRef<PartitionedRadixMap::Dimension> dimensions,
+    unsigned partition) {
+  llvm::SmallVector<uint64_t> counts;
+  counts.reserve(dimensions.size());
+  for (const auto &dim : dimensions) {
+    auto count = getDimensionOrdinalCount(dim, partition);
+    if (failed(count))
+      return failure();
+    counts.push_back(*count);
+  }
+  return counts;
+}
+
+struct OrdinalRange {
+  uint64_t base;
+  uint64_t count;
+};
+
+static OrdinalRange getOrdinalRange(uint64_t total, unsigned partition,
+                                    uint32_t freePartitionMask,
+                                    unsigned freePartitionCount) {
+  uint64_t freeOrdinal = compressBits(partition, freePartitionMask);
+  uint64_t quotient = total / freePartitionCount;
+  uint64_t remainder = total % freePartitionCount;
+  return {freeOrdinal * quotient + std::min(freeOrdinal, remainder),
+          quotient + static_cast<uint64_t>(freeOrdinal < remainder)};
+}
+
+} // namespace
+
+int32_t PartitionedRadixMap::Partition::getStride() const {
+  return static_cast<int32_t>(uint64_t(span) << bitCount);
+}
+
+FailureOr<PartitionedRadixMap>
+PartitionedRadixMap::create(llvm::ArrayRef<Dimension> dimensions,
+                            llvm::ArrayRef<unsigned> dimensionOrder,
+                            unsigned partitionCount, Mode mode) {
+  if (!llvm::isPowerOf2_32(partitionCount))
+    return failure();
+  if (dimensionOrder.size() != dimensions.size())
+    return failure();
+  llvm::SmallVector<bool> seenDimensions(dimensions.size());
+  for (unsigned dim : dimensionOrder) {
+    if (dim >= dimensions.size() || seenDimensions[dim])
+      return failure();
+    seenDimensions[dim] = true;
+  }
+  unsigned partitionBits = llvm::Log2_32(partitionCount);
+  uint32_t constrainedMask = 0;
+  llvm::SmallVector<uint64_t> extents;
+  extents.reserve(dimensions.size());
+  for (const Dimension &dim : dimensions) {
+    if (dim.extent <= 0)
+      return failure();
+    extents.push_back(dim.extent);
+    if (!dim.partition)
+      continue;
+    const Partition &part = *dim.partition;
+    if (mode == Mode::Replicate || part.span <= 0 || part.span > dim.extent ||
+        part.bitCount == 0 || part.bitOffset > partitionBits ||
+        part.bitCount > partitionBits - part.bitOffset)
+      return failure();
+    uint64_t stride = uint64_t(part.span) << part.bitCount;
+    if (stride > std::numeric_limits<int32_t>::max())
+      return failure();
+    uint32_t mask = ((uint32_t{1} << part.bitCount) - 1) << part.bitOffset;
+    if (constrainedMask & mask)
+      return failure();
+    constrainedMask |= mask;
+  }
+  auto totalElements = checkedProduct(extents);
+  if (failed(totalElements) ||
+      *totalElements > std::numeric_limits<int32_t>::max())
+    return failure();
+
+  PartitionedRadixMap result;
+  result.dimensions.assign(dimensions.begin(), dimensions.end());
+  result.dimensionOrder.assign(dimensionOrder.begin(), dimensionOrder.end());
+  result.partitionCount = partitionCount;
+  result.mode = mode;
+  result.constrainedPartitionMask = constrainedMask;
+  uint32_t partitionMask = partitionCount - 1;
+  result.freePartitionMask =
+      mode == Mode::Replicate ? 0 : partitionMask & ~constrainedMask;
+  result.freePartitionCount = uint32_t{1}
+                              << llvm::popcount(result.freePartitionMask);
+  return result;
+}
+
+FailureOr<uint64_t>
+PartitionedRadixMap::getLocalOrdinalCount(unsigned partition) const {
+  if (partition >= partitionCount)
+    return failure();
+  auto counts = getDimensionOrdinalCounts(dimensions, partition);
+  if (failed(counts))
+    return failure();
+  auto total = checkedProduct(*counts);
+  if (failed(total))
+    return failure();
+  return getOrdinalRange(*total, partition, freePartitionMask,
+                         freePartitionCount)
+      .count;
+}
+
+FailureOr<llvm::SmallVector<int32_t>>
+PartitionedRadixMap::delinearize(unsigned partition,
+                                 uint64_t localOrdinal) const {
+  if (partition >= partitionCount)
+    return failure();
+  auto counts = getDimensionOrdinalCounts(dimensions, partition);
+  if (failed(counts))
+    return failure();
+  auto total = checkedProduct(*counts);
+  if (failed(total))
+    return failure();
+  OrdinalRange range =
+      getOrdinalRange(*total, partition, freePartitionMask, freePartitionCount);
+  if (localOrdinal >= range.count)
+    return failure();
+  uint64_t ordinal = range.base + localOrdinal;
+
+  llvm::SmallVector<int32_t> coordinates(dimensions.size());
+  for (unsigned logicalDim : dimensionOrder) {
+    const Dimension &dim = dimensions[logicalDim];
+    uint64_t count = (*counts)[logicalDim];
+    uint64_t local = ordinal % count;
+    ordinal /= count;
+    uint64_t coordinate = local;
+    if (dim.partition) {
+      const Partition &part = *dim.partition;
+      uint64_t base = uint64_t(getPartitionDigit(part, partition)) * part.span;
+      coordinate =
+          base + (local / part.span) * part.getStride() + local % part.span;
+    }
+    if (coordinate >= static_cast<uint64_t>(dim.extent))
+      return failure();
+    coordinates[logicalDim] = coordinate;
+  }
+  return coordinates;
+}
+
+FailureOr<uint64_t>
+PartitionedRadixMap::linearize(unsigned partition,
+                               llvm::ArrayRef<int32_t> coordinates) const {
+  if (partition >= partitionCount || coordinates.size() != dimensions.size())
+    return failure();
+  auto counts = getDimensionOrdinalCounts(dimensions, partition);
+  if (failed(counts))
+    return failure();
+
+  uint64_t ordinal = 0;
+  uint64_t multiplier = 1;
+  for (unsigned logicalDim : dimensionOrder) {
+    int32_t coordinate = coordinates[logicalDim];
+    const Dimension &dim = dimensions[logicalDim];
+    uint64_t count = (*counts)[logicalDim];
+    if (coordinate < 0 || coordinate >= dim.extent)
+      return failure();
+    uint64_t local = coordinate;
+    if (dim.partition) {
+      const Partition &part = *dim.partition;
+      uint64_t base = uint64_t(getPartitionDigit(part, partition)) * part.span;
+      if (static_cast<uint64_t>(coordinate) < base)
+        return failure();
+      uint64_t delta = coordinate - base;
+      uint64_t inner = delta % part.getStride();
+      if (inner >= static_cast<uint64_t>(part.span))
+        return failure();
+      local = (delta / part.getStride()) * part.span + inner;
+    }
+    if (local >= count ||
+        local > (std::numeric_limits<uint64_t>::max() - ordinal) / multiplier)
+      return failure();
+    ordinal += local * multiplier;
+    if (count != 0 && multiplier > std::numeric_limits<uint64_t>::max() / count)
+      return failure();
+    multiplier *= count;
+  }
+
+  auto total = checkedProduct(*counts);
+  if (failed(total))
+    return failure();
+  OrdinalRange range =
+      getOrdinalRange(*total, partition, freePartitionMask, freePartitionCount);
+  if (ordinal < range.base || ordinal - range.base >= range.count)
+    return failure();
+  return ordinal - range.base;
+}
+
+FailureOr<PartitionedRadixMap>
+PartitionedRadixMap::removeUnitDimension(unsigned dimension) const {
+  if (dimension >= dimensions.size() || dimensions[dimension].extent != 1)
+    return failure();
+
+  llvm::SmallVector<Dimension> restrictedDimensions(dimensions.begin(),
+                                                    dimensions.end());
+  restrictedDimensions.erase(restrictedDimensions.begin() + dimension);
+  llvm::SmallVector<unsigned> restrictedOrder;
+  restrictedOrder.reserve(dimensionOrder.size() - 1);
+  for (unsigned orderedDimension : dimensionOrder) {
+    if (orderedDimension == dimension)
+      continue;
+    restrictedOrder.push_back(
+        orderedDimension > dimension ? orderedDimension - 1 : orderedDimension);
+  }
+  return create(restrictedDimensions, restrictedOrder, partitionCount, mode);
+}
+
+} // namespace mlir::triton

--- a/unittest/Tools/CMakeLists.txt
+++ b/unittest/Tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_triton_ut(
 	NAME LinearLayout
-	SRCS LayoutUtilsTest.cpp LinearLayoutTest.cpp ModularArithmeticTest.cpp
+	SRCS LayoutUtilsTest.cpp LinearLayoutTest.cpp ModularArithmeticTest.cpp RadixLayoutTest.cpp
 	LIBS TritonTools
 )

--- a/unittest/Tools/RadixLayoutTest.cpp
+++ b/unittest/Tools/RadixLayoutTest.cpp
@@ -1,0 +1,215 @@
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "triton/Tools/RadixLayout.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace mlir::triton {
+namespace {
+
+using Dimension = PartitionedRadixMap::Dimension;
+using Mode = PartitionedRadixMap::Mode;
+using Partition = PartitionedRadixMap::Partition;
+
+TEST(PartitionedRadixMapTest, MixedRadixOrderAndRoundTrip) {
+  auto map = PartitionedRadixMap::create({{3, {}}, {5, {}}}, {0, 1}, 1,
+                                         Mode::Replicate);
+  ASSERT_TRUE(succeeded(map));
+  EXPECT_EQ(*map->getLocalOrdinalCount(0), 15);
+  EXPECT_EQ(*map->delinearize(0, 0), llvm::SmallVector<int32_t>({0, 0}));
+  EXPECT_EQ(*map->delinearize(0, 1), llvm::SmallVector<int32_t>({1, 0}));
+  EXPECT_EQ(*map->delinearize(0, 3), llvm::SmallVector<int32_t>({0, 1}));
+  EXPECT_EQ(*map->delinearize(0, 14), llvm::SmallVector<int32_t>({2, 4}));
+  for (uint64_t ordinal = 0; ordinal < 15; ++ordinal) {
+    auto coordinates = map->delinearize(0, ordinal);
+    ASSERT_TRUE(succeeded(coordinates));
+    EXPECT_EQ(*map->linearize(0, *coordinates), ordinal);
+  }
+
+  auto transposed = PartitionedRadixMap::create({{3, {}}, {5, {}}}, {1, 0}, 1,
+                                                Mode::Replicate);
+  ASSERT_TRUE(succeeded(transposed));
+  EXPECT_EQ(*transposed->delinearize(0, 1), llvm::SmallVector<int32_t>({0, 1}));
+  EXPECT_EQ(*transposed->linearize(0, {2, 4}), 14);
+}
+
+TEST(PartitionedRadixMapTest, DistributedImagesCoverExactlyOnce) {
+  auto map = PartitionedRadixMap::create({{3, {}}, {48, {}}}, {0, 1}, 4,
+                                         Mode::Distribute);
+  ASSERT_TRUE(succeeded(map));
+  EXPECT_EQ(map->getConstrainedPartitionMask(), 0);
+  EXPECT_EQ(map->getFreePartitionMask(), 3);
+  EXPECT_EQ(map->getFreePartitionCount(), 4);
+  llvm::SmallVector<unsigned> coverage(3 * 48);
+  for (unsigned partition = 0; partition < 4; ++partition) {
+    EXPECT_EQ(*map->getLocalOrdinalCount(partition), 36);
+    for (uint64_t ordinal = 0; ordinal < 36; ++ordinal) {
+      auto coordinates = map->delinearize(partition, ordinal);
+      ASSERT_TRUE(succeeded(coordinates));
+      ++coverage[(*coordinates)[0] + 3 * (*coordinates)[1]];
+      EXPECT_EQ(*map->linearize(partition, *coordinates), ordinal);
+    }
+  }
+  EXPECT_TRUE(
+      llvm::all_of(coverage, [](unsigned count) { return count == 1; }));
+}
+
+TEST(PartitionedRadixMapTest, ReplicatedPartitionsHaveEqualImages) {
+  auto map = PartitionedRadixMap::create({{3, {}}, {5, {}}}, {0, 1}, 4,
+                                         Mode::Replicate);
+  ASSERT_TRUE(succeeded(map));
+  for (unsigned partition = 0; partition < 4; ++partition) {
+    EXPECT_EQ(*map->getLocalOrdinalCount(partition), 15);
+    for (uint64_t ordinal = 0; ordinal < 15; ++ordinal)
+      EXPECT_EQ(*map->delinearize(partition, ordinal),
+                *map->delinearize(0, ordinal));
+  }
+}
+
+TEST(PartitionedRadixMapTest, ConstrainedAndFreePartitionBits) {
+  llvm::SmallVector<Dimension> dimensions = {{16, Partition{2, 0, 1}},
+                                             {12, Partition{3, 2, 1}}};
+  auto map =
+      PartitionedRadixMap::create(dimensions, {0, 1}, 8, Mode::Distribute);
+  ASSERT_TRUE(succeeded(map));
+  EXPECT_EQ(map->getConstrainedPartitionMask(), 5);
+  EXPECT_EQ(map->getFreePartitionMask(), 2);
+  EXPECT_EQ(map->getFreePartitionCount(), 2);
+  llvm::SmallVector<unsigned> coverage(16 * 12);
+  for (unsigned partition = 0; partition < 8; ++partition) {
+    auto count = map->getLocalOrdinalCount(partition);
+    ASSERT_TRUE(succeeded(count));
+    for (uint64_t ordinal = 0; ordinal < *count; ++ordinal) {
+      auto coordinates = map->delinearize(partition, ordinal);
+      ASSERT_TRUE(succeeded(coordinates));
+      ++coverage[(*coordinates)[0] + 16 * (*coordinates)[1]];
+      EXPECT_EQ(*map->linearize(partition, *coordinates), ordinal);
+    }
+  }
+  EXPECT_TRUE(
+      llvm::all_of(coverage, [](unsigned count) { return count == 1; }));
+}
+
+TEST(PartitionedRadixMapTest, ConstrainedAndFreeTailsCoverExactlyOnce) {
+  llvm::SmallVector<Dimension> dimensions = {{5, Partition{1, 0, 1}}, {7, {}}};
+  auto map =
+      PartitionedRadixMap::create(dimensions, {0, 1}, 4, Mode::Distribute);
+  ASSERT_TRUE(succeeded(map));
+  EXPECT_EQ(map->getConstrainedPartitionMask(), 1);
+  EXPECT_EQ(map->getFreePartitionMask(), 2);
+  EXPECT_EQ(*map->getLocalOrdinalCount(0), 11);
+  EXPECT_EQ(*map->getLocalOrdinalCount(1), 7);
+  EXPECT_EQ(*map->getLocalOrdinalCount(2), 10);
+  EXPECT_EQ(*map->getLocalOrdinalCount(3), 7);
+
+  llvm::SmallVector<unsigned> coverage(5 * 7);
+  for (unsigned partition = 0; partition < 4; ++partition) {
+    auto count = map->getLocalOrdinalCount(partition);
+    ASSERT_TRUE(succeeded(count));
+    for (uint64_t ordinal = 0; ordinal < *count; ++ordinal) {
+      auto coordinates = map->delinearize(partition, ordinal);
+      ASSERT_TRUE(succeeded(coordinates));
+      ++coverage[(*coordinates)[0] + 5 * (*coordinates)[1]];
+      EXPECT_EQ(*map->linearize(partition, *coordinates), ordinal);
+    }
+  }
+  EXPECT_TRUE(
+      llvm::all_of(coverage, [](unsigned count) { return count == 1; }));
+}
+
+TEST(PartitionedRadixMapTest, FreePartitionsOwnContiguousRanges) {
+  auto map = PartitionedRadixMap::create({{17, {}}}, {0}, 2, Mode::Distribute);
+  ASSERT_TRUE(succeeded(map));
+  EXPECT_EQ(*map->getLocalOrdinalCount(0), 9);
+  EXPECT_EQ(*map->getLocalOrdinalCount(1), 8);
+  EXPECT_EQ(*map->delinearize(0, 0), llvm::SmallVector<int32_t>({0}));
+  EXPECT_EQ(*map->delinearize(0, 8), llvm::SmallVector<int32_t>({8}));
+  EXPECT_EQ(*map->delinearize(1, 0), llvm::SmallVector<int32_t>({9}));
+  EXPECT_EQ(*map->delinearize(1, 7), llvm::SmallVector<int32_t>({16}));
+}
+
+TEST(PartitionedRadixMapTest, InverseIsDefinedExactlyOnPartitionImage) {
+  auto map = PartitionedRadixMap::create({{5, Partition{1, 0, 1}}, {7, {}}},
+                                         {1, 0}, 4, Mode::Distribute);
+  ASSERT_TRUE(succeeded(map));
+  for (int32_t row = 0; row < 5; ++row) {
+    for (int32_t col = 0; col < 7; ++col) {
+      unsigned owners = 0;
+      for (unsigned partition = 0; partition < 4; ++partition) {
+        auto ordinal = map->linearize(partition, {row, col});
+        if (failed(ordinal))
+          continue;
+        ++owners;
+        EXPECT_EQ(*map->delinearize(partition, *ordinal),
+                  llvm::SmallVector<int32_t>({row, col}));
+      }
+      EXPECT_EQ(owners, 1);
+    }
+  }
+}
+
+TEST(PartitionedRadixMapTest, RemoveUnitDimensionPreservesPartitionImages) {
+  auto parent = PartitionedRadixMap::create({{1, {}}, {33, {}}}, {1, 0}, 4,
+                                            Mode::Distribute);
+  ASSERT_TRUE(succeeded(parent));
+  auto slice = parent->removeUnitDimension(0);
+  ASSERT_TRUE(succeeded(slice));
+  for (unsigned partition = 0; partition < 4; ++partition) {
+    auto parentCount = parent->getLocalOrdinalCount(partition);
+    auto sliceCount = slice->getLocalOrdinalCount(partition);
+    ASSERT_TRUE(succeeded(parentCount));
+    ASSERT_TRUE(succeeded(sliceCount));
+    ASSERT_EQ(*parentCount, *sliceCount);
+    for (uint64_t ordinal = 0; ordinal < *parentCount; ++ordinal) {
+      auto parentCoordinate = parent->delinearize(partition, ordinal);
+      auto sliceCoordinate = slice->delinearize(partition, ordinal);
+      ASSERT_TRUE(succeeded(parentCoordinate));
+      ASSERT_TRUE(succeeded(sliceCoordinate));
+      EXPECT_EQ((*parentCoordinate)[0], 0);
+      EXPECT_EQ((*parentCoordinate)[1], (*sliceCoordinate)[0]);
+      EXPECT_EQ(*slice->linearize(partition, *sliceCoordinate), ordinal);
+    }
+  }
+  EXPECT_TRUE(failed(parent->removeUnitDimension(1)));
+}
+
+TEST(PartitionedRadixMapTest, TailAndEmptyPartitions) {
+  auto map = PartitionedRadixMap::create({{3, Partition{1, 0, 2}}}, {0}, 4,
+                                         Mode::Distribute);
+  ASSERT_TRUE(succeeded(map));
+  for (unsigned partition = 0; partition < 3; ++partition) {
+    EXPECT_EQ(*map->getLocalOrdinalCount(partition), 1);
+    EXPECT_EQ(*map->delinearize(partition, 0),
+              llvm::SmallVector<int32_t>({static_cast<int32_t>(partition)}));
+  }
+  EXPECT_EQ(*map->getLocalOrdinalCount(3), 0);
+  EXPECT_TRUE(failed(map->delinearize(3, 0)));
+  EXPECT_TRUE(failed(map->linearize(0, {1})));
+}
+
+TEST(PartitionedRadixMapTest, RejectsInvalidDescriptors) {
+  EXPECT_TRUE(
+      failed(PartitionedRadixMap::create({{3, {}}}, {0}, 3, Mode::Distribute)));
+  EXPECT_TRUE(failed(PartitionedRadixMap::create(
+      {{8, Partition{2, 0, 1}}, {8, Partition{2, 0, 1}}}, {0, 1}, 2,
+      Mode::Distribute)));
+  EXPECT_TRUE(failed(PartitionedRadixMap::create({{8, Partition{2, 1, 1}}}, {0},
+                                                 2, Mode::Distribute)));
+  EXPECT_TRUE(failed(PartitionedRadixMap::create(
+      {{8, Partition{2, std::numeric_limits<unsigned>::max(), 2}}}, {0}, 2,
+      Mode::Distribute)));
+  EXPECT_TRUE(failed(PartitionedRadixMap::create({{8, Partition{2, 0, 1}}}, {0},
+                                                 2, Mode::Replicate)));
+  EXPECT_TRUE(failed(PartitionedRadixMap::create({{50000, {}}, {50000, {}}},
+                                                 {0, 1}, 1, Mode::Replicate)));
+  EXPECT_TRUE(failed(PartitionedRadixMap::create({{3, {}}, {5, {}}}, {0}, 1,
+                                                 Mode::Replicate)));
+  EXPECT_TRUE(failed(PartitionedRadixMap::create({{3, {}}, {5, {}}}, {0, 0}, 1,
+                                                 Mode::Replicate)));
+  EXPECT_TRUE(failed(PartitionedRadixMap::create({{3, {}}, {5, {}}}, {0, 2}, 1,
+                                                 Mode::Replicate)));
+}
+
+} // namespace
+} // namespace mlir::triton


### PR DESCRIPTION
Summary:
Add the small mixed-radix coordinate primitive used immediately by the compact register ABI.

PartitionedRadixMap assigns balanced contiguous ordinal ranges in an explicit dimension order. Constrained partition bits select strided dimension slices; remaining partition bits distribute each slice without holes or aliases. Replicate mode deliberately gives every partition the same image.

Provide analytic delinearize(partition, localOrdinal) and linearize(partition, coordinates) operations. They are mutual inverses exactly on a partition image; coordinates outside that image fail instead of using search, modulo fill, or a pseudo-inverse. Unit-dimension restriction preserves the parent partition for Slice plans.

This is a directly consumed foundation for the next compact-coordinate ABI diff, not a general affine-mod composition framework.

Differential Revision: D115084884


