### PR TITLE
[AMD] Add TTGIR instruction scheduling via fine-grained scheduling-group control

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -136,6 +136,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerTritonAMDGPUConvertToTensorOps();
   mlir::registerTritonAMDGPUOptimizeBufferOpPtr();
   mlir::registerTritonAMDGPUDotDecomposeAndSchedule();
+  mlir::registerTritonAMDGPUSchedGroupBarrierScheduler();
   mlir::registerTritonAMDGPUInThreadTranspose();
   mlir::registerTritonAMDGPUCoalesceAsyncCopy();
   mlir::registerTritonAMDGPUCoalesceBufferOps();

--- a/docs/design/modulo_schedule/amd_ttgir_instruction_scheduling.md
+++ b/docs/design/modulo_schedule/amd_ttgir_instruction_scheduling.md
@@ -1,0 +1,396 @@
+# TTGIR-guided instruction scheduling on AMD
+
+This document describes AMD TTGIR-guided instruction scheduling: how the
+compiler derives a machine-scheduling plan from final TTGIR and carries that
+plan through lowering to the AMDGPU machine scheduler.
+
+The user-facing capability is **TTGIR instruction scheduling**. The current AMD
+backend realization uses `sched_group_barrier`, so the implementation pass is
+deliberately named `SchedGroupBarrierScheduler`. Keeping the implementation
+name mechanism-specific distinguishes it from Triton's existing dot
+decomposition, modulo scheduling, and loop scheduling passes.
+
+The scheduler is default-off and independent of any one kernel. The gfx950
+shared-A BMM is the first tuned consumer and the validation case used for the
+performance results below.
+
+## Motivation
+
+Useful scheduling decisions require information from two different compiler
+levels:
+
+* Final TTGIR still contains tensor layouts, MFMA encodings, vectorization,
+  pointer alignment, and the relationship between memory operations and dots.
+* The real LDS hazard boundaries are created later by
+  `ModuleMembarAnalysis`. Those boundaries define the regions within which the
+  AMDGPU machine scheduler is allowed to interleave instructions.
+
+An LLVM IR scheduler sees the second part of this picture but has lost much of
+the first. A scheduler that runs only at TTGIR sees the first part but cannot
+place constraints at Membar boundaries that do not exist yet.
+
+The design therefore separates **planning** from **materialization**:
+
+```text
+final TTGIR
+  -> classify relevant operations
+  -> predict lowering-aware machine-instruction multiplicities
+  -> record the plan as TTGIR/module metadata
+  -> run ModuleMembarAnalysis
+  -> split blocks into the actual machine-scheduling regions
+  -> materialize ordered scheduling groups at those boundaries
+  -> run the LLVM AMDGPU machine scheduler
+```
+
+No LLVM IR instruction reordering is performed. TTGIR decides what should be
+interleaved; AMD lowering places the constraints where the machine scheduler
+can realize that decision.
+
+## Goals and non-goals
+
+The current design has four goals:
+
+1. Make the scheduling decision while tensor and layout semantics are present.
+2. Express the decision at the actual LDS hazard boundaries.
+3. Predict machine-instruction counts from the same information used by
+   lowering, rather than treating one TTGIR operation as one instruction.
+4. Keep selection cache-keyed and per kernel so it can be autotuned.
+
+The pass does not:
+
+* change data dependencies or reorder TTGIR/LLVM IR operations;
+* replace dot decomposition or modulo scheduling;
+* infer an arbitrary kernel's best cover ratio in the current version;
+* enable itself globally by default;
+* claim a machine class whose lowering multiplicity is not modeled.
+
+## Compiler placement
+
+`TritonAMDGPUSchedGroupBarrierSchedulerPass` runs at the end of the AMD TTGIR
+pipeline, after transformations that can change instruction classes or widths,
+including buffer-op conversion, in-thread transpose, and late layout cleanup.
+This placement is important: moving the pass earlier can price an operation
+using a layout or access width that no longer exists in the final program.
+
+The pass only attaches metadata. During AMD-to-LLVM conversion,
+`ModuleMembarAnalysis` first creates the real `ttg.barrier` operations. The
+conversion then calls `materializeDeferredSchedGroupBarriers` before lowering
+the remaining Triton operations.
+
+## Scheduling model
+
+The model uses four machine-instruction classes:
+
+| Symbol | Machine class | AMD scheduler mask |
+| --- | --- | ---: |
+| `M` | MFMA | `1 << 3` |
+| `G` | VMEM read | `1 << 5` |
+| `R` | DS read | `1 << 8` |
+| `W` | DS write | `1 << 9` |
+
+Memory instructions are **anchors**. Independent MFMA instructions are the
+latency-hiding **cover** scheduled after each anchor. A region is represented
+as an ordered sequence of anchor/cover pairs:
+
+```text
+(G128, M x 4), (G64, M x 2), (G32, M x 1),
+(R, M x 1), ..., (W, M x write_cover)
+```
+
+All pairs in one region use the same scheduler sync ID. This makes their order
+one machine-scheduling pipeline rather than a collection of unrelated hints.
+
+## Phase 1: classify and price final TTGIR
+
+Every relevant TTGIR operation receives:
+
+* `ttg.amd.sched_group_barrier.machine_mask`: eventual AMD machine class;
+* `ttg.amd.sched_group_barrier.machine_count`: predicted number of machine
+  instructions produced by lowering;
+* `ttg.amd.sched_group_barrier.mfma_cover`: MFMA cover for each VMEM machine
+  instruction, derived from its final access width.
+
+The module records that the plan is enabled and the optional required region
+count. The attributes are a deferred plan; they are not scheduling
+instructions and do not change program semantics.
+
+### MFMA multiplicity
+
+For a block-level dot, the predicted number of MFMAs is:
+
+```text
+ceil(M / (instrM * warpsM))
+  * ceil(N / (instrN * warpsN))
+  * ceil(logicalK / instrK)
+```
+
+`M` and `N` come from the result tensor. The instruction shape and warp
+partition come from `AMDMfmaEncodingAttr`. `logicalK` comes from the A operand.
+For E2M1 `tt.dot_scaled`, the stored K dimension counts bytes containing two
+fp4 values, so the model doubles K before applying the formula.
+
+This is a per-operation calculation. Matching only the block's total MFMA
+count is insufficient: two incorrectly priced dots can cancel in the total
+while producing unfillable groups at their actual positions.
+
+### DS-read multiplicity
+
+The model obtains the exact elements held by each lane from the operation's
+`LinearLayout`, then divides the per-lane bytes by the access width selected by
+lowering:
+
+```text
+ds_read_count = ceil(bytes_per_lane / ds_access_bytes)
+```
+
+The common path uses 16-byte `ds_read_b128`. On gfx950, MFMA B operands use the
+transposed 8-byte DS-read path, so those operations are priced at twice the
+instruction count of a 16-byte access with the same lane payload.
+
+Using `getTotalElemsPerThread` is intentional. A dot-operand layout can be
+replicated across a warp dimension it does not span; byte arithmetic based
+only on the logical tensor shape misses that replication.
+
+### DS-write multiplicity
+
+DS-store width is derived by mirroring local-store lowering:
+
+1. Convert the source register type and destination memdesc to linear layouts.
+2. Compose the register-to-LDS conversion, including padded encodings.
+3. Remove broadcast register dimensions.
+4. Ask `largestVectorisation` for the legal store width.
+5. Divide the register dimension by that width.
+
+A large logical store can therefore lower to scalar DS writes when padding
+breaks physical contiguity. Assuming every store becomes `ds_write_b128`
+under-counts this case.
+
+### VMEM-read multiplicity
+
+For buffer loads, the candidate vector width is computed from:
+
+* AxisInfo offset contiguity;
+* base-pointer divisibility in elements;
+* contiguous elements per thread in the final layout;
+* the 128-bit maximum buffer-load width;
+* non-power-of-two and blocked-layout clamping.
+
+The contiguity already selected by buffer-op conversion is then retained as an
+input to the final width.
+
+The machine count is the per-thread element count divided by the resulting
+vector width. Direct-to-LDS and remaining load forms use their final tensor or
+memdesc layout to derive an equivalent count.
+
+The same final width selects a small cover pattern. A 128-bit
+`buffer_load_dwordx4` receives four MFMAs, a 64-bit
+`buffer_load_dwordx2` receives two, and a 32-bit `buffer_load_dword` receives
+one. Narrower reads conservatively receive one. In formula form, for the
+default calibration:
+
+```text
+vmem_cover = max(1, ceil(mfma_per_dwordx4 * min(access_bytes, 16) / 16))
+```
+
+This width-aware rule does not invoke Triton's general modulo scheduler. The
+128-bit case is the measured performance anchor. Scaling down prevents a
+narrower lowering, which already contains more VMEM instructions for the same
+payload, from receiving four MFMAs after every instruction.
+
+### Why multiplicity accuracy matters
+
+`sched_group_barrier` counts machine instructions, not IR operations.
+Under-counting leaves matching instructions outside the requested pipeline,
+where they can form a long cluster. Over-counting asks the backend to fill a
+group that does not exist. Both change the realized ISA schedule.
+
+The implementation does not emit a catch-all group. A broad mask can also
+match scheduling pseudo-instructions and invalidate the ordered program. New
+machine classes must therefore provide a lowering-aware count model before
+they are admitted.
+
+## Phase 2: discover real scheduling regions
+
+After `ModuleMembarAnalysis`, each block is split at every `ttg.barrier`:
+
+```text
+region 0 | barrier | region 1 | barrier | ... | region N
+```
+
+The block is eligible when:
+
+* it contains at least one predicted MFMA and one predicted memory anchor; and
+* `required_region_count` is zero, or the block has exactly the requested
+  number of regions.
+
+The region-count policy is a generic topology selector, not a kernel-shape
+check. It lets an autotuning configuration select a validated steady-state
+structure while declining a structurally different tail block. The shared-A
+BMM selects four regions; the compiler contains no BMM dimensions.
+
+If a block is accepted, hard `sched_barrier(0)` fences are placed at its start,
+between Membar-delimited regions, and at its end. These fences prevent the
+machine scheduler from moving an instruction into a neighboring region.
+
+## Phase 3: build an anchor/cover program
+
+For every accepted region, the algorithm walks annotated operations in their
+original TTGIR order and computes:
+
+```text
+mfmas       = sum(machine_count for M operations)
+vmem_reads  = sum(machine_count for G operations)
+ds_reads    = sum(machine_count for R operations)
+ds_writes   = sum(machine_count for W operations)
+
+fixed_cover = sum(machine_count * mfma_cover for G operations) + ds_reads
+
+write_cover = 1
+if ds_writes > 0 and mfmas > fixed_cover:
+  write_cover = max(1, floor((mfmas - fixed_cover) / ds_writes))
+```
+
+The cover assigned to each anchor instance is:
+
+| Anchor | MFMA cover |
+| --- | ---: |
+| 128-bit VMEM read (`G`) | 4 |
+| 64-bit VMEM read (`G`) | 2 |
+| 32-bit or narrower VMEM read (`G`) | 1 |
+| DS read (`R`) | 1 |
+| DS write (`W`) | `write_cover` |
+
+The algorithm expands each operation by its predicted machine count. For each
+anchor instruction it emits one anchor group followed by its MFMA cover group.
+If a region has no MFMA work, it emits only the ordered memory groups.
+
+A memory-only prologue has one conservative special case: the first VMEM
+operation may move after the first DS-read operation. The move is performed at
+whole-operation granularity; the internal machine count of either operation is
+not split.
+
+In pseudocode, materialization is:
+
+```text
+for block in function:
+  regions = split_at_membar_boundaries(block)
+  if not eligible(block, regions):
+    continue
+
+  emit_hard_fence(block.begin)
+  for region in regions:
+    anchors, mfmas = collect_in_ttgir_order(region)
+    groups = allocate_cover(anchors, mfmas)
+    sync_id = fresh_sync_id()
+    for anchor, cover in groups:
+      emit_group(anchor.mask, count=1, sync_id)
+      if cover != 0:
+        emit_group(MFMA, count=cover, sync_id)
+    emit_hard_fence(region.end)
+```
+
+The materialized operations lower through ROCDL to the AMDGPU scheduler. The
+final ISA order, not the presence of metadata or ROCDL operations, is the
+source of truth for whether the plan was realized.
+
+## Selection and autotuning contract
+
+The scheduler is default-off. A kernel or autotuning configuration enables it
+with cache-keyed HIPOptions:
+
+```python
+enable_sched_group_barrier_scheduler = True
+sched_group_barrier_mfma_per_dwordx4 = 4
+sched_group_barrier_required_region_count = 0
+```
+
+For compiler experiments, the environment can provide the default enablement:
+
+```bash
+TRITON_AMD_TTGIR_SCHEDULE=1
+```
+
+An explicit HIPOption takes precedence over the environment. The resolved
+value and both tuning parameters are stored in `HIPOptions`, so they
+participate in the compilation cache key. An autotuner can therefore compare
+enabled/disabled variants, cover ratios, and region policies without reusing a
+binary compiled for another schedule.
+
+AMDGPU's generic high-register-pressure strategy can replace an otherwise
+valid pre-RA schedule. A pressure-sensitive consumer may also select the
+cache-keyed `disable_unclustered_high_rp_reschedule` option. This is not part of
+the anchor/cover algorithm; it prevents a later policy from discarding an
+accepted plan. Spill size and occupancy must still be validated.
+
+## Performance result
+
+The gfx950 shared-A BMM uses a 256x256 MI16 tile and the four-region policy. For
+`B=1024, M=1195, N=256, K=2309`, an eight-round paired warm-cache benchmark
+alternated the LLVM-IR and TTGIR variants and bracketed them with unscheduled
+measurements to reduce clock and temperature bias.
+
+| Scheduling path | Median latency | vs. no scheduling | vs. best LLVM-IR |
+| --- | ---: | ---: | ---: |
+| No scheduling (before) | 2249 us | - | - |
+| Best LLVM-IR scheduler evaluated | 2070 us | -8.0% | - |
+| **TTGIR scheduling (after)** | **1972 us** | **-12.2%** | **-4.7%** |
+
+TTGIR scheduling outperformed every LLVM-IR scheduling configuration evaluated
+for this kernel. All three measured variants were bitwise exact and used zero
+scratch.
+
+The realized TTGIR-scheduled hot loop contains:
+
+```text
+MFMA=128, DS_READ=48, DS_WRITE=8, VMEM_READ=16, hard barriers=3
+```
+
+Its class stream starts with `R8 G4 R16`, then interleaves the memory anchors
+with MFMA cover groups. The maximum consecutive MFMA run is 10. The final
+object uses a zero-byte private segment and 510 VGPRs.
+
+## Validation procedure
+
+A scheduling change is not validated by counting IR hints. Validate the final
+object and runtime behavior:
+
+1. Compare every predicted per-operation machine count with disassembly and
+   source locations.
+2. Compare hot-loop totals and the requested/realized class stream.
+3. Check hard-fence placement at every expected region boundary.
+4. Check private-segment size, VGPR allocation, and occupancy.
+5. Run fixed-seed numerical correctness, including partial and unaligned K.
+6. Benchmark enabled and disabled variants in the same process with alternating
+   order and bracket samples.
+7. Run the AMD TLX regression suite to catch unrelated layout regressions.
+
+For the current stack:
+
+* `test_tlx_amd.py`: 91 passed, 5 skipped;
+* focused option, validation, and environment-precedence tests: 4 passed;
+* target BMM: bitwise exact against `torch.bmm`, `max_abs=0`;
+* Buck targets and the local `libtriton.so` build succeed.
+
+## Current limitations and extension points
+
+The region mechanism is general, but the current cost model covers only MFMA,
+VMEM reads, DS reads, and DS writes. It uses a configurable fixed VMEM cover,
+a one-MFMA DS-read cover, and an even distribution of residual MFMA work over
+DS writes. It does not yet derive these ratios from a device throughput model.
+
+The `required_region_count` gate selects a complete block topology. The current
+implementation does not independently accept or reject each region with a
+profitability model. Extending admission should preserve the existing
+all-or-nothing block boundary contract unless cross-region motion is proven
+safe.
+
+Adding a new machine class requires:
+
+1. a stable mapping from final TTGIR to the backend machine class;
+2. a lowering-aware per-operation multiplicity model;
+3. an anchor or cover policy;
+4. disassembly-based validation across the affected layouts and access widths.
+
+Future autotuning can search enablement, VMEM cover, and region topology first.
+A later profitability model can replace the fixed cover policy without
+changing the TTGIR-planning/post-Membar-materialization architecture.

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -46,6 +46,22 @@ GFX942 = GPUTarget("hip", "gfx942", 64)
 GFX1250 = GPUTarget("hip", "gfx1250", 32)
 
 
