### PR TITLE
[AutoWS] Peel a partition-local masked loop prologue (#2886)

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PartitionLoopPeeling.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PartitionLoopPeeling.h
@@ -1,0 +1,21 @@
+#ifndef TRITON_DIALECT_TRITONGPU_TRANSFORMS_PARTITIONLOOPPEELING_H_
+#define TRITON_DIALECT_TRITONGPU_TRANSFORMS_PARTITIONLOOPPEELING_H_
+
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir::triton::gpu {
+
+// The warp-specialization task attribute. Named here because core transforms
+// cannot include the NVIDIA backend's WarpSpecialization/Utility.h, which
+// declares the same name for backend passes.
+constexpr inline llvm::StringLiteral kAsyncTaskIdAttrName = "async_task_id";
+
+// Peel the first iteration of partition-local loops whose first-tile predicate
+// has the canonical `iv < lower_bound + step` form. This runs after pipeline
+// load lowering, so the peeled prologue cannot invalidate schedule analysis.
+void peelPartitionLoops(ModuleOp moduleOp);
+
+} // namespace mlir::triton::gpu
+
+#endif // TRITON_DIALECT_TRITONGPU_TRANSFORMS_PARTITIONLOOPPEELING_H_

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ add_triton_library(TritonGPUTransforms
   Pipeliner/ScheduleLoops.cpp
   Pipeliner/WGMMAPipeline.cpp
   Pipeliner/PipelineExpander.cpp
+  Pipeliner/PartitionLoopPeeling.cpp
   Pipeliner/TestPipelineLowerLoop.cpp
   Pipeliner/SoftwarePipeliner.cpp
   Pipeliner/TMAStoresPipeline.cpp

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PartitionLoopPeeling.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PartitionLoopPeeling.cpp
@@ -1,0 +1,183 @@
+#include "triton/Dialect/TritonGPU/Transforms/PartitionLoopPeeling.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir::triton::gpu {
+namespace {
+
+// Match `iv < lb + step`, the guard the frontend emits for "first iteration
+// only" work, and return it when it controls an scf.if in the loop body.
+//
+// The match is intentionally narrow. The comparison must live directly in the
+// loop body (not in a nested region) and must feed an scf.if condition, so any
+// other control flow -- nested loops, an scf.if on an unrelated predicate, a
+// while loop -- simply fails to match and the loop is left alone. Peeling only
+// ever runs on a shape it fully understands; there is no partial rewrite to
+// unwind. When several comparisons match, only the first in walk order is
+// peeled: the transform is a first-iteration split, so peeling more than one
+// guard would need nested prologues, and the HSTU masked prologue this targets
+// has exactly one.
+static arith::CmpIOp getFirstIterationPredicate(scf::ForOp forOp) {
+  arith::CmpIOp candidate;
+  forOp.getBody()->walk([&](arith::CmpIOp cmp) {
+    if (cmp.getPredicate() != arith::CmpIPredicate::slt ||
+        cmp.getLhs() != forOp.getInductionVar() ||
+        cmp->getBlock() != forOp.getBody())
+      return WalkResult::advance();
+
+    auto add = cmp.getRhs().getDefiningOp<arith::AddIOp>();
+    if (!add)
+      return WalkResult::advance();
+    bool isFirstIterationBoundary = (add.getLhs() == forOp.getLowerBound() &&
+                                     add.getRhs() == forOp.getStep()) ||
+                                    (add.getRhs() == forOp.getLowerBound() &&
+                                     add.getLhs() == forOp.getStep());
+    if (!isFirstIterationBoundary)
+      return WalkResult::advance();
+
+    bool controlsIf = llvm::any_of(cmp->getUsers(), [&](Operation *user) {
+      auto ifOp = dyn_cast<scf::IfOp>(user);
+      return ifOp && ifOp.getCondition() == cmp.getResult();
+    });
+    if (!controlsIf)
+      return WalkResult::advance();
+
+    candidate = cmp;
+    return WalkResult::interrupt();
+  });
+  return candidate;
+}
+
+static SmallVector<Value>
+cloneIteration(IRRewriter &rewriter, scf::ForOp source, Block *destination,
+               Value inductionValue, ValueRange iterArgs,
+               arith::CmpIOp predicate, bool predicateValue) {
+  IRMapping mapping;
+  mapping.map(source.getInductionVar(), inductionValue);
+  mapping.map(source.getRegionIterArgs(), iterArgs);
+
+  rewriter.setInsertionPointToStart(destination);
+  auto foldedPredicate = arith::ConstantIntOp::create(
+      rewriter, predicate.getLoc(), predicateValue, 1);
+  // The remainder is still consumed by PipelineExpander. Preserve the
+  // predicate's serialized stage/cluster on its constant replacement so every
+  // operation in that loop remains scheduled.
+  foldedPredicate->setAttrs(predicate->getAttrs());
+  mapping.map(predicate.getResult(), foldedPredicate);
+
+  for (Operation &op : source.getBody()->without_terminator()) {
+    if (&op == predicate.getOperation())
+      continue;
+    rewriter.clone(op, mapping);
+  }
+
+  auto oldYield = cast<scf::YieldOp>(source.getBody()->getTerminator());
+  SmallVector<Value> yielded;
+  yielded.reserve(oldYield.getNumOperands());
+  for (Value value : oldYield.getOperands())
+    yielded.push_back(mapping.lookupOrDefault(value));
+  return yielded;
+}
+
+// The scaffolding below is created inside a physical warp-specialize region,
+// where every operation carries the partition task id. Mirror the source loop's
+// so the new ops are not the only unannotated ones in that region.
+static void copyTaskId(Operation *source, Operation *destination) {
+  if (Attribute attr = source->getAttr(kAsyncTaskIdAttrName))
+    destination->setAttr(kAsyncTaskIdAttrName, attr);
+}
+
+// Copy only the discardable attributes, leaving whatever inherent state the
+// destination op was constructed with intact -- setAttrs would overwrite the
+// whole dictionary, which is safe for today's scf.for but not for a loop op
+// that carries inherent attributes.
+static void copyDiscardableAttrs(Operation *source, Operation *destination) {
+  for (NamedAttribute attr : source->getDiscardableAttrs())
+    destination->setDiscardableAttr(attr.getName(), attr.getValue());
+}
+
+static void peelFirstIteration(scf::ForOp forOp, arith::CmpIOp predicate) {
+  IRRewriter rewriter(forOp);
+  Location loc = forOp.getLoc();
+
+  auto hasFirstIterationOp =
+      arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::slt,
+                            forOp.getLowerBound(), forOp.getUpperBound());
+  copyTaskId(forOp, hasFirstIterationOp);
+  Value hasFirstIteration = hasFirstIterationOp.getResult();
+  auto peeled = scf::IfOp::create(rewriter, loc, forOp.getResultTypes(),
+                                  hasFirstIteration, /*withElseRegion=*/true);
+  copyTaskId(forOp, peeled);
+  // scf.IfOp auto-inserts a yield in each region when the op has no results
+  // (a loop without iter args). Drop those so the explicit yields below are the
+  // only terminators, instead of appending ops after a terminator.
+  for (Block *block : {peeled.thenBlock(), peeled.elseBlock()})
+    if (block->mightHaveTerminator())
+      rewriter.eraseOp(block->getTerminator());
+
+  Block *thenBlock = peeled.thenBlock();
+  SmallVector<Value> firstResults =
+      cloneIteration(rewriter, forOp, thenBlock, forOp.getLowerBound(),
+                     forOp.getInitArgs(), predicate, /*predicateValue=*/true);
+
+  rewriter.setInsertionPointToEnd(thenBlock);
+  auto remainderLowerBoundOp = arith::AddIOp::create(
+      rewriter, loc, forOp.getLowerBound(), forOp.getStep());
+  copyTaskId(forOp, remainderLowerBoundOp);
+  Value remainderLowerBound = remainderLowerBoundOp.getResult();
+  auto remainder =
+      scf::ForOp::create(rewriter, loc, remainderLowerBound,
+                         forOp.getUpperBound(), forOp.getStep(), firstResults);
+  // Only the remainder loop continues to expandLoops, so it inherits the
+  // source loop's schedule metadata. The peeled prologue is a straight-line
+  // clone whose ops keep their own per-op stage/cluster attributes; giving it
+  // loop-level schedule attributes would present a second schedulable loop to
+  // the pipeliner.
+  copyDiscardableAttrs(forOp, remainder);
+  SmallVector<Value> remainderResults = cloneIteration(
+      rewriter, forOp, remainder.getBody(), remainder.getInductionVar(),
+      remainder.getRegionIterArgs(), predicate, /*predicateValue=*/false);
+  rewriter.setInsertionPointToEnd(remainder.getBody());
+  auto remainderYield = scf::YieldOp::create(rewriter, loc, remainderResults);
+  copyDiscardableAttrs(forOp.getBody()->getTerminator(), remainderYield);
+
+  rewriter.setInsertionPointAfter(remainder);
+  auto thenYield = scf::YieldOp::create(rewriter, loc, remainder.getResults());
+  copyTaskId(forOp, thenYield);
+
+  rewriter.setInsertionPointToStart(peeled.elseBlock());
+  auto elseYield = scf::YieldOp::create(rewriter, loc, forOp.getInitArgs());
+  copyTaskId(forOp, elseYield);
+
+  rewriter.replaceOp(forOp, peeled.getResults());
+}
+
+} // namespace
+
+void peelPartitionLoops(ModuleOp moduleOp) {
+  SmallVector<std::pair<scf::ForOp, arith::CmpIOp>> candidates;
+  moduleOp.walk([&](WarpSpecializeOp wsOp) {
+    for (Region *partition : wsOp.getPartitionRegions()) {
+      partition->walk([&](scf::ForOp forOp) {
+        if (forOp->getParentOfType<WarpSpecializeOp>() != wsOp)
+          return;
+        if (auto predicate = getFirstIterationPredicate(forOp))
+          candidates.emplace_back(forOp, predicate);
+      });
+    }
+  });
+
+  // Peel in walk (post) order, i.e. innermost first. Peeling replaces a loop
+  // with an scf.if and erases the original, so an outer loop must be peeled
+  // after the inner ones it contains -- the other way round the outer clone
+  // erases the inner loop and leaves the remaining entries dangling.
+  for (auto [forOp, predicate] : candidates)
+    peelFirstIteration(forOp, predicate);
+}
+
+} // namespace mlir::triton::gpu

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -211,13 +211,22 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
   }
   // Ops without a built-in pred operand: wrap in scf.if.
   //
