### PR TITLE
[Performance-Fix] [triton][beta] Add branch weights to warp specialization dispatch

### DIFF
--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -191,7 +191,7 @@ llvm.func @generate_switch_loop() attributes {allocation.offset = 32 : i32} {
   // CHECK-NEXT: [[WID:%.*]] = llvm.udiv [[TIDX]], [[C32]]
   // CHECK-NEXT: [[WARP_ID:%.*]] = nvvm.shfl.sync idx [[CNEG1]], [[WID]], [[C0]], [[C31]]
   // CHECK-NEXT: [[IS_DEFAULT:%.*]] = llvm.icmp "ult" [[WARP_ID]], [[C4]]
-  // CHECK-NEXT: llvm.cond_br [[IS_DEFAULT]], [[BODY:\^.*]], [[SWITCH_LOOP:\^.*]]
+  // CHECK-NEXT: llvm.cond_br [[IS_DEFAULT]] weights([4, 7]), [[BODY:\^.*]], [[SWITCH_LOOP:\^.*]]
 
   // CHECK: [[SWITCH_LOOP]]:
   // CHECK-NEXT: "llvm.nvvm.barrier.cta.sync.all"([[C1]])

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -195,7 +195,11 @@ static LogicalResult lowerWarpSpecialize(LLVM::LLVMFuncOp func,
     auto voidTy = void_ty(ctx);
     ptxBuilder.launch(b, func.getLoc(), voidTy);
   }
-  LLVM::CondBrOp::create(b, b.getLoc(), isDefault, entry, switchLoop);
+  LLVM::CondBrOp::create(
+      b, b.getLoc(), isDefault, entry, ValueRange{}, switchLoop, ValueRange{},
+      std::pair<uint32_t, uint32_t>{
+          static_cast<uint32_t>(defaultNumWarps),
+          static_cast<uint32_t>(totalNumWarpsAttr.getInt() - defaultNumWarps)});
 
   // Forward arguments from the header into the old entry block.
   for (auto [arg, oldArg] :


### PR DESCRIPTION
Summary:
Port from stable: In ConvertWarpSpecializeToLLVM.cpp, the warp specialization lowering emits a cond_br that branches on isDefault (warp_id < defaultNumWarps) to decide between default warp group and worker warp groups switch loop. Previously this was unweighted, so LLVM treats it as 50/50.

Real warp population is skewed - e.g. 4 default vs 7 workers in lit test, 4 vs 8 in production kernels. This causes suboptimal MachineBlockPlacement - the worker path should be fallthrough.

Fix: use weighted branch (WeightedBranchOpInterface) with weights [defaultNumWarps, totalNumWarps - defaultNumWarps]. This describes partition populations to LLVM, allowing proper block frequency and placement. Observed +4.9% latency improvement on GPU3 (1.152960ms -> 1.096544ms) for affected kernel, recovering ~90% of placement loss, as reported in the original stable context session.

Test file updated to expect weights([4,7]) identical to stable.

Original context: internal session 01a01067-4605-76f3-96c8-18b7f7d8cfff - motivation is to help LLVM's block placement by exposing actual warp counts.

Reviewed By: htyu

Differential Revision: D116320581