+def test_amd_ttgir_schedule_env_is_cache_keyed_and_overridable(monkeypatch):
+    backend = amd_compiler.HIPBackend(GFX950)
+    monkeypatch.delenv("TRITON_AMD_TTGIR_SCHEDULE", raising=False)
+    baseline = backend.parse_options({})
+
+    monkeypatch.setenv("TRITON_AMD_TTGIR_SCHEDULE", "1")
+    env_enabled = backend.parse_options({})
+    config_disabled = backend.parse_options({"enable_sched_group_barrier_scheduler": False})
+
+    assert not baseline.enable_sched_group_barrier_scheduler
+    assert env_enabled.enable_sched_group_barrier_scheduler
+    assert env_enabled.hash() != baseline.hash()
+    assert not config_disabled.enable_sched_group_barrier_scheduler
+    assert config_disabled.hash() == baseline.hash()
+
+
 def test_amd_regalloc_codegen_options_are_cache_keyed():
     baseline = amd_compiler.HIPOptions(arch="gfx950")
     tuned = amd_compiler.HIPOptions(
@@ -53,6 +69,7 @@ def test_amd_regalloc_codegen_options_are_cache_keyed():
         reverse_local_assignment=True,
         sink_insts_to_avoid_spills=True,
         regclass_priority_trumps_globalness=True,
+        disable_unclustered_high_rp_reschedule=True,
     )
 
     assert tuned.hash() != baseline.hash()
