### PR TITLE
[TLX][AMD] Fix silently wrong addmm results when autotune picks a split-K PERSISTENT config

### DIFF
--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1460,6 +1460,15 @@ class ROCmAddMMPersistentWarpPipeTemplateConfigHeuristic(
         for template_kwargs in super()._get_template_configs_impl(
             kernel_inputs, op_name
         ):
+            # The persistent template has NO split-K body -- it never peels split_id and
+            # never writes split_k_ws; it stores straight through store_output. But
+            # SPLIT_K > 1 alone makes _tlx_tt_generate allocate the UNINITIALIZED
+            # split_k_ws and _tlx_emit_post_kernel_code emit _reduce_k after the kernel,
+            # and that reducer then sums the never-written workspace over the output.
+            # Inheriting the per-tile heuristic's split-K candidates therefore yields
+            # silently WRONG results whenever autotune happens to pick one. Drop them.
+            if int(template_kwargs.get("SPLIT_K", 1)) > 1:
+                continue
             yield {**template_kwargs, "NUM_SMS": num_sms}
 
 


### PR DESCRIPTION
Summary:
`ROCmAddMMPersistentWarpPipeTemplateConfigHeuristic` inherits `_get_template_configs_impl` from the per-tile warp-pipe heuristic, so it emits `SPLIT_K` 2/4/8 candidates for undersaturated grids. But `amd_addmm_persistent_warppipe.py.jinja` has NO split-K body: it never peels `split_id`, never references `split_k_ws`, and stores straight through `store_output` (grep: 0 occurrences of `split_id` / `split_k_ws` / `SPLIT_K` in that template, versus 7 / 6 / 13 in the per-tile one).

`SPLIT_K > 1` alone is enough to arm the split-K plumbing, because both halves of it are keyed on the meta kwarg and not on which template ran:
- `_tlx_tt_generate` allocates the `split_k_ws` fp32 workspace with `WorkspaceZeroMode.UNINITIALIZED` (deliberately -- the per-tile template writes every element exactly once, so zero-filling it would be pure overhead);
- `_tlx_emit_post_kernel_code` fires on `split_k > 1 and self.workspace_arg is not None` and emits `_reduce_k` after the kernel.

So a persistent kernel computes the correct result and stores it, and then the reducer sums SPLIT_K slabs of an UNWRITTEN, UNINITIALIZED workspace on top of the output. The result is garbage, with no error anywhere.

Observed on gfx950, `addmm(1024x512, 1024x2560, 2560x512)`, `TORCHINDUCTOR_TLX_SPLIT_K=1`: `correct=False maxabs=1783.1094` when the autotune winner was `triton_tlx_amd_addmm_persistent_warppipe ... SPLIT_K=2,NUM_SMS=256`. The same shape passes on a rerun that picks `SPLIT_K=1` -- the top three candidates are within 0.3% (0.0155 ms), so which one wins is timing noise, which is exactly why this is intermittent.

Fix: drop `SPLIT_K > 1` configs in the persistent heuristic (the template does not implement split-K). This is the same shape of guard the heuristic already needs for any template-body feature it does not inherit.

## Why this is the terminal fix, not a stopgap

The obvious alternative is to implement split-K in the persistent template so both addmm templates compete on equal footing (they do both compete -- measured below). Three reasons not to:

**1. The two features are gated on opposite saturation regimes.** Split-K candidates are only generated when `tiles < NUM_SMS`. Persistence only buys anything when `tiles >> NUM_SMS` (amortised launch, LDS/L2 kept warm across tiles) -- the per-tile body is copied verbatim into the persistent template, the only delta being the `for tile_iter in tl.range(start_pid, num_tiles, NUM_SMS)` wrapper and hoisting the SMEM allocation. The intersection is empty by construction.

**2. In that regime the persistent kernel is usually, but not always, the weaker of the two.** With `tiles < NUM_SMS` and `SPLIT_K=1` the persistent grid is `min(NUM_SMS, tiles)` = `tiles`, identical to the per-tile grid, and the loop body executes exactly once -- so the only difference is the `for tile_iter in tl.range(...)` wrapper, whose dynamic trip count costs optimisation freedom and registers. Head-to-head, best TLX candidate per template, undersaturated addmm, gfx950 BS=1024:

| model | per-tile faster | persistent faster | largest per-tile margin | largest persistent margin |
|---|---|---|---|---|
| AF OC 200x (1116908456_0) | 9 / 12 | 3 | +30.7% | +3.6% |
| HI OC 700x (1080674750_16) | 15 / 24 | 9 | +45.8% | +5.1% |
| HI IG CTR (1087773826_1723) | 23 / 53 | **30** | +21.4% | +4.1% |

On the two OC nets per-tile dominates. **On HI IG CTR -- the model D114632771 used to justify the gate -- persistent is the better TLX variant on the majority of undersaturated shapes**, though never by much (all <=4.1%, median 3-4%). An earlier revision of this summary claimed persistent "is not the best TLX candidate in either regime on either model"; that generalised from two models and is wrong on the third.

**3. Nothing is lost today -- and this now has a sharper test.** Autotune picks the best candidate across the union of templates, not the best per template. The falsifying test below is met in its loose form on HI IG CTR: of the 31 undersaturated addmm shapes there with `SPLIT_K>1` candidates generated, persistent beats the best per-tile candidate on 14. But on **all 14, per-tile's own best was `SPLIT_K=1`** -- split-K was never the deciding factor, so persistent lacking it costs nothing on those shapes.

The decisive check is the shapes where split-K actually wins. There are two on that model, and persistent's `SPLIT_K=1` time is level with or worse than per-tile's at the same `SPLIT_K=1`, while split-K delivers a large gain from that shared baseline:

| M x N x K | tiles | rocBLAS | per-tile SK=1 | persistent SK=1 | per-tile best |
|---|---|---|---|---|---|
| 1024x512x12288 | 16 | 38.8us | 49.8 | 49.9 | **36.2 (SK=8, -27%)** |
| 1024x1024x159744 | 32 | 464.2us | 884.3 | 971.0 | **433.5 (SK=8, -51%)** |

Since the two templates start from the same place at `SPLIT_K=1` on exactly the shapes where split-K matters, adding split-K to the persistent template would at best tie the per-tile result -- it cannot unlock a win per-tile does not already have. That, rather than "persistent never wins", is the reason to keep this fix as the terminal one.

Falsifying test if this should be revisited: find a shape with `tiles < NUM_SMS` where the best persistent candidate beats the best per-tile candidate **and per-tile's best uses `SPLIT_K>1`**. Across all three models there are none; the 14 near-misses on HI IG CTR all have per-tile at `SPLIT_K=1`.

## Landing order

This is the middle of a 3-diff stack: D115683242 (charge the `_reduce_k` reducer during autotune) -> this diff -> D115683243 (turn split-K on by default). It must land before D115683243: with split-K on and this fix missing, the corruption above becomes reachable in a shipped lowering. Today it is not -- split-K is opt-in behind `TORCHINDUCTOR_TLX_SPLIT_K=1` (default off) -- so this only fires for anyone A/B-ing split-K, which is how it was found.

Authored with Claude Code.

Differential Revision: D115345022


