### PR TITLE
[PartitionSchedulingMeta] [AutoWS][CLC] Support HSTU backward partition scheduling

### DIFF
--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-fa-bwd.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-fa-bwd.mlir
@@ -13,22 +13,24 @@
 
 // CHECK-LABEL: @_attn_bwd_persist
 //
-// --- Pre-loop: address computation -> reduction partition ---
-// (scalar ops may be unscheduled since they can be rematerialized)
-// CHECK: arith.divsi {{.*}}ttg.partition = array<i32: [[RED:[0-9]+]]>
-// CHECK: arith.remsi {{.*}}ttg.partition = array<i32: [[RED]]>
-// CHECK: arith.muli {{.*}}ttg.partition = array<i32: [[RED]]>
-// CHECK: arith.divsi {{.*}}ttg.partition = array<i32: [[RED]]>
-// CHECK: arith.muli {{.*}}ttg.partition = array<i32: [[RED]]>
-// CHECK: arith.addi {{.*}}ttg.partition = array<i32: [[RED]]>
-// CHECK: arith.extsi {{.*}}ttg.partition = array<i32: [[RED]]>
-// CHECK: arith.divsi {{.*}}ttg.partition = array<i32: [[RED]]>
+// --- Tile-index scalars are REPLICATED, not channeled. Each scalar in the
+//     offset chain must carry the union of its consumers' partitions
+//     (reduction + load + computation here), so code partitioning clones the
+//     chain into each consuming task. A single-id set on these ops means the
+//     scalar closure regressed and the value would need a cross-partition
+//     scalar channel, which buffer allocation cannot materialize. ---
+// CHECK: arith.divsi {{.*}}ttg.partition = array<i32: [[RED:[0-9]+]], [[LOAD:[0-9]+]], [[COMP:[0-9]+]]>
+// CHECK: arith.remsi {{.*}}ttg.partition = array<i32: [[RED]], [[LOAD]], [[COMP]]>
+// CHECK: arith.muli {{.*}}ttg.partition = array<i32: [[RED]], [[LOAD]], [[COMP]]>
+// CHECK: arith.addi {{.*}}ttg.partition = array<i32: [[RED]], [[LOAD]], [[COMP]]>
+// CHECK: arith.extsi {{.*}}ttg.partition = array<i32: [[RED]], [[LOAD]], [[COMP]]>
+//
 // --- Pre-loop: K, V descriptor_load -> load partition ---
-// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD:[0-9]+]]>
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
 // CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
 // CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: [[LOAD]]>
 // CHECK: ttg.local_alloc {{.*}}ttg.partition = array<i32: [[LOAD]]>