@@ -61,7 +78,27 @@ def test_amd_regalloc_codegen_options_are_cache_keyed():
         "greedy-reverse-local-assignment",
         "sink-insts-to-avoid-spills",
         "greedy-regclass-priority-trumps-globalness",
+        "amdgpu-disable-unclustered-high-rp-reschedule",
     ]
+
+
+def test_amd_sched_group_barrier_options_are_cache_keyed_and_validated():
+    baseline = amd_compiler.HIPOptions(arch="gfx950")
+    tuned = amd_compiler.HIPOptions(
+        arch="gfx950",
+        enable_sched_group_barrier_scheduler=True,
+        sched_group_barrier_mfma_per_dwordx4=2,
+        sched_group_barrier_required_region_count=4,
+    )
+
+    assert tuned.hash() != baseline.hash()
+    assert tuned.enable_sched_group_barrier_scheduler
+    assert tuned.sched_group_barrier_mfma_per_dwordx4 == 2
+    assert tuned.sched_group_barrier_required_region_count == 4
+    with pytest.raises(ValueError, match="sched_group_barrier_mfma_per_dwordx4 must be positive"):
+        amd_compiler.HIPOptions(arch="gfx950", sched_group_barrier_mfma_per_dwordx4=0)
+    with pytest.raises(ValueError, match="sched_group_barrier_required_region_count must be non-negative"):
+        amd_compiler.HIPOptions(arch="gfx950", sched_group_barrier_required_region_count=-1)
 
 
 def compile_for_target(fn, signature, constexprs, target):

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -630,6 +630,7 @@ class amd_knobs(base_knobs):
     use_in_thread_transpose: env_opt_bool = env_opt_bool("TRITON_HIP_USE_IN_THREAD_TRANSPOSE")
     use_async_copy: env_opt_bool = env_opt_bool("TRITON_HIP_USE_ASYNC_COPY")
     use_expert_scheduling: env_opt_bool = env_opt_bool("TRITON_HIP_USE_EXPERT_SCHEDULING")
