### PR TITLE
[Feature-Fix] [triton][NVIDIA] Gate mbarrier multicast on PTX support (#2823)

### DIFF
--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -2,6 +2,7 @@
 // RUN: triton-opt %s -split-input-file --nvgpu-tma-store-token-wait-lowering --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=85' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=85' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX85 %s
 // RUN: triton-opt %s -split-input-file --nvgpu-tma-store-token-wait-lowering --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=86' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=86' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX86 %s
 // RUN: triton-opt %s -split-input-file --nvgpu-tma-store-token-wait-lowering --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=88' --initialize-ws-cluster-barriers='compute-capability=90 ptx-version=88' -reconcile-unrealized-casts | FileCheck --check-prefix=PTX88 %s
+// RUN: triton-opt %s -split-input-file --nvgpu-tma-store-token-wait-lowering --convert-triton-gpu-to-llvm='compute-capability=107 ptx-version=87' --initialize-ws-cluster-barriers='compute-capability=107 ptx-version=87' -reconcile-unrealized-casts | FileCheck --check-prefix=RUBIN-PTX87 %s
 // RUN: triton-opt %s -split-input-file --nvgpu-tma-store-token-wait-lowering --convert-triton-gpu-to-llvm='compute-capability=107 ptx-version=94' --initialize-ws-cluster-barriers='compute-capability=107 ptx-version=94' -reconcile-unrealized-casts | FileCheck --check-prefix=RUBIN %s
 
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
@@ -207,8 +208,14 @@ module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.num-ctas" = 2 : i32, "ttg
     // CHECK: fence.mbarrier_init.release.cluster
     // CHECK: nvvm.cluster.arrive.relaxed
     // CHECK-NEXT: nvvm.cluster.wait
-    // CHECK: mbarrier.arrive.release.cluster.shared::cluster.multicast::cluster::32b.b64 _, [${{.*}}], ${{.*}};
+    // CHECK-COUNT-2: mbarrier.arrive.release.cluster.shared::cluster.b64 _, [${{.*}}];
+    // CHECK-NOT: multicast::cluster::32b
     // CHECK-NOT: mbarrier.arrive.release.cluster.shared::cta.b64
+    // RUBIN-PTX87-LABEL: arrive_barrier_multicast
+    // RUBIN-PTX87-COUNT-2: mbarrier.arrive.release.cluster.shared::cluster.b64 _, [${{.*}}];
+    // RUBIN-PTX87-NOT: multicast::cluster::32b
+    // RUBIN-LABEL: arrive_barrier_multicast
+    // RUBIN: mbarrier.arrive.release.cluster.shared::cluster.multicast::cluster::32b.b64 _, [${{.*}}], ${{.*}};
     ttng.init_barrier %alloc, 1 : !ttg.memdesc<2xi64, #shared0, #smem, mutable>
     ttng.arrive_barrier %alloc, 1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64, #shared0, #smem, mutable>
     tt.return
@@ -1138,6 +1145,11 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
   // RUBIN-COUNT-1: mbarrier.arrive.release.cluster.shared::cluster.multicast::cluster::32b.b64 _, [$1], $2;
   // RUBIN-NOT: mbarrier.arrive
   // RUBIN: mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64
+  // RUBIN-PTX87-LABEL: @cluster_barrier_inside_warp_specialize_rubin
+  // RUBIN-PTX87: %[[RAW_TID:.*]] = nvvm.read.ptx.sreg.tid.x
+  // RUBIN-PTX87: %[[ARRIVE_PRED:.*]] = llvm.icmp "ult"
+  // RUBIN-PTX87-COUNT-1: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // RUBIN-PTX87-NOT: multicast::cluster::32b
   tt.func @cluster_barrier_inside_warp_specialize_rubin() {
     ttg.warp_specialize()
     default {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -383,7 +383,13 @@ struct WaitBarrierOpConversion
 
 struct ArriveBarrierOpConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::ArriveBarrierOp> {
-  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  const NVIDIA::TargetInfo *targetInfo;
+
+  ArriveBarrierOpConversion(LLVMTypeConverter &typeConverter,
+                            PatternBenefit benefit,
+                            const NVIDIA::TargetInfo &targetInfo)
+      : ConvertOpToLLVMPattern(typeConverter, benefit),
+        targetInfo(&targetInfo) {}
 
   LogicalResult
   matchAndRewrite(triton::nvidia_gpu::ArriveBarrierOp op, OpAdaptor adaptor,
@@ -457,42 +463,60 @@ struct ArriveBarrierOpConversion
       Value barrierPtr = LLVM::NVIDIA::getLeaderAddress(
           loc, rewriter, smemObj.getBase(), barrierTy);
 
-      std::stringstream ptxAsm;
-      ptxAsm << "@$0 mbarrier.arrive.";
-      if (op.isMulticast())
-        ptxAsm << "release.cluster.";
-      ptxAsm << (isRemoteBarrier || isCrossCluster || op.isMulticast()
-                     ? "shared::cluster"
-                     : "shared::cta");
-      if (op.isMulticast())
-        ptxAsm << ".multicast::cluster::32b";
-      ptxAsm << ".b64 _, [$1]";
-      if (op.getCount() > 1) {
-        ptxAsm << ", " << op.getCount();
-      }
-      if (op.isMulticast())
-        ptxAsm << ", $2";
-      ptxAsm << ";";
-
       Value id = getThreadId(rewriter, loc);
       Value pred = b.icmp_eq(id, b.i32_val(0));
       if (op.getPred())
         pred = b.and_(pred, adaptor.getPred());
 
-      PTXBuilder ptxBuilder;
-      SmallVector<PTXBuilder::Operand *, 3> operands = {
-          ptxBuilder.newOperand(pred, "b"),
-          ptxBuilder.newOperand(barrierPtr, "r")};
-      if (op.isMulticast()) {
+      auto emitArrive = [&](Value targetBarrier, Value multicastMask = {}) {
+        std::stringstream ptxAsm;
+        ptxAsm << "@$0 mbarrier.arrive.";
+        if (op.isMulticast())
+          ptxAsm << "release.cluster.";
+        ptxAsm << (isRemoteBarrier || isCrossCluster || op.isMulticast()
+                       ? "shared::cluster"
+                       : "shared::cta");
+        if (multicastMask)
+          ptxAsm << ".multicast::cluster::32b";
+        ptxAsm << ".b64 _, [$1]";
+        if (op.getCount() > 1)
+          ptxAsm << ", " << op.getCount();
+        if (multicastMask)
+          ptxAsm << ", $2";
+        ptxAsm << ";";
+
+        PTXBuilder ptxBuilder;
+        SmallVector<PTXBuilder::Operand *, 3> operands = {
+            ptxBuilder.newOperand(pred, "b"),
+            ptxBuilder.newOperand(targetBarrier, "r")};
+        if (multicastMask)
+          operands.push_back(ptxBuilder.newOperand(multicastMask, "r"));
+        auto arriveOp = *ptxBuilder.create<>(ptxAsm.str());
+        arriveOp(operands, /*onlyAttachMLIRArgs=*/true);
+        ptxBuilder.launch(rewriter, loc, void_ty(getContext()));
+      };
+
+      if (op.isMulticast() && targetInfo->supportsMbarrierMulticast()) {
         Value mask = LLVM::NVIDIA::createTMAMulticastMask(
             loc, rewriter, static_cast<uint16_t>(op.getCtaMask()));
-        operands.push_back(ptxBuilder.newOperand(mask, "r"));
+        emitArrive(barrierPtr, mask);
+      } else if (op.isMulticast()) {
+        Value barrierInt = b.ptrtoint(i32_ty, barrierPtr);
+        uint32_t broadcastMask = op.getCtaMask();
+        uint32_t ctaOffset = broadcastMask;
+        while (true) {
+          Value targetBarrierInt =
+              b.xor_(barrierInt, b.i32_val(ctaOffset << 24));
+          Value targetBarrier =
+              b.inttoptr(barrierPtr.getType(), targetBarrierInt);
+          emitArrive(targetBarrier);
+          if (ctaOffset == 0)
+            break;
+          ctaOffset = (ctaOffset - 1) & broadcastMask;
+        }
+      } else {
+        emitArrive(barrierPtr);
       }
-
-      auto arriveOp = *ptxBuilder.create<>(ptxAsm.str());
-      arriveOp(operands, /*onlyAttachMLIRArgs=*/true);
-      auto voidTy = void_ty(getContext());
-      ptxBuilder.launch(rewriter, loc, voidTy);
     }
 
     rewriter.eraseOp(op);
@@ -894,7 +918,7 @@ void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
       typeConverter, benefit, targetInfo);
   patterns.add<WaitBarrierOpConversion>(typeConverter, benefit, targetInfo);
   patterns.add<BarrierExpectConversion>(typeConverter, benefit);
-  patterns.add<ArriveBarrierOpConversion>(typeConverter, benefit);
+  patterns.add<ArriveBarrierOpConversion>(typeConverter, benefit, targetInfo);
   // Meta Triton CLC + named-barrier + vote-ballot patterns
   patterns.add<NamedBarrierArriveOpConversion>(typeConverter, benefit);
   patterns.add<NamedBarrierWaitOpConversion>(typeConverter, benefit);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -319,7 +319,7 @@ struct ClusterBarrierOpConversion
     Value pred = b.icmp_eq(threadId, b.i32_val(0));
     int numCTAs = triton::gpu::lookupNumCTAs(op);
     bool relaxed = op.getRelaxed() && targetInfo.getPtxVersion() >= 86;
-    if (targetInfo.getTargetFeatures().supportsMbarMulticast()) {
+    if (targetInfo.supportsMbarrierMulticast()) {
       Value ctaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
       // Exclude the issuing CTA: the mbarriers expect numCTAs - 1 arrivals.
       Value peerMask =

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -98,6 +98,10 @@ public:
   int getComputeCapability() const {
     return targetFeatures.getComputeCapability();
   }
+  bool supportsMbarrierMulticast() const {
+    // mbarrier.arrive.multicast was introduced in PTX 9.4 for Rubin.
+    return targetFeatures.supportsMbarMulticast() && ptxVersion >= 94;
+  }
   const triton::nvidia_gpu::TargetFeatures &getTargetFeatures() const {
     return targetFeatures;
   }


### PR DESCRIPTION
Summary:

Gate `mbarrier.arrive.multicast::cluster::32b` on both Rubin hardware and PTX 9.4 support. Direct multicast barrier arrivals now fall back to one cluster-scoped remote arrival per CTA in the static broadcast group when the selected PTX toolchain does not support the masked instruction. The existing warp-specialized cluster-barrier lowering uses the same combined capability check.

Reviewed By: warrendeng

Differential Revision: D115782537


