### PR TITLE
[triton][backport-needed] Report why each candidate was rejected in "Cannot find <tool>" (#2844)

### DIFF
--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import shutil
+import sys
 import triton
 from triton._C.libtriton import get_cache_invalidating_env_vars  # type: ignore[attr-defined]
 from triton._internal_testing import is_hip
@@ -291,6 +292,81 @@ def test_nvidia_tool(fresh_knobs, tmp_path, monkeypatch):
     monkeypatch.delenv("PTXAS_OPTIONS")
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
     assert fresh_knobs.nvidia.ptxas_options is None
+
+
+def _fake_tool(path, body):
+    """A stand-in for ptxas: a script running `body` under this interpreter."""
+    path.write_text(f"#!{sys.executable}\nimport sys\n{body}\n")
+    path.chmod(0o755)
+    return path
+
+
+def test_nvidia_tool_probe_reports_reason(tmp_path):
+    probe = triton.knobs.NvidiaTool.probe
+
+    tool, reason = probe(str(tmp_path / "absent"))
+    assert tool is None
+    assert reason == "no such file"
+
+    # The case that motivated this: present and executable, but killed at exec.
+    broken = _fake_tool(tmp_path / "broken",
+                        'sys.stderr.write("undefined symbol: unw_backtrace\\n"); sys.exit(127)')
+    tool, reason = probe(str(broken))
+    assert tool is None
+    assert "exited with status 127" in reason
+    assert "undefined symbol: unw_backtrace" in reason
+
+    # Executable, but not a runnable image: exec fails with ENOEXEC, an OSError
+    # that is not FileNotFoundError, and it has to come back as a reason rather
+    # than propagate out of the candidate loop. ENOEXEC rather than a cleared
+    # execute bit so the case does not depend on who runs the test.
+    not_a_binary = tmp_path / "not-a-binary"
+    not_a_binary.write_bytes(b"\x7fnot an ELF header\n")
+    not_a_binary.chmod(0o755)
+    tool, reason = probe(str(not_a_binary))
+    assert tool is None
+    assert reason.startswith("cannot execute: ")
+
+    unparseable = _fake_tool(tmp_path / "unparseable", 'print("not a version string")')
+    tool, reason = probe(str(unparseable))
+    assert tool is None
+    assert "release X.Y" in reason
+
+    good = _fake_tool(tmp_path / "good", 'print("Cuda compilation tools, release 12.8, V12.8.93")')
+    tool, reason = probe(str(good))
+    assert reason is None
+    assert tool.version == "12.8"
+
+
+def test_nvidia_tool_probe_truncates_output(tmp_path):
+    noisy = _fake_tool(tmp_path / "noisy", 'sys.stderr.write("E" * 100000); sys.exit(1)')
+    _, reason = triton.knobs.NvidiaTool.probe(str(noisy))
+    assert len(reason) < 4096
+    assert reason.startswith("`--version` exited with status 1: ...")
+
+
+def test_nvidia_tool_error_lists_all_candidates(fresh_knobs, tmp_path, monkeypatch):
+    broken = _fake_tool(tmp_path / "broken-ptxas", 'sys.stderr.write("boom\\n"); sys.exit(127)')
+    absent = tmp_path / "absent-ptxas"
+
+    # Both candidates must fail for transform() to raise.
+    monkeypatch.setattr(type(fresh_knobs.nvidia).__dict__["ptxas"], "default_path", str(absent))
+    monkeypatch.setenv("TRITON_PTXAS_PATH", str(broken))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        fresh_knobs.nvidia.ptxas
+
+    msg = str(excinfo.value)
+    assert "Cannot find ptxas" in msg
+    # The interpreter running the fake tool is free to add its own noise to the
+    # captured stream, so `boom` is not necessarily flush against the status --
+    # only assert it lands in the broken candidate's reason.
+    broken_prefix = f"{broken}: `--version` exited with status 127:"
+    absent_reason = f"{absent}: no such file"
+    assert broken_prefix in msg
+    assert absent_reason in msg
+    broken_reason = msg.split(broken_prefix, 1)[1].split(absent_reason, 1)[0]
+    assert "boom" in broken_reason
 
 
 def test_opt_bool(fresh_knobs_including_libraries, monkeypatch):

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import functools
 import importlib
 import os
@@ -186,6 +187,12 @@ class env_class(Generic[ClassType], env_base[Optional[Type[ClassType]], Optional
         return cast(Type[ClassType], cls)
 
 
+# How much of a failed tool's output to quote back in the failure reason. A tool
+# that fails verbosely should not be able to turn into a multi-megabyte
+# exception string. The tail is kept because that is where the error usually is.
+_MAX_TOOL_OUTPUT = 2048
+
+
 @dataclass
 class NvidiaTool:
     path: str
@@ -193,15 +200,40 @@ class NvidiaTool:
 
     @staticmethod
     @functools.lru_cache
-    def from_path(path: str) -> Optional[NvidiaTool]:
+    def probe(path: str) -> tuple[Optional[NvidiaTool], Optional[str]]:
+        """Run `<path> --version`.
+
+        Returns `(tool, None)` on success and `(None, reason)` on failure, where
+        `reason` explains why the binary was unusable. Callers that surface a
+        "cannot find" error should include it: a tool that exists but cannot be
+        executed is indistinguishable from a missing one otherwise.
+        """
         try:
             result = subprocess.check_output([path, "--version"], stderr=subprocess.STDOUT)
-            version = re.search(r".*release (\d+\.\d+).*", result.decode("utf-8"), flags=re.MULTILINE)
-            if version is None:
-                return None
-            return NvidiaTool(path, version.group(1))
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            return None
+        except OSError as e:
+            if e.errno in (errno.ENOENT, errno.ENOTDIR):
+                return None, "no such file"
+            if e.errno in (errno.EACCES, errno.EPERM, errno.ENOEXEC, errno.EISDIR):
+                return None, f"cannot execute: {e.strerror or e}"
+            # Anything else -- EMFILE, EAGAIN, ENOMEM -- is a failure of the
+            # spawning process, not of this candidate. Reporting it as a
+            # per-candidate reason would bury it under the same misleading
+            # "Cannot find <tool>" that this reporting exists to eliminate.
+            raise
+        except subprocess.CalledProcessError as e:
+            output = (e.output or b"").decode(errors="replace").strip()
+            if len(output) > _MAX_TOOL_OUTPUT:
+                output = "..." + output[-_MAX_TOOL_OUTPUT:]
+            reason = f"`--version` exited with status {e.returncode}"
+            return None, f"{reason}: {output}" if output else reason
+        version = re.search(r".*release (\d+\.\d+).*", result.decode("utf-8"), flags=re.MULTILINE)
+        if version is None:
+            return None, "`--version` did not report a `release X.Y` version"
+        return NvidiaTool(path, version.group(1)), None
+
+    @staticmethod
+    def from_path(path: str) -> Optional[NvidiaTool]:
+        return NvidiaTool.probe(path)[0]
 
 
 class env_nvidia_tool(env_base[str, NvidiaTool]):
@@ -224,11 +256,14 @@ class env_nvidia_tool(env_base[str, NvidiaTool]):
         else:
             paths = [self.default_path]
 
+        failures = []
         for path in paths:
-            if tool := NvidiaTool.from_path(path):
+            tool, reason = NvidiaTool.probe(path)
+            if tool is not None:
                 return tool
+            failures.append(f"  {path}: {reason}")
 
-        raise RuntimeError(f"Cannot find {self.binary}")
+        raise RuntimeError("Cannot find {}. Tried:\n{}".format(self.binary, "\n".join(failures)))
 
 
 # Separate classes so that types are correct


### PR DESCRIPTION
Summary:

`env_nvidia_tool.transform()` raises `RuntimeError: Cannot find ptxas` for two
completely different situations: the binary is genuinely absent, or it exists
and is executable but cannot be run. `NvidiaTool.from_path()` catches
`CalledProcessError` and returns `None`, throwing away both the exit status and
the stderr it already captured via `stderr=subprocess.STDOUT`.

That distinction matters, and losing it actively misled us. In S696304, PyPER
recurring training attempts died on their first batch with
`RuntimeError: Cannot find ptxas` while `triton/backends/nvidia/bin/ptxas` was
present and executable in the link tree the whole time. The fbcode PAR exports
`LD_PRELOAD=<link-tree>/runtime/lib/__python_generated_allocator_preload`, and
that shim leaves `unw_backtrace` undefined — libunwind lives in the omnibus lib,
so the symbol resolves inside the Python binary but not inside a standalone C++
binary that inherits the preload. When jemalloc heap profiling is enabled in the
environment, ptxas exits 127 with
`symbol lookup error: ... undefined symbol: unw_backtrace`, `check_output`
raises `CalledProcessError`, and the handler discards it. Per the investigation
in P2460695656, 144 of 157 affected attempts reported nothing but "Cannot find
ptxas"; only the 7 that happened to fail later, inside `make_cubin`, carried the
real message. The failure ran unowned for roughly three months in large part
because the error text pointed at the wrong problem.

This splits the probe into `NvidiaTool.probe()`, which returns
`(tool, reason)`, and keeps `from_path()` as a thin wrapper so existing callers
are unaffected. The `lru_cache` added in #7569 moves to `probe()`, so probing is
still done at most once per path; note that `NvidiaTool.from_path.cache_clear()`
is consequently gone (nothing in tree used it) and is now
`NvidiaTool.probe.cache_clear()`. `transform()` lists every candidate path it
tried along with why that path was rejected.

Same exception type, same control flow, no additional subprocess calls — this
only changes what the message says.

The quoted output is capped at 2KB (tail kept, since that is where the error
is) so a verbosely-failing tool cannot turn into a multi-megabyte exception
string that then lands in logging.

Backport: needs upstreaming to triton-lang/triton.

Authored with Claude Code.

Reviewed By: agron911, srkamath, njriasan

Differential Revision: D115938451


