### PR TITLE
[Test-Fix] [Triton][Beta] Force layout hoists only over SMEM budget

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -150,8 +150,7 @@ private:
 
 class LayoutRematerialization {
 public:
-  LayoutRematerialization(FuncOp F, unsigned smemBudget = 0)
-      : funcOp(F), smemBudget(smemBudget) {}
+  LayoutRematerialization(FuncOp F) : funcOp(F) {}
 
   // Map the original value to the remat'ed one.
   void addRematValue(Value old, Attribute encoding, Value newV);
@@ -170,7 +169,8 @@ public:
 
   // TODO: Merge the three hoistConvert*(); functions as they are duplicate code
   void hoistConvertDotOperand();
-  void hoistConvertOnTopOfExtOrBroadcast();
+  void hoistConvertOnTopOfExtOrBroadcast(
+      const DenseSet<Operation *> *forceHoists = nullptr);
   void hoistConvertIntoConditionals();
 
   /// Attempt to hoist \p convertOp above operations that make the tensor larger
@@ -178,7 +178,8 @@ public:
   /// possible, rematerialize the slice between the convert and that operation
   /// and hoist the convert above it.
   /// \return true if \p convertOp was hoisted, false otherwise.
-  bool hoistConvertOnTopOfExtOrBroadcast(ConvertLayoutOp convertOp);
+  bool hoistConvertOnTopOfExtOrBroadcast(ConvertLayoutOp convertOp,
+                                         bool forceHoist = false);
 
   /// Attempt to hoist \p convertOp into conditionals so the conversion is only
   /// conditionally executed. If this is possible, rematerialize the slice
@@ -223,9 +224,6 @@ private:
   // map of the values remat based on encoding.
   DenseMap<std::pair<Value, Attribute>, Value> rematMapping;
   FuncOp funcOp;
-  // Meta extension: when > 0, the remove-layout pass is operating under a SMEM
-  // budget and convert-elimination hoists bypass the upstream perf cost gate.
-  unsigned smemBudget;
   DominanceInfo domInfo;
   PostDominanceInfo postDomInfo;
 };
@@ -1239,13 +1237,16 @@ bool LayoutRematerialization::backwardRematerialization() {
   return changed;
 }
 
