### PR TITLE
[TLX][AMD] Skill + rule: GEMM perf benchmark harness (AOTI + JIT)

### DIFF
--- a/.claude/rules/gemm-perf-measurement.md
+++ b/.claude/rules/gemm-perf-measurement.md
@@ -1,0 +1,9 @@
+# Rule: measuring TLX GEMM perf — use the benchmark-harness skill
+
+When benchmarking or profiling the TLX addmm/bmm templates here (`third_party/tlx/language/tlx/inductor/*.jinja`, `registry.py`) vs rocBLAS / split-K / Stream-K on AMD gfx950, load the **`gemm-perf-benchmark-harness`** skill FIRST (full text: `fbcode/inference_acceleration/ops/.claude/skills/gemm-perf-benchmark-harness/SKILL.md`).
+
+It exists so you don't reproduce past perf results from scratch. The one rule you must not forget:
+
+**RULE #0 — do NOT judge TLX-vs-rocBLAS from an isolated eager/JIT `torch.profiler` or `do_bench` wall-clock.** They under-measure production hipBLASLt by ~15-40% (measured: rocBLAS `addmm 1024x1024x12288` = 40us isolated vs 47us in production AOTI kineto) and give the WRONG winner. Use the **production AOTI kineto** (`mts_gpu_benchmark --gpu-trace --op-level-profiling`, local `/tmp/libkineto_activities_<pid>.json`) or the **autotune `do_bench`** from the AUTOTUNE logs. Note rocBLAS/hipBLASLt is itself a split-K (`Cijk_..._PostGSU8_...` reducer) on undersaturated high-K shapes.
+
+The skill has the exact mts + JIT commands, the kineto parse snippet, the `sl cat -r <rev>` template-swap trick, and ground-truth numbers.


### PR DESCRIPTION
Summary:
Records the CORRECT way to measure TLX / split-K / Stream-K vs rocBLAS GEMM (addmm/bmm) perf on AMD gfx950 (MI350X) for the AOT_INDUCTOR-lowered ads merge nets, so we stop reproducing past perf results from scratch and stop drawing wrong conclusions from bad measurements.

Three files:
- `fbcode/inference_acceleration/ops/.claude/skills/gemm-perf-benchmark-harness/SKILL.md`: the harnesses (production AOTI via `mts_gpu_benchmark --gpu-trace --op-level-profiling` + local kineto parse; JIT autotune recompare), a method matrix, the exact commands/flags, the `sl cat` template-swap trick, and ground-truth numbers.
- `fbcode/inference_acceleration/ops/.claude/skills/gemm-perf-benchmark-harness/tlx_selection_report.py` (+ `BUCK`): generates the standard TLX-selection report from a TLX-`allow` mts log plus its kineto trace -- GEMM share of merge latency, one table per (op category, model) with every kernel ranked by measured `ms/iter = us/call x calls/iter`, the shapes TLX beats rocBLAS on and loses on, and a shape-characteristics summary to steer template work. Example output: P2457097152.
- `third-party/triton/beta/triton/.claude/rules/gemm-perf-measurement.md`: a thin auto-load pointer that surfaces the skill when editing the TLX addmm/bmm templates in that tree.

RULE #0 (the mistake this prevents): do NOT judge TLX-vs-rocBLAS from an isolated eager/JIT `torch.profiler` or `do_bench` wall-clock -- they under-measure production hipBLASLt by ~15-40% (measured: rocBLAS addmm 1024x1024x12288 = 40us isolated vs 47us in production AOTI kineto) and pick the wrong winner. Use the production AOTI kineto or the autotune `do_bench`. (rocBLAS/hipBLASLt is itself a split-K -- `Cijk_..._PostGSU8_...` reducer -- on undersaturated high-K shapes.)

The skill also now documents the split-K accounting trap it took two studies to pin down: autotune scores a candidate on the GEMM kernel alone and excludes the separate `_reduce_k` kernel (7.6 / 9.0 / 15.1 us for SK=2/4/8 at a 1024x1024 output), so split-K can win selection while losing e2e. Verified on HI OC 700x: enabling split-K moved ~2 ms/iter of GEMM work from rocBLAS to TLX for zero net GEMM gain.

Authored with Claude Code.

Reviewed By: jobodobo

Differential Revision: D114691147


