### PR TITLE
[lint-autofix] Fix pre-commit formatting issues

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
@@ -221,9 +221,8 @@ struct AllocateWarpGroups
 
       // Group the partitions into warpgroups.
       SmallVector<WarpGroupPartition> orderedPartitions;
-      for (auto [startId, partition, estRegs, numWarps] :
-           llvm::zip(startIds, op.getPartitionRegions(), requestedRegisters,
-                     arr)) {
+      for (auto [startId, partition, estRegs, numWarps] : llvm::zip(
+               startIds, op.getPartitionRegions(), requestedRegisters, arr)) {
         int minRegs =
             minRegistersForRegion(*partition, laterInstrumentation, estRegs);
         orderedPartitions.push_back({startId, partition, minRegs, numWarps});
@@ -271,8 +270,7 @@ struct AllocateWarpGroups
       for (const WarpGroupInfo &wg : warpGroups) {
         assert(wg.numWarps % 4 == 0);
         if (wg.maxRequestedRegs > 0)
-          remainingRegs -=
-              wg.maxRequestedRegs * wg.numWarps * threadsPerWarp;
+          remainingRegs -= wg.maxRequestedRegs * wg.numWarps * threadsPerWarp;
         else
           sharingThreads += wg.numWarps * threadsPerWarp;
       }
@@ -291,11 +289,9 @@ struct AllocateWarpGroups
           return;
       }
 
-      maxnregsPerPartition.front() =
-          defaultRegs > 0 ? defaultRegs : sharedRegs;
+      maxnregsPerPartition.front() = defaultRegs > 0 ? defaultRegs : sharedRegs;
       for (const WarpGroupInfo &wg : warpGroups) {
-        int regs =
-            wg.maxRequestedRegs > 0 ? wg.maxRequestedRegs : sharedRegs;
+        int regs = wg.maxRequestedRegs > 0 ? wg.maxRequestedRegs : sharedRegs;
         for (Region *region : wg.partitions)
           maxnregsPerPartition[1 + region->getRegionNumber()] = regs;
       }

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -3135,11 +3135,7 @@ def _compile_a4w4_inter_wave_256tile(m, n, k, preshuffled_scales=False):
     c = MockTensor(torch.bfloat16, (m, n))
     a_scales = MockTensor(torch.uint8, (m * k // 32, ) if preshuffled_scales else (m, k // 32))
     b_scales = MockTensor(torch.uint8, (n * k // 32, ) if preshuffled_scales else (n, k // 32))
-    kernel = (
-        _a4w4_inter_wave_preshuffled_scales_kernel
-        if preshuffled_scales
-        else _a4w4_inter_wave_256tile_kernel
-    )
+    kernel = (_a4w4_inter_wave_preshuffled_scales_kernel if preshuffled_scales else _a4w4_inter_wave_256tile_kernel)
     scale_strides = () if preshuffled_scales else (1, m, 1, n)
 
     with knobs.runtime.scope():
@@ -3363,8 +3359,7 @@ def test_a4w4_inter_wave_preshuffled_scale_correctness_gfx950(device, k, split_k
     a, b, a_scales, b_scales = _generate_a4w4_inputs(m, n, k)
     a_scales_preshuffled = _preshuffle_a4w4_a_scales(a_scales)
     b_scales_preshuffled = _preshuffle_a4w4_b_scales(b_scales)
-    actual = _a4w4_inter_wave_matmul_preshuffled(
-        a, b, a_scales_preshuffled, b_scales_preshuffled, SPLIT_K=split_k)
+    actual = _a4w4_inter_wave_matmul_preshuffled(a, b, a_scales_preshuffled, b_scales_preshuffled, SPLIT_K=split_k)
     expected = _a4w4_reference(a, b, a_scales, b_scales)
     torch.testing.assert_close(actual, expected, atol=0.0, rtol=0.0)
 

--- a/python/test/unit/runtime/test_fast_cache_edge_cases.py
+++ b/python/test/unit/runtime/test_fast_cache_edge_cases.py
@@ -686,11 +686,11 @@ class TestUnhashableKwargs(TestCase):
         out = torch.zeros(32, device=device)
 
         # Normal call — warmup (populates cache with options_hash=0).
-        nop_kernel[(1,)](out, 32)
+        nop_kernel[(1, )](out, 32)
 
         # Call with extern_libs dict — the fast path must hash this without
         # raising ``TypeError: unhashable type: 'dict'``.
-        nop_kernel[(1,)](out, 32, extern_libs={"libdevice": "/dev/null"})
+        nop_kernel[(1, )](out, 32, extern_libs={"libdevice": "/dev/null"})
 
     def test_extern_libs_empty_dict_no_crash(self):
         """extern_libs={} (empty dict) must not crash the fast path hash."""
@@ -703,9 +703,9 @@ class TestUnhashableKwargs(TestCase):
         device = _get_device()
         out = torch.zeros(32, device=device)
 
-        nop_kernel2[(1,)](out, 32)
+        nop_kernel2[(1, )](out, 32)
         # Empty dict is still a dict — must not crash.
-        nop_kernel2[(1,)](out, 32, extern_libs={})
+        nop_kernel2[(1, )](out, 32, extern_libs={})
 
     def test_multi_entry_extern_libs_no_crash(self):
         """Multi-entry extern_libs dict must not crash the fast path hash."""
@@ -718,11 +718,9 @@ class TestUnhashableKwargs(TestCase):
         device = _get_device()
         out = torch.zeros(32, device=device)
 
-        nop_kernel3[(1,)](out, 32)
+        nop_kernel3[(1, )](out, 32)
         # Multi-entry extern_libs dict — must not crash the hash.
-        nop_kernel3[(1,)](
-            out, 32, extern_libs={"libA": "/dev/null", "libB": "/dev/null"}
-        )
+        nop_kernel3[(1, )](out, 32, extern_libs={"libA": "/dev/null", "libB": "/dev/null"})
 
     def test_make_hashable_produces_different_hashes(self):
         """_make_hashable must produce different hashes for different dicts."""
@@ -730,9 +728,7 @@ class TestUnhashableKwargs(TestCase):
         h2 = _hash_fc_opts({"extern_libs": {"libB": "/path/b"}})
         h3 = _hash_fc_opts({"extern_libs": {"libA": "/path/a"}})
 
-        self.assertNotEqual(
-            h1, h2, "Different dict values must produce different hashes"
-        )
+        self.assertNotEqual(h1, h2, "Different dict values must produce different hashes")
         self.assertEqual(h1, h3, "Same dict values must produce the same hash")
 
     def test_different_none_pattern_different_cache_entry(self):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -4053,11 +4053,9 @@ class AutoWSLoopOptions(base_value):
         default=False, metadata=_loop_attr("tt.merge_epilogue_to_computation", "bool"))
     merge_correction: bool | constexpr = field(default=False, metadata=_loop_attr("tt.merge_correction", "bool"))
     separate_epilogue_store: bool | constexpr = field(default=False,
-                                                       metadata=_loop_attr("tt.separate_epilogue_store", "bool"))
-    tmem_alloc_algo: int | constexpr | None = field(default=None,
-                                                     metadata=_loop_attr("tt.tmem_alloc_algo", "int32"))
-    smem_alloc_algo: int | constexpr | None = field(default=None,
-                                                     metadata=_loop_attr("tt.smem_alloc_algo", "int32"))
+                                                      metadata=_loop_attr("tt.separate_epilogue_store", "bool"))
+    tmem_alloc_algo: int | constexpr | None = field(default=None, metadata=_loop_attr("tt.tmem_alloc_algo", "int32"))
+    smem_alloc_algo: int | constexpr | None = field(default=None, metadata=_loop_attr("tt.smem_alloc_algo", "int32"))
     smem_budget: int | constexpr | None = field(default=None, metadata=_loop_attr("tt.smem_budget", "int32"))
     smem_circular_reuse: bool | constexpr | None = field(default=None,
                                                          metadata=_loop_attr("tt.smem_circular_reuse", "bool_opt"))

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -152,7 +152,7 @@ static void materializeDeferredSchedGroupBarriers(ModuleOp mod) {
           unsigned cover = anchor.mask == (1 << 5)   ? anchor.mfmaCover
                            : anchor.mask == (1 << 8) ? 1
                            : anchor.mask == (1 << 9) ? writeCover
-                                                    : 0;
+                                                     : 0;
           for (unsigned i = 0; i < anchor.count; ++i)
             groups.push_back({anchor.mask, mfmas ? cover : 0});
         }
@@ -436,8 +436,8 @@ createConvertTritonAMDGPUToLLVMPass(StringRef gfxArch, bool ftz) {
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertTritonAMDGPUToLLVMPass(StringRef gfxArch, bool ftz,
                                     bool enableTreeReduction) {
-  return std::make_unique<ConvertTritonAMDGPUToLLVM>(
-      gfxArch, ftz, enableTreeReduction);
+  return std::make_unique<ConvertTritonAMDGPUToLLVM>(gfxArch, ftz,
+                                                     enableTreeReduction);
 }
 
 } // namespace mlir::triton

--- a/third_party/amd/lib/TritonAMDGPUTransforms/SchedGroupBarrierScheduler.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/SchedGroupBarrierScheduler.cpp
@@ -224,8 +224,8 @@ priceBufferAccess(Value ptr, Value offset, unsigned contiguityHint,
   return {/*count=*/std::max(1u, (elems + vec - 1) / vec),
           /*accessBytes=*/std::max(1u, vec * elemBytes)};
 }
-static VMEMPrice
-priceVMEM(Operation *op, triton::AMD::ModuleAxisInfoAnalysis &axisInfo) {
+static VMEMPrice priceVMEM(Operation *op,
+                           triton::AMD::ModuleAxisInfoAnalysis &axisInfo) {
   if (auto load = dyn_cast<triton::amdgpu::BufferLoadOp>(op))
     return priceBufferAccess(load.getPtr(), load.getOffsets(),
                              load.getContiguity(), axisInfo);
@@ -241,8 +241,7 @@ priceVMEM(Operation *op, triton::AMD::ModuleAxisInfoAnalysis &axisInfo) {
       int64_t e = 1;
       for (int64_t d : md.getShape())
         e *= d;
-      return {/*count=*/std::max<unsigned>(
-                  1, (unsigned)((e * eb) / 256) / 16),
+      return {/*count=*/std::max<unsigned>(1, (unsigned)((e * eb) / 256) / 16),
               /*accessBytes=*/16};
     }
     if (isa<RankedTensorType>(r.getType()))
@@ -255,8 +254,7 @@ priceVMEM(Operation *op, triton::AMD::ModuleAxisInfoAnalysis &axisInfo) {
       int64_t e = 1;
       for (int64_t d : md.getShape())
         e *= d;
-      return {/*count=*/std::max<unsigned>(
-                  1, (unsigned)((e * eb) / 256) / 16),
+      return {/*count=*/std::max<unsigned>(1, (unsigned)((e * eb) / 256) / 16),
               /*accessBytes=*/16};
     }
   return {/*count=*/1, /*accessBytes=*/16};
@@ -308,9 +306,9 @@ struct TritonAMDGPUSchedGroupBarrierSchedulerPass
 
     Builder b(&getContext());
     mod->setAttr("ttg.amd.sched_group_barrier.enabled", b.getUnitAttr());
-    mod->setAttr("ttg.amd.sched_group_barrier.required_region_count",
-                 b.getI32IntegerAttr(
-                     static_cast<unsigned>(requiredRegionCount)));
+    mod->setAttr(
+        "ttg.amd.sched_group_barrier.required_region_count",
+        b.getI32IntegerAttr(static_cast<unsigned>(requiredRegionCount)));
   }
 };
 

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -50,12 +50,11 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
         [](mlir::PassManager &pm, const std::string &arch, bool ftz) {
           pm.addPass(createConvertTritonAMDGPUToLLVMPass(arch, ftz));
         });
-  m.def("add_to_llvmir",
-        [](mlir::PassManager &pm, const std::string &arch, bool ftz,
-           bool enableTreeReduction) {
-          pm.addPass(createConvertTritonAMDGPUToLLVMPass(
-              arch, ftz, enableTreeReduction));
-        });
+  m.def("add_to_llvmir", [](mlir::PassManager &pm, const std::string &arch,
+                            bool ftz, bool enableTreeReduction) {
+    pm.addPass(
+        createConvertTritonAMDGPUToLLVMPass(arch, ftz, enableTreeReduction));
+  });
   m.def("add_builtin_func_to_llvmir",
         [](mlir::PassManager &pm, const std::string &arch, bool ftz) {
           pm.addPass(createConvertBuiltinFuncToLLVMPass(arch, ftz));

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -1405,7 +1405,7 @@ void init_triton_tlx_ir(py::module &&m) {
       .def("create_assume_uniform",
            [](TritonOpBuilder &self, Value value) -> Value {
              return self.create<ttag::AssumeUniformOp>(value.getType(), value);
-            });
+           });
 }
 
 void init_triton_tlx_passes(py::module &&m) {

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
@@ -746,9 +746,9 @@ _TORCH_TO_TL = {torch.float16: tl.float16, torch.bfloat16: tl.bfloat16, torch.fl
 
 
 @triton.jit
-def _reduce_k_kernel(workspace_ptr, bias_ptr, c_ptr, M, N, stride_bias_m, stride_bias_n,
-                     SPLIT_K: tl.constexpr, BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr,
-                     OUTPUT_DTYPE: tl.constexpr, ADD_BIAS: tl.constexpr):
+def _reduce_k_kernel(workspace_ptr, bias_ptr, c_ptr, M, N, stride_bias_m, stride_bias_n, SPLIT_K: tl.constexpr,
+                     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, OUTPUT_DTYPE: tl.constexpr,
+                     ADD_BIAS: tl.constexpr):
     # Sum the SPLIT_K partials (each a contiguous (M, N) slab in workspace) into
     # C with fp32 accumulation. Small tiles (32x32) so small outputs still spawn
     # many CTAs -- else the reduce is CTA-starved and dominates (D97513062).

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a4w4/matmul_kernel.py
@@ -87,8 +87,7 @@ import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
 from triton.language.extra.tlx.tutorials.gfx9_gemm.intra_wave.a4w4.matmul_kernel import (
-    matmul as intra_wave_matmul,
-)
+    matmul as intra_wave_matmul, )
 from triton.language.extra.tlx.tutorials.gfx9_gemm.skinny.a4w4 import is_skinny, skinny_matmul
 
 BLOCK_M = 256
@@ -170,8 +169,20 @@ def _a4w4_8wave_kernel(
     shared_tile: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
         [[1024, 32]],
         [
-            [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64],
-            [1, 0], [32, 0], [64, 0], [2, 0], [4, 0], [8, 0], [16, 0],
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [0, 64],
+            [1, 0],
+            [32, 0],
+            [64, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+            [16, 0],
         ],
         [HALF_M, HALF_K],
     )
@@ -183,16 +194,33 @@ def _a4w4_8wave_kernel(
     # remain unchanged, preserving each contiguous 8-byte global segment.
     shared_a_scales: tl.constexpr = tlx.shared_linear_layout_encoding(
         offset_bases=[
-            [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0],
-            [0, 1], [0, 2], [16, 4],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+            [16, 0],
+            [32, 0],
+            [64, 0],
+            [0, 1],
+            [0, 2],
+            [16, 4],
         ],
         block_bases=[],
         alignment=16,
     )
     shared_b_scales: tl.constexpr = tlx.shared_linear_layout_encoding(
         offset_bases=[
-            [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0], [128, 0],
-            [16, 1], [0, 2], [32, 4],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+            [16, 0],
+            [32, 0],
+            [64, 0],
+            [128, 0],
+            [16, 1],
+            [0, 2],
+            [32, 4],
         ],
         block_bases=[],
         alignment=16,
@@ -599,15 +627,37 @@ def _a4w4_8wave_preshuffled_scales_kernel(
     shared_tile: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
         [[1024, 32]],
         [
-            [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64],
-            [1, 0], [32, 0], [64, 0], [2, 0], [4, 0], [8, 0], [16, 0],
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [0, 64],
+            [1, 0],
+            [32, 0],
+            [64, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+            [16, 0],
         ],
         [HALF_M, HALF_K],
     )
     # Each preshuffled scale allocation is a raw byte-linear LDS image.
     shared_scale_preshuffled: tl.constexpr = tlx.shared_linear_layout_encoding(
         offset_bases=[
-            [1], [2], [4], [8], [16], [32], [64], [128], [256], [512], [1024],
+            [1],
+            [2],
+            [4],
+            [8],
+            [16],
+            [32],
+            [64],
+            [128],
+            [256],
+            [512],
+            [1024],
         ],
         block_bases=[],
         alignment=16,
@@ -687,10 +737,8 @@ def _a4w4_8wave_preshuffled_scales_kernel(
     smem_a_bot = tlx.local_alloc((HALF_M, HALF_K), tlx.dtype_of(a_ptr), 2, layout=shared_tile)
     smem_b_left = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
     smem_b_right = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
-    smem_a_sc = tlx.local_alloc(
-        (BLOCK_M * NG, ), tlx.dtype_of(a_scales_ptr), 2, layout=shared_scale_preshuffled)
-    smem_b_sc = tlx.local_alloc(
-        (BLOCK_N * NG, ), tlx.dtype_of(b_scales_ptr), 2, layout=shared_scale_preshuffled)
+    smem_a_sc = tlx.local_alloc((BLOCK_M * NG, ), tlx.dtype_of(a_scales_ptr), 2, layout=shared_scale_preshuffled)
+    smem_b_sc = tlx.local_alloc((BLOCK_N * NG, ), tlx.dtype_of(b_scales_ptr), 2, layout=shared_scale_preshuffled)
     offs_am = tl.arange(0, HALF_M)
     offs_ak = tl.arange(0, HALF_K)
     a_tile_offsets = tlx.require_layout(offs_am[:, None] * stride_am + offs_ak[None, :] * stride_ak, g_load_layout)
@@ -1031,8 +1079,20 @@ def _a4w4_8wave_merged_scales_kernel(
     shared_tile: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
         [[1024, 32]],
         [
-            [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64],
-            [1, 0], [32, 0], [64, 0], [2, 0], [4, 0], [8, 0], [16, 0],
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [0, 64],
+            [1, 0],
+            [32, 0],
+            [64, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+            [16, 0],
         ],
         [HALF_M, HALF_K],
     )
@@ -1046,9 +1106,19 @@ def _a4w4_8wave_merged_scales_kernel(
     # the A view; physical bit 12 selects the second K tile.
     shared_merged_a_scales_combined: tl.constexpr = tlx.shared_linear_layout_encoding(
         offset_bases=[
-            [0, 0, 4], [0, 32, 0], [0, 64, 0], [0, 128, 0],
-            [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0],
-            [0, 16, 0], [0, 0, 1], [0, 0, 2], [0, 0, 0], [1, 0, 0],
+            [0, 0, 4],
+            [0, 32, 0],
+            [0, 64, 0],
+            [0, 128, 0],
+            [0, 1, 0],
+            [0, 2, 0],
+            [0, 4, 0],
+            [0, 8, 0],
+            [0, 16, 0],
+            [0, 0, 1],
+            [0, 0, 2],
+            [0, 0, 0],
+            [1, 0, 0],
         ],
         block_bases=[],
         alignment=16,
@@ -1058,9 +1128,19 @@ def _a4w4_8wave_merged_scales_kernel(
     # slicing.
     shared_merged_b_scales: tl.constexpr = tlx.shared_linear_layout_encoding(
         offset_bases=[
-            [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0],
-            [0, 32, 0], [0, 64, 0], [0, 128, 0], [0, 16, 1], [0, 0, 2],
-            [0, 32, 4], [1, 0, 0], [2, 0, 0],
+            [0, 1, 0],
+            [0, 2, 0],
+            [0, 4, 0],
+            [0, 8, 0],
+            [0, 16, 0],
+            [0, 32, 0],
+            [0, 64, 0],
+            [0, 128, 0],
+            [0, 16, 1],
+            [0, 0, 2],
+            [0, 32, 4],
+            [1, 0, 0],
+            [2, 0, 0],
         ],
         block_bases=[],
         alignment=16,
@@ -1068,7 +1148,19 @@ def _a4w4_8wave_merged_scales_kernel(
     # The merged DMA writes one raw byte-linear 8192-byte A+B image.
     shared_scale_merged: tl.constexpr = tlx.shared_linear_layout_encoding(
         offset_bases=[
-            [1], [2], [4], [8], [16], [32], [64], [128], [256], [512], [1024], [2048], [4096],
+            [1],
+            [2],
+            [4],
+            [8],
+            [16],
+            [32],
+            [64],
+            [128],
+            [256],
+            [512],
+            [1024],
+            [2048],
+            [4096],
         ],
         block_bases=[],
         alignment=16,
@@ -1145,12 +1237,10 @@ def _a4w4_8wave_merged_scales_kernel(
     smem_a_bot = tlx.local_alloc((HALF_M, HALF_K), tlx.dtype_of(a_ptr), 2, layout=shared_tile)
     smem_b_left = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
     smem_b_right = tlx.local_alloc((HALF_N, HALF_K), tlx.dtype_of(b_ptr), 2, layout=shared_tile)
-    smem_sc = tlx.local_alloc(
-        (2 * (BLOCK_M + BLOCK_N) * NG, ), tlx.dtype_of(scales_ptr), 1, layout=shared_scale_merged)
-    smem_sc_a_view = tlx.local_reinterpret(
-        smem_sc[0], tl.uint8, [2, BLOCK_M, NG], layout=shared_merged_a_scales_combined)
-    smem_sc_b_view = tlx.local_reinterpret(
-        smem_sc[0], tl.uint8, [4, BLOCK_N, NG], layout=shared_merged_b_scales)
+    smem_sc = tlx.local_alloc((2 * (BLOCK_M + BLOCK_N) * NG, ), tlx.dtype_of(scales_ptr), 1, layout=shared_scale_merged)
+    smem_sc_a_view = tlx.local_reinterpret(smem_sc[0], tl.uint8, [2, BLOCK_M, NG],
+                                           layout=shared_merged_a_scales_combined)
+    smem_sc_b_view = tlx.local_reinterpret(smem_sc[0], tl.uint8, [4, BLOCK_N, NG], layout=shared_merged_b_scales)
     offs_am = tl.arange(0, HALF_M)
     offs_ak = tl.arange(0, HALF_K)
     a_tile_offsets = tlx.require_layout(offs_am[:, None] * stride_am + offs_ak[None, :] * stride_ak, g_load_layout)
@@ -1221,10 +1311,8 @@ def _a4w4_8wave_merged_scales_kernel(
     tlx.async_load_wait_group(6)
     b_left = tlx.local_load(tlx.local_trans(smem_b_left[0]), relaxed=True)
     a_top = tlx.local_load(smem_a_top[0], relaxed=True)
-    b_sc_view_init = tlx.local_slice(
-        smem_sc_b_view, [1, 0, 0], [1, BLOCK_N, NG])
-    a_sc_view_init = tlx.local_slice(
-        smem_sc_a_view, [0, 0, 0], [1, BLOCK_M, NG])
+    b_sc_view_init = tlx.local_slice(smem_sc_b_view, [1, 0, 0], [1, BLOCK_N, NG])
+    a_sc_view_init = tlx.local_slice(smem_sc_a_view, [0, 0, 0], [1, BLOCK_M, NG])
     a_sc_comb = tlx.local_load(a_sc_view_init, layout=scale_a_comb_layout, relaxed=True)
     a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
     a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
@@ -1270,10 +1358,8 @@ def _a4w4_8wave_merged_scales_kernel(
             acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_top = tlx.local_load(smem_a_top[1], relaxed=True)
-            a_sc_view_1 = tlx.local_slice(
-                smem_sc_a_view, [1, 0, 0], [1, BLOCK_M, NG])
-            b_sc_view_1 = tlx.local_slice(
-                smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
+            a_sc_view_1 = tlx.local_slice(smem_sc_a_view, [1, 0, 0], [1, BLOCK_M, NG])
+            b_sc_view_1 = tlx.local_slice(smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
             a_sc_comb = tlx.local_load(a_sc_view_1, layout=scale_a_comb_layout, relaxed=True)
             a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
             a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
@@ -1321,10 +1407,8 @@ def _a4w4_8wave_merged_scales_kernel(
             acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
         with tlx.warp_pipeline_stage("mem", priority=1):
             a_top = tlx.local_load(smem_a_top[0], relaxed=True)
-            a_sc_view_0 = tlx.local_slice(
-                smem_sc_a_view, [0, 0, 0], [1, BLOCK_M, NG])
-            b_sc_view_0 = tlx.local_slice(
-                smem_sc_b_view, [1, 0, 0], [1, BLOCK_N, NG])
+            a_sc_view_0 = tlx.local_slice(smem_sc_a_view, [0, 0, 0], [1, BLOCK_M, NG])
+            b_sc_view_0 = tlx.local_slice(smem_sc_b_view, [1, 0, 0], [1, BLOCK_N, NG])
             a_sc_comb = tlx.local_load(a_sc_view_0, layout=scale_a_comb_layout, relaxed=True)
             a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
             a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
@@ -1356,10 +1440,8 @@ def _a4w4_8wave_merged_scales_kernel(
     acc_br = tl.dot_scaled(a_bot, a_sc_bot, "e2m1", b_right, b_sc_right, "e2m1", acc_br)
     tlx.async_load_wait_group(2)
     a_top = tlx.local_load(tlx.local_view(smem_a_top, g_idx), relaxed=True)
-    a_sc_view_epilogue = tlx.local_slice(
-        smem_sc_a_view, [1, 0, 0], [1, BLOCK_M, NG])
-    b_sc_view_epilogue = tlx.local_slice(
-        smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
+    a_sc_view_epilogue = tlx.local_slice(smem_sc_a_view, [1, 0, 0], [1, BLOCK_M, NG])
+    b_sc_view_epilogue = tlx.local_slice(smem_sc_b_view, [3, 0, 0], [1, BLOCK_N, NG])
     a_sc_comb = tlx.local_load(a_sc_view_epilogue, layout=scale_a_comb_layout, relaxed=True)
     a_sc_t, a_sc_b = tl.split(tl.trans(tl.reshape(a_sc_comb, 2, HALF_M, NG), 1, 2, 0))
     a_sc_top = tlx.require_layout(a_sc_t, scale_a_layout)
@@ -1498,40 +1580,22 @@ def preshuffle_mxfp4_a_scales(scales):
     value (0x7f).
     """
     padded, padded_rows, padded_groups = _pad_mxfp4_scales(scales)
-    return (
-        padded.reshape(
-            padded_rows // 256, 2, 2, 2, 2, 2, 2, 2, 2,
-            padded_groups // 8, 2, 2, 2)
-        .permute(0, 9, 11, 12, 7, 8, 4, 5, 6, 1, 2, 3, 10)
-        .contiguous()
-        .reshape(-1)
-    )
+    return (padded.reshape(padded_rows // 256, 2, 2, 2, 2, 2, 2, 2, 2, padded_groups // 8, 2, 2,
+                           2).permute(0, 9, 11, 12, 7, 8, 4, 5, 6, 1, 2, 3, 10).contiguous().reshape(-1))
 
 
 def _preshuffle_mxfp4_a_scales_b128(scales):
     """Pack A scales for the merged ABI's conflict-free 128-bit LDS read."""
     padded, padded_rows, padded_groups = _pad_mxfp4_scales(scales)
-    return (
-        padded.reshape(
-            padded_rows // 256, 2, 2, 2, 2, 2, 2, 2, 2,
-            padded_groups // 8, 2, 2, 2)
-        .permute(0, 9, 11, 12, 4, 5, 6, 7, 8, 1, 2, 3, 10)
-        .contiguous()
-        .reshape(-1)
-    )
+    return (padded.reshape(padded_rows // 256, 2, 2, 2, 2, 2, 2, 2, 2, padded_groups // 8, 2, 2,
+                           2).permute(0, 9, 11, 12, 4, 5, 6, 7, 8, 1, 2, 3, 10).contiguous().reshape(-1))
 
 
 def preshuffle_mxfp4_b_scales(scales):
     """Pack B scales into the ordinary 64-bit LDS consumer order."""
     padded, padded_rows, padded_groups = _pad_mxfp4_scales(scales)
-    return (
-        padded.reshape(
-            padded_rows // 256, 2, 2, 2, 2, 2, 2, 2, 2,
-            padded_groups // 8, 2, 2, 2)
-        .permute(0, 9, 11, 12, 3, 8, 4, 5, 6, 7, 1, 2, 10)
-        .contiguous()
-        .reshape(-1)
-    )
+    return (padded.reshape(padded_rows // 256, 2, 2, 2, 2, 2, 2, 2, 2, padded_groups // 8, 2, 2,
+                           2).permute(0, 9, 11, 12, 3, 8, 4, 5, 6, 7, 1, 2, 10).contiguous().reshape(-1))
 
 
 def _preshuffle_mxfp4_b_scales_conflict_free(scales):


### PR DESCRIPTION
Summary:
Automated formatting fix generated by running `pre-commit run --all-files`
and `pre-commit run clang-format --all-files` on the GitHub mirror
(facebookexperimental/triton). 10 file(s) fixed.

Reviewed By: njriasan

Differential Revision: D116376868


