### PR TITLE
[triton][backport-needed] Don't leak the fbcode allocator LD_PRELOAD into ptxas (#2845)

### DIFF
--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -369,6 +369,44 @@ def test_nvidia_tool_error_lists_all_candidates(fresh_knobs, tmp_path, monkeypat
     assert "boom" in broken_reason
 
 
+def test_nvidia_tool_env_hook(fresh_knobs, tmp_path, monkeypatch):
+    # A tool that dies unless a specific variable is scrubbed from its
+    # environment -- the shape of an inherited LD_PRELOAD that only resolves
+    # inside the host interpreter.
+    poison = "TRITON_TEST_POISONED_ENV"
+    tool = _fake_tool(
+        tmp_path / "ptxas", 'import os\n'
+        f'if os.environ.get("{poison}"):\n'
+        '    sys.stderr.write("undefined symbol: unw_backtrace\\n"); sys.exit(127)\n'
+        'print("Cuda compilation tools, release 12.8, V12.8.93")')
+    monkeypatch.setenv(poison, "1")
+
+    # Drive both directions explicitly rather than relying on the ambient value:
+    # `fresh_knobs` deliberately does not reset `nvidia`, and a packager may have
+    # installed a hook at import (fbcode's `set_configs()` does). `scope()`
+    # snapshots `nvidia.__dict__` and restores it on exit, so whatever was
+    # installed survives this test.
+    with fresh_knobs.nvidia.scope():
+        # No hook: the environment is inherited as-is, so the tool dies.
+        fresh_knobs.nvidia.tool_env = None
+        assert fresh_knobs.nvidia.get_tool_env() is None
+        triton.knobs.NvidiaTool.probe.cache_clear()
+        tool_obj, reason = triton.knobs.NvidiaTool.probe(str(tool))
+        assert tool_obj is None
+        assert "unw_backtrace" in reason
+
+        # With a hook that scrubs the marker, the same tool resolves.
+        fresh_knobs.nvidia.tool_env = lambda: {k: v for k, v in os.environ.items() if k != poison}
+        triton.knobs.NvidiaTool.probe.cache_clear()
+        tool_obj, reason = triton.knobs.NvidiaTool.probe(str(tool))
+        assert reason is None
+        assert tool_obj.version == "12.8"
+
+    # `probe` is lru_cached per path and the cache is process-wide; don't leave
+    # entries behind that were resolved under this test's hook.
+    triton.knobs.NvidiaTool.probe.cache_clear()
+
+
 def test_opt_bool(fresh_knobs_including_libraries, monkeypatch):
     fresh_knobs = fresh_knobs_including_libraries
     assert fresh_knobs.amd.use_block_pingpong is None

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import shutil
+import sys
 import triton
 from triton._C.libtriton import get_cache_invalidating_env_vars  # type: ignore[attr-defined]
 from triton._internal_testing import is_hip
@@ -291,6 +292,81 @@ def test_nvidia_tool(fresh_knobs, tmp_path, monkeypatch):
     monkeypatch.delenv("PTXAS_OPTIONS")
     assert Path(fresh_knobs.nvidia.ptxas.path).resolve() == default_ptxas.resolve()
     assert fresh_knobs.nvidia.ptxas_options is None
+
+
+def _fake_tool(path, body):
+    """A stand-in for ptxas: a script running `body` under this interpreter."""
+    path.write_text(f"#!{sys.executable}\nimport sys\n{body}\n")
+    path.chmod(0o755)
+    return path
+
+
+def test_nvidia_tool_probe_reports_reason(tmp_path):
+    probe = triton.knobs.NvidiaTool.probe
+
+    tool, reason = probe(str(tmp_path / "absent"))
+    assert tool is None
+    assert reason == "no such file"
+
+    # The case that motivated this: present and executable, but killed at exec.
+    broken = _fake_tool(tmp_path / "broken",
+                        'sys.stderr.write("undefined symbol: unw_backtrace\\n"); sys.exit(127)')
+    tool, reason = probe(str(broken))
+    assert tool is None
+    assert "exited with status 127" in reason
+    assert "undefined symbol: unw_backtrace" in reason
+
+    # Executable, but not a runnable image: exec fails with ENOEXEC, an OSError
+    # that is not FileNotFoundError, and it has to come back as a reason rather
+    # than propagate out of the candidate loop. ENOEXEC rather than a cleared
+    # execute bit so the case does not depend on who runs the test.
+    not_a_binary = tmp_path / "not-a-binary"
+    not_a_binary.write_bytes(b"\x7fnot an ELF header\n")
+    not_a_binary.chmod(0o755)
+    tool, reason = probe(str(not_a_binary))
+    assert tool is None
+    assert reason.startswith("cannot execute: ")
+
+    unparseable = _fake_tool(tmp_path / "unparseable", 'print("not a version string")')
+    tool, reason = probe(str(unparseable))
+    assert tool is None
+    assert "release X.Y" in reason
+
+    good = _fake_tool(tmp_path / "good", 'print("Cuda compilation tools, release 12.8, V12.8.93")')
+    tool, reason = probe(str(good))
+    assert reason is None
+    assert tool.version == "12.8"
+
+
+def test_nvidia_tool_probe_truncates_output(tmp_path):
+    noisy = _fake_tool(tmp_path / "noisy", 'sys.stderr.write("E" * 100000); sys.exit(1)')
+    _, reason = triton.knobs.NvidiaTool.probe(str(noisy))
+    assert len(reason) < 4096
+    assert reason.startswith("`--version` exited with status 1: ...")
+
+
+def test_nvidia_tool_error_lists_all_candidates(fresh_knobs, tmp_path, monkeypatch):
+    broken = _fake_tool(tmp_path / "broken-ptxas", 'sys.stderr.write("boom\\n"); sys.exit(127)')
+    absent = tmp_path / "absent-ptxas"
+
+    # Both candidates must fail for transform() to raise.
+    monkeypatch.setattr(type(fresh_knobs.nvidia).__dict__["ptxas"], "default_path", str(absent))
+    monkeypatch.setenv("TRITON_PTXAS_PATH", str(broken))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        fresh_knobs.nvidia.ptxas
+
+    msg = str(excinfo.value)
+    assert "Cannot find ptxas" in msg
+    # The interpreter running the fake tool is free to add its own noise to the
+    # captured stream, so `boom` is not necessarily flush against the status --
+    # only assert it lands in the broken candidate's reason.
+    broken_prefix = f"{broken}: `--version` exited with status 127:"
+    absent_reason = f"{absent}: no such file"
+    assert broken_prefix in msg
+    assert absent_reason in msg
+    broken_reason = msg.split(broken_prefix, 1)[1].split(absent_reason, 1)[0]
+    assert "boom" in broken_reason
 
 
 def test_opt_bool(fresh_knobs_including_libraries, monkeypatch):

--- a/python/test/unit/tools/test_disasm.py
+++ b/python/test/unit/tools/test_disasm.py
@@ -26,7 +26,9 @@ def test_extract_handles_large_instruction_offsets(monkeypatch):
     # cuobjdump widens instruction offsets to 5+ hex digits past 64 KiB.
     # Make sure the parser keeps consuming instructions instead of stopping at
     # /*10000*/.
-    def fake_check_output(cmd):
+    # **kwargs so the fake keeps accepting whatever extra arguments extract()
+    # forwards to subprocess (e.g. env=); this test is about offset parsing.
+    def fake_check_output(cmd, **kwargs):
         assert cmd == ["/fake/cuobjdump", "-sass", "fake.cubin"]
         return b"""Function : test_kernel
 .headerflags    @"EF_CUDA_SM103 EF_CUDA_PTX_SM(EF_CUDA_SM103)"

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import functools
 import importlib
 import os
@@ -186,6 +187,12 @@ class env_class(Generic[ClassType], env_base[Optional[Type[ClassType]], Optional
         return cast(Type[ClassType], cls)
 
 
+# How much of a failed tool's output to quote back in the failure reason. A tool
+# that fails verbosely should not be able to turn into a multi-megabyte
+# exception string. The tail is kept because that is where the error usually is.
+_MAX_TOOL_OUTPUT = 2048
+
+
 @dataclass
 class NvidiaTool:
     path: str
@@ -193,15 +200,40 @@ class NvidiaTool:
 
     @staticmethod
     @functools.lru_cache
-    def from_path(path: str) -> Optional[NvidiaTool]:
+    def probe(path: str) -> tuple[Optional[NvidiaTool], Optional[str]]:
+        """Run `<path> --version`.
+
+        Returns `(tool, None)` on success and `(None, reason)` on failure, where
+        `reason` explains why the binary was unusable. Callers that surface a
+        "cannot find" error should include it: a tool that exists but cannot be
+        executed is indistinguishable from a missing one otherwise.
+        """
         try:
             result = subprocess.check_output([path, "--version"], stderr=subprocess.STDOUT)
-            version = re.search(r".*release (\d+\.\d+).*", result.decode("utf-8"), flags=re.MULTILINE)
-            if version is None:
-                return None
-            return NvidiaTool(path, version.group(1))
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            return None
+        except OSError as e:
+            if e.errno in (errno.ENOENT, errno.ENOTDIR):
+                return None, "no such file"
+            if e.errno in (errno.EACCES, errno.EPERM, errno.ENOEXEC, errno.EISDIR):
+                return None, f"cannot execute: {e.strerror or e}"
+            # Anything else -- EMFILE, EAGAIN, ENOMEM -- is a failure of the
+            # spawning process, not of this candidate. Reporting it as a
+            # per-candidate reason would bury it under the same misleading
+            # "Cannot find <tool>" that this reporting exists to eliminate.
+            raise
+        except subprocess.CalledProcessError as e:
+            output = (e.output or b"").decode(errors="replace").strip()
+            if len(output) > _MAX_TOOL_OUTPUT:
+                output = "..." + output[-_MAX_TOOL_OUTPUT:]
+            reason = f"`--version` exited with status {e.returncode}"
+            return None, f"{reason}: {output}" if output else reason
+        version = re.search(r".*release (\d+\.\d+).*", result.decode("utf-8"), flags=re.MULTILINE)
+        if version is None:
+            return None, "`--version` did not report a `release X.Y` version"
+        return NvidiaTool(path, version.group(1)), None
+
+    @staticmethod
+    def from_path(path: str) -> Optional[NvidiaTool]:
+        return NvidiaTool.probe(path)[0]
 
 
 class env_nvidia_tool(env_base[str, NvidiaTool]):
@@ -224,11 +256,14 @@ class env_nvidia_tool(env_base[str, NvidiaTool]):
         else:
             paths = [self.default_path]
 
+        failures = []
         for path in paths:
-            if tool := NvidiaTool.from_path(path):
+            tool, reason = NvidiaTool.probe(path)
+            if tool is not None:
                 return tool
+            failures.append(f"  {path}: {reason}")
 
-        raise RuntimeError(f"Cannot find {self.binary}")
+        raise RuntimeError("Cannot find {}. Tried:\n{}".format(self.binary, "\n".join(failures)))
 
 
 # Separate classes so that types are correct

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -209,7 +209,7 @@ class NvidiaTool:
         executed is indistinguishable from a missing one otherwise.
         """
         try:
-            result = subprocess.check_output([path, "--version"], stderr=subprocess.STDOUT)
+            result = subprocess.check_output([path, "--version"], stderr=subprocess.STDOUT, env=nvidia.get_tool_env())
         except OSError as e:
             if e.errno in (errno.ENOENT, errno.ENOTDIR):
                 return None, "no such file"
@@ -598,6 +598,17 @@ class nvidia_knobs(base_knobs):
     libdevice_path: env_opt_str = env_opt_str("TRITON_LIBDEVICE_PATH")
     libcuda_path: env_opt_str = env_opt_str("TRITON_LIBCUDA_PATH")
     use_meta_ws: env_bool = env_bool("TRITON_USE_META_WS")
+
+    # Environment used to spawn the NVIDIA tools above. `None` inherits the
+    # current environment. Packagers whose interpreter runs with an environment
+    # that is hostile to standalone binaries -- e.g. an LD_PRELOAD'd allocator
+    # that only resolves its own symbols inside the host interpreter -- can
+    # install a callable here to sanitize it. Set it before the first tool
+    # lookup: `NvidiaTool.probe` caches per path.
+    tool_env: Union[Callable[[], Optional[dict[str, str]]], None] = None
+
+    def get_tool_env(self) -> Optional[dict[str, str]]:
+        return self.tool_env() if self.tool_env is not None else None
     # Number of buffers for the dynamic-persistent tile-id broadcast channel
     # (cross-partition run-once atomic support). 1 = single-stage.
     ws_tile_prefetch_depth: env_int = env_int("TRITON_WS_TILE_PREFETCH_DEPTH", 1)

--- a/python/triton/tools/disasm.py
+++ b/python/triton/tools/disasm.py
@@ -81,11 +81,14 @@ def path_to_cuobjdump():
 
 
 def extract(file_path, fun):
+    from triton import knobs
     cuobjdump = path_to_cuobjdump()
+    # Same environment the tool was probed with; see knobs.nvidia.tool_env.
+    env = knobs.nvidia.get_tool_env()
     if fun is None:
-        sass_str = subprocess.check_output([cuobjdump, "-sass", file_path])
+        sass_str = subprocess.check_output([cuobjdump, "-sass", file_path], env=env)
     else:
-        sass_str = subprocess.check_output([cuobjdump, "-fun", fun, "-sass", file_path])
+        sass_str = subprocess.check_output([cuobjdump, "-fun", fun, "-sass", file_path], env=env)
     sass_lines = sass_str.splitlines()
     line_idx = 0
     while line_idx < len(sass_lines):

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -83,7 +83,8 @@ def get_ptxas_version(arch: int = 80):
     mock_ver = knobs.nvidia.mock_ptx_version
     if mock_ver is not None:
         return mock_ver  # This is not really a version of ptxas, but it is good enough for testing
-    version = subprocess.check_output([get_ptxas(arch).path, "--version"]).decode("utf-8")
+    version = subprocess.check_output([get_ptxas(arch).path, "--version"],
+                                      env=knobs.nvidia.get_tool_env()).decode("utf-8")
     return version
 
 
@@ -1370,7 +1371,8 @@ class CUDABackend(BaseBackend):
                 fbin,
             ]
             try:
