### PR TITLE
[Triton][ModularArithmetic] Fail closed on unsupported modular solves (#2875)

### DIFF
--- a/include/triton/Tools/ModularArithmetic.h
+++ b/include/triton/Tools/ModularArithmetic.h
@@ -54,13 +54,14 @@ struct ModMatrix {
 // Gaussian elimination to RREF in Z/nZ. Modifies matrix in-place, returns rank.
 int modRREF(ModMatrix &mat);
 
-// Solve Ax = b (mod modulus) using Gaussian elimination.
-// The modulus parameter overrides A.modulus for the solve operation.
+// Solve Ax = b over a prime field using Gaussian elimination.
+// Returns {} outside this family or if no solution is found.
 std::vector<int64_t> modSolveLinear(const ModMatrix &A,
                                     const std::vector<int64_t> &b,
                                     int64_t modulus);
 
-// Solve Ax = b (mod p^e) using Hensel lifting
+// Solve Ax = b (mod p^e) using Hensel lifting. Solvable singular systems such
+// as 2x = 2 (mod 4) currently return {}.
 std::vector<int64_t> modSolveLinearHensel(const ModMatrix &A,
                                           const std::vector<int64_t> &b,
                                           int64_t prime, int exponent);

--- a/lib/Tools/ModularArithmetic.cpp
+++ b/lib/Tools/ModularArithmetic.cpp
@@ -101,6 +101,37 @@ bool arePairwiseCoprime(const std::vector<int64_t> &moduli) {
         return false;
   return true;
 }
+
+bool isPrime(int64_t modulus) {
+  PrimeFactorization factors = factorize(modulus);
+  return factors.factors.size() == 1 && factors.factors[0].first == modulus &&
+         factors.factors[0].second == 1;
+}
+
+int64_t normalizeMod(__int128 value, int64_t modulus) {
+  int64_t normalized = value % modulus;
+  return normalized < 0 ? normalized + modulus : normalized;
+}
+
+bool isSolution(const ModMatrix &A, const std::vector<int64_t> &b,
+                const std::vector<int64_t> &x, int64_t modulus) {
+  if (modulus <= 0 || static_cast<int>(b.size()) != A.rows ||
+      static_cast<int>(x.size()) != A.cols)
+    return false;
+
+  for (int row = 0; row < A.rows; ++row) {
+    int64_t actual = 0;
+    for (int col = 0; col < A.cols; ++col)
+      actual = normalizeMod(static_cast<__int128>(actual) +
+                                static_cast<__int128>(A.at(row, col)) * x[col],
+                            modulus);
+
+    int64_t expected = normalizeMod(b[row], modulus);
+    if (actual != expected)
+      return false;
+  }
+  return true;
+}
 } // namespace
 
 std::optional<CRTResult> solveCRT(const std::vector<int64_t> &remainders,
@@ -259,10 +290,7 @@ std::vector<int64_t> modSolveLinear(const ModMatrix &A,
     return {}; // Size mismatch
   }
 
-  // Z/N arithmetic is only defined for N > 0. The downstream % modulus
-  // operations would otherwise crash (modulus == 0) or produce ill-defined
-  // results (modulus < 0).
-  if (modulus <= 0) {
+  if (!isPrime(modulus)) {
     return {};
   }
 
@@ -318,7 +346,7 @@ std::vector<int64_t> modSolveLinear(const ModMatrix &A,
     }
   }
 
-  return x;
+  return isSolution(A, b, x, modulus) ? x : std::vector<int64_t>{};
 }
 
 // Solve Ax = b (mod p^e) by solving mod p then lifting each power via
@@ -406,7 +434,7 @@ std::vector<int64_t> modSolveLinearHensel(const ModMatrix &A,
     val = ((val % p_e) + p_e) % p_e;
   }
 
-  return x_k;
+  return isSolution(A, b, x_k, p_e) ? x_k : std::vector<int64_t>{};
 }
 
 std::vector<int64_t> modSolveLinearCRT(const ModMatrix &A,
@@ -480,7 +508,7 @@ std::vector<int64_t> modSolveLinearCRT(const ModMatrix &A,
     x[var] = crt_result->solution;
   }
 
-  return x;
+  return isSolution(A, b, x, modulus) ? x : std::vector<int64_t>{};
 }
 
 int64_t PrimeFactorization::product() const {

--- a/unittest/Tools/ModularArithmeticTest.cpp
+++ b/unittest/Tools/ModularArithmeticTest.cpp
@@ -281,6 +281,48 @@ TEST_F(ModularArithmeticTest, ModSolveLinear_Basic) {
   EXPECT_EQ((A3.at(0, 0) * x3[0] + A3.at(0, 1) * x3[1]) % 7, b3[0] % 7);
 }
 
+TEST_F(ModularArithmeticTest, ModSolveLinear_RejectsCompositeModulus) {
+  ModMatrix A(1, 1, 4);
+  A.at(0, 0) = 2;
+
+  EXPECT_TRUE(modSolveLinear(A, {1}, 4).empty());
+  EXPECT_TRUE(modSolveLinear(A, {2}, 4).empty());
+}
+
+TEST_F(ModularArithmeticTest, ModSolveLinear_ExhaustivePrimeField) {
+  for (int64_t prime : {2, 3}) {
+    for (int matrixOrdinal = 0; matrixOrdinal < intPow(prime, 4);
+         ++matrixOrdinal) {
+      ModMatrix A(2, 2, prime);
+      int remaining = matrixOrdinal;
+      for (int row = 0; row < 2; ++row) {
+        for (int col = 0; col < 2; ++col) {
+          A.at(row, col) = remaining % prime;
+          remaining /= prime;
+        }
+      }
+
+      for (int64_t b0 = 0; b0 < prime; ++b0) {
+        for (int64_t b1 = 0; b1 < prime; ++b1) {
+          auto result = modSolveLinear(A, {b0, b1}, prime);
+          bool hasSolution = false;
+          for (int64_t x0 = 0; x0 < prime; ++x0) {
+            for (int64_t x1 = 0; x1 < prime; ++x1) {
+              hasSolution |=
+                  (A.at(0, 0) * x0 + A.at(0, 1) * x1) % prime == b0 &&
+                  (A.at(1, 0) * x0 + A.at(1, 1) * x1) % prime == b1;
+            }
+          }
+
+          EXPECT_EQ(!result.empty(), hasSolution)
+              << "prime=" << prime << " matrix=" << matrixOrdinal << " b={"
+              << b0 << "," << b1 << "}";
+        }
+      }
+    }
+  }
+}
+
 TEST_F(ModularArithmeticTest, ModSolveLinearHensel_Mod9) {
   // modulus = 9 = 3^2
   ModMatrix A(2, 2, 9);
@@ -383,6 +425,7 @@ TEST_F(ModularArithmeticTest, ModSolveLinearHensel_InvalidPrimeRejected) {
   EXPECT_TRUE(modSolveLinearHensel(A, b, /*prime=*/1, /*exponent=*/2).empty());
   EXPECT_TRUE(modSolveLinearHensel(A, b, /*prime=*/0, /*exponent=*/2).empty());
   EXPECT_TRUE(modSolveLinearHensel(A, b, /*prime=*/-3, /*exponent=*/2).empty());
+  EXPECT_TRUE(modSolveLinearHensel(A, b, /*prime=*/4, /*exponent=*/2).empty());
 }
 
 TEST_F(ModularArithmeticTest, ModSolveLinearCRT_Composite_Mod15) {


### PR DESCRIPTION
Summary:

Restrict modSolveLinear to the prime-field domain its Gaussian elimination supports and reject composite moduli instead of returning an unchecked answer. Composite working moduli remain supported through modSolveLinearCRT, which factorizes them and calls modSolveLinear only with primes.

Validate every solution returned by the direct, Hensel, and CRT entry points against A*x = b before exposing it. Typed failure outcomes remain follow-up work on T284579356; optional non-unit solving is tracked by T284919748.

Reviewed By: htyu

Differential Revision: D116320157


