### PR TITLE
[Test-Fix][triton][beta] Relax constexpr call-site typing

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -4026,26 +4026,33 @@ class AutoWSLoopOptions(base_value):
     option is one new field), and the code generator emits them identically onto
     ``scf.for`` and ``scf.while``. See ``tl.range`` for the per-option docs.
     """
-    num_stages: Optional[constexpr] = field(default=None, metadata=_loop_attr("tt.num_stages", "int32"))
-    loop_unroll_factor: Optional[constexpr] = field(default=None, metadata=_loop_attr("tt.loop_unroll_factor", "int32"))
-    disallow_acc_multi_buffer: bool = field(default=False, metadata=_loop_attr("tt.disallow_acc_multi_buffer", "unit"))
-    flatten: bool = field(default=False, metadata=_loop_attr("tt.flatten", "unit"))
-    warp_specialize: bool = field(default=False, metadata=_loop_attr("tt.warp_specialize", "unit"))
-    multi_cta: bool = field(default=False, metadata=_loop_attr("tt.multi_cta", "unit"))
-    disable_licm: bool = field(default=False, metadata=_loop_attr("llvm.loop_annotation", "licm"))
-    data_partition_factor: Optional[constexpr] = field(default=None,
-                                                       metadata=_loop_attr("tt.data_partition_factor", "int32"))
-    list_schedule_pick: Optional[constexpr] = field(default=None, metadata=_loop_attr("tt.list_schedule_pick", "int32"))
-    mem_plan_pick: Optional[constexpr] = field(default=None, metadata=_loop_attr("tt.mem_plan_pick", "int32"))
-    merge_epilogue: bool = field(default=False, metadata=_loop_attr("tt.merge_epilogue", "bool"))
-    merge_epilogue_to_computation: bool = field(default=False, metadata=_loop_attr("tt.merge_epilogue_to_computation",
-                                                                                   "bool"))
-    merge_correction: bool = field(default=False, metadata=_loop_attr("tt.merge_correction", "bool"))
-    separate_epilogue_store: bool = field(default=False, metadata=_loop_attr("tt.separate_epilogue_store", "bool"))
-    tmem_alloc_algo: Optional[constexpr] = field(default=None, metadata=_loop_attr("tt.tmem_alloc_algo", "int32"))
-    smem_alloc_algo: Optional[constexpr] = field(default=None, metadata=_loop_attr("tt.smem_alloc_algo", "int32"))
-    smem_budget: Optional[constexpr] = field(default=None, metadata=_loop_attr("tt.smem_budget", "int32"))
-    smem_circular_reuse: Optional[bool] = field(default=None, metadata=_loop_attr("tt.smem_circular_reuse", "bool_opt"))
+    num_stages: int | constexpr | None = field(default=None, metadata=_loop_attr("tt.num_stages", "int32"))
+    loop_unroll_factor: int | constexpr | None = field(default=None,
+                                                       metadata=_loop_attr("tt.loop_unroll_factor", "int32"))
+    disallow_acc_multi_buffer: bool | constexpr = field(default=False,
+                                                        metadata=_loop_attr("tt.disallow_acc_multi_buffer", "unit"))
+    flatten: bool | constexpr = field(default=False, metadata=_loop_attr("tt.flatten", "unit"))
+    warp_specialize: bool | constexpr = field(default=False, metadata=_loop_attr("tt.warp_specialize", "unit"))
+    multi_cta: bool | constexpr = field(default=False, metadata=_loop_attr("tt.multi_cta", "unit"))
+    disable_licm: bool | constexpr = field(default=False, metadata=_loop_attr("llvm.loop_annotation", "licm"))
+    data_partition_factor: int | constexpr | None = field(default=None,
+                                                          metadata=_loop_attr("tt.data_partition_factor", "int32"))
+    list_schedule_pick: int | constexpr | None = field(default=None,
+                                                       metadata=_loop_attr("tt.list_schedule_pick", "int32"))
+    mem_plan_pick: int | constexpr | None = field(default=None, metadata=_loop_attr("tt.mem_plan_pick", "int32"))
+    merge_epilogue: bool | constexpr = field(default=False, metadata=_loop_attr("tt.merge_epilogue", "bool"))
+    merge_epilogue_to_computation: bool | constexpr = field(
+        default=False, metadata=_loop_attr("tt.merge_epilogue_to_computation", "bool"))
+    merge_correction: bool | constexpr = field(default=False, metadata=_loop_attr("tt.merge_correction", "bool"))
+    separate_epilogue_store: bool | constexpr = field(default=False,
+                                                       metadata=_loop_attr("tt.separate_epilogue_store", "bool"))
+    tmem_alloc_algo: int | constexpr | None = field(default=None,
+                                                     metadata=_loop_attr("tt.tmem_alloc_algo", "int32"))
+    smem_alloc_algo: int | constexpr | None = field(default=None,
+                                                     metadata=_loop_attr("tt.smem_alloc_algo", "int32"))
+    smem_budget: int | constexpr | None = field(default=None, metadata=_loop_attr("tt.smem_budget", "int32"))
+    smem_circular_reuse: bool | constexpr | None = field(default=None,
+                                                         metadata=_loop_attr("tt.smem_circular_reuse", "bool_opt"))
 
 
 @dataclass(eq=False)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -494,7 +494,7 @@ class KernelInterface(Generic[T]):
     def run(self, *args, grid, warmup, **kwargs):
         raise NotImplementedError("run not implemented")
 
-    def __getitem__(self, grid) -> T:
+    def __getitem__(self: "KernelInterface[Callable[..., R]]", grid) -> Callable[..., R]:
         """
         A JIT function is launched with: fn[grid](*args, **kwargs).
         Hence JITFunction.__getitem__ returns a callable proxy that
@@ -1368,7 +1368,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
                             [attrs], warmup)
         return kernel
 
-    def __call__(self: "JITFunction[Callable[P, R]]", *args: P.args, **kwargs: P.kwargs) -> R:
+    def __call__(self: "JITFunction[Callable[..., R]]", *args: Any, **kwargs: Any) -> R:
         raise RuntimeError("Cannot call @triton.jit'd outside of the scope of a kernel")
 
     if TYPE_CHECKING:


### PR DESCRIPTION
Summary:
Model Triton JIT calls and launches with permissive argument types while preserving callable return types. Widen AutoWS loop options to accept the Python literals and `tl.constexpr` wrappers supported by the DSL.

Authored with AI assistance (Codex).

Reviewed By: xuzhao9

Differential Revision: D116089804


