### PR TITLE
[Triton][TLX][AMD] Specialize HSTU batch topology

### DIFF
--- a/third_party/tlx/tutorials/amd_hstu_attn.py
+++ b/third_party/tlx/tutorials/amd_hstu_attn.py
@@ -565,7 +565,7 @@ def _ragged_hstu_attn_fwd(  # noqa C901
     stride_om,
     stride_oh,
     alpha,
-    Z,
+    Z: tl.constexpr,
     H,
     MAX_SEQ_LEN,
     DeltaSize,


### PR DESCRIPTION
Summary:
https://github.com/facebookexperimental/triton/issues/2741

The HSTU kernel uses the exact batch count `Z` when remapping programs to sequence tiles. Runtime integer specialization grouped `Z=32` and `Z=1024` under the same divisible-by-16 cache identity, allowing the last parameterization to reuse an incompatible earlier kernel artifact.

Mark `Z` as `tl.constexpr` so each batch topology receives an exact-value JIT cache entry.

This diff was authored with Claude.

Differential Revision: D116099476


