### PR TITLE
[triton][c_cache] Fix TypeError: unhashable type dict when extern_libs is passed to C fast path (#2829)

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -13,7 +13,7 @@ from functools import cached_property
 from typing import Dict, Tuple, List, Optional
 
 from .. import knobs
-from .jit import KernelInterface, JITFunction, _compile_iq_suppress_competition
+from .jit import KernelInterface, JITFunction, _compile_iq_suppress_competition, _hash_fc_opts
 from .errors import OutOfResources, PTXASError, AutotunerError
 from .driver import driver
 from .cache import get_cache_manager, triton_key
@@ -647,7 +647,7 @@ class Autotuner(KernelInterface):
         _meta = {k: v for k, v in config_kwargs.items() if k not in fn_arg_name_set}
         _meta_opts = {k: v for k, v in _meta.items() if k not in getattr(self.fn, '_param_name_to_idx', {})}
         if _meta_opts:
-            options_hash = hash(tuple(sorted(_meta_opts.items()))) & 0xFFFFFFFFFFFFFFFF
+            options_hash = _hash_fc_opts(_meta_opts)
         else:
             options_hash = getattr(self.fn, '_fc_options_hash', 0)
 
@@ -747,7 +747,7 @@ class Autotuner(KernelInterface):
             if _meta:
                 _meta_opts = {k: v for k, v in _meta.items() if k not in getattr(self.fn, '_param_name_to_idx', {})}
                 if _meta_opts:
-                    self.fn._fc_options_hash = hash(tuple(sorted(_meta_opts.items()))) & 0xFFFFFFFFFFFFFFFF
+                    self.fn._fc_options_hash = _hash_fc_opts(_meta_opts)
                 # Store meta kwargs for C proxy fallback forwarding.
                 self.fn._fc_meta_kwargs = _meta
                 # Invalidate proxy cache so next __getitem__ creates a new proxy

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -87,6 +87,31 @@ if _CACHE_STATS_ON:
             print(f"  {kname}: {summary}", file=_sys.stderr, flush=True)
 
 
+def _make_hashable(v):
+    """Convert unhashable types to hashable equivalents for options hashing.
+
+    The C fast-path hashes non-parameter kwargs (e.g. ``extern_libs``) via
+    ``hash(tuple(sorted(opts.items())))``.  Dict/list/set values are not
+    hashable, so we recursively convert them:
+    - dicts  -> tuple of (key, transformed-value) pairs sorted by key
+    - sets   -> sorted tuple (order-independent hash)
+    - lists  -> tuple preserving order
+    """
+    if isinstance(v, dict):
+        return tuple((k, _make_hashable(val)) for k, val in sorted(v.items(), key=lambda kv: kv[0]))
+    if isinstance(v, (set, frozenset)):
+        return tuple(sorted(_make_hashable(x) for x in v))
+    if isinstance(v, list):
+        return tuple(_make_hashable(x) for x in v)
+    return v
+
+
+def _hash_fc_opts(opts):
+    """Compute a stable uint64 hash over non-parameter kwargs for the C fast cache."""
+    return hash(tuple(
+        (k, _make_hashable(v)) for k, v in sorted(opts.items(), key=lambda kv: kv[0]))) & 0xFFFFFFFFFFFFFFFF
+
+
 # Fast tensor access API — lazily registered on first use.
 # Provides ~10x faster dtype/data_ptr extraction via direct C struct access.
 _torch_bridge_loaded = False
@@ -973,8 +998,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
                     else:
                         _fc_opts[k] = v
                 _fc_args = tuple(_fc_args)
-                _fc_hash = (hash(tuple(sorted(_fc_opts.items())))
-                            & 0xFFFFFFFFFFFFFFFF) if _fc_opts else self._fc_options_hash
+                _fc_hash = _hash_fc_opts(_fc_opts) if _fc_opts else self._fc_options_hash
             else:
                 _fc_args = args
                 _fc_hash = self._fc_options_hash
@@ -1192,8 +1216,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
                         else:
                             _ins_opts[k] = v
                     _ins_args = tuple(_ins_args)
-                    _ins_hash = (hash(tuple(sorted(_ins_opts.items())))
-                                 & 0xFFFFFFFFFFFFFFFF) if _ins_opts else self._fc_options_hash
+                    _ins_hash = _hash_fc_opts(_ins_opts) if _ins_opts else self._fc_options_hash
                 else:
                     _ins_args = args
                     _ins_hash = self._fc_options_hash


### PR DESCRIPTION
Summary:

## Context
Beta Triton's C fast-path cache (default ON via `TRITON_ENABLE_C_CACHE=True`)
collects non-parameter kwargs into `_fc_opts` and then hashes them to build the
cache key. This works for simple scalar kwargs but breaks when an unhashable
type (dict, list, set) is passed as a value.

## Problem
When a `triton.jit` kernel receives `extern_libs=<dict>` (e.g. torchcomms'
`GridCallableWithExtern.run(..., extern_libs=self.extern_libs)`), the fast path
executes:

```python
_fc_opts[k] = v                       # extern_libs -> {"extern_libs": {dict}}
_fc_hash = hash(tuple(sorted(_fc_opts.items())))   # TypeError!
```

`hash(("extern_libs", {dict}))` raises `TypeError: unhashable type: 'dict'`.

Stable Triton has no C fast path, so it goes directly through `parse_options`
which converts `extern_libs` to `tuple(extern_libs.items())` before hashing
(compiler.py:225), avoiding the crash entirely.

## Fix
- Added `_make_hashable(v)` which recursively converts dicts to
  `tuple(sorted(items))`, lists/sets to tuples.
- Added `_hash_fc_opts(opts)` wrapper that applies `_make_hashable` before
  hashing.
- Replaced all 4 raw `hash(tuple(sorted(...)))` call sites:
  - `jit.py`: fast-path lookup (L990) and insertion (L1195)
  - `autotuner.py`: autotuner options hash (L650 and L750)

Reviewed By: htyu

Differential Revision: D115805330