-  // The TMA "store" family (copy local->global, reduce, scatter) all write to
-  // global memory but have no mask/pred operand, so they cannot be masked in
-  // place. They must be predicated when the pipeliner peels prologue/epilogue
-  // iterations of a dynamic loop: executing a store/reduce/scatter for an
-  // iteration past the real trip count would corrupt the output (e.g. a
-  // spurious atomic add for a TMA reduce). Guard them with scf.if(pred).
-  if (isa<ttng::AsyncTMACopyLocalToGlobalOp, ttng::AsyncTMAReduceOp,
+  // Synchronous descriptor loads/gathers and the TMA "store" family have no
+  // mask/pred operand, so they cannot be masked in place. They must be
+  // predicated when the pipeliner peels prologue/epilogue iterations of a
+  // dynamic loop. Guard them with scf.if(pred); result-producing operations
+  // yield poison on the inactive path because their consumers are predicated
+  // by the same pipeline-stage condition.
+  //
+  // tt.descriptor_load / tt.descriptor_gather reach this path only outside
+  // warp specialization. Under autoWS the loads have already been rewritten to
+  // nvws.descriptor_load / nvws.descriptor_gather, which LowerAref turns into
+  // ttng.async_tma_copy_global_to_local carrying a real `pred` operand, so
+  // those are masked in place and never need the scf.if wrapper. An nvws load
+  // arriving here would hit the "doesn't know how to predicate" error below
+  // rather than being silently mishandled.
+  if (isa<tt::DescriptorLoadOp, tt::DescriptorGatherOp,
+          ttng::AsyncTMACopyLocalToGlobalOp, ttng::AsyncTMAReduceOp,
           ttng::AsyncTMAScatterOp, ttng::TMAStoreTokenWaitOp>(op)) {
     rewriter.setInsertionPoint(op);
     bool hasResults = op->getNumResults() > 0;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -10,6 +10,7 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/Triton/Transforms/LoopPeeling.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/PartitionLoopPeeling.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipelineExpander.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
@@ -198,6 +199,18 @@ struct PipelinePass : public impl::TritonGPUPipelineBase<PipelinePass> {
     if (dumpIntermediateSteps) {
       ::mlir::triton::tools::mlirDumpsOrDbgs()
           << "// -----// SoftwarePipeliner internal IR Dump After: LowerLoops\n"
+          << moduleOp << "\n\n\n";
+    }
+
+    // Code partitioning has already produced physical warp-specialize regions.
+    // Peel only after lowerLoops has consumed the original schedule: moving a
+    // scheduled use into a prologue earlier would invalidate its def-use stage
+    // analysis.
+    peelPartitionLoops(moduleOp);
+    if (dumpIntermediateSteps) {
+      ::mlir::triton::tools::mlirDumpsOrDbgs()
+          << "// -----// SoftwarePipeliner internal IR Dump After: "
+             "PartitionLoopPeeling\n"
           << moduleOp << "\n\n\n";
     }
 

--- a/test/Hopper/WarpSpecialization/ws_single_partition_else_hstu_bwd.mlir
+++ b/test/Hopper/WarpSpecialization/ws_single_partition_else_hstu_bwd.mlir
@@ -1,0 +1,274 @@
+// RUN: triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=2 smem-budget=300000" --tritongpu-pipeline="num-stages=2" --canonicalize | FileCheck %s
+//
+// Reduced from the post-doTaskIdPropagate dump of the HSTU self-attention
+// CLC backward benchmark with runtime masked/unmasked activation branches.
+// Both result-producing scf.if operations and their complete then/else bodies
+// are assigned to computation task 3. After specialization, the first masked
+// tile must be peeled from the unmasked remainder loop in partition3.
+//
+// CHECK-LABEL: @_hstu_attn_bwd_clc
+// CHECK: ttg.warp_specialize
+// CHECK-SAME: ttg.partition.types = ["reduction", "gemm", "load", "computation"]
+// Task 3 is the third physical WS region (partition2; the default region is
+// not numbered).
+// CHECK: partition2
+// The zero-trip guard encloses a straight-line masked first tile. Its element
+// predicate and selects survive, but its scalar masked/unmasked IfOps fold.
+// CHECK: %[[HAS_FIRST:.*]] = arith.cmpi slt
+// CHECK: scf.if %[[HAS_FIRST]]
+// CHECK: tt.expand_dims
+// CHECK: arith.select
+// The remainder starts at lb + step and contains only the unmasked activation
+// path: no scalar branch and no per-element activation select.
+// CHECK: arith.addi
+// CHECK: scf.for
+// CHECK-NOT: scf.if
+// CHECK-NOT: arith.select
+// CHECK: scf.yield
+
+// -----// WarpSpec internal IR Dump After: doTaskIdPropagate
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 2, 8], threadsPerWarp = [8, 1, 4], warpsPerCTA = [4, 1, 1], order = [1, 2, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 8, 2], threadsPerWarp = [8, 4, 1], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64]], block = []}>
+#linear2 = #ttg.linear<{register = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0], [64, 0, 0]], lane = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16]], warp = [[0, 0, 32], [0, 1, 0]], block = []}>
+#linear3 = #ttg.linear<{register = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0], [64, 0, 0]], lane = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0]], warp = [[0, 32, 0], [0, 0, 1]], block = []}>
+#linear4 = #ttg.linear<{register = [[0, 0, 1], [0, 32, 0], [0, 1, 0], [0, 2, 0], [0, 4, 0], [32, 0, 0], [64, 0, 0]], lane = [[0, 8, 0], [0, 16, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[8, 0, 0], [16, 0, 0]], block = []}>
+#linear5 = #ttg.linear<{register = [[0, 32], [0, 1], [0, 2], [0, 4], [32, 0], [64, 0]], lane = [[0, 8], [0, 16], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.max_reg_auto_ws = 192 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @_hstu_attn_bwd_clc(%Q: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %K: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %V: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %seq_offsets: !tt.ptr<i64> {tt.divisibility = 16 : i32}, %seq_offsets_q: !tt.ptr<i64> {tt.divisibility = 16 : i32}, %DOut: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %DQ: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %DK: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %DV: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %TILE_IDS: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %LOCK: !tt.ptr<i32> {tt.divisibility = 16 : i32}, %stride_qm: i32 {tt.divisibility = 16 : i32}, %stride_qh: i32 {tt.divisibility = 16 : i32}, %stride_kn: i32 {tt.divisibility = 16 : i32}, %stride_kh: i32 {tt.divisibility = 16 : i32}, %stride_vn: i32 {tt.divisibility = 16 : i32}, %stride_vh: i32 {tt.divisibility = 16 : i32}, %stride_dom: i32 {tt.divisibility = 16 : i32}, %stride_doh: i32 {tt.divisibility = 16 : i32}, %stride_dqm: i32 {tt.divisibility = 16 : i32}, %stride_dqh: i32 {tt.divisibility = 16 : i32}, %stride_dkn: i32 {tt.divisibility = 16 : i32}, %stride_dkh: i32 {tt.divisibility = 16 : i32}, %stride_dvn: i32 {tt.divisibility = 16 : i32}, %stride_dvh: i32 {tt.divisibility = 16 : i32}, %alpha: f32, %attn_scale: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %Z: i32, %AUTOTUNE_Z: i32, %H: i32, %max_q_len: i32 {tt.divisibility = 16 : i32}, %AUTOTUNE_MAX_SEQ_LEN: i32 {tt.divisibility = 16 : i32}, %DimQ: i32 {tt.divisibility = 16 : i32}, %DimV: i32 {tt.divisibility = 16 : i32}, %max_attn_len: i32 {tt.divisibility = 16 : i32}, %contextual_seq_len: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant {async_task_id = array<i32: 1>} false
+    %cst = arith.constant {async_task_id = array<i32: 0, 3>} dense<0.000000e+00> : tensor<128x128xf32, #linear>
+    %cst_0 = arith.constant {async_task_id = array<i32: 3>} dense<1.000000e+00> : tensor<128x128xf32, #linear>
+    %c96_i64 = arith.constant {async_task_id = array<i32: 0>} 96 : i64
+    %c64_i64 = arith.constant {async_task_id = array<i32: 0>} 64 : i64
+    %c32_i64 = arith.constant {async_task_id = array<i32: 0>} 32 : i64
+    %c1_i64 = arith.constant {async_task_id = array<i32: 0, 2, 3>} 1 : i64
+    %true = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} true
+    %c128_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 128 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 1 : i32
+    %num_n_tiles = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 127 : i32
+    %cst_1 = arith.constant {async_task_id = array<i32: 3>} dense<0> : tensor<128x128xi32, #linear>
+    %cst_2 = arith.constant {async_task_id = array<i32: 3>} dense<true> : tensor<128x128xi1, #linear>
+    %total_kv = tt.addptr %seq_offsets, %Z {async_task_id = array<i32: 2, 3>} : !tt.ptr<i64>, i32
+    %total_kv_3 = tt.load %total_kv {async_task_id = array<i32: 2, 3>} : !tt.ptr<i64>
+    %total_q = tt.addptr %seq_offsets_q, %Z {async_task_id = array<i32: 0, 2>} : !tt.ptr<i64>, i32
+    %total_q_4 = tt.load %total_q {async_task_id = array<i32: 0, 2>} : !tt.ptr<i64>
+    %desc_q = arith.muli %H, %DimQ {async_task_id = array<i32: 0, 2, 3>} : i32
+    %desc_q_5 = arith.trunci %total_q_4 {async_task_id = array<i32: 0, 2>} : i64 to i32
+    %desc_q_6 = arith.extsi %desc_q {async_task_id = array<i32: 0, 2, 3>} : i32 to i64
+    %desc_q_7 = tt.make_tensor_descriptor %Q, [%desc_q_5, %desc_q], [%desc_q_6, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<bf16>, !tt.tensordesc<128x128xbf16, #shared>
+    %desc_k = arith.trunci %total_kv_3 {async_task_id = array<i32: 2, 3>} : i64 to i32
+    %desc_k_8 = tt.make_tensor_descriptor %K, [%desc_k, %desc_q], [%desc_q_6, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<bf16>, !tt.tensordesc<128x128xbf16, #shared>
+    %desc_v = arith.muli %H, %DimV {async_task_id = array<i32: 2, 3>} : i32
+    %desc_v_9 = arith.extsi %desc_v {async_task_id = array<i32: 2, 3>} : i32 to i64
+    %desc_v_10 = tt.make_tensor_descriptor %V, [%desc_k, %desc_v], [%desc_v_9, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<bf16>, !tt.tensordesc<128x128xbf16, #shared>
+    %desc_do = tt.make_tensor_descriptor %DOut, [%desc_q_5, %desc_v], [%desc_v_9, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<bf16>, !tt.tensordesc<128x128xbf16, #shared>
+    %desc_dq = tt.make_tensor_descriptor %DQ, [%desc_q_5, %desc_q], [%desc_q_6, %c1_i64] {async_task_id = array<i32: 0>} : !tt.ptr<bf16>, !tt.tensordesc<128x32xbf16, #shared1>
+    %desc_dk = tt.make_tensor_descriptor %DK, [%desc_k, %desc_q], [%desc_q_6, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<bf16>, !tt.tensordesc<128x128xbf16, #shared>
+    %desc_dv = tt.make_tensor_descriptor %DV, [%desc_k, %desc_v], [%desc_v_9, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<bf16>, !tt.tensordesc<128x128xbf16, #shared>
+    %num_n_tiles_11 = arith.addi %max_q_len, %num_n_tiles {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %num_n_tiles_12 = arith.divsi %num_n_tiles_11, %c128_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %sched = tt.get_program_id x {async_task_id = array<i32: 0, 2, 3>} : i32
+    %offs_m = tt.make_range {async_task_id = array<i32: 3>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #linear}>>
+    %offs_m_13 = tt.make_range {async_task_id = array<i32: 3>, end = 128 : i32, start = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #linear}>>
+    %k = arith.extsi %stride_kh {async_task_id = array<i32: 2>} : i32 to i64
+    %v = arith.extsi %stride_vh {async_task_id = array<i32: 2>} : i32 to i64
+    %q = arith.extsi %stride_qh {async_task_id = array<i32: 2>} : i32 to i64
+    %do = arith.extsi %stride_doh {async_task_id = array<i32: 2>} : i32 to i64
+    %dq_trans = tt.splat %alpha {async_task_id = array<i32: 0, 3>} : f32 -> tensor<128x128xf32, #linear>
+    %0 = arith.extsi %stride_dqh {async_task_id = array<i32: 0>} : i32 to i64
+    %1 = arith.extsi %stride_dvh {async_task_id = array<i32: 3>} : i32 to i64
+    %2 = arith.extsi %stride_dkh {async_task_id = array<i32: 3>} : i32 to i64
+    %sched._z = scf.while (%sched._valid = %true, %sched._x = %sched) : (i1, i32) -> i32 {
+      scf.condition(%sched._valid) {async_task_id = array<i32: 0, 1, 2, 3>} %sched._x : i32
+    } do {
+    ^bb0(%sched._x: i32):
+      %sched_14 = ttng.clc_try_cancel_async {async_task_id = array<i32: 0, 1, 2, 3>} : !ttg.async.token
+      %tile_id = tt.addptr %TILE_IDS, %sched._x {async_task_id = array<i32: 0, 2, 3>} : !tt.ptr<i32>, i32
+      %tile_id_15 = tt.load %tile_id {async_task_id = array<i32: 0, 1, 2, 3>} : !tt.ptr<i32>
+      %off_hz = arith.divsi %tile_id_15, %num_n_tiles_12 {async_task_id = array<i32: 0, 2, 3>} : i32
+      %start_n = arith.remsi %tile_id_15, %num_n_tiles_12 {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+      %start_n_16 = arith.muli %start_n, %c128_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+      %off_z = arith.divsi %off_hz, %H {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_h = arith.remsi %off_hz, %H {async_task_id = array<i32: 0, 2, 3>} : i32
+      %off_h_17 = arith.extsi %off_h {async_task_id = array<i32: 0, 2, 3>} : i32 to i64
+      %seq_start_kv = tt.addptr %seq_offsets, %off_z {async_task_id = array<i32: 2, 3>} : !tt.ptr<i64>, i32
+      %seq_start_kv_18 = tt.load %seq_start_kv {async_task_id = array<i32: 2, 3>} : !tt.ptr<i64>
+      %seq_start_q = tt.addptr %seq_offsets_q, %off_z {async_task_id = array<i32: 0, 2>} : !tt.ptr<i64>, i32
+      %seq_start_q_19 = tt.load %seq_start_q {async_task_id = array<i32: 0, 1, 2, 3>} : !tt.ptr<i64>
+      %seq_end_q = tt.addptr %seq_start_q, %c1_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : !tt.ptr<i64>, i32
+      %seq_end_q_20 = tt.load %seq_end_q {async_task_id = array<i32: 0, 1, 2, 3>} : !tt.ptr<i64>
+      %seq_len_q = arith.subi %seq_end_q_20, %seq_start_q_19 {async_task_id = array<i32: 0, 1, 2, 3>} : i64
+      %seq_len_q_21 = arith.trunci %seq_len_q {async_task_id = array<i32: 0, 1, 2, 3>} : i64 to i32
+      %k_22 = arith.extsi %start_n_16 {async_task_id = array<i32: 2, 3>} : i32 to i64
+      %k_23 = arith.addi %seq_start_kv_18, %k_22 {async_task_id = array<i32: 2, 3>} : i64
+      %k_24 = arith.trunci %k_23 {async_task_id = array<i32: 2, 3>} : i64 to i32
+      %k_25 = arith.muli %off_h_17, %k {async_task_id = array<i32: 2>} : i64
+      %k_26 = arith.trunci %k_25 {async_task_id = array<i32: 2>} : i64 to i32
+      %k_27 = tt.descriptor_load %desc_k_8[%k_24, %k_26] {async_task_id = array<i32: 2>} : !tt.tensordesc<128x128xbf16, #shared> -> tensor<128x128xbf16, #blocked>
+      %k_28 = ttg.local_alloc %k_27 {async_task_id = array<i32: 2>} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+      %v_29 = arith.muli %off_h_17, %v {async_task_id = array<i32: 2>} : i64
+      %v_30 = arith.trunci %v_29 {async_task_id = array<i32: 2>} : i64 to i32
+      %v_31 = tt.descriptor_load %desc_v_10[%k_24, %v_30] {async_task_id = array<i32: 2>} : !tt.tensordesc<128x128xbf16, #shared> -> tensor<128x128xbf16, #blocked>
+      %v_32 = ttg.local_alloc %v_31 {async_task_id = array<i32: 2>} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+      %offs_n = tt.splat %start_n_16 {async_task_id = array<i32: 3>} : i32 -> tensor<128xi32, #ttg.slice<{dim = 1, parent = #linear}>>
+      %offs_n_33 = arith.addi %offs_n, %offs_m_13 {async_task_id = array<i32: 3>} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #linear}>>
+      %q_34 = arith.muli %off_h_17, %q {async_task_id = array<i32: 2>} : i64
+      %q_35 = arith.trunci %q_34 {async_task_id = array<i32: 2>} : i64 to i32
+      %apply_mask = arith.addi %start_n_16, %c128_i32 {async_task_id = array<i32: 3>} : i32
+      %do_36 = arith.muli %off_h_17, %do {async_task_id = array<i32: 2>} : i64
+      %do_37 = arith.trunci %do_36 {async_task_id = array<i32: 2>} : i64 to i32
+      %dq_trans_38 = ttg.memdesc_trans %k_28 {async_task_id = array<i32: 1>, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem> -> !ttg.memdesc<128x128xbf16, #shared2, #smem>
+      %3 = arith.muli %off_h_17, %0 {async_task_id = array<i32: 0>} : i64
+      %4 = arith.trunci %3 {async_task_id = array<i32: 0>} : i64 to i32
+      %5 = arith.addi %3, %c32_i64 {async_task_id = array<i32: 0>} : i64
+      %6 = arith.trunci %5 {async_task_id = array<i32: 0>} : i64 to i32
+      %7 = arith.addi %3, %c64_i64 {async_task_id = array<i32: 0>} : i64
+      %8 = arith.trunci %7 {async_task_id = array<i32: 0>} : i64 to i32
+      %9 = arith.addi %3, %c96_i64 {async_task_id = array<i32: 0>} : i64
+      %10 = arith.trunci %9 {async_task_id = array<i32: 0>} : i64 to i32
+      %dv, %dv_39 = ttng.tmem_alloc {async_task_id = array<i32: 0, 1, 3>} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %dk, %dk_40 = ttng.tmem_alloc {async_task_id = array<i32: 0, 1, 3>} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %dk_41 = ttng.tmem_store %cst, %dk[%dk_40], %true {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %dv_42 = ttng.tmem_store %cst, %dv[%dv_39], %true {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %dk_43:3 = scf.for %start_m = %start_n_16 to %seq_len_q_21 step %c128_i32 iter_args(%dv_53 = %false, %dv_54 = %dv_42, %dk_55 = %dk_41) -> (i1, !ttg.async.token, !ttg.async.token)  : i32 {
+        %offs_m_56 = tt.splat %start_m {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i32 -> tensor<128xi32, #ttg.slice<{dim = 0, parent = #linear}>>
+        %offs_m_57 = arith.addi %offs_m, %offs_m_56 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #linear}>>
+        %scale = tt.load %attn_scale {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.ptr<f32>
+        %q_58 = arith.extsi %start_m {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i32 to i64
+        %q_59 = arith.extsi %start_m {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i32 to i64
+        %q_60 = arith.addi %seq_start_q_19, %q_58 {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+        %q_61 = arith.addi %seq_start_q_19, %q_59 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+        %q_62 = arith.trunci %q_60 {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i32
+        %q_63 = arith.trunci %q_61 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i32
+        %q_64 = tt.descriptor_load %desc_q_7[%q_62, %q_35] {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x128xbf16, #shared> -> tensor<128x128xbf16, #blocked>
+        %q_65 = ttg.local_alloc %q_64 {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+        %q_trans = ttg.memdesc_trans %q_65 {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem> -> !ttg.memdesc<128x128xbf16, #shared2, #smem>
+        %qk_trans, %qk_trans_66 = ttng.tmem_alloc {async_task_id = array<i32: 1, 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %qk_trans_67 = ttng.tc_gen5_mma %k_28, %q_trans, %qk_trans[%qk_trans_66], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndD,tmem,1,2\22]}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared2, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %apply_mask_68 = arith.cmpi slt, %start_m, %apply_mask {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i32
+        %qk_trans_69, %qk_trans_70 = ttng.tmem_load %qk_trans[%qk_trans_67] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+        %21:4 = scf.if %apply_mask_68 -> (tensor<128x128xf32, #linear>, tensor<128x128xbf16, #linear>, tensor<128x128xf32, #linear>, tensor<128x128xi1, #linear>) {
+          %valid_mask_trans = tt.expand_dims %offs_m_57 {async_task_id = array<i32: 3>, axis = 0 : i32} : tensor<128xi32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xi32, #linear>
+          %valid_mask_trans_103 = tt.expand_dims %offs_n_33 {async_task_id = array<i32: 3>, axis = 1 : i32} : tensor<128xi32, #ttg.slice<{dim = 1, parent = #linear}>> -> tensor<128x1xi32, #linear>
+          %valid_mask_trans_104 = tt.broadcast %valid_mask_trans {async_task_id = array<i32: 3>} : tensor<1x128xi32, #linear> -> tensor<128x128xi32, #linear>
+          %valid_mask_trans_105 = tt.broadcast %valid_mask_trans_103 {async_task_id = array<i32: 3>} : tensor<128x1xi32, #linear> -> tensor<128x128xi32, #linear>
+          %valid_mask_trans_106 = arith.cmpi eq, %valid_mask_trans_104, %valid_mask_trans_105 {async_task_id = array<i32: 3>} : tensor<128x128xi32, #linear>
+          %pos_offs_m_minus_n = arith.subi %valid_mask_trans_104, %valid_mask_trans_105 {async_task_id = array<i32: 3>} : tensor<128x128xi32, #linear>
+          %valid_mask_trans_107 = arith.cmpi sgt, %pos_offs_m_minus_n, %cst_1 {async_task_id = array<i32: 3>} : tensor<128x128xi32, #linear>
+          %valid_mask_trans_108 = arith.ori %valid_mask_trans_106, %valid_mask_trans_107 {async_task_id = array<i32: 3>} : tensor<128x128xi1, #linear>
+          %qk_trans_109 = arith.mulf %qk_trans_69, %dq_trans {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %sig_trans = arith.negf %qk_trans_109 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %sig_trans_110 = math.exp %sig_trans {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %sig_trans_111 = arith.addf %sig_trans_110, %cst_0 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %sig_trans_112 = tt.extern_elementwise %cst_0, %sig_trans_111 {async_task_id = array<i32: 3>, libname = "", libpath = "", pure = true, symbol = "__nv_fast_fdividef"} : (tensor<128x128xf32, #linear>, tensor<128x128xf32, #linear>) -> tensor<128x128xf32, #linear>
+          %silu_trans = arith.mulf %qk_trans_109, %sig_trans_112 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %silu_trans_113 = tt.splat %scale {async_task_id = array<i32: 3>} : f32 -> tensor<128x128xf32, #linear>
+          %silu_trans_114 = arith.mulf %silu_trans, %silu_trans_113 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %act_qk_trans = arith.select %valid_mask_trans_108, %silu_trans_114, %cst {async_task_id = array<i32: 3>} : tensor<128x128xi1, #linear>, tensor<128x128xf32, #linear>
+          %act_qk_trans_115 = arith.truncf %act_qk_trans {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear> to tensor<128x128xbf16, #linear>
+          scf.yield {async_task_id = array<i32: 3>} %qk_trans_109, %act_qk_trans_115, %sig_trans_112, %valid_mask_trans_108 : tensor<128x128xf32, #linear>, tensor<128x128xbf16, #linear>, tensor<128x128xf32, #linear>, tensor<128x128xi1, #linear>
+        } else {
+          %qk_trans_103 = arith.mulf %qk_trans_69, %dq_trans {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %sig_trans = arith.negf %qk_trans_103 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %sig_trans_104 = math.exp %sig_trans {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %sig_trans_105 = arith.addf %sig_trans_104, %cst_0 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %sig_trans_106 = tt.extern_elementwise %cst_0, %sig_trans_105 {async_task_id = array<i32: 3>, libname = "", libpath = "", pure = true, symbol = "__nv_fast_fdividef"} : (tensor<128x128xf32, #linear>, tensor<128x128xf32, #linear>) -> tensor<128x128xf32, #linear>
+          %act_qk_trans = arith.mulf %qk_trans_103, %sig_trans_106 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %act_qk_trans_107 = tt.splat %scale {async_task_id = array<i32: 3>} : f32 -> tensor<128x128xf32, #linear>
+          %act_qk_trans_108 = arith.mulf %act_qk_trans, %act_qk_trans_107 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %act_qk_trans_109 = arith.truncf %act_qk_trans_108 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear> to tensor<128x128xbf16, #linear>
+          scf.yield {async_task_id = array<i32: 3>} %qk_trans_103, %act_qk_trans_109, %sig_trans_106, %cst_2 : tensor<128x128xf32, #linear>, tensor<128x128xbf16, #linear>, tensor<128x128xf32, #linear>, tensor<128x128xi1, #linear>
+        } {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32}
+        %22 = ttg.local_alloc %21#1 {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : (tensor<128x128xbf16, #linear>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+        %do_71 = tt.descriptor_load %desc_do[%q_62, %do_37] {async_task_id = array<i32: 2>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x128xbf16, #shared> -> tensor<128x128xbf16, #blocked>
+        %do_72 = ttg.local_alloc %do_71 {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+        %dact_qk_trans = ttg.memdesc_trans %do_72 {async_task_id = array<i32: 1>, loop.cluster = 4 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem> -> !ttg.memdesc<128x128xbf16, #shared2, #smem>
+        %dact_qk_trans_73, %dact_qk_trans_74 = ttng.tmem_alloc {async_task_id = array<i32: 1, 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %dact_qk_trans_75 = ttng.tc_gen5_mma %v_32, %dact_qk_trans, %dact_qk_trans_73[%dact_qk_trans_74], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndD,tmem,1,5\22]}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared2, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dv_76 = ttng.tc_gen5_mma %22, %do_72, %dv[%dv_54], %dv_53, %true {async_task_id = array<i32: 1>, loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,11\22, \22opndD,tmem,1,7\22]}", tt.self_latency = 0 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dact_qk_trans_77, %dact_qk_trans_78 = ttng.tmem_load %dact_qk_trans_73[%dact_qk_trans_75] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+        %23 = scf.if %apply_mask_68 -> (tensor<128x128xf32, #linear>) {
+          %dqk_trans_103 = arith.mulf %dact_qk_trans_77, %21#2 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %dqk_trans_104 = arith.subf %cst_0, %21#2 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %dqk_trans_105 = arith.mulf %21#0, %dqk_trans_104 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %dqk_trans_106 = arith.addf %dqk_trans_105, %cst_0 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %dqk_trans_107 = arith.mulf %dqk_trans_103, %dqk_trans_106 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %dqk_trans_108 = tt.splat %scale {async_task_id = array<i32: 3>} : f32 -> tensor<128x128xf32, #linear>
+          %dqk_trans_109 = arith.mulf %dqk_trans_107, %dqk_trans_108 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %dqk_trans_110 = arith.select %21#3, %dqk_trans_109, %cst {async_task_id = array<i32: 3>} : tensor<128x128xi1, #linear>, tensor<128x128xf32, #linear>
+          scf.yield {async_task_id = array<i32: 3>} %dqk_trans_110 : tensor<128x128xf32, #linear>
+        } else {
+          %dqk_trans_103 = arith.mulf %dact_qk_trans_77, %21#2 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %dqk_trans_104 = arith.subf %cst_0, %21#2 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %dqk_trans_105 = arith.mulf %21#0, %dqk_trans_104 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %dqk_trans_106 = arith.addf %dqk_trans_105, %cst_0 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %dqk_trans_107 = arith.mulf %dqk_trans_103, %dqk_trans_106 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          %dqk_trans_108 = tt.splat %scale {async_task_id = array<i32: 3>} : f32 -> tensor<128x128xf32, #linear>
+          %dqk_trans_109 = arith.mulf %dqk_trans_107, %dqk_trans_108 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+          scf.yield {async_task_id = array<i32: 3>} %dqk_trans_109 : tensor<128x128xf32, #linear>
+        } {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 1 : i32}
+        %dqk_trans = arith.truncf %23 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #linear> to tensor<128x128xbf16, #linear>
+        %dqk_trans_79 = ttg.local_alloc %dqk_trans {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : (tensor<128x128xbf16, #linear>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
+        %dk_80 = ttng.tc_gen5_mma %dqk_trans_79, %q_65, %dk[%dk_55], %dv_53, %true {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,10\22]}", tt.self_latency = 0 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dq_trans_81, %dq_trans_82 = ttng.tmem_alloc {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %dq_trans_83 = ttng.tc_gen5_mma %dq_trans_38, %dqk_trans_79, %dq_trans_81[%dq_trans_82], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndD,tmem,1,5\22]}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #shared2, #smem>, !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dq_trans_84, %dq_trans_85 = ttng.tmem_load %dq_trans_81[%dq_trans_83] {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+        %dq_trans_86 = arith.mulf %dq_trans_84, %dq_trans {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #linear>
+        %dq = tt.trans %dq_trans_86 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : tensor<128x128xf32, #linear> -> tensor<128x128xf32, #linear1>
+        %dq_87 = arith.truncf %dq {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x128xf32, #linear1> to tensor<128x128xbf16, #linear1>
+        %dqs = tt.reshape %dq_87 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x128xbf16, #linear1> -> tensor<128x2x64xbf16, #linear2>
+        %dqs_88 = tt.trans %dqs {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x64xbf16, #linear2> -> tensor<128x64x2xbf16, #linear3>
+        %dqs_89 = ttg.convert_layout %dqs_88 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64x2xbf16, #linear3> -> tensor<128x64x2xbf16, #linear4>
+        %dqs_90, %dqs_91 = tt.split %dqs_89 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64x2xbf16, #linear4> -> tensor<128x64xbf16, #linear5>
+        %dqs_92 = tt.reshape %dqs_90 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xbf16, #linear5> -> tensor<128x2x32xbf16, #blocked1>
+        %dqs_93 = tt.trans %dqs_92 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xbf16, #blocked1> -> tensor<128x32x2xbf16, #blocked2>
+        %dqs_94, %dqs_95 = tt.split %dqs_93 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32x2xbf16, #blocked2> -> tensor<128x32xbf16, #blocked3>
+        %dqs_96 = tt.reshape %dqs_91 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xbf16, #linear5> -> tensor<128x2x32xbf16, #blocked1>
+        %dqs_97 = tt.trans %dqs_96 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xbf16, #blocked1> -> tensor<128x32x2xbf16, #blocked2>
+        %dqs_98, %dqs_99 = tt.split %dqs_97 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32x2xbf16, #blocked2> -> tensor<128x32xbf16, #blocked3>
+        %desc_dq_reduce_staging = ttg.local_alloc %dqs_94 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : (tensor<128x32xbf16, #blocked3>) -> !ttg.memdesc<128x32xbf16, #shared1, #smem, mutable>
+        %24 = ttng.async_tma_reduce add, %desc_dq[%q_63, %4] %desc_dq_reduce_staging {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x32xbf16, #shared1>, !ttg.memdesc<128x32xbf16, #shared1, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %24   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token
+        %desc_dq_reduce_staging_100 = ttg.local_alloc %dqs_95 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : (tensor<128x32xbf16, #blocked3>) -> !ttg.memdesc<128x32xbf16, #shared1, #smem, mutable>
+        %25 = ttng.async_tma_reduce add, %desc_dq[%q_63, %6] %desc_dq_reduce_staging_100 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x32xbf16, #shared1>, !ttg.memdesc<128x32xbf16, #shared1, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %25   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token
+        %desc_dq_reduce_staging_101 = ttg.local_alloc %dqs_98 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : (tensor<128x32xbf16, #blocked3>) -> !ttg.memdesc<128x32xbf16, #shared1, #smem, mutable>
+        %26 = ttng.async_tma_reduce add, %desc_dq[%q_63, %8] %desc_dq_reduce_staging_101 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x32xbf16, #shared1>, !ttg.memdesc<128x32xbf16, #shared1, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %26   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token
+        %desc_dq_reduce_staging_102 = ttg.local_alloc %dqs_99 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : (tensor<128x32xbf16, #blocked3>) -> !ttg.memdesc<128x32xbf16, #shared1, #smem, mutable>
+        %27 = ttng.async_tma_reduce add, %desc_dq[%q_63, %10] %desc_dq_reduce_staging_102 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x32xbf16, #shared1>, !ttg.memdesc<128x32xbf16, #shared1, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %27   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token
+        scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %true, %dv_76, %dk_80 : i1, !ttg.async.token, !ttg.async.token
+      } {async_task_id = array<i32: 0, 1, 2, 3>, tt.loop_unroll_factor = 1 : i32, tt.merge_epilogue_to_computation = true, tt.scheduled_max_stage = 1 : i32}
+      %dv_44, %dv_45 = ttng.tmem_load %dv[%dk_43#1] {async_task_id = array<i32: 3>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %dk_46, %dk_47 = ttng.tmem_load %dk[%dk_43#2] {async_task_id = array<i32: 3>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %dk_48 = arith.mulf %dk_46, %dq_trans {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear>
+      %11 = arith.muli %off_h_17, %1 {async_task_id = array<i32: 3>} : i64
+      %12 = arith.trunci %11 {async_task_id = array<i32: 3>} : i64 to i32
+      %13 = arith.truncf %dv_44 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear> to tensor<128x128xbf16, #linear>
+      %14 = ttg.convert_layout %13 {async_task_id = array<i32: 3>} : tensor<128x128xbf16, #linear> -> tensor<128x128xbf16, #blocked>
+      %desc_dv_staging = ttg.local_alloc %14 {async_task_id = array<i32: 3>} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+      %15 = ttng.async_tma_copy_local_to_global %desc_dv[%k_24, %12] %desc_dv_staging {async_task_id = array<i32: 3>} : !tt.tensordesc<128x128xbf16, #shared>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %15   {async_task_id = array<i32: 3>} : !ttg.async.token
+      %16 = arith.muli %off_h_17, %2 {async_task_id = array<i32: 3>} : i64
+      %17 = arith.trunci %16 {async_task_id = array<i32: 3>} : i64 to i32
+      %18 = arith.truncf %dk_48 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear> to tensor<128x128xbf16, #linear>
+      %19 = ttg.convert_layout %18 {async_task_id = array<i32: 3>} : tensor<128x128xbf16, #linear> -> tensor<128x128xbf16, #blocked>
+      %desc_dk_staging = ttg.local_alloc %19 {async_task_id = array<i32: 3>} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared, #smem, mutable>
+      %20 = ttng.async_tma_copy_local_to_global %desc_dk[%k_24, %17] %desc_dk_staging {async_task_id = array<i32: 3>} : !tt.tensordesc<128x128xbf16, #shared>, !ttg.memdesc<128x128xbf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %20   {async_task_id = array<i32: 3>} : !ttg.async.token
+      %sched_49, %sched_50, %sched_51, %sched_52 = ttng.clc_read %sched_14 {async_task_id = array<i32: 0, 1, 2, 3>} : !ttg.async.token -> i1, i32, i32, i32
+      scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %sched_49, %sched_50 : i1, i32
+    } attributes {async_task_id = array<i32: 0, 1, 2, 3>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 2 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -147,22 +147,6 @@ public:
       return bailOut(funcOp);
     }
 
-    // FIXME: skip warpspec if there is else block. Need to improve
-    // CodePartitioning to correctly handle channels in else block.
-    bool hasElse = false;
-    funcOp->walk([&](scf::IfOp ifOp) {
-      if (ifOp.elseBlock()) {
-        for (Operation &op : ifOp.elseBlock()->getOperations()) {
-          if (!isa<scf::YieldOp>(&op))
-            hasElse = true;
-        }
-      }
-    });
-    if (hasElse) {
-      LDBG("Warp specialization does not support else blocks. Skipping.");
-      return bailOut(funcOp);
-    }
-
     OpBuilder builder(funcOp);
     auto moduleOp = funcOp->getParentOfType<ModuleOp>();
     // FIXME: skip data partitioning for Blackwell.
@@ -204,6 +188,29 @@ public:
     if (getNestedAsyncTaskIds(funcOp).empty()) {
       LDBG("Warp specialization found no partitions to specialize. "
            "Skipping.");
+      return bailOut(funcOp);
+    }
+
+    // Code partitioning cannot yet place communication channels in both sides
+    // of an IfOp. An IfOp whose complete then/else region belongs to one task
+    // does not need such a channel, however, and specialization already knows
+    // how to clone both regions and their yields. Check this after task ID
+    // propagation so the decision uses the materialized nested task IDs.
+    bool hasUnsupportedElse = false;
+    funcOp->walk([&](scf::IfOp ifOp) {
+      if (!ifOp.elseBlock() || hasUnsupportedElse)
+        return;
+      bool hasNonTrivialElse =
+          llvm::any_of(ifOp.elseBlock()->getOperations(),
+                       [](Operation &op) { return !isa<scf::YieldOp>(op); });
+      if (!hasNonTrivialElse)
+        return;
+      SmallVector<AsyncTaskId> taskIds = getNestedAsyncTaskIds(ifOp);
+      hasUnsupportedElse = taskIds.size() != 1;
+    });
+    if (hasUnsupportedElse) {
+      LDBG("Warp specialization only supports else blocks contained in one "
+           "task. Skipping.");
       return bailOut(funcOp);
     }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -25,6 +25,9 @@ doTaskPartition          (Hopper only; skipped on Blackwell)
   → doPingPongSync       (optional)
   → doTokenLowering
   → doLoopSchedulePreprocessing + scheduleLoops  (external, not in this directory)
+  → SoftwarePipeliner::lowerLoops
+  → peelPartitionLoops   (first masked tile vs. unmasked remainder)
+  → SoftwarePipeliner::expandLoops
 ```
 
 On Blackwell, task assignments are expected to come from an earlier partition
@@ -90,6 +93,7 @@ recognizes the `scf.while` outer loop (same doc).
 | `WSBuffer.cpp` | `appendAccumCntsForOps` | Accumulation counter infrastructure for multi-buffer indexing |
 | `WSMemoryPlanner.cpp` | `doMemoryPlanner` | Plans SMEM and TMEM allocation (multi-buffering, liveness) |
 | `WSCodePartition.cpp` | `doCodePartition` | Creates channels, inserts async copies and barriers |
+| `Pipeliner/PartitionLoopPeeling.cpp` | `peelPartitionLoops` | After scheduled-load lowering, peels a partition-local first iteration when `iv < lb + step`, folding the masked prologue and unmasked remainder predicates |
 | `WSLowerMem.cpp` | `doConvertDescriptorLoadsToNVWS` / `optimizeTMALoads` | Converts `tt.descriptor_load` to buffered `nvws.descriptor_load` before buffer hoisting, then lowers it to async TMA copies after planning |
 | `WSSpecialize.cpp` | `specializeRegion` | Clones ops into `ttg.WarpSpecializeOp` regions |
 | `WSLowerToken.cpp` | `doTokenLowering` | Lowers `ProducerAcquireOp`/`ConsumerWaitOp` to hardware barriers |
@@ -135,6 +139,7 @@ recognizes the `scf.while` outer loop (same doc).
 - [Data Partitioning](DataPartition.md) — splitting tensor dimensions across consumer warp groups
 - [Code Partitioning](CodePartition.md) — channel discovery, buffer creation, sync insertion
 - [Code Specialization](CodeSpecialization.md) — how ops are cloned into WarpSpecializeOp regions
+- [Partition Loop Peeling](PartitionLoopPeeling.md) — first-tile control-flow peeling after physical specialization
 - [Memory Lowering](MemoryLowering.md) — async copy creation and TMA store lowering
 - [Token & Barrier Lowering](TokenBarrierLowering.md) — lowering abstract tokens to hardware mbarriers
 - [Buffer Allocation](BufferAllocation.md) — channel discovery and SMEM/TMEM allocation hoisting

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionLoopPeeling.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionLoopPeeling.md
@@ -1,0 +1,54 @@
+# Partition Loop Peeling
+
+`peelPartitionLoops` runs in the generic software pipeliner after `lowerLoops`
+and before `expandLoops`. Code partitioning has already cloned code into
+physical `ttg.warp_specialize` regions. This placement matters: `lowerLoops`
+must consume the original schedule before peeling moves one iteration into a
+prologue. It exposes separate first-tile and remainder paths inside one
+numbered partition without requiring every partition to share the same
+control-flow shape.
+
+The transformation is intentionally narrow. It recognizes an `scf.for` body
+predicate of the form:
+
+```mlir
+%boundary = arith.addi %lb, %step
+%masked = arith.cmpi slt, %iv, %boundary
+%result = scf.if %masked { ... } else { ... }
+```
+
+when `%iv` is the loop induction variable and the comparison controls an
+`scf.if`. It rewrites the loop to a zero-trip-safe outer `scf.if`, clones the
+first iteration with `%masked = true`, and creates a remainder loop beginning
+at `%lb + %step` with `%masked = false`. Canonicalization removes the dead side
+of each activation branch later in the AutoWS pipeline.
+
+## Matching contract
+
+The comparison must live directly in the `scf.for` body block and must feed an
+`scf.if` condition. Anything else -- a guard buried in a nested region, a
+comparison that feeds arithmetic instead of a branch, or an `scf.while` (which
+has no induction variable to split on, so CLC's dynamic outer loop is out of
+scope) -- fails to match and the loop is left untouched. Peeling therefore never
+partially rewrites a shape it does not fully recognize.
+
+Loops are peeled in walk (post) order, innermost first. Peeling replaces a loop
+with an `scf.if` and erases the original, so peeling an outer loop first would
+erase the inner loops collected alongside it.
+
+When more than one comparison matches, only the first in walk order is peeled:
+the rewrite is a single first-iteration split, and peeling a second guard would
+require nesting prologues. Loops without iteration arguments are supported; the
+outer `scf.if` drops the terminators `scf.IfOp` auto-inserts for a result-less
+op before the explicit yields are attached.
+
+Only numbered partition regions returned by
+`ttg.warp_specialize.getPartitionRegions()` are considered. The default region
+is excluded, and the pass does not traverse into nested warp-specialize ops.
+This placement and restriction are important: communication channels and
+physical buffers have already been planned, so peeling cannot change channel
+discovery or memory-planner decisions.
+
+The HSTU self-attention backward kernel uses this pattern for its first masked
+dK/dV tile. Its benchmark-derived regression is
+`test/Hopper/WarpSpecialization/ws_single_partition_else_hstu_bwd.mlir`.


### PR DESCRIPTION
Summary:

The first tile of the HSTU causal backward loop uses a masked path, while every later tile uses the simpler unmasked path; leaving that condition inside the pipelined partition adds repeated branches and prevents simplification. This change peels the first iteration after scheduled-load lowering, preserves the masked prologue, and pipelines a branch-free remainder without changing channel or memory planning. It also permits non-trivial IfOps whose complete bodies are proven to belong to one task, which is the minimum eligibility support required by this fixture.

Reviewed By: njriasan

Differential Revision: D114610693


