### PR TITLE
[TLX] Fix clc_response memdesc type mismatch across tt.call

### DIFF
--- a/python/test/unit/language/test_tlx_cluster.py
+++ b/python/test/unit/language/test_tlx_cluster.py
@@ -715,6 +715,88 @@ def test_cluster_launch_control_multi_cta_delayed_exit(device):
     torch.testing.assert_close(output, ref_out)
 
 
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+@pytest.mark.parametrize("noinline", [False, True])
+def test_cluster_launch_control_across_call(noinline, device):
+    """CLC state crossing a tt.call boundary.
+
+    The callee's parameter type is rebuilt from the frontend `clc_response_type`,
+    so it must match the `ui128` memdesc that `create_alloc_clc_responses`
+    allocates. When it did not, this failed TTIR verification with
+    "'tt.call' op operand type mismatch: expected ... 1xi64 ... provided ... 1xui128".
+    """
+
+    # Wrapping the `clc_consumer` builtin in a @triton.jit function is what forces
+    # a real tt.call: builtins expand inline at trace time, so only a jit callee
+    # gets a signature rebuilt from the frontend types.
+    @triton.jit(noinline=noinline)
+    def clc_consumer_callee(clc_context, clc_phase_consumer):
+        return tlx.clc_consumer(clc_context, clc_phase_consumer)
+
+    @triton.jit
+    def clc_call_kernel(
+        x_ptr,
+        y_ptr,
+        z_ptr,
+        n_elements,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        tile_id = tl.program_id(axis=0)
+        clc_phase_producer = 1
+        clc_phase_consumer = 0
+        clc_context = tlx.clc_create_context(1)
+
+        while tile_id != -1:
+            tlx.clc_producer(clc_context, clc_phase_producer)
+            clc_phase_producer ^= 1
+
+            block_start = tile_id * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(x_ptr + offsets, mask=mask)
+            y = tl.load(y_ptr + offsets, mask=mask)
+            tl.store(z_ptr + offsets, x + y, mask=mask)
+
+            # The whole CLCPipelineContext (mbarriers + clc_response) crosses the call.
+            tile_id = clc_consumer_callee(clc_context, clc_phase_consumer)
+            clc_phase_consumer ^= 1
+
+    BLOCK_SIZE = 1024
+    n_elements = BLOCK_SIZE * 16
+    x = torch.randn(n_elements, device=device)
+    y = torch.randn(n_elements, device=device)
+    output = torch.zeros_like(x)
+    grid = (triton.cdiv(n_elements, BLOCK_SIZE), )
+
+    kernel = clc_call_kernel[grid](x, y, output, n_elements, BLOCK_SIZE=BLOCK_SIZE, launch_cooperative_grid=True)
+
+    if noinline:
+        # The callee only survives the TTIR inliner when marked noinline. Pin
+        # its clc_response parameter to the `ui128` memdesc so a regression
+        # fails here rather than as an opaque verifier error.
+        callee_sigs = [line for line in kernel.asm["ttir"].splitlines() if line.lstrip().startswith("tt.func private")]
+        assert callee_sigs, "expected the noinline callee to survive the TTIR inliner"
+        assert any("ui128" in sig for sig in callee_sigs), callee_sigs
+
+    assert re.search(r"clusterlaunchcontrol.try_cancel", kernel.asm["ptx"])
+    torch.testing.assert_close(output, x + y)
+
+
+def test_clc_response_type_mangle():
+    """`clc_response_type` must not share a mangled name with `mbarrier_type`.
+
+    Both carry a placeholder `tl.int64` element type (Triton has no 128-bit
+    dtype), so the inherited `buffered_tensor_type.mangle` collapses them to the
+    same string for a given shape. A clc_response lowers to a `ui128` memdesc
+    and an mbarrier to an `i64` one, so that collision would let the `tt.func`
+    generated for one be reused from the JIT cache for the other.
+    """
+    for num in (0, 1):
+        clc_mangle = tlx.clc_response_type(num, None).mangle()
+        mbar_mangle = tlx.mbarrier_type(num, None, tlx.storage_kind.smem).mangle()
+        assert clc_mangle != mbar_mangle, f"num={num}: {clc_mangle}"
+
+
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper or newer for cluster sync")
 def test_explicit_cluster_sync_ws(device):
     """Test explicit cluster_barrier() behavior in WS mode.

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -37,6 +37,15 @@ namespace tlx = triton::tlx;
 namespace amdgpu = triton::amdgpu;
 namespace ttag = triton::amdgpu;
 
+// Element type of a CLC (Cluster Launch Control) response buffer. A CLC
+// response is a 16-byte opaque hardware object, so each stage is stored as one
+// `ui128`. Single source of truth: both `create_alloc_clc_responses` and the
+// `get_clc_response_element_ty` binding used by `tlx.clc_response_type.to_ir()`
+// go through here so the allocation and the frontend type can never diverge.
+static mlir::Type getCLCResponseElementType(mlir::OpBuilder &builder) {
+  return builder.getIntegerType(128, /*signed=*/false);
+}
+
 // Construct a CGAEncodingAttr from legacy (CTAsPerCGA, CTASplitNum, CTAOrder)
 // params. The single-CTA case must go through get1CTALayout: feeding all-1
 // params to CGAEncodingAttr::fromSplitParams builds a layout whose out-dims
@@ -1074,14 +1083,25 @@ void init_triton_tlx_ir(py::module &&m) {
              // This links the storage_alias_spec to the reuse_group tree
              self.create<tlx::SetBufferOverlapOp>(storageAliasSpec, overlapDef);
            })
+      // The element type of a CLC response buffer. A CLC response is a 16-byte
+      // opaque hardware object, so it is stored as one `ui128` per stage. This
+      // is exposed to Python so that `tlx.clc_response_type.to_ir()` rebuilds
+      // the exact same memdesc type as `create_alloc_clc_responses` below --
+      // any divergence only shows up when a CLC context crosses a `tt.call`
+      // (a CLC context passed into a @triton.jit helper), where the callee's
+      // parameter type is rebuilt from the frontend type and TTIR verification
+      // then fails with a `tt.call` operand type mismatch.
+      .def("get_clc_response_element_ty",
+           [](TritonOpBuilder &self) -> Type {
+             return getCLCResponseElementType(self.getBuilder());
+           })
       .def("create_alloc_clc_responses",
            [](TritonOpBuilder &self, int numResponses,
               Attribute clcResEncoding) -> mlir::Value {
              auto context = self.getBuilder().getContext();
              auto memorySpace = ttg::SharedMemorySpaceAttr::get(context);
              auto memDescType = ttg::MemDescType::get(
-                 {numResponses},
-                 self.getBuilder().getIntegerType(128, /*signed=*/false),
+                 {numResponses}, getCLCResponseElementType(self.getBuilder()),
                  clcResEncoding, memorySpace, /*mutableMemory=*/true);
 
              mlir::Value bufferViews =

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -1356,11 +1356,21 @@ class clc_response_type(buffered_tensor_type):
     # both of which are opaque objects with fixed size
 
     def __init__(self, num: int, layout: Optional[swizzled_shared_layout_encoding]):
+        # A CLC response is a 16-byte opaque hardware object, i.e. one `ui128`
+        # per stage. Triton has no 128-bit `tl.dtype`, so the base class is
+        # given `tl.int64` as a placeholder and `to_ir` below builds the real
+        # element type through the builder instead of from `self.element_ty`.
         super().__init__(tl.int64, [1], num, storage_kind.smem, layout)
 
     def _unflatten_ir(self, handles: List[ir.value], cursor: int) -> Tuple[clc_response, int]:
         value = clc_response(handles[cursor], self.num, self.layout)
         return value, cursor + 1
+
+    def mangle(self) -> str:
+        # Distinct from buffered_tensor_type/mbarrier_type, whose mangles are
+        # derived from the (placeholder) int64 element type and would otherwise
+        # collide with this one for the same shape.
+        return f"clc_response_{self.num}"
 
     def to_ir(self, builder: ir.builder) -> None:
         if self.num >= 1:
@@ -1369,7 +1379,13 @@ class clc_response_type(buffered_tensor_type):
             shape = self.shape
         return builder.get_memdesc_type(
             shape,
-            self.element_ty.to_ir(builder),
+            # NOT self.element_ty: the allocation created by
+            # create_alloc_clc_responses uses `ui128`. Using the placeholder
+            # int64 here builds a different memdesc type whenever this type is
+            # reconstructed -- notably for a @triton.jit callee's parameter when
+            # a CLC context crosses a tt.call -- which fails TTIR verification
+            # with a `tt.call` operand type mismatch.
+            builder.get_clc_response_element_ty(),
             self.layout.to_ir(builder),
             self.storage.value,
         )


### PR DESCRIPTION
A CLC response is allocated as a `ui128` memdesc, but the frontend `clc_response_type` carries `tl.int64` as a placeholder element type because Triton has no 128-bit dtype. `to_ir` built the memdesc from that placeholder, so the reconstructed type diverged from the allocation. The only path that reconstructs it is a `tt.call`: passing a CLC context into a @triton.jit helper builds the callee signature from the frontend types while the call operands carry the real handles, failing TTIR verification with a `tt.call` operand type mismatch.

`to_ir` now builds the element type through a new builder binding that shares a single source of truth with `create_alloc_clc_responses`, and `clc_response_type` gets its own mangle so it can no longer collide with `mbarrier_type` in the JIT function cache.

## Test plan

`pytest python/test/unit/language/test_tlx_cluster.py`

Authored with Claude.