### PR TITLE
[triton][beta] Make compiler cache text I/O explicitly UTF-8

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -6,6 +6,8 @@ import re
 import gc
 import shutil
 import pathlib
+import subprocess
+import sys
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 
 import pytest
@@ -15,6 +17,29 @@ import triton
 import triton.language as tl
 from triton._internal_testing import is_hip
 from triton.runtime.cache import FileCacheManager, RemoteCacheManager
+
+
+def test_file_cache_manager_writes_utf8_under_ascii_locale(tmp_path):
+    env = os.environ.copy()
+    env.update({
+        "LANG": "C",
+        "LC_ALL": "C",
+        "PYTHONCOERCECLOCALE": "0",
+        "PYTHONUTF8": "0",
+        "TRITON_CACHE_DIR": str(tmp_path),
+    })
+    script = """
+import locale
+from pathlib import Path
+
+from triton.runtime.cache import FileCacheManager
+
+assert locale.getpreferredencoding(False) == "ANSI_X3.4-1968"
+text = "generated launcher " + chr(0x2014)
+path = FileCacheManager("unicode").put(text, "launcher.c", binary=False)
+assert Path(path).read_text(encoding="utf-8") == text
+"""
+    subprocess.run([sys.executable, "-c", script], check=True, env=env)
 
 
 def test_file_cache_manager_get_group_rejects_missing_child(fresh_knobs, tmp_path):

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -100,7 +100,7 @@ class IRSource:
         path = Path(path)
         self.ext = path.suffix[1:]
         self.language = Language.TRITON
-        self.src = path.read_text()
+        self.src = path.read_text(encoding="utf-8")
         ir.load_dialects(context)
         backend.load_dialects(context)
 
@@ -150,7 +150,7 @@ def parse(full_name, ext, context):
         module.context = context
         return module
     if ext == "llir" or ext == "ptx" or ext == "amdgcn":
-        return Path(full_name).read_text()
+        return Path(full_name).read_text(encoding="utf-8")
     if ext == "cubin" or ext == "hsaco":
         return Path(full_name).read_bytes()
 
@@ -522,7 +522,7 @@ class CompiledKernel:
     def __init__(self, src, metadata_group, hash):
         from collections import namedtuple
         metadata_path = next((Path(p) for c, p in metadata_group.items() if c.endswith(".json")))
-        metadata = json.loads(metadata_path.read_text())
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
         if metadata.get('ctas_per_cga') is not None:
             metadata['ctas_per_cga'] = tuple(metadata['ctas_per_cga'])
         if metadata.get('preferred_ctas_per_cga') is not None:
@@ -541,7 +541,8 @@ class CompiledKernel:
         asm_files = [Path(p) for c, p in metadata_group.items() if not c.endswith(".json")]
         binary_ext = backend.binary_ext
         self.asm = AsmDict({
-            file.suffix[1:]: file.read_bytes() if file.suffix[1:] == binary_ext else file.read_text()
+            file.suffix[1:]: file.read_bytes()
+            if file.suffix[1:] == binary_ext else file.read_text(encoding="utf-8")
             for file in asm_files
         })
         self.metadata_group = metadata_group

--- a/python/triton/runtime/cache.py
+++ b/python/triton/runtime/cache.py
@@ -76,7 +76,7 @@ class FileCacheManager(CacheManager):
             return None
         grp_filepath = self._make_path(grp_filename)
         try:
-            with open(grp_filepath) as f:
+            with open(grp_filepath, encoding="utf-8") as f:
                 grp_data = json.load(f)
         except Exception:
             # exit on corrupted cache.
@@ -117,9 +117,12 @@ class FileCacheManager(CacheManager):
         os.makedirs(temp_dir, exist_ok=True)
         temp_path = os.path.join(temp_dir, filename)
 
-        mode = "wb" if binary else "w"
-        with open(temp_path, mode) as f:
-            f.write(data)
+        if binary:
+            with open(temp_path, "wb") as f:
+                f.write(data)
+        else:
+            with open(temp_path, "w", encoding="utf-8") as f:
+                f.write(data)
         # Replace is guaranteed to be atomic on POSIX systems if it succeeds
         # so filepath cannot see a partial write
         os.replace(temp_path, filepath)

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -121,11 +121,11 @@ class CudaUtils(object):
         # launch.h"` would not resolve. Substituting the header text keeps a
         # single source of truth (launch.h) while making the compile
         # self-contained.
-        driver_src = Path(os.path.join(dirname, "driver.c")).read_text()
+        driver_src = Path(os.path.join(dirname, "driver.c")).read_text(encoding="utf-8")
         launch_h_path = next((p for p in _launch_h_candidates if os.path.exists(p)), None)
         if launch_h_path is None:
             raise FileNotFoundError(f"launch.h not found in any of: {_launch_h_candidates}")
-        launch_h_src = Path(launch_h_path).read_text()
+        launch_h_src = Path(launch_h_path).read_text(encoding="utf-8")
         include_marker = '#include "nvidia/backend/launch.h"'
         if include_marker not in driver_src:
             raise RuntimeError(f"driver.c must contain the marker {include_marker!r} for "


### PR DESCRIPTION
Summary:
Failing tests on D115081437 (61 signals, ASCII-locale workers):
- UnicodeDecodeError reading driver.c byte 0xe2: fast_moe (3), test_meta_cuda (46), Sonic (1), and 2 BoTorch signals.
- UnicodeEncodeError writing launcher U+2014: AEPsych (6), SLL (1), and 2 BoTorch signals. A fresh cache then hits the matching UnicodeDecodeError when CompiledKernel reloads that launcher.

Cause: Meta's shared launcher (D108687968) reads driver.c, inlines a UTF-8 launch.h, and caches the result. Public Triton main compiles an ASCII-only driver.c directly and does not currently reproduce.

Fix: make source, cache, and compiler text I/O explicitly UTF-8, preserve binary I/O, and add an ASCII-locale regression test.

Differential Revision: D115535166


