### PR TITLE
[triton][autotuner] Fix ctas_per_cga dropped on steady-state C fast-dispatch path (#2820)

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -1029,6 +1029,8 @@ class JITFunction(JITCallable, KernelInterface[T]):
                 reasons.append("pre_run_hooks active")
             if knobs.compilation.always_compile:
                 reasons.append("always_compile=True")
+            if self.used_global_vals:
+                reasons.append("used_global_vals non-empty")
             if knobs.runtime.add_stages_inspection_hook is not None:
                 reasons.append("add_stages_inspection_hook active")
             if knobs.runtime.launch_enter_hook:
@@ -1043,6 +1045,18 @@ class JITFunction(JITCallable, KernelInterface[T]):
                 stacklevel=2,
             )
         _user_kwargs = dict(kwargs) if kwargs else {}
+        # When the autotuner seeds the C fast-dispatch cache it stores the
+        # winning config's compilation options (num_warps, ctas_per_cga, …) in
+        # _fc_meta_kwargs. The steady-state autotuner path dispatches via
+        # self.fn[grid](*args) WITHOUT those kwargs. If the C cache misses (new
+        # argument specialization), we fall through to here and need the options
+        # for a correct recompilation. Merge them as defaults so callers that
+        # explicitly pass kwargs still win.
+        _fc_meta = getattr(self, '_fc_meta_kwargs', None)
+        if _fc_meta:
+            for k, v in _fc_meta.items():
+                if k not in kwargs:
+                    kwargs[k] = v
         kwargs["debug"] = kwargs.get("debug", self.debug) or knobs.runtime.debug
         # Enable sanitize_overflow if explicitly set via kwarg, env var (TRITON_SANITIZE_OVERFLOW), or if debug is enabled
         kwargs["sanitize_overflow"] = kwargs.get("sanitize_overflow",


### PR DESCRIPTION
Summary:

The autotuner C fast-dispatch cache seeds once per autotune key
(`_fc_seeded`, `_try_fast_path`). After seeding, the steady-state path
dispatches via `self.fn[grid](*args)` WITHOUT the winning config's
compilation options (`ctas_per_cga`, `num_warps`, etc.).

When `__getitem__` returns the lambda fallback (e.g. because
`used_global_vals` is non-empty — any kernel referencing a module-level
global), `JITFunction.run()` is called without meta kwargs. If the
Python kernel cache misses (the cache key includes compilation options,
so a key built without `ctas_per_cga` won't match one built with it),
the kernel is recompiled without cluster configuration and
`cuLaunchKernelEx` fails with error 912 ("cluster misconfiguration").

A second trigger: for single-config autotune, `_last_key` is only set
in the multi-config branch of `Autotuner.run()`, so `_seed_key` is
always `None`. After the first call seeds (adding `None` to
`_fc_seeded`), *every* subsequent call — regardless of shape or autotune
key — goes straight to the steady-state path.

D115592517 worked around this by bypassing `triton.autotune` entirely
for 2-CTA kernels, launching `JITFunction.run()` directly with explicit
meta kwargs. This diff fixes the root cause so `triton.autotune` +
`ctas_per_cga` works correctly.

**Fix:** In `JITFunction.run()`, before the binder parses options, merge
`_fc_meta_kwargs` (stored by the autotuner during seed) into `kwargs` as
defaults. Callers that explicitly pass kwargs still win (`if k not in
kwargs`). This only runs on the slow/compilation path — C cache hits
never reach this code.

**Bonus:** The "C fast path bypassed: unknown reason" warning was missing
`used_global_vals` in its reasons list. Added it so the warning now says
"used_global_vals non-empty" instead of "unknown reason".

Reviewed By: htyu

Differential Revision: D115755448


