### PR TITLE
[TLX] Fix test_split_k_no_fusion assertions after D114342717

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -739,7 +739,7 @@ class TestSplitK(TestCase):
     )
     @unittest.skipIf(not has_tlx(), "TLX not available")
     def test_split_k_no_fusion(self):
-        """Verify epilogue fusion is disabled with split-K (relu applied separately)."""
+        """Verify the split-K epilogue is fused into the generated reducer."""
 
         def relu_mm(a, b):
             return torch.relu(torch.mm(a, b))
@@ -762,11 +762,12 @@ class TestSplitK(TestCase):
         torch.testing.assert_close(c_actual, c_expected, atol=0.01, rtol=0.01)
 
         code_str = "\n".join(code)
-        # Reduction kernel present (split-K was used)
-        self.assertIn("_reduce_k_kernel", code_str)
-        # relu should NOT be fused into the GEMM kernel — it should appear
-        # as a separate pointwise kernel after the reduction
-        self.assertIn("triton_poi_", code_str)
+        # Reduction kernel present (split-K was used). The generated reducer is
+        # named "{main_kernel}_reduce_k"; the legacy "_reduce_k_kernel" symbol is
+        # only emitted on the no-epilogue path.
+        self.assertIn("_reduce_k", code_str)
+        # relu is fused into the reducer, so no separate pointwise kernel
+        self.assertNotIn("triton_poi_", code_str)
 
 
 class TestReduceKKernel(TestCase):


### PR DESCRIPTION
Summary:
test_split_k_no_fusion has failed on 10 of its last 10 CI runs. It is a stale
test, not a product bug.

D114342717 unified every split-K reducer onto the code-generated define_kernel
path, whose name is built as f"{main_kernel_name}_reduce_k" (reduce_k.py:201),
and at the same time made the JIT wrapper fuse the epilogue into that reducer by
dropping the allow_epilogue_fusion=False gate and always setting
_unfused_epilogues = [] (registry.py:2169-2187). Both of this test's assertions
encode the pre-D114342717 behaviour: it looks for the literal _reduce_k_kernel,
which is now only emitted on the no-epilogue path, and for a separate triton_poi_
pointwise kernel, which is no longer emitted at all. That is also why its
siblings still pass -- test_split_k_codegen and test_interleave_split_k_codegen
use a plain mm with no epilogue, so they take the legacy path and still see the
old symbol. The sibling AMD tests were refreshed to assertIn("_reduce_k") +
assertNotIn("triton_poi_") in the same stack; the Blackwell ones in TestSplitK
were not, because that work was validated on gfx950/MI350X where they skip.

This brings the assertions in line with the AMD siblings and rewrites the
docstring, which described the opposite of the current behaviour. I left the test
name alone: renaming it to something like test_split_k_epilogue_fused would be
more honest, but it changes the test's identity and its CI history, so that call
belongs to the owner of D114342717.

Authored with Claude Code.

Reviewed By: rocketerfb

Differential Revision: D115484094


