### PR TITLE
[AMD] Diagnose unsupported multi-pair padding in TDM loads

### DIFF
--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -227,6 +227,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     amdg.async_tdm_copy_local_to_global %tensorDesc from %memDesc: !ttg.memdesc<128x64xf16, #shared_2_intervals, #smem, mutable> -> !tt.tensordesc<128x64xf16>
     tt.return
   }
+
+  tt.func public @tdm_load_two_padding_intervals(
+    %tensorDesc: !tt.tensordesc<128x64xf16>,
+    %memDesc: !ttg.memdesc<128x64xf16, #shared_2_intervals, #smem, mutable>
+  ) {
+    // expected-error @+1 {{TDM load only supports a single interval-padding pair}}
+    %0 = amdg.async_tdm_copy_global_to_local %tensorDesc into %memDesc : !tt.tensordesc<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared_2_intervals, #smem, mutable>
+    tt.return
+  }
 }
 
 // -----

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -1028,6 +1028,13 @@ LogicalResult AsyncTDMCopyGlobalToLocalOp::verify() {
   if (!paddedEnc && !swizzledEnc && !partitionedEnc)
     return emitOpError("Invalid shared memory layout for TDM");
 
+  if (auto effectivePadded = gpu::getPaddedEncoding(enc)) {
+    if (effectivePadded.getIntervals().size() != 1 ||
+        effectivePadded.getPaddings().size() != 1)
+      return emitOpError(
+          "TDM load only supports a single interval-padding pair");
+  }
+
   Type elementType = smemTy.getElementType();
   auto elementBitWidth = elementType.getIntOrFloatBitWidth();
   if (paddedEnc) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1265,8 +1265,9 @@ struct AsyncTDMCopyGlobalToLocalOpConversion
     unsigned padInterval = 0;
     unsigned padAmount = 0;
     if (auto padEnc = getPaddedEncoding(encoding)) {
-      assert(padEnc.getIntervals().size() == 1 &&
-             padEnc.getPaddings().size() == 1);
+      if (padEnc.getIntervals().size() != 1 || padEnc.getPaddings().size() != 1)
+        return op.emitOpError(
+            "TDM load only supports a single interval-padding pair");
       padInterval = padEnc.getIntervals()[0];
       padAmount = padEnc.getPaddings()[0];
     }


### PR DESCRIPTION
The gfx1250 TDM descriptor encodes one padding interval and one padding amount, while padded shared layouts may contain multiple interval-padding pairs. Ordinary TDM loads currently accept such layouts in verification and then hit an assertion when LLVM lowering indexes the single hardware fields.

Reject multiple pairs using the effective padded encoding at the dialect boundary, including padded layouts nested under partitioned shared encodings. Retain the same check in LLVM lowering as a defensive diagnostic instead of an assertion.

Add an invalid-IR regression beside the existing TDM-store padding coverage.

Extracted from https://github.com/facebookexperimental/triton/pull/2773