### PR TITLE
Support register budgets for TLX default async tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,9 +814,33 @@ Examples: how mbarriers are communicated in warp specialization
 |-----------|-------------|
 | `"default"` | First positional argument to mark this as the default/trunk task |
 | `num_warps` | Number of warps to reserve for this task |
-| `num_regs` | Number of registers per thread (optional, for register allocation tuning). When provided, it must be divisible by 8. |
+| `num_regs` | Number of registers per thread (optional, for register allocation tuning). It is supported by both default and non-default tasks and must be divisible by 8. |
 | `replicate` | Number of replicas for this task (default: 1). Creates multiple copies of the task region |
 | `warp_group_start_id` | Starting warp ID for this task (optional). Allows explicit control over warp assignment |
+
+#### Default Task Register Budget
+
+Register budgets are specified per thread. When the default task does not set
+`num_regs`, register allocation keeps the original donation model: non-default
+warp groups receive their requested budgets, and the default task receives the
+remaining registers.
+
+Setting `num_regs` on the default task selects a fixed budget instead:
+
+```python
+with tlx.async_tasks():
+    with tlx.async_task("default", num_regs=80):
+        ...
+    with tlx.async_task(num_warps=4, num_regs=24):
+        ...
+```
+
+In this example, the default and non-default tasks receive 80 and 24 registers
+per thread, respectively. The default task does not absorb unused registers.
+Non-default warp groups without an explicit budget evenly share the remaining
+register pool. If every task has a fixed budget, any surplus is left unused.
+The compiler may raise a request to the hardware or instrumentation safety
+minimum when required.
 
 #### Explicit Warp Assignment with warp_group_start_id
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -713,6 +713,7 @@ def TTG_WarpSpecializeOp
   let arguments = (ins DenseI32ArrayAttr:$partitionNumWarps,
       OptionalAttr<DenseI32ArrayAttr>:$warpGroupStartIds,
       OptionalAttr<DenseI32ArrayAttr>:$requestedRegisters,
+      OptionalAttr<I32Attr>:$defaultRequestedRegisters,
       OptionalAttr<DenseI32ArrayAttr>:$actualRegisters);
   let results = (outs Variadic<AnyType>:$defaultPassthrough);
 

--- a/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
@@ -170,7 +170,7 @@ struct AllocateWarpGroups
 
     bool needsRegisterOptimization = false;
     mod.walk([&](WarpSpecializeOp op) {
-      if (op.getRequestedRegisters())
+      if (op.getRequestedRegisters() || op.getDefaultRequestedRegisters())
         needsRegisterOptimization = true;
     });
 
@@ -210,13 +210,20 @@ struct AllocateWarpGroups
 
       // Require that an estimate has been set and that we have even warpgroups.
       auto regsAttr = op.getRequestedRegisters();
-      if (!regsAttr || op.getTotalPartitionWarps() % 4 != 0)
+      auto defaultRegsAttr = op.getDefaultRequestedRegisters();
+      if ((!regsAttr && !defaultRegsAttr) ||
+          op.getTotalPartitionWarps() % 4 != 0)
         return;
+
+      SmallVector<int32_t> requestedRegisters(arr.size(), -1);
+      if (regsAttr)
+        llvm::copy(*regsAttr, requestedRegisters.begin());
 
       // Group the partitions into warpgroups.
       SmallVector<WarpGroupPartition> orderedPartitions;
       for (auto [startId, partition, estRegs, numWarps] :
-           llvm::zip(startIds, op.getPartitionRegions(), *regsAttr, arr)) {
+           llvm::zip(startIds, op.getPartitionRegions(), requestedRegisters,
+                     arr)) {
         int minRegs =
             minRegistersForRegion(*partition, laterInstrumentation, estRegs);
         orderedPartitions.push_back({startId, partition, minRegs, numWarps});
@@ -244,77 +251,53 @@ struct AllocateWarpGroups
         warpGroups.back().numWarps += numWarps;
       }
 
-      // Check if any warp groups have the sentinel value (-1).
-      bool hasSentinelGroups =
-          llvm::any_of(warpGroups, [](const WarpGroupInfo &wg) {
-            return wg.maxRequestedRegs < 0;
-          });
-
       SmallVector<int32_t> maxnregsPerPartition(1 + arr.size());
 
