### PR TITLE
[triton][beta][AMD] Fast-path flat HIP launcher signatures

### DIFF
--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -1050,6 +1050,7 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
   PyObject *arg_annotations = NULL;
   Py_buffer signature;
   PyObject *kernel_args = NULL;
+  PyObject *fast_kernel_args = NULL;
   if (!PyArg_ParseTuple(args, "piiiKKOO(iii)OOOiOy*O", &launch_cooperative_grid,
                         &gridX, &gridY, &gridZ, &_stream, &_function,
                         &global_scratch_obj, &profile_scratch_obj, &num_warps,
@@ -1067,14 +1068,31 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
   uint8_t *extractor_data = (uint8_t *)signature.buf;
   Py_ssize_t num_args = signature.len;
 
-  // Extract kernel parameters - flatten tuples & remove constexpr.
-  PyObject **args_data = (PyObject **)alloca(num_args * sizeof(PyObject *));
-  if (args_data == NULL) {
-    goto cleanup;
-  }
-  int list_idx = 0;
-  if (!extractArgs(args_data, &list_idx, kernel_args, arg_annotations)) {
-    goto cleanup;
+  // Flat runtime signatures need no constexpr filtering or tuple flattening.
+  // Keep the annotation walk for structured signatures only.
+  PyObject **args_data;
+  if (arg_annotations == Py_None) {
+    fast_kernel_args = PySequence_Fast(
+        kernel_args, "Expected kernel_args to be a sequence or iterable");
+    if (!fast_kernel_args) {
+      goto cleanup;
+    }
+    if (PySequence_Fast_GET_SIZE(fast_kernel_args) != num_args) {
+      PyErr_Format(PyExc_TypeError,
+                   "Expected %zd kernel arguments, received %zd", num_args,
+                   PySequence_Fast_GET_SIZE(fast_kernel_args));
+      goto cleanup;
+    }
+    args_data = PySequence_Fast_ITEMS(fast_kernel_args);
+  } else {
+    args_data = (PyObject **)alloca(num_args * sizeof(PyObject *));
+    if (args_data == NULL) {
+      goto cleanup;
+    }
+    int list_idx = 0;
+    if (!extractArgs(args_data, &list_idx, kernel_args, arg_annotations)) {
+      goto cleanup;
+    }
   }
 
   // Number of parameters passed to kernel. + 2 for global & profile scratch.
@@ -1119,10 +1137,12 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
   if (PyErr_Occurred()) {
     goto cleanup;
   }
+  Py_XDECREF(fast_kernel_args);
   PyBuffer_Release(&signature);
   Py_RETURN_NONE;
 
 cleanup:
+  Py_XDECREF(fast_kernel_args);
   PyBuffer_Release(&signature);
   return NULL;
 }

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -323,7 +323,11 @@ class HIPLauncher(object):
         tensordesc_meta = getattr(metadata, "tensordesc_meta", None)
         launcher = triton.runtime.driver.active.utils.launch
         expanded_signature = expand_signature(signature.values(), tensordesc_meta, "tensordesc")
-        self.arg_annotations = annotate_arguments(expanded_signature)
+        # Most kernels already have a flat, constexpr-free runtime signature.
+        # Let the C launcher consume their argument tuple directly instead of
+        # walking an equivalent annotation tree on every launch.
+        is_flat_signature = all(not isinstance(arg, tuple) and arg != "constexpr" for arg in expanded_signature)
+        self.arg_annotations = None if is_flat_signature else annotate_arguments(expanded_signature)
         self.kernel_signature = make_kernel_signature(expanded_signature)
         self.launch = wrap_handle_tensordesc(launcher, signature, tensordesc_meta)
         self.launch_cooperative_grid = metadata.launch_cooperative_grid

--- a/third_party/amd/python/test/test_launcher.py
+++ b/third_party/amd/python/test/test_launcher.py
@@ -1,0 +1,52 @@
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+from triton._internal_testing import is_hip
+
+
+@triton.jit
+def _add_kernel(x, y, output, n_elements):
+    BLOCK_SIZE: tl.constexpr = 256
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    tl.store(
+        output + offsets,
+        tl.load(x + offsets, mask=mask) + tl.load(y + offsets, mask=mask),
+        mask=mask,
+    )
+
+
+@triton.jit
+def _tuple_scale_kernel(inputs, output, SCALE: tl.constexpr):
+    tl.store(output, (tl.load(inputs[0]) + tl.load(inputs[1])) * SCALE)
+
+
+@pytest.mark.skipif(not is_hip(), reason="Requires HIP")
+def test_flat_signature_launcher():
+    n_elements = 1025
+    x = torch.randn(n_elements, device="cuda")
+    y = torch.randn(n_elements, device="cuda")
+    output = torch.empty_like(x)
+    grid = (triton.cdiv(n_elements, 256), )
+
+    compiled = _add_kernel.warmup(x, y, output, n_elements, grid=grid)
+    assert compiled.run.arg_annotations is None
+
+    _add_kernel[grid](x, y, output, n_elements)
+
+    torch.testing.assert_close(output, x + y)
+
+
+@pytest.mark.skipif(not is_hip(), reason="Requires HIP")
+def test_structured_signature_launcher_fallback():
+    x = torch.tensor([11.0], device="cuda")
+    y = torch.tensor([31.0], device="cuda")
+    output = torch.empty_like(x)
+
+    compiled = _tuple_scale_kernel.warmup((x, y), output, SCALE=2.0, grid=(1, ))
+    assert compiled.run.arg_annotations is not None
+
+    _tuple_scale_kernel[(1, )]((x, y), output, SCALE=2.0)
+    torch.testing.assert_close(output, torch.full_like(output, 84.0))


### PR DESCRIPTION
Summary:
# Problem
Triton 3.8 adds small but repeatable host overhead to ordinary flat HIP kernel launches. This is a performance regression, not a correctness-test failure. The focused MI350 repro runs a one-block flat pointer/scalar kernel in nine five-second samples:

| Version | Launch time | Delta vs. stock 3.8 |
| --- | ---: | ---: |
| Triton 3.5 | 6.622 us | -0.055 us |
| Triton 3.8 | 6.677 us | baseline |
| Triton 3.8 with this diff | 6.602 us | -0.075 us |

The Triton 3.8 result is 0.83% (about 55 ns) slower than 3.5. This diff recovers that overhead. The original FlexAttention measurements are too noisy on this host to support a precise end-to-end percentage, so this change makes no such claim.

Repro:

    python3 /data/users/warrdeng/intern/mi350_regression_investigation/20260811/launcher_microbench.py

# Root cause
Triton 3.8 newly includes D103454938, the backport of upstream #6788. It replaces AMD's generated per-signature launcher with a generic variadic C launcher. Every launch recursively walks argument annotations to flatten tuples and remove constexpr values, even when the runtime signature is already flat and contains no constexpr arguments.

# This Diff
Mark flat, constexpr-free signatures in Python and let the C launcher consume their argument sequence directly. The existing recursive path remains unchanged for nested tuples, tensor descriptors, and constexpr arguments.

The fast path uses `PySequence_Fast`, validates the exact argument count before extraction, and retains the owning sequence until launch completion. It changes host argument processing only; generated device code is unchanged.

# CI triage
The current ServiceLab failures do not exercise this regression fix:

- MI300: `fbcode/hammer/ops/tests/amd/jagged_test.py - jagged_test.JaggedBiasTest.test_jagged_dense_bmm_broadcast_add_triton` hit Hypothesis `HealthCheck.too_slow` during input generation. Its kernel reports that it has no C dispatcher and falls back to Python launch, so this diff's launcher fast path is not used. Four model files also crash on missing Python imports on both control and treatment.
- A100: `test_aot.py` changed classification from failed on control to timed out on treatment. Control already had five timeout files; treatment has six, with one fewer failed file and no increase in the total broken-file count.
- H100: aggregation failed because the control side emitted no metric data.

Reviewed By: tissue3

Differential Revision: D115648074


