### PR TITLE
[TLX][AMD] Lower lane-distributed reductions with shuffles

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -477,11 +477,13 @@ LinearLayout ReduceOpHelper::reducedRegLaneLayout(RankedTensorType srcTy,
                                                   int axis) {
   auto *ctx = srcTy.getContext();
   auto kReg = StringAttr::get(ctx, "register");
+  auto kLane = StringAttr::get(ctx, "lane");
   auto reduced = toLinearLayout(srcTy);
   reduced = actionRemoveBroadcastedRegs(reduced).apply(reduced);
   reduced = moveAxisBasesToFront(reduced, axis).apply(reduced);
   reduced = zeroBasesAlongDimAndReorder(reduced, axis, kReg);
   reduced = actionRemoveBroadcastedRegs(reduced).apply(reduced);
+  reduced = zeroBasesAlongDimAndReorder(reduced, axis, kLane);
   return reduced;
 }
 

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -19,6 +19,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierMbarAllocator.h"
 #include "triton/Tools/GenericSwizzling.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "llvm/Support/MathExtras.h"
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -85,6 +86,8 @@ private:
         vals = removeBroadcast.apply(vals);
     }
 
+    std::tie(regLl, accs) =
+        reduceWithinThreads(op, std::move(regLl), std::move(accs), rewriter);
     std::tie(regLl, accs) =
         reduceWithinWarps(op, std::move(regLl), std::move(accs), rewriter);
 
@@ -697,9 +700,9 @@ private:
   }
 
   std::pair<LinearLayout, SmallVector<SmallVector<Value>>>