-      if (!hasSentinelGroups) {
-        // All partitions have fixed register requests. Give leftover to
-        // the default partition (original behavior).
-        int registerBudget = maxnreg * baseNumWarps * threadsPerWarp;
-        for (const WarpGroupInfo &wg : warpGroups) {
-          assert(wg.numWarps % 4 == 0);
-          registerBudget +=
-              (maxnreg - wg.maxRequestedRegs) * wg.numWarps * threadsPerWarp;
-        }
-        if (registerBudget <= 0)
-          return;
+      int totalWarps = baseNumWarps;
+      for (const WarpGroupInfo &wg : warpGroups)
+        totalWarps += wg.numWarps;
+      int remainingRegs = maxnreg * totalWarps * threadsPerWarp;
+      int sharingThreads = 0;
 
-        int leftover = registerBudget / (baseNumWarps * threadsPerWarp);
-        leftover = leftover / 8 * 8;
-        if (leftover < minRegistersForRegion(op.getDefaultRegion(),
-                                             laterInstrumentation,
-                                             /*minRegisters=*/24))
-          return;
-
-        for (const WarpGroupInfo &wg : warpGroups) {
-          for (Region *region : wg.partitions)
-            maxnregsPerPartition[1 + region->getRegionNumber()] =
-                wg.maxRequestedRegs;
-        }
-        maxnregsPerPartition.front() = leftover;
+      int defaultRegs = -1;
+      if (defaultRegsAttr) {
+        defaultRegs = minRegistersForRegion(
+            op.getDefaultRegion(), laterInstrumentation, *defaultRegsAttr);
+        remainingRegs -= defaultRegs * baseNumWarps * threadsPerWarp;
       } else {
-        // Some warp groups are sentinel (-1). Fixed groups get their
-        // requested amount; sentinel groups and the default partition
-        // evenly split the remaining registers.
-        int totalWarps = baseNumWarps;
-        for (const WarpGroupInfo &wg : warpGroups)
-          totalWarps += wg.numWarps;
-        int totalRegs = maxnreg * totalWarps * threadsPerWarp;
+        sharingThreads += baseNumWarps * threadsPerWarp;
+      }
 
-        int fixedRegs = 0;
-        for (const WarpGroupInfo &wg : warpGroups) {
-          if (wg.maxRequestedRegs > 0)
-            fixedRegs += wg.maxRequestedRegs * wg.numWarps * threadsPerWarp;
-        }
-        int remainingRegs = totalRegs - fixedRegs;
-        if (remainingRegs <= 0)
+      for (const WarpGroupInfo &wg : warpGroups) {
+        assert(wg.numWarps % 4 == 0);
+        if (wg.maxRequestedRegs > 0)
+          remainingRegs -=
+              wg.maxRequestedRegs * wg.numWarps * threadsPerWarp;
+        else
+          sharingThreads += wg.numWarps * threadsPerWarp;
+      }
+      if (remainingRegs < 0)
+        return;
+
+      int sharedRegs = -1;
+      if (sharingThreads > 0) {
+        sharedRegs = remainingRegs / sharingThreads;
+        sharedRegs = sharedRegs / 8 * 8;
+        int minSharedRegs = 24;
+        if (defaultRegs < 0)
+          minSharedRegs = minRegistersForRegion(
+              op.getDefaultRegion(), laterInstrumentation, minSharedRegs);
+        if (sharedRegs < minSharedRegs)
           return;
+      }
 
-        int leftoverThreads = baseNumWarps * threadsPerWarp;
-        for (const WarpGroupInfo &wg : warpGroups) {
-          if (wg.maxRequestedRegs < 0)
-            leftoverThreads += wg.numWarps * threadsPerWarp;
-        }
-
-        int leftoverRegsPerThread = remainingRegs / leftoverThreads;
-        leftoverRegsPerThread = leftoverRegsPerThread / 8 * 8;
-        if (leftoverRegsPerThread < minRegistersForRegion(op.getDefaultRegion(),
-                                                          laterInstrumentation,
-                                                          /*minRegisters=*/24))
-          return;
-
-        for (const WarpGroupInfo &wg : warpGroups) {
-          int regs = wg.maxRequestedRegs > 0 ? wg.maxRequestedRegs
-                                             : leftoverRegsPerThread;
-          for (Region *region : wg.partitions)
-            maxnregsPerPartition[1 + region->getRegionNumber()] = regs;
-        }
-        maxnregsPerPartition.front() = leftoverRegsPerThread;
+      maxnregsPerPartition.front() =
+          defaultRegs > 0 ? defaultRegs : sharedRegs;
+      for (const WarpGroupInfo &wg : warpGroups) {
+        int regs =
+            wg.maxRequestedRegs > 0 ? wg.maxRequestedRegs : sharedRegs;
+        for (Region *region : wg.partitions)
+          maxnregsPerPartition[1 + region->getRegionNumber()] = regs;
       }
 
       op.setActualRegisters(maxnregsPerPartition);

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1478,7 +1478,7 @@ void WarpSpecializeOp::build(OpBuilder &builder, OperationState &state,
                              TypeRange resultTypes,
                              ArrayRef<int32_t> partitionNumWarps,
                              unsigned partitionNumRegions) {
-  build(builder, state, resultTypes, partitionNumWarps, {}, {}, {});
+  build(builder, state, resultTypes, partitionNumWarps, {}, {}, {}, {});
   OpBuilder::InsertionGuard guard(builder);
   builder.createBlock(state.regions.back().get());
   WarpSpecializePartitionsOp::create(builder, state.location,
@@ -1489,7 +1489,7 @@ void WarpSpecializeOp::build(OpBuilder &builder, OperationState &state,
 void WarpSpecializeOp::build(OpBuilder &builder, OperationState &state,
                              TypeRange resultTypes,
                              ArrayRef<int32_t> partitionNumWarps) {
-  build(builder, state, resultTypes, partitionNumWarps, {}, {}, {});
+  build(builder, state, resultTypes, partitionNumWarps, {}, {}, {}, {});
 }
 
 ParseResult WarpSpecializeOp::parse(OpAsmParser &p, OperationState &result) {

--- a/python/test/unit/language/test_tlx_warp_specialization.py
+++ b/python/test/unit/language/test_tlx_warp_specialization.py
@@ -285,14 +285,31 @@ def test_async_tasks_region_error(device):
     assert "division by zero" in exc_msg, "\n\nExpected 'division by zero' but got: \n\n" + exc_msg + "\n\n"
 
 
-def test_default_task_rejects_registers():
-    """Specifying registers on the default async_task is banned because the
-    default always receives leftover registers from the partition budget."""
-    with pytest.raises(AssertionError, match="Cannot specify registers"):
-        tlx.async_task("default", registers=128)
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper or newer")
+def test_default_task_register_budget(device):
 
-    with pytest.raises(AssertionError, match="Cannot specify registers"):
-        tlx.async_task("default", num_regs=128)
+    @triton.jit
+    def register_budget_kernel(default_out, worker_out):
+        with tlx.async_tasks():
+            with tlx.async_task("default", num_regs=80):
+                tl.store(default_out, 1)
+            with tlx.async_task(num_warps=4, num_regs=24):
+                tl.store(worker_out, 2)
+
+    default_out = torch.empty((), device=device, dtype=torch.int32)
+    worker_out = torch.empty((), device=device, dtype=torch.int32)
+    kernel = register_budget_kernel[(1, )](default_out, worker_out, num_warps=4)
+
+    ttgir = kernel.asm["ttgir"]
+    assert "defaultRequestedRegisters = 80 : i32" in ttgir
+    assert default_out.item() == 1
+    assert worker_out.item() == 2
+
+
+@pytest.mark.parametrize("kwargs", [{"num_regs": 128}, {"registers": 128}])
+def test_default_task_accepts_registers(kwargs):
+    task = tlx.async_task("default", **kwargs)
+    assert task.num_regs == 128
 
 
 @pytest.mark.parametrize(
@@ -302,9 +319,13 @@ def test_default_task_rejects_registers():
         {"registers": 25},
     ],
 )
-def test_async_task_rejects_unaligned_registers(kwargs):
+@pytest.mark.parametrize("task_args", [(), ("default", )])
+def test_async_task_rejects_unaligned_registers(kwargs, task_args):
     with pytest.raises(ValueError, match="divisible by 8"):
-        tlx.async_task(num_warps=1, **kwargs)
+        if task_args:
+            tlx.async_task(*task_args, **kwargs)
+        else:
+            tlx.async_task(num_warps=1, **kwargs)
 
 
 @pytest.mark.parametrize(

--- a/test/Conversion/allocate_warp_groups.mlir
+++ b/test/Conversion/allocate_warp_groups.mlir
@@ -96,6 +96,44 @@ tt.func @setmaxnreg() {
 
 // -----
 
+module attributes {"ttg.num-warps" = 4 : i32, ttg.maxnreg = 128 : i32} {
+
+// CHECK-LABEL: tt.func @fixed_default_registers
+tt.func @fixed_default_registers() {
+  // CHECK: actualRegisters = array<i32: 80, 24>
+  ttg.warp_specialize() attributes {defaultRequestedRegisters = 80 : i32, requestedRegisters = array<i32: 24>}
+  default {
+    ttg.warp_yield
+  }
+  partition0() num_warps(4) {
+    ttg.warp_return
+  } : () -> ()
+  tt.return
+}
+
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 4 : i32, ttg.maxnreg = 128 : i32} {
+
+// CHECK-LABEL: tt.func @fixed_default_shared_worker_registers
+tt.func @fixed_default_shared_worker_registers() {
+  // CHECK: actualRegisters = array<i32: 80, 176>
+  ttg.warp_specialize() attributes {defaultRequestedRegisters = 80 : i32}
+  default {
+    ttg.warp_yield
+  }
+  partition0() num_warps(4) {
+    ttg.warp_return
+  } : () -> ()
+  tt.return
+}
+
+}
+
+// -----
+
 // CHECK: module attributes {ttg.maxnreg = 40 : i32
 module attributes {"ttg.num-warps" = 4 : i32, ttg.maxnreg = 40 : i32} {
 

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -1216,6 +1216,7 @@ void init_triton_tlx_ir(py::module &&m) {
       .def("create_warp_specialize_op",
            [](TritonOpBuilder &self, std::vector<int> partitionNumWarps,
               std::optional<std::vector<int>> requestedRegisters,
+              std::optional<int> defaultRequestedRegisters,
               int numPartitionRegions,
               std::optional<std::vector<int>> warpGroupStartIds)
                -> ttg::WarpSpecializeOp {
@@ -1224,6 +1225,7 @@ void init_triton_tlx_ir(py::module &&m) {
                  dummyTypes, partitionNumWarps, numPartitionRegions);
 
              wsOp.setRequestedRegisters(requestedRegisters);
+             wsOp.setDefaultRequestedRegisters(defaultRequestedRegisters);
              wsOp.setWarpGroupStartIds(warpGroupStartIds);
 
              return wsOp;

--- a/third_party/tlx/language/tlx/async_task_utils.py
+++ b/third_party/tlx/language/tlx/async_task_utils.py
@@ -26,8 +26,8 @@ class async_task:
             if core._unwrap_if_constexpr(args[0]) == "default":
                 self.is_explict = True
                 self.is_default = True
-                assert "num_regs" not in kwargs and "registers" not in kwargs, \
-                    "Cannot specify registers for the default async_task; it receives leftover registers from the partition budget"
+                self.num_regs = core._unwrap_if_constexpr(kwargs.get("num_regs", kwargs.get("registers", None)))
+                _validate_num_regs(self.num_regs)
                 self.replicate = core._unwrap_if_constexpr(kwargs.get("replicate", 1))
                 self.warp_group_start_id = core._unwrap_if_constexpr(kwargs.get("warp_group_start_id", None))
             else:

--- a/third_party/tlx/language/tlx/compiler/code_generator.py
+++ b/third_party/tlx/language/tlx/compiler/code_generator.py
@@ -233,12 +233,14 @@ def visit_withAsyncTasks(self, node):
             region_replica_id_stack.append(-1)  # dummy placeholder
 
             num_default = 0
+            default_num_regs = None
             for stmt in stmts:
                 task = _get_async_task(self, stmt)
                 assert task.is_explict
                 assert task.replicate is not None, "Replicate must be non-None task"
                 if task.is_default:
                     num_default += 1
+                    default_num_regs = task.num_regs
                     if task.replicate > 1:
                         task_replicas.append(task.replicate - 1)
                         task_num_warps.extend([self.builder.options.num_warps] * (task.replicate - 1))
@@ -285,6 +287,7 @@ def visit_withAsyncTasks(self, node):
         ws_op = self.builder.create_warp_specialize_op(
             task_num_warps,
             task_num_regs if task_num_regs else None,
+            default_num_regs if default_num_regs else None,
             sum(task_replicas),
             task_warp_group_start_ids if task_warp_group_start_ids else None,
         )


### PR DESCRIPTION
Summary: Honor `num_regs` and `registers` on `tlx.async_task("default")` by plumbing a fixed default request through `WarpSpecializeOp` and register allocation. When the default task omits a budget, preserve the legacy donation semantics: explicitly budgeted non-default warp groups donate unused registers and the default receives the remainder. When the default specifies a budget, it receives that fixed per-thread allocation and no longer absorbs surplus; unbudgeted non-default groups evenly share the remaining registers, and surplus is left unused when every group is fixed. Document these semantics in the top-level `README.md`.

Differential Revision: D115803750


