### PR TITLE
[TLX][AMD] Respect pinned shared layouts in TDM views

### DIFF
--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -2440,6 +2440,60 @@ def test_async_amd_desc_load_auto_propagates_padded_layout_gfx1250(device):
     assert "padded_shared" in ttgir
 
 
+@triton.jit
+def _pinned_tdm_memdesc_view_kernel(
+    input_ptr,
+    output_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    VIEW: tl.constexpr,
+):
+    smem_layout: tl.constexpr = tlx.padded_shared_layout_encoding.with_identity_for([(N, 128 // 16)], [M, N])
+    desc = tl.make_tensor_descriptor(input_ptr, [M, N], [N, 1], [M, N])
+    buffers = tlx.local_alloc((M, N), tl.float16, 1, layout=smem_layout)
+    full = tlx.local_view(buffers, 0)
+
+    token = tlx.async_amd_descriptor_load(desc, full, [0, 0])
+    tlx.async_amd_descriptor_wait(tokens=[token])
+
+    if VIEW == 0:
+        view = tlx.local_slice(full, [0, 32], [M, 32])
+        rows = tl.arange(0, M)
+        cols = tl.arange(0, 32)
+        width: tl.constexpr = 32
+    else:
+        view = tlx.local_reshape(full, [N, M])
+        rows = tl.arange(0, N)
+        cols = tl.arange(0, M)
+        width: tl.constexpr = M
+
+    values = tlx.local_load(view)
+    tl.store(output_ptr + rows[:, None] * width + cols[None, :], values)
+
+
+@pytest.mark.skipif(not is_hip(), reason="Requires HIP runtime")
+@pytest.mark.parametrize(
+    "view, expected_op",
+    [(0, "ttg.memdesc_subslice"), (1, "ttg.memdesc_reshape")],
+    ids=["slice", "reshape"],
+)
+def test_pinned_tdm_memdesc_views_compile_gfx1250(device, view, expected_op):
+    compiled = compile_for_gfx1250(
+        _pinned_tdm_memdesc_view_kernel,
+        signature={"input_ptr": "*fp16", "output_ptr": "*fp16"},
+        constexprs={"M": 32, "N": 128, "VIEW": view},
+    )
+    ttgir = compiled.asm["ttgir"]
+    assert ttgir.count("amdg.async_tdm_copy_global_to_local") == 1
+    assert expected_op in ttgir
+    assert "#ttg.padded_shared<[128:+8]" in ttgir
+    assert "#tlx.user_layout" not in ttgir
+    assert "#tlx.no_verify_layout" not in ttgir
+    assert "tlx.require_layout" not in ttgir
+    amdgcn = compiled.asm["amdgcn"]
+    assert "tensor_load_to_lds" in amdgcn or "tensor.load.to.lds" in amdgcn
+
+
 # ---------------------------------------------------------------------------
 # TDM GEMM tutorial compile test
 # ---------------------------------------------------------------------------

--- a/test/TritonGPU/amd/amd-optimize-descriptor-encoding.mlir
+++ b/test/TritonGPU/amd/amd-optimize-descriptor-encoding.mlir
@@ -228,3 +228,59 @@ tt.func public @tdm_store_allocation_encoding(%desc: !tt.tensordesc<32x32xf16>) 
   tt.return
 }
 }
+
+// -----
+// A pinned allocation is valid for TDM, and descriptor assignment uses the
+// concrete physical layout under the pin rather than the wrapper.
+#padded = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [128, 32]}>
+#pinned = #tlx.user_layout<#padded>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[$PINNED_TDM_PADDED:.*]] = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [128, 32]}>
+// CHECK-DAG: #[[$PINNED_TDM:.*]] = #tlx.user_layout<#[[$PINNED_TDM_PADDED]]>
+// CHECK-LABEL: @tdm_load_pinned_allocation_encoding
+tt.func public @tdm_load_pinned_allocation_encoding(%desc: !tt.tensordesc<128x32xf16>) {
+  // CHECK-SAME: %[[PINNED_DESC:.*]]: !tt.tensordesc<128x32xf16, #[[$PINNED_TDM_PADDED]]>
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<128x32xf16, #pinned, #smem, mutable>
+  // CHECK: amdg.async_tdm_copy_global_to_local %[[PINNED_DESC]] into {{.*}} : !tt.tensordesc<128x32xf16, #[[$PINNED_TDM_PADDED]]> -> !ttg.memdesc<128x32xf16, #[[$PINNED_TDM]], #smem, mutable>
+  %token = amdg.async_tdm_copy_global_to_local %desc into %alloc : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #pinned, #smem, mutable>
+  tt.return
+}
+}
+
+// -----
+// Store descriptor assignment also reads through the allocation pin.
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#pinned = #tlx.user_layout<#shared>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[$PINNED_TDM_SHARED:.*]] = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+// CHECK-DAG: #[[$PINNED_TDM_STORE:.*]] = #tlx.user_layout<#[[$PINNED_TDM_SHARED]]>
+// CHECK-LABEL: @tdm_store_pinned_allocation_encoding
+tt.func public @tdm_store_pinned_allocation_encoding(%desc: !tt.tensordesc<32x32xf16>) {
+  // CHECK-SAME: %[[PINNED_STORE_DESC:.*]]: !tt.tensordesc<32x32xf16, #[[$PINNED_TDM_SHARED]]>
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<32x32xf16, #pinned, #smem, mutable>
+  // CHECK: amdg.async_tdm_copy_local_to_global %[[PINNED_STORE_DESC]] from {{.*}} : !ttg.memdesc<32x32xf16, #[[$PINNED_TDM_STORE]], #smem, mutable> -> !tt.tensordesc<32x32xf16, #[[$PINNED_TDM_SHARED]]>
+  amdg.async_tdm_copy_local_to_global %desc from %alloc : !ttg.memdesc<32x32xf16, #pinned, #smem, mutable> -> !tt.tensordesc<32x32xf16>
+  tt.return
+}
+}
+
+// -----
+// Pins nested inside a partitioned layout are normalized before descriptor
+// assignment and verification as well.
+#padded = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [128, 32]}>
+#pinned_inner = #tlx.user_layout<#padded>
+#partitioned = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 1, partitionDim = 0, partitionLayout = #pinned_inner}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+// CHECK-DAG: #[[$PARTITIONED_TDM_PADDED:.*]] = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [128, 32]}>
+// CHECK-LABEL: @tdm_load_partitioned_pinned_inner_encoding
+tt.func public @tdm_load_partitioned_pinned_inner_encoding(%desc: !tt.tensordesc<128x32xf16>) {
+  // CHECK-SAME: %[[PARTITIONED_DESC:.*]]: !tt.tensordesc<128x32xf16, #[[$PARTITIONED_TDM_PADDED]]>
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<128x32xf16, #partitioned, #smem, mutable>
+  // CHECK: amdg.async_tdm_copy_global_to_local %[[PARTITIONED_DESC]] into
+  %token = amdg.async_tdm_copy_global_to_local %desc into %alloc : !tt.tensordesc<128x32xf16> -> !ttg.memdesc<128x32xf16, #partitioned, #smem, mutable>
+  tt.return
+}
+}

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -1,5 +1,21 @@
 // RUN: triton-opt --split-input-file %s --verify-diagnostics
 
