### PR TITLE
[triton][TMA-Multicast] Define multi-CTA grid requirements (#2871)

### DIFF
--- a/docs/design/multi_cta_autows_requirements.md
+++ b/docs/design/multi_cta_autows_requirements.md
@@ -1,0 +1,228 @@
+# AutoWS requirements for multi-CTA operations
+
+## Summary
+
+This document extends the
+[multi-CTA control-flow contract](multi_cta_control_flow_contract.md) to
+compiler-driven warp specialization.
+
+AutoWS is a uniform transformation of the original CTA program. Until
+multi-CTA lowering runs during code partitioning, every CTA has the same
+partially transformed program, including the same task assignments, data
+partitions, and channels. Physical warp-specialize regions are created later.
+CTAs may evaluate the common program differently when the original program
+contains CTA-dependent values, but AutoWS does not choose a different program
+for each CTA rank.
+
+Multi-CTA lowering is the phase that intentionally introduces asymmetric CTA
+roles, such as a TMA multicast leader and its recipients. The design therefore
+needs to answer four questions:
+
+1. Which multi-CTA facts must be established before AutoWS, and which lowering
+   preconditions can be checked during AutoWS code partitioning?
+2. How does an AutoWS channel's ready/done synchronization protocol become
+   multi-CTA barrier handling?
+3. Under what conditions does a value transported through an AutoWS channel
+   retain the equality facts required by the control-flow contract?
+4. How must cluster communication account for independently executing
+   warp-group partitions within each CTA?
+
+The running example is a descriptor load selected for TMA multicast across
+ranks 0 and 1 of a `(2, 1, 1)` cluster.
+
+## Proof placement around AutoWS
+
+The compilation model is:
+
+```text
+one original CTA program
+  -> Multi-CTA Validation
+  -> uniform AutoWS task and data partitioning
+  -> channel discovery and buffer planning
+  -> multi-CTA lowering during code partitioning
+  -> physical warp specialization and token/barrier lowering
+```
+
+These phases do not create two versions of the kernel. Validation establishes
+the semantic facts. AutoWS lowering selects a supported strategy using the
+actual partition, channel, and buffer graph, then adds CTA roles and cross-CTA
+synchronization as part of code partitioning.
+
+### What code partitioning can use directly
+
+Lowering is most direct when a candidate operation has no incoming
+cross-partition data dependencies. The operation, its enclosing control flow,
+and the values covered by its multi-CTA proof must all be available in the
+owning partition. Code partitioning can then inspect:
+
+- the partition that owns each candidate operation;
+- its enclosing `scf.if`, `scf.for`, and `scf.while` operations and their task
+  assignments;
+- its direct SSA dependencies; and
+- pure expressions whose operands have established CTA-group equality.
+
+This commonly applies to producer operations. For example, a descriptor load in
+a producer partition can be analyzed directly when its enclosing conditions and
+loop bounds are captured from kernel arguments or rematerialized from
+group-uniform operands. The uniform transformation also makes its owning
+partition a static property of the program: the operation has the same owner in
+every CTA.
+
+This proof establishes the producer operation's control-flow trace. It is not
+sufficient to determine which cluster communication operations are required.
+That decision also depends on the consumer partitions, buffer lifetime, ready
+and done paths, and the hardware participation scope. If any controlling value
+reaches the producer through a channel, the stronger channel-provenance rules
+below apply instead.
+
+### Data dependencies through intermediate buffers
+
+When a value crosses warp-group partitions, AutoWS may replace the original SSA
+dependency with a synchronized intermediate SMEM or TMEM buffer. This applies
+to ordinary operation operands and to values that control whether or when an
+operation executes, including branch predicates and loop continuation or
+termination conditions.
+
+For example, a scheduler partition may compute whether a persistent loop has
+more work, store that condition in an intermediate buffer, and broadcast it to
+the other partitions. The channel proves that those partitions within one CTA
+observe the scheduler partition's value. It does not prove that scheduler
+partitions in different CTAs produced the same condition or exit on the same
+iteration.
+
+After this rewrite, a `local_load` exposes the immediate buffer dependency but
+not whether the original value came from a kernel argument, a CTA coordinate, a
+scheduler result, or mutable memory. Code partitioning may use that channel in a
+multi-CTA lowering only when it can associate the payload with an established
+equality fact and dynamic iteration. The local wait and load alone are
+insufficient.
+
+### Two-phase protocol
+
+The design has two stages:
+
+1. **Multi-CTA Validation.** This stage must run before any AutoWS pass. It
+   proves CTA-group equality, whole-path reachability, and loop exits while the
+   original SSA provenance is visible. It records which operations satisfy the
+   multi-CTA control-flow contract but does not introduce CTA roles or
+   synchronization.
+2. **AutoWS lowering.** This stage runs during code partitioning, after the
+   owning partitions and producer-consumer graph are known. It integrates the
+   multi-CTA operation with AutoWS token and barrier handling and is responsible
+   for producing correct cluster communication semantics. If the final
+   partition or channel shape has no supported lowering, this stage aborts the
+   optional multi-CTA transformation and retains the original per-CTA
+   operation.
+
+The later multi-CTA barrier-handling section describes the full/empty-path and
+backend synchronization requirements of AutoWS lowering in detail.
+
+If validation runs before data partitioning, AutoWS must retain a mapping from
+each validated source operation to any resulting clone or slice, including its
+execution count, tile, and pipeline epoch. If that mapping is unavailable, or
+if no lowering pattern understands the result, AutoWS lowering aborts the
+multi-CTA transformation.
+
+## Multi-CTA barrier handling
+
+The high-level challenge is that a multi-CTA operation cannot be lowered as an
+isolated instruction. Every dynamic multi-CTA operation conceptually
+participates in at least two coordinated events for its logical buffer or
+resource:
+
+- **Ready:** production is complete and every participating CTA may consume its
+  destination.
+- **Done:** every participating CTA has completed all uses of its destination,
+  so the producer may reuse the logical buffer slot.
+
+Both events are group-level properties. It is insufficient to prove only that
+the leader can issue an operation or that one recipient has completed. The
+lowering must connect the operation that produces ready state with the
+operation or operations that establish done state.
+
+Barrier handling includes both the abstract synchronization constructed during
+AutoWS code partitioning and the concrete barriers emitted by the backend. Code
+partitioning may call these states full and empty and represent them with
+tokens or logical semaphores. A later backend stage may use mbarriers or another
+hardware protocol. These are different implementations of the same ready/done
+protocol.
+
+### TMA multicast example
+
+For the `(2, 1, 1)` TMA multicast example, multicast completion is the ready
+event for the destination buffers in ranks 0 and 1. The corresponding done
+event comes from completion of the consumers of those buffers, often an MMA.
+The relevant lowering unit is therefore the complete ready/done barrier
+protocol, not the TMA instruction in isolation.
+
+### AutoWS lowering requirements
+
+AutoWS splits the original CTA program into regions that may start and make
+progress independently. Multi-CTA barrier lowering must preserve three
+properties across those regions:
+
+1. **Expected arrivals.** For each ready or done barrier, lowering must identify
+   the specialized regions and hardware threads expected to arrive. The
+   initialized arrival count and the emitted arrivals must still match after
+   code partitioning. If several regions participate in one logical CTA
+   arrival, lowering must coordinate them rather than accidentally counting the
+   CTA more than once or omitting it. Lowering updates these arrivals alongside
+   the other barrier arrival counts and must track the participating regions
+   with the correct masks.
+2. **Barrier lifetime.** Barrier storage and state must remain live for every
+   specialized region that can use it, for the full duration of the kernel or
+   enclosing persistent loop. Correctness cannot depend on producer and
+   consumer regions launching or progressing concurrently.
+3. **Iteration-count agreement.** Every participating region and CTA must
+   execute the same ordered number of uses of the corresponding barrier. Code
+   partitioning must not make that count data-dependent in a way that can vary
+   between tiles, partitions, or CTA participants. Multi-CTA Validation covers
+   source-level exits; lowering must preserve that result when control flow is
+   distributed across specialized regions.
+
+This document assumes the existing AutoWS indexing and phase construction are
+valid. The requirement is agreement on the dynamic barrier-use count, not a new
+analysis of arbitrary indices or phase values. If lowering cannot establish the
+expected arrivals, lifetime, or iteration-count agreement, it must abort the
+optional multi-CTA transformation.
+
+Current AutoWS 2-CTA MMA is a narrow precedent. It inserts a pair-scoped remote
+mbarrier protocol after warp specialization, when the owning MMA partition is
+known. Both CTAs arrive on the even CTA's barrier, and only the even CTA waits
+and issues the cooperative MMA. This avoids placing a full-cluster barrier
+inside one consumer warp group, but still relies on the paired CTAs executing
+the same dynamic MMA and barrier instances.
+
+## Future work
+
+### Dead-tile participation
+
+Multi-CTA operations have a fixed participation width. The scheduled tile count
+along the grouping dimension must therefore be divisible by that width. For
+example, every dynamic 2-CTA GEMM requires two CTAs to participate, even when
+the logical matrix has work for only one CTA in the final pair. The schedule
+must add a **dead tile** to complete that pair.
+
+The question is not whether the CTA assigned the dead tile may opt out. It is
+how that CTA can participate in the required multi-CTA operation without
+producing an incorrect result. The current implementation keeps it on the normal
+cooperative execution path and requires its input and output data to be
+harmless. This includes masking on any store or any intermediate value.
+
+This differs from ordinary edge masking. A partially valid tile still produces
+some logical output, but there are known issues with trying to write fully
+past the bounds with TMA stores (although this may just be a bug).
+
+The current 2-CTA matmul test demonstrates this for `M = 128` and
+`BLOCK_M = 128`. Its launch wrapper starts two CTAs even though there is only
+one logical M tile. Both CTAs execute the same K loop, descriptor loads,
+cross-CTA synchronization, and 2-CTA MMA. The second CTA's A tile is entirely
+out of bounds, so the descriptor load supplies padding values. The non-AutoWS
+kernel suppresses its output with a masked store; the AutoWS kernel relies on
+descriptor-store bounds behavior. The dead CTA therefore performs dummy work
+rather than skipping the collective operation.
+
+This is not yet in scope, but it will be an important followup for solidifying
+stable multi-CTA handling. For AutoWS, a dead tile may need to perform the
+multi-CTA operation (for example, a TMA multicast load) without performing the
+rest of the kernel.

--- a/docs/design/multi_cta_grid_requirements.md
+++ b/docs/design/multi_cta_grid_requirements.md
@@ -1,0 +1,231 @@
+# Multi-CTA grid requirements
+
+## Summary
+
+This document complements the
+[multi-CTA control-flow contract](multi_cta_control_flow_contract.md) and the
+[AutoWS requirements](multi_cta_autows_requirements.md). It defines two
+additional pieces of the multi-CTA correctness contract:
+
+1. a launcher-side verification process for checking that a launch grid is
+   compatible with the compiled kernel's required cluster shape; and
+2. rules for handling tiles that have no logical work but must exist to complete
+   a multi-CTA participation group.
+
+Cluster verification and dead-tile safety are separate proofs. A divisible grid
+ensures that CUDA can form complete physical clusters. It does not prove that a
+padded CTA uses safe data or follows the required collective trace. Conversely,
+a kernel with safe dead-tile behavior is not launchable if the physical grid
+cannot be partitioned into its required clusters.
+
+For non-persistent kernels, each launched CTA has one statically determined tile
+assignment, so launch-grid verification also constrains the tile schedule. For
+persistent kernels, per-dimension divisibility is still required. The derived
+flat-grid property that the total number of launched CTAs is divisible by
+`Cx * Cy * Cz` makes explicit that a whole number of clusters is scheduled, but
+it is not an alternative verification rule. Correctness of the dynamic tile
+assignments remains a separate kernel-level scheduler obligation.
+
+## Terminology and running example
+
+Let:
+
+- `G = (Gx, Gy, Gz)` be the final physical CTA grid passed to CUDA; and
+- `C = (Cx, Cy, Cz)` be the exact required cluster shape.
+
+For `ctas_per_cga`, `G` is already the total CTA grid. Other frontend options
+may express a grid in logical programs and expand it before launch. Verification
+always operates on the final physical CTA grid, after any such expansion.
+
+A **dead tile** is a physical tile assignment with no corresponding logical
+output. Dead tiles are schedule padding, not partially valid edge tiles. For
+example, a 2-CTA GEMM grouped along X requires an even number of X tiles. If the
+logical M-tile count is three, the kernel must launch four X CTAs:
+
+```text
+logical tiles:   [0] [1] [2]
+physical CTAs:   [0] [1] [2] [dead]
+2-CTA groups:     \___/     \_______/
+```
+
+The last CTA has no logical output, but it is still the second participant in
+the cooperative operation for the final pair.
+
+## Component 1: Launcher-side cluster verification
+
+### Why the check belongs at launch
+
+The compiler knows the required cluster shape, but a Triton launch grid may be a
+runtime function of tensor shapes and autotuning parameters. Compilation alone
+therefore cannot prove that every invocation supplies a compatible grid.
+
+CUDA ultimately rejects invalid cluster launches, but relying on a driver error
+provides a late and implementation-dependent diagnostic. Triton should verify
+the contract before allocating launch-scoped resources or invoking CUDA.
+
+### Required launch metadata
+
+A compiled kernel containing a multi-CTA operation must expose one normalized,
+exact cluster requirement to the launcher:
+
+- the required physical cluster shape `C`;
+- whether the user-provided grid already counts physical CTAs or must first be
+  expanded; and
+- whether the kernel requires exact clustering.
+
+Preferred or fallback cluster shapes, for which the driver may select a
+different physical shape, are outside this contract.
+
+All multi-CTA operations in one kernel must be compatible with that requirement.
+The compiler must reject or avoid forming an operation that requires a different
+physical cluster shape.
+
+### Verification process
+
+For every launch of a kernel with an exact cluster requirement, the launcher
+must perform the following checks:
+
+1. Verify per-dimension divisibility:
+
+   ```text
+   Gx % Cx == 0
+   Gy % Cy == 0
+   Gz % Cz == 0
+   ```
+
+   For a persistent kernel, the corresponding kernel-granularity requirement
+   is:
+
+   ```text
+   (Gx * Gy * Gz) % (Cx * Cy * Cz) == 0
+   ```
+
+   This flat-count check makes explicit that the launch contains an integral
+   number of schedulable clusters. It does not replace the per-dimension checks
+   when the required cluster shape is multidimensional.
+2. Verify that the target device and launch resources support the required
+   cluster shape. The CUDA driver remains the final authority, but the launcher
+   should report the incompatibility as a cluster-requirement error rather than
+   an unexplained launch failure.
+
+The launcher must not silently round `G`. Rounding creates new CTA program IDs,
+which is a semantic transformation: the kernel must map them to dead tiles,
+make their memory accesses safe, suppress their side effects, and keep them on
+the collective trace. The launcher cannot infer those properties from cluster
+metadata.
+
+Failure of either check is a launch-time error for the selected compiled
+kernel. The diagnostic must identify the physical grid `G` and required cluster
+shape `C`, along with any known target or resource incompatibility. Kernel
+caching, recompilation, and selection of a different compiled variant are
+outside this contract and must not be relied upon to bypass these checks.
+
+### What this proves
+
+Successful verification proves only that the physical grid can be partitioned
+into complete clusters of the required shape. Because the compiler has already
+proved that each multi-CTA participation group is contained within that shape,
+no group is truncated at the edge of the launch grid.
+
+It does not prove:
+
+- that the logical tile count fills the physical grid;
+- that padded program IDs are mapped to safe dead tiles;
+- that dead-tile loads, stores, atomics, or other side effects are safe; or
+- that participating CTAs execute compatible control flow.
+
+Those are kernel and compiler obligations described below and in the
+multi-CTA control-flow contract.
+
+## Component 2: Dead-tile handling
+
+### Dead-tile execution
+
+Ordinary masking and dead-tile participation are different:
+
+- A **partially valid tile** has some logical output. The kernel executes the
+  tile and masks individual out-of-bounds elements.
+- A **dead tile** has no logical output. It exists only to complete a physical
+  cluster or multi-CTA participation group.
+
+Most kernels handle partially valid edge tiles, but that does not imply that
+they safely handle a fully dead tile. A kernel may fail when an operation
+receives a tile with no in-bounds elements. For example, a TMA store can crash
+when the tile's lower bound lies past the tensor's upper bound. It is currently
+unclear whether this is an implementation bug or an API gap.
+
+### Kernel-author responsibilities
+
+For the initial design, the kernel author or launch wrapper must:
+
+- round the logical grid to complete physical clusters;
+- map padded program IDs to dead tiles without wrapping them onto unrelated
+  live work;
+- provide safe values for every load performed by a dead tile, using descriptor
+  out-of-bounds fill or explicit masks as appropriate;
+- ensure padded values are semantically harmless for the collective operation;
+- suppress every externally visible dead-tile effect, including output stores,
+  atomics, counters, queue updates, and debugging writes; and
+- structure control flow and tile-validity handling so the compiler can prove
+  that dead CTAs remain on the same ordered multi-CTA and barrier trace as their
+  live partners.
+
+The author must not assume that output masking makes input accesses or
+intermediate side effects safe.
+
+### Compiler support
+
+Kernel constructs such as CTA-dependent early exits can prevent the compiler
+from proving that every participant reaches an operation that could otherwise
+use multiple CTAs. When an author introduces such constructs, additional kernel
+structure or compiler-visible information may be required before the compiler
+can safely form a multi-CTA operation. Until that participation can be proved,
+the affected operation must remain single-CTA.
+
+### 2-CTA GEMM example
+
+For a non-persistent GEMM grouped along M, the launch wrapper can construct a
+complete grid as follows:
+
+```python
+logical_m_tiles = triton.cdiv(M, BLOCK_M)
+grid_m = triton.cdiv(logical_m_tiles, Cx) * Cx
+```
+
+The wrapper must apply the corresponding rounding to every clustered grid
+dimension, using `Cy` and `Cz` for Y and Z.
+
+When `logical_m_tiles` is odd, the last CTA is dead. Both CTAs in its pair still
+execute the same K-loop iterations, descriptor loads, 2-CTA MMA operations, and
+barrier epochs. The dead CTA's input loads return safe padding, and an explicit
+output mask prevents it from writing outside the output tensor.
+
+This is safe:
+
+```text
+both CTAs: load -> arrive/wait -> 2-CTA MMA -> repeat
+dead CTA:  suppress final output writes
+```
+
+This is not safe:
+
+```text
+live CTA:  load -> arrive/wait -> 2-CTA MMA
+dead CTA:  return or continue to the next tile
+```
+
+### Expected failure modes
+
+| Contract violation | Likely symptom |
+|---|---|
+| Physical grid is not divisible by the exact cluster shape | Launcher cluster-requirement error before CUDA is invoked; without this verification, CUDA rejects the launch |
+| A dead CTA returns or skips a collective operation | Barrier wait that never completes or a kernel hang |
+| A dead AutoWS partition skips a ready/done event | Channel epoch drift, stale buffers, or an intermittent hang |
+| Dead-tile inputs are not padded or masked | Out-of-bounds access, illegal memory access, or invalid MMA data |
+| Padding values are not neutral for the operation | Silent corruption of a live partner's result |
+| Dead-tile stores, atomics, or counters are not suppressed | Out-of-bounds writes, duplicated work, or corrupted scheduler state |
+
+The most dangerous failures are not necessarily immediate launch errors. A
+missing barrier arrival or mismatched AutoWS epoch can depend on scheduling and
+appear as an intermittent hang, while a non-neutral padded operand can silently
+corrupt otherwise in-bounds output.

--- a/docs/design/triton_tma_multicast.md
+++ b/docs/design/triton_tma_multicast.md
@@ -243,30 +243,28 @@ The implementation flows through the compiler as follows:
    descriptor-encoding optimization. For each enabled `tt.descriptor_load`, it
    computes program-ID dependencies and records the proven broadcast axes in
    the internal `tt.multicast_axes` attribute.
-3. TMA lowering and software-pipelining preserve that attribute, allocate one
-   completion barrier slot per recipient group, and insert cluster barriers
+3. TMA lowering and software-pipelining preserve that attribute, allocate a
+   local completion barrier in every recipient CTA, and insert cluster barriers
    around the multicast transaction. Loads with different broadcast axes are
-   kept in different pipeline groups. Native `tl.range(...,
-   warp_specialize=True)` lowering carries the same plan through its load
-   partitions.
-4. NVIDIA LLVM lowering derives a rank-dependent 16-bit recipient mask from the
-   cluster shape and broadcast axes. Only the lowest-ranked CTA in each group
-   issues `cp.async.bulk.tensor...multicast::cluster` and waits on the
-   corresponding cluster-visible completion barrier; the following cluster
-   barrier releases the other recipients.
+   kept in different pipeline groups. Native and Meta warp-specialized lowering
+   carry the same plan through their load partitions and memory channels.
+4. TMA lowering derives a rank-dependent recipient mask from the cluster shape
+   and broadcast axes, stores it in `multicastTargets`, and predicates the copy
+   on the lowest-ranked CTA in each group. The elected CTA issues
+   `cp.async.bulk.tensor...multicast::cluster`; hardware completes the
+   corresponding local barrier in every target CTA. Each recipient waits on
+   its local barrier before the following cluster rendezvous.
 
 The planner accepts only tiled `tt.descriptor_load` operations, an exact
 power-of-two `ctas_per_cga` shape containing 2 to 16 CTAs, and index/control-flow
-expressions whose program-ID dependencies it can prove. It conservatively
-rejects memory-derived or atomic tile IDs, CLC operations, divergent surrounding
-control flow, unsupported expression kinds, and Meta AutoWS (`ttg.use-meta-ws`).
-CLC and dynamic-persistent schedules are unsupported because their regular
-Triton schedulers do not yet support multi-CTA execution. When those schedulers
-gain multi-CTA support, the multicast analysis must be extended to understand
-their cluster-level work assignment and prove which per-CTA tiles remain shared.
-It currently selects every proven broadcast axis and has no cost model or
-user-facing optimization remarks. Selection can be inspected in TTGIR through
-`tt.multicast_axes` and in PTX through `.multicast::cluster`.
+expressions whose program-ID dependencies it can prove. It understands CLC
+schedule results and cluster-uniform `scf.for`/`scf.while` control flow, and it
+preserves plans through Meta AutoWS channels. It conservatively rejects
+memory-derived or atomic tile IDs, cluster-divergent control flow, and
+unsupported expression kinds. It currently selects every proven broadcast axis
+and has no cost model or user-facing optimization remarks. Selection can be
+inspected in TTGIR through `tt.multicast_axes`, on lowered TMA operations through
+`multicastTargets`, and in PTX through `.multicast::cluster`.
 
 The internal attribute is a compiler contract, not a user API. Standard Triton
 users grant permission through the kernel option or load override; they do not


### PR DESCRIPTION
Summary:

Defines launcher and kernel responsibilities for exact multi-CTA clusters. Launchers validate final physical grid divisibility without silently rounding; kernel authors pad schedules with dead CTAs, keep them on the collective trace, provide neutral inputs, and suppress externally visible side effects. This separates physical cluster validation from dead-tile correctness.

Reviewed By: Sibylau

Differential Revision: D115497606