-                subprocess.run(ptxas_cmd, check=True, close_fds=False, stderr=flog)
+                subprocess.run(ptxas_cmd, check=True, close_fds=False, stderr=flog,
+                               env=knobs.nvidia.get_tool_env())
                 if knobs.nvidia.dump_ptxas_log:
                     with open(flog.name) as log_file:
                         print(log_file.read())


### PR DESCRIPTION
Summary:

Every fbcode PAR exports
`LD_PRELOAD=<link-tree>/runtime/lib/__python_generated_allocator_preload`
(generated by `python_common.bzl::_allocator_preload`). The shim bundles
jemalloc but leaves `unw_backtrace` undefined — libunwind is linked into the
omnibus lib, not into the shim — so the symbol resolves inside the host Python
binary and nowhere else. Any standalone binary that inherits the preload and
reaches jemalloc's profiling path (`MALLOC_CONF=prof:true`) is killed by the
loader with `symbol lookup error: ...: undefined symbol: unw_backtrace` and
exits 127.

ptxas is exactly such a binary, and Triton spawns it in three places that all
inherit that environment: the `--version` probe in `NvidiaTool.probe`,
`get_ptxas_version()`, and the real invocation in `make_cubin`. This is
S696304 — per the investigation in P2460695656, 146 PyPER recurring training
jobs across 157 attempts in 30 days died on their very first batch, when
Inductor's lazily-compiled Triton kernels were materialized for the first time.
`cuobjdump` goes through the same `env_nvidia_tool`, and `tools/disasm.py`
spawns it a second time to dump SASS, so that invocation is fixed too --
otherwise the probe would succeed and the real call would die, which is exactly
the shape of the seven `PTXASError` samples in the SEV.

