### PR TITLE
[Test fix][triton][beta] Avoid fast-cache teardown during finalization

### DIFF
--- a/python/src/specialize.cc
+++ b/python/src/specialize.cc
@@ -40,6 +40,14 @@ specialize_arg(PyObject *backend, PyObject *arg, bool is_const,
 
 static bool init_called = false;
 
+static bool is_python_finalizing() {
+#if PY_VERSION_HEX >= 0x030D0000
+  return Py_IsFinalizing() != 0;
+#else
+  return _Py_IsFinalizing() != 0;
+#endif
+}
+
 // --- dispatch/cache stats (opt-in via TRITON_CACHE_STATS=1) ------------------
 // Counts hit vs fallback per dispatch path, per kernel, so owners can find
 // kernels that silently miss the C fast path once the flags are on by default.
@@ -1118,6 +1126,9 @@ static int fc_get_tensor_specialization(PyObject *arg, uint64_t threshold,
 }
 
 static void fc_capsule_destructor(PyObject *capsule) {
+  // Cached Python objects may already be partially finalized at process exit.
+  if (is_python_finalizing())
+    return;
   FastCache *c = (FastCache *)PyCapsule_GetPointer(capsule, "FastCache");
   if (c)
     delete c;


### PR DESCRIPTION
Summary:
Mirror D116287429 into Triton beta. With the C dispatcher/cache enabled by default, `FastCache` capsule destruction can decreference compiled kernels and dispatchers after CPython has begun finalizing dependent modules, causing a post-test SIGSEGV.

Detect CPython finalization and leave the process-lifetime cache for the operating system to reclaim. Normal capsule destruction still releases all references. The version switch supports Python 3.12 through 3.14.

Authored with AI assistance (Codex).

Reviewed By: njriasan

Differential Revision: D116287537