+// A pinned layout is still subject to the physical TDM layout constraints.
+#tdm_bad_swizzle = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 2, order = [1, 0]}>
+#tdm_bad_pinned = #tlx.user_layout<#tdm_bad_swizzle>
+#tdm_bad_smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @tdm_pinned_layout_still_validated(
+      %desc: !tt.tensordesc<32x32xf16>,
+      %buf: !ttg.memdesc<32x32xf16, #tdm_bad_pinned, #tdm_bad_smem, mutable>) {
+    // expected-error @+1 {{TDM does not support swizzling}}
+    %token = amdg.async_tdm_copy_global_to_local %desc into %buf : !tt.tensordesc<32x32xf16> -> !ttg.memdesc<32x32xf16, #tdm_bad_pinned, #tdm_bad_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 // expected-error @+1 {{WMMA version must be in the [1, 3] range}}
 #wmma = #ttg.amd_wmma<{version = 0, isTranspose = false, ctaLayout = {warp = [[0, 1], [1, 0]]}}>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -110,14 +110,33 @@ LogicalResult verifyTDMBlockSize(Operation *op, ArrayRef<int64_t> blockShape) {
   return success();
 }
 
+// TLX pins explicit shared layouts with a generic PinnedEncodingTrait wrapper.
+// TDM validation is concerned with the physical shared layout underneath it.
+Attribute unwrapPinnedTDMLayout(Attribute layout) {
+  if (!layout)
+    return layout;
+  while (auto pinned = llvm::dyn_cast<gpu::PinnedEncodingTrait>(layout))
+    layout = pinned.getPinnedLayout();
+  if (auto partitioned =
+          llvm::dyn_cast<gpu::PartitionedSharedEncodingAttr>(layout)) {
+    auto inner = llvm::cast<gpu::SharedEncodingTrait>(
+        unwrapPinnedTDMLayout(partitioned.getPartitionLayout()));
+    if (inner != partitioned.getPartitionLayout())
+      layout = gpu::PartitionedSharedEncodingAttr::get(
+          layout.getContext(), partitioned.getNumPartitions(),
+          partitioned.getNumGroups(), partitioned.getPartitionDim(), inner);
+  }
+  return layout;
+}
+
 // Verify the descriptor and allocation carry a consistent TDM shared layout
 LogicalResult verifyTDMLayoutConsistency(Operation *op,
                                          triton::TensorDescType descTy,
                                          gpu::MemDescType smemTy) {
-  Attribute descLayout = descTy.getSharedLayout();
+  Attribute descLayout = unwrapPinnedTDMLayout(descTy.getSharedLayout());
   if (!descLayout)
     return success();
-  Attribute allocLayout = smemTy.getEncoding();
+  Attribute allocLayout = unwrapPinnedTDMLayout(smemTy.getEncoding());
   auto descPartitioned =
       llvm::dyn_cast<gpu::PartitionedSharedEncodingAttr>(descLayout);
   auto allocPartitioned =
@@ -163,8 +182,8 @@ LogicalResult verifyTDMCommonLayout(Operation *op,
   if (failed(verifyTDMBlockSize(op, descTy.getShape())))
     return failure();
 
-  auto swizzledEnc =
-      llvm::dyn_cast<gpu::SwizzledSharedEncodingAttr>(smemTy.getEncoding());
+  auto swizzledEnc = llvm::dyn_cast<gpu::SwizzledSharedEncodingAttr>(
+      unwrapPinnedTDMLayout(smemTy.getEncoding()));
   if (swizzledEnc && swizzledEnc.getMaxPhase() != 1)
     return op->emitOpError("TDM does not support swizzling");
 
@@ -1004,7 +1023,7 @@ LogicalResult AsyncTDMCopyGlobalToLocalOp::verify() {
   if (failed(verifyTDMCommonLayout(getOperation(), tensorDescTy, smemTy)))
     return failure();
 
-  auto enc = smemTy.getEncoding();
+  auto enc = unwrapPinnedTDMLayout(smemTy.getEncoding());
   auto paddedEnc = llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(enc);
   auto swizzledEnc = llvm::dyn_cast<gpu::SwizzledSharedEncodingAttr>(enc);
 
@@ -1089,7 +1108,7 @@ LogicalResult AsyncTDMCopyLocalToGlobalOp::verify() {
   if (failed(verifyTDMCommonLayout(getOperation(), tensorDescTy, smemTy)))
     return failure();
 
-  auto enc = smemTy.getEncoding();
+  auto enc = unwrapPinnedTDMLayout(smemTy.getEncoding());
   auto paddedEnc = llvm::dyn_cast<gpu::PaddedSharedEncodingAttr>(enc);
   if (!paddedEnc && !llvm::isa<gpu::SwizzledSharedEncodingAttr>(enc))
     return emitOpError("Invalid shared memory layout for TDM");
@@ -1127,7 +1146,7 @@ LogicalResult AsyncTDMScatterOp::verify() {
   if (failed(verifyTDMCommonLayout(getOperation(), tensorDescTy, smemTy)))
     return failure();
 
-  auto enc = smemTy.getEncoding();
+  auto enc = unwrapPinnedTDMLayout(smemTy.getEncoding());
   if (!llvm::isa<gpu::PaddedSharedEncodingAttr>(enc) &&
       !llvm::isa<gpu::SwizzledSharedEncodingAttr>(enc))
     return emitOpError("Invalid shared memory layout for TDM");
@@ -1178,7 +1197,7 @@ LogicalResult AsyncTDMGatherOp::verify() {
   if (failed(verifyTDMCommonLayout(getOperation(), tensorDescTy, smemTy)))
     return failure();
 
-  auto enc = smemTy.getEncoding();
+  auto enc = unwrapPinnedTDMLayout(smemTy.getEncoding());
   if (!llvm::isa<gpu::PaddedSharedEncodingAttr>(enc) &&
       !llvm::isa<gpu::SwizzledSharedEncodingAttr>(enc))
     return emitOpError("Invalid shared memory layout for TDM");

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeDescriptorEncoding.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeDescriptorEncoding.cpp
@@ -185,9 +185,13 @@ Attribute AMDGPUAssignDescriptorMemoryLayouts::getDesiredDescriptorEncoding(
         continue;
 
       Attribute encoding = memoryType.getEncoding();
+      while (auto pinned = dyn_cast<ttg::PinnedEncodingTrait>(encoding))
+        encoding = pinned.getPinnedLayout();
       if (auto partitioned =
               dyn_cast<ttg::PartitionedSharedEncodingAttr>(encoding))
         encoding = partitioned.getPartitionLayout();
+      while (auto pinned = dyn_cast<ttg::PinnedEncodingTrait>(encoding))
+        encoding = pinned.getPinnedLayout();
       encoding = getCompatibleSharedEncoding(encoding, memoryType.getShape(),
                                              memoryType.getElementType());
       if (!encoding)

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -75,6 +75,22 @@ makeCGALayoutFromBases(mlir::MLIRContext *ctx,
                                    tt::LinearLayout(std::move(bases), outDims));
 }
 
+// Memdesc view ops must infer their result from the concrete shared layout,
+// not from a TLX wrapper carrying the user pin. Bridge the source to that
+// concrete encoding while retaining the pin on the allocation itself.
+static Value materializeConcreteMemDesc(TritonOpBuilder &builder, Value value) {
+  auto type = cast<ttg::MemDescType>(value.getType());
+  Attribute encoding = type.getEncoding();
+  Attribute concrete = tlx::getEffectiveEncoding(encoding);
+  if (concrete == encoding)
+    return value;
+
+  auto concreteType = ttg::MemDescType::get(
+      type.getShape(), type.getElementType(), concrete, type.getMemorySpace(),
+      type.getMutableMemory(), type.getAllocShape());
+  return builder.create<tlx::RequireLayoutOp>(concreteType, value);
+}
+
 void init_triton_tlx_ir(py::module &&m) {
   auto *builder_cls = ir::getBuilderClass();
   builder_cls
@@ -103,6 +119,7 @@ void init_triton_tlx_ir(py::module &&m) {
            [](TritonOpBuilder &self, Value localAlloc,
               std::vector<int32_t> offsets,
               std::vector<int64_t> newShape) -> mlir::Value {
+             localAlloc = materializeConcreteMemDesc(self, localAlloc);
              auto localAllocType = cast<ttg::MemDescType>(localAlloc.getType());
              auto localAllocShape = localAllocType.getShape();
              assert(localAllocShape.size() == offsets.size() &&
@@ -938,7 +955,8 @@ void init_triton_tlx_ir(py::module &&m) {
       .def("create_memdesc_reshape",
            [](TritonOpBuilder &self, Value &src,
               std::vector<int64_t> shape) -> mlir::Value {
-             return self.create<ttg::MemDescReshapeOp>(src, shape);
+             Value reshapeSrc = materializeConcreteMemDesc(self, src);
+             return self.create<ttg::MemDescReshapeOp>(reshapeSrc, shape);
            })
       .def(
           "create_memdesc_reinterpret",


### PR DESCRIPTION
TLX represents an explicit shared-memory layout with a user-layout pin around the concrete encoding. AMD TDM verification and descriptor-layout assignment currently inspect that wrapper as if it were the physical layout, rejecting valid TDM buffers or attempting to propagate a TLX attribute into the descriptor.

Normalize pinned layouts to their concrete encoding for every TDM verifier and for descriptor assignment, including pins nested inside partitioned shared layouts. Bridge pinned memdesc subslice and reshape sources through one factored concrete-layout helper so derived views infer from the physical padded layout without transferring the user pin to the view.

Add native coverage for pinned load/store descriptor assignment, nested partitioned pins, and continued validation of an invalid pinned swizzle. Add compile coverage for pinned TDM subslice and reshape views through AMDGCN lowering.

Extracted from https://github.com/facebookexperimental/triton/pull/2773