-// CHECK: tt.splat {{.*}}ttg.partition = array<i32: [[COMP:[0-9]+]]>
+// CHECK: tt.splat {{.*}}ttg.partition = array<i32: [[COMP]]>
 // CHECK: tt.splat {{.*}}ttg.partition = array<i32: [[COMP]]>
 // --- Pre-loop: dq tmem_alloc, dk/dv init → reduction partition ---
 // CHECK: ttng.tmem_alloc {{.*}}ttg.partition = array<i32: [[RED]]>

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-flex-attention.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-flex-attention.mlir
@@ -39,12 +39,12 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "cuda:100"} {
 // CHECK: ttng.tmem_load {{.*}} ttg.partition = array<i32: [[COMP_A:[0-9]+]]>
 // CHECK: ttng.tmem_load {{.*}} ttg.partition = array<i32: [[COMP_B:[0-9]+]]>
 //
-// --- Split scf.if: the condition must NOT have a ttg.partition attribute.
-//     If it keeps partition 0 (from the original shared scf.if),
-//     doTaskIdPropagate expands the split scf.if's task set to include
-//     partition 0, creating a cross-partition SMEM channel. ---
-// CHECK: arith.cmpi
-// CHECK-NOT: ttg.partition
+// --- Split scf.if: the condition is replicated into exactly the two
+//     computation partitions that consume it. It must NOT retain partition 0
+//     from the original shared scf.if: doTaskIdPropagate would then expand the
+//     split scf.if's task set to include partition 0, creating a
+//     cross-partition SMEM channel. ---
+// CHECK: arith.cmpi {{.*}}ttg.partition = array<i32: [[COMP_B]], [[COMP_A]]>
 //
 // --- Split scf.if: ops inside then-block get the parent's computation partition.
 //     The scf.if itself inherits loop scheduling attributes from the original so

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -422,7 +422,8 @@ public:
   /// Get operations in a specific category.
   SmallVector<CategorizedOp> getOpsInCategory(OpCategory cat) const {
     SmallVector<CategorizedOp> result;
-    for (auto &[op, catOp] : opCategories) {
+    for (Operation *op : opCategoryOrder) {
+      const CategorizedOp &catOp = opCategories.at(op);
       if (catOp.category == cat)
         result.push_back(catOp);
     }
@@ -484,7 +485,8 @@ public:
 
     for (OpCategory cat : categoryOrder) {
       SmallVector<const CategorizedOp *> ops;
-      for (auto &[op, catOp] : opCategories) {
+      for (Operation *op : opCategoryOrder) {
+        const CategorizedOp &catOp = opCategories.at(op);
         if (catOp.category == cat)
           ops.push_back(&catOp);
       }
@@ -952,6 +954,8 @@ private:
       if (it != opToDpId.end() && it->second != SHARED_DPID)
         dataPartitionId = it->second;
     }
+    if (!opCategories.contains(op))
+      opCategoryOrder.insert(op);
     opCategories[op] = CategorizedOp{op, cat, dataPartitionId, parentMMA};
   }
 
@@ -959,6 +963,7 @@ private:
   SmallVector<LoopLikeOpInterface> loops;
   SmallVector<Operation *> mmas;
   DenseMap<Operation *, CategorizedOp> opCategories;
+  SetVector<Operation *> opCategoryOrder;
   DenseMap<Operation *, SetVector<Operation *>> mmaToSlice;
   DenseSet<Operation *> sharedOps;
   DenseMap<Operation *, unsigned> opToDpId;
@@ -2218,6 +2223,19 @@ static bool isScalarOp(Operation *op) {
   });
 }
 
+// A primitive scalar value can be cloned into multiple async tasks without a
+// communication buffer.  Keep this deliberately narrower than isScalarOp:
+// descriptor, token, and other opaque results are not ranked tensors either,
+// but duplicating their task ownership changes synchronization semantics.
+static bool isRematerializablePrimitiveScalarOp(Operation *op) {
+  if (op->getNumResults() == 0 || op->getNumRegions() != 0)
+    return false;
+  return llvm::all_of(op->getResults(), [](Value value) {
+    Type type = value.getType();
+    return type.isIntOrIndexOrFloat() || isa<triton::PointerType>(type);
+  });
+}
+
 void propagatePartitions(LoopLikeOpInterface loop, PartitionSet &schedule,
                          bool createComputePartitions,
                          Partition *defaultPartition) {
@@ -2502,7 +2520,9 @@ static bool isRematerializableForClone(Operation *defOp) {
 /// them through a cross-partition memory channel.
 ///
 /// Cloneable: MemDescTransOp (metadata-only SMEM-layout reinterpretation),
-/// ConvertLayoutOp, BroadcastOp, ExpandDimsOp (cheap element rearrangement).
+/// cheap integer index arithmetic, and ConvertLayoutOp/BroadcastOp/
+/// ExpandDimsOp/MakeRangeOp/SplatOp (cheap element rearrangement or index
+/// construction).
 /// LocalAllocOp is NOT cloned: a shared SMEM buffer (e.g. K/V in FA) is one
 /// producer feeding N consumer partitions, so cloning would duplicate the
 /// buffer. separateLocalAllocWithSrc instead tags the local_store with the
@@ -2552,7 +2572,14 @@ void optimizeSchedule(LoopLikeOpInterface loop, PartitionSet &schedule) {
           continue;
         Operation *pullClone = OpBuilder(defOp).clone(*defOp);
         setPartition(pullClone, userPartition);
-        current->setOperand(idx, pullClone->getResult(0));
+        // Rewire to the SAME result the operand referred to. Every op accepted
+        // by isRematerializableForClone is single-result today, but keying off
+        // the original result number keeps this correct if a multi-result op
+        // is ever added to the cloneable set instead of silently substituting
+        // result 0.
+        current->setOperand(
+            idx,
+            pullClone->getResult(cast<OpResult>(operand).getResultNumber()));
         worklist.push_back(pullClone);
       }
     }
@@ -2562,8 +2589,7 @@ void optimizeSchedule(LoopLikeOpInterface loop, PartitionSet &schedule) {
   // operands.
   getLoopBodyRegion(loop).walk<WalkOrder::PostOrder, ReverseIterator>(
       [&](Operation *op) {
-        if (!isa<MemDescTransOp, ConvertLayoutOp, BroadcastOp, ExpandDimsOp>(
-                op))
+        if (!isa<MemDescTransOp>(op) && !isRematerializableForClone(op))
           return;
 
         Partition *partition = getPartition(op);
@@ -2940,6 +2966,82 @@ void PartitionSchedulingMeta::runOnOperation() {
         }
       }
 
+      // Scalar values are rematerializable and must not become cross-partition
+      // channels: WS buffer allocation only materializes ranked tensor values.
+      // This matters for persistent jagged kernels where a scalar seq-offset
+      // load is initially anchored in the load partition but its length/offset
+      // users span reduction, GEMM, load, and computation tasks. Expand scalar
+      // producers to the union of their users' partitions so specialization
+      // clones the scalar chain into each consuming task.
+      bool scalarPartitionsChanged = true;
+      while (scalarPartitionsChanged) {
+        scalarPartitionsChanged = false;
+        getLoopBodyRegion(loop).walk([&](Operation *op) {
+          if (!isRematerializablePrimitiveScalarOp(op))
+            return;
+          SetVector<int> unionIds;
+          SetVector<int> currentIds = safeGetPartitionIds(op);
+          unionIds.insert(currentIds.begin(), currentIds.end());
+          for (Operation *user : op->getUsers()) {
+            SetVector<int> userIds = safeGetPartitionIds(user);
+            unionIds.insert(userIds.begin(), userIds.end());
+          }
+          if (unionIds.empty() || unionIds.size() == currentIds.size())
+            return;
+          setPartition(op, unionIds);
+          scalarPartitionsChanged = true;
+        });
+      }
+
+      auto idsToStr = [](const SetVector<int> &ids) {
+        std::string s;
+        llvm::raw_string_ostream os(s);
+        llvm::interleaveComma(ids, os);
+        return os.str();
+      };
+
+      // Backstop: the closure above must leave every scalar producer owning at
+      // least the partitions of all its consumers, i.e. no scalar value is a
+      // cross-partition channel. Buffer allocation only materializes ranked
+      // tensor channels, so a surviving scalar edge either crashes channel
+      // creation or silently drops the value in the consuming task. The
+      // closure runs to a fixpoint immediately above, so this can only fire if
+      // it stops converging or a later phase re-partitions scalars — make that
+      // a hard compile error here (checkable by any lit test that runs the
+      // pass) instead of an unattributable failure much further downstream.
+      WalkResult scalarVr =
+          getLoopBodyRegion(loop).walk([&](Operation *op) -> WalkResult {
+            if (!isRematerializablePrimitiveScalarOp(op))
+              return WalkResult::advance();
+            SetVector<int> defIds = safeGetPartitionIds(op);
+            if (defIds.empty())
+              return WalkResult::advance();
+            for (Operation *user : op->getUsers()) {
+              SetVector<int> userIds = safeGetPartitionIds(user);
+              for (int id : userIds) {
+                if (defIds.contains(id))
+                  continue;
+                InFlightDiagnostic diag =
+                    op->emitError()
+                    << "warp specialization left a scalar value crossing a "
+                       "partition boundary: this op owns partitions {"
+                    << idsToStr(defIds) << "} but a consumer runs in partition "
+                    << id
+                    << ". Scalars are rematerialized per task, not routed "
+                       "through a channel, so the scalar closure must expand "
+                       "the producer to the union of its consumers' "
+                       "partitions.";
+                diag.attachNote(user->getLoc())
+                    << "consumed here, in partitions {" << idsToStr(userIds)
+                    << "}";
+                return WalkResult::interrupt();
+              }
+            }
+            return WalkResult::advance();
+          });
+      if (scalarVr.wasInterrupted())
+        return signalPassFailure();
+
       // Backstop: verify no two accumulator-chained MMAs were assigned to
       // partitions that cannot be co-located. The data-partition grouping
       // (Layer 1) should keep them together, but any other assignment path
@@ -2958,12 +3060,6 @@ void PartitionSchedulingMeta::runOnOperation() {
       // moment it empties. Store the first writer to point the diagnostic at
       // it.
       DenseMap<Operation *, std::pair<Operation *, SetVector<int>>> accOwner;
-      auto idsToStr = [](const SetVector<int> &ids) {
-        std::string s;
-        llvm::raw_string_ostream os(s);
-        llvm::interleaveComma(ids, os);
-        return os.str();
-      };
       WalkResult vr = loop.walk([&](Operation *op) -> WalkResult {
         Operation *buf = getAccumulatorBuffer(op);
         if (!buf)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
@@ -167,6 +167,12 @@ categorizeDataPartitionOps()    ← skips already-categorized ops
 Correction runs before DataPartition so that correction ops (accumulator
 rescaling) are not stolen by the data partition categorizer.
 
+Categorized operations retain their deterministic discovery order separately
+from the pointer-keyed category lookup map. Scheduling phases process operations
+in that discovery order; iterating the lookup map directly would make shared
+producer ownership depend on pointer hash order when multiple anchor backward
+slices reach the same index or mask chain.
+
 ### Central dpId Assignment (`collectMMABackwardSlices`)
 
 `collectMMABackwardSlices` is the single source of truth for data partition ID
@@ -400,6 +406,25 @@ rematerialized in any partition and should not force partition assignment.
 Clusters with empty `defPartitions` (containing only scalar ops) are also
 skipped.
 
+After schedule optimization, a scalar closure expands every scalar producer to
+the union of its consumers' partitions. This includes scalar ops that already
+have an anchor partition, such as a jagged sequence-offset `tt.load` initially
+assigned to the load task. Code specialization then clones the scalar chain in
+each consuming task instead of attempting an unsupported cross-partition scalar
+channel. The closure runs to a fixpoint so pointer arithmetic feeding a scalar
+load inherits the same task set.
+
+A backstop immediately after the closure verifies the property the closure is
+supposed to establish: every scalar producer owns at least the partitions of
+all its consumers. A violation is reported as a compile error naming the
+producer, the partitions it owns, and the consuming partition, so a scalar edge
+that escapes the closure fails here instead of crashing channel creation or
+silently dropping the value in the consuming task. It sits next to the
+accumulator-chained MMA backstop and, like it, is unreachable while the phase
+above it is intact — it exists to keep a later re-partitioning phase from
+reintroducing a scalar channel undetected. Any lit test that runs the pass
+enforces it.
+
 Cluster assignment rules:
 
 1. **Multiple def or sink partitions**: The cluster sits between multiple
@@ -420,7 +445,11 @@ cross-partition channels.
 
 **Cloneable ops**:
 - `MemDescTransOp`: metadata-only reinterpretation of shared memory layout
-- `ConvertLayoutOp`, `BroadcastOp`, `ExpandDimsOp`: cheap element rearrangement
+- `ConvertLayoutOp`, `BroadcastOp`, `ExpandDimsOp`, `MakeRangeOp`, `SplatOp`:
+  cheap element rearrangement or index construction
+- integer/index `arith` operations: cheap index and mask construction. Floating
+  point tensor arithmetic remains excluded so reductions and activation work
+  are not duplicated into multiple partitions.
 
 **Not cloned**: `LocalAllocOp`. When a shared SMEM buffer (e.g., K/V in
 Flash Attention) is consumed by ops in multiple partitions, the correct
@@ -437,12 +466,15 @@ The cloning walks in reverse post-order so that an `ExpandDimsOp` feeding a
 `ExpandDimsOp` E feeds B, then E is also cloned into P in the same pass
 (because E's user — the cloned B — is now in P).
 
-**Operand chain cloning**: After cloning a `BroadcastOp`/`ExpandDimsOp`,
+**Operand chain cloning**: After cloning any cloneable root,
 `optimizeSchedule` walks backward through the clone's operand chain and
-also clones any `ConvertLayoutOp`, `BroadcastOp`, or `ExpandDimsOp` that
-feeds it from a different partition. This handles the case where upstream
-layout passes insert a `ConvertLayoutOp` between `ExpandDimsOp` and
-`BroadcastOp` (e.g., `expand_dims -> convert_layout -> broadcast`).
+also clones cloneable producers that feed it from a different partition. This
+handles both layout chains (for example,
+`expand_dims -> convert_layout -> broadcast`) and causal-mask index chains
+such as `make_range -> addi -> expand_dims -> broadcast`. Starting the walk
+from integer arithmetic users is necessary when the broadcast itself feeds an
+unassigned mask cluster; otherwise the full broadcasted index tensor becomes a
+cross-partition SMEM channel.
 
 When a `MemDescTransOp` clone references a `LocalAllocOp` from a different
 partition (e.g., `local_alloc -> memdesc_trans -> dot`), the backward walk


### PR DESCRIPTION
Summary:
HSTU CLC backward combines a persistent work-stealing loop, multiple data-parallel MMA slices, subtiled channels, and causal-mask index chains that the generic partition scheduler did not assign deterministically. This change adds ordered-subset CLC scheduling, stable backward anchor assignment, and accumulation-counter handling for subtiled channels, while rematerializing inexpensive index operations into the computation partition. The generated partitions then have consistent task ownership and channel cadence across CLC iterations.

Review comments addressed in this revision:
- cloneOperandChain no longer hardcodes pullClone->getResult(0); it rewires the operand to the same result index it originally referred to (cast<OpResult>(operand).getResultNumber()), so adding a multi-result op to the cloneable set cannot silently substitute result 0.
- Added the analysis backstop njriasan asked for: immediately after the scalar closure, the pass verifies that every rematerializable scalar producer owns at least the partitions of all its consumers, and reports a compile error naming the producer, its partitions, and the consuming partition otherwise. It sits next to the existing accumulator-chained-MMA backstop, so every lit test that runs the pass enforces the invariant instead of letting a stray scalar edge surface as a channel-creation crash further downstream.
- partition-scheduling-meta-fa-bwd.mlir no longer just drops the scalar CHECK lines: it pins the scalar offset chain carrying the UNION of its consumers' partitions. Verified discriminating -- disabling the scalar closure and rebuilding makes the test fail.
- PartitionSchedulingMeta.md documents the backstop next to the scalar-closure description.

Reviewed By: njriasan

Differential Revision: D114610709


