### PR TITLE
[TLX][AMD] More gfx950 mxfp kernels variants.

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2099,11 +2099,18 @@ SharedLinearEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
   const auto &ll = getLinearLayout();
   auto outDimNames = llvm::to_vector(ll.getOutDimNames());
   assert(shape.size() == outDimNames.size());
-  // We don't support automatic broadcasting for shared linear layouts
-  for (auto [size, llSize] : llvm::zip(shape, ll.getOutDimSizes())) {
-    assert(size == llSize);
+  LinearLayout result = ll;
+  // A memdesc_subslice retains its parent's encoding and carries its physical
+  // base separately.  Permit the logical tile to shrink by dropping bases
+  // outside the subview; growing would be implicit broadcasting and remains
+  // unsupported.
+  for (auto [dim, size, llSize] :
+       llvm::zip(outDimNames, shape, ll.getOutDimSizes())) {
+    assert(size <= llSize);
+    if (size < llSize)
+      result = result.resizeOutDim(dim, size);
   }
-  return ll;
+  return result;
 }
 
 //===----------------------------------------------------------------------===//

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -42,11 +42,14 @@ from triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a4w4.matmul_kernel
     BLOCK_N as _A4W4_INTER_WAVE_BLOCK_N,
     MIN_K as _A4W4_INTER_WAVE_MIN_K,
     _a4w4_8wave_kernel as _a4w4_inter_wave_256tile_kernel,
+    _a4w4_8wave_merged_scales_kernel as _a4w4_inter_wave_merged_scales_kernel,
     _A4W4_8WAVE_LLVM_FN_ATTRS,
     matmul as _a4w4_inter_wave_matmul,
+    matmul_merged_scales as _a4w4_inter_wave_matmul_merged_scales,
     matmul_preshuffled as _a4w4_inter_wave_matmul_preshuffled,
     preshuffle_mxfp4_a_scales as _preshuffle_a4w4_a_scales,
     preshuffle_mxfp4_b_scales as _preshuffle_a4w4_b_scales,
+    preshuffle_mxfp4_scales as _preshuffle_a4w4_scales,
     select_matmul_path as _select_a4w4_inter_wave_path,
 )
 
@@ -3097,6 +3100,46 @@ def _compile_a4w4_inter_wave_256tile(m, n, k, preshuffled_scales=False):
         )
 
 