+    enable_ttgir_schedule: env_bool = env_bool("TRITON_AMD_TTGIR_SCHEDULE")
 
     scalarize_packed_fops: env_bool = env_bool("AMDGCN_SCALARIZE_PACKED_FOPS")
 

--- a/test/TritonGPU/amd/amd-sched-group-barrier-width-cover.mlir
+++ b/test/TritonGPU/amd/amd-sched-group-barrier-width-cover.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-sched-group-barrier-scheduler | FileCheck %s
+
+// The VMEM cover scales with the access width that final TTGIR will lower:
+// dwordx4 -> 4 MFMA, dwordx2 -> 2 MFMA, dword -> 1 MFMA.
+
+// CHECK-LABEL: @dwordx4
+// CHECK: amdg.buffer_load
+// CHECK-SAME: machine_count = 1 : i32
+// CHECK-SAME: machine_mask = 32 : i32
+// CHECK-SAME: mfma_cover = 4 : i32
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @dwordx4(
+      %ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %offsets: tensor<1024xi32, #blocked> {tt.contiguity = 4 : i32, tt.divisibility = 16 : i32}) {
+    %result = amdg.buffer_load %ptr[%offsets] : tensor<1024xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @dwordx2
+// CHECK: amdg.buffer_load
+// CHECK-SAME: machine_count = 1 : i32
+// CHECK-SAME: machine_mask = 32 : i32
+// CHECK-SAME: mfma_cover = 2 : i32
+#blocked = #ttg.blocked<{sizePerThread = [2], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @dwordx2(
+      %ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %offsets: tensor<512xi32, #blocked> {tt.contiguity = 2 : i32, tt.divisibility = 16 : i32}) {
+    %result = amdg.buffer_load %ptr[%offsets] : tensor<512xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @dword
+// CHECK: amdg.buffer_load
+// CHECK-SAME: machine_count = 1 : i32
+// CHECK-SAME: machine_mask = 32 : i32
+// CHECK-SAME: mfma_cover = 1 : i32
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @dword(
+      %ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %offsets: tensor<256xi32, #blocked> {tt.contiguity = 1 : i32, tt.divisibility = 16 : i32}) {
+    %result = amdg.buffer_load %ptr[%offsets] : tensor<256xf32, #blocked>
+    tt.return
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -77,6 +77,8 @@ def _get_codegen_flags(options):
         flags.append("sink-insts-to-avoid-spills")
     if options.regclass_priority_trumps_globalness:
         flags.append("greedy-regclass-priority-trumps-globalness")
+    if options.disable_unclustered_high_rp_reschedule:
+        flags.append("amdgpu-disable-unclustered-high-rp-reschedule")
     return flags
 
 
@@ -124,6 +126,16 @@ class HIPOptions:
     reverse_local_assignment: bool = False
     sink_insts_to_avoid_spills: bool = False
     regclass_priority_trumps_globalness: bool = False
+    # Keep the pre-RA scheduler from replacing a pressure-sensitive schedule
+    # with the generic unclustered high-RP strategy. This is cache-keyed and
+    # per kernel so unrelated kernels retain the default pressure policy.
+    disable_unclustered_high_rp_reschedule: bool = False
+
+    # Cache-keyed, per-kernel schedule-group-barrier planning. Keep this name
+    # distinct from the pre-existing TTGIR dot-decomposition scheduler.
+    enable_sched_group_barrier_scheduler: bool = False
+    sched_group_barrier_mfma_per_dwordx4: int = 4
+    sched_group_barrier_required_region_count: int = 0
 
     def __post_init__(self):
         gfx_major = int(self.arch[3:-2])  # Drop "gfx" prefix and minor/patch number
@@ -138,6 +150,11 @@ class HIPOptions:
             object.__setattr__(self, "kpack", 1)
 
         object.__setattr__(self, 'llvm_fn_attrs', _parse_llvm_fn_attrs(self.llvm_fn_attrs))
+
+        if self.sched_group_barrier_mfma_per_dwordx4 <= 0:
+            raise ValueError("sched_group_barrier_mfma_per_dwordx4 must be positive")
+        if self.sched_group_barrier_required_region_count < 0:
+            raise ValueError("sched_group_barrier_required_region_count must be non-negative")
 
         default_libdir = Path(__file__).parent / "lib"
         extern_libs = {} if self.extern_libs is None else dict(self.extern_libs)
@@ -193,6 +210,11 @@ class HIPBackend(BaseBackend):
 
         if "enable_fp_fusion" not in opts:
             args["enable_fp_fusion"] = knobs.language.default_fp_fusion
+        if "enable_sched_group_barrier_scheduler" not in opts:
+            # Keep the environment variable as an experimental default. An
+            # explicit per-config value takes precedence so autotuning can
+            # select the scheduler independently for each kernel variant.
+            args["enable_sched_group_barrier_scheduler"] = knobs.amd.enable_ttgir_schedule
         args.update({k: opts[k] for k in HIPOptions.__dataclass_fields__.keys() if k in opts and opts[k] is not None})
         return HIPOptions(**args)
 
@@ -409,6 +431,12 @@ class HIPBackend(BaseBackend):
         # kernels) and as the last pass before pm.run so the cleanup passes above do
         # not strip the priority markers before the pipeliner consumes them.
         amd.passes.ttgpuir.add_warp_pipeline(pm)
+        if options.enable_sched_group_barrier_scheduler:
+            amd.passes.ttgpuir.add_sched_group_barrier_scheduler(
+                pm,
+                options.sched_group_barrier_mfma_per_dwordx4,
+                options.sched_group_barrier_required_region_count,
+            )
         if options.instrumentation_mode == "fpsan":
             amd.passes.ttgpuir.add_fp_sanitizer(pm)
             passes.ttgpuir.add_fp_sanitizer(pm)

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -446,4 +446,35 @@ def TritonAMDGPUDotDecomposeAndSchedule
                            "mlir::ROCDL::ROCDLDialect"];
 }
 
