### PR TITLE
[Test-Fix] [Triton] [Beta] Score atomic layouts by contiguous width (#2811)

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Transforms/Passes.h"
 #include "mlir/Transforms/RegionUtils.h"
 #include "triton/Analysis/Allocation.h"
+#include "triton/Analysis/AxisInfo.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
@@ -594,7 +595,77 @@ static int64_t getLayoutScore(Attribute encoding) {
   return score;
 }
 
+// Estimate the number of contiguous atomic elements for a candidate layout.
+// AxisInfo is multidimensional, so evaluate it along the candidate layout's
+// register-contiguous dimension instead of treating sizePerThread as a scalar.
+static int64_t getAtomicContiguousWidth(
+    Value value, Attribute encoding,
+    ModuleAxisInfoAnalysis &axisInfoAnalysis) {
+  Operation *op = value.getDefiningOp();
+  if (!op || !isa<AtomicRMWOp, AtomicCASOp>(op))
+    return 0;
+
+  Value ptr;
+  Value mask;
+  if (auto atomicRmw = dyn_cast<AtomicRMWOp>(op)) {
+    ptr = atomicRmw.getPtr();
+    mask = atomicRmw.getMask();
+  } else {
+    ptr = cast<AtomicCASOp>(op).getPtr();
+  }
+
+  auto ptrTy = dyn_cast<RankedTensorType>(ptr.getType());
+  auto *ptrAxisInfo = axisInfoAnalysis.getAxisInfo(ptr);
+  if (!ptrTy || !ptrAxisInfo)
+    return 0;
+
+  auto candidateTy = ptrTy.cloneWithEncoding(encoding);
+  auto order = getOrder(candidateTy);
+  auto contigPerThread = getContigPerThread(candidateTy);
+  if (order.empty() || order[0] >= contigPerThread.size() ||
+      order[0] >= static_cast<unsigned>(ptrAxisInfo->getRank()))
+    return 0;
+
+  unsigned contiguousDim = order[0];
+  Type elemTy = ptrTy.getElementType();
+  if (auto pointerTy = dyn_cast<PointerType>(elemTy))
+    elemTy = pointerTy.getPointeeType();
+  unsigned elemBitWidth = elemTy.getIntOrFloatBitWidth();
+  unsigned elemBytes = std::max<unsigned>(elemBitWidth / 8, 1);
+  int64_t ptrAlignment = std::max<int64_t>(
+      ptrAxisInfo->getDivisibility(contiguousDim) / elemBytes, 1);
+  int64_t width = std::min<int64_t>(
+      contigPerThread[contiguousDim],
+      std::min(ptrAxisInfo->getContiguity(contiguousDim), ptrAlignment));
+
+  if (mask) {
+    auto *maskAxisInfo = axisInfoAnalysis.getAxisInfo(mask);
+    if (!maskAxisInfo ||
+        contiguousDim >= static_cast<unsigned>(maskAxisInfo->getRank()))
+      return 1;
+    width = std::min<int64_t>(
+        width, std::max<int64_t>(
+                   maskAxisInfo->getConstancy(contiguousDim), 1));
+  }
+  int64_t maxVectorWidth = std::max<unsigned>(128 / elemBitWidth, 1);
+  return std::min(std::max<int64_t>(width, 1), maxVectorWidth);
+}
+
+// The first component captures operation-specific vectorization and the second
+// preserves the existing total-elements-per-thread heuristic as a tiebreaker.
+static std::pair<int64_t, int64_t>
+getLayoutScore(Value value, Attribute encoding,
+               ModuleAxisInfoAnalysis *axisInfoAnalysis) {
+  int64_t elementsPerThread = getLayoutScore(encoding);
+  if (axisInfoAnalysis && value.getDefiningOp() &&
+      isa<AtomicRMWOp, AtomicCASOp>(value.getDefiningOp()))
+    return {getAtomicContiguousWidth(value, encoding, *axisInfoAnalysis),
+            elementsPerThread};
+  return {elementsPerThread, 0};
+}
+
 void LayoutPropagation::resolveConflicts() {
+  std::unique_ptr<ModuleAxisInfoAnalysis> axisInfoAnalysis;
   for (auto &it : layouts) {
     Operation *op = it.first.getDefiningOp();
     LayoutInfo &info = it.second;
@@ -611,14 +682,17 @@ void LayoutPropagation::resolveConflicts() {
     Attribute encoding = *info.encodings.begin();
     bool isLoadOrStore =
         op && isa<LoadOp, StoreOp, AtomicRMWOp, AtomicCASOp>(op);
+    if (op && isa<AtomicRMWOp, AtomicCASOp>(op) && !axisInfoAnalysis)
+      axisInfoAnalysis = std::make_unique<ModuleAxisInfoAnalysis>(
+          funcOp->getParentOfType<ModuleOp>());
     // Pick the layout with maximum score.
     // This prefers layouts with larger sizePerThread values for better
     // vectorized memory access. Both blocked and linear encodings are scored,
     // so e.g. a linear layout from TMEMLoadOp (sizePerThread=[1,32]) beats
     // a blocked layout from local_load (sizePerThread=[1,8]).
-    int64_t bestScore = getLayoutScore(encoding);
+    auto bestScore = getLayoutScore(it.first, encoding, axisInfoAnalysis.get());
     for (Attribute e : info.encodings) {
-      int64_t score = getLayoutScore(e);
+      auto score = getLayoutScore(it.first, e, axisInfoAnalysis.get());
       if (score > bestScore) {
         bestScore = score;
         encoding = e;
@@ -626,7 +700,7 @@ void LayoutPropagation::resolveConflicts() {
     }
     // If no layout with vectorization found, fall back to the original
     // heuristic (prefer blocked for load/store, MMA for compute).
-    if (bestScore == 0) {
+    if (bestScore == std::pair<int64_t, int64_t>{0, 0}) {
       for (Attribute e : info.encodings) {
         if ((isLoadOrStore && isa<BlockedEncodingAttr>(e)) ||
             (!isLoadOrStore && isa<MmaEncodingTrait>(e))) {

--- a/test/TritonGPU/remove-layout-conversions-atomic.mlir
+++ b/test/TritonGPU/remove-layout-conversions-atomic.mlir
@@ -1,0 +1,45 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-remove-layout-conversions | FileCheck %s
+
+// The producer layout has more total elements per thread, but its contiguous
+// register dimension is strided for the atomic pointer. The atomic layout must
+// win because it can issue eight contiguous operations instead of one.
+
+// CHECK: #[[$ATOMIC:.*]] = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
+// CHECK-LABEL: @multidimensional_atomic_layout
+// CHECK: tt.atomic_rmw fadd, relaxed, gpu, %{{.*}}, %{{.*}}, %{{.*}} : (tensor<128x32x!tt.ptr<bf16>, #[[$ATOMIC]]>, tensor<128x32xbf16, #[[$ATOMIC]]>, tensor<128x32xi1, #[[$ATOMIC]]>) -> tensor<128x32xbf16, #[[$ATOMIC]]>
+
+#atomic = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
+#producer = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  tt.func @multidimensional_atomic_layout(
+      %ptr: tensor<128x32x!tt.ptr<bf16>, #atomic> {tt.contiguity = dense<[128, 1]> : tensor<2xi32>, tt.divisibility = dense<[16, 2]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>},
+      %value: tensor<128x32xbf16, #producer>,
+      %mask: tensor<128x32xi1, #atomic> {tt.constancy = dense<[128, 1]> : tensor<2xi32>}) {
+    %value_atomic = ttg.convert_layout %value : tensor<128x32xbf16, #producer> -> tensor<128x32xbf16, #atomic>
+    %result = tt.atomic_rmw fadd, relaxed, gpu, %ptr, %value_atomic, %mask : (tensor<128x32x!tt.ptr<bf16>, #atomic>, tensor<128x32xbf16, #atomic>, tensor<128x32xi1, #atomic>) -> tensor<128x32xbf16, #atomic>
+    tt.return
+  }
+}
+
+// -----
+
+// Both layouts provide at least 128 bits of contiguous fp32 elements. Once
+// their vector widths are capped at four, prefer the layout with more total
+// elements per thread using the existing score as a tiebreaker.
+
+// CHECK: #[[$BALANCED:.*]] = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [0, 1]}>
+// CHECK-LABEL: @atomic_vector_width_tie
+// CHECK: tt.atomic_rmw fadd, relaxed, gpu, %{{.*}}, %{{.*}}, %{{.*}} : (tensor<128x32x!tt.ptr<f32>, #[[$BALANCED]]>, tensor<128x32xf32, #[[$BALANCED]]>, tensor<128x32xi1, #[[$BALANCED]]>) -> tensor<128x32xf32, #[[$BALANCED]]>
+
+#wide = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
+#balanced = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  tt.func @atomic_vector_width_tie(
+      %ptr: tensor<128x32x!tt.ptr<f32>, #wide> {tt.contiguity = dense<[128, 1]> : tensor<2xi32>, tt.divisibility = dense<[32, 4]> : tensor<2xi32>, tt.constancy = dense<[1, 1]> : tensor<2xi32>},
+      %value: tensor<128x32xf32, #balanced>,
+      %mask: tensor<128x32xi1, #wide> {tt.constancy = dense<[128, 1]> : tensor<2xi32>}) {
+    %value_wide = ttg.convert_layout %value : tensor<128x32xf32, #balanced> -> tensor<128x32xf32, #wide>
+    %result = tt.atomic_rmw fadd, relaxed, gpu, %ptr, %value_wide, %mask : (tensor<128x32x!tt.ptr<f32>, #wide>, tensor<128x32xf32, #wide>, tensor<128x32xi1, #wide>) -> tensor<128x32xf32, #wide>
+    tt.return
+  }
+}


### PR DESCRIPTION
Summary:

Layout conflict resolution currently scores `sizePerThread` by multiplying every dimension. For multidimensional atomics this can select a layout whose register-contiguous dimension is strided in memory, scalarizing an otherwise vectorizable atomic.

Score `AtomicRMWOp` and `AtomicCASOp` candidates by the achievable contiguous width along each candidate's register order, including pointer alignment and mask constancy. Preserve total elements per thread as a tiebreaker and retain the existing heuristic for non-atomic operations. Apply the same change and regression coverage to Triton stable and beta.

AI-assisted by Codex.

Differential Revision: D115503650