-  reduceWithinWarps(triton::ReduceOp op, LinearLayout layout,
-                    SmallVector<SmallVector<Value>> accs,
-                    ConversionPatternRewriter &rewriter) const {
+  reduceWithinThreads(triton::ReduceOp op, LinearLayout layout,
+                      SmallVector<SmallVector<Value>> accs,
+                      ConversionPatternRewriter &rewriter) const {
     auto *ctx = op.getContext();
     auto loc = op.getLoc();
     unsigned axis = op.getAxis();
@@ -781,6 +784,74 @@ private:
     layout = ReduceOpHelper::zeroBasesAlongDimAndReorder(layout, axis, kReg);
     layout = actionRemoveBroadcastedRegs(layout).apply(layout);
     return {std::move(layout), std::move(accs)};
+  }
+
+  // Reduce lane bases that move the reduction axis. The mask identifies the
+  // lane-id bits that distinguish values belonging to the same reduction.
+  std::pair<LinearLayout, SmallVector<SmallVector<Value>>>
+  reduceWithinWarps(triton::ReduceOp op, LinearLayout layout,
+                    SmallVector<SmallVector<Value>> accs,
+                    ConversionPatternRewriter &rewriter) const {
+    auto *ctx = op.getContext();
+    auto kLane = str_attr("lane");
+    const auto &laneBases = layout.getBases().lookup(kLane);
+    unsigned reduceLaneIdMask = 0;
+    for (unsigned bit = 0; bit < laneBases.size(); ++bit) {
+      if (laneBases[bit][op.getAxis()] != 0)
+        reduceLaneIdMask |= 1u << bit;
+    }
+    if (reduceLaneIdMask == 0)
+      return {std::move(layout), std::move(accs)};
+
+    for (unsigned reg = 0; reg < accs.front().size(); ++reg) {
+      SmallVector<Value> acc(op.getNumOperands());
+      for (unsigned i = 0; i < op.getNumOperands(); ++i)
+        acc[i] = accs[i][reg];
+
+      warpReduceLaneMask(rewriter, op, acc, reduceLaneIdMask);
+
+      for (unsigned i = 0; i < op.getNumOperands(); ++i)
+        accs[i][reg] = acc[i];
+    }
+
+    layout = ReduceOpHelper::zeroBasesAlongDimAndReorder(layout, op.getAxis(),
+                                                         kLane);
+    return {std::move(layout), std::move(accs)};
+  }
+
+  void warpReduceLaneMask(ConversionPatternRewriter &rewriter,
+                          triton::ReduceOp op, SmallVector<Value> &acc,
+                          unsigned reduceLaneIdMask) const {
+    auto moduleOp = op->getParentOfType<ModuleOp>();
+    unsigned warpSize =
+        triton::gpu::TritonGPUDialect::getThreadsPerWarp(moduleOp);
+    assert(reduceLaneIdMask < warpSize &&
+           "expected reduce lane ID mask to be smaller than the warp size");
+
+    unsigned firstBit = llvm::countr_zero(reduceLaneIdMask);
+    unsigned numBits = llvm::popcount(reduceLaneIdMask);
+    unsigned contiguousMask = ((1u << numBits) - 1) << firstBit;
+
+    // Keep target-specific optimized reductions for the common contiguous
+    // case. Non-contiguous lane distributions require one XOR shuffle per
+    // participating lane-id bit.
+    if (reduceLaneIdMask == contiguousMask) {
+      warpReduce(rewriter, op.getLoc(), acc, op, 1u << numBits, 1u << firstBit);
+      return;
+    }
+
+    // Preserve upstream's established inverse bit order for reductions whose
+    // participating lane-id bits cannot use the contiguous target hook.
+    for (int bit = llvm::Log2_32(warpSize) - 1; bit >= 0; --bit) {
+      unsigned mask = 1u << bit;
+      if ((reduceLaneIdMask & mask) == 0)
+        continue;
+      SmallVector<Value> shuffled(op.getNumOperands());
+      for (unsigned i = 0; i < op.getNumOperands(); ++i)
+        shuffled[i] =
+            targetInfo.shuffleXor(rewriter, op.getLoc(), acc[i], mask);
+      accumulate(op.getLoc(), rewriter, op.getCombineOp(), acc, shuffled);
+    }
   }
 
   // Apply warp reduction across the given number of contiguous lanes using op

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -34,6 +34,8 @@
 // PartitionedSharedEncoding attributes for testing
 #PARTITIONED_SHARED_SWIZZLE = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #A_SHARED}>
 #PARTITIONED_SHARED_PADDED = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 1, partitionDim = 1, partitionLayout = #PADDED_SHARED_0_16x32}>
+#LANE_INTERLEAVED = #ttg.linear<{register = [[0, 1]], lane = [[1, 0], [0, 2], [2, 0], [0, 4], [4, 0]], warp = [[0, 8], [0, 16]], block = []}>
+#LANE_INTERLEAVED_SLICE = #ttg.slice<{dim = 0, parent = #LANE_INTERLEAVED}>
 
 #smem = #ttg.shared_memory
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
@@ -45,6 +47,19 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 tt.func @empty(%A : !tt.ptr<f16>) {
   %cst_2 = arith.constant dense<0.000000e+00> : tensor<16x32xf16, #AL>
   %0 = ttg.convert_layout %cst_2 : tensor<16x32xf16, #AL> -> tensor<16x32xf16, #AL>
+  tt.return
+}
+
+// A warp-synchronous reduction is completed by lane shuffles and reserves no
+// shared-memory scratch, even when its lane-id bits are non-contiguous.
+// expected-remark @below {{lane_reduction_no_scratch}}
+// expected-remark @below {{size = 0}}
+tt.func @lane_reduction_no_scratch(%arg0: tensor<8x32xf32, #LANE_INTERLEAVED>) {
+  %0 = "tt.reduce"(%arg0) ({
+  ^bb0(%arg1: f32, %arg2: f32):
+    %1 = arith.addf %arg1, %arg2 : f32
+    tt.reduce.return %1 : f32
+  }) {axis = 0 : i32} : (tensor<8x32xf32, #LANE_INTERLEAVED>) -> tensor<32xf32, #LANE_INTERLEAVED_SLICE>
   tt.return
 }
 

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -327,9 +327,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // GFX1250-LABEL: reduce_xor_row_xmask
   tt.func @reduce_xor_row_xmask(%arg0: tensor<16x2xf32, #linear>) {
-    // beta gfx1250: ROW_XMASK dpp shuffles only; this #linear reduction produces
-    // no stride-16 permlane step, so neither permlanex16 nor ds_bpermute is emitted.
+    // Lane bit 1 is broadcast while bits 0, 2, 3, and 4 move the reduction
+    // axis. Reduce only those participating bits: strides 16, 8, 4, and 1.
     // GFX1250-NOT: rocdl.ds_bpermute
+
+    // stride 16: permlanex16
+    // GFX1250: rocdl.permlanex16
 
     // stride 8: ROW_XMASK:8
     // GFX1250: rocdl.update.dpp
@@ -338,10 +341,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     // stride 4: ROW_XMASK:4
     // GFX1250: rocdl.update.dpp
     // GFX1250-SAME: with 356, 15, 15, true
-
-    // stride 2: ROW_XMASK:2
-    // GFX1250: rocdl.update.dpp
-    // GFX1250-SAME: with 354, 15, 15, true
 
     // stride 1: ROW_XMASK:1
     // GFX1250: rocdl.update.dpp

--- a/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm_gfx1250.mlir
@@ -19,12 +19,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, "ttg.thr
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   // GFX1250-LABEL: reduce_16x16
   tt.func @reduce_16x16(%input: tensor<128x128xf32, #mma>) {
+    // GFX1250-NOT: llvm.vector.reduce
     // GFX1250-COUNT-2: rocdl.permlanex16
+    // GFX1250-NOT: llvm.vector.reduce
     %0 = "tt.reduce"(%input) <{axis = 1 : i32}> ({
       ^bb0(%arg1: f32 , %arg2: f32):
       %2 = "arith.maxnumf"(%arg1, %arg2) : (f32, f32) -> f32
       tt.reduce.return %2 : f32 }) : (tensor<128x128xf32, #mma>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #mma}>>
    tt.return
+  }
+
+  // GFX1250-LABEL: reduce_sum_16x16
+  tt.func @reduce_sum_16x16(%input: tensor<128x128xf32, #mma>) {
+    // GFX1250-NOT: llvm.vector.reduce
+    // GFX1250-COUNT-2: rocdl.permlanex16
+    // GFX1250-NOT: llvm.vector.reduce
+    %0 = "tt.reduce"(%input) <{axis = 1 : i32}> ({
+      ^bb0(%arg1: f32, %arg2: f32):
+      %2 = arith.addf %arg1, %arg2 : f32
+      tt.reduce.return %2 : f32
+    }) : (tensor<128x128xf32, #mma>) -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #mma}>>
+    tt.return
   }
 }
 

--- a/test/Conversion/reduce_inner_tree_to_llvm.mlir
+++ b/test/Conversion/reduce_inner_tree_to_llvm.mlir
@@ -7,6 +7,7 @@
 // warp reduction and combines the groups later when packing the result.
 
 #linear = #ttg.linear<{register = [[0, 2], [2, 0]], lane = [[0, 8], [8, 0], [1, 0], [4, 0], [16, 0]], warp = [[0, 1], [0, 4]], block = []}>
+#lane_interleaved = #ttg.linear<{register = [[0, 1]], lane = [[1, 0], [0, 2], [2, 0], [0, 4], [4, 0]], warp = [[0, 8], [0, 16]], block = []}>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
 
@@ -63,10 +64,33 @@ tt.func private @reduce_inner_tree(%arg0: tensor<32x16xi32, #linear>) -> tensor<
   tt.return %0 : tensor<16xi32, #ttg.slice<{dim = 0, parent = #linear}>>
 }
 
-tt.func @anchor(%ptr: !llvm.ptr, %arg0: tensor<32x16xi32, #linear>) {
+// A lane distribution may interleave reduction and non-reduction lane-id
+// bits. Reduce exactly the bits that move axis 0: 4, 2, and 0, corresponding
+// to XOR masks 16, 4, and 1 in the established count-down order.
+// CHECK-LABEL: @reduce_lane_interleaved
+tt.func private @reduce_lane_interleaved(%arg0: tensor<8x32xi32, #lane_interleaved>) -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #lane_interleaved}>> {
+  // CHECK: call i32 @llvm.nvvm.shfl.sync.bfly.i32({{.*}}i32 16, i32 31)
+  // CHECK: call i32 @llvm.nvvm.shfl.sync.bfly.i32({{.*}}i32 4, i32 31)
+  // CHECK: call i32 @llvm.nvvm.shfl.sync.bfly.i32({{.*}}i32 1, i32 31)
+  // CHECK: call i32 @llvm.nvvm.shfl.sync.bfly.i32({{.*}}i32 16, i32 31)
+  // CHECK: call i32 @llvm.nvvm.shfl.sync.bfly.i32({{.*}}i32 4, i32 31)
+  // CHECK: call i32 @llvm.nvvm.shfl.sync.bfly.i32({{.*}}i32 1, i32 31)
+  // CHECK-NOT: call i32 @llvm.nvvm.shfl.sync.bfly.i32
+  %0 = "tt.reduce"(%arg0) ({
+  ^bb0(%arg1: i32, %arg2: i32):
+    %1 = arith.addi %arg1, %arg2 : i32
+    tt.reduce.return %1 : i32
+  }) {axis = 0 : i32} : (tensor<8x32xi32, #lane_interleaved>) -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #lane_interleaved}>>
+  tt.return %0 : tensor<32xi32, #ttg.slice<{dim = 0, parent = #lane_interleaved}>>
+}
+
+tt.func @anchor(%ptr: !llvm.ptr, %lane_ptr: !llvm.ptr, %arg0: tensor<32x16xi32, #linear>, %arg1: tensor<8x32xi32, #lane_interleaved>) {
   %0 = tt.call @reduce_inner_tree(%arg0) : (tensor<32x16xi32, #linear>) -> tensor<16xi32, #ttg.slice<{dim = 0, parent = #linear}>>
   %1 = builtin.unrealized_conversion_cast %0 : tensor<16xi32, #ttg.slice<{dim = 0, parent = #linear}>> to !llvm.struct<(i32, i32)>
   llvm.store volatile %1, %ptr : !llvm.struct<(i32, i32)>, !llvm.ptr
+  %2 = tt.call @reduce_lane_interleaved(%arg1) : (tensor<8x32xi32, #lane_interleaved>) -> tensor<32xi32, #ttg.slice<{dim = 0, parent = #lane_interleaved}>>
+  %3 = builtin.unrealized_conversion_cast %2 : tensor<32xi32, #ttg.slice<{dim = 0, parent = #lane_interleaved}>> to !llvm.struct<(i32, i32)>
+  llvm.store volatile %3, %lane_ptr : !llvm.struct<(i32, i32)>, !llvm.ptr
   tt.return
 }
 


### PR DESCRIPTION
The beta backport of the upstream LinearLayout reduction lowering reduces register bases but falls back to the legacy map-based path whenever the reduction axis is also distributed across lanes. That fallback assumes a contiguous lane distribution: layouts with interleaved broadcast and reduction lane bits can shuffle the wrong peers, while gfx1250 WMMA reductions miss the intended no-scratch lowering.

Restore the upstream split between within-thread register reduction and within-warp lane reduction. Build a mask from the lane bases that move the reduction axis, retain target-specific optimized lowering for contiguous masks, and emit inverse-order XOR shuffles for non-contiguous masks. Update ReduceOpHelper::reducedRegLaneLayout to remove the same lane bases so scratch allocation agrees with code generation. Keep beta's separate inner_tree ordering path unchanged.

Add backend-neutral coverage for interleaved lane bits, allocation coverage for a zero-scratch warp-synchronous reduction, and gfx1250 coverage for the corrected lane mask and WMMA max/sum lowering without vector reductions. This ports the missing behavior from upstream 483327f033 while adapting it to beta's existing num-lanes/interleave target hook.