### PR TITLE
[triton][beta][Test-Fix] Preserve realizable nested branch layouts (#2837)

### DIFF
--- a/test/TLX/insert-require-layout-pipeline-fallback.mlir
+++ b/test/TLX/insert-require-layout-pipeline-fallback.mlir
@@ -38,6 +38,85 @@ module attributes {tlx.has_explicit_local_mem_access = true, "ttg.num-ctas" = 1 
 }
 
 // -----
+#blocked_nested = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma_nested = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [16, 16, 16], isTransposed = true}>
+#dot_nested = #ttg.dot_op<{opIdx = 0, parent = #mma_nested, kWidth = 4}>
+#shared_nested = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem_nested = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-DAG: #[[$NESTED_BLOCKED:.*]] = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+  // CHECK-DAG: #[[$NESTED_MMA:.*]] = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [16, 16, 16], isTransposed = true}>
+  // CHECK-LABEL: @nested_non_retaggable_edge
+  tt.func public @nested_non_retaggable_edge(
+      %cond: i1,
+      %x: tensor<64x32xf32, #blocked_nested>) -> tensor<64x32xbf16, #dot_nested> {
+    %trunc = arith.truncf %x : tensor<64x32xf32, #blocked_nested> to tensor<64x32xbf16, #blocked_nested>
+    %alloc = ttg.local_alloc %trunc : (tensor<64x32xbf16, #blocked_nested>) -> !ttg.memdesc<64x32xbf16, #shared_nested, #smem_nested>
+    // CHECK: ttg.local_load {{.*}} -> tensor<64x32xbf16, #[[$NESTED_BLOCKED]]>
+    %load = ttg.local_load %alloc : !ttg.memdesc<64x32xbf16, #shared_nested, #smem_nested> -> tensor<64x32xbf16, #blocked_nested>
+    // CHECK: scf.if {{.*}} -> (tensor<64x32xbf16, #[[$NESTED_BLOCKED]]>)
+    %selected = scf.if %cond -> (tensor<64x32xbf16, #blocked_nested>) {
+      %inner = scf.if %cond -> (tensor<64x32xbf16, #blocked_nested>) {
+        scf.yield %trunc : tensor<64x32xbf16, #blocked_nested>
+      } else {
+        scf.yield %trunc : tensor<64x32xbf16, #blocked_nested>
+      }
+      scf.yield %inner : tensor<64x32xbf16, #blocked_nested>
+    } else {
+      scf.yield %load : tensor<64x32xbf16, #blocked_nested>
+    }
+    %required = tlx.require_layout %selected : tensor<64x32xbf16, #blocked_nested> -> tensor<64x32xbf16, #dot_nested>
+    tt.return %required : tensor<64x32xbf16, #dot_nested>
+  }
+
+  // CHECK-LABEL: @nested_blocked_inward
+  tt.func public @nested_blocked_inward(
+      %cond: i1,
+      %x: tensor<64x32xf32, #blocked_nested>,
+      %buf: !ttg.memdesc<64x32xbf16, #shared_nested, #smem_nested>) -> tensor<64x32xbf16, #dot_nested> {
+    %trunc = arith.truncf %x : tensor<64x32xf32, #blocked_nested> to tensor<64x32xbf16, #blocked_nested>
+    // CHECK: ttg.local_load {{.*}} -> tensor<64x32xbf16, #[[$NESTED_BLOCKED]]>
+    %load = ttg.local_load %buf : !ttg.memdesc<64x32xbf16, #shared_nested, #smem_nested> -> tensor<64x32xbf16, #blocked_nested>
+    // CHECK: scf.if {{.*}} -> (tensor<64x32xbf16, #[[$NESTED_BLOCKED]]>)
+    %selected = scf.if %cond -> (tensor<64x32xbf16, #blocked_nested>) {
+      %inner = scf.if %cond -> (tensor<64x32xbf16, #blocked_nested>) {
+        scf.yield %load : tensor<64x32xbf16, #blocked_nested>
+      } else {
+        scf.yield %load : tensor<64x32xbf16, #blocked_nested>
+      }
+      scf.yield %inner : tensor<64x32xbf16, #blocked_nested>
+    } else {
+      scf.yield %trunc : tensor<64x32xbf16, #blocked_nested>
+    }
+    %required = tlx.require_layout %selected : tensor<64x32xbf16, #blocked_nested> -> tensor<64x32xbf16, #dot_nested>
+    tt.return %required : tensor<64x32xbf16, #dot_nested>
+  }
+
+  // CHECK-LABEL: @nested_retaggable_edges
+  tt.func public @nested_retaggable_edges(
+      %cond: i1,
+      %buf: !ttg.memdesc<64x32xbf16, #shared_nested, #smem_nested>) -> tensor<64x32xbf16, #dot_nested> {
+    // CHECK: ttg.local_load {{.*}} -> tensor<64x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #[[$NESTED_MMA]], kWidth = 4}>>
+    %load = ttg.local_load %buf : !ttg.memdesc<64x32xbf16, #shared_nested, #smem_nested> -> tensor<64x32xbf16, #blocked_nested>
+    // CHECK: scf.if {{.*}} -> (tensor<64x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #[[$NESTED_MMA]], kWidth = 4}>>)
+    %selected = scf.if %cond -> (tensor<64x32xbf16, #blocked_nested>) {
+      // CHECK: scf.if {{.*}} -> (tensor<64x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #[[$NESTED_MMA]], kWidth = 4}>>)
+      %inner = scf.if %cond -> (tensor<64x32xbf16, #blocked_nested>) {
+        scf.yield %load : tensor<64x32xbf16, #blocked_nested>
+      } else {
+        scf.yield %load : tensor<64x32xbf16, #blocked_nested>
+      }
+      scf.yield %inner : tensor<64x32xbf16, #blocked_nested>
+    } else {
+      scf.yield %load : tensor<64x32xbf16, #blocked_nested>
+    }
+    %required = tlx.require_layout %selected : tensor<64x32xbf16, #blocked_nested> -> tensor<64x32xbf16, #dot_nested>
+    tt.return %required : tensor<64x32xbf16, #dot_nested>
+  }
+}
+
+// -----
 // Test that when tensor propagation through an scf.for carrier cannot make the
 // init value and the backedge agree, the pipeline keeps an explicit layout
 // conversion instead of retagging the loop-carried tensor.

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -9,6 +9,7 @@
 #include "triton/Dialect/TritonGPU/IR/Types.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
@@ -170,9 +171,7 @@ static bool isRetaggableTensorProducerValue(Value value) {
     return false;
 
   Operation *definingOp = value.getDefiningOp();
-  // Sparse dataflow handles the RegionBranchOpInterface edge consistency; if
-  // all incoming values agree, retagging the region result is safe.
-  return isa_and_nonnull<ttg::LocalLoadOp, RegionBranchOpInterface>(definingOp);
+  return isa_and_nonnull<ttg::LocalLoadOp>(definingOp);
 }
 
 static Type getTensorCandidateType(Value value, DataFlowSolver &solver,
@@ -312,9 +311,30 @@ collectRegionBranchSuccessors(RegionBranchOpInterface branchOp,
   }
 }
 
+using TensorTypeMap = llvm::DenseMap<Value, Type>;
+
+struct TensorRegionInfo {
+  llvm::DenseSet<Value> blockedValues;
+  TensorTypeMap regionTypes;
+};
+
+// The type an incoming region edge value actually contributes to the consensus.
+static Type getTensorEdgeType(Value value, DataFlowSolver &solver,
+                              const llvm::DenseSet<Value> &blockedValues,
+                              const TensorTypeMap &regionTypes) {
+  auto tensorType = cast<RankedTensorType>(value.getType());
+  // Region carriers must use the type realizable by their nested input edges.
+  if (auto it = regionTypes.find(value); it != regionTypes.end())
+    return it->second;
+  if (!isRetaggableTensorProducerValue(value))
+    return tensorType;
+  return getTensorCandidateType(value, solver, blockedValues);
+}
+
 static std::optional<Type>
 getTensorConsensusType(ValueRange values, DataFlowSolver &solver,
-                       const llvm::DenseSet<Value> &blockedValues) {
+                       const llvm::DenseSet<Value> &blockedValues,
+                       const TensorTypeMap &regionTypes) {
   if (values.empty())
     return std::nullopt;
 
@@ -323,7 +343,8 @@ getTensorConsensusType(ValueRange values, DataFlowSolver &solver,
     if (!isa<RankedTensorType>(value.getType()))
       return std::nullopt;
 
-    Type candidateType = getTensorCandidateType(value, solver, blockedValues);
+    Type candidateType =
+        getTensorEdgeType(value, solver, blockedValues, regionTypes);
     if (!consensusType) {
       consensusType = candidateType;
       continue;
@@ -334,12 +355,69 @@ getTensorConsensusType(ValueRange values, DataFlowSolver &solver,
   return consensusType;
 }
 
-static llvm::DenseSet<Value>
-computeBlockedTensorValues(triton::FuncOp funcOp, DataFlowSolver &solver) {
-  llvm::DenseSet<Value> blockedValues;
+static TensorTypeMap
+computeTensorRegionTypes(triton::FuncOp funcOp, DataFlowSolver &solver,
+                         const llvm::DenseSet<Value> &blockedValues) {
+  TensorTypeMap regionTypes;
+  funcOp.walk([&](RegionBranchOpInterface branchOp) {
+    SmallVector<RegionSuccessor> successors;
+    collectRegionBranchSuccessors(branchOp, successors);
+    for (RegionSuccessor successor : successors) {
+      for (Value input : branchOp.getSuccessorInputs(successor)) {
+        if (isa<RankedTensorType>(input.getType()))
+          regionTypes.try_emplace(
+              input, getTensorCandidateType(input, solver, blockedValues));
+      }
+    }
+  });
+
   bool changed = true;
   while (changed) {
     changed = false;
+    funcOp.walk<WalkOrder::PostOrder>([&](RegionBranchOpInterface branchOp) {
+      SmallVector<RegionSuccessor> successors;
+      collectRegionBranchSuccessors(branchOp, successors);
+      for (RegionSuccessor successor : successors) {
+        ValueRange inputs = branchOp.getSuccessorInputs(successor);
+        for (auto [index, input] : llvm::enumerate(inputs)) {
+          auto tensorType = dyn_cast<RankedTensorType>(input.getType());
+          if (!tensorType)
+            continue;
+
+          SmallVector<Value> predecessors;
+          branchOp.getPredecessorValues(successor, index, predecessors);
+          if (predecessors.empty())
+            continue;
+
+          std::optional<Type> consensus = getTensorConsensusType(
+              ValueRange(predecessors), solver, blockedValues, regionTypes);
+          Type type = consensus.value_or(input.getType());
+          if (blockedValues.contains(input) ||
+              isa_and_nonnull<UserLayoutAttr>(tensorType.getEncoding()))
+            type = input.getType();
+          auto it = regionTypes.find(input);
+          assert(it != regionTypes.end() && "expected seeded region type");
+          if (it == regionTypes.end())
+            continue;
+          if (it->second == type)
+            continue;
+          it->second = type;
+          changed = true;
+        }
+      }
+    });
+  }
+  return regionTypes;
+}
+
+static TensorRegionInfo computeTensorRegionInfo(triton::FuncOp funcOp,
+                                                DataFlowSolver &solver) {
+  TensorRegionInfo info;
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    info.regionTypes =
+        computeTensorRegionTypes(funcOp, solver, info.blockedValues);
     funcOp.walk([&](RegionBranchOpInterface branchOp) {
       SmallVector<RegionSuccessor> successors;
       collectRegionBranchSuccessors(branchOp, successors);
@@ -355,55 +433,41 @@ computeBlockedTensorValues(triton::FuncOp funcOp, DataFlowSolver &solver) {
           if (predecessorValues.empty())
             continue;
 
-          if (getTensorConsensusType(ValueRange(predecessorValues), solver,
-                                     blockedValues))
+          bool successorBlocked = info.blockedValues.contains(successorInput);
+          if (!successorBlocked &&
+              getTensorConsensusType(ValueRange(predecessorValues), solver,
+                                     info.blockedValues, info.regionTypes))
             continue;
 
-          LDBG("Blocking tensor carrier value due to inconsistent predecessor "
-               "layouts at "
-               << branchOp->getName());
-          changed |= blockedValues.insert(successorInput).second;
+          if (!successorBlocked)
+            LDBG("Blocking tensor carrier value due to inconsistent "
+                 "predecessor layouts at "
+                 << branchOp->getName());
+          changed |= info.blockedValues.insert(successorInput).second;
           for (Value predecessorValue : predecessorValues) {
             if (!isa<RankedTensorType>(predecessorValue.getType()))
               continue;
-            changed |= blockedValues.insert(predecessorValue).second;
+            changed |= info.blockedValues.insert(predecessorValue).second;
           }
         }
       }
-
-      return WalkResult::advance();
     });
   }
 
-  return blockedValues;
+  return info;
 }
 
-static void
-updateTensorRegionBranchTypes(triton::FuncOp funcOp, DataFlowSolver &solver,
-                              const llvm::DenseSet<Value> &blockedValues) {
+static void updateTensorRegionBranchTypes(triton::FuncOp funcOp,
+                                          const TensorTypeMap &regionTypes) {
   funcOp.walk<WalkOrder::PostOrder>([&](RegionBranchOpInterface branchOp) {
     SmallVector<RegionSuccessor> successors;
     collectRegionBranchSuccessors(branchOp, successors);
 
-    bool changed = true;
-    while (changed) {
-      changed = false;
-      for (RegionSuccessor successor : successors) {
-        ValueRange successorInputs = branchOp.getSuccessorInputs(successor);
-        for (auto [index, successorInput] : llvm::enumerate(successorInputs)) {
-          if (!isa<RankedTensorType>(successorInput.getType()))
-            continue;
-
-          SmallVector<Value> predecessorValues;
-          branchOp.getPredecessorValues(successor, index, predecessorValues);
-          std::optional<Type> consensusType = getTensorConsensusType(
-              ValueRange(predecessorValues), solver, blockedValues);
-          if (!consensusType || successorInput.getType() == *consensusType)
-            continue;
-
-          successorInput.setType(*consensusType);
-          changed = true;
-        }
+    for (RegionSuccessor successor : successors) {
+      for (Value input : branchOp.getSuccessorInputs(successor)) {
+        auto it = regionTypes.find(input);
+        if (it != regionTypes.end() && input.getType() != it->second)
+          input.setType(it->second);
       }
     }
   });
@@ -473,8 +537,7 @@ public:
     if (failed(solver.initializeAndRun(op)))
       return signalPassFailure();
 
-    llvm::DenseSet<Value> blockedTensorValues =
-        computeBlockedTensorValues(funcOp, solver);
+    TensorRegionInfo tensorRegionInfo = computeTensorRegionInfo(funcOp, solver);
 
     WalkResult typeRewriteWalk = funcOp.walk([&](mlir::Operation *op) {
       if (isa<tlx::RequireLayoutOp>(op))
@@ -523,7 +586,8 @@ public:
 
       for (Value result : op->getResults()) {
         if (!isa<ttg::MemDescType>(result.getType())) {
-          rewriteTensorValueFromLattice(result, solver, blockedTensorValues);
+          rewriteTensorValueFromLattice(result, solver,
+                                        tensorRegionInfo.blockedValues);
           continue;
         }
 
@@ -535,7 +599,7 @@ public:
     if (typeRewriteWalk.wasInterrupted())
       return signalPassFailure();
 
-    updateTensorRegionBranchTypes(funcOp, solver, blockedTensorValues);
+    updateTensorRegionBranchTypes(funcOp, tensorRegionInfo.regionTypes);
 
     // Verify that no DummyTMEMLayoutAttr remains after layout propagation.
     bool hasDummyLayout = false;


### PR DESCRIPTION
Summary:

# Problem
- The Triton 3.5 to 3.8 upgrade makes [`test_cross_attn_triton_v3_layout_repro`](https://www.internalfb.com/intern/testinfra/diagnostics/28428972673151231.562950355354059.1786611987/) fail on MI300/gfx942 while compiling the Triton V3 cross-attention backward kernel [`_hstu_attn_bwd_redkv`](https://www.internalfb.com/code/fbsource/[0e67b94cf7c229fe4baa8f37a8dd6965902cc898]/fbcode/hammer/v2/ops/triton/template/triton_bw_cross_attention.py), called through `_hstu_attn_bwd_redkv_inner`.
- The compiler fails at the nested `if off_h < num_softmax_heads` / `if q_needs_mask or HAS_CAUSAL` branch with this exact error:
```
error: 'scf.if' op along control flow edge from Operation scf.yield to parent: successor operand type #1 'tensor<64x32xbf16, #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>>' should match successor input type #1 'tensor<64x32xbf16, #ttg.dot_op<{opIdx = 0, parent = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [16, 16, 16], isTransposed = true}>, kWidth = 4}>>'
```
- A nested `scf.if` yields a blocked tensor while its result is retagged to a dot layout, violating the region edge type contract. The kernel does not execute; this is a TLX compiler failure.
- The exact HSTU case passes on stable Triton 3.5 and fails on unpatched beta Triton 3.8.

# Root Cause
- The first bad compiler change is D106525260, which added tensor backward propagation through `RegionBranchOpInterface`. On 3.8 we tested reverting this diff which fixed our failures.
- The lattice type for a nested branch result is only a proposal. It can be dot even when a non-retaggable incoming edge must remain blocked. Using that proposal in the enclosing branch consensus creates an unrealizable result type.
- When an outer carrier is blocked by a conflicting edge, that constraint must also propagate inward to nested carriers and local loads.

# This Diff
- Computes realizable region-carrier types from actual predecessor candidates, bottom-up to a fixed point.
- Retags only local-load producers directly and propagates blocked carrier constraints through incoming edges.
- Keeps legal propagation: a nested branch whose edges are all retaggable still becomes dot layout.
- Adds three focused MLIR cases for the unrealizable edge, inward blocking, and the legal positive path.

Reviewed By: njriasan

Differential Revision: D115701797


