### PR TITLE
[TLX][AMD] Turn split-K addmm candidates on by default

### DIFF
--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1240,19 +1240,19 @@ class ROCmAddMMWarpPipeTemplateConfigHeuristic(
         # to that case -- unit-scalar addmm and plain mm both qualify. sympy Symbol == 1
         # returns a plain False, so this stays safe for symbolic scalars.
         scalars = getattr(kernel_inputs, "_scalars", None) or {}
-        # Split-K is opt-in via TORCHINDUCTOR_TLX_SPLIT_K=1 (default off). It was gated
-        # because autotune scored each addmm candidate on the GEMM kernel's own time only
-        # and excluded the separate reduce_k kernel, so a split-K TLX addmm could beat
-        # rocBLAS on the GEMM yet be net-slower e2e (HIM: split-K on 46.4K vs off 47.6K
-        # qps T2). TritonTemplateCaller.benchmark now charges every SPLIT_K > 1 candidate
-        # for its measured reducer (see _tlx_caller_benchmark and
-        # reduce_k.reduce_k_cost_ms), which removes that asymmetry -- the default flip is
-        # a follow-up so it can be A/B'd on its own. Correctness also requires
-        # alpha == beta == 1.
+        # Split-K is on by default; TORCHINDUCTOR_TLX_SPLIT_K=0 suppresses the candidates.
+        # It was gated off because autotune scored each addmm candidate on the GEMM
+        # kernel's own time only and excluded the separate reduce_k kernel, so a split-K
+        # TLX addmm could beat rocBLAS on the GEMM yet be net-slower e2e (HIM: split-K on
+        # 46.4K vs off 47.6K qps T2). TritonTemplateCaller.benchmark now charges every
+        # SPLIT_K > 1 candidate for its measured reducer (see _tlx_caller_benchmark and
+        # reduce_k.reduce_k_cost_ms), so the comparison against SPLIT_K=1 candidates is
+        # apples-to-apples and the candidates can compete on their true cost.
+        # Correctness also requires alpha == beta == 1.
         allow_split_k = (
             scalars.get("alpha", 1) == 1
             and scalars.get("beta", 1) == 1
-            and os.environ.get("TORCHINDUCTOR_TLX_SPLIT_K", "0") == "1"
+            and os.environ.get("TORCHINDUCTOR_TLX_SPLIT_K", "1") == "1"
         )
         m_hint = sizevars.optimization_hint(m, fallback=NUM_SMS)
         n_hint = sizevars.optimization_hint(n, fallback=NUM_SMS)

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -1460,6 +1460,15 @@ class ROCmAddMMPersistentWarpPipeTemplateConfigHeuristic(
         for template_kwargs in super()._get_template_configs_impl(
             kernel_inputs, op_name
         ):
+            # The persistent template has NO split-K body -- it never peels split_id and
+            # never writes split_k_ws; it stores straight through store_output. But
+            # SPLIT_K > 1 alone makes _tlx_tt_generate allocate the UNINITIALIZED
+            # split_k_ws and _tlx_emit_post_kernel_code emit _reduce_k after the kernel,
+            # and that reducer then sums the never-written workspace over the output.
+            # Inheriting the per-tile heuristic's split-K candidates therefore yields
+            # silently WRONG results whenever autotune happens to pick one. Drop them.
+            if int(template_kwargs.get("SPLIT_K", 1)) > 1:
+                continue
             yield {**template_kwargs, "NUM_SMS": num_sms}
 
 


### PR DESCRIPTION
Summary:
Flips `TORCHINDUCTOR_TLX_SPLIT_K` from off to on now that the split-K reducer is charged during autotune. Set `TORCHINDUCTOR_TLX_SPLIT_K=0` to suppress the candidates again.

Split-K was gated off in D114632771 because selection was unfair, not because the kernels were bad: autotune compared a split-K candidate's GEMM kernel against SPLIT_K=1 candidates that carry no reducer, so it could pick split-K and lose end-to-end. With D115683242 in place a split-K candidate only wins when it is genuinely faster including the reducer.

This is deliberately its own diff so it can be A/B'd and reverted independently of the machinery below it.

Both prerequisites are stacked below rather than left as prose:
- D115683242 charges the reducer, without which turning this on reintroduces the bad selection the original gate was protecting against.
- D115345022 drops the inherited split-K candidates from the persistent addmm heuristic, which has no split-K body. Without it, split-K on lets autotune pick a persistent split-K config whose reducer sums a never-written workspace over the output and silently produces wrong results.

## Only one of the two addmm templates gains split-K, and that is fine

There are two TLX addmm templates and autotune runs both on every eligible shape:

| | file | autotune candidate | split-K |
|---|---|---|---|
| per-tile | `amd_addmm_warppipe.py.jinja` | `triton_tlx_amd_addmm_warppipe_*` | yes (12 `SPLIT_K` / 6 `split_id` / 2 `split_k_ws` refs) |
| persistent | `amd_addmm_persistent_warppipe.py.jinja` | `triton_tlx_amd_addmm_persistent_warppipe_*` | none (0 / 0 / 0) |

So this flip only arms the per-tile template. That does not disadvantage anything, because the regime where split-K candidates are generated (`tiles < NUM_SMS` = 256 on gfx950) is the regime the per-tile template already wins. Two measurements, both gfx950 BS=1024, best TLX candidate per template within the same autotune run, over every undersaturated addmm shape in both models where both templates bid.

### Table 1 -- both templates constrained to SPLIT_K=1 (split-K off)

Baseline: is the persistent template competitive *before* split-K enters the picture? Every candidate on both sides of this table is **`SPLIT_K=1`** -- verified, that is the only SPLIT_K value present anywhere in these two runs -- so no `split_k_ws` is allocated, **no `_reduce_k` is emitted for either template, and no reducer cost is charged to or omitted from either side.** It is a clean single-kernel-vs-single-kernel comparison; the only structural difference is the persistent template's `for tile_iter in tl.range(...)` wrapper.

| model | M x N x K | MN tiles | per-tile us | persistent us | faster |
|---|---|---|---|---|---|
| HI OC 700x | 1024x256x160 | 8 | 8.3 | 12.1 | **per-tile +45.8%** |
| HI OC 700x | 1024x896x152 | 32 | 7.6 | 10.7 | **per-tile +40.8%** |
| HI OC 700x | 1024x2048x3411 | 64 | 62.6 | 86.8 | **per-tile +38.7%** |
| AF OC 200x | 9344x128x160 | 73 | 7.5 | 9.8 | **per-tile +30.7%** |
| HI OC 700x | 1024x6144x22272 | 192 | 389.7 | 491.8 | **per-tile +26.2%** |
| AF OC 200x | 3072x1536x3072 | 144 | 46.3 | 55.9 | **per-tile +20.7%** |
| AF OC 200x | 3072x2560x4096 | 240 | 78.3 | 93.9 | **per-tile +19.9%** |
| HI OC 700x | 1024x1024x3411 | 32 | 42.5 | 50.5 | **per-tile +18.8%** |
| AF OC 200x | 3072x2048x4096 | 192 | 71.3 | 80.2 | **per-tile +12.5%** |
| HI OC 700x | 1024x6144x4096 | 192 | 69.5 | 78.1 | **per-tile +12.4%** |
| HI OC 700x | 1024x896x240 | 32 | 7.7 | 8.6 | **per-tile +11.7%** |
| HI OC 700x | 1024x256x256 | 8 | 8.7 | 9.6 | **per-tile +10.3%** |
| AF OC 200x | 3072x768x4096 | 72 | 42.7 | 46.2 | **per-tile +8.2%** |
| HI OC 700x | 1024x256x256 | 8 | 7.5 | 8.0 | **per-tile +6.7%** |
| HI OC 700x | 1024x256x100 | 8 | 6.9 | 7.3 | **per-tile +5.8%** |
| HI OC 700x | 1024x3411x1024 | 112 | 22.3 | 23.5 | **per-tile +5.4%** |
| HI OC 700x | 1024x4096x6144 | 128 | 76.7 | 80.0 | **per-tile +4.3%** |
| HI OC 700x | 1024x6144x512 | 192 | 17.4 | 18.1 | **per-tile +4.0%** |
| AF OC 200x | 16384x8x146 | 128 | 7.0 | 7.2 | **per-tile +2.9%** |
| AF OC 200x | 3072x768x768 | 72 | 14.5 | 14.9 | **per-tile +2.8%** |
| AF OC 200x | 128x3072x19404 | 12 | 142.0 | 144.3 | **per-tile +1.6%** |
| HI OC 700x | 1024x896x92 | 32 | 7.1 | 7.2 | **per-tile +1.4%** |
| AF OC 200x | 3072x1024x1024 | 96 | 17.8 | 18.0 | **per-tile +1.1%** |
| HI OC 700x | 1024x1024x22272 | 32 | 114.5 | 114.6 | **per-tile +0.1%** |
| HI OC 700x | 1024x2048x6144 | 64 | 57.7 | 57.6 | persistent +0.2% |
| HI OC 700x | 1024x1024x12288 | 32 | 63.7 | 63.5 | persistent +0.3% |
| AF OC 200x | 3072x512x3072 | 48 | 32.6 | 32.3 | persistent +0.9% |
| HI OC 700x | 1024x256x512 | 8 | 8.2 | 8.1 | persistent +1.2% |
| HI OC 700x | 1024x1536x2048 | 48 | 23.2 | 22.8 | persistent +1.7% |
| AF OC 200x | 128x7168x3072 | 28 | 21.2 | 20.8 | persistent +1.9% |
| HI OC 700x | 1024x512x2560 | 16 | 16.3 | 15.9 | persistent +2.5% |
| HI OC 700x | 1024x1x512 | 8 | 8.0 | 7.8 | persistent +2.5% |
| HI OC 700x | 1024x896x1840 | 32 | 15.5 | 15.1 | persistent +2.6% |
| HI OC 700x | 1024x896x520 | 32 | 9.2 | 8.9 | persistent +3.3% |
| AF OC 200x | 3072x1x512 | 24 | 8.3 | 8.0 | persistent +3.6% |
| HI OC 700x | 1024x1024x1024 | 32 | 11.8 | 11.2 | persistent +5.1% |

36 undersaturated addmm shapes where both templates bid. per-tile faster on 24, persistent faster on 12. Largest per-tile margin +45.8%; largest persistent margin +5.1%.

### Table 2 -- constraint removed: per-tile free to use split-K, reducer charged

The shipping configuration once this stack lands: per-tile may pick any `SPLIT_K`, and its time **includes the measured `_reduce_k`** (D115683242). The persistent template has no split-K body, so its candidates remain `SPLIT_K=1` (verified: 1 is the only value among persistent candidates in these runs, i.e. D115345022's guard is active).

| model | M x N x K | MN tiles | per-tile us (best SK) | persistent us (SK=1) | faster |
|---|---|---|---|---|---|
| HI OC 700x | 1024x1024x22272 | 32 | 85.5 (SK=8) | 129.8 | **per-tile +51.8%** |
| HI OC 700x | 1024x256x160 | 8 | 8.6 (SK=1) | 12.2 | **per-tile +41.9%** |
| HI OC 700x | 1024x2048x3411 | 64 | 62.8 (SK=1) | 87.0 | **per-tile +38.5%** |
| HI OC 700x | 1024x896x152 | 32 | 7.8 (SK=1) | 10.8 | **per-tile +38.5%** |
| HI OC 700x | 1024x6144x22272 | 192 | 378.6 (SK=1) | 497.3 | **per-tile +31.4%** |
| AF OC 200x | 9344x128x160 | 73 | 7.7 (SK=1) | 9.9 | **per-tile +28.6%** |
| AF OC 200x | 3072x2560x4096 | 240 | 77.6 (SK=1) | 94.3 | **per-tile +21.5%** |
| HI OC 700x | 1024x4096x6144 | 128 | 80.1 (SK=2) | 97.0 | **per-tile +21.1%** |
| HI OC 700x | 1024x1024x12288 | 32 | 56.0 (SK=4) | 67.5 | **per-tile +20.5%** |
| AF OC 200x | 3072x1536x3072 | 144 | 46.7 (SK=1) | 56.2 | **per-tile +20.3%** |
| AF OC 200x | 3072x2048x4096 | 192 | 66.3 (SK=1) | 79.6 | **per-tile +20.1%** |
| HI OC 700x | 1024x1024x3411 | 32 | 42.5 (SK=1) | 50.6 | **per-tile +19.1%** |
| HI OC 700x | 1024x6144x4096 | 192 | 72.3 (SK=1) | 85.1 | **per-tile +17.7%** |
| HI OC 700x | 1024x2048x6144 | 64 | 51.3 (SK=2) | 57.7 | **per-tile +12.5%** |
| HI OC 700x | 1024x896x240 | 32 | 7.8 (SK=1) | 8.7 | **per-tile +11.5%** |
| HI OC 700x | 1024x256x256 | 8 | 8.9 (SK=1) | 9.8 | **per-tile +10.1%** |
| AF OC 200x | 3072x768x4096 | 72 | 42.5 (SK=1) | 46.2 | **per-tile +8.7%** |
| HI OC 700x | 1024x256x256 | 8 | 7.6 (SK=1) | 8.1 | **per-tile +6.6%** |
| HI OC 700x | 1024x256x100 | 8 | 7.2 (SK=1) | 7.6 | **per-tile +5.6%** |
| HI OC 700x | 1024x3411x1024 | 112 | 22.6 (SK=1) | 23.6 | **per-tile +4.4%** |
| HI OC 700x | 1024x896x92 | 32 | 7.1 (SK=1) | 7.4 | **per-tile +4.2%** |
| AF OC 200x | 128x7168x3072 | 28 | 21.5 (SK=1) | 22.4 | **per-tile +4.2%** |
| HI OC 700x | 1024x6144x512 | 192 | 17.6 (SK=1) | 18.3 | **per-tile +4.0%** |
| HI OC 700x | 1024x1x512 | 8 | 8.1 (SK=1) | 8.4 | **per-tile +3.7%** |
| AF OC 200x | 3072x768x768 | 72 | 14.5 (SK=1) | 15.0 | **per-tile +3.4%** |
| AF OC 200x | 3072x512x3072 | 48 | 31.4 (SK=2) | 32.4 | **per-tile +3.2%** |
| AF OC 200x | 16384x8x146 | 128 | 7.0 (SK=1) | 7.2 | **per-tile +2.9%** |
| AF OC 200x | 128x3072x19404 | 12 | 141.2 (SK=1) | 143.8 | **per-tile +1.8%** |
| AF OC 200x | 3072x1x512 | 24 | 8.4 (SK=1) | 8.4 | persistent +0.0% |
| HI OC 700x | 1024x1536x2048 | 48 | 23.2 (SK=1) | 22.9 | persistent +1.3% |
| HI OC 700x | 1024x512x2560 | 16 | 16.4 (SK=1) | 16.1 | persistent +1.8% |
| AF OC 200x | 3072x1024x1024 | 96 | 18.4 (SK=1) | 18.0 | persistent +2.2% |
| HI OC 700x | 1024x256x512 | 8 | 8.4 (SK=1) | 8.2 | persistent +2.4% |
| HI OC 700x | 1024x896x1840 | 32 | 15.8 (SK=1) | 15.4 | persistent +2.5% |
| HI OC 700x | 1024x896x520 | 32 | 9.3 (SK=1) | 9.0 | persistent +3.2% |
| HI OC 700x | 1024x1024x1024 | 32 | 12.0 (SK=1) | 11.4 | persistent +5.0% |

36 shapes. per-tile faster on 28, persistent faster on 8. per-tile's winning candidate used SPLIT_K>1 on 5 of them. Largest per-tile margin +51.8%; largest persistent margin +5.0%.
SPLIT_K values seen among persistent candidates: [1]

Per-tile's advantage widens rather than narrows once it can use split-K: 24 -> 28 of 36 shapes, largest margin +45.8% -> +51.8%. It only needed `SPLIT_K>1` on 5 shapes to get there; on the rest it was already ahead at `SPLIT_K=1`. The 8 shapes persistent still takes, it takes by <=5.0%, inside autotune noise for these sub-20us kernels.

The reason is structural: at `tiles < NUM_SMS` the persistent grid is `min(NUM_SMS, tiles)` = `tiles`, identical to the per-tile grid, and the persistent loop body executes exactly once. The only delta is the loop wrapper itself, whose dynamic trip count costs optimisation freedom and registers. Persistence only pays when `tiles >> NUM_SMS`, which is exactly where split-K is never generated.

Consequence for this flip: on every undersaturated shape where the persistent variant was TLX's best with split-K off, turning split-K on either hands the win to a per-tile split-K candidate (`1024x1024x12288` 63.5 -> 56.0us SK=4, `1024x2048x6144` 57.6 -> 51.3 SK=2, `3072x512x3072` 32.3 -> 31.4 SK=2 -- all three reducer-inclusive) or leaves the persistent SPLIT_K=1 candidate winning unchanged. No shape regresses because the persistent template lacks split-K. Rationale for not implementing split-K there is in D115345022.

### Table 3 -- saturated shapes (`tiles >= NUM_SMS`), where split-K is never generated

Completes the coverage: the 35 saturated addmm shapes excluded from Tables 1-2, in the same per-GEMM head-to-head form, with rocBLAS and stock Triton as references.

**Verified: zero `SPLIT_K>1` candidates exist on any of these 35 shapes** -- the generation gate requires `tiles < NUM_SMS`, so this flip provably cannot change anything in this regime. It follows that **the per-tile column here carries no `_reduce_k` charge**: every per-tile candidate shown is `SPLIT_K=1`, and D115683242's charge only applies to `SPLIT_K>1`. So, as in Table 1, both TLX columns are single-kernel times with no reducer on either side.

Note there is no saturation gate on template *eligibility*: neither heuristic filters by tile count (the only tile-count test in either is the split-K one), so both templates bid on every eligible shape. Measured: persistent never bids alone -- both bid on 31 of 35 here, per-tile alone on 3, neither on 1. This is also the regime persistence exists for, so it is the fair place to ask whether the persistent template earns its keep.

| model | M x N x K | MN tiles | rocBLAS us | stock Triton us | per-tile us | persistent us | faster (TLX head-to-head) | roc/per-tile | roc/persistent | autotune picked |
|---|---|---|---|---|---|---|---|---|---|---|
| AF OC 200x | 218112x128x160 | 1704 | 42.9 | 44.2 | 43.3 | 58.3 | **per-tile +34.6%** | 0.99 | 0.74 | rocBLAS |
| AF OC 200x | 3072x3072x14208 | 288 | 261.1 | 395.2 | 398.9 | 525.5 | **per-tile +31.7%** | 0.65 | 0.50 | rocBLAS |
| AF OC 200x | 393216x32x142 | 3072 | 51.2 | 47.8 | 54.1 | 69.1 | **per-tile +27.7%** | 0.95 | 0.74 | stock Triton |
| HI OC 700x | 262144x48x294 | 2048 | 77.8 | 62.6 | 64.4 | 82.2 | **per-tile +27.6%** | **1.21** | 0.95 | stock Triton |
| AF OC 200x | 3072x4096x25344 | 384 | 633.1 | 803.2 | 869.9 | 1084.8 | **per-tile +24.7%** | 0.73 | 0.58 | rocBLAS |
| AF OC 200x | 3072x3072x11800 | 288 | 268.4 | 383.9 | 413.1 | 513.7 | **per-tile +24.4%** | 0.65 | 0.52 | rocBLAS |
| AF OC 200x | 3072x8192x3072 | 768 | 151.8 | 197.4 | 183.7 | 223.4 | **per-tile +21.6%** | 0.83 | 0.68 | rocBLAS |
| AF OC 200x | 3072x4096x2560 | 384 | 77.4 | 86.6 | 88.0 | 105.5 | **per-tile +19.9%** | 0.88 | 0.73 | rocBLAS |
| HI OC 700x | 1024x20480x6144 | 640 | 264.6 | 389.6 | 370.3 | 441.4 | **per-tile +19.2%** | 0.71 | 0.60 | rocBLAS |
| AF OC 200x | 3072x4096x2048 | 384 | 66.6 | 68.8 | 72.4 | 85.6 | **per-tile +18.2%** | 0.92 | 0.78 | rocBLAS |
| AF OC 200x | 3072x9216x3072 | 864 | 165.8 | 217.8 | 229.6 | 267.9 | **per-tile +16.7%** | 0.72 | 0.62 | rocBLAS |
| AF OC 200x | 3072x3072x1536 | 288 | 46.8 | 47.8 | 50.5 | 58.8 | **per-tile +16.4%** | 0.93 | 0.80 | rocBLAS |
| AF OC 200x | 3072x15360x4096 | 1440 | 434.4 | 491.6 | 524.9 | 577.1 | **per-tile +9.9%** | 0.83 | 0.75 | rocBLAS |
| HI OC 700x | 1024x43008x512 | 1344 | 78.0 | 83.6 | 94.1 | 102.2 | **per-tile +8.6%** | 0.83 | 0.76 | rocBLAS |
| HI OC 700x | 1024x18816x1024 | 592 | 59.4 | 69.6 | 67.6 | 73.4 | **per-tile +8.6%** | 0.88 | 0.81 | rocBLAS |
| HI OC 700x | 1024x22272x1024 | 696 | 64.0 | 74.4 | 73.5 | 79.2 | **per-tile +7.8%** | 0.87 | 0.81 | rocBLAS |
| HI OC 700x | 262144x262x294 | 4096 | 153.4 | 179.6 | 234.8 | 251.5 | **per-tile +7.1%** | 0.65 | 0.61 | rocBLAS |
| HI OC 700x | 2252800x768x256 | 52800 | 2619.9 | 2014.4 | 2158.1 | 2305.2 | **per-tile +6.8%** | **1.21** | **1.14** | stock Triton |
| HI OC 700x | 1024x16384x1024 | 512 | 40.6 | 45.4 | 52.5 | 56.0 | **per-tile +6.7%** | 0.77 | 0.72 | rocBLAS |
| AF OC 200x | 3072x5120x1024 | 480 | 54.0 | 48.9 | 54.4 | 56.9 | **per-tile +4.6%** | 0.99 | 0.95 | stock Triton |
| HI OC 700x | 2252800x512x256 | 35200 | 1737.5 | 1384.7 | 1430.4 | 1483.6 | **per-tile +3.7%** | **1.21** | **1.17** | stock Triton |
| AF OC 200x | 3072x11136x1024 | 1056 | 128.4 | 128.1 | 130.8 | 135.2 | **per-tile +3.4%** | 0.98 | 0.95 | stock Triton |
| AF OC 200x | 3072x10240x1024 | 960 | 102.7 | 100.3 | 115.6 | 115.7 | **per-tile +0.1%** | 0.89 | 0.89 | stock Triton |
| HI OC 700x | 2252800x256x512 | 17600 | 1022.9 | 1195.3 | 1302.0 | 1296.6 | persistent +0.4% | 0.79 | 0.79 | rocBLAS |
| AF OC 200x | 3072x4096x768 | 384 | 27.3 | 31.7 | 35.9 | 35.7 | persistent +0.6% | 0.76 | 0.76 | rocBLAS |
| AF OC 200x | 3072x22272x1024 | 2088 | 235.1 | 237.5 | 257.8 | 256.0 | persistent +0.7% | 0.91 | 0.92 | rocBLAS |
| HI OC 700x | 32768x256x256 | 256 | 17.8 | 13.6 | 15.7 | 15.2 | persistent +3.2% | **1.13** | **1.17** | stock Triton |
| HI OC 700x | 204800x256x256 | 1600 | 73.6 | 74.1 | 87.1 | 83.8 | persistent +3.8% | 0.85 | 0.88 | rocBLAS |
| HI OC 700x | 2252800x256x256 | 17600 | 673.2 | 749.5 | 811.6 | 767.1 | persistent +5.5% | 0.83 | 0.88 | rocBLAS |
| HI OC 700x | 409600x256x256 | 3200 | 141.9 | 140.4 | 157.4 | 147.4 | persistent +6.4% | 0.90 | 0.96 | stock Triton |
| HI OC 700x | 229376x256x256 | 1792 | 81.3 | 82.1 | 92.3 | 85.1 | persistent +7.8% | 0.88 | 0.96 | rocBLAS |
| AF OC 200x | 128000x128x128 | 1000 | 22.5 | 18.0 | 31.0 | — | — (only one bid) | 0.73 | — | stock Triton |
| AF OC 200x | 128000x256x128 | 1000 | 31.8 | 29.6 | 37.6 | — | — (only one bid) | 0.85 | — | stock Triton |
| AF OC 200x | 393216x32x80 | 3072 | 36.1 | 21.3 | — | — | — (only one bid) | — | — | stock Triton |
| AF OC 200x | 98304x128x128 | 768 | 18.3 | 15.1 | 21.3 | — | — (only one bid) | 0.86 | — | stock Triton |

35 saturated addmm shapes; 31 have both TLX variants bidding. per-tile faster on 23, persistent faster on 8. per-tile beats rocBLAS on 4/35, persistent on 3/31. Median roc/per-tile 0.86, roc/persistent 0.79.
Autotune winner: rocBLAS=22, stock Triton=13 -- TLX never selected.

It does not, on these two models. Even in its home regime the persistent template loses the head-to-head on 23/31 shapes; median `rocBLAS/persistent` is 0.79 against 0.86 for per-tile, and **autotune selected TLX on 0 of the 35**.

The one coherent exception is worth naming: every shape persistent wins is tall-M with `N = K = 256` (`229376x256x256` +7.8%, `409600x256x256` +6.4%, `2252800x256x256` +5.5%, `204800x256x256` +3.8%, `32768x256x256` +3.2%) -- the family where persistence behaves as designed. It is still not enough to be selected: rocBLAS or stock Triton wins each of them. Conversely per-tile's largest saturated margins are deep-K (`3072x3072x14208` +31.7%, `3072x4096x25344` +24.7%), where the loop wrapper appears to cost most.

### Third model: HIM IG CTR (1087773826_1723) -- the net that motivated the gate

D114632771 gated split-K off after measuring this model: TLX split-K off 47,628 / 47,600 qps vs split-K on 46,440 / 45,416 qps (-2.5% / -4.6%), with "12 of 17 TLX GEMMs selected at SPLIT_K=2/4/8". Re-measured here with the reducer charged (`mts_gpu_benchmark`, AOT_INDUCTOR, BS=1024, gfx950; both arms `Accuracy: True`):

| | split-K off | split-K on + reducer charged |
|---|---|---|
| E2E | 33.73 ms/iter | 34.21 ms/iter |
| GEMM total | 22.545 ms/iter | 22.844 ms/iter |
| rocBLAS / stock Triton / TLX | 17.831 / 3.617 / 1.097 | 17.070 / 3.848 / 1.863 (+0.063 `_reduce_k`) |
| GEMM sites selecting TLX | 5 of 100 | 7 of 100 |
| sites selecting a `SPLIT_K>1` candidate | 0 | **2** |

**Costing collapses split-K selection from "12 of 17" to 2 of 100, and both survivors are wins:**

| M x N x K | tiles | rocBLAS | per-tile SK=1 | persistent SK=1 | per-tile best | vs rocBLAS |
|---|---|---|---|---|---|---|
| 1024x512x12288 | 16 | 38.8us | 49.8 | 49.9 | **36.2 (SK=8)** | **1.07** |
| 1024x1024x159744 | 32 | 464.2us | 884.3 | 971.0 | **433.5 (SK=8)** | **1.07** |

The +1.3% GEMM / +1.4% E2E delta is **not** attributable to split-K. Every regressed site kept the same backend in both runs -- `1024x159744x1024` rocBLAS 375.6 -> rocBLAS 452.4us (+20.4%), `1024x1024x8192` rocBLAS 39.6 -> 44.1 (+11.4%), four stock-Triton -> stock-Triton at +2.9% -- i.e. autotune/hipBLASLt run-to-run variance on shapes whose selection never changed. The contention control points the other way: the identical `_attn_fwd` kernel ran 65.0us in the split-K arm vs 66.8us in the baseline, so if anything the split-K arm had the better conditions.

So the original -2.5%/-4.6% is consistent with uncharged selection taking split-K on 12 of 17 GEMMs; with the reducer charged it takes 2 of 100 and both are faster than rocBLAS.

### Tables 4-6 -- HI IG CTR (1087773826_1723), full per-GEMM lists

Same three views as Tables 1-3, for the third model. 93 addmm sites total (plus 7 bmm).

#### Table 4 -- both templates constrained to SPLIT_K=1 (split-K off)

All candidates on both sides are `SPLIT_K=1`; no `_reduce_k` is emitted for either template, so no reducer cost is charged to or omitted from either side.

| M x N x K | MN tiles | per-tile us | persistent us | faster |
|---|---|---|---|---|
| 1024x2048x5114 | 64 | 46.6 | 66.1 | **per-tile +41.8%** |
| 1024x512x160 | 16 | 7.4 | 10.2 | **per-tile +37.8%** |
| 1024x256x144 | 8 | 7.2 | 9.9 | **per-tile +37.5%** |
| 1024x512x144 | 16 | 7.3 | 10.0 | **per-tile +37.0%** |
| 32x512x160 | 2 | 6.9 | 9.2 | **per-tile +33.3%** |
| 1024x6144x22592 | 192 | 382.6 | 502.8 | **per-tile +31.4%** |
| 1024x5114x512 | 160 | 19.1 | 23.9 | **per-tile +25.1%** |
| 1024x6144x159744 | 192 | 2806.5 | 3479.1 | **per-tile +24.0%** |
| 1024x6144x3072 | 192 | 50.9 | 59.9 | **per-tile +17.7%** |
| 1024x512x5114 | 16 | 30.2 | 32.6 | **per-tile +7.9%** |
| 1024x48x256 | 8 | 7.2 | 7.6 | **per-tile +5.6%** |
| 1024x256x256 | 8 | 7.3 | 7.7 | **per-tile +5.5%** |
| 1024x512x100 | 16 | 6.9 | 7.2 | **per-tile +4.3%** |
| 1024x64x256 | 8 | 7.1 | 7.4 | **per-tile +4.2%** |
| 1024x144x256 | 8 | 7.4 | 7.7 | **per-tile +4.1%** |
| 1024x512x256 | 16 | 7.6 | 7.9 | **per-tile +3.9%** |
| 1024x6144x512 | 192 | 17.7 | 18.3 | **per-tile +3.4%** |
| 3200x128x256 | 25 | 7.4 | 7.6 | **per-tile +2.7%** |
| 4800x128x256 | 38 | 7.6 | 7.8 | **per-tile +2.6%** |
| 1024x624x256 | 24 | 7.8 | 8.0 | **per-tile +2.6%** |
| 9600x256x512 | 75 | 12.6 | 12.9 | **per-tile +2.4%** |
| 9600x512x256 | 150 | 12.8 | 13.0 | **per-tile +1.6%** |
| 1024x3072x6144 | 96 | 66.3 | 66.4 | **per-tile +0.2%** |
| 6400x768x256 | 150 | 12.8 | 12.8 | persistent +0.0% |
| 1024x1024x864 | 32 | 11.1 | 11.1 | persistent +0.0% |
| 1024x1024x28 | 32 | 7.0 | 7.0 | persistent +0.0% |
| 1024x3072x512 | 96 | 12.5 | 12.5 | persistent +0.0% |
| 1024x2560x320 | 80 | 10.6 | 10.6 | persistent +0.0% |
| 1024x512x12288 | 16 | 49.8 | 49.7 | persistent +0.2% |
| 1024x1024x159744 | 32 | 894.8 | 892.9 | persistent +0.2% |
| 1024x1024x8192 | 32 | 45.4 | 45.3 | persistent +0.2% |
| 1024x1024x22592 | 32 | 120.5 | 120.0 | persistent +0.4% |
| 1024x1024x12288 | 32 | 65.7 | 65.3 | persistent +0.6% |
| 1024x3072x320 | 96 | 10.9 | 10.8 | persistent +0.9% |
| 9600x256x256 | 75 | 10.1 | 10.0 | persistent +1.0% |
| 1024x256x6144 | 8 | 28.3 | 28.0 | persistent +1.1% |
| 6400x512x256 | 100 | 10.6 | 10.4 | persistent +1.9% |
| 9600x768x256 | 225 | 15.2 | 14.9 | persistent +2.0% |
| 1024x768x624 | 24 | 9.2 | 9.0 | persistent +2.2% |
| 1024x512x624 | 16 | 9.0 | 8.8 | persistent +2.2% |
| 1024x256x512 | 8 | 8.2 | 8.0 | persistent +2.4% |
| 1024x512x2560 | 16 | 16.3 | 15.9 | persistent +2.5% |
| 1024x256x2048 | 8 | 13.6 | 13.2 | persistent +2.9% |
| 1024x1024x456 | 32 | 9.0 | 8.7 | persistent +3.3% |
| 6400x256x256 | 50 | 8.8 | 8.5 | persistent +3.4% |
| 1024x512x2048 | 16 | 14.2 | 13.7 | persistent +3.5% |
| 6400x256x512 | 50 | 11.0 | 10.6 | persistent +3.6% |
| 32x256x512 | 1 | 8.1 | 7.8 | persistent +3.7% |
| 1024x512x320 | 16 | 7.7 | 7.4 | persistent +3.9% |
| 1024x256x328 | 8 | 7.7 | 7.4 | persistent +3.9% |
| 32x512x1024 | 2 | 10.1 | 9.7 | persistent +4.0% |
| 1024x1024x1024 | 32 | 12.1 | 11.6 | persistent +4.1% |
| 1024x1x512 | 8 | 8.4 | 8.0 | persistent +4.8% |

53 undersaturated addmm shapes where both templates bid. per-tile faster on 23, persistent faster on 30. Largest per-tile margin +41.8%; largest persistent margin +4.8%.

#### Table 5 -- constraint removed: per-tile free to use split-K, reducer charged

Per-tile may pick any `SPLIT_K` and its time **includes the measured `_reduce_k`**; persistent stays `SPLIT_K=1`.

| M x N x K | MN tiles | per-tile us (best SK) | persistent us (SK=1) | faster |
|---|---|---|---|---|
| 1024x1024x159744 | 32 | 433.5 (SK=8) | 971.0 | **per-tile +124.0%** |
| 1024x1024x22592 | 32 | 83.1 (SK=8) | 135.4 | **per-tile +62.9%** |
| 1024x2048x5114 | 64 | 46.6 (SK=1) | 66.5 | **per-tile +42.7%** |
| 1024x512x12288 | 16 | 36.2 (SK=8) | 49.9 | **per-tile +37.8%** |
| 1024x512x160 | 16 | 7.5 (SK=1) | 10.3 | **per-tile +37.3%** |
| 1024x256x144 | 8 | 7.3 (SK=1) | 10.0 | **per-tile +37.0%** |
| 1024x6144x159744 | 192 | 2525.0 (SK=4) | 3435.3 | **per-tile +36.1%** |
| 1024x512x144 | 16 | 7.5 (SK=1) | 10.2 | **per-tile +36.0%** |
| 32x512x160 | 2 | 7.0 (SK=1) | 9.2 | **per-tile +31.4%** |
| 1024x6144x22592 | 192 | 379.1 (SK=1) | 489.9 | **per-tile +29.2%** |
| 1024x256x6144 | 8 | 21.8 (SK=4) | 28.1 | **per-tile +28.9%** |
| 1024x5114x512 | 160 | 19.0 (SK=1) | 23.7 | **per-tile +24.7%** |
| 1024x1024x12288 | 32 | 55.2 (SK=4) | 66.2 | **per-tile +19.9%** |
| 1024x6144x3072 | 192 | 53.0 (SK=1) | 59.7 | **per-tile +12.6%** |
| 1024x512x5114 | 16 | 30.4 (SK=1) | 32.5 | **per-tile +6.9%** |
| 1024x48x256 | 8 | 7.3 (SK=1) | 7.8 | **per-tile +6.8%** |
| 1024x3072x6144 | 96 | 62.3 (SK=1) | 66.3 | **per-tile +6.4%** |
| 1024x144x256 | 8 | 7.5 (SK=1) | 7.9 | **per-tile +5.3%** |
| 4800x128x256 | 38 | 7.8 (SK=1) | 8.2 | **per-tile +5.1%** |
| 1024x512x100 | 16 | 7.0 (SK=1) | 7.3 | **per-tile +4.3%** |
| 1024x256x256 | 8 | 7.5 (SK=1) | 7.8 | **per-tile +4.0%** |
| 3200x128x256 | 25 | 7.6 (SK=1) | 7.9 | **per-tile +3.9%** |
| 1024x6144x512 | 192 | 17.8 (SK=1) | 18.5 | **per-tile +3.9%** |
| 1024x512x256 | 16 | 7.7 (SK=1) | 8.0 | **per-tile +3.9%** |
| 1024x624x256 | 24 | 7.9 (SK=1) | 8.2 | **per-tile +3.8%** |
| 9600x256x512 | 75 | 12.6 (SK=1) | 13.0 | **per-tile +3.2%** |
| 1024x1024x8192 | 32 | 44.2 (SK=4) | 45.6 | **per-tile +3.2%** |
| 1024x64x256 | 8 | 7.4 (SK=1) | 7.6 | **per-tile +2.7%** |
| 6400x768x256 | 150 | 12.6 (SK=1) | 12.8 | **per-tile +1.6%** |
| 9600x512x256 | 150 | 12.8 (SK=1) | 12.9 | **per-tile +0.8%** |
| 1024x1x512 | 8 | 8.2 (SK=1) | 8.2 | persistent +0.0% |
| 1024x1024x864 | 32 | 11.2 (SK=1) | 11.2 | persistent +0.0% |
| 1024x1024x28 | 32 | 7.1 (SK=1) | 7.1 | persistent +0.0% |
| 1024x3072x512 | 96 | 12.6 (SK=1) | 12.6 | persistent +0.0% |
| 1024x2560x320 | 80 | 10.6 (SK=1) | 10.6 | persistent +0.0% |
| 1024x3072x320 | 96 | 11.0 (SK=1) | 10.9 | persistent +0.9% |
| 32x256x512 | 1 | 8.0 (SK=1) | 7.9 | persistent +1.2% |
| 6400x512x256 | 100 | 10.8 (SK=1) | 10.6 | persistent +1.9% |
| 9600x256x256 | 75 | 10.2 (SK=1) | 10.0 | persistent +2.0% |
| 32x512x1024 | 2 | 10.1 (SK=1) | 9.9 | persistent +2.0% |
| 1024x512x624 | 16 | 9.2 (SK=1) | 9.0 | persistent +2.2% |
| 1024x256x512 | 8 | 8.4 (SK=1) | 8.2 | persistent +2.4% |
| 1024x512x2560 | 16 | 16.3 (SK=1) | 15.9 | persistent +2.5% |
| 1024x256x328 | 8 | 7.7 (SK=1) | 7.5 | persistent +2.6% |
| 9600x768x256 | 225 | 15.1 (SK=1) | 14.7 | persistent +2.6% |
| 6400x256x512 | 50 | 11.1 (SK=1) | 10.8 | persistent +2.7% |
| 1024x512x2048 | 16 | 14.2 (SK=1) | 13.8 | persistent +2.8% |
| 1024x256x2048 | 8 | 13.8 (SK=1) | 13.4 | persistent +2.9% |
| 1024x768x624 | 24 | 9.4 (SK=1) | 9.1 | persistent +3.2% |
| 1024x1024x456 | 32 | 9.1 (SK=1) | 8.8 | persistent +3.3% |
| 1024x512x320 | 16 | 7.7 (SK=1) | 7.4 | persistent +3.9% |
| 1024x1024x1024 | 32 | 12.2 (SK=1) | 11.7 | persistent +4.1% |
| 6400x256x256 | 50 | 9.0 (SK=1) | 8.6 | persistent +4.4% |

53 shapes. per-tile faster on 30, persistent faster on 23. per-tile's winning candidate used SPLIT_K>1 on 7. Largest per-tile margin +124.0%; largest persistent margin +4.4%.

#### Table 6 -- saturated shapes (`tiles >= NUM_SMS`), where split-K is never generated

| M x N x K | MN tiles | rocBLAS us | stock Triton us | per-tile us | persistent us | faster (TLX head-to-head) | roc/per-tile | roc/persistent | autotune picked |
|---|---|---|---|---|---|---|---|---|---|
| 262144x433x2400 | 4096 | 651.5 | 1054.7 | 1057.5 | 1636.0 | **per-tile +54.7%** | 0.62 | 0.40 | rocBLAS |
| 262144x176x257 | 2048 | 102.8 | 135.5 | 134.8 | 164.5 | **per-tile +22.0%** | 0.76 | 0.62 | rocBLAS |
| 1024x32768x6144 | 1024 | 371.8 | 507.9 | 518.7 | 627.9 | **per-tile +21.1%** | 0.72 | 0.59 | rocBLAS |
| 262144x48x257 | 2048 | 68.6 | 61.2 | 91.0 | 103.7 | **per-tile +14.0%** | 0.75 | 0.66 | stock Triton |
| 1024x153600x1024 | 4800 | 386.5 | 479.4 | 523.5 | 586.7 | **per-tile +12.1%** | 0.74 | 0.66 | rocBLAS |
| 1024x22592x1024 | 712 | 69.0 | 73.8 | 74.0 | 79.6 | **per-tile +7.6%** | 0.93 | 0.87 | rocBLAS |
| 1024x159744x1024 | 4992 | 452.4 | 478.5 | 545.0 | 570.1 | **per-tile +4.6%** | 0.83 | 0.79 | rocBLAS |
| 1024x65536x256 | 2048 | 70.5 | 82.9 | 90.4 | 94.2 | **per-tile +4.2%** | 0.78 | 0.75 | rocBLAS |
| 1024x16448x1024 | 520 | 54.7 | 64.6 | 62.4 | 64.8 | **per-tile +3.8%** | 0.88 | 0.84 | rocBLAS |
| 32768x128x256 | 256 | 11.9 | 10.3 | 11.3 | 11.7 | **per-tile +3.5%** | **1.05** | **1.02** | stock Triton |
| 48000x256x256 | 375 | 23.4 | 18.1 | 22.3 | 21.6 | persistent +3.1% | **1.05** | **1.08** | stock Triton |
| 64000x256x512 | 500 | 34.1 | 33.6 | 42.6 | 41.2 | persistent +3.3% | 0.80 | 0.83 | stock Triton |
| 64000x768x256 | 1500 | 55.6 | 58.3 | 68.9 | 66.2 | persistent +3.9% | 0.81 | 0.84 | rocBLAS |
| 204800x256x256 | 1600 | 76.1 | 70.1 | 85.8 | 82.1 | persistent +4.3% | 0.89 | 0.93 | stock Triton |
| 1024x16384x512 | 512 | 28.0 | 31.1 | 36.9 | 34.9 | persistent +5.4% | 0.76 | 0.80 | rocBLAS |
| 64000x256x256 | 500 | 24.6 | 22.3 | 27.3 | 25.6 | persistent +6.2% | 0.90 | 0.96 | stock Triton |
| 48000x512x256 | 750 | 37.7 | 29.6 | 38.2 | 35.5 | persistent +7.1% | 0.99 | **1.06** | stock Triton |
| 64000x512x256 | 1000 | 45.8 | 38.1 | 48.8 | 45.0 | persistent +7.8% | 0.94 | **1.02** | stock Triton |
| 48000x768x256 | 1125 | 43.8 | 43.6 | 52.7 | 46.3 | persistent +12.1% | 0.83 | 0.95 | stock Triton |
| 48000x256x512 | 375 | 29.1 | 26.3 | 35.7 | 30.4 | persistent +14.8% | 0.82 | 0.96 | stock Triton |
| 32768x128x128 | 256 | 10.4 | 8.6 | 11.3 | — | — (only one bid) | 0.92 | — | stock Triton |

21 saturated addmm shapes; 20 have both TLX variants bidding. per-tile faster on 10, persistent faster on 10. persistent beats rocBLAS on 4/20, per-tile on 2/21. Median roc/per-tile 0.83, roc/persistent 0.84.
Autotune winner: rocBLAS=10, stock Triton=11.

Reading Tables 4-6 against 1-3: this model inverts the undersaturated result -- persistent takes 30 of 53 with split-K off, and still 23 of 53 with it on -- but every one of those wins is <=4.8%, and per-tile's wins include a +124.0% (`1024x1024x159744`, where split-K is the difference) and a +41.8%. In the saturated regime it is an even 10/10 split, with persistent's wins concentrated in the same tall-M / small-N / small-K family as the OC nets and reaching +14.8% here. Autotune still selects TLX on only 7 of 100 sites.

### Correction to the persistent-template claim, from this third model

An earlier revision of this summary said the persistent template "is not the best TLX candidate in either regime on either model". That was true of the two OC nets and is **false on HI IG CTR**, where persistent is frequently the better TLX variant on undersaturated addmm:

| model | undersaturated head-to-head, split-K off | with split-K on |
|---|---|---|
| AF OC 200x | per-tile 9 / persistent 3 | -- |
| HI OC 700x | per-tile 15 / persistent 9 | -- |
| **HI IG CTR** | **per-tile 23 / persistent 30** | per-tile 30 / persistent 23 |

Of the 31 undersaturated addmm shapes on this model where `SPLIT_K>1` candidates were generated, persistent beats the best per-tile candidate on **14** (up to +4.1%: `1024x1024x1024` 11.7 vs 12.2us, `1024x512x320` 7.4 vs 7.7, `1024x1024x456` 8.8 vs 9.1).

This does not change the decision for this diff, for a specific reason: on all 14, per-tile's best was itself `SPLIT_K=1`, so split-K was never the deciding factor -- persistent lacking it costs nothing there. And on the 2 shapes where split-K *is* decisive, persistent's `SPLIT_K=1` time is level with or worse than per-tile's (49.9 vs 49.8us; 971.0 vs 884.3us) while split-K delivers -27% and -51% from that same baseline. Giving the persistent template split-K would therefore at best tie the per-tile result, never unlock a win it does not already have.

Read across all three models, three separate conclusions:

1. **Arming only the per-tile template costs nothing measurable.** No shape regressed because the persistent template lacks split-K.
2. **"Persistent never wins" is not a claim this data supports** -- an earlier revision of this summary said so and was wrong.
3. **Persistent has exactly one genuine strength, and it is not in this diff's regime.** Its 25 undersaturated wins are all +0.9% to +5.0% with no structural pattern (M from 32 to 9600, N from 256 to 3072) -- plausibly noise. Its 18 *saturated* wins are a coherent family and much larger: tall-M (32K to 2.25M rows), small-N (256-768), small-K (256-512), up to **+14.8%** (`48000x256x512`), +12.1% (`48000x768x256`), +7.8% (`229376x256x256` and `64000x512x256`), +7.1%, +6.4%, +6.2%, +5.5%. Split-K is never generated for any of them, so this diff cannot touch that family -- but it is the evidence to weigh before anyone prunes the persistent template on autotune-cost grounds.

Rationale for not implementing split-K in the persistent template is in D115345022.

Worth knowing before landing: the HIM QPS sweep in D114632771 was a serving-throughput measurement (batch 1024 / ads 45 / HWQ 16), which `mts_gpu_benchmark` does not reproduce. The numbers above are the AOTI lowering of the same model. Re-running the original QPS sweep with costing on is still the right final check.

Authored with Claude Code.

Differential Revision: D115683243


