### PR TITLE
[TLX][AMD] Accelerate standalone addmm partial-K tails

### DIFF
--- a/third_party/tlx/tutorials/amd_addmm_gfx950.py
+++ b/third_party/tlx/tutorials/amd_addmm_gfx950.py
@@ -8,6 +8,7 @@ one-dimensional ``(N,)`` or broadcastable to ``(M, N)``.
 import torch
 
 import triton
+import triton.language as tl
 
 from triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a16w16.matmul_kernel import (
     BLOCK_K,
@@ -19,10 +20,34 @@ from triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a16w16.matmul_kern
 _PATH_AUTOTUNE_WARMUP = 25
 _PATH_AUTOTUNE_REP = 100
 _PATH_CACHE: dict[tuple[object, ...], str] = {}
+_TAIL_BLOCK_K = 2 * BLOCK_K
+_MAX_DEFERRED_EPILOGUE_ELEMENTS = 16 * 1024 * 1024
+_TAIL_CONFIGS = [
+    triton.Config({"BLOCK_M": block_m, "BLOCK_N": block_n}, num_warps=num_warps)
+    for block_m, block_n, num_warps in (
+        (64, 64, 4),
+        (64, 128, 4),
+        (128, 64, 4),
+        (128, 128, 8),
+    )
+]
 
 
 def _can_use_inter_wave(a: torch.Tensor) -> bool:
     return a.shape[1] >= 2 * BLOCK_K and a.shape[1] % BLOCK_K == 0
+
+
+def _can_use_inter_wave_tail(a: torch.Tensor, b: torch.Tensor) -> bool:
+    M, K = a.shape
+    N = b.shape[1]
+    output_elements = M * N
+    return (
+        K > 1536
+        and K % BLOCK_K != 0
+        and K * a.element_size() % 16 == 0
+        and a.element_size() == 2
+        and 2 * 1024 * 1024 < output_elements <= _MAX_DEFERRED_EPILOGUE_ELEMENTS
+    )
 
 
 def _path_key(
@@ -44,6 +69,80 @@ def _path_key(
     )
 
 
+@triton.autotune(configs=_TAIL_CONFIGS, key=["M", "N", "K_TAIL"])
+@triton.jit
+def _addmm_tail_kernel(
+    a_ptr,
+    b_ptr,
+    main_ptr,
+    bias_ptr,
+    c_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K_OFFSET: tl.constexpr,
+    K_TAIL: tl.constexpr,
+    stride_am: tl.constexpr,
+    stride_ak: tl.constexpr,
+    stride_bk: tl.constexpr,
+    stride_bn: tl.constexpr,
+    stride_bias_m: tl.constexpr,
+    stride_bias_n: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    grid_n = tl.cdiv(N, BLOCK_N)
+    pid_m = pid // grid_n
+    pid_n = pid % grid_n
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, _TAIL_BLOCK_K)
+    a = tl.load(
+        a_ptr + offs_m[:, None] * stride_am + (K_OFFSET + offs_k[None, :]) * stride_ak,
+        mask=(offs_m[:, None] < M) & (offs_k[None, :] < K_TAIL),
+        other=0.0,
+    )
+    b = tl.load(
+        b_ptr + (K_OFFSET + offs_k[:, None]) * stride_bk + offs_n[None, :] * stride_bn,
+        mask=(offs_k[:, None] < K_TAIL) & (offs_n[None, :] < N),
+        other=0.0,
+    )
+    acc = tl.dot(a, b, allow_tf32=False, out_dtype=tl.float32)
+    c_offsets = offs_m[:, None] * N + offs_n[None, :]
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    main = tl.load(main_ptr + c_offsets, mask=mask, other=0.0)
+    bias_offsets = offs_m[:, None] * stride_bias_m + offs_n[None, :] * stride_bias_n
+    bias = tl.load(bias_ptr + bias_offsets, mask=mask, other=0.0)
+    tl.store(c_ptr + c_offsets, main + acc + bias.to(tl.float32), mask=mask)
+
+
+def _launch_inter_wave_with_tail(bias: torch.Tensor, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """Run aligned K through inter-wave and finish the tail from its fp32 partials."""
+    M, K = a.shape
+    _, N = b.shape
+    k_main = K // _TAIL_BLOCK_K * _TAIL_BLOCK_K
+    main, out = _launch(a, b, SPLIT_K=1, TILE=(256, 256), K_LIMIT=k_main, DEFER_EPILOGUE=True)
+    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]),)
+    _addmm_tail_kernel[grid](
+        a,
+        b,
+        main,
+        bias,
+        out,
+        M,
+        N,
+        k_main,
+        K - k_main,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        bias.stride(0),
+        bias.stride(1),
+    )
+    return out
+
+
 def _autotune_path(
     bias: torch.Tensor,
     a: torch.Tensor,
@@ -63,6 +162,11 @@ def _autotune_path(
         inter_wave_output = inter_wave()
         if torch.allclose(register_output, inter_wave_output, rtol=1e-2, atol=1e-2):
             candidates["inter_wave"] = inter_wave
+    elif _can_use_inter_wave_tail(a, b):
+        inter_wave_tail = lambda: _launch_inter_wave_with_tail(bias, a, b)
+        inter_wave_tail_output = inter_wave_tail()
+        if torch.allclose(register_output, inter_wave_tail_output, rtol=1e-2, atol=1e-2):
+            candidates["inter_wave_tail"] = inter_wave_tail
     timings = {
         name: triton.testing.do_bench(
             candidate,
@@ -101,4 +205,6 @@ def addmm(bias: torch.Tensor, a: torch.Tensor, b: torch.Tensor, SPLIT_K=None):
     winner = _autotune_path(bias_2d, a, b, SPLIT_K)
     if winner == "inter_wave":
         return _launch(a, b, bias=bias_2d, SPLIT_K=SPLIT_K)
+    if winner == "inter_wave_tail":
+        return _launch_inter_wave_with_tail(bias_2d, a, b)
     return _launch_register(a, b, bias=bias_2d)

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
@@ -247,6 +247,11 @@ _A_BASES_256 = tl.constexpr(_swz_offset_bases([_HALF_256, BLOCK_K], 1))
 _A_BASES_128 = tl.constexpr(_swz_offset_bases([_HALF_128, BLOCK_K], 1))
 _B_BASES_256 = tl.constexpr(_swz_offset_bases([BLOCK_K, _HALF_256], 0))
 _B_BASES_128 = tl.constexpr(_swz_offset_bases([BLOCK_K, _HALF_128], 0))
+# Direct-to-LDS offset layouts inferred by the aligned 256x256 path. Pinning
+# these keeps a merely 16-byte-aligned leading stride from falling back to a
+# blocked layout that the AMD buffer-load lowering cannot consume.
+_A_OFFSET_LAYOUT_256 = tlx.layout(shape=((8, 8, 8), (8, 2)), stride=((8, 1024, 64), (1, 512)))
+_B_OFFSET_LAYOUT_256 = tlx.layout(shape=((8, 8, 8), (8, 2)), stride=((1024, 16, 1), (128, 8)))
 
 
 @triton.autotune(
@@ -397,6 +402,9 @@ def a16w16_8wave(
     GRID_MN: tl.constexpr,
     SPLIT_K: tl.constexpr,
     ADD_BIAS: tl.constexpr,
+    HAS_REGISTER_TAIL: tl.constexpr,
+    PIN_OFFSET_LAYOUT: tl.constexpr,
+    DEFER_EPILOGUE: tl.constexpr,
 ):
     # ── Split-K: grid is GRID_MN*SPLIT_K. Peel off split_id, keep the MN pid for
     # the XCD/group remap below. Each split owns a contiguous K-slice of size KS.
@@ -446,6 +454,9 @@ def a16w16_8wave(
     tl.assume(stride_ak > 0)
     tl.assume(stride_bn > 0)
     tl.assume(stride_bk > 0)
+    if PIN_OFFSET_LAYOUT:
+        stride_am = tl.multiple_of(stride_am, 8)
+        stride_bn = tl.multiple_of(stride_bn, 8)
 
     HALF_M: tl.constexpr = BLOCK_M // 2
     HALF_N: tl.constexpr = BLOCK_N // 2
@@ -482,10 +493,20 @@ def a16w16_8wave(
     offs_bn = pid_n * BLOCK_N + tl.arange(0, HALF_N)
     offs_k = tl.arange(0, BLOCK_K)
 
-    a_top_off = offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak
+    a_row_off = offs_am[:, None] * stride_am
+    b_col_off = offs_bn[None, :] * stride_bn
+    if PIN_OFFSET_LAYOUT:
+        a_row_off = tl.multiple_of(a_row_off, (8, 8))
+        b_col_off = tl.multiple_of(b_col_off, (8, 8))
+    a_top_off = a_row_off + offs_k[None, :] * stride_ak
     a_bot_off = a_top_off + HALF_M * stride_am
-    b_left_off = offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+    b_left_off = offs_k[:, None] * stride_bk + b_col_off
     b_right_off = b_left_off + HALF_N * stride_bn
+    if PIN_OFFSET_LAYOUT:
+        a_top_off = tlx.require_layout(a_top_off, _A_OFFSET_LAYOUT_256)
+        a_bot_off = tlx.require_layout(a_bot_off, _A_OFFSET_LAYOUT_256)
+        b_left_off = tlx.require_layout(b_left_off, _B_OFFSET_LAYOUT_256)
+        b_right_off = tlx.require_layout(b_right_off, _B_OFFSET_LAYOUT_256)
 
     # _next = the K+1 buffer (offset one BLOCK_K along K).
     a_top_off_n = a_top_off + BLOCK_K * stride_ak
@@ -646,23 +667,24 @@ def a16w16_8wave(
     # no pipeline. The K-mask zeros the missing contraction elements (they add 0
     # to C = sum_k A*B), so this is correct for arbitrary K. Runs 0-2 iterations;
     # the whole-tile even hot path (n_pipe*BLOCK_K == K) skips it entirely.
-    offs_am_bot = offs_am + HALF_M
-    offs_bn_right = offs_bn + HALF_N
-    for kk in tl.range(n_pipe * BLOCK_K, KS, BLOCK_K, num_stages=1):
-        offs_kt = kk + offs_k
-        k_mask = offs_kt < KS
-        a_top_t = tl.load(a_ptr + ak_split + offs_am[:, None] * stride_am + offs_kt[None, :] * stride_ak,
-                          mask=(offs_am[:, None] < M) & k_mask[None, :], other=0.0)
-        a_bot_t = tl.load(a_ptr + ak_split + offs_am_bot[:, None] * stride_am + offs_kt[None, :] * stride_ak,
-                          mask=(offs_am_bot[:, None] < M) & k_mask[None, :], other=0.0)
-        b_left_t = tl.load(b_ptr + bk_split + offs_kt[:, None] * stride_bk + offs_bn[None, :] * stride_bn,
-                           mask=k_mask[:, None] & (offs_bn[None, :] < N), other=0.0)
-        b_right_t = tl.load(b_ptr + bk_split + offs_kt[:, None] * stride_bk + offs_bn_right[None, :] * stride_bn,
-                            mask=k_mask[:, None] & (offs_bn_right[None, :] < N), other=0.0)
-        acc_tl = tl.dot(a_top_t, b_left_t, acc_tl)
-        acc_bl = tl.dot(a_bot_t, b_left_t, acc_bl)
-        acc_tr = tl.dot(a_top_t, b_right_t, acc_tr)
-        acc_br = tl.dot(a_bot_t, b_right_t, acc_br)
+    if HAS_REGISTER_TAIL:
+        offs_am_bot = offs_am + HALF_M
+        offs_bn_right = offs_bn + HALF_N
+        for kk in tl.range(n_pipe * BLOCK_K, KS, BLOCK_K, num_stages=1):
+            offs_kt = kk + offs_k
+            k_mask = offs_kt < KS
+            a_top_t = tl.load(a_ptr + ak_split + offs_am[:, None] * stride_am + offs_kt[None, :] * stride_ak,
+                              mask=(offs_am[:, None] < M) & k_mask[None, :], other=0.0)
+            a_bot_t = tl.load(a_ptr + ak_split + offs_am_bot[:, None] * stride_am + offs_kt[None, :] * stride_ak,
+                              mask=(offs_am_bot[:, None] < M) & k_mask[None, :], other=0.0)
+            b_left_t = tl.load(b_ptr + bk_split + offs_kt[:, None] * stride_bk + offs_bn[None, :] * stride_bn,
+                               mask=k_mask[:, None] & (offs_bn[None, :] < N), other=0.0)
+            b_right_t = tl.load(b_ptr + bk_split + offs_kt[:, None] * stride_bk + offs_bn_right[None, :] * stride_bn,
+                                mask=k_mask[:, None] & (offs_bn_right[None, :] < N), other=0.0)
+            acc_tl = tl.dot(a_top_t, b_left_t, acc_tl)
+            acc_bl = tl.dot(a_bot_t, b_left_t, acc_bl)
+            acc_tr = tl.dot(a_top_t, b_right_t, acc_tr)
+            acc_br = tl.dot(a_bot_t, b_right_t, acc_br)
 
     offs_cm_top = pid_m * BLOCK_M + tl.arange(0, HALF_M)
     offs_cm_bot = offs_cm_top + HALF_M
@@ -673,7 +695,7 @@ def a16w16_8wave(
     n_left = offs_cn_left[None, :] < N
     n_right = offs_cn_right[None, :] < N
 
-    if SPLIT_K == 1:
+    if SPLIT_K == 1 and not DEFER_EPILOGUE:
         if ADD_BIAS:
             acc_tl += tl.load(
                 bias_ptr + stride_bias_m * offs_cm_top[:, None] + stride_bias_n * offs_cn_left[None, :],
@@ -835,11 +857,13 @@ def choose_split_k(M, N, K):
     return choose_tile(M, N, K)[2]
 
 
-def _launch(a, b, bias=None, SPLIT_K=None, TILE=None):
+def _launch(a, b, bias=None, SPLIT_K=None, TILE=None, K_LIMIT=None, DEFER_EPILOGUE=False):
     """Launch the shared gfx950 GEMM core, optionally with a fused bias."""
-    assert a.shape[1] == b.shape[0], "Incompatible dimensions"
-    M, K = a.shape
-    K, N = b.shape
+    M, input_k = a.shape
+    b_k, N = b.shape
+    assert input_k == b_k, "Incompatible dimensions"
+    K = input_k if K_LIMIT is None else K_LIMIT
+    assert 0 < K <= input_k, f"K_LIMIT={K} must be in (0, {input_k}]"
     if bias is not None:
         assert bias.shape == (M, N), f"Bias must expand to ({M}, {N}), got {tuple(bias.shape)}"
         assert bias.device == a.device, "Bias and matrix operands must be on the same device"
@@ -861,7 +885,7 @@ def _launch(a, b, bias=None, SPLIT_K=None, TILE=None):
     assert KS * a.element_size() % 16 == 0, f"K/SPLIT_K={KS} must preserve 16-byte split alignment"
     c = torch.empty((M, N), device=a.device, dtype=a.dtype)
     GRID_MN = triton.cdiv(M, BM) * triton.cdiv(N, BN)
-    if SPLIT_K > 1:
+    if SPLIT_K > 1 or DEFER_EPILOGUE:
         # fp32 workspace: partials are stored without a rounding step, so the
         # split-K result matches a single fp32-accumulated GEMM (an fp16 workspace
         # would lose ~1e-1 near cancellation). The reduce sums in fp32 too.
@@ -897,6 +921,9 @@ def _launch(a, b, bias=None, SPLIT_K=None, TILE=None):
         GRID_MN=GRID_MN,
         SPLIT_K=SPLIT_K,
         ADD_BIAS=bias is not None,
+        HAS_REGISTER_TAIL=KS % (2 * BLOCK_K) != 0,
+        PIN_OFFSET_LAYOUT=K_LIMIT is not None,
+        DEFER_EPILOGUE=DEFER_EPILOGUE,
         num_warps=NUM_WARPS,
         num_stages=1,
         matrix_instr_nonkdim=16,
@@ -927,6 +954,8 @@ def _launch(a, b, bias=None, SPLIT_K=None, TILE=None):
             ADD_BIAS=bias is not None,
             num_warps=rw,
         )
+    if DEFER_EPILOGUE:
+        return workspace, c
     return c
 
 


### PR DESCRIPTION
Summary:
The standalone addmm path previously routed every partial-K shape to the register kernel. The inter-wave kernel could not lower these shapes because its direct-to-LDS offsets lost the proven linear layout when the leading stride was only 16-byte aligned, while keeping the register tail in the same kernel left unsupported layout conversions in the generated IR.

Run the even 128-element K prefix through the existing inter-wave pipeline, pinning the offset layouts already inferred by its aligned 256x256 path and preserving the true eight-element fp16 alignment. Defer the epilogue into an fp32 workspace, then finish the remaining K values and bias in a small autotuned tail kernel so the result has only one fp16 rounding step. Large outputs keep the register path because the fp32 workspace traffic outweighs the pipeline gain; non-16-bit partial-K inputs also remain on the existing fallback.

On a locked MI350X, `(3072, 3072, 11800)` improves from 561.360 to 597.182 TFLOPS (+6.38%) with accuracy 1. The same 32-shape sweep reports 592.468 TFLOPS average versus 591.128 in the preceding diff (+0.23%), with accuracy 1 on all 32 shapes. The full sweep took 10m29s including one-time autotuning. rocBLAS remains faster on the target shape at 719.395 TFLOPS in that sweep.

Reviewed By: wlei-llvm

Differential Revision: D116317062


