### PR TITLE
[triton][beta][AMD] Legalize explicit async copies on gfx942

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -355,8 +355,7 @@ class HIPBackend(BaseBackend):
         else:
             amd.passes.ttgpuir.add_schedule_loops(pm, options.num_stages)
             amd.passes.ttgpuir.add_pipeline(pm, use_async_copy, use_block_pingpong)
-        if use_async_copy:
-            amd.passes.ttgpuir.add_coalesce_async_copy(pm, options.arch)
+        amd.passes.ttgpuir.add_coalesce_async_copy(pm, options.arch, use_async_copy)
         amd.passes.ttgpuir.add_convert_to_tensor_ops(pm)
         # Phase 0 — opt-in TTGIR-level scheduler scaffold. No-ops unless
         # TRITON_ENABLE_TTGIR_SCHED=1 (also re-checked inside the pass).

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -310,6 +310,8 @@ def TritonAMDGPUCoalesceAsyncCopy
   let options =
       [Option<"gfxArch", "gfx-arch", "std::string", /*default=*/"std::string{}",
               "Specify the GFX architecture name, e.g., gfx942, gfx950, etc.">,
+       Option<"useAsyncCopy", "use_async_copy", "bool", /*default=*/"true",
+              "Whether the pipeline automatically generates async copies">,
   ];
 }
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CoalesceAsyncCopy.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CoalesceAsyncCopy.cpp
@@ -285,15 +285,22 @@ public:
 
   void runOnOperation() override {
     ModuleOp m = getOperation();
-    MLIRContext *context = &getContext();
-
     triton::AMD::TargetInfo targetInfo(gfxArch);
-
-    mlir::RewritePatternSet patterns(context);
 
     if (!llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4},
                             targetInfo.getISAFamily()))
       return; // This pass is CDNA3 and CDNA4 specific.
+
+    if (!useAsyncCopy) {
+      bool hasAsyncCopy = m->walk([](ttg::AsyncCopyGlobalToLocalOp) {
+                             return WalkResult::interrupt();
+                           }).wasInterrupted();
+      if (!hasAsyncCopy)
+        return;
+    }
+
+    MLIRContext *context = &getContext();
+    mlir::RewritePatternSet patterns(context);
 
     // Precompute the contiguity of all AsyncCopy ops based on the src and
     // mask contiguity/alignment to avoid rebuilding ModuleAxisInfoAnalysis

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -108,9 +108,9 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
                             bool, bool);
   ADD_PASS_WRAPPER_0("add_coalesce_buffer_ops",
                      mlir::createTritonAMDGPUCoalesceBufferOps);
-  ADD_PASS_OPTION_WRAPPER_1("add_coalesce_async_copy",
+  ADD_PASS_OPTION_WRAPPER_2("add_coalesce_async_copy",
                             mlir::createTritonAMDGPUCoalesceAsyncCopy,
-                            std::string);
+                            std::string, bool);
   ADD_PASS_OPTION_WRAPPER_1("add_update_async_wait_count",
                             mlir::createTritonAMDGPUUpdateAsyncWaitCount,
                             std::string);


### PR DESCRIPTION
Summary:
## Problem

This beta test fails on MI300/gfx942 while compiling a kernel that explicitly uses `tlx.async_load`:

`test_amd_warp_pipeline.py::test_warp_pipeline_lowering`

```
error: LLVM Translation failed for operation: builtin.unrealized_conversion_cast
RuntimeError: failed to translate module to LLVM IR
```

## Why the guard is wrong

[`use_async_copy` was introduced](https://github.com/triton-lang/triton/pull/6270) to control whether the stream pipeliner converts ordinary `tt.load` operations into async copies. At the time, the pipeliner was the only source of async-copy operations, so `CoalesceAsyncCopy` was placed under the same guard.

`tlx.async_load` later added a second source: it explicitly emits an async-copy operation regardless of the pipeliner setting. On MI300, automatic generation is disabled, but the explicit operation still exists. The old guard therefore skips the pass required to legalize it.

## Fix

Continue passing `use_async_copy` to the pipeline, so automatic async-copy generation remains disabled on MI300. Register `CoalesceAsyncCopy` independently and pass it the same option.

When `use_async_copy` is false, the pass checks the actual IR for async-copy operations. It returns before constructing `ModuleAxisInfoAnalysis` when none exist, but legalizes an explicitly created operation when present. When `use_async_copy` is true, the pass retains its existing path without the preliminary check. The MLIR pass option defaults to true for compatibility with existing textual and lit-test invocations.

The pass does not create async copies; it only legalizes existing operations and remains restricted to supported CDNA architectures.

## Regression history

[facebookexperimental/triton PR #1717](https://github.com/facebookexperimental/triton/pull/1717) added the AMD warp-pipeline test in Triton 3.8 and validated it on gfx950. The promotion exposed the older gfx942 pass-scheduling bug.

Differential Revision: D115534910