The fix is a `knobs.nvidia.tool_env` hook: an optional callable returning the
environment to spawn the NVIDIA tools with. `None`, the default and the only
behaviour anyone outside fbcode sees, inherits `os.environ` exactly as today.
fbcode's `set_configs()` installs `native_tool_env`, which drops only the
allocator shim from `LD_PRELOAD` and `FB_SAVED_LD_PRELOAD` and leaves every
other entry alone — callers legitimately prepend their own (libcudart, for
one) — and does not touch `MALLOC_CONF`. Dropping the preload costs ptxas
nothing beyond using the system allocator. The hook has to be installed before
the first tool lookup because `NvidiaTool.probe` caches per path, and it is
`hasattr`-guarded because the fb config layer is shared with Triton channels
that don't carry the knob yet.

Worth recording why the cheaper options don't work, since three of them look
plausible. Setting `TRITON_PTXAS_PATH` to a known-good ptxas does not help:
`transform()` still probes the new path through the same poisoned environment,
verified below. `TRITON_MOCK_PTX_VERSION` only short-circuits
`get_ptxas_version()`; `make_cubin` still has to actually run ptxas to produce
a cubin. A `#!/bin/sh` wrapper that unsets `LD_PRELOAD` fails too, because
`/bin/sh` is itself a standalone binary that dies the same way — this is the
failure `smart/inference_platform_sp/sglang_predictor_gpu/handler.py` documents
for the `numactl` re-exec path. And clearing `LD_PRELOAD` process-wide would
hit Inductor's compile workers, which are re-exec'd fbcode Python binaries that
do want the allocator.

This is the narrow fix. The durable one is to make the preload shim
self-contained (or to drop jemalloc's libunwind dependency), which belongs to
fbcode_build_infra and affects every fbcode PAR, not just Triton. Landed on
beta only.

Regression test in `python/test/unit/test_knobs.py`:
`test_nvidia_tool_env_hook` builds a fake tool that exits 127 with an
`unw_backtrace` message unless a marker variable is scrubbed from its
environment, then checks it fails without the hook, succeeds with it, and that
`get_tool_env()` still returns `None` when no hook is installed. No GPU and no
real ptxas needed. Passes locally against Triton 3.6.0 with this patch applied.

Backport: needs upstreaming to triton-lang/triton.

Authored with Claude Code.

Reviewed By: njriasan

Differential Revision: D115938452


