### PR TITLE
[Triton][docs] Document masked async_load behavior on MI350X

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,10 @@ Binary wheels are available for CPython 3.10-3.14.
 
    The operation returns a token object which can be used to track the completion of the operation.
 
+   **MI350X caveat:** When `mask` is provided, callers should also provide `other`—typically `0.0` for numerical kernels. Elements for which `mask=True` are copied from global memory into the destination local buffer. For elements where `mask=False`, `other` is written only if it is provided. Otherwise, the corresponding LDS locations retain unspecified, potentially stale contents from an earlier use of the buffer.
+
+   For example, in FlashAttention, when the sequence length is not a multiple of `BLOCK_N`, the final `V` tile contains masked-out rows. If `other` is omitted, those rows may contain unspecified values, including bit patterns representing NaN or infinity. These values can propagate through the subsequent matrix multiplication and produce incorrect output. Use `other=0.0` for such padded tiles.
+
 
 - `tlx.async_load_commit_group(tokens)` **[Hopper+, MI350]**
 


### PR DESCRIPTION
Summary: Document that masked tlx.async_load operations on MI350X should provide an `other` value to initialize masked-out LDS locations. Include a FlashAttention example explaining the possible correctness impact.

Reviewed By: wlei-llvm

Differential Revision: D115743419