-void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast() {
+void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
+    const DenseSet<Operation *> *forceHoists) {
   // Go through each ConvertLayoutOp.
   SmallVector<ConvertLayoutOp> convertOps;
   funcOp.walk(
       [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
   for (ConvertLayoutOp convertOp : convertOps) {
-    if (!hoistConvertOnTopOfExtOrBroadcast(convertOp)) {
+    bool forceHoist =
+        forceHoists && forceHoists->contains(convertOp.getOperation());
+    if (!hoistConvertOnTopOfExtOrBroadcast(convertOp, forceHoist)) {
       // If the conversion didn't get removed, consider it for reuse in future
       // backward slices.
       addRematValue(convertOp.getSrc(), convertOp.getType().getEncoding(),
@@ -1648,7 +1649,7 @@ bool LayoutRematerialization::hoistConvertDotOperand(
 // For convert left we try to hoist them above type extension to reduce the cost
 // of the convert.
 bool LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
-    ConvertLayoutOp convertOp) {
+    ConvertLayoutOp convertOp, bool forceHoist) {
   // DotOperand is hoisted by hoistDotOperand
   RankedTensorType targetType = convertOp.getType();
   if (isa<DotOperandEncodingAttr>(targetType.getEncoding()))
@@ -1707,10 +1708,9 @@ bool LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
   Attribute srcEncoding = inferSrcEncoding(extOrBroadcastOp, dstEncoding);
   if (!srcEncoding)
     return false;
-  // Under a SMEM budget (a Meta extension) eliminating convert-layout scratch
-  // takes priority over the upstream perf-cost heuristic (#9194), so force the
-  // hoist. Without a budget, keep the upstream cost gate.
-  if (smemBudget == 0) {
+  // Eliminating an over-budget convert-layout scratch allocation takes
+  // priority over the upstream perf-cost heuristic (#9194).
+  if (!forceHoist) {
     int64_t newCvtCost =
         getConvertCost(extOrBroadcastOp->getOperand(0), srcEncoding);
     if (!isRematBeneficial(convertOp, slice, layout, newCvtCost))
@@ -1863,11 +1863,12 @@ bool backwardRematerialization(ModuleOp module) {
   return changed;
 }
 
-void hoistConvert(ModuleOp module, unsigned smemBudget = 0) {
+void hoistConvert(ModuleOp module,
+                  const DenseSet<Operation *> *forceHoists = nullptr) {
   SmallVector<ConvertLayoutOp> convertOps;
-  module.walk([smemBudget](FuncOp funcOp) {
-    LayoutRematerialization layoutRemat(funcOp, smemBudget);
-    layoutRemat.hoistConvertOnTopOfExtOrBroadcast();
+  module.walk([forceHoists](FuncOp funcOp) {
+    LayoutRematerialization layoutRemat(funcOp);
+    layoutRemat.hoistConvertOnTopOfExtOrBroadcast(forceHoists);
 
     layoutRemat = LayoutRematerialization(funcOp);
     layoutRemat.hoistConvertIntoConditionals();
@@ -2001,7 +2002,7 @@ public:
     } while (changed);
     // 3. For remaining converts, try to hoist them above cast generating larger
     // size types in order to reduce the cost of the convert op.
-    hoistConvert(m, smemBudget);
+    hoistConvert(m);
     LLVM_DEBUG({
       DBGS() << "Module after hoisting converts:\n";
       m.dump();
@@ -2036,8 +2037,8 @@ public:
     // convert_layout ops whose scratch would push SMEM over budget, and try to
     // eliminate them by propagating the source encoding through their users.
     if (smemBudget > 0) {
-      eliminateOverBudgetConverts(m);
-      hoistConvert(m, smemBudget);
+      DenseSet<Operation *> forcedHoists = eliminateOverBudgetConverts(m);
+      hoistConvert(m, &forcedHoists);
       cleanupConvertOps();
     }
   }
@@ -2047,12 +2048,13 @@ public:
   // tmem_load) and the users are elementwise ops feeding into local_store/
   // local_load (which can accept any layout), propagate the source layout
   // through the convert's users and erase the convert.
-  void eliminateOverBudgetConverts(ModuleOp m) {
-    m.walk([this](FuncOp funcOp) {
+  DenseSet<Operation *> eliminateOverBudgetConverts(ModuleOp m) {
+    DenseSet<Operation *> forcedHoists;
+    m.walk([this, &forcedHoists](FuncOp funcOp) {
       unsigned baseSmem = computeBaseSmem(funcOp);
 
       // Collect converts whose scratch would push SMEM over budget.
-      SmallVector<ConvertLayoutOp> overBudgetConverts;
+      SmallVector<ConvertLayoutOp> candidates;
       funcOp->walk([&](ConvertLayoutOp cvt) {
         auto srcTy = cvt.getSrc().getType();
         auto dstTy = cvt.getType();
@@ -2064,17 +2066,20 @@ public:
         unsigned scratchBytes = getNumScratchElemsSwizzledCvt(srcTy, dstTy) *
                                 getElementBitWidth(srcTy) / 8;
         if (baseSmem + scratchBytes > smemBudget) {
-          overBudgetConverts.push_back(cvt);
+          candidates.push_back(cvt);
         }
       });
 
-      for (ConvertLayoutOp cvt : overBudgetConverts) {
+      for (ConvertLayoutOp cvt : candidates) {
         Attribute srcEnc = cvt.getSrc().getType().getEncoding();
         if (canPropagateSrcEncodingThroughUsers(cvt, srcEnc)) {
           propagateSrcEncodingAndErase(cvt, srcEnc);
+        } else {
+          forcedHoists.insert(cvt.getOperation());
         }
       }
     });
+    return forcedHoists;
   }
 
   // Check whether we can propagate srcEnc through all transitive users of the

--- a/test/TLX/remove-layout-autows-budget.mlir
+++ b/test/TLX/remove-layout-autows-budget.mlir
@@ -1,0 +1,74 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-remove-layout-conversions="smem-budget=232448" | FileCheck %s --check-prefix=OVER
+// RUN: triton-opt %s -split-input-file -tritongpu-remove-layout-conversions="smem-budget=300000" | FileCheck %s --check-prefix=UNDER
+
+// Reduced from Tutorial 09's B200 AutoWS persistent-matmul configuration. Its
+// live multibuffers and auxiliary workspace consume 229376 bytes of SMEM. The
+// layout conversion needs 16384 bytes of scratch, so 229376 + 16384 exceeds
+// the real 232448-byte device budget.
+
+// OVER-LABEL: @tutorial09_autows_budget
+// OVER-COUNT-6: ttg.local_alloc
+// OVER: tt.return
+
+#linear_tmem = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 32]], warp = [[16, 0], [32, 0], [0, 64]], block = []}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared64 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#shared_out = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#shared_aux = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tutorial09_autows_budget(
+      %arg0: tensor<64x128xf32, #linear_tmem>,
+      %local: !ttg.memdesc<64x128xbf16, #shared_out, #smem>,
+      %out0: !ttg.memdesc<64x128xf32, #shared_out, #smem, mutable>,
+      %out1: !ttg.memdesc<64x128xf32, #shared_out, #smem, mutable>) ->
+      (!ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>,
+       !ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>,
+       !ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>,
+       !ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>,
+       !ttg.memdesc<3x128x32xf16, #shared64, #smem, mutable>,
+       !ttg.memdesc<8192xi8, #shared_aux, #smem, mutable>) {
+    %a0 = ttg.local_alloc : () -> !ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>
+    %a1 = ttg.local_alloc : () -> !ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>
+    %epilogue0 = ttg.local_alloc : () -> !ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>
+    %epilogue1 = ttg.local_alloc : () -> !ttg.memdesc<3x128x32xf16, #shared64, #smem, mutable>
+    %aux = ttg.local_alloc : () -> !ttg.memdesc<8192xi8, #shared_aux, #smem, mutable>
+    %converted = ttg.convert_layout %arg0 : tensor<64x128xf32, #linear_tmem> -> tensor<64x128xf32, #blocked>
+    %load = ttg.local_load %local : !ttg.memdesc<64x128xbf16, #shared_out, #smem> -> tensor<64x128xbf16, #blocked>
+    %ext = arith.extf %load : tensor<64x128xbf16, #blocked> to tensor<64x128xf32, #blocked>
+    %sub = arith.subf %converted, %ext : tensor<64x128xf32, #blocked>
+    ttg.local_store %sub, %out0 : tensor<64x128xf32, #blocked> -> !ttg.memdesc<64x128xf32, #shared_out, #smem, mutable>
+    %neg = arith.negf %ext : tensor<64x128xf32, #blocked>
+    ttg.local_store %neg, %out1 : tensor<64x128xf32, #blocked> -> !ttg.memdesc<64x128xf32, #shared_out, #smem, mutable>
+    tt.return %a0, %a1, %b, %epilogue0, %epilogue1, %aux : !ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<3x128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<3x128x32xf16, #shared64, #smem, mutable>, !ttg.memdesc<8192xi8, #shared_aux, #smem, mutable>
+  }
+}
+
+// -----
+
+// A non-binding budget must retain the profitability gate and avoid cloning
+// the layer-normalization reduction.
+
+// UNDER-LABEL: @nonbinding_budget_keeps_cost_gate
+// UNDER: "tt.reduce"(
+// UNDER-NOT: "tt.reduce"(
+// UNDER: tt.return
+
+#src = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [1, 2], order = [1, 0]}>
+#dst = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [2, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @nonbinding_budget_keeps_cost_gate(%arg0: tensor<16x512xf32, #src>) -> (tensor<16x512xf32, #src>, tensor<16x512xf32, #dst>) {
+    %sum = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %add = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %add : f32
+    }) : (tensor<16x512xf32, #src>) -> tensor<16xf32, #ttg.slice<{dim = 1, parent = #src}>>
+    %expanded = tt.expand_dims %sum {axis = 1 : i32} : tensor<16xf32, #ttg.slice<{dim = 1, parent = #src}>> -> tensor<16x1xf32, #src>
+    %broadcast = tt.broadcast %expanded : tensor<16x1xf32, #src> -> tensor<16x512xf32, #src>
+    %centered = arith.subf %arg0, %broadcast : tensor<16x512xf32, #src>
+    %converted = ttg.convert_layout %centered : tensor<16x512xf32, #src> -> tensor<16x512xf32, #dst>
+    tt.return %centered, %converted : tensor<16x512xf32, #src>, tensor<16x512xf32, #dst>
+  }
+}

--- a/test/TLX/remove-layout-budget-convert.mlir
+++ b/test/TLX/remove-layout-budget-convert.mlir
@@ -1,27 +1,21 @@
 // RUN: triton-opt %s -split-input-file -tritongpu-remove-layout-conversions="smem-budget=1" | FileCheck %s
 
-// Test that the budget-aware convert elimination correctly handles a local_load
-// chain where a value has users with different encoding requirements.
+// Test that a nonzero budget does not force elimination of a conversion that
+// needs no shared-memory scratch.
 //
 // Setup: a function argument anchored at #blocked_a feeds through a
 // convert_layout to #blocked_b. A local_load in #blocked_b feeds through
 // arith.extf into arith.subf (which also consumes the convert result) and
-// arith.negf. The pass should eliminate the convert without creating encoding
-// mismatches. The expected behavior is that backward rematerialization clones
-// the local_load chain so each user gets its preferred layout, avoiding any
-// convert_layout entirely.
+// arith.negf. The selected conversion is register-only, so it must retain the
+// normal profitability behavior even though the numeric budget is tiny.
 
 // CHECK-DAG: #[[$BLOCKED_A:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 // CHECK-DAG: #[[$BLOCKED_B:.*]] = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 // CHECK-LABEL: @local_load_chain_external_user
-// The local_load chain is cloned: one in #blocked_a for subf, one in #blocked_b for negf
-// CHECK: ttg.local_load %{{.*}} -> tensor<128x64xbf16, #[[$BLOCKED_A]]>
 // CHECK: ttg.local_load %{{.*}} -> tensor<128x64xbf16, #[[$BLOCKED_B]]>
-// CHECK: arith.extf {{.*}} : tensor<128x64xbf16, #[[$BLOCKED_A]]> to tensor<128x64xf32, #[[$BLOCKED_A]]>
 // CHECK: arith.extf {{.*}} : tensor<128x64xbf16, #[[$BLOCKED_B]]> to tensor<128x64xf32, #[[$BLOCKED_B]]>
-// The subf operates in #blocked_a (matching its function argument operand)
+// CHECK: ttg.convert_layout {{.*}} : tensor<128x64xf32, #[[$BLOCKED_B]]> -> tensor<128x64xf32, #[[$BLOCKED_A]]>
 // CHECK: arith.subf {{.*}} : tensor<128x64xf32, #[[$BLOCKED_A]]>
-// The external user (negf) keeps #blocked_b — no encoding mismatch
 // CHECK: arith.negf {{.*}} : tensor<128x64xf32, #[[$BLOCKED_B]]>
 
 #blocked_a = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>


### PR DESCRIPTION
Summary:
The terminal `RemoveLayoutConversions` pass forwarded any nonzero SMEM budget as a blanket force flag to earlier and final hoisting. This could clone expensive reduction slices even when `baseSmem + scratchBytes` stayed within the device budget.

Keep normal layout-conversion hoists behind the profitability gate. After Phase 5 applies the byte-budget classifier, force hoisting only for conversions that are actually over budget and cannot be eliminated by layout propagation. Add beta lit coverage for binding AutoWS budgets, non-binding reduction layouts, and register-only conversions.

This fixes a bug where the SMEM based layout fix was only supposed to apply to OOM cases, but was being applied otherwise and regressing TLX layer norm on the release.

Differential Revision: D115658500


