### PR TITLE
[triton][beta] Skip the launcher compile test when the C compiler cannot run

### DIFF
--- a/python/test/unit/runtime/test_launch_metadata.py
+++ b/python/test/unit/runtime/test_launch_metadata.py
@@ -422,6 +422,15 @@ def test_launcher_src_compiles_with_gcc():
     if cc is None:
         pytest.skip("No C compiler available")
 
+    # Being on PATH is not enough. fbcode's gcc is a wrapper that resolves the
+    # real toolchain through /mnt/gvfs, which is not mounted in every container
+    # the tests run in; there it exits non-zero having compiled nothing, and the
+    # returncode assert below reports it as a launcher_src compile failure. Probe
+    # the compiler so an unusable toolchain skips instead.
+    probe = subprocess.run([cc, "--version"], capture_output=True, timeout=30)
+    if probe.returncode != 0:
+        pytest.skip(f"C compiler {cc} is present but not runnable")
+
     # Find cuda.h include dir
     cuda_include = os.path.join(backend_dir, "include")
     if not os.path.exists(os.path.join(cuda_include, "cuda.h")):


### PR DESCRIPTION
Summary:
`test_launcher_src_compiles_with_gcc` guards on `shutil.which("gcc") or ... clang ... cc`, which proves a compiler is on PATH but not that it runs. In the reactor CI MAST container `/usr/local/fbcode/bin/gcc` is on PATH, but it is a wrapper that resolves the real toolchain through `/mnt/gvfs`, which is not mounted there. It exits non-zero having compiled nothing, and the test's `assert result.returncode == 0` then reports it as a generated-launcher compile failure:

```
+  where 1 = CompletedProcess(args=['/usr/local/fbcode/bin/gcc', '-fsyntax-only', '-c',
   '/tmp/tmppe7v5j73.c', '-I/tmp/jetter.../triton/backends/nvidia/include'],
   returncode=1, stdout='', stderr='...
   FileNotFoundError: [Errno 2] No such file or directory:
   \'/mnt/gvfs/third-party2/llvm-fb/.../build.dat\'')
```

The stderr is the wrapper's own Python traceback -- there are no C diagnostics, because nothing was compiled.

Probe the compiler with `--version` and skip when it does not run, alongside the guards this test already has for a missing compiler, a missing `launch.h` and a missing `cuda.h`. Environments with a working toolchain are unaffected; the compile still runs and still asserts.

This is the same situation as the existing "Requires gcc, but RE doesn't have gcc" BUCK skips, except RE has no gcc on PATH at all, so the existing `which` guard catches it there. Fixing the guard rather than adding a BUCK skip keeps the test running wherever a toolchain actually works.

Beta only: `stable` has no `python/test/unit/runtime/test_launch_metadata.py`.

Reviewed By: FindHao

Differential Revision: D115973261


