### PR TITLE
[TLX][AMD] Fix negative LDS buffer index in amd_gemm_pipelined (#2816)

### DIFF
--- a/third_party/tlx/tutorials/amd_gemm_pipelined.py
+++ b/third_party/tlx/tutorials/amd_gemm_pipelined.py
@@ -193,8 +193,14 @@ def matmul_kernel_pipelined_mi300(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, strid
         b_k_smem_view = tlx.local_view(buffers_B, k % NUM_BUFFERS)
         a_load_reg = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K)
 
-        # do compute on data fetched ahead by NUM_STAGES - 1
-        buf = (k - NUM_STAGES - 1) % NUM_BUFFERS
+        # Compute on the tile fetched NUM_STAGES - 1 iterations ago, i.e. tile
+        #   k - (NUM_STAGES - 1) == k - NUM_BUFFERS
+        # since NUM_BUFFERS is defined as NUM_STAGES - 1 above. Buffers rotate
+        # modulo NUM_BUFFERS, so that tile sits in buffer
+        #   (k - NUM_BUFFERS) % NUM_BUFFERS == k % NUM_BUFFERS
+        # and it is read here before the local_store below refills the same
+        # buffer with tile k.
+        buf = k % NUM_BUFFERS
         a_k_prev_shmem = tlx.local_view(buffers_A, buf)
         b_k_prev_shmem = tlx.local_view(buffers_B, buf)
         a_k_prev_reg = tlx.local_load(a_k_prev_shmem)


### PR DESCRIPTION
Summary:

`matmul_kernel_pipelined_mi300` picks the buffer to feed `tl.dot` with

    buf = (k - NUM_STAGES - 1) % NUM_BUFFERS

The main loop starts at `k = NUM_STAGES - 1`, so the numerator is negative on
the first iterations. Triton's `%` lowers to `arith.remsi`, whose sign follows
the dividend, so this evaluates to a *negative* buffer index and `local_view`
reads the wrong tile.

The bug is dormant today because every shipped config in `hip_configs` uses
`NUM_STAGES = 2`, giving `NUM_BUFFERS = 1`, and `remsi(x, 1)` is always 0.
It fires for any `NUM_STAGES >= 3`.

The correct index is simply `k % NUM_BUFFERS`: with
`NUM_BUFFERS = NUM_STAGES - 1`, buffer `k % NUM_BUFFERS` holds tile
`k - NUM_BUFFERS`, which is the tile due at iteration `k`, and it is read
before being overwritten later in the same iteration.

Note that deeper pipelining is not a win on gfx942 even once it is correct --
measured at 4096^3, `128x128x64` drops 396 -> 374 TFLOPS going from
`NUM_STAGES` 2 to 3, and `128x128x32` drops 371 -> 368 -> 320 -> 294 across
`NUM_STAGES` 2/3/4/5. The extra LDS copies cost occupancy without buying
overlap, because this kernel prefetches into registers (`tl.load` +
`tlx.local_store`), not into LDS. So `hip_configs` and
`get_hip_autotune_config_full` are intentionally left at `NUM_STAGES = 2`;
this change only makes the deeper settings correct if someone opts into them.

Reviewed By: wlei-llvm

Differential Revision: D115318954


