### PR TITLE
[TLX][Blackwell] Reduce FA backward dQ epilogue overhead

### DIFF
--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -1392,7 +1392,7 @@ configs_bwd_2cta = [
             "NUM_COMPUTE_SLICES": 2,
             "DQ_REDUCE_STAGES": 2,
             "DQ_REDUCE_NCOL": 32,
-            "EPILOGUE_SUBTILE": 8,
+            "EPILOGUE_SUBTILE": 4,
             "GROUP_SIZE_M": 1,
             "USE_WARP_BARRIER": False,
             "NUM_CTAS": 2,
@@ -2607,7 +2607,8 @@ def _attn_bwd_ws(
     DQ_STORE_M: tl.constexpr = BLOCK_M1 // NUM_CTAS
     DQ_SLICE_N: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
     if USE_2CTA:
-        dq_store_buf = tlx.local_alloc((BLOCK_M1, DQ_SLICE_N), tlx.dtype_of(desc_dq), 2)
+        DQ_STORE_STAGES: tl.constexpr = 1 if EPILOGUE_SUBTILE == 4 else 2
+        dq_store_buf = tlx.local_alloc((BLOCK_M1, DQ_SLICE_N), tlx.dtype_of(desc_dq), DQ_STORE_STAGES)
     else:
         DQ_REDUCE_ITERS: tl.constexpr = HEAD_DIM // DQ_REDUCE_NCOL
         dq_store_buf = tlx.local_alloc((BLOCK_M1, DQ_REDUCE_NCOL), tlx.dtype_of(desc_dq), DQ_REDUCE_STAGES)
@@ -2987,8 +2988,8 @@ def _attn_bwd_ws(
                     dq_full = dq_full * LN2
                     dq_slices = _split_n_2D(dq_full, DQ_PACK_ITERS)
                     for slice_id in tl.static_range(DQ_PACK_ITERS):
-                        dq_smem = dq_store_buf[slice_id % 2]
-                        tlx.async_descriptor_store_wait(1)
+                        dq_smem = dq_store_buf[slice_id % DQ_STORE_STAGES]
+                        tlx.async_descriptor_store_wait(DQ_STORE_STAGES - 1)
                         tlx.local_store(dq_smem, dq_slices[slice_id].to(tlx.dtype_of(desc_dq)))
                         tlx.async_descriptor_store(
                             desc_dq,


### PR DESCRIPTION
Summary:
Use one wider `128x32` staging tile for the 2-CTA backward `dQ` epilogue instead of two `128x16` tiles. This keeps shared-memory usage unchanged while halving TMA reduce launches.

On B200, the BF16 backward TritonBench sweep uses `B=4`, `H=H_KV=48`, and `D=128`:

| Sequence length | TLX before | TLX after | TLX change | FA4 |
| ---: | ---: | ---: | ---: | ---: |
| 1024 | 571.849 | 581.913 | +1.76% | 639.882 |
| 2048 | 725.947 | 744.009 | +2.49% | 775.307 |
| 4096 | 840.875 | 858.887 | +2.14% | 880.114 |
| 8192 | 909.157 | 925.123 | +1.76% | 936.761 |
| 16384 | 943.298 | 961.246 | +1.90% | 968.006 |
| Average | 798.225 | 814.236 | +2.01% | 840.014 |

All performance values are TFLOPS. TLX improves at every sequence length and gains 2.01% on average. The FA4 average is 840.014. As a run-stability control, cuDNN averages 763.119 before and 761.321 after. NCU also shows shared-store conflicts decreasing from about 69.6M to 37.2M.

Differential Revision: D115938355