+def _compile_a4w4_inter_wave_merged_scales(m, n, k):
+    grid_mn = triton.cdiv(m, _A4W4_INTER_WAVE_BLOCK_M) * triton.cdiv(n, _A4W4_INTER_WAVE_BLOCK_N)
+    a = MockTensor(torch.uint8, (m, k // 2))
+    b = MockTensor(torch.uint8, (n, k // 2))
+    c = MockTensor(torch.bfloat16, (m, n))
+    scales = MockTensor(torch.uint8, ((m + n) * k // 32, ))
+
+    with knobs.runtime.scope():
+        knobs.runtime.override_arch = "gfx950"
+        return _a4w4_inter_wave_merged_scales_kernel.warmup(
+            a,
+            b,
+            c,
+            c,
+            scales,
+            m,
+            n,
+            k,
+            k // _A4W4_INTER_WAVE_BLOCK_K,
+            k // 2,
+            1,
+            k // 2,
+            1,
+            n,
+            1,
+            BLOCK_M=_A4W4_INTER_WAVE_BLOCK_M,
+            BLOCK_N=_A4W4_INTER_WAVE_BLOCK_N,
+            BLOCK_K=_A4W4_INTER_WAVE_BLOCK_K,
+            GROUP_SIZE_M=4,
+            NUM_XCDS=8,
+            GRID_MN=grid_mn,
+            SPLIT_K=1,
+            grid=(grid_mn, ),
+            num_warps=8,
+            num_stages=1,
+            matrix_instr_nonkdim=16,
+            llvm_fn_attrs=_A4W4_8WAVE_LLVM_FN_ATTRS,
+        )
+
+
 def test_a4w4_inter_wave_256tile_codegen_gfx950(device, fresh_triton_cache):
     """Check the performance-sensitive structure of the compiled 256-tile path."""
     compiled = _compile_a4w4_inter_wave_256tile(768, 768, 1536)
@@ -3195,6 +3238,36 @@ def test_a4w4_inter_wave_preshuffled_scale_codegen_gfx950(device, fresh_triton_c
     assert ".vgpr_spill_count: 0" in amdgcn
 
 
+def test_a4w4_inter_wave_merged_scale_codegen_gfx950(device, fresh_triton_cache):
+    """One merged scale ABI emits two full-workgroup scale DMAs per loop body."""
+    compiled = _compile_a4w4_inter_wave_merged_scales(768, 768, 1536)
+    ttgir = compiled.asm["ttgir"]
+    amdgcn = compiled.asm["amdgcn"]
+
+    assert "#tlx.user_layout" not in ttgir
+    assert "#tlx.no_verify_layout" not in ttgir
+    assert ttgir.count("amdg.buffer_load_to_local") == 18
+    assert len(re.findall(r"^\s*buffer_load_[^\n]*\blds\s*$", amdgcn, re.MULTILINE)) == 34
+    assert len(re.findall(r"^\s*buffer_load_dwordx4[^\n]*\blds\s*$", amdgcn, re.MULTILINE)) == 34
+    assert "ds_read_b64_tr_b8" not in amdgcn
+    assert len(re.findall(r"^\s*ds_read_b64\b", amdgcn, re.MULTILINE)) == 4
+    assert len(re.findall(r"^\s*ds_read_b128\b", amdgcn, re.MULTILINE)) == 116
+    assert len(re.findall(r"^\s*ds_read", amdgcn, re.MULTILINE)) == 120
+    assert "v_perm_b32" not in amdgcn
+    # Refilling immediately after the second-half reads starts the next pair one
+    # stage earlier. This deliberately pays a RAW-to-refill wait/barrier; moving
+    # the copy across the next existing barrier shortens DMA latency hiding and
+    # regresses both measured benchmark shapes.
+    assert len(re.findall(r"^\s*s_waitcnt\b", amdgcn, re.MULTILINE)) == 66
+    assert len(re.findall(r"^\s*s_barrier\s*$", amdgcn, re.MULTILINE)) == 42
+    assert compiled.metadata.shared == 143232
+    assert compiled.metadata.global_scratch_size == 0
+    assert ".private_segment_fixed_size: 0" in amdgcn
+    assert ".sgpr_count:     58" in amdgcn
+    assert ".sgpr_spill_count: 0" in amdgcn
+    assert ".vgpr_spill_count: 0" in amdgcn
+
+
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
 def test_a4w4_shape_stride_layouts_correctness_gfx950(device):
     m = n = 256
@@ -3214,6 +3287,17 @@ def test_a4w4_inter_wave_preshuffled_scale_correctness_gfx950(device, k, split_k
     b_scales_preshuffled = _preshuffle_a4w4_b_scales(b_scales)
     actual = _a4w4_inter_wave_matmul_preshuffled(
         a, b, a_scales_preshuffled, b_scales_preshuffled, SPLIT_K=split_k)
+    expected = _a4w4_reference(a, b, a_scales, b_scales)
+    torch.testing.assert_close(actual, expected, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.parametrize("k, split_k", [(1024, 1), (4096, 2)])
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_a4w4_inter_wave_merged_scale_correctness_gfx950(device, k, split_k):
+    m = n = 256
+    a, b, a_scales, b_scales = _generate_a4w4_inputs(m, n, k)
+    scales = _preshuffle_a4w4_scales(a_scales, b_scales)
+    actual = _a4w4_inter_wave_matmul_merged_scales(a, b, scales, SPLIT_K=split_k)
     expected = _a4w4_reference(a, b, a_scales, b_scales)
     torch.testing.assert_close(actual, expected, atol=0.0, rtol=0.0)
 

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -44,6 +44,8 @@ from triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a4w4.matmul_kernel
     _a4w4_8wave_kernel as _a4w4_inter_wave_256tile_kernel,
     _A4W4_8WAVE_LLVM_FN_ATTRS,
     matmul as _a4w4_inter_wave_matmul,
+    matmul_preshuffled as _a4w4_inter_wave_matmul_preshuffled,
+    preshuffle_mxfp4_a_scales as _preshuffle_a4w4_scales,
     select_matmul_path as _select_a4w4_inter_wave_path,
 )
 
@@ -3047,12 +3049,12 @@ def test_a4w4_shape_stride_layouts_compile_gfx950(device, tmp_path):
     assert "buffer_store_dwordx4" in amdgcn
 
 
-def _compile_a4w4_inter_wave_256tile(m, n, k):
+def _compile_a4w4_inter_wave_256tile(m, n, k, preshuffled_scales=False):
     grid_mn = triton.cdiv(m, _A4W4_INTER_WAVE_BLOCK_M) * triton.cdiv(n, _A4W4_INTER_WAVE_BLOCK_N)
     a = MockTensor(torch.uint8, (m, k // 2))
     b = MockTensor(torch.uint8, (n, k // 2))
     c = MockTensor(torch.bfloat16, (m, n))
-    a_scales = MockTensor(torch.uint8, (m, k // 32))
+    a_scales = MockTensor(torch.uint8, (m * k // 32, ) if preshuffled_scales else (m, k // 32))
     b_scales = MockTensor(torch.uint8, (n, k // 32))
 
     with knobs.runtime.scope():
@@ -3085,6 +3087,7 @@ def _compile_a4w4_inter_wave_256tile(m, n, k):
             NUM_XCDS=8,
             GRID_MN=grid_mn,
             SPLIT_K=1,
+            PRESHUFFLED_A_SCALES=preshuffled_scales,
             grid=(grid_mn, ),
             num_warps=8,
             num_stages=1,
@@ -3170,6 +3173,22 @@ def test_a4w4_inter_wave_256tile_single_trip_codegen_gfx950(device, fresh_triton
     assert ".vgpr_spill_count: 1" in amdgcn
 
 
+def test_a4w4_inter_wave_preshuffled_scale_codegen_gfx950(device, fresh_triton_cache):
+    """The experimental ABI loads A scales as register-native 8-byte vectors."""
+    compiled = _compile_a4w4_inter_wave_256tile(768, 768, 1536, preshuffled_scales=True)
+    ttgir = compiled.asm["ttgir"]
+    amdgcn = compiled.asm["amdgcn"]
+
+    assert "#tlx.user_layout" not in ttgir
+    assert "#tlx.no_verify_layout" not in ttgir
+    assert ttgir.count("amdg.buffer_load_to_local") == 20
+    assert len(re.findall(r"^\s*buffer_load_dwordx2\b", amdgcn, re.MULTILINE)) == 8
+    assert len(re.findall(r"^\s*buffer_load_[^\n]*\blds\s*$", amdgcn, re.MULTILINE)) == 36
+    assert len(re.findall(r"^\s*ds_read_b64_tr_b8\b", amdgcn, re.MULTILINE)) == 4
+    assert compiled.metadata.shared == 139136
+    assert compiled.metadata.global_scratch_size == 0
+
+
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
 def test_a4w4_shape_stride_layouts_correctness_gfx950(device):
     m = n = 256
@@ -3178,6 +3197,18 @@ def test_a4w4_shape_stride_layouts_correctness_gfx950(device):
         actual = _launch_a4w4(a, b, a_scales, b_scales)
         expected = _a4w4_reference(a, b, a_scales, b_scales)
         torch.testing.assert_close(actual, expected, atol=0.1, rtol=0.0)
+
+
+@pytest.mark.parametrize("k, split_k", [(1024, 1), (4096, 2)])
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_a4w4_inter_wave_preshuffled_scale_correctness_gfx950(device, k, split_k):
+    m = n = 256
+    a, b, a_scales, b_scales = _generate_a4w4_inputs(m, n, k)
+    a_scales_preshuffled = _preshuffle_a4w4_scales(a_scales)
+    actual = _a4w4_inter_wave_matmul_preshuffled(
+        a, b, a_scales_preshuffled, b_scales, SPLIT_K=split_k)
+    expected = _a4w4_reference(a, b, a_scales, b_scales)
+    torch.testing.assert_close(actual, expected, atol=0.0, rtol=0.0)
 
 
 @pytest.mark.parametrize(

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -3240,7 +3240,7 @@ def test_a4w4_inter_wave_preshuffled_scale_codegen_gfx950(device, fresh_triton_c
 
 
 def test_a4w4_inter_wave_merged_scale_codegen_gfx950(device, fresh_triton_cache):
-    """One merged scale ABI emits two full-workgroup scale DMAs per loop body."""
+    """The merged ABI combines wide scale DMA with conflict-free A b128 reads."""
     compiled = _compile_a4w4_inter_wave_merged_scales(768, 768, 1536)
     ttgir = compiled.asm["ttgir"]
     amdgcn = compiled.asm["amdgcn"]
@@ -3251,24 +3251,23 @@ def test_a4w4_inter_wave_merged_scale_codegen_gfx950(device, fresh_triton_cache)
     assert "ttg.memdesc_reinterpret" in ttgir
     assert len(re.findall(r"^\s*buffer_load_[^\n]*\blds\s*$", amdgcn, re.MULTILINE)) == 34
     assert len(re.findall(r"^\s*buffer_load_dwordx4[^\n]*\blds\s*$", amdgcn, re.MULTILINE)) == 34
-    assert len(re.findall(r"^\s*ds_read_b64_tr_b8\b", amdgcn, re.MULTILINE)) == 12
+    assert len(re.findall(r"^\s*ds_read_b64_tr_b8\b", amdgcn, re.MULTILINE)) == 4
     assert "ds_read_b64 " not in amdgcn
-    assert len(re.findall(r"^\s*ds_read_b128\b", amdgcn, re.MULTILINE)) == 112
-    assert len(re.findall(r"^\s*ds_read", amdgcn, re.MULTILINE)) == 124
+    assert len(re.findall(r"^\s*ds_read_b128\b", amdgcn, re.MULTILINE)) == 116
+    assert len(re.findall(r"^\s*ds_read", amdgcn, re.MULTILINE)) == 120
     assert "v_perm_b32" not in amdgcn
     # Refilling immediately after the second-half reads starts the next pair one
     # stage earlier. This deliberately pays a RAW-to-refill wait/barrier; moving
     # the copy across the next existing barrier shortens DMA latency hiding and
     # regresses both measured benchmark shapes.
-    # Three folded VGPR spills add one scratch wait at each epilogue reload.
-    assert len(re.findall(r"^\s*s_waitcnt\b", amdgcn, re.MULTILINE)) == 69
+    assert len(re.findall(r"^\s*s_waitcnt\b", amdgcn, re.MULTILINE)) == 66
     assert len(re.findall(r"^\s*s_barrier\s*$", amdgcn, re.MULTILINE)) == 42
     assert compiled.metadata.shared == 143232
     assert compiled.metadata.global_scratch_size == 0
-    assert ".private_segment_fixed_size: 16" in amdgcn
+    assert ".private_segment_fixed_size: 0" in amdgcn
     assert ".sgpr_count:     58" in amdgcn
     assert ".sgpr_spill_count: 0" in amdgcn
-    assert ".vgpr_spill_count: 3" in amdgcn
+    assert ".vgpr_spill_count: 0" in amdgcn
 
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -43,6 +43,7 @@ from triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a4w4.matmul_kernel
     MIN_K as _A4W4_INTER_WAVE_MIN_K,
     _a4w4_8wave_kernel as _a4w4_inter_wave_256tile_kernel,
     _a4w4_8wave_merged_scales_kernel as _a4w4_inter_wave_merged_scales_kernel,
+    _a4w4_8wave_preshuffled_scales_kernel as _a4w4_inter_wave_preshuffled_scales_kernel,
     _A4W4_8WAVE_LLVM_FN_ATTRS,
     matmul as _a4w4_inter_wave_matmul,
     matmul_merged_scales as _a4w4_inter_wave_matmul_merged_scales,
@@ -3060,10 +3061,16 @@ def _compile_a4w4_inter_wave_256tile(m, n, k, preshuffled_scales=False):
     c = MockTensor(torch.bfloat16, (m, n))
     a_scales = MockTensor(torch.uint8, (m * k // 32, ) if preshuffled_scales else (m, k // 32))
     b_scales = MockTensor(torch.uint8, (n * k // 32, ) if preshuffled_scales else (n, k // 32))
+    kernel = (
+        _a4w4_inter_wave_preshuffled_scales_kernel
+        if preshuffled_scales
+        else _a4w4_inter_wave_256tile_kernel
+    )
+    scale_strides = () if preshuffled_scales else (1, m, 1, n)
 
     with knobs.runtime.scope():
         knobs.runtime.override_arch = "gfx950"
-        return _a4w4_inter_wave_256tile_kernel.warmup(
+        return kernel.warmup(
             a,
             b,
             c,
@@ -3080,10 +3087,7 @@ def _compile_a4w4_inter_wave_256tile(m, n, k, preshuffled_scales=False):
             1,
             n,
             1,
-            1,
-            m,
-            1,
-            n,
+            *scale_strides,
             BLOCK_M=_A4W4_INTER_WAVE_BLOCK_M,
             BLOCK_N=_A4W4_INTER_WAVE_BLOCK_N,
             BLOCK_K=_A4W4_INTER_WAVE_BLOCK_K,
@@ -3091,7 +3095,6 @@ def _compile_a4w4_inter_wave_256tile(m, n, k, preshuffled_scales=False):
             NUM_XCDS=8,
             GRID_MN=grid_mn,
             SPLIT_K=1,
-            PRESHUFFLED_SCALES=preshuffled_scales,
             grid=(grid_mn, ),
             num_warps=8,
             num_stages=1,

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -3218,7 +3218,7 @@ def test_a4w4_inter_wave_256tile_single_trip_codegen_gfx950(device, fresh_triton
 
 
 def test_a4w4_inter_wave_preshuffled_scale_codegen_gfx950(device, fresh_triton_cache):
-    """The prepacked ABI reuses the canonical conflict-free scale reads."""
+    """The fastest prepacked ABI coalesces both A halves into one b128 read."""
     compiled = _compile_a4w4_inter_wave_256tile(768, 768, 1536, preshuffled_scales=True)
     ttgir = compiled.asm["ttgir"]
     amdgcn = compiled.asm["amdgcn"]
@@ -3226,13 +3226,12 @@ def test_a4w4_inter_wave_preshuffled_scale_codegen_gfx950(device, fresh_triton_c
     assert "#tlx.user_layout" not in ttgir
     assert "#tlx.no_verify_layout" not in ttgir
     assert ttgir.count("amdg.buffer_load_to_local") == 24
-    assert "ttg.memdesc_reinterpret" in ttgir
     assert "buffer_load_dwordx2" not in amdgcn
     assert len(re.findall(r"^\s*buffer_load_[^\n]*\blds\s*$", amdgcn, re.MULTILINE)) == 40
-    assert len(re.findall(r"^\s*ds_read_b64_tr_b8\b", amdgcn, re.MULTILINE)) == 12
-    assert "ds_read_b64 " not in amdgcn
-    assert len(re.findall(r"^\s*ds_read_b128\b", amdgcn, re.MULTILINE)) == 112
-    assert len(re.findall(r"^\s*ds_read", amdgcn, re.MULTILINE)) == 124
+    assert "ds_read_b64_tr_b8" not in amdgcn
+    assert len(re.findall(r"^\s*ds_read_b64\b", amdgcn, re.MULTILINE)) == 4
+    assert len(re.findall(r"^\s*ds_read_b128\b", amdgcn, re.MULTILINE)) == 116
+    assert len(re.findall(r"^\s*ds_read", amdgcn, re.MULTILINE)) == 120
     assert compiled.metadata.shared == 143232
     assert compiled.metadata.global_scratch_size == 0
     assert ".private_segment_fixed_size: 0" in amdgcn

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -45,7 +45,8 @@ from triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a4w4.matmul_kernel
     _A4W4_8WAVE_LLVM_FN_ATTRS,
     matmul as _a4w4_inter_wave_matmul,
     matmul_preshuffled as _a4w4_inter_wave_matmul_preshuffled,
-    preshuffle_mxfp4_a_scales as _preshuffle_a4w4_scales,
+    preshuffle_mxfp4_a_scales as _preshuffle_a4w4_a_scales,
+    preshuffle_mxfp4_b_scales as _preshuffle_a4w4_b_scales,
     select_matmul_path as _select_a4w4_inter_wave_path,
 )
 
@@ -3055,7 +3056,7 @@ def _compile_a4w4_inter_wave_256tile(m, n, k, preshuffled_scales=False):
     b = MockTensor(torch.uint8, (n, k // 2))
     c = MockTensor(torch.bfloat16, (m, n))
     a_scales = MockTensor(torch.uint8, (m * k // 32, ) if preshuffled_scales else (m, k // 32))
-    b_scales = MockTensor(torch.uint8, (n, k // 32))
+    b_scales = MockTensor(torch.uint8, (n * k // 32, ) if preshuffled_scales else (n, k // 32))
 
     with knobs.runtime.scope():
         knobs.runtime.override_arch = "gfx950"
@@ -3087,7 +3088,7 @@ def _compile_a4w4_inter_wave_256tile(m, n, k, preshuffled_scales=False):
             NUM_XCDS=8,
             GRID_MN=grid_mn,
             SPLIT_K=1,
-            PRESHUFFLED_A_SCALES=preshuffled_scales,
+            PRESHUFFLED_SCALES=preshuffled_scales,
             grid=(grid_mn, ),
             num_warps=8,
             num_stages=1,
@@ -3174,19 +3175,24 @@ def test_a4w4_inter_wave_256tile_single_trip_codegen_gfx950(device, fresh_triton
 
 
 def test_a4w4_inter_wave_preshuffled_scale_codegen_gfx950(device, fresh_triton_cache):
-    """The experimental ABI loads A scales as register-native 8-byte vectors."""
+    """The experimental ABI coalesces both A halves into a 128-bit LDS read."""
     compiled = _compile_a4w4_inter_wave_256tile(768, 768, 1536, preshuffled_scales=True)
     ttgir = compiled.asm["ttgir"]
     amdgcn = compiled.asm["amdgcn"]
 
     assert "#tlx.user_layout" not in ttgir
     assert "#tlx.no_verify_layout" not in ttgir
-    assert ttgir.count("amdg.buffer_load_to_local") == 20
-    assert len(re.findall(r"^\s*buffer_load_dwordx2\b", amdgcn, re.MULTILINE)) == 8
-    assert len(re.findall(r"^\s*buffer_load_[^\n]*\blds\s*$", amdgcn, re.MULTILINE)) == 36
-    assert len(re.findall(r"^\s*ds_read_b64_tr_b8\b", amdgcn, re.MULTILINE)) == 4
-    assert compiled.metadata.shared == 139136
+    assert ttgir.count("amdg.buffer_load_to_local") == 24
+    assert "buffer_load_dwordx2" not in amdgcn
+    assert len(re.findall(r"^\s*buffer_load_[^\n]*\blds\s*$", amdgcn, re.MULTILINE)) == 40
+    assert "ds_read_b64_tr_b8" not in amdgcn
+    assert len(re.findall(r"^\s*ds_read_b64\b", amdgcn, re.MULTILINE)) == 4
+    assert len(re.findall(r"^\s*ds_read_b128\b", amdgcn, re.MULTILINE)) == 116
+    assert len(re.findall(r"^\s*ds_read", amdgcn, re.MULTILINE)) == 120
+    assert compiled.metadata.shared == 143232
     assert compiled.metadata.global_scratch_size == 0
+    assert ".private_segment_fixed_size: 0" in amdgcn
+    assert ".vgpr_spill_count: 0" in amdgcn
 
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
@@ -3204,9 +3210,10 @@ def test_a4w4_shape_stride_layouts_correctness_gfx950(device):
 def test_a4w4_inter_wave_preshuffled_scale_correctness_gfx950(device, k, split_k):
     m = n = 256
     a, b, a_scales, b_scales = _generate_a4w4_inputs(m, n, k)
-    a_scales_preshuffled = _preshuffle_a4w4_scales(a_scales)
+    a_scales_preshuffled = _preshuffle_a4w4_a_scales(a_scales)
+    b_scales_preshuffled = _preshuffle_a4w4_b_scales(b_scales)
     actual = _a4w4_inter_wave_matmul_preshuffled(
-        a, b, a_scales_preshuffled, b_scales, SPLIT_K=split_k)
+        a, b, a_scales_preshuffled, b_scales_preshuffled, SPLIT_K=split_k)
     expected = _a4w4_reference(a, b, a_scales, b_scales)
     torch.testing.assert_close(actual, expected, atol=0.0, rtol=0.0)
 

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -3218,7 +3218,7 @@ def test_a4w4_inter_wave_256tile_single_trip_codegen_gfx950(device, fresh_triton
 
 
 def test_a4w4_inter_wave_preshuffled_scale_codegen_gfx950(device, fresh_triton_cache):
-    """The experimental ABI coalesces both A halves into a 128-bit LDS read."""
+    """The prepacked ABI reuses the canonical conflict-free scale reads."""
     compiled = _compile_a4w4_inter_wave_256tile(768, 768, 1536, preshuffled_scales=True)
     ttgir = compiled.asm["ttgir"]
     amdgcn = compiled.asm["amdgcn"]
@@ -3226,12 +3226,13 @@ def test_a4w4_inter_wave_preshuffled_scale_codegen_gfx950(device, fresh_triton_c
     assert "#tlx.user_layout" not in ttgir
     assert "#tlx.no_verify_layout" not in ttgir
     assert ttgir.count("amdg.buffer_load_to_local") == 24
+    assert "ttg.memdesc_reinterpret" in ttgir
     assert "buffer_load_dwordx2" not in amdgcn
     assert len(re.findall(r"^\s*buffer_load_[^\n]*\blds\s*$", amdgcn, re.MULTILINE)) == 40
-    assert "ds_read_b64_tr_b8" not in amdgcn
-    assert len(re.findall(r"^\s*ds_read_b64\b", amdgcn, re.MULTILINE)) == 4
-    assert len(re.findall(r"^\s*ds_read_b128\b", amdgcn, re.MULTILINE)) == 116
-    assert len(re.findall(r"^\s*ds_read", amdgcn, re.MULTILINE)) == 120
+    assert len(re.findall(r"^\s*ds_read_b64_tr_b8\b", amdgcn, re.MULTILINE)) == 12
+    assert "ds_read_b64 " not in amdgcn
+    assert len(re.findall(r"^\s*ds_read_b128\b", amdgcn, re.MULTILINE)) == 112
+    assert len(re.findall(r"^\s*ds_read", amdgcn, re.MULTILINE)) == 124
     assert compiled.metadata.shared == 143232
     assert compiled.metadata.global_scratch_size == 0
     assert ".private_segment_fixed_size: 0" in amdgcn
@@ -3247,25 +3248,27 @@ def test_a4w4_inter_wave_merged_scale_codegen_gfx950(device, fresh_triton_cache)
     assert "#tlx.user_layout" not in ttgir
     assert "#tlx.no_verify_layout" not in ttgir
     assert ttgir.count("amdg.buffer_load_to_local") == 18
+    assert "ttg.memdesc_reinterpret" in ttgir
     assert len(re.findall(r"^\s*buffer_load_[^\n]*\blds\s*$", amdgcn, re.MULTILINE)) == 34
     assert len(re.findall(r"^\s*buffer_load_dwordx4[^\n]*\blds\s*$", amdgcn, re.MULTILINE)) == 34
-    assert "ds_read_b64_tr_b8" not in amdgcn
-    assert len(re.findall(r"^\s*ds_read_b64\b", amdgcn, re.MULTILINE)) == 4
-    assert len(re.findall(r"^\s*ds_read_b128\b", amdgcn, re.MULTILINE)) == 116
-    assert len(re.findall(r"^\s*ds_read", amdgcn, re.MULTILINE)) == 120
+    assert len(re.findall(r"^\s*ds_read_b64_tr_b8\b", amdgcn, re.MULTILINE)) == 12
+    assert "ds_read_b64 " not in amdgcn
+    assert len(re.findall(r"^\s*ds_read_b128\b", amdgcn, re.MULTILINE)) == 112
+    assert len(re.findall(r"^\s*ds_read", amdgcn, re.MULTILINE)) == 124
     assert "v_perm_b32" not in amdgcn
     # Refilling immediately after the second-half reads starts the next pair one
     # stage earlier. This deliberately pays a RAW-to-refill wait/barrier; moving
     # the copy across the next existing barrier shortens DMA latency hiding and
     # regresses both measured benchmark shapes.
-    assert len(re.findall(r"^\s*s_waitcnt\b", amdgcn, re.MULTILINE)) == 66
+    # Three folded VGPR spills add one scratch wait at each epilogue reload.
+    assert len(re.findall(r"^\s*s_waitcnt\b", amdgcn, re.MULTILINE)) == 69
     assert len(re.findall(r"^\s*s_barrier\s*$", amdgcn, re.MULTILINE)) == 42
     assert compiled.metadata.shared == 143232
     assert compiled.metadata.global_scratch_size == 0
-    assert ".private_segment_fixed_size: 0" in amdgcn
+    assert ".private_segment_fixed_size: 16" in amdgcn
     assert ".sgpr_count:     58" in amdgcn
     assert ".sgpr_spill_count: 0" in amdgcn
-    assert ".vgpr_spill_count: 0" in amdgcn
+    assert ".vgpr_spill_count: 3" in amdgcn
 
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -3180,13 +3180,16 @@ def test_a4w4_shape_stride_layouts_correctness_gfx950(device):
         torch.testing.assert_close(actual, expected, atol=0.1, rtol=0.0)
 
 
-@pytest.mark.parametrize("k", [1536, 2048])
+@pytest.mark.parametrize(
+    "k, expected_path",
+    [(1536, "intra_wave_256x256"), (2048, "inter_wave_256x256")],
+)
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
-def test_a4w4_inter_wave_256tile_correctness_gfx950(device, k):
-    # A 2x33 grid exceeds the skinny-dispatch threshold, so these neighboring K
-    # values exercise the 8-wave 256x256 path with two and three main-loop trips.
+def test_a4w4_inter_wave_large_grid_dispatch_correctness_gfx950(device, k, expected_path):
+    # A 2x33 grid exceeds the skinny threshold. K=1536 selects the measured
+    # lower-overhead 4-wave path; K=2048 selects the 8-wave pipeline.
     m, n = 512, 8448
-    assert _select_a4w4_inter_wave_path(m, n, k) == "inter_wave_256x256"
+    assert _select_a4w4_inter_wave_path(m, n, k) == expected_path
     a, b, a_scales, b_scales = _generate_a4w4_inputs(m, n, k)
     actual = _a4w4_inter_wave_matmul(a, b, a_scales, b_scales)
     expected = _a4w4_reference(a, b, a_scales, b_scales)
@@ -3195,18 +3198,14 @@ def test_a4w4_inter_wave_256tile_correctness_gfx950(device, k):
 
 @pytest.mark.parametrize("m, n", [(256, 16640), (512, 8448)])
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
-def test_a4w4_inter_wave_256tile_single_trip_stress_gfx950(device, m, n):
-    # K=1024 has four K tiles: two are prefetched and one two-tile main-loop
-    # step consumes/refills the ring before the two-tile drain.
+def test_a4w4_short_k_dispatch_stress_gfx950(device, m, n):
     # Both public shapes exceed the skinny threshold by the smallest possible
-    # grid margins and cover different multi-CTA grids through the dispatcher.
+    # grid margins. K=1024 must dispatch to the measured 4-wave path.
     k = _A4W4_INTER_WAVE_MIN_K
     grid_mn = triton.cdiv(m, _A4W4_INTER_WAVE_BLOCK_M) * triton.cdiv(n, _A4W4_INTER_WAVE_BLOCK_N)
-    iter_max = k // _A4W4_INTER_WAVE_BLOCK_K
-    main_trips = len(range(0, iter_max - 2, 2))
     assert grid_mn in (65, 66)
-    assert _select_a4w4_inter_wave_path(m, n, k) == "inter_wave_256x256"
-    assert (k, iter_max, main_trips) == (1024, 4, 1)
+    assert _select_a4w4_inter_wave_path(m, n, k) == "intra_wave_256x256"
+    assert k == 1024
 
     a, b, a_scales, b_scales = _generate_a4w4_inputs(m, n, k)
     expected = _a4w4_reference(a, b, a_scales, b_scales)

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
@@ -409,10 +409,10 @@ def _a4w4_8wave_kernel(
     tl.assume(iter_max > 3)
 
     # ---- Prologue: prefetch K-steps 0,1 into buffers 0,1 (8 commits) ----
-    tlx.buffer_load_to_local(smem_b_left[0], b_base, b_tile_offsets)
     if MERGED_SCALE_DMA:
         tlx.buffer_load_to_local(smem_sc[0], a_scales_ptr, scale_offsets)
-    else:
+    tlx.buffer_load_to_local(smem_b_left[0], b_base, b_tile_offsets)
+    if not MERGED_SCALE_DMA:
         tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_top[0], a_base, a_tile_offsets)

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
@@ -25,11 +25,11 @@ The production entry point uses the same ABI as the 4-wave a4w4 kernel:
   * C: bfloat16, shape (M, N)
 
 ``matmul_preshuffled`` is a separate experimental ABI: both scale operands are
-packed into their LDS-consumer order and retain the production DMA-to-LDS
-pipeline.  The full 256-row A scale tile is read once, then split into its two
-128-row MFMA fragments; this is intended to coalesce the two canonical
-``ds_read_b64_tr_b8`` operations into one ``ds_read_b128``.  It remains outside
-``matmul`` because its flat, prepacked scale buffers are a distinct caller ABI.
+packed into the canonical XOR-swizzled LDS image and retain the production
+DMA-to-LDS pipeline. The flat DMA destination is reinterpreted, without copying,
+through the same bank-conflict-free layouts used by the production kernel.
+It remains outside ``matmul`` because its flat, prepacked scale buffers are a
+distinct caller ABI.
 
 ``matmul_merged_scales`` is a second experimental kernel and ABI. It accepts one
 flat allocation containing the packed A image followed by the packed B image,
@@ -192,10 +192,41 @@ def _a4w4_8wave_kernel(
         block_bases=[],
         alignment=16,
     )
-    # Experimental scale ABI.  Its physical low bits are exactly the value
-    # bases consumed by each wave.  In particular the combined A tile puts
-    # (group bit 2, row bits 5, 6, 7) in adjacent bytes, so one ordinary
-    # 128-bit LDS transaction produces both 128-row A scale fragments.
+    # Physical A images concatenate the two canonical 128x8 half tiles. The
+    # merged layouts add section and K-tile selector bits around the canonical
+    # A/B maps so the full raw allocation can be reinterpreted before slicing.
+    shared_a_scales_packed: tl.constexpr = tlx.shared_linear_layout_encoding(
+        offset_bases=[
+            [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0],
+            [0, 32, 0], [0, 64, 0], [0, 0, 1], [0, 0, 2], [0, 16, 4],
+            [1, 0, 0],
+        ],
+        block_bases=[],
+        alignment=16,
+    )
+    shared_merged_a_scales: tl.constexpr = tlx.shared_linear_layout_encoding(
+        offset_bases=[
+            [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0],
+            [0, 32, 0], [0, 64, 0], [0, 0, 1], [0, 0, 2], [0, 16, 4],
+            [1, 0, 0], [2, 0, 0], [4, 0, 0],
+        ],
+        block_bases=[],
+        alignment=16,
+    )
+    shared_merged_b_scales: tl.constexpr = tlx.shared_linear_layout_encoding(
+        offset_bases=[
+            [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0],
+            [0, 32, 0], [0, 64, 0], [0, 128, 0], [0, 16, 1], [0, 0, 2],
+            [0, 32, 4], [1, 0, 0], [2, 0, 0],
+        ],
+        block_bases=[],
+        alignment=16,
+    )
+    # The preshuffled ABIs DMA an already-swizzled physical image. Keep the raw
+    # destination byte-linear so every wave writes consecutive 4-byte (separate)
+    # or 16-byte (merged) vectors. Consumers reinterpret subranges through the
+    # canonical A/B XOR layouts above; the reinterpret changes only the LDS
+    # descriptor, not the bytes or their addresses.
     shared_scale_preshuffled: tl.constexpr = tlx.shared_linear_layout_encoding(
         offset_bases=[
             [1], [2], [4], [8], [16], [32], [64], [128], [256], [512], [1024],
@@ -210,10 +241,8 @@ def _a4w4_8wave_kernel(
         block_bases=[],
         alignment=16,
     )
-    # Match each scale tile's physical shared offset order: two 4-byte value
-    # bits, six lane bits, then warp bits. The XOR bases live entirely in the
-    # warp mapping, so TLX resolves these to #ttg.generic_linear and gfx9 can
-    # write the swizzled LDS image directly from ordinary logical offsets.
+    # Match each raw scale image's byte-linear shared order: two 4-byte value
+    # bits, six lane bits, then warp bits.
     scale_load_a_layout: tl.constexpr = tlx.layout(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2)),
         stride=((32, 64, 128, 256, 512, 1, 2, 132, 0), (8, 16)),
@@ -234,20 +263,10 @@ def _a4w4_8wave_kernel(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2)),
         stride=((16, 32, 64, 128, 256, 512, 1024, 2048, 4096), (1, 2, 4, 8)),
     )
-    preshuffled_scale_shape: tl.constexpr = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
-    merged_scale_shape: tl.constexpr = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
-    preshuffled_a_to_logical: tl.constexpr = (7, 8, 9, 4, 5, 6, 2, 3, 10, 0, 1)
-    preshuffled_b_to_logical: tl.constexpr = (8, 9, 2, 4, 5, 6, 7, 3, 10, 0, 1)
-    merged_a_to_logical: tl.constexpr = (0, 1, 9, 10, 11, 6, 7, 8, 4, 5, 12, 2, 3)
-    merged_b_to_logical: tl.constexpr = (0, 1, 10, 11, 4, 6, 7, 8, 9, 5, 12, 2, 3)
     # ---- MFMA scale register layouts (get_mfma_scale_layout) ----
     scale_a_layout: tl.constexpr = tlx.layout(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2)),
         stride=((8, 16, 32, 64, 1, 2, 0, 0, 128), (4, 256, 512)),
-    )
-    scale_a_comb_layout: tl.constexpr = tlx.layout(
-        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2)),
-        stride=((8, 16, 32, 64, 1, 2, 0, 0, 128), (4, 256, 512, 1024)),
     )
     scale_b_layout: tl.constexpr = tlx.layout(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2)),
@@ -310,6 +329,10 @@ def _a4w4_8wave_kernel(
     if MERGED_SCALE_DMA:
         smem_sc = tlx.local_alloc(
             (2 * (BLOCK_M + BLOCK_N) * NG, ), tlx.dtype_of(a_scales_ptr), 1, layout=shared_scale_merged)
+        smem_sc_a_view = tlx.local_reinterpret(
+            smem_sc[0], tl.uint8, [8, HALF_M, NG], layout=shared_merged_a_scales)
+        smem_sc_b_view = tlx.local_reinterpret(
+            smem_sc[0], tl.uint8, [4, BLOCK_N, NG], layout=shared_merged_b_scales)
     elif PRESHUFFLED_SCALES:
         smem_a_sc = tlx.local_alloc(
             (BLOCK_M * NG, ), tlx.dtype_of(a_scales_ptr), 2, layout=shared_scale_preshuffled)
@@ -458,35 +481,56 @@ def _a4w4_8wave_kernel(
     a_top = tlx.local_load(smem_a_top[0], relaxed=True)
     if PRESHUFFLED_SCALES:
         if MERGED_SCALE_DMA:
-            sc_phys_init = tlx.local_reshape(smem_sc[0], [2] + merged_scale_shape)
-            a_sc_view_init = tlx.local_trans(sc_phys_init, merged_a_to_logical)
-            a_sc_view_init = tlx.local_reshape(a_sc_view_init, [2, 2, BLOCK_M, NG])
-            a_sc_view_init = tlx.local_slice(a_sc_view_init, [0, 0, 0, 0], [1, 1, BLOCK_M, NG])
-            a_sc_comb = tl.reshape(
-                tlx.local_load(a_sc_view_init, layout=scale_a_comb_layout, relaxed=True), BLOCK_M, NG)
-            b_sc_view_init = tlx.local_trans(sc_phys_init, merged_b_to_logical)
-            b_sc_view_init = tlx.local_reshape(b_sc_view_init, [2, 2, BLOCK_N, NG])
-            b_sc_view_init = tlx.local_slice(b_sc_view_init, [0, 1, 0, 0], [1, 1, BLOCK_N, NG])
-            b_sc_comb = tl.reshape(
-                tlx.local_load(b_sc_view_init, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
+            b_sc_view_init = tlx.local_slice(
+                smem_sc_b_view, [1, 0, 0], [1, BLOCK_N, NG])
+            a_sc_top = tl.reshape(
+                tlx.local_load(
+                    tlx.local_slice(smem_sc_a_view, [0, 0, 0], [1, HALF_M, NG]),
+                    layout=scale_a_layout,
+                    relaxed=True,
+                ),
+                HALF_M,
+                NG,
+            )
+            a_sc_bot0 = tl.reshape(
+                tlx.local_load(
+                    tlx.local_slice(smem_sc_a_view, [1, 0, 0], [1, HALF_M, NG]),
+                    layout=scale_a_layout,
+                    relaxed=True,
+                ),
+                HALF_M,
+                NG,
+            )
         else:
-            a_sc_phys_init = smem_a_sc[0]
-            a_sc_view_init = tlx.local_reshape(a_sc_phys_init, preshuffled_scale_shape)
-            a_sc_view_init = tlx.local_trans(a_sc_view_init, preshuffled_a_to_logical)
-            a_sc_view_init = tlx.local_reshape(a_sc_view_init, [BLOCK_M, NG])
-            a_sc_comb = tlx.local_load(a_sc_view_init, layout=scale_a_comb_layout, relaxed=True)
-        a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
-        a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
-        a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
+            a_sc_view_init = tlx.local_reinterpret(
+                smem_a_sc[0], tl.uint8, [2, HALF_M, NG], layout=shared_a_scales_packed)
+            a_sc_top = tl.reshape(
+                tlx.local_load(
+                    tlx.local_slice(a_sc_view_init, [0, 0, 0], [1, HALF_M, NG]),
+                    layout=scale_a_layout,
+                    relaxed=True,
+                ),
+                HALF_M,
+                NG,
+            )
+            a_sc_bot0 = tl.reshape(
+                tlx.local_load(
+                    tlx.local_slice(a_sc_view_init, [1, 0, 0], [1, HALF_M, NG]),
+                    layout=scale_a_layout,
+                    relaxed=True,
+                ),
+                HALF_M,
+                NG,
+            )
     else:
         a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
     if PRESHUFFLED_SCALES:
         if not MERGED_SCALE_DMA:
             b_sc_phys_init = smem_b_sc[0]
-            b_sc_view_init = tlx.local_reshape(b_sc_phys_init, preshuffled_scale_shape)
-            b_sc_view_init = tlx.local_trans(b_sc_view_init, preshuffled_b_to_logical)
-            b_sc_view_init = tlx.local_reshape(b_sc_view_init, [BLOCK_N, NG])
-            b_sc_comb = tlx.local_load(b_sc_view_init, layout=scale_b_comb_layout, relaxed=True)
+            b_sc_view_init = tlx.local_reinterpret(
+                b_sc_phys_init, tl.uint8, [BLOCK_N, NG], layout=shared_b_scales)
+        b_sc_comb = tl.reshape(
+            tlx.local_load(b_sc_view_init, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
     else:
         b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
     b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
@@ -542,35 +586,56 @@ def _a4w4_8wave_kernel(
             a_top = tlx.local_load(smem_a_top[1], relaxed=True)
             if PRESHUFFLED_SCALES:
                 if MERGED_SCALE_DMA:
-                    sc_phys_1 = tlx.local_reshape(smem_sc[0], [2] + merged_scale_shape)
-                    a_sc_view_1 = tlx.local_trans(sc_phys_1, merged_a_to_logical)
-                    a_sc_view_1 = tlx.local_reshape(a_sc_view_1, [2, 2, BLOCK_M, NG])
-                    a_sc_view_1 = tlx.local_slice(a_sc_view_1, [1, 0, 0, 0], [1, 1, BLOCK_M, NG])
-                    a_sc_comb = tl.reshape(
-                        tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True), BLOCK_M, NG)
-                    b_sc_view_1 = tlx.local_trans(sc_phys_1, merged_b_to_logical)
-                    b_sc_view_1 = tlx.local_reshape(b_sc_view_1, [2, 2, BLOCK_N, NG])
-                    b_sc_view_1 = tlx.local_slice(b_sc_view_1, [1, 1, 0, 0], [1, 1, BLOCK_N, NG])
-                    b_sc_comb = tl.reshape(
-                        tlx.local_load(b_sc_view_1, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
+                    a_sc_top = tl.reshape(
+                        tlx.local_load(
+                            tlx.local_slice(smem_sc_a_view, [4, 0, 0], [1, HALF_M, NG]),
+                            layout=scale_a_layout,
+                            relaxed=True,
+                        ),
+                        HALF_M,
+                        NG,
+                    )
+                    a_sc_bot1 = tl.reshape(
+                        tlx.local_load(
+                            tlx.local_slice(smem_sc_a_view, [5, 0, 0], [1, HALF_M, NG]),
+                            layout=scale_a_layout,
+                            relaxed=True,
+                        ),
+                        HALF_M,
+                        NG,
+                    )
+                    b_sc_view_1 = tlx.local_slice(
+                        smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
                 else:
-                    a_sc_phys_1 = smem_a_sc[1]
-                    a_sc_view_1 = tlx.local_reshape(a_sc_phys_1, preshuffled_scale_shape)
-                    a_sc_view_1 = tlx.local_trans(a_sc_view_1, preshuffled_a_to_logical)
-                    a_sc_view_1 = tlx.local_reshape(a_sc_view_1, [BLOCK_M, NG])
-                    a_sc_comb = tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True)
-                a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
-                a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
-                a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
+                    a_sc_view_1 = tlx.local_reinterpret(
+                        smem_a_sc[1], tl.uint8, [2, HALF_M, NG], layout=shared_a_scales_packed)
+                    a_sc_top = tl.reshape(
+                        tlx.local_load(
+                            tlx.local_slice(a_sc_view_1, [0, 0, 0], [1, HALF_M, NG]),
+                            layout=scale_a_layout,
+                            relaxed=True,
+                        ),
+                        HALF_M,
+                        NG,
+                    )
+                    a_sc_bot1 = tl.reshape(
+                        tlx.local_load(
+                            tlx.local_slice(a_sc_view_1, [1, 0, 0], [1, HALF_M, NG]),
+                            layout=scale_a_layout,
+                            relaxed=True,
+                        ),
+                        HALF_M,
+                        NG,
+                    )
             else:
                 a_sc_top = tlx.local_load(smem_a_sc_t[1], layout=scale_a_layout)
             if PRESHUFFLED_SCALES:
                 if not MERGED_SCALE_DMA:
                     b_sc_phys_1 = smem_b_sc[1]
-                    b_sc_view_1 = tlx.local_reshape(b_sc_phys_1, preshuffled_scale_shape)
-                    b_sc_view_1 = tlx.local_trans(b_sc_view_1, preshuffled_b_to_logical)
-                    b_sc_view_1 = tlx.local_reshape(b_sc_view_1, [BLOCK_N, NG])
-                    b_sc_comb = tlx.local_load(b_sc_view_1, layout=scale_b_comb_layout, relaxed=True)
+                    b_sc_view_1 = tlx.local_reinterpret(
+                        b_sc_phys_1, tl.uint8, [BLOCK_N, NG], layout=shared_b_scales)
+                b_sc_comb = tl.reshape(
+                    tlx.local_load(b_sc_view_1, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
             else:
                 b_sc_comb = tlx.local_load(smem_b_sc[1], layout=scale_b_comb_layout)
             b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
@@ -629,35 +694,56 @@ def _a4w4_8wave_kernel(
             a_top = tlx.local_load(smem_a_top[0], relaxed=True)
             if PRESHUFFLED_SCALES:
                 if MERGED_SCALE_DMA:
-                    sc_phys_0 = tlx.local_reshape(smem_sc[0], [2] + merged_scale_shape)
-                    a_sc_view_0 = tlx.local_trans(sc_phys_0, merged_a_to_logical)
-                    a_sc_view_0 = tlx.local_reshape(a_sc_view_0, [2, 2, BLOCK_M, NG])
-                    a_sc_view_0 = tlx.local_slice(a_sc_view_0, [0, 0, 0, 0], [1, 1, BLOCK_M, NG])
-                    a_sc_comb = tl.reshape(
-                        tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True), BLOCK_M, NG)
-                    b_sc_view_0 = tlx.local_trans(sc_phys_0, merged_b_to_logical)
-                    b_sc_view_0 = tlx.local_reshape(b_sc_view_0, [2, 2, BLOCK_N, NG])
-                    b_sc_view_0 = tlx.local_slice(b_sc_view_0, [0, 1, 0, 0], [1, 1, BLOCK_N, NG])
-                    b_sc_comb = tl.reshape(
-                        tlx.local_load(b_sc_view_0, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
+                    a_sc_top = tl.reshape(
+                        tlx.local_load(
+                            tlx.local_slice(smem_sc_a_view, [0, 0, 0], [1, HALF_M, NG]),
+                            layout=scale_a_layout,
+                            relaxed=True,
+                        ),
+                        HALF_M,
+                        NG,
+                    )
+                    a_sc_bot0 = tl.reshape(
+                        tlx.local_load(
+                            tlx.local_slice(smem_sc_a_view, [1, 0, 0], [1, HALF_M, NG]),
+                            layout=scale_a_layout,
+                            relaxed=True,
+                        ),
+                        HALF_M,
+                        NG,
+                    )
+                    b_sc_view_0 = tlx.local_slice(
+                        smem_sc_b_view, [1, 0, 0], [1, BLOCK_N, NG])
                 else:
-                    a_sc_phys_0 = smem_a_sc[0]
-                    a_sc_view_0 = tlx.local_reshape(a_sc_phys_0, preshuffled_scale_shape)
-                    a_sc_view_0 = tlx.local_trans(a_sc_view_0, preshuffled_a_to_logical)
-                    a_sc_view_0 = tlx.local_reshape(a_sc_view_0, [BLOCK_M, NG])
-                    a_sc_comb = tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True)
-                a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
-                a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
-                a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
+                    a_sc_view_0 = tlx.local_reinterpret(
+                        smem_a_sc[0], tl.uint8, [2, HALF_M, NG], layout=shared_a_scales_packed)
+                    a_sc_top = tl.reshape(
+                        tlx.local_load(
+                            tlx.local_slice(a_sc_view_0, [0, 0, 0], [1, HALF_M, NG]),
+                            layout=scale_a_layout,
+                            relaxed=True,
+                        ),
+                        HALF_M,
+                        NG,
+                    )
+                    a_sc_bot0 = tl.reshape(
+                        tlx.local_load(
+                            tlx.local_slice(a_sc_view_0, [1, 0, 0], [1, HALF_M, NG]),
+                            layout=scale_a_layout,
+                            relaxed=True,
+                        ),
+                        HALF_M,
+                        NG,
+                    )
             else:
                 a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
             if PRESHUFFLED_SCALES:
                 if not MERGED_SCALE_DMA:
                     b_sc_phys_0 = smem_b_sc[0]
-                    b_sc_view_0 = tlx.local_reshape(b_sc_phys_0, preshuffled_scale_shape)
-                    b_sc_view_0 = tlx.local_trans(b_sc_view_0, preshuffled_b_to_logical)
-                    b_sc_view_0 = tlx.local_reshape(b_sc_view_0, [BLOCK_N, NG])
-                    b_sc_comb = tlx.local_load(b_sc_view_0, layout=scale_b_comb_layout, relaxed=True)
+                    b_sc_view_0 = tlx.local_reinterpret(
+                        b_sc_phys_0, tl.uint8, [BLOCK_N, NG], layout=shared_b_scales)
+                b_sc_comb = tl.reshape(
+                    tlx.local_load(b_sc_view_0, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
             else:
                 b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
             b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
@@ -699,37 +785,56 @@ def _a4w4_8wave_kernel(
     a_top = tlx.local_load(tlx.local_view(smem_a_top, g_idx), relaxed=True)
     if PRESHUFFLED_SCALES:
         if MERGED_SCALE_DMA:
-            sc_phys_epilogue = tlx.local_reshape(smem_sc[0], [2] + merged_scale_shape)
-            a_sc_view_epilogue = tlx.local_trans(sc_phys_epilogue, merged_a_to_logical)
-            a_sc_view_epilogue = tlx.local_reshape(a_sc_view_epilogue, [2, 2, BLOCK_M, NG])
-            a_sc_view_epilogue = tlx.local_slice(
-                a_sc_view_epilogue, [1, 0, 0, 0], [1, 1, BLOCK_M, NG])
-            a_sc_comb = tl.reshape(
-                tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True), BLOCK_M, NG)
-            b_sc_view_epilogue = tlx.local_trans(sc_phys_epilogue, merged_b_to_logical)
-            b_sc_view_epilogue = tlx.local_reshape(b_sc_view_epilogue, [2, 2, BLOCK_N, NG])
+            a_sc_top = tl.reshape(
+                tlx.local_load(
+                    tlx.local_slice(smem_sc_a_view, [4, 0, 0], [1, HALF_M, NG]),
+                    layout=scale_a_layout,
+                    relaxed=True,
+                ),
+                HALF_M,
+                NG,
+            )
+            a_sc_bot1 = tl.reshape(
+                tlx.local_load(
+                    tlx.local_slice(smem_sc_a_view, [5, 0, 0], [1, HALF_M, NG]),
+                    layout=scale_a_layout,
+                    relaxed=True,
+                ),
+                HALF_M,
+                NG,
+            )
             b_sc_view_epilogue = tlx.local_slice(
-                b_sc_view_epilogue, [1, 1, 0, 0], [1, 1, BLOCK_N, NG])
-            b_sc_comb = tl.reshape(
-                tlx.local_load(b_sc_view_epilogue, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
+                smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
         else:
-            a_sc_phys_epilogue = smem_a_sc[g_idx]
-            a_sc_view_epilogue = tlx.local_reshape(a_sc_phys_epilogue, preshuffled_scale_shape)
-            a_sc_view_epilogue = tlx.local_trans(a_sc_view_epilogue, preshuffled_a_to_logical)
-            a_sc_view_epilogue = tlx.local_reshape(a_sc_view_epilogue, [BLOCK_M, NG])
-            a_sc_comb = tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True)
-        a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
-        a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
-        a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
+            a_sc_view_epilogue = tlx.local_reinterpret(
+                smem_a_sc[g_idx], tl.uint8, [2, HALF_M, NG], layout=shared_a_scales_packed)
+            a_sc_top = tl.reshape(
+                tlx.local_load(
+                    tlx.local_slice(a_sc_view_epilogue, [0, 0, 0], [1, HALF_M, NG]),
+                    layout=scale_a_layout,
+                    relaxed=True,
+                ),
+                HALF_M,
+                NG,
+            )
+            a_sc_bot1 = tl.reshape(
+                tlx.local_load(
+                    tlx.local_slice(a_sc_view_epilogue, [1, 0, 0], [1, HALF_M, NG]),
+                    layout=scale_a_layout,
+                    relaxed=True,
+                ),
+                HALF_M,
+                NG,
+            )
     else:
         a_sc_top = tlx.local_load(smem_a_sc_t[g_idx], layout=scale_a_layout)
     if PRESHUFFLED_SCALES:
         if not MERGED_SCALE_DMA:
             b_sc_phys_epilogue = smem_b_sc[g_idx]
-            b_sc_view_epilogue = tlx.local_reshape(b_sc_phys_epilogue, preshuffled_scale_shape)
-            b_sc_view_epilogue = tlx.local_trans(b_sc_view_epilogue, preshuffled_b_to_logical)
-            b_sc_view_epilogue = tlx.local_reshape(b_sc_view_epilogue, [BLOCK_N, NG])
-            b_sc_comb = tlx.local_load(b_sc_view_epilogue, layout=scale_b_comb_layout, relaxed=True)
+            b_sc_view_epilogue = tlx.local_reinterpret(
+                b_sc_phys_epilogue, tl.uint8, [BLOCK_N, NG], layout=shared_b_scales)
+        b_sc_comb = tl.reshape(
+            tlx.local_load(b_sc_view_epilogue, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
     else:
         b_sc_comb = tlx.local_load(smem_b_sc[g_idx], layout=scale_b_comb_layout)
     b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
@@ -921,34 +1026,34 @@ def _pad_mxfp4_scales(scales):
 
 
 def preshuffle_mxfp4_a_scales(scales):
-    """Pack A scales so a combined 256x8 LDS tile is read with ``ds_read_b128``.
+    """Pack A scales into two canonical conflict-free 128x8 LDS images.
 
-    The four physical low bits are group bit 2 and row bits 5, 6, and 7: the
-    exact value bases of ``scale_a_comb_layout``. Padding uses the E8M0 identity
-    value (0x7f).
+    For each half tile the physical row is ``row ^ ((group & 4) << 2)``.
+    Physical rows remain contiguous inside each group, so the packed image is
+    byte-linear for DMA and reinterprets directly as ``shared_a_scales``.
+    Padding uses the E8M0 identity value (0x7f).
     """
     padded, padded_rows, padded_groups = _pad_mxfp4_scales(scales)
-    return (
-        padded.reshape(
-            padded_rows // 256, 2, 2, 2, 2, 2, 2, 2, 2,
-            padded_groups // 8, 2, 2, 2)
-        .permute(0, 9, 11, 12, 7, 8, 4, 5, 6, 1, 2, 3, 10)
-        .contiguous()
-        .reshape(-1)
-    )
+    tiles = padded.reshape(padded_rows // 256, 2, 128, padded_groups // 8, 8)
+    tiles = tiles.permute(0, 3, 1, 4, 2)
+    physical_rows = torch.arange(128, dtype=torch.int64, device=scales.device)
+    groups = torch.arange(8, dtype=torch.int64, device=scales.device)
+    logical_rows = physical_rows[None, :] ^ ((groups[:, None] & 4) << 2)
+    logical_rows = logical_rows.reshape(1, 1, 1, 8, 128).expand_as(tiles)
+    return torch.gather(tiles, -1, logical_rows).contiguous().reshape(-1)
 
 
 def preshuffle_mxfp4_b_scales(scales):
-    """Pack B scales into the ordinary 64-bit LDS consumer order."""
+    """Pack B scales into the canonical conflict-free 256x8 LDS image."""
     padded, padded_rows, padded_groups = _pad_mxfp4_scales(scales)
-    return (
-        padded.reshape(
-            padded_rows // 256, 2, 2, 2, 2, 2, 2, 2, 2,
-            padded_groups // 8, 2, 2, 2)
-        .permute(0, 9, 11, 12, 3, 8, 4, 5, 6, 7, 1, 2, 10)
-        .contiguous()
-        .reshape(-1)
-    )
+    tiles = padded.reshape(padded_rows // 256, 256, padded_groups // 8, 8)
+    tiles = tiles.permute(0, 2, 3, 1)
+    physical_rows = torch.arange(256, dtype=torch.int64, device=scales.device)
+    groups = torch.arange(8, dtype=torch.int64, device=scales.device)
+    row_xor = ((groups[:, None] & 1) << 4) ^ ((groups[:, None] & 4) << 3)
+    logical_rows = physical_rows[None, :] ^ row_xor
+    logical_rows = logical_rows.reshape(1, 1, 8, 256).expand_as(tiles)
+    return torch.gather(tiles, -1, logical_rows).contiguous().reshape(-1)
 
 
 def preshuffle_mxfp4_scales(a_scales, b_scales):

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
@@ -34,7 +34,9 @@ distinct caller ABI.
 ``matmul_merged_scales`` is a second experimental kernel and ABI. It accepts one
 flat allocation containing the packed A image followed by the packed B image,
 and uses one 16-byte DMA from every thread to gather the adjacent A+B images for
-two K tiles into LDS.
+two K tiles into LDS. Its A image places the four scale register values in the
+low physical bits for one aligned ``ds_read_b128``; bank-group address bits 4..6
+come from lane bits 0..2, keeping that wide read conflict-free.
 
 The Shape:Stride register/blocked/accumulator layouts below encode the gfx950
 16x16x128 scaled-MFMA / dot-operand / scale distributions, and are
@@ -192,23 +194,31 @@ def _a4w4_8wave_kernel(
         block_bases=[],
         alignment=16,
     )
+    # The combined A view assigns the four register-value bits to the low four
+    # physical address bits, so one aligned ds_read_b128 produces both 128-row
+    # MFMA scale fragments.  Address bits 4..6 are lane bits 0..2, which gives
+    # each dword phase all 32 LDS banks; the remaining lane and warp ownership
+    # bits select higher 128-byte regions.
+    # The merged layouts add the K-tile selector around the combined A map.
+    # Physical bit 11 is the 2048-byte A/B section selector, so it is unused by
+    # the A view; physical bit 12 selects the second K tile.
+    shared_merged_a_scales_combined: tl.constexpr = tlx.shared_linear_layout_encoding(
+        offset_bases=[
+            [0, 0, 4], [0, 32, 0], [0, 64, 0], [0, 128, 0],
+            [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0],
+            [0, 16, 0], [0, 0, 1], [0, 0, 2], [0, 0, 0], [1, 0, 0],
+        ],
+        block_bases=[],
+        alignment=16,
+    )
     # Physical A images concatenate the two canonical 128x8 half tiles. The
-    # merged layouts add section and K-tile selector bits around the canonical
-    # A/B maps so the full raw allocation can be reinterpreted before slicing.
+    # merged B layout adds section and K-tile selector bits around its canonical
+    # map so the full raw allocation can be reinterpreted before slicing.
     shared_a_scales_packed: tl.constexpr = tlx.shared_linear_layout_encoding(
         offset_bases=[
             [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0],
             [0, 32, 0], [0, 64, 0], [0, 0, 1], [0, 0, 2], [0, 16, 4],
             [1, 0, 0],
-        ],
-        block_bases=[],
-        alignment=16,
-    )
-    shared_merged_a_scales: tl.constexpr = tlx.shared_linear_layout_encoding(
-        offset_bases=[
-            [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0],
-            [0, 32, 0], [0, 64, 0], [0, 0, 1], [0, 0, 2], [0, 16, 4],
-            [1, 0, 0], [2, 0, 0], [4, 0, 0],
         ],
         block_bases=[],
         alignment=16,
@@ -225,8 +235,8 @@ def _a4w4_8wave_kernel(
     # The preshuffled ABIs DMA an already-swizzled physical image. Keep the raw
     # destination byte-linear so every wave writes consecutive 4-byte (separate)
     # or 16-byte (merged) vectors. Consumers reinterpret subranges through the
-    # canonical A/B XOR layouts above; the reinterpret changes only the LDS
-    # descriptor, not the bytes or their addresses.
+    # corresponding conflict-free consumer layouts above; reinterpretation
+    # changes only the LDS descriptor, not the bytes or their addresses.
     shared_scale_preshuffled: tl.constexpr = tlx.shared_linear_layout_encoding(
         offset_bases=[
             [1], [2], [4], [8], [16], [32], [64], [128], [256], [512], [1024],
@@ -267,6 +277,10 @@ def _a4w4_8wave_kernel(
     scale_a_layout: tl.constexpr = tlx.layout(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2)),
         stride=((8, 16, 32, 64, 1, 2, 0, 0, 128), (4, 256, 512)),
+    )
+    scale_a_comb_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2)),
+        stride=((8, 16, 32, 64, 1, 2, 0, 0, 128), (4, 256, 512, 1024)),
     )
     scale_b_layout: tl.constexpr = tlx.layout(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2)),
@@ -330,7 +344,7 @@ def _a4w4_8wave_kernel(
         smem_sc = tlx.local_alloc(
             (2 * (BLOCK_M + BLOCK_N) * NG, ), tlx.dtype_of(a_scales_ptr), 1, layout=shared_scale_merged)
         smem_sc_a_view = tlx.local_reinterpret(
-            smem_sc[0], tl.uint8, [8, HALF_M, NG], layout=shared_merged_a_scales)
+            smem_sc[0], tl.uint8, [2, BLOCK_M, NG], layout=shared_merged_a_scales_combined)
         smem_sc_b_view = tlx.local_reinterpret(
             smem_sc[0], tl.uint8, [4, BLOCK_N, NG], layout=shared_merged_b_scales)
     elif PRESHUFFLED_SCALES:
@@ -483,24 +497,12 @@ def _a4w4_8wave_kernel(
         if MERGED_SCALE_DMA:
             b_sc_view_init = tlx.local_slice(
                 smem_sc_b_view, [1, 0, 0], [1, BLOCK_N, NG])
-            a_sc_top = tl.reshape(
-                tlx.local_load(
-                    tlx.local_slice(smem_sc_a_view, [0, 0, 0], [1, HALF_M, NG]),
-                    layout=scale_a_layout,
-                    relaxed=True,
-                ),
-                HALF_M,
-                NG,
-            )
-            a_sc_bot0 = tl.reshape(
-                tlx.local_load(
-                    tlx.local_slice(smem_sc_a_view, [1, 0, 0], [1, HALF_M, NG]),
-                    layout=scale_a_layout,
-                    relaxed=True,
-                ),
-                HALF_M,
-                NG,
-            )
+            a_sc_view_init = tlx.local_slice(
+                smem_sc_a_view, [0, 0, 0], [1, BLOCK_M, NG])
+            a_sc_comb = tlx.local_load(a_sc_view_init, layout=scale_a_comb_layout, relaxed=True)
+            a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+            a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+            a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
         else:
             a_sc_view_init = tlx.local_reinterpret(
                 smem_a_sc[0], tl.uint8, [2, HALF_M, NG], layout=shared_a_scales_packed)
@@ -586,29 +588,19 @@ def _a4w4_8wave_kernel(
             a_top = tlx.local_load(smem_a_top[1], relaxed=True)
             if PRESHUFFLED_SCALES:
                 if MERGED_SCALE_DMA:
-                    a_sc_top = tl.reshape(
-                        tlx.local_load(
-                            tlx.local_slice(smem_sc_a_view, [4, 0, 0], [1, HALF_M, NG]),
-                            layout=scale_a_layout,
-                            relaxed=True,
-                        ),
-                        HALF_M,
-                        NG,
-                    )
-                    a_sc_bot1 = tl.reshape(
-                        tlx.local_load(
-                            tlx.local_slice(smem_sc_a_view, [5, 0, 0], [1, HALF_M, NG]),
-                            layout=scale_a_layout,
-                            relaxed=True,
-                        ),
-                        HALF_M,
-                        NG,
-                    )
+                    a_sc_view_1 = tlx.local_slice(
+                        smem_sc_a_view, [1, 0, 0], [1, BLOCK_M, NG])
                     b_sc_view_1 = tlx.local_slice(
                         smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
                 else:
                     a_sc_view_1 = tlx.local_reinterpret(
                         smem_a_sc[1], tl.uint8, [2, HALF_M, NG], layout=shared_a_scales_packed)
+                if MERGED_SCALE_DMA:
+                    a_sc_comb = tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True)
+                    a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+                    a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+                    a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
+                else:
                     a_sc_top = tl.reshape(
                         tlx.local_load(
                             tlx.local_slice(a_sc_view_1, [0, 0, 0], [1, HALF_M, NG]),
@@ -694,29 +686,19 @@ def _a4w4_8wave_kernel(
             a_top = tlx.local_load(smem_a_top[0], relaxed=True)
             if PRESHUFFLED_SCALES:
                 if MERGED_SCALE_DMA:
-                    a_sc_top = tl.reshape(
-                        tlx.local_load(
-                            tlx.local_slice(smem_sc_a_view, [0, 0, 0], [1, HALF_M, NG]),
-                            layout=scale_a_layout,
-                            relaxed=True,
-                        ),
-                        HALF_M,
-                        NG,
-                    )
-                    a_sc_bot0 = tl.reshape(
-                        tlx.local_load(
-                            tlx.local_slice(smem_sc_a_view, [1, 0, 0], [1, HALF_M, NG]),
-                            layout=scale_a_layout,
-                            relaxed=True,
-                        ),
-                        HALF_M,
-                        NG,
-                    )
+                    a_sc_view_0 = tlx.local_slice(
+                        smem_sc_a_view, [0, 0, 0], [1, BLOCK_M, NG])
                     b_sc_view_0 = tlx.local_slice(
                         smem_sc_b_view, [1, 0, 0], [1, BLOCK_N, NG])
                 else:
                     a_sc_view_0 = tlx.local_reinterpret(
                         smem_a_sc[0], tl.uint8, [2, HALF_M, NG], layout=shared_a_scales_packed)
+                if MERGED_SCALE_DMA:
+                    a_sc_comb = tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True)
+                    a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+                    a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+                    a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
+                else:
                     a_sc_top = tl.reshape(
                         tlx.local_load(
                             tlx.local_slice(a_sc_view_0, [0, 0, 0], [1, HALF_M, NG]),
@@ -785,29 +767,19 @@ def _a4w4_8wave_kernel(
     a_top = tlx.local_load(tlx.local_view(smem_a_top, g_idx), relaxed=True)
     if PRESHUFFLED_SCALES:
         if MERGED_SCALE_DMA:
-            a_sc_top = tl.reshape(
-                tlx.local_load(
-                    tlx.local_slice(smem_sc_a_view, [4, 0, 0], [1, HALF_M, NG]),
-                    layout=scale_a_layout,
-                    relaxed=True,
-                ),
-                HALF_M,
-                NG,
-            )
-            a_sc_bot1 = tl.reshape(
-                tlx.local_load(
-                    tlx.local_slice(smem_sc_a_view, [5, 0, 0], [1, HALF_M, NG]),
-                    layout=scale_a_layout,
-                    relaxed=True,
-                ),
-                HALF_M,
-                NG,
-            )
+            a_sc_view_epilogue = tlx.local_slice(
+                smem_sc_a_view, [1, 0, 0], [1, BLOCK_M, NG])
             b_sc_view_epilogue = tlx.local_slice(
                 smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
         else:
             a_sc_view_epilogue = tlx.local_reinterpret(
                 smem_a_sc[g_idx], tl.uint8, [2, HALF_M, NG], layout=shared_a_scales_packed)
+        if MERGED_SCALE_DMA:
+            a_sc_comb = tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True)
+            a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+            a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+            a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
+        else:
             a_sc_top = tl.reshape(
                 tlx.local_load(
                     tlx.local_slice(a_sc_view_epilogue, [0, 0, 0], [1, HALF_M, NG]),
@@ -1043,6 +1015,19 @@ def preshuffle_mxfp4_a_scales(scales):
     return torch.gather(tiles, -1, logical_rows).contiguous().reshape(-1)
 
 
+def _preshuffle_mxfp4_a_scales_b128(scales):
+    """Pack A scales for the merged ABI's conflict-free 128-bit LDS read."""
+    padded, padded_rows, padded_groups = _pad_mxfp4_scales(scales)
+    return (
+        padded.reshape(
+            padded_rows // 256, 2, 2, 2, 2, 2, 2, 2, 2,
+            padded_groups // 8, 2, 2, 2)
+        .permute(0, 9, 11, 12, 4, 5, 6, 7, 8, 1, 2, 3, 10)
+        .contiguous()
+        .reshape(-1)
+    )
+
+
 def preshuffle_mxfp4_b_scales(scales):
     """Pack B scales into the canonical conflict-free 256x8 LDS image."""
     padded, padded_rows, padded_groups = _pad_mxfp4_scales(scales)
@@ -1059,14 +1044,14 @@ def preshuffle_mxfp4_b_scales(scales):
 def preshuffle_mxfp4_scales(a_scales, b_scales):
     """Pack A and B scales into the merged kernel's single flat allocation.
 
-    Each half retains its native LDS-consumer order. The kernel creates two
-    logical subviews of the adjacent physical image, so no scale redistribution
-    is needed after the DMA.
+    A uses the combined b128 consumer order and B uses its canonical transpose
+    order. The kernel creates logical subviews of the adjacent physical image,
+    so no scale redistribution is needed after the DMA.
     """
     assert a_scales.device == b_scales.device, "A and B scales must be on the same device"
     assert a_scales.ndim == 2 and b_scales.ndim == 2
     assert a_scales.shape[1] == b_scales.shape[1], "A and B scales must have the same K groups"
-    return torch.cat((preshuffle_mxfp4_a_scales(a_scales), preshuffle_mxfp4_b_scales(b_scales)))
+    return torch.cat((_preshuffle_mxfp4_a_scales_b128(a_scales), preshuffle_mxfp4_b_scales(b_scales)))
 
 
 def _matmul_256tile(a, b, a_scales, b_scales, SPLIT_K=None):

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
@@ -25,11 +25,11 @@ The production entry point uses the same ABI as the 4-wave a4w4 kernel:
   * C: bfloat16, shape (M, N)
 
 ``matmul_preshuffled`` is a separate experimental ABI: both scale operands are
-packed into the canonical XOR-swizzled LDS image and retain the production
-DMA-to-LDS pipeline. The flat DMA destination is reinterpreted, without copying,
-through the same bank-conflict-free layouts used by the production kernel.
-It remains outside ``matmul`` because its flat, prepacked scale buffers are a
-distinct caller ABI.
+packed directly into their wide LDS-consumer order and retain the production
+DMA-to-LDS pipeline. The combined A tile is read once with ``ds_read_b128`` and
+split into its two 128-row MFMA fragments in registers. This measured faster
+than the zero-conflict two-read form despite approximately 1.2% LDS conflicts.
+It remains outside ``matmul`` because its flat buffers are a distinct caller ABI.
 
 ``matmul_merged_scales`` is a second experimental kernel and ABI. It accepts one
 flat allocation containing the packed A image followed by the packed B image,
@@ -211,18 +211,9 @@ def _a4w4_8wave_kernel(
         block_bases=[],
         alignment=16,
     )
-    # Physical A images concatenate the two canonical 128x8 half tiles. The
-    # merged B layout adds section and K-tile selector bits around its canonical
-    # map so the full raw allocation can be reinterpreted before slicing.
-    shared_a_scales_packed: tl.constexpr = tlx.shared_linear_layout_encoding(
-        offset_bases=[
-            [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0],
-            [0, 32, 0], [0, 64, 0], [0, 0, 1], [0, 0, 2], [0, 16, 4],
-            [1, 0, 0],
-        ],
-        block_bases=[],
-        alignment=16,
-    )
+    # The merged B layout adds section and K-tile selector bits around its
+    # canonical map so the full raw allocation can be reinterpreted before
+    # slicing.
     shared_merged_b_scales: tl.constexpr = tlx.shared_linear_layout_encoding(
         offset_bases=[
             [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0],
@@ -232,11 +223,9 @@ def _a4w4_8wave_kernel(
         block_bases=[],
         alignment=16,
     )
-    # The preshuffled ABIs DMA an already-swizzled physical image. Keep the raw
+    # The preshuffled ABIs DMA an already-packed physical image. Keep the raw
     # destination byte-linear so every wave writes consecutive 4-byte (separate)
-    # or 16-byte (merged) vectors. Consumers reinterpret subranges through the
-    # corresponding conflict-free consumer layouts above; reinterpretation
-    # changes only the LDS descriptor, not the bytes or their addresses.
+    # or 16-byte (merged) vectors.
     shared_scale_preshuffled: tl.constexpr = tlx.shared_linear_layout_encoding(
         offset_bases=[
             [1], [2], [4], [8], [16], [32], [64], [128], [256], [512], [1024],
@@ -266,6 +255,12 @@ def _a4w4_8wave_kernel(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2)),
         stride=((4, 8, 16, 32, 64, 128, 256, 512, 1024), (1, 2)),
     )
+    # Reinterpret each separate scale image from physical byte order into the
+    # logical [row, group] tile. These permutations preserve the measured-fast
+    # combined A b128 and ordinary B b64 reads from the original wide ABI.
+    preshuffled_scale_shape: tl.constexpr = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+    preshuffled_a_to_logical: tl.constexpr = (7, 8, 9, 4, 5, 6, 2, 3, 10, 0, 1)
+    preshuffled_b_to_logical: tl.constexpr = (8, 9, 2, 4, 5, 6, 7, 3, 10, 0, 1)
     # One 16-byte vector per thread stages two adjacent A+B scale images.  The
     # high warp bit selects the second K tile, so all eight waves contribute to
     # one full-workgroup 8192-byte DMA.
@@ -504,35 +499,21 @@ def _a4w4_8wave_kernel(
             a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
             a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
         else:
-            a_sc_view_init = tlx.local_reinterpret(
-                smem_a_sc[0], tl.uint8, [2, HALF_M, NG], layout=shared_a_scales_packed)
-            a_sc_top = tl.reshape(
-                tlx.local_load(
-                    tlx.local_slice(a_sc_view_init, [0, 0, 0], [1, HALF_M, NG]),
-                    layout=scale_a_layout,
-                    relaxed=True,
-                ),
-                HALF_M,
-                NG,
-            )
-            a_sc_bot0 = tl.reshape(
-                tlx.local_load(
-                    tlx.local_slice(a_sc_view_init, [1, 0, 0], [1, HALF_M, NG]),
-                    layout=scale_a_layout,
-                    relaxed=True,
-                ),
-                HALF_M,
-                NG,
-            )
+            a_sc_view_init = tlx.local_reshape(smem_a_sc[0], preshuffled_scale_shape)
+            a_sc_view_init = tlx.local_trans(a_sc_view_init, preshuffled_a_to_logical)
+            a_sc_view_init = tlx.local_reshape(a_sc_view_init, [BLOCK_M, NG])
+            a_sc_comb = tlx.local_load(a_sc_view_init, layout=scale_a_comb_layout, relaxed=True)
+            a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+            a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+            a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
     else:
         a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
     if PRESHUFFLED_SCALES:
         if not MERGED_SCALE_DMA:
-            b_sc_phys_init = smem_b_sc[0]
-            b_sc_view_init = tlx.local_reinterpret(
-                b_sc_phys_init, tl.uint8, [BLOCK_N, NG], layout=shared_b_scales)
-        b_sc_comb = tl.reshape(
-            tlx.local_load(b_sc_view_init, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
+            b_sc_view_init = tlx.local_reshape(smem_b_sc[0], preshuffled_scale_shape)
+            b_sc_view_init = tlx.local_trans(b_sc_view_init, preshuffled_b_to_logical)
+            b_sc_view_init = tlx.local_reshape(b_sc_view_init, [BLOCK_N, NG])
+        b_sc_comb = tlx.local_load(b_sc_view_init, layout=scale_b_comb_layout, relaxed=True)
     else:
         b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
     b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
@@ -593,41 +574,27 @@ def _a4w4_8wave_kernel(
                     b_sc_view_1 = tlx.local_slice(
                         smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
                 else:
-                    a_sc_view_1 = tlx.local_reinterpret(
-                        smem_a_sc[1], tl.uint8, [2, HALF_M, NG], layout=shared_a_scales_packed)
+                    a_sc_view_1 = tlx.local_reshape(smem_a_sc[1], preshuffled_scale_shape)
+                    a_sc_view_1 = tlx.local_trans(a_sc_view_1, preshuffled_a_to_logical)
+                    a_sc_view_1 = tlx.local_reshape(a_sc_view_1, [BLOCK_M, NG])
                 if MERGED_SCALE_DMA:
                     a_sc_comb = tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True)
                     a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
                     a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
                     a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
                 else:
-                    a_sc_top = tl.reshape(
-                        tlx.local_load(
-                            tlx.local_slice(a_sc_view_1, [0, 0, 0], [1, HALF_M, NG]),
-                            layout=scale_a_layout,
-                            relaxed=True,
-                        ),
-                        HALF_M,
-                        NG,
-                    )
-                    a_sc_bot1 = tl.reshape(
-                        tlx.local_load(
-                            tlx.local_slice(a_sc_view_1, [1, 0, 0], [1, HALF_M, NG]),
-                            layout=scale_a_layout,
-                            relaxed=True,
-                        ),
-                        HALF_M,
-                        NG,
-                    )
+                    a_sc_comb = tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True)
+                    a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+                    a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+                    a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
             else:
                 a_sc_top = tlx.local_load(smem_a_sc_t[1], layout=scale_a_layout)
             if PRESHUFFLED_SCALES:
                 if not MERGED_SCALE_DMA:
-                    b_sc_phys_1 = smem_b_sc[1]
-                    b_sc_view_1 = tlx.local_reinterpret(
-                        b_sc_phys_1, tl.uint8, [BLOCK_N, NG], layout=shared_b_scales)
-                b_sc_comb = tl.reshape(
-                    tlx.local_load(b_sc_view_1, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
+                    b_sc_view_1 = tlx.local_reshape(smem_b_sc[1], preshuffled_scale_shape)
+                    b_sc_view_1 = tlx.local_trans(b_sc_view_1, preshuffled_b_to_logical)
+                    b_sc_view_1 = tlx.local_reshape(b_sc_view_1, [BLOCK_N, NG])
+                b_sc_comb = tlx.local_load(b_sc_view_1, layout=scale_b_comb_layout, relaxed=True)
             else:
                 b_sc_comb = tlx.local_load(smem_b_sc[1], layout=scale_b_comb_layout)
             b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
@@ -691,41 +658,27 @@ def _a4w4_8wave_kernel(
                     b_sc_view_0 = tlx.local_slice(
                         smem_sc_b_view, [1, 0, 0], [1, BLOCK_N, NG])
                 else:
-                    a_sc_view_0 = tlx.local_reinterpret(
-                        smem_a_sc[0], tl.uint8, [2, HALF_M, NG], layout=shared_a_scales_packed)
+                    a_sc_view_0 = tlx.local_reshape(smem_a_sc[0], preshuffled_scale_shape)
+                    a_sc_view_0 = tlx.local_trans(a_sc_view_0, preshuffled_a_to_logical)
+                    a_sc_view_0 = tlx.local_reshape(a_sc_view_0, [BLOCK_M, NG])
                 if MERGED_SCALE_DMA:
                     a_sc_comb = tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True)
                     a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
                     a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
                     a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
                 else:
-                    a_sc_top = tl.reshape(
-                        tlx.local_load(
-                            tlx.local_slice(a_sc_view_0, [0, 0, 0], [1, HALF_M, NG]),
-                            layout=scale_a_layout,
-                            relaxed=True,
-                        ),
-                        HALF_M,
-                        NG,
-                    )
-                    a_sc_bot0 = tl.reshape(
-                        tlx.local_load(
-                            tlx.local_slice(a_sc_view_0, [1, 0, 0], [1, HALF_M, NG]),
-                            layout=scale_a_layout,
-                            relaxed=True,
-                        ),
-                        HALF_M,
-                        NG,
-                    )
+                    a_sc_comb = tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True)
+                    a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+                    a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+                    a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
             else:
                 a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
             if PRESHUFFLED_SCALES:
                 if not MERGED_SCALE_DMA:
-                    b_sc_phys_0 = smem_b_sc[0]
-                    b_sc_view_0 = tlx.local_reinterpret(
-                        b_sc_phys_0, tl.uint8, [BLOCK_N, NG], layout=shared_b_scales)
-                b_sc_comb = tl.reshape(
-                    tlx.local_load(b_sc_view_0, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
+                    b_sc_view_0 = tlx.local_reshape(smem_b_sc[0], preshuffled_scale_shape)
+                    b_sc_view_0 = tlx.local_trans(b_sc_view_0, preshuffled_b_to_logical)
+                    b_sc_view_0 = tlx.local_reshape(b_sc_view_0, [BLOCK_N, NG])
+                b_sc_comb = tlx.local_load(b_sc_view_0, layout=scale_b_comb_layout, relaxed=True)
             else:
                 b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
             b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
@@ -772,41 +725,27 @@ def _a4w4_8wave_kernel(
             b_sc_view_epilogue = tlx.local_slice(
                 smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
         else:
-            a_sc_view_epilogue = tlx.local_reinterpret(
-                smem_a_sc[g_idx], tl.uint8, [2, HALF_M, NG], layout=shared_a_scales_packed)
+            a_sc_view_epilogue = tlx.local_reshape(smem_a_sc[g_idx], preshuffled_scale_shape)
+            a_sc_view_epilogue = tlx.local_trans(a_sc_view_epilogue, preshuffled_a_to_logical)
+            a_sc_view_epilogue = tlx.local_reshape(a_sc_view_epilogue, [BLOCK_M, NG])
         if MERGED_SCALE_DMA:
             a_sc_comb = tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True)
             a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
             a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
             a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
         else:
-            a_sc_top = tl.reshape(
-                tlx.local_load(
-                    tlx.local_slice(a_sc_view_epilogue, [0, 0, 0], [1, HALF_M, NG]),
-                    layout=scale_a_layout,
-                    relaxed=True,
-                ),
-                HALF_M,
-                NG,
-            )
-            a_sc_bot1 = tl.reshape(
-                tlx.local_load(
-                    tlx.local_slice(a_sc_view_epilogue, [1, 0, 0], [1, HALF_M, NG]),
-                    layout=scale_a_layout,
-                    relaxed=True,
-                ),
-                HALF_M,
-                NG,
-            )
+            a_sc_comb = tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True)
+            a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+            a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+            a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
     else:
         a_sc_top = tlx.local_load(smem_a_sc_t[g_idx], layout=scale_a_layout)
     if PRESHUFFLED_SCALES:
         if not MERGED_SCALE_DMA:
-            b_sc_phys_epilogue = smem_b_sc[g_idx]
-            b_sc_view_epilogue = tlx.local_reinterpret(
-                b_sc_phys_epilogue, tl.uint8, [BLOCK_N, NG], layout=shared_b_scales)
-        b_sc_comb = tl.reshape(
-            tlx.local_load(b_sc_view_epilogue, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
+            b_sc_view_epilogue = tlx.local_reshape(smem_b_sc[g_idx], preshuffled_scale_shape)
+            b_sc_view_epilogue = tlx.local_trans(b_sc_view_epilogue, preshuffled_b_to_logical)
+            b_sc_view_epilogue = tlx.local_reshape(b_sc_view_epilogue, [BLOCK_N, NG])
+        b_sc_comb = tlx.local_load(b_sc_view_epilogue, layout=scale_b_comb_layout, relaxed=True)
     else:
         b_sc_comb = tlx.local_load(smem_b_sc[g_idx], layout=scale_b_comb_layout)
     b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
@@ -998,21 +937,21 @@ def _pad_mxfp4_scales(scales):
 
 
 def preshuffle_mxfp4_a_scales(scales):
-    """Pack A scales into two canonical conflict-free 128x8 LDS images.
+    """Pack A scales so a combined 256x8 LDS tile uses ``ds_read_b128``.
 
-    For each half tile the physical row is ``row ^ ((group & 4) << 2)``.
-    Physical rows remain contiguous inside each group, so the packed image is
-    byte-linear for DMA and reinterprets directly as ``shared_a_scales``.
-    Padding uses the E8M0 identity value (0x7f).
+    The four physical low bits are group bit 2 and row bits 5, 6, and 7: the
+    exact value bases of ``scale_a_comb_layout``. Padding uses the E8M0 identity
+    value (0x7f).
     """
     padded, padded_rows, padded_groups = _pad_mxfp4_scales(scales)
-    tiles = padded.reshape(padded_rows // 256, 2, 128, padded_groups // 8, 8)
-    tiles = tiles.permute(0, 3, 1, 4, 2)
-    physical_rows = torch.arange(128, dtype=torch.int64, device=scales.device)
-    groups = torch.arange(8, dtype=torch.int64, device=scales.device)
-    logical_rows = physical_rows[None, :] ^ ((groups[:, None] & 4) << 2)
-    logical_rows = logical_rows.reshape(1, 1, 1, 8, 128).expand_as(tiles)
-    return torch.gather(tiles, -1, logical_rows).contiguous().reshape(-1)
+    return (
+        padded.reshape(
+            padded_rows // 256, 2, 2, 2, 2, 2, 2, 2, 2,
+            padded_groups // 8, 2, 2, 2)
+        .permute(0, 9, 11, 12, 7, 8, 4, 5, 6, 1, 2, 3, 10)
+        .contiguous()
+        .reshape(-1)
+    )
 
 
 def _preshuffle_mxfp4_a_scales_b128(scales):
@@ -1029,7 +968,20 @@ def _preshuffle_mxfp4_a_scales_b128(scales):
 
 
 def preshuffle_mxfp4_b_scales(scales):
-    """Pack B scales into the canonical conflict-free 256x8 LDS image."""
+    """Pack B scales into the ordinary 64-bit LDS consumer order."""
+    padded, padded_rows, padded_groups = _pad_mxfp4_scales(scales)
+    return (
+        padded.reshape(
+            padded_rows // 256, 2, 2, 2, 2, 2, 2, 2, 2,
+            padded_groups // 8, 2, 2, 2)
+        .permute(0, 9, 11, 12, 3, 8, 4, 5, 6, 7, 1, 2, 10)
+        .contiguous()
+        .reshape(-1)
+    )
+
+
+def _preshuffle_mxfp4_b_scales_conflict_free(scales):
+    """Pack B scales for the merged ABI's conflict-free transpose read."""
     padded, padded_rows, padded_groups = _pad_mxfp4_scales(scales)
     tiles = padded.reshape(padded_rows // 256, 256, padded_groups // 8, 8)
     tiles = tiles.permute(0, 2, 3, 1)
@@ -1051,7 +1003,10 @@ def preshuffle_mxfp4_scales(a_scales, b_scales):
     assert a_scales.device == b_scales.device, "A and B scales must be on the same device"
     assert a_scales.ndim == 2 and b_scales.ndim == 2
     assert a_scales.shape[1] == b_scales.shape[1], "A and B scales must have the same K groups"
-    return torch.cat((_preshuffle_mxfp4_a_scales_b128(a_scales), preshuffle_mxfp4_b_scales(b_scales)))
+    return torch.cat((
+        _preshuffle_mxfp4_a_scales_b128(a_scales),
+        _preshuffle_mxfp4_b_scales_conflict_free(b_scales),
+    ))
 
 
 def _matmul_256tile(a, b, a_scales, b_scales, SPLIT_K=None):

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
@@ -67,6 +67,9 @@ import torch
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
+from triton.language.extra.tlx.tutorials.gfx9_gemm.intra_wave.a4w4.matmul_kernel import (
+    matmul as intra_wave_matmul,
+)
 from triton.language.extra.tlx.tutorials.gfx9_gemm.skinny.a4w4 import is_skinny, skinny_matmul
 
 BLOCK_M = 256
@@ -91,6 +94,7 @@ _A4W4_8WAVE_LLVM_FN_ATTRS = (
 # the pinned operand layouts.
 MIN_K = 4 * BLOCK_K
 KERNEL_NAME = "a4w4_8wave"
+INTRA_WAVE_MAX_K = 1536
 
 
 @triton.jit
@@ -632,7 +636,8 @@ def _matmul_256tile(a, b, a_scales, b_scales, SPLIT_K=None):
         num_warps=NUM_WARPS,
         num_stages=1,
         matrix_instr_nonkdim=16,
-        # Forbid AGPRs: f32 accumulators write VGPRs directly (packs tighter, no spills).
+        # Keep f32 accumulators in VGPRs. Allowing AGPR allocation increases
+        # private-segment spills and regresses this 8-wave ownership model.
         llvm_fn_attrs=_A4W4_8WAVE_LLVM_FN_ATTRS,
     )
     if SPLIT_K > 1:
@@ -654,9 +659,11 @@ def _matmul_256tile(a, b, a_scales, b_scales, SPLIT_K=None):
 
 
 def select_matmul_path(M, N, K):
-    """Select the measured small-M path without changing the existing fallback."""
+    """Select the measured gfx950 tile and wave-ownership strategy."""
     if is_skinny(M, N, K):
         return "skinny"
+    if K <= INTRA_WAVE_MAX_K:
+        return "intra_wave_256x256"
     return "inter_wave_256x256"
 
 
@@ -664,7 +671,8 @@ def matmul(a, b, a_scales, b_scales):
     """A @ B.T for packed MXFP4 A/B using measured gfx950 dispatch.
 
     * occupancy-starved grids use measured 32/64/128x128 tiles and bounded split-K;
-    * other grids retain the existing 8-wave 256x256 inter-wave path.
+    * well-filled K=1024/1536 grids use the lower-overhead 4-wave 256x256 path;
+    * K >= 2048 well-filled grids use the 8-wave 256x256 inter-wave pipeline.
     """
     M = a.shape[0]
     K = a.shape[1] * 2
@@ -672,4 +680,6 @@ def matmul(a, b, a_scales, b_scales):
     path = select_matmul_path(M, N, K)
     if path == "skinny":
         return skinny_matmul(a, b, a_scales, b_scales)
+    if path == "intra_wave_256x256":
+        return intra_wave_matmul(a, b, a_scales, b_scales)
     return _matmul_256tile(a, b, a_scales, b_scales)

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
@@ -18,11 +18,17 @@ Key ideas (same skeleton as the a16w16 8-wave inter_wave kernel):
     then split it into the two [128, 8] N-halves with a free register-bit split
     (`scale_b_comb_layout` == `scale_b_layout` + one extra register base [128,0]).
 
-Inputs use the same ABI as the 4-wave a4w4 kernel:
+The production entry point uses the same ABI as the 4-wave a4w4 kernel:
   * A: packed e2m1, shape (M, K // 2), K-contiguous
   * B: packed e2m1, shape (N, K // 2), K-contiguous; computes A @ B.T
   * scales: e8m0 uint8, shapes (M, K // 32) and (N, K // 32), contiguous along M/N
   * C: bfloat16, shape (M, N)
+
+``matmul_preshuffled`` is a separate experimental ABI: A scales are packed by
+``preshuffle_mxfp4_a_scales`` and loaded directly into MFMA scale registers,
+while B scales retain the canonical DMA-to-LDS path. It is intentionally not
+selected by ``matmul`` because controlled measurements show that its longer
+scale live ranges outweigh the removed LDS traffic.
 
 The Shape:Stride register/blocked/accumulator layouts below encode the gfx950
 16x16x128 scaled-MFMA / dot-operand / scale distributions, and are
@@ -94,6 +100,7 @@ _A4W4_8WAVE_LLVM_FN_ATTRS = (
 # the pinned operand layouts.
 MIN_K = 4 * BLOCK_K
 KERNEL_NAME = "a4w4_8wave"
+PRESHUFFLED_KERNEL_NAME = "a4w4_8wave_preshuffled_scales"
 INTRA_WAVE_MAX_K = 1536
 
 
@@ -126,6 +133,7 @@ def _a4w4_8wave_kernel(
     NUM_XCDS: tl.constexpr,
     GRID_MN: tl.constexpr,
     SPLIT_K: tl.constexpr,
+    PRESHUFFLED_A_SCALES: tl.constexpr = False,
 ):
     SCALE_GROUP_SIZE: tl.constexpr = 32
     HALF_M: tl.constexpr = BLOCK_M // 2  # 128
@@ -138,6 +146,7 @@ def _a4w4_8wave_kernel(
     KS: tl.constexpr = K // SPLIT_K
     KS_PACKED: tl.constexpr = KS // 2  # packed fp4 columns per split
     KS_SCALE: tl.constexpr = KS // SCALE_GROUP_SIZE  # scale groups per split
+    SCALE_GROUP_BLOCKS: tl.constexpr = K // BLOCK_K
 
     # ---- fp4 tile global-load register layout (#linear, [128,128]) ----
     g_load_layout: tl.constexpr = tlx.layout(
@@ -246,8 +255,9 @@ def _a4w4_8wave_kernel(
     smem_a_bot = tlx.local_alloc((HALF_M, HALF_K), tlx.dtype_of(a_ptr), 2, layout=shared_tile)
     smem_b_left = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
     smem_b_right = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
-    smem_a_sc_t = tlx.local_alloc((HALF_M, NG), tlx.dtype_of(a_scales_ptr), 2, layout=shared_a_scales)
-    smem_a_sc_b = tlx.local_alloc((HALF_M, NG), tlx.dtype_of(a_scales_ptr), 2, layout=shared_a_scales)
+    if not PRESHUFFLED_A_SCALES:
+        smem_a_sc_t = tlx.local_alloc((HALF_M, NG), tlx.dtype_of(a_scales_ptr), 2, layout=shared_a_scales)
+        smem_a_sc_b = tlx.local_alloc((HALF_M, NG), tlx.dtype_of(a_scales_ptr), 2, layout=shared_a_scales)
     smem_b_sc = tlx.local_alloc((BLOCK_N, NG), tlx.dtype_of(b_scales_ptr), 2, layout=shared_b_scales)
 
     # ---- fp4 tile load offsets ([128,128]) ----
@@ -264,9 +274,25 @@ def _a4w4_8wave_kernel(
     # ---- A scale load offsets ([128,8]) ----
     offs_ks_a = tl.arange(0, NG)
     offs_asm = pid_m * BLOCK_M + tl.arange(0, HALF_M)
-    a_sc_offsets = tl.mul(offs_asm[:, None], stride_asm, sanitize_overflow=False) + tl.mul(
-        offs_ks_a[None, :], stride_ask, sanitize_overflow=False)
-    a_sc_offsets = tlx.require_layout(a_sc_offsets, scale_load_a_layout)
+    if PRESHUFFLED_A_SCALES:
+        # Match the first scale operand in AITER's kernel: row/group low bits
+        # select the lane, row bit 4 selects the M wave, and (group bit 2,
+        # row bits 5..6) select eight consecutive register bytes. Row bit 7
+        # selects the top/bottom 128-row half.
+        a_sc_offsets = (
+            (offs_asm[:, None] // 256 * SCALE_GROUP_BLOCKS) * 2048
+            + (offs_asm[:, None] % 256) // 128 * 1024
+            + (((offs_asm[:, None] % 32) // 16) * 64
+               + (offs_ks_a[None, :] % 4) * 16
+               + offs_asm[:, None] % 16) * 8
+            + (offs_asm[:, None] % 128) // 32 * 2
+            + offs_ks_a[None, :] // 4
+        )
+        a_sc_offsets = tlx.require_layout(a_sc_offsets, scale_a_layout)
+    else:
+        a_sc_offsets = tl.mul(offs_asm[:, None], stride_asm, sanitize_overflow=False) + tl.mul(
+            offs_ks_a[None, :], stride_ask, sanitize_overflow=False)
+        a_sc_offsets = tlx.require_layout(a_sc_offsets, scale_load_a_layout)
 
     # ---- B scale load offsets: FULL [256,8] in one copy ----
     offs_ks_b = tl.arange(0, NG)
@@ -280,9 +306,14 @@ def _a4w4_8wave_kernel(
     b_half_n = HALF_N * stride_bn  # b_left -> b_right
     a_k2 = HALF_K * stride_ak  # even -> odd (_next) K-step
     b_k2 = HALF_K * stride_bk
-    a_sc_half_m = HALF_M * stride_asm
-    a_sc_k = NG * stride_ask
-    b_sc_k = NG * stride_bsk
+    if PRESHUFFLED_A_SCALES:
+        a_sc_half_m: tl.constexpr = 1024
+        a_sc_k: tl.constexpr = 2048
+        b_sc_k = NG * stride_bsk
+    else:
+        a_sc_half_m = HALF_M * stride_asm
+        a_sc_k = NG * stride_ask
+        b_sc_k = NG * stride_bsk
 
     # Advance every base to this split's K-slice (no-op when SPLIT_K==1). The
     # A/B tiles are K-packed (KS_PACKED cols) and the scales are per-group
@@ -290,8 +321,12 @@ def _a4w4_8wave_kernel(
     # fat pointer as it already does for the pid_m/pid_n base offsets.
     a_base += split_id * KS_PACKED * stride_ak
     b_base += split_id * KS_PACKED * stride_bk
-    a_scales_ptr += split_id * KS_SCALE * stride_ask
-    b_scales_ptr += split_id * KS_SCALE * stride_bsk
+    if PRESHUFFLED_A_SCALES:
+        a_scales_ptr += split_id * (KS_SCALE // NG) * 2048
+        b_scales_ptr += split_id * KS_SCALE * stride_bsk
+    else:
+        a_scales_ptr += split_id * KS_SCALE * stride_ask
+        b_scales_ptr += split_id * KS_SCALE * stride_bsk
 
     acc_tl = tl.zeros((HALF_M, HALF_N), dtype=tl.float32)
     acc_bl = tl.zeros((HALF_M, HALF_N), dtype=tl.float32)
@@ -309,10 +344,18 @@ def _a4w4_8wave_kernel(
     tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_top[0], a_base, a_tile_offsets)
-    tlx.buffer_load_to_local(smem_a_sc_t[0], a_scales_ptr, a_sc_offsets)
+    if PRESHUFFLED_A_SCALES:
+        a_sc_top0 = tlx.buffer_load(a_scales_ptr, a_sc_offsets, contiguity=8)
+        a_sc_top0 = tlx.require_layout(a_sc_top0, scale_a_layout)
+    else:
+        tlx.buffer_load_to_local(smem_a_sc_t[0], a_scales_ptr, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_bot[0], a_base + a_half_m, a_tile_offsets)
-    tlx.buffer_load_to_local(smem_a_sc_b[0], a_scales_ptr + a_sc_half_m, a_sc_offsets)
+    if PRESHUFFLED_A_SCALES:
+        a_sc_bot0 = tlx.buffer_load(a_scales_ptr + a_sc_half_m, a_sc_offsets, contiguity=8)
+        a_sc_bot0 = tlx.require_layout(a_sc_bot0, scale_a_layout)
+    else:
+        tlx.buffer_load_to_local(smem_a_sc_b[0], a_scales_ptr + a_sc_half_m, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_b_right[0], b_base + b_half_n, b_tile_offsets)
     tlx.async_load_commit_group()
@@ -321,10 +364,18 @@ def _a4w4_8wave_kernel(
     tlx.buffer_load_to_local(smem_b_sc[1], b_scales_ptr + b_sc_k, b_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_top[1], a_base + a_k2, a_tile_offsets)
-    tlx.buffer_load_to_local(smem_a_sc_t[1], a_scales_ptr + a_sc_k, a_sc_offsets)
+    if PRESHUFFLED_A_SCALES:
+        a_sc_top1 = tlx.buffer_load(a_scales_ptr + a_sc_k, a_sc_offsets, contiguity=8)
+        a_sc_top1 = tlx.require_layout(a_sc_top1, scale_a_layout)
+    else:
+        tlx.buffer_load_to_local(smem_a_sc_t[1], a_scales_ptr + a_sc_k, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_bot[1], a_base + a_half_m + a_k2, a_tile_offsets)
-    tlx.buffer_load_to_local(smem_a_sc_b[1], a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets)
+    if PRESHUFFLED_A_SCALES:
+        a_sc_bot1 = tlx.buffer_load(a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets, contiguity=8)
+        a_sc_bot1 = tlx.require_layout(a_sc_bot1, scale_a_layout)
+    else:
+        tlx.buffer_load_to_local(smem_a_sc_b[1], a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_b_right[1], b_base + b_half_n + b_k2, b_tile_offsets)
     tlx.async_load_commit_group()
@@ -337,7 +388,10 @@ def _a4w4_8wave_kernel(
     tlx.async_load_wait_group(6)
     b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
     a_top = tlx.local_load(smem_a_top[0], relaxed=True)
-    a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
+    if PRESHUFFLED_A_SCALES:
+        a_sc_top = a_sc_top0
+    else:
+        a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
     b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
     b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
     b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
@@ -351,7 +405,10 @@ def _a4w4_8wave_kernel(
             acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_bot = tlx.local_load(smem_a_bot[0], relaxed=True)
-            a_sc_bot = tlx.local_load(smem_a_sc_b[0], layout=scale_a_layout)
+            if PRESHUFFLED_A_SCALES:
+                a_sc_bot = a_sc_bot0
+            else:
+                a_sc_bot = tlx.local_load(smem_a_sc_b[0], layout=scale_a_layout)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_b_left[0], b_base, b_tile_offsets)
             tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
@@ -364,7 +421,11 @@ def _a4w4_8wave_kernel(
             b_right = tlx.local_load(tlx.local_trans(smem_b_right[0]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_top[0], a_base, a_tile_offsets)
-            tlx.buffer_load_to_local(smem_a_sc_t[0], a_scales_ptr, a_sc_offsets)
+            if PRESHUFFLED_A_SCALES:
+                a_sc_next_top0 = tlx.buffer_load(a_scales_ptr, a_sc_offsets, contiguity=8)
+                a_sc_next_top0 = tlx.require_layout(a_sc_next_top0, scale_a_layout)
+            else:
+                tlx.buffer_load_to_local(smem_a_sc_t[0], a_scales_ptr, a_sc_offsets)
             tlx.async_load_commit_group()
 
         tlx.async_load_wait_group(5)
@@ -374,7 +435,11 @@ def _a4w4_8wave_kernel(
             b_left = tlx.local_load(tlx.local_trans(smem_b_left[1]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_bot[0], a_base + a_half_m, a_tile_offsets)
-            tlx.buffer_load_to_local(smem_a_sc_b[0], a_scales_ptr + a_sc_half_m, a_sc_offsets)
+            if PRESHUFFLED_A_SCALES:
+                a_sc_next_bot0 = tlx.buffer_load(a_scales_ptr + a_sc_half_m, a_sc_offsets, contiguity=8)
+                a_sc_next_bot0 = tlx.require_layout(a_sc_next_bot0, scale_a_layout)
+            else:
+                tlx.buffer_load_to_local(smem_a_sc_b[0], a_scales_ptr + a_sc_half_m, a_sc_offsets)
             tlx.async_load_commit_group()
 
         tlx.async_load_wait_group(5)
@@ -382,7 +447,10 @@ def _a4w4_8wave_kernel(
             acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_top = tlx.local_load(smem_a_top[1], relaxed=True)
-            a_sc_top = tlx.local_load(smem_a_sc_t[1], layout=scale_a_layout)
+            if PRESHUFFLED_A_SCALES:
+                a_sc_top = a_sc_top1
+            else:
+                a_sc_top = tlx.local_load(smem_a_sc_t[1], layout=scale_a_layout)
             b_sc_comb = tlx.local_load(smem_b_sc[1], layout=scale_b_comb_layout)
             b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
             b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
@@ -397,7 +465,10 @@ def _a4w4_8wave_kernel(
             acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_bot = tlx.local_load(smem_a_bot[1], relaxed=True)
-            a_sc_bot = tlx.local_load(smem_a_sc_b[1], layout=scale_a_layout)
+            if PRESHUFFLED_A_SCALES:
+                a_sc_bot = a_sc_bot1
+            else:
+                a_sc_bot = tlx.local_load(smem_a_sc_b[1], layout=scale_a_layout)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_b_left[1], b_base + b_k2, b_tile_offsets)
             tlx.buffer_load_to_local(smem_b_sc[1], b_scales_ptr + b_sc_k, b_sc_offsets)
@@ -410,7 +481,11 @@ def _a4w4_8wave_kernel(
             b_right = tlx.local_load(tlx.local_trans(smem_b_right[1]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_top[1], a_base + a_k2, a_tile_offsets)
-            tlx.buffer_load_to_local(smem_a_sc_t[1], a_scales_ptr + a_sc_k, a_sc_offsets)
+            if PRESHUFFLED_A_SCALES:
+                a_sc_next_top1 = tlx.buffer_load(a_scales_ptr + a_sc_k, a_sc_offsets, contiguity=8)
+                a_sc_next_top1 = tlx.require_layout(a_sc_next_top1, scale_a_layout)
+            else:
+                tlx.buffer_load_to_local(smem_a_sc_t[1], a_scales_ptr + a_sc_k, a_sc_offsets)
             tlx.async_load_commit_group()
 
         tlx.async_load_wait_group(5)
@@ -420,7 +495,12 @@ def _a4w4_8wave_kernel(
             b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_bot[1], a_base + a_half_m + a_k2, a_tile_offsets)
-            tlx.buffer_load_to_local(smem_a_sc_b[1], a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets)
+            if PRESHUFFLED_A_SCALES:
+                a_sc_next_bot1 = tlx.buffer_load(
+                    a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets, contiguity=8)
+                a_sc_next_bot1 = tlx.require_layout(a_sc_next_bot1, scale_a_layout)
+            else:
+                tlx.buffer_load_to_local(smem_a_sc_b[1], a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets)
             tlx.async_load_commit_group()
 
         tlx.async_load_wait_group(5)
@@ -428,7 +508,13 @@ def _a4w4_8wave_kernel(
             acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_top = tlx.local_load(smem_a_top[0], relaxed=True)
-            a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
+            if PRESHUFFLED_A_SCALES:
+                a_sc_top = a_sc_next_top0
+                a_sc_bot0 = a_sc_next_bot0
+                a_sc_top1 = a_sc_next_top1
+                a_sc_bot1 = a_sc_next_bot1
+            else:
+                a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
             b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
             b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
             b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
@@ -447,7 +533,10 @@ def _a4w4_8wave_kernel(
     tlx.async_load_wait_group(5)
     l_idx: tl.constexpr = 0  # (iter_max - 2) % 2, always 0 (iter_max even)
     a_bot = tlx.local_load(tlx.local_view(smem_a_bot, l_idx), relaxed=True)
-    a_sc_bot = tlx.local_load(smem_a_sc_b[l_idx], layout=scale_a_layout)
+    if PRESHUFFLED_A_SCALES:
+        a_sc_bot = a_sc_bot0
+    else:
+        a_sc_bot = tlx.local_load(smem_a_sc_b[l_idx], layout=scale_a_layout)
 
     acc_bl = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_left, b_sc_left, "e2m1", acc_bl)
     tlx.async_load_wait_group(4)
@@ -461,7 +550,10 @@ def _a4w4_8wave_kernel(
     acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
     tlx.async_load_wait_group(2)
     a_top = tlx.local_load(tlx.local_view(smem_a_top, g_idx), relaxed=True)
-    a_sc_top = tlx.local_load(smem_a_sc_t[g_idx], layout=scale_a_layout)
+    if PRESHUFFLED_A_SCALES:
+        a_sc_top = a_sc_top1
+    else:
+        a_sc_top = tlx.local_load(smem_a_sc_t[g_idx], layout=scale_a_layout)
     b_sc_comb = tlx.local_load(smem_b_sc[g_idx], layout=scale_b_comb_layout)
     b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
     b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
@@ -471,7 +563,10 @@ def _a4w4_8wave_kernel(
     acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
     tlx.async_load_wait_group(1)
     a_bot = tlx.local_load(tlx.local_view(smem_a_bot, g_idx), relaxed=True)
-    a_sc_bot = tlx.local_load(smem_a_sc_b[g_idx], layout=scale_a_layout)
+    if PRESHUFFLED_A_SCALES:
+        a_sc_bot = a_sc_bot1
+    else:
+        a_sc_bot = tlx.local_load(smem_a_sc_b[g_idx], layout=scale_a_layout)
 
     acc_bl = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_left, b_sc_left, "e2m1", acc_bl)
     tlx.async_load_wait_group(0)
@@ -571,6 +666,36 @@ def choose_split_k(M, N, K):
     return best
 
 
+def preshuffle_mxfp4_a_scales(scales):
+    """Pack canonical ``[rows, K/32]`` E8M0 scales for direct register loads.
+
+    This adapts AITER's lane-major scale-preshuffle to this kernel's 2x4 wave
+    ownership. Physical storage is tiled as ``[256 rows, 8 groups]`` and ordered
+    ``[128-row half, M wave, lane, register]``, so each lane fetches its eight
+    A-scale bytes contiguously. Padding uses the E8M0 identity value (0x7f).
+    """
+    assert scales.dtype is torch.uint8
+    assert scales.is_cuda
+    assert scales.ndim == 2
+    rows, groups = scales.shape
+    assert rows > 0 and groups > 0
+    padded_rows = triton.cdiv(rows, 256) * 256
+    padded_groups = triton.cdiv(groups, 8) * 8
+    padded = torch.full(
+        (padded_rows, padded_groups),
+        0x7F,
+        dtype=torch.uint8,
+        device=scales.device,
+    )
+    padded[:rows, :groups] = scales
+    return (
+        padded.reshape(padded_rows // 256, 2, 4, 2, 16, padded_groups // 8, 2, 4)
+        .permute(0, 5, 1, 3, 7, 4, 2, 6)
+        .contiguous()
+        .reshape(-1)
+    )
+
+
 def _matmul_256tile(a, b, a_scales, b_scales, SPLIT_K=None):
     """256x256-tile inter-wave path -- the fast path for well-filled / large N."""
     assert a.dtype is torch.uint8
@@ -633,6 +758,7 @@ def _matmul_256tile(a, b, a_scales, b_scales, SPLIT_K=None):
         NUM_XCDS=NUM_XCDS,
         GRID_MN=grid_mn,
         SPLIT_K=SPLIT_K,
+        PRESHUFFLED_A_SCALES=False,
         num_warps=NUM_WARPS,
         num_stages=1,
         matrix_instr_nonkdim=16,
@@ -645,6 +771,97 @@ def _matmul_256tile(a, b, a_scales, b_scales, SPLIT_K=None):
         rbm, rbn, rw = (128, 128, 8) if big else (32, 32, 4)
         reduce_grid = (triton.cdiv(M, rbm), triton.cdiv(N, rbn))
         _reduce_k_kernel[reduce_grid](
+            workspace,
+            c,
+            M,
+            N,
+            SPLIT_K=SPLIT_K,
+            BLOCK_SIZE_M=rbm,
+            BLOCK_SIZE_N=rbn,
+            OUTPUT_DTYPE=tl.bfloat16,
+            num_warps=rw,
+        )
+    return c
+
+
+def matmul_preshuffled(a, b, a_scales, b_scales, SPLIT_K=None):
+    """Experimental inter-wave kernel for a preshuffled A-scale buffer.
+
+    ``a_scales`` is a flat buffer returned by :func:`preshuffle_mxfp4_a_scales`
+    and loads directly into the scaled-MFMA register layout. ``b_scales`` keeps
+    the canonical ``[N, K/32]`` ABI and direct-to-LDS DMA, matching the operand
+    orientation used by AITER's 256x256 kernel.
+    """
+    assert a.dtype is torch.uint8
+    assert b.dtype is torch.uint8
+    assert a_scales.dtype is torch.uint8
+    assert b_scales.dtype is torch.uint8
+    assert a.is_cuda and b.is_cuda and a_scales.is_cuda and b_scales.is_cuda
+    assert a_scales.ndim == 1 and b_scales.ndim == 2
+
+    M = a.shape[0]
+    K_packed = a.shape[1]
+    K = K_packed * 2
+    N = b.shape[0]
+    groups = K // 32
+    padded_groups = triton.cdiv(groups, 8) * 8
+    assert b.shape == (N, K_packed), "B must have shape (N, K // 2)"
+    assert a_scales.numel() == triton.cdiv(M, 256) * 256 * padded_groups
+    assert b_scales.shape == (N, groups)
+    assert b_scales.stride(0) == 1, "B scales must be contiguous along N"
+    assert M % BLOCK_M == 0, "M must be a multiple of 256"
+    assert N % BLOCK_N == 0, "N must be a multiple of 256"
+    assert K >= MIN_K and K % (2 * BLOCK_K) == 0, \
+        f"K must be at least {MIN_K} and a multiple of {2 * BLOCK_K}"
+
+    if SPLIT_K is None:
+        SPLIT_K = choose_split_k(M, N, K)
+    KS = K // SPLIT_K
+    assert K % SPLIT_K == 0, f"K={K} must be divisible by SPLIT_K={SPLIT_K}"
+    assert KS >= MIN_K and KS % (2 * BLOCK_K) == 0, \
+        f"K/SPLIT_K={KS} must be >= {MIN_K} and a multiple of {2 * BLOCK_K}"
+
+    c = torch.empty((M, N), device=a.device, dtype=torch.bfloat16)
+    grid_mn = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
+    workspace = torch.empty((SPLIT_K * M, N), device=a.device, dtype=torch.float32) if SPLIT_K > 1 else c
+    _a4w4_8wave_kernel[(grid_mn * SPLIT_K, )](
+        a,
+        b,
+        c,
+        workspace,
+        a_scales,
+        b_scales,
+        M,
+        N,
+        K,
+        KS // BLOCK_K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        0,
+        0,
+        b_scales.stride(0),
+        b_scales.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        NUM_XCDS=NUM_XCDS,
+        GRID_MN=grid_mn,
+        SPLIT_K=SPLIT_K,
+        PRESHUFFLED_A_SCALES=True,
+        num_warps=NUM_WARPS,
+        num_stages=1,
+        matrix_instr_nonkdim=16,
+        llvm_fn_attrs=_A4W4_8WAVE_LLVM_FN_ATTRS,
+    )
+    if SPLIT_K > 1:
+        big = (M * N) >= (2048 * 2048)
+        rbm, rbn, rw = (128, 128, 8) if big else (32, 32, 4)
+        _reduce_k_kernel[(triton.cdiv(M, rbm), triton.cdiv(N, rbn))](
             workspace,
             c,
             M,

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
@@ -31,6 +31,11 @@ pipeline.  The full 256-row A scale tile is read once, then split into its two
 ``ds_read_b64_tr_b8`` operations into one ``ds_read_b128``.  It remains outside
 ``matmul`` because its flat, prepacked scale buffers are a distinct caller ABI.
 
+``matmul_merged_scales`` is a second experimental kernel and ABI. It accepts one
+flat allocation containing the packed A image followed by the packed B image,
+and uses one 16-byte DMA from every thread to gather the adjacent A+B images for
+two K tiles into LDS.
+
 The Shape:Stride register/blocked/accumulator layouts below encode the gfx950
 16x16x128 scaled-MFMA / dot-operand / scale distributions, and are
 round-trip-verified against the compiler's resolved linear layouts.
@@ -102,6 +107,7 @@ _A4W4_8WAVE_LLVM_FN_ATTRS = (
 MIN_K = 4 * BLOCK_K
 KERNEL_NAME = "a4w4_8wave"
 PRESHUFFLED_KERNEL_NAME = "a4w4_8wave_preshuffled_scales"
+MERGED_SCALES_KERNEL_NAME = "a4w4_8wave_merged_scales"
 INTRA_WAVE_MAX_K = 1536
 
 
@@ -135,6 +141,7 @@ def _a4w4_8wave_kernel(
     GRID_MN: tl.constexpr,
     SPLIT_K: tl.constexpr,
     PRESHUFFLED_SCALES: tl.constexpr = False,
+    MERGED_SCALE_DMA: tl.constexpr = False,
 ):
     SCALE_GROUP_SIZE: tl.constexpr = 32
     HALF_M: tl.constexpr = BLOCK_M // 2  # 128
@@ -196,6 +203,13 @@ def _a4w4_8wave_kernel(
         block_bases=[],
         alignment=16,
     )
+    shared_scale_merged: tl.constexpr = tlx.shared_linear_layout_encoding(
+        offset_bases=[
+            [1], [2], [4], [8], [16], [32], [64], [128], [256], [512], [1024], [2048], [4096],
+        ],
+        block_bases=[],
+        alignment=16,
+    )
     # Match each scale tile's physical shared offset order: two 4-byte value
     # bits, six lane bits, then warp bits. The XOR bases live entirely in the
     # warp mapping, so TLX resolves these to #ttg.generic_linear and gfx9 can
@@ -208,16 +222,24 @@ def _a4w4_8wave_kernel(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2)),
         stride=((32, 64, 128, 256, 512, 1024, 129, 2, 260), (8, 16)),
     )
-    # Four byte values per thread stage each 256x8 preshuffled tile.  The value
-    # bases are physical bits 0 and 1; the remaining physical bits are assigned
-    # across the 512 CTA threads.
+    # Four bytes per thread stage each independent 256x8 preshuffled tile.
     scale_load_preshuffled_layout: tl.constexpr = tlx.layout(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2)),
         stride=((4, 8, 16, 32, 64, 128, 256, 512, 1024), (1, 2)),
     )
+    # One 16-byte vector per thread stages two adjacent A+B scale images.  The
+    # high warp bit selects the second K tile, so all eight waves contribute to
+    # one full-workgroup 8192-byte DMA.
+    scale_load_merged_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2)),
+        stride=((16, 32, 64, 128, 256, 512, 1024, 2048, 4096), (1, 2, 4, 8)),
+    )
     preshuffled_scale_shape: tl.constexpr = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+    merged_scale_shape: tl.constexpr = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
     preshuffled_a_to_logical: tl.constexpr = (7, 8, 9, 4, 5, 6, 2, 3, 10, 0, 1)
     preshuffled_b_to_logical: tl.constexpr = (8, 9, 2, 4, 5, 6, 7, 3, 10, 0, 1)
+    merged_a_to_logical: tl.constexpr = (0, 1, 9, 10, 11, 6, 7, 8, 4, 5, 12, 2, 3)
+    merged_b_to_logical: tl.constexpr = (0, 1, 10, 11, 4, 6, 7, 8, 9, 5, 12, 2, 3)
     # ---- MFMA scale register layouts (get_mfma_scale_layout) ----
     scale_a_layout: tl.constexpr = tlx.layout(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2)),
@@ -277,13 +299,18 @@ def _a4w4_8wave_kernel(
         pid_n = (pid % num_pid_in_group) // group_size_m
 
     # Four double-buffered operand half-tiles plus scale tiles.  The canonical
-    # path keeps separate A halves; the experimental ABI stages one combined A
-    # tile so its consumer can issue a single 128-bit read.
+    # path keeps separate scale allocations; the merged ABI uses one 8192-byte
+    # allocation for the two K tiles consumed by an unrolled iteration. It is
+    # refilled after both scale halves have been read, so it needs no second
+    # scale buffer and keeps the total LDS footprint unchanged.
     smem_a_top = tlx.local_alloc((HALF_M, HALF_K), tlx.dtype_of(a_ptr), 2, layout=shared_tile)
     smem_a_bot = tlx.local_alloc((HALF_M, HALF_K), tlx.dtype_of(a_ptr), 2, layout=shared_tile)
     smem_b_left = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
     smem_b_right = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
-    if PRESHUFFLED_SCALES:
+    if MERGED_SCALE_DMA:
+        smem_sc = tlx.local_alloc(
+            (2 * (BLOCK_M + BLOCK_N) * NG, ), tlx.dtype_of(a_scales_ptr), 1, layout=shared_scale_merged)
+    elif PRESHUFFLED_SCALES:
         smem_a_sc = tlx.local_alloc(
             (BLOCK_M * NG, ), tlx.dtype_of(a_scales_ptr), 2, layout=shared_scale_preshuffled)
         smem_b_sc = tlx.local_alloc(
@@ -304,9 +331,25 @@ def _a4w4_8wave_kernel(
     b_tile_offsets = tlx.require_layout(offs_bn[:, None] * stride_bn + offs_bk[None, :] * stride_bk, g_load_layout)
     b_base = b_ptr + pid_n * BLOCK_N * stride_bn
 
-    # ---- A scale load offsets ----
+    # ---- Scale load offsets ----
     offs_ks_a = tl.arange(0, NG)
-    if PRESHUFFLED_SCALES:
+    if MERGED_SCALE_DMA:
+        scale_physical_offsets = tl.arange(0, 2 * (BLOCK_M + BLOCK_N) * NG)
+        scale_k_tile = scale_physical_offsets // ((BLOCK_M + BLOCK_N) * NG)
+        scale_in_tile = scale_physical_offsets % ((BLOCK_M + BLOCK_N) * NG)
+        a_scale_tile_base = pid_m * SCALE_GROUP_BLOCKS * BLOCK_M * NG
+        b_scale_tile_base = num_pid_m * SCALE_GROUP_BLOCKS * BLOCK_M * NG
+        b_scale_tile_base += pid_n * SCALE_GROUP_BLOCKS * BLOCK_N * NG
+        split_scale_base = split_id * (KS_SCALE // NG) * BLOCK_M * NG
+        a_scale_tile_base += split_scale_base
+        b_scale_tile_base += split_scale_base
+        scale_offsets = tl.where(
+            scale_in_tile < BLOCK_M * NG,
+            a_scale_tile_base + scale_k_tile * BLOCK_M * NG + scale_in_tile,
+            b_scale_tile_base + scale_k_tile * BLOCK_N * NG + scale_in_tile - BLOCK_M * NG,
+        )
+        scale_offsets = tlx.require_layout(scale_offsets, scale_load_merged_layout)
+    elif PRESHUFFLED_SCALES:
         a_sc_offsets = tlx.require_layout(tl.arange(0, BLOCK_M * NG), scale_load_preshuffled_layout)
     else:
         offs_asm = pid_m * BLOCK_M + tl.arange(0, HALF_M)
@@ -316,9 +359,9 @@ def _a4w4_8wave_kernel(
 
     # ---- B scale load offsets: FULL [256,8] in one copy ----
     offs_ks_b = tl.arange(0, NG)
-    if PRESHUFFLED_SCALES:
+    if PRESHUFFLED_SCALES and not MERGED_SCALE_DMA:
         b_sc_offsets = tlx.require_layout(tl.arange(0, BLOCK_N * NG), scale_load_preshuffled_layout)
-    else:
+    elif not PRESHUFFLED_SCALES:
         offs_bsn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
         b_sc_offsets = tl.mul(offs_bsn[:, None], stride_bsn, sanitize_overflow=False) + tl.mul(
             offs_ks_b[None, :], stride_bsk, sanitize_overflow=False)
@@ -330,8 +373,8 @@ def _a4w4_8wave_kernel(
     a_k2 = HALF_K * stride_ak  # even -> odd (_next) K-step
     b_k2 = HALF_K * stride_bk
     if PRESHUFFLED_SCALES:
-        a_sc_k: tl.constexpr = 2048
-        b_sc_k: tl.constexpr = 2048
+        a_sc_k: tl.constexpr = BLOCK_M * NG
+        b_sc_k: tl.constexpr = BLOCK_N * NG
     else:
         a_sc_half_m = HALF_M * stride_asm
         a_sc_k = NG * stride_ask
@@ -343,11 +386,13 @@ def _a4w4_8wave_kernel(
     # fat pointer as it already does for the pid_m/pid_n base offsets.
     a_base += split_id * KS_PACKED * stride_ak
     b_base += split_id * KS_PACKED * stride_bk
-    if PRESHUFFLED_SCALES:
-        a_scales_ptr += pid_m * SCALE_GROUP_BLOCKS * 2048
-        b_scales_ptr += pid_n * SCALE_GROUP_BLOCKS * 2048
-        a_scales_ptr += split_id * (KS_SCALE // NG) * 2048
-        b_scales_ptr += split_id * (KS_SCALE // NG) * 2048
+    if MERGED_SCALE_DMA:
+        pass
+    elif PRESHUFFLED_SCALES:
+        a_scales_ptr += pid_m * SCALE_GROUP_BLOCKS * a_sc_k
+        b_scales_ptr += pid_n * SCALE_GROUP_BLOCKS * b_sc_k
+        a_scales_ptr += split_id * (KS_SCALE // NG) * a_sc_k
+        b_scales_ptr += split_id * (KS_SCALE // NG) * b_sc_k
     else:
         a_scales_ptr += split_id * KS_SCALE * stride_ask
         b_scales_ptr += split_id * KS_SCALE * stride_bsk
@@ -365,12 +410,15 @@ def _a4w4_8wave_kernel(
 
     # ---- Prologue: prefetch K-steps 0,1 into buffers 0,1 (8 commits) ----
     tlx.buffer_load_to_local(smem_b_left[0], b_base, b_tile_offsets)
-    tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
+    if MERGED_SCALE_DMA:
+        tlx.buffer_load_to_local(smem_sc[0], a_scales_ptr, scale_offsets)
+    else:
+        tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_top[0], a_base, a_tile_offsets)
-    if PRESHUFFLED_SCALES:
+    if PRESHUFFLED_SCALES and not MERGED_SCALE_DMA:
         tlx.buffer_load_to_local(smem_a_sc[0], a_scales_ptr, a_sc_offsets)
-    else:
+    elif not PRESHUFFLED_SCALES:
         tlx.buffer_load_to_local(smem_a_sc_t[0], a_scales_ptr, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_bot[0], a_base + a_half_m, a_tile_offsets)
@@ -381,12 +429,13 @@ def _a4w4_8wave_kernel(
     tlx.async_load_commit_group()
 
     tlx.buffer_load_to_local(smem_b_left[1], b_base + b_k2, b_tile_offsets)
-    tlx.buffer_load_to_local(smem_b_sc[1], b_scales_ptr + b_sc_k, b_sc_offsets)
+    if not MERGED_SCALE_DMA:
+        tlx.buffer_load_to_local(smem_b_sc[1], b_scales_ptr + b_sc_k, b_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_top[1], a_base + a_k2, a_tile_offsets)
-    if PRESHUFFLED_SCALES:
+    if PRESHUFFLED_SCALES and not MERGED_SCALE_DMA:
         tlx.buffer_load_to_local(smem_a_sc[1], a_scales_ptr + a_sc_k, a_sc_offsets)
-    else:
+    elif not PRESHUFFLED_SCALES:
         tlx.buffer_load_to_local(smem_a_sc_t[1], a_scales_ptr + a_sc_k, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_bot[1], a_base + a_half_m + a_k2, a_tile_offsets)
@@ -398,27 +447,46 @@ def _a4w4_8wave_kernel(
 
     a_base += a_k2 * 2
     b_base += b_k2 * 2
-    a_scales_ptr += a_sc_k * 2
-    b_scales_ptr += b_sc_k * 2
+    if MERGED_SCALE_DMA:
+        scale_iter_offset = a_sc_k * 2
+    else:
+        a_scales_ptr += a_sc_k * 2
+        b_scales_ptr += b_sc_k * 2
 
     tlx.async_load_wait_group(6)
     b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
     a_top = tlx.local_load(smem_a_top[0], relaxed=True)
     if PRESHUFFLED_SCALES:
-        a_sc_view_init = tlx.local_reshape(smem_a_sc[0], preshuffled_scale_shape)
-        a_sc_view_init = tlx.local_trans(a_sc_view_init, preshuffled_a_to_logical)
-        a_sc_view_init = tlx.local_reshape(a_sc_view_init, [BLOCK_M, NG])
-        a_sc_comb = tlx.local_load(a_sc_view_init, layout=scale_a_comb_layout, relaxed=True)
+        if MERGED_SCALE_DMA:
+            sc_phys_init = tlx.local_reshape(smem_sc[0], [2] + merged_scale_shape)
+            a_sc_view_init = tlx.local_trans(sc_phys_init, merged_a_to_logical)
+            a_sc_view_init = tlx.local_reshape(a_sc_view_init, [2, 2, BLOCK_M, NG])
+            a_sc_view_init = tlx.local_slice(a_sc_view_init, [0, 0, 0, 0], [1, 1, BLOCK_M, NG])
+            a_sc_comb = tl.reshape(
+                tlx.local_load(a_sc_view_init, layout=scale_a_comb_layout, relaxed=True), BLOCK_M, NG)
+            b_sc_view_init = tlx.local_trans(sc_phys_init, merged_b_to_logical)
+            b_sc_view_init = tlx.local_reshape(b_sc_view_init, [2, 2, BLOCK_N, NG])
+            b_sc_view_init = tlx.local_slice(b_sc_view_init, [0, 1, 0, 0], [1, 1, BLOCK_N, NG])
+            b_sc_comb = tl.reshape(
+                tlx.local_load(b_sc_view_init, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
+        else:
+            a_sc_phys_init = smem_a_sc[0]
+            a_sc_view_init = tlx.local_reshape(a_sc_phys_init, preshuffled_scale_shape)
+            a_sc_view_init = tlx.local_trans(a_sc_view_init, preshuffled_a_to_logical)
+            a_sc_view_init = tlx.local_reshape(a_sc_view_init, [BLOCK_M, NG])
+            a_sc_comb = tlx.local_load(a_sc_view_init, layout=scale_a_comb_layout, relaxed=True)
         a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
         a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
         a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
     else:
         a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
     if PRESHUFFLED_SCALES:
-        b_sc_view_init = tlx.local_reshape(smem_b_sc[0], preshuffled_scale_shape)
-        b_sc_view_init = tlx.local_trans(b_sc_view_init, preshuffled_b_to_logical)
-        b_sc_view_init = tlx.local_reshape(b_sc_view_init, [BLOCK_N, NG])
-        b_sc_comb = tlx.local_load(b_sc_view_init, layout=scale_b_comb_layout, relaxed=True)
+        if not MERGED_SCALE_DMA:
+            b_sc_phys_init = smem_b_sc[0]
+            b_sc_view_init = tlx.local_reshape(b_sc_phys_init, preshuffled_scale_shape)
+            b_sc_view_init = tlx.local_trans(b_sc_view_init, preshuffled_b_to_logical)
+            b_sc_view_init = tlx.local_reshape(b_sc_view_init, [BLOCK_N, NG])
+            b_sc_comb = tlx.local_load(b_sc_view_init, layout=scale_b_comb_layout, relaxed=True)
     else:
         b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
     b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
@@ -439,7 +507,8 @@ def _a4w4_8wave_kernel(
                 a_sc_bot = tlx.local_load(smem_a_sc_b[0], layout=scale_a_layout)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_b_left[0], b_base, b_tile_offsets)
-            tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
+            if not MERGED_SCALE_DMA:
+                tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
             tlx.async_load_commit_group()
 
         tlx.async_load_wait_group(5)
@@ -449,9 +518,9 @@ def _a4w4_8wave_kernel(
             b_right = tlx.local_load(tlx.local_trans(smem_b_right[0]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_top[0], a_base, a_tile_offsets)
-            if PRESHUFFLED_SCALES:
+            if PRESHUFFLED_SCALES and not MERGED_SCALE_DMA:
                 tlx.buffer_load_to_local(smem_a_sc[0], a_scales_ptr, a_sc_offsets)
-            else:
+            elif not PRESHUFFLED_SCALES:
                 tlx.buffer_load_to_local(smem_a_sc_t[0], a_scales_ptr, a_sc_offsets)
             tlx.async_load_commit_group()
 
@@ -472,20 +541,36 @@ def _a4w4_8wave_kernel(
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_top = tlx.local_load(smem_a_top[1], relaxed=True)
             if PRESHUFFLED_SCALES:
-                a_sc_view_1 = tlx.local_reshape(smem_a_sc[1], preshuffled_scale_shape)
-                a_sc_view_1 = tlx.local_trans(a_sc_view_1, preshuffled_a_to_logical)
-                a_sc_view_1 = tlx.local_reshape(a_sc_view_1, [BLOCK_M, NG])
-                a_sc_comb = tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True)
+                if MERGED_SCALE_DMA:
+                    sc_phys_1 = tlx.local_reshape(smem_sc[0], [2] + merged_scale_shape)
+                    a_sc_view_1 = tlx.local_trans(sc_phys_1, merged_a_to_logical)
+                    a_sc_view_1 = tlx.local_reshape(a_sc_view_1, [2, 2, BLOCK_M, NG])
+                    a_sc_view_1 = tlx.local_slice(a_sc_view_1, [1, 0, 0, 0], [1, 1, BLOCK_M, NG])
+                    a_sc_comb = tl.reshape(
+                        tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True), BLOCK_M, NG)
+                    b_sc_view_1 = tlx.local_trans(sc_phys_1, merged_b_to_logical)
+                    b_sc_view_1 = tlx.local_reshape(b_sc_view_1, [2, 2, BLOCK_N, NG])
+                    b_sc_view_1 = tlx.local_slice(b_sc_view_1, [1, 1, 0, 0], [1, 1, BLOCK_N, NG])
+                    b_sc_comb = tl.reshape(
+                        tlx.local_load(b_sc_view_1, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
+                else:
+                    a_sc_phys_1 = smem_a_sc[1]
+                    a_sc_view_1 = tlx.local_reshape(a_sc_phys_1, preshuffled_scale_shape)
+                    a_sc_view_1 = tlx.local_trans(a_sc_view_1, preshuffled_a_to_logical)
+                    a_sc_view_1 = tlx.local_reshape(a_sc_view_1, [BLOCK_M, NG])
+                    a_sc_comb = tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True)
                 a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
                 a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
                 a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
             else:
                 a_sc_top = tlx.local_load(smem_a_sc_t[1], layout=scale_a_layout)
             if PRESHUFFLED_SCALES:
-                b_sc_view_1 = tlx.local_reshape(smem_b_sc[1], preshuffled_scale_shape)
-                b_sc_view_1 = tlx.local_trans(b_sc_view_1, preshuffled_b_to_logical)
-                b_sc_view_1 = tlx.local_reshape(b_sc_view_1, [BLOCK_N, NG])
-                b_sc_comb = tlx.local_load(b_sc_view_1, layout=scale_b_comb_layout, relaxed=True)
+                if not MERGED_SCALE_DMA:
+                    b_sc_phys_1 = smem_b_sc[1]
+                    b_sc_view_1 = tlx.local_reshape(b_sc_phys_1, preshuffled_scale_shape)
+                    b_sc_view_1 = tlx.local_trans(b_sc_view_1, preshuffled_b_to_logical)
+                    b_sc_view_1 = tlx.local_reshape(b_sc_view_1, [BLOCK_N, NG])
+                    b_sc_comb = tlx.local_load(b_sc_view_1, layout=scale_b_comb_layout, relaxed=True)
             else:
                 b_sc_comb = tlx.local_load(smem_b_sc[1], layout=scale_b_comb_layout)
             b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
@@ -493,6 +578,8 @@ def _a4w4_8wave_kernel(
             b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_b_right[0], b_base + b_half_n, b_tile_offsets)
+            if MERGED_SCALE_DMA:
+                tlx.buffer_load_to_local(smem_sc[0], a_scales_ptr, scale_offsets + scale_iter_offset)
             tlx.async_load_commit_group()
 
         # --- sub-iter 1 (buffer 1, base + one K-step) ---
@@ -507,7 +594,8 @@ def _a4w4_8wave_kernel(
                 a_sc_bot = tlx.local_load(smem_a_sc_b[1], layout=scale_a_layout)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_b_left[1], b_base + b_k2, b_tile_offsets)
-            tlx.buffer_load_to_local(smem_b_sc[1], b_scales_ptr + b_sc_k, b_sc_offsets)
+            if not MERGED_SCALE_DMA:
+                tlx.buffer_load_to_local(smem_b_sc[1], b_scales_ptr + b_sc_k, b_sc_offsets)
             tlx.async_load_commit_group()
 
         tlx.async_load_wait_group(5)
@@ -517,9 +605,9 @@ def _a4w4_8wave_kernel(
             b_right = tlx.local_load(tlx.local_trans(smem_b_right[1]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_top[1], a_base + a_k2, a_tile_offsets)
-            if PRESHUFFLED_SCALES:
+            if PRESHUFFLED_SCALES and not MERGED_SCALE_DMA:
                 tlx.buffer_load_to_local(smem_a_sc[1], a_scales_ptr + a_sc_k, a_sc_offsets)
-            else:
+            elif not PRESHUFFLED_SCALES:
                 tlx.buffer_load_to_local(smem_a_sc_t[1], a_scales_ptr + a_sc_k, a_sc_offsets)
             tlx.async_load_commit_group()
 
@@ -540,20 +628,36 @@ def _a4w4_8wave_kernel(
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_top = tlx.local_load(smem_a_top[0], relaxed=True)
             if PRESHUFFLED_SCALES:
-                a_sc_view_0 = tlx.local_reshape(smem_a_sc[0], preshuffled_scale_shape)
-                a_sc_view_0 = tlx.local_trans(a_sc_view_0, preshuffled_a_to_logical)
-                a_sc_view_0 = tlx.local_reshape(a_sc_view_0, [BLOCK_M, NG])
-                a_sc_comb = tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True)
+                if MERGED_SCALE_DMA:
+                    sc_phys_0 = tlx.local_reshape(smem_sc[0], [2] + merged_scale_shape)
+                    a_sc_view_0 = tlx.local_trans(sc_phys_0, merged_a_to_logical)
+                    a_sc_view_0 = tlx.local_reshape(a_sc_view_0, [2, 2, BLOCK_M, NG])
+                    a_sc_view_0 = tlx.local_slice(a_sc_view_0, [0, 0, 0, 0], [1, 1, BLOCK_M, NG])
+                    a_sc_comb = tl.reshape(
+                        tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True), BLOCK_M, NG)
+                    b_sc_view_0 = tlx.local_trans(sc_phys_0, merged_b_to_logical)
+                    b_sc_view_0 = tlx.local_reshape(b_sc_view_0, [2, 2, BLOCK_N, NG])
+                    b_sc_view_0 = tlx.local_slice(b_sc_view_0, [0, 1, 0, 0], [1, 1, BLOCK_N, NG])
+                    b_sc_comb = tl.reshape(
+                        tlx.local_load(b_sc_view_0, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
+                else:
+                    a_sc_phys_0 = smem_a_sc[0]
+                    a_sc_view_0 = tlx.local_reshape(a_sc_phys_0, preshuffled_scale_shape)
+                    a_sc_view_0 = tlx.local_trans(a_sc_view_0, preshuffled_a_to_logical)
+                    a_sc_view_0 = tlx.local_reshape(a_sc_view_0, [BLOCK_M, NG])
+                    a_sc_comb = tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True)
                 a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
                 a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
                 a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
             else:
                 a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
             if PRESHUFFLED_SCALES:
-                b_sc_view_0 = tlx.local_reshape(smem_b_sc[0], preshuffled_scale_shape)
-                b_sc_view_0 = tlx.local_trans(b_sc_view_0, preshuffled_b_to_logical)
-                b_sc_view_0 = tlx.local_reshape(b_sc_view_0, [BLOCK_N, NG])
-                b_sc_comb = tlx.local_load(b_sc_view_0, layout=scale_b_comb_layout, relaxed=True)
+                if not MERGED_SCALE_DMA:
+                    b_sc_phys_0 = smem_b_sc[0]
+                    b_sc_view_0 = tlx.local_reshape(b_sc_phys_0, preshuffled_scale_shape)
+                    b_sc_view_0 = tlx.local_trans(b_sc_view_0, preshuffled_b_to_logical)
+                    b_sc_view_0 = tlx.local_reshape(b_sc_view_0, [BLOCK_N, NG])
+                    b_sc_comb = tlx.local_load(b_sc_view_0, layout=scale_b_comb_layout, relaxed=True)
             else:
                 b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
             b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
@@ -564,8 +668,11 @@ def _a4w4_8wave_kernel(
             tlx.async_load_commit_group()
             a_base += a_k2 * 2
             b_base += b_k2 * 2
-            a_scales_ptr += a_sc_k * 2
-            b_scales_ptr += b_sc_k * 2
+            if MERGED_SCALE_DMA:
+                scale_iter_offset += a_sc_k * 2
+            else:
+                a_scales_ptr += a_sc_k * 2
+                b_scales_ptr += b_sc_k * 2
 
     # ---- Epilogue: last 2 K-steps, drain, 4-quadrant store ----
     # iter iter_max-2 (b_sc_left/right for this step were prefetched at loop tail)
@@ -591,20 +698,38 @@ def _a4w4_8wave_kernel(
     tlx.async_load_wait_group(2)
     a_top = tlx.local_load(tlx.local_view(smem_a_top, g_idx), relaxed=True)
     if PRESHUFFLED_SCALES:
-        a_sc_view_epilogue = tlx.local_reshape(smem_a_sc[g_idx], preshuffled_scale_shape)
-        a_sc_view_epilogue = tlx.local_trans(a_sc_view_epilogue, preshuffled_a_to_logical)
-        a_sc_view_epilogue = tlx.local_reshape(a_sc_view_epilogue, [BLOCK_M, NG])
-        a_sc_comb = tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True)
+        if MERGED_SCALE_DMA:
+            sc_phys_epilogue = tlx.local_reshape(smem_sc[0], [2] + merged_scale_shape)
+            a_sc_view_epilogue = tlx.local_trans(sc_phys_epilogue, merged_a_to_logical)
+            a_sc_view_epilogue = tlx.local_reshape(a_sc_view_epilogue, [2, 2, BLOCK_M, NG])
+            a_sc_view_epilogue = tlx.local_slice(
+                a_sc_view_epilogue, [1, 0, 0, 0], [1, 1, BLOCK_M, NG])
+            a_sc_comb = tl.reshape(
+                tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True), BLOCK_M, NG)
+            b_sc_view_epilogue = tlx.local_trans(sc_phys_epilogue, merged_b_to_logical)
+            b_sc_view_epilogue = tlx.local_reshape(b_sc_view_epilogue, [2, 2, BLOCK_N, NG])
+            b_sc_view_epilogue = tlx.local_slice(
+                b_sc_view_epilogue, [1, 1, 0, 0], [1, 1, BLOCK_N, NG])
+            b_sc_comb = tl.reshape(
+                tlx.local_load(b_sc_view_epilogue, layout=scale_b_comb_layout, relaxed=True), BLOCK_N, NG)
+        else:
+            a_sc_phys_epilogue = smem_a_sc[g_idx]
+            a_sc_view_epilogue = tlx.local_reshape(a_sc_phys_epilogue, preshuffled_scale_shape)
+            a_sc_view_epilogue = tlx.local_trans(a_sc_view_epilogue, preshuffled_a_to_logical)
+            a_sc_view_epilogue = tlx.local_reshape(a_sc_view_epilogue, [BLOCK_M, NG])
+            a_sc_comb = tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True)
         a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
         a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
         a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
     else:
         a_sc_top = tlx.local_load(smem_a_sc_t[g_idx], layout=scale_a_layout)
     if PRESHUFFLED_SCALES:
-        b_sc_view_epilogue = tlx.local_reshape(smem_b_sc[g_idx], preshuffled_scale_shape)
-        b_sc_view_epilogue = tlx.local_trans(b_sc_view_epilogue, preshuffled_b_to_logical)
-        b_sc_view_epilogue = tlx.local_reshape(b_sc_view_epilogue, [BLOCK_N, NG])
-        b_sc_comb = tlx.local_load(b_sc_view_epilogue, layout=scale_b_comb_layout, relaxed=True)
+        if not MERGED_SCALE_DMA:
+            b_sc_phys_epilogue = smem_b_sc[g_idx]
+            b_sc_view_epilogue = tlx.local_reshape(b_sc_phys_epilogue, preshuffled_scale_shape)
+            b_sc_view_epilogue = tlx.local_trans(b_sc_view_epilogue, preshuffled_b_to_logical)
+            b_sc_view_epilogue = tlx.local_reshape(b_sc_view_epilogue, [BLOCK_N, NG])
+            b_sc_comb = tlx.local_load(b_sc_view_epilogue, layout=scale_b_comb_layout, relaxed=True)
     else:
         b_sc_comb = tlx.local_load(smem_b_sc[g_idx], layout=scale_b_comb_layout)
     b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
@@ -675,6 +800,65 @@ def _a4w4_8wave_kernel(
         tl.store(workspace_ptr + offs_cm_b[:, None] * stride_cm + offs_cn_l[None, :] * stride_cn, acc_bl)
         tl.store(workspace_ptr + offs_cm_t[:, None] * stride_cm + offs_cn_r[None, :] * stride_cn, acc_tr)
         tl.store(workspace_ptr + offs_cm_b[:, None] * stride_cm + offs_cn_r[None, :] * stride_cn, acc_br)
+
+
+@triton.jit
+def _a4w4_8wave_merged_scales_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    workspace_ptr,
+    scales_ptr,
+    M,
+    N,
+    K: tl.constexpr,
+    K_TILES,
+    stride_am,
+    stride_ak,
+    stride_bn,
+    stride_bk,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    GRID_MN: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+):
+    """Distinct one-scale-pointer ABI for the merged 16-byte DMA experiment."""
+    _a4w4_8wave_kernel(
+        a_ptr,
+        b_ptr,
+        c_ptr,
+        workspace_ptr,
+        scales_ptr,
+        scales_ptr,
+        M,
+        N,
+        K,
+        K_TILES,
+        stride_am,
+        stride_ak,
+        stride_bn,
+        stride_bk,
+        stride_cm,
+        stride_cn,
+        0,
+        0,
+        0,
+        0,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        NUM_XCDS=NUM_XCDS,
+        GRID_MN=GRID_MN,
+        SPLIT_K=SPLIT_K,
+        PRESHUFFLED_SCALES=True,
+        MERGED_SCALE_DMA=True,
+    )
 
 
 @triton.jit
@@ -767,6 +951,19 @@ def preshuffle_mxfp4_b_scales(scales):
     )
 
 
+def preshuffle_mxfp4_scales(a_scales, b_scales):
+    """Pack A and B scales into the merged kernel's single flat allocation.
+
+    Each half retains its native LDS-consumer order. The kernel creates two
+    logical subviews of the adjacent physical image, so no scale redistribution
+    is needed after the DMA.
+    """
+    assert a_scales.device == b_scales.device, "A and B scales must be on the same device"
+    assert a_scales.ndim == 2 and b_scales.ndim == 2
+    assert a_scales.shape[1] == b_scales.shape[1], "A and B scales must have the same K groups"
+    return torch.cat((preshuffle_mxfp4_a_scales(a_scales), preshuffle_mxfp4_b_scales(b_scales)))
+
+
 def _matmul_256tile(a, b, a_scales, b_scales, SPLIT_K=None):
     """256x256-tile inter-wave path -- the fast path for well-filled / large N."""
     assert a.dtype is torch.uint8
@@ -830,6 +1027,7 @@ def _matmul_256tile(a, b, a_scales, b_scales, SPLIT_K=None):
         GRID_MN=grid_mn,
         SPLIT_K=SPLIT_K,
         PRESHUFFLED_SCALES=False,
+        MERGED_SCALE_DMA=False,
         num_warps=NUM_WARPS,
         num_stages=1,
         matrix_instr_nonkdim=16,
@@ -922,6 +1120,90 @@ def matmul_preshuffled(a, b, a_scales, b_scales, SPLIT_K=None):
         GRID_MN=grid_mn,
         SPLIT_K=SPLIT_K,
         PRESHUFFLED_SCALES=True,
+        MERGED_SCALE_DMA=False,
+        num_warps=NUM_WARPS,
+        num_stages=1,
+        matrix_instr_nonkdim=16,
+        llvm_fn_attrs=_A4W4_8WAVE_LLVM_FN_ATTRS,
+    )
+    if SPLIT_K > 1:
+        big = (M * N) >= (2048 * 2048)
+        rbm, rbn, rw = (128, 128, 8) if big else (32, 32, 4)
+        _reduce_k_kernel[(triton.cdiv(M, rbm), triton.cdiv(N, rbn))](
+            workspace,
+            c,
+            M,
+            N,
+            SPLIT_K=SPLIT_K,
+            BLOCK_SIZE_M=rbm,
+            BLOCK_SIZE_N=rbn,
+            OUTPUT_DTYPE=tl.bfloat16,
+            num_warps=rw,
+        )
+    return c
+
+
+def matmul_merged_scales(a, b, scales, SPLIT_K=None):
+    """Experimental one-pointer ABI using one full-workgroup 16-byte scale DMA.
+
+    ``scales`` is the flat allocation returned by
+    :func:`preshuffle_mxfp4_scales`: all packed A scales followed immediately
+    by all packed B scales.
+    """
+    assert a.dtype is torch.uint8
+    assert b.dtype is torch.uint8
+    assert scales.dtype is torch.uint8
+    assert a.is_cuda and b.is_cuda and scales.is_cuda
+    assert scales.ndim == 1
+
+    M = a.shape[0]
+    K_packed = a.shape[1]
+    K = K_packed * 2
+    N = b.shape[0]
+    groups = K // 32
+    padded_groups = triton.cdiv(groups, 8) * 8
+    a_scales_size = triton.cdiv(M, 256) * 256 * padded_groups
+    b_scales_size = triton.cdiv(N, 256) * 256 * padded_groups
+    assert b.shape == (N, K_packed), "B must have shape (N, K // 2)"
+    assert scales.numel() == a_scales_size + b_scales_size
+    assert M % BLOCK_M == 0, "M must be a multiple of 256"
+    assert N % BLOCK_N == 0, "N must be a multiple of 256"
+    assert K >= MIN_K and K % (2 * BLOCK_K) == 0, \
+        f"K must be at least {MIN_K} and a multiple of {2 * BLOCK_K}"
+
+    if SPLIT_K is None:
+        SPLIT_K = choose_split_k(M, N, K)
+    KS = K // SPLIT_K
+    assert K % SPLIT_K == 0, f"K={K} must be divisible by SPLIT_K={SPLIT_K}"
+    assert KS >= MIN_K and KS % (2 * BLOCK_K) == 0, \
+        f"K/SPLIT_K={KS} must be >= {MIN_K} and a multiple of {2 * BLOCK_K}"
+
+    c = torch.empty((M, N), device=a.device, dtype=torch.bfloat16)
+    grid_mn = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
+    workspace = torch.empty((SPLIT_K * M, N), device=a.device, dtype=torch.float32) if SPLIT_K > 1 else c
+    _a4w4_8wave_merged_scales_kernel[(grid_mn * SPLIT_K, )](
+        a,
+        b,
+        c,
+        workspace,
+        scales,
+        M,
+        N,
+        K,
+        KS // BLOCK_K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        NUM_XCDS=NUM_XCDS,
+        GRID_MN=grid_mn,
+        SPLIT_K=SPLIT_K,
         num_warps=NUM_WARPS,
         num_stages=1,
         matrix_instr_nonkdim=16,

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
@@ -24,11 +24,12 @@ The production entry point uses the same ABI as the 4-wave a4w4 kernel:
   * scales: e8m0 uint8, shapes (M, K // 32) and (N, K // 32), contiguous along M/N
   * C: bfloat16, shape (M, N)
 
-``matmul_preshuffled`` is a separate experimental ABI: A scales are packed by
-``preshuffle_mxfp4_a_scales`` and loaded directly into MFMA scale registers,
-while B scales retain the canonical DMA-to-LDS path. It is intentionally not
-selected by ``matmul`` because controlled measurements show that its longer
-scale live ranges outweigh the removed LDS traffic.
+``matmul_preshuffled`` is a separate experimental ABI: both scale operands are
+packed into their LDS-consumer order and retain the production DMA-to-LDS
+pipeline.  The full 256-row A scale tile is read once, then split into its two
+128-row MFMA fragments; this is intended to coalesce the two canonical
+``ds_read_b64_tr_b8`` operations into one ``ds_read_b128``.  It remains outside
+``matmul`` because its flat, prepacked scale buffers are a distinct caller ABI.
 
 The Shape:Stride register/blocked/accumulator layouts below encode the gfx950
 16x16x128 scaled-MFMA / dot-operand / scale distributions, and are
@@ -133,7 +134,7 @@ def _a4w4_8wave_kernel(
     NUM_XCDS: tl.constexpr,
     GRID_MN: tl.constexpr,
     SPLIT_K: tl.constexpr,
-    PRESHUFFLED_A_SCALES: tl.constexpr = False,
+    PRESHUFFLED_SCALES: tl.constexpr = False,
 ):
     SCALE_GROUP_SIZE: tl.constexpr = 32
     HALF_M: tl.constexpr = BLOCK_M // 2  # 128
@@ -184,6 +185,17 @@ def _a4w4_8wave_kernel(
         block_bases=[],
         alignment=16,
     )
+    # Experimental scale ABI.  Its physical low bits are exactly the value
+    # bases consumed by each wave.  In particular the combined A tile puts
+    # (group bit 2, row bits 5, 6, 7) in adjacent bytes, so one ordinary
+    # 128-bit LDS transaction produces both 128-row A scale fragments.
+    shared_scale_preshuffled: tl.constexpr = tlx.shared_linear_layout_encoding(
+        offset_bases=[
+            [1], [2], [4], [8], [16], [32], [64], [128], [256], [512], [1024],
+        ],
+        block_bases=[],
+        alignment=16,
+    )
     # Match each scale tile's physical shared offset order: two 4-byte value
     # bits, six lane bits, then warp bits. The XOR bases live entirely in the
     # warp mapping, so TLX resolves these to #ttg.generic_linear and gfx9 can
@@ -196,10 +208,24 @@ def _a4w4_8wave_kernel(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2)),
         stride=((32, 64, 128, 256, 512, 1024, 129, 2, 260), (8, 16)),
     )
+    # Four byte values per thread stage each 256x8 preshuffled tile.  The value
+    # bases are physical bits 0 and 1; the remaining physical bits are assigned
+    # across the 512 CTA threads.
+    scale_load_preshuffled_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2)),
+        stride=((4, 8, 16, 32, 64, 128, 256, 512, 1024), (1, 2)),
+    )
+    preshuffled_scale_shape: tl.constexpr = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+    preshuffled_a_to_logical: tl.constexpr = (7, 8, 9, 4, 5, 6, 2, 3, 10, 0, 1)
+    preshuffled_b_to_logical: tl.constexpr = (8, 9, 2, 4, 5, 6, 7, 3, 10, 0, 1)
     # ---- MFMA scale register layouts (get_mfma_scale_layout) ----
     scale_a_layout: tl.constexpr = tlx.layout(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2)),
         stride=((8, 16, 32, 64, 1, 2, 0, 0, 128), (4, 256, 512)),
+    )
+    scale_a_comb_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2)),
+        stride=((8, 16, 32, 64, 1, 2, 0, 0, 128), (4, 256, 512, 1024)),
     )
     scale_b_layout: tl.constexpr = tlx.layout(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2)),
@@ -250,15 +276,22 @@ def _a4w4_8wave_kernel(
         pid_m = first_pid_m + (pid % num_pid_in_group) % group_size_m
         pid_n = (pid % num_pid_in_group) // group_size_m
 
-    # Four double-buffered operand half-tiles + A-scale halves + combined B scale.
+    # Four double-buffered operand half-tiles plus scale tiles.  The canonical
+    # path keeps separate A halves; the experimental ABI stages one combined A
+    # tile so its consumer can issue a single 128-bit read.
     smem_a_top = tlx.local_alloc((HALF_M, HALF_K), tlx.dtype_of(a_ptr), 2, layout=shared_tile)
     smem_a_bot = tlx.local_alloc((HALF_M, HALF_K), tlx.dtype_of(a_ptr), 2, layout=shared_tile)
     smem_b_left = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
     smem_b_right = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
-    if not PRESHUFFLED_A_SCALES:
+    if PRESHUFFLED_SCALES:
+        smem_a_sc = tlx.local_alloc(
+            (BLOCK_M * NG, ), tlx.dtype_of(a_scales_ptr), 2, layout=shared_scale_preshuffled)
+        smem_b_sc = tlx.local_alloc(
+            (BLOCK_N * NG, ), tlx.dtype_of(b_scales_ptr), 2, layout=shared_scale_preshuffled)
+    else:
         smem_a_sc_t = tlx.local_alloc((HALF_M, NG), tlx.dtype_of(a_scales_ptr), 2, layout=shared_a_scales)
         smem_a_sc_b = tlx.local_alloc((HALF_M, NG), tlx.dtype_of(a_scales_ptr), 2, layout=shared_a_scales)
-    smem_b_sc = tlx.local_alloc((BLOCK_N, NG), tlx.dtype_of(b_scales_ptr), 2, layout=shared_b_scales)
+        smem_b_sc = tlx.local_alloc((BLOCK_N, NG), tlx.dtype_of(b_scales_ptr), 2, layout=shared_b_scales)
 
     # ---- fp4 tile load offsets ([128,128]) ----
     offs_am = tl.arange(0, HALF_M)
@@ -271,45 +304,34 @@ def _a4w4_8wave_kernel(
     b_tile_offsets = tlx.require_layout(offs_bn[:, None] * stride_bn + offs_bk[None, :] * stride_bk, g_load_layout)
     b_base = b_ptr + pid_n * BLOCK_N * stride_bn
 
-    # ---- A scale load offsets ([128,8]) ----
+    # ---- A scale load offsets ----
     offs_ks_a = tl.arange(0, NG)
-    offs_asm = pid_m * BLOCK_M + tl.arange(0, HALF_M)
-    if PRESHUFFLED_A_SCALES:
-        # Match the first scale operand in AITER's kernel: row/group low bits
-        # select the lane, row bit 4 selects the M wave, and (group bit 2,
-        # row bits 5..6) select eight consecutive register bytes. Row bit 7
-        # selects the top/bottom 128-row half.
-        a_sc_offsets = (
-            (offs_asm[:, None] // 256 * SCALE_GROUP_BLOCKS) * 2048
-            + (offs_asm[:, None] % 256) // 128 * 1024
-            + (((offs_asm[:, None] % 32) // 16) * 64
-               + (offs_ks_a[None, :] % 4) * 16
-               + offs_asm[:, None] % 16) * 8
-            + (offs_asm[:, None] % 128) // 32 * 2
-            + offs_ks_a[None, :] // 4
-        )
-        a_sc_offsets = tlx.require_layout(a_sc_offsets, scale_a_layout)
+    if PRESHUFFLED_SCALES:
+        a_sc_offsets = tlx.require_layout(tl.arange(0, BLOCK_M * NG), scale_load_preshuffled_layout)
     else:
+        offs_asm = pid_m * BLOCK_M + tl.arange(0, HALF_M)
         a_sc_offsets = tl.mul(offs_asm[:, None], stride_asm, sanitize_overflow=False) + tl.mul(
             offs_ks_a[None, :], stride_ask, sanitize_overflow=False)
         a_sc_offsets = tlx.require_layout(a_sc_offsets, scale_load_a_layout)
 
     # ---- B scale load offsets: FULL [256,8] in one copy ----
     offs_ks_b = tl.arange(0, NG)
-    offs_bsn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    b_sc_offsets = tl.mul(offs_bsn[:, None], stride_bsn, sanitize_overflow=False) + tl.mul(
-        offs_ks_b[None, :], stride_bsk, sanitize_overflow=False)
-    b_sc_offsets = tlx.require_layout(b_sc_offsets, scale_load_b_layout)
+    if PRESHUFFLED_SCALES:
+        b_sc_offsets = tlx.require_layout(tl.arange(0, BLOCK_N * NG), scale_load_preshuffled_layout)
+    else:
+        offs_bsn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        b_sc_offsets = tl.mul(offs_bsn[:, None], stride_bsn, sanitize_overflow=False) + tl.mul(
+            offs_ks_b[None, :], stride_bsk, sanitize_overflow=False)
+        b_sc_offsets = tlx.require_layout(b_sc_offsets, scale_load_b_layout)
 
     # Scalar (uniform) base-pointer deltas for the quadrant / K-buffer variants.
     a_half_m = HALF_M * stride_am  # a_top -> a_bot
     b_half_n = HALF_N * stride_bn  # b_left -> b_right
     a_k2 = HALF_K * stride_ak  # even -> odd (_next) K-step
     b_k2 = HALF_K * stride_bk
-    if PRESHUFFLED_A_SCALES:
-        a_sc_half_m: tl.constexpr = 1024
+    if PRESHUFFLED_SCALES:
         a_sc_k: tl.constexpr = 2048
-        b_sc_k = NG * stride_bsk
+        b_sc_k: tl.constexpr = 2048
     else:
         a_sc_half_m = HALF_M * stride_asm
         a_sc_k = NG * stride_ask
@@ -321,9 +343,11 @@ def _a4w4_8wave_kernel(
     # fat pointer as it already does for the pid_m/pid_n base offsets.
     a_base += split_id * KS_PACKED * stride_ak
     b_base += split_id * KS_PACKED * stride_bk
-    if PRESHUFFLED_A_SCALES:
+    if PRESHUFFLED_SCALES:
+        a_scales_ptr += pid_m * SCALE_GROUP_BLOCKS * 2048
+        b_scales_ptr += pid_n * SCALE_GROUP_BLOCKS * 2048
         a_scales_ptr += split_id * (KS_SCALE // NG) * 2048
-        b_scales_ptr += split_id * KS_SCALE * stride_bsk
+        b_scales_ptr += split_id * (KS_SCALE // NG) * 2048
     else:
         a_scales_ptr += split_id * KS_SCALE * stride_ask
         b_scales_ptr += split_id * KS_SCALE * stride_bsk
@@ -344,17 +368,13 @@ def _a4w4_8wave_kernel(
     tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_top[0], a_base, a_tile_offsets)
-    if PRESHUFFLED_A_SCALES:
-        a_sc_top0 = tlx.buffer_load(a_scales_ptr, a_sc_offsets, contiguity=8)
-        a_sc_top0 = tlx.require_layout(a_sc_top0, scale_a_layout)
+    if PRESHUFFLED_SCALES:
+        tlx.buffer_load_to_local(smem_a_sc[0], a_scales_ptr, a_sc_offsets)
     else:
         tlx.buffer_load_to_local(smem_a_sc_t[0], a_scales_ptr, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_bot[0], a_base + a_half_m, a_tile_offsets)
-    if PRESHUFFLED_A_SCALES:
-        a_sc_bot0 = tlx.buffer_load(a_scales_ptr + a_sc_half_m, a_sc_offsets, contiguity=8)
-        a_sc_bot0 = tlx.require_layout(a_sc_bot0, scale_a_layout)
-    else:
+    if not PRESHUFFLED_SCALES:
         tlx.buffer_load_to_local(smem_a_sc_b[0], a_scales_ptr + a_sc_half_m, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_b_right[0], b_base + b_half_n, b_tile_offsets)
@@ -364,17 +384,13 @@ def _a4w4_8wave_kernel(
     tlx.buffer_load_to_local(smem_b_sc[1], b_scales_ptr + b_sc_k, b_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_top[1], a_base + a_k2, a_tile_offsets)
-    if PRESHUFFLED_A_SCALES:
-        a_sc_top1 = tlx.buffer_load(a_scales_ptr + a_sc_k, a_sc_offsets, contiguity=8)
-        a_sc_top1 = tlx.require_layout(a_sc_top1, scale_a_layout)
+    if PRESHUFFLED_SCALES:
+        tlx.buffer_load_to_local(smem_a_sc[1], a_scales_ptr + a_sc_k, a_sc_offsets)
     else:
         tlx.buffer_load_to_local(smem_a_sc_t[1], a_scales_ptr + a_sc_k, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_bot[1], a_base + a_half_m + a_k2, a_tile_offsets)
-    if PRESHUFFLED_A_SCALES:
-        a_sc_bot1 = tlx.buffer_load(a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets, contiguity=8)
-        a_sc_bot1 = tlx.require_layout(a_sc_bot1, scale_a_layout)
-    else:
+    if not PRESHUFFLED_SCALES:
         tlx.buffer_load_to_local(smem_a_sc_b[1], a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_b_right[1], b_base + b_half_n + b_k2, b_tile_offsets)
@@ -388,11 +404,23 @@ def _a4w4_8wave_kernel(
     tlx.async_load_wait_group(6)
     b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
     a_top = tlx.local_load(smem_a_top[0], relaxed=True)
-    if PRESHUFFLED_A_SCALES:
-        a_sc_top = a_sc_top0
+    if PRESHUFFLED_SCALES:
+        a_sc_view_init = tlx.local_reshape(smem_a_sc[0], preshuffled_scale_shape)
+        a_sc_view_init = tlx.local_trans(a_sc_view_init, preshuffled_a_to_logical)
+        a_sc_view_init = tlx.local_reshape(a_sc_view_init, [BLOCK_M, NG])
+        a_sc_comb = tlx.local_load(a_sc_view_init, layout=scale_a_comb_layout, relaxed=True)
+        a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+        a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+        a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
     else:
         a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
-    b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
+    if PRESHUFFLED_SCALES:
+        b_sc_view_init = tlx.local_reshape(smem_b_sc[0], preshuffled_scale_shape)
+        b_sc_view_init = tlx.local_trans(b_sc_view_init, preshuffled_b_to_logical)
+        b_sc_view_init = tlx.local_reshape(b_sc_view_init, [BLOCK_N, NG])
+        b_sc_comb = tlx.local_load(b_sc_view_init, layout=scale_b_comb_layout, relaxed=True)
+    else:
+        b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
     b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
     b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
     b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
@@ -405,7 +433,7 @@ def _a4w4_8wave_kernel(
             acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_bot = tlx.local_load(smem_a_bot[0], relaxed=True)
-            if PRESHUFFLED_A_SCALES:
+            if PRESHUFFLED_SCALES:
                 a_sc_bot = a_sc_bot0
             else:
                 a_sc_bot = tlx.local_load(smem_a_sc_b[0], layout=scale_a_layout)
@@ -421,9 +449,8 @@ def _a4w4_8wave_kernel(
             b_right = tlx.local_load(tlx.local_trans(smem_b_right[0]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_top[0], a_base, a_tile_offsets)
-            if PRESHUFFLED_A_SCALES:
-                a_sc_next_top0 = tlx.buffer_load(a_scales_ptr, a_sc_offsets, contiguity=8)
-                a_sc_next_top0 = tlx.require_layout(a_sc_next_top0, scale_a_layout)
+            if PRESHUFFLED_SCALES:
+                tlx.buffer_load_to_local(smem_a_sc[0], a_scales_ptr, a_sc_offsets)
             else:
                 tlx.buffer_load_to_local(smem_a_sc_t[0], a_scales_ptr, a_sc_offsets)
             tlx.async_load_commit_group()
@@ -435,10 +462,7 @@ def _a4w4_8wave_kernel(
             b_left = tlx.local_load(tlx.local_trans(smem_b_left[1]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_bot[0], a_base + a_half_m, a_tile_offsets)
-            if PRESHUFFLED_A_SCALES:
-                a_sc_next_bot0 = tlx.buffer_load(a_scales_ptr + a_sc_half_m, a_sc_offsets, contiguity=8)
-                a_sc_next_bot0 = tlx.require_layout(a_sc_next_bot0, scale_a_layout)
-            else:
+            if not PRESHUFFLED_SCALES:
                 tlx.buffer_load_to_local(smem_a_sc_b[0], a_scales_ptr + a_sc_half_m, a_sc_offsets)
             tlx.async_load_commit_group()
 
@@ -447,11 +471,23 @@ def _a4w4_8wave_kernel(
             acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_top = tlx.local_load(smem_a_top[1], relaxed=True)
-            if PRESHUFFLED_A_SCALES:
-                a_sc_top = a_sc_top1
+            if PRESHUFFLED_SCALES:
+                a_sc_view_1 = tlx.local_reshape(smem_a_sc[1], preshuffled_scale_shape)
+                a_sc_view_1 = tlx.local_trans(a_sc_view_1, preshuffled_a_to_logical)
+                a_sc_view_1 = tlx.local_reshape(a_sc_view_1, [BLOCK_M, NG])
+                a_sc_comb = tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True)
+                a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+                a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+                a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
             else:
                 a_sc_top = tlx.local_load(smem_a_sc_t[1], layout=scale_a_layout)
-            b_sc_comb = tlx.local_load(smem_b_sc[1], layout=scale_b_comb_layout)
+            if PRESHUFFLED_SCALES:
+                b_sc_view_1 = tlx.local_reshape(smem_b_sc[1], preshuffled_scale_shape)
+                b_sc_view_1 = tlx.local_trans(b_sc_view_1, preshuffled_b_to_logical)
+                b_sc_view_1 = tlx.local_reshape(b_sc_view_1, [BLOCK_N, NG])
+                b_sc_comb = tlx.local_load(b_sc_view_1, layout=scale_b_comb_layout, relaxed=True)
+            else:
+                b_sc_comb = tlx.local_load(smem_b_sc[1], layout=scale_b_comb_layout)
             b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
             b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
             b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
@@ -465,7 +501,7 @@ def _a4w4_8wave_kernel(
             acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_bot = tlx.local_load(smem_a_bot[1], relaxed=True)
-            if PRESHUFFLED_A_SCALES:
+            if PRESHUFFLED_SCALES:
                 a_sc_bot = a_sc_bot1
             else:
                 a_sc_bot = tlx.local_load(smem_a_sc_b[1], layout=scale_a_layout)
@@ -481,9 +517,8 @@ def _a4w4_8wave_kernel(
             b_right = tlx.local_load(tlx.local_trans(smem_b_right[1]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_top[1], a_base + a_k2, a_tile_offsets)
-            if PRESHUFFLED_A_SCALES:
-                a_sc_next_top1 = tlx.buffer_load(a_scales_ptr + a_sc_k, a_sc_offsets, contiguity=8)
-                a_sc_next_top1 = tlx.require_layout(a_sc_next_top1, scale_a_layout)
+            if PRESHUFFLED_SCALES:
+                tlx.buffer_load_to_local(smem_a_sc[1], a_scales_ptr + a_sc_k, a_sc_offsets)
             else:
                 tlx.buffer_load_to_local(smem_a_sc_t[1], a_scales_ptr + a_sc_k, a_sc_offsets)
             tlx.async_load_commit_group()
@@ -495,11 +530,7 @@ def _a4w4_8wave_kernel(
             b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_bot[1], a_base + a_half_m + a_k2, a_tile_offsets)
-            if PRESHUFFLED_A_SCALES:
-                a_sc_next_bot1 = tlx.buffer_load(
-                    a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets, contiguity=8)
-                a_sc_next_bot1 = tlx.require_layout(a_sc_next_bot1, scale_a_layout)
-            else:
+            if not PRESHUFFLED_SCALES:
                 tlx.buffer_load_to_local(smem_a_sc_b[1], a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets)
             tlx.async_load_commit_group()
 
@@ -508,14 +539,23 @@ def _a4w4_8wave_kernel(
             acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_top = tlx.local_load(smem_a_top[0], relaxed=True)
-            if PRESHUFFLED_A_SCALES:
-                a_sc_top = a_sc_next_top0
-                a_sc_bot0 = a_sc_next_bot0
-                a_sc_top1 = a_sc_next_top1
-                a_sc_bot1 = a_sc_next_bot1
+            if PRESHUFFLED_SCALES:
+                a_sc_view_0 = tlx.local_reshape(smem_a_sc[0], preshuffled_scale_shape)
+                a_sc_view_0 = tlx.local_trans(a_sc_view_0, preshuffled_a_to_logical)
+                a_sc_view_0 = tlx.local_reshape(a_sc_view_0, [BLOCK_M, NG])
+                a_sc_comb = tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True)
+                a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+                a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+                a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
             else:
                 a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
-            b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
+            if PRESHUFFLED_SCALES:
+                b_sc_view_0 = tlx.local_reshape(smem_b_sc[0], preshuffled_scale_shape)
+                b_sc_view_0 = tlx.local_trans(b_sc_view_0, preshuffled_b_to_logical)
+                b_sc_view_0 = tlx.local_reshape(b_sc_view_0, [BLOCK_N, NG])
+                b_sc_comb = tlx.local_load(b_sc_view_0, layout=scale_b_comb_layout, relaxed=True)
+            else:
+                b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
             b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
             b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
             b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
@@ -533,7 +573,7 @@ def _a4w4_8wave_kernel(
     tlx.async_load_wait_group(5)
     l_idx: tl.constexpr = 0  # (iter_max - 2) % 2, always 0 (iter_max even)
     a_bot = tlx.local_load(tlx.local_view(smem_a_bot, l_idx), relaxed=True)
-    if PRESHUFFLED_A_SCALES:
+    if PRESHUFFLED_SCALES:
         a_sc_bot = a_sc_bot0
     else:
         a_sc_bot = tlx.local_load(smem_a_sc_b[l_idx], layout=scale_a_layout)
@@ -550,11 +590,23 @@ def _a4w4_8wave_kernel(
     acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
     tlx.async_load_wait_group(2)
     a_top = tlx.local_load(tlx.local_view(smem_a_top, g_idx), relaxed=True)
-    if PRESHUFFLED_A_SCALES:
-        a_sc_top = a_sc_top1
+    if PRESHUFFLED_SCALES:
+        a_sc_view_epilogue = tlx.local_reshape(smem_a_sc[g_idx], preshuffled_scale_shape)
+        a_sc_view_epilogue = tlx.local_trans(a_sc_view_epilogue, preshuffled_a_to_logical)
+        a_sc_view_epilogue = tlx.local_reshape(a_sc_view_epilogue, [BLOCK_M, NG])
+        a_sc_comb = tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True)
+        a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+        a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+        a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
     else:
         a_sc_top = tlx.local_load(smem_a_sc_t[g_idx], layout=scale_a_layout)
-    b_sc_comb = tlx.local_load(smem_b_sc[g_idx], layout=scale_b_comb_layout)
+    if PRESHUFFLED_SCALES:
+        b_sc_view_epilogue = tlx.local_reshape(smem_b_sc[g_idx], preshuffled_scale_shape)
+        b_sc_view_epilogue = tlx.local_trans(b_sc_view_epilogue, preshuffled_b_to_logical)
+        b_sc_view_epilogue = tlx.local_reshape(b_sc_view_epilogue, [BLOCK_N, NG])
+        b_sc_comb = tlx.local_load(b_sc_view_epilogue, layout=scale_b_comb_layout, relaxed=True)
+    else:
+        b_sc_comb = tlx.local_load(smem_b_sc[g_idx], layout=scale_b_comb_layout)
     b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
     b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
     b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
@@ -563,7 +615,7 @@ def _a4w4_8wave_kernel(
     acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
     tlx.async_load_wait_group(1)
     a_bot = tlx.local_load(tlx.local_view(smem_a_bot, g_idx), relaxed=True)
-    if PRESHUFFLED_A_SCALES:
+    if PRESHUFFLED_SCALES:
         a_sc_bot = a_sc_bot1
     else:
         a_sc_bot = tlx.local_load(smem_a_sc_b[g_idx], layout=scale_a_layout)
@@ -666,14 +718,7 @@ def choose_split_k(M, N, K):
     return best
 
 
-def preshuffle_mxfp4_a_scales(scales):
-    """Pack canonical ``[rows, K/32]`` E8M0 scales for direct register loads.
-
-    This adapts AITER's lane-major scale-preshuffle to this kernel's 2x4 wave
-    ownership. Physical storage is tiled as ``[256 rows, 8 groups]`` and ordered
-    ``[128-row half, M wave, lane, register]``, so each lane fetches its eight
-    A-scale bytes contiguously. Padding uses the E8M0 identity value (0x7f).
-    """
+def _pad_mxfp4_scales(scales):
     assert scales.dtype is torch.uint8
     assert scales.is_cuda
     assert scales.ndim == 2
@@ -688,9 +733,35 @@ def preshuffle_mxfp4_a_scales(scales):
         device=scales.device,
     )
     padded[:rows, :groups] = scales
+    return padded, padded_rows, padded_groups
+
+
+def preshuffle_mxfp4_a_scales(scales):
+    """Pack A scales so a combined 256x8 LDS tile is read with ``ds_read_b128``.
+
+    The four physical low bits are group bit 2 and row bits 5, 6, and 7: the
+    exact value bases of ``scale_a_comb_layout``. Padding uses the E8M0 identity
+    value (0x7f).
+    """
+    padded, padded_rows, padded_groups = _pad_mxfp4_scales(scales)
     return (
-        padded.reshape(padded_rows // 256, 2, 4, 2, 16, padded_groups // 8, 2, 4)
-        .permute(0, 5, 1, 3, 7, 4, 2, 6)
+        padded.reshape(
+            padded_rows // 256, 2, 2, 2, 2, 2, 2, 2, 2,
+            padded_groups // 8, 2, 2, 2)
+        .permute(0, 9, 11, 12, 7, 8, 4, 5, 6, 1, 2, 3, 10)
+        .contiguous()
+        .reshape(-1)
+    )
+
+
+def preshuffle_mxfp4_b_scales(scales):
+    """Pack B scales into the ordinary 64-bit LDS consumer order."""
+    padded, padded_rows, padded_groups = _pad_mxfp4_scales(scales)
+    return (
+        padded.reshape(
+            padded_rows // 256, 2, 2, 2, 2, 2, 2, 2, 2,
+            padded_groups // 8, 2, 2, 2)
+        .permute(0, 9, 11, 12, 3, 8, 4, 5, 6, 7, 1, 2, 10)
         .contiguous()
         .reshape(-1)
     )
@@ -758,7 +829,7 @@ def _matmul_256tile(a, b, a_scales, b_scales, SPLIT_K=None):
         NUM_XCDS=NUM_XCDS,
         GRID_MN=grid_mn,
         SPLIT_K=SPLIT_K,
-        PRESHUFFLED_A_SCALES=False,
+        PRESHUFFLED_SCALES=False,
         num_warps=NUM_WARPS,
         num_stages=1,
         matrix_instr_nonkdim=16,
@@ -785,19 +856,18 @@ def _matmul_256tile(a, b, a_scales, b_scales, SPLIT_K=None):
 
 
 def matmul_preshuffled(a, b, a_scales, b_scales, SPLIT_K=None):
-    """Experimental inter-wave kernel for a preshuffled A-scale buffer.
+    """Experimental pure-DMA kernel for two preshuffled scale buffers.
 
-    ``a_scales`` is a flat buffer returned by :func:`preshuffle_mxfp4_a_scales`
-    and loads directly into the scaled-MFMA register layout. ``b_scales`` keeps
-    the canonical ``[N, K/32]`` ABI and direct-to-LDS DMA, matching the operand
-    orientation used by AITER's 256x256 kernel.
+    Both scale arguments are flat buffers returned by the corresponding
+    :func:`preshuffle_mxfp4_a_scales` and
+    :func:`preshuffle_mxfp4_b_scales` helpers.
     """
     assert a.dtype is torch.uint8
     assert b.dtype is torch.uint8
     assert a_scales.dtype is torch.uint8
     assert b_scales.dtype is torch.uint8
     assert a.is_cuda and b.is_cuda and a_scales.is_cuda and b_scales.is_cuda
-    assert a_scales.ndim == 1 and b_scales.ndim == 2
+    assert a_scales.ndim == 1 and b_scales.ndim == 1
 
     M = a.shape[0]
     K_packed = a.shape[1]
@@ -807,8 +877,7 @@ def matmul_preshuffled(a, b, a_scales, b_scales, SPLIT_K=None):
     padded_groups = triton.cdiv(groups, 8) * 8
     assert b.shape == (N, K_packed), "B must have shape (N, K // 2)"
     assert a_scales.numel() == triton.cdiv(M, 256) * 256 * padded_groups
-    assert b_scales.shape == (N, groups)
-    assert b_scales.stride(0) == 1, "B scales must be contiguous along N"
+    assert b_scales.numel() == triton.cdiv(N, 256) * 256 * padded_groups
     assert M % BLOCK_M == 0, "M must be a multiple of 256"
     assert N % BLOCK_N == 0, "N must be a multiple of 256"
     assert K >= MIN_K and K % (2 * BLOCK_K) == 0, \
@@ -843,8 +912,8 @@ def matmul_preshuffled(a, b, a_scales, b_scales, SPLIT_K=None):
         c.stride(1),
         0,
         0,
-        b_scales.stride(0),
-        b_scales.stride(1),
+        0,
+        0,
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
         BLOCK_K=BLOCK_K,
@@ -852,7 +921,7 @@ def matmul_preshuffled(a, b, a_scales, b_scales, SPLIT_K=None):
         NUM_XCDS=NUM_XCDS,
         GRID_MN=grid_mn,
         SPLIT_K=SPLIT_K,
-        PRESHUFFLED_A_SCALES=True,
+        PRESHUFFLED_SCALES=True,
         num_warps=NUM_WARPS,
         num_stages=1,
         matrix_instr_nonkdim=16,

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
@@ -38,6 +38,11 @@ two K tiles into LDS. Its A image places the four scale register values in the
 low physical bits for one aligned ``ds_read_b128``; bank-group address bits 4..6
 come from lane bits 0..2, keeping that wide read conflict-free.
 
+Canonical, separate-preshuffled, and merged scales each have an independent
+``@triton.jit`` kernel body. Their initial bodies deliberately preserve the
+previous specializations exactly so subsequent tuning can change one ABI's
+prologue, pipeline, or epilogue without coupling the other two.
+
 The Shape:Stride register/blocked/accumulator layouts below encode the gfx950
 16x16x128 scaled-MFMA / dot-operand / scale distributions, and are
 round-trip-verified against the compiler's resolved linear layouts.
@@ -142,9 +147,8 @@ def _a4w4_8wave_kernel(
     NUM_XCDS: tl.constexpr,
     GRID_MN: tl.constexpr,
     SPLIT_K: tl.constexpr,
-    PRESHUFFLED_SCALES: tl.constexpr = False,
-    MERGED_SCALE_DMA: tl.constexpr = False,
 ):
+    """Canonical two-scale-pointer kernel with in-kernel scale swizzling."""
     SCALE_GROUP_SIZE: tl.constexpr = 32
     HALF_M: tl.constexpr = BLOCK_M // 2  # 128
     HALF_N: tl.constexpr = BLOCK_N // 2  # 128
@@ -156,7 +160,6 @@ def _a4w4_8wave_kernel(
     KS: tl.constexpr = K // SPLIT_K
     KS_PACKED: tl.constexpr = KS // 2  # packed fp4 columns per split
     KS_SCALE: tl.constexpr = KS // SCALE_GROUP_SIZE  # scale groups per split
-    SCALE_GROUP_BLOCKS: tl.constexpr = K // BLOCK_K
 
     # ---- fp4 tile global-load register layout (#linear, [128,128]) ----
     g_load_layout: tl.constexpr = tlx.layout(
@@ -194,54 +197,7 @@ def _a4w4_8wave_kernel(
         block_bases=[],
         alignment=16,
     )
-    # The combined A view assigns the four register-value bits to the low four
-    # physical address bits, so one aligned ds_read_b128 produces both 128-row
-    # MFMA scale fragments.  Address bits 4..6 are lane bits 0..2, which gives
-    # each dword phase all 32 LDS banks; the remaining lane and warp ownership
-    # bits select higher 128-byte regions.
-    # The merged layouts add the K-tile selector around the combined A map.
-    # Physical bit 11 is the 2048-byte A/B section selector, so it is unused by
-    # the A view; physical bit 12 selects the second K tile.
-    shared_merged_a_scales_combined: tl.constexpr = tlx.shared_linear_layout_encoding(
-        offset_bases=[
-            [0, 0, 4], [0, 32, 0], [0, 64, 0], [0, 128, 0],
-            [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0],
-            [0, 16, 0], [0, 0, 1], [0, 0, 2], [0, 0, 0], [1, 0, 0],
-        ],
-        block_bases=[],
-        alignment=16,
-    )
-    # The merged B layout adds section and K-tile selector bits around its
-    # canonical map so the full raw allocation can be reinterpreted before
-    # slicing.
-    shared_merged_b_scales: tl.constexpr = tlx.shared_linear_layout_encoding(
-        offset_bases=[
-            [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0],
-            [0, 32, 0], [0, 64, 0], [0, 128, 0], [0, 16, 1], [0, 0, 2],
-            [0, 32, 4], [1, 0, 0], [2, 0, 0],
-        ],
-        block_bases=[],
-        alignment=16,
-    )
-    # The preshuffled ABIs DMA an already-packed physical image. Keep the raw
-    # destination byte-linear so every wave writes consecutive 4-byte (separate)
-    # or 16-byte (merged) vectors.
-    shared_scale_preshuffled: tl.constexpr = tlx.shared_linear_layout_encoding(
-        offset_bases=[
-            [1], [2], [4], [8], [16], [32], [64], [128], [256], [512], [1024],
-        ],
-        block_bases=[],
-        alignment=16,
-    )
-    shared_scale_merged: tl.constexpr = tlx.shared_linear_layout_encoding(
-        offset_bases=[
-            [1], [2], [4], [8], [16], [32], [64], [128], [256], [512], [1024], [2048], [4096],
-        ],
-        block_bases=[],
-        alignment=16,
-    )
-    # Match each raw scale image's byte-linear shared order: two 4-byte value
-    # bits, six lane bits, then warp bits.
+    # Canonical A/B scale DMA layouts encode the same XOR maps as the LDS views.
     scale_load_a_layout: tl.constexpr = tlx.layout(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2)),
         stride=((32, 64, 128, 256, 512, 1, 2, 132, 0), (8, 16)),
@@ -249,6 +205,412 @@ def _a4w4_8wave_kernel(
     scale_load_b_layout: tl.constexpr = tlx.layout(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2)),
         stride=((32, 64, 128, 256, 512, 1024, 129, 2, 260), (8, 16)),
+    )
+    # ---- MFMA scale register layouts (get_mfma_scale_layout) ----
+    scale_a_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2)),
+        stride=((8, 16, 32, 64, 1, 2, 0, 0, 128), (4, 256, 512)),
+    )
+    scale_b_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2)),
+        stride=((8, 16, 32, 64, 1, 2, 128, 256, 0), (4, 512)),
+    )
+    scale_b_comb_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2)),
+        stride=((8, 16, 32, 64, 1, 2, 128, 256, 0), (4, 512, 1024)),
+    )
+    # ---- MFMA accumulator layout (#mma 16x16x128 [2,4], one [128,128] quadrant) ----
+    accumulator_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2, 2)),
+        stride=((128, 256, 512, 1024, 4, 8, 16, 32, 2048), (1, 2, 64, 4096, 8192)),
+    )
+    # ---- store layout (#blocked2, [128,128] bf16 quadrant) ----
+    store_layout_c: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2, 2)),
+        stride=((8, 16, 32, 64, 128, 256, 512, 1024, 2048), (1, 2, 4, 4096, 8192)),
+    )
+
+    # Grid is GRID_MN * SPLIT_K; peel the split id, keep the MN pid for the
+    # XCD / GROUP_SIZE_M remap below.
+    split_id = tl.program_id(0) // GRID_MN
+    pid = tl.program_id(0) % GRID_MN
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+
+    if NUM_XCDS != 1:
+        pids_per_xcd = (GRID_MN + NUM_XCDS - 1) // NUM_XCDS
+        tall_xcds = GRID_MN % NUM_XCDS
+        tall_xcds = NUM_XCDS if tall_xcds == 0 else tall_xcds
+        xcd = pid % NUM_XCDS
+        local_pid = pid // NUM_XCDS
+        if xcd < tall_xcds:
+            pid = xcd * pids_per_xcd + local_pid
+        else:
+            pid = tall_xcds * pids_per_xcd + (xcd - tall_xcds) * (pids_per_xcd - 1) + local_pid
+
+    if GROUP_SIZE_M == 1:
+        pid_m = pid // num_pid_n
+        pid_n = pid % num_pid_n
+    else:
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        tl.assume(group_size_m > 0)
+        pid_m = first_pid_m + (pid % num_pid_in_group) % group_size_m
+        pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # Four double-buffered operand half-tiles plus canonical A-top, A-bottom,
+    # and combined-B scale tiles.
+    smem_a_top = tlx.local_alloc((HALF_M, HALF_K), tlx.dtype_of(a_ptr), 2, layout=shared_tile)
+    smem_a_bot = tlx.local_alloc((HALF_M, HALF_K), tlx.dtype_of(a_ptr), 2, layout=shared_tile)
+    smem_b_left = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
+    smem_b_right = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
+    smem_a_sc_t = tlx.local_alloc((HALF_M, NG), tlx.dtype_of(a_scales_ptr), 2, layout=shared_a_scales)
+    smem_a_sc_b = tlx.local_alloc((HALF_M, NG), tlx.dtype_of(a_scales_ptr), 2, layout=shared_a_scales)
+    smem_b_sc = tlx.local_alloc((BLOCK_N, NG), tlx.dtype_of(b_scales_ptr), 2, layout=shared_b_scales)
+
+    # ---- fp4 tile load offsets ([128,128]) ----
+    offs_am = tl.arange(0, HALF_M)
+    offs_ak = tl.arange(0, HALF_K)
+    a_tile_offsets = tlx.require_layout(offs_am[:, None] * stride_am + offs_ak[None, :] * stride_ak, g_load_layout)
+    a_base = a_ptr + pid_m * BLOCK_M * stride_am
+
+    offs_bn = tl.arange(0, HALF_N)
+    offs_bk = tl.arange(0, HALF_K)
+    b_tile_offsets = tlx.require_layout(offs_bn[:, None] * stride_bn + offs_bk[None, :] * stride_bk, g_load_layout)
+    b_base = b_ptr + pid_n * BLOCK_N * stride_bn
+
+    # ---- Scale load offsets ----
+    offs_ks_a = tl.arange(0, NG)
+    offs_asm = pid_m * BLOCK_M + tl.arange(0, HALF_M)
+    a_sc_offsets = tl.mul(offs_asm[:, None], stride_asm, sanitize_overflow=False) + tl.mul(
+        offs_ks_a[None, :], stride_ask, sanitize_overflow=False)
+    a_sc_offsets = tlx.require_layout(a_sc_offsets, scale_load_a_layout)
+
+    # ---- B scale load offsets: FULL [256,8] in one copy ----
+    offs_ks_b = tl.arange(0, NG)
+    offs_bsn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    b_sc_offsets = tl.mul(offs_bsn[:, None], stride_bsn, sanitize_overflow=False) + tl.mul(
+        offs_ks_b[None, :], stride_bsk, sanitize_overflow=False)
+    b_sc_offsets = tlx.require_layout(b_sc_offsets, scale_load_b_layout)
+
+    # Scalar (uniform) base-pointer deltas for the quadrant / K-buffer variants.
+    a_half_m = HALF_M * stride_am  # a_top -> a_bot
+    b_half_n = HALF_N * stride_bn  # b_left -> b_right
+    a_k2 = HALF_K * stride_ak  # even -> odd (_next) K-step
+    b_k2 = HALF_K * stride_bk
+    a_sc_half_m = HALF_M * stride_asm
+    a_sc_k = NG * stride_ask
+    b_sc_k = NG * stride_bsk
+
+    # Advance every base to this split's K-slice (no-op when SPLIT_K==1). The
+    # A/B tiles are K-packed (KS_PACKED cols) and the scales are per-group
+    # (KS_SCALE groups). All arith bases; buffer_load_to_local materializes the
+    # fat pointer as it already does for the pid_m/pid_n base offsets.
+    a_base += split_id * KS_PACKED * stride_ak
+    b_base += split_id * KS_PACKED * stride_bk
+    a_scales_ptr += split_id * KS_SCALE * stride_ask
+    b_scales_ptr += split_id * KS_SCALE * stride_bsk
+
+    acc_tl = tl.zeros((HALF_M, HALF_N), dtype=tl.float32)
+    acc_bl = tl.zeros((HALF_M, HALF_N), dtype=tl.float32)
+    acc_tr = tl.zeros((HALF_M, HALF_N), dtype=tl.float32)
+    acc_br = tl.zeros((HALF_M, HALF_N), dtype=tl.float32)
+
+    # _matmul_256tile derives this trusted runtime value from the asserted KS.
+    # The assumption keeps range/liveness analysis as precise as the old
+    # constexpr bound while preserving the one-trip scf.for at K=1024.
+    iter_max = K_TILES
+    tl.assume(iter_max > 3)
+
+    # ---- Prologue: prefetch K-steps 0,1 into buffers 0,1 (8 commits) ----
+    tlx.buffer_load_to_local(smem_b_left[0], b_base, b_tile_offsets)
+    tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_a_top[0], a_base, a_tile_offsets)
+    tlx.buffer_load_to_local(smem_a_sc_t[0], a_scales_ptr, a_sc_offsets)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_a_bot[0], a_base + a_half_m, a_tile_offsets)
+    tlx.buffer_load_to_local(smem_a_sc_b[0], a_scales_ptr + a_sc_half_m, a_sc_offsets)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_b_right[0], b_base + b_half_n, b_tile_offsets)
+    tlx.async_load_commit_group()
+
+    tlx.buffer_load_to_local(smem_b_left[1], b_base + b_k2, b_tile_offsets)
+    tlx.buffer_load_to_local(smem_b_sc[1], b_scales_ptr + b_sc_k, b_sc_offsets)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_a_top[1], a_base + a_k2, a_tile_offsets)
+    tlx.buffer_load_to_local(smem_a_sc_t[1], a_scales_ptr + a_sc_k, a_sc_offsets)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_a_bot[1], a_base + a_half_m + a_k2, a_tile_offsets)
+    tlx.buffer_load_to_local(smem_a_sc_b[1], a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_b_right[1], b_base + b_half_n + b_k2, b_tile_offsets)
+    tlx.async_load_commit_group()
+
+    a_base += a_k2 * 2
+    b_base += b_k2 * 2
+    a_scales_ptr += a_sc_k * 2
+    b_scales_ptr += b_sc_k * 2
+
+    tlx.async_load_wait_group(6)
+    b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
+    a_top = tlx.local_load(smem_a_top[0], relaxed=True)
+    a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
+    b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
+    b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
+    b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
+    b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
+
+    # ---- Main loop (2x unrolled): 8 (mfma + mem) regions ----
+    for k in tl.range(0, iter_max - 2, 2, num_stages=1):
+        # --- sub-iter 0 (buffer 0) ---
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_bot = tlx.local_load(smem_a_bot[0], relaxed=True)
+            a_sc_bot = tlx.local_load(smem_a_sc_b[0], layout=scale_a_layout)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_b_left[0], b_base, b_tile_offsets)
+            tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_bl = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_left, b_sc_left, "e2m1", acc_bl)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            b_right = tlx.local_load(tlx.local_trans(smem_b_right[0]), relaxed=True)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_a_top[0], a_base, a_tile_offsets)
+            tlx.buffer_load_to_local(smem_a_sc_t[0], a_scales_ptr, a_sc_offsets)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_tr = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_right, b_sc_right, "e2m1", acc_tr)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            b_left = tlx.local_load(tlx.local_trans(smem_b_left[1]), relaxed=True)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_a_bot[0], a_base + a_half_m, a_tile_offsets)
+            tlx.buffer_load_to_local(smem_a_sc_b[0], a_scales_ptr + a_sc_half_m, a_sc_offsets)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_top = tlx.local_load(smem_a_top[1], relaxed=True)
+            a_sc_top = tlx.local_load(smem_a_sc_t[1], layout=scale_a_layout)
+            b_sc_comb = tlx.local_load(smem_b_sc[1], layout=scale_b_comb_layout)
+            b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
+            b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
+            b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_b_right[0], b_base + b_half_n, b_tile_offsets)
+            tlx.async_load_commit_group()
+
+        # --- sub-iter 1 (buffer 1, base + one K-step) ---
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_bot = tlx.local_load(smem_a_bot[1], relaxed=True)
+            a_sc_bot = tlx.local_load(smem_a_sc_b[1], layout=scale_a_layout)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_b_left[1], b_base + b_k2, b_tile_offsets)
+            tlx.buffer_load_to_local(smem_b_sc[1], b_scales_ptr + b_sc_k, b_sc_offsets)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_bl = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_left, b_sc_left, "e2m1", acc_bl)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            b_right = tlx.local_load(tlx.local_trans(smem_b_right[1]), relaxed=True)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_a_top[1], a_base + a_k2, a_tile_offsets)
+            tlx.buffer_load_to_local(smem_a_sc_t[1], a_scales_ptr + a_sc_k, a_sc_offsets)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_tr = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_right, b_sc_right, "e2m1", acc_tr)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_a_bot[1], a_base + a_half_m + a_k2, a_tile_offsets)
+            tlx.buffer_load_to_local(smem_a_sc_b[1], a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_top = tlx.local_load(smem_a_top[0], relaxed=True)
+            a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
+            b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
+            b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
+            b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
+            b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_b_right[1], b_base + b_half_n + b_k2, b_tile_offsets)
+            tlx.async_load_commit_group()
+            a_base += a_k2 * 2
+            b_base += b_k2 * 2
+            a_scales_ptr += a_sc_k * 2
+            b_scales_ptr += b_sc_k * 2
+
+    # ---- Epilogue: last 2 K-steps, drain, 4-quadrant store ----
+    # iter iter_max-2 (b_sc_left/right for this step were prefetched at loop tail)
+    acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
+    tlx.async_load_wait_group(5)
+    l_idx: tl.constexpr = 0  # (iter_max - 2) % 2, always 0 (iter_max even)
+    a_bot = tlx.local_load(tlx.local_view(smem_a_bot, l_idx), relaxed=True)
+    a_sc_bot = tlx.local_load(smem_a_sc_b[l_idx], layout=scale_a_layout)
+
+    acc_bl = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_left, b_sc_left, "e2m1", acc_bl)
+    tlx.async_load_wait_group(4)
+    b_right = tlx.local_load(tlx.local_trans(tlx.local_view(smem_b_right, l_idx)), relaxed=True)
+
+    acc_tr = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_right, b_sc_right, "e2m1", acc_tr)
+    tlx.async_load_wait_group(3)
+    g_idx: tl.constexpr = 1  # 1 - l_idx
+    b_left = tlx.local_load(tlx.local_trans(tlx.local_view(smem_b_left, g_idx)), relaxed=True)
+
+    acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
+    tlx.async_load_wait_group(2)
+    a_top = tlx.local_load(tlx.local_view(smem_a_top, g_idx), relaxed=True)
+    a_sc_top = tlx.local_load(smem_a_sc_t[g_idx], layout=scale_a_layout)
+    b_sc_comb = tlx.local_load(smem_b_sc[g_idx], layout=scale_b_comb_layout)
+    b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
+    b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
+    b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
+
+    # iter iter_max-1: finish ALL four accumulators, then convert + store.
+    acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
+    tlx.async_load_wait_group(1)
+    a_bot = tlx.local_load(tlx.local_view(smem_a_bot, g_idx), relaxed=True)
+    a_sc_bot = tlx.local_load(smem_a_sc_b[g_idx], layout=scale_a_layout)
+
+    acc_bl = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_left, b_sc_left, "e2m1", acc_bl)
+    tlx.async_load_wait_group(0)
+    b_right = tlx.local_load(tlx.local_trans(tlx.local_view(smem_b_right, g_idx)), relaxed=True)
+
+    acc_tr = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_right, b_sc_right, "e2m1", acc_tr)
+    acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
+
+    # ---- 4-quadrant store ----
+    if SPLIT_K == 1:
+        # Direct coalesced store to C (bf16). c_quad_offsets is shared by all four
+        # quadrants (same relative layout, different base).
+        offs_cm = tl.arange(0, HALF_M)
+        offs_cn = tl.arange(0, HALF_N)
+        c_quad_offsets = tl.mul(stride_cm, offs_cm[:, None], sanitize_overflow=False) + tl.mul(
+            stride_cn, offs_cn[None, :], sanitize_overflow=False)
+        c_quad_offsets = tlx.require_layout(c_quad_offsets, store_layout_c)
+        c_tl_base = c_ptr + pid_m * BLOCK_M * stride_cm + pid_n * BLOCK_N * stride_cn
+        c_bl_base = c_tl_base + HALF_M * stride_cm
+        c_tr_base = c_tl_base + HALF_N * stride_cn
+        c_br_base = c_bl_base + HALF_N * stride_cn
+
+        # require(accumulator) -> cast -> require(store): freeze the MFMA register
+        # distribution, cast bf16 register-local in it, then require the coalesced
+        # store layout. The compiler narrows before redistributing (no explicit
+        # release_layout needed).
+        et = c_ptr.dtype.element_ty
+        acc_tl = tlx.require_layout(acc_tl, accumulator_layout)
+        c_tl = tlx.require_layout(acc_tl.to(et), store_layout_c)
+        tlx.buffer_store(c_tl, c_tl_base, c_quad_offsets)
+
+        acc_bl = tlx.require_layout(acc_bl, accumulator_layout)
+        c_bl = tlx.require_layout(acc_bl.to(et), store_layout_c)
+        tlx.buffer_store(c_bl, c_bl_base, c_quad_offsets)
+
+        acc_tr = tlx.require_layout(acc_tr, accumulator_layout)
+        c_tr = tlx.require_layout(acc_tr.to(et), store_layout_c)
+        tlx.buffer_store(c_tr, c_tr_base, c_quad_offsets)
+
+        acc_br = tlx.require_layout(acc_br, accumulator_layout)
+        c_br = tlx.require_layout(acc_br.to(et), store_layout_c)
+        tlx.buffer_store(c_br, c_br_base, c_quad_offsets)
+    else:
+        # Split-K: write this split's fp32 partials into its workspace slice
+        # (rows [split_id*M, split_id*M+M)); a separate fp32 reduce kernel sums
+        # the SPLIT_K slabs into C, keeping the result bit-identical to a single
+        # fp32-accumulated GEMM. Plain tl.store (fp32, no narrowing).
+        rb = split_id * M
+        offs_cm_t = rb + pid_m * BLOCK_M + tl.arange(0, HALF_M)
+        offs_cm_b = offs_cm_t + HALF_M
+        offs_cn_l = pid_n * BLOCK_N + tl.arange(0, HALF_N)
+        offs_cn_r = offs_cn_l + HALF_N
+        tl.store(workspace_ptr + offs_cm_t[:, None] * stride_cm + offs_cn_l[None, :] * stride_cn, acc_tl)
+        tl.store(workspace_ptr + offs_cm_b[:, None] * stride_cm + offs_cn_l[None, :] * stride_cn, acc_bl)
+        tl.store(workspace_ptr + offs_cm_t[:, None] * stride_cm + offs_cn_r[None, :] * stride_cn, acc_tr)
+        tl.store(workspace_ptr + offs_cm_b[:, None] * stride_cm + offs_cn_r[None, :] * stride_cn, acc_br)
+
+
+@triton.jit
+def _a4w4_8wave_preshuffled_scales_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    workspace_ptr,
+    a_scales_ptr,
+    b_scales_ptr,
+    M,
+    N,
+    K: tl.constexpr,
+    K_TILES,
+    stride_am,
+    stride_ak,
+    stride_bn,
+    stride_bk,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    GRID_MN: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+):
+    """Separate-preshuffled two-scale-pointer kernel."""
+    SCALE_GROUP_SIZE: tl.constexpr = 32
+    HALF_M: tl.constexpr = BLOCK_M // 2  # 128
+    HALF_N: tl.constexpr = BLOCK_N // 2  # 128
+    HALF_K: tl.constexpr = BLOCK_K // 2  # 128 (packed fp4)
+    NG: tl.constexpr = BLOCK_K // SCALE_GROUP_SIZE  # 8 scale groups along K
+    # Split-K: each program owns a contiguous K-slice of length KS (== K when
+    # SPLIT_K==1). KS is constexpr, so every derived offset stays constexpr and
+    # keeps its divisibility (no #linear -> #blocked collapse).
+    KS: tl.constexpr = K // SPLIT_K
+    KS_PACKED: tl.constexpr = KS // 2  # packed fp4 columns per split
+    KS_SCALE: tl.constexpr = KS // SCALE_GROUP_SIZE  # scale groups per split
+    SCALE_GROUP_BLOCKS: tl.constexpr = K // BLOCK_K
+
+    # ---- fp4 tile global-load register layout (#linear, [128,128]) ----
+    g_load_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2, 2)),
+        stride=((16, 32, 64, 128, 4096, 8192, 256, 512, 1024), (1, 2, 4, 8, 2048)),
+    )
+    # ---- padded shared tile layout ([128,128] fp4, pad 32 @ 1024) ----
+    shared_tile: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [[1024, 32]],
+        [
+            [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64],
+            [1, 0], [32, 0], [64, 0], [2, 0], [4, 0], [8, 0], [16, 0],
+        ],
+        [HALF_M, HALF_K],
+    )
+    # Each preshuffled scale allocation is a raw byte-linear LDS image.
+    shared_scale_preshuffled: tl.constexpr = tlx.shared_linear_layout_encoding(
+        offset_bases=[
+            [1], [2], [4], [8], [16], [32], [64], [128], [256], [512], [1024],
+        ],
+        block_bases=[],
+        alignment=16,
     )
     # Four bytes per thread stage each independent 256x8 preshuffled tile.
     scale_load_preshuffled_layout: tl.constexpr = tlx.layout(
@@ -261,13 +623,6 @@ def _a4w4_8wave_kernel(
     preshuffled_scale_shape: tl.constexpr = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
     preshuffled_a_to_logical: tl.constexpr = (7, 8, 9, 4, 5, 6, 2, 3, 10, 0, 1)
     preshuffled_b_to_logical: tl.constexpr = (8, 9, 2, 4, 5, 6, 7, 3, 10, 0, 1)
-    # One 16-byte vector per thread stages two adjacent A+B scale images.  The
-    # high warp bit selects the second K tile, so all eight waves contribute to
-    # one full-workgroup 8192-byte DMA.
-    scale_load_merged_layout: tl.constexpr = tlx.layout(
-        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2)),
-        stride=((16, 32, 64, 128, 256, 512, 1024, 2048, 4096), (1, 2, 4, 8)),
-    )
     # ---- MFMA scale register layouts (get_mfma_scale_layout) ----
     scale_a_layout: tl.constexpr = tlx.layout(
         shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2)),
@@ -326,33 +681,16 @@ def _a4w4_8wave_kernel(
         pid_m = first_pid_m + (pid % num_pid_in_group) % group_size_m
         pid_n = (pid % num_pid_in_group) // group_size_m
 
-    # Four double-buffered operand half-tiles plus scale tiles.  The canonical
-    # path keeps separate scale allocations; the merged ABI uses one 8192-byte
-    # allocation for the two K tiles consumed by an unrolled iteration. It is
-    # refilled after both scale halves have been read, so it needs no second
-    # scale buffer and keeps the total LDS footprint unchanged.
+    # Four double-buffered operand half-tiles plus independent double-buffered
+    # byte-linear A/B scale images.
     smem_a_top = tlx.local_alloc((HALF_M, HALF_K), tlx.dtype_of(a_ptr), 2, layout=shared_tile)
     smem_a_bot = tlx.local_alloc((HALF_M, HALF_K), tlx.dtype_of(a_ptr), 2, layout=shared_tile)
     smem_b_left = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
     smem_b_right = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
-    if MERGED_SCALE_DMA:
-        smem_sc = tlx.local_alloc(
-            (2 * (BLOCK_M + BLOCK_N) * NG, ), tlx.dtype_of(a_scales_ptr), 1, layout=shared_scale_merged)
-        smem_sc_a_view = tlx.local_reinterpret(
-            smem_sc[0], tl.uint8, [2, BLOCK_M, NG], layout=shared_merged_a_scales_combined)
-        smem_sc_b_view = tlx.local_reinterpret(
-            smem_sc[0], tl.uint8, [4, BLOCK_N, NG], layout=shared_merged_b_scales)
-    elif PRESHUFFLED_SCALES:
-        smem_a_sc = tlx.local_alloc(
-            (BLOCK_M * NG, ), tlx.dtype_of(a_scales_ptr), 2, layout=shared_scale_preshuffled)
-        smem_b_sc = tlx.local_alloc(
-            (BLOCK_N * NG, ), tlx.dtype_of(b_scales_ptr), 2, layout=shared_scale_preshuffled)
-    else:
-        smem_a_sc_t = tlx.local_alloc((HALF_M, NG), tlx.dtype_of(a_scales_ptr), 2, layout=shared_a_scales)
-        smem_a_sc_b = tlx.local_alloc((HALF_M, NG), tlx.dtype_of(a_scales_ptr), 2, layout=shared_a_scales)
-        smem_b_sc = tlx.local_alloc((BLOCK_N, NG), tlx.dtype_of(b_scales_ptr), 2, layout=shared_b_scales)
-
-    # ---- fp4 tile load offsets ([128,128]) ----
+    smem_a_sc = tlx.local_alloc(
+        (BLOCK_M * NG, ), tlx.dtype_of(a_scales_ptr), 2, layout=shared_scale_preshuffled)
+    smem_b_sc = tlx.local_alloc(
+        (BLOCK_N * NG, ), tlx.dtype_of(b_scales_ptr), 2, layout=shared_scale_preshuffled)
     offs_am = tl.arange(0, HALF_M)
     offs_ak = tl.arange(0, HALF_K)
     a_tile_offsets = tlx.require_layout(offs_am[:, None] * stride_am + offs_ak[None, :] * stride_ak, g_load_layout)
@@ -364,71 +702,20 @@ def _a4w4_8wave_kernel(
     b_base = b_ptr + pid_n * BLOCK_N * stride_bn
 
     # ---- Scale load offsets ----
-    offs_ks_a = tl.arange(0, NG)
-    if MERGED_SCALE_DMA:
-        scale_physical_offsets = tl.arange(0, 2 * (BLOCK_M + BLOCK_N) * NG)
-        scale_k_tile = scale_physical_offsets // ((BLOCK_M + BLOCK_N) * NG)
-        scale_in_tile = scale_physical_offsets % ((BLOCK_M + BLOCK_N) * NG)
-        a_scale_tile_base = pid_m * SCALE_GROUP_BLOCKS * BLOCK_M * NG
-        b_scale_tile_base = num_pid_m * SCALE_GROUP_BLOCKS * BLOCK_M * NG
-        b_scale_tile_base += pid_n * SCALE_GROUP_BLOCKS * BLOCK_N * NG
-        split_scale_base = split_id * (KS_SCALE // NG) * BLOCK_M * NG
-        a_scale_tile_base += split_scale_base
-        b_scale_tile_base += split_scale_base
-        scale_offsets = tl.where(
-            scale_in_tile < BLOCK_M * NG,
-            a_scale_tile_base + scale_k_tile * BLOCK_M * NG + scale_in_tile,
-            b_scale_tile_base + scale_k_tile * BLOCK_N * NG + scale_in_tile - BLOCK_M * NG,
-        )
-        scale_offsets = tlx.require_layout(scale_offsets, scale_load_merged_layout)
-    elif PRESHUFFLED_SCALES:
-        a_sc_offsets = tlx.require_layout(tl.arange(0, BLOCK_M * NG), scale_load_preshuffled_layout)
-    else:
-        offs_asm = pid_m * BLOCK_M + tl.arange(0, HALF_M)
-        a_sc_offsets = tl.mul(offs_asm[:, None], stride_asm, sanitize_overflow=False) + tl.mul(
-            offs_ks_a[None, :], stride_ask, sanitize_overflow=False)
-        a_sc_offsets = tlx.require_layout(a_sc_offsets, scale_load_a_layout)
-
-    # ---- B scale load offsets: FULL [256,8] in one copy ----
-    offs_ks_b = tl.arange(0, NG)
-    if PRESHUFFLED_SCALES and not MERGED_SCALE_DMA:
-        b_sc_offsets = tlx.require_layout(tl.arange(0, BLOCK_N * NG), scale_load_preshuffled_layout)
-    elif not PRESHUFFLED_SCALES:
-        offs_bsn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-        b_sc_offsets = tl.mul(offs_bsn[:, None], stride_bsn, sanitize_overflow=False) + tl.mul(
-            offs_ks_b[None, :], stride_bsk, sanitize_overflow=False)
-        b_sc_offsets = tlx.require_layout(b_sc_offsets, scale_load_b_layout)
-
-    # Scalar (uniform) base-pointer deltas for the quadrant / K-buffer variants.
+    a_sc_offsets = tlx.require_layout(tl.arange(0, BLOCK_M * NG), scale_load_preshuffled_layout)
+    b_sc_offsets = tlx.require_layout(tl.arange(0, BLOCK_N * NG), scale_load_preshuffled_layout)
     a_half_m = HALF_M * stride_am  # a_top -> a_bot
     b_half_n = HALF_N * stride_bn  # b_left -> b_right
     a_k2 = HALF_K * stride_ak  # even -> odd (_next) K-step
     b_k2 = HALF_K * stride_bk
-    if PRESHUFFLED_SCALES:
-        a_sc_k: tl.constexpr = BLOCK_M * NG
-        b_sc_k: tl.constexpr = BLOCK_N * NG
-    else:
-        a_sc_half_m = HALF_M * stride_asm
-        a_sc_k = NG * stride_ask
-        b_sc_k = NG * stride_bsk
-
-    # Advance every base to this split's K-slice (no-op when SPLIT_K==1). The
-    # A/B tiles are K-packed (KS_PACKED cols) and the scales are per-group
-    # (KS_SCALE groups). All arith bases; buffer_load_to_local materializes the
-    # fat pointer as it already does for the pid_m/pid_n base offsets.
+    a_sc_k: tl.constexpr = BLOCK_M * NG
+    b_sc_k: tl.constexpr = BLOCK_N * NG
     a_base += split_id * KS_PACKED * stride_ak
     b_base += split_id * KS_PACKED * stride_bk
-    if MERGED_SCALE_DMA:
-        pass
-    elif PRESHUFFLED_SCALES:
-        a_scales_ptr += pid_m * SCALE_GROUP_BLOCKS * a_sc_k
-        b_scales_ptr += pid_n * SCALE_GROUP_BLOCKS * b_sc_k
-        a_scales_ptr += split_id * (KS_SCALE // NG) * a_sc_k
-        b_scales_ptr += split_id * (KS_SCALE // NG) * b_sc_k
-    else:
-        a_scales_ptr += split_id * KS_SCALE * stride_ask
-        b_scales_ptr += split_id * KS_SCALE * stride_bsk
-
+    a_scales_ptr += pid_m * SCALE_GROUP_BLOCKS * a_sc_k
+    b_scales_ptr += pid_n * SCALE_GROUP_BLOCKS * b_sc_k
+    a_scales_ptr += split_id * (KS_SCALE // NG) * a_sc_k
+    b_scales_ptr += split_id * (KS_SCALE // NG) * b_sc_k
     acc_tl = tl.zeros((HALF_M, HALF_N), dtype=tl.float32)
     acc_bl = tl.zeros((HALF_M, HALF_N), dtype=tl.float32)
     acc_tr = tl.zeros((HALF_M, HALF_N), dtype=tl.float32)
@@ -441,81 +728,47 @@ def _a4w4_8wave_kernel(
     tl.assume(iter_max > 3)
 
     # ---- Prologue: prefetch K-steps 0,1 into buffers 0,1 (8 commits) ----
-    if MERGED_SCALE_DMA:
-        tlx.buffer_load_to_local(smem_sc[0], a_scales_ptr, scale_offsets)
     tlx.buffer_load_to_local(smem_b_left[0], b_base, b_tile_offsets)
-    if not MERGED_SCALE_DMA:
-        tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
+    tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_top[0], a_base, a_tile_offsets)
-    if PRESHUFFLED_SCALES and not MERGED_SCALE_DMA:
-        tlx.buffer_load_to_local(smem_a_sc[0], a_scales_ptr, a_sc_offsets)
-    elif not PRESHUFFLED_SCALES:
-        tlx.buffer_load_to_local(smem_a_sc_t[0], a_scales_ptr, a_sc_offsets)
+    tlx.buffer_load_to_local(smem_a_sc[0], a_scales_ptr, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_bot[0], a_base + a_half_m, a_tile_offsets)
-    if not PRESHUFFLED_SCALES:
-        tlx.buffer_load_to_local(smem_a_sc_b[0], a_scales_ptr + a_sc_half_m, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_b_right[0], b_base + b_half_n, b_tile_offsets)
     tlx.async_load_commit_group()
 
     tlx.buffer_load_to_local(smem_b_left[1], b_base + b_k2, b_tile_offsets)
-    if not MERGED_SCALE_DMA:
-        tlx.buffer_load_to_local(smem_b_sc[1], b_scales_ptr + b_sc_k, b_sc_offsets)
+    tlx.buffer_load_to_local(smem_b_sc[1], b_scales_ptr + b_sc_k, b_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_top[1], a_base + a_k2, a_tile_offsets)
-    if PRESHUFFLED_SCALES and not MERGED_SCALE_DMA:
-        tlx.buffer_load_to_local(smem_a_sc[1], a_scales_ptr + a_sc_k, a_sc_offsets)
-    elif not PRESHUFFLED_SCALES:
-        tlx.buffer_load_to_local(smem_a_sc_t[1], a_scales_ptr + a_sc_k, a_sc_offsets)
+    tlx.buffer_load_to_local(smem_a_sc[1], a_scales_ptr + a_sc_k, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_a_bot[1], a_base + a_half_m + a_k2, a_tile_offsets)
-    if not PRESHUFFLED_SCALES:
-        tlx.buffer_load_to_local(smem_a_sc_b[1], a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets)
     tlx.async_load_commit_group()
     tlx.buffer_load_to_local(smem_b_right[1], b_base + b_half_n + b_k2, b_tile_offsets)
     tlx.async_load_commit_group()
 
     a_base += a_k2 * 2
     b_base += b_k2 * 2
-    if MERGED_SCALE_DMA:
-        scale_iter_offset = a_sc_k * 2
-    else:
-        a_scales_ptr += a_sc_k * 2
-        b_scales_ptr += b_sc_k * 2
+    a_scales_ptr += a_sc_k * 2
+    b_scales_ptr += b_sc_k * 2
 
     tlx.async_load_wait_group(6)
     b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
     a_top = tlx.local_load(smem_a_top[0], relaxed=True)
-    if PRESHUFFLED_SCALES:
-        if MERGED_SCALE_DMA:
-            b_sc_view_init = tlx.local_slice(
-                smem_sc_b_view, [1, 0, 0], [1, BLOCK_N, NG])
-            a_sc_view_init = tlx.local_slice(
-                smem_sc_a_view, [0, 0, 0], [1, BLOCK_M, NG])
-            a_sc_comb = tlx.local_load(a_sc_view_init, layout=scale_a_comb_layout, relaxed=True)
-            a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
-            a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
-            a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
-        else:
-            a_sc_view_init = tlx.local_reshape(smem_a_sc[0], preshuffled_scale_shape)
-            a_sc_view_init = tlx.local_trans(a_sc_view_init, preshuffled_a_to_logical)
-            a_sc_view_init = tlx.local_reshape(a_sc_view_init, [BLOCK_M, NG])
-            a_sc_comb = tlx.local_load(a_sc_view_init, layout=scale_a_comb_layout, relaxed=True)
-            a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
-            a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
-            a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
-    else:
-        a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
-    if PRESHUFFLED_SCALES:
-        if not MERGED_SCALE_DMA:
-            b_sc_view_init = tlx.local_reshape(smem_b_sc[0], preshuffled_scale_shape)
-            b_sc_view_init = tlx.local_trans(b_sc_view_init, preshuffled_b_to_logical)
-            b_sc_view_init = tlx.local_reshape(b_sc_view_init, [BLOCK_N, NG])
-        b_sc_comb = tlx.local_load(b_sc_view_init, layout=scale_b_comb_layout, relaxed=True)
-    else:
-        b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
+    a_sc_view_init = tlx.local_reshape(smem_a_sc[0], preshuffled_scale_shape)
+    a_sc_view_init = tlx.local_trans(a_sc_view_init, preshuffled_a_to_logical)
+    a_sc_view_init = tlx.local_reshape(a_sc_view_init, [BLOCK_M, NG])
+    a_sc_comb = tlx.local_load(a_sc_view_init, layout=scale_a_comb_layout, relaxed=True)
+    a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+    a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+    a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
+    b_sc_view_init = tlx.local_reshape(smem_b_sc[0], preshuffled_scale_shape)
+    b_sc_view_init = tlx.local_trans(b_sc_view_init, preshuffled_b_to_logical)
+    b_sc_view_init = tlx.local_reshape(b_sc_view_init, [BLOCK_N, NG])
+    b_sc_comb = tlx.local_load(b_sc_view_init, layout=scale_b_comb_layout, relaxed=True)
     b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
     b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
     b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
@@ -528,14 +781,10 @@ def _a4w4_8wave_kernel(
             acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_bot = tlx.local_load(smem_a_bot[0], relaxed=True)
-            if PRESHUFFLED_SCALES:
-                a_sc_bot = a_sc_bot0
-            else:
-                a_sc_bot = tlx.local_load(smem_a_sc_b[0], layout=scale_a_layout)
+            a_sc_bot = a_sc_bot0
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_b_left[0], b_base, b_tile_offsets)
-            if not MERGED_SCALE_DMA:
-                tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
+            tlx.buffer_load_to_local(smem_b_sc[0], b_scales_ptr, b_sc_offsets)
             tlx.async_load_commit_group()
 
         tlx.async_load_wait_group(5)
@@ -545,10 +794,7 @@ def _a4w4_8wave_kernel(
             b_right = tlx.local_load(tlx.local_trans(smem_b_right[0]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_top[0], a_base, a_tile_offsets)
-            if PRESHUFFLED_SCALES and not MERGED_SCALE_DMA:
-                tlx.buffer_load_to_local(smem_a_sc[0], a_scales_ptr, a_sc_offsets)
-            elif not PRESHUFFLED_SCALES:
-                tlx.buffer_load_to_local(smem_a_sc_t[0], a_scales_ptr, a_sc_offsets)
+            tlx.buffer_load_to_local(smem_a_sc[0], a_scales_ptr, a_sc_offsets)
             tlx.async_load_commit_group()
 
         tlx.async_load_wait_group(5)
@@ -558,8 +804,6 @@ def _a4w4_8wave_kernel(
             b_left = tlx.local_load(tlx.local_trans(smem_b_left[1]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_bot[0], a_base + a_half_m, a_tile_offsets)
-            if not PRESHUFFLED_SCALES:
-                tlx.buffer_load_to_local(smem_a_sc_b[0], a_scales_ptr + a_sc_half_m, a_sc_offsets)
             tlx.async_load_commit_group()
 
         tlx.async_load_wait_group(5)
@@ -567,43 +811,22 @@ def _a4w4_8wave_kernel(
             acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_top = tlx.local_load(smem_a_top[1], relaxed=True)
-            if PRESHUFFLED_SCALES:
-                if MERGED_SCALE_DMA:
-                    a_sc_view_1 = tlx.local_slice(
-                        smem_sc_a_view, [1, 0, 0], [1, BLOCK_M, NG])
-                    b_sc_view_1 = tlx.local_slice(
-                        smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
-                else:
-                    a_sc_view_1 = tlx.local_reshape(smem_a_sc[1], preshuffled_scale_shape)
-                    a_sc_view_1 = tlx.local_trans(a_sc_view_1, preshuffled_a_to_logical)
-                    a_sc_view_1 = tlx.local_reshape(a_sc_view_1, [BLOCK_M, NG])
-                if MERGED_SCALE_DMA:
-                    a_sc_comb = tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True)
-                    a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
-                    a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
-                    a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
-                else:
-                    a_sc_comb = tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True)
-                    a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
-                    a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
-                    a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
-            else:
-                a_sc_top = tlx.local_load(smem_a_sc_t[1], layout=scale_a_layout)
-            if PRESHUFFLED_SCALES:
-                if not MERGED_SCALE_DMA:
-                    b_sc_view_1 = tlx.local_reshape(smem_b_sc[1], preshuffled_scale_shape)
-                    b_sc_view_1 = tlx.local_trans(b_sc_view_1, preshuffled_b_to_logical)
-                    b_sc_view_1 = tlx.local_reshape(b_sc_view_1, [BLOCK_N, NG])
-                b_sc_comb = tlx.local_load(b_sc_view_1, layout=scale_b_comb_layout, relaxed=True)
-            else:
-                b_sc_comb = tlx.local_load(smem_b_sc[1], layout=scale_b_comb_layout)
+            a_sc_view_1 = tlx.local_reshape(smem_a_sc[1], preshuffled_scale_shape)
+            a_sc_view_1 = tlx.local_trans(a_sc_view_1, preshuffled_a_to_logical)
+            a_sc_view_1 = tlx.local_reshape(a_sc_view_1, [BLOCK_M, NG])
+            a_sc_comb = tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True)
+            a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+            a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+            a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
+            b_sc_view_1 = tlx.local_reshape(smem_b_sc[1], preshuffled_scale_shape)
+            b_sc_view_1 = tlx.local_trans(b_sc_view_1, preshuffled_b_to_logical)
+            b_sc_view_1 = tlx.local_reshape(b_sc_view_1, [BLOCK_N, NG])
+            b_sc_comb = tlx.local_load(b_sc_view_1, layout=scale_b_comb_layout, relaxed=True)
             b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
             b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
             b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_b_right[0], b_base + b_half_n, b_tile_offsets)
-            if MERGED_SCALE_DMA:
-                tlx.buffer_load_to_local(smem_sc[0], a_scales_ptr, scale_offsets + scale_iter_offset)
             tlx.async_load_commit_group()
 
         # --- sub-iter 1 (buffer 1, base + one K-step) ---
@@ -612,14 +835,10 @@ def _a4w4_8wave_kernel(
             acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_bot = tlx.local_load(smem_a_bot[1], relaxed=True)
-            if PRESHUFFLED_SCALES:
-                a_sc_bot = a_sc_bot1
-            else:
-                a_sc_bot = tlx.local_load(smem_a_sc_b[1], layout=scale_a_layout)
+            a_sc_bot = a_sc_bot1
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_b_left[1], b_base + b_k2, b_tile_offsets)
-            if not MERGED_SCALE_DMA:
-                tlx.buffer_load_to_local(smem_b_sc[1], b_scales_ptr + b_sc_k, b_sc_offsets)
+            tlx.buffer_load_to_local(smem_b_sc[1], b_scales_ptr + b_sc_k, b_sc_offsets)
             tlx.async_load_commit_group()
 
         tlx.async_load_wait_group(5)
@@ -629,10 +848,7 @@ def _a4w4_8wave_kernel(
             b_right = tlx.local_load(tlx.local_trans(smem_b_right[1]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_top[1], a_base + a_k2, a_tile_offsets)
-            if PRESHUFFLED_SCALES and not MERGED_SCALE_DMA:
-                tlx.buffer_load_to_local(smem_a_sc[1], a_scales_ptr + a_sc_k, a_sc_offsets)
-            elif not PRESHUFFLED_SCALES:
-                tlx.buffer_load_to_local(smem_a_sc_t[1], a_scales_ptr + a_sc_k, a_sc_offsets)
+            tlx.buffer_load_to_local(smem_a_sc[1], a_scales_ptr + a_sc_k, a_sc_offsets)
             tlx.async_load_commit_group()
 
         tlx.async_load_wait_group(5)
@@ -642,8 +858,6 @@ def _a4w4_8wave_kernel(
             b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
             tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
             tlx.buffer_load_to_local(smem_a_bot[1], a_base + a_half_m + a_k2, a_tile_offsets)
-            if not PRESHUFFLED_SCALES:
-                tlx.buffer_load_to_local(smem_a_sc_b[1], a_scales_ptr + a_sc_half_m + a_sc_k, a_sc_offsets)
             tlx.async_load_commit_group()
 
         tlx.async_load_wait_group(5)
@@ -651,36 +865,17 @@ def _a4w4_8wave_kernel(
             acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_top = tlx.local_load(smem_a_top[0], relaxed=True)
-            if PRESHUFFLED_SCALES:
-                if MERGED_SCALE_DMA:
-                    a_sc_view_0 = tlx.local_slice(
-                        smem_sc_a_view, [0, 0, 0], [1, BLOCK_M, NG])
-                    b_sc_view_0 = tlx.local_slice(
-                        smem_sc_b_view, [1, 0, 0], [1, BLOCK_N, NG])
-                else:
-                    a_sc_view_0 = tlx.local_reshape(smem_a_sc[0], preshuffled_scale_shape)
-                    a_sc_view_0 = tlx.local_trans(a_sc_view_0, preshuffled_a_to_logical)
-                    a_sc_view_0 = tlx.local_reshape(a_sc_view_0, [BLOCK_M, NG])
-                if MERGED_SCALE_DMA:
-                    a_sc_comb = tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True)
-                    a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
-                    a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
-                    a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
-                else:
-                    a_sc_comb = tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True)
-                    a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
-                    a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
-                    a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
-            else:
-                a_sc_top = tlx.local_load(smem_a_sc_t[0], layout=scale_a_layout)
-            if PRESHUFFLED_SCALES:
-                if not MERGED_SCALE_DMA:
-                    b_sc_view_0 = tlx.local_reshape(smem_b_sc[0], preshuffled_scale_shape)
-                    b_sc_view_0 = tlx.local_trans(b_sc_view_0, preshuffled_b_to_logical)
-                    b_sc_view_0 = tlx.local_reshape(b_sc_view_0, [BLOCK_N, NG])
-                b_sc_comb = tlx.local_load(b_sc_view_0, layout=scale_b_comb_layout, relaxed=True)
-            else:
-                b_sc_comb = tlx.local_load(smem_b_sc[0], layout=scale_b_comb_layout)
+            a_sc_view_0 = tlx.local_reshape(smem_a_sc[0], preshuffled_scale_shape)
+            a_sc_view_0 = tlx.local_trans(a_sc_view_0, preshuffled_a_to_logical)
+            a_sc_view_0 = tlx.local_reshape(a_sc_view_0, [BLOCK_M, NG])
+            a_sc_comb = tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True)
+            a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+            a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+            a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
+            b_sc_view_0 = tlx.local_reshape(smem_b_sc[0], preshuffled_scale_shape)
+            b_sc_view_0 = tlx.local_trans(b_sc_view_0, preshuffled_b_to_logical)
+            b_sc_view_0 = tlx.local_reshape(b_sc_view_0, [BLOCK_N, NG])
+            b_sc_comb = tlx.local_load(b_sc_view_0, layout=scale_b_comb_layout, relaxed=True)
             b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
             b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
             b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
@@ -689,11 +884,8 @@ def _a4w4_8wave_kernel(
             tlx.async_load_commit_group()
             a_base += a_k2 * 2
             b_base += b_k2 * 2
-            if MERGED_SCALE_DMA:
-                scale_iter_offset += a_sc_k * 2
-            else:
-                a_scales_ptr += a_sc_k * 2
-                b_scales_ptr += b_sc_k * 2
+            a_scales_ptr += a_sc_k * 2
+            b_scales_ptr += b_sc_k * 2
 
     # ---- Epilogue: last 2 K-steps, drain, 4-quadrant store ----
     # iter iter_max-2 (b_sc_left/right for this step were prefetched at loop tail)
@@ -701,11 +893,7 @@ def _a4w4_8wave_kernel(
     tlx.async_load_wait_group(5)
     l_idx: tl.constexpr = 0  # (iter_max - 2) % 2, always 0 (iter_max even)
     a_bot = tlx.local_load(tlx.local_view(smem_a_bot, l_idx), relaxed=True)
-    if PRESHUFFLED_SCALES:
-        a_sc_bot = a_sc_bot0
-    else:
-        a_sc_bot = tlx.local_load(smem_a_sc_b[l_idx], layout=scale_a_layout)
-
+    a_sc_bot = a_sc_bot0
     acc_bl = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_left, b_sc_left, "e2m1", acc_bl)
     tlx.async_load_wait_group(4)
     b_right = tlx.local_load(tlx.local_trans(tlx.local_view(smem_b_right, l_idx)), relaxed=True)
@@ -718,36 +906,17 @@ def _a4w4_8wave_kernel(
     acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
     tlx.async_load_wait_group(2)
     a_top = tlx.local_load(tlx.local_view(smem_a_top, g_idx), relaxed=True)
-    if PRESHUFFLED_SCALES:
-        if MERGED_SCALE_DMA:
-            a_sc_view_epilogue = tlx.local_slice(
-                smem_sc_a_view, [1, 0, 0], [1, BLOCK_M, NG])
-            b_sc_view_epilogue = tlx.local_slice(
-                smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
-        else:
-            a_sc_view_epilogue = tlx.local_reshape(smem_a_sc[g_idx], preshuffled_scale_shape)
-            a_sc_view_epilogue = tlx.local_trans(a_sc_view_epilogue, preshuffled_a_to_logical)
-            a_sc_view_epilogue = tlx.local_reshape(a_sc_view_epilogue, [BLOCK_M, NG])
-        if MERGED_SCALE_DMA:
-            a_sc_comb = tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True)
-            a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
-            a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
-            a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
-        else:
-            a_sc_comb = tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True)
-            a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
-            a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
-            a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
-    else:
-        a_sc_top = tlx.local_load(smem_a_sc_t[g_idx], layout=scale_a_layout)
-    if PRESHUFFLED_SCALES:
-        if not MERGED_SCALE_DMA:
-            b_sc_view_epilogue = tlx.local_reshape(smem_b_sc[g_idx], preshuffled_scale_shape)
-            b_sc_view_epilogue = tlx.local_trans(b_sc_view_epilogue, preshuffled_b_to_logical)
-            b_sc_view_epilogue = tlx.local_reshape(b_sc_view_epilogue, [BLOCK_N, NG])
-        b_sc_comb = tlx.local_load(b_sc_view_epilogue, layout=scale_b_comb_layout, relaxed=True)
-    else:
-        b_sc_comb = tlx.local_load(smem_b_sc[g_idx], layout=scale_b_comb_layout)
+    a_sc_view_epilogue = tlx.local_reshape(smem_a_sc[g_idx], preshuffled_scale_shape)
+    a_sc_view_epilogue = tlx.local_trans(a_sc_view_epilogue, preshuffled_a_to_logical)
+    a_sc_view_epilogue = tlx.local_reshape(a_sc_view_epilogue, [BLOCK_M, NG])
+    a_sc_comb = tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True)
+    a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+    a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+    a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
+    b_sc_view_epilogue = tlx.local_reshape(smem_b_sc[g_idx], preshuffled_scale_shape)
+    b_sc_view_epilogue = tlx.local_trans(b_sc_view_epilogue, preshuffled_b_to_logical)
+    b_sc_view_epilogue = tlx.local_reshape(b_sc_view_epilogue, [BLOCK_N, NG])
+    b_sc_comb = tlx.local_load(b_sc_view_epilogue, layout=scale_b_comb_layout, relaxed=True)
     b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
     b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
     b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
@@ -756,11 +925,7 @@ def _a4w4_8wave_kernel(
     acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
     tlx.async_load_wait_group(1)
     a_bot = tlx.local_load(tlx.local_view(smem_a_bot, g_idx), relaxed=True)
-    if PRESHUFFLED_SCALES:
-        a_sc_bot = a_sc_bot1
-    else:
-        a_sc_bot = tlx.local_load(smem_a_sc_b[g_idx], layout=scale_a_layout)
-
+    a_sc_bot = a_sc_bot1
     acc_bl = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_left, b_sc_left, "e2m1", acc_bl)
     tlx.async_load_wait_group(0)
     b_right = tlx.local_load(tlx.local_trans(tlx.local_view(smem_b_right, g_idx)), relaxed=True)
@@ -843,38 +1008,427 @@ def _a4w4_8wave_merged_scales_kernel(
     GRID_MN: tl.constexpr,
     SPLIT_K: tl.constexpr,
 ):
-    """Distinct one-scale-pointer ABI for the merged 16-byte DMA experiment."""
-    _a4w4_8wave_kernel(
-        a_ptr,
-        b_ptr,
-        c_ptr,
-        workspace_ptr,
-        scales_ptr,
-        scales_ptr,
-        M,
-        N,
-        K,
-        K_TILES,
-        stride_am,
-        stride_ak,
-        stride_bn,
-        stride_bk,
-        stride_cm,
-        stride_cn,
-        0,
-        0,
-        0,
-        0,
-        BLOCK_M=BLOCK_M,
-        BLOCK_N=BLOCK_N,
-        BLOCK_K=BLOCK_K,
-        GROUP_SIZE_M=GROUP_SIZE_M,
-        NUM_XCDS=NUM_XCDS,
-        GRID_MN=GRID_MN,
-        SPLIT_K=SPLIT_K,
-        PRESHUFFLED_SCALES=True,
-        MERGED_SCALE_DMA=True,
+    """Merged one-scale-pointer kernel with a 16-byte scale DMA."""
+    SCALE_GROUP_SIZE: tl.constexpr = 32
+    HALF_M: tl.constexpr = BLOCK_M // 2  # 128
+    HALF_N: tl.constexpr = BLOCK_N // 2  # 128
+    HALF_K: tl.constexpr = BLOCK_K // 2  # 128 (packed fp4)
+    NG: tl.constexpr = BLOCK_K // SCALE_GROUP_SIZE  # 8 scale groups along K
+    # Split-K: each program owns a contiguous K-slice of length KS (== K when
+    # SPLIT_K==1). KS is constexpr, so every derived offset stays constexpr and
+    # keeps its divisibility (no #linear -> #blocked collapse).
+    KS: tl.constexpr = K // SPLIT_K
+    KS_PACKED: tl.constexpr = KS // 2  # packed fp4 columns per split
+    KS_SCALE: tl.constexpr = KS // SCALE_GROUP_SIZE  # scale groups per split
+    SCALE_GROUP_BLOCKS: tl.constexpr = K // BLOCK_K
+
+    # ---- fp4 tile global-load register layout (#linear, [128,128]) ----
+    g_load_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2, 2)),
+        stride=((16, 32, 64, 128, 4096, 8192, 256, 512, 1024), (1, 2, 4, 8, 2048)),
     )
+    # ---- padded shared tile layout ([128,128] fp4, pad 32 @ 1024) ----
+    shared_tile: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [[1024, 32]],
+        [
+            [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64],
+            [1, 0], [32, 0], [64, 0], [2, 0], [4, 0], [8, 0], [16, 0],
+        ],
+        [HALF_M, HALF_K],
+    )
+    # The combined A view assigns the four register-value bits to the low four
+    # physical address bits, so one aligned ds_read_b128 produces both 128-row
+    # MFMA scale fragments.  Address bits 4..6 are lane bits 0..2, which gives
+    # each dword phase all 32 LDS banks; the remaining lane and warp ownership
+    # bits select higher 128-byte regions.
+    # The merged layouts add the K-tile selector around the combined A map.
+    # Physical bit 11 is the 2048-byte A/B section selector, so it is unused by
+    # the A view; physical bit 12 selects the second K tile.
+    shared_merged_a_scales_combined: tl.constexpr = tlx.shared_linear_layout_encoding(
+        offset_bases=[
+            [0, 0, 4], [0, 32, 0], [0, 64, 0], [0, 128, 0],
+            [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0],
+            [0, 16, 0], [0, 0, 1], [0, 0, 2], [0, 0, 0], [1, 0, 0],
+        ],
+        block_bases=[],
+        alignment=16,
+    )
+    # The merged B layout adds section and K-tile selector bits around its
+    # canonical map so the full raw allocation can be reinterpreted before
+    # slicing.
+    shared_merged_b_scales: tl.constexpr = tlx.shared_linear_layout_encoding(
+        offset_bases=[
+            [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0],
+            [0, 32, 0], [0, 64, 0], [0, 128, 0], [0, 16, 1], [0, 0, 2],
+            [0, 32, 4], [1, 0, 0], [2, 0, 0],
+        ],
+        block_bases=[],
+        alignment=16,
+    )
+    # The merged DMA writes one raw byte-linear 8192-byte A+B image.
+    shared_scale_merged: tl.constexpr = tlx.shared_linear_layout_encoding(
+        offset_bases=[
+            [1], [2], [4], [8], [16], [32], [64], [128], [256], [512], [1024], [2048], [4096],
+        ],
+        block_bases=[],
+        alignment=16,
+    )
+    # One 16-byte vector per thread stages two adjacent A+B scale images.  The
+    # high warp bit selects the second K tile, so all eight waves contribute to
+    # one full-workgroup 8192-byte DMA.
+    scale_load_merged_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2)),
+        stride=((16, 32, 64, 128, 256, 512, 1024, 2048, 4096), (1, 2, 4, 8)),
+    )
+    # ---- MFMA scale register layouts (get_mfma_scale_layout) ----
+    scale_a_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2)),
+        stride=((8, 16, 32, 64, 1, 2, 0, 0, 128), (4, 256, 512)),
+    )
+    scale_a_comb_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2)),
+        stride=((8, 16, 32, 64, 1, 2, 0, 0, 128), (4, 256, 512, 1024)),
+    )
+    scale_b_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2)),
+        stride=((8, 16, 32, 64, 1, 2, 128, 256, 0), (4, 512)),
+    )
+    scale_b_comb_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2)),
+        stride=((8, 16, 32, 64, 1, 2, 128, 256, 0), (4, 512, 1024)),
+    )
+    # ---- MFMA accumulator layout (#mma 16x16x128 [2,4], one [128,128] quadrant) ----
+    accumulator_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2, 2)),
+        stride=((128, 256, 512, 1024, 4, 8, 16, 32, 2048), (1, 2, 64, 4096, 8192)),
+    )
+    # ---- store layout (#blocked2, [128,128] bf16 quadrant) ----
+    store_layout_c: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2, 2)),
+        stride=((8, 16, 32, 64, 128, 256, 512, 1024, 2048), (1, 2, 4, 4096, 8192)),
+    )
+
+    # Grid is GRID_MN * SPLIT_K; peel the split id, keep the MN pid for the
+    # XCD / GROUP_SIZE_M remap below.
+    split_id = tl.program_id(0) // GRID_MN
+    pid = tl.program_id(0) % GRID_MN
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+
+    if NUM_XCDS != 1:
+        pids_per_xcd = (GRID_MN + NUM_XCDS - 1) // NUM_XCDS
+        tall_xcds = GRID_MN % NUM_XCDS
+        tall_xcds = NUM_XCDS if tall_xcds == 0 else tall_xcds
+        xcd = pid % NUM_XCDS
+        local_pid = pid // NUM_XCDS
+        if xcd < tall_xcds:
+            pid = xcd * pids_per_xcd + local_pid
+        else:
+            pid = tall_xcds * pids_per_xcd + (xcd - tall_xcds) * (pids_per_xcd - 1) + local_pid
+
+    if GROUP_SIZE_M == 1:
+        pid_m = pid // num_pid_n
+        pid_n = pid % num_pid_n
+    else:
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        tl.assume(group_size_m > 0)
+        pid_m = first_pid_m + (pid % num_pid_in_group) % group_size_m
+        pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # Four double-buffered operand half-tiles plus one 8192-byte scale image for
+    # the two K tiles consumed by an unrolled iteration. It is refilled after
+    # both scale halves have been read, so it needs no second scale buffer.
+    smem_a_top = tlx.local_alloc((HALF_M, HALF_K), tlx.dtype_of(a_ptr), 2, layout=shared_tile)
+    smem_a_bot = tlx.local_alloc((HALF_M, HALF_K), tlx.dtype_of(a_ptr), 2, layout=shared_tile)
+    smem_b_left = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
+    smem_b_right = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
+    smem_sc = tlx.local_alloc(
+        (2 * (BLOCK_M + BLOCK_N) * NG, ), tlx.dtype_of(scales_ptr), 1, layout=shared_scale_merged)
+    smem_sc_a_view = tlx.local_reinterpret(
+        smem_sc[0], tl.uint8, [2, BLOCK_M, NG], layout=shared_merged_a_scales_combined)
+    smem_sc_b_view = tlx.local_reinterpret(
+        smem_sc[0], tl.uint8, [4, BLOCK_N, NG], layout=shared_merged_b_scales)
+    offs_am = tl.arange(0, HALF_M)
+    offs_ak = tl.arange(0, HALF_K)
+    a_tile_offsets = tlx.require_layout(offs_am[:, None] * stride_am + offs_ak[None, :] * stride_ak, g_load_layout)
+    a_base = a_ptr + pid_m * BLOCK_M * stride_am
+
+    offs_bn = tl.arange(0, HALF_N)
+    offs_bk = tl.arange(0, HALF_K)
+    b_tile_offsets = tlx.require_layout(offs_bn[:, None] * stride_bn + offs_bk[None, :] * stride_bk, g_load_layout)
+    b_base = b_ptr + pid_n * BLOCK_N * stride_bn
+
+    # ---- Scale load offsets ----
+    scale_physical_offsets = tl.arange(0, 2 * (BLOCK_M + BLOCK_N) * NG)
+    scale_k_tile = scale_physical_offsets // ((BLOCK_M + BLOCK_N) * NG)
+    scale_in_tile = scale_physical_offsets % ((BLOCK_M + BLOCK_N) * NG)
+    a_scale_tile_base = pid_m * SCALE_GROUP_BLOCKS * BLOCK_M * NG
+    b_scale_tile_base = num_pid_m * SCALE_GROUP_BLOCKS * BLOCK_M * NG
+    b_scale_tile_base += pid_n * SCALE_GROUP_BLOCKS * BLOCK_N * NG
+    split_scale_base = split_id * (KS_SCALE // NG) * BLOCK_M * NG
+    a_scale_tile_base += split_scale_base
+    b_scale_tile_base += split_scale_base
+    scale_offsets = tl.where(
+        scale_in_tile < BLOCK_M * NG,
+        a_scale_tile_base + scale_k_tile * BLOCK_M * NG + scale_in_tile,
+        b_scale_tile_base + scale_k_tile * BLOCK_N * NG + scale_in_tile - BLOCK_M * NG,
+    )
+    scale_offsets = tlx.require_layout(scale_offsets, scale_load_merged_layout)
+    a_half_m = HALF_M * stride_am  # a_top -> a_bot
+    b_half_n = HALF_N * stride_bn  # b_left -> b_right
+    a_k2 = HALF_K * stride_ak  # even -> odd (_next) K-step
+    b_k2 = HALF_K * stride_bk
+    a_sc_k: tl.constexpr = BLOCK_M * NG
+    a_base += split_id * KS_PACKED * stride_ak
+    b_base += split_id * KS_PACKED * stride_bk
+    acc_tl = tl.zeros((HALF_M, HALF_N), dtype=tl.float32)
+    acc_bl = tl.zeros((HALF_M, HALF_N), dtype=tl.float32)
+    acc_tr = tl.zeros((HALF_M, HALF_N), dtype=tl.float32)
+    acc_br = tl.zeros((HALF_M, HALF_N), dtype=tl.float32)
+
+    # _matmul_256tile derives this trusted runtime value from the asserted KS.
+    # The assumption keeps range/liveness analysis as precise as the old
+    # constexpr bound while preserving the one-trip scf.for at K=1024.
+    iter_max = K_TILES
+    tl.assume(iter_max > 3)
+
+    # ---- Prologue: prefetch K-steps 0,1 into buffers 0,1 (8 commits) ----
+    tlx.buffer_load_to_local(smem_sc[0], scales_ptr, scale_offsets)
+    tlx.buffer_load_to_local(smem_b_left[0], b_base, b_tile_offsets)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_a_top[0], a_base, a_tile_offsets)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_a_bot[0], a_base + a_half_m, a_tile_offsets)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_b_right[0], b_base + b_half_n, b_tile_offsets)
+    tlx.async_load_commit_group()
+
+    tlx.buffer_load_to_local(smem_b_left[1], b_base + b_k2, b_tile_offsets)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_a_top[1], a_base + a_k2, a_tile_offsets)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_a_bot[1], a_base + a_half_m + a_k2, a_tile_offsets)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_b_right[1], b_base + b_half_n + b_k2, b_tile_offsets)
+    tlx.async_load_commit_group()
+
+    a_base += a_k2 * 2
+    b_base += b_k2 * 2
+    scale_iter_offset = a_sc_k * 2
+    tlx.async_load_wait_group(6)
+    b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
+    a_top = tlx.local_load(smem_a_top[0], relaxed=True)
+    b_sc_view_init = tlx.local_slice(
+        smem_sc_b_view, [1, 0, 0], [1, BLOCK_N, NG])
+    a_sc_view_init = tlx.local_slice(
+        smem_sc_a_view, [0, 0, 0], [1, BLOCK_M, NG])
+    a_sc_comb = tlx.local_load(a_sc_view_init, layout=scale_a_comb_layout, relaxed=True)
+    a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+    a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+    a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
+    b_sc_comb = tlx.local_load(b_sc_view_init, layout=scale_b_comb_layout, relaxed=True)
+    b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
+    b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
+    b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
+
+    # ---- Main loop (2x unrolled): 8 (mfma + mem) regions ----
+    for k in tl.range(0, iter_max - 2, 2, num_stages=1):
+        # --- sub-iter 0 (buffer 0) ---
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_bot = tlx.local_load(smem_a_bot[0], relaxed=True)
+            a_sc_bot = a_sc_bot0
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_b_left[0], b_base, b_tile_offsets)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_bl = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_left, b_sc_left, "e2m1", acc_bl)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            b_right = tlx.local_load(tlx.local_trans(smem_b_right[0]), relaxed=True)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_a_top[0], a_base, a_tile_offsets)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_tr = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_right, b_sc_right, "e2m1", acc_tr)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            b_left = tlx.local_load(tlx.local_trans(smem_b_left[1]), relaxed=True)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_a_bot[0], a_base + a_half_m, a_tile_offsets)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_top = tlx.local_load(smem_a_top[1], relaxed=True)
+            a_sc_view_1 = tlx.local_slice(
+                smem_sc_a_view, [1, 0, 0], [1, BLOCK_M, NG])
+            b_sc_view_1 = tlx.local_slice(
+                smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
+            a_sc_comb = tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True)
+            a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+            a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+            a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
+            b_sc_comb = tlx.local_load(b_sc_view_1, layout=scale_b_comb_layout, relaxed=True)
+            b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
+            b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
+            b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_b_right[0], b_base + b_half_n, b_tile_offsets)
+            tlx.buffer_load_to_local(smem_sc[0], scales_ptr, scale_offsets + scale_iter_offset)
+            tlx.async_load_commit_group()
+
+        # --- sub-iter 1 (buffer 1, base + one K-step) ---
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_bot = tlx.local_load(smem_a_bot[1], relaxed=True)
+            a_sc_bot = a_sc_bot1
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_b_left[1], b_base + b_k2, b_tile_offsets)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_bl = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_left, b_sc_left, "e2m1", acc_bl)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            b_right = tlx.local_load(tlx.local_trans(smem_b_right[1]), relaxed=True)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_a_top[1], a_base + a_k2, a_tile_offsets)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_tr = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_right, b_sc_right, "e2m1", acc_tr)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_a_bot[1], a_base + a_half_m + a_k2, a_tile_offsets)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_top = tlx.local_load(smem_a_top[0], relaxed=True)
+            a_sc_view_0 = tlx.local_slice(
+                smem_sc_a_view, [0, 0, 0], [1, BLOCK_M, NG])
+            b_sc_view_0 = tlx.local_slice(
+                smem_sc_b_view, [1, 0, 0], [1, BLOCK_N, NG])
+            a_sc_comb = tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True)
+            a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+            a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+            a_sc_bot0 = tlx.require_layout(a_sc_b, scale_a_layout)
+            b_sc_comb = tlx.local_load(b_sc_view_0, layout=scale_b_comb_layout, relaxed=True)
+            b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
+            b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
+            b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
+            tlx.amd_sched_barrier(0)  # keep ds_read(local_load) ahead of the global loads
+            tlx.buffer_load_to_local(smem_b_right[1], b_base + b_half_n + b_k2, b_tile_offsets)
+            tlx.async_load_commit_group()
+            a_base += a_k2 * 2
+            b_base += b_k2 * 2
+            scale_iter_offset += a_sc_k * 2
+    acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
+    tlx.async_load_wait_group(5)
+    l_idx: tl.constexpr = 0  # (iter_max - 2) % 2, always 0 (iter_max even)
+    a_bot = tlx.local_load(tlx.local_view(smem_a_bot, l_idx), relaxed=True)
+    a_sc_bot = a_sc_bot0
+    acc_bl = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_left, b_sc_left, "e2m1", acc_bl)
+    tlx.async_load_wait_group(4)
+    b_right = tlx.local_load(tlx.local_trans(tlx.local_view(smem_b_right, l_idx)), relaxed=True)
+
+    acc_tr = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_right, b_sc_right, "e2m1", acc_tr)
+    tlx.async_load_wait_group(3)
+    g_idx: tl.constexpr = 1  # 1 - l_idx
+    b_left = tlx.local_load(tlx.local_trans(tlx.local_view(smem_b_left, g_idx)), relaxed=True)
+
+    acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
+    tlx.async_load_wait_group(2)
+    a_top = tlx.local_load(tlx.local_view(smem_a_top, g_idx), relaxed=True)
+    a_sc_view_epilogue = tlx.local_slice(
+        smem_sc_a_view, [1, 0, 0], [1, BLOCK_M, NG])
+    b_sc_view_epilogue = tlx.local_slice(
+        smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
+    a_sc_comb = tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True)
+    a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
+    a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
+    a_sc_bot1 = tlx.require_layout(a_sc_b, scale_a_layout)
+    b_sc_comb = tlx.local_load(b_sc_view_epilogue, layout=scale_b_comb_layout, relaxed=True)
+    b_sc_l, b_sc_r = tl.split(tl.trans(tl.reshape(b_sc_comb, 2, HALF_N, NG), 1, 2, 0))
+    b_sc_left = tlx.require_layout(b_sc_l, scale_b_layout)
+    b_sc_right = tlx.require_layout(b_sc_r, scale_b_layout)
+
+    # iter iter_max-1: finish ALL four accumulators, then convert + store.
+    acc_tl = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_left, b_sc_left, "e2m1", acc_tl)
+    tlx.async_load_wait_group(1)
+    a_bot = tlx.local_load(tlx.local_view(smem_a_bot, g_idx), relaxed=True)
+    a_sc_bot = a_sc_bot1
+    acc_bl = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_left, b_sc_left, "e2m1", acc_bl)
+    tlx.async_load_wait_group(0)
+    b_right = tlx.local_load(tlx.local_trans(tlx.local_view(smem_b_right, g_idx)), relaxed=True)
+
+    acc_tr = tl.dot_scaled(a_top, a_sc_top, "e2m1", b_right, b_sc_right, "e2m1", acc_tr)
+    acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
+
+    # ---- 4-quadrant store ----
+    if SPLIT_K == 1:
+        # Direct coalesced store to C (bf16). c_quad_offsets is shared by all four
+        # quadrants (same relative layout, different base).
+        offs_cm = tl.arange(0, HALF_M)
+        offs_cn = tl.arange(0, HALF_N)
+        c_quad_offsets = tl.mul(stride_cm, offs_cm[:, None], sanitize_overflow=False) + tl.mul(
+            stride_cn, offs_cn[None, :], sanitize_overflow=False)
+        c_quad_offsets = tlx.require_layout(c_quad_offsets, store_layout_c)
+        c_tl_base = c_ptr + pid_m * BLOCK_M * stride_cm + pid_n * BLOCK_N * stride_cn
+        c_bl_base = c_tl_base + HALF_M * stride_cm
+        c_tr_base = c_tl_base + HALF_N * stride_cn
+        c_br_base = c_bl_base + HALF_N * stride_cn
+
+        # require(accumulator) -> cast -> require(store): freeze the MFMA register
+        # distribution, cast bf16 register-local in it, then require the coalesced
+        # store layout. The compiler narrows before redistributing (no explicit
+        # release_layout needed).
+        et = c_ptr.dtype.element_ty
+        acc_tl = tlx.require_layout(acc_tl, accumulator_layout)
+        c_tl = tlx.require_layout(acc_tl.to(et), store_layout_c)
+        tlx.buffer_store(c_tl, c_tl_base, c_quad_offsets)
+
+        acc_bl = tlx.require_layout(acc_bl, accumulator_layout)
+        c_bl = tlx.require_layout(acc_bl.to(et), store_layout_c)
+        tlx.buffer_store(c_bl, c_bl_base, c_quad_offsets)
+
+        acc_tr = tlx.require_layout(acc_tr, accumulator_layout)
+        c_tr = tlx.require_layout(acc_tr.to(et), store_layout_c)
+        tlx.buffer_store(c_tr, c_tr_base, c_quad_offsets)
+
+        acc_br = tlx.require_layout(acc_br, accumulator_layout)
+        c_br = tlx.require_layout(acc_br.to(et), store_layout_c)
+        tlx.buffer_store(c_br, c_br_base, c_quad_offsets)
+    else:
+        # Split-K: write this split's fp32 partials into its workspace slice
+        # (rows [split_id*M, split_id*M+M)); a separate fp32 reduce kernel sums
+        # the SPLIT_K slabs into C, keeping the result bit-identical to a single
+        # fp32-accumulated GEMM. Plain tl.store (fp32, no narrowing).
+        rb = split_id * M
+        offs_cm_t = rb + pid_m * BLOCK_M + tl.arange(0, HALF_M)
+        offs_cm_b = offs_cm_t + HALF_M
+        offs_cn_l = pid_n * BLOCK_N + tl.arange(0, HALF_N)
+        offs_cn_r = offs_cn_l + HALF_N
+        tl.store(workspace_ptr + offs_cm_t[:, None] * stride_cm + offs_cn_l[None, :] * stride_cn, acc_tl)
+        tl.store(workspace_ptr + offs_cm_b[:, None] * stride_cm + offs_cn_l[None, :] * stride_cn, acc_bl)
+        tl.store(workspace_ptr + offs_cm_t[:, None] * stride_cm + offs_cn_r[None, :] * stride_cn, acc_tr)
+        tl.store(workspace_ptr + offs_cm_b[:, None] * stride_cm + offs_cn_r[None, :] * stride_cn, acc_br)
 
 
 @triton.jit
@@ -1071,8 +1625,6 @@ def _matmul_256tile(a, b, a_scales, b_scales, SPLIT_K=None):
         NUM_XCDS=NUM_XCDS,
         GRID_MN=grid_mn,
         SPLIT_K=SPLIT_K,
-        PRESHUFFLED_SCALES=False,
-        MERGED_SCALE_DMA=False,
         num_warps=NUM_WARPS,
         num_stages=1,
         matrix_instr_nonkdim=16,
@@ -1136,7 +1688,7 @@ def matmul_preshuffled(a, b, a_scales, b_scales, SPLIT_K=None):
     c = torch.empty((M, N), device=a.device, dtype=torch.bfloat16)
     grid_mn = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
     workspace = torch.empty((SPLIT_K * M, N), device=a.device, dtype=torch.float32) if SPLIT_K > 1 else c
-    _a4w4_8wave_kernel[(grid_mn * SPLIT_K, )](
+    _a4w4_8wave_preshuffled_scales_kernel[(grid_mn * SPLIT_K, )](
         a,
         b,
         c,
@@ -1153,10 +1705,6 @@ def matmul_preshuffled(a, b, a_scales, b_scales, SPLIT_K=None):
         b.stride(1),
         c.stride(0),
         c.stride(1),
-        0,
-        0,
-        0,
-        0,
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
         BLOCK_K=BLOCK_K,
@@ -1164,8 +1712,6 @@ def matmul_preshuffled(a, b, a_scales, b_scales, SPLIT_K=None):
         NUM_XCDS=NUM_XCDS,
         GRID_MN=grid_mn,
         SPLIT_K=SPLIT_K,
-        PRESHUFFLED_SCALES=True,
-        MERGED_SCALE_DMA=False,
         num_warps=NUM_WARPS,
         num_stages=1,
         matrix_instr_nonkdim=16,


### PR DESCRIPTION
Depends on https://github.com/facebookexperimental/triton/pull/2805

Add 2 more variants of inter-wave mxfp kernels:
* First accepts a AITER-style preshuffled scales, allowing wider LDS reads.
* Second on top of preshuffling also merges both scale buffers into one, allowing to coalesce both scales global-to-LDS into single wide one.

## Summary

Add two experimental preshuffled-scale ABIs to the gfx950 inter-wave MXFP4 GEMM:

- `matmul_preshuffled` accepts separate packed A/B scale buffers and keeps the fastest measured wide-LDS consumer: one `ds_read_b128` produces both A-scale halves, while B uses ordinary `ds_read_b64` loads.
- `matmul_merged_scales` accepts one allocation containing adjacent packed A/B scales for two K tiles. Every thread issues one 16-byte DMA, A uses a conflict-free `ds_read_b128`, and B retains conflict-free transpose reads.

The existing `matmul` ABI and production dispatch remain unchanged.

## Implementation

- Add host helpers that pack canonical `[rows, K / 32]` E8M0 scales into each kernel's physical LDS-consumer order.
- Keep the separate ABI's measured-fast 120-read implementation even though it has approximately 1.2% LDS bank conflicts; the zero-conflict two-read form emitted 124 LDS reads and was slower.
- Give the merged ABI distinct A/B packers. Its A bank-group address bits come from lane bits 0..2, preserving aligned `ds_read_b128` loads with zero measured conflicts.
- Merge the A/B scale transfers into one 16-byte DMA per thread, issue it first in the prologue, and reduce the kernel to 34 total `buffer_load_dwordx4 ... lds` instructions.
- Permit `SharedLinearEncodingAttr` to represent a shrinking memdesc subslice by resizing output dimensions and dropping bases outside the logical subview. Growing the layout remains unsupported.
- Add codegen checks for DMA width, LDS read width/count, barriers, waits, scratch use, and spills, plus exact correctness coverage for both ABIs and split-K.

## Generated ISA

| Kernel | Scale LDS reads | Total LDS reads | Scale DMA | VGPR spills | Private segment |
|---|---:|---:|---|---:|---:|
| Separate preshuffled | 4 b128 + 4 b64 | 120 | 4 bytes/thread per scale image | 0 | 0 |
| Merged scales | 4 b128 + 4 b64 transpose | 120 | 16 bytes/thread | 0 | 0 |