### PR TITLE
[triton][beta][AMD][Test-Fix] Key the C cache by storage-size specialization (#2838)

### DIFF
--- a/python/src/_torch_bridge.cpp
+++ b/python/src/_torch_bridge.cpp
@@ -33,6 +33,8 @@ struct TritonTensorAccessAPI {
   // device, 0 if it is a torch tensor NOT on CUDA (e.g. a cpu tensor), and -1
   // if obj is not a torch tensor at all (device unknown — caller decides).
   int8_t (*is_cuda_tensor)(PyObject *obj);
+  int (*extract_tensor_metadata)(PyObject *obj, uint64_t *out_data_ptr,
+                                 uint64_t *out_storage_size);
 };
 
 // ============================================================================
@@ -63,6 +65,20 @@ static int8_t fast_is_cuda_tensor(PyObject *obj) {
     return -1; // not a torch tensor — device unknown to the bridge
   const auto &tensor = THPVariable_Unpack(obj);
   return tensor.is_cuda() ? 1 : 0;
+}
+
+static int fast_extract_tensor_metadata(PyObject *obj, uint64_t *out_data_ptr,
+                                        uint64_t *out_storage_size) {
+  if (!THPVariable_Check(obj))
+    return -1;
+  try {
+    const auto &tensor = THPVariable_Unpack(obj);
+    *out_data_ptr = reinterpret_cast<uint64_t>(tensor.data_ptr());
+    *out_storage_size = tensor.storage().nbytes();
+    return 0;
+  } catch (...) {
+    return -1;
+  }
 }
 
 // Interned attribute name strings for fast dict lookup
@@ -126,10 +142,9 @@ static int fast_extract_tensordesc(PyObject *td_obj, uint64_t *out_data_ptr,
 
 // Singleton API instance
 static TritonTensorAccessAPI g_api = {
-    fast_get_scalar_type,
-    fast_get_data_ptr,
-    fast_extract_tensordesc,
-    fast_is_cuda_tensor,
+    fast_get_scalar_type,         fast_get_data_ptr,
+    fast_extract_tensordesc,      fast_is_cuda_tensor,
+    fast_extract_tensor_metadata,
 };
 
 // ============================================================================

--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -119,6 +119,8 @@ struct TritonTensorAccessAPI {
   int (*extract_tensordesc)(PyObject *td_obj, uint64_t *out_data_ptr,
                             int64_t *out_shape, int64_t *out_strides,
                             int max_ndim);
+  int8_t (*is_cuda_tensor)(PyObject *);
+  int (*extract_tensor_metadata)(PyObject *, uint64_t *, uint64_t *);
 };
 static TritonTensorAccessAPI *g_tensor_api = nullptr;
 
@@ -786,6 +788,7 @@ struct FastCache {
   FCEntry *table;
   size_t capacity;
   size_t count;
+  uint64_t tensor_size_threshold = 0;
 
   FastCache() : n_params(0), table(nullptr), capacity(0), count(0) {
     memset(param_meta, 0, sizeof(param_meta));
@@ -1080,14 +1083,30 @@ slow_path:
   return is_const ? (TC_PTR_CONST_BASE + code) : (TC_PTR_BASE + code);
 }
 
-static int fc_get_tensor_alignment(PyObject *arg) {
-  // Fast path: direct struct access via torch_bridge
-  if (g_tensor_api) {
+static int fc_get_tensor_specialization(PyObject *arg, uint64_t threshold,
+                                        bool align) {
+  int size_bit = 0;
+  if (threshold) {
+    // Unknown size cannot be keyed safely; use Python specialization.
+    if (!g_tensor_api || !g_tensor_api->extract_tensor_metadata)
+      return -1;
+    uint64_t ptr;
+    uint64_t storage_size;
+    if (g_tensor_api->extract_tensor_metadata(arg, &ptr, &storage_size) < 0)
+      return -1;
+    size_bit = storage_size <= threshold ? 2 : 0;
+    if (!align)
+      return size_bit;
+    if (ptr != 0)
+      return ((ptr & 15) == 0 ? 1 : 0) | size_bit;
+  } else if (!align) {
+    return 0;
+  } else if (g_tensor_api) {
     uint64_t ptr = g_tensor_api->get_data_ptr(arg);
     if (ptr != 0)
       return (ptr & 15) == 0 ? 1 : 0;
-    // ptr==0: either not a torch tensor or zero-size tensor — fall through
   }
+
   PyObject *ptr_obj = PyObject_CallMethodNoArgs(arg, data_ptr_attr);
   if (!ptr_obj)
     return -1;
@@ -1095,7 +1114,7 @@ static int fc_get_tensor_alignment(PyObject *arg) {
   Py_DECREF(ptr_obj);
   if (PyErr_Occurred())
     return -1;
-  return (ptr & 15) == 0 ? 1 : 0;
+  return ((ptr & 15) == 0 ? 1 : 0) | size_bit;
 }
 
 static void fc_capsule_destructor(PyObject *capsule) {
@@ -1312,15 +1331,14 @@ static bool fc_build_key(FCCacheKey &key, FastCache *cache,
       key.slots[i].type_code = tc;
       bool spec = !meta.do_not_specialize;
       bool align_flag = !meta.do_not_specialize_on_alignment;
-      if (spec && align_flag) {
-        int a = fc_get_tensor_alignment(arg);
-        if (a < 0) {
+      if (spec) {
+        int value = fc_get_tensor_specialization(
+            arg, cache->tensor_size_threshold, align_flag);
+        if (value < 0) {
           PyErr_Clear();
           return false;
         }
-        key.slots[i].align_bit = (uint8_t)a;
-      } else if (spec) {
-        key.slots[i].align_bit = 0;
+        key.slots[i].align_bit = (uint8_t)value;
       } else {
         key.slots[i].align_bit = 255;
       }
@@ -1347,15 +1365,14 @@ static bool fc_build_key(FCCacheKey &key, FastCache *cache,
         key.slots[i].type_code = tc;
         bool spec = !meta.do_not_specialize;
         bool align_flag = !meta.do_not_specialize_on_alignment;
-        if (spec && align_flag) {
-          int a = fc_get_tensor_alignment(arg);
-          if (a < 0) {
+        if (spec) {
+          int value = fc_get_tensor_specialization(
+              arg, cache->tensor_size_threshold, align_flag);
+          if (value < 0) {
             PyErr_Clear();
             return false;
           }
-          key.slots[i].align_bit = (uint8_t)a;
-        } else if (spec) {
-          key.slots[i].align_bit = 0;
+          key.slots[i].align_bit = (uint8_t)value;
         } else {
           key.slots[i].align_bit = 255;
         }
@@ -1537,6 +1554,23 @@ PyObject *native_fast_dispatch_insert(PyObject *self, PyObject *const *args,
   if (!cache) {
     PyErr_Clear();
     Py_RETURN_NONE;
+  }
+
+  // Binding precedes insertion, so the threshold is available by the time the
+  // first entry is built. Before then, lookups skip key construction entirely.
+  if (cache->count == 0) {
+    PyObject *value =
+        PyObject_GetAttrString(jit_fn, "_fc_tensor_size_threshold");
+    if (!value) {
+      PyErr_Clear();
+      Py_RETURN_NONE;
+    }
+    cache->tensor_size_threshold = PyLong_AsUnsignedLongLong(value);
+    Py_DECREF(value);
+    if (PyErr_Occurred()) {
+      PyErr_Clear();
+      Py_RETURN_NONE;
+    }
   }
 
   FCCacheKey key;

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -851,6 +851,25 @@ def test_within_2gb(device, fresh_triton_cache) -> None:
             kernel_add[(1, 0)](torch.empty(2**31 - 1, dtype=torch.int8, device=device))
             assert pointer_range_32 == pointer_range
 
+        with triton.knobs.runtime.scope():
+            # The C cache must distinguish HIP's storage-size specializations.
+            triton.knobs.runtime.jit_cache_hook = None
+            triton.knobs.amd.use_buffer_ops = True
+
+            @triton.jit(c_cache=True)
+            def kernel_add_with_c_cache(a):
+                tl.load(a)
+
+            launch = kernel_add_with_c_cache[(1, 0)]
+            launch(torch.empty(2**31 - 1, dtype=torch.int8, device=device))
+            assert kernel_add_with_c_cache.c_cache is True
+            device_id = getattr(torch, device).current_device()
+            kernel_cache = kernel_add_with_c_cache.device_caches[device_id][0]
+            assert len(kernel_cache) == 1
+
+            launch(torch.empty(2**31, dtype=torch.int8, device=device))
+            assert len(kernel_cache) == 2
+
 
 def test_function_arguments(device):
 

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -928,6 +928,9 @@ class JITFunction(JITCallable, KernelInterface[T]):
         from ..compiler import CompiledKernel, compile, ASTSource, make_backend
         target = driver.active.get_current_target()
         backend = make_backend(target)
+        if self.c_cache:
+            get_threshold = getattr(backend, "get_tensor_size_specialization_threshold", None)
+            self._fc_tensor_size_threshold = (get_threshold() if get_threshold else None) or 0
         self.CompiledKernel = CompiledKernel
         self.compile = compile
         self.ASTSource = ASTSource

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -12,6 +12,8 @@ import functools
 import warnings
 from pathlib import Path
 
+MAX_INT_32 = 2**31 - 1
+
 
 def get_min_dot_size(target: GPUTarget):
     # We fallback to use FMA and cast arguments if certain configurations is
@@ -259,12 +261,14 @@ class HIPBackend(BaseBackend):
         elif HIPBackend._torch_available:
             import torch
 
-        MAX_INT_32 = 2**31 - 1
         if hasattr(arg, "ptr_range"):
             return arg.ptr_range() <= MAX_INT_32
         if (HIPBackend._torch_available and isinstance(arg, torch.Tensor) and hasattr(arg, "untyped_storage")):
             return arg.untyped_storage().size() <= MAX_INT_32
         return False
+
+    def get_tensor_size_specialization_threshold(self):
+        return MAX_INT_32 if knobs.amd.use_buffer_ops else None
 
     @staticmethod
     def parse_attr(desc):


### PR DESCRIPTION
Summary:

# Problem
On MI300/gfx942, the Triton 3.8 promotion makes `fbcode//hammer/ops/tests/amd:jagged_test - test_concat_2D_jagged_backward_triton` silently return wrong data for `case='large_64bit'` (`D=512`, `batch_size=512`, `max_len_a=2560`). See CI of D115081437 and https://www.internalfb.com/intern/testinfra/testconsole/testrun/10696049304217615/
```
FAIL: test_concat_2D_jagged_backward_triton (hammer.ops.tests.amd.jagged_test.Concat2DJaggedBackwardTest) (case='large_64bit', D=1024, batch_size=256, max_len_a=2560)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/users/warrdeng/internal-triton-pin/pinned-412571651-clean/buck-out/v2/art/fbcode/bf11e3f435d2405a/hammer/ops/tests/amd/__jagged_test__/jagged_test#link-tree/hammer/ops/tests/amd/jagged_test.py", line 588, in test_concat_2D_jagged_backward_triton
    self._run_case(
  File "/data/users/warrdeng/internal-triton-pin/pinned-412571651-clean/buck-out/v2/art/fbcode/bf11e3f435d2405a/hammer/ops/tests/amd/__jagged_test__/jagged_test#link-tree/hammer/ops/tests/amd/jagged_test.py", line 544, in _run_case
    torch.testing.assert_close(out, ref_out)
  File "/data/users/warrdeng/internal-triton-pin/pinned-412571651-clean/buck-out/v2/art/fbcode/bf11e3f435d2405a/hammer/ops/tests/amd/__jagged_test__/jagged_test#link-tree/torch/testing/_comparison.py", line 1689, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 134478536 / 671350784 (20.0%)
Greatest absolute difference: 1.0 at index (527895, 577) (up to 1e-05 allowed)
Greatest relative difference: 1.0 at index (524287, 1023) (up to 1.3e-06 allowed)
```

Independently running this test on Triton 3.5 shows that this is a new regression.

# Root cause:
We validated on Triton 3.8 that setting `TRITON_ENABLE_C_CACHE=0` fixes the issue on MI300
```
buck test fbcode//mode/opt-amd-gpu \
    fbcode//hammer/ops/tests/amd:jagged_test -- \
    --env TRITON_ENABLE_C_CACHE=0 \
    --exact 'fbcode//hammer/ops/tests/amd:jagged_test - test_concat_2D_jagged_backward_triton
    (hammer.ops.tests.amd.jagged_test.Concat2DJaggedBackwardTest)
```
With buffer operations enabled, HIP compiles different kernel variants based on each tensor argument's backing-storage size. Backing storage of at most 2 GiB receives a 32-bit pointer-range assumption; larger storage requires general addressing. Triton's Python cache distinguishes these variants, but the C fast-dispatch cache did not. It could therefore reuse a kernel compiled for a small backing allocation when launching the same function with a larger one, where that addressing assumption is invalid. In the failing case this returns incorrect tensor data.

# This Diff
Keep the C fast-dispatch cache enabled and add the missing distinction to its existing tensor-specialization byte. HIP supplies its existing buffer-operations storage threshold. The PyTorch bridge returns backing-storage bytes alongside its pointer metadata, allowing the cache to distinguish the two kernel variants.

The generic cache does not hardcode 2 GiB. Backends without size-based specialization retain the existing key path. Tensor-like objects whose storage size cannot be obtained safely fall back to Python specialization instead of risking an incorrect cache hit.

This adds no Python call to the launch path. HIP performs the same number of native bridge calls as before; the existing pointer extraction also returns backing-storage size.

Reviewed By: tissue3, njriasan

Differential Revision: D115701753
