### PR TITLE
[TLX][AMD] Preserve inter-wave MFMA/VMEM scheduling

### DIFF
--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
@@ -903,6 +903,7 @@ def _launch(a, b, bias=None, SPLIT_K=None, TILE=None):
         # Forbid AGPRs: f32 accumulators write VGPRs directly (packs tighter, no
         # v_accvgpr moves around each mfma). Essential to match the reference perf.
         llvm_fn_attrs=(("amdgpu-agpr-alloc", "0,0"), ),
+        enable_sched_group_barrier_scheduler=True,
     )
     if SPLIT_K > 1:
         # Adaptive reduce tile: small outputs need many small CTAs to fill the CUs;


### PR DESCRIPTION
Summary:
The standalone addmm inter-wave kernel expresses a staged MFMA and VMEM schedule, but the default backend scheduling path does not consistently preserve it. This leaves several deep-reduction shapes below the throughput available from the same kernel structure.

Enable the cache-keyed schedule-group-barrier scheduler on this kernel's `tlx.compile` call. The option applies the scheduling policy per kernel without a process-wide compiler override.

The scheduler-only ablation used FP16, col-major B, 100 warmups, and 500 repetitions on a locked MI350X. Accuracy is 1 for every configuration and shape.

| (M, N, K) | baseline | scheduler only | delta |
|---|---:|---:|---:|
| (3072, 3072, 14208) | 872.053 | 889.642 | +2.02% |
| (3072, 4096, 25344) | 1007.850 | 1017.040 | +0.91% |
| (3072, 8192, 3072) | 814.593 | 876.458 | +7.59% |
| (3072, 4096, 2560) | 783.515 | 894.450 | +14.16% |
| (1024, 20480, 6144) | 783.048 | 799.766 | +2.13% |
| (3072, 4096, 2048) | 734.770 | 844.564 | +14.94% |
| (3072, 9216, 3072) | 853.477 | 916.417 | +7.37% |
| (3072, 15360, 4096) | 948.269 | 998.116 | +5.26% |
| (1024, 32768, 6144) | 952.302 | 976.847 | +2.58% |
| average | 861.097 | 912.589 | +5.98% |

The scheduler improves all nine shapes that route through the inter-wave kernel, with gains from 0.91% to 14.94%. Keep `enable_sched_group_barrier_scheduler=True` on this kernel.

The complete scheduler-only sweep below compares rocBLAS, stock Triton, TorchTLX, and standalone TLX. It used the same FP16, col-major B, 100-warmup, 500-repetition setup and took 11m57s. Accuracy is 1 for every provider and shape.

| (M, N, K) | rocBLAS | stock Triton | TorchTLX | standalone TLX | best |
|---|---:|---:|---:|---:|---|
| (218112, 128, 160) | 121.828 | 159.349 | 156.238 | 158.784 | stock Triton |
| (3072, 3072, 14208) | 914.024 | 662.485 | 633.981 | 879.951 | rocBLAS |
| (3072, 4096, 25344) | 990.510 | 793.019 | 811.091 | 1003.918 | standalone TLX |
| (3072, 3072, 11800) | 711.220 | 537.776 | 525.245 | 579.772 | rocBLAS |
| (3072, 8192, 3072) | 801.754 | 693.465 | 753.325 | 871.523 | standalone TLX |
| (3072, 4096, 2560) | 783.144 | 726.617 | 667.597 | 865.148 | standalone TLX |
| (1024, 20480, 6144) | 807.788 | 633.086 | 709.258 | 802.258 | rocBLAS |
| (3072, 4096, 2048) | 736.870 | 695.523 | 645.362 | 819.837 | standalone TLX |
| (3072, 9216, 3072) | 797.602 | 736.300 | 686.447 | 915.453 | standalone TLX |
| (3072, 3072, 1536) | 593.299 | 567.302 | 523.843 | 620.729 | standalone TLX |
| (3072, 15360, 4096) | 844.675 | 784.413 | 755.415 | 995.856 | standalone TLX |
| (1024, 43008, 512) | 371.958 | 401.323 | 401.751 | 420.932 | standalone TLX |
| (1024, 18816, 1024) | 456.302 | 474.967 | 483.809 | 532.346 | standalone TLX |
| (1024, 22272, 1024) | 474.321 | 447.607 | 516.474 | 578.628 | standalone TLX |
| (262144, 262, 294) | 161.451 | 206.100 | 178.996 | 212.376 | standalone TLX |
| (1024, 16384, 1024) | 413.378 | 606.930 | 569.148 | 635.649 | standalone TLX |
| (2252800, 256, 512) | 371.639 | 423.130 | 408.115 | 449.145 | standalone TLX |
| (3072, 4096, 768) | 449.338 | 518.775 | 473.554 | 564.159 | standalone TLX |
| (3072, 22272, 1024) | 543.627 | 566.287 | 565.830 | 640.724 | standalone TLX |
| (204800, 256, 256) | 204.811 | 284.430 | 283.710 | 287.716 | standalone TLX |
| (2252800, 256, 256) | 231.164 | 269.212 | 318.259 | 341.143 | standalone TLX |
| (229376, 256, 256) | 195.606 | 293.141 | 278.197 | 304.644 | standalone TLX |
| (262144, 433, 2400) | 589.975 | 489.446 | 495.264 | 557.276 | rocBLAS |
| (262144, 176, 257) | 167.375 | 151.418 | 150.727 | 152.664 | rocBLAS |
| (1024, 32768, 6144) | 941.431 | 668.655 | 795.055 | 977.866 | standalone TLX |
| (1024, 153600, 1024) | 520.945 | 574.510 | 573.569 | 624.665 | standalone TLX |
| (1024, 22592, 1024) | 455.784 | 496.247 | 511.233 | 561.635 | standalone TLX |
| (1024, 159744, 1024) | 575.573 | 604.080 | 570.053 | 624.662 | standalone TLX |
| (1024, 65536, 256) | 233.494 | 304.121 | 293.842 | 317.120 | standalone TLX |
| (1024, 16448, 1024) | 428.807 | 445.180 | 451.240 | 519.108 | standalone TLX |
| (64000, 768, 256) | 227.406 | 309.762 | 295.116 | 309.766 | standalone TLX |
| (1024, 16384, 512) | 317.979 | 427.777 | 395.871 | 480.353 | standalone TLX |
| average | 513.596 | 498.514 | 496.175 | 581.431 | standalone TLX |

Standalone TLX is fastest on 26 of 32 shapes, rocBLAS on five, and stock Triton on one. Its average throughput is 16.63% above stock Triton and 13.21% above rocBLAS.

Reviewed By: wlei-llvm, dshi7

Differential Revision: D116253327