+def TritonAMDGPUSchedGroupBarrierScheduler
+    : Pass<"tritonamdgpu-sched-group-barrier-scheduler", "mlir::ModuleOp"> {
+  let summary =
+      "Price TTGIR operations for AMD sched_group_barrier scheduling";
+
+  let description = [{
+    Runs at the end of the AMD TTGIR pipeline, after transformations that can
+    change memory instruction classes or widths. The pass annotates relevant
+    operations with their eventual AMD machine-instruction class and exact
+    instruction count. It does not reorder TTGIR or emit LLVM IR.
+
+    ConvertTritonAMDGPUToLLVM consumes the annotations immediately after
+    ModuleMembarAnalysis, when the real LDS hazard regions are available, and
+    materializes an anchor/cover sched_group_barrier program in each eligible
+    region.
+  }];
+
+  let options = [
+    Option<"mfmaPerDwordx4", "mfma-per-dwordx4", "unsigned", /*default=*/"4",
+           "MFMA cover for a 128-bit VMEM read; narrower reads scale down.">,
+    Option<"requiredRegionCount", "required-region-count", "unsigned",
+           /*default=*/"0",
+           "Schedule only blocks with this many Membar-delimited regions; "
+           "zero accepts any region count.">,
+  ];
+
+  let dependentDialects = ["mlir::triton::TritonDialect",
+                           "mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::amdgpu::TritonAMDGPUDialect"];
+}
+
 #endif

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -39,6 +39,142 @@ using namespace mlir;
 
 namespace {
 
+// Materialize the schedule-group program at real LDS hazard boundaries. The
+// TTGIR pass provides the scheduling decision and exact machine counts; this
+// stage only gains the boundaries after ModuleMembarAnalysis.
+static void materializeDeferredSchedGroupBarriers(ModuleOp mod) {
+  if (!mod->hasAttr("ttg.amd.sched_group_barrier.enabled"))
+    return;
+
+  unsigned requiredRegionCount = 0;
+  if (auto attr = mod->getAttrOfType<IntegerAttr>(
+          "ttg.amd.sched_group_barrier.required_region_count"))
+    requiredRegionCount = static_cast<unsigned>(attr.getInt());
+
+  unsigned nextSyncId = 1;
+  mod.walk([&](triton::FuncOp func) {
+    for (Block &block : func.getBody()) {
+      SmallVector<Operation *> boundaries;
+      for (Operation &op : block.without_terminator())
+        if (isa<triton::gpu::BarrierOp>(op))
+          boundaries.push_back(&op);
+
+      SmallVector<SmallVector<Operation *>, 4> regions(1);
+      unsigned totalMFMA = 0;
+      unsigned totalAnchors = 0;
+      for (Operation &op : block.without_terminator()) {
+        if (isa<triton::gpu::BarrierOp>(op)) {
+          regions.emplace_back();
+          continue;
+        }
+        auto mask = op.getAttrOfType<IntegerAttr>(
+            "ttg.amd.sched_group_barrier.machine_mask");
+        auto count = op.getAttrOfType<IntegerAttr>(
+            "ttg.amd.sched_group_barrier.machine_count");
+        if (!mask || !count)
+          continue;
+        regions.back().push_back(&op);
+        if (mask.getInt() == (1 << 3))
+          totalMFMA += static_cast<unsigned>(count.getInt());
+        else
+          totalAnchors += static_cast<unsigned>(count.getInt());
+      }
+      if (totalMFMA == 0 || totalAnchors == 0 ||
+          (requiredRegionCount && regions.size() != requiredRegionCount))
+        continue;
+      boundaries.push_back(block.getTerminator());
+
+      Location loc = block.front().getLoc();
+      OpBuilder startBuilder(&block.front());
+      ROCDL::SchedBarrier::create(startBuilder, loc, /*mask=*/0);
+
+      for (auto [regionIndex, pair] :
+           llvm::enumerate(llvm::zip(regions, boundaries))) {
+        auto &[ops, boundary] = pair;
+        struct Anchor {
+          int32_t mask;
+          unsigned count;
+          unsigned mfmaCover;
+        };
+        SmallVector<Anchor> anchors;
+        unsigned mfmas = 0;
+        unsigned numWrites = 0;
+        for (Operation *op : ops) {
+          auto mask = op->getAttrOfType<IntegerAttr>(
+              "ttg.amd.sched_group_barrier.machine_mask");
+          auto count = op->getAttrOfType<IntegerAttr>(
+              "ttg.amd.sched_group_barrier.machine_count");
+          unsigned n = static_cast<unsigned>(count.getInt());
+          if (mask.getInt() == (1 << 3)) {
+            mfmas += n;
+            continue;
+          }
+          unsigned mfmaCover = 0;
+          if (auto attr = op->getAttrOfType<IntegerAttr>(
+                  "ttg.amd.sched_group_barrier.mfma_cover"))
+            mfmaCover = static_cast<unsigned>(attr.getInt());
+          anchors.push_back(
+              {static_cast<int32_t>(mask.getInt()), n, mfmaCover});
+          if (mask.getInt() == (1 << 9))
+            numWrites += n;
+        }
+
+        // In a memory-only prologue, issue the first global load after the
+        // first local-load operation instead of after every LDS read.
+        if (mfmas == 0 && anchors.size() > 2) {
+          auto firstGlobal = llvm::find_if(
+              anchors, [](const Anchor &a) { return a.mask == (1 << 5); });
+          if (firstGlobal != anchors.end() &&
+              firstGlobal != anchors.begin() + 1) {
+            Anchor global = *firstGlobal;
+            anchors.erase(firstGlobal);
+            anchors.insert(anchors.begin() + 1, global);
+          }
+        }
+
+        unsigned fixedCover = 0;
+        for (const Anchor &anchor : anchors) {
+          if (anchor.mask == (1 << 5))
+            fixedCover += anchor.mfmaCover * anchor.count;
+          else if (anchor.mask == (1 << 8))
+            fixedCover += anchor.count;
+        }
+        unsigned writeCover = 1;
+        if (numWrites && mfmas > fixedCover)
+          writeCover = std::max(1u, (mfmas - fixedCover) / numWrites);
+
+        struct Group {
+          int32_t mask;
+          unsigned cover;
+        };
+        SmallVector<Group> groups;
+        for (const Anchor &anchor : anchors) {
+          unsigned cover = anchor.mask == (1 << 5)   ? anchor.mfmaCover
+                           : anchor.mask == (1 << 8) ? 1
+                           : anchor.mask == (1 << 9) ? writeCover
+                                                    : 0;
+          for (unsigned i = 0; i < anchor.count; ++i)
+            groups.push_back({anchor.mask, mfmas ? cover : 0});
+        }
+
+        OpBuilder builder(boundary);
+        unsigned syncId = nextSyncId++;
+        for (const Group &group : groups) {
+          ROCDL::SchedGroupBarrier::create(builder, loc, group.mask, 1, syncId);
+          if (group.cover)
+            ROCDL::SchedGroupBarrier::create(builder, loc, 1 << 3, group.cover,
+                                             syncId);
+        }
+        if (regionIndex + 1 < regions.size())
+          ROCDL::SchedBarrier::create(builder, loc, /*mask=*/0);
+      }
+
+      OpBuilder endBuilder(block.getTerminator());
+      ROCDL::SchedBarrier::create(endBuilder, loc, /*mask=*/0);
+    }
+  });
+}
+
 class TritonLLVMFunctionConversionTarget : public ConversionTarget {
 public:
   explicit TritonLLVMFunctionConversionTarget(MLIRContext &ctx)
@@ -114,6 +250,7 @@ struct ConvertTritonAMDGPUToLLVM
     ModuleMembarAnalysis membarPass(&allocation,
                                     mlir::triton::AMD::membarFilter);
     membarPass.run();
+    materializeDeferredSchedGroupBarriers(mod);
 
     // Lower functions
     {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_triton_library(TritonAMDGPUTransforms
   ConvertToBufferOps.cpp
   ConvertToTensorOps.cpp
   DotDecomposeAndSchedule.cpp
+  SchedGroupBarrierScheduler.cpp
   LowerBarrierOps.cpp
   OptimizeBufferOpPtr.cpp
   OptimizeDescriptorEncoding.cpp

--- a/third_party/amd/lib/TritonAMDGPUTransforms/SchedGroupBarrierScheduler.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/SchedGroupBarrierScheduler.cpp
@@ -1,0 +1,317 @@
+//===- SchedGroupBarrierScheduler.cpp - AMD machine scheduling ------------===//
+//
+// This pass classifies relevant TTGIR operations by their eventual AMD machine
+// instruction class and predicts the instruction count produced by lowering.
+//
+// Real LDS hazard boundaries do not exist until ModuleMembarAnalysis runs. This
+// pass therefore records its decision as module/op attributes. The AMD-to-LLVM
+// conversion consumes those attributes after Membar analysis, partitions each
+// block at the real barriers, and materializes rocdl.sched.group.barrier plus
+// hard scheduling fences in the corresponding regions.
+//
+//   TTGIR classification -> Membar boundaries -> hint materialization -> LLVM
+//
+//===----------------------------------------------------------------------===//
+
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "mlir/IR/Builders.h"
+#include "third_party/amd/include/Analysis/AxisInfoExt.h"
+#include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Tools/LayoutUtils.h"
+#include "llvm/Support/MathExtras.h"
+
+namespace mlir {
+#define GEN_PASS_DEF_TRITONAMDGPUSCHEDGROUPBARRIERSCHEDULER
+#include "TritonAMDGPUTransforms/Passes.h.inc"
+} // namespace mlir
+
+using namespace mlir;
+using triton::LinearLayout;
+
+namespace {
+
+// LLVM AMDGPU SchedGroupMask bits (AMDGPUIGroupLP.cpp). Same encoding as the
+// sched_barrier mask.
+enum : int32_t {
+  kMaskMFMA = 1 << 3,
+  kMaskVMEMRead = 1 << 5,
+  kMaskDSRead = 1 << 8,
+  kMaskDSWrite = 1 << 9,
+};
+
+// --- "pretend it is decomposed": machine-instruction counts per TTGIR op -----
+// The hint interface counts MACHINE instructions, so every op must be priced
+// as the run it becomes. Nothing is split; this is a counting fiction.
+
+// A block-level dot lowers to (M/(instrM*warpsM)) * (N/(instrN*warpsN)) *
+// (K/instrK) MFMAs.
+//
+// K UNIT TRAP: for tt.dot_scaled with an e2m1 (fp4) operand the tensor's K dim
+// counts BYTES -- two 4-bit values per i8 -- while instrShape[2] counts logical
+// elements. They are NOT the same unit, so K must be doubled. Verified against
+// the ISA: 4 dots of 256x128, A=256x128xi8 e2m1, instrShape [16,16,128],
+// warpsPerCTA [2,2] -> (256/32)*(128/32)*(256/128) = 64 each = 256 total,
+// which is exactly what the loop contains. Without the doubling the model says
+// 32 each = 128, so half the MFMAs get no group and clump into a 50-long run.
+// (The bug hid for a while because on a K=8192 shape the body has 8 dots and
+// 8*32 also came to 256 -- the TOTAL matched while every per-dot count was
+// half. Always check the per-op count against the ISA, not just the total.)
+static unsigned mfmaCountOf(Operation *op) {
+  auto rt = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!rt || rt.getRank() != 2)
+    return 1;
+  auto mma =
+      dyn_cast_or_null<triton::gpu::AMDMfmaEncodingAttr>(rt.getEncoding());
+  if (!mma)
+    return 1;
+  auto aT = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+  if (!aT || aT.getRank() < 2)
+    return 1;
+  auto instr = mma.getInstrShape();
+  auto warps = mma.getWarpsPerCTA();
+  if (instr.size() < 3 || warps.size() < 2)
+    return 1;
+  int64_t k = aT.getShape()[1];
+  if (auto ds = dyn_cast<triton::DotScaledOp>(op))
+    if (ds.getAElemType() == triton::ScaleDotElemType::E2M1)
+      k *= 2; // two fp4 values per byte
+  int64_t tileM = std::max<int64_t>(1, (int64_t)instr[0] * warps[0]);
+  int64_t tileN = std::max<int64_t>(1, (int64_t)instr[1] * warps[1]);
+  int64_t iK = std::max<int64_t>(1, (int64_t)instr[2]);
+  int64_t m = (rt.getShape()[0] + tileM - 1) / tileM;
+  int64_t n = (rt.getShape()[1] + tileN - 1) / tileN;
+  int64_t kc = (k + iK - 1) / iK;
+  return (unsigned)std::max<int64_t>(1, m * n * kc);
+}
+
+// EXACT per-lane element count, from the layout.
+//
+// The count must be exact. Measured in sgb_repro, MFMA remainder always
+// distributed, only the claim count varied:
+//   under-claim by 1 instruction : maxMFMArun 3 -> 64   (a cliff, not a slope;
+//                                  1 missing is as bad as 8)
+//   over-claim by 1,2,4,8 groups : 6, 7, 10, 18         (gradual decay)
+// So `bytes / 16` estimation cannot work -- there is exactly one right answer
+// and both errors hurt. getTotalElemsPerThread reads it off the LinearLayout,
+// which accounts for replication/broadcast by construction (a dot_operand tile
+// is replicated across the warp dim it does not span, which is what made the
+// arithmetic version half-count).
+static unsigned accessCount(Type ty, unsigned accessBytes) {
+  auto rt = dyn_cast<RankedTensorType>(ty);
+  if (!rt)
+    return 1;
+  unsigned elems = triton::gpu::getTotalElemsPerThread(rt);
+  unsigned eb =
+      std::max<unsigned>(1, rt.getElementType().getIntOrFloatBitWidth() / 8);
+  unsigned bytes = std::max(1u, elems * eb);
+  return std::max(1u, (bytes + accessBytes - 1) / accessBytes);
+}
+
+static unsigned dsReadCountOf(Operation *op) {
+  // Access width depends on which read the backend picks, and they differ by
+  // 2x. Confirmed by mapping the ISA back through its .loc directives on the
+  // a4w4 body: the 64 dot-operand reads are ds_read_b128 (16 B), while all 8
+  // scale reads are ds_read_b64_tr_b8 -- CDNA4's transposed read, which is
+  // HALF width. A 256x8 scale tile holds 16 elems/lane, so it costs 2 of them,
+  // not 1. Getting those 2 wrong is not a rounding error: leaving a single
+  // instruction unclaimed takes maxMFMArun from 3 to 64 (sgb_repro).
+  Type ty = op->getResult(0).getType();
+  unsigned accessBytes = 16; // ds_read_b128
+  if (auto rt = dyn_cast<RankedTensorType>(ty)) {
+    // On gfx950, the B operand of MFMA is lowered through the transposed
+    // ds_read_b64 path.  D115508145 tested "not a dot operand" here, which is
+    // backwards for the target BMM and under-counts every B local_load by 2x.
+    if (auto dot = dyn_cast_or_null<triton::gpu::DotOperandEncodingAttr>(
+            rt.getEncoding()))
+      if (dot.getOpIdx() == 1)
+        accessBytes = 8;
+  }
+  return accessCount(ty, accessBytes);
+}
+
+// Mirror the generic local-store lowering's vectorisation calculation.  The
+// instruction count is not bytes/16: a padded register->LDS layout can force
+// scalar ds_write_b16 even when the source tensor holds many contiguous bytes.
+static unsigned dsWriteCountOf(Operation *op) {
+  auto store = dyn_cast<triton::gpu::LocalStoreOp>(op);
+  if (!store)
+    return 1;
+  auto regTy = dyn_cast<RankedTensorType>(store.getSrc().getType());
+  auto memTy = dyn_cast<triton::gpu::MemDescType>(store.getDst().getType());
+  if (!regTy || !memTy)
+    return 1;
+
+  LinearLayout regLayout = triton::gpu::toLinearLayout(regTy);
+  LinearLayout cvt = LinearLayout::empty();
+  if (triton::gpu::isPaddedEncoding(memTy.getEncoding())) {
+    cvt = triton::invertAndComposeBlockLocal(
+        triton::gpu::paddedLinearLayout(memTy), regLayout);
+  } else {
+    LinearLayout sharedLayout = triton::gpu::toLinearLayout(memTy);
+    if (regLayout.isModular()) {
+      auto allocShape = triton::gpu::getAllocationShapePerCTA(memTy);
+      sharedLayout =
+          triton::gpu::toLinearLayout(allocShape, memTy.getEncoding());
+      SmallVector<std::pair<StringAttr, int32_t>> paddedOutDims;
+      for (StringAttr dim : regLayout.getOutDimNames())
+        paddedOutDims.push_back({dim, sharedLayout.getOutDimSize(dim)});
+      regLayout = LinearLayout(regLayout.getBases(), paddedOutDims,
+                               /*requireSurjective=*/false);
+    }
+    cvt = triton::invertAndComposeBlockLocal(sharedLayout, regLayout);
+  }
+  cvt = triton::actionRemoveBroadcastedRegs(cvt).apply(cvt);
+  std::optional<int> maxVec;
+  if (triton::gpu::isPaddedEncoding(memTy.getEncoding()))
+    maxVec = triton::gpu::getMinInterval(memTy.getEncoding());
+  unsigned bitWidth = memTy.getElementType().getIntOrFloatBitWidth();
+  auto [elemsPerVec, permutation] =
+      triton::largestVectorisation(op->getContext(), cvt, bitWidth, maxVec);
+  (void)permutation;
+  auto kReg = StringAttr::get(op->getContext(), "register");
+  return std::max(1, cvt.getInDimSize(kReg) / elemsPerVec);
+}
+
+static unsigned clampVectorSize(unsigned vec, RankedTensorType tensorTy) {
+  if (vec <= 1)
+    return vec;
+  if (!llvm::isPowerOf2_32(vec))
+    vec = 1u << llvm::Log2_32(vec);
+  if (auto blocked =
+          dyn_cast<triton::gpu::BlockedEncodingAttr>(tensorTy.getEncoding())) {
+    auto order = triton::gpu::getOrder(tensorTy);
+    unsigned sizePerThread = blocked.getSizePerThread()[order[0]];
+    if (sizePerThread && !llvm::isPowerOf2_32(sizePerThread))
+      vec = std::min(vec, sizePerThread & (0u - sizePerThread));
+  }
+  return vec;
+}
+
+// Match BufferLoadOpConversion / BufferLoadToLocalOpConversion: axis
+// contiguity and base-pointer alignment determine the actual buffer_load width.
+struct VMEMPrice {
+  unsigned count;
+  unsigned accessBytes;
+};
+
+static VMEMPrice
+priceBufferAccess(Value ptr, Value offset, unsigned contiguityHint,
+                  triton::AMD::ModuleAxisInfoAnalysis &axisInfo) {
+  auto offsetTy = dyn_cast<RankedTensorType>(offset.getType());
+  if (!offsetTy)
+    return {/*count=*/1, /*accessBytes=*/16};
+  unsigned elemBits = triton::getPointeeBitWidth(ptr.getType());
+  unsigned elemBytes = std::max(1u, elemBits / 8);
+  unsigned contiguity = axisInfo.getContiguity(offset, elemBits);
+  if (auto *info = axisInfo.getAxisInfo(ptr))
+    contiguity = std::min(
+        contiguity, std::max(1u, static_cast<unsigned>(
+                                     info->getDivisibility(0) / elemBytes)));
+
+  auto linear = triton::gpu::toLinearLayout(offsetTy);
+  auto linearAttr = triton::gpu::LinearEncodingAttr::get(offsetTy.getContext(),
+                                                         std::move(linear));
+  auto order = triton::gpu::getOrder(offsetTy);
+  auto perThread = linearAttr.getContigPerThread();
+  contiguity = std::min(contiguity, perThread[order[0]]);
+  unsigned vec = std::min(128u / elemBits, contiguity);
+  vec = clampVectorSize(vec, offsetTy);
+  vec = std::max(vec, contiguityHint);
+  unsigned elems = triton::gpu::getTotalElemsPerThread(offsetTy);
+  return {/*count=*/std::max(1u, (elems + vec - 1) / vec),
+          /*accessBytes=*/std::max(1u, vec * elemBytes)};
+}
+static VMEMPrice
+priceVMEM(Operation *op, triton::AMD::ModuleAxisInfoAnalysis &axisInfo) {
+  if (auto load = dyn_cast<triton::amdgpu::BufferLoadOp>(op))
+    return priceBufferAccess(load.getPtr(), load.getOffsets(),
+                             load.getContiguity(), axisInfo);
+  if (auto load = dyn_cast<triton::amdgpu::BufferLoadToLocalOp>(op))
+    return priceBufferAccess(load.getPtr(), load.getOffsets(),
+                             load.getContiguity(), axisInfo);
+  // The tile is the DESTINATION memdesc for buffer_load_to_local; operand(0)
+  // is the base pointer.
+  for (Value r : op->getResults()) {
+    if (auto md = dyn_cast<triton::gpu::MemDescType>(r.getType())) {
+      unsigned eb = std::max<unsigned>(
+          1, md.getElementType().getIntOrFloatBitWidth() / 8);
+      int64_t e = 1;
+      for (int64_t d : md.getShape())
+        e *= d;
+      return {/*count=*/std::max<unsigned>(
+                  1, (unsigned)((e * eb) / 256) / 16),
+              /*accessBytes=*/16};
+    }
+    if (isa<RankedTensorType>(r.getType()))
+      return {/*count=*/accessCount(r.getType(), 16), /*accessBytes=*/16};
+  }
+  for (Value v : op->getOperands())
+    if (auto md = dyn_cast<triton::gpu::MemDescType>(v.getType())) {
+      unsigned eb = std::max<unsigned>(
+          1, md.getElementType().getIntOrFloatBitWidth() / 8);
+      int64_t e = 1;
+      for (int64_t d : md.getShape())
+        e *= d;
+      return {/*count=*/std::max<unsigned>(
+                  1, (unsigned)((e * eb) / 256) / 16),
+              /*accessBytes=*/16};
+    }
+  return {/*count=*/1, /*accessBytes=*/16};
+}
+
+struct TritonAMDGPUSchedGroupBarrierSchedulerPass
+    : public impl::TritonAMDGPUSchedGroupBarrierSchedulerBase<
+          TritonAMDGPUSchedGroupBarrierSchedulerPass> {
+  using impl::TritonAMDGPUSchedGroupBarrierSchedulerBase<
+      TritonAMDGPUSchedGroupBarrierSchedulerPass>::
+      TritonAMDGPUSchedGroupBarrierSchedulerBase;
+
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    triton::AMD::ModuleAxisInfoAnalysis axisInfo(mod);
+
+    auto annotate = [&](Operation *op, int32_t mask, unsigned count,
+                        unsigned mfmaCover = 0) {
+      Builder b(op->getContext());
+      op->setAttr("ttg.amd.sched_group_barrier.machine_mask",
+                  b.getI32IntegerAttr(mask));
+      op->setAttr("ttg.amd.sched_group_barrier.machine_count",
+                  b.getI32IntegerAttr(count));
+      if (mfmaCover)
+        op->setAttr("ttg.amd.sched_group_barrier.mfma_cover",
+                    b.getI32IntegerAttr(mfmaCover));
+    };
+    mod.walk([&](Operation *op) {
+      if (isa<triton::DotOp, triton::DotScaledOp>(op))
+        annotate(op, kMaskMFMA, mfmaCountOf(op));
+      else if (isa<triton::gpu::LocalLoadOp>(op))
+        annotate(op, kMaskDSRead, dsReadCountOf(op));
+      else if (isa<triton::gpu::LocalStoreOp>(op))
+        annotate(op, kMaskDSWrite, dsWriteCountOf(op));
+      else if (isa<triton::gpu::AsyncCopyGlobalToLocalOp,
+                   triton::amdgpu::BufferLoadToLocalOp,
+                   triton::amdgpu::BufferLoadOp, triton::LoadOp>(op)) {
+        VMEMPrice price = priceVMEM(op, axisInfo);
+        // Keep the measured dwordx4 schedule as the calibration point, then
+        // scale the MFMA cover with the actual lowering width. This avoids
+        // over-covering a dword/dwordx2 stream merely because it contains more
+        // machine loads for the same TTGIR operation.
+        unsigned bytes = std::min(price.accessBytes, 16u);
+        unsigned cover = std::max(
+            1u, (static_cast<unsigned>(mfmaPerDwordx4) * bytes + 15u) / 16u);
+        annotate(op, kMaskVMEMRead, price.count, cover);
+      }
+    });
+
+    Builder b(&getContext());
+    mod->setAttr("ttg.amd.sched_group_barrier.enabled", b.getUnitAttr());
+    mod->setAttr("ttg.amd.sched_group_barrier.required_region_count",
+                 b.getI32IntegerAttr(
+                     static_cast<unsigned>(requiredRegionCount)));
+  }
+};
+
+} // namespace

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -121,6 +121,9 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
   ADD_PASS_OPTION_WRAPPER_1("add_dot_decompose_and_schedule",
                             mlir::createTritonAMDGPUDotDecomposeAndSchedule,
                             const std::string &);
+  ADD_PASS_OPTION_WRAPPER_2("add_sched_group_barrier_scheduler",
+                            mlir::createTritonAMDGPUSchedGroupBarrierScheduler,
+                            unsigned, unsigned);
   mlir::registerConSanAMDHooks();
   m.def("add_in_thread_transpose", [](mlir::PassManager &pm) {
     pm.addNestedPass<mlir::triton::FuncOp>(


### PR DESCRIPTION
Summary:
Add a TTGIR-guided instruction-scheduling algorithm for AMD matrix kernels. At final TTGIR, the pass maps MFMA, VMEM-read, DS-read, and DS-write operations to their eventual machine-instruction classes and predicts their lowering multiplicities from layout, MFMA encoding, AxisInfo, alignment, and vectorization.

After ModuleMembarAnalysis establishes the actual LDS hazard boundaries, the algorithm schedules each region as an anchor/cover pipeline. Memory instructions form the anchors, and independent MFMA issues form the latency-hiding cover. The pass partitions the available MFMA work across VMEM and DS anchors and emits ordered scheduling groups; blocks that do not match the selected Membar-region topology are left unchanged. AMD lowering materializes the groups at the Membar boundaries, allowing the machine scheduler to realize the TTGIR plan without LLVM IR reordering.

This placement combines tensor- and layout-level information that is no longer available in LLVM IR with the real hazard regions discovered by the backend. For B=1024, M=1195, N=256, K=2309, the eight-round paired warm-cache results are:

| Scheduling path | Median latency | vs. no scheduling | vs. best LLVM-IR |
| --- | ---: | ---: | ---: |
| No scheduling (before) | 2249 us | - | - |
| Best LLVM-IR scheduler | 2070 us | -8.0% | - |
| **TTGIR scheduling (after)** | **1972 us** | **-12.2%** | **-4.7%** |

TTGIR scheduling outperforms every LLVM-IR scheduling configuration evaluated for this kernel. All three variants are bitwise exact and use zero scratch.

Reviewed By: htyu

Differential Revision: D115508145